### PR TITLE
ci: pass repo_token to scorecard for branch-protection reads

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,6 +31,10 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
+          # Reads classic branch protection rules. Default GITHUB_TOKEN
+          # cannot, so Branch-Protection falls back to -1 ("internal
+          # error") without a PAT. See #89 for the secret setup.
+          repo_token: ${{ secrets.SCORECARD_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
Default `GITHUB_TOKEN` cannot read classic branch protection rules, so Scorecard's Branch-Protection check falls back to -1 ("internal error") even when protection is configured.

Pass `repo_token` from an optional `SCORECARD_TOKEN` secret (PAT with `Administration: read` on this repo), falling back to `GITHUB_TOKEN` so the workflow stays green before the secret exists.

The actual secret setup is in #89.
