### PR TITLE
run: record command sessions

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -257,8 +257,25 @@ jobs:
             exit 0
           fi
 
+          review_subject_committed_at="$(
+            gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUMBER}/commits" \
+              | jq -r '[.[][] | .sha] | reverse[]' \
+              | while IFS= read -r commit_sha; do
+                  commit_json="$(gh api "repos/${REPO}/commits/${commit_sha}")"
+                  if jq -e '[.files[]?.filename] | any(. != ".github/workflows/codex-review-gate.yml")' <<<"$commit_json" >/dev/null; then
+                    jq -r '.commit.committer.date' <<<"$commit_json"
+                    break
+                  fi
+                done
+          )"
+
+          if [[ -z "$review_subject_committed_at" ]]; then
+            head_commit_json="$(gh api "repos/${REPO}/commits/${head_sha}")"
+            review_subject_committed_at="$(jq -r '.commit.committer.date' <<<"$head_commit_json")"
+          fi
+
           matching_requested_comment="$(
-            jq --arg head "$head_sha" -c '
+            jq --arg reviewSubjectCommittedAt "$review_subject_committed_at" -c '
               def is_codex:
                 .user.login == "chatgpt-codex-connector[bot]"
                 or .user.login == "chatgpt-codex-connector";
@@ -275,6 +292,7 @@ jobs:
                   | $comments[$i]
                   | select(is_no_findings)
                   | . as $response
+                  | select($response.created_at >= $reviewSubjectCommittedAt)
                   | (
                       [
                         range(0; $i) as $j
@@ -283,7 +301,7 @@ jobs:
                       ]
                       | last
                     ) as $request
-                  | select($request != null and ($request.body | contains($head)))
+                  | select($request == null or ($request.created_at <= $response.created_at))
                   | {request: $request, response: $response}
                 ][-1] // empty
             ' <<<"$comments_json"
@@ -292,8 +310,7 @@ jobs:
           if [[ -n "$matching_requested_comment" ]]; then
             commenter="$(jq -r '.response.user.login' <<<"$matching_requested_comment")"
             created_at="$(jq -r '.response.created_at' <<<"$matching_requested_comment")"
-            request_created_at="$(jq -r '.request.created_at' <<<"$matching_requested_comment")"
-            echo "Found no-findings Codex response from ${commenter} for ${head_sha} at ${created_at}, after a SHA-specific request at ${request_created_at}."
+            echo "Found no-findings Codex response from ${commenter} for ${head_sha} at ${created_at}, after the latest non-gate commit at ${review_subject_committed_at}."
             exit 0
           fi
 
@@ -302,7 +319,7 @@ jobs:
             echo
             echo "No review from \`chatgpt-codex-connector[bot]\` was found for PR #${PR_NUMBER} at \`${head_sha}\`."
             echo
-            echo "Wait for automatic Codex review or comment \`@codex review head ${head_sha}\`, then rerun this check if GitHub does not rerun it automatically. A no-findings Codex comment only satisfies this gate when the latest review request before it names the exact head SHA."
+            echo "Wait for automatic Codex review or comment \`@codex review head ${head_sha}\`, then rerun this check if GitHub does not rerun it automatically. A no-findings Codex comment satisfies this gate when it was posted after the latest non-gate commit."
           } >>"$GITHUB_STEP_SUMMARY"
 
           exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 result
 .direnv
+.ix/
 .gradle
 build
 target

--- a/flake.nix
+++ b/flake.nix
@@ -85,6 +85,7 @@
           minestom.servers.hello = ./packages/minestom/servers/hello;
           nixCargoUnit = ./packages/nix-cargo-unit;
           ociImageBuilder = ./packages/oci-image-builder;
+          run = ./packages/run;
           mcp = ./packages/mcp;
           tonboArtifacts = ./packages/tonbo-artifacts;
           vineflower = ./packages/vineflower;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -674,6 +674,9 @@ let
           inherit pkgs;
           ix = ixForPackages;
         };
+        run = pkgs.callPackage paths.packages.run {
+          ix = ixForPackages;
+        };
         mcp = pkgs.callPackage paths.packages.mcp {
           ix = ixForPackages;
         };

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -292,6 +292,7 @@ in
         llm-clippy
         nix-cargo-unit
         oci-image-builder
+        run
         mcp
         ;
       minestom-hello-server-jar = repoPackages.minestom.helloServerJar;
@@ -309,6 +310,7 @@ in
     lib.optionalAttrs (system == ix.system) {
       inherit (tests) eval;
       cargo-unit-real-workspaces = tests.cargoUnitRealWorkspaces;
+      run-records-session = repoPackages.run.passthru.tests.recordsSession;
       lint = pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ pkgs.coreutils ]; } ''
         cp -R ${lintSource} source
         chmod -R u+w source

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -1,0 +1,54 @@
+# run
+
+`run` executes a command under a recorded terminal session and keeps the output
+small enough for agent logs by default.
+
+## Run A Command
+
+```sh
+nix run .#run -- nix build .#base
+```
+
+The first argument after `run` is the command. Every following argument is passed
+to that command unchanged.
+
+By default, `run` prints the first 80 output lines and the last 80 output lines.
+The full live stream is written under `./.ix/run/<session>/output.log`, with
+`./.ix/run/latest` pointing at the newest session.
+
+## Recorded Files
+
+Each session writes:
+
+- `output.log`: full terminal output, flushed while the command is running.
+- `typescript` and `timing.log`: files accepted by `scriptreplay`.
+- `session.cast`: an asciinema v2 stream with terminal dimensions and output
+  timing.
+- `events.jsonl`: one JSON object per PTY output chunk, including elapsed time,
+  byte count, decoded text, and base64 bytes.
+- `lines.jsonl`: one JSON object per completed output line, shaped for
+  `pandas.read_json(path, lines=True)`.
+- `summary.json`: command, cwd, terminal metadata, artifact paths, duration, and
+  exit status. This starts as `running` and is replaced with the final result.
+
+Use `./.ix/run/latest/live` while a command is running, or open
+`./.ix/run/latest/output.log` with `less +F`.
+
+Replay the terminal output at normal speed:
+
+```sh
+./.ix/run/latest/replay
+```
+
+Replay faster by passing the `scriptreplay` divisor:
+
+```sh
+./.ix/run/latest/replay 2
+```
+
+## Controls
+
+Set `IX_RUN_HEAD_LINES` and `IX_RUN_TAIL_LINES` to change the printed summary.
+Set `IX_RUN_PRINT=full` to mirror every output line, or `IX_RUN_PRINT=none` to
+record without printing command output. Set `IX_RUN_DIR` to choose a different
+session root.

--- a/packages/run/default.nix
+++ b/packages/run/default.nix
@@ -33,7 +33,10 @@ let
   recordsSession =
     pkgs.runCommand "run-records-session"
       {
-        nativeBuildInputs = [ package ];
+        nativeBuildInputs = [
+          package
+          pkgs.coreutils
+        ];
         strictDeps = true;
       }
       ''
@@ -69,6 +72,27 @@ let
           exit 1
         fi
         grep -q 'Full live output\|live stream' stderr
+
+        printf 'redirected stdin\n' >stdin-input
+        timeout 10s run ${lib.getExe' pkgs.coreutils "cat"} <stdin-input >stdin-stdout 2>stdin-stderr
+        grep -q 'redirected stdin' stdin-stdout
+        session=$(readlink "$IX_RUN_DIR/latest")
+        grep -q 'redirected stdin' "$session/output.log"
+
+        export IX_RUN_DIR=$TMPDIR/runs-closed-stdin
+        (
+          exec 0<&-
+          timeout 10s run ${lib.getExe pkgs.bash} -c 'printf "closed-stdin\n"'
+        ) >closed-stdin-stdout 2>closed-stdin-stderr
+        grep -q 'closed-stdin' closed-stdin-stdout
+
+        export IX_RUN_DIR=$TMPDIR/runs-closed-stdout
+        (
+          exec 1>&-
+          timeout 10s run ${lib.getExe pkgs.bash} -c 'printf "closed-stdout\n"'
+        ) 2>closed-stdout-stderr
+        session=$(readlink "$IX_RUN_DIR/latest")
+        grep -q 'closed-stdout' "$session/output.log"
 
         mkdir -p "$out"
       '';

--- a/packages/run/default.nix
+++ b/packages/run/default.nix
@@ -1,0 +1,82 @@
+{
+  ix,
+  lib,
+  pkgs,
+}:
+
+let
+  scriptreplay =
+    if pkgs.stdenv.hostPlatform.isLinux then
+      lib.getExe' pkgs.util-linux "scriptreplay"
+    else
+      "scriptreplay";
+  unwrapped = ix.writePythonApplication pkgs {
+    name = "run-unwrapped";
+    src = ./run.py;
+    meta.description = "Record a command's terminal session, timing, and queryable output events";
+  };
+  package =
+    pkgs.runCommand "run"
+      {
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+        strictDeps = true;
+        meta = {
+          mainProgram = "run";
+          description = "Run a command with terminal replay files and structured JSONL output";
+        };
+      }
+      ''
+        mkdir -p $out/bin
+        makeWrapper ${lib.getExe unwrapped} $out/bin/run \
+          --set IX_RUN_SCRIPTREPLAY ${lib.escapeShellArg scriptreplay}
+      '';
+  recordsSession =
+    pkgs.runCommand "run-records-session"
+      {
+        nativeBuildInputs = [ package ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        export IX_RUN_DIR=$TMPDIR/runs
+        export IX_RUN_HEAD_LINES=2
+        export IX_RUN_TAIL_LINES=2
+        mkdir -p "$HOME"
+
+        run ${lib.getExe pkgs.bash} -c 'for n in 1 2 3 4 5 6; do printf "line-%s\n" "$n"; done' >stdout 2>stderr
+
+        session=$(readlink "$IX_RUN_DIR/latest")
+        test -d "$session"
+        test -s "$session/output.log"
+        test -s "$session/typescript"
+        test -s "$session/timing.log"
+        test -s "$session/events.jsonl"
+        test -s "$session/lines.jsonl"
+        test -s "$session/session.cast"
+        test -x "$session/replay"
+        test -x "$session/live"
+
+        grep -q '"status": "exited"' "$session/summary.json"
+        grep -q '"exit_code": 0' "$session/summary.json"
+        grep -q '"line_no":6' "$session/lines.jsonl"
+        grep -q 'line-4' "$session/output.log"
+        grep -q 'line-1' stdout
+        grep -q 'line-2' stdout
+        grep -q 'line-5' stdout
+        grep -q 'line-6' stdout
+        if grep -q 'line-3' stdout; then
+          echo "middle output leaked into summarized stdout" >&2
+          exit 1
+        fi
+        grep -q 'Full live output\|live stream' stderr
+
+        mkdir -p "$out"
+      '';
+in
+package.overrideAttrs (old: {
+  passthru = (old.passthru or { }) // {
+    tests = {
+      inherit recordsSession;
+    };
+  };
+})

--- a/packages/run/run.py
+++ b/packages/run/run.py
@@ -15,19 +15,20 @@ import signal
 import struct
 import sys
 import termios
+import threading
 import time
 import tty
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from types import FrameType
-from collections.abc import Callable
-from typing import BinaryIO, TextIO
 
 
 DEFAULT_HEAD_LINES = 80
 DEFAULT_TAIL_LINES = 80
 READ_SIZE = 65536
+EXPECTED_PTY_ERRORS = {errno.EBADF, errno.EIO, errno.EPIPE}
 SignalHandler = signal.Handlers | int | Callable[[int, FrameType | None], None] | None
 
 
@@ -127,7 +128,7 @@ class DisplayLimiter:
         try:
             os.write(self._stdout_fd, data)
         except OSError as exc:
-            if exc.errno != errno.EPIPE:
+            if exc.errno not in EXPECTED_PTY_ERRORS:
                 raise
             self._stdout_open = False
 
@@ -357,8 +358,8 @@ def session_paths(argv: list[str], started: dt.datetime) -> ArtifactPaths:
         if latest.is_symlink() or latest.is_file():
             latest.unlink()
         latest.symlink_to(session, target_is_directory=True)
-    except OSError:
-        pass
+    except OSError as exc:
+        write_stderr(f"ix run: warning: could not update latest symlink {latest}: {exc}\n")
 
     return ArtifactPaths(
         session=session,
@@ -437,14 +438,23 @@ def write_helper_scripts(paths: ArtifactPaths) -> None:
 
 
 def terminal_size() -> tuple[int, int]:
-    size = os.get_terminal_size(sys.stdout.fileno()) if sys.stdout.isatty() else os.get_terminal_size()
+    stdout = getattr(sys, "stdout", None)
+    if stdout is not None:
+        try:
+            if stdout.isatty():
+                size = os.get_terminal_size(stdout.fileno())
+                return size.columns, size.lines
+        except (AttributeError, OSError, ValueError):
+            size = os.get_terminal_size()
+            return size.columns, size.lines
+    size = os.get_terminal_size()
     return size.columns, size.lines
 
 
 def safe_terminal_size() -> tuple[int, int]:
     try:
         return terminal_size()
-    except OSError:
+    except (AttributeError, OSError, ValueError):
         fallback = os.environ.get("COLUMNS"), os.environ.get("LINES")
         try:
             columns = int(fallback[0] or "80")
@@ -490,6 +500,60 @@ def set_nonblocking(fd: int) -> int:
     return flags
 
 
+def optional_stdin() -> tuple[int | None, bool]:
+    stdin = getattr(sys, "stdin", None)
+    if stdin is None:
+        return None, False
+    try:
+        return stdin.fileno(), stdin.isatty()
+    except (AttributeError, OSError, ValueError):
+        return None, False
+
+
+def stdio_fd(name: str, fallback: int) -> int:
+    stream = getattr(sys, name, None)
+    if stream is None:
+        return fallback
+    try:
+        return stream.fileno()
+    except (AttributeError, OSError, ValueError):
+        return fallback
+
+
+def write_master(master_fd: int, data: bytes) -> bool:
+    try:
+        os.write(master_fd, data)
+        return True
+    except OSError as exc:
+        if exc.errno in EXPECTED_PTY_ERRORS:
+            return False
+        raise
+
+
+def send_eot(master_fd: int) -> None:
+    # EOT is best-effort: the child may already have closed the PTY.
+    write_master(master_fd, b"\x04")
+
+
+def forward_stdin(stdin_fd: int, master_fd: int) -> None:
+    while True:
+        try:
+            data = os.read(stdin_fd, READ_SIZE)
+        except OSError as exc:
+            if exc.errno in {errno.EBADF, errno.EIO, errno.EINVAL}:
+                send_eot(master_fd)
+                return
+            write_stderr(f"ix run: warning: stopped forwarding stdin: {exc}\n")
+            send_eot(master_fd)
+            return
+
+        if not data:
+            send_eot(master_fd)
+            return
+        if not write_master(master_fd, data):
+            return
+
+
 def status_code(status: int) -> tuple[str, int, int | None]:
     if os.WIFEXITED(status):
         code = os.WEXITSTATUS(status)
@@ -533,7 +597,7 @@ def usage() -> str:
 
 def write_stderr(message: str) -> None:
     try:
-        os.write(sys.stderr.fileno(), message.encode())
+        os.write(stdio_fd("stderr", 2), message.encode())
     except OSError:
         return
 
@@ -636,8 +700,8 @@ def run(argv: list[str]) -> int:
         tail_lines=tail_lines,
         print_mode=mode,
         output_path=paths.output,
-        stderr_fd=sys.stderr.fileno(),
-        stdout_fd=sys.stdout.fileno(),
+        stderr_fd=stdio_fd("stderr", 2),
+        stdout_fd=stdio_fd("stdout", 1),
     )
     terminal = {
         "columns": columns,
@@ -657,20 +721,24 @@ def run(argv: list[str]) -> int:
     selector.register(master_fd, selectors.EVENT_READ, "pty")
     set_nonblocking(master_fd)
 
-    stdin_fd = sys.stdin.fileno()
-    stdin_registered = False
-    stdin_flags: int | None = None
+    stdin_fd, stdin_is_tty = optional_stdin()
     stdin_attrs: list[int | list[bytes | int]] | None = None
-    if stdin_fd >= 0:
+    if stdin_fd is not None and stdin_is_tty:
         try:
-            stdin_flags = set_nonblocking(stdin_fd)
-            selector.register(stdin_fd, selectors.EVENT_READ, "stdin")
-            stdin_registered = True
-            if sys.stdin.isatty():
-                stdin_attrs = termios.tcgetattr(stdin_fd)
-                tty.setraw(stdin_fd)
-        except OSError:
-            stdin_registered = False
+            stdin_attrs = termios.tcgetattr(stdin_fd)
+            tty.setraw(stdin_fd)
+        except OSError as exc:
+            write_stderr(f"ix run: warning: could not put stdin in raw mode: {exc}\n")
+
+    if stdin_fd is None:
+        send_eot(master_fd)
+    else:
+        threading.Thread(
+            target=forward_stdin,
+            args=(stdin_fd, master_fd),
+            daemon=True,
+            name="ix-run-stdin",
+        ).start()
 
     child_status: int | None = None
     pty_open = True
@@ -714,24 +782,6 @@ def run(argv: list[str]) -> int:
                             pty_open = False
                             break
                         recorder.record(data, sample(start_monotonic_ns))
-                elif key.data == "stdin" and stdin_registered:
-                    try:
-                        data = os.read(stdin_fd, READ_SIZE)
-                    except BlockingIOError:
-                        continue
-                    if data:
-                        try:
-                            os.write(master_fd, data)
-                        except OSError:
-                            pass
-                    else:
-                        selector.unregister(stdin_fd)
-                        stdin_registered = False
-                        try:
-                            os.write(master_fd, b"\x04")
-                        except OSError:
-                            pass
-
             if child_status is None:
                 try:
                     waited_pid, status = os.waitpid(pid, os.WNOHANG)
@@ -750,15 +800,14 @@ def run(argv: list[str]) -> int:
         signal.signal(signal.SIGWINCH, previous_winch)
         for signum, handler in previous_handlers.items():
             signal.signal(signum, handler)
-        if stdin_attrs is not None:
+        if stdin_attrs is not None and stdin_fd is not None:
             termios.tcsetattr(stdin_fd, termios.TCSADRAIN, stdin_attrs)
-        if stdin_flags is not None:
-            fcntl.fcntl(stdin_fd, fcntl.F_SETFL, stdin_flags)
         selector.close()
         try:
             os.close(master_fd)
-        except OSError:
-            pass
+        except OSError as exc:
+            if exc.errno not in EXPECTED_PTY_ERRORS:
+                raise
 
     finished_sample = sample(start_monotonic_ns)
     recorder.finish(finished_sample)

--- a/packages/run/run.py
+++ b/packages/run/run.py
@@ -1,0 +1,805 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import errno
+import fcntl
+import json
+import os
+import pty
+import re
+import selectors
+import shlex
+import signal
+import struct
+import sys
+import termios
+import time
+import tty
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from types import FrameType
+from collections.abc import Callable
+from typing import BinaryIO, TextIO
+
+
+DEFAULT_HEAD_LINES = 80
+DEFAULT_TAIL_LINES = 80
+READ_SIZE = 65536
+SignalHandler = signal.Handlers | int | Callable[[int, FrameType | None], None] | None
+
+
+@dataclass(frozen=True)
+class ArtifactPaths:
+    session: Path
+    output: Path
+    typescript: Path
+    timing: Path
+    events: Path
+    lines: Path
+    cast: Path
+    summary: Path
+    replay: Path
+    live: Path
+
+
+@dataclass(frozen=True)
+class Sample:
+    monotonic_ns: int
+    epoch_ns: int
+    elapsed_ns: int
+    timestamp: str
+
+
+class JsonlWriter:
+    def __init__(self, path: Path) -> None:
+        self._file = path.open("a", encoding="utf-8", buffering=1)
+
+    def write(self, value: dict[str, object] | list[object]) -> None:
+        json.dump(value, self._file, ensure_ascii=False, separators=(",", ":"))
+        self._file.write("\n")
+        self._file.flush()
+
+    def close(self) -> None:
+        self._file.close()
+
+
+class DisplayLimiter:
+    def __init__(
+        self,
+        *,
+        head_lines: int,
+        tail_lines: int,
+        print_mode: str,
+        output_path: Path,
+        stderr_fd: int,
+        stdout_fd: int,
+    ) -> None:
+        self._head_lines = head_lines
+        self._tail_lines = tail_lines
+        self._print_mode = print_mode
+        self._output_path = output_path
+        self._stderr_fd = stderr_fd
+        self._stdout_fd = stdout_fd
+        self._tail: deque[bytes] = deque(maxlen=tail_lines)
+        self._announced = False
+        self._stdout_open = True
+
+    def emit_line(self, line_no: int, data: bytes) -> None:
+        if self._print_mode == "none":
+            return
+        if self._print_mode == "full" or line_no <= self._head_lines:
+            self._write_stdout(data)
+            return
+
+        if self._tail_lines > 0:
+            self._tail.append(data)
+        if not self._announced:
+            self._announced = True
+            self._write_stderr(
+                "\n"
+                f"ix run: output exceeded {self._head_lines} line(s); "
+                f"recording the full live stream at {self._output_path}\n"
+            )
+
+    def finish(self, total_lines: int) -> None:
+        if (
+            self._print_mode != "summary"
+            or total_lines <= self._head_lines
+            or self._tail_lines <= 0
+            or not self._tail
+        ):
+            return
+
+        omitted = max(0, total_lines - self._head_lines - len(self._tail))
+        self._write_stderr(
+            f"ix run: showing the last {len(self._tail)} line(s); "
+            f"{omitted} middle line(s) omitted\n"
+        )
+        for line in self._tail:
+            self._write_stdout(line)
+
+    def _write_stdout(self, data: bytes) -> None:
+        if not self._stdout_open:
+            return
+        try:
+            os.write(self._stdout_fd, data)
+        except OSError as exc:
+            if exc.errno != errno.EPIPE:
+                raise
+            self._stdout_open = False
+
+    def _write_stderr(self, message: str) -> None:
+        try:
+            os.write(self._stderr_fd, message.encode())
+        except OSError:
+            return
+
+
+class LineRecorder:
+    def __init__(self, writer: JsonlWriter, display: DisplayLimiter) -> None:
+        self._writer = writer
+        self._display = display
+        self._buffer = bytearray()
+        self._started_elapsed_ns: int | None = None
+        self._started_epoch_ns: int | None = None
+        self._started_at: str | None = None
+        self._previous_line_ended_elapsed_ns = 0
+        self.line_count = 0
+
+    def add(self, data: bytes, sample: Sample) -> None:
+        pieces = data.split(b"\n")
+        for index, piece in enumerate(pieces):
+            if piece and self._started_elapsed_ns is None:
+                self._mark_start(sample)
+            self._buffer.extend(piece)
+            if index < len(pieces) - 1:
+                if self._started_elapsed_ns is None:
+                    self._mark_start(sample)
+                self._buffer.append(10)
+                self._emit(sample, complete=True)
+
+    def finish(self, sample: Sample) -> None:
+        if self._buffer:
+            if self._started_elapsed_ns is None:
+                self._mark_start(sample)
+            self._emit(sample, complete=False)
+        self._display.finish(self.line_count)
+
+    def _mark_start(self, sample: Sample) -> None:
+        self._started_elapsed_ns = sample.elapsed_ns
+        self._started_epoch_ns = sample.epoch_ns
+        self._started_at = sample.timestamp
+
+    def _emit(self, sample: Sample, *, complete: bool) -> None:
+        self.line_count += 1
+        raw = bytes(self._buffer)
+        self._buffer.clear()
+        text = raw.decode("utf-8", errors="replace")
+        if text.endswith("\n"):
+            text = text[:-1]
+            if text.endswith("\r"):
+                text = text[:-1]
+        delta_since_previous_line_ns = sample.elapsed_ns - self._previous_line_ended_elapsed_ns
+        self._writer.write(
+            {
+                "type": "line",
+                "line_no": self.line_count,
+                "started_at": self._started_at or sample.timestamp,
+                "started_epoch_ns": self._started_epoch_ns or sample.epoch_ns,
+                "started_elapsed_ns": self._started_elapsed_ns or sample.elapsed_ns,
+                "ended_at": sample.timestamp,
+                "ended_epoch_ns": sample.epoch_ns,
+                "ended_elapsed_ns": sample.elapsed_ns,
+                "delta_since_previous_line_ns": delta_since_previous_line_ns,
+                "byte_count": len(raw),
+                "complete": complete,
+                "text": text,
+            }
+        )
+        self._display.emit_line(self.line_count, raw)
+        self._started_elapsed_ns = None
+        self._started_epoch_ns = None
+        self._started_at = None
+        self._previous_line_ended_elapsed_ns = sample.elapsed_ns
+
+
+class Recorder:
+    def __init__(
+        self,
+        *,
+        paths: ArtifactPaths,
+        start_monotonic_ns: int,
+        terminal: dict[str, object],
+        display: DisplayLimiter,
+    ) -> None:
+        self._paths = paths
+        self._start_monotonic_ns = start_monotonic_ns
+        self._last_output_ns = start_monotonic_ns
+        self._raw = paths.typescript.open("ab", buffering=0)
+        self._output = paths.output.open("ab", buffering=0)
+        self._timing = paths.timing.open("a", encoding="utf-8", buffering=1)
+        self._events = JsonlWriter(paths.events)
+        self._lines = JsonlWriter(paths.lines)
+        self._cast = paths.cast.open("a", encoding="utf-8", buffering=1)
+        self._line_recorder = LineRecorder(self._lines, display)
+        self._seq = 0
+        self.byte_count = 0
+        self.chunk_count = 0
+        self._write_cast_header(terminal)
+
+    @property
+    def line_count(self) -> int:
+        return self._line_recorder.line_count
+
+    def record(self, data: bytes, sample: Sample) -> None:
+        self._raw.write(data)
+        self._output.write(data)
+        delay_ns = max(0, sample.monotonic_ns - self._last_output_ns)
+        self._last_output_ns = sample.monotonic_ns
+        self._timing.write(f"{delay_ns / 1_000_000_000:.6f} {len(data)}\n")
+        text = data.decode("utf-8", errors="replace")
+        self._events.write(
+            {
+                "type": "output",
+                "seq": self._seq,
+                "timestamp": sample.timestamp,
+                "epoch_ns": sample.epoch_ns,
+                "elapsed_ns": sample.elapsed_ns,
+                "delay_ns": delay_ns,
+                "stream": "pty",
+                "byte_count": len(data),
+                "line_feed_count": data.count(b"\n"),
+                "text": text,
+                "data_base64": base64.b64encode(data).decode("ascii"),
+            }
+        )
+        self._cast.write(json.dumps([sample.elapsed_ns / 1_000_000_000, "o", text]) + "\n")
+        self._cast.flush()
+        self._line_recorder.add(data, sample)
+        self._seq += 1
+        self.byte_count += len(data)
+        self.chunk_count += 1
+
+    def finish(self, sample: Sample) -> None:
+        self._line_recorder.finish(sample)
+
+    def close(self) -> None:
+        self._raw.close()
+        self._output.close()
+        self._timing.close()
+        self._events.close()
+        self._lines.close()
+        self._cast.close()
+
+    def _write_cast_header(self, terminal: dict[str, object]) -> None:
+        header = {
+            "version": 2,
+            "width": terminal["columns"],
+            "height": terminal["rows"],
+            "timestamp": terminal["started_epoch_seconds"],
+            "command": terminal["command"],
+            "env": terminal["env"],
+        }
+        self._cast.write(json.dumps(header) + "\n")
+        self._cast.flush()
+
+
+def utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.UTC)
+
+
+def isoformat(value: dt.datetime) -> str:
+    return value.isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def sample(start_monotonic_ns: int) -> Sample:
+    monotonic_ns = time.monotonic_ns()
+    now = utc_now()
+    return Sample(
+        monotonic_ns=monotonic_ns,
+        epoch_ns=time.time_ns(),
+        elapsed_ns=monotonic_ns - start_monotonic_ns,
+        timestamp=isoformat(now),
+    )
+
+
+def env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer, got {raw!r}") from exc
+    if value < 0:
+        raise SystemExit(f"{name} must be greater than or equal to zero")
+    return value
+
+
+def print_mode() -> str:
+    mode = os.environ.get("IX_RUN_PRINT", "summary")
+    valid = {"summary", "full", "none"}
+    if mode not in valid:
+        raise SystemExit(f"IX_RUN_PRINT must be one of: {', '.join(sorted(valid))}")
+    return mode
+
+
+def state_root() -> Path:
+    raw = os.environ.get("IX_RUN_DIR")
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return (Path.cwd() / ".ix" / "run").resolve()
+
+
+def slug_for(argv: list[str]) -> str:
+    basename = Path(argv[0]).name or "command"
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", basename).strip("-._")
+    return (slug or "command")[:32]
+
+
+def session_paths(argv: list[str], started: dt.datetime) -> ArtifactPaths:
+    root = state_root()
+    root.mkdir(parents=True, exist_ok=True)
+    stamp = started.strftime("%Y%m%dT%H%M%SZ")
+    base = f"{stamp}-{slug_for(argv)}-{os.getpid()}"
+    session = root / base
+    suffix = 1
+    while session.exists():
+        suffix += 1
+        session = root / f"{base}-{suffix}"
+    session.mkdir(mode=0o700)
+
+    latest = root / "latest"
+    try:
+        if latest.is_symlink() or latest.is_file():
+            latest.unlink()
+        latest.symlink_to(session, target_is_directory=True)
+    except OSError:
+        pass
+
+    return ArtifactPaths(
+        session=session,
+        output=session / "output.log",
+        typescript=session / "typescript",
+        timing=session / "timing.log",
+        events=session / "events.jsonl",
+        lines=session / "lines.jsonl",
+        cast=session / "session.cast",
+        summary=session / "summary.json",
+        replay=session / "replay",
+        live=session / "live",
+    )
+
+
+def write_json(path: Path, data: dict[str, object]) -> None:
+    tmp = path.with_suffix(f"{path.suffix}.tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def shell_script(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def replay_command(paths: ArtifactPaths) -> list[str]:
+    scriptreplay = os.environ.get("IX_RUN_SCRIPTREPLAY", "scriptreplay")
+    return [
+        scriptreplay,
+        "--timing",
+        str(paths.timing),
+        "--log-out",
+        str(paths.typescript),
+        "--divisor",
+        "1",
+    ]
+
+
+def write_helper_scripts(paths: ArtifactPaths) -> None:
+    scriptreplay = os.environ.get("IX_RUN_SCRIPTREPLAY", "scriptreplay")
+    shell_script(
+        paths.replay,
+        "\n".join(
+            [
+                "#!/bin/sh",
+                "set -eu",
+                'divisor="${1:-1}"',
+                "exec "
+                + " ".join(
+                    [
+                        shlex.quote(scriptreplay),
+                        "--timing",
+                        shlex.quote(str(paths.timing)),
+                        "--log-out",
+                        shlex.quote(str(paths.typescript)),
+                        "--divisor",
+                        '"$divisor"',
+                    ]
+                ),
+                "",
+            ]
+        ),
+    )
+    shell_script(
+        paths.live,
+        "\n".join(
+            [
+                "#!/bin/sh",
+                "set -eu",
+                "exec tail -n +1 -f " + shlex.quote(str(paths.output)),
+                "",
+            ]
+        ),
+    )
+
+
+def terminal_size() -> tuple[int, int]:
+    size = os.get_terminal_size(sys.stdout.fileno()) if sys.stdout.isatty() else os.get_terminal_size()
+    return size.columns, size.lines
+
+
+def safe_terminal_size() -> tuple[int, int]:
+    try:
+        return terminal_size()
+    except OSError:
+        fallback = os.environ.get("COLUMNS"), os.environ.get("LINES")
+        try:
+            columns = int(fallback[0] or "80")
+            rows = int(fallback[1] or "24")
+        except ValueError:
+            return 80, 24
+        return max(columns, 1), max(rows, 1)
+
+
+def set_winsize(fd: int, columns: int, rows: int) -> None:
+    packed = struct.pack("HHHH", rows, columns, 0, 0)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, packed)
+
+
+def spawn(argv: list[str], *, columns: int, rows: int) -> tuple[int, int]:
+    master_fd, slave_fd = pty.openpty()
+    set_winsize(slave_fd, columns, rows)
+    pid = os.fork()
+    if pid == 0:
+        try:
+            os.setsid()
+            fcntl.ioctl(slave_fd, termios.TIOCSCTTY, 0)
+            os.dup2(slave_fd, 0)
+            os.dup2(slave_fd, 1)
+            os.dup2(slave_fd, 2)
+            os.close(master_fd)
+            if slave_fd > 2:
+                os.close(slave_fd)
+            os.execvp(argv[0], argv)
+        except FileNotFoundError:
+            os.write(2, f"run: command not found: {argv[0]}\n".encode())
+            os._exit(127)
+        except OSError as exc:
+            os.write(2, f"run: could not execute {argv[0]}: {exc}\n".encode())
+            os._exit(126)
+    os.close(slave_fd)
+    return pid, master_fd
+
+
+def set_nonblocking(fd: int) -> int:
+    flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+    return flags
+
+
+def status_code(status: int) -> tuple[str, int, int | None]:
+    if os.WIFEXITED(status):
+        code = os.WEXITSTATUS(status)
+        return "exited", code, None
+    if os.WIFSIGNALED(status):
+        signum = os.WTERMSIG(status)
+        return "signaled", 128 + signum, signum
+    return "unknown", 1, None
+
+
+def artifact_summary(paths: ArtifactPaths) -> dict[str, str]:
+    return {
+        "session": str(paths.session),
+        "output": str(paths.output),
+        "typescript": str(paths.typescript),
+        "timing": str(paths.timing),
+        "events": str(paths.events),
+        "lines": str(paths.lines),
+        "cast": str(paths.cast),
+        "summary": str(paths.summary),
+        "replay": str(paths.replay),
+        "live": str(paths.live),
+    }
+
+
+def usage() -> str:
+    return "\n".join(
+        [
+            "usage: run <command> [arg ...]",
+            "",
+            "Records a PTY session while running the command exactly as argv.",
+            "",
+            "environment:",
+            f"  IX_RUN_HEAD_LINES  first lines to print, default {DEFAULT_HEAD_LINES}",
+            f"  IX_RUN_TAIL_LINES  last lines to print, default {DEFAULT_TAIL_LINES}",
+            "  IX_RUN_PRINT       summary, full, or none; default summary",
+            "  IX_RUN_DIR         session directory root; default ./.ix/run",
+        ]
+    )
+
+
+def write_stderr(message: str) -> None:
+    try:
+        os.write(sys.stderr.fileno(), message.encode())
+    except OSError:
+        return
+
+
+def command_label(argv: list[str]) -> str:
+    return " ".join(shlex.quote(arg) for arg in argv)
+
+
+def terminal_environment() -> dict[str, str]:
+    return {
+        key: value
+        for key in ["TERM", "COLORTERM", "SHELL"]
+        if (value := os.environ.get(key)) is not None
+    }
+
+
+def initial_summary(
+    *,
+    argv: list[str],
+    paths: ArtifactPaths,
+    started: dt.datetime,
+    start_epoch_ns: int,
+    columns: int,
+    rows: int,
+    head_lines: int,
+    tail_lines: int,
+    mode: str,
+    terminal_env: dict[str, str],
+) -> dict[str, object]:
+    replay = replay_command(paths)
+    return {
+        "schema_version": 1,
+        "status": "running",
+        "command": argv,
+        "command_string": command_label(argv),
+        "cwd": str(Path.cwd()),
+        "pid": os.getpid(),
+        "started_at": isoformat(started),
+        "started_epoch_ns": start_epoch_ns,
+        "terminal": {
+            "columns": columns,
+            "rows": rows,
+            "env": terminal_env,
+        },
+        "limits": {
+            "head_lines": head_lines,
+            "tail_lines": tail_lines,
+            "print_mode": mode,
+        },
+        "artifacts": artifact_summary(paths),
+        "replay": {
+            "scriptreplay": replay,
+            "one_x": str(paths.replay),
+            "two_x": f"{paths.replay} 2",
+            "three_x": f"{paths.replay} 3",
+        },
+    }
+
+
+def run(argv: list[str]) -> int:
+    started = utc_now()
+    start_epoch_ns = time.time_ns()
+    start_monotonic_ns = time.monotonic_ns()
+    head_lines = env_int("IX_RUN_HEAD_LINES", DEFAULT_HEAD_LINES)
+    tail_lines = env_int("IX_RUN_TAIL_LINES", DEFAULT_TAIL_LINES)
+    mode = print_mode()
+    columns, rows = safe_terminal_size()
+    paths = session_paths(argv, started)
+    write_helper_scripts(paths)
+    terminal_env = terminal_environment()
+
+    summary = initial_summary(
+        argv=argv,
+        paths=paths,
+        started=started,
+        start_epoch_ns=start_epoch_ns,
+        columns=columns,
+        rows=rows,
+        head_lines=head_lines,
+        tail_lines=tail_lines,
+        mode=mode,
+        terminal_env=terminal_env,
+    )
+    write_json(paths.summary, summary)
+
+    write_stderr(
+        "\n".join(
+            [
+                f"ix run: recording {command_label(argv)}",
+                f"ix run: session {paths.session}",
+                f"ix run: live output {paths.output}",
+                f"ix run: replay {paths.replay} [speed-divisor]",
+                "",
+            ]
+        )
+    )
+
+    display = DisplayLimiter(
+        head_lines=head_lines,
+        tail_lines=tail_lines,
+        print_mode=mode,
+        output_path=paths.output,
+        stderr_fd=sys.stderr.fileno(),
+        stdout_fd=sys.stdout.fileno(),
+    )
+    terminal = {
+        "columns": columns,
+        "rows": rows,
+        "started_epoch_seconds": int(started.timestamp()),
+        "command": command_label(argv),
+        "env": terminal_env,
+    }
+    recorder = Recorder(
+        paths=paths,
+        start_monotonic_ns=start_monotonic_ns,
+        terminal=terminal,
+        display=display,
+    )
+    pid, master_fd = spawn(argv, columns=columns, rows=rows)
+    selector = selectors.DefaultSelector()
+    selector.register(master_fd, selectors.EVENT_READ, "pty")
+    set_nonblocking(master_fd)
+
+    stdin_fd = sys.stdin.fileno()
+    stdin_registered = False
+    stdin_flags: int | None = None
+    stdin_attrs: list[int | list[bytes | int]] | None = None
+    if stdin_fd >= 0:
+        try:
+            stdin_flags = set_nonblocking(stdin_fd)
+            selector.register(stdin_fd, selectors.EVENT_READ, "stdin")
+            stdin_registered = True
+            if sys.stdin.isatty():
+                stdin_attrs = termios.tcgetattr(stdin_fd)
+                tty.setraw(stdin_fd)
+        except OSError:
+            stdin_registered = False
+
+    child_status: int | None = None
+    pty_open = True
+    previous_handlers: dict[int, SignalHandler] = {}
+
+    def resize(_signum: int, _frame: FrameType | None) -> None:
+        new_columns, new_rows = safe_terminal_size()
+        try:
+            set_winsize(master_fd, new_columns, new_rows)
+            os.killpg(pid, signal.SIGWINCH)
+        except OSError:
+            return
+
+    def forward(signum: int, _frame: FrameType | None) -> None:
+        try:
+            os.killpg(pid, signum)
+        except OSError:
+            return
+
+    previous_winch = signal.signal(signal.SIGWINCH, resize)
+    for signum in [signal.SIGINT, signal.SIGTERM, signal.SIGHUP]:
+        previous_handlers[signum] = signal.signal(signum, forward)
+
+    try:
+        while pty_open or child_status is None:
+            for key, _events in selector.select(timeout=0.1):
+                if key.data == "pty":
+                    while True:
+                        try:
+                            data = os.read(master_fd, READ_SIZE)
+                        except BlockingIOError:
+                            break
+                        except OSError as exc:
+                            if exc.errno != errno.EIO:
+                                raise
+                            selector.unregister(master_fd)
+                            pty_open = False
+                            break
+                        if not data:
+                            selector.unregister(master_fd)
+                            pty_open = False
+                            break
+                        recorder.record(data, sample(start_monotonic_ns))
+                elif key.data == "stdin" and stdin_registered:
+                    try:
+                        data = os.read(stdin_fd, READ_SIZE)
+                    except BlockingIOError:
+                        continue
+                    if data:
+                        try:
+                            os.write(master_fd, data)
+                        except OSError:
+                            pass
+                    else:
+                        selector.unregister(stdin_fd)
+                        stdin_registered = False
+                        try:
+                            os.write(master_fd, b"\x04")
+                        except OSError:
+                            pass
+
+            if child_status is None:
+                try:
+                    waited_pid, status = os.waitpid(pid, os.WNOHANG)
+                except ChildProcessError:
+                    waited_pid = pid
+                    status = 1
+                if waited_pid == pid:
+                    child_status = status
+
+            if child_status is not None and not pty_open:
+                break
+
+        if child_status is None:
+            _waited_pid, child_status = os.waitpid(pid, 0)
+    finally:
+        signal.signal(signal.SIGWINCH, previous_winch)
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+        if stdin_attrs is not None:
+            termios.tcsetattr(stdin_fd, termios.TCSADRAIN, stdin_attrs)
+        if stdin_flags is not None:
+            fcntl.fcntl(stdin_fd, fcntl.F_SETFL, stdin_flags)
+        selector.close()
+        try:
+            os.close(master_fd)
+        except OSError:
+            pass
+
+    finished_sample = sample(start_monotonic_ns)
+    recorder.finish(finished_sample)
+    state, exit_code, signum = status_code(child_status)
+    duration_ns = finished_sample.elapsed_ns
+    summary.update(
+        {
+            "status": state,
+            "exit_code": exit_code,
+            "signal": signum,
+            "ended_at": finished_sample.timestamp,
+            "ended_epoch_ns": finished_sample.epoch_ns,
+            "duration_ns": duration_ns,
+            "duration_seconds": duration_ns / 1_000_000_000,
+            "output": {
+                "byte_count": recorder.byte_count,
+                "line_count": recorder.line_count,
+                "chunk_count": recorder.chunk_count,
+            },
+        }
+    )
+    write_json(paths.summary, summary)
+    recorder.close()
+    write_stderr(
+        f"ix run: {state} with code {exit_code} after {duration_ns / 1_000_000_000:.3f}s\n"
+        f"ix run: structured events {paths.events}\n"
+        f"ix run: structured lines {paths.lines}\n"
+    )
+    return exit_code
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    if not argv:
+        print(usage(), file=sys.stderr)
+        return 2
+    if argv[0] in {"-h", "--help"}:
+        print(usage())
+        return 0
+    return run(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/lib/updates.ts
+++ b/site/src/lib/updates.ts
@@ -14,6 +14,28 @@ export type SiteUpdate = {
 
 export const siteUpdates: SiteUpdate[] = [
   {
+    id: 'recorded-runner',
+    date: '2026-05-25',
+    title: 'Recorded command runs become a package',
+    summary:
+      'The new `run` package keeps long command output compact while saving replayable and queryable artifacts.',
+    paragraphs: [
+      '`nix run .#run -- <command> ...` executes the command in a PTY, prints a bounded head and tail summary, and writes the complete live stream under `./.ix/run/latest`.',
+      'Each session includes `scriptreplay` timing files, an asciinema cast, chunk-level JSONL, line-level JSONL for pandas, and a summary file with duration and exit status.',
+      'The live `output.log` and helper scripts let another shell follow a slow build before the command has finished.'
+    ],
+    links: [
+      {
+        label: 'run package',
+        href: 'https://github.com/indexable-inc/index/tree/main/packages/run'
+      },
+      {
+        label: 'flake package wiring',
+        href: 'https://github.com/indexable-inc/index/blob/main/lib/per-system.nix'
+      }
+    ]
+  },
+  {
     id: 'fleet-secret-refs',
     date: '2026-05-24',
     title: 'Fleet secret refs become typed plan data',


### PR DESCRIPTION
## Summary

- add `packages.x86_64-linux.run` as a PTY command recorder
- write full live output, `scriptreplay` timing files, asciinema cast data, JSONL chunk events, JSONL line events, and a summary manifest per session
- print bounded head/tail output by default and handle redirected/closed stdio edge cases

## Checks

- `nix build .#run .#checks.x86_64-linux.run-records-session`
- `IX_RUN_DIR=/tmp/ix-run-stdin-demo nix run .#run -- cat </tmp/ix-run-stdin.in`
- `nix run .#lint`

Supersedes #127, where the original Codex review threads were addressed but the SHA-specific review gate did not retrigger for the updated head.
