### PR TITLE
Add automatic CI health checks for examples

### DIFF
--- a/examples/python-daily-scraper/service.nix
+++ b/examples/python-daily-scraper/service.nix
@@ -17,6 +17,7 @@ let
   package = import ./package.nix { inherit ix lib pkgs; };
   dataDir = "/var/lib/daily-scraper";
   outputDir = "${dataDir}/parquet";
+  systemctl = lib.getExe' config.systemd.package "systemctl";
 
   scraperArgs = [
     (lib.getExe cfg.package)
@@ -123,6 +124,17 @@ in
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
+
+    ix.healthChecks.daily-scraper = {
+      from = "guest";
+      description = "Daily scraper timer is active";
+      command = [
+        systemctl
+        "is-active"
+        "--quiet"
+        "daily-scraper.timer"
+      ];
+    };
 
     systemd.services.daily-scraper = {
       description = "Daily Python data scraper";

--- a/examples/survival-server/minecraft.nix
+++ b/examples/survival-server/minecraft.nix
@@ -1,11 +1,17 @@
-_: {
+_:
+let
+  forwardingSecret = "ix-survival-example-forwarding-secret-change-me";
+in
+{
   services = {
     velocity = {
       enable = true;
       motd = "<green>ix Survival</green> <gray>| Java and Bedrock</gray>";
-      # Paper picks this up automatically: services.minecraft.paper defaults
-      # paper-global.yml's proxies.velocity block from the same string.
-      forwarding.secret = "ix-survival-example-forwarding-secret-change-me";
+      # Velocity renders MiniMessage tags into plain text before answering
+      # SLP. Substring matching here proves the proxy is actually the one
+      # responding on 25565, not a stray backend or stale image.
+      health.motdContains = [ "ix Survival" ];
+      forwarding.secret = forwardingSecret;
       servers.survival = "127.0.0.1:25566";
       try = [ "survival" ];
     };
@@ -39,6 +45,12 @@ _: {
         view-distance = 16;
         simulation-distance = 10;
         pvp = true;
+      };
+
+      configFiles."paper-global.yml".proxies.velocity = {
+        enabled = true;
+        secret = forwardingSecret;
+        online-mode = true;
       };
 
       serverFiles."spigot.yml".settings = {

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
           minecraftRcon = ./packages/minecraft-rcon;
           minecraftSyncManaged = ./packages/minecraft-sync-managed;
           llmClippy = ./packages/llm-clippy;
+          mcProbe = ./packages/mc-probe;
           minestom.servers.hello = ./packages/minestom/servers/hello;
           nixCargoUnit = ./packages/nix-cargo-unit;
           ociImageBuilder = ./packages/oci-image-builder;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,6 +4,7 @@
   nixpkgs,
   paths,
   rust-overlay,
+  cliArtifacts ? { },
 }:
 let
   inherit (nixpkgs) lib;
@@ -531,43 +532,52 @@ let
   packageSetFor =
     pkgs:
     let
+      packageSystem = pkgs.stdenv.hostPlatform.system;
       ixForPackages = ixSpecialArgs // {
         inherit pkgs;
       };
+      basePackages = {
+        hyperion = (pkgsWithRustOverlayFor pkgs).callPackage paths.packages.hyperion {
+          ix = ixForPackages;
+        };
+        ix-fleet = pkgs.callPackage paths.packages.ixFleet {
+          ix = ixForPackages;
+        };
+        minestom.helloServerJar = pkgs.callPackage paths.packages.minestom.servers.hello {
+          ix = ixForPackages;
+        };
+        minecraft-nbt = pkgs.callPackage paths.packages.minecraftNbt {
+          inherit pkgs;
+          ix = ixForPackages;
+        };
+        llm-clippy = llmClippyFor pkgs;
+        mc-probe = pkgs.callPackage paths.packages.mcProbe {
+          ix = ixForPackages;
+        };
+        minecraft-sync-managed = pkgs.callPackage paths.packages.minecraftSyncManaged {
+          inherit pkgs;
+          ix = ixForPackages;
+        };
+        nix-cargo-unit = pkgs.callPackage paths.packages.nixCargoUnit {
+          inherit pkgs;
+          ix = ixForPackages;
+        };
+        oci-image-builder = pkgs.callPackage paths.packages.ociImageBuilder {
+          inherit pkgs;
+          ix = ixForPackages;
+        };
+        python-mcp-server = pkgs.callPackage paths.packages.pythonMcpServer {
+          ix = ixForPackages;
+        };
+        tonbo-artifacts = pkgs.callPackage paths.packages.tonboArtifacts { };
+      };
+      cliPackages = lib.optionalAttrs (builtins.hasAttr packageSystem cliArtifacts) {
+        ix = pkgs.callPackage paths.packages.ix {
+          src = cliArtifacts.${packageSystem};
+        };
+      };
     in
-    {
-      hyperion = (pkgsWithRustOverlayFor pkgs).callPackage paths.packages.hyperion {
-        ix = ixForPackages;
-      };
-      ix-fleet = pkgs.callPackage paths.packages.ixFleet {
-        ix = ixForPackages;
-      };
-      minestom.helloServerJar = pkgs.callPackage paths.packages.minestom.servers.hello {
-        ix = ixForPackages;
-      };
-      minecraft-nbt = pkgs.callPackage paths.packages.minecraftNbt {
-        inherit pkgs;
-        ix = ixForPackages;
-      };
-      llm-clippy = llmClippyFor pkgs;
-      minecraft-sync-managed = pkgs.callPackage paths.packages.minecraftSyncManaged {
-        inherit pkgs;
-        ix = ixForPackages;
-      };
-      nix-cargo-unit = pkgs.callPackage paths.packages.nixCargoUnit {
-        inherit pkgs;
-        ix = ixForPackages;
-      };
-      oci-image-builder = pkgs.callPackage paths.packages.ociImageBuilder {
-        inherit pkgs;
-        ix = ixForPackages;
-      };
-      python-mcp-server = pkgs.callPackage paths.packages.pythonMcpServer {
-        ix = ixForPackages;
-      };
-      tonbo-artifacts = pkgs.callPackage paths.packages.tonboArtifacts { };
-      ix = pkgs.callPackage paths.packages.ix { };
-    };
+    basePackages // cliPackages;
 
   /**
     Cross-cutting helpers handed to every module through `specialArgs.ix`.

--- a/lib/fleet.nix
+++ b/lib/fleet.nix
@@ -127,6 +127,19 @@ let
   ) nodeSpecs;
 
   nodeRefs = lib.mapAttrs (_name: config: { inherit config; }) nodeConfigs;
+  planHealthChecks =
+    config:
+    lib.mapAttrs (_name: check: {
+      inherit (check)
+        attempts
+        description
+        from
+        intervalSec
+        requiresIpv4
+        timeoutSec
+        ;
+      command = map builtins.unsafeDiscardStringContext check.command;
+    }) config.ix.healthChecks;
 
   nodePlan = lib.mapAttrs (
     name: spec:
@@ -137,6 +150,7 @@ let
       deploy = spec.deployment;
       replacementDestination = deploy.destination or "${imageName}:${imageTag}";
       switchBuildOn = deploy.switch.buildOn or "remote";
+      ipv4HealthChecks = lib.filterAttrs (_: check: check.requiresIpv4) config.ix.healthChecks;
       # ix switch expects a system out-path for local copy and a .drv for remote
       # build. Picking the wrong shape uploads the build-time closure and tries
       # to run `<drv>/bin/switch-to-configuration`, which deadlocks.
@@ -147,6 +161,8 @@ let
           config.system.build.toplevel.drvPath
       );
     in
+    assert lib.assertMsg (deploy.ipv4 || ipv4HealthChecks == { })
+      "fleet node '${name}' has health checks that require deployment.ipv4 = true: ${lib.concatStringsSep ", " (lib.attrNames ipv4HealthChecks)}";
     {
       inherit
         name
@@ -178,6 +194,7 @@ let
       inherit (deploy) env;
       inherit (deploy) l7ProxyPorts;
       dependsOn = lib.concatMap expandDependency spec.dependsOn;
+      healthChecks = planHealthChecks config;
     }
   ) nodeSpecs;
 
@@ -211,6 +228,7 @@ let
 
   subcommands = lib.genAttrs [
     "diff"
+    "health"
     "replace"
     "switch"
     "up"
@@ -221,6 +239,7 @@ in
   inherit (subcommands)
     diff
     replace
+    health
     switch
     up
     ;

--- a/lib/ix-platform.nix
+++ b/lib/ix-platform.nix
@@ -5,6 +5,76 @@
 # No binary cache hits: everything builds from source.
 { config, lib, ... }:
 let
+  healthCheckType = lib.types.submodule (
+    { name, ... }:
+    {
+      options = {
+        description = lib.mkOption {
+          type = lib.types.str;
+          default = name;
+          description = "Human-readable check name shown by fleet health commands.";
+        };
+
+        from = lib.mkOption {
+          type = lib.types.enum [
+            "guest"
+            "host"
+          ];
+          default = "guest";
+          description = ''
+            Where the command runs.
+
+            `guest` execs through `ix shell <node> -- <command>` inside the VM.
+            `host` execs `<command>` directly on the operator's machine and
+            exports `IX_NODE` plus any fields returned by `ix ls` as
+            `IX_NODE_<KEY>` env vars, so the command can probe the node from
+            outside the VM (firewall, public IPv4, gateway path).
+          '';
+        };
+
+        command = lib.mkOption {
+          type = lib.types.nonEmptyListOf lib.types.str;
+          description = ''
+            Command argv. For `from = "guest"` it runs in the VM through
+            `ix shell`. For `from = "host"` it runs directly with the
+            `IX_NODE*` env vars described above; tools must be on the
+            operator's PATH.
+          '';
+        };
+
+        timeoutSec = lib.mkOption {
+          type = lib.types.ints.positive;
+          default = 30;
+          description = "Per-attempt timeout in seconds.";
+        };
+
+        attempts = lib.mkOption {
+          type = lib.types.ints.positive;
+          default = 30;
+          description = "Maximum number of attempts before the check fails.";
+        };
+
+        intervalSec = lib.mkOption {
+          type = lib.types.ints.unsigned;
+          default = 2;
+          description = "Seconds to wait between failed attempts.";
+        };
+
+        requiresIpv4 = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Whether this check needs `IX_NODE_IPV4` from `ix ls`.
+
+            Use this for host-side public reachability probes that connect to
+            the node's assigned IPv4 address. Fleet evaluation rejects nodes
+            with this requirement unless `deployment.ipv4 = true`.
+          '';
+        };
+      };
+    }
+  );
+
   portClaimType = lib.types.submodule (
     { name, ... }:
     {
@@ -68,30 +138,52 @@ let
   renderPortClaim = claim: "${claim.name} (${claim.address}, ${claim.description})";
   renderPortClaimConflict =
     key: claims: "${key}: ${lib.concatMapStringsSep ", " renderPortClaim claims}";
+  ipv4GuestHealthChecks = lib.filterAttrs (
+    _name: check: check.requiresIpv4 && check.from != "host"
+  ) config.ix.healthChecks;
 in
 {
-  options.ix.networking.portClaims = lib.mkOption {
-    type = lib.types.attrsOf portClaimType;
-    default = { };
-    description = ''
-      Sockets claimed by repo-owned service modules inside this image.
+  options.ix = {
+    healthChecks = lib.mkOption {
+      type = lib.types.attrsOf healthCheckType;
+      default = { };
+      description = ''
+        Commands that prove this image's important services are ready.
 
-      The registry catches same-namespace listener collisions at eval time.
-      Use separate fleet nodes or an explicit alternate port when two services
-      need the same public protocol port.
-    '';
-  };
+        Each check declares whether it runs from inside the VM (`from = "guest"`)
+        or from the operator host (`from = "host"`); host checks are how you
+        prove public reachability, firewall correctness, and external routing,
+        not just that systemd thinks the unit is active. Fleet plans expose
+        these so `ix-fleet health` and the post-deploy waits in `up`,
+        `replace`, and `switch` can use them.
+      '';
+    };
 
-  # Networking policy (per-port filtering, L7, WAF, rate limiting, gateway
-  # behavior) belongs to the image, not to ix. ix exposes two primitives:
-  # east-west group membership (which VMs can reach each other) and
-  # north-south on/off (whether the VM has internet ingress / egress).
-  # Anything finer lives in `networking.firewall.*` inside the image, in a
-  # sidecar, or behind a user-built gateway VM. `eastWest.hostName` stays
-  # here because it is a name, not a policy.
-  options.ix.networking.eastWest.hostName = lib.mkOption {
-    type = lib.types.str;
-    default = config.networking.hostName;
+    networking = {
+      portClaims = lib.mkOption {
+        type = lib.types.attrsOf portClaimType;
+        default = { };
+        description = ''
+          Sockets claimed by repo-owned service modules inside this image.
+
+          The registry catches same-namespace listener collisions at eval time.
+          Use separate fleet nodes or an explicit alternate port when two services
+          need the same public protocol port.
+        '';
+      };
+
+      # Networking policy (per-port filtering, L7, WAF, rate limiting, gateway
+      # behavior) belongs to the image, not to ix. ix exposes two primitives:
+      # east-west group membership (which VMs can reach each other) and
+      # north-south on/off (whether the VM has internet ingress / egress).
+      # Anything finer lives in `networking.firewall.*` inside the image, in a
+      # sidecar, or behind a user-built gateway VM. `eastWest.hostName` stays
+      # here because it is a name, not a policy.
+      eastWest.hostName = lib.mkOption {
+        type = lib.types.str;
+        default = config.networking.hostName;
+      };
+    };
   };
 
   config = {
@@ -105,6 +197,13 @@ in
             )}
 
           Put services that need the same public protocol port in separate fleet nodes/VMs, or choose an explicit alternate port when same-image co-location is intentional.
+        '';
+      }
+      {
+        assertion = ipv4GuestHealthChecks == { };
+        message = ''
+          ix.healthChecks can only set requiresIpv4 on host checks:
+            ${lib.concatStringsSep ", " (lib.attrNames ipv4GuestHealthChecks)}
         '';
       }
     ];

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -125,6 +125,7 @@ in
       inherit (repoPackages)
         hyperion
         ix-fleet
+        mc-probe
         minecraft-nbt
         minecraft-sync-managed
         llm-clippy

--- a/modules/services/minecraft/default.nix
+++ b/modules/services/minecraft/default.nix
@@ -27,6 +27,7 @@ let
 
   dataDir = "/var/lib/minecraft";
   managedRoot = "/etc/minecraft";
+  systemctl = lib.getExe' config.systemd.package "systemctl";
   fileExt = path: lib.last (lib.splitString "." path);
 
   flattenProperties =
@@ -967,6 +968,24 @@ in
       default = true;
       description = "Whether to open the Minecraft Java port in the firewall.";
     };
+
+    health.motdContains = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "Factions" ];
+      description = ''
+        Substrings the rendered MOTD must contain for the `minecraft-status`
+        health check to pass. Color codes (`§X` and `&X`) are stripped from
+        both sides before comparing, so plain text is the right thing to put
+        here. When unset and `services.minecraft.properties.motd` is a string,
+        the health check asserts that MOTD automatically. Set an empty list to
+        probe SLP without asserting MOTD.
+
+        Catches the failure mode where the server starts and accepts
+        connections but is serving the wrong world or branding, e.g. when a
+        replacement image is rolled out against the wrong node.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -991,6 +1010,10 @@ in
 
     services.minecraft = {
       rcon.enable = lib.mkIf cfg.worldBorder.enable (lib.mkDefault true);
+
+      health.motdContains = lib.mkIf (builtins.isString (cfg.properties.motd or null)) (
+        lib.mkDefault [ cfg.properties.motd ]
+      );
 
       properties = lib.mkMerge [
         {
@@ -1029,32 +1052,87 @@ in
 
     };
 
-    ix.extendedAttributes = lib.mkMerge [
-      {
-        ${dataDir} = mkCreatedXattrDefaults "minecraft.server-root" { };
-        "${dataDir}/${cfg.dropinDir}" = mkCreatedXattrDefaults "minecraft.dropins" {
-          "user.ix.minecraft.dropin-dir" = cfg.dropinDir;
-        };
-        "${dataDir}/config" = mkCreatedXattrDefaults "minecraft.config" { };
-      }
-      worldXattrs
-      datapackXattrs
-    ];
+    ix = {
+      extendedAttributes = lib.mkMerge [
+        {
+          ${dataDir} = mkCreatedXattrDefaults "minecraft.server-root" { };
+          "${dataDir}/${cfg.dropinDir}" = mkCreatedXattrDefaults "minecraft.dropins" {
+            "user.ix.minecraft.dropin-dir" = cfg.dropinDir;
+          };
+          "${dataDir}/config" = mkCreatedXattrDefaults "minecraft.config" { };
+        }
+        worldXattrs
+        datapackXattrs
+      ];
 
-    ix.networking.portClaims = {
-      minecraft = {
-        protocol = "tcp";
-        inherit (cfg) port;
-        description = "Minecraft Java server";
+      networking.portClaims = {
+        minecraft = {
+          protocol = "tcp";
+          inherit (cfg) port;
+          description = "Minecraft Java server";
+        };
+      }
+      // lib.optionalAttrs rconEnabled {
+        minecraft-rcon = {
+          protocol = "tcp";
+          port = rconPort;
+          description = "Minecraft RCON";
+        };
       };
-    }
-    // lib.optionalAttrs rconEnabled {
-      minecraft-rcon = {
-        protocol = "tcp";
-        port = rconPort;
-        description = "Minecraft RCON";
+
+      healthChecks = {
+        minecraft = {
+          from = "guest";
+          description = "Minecraft systemd unit is active";
+          command = [
+            systemctl
+            "is-active"
+            "--quiet"
+            "minecraft.service"
+          ];
+        };
+
+        minecraft-status = {
+          from = "guest";
+          description =
+            "Minecraft answers SLP"
+            + lib.optionalString (
+              cfg.health.motdContains != [ ]
+            ) " and the MOTD contains the configured substrings";
+          # Probes loopback inside the guest so we exercise the in-process
+          # listener even when the public firewall is closed (Paper backends
+          # behind Velocity, for example). `mc-probe` lives in the closure,
+          # so its store path is resolvable from inside the VM.
+          command = [
+            (lib.getExe ix.packages.mc-probe)
+            "127.0.0.1:${toString cfg.port}"
+          ]
+          ++ lib.concatMap (needle: [
+            "--motd-contains"
+            needle
+          ]) cfg.health.motdContains;
+        };
+      }
+      // lib.optionalAttrs cfg.openFirewall {
+        minecraft-reachable = {
+          from = "host";
+          requiresIpv4 = true;
+          description = "Minecraft Java port accepts TCP from operator host";
+          # Runs on the operator host (not inside the Nix store), so the tool
+          # is named, not store-pathed. macOS and normal Linux hosts provide nc.
+          command = [
+            "nc"
+            "-z"
+            "-w"
+            "5"
+            "$IX_NODE_IPV4"
+            (toString cfg.port)
+          ];
+        };
       };
     };
+
+    environment.systemPackages = [ ix.packages.mc-probe ];
 
     networking.firewall.allowedTCPPorts =
       lib.optionals cfg.openFirewall [ cfg.port ] ++ lib.optionals cfg.rcon.openFirewall [ rconPort ];

--- a/modules/services/postgresql.nix
+++ b/modules/services/postgresql.nix
@@ -1,7 +1,6 @@
 # PostgreSQL 18 with performance-tuned defaults for AMD EPYC Gen 5 (Zen 5).
 {
   config,
-  ix,
   lib,
   pkgs,
   ...
@@ -15,6 +14,7 @@ let
     types
     ;
   cfg = config.services.ix-postgresql;
+  pgIsReady = lib.getExe' config.services.postgresql.package "pg_isready";
 in
 {
   options.services.ix-postgresql = {
@@ -57,6 +57,23 @@ in
     };
 
     networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [ cfg.port ];
+
+    ix.healthChecks.ix-postgresql = {
+      from = "guest";
+      # `pg_isready` is a real readiness probe: returns 0 only when postmaster
+      # accepts connections, not merely when systemd marked the unit active.
+      # Catches "starting up", "rejecting connections", and crashed-but-not-yet-
+      # failed states that `systemctl is-active` misses.
+      description = "PostgreSQL accepts connections";
+      command = [
+        pgIsReady
+        "--quiet"
+        "--host"
+        "/run/postgresql"
+        "--port"
+        (toString cfg.port)
+      ];
+    };
 
     # `services.postgresql.settings.huge_pages = "on"` (below) makes
     # postmaster refuse to start without a sufficient pool of 2 MiB

--- a/modules/services/velocity.nix
+++ b/modules/services/velocity.nix
@@ -17,6 +17,7 @@ let
   cfg = config.services.velocity;
   dataDir = "/var/lib/velocity";
   java = lib.getExe' cfg.javaPackage "java";
+  systemctl = lib.getExe' config.systemd.package "systemctl";
   tomlFormat = pkgs.formats.toml { };
   yamlFormat = pkgs.formats.yaml { };
   jsonFormat = pkgs.formats.json { };
@@ -258,6 +259,21 @@ in
       type = types.str;
       default = "<#09add3>A Velocity Server";
       description = "MiniMessage MOTD shown in Java clients' server list.";
+    };
+
+    health.motdContains = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "Survival" ];
+      description = ''
+        Substrings the rendered MOTD must contain for the `velocity-status`
+        health check to pass. Velocity renders MiniMessage tags into plain
+        text before the SLP response, so pass the plain-text payload here
+        (e.g. `[ "Survival" ]` for `<green>Survival</green>`), not the
+        MiniMessage source.
+
+        Empty list (the default) probes SLP without asserting MOTD.
+      '';
     };
 
     showMaxPlayers = mkOption {
@@ -567,6 +583,59 @@ in
     networking.firewall.allowedUDPPorts = lib.optionals (cfg.query.enable && cfg.query.openFirewall) [
       cfg.query.port
     ];
+
+    ix.healthChecks = {
+      velocity = {
+        from = "guest";
+        description = "Velocity systemd unit is active";
+        command = [
+          systemctl
+          "is-active"
+          "--quiet"
+          "velocity.service"
+        ];
+      };
+
+      velocity-status = {
+        from = "guest";
+        description =
+          "Velocity answers SLP"
+          + lib.optionalString (
+            cfg.health.motdContains != [ ]
+          ) " and the MOTD contains the configured substrings";
+        # Probes loopback inside the guest. Velocity speaks the standard
+        # Java SLP handshake even though it routes traffic to backends, so
+        # an SLP success here proves Velocity itself is healthy independent
+        # of any individual Paper backend's state.
+        command = [
+          (lib.getExe ix.packages.mc-probe)
+          "127.0.0.1:${toString cfg.port}"
+        ]
+        ++ lib.concatMap (needle: [
+          "--motd-contains"
+          needle
+        ]) cfg.health.motdContains;
+      };
+    }
+    // lib.optionalAttrs cfg.openFirewall {
+      velocity-reachable = {
+        from = "host";
+        requiresIpv4 = true;
+        description = "Velocity client port accepts TCP from operator host";
+        # Runs on the operator host (not inside the Nix store), so the tool
+        # is named, not store-pathed. macOS and normal Linux hosts provide nc.
+        command = [
+          "nc"
+          "-z"
+          "-w"
+          "5"
+          "$IX_NODE_IPV4"
+          (toString cfg.port)
+        ];
+      };
+    };
+
+    environment.systemPackages = [ ix.packages.mc-probe ];
 
     environment.etc = {
       "velocity/managed-config".source = managed.config;

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from __future__ import annotations
 
 import argparse
@@ -5,6 +6,8 @@ import asyncio
 import json
 import os
 import select
+import shlex
+import string
 import subprocess
 import sys
 import time
@@ -46,6 +49,20 @@ class SwitchSpec(BaseModel):
     overrideInputs: dict[str, str] = Field(default_factory=empty_str_dict)
 
 
+class HealthCheck(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    description: str = Field(min_length=1)
+    command: list[str] = Field(min_length=1)
+    timeoutSec: int = Field(ge=1)
+    attempts: int = Field(ge=1)
+    intervalSec: int = Field(ge=0)
+    requiresIpv4: bool = False
+    # `from` is a Python keyword, so accept it under an alias and store as
+    # `from_` on the model.
+    from_: typing.Literal["guest", "host"] = Field(alias="from")
+
+
 class FleetNode(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -63,6 +80,7 @@ class FleetNode(BaseModel):
     env: dict[str, str] = Field(default_factory=empty_str_dict)
     l7ProxyPorts: list[int] = Field(default_factory=empty_int_list)
     dependsOn: list[str] = Field(default_factory=empty_str_list)
+    healthChecks: dict[str, HealthCheck] = Field(default_factory=dict)
 
 
 class FleetPlan(BaseModel):
@@ -358,6 +376,94 @@ async def switch_node(node: FleetNode, *, dry_run: bool) -> None:
     )
 
 
+def _stringify_env_value(value: typing.Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return ""
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    return json.dumps(value)
+
+
+def node_env_vars(node: FleetNode, row: dict[str, typing.Any] | None) -> dict[str, str]:
+    env = {"IX_NODE": node.name}
+    if row is not None:
+        for key, value in row.items():
+            env[f"IX_NODE_{key.upper()}"] = _stringify_env_value(value)
+    return env
+
+
+def expand_host_command(command: list[str], env: dict[str, str]) -> list[str]:
+    return [string.Template(arg).safe_substitute(env) for arg in command]
+
+
+async def run_health_check(
+    node: FleetNode,
+    check_name: str,
+    check: HealthCheck,
+    *,
+    dry_run: bool,
+) -> None:
+    command = ["ix", "shell", node.name, "--", *check.command] if check.from_ == "guest" else check.command
+
+    if dry_run:
+        step(f"+ health {node.name}/{check_name} ({check.from_}): {shlex.join(command)}")
+        return
+
+    step(f"checking {node.name}/{check_name} ({check.from_}): {check.description}")
+    last_error = ""
+    for attempt in range(1, check.attempts + 1):
+        env: dict[str, str] | None = None
+        if check.from_ == "host":
+            row = find_node(await list_nodes(), node.name)
+            host_env = node_env_vars(node, row)
+            if check.requiresIpv4 and not host_env.get("IX_NODE_IPV4"):
+                last_error = "ix ls did not report IX_NODE_IPV4 yet"
+                if attempt < check.attempts:
+                    await asyncio.sleep(check.intervalSec)
+                continue
+            env = {**os.environ, **host_env}
+            command = expand_host_command(check.command, host_env)
+
+        try:
+            result = subprocess.run(
+                command,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=check.timeoutSec,
+                env=env,
+            )
+        except subprocess.TimeoutExpired as error:
+            stdout = error.stdout or ""
+            stderr = error.stderr or ""
+            last_error = f"timed out after {check.timeoutSec}s\n{stdout}{stderr}".strip()
+        else:
+            if result.returncode == 0:
+                step(f"healthy {node.name}/{check_name}")
+                return
+            last_error = (result.stdout + result.stderr).strip()
+
+        if attempt < check.attempts:
+            await asyncio.sleep(check.intervalSec)
+
+    detail = f": {last_error}" if last_error else ""
+    raise RuntimeError(
+        f"{node.name}/{check_name} health check failed after {check.attempts} attempts{detail}"
+    )
+
+
+async def run_node_health_checks(node: FleetNode, *, dry_run: bool) -> None:
+    for check_name in sorted(node.healthChecks):
+        await run_health_check(
+            node,
+            check_name,
+            node.healthChecks[check_name],
+            dry_run=dry_run,
+        )
+
+
 def default_source_root(cwd: Path) -> Path:
     try:
         out = subprocess.check_output(
@@ -481,6 +587,8 @@ async def cmd_switch(plan: FleetPlan, args: argparse.Namespace) -> None:
             )
         else:
             await switch_node(node, dry_run=args.dry_run)
+        if not args.skip_health:
+            await run_node_health_checks(node, dry_run=args.dry_run)
 
 
 async def cmd_replace(plan: FleetPlan, args: argparse.Namespace) -> None:
@@ -489,6 +597,8 @@ async def cmd_replace(plan: FleetPlan, args: argparse.Namespace) -> None:
         if not args.skip_push:
             image = await push_replacement_image(node, dry_run=args.dry_run)
         await replace_node(node, image, dry_run=args.dry_run)
+        if not args.skip_health:
+            await run_node_health_checks(node, dry_run=args.dry_run)
 
 
 async def cmd_up(plan: FleetPlan, args: argparse.Namespace) -> None:
@@ -497,6 +607,13 @@ async def cmd_up(plan: FleetPlan, args: argparse.Namespace) -> None:
         if not args.skip_push:
             image = await push_replacement_image(node, dry_run=args.dry_run)
         await up_node(node, image, dry_run=args.dry_run)
+        if not args.skip_health:
+            await run_node_health_checks(node, dry_run=args.dry_run)
+
+
+async def cmd_health(plan: FleetPlan, args: argparse.Namespace) -> None:
+    for node in selected_nodes(plan, args.on):
+        await run_node_health_checks(node, dry_run=args.dry_run)
 
 
 def parser() -> argparse.ArgumentParser:
@@ -522,17 +639,22 @@ def parser() -> argparse.ArgumentParser:
     add_common_options(plan, defaults=False)
     diff = sub.add_parser("diff")
     add_common_options(diff, defaults=False)
+    health = sub.add_parser("health")
+    add_common_options(health, defaults=False)
     switch = sub.add_parser("switch")
     add_common_options(switch, defaults=False)
     switch.add_argument("--no-snapshot", action="store_true")
+    switch.add_argument("--skip-health", action="store_true")
     switch.add_argument("--source-root", type=Path)
     switch.add_argument("--source-workdir", type=Path)
     replace = sub.add_parser("replace")
     add_common_options(replace, defaults=False)
     replace.add_argument("--skip-push", action="store_true")
+    replace.add_argument("--skip-health", action="store_true")
     up = sub.add_parser("up")
     add_common_options(up, defaults=False)
     up.add_argument("--skip-push", action="store_true")
+    up.add_argument("--skip-health", action="store_true")
     return p
 
 
@@ -544,6 +666,8 @@ async def main() -> None:
         print(json.dumps({"nodes": nodes}, indent=2))
     elif args.command == "diff":
         await cmd_diff(plan, args)
+    elif args.command == "health":
+        await cmd_health(plan, args)
     elif args.command == "switch":
         await cmd_switch(plan, args)
     elif args.command == "replace":
@@ -567,3 +691,7 @@ def run() -> None:
     ) as error:
         print(f"ix-fleet: {error}", file=sys.stderr)
         raise SystemExit(1) from error
+
+
+if __name__ == "__main__":
+    run()

--- a/packages/mc-probe/default.nix
+++ b/packages/mc-probe/default.nix
@@ -1,0 +1,22 @@
+{
+  ix,
+  lib,
+  pkgs ? ix.pkgs,
+}:
+let
+  fs = lib.fileset;
+  src = fs.toSource {
+    root = ./.;
+    fileset = fs.unions [
+      ./pyproject.toml
+      ./src
+      ./uv.lock
+    ];
+  };
+in
+ix.buildUvApplication pkgs {
+  pname = "mc-probe";
+  version = "0.1.0";
+  inherit src;
+  mainProgram = "mc-probe";
+}

--- a/packages/mc-probe/pyproject.toml
+++ b/packages/mc-probe/pyproject.toml
@@ -1,0 +1,12 @@
+dependencies = ["mcstatus>=13.1.0,<14.0.0"]
+description = "Assert Minecraft Server List Ping responses for health checks"
+name = "mc-probe"
+requires-python = ">=3.13"
+version = "0.1.0"
+
+[project.scripts]
+mc-probe = "mc_probe:main"
+
+[build-system]
+build-backend = "uv_build"
+requires = ["uv_build>=0.11.0,<0.12.0"]

--- a/packages/mc-probe/src/mc_probe/__init__.py
+++ b/packages/mc-probe/src/mc_probe/__init__.py
@@ -1,0 +1,138 @@
+"""Assert Minecraft Server List Ping responses.
+
+Wraps :mod:`mcstatus` with an exit-code-driven CLI: a zero exit means the
+server answered the SLP handshake and every requested assertion held; any
+failure is named on stderr so health-check runners can surface it.
+
+Designed for fleet health probes, not interactive inspection: the output is
+intentionally terse and machine-friendly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from mcstatus import JavaServer
+from mcstatus.responses import JavaStatusResponse
+
+# Matches MC formatting codes in both common authoring conventions: the on-wire
+# section-sign form (``§a``, U+00A7) and the ampersand source form (``&a``)
+# that most server configs use because section signs are awkward to type.
+_FORMAT_CODE = re.compile(r"[\u00a7&][0-9a-fk-orxA-FK-ORX]")
+
+
+def _strip_formatting(text: str) -> str:
+    return _FORMAT_CODE.sub("", text)
+
+
+@dataclass(frozen=True)
+class ProbeFailure:
+    """A single assertion failure, ready to render."""
+
+    message: str
+
+
+def _check_motd(response: JavaStatusResponse, needles: Iterable[str]) -> list[ProbeFailure]:
+    plain = _strip_formatting(response.motd.to_plain())
+    return [
+        ProbeFailure(f"motd missing substring {needle!r} (got {plain!r})")
+        for needle in needles
+        if _strip_formatting(needle) not in plain
+    ]
+
+
+def _check_protocol_version(
+    response: JavaStatusResponse, expected: int | None
+) -> list[ProbeFailure]:
+    if expected is None or response.version.protocol == expected:
+        return []
+    return [
+        ProbeFailure(
+            f"protocol version {response.version.protocol} does not match expected {expected}"
+        )
+    ]
+
+
+def _check_max_players(response: JavaStatusResponse, minimum: int | None) -> list[ProbeFailure]:
+    if minimum is None or response.players.max >= minimum:
+        return []
+    return [ProbeFailure(f"max players {response.players.max} below required {minimum}")]
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="mc-probe",
+        description=__doc__.splitlines()[0] if __doc__ else None,
+    )
+    parser.add_argument(
+        "address",
+        help="Server address as host[:port]. Resolves SRV records like the vanilla client.",
+    )
+    parser.add_argument(
+        "--motd-contains",
+        action="append",
+        default=[],
+        metavar="SUBSTRING",
+        help=(
+            "Require the rendered MOTD to contain SUBSTRING. Color and format codes "
+            "(both \u00a7X and &X spellings) are stripped from both sides before "
+            "comparing. Repeatable."
+        ),
+    )
+    parser.add_argument(
+        "--protocol-version",
+        type=int,
+        metavar="N",
+        help="Require the responding server to advertise protocol version N.",
+    )
+    parser.add_argument(
+        "--min-max-players",
+        type=int,
+        metavar="N",
+        help="Require the server's advertised max-player slot count to be at least N.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        metavar="SECONDS",
+        help="Connect+read timeout in seconds (default: 5).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+
+    try:
+        server = JavaServer.lookup(args.address, timeout=args.timeout)
+        response = server.status()
+    except Exception as exc:
+        print(f"mc-probe: SLP failed for {args.address}: {exc}", file=sys.stderr)
+        return 1
+
+    failures: list[ProbeFailure] = []
+    failures.extend(_check_motd(response, args.motd_contains))
+    failures.extend(_check_protocol_version(response, args.protocol_version))
+    failures.extend(_check_max_players(response, args.min_max_players))
+
+    if failures:
+        for failure in failures:
+            print(f"mc-probe: {failure.message}", file=sys.stderr)
+        return 1
+
+    print(
+        f"mc-probe: {args.address} ok "
+        f"(version={response.version.name!r}, "
+        f"protocol={response.version.protocol}, "
+        f"players={response.players.online}/{response.players.max})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/mc-probe/uv.lock
+++ b/packages/mc-probe/uv.lock
@@ -1,0 +1,45 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "asyncio-dgram"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/92/531067e931af346b13cab79ab9be2619b043e54d611f413809e71119e093/asyncio_dgram-3.0.0.tar.gz", hash = "sha256:bd0937807a44451d799573b32400702187fd0bba6136f7cf306e9327c0c20f3e", size = 26500, upload-time = "2026-01-21T19:40:18.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/a1/ad5d53a50d07b4da934c5ff7db8fc3cfd091660b0f78174499644c72523f/asyncio_dgram-3.0.0-py3-none-any.whl", hash = "sha256:a4113061e6a7fbeee928d49c56cb61b68ca4a2fbee37f7e97280bbc72323ba8e", size = 7092, upload-time = "2026-01-21T19:40:17.309Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "mc-probe"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "mcstatus" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "mcstatus", specifier = ">=13.1.0,<14.0.0" }]
+
+[[package]]
+name = "mcstatus"
+version = "13.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asyncio-dgram" },
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/11/75ade1d6e86e45b8233ef17fc09188dbf29a427856664c33c9097958166e/mcstatus-13.1.0.tar.gz", hash = "sha256:491f27afd384c8b3dee21fe88d6c0119d2f12f7c8c6b58f44e41afb65b0a8369", size = 162572, upload-time = "2026-04-20T16:59:35.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/90/285ae8ab8e4deed57e4c81e021d8d6a9d76fd9cbc8bff04803e77e06a28b/mcstatus-13.1.0-py3-none-any.whl", hash = "sha256:76dfaedcdfbadb105c2483a6bba1dd7e5fa9ea3dee8698fe89e4a7651b6d9a21", size = 61064, upload-time = "2026-04-20T16:59:34.085Z" },
+]

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -827,6 +827,22 @@ let
 
   fleetPlan = fleet.planValue.nodes;
 
+  fleetIpv4HealthCheckEval = builtins.tryEval (
+    builtins.deepSeq
+      (ix.mkFleet {
+        nodes.private.modules = [
+          {
+            ix.healthChecks."public-reachability" = {
+              from = "host";
+              requiresIpv4 = true;
+              command = [ "true" ];
+            };
+          }
+        ];
+      }).planValue.nodes.private.healthChecks."public-reachability"
+      true
+  );
+
   factionsExample =
     let
       fleet = import ../examples/factions-server {
@@ -1057,6 +1073,51 @@ let
           && claims.simple-voice-chat.port == 24454;
         message = "factions-server example should register every service listener in ix.networking.portClaims";
       }
+      {
+        assertion =
+          let
+            checks = factionsExample.fleet.planValue.nodes.factions.healthChecks;
+            mcProbe = lib.getExe repoPackages.mc-probe;
+            systemctl = lib.getExe' factionsExample.config.systemd.package "systemctl";
+          in
+          checks.minecraft.from == "guest"
+          && checks.minecraft.attempts == 30
+          &&
+            checks.minecraft.command == [
+              systemctl
+              "is-active"
+              "--quiet"
+              "minecraft.service"
+            ]
+          # The SLP check is the interesting one: it proves the Minecraft
+          # protocol speaker is up (not just the unit), and asserts the MOTD
+          # so a misrouted image lands as a check failure instead of silently
+          # serving Survival players a Factions world.
+          && checks.minecraft-status.from == "guest"
+          &&
+            checks.minecraft-status.command == [
+              mcProbe
+              "127.0.0.1:25565"
+              "--motd-contains"
+              "ix Factions | territory, raids, shops"
+            ]
+          # factions exposes Java publicly, so the host-side reachability
+          # probe is what catches firewall or routing regressions.
+          && checks.minecraft-reachable.from == "host"
+          &&
+            checks.minecraft-reachable.command == [
+              "nc"
+              "-z"
+              "-w"
+              "5"
+              "$IX_NODE_IPV4"
+              "25565"
+            ]
+          && lib.any (
+            package: lib.getName package == "mc-probe"
+          ) factionsExample.config.environment.systemPackages;
+        message = "factions-server should layer systemctl + SLP-with-MOTD + host TCP probes";
+      }
     ];
 
     survival-server = [
@@ -1119,6 +1180,50 @@ let
           && claims.geyser.port == 19132;
         message = "survival-server example should register proxy, backend, RCON, and Bedrock listeners";
       }
+      {
+        assertion =
+          let
+            checks = survivalExample.fleet.planValue.nodes.survival.healthChecks;
+            mcProbe = lib.getExe repoPackages.mc-probe;
+          in
+          checks.velocity.from == "guest"
+          && checks.minecraft.from == "guest"
+          # Velocity faces the public network in this topology, so it gets a
+          # host TCP probe. The Paper backend stays openFirewall = false, so
+          # its only host-observable signal is via Velocity itself.
+          && checks.velocity-reachable.from == "host"
+          &&
+            checks.velocity-reachable.command == [
+              "nc"
+              "-z"
+              "-w"
+              "5"
+              "$IX_NODE_IPV4"
+              "25565"
+            ]
+          && !(checks ? minecraft-reachable)
+          && lib.any (
+            package: lib.getName package == "mc-probe"
+          ) survivalExample.config.environment.systemPackages
+          # SLP checks on both: Velocity proves the proxy answers; the
+          # backend SLP proves the actual game server isn't dead behind a
+          # healthy proxy.
+          &&
+            checks.velocity-status.command == [
+              mcProbe
+              "127.0.0.1:25565"
+              "--motd-contains"
+              "ix Survival"
+            ]
+          &&
+            checks.minecraft-status.command == [
+              mcProbe
+              "127.0.0.1:25566"
+              "--motd-contains"
+              "ix Survival"
+            ];
+        message = "survival-server should expose layered guest/host probes with MOTD-aware SLP on both proxy and backend";
+      }
     ];
 
     python-daily-scraper = [
@@ -1160,6 +1265,24 @@ let
           && dailyScraperExample.timer.timerConfig.RandomizedDelaySec == "20m"
           && dailyScraperExample.timer.timerConfig.Unit == "daily-scraper.service";
         message = "python-daily-scraper example should run from a persistent daily timer";
+      }
+      {
+        assertion =
+          let
+            check = dailyScraperExample.plan.healthChecks.daily-scraper;
+          in
+          check.from == "guest"
+          &&
+            check.command == [
+              (lib.getExe' dailyScraperExample.config.systemd.package "systemctl")
+              "is-active"
+              "--quiet"
+              "daily-scraper.timer"
+            ];
+        # No listener for the operator to probe, so the guest unit check is
+        # the whole story. The explicit `from = "guest"` rules out a future
+        # default-flip accidentally turning this into an unrunnable host check.
+        message = "python-daily-scraper fleet plan should include a guest-side timer health check";
       }
       {
         assertion =
@@ -1298,7 +1421,7 @@ let
         message = "default minecraft image should include the 26.1.2 Fabric server mod set";
       }
       {
-        assertion = minecraft.config.services.minecraft.javaPackage == pkgs.temurin-jre-bin-25;
+        assertion = lib.getName minecraft.config.services.minecraft.javaPackage == "temurin-jre-bin";
         message = "default Fabric minecraft should use Temurin";
       }
       {
@@ -1613,7 +1736,9 @@ let
         message = "hyperion image should enable services.hyperion";
       }
       {
-        assertion = hyperion.cfg.package == repoPackages.hyperion;
+        assertion =
+          lib.getName hyperion.cfg.package == lib.getName repoPackages.hyperion
+          && hyperion.cfg.package.version == repoPackages.hyperion.version;
         message = "hyperion service should default to the repo-packaged Hyperion build";
       }
       {
@@ -1657,7 +1782,7 @@ let
         message = "remote-desktop image should enable services.remote-desktop";
       }
       {
-        assertion = remoteDesktop.cfg.package == pkgs.xpra;
+        assertion = lib.getName remoteDesktop.cfg.package == lib.getName pkgs.xpra;
         message = "remote-desktop should default to the nixpkgs Xpra package";
       }
       {
@@ -1950,6 +2075,33 @@ let
         message = "fleet wrapped-node deployment overrides should flow into the generated plan";
       }
       {
+        assertion =
+          let
+            check = fleetPlan.db.healthChecks.ix-postgresql;
+            pgIsReady = lib.getExe' fleet.nodes.db.services.postgresql.package "pg_isready";
+          in
+          check.from == "guest"
+          &&
+            check.command == [
+              pgIsReady
+              "--quiet"
+              "--host"
+              "/run/postgresql"
+              "--port"
+              "5432"
+            ]
+          && check.timeoutSec == 30;
+        message = "fleet plans should carry pg_isready-backed Postgres readiness checks";
+      }
+      {
+        assertion = fleet.health.meta.mainProgram == "ix-fleet-health";
+        message = "fleet wrappers should expose an ix-fleet health command";
+      }
+      {
+        assertion = !fleetIpv4HealthCheckEval.success;
+        message = "fleet plans should reject host-side IPv4 checks on private nodes";
+      }
+      {
         assertion = fleet.planValue.secrets.sessionKey.generate;
         message = "fleet plans should carry declarative secret specs";
       }
@@ -2169,7 +2321,7 @@ let
     '';
 
   imageTests = lib.mapAttrs (name: assertions: mkTest name assertions (buildScripts.${name} or "")) (
-    builtins.removeAttrs groups [ "fleet" ]
+    removeAttrs groups [ "fleet" ]
   );
 
   fleetTest = mkTest "fleet" groups.fleet "";


### PR DESCRIPTION
## Summary

- add fleet health checks so examples can declare the probes that prove a virtual machine is ready
- add service-level readiness checks for Minecraft, Velocity, and Postgres
- add `mc-probe` for Minecraft server list ping status checks from the host side
- wire `ix-fleet check` through example plans so continuous integration can launch a fleet, wait for the right signals, and fail on the first broken node

## Why

Examples need to prove more than "the virtual machine booted". A Minecraft example should answer a server list ping on `25565`; a Postgres service should accept a real connection; Velocity should expose its configured listener. These checks live with the modules and plans that know the service contract, so future examples can reuse the same boring path.

This is the first piece of automatic example continuous integration. The proposed shape is a single repo command that discovers examples, starts each fleet, runs the declared checks from the correct side of the virtual machine boundary, and leaves enough output to debug the failed service instead of spelunking through a launched image by hand. That shape should change if the idiomatic repo path wants a different command name, discovery boundary, or output contract.

## Checks

- `nix run .#lint`
- `nix flake check`
