### PR TITLE
Switch fleets from local images to source switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Building on macOS still needs a Linux builder configured for the resulting `x86_
 
 ## Fleets
 
-Fleets are VM-level NixOS systems, not primarily OCI rollouts. The OCI image is only the bootstrap artifact for creating or intentionally replacing a VM; normal updates use `switch` to activate a new NixOS system closure in place.
+Fleets are VM-level NixOS systems, not primarily OCI rollouts. Missing VMs are created from a shared ix NixOS bootstrap image, then `switch` activates the desired system closure in place. Node-specific OCI archives are only for intentional VM replacement.
 
 See [examples/minecraft-fleet/README.md](examples/minecraft-fleet/README.md) for a multi-file hypothetical Minecraft network using Velocity, Geyser, Floodgate, and replicated Folia shards.
 
-Outputs `packages.<node>` (bootstrap OCI archives), `plan` (JSON), `command`, and `switch`.
+Outputs `packages.<node>` (replacement OCI archives), `packages.<node>-system` (NixOS systems), `plan` (JSON), `command`, and `switch`.
 
 ```nix
 apps.switch.program = "${fleet.switch}/bin/ix-fleet-switch";

--- a/examples/minecraft-fleet/README.md
+++ b/examples/minecraft-fleet/README.md
@@ -24,7 +24,7 @@ examples/minecraft-fleet/
 - `survival` expands into stable VM identities: `survival-0`, `survival-1`, `survival-2`.
 - Every VM automatically has two virtio-net devices: north-south for public ingress and east-west for the private mesh. Users do not define or attach these networks.
 
-The Velocity/Geyser/Floodgate modules shown here are the intended API shape, not a claim that those modules all exist in this repo today. The OCI image is only the bootstrap artifact; normal updates use `switch` to activate a new NixOS system closure in place.
+The Velocity/Geyser/Floodgate modules shown here are the intended API shape, not a claim that those modules all exist in this repo today. Missing VMs start from the shared ix NixOS bootstrap image; normal updates use `switch` to activate the desired NixOS system closure in place.
 
 ## Secrets
 

--- a/examples/minecraft-fleet/default.nix
+++ b/examples/minecraft-fleet/default.nix
@@ -25,6 +25,8 @@ in
 ix.lib.mkFleetFor hostSystem {
   inherit secrets;
 
+  deployment.switch.overrideInputs.ix-images = ".";
+
   nodes = {
     proxy = import ./nodes/proxy.nix {
       inherit

--- a/examples/minecraft-fleet/flake.nix
+++ b/examples/minecraft-fleet/flake.nix
@@ -46,6 +46,7 @@
               fleet = fleetFor system;
             in
             fleet.packages
+            // fleet.systemPackages
             // {
               inherit (fleet) command switch;
             };

--- a/lib/fleet.nix
+++ b/lib/fleet.nix
@@ -23,6 +23,7 @@ let
       [ ];
 
   deploymentDefaults = {
+    bootstrapImage = "registry.ix.dev/ix/test-cluster-bootstrap:a00f95b4a00a07fa";
     region = "hil-1";
     ipv4 = false;
     snapshot = true;
@@ -126,7 +127,7 @@ let
       imageName = config.ix.image.name;
       imageTag = config.ix.image.tag;
       deploy = spec.deployment;
-      destination = deploy.destination or "${imageName}:${imageTag}";
+      replacementDestination = deploy.destination or "${imageName}:${imageTag}";
       switchTarget =
         deploy.switch.target or builtins.unsafeDiscardStringContext
           config.system.build.toplevel.drvPath;
@@ -142,13 +143,16 @@ let
       switch = {
         target = switchTarget;
         buildOn = switchBuildOn;
+        sourceInstallable = deploy.switch.sourceInstallable or ".#${name}-system";
+        overrideInputs = deploy.switch.overrideInputs or { };
       };
-      bootstrapImage = {
+      bootstrapImage = deploy.bootstrapImage;
+      replacementImage = {
         inherit
           imageName
           imageTag
-          destination
           ;
+        destination = replacementDestination;
         source = builtins.unsafeDiscardStringContext "${config.ix.build.ociImage}";
         sourceDrv = builtins.unsafeDiscardStringContext config.ix.build.ociImage.drvPath;
       };
@@ -193,4 +197,7 @@ in
   nodes = nodeConfigs;
   meta = nodeSpecs;
   packages = lib.mapAttrs (name: config: config.ix.build.ociImage) nodeConfigs;
+  systemPackages = lib.mapAttrs' (
+    name: config: lib.nameValuePair "${name}-system" config.system.build.toplevel
+  ) nodeConfigs;
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -295,26 +295,41 @@ let
       message = "fleet plain attrset nodes should be treated as modules";
     }
     {
-      assertion = fleetPlan.web.bootstrapImage.destination == "fleet-web:latest";
-      message = "fleet wrapped-node deployment destination should flow into the generated plan";
+      assertion =
+        fleetPlan.web.bootstrapImage == "registry.ix.dev/ix/test-cluster-bootstrap:a00f95b4a00a07fa";
+      message = "fleet switches should create missing nodes from the shared NixOS bootstrap image";
+    }
+    {
+      assertion = fleetPlan.web.replacementImage.destination == "fleet-web:latest";
+      message = "fleet wrapped-node deployment destination should flow into the replacement image plan";
     }
     {
       assertion = fleetPlan.web.system == "${fleet.nodes.web.system.build.toplevel}";
       message = "fleet plans should expose the NixOS system closure for switch";
     }
     {
+      assertion = fleet.systemPackages.web-system == fleet.nodes.web.system.build.toplevel;
+      message = "fleet system package outputs should match default source switch installables";
+    }
+    {
+      assertion = fleet.packages.web == fleet.nodes.web.ix.build.ociImage;
+      message = "fleet replacement package outputs should keep node names";
+    }
+    {
       assertion =
         fleetPlan.web.switch == {
           target = builtins.unsafeDiscardStringContext fleet.nodes.web.system.build.toplevel.drvPath;
           buildOn = "remote";
+          sourceInstallable = ".#web-system";
+          overrideInputs = { };
         };
       message = "fleet plans should default to local eval and remote build switch metadata";
     }
     {
       assertion =
-        fleetPlan.web.bootstrapImage.sourceDrv
+        fleetPlan.web.replacementImage.sourceDrv
         == builtins.unsafeDiscardStringContext fleet.nodes.web.ix.build.ociImage.drvPath;
-      message = "fleet plans should expose bootstrap image derivations without forcing local image builds";
+      message = "fleet plans should expose replacement image derivations without forcing local image builds";
     }
     {
       assertion = fleetPlan.web.region == "hil-1";

--- a/tools/ix-fleet.py
+++ b/tools/ix-fleet.py
@@ -24,7 +24,7 @@ def empty_str_dict() -> dict[str, str]:
     return {}
 
 
-class BootstrapImage(BaseModel):
+class ReplacementImage(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     imageName: str = Field(min_length=1)
@@ -39,6 +39,8 @@ class SwitchSpec(BaseModel):
 
     target: str = Field(min_length=1)
     buildOn: typing.Literal["auto", "local", "remote"] = "auto"
+    sourceInstallable: str = Field(min_length=1)
+    overrideInputs: dict[str, str] = Field(default_factory=empty_str_dict)
 
 
 class FleetNode(BaseModel):
@@ -49,7 +51,8 @@ class FleetNode(BaseModel):
     replicaIndex: int | None = None
     system: str = Field(min_length=1)
     switch: SwitchSpec
-    bootstrapImage: BootstrapImage
+    bootstrapImage: str = Field(min_length=1)
+    replacementImage: ReplacementImage
     region: str = Field(min_length=1)
     ipv4: bool
     snapshot: bool
@@ -142,8 +145,42 @@ def run_cli(command: list[str], *, dry_run: bool) -> str:
     return result.stdout
 
 
-async def push_bootstrap_image(node: FleetNode, *, dry_run: bool) -> str:
-    image = node.bootstrapImage
+async def wait_node_ready(node: FleetNode, *, dry_run: bool) -> None:
+    command = [
+        "ix",
+        "shell",
+        node.name,
+        "--",
+        "/run/current-system/sw/bin/bash",
+        "-lc",
+        (
+            "set -euo pipefail\n"
+            "export PATH=/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:$PATH\n"
+            "if command -v systemctl >/dev/null 2>&1; then\n"
+            "  systemctl start nix-daemon.socket >/dev/null 2>&1 || true\n"
+            "fi\n"
+            "nix --extra-experimental-features nix-command store info >/dev/null"
+        ),
+    ]
+    if dry_run:
+        step("+ wait until bootstrap is ready: " + " ".join(command))
+        return
+
+    step(f"waiting for {node.name} bootstrap")
+    deadline = asyncio.get_running_loop().time() + 180
+    last_error = ""
+    while asyncio.get_running_loop().time() < deadline:
+        result = subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if result.returncode == 0:
+            return
+        last_error = (result.stderr or result.stdout).strip()
+        await asyncio.sleep(2)
+
+    raise RuntimeError(f"{node.name} bootstrap did not become ready: {last_error}")
+
+
+async def push_replacement_image(node: FleetNode, *, dry_run: bool) -> str:
+    image = node.replacementImage
     source = image.source
     if not dry_run and not Path(source).exists():
         out = run_cli(["nix-store", "--realise", image.sourceDrv], dry_run=False)
@@ -156,12 +193,16 @@ async def push_bootstrap_image(node: FleetNode, *, dry_run: bool) -> str:
     return refs[-1] if refs else image.destination
 
 
-async def node_exists(node: FleetNode) -> bool:
+async def list_nodes() -> list[dict[str, typing.Any]]:
     out = run_cli(["ix", "ls", "--output", "json"], dry_run=False)
     rows = json.loads(out)
     if not isinstance(rows, list):
         raise TypeError("ix ls --output json must return a list")
-    return any(isinstance(row, dict) and row.get("name") == node.name for row in rows)
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def find_node(rows: list[dict[str, typing.Any]], name: str) -> dict[str, typing.Any] | None:
+    return next((row for row in rows if row.get("name") == name), None)
 
 
 async def create_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
@@ -186,14 +227,28 @@ async def create_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
 
 async def ensure_node(node: FleetNode, *, dry_run: bool) -> bool:
     if dry_run:
-        step(f"ensure {node.name} exists from {node.bootstrapImage.destination}")
-        return False
-    if await node_exists(node):
+        step(f"ensure {node.name} exists from {node.bootstrapImage}")
         return False
 
-    image = await push_bootstrap_image(node, dry_run=False)
-    await create_node(node, image, dry_run=False)
-    return True
+    existing = find_node(await list_nodes(), node.name)
+    if existing is None:
+        await create_node(node, node.bootstrapImage, dry_run=dry_run)
+        await wait_node_ready(node, dry_run=dry_run)
+        return True
+
+    if existing.get("status") == "failed":
+        run_cli(["ix", "rm", "--force", node.name], dry_run=dry_run)
+        await create_node(node, node.bootstrapImage, dry_run=dry_run)
+        await wait_node_ready(node, dry_run=dry_run)
+        return True
+
+    if existing.get("status") == "running":
+        await wait_node_ready(node, dry_run=dry_run)
+        return False
+
+    run_cli(["ix", "start", node.name], dry_run=dry_run)
+    await wait_node_ready(node, dry_run=dry_run)
+    return False
 
 
 async def snapshot_node(node: FleetNode, *, dry_run: bool) -> None:
@@ -205,6 +260,48 @@ async def switch_node(node: FleetNode, *, dry_run: bool) -> None:
         ["ix", "switch", node.name, node.switch.target, "--build-on", node.switch.buildOn],
         dry_run=dry_run,
     )
+
+
+def default_source_root(cwd: Path) -> Path:
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", str(cwd), "rev-parse", "--show-toplevel"],
+            text=True,
+        )
+        return Path(out.strip()).resolve()
+    except (OSError, subprocess.CalledProcessError):
+        return cwd.resolve()
+
+
+def default_source_workdir(cwd: Path, source_root: Path) -> Path:
+    try:
+        return cwd.resolve().relative_to(source_root.resolve())
+    except ValueError:
+        return Path(".")
+
+
+async def switch_node_from_source(
+    node: FleetNode,
+    source_root: Path,
+    source_workdir: Path,
+    *,
+    dry_run: bool,
+) -> None:
+    command = [
+        "ix",
+        "switch",
+        node.name,
+        node.switch.sourceInstallable,
+        "--build-on",
+        "remote",
+        "--source",
+        str(source_root),
+        "--source-workdir",
+        str(source_workdir),
+    ]
+    for name, path in sorted(node.switch.overrideInputs.items()):
+        command.extend(["--override-input", f"{name}={path}"])
+    run_cli(command, dry_run=dry_run)
 
 
 async def replace_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
@@ -229,23 +326,35 @@ async def replace_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
 
 async def cmd_diff(plan: FleetPlan, args: argparse.Namespace) -> None:
     for node in selected_nodes(plan, args.on):
-        print(f"{node.name}\twant {node.switch.target} ({node.switch.buildOn})")
+        if node.switch.buildOn == "remote":
+            print(f"{node.name}\twant {node.switch.sourceInstallable} (remote source)")
+        else:
+            print(f"{node.name}\twant {node.switch.target} ({node.switch.buildOn})")
 
 
 async def cmd_switch(plan: FleetPlan, args: argparse.Namespace) -> None:
+    source_root = (args.source_root or default_source_root(Path.cwd())).resolve()
+    source_workdir = args.source_workdir or default_source_workdir(Path.cwd(), source_root)
     for node in selected_nodes(plan, args.on):
         created = await ensure_node(node, dry_run=args.dry_run)
         if not created and node.snapshot and not args.no_snapshot:
             await snapshot_node(node, dry_run=args.dry_run)
-        if not created:
+        if node.switch.buildOn == "remote":
+            await switch_node_from_source(
+                node,
+                source_root,
+                source_workdir,
+                dry_run=args.dry_run,
+            )
+        else:
             await switch_node(node, dry_run=args.dry_run)
 
 
 async def cmd_replace(plan: FleetPlan, args: argparse.Namespace) -> None:
     for node in selected_nodes(plan, args.on):
-        image = node.bootstrapImage.destination
+        image = node.replacementImage.destination
         if not args.skip_push:
-            image = await push_bootstrap_image(node, dry_run=args.dry_run)
+            image = await push_replacement_image(node, dry_run=args.dry_run)
         await replace_node(node, image, dry_run=args.dry_run)
 
 
@@ -275,6 +384,8 @@ def parser() -> argparse.ArgumentParser:
     switch = sub.add_parser("switch")
     add_common_options(switch, defaults=False)
     switch.add_argument("--no-snapshot", action="store_true")
+    switch.add_argument("--source-root", type=Path)
+    switch.add_argument("--source-workdir", type=Path)
     replace = sub.add_parser("replace")
     add_common_options(replace, defaults=False)
     replace.add_argument("--skip-push", action="store_true")


### PR DESCRIPTION
## Summary
- create missing fleet VMs from the shared ix NixOS bootstrap image
- use source-based remote `ix switch` for normal fleet updates
- keep per-node OCI artifacts for explicit replacement rollouts

## Validation
- `python3 -m py_compile tools/ix-fleet.py`
- `nix build .#checks.x86_64-linux.eval`
- `nix run nixpkgs#ast-grep -- scan`
- `git diff --check`