### PR TITLE
ci: advertise gccarch-znver5 to the Nix daemon

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,6 +22,15 @@ jobs:
 
       - name: Install Determinate Nix
         uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          # Every image in this repo pins `nixpkgs.hostPlatform.gcc.arch =
+          # "znver5"`, which marks each derivation as needing the
+          # `gccarch-znver5` system feature. GitHub runners don't advertise
+          # that feature by default, so flake-check fails with
+          # `missing system features ... Required features: {gccarch-znver5}`
+          # before evaluating any image.
+          extra-conf: |
+            extra-system-features = gccarch-znver5
 
       - name: nix flake check
         run: nix flake check -L


### PR DESCRIPTION
## Summary

- Pass `extra-system-features = gccarch-znver5` to determinate-nix-action via `extra-conf`, so the GitHub runner's Nix daemon will accept builds that the repo's `znver5` platform pin requires.

## Why

Every image sets `nixpkgs.hostPlatform.gcc.arch = "znver5"` in `lib/ix-platform.nix`, which propagates a `gccarch-znver5` requirement onto every derivation in the closure. Hosted runners only advertise `{benchmark, big-parallel, kvm, nixos-test, uid-range}`, so `nix flake check -L` fails on the first relevant build:

```
error: Cannot build '/nix/store/...-bootstrap-stage0-glibc-minimal-bootstrap.drv'.
       Reason: missing system features
       Required features: {gccarch-znver5}
       Available features: {benchmark, big-parallel, kvm, nixos-test, uid-range}
```

Failure is reproducible on both push-to-main (run 26078929099) and PR runs (e.g. run 26088252481). Advertising the feature lets the runner perform the local builds the closure already expects.

## Test plan

- [ ] CI on this PR turns green (`flake-check`).