### PR TITLE
Followup: unify paths manifest, drop tonbo-artifacts overlay coupling

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,19 +17,31 @@
     }:
     let
       inherit (nixpkgs) lib;
-      ix = import ./lib {
-        inherit nixpkgs llm-agents;
-        paths = {
-          modules = ./modules;
-          nixPackages = {
-            minecraftHotReloadAgent = ./nix/packages/minecraft-hot-reload-agent.nix;
-            minecraftRcon = ./nix/packages/minecraft-rcon.nix;
-            tonboArtifacts = ./nix/packages/tonbo-artifacts.nix;
-          };
-          packages.minestom.servers.hello = ./packages/minestom/servers/hello;
-          tools.ixFleet = ./tools/ix-fleet.py;
-          tools.minecraftSyncManaged = ./nix/packages/minecraft-sync-managed.py;
+
+      # All path literals the flake exposes. Centralized so lib/ and
+      # lib/per-system.nix have a single source of truth.
+      paths = {
+        root = ./.;
+        images = ./images;
+        modules = ./modules;
+        tests = ./tests;
+        bench.filesystem = ./bench/filesystem;
+        examples.claudeCodeDemo = ./examples/claude-code-demo;
+        nixPackages = {
+          minecraftHotReloadAgent = ./nix/packages/minecraft-hot-reload-agent.nix;
+          minecraftRcon = ./nix/packages/minecraft-rcon.nix;
+          tonboArtifacts = ./nix/packages/tonbo-artifacts.nix;
         };
+        packages.minestom.servers.hello = ./packages/minestom/servers/hello;
+        tools = {
+          ixFleet = ./tools/ix-fleet.py;
+          minecraftSyncManaged = ./nix/packages/minecraft-sync-managed.py;
+          updateMods = ./tools/update-mods.py;
+        };
+      };
+
+      ix = import ./lib {
+        inherit nixpkgs llm-agents paths;
       };
       devSystems = [
         "x86_64-linux"
@@ -42,9 +54,8 @@
             system
             ix
             nixpkgs
+            paths
             ;
-          repoRoot = ./.;
-          examplePaths.claudeCodeDemo = ./examples/claude-code-demo;
         }
       );
       collect = key: lib.mapAttrs (_: out: out.${key}) perSystem;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -110,13 +110,14 @@ let
     };
 
   # Overlays: llm-agents provides claude-code and codex; plus repo-local
-  # packages used by images.
+  # packages consumed by NixOS modules via `pkgs.<name>`. Packages that are
+  # only exposed as flake outputs (e.g. tonbo-artifacts) stay out of the
+  # overlay so they don't pollute the nixpkgs namespace inside images.
   overlay = final: _prev: {
     minecraft-hot-reload-agent = final.callPackage paths.nixPackages.minecraftHotReloadAgent { };
     minecraft-rcon = final.callPackage paths.nixPackages.minecraftRcon {
       writePythonApplication = writePythonApplication final;
     };
-    tonbo-artifacts = final.callPackage paths.nixPackages.tonboArtifacts { };
   };
   overlays = [
     llm-agents.overlays.default
@@ -195,6 +196,10 @@ let
       };
     };
   };
+
+  # x86_64-linux-only binary blob distributed by upstream Tonbo. Lives here
+  # rather than in `packageSetFor` because it has no useful cross-compile.
+  tonbo-artifacts = pkgs.callPackage paths.nixPackages.tonboArtifacts { };
 
   packageSetFor =
     pkgs:
@@ -321,6 +326,7 @@ in
     mkMinecraftLoader
     mkMinecraftSyncManaged
     packageSetFor
+    tonbo-artifacts
     writeNushellApplication
     writePythonApplication
     ;

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1,14 +1,13 @@
-# Per-system flake outputs (packages / apps / checks / devShells / formatter).
+# Per-system flake outputs (packages / apps / checks / formatter).
 #
 # Kept out of flake.nix so the flake top-level can read as a manifest of
 # inputs and output categories. All composition logic for apps, demo
-# wrappers, lint plumbing, and the dev shell lives here.
+# wrappers, and lint plumbing lives here.
 {
   system,
   ix,
   nixpkgs,
-  repoRoot,
-  examplePaths,
+  paths,
 }:
 let
   inherit (nixpkgs) lib;
@@ -21,7 +20,23 @@ let
     meta = { inherit description; };
   };
 
-  python = pkgs.python3.withPackages (ps: [ ps.pydantic ]);
+  pythonWithPydantic = pkgs.python3.withPackages (ps: [ ps.pydantic ]);
+
+  mkPythonWrapper =
+    {
+      name,
+      script,
+      python ? pkgs.python3,
+    }:
+    ix.writeNushellApplication pkgs {
+      inherit name;
+      runtimeInputs = [ python ];
+      text = ''
+        def main [...args] {
+          exec python3 ${script} ...$args
+        }
+      '';
+    };
 
   lint = ix.writeNushellApplication pkgs {
     name = "lint";
@@ -51,29 +66,20 @@ let
     '';
   };
 
-  updateMods = ix.writeNushellApplication pkgs {
+  updateMods = mkPythonWrapper {
     name = "update-mods";
-    runtimeInputs = [ pkgs.python3 ];
-    text = ''
-      def main [...args] {
-        exec python3 ${repoRoot + "/tools/update-mods.py"} ...$args
-      }
-    '';
+    script = paths.tools.updateMods;
   };
 
-  ixFleet = ix.writeNushellApplication pkgs {
+  ixFleet = mkPythonWrapper {
     name = "ix-fleet";
-    runtimeInputs = [ python ];
-    text = ''
-      def main [...args] {
-        exec python3 ${repoRoot + "/tools/ix-fleet.py"} ...$args
-      }
-    '';
+    script = paths.tools.ixFleet;
+    python = pythonWithPydantic;
   };
 
-  benchFilesystem = import (repoRoot + "/bench/filesystem") { inherit ix pkgs; };
+  benchFilesystem = import paths.bench.filesystem { inherit ix pkgs; };
 
-  claudeCodeDemo = import examplePaths.claudeCodeDemo {
+  claudeCodeDemo = import paths.examples.claudeCodeDemo {
     ix = ix // {
       lib = ix;
     };
@@ -98,18 +104,14 @@ let
 
   repoPackages = ix.packageSetFor pkgs;
 
-  imagePackages = ix.discoverImages (repoRoot + "/images") // {
-    inherit (ix.pkgs) tonbo-artifacts;
-  };
-
   lintSource = fs.toSource {
-    root = repoRoot;
-    fileset = fs.gitTracked repoRoot;
+    inherit (paths) root;
+    fileset = fs.gitTracked paths.root;
   };
 in
 {
   packages =
-    imagePackages
+    (ix.discoverImages paths.images)
     // claudeCodeDemo.systemPackages
     // claudeCodeDemoImages
     // {
@@ -122,6 +124,7 @@ in
       claude-code-demo-linux-up = claudeCodeDemoLinuxUp;
       claude-code-demo-minecraft-up = claudeCodeDemoMinecraftUp;
       minestom-hello-server-jar = repoPackages.minestom.helloServerJar;
+      inherit (ix) tonbo-artifacts;
     };
 
   apps = {
@@ -139,7 +142,7 @@ in
   };
 
   checks = lib.optionalAttrs (system == ix.system) {
-    eval = import (repoRoot + "/tests") { inherit nixpkgs ix; };
+    eval = import paths.tests { inherit nixpkgs ix; };
     lint = pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ pkgs.coreutils ]; } ''
       cp -R ${lintSource} source
       chmod -R u+w source


### PR DESCRIPTION
Fresh-eyes pass over the cleaned flake from #38 turned up two small things worth tightening.

**`tonbo-artifacts` was in the overlay for no reason.** Overlays should only carry packages that NixOS modules actually consume via `pkgs.<name>` (in this repo: `minecraft-rcon`, `minecraft-hot-reload-agent`). `tonbo-artifacts` is only ever pulled as a flake output, but it was polluting nixpkgs inside every image evaluation, and it was being misfiled into `imagePackages` despite not being an image. Now it lives as a top-level `ix.tonbo-artifacts` value (built against `ix.pkgs` since the upstream tarball is x86_64-linux only), and `per-system.nix` `inherit`s it directly into the packages set.

**Path literals were duplicated across `flake.nix` and `lib/per-system.nix`.** `flake.nix` already had a `paths` manifest threaded into `lib/default.nix`, but `per-system.nix` separately took `repoRoot` plus `examplePaths` and rebuilt several paths inline: `repoRoot + "/images"`, `"/tools/update-mods.py"`, `"/tools/ix-fleet.py"`, `"/tests"`, `"/bench/filesystem"`. One of those, `tools/ix-fleet.py`, was already declared as `paths.tools.ixFleet` and used by the fleet runtime, so the same literal lived in two places. Unify everything under a single `paths` attrset in `flake.nix` (now also holding `root`, `images`, `tests`, `bench.filesystem`, `examples.claudeCodeDemo`, `tools.updateMods`) and pass it to both lib entries.

While in there I factored the two python wrappers (`update-mods`, `ix-fleet`) into one `mkPythonWrapper { name, script, python ? pkgs.python3 }` helper since they had been verbatim copies.

## Numbers

`flake.nix` 65 → 76 lines (paths gained explicit entries, worth it). `lib/per-system.nix` 153 → 156 lines (helper + cleanup roughly cancel). No functional changes: `tonbo-artifacts`, `lint`, and `minestom-hello-server-jar` all evaluate to the same store paths as before. Image and demo store paths shift because the flake source root content changes with these edits.

## Verifying

- `nix run .#lint` clean.
- `nix eval --raw .#packages.aarch64-darwin.tonbo-artifacts` -> same `/nix/store/h30m67ws...` as on `main`.
- `nix eval --raw .#packages.aarch64-darwin.minecraft_26.1.2-fabric` -> new store path because of source-root churn, but it evaluates.
