### PR TITLE
platform: demote libtpms -Wstringop-overflow to a warning

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -151,7 +151,7 @@ let
     instead so they don't leak into the nixpkgs namespace inside images.
   */
   overlay =
-    final: _prev:
+    final: prev:
     let
       ixForOverlay = {
         buildRustPackage = pkgs: (rustFor pkgs).buildPackage;
@@ -163,6 +163,26 @@ let
     in
     {
       drgn = final.callPackage paths.packages.drgn { };
+
+      # libtpms 0.10.2 + GCC 15.2 (the znver5-tuned compiler the platform
+      # produces) fails the build with `-Werror=stringop-overflow` on a
+      # CryptCmac.c buffer access GCC can't statically prove safe. Upstream
+      # PR stefanberger/libtpms#478 silenced an earlier related warning by
+      # adding asserts, but GCC 15 finds a new false-positive site that the
+      # current 0.10.2 release does not cover. No public bug exists for the
+      # exact GCC 15.2 + libtpms 0.10.2 failure (checked upstream issues and
+      # nixpkgs issues). Demote the warning back to a warning so the build
+      # completes; remove this override when libtpms bumps past 0.10.2 with
+      # the upstream fix or when nixpkgs' libtpms drops `-Werror`.
+      libtpms = prev.libtpms.overrideAttrs (oldAttrs: {
+        env = (oldAttrs.env or { }) // {
+          NIX_CFLAGS_COMPILE = toString [
+            ((oldAttrs.env or { }).NIX_CFLAGS_COMPILE or "")
+            "-Wno-error=stringop-overflow"
+          ];
+        };
+      });
+
       minecraft-hot-reload-agent = final.callPackage paths.packages.minecraft.hotReloadAgent { };
       minecraft-rcon = final.callPackage paths.packages.minecraft.rcon {
         writePythonApplication = writePythonApplication final;


### PR DESCRIPTION
znver5 forces every package in the closure to build from source. That puts every nixpkgs derivation in the path of the GCC 15.2 the platform produces. `libtpms` 0.10.2 + GCC 15.2 emit a stringop-overflow false positive that the package treats as fatal because nixpkgs ships `-Werror=stringop-overflow` on it. The build fails, and every image plus `nix run .#health-checks` cascades.

Upstream [`stefanberger/libtpms#478`](https://github.com/stefanberger/libtpms/pull/478) silenced an earlier related warning in `CryptCmac.c` by adding asserts. GCC 15 finds a new false-positive site that the current 0.10.2 release does not cover, and no public bug exists for the exact GCC 15.2 + libtpms 0.10.2 failure mode (checked upstream issues and nixpkgs issues; if anyone finds one, the comment should grow a link).

Override the package to layer `-Wno-error=stringop-overflow` onto `NIX_CFLAGS_COMPILE`. That demotes that one diagnostic back to a warning so the build completes. The underlying access is plausibly safe; GCC just cannot statically prove it.

The overlay's `prev` argument was previously `_prev` (intentionally unused). Renamed to `prev` since the libtpms override now reads it. The `_` prefix is reserved for actually-unused bindings.

Remove the override when libtpms ships the upstream fix in a release past 0.10.2 or when nixpkgs' libtpms package drops `-Werror`.

To reproduce on `development` before this patch:

```
nix build .#test-cluster-bootstrap
```

(or anything else that pulls libtpms into a fresh znver5 closure, including `nix run .#health-checks`).

Refs the broader `nix run .#health-checks` work alongside #84 (mc-probe pyproject) and #92 (lazy-trees, merged).