### PR TITLE
ci: push znver5 closures to indexable-inc.cachix.org

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,8 +32,24 @@ jobs:
           # that feature by default, so flake-check fails with
           # `missing system features ... Required features: {gccarch-znver5}`
           # before evaluating any image.
+          #
+          # `accept-flake-config` lets CI consume the flake's `nixConfig`
+          # (the Cachix substituter) without an interactive prompt.
           extra-conf: |
             extra-system-features = gccarch-znver5
+            accept-flake-config = true
+
+      # Configures the indexable-inc Cachix substituter for the daemon and
+      # uploads every store path realised during this job. PRs from forks
+      # cannot read `secrets.CACHIX_AUTH_TOKEN` so the action degrades to
+      # read-only automatically. Push-event jobs (development, main) supply
+      # the token and become writers; this gates publish credentials on the
+      # reviewed ref per the supply-chain rule in AGENTS.md.
+      - name: Set up Cachix
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: indexable-inc
+          authToken: ${{ github.event_name == 'push' && secrets.CACHIX_AUTH_TOKEN || '' }}
 
       - name: nix flake check
         run: nix flake check -L

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,18 @@
 {
   description = "Pre-built OCI images for ix VMs";
 
+  # znver5 forces every package in the closure to build from source: the
+  # nixpkgs binary cache is generic x86_64 and never has a hit. The
+  # indexable-inc Cachix cache stores the znver5-tuned closures CI builds,
+  # so a fresh checkout downloads instead of recompiling. Priority 30 (set
+  # in the cache settings) puts it ahead of cache.nixos.org by default.
+  nixConfig = {
+    extra-substituters = [ "https://indexable-inc.cachix.org" ];
+    extra-trusted-public-keys = [
+      "indexable-inc.cachix.org-1:HQ5mjdOyhgNjLVhjv0qgVMJ5YiO1zEEVMAtF9mTcpiI="
+    ];
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";


### PR DESCRIPTION
znver5 forces every package in the closure to build from source because the nixpkgs binary cache only ships generic x86_64. A fresh dev checkout spends ~1 hour rebuilding things that one CI machine already built. This wires the [`indexable-inc` Cachix cache](https://indexable-inc.cachix.org) so CI on `development` and `main` populates it after every green run, and `flake.nix` exposes the substituter to every consumer through `nixConfig`. Future fresh checkouts download the closure instead of recompiling.

## Push gating

The auth token (`CACHIX_AUTH_TOKEN`, stored in repo secrets) is passed to `cachix-action` only on `push` events:

```yaml
authToken: ${{ github.event_name == 'push' && secrets.CACHIX_AUTH_TOKEN || '' }}
```

PRs (including from forks) configure the substituter for reads but degrade to read-only because the conditional resolves to an empty token. That matches the AGENTS.md supply-chain rule:

> Main/tag release jobs should restore caches only from trusted refs, mint registry publish credentials only after the reviewed ref is selected.

CI uses `accept-flake-config = true` so the substituter is consumed without an interactive prompt. Local developers get a one-time prompt the first time they run `nix build` in this repo; one `y` and they're permanently configured.

## Cache configuration (already set in cachix dashboard)

- **Public read**, signing managed by Cachix.
- **ZSTD** compression (faster decompress for big closures).
- **Priority 30** (ahead of cache.nixos.org's 40, so Nix checks indexable-inc first).
- **Upstream cache** `cache.nixos.org` set, so paths that exist there are skipped on upload.
- Owned by the `indexable-inc` GitHub org.

## What lands after merge

1. Next push to `development` triggers `Check`. The new step uploads everything realised during `nix flake check` to the cache.
2. Subsequent `nix build .#<image>` or `nix run .#health-checks` on any machine pulls the closure from cachix instead of compiling.
3. The first push is the slow one. Everything after is fast.

## Caveat

Cachix free tier is 5 GB. znver5 closures will blow past that quickly. Andrew will need to bump to the Medium plan ($249/mo, 100 GB) before the cache fills, or we accept that some paths get evicted. Worth tracking storage from the dashboard after the first few runs.