### PR TITLE
Make Claude demo compile helper bootstrap sources

### DIFF
--- a/examples/claude-code-demo/default.nix
+++ b/examples/claude-code-demo/default.nix
@@ -147,6 +147,7 @@ let
     name = "compile";
     runtimeInputs = [
       pkgs.coreutils
+      pkgs.git
       pkgs.gnumake
       pkgs.systemd
     ];
@@ -172,16 +173,44 @@ let
           $"MemoryMax=($memory_max)"
         ]
 
-        ^systemd-run --scope --quiet --wait --collect ...$limits ...$command
+        if ("/run/systemd/private" | path exists) {
+          ^systemd-run --quiet --wait --collect ...$limits ...$command
+        } else {
+          ^$command.0 ...($command | skip 1)
+        }
+      }
+
+      def source-ready [source_dir: string] {
+        [
+          "Makefile"
+          "kernel"
+          "scripts"
+          "arch/x86/boot"
+        ] | all {|path| ($source_dir | path join $path) | path exists }
+      }
+
+      def ensure-source [source_dir: string] {
+        if (source-ready $source_dir) {
+          return
+        }
+
+        if ($source_dir | path exists) {
+          rm --recursive --force $source_dir
+        }
+
+        mkdir ($source_dir | path dirname)
+        ^${lib.getExe pkgs.git} clone --quiet --depth 1 --single-branch https://github.com/torvalds/linux.git $source_dir
+
+        if not (source-ready $source_dir) {
+          error make {
+            msg: $"Linux source tree bootstrap did not produce a complete checkout at ($source_dir)."
+          }
+        }
       }
 
       def main [...targets: string] {
         let source_dir = (env-or LINUX_SOURCE_DIR "/src/linux")
-        if not ($source_dir | path exists) {
-          error make {
-            msg: $"Linux source tree is missing at ($source_dir); wait for git-clone.service to finish."
-          }
-        }
+        ensure-source $source_dir
 
         cd $source_dir
 


### PR DESCRIPTION
## Summary

Follow-up to #30 with the runtime fixes from testing on `linux-shell`.

Simple command after rebuilding/replacing the demo image:

```sh
ix shell linux-shell /run/current-system/sw/bin/compile bzImage
```

The helper now:

- uses valid Nushell instead of Bash-style backslash continuations
- avoids `systemd-run --scope --wait`, which systemd rejects
- falls back to direct `make` when `/run/systemd/private` is unavailable
- includes `git` in the helper runtime path
- bootstraps `/src/linux` with a quiet shallow clone when the source tree is missing or incomplete
- validates the source tree has `Makefile`, `kernel`, `scripts`, and `arch/x86/boot` before compiling

Refs #28

## Tests

- `nix build .#claude-code-demo-command --no-link --print-out-paths`
- `nix run .#lint`
- On `linux-shell`, confirmed the previous image's helper contains the old invalid Nu and that `systemd-run --scope --wait` is rejected.
- On `linux-shell`, attempted full kernel compile validation, but the existing `/src/linux` checkout was left incomplete by an interrupted clone and subsequent checkout repair stalled on the VM filesystem. This change makes the helper remove incomplete source trees and reclone quietly before building, which addresses that failure mode.
