### PR TITLE
Revert "platform: cross build znver5 image closures (#108)"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,9 +27,17 @@ jobs:
       - name: Install Determinate Nix
         uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3
         with:
+          # Every image in this repo pins `nixpkgs.hostPlatform.gcc.arch =
+          # "znver5"`, which marks each derivation as needing the
+          # `gccarch-znver5` system feature. GitHub runners don't advertise
+          # that feature by default, so flake-check fails with
+          # `missing system features ... Required features: {gccarch-znver5}`
+          # before evaluating any image.
+          #
           # `accept-flake-config` lets CI consume the flake's `nixConfig`
           # (the Cachix substituter) without an interactive prompt.
           extra-conf: |
+            extra-system-features = gccarch-znver5
             accept-flake-config = true
 
       # Configures the indexable-inc Cachix substituter for the daemon and

--- a/lib/ix-platform.nix
+++ b/lib/ix-platform.nix
@@ -1,12 +1,10 @@
 # Target platform applied to every image.
 #
-# All images run on EPYC Gen 5 (Turin, Zen 5). The build platform stays
-# generic x86_64-linux so CI can execute build-time tools, while
-# hostPlatform.gcc.arch propagates -march=znver5 -mtune=znver5 to the image
-# closure. The upstream nixpkgs cache (generic x86_64) never hits; the
-# repo's own indexable-inc.cachix.org substituter, wired in flake.nix,
-# serves the znver5 closures CI has already built, with from-source as the
-# fallback.
+# All images run on EPYC Gen 5 (Turin, Zen 5). Setting hostPlatform.gcc.arch
+# propagates -march=znver5 -mtune=znver5 to the image closure. The upstream
+# nixpkgs cache is generic x86_64 and never has a hit; the repo's own
+# indexable-inc.cachix.org substituter, wired in flake.nix, serves the znver5
+# closures CI has already built, with from-source as the fallback.
 {
   config,
   lib,
@@ -233,14 +231,11 @@ in
       }
     ];
 
-    nixpkgs = {
-      buildPlatform = "x86_64-linux";
-      hostPlatform = {
-        system = "x86_64-linux";
-        gcc = {
-          arch = "znver5";
-          tune = "znver5";
-        };
+    nixpkgs.hostPlatform = {
+      system = "x86_64-linux";
+      gcc = {
+        arch = "znver5";
+        tune = "znver5";
       };
     };
 


### PR DESCRIPTION
Setting up cross compile means that packages from upstream package cache are not used, even when compiling on a znver5 host.

This reverts commit 022d22855f46415234696437efff7ee89fa3fdd1.