### PR TITLE
run: retry stdin pty writes

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -257,25 +257,11 @@ jobs:
             exit 0
           fi
 
-          review_subject_committed_at="$(
-            gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUMBER}/commits" \
-              | jq -r '[.[][] | .sha] | reverse[]' \
-              | while IFS= read -r commit_sha; do
-                  commit_json="$(gh api "repos/${REPO}/commits/${commit_sha}")"
-                  if jq -e '[.files[]?.filename] | any(. != ".github/workflows/codex-review-gate.yml")' <<<"$commit_json" >/dev/null; then
-                    jq -r '.commit.committer.date' <<<"$commit_json"
-                    break
-                  fi
-                done
-          )"
-
-          if [[ -z "$review_subject_committed_at" ]]; then
-            head_commit_json="$(gh api "repos/${REPO}/commits/${head_sha}")"
-            review_subject_committed_at="$(jq -r '.commit.committer.date' <<<"$head_commit_json")"
-          fi
+          head_commit_json="$(gh api "repos/${REPO}/commits/${head_sha}")"
+          head_committed_at="$(jq -r '.commit.committer.date' <<<"$head_commit_json")"
 
           matching_requested_comment="$(
-            jq --arg reviewSubjectCommittedAt "$review_subject_committed_at" -c '
+            jq --arg headCommittedAt "$head_committed_at" -c '
               def is_codex:
                 .user.login == "chatgpt-codex-connector[bot]"
                 or .user.login == "chatgpt-codex-connector";
@@ -292,7 +278,7 @@ jobs:
                   | $comments[$i]
                   | select(is_no_findings)
                   | . as $response
-                  | select($response.created_at >= $reviewSubjectCommittedAt)
+                  | select($response.created_at >= $headCommittedAt)
                   | (
                       [
                         range(0; $i) as $j
@@ -310,7 +296,7 @@ jobs:
           if [[ -n "$matching_requested_comment" ]]; then
             commenter="$(jq -r '.response.user.login' <<<"$matching_requested_comment")"
             created_at="$(jq -r '.response.created_at' <<<"$matching_requested_comment")"
-            echo "Found no-findings Codex response from ${commenter} for ${head_sha} at ${created_at}, after the latest non-gate commit at ${review_subject_committed_at}."
+            echo "Found no-findings Codex response from ${commenter} for ${head_sha} at ${created_at}, after the current head commit at ${head_committed_at}."
             exit 0
           fi
 
@@ -319,7 +305,7 @@ jobs:
             echo
             echo "No review from \`chatgpt-codex-connector[bot]\` was found for PR #${PR_NUMBER} at \`${head_sha}\`."
             echo
-            echo "Wait for automatic Codex review or comment \`@codex review head ${head_sha}\`, then rerun this check if GitHub does not rerun it automatically. A no-findings Codex comment satisfies this gate when it was posted after the latest non-gate commit."
+            echo "Wait for automatic Codex review or comment \`@codex review head ${head_sha}\`, then rerun this check if GitHub does not rerun it automatically. A no-findings Codex comment satisfies this gate when it was posted after the current head commit."
           } >>"$GITHUB_STEP_SUMMARY"
 
           exit 1

--- a/packages/run/default.nix
+++ b/packages/run/default.nix
@@ -79,6 +79,17 @@ let
         session=$(readlink "$IX_RUN_DIR/latest")
         grep -q 'redirected stdin' "$session/output.log"
 
+        i=0
+        while [ "$i" -lt 40000 ]; do
+          printf '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n'
+          i=$((i + 1))
+        done >large-stdin-input
+        large_size=$(wc -c <large-stdin-input | tr -d ' ')
+        export IX_RUN_DIR=$TMPDIR/runs-large-stdin
+        timeout 20s run ${lib.getExe pkgs.bash} -c 'stty -echo; sleep 1; cat >large-stdin-copy; wc -c <large-stdin-copy' \
+          <large-stdin-input >large-stdin-stdout 2>large-stdin-stderr
+        grep -q "^$large_size" large-stdin-stdout
+
         export IX_RUN_DIR=$TMPDIR/runs-closed-stdin
         (
           exec 0<&-

--- a/packages/run/run.py
+++ b/packages/run/run.py
@@ -9,6 +9,7 @@ import json
 import os
 import pty
 import re
+import select
 import selectors
 import shlex
 import signal
@@ -29,6 +30,7 @@ DEFAULT_HEAD_LINES = 80
 DEFAULT_TAIL_LINES = 80
 READ_SIZE = 65536
 EXPECTED_PTY_ERRORS = {errno.EBADF, errno.EIO, errno.EPIPE}
+RETRYABLE_WRITE_ERRORS = {errno.EAGAIN, errno.EWOULDBLOCK}
 SignalHandler = signal.Handlers | int | Callable[[int, FrameType | None], None] | None
 
 
@@ -520,14 +522,45 @@ def stdio_fd(name: str, fallback: int) -> int:
         return fallback
 
 
-def write_master(master_fd: int, data: bytes) -> bool:
+def wait_master_writable(master_fd: int) -> bool:
     try:
-        os.write(master_fd, data)
+        select.select([], [master_fd], [])
         return True
     except OSError as exc:
         if exc.errno in EXPECTED_PTY_ERRORS:
             return False
         raise
+    except ValueError:
+        return False
+
+
+def write_master(master_fd: int, data: bytes) -> bool:
+    remaining = memoryview(data)
+    while remaining:
+        try:
+            written = os.write(master_fd, remaining)
+        except BlockingIOError:
+            if not wait_master_writable(master_fd):
+                return False
+            continue
+        except InterruptedError:
+            continue
+        except OSError as exc:
+            if exc.errno in EXPECTED_PTY_ERRORS:
+                return False
+            if exc.errno in RETRYABLE_WRITE_ERRORS:
+                if not wait_master_writable(master_fd):
+                    return False
+                continue
+            raise
+
+        if written == 0:
+            if not wait_master_writable(master_fd):
+                return False
+            continue
+        remaining = remaining[written:]
+
+    return True
 
 
 def send_eot(master_fd: int) -> None:


### PR DESCRIPTION
## Summary
- retry nonblocking PTY writes when forwarding stdin so short writes and EAGAIN do not drop redirected input
- add a large redirected-stdin regression for `run`
- tighten the Codex review gate so a no-findings comment must be current for the PR head

## Checks
- `nix build .#run .#checks.x86_64-linux.run-records-session`
- `nix run .#lint`
- `nix flake check`
