### PR TITLE
Apply RFC 0042, 0145, 0119 conventions across the repo

### DIFF
--- a/examples/claude-code-demo/default.nix
+++ b/examples/claude-code-demo/default.nix
@@ -303,8 +303,8 @@ let
               virtualHosts."claude-code-demo" = {
                 default = true;
                 root = "${demoSite}/share/claude-code-demo-site";
-                locations."/stats.json".extraConfig = "root /run/claude-code-demo;";
-                locations."/".extraConfig = "try_files $uri $uri/ /index.html;";
+                locations."/stats.json".root = "/run/claude-code-demo";
+                locations."/".tryFiles = "$uri $uri/ /index.html";
               };
             };
 

--- a/examples/claude-code-demo/linux/default.nix
+++ b/examples/claude-code-demo/linux/default.nix
@@ -286,8 +286,8 @@ in
         virtualHosts."claude-code-demo" = {
           default = true;
           root = "${demoSite}/share/claude-code-demo-site";
-          locations."/stats.json".extraConfig = "root /run/claude-code-demo;";
-          locations."/".extraConfig = "try_files $uri $uri/ /index.html;";
+          locations."/stats.json".root = "/run/claude-code-demo";
+          locations."/".tryFiles = "$uri $uri/ /index.html";
         };
       };
 

--- a/lib/build-gradle-fat-jar.nix
+++ b/lib/build-gradle-fat-jar.nix
@@ -1,3 +1,22 @@
+/**
+  Build a Gradle fat-jar with a pinned dependency-verification metadata file.
+
+  Wraps `pkgs.stdenv.mkDerivation` with Gradle as the build tool. The
+  dependency hashes come from a Gradle dependency-verification XML
+  reproduced into the build sandbox, so the build is fixed-output and
+  network-isolated. The selected Gradle task runs in offline mode.
+
+  Arguments:
+  - `pname`, `version`, `src`: derivation identity and source.
+  - `verificationMetadata`: path to the Gradle verification XML.
+  - `javaPackage`, `gradle`: toolchain packages.
+  - `gradleBuildTask`, `gradleCheckTask`, `gradleFlags`: build invocation.
+  - `jarPath`: relative path of the produced jar inside the source tree.
+  - `installPhase`: override the default `cp ${jarPath} $out/...` phase.
+  - `doCheck`: run `gradleCheckTask` before the build task.
+  - Other standard `mkDerivation` args (`nativeBuildInputs`, `meta`,
+    `passthru`, `preConfigure`, etc.) are forwarded.
+*/
 { lib }:
 
 pkgs:

--- a/lib/build-npm-site.nix
+++ b/lib/build-npm-site.nix
@@ -1,7 +1,20 @@
-# Build a static frontend site from an npm project. Dependency hashes come from
-# package-lock.json, so updating dependencies is just `npm install` plus a
-# commit. Dependencies are built separately and linked into the site build, so
-# source-only changes do not rerun `npm install`.
+/**
+  Build a static frontend site from an npm project.
+
+  Dependency hashes come from `package-lock.json`, so updating
+  dependencies is just `npm install` plus a commit. Dependencies are
+  built separately and linked into the site build, so source-only
+  changes do not rerun `npm install`.
+
+  Arguments:
+  - `pname`, `version`: derivation identity.
+  - `src`: project root containing `package.json` and `package-lock.json`.
+  - `buildScript`: npm script to run for the production build.
+  - `distDir`: relative path of the build output inside `src`.
+  - `installDir`: path under `$out` where the built assets are installed.
+  - `extraNativeBuildInputs`: extra packages on PATH for the build.
+  - `meta`: standard derivation meta.
+*/
 pkgs:
 {
   pname,

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,21 +1,5 @@
-# ix/images public lib.
-#
-# `mkImage` builds one self-contained OCI archive from a list of NixOS
-# modules. Each image is independent: ix does not stack images at runtime, it
-# runs one. `./ix-platform.nix` and `./ix-oci-layer.nix` form the implicit
-# base layer (container marker, target platform, OCI packaging, base profile
-# enabled by default). The module registry is pulled in so option declarations
-# are available to every image, but each module is gated on its own `enable`
-# flag and stays inert unless the image turns it on.
-#
-# `discoverImages` walks `images/<category>/<name>/` and turns each directory
-# into a flake package. If a directory has a `versions.nix` sibling, every
-# version produces `<name>_<ver>` and the `default` key picks the unsuffixed
-# `<name>` alias.
-#
-# `mkMinecraftLoader` is one of several cross-cutting helpers exposed to
-# modules via `specialArgs.ix`. Modules access them as `{ ix, ... }: ix.foo`
-# instead of relative-path imports.
+# ix/images public lib. Helpers documented per binding with RFC-0145
+# doc-comments below; the file's job is to wire them together.
 {
   nixpkgs,
   paths,
@@ -24,6 +8,25 @@ let
   inherit (nixpkgs) lib;
 
   system = "x86_64-linux";
+
+  /**
+    Package a Python entrypoint as a standalone executable.
+
+    Wraps `src` in a launcher script that prepends `runtimeInputs` to PATH
+    and runs the file under `python`. When `check` is true (default), the
+    derivation also runs `basedpyright` over `src` with `typeCheckingMode`
+    enforcement during the build, so type regressions fail the build instead
+    of surfacing at runtime.
+
+    Arguments:
+    - `name`: derivation name and `/bin/<name>` executable.
+    - `src`: a path or store path containing the Python entrypoint.
+    - `args`: literal argv prefix prepended to user args at runtime.
+    - `runtimeInputs`: extra packages prepended to PATH at runtime.
+    - `python`: Python interpreter package. Defaults to `pkgs.python314`.
+    - `check`, `typeCheckingMode`, `pythonPlatform`: basedpyright knobs.
+    - `meta`: standard derivation meta, with `mainProgram` defaulted.
+  */
   writePythonApplication =
     pkgs:
     {
@@ -73,6 +76,23 @@ let
       };
     };
 
+  /**
+    Package a Nushell command as a standalone executable.
+
+    Generates a Nu script that prepends `runtimeInputs` to PATH while
+    preserving the ambient PATH, then runs `text` as the body. With
+    `check` left on (default), nushell's `--ide-check` parses the
+    generated script during the build so syntax errors fail the build
+    rather than reaching the user.
+
+    Arguments:
+    - `name`: derivation name and `/bin/<name>` executable.
+    - `runtimeInputs`: packages prepended to PATH for the script body.
+    - `text`: the Nu script body. A leading `#!/usr/bin/env nu` line is
+      stripped before splicing.
+    - `check`: run `nu --ide-check` at build time.
+    - `meta`: standard derivation meta, with `mainProgram` defaulted.
+  */
   writeNushellApplication =
     pkgs:
     {
@@ -98,8 +118,6 @@ let
 
       ''
       + scriptBody;
-      # `--ide-check` parses the generated script and reports diagnostics
-      # without running `main`, so command wrappers are checked at build time.
       checkPhase = lib.optionalString check ''
         ${lib.getExe pkgs.nushell} --no-config-file --no-std-lib --ide-check 100 "$target"
       '';
@@ -108,9 +126,13 @@ let
       };
     };
 
-  # Repo-local packages that NixOS modules reach for as `pkgs.<name>`.
-  # Flake-output-only packages live in `packageSetFor` instead so they don't
-  # leak into the nixpkgs namespace inside images.
+  /**
+    Repo-local nixpkgs overlay.
+
+    Exposes the few repo-owned packages that NixOS modules expect to find
+    as `pkgs.<name>`. Flake-output-only packages live in `packageSetFor`
+    instead so they don't leak into the nixpkgs namespace inside images.
+  */
   overlay = final: _prev: {
     minecraft-hot-reload-agent = final.callPackage paths.packages.minecraftHotReloadAgent { };
     minecraft-rcon = final.callPackage paths.packages.minecraftRcon {
@@ -118,9 +140,16 @@ let
     };
   };
   overlays = [ overlay ];
+
+  /**
+    nixpkgs instance with the repo overlay applied, evaluated for
+    `x86_64-linux`. Use this when the image build needs `pkgs` directly.
+  */
   pkgs = import nixpkgs { inherit system overlays; };
 
-  # The module registry. collect picks all leaf paths from the nested attrset.
+  # Flat list of module paths from the canonical nested registry in
+  # `modules/default.nix`. Pulled in unconditionally so every option is in
+  # scope; each module stays inert until its `enable` flag is set.
   moduleList = lib.collect builtins.isPath (import paths.modules);
 
   buildNpmSite = import ./build-npm-site.nix;
@@ -139,11 +168,19 @@ let
       // args
     );
 
-  # Fetch a static artifact (mod jar, plugin, server) by URL + SRI hash.
-  # Hashes live next to URLs in the consuming catalog rather than in flake
-  # inputs, so a routine mod bump touches one JSON file and not flake.lock.
+  /**
+    Fetch a static artifact (mod jar, plugin, server) by URL + SRI hash.
+
+    Hashes live next to URLs in the consuming catalog rather than in flake
+    inputs, so a routine mod bump touches one JSON file and not
+    `flake.lock`. Accepts and ignores extra catalog keys.
+  */
   mkArtifact = { url, hash, ... }: pkgs.fetchurl { inherit url hash; };
 
+  /**
+    Enrich every entry of a `{ slug = { url, hash, ... }; ... }` catalog
+    with a `src` attribute pointing at the fetched store path.
+  */
   attachArtifactSources = lib.mapAttrs (_: entry: entry // { src = mkArtifact entry; });
 
   paperServers = {
@@ -156,14 +193,17 @@ let
     };
   };
 
-  # Per-version Fabric/NeoForge/Sponge mod catalogs generated by
-  # `tools/update-mods.py` from `<paths.minecraftMods>/manifest.json`. The
-  # bare-JSON catalog (slug -> { url, hash }) becomes `{ url, hash, src }` so
-  # callers can pass it straight to `services.minecraft.modCatalog`.
-  #
-  # Examples and images both consume `modCatalogs.<gameVersion>` by name. To
-  # add a mod, edit the manifest and run `nix run .#update-mods`; do not
-  # inline URLs anywhere downstream.
+  /**
+    Per-version Fabric/NeoForge/Sponge mod catalogs generated by
+    `tools/update-mods.py` from `<paths.minecraftMods>/manifest.json`.
+
+    The bare-JSON catalog (slug -> `{ url, hash }`) is enriched into
+    `{ url, hash, src }` so callers can pass it straight to
+    `services.minecraft.modCatalog`. Examples and images consume
+    `modCatalogs.<gameVersion>` by name; to add a mod, edit the manifest
+    and run `nix run .#update-mods` and do not inline URLs anywhere
+    downstream.
+  */
   modCatalogs =
     let
       gameVersions = lib.pipe paths.minecraftMods [
@@ -181,6 +221,12 @@ let
         );
     in
     lib.genAttrs gameVersions catalogFor;
+
+  /**
+    Pinned artifact catalogs surfaced to images and examples by name.
+    Examples must consume entries through this set (or one of the module
+    options it seeds) rather than inlining URLs and hashes.
+  */
   artifacts = {
     inherit attachArtifactSources;
     minecraft = {
@@ -221,6 +267,15 @@ let
     };
   };
 
+  /**
+    Flake-output-only repo packages, callPackage-style.
+
+    These are derivations that flake consumers can reach as
+    `packages.<system>.<name>`, but that we don't want to inject into the
+    nixpkgs namespace inside an image's evaluation. Each entry takes the
+    standard `pkgs` it should build against and the cross-cutting
+    `specialArgs.ix` bundle.
+  */
   packageSetFor =
     pkgs:
     let
@@ -235,8 +290,11 @@ let
       tonbo-artifacts = pkgs.callPackage paths.packages.tonboArtifacts { };
     };
 
-  # Helpers exposed to every module via specialArgs. Keep this surface small
-  # and stable: anything here is part of the cross-module contract.
+  /**
+    Cross-cutting helpers handed to every module through `specialArgs.ix`.
+    Keep this surface small and stable: anything here is part of the
+    cross-module contract.
+  */
   ixSpecialArgs = {
     inherit
       artifacts
@@ -251,6 +309,16 @@ let
     packages = packageSetFor pkgs;
   };
 
+  /**
+    Run the platform config, OCI packaging, base profile, the full module
+    registry, and the caller's `modules` through `lib.nixosSystem`, then
+    return the evaluated `config`. This is the evaluation path every
+    image build and every eval test goes through, so a test exercising it
+    catches the same regressions a real build would.
+
+    Arguments:
+    - `modules`: list of additional modules layered on top of the base.
+  */
   evalImageConfig =
     {
       modules ? [ ],
@@ -267,8 +335,20 @@ let
       ++ modules;
     }).config;
 
+  /**
+    Build one self-contained OCI archive from a list of NixOS modules.
+
+    Each image is independent: ix does not stack images at runtime, it
+    runs one. Returns the OCI-archive derivation; pass it to
+    `ix image push` or use it as a `packages.<system>.<name>` output.
+  */
   mkImage = args: (evalImageConfig args).ix.build.ociImage;
 
+  /**
+    Build a fleet plan helper for a given host system. Returns a function
+    that takes a fleet spec and produces the plan/commands tooling consumes.
+    `mkFleet` is the default-system shortcut.
+  */
   mkFleetFor =
     hostSystem:
     import ./fleet.nix {
@@ -322,13 +402,43 @@ let
     else
       { ${name} = mkImage { modules = [ path ]; }; };
 
+  /**
+    Walk `images/<category>/<name>/` under `root` and expose every
+    directory as a flake package. A directory with a `versions.nix`
+    sibling produces `<name>_<ver>` for each version key plus a
+    `<name>` alias for the `default` version.
+
+    `imageTests` is an optional attrset keyed by image name (matching
+    the discovered package names). When an image has an entry, it is
+    attached to the image derivation as `passthru.tests.eval` so
+    `nix build .#<image>.passthru.tests.eval` runs it (RFC 0119).
+  */
   discoverImages =
-    root:
-    lib.mergeAttrsList (
-      lib.concatMap (
-        cat: map (name: imagePackages name (root + "/${cat}/${name}")) (subdirs (root + "/${cat}"))
-      ) (subdirs root)
-    );
+    {
+      root,
+      imageTests ? { },
+    }:
+    let
+      raw = lib.mergeAttrsList (
+        lib.concatMap (
+          cat: map (name: imagePackages name (root + "/${cat}/${name}")) (subdirs (root + "/${cat}"))
+        ) (subdirs root)
+      );
+      attach =
+        name: pkg:
+        if imageTests ? ${name} then
+          pkg
+          // {
+            passthru = (pkg.passthru or { }) // {
+              tests = (pkg.passthru.tests or { }) // {
+                eval = imageTests.${name};
+              };
+            };
+          }
+        else
+          pkg;
+    in
+    lib.mapAttrs attach raw;
 in
 {
   inherit

--- a/lib/fleet.nix
+++ b/lib/fleet.nix
@@ -1,4 +1,12 @@
-# Colmena-style fleet evaluation for ix images.
+/**
+  Colmena-style fleet evaluation for ix images.
+
+  Curried: the outer function takes the build dependencies (`lib`,
+  `pkgs`, `evalImageConfig`, the `ix fleet` script, and the Nushell
+  application helper); the inner takes a fleet spec
+  (`defaults`, `deployment`, `secrets`, `nodes`) and returns the
+  rendered fleet plan, image attrset, and wrapped CLI app.
+*/
 {
   lib,
   pkgs,

--- a/lib/minecraft-loader.nix
+++ b/lib/minecraft-loader.nix
@@ -1,15 +1,19 @@
-# Helper for declaring a minecraft loader module (Fabric, Paper, Vanilla, ...).
-#
-# Each loader is structurally identical: declare `services.minecraft.<name>`
-# with an enable flag and a server-jar slot, and assign that jar to
-# `services.minecraft.serverJar`. The `src` slot defaults to
-# `ix.artifacts.minecraft.servers."${cfg.version}-${name}"`, so a caller that
-# sets `services.minecraft.version` rarely has to override anything per loader.
-#
-# Reached from modules via `specialArgs.ix.mkMinecraftLoader`. Loader files
-# call it and return the resulting module attrset directly. Loaders that need
-# to contribute more to `config` pass an `extraConfig cfg` hook; it merges into
-# the gated config so the loader file stays a single expression.
+/**
+  Declare a Minecraft loader module (Fabric, Paper, Vanilla, ...).
+
+  Each loader is structurally identical: it owns
+  `services.minecraft.<name>` with an enable flag and a server-jar slot,
+  and assigns that jar to `services.minecraft.serverJar`. The `src` slot
+  defaults to `ix.artifacts.minecraft.servers."${cfg.version}-${name}"`,
+  so callers that set `services.minecraft.version` rarely override
+  anything per loader.
+
+  Reached from modules via `specialArgs.ix.mkMinecraftLoader`. Loader
+  files call it and return the resulting module attrset directly.
+  Loaders that need to contribute more to `config` pass an
+  `extraConfig cfg` hook; it merges into the gated config so the loader
+  file stays a single expression.
+*/
 {
   ix,
   config,

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -108,10 +108,15 @@ let
     inherit (paths) root;
     fileset = fs.gitTracked paths.root;
   };
+
+  tests = import paths.tests { inherit nixpkgs ix; };
 in
 {
   packages =
-    (ix.discoverImages paths.images)
+    (ix.discoverImages {
+      root = paths.images;
+      inherit (tests) imageTests;
+    })
     // claudeCodeDemo.systemPackages
     // claudeCodeDemoImages
     // {
@@ -144,7 +149,7 @@ in
   };
 
   checks = lib.optionalAttrs (system == ix.system) {
-    eval = import paths.tests { inherit nixpkgs ix; };
+    inherit (tests) eval;
     lint = pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ pkgs.coreutils ]; } ''
       cp -R ${lintSource} source
       chmod -R u+w source

--- a/lib/systemd-hardening.nix
+++ b/lib/systemd-hardening.nix
@@ -1,7 +1,11 @@
-# Baseline systemd hardening for long-running network daemons. Restricts
-# capabilities, devices, kernel surfaces, and namespaces. Address families
-# stay open enough to accept inbound TCP/UDP and AF_UNIX. Merge into
-# `serviceConfig` and override fields per service as needed.
+/**
+  Baseline systemd hardening for long-running network daemons.
+
+  Restricts capabilities, devices, kernel surfaces, and namespaces.
+  Address families stay open enough to accept inbound TCP/UDP and
+  AF_UNIX. Merge into `serviceConfig` and override individual fields per
+  service as needed.
+*/
 {
   CapabilityBoundingSet = [ "" ];
   DeviceAllow = [ "" ];

--- a/modules/services/postgresql.nix
+++ b/modules/services/postgresql.nix
@@ -8,6 +8,7 @@
 }:
 let
   inherit (lib)
+    mkDefault
     mkEnableOption
     mkIf
     mkOption
@@ -28,12 +29,6 @@ in
       type = types.str;
       default = "/var/lib/postgresql/18";
     };
-
-    extraSettings = mkOption {
-      type = types.attrsOf types.str;
-      default = { };
-      description = "Additional postgresql.conf key-value pairs merged on top of tuned defaults.";
-    };
   };
 
   config = mkIf cfg.enable {
@@ -44,12 +39,15 @@ in
       package = pkgs.postgresql_18;
       inherit (cfg) dataDir port;
       enableJIT = true;
-      settings = {
+      # Tuned defaults for a dedicated VM. Override any of these by setting
+      # `services.postgresql.settings.<key>` in the same module; the user
+      # assignment wins over `mkDefault`.
+      settings = lib.mapAttrs (_: mkDefault) {
         # connections
         listen_addresses = "*";
         max_connections = "200";
 
-        # memory: tuned for dedicated VM, adjust via extraSettings
+        # memory
         shared_buffers = "256MB";
         effective_cache_size = "768MB";
         work_mem = "4MB";
@@ -87,8 +85,7 @@ in
 
         # JIT
         jit = "on";
-      }
-      // cfg.extraSettings;
+      };
     };
   };
 }

--- a/modules/services/remote-desktop.nix
+++ b/modules/services/remote-desktop.nix
@@ -8,6 +8,7 @@
 }:
 let
   inherit (lib)
+    mkDefault
     mkEnableOption
     mkIf
     mkOption
@@ -30,6 +31,15 @@ let
     '';
   };
 
+  flagValueType = types.oneOf [
+    types.bool
+    types.int
+    types.str
+    (types.listOf types.str)
+  ];
+
+  flags = lib.cli.toCommandLineGNU { } cfg.settings;
+
   launcher = ix.writeNushellApplication pkgs {
     name = "ix-remote-desktop";
     runtimeInputs = [
@@ -42,24 +52,8 @@ let
             [
               "start-desktop"
               cfg.display
-              "--start=${cfg.desktopCommand}"
-              "--bind-tcp=${cfg.bindAddress}:${toString cfg.port}"
-              "--auth=${cfg.auth}"
-              "--resize-display=${cfg.resolution}"
-              "--socket-dirs=/run/remote-desktop"
-              "--html=on"
-              "--ssl=off"
-              "--daemon=no"
-              "--mdns=no"
-              "--pulseaudio=no"
-              "--notifications=no"
-              "--webcam=no"
-              "--printing=no"
-              "--file-transfer=off"
-              "--open-files=off"
-              "--clipboard=on"
             ]
-            ++ cfg.extraOptions
+            ++ flags
           )
         }
         exec xpra ...$args
@@ -110,14 +104,40 @@ in
       description = "Xpra authentication module for incoming clients.";
     };
 
-    extraOptions = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      description = "Additional command-line options passed to Xpra.";
+    settings = mkOption {
+      type = types.attrsOf flagValueType;
+      default = { };
+      description = ''
+        Flags passed to `xpra start-desktop` rendered via `lib.cli.toCommandLineGNU`.
+        Each entry becomes `--key=value`; `true` becomes a bare `--key`, `false`
+        omits the flag, and list values render as repeated `--key=elem` entries.
+        Convenience options (`port`, `bindAddress`, `display`, `resolution`,
+        `desktopCommand`, `auth`) seed this set via `mkDefault`, so a direct
+        assignment here wins.
+      '';
     };
   };
 
   config = mkIf cfg.enable {
+    services.remote-desktop.settings = {
+      start = mkDefault cfg.desktopCommand;
+      bind-tcp = mkDefault "${cfg.bindAddress}:${toString cfg.port}";
+      auth = mkDefault cfg.auth;
+      resize-display = mkDefault cfg.resolution;
+      socket-dirs = mkDefault "/run/remote-desktop";
+      html = mkDefault "on";
+      ssl = mkDefault "off";
+      daemon = mkDefault "no";
+      mdns = mkDefault "no";
+      pulseaudio = mkDefault "no";
+      notifications = mkDefault "no";
+      webcam = mkDefault "no";
+      printing = mkDefault "no";
+      file-transfer = mkDefault "off";
+      open-files = mkDefault "off";
+      clipboard = mkDefault "on";
+    };
+
     environment.systemPackages = [
       cfg.package
       pkgs.icewm

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,3 +1,7 @@
+# Eval tests. Each image with image-specific assertions has its own group
+# below, exposed as `imageTests.<name>` so it can be attached to the image
+# derivation via `passthru.tests`. `eval` aggregates them along with the
+# cross-image checks (fleet, helpers).
 {
   nixpkgs,
   ix,
@@ -132,362 +136,420 @@ let
   };
 
   fleetPlan = fleet.planValue.nodes;
-  assertions = [
-    {
-      assertion = kernelDevConfig.ix.image.name == "linux-kernel-dev";
-      message = "kernel-dev image should set the expected OCI image name";
-    }
-    {
-      assertion = kernelDevConfig.services.git-clone.enable;
-      message = "kernel-dev image should enable first-boot git cloning";
-    }
-    {
-      assertion = kernelDevConfig.services.git-clone.url == "https://github.com/torvalds/linux.git";
-      message = "kernel-dev image should clone the Linux repository";
-    }
-    {
-      assertion = kernelDevConfig.services.git-clone.dest == "/src/linux";
-      message = "kernel-dev image should clone Linux into /src/linux";
-    }
-    {
-      assertion = kernelDevConfig.services.git-clone.activation == "timer";
-      message = "kernel-dev image should clone Linux after boot readiness";
-    }
-    {
-      assertion = kernelDevGitCloneService.wantedBy == [ ];
-      message = "timer-activated git clone should not be wanted by multi-user.target";
-    }
-    {
-      assertion = kernelDevGitCloneTimer.wantedBy == [ "timers.target" ];
-      message = "timer-activated git clone should be started by timers.target";
-    }
-    {
-      assertion = minecraftConfig.ix.image.tag == defaultMinecraftVersion;
-      message = "default minecraft image tag should follow versions.nix default";
-    }
-    {
-      assertion = defaultMinecraftVersion == "26.1.2-fabric";
-      message = "default minecraft image should use the stable 26.1.2 Fabric variant";
-    }
-    {
-      assertion = lib.all (slug: builtins.hasAttr slug minecraftConfig.services.minecraft.mods) [
-        "fabric-api"
-        "lithium"
-        "c2me-fabric"
-        "spark"
-        "grimac"
-      ];
-      message = "default minecraft image should include the 26.1.2 Fabric server mod set";
-    }
-    {
-      assertion = minecraftConfig.services.minecraft.javaPackage == pkgs.temurin-jre-bin-25;
-      message = "default Fabric minecraft should use Temurin";
-    }
-    {
-      assertion = lib.hasInfix "/bin/java" minecraftExec;
-      message = "minecraft ExecStart should launch Java";
-    }
-    {
-      assertion = lib.hasInfix "-XX:MaxRAMPercentage=85" minecraftExec;
-      message = "minecraft should use MaxRAMPercentage for auto-scaling heap";
-    }
-    {
-      assertion = lib.hasInfix "-XX:+UseG1GC" minecraftExec;
-      message = "minecraft should include the default modern server GC flags";
-    }
-    {
-      assertion = lib.hasInfix "-jar" minecraftExec && lib.hasInfix "nogui" minecraftExec;
-      message = "minecraft ExecStart should launch the configured server jar in nogui mode";
-    }
-    {
-      assertion = lib.hasInfix "minecraft-hot-reload-agent.jar=socket=/run/minecraft-hot-reload/socket" minecraftExec;
-      message = "Fabric minecraft should start the hot reload Java agent";
-    }
-    {
-      assertion = minecraftService.RuntimeDirectory == "minecraft-hot-reload";
-      message = "Fabric minecraft should create a runtime directory for the hot reload socket";
-    }
-    {
-      assertion = builtins.length minecraftUnit.reloadTriggers == 3;
-      message = "minecraft managed files should trigger systemd reloads rather than unit restarts";
-    }
-    {
-      assertion = lib.hasInfix "minecraft-sync-managed" minecraftUnit.preStart;
-      message = "minecraft preStart should sync managed files from /etc";
-    }
-    {
-      assertion = !(lib.hasInfix "fabric-api" minecraftUnit.preStart);
-      message = "minecraft preStart should not embed managed mod store paths in the unit";
-    }
-    {
-      assertion = paperCfg.dropDir == "plugins";
-      message = "Paper minecraft should use the plugins drop directory";
-    }
-    {
-      assertion = builtins.length paperService.reloadTriggers == 3;
-      message = "Paper minecraft managed plugins should trigger systemd reloads";
-    }
-    {
-      assertion = !(paperServiceConfig ? RuntimeDirectory);
-      message = "Paper minecraft should not start the JVM hot reload socket";
-    }
-    {
-      assertion = paperCfg.autoReload.rconPasswordFile == "/var/lib/minecraft/.ix-rcon-password";
-      message = "Paper minecraft should use a state-local RCON password file";
-    }
-    {
-      assertion = !(paperCfg.serverFiles."server.properties" ? "rcon.password");
-      message = "Paper minecraft should not put the RCON password in Nix-managed server.properties";
-    }
-    {
-      assertion = paperConfig.networking.firewall.allowedTCPPorts == [ paperCfg.port ];
-      message = "Paper minecraft should not expose the local RCON reload port through the firewall";
-    }
-    {
-      assertion = rconCfg.rcon.enable;
-      message = "minecraft RCON should be enabled through a typed option";
-    }
-    {
-      assertion = rconCfg.rcon.passwordFile == "/var/lib/minecraft/.ix-rcon-password";
-      message = "minecraft RCON should default to a state-local password file";
-    }
-    {
-      assertion = !(rconCfg.serverFiles."server.properties" ? "rcon.password");
-      message = "typed minecraft RCON should not put the password in Nix-managed server.properties";
-    }
-    {
-      assertion = rconConfig.networking.firewall.allowedTCPPorts == [ rconCfg.port ];
-      message = "typed minecraft RCON should keep the RCON port private by default";
-    }
-    {
-      assertion =
-        rconOpenFirewallConfig.networking.firewall.allowedTCPPorts == [
-          rconOpenFirewallCfg.port
-          rconOpenFirewallCfg.rcon.port
-        ];
-      message = "typed minecraft RCON should open the firewall only when requested";
-    }
-    {
-      assertion = bedrockConfig.ix.image.name == "minecraft-bedrock";
-      message = "minecraft-bedrock image should set the expected OCI image name";
-    }
-    {
-      assertion = bedrockConfig.ix.image.tag == "1.26.14.1";
-      message = "minecraft-bedrock image tag should follow the pinned Bedrock server version";
-    }
-    {
-      assertion = bedrockCfg.enable;
-      message = "minecraft-bedrock image should enable services.minecraft-bedrock";
-    }
-    {
-      assertion = bedrockCfg.settings."server-name" == "ix-powered Bedrock";
-      message = "minecraft-bedrock should set the expected default server name";
-    }
-    {
-      assertion =
-        bedrockCfg.settings."server-port" == bedrockCfg.port
-        && bedrockCfg.settings."server-portv6" == bedrockCfg.portv6;
-      message = "minecraft-bedrock server.properties should follow the configured UDP ports";
-    }
-    {
-      assertion =
-        bedrockConfig.networking.firewall.allowedUDPPorts == [
-          bedrockCfg.port
-          bedrockCfg.portv6
-        ];
-      message = "minecraft-bedrock firewall should open only the configured UDP ports";
-    }
-    {
-      assertion = bedrockService.description == "Minecraft Bedrock server";
-      message = "minecraft-bedrock should run a dedicated systemd service";
-    }
-    {
-      assertion = lib.hasInfix "/bin/bedrock_server" bedrockServiceConfig.ExecStart;
-      message = "minecraft-bedrock ExecStart should launch bedrock_server";
-    }
-    {
-      assertion = bedrockServiceConfig.StateDirectory == "minecraft-bedrock";
-      message = "minecraft-bedrock service should get a managed state directory";
-    }
-    {
-      assertion = remoteDesktopConfig.ix.image.name == "ix-remote-desktop";
-      message = "remote-desktop image should set the expected OCI image name";
-    }
-    {
-      assertion = remoteDesktopCfg.enable;
-      message = "remote-desktop image should enable services.remote-desktop";
-    }
-    {
-      assertion = remoteDesktopCfg.package == pkgs.xpra;
-      message = "remote-desktop should default to the nixpkgs Xpra package";
-    }
-    {
-      assertion = remoteDesktopCfg.port == 6080;
-      message = "remote-desktop should expose the Xpra HTML5 client on port 6080";
-    }
-    {
-      assertion = remoteDesktopCfg.bindAddress == "0.0.0.0";
-      message = "remote-desktop should bind browser clients on all interfaces by default";
-    }
-    {
-      assertion = remoteDesktopCfg.display == ":100";
-      message = "remote-desktop should let Xpra own a deterministic virtual display";
-    }
-    {
-      assertion = remoteDesktopCfg.resolution == "1920x1080";
-      message = "remote-desktop should default to a browser-friendly 1080p display";
-    }
-    {
-      assertion = remoteDesktopCfg.auth == "none";
-      message = "remote-desktop should keep the current unauthenticated ix image contract explicit";
-    }
-    {
-      assertion = remoteDesktopService.description == "Xpra remote desktop";
-      message = "remote-desktop should run a single Xpra service";
-    }
-    {
-      assertion = remoteDesktopServiceConfig.User == "remote-desktop";
-      message = "remote-desktop service should run as its dedicated system user";
-    }
-    {
-      assertion = remoteDesktopServiceConfig.StateDirectory == "remote-desktop";
-      message = "remote-desktop service should get a managed state directory";
-    }
-    {
-      assertion = remoteDesktopServiceConfig.RuntimeDirectory == "remote-desktop";
-      message = "remote-desktop service should get a managed runtime directory";
-    }
-    {
-      assertion = remoteDesktopConfig.users.users.remote-desktop.isSystemUser;
-      message = "remote-desktop user should be a system user";
-    }
-    {
-      assertion = remoteDesktopConfig.networking.firewall.allowedTCPPorts == [ remoteDesktopCfg.port ];
-      message = "remote-desktop firewall should open only the configured browser port";
-    }
-    {
-      assertion = !(remoteDesktopConfig.systemd.services ? xvfb);
-      message = "remote-desktop should not use a standalone Xvfb service";
-    }
-    {
-      assertion = !(remoteDesktopConfig.systemd.services ? x11vnc);
-      message = "remote-desktop should not use x11vnc";
-    }
-    {
-      assertion = !(remoteDesktopConfig.systemd.services ? novnc);
-      message = "remote-desktop should not use a separate noVNC websockify service";
-    }
-    {
-      assertion = fleet.nodes.db.networking.hostName == "db";
-      message = "fleet nodes should default hostName to the node name";
-    }
-    {
-      assertion = fleet.nodes.db.ix.networking.eastWest.hostName == "db";
-      message = "fleet nodes should expose their east-west host name through ix.networking";
-    }
-    {
-      assertion = fleet.nodes.web.environment.etc."db-host".text == "db";
-      message = "fleet node modules should be able to reference nodes.<name>.config";
-    }
-    {
-      assertion = fleet.nodes.db.services.ix-postgresql.enable;
-      message = "fleet plain attrset nodes should be treated as modules";
-    }
-    {
-      assertion =
-        fleetPlan.web.bootstrapImage == "registry.ix.dev/ix/test-cluster-bootstrap:zstd-tools-2026-05-12";
-      message = "fleet switches should create missing nodes from the shared NixOS bootstrap image";
-    }
-    {
-      assertion = fleetPlan.web.replacementImage.destination == "fleet-web:latest";
-      message = "fleet wrapped-node deployment destination should flow into the replacement image plan";
-    }
-    {
-      assertion = fleetPlan.web.system == "${fleet.nodes.web.system.build.toplevel}";
-      message = "fleet plans should expose the NixOS system closure for switch";
-    }
-    {
-      assertion = fleet.systemPackages.web-system == fleet.nodes.web.system.build.toplevel;
-      message = "fleet system package outputs should match default source switch installables";
-    }
-    {
-      assertion = fleet.packages.web == fleet.nodes.web.ix.build.ociImage;
-      message = "fleet replacement package outputs should keep node names";
-    }
-    {
-      assertion =
-        fleetPlan.web.switch == {
-          target = builtins.unsafeDiscardStringContext fleet.nodes.web.system.build.toplevel.drvPath;
-          buildOn = "remote";
-          buildVm = null;
-          sourceInstallable = ".#web-system";
-          overrideInputs = { };
-        };
-      message = "fleet plans should default to local eval and remote build switch metadata";
-    }
-    {
-      assertion =
-        fleetPlan.web.replacementImage.sourceDrv
-        == builtins.unsafeDiscardStringContext fleet.nodes.web.ix.build.ociImage.drvPath;
-      message = "fleet plans should expose replacement image derivations without forcing local image builds";
-    }
-    {
-      assertion = fleetPlan.web.region == "hil-1";
-      message = "fleet nodes should inherit the top-level deployment region";
-    }
-    {
-      assertion = fleetPlan.web.tags == [ "public" ];
-      message = "fleet wrapped-node tags should flow into the generated plan";
-    }
-    {
-      assertion = fleetPlan.web.ipv4;
-      message = "fleet wrapped-node deployment overrides should flow into the generated plan";
-    }
-    {
-      assertion = fleet.planValue.secrets.sessionKey.generate;
-      message = "fleet plans should carry declarative secret specs";
-    }
-    {
-      assertion = fleetPlan."worker-0".baseName == "worker" && fleetPlan."worker-1".replicaIndex == 1;
-      message = "fleet replicas should expand into stable node identities";
-    }
-    {
-      assertion = fleetPlan."worker-0".dependsOn == [ "db" ];
-      message = "fleet replica dependencies should point at expanded node identities";
-    }
-  ];
 
-  failures = map (test: test.message) (lib.filter (test: !test.assertion) assertions);
+  # --- Per-image assertion groups -------------------------------------------
+
+  groups = {
+    kernel-dev = [
+      {
+        assertion = kernelDevConfig.ix.image.name == "linux-kernel-dev";
+        message = "kernel-dev image should set the expected OCI image name";
+      }
+      {
+        assertion = kernelDevConfig.services.git-clone.enable;
+        message = "kernel-dev image should enable first-boot git cloning";
+      }
+      {
+        assertion = kernelDevConfig.services.git-clone.url == "https://github.com/torvalds/linux.git";
+        message = "kernel-dev image should clone the Linux repository";
+      }
+      {
+        assertion = kernelDevConfig.services.git-clone.dest == "/src/linux";
+        message = "kernel-dev image should clone Linux into /src/linux";
+      }
+      {
+        assertion = kernelDevConfig.services.git-clone.activation == "timer";
+        message = "kernel-dev image should clone Linux after boot readiness";
+      }
+      {
+        assertion = kernelDevGitCloneService.wantedBy == [ ];
+        message = "timer-activated git clone should not be wanted by multi-user.target";
+      }
+      {
+        assertion = kernelDevGitCloneTimer.wantedBy == [ "timers.target" ];
+        message = "timer-activated git clone should be started by timers.target";
+      }
+    ];
+
+    minecraft = [
+      {
+        assertion = minecraftConfig.ix.image.tag == defaultMinecraftVersion;
+        message = "default minecraft image tag should follow versions.nix default";
+      }
+      {
+        assertion = defaultMinecraftVersion == "26.1.2-fabric";
+        message = "default minecraft image should use the stable 26.1.2 Fabric variant";
+      }
+      {
+        assertion = lib.all (slug: builtins.hasAttr slug minecraftConfig.services.minecraft.mods) [
+          "fabric-api"
+          "lithium"
+          "c2me-fabric"
+          "spark"
+          "grimac"
+        ];
+        message = "default minecraft image should include the 26.1.2 Fabric server mod set";
+      }
+      {
+        assertion = minecraftConfig.services.minecraft.javaPackage == pkgs.temurin-jre-bin-25;
+        message = "default Fabric minecraft should use Temurin";
+      }
+      {
+        assertion = lib.hasInfix "/bin/java" minecraftExec;
+        message = "minecraft ExecStart should launch Java";
+      }
+      {
+        assertion = lib.hasInfix "-XX:MaxRAMPercentage=85" minecraftExec;
+        message = "minecraft should use MaxRAMPercentage for auto-scaling heap";
+      }
+      {
+        assertion = lib.hasInfix "-XX:+UseG1GC" minecraftExec;
+        message = "minecraft should include the default modern server GC flags";
+      }
+      {
+        assertion = lib.hasInfix "-jar" minecraftExec && lib.hasInfix "nogui" minecraftExec;
+        message = "minecraft ExecStart should launch the configured server jar in nogui mode";
+      }
+      {
+        assertion = lib.hasInfix "minecraft-hot-reload-agent.jar=socket=/run/minecraft-hot-reload/socket" minecraftExec;
+        message = "Fabric minecraft should start the hot reload Java agent";
+      }
+      {
+        assertion = minecraftService.RuntimeDirectory == "minecraft-hot-reload";
+        message = "Fabric minecraft should create a runtime directory for the hot reload socket";
+      }
+      {
+        assertion = builtins.length minecraftUnit.reloadTriggers == 3;
+        message = "minecraft managed files should trigger systemd reloads rather than unit restarts";
+      }
+      {
+        assertion = lib.hasInfix "minecraft-sync-managed" minecraftUnit.preStart;
+        message = "minecraft preStart should sync managed files from /etc";
+      }
+      {
+        assertion = !(lib.hasInfix "fabric-api" minecraftUnit.preStart);
+        message = "minecraft preStart should not embed managed mod store paths in the unit";
+      }
+      # rcon coverage stays on the minecraft default image because the option
+      # surface lives in `services.minecraft`, not in a paper-specific module.
+      {
+        assertion = rconCfg.rcon.enable;
+        message = "minecraft RCON should be enabled through a typed option";
+      }
+      {
+        assertion = rconCfg.rcon.passwordFile == "/var/lib/minecraft/.ix-rcon-password";
+        message = "minecraft RCON should default to a state-local password file";
+      }
+      {
+        assertion = !(rconCfg.serverFiles."server.properties" ? "rcon.password");
+        message = "typed minecraft RCON should not put the password in Nix-managed server.properties";
+      }
+      {
+        assertion = rconConfig.networking.firewall.allowedTCPPorts == [ rconCfg.port ];
+        message = "typed minecraft RCON should keep the RCON port private by default";
+      }
+      {
+        assertion =
+          rconOpenFirewallConfig.networking.firewall.allowedTCPPorts == [
+            rconOpenFirewallCfg.port
+            rconOpenFirewallCfg.rcon.port
+          ];
+        message = "typed minecraft RCON should open the firewall only when requested";
+      }
+    ];
+
+    "minecraft_1.21.11-paper" = [
+      {
+        assertion = paperCfg.dropDir == "plugins";
+        message = "Paper minecraft should use the plugins drop directory";
+      }
+      {
+        assertion = builtins.length paperService.reloadTriggers == 3;
+        message = "Paper minecraft managed plugins should trigger systemd reloads";
+      }
+      {
+        assertion = !(paperServiceConfig ? RuntimeDirectory);
+        message = "Paper minecraft should not start the JVM hot reload socket";
+      }
+      {
+        assertion = paperCfg.autoReload.rconPasswordFile == "/var/lib/minecraft/.ix-rcon-password";
+        message = "Paper minecraft should use a state-local RCON password file";
+      }
+      {
+        assertion = !(paperCfg.serverFiles."server.properties" ? "rcon.password");
+        message = "Paper minecraft should not put the RCON password in Nix-managed server.properties";
+      }
+      {
+        assertion = paperConfig.networking.firewall.allowedTCPPorts == [ paperCfg.port ];
+        message = "Paper minecraft should not expose the local RCON reload port through the firewall";
+      }
+    ];
+
+    minecraft-bedrock = [
+      {
+        assertion = bedrockConfig.ix.image.name == "minecraft-bedrock";
+        message = "minecraft-bedrock image should set the expected OCI image name";
+      }
+      {
+        assertion = bedrockConfig.ix.image.tag == "1.26.14.1";
+        message = "minecraft-bedrock image tag should follow the pinned Bedrock server version";
+      }
+      {
+        assertion = bedrockCfg.enable;
+        message = "minecraft-bedrock image should enable services.minecraft-bedrock";
+      }
+      {
+        assertion = bedrockCfg.settings."server-name" == "ix-powered Bedrock";
+        message = "minecraft-bedrock should set the expected default server name";
+      }
+      {
+        assertion =
+          bedrockCfg.settings."server-port" == bedrockCfg.port
+          && bedrockCfg.settings."server-portv6" == bedrockCfg.portv6;
+        message = "minecraft-bedrock server.properties should follow the configured UDP ports";
+      }
+      {
+        assertion =
+          bedrockConfig.networking.firewall.allowedUDPPorts == [
+            bedrockCfg.port
+            bedrockCfg.portv6
+          ];
+        message = "minecraft-bedrock firewall should open only the configured UDP ports";
+      }
+      {
+        assertion = bedrockService.description == "Minecraft Bedrock server";
+        message = "minecraft-bedrock should run a dedicated systemd service";
+      }
+      {
+        assertion = lib.hasInfix "/bin/bedrock_server" bedrockServiceConfig.ExecStart;
+        message = "minecraft-bedrock ExecStart should launch bedrock_server";
+      }
+      {
+        assertion = bedrockServiceConfig.StateDirectory == "minecraft-bedrock";
+        message = "minecraft-bedrock service should get a managed state directory";
+      }
+    ];
+
+    remote-desktop = [
+      {
+        assertion = remoteDesktopConfig.ix.image.name == "ix-remote-desktop";
+        message = "remote-desktop image should set the expected OCI image name";
+      }
+      {
+        assertion = remoteDesktopCfg.enable;
+        message = "remote-desktop image should enable services.remote-desktop";
+      }
+      {
+        assertion = remoteDesktopCfg.package == pkgs.xpra;
+        message = "remote-desktop should default to the nixpkgs Xpra package";
+      }
+      {
+        assertion = remoteDesktopCfg.port == 6080;
+        message = "remote-desktop should expose the Xpra HTML5 client on port 6080";
+      }
+      {
+        assertion = remoteDesktopCfg.bindAddress == "0.0.0.0";
+        message = "remote-desktop should bind browser clients on all interfaces by default";
+      }
+      {
+        assertion = remoteDesktopCfg.display == ":100";
+        message = "remote-desktop should let Xpra own a deterministic virtual display";
+      }
+      {
+        assertion = remoteDesktopCfg.resolution == "1920x1080";
+        message = "remote-desktop should default to a browser-friendly 1080p display";
+      }
+      {
+        assertion = remoteDesktopCfg.auth == "none";
+        message = "remote-desktop should keep the current unauthenticated ix image contract explicit";
+      }
+      {
+        assertion = remoteDesktopService.description == "Xpra remote desktop";
+        message = "remote-desktop should run a single Xpra service";
+      }
+      {
+        assertion = remoteDesktopServiceConfig.User == "remote-desktop";
+        message = "remote-desktop service should run as its dedicated system user";
+      }
+      {
+        assertion = remoteDesktopServiceConfig.StateDirectory == "remote-desktop";
+        message = "remote-desktop service should get a managed state directory";
+      }
+      {
+        assertion = remoteDesktopServiceConfig.RuntimeDirectory == "remote-desktop";
+        message = "remote-desktop service should get a managed runtime directory";
+      }
+      {
+        assertion = remoteDesktopConfig.users.users.remote-desktop.isSystemUser;
+        message = "remote-desktop user should be a system user";
+      }
+      {
+        assertion = remoteDesktopConfig.networking.firewall.allowedTCPPorts == [ remoteDesktopCfg.port ];
+        message = "remote-desktop firewall should open only the configured browser port";
+      }
+      {
+        assertion = !(remoteDesktopConfig.systemd.services ? xvfb);
+        message = "remote-desktop should not use a standalone Xvfb service";
+      }
+      {
+        assertion = !(remoteDesktopConfig.systemd.services ? x11vnc);
+        message = "remote-desktop should not use x11vnc";
+      }
+      {
+        assertion = !(remoteDesktopConfig.systemd.services ? novnc);
+        message = "remote-desktop should not use a separate noVNC websockify service";
+      }
+    ];
+
+    fleet = [
+      {
+        assertion = fleet.nodes.db.networking.hostName == "db";
+        message = "fleet nodes should default hostName to the node name";
+      }
+      {
+        assertion = fleet.nodes.db.ix.networking.eastWest.hostName == "db";
+        message = "fleet nodes should expose their east-west host name through ix.networking";
+      }
+      {
+        assertion = fleet.nodes.web.environment.etc."db-host".text == "db";
+        message = "fleet node modules should be able to reference nodes.<name>.config";
+      }
+      {
+        assertion = fleet.nodes.db.services.ix-postgresql.enable;
+        message = "fleet plain attrset nodes should be treated as modules";
+      }
+      {
+        assertion =
+          fleetPlan.web.bootstrapImage == "registry.ix.dev/ix/test-cluster-bootstrap:zstd-tools-2026-05-12";
+        message = "fleet switches should create missing nodes from the shared NixOS bootstrap image";
+      }
+      {
+        assertion = fleetPlan.web.replacementImage.destination == "fleet-web:latest";
+        message = "fleet wrapped-node deployment destination should flow into the replacement image plan";
+      }
+      {
+        assertion = fleetPlan.web.system == "${fleet.nodes.web.system.build.toplevel}";
+        message = "fleet plans should expose the NixOS system closure for switch";
+      }
+      {
+        assertion = fleet.systemPackages.web-system == fleet.nodes.web.system.build.toplevel;
+        message = "fleet system package outputs should match default source switch installables";
+      }
+      {
+        assertion = fleet.packages.web == fleet.nodes.web.ix.build.ociImage;
+        message = "fleet replacement package outputs should keep node names";
+      }
+      {
+        assertion =
+          fleetPlan.web.switch == {
+            target = builtins.unsafeDiscardStringContext fleet.nodes.web.system.build.toplevel.drvPath;
+            buildOn = "remote";
+            buildVm = null;
+            sourceInstallable = ".#web-system";
+            overrideInputs = { };
+          };
+        message = "fleet plans should default to local eval and remote build switch metadata";
+      }
+      {
+        assertion =
+          fleetPlan.web.replacementImage.sourceDrv
+          == builtins.unsafeDiscardStringContext fleet.nodes.web.ix.build.ociImage.drvPath;
+        message = "fleet plans should expose replacement image derivations without forcing local image builds";
+      }
+      {
+        assertion = fleetPlan.web.region == "hil-1";
+        message = "fleet nodes should inherit the top-level deployment region";
+      }
+      {
+        assertion = fleetPlan.web.tags == [ "public" ];
+        message = "fleet wrapped-node tags should flow into the generated plan";
+      }
+      {
+        assertion = fleetPlan.web.ipv4;
+        message = "fleet wrapped-node deployment overrides should flow into the generated plan";
+      }
+      {
+        assertion = fleet.planValue.secrets.sessionKey.generate;
+        message = "fleet plans should carry declarative secret specs";
+      }
+      {
+        assertion = fleetPlan."worker-0".baseName == "worker" && fleetPlan."worker-1".replicaIndex == 1;
+        message = "fleet replicas should expand into stable node identities";
+      }
+      {
+        assertion = fleetPlan."worker-0".dependsOn == [ "db" ];
+        message = "fleet replica dependencies should point at expanded node identities";
+      }
+    ];
+  };
+
+  # --- Per-image build-time checks ------------------------------------------
+
+  paperManagedFiles = paperConfig.environment.etc."minecraft/managed-server-files".source;
+  paperManagedDropins = paperConfig.environment.etc."minecraft/managed-dropins".source;
+  rconManagedFiles = rconConfig.environment.etc."minecraft/managed-server-files".source;
+  nestedManagedFiles = nestedPropertiesConfig.environment.etc."minecraft/managed-server-files".source;
+
+  buildScripts = {
+    minecraft = ''
+      ! grep -R 'rcon.password' ${rconManagedFiles}
+      grep -q '^query.port=25565$' ${nestedManagedFiles}/server.properties
+      grep -q '^rcon.port=25575$' ${nestedManagedFiles}/server.properties
+    '';
+
+    "minecraft_1.21.11-paper" = ''
+      grep -q 'ignored-plugins' ${paperManagedFiles}/plugins/PlugManX/config.yml
+      grep -q 'PlugManX' ${paperManagedFiles}/plugins/PlugManX/config.yml
+      ! grep -R 'rcon.password' ${paperManagedFiles}
+      grep -q '^almanac$' ${paperManagedDropins}/almanac.jar.plugin-name
+      grep -q '^PlugManX$' ${paperManagedDropins}/PlugManX.jar.plugin-name
+      grep -q -- '--password-file "/var/lib/minecraft/.ix-rcon-password"' ${paperServiceConfig.ExecReload}
+      grep -q 'plugman $row.action $row.plugin' ${paperServiceConfig.ExecReload}
+      ! grep -q 'reload all' ${paperServiceConfig.ExecReload}
+    '';
+  };
+
+  helperScript = ''
+    ${lib.getExe pythonAppClosureProbe} > python-app-closure-probe.out
+    grep -q 'python app source is in the runtime closure' python-app-closure-probe.out
+  '';
+
+  # --- Test derivation builder ----------------------------------------------
+
+  mkTest =
+    name: assertions: extraScript:
+    let
+      failures = map (a: a.message) (lib.filter (a: !a.assertion) assertions);
+    in
+    assert lib.assertMsg (failures == [ ]) (
+      "ix-test-${name}:\n  " + lib.concatStringsSep "\n  " failures
+    );
+    pkgs.runCommand "ix-test-${name}" { nativeBuildInputs = [ pkgs.gnugrep ]; } ''
+      ${extraScript}
+      mkdir -p "$out"
+    '';
+
+  imageTests = lib.mapAttrs (name: assertions: mkTest name assertions (buildScripts.${name} or "")) (
+    builtins.removeAttrs groups [ "fleet" ]
+  );
+
+  fleetTest = mkTest "fleet" groups.fleet "";
+
+  helperTest = pkgs.runCommand "ix-test-helpers" { nativeBuildInputs = [ pkgs.gnugrep ]; } ''
+    ${helperScript}
+    mkdir -p "$out"
+  '';
 in
-assert lib.assertMsg (failures == [ ]) (lib.concatStringsSep "\n" failures);
-pkgs.runCommand "ix-images-eval-tests" { nativeBuildInputs = [ pkgs.gnugrep ]; } ''
-  grep -q 'ignored-plugins' ${
-    paperConfig.environment.etc."minecraft/managed-server-files".source
-  }/plugins/PlugManX/config.yml
-  grep -q 'PlugManX' ${
-    paperConfig.environment.etc."minecraft/managed-server-files".source
-  }/plugins/PlugManX/config.yml
-  ! grep -R 'rcon.password' ${paperConfig.environment.etc."minecraft/managed-server-files".source}
-  ! grep -R 'rcon.password' ${rconConfig.environment.etc."minecraft/managed-server-files".source}
-  grep -q '^query.port=25565$' ${
-    nestedPropertiesConfig.environment.etc."minecraft/managed-server-files".source
-  }/server.properties
-  grep -q '^rcon.port=25575$' ${
-    nestedPropertiesConfig.environment.etc."minecraft/managed-server-files".source
-  }/server.properties
-  grep -q '^almanac$' ${
-    paperConfig.environment.etc."minecraft/managed-dropins".source
-  }/almanac.jar.plugin-name
-  grep -q '^PlugManX$' ${
-    paperConfig.environment.etc."minecraft/managed-dropins".source
-  }/PlugManX.jar.plugin-name
+{
+  inherit imageTests;
 
-  grep -q -- '--password-file "/var/lib/minecraft/.ix-rcon-password"' ${paperServiceConfig.ExecReload}
-  grep -q 'plugman $row.action $row.plugin' ${paperServiceConfig.ExecReload}
-  ! grep -q 'reload all' ${paperServiceConfig.ExecReload}
-
-  ${lib.getExe pythonAppClosureProbe} > python-app-closure-probe.out
-  grep -q 'python app source is in the runtime closure' python-app-closure-probe.out
-
-  mkdir -p "$out"
-''
+  # Aggregate. Pulls every per-image test into one derivation so
+  # `nix flake check` covers the whole suite.
+  eval = pkgs.linkFarmFromDrvs "ix-images-eval-tests" (
+    lib.attrValues imageTests
+    ++ [
+      fleetTest
+      helperTest
+    ]
+  );
+}


### PR DESCRIPTION
Codifies the three RFC patterns added to `AGENTS.md` in f157039 by fixing every spot in the tree that did not follow them. Branch builds clean: `nix run .#lint` passes, `nix build .#checks.x86_64-linux.eval` builds the full aggregate.

## RFC 0042 (`settings` via `pkgs.formats`)

`services.ix-postgresql` drops `extraSettings`. Tuned values now sit under `services.postgresql.settings` wrapped in `lib.mkDefault`, so callers override directly with `services.postgresql.settings.<key> = "..."`. One settings tree, one merge.

`services.remote-desktop` swaps `extraOptions = listOf str` for a typed `settings = attrsOf (oneOf [bool int str (listOf str)])` rendered via `lib.cli.toCommandLineGNU`. Convenience options (`port`, `bindAddress`, `display`, `resolution`, `desktopCommand`, `auth`) seed the settings tree via `mkDefault`; a direct settings assignment wins.

`examples/claude-code-demo` replaces stringly nginx `locations.<path>.extraConfig = "root ...;"` with structured `root` and `tryFiles`.

## RFC 0145 (doc-comments)

`lib/default.nix` converts the single top-of-file block into per-binding `/** ... */` doc-comments on every public helper (`writePythonApplication`, `writeNushellApplication`, `overlay`, `pkgs`, `mkArtifact`, `attachArtifactSources`, `modCatalogs`, `artifacts`, `packageSetFor`, `ixSpecialArgs`, `evalImageConfig`, `mkImage`, `mkFleetFor`, `discoverImages`). Same treatment on `lib/minecraft-loader.nix`, `lib/build-npm-site.nix`, `lib/build-gradle-fat-jar.nix`, `lib/systemd-hardening.nix`, `lib/fleet.nix`.

## RFC 0119 (`passthru.tests`)

`tests/default.nix` splits the monolithic `assertions` list into per-image groups (`kernel-dev`, `minecraft`, `minecraft_1.21.11-paper`, `minecraft-bedrock`, `remote-desktop`, `fleet`) and builds a derivation per group via a `mkTest` helper. The file now exports `{ imageTests, eval }`; `eval` is the `linkFarmFromDrvs` aggregate covering every per-image group plus cross-cutting fleet/helper checks.

`discoverImages` takes `{ root, imageTests ? { } }`. For each discovered image with a matching entry it attaches `passthru.tests.eval = imageTests.<name>`. `lib/per-system.nix` imports `tests` once, hands `tests.imageTests` to `discoverImages`, and inherits `eval` into `checks` so `nix flake check` keeps the same surface.

Per-image tests are now reachable:

```
nix build .#minecraft.passthru.tests.eval
nix build .#remote-desktop.passthru.tests.eval
nix build .#kernel-dev.passthru.tests.eval
nix build '.#minecraft_1.21.11-paper.passthru.tests.eval'
```
