### PR TITLE
fleet: default to canonical west region

### DIFF
--- a/lib/fleet.nix
+++ b/lib/fleet.nix
@@ -40,7 +40,7 @@ let
 
   deploymentDefaults = {
     bootstrapImage = "registry.ix.dev/${bootstrapImage.name}:${bootstrapImage.tag}";
-    region = "hil-1";
+    region = "us-west-1";
     ipv4 = false;
     snapshot = true;
     switch.buildOn = "remote";

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -765,7 +765,7 @@ let
   pythonMcpServerPackage = (ix.packageSetFor pkgs).python-mcp-server;
 
   fleet = ix.mkFleet {
-    deployment.region = "hil-1";
+    deployment.region = "us-west-1";
     secrets.sessionKey.generate = true;
 
     nodes = {
@@ -2082,7 +2082,7 @@ let
         message = "fleet plans should expose replacement image derivations without forcing local image builds";
       }
       {
-        assertion = fleetPlan.web.region == "hil-1";
+        assertion = fleetPlan.web.region == "us-west-1";
         message = "fleet nodes should inherit the top-level deployment region";
       }
       {


### PR DESCRIPTION
## Summary
- change the default fleet deployment region from `hil-1` to canonical `us-west-1`
- update the fleet eval test fixture and assertion to match
- checked remaining `lib/`, `tests/`, and package code for stale `hil-1` references

## Validation
- `nix build .#checks.x86_64-linux.eval --no-link --print-out-paths`
- `git diff --check`
- `nix run --system x86_64-linux .#lint` returned without lint failures on this aarch64-linux host; Nix printed a local eval-cache busy warning