### PR TITLE
[codex] Add reusable runtime xattr metadata

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -8,6 +8,7 @@
 # `profiles/base.nix`, which `lib/ix-oci-layer.nix` enables by default.
 {
   base = ./profiles/base.nix;
+  extended-attributes = ./profiles/extended-attributes.nix;
   git-clone = ./services/git-clone.nix;
   minestom = ./services/minestom.nix;
   minecraft-bedrock = ./services/minecraft-bedrock.nix;

--- a/modules/profiles/extended-attributes.nix
+++ b/modules/profiles/extended-attributes.nix
@@ -1,0 +1,113 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    types
+    ;
+
+  cfg = config.ix.extendedAttributes;
+
+  xattrEntryType = types.submodule {
+    options = {
+      create = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to create this path as a directory before applying extended attributes.";
+      };
+
+      attributes = mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        description = "Extended attributes to apply to this path. Attribute names must use the `user.` namespace.";
+      };
+    };
+  };
+
+  pathSegments = path: lib.drop 1 (lib.splitString "/" path);
+  invalidPaths = lib.filter (
+    path:
+    let
+      segments = pathSegments path;
+    in
+    path == "" || !lib.hasPrefix "/" path || builtins.elem "" segments || builtins.elem ".." segments
+  ) (lib.attrNames cfg);
+
+  invalidAttributeNames = lib.concatMapAttrsToList (
+    path: entry:
+    map (name: "${path}: ${name}") (
+      lib.filter (name: !(lib.hasPrefix "user." name) || name == "user.") (lib.attrNames entry.attributes)
+    )
+  ) cfg;
+
+  setfattr = "${pkgs.attr}/bin/setfattr";
+  mkdir = "${pkgs.coreutils}/bin/mkdir";
+
+  applyPath =
+    path: entry:
+    let
+      escapedPath = lib.escapeShellArg path;
+      create = lib.optionalString entry.create ''
+        ${mkdir} -p -- ${escapedPath}
+      '';
+      setAttributes =
+        if entry.attributes == { } then
+          ":"
+        else
+          lib.concatStringsSep "\n" (
+            lib.mapAttrsToList (
+              name: value:
+              "${setfattr} --name ${lib.escapeShellArg name} --value ${lib.escapeShellArg value} -- ${escapedPath}"
+            ) entry.attributes
+          );
+    in
+    ''
+      ${create}
+      if [ -L ${escapedPath} ]; then
+        printf '%s\n' ${lib.escapeShellArg "refusing to set extended attributes on symlink: ${path}"} >&2
+        exit 1
+      fi
+
+      if [ -e ${escapedPath} ]; then
+        ${setAttributes}
+      fi
+    '';
+
+  applyScript = lib.concatStringsSep "\n" (lib.mapAttrsToList applyPath cfg);
+in
+{
+  options.ix.extendedAttributes = mkOption {
+    type = types.attrsOf xattrEntryType;
+    default = { };
+    description = ''
+      Extended attributes to apply to runtime filesystem paths during system
+      activation. Keys are absolute paths. Missing paths are skipped unless
+      `create` is true.
+
+      This is metadata, not a containment boundary: use the `user.ix.*`
+      namespace for ix-owned labels that runtime tools can inspect.
+    '';
+  };
+
+  config = mkIf (cfg != { }) {
+    assertions = [
+      {
+        assertion = invalidPaths == [ ];
+        message = "ix.extendedAttributes keys must be absolute paths without empty or '..' segments: ${lib.concatStringsSep ", " invalidPaths}";
+      }
+      {
+        assertion = invalidAttributeNames == [ ];
+        message = "ix.extendedAttributes attribute names must use the user.* namespace: ${lib.concatStringsSep ", " invalidAttributeNames}";
+      }
+    ];
+
+    environment.systemPackages = [ pkgs.attr ];
+
+    system.activationScripts.ix-extended-attributes.text = applyScript;
+  };
+}

--- a/modules/services/minecraft/default.nix
+++ b/modules/services/minecraft/default.nix
@@ -159,6 +159,7 @@ let
     "ops.json"
     "whitelist.json"
   ] (lib.attrNames cfg.serverFiles);
+
   bukkit = {
     worlds = lib.filterAttrs (_: world: world != { }) (
       lib.mapAttrs (
@@ -322,6 +323,59 @@ let
   normalizeFor = path: value: if fileExt path == "properties" then flattenProperties value else value;
 
   serverFiles = cfg.serverFiles // pluginConfigFiles;
+
+  defaultWorldName = toString (cfg.properties."level-name" or "world");
+  annotatedWorldNames = lib.unique ([ defaultWorldName ] ++ lib.attrNames cfg.worlds);
+  mkXattrDefaults = kind: attributes: {
+    attributes = lib.mapAttrs (_: lib.mkDefault) (
+      {
+        "user.ix.managed-by" = "nix";
+        "user.ix.service" = "minecraft";
+        "user.ix.kind" = kind;
+      }
+      // attributes
+    );
+  };
+  mkCreatedXattrDefaults =
+    kind: attributes:
+    mkXattrDefaults kind attributes
+    // {
+      create = lib.mkDefault true;
+    };
+  regionDirectoriesFor = world: [
+    {
+      path = "${dataDir}/${world}/region";
+      dimension = "overworld";
+    }
+    {
+      path = "${dataDir}/${world}/DIM-1/region";
+      dimension = "nether";
+    }
+    {
+      path = "${dataDir}/${world}/DIM1/region";
+      dimension = "end";
+    }
+  ];
+  worldXattrs = lib.listToAttrs (
+    lib.concatMap (
+      world:
+      [
+        {
+          name = "${dataDir}/${world}";
+          value = mkCreatedXattrDefaults "minecraft.world" {
+            "user.ix.minecraft.world" = world;
+          };
+        }
+      ]
+      ++ map (region: {
+        name = region.path;
+        value = mkCreatedXattrDefaults "minecraft.region-directory" {
+          "user.ix.minecraft.world" = world;
+          "user.ix.minecraft.dimension" = region.dimension;
+        };
+      }) (regionDirectoriesFor world)
+    ) annotatedWorldNames
+  );
 
   mkManaged =
     label: source:
@@ -745,7 +799,19 @@ in
           "bukkit.yml" = cfg.bukkit;
         })
       ];
+
     };
+
+    ix.extendedAttributes = lib.mkMerge [
+      {
+        ${dataDir} = mkCreatedXattrDefaults "minecraft.server-root" { };
+        "${dataDir}/${cfg.dropinDir}" = mkCreatedXattrDefaults "minecraft.dropins" {
+          "user.ix.minecraft.dropin-dir" = cfg.dropinDir;
+        };
+        "${dataDir}/config" = mkCreatedXattrDefaults "minecraft.config" { };
+      }
+      worldXattrs
+    ];
 
     networking.firewall.allowedTCPPorts = [
       cfg.port

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -477,9 +477,49 @@ let
 
   fleetPlan = fleet.planValue.nodes;
 
+  extendedAttributes =
+    let
+      config = evalConfig [
+        {
+          ix.extendedAttributes."/build/ix-xattr-test" = {
+            create = true;
+            attributes = {
+              "user.ix.kind" = "test.path";
+              "user.ix.owner" = "ix";
+            };
+          };
+        }
+      ];
+    in
+    {
+      inherit config;
+      activationScript = config.system.activationScripts.ix-extended-attributes.text;
+    };
+
   # --- Per-image assertion groups -------------------------------------------
 
   groups = {
+    extended-attributes = [
+      {
+        assertion = builtins.hasAttr "/build/ix-xattr-test" extendedAttributes.config.ix.extendedAttributes;
+        message = "generic ix.extendedAttributes should expose absolute runtime paths";
+      }
+      {
+        assertion = builtins.elem pkgs.attr extendedAttributes.config.environment.systemPackages;
+        message = "generic ix.extendedAttributes should add attr tools for runtime inspection";
+      }
+      {
+        assertion =
+          lib.hasInfix "/bin/setfattr" extendedAttributes.activationScript
+          && lib.hasInfix "user.ix.kind" extendedAttributes.activationScript;
+        message = "generic ix.extendedAttributes should render setfattr activation commands";
+      }
+      {
+        assertion = lib.hasInfix "refusing to set extended attributes on symlink" extendedAttributes.activationScript;
+        message = "generic ix.extendedAttributes should avoid following symlinks";
+      }
+    ];
+
     kernel-dev = [
       {
         assertion = kernelDev.config.ix.image.name == "linux-kernel-dev";
@@ -597,6 +637,30 @@ let
       {
         assertion = !(lib.hasInfix "fabric-api" minecraft.service.unit.preStart);
         message = "minecraft preStart should not embed managed mod store paths in the unit";
+      }
+      {
+        assertion =
+          minecraft.config.ix.extendedAttributes."/var/lib/minecraft".attributes."user.ix.kind"
+          == "minecraft.server-root";
+        message = "minecraft should label its runtime data directory through the generic xattr module";
+      }
+      {
+        assertion =
+          minecraft.config.ix.extendedAttributes."/var/lib/minecraft/world/region".attributes."user.ix.kind"
+          == "minecraft.region-directory"
+          &&
+            minecraft.config.ix.extendedAttributes."/var/lib/minecraft/world/region".attributes."user.ix.minecraft.dimension"
+            == "overworld";
+        message = "minecraft should label overworld region directories through the generic xattr module";
+      }
+      {
+        assertion =
+          minecraft.config.ix.extendedAttributes."/var/lib/minecraft/world/DIM-1/region".attributes."user.ix.minecraft.dimension"
+          == "nether"
+          &&
+            minecraft.config.ix.extendedAttributes."/var/lib/minecraft/world/DIM1/region".attributes."user.ix.minecraft.dimension"
+            == "end";
+        message = "minecraft should label Nether and End region directories through the generic xattr module";
       }
       # rcon coverage stays on the minecraft default image because the option
       # surface lives in `services.minecraft`, not in a paper-specific module.
@@ -959,6 +1023,19 @@ let
   # --- Per-image build-time checks ------------------------------------------
 
   buildScripts = {
+    extended-attributes = ''
+      rm -rf /build/ix-xattr-test
+      mkdir -p /build/ix-xattr-probe
+      if ${pkgs.attr}/bin/setfattr --name user.ix.probe --value yes -- /build/ix-xattr-probe; then
+        ${extendedAttributes.activationScript}
+        test -d /build/ix-xattr-test
+        test "$(${pkgs.attr}/bin/getfattr --absolute-names --only-values -n user.ix.kind /build/ix-xattr-test)" = "test.path"
+        test "$(${pkgs.attr}/bin/getfattr --absolute-names --only-values -n user.ix.owner /build/ix-xattr-test)" = "ix"
+      else
+        echo "xattrs are not supported by the Nix build sandbox filesystem; checked activation rendering by eval"
+      fi
+    '';
+
     minecraft = ''
       ! grep -R 'rcon.password' ${minecraft.rcon.managed.serverFiles}
       grep -q '^query.port=25565$' ${minecraft.nestedProperties.managed.serverFiles}/server.properties


### PR DESCRIPTION
## Summary

- Add a generic `ix.extendedAttributes` module for activation-time `user.*` xattr metadata on absolute runtime paths.
- Add optional directory creation, symlink refusal, path/name assertions, and `attr` tools for runtime inspection.
- Have the Minecraft module declare server-root, dropin/config, world, and region-directory labels through the generic option.

## Validation

- `nix build .#checks.x86_64-linux.eval --print-out-paths --no-link`
- `nix run .#lint`
- Local host xattr smoke test with `setfattr`/`getfattr` on a temporary directory