### PR TITLE
oci: support long symlink targets in layers

### DIFF
--- a/packages/oci-image-builder/src/main.rs
+++ b/packages/oci-image-builder/src/main.rs
@@ -747,8 +747,7 @@ fn append_normalized_entry<W: Write>(
         let link_target = fs::read_link(source)?;
         header.set_entry_type(tar::EntryType::Symlink);
         header.set_size(0);
-        header.set_link_name(&link_target)?;
-        builder.append_data(&mut header, archive_name, io::empty())?;
+        builder.append_link(&mut header, archive_name, link_target)?;
     } else if file_type.is_dir() {
         header.set_entry_type(tar::EntryType::Directory);
         header.set_size(0);


### PR DESCRIPTION
## Summary

- use tar::Builder::append_link for OCI layer symlinks
- let the tar crate emit the required long-link metadata for symlink targets that do not fit in the fixed header field

## Context

Health-check image builds got past the absolute path header failure, then failed on a Neovim closure symlink with:

```
Error: Custom { kind: Other, error: "provided value is too long when setting link name for " }
```

The failure came from calling Header::set_link_name directly before appending the entry.

## Testing

Not run locally. This targets the health-check failure observed on the live development run.

