### PR TITLE
Add OCI image up flow for demo fleet

### DIFF
--- a/examples/claude-code-demo/README.md
+++ b/examples/claude-code-demo/README.md
@@ -9,8 +9,12 @@ Two VMs:
 
 ```bash
 nix run .#claude-code-demo-plan
-nix run .#claude-code-demo-switch
+nix run .#claude-code-demo-up
 ```
+
+`up` builds the fleet's OCI image derivations, uploads the archives with the ix
+CLI, and creates or starts the VMs from those uploaded images. Use this while
+`ix switch` source switching is still unstable.
 
 ## Demo Flow
 

--- a/flake.nix
+++ b/flake.nix
@@ -247,6 +247,7 @@
               claude-code-demo-plan = claudeCodeDemo.planCommand;
               claude-code-demo-replace = claudeCodeDemo.replace;
               claude-code-demo-switch = claudeCodeDemo.switch;
+              claude-code-demo-up = claudeCodeDemo.up;
               minestom-hello-server-jar = repoPackages.minestom.helloServerJar;
             };
         }) devSystems
@@ -408,6 +409,12 @@
                 type = "app";
                 program = lib.getExe claudeCodeDemo.replace;
                 meta.description = "Build replacement images for the Claude Code demo fleet";
+              };
+
+              claude-code-demo-up = {
+                type = "app";
+                program = lib.getExe claudeCodeDemo.up;
+                meta.description = "Build and upload demo OCI images, then create or start VMs from them";
               };
 
               claude-code-demo-switch = {

--- a/lib/fleet.nix
+++ b/lib/fleet.nix
@@ -187,7 +187,7 @@ let
     name = "ix-fleet";
     runtimeInputs = [ python ];
     text = ''
-      def main [...args] {
+      def --wrapped main [...args] {
         exec python3 ${ixFleetScript} --plan ${plan} ...$args
       }
     '';
@@ -196,7 +196,7 @@ let
     name = "ix-fleet-plan";
     runtimeInputs = [ python ];
     text = ''
-      def main [...args] {
+      def --wrapped main [...args] {
         exec python3 ${ixFleetScript} --plan ${plan} plan ...$args
       }
     '';
@@ -205,7 +205,7 @@ let
     name = "ix-fleet-diff";
     runtimeInputs = [ python ];
     text = ''
-      def main [...args] {
+      def --wrapped main [...args] {
         exec python3 ${ixFleetScript} --plan ${plan} diff ...$args
       }
     '';
@@ -214,7 +214,7 @@ let
     name = "ix-fleet-switch";
     runtimeInputs = [ python ];
     text = ''
-      def main [...args] {
+      def --wrapped main [...args] {
         exec python3 ${ixFleetScript} --plan ${plan} switch ...$args
       }
     '';
@@ -223,8 +223,17 @@ let
     name = "ix-fleet-replace";
     runtimeInputs = [ python ];
     text = ''
-      def main [...args] {
+      def --wrapped main [...args] {
         exec python3 ${ixFleetScript} --plan ${plan} replace ...$args
+      }
+    '';
+  };
+  up = writeNushellApplication pkgs {
+    name = "ix-fleet-up";
+    runtimeInputs = [ python ];
+    text = ''
+      def --wrapped main [...args] {
+        exec python3 ${ixFleetScript} --plan ${plan} up ...$args
       }
     '';
   };
@@ -238,6 +247,7 @@ in
     planCommand
     replace
     switch
+    up
     ;
 
   inherit planValue;

--- a/tools/ix-fleet.py
+++ b/tools/ix-fleet.py
@@ -267,11 +267,13 @@ async def wait_node_ready(node: FleetNode, *, dry_run: bool) -> None:
 async def push_replacement_image(node: FleetNode, *, dry_run: bool) -> str:
     image = node.replacementImage
     source = image.source
-    if not dry_run and not Path(source).exists():
+    if not dry_run:
         out = run_cli(["nix-store", "--realise", image.sourceDrv], dry_run=False)
         realised = [line.strip() for line in out.splitlines() if line.strip()]
         if realised:
             source = realised[-1]
+        if not Path(source).exists():
+            raise RuntimeError(f"OCI image derivation did not realise to an existing path: {source}")
 
     out = run_cli(["ix", "push", source, image.destination], dry_run=dry_run)
     refs = [line.strip() for line in out.splitlines() if line.strip()]
@@ -436,6 +438,25 @@ async def replace_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
     run_cli(command, dry_run=dry_run)
 
 
+async def up_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
+    if dry_run:
+        step(f"ensure {node.name} exists from uploaded image {image}")
+        return
+
+    existing = find_node(await list_nodes(), node.name)
+    if existing is None:
+        await create_node(node, image, dry_run=dry_run)
+        return
+
+    if existing.get("status") == "failed":
+        run_cli(["ix", "rm", "--force", node.name], dry_run=dry_run)
+        await create_node(node, image, dry_run=dry_run)
+        return
+
+    if existing.get("status") != "running":
+        run_cli(["ix", "start", node.name], dry_run=dry_run)
+
+
 async def cmd_diff(plan: FleetPlan, args: argparse.Namespace) -> None:
     for node in selected_nodes(plan, args.on):
         if node.switch.buildOn == "remote":
@@ -470,6 +491,14 @@ async def cmd_replace(plan: FleetPlan, args: argparse.Namespace) -> None:
         await replace_node(node, image, dry_run=args.dry_run)
 
 
+async def cmd_up(plan: FleetPlan, args: argparse.Namespace) -> None:
+    for node in selected_nodes(plan, args.on):
+        image = node.replacementImage.destination
+        if not args.skip_push:
+            image = await push_replacement_image(node, dry_run=args.dry_run)
+        await up_node(node, image, dry_run=args.dry_run)
+
+
 def parser() -> argparse.ArgumentParser:
     def add_common_options(target: argparse.ArgumentParser, *, defaults: bool) -> None:
         target.add_argument(
@@ -501,6 +530,9 @@ def parser() -> argparse.ArgumentParser:
     replace = sub.add_parser("replace")
     add_common_options(replace, defaults=False)
     replace.add_argument("--skip-push", action="store_true")
+    up = sub.add_parser("up")
+    add_common_options(up, defaults=False)
+    up.add_argument("--skip-push", action="store_true")
     return p
 
 
@@ -516,6 +548,8 @@ async def main() -> None:
         await cmd_switch(plan, args)
     elif args.command == "replace":
         await cmd_replace(plan, args)
+    elif args.command == "up":
+        await cmd_up(plan, args)
     else:
         raise AssertionError(args.command)
 


### PR DESCRIPTION
## Summary
- add an `ix-fleet up` command that realizes OCI image derivations, uploads them with the ix CLI, and creates or starts VMs from the uploaded image
- expose `claude-code-demo-up` as a flake package/app and make the demo docs use it while `ix switch` is unstable
- make generated Nushell fleet wrappers forward flags such as `--on` and `--dry-run` correctly

## Validation
- `nix eval .#packages.aarch64-darwin.claude-code-demo-up.meta.mainProgram --raw`
- `nix run .#claude-code-demo-plan -- --on minecraft`
- `nix run .#claude-code-demo-up -- --on minecraft --dry-run`
- `nix run .#lint`

Refs ENG-1226
Future ix switch tracking: #19