### PR TITLE
AGENTS: document gh token pushes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,18 @@ the same head because it weakens that audit trail.
 
 Remove the worktree and delete the local branch after the PR has merged.
 
+Use the GitHub CLI credential helper for HTTPS pushes when the default helper
+would reuse a read-only bot credential:
+
+```sh
+gh auth setup-git
+git push -u <canonical-remote> <branch>
+```
+
+Choose the remote name that points at `indexable-inc/index`, such as `origin` in
+the shared checkout or `upstream` in a fork-based clone. Keep the branch tracking
+the same remote that received the push.
+
 Commit one logical change at a time. Use the pathspec form so unrelated staged
 or unstaged files cannot ride along:
 


### PR DESCRIPTION
## Summary
- document using `gh auth token` for HTTPS branch pushes
- include the follow-up fetch/upstream reset so token URLs do not remain in branch config

## Checks
- `nix run .#lint`
