### PR TITLE
Refactor for idiomatic modern Nix practices

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -200,6 +200,7 @@
         root = ./.;
         fileset = fs.gitTracked ./.;
       };
+      # Evaluated once per host system so packages and apps share the derivations.
       claudeCodeDemoFor =
         hostSystem:
         import ./examples/claude-code-demo/default.nix {
@@ -208,6 +209,7 @@
           };
           inherit hostSystem;
         };
+      claudeCodeDemos = lib.genAttrs devSystems claudeCodeDemoFor;
       preCommitCheckFor =
         system:
         pre-commit-hooks.lib.${system}.run {
@@ -226,85 +228,71 @@
       modules = import ./modules;
       overlays.default = ix.overlay;
 
-      packages = builtins.listToAttrs (
-        map (system: {
-          name = system;
-          value =
-            let
-              pkgs = nixpkgs.legacyPackages.${system};
-              claudeCodeDemo = claudeCodeDemoFor system;
-              claudeCodeDemoImages = lib.mapAttrs' (
-                name: package: lib.nameValuePair "claude-code-demo-${name}-image" package
-              ) claudeCodeDemo.packages;
-              repoPackages = ix.packageSetFor pkgs;
-              claudeCodeDemoLinuxUp = ix.writeNushellApplication pkgs {
-                name = "claude-code-demo-linux-up";
-                runtimeInputs = [
-                  claudeCodeDemo.up
-                ];
-                text = ''
-                  def --wrapped main [...args] {
-                    exec ix-fleet-up --on linux ...$args
-                  }
-                '';
-              };
-              claudeCodeDemoMinecraftUp = ix.writeNushellApplication pkgs {
-                name = "claude-code-demo-minecraft-up";
-                runtimeInputs = [
-                  claudeCodeDemo.up
-                ];
-                text = ''
-                  def --wrapped main [...args] {
-                    exec ix-fleet-up --on minecraft ...$args
-                  }
-                '';
-              };
-            in
-            imagePackages
-            // claudeCodeDemo.systemPackages
-            // claudeCodeDemoImages
-            // {
-              claude-code-demo-command = claudeCodeDemo.command;
-              claude-code-demo-diff = claudeCodeDemo.diff;
-              claude-code-demo-plan = claudeCodeDemo.planCommand;
-              claude-code-demo-replace = claudeCodeDemo.replace;
-              claude-code-demo-switch = claudeCodeDemo.switch;
-              claude-code-demo-up = claudeCodeDemo.up;
-              claude-code-demo-linux-up = claudeCodeDemoLinuxUp;
-              claude-code-demo-minecraft-up = claudeCodeDemoMinecraftUp;
-              minestom-hello-server-jar = repoPackages.minestom.helloServerJar;
-            };
-        }) devSystems
-      );
-      checks = builtins.listToAttrs (
-        map (system: {
-          name = system;
-          value = {
-            pre-commit = preCommitCheckFor system;
+      packages = lib.genAttrs devSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          claudeCodeDemo = claudeCodeDemos.${system};
+          claudeCodeDemoImages = lib.mapAttrs' (
+            name: package: lib.nameValuePair "claude-code-demo-${name}-image" package
+          ) claudeCodeDemo.packages;
+          repoPackages = ix.packageSetFor pkgs;
+          claudeCodeDemoLinuxUp = ix.writeNushellApplication pkgs {
+            name = "claude-code-demo-linux-up";
+            runtimeInputs = [
+              claudeCodeDemo.up
+            ];
+            text = ''
+              def --wrapped main [...args] {
+                exec ix-fleet-up --on linux ...$args
+              }
+            '';
+          };
+          claudeCodeDemoMinecraftUp = ix.writeNushellApplication pkgs {
+            name = "claude-code-demo-minecraft-up";
+            runtimeInputs = [
+              claudeCodeDemo.up
+            ];
+            text = ''
+              def --wrapped main [...args] {
+                exec ix-fleet-up --on minecraft ...$args
+              }
+            '';
+          };
+        in
+        imagePackages
+        // claudeCodeDemo.systemPackages
+        // claudeCodeDemoImages
+        // {
+          claude-code-demo-command = claudeCodeDemo.command;
+          claude-code-demo-diff = claudeCodeDemo.diff;
+          claude-code-demo-plan = claudeCodeDemo.planCommand;
+          claude-code-demo-replace = claudeCodeDemo.replace;
+          claude-code-demo-switch = claudeCodeDemo.switch;
+          claude-code-demo-up = claudeCodeDemo.up;
+          claude-code-demo-linux-up = claudeCodeDemoLinuxUp;
+          claude-code-demo-minecraft-up = claudeCodeDemoMinecraftUp;
+          minestom-hello-server-jar = repoPackages.minestom.helloServerJar;
+        });
+
+      checks = lib.genAttrs devSystems (system:
+        { pre-commit = preCommitCheckFor system; }
+        // lib.optionalAttrs (system == ix.system) (
+          let
+            lint = self.apps.${ix.system}.lint.program;
+          in
+          {
+            eval = import ./tests { inherit nixpkgs ix; };
+            lint = ix.pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ ix.pkgs.coreutils ]; } ''
+              cp -R ${lintSource} source
+              chmod -R u+w source
+              cd source
+              ${lint}
+              mkdir -p "$out"
+            '';
           }
-          // lib.optionalAttrs (system == ix.system) (
-            let
-              lint = self.apps.${ix.system}.lint.program;
-            in
-            {
-              eval = import ./tests { inherit nixpkgs ix; };
-              lint = ix.pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ ix.pkgs.coreutils ]; } ''
-                cp -R ${lintSource} source
-                chmod -R u+w source
-                cd source
-                ${lint}
-                mkdir -p "$out"
-              '';
-            }
-          );
-        }) devSystems
-      );
-      formatter = builtins.listToAttrs (
-        map (system: {
-          name = system;
-          value = nixpkgs.legacyPackages.${system}.nixfmt;
-        }) devSystems
-      );
+        ));
+
+      formatter = lib.genAttrs devSystems (system: nixpkgs.legacyPackages.${system}.nixfmt);
 
       templates.default = {
         path = ./template;
@@ -312,176 +300,148 @@
       };
 
       # Developer tooling. Exposed for both Linux CI and macOS dev machines.
-      devShells = builtins.listToAttrs (
-        map (system: {
-          name = system;
-          value.default =
-            let
-              pkgs = nixpkgs.legacyPackages.${system};
-              preCommitCheck = self.checks.${system}.pre-commit;
-            in
-            pkgs.mkShell {
-              packages = [
-                pkgs.ast-grep
-                pkgs.deadnix
-                pkgs.gradle_9
-                pkgs.jdk25
-                pkgs.nixfmt
-                pkgs.statix
-              ]
-              ++ preCommitCheck.enabledPackages;
+      devShells = lib.genAttrs devSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          preCommitCheck = self.checks.${system}.pre-commit;
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              pkgs.ast-grep
+              pkgs.deadnix
+              pkgs.gradle_9
+              pkgs.jdk25
+              pkgs.nixfmt
+              pkgs.statix
+            ]
+            ++ preCommitCheck.enabledPackages;
 
-              JAVA_HOME = pkgs.jdk25.home;
-              inherit (preCommitCheck) shellHook;
-            };
-        }) devSystems
-      );
+            JAVA_HOME = pkgs.jdk25.home;
+            inherit (preCommitCheck) shellHook;
+          };
+        });
 
-      apps = builtins.listToAttrs (
-        map (system: {
-          name = system;
-          value =
-            let
-              pkgs = nixpkgs.legacyPackages.${system};
-              benchFilesystem = import ./bench/filesystem { inherit ix pkgs; };
-              updateMods = ix.writeNushellApplication pkgs {
-                name = "update-mods";
-                runtimeInputs = [ pkgs.python3 ];
-                text = ''
-                  def main [...args] {
-                    exec python3 ${./tools/update-mods.py} ...$args
-                  }
-                '';
-              };
-              python = pkgs.python3.withPackages (ps: [ ps.pydantic ]);
-              ixFleet = ix.writeNushellApplication pkgs {
-                name = "ix-fleet";
-                runtimeInputs = [ python ];
-                text = ''
-                  def main [...args] {
-                    exec python3 ${./tools/ix-fleet.py} ...$args
-                  }
-                '';
-              };
-              lint = ix.writeNushellApplication pkgs {
-                name = "lint";
-                runtimeInputs = [
-                  pkgs.ast-grep
-                  pkgs.deadnix
-                  pkgs.fd
-                  pkgs.nixfmt
-                  pkgs.statix
-                ];
-                text = ''
-                  def main [] {
-                    let nix_files = (fd --extension nix | lines)
+      apps = lib.genAttrs devSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          # Reuse derivations already built for packages to avoid evaluating them twice.
+          claudeCodeDemo = claudeCodeDemos.${system};
+          benchFilesystem = import ./bench/filesystem { inherit ix pkgs; };
+          updateMods = ix.writeNushellApplication pkgs {
+            name = "update-mods";
+            runtimeInputs = [ pkgs.python3 ];
+            text = ''
+              def main [...args] {
+                exec python3 ${./tools/update-mods.py} ...$args
+              }
+            '';
+          };
+          python = pkgs.python3.withPackages (ps: [ ps.pydantic ]);
+          ixFleet = ix.writeNushellApplication pkgs {
+            name = "ix-fleet";
+            runtimeInputs = [ python ];
+            text = ''
+              def main [...args] {
+                exec python3 ${./tools/ix-fleet.py} ...$args
+              }
+            '';
+          };
+          lint = ix.writeNushellApplication pkgs {
+            name = "lint";
+            runtimeInputs = [
+              pkgs.ast-grep
+              pkgs.deadnix
+              pkgs.fd
+              pkgs.nixfmt
+              pkgs.statix
+            ];
+            text = ''
+              def main [] {
+                let nix_files = (fd --extension nix | lines)
 
-                    print "nixfmt"
-                    nixfmt --check ...$nix_files
+                print "nixfmt"
+                nixfmt --check ...$nix_files
 
-                    print "statix"
-                    statix check .
+                print "statix"
+                statix check .
 
-                    print "deadnix"
-                    deadnix --fail --no-lambda-pattern-names .
+                print "deadnix"
+                deadnix --fail --no-lambda-pattern-names .
 
-                    print "ast-grep"
-                    ast-grep scan --error .
-                  }
-                '';
-              };
-              claudeCodeDemo = claudeCodeDemoFor system;
-              claudeCodeDemoLinuxUp = ix.writeNushellApplication pkgs {
-                name = "claude-code-demo-linux-up";
-                runtimeInputs = [
-                  claudeCodeDemo.up
-                ];
-                text = ''
-                  def --wrapped main [...args] {
-                    exec ix-fleet-up --on linux ...$args
-                  }
-                '';
-              };
-              claudeCodeDemoMinecraftUp = ix.writeNushellApplication pkgs {
-                name = "claude-code-demo-minecraft-up";
-                runtimeInputs = [
-                  claudeCodeDemo.up
-                ];
-                text = ''
-                  def --wrapped main [...args] {
-                    exec ix-fleet-up --on minecraft ...$args
-                  }
-                '';
-              };
-            in
-            {
-              lint = {
-                type = "app";
-                program = lib.getExe lint;
-                meta.description = "Run all Nix formatting and lint checks";
-              };
+                print "ast-grep"
+                ast-grep scan --error .
+              }
+            '';
+          };
+        in
+        {
+          lint = {
+            type = "app";
+            program = lib.getExe lint;
+            meta.description = "Run all Nix formatting and lint checks";
+          };
 
-              bench-filesystem = {
-                type = "app";
-                program = lib.getExe benchFilesystem;
-                meta.description = "Benchmark file-system behavior from inside an ix VM";
-              };
+          bench-filesystem = {
+            type = "app";
+            program = lib.getExe benchFilesystem;
+            meta.description = "Benchmark file-system behavior from inside an ix VM";
+          };
 
-              update-mods = {
-                type = "app";
-                program = lib.getExe updateMods;
-                meta.description = "Regenerate Minecraft mod catalogs";
-              };
+          update-mods = {
+            type = "app";
+            program = lib.getExe updateMods;
+            meta.description = "Regenerate Minecraft mod catalogs";
+          };
 
-              ix-fleet = {
-                type = "app";
-                program = lib.getExe ixFleet;
-                meta.description = "Render ix fleet plans and commands";
-              };
+          ix-fleet = {
+            type = "app";
+            program = lib.getExe ixFleet;
+            meta.description = "Render ix fleet plans and commands";
+          };
 
-              claude-code-demo-diff = {
-                type = "app";
-                program = lib.getExe claudeCodeDemo.diff;
-                meta.description = "Diff the Claude Code demo fleet against live VMs";
-              };
+          claude-code-demo-diff = {
+            type = "app";
+            program = lib.getExe claudeCodeDemo.diff;
+            meta.description = "Diff the Claude Code demo fleet against live VMs";
+          };
 
-              claude-code-demo-plan = {
-                type = "app";
-                program = lib.getExe claudeCodeDemo.planCommand;
-                meta.description = "Render the Claude Code demo fleet plan";
-              };
+          claude-code-demo-plan = {
+            type = "app";
+            program = lib.getExe claudeCodeDemo.planCommand;
+            meta.description = "Render the Claude Code demo fleet plan";
+          };
 
-              claude-code-demo-replace = {
-                type = "app";
-                program = lib.getExe claudeCodeDemo.replace;
-                meta.description = "Build replacement images for the Claude Code demo fleet";
-              };
+          claude-code-demo-replace = {
+            type = "app";
+            program = lib.getExe claudeCodeDemo.replace;
+            meta.description = "Build replacement images for the Claude Code demo fleet";
+          };
 
-              claude-code-demo-up = {
-                type = "app";
-                program = lib.getExe claudeCodeDemo.up;
-                meta.description = "Build and upload demo OCI images, then create or start VMs from them";
-              };
+          claude-code-demo-up = {
+            type = "app";
+            program = lib.getExe claudeCodeDemo.up;
+            meta.description = "Build and upload demo OCI images, then create or start VMs from them";
+          };
 
-              claude-code-demo-linux-up = {
-                type = "app";
-                program = lib.getExe claudeCodeDemoLinuxUp;
-                meta.description = "Build and upload the Claude Code demo Linux image, then create or start only the Linux VM";
-              };
+          # Reuse the wrappers already built for packages rather than rebuilding them.
+          claude-code-demo-linux-up = {
+            type = "app";
+            program = lib.getExe self.packages.${system}.claude-code-demo-linux-up;
+            meta.description = "Build and upload the Claude Code demo Linux image, then create or start only the Linux VM";
+          };
 
-              claude-code-demo-minecraft-up = {
-                type = "app";
-                program = lib.getExe claudeCodeDemoMinecraftUp;
-                meta.description = "Build and upload the Claude Code demo Minecraft image, then create or start only the Minecraft VM";
-              };
+          claude-code-demo-minecraft-up = {
+            type = "app";
+            program = lib.getExe self.packages.${system}.claude-code-demo-minecraft-up;
+            meta.description = "Build and upload the Claude Code demo Minecraft image, then create or start only the Minecraft VM";
+          };
 
-              claude-code-demo-switch = {
-                type = "app";
-                program = lib.getExe claudeCodeDemo.switch;
-                meta.description = "Switch the Claude Code demo fleet";
-              };
-            };
-        }) devSystems
-      );
+          claude-code-demo-switch = {
+            type = "app";
+            program = lib.getExe claudeCodeDemo.switch;
+            meta.description = "Switch the Claude Code demo fleet";
+          };
+        });
     };
 }

--- a/lib/build-npm-site.nix
+++ b/lib/build-npm-site.nix
@@ -22,7 +22,7 @@ let
     };
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+pkgs.stdenvNoCC.mkDerivation (_: {
   inherit
     pname
     version
@@ -51,4 +51,4 @@ pkgs.stdenvNoCC.mkDerivation {
     cp -R "${distDir}/." "$out/${installDir}/"
     runHook postInstall
   '';
-}
+})

--- a/modules/services/minecraft-bedrock.nix
+++ b/modules/services/minecraft-bedrock.nix
@@ -18,7 +18,7 @@ let
 
   version = "1.26.14.1";
 
-  bedrockServer = pkgs.stdenv.mkDerivation {
+  bedrockServer = pkgs.stdenv.mkDerivation (finalAttrs: {
     pname = "minecraft-bedrock-server";
     inherit version;
 
@@ -61,7 +61,7 @@ let
     '';
 
     meta.mainProgram = "bedrock_server";
-  };
+  });
 
   cfg = config.services.minecraft-bedrock;
   dataDir = "/var/lib/minecraft-bedrock";

--- a/nix/packages/minecraft-hot-reload-agent.nix
+++ b/nix/packages/minecraft-hot-reload-agent.nix
@@ -14,7 +14,7 @@ let
     ];
   };
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "minecraft-hot-reload-agent";
   version = "0.1.0";
   inherit src;
@@ -45,4 +45,4 @@ stdenv.mkDerivation {
     description = "Minecraft development hot-reload Java agent";
     license = lib.licenses.mit;
   };
-}
+})

--- a/nix/packages/tonbo-artifacts.nix
+++ b/nix/packages/tonbo-artifacts.nix
@@ -3,7 +3,7 @@
   src,
 }:
 
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "tonbo-artifacts";
   version = "e16636b0e5ce";
 
@@ -27,4 +27,4 @@ stdenvNoCC.mkDerivation {
     mainProgram = "artifacts";
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4,10 +4,8 @@
 }:
 let
   inherit (nixpkgs) lib;
-  inherit (ix) system;
   inherit (ix) pkgs;
 
-  moduleList = lib.collect builtins.isPath (import ../modules);
   versions = import ../images/games/minecraft/versions.nix {
     inherit lib;
     inherit (ix) artifacts;
@@ -15,27 +13,9 @@ let
   defaultMinecraftVersion = versions.default;
   defaultMinecraftModule = versions.${defaultMinecraftVersion};
 
-  evalConfig =
-    modules:
-    (lib.nixosSystem {
-      inherit system;
-      specialArgs.ix = {
-        inherit (ix)
-          artifacts
-          mkMinecraftLoader
-          mkMinecraftSyncManaged
-          writeNushellApplication
-          writePythonApplication
-          ;
-      };
-      modules = [
-        { nixpkgs.overlays = ix.overlays; }
-        ../lib/ix-platform.nix
-        ../lib/ix-oci-layer.nix
-      ]
-      ++ moduleList
-      ++ modules;
-    }).config;
+  # Thin wrapper to keep call sites as plain lists; delegates to ix.evalImageConfig
+  # so tests exercise the same evaluation path as production image builds.
+  evalConfig = modules: ix.evalImageConfig { inherit modules; };
 
   minecraftConfig = evalConfig [
     ../images/games/minecraft


### PR DESCRIPTION
- flake.nix: replace `builtins.listToAttrs (map ...)` anti-pattern with `lib.genAttrs devSystems` throughout packages, checks, formatter, devShells, and apps — the idiomatic hand-rolled forAllSystems pattern.

- flake.nix: lift `claudeCodeDemos = lib.genAttrs devSystems claudeCodeDemoFor` out of the per-output generators so the fleet is evaluated once per host system rather than once per output attribute.

- flake.nix: deduplicate claude-code-demo-linux-up / claude-code-demo-minecraft-up wrappers — apps now references `self.packages.${system}` instead of rebuilding identical derivations.

- tests/default.nix: replace the local `evalConfig`/`moduleList` reimplementation with a thin delegate to `ix.evalImageConfig`, so tests exercise the same evaluation path as production image builds. Remove the now-redundant `inherit (ix) system` and `moduleList` bindings.

- minecraft-hot-reload-agent.nix, tonbo-artifacts.nix, minecraft-bedrock.nix, build-npm-site.nix: use the canonical `mkDerivation (finalAttrs: ...)` / `mkDerivation (_: ...)` pattern instead of the plain attrset form, so overrideAttrs chains propagate correctly and tooling recognises the fixed-point shape.