### PR TITLE
Add Minecraft terrain diffusion variant

### DIFF
--- a/images/games/minecraft/mods/1.21.11.json
+++ b/images/games/minecraft/mods/1.21.11.json
@@ -1,0 +1,10 @@
+{
+  "fabric-api": {
+    "hash": "sha512-wgwBfiPW0ndGkNDdd0zshMFr+sVGHaLZNFoc2V7uSVsZVDM8Qh49HGYYYoTSSkM/awzO2AIfYuC/phfSOE0EcQ==",
+    "url": "https://cdn.modrinth.com/data/P7dR8mSH/versions/i5tSkVBH/fabric-api-0.141.3%2B1.21.11.jar"
+  },
+  "terrain-diffusion": {
+    "hash": "sha256-qenGaiUue9508lSkBWUy7gvovP68nCl7h3PoQ0e8ews=",
+    "url": "https://github.com/xandergos/terrain-diffusion-mc/releases/download/v2.1.0/terrain-diffusion-mc-2.1.0-cpu%2B1.21.11.jar"
+  }
+}

--- a/images/games/minecraft/mods/manifest.json
+++ b/images/games/minecraft/mods/manifest.json
@@ -5,6 +5,13 @@
     "game_versions": ["26.1.2", "26.2-snapshot-5"]
   },
   "versions": {
+    "1.21.11": [
+      "fabric-api",
+      {
+        "slug": "terrain-diffusion",
+        "url": "https://github.com/xandergos/terrain-diffusion-mc/releases/download/v2.1.0/terrain-diffusion-mc-2.1.0-cpu%2B1.21.11.jar"
+      }
+    ],
     "26.1.2": ["fabric-api", "lithium", "c2me-fabric", "krypton", "ferrite-core", "distanthorizons", "servercore", "vmp-fabric", "clumps", "chunky", "bluemap", "luckperms", "simple-voice-chat", "spark", "terralith", "tectonic", "grimac"],
     "26.2-snapshot-5": ["fabric-api", "c2me-fabric"]
   }

--- a/images/games/minecraft/versions.nix
+++ b/images/games/minecraft/versions.nix
@@ -44,6 +44,18 @@ let
         "grimac"
       ];
     };
+
+    "1.21.11-fabric" = {
+      loader = "fabric";
+      version = "1.21.11";
+      loaderVersion = "0.19.2";
+      installerVersion = "1.1.1";
+      hash = "sha256-xDK1HU7Xwbr0Z7pw7Dtdtob0zvlfq9pZ9J4O32u4jBc=";
+      mods = [
+        "fabric-api"
+        "terrain-diffusion"
+      ];
+    };
   };
 
   mkVariant =

--- a/tools/update-mods.py
+++ b/tools/update-mods.py
@@ -4,6 +4,7 @@
 import argparse
 import base64
 import binascii
+import hashlib
 import json
 import sys
 import time
@@ -67,12 +68,21 @@ def hex_to_sri(hex_hash: str) -> str:
     return "sha512-" + base64.b64encode(binascii.unhexlify(hex_hash)).decode()
 
 
+def url_to_sri(url: str) -> str:
+    req = urllib.request.Request(url, headers=HEADERS)
+    h = hashlib.sha256()
+    with urllib.request.urlopen(req) as resp:
+        while chunk := resp.read(1024 * 1024):
+            h.update(chunk)
+    return "sha256-" + base64.b64encode(h.digest()).decode()
+
+
 def primary_file(version: dict) -> dict:
     return next((f for f in version["files"] if f["primary"]), version["files"][0])
 
 
 def resolve(
-    ids_or_slugs: list[str],
+    ids_or_slugs: list[str | dict],
     game_versions: list[str],
     loader: str,
     resolved: dict[str, dict] | None = None,
@@ -85,6 +95,16 @@ def resolve(
     queue = list(ids_or_slugs)
     while queue:
         ref = queue.pop(0)
+        if isinstance(ref, dict):
+            slug = ref["slug"]
+            url = ref["url"]
+            resolved[slug] = {
+                "url": url,
+                "hash": url_to_sri(url),
+            }
+            print(f"  {slug}: explicit artifact", file=sys.stderr)
+            continue
+
         proj = get_project(ref)
         pid = proj["id"]
         if pid in seen_pids:


### PR DESCRIPTION
Adds a 1.21.11 Fabric Minecraft image variant with fabric-api and the Terrain Diffusion CPU jar. Extends the mod catalog generator to support explicit non-Modrinth artifact URLs and hash them directly.

Checks:
- python3 tools/update-mods.py --version 1.21.11
- nix run nixpkgs#ast-grep -- scan
- nix build .#checks.x86_64-linux.eval --no-link
- python3 -m py_compile tools/update-mods.py
- nix run nixpkgs#nixfmt -- --check images/games/minecraft/versions.nix
- git diff --check
- nix build '.#packages.x86_64-linux."minecraft_1.21.11-fabric"' --no-link