### PR TITLE
docs: mirror the indexable-inc/docs README logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/logo.svg" width="80" alt="ix" />
+</p>
+
 # Index
 
 `index` builds ready-to-run [ix](https://ix.dev/) VM images from NixOS modules.

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+	<rect width="512" height="512" fill="#1a1a1a"/>
+	<svg x="64" y="64" width="384" height="384" viewBox="0 0 24 24">
+		<path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" fill="#f0f0f0"/>
+	</svg>
+</svg>


### PR DESCRIPTION
## Summary

- Add `assets/logo.svg` (copied verbatim from `indexable-inc/docs`).
- Centered `<img src="assets/logo.svg" width="80" alt="ix" />` block at the top of `README.md`, identical to the docs site treatment.

## Test plan

- [ ] GitHub renders `assets/logo.svg` in the README preview.