### PR TITLE
feat: add nginx lifecycle fleet example

### DIFF
--- a/examples/nginx-lifecycle/default.nix
+++ b/examples/nginx-lifecycle/default.nix
@@ -1,0 +1,10 @@
+{ index }:
+
+index.lib.mkFleet {
+  defaults = [ { ix.image.tag = "nginx-lifecycle"; } ];
+
+  nodes.nginx = {
+    deployment.recreateOnUp = true;
+    modules = [ ./service.nix ];
+  };
+}

--- a/examples/nginx-lifecycle/service.nix
+++ b/examples/nginx-lifecycle/service.nix
@@ -1,0 +1,46 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  nginxPort = 80;
+in
+{
+  services.nginx = {
+    enable = true;
+    virtualHosts.localhost.locations."/".return = "200 'ix nginx lifecycle ok\n'";
+  };
+
+  networking.firewall.allowedTCPPorts = [ nginxPort ];
+  environment.systemPackages = [ pkgs.curl ];
+
+  ix.networking.portClaims.nginx = {
+    protocol = "tcp";
+    port = nginxPort;
+    description = "nginx lifecycle HTTP";
+  };
+
+  ix.healthChecks = {
+    nginx = {
+      command = [
+        (lib.getExe' config.systemd.package "systemctl")
+        "is-active"
+        "--quiet"
+        "nginx.service"
+      ];
+    };
+
+    nginx-http = {
+      description = "nginx HTTP loopback";
+      command = [
+        (lib.getExe pkgs.curl)
+        "--fail"
+        "--silent"
+        "--show-error"
+        "http://127.0.0.1/"
+      ];
+    };
+  };
+}

--- a/lib/fleet.nix
+++ b/lib/fleet.nix
@@ -190,6 +190,7 @@ let
       inherit (deploy) region;
       inherit (deploy) ipv4;
       inherit (deploy) snapshot;
+      recreateOnUp = deploy.recreateOnUp or false;
       inherit (spec) tags;
       inherit (deploy) env;
       inherit (deploy) l7ProxyPorts;

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -76,6 +76,7 @@ class FleetNode(BaseModel):
     region: str = Field(min_length=1)
     ipv4: bool
     snapshot: bool
+    recreateOnUp: bool = False
     tags: list[str] = Field(default_factory=empty_str_list)
     env: dict[str, str] = Field(default_factory=empty_str_dict)
     l7ProxyPorts: list[int] = Field(default_factory=empty_int_list)
@@ -546,10 +547,16 @@ async def replace_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
 
 async def up_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
     if dry_run:
-        step(f"ensure {node.name} exists from uploaded image {image}")
+        verb = "recreate" if node.recreateOnUp else "ensure"
+        step(f"{verb} {node.name} from uploaded image {image}")
         return
 
     existing = find_node(await list_nodes(), node.name)
+    if existing is not None and node.recreateOnUp:
+        run_cli(["ix", "rm", "--force", node.name], dry_run=dry_run)
+        await create_node(node, image, dry_run=dry_run)
+        return
+
     if existing is None:
         await create_node(node, image, dry_run=dry_run)
         return

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -900,6 +900,21 @@ let
       timer = config.systemd.timers.daily-scraper;
     };
 
+  nginxLifecycleExample =
+    let
+      fleet = import ../examples/nginx-lifecycle {
+        index = {
+          lib = ix;
+        };
+      };
+      config = fleet.nodes.nginx;
+    in
+    {
+      inherit fleet config;
+      cfg = config.services.nginx;
+      plan = fleet.planValue.nodes.nginx;
+    };
+
   dailyScraperS3 =
     let
       config = evalConfig [
@@ -1295,6 +1310,59 @@ let
             ]
           && dailyScraperS3.service.serviceConfig.EnvironmentFile == "%d/aws-env";
         message = "python-daily-scraper service should support S3 sync through systemd credentials";
+      }
+    ];
+
+    nginx-lifecycle = [
+      {
+        assertion = nginxLifecycleExample.config.ix.image.tag == "nginx-lifecycle";
+        message = "nginx-lifecycle example should set a stable replacement image tag";
+      }
+      {
+        assertion = nginxLifecycleExample.plan.recreateOnUp;
+        message = "nginx-lifecycle fleet plan should recreate the VM on every ix-fleet up run";
+      }
+      {
+        assertion =
+          nginxLifecycleExample.cfg.enable
+          &&
+            nginxLifecycleExample.cfg.virtualHosts.localhost.locations."/".return
+            == "200 'ix nginx lifecycle ok\n'";
+        message = "nginx-lifecycle example should serve a fixed HTTP success body";
+      }
+      {
+        assertion =
+          let
+            claims = nginxLifecycleExample.config.ix.networking.portClaims;
+          in
+          claims.nginx.protocol == "tcp"
+          && claims.nginx.port == 80
+          && builtins.elem 80 nginxLifecycleExample.config.networking.firewall.allowedTCPPorts;
+        message = "nginx-lifecycle example should declare and open its HTTP listener";
+      }
+      {
+        assertion =
+          let
+            checks = nginxLifecycleExample.plan.healthChecks;
+          in
+          checks.nginx.from == "guest"
+          &&
+            checks.nginx.command == [
+              (lib.getExe' nginxLifecycleExample.config.systemd.package "systemctl")
+              "is-active"
+              "--quiet"
+              "nginx.service"
+            ]
+          && checks.nginx-http.from == "guest"
+          && lib.hasSuffix "/bin/curl" (builtins.head checks.nginx-http.command)
+          &&
+            builtins.tail checks.nginx-http.command == [
+              "--fail"
+              "--silent"
+              "--show-error"
+              "http://127.0.0.1/"
+            ];
+        message = "nginx-lifecycle fleet plan should prove the service unit and HTTP loopback path";
       }
     ];
 


### PR DESCRIPTION
Adds an index-owned nginx lifecycle fleet example and teaches ix-fleet plans to mark nodes that should be recreated on each up. The example exposes nginx on port 80, declares the port claim, and includes guest health checks for systemd and HTTP loopback.

This moves the fresh VM launch probe into index so external schedulers can run it with the rest of the fleet integration suite. The recreate flag keeps the lifecycle semantics explicit inside the fleet plan.