### PR TITLE
Add stock Caddy reverse-proxy gateway image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,22 @@ Images are not stacked at runtime. ix runs one image. Layering is purely a build
 
 ix VMs implicitly have snapshots and effectively unbounded disk. Fleet and stateful-service designs should lean on those primitives: take snapshots before destructive or data-format-changing operations, prefer in-place NixOS/system switches for stateful nodes, and do not design around fixed-root-disk exhaustion as a primary constraint.
 
+## Trust model
+
+Assume the agent running inside a VM has root and a goal it is optimizing for. It can install packages, edit `/etc`, restart services, flip `networking.firewall.enable`, and overwrite anything reachable from inside the guest. What it does not have by default: host API credentials, the ix CLI's host-side authority, registry-write tokens, or any secret you do not mount in. Design follows from that asymmetry. Anything that must hold against a misbehaving in-VM process belongs outside the VM, where the agent cannot reach it.
+
+Concrete shapes this principle produces:
+
+- **Network policy.** In-VM `networking.firewall.*` is convenience for a cooperative guest. The guest can disable it, so it is not a containment boundary. When a port must stay closed against a rogue guest, the enforcement point is a separate router/gateway VM the agent has no shell on, or one of ix's group/internet primitives. Inline `networking.firewall.allowedTCPPorts` is still the right place to *declare* intent (co-located with the service that needs the port); the enforcing layer reads that intent from outside.
+- **Secrets.** Long-lived credentials (API keys, registry-write tokens, cloud creds) stay on the host or in a sibling VM that does not share a kernel with the agent. Mount only the short-lived, narrowly-scoped material the agent needs for the current task.
+- **Snapshot and rollback authority.** The operator owns snapshot/rollback. An agent that can `ix snapshot` its own VM can paper over destructive behavior, so that surface belongs on the host side.
+- **Image and switch-source authority.** The agent should not be able to switch its own VM to an unsigned or unreviewed image, or rewrite the source the VM was built from. That capability lives with the operator.
+
+The "VM networking" section below is one specialization of this principle. Apply the same lens whenever a new feature lands: "if a rogue agent in this VM tried to subvert this, where does the rule actually live?"
+
 ## VM networking
 
-Networking policy lives in the image, not in ix. ix exposes two primitives: VM group membership (east-west, which VMs can reach each other) and internet ingress/egress on or off (north-south, per direction). Per-port filtering, L7 rules, WAF, rate limiting, and mTLS termination belong in the image's NixOS config (`networking.firewall.*`, services in front of the workload) or in a user-built gateway VM. Do not push port allowlists or L7 features into ix; the matching rule on the ix side is recorded in `ix/AGENTS.md` under "Architecture that must not drift". If a service needs only some ports exposed, declare it in the image with `networking.firewall.allowedTCPPorts` or front it with a gateway VM.
+Networking policy lives in the image, not in ix. ix exposes two primitives: VM group membership (east-west, which VMs can reach each other) and internet ingress/egress on or off (north-south, per direction). Per-port filtering, L7 rules, WAF, rate limiting, and mTLS termination belong in the image's NixOS config (`networking.firewall.*`, services in front of the workload) or in a user-built gateway VM. Do not push port allowlists or L7 features into ix; the matching rule on the ix side is recorded in `ix/AGENTS.md` under "Architecture that must not drift". If a service needs only some ports exposed, declare it in the image with `networking.firewall.allowedTCPPorts` or front it with a gateway VM. Treat in-image firewall config as cooperative-guest intent per the trust model above: if the policy must hold against a rogue agent inside the same VM, the enforcement layer must live on a separate gateway/router VM the agent cannot reach.
 
 ## Registry access
 

--- a/images/services/gateway/default.nix
+++ b/images/services/gateway/default.nix
@@ -1,0 +1,11 @@
+# Stock reverse-proxy gateway image. Enables `services.gateway` (Caddy) with
+# auto-HTTPS so a fleet can put a "expose only some ports" VM in front of
+# its backends without rolling its own haproxy/nginx/caddy config. Users
+# override `services.gateway.routes` (and usually `services.gateway.tlsEmail`)
+# in their fleet definition; the image ships unusable-as-is on purpose so a
+# blank `latest` tag cannot accidentally route public traffic somewhere.
+_: {
+  ix.image.name = "gateway";
+
+  services.gateway.enable = true;
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -8,6 +8,7 @@
 # `profiles/base.nix`, which `lib/ix-oci-layer.nix` enables by default.
 {
   base = ./profiles/base.nix;
+  gateway = ./services/gateway.nix;
   git-clone = ./services/git-clone.nix;
   minestom = ./services/minestom.nix;
   minecraft-bedrock = ./services/minecraft-bedrock.nix;

--- a/modules/services/gateway.nix
+++ b/modules/services/gateway.nix
@@ -1,0 +1,92 @@
+# Caddy-based reverse-proxy gateway. Stock starting point for "expose only
+# some ports" workflows under the primitives-only networking rule (see
+# `ix/AGENTS.md` and the `VM networking` section of `AGENTS.md`): users put a
+# gateway VM in front of their backend VMs, declare `services.gateway.routes`
+# in Nix, and ix's host layer never sees per-port intent.
+{
+  config,
+  lib,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
+  cfg = config.services.gateway;
+in
+{
+  options.services.gateway = {
+    enable = mkEnableOption "Caddy reverse-proxy gateway";
+
+    routes = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = {
+        "example.com" = "http://backend:8080";
+      };
+      description = ''
+        Map from Caddy site address (typically a public hostname, optionally
+        with a path matcher) to upstream URL. Each entry becomes a Caddy
+        virtual host with a `reverse_proxy` directive. Set at least one entry
+        before deploying or Caddy will start with no listeners.
+      '';
+    };
+
+    tlsEmail = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "ops@example.com";
+      description = ''
+        Contact email for Let's Encrypt account registration. Required for
+        automatic HTTPS on real domains; leave null for local-only deployments
+        where Caddy will issue an internal CA cert instead.
+      '';
+    };
+
+    httpRedirect = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Redirect HTTP traffic to HTTPS. Off only for intranet routes that must
+        serve plain HTTP (Caddy still issues internal certs by default).
+      '';
+    };
+
+    maxRequestBodyMiB = mkOption {
+      type = types.ints.positive;
+      default = 32;
+      description = "Maximum request body size, in mebibytes. Applied to every route.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.caddy = {
+      enable = true;
+      email = mkIf (cfg.tlsEmail != null) cfg.tlsEmail;
+      globalConfig = mkIf (!cfg.httpRedirect) ''
+        auto_https disable_redirects
+      '';
+      virtualHosts = lib.mapAttrs (_host: upstream: {
+        extraConfig = ''
+          reverse_proxy ${upstream}
+          request_body {
+            max_size ${toString cfg.maxRequestBodyMiB}MB
+          }
+          encode gzip zstd
+          log {
+            output stdout
+            format json
+          }
+        '';
+      }) cfg.routes;
+    };
+
+    networking.firewall.allowedTCPPorts = [
+      80
+      443
+    ];
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -85,6 +85,18 @@ let
   kernelDevGitCloneService = kernelDevConfig.systemd.services.git-clone;
   kernelDevGitCloneTimer = kernelDevConfig.systemd.timers.git-clone;
 
+  gatewayConfig = evalConfig [
+    ../images/services/gateway
+    {
+      services.gateway = {
+        routes."example.com" = "http://backend:8080";
+        tlsEmail = "ops@example.com";
+      };
+    }
+  ];
+  gatewayCaddy = gatewayConfig.services.caddy;
+  gatewayExampleHost = gatewayCaddy.virtualHosts."example.com";
+
   pythonAppClosureProbe = ix.writePythonApplication pkgs {
     name = "python-app-closure-probe";
     src = pkgs.writeText "python-app-closure-probe.py" ''
@@ -376,6 +388,31 @@ let
     {
       assertion = !(remoteDesktopConfig.systemd.services ? novnc);
       message = "remote-desktop should not use a separate noVNC websockify service";
+    }
+    {
+      assertion = gatewayCaddy.enable;
+      message = "gateway image should enable services.caddy via services.gateway";
+    }
+    {
+      assertion = gatewayCaddy.email == "ops@example.com";
+      message = "gateway tlsEmail should flow into the Caddy ACME contact";
+    }
+    {
+      assertion =
+        gatewayConfig.networking.firewall.allowedTCPPorts == [
+          80
+          443
+        ];
+      message = "gateway image should open only 80 and 443 in the in-guest firewall";
+    }
+    {
+      assertion =
+        builtins.match ".*reverse_proxy http://backend:8080.*" gatewayExampleHost.extraConfig != null;
+      message = "gateway routes should render a Caddy reverse_proxy directive for each entry";
+    }
+    {
+      assertion = builtins.match ".*max_size 32MB.*" gatewayExampleHost.extraConfig != null;
+      message = "gateway maxRequestBodyMiB should default to a 32MB request_body cap";
     }
     {
       assertion = fleet.nodes.db.networking.hostName == "db";


### PR DESCRIPTION
Closes #42.

Under the "networking policy lives in the image, not in ix" rule, a user who wants the AWS-reflex "expose only port 443" shape has to put a gateway VM in front of their backends. Today there's no stock image for that, so every first-time user spends the first ten minutes wiring up haproxy or caddy in Nix instead of shipping. This adds a tiny `services.gateway` module wrapping Caddy and a thin `images/services/gateway` image that fleets can drop in.

Surface (intentionally small):

- `services.gateway.routes` is an attrset from Caddy site address (typically a public hostname, optionally with a path matcher) to upstream URL. Each entry becomes a Caddy virtual host with `reverse_proxy`, a default 32 MiB `request_body` cap (`services.gateway.maxRequestBodyMiB`), `encode gzip zstd`, and JSON access logs to stdout.
- `services.gateway.tlsEmail` flows into the Caddy ACME contact; set it for Let's Encrypt on real domains, leave it null for local-only deployments where Caddy issues an internal CA cert.
- `services.gateway.httpRedirect` defaults on. Off only for intranet routes that must stay plain HTTP.
- The module opens 80 and 443 in the in-guest firewall and nothing else; finer policy is the user's problem per the philosophy.

The image flips `services.gateway.enable = true` and leaves `routes` empty by design. A freshly-tagged `gateway:latest` cannot accidentally proxy traffic somewhere; the fleet that consumes it has to declare routes explicitly.

Out of scope for v0: L4 / raw TCP / UDP passthrough, weighted load balancing, per-route auth, rewrites beyond Caddy defaults. The image is meant to be forked when those land. The trade-off list (Caddy vs HAProxy) is recorded in #42; Caddy won on auto-HTTPS, HTTP/3, sane defaults, and Nix-config ergonomics.

Eval tests in `tests/default.nix` cover: `services.caddy` is enabled through `services.gateway`, `tlsEmail` flows to the Caddy ACME contact, the firewall opens 80 and 443 only, a configured route renders as a Caddy `reverse_proxy` directive, and the request-body cap renders at the default 32MB.

Image build was verified locally (`nix build .#gateway` -> `gateway-oci.tar`).
