### PR TITLE
Start large git clones after boot readiness

### DIFF
--- a/examples/claude-code-demo/default.nix
+++ b/examples/claude-code-demo/default.nix
@@ -177,6 +177,7 @@ let
 
             services.git-clone = {
               enable = true;
+              activation = "timer";
               url = "https://github.com/torvalds/linux.git";
               dest = "/src/linux";
             };

--- a/images/dev/kernel-dev/default.nix
+++ b/images/dev/kernel-dev/default.nix
@@ -13,6 +13,7 @@
 
   services.git-clone = {
     enable = true;
+    activation = "timer";
     url = "https://github.com/torvalds/linux.git";
     dest = "/src/linux";
   };

--- a/modules/services/git-clone.nix
+++ b/modules/services/git-clone.nix
@@ -12,6 +12,7 @@ let
     mkEnableOption
     mkOption
     mkIf
+    mkMerge
     types
     ;
   cfg = config.services.git-clone;
@@ -36,36 +37,62 @@ in
       type = types.nullOr types.str;
       default = null;
     };
+
+    activation = mkOption {
+      type = types.enum [
+        "multi-user"
+        "timer"
+      ];
+      default = "multi-user";
+      description = ''
+        How the clone is started. Use timer for large repositories that should
+        be fetched after boot readiness instead of blocking multi-user.target.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.gitoxide ];
 
-    systemd.services.git-clone = {
-      description = "Clone ${cfg.url}";
-      after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
-      };
-      path = [
-        pkgs.coreutils
-        pkgs.gitoxide
-      ];
-      script =
-        let
-          depthFlag = lib.optionalString cfg.shallow "--depth 1";
-          refFlag = lib.optionalString (cfg.ref != null) "--ref ${lib.escapeShellArg cfg.ref}";
-          destParent = builtins.dirOf cfg.dest;
-        in
-        ''
-          if [ ! -d "${cfg.dest}/.git" ]; then
-            mkdir -p ${lib.escapeShellArg destParent}
-            gix clone ${depthFlag} ${refFlag} ${lib.escapeShellArg cfg.url} ${lib.escapeShellArg cfg.dest}
-          fi
-        '';
-    };
+    systemd = mkMerge [
+      {
+        services.git-clone = {
+          description = "Clone ${cfg.url}";
+          after = [ "network-online.target" ];
+          wants = [ "network-online.target" ];
+          wantedBy = lib.optional (cfg.activation == "multi-user") "multi-user.target";
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+          };
+          path = [
+            pkgs.coreutils
+            pkgs.gitoxide
+          ];
+          script =
+            let
+              depthFlag = lib.optionalString cfg.shallow "--depth 1";
+              refFlag = lib.optionalString (cfg.ref != null) "--ref ${lib.escapeShellArg cfg.ref}";
+              destParent = builtins.dirOf cfg.dest;
+            in
+            ''
+              if [ ! -d "${cfg.dest}/.git" ]; then
+                mkdir -p ${lib.escapeShellArg destParent}
+                gix clone ${depthFlag} ${refFlag} ${lib.escapeShellArg cfg.url} ${lib.escapeShellArg cfg.dest}
+              fi
+            '';
+        };
+      }
+      (mkIf (cfg.activation == "timer") {
+        timers.git-clone = {
+          description = "Start git clone after boot";
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            OnBootSec = "15s";
+            Unit = "git-clone.service";
+          };
+        };
+      })
+    ];
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -65,6 +65,8 @@ let
   remoteDesktopServiceConfig = remoteDesktopService.serviceConfig;
 
   kernelDevConfig = evalConfig [ ../images/dev/kernel-dev ];
+  kernelDevGitCloneService = kernelDevConfig.systemd.services.git-clone;
+  kernelDevGitCloneTimer = kernelDevConfig.systemd.timers.git-clone;
 
   fleet = ix.mkFleet {
     deployment.region = "hil-1";
@@ -121,6 +123,18 @@ let
     {
       assertion = kernelDevConfig.services.git-clone.dest == "/src/linux";
       message = "kernel-dev image should clone Linux into /src/linux";
+    }
+    {
+      assertion = kernelDevConfig.services.git-clone.activation == "timer";
+      message = "kernel-dev image should clone Linux after boot readiness";
+    }
+    {
+      assertion = kernelDevGitCloneService.wantedBy == [ ];
+      message = "timer-activated git clone should not be wanted by multi-user.target";
+    }
+    {
+      assertion = kernelDevGitCloneTimer.wantedBy == [ "timers.target" ];
+      message = "timer-activated git clone should be started by timers.target";
     }
     {
       assertion = minecraftConfig.ix.image.tag == defaultMinecraftVersion;


### PR DESCRIPTION
## Summary
- add a timer activation mode for services.git-clone
- use timer activation for the kernel-dev image and Claude demo Linux node so large first-boot clones do not block multi-user.target
- add eval assertions for the non-blocking systemd wiring

## Validation
- nix run .#lint
- nix eval of kernel-dev systemd wiring: activation = "timer", serviceWantedBy = [ ], timerWantedBy = [ "timers.target" ]

Note: nix build .#checks.x86_64-linux.eval could not run on this aarch64-darwin host because it requires x86_64-linux build dependencies.
