### PR TITLE
Rebase PR 122 audit cleanup

### DIFF
--- a/lib/build-uv-application.nix
+++ b/lib/build-uv-application.nix
@@ -38,7 +38,21 @@ pkgs:
 {
   pname,
   version ? "0.0.0",
-  src,
+  # Pass `srcRoot = ./.` for a standard uv project (pyproject.toml + src/ +
+  # uv.lock at the root); pass `src` directly to provide a custom fileset.
+  srcRoot ? null,
+  src ?
+    if srcRoot != null then
+      pkgs.lib.fileset.toSource {
+        root = srcRoot;
+        fileset = pkgs.lib.fileset.unions [
+          (srcRoot + "/pyproject.toml")
+          (srcRoot + "/src")
+          (srcRoot + "/uv.lock")
+        ];
+      }
+    else
+      throw "buildUvApplication: pass `srcRoot` for a standard uv project layout or `src` for a custom one",
   python ? pkgs.python3,
   mainProgram ? pname,
   groups ? [ ],

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -151,26 +151,15 @@ let
     as `pkgs.<name>`. Flake-output-only packages live in `packageSetFor`
     instead so they don't leak into the nixpkgs namespace inside images.
   */
-  overlay =
-    final: _prev:
-    let
-      ixForOverlay = {
-        buildRustPackage = pkgs: (rustFor pkgs).buildPackage;
-      };
-      checkedOciImageBuilder = final.callPackage paths.packages.ociImageBuilder {
-        pkgs = final;
-        ix = ixForOverlay;
-      };
-    in
-    {
-      drgn = final.callPackage paths.packages.drgn { };
+  overlay = final: _prev: {
+    drgn = final.callPackage paths.packages.drgn { };
 
-      minecraft-hot-reload-agent = final.callPackage paths.packages.minecraft.hotReloadAgent { };
-      minecraft-rcon = final.callPackage paths.packages.minecraft.rcon {
-        writePythonApplication = writePythonApplication final;
-      };
-      oci-image-builder = checkedOciImageBuilder.passthru.unchecked or checkedOciImageBuilder;
+    minecraft-hot-reload-agent = final.callPackage paths.packages.minecraft.hotReloadAgent { };
+    minecraft-rcon = final.callPackage paths.packages.minecraft.rcon {
+      writePythonApplication = writePythonApplication final;
     };
+    oci-image-builder = buildIxRustTool final paths.packages.ociImageBuilder;
+  };
   overlays = [ overlay ];
 
   /**
@@ -264,20 +253,24 @@ let
       rustToolchain = rustNightlyToolchainFor pkgs;
       writePythonApplication = writePythonApplication pkgs;
     };
-  cargoUnitFor =
-    pkgs:
+  # Build a repo-owned Rust tool whose default.nix calls `ix.buildRustPackage`.
+  # Returns the policy-unchecked variant when present, so generators that
+  # only need the binary do not drag the policy-check graph into their closure.
+  buildIxRustTool =
+    hostPkgs: path:
     let
-      rust = rustFor pkgs;
-      checkedNixCargoUnit = pkgs.callPackage paths.packages.nixCargoUnit {
-        inherit pkgs;
-        ix = {
-          buildRustPackage = pkgs: (rustFor pkgs).buildPackage;
-        };
+      checked = hostPkgs.callPackage path {
+        pkgs = hostPkgs;
+        ix.buildRustPackage = pkgs: (rustFor pkgs).buildPackage;
       };
     in
+    checked.passthru.unchecked or checked;
+  cargoUnitFor =
+    pkgs:
     import ./cargo-unit.nix {
-      inherit lib pkgs rust;
-      nixCargoUnit = checkedNixCargoUnit.passthru.unchecked or checkedNixCargoUnit;
+      inherit lib pkgs;
+      rust = rustFor pkgs;
+      nixCargoUnit = buildIxRustTool pkgs paths.packages.nixCargoUnit;
     };
   cargoUnit = cargoUnitFor pkgs;
 
@@ -424,13 +417,7 @@ let
         "zlib"
       ];
       jsonFormat = pkgs.formats.json { };
-      checkedMinecraftNbt = pkgs.callPackage paths.packages.minecraft.nbt {
-        inherit pkgs;
-        ix = {
-          buildRustPackage = pkgs: (rustFor pkgs).buildPackage;
-        };
-      };
-      minecraftNbt = checkedMinecraftNbt.passthru.unchecked or checkedMinecraftNbt;
+      minecraftNbt = buildIxRustTool pkgs paths.packages.minecraft.nbt;
     in
     assert lib.assertMsg (builtins.elem format validFormats)
       "mkMinecraftNbtFormat: format must be one of ${lib.concatStringsSep ", " validFormats}";
@@ -463,17 +450,9 @@ let
   */
   mkMinecraftSyncManaged =
     args:
-    let
-      checkedPackage = pkgs.callPackage paths.packages.minecraft.syncManaged {
-        inherit pkgs;
-        ix = {
-          buildRustPackage = pkgs: (rustFor pkgs).buildPackage;
-        };
-      };
-    in
     import ./minecraft-sync-managed.nix (
       {
-        package = checkedPackage.passthru.unchecked or checkedPackage;
+        package = buildIxRustTool pkgs paths.packages.minecraft.syncManaged;
         inherit writeNushellApplication;
       }
       // args

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -189,7 +189,6 @@ let
     import ./bun-lock.nix {
       inherit lib pkgs;
     };
-  bunLock = bunLockFor pkgs;
   buildBunSite = import ./build-bun-site.nix {
     inherit bunLockFor;
   };
@@ -199,7 +198,6 @@ let
     import ./uv-lock.nix {
       inherit lib pkgs;
     };
-  uvLock = uvLockFor pkgs;
   basedpyrightTypeCheckingModes = [
     "off"
     "basic"
@@ -297,7 +295,7 @@ let
   /**
     Helpers that throw with a fixable error message instead of a deep-eval
     crash. See [`lib/errors.nix`](lib/errors.nix) for the full surface:
-    `assertEnum`, `atMostOne`, `exactlyOne`, `requireAttr`, `requireInput`.
+    `assertEnum`, `requireArg`, `requireAttr`.
   */
   errors = import ./errors.nix { inherit lib; };
 
@@ -720,11 +718,7 @@ let
       buildRustPackage
       buildNpmSite
       buildUvApplication
-      bunLock
-      bunLockFor
       cargoUnit
-      cargoUnitFor
-      errors
       languages
       minecraft
       mkMinecraftLoader
@@ -733,8 +727,6 @@ let
       relativePath
       secrets
       systemdHardening
-      uvLock
-      uvLockFor
       writeNushellApplication
       writePythonApplication
       ;
@@ -968,24 +960,7 @@ let
       map (e: lib.nameValuePair e.name (import e.path { index = indexShim; })) (flatPairs ++ nestedPairs)
     );
 
-  /**
-    Default-system shortcut over `exampleFleetsFor`. Used by aggregators
-    like `examplesHealthChecks` that only need plan data (which is
-    system-independent), not the wrapper derivations.
-  */
-  exampleFleets = exampleFleetsFor { hostSystem = system; };
-
-  /**
-    `ix.healthChecks` declared by every example, keyed by example name and
-    fleet node. Plain-data attrset suitable for `nix eval --json` and `jq`
-    pipelines; the `health-checks` Nu wrapper pretty-prints the same data
-    as a table.
-  */
-  examplesHealthChecks = lib.mapAttrs (
-    _name: fleet: lib.mapAttrs (_node: nodePlan: nodePlan.healthChecks) fleet.planValue.nodes
-  ) exampleFleets;
-
-  # Self-reference (let-bindings are mutually recursive): `exampleFleets`
+  # Self-reference (let-bindings are mutually recursive): `exampleFleetsFor`
   # passes `ixReturn` back into examples as `index.lib`. Forced only when
   # an example actually reads from it.
   ixReturn = {
@@ -997,21 +972,14 @@ let
       evalImageConfig
       mkImage
       mkFleet
-      mkFleetFor
       discoverImages
-      exampleFleets
       exampleFleetsFor
-      examplesHealthChecks
       artifacts
       buildBunSite
       buildGradleFatJar
       buildNpmSite
       buildUvApplication
-      bunLock
-      bunLockFor
       cargoUnit
-      cargoUnitFor
-      errors
       languages
       minecraft
       mkMinecraftLoader
@@ -1021,8 +989,6 @@ let
       relativePath
       secrets
       systemdHardening
-      uvLock
-      uvLockFor
       writeNushellApplication
       writePythonApplication
       ;

--- a/lib/errors.nix
+++ b/lib/errors.nix
@@ -1,9 +1,7 @@
 { lib }:
 let
-  inherit (lib) concatStringsSep filterAttrs attrNames;
-  inherit (builtins) elem head length;
-
-  enabledKeys = options: attrNames (filterAttrs (_: v: v == true) options);
+  inherit (lib) concatStringsSep;
+  inherit (builtins) elem;
 in
 {
   /**
@@ -33,68 +31,6 @@ in
       value
     else
       throw "ix: invalid ${name} = ${toString value}. Valid values: ${concatStringsSep ", " valid}.";
-
-  /**
-    Assert that at most one of the boolean flags in `options` is true.
-
-    The `context` string heads the error and should name the surface the
-    flags belong to (for example `"services.rust: linker selection"`). On
-    failure the message lists every flag the caller declared and which
-    ones were set to `true`, so the conflict is fixable without reading
-    the module source.
-
-    Returns `null` on success so the call can be sequenced inside a `let`
-    binding before the value that depends on the assertion.
-  */
-  atMostOne =
-    {
-      context,
-      options,
-    }:
-    let
-      enabled = enabledKeys options;
-      keys = attrNames options;
-    in
-    if length enabled <= 1 then
-      null
-    else
-      throw ''
-        ix: ${context}
-          At most one of [${concatStringsSep ", " keys}] may be true.
-          Got: ${concatStringsSep ", " enabled}.
-      '';
-
-  /**
-    Assert that exactly one of the boolean flags in `options` is true.
-    Returns the name of the chosen flag, so the caller can use the result
-    to select a downstream value without re-checking the booleans.
-
-    Errors distinguish "none set" from "multiple set" because the fix
-    is different in each case.
-  */
-  exactlyOne =
-    {
-      context,
-      options,
-    }:
-    let
-      enabled = enabledKeys options;
-      keys = attrNames options;
-    in
-    if length enabled == 1 then
-      head enabled
-    else if enabled == [ ] then
-      throw ''
-        ix: ${context}
-          Exactly one of [${concatStringsSep ", " keys}] must be true.
-          Got: none.
-      ''
-    else
-      throw ''
-        ix: ${context}
-          Exactly one of [${concatStringsSep ", " keys}] must be true.
-          Got: ${concatStringsSep ", " enabled}.
-      '';
 
   /**
     Look up `name` in `args` and return the value. Throws naming the
@@ -141,36 +77,6 @@ in
     }:
     attrset.${key} or (throw ''
       ix: ${context}
-        Missing key '${toString key}'. Available: ${concatStringsSep ", " (attrNames attrset)}.
-    '');
-
-  /**
-    Return `inputs.${name}` if present; otherwise throw with a ready-to-paste
-    `flake.nix` snippet that adds the input. `usedBy` names the consuming
-    option or helper, so the message points back to the caller that needs
-    the input. `follows` lists inputs that should pin through nixpkgs (or
-    similar) and is reflected in the snippet.
-
-    Pattern borrowed from [devenv's `getInput`](https://github.com/cachix/devenv/blob/main/src/modules/lib.nix);
-    adapted for this repo's single-flake layout (no `devenv.yaml`).
-  */
-  requireInput =
-    {
-      inputs,
-      name,
-      url,
-      usedBy,
-      follows ? [ ],
-    }:
-    inputs.${name} or (throw ''
-      ix: ${usedBy} requires the '${name}' flake input.
-
-      Add to flake.nix:
-        inputs.${name}.url = "${url}";${
-          if follows == [ ] then
-            ""
-          else
-            "\n" + concatStringsSep "\n" (map (i: "  inputs.${name}.inputs.${i}.follows = \"${i}\";") follows)
-        }
+        Missing key '${toString key}'. Available: ${concatStringsSep ", " (lib.attrNames attrset)}.
     '');
 }

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -24,17 +24,6 @@ let
   };
   fs = lib.fileset;
 
-  # Add `meta.description` to a derivation without rewriting the original
-  # call site. Used for repoPackages entries and generated fleet wrappers
-  # whose derivations are constructed elsewhere.
-  withDescription =
-    description: drv:
-    drv.overrideAttrs (old: {
-      meta = (old.meta or { }) // {
-        inherit description;
-      };
-    });
-
   # Each lint stage is one subcommand on a single binary so the spec keys
   # off `lib.getExe lintStage` without registering four sibling packages.
   # The Nu wrapper checks syntax at build time, so a typo in a stage shows
@@ -233,7 +222,11 @@ let
       lib.listToAttrs (
         map (sub: {
           name = "${name}-${sub}";
-          value = withDescription "Run `ix fleet ${sub}` against the ${name} example fleet" fleet.${sub};
+          value = fleet.${sub}.overrideAttrs (old: {
+            meta = (old.meta or { }) // {
+              description = "Run `ix fleet ${sub}` against the ${name} example fleet";
+            };
+          });
         }) fleetSubs
       )
     ) exampleFleets;

--- a/lib/rust.nix
+++ b/lib/rust.nix
@@ -643,9 +643,34 @@ let
       '';
     };
 
-  buildPackage =
+  # Shortcut: pass `srcRoot = ./.` for a repo-owned crate whose tracked tree
+  # is the build closure. Expands to the standard `gitTracked` filter, defaults
+  # `meta.mainProgram` to `pname`, and keeps `commonArgs`'s `cargoLock` default
+  # (`src + "/Cargo.lock"`) intact.
+  expandSrcRoot =
     rawArgs:
+    if rawArgs ? srcRoot then
+      let
+        inherit (rawArgs) srcRoot;
+        pname = rawArgs.pname or rawArgs.name or "rust-package";
+      in
+      (builtins.removeAttrs rawArgs [ "srcRoot" ])
+      // {
+        src = lib.fileset.toSource {
+          root = srcRoot;
+          fileset = lib.fileset.gitTracked srcRoot;
+        };
+        meta = (rawArgs.meta or { }) // {
+          mainProgram = rawArgs.meta.mainProgram or pname;
+        };
+      }
+    else
+      rawArgs;
+
+  buildPackage =
+    expandedArgs:
     let
+      rawArgs = expandSrcRoot expandedArgs;
       args = commonArgs rawArgs;
       testEnabled = args.policy.tests.enable && (rawArgs.doCheck or true);
       rustcArgs = rustcArgsForPolicy args.policy;

--- a/lib/rust.nix
+++ b/lib/rust.nix
@@ -700,23 +700,14 @@ in
   inherit
     buildPackage
     cargoAuditCheck
-    cargoClippyCheck
-    cargoMacheteCheck
     cargoLockFile
-    defaultClippyAllowedLints
-    defaultClippyDeniedLints
-    defaultPolicy
     defaultRustToolchain
-    defaultRustsecAdvisoryDb
     nativeBuildInputsForPolicy
     policyChecksFor
     resolvePolicy
     resolveVendorSources
     resolveVendorDir
-    rustcArgsForPolicy
     rustcArgsForPolicyForPlatform
-    rustFlagsStringForPolicy
     vendorConfigScript
-    withPolicyChecks
     ;
 }

--- a/packages/dag-runner/default.nix
+++ b/packages/dag-runner/default.nix
@@ -1,19 +1,7 @@
-{
-  ix,
-  lib,
-  pkgs,
-}:
+{ ix, pkgs }:
 
 ix.buildRustPackage pkgs {
   pname = "dag-runner";
   version = "0.1.0";
-
-  src = lib.fileset.toSource {
-    root = ./.;
-    fileset = lib.fileset.gitTracked ./.;
-  };
-
-  cargoLock.lockFile = ./Cargo.lock;
-
-  meta.mainProgram = "dag-runner";
+  srcRoot = ./.;
 }

--- a/packages/ix-fleet/default.nix
+++ b/packages/ix-fleet/default.nix
@@ -1,22 +1,10 @@
 {
   ix,
-  lib,
   pkgs ? ix.pkgs,
 }:
-let
-  fs = lib.fileset;
-  src = fs.toSource {
-    root = ./.;
-    fileset = fs.unions [
-      ./pyproject.toml
-      ./src
-      ./uv.lock
-    ];
-  };
-in
+
 ix.buildUvApplication pkgs {
   pname = "ix-fleet";
   version = "0.1.0";
-  inherit src;
-  mainProgram = "ix-fleet";
+  srcRoot = ./.;
 }

--- a/packages/minecraft/nbt/default.nix
+++ b/packages/minecraft/nbt/default.nix
@@ -1,19 +1,7 @@
-{
-  ix,
-  lib,
-  pkgs,
-}:
+{ ix, pkgs }:
 
 ix.buildRustPackage pkgs {
   pname = "minecraft-nbt";
   version = "0.1.0";
-
-  src = lib.fileset.toSource {
-    root = ./.;
-    fileset = lib.fileset.gitTracked ./.;
-  };
-
-  cargoLock.lockFile = ./Cargo.lock;
-
-  meta.mainProgram = "minecraft-nbt";
+  srcRoot = ./.;
 }

--- a/packages/minecraft/probe/default.nix
+++ b/packages/minecraft/probe/default.nix
@@ -1,22 +1,10 @@
 {
   ix,
-  lib,
   pkgs ? ix.pkgs,
 }:
-let
-  fs = lib.fileset;
-  src = fs.toSource {
-    root = ./.;
-    fileset = fs.unions [
-      ./pyproject.toml
-      ./src
-      ./uv.lock
-    ];
-  };
-in
+
 ix.buildUvApplication pkgs {
   pname = "mc-probe";
   version = "0.1.0";
-  inherit src;
-  mainProgram = "mc-probe";
+  srcRoot = ./.;
 }

--- a/packages/minecraft/sync-managed/default.nix
+++ b/packages/minecraft/sync-managed/default.nix
@@ -1,19 +1,7 @@
-{
-  ix,
-  lib,
-  pkgs,
-}:
+{ ix, pkgs }:
 
 ix.buildRustPackage pkgs {
   pname = "minecraft-sync-managed";
   version = "0.1.0";
-
-  src = lib.fileset.toSource {
-    root = ./.;
-    fileset = lib.fileset.gitTracked ./.;
-  };
-
-  cargoLock.lockFile = ./Cargo.lock;
-
-  meta.mainProgram = "minecraft-sync-managed";
+  srcRoot = ./.;
 }

--- a/packages/nix-cargo-unit/default.nix
+++ b/packages/nix-cargo-unit/default.nix
@@ -1,19 +1,7 @@
-{
-  ix,
-  lib,
-  pkgs,
-}:
+{ ix, pkgs }:
 
 ix.buildRustPackage pkgs {
   pname = "nix-cargo-unit";
   version = "0.1.0";
-
-  src = lib.fileset.toSource {
-    root = ./.;
-    fileset = lib.fileset.gitTracked ./.;
-  };
-
-  cargoLock.lockFile = ./Cargo.lock;
-
-  meta.mainProgram = "nix-cargo-unit";
+  srcRoot = ./.;
 }

--- a/packages/oci-image-builder/default.nix
+++ b/packages/oci-image-builder/default.nix
@@ -1,19 +1,7 @@
-{
-  ix,
-  lib,
-  pkgs,
-}:
+{ ix, pkgs }:
 
 ix.buildRustPackage pkgs {
   pname = "oci-image-builder";
   version = "0.1.0";
-
-  src = lib.fileset.toSource {
-    root = ./.;
-    fileset = lib.fileset.gitTracked ./.;
-  };
-
-  cargoLock.lockFile = ./Cargo.lock;
-
-  meta.mainProgram = "oci-image-builder";
+  srcRoot = ./.;
 }


### PR DESCRIPTION
Rebased Wyatt's PR #122 onto current main after #123 replaced the old Python MCP package.

This preserves the PR changes and resolves the only conflict by keeping `packages/python-mcp-server/default.nix` deleted, since `main` now owns that surface through `packages/mcp`.

Refs #122
