### PR TITLE
ci: apply znver5 zlib workaround to image builds

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -164,6 +164,12 @@ let
     {
       drgn = final.callPackage paths.packages.drgn { };
 
+      # GitHub's x86_64 runners cannot execute znver5-tuned zlib test
+      # binaries, but CI has to build the same znver5 closures images use.
+      zlib = prev.zlib.overrideAttrs (_: {
+        doCheck = false;
+      });
+
       # libtpms 0.10.2 + GCC 15.2 (the znver5-tuned compiler the platform
       # produces) fails the build with `-Werror=stringop-overflow` on a
       # CryptCmac.c buffer access GCC can't statically prove safe. Upstream

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -12,17 +12,11 @@
 }:
 let
   inherit (nixpkgs) lib;
-  ciPlatformOverlay = final: prev: {
-    zlib = prev.zlib.overrideAttrs (_: {
-      # GitHub's x86_64 runners cannot execute znver5-tuned zlib test binaries.
-      doCheck = false;
-    });
-  };
   pkgs = import nixpkgs {
     inherit system;
     overlays = [
       rust-overlay.overlays.default
-      ciPlatformOverlay
+      ix.overlay
     ];
   };
   fs = lib.fileset;


### PR DESCRIPTION
## Summary
- move the znver5 zlib check workaround into the repo overlay used by image builds
- reuse the repo overlay from per-system package imports so flake packages and image evaluation share the same zlib override

## Failure
The development Check workflow is failing in `flake-check` while building `zlib-1.3.2`. GitHub's x86_64 runner accepts `gccarch-znver5` as a Nix system feature, then executes zlib's znver5-tuned `minigzip` test binaries on hardware that traps with `Illegal instruction`.

## Validation
- `git diff --check`
- PR CI is the authoritative validation target for this fix