### PR TITLE
mc-probe: add missing [project] table header to pyproject.toml

### DIFF
--- a/packages/minecraft/probe/pyproject.toml
+++ b/packages/minecraft/probe/pyproject.toml
@@ -1,3 +1,4 @@
+[project]
 dependencies = ["mcstatus>=13.1.0,<14.0.0"]
 description = "Assert Minecraft Server List Ping responses for health checks"
 name = "mc-probe"


### PR DESCRIPTION
Commit 6153f91 ("packages: nest mc-probe under packages/minecraft/") introduced the new `packages/minecraft/probe/pyproject.toml` without the leading `[project]` line, so uv parses the keys at the top level and fails the build with:

```
error: Failed to parse: `pyproject.toml`
  Caused by: TOML parse error at line 7, column 2
  |
7 | [project.scripts]
  |  ^^^^^^^
`pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
```

This breaks `nix build .#mc-probe` and every downstream consumer that realises it, including `nix run .#health-checks` (mc-probe is in the pinned image closure of the velocity and minecraft example fleets).

Fix: prepend `[project]` so the existing keys land inside the project table, matching the shape of `packages/ix-fleet/pyproject.toml`.

To reproduce on `development` before this patch:

```
nix build .#mc-probe
```