### PR TITLE
feat(fleet): add bootstrap and down verbs

### DIFF
--- a/lib/fleet.nix
+++ b/lib/fleet.nix
@@ -328,7 +328,9 @@ let
     };
 
   subcommands = lib.genAttrs [
+    "bootstrap"
     "diff"
+    "down"
     "health"
     "replace"
     "switch"
@@ -338,7 +340,9 @@ let
 in
 {
   inherit (subcommands)
+    bootstrap
     diff
+    down
     replace
     health
     switch

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -422,6 +422,48 @@ async def ensure_node_groups(node: FleetNode, *, dry_run: bool) -> None:
             raise
 
 
+async def bootstrap_node(node: FleetNode, *, dry_run: bool) -> None:
+    await ensure_node(node, dry_run=dry_run)
+    await ensure_node_groups(node, dry_run=dry_run)
+
+
+def dependency_batches(plan: FleetPlan, selectors: list[str]) -> list[list[FleetNode]]:
+    remaining = {node.name for node in selected_nodes(plan, selectors)}
+    completed: set[str] = set()
+    batches: list[list[FleetNode]] = []
+    while remaining:
+        batch = [
+            plan.nodes[name]
+            for name in plan.order
+            if name in remaining and all(dep not in remaining or dep in completed for dep in plan.nodes[name].dependsOn)
+        ]
+        if not batch:
+            names = ", ".join(sorted(remaining))
+            raise ValueError(f"dependency cycle among selected nodes: {names}")
+        batches.append(batch)
+        for node in batch:
+            remaining.remove(node.name)
+            completed.add(node.name)
+    return batches
+
+
+def is_missing_node_error(error: CliError) -> bool:
+    return "not found" in error.output.lower()
+
+
+async def remove_node(node: FleetNode, *, dry_run: bool) -> None:
+    if dry_run:
+        step(f"remove {node.name}")
+        return
+    try:
+        run_cli(["ix", "rm", "--force", node.name], dry_run=dry_run)
+    except CliError as error:
+        if is_missing_node_error(error):
+            step(f"{node.name} is already absent")
+            return
+        raise
+
+
 def _stringify_env_value(value: typing.Any) -> str:
     if isinstance(value, bool):
         return "true" if value else "false"
@@ -671,6 +713,22 @@ async def cmd_health(plan: FleetPlan, args: argparse.Namespace) -> None:
         await run_node_health_checks(node, dry_run=args.dry_run)
 
 
+async def cmd_bootstrap(plan: FleetPlan, args: argparse.Namespace) -> None:
+    for batch in dependency_batches(plan, args.on):
+        await asyncio.gather(*(bootstrap_node(node, dry_run=args.dry_run) for node in batch))
+
+
+async def cmd_down(plan: FleetPlan, args: argparse.Namespace) -> None:
+    failures: list[str] = []
+    for node in reversed(selected_nodes(plan, args.on)):
+        try:
+            await remove_node(node, dry_run=args.dry_run)
+        except (CliError, OSError) as error:
+            failures.append(f"{node.name}: {error}")
+    if failures:
+        raise RuntimeError("failed to remove fleet nodes: " + "; ".join(failures))
+
+
 def parser() -> argparse.ArgumentParser:
     def add_common_options(target: argparse.ArgumentParser, *, defaults: bool) -> None:
         target.add_argument(
@@ -690,6 +748,10 @@ def parser() -> argparse.ArgumentParser:
     add_common_options(p, defaults=True)
 
     sub = p.add_subparsers(dest="command", required=True)
+    bootstrap = sub.add_parser("bootstrap")
+    add_common_options(bootstrap, defaults=False)
+    down = sub.add_parser("down")
+    add_common_options(down, defaults=False)
     plan = sub.add_parser("plan")
     add_common_options(plan, defaults=False)
     diff = sub.add_parser("diff")
@@ -719,6 +781,10 @@ async def main() -> None:
     if args.command == "plan":
         nodes = [node.model_dump() for node in selected_nodes(plan, args.on)]
         print(json.dumps({"nodes": nodes}, indent=2))
+    elif args.command == "bootstrap":
+        await cmd_bootstrap(plan, args)
+    elif args.command == "down":
+        await cmd_down(plan, args)
     elif args.command == "diff":
         await cmd_diff(plan, args)
     elif args.command == "health":

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -172,5 +172,107 @@ class EastWestGroupTests(unittest.TestCase):
         )
 
 
+class BootstrapTests(unittest.TestCase):
+    def test_bootstrap_waits_for_dependencies_before_selected_node(self) -> None:
+        plan = ix_fleet.FleetPlan.model_validate(
+            fleet_plan(["db", "web"], [fleet_node("web", depends_on=["db"]), fleet_node("db")])
+        )
+        calls: list[str] = []
+
+        async def fake_bootstrap_node(node: ix_fleet.FleetNode, *, dry_run: bool) -> None:
+            self.assertFalse(dry_run)
+            calls.append(node.name)
+
+        with patch.object(ix_fleet, "bootstrap_node", fake_bootstrap_node):
+            args = argparse_namespace(on=["web"], dry_run=False)
+            asyncio.run(ix_fleet.cmd_bootstrap(plan, args))
+
+        self.assertEqual(calls, ["db", "web"])
+
+    def test_bootstrap_uses_bootstrap_image_without_replacement_push(self) -> None:
+        calls: list[list[str]] = []
+        ready: list[str] = []
+        node = ix_fleet.FleetNode.model_validate(fleet_node("api"))
+
+        async def fake_list_nodes() -> list[dict[str, typing.Any]]:
+            return []
+
+        async def fake_wait_node_ready(node: ix_fleet.FleetNode, *, dry_run: bool) -> None:
+            self.assertFalse(dry_run)
+            ready.append(node.name)
+
+        def fake_run_cli(command: list[str], *, dry_run: bool, timeout: int | None = None) -> str:
+            del timeout
+            self.assertFalse(dry_run)
+            calls.append(command)
+            return ""
+
+        with (
+            patch.object(ix_fleet, "list_nodes", fake_list_nodes),
+            patch.object(ix_fleet, "run_cli", fake_run_cli),
+            patch.object(ix_fleet, "wait_node_ready", fake_wait_node_ready),
+        ):
+            asyncio.run(ix_fleet.bootstrap_node(node, dry_run=False))
+
+        self.assertEqual(
+            calls,
+            [
+                [
+                    "ix",
+                    "new",
+                    "registry.ix.dev/ix/base:latest",
+                    "--name",
+                    "api",
+                    "--region",
+                    "us-west-1",
+                    "--no-shell",
+                ],
+            ],
+        )
+        self.assertEqual(ready, ["api"])
+
+
+class DownTests(unittest.TestCase):
+    def test_down_continues_after_node_failure(self) -> None:
+        plan = ix_fleet.FleetPlan.model_validate(
+            fleet_plan(["db", "web"], [fleet_node("db"), fleet_node("web")])
+        )
+        calls: list[list[str]] = []
+
+        def fake_run_cli(command: list[str], *, dry_run: bool, timeout: int | None = None) -> str:
+            del dry_run, timeout
+            calls.append(command)
+            if command[-1] == "web":
+                raise ix_fleet.CliError(command, 1, "", "permission denied")
+            return ""
+
+        with patch.object(ix_fleet, "run_cli", fake_run_cli):
+            args = argparse_namespace(on=[], dry_run=False)
+            with self.assertRaisesRegex(RuntimeError, "web: command failed"):
+                asyncio.run(ix_fleet.cmd_down(plan, args))
+
+        self.assertEqual(
+            calls,
+            [
+                ["ix", "rm", "--force", "web"],
+                ["ix", "rm", "--force", "db"],
+            ],
+        )
+
+    def test_down_treats_missing_nodes_as_absent(self) -> None:
+        node = ix_fleet.FleetNode.model_validate(fleet_node("api"))
+
+        def fake_run_cli(command: list[str], *, dry_run: bool, timeout: int | None = None) -> str:
+            del dry_run, timeout
+            raise ix_fleet.CliError(command, 1, "", "VM not found")
+
+        with patch.object(ix_fleet, "run_cli", fake_run_cli):
+            asyncio.run(ix_fleet.remove_node(node, dry_run=False))
+
+
+def argparse_namespace(**kwargs: typing.Any) -> typing.Any:
+    return type("Args", (), kwargs)()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2701,6 +2701,14 @@ let
         message = "fleet wrappers should expose an ix-fleet health command";
       }
       {
+        assertion = fleet.bootstrap.meta.mainProgram == "ix-fleet-bootstrap";
+        message = "fleet wrappers should expose an ix-fleet bootstrap command";
+      }
+      {
+        assertion = fleet.down.meta.mainProgram == "ix-fleet-down";
+        message = "fleet wrappers should expose an ix-fleet down command";
+      }
+      {
         assertion = !fleetIpv4HealthCheckEval.success;
         message = "fleet plans should reject host-side IPv4 checks on private nodes";
       }


### PR DESCRIPTION
feat(fleet): add bootstrap and down verbs

ENG-1605 needs deploy-test to reuse the generic fleet create and cleanup path without invoking replacement-image pushes or switches. This adds ix-fleet bootstrap, which creates selected nodes from their bootstrap image, waits for node readiness, and preserves dependency ordering while allowing independent nodes in a batch to run concurrently.

This also adds ix-fleet down, which removes selected nodes in reverse plan order, treats already-missing nodes as absent, and continues cleanup across nodes before returning one failure if any removal failed.

Validation:
- nix shell --impure --expr 'with import <nixpkgs> {}; python313.withPackages (ps: [ ps.pydantic ])' -c env PYTHONPATH=packages/ix-fleet/src python -m unittest packages/ix-fleet/tests/test_ix_fleet.py
- nix eval .#checks.x86_64-linux.eval.name

Note: nix build .#checks.x86_64-linux.eval cannot run on this aarch64 host because Nix refuses to build the x86_64 cargo vendor derivation locally.
