### PR TITLE
rfcs: bootstrap folder with router-VM RFC (0001)

### DIFF
--- a/rfcs/0000-template.html
+++ b/rfcs/0000-template.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>RFC 0000: Template · ix images</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #fdfdfc;
+    --fg: #1a1a1a;
+    --fg-dim: #5b5b5b;
+    --link: #0050b3;
+    --code-bg: #f3f3ef;
+    --rule: #e4e2dc;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #161614;
+      --fg: #e8e6df;
+      --fg-dim: #9b9890;
+      --link: #79b8ff;
+      --code-bg: #22221f;
+      --rule: #2e2d2a;
+    }
+  }
+  html { background: var(--bg); color: var(--fg); }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    max-width: 720px;
+    margin: 3rem auto;
+    padding: 0 1.25rem 4rem;
+    font-size: 17px;
+    line-height: 1.55;
+  }
+  h1, h2, h3 { line-height: 1.25; font-weight: 600; }
+  h1 { font-size: 1.9rem; margin: 0 0 0.25rem; }
+  .subtitle { color: var(--fg-dim); font-size: 1rem; margin: 0 0 2rem; }
+  h2 { font-size: 1.35rem; margin-top: 2.5rem; padding-top: 1rem; border-top: 1px solid var(--rule); }
+  h3 { font-size: 1.1rem; margin-top: 1.75rem; }
+  p { margin: 0.85rem 0; }
+  a { color: var(--link); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code, pre {
+    font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    font-size: 0.92em;
+  }
+  code { background: var(--code-bg); padding: 0.08em 0.3em; border-radius: 3px; }
+  pre {
+    background: var(--code-bg);
+    padding: 0.85rem 1rem;
+    border-radius: 6px;
+    overflow-x: auto;
+    line-height: 1.45;
+  }
+  pre code { background: transparent; padding: 0; }
+  ul, ol { padding-left: 1.4rem; }
+  li { margin: 0.3rem 0; }
+  blockquote {
+    border-left: 3px solid var(--rule);
+    margin: 1rem 0;
+    padding: 0.1rem 0 0.1rem 1rem;
+    color: var(--fg-dim);
+  }
+  dl.frontmatter {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.25rem 1rem;
+    margin: 0 0 2rem;
+    font-size: 0.95rem;
+  }
+  dl.frontmatter dt { font-weight: 600; color: var(--fg-dim); }
+  dl.frontmatter dd { margin: 0; }
+  strong { font-weight: 600; }
+</style>
+</head>
+<body>
+
+<h1>RFC 0000: &lt;RFC title&gt;</h1>
+<p class="subtitle">Template. Copy to <code>NNNN-short-slug.html</code>, update <code>&lt;title&gt;</code> and the <code>h1</code>, fill in frontmatter and body.</p>
+
+<dl class="frontmatter">
+  <dt>Number</dt><dd>0000</dd>
+  <dt>Title</dt><dd>&lt;RFC title&gt;</dd>
+  <dt>Status</dt><dd>Draft</dd>
+  <dt>Authors</dt><dd>&lt;github-handle&gt;</dd>
+  <dt>Created</dt><dd>YYYY-MM-DD</dd>
+  <dt>Updated</dt><dd>YYYY-MM-DD</dd>
+  <dt>Tracking issue</dt><dd>—</dd>
+  <dt>Supersedes</dt><dd>—</dd>
+  <dt>Superseded by</dt><dd>—</dd>
+</dl>
+
+<h2>Summary</h2>
+<p>One paragraph. State what this RFC proposes in concrete terms a reader can act on. If the summary is hard to write, the RFC is not ready yet.</p>
+
+<h2>Motivation</h2>
+<p>Why does this need to exist? What goes wrong today? What forces the change? Cite specific files, options, conversations, or incidents. Prefer concrete pain over abstract elegance.</p>
+
+<h2>Detailed design</h2>
+<p>The bulk of the document. Describe the proposed shape in enough detail that someone who is <em>not</em> the author could implement it. Cover:</p>
+<ul>
+  <li>The user-visible API: options, commands, file layout.</li>
+  <li>The internal mechanics where they affect more than one file.</li>
+  <li>How this composes with existing pieces: modules, fleet helpers, lint rules, image conventions.</li>
+  <li>Migration: what existing callers or configs need to change, and whether that is an automatic rewrite or manual.</li>
+</ul>
+<p>Use real names and real types. Avoid abstract sketches. Concrete is reviewable; vague is not.</p>
+
+<h2>Drawbacks</h2>
+<p>What goes wrong if we ship this? Performance cost, increased surface area, lock-in, operator confusion, security implications. Be honest. Listing zero drawbacks means the section was skipped.</p>
+
+<h2>Alternatives</h2>
+<p>What else was considered? Why is the proposed design preferred over each? Include the "do nothing" alternative explicitly.</p>
+
+<h2>Prior art</h2>
+<p>Where does this pattern exist already, in this repo, in NixOS, in upstream Linux, in cloud providers, in other RFC processes? Link concrete artifacts where possible.</p>
+
+<h2>Unresolved questions</h2>
+<p>Specific open points the RFC author wants reviewers to answer or push back on. Keep them tractable: each should be resolvable inside the PR thread, not its own follow-up RFC.</p>
+
+<h2>Future possibilities</h2>
+<p>Optional. Sketch directions this design enables but does not commit to. Useful for reviewers to understand "where does this go next" without thinking the RFC is promising to deliver it.</p>
+
+</body>
+</html>

--- a/rfcs/0001-router-vm.html
+++ b/rfcs/0001-router-vm.html
@@ -1,0 +1,209 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>RFC 0001: User-built router VM · ix images</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #fdfdfc;
+    --fg: #1a1a1a;
+    --fg-dim: #5b5b5b;
+    --link: #0050b3;
+    --code-bg: #f3f3ef;
+    --rule: #e4e2dc;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #161614;
+      --fg: #e8e6df;
+      --fg-dim: #9b9890;
+      --link: #79b8ff;
+      --code-bg: #22221f;
+      --rule: #2e2d2a;
+    }
+  }
+  html { background: var(--bg); color: var(--fg); }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    max-width: 720px;
+    margin: 3rem auto;
+    padding: 0 1.25rem 4rem;
+    font-size: 17px;
+    line-height: 1.55;
+  }
+  h1, h2, h3 { line-height: 1.25; font-weight: 600; }
+  h1 { font-size: 1.9rem; margin: 0 0 0.25rem; }
+  .subtitle { color: var(--fg-dim); font-size: 1rem; margin: 0 0 2rem; }
+  h2 { font-size: 1.35rem; margin-top: 2.5rem; padding-top: 1rem; border-top: 1px solid var(--rule); }
+  h3 { font-size: 1.1rem; margin-top: 1.75rem; }
+  p { margin: 0.85rem 0; }
+  a { color: var(--link); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code, pre {
+    font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    font-size: 0.92em;
+  }
+  code { background: var(--code-bg); padding: 0.08em 0.3em; border-radius: 3px; }
+  pre {
+    background: var(--code-bg);
+    padding: 0.85rem 1rem;
+    border-radius: 6px;
+    overflow-x: auto;
+    line-height: 1.45;
+  }
+  pre code { background: transparent; padding: 0; }
+  ul, ol { padding-left: 1.4rem; }
+  li { margin: 0.3rem 0; }
+  blockquote {
+    border-left: 3px solid var(--rule);
+    margin: 1rem 0;
+    padding: 0.1rem 0 0.1rem 1rem;
+    color: var(--fg-dim);
+  }
+  dl.frontmatter {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.25rem 1rem;
+    margin: 0 0 2rem;
+    font-size: 0.95rem;
+  }
+  dl.frontmatter dt { font-weight: 600; color: var(--fg-dim); }
+  dl.frontmatter dd { margin: 0; }
+  strong { font-weight: 600; }
+</style>
+</head>
+<body>
+
+<h1>RFC 0001: User-built router VM for fleet networking policy</h1>
+<p class="subtitle"><a href="index.html">↩ RFC index</a></p>
+
+<dl class="frontmatter">
+  <dt>Number</dt><dd>0001</dd>
+  <dt>Title</dt><dd>User-built router VM for fleet networking policy</dd>
+  <dt>Status</dt><dd>Draft</dd>
+  <dt>Authors</dt><dd>andrewgazelka</dd>
+  <dt>Created</dt><dd>2026-05-13</dd>
+  <dt>Updated</dt><dd>2026-05-13</dd>
+  <dt>Tracking issue</dt><dd>—</dd>
+  <dt>Supersedes</dt><dd>—</dd>
+  <dt>Superseded by</dt><dd>—</dd>
+</dl>
+
+<h2>Summary</h2>
+<p>Let a fleet designate one node in a VM group as the group's router. ix wires the other members' default route through that node and turns their internet egress off; the router VM owns all networking policy (NAT, firewall, L7 termination, VPN, deep packet inspection, whatever) as ordinary NixOS config inside the guest. ix does not learn about ports, protocols, or L3+ semantics. A stock <code>services.ix-router</code> module covers the common "NAT + nftables allowlist" case so the first ten minutes are not "write nftables in Nix"; users override or replace for everything else.</p>
+
+<h2>Motivation</h2>
+<p>Two forces meet:</p>
+<ol>
+  <li>The repo's standing rule that <strong>networking policy lives in the image, not in ix</strong> (see <code>AGENTS.md</code> § VM networking, and the corresponding line in <code>ix/AGENTS.md</code> under "Architecture that must not drift"). ix exposes coarse primitives (group membership, internet ingress/egress on/off); per-port filtering, L7 rules, WAF, rate limiting, and mTLS termination are user concerns.</li>
+  <li>The repo's <strong>trust model</strong> (<code>AGENTS.md</code> § Trust model). An agent inside a VM has root and is goal-optimizing. It can flip <code>networking.firewall.enable</code>. In-VM firewall config is convenience for a cooperative guest, not a containment boundary. Anything that must hold against a misbehaving in-VM process belongs outside the VM.</li>
+</ol>
+<p>Together, these say: when a port must stay closed against a rogue guest, the enforcement point is <em>another</em> VM the agent has no shell on. Today the repo documents the rule but does not provide a low-friction path to actually build such a node. Users who want the AWS-reflex "expose only 443" shape are on their own. PR #43 tried to fill the gap with a stock Caddy reverse-proxy image; that PR was closed in favor of this design because L7 is too narrow: a router VM also wants L4 NAT, conntrack, optional WireGuard, optional FRR/BGP for multi-group routing, and the same module shape should cover all of it.</p>
+<p>The opportunity is that <strong>Linux already solves this problem</strong>. If ix hands a router VM an ordinary ethernet interface into the group, every off-the-shelf piece of Linux networking software works against it (<code>nftables</code>, <code>iproute2</code>, <code>frr</code>, <code>bird</code>, <code>wireguard-tools</code>, <code>conntrackd</code>, custom eBPF). ix does not need to model any of it.</p>
+
+<h2>Detailed design</h2>
+
+<h3>Fleet-layer primitive</h3>
+<p><code>lib/fleet.nix</code> learns a <code>router</code> field per group:</p>
+<pre><code>{
+  groups.web = {
+    nodes = [ "api" "db" "frontend" ];
+    router = "gw";
+    internet = "via-router";
+  };
+  nodes = {
+    gw = ./images/services/router;
+    api = ./images/services/api;
+    db = ./images/services/db;
+    frontend = ./images/services/frontend;
+  };
+}</code></pre>
+
+<p>Semantics when <code>router = "gw"</code> is set on a group:</p>
+<ul>
+  <li><code>gw</code> joins the group like any other member (gets a group-local interface).</li>
+  <li>Non-router members of the group have their default route rendered to point at <code>gw</code>'s group-local address. Concretely this is a <code>networking.defaultGateway</code> (or equivalent <code>systemd-networkd</code> route) populated at fleet eval time. The address itself comes from ix's existing group-IP allocation; the fleet helper just reads it.</li>
+  <li>Non-router members get <code>internet egress = false</code> from ix (north-south is closed at the host primitive).</li>
+  <li><code>gw</code> keeps <code>internet egress = true</code> so it can NAT outbound traffic for the group.</li>
+  <li><code>internet = "via-router"</code> is the new value for the existing group-level internet flag, in addition to today's <code>on</code>/<code>off</code>.</li>
+</ul>
+
+<h3>services.ix-router module</h3>
+<p>A new module under <code>modules/services/router.nix</code>, registered in <code>modules/default.nix</code>. Shape mirrors <code>services.gateway</code> (Caddy) one layer down:</p>
+<pre><code>services.ix-router = {
+  enable = true;
+  upstream = "eth0";
+  # Optional: forward allowlist. Anything not matched is dropped.
+  forward = {
+    "api" = { dst = "10.0.0.2"; ports = [ 443 ]; proto = "tcp"; };
+    "db"  = { dst = "10.0.0.3"; ports = [ 5432 ]; proto = "tcp"; };
+  };
+  masquerade = true;
+};</code></pre>
+
+<p>When enabled, the module:</p>
+<ul>
+  <li>Sets <code>boot.kernel.sysctl."net.ipv4.ip_forward" = 1</code> and the IPv6 equivalent.</li>
+  <li>Brings up <code>networking.nftables.enable = true</code> with a <code>forward</code> chain that defaults to drop and admits entries from <code>services.ix-router.forward</code> plus any <code>extraInputRules</code>-style escape hatch (typed where possible, freeform-submodule via <code>pkgs.formats.*</code> per RFC 0042; <strong>no</strong> stringly <code>extraConfig</code> on this module).</li>
+  <li>If <code>masquerade = true</code>, adds a <code>postrouting</code> rule that NATs the group's source range to <code>upstream</code>.</li>
+  <li>Loads <code>nf_conntrack</code> and tunes the conntrack table size; sets <code>net.netfilter.nf_conntrack_max</code> to something sane for the configured group size.</li>
+</ul>
+<p>The module is intentionally narrow. Users who want FRR for BGP, WireGuard for VPN egress, bird for OSPF, Suricata for IDS, or hand-rolled eBPF programs disable <code>services.ix-router</code> and write their own NixOS config against the same group interface. The fleet primitive (router designation) and the stock module are decoupled; the primitive does not assume the stock module is enabled.</p>
+
+<h3>Image</h3>
+<p><code>images/services/router/default.nix</code> ships as the stock router image: enables <code>services.ix-router</code> and exposes typical knobs through fleet overrides. Empty <code>forward = {}</code> by default so a freshly-tagged <code>latest</code> does not silently allow traffic.</p>
+
+<h3>Composition with services.gateway</h3>
+<p><code>services.gateway</code> (Caddy reverse proxy) and <code>services.ix-router</code> are orthogonal modules. Small fleets put both on the router node and run Caddy as the L7 face of the gateway. Larger fleets separate them: router node does L4/NAT only, a backend Caddy node behind it terminates TLS. Both shapes work without changes to either module because the gateway module already opens 80/443 and the router module already permits forward traffic to whatever its <code>forward</code> table allows.</p>
+
+<h3>Migration</h3>
+<p>No existing callers. The closed PR #43 (<code>services.gateway</code>) lands or does not land independently; this RFC does not depend on it.</p>
+
+<h2>Drawbacks</h2>
+<ul>
+  <li><strong>Single point of failure.</strong> A router node going down severs north-south for the whole group. Mitigations (VRRP/keepalived, ECMP, two router nodes) work on top of this primitive but are explicitly out of scope for v1.</li>
+  <li><strong>Performance bottleneck.</strong> All north-south traffic for the group funnels through one node's CPU. For most ix workloads this is fine; for high-throughput edge nodes the answer is again HA or sharding, not in-line firewall on every VM.</li>
+  <li><strong>Boot ordering.</strong> Backend VMs that come up before the router cannot reach the internet. Solvable with <code>network-online.target</code> discipline and retries on the backend side; the router image should be the first node in the group's boot order where ix exposes that knob.</li>
+  <li><strong>Operator lockout.</strong> A misconfigured router can lock the operator out of every VM in the group. Recovery path needed: ix CLI should provide a way to bypass the designated router for <code>ix shell</code>/<code>ix switch</code> traffic from the host. This is a real ask of the ix team and is the load-bearing open question below.</li>
+  <li><strong>Adds a network hop.</strong> Tens of microseconds of latency inside the same datacenter. Acceptable for the use cases this is aimed at.</li>
+</ul>
+
+<h2>Alternatives</h2>
+<ul>
+  <li><strong>ix host-side firewall driven by <code>networking.firewall.allowedTCPPorts</code>.</strong> Rejected. Violates the "Architecture that must not drift" rule on the ix side and the trust model section in <code>AGENTS.md</code>. ix would have to learn per-port intent, which is the thing the repo has explicitly committed to not doing.</li>
+  <li><strong>TUN-style L3-only primitive.</strong> Rejected. TUN drops ARP, broadcast, ethertype, and the ability to run any off-the-shelf Linux routing daemon. The "no special application-side logic" goal lands on TAP/L2. Users who specifically want an L3 tunnel can <code>ip tuntap add</code> inside their VM; ix does not need to model VPNs.</li>
+  <li><strong>Parallel ix option for exposed ports</strong> (e.g. <code>ix.exposedPorts</code>). Rejected. The right way to declare "this VM uses port 25565" is <code>networking.firewall.allowedTCPPorts = [25565]</code>, the standard NixOS option, co-located with the service that needs the port. Inventing a parallel option forces users to keep two lists in sync.</li>
+  <li><strong>Stock Caddy reverse-proxy image only</strong> (PR #43). Rejected as the primary path. L7 is too narrow; users also want L4 NAT, VPN egress, BGP, IDS. Caddy reverse-proxy is one valid composition on top of this design and can land as its own module later.</li>
+  <li><strong>Do nothing.</strong> The trust-model section of <code>AGENTS.md</code> already names the gateway/router VM as the place where enforcement lives. Leaving users to assemble it from scratch every time is the current state and it is producing real PRs that try to fill the gap.</li>
+</ul>
+
+<h2>Prior art</h2>
+<ul>
+  <li><strong>AWS NAT instance.</strong> An ordinary EC2 instance plugged into a private subnet and a public subnet, with iptables for filtering and the private subnet's default route pointed at it. Exactly the shape proposed here, at AWS-flavored scale.</li>
+  <li><strong>OpenStack neutron router.</strong> A VM with a routed interface per tenant network; OpenStack's L3 agent renders nftables/iptables into it. Similar split between platform primitive (network attachment) and tenant policy (rules inside the router).</li>
+  <li><strong>Proxmox + OPNsense.</strong> The "buy a thin VM, run OPNsense or pfSense, point your other VMs at it" pattern. Same idea, with a heavier off-the-shelf appliance.</li>
+  <li><strong>Tailscale subnet routers.</strong> A node in a Tailscale tailnet advertises one or more subnets and forwards traffic into them. Different mechanism (no NAT, identity-based ACL) but the same architectural shape: one designated node, ordinary OS userspace, no platform-side L3 policy.</li>
+  <li><strong>NixOS router cookbook entries.</strong> Existing community write-ups for using NixOS as a home router give the basic systemd-networkd + nftables + ip_forward pattern; <code>services.ix-router</code> is essentially the curated repo-house version of that.</li>
+</ul>
+
+<h2>Unresolved questions</h2>
+<ol>
+  <li><strong>Granularity: per-group vs per-fleet.</strong> Per-group lets each group have its own router and isolates blast radius. Per-fleet is simpler and probably covers 80% of users. Leaning per-group; want pushback before committing.</li>
+  <li><strong>Underlying ix capability.</strong> Does ix today actually allow a designated node to be the L2 next-hop for other nodes in a group? If groups today are fully ix-managed L2 segments with no escape hatch for "this member is special," the fleet-layer change is cheap; otherwise it is a conversation with the ix team and an ix-side primitive. Need to confirm before implementation.</li>
+  <li><strong>Operator recovery path.</strong> What is the supported way to reach a VM whose router is misconfigured? Probably host-side bypass for <code>ix shell</code>/<code>ix switch</code>, but that has to come from ix. The RFC depends on it.</li>
+  <li><strong>IPv6.</strong> All the above is written assuming v4. The mechanics translate (<code>net.ipv6.conf.all.forwarding</code>, nftables <code>ip6</code> chains, NAT66 only if you actually need it) but the fleet-layer wiring needs to allocate v6 too. Confirm ix exposes group-local v6 addresses before committing the design to dual-stack from day one.</li>
+  <li><strong>Boot-order signaling.</strong> Does the fleet layer have a way to say "boot <code>gw</code> before the other members of <code>web</code>"? If not, backend VMs need retry semantics on <code>network-online.target</code>, which is fine but should be called out in the stock image.</li>
+</ol>
+
+<h2>Future possibilities</h2>
+<ul>
+  <li><strong>HA router pairs.</strong> VRRP or ECMP across two router nodes. Independent design; fits on this primitive.</li>
+  <li><strong>East-west policy.</strong> Today the proposal only governs north-south. A second router-VM-per-group could mediate cross-VM traffic for groups that want microsegmentation, but this is a v3 problem.</li>
+  <li><strong>L7 composition library.</strong> Once the L4 router is the standard piece, common L7 patterns (TLS-terminating gateway, OIDC auth proxy, rate-limiter) ship as composable modules a user can drop into the router image or a sibling node.</li>
+  <li><strong>Out-of-fleet routers.</strong> A router VM that lives in one fleet but is the designated north-south point for VMs in another fleet. Useful for shared-edge architectures. Out of scope for v1 but the primitive does not preclude it.</li>
+</ul>
+
+</body>
+</html>

--- a/rfcs/index.html
+++ b/rfcs/index.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>RFCs · ix images</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #fdfdfc;
+    --fg: #1a1a1a;
+    --fg-dim: #5b5b5b;
+    --link: #0050b3;
+    --code-bg: #f3f3ef;
+    --rule: #e4e2dc;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #161614;
+      --fg: #e8e6df;
+      --fg-dim: #9b9890;
+      --link: #79b8ff;
+      --code-bg: #22221f;
+      --rule: #2e2d2a;
+    }
+  }
+  html { background: var(--bg); color: var(--fg); }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    max-width: 720px;
+    margin: 3rem auto;
+    padding: 0 1.25rem 4rem;
+    font-size: 17px;
+    line-height: 1.55;
+  }
+  h1, h2, h3 { line-height: 1.25; font-weight: 600; }
+  h1 { font-size: 1.9rem; margin: 0 0 0.25rem; }
+  .subtitle { color: var(--fg-dim); font-size: 1rem; margin: 0 0 2rem; }
+  h2 { font-size: 1.35rem; margin-top: 2.5rem; padding-top: 1rem; border-top: 1px solid var(--rule); }
+  h3 { font-size: 1.1rem; margin-top: 1.75rem; }
+  p { margin: 0.85rem 0; }
+  a { color: var(--link); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code, pre {
+    font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    font-size: 0.92em;
+  }
+  code { background: var(--code-bg); padding: 0.08em 0.3em; border-radius: 3px; }
+  pre {
+    background: var(--code-bg);
+    padding: 0.85rem 1rem;
+    border-radius: 6px;
+    overflow-x: auto;
+    line-height: 1.45;
+  }
+  pre code { background: transparent; padding: 0; }
+  ul, ol { padding-left: 1.4rem; }
+  li { margin: 0.3rem 0; }
+  blockquote {
+    border-left: 3px solid var(--rule);
+    margin: 1rem 0;
+    padding: 0.1rem 0 0.1rem 1rem;
+    color: var(--fg-dim);
+  }
+  dl.frontmatter {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.25rem 1rem;
+    margin: 0 0 2rem;
+    font-size: 0.95rem;
+  }
+  dl.frontmatter dt { font-weight: 600; color: var(--fg-dim); }
+  dl.frontmatter dd { margin: 0; }
+  strong { font-weight: 600; }
+  .status { color: var(--fg-dim); font-size: 0.9em; }
+</style>
+</head>
+<body>
+
+<h1>RFCs</h1>
+<p class="subtitle">Design documents for non-trivial changes to this repo.</p>
+
+<p>RFCs capture <em>why</em> a decision was made and what alternatives were considered, which <code>git log</code> does not. The format is HTML so each file is self-contained: open it in any browser and it reads, no Markdown processor or build step required.</p>
+
+<h2>Index</h2>
+<ul>
+  <li><a href="0001-router-vm.html">RFC 0001 — User-built router VM for fleet networking policy</a> <span class="status">· Draft</span></li>
+</ul>
+
+<h2>When to write one</h2>
+<p>Open an RFC for changes that touch shared abstractions: the fleet API, module conventions, the trust model, networking primitives, lint rules, or anything that asks contributors to do something noticeably differently. Bug fixes, refactors that do not change a public surface, and one-off additions do not need an RFC; a normal PR is enough.</p>
+<p>If you are unsure, open an RFC. The cost is low.</p>
+
+<h2>Process</h2>
+<ol>
+  <li>Copy <code>0000-template.html</code> to <code>NNNN-short-slug.html</code>, using the next free number.</li>
+  <li>Fill in the frontmatter (status starts at <code>Draft</code>) and the body.</li>
+  <li>Open a PR titled <code>RFC NNNN: &lt;short title&gt;</code>.</li>
+  <li>PR review is the discussion. Line comments are the unit of feedback.</li>
+  <li>Merge when the proposal is coherent enough to read, even if it is not "finished". Subsequent edits land as follow-up PRs against the same file. The status field in the frontmatter tracks lifecycle; PR state is just how edits get in.</li>
+</ol>
+
+<h2>Status values</h2>
+<ul>
+  <li><code>Draft</code>: the proposal exists and is open to feedback. Default for a freshly merged RFC.</li>
+  <li><code>Accepted</code>: the design is the plan of record. Implementation may not be started.</li>
+  <li><code>Implemented</code>: the proposal landed and the relevant code, docs, or process exist. Link the tracking issue and the PRs.</li>
+  <li><code>Rejected</code>: a follow-up PR set this status. Keep the file so the reasoning is preserved.</li>
+  <li><code>Withdrawn</code>: the author no longer pursues it. Same retention rule.</li>
+  <li><code>Superseded</code>: pointed at a newer RFC via <code>superseded-by</code> in frontmatter.</li>
+</ul>
+
+<h2>Numbering</h2>
+<p>Numbers are zero-padded to four digits and never reused. If two PRs race for the same number, the later one renames before merge.</p>
+
+<h2>Implementation tracking</h2>
+<p>Once an RFC is <code>Accepted</code>, file a GitHub issue tagged <code>rfc-implementation</code> that links the RFC. The issue tracks the work; the RFC remains the design source of truth. When the work lands, a follow-up PR sets the RFC status to <code>Implemented</code> and links the issue and PRs from the frontmatter.</p>
+
+<h2>Why HTML</h2>
+<p>HTML over Markdown so each RFC has direct control over typography, embedded diagrams, and any future interactivity, without a build step or external CSS dependency. The downside is more verbose source; the upside is that you can open any file with <code>file://</code> in a browser and read it as intended. PR review still works because the prose dominates the diff and the surrounding HTML is stable boilerplate.</p>
+
+</body>
+</html>


### PR DESCRIPTION
Introduces an in-repo `rfcs/` folder for design documents and lands the router-VM RFC as the first entry.

**Source format is HTML, one self-contained file per RFC.** Inline CSS in each file with light/dark schemes; open any RFC as a `file://` URL in a browser and it reads as intended. No Markdown processor, no build step, no shared stylesheet to maintain. Slightly more verbose source than Markdown, but the prose dominates the diff and the surrounding HTML is stable boilerplate so PR review still works.

**Why a folder over a GitHub issue:** line-by-line PR review is the right unit of feedback once a proposal is longer than a paragraph; flat issue threads fragment fast. Numbered, merged RFCs become readable project history.

**Why in-repo over a separate `index-rfcs` repo:** RFCs here are about this repo's abstractions (fleet API, modules, networking primitives, trust model), so co-locating with the code keeps cross-references real. Splittable later if volume justifies.

**Process is intentionally light:**
- PR adds a numbered file with `status: Draft` in frontmatter.
- Merge when the proposal is coherent enough to read, even if not finished.
- Subsequent edits land as follow-up PRs against the same file.
- The status field in frontmatter tracks lifecycle; PR state is just how edits get in.
- Once `Accepted`, file a GitHub issue tagged `rfc-implementation` that links the RFC.

**Files:**
- `rfcs/index.html`: process doc (when to write one, status values, numbering, implementation tracking) plus the RFC index.
- `rfcs/0000-template.html`: frontmatter + standard sections (Summary, Motivation, Detailed design, Drawbacks, Alternatives, Prior art, Unresolved questions, Future possibilities).
- `rfcs/0001-router-vm.html`: first real RFC. Proposes a per-group designated router VM. ix wires the other members' default route through it and turns their internet egress off; the router VM owns all networking policy (NAT, firewall, L7, VPN, BGP, IDS) as ordinary NixOS config. A stock `services.ix-router` module covers the NAT + nftables-allowlist common case so users do not start from scratch.

Composes with the trust-model section in #46 (the load-bearing rationale for keeping enforcement out of the guest) and replaces the design behind the just-closed #43 (`services.gateway`/Caddy was too narrow a shape for the problem; L4 NAT, VPN egress, BGP, IDS all want the same primitive).

Merging this PR fast (as Draft) is the intended workflow: the RFC is open to edits via follow-up PRs once it is in tree. Open the document, leave line comments here for anything that needs to land before merge.
