### PR TITLE
Fix #51: Make ix CLI a self-fetching package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,41 +1,5 @@
 {
   "nodes": {
-    "ixCliAarch64Darwin": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-lPxd7XkazzfTkM2Az4R1ENlEmXzaF70O93OagH1Kn2s=",
-        "type": "file",
-        "url": "https://ix.dev/cli/darwin-arm64/ix"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://ix.dev/cli/darwin-arm64/ix"
-      }
-    },
-    "ixCliX86_64Darwin": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-ivkOJr+NUsoeyZ5m90LcS1BC89ibnzVKPui+Z7GdjkQ=",
-        "type": "file",
-        "url": "https://ix.dev/cli/darwin-x86_64/ix"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://ix.dev/cli/darwin-x86_64/ix"
-      }
-    },
-    "ixCliX86_64Linux": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-6TpD+Wrme2pl0BV/Z+UqOqz/qeAHv+Bqdo1DyIdXzpo=",
-        "type": "file",
-        "url": "https://ix.dev/cli/linux-x86_64/ix"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://ix.dev/cli/linux-x86_64/ix"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1777578337,
@@ -54,9 +18,6 @@
     },
     "root": {
       "inputs": {
-        "ixCliAarch64Darwin": "ixCliAarch64Darwin",
-        "ixCliX86_64Darwin": "ixCliX86_64Darwin",
-        "ixCliX86_64Linux": "ixCliX86_64Linux",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,26 +3,11 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    ixCliX86_64Linux = {
-      url = "https://ix.dev/cli/linux-x86_64/ix";
-      flake = false;
-    };
-    ixCliAarch64Darwin = {
-      url = "https://ix.dev/cli/darwin-arm64/ix";
-      flake = false;
-    };
-    ixCliX86_64Darwin = {
-      url = "https://ix.dev/cli/darwin-x86_64/ix";
-      flake = false;
-    };
   };
 
   outputs =
     {
       nixpkgs,
-      ixCliAarch64Darwin,
-      ixCliX86_64Linux,
-      ixCliX86_64Darwin,
       ...
     }:
     let
@@ -57,11 +42,6 @@
 
       ix = import ./lib {
         inherit nixpkgs paths;
-        cliArtifacts = {
-          aarch64-darwin = ixCliAarch64Darwin;
-          x86_64-linux = ixCliX86_64Linux;
-          x86_64-darwin = ixCliX86_64Darwin;
-        };
       };
       devSystems = [
         "x86_64-linux"

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -3,7 +3,6 @@
 {
   nixpkgs,
   paths,
-  cliArtifacts ? { },
 }:
 let
   inherit (nixpkgs) lib;
@@ -304,25 +303,19 @@ let
   packageSetFor =
     pkgs:
     let
-      packageSystem = pkgs.stdenv.hostPlatform.system;
       ixForPackages = ixSpecialArgs // {
         inherit pkgs;
       };
-      basePackages = {
-        minestom.helloServerJar = pkgs.callPackage paths.packages.minestom.servers.hello {
-          ix = ixForPackages;
-        };
-        nix-cargo-unit = pkgs.callPackage paths.packages.nixCargoUnit { };
-        oci-image-builder = pkgs.callPackage paths.packages.ociImageBuilder { };
-        tonbo-artifacts = pkgs.callPackage paths.packages.tonboArtifacts { };
-      };
-      cliPackages = lib.optionalAttrs (builtins.hasAttr packageSystem cliArtifacts) {
-        ix = pkgs.callPackage paths.packages.ix {
-          src = cliArtifacts.${packageSystem};
-        };
-      };
     in
-    basePackages // cliPackages;
+    {
+      ix = pkgs.callPackage paths.packages.ix { };
+      minestom.helloServerJar = pkgs.callPackage paths.packages.minestom.servers.hello {
+        ix = ixForPackages;
+      };
+      nix-cargo-unit = pkgs.callPackage paths.packages.nixCargoUnit { };
+      oci-image-builder = pkgs.callPackage paths.packages.ociImageBuilder { };
+      tonbo-artifacts = pkgs.callPackage paths.packages.tonboArtifacts { };
+    };
 
   /**
     Cross-cutting helpers handed to every module through `specialArgs.ix`.

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -114,11 +114,8 @@ in
       claude-code-demo-up = claudeCodeDemo.up;
       claude-code-demo-linux-up = claudeCodeDemoLinuxUp;
       claude-code-demo-minecraft-up = claudeCodeDemoMinecraftUp;
-      inherit (repoPackages) nix-cargo-unit oci-image-builder;
+      inherit (repoPackages) ix nix-cargo-unit oci-image-builder;
       minestom-hello-server-jar = repoPackages.minestom.helloServerJar;
-    }
-    // lib.optionalAttrs (repoPackages ? ix) {
-      inherit (repoPackages) ix;
     }
     // lib.optionalAttrs (system == ix.system) {
       inherit (repoPackages) tonbo-artifacts;

--- a/packages/ix/default.nix
+++ b/packages/ix/default.nix
@@ -1,8 +1,30 @@
 {
   lib,
   stdenvNoCC,
-  src,
+  fetchurl,
 }:
+let
+  # URL + hash per platform.  When ix.dev ships a new CLI, update the
+  # hash here (one place) instead of running `nix flake update`.
+  sources = {
+    "x86_64-linux" = {
+      url = "https://ix.dev/cli/linux-x86_64/ix";
+      hash = "sha256-6TpD+Wrme2pl0BV/Z+UqOqz/qeAHv+Bqdo1DyIdXzpo=";
+    };
+    "aarch64-darwin" = {
+      url = "https://ix.dev/cli/darwin-arm64/ix";
+      hash = "sha256-lPxd7XkazzfTkM2Az4R1ENlEmXzaF70O93OagH1Kn2s=";
+    };
+    "x86_64-darwin" = {
+      url = "https://ix.dev/cli/darwin-x86_64/ix";
+      hash = "sha256-ivkOJr+NUsoeyZ5m90LcS1BC89ibnzVKPui+Z7GdjkQ=";
+    };
+  };
+  platform = stdenvNoCC.hostPlatform.system;
+  src = fetchurl sources.${platform};
+in
+assert lib.assertMsg (builtins.hasAttr platform sources)
+  "ix CLI: no precompiled binary for ${platform}";
 
 stdenvNoCC.mkDerivation {
   pname = "ix";


### PR DESCRIPTION
Closes #51.

Following the rule in `AGENTS.md` ("No artifact URLs in flake.nix inputs"), this removes the mutable `ixCli*` flake inputs and instead fetches the precompiled binaries directly in `packages/ix/default.nix` using `pkgs.fetchurl` with locked hashes. 

This prevents `nix flake check` from crashing when the `ix.dev` latest URL drifts.
