### PR TITLE
dag-runner: add --only filter to run a subset of nodes

### DIFF
--- a/packages/dag-runner/README.md
+++ b/packages/dag-runner/README.md
@@ -7,10 +7,12 @@ The runner is meant for short, hands-off batches: spawn a fan-out of independent
 ## Usage
 
 ```
-dag-runner <spec.json> [--output auto|tui|plain|json]
+dag-runner <spec.json> [--output auto|tui|plain|json] [--only NAMES]
 ```
 
 `--output auto` (default) picks `tui` when stdout is a TTY and `plain` otherwise. `json` emits NDJSON events to stdout and a final `summary` line; everything else still goes to stderr.
+
+`--only` restricts the run to the named nodes (comma-separated, repeatable: `--only a,b --only c`). Unknown names and edges left dangling by the cut (a kept node depending on a dropped one) are rejected before any node is spawned, so a filtered run keeps the same "every kept node has every dep it needs" invariant as an unfiltered run.
 
 ## Spec schema
 

--- a/packages/dag-runner/src/main.rs
+++ b/packages/dag-runner/src/main.rs
@@ -48,6 +48,14 @@ struct Args {
     /// Output mode.
     #[arg(long, value_enum, default_value_t = OutputMode::Auto)]
     output: OutputMode,
+
+    /// Restrict the run to these node names. Comma-separated, repeatable
+    /// (`--only a,b --only c`). Every name must exist in the spec, and any
+    /// kept node may only depend on other kept nodes; otherwise the runner
+    /// errors out before spawning anything so the remaining graph still has
+    /// well-defined semantics (no silent skips, no exit-code surprises).
+    #[arg(long, value_delimiter = ',')]
+    only: Vec<String>,
 }
 
 #[derive(Clone, Copy, ValueEnum)]
@@ -136,7 +144,11 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     let text = std::fs::read_to_string(&args.spec)
         .with_context(|| format!("reading spec: {}", args.spec.display()))?;
-    let spec: Spec = serde_json::from_str(&text).context("parsing spec JSON")?;
+    let mut spec: Spec = serde_json::from_str(&text).context("parsing spec JSON")?;
+
+    if !args.only.is_empty() {
+        filter_only(&mut spec, &args.only)?;
+    }
 
     validate(&spec)?;
 
@@ -205,6 +217,45 @@ fn validate(spec: &Spec) -> Result<()> {
         }
     }
     detect_cycle(&spec.nodes)?;
+    Ok(())
+}
+
+/// Trim `spec.nodes` to the names in `only`. Unknown names and edges left
+/// dangling by the cut are rejected here, so the remaining graph keeps the
+/// "every kept node has every dep it needs" invariant of an unfiltered run.
+fn filter_only(spec: &mut Spec, only: &[String]) -> Result<()> {
+    let keep: HashSet<&str> = only.iter().map(String::as_str).collect();
+
+    let mut missing: Vec<&str> = keep
+        .iter()
+        .copied()
+        .filter(|name| !spec.nodes.contains_key(*name))
+        .collect();
+    if !missing.is_empty() {
+        missing.sort_unstable();
+        bail!("--only names not found in spec: {}", missing.join(", "));
+    }
+
+    spec.nodes.retain(|name, _| keep.contains(name.as_str()));
+
+    let mut dangling: Vec<String> = spec
+        .nodes
+        .iter()
+        .flat_map(|(name, node)| {
+            node.depends_on
+                .iter()
+                .filter(|dep| !keep.contains(dep.as_str()))
+                .map(move |dep| format!("{name} -> {dep}"))
+        })
+        .collect();
+    if !dangling.is_empty() {
+        dangling.sort();
+        bail!(
+            "--only would drop dependencies of kept nodes: {}; add the missing names to --only",
+            dangling.join(", ")
+        );
+    }
+
     Ok(())
 }
 
@@ -840,6 +891,29 @@ mod tests {
         let mut records = BTreeMap::new();
         records.insert("a".into(), record(Outcome::Skipped));
         assert_eq!(exit_code(&records), 1);
+    }
+
+    #[test]
+    fn filter_only_keeps_named_nodes_and_drops_the_rest() {
+        let mut spec = spec_of(&[("a", &[]), ("b", &["a"]), ("c", &[])]);
+        filter_only(&mut spec, &["a".into(), "b".into()]).unwrap();
+        let mut kept: Vec<&str> = spec.nodes.keys().map(String::as_str).collect();
+        kept.sort_unstable();
+        assert_eq!(kept, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn filter_only_errors_on_missing_name() {
+        let mut spec = spec_of(&[("a", &[])]);
+        let err = filter_only(&mut spec, &["ghost".into()]).unwrap_err().to_string();
+        assert!(err.contains("ghost"), "error should name the missing entry, got: {err}");
+    }
+
+    #[test]
+    fn filter_only_errors_when_kept_node_loses_its_dep() {
+        let mut spec = spec_of(&[("a", &[]), ("b", &["a"])]);
+        let err = filter_only(&mut spec, &["b".into()]).unwrap_err().to_string();
+        assert!(err.contains("b -> a"), "error should show the dropped edge, got: {err}");
     }
 
     #[test]

--- a/packages/dag-runner/tests/integration.rs
+++ b/packages/dag-runner/tests/integration.rs
@@ -256,3 +256,37 @@ fn empty_command_is_rejected_before_running() {
         "empty command should be a validation error: {stderr}"
     );
 }
+
+#[test]
+fn only_runs_just_the_named_nodes_and_skips_spawning_the_rest() {
+    // The dropped node would exit 7 if it ran; success here proves --only
+    // filtered it out before spawn rather than just hiding it from the report.
+    let spec = r#"{"nodes":{
+        "a":{"command":["sh","-c","exit 7"]},
+        "b":{"command":["true"]},
+        "c":{"command":["true"]}
+    }}"#;
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("spec.json");
+    std::fs::write(&path, spec).unwrap();
+    let bin = env!("CARGO_BIN_EXE_dag-runner");
+    let output = Command::new(bin)
+        .arg("--output").arg("json")
+        .arg("--only").arg("b,c")
+        .arg(&path)
+        .output()
+        .expect("spawn dag-runner");
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+
+    let events = parse_events(&output.stdout);
+    let summary = events.iter().find(|e| e["event"] == "summary").unwrap();
+    assert_eq!(summary["total"], 2);
+    assert_eq!(summary["succeeded"], 2);
+    let mut ran: Vec<&str> = events
+        .iter()
+        .filter(|e| e["event"] == "node_finished")
+        .map(|e| e["node"].as_str().unwrap())
+        .collect();
+    ran.sort_unstable();
+    assert_eq!(ran, vec!["b", "c"]);
+}


### PR DESCRIPTION
## Summary

Adds `--only <NAMES>` to [`dag-runner`](packages/dag-runner/) so consumers can run a subset of nodes from a spec without editing it. Headline use case: `nix run .#health-checks -- --only nginx-lifecycle` iterates on one example instead of booting every fleet.

`--only` is comma-separated and repeatable (`--only a,b --only c`). Unknown names and edges left dangling by the cut (a kept node depending on a dropped one) are rejected before any node is spawned, so a filtered run keeps the same "every kept node has every dep it needs" invariant as an unfiltered one. No runtime skip semantics; no exit-code surprises.

The existing [`lib/health-checks.nix`](lib/health-checks.nix) `dag` wrapper already forwards `...$args` to the runner, so `nix run .#health-checks -- --only <name>` works without a Nix change.

Refs #71.

## Test plan
- [x] `cargo test` in `packages/dag-runner` (3 new unit tests + 1 new integration test; 19 unit + 15 integration green)
- [ ] `nix run .#health-checks -- --only nginx-lifecycle` smoke-runs end to end on a working cache
- [ ] `nix flake check` green on CI
