### PR TITLE
examples: add multi-client-file-sharing fleet

### DIFF
--- a/examples/multi-client-file-sharing/README.md
+++ b/examples/multi-client-file-sharing/README.md
@@ -1,0 +1,61 @@
+# Multi-client file sharing
+
+Standalone consumer example for sharing files across ix VMs over SMB with
+correct POSIX locking semantics.
+
+A `file-server` node exports `/var/lib/file-share` as the share named `share`.
+Two client replicas (`client-0` and `client-1`) mount it at `/mnt/share` over
+SMB 3.1.1. Linux's `cifs.ko` translates both `fcntl` byte-range locks and
+`flock()` into native SMB byte-range locks, and `smbd` is configured to
+mediate locks centrally, so locks coordinate across both clients.
+
+## Run
+
+```sh
+ix up
+```
+
+## Shape
+
+- [`default.nix`](default.nix) defines the fleet: one server node and two
+  client replicas with `dependsOn` so the server is up first.
+- [`server.nix`](server.nix) configures Samba with the locking knobs
+  (`strict locking`, `posix locking`, `kernel oplocks = no`,
+  `strict sync = yes`) that keep two clients honest about each other's writes.
+- [`client.nix`](client.nix) declares the CIFS mount with `vers=3.1.1` and an
+  explicit `nobrl=0` so a future option-list tweak can't silently disable
+  byte-range locks.
+
+## Verify cross-client locking
+
+Hold an exclusive `flock` on a file from one client:
+
+```sh
+ix shell client-0 -- flock -x /mnt/share/lockfile -c 'sleep 60'
+```
+
+From a second host shell, try to grab the same lock from the other client
+non-blocking:
+
+```sh
+ix shell client-1 -- flock -nx /mnt/share/lockfile -c 'echo got-it'
+```
+
+The second invocation exits with status 1 until the first releases. Swap
+`flock` for a `python -c 'import fcntl; fcntl.lockf(...)'` snippet to exercise
+the same path via `fcntl` byte-range locks.
+
+## Tradeoffs
+
+- The share is **guest-writable** by default so `ix up` works without secrets
+  plumbing. Real deployments should drop `guest ok = yes` from
+  [`server.nix`](server.nix), add a Samba user with `smbpasswd`, and pass
+  `credentials=` to the CIFS mount through a systemd `LoadCredential` (the
+  same shape [`python-daily-scraper`](../python-daily-scraper) uses for AWS
+  keys).
+- ix VMs share the host `linux-ix` kernel, so the SMB server has to be
+  userspace `smbd` rather than in-kernel `ksmbd`. The client side still rides
+  on `cifs.ko` from the host kernel.
+- `strict sync = yes` plus `actimeo=1` trade some throughput for prompt
+  cross-client visibility. Append-only or single-writer workloads can relax
+  both.

--- a/examples/multi-client-file-sharing/client.nix
+++ b/examples/multi-client-file-sharing/client.nix
@@ -1,0 +1,78 @@
+{
+  config,
+  lib,
+  nodes,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.file-share-client;
+  serverHost = nodes.file-server.config.ix.networking.eastWest.hostName;
+in
+{
+  options.services.file-share-client = {
+    mountPoint = lib.mkOption {
+      type = lib.types.str;
+      default = "/mnt/share";
+      description = "Local path where the CIFS share is mounted.";
+    };
+
+    shareName = lib.mkOption {
+      type = lib.types.str;
+      default = "share";
+      description = "Samba share name exported by the file-server node.";
+    };
+  };
+
+  config = {
+    # `cifs.ko` is loaded from the host `linux-ix` kernel; we don't set
+    # `boot.supportedFilesystems` because a `boot.isContainer = true`
+    # image can't `modprobe` host modules itself. The mount unit will
+    # surface a clear error if cifs is unavailable on the host kernel.
+    # Linux's cifs translates `flock()` to a byte-range lock on the
+    # whole file (kernel >= 5.4), so both `flock` and `fcntl` byte-range
+    # locks reach the server's lock manager and coordinate across mounts.
+
+    fileSystems.${cfg.mountPoint} = {
+      device = "//${serverHost}/${cfg.shareName}";
+      fsType = "cifs";
+      options = [
+        "vers=3.1.1"
+        "guest"
+        "uid=0"
+        "gid=0"
+        "file_mode=0660"
+        "dir_mode=0770"
+        # We deliberately do NOT pass `nobrl`: it is a pure flag that
+        # disables byte-range locking, the very thing this example
+        # exists to demonstrate. The default is BRL enabled. Don't add
+        # `nobrl` here without rewriting the README.
+        # Short attribute cache keeps cross-client metadata reads fresh
+        # without disabling the cache entirely.
+        "actimeo=1"
+        "_netdev"
+        "nofail"
+        "x-systemd.requires=network-online.target"
+        "x-systemd.after=network-online.target"
+      ];
+      noCheck = true;
+    };
+
+    environment.systemPackages = [
+      pkgs.cifs-utils
+      # `flock(1)` lives here; pre-installed so `ix shell client-0 -- flock`
+      # works without reaching for `nix run nixpkgs#util-linux`.
+      pkgs.util-linux
+    ];
+
+    ix.healthChecks.cifs-mount = {
+      description = "CIFS share is mounted";
+      command = [
+        (lib.getExe' pkgs.util-linux "findmnt")
+        "--type"
+        "cifs"
+        cfg.mountPoint
+      ];
+    };
+  };
+}

--- a/examples/multi-client-file-sharing/default.nix
+++ b/examples/multi-client-file-sharing/default.nix
@@ -1,0 +1,15 @@
+{ index }:
+
+index.lib.mkFleet {
+  defaults = [ { ix.image.tag = "multi-client-file-sharing"; } ];
+
+  nodes = {
+    file-server.modules = [ ./server.nix ];
+
+    client = {
+      replicas = 2;
+      dependsOn = [ "file-server" ];
+      modules = [ ./client.nix ];
+    };
+  };
+}

--- a/examples/multi-client-file-sharing/flake.nix
+++ b/examples/multi-client-file-sharing/flake.nix
@@ -1,0 +1,12 @@
+{
+  inputs.index.url = "github:indexable-inc/index";
+
+  outputs =
+    { index, ... }:
+    let
+      fleet = import ./default.nix { inherit index; };
+    in
+    {
+      packages.x86_64-linux = fleet.packages;
+    };
+}

--- a/examples/multi-client-file-sharing/server.nix
+++ b/examples/multi-client-file-sharing/server.nix
@@ -1,0 +1,87 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  sambaPort = 445;
+  shareDir = "/var/lib/file-share";
+in
+{
+  # Userspace `smbd` rather than in-kernel `ksmbd`: ix images are
+  # `boot.isContainer = true` and share the host `linux-ix` kernel, so
+  # the SMB server has to live in userspace. Linux clients still use
+  # `cifs.ko` from the host kernel.
+  services.samba = {
+    enable = true;
+    # We claim and open TCP 445 explicitly below so the firewall rule and
+    # the `ix.networking.portClaims` registry stay co-located with the
+    # rest of the listener policy.
+    openFirewall = false;
+
+    settings = {
+      global = {
+        "workgroup" = "WORKGROUP";
+        "server string" = "ix multi-client file share";
+        "security" = "user";
+        "map to guest" = "Bad User";
+        "guest account" = "nobody";
+
+        # SMB 3.1.1 on both ends. Older dialects predate the byte-range
+        # lock improvements the brief is asking us to demonstrate.
+        "server min protocol" = "SMB3_11";
+        "client min protocol" = "SMB3_11";
+
+        # Mediate every byte-range lock in `smbd` instead of pushing them
+        # down to the host kernel's local-fs locks. Two CIFS clients
+        # otherwise contend through the server's POSIX lock manager,
+        # which Linux maps onto fcntl byte-range locks only — `flock()`
+        # over CIFS would lose coordination across clients.
+        "locking" = "yes";
+        "strict locking" = "yes";
+        "posix locking" = "yes";
+        "oplocks" = "yes";
+        "kernel oplocks" = "no";
+
+        # Cross-client visibility over throughput: a write from
+        # `client-0` should be readable from `client-1` without waiting
+        # for cache to expire on its own.
+        "strict sync" = "yes";
+      };
+
+      share = {
+        "path" = shareDir;
+        "browseable" = "yes";
+        "read only" = "no";
+        "writable" = "yes";
+        "guest ok" = "yes";
+        "force user" = "nobody";
+        "force group" = "nogroup";
+        "create mask" = "0660";
+        "directory mask" = "0770";
+      };
+    };
+  };
+
+  systemd.tmpfiles.rules = [
+    "d ${shareDir} 0770 nobody nogroup -"
+  ];
+
+  networking.firewall.allowedTCPPorts = [ sambaPort ];
+
+  ix.networking.portClaims.samba = {
+    protocol = "tcp";
+    port = sambaPort;
+    description = "Samba SMB3 share for east-west clients";
+  };
+
+  ix.healthChecks.smbd = {
+    description = "smbd is active";
+    command = [
+      (lib.getExe' config.systemd.package "systemctl")
+      "is-active"
+      "--quiet"
+      "smbd.service"
+    ];
+  };
+}


### PR DESCRIPTION
Three-node ix fleet demonstrating an SMB share consumed by multiple VMs
with correct cross-client locking semantics: one `file-server` node runs
userspace Samba with the locking knobs that mediate every byte-range
lock in `smbd`, and two `client` replicas mount the share with cifs.ko,
which translates `flock()` and `fcntl` byte-range locks into native SMB
locks.

Userspace smbd (rather than in-kernel ksmbd) because images are
`boot.isContainer = true` and share the host `linux-ix` kernel. The
client side still rides on cifs.ko from that host kernel.