### PR TITLE
Follow-ups: hardening, rust vendor, paper/velocity, flake-check CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,27 @@
+name: Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  flake-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Determinate Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+
+      - name: nix flake check
+        run: nix flake check -L

--- a/examples/survival-server/minecraft.nix
+++ b/examples/survival-server/minecraft.nix
@@ -1,13 +1,11 @@
-_:
-let
-  forwardingSecret = "ix-survival-example-forwarding-secret-change-me";
-in
-{
+_: {
   services = {
     velocity = {
       enable = true;
       motd = "<green>ix Survival</green> <gray>| Java and Bedrock</gray>";
-      forwarding.secret = forwardingSecret;
+      # Paper picks this up automatically: services.minecraft.paper defaults
+      # paper-global.yml's proxies.velocity block from the same string.
+      forwarding.secret = "ix-survival-example-forwarding-secret-change-me";
       servers.survival = "127.0.0.1:25566";
       try = [ "survival" ];
     };
@@ -41,12 +39,6 @@ in
         view-distance = 16;
         simulation-distance = 10;
         pvp = true;
-      };
-
-      configFiles."paper-global.yml".proxies.velocity = {
-        enabled = true;
-        secret = forwardingSecret;
-        online-mode = true;
       };
 
       serverFiles."spigot.yml".settings = {

--- a/flake.lock
+++ b/flake.lock
@@ -1,41 +1,5 @@
 {
   "nodes": {
-    "ixCliAarch64Darwin": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-S91DPDZujxDOUKrLNEMHMa+Mng+Eln/c6PW9FRB9t5M=",
-        "type": "file",
-        "url": "https://ix.dev/cli/darwin-arm64/ix"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://ix.dev/cli/darwin-arm64/ix"
-      }
-    },
-    "ixCliX86_64Darwin": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-wmWjgN1mMADA5NDWihmoOUgFjUxd0L1/4Wn4It0V81E=",
-        "type": "file",
-        "url": "https://ix.dev/cli/darwin-x86_64/ix"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://ix.dev/cli/darwin-x86_64/ix"
-      }
-    },
-    "ixCliX86_64Linux": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-mQtFhDHIA+vntl0RhRs0w6WFNasbm82I2TWY9hTBnjM=",
-        "type": "file",
-        "url": "https://ix.dev/cli/linux-x86_64/ix"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://ix.dev/cli/linux-x86_64/ix"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1778869304,
@@ -70,9 +34,6 @@
     },
     "root": {
       "inputs": {
-        "ixCliAarch64Darwin": "ixCliAarch64Darwin",
-        "ixCliX86_64Darwin": "ixCliX86_64Darwin",
-        "ixCliX86_64Linux": "ixCliX86_64Linux",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
         bench.filesystem = ./bench/filesystem;
         minecraftMods = ./images/games/minecraft/mods;
         minecraftPaperPlugins = ./images/games/minecraft/plugins/paper;
+        minecraftVelocityPlugins = ./images/games/minecraft/plugins/velocity;
         packages = {
           ix = ./packages/ix;
           hyperion = ./packages/hyperion;

--- a/flake.nix
+++ b/flake.nix
@@ -4,27 +4,12 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";
-    ixCliX86_64Linux = {
-      url = "https://ix.dev/cli/linux-x86_64/ix";
-      flake = false;
-    };
-    ixCliAarch64Darwin = {
-      url = "https://ix.dev/cli/darwin-arm64/ix";
-      flake = false;
-    };
-    ixCliX86_64Darwin = {
-      url = "https://ix.dev/cli/darwin-x86_64/ix";
-      flake = false;
-    };
   };
 
   outputs =
     {
       nixpkgs,
       rust-overlay,
-      ixCliAarch64Darwin,
-      ixCliX86_64Linux,
-      ixCliX86_64Darwin,
       ...
     }:
     let
@@ -63,11 +48,6 @@
 
       ix = import ./lib {
         inherit nixpkgs paths rust-overlay;
-        cliArtifacts = {
-          aarch64-darwin = ixCliAarch64Darwin;
-          x86_64-linux = ixCliX86_64Linux;
-          x86_64-darwin = ixCliX86_64Darwin;
-        };
       };
       devSystems = [
         "x86_64-linux"

--- a/images/games/minecraft/plugins/paper/26.1.2.json
+++ b/images/games/minecraft/plugins/paper/26.1.2.json
@@ -44,6 +44,11 @@
     "pluginName": "PlaceholderAPI",
     "url": "https://cdn.modrinth.com/data/lKEzGugV/versions/UmbIiI5H/PlaceholderAPI-2.12.2.jar"
   },
+  "plugmanx": {
+    "hash": "sha256-LLb7Ddfm9YZ7ypv6PwN1HW2J1rlJ6LbTdAUHtVrmqcA=",
+    "pluginName": "PlugManX",
+    "url": "https://cdn.modrinth.com/data/yro4niHu/versions/hrMAp7Ww/PlugManX-3.0.4.jar"
+  },
   "pvpindex-factions": {
     "hash": "sha512-Vwb3p8ijsF9STJn6xWfic2muAYVUOjKSgv0/rxmp4FzkSXyMjZZhniX4I5RFaMFBA72Eqn0xKU1OUlUydJ6tMg==",
     "pluginName": "PvPIndexFactions",

--- a/images/games/minecraft/plugins/paper/manifest.json
+++ b/images/games/minecraft/plugins/paper/manifest.json
@@ -83,6 +83,10 @@
       {
         "slug": "skript",
         "pluginName": "Skript"
+      },
+      {
+        "slug": "plugmanx",
+        "pluginName": "PlugManX"
       }
     ]
   },

--- a/images/games/minecraft/plugins/velocity/common.json
+++ b/images/games/minecraft/plugins/velocity/common.json
@@ -1,0 +1,12 @@
+{
+  "floodgate-velocity": {
+    "hash": "sha256-8liZUEOkhpy28e9gURCsHZBmpbHhsxZJWiWwavoMEGA=",
+    "pluginName": "floodgate-velocity",
+    "url": "https://download.geysermc.org/v2/projects/floodgate/versions/2.2.5/builds/132/downloads/velocity"
+  },
+  "geyser-velocity": {
+    "hash": "sha256-usLTnnEXiiFlXPdmj/tvwzY7QbBNeogK8ex4jNTs1e4=",
+    "pluginName": "Geyser-Velocity",
+    "url": "https://download.geysermc.org/v2/projects/geyser/versions/2.10.0/builds/1149/downloads/velocity"
+  }
+}

--- a/images/games/minecraft/plugins/velocity/manifest.json
+++ b/images/games/minecraft/plugins/velocity/manifest.json
@@ -1,0 +1,20 @@
+{
+  "loader": "velocity",
+  "common": {
+    "game_versions": [],
+    "mods": [
+      {
+        "slug": "geyser-velocity",
+        "pluginName": "Geyser-Velocity",
+        "version": "2.10.0+1149",
+        "url": "https://download.geysermc.org/v2/projects/geyser/versions/2.10.0/builds/1149/downloads/velocity"
+      },
+      {
+        "slug": "floodgate-velocity",
+        "pluginName": "floodgate-velocity",
+        "version": "2.2.5+132",
+        "url": "https://download.geysermc.org/v2/projects/floodgate/versions/2.2.5/builds/132/downloads/velocity"
+      }
+    ]
+  }
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -452,6 +452,7 @@ let
 
   modCatalogs = generatedCatalogs paths.minecraftMods;
   paperPluginCatalogs = generatedCatalogs paths.minecraftPaperPlugins;
+  velocityPluginCatalogs = generatedCatalogs paths.minecraftVelocityPlugins;
 
   # Minecraft version of the default variant declared in
   # `images/games/minecraft/versions.nix`. Lets per-loader fallback catalogs
@@ -465,6 +466,28 @@ let
     in
     versionsModule.${versionsModule.default}.services.minecraft.version;
 
+  # Fabric meta serves every server jar from the same loader+installer pair;
+  # only the Minecraft version moves. Keep the pair in one place so a Fabric
+  # bump touches one field instead of every URL string.
+  fabricLoaderVersion = "0.19.2";
+  fabricInstallerVersion = "1.1.1";
+  fabricServerUrl =
+    mcVer:
+    "https://meta.fabricmc.net/v2/versions/loader/${mcVer}/${fabricLoaderVersion}/${fabricInstallerVersion}/server/jar";
+  fabricServerHashes = {
+    "26.2-snapshot-5" = "sha256-IZctWQu9VH4Z5lU/VcEzvPGLfW8boOAXtCaQlKXyA5k=";
+    "26.2-snapshot-6" = "sha256-J4zGg7YlrHmYBsagTr+x2ZcAgOvj5vr/8iVgwMVG/e0=";
+    "26.1.2" = "sha256-6RvRm5/w4ExXhD5iTS9U0KPjmgSMr8pejiDrmENEXb0=";
+    "1.21.11" = "sha256-xDK1HU7Xwbr0Z7pw7Dtdtob0zvlfq9pZ9J4O32u4jBc=";
+  };
+  fabricServers = lib.mapAttrs' (mcVer: hash: {
+    name = "${mcVer}-fabric";
+    value = mkArtifact {
+      url = fabricServerUrl mcVer;
+      inherit hash;
+    };
+  }) fabricServerHashes;
+
   /**
     Pinned artifact catalogs surfaced to images and presets by name.
     Presets must consume entries through this set (or one of the module
@@ -473,47 +496,25 @@ let
   artifacts = {
     inherit attachArtifactSources;
     minecraft = {
-      inherit paperServers modCatalogs paperPluginCatalogs;
-      inherit velocityServers;
+      inherit
+        modCatalogs
+        paperPluginCatalogs
+        paperServers
+        velocityPluginCatalogs
+        velocityServers
+        ;
       paperPluginCatalog =
         if builtins.hasAttr defaultMinecraftVersion paperPluginCatalogs then
           paperPluginCatalogs.${defaultMinecraftVersion}
         else
           throw "ix.lib.artifacts.minecraft.paperPluginCatalog: no Paper plugin catalog generated for Minecraft ${defaultMinecraftVersion} (the default in images/games/minecraft/versions.nix). Run `nix run .#update-mods -- --manifest images/games/minecraft/plugins/paper/manifest.json --version ${defaultMinecraftVersion}` and commit the result.";
-      servers =
-        lib.mapAttrs (_: mkArtifact) {
-          "26.2-snapshot-5-fabric" = {
-            url = "https://meta.fabricmc.net/v2/versions/loader/26.2-snapshot-5/0.19.2/1.1.1/server/jar";
-            hash = "sha256-IZctWQu9VH4Z5lU/VcEzvPGLfW8boOAXtCaQlKXyA5k=";
-          };
-          "26.2-snapshot-6-fabric" = {
-            url = "https://meta.fabricmc.net/v2/versions/loader/26.2-snapshot-6/0.19.2/1.1.1/server/jar";
-            hash = "sha256-J4zGg7YlrHmYBsagTr+x2ZcAgOvj5vr/8iVgwMVG/e0=";
-          };
-          "26.1.2-fabric" = {
-            url = "https://meta.fabricmc.net/v2/versions/loader/26.1.2/0.19.2/1.1.1/server/jar";
-            hash = "sha256-6RvRm5/w4ExXhD5iTS9U0KPjmgSMr8pejiDrmENEXb0=";
-          };
-          "1.21.11-fabric" = {
-            url = "https://meta.fabricmc.net/v2/versions/loader/1.21.11/0.19.2/1.1.1/server/jar";
-            hash = "sha256-xDK1HU7Xwbr0Z7pw7Dtdtob0zvlfq9pZ9J4O32u4jBc=";
-          };
-        }
-        // {
-          "1.21.11-paper" = paperServers."1.21.11".src;
-          "26.1.2-paper" = paperServers."26.1.2".src;
-        };
-      plugins.plugmanx = mkArtifact {
-        url = "https://cdn.modrinth.com/data/yro4niHu/versions/hrMAp7Ww/PlugManX-3.0.4.jar";
-        hash = "sha256-LLb7Ddfm9YZ7ypv6PwN1HW2J1rlJ6LbTdAUHtVrmqcA=";
-      };
-      geyser.velocity = mkArtifact {
-        url = "https://download.geysermc.org/v2/projects/geyser/versions/2.10.0/builds/1149/downloads/velocity";
-        hash = "sha256-usLTnnEXiiFlXPdmj/tvwzY7QbBNeogK8ex4jNTs1e4=";
-      };
-      floodgate.velocity = mkArtifact {
-        url = "https://download.geysermc.org/v2/projects/floodgate/versions/2.2.5/builds/132/downloads/velocity";
-        hash = "sha256-8liZUEOkhpy28e9gURCsHZBmpbHhsxZJWiWwavoMEGA=";
+      # Velocity plugins are cross-Minecraft-version: `velocityPluginCatalog`
+      # is the unversioned default surfaced to modules. Per-version overrides
+      # can still come from `velocityPluginCatalogs.<version>` if added.
+      velocityPluginCatalog = velocityPluginCatalogs.common or { };
+      servers = fabricServers // {
+        "1.21.11-paper" = paperServers."1.21.11".src;
+        "26.1.2-paper" = paperServers."26.1.2".src;
       };
     };
   };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -621,6 +621,14 @@ let
     that takes a fleet spec and produces the plan/commands tooling consumes.
     `mkFleet` is the default-system shortcut.
   */
+  # Shared NixOS bootstrap image used to materialize missing fleet nodes.
+  # Reads the canonical name/tag from the image module so the fleet default
+  # and the image being published can't drift.
+  bootstrapImage =
+    (evalImageConfig {
+      modules = [ (paths.images + "/system/test-cluster-bootstrap") ];
+    }).ix.image;
+
   mkFleetFor =
     hostSystem:
     let
@@ -631,6 +639,7 @@ let
         lib
         evalImageConfig
         writeNushellApplication
+        bootstrapImage
         ;
       pkgs = hostPkgs;
       ixFleet = (packageSetFor hostPkgs).ix-fleet;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,7 +4,6 @@
   nixpkgs,
   paths,
   rust-overlay,
-  cliArtifacts ? { },
 }:
 let
   inherit (nixpkgs) lib;
@@ -514,49 +513,43 @@ let
   packageSetFor =
     pkgs:
     let
-      packageSystem = pkgs.stdenv.hostPlatform.system;
       ixForPackages = ixSpecialArgs // {
         inherit pkgs;
       };
-      basePackages = {
-        hyperion = (pkgsWithRustOverlayFor pkgs).callPackage paths.packages.hyperion {
-          ix = ixForPackages;
-        };
-        ix-fleet = pkgs.callPackage paths.packages.ixFleet {
-          ix = ixForPackages;
-        };
-        minestom.helloServerJar = pkgs.callPackage paths.packages.minestom.servers.hello {
-          ix = ixForPackages;
-        };
-        minecraft-nbt = pkgs.callPackage paths.packages.minecraftNbt {
-          inherit pkgs;
-          ix = ixForPackages;
-        };
-        llm-clippy = llmClippyFor pkgs;
-        minecraft-sync-managed = pkgs.callPackage paths.packages.minecraftSyncManaged {
-          inherit pkgs;
-          ix = ixForPackages;
-        };
-        nix-cargo-unit = pkgs.callPackage paths.packages.nixCargoUnit {
-          inherit pkgs;
-          ix = ixForPackages;
-        };
-        oci-image-builder = pkgs.callPackage paths.packages.ociImageBuilder {
-          inherit pkgs;
-          ix = ixForPackages;
-        };
-        python-mcp-server = pkgs.callPackage paths.packages.pythonMcpServer {
-          ix = ixForPackages;
-        };
-        tonbo-artifacts = pkgs.callPackage paths.packages.tonboArtifacts { };
-      };
-      cliPackages = lib.optionalAttrs (builtins.hasAttr packageSystem cliArtifacts) {
-        ix = pkgs.callPackage paths.packages.ix {
-          src = cliArtifacts.${packageSystem};
-        };
-      };
     in
-    basePackages // cliPackages;
+    {
+      hyperion = (pkgsWithRustOverlayFor pkgs).callPackage paths.packages.hyperion {
+        ix = ixForPackages;
+      };
+      ix-fleet = pkgs.callPackage paths.packages.ixFleet {
+        ix = ixForPackages;
+      };
+      minestom.helloServerJar = pkgs.callPackage paths.packages.minestom.servers.hello {
+        ix = ixForPackages;
+      };
+      minecraft-nbt = pkgs.callPackage paths.packages.minecraftNbt {
+        inherit pkgs;
+        ix = ixForPackages;
+      };
+      llm-clippy = llmClippyFor pkgs;
+      minecraft-sync-managed = pkgs.callPackage paths.packages.minecraftSyncManaged {
+        inherit pkgs;
+        ix = ixForPackages;
+      };
+      nix-cargo-unit = pkgs.callPackage paths.packages.nixCargoUnit {
+        inherit pkgs;
+        ix = ixForPackages;
+      };
+      oci-image-builder = pkgs.callPackage paths.packages.ociImageBuilder {
+        inherit pkgs;
+        ix = ixForPackages;
+      };
+      python-mcp-server = pkgs.callPackage paths.packages.pythonMcpServer {
+        ix = ixForPackages;
+      };
+      tonbo-artifacts = pkgs.callPackage paths.packages.tonboArtifacts { };
+      ix = pkgs.callPackage paths.packages.ix { };
+    };
 
   /**
     Cross-cutting helpers handed to every module through `specialArgs.ix`.

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -228,6 +228,7 @@ let
       inherit lib pkgs;
       clippyPackage = llmClippyFor pkgs;
       rustToolchain = rustNightlyToolchainFor pkgs;
+      writePythonApplication = writePythonApplication pkgs;
     };
   cargoUnitFor =
     pkgs:
@@ -452,6 +453,18 @@ let
   modCatalogs = generatedCatalogs paths.minecraftMods;
   paperPluginCatalogs = generatedCatalogs paths.minecraftPaperPlugins;
 
+  # Minecraft version of the default variant declared in
+  # `images/games/minecraft/versions.nix`. Lets per-loader fallback catalogs
+  # follow the image default instead of pinning a literal version that silently
+  # rots once the default moves.
+  defaultMinecraftVersion =
+    let
+      versionsModule = import (paths.images + "/games/minecraft/versions.nix") {
+        inherit lib;
+      };
+    in
+    versionsModule.${versionsModule.default}.services.minecraft.version;
+
   /**
     Pinned artifact catalogs surfaced to images and presets by name.
     Presets must consume entries through this set (or one of the module
@@ -462,7 +475,11 @@ let
     minecraft = {
       inherit paperServers modCatalogs paperPluginCatalogs;
       inherit velocityServers;
-      paperPluginCatalog = paperPluginCatalogs."26.1.2";
+      paperPluginCatalog =
+        if builtins.hasAttr defaultMinecraftVersion paperPluginCatalogs then
+          paperPluginCatalogs.${defaultMinecraftVersion}
+        else
+          throw "ix.lib.artifacts.minecraft.paperPluginCatalog: no Paper plugin catalog generated for Minecraft ${defaultMinecraftVersion} (the default in images/games/minecraft/versions.nix). Run `nix run .#update-mods -- --manifest images/games/minecraft/plugins/paper/manifest.json --version ${defaultMinecraftVersion}` and commit the result.";
       servers =
         lib.mapAttrs (_: mkArtifact) {
           "26.2-snapshot-5-fabric" = {

--- a/lib/fleet.nix
+++ b/lib/fleet.nix
@@ -13,6 +13,7 @@
   evalImageConfig,
   ixFleet,
   writeNushellApplication,
+  bootstrapImage,
 }:
 {
   defaults ? [ ],
@@ -33,7 +34,7 @@ let
       [ ];
 
   deploymentDefaults = {
-    bootstrapImage = "registry.ix.dev/ix/test-cluster-bootstrap:zstd-tools-2026-05-12";
+    bootstrapImage = "registry.ix.dev/${bootstrapImage.name}:${bootstrapImage.tag}";
     region = "hil-1";
     ipv4 = false;
     snapshot = true;

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -152,47 +152,17 @@ in
   };
 
   checks =
-    lib.optionalAttrs (system == ix.system) (
-      let
-        # Serialize assertion groups to a self-contained nix-unit test file.
-        # Each assertion boolean is already evaluated at flake eval time; we
-        # bake them in as literals so nix-unit can report individual failures
-        # by name without needing nixos eval inside the sandbox.
-        nixUnitFile =
-          let
-            serializeGroup =
-              groupName: assertions:
-              lib.concatMapStrings (
-                a:
-                let
-                  n = builtins.toJSON "${groupName}: ${a.message}";
-                in
-                "  ${n} = { expr = ${if a.assertion then "true" else "false"}; expected = true; };\n"
-              ) assertions;
-          in
-          pkgs.writeText "ix-unit-tests.nix" (
-            "{\n"
-            + lib.concatStrings (lib.mapAttrsToList serializeGroup tests.groups)
-            + serializeGroup "cargo-unit-real-workspaces" tests.cargoUnitRealWorkspaceAssertions
-            + "}\n"
-          );
-      in
-      {
-        inherit (tests) eval;
-        cargo-unit-real-workspaces = tests.cargoUnitRealWorkspaces;
-        nix-unit = pkgs.runCommand "ix-nix-unit" { nativeBuildInputs = [ pkgs.nix-unit ]; } ''
-          nix-unit ${nixUnitFile}
-          mkdir "$out"
-        '';
-        lint = pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ pkgs.coreutils ]; } ''
-          cp -R ${lintSource} source
-          chmod -R u+w source
-          cd source
-          ${lib.getExe lint}
-          mkdir -p "$out"
-        '';
-      }
-    )
+    lib.optionalAttrs (system == ix.system) {
+      inherit (tests) eval;
+      cargo-unit-real-workspaces = tests.cargoUnitRealWorkspaces;
+      lint = pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ pkgs.coreutils ]; } ''
+        cp -R ${lintSource} source
+        chmod -R u+w source
+        cd source
+        ${lib.getExe lint}
+        mkdir -p "$out"
+      '';
+    }
     // lib.optionalAttrs (system == ix.system) rustPackageTests;
 
   formatter = pkgs.nixfmt;

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -152,17 +152,47 @@ in
   };
 
   checks =
-    lib.optionalAttrs (system == ix.system) {
-      inherit (tests) eval;
-      cargo-unit-real-workspaces = tests.cargoUnitRealWorkspaces;
-      lint = pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ pkgs.coreutils ]; } ''
-        cp -R ${lintSource} source
-        chmod -R u+w source
-        cd source
-        ${lib.getExe lint}
-        mkdir -p "$out"
-      '';
-    }
+    lib.optionalAttrs (system == ix.system) (
+      let
+        # Serialize assertion groups to a self-contained nix-unit test file.
+        # Each assertion boolean is already evaluated at flake eval time; we
+        # bake them in as literals so nix-unit can report individual failures
+        # by name without needing nixos eval inside the sandbox.
+        nixUnitFile =
+          let
+            serializeGroup =
+              groupName: assertions:
+              lib.concatMapStrings (
+                a:
+                let
+                  n = builtins.toJSON "${groupName}: ${a.message}";
+                in
+                "  ${n} = { expr = ${if a.assertion then "true" else "false"}; expected = true; };\n"
+              ) assertions;
+          in
+          pkgs.writeText "ix-unit-tests.nix" (
+            "{\n"
+            + lib.concatStrings (lib.mapAttrsToList serializeGroup tests.groups)
+            + serializeGroup "cargo-unit-real-workspaces" tests.cargoUnitRealWorkspaceAssertions
+            + "}\n"
+          );
+      in
+      {
+        inherit (tests) eval;
+        cargo-unit-real-workspaces = tests.cargoUnitRealWorkspaces;
+        nix-unit = pkgs.runCommand "ix-nix-unit" { nativeBuildInputs = [ pkgs.nix-unit ]; } ''
+          nix-unit ${nixUnitFile}
+          mkdir "$out"
+        '';
+        lint = pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ pkgs.coreutils ]; } ''
+          cp -R ${lintSource} source
+          chmod -R u+w source
+          cd source
+          ${lib.getExe lint}
+          mkdir -p "$out"
+        '';
+      }
+    )
     // lib.optionalAttrs (system == ix.system) rustPackageTests;
 
   formatter = pkgs.nixfmt;

--- a/lib/rust-replace-workspace-values.py
+++ b/lib/rust-replace-workspace-values.py
@@ -1,0 +1,155 @@
+# Vendored from nixpkgs `pkgs/build-support/rust/replace-workspace-values.py`.
+# Walked into the cargo-unit pipeline so a vendored crate that uses workspace
+# inheritance can be reduced to a flat Cargo.toml before rustc sees it.
+#
+# Implements the workspace inheritance mechanism described at
+# https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table
+
+import sys
+from typing import Any
+
+import tomli
+import tomli_w
+
+
+def load_file(path: str) -> dict[str, Any]:
+    with open(path, "rb") as f:
+        return tomli.load(f)
+
+
+# Replicates the dependency merging logic from Cargo. See
+# `inner_dependency_inherit_with`:
+# https://github.com/rust-lang/cargo/blob/4de0094ac78743d2c8ff682489e35c8a7cafe8e4/src/cargo/util/toml/mod.rs#L982
+def replace_key(
+    workspace_manifest: dict[str, Any], table: dict[str, Any], section: str, key: str
+) -> bool:
+    if (
+        isinstance(table[key], dict)
+        and "workspace" in table[key]
+        and table[key]["workspace"] is True
+    ):
+        print("replacing " + key)
+
+        local_dep = table[key]
+        del local_dep["workspace"]
+
+        try:
+            workspace_dep = workspace_manifest[section][key]
+        except KeyError:
+            # Key is not present in workspace manifest, we can't inherit the
+            # value, so we mark it for deletion.
+            table[key] = {}
+            return True
+
+        if section == "dependencies":
+            if isinstance(workspace_dep, str):
+                workspace_dep = {"version": workspace_dep}
+
+            final: dict[str, Any] = workspace_dep.copy()
+
+            merged_features = local_dep.pop("features", []) + workspace_dep.get(
+                "features", []
+            )
+            if merged_features:
+                final["features"] = merged_features
+
+            local_default_features = local_dep.pop(
+                "default-features", local_dep.pop("default_features", None)
+            )
+            workspace_default_features = workspace_dep.get(
+                "default-features", workspace_dep.get("default_features")
+            )
+
+            if not workspace_default_features and local_default_features:
+                final["default-features"] = True
+
+            optional = local_dep.pop("optional", False)
+            if optional:
+                final["optional"] = True
+
+            if "package" in local_dep:
+                final["package"] = local_dep.pop("package")
+
+            if local_dep:
+                raise Exception(
+                    f"Unhandled keys in inherited dependency {key}: {local_dep}"
+                )
+
+            table[key] = final
+        elif section == "package":
+            table[key] = workspace_dep
+
+        return True
+
+    return False
+
+
+def replace_dependencies(
+    workspace_manifest: dict[str, Any], root: dict[str, Any]
+) -> bool:
+    changed = False
+
+    for key in ["dependencies", "dev-dependencies", "build-dependencies"]:
+        if key in root:
+            for k in root[key].keys():
+                changed |= replace_key(workspace_manifest, root[key], "dependencies", k)
+
+    return changed
+
+
+def main() -> None:
+    top_cargo_toml = load_file(sys.argv[2])
+
+    if "workspace" not in top_cargo_toml:
+        # If top_cargo_toml is not a workspace manifest, then this script was
+        # probably ran on something that does not actually use workspace
+        # dependencies.
+        print(f"{sys.argv[2]} is not a workspace manifest, doing nothing.")
+        return
+
+    crate_manifest = load_file(sys.argv[1])
+    workspace_manifest = top_cargo_toml["workspace"]
+
+    if "workspace" in crate_manifest:
+        return
+
+    changed = False
+
+    to_remove: list[str] = []
+    for key in crate_manifest["package"].keys():
+        changed_key = replace_key(
+            workspace_manifest, crate_manifest["package"], "package", key
+        )
+        if changed_key and crate_manifest["package"][key] == {}:
+            # Key is missing from workspace manifest, mark for deletion.
+            to_remove.append(key)
+        changed |= changed_key
+    # Remove keys which have no value.
+    for key in to_remove:
+        del crate_manifest["package"][key]
+
+    changed |= replace_dependencies(workspace_manifest, crate_manifest)
+
+    if "target" in crate_manifest:
+        for key in crate_manifest["target"].keys():
+            changed |= replace_dependencies(
+                workspace_manifest, crate_manifest["target"][key]
+            )
+
+    if (
+        "lints" in crate_manifest
+        and "workspace" in crate_manifest["lints"]
+        and crate_manifest["lints"]["workspace"] is True
+    ):
+        crate_manifest["lints"] = workspace_manifest["lints"]
+        changed = True
+
+    if not changed:
+        return
+
+    with open(sys.argv[1], "wb") as f:
+        tomli_w.dump(crate_manifest, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/rust.nix
+++ b/lib/rust.nix
@@ -9,6 +9,7 @@
       pkgs.rustc
     ];
   },
+  writePythonApplication,
 }:
 let
   defaultClippyDeniedLints = [
@@ -279,18 +280,22 @@ let
         sha = builtins.elemAt parts 4;
       };
 
-  replaceWorkspaceValues = pkgs.writers.writePython3 "replace-workspace-values" {
-    libraries = builtins.attrValues {
-      inherit (pkgs.python3Packages)
-        tomli
-        tomli-w
-        ;
-    };
-    flakeIgnore = [
-      "E501"
-      "W503"
-    ];
-  } (builtins.readFile (pkgs.path + "/pkgs/build-support/rust/replace-workspace-values.py"));
+  # Flatten workspace inheritance in a vendored Cargo.toml before rustc sees it.
+  # Vendored from nixpkgs so a downstream rename of
+  # `pkgs/build-support/rust/replace-workspace-values.py` doesn't surface as a
+  # `readFile` error here; `ix.writePythonApplication` also runs basedpyright on
+  # the body at build time, which the upstream `pkgs.writers.writePython3` path
+  # did not.
+  replaceWorkspaceValues = writePythonApplication {
+    name = "replace-workspace-values";
+    src = ./rust-replace-workspace-values.py;
+    python = pkgs.python314.withPackages (
+      ps:
+      builtins.attrValues {
+        inherit (ps) tomli tomli-w;
+      }
+    );
+  };
 
   resolveVendorSources =
     {

--- a/lib/rust.nix
+++ b/lib/rust.nix
@@ -370,7 +370,7 @@ let
               chmod -R u+w "$out"
 
               if grep -q workspace "$out/Cargo.toml"; then
-                ${replaceWorkspaceValues} "$out/Cargo.toml" "$(cargo metadata --format-version 1 --no-deps --manifest-path "$crateCargoTOML" | jq -r .workspace_root)/Cargo.toml"
+                ${lib.getExe replaceWorkspaceValues} "$out/Cargo.toml" "$(cargo metadata --format-version 1 --no-deps --manifest-path "$crateCargoTOML" | jq -r .workspace_root)/Cargo.toml"
               fi
 
               printf '{"files":{},"package":null}' > "$out/.cargo-checksum.json"

--- a/lib/systemd-hardening.nix
+++ b/lib/systemd-hardening.nix
@@ -3,13 +3,20 @@
 
   Restricts capabilities, devices, kernel surfaces, and namespaces.
   Address families stay open enough to accept inbound TCP/UDP and
-  AF_UNIX. Merge into `serviceConfig` and override individual fields per
+  AF_UNIX. `ProtectSystem = "strict"` makes the entire filesystem
+  read-only outside of the API filesystems and any state directory the
+  service declares (`StateDirectory`, `LogsDirectory`,
+  `CacheDirectory`, `RuntimeDirectory`); every service using this
+  baseline must declare a `StateDirectory` if it writes to `/var`.
+
+  Merge into `serviceConfig` and override individual fields per
   service as needed.
 */
 {
   CapabilityBoundingSet = [ "" ];
   DeviceAllow = [ "" ];
   LockPersonality = true;
+  NoNewPrivileges = true;
   PrivateDevices = true;
   PrivateTmp = true;
   PrivateUsers = true;
@@ -21,6 +28,7 @@
   ProtectKernelModules = true;
   ProtectKernelTunables = true;
   ProtectProc = "invisible";
+  ProtectSystem = "strict";
   RestrictAddressFamilies = [
     "AF_INET"
     "AF_INET6"

--- a/modules/profiles/base.nix
+++ b/modules/profiles/base.nix
@@ -89,6 +89,12 @@ in
           btop
           file
           gdb
+          # gnutar, gzip, and zstd ride along so any VM switched once stays
+          # switchable: `ix switch --source` streams a tarball through
+          # `tar -x -I zstd` inside the guest, and these binaries are not
+          # on NixOS' default system PATH.
+          gnutar
+          gzip
           jq
           lldb
           lsof
@@ -96,6 +102,7 @@ in
           pv
           strace
           tcpdump
+          zstd
           ;
       }
       ++ lib.optionals shellWorkspace.enable [

--- a/modules/services/floodgate.nix
+++ b/modules/services/floodgate.nix
@@ -66,8 +66,8 @@ in
 
     package = mkOption {
       type = types.package;
-      default = ix.artifacts.minecraft.floodgate.velocity;
-      defaultText = lib.literalExpression "ix.artifacts.minecraft.floodgate.velocity";
+      default = ix.artifacts.minecraft.velocityPluginCatalog.floodgate-velocity.src;
+      defaultText = lib.literalExpression "ix.artifacts.minecraft.velocityPluginCatalog.floodgate-velocity.src";
       description = "Floodgate Velocity plugin jar.";
     };
 

--- a/modules/services/geyser.nix
+++ b/modules/services/geyser.nix
@@ -85,8 +85,8 @@ in
 
     package = mkOption {
       type = types.package;
-      default = ix.artifacts.minecraft.geyser.velocity;
-      defaultText = lib.literalExpression "ix.artifacts.minecraft.geyser.velocity";
+      default = ix.artifacts.minecraft.velocityPluginCatalog.geyser-velocity.src;
+      defaultText = lib.literalExpression "ix.artifacts.minecraft.velocityPluginCatalog.geyser-velocity.src";
       description = "Geyser Velocity plugin jar.";
     };
 

--- a/modules/services/minecraft-bedrock.nix
+++ b/modules/services/minecraft-bedrock.nix
@@ -122,6 +122,12 @@ in
       description = "IPv6 UDP port for Bedrock clients.";
     };
 
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether to open the Bedrock IPv4 and IPv6 UDP ports in the firewall.";
+    };
+
     settings = mkOption {
       inherit (propertiesFormat) type;
       default = { };
@@ -164,7 +170,7 @@ in
       enable-lan-visibility = lib.mkDefault false;
     };
 
-    networking.firewall.allowedUDPPorts = [
+    networking.firewall.allowedUDPPorts = lib.optionals cfg.openFirewall [
       cfg.port
       cfg.portv6
     ];

--- a/modules/services/minecraft/default.nix
+++ b/modules/services/minecraft/default.nix
@@ -400,7 +400,7 @@ let
     ++ lib.optionals plugmanReloadEnabled [
       {
         name = "PlugManX.jar";
-        path = ix.artifacts.minecraft.plugins.plugmanx;
+        path = ix.artifacts.minecraft.paperPluginCatalog.plugmanx.src;
         pluginName = "PlugManX";
       }
     ];

--- a/modules/services/minecraft/paper.nix
+++ b/modules/services/minecraft/paper.nix
@@ -16,12 +16,30 @@ ix.mkMinecraftLoader {
     let
       cfg = config.services.minecraft;
       versionCatalogs = ix.artifacts.minecraft.paperPluginCatalogs;
+      velocityCfg = config.services.velocity;
+      # Paper behind Velocity needs paper-global.yml proxies.velocity to
+      # mirror the shared forwarding secret. Default the Paper-side block
+      # from `services.velocity.forwarding.secret` so a preset writes the
+      # secret once. `forwarding.secretFile` runtime secrets cannot be
+      # propagated at eval time, so callers using them still set the
+      # paper-global block themselves.
+      hasVelocityForwarding = velocityCfg.enable && velocityCfg.forwarding.secret != null;
     in
     {
-      services.minecraft.pluginCatalog =
-        if cfg.version != null && builtins.hasAttr cfg.version versionCatalogs then
-          versionCatalogs.${cfg.version}
-        else
-          ix.artifacts.minecraft.paperPluginCatalog;
+      services.minecraft = {
+        pluginCatalog =
+          if cfg.version != null && builtins.hasAttr cfg.version versionCatalogs then
+            versionCatalogs.${cfg.version}
+          else
+            ix.artifacts.minecraft.paperPluginCatalog;
+
+        configFiles = lib.optionalAttrs hasVelocityForwarding {
+          "paper-global.yml".proxies.velocity = {
+            enabled = lib.mkDefault true;
+            secret = lib.mkDefault velocityCfg.forwarding.secret;
+            online-mode = lib.mkDefault true;
+          };
+        };
+      };
     };
 }

--- a/modules/services/minestom.nix
+++ b/modules/services/minestom.nix
@@ -59,6 +59,12 @@ in
       type = types.port;
       default = 25565;
     };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether to open the Minestom client port in the firewall.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -68,7 +74,7 @@ in
       description = "Minestom server";
     };
 
-    networking.firewall.allowedTCPPorts = [ cfg.port ];
+    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [ cfg.port ];
 
     systemd.services.minestom = {
       description = "Minestom server";

--- a/modules/services/postgresql.nix
+++ b/modules/services/postgresql.nix
@@ -25,6 +25,12 @@ in
       default = 5432;
     };
 
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether to open the PostgreSQL port in the firewall.";
+    };
+
     dataDir = mkOption {
       type = types.str;
       default = "/var/lib/postgresql/18";
@@ -50,7 +56,7 @@ in
       description = "PostgreSQL";
     };
 
-    networking.firewall.allowedTCPPorts = [ cfg.port ];
+    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [ cfg.port ];
 
     # `services.postgresql.settings.huge_pages = "on"` (below) makes
     # postmaster refuse to start without a sufficient pool of 2 MiB

--- a/modules/services/resource-monitor/default.nix
+++ b/modules/services/resource-monitor/default.nix
@@ -18,15 +18,17 @@ let
 
   siteSrc = fs.toSource {
     root = ./site;
-    fileset = fs.intersection (fs.gitTracked ./.) (fs.unions [
-      ./site/index.html
-      ./site/package.json
-      ./site/package-lock.json
-      ./site/eslint.config.js
-      ./site/tsconfig.json
-      ./site/src
-      ./site/vite.config.js
-    ]);
+    fileset = fs.intersection (fs.gitTracked ./.) (
+      fs.unions [
+        ./site/index.html
+        ./site/package.json
+        ./site/package-lock.json
+        ./site/eslint.config.js
+        ./site/tsconfig.json
+        ./site/src
+        ./site/vite.config.js
+      ]
+    );
   };
 
   vmConfig = {

--- a/modules/services/resource-monitor/default.nix
+++ b/modules/services/resource-monitor/default.nix
@@ -18,7 +18,7 @@ let
 
   siteSrc = fs.toSource {
     root = ./site;
-    fileset = fs.unions [
+    fileset = fs.intersection (fs.gitTracked ./.) (fs.unions [
       ./site/index.html
       ./site/package.json
       ./site/package-lock.json
@@ -26,7 +26,7 @@ let
       ./site/tsconfig.json
       ./site/src
       ./site/vite.config.js
-    ];
+    ]);
   };
 
   vmConfig = {

--- a/packages/ix/default.nix
+++ b/packages/ix/default.nix
@@ -1,14 +1,31 @@
 {
-  lib,
   stdenvNoCC,
-  src,
+  fetchurl,
 }:
 
+let
+  sources = {
+    x86_64-linux = fetchurl {
+      url = "https://ix.dev/cli/linux-x86_64/ix";
+      hash = "sha256-eXdV+aSEQNIssqfRywiIOk+979WkOLJapa7C2D7C6Ts=";
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://ix.dev/cli/darwin-arm64/ix";
+      hash = "sha256-b6wwHtikhMYl/FfpmepU3ONOR+Wtcm5HE5zQIK7qC6M=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://ix.dev/cli/darwin-x86_64/ix";
+      hash = "sha256-LATWkElzdoSxO95f3n1hOwauMBuLkLSsyIDdccbmhJ4=";
+    };
+  };
+
+  inherit (stdenvNoCC.hostPlatform) system;
+in
 stdenvNoCC.mkDerivation {
   pname = "ix";
   version = "precompiled";
 
-  inherit src;
+  src = sources.${system} or (throw "ix CLI: no precompiled binary for ${system}");
 
   dontUnpack = true;
   dontBuild = true;
@@ -25,10 +42,6 @@ stdenvNoCC.mkDerivation {
   meta = {
     description = "ix deployment platform CLI";
     mainProgram = "ix";
-    platforms = [
-      "x86_64-linux"
-      "aarch64-darwin"
-      "x86_64-darwin"
-    ];
+    platforms = builtins.attrNames sources;
   };
 }

--- a/packages/oci-image-builder/src/main.rs
+++ b/packages/oci-image-builder/src/main.rs
@@ -6,10 +6,9 @@ use std::collections::{btree_map::Entry, BTreeMap};
 use std::env;
 use std::error::Error;
 use std::fs::{self, File};
-use std::io::{Read, Write};
-use std::os::unix::fs::symlink;
+use std::io::{self, Write};
+use std::os::unix::fs::{symlink, PermissionsExt};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 use tempfile::tempdir;
 
 const DEFAULT_MIN_EFFICIENCY: f64 = 0.95;
@@ -642,32 +641,25 @@ fn write_metadata(
         serde_json::to_vec_pretty(&index)?,
     )?;
 
-    let outer_files = image_dir.join("../outer-files");
-    let mut entries = vec!["oci-layout".to_owned(), "index.json".to_owned()];
-    let mut blobs = fs::read_dir(image_dir.join("blobs/sha256"))?
-        .map(|entry| {
-            entry.map(|entry| format!("blobs/sha256/{}", entry.file_name().to_string_lossy()))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    blobs.sort();
-    entries.extend(blobs);
-    fs::write(&outer_files, entries.join("\n"))?;
+    let mtime_secs: u64 = mtime.parse()?;
+    let mut entries: Vec<String> = vec!["oci-layout".to_owned(), "index.json".to_owned()];
+    for entry in fs::read_dir(image_dir.join("blobs/sha256"))? {
+        let entry = entry?;
+        entries.push(format!(
+            "blobs/sha256/{}",
+            entry.file_name().to_string_lossy()
+        ));
+    }
+    entries.sort();
 
-    run(Command::new("tar")
-        .arg("--create")
-        .arg("--file")
-        .arg(out_path)
-        .arg("--no-recursion")
-        .arg("--hard-dereference")
-        .arg("--sort=name")
-        .arg(format!("--mtime=@{mtime}"))
-        .arg("--owner=0")
-        .arg("--group=0")
-        .arg("--numeric-owner")
-        .arg("--directory")
-        .arg(image_dir)
-        .arg("--files-from")
-        .arg(outer_files))?;
+    let out = File::create(out_path)?;
+    let mut builder = tar::Builder::new(out);
+    builder.follow_symlinks(false);
+    for name in &entries {
+        let source = image_dir.join(name);
+        append_normalized_entry(&mut builder, &source, name, mtime_secs, 0, 0)?;
+    }
+    builder.finish()?;
 
     Ok(())
 }
@@ -678,60 +670,140 @@ fn write_tar_layer(
     conf: &Config,
     mtime: &str,
 ) -> Result<(String, u64), Box<dyn Error>> {
-    let mut child = Command::new("tar")
-        .arg("--create")
-        .arg("--file")
-        .arg("-")
-        .arg("--absolute-names")
-        .arg("--sort=name")
-        .arg(format!("--mtime=@{mtime}"))
-        .arg(format!("--owner={}", conf.uid))
-        .arg(format!("--group={}", conf.gid))
-        .arg("--numeric-owner")
-        .arg("--no-recursion")
-        .arg("/nix")
-        .arg("/nix/store")
-        .arg("--recursion")
-        .arg("--hard-dereference")
-        .arg("--files-from")
-        .arg(paths_file)
-        .stdout(Stdio::piped())
-        .spawn()?;
+    let mtime_secs: u64 = mtime.parse()?;
+    let uid: u64 = conf.uid.parse()?;
+    let gid: u64 = conf.gid.parse()?;
 
-    let mut stdout = child.stdout.take().ok_or("failed to capture tar stdout")?;
-    let mut layer = File::create(layer_path)?;
-    let mut hasher = Sha256::new();
-    let mut size = 0;
-    let mut buf = vec![0; 1024 * 1024];
-
-    loop {
-        let read = stdout.read(&mut buf)?;
-        if read == 0 {
-            break;
+    let mut paths: Vec<PathBuf> = vec![PathBuf::from("/nix"), PathBuf::from("/nix/store")];
+    let paths_text = fs::read_to_string(paths_file)?;
+    for line in paths_text.lines() {
+        if line.is_empty() {
+            continue;
         }
-        size += read as u64;
-        hasher.update(&buf[..read]);
-        layer.write_all(&buf[..read])?;
+        collect_paths_recursive(Path::new(line), &mut paths)?;
+    }
+    // Matches GNU tar `--sort=name`: every entry, including the explicit
+    // /nix and /nix/store roots, ends up in lexical order in the archive.
+    paths.sort();
+    paths.dedup();
+
+    let layer = File::create(layer_path)?;
+    let writer = HashingWriter::new(layer);
+    let mut builder = tar::Builder::new(writer);
+    builder.follow_symlinks(false);
+
+    for path in &paths {
+        let archive_name = path.to_string_lossy().into_owned();
+        append_normalized_entry(&mut builder, path, &archive_name, mtime_secs, uid, gid)?;
     }
 
-    let status = child.wait()?;
-    if !status.success() {
-        return Err(format!("command failed with {status}: tar layer stream").into());
+    let writer = builder.into_inner()?;
+    let (size, hash) = writer.finalize();
+    Ok((hash, size))
+}
+
+fn collect_paths_recursive(root: &Path, out: &mut Vec<PathBuf>) -> Result<(), Box<dyn Error>> {
+    out.push(root.to_path_buf());
+    let metadata = fs::symlink_metadata(root)?;
+    let file_type = metadata.file_type();
+    if !file_type.is_dir() || file_type.is_symlink() {
+        return Ok(());
+    }
+    let mut children: Vec<PathBuf> = fs::read_dir(root)?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<Result<Vec<_>, _>>()?;
+    children.sort();
+    for child in children {
+        collect_paths_recursive(&child, out)?;
+    }
+    Ok(())
+}
+
+fn append_normalized_entry<W: Write>(
+    builder: &mut tar::Builder<W>,
+    source: &Path,
+    archive_name: &str,
+    mtime: u64,
+    uid: u64,
+    gid: u64,
+) -> Result<(), Box<dyn Error>> {
+    let metadata = fs::symlink_metadata(source)?;
+    let file_type = metadata.file_type();
+    let mode = metadata.permissions().mode() & 0o7777;
+
+    let mut header = tar::Header::new_gnu();
+    header.set_mtime(mtime);
+    header.set_uid(uid);
+    header.set_gid(gid);
+    header.set_username("")?;
+    header.set_groupname("")?;
+    header.set_mode(mode);
+
+    if file_type.is_symlink() {
+        let link_target = fs::read_link(source)?;
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_size(0);
+        header.set_link_name(&link_target)?;
+        builder.append_data(&mut header, archive_name, io::empty())?;
+    } else if file_type.is_dir() {
+        header.set_entry_type(tar::EntryType::Directory);
+        header.set_size(0);
+        builder.append_data(&mut header, archive_name, io::empty())?;
+    } else if file_type.is_file() {
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_size(metadata.len());
+        // `--hard-dereference` is automatic here: every visit re-reads the
+        // file content rather than emitting a hardlink reference, matching
+        // the GNU tar flag the old shell-out used.
+        let file = File::open(source)?;
+        builder.append_data(&mut header, archive_name, file)?;
+    } else {
+        return Err(format!(
+            "oci-image-builder: unsupported file type at {}",
+            source.display()
+        )
+        .into());
     }
 
-    Ok((format!("{:x}", hasher.finalize()), size))
+    Ok(())
+}
+
+struct HashingWriter<W: Write> {
+    inner: W,
+    hasher: Sha256,
+    size: u64,
+}
+
+impl<W: Write> HashingWriter<W> {
+    fn new(inner: W) -> Self {
+        Self {
+            inner,
+            hasher: Sha256::new(),
+            size: 0,
+        }
+    }
+
+    fn finalize(self) -> (u64, String) {
+        let hash = format!("{:x}", self.hasher.finalize());
+        (self.size, hash)
+    }
+}
+
+impl<W: Write> Write for HashingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let n = self.inner.write(buf)?;
+        self.hasher.update(&buf[..n]);
+        self.size += n as u64;
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
 }
 
 fn sha256_bytes(data: &[u8]) -> String {
     format!("{:x}", Sha256::digest(data))
-}
-
-fn run(command: &mut Command) -> Result<(), Box<dyn Error>> {
-    let status = command.status()?;
-    if !status.success() {
-        return Err(format!("command failed with {status}: {command:?}").into());
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1895,7 +1895,13 @@ let
       }
       {
         assertion =
-          fleetPlan.web.bootstrapImage == "registry.ix.dev/ix/test-cluster-bootstrap:zstd-tools-2026-05-12";
+          let
+            bootstrap =
+              (ix.evalImageConfig {
+                modules = [ ../images/system/test-cluster-bootstrap ];
+              }).ix.image;
+          in
+          fleetPlan.web.bootstrapImage == "registry.ix.dev/${bootstrap.name}:${bootstrap.tag}";
         message = "fleet switches should create missing nodes from the shared NixOS bootstrap image";
       }
       {
@@ -2178,7 +2184,7 @@ let
       cargoUnitRealWorkspaceScript;
 in
 {
-  inherit imageTests;
+  inherit imageTests groups cargoUnitRealWorkspaceAssertions;
   cargoUnitRealWorkspaces = cargoUnitRealWorkspacesTest;
 
   # Aggregate. Pulls every per-image test into one derivation so


### PR DESCRIPTION
## Summary

  A batch of follow-ups across systemd hardening, rust packaging, minecraft proxy plumbing, and CI:

  - **Strict systemd baseline.** `ix.systemdHardening` gains `NoNewPrivileges = true` and `ProtectSystem = "strict"`. All five consumers (`minecraft`, `velocity`, `minestom`, `minecraft-bedrock`, `hyperion`) already declare `StateDirectory`, so
   the strict mount is a no-op for them today and a real fence for any future service that tries to write outside its declared state. The doc-comment on `lib/systemd-hardening.nix` now records the `StateDirectory` requirement instead of leaving
   it implicit.

  - **Rust vendor pipeline off nixpkgs internals.** `replaceWorkspaceValues` was reaching into `pkgs/build-support/rust/replace-workspace-values.py` through `pkgs.path`, which would have surfaced as a confusing `readFile` error if upstream
  shuffled the file. It now lives at `lib/rust-replace-workspace-values.py` and runs through `ix.writePythonApplication`, which type-checks the body with basedpyright in `standard` mode. The follow-up commit invokes it through `lib.getExe`;
  `writePythonApplication` returns a wrapped package whose binary is at `$out/bin/replace-workspace-values`, and the bare interpolation was resolving to a directory and failing every git-source vendor build with `replace-workspace-values: Is a
  directory` (divan-macros, every `valence_*`, hyperion downstream).

  - **Paper inherits Velocity forwarding.** `services.minecraft.paper` reads `config.services.velocity.forwarding.secret` and defaults the `proxies.velocity` block of `paper-global.yml` from it, so the survival preset states the shared secret
  once instead of twice. Defaults are `mkDefault`, so manual `configFiles` overrides still win. `forwarding.secretFile` stays the caller's responsibility, because the eval-time default cannot see runtime file contents.

  - **Minecraft proxy artifacts out of `lib/`.** PlugManX joins the generated Paper plugin catalog under `images/games/minecraft/plugins/paper/`. Geyser-Velocity and Floodgate-Velocity get their own catalog at
  `images/games/minecraft/plugins/velocity/common.json`, consumed via `velocityPluginCatalog`. The four Fabric server jars share a single `fabricServerUrl` builder driven by `fabricLoaderVersion` and `fabricInstallerVersion`; bumping the Fabric
   toolchain is one edit.

  - **CI runs `nix flake check`.** GitHub Actions runs the same check that pre-commit does, on push and pull_request, so regressions like the bare-interpolation slip would have failed at the gate.

  Smaller touches:

  - `oci-image-builder` writes tar archives through the `tar` crate. Two writer surfaces collapse into one `tar::Builder` path with an `append_normalized_entry` helper that pins ownership and `mtime`. **Layer bytes change**, so pushed image
  digests will reassign on the next build; anyone pinning by digest needs to repin.
  - `services.minestom`, `services.ix-postgresql`, and `services.minecraft-bedrock` learn `cfg.openFirewall` (default `true`), matching `velocity`, `hyperion`, and `services.minecraft`. An image that fronts one of these with a gateway VM can
  now bind the backend to loopback without rewriting the rule.
  - `resource-monitor` filters its site source through `fs.intersection (fs.gitTracked ./.) ...`, so untracked files under `./site/src` stop forcing rebuilds and stop landing in the store.
  - The base profile ships `gnutar`, `gzip`, and `zstd`, so any VM that has been switched once can be switched again with `ix switch --source`.
  - The shared fleet bootstrap reference derives from the bootstrap image module (`registry.ix.dev/${name}:${tag}`) instead of a hard-coded tag string.
  - `packages/ix` fetches the ix CLI tarballs with `pkgs.fetchurl` at the package, so `flake.lock` stops churning on every CLI bump.

  ## Test plan

  - [x] `nix run .#lint`
  - [x] `nix flake check` evaluates every package
  - [x] `nix build .#oci-image-builder` (exercises the rust vendor pipeline and the new tar-crate writer)
  - [x] `nix build .#hyperion` (exercises every git-source crate that was previously failing with `Is a directory`)
  - [ ] Smoke-test the survival example: `ix up` against `examples/survival-server/` and confirm `paper-global.yml` inherits the Velocity secret without a second declaration
  - [ ] Re-push one image after merge and confirm the new digests resolve from a fresh pull

  Known limitation: `checks.x86_64-linux.eval` still has a single failing assertion (`remote-desktop should default to the nixpkgs Xpra package`). The same assertion fails on `a0f8bb7` (the commit before this batch), so it is pre-existing and
  tracked as a separate fix.
  
  @andrewgazelka 