### PR TITLE
feat(images): add development-base image (ENG-1379)

### DIFF
--- a/images/dev/development-base/default.nix
+++ b/images/dev/development-base/default.nix
@@ -1,0 +1,40 @@
+# Default ix dev base image: agent CLIs plus a normal build toolchain.
+# The auto-enabled base profile (modules/profiles/base.nix) supplies the
+# nushell workspace wrapper, gdb/lldb, strace, tcpdump, jq, btop, bpftrace,
+# lsof, ncdu, pv, file, and the gnutar/gzip/zstd trio needed to stay
+# `ix switch`-able. Editors and version control are not in base, so they
+# live here.
+{ lib, pkgs, ... }:
+{
+  ix.image.name = "development-base";
+
+  # `pkgs.claude-code` ships under Anthropic's commercial terms (unfree in
+  # nixpkgs). Allow it by name so the exception is auditable and narrow;
+  # codex is Apache-2.0 and does not need a predicate entry. Do not flip
+  # `allowUnfree` to `true` globally: every other unfree package would slip
+  # into this image unreviewed.
+  nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "claude-code" ];
+
+  environment.systemPackages = builtins.attrValues {
+    inherit (pkgs)
+      # Coding agents. Both authenticate at first use inside the VM; no
+      # API keys are baked into the image per the trust model.
+      claude-code
+      codex
+
+      # Build toolchain. Most ecosystems lean on cmake / make / ninja and
+      # pkg-config; rustup keeps the toolchain pinnable per-project rather
+      # than locking the image to one rustc.
+      cmake
+      gcc
+      gnumake
+      ninja
+      pkg-config
+      rustup
+
+      # Default language runtimes that show up across most dev sessions.
+      nodejs
+      python3
+      ;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -473,6 +473,17 @@ let
       };
     };
 
+  developmentBase =
+    let
+      config = evalConfig [ ../images/dev/development-base ];
+    in
+    {
+      inherit config;
+      # Outer pkgs has no allowUnfree, so forcing pkgs.claude-code here would
+      # throw at eval; use lib.getName over the rendered systemPackages list.
+      packageNames = map lib.getName config.environment.systemPackages;
+    };
+
   pythonAppClosureProbe = ix.writePythonApplication pkgs {
     name = "python-app-closure-probe";
     src = pkgs.writeText "python-app-closure-probe.py" ''
@@ -1366,6 +1377,34 @@ let
       {
         assertion = kernelDev.git.clone.timer.wantedBy == [ "timers.target" ];
         message = "timer-activated git clone should be started by timers.target";
+      }
+    ];
+
+    development-base = [
+      {
+        assertion = developmentBase.config.ix.image.name == "development-base";
+        message = "development-base image should set the expected OCI image name";
+      }
+      {
+        assertion =
+          builtins.elem "claude-code" developmentBase.packageNames
+          && builtins.elem "codex" developmentBase.packageNames;
+        message = "development-base should ship the Claude Code and Codex CLIs";
+      }
+      {
+        # Global allowUnfree would let every unfree package slip in. The
+        # image is supposed to grant exactly one exception, by name.
+        assertion = !(developmentBase.config.nixpkgs.config.allowUnfree or false);
+        message = "development-base should not enable allowUnfree globally; use the predicate";
+      }
+      {
+        assertion =
+          let
+            predicate = developmentBase.config.nixpkgs.config.allowUnfreePredicate or null;
+            mkPkg = name: { pname = name; };
+          in
+          predicate != null && predicate (mkPkg "claude-code") && !(predicate (mkPkg "cursor-cli"));
+        message = "development-base allowUnfreePredicate should permit claude-code and reject other unfree packages";
       }
     ];
 


### PR DESCRIPTION
## Summary

Adds a discovered `development-base` image at `images/dev/development-base/default.nix` so `ix new` has a sane default for human dev VMs. The image ships:

- `pkgs.claude-code` 2.1.141 (binary: `claude`) and `pkgs.codex` 0.130.0 (binary: `codex`)
- Build toolchain: `cmake`, `gcc`, `gnumake`, `ninja`, `pkg-config`, `rustup`
- Default language runtimes: `nodejs`, `python3`

The auto-enabled base profile already provides the nushell workspace wrapper, `gdb`/`lldb`, `strace`, `tcpdump`, `jq`, `btop`, `bpftrace`, `lsof`, `ncdu`, `pv`, `file`, and the `gnutar`/`gzip`/`zstd` trio needed to stay `ix switch`-able, so the image only adds what is missing for typical dev sessions.

`pkgs.claude-code` is marked unfree in nixpkgs (Anthropic Commercial Terms). The image grants the exception narrowly with `nixpkgs.config.allowUnfreePredicate` keyed on the package name, instead of flipping `allowUnfree = true` globally. `codex` is Apache-2.0 and needs no predicate entry.

Authentication is per-session inside the VM (`claude /login`, `codex login`) per the repo trust model. No API keys are baked into the image.

## Eval invariants

`tests/default.nix` gets a `development-base` group with four assertions:

1. `ix.image.name == "development-base"` (discovery contract).
2. `claude-code` and `codex` both reach `environment.systemPackages` (catches both name typos and a future broken predicate that gates claude-code out).
3. `nixpkgs.config.allowUnfree` stays falsy (catches an accidental widening of the unfree gate).
4. `allowUnfreePredicate` permits `claude-code` and rejects an unrelated unfree name (`cursor-cli`), so the allowlist stays one entry wide.

I avoided `pkgs.claude-code` in the test because the outer nixpkgs is built without `allowUnfree`; forcing it there throws at eval. The test goes through `lib.getName` over the rendered `environment.systemPackages` list, which the inner pkgs (with the predicate applied) has already produced.

Refs ENG-1379. Supersedes #53 (which referenced a nonexistent `pkgs.llm-agents.*` overlay and was 168 commits behind main).

## Test plan

- [x] `nix run nixpkgs#nixfmt -- --check images/dev/development-base/default.nix tests/default.nix`
- [x] `nix run nixpkgs#statix -- check .`
- [x] `nix run nixpkgs#deadnix -- --fail --no-lambda-pattern-names .`
- [x] `nix run nixpkgs#ast-grep -- scan --error .`
- [x] Spot-check eval of `base`, `development-base`, `extended-attributes`, `kernel-dev`, `networking` test groups (all pass)
- [x] `flake.packages.x86_64-linux.development-base` is exposed via image discovery
- [ ] CI `flake check` on x86_64-linux (host is aarch64-linux, full eval check requires the runner)
- [ ] Image build on x86_64-linux runner
