### PR TITLE
Add Neovim CI image

### DIFF
--- a/images/dev/neovim-ci/default.nix
+++ b/images/dev/neovim-ci/default.nix
@@ -1,0 +1,44 @@
+# Neovim Linux CI image: toolchain and test dependencies for ix-backed jobs.
+{ pkgs, ... }:
+let
+  python = pkgs.python3.withPackages (ps: [
+    ps.pynvim
+  ]);
+in
+{
+  ix.image.name = "neovim-ci";
+
+  environment.systemPackages = [
+    pkgs.attr
+    pkgs.cmake
+    pkgs.diffutils
+    pkgs.fish
+    pkgs.gcc
+    pkgs.gettext
+    pkgs.glibcLocales
+    pkgs.gnumake
+    pkgs.inotify-tools
+    pkgs.lua51Packages.lpeg
+    pkgs.lua51Packages.luafilesystem
+    pkgs.lua51Packages.luv
+    pkgs.luajit
+    pkgs.ninja
+    pkgs.nodejs
+    pkgs.perl
+    pkgs.perlPackages.Appcpanminus
+    pkgs.perlPackages.NeovimExt
+    pkgs.pkg-config
+    pkgs.ruby
+    pkgs.shellcheck
+    pkgs.stylua
+    pkgs.ts_query_ls
+    pkgs.unzip
+    pkgs.xdg-utils
+    pkgs.zig
+
+    python
+
+    pkgs.llvmPackages_21.clang
+    pkgs.llvmPackages_21.clang-tools
+  ];
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -106,6 +106,7 @@ let
   ++ map (version: "minecraft_${version}") minecraftVersions
   ++ [
     "minestom"
+    "neovim-ci"
     "remote-desktop"
   ];
 


### PR DESCRIPTION
## Summary

Adds a first-pass Neovim Linux CI base image for ix-backed CI experiments.

This image is based on the current Neovim upstream checkout I reviewed:

- Repository: neovim/neovim
- Branch: master
- Commit: 5d1910e1e0f7e5044c91a54cb8bf2c98a96cb5c1
- Relevant workflows reviewed:
  - .github/workflows/test.yml
  - .github/workflows/build.yml
  - .github/workflows/test_windows.yml
  - .github/actions/setup/action.yml
  - .github/scripts/install_deps.sh

## Intended Scope

This is meant to cover the Linux CI substrate first, not the full GitHub Actions replacement.

The image is intended for ix-backed experiments around these Linux lanes:

- test.yml lint
- test.yml clang-analyzer
- test.yml Linux posix matrix, including asan, tsan, release, and puc-lua flavors
- test.yml zig-build-linux
- test.yml with-external-deps
- build.yml old-cmake and use-existing-src setup paths

It intentionally does not cover macOS, Windows, release publishing, CodeQL, label/reviewer automation, or GitHub check orchestration.

## Included Tooling

The image includes the shared build/test tooling Neovim currently installs or downloads in Linux CI, including:

- CMake, Ninja, GNU make, GCC
- LLVM 21 clang and clang-tools
- Zig
- Python with pynvim
- Perl with App::cpanminus and Neovim::Ext
- Node.js and Ruby runtimes
- shellcheck, stylua, ts_query_ls
- LuaJIT and Lua 5.1 packages used by the external-deps lane
- locales, attr tools, inotify-tools, xdg-utils, unzip, gettext

## CI Sweep Notes

I did a second pass over Neovim CI before updating this PR. The main correction from that sweep was that lint would have been a footgun without shellcheck and ts_query_ls: CMake config with CI_LINT=ON requires shellcheck, stylua, and ts_query_ls.

I also added pkg-config plus LuaJIT/Lua 5.1 packages for the external-deps lane. That lane may still need runner-side CMake environment wiring because NixOS systemPackages are not exactly the same contract as Ubuntu dev packages installed with apt. The first Neovim-side integration should prove one or two Linux lanes before expanding the whole Linux matrix.

## Validation

Ran:

- nix eval .#packages.x86_64-linux.neovim-ci.name --json
- nix eval .#checks.x86_64-linux.eval.drvPath
- nix run nixpkgs#ast-grep -- scan

The full local OCI image build was not completed. This host reports Nix as aarch64-linux while images target x86_64-linux, and realizing the full image closure is source-build heavy in this repo.