### PR TITLE
platform: drop lazy-trees from experimental-features

### DIFF
--- a/lib/ix-platform.nix
+++ b/lib/ix-platform.nix
@@ -348,10 +348,6 @@ in
           "ca-derivations"
           "dynamic-derivations"
           "git-hashing"
-          # Determinate-only: 3x+ eval speedups and 20x less source-copy
-          # disk in large repos. Safe to list against upstream Nix too,
-          # which just ignores unknown experimental features.
-          "lazy-trees"
         ];
         allow-import-from-derivation = lib.mkDefault true;
         warn-dirty = false;


### PR DESCRIPTION
Commit dd0f879 ("platform: add fetch-tree and lazy-trees experimental features") added `lazy-trees` to `nix.settings.experimental-features` in `lib/ix-platform.nix` on the assumption that "Safe to list against upstream Nix too, which just ignores unknown experimental features."

Determinate Nix 3.x is stricter. `lazy-trees` is now default-on and removed from the experimental-features registry, so the validator rejects it. Every image build fails at the `nix.conf` step:

```
error: Cannot build '/nix/store/.../nix.conf.drv'.
       Last 2 log lines:
       > Validating generated nix.conf
       > error: unknown experimental feature 'lazy-trees'
```

That cascades: every health-check OCI archive, every example fleet, and `nix run .#health-checks` fail to build because they all need an image whose `nix.conf` does not validate.

Dropping the entry restores image builds. The underlying optimization is unchanged because Determinate v3.20.0 (pinned in `flake.lock`) already enables lazy-trees by default.

To reproduce on `development` before this patch:

```
nix build .#nginx
```

Refs the same area of work as #84 (mc-probe pyproject), which fixes the next bug in the same `nix run .#health-checks` chain.