### PR TITLE
Define shared bootstrap image in index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ Commit and push after making changes by default.
 
 Contributor setup and local checks are in @CONTRIBUTING.md.
 
+For PR-sized changes, work in a dedicated git worktree instead of the shared checkout. Keep the main checkout on `main` so other sessions and tools see a stable tree. Put active worktrees outside the repo, for example `/tmp/$USER/index-worktrees/<topic>`, and run repo commands from that worktree. If using natural-language code search, run `mgrep search -c {query}` from the main non-worktree checkout, because `mgrep` can be slow or stale inside worktrees.
+
 When a commit actually fixes a tracked GitHub issue, include an auto-closing keyword in the commit body, for example `Fixes #123`, `Closes #123`, or `Resolves #123`. Use `Refs #123` only for related work, policy docs, investigation, or partial cleanup that should not close the issue.
 
 ## Overview

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ ix VMs implicitly have snapshots and effectively unbounded disk. Fleet and state
 
 Do not assume every `registry.ix.dev` image is public. The `ix` namespace is system-owned, so shared bootstrap refs such as `registry.ix.dev/ix/test-cluster-bootstrap:<tag>` are expected to be public. User images live under `registry.ix.dev/<username>/<image>:<tag>` and default to private; private images require the owner’s auth and should behave like not-found for other users. When debugging image pulls, distinguish a public system bootstrap image from a user-owned private image before treating access as a registry outage.
 
+The shared fleet bootstrap image is defined at `images/system/test-cluster-bootstrap`. It is an ordinary image that extends the repo base profile; keep source-switch tools such as `gnutar`, `zstd`, and `gzip` in `modules/profiles/base.nix` so any VM that has been switched once can be switched again. Build the bootstrap with `nix build .#test-cluster-bootstrap --print-out-paths --no-link`; upload it only with an admin ix profile, using an explicit system namespace ref such as `ix image push <archive>.tar registry.ix.dev/ix/test-cluster-bootstrap:<tag>`. TODO: replace full payload uploads with CAS/CDC-aware transfer for both bootstrap image publishing and `ix switch --source`, so routine updates send only changed chunks and then update the registry or switch input reference.
+
 ## Layout
 
 ```

--- a/images/system/test-cluster-bootstrap/default.nix
+++ b/images/system/test-cluster-bootstrap/default.nix
@@ -1,0 +1,24 @@
+{ pkgs, ... }:
+{
+  ix.image = {
+    name = "ix/test-cluster-bootstrap";
+    tag = "zstd-tools-2026-05-12";
+  };
+
+  networking.hostName = "test-cluster-bootstrap";
+
+  nix.settings = {
+    experimental-features = [
+      "nix-command"
+      "flakes"
+    ];
+    substituters = [
+      "http://cache.ix.dev:8501"
+      "https://cache.nixos.org/"
+    ];
+    trusted-public-keys = [
+      "hil-compute-1:eu2JX3qkNaxdO0/ane+bTmOIKOtR5P/quLlTHBqqIpM="
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+    ];
+  };
+}

--- a/lib/fleet.nix
+++ b/lib/fleet.nix
@@ -24,7 +24,7 @@ let
       [ ];
 
   deploymentDefaults = {
-    bootstrapImage = "registry.ix.dev/ix/test-cluster-bootstrap:a00f95b4a00a07fa";
+    bootstrapImage = "registry.ix.dev/ix/test-cluster-bootstrap:zstd-tools-2026-05-12";
     region = "hil-1";
     ipv4 = false;
     snapshot = true;

--- a/modules/profiles/base.nix
+++ b/modules/profiles/base.nix
@@ -38,11 +38,16 @@
 
         # files
         inherit (pkgs)
-          ripgrep
+          bzip2
           fd
           file
+          gzip
+          gnutar
           tree
           unzip
+          xz
+          zstd
+          ripgrep
           less
           jq
           ;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -361,7 +361,7 @@ let
     }
     {
       assertion =
-        fleetPlan.web.bootstrapImage == "registry.ix.dev/ix/test-cluster-bootstrap:a00f95b4a00a07fa";
+        fleetPlan.web.bootstrapImage == "registry.ix.dev/ix/test-cluster-bootstrap:zstd-tools-2026-05-12";
       message = "fleet switches should create missing nodes from the shared NixOS bootstrap image";
     }
     {


### PR DESCRIPTION
Defines the shared test-cluster bootstrap image in the image repo, points fleet defaults at the uploaded system namespace ref, keeps source-switch archive tools in the base profile for derived images, and documents upload/cache expectations in AGENTS.md.\n\nValidation:\n- nix run .#lint\n- nix build .#test-cluster-bootstrap --print-out-paths --no-link