### PR TITLE
ci: add Codex review gate

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -14,6 +14,11 @@ on:
       - submitted
       - edited
       - dismissed
+  pull_request_review_comment:
+    types:
+      - created
+      - edited
+      - deleted
   issue_comment:
     types:
       - created

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -20,7 +20,6 @@ on:
       - edited
 
 permissions:
-  checks: read
   contents: read
   issues: read
   pull-requests: read
@@ -45,17 +44,6 @@ jobs:
 
           pr_json="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
           head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
-          check_runs_json="$(gh api "repos/${REPO}/commits/${head_sha}/check-runs")"
-          head_checked_at="$(
-            jq -r '
-              [
-                .check_runs[]
-                | (.started_at // .created_at)
-                | select(. != null)
-              ]
-              | min // empty
-            ' <<<"$check_runs_json"
-          )"
 
           reviews_json="$(
             gh api --paginate --slurp \
@@ -89,19 +77,13 @@ jobs:
           )"
 
           matching_comment="$(
-            jq --arg head "$head_sha" --arg head_checked_at "$head_checked_at" -c '
+            jq --arg head "$head_sha" -c '
               [
                 .[][]
                 | select(
                     (.user.login == "chatgpt-codex-connector[bot]" or .user.login == "chatgpt-codex-connector")
-                    and (
-                      ((.body | test("Codex Review|Reviewed commit"; "i")) and (.body | contains($head)))
-                      or (
-                        (.body | startswith("Codex Review: Didn'\''t find any major issues."))
-                        and $head_checked_at != ""
-                        and .created_at >= $head_checked_at
-                      )
-                    )
+                    and (.body | test("Codex Review|Reviewed commit"; "i"))
+                    and (.body | contains($head))
                   )
               ][0] // empty
             ' <<<"$comments_json"
@@ -119,7 +101,7 @@ jobs:
             echo
             echo "No review from \`chatgpt-codex-connector[bot]\` was found for PR #${PR_NUMBER} at \`${head_sha}\`."
             echo
-            echo "Wait for automatic Codex review or comment \`@codex review\`, then rerun this check if GitHub does not rerun it automatically."
+            echo "Wait for automatic Codex review or comment \`@codex review\`, then rerun this check if GitHub does not rerun it automatically. A no-findings Codex comment only satisfies this gate when it names the exact head SHA."
           } >>"$GITHUB_STEP_SUMMARY"
 
           exit 1

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -252,12 +252,52 @@ jobs:
             exit 0
           fi
 
+          matching_requested_comment="$(
+            jq --arg head "$head_sha" -c '
+              def is_codex:
+                .user.login == "chatgpt-codex-connector[bot]"
+                or .user.login == "chatgpt-codex-connector";
+              def is_review_request:
+                .body | test("@codex[[:space:]]+review"; "i");
+              def is_no_findings:
+                is_codex
+                and (.body | test("Codex Review"; "i"))
+                and (.body | test("didn.?t find any major issues"; "i"));
+
+              [ .[][] ] as $comments
+              | [
+                  range(0; $comments | length) as $i
+                  | $comments[$i]
+                  | select(is_no_findings)
+                  | . as $response
+                  | (
+                      [
+                        range(0; $i) as $j
+                        | $comments[$j]
+                        | select((is_codex | not) and is_review_request)
+                      ]
+                      | last
+                    ) as $request
+                  | select($request != null and ($request.body | contains($head)))
+                  | {request: $request, response: $response}
+                ][-1] // empty
+            ' <<<"$comments_json"
+          )"
+
+          if [[ -n "$matching_requested_comment" ]]; then
+            commenter="$(jq -r '.response.user.login' <<<"$matching_requested_comment")"
+            created_at="$(jq -r '.response.created_at' <<<"$matching_requested_comment")"
+            request_created_at="$(jq -r '.request.created_at' <<<"$matching_requested_comment")"
+            echo "Found no-findings Codex response from ${commenter} for ${head_sha} at ${created_at}, after a SHA-specific request at ${request_created_at}."
+            exit 0
+          fi
+
           {
             echo "## Codex review required"
             echo
             echo "No review from \`chatgpt-codex-connector[bot]\` was found for PR #${PR_NUMBER} at \`${head_sha}\`."
             echo
-            echo "Wait for automatic Codex review or comment \`@codex review\`, then rerun this check if GitHub does not rerun it automatically. A no-findings Codex comment only satisfies this gate when it names the exact head SHA."
+            echo "Wait for automatic Codex review or comment \`@codex review head ${head_sha}\`, then rerun this check if GitHub does not rerun it automatically. A no-findings Codex comment only satisfies this gate when the latest review request before it names the exact head SHA."
           } >>"$GITHUB_STEP_SUMMARY"
 
           exit 1

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -1,0 +1,107 @@
+name: Codex review gate
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+      - dismissed
+  issue_comment:
+    types:
+      - created
+      - edited
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: codex-review-gate-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  codex-review:
+    name: chatgpt-codex-connector reviewed head
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify Codex reviewed the current head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          pr_json="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
+          head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+
+          reviews_json="$(
+            gh api --paginate --slurp \
+              "repos/${REPO}/pulls/${PR_NUMBER}/reviews"
+          )"
+
+          matching_review="$(
+            jq --arg head "$head_sha" -c '
+              [
+                .[][]
+                | select(
+                    (.user.login == "chatgpt-codex-connector[bot]" or .user.login == "chatgpt-codex-connector")
+                    and .commit_id == $head
+                    and .state != "PENDING"
+                  )
+              ][0] // empty
+            ' <<<"$reviews_json"
+          )"
+
+          if [[ -n "$matching_review" ]]; then
+            reviewer="$(jq -r '.user.login' <<<"$matching_review")"
+            state="$(jq -r '.state' <<<"$matching_review")"
+            submitted_at="$(jq -r '.submitted_at' <<<"$matching_review")"
+            echo "Found ${state} review from ${reviewer} for ${head_sha} at ${submitted_at}."
+            exit 0
+          fi
+
+          comments_json="$(
+            gh api --paginate --slurp \
+              "repos/${REPO}/issues/${PR_NUMBER}/comments"
+          )"
+
+          matching_comment="$(
+            jq --arg head "$head_sha" -c '
+              [
+                .[][]
+                | select(
+                    (.user.login == "chatgpt-codex-connector[bot]" or .user.login == "chatgpt-codex-connector")
+                    and (.body | test("Codex Review|Reviewed commit"; "i"))
+                    and (.body | contains($head))
+                  )
+              ][0] // empty
+            ' <<<"$comments_json"
+          )"
+
+          if [[ -n "$matching_comment" ]]; then
+            commenter="$(jq -r '.user.login' <<<"$matching_comment")"
+            created_at="$(jq -r '.created_at' <<<"$matching_comment")"
+            echo "Found Codex review comment from ${commenter} for ${head_sha} at ${created_at}."
+            exit 0
+          fi
+
+          {
+            echo "## Codex review required"
+            echo
+            echo "No review from \`chatgpt-codex-connector[bot]\` was found for PR #${PR_NUMBER} at \`${head_sha}\`."
+            echo
+            echo "Wait for automatic Codex review or comment \`@codex review\`, then rerun this check if GitHub does not rerun it automatically."
+          } >>"$GITHUB_STEP_SUMMARY"
+
+          exit 1

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -20,6 +20,7 @@ on:
       - edited
 
 permissions:
+  checks: read
   contents: read
   issues: read
   pull-requests: read
@@ -44,8 +45,17 @@ jobs:
 
           pr_json="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
           head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
-          head_json="$(gh api "repos/${REPO}/commits/${head_sha}")"
-          head_committed_at="$(jq -r '.commit.committer.date' <<<"$head_json")"
+          check_runs_json="$(gh api "repos/${REPO}/commits/${head_sha}/check-runs")"
+          head_checked_at="$(
+            jq -r '
+              [
+                .check_runs[]
+                | (.started_at // .created_at)
+                | select(. != null)
+              ]
+              | min // empty
+            ' <<<"$check_runs_json"
+          )"
 
           reviews_json="$(
             gh api --paginate --slurp \
@@ -79,7 +89,7 @@ jobs:
           )"
 
           matching_comment="$(
-            jq --arg head "$head_sha" --arg head_committed_at "$head_committed_at" -c '
+            jq --arg head "$head_sha" --arg head_checked_at "$head_checked_at" -c '
               [
                 .[][]
                 | select(
@@ -88,7 +98,8 @@ jobs:
                       ((.body | test("Codex Review|Reviewed commit"; "i")) and (.body | contains($head)))
                       or (
                         (.body | startswith("Codex Review: Didn'\''t find any major issues."))
-                        and .created_at >= $head_committed_at
+                        and $head_checked_at != ""
+                        and .created_at >= $head_checked_at
                       )
                     )
                   )

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -44,6 +44,70 @@ jobs:
 
           pr_json="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
           head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+          owner="${REPO%%/*}"
+          repo_name="${REPO#*/}"
+          threads_query="$(
+            cat <<'GRAPHQL'
+          query($owner: String!, $repo: String!, $number: Int!) {
+            repository(owner: $owner, name: $repo) {
+              pullRequest(number: $number) {
+                reviewThreads(first: 100) {
+                  nodes {
+                    id
+                    isResolved
+                    isOutdated
+                    comments(first: 20) {
+                      nodes {
+                        author { login }
+                        body
+                        url
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          GRAPHQL
+          )"
+
+          threads_json="$(
+            gh api graphql \
+              -f owner="$owner" \
+              -f repo="$repo_name" \
+              -F number="$PR_NUMBER" \
+              -f query="$threads_query"
+          )"
+
+          unresolved_codex_threads="$(
+            jq -c '
+              [
+                .data.repository.pullRequest.reviewThreads.nodes[]
+                | select(.isResolved == false)
+                | select(
+                    [
+                      .comments.nodes[].author.login
+                    ]
+                    | any(. == "chatgpt-codex-connector[bot]" or . == "chatgpt-codex-connector")
+                  )
+              ]
+            ' <<<"$threads_json"
+          )"
+
+          if jq -e 'length > 0' <<<"$unresolved_codex_threads" >/dev/null; then
+            {
+              echo "## Resolve Codex review threads"
+              echo
+              echo "Codex has unresolved review feedback on this PR. Fix or intentionally resolve every thread before this gate can pass."
+              echo
+              jq -r '
+                .[]
+                | "- " + (.comments.nodes[-1].url // .id)
+              ' <<<"$unresolved_codex_threads"
+            } >>"$GITHUB_STEP_SUMMARY"
+
+            exit 1
+          fi
 
           reviews_json="$(
             gh api --paginate --slurp \

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -57,7 +57,7 @@ jobs:
                 | select(
                     (.user.login == "chatgpt-codex-connector[bot]" or .user.login == "chatgpt-codex-connector")
                     and .commit_id == $head
-                    and .state != "PENDING"
+                    and (.state == "COMMENTED" or .state == "APPROVED" or .state == "CHANGES_REQUESTED")
                   )
               ][0] // empty
             ' <<<"$reviews_json"

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -44,6 +44,8 @@ jobs:
 
           pr_json="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
           head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+          head_json="$(gh api "repos/${REPO}/commits/${head_sha}")"
+          head_committed_at="$(jq -r '.commit.committer.date' <<<"$head_json")"
 
           reviews_json="$(
             gh api --paginate --slurp \
@@ -77,13 +79,18 @@ jobs:
           )"
 
           matching_comment="$(
-            jq --arg head "$head_sha" -c '
+            jq --arg head "$head_sha" --arg head_committed_at "$head_committed_at" -c '
               [
                 .[][]
                 | select(
                     (.user.login == "chatgpt-codex-connector[bot]" or .user.login == "chatgpt-codex-connector")
-                    and (.body | test("Codex Review|Reviewed commit"; "i"))
-                    and (.body | contains($head))
+                    and (
+                      ((.body | test("Codex Review|Reviewed commit"; "i")) and (.body | contains($head)))
+                      or (
+                        (.body | startswith("Codex Review: Didn'\''t find any major issues."))
+                        and .created_at >= $head_committed_at
+                      )
+                    )
                   )
               ][0] // empty
             ' <<<"$comments_json"

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -18,6 +18,7 @@ on:
     types:
       - created
       - edited
+      - deleted
 
 permissions:
   contents: read
@@ -46,20 +47,26 @@ jobs:
           head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
           owner="${REPO%%/*}"
           repo_name="${REPO#*/}"
+          codex_logins='["chatgpt-codex-connector[bot]","chatgpt-codex-connector"]'
           threads_query="$(
             cat <<'GRAPHQL'
-          query($owner: String!, $repo: String!, $number: Int!) {
+          query($owner: String!, $repo: String!, $number: Int!, $after: String) {
             repository(owner: $owner, name: $repo) {
               pullRequest(number: $number) {
-                reviewThreads(first: 100) {
+                reviewThreads(first: 100, after: $after) {
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
                   nodes {
                     id
                     isResolved
-                    isOutdated
-                    comments(first: 20) {
+                    comments(first: 100) {
+                      pageInfo {
+                        hasNextPage
+                      }
                       nodes {
                         author { login }
-                        body
                         url
                       }
                     }
@@ -70,40 +77,125 @@ jobs:
           }
           GRAPHQL
           )"
-
-          threads_json="$(
-            gh api graphql \
-              -f owner="$owner" \
-              -f repo="$repo_name" \
-              -F number="$PR_NUMBER" \
-              -f query="$threads_query"
+          comments_query="$(
+            cat <<'GRAPHQL'
+          query($threadId: ID!, $after: String) {
+            node(id: $threadId) {
+              ... on PullRequestReviewThread {
+                comments(first: 100, after: $after) {
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
+                  nodes {
+                    author { login }
+                    url
+                  }
+                }
+              }
+            }
+          }
+          GRAPHQL
           )"
 
-          unresolved_codex_threads="$(
-            jq -c '
-              [
+          find_codex_comment_url() {
+            local thread_id="$1"
+            local after=""
+            local comments_json
+            local url
+
+            while true; do
+              local args=(-f threadId="$thread_id" -f query="$comments_query")
+              if [[ -n "$after" ]]; then
+                args+=(-f after="$after")
+              fi
+
+              comments_json="$(gh api graphql "${args[@]}")"
+              url="$(
+                jq -r --argjson codexLogins "$codex_logins" '
+                  [
+                    .data.node.comments.nodes[]?
+                    | select(.author.login as $login | $codexLogins | index($login))
+                    | .url
+                  ][0] // empty
+                ' <<<"$comments_json"
+              )"
+
+              if [[ -n "$url" ]]; then
+                printf '%s\n' "$url"
+                return 0
+              fi
+
+              if [[ "$(jq -r '.data.node.comments.pageInfo.hasNextPage' <<<"$comments_json")" != "true" ]]; then
+                return 1
+              fi
+
+              after="$(jq -r '.data.node.comments.pageInfo.endCursor' <<<"$comments_json")"
+            done
+          }
+
+          unresolved_codex_threads=()
+          after=""
+          while true; do
+            args=(
+              -f owner="$owner"
+              -f repo="$repo_name"
+              -F number="$PR_NUMBER"
+              -f query="$threads_query"
+            )
+            if [[ -n "$after" ]]; then
+              args+=(-f after="$after")
+            fi
+
+            threads_json="$(gh api graphql "${args[@]}")"
+
+            while IFS= read -r thread_json; do
+              thread_id="$(jq -r '.id' <<<"$thread_json")"
+              first_codex_url="$(jq -r '.firstCodexUrl // empty' <<<"$thread_json")"
+              has_more_comments="$(jq -r '.hasMoreComments' <<<"$thread_json")"
+
+              if [[ -n "$first_codex_url" ]]; then
+                unresolved_codex_threads+=("$first_codex_url")
+                continue
+              fi
+
+              if [[ "$has_more_comments" == "true" ]]; then
+                if url="$(find_codex_comment_url "$thread_id")"; then
+                  unresolved_codex_threads+=("$url")
+                fi
+              fi
+            done < <(
+              jq -c --argjson codexLogins "$codex_logins" '
                 .data.repository.pullRequest.reviewThreads.nodes[]
                 | select(.isResolved == false)
-                | select(
-                    [
-                      .comments.nodes[].author.login
-                    ]
-                    | any(. == "chatgpt-codex-connector[bot]" or . == "chatgpt-codex-connector")
-                  )
-              ]
-            ' <<<"$threads_json"
-          )"
+                | {
+                    id,
+                    firstCodexUrl: (
+                      [
+                        .comments.nodes[]?
+                        | select(.author.login as $login | $codexLogins | index($login))
+                        | .url
+                      ][0] // ""
+                    ),
+                    hasMoreComments: .comments.pageInfo.hasNextPage
+                  }
+              ' <<<"$threads_json"
+            )
 
-          if jq -e 'length > 0' <<<"$unresolved_codex_threads" >/dev/null; then
+            if [[ "$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"$threads_json")" != "true" ]]; then
+              break
+            fi
+
+            after="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<<"$threads_json")"
+          done
+
+          if ((${#unresolved_codex_threads[@]} > 0)); then
             {
               echo "## Resolve Codex review threads"
               echo
               echo "Codex has unresolved review feedback on this PR. Fix or intentionally resolve every thread before this gate can pass."
               echo
-              jq -r '
-                .[]
-                | "- " + (.comments.nodes[-1].url // .id)
-              ' <<<"$unresolved_codex_threads"
+              printf -- '- %s\n' "${unresolved_codex_threads[@]}"
             } >>"$GITHUB_STEP_SUMMARY"
 
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,19 @@ If the shared checkout already has unrelated edits, name the paths and the one
 line summary of what they appear to be doing before creating the new worktree.
 Avoid stashing operator work out of the way.
 
-After local checks pass, push the branch and open a PR targeting `main`. Enable
-auto-merge when branch protection and review state allow it. Remove the worktree
-and delete the local branch after the PR has merged.
+After local checks pass, push the branch and open a PR targeting `main`. Watch
+required checks with `gh pr checks --watch --fail-fast`; if a check fails,
+inspect the run logs, fix the branch, push again, and keep watching until the PR
+is green.
+
+Treat PR comments and reviews as part of the work. Read them with
+`gh pr view --comments` and the review fields from `gh pr view --json reviews`.
+Address Codex comments in code when they identify a real issue, reply when a
+comment is intentionally declined, and resolve review threads before enabling
+auto-merge. Enable auto-merge only after required checks pass and required
+review state is clear.
+
+Remove the worktree and delete the local branch after the PR has merged.
 
 Commit one logical change at a time. Use the pathspec form so unrelated staged
 or unstaged files cannot ride along:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,11 @@ with the GitHub review-thread API, then request a fresh Codex review if the head
 changed. If the head did not change and GitHub does not rerun the failed gate,
 rerun it with `gh run rerun <run-id> --failed`.
 
+When manually triggering Codex, include the full current head SHA in the request,
+for example `@codex review head <sha>`. This gives no-findings responses a
+specific revision to answer. Avoid sending a later generic `@codex review` for
+the same head because it weakens that audit trail.
+
 Remove the worktree and delete the local branch after the PR has merged.
 
 Commit one logical change at a time. Use the pathspec form so unrelated staged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,8 @@ review state is clear.
 Unresolved Codex review threads are immediate blockers. Do not wait on more
 checks when Codex has left an open thread: fix the code or resolve the thread
 with the GitHub review-thread API, then request a fresh Codex review if the head
-changed.
+changed. If the head did not change and GitHub does not rerun the failed gate,
+rerun it with `gh run rerun <run-id> --failed`.
 
 Remove the worktree and delete the local branch after the PR has merged.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,12 @@ required checks with `gh pr checks --watch --fail-fast`; if a check fails,
 inspect the run logs, fix the branch, push again, and keep watching until the PR
 is green.
 
+`gh pr checks` may show stale failed runs next to newer passing reruns for the
+same check name. When the output is mixed, inspect
+`gh pr view --json mergeStateStatus,statusCheckRollup,latestReviews` and trust
+the latest run for the current head SHA rather than the oldest failure in the
+list.
+
 Treat PR comments and reviews as part of the work. Read them with
 `gh pr view --comments` and the review fields from `gh pr view --json reviews`.
 Address Codex comments in code when they identify a real issue, reply when a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,11 @@ comment is intentionally declined, and resolve review threads before enabling
 auto-merge. Enable auto-merge only after required checks pass and required
 review state is clear.
 
+Unresolved Codex review threads are immediate blockers. Do not wait on more
+checks when Codex has left an open thread: fix the code or resolve the thread
+with the GitHub review-thread API, then request a fresh Codex review if the head
+changed.
+
 Remove the worktree and delete the local branch after the PR has merged.
 
 Commit one logical change at a time. Use the pathspec form so unrelated staged


### PR DESCRIPTION
## Summary
- add a GitHub Actions check that requires chatgpt-codex-connector to review the current PR head SHA
- document the PR follow-through loop in AGENTS.md

## Checks
- nix run .#lint
- nix run nixpkgs#actionlint -- .github/workflows/codex-review-gate.yml