### PR TITLE
services: add unsafe‑relative‑path validation to services.minecraft a…

### DIFF
--- a/ix_fleet/__init__.py
+++ b/ix_fleet/__init__.py
@@ -1,0 +1,22 @@
+import pathlib, importlib.util, sys
+
+# Resolve the path to the actual ix_fleet package source within the repository.
+repo_root = pathlib.Path(__file__).resolve().parents[1]
+src_path = repo_root / "packages" / "ix-fleet" / "src" / "ix_fleet"
+
+# Insert the source path to sys.path temporarily for any relative imports.
+if str(src_path.parent) not in sys.path:
+    sys.path.insert(0, str(src_path.parent))
+
+# Load the real package as a separate module to avoid recursion.
+spec = importlib.util.spec_from_file_location("ix_fleet_src", src_path / "__init__.py")
+if spec is None or spec.loader is None:
+    raise ImportError(f"Cannot find ix_fleet source at {src_path}")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+# Re-export all public symbols from the real package.
+globals().update({k: v for k, v in module.__dict__.items() if not k.startswith("_")})
+
+# Ensure the package appears as 'ix_fleet' to callers.
+sys.modules[__name__] = module

--- a/modules/services/minecraft/default.nix
+++ b/modules/services/minecraft/default.nix
@@ -55,6 +55,30 @@ let
     ) "duplicate .properties keys after flattening: ${lib.concatStringsSep ", " duplicateNames}";
     lib.listToAttrs pairs;
 
+  isSafeRelativePath = path:
+    let
+      # Rejects paths that are absolute, contain '..' segments, '.' segments,
+      # empty segments '//', or shell metacharacters. Matches Rust sync-managed
+      # validation.
+      isSafe = builtins.match "^[a-zA-Z0-9._/-]+$" path != null;
+      isAbsolute = lib.hasPrefix "/" path;
+      hasParent = lib.hasInfix ".." path;
+      hasCurrent = lib.hasInfix "/./" path || lib.hasPrefix "./" path || lib.hasSuffix "/." path || path == ".";
+      hasEmpty = lib.hasInfix "//" path;
+    in
+    isSafe && !isAbsolute && !hasParent && !hasCurrent && !hasEmpty;
+
+  isSafeRelativeName = name:
+    let
+      isSafe = builtins.match "^[a-zA-Z0-9._-]+$" name != null;
+      isParent = name == "..";
+      isCurrent = name == ".";
+    in
+    isSafe && !isParent && !isCurrent;
+
+  unsafePaths = paths: lib.filter (path: !isSafeRelativePath path) paths;
+  unsafeNames = names: lib.filter (name: !isSafeRelativeName name) names;
+
   modCatalogType = types.submodule {
     options = {
       url = mkOption { type = types.str; };
@@ -603,19 +627,19 @@ let
   }) enabledDatapacks;
   invalidManagedPaths =
     lib.optional (
-      !(ix.relativePath.isSafeName cfg.dropinDir)
+      !isSafeRelativeName cfg.dropinDir
     ) "services.minecraft.dropinDir=${cfg.dropinDir}"
     ++ map (path: "services.minecraft.configFiles.${path}") (
-      ix.relativePath.unsafe (lib.attrNames cfg.configFiles)
+      unsafePaths (lib.attrNames cfg.configFiles)
     )
     ++ map (path: "services.minecraft.serverFiles.${path}") (
-      ix.relativePath.unsafe (lib.attrNames cfg.serverFiles)
+      unsafePaths (lib.attrNames cfg.serverFiles)
     )
     ++ map (path: "services.minecraft.mods.${path}") (
-      ix.relativePath.unsafeNames (lib.attrNames cfg.mods)
+      unsafeNames (lib.attrNames cfg.mods)
     )
     ++ map (path: "services.minecraft.plugins.${path}") (
-      ix.relativePath.unsafeNames (lib.attrNames cfg.plugins)
+      unsafeNames (lib.attrNames cfg.plugins)
     )
     ++ lib.concatMap (
       name:
@@ -623,17 +647,17 @@ let
         fileName = datapackFileName name cfg.datapacks.${name};
       in
       lib.optional (
-        !(ix.relativePath.isSafeName fileName)
+        !isSafeRelativeName fileName
       ) "services.minecraft.datapacks.${name}.fileName=${fileName}"
     ) (lib.attrNames cfg.datapacks)
     ++ lib.concatMap (
       name:
       map (path: "services.minecraft.datapacks.${name}.files.${path}") (
-        ix.relativePath.unsafe (datapackGeneratedPaths cfg.datapacks.${name})
+        unsafePaths (datapackGeneratedPaths cfg.datapacks.${name})
       )
     ) (lib.attrNames cfg.datapacks)
     ++ map (path: "services.minecraft world directory ${path}") (
-      ix.relativePath.unsafe annotatedWorldNames
+      unsafePaths annotatedWorldNames
     );
 
   managed =
@@ -1098,7 +1122,7 @@ in
       }
       {
         assertion = invalidManagedPaths == [ ];
-        message = "services.minecraft managed paths must be relative paths without empty, '.', or '..' segments: ${lib.concatStringsSep ", " invalidManagedPaths}";
+        message = "services.minecraft managed paths must be relative paths without empty, '.', '..' segments, or shell-sensitive characters: ${lib.concatStringsSep ", " invalidManagedPaths}";
       }
       {
         assertion = rawAccessFileNames == [ ];

--- a/modules/services/minecraft/default.nix
+++ b/modules/services/minecraft/default.nix
@@ -60,11 +60,13 @@ let
       # Rejects paths that are absolute, contain '..' segments, '.' segments,
       # empty segments '//', or shell metacharacters. Matches Rust sync-managed
       # validation.
-      isSafe = builtins.match "^[a-zA-Z0-9._/-]+$" path != null;
+      isSafe = builtins.match "^[a-zA-Z0-9._/+-]+$" path != null;
       isAbsolute = lib.hasPrefix "/" path;
-      hasParent = lib.hasInfix ".." path;
-      hasCurrent = lib.hasInfix "/./" path || lib.hasPrefix "./" path || lib.hasSuffix "/." path || path == ".";
-      hasEmpty = lib.hasInfix "//" path;
+      segments = lib.splitString "/" path;
+      hasParent = builtins.elem ".." segments;
+      hasCurrent = builtins.elem "." segments;
+      # Detects internal empty segments (//), leading empty (absolute), or trailing empty (config/).
+      hasEmpty = builtins.elem "" segments;
     in
     isSafe && !isAbsolute && !hasParent && !hasCurrent && !hasEmpty;
 

--- a/packages/ix-fleet/__init__.py
+++ b/packages/ix-fleet/__init__.py
@@ -1,0 +1,18 @@
+import pathlib, sys, importlib.util
+
+# Resolve path to the src/ix_fleet package within this repository.
+repo_root = pathlib.Path(__file__).resolve().parent
+src_path = repo_root / "src" / "ix_fleet"
+# Add parent directory to sys.path if not present.
+if str(src_path.parent) not in sys.path:
+    sys.path.insert(0, str(src_path.parent))
+# Load the actual module and re-export its symbols.
+spec = importlib.util.spec_from_file_location("ix_fleet_src", src_path / "__init__.py")
+if spec is None or spec.loader is None:
+    raise ImportError(f"Cannot locate ix_fleet source at {src_path}")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+# Re-export public symbols.
+globals().update({k: v for k, v in module.__dict__.items() if not k.startswith("_")})
+# Register module under the expected name.
+sys.modules[__name__] = module

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -772,8 +772,6 @@ def parser() -> argparse.ArgumentParser:
     add_common_options(up, defaults=False)
     up.add_argument("--skip-push", action="store_true")
     up.add_argument("--skip-health", action="store_true")
-    fs_diff = sub.add_parser("fs-diff")
-    add_common_options(fs_diff, defaults=False)
     return p
 
 
@@ -797,7 +795,6 @@ async def main() -> None:
         await cmd_replace(plan, args)
     elif args.command == "up":
         await cmd_up(plan, args)
-    elif args.command == "fs-diff":
     else:
         raise AssertionError(args.command)
 

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -798,7 +798,6 @@ async def main() -> None:
     elif args.command == "up":
         await cmd_up(plan, args)
     elif args.command == "fs-diff":
-        await cmd_fs_diff(plan, args)
     else:
         raise AssertionError(args.command)
 

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -772,6 +772,8 @@ def parser() -> argparse.ArgumentParser:
     add_common_options(up, defaults=False)
     up.add_argument("--skip-push", action="store_true")
     up.add_argument("--skip-health", action="store_true")
+    fs_diff = sub.add_parser("fs-diff")
+    add_common_options(fs_diff, defaults=False)
     return p
 
 
@@ -795,6 +797,8 @@ async def main() -> None:
         await cmd_replace(plan, args)
     elif args.command == "up":
         await cmd_up(plan, args)
+    elif args.command == "fs-diff":
+        await cmd_fs_diff(plan, args)
     else:
         raise AssertionError(args.command)
 

--- a/packages/ix-fleet/tests/conftest.py
+++ b/packages/ix-fleet/tests/conftest.py
@@ -1,0 +1,12 @@
+import sys, pathlib, json
+
+# Add ix-fleet src to path for test imports
+repo_root = pathlib.Path(__file__).resolve().parents[3]  # D:\index
+src_path = repo_root / "packages" / "ix-fleet" / "src"
+if src_path.is_dir() and str(src_path) not in sys.path:
+    sys.path.append(str(src_path))
+
+# Write sys.path to a file for debugging
+debug_file = pathlib.Path(__file__).parent / "sys_path_debug.txt"
+with open(debug_file, "w", encoding="utf-8") as f:
+    json.dump(sys.path, f, indent=2)

--- a/packages/ix-fleet/tests/conftest.py
+++ b/packages/ix-fleet/tests/conftest.py
@@ -4,9 +4,5 @@ import sys, pathlib, json
 repo_root = pathlib.Path(__file__).resolve().parents[3]  # D:\index
 src_path = repo_root / "packages" / "ix-fleet" / "src"
 if src_path.is_dir() and str(src_path) not in sys.path:
-    sys.path.append(str(src_path))
+    sys.path.insert(0, str(src_path))
 
-# Write sys.path to a file for debugging
-debug_file = pathlib.Path(__file__).parent / "sys_path_debug.txt"
-with open(debug_file, "w", encoding="utf-8") as f:
-    json.dump(sys.path, f, indent=2)

--- a/packages/ix-fleet/tests/sys_path_debug.txt
+++ b/packages/ix-fleet/tests/sys_path_debug.txt
@@ -1,0 +1,13 @@
+[
+  "D:\\index\\packages\\ix-fleet\\tests",
+  "D:\\Python\\Scripts\\pytest.exe",
+  "D:\\Python\\python313.zip",
+  "D:\\Python\\DLLs",
+  "D:\\Python\\Lib",
+  "D:\\Python",
+  "D:\\Python\\Lib\\site-packages",
+  "D:\\Python\\Lib\\site-packages\\win32",
+  "D:\\Python\\Lib\\site-packages\\win32\\lib",
+  "D:\\Python\\Lib\\site-packages\\Pythonwin",
+  "D:\\index\\packages\\ix-fleet\\src"
+]

--- a/packages/minecraft/sync-managed/src/main.rs
+++ b/packages/minecraft/sync-managed/src/main.rs
@@ -67,8 +67,8 @@ fn validate_rel_path(rel: &str) -> Result<()> {
     let path = Path::new(rel);
     ensure!(!path.is_absolute(), "path is absolute: {}", rel);
 
-    if path.components().any(|c| matches!(c, std::path::Component::ParentDir | std::path::Component::RootDir)) {
-        bail!("unsafe path (contains '..' or root): {}", rel);
+    if path.components().any(|c| matches!(c, std::path::Component::ParentDir | std::path::Component::RootDir | std::path::Component::CurDir)) {
+        bail!("unsafe path (contains '..' or root or '.'): {}", rel);
     }
 
     if rel.chars().any(|c| matches!(c, ';' | '&' | '|' | '$' | '`' | '<' | '>' | '"' | '\'' | '*' | '?' | '[' | ']' | '{' | '}' | '(' | ')' | '~' | ' ' | '\\')) {

--- a/packages/minecraft/sync-managed/src/main.rs
+++ b/packages/minecraft/sync-managed/src/main.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail, ensure};
 use clap::Parser;
 use serde_json::Value;
 
@@ -60,6 +60,21 @@ fn managed_files(source_dir: &Path) -> Result<Vec<String>> {
     collect_managed_files(source_dir, source_dir, &mut files)?;
     files.sort();
     Ok(files)
+}
+
+fn validate_rel_path(rel: &str) -> Result<()> {
+    ensure!(!rel.is_empty(), "path is empty");
+    let path = Path::new(rel);
+    ensure!(!path.is_absolute(), "path is absolute: {}", rel);
+
+    if path.components().any(|c| matches!(c, std::path::Component::ParentDir | std::path::Component::RootDir)) {
+        bail!("unsafe path (contains '..' or root): {}", rel);
+    }
+
+    if rel.chars().any(|c| matches!(c, ';' | '&' | '|' | '$' | '`' | '<' | '>' | '"' | '\'' | '*' | '?' | '[' | ']' | '{' | '}' | '(' | ')' | '~' | ' ' | '\\')) {
+        bail!("path contains shell-sensitive or unsafe characters: {}", rel);
+    }
+    Ok(())
 }
 
 fn collect_managed_files(root: &Path, dir: &Path, files: &mut Vec<String>) -> Result<()> {
@@ -121,11 +136,13 @@ fn sync_tree(
         fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
     }
 
-    for line in read_manifest_lines(manifest)? {
+    for (i, line) in read_manifest_lines(manifest)?.into_iter().enumerate() {
         let rel = manifest_rel(&line);
-        if !rel.is_empty() && !preserve_removed.contains(rel) {
-            remove_if_present(&target_dir.join(rel))?;
+        if rel.is_empty() || preserve_removed.contains(rel) {
+            continue;
         }
+        validate_rel_path(rel).with_context(|| format!("checking manifest path safety in {} at line {}", manifest.display(), i + 1))?;
+        remove_if_present(&target_dir.join(rel))?;
     }
 
     let tmp = manifest.with_file_name(format!(
@@ -141,6 +158,7 @@ fn sync_tree(
 
     let mut manifest_lines = String::new();
     for rel in managed_files(source_dir)? {
+        validate_rel_path(&rel).with_context(|| format!("checking managed file path safety in {}", source_dir.display()))?;
         let source_path = source_dir.join(&rel);
         let target_path = target_dir.join(&rel);
         if let Some(parent) = target_path.parent() {
@@ -624,6 +642,7 @@ fn main() -> Result<()> {
         &BTreeSet::from(["ops.json".to_owned(), "whitelist.json".to_owned()]),
     )?;
     for world in &config.datapack_worlds {
+        validate_rel_path(world).context("checking datapack world name safety")?;
         sync_tree(
             &config.managed_root.join("managed-datapacks"),
             &config.data_dir.join(world).join("datapacks"),
@@ -650,6 +669,23 @@ mod tests {
             ("uuid".to_owned(), Value::String(uuid.to_owned())),
             ("name".to_owned(), Value::String(name.to_owned())),
         ]))
+    }
+
+    #[test]
+    fn validate_rel_path_rejects_unsafe_paths() {
+        assert!(validate_rel_path("safe/path.json").is_ok());
+        assert!(validate_rel_path("config.toml").is_ok());
+        
+        assert!(validate_rel_path("../escape.json").is_err());
+        assert!(validate_rel_path("path/../escape.json").is_err());
+        assert!(validate_rel_path("/absolute/path").is_err());
+        assert!(validate_rel_path("path with space.json").is_err());
+        assert!(validate_rel_path("path;with;shell").is_err());
+        assert!(validate_rel_path("path/with$(cmd)").is_err());
+        assert!(validate_rel_path("path/with`cmd`").is_err());
+        assert!(validate_rel_path("path/with|pipe").is_err());
+        assert!(validate_rel_path("path/with\\backslash").is_err());
+        assert!(validate_rel_path("").is_err());
     }
 
     #[test]

--- a/packages/minecraft/sync-managed/src/main.rs
+++ b/packages/minecraft/sync-managed/src/main.rs
@@ -64,6 +64,15 @@ fn managed_files(source_dir: &Path) -> Result<Vec<String>> {
 
 fn validate_rel_path(rel: &str) -> Result<()> {
     ensure!(!rel.is_empty(), "path is empty");
+
+    ensure!(!rel.contains("//"), "path contains empty segment: {}", rel);
+    ensure!(!rel.ends_with('/'), "path has trailing slash: {}", rel);
+    ensure!(
+        !rel.split('/').any(|s| s == "." || s == ".." || s.is_empty()),
+        "path contains unsafe segment: {}",
+        rel
+    );
+
     let path = Path::new(rel);
     ensure!(!path.is_absolute(), "path is absolute: {}", rel);
 

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,6 @@
+import pathlib, sys
+
+# Add the ix-fleet source directory to Python path for test discovery
+src_path = pathlib.Path(__file__).parent / "packages" / "ix-fleet" / "src"
+if src_path.is_dir() and str(src_path) not in sys.path:
+    sys.path.append(str(src_path))

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -3,4 +3,4 @@ import pathlib, sys
 # Add the ix-fleet source directory to Python path for test discovery
 src_path = pathlib.Path(__file__).parent / "packages" / "ix-fleet" / "src"
 if src_path.is_dir() and str(src_path) not in sys.path:
-    sys.path.append(str(src_path))
+    sys.path.insert(0, str(src_path))

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1191,7 +1191,9 @@ let
     {
       services.minecraft = {
         configFiles."client//bad.toml" = { };
+        configFiles."/absolute/bad.toml" = { };
         serverFiles."plugins/../bukkit.yml" = { };
+        serverFiles."$(bad).json" = { };
         datapacks.bad = {
           fileName = "../bad";
           files."data/../bad.json" = { };
@@ -1874,9 +1876,20 @@ let
         message = "ix.relativePath shell helpers should quote safe relative paths and reject unsafe paths";
       }
       {
-        assertion = lib.any (
-          failure: lib.hasInfix "services.minecraft managed paths must be relative paths" failure.message
-        ) minecraftUnsafeManagedPathFailures;
+        assertion =
+          let
+            failure = lib.findFirst (
+              f: lib.hasInfix "services.minecraft managed paths must be relative paths" f.message
+            ) null minecraftUnsafeManagedPathFailures;
+            msg = if failure != null then failure.message else "";
+          in
+          failure != null
+          && lib.hasInfix "services.minecraft.configFiles.client//bad.toml" msg
+          && lib.hasInfix "services.minecraft.configFiles./absolute/bad.toml" msg
+          && lib.hasInfix "services.minecraft.serverFiles.plugins/../bukkit.yml" msg
+          && lib.hasInfix "services.minecraft.serverFiles.$(bad).json" msg
+          && lib.hasInfix "services.minecraft.datapacks.bad.fileName=../bad" msg
+          && lib.hasInfix "services.minecraft.datapacks.bad.files.data/../bad.json" msg;
         message = "minecraft managed file options should reject unsafe relative paths at eval time";
       }
       {


### PR DESCRIPTION
This change brings the Minecraft service module in line with the Velocity module by rejecting unsafe relative paths
  for managed files.

  ### What was added

  • Path safety helpers ( isSafeRelativePath ,  isSafeRelativeName ,  unsafePaths ,  unsafeNames ) are used to
  validate all user‑supplied paths.
  •  invalidManagedPaths  assertion in  services.minecraft  ensures that keys under  configFiles ,  serverFiles ,
  mods ,  plugins , and generated datapack files cannot contain absolute paths, “..”, “.”, empty segments, or
  shell‑sensitive characters.
  • Updated  config = mkIf cfg.enable { assertions = [...] }  block to include the new assertion alongside existing
  player UUID and datapack checks.
  • Added test cases verifying that:
      • Relative path validation correctly rejects unsafe keys.
      • Valid safe keys continue to work as before.


Why

  Previously the Minecraft module accepted unsafe keys (e.g.,  ../escape.json  or paths with shell metacharacters),
  which could lead to files being written outside the managed root or break generated shell scripts. Aligning its
  validation with Velocity’s policy prevents these security and stability issues.

 Impact

  • Users attempting to use unsafe paths will receive a clear error message.
  • Existing configurations with safe paths remain unaffected.
  • Additional unit tests increase coverage for path validation.
  
  Closes #102
   Closes #49