### PR TITLE
platform: add ix.dev diagnostic probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -95,7 +95,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -176,6 +176,45 @@ dependencies = [
  "rustc-hash",
  "unicode-ident",
  "winnow",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -491,7 +530,17 @@ dependencies = [
  "encode_unicode",
  "libc",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -640,6 +689,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,7 +834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1427,6 +1499,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "ix-dev-diagnose"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "clap",
+ "rustls",
+ "rustls-native-certs",
+ "serde",
+ "serde_json",
+ "sha2",
+ "url",
+ "webpki-roots",
+ "x509-parser",
+]
+
+[[package]]
 name = "ix-mcp"
 version = "0.1.0"
 dependencies = [
@@ -1745,6 +1834,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,7 +1857,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1780,6 +1875,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,7 +1896,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1826,6 +1931,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1889,6 +2000,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,6 +2019,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "owo-colors"
@@ -2023,6 +2149,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2256,6 +2388,20 @@ name = "resource-monitor-stats-writer"
 version = "0.1.0"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rmcp"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2312,6 +2458,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,7 +2476,53 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2335,6 +2536,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "schemars"
@@ -2373,6 +2583,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2576,7 +2809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2599,6 +2832,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2660,7 +2899,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2713,6 +2952,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,7 +3005,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2995,6 +3265,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3003,6 +3279,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -3143,6 +3420,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3203,12 +3489,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -3320,6 +3679,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3404,6 +3780,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "modules/services/resource-monitor/stats-writer",
   "packages/dag-runner",
+  "packages/ix-dev-diagnose",
   "packages/loop",
   "packages/mcp",
   "packages/minecraft/nbt",
@@ -31,6 +32,8 @@ libc = "0.2"
 loro = "1.12"
 quartz_nbt = "0.2.9"
 rmcp = "1.7"
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+rustls-native-certs = "0.8"
 schemars = "1"
 serde = "1"
 serde_json = "1"
@@ -41,3 +44,5 @@ tokio = "1"
 toml = { version = "1.1.2", default-features = false }
 tower-http = "0.6"
 url = { version = "2.5.8", default-features = false }
+webpki-roots = "1"
+x509-parser = "0.18"

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,7 @@
         packages = {
           ix = ./packages/ix;
           ixFleet = ./packages/ix-fleet;
+          ixDevDiagnose = ./packages/ix-dev-diagnose;
           minecraft = {
             hotReloadAgent = ./packages/minecraft/hot-reload-agent;
             nbt = ./packages/minecraft/nbt;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -625,6 +625,10 @@ let
         ix-fleet = pkgs.callPackage paths.packages.ixFleet {
           ix = ixForPackages;
         };
+        ix-dev-diagnose = pkgs.callPackage paths.packages.ixDevDiagnose {
+          inherit pkgs;
+          ix = ixForPackages;
+        };
         minestom.helloServerJar = pkgs.callPackage paths.packages.minestom.servers.hello {
           ix = ixForPackages;
         };
@@ -712,6 +716,7 @@ let
             (root + "/Cargo.lock")
             (paths.modules + "/services/resource-monitor/stats-writer")
             paths.packages.dagRunner
+            paths.packages.ixDevDiagnose
             paths.packages.loop
             paths.packages.mcp
             paths.packages.minecraft.nbt

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -285,6 +285,7 @@ in
       inherit (repoPackages)
         dag-runner
         drgn
+        ix-dev-diagnose
         ix-fleet
         mc-probe
         minecraft-nbt

--- a/packages/ix-dev-diagnose/Cargo.toml
+++ b/packages/ix-dev-diagnose/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ix-dev-diagnose"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Collect JSON diagnostics for ix.dev HTTPS reachability"
+license = "MIT"
+
+[dependencies]
+anyhow.workspace = true
+base64.workspace = true
+clap = { workspace = true, features = ["derive"] }
+rustls.workspace = true
+rustls-native-certs.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sha2.workspace = true
+url = { workspace = true, features = ["std"] }
+webpki-roots.workspace = true
+x509-parser.workspace = true

--- a/packages/ix-dev-diagnose/README.md
+++ b/packages/ix-dev-diagnose/README.md
@@ -1,0 +1,16 @@
+# ix-dev-diagnose
+
+`ix-dev-diagnose` probes `https://ix.dev/` from the caller's network path and
+prints JSON for support/debugging.
+
+```sh
+nix run .#ix-dev-diagnose -- --pretty
+```
+
+The report includes local DNS answers, one TCP/TLS/HTTP probe per resolved
+address, the certificate chain fingerprints and parsed issuer names, native and
+Mozilla-root verification results, response headers, and a bounded base64 sample
+of the response body. Share the JSON when `https://ix.dev` works for one network
+but fails with browser errors such as `SEC_ERROR_UNKNOWN_ISSUER` on another.
+Pass an explicit URL when the bad bytes are for a specific artifact, such as a
+CLI binary path.

--- a/packages/ix-dev-diagnose/default.nix
+++ b/packages/ix-dev-diagnose/default.nix
@@ -1,0 +1,19 @@
+{
+  ix,
+  pkgs,
+}:
+
+ix.buildRustPackage pkgs {
+  pname = "ix-dev-diagnose";
+  version = "0.1.0";
+
+  src = ix.rustWorkspace.src;
+  cargoLock.lockFile = ix.rustWorkspace.cargoLock;
+  buildAndTestSubdir = "packages/ix-dev-diagnose";
+  cargoArgs = [
+    "-p"
+    "ix-dev-diagnose"
+  ];
+
+  meta.mainProgram = "ix-dev-diagnose";
+}

--- a/packages/ix-dev-diagnose/src/main.rs
+++ b/packages/ix-dev-diagnose/src/main.rs
@@ -1,0 +1,1359 @@
+use std::{
+    collections::BTreeSet,
+    io::{ErrorKind, Read, Write},
+    net::{IpAddr, SocketAddr, TcpStream, ToSocketAddrs},
+    sync::{Arc, Mutex},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result, bail};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use clap::{Parser, ValueEnum};
+use rustls::{
+    ClientConfig, ClientConnection, DigitallySignedStruct, Error as RustlsError, RootCertStore,
+    SignatureScheme, StreamOwned,
+    client::{
+        WebPkiServerVerifier,
+        danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    },
+    pki_types::{CertificateDer, ServerName, UnixTime},
+};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use url::Url;
+use x509_parser::{extensions::GeneralName, prelude::*};
+
+const DEFAULT_URL: &str = "https://ix.dev/";
+const DEFAULT_CONNECT_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_READ_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_MAX_BODY_BYTES: usize = 64 * 1024;
+const MAX_HEADER_BYTES: usize = 64 * 1024;
+const RESPONSE_PREFIX_BYTES: usize = 96;
+
+#[derive(Parser)]
+#[command(
+    about = "Probe ix.dev HTTPS reachability and print JSON diagnostics.",
+    version
+)]
+struct Args {
+    /// HTTPS URL to probe.
+    #[arg(default_value = DEFAULT_URL)]
+    url: String,
+
+    /// Restrict probes to one address family.
+    #[arg(long, value_enum, default_value_t = AddressFamily::Any)]
+    family: AddressFamily,
+
+    /// TCP connect timeout per address.
+    #[arg(long, default_value_t = DEFAULT_CONNECT_TIMEOUT_MS)]
+    connect_timeout_ms: u64,
+
+    /// TLS and HTTP read/write timeout per address.
+    #[arg(long, default_value_t = DEFAULT_READ_TIMEOUT_MS)]
+    read_timeout_ms: u64,
+
+    /// Maximum response body bytes to retain in the JSON report.
+    #[arg(long, default_value_t = DEFAULT_MAX_BODY_BYTES)]
+    max_body_bytes: usize,
+
+    /// Pretty-print the JSON report.
+    #[arg(long)]
+    pretty: bool,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum AddressFamily {
+    Any,
+    Ipv4,
+    Ipv6,
+}
+
+#[derive(Serialize)]
+struct Report {
+    command: CommandReport,
+    target: TargetReport,
+    trust_roots: TrustRootsReport,
+    dns: DnsReport,
+    probes: Vec<ProbeReport>,
+    summary: SummaryReport,
+}
+
+#[derive(Serialize)]
+struct CommandReport {
+    name: &'static str,
+    version: &'static str,
+    started_unix_ms: u64,
+}
+
+#[derive(Serialize)]
+struct TargetReport {
+    url: String,
+    host: String,
+    port: u16,
+    path_and_query: String,
+}
+
+#[derive(Serialize)]
+struct TrustRootsReport {
+    native: RootStoreReport,
+    mozilla: RootStoreReport,
+}
+
+#[derive(Serialize)]
+struct RootStoreReport {
+    loaded: usize,
+    accepted: usize,
+    ignored: usize,
+    errors: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct DnsReport {
+    resolver: &'static str,
+    addresses: Vec<AddressReport>,
+    error: Option<String>,
+}
+
+#[derive(Serialize, Clone)]
+struct AddressReport {
+    socket_addr: String,
+    ip: String,
+    family: &'static str,
+}
+
+#[derive(Serialize)]
+struct ProbeReport {
+    address: AddressReport,
+    tcp: TcpReport,
+    tls: Option<TlsReport>,
+    http: Option<HttpReport>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum TcpReport {
+    Connected {
+        elapsed_ms: u64,
+        local_addr: Option<String>,
+    },
+    Failed {
+        elapsed_ms: u64,
+        error: String,
+    },
+}
+
+#[derive(Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum TlsReport {
+    Completed {
+        elapsed_ms: u64,
+        verification_mode: &'static str,
+        protocol_version: Option<String>,
+        cipher_suite: Option<String>,
+        alpn_protocol: Option<String>,
+        certificate_verification: CertificateVerificationReport,
+        peer_certificates: Vec<CertificateReport>,
+    },
+    Failed {
+        elapsed_ms: u64,
+        error: String,
+        certificate_verification: CertificateVerificationReport,
+        peer_certificates: Vec<CertificateReport>,
+    },
+}
+
+#[derive(Serialize)]
+struct CertificateVerificationReport {
+    native_roots: VerificationStatus,
+    mozilla_roots: VerificationStatus,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum VerificationStatus {
+    Passed,
+    Failed { error: String },
+    NotRun { reason: String },
+}
+
+#[derive(Serialize)]
+struct CertificateReport {
+    index: usize,
+    sha256: String,
+    subject: Option<String>,
+    issuer: Option<String>,
+    serial: Option<String>,
+    not_before: Option<String>,
+    not_after: Option<String>,
+    subject_alt_names: SubjectAltNameReport,
+    parse_error: Option<String>,
+}
+
+#[derive(Default, Serialize)]
+struct SubjectAltNameReport {
+    dns_names: Vec<String>,
+    ip_addresses: Vec<String>,
+    uris: Vec<String>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum HttpReport {
+    Completed {
+        elapsed_ms: u64,
+        status_code: Option<u16>,
+        reason: Option<String>,
+        headers: Vec<HttpHeader>,
+        header_bytes: usize,
+        response_complete: bool,
+        read_limit_reached: bool,
+        body_sample_bytes: usize,
+        body_sample_complete: bool,
+        body_sample_sha256: String,
+        body_sample_base64: String,
+        response_prefix_hex: String,
+    },
+    Failed {
+        elapsed_ms: u64,
+        error: String,
+        bytes_read: usize,
+        response_prefix_hex: String,
+    },
+}
+
+#[derive(Serialize)]
+struct HttpHeader {
+    name: String,
+    value: String,
+}
+
+#[derive(Serialize)]
+struct SummaryReport {
+    ok: bool,
+    diagnoses: Vec<String>,
+}
+
+#[derive(Debug, Default, Clone)]
+struct VerificationCapture {
+    peer_certificates: Vec<Vec<u8>>,
+    native_roots: Option<VerificationStatus>,
+    mozilla_roots: Option<VerificationStatus>,
+}
+
+#[derive(Debug)]
+struct RecordingVerifier {
+    native: Option<Arc<WebPkiServerVerifier>>,
+    mozilla: Arc<WebPkiServerVerifier>,
+    capture: Arc<Mutex<VerificationCapture>>,
+}
+
+struct RootVerifiers {
+    native: Option<Arc<WebPkiServerVerifier>>,
+    mozilla: Arc<WebPkiServerVerifier>,
+    report: TrustRootsReport,
+}
+
+struct TlsOutcome {
+    stream: StreamOwned<ClientConnection, TcpStream>,
+    report: TlsReport,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let pretty = args.pretty;
+    let report = run(&args)?;
+    if pretty {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!("{}", serde_json::to_string(&report)?);
+    }
+    Ok(())
+}
+
+fn run(args: &Args) -> Result<Report> {
+    let started_unix_ms = unix_ms(SystemTime::now());
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
+    let url = Url::parse(&args.url).with_context(|| format!("failed to parse {}", args.url))?;
+    if url.scheme() != "https" {
+        bail!("ix-dev-diagnose only supports https URLs");
+    }
+
+    let host = url
+        .host_str()
+        .context("target URL must include a host")?
+        .to_owned();
+    let port = url.port_or_known_default().unwrap_or(443);
+    let path_and_query = path_and_query(&url);
+    let trust_roots = build_root_verifiers()?;
+    let (addresses, dns_error) = resolve_addresses(&host, port, args.family);
+    let address_reports = addresses.iter().copied().map(AddressReport::from).collect();
+
+    let target = TargetReport {
+        url: url.to_string(),
+        host,
+        port,
+        path_and_query,
+    };
+    let probes = addresses
+        .iter()
+        .copied()
+        .map(|address| probe_address(address, &target, &trust_roots, args))
+        .collect::<Vec<_>>();
+    let dns = DnsReport {
+        resolver: "system",
+        addresses: address_reports,
+        error: dns_error,
+    };
+    let summary = summarize(&dns, &probes);
+
+    Ok(Report {
+        command: CommandReport {
+            name: "ix-dev-diagnose",
+            version: env!("CARGO_PKG_VERSION"),
+            started_unix_ms,
+        },
+        target,
+        trust_roots: trust_roots.report,
+        dns,
+        probes,
+        summary,
+    })
+}
+
+fn build_root_verifiers() -> Result<RootVerifiers> {
+    let native_result = rustls_native_certs::load_native_certs();
+    let native_loaded = native_result.certs.len();
+    let native_errors = native_result
+        .errors
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    let mut native_store = RootCertStore::empty();
+    let (native_accepted, native_ignored) =
+        native_store.add_parsable_certificates(native_result.certs);
+    let native = if native_store.is_empty() {
+        None
+    } else {
+        Some(
+            WebPkiServerVerifier::builder(Arc::new(native_store))
+                .build()
+                .context("failed to build native-root verifier")?,
+        )
+    };
+
+    let mozilla_loaded = webpki_roots::TLS_SERVER_ROOTS.len();
+    let mut mozilla_store = RootCertStore::empty();
+    mozilla_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let mozilla = WebPkiServerVerifier::builder(Arc::new(mozilla_store))
+        .build()
+        .context("failed to build Mozilla-root verifier")?;
+
+    Ok(RootVerifiers {
+        native,
+        mozilla,
+        report: TrustRootsReport {
+            native: RootStoreReport {
+                loaded: native_loaded,
+                accepted: native_accepted,
+                ignored: native_ignored,
+                errors: native_errors,
+            },
+            mozilla: RootStoreReport {
+                loaded: mozilla_loaded,
+                accepted: mozilla_loaded,
+                ignored: 0,
+                errors: Vec::new(),
+            },
+        },
+    })
+}
+
+fn resolve_addresses(
+    host: &str,
+    port: u16,
+    family: AddressFamily,
+) -> (Vec<SocketAddr>, Option<String>) {
+    match (host, port).to_socket_addrs() {
+        Ok(addrs) => {
+            let addresses = addrs
+                .filter(|address| family.matches(address.ip()))
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            (addresses, None)
+        }
+        Err(error) => (Vec::new(), Some(error.to_string())),
+    }
+}
+
+fn probe_address(
+    address: SocketAddr,
+    target: &TargetReport,
+    trust_roots: &RootVerifiers,
+    args: &Args,
+) -> ProbeReport {
+    let address_report = AddressReport::from(address);
+    let connect_start = Instant::now();
+    let connect_timeout = Duration::from_millis(args.connect_timeout_ms);
+    let stream = match TcpStream::connect_timeout(&address, connect_timeout) {
+        Ok(stream) => stream,
+        Err(error) => {
+            return ProbeReport {
+                address: address_report,
+                tcp: TcpReport::Failed {
+                    elapsed_ms: elapsed_ms(connect_start),
+                    error: error.to_string(),
+                },
+                tls: None,
+                http: None,
+            };
+        }
+    };
+
+    let local_addr = stream.local_addr().ok().map(|addr| addr.to_string());
+    let tcp = TcpReport::Connected {
+        elapsed_ms: elapsed_ms(connect_start),
+        local_addr,
+    };
+    let timeout = Duration::from_millis(args.read_timeout_ms);
+    if let Err(error) = stream.set_read_timeout(Some(timeout)) {
+        return tls_setup_failure(address_report, tcp, &error);
+    }
+    if let Err(error) = stream.set_write_timeout(Some(timeout)) {
+        return tls_setup_failure(address_report, tcp, &error);
+    }
+
+    match probe_tls(stream, target, trust_roots) {
+        Ok(mut outcome) => {
+            let http = Some(probe_http(&mut outcome.stream, target, args.max_body_bytes));
+            ProbeReport {
+                address: address_report,
+                tcp,
+                tls: Some(outcome.report),
+                http,
+            }
+        }
+        Err(report) => ProbeReport {
+            address: address_report,
+            tcp,
+            tls: Some(*report),
+            http: None,
+        },
+    }
+}
+
+fn tls_setup_failure(
+    address: AddressReport,
+    tcp: TcpReport,
+    error: &std::io::Error,
+) -> ProbeReport {
+    ProbeReport {
+        address,
+        tcp,
+        tls: Some(TlsReport::Failed {
+            elapsed_ms: 0,
+            error: format!("failed to configure socket timeout: {error}"),
+            certificate_verification: CertificateVerificationReport::not_run(
+                "TLS handshake did not start",
+            ),
+            peer_certificates: Vec::new(),
+        }),
+        http: None,
+    }
+}
+
+fn probe_tls(
+    stream: TcpStream,
+    target: &TargetReport,
+    trust_roots: &RootVerifiers,
+) -> std::result::Result<TlsOutcome, Box<TlsReport>> {
+    let capture = Arc::new(Mutex::new(VerificationCapture::default()));
+    let verifier = RecordingVerifier {
+        native: trust_roots.native.clone(),
+        mozilla: Arc::clone(&trust_roots.mozilla),
+        capture: Arc::clone(&capture),
+    };
+    let mut config = ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(verifier))
+        .with_no_client_auth();
+    config.alpn_protocols = vec![b"http/1.1".to_vec()];
+
+    let server_name = match ServerName::try_from(target.host.clone()) {
+        Ok(name) => name,
+        Err(error) => {
+            return Err(Box::new(TlsReport::Failed {
+                elapsed_ms: 0,
+                error: format!("invalid TLS server name: {error}"),
+                certificate_verification: CertificateVerificationReport::not_run(
+                    "invalid server name",
+                ),
+                peer_certificates: Vec::new(),
+            }));
+        }
+    };
+    let mut connection = match ClientConnection::new(Arc::new(config), server_name) {
+        Ok(connection) => connection,
+        Err(error) => {
+            return Err(Box::new(TlsReport::Failed {
+                elapsed_ms: 0,
+                error: error.to_string(),
+                certificate_verification: CertificateVerificationReport::not_run(
+                    "TLS client setup failed",
+                ),
+                peer_certificates: Vec::new(),
+            }));
+        }
+    };
+
+    let tls_start = Instant::now();
+    let mut socket = stream;
+    while connection.is_handshaking() {
+        if let Err(error) = connection.complete_io(&mut socket) {
+            let captured = captured_verification(&capture);
+            return Err(Box::new(TlsReport::Failed {
+                elapsed_ms: elapsed_ms(tls_start),
+                error: error.to_string(),
+                certificate_verification: captured.verification,
+                peer_certificates: captured.certificates,
+            }));
+        }
+    }
+
+    let captured = captured_verification(&capture);
+    let report = TlsReport::Completed {
+        elapsed_ms: elapsed_ms(tls_start),
+        verification_mode: "recording_verifier",
+        protocol_version: connection
+            .protocol_version()
+            .map(|version| format!("{version:?}")),
+        cipher_suite: connection
+            .negotiated_cipher_suite()
+            .map(|suite| format!("{:?}", suite.suite())),
+        alpn_protocol: connection
+            .alpn_protocol()
+            .map(|protocol| String::from_utf8_lossy(protocol).into_owned()),
+        certificate_verification: captured.verification,
+        peer_certificates: captured.certificates,
+    };
+
+    Ok(TlsOutcome {
+        stream: StreamOwned::new(connection, socket),
+        report,
+    })
+}
+
+fn probe_http(
+    stream: &mut StreamOwned<ClientConnection, TcpStream>,
+    target: &TargetReport,
+    max_body_bytes: usize,
+) -> HttpReport {
+    let start = Instant::now();
+    let request = format!(
+        "GET {} HTTP/1.1\r\nHost: {}\r\nUser-Agent: ix-dev-diagnose/{}\r\nAccept: */*\r\nConnection: close\r\n\r\n",
+        target.path_and_query,
+        host_header(&target.host, target.port),
+        env!("CARGO_PKG_VERSION"),
+    );
+    if let Err(error) = stream.write_all(request.as_bytes()) {
+        return HttpReport::Failed {
+            elapsed_ms: elapsed_ms(start),
+            error: error.to_string(),
+            bytes_read: 0,
+            response_prefix_hex: String::new(),
+        };
+    }
+    if let Err(error) = stream.flush() {
+        return HttpReport::Failed {
+            elapsed_ms: elapsed_ms(start),
+            error: error.to_string(),
+            bytes_read: 0,
+            response_prefix_hex: String::new(),
+        };
+    }
+
+    let limit = MAX_HEADER_BYTES.saturating_add(max_body_bytes);
+    let mut response = Vec::new();
+    let mut buffer = [0_u8; 8192];
+    let mut response_complete = false;
+    let mut read_limit_reached = false;
+    loop {
+        let remaining = limit.saturating_sub(response.len());
+        if remaining == 0 {
+            read_limit_reached = true;
+            break;
+        }
+        let read_len = buffer.len().min(remaining);
+        match stream.read(&mut buffer[..read_len]) {
+            Ok(0) => {
+                response_complete = eof_completes_response(&response);
+                break;
+            }
+            Ok(count) => {
+                response.extend_from_slice(&buffer[..count]);
+                if response_has_complete_framing(&response) {
+                    response_complete = true;
+                    break;
+                }
+            }
+            Err(error) if error.kind() == ErrorKind::UnexpectedEof && !response.is_empty() => {
+                response_complete = eof_completes_response(&response);
+                break;
+            }
+            Err(error) => {
+                return HttpReport::Failed {
+                    elapsed_ms: elapsed_ms(start),
+                    error: error.to_string(),
+                    bytes_read: response.len(),
+                    response_prefix_hex: hex_prefix(&response),
+                };
+            }
+        }
+    }
+
+    parse_http_response(
+        &response,
+        max_body_bytes,
+        response_complete,
+        read_limit_reached,
+        elapsed_ms(start),
+    )
+}
+
+fn parse_http_response(
+    response: &[u8],
+    max_body_bytes: usize,
+    response_complete: bool,
+    read_limit_reached: bool,
+    elapsed_ms: u64,
+) -> HttpReport {
+    let Some((header_start, header_end)) = final_header_block(response) else {
+        return HttpReport::Failed {
+            elapsed_ms,
+            error: "response did not contain complete HTTP headers".to_owned(),
+            bytes_read: response.len(),
+            response_prefix_hex: hex_prefix(response),
+        };
+    };
+    let header_bytes = &response[header_start..header_end];
+    let body_start = header_end + 4;
+    let body = response.get(body_start..).unwrap_or_default();
+    let body_sample = &body[..body.len().min(max_body_bytes)];
+    let (status_code, reason, headers) = parse_headers(header_bytes);
+
+    HttpReport::Completed {
+        elapsed_ms,
+        status_code,
+        reason,
+        headers,
+        header_bytes: header_bytes.len(),
+        response_complete,
+        read_limit_reached,
+        body_sample_bytes: body_sample.len(),
+        body_sample_complete: response_complete && body.len() <= max_body_bytes,
+        body_sample_sha256: sha256_hex(body_sample),
+        body_sample_base64: BASE64_STANDARD.encode(body_sample),
+        response_prefix_hex: hex_prefix(response),
+    }
+}
+
+fn parse_headers(header_bytes: &[u8]) -> (Option<u16>, Option<String>, Vec<HttpHeader>) {
+    let header_text = String::from_utf8_lossy(header_bytes);
+    let mut lines = header_text.split("\r\n");
+    let (status_code, reason) = lines.next().map_or((None, None), parse_status_line);
+    let headers = lines
+        .filter_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            Some(HttpHeader {
+                name: name.trim().to_owned(),
+                value: value.trim().to_owned(),
+            })
+        })
+        .collect();
+
+    (status_code, reason, headers)
+}
+
+fn parse_status_line(line: &str) -> (Option<u16>, Option<String>) {
+    let mut parts = line.splitn(3, ' ');
+    let _version = parts.next();
+    let status_code = parts.next().and_then(|code| code.parse().ok());
+    let reason = parts.next().map(str::to_owned);
+    (status_code, reason)
+}
+
+fn final_header_block(response: &[u8]) -> Option<(usize, usize)> {
+    let mut header_start = 0;
+    loop {
+        let header_end = header_start + find_header_end(&response[header_start..])?;
+        let header_bytes = &response[header_start..header_end];
+        let (status_code, _reason, _headers) = parse_headers(header_bytes);
+        if matches!(status_code, Some(100..=199)) {
+            header_start = header_end + 4;
+            continue;
+        }
+
+        return Some((header_start, header_end));
+    }
+}
+
+fn response_has_complete_framing(response: &[u8]) -> bool {
+    matches!(response_framing(response), ResponseFraming::Complete)
+}
+
+fn eof_completes_response(response: &[u8]) -> bool {
+    matches!(
+        response_framing(response),
+        ResponseFraming::Complete | ResponseFraming::CloseDelimited
+    )
+}
+
+fn response_framing(response: &[u8]) -> ResponseFraming {
+    let Some((header_start, header_end)) = final_header_block(response) else {
+        return ResponseFraming::Incomplete;
+    };
+    let header_bytes = &response[header_start..header_end];
+    let (status_code, _reason, headers) = parse_headers(header_bytes);
+    if matches!(status_code, Some(204 | 205 | 304)) {
+        return ResponseFraming::Complete;
+    }
+
+    let body_start = header_end + 4;
+    let body = response.get(body_start..).unwrap_or_default();
+    if transfer_encoding_is_chunked(&headers) {
+        return if chunked_body_complete(body) {
+            ResponseFraming::Complete
+        } else {
+            ResponseFraming::Incomplete
+        };
+    }
+    if let Some(content_length) = content_length(&headers) {
+        return if body.len() >= content_length {
+            ResponseFraming::Complete
+        } else {
+            ResponseFraming::Incomplete
+        };
+    }
+
+    ResponseFraming::CloseDelimited
+}
+
+#[derive(Clone, Copy)]
+enum ResponseFraming {
+    Complete,
+    Incomplete,
+    CloseDelimited,
+}
+
+fn content_length(headers: &[HttpHeader]) -> Option<usize> {
+    headers
+        .iter()
+        .find(|header| header.name.eq_ignore_ascii_case("content-length"))
+        .and_then(|header| header.value.parse().ok())
+}
+
+fn transfer_encoding_is_chunked(headers: &[HttpHeader]) -> bool {
+    headers
+        .iter()
+        .filter(|header| header.name.eq_ignore_ascii_case("transfer-encoding"))
+        .flat_map(|header| header.value.split(','))
+        .any(|coding| coding.trim().eq_ignore_ascii_case("chunked"))
+}
+
+fn chunked_body_complete(mut body: &[u8]) -> bool {
+    loop {
+        let Some(size_line_end) = find_crlf(body) else {
+            return false;
+        };
+        let size_line = &body[..size_line_end];
+        let Some(chunk_size) = parse_chunk_size(size_line) else {
+            return false;
+        };
+        body = &body[size_line_end + 2..];
+        if chunk_size == 0 {
+            return trailer_block_complete(body);
+        }
+        let Some(chunk_with_crlf) = chunk_size.checked_add(2) else {
+            return false;
+        };
+        if body.len() < chunk_with_crlf {
+            return false;
+        }
+        if &body[chunk_size..chunk_size + 2] != b"\r\n" {
+            return false;
+        }
+        body = &body[chunk_with_crlf..];
+    }
+}
+
+fn parse_chunk_size(size_line: &[u8]) -> Option<usize> {
+    let size_text = std::str::from_utf8(size_line).ok()?;
+    let size_hex = size_text
+        .split_once(';')
+        .map_or(size_text, |(size, _)| size);
+    usize::from_str_radix(size_hex.trim(), 16).ok()
+}
+
+fn trailer_block_complete(trailers: &[u8]) -> bool {
+    trailers.starts_with(b"\r\n") || find_header_end(trailers).is_some()
+}
+
+fn find_crlf(bytes: &[u8]) -> Option<usize> {
+    bytes.windows(2).position(|window| window == b"\r\n")
+}
+
+fn captured_verification(capture: &Mutex<VerificationCapture>) -> CapturedVerification {
+    let captured = capture.lock().map_or_else(
+        |_| VerificationCapture {
+            peer_certificates: Vec::new(),
+            native_roots: Some(VerificationStatus::NotRun {
+                reason: "verification capture mutex was poisoned".to_owned(),
+            }),
+            mozilla_roots: Some(VerificationStatus::NotRun {
+                reason: "verification capture mutex was poisoned".to_owned(),
+            }),
+        },
+        |guard| guard.clone(),
+    );
+    let certificates = captured
+        .peer_certificates
+        .iter()
+        .enumerate()
+        .map(|(index, der)| certificate_report(index, der))
+        .collect();
+    let verification = CertificateVerificationReport {
+        native_roots: captured
+            .native_roots
+            .unwrap_or_else(|| VerificationStatus::NotRun {
+                reason: "certificate verifier was not called".to_owned(),
+            }),
+        mozilla_roots: captured
+            .mozilla_roots
+            .unwrap_or_else(|| VerificationStatus::NotRun {
+                reason: "certificate verifier was not called".to_owned(),
+            }),
+    };
+
+    CapturedVerification {
+        certificates,
+        verification,
+    }
+}
+
+struct CapturedVerification {
+    certificates: Vec<CertificateReport>,
+    verification: CertificateVerificationReport,
+}
+
+fn certificate_report(index: usize, der: &[u8]) -> CertificateReport {
+    let sha256 = sha256_hex(der);
+    match X509Certificate::from_der(der) {
+        Ok((_remaining, cert)) => {
+            let validity = cert.validity();
+            CertificateReport {
+                index,
+                sha256,
+                subject: Some(cert.subject().to_string()),
+                issuer: Some(cert.issuer().to_string()),
+                serial: Some(cert.tbs_certificate.raw_serial_as_string()),
+                not_before: Some(format_time(validity.not_before)),
+                not_after: Some(format_time(validity.not_after)),
+                subject_alt_names: subject_alt_names(&cert),
+                parse_error: None,
+            }
+        }
+        Err(error) => CertificateReport {
+            index,
+            sha256,
+            subject: None,
+            issuer: None,
+            serial: None,
+            not_before: None,
+            not_after: None,
+            subject_alt_names: SubjectAltNameReport::default(),
+            parse_error: Some(error.to_string()),
+        },
+    }
+}
+
+fn subject_alt_names(cert: &X509Certificate<'_>) -> SubjectAltNameReport {
+    let mut names = SubjectAltNameReport::default();
+    let Ok(Some(extension)) = cert.subject_alternative_name() else {
+        return names;
+    };
+
+    for name in &extension.value.general_names {
+        match name {
+            GeneralName::DNSName(name) => names.dns_names.push((*name).to_owned()),
+            GeneralName::IPAddress(bytes) => names.ip_addresses.push(format_ip_san(bytes)),
+            GeneralName::URI(uri) => names.uris.push((*uri).to_owned()),
+            _ => {}
+        }
+    }
+
+    names
+}
+
+fn format_ip_san(bytes: &[u8]) -> String {
+    match bytes.len() {
+        4 => IpAddr::from([bytes[0], bytes[1], bytes[2], bytes[3]]).to_string(),
+        16 => {
+            let mut octets = [0_u8; 16];
+            octets.copy_from_slice(bytes);
+            IpAddr::from(octets).to_string()
+        }
+        _ => hex(bytes),
+    }
+}
+
+fn summarize(dns: &DnsReport, probes: &[ProbeReport]) -> SummaryReport {
+    let mut diagnoses = BTreeSet::new();
+    if dns.error.is_some() {
+        diagnoses.insert("dns_failed".to_owned());
+    }
+    if dns.addresses.is_empty() && dns.error.is_none() {
+        diagnoses.insert("dns_returned_no_addresses".to_owned());
+    }
+    if !probes.is_empty() && probes.iter().all(|probe| tcp_failed(&probe.tcp)) {
+        diagnoses.insert("tcp_connect_failed_for_all_addresses".to_owned());
+    }
+    if probes.iter().any(tls_failed) {
+        diagnoses.insert("tls_handshake_failed".to_owned());
+    }
+    if probes.iter().any(verification_failed) {
+        diagnoses.insert("certificate_verification_failed".to_owned());
+    }
+    if probes.iter().any(unknown_issuer) {
+        diagnoses.insert("certificate_unknown_issuer".to_owned());
+    }
+    if probes.iter().any(unexpected_http_status) {
+        diagnoses.insert("unexpected_http_status".to_owned());
+    }
+    if probes.iter().any(http_bytes_failed) {
+        diagnoses.insert("http_response_bytes_unavailable".to_owned());
+    }
+    if probes.iter().any(http_response_incomplete) {
+        diagnoses.insert("http_response_incomplete".to_owned());
+    }
+    if diagnoses.is_empty() && probes.iter().any(probe_ok) {
+        diagnoses.insert("reachable".to_owned());
+    }
+
+    let diagnoses = diagnoses.into_iter().collect::<Vec<_>>();
+    SummaryReport {
+        ok: diagnoses.len() == 1 && diagnoses[0] == "reachable",
+        diagnoses,
+    }
+}
+
+const fn tcp_failed(tcp: &TcpReport) -> bool {
+    matches!(tcp, TcpReport::Failed { .. })
+}
+
+const fn tls_failed(probe: &ProbeReport) -> bool {
+    matches!(probe.tls, Some(TlsReport::Failed { .. }))
+}
+
+fn verification_failed(probe: &ProbeReport) -> bool {
+    verification_statuses(probe)
+        .iter()
+        .any(|status| matches!(status, VerificationStatus::Failed { .. }))
+}
+
+fn unknown_issuer(probe: &ProbeReport) -> bool {
+    verification_statuses(probe)
+        .iter()
+        .any(|status| match status {
+            VerificationStatus::Failed { error } => {
+                let lowercase = error.to_ascii_lowercase();
+                lowercase.contains("unknownissuer") || lowercase.contains("unknown issuer")
+            }
+            VerificationStatus::Passed | VerificationStatus::NotRun { .. } => false,
+        })
+}
+
+fn unexpected_http_status(probe: &ProbeReport) -> bool {
+    matches!(
+        probe.http,
+        Some(HttpReport::Completed {
+            status_code: Some(code),
+            ..
+        }) if !(200..400).contains(&code)
+    )
+}
+
+const fn http_bytes_failed(probe: &ProbeReport) -> bool {
+    matches!(probe.http, Some(HttpReport::Failed { .. }))
+}
+
+const fn http_response_incomplete(probe: &ProbeReport) -> bool {
+    matches!(
+        probe.http,
+        Some(HttpReport::Completed {
+            response_complete: false,
+            read_limit_reached: false,
+            ..
+        })
+    )
+}
+
+fn probe_ok(probe: &ProbeReport) -> bool {
+    matches!(probe.tcp, TcpReport::Connected { .. })
+        && matches!(probe.tls, Some(TlsReport::Completed { .. }))
+        && !verification_failed(probe)
+        && matches!(
+            probe.http,
+            Some(
+                HttpReport::Completed {
+                    status_code: Some(200..=399),
+                    response_complete: true,
+                    ..
+                } | HttpReport::Completed {
+                    status_code: Some(200..=399),
+                    read_limit_reached: true,
+                    ..
+                }
+            )
+        )
+}
+
+fn verification_statuses(probe: &ProbeReport) -> Vec<&VerificationStatus> {
+    match &probe.tls {
+        Some(
+            TlsReport::Completed {
+                certificate_verification,
+                ..
+            }
+            | TlsReport::Failed {
+                certificate_verification,
+                ..
+            },
+        ) => vec![
+            &certificate_verification.native_roots,
+            &certificate_verification.mozilla_roots,
+        ],
+        None => Vec::new(),
+    }
+}
+
+impl ServerCertVerifier for RecordingVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        server_name: &ServerName<'_>,
+        ocsp_response: &[u8],
+        now: UnixTime,
+    ) -> std::result::Result<ServerCertVerified, RustlsError> {
+        let peer_certificates = certificate_chain(end_entity, intermediates);
+        let native_roots = verify_with_optional(
+            self.native.as_deref(),
+            end_entity,
+            intermediates,
+            server_name,
+            ocsp_response,
+            now,
+        );
+        let mozilla_roots = verify_with(
+            &self.mozilla,
+            end_entity,
+            intermediates,
+            server_name,
+            ocsp_response,
+            now,
+        );
+        if let Ok(mut capture) = self.capture.lock() {
+            capture.peer_certificates = peer_certificates;
+            capture.native_roots = Some(native_roots);
+            capture.mozilla_roots = Some(mozilla_roots);
+        }
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, RustlsError> {
+        self.mozilla.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, RustlsError> {
+        self.mozilla.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.mozilla.supported_verify_schemes()
+    }
+}
+
+impl CertificateVerificationReport {
+    fn not_run(reason: &str) -> Self {
+        Self {
+            native_roots: VerificationStatus::NotRun {
+                reason: reason.to_owned(),
+            },
+            mozilla_roots: VerificationStatus::NotRun {
+                reason: reason.to_owned(),
+            },
+        }
+    }
+}
+
+impl AddressFamily {
+    const fn matches(self, ip: IpAddr) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Ipv4 => ip.is_ipv4(),
+            Self::Ipv6 => ip.is_ipv6(),
+        }
+    }
+}
+
+impl From<SocketAddr> for AddressReport {
+    fn from(address: SocketAddr) -> Self {
+        let ip = address.ip();
+        Self {
+            socket_addr: address.to_string(),
+            ip: ip.to_string(),
+            family: if ip.is_ipv4() { "ipv4" } else { "ipv6" },
+        }
+    }
+}
+
+fn verify_with_optional(
+    verifier: Option<&WebPkiServerVerifier>,
+    end_entity: &CertificateDer<'_>,
+    intermediates: &[CertificateDer<'_>],
+    server_name: &ServerName<'_>,
+    ocsp_response: &[u8],
+    now: UnixTime,
+) -> VerificationStatus {
+    verifier.map_or_else(
+        || VerificationStatus::NotRun {
+            reason: "no native trust roots were available".to_owned(),
+        },
+        |verifier| {
+            verify_with(
+                verifier,
+                end_entity,
+                intermediates,
+                server_name,
+                ocsp_response,
+                now,
+            )
+        },
+    )
+}
+
+fn verify_with(
+    verifier: &WebPkiServerVerifier,
+    end_entity: &CertificateDer<'_>,
+    intermediates: &[CertificateDer<'_>],
+    server_name: &ServerName<'_>,
+    ocsp_response: &[u8],
+    now: UnixTime,
+) -> VerificationStatus {
+    match verifier.verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now) {
+        Ok(_) => VerificationStatus::Passed,
+        Err(error) => VerificationStatus::Failed {
+            error: error.to_string(),
+        },
+    }
+}
+
+fn certificate_chain(
+    end_entity: &CertificateDer<'_>,
+    intermediates: &[CertificateDer<'_>],
+) -> Vec<Vec<u8>> {
+    let mut certificates = Vec::with_capacity(intermediates.len() + 1);
+    certificates.push(end_entity.as_ref().to_vec());
+    certificates.extend(
+        intermediates
+            .iter()
+            .map(|certificate| certificate.as_ref().to_vec()),
+    );
+    certificates
+}
+
+fn path_and_query(url: &Url) -> String {
+    let mut path = if url.path().is_empty() {
+        "/".to_owned()
+    } else {
+        url.path().to_owned()
+    };
+    if let Some(query) = url.query() {
+        path.push('?');
+        path.push_str(query);
+    }
+    path
+}
+
+fn host_header(host: &str, port: u16) -> String {
+    let host = if host.contains(':') {
+        format!("[{host}]")
+    } else {
+        host.to_owned()
+    };
+    if port == 443 {
+        host
+    } else {
+        format!("{host}:{port}")
+    }
+}
+
+fn find_header_end(response: &[u8]) -> Option<usize> {
+    response.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+fn format_time(time: ASN1Time) -> String {
+    time.to_rfc2822().unwrap_or_else(|_| time.to_string())
+}
+
+fn unix_ms(time: SystemTime) -> u64 {
+    time.duration_since(UNIX_EPOCH).map_or(0, millis)
+}
+
+fn elapsed_ms(start: Instant) -> u64 {
+    millis(start.elapsed())
+}
+
+fn millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    hex(Sha256::digest(bytes).as_slice())
+}
+
+fn hex_prefix(bytes: &[u8]) -> String {
+    hex(&bytes[..bytes.len().min(RESPONSE_PREFIX_BYTES)])
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(char::from(HEX[usize::from(byte >> 4)]));
+        output.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_http_status_headers_and_body() {
+        let response = b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nhello";
+        let HttpReport::Completed {
+            status_code,
+            headers,
+            body_sample_bytes,
+            body_sample_complete,
+            ..
+        } = parse_http_response(response, 32, true, false, 7)
+        else {
+            panic!("expected completed HTTP report");
+        };
+
+        assert_eq!(status_code, Some(200));
+        assert_eq!(headers[0].name, "Content-Type");
+        assert_eq!(headers[0].value, "text/plain");
+        assert_eq!(body_sample_bytes, 5);
+        assert!(body_sample_complete);
+    }
+
+    #[test]
+    fn marks_body_sample_incomplete_when_read_stopped_at_limit() {
+        let response = b"HTTP/1.1 200 OK\r\nContent-Length: 1024\r\n\r\nabc";
+        let HttpReport::Completed {
+            body_sample_bytes,
+            body_sample_complete,
+            ..
+        } = parse_http_response(response, 3, false, true, 7)
+        else {
+            panic!("expected completed HTTP report");
+        };
+
+        assert_eq!(body_sample_bytes, 3);
+        assert!(!body_sample_complete);
+    }
+
+    #[test]
+    fn skips_interim_http_headers() {
+        let response = b"HTTP/1.1 103 Early Hints\r\nLink: </style.css>\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nok";
+        let HttpReport::Completed {
+            status_code,
+            headers,
+            body_sample_bytes,
+            ..
+        } = parse_http_response(response, 32, true, false, 7)
+        else {
+            panic!("expected completed HTTP report");
+        };
+
+        assert_eq!(status_code, Some(200));
+        assert_eq!(headers[0].name, "Content-Type");
+        assert_eq!(headers[0].value, "text/plain");
+        assert_eq!(body_sample_bytes, 2);
+    }
+
+    #[test]
+    fn detects_complete_content_length_response() {
+        let response = b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello";
+        assert!(response_has_complete_framing(response));
+
+        let incomplete = b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhe";
+        assert!(!response_has_complete_framing(incomplete));
+        assert!(!eof_completes_response(incomplete));
+    }
+
+    #[test]
+    fn detects_complete_chunked_response() {
+        let response =
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
+        assert!(response_has_complete_framing(response));
+
+        let incomplete = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n";
+        assert!(!response_has_complete_framing(incomplete));
+        assert!(!eof_completes_response(incomplete));
+    }
+
+    #[test]
+    fn treats_no_body_status_as_complete() {
+        let response = b"HTTP/1.1 205 Reset Content\r\n\r\n";
+        assert!(response_has_complete_framing(response));
+    }
+
+    #[test]
+    fn transfer_encoding_overrides_content_length() {
+        let incomplete = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n";
+        assert!(!response_has_complete_framing(incomplete));
+
+        let complete = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
+        assert!(response_has_complete_framing(complete));
+    }
+
+    #[test]
+    fn rejects_chunk_size_that_would_overflow() {
+        let response = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\nffffffffffffffff\r\n";
+        assert!(!response_has_complete_framing(response));
+    }
+
+    #[test]
+    fn keeps_query_in_request_target() {
+        let url = Url::parse("https://ix.dev/cli/linux-x86_64/ix?download=1").unwrap();
+        assert_eq!(path_and_query(&url), "/cli/linux-x86_64/ix?download=1");
+    }
+}

--- a/site/src/lib/updates.ts
+++ b/site/src/lib/updates.ts
@@ -14,6 +14,28 @@ export type SiteUpdate = {
 
 export const siteUpdates: SiteUpdate[] = [
   {
+    id: 'ix-dev-diagnose',
+    date: '2026-05-25',
+    title: 'ix.dev reachability gets a JSON probe',
+    summary:
+      '`ix-dev-diagnose` captures DNS, TLS, certificate, and response-byte clues when ix.dev behaves differently by network.',
+    paragraphs: [
+      '`nix run .#ix-dev-diagnose -- --pretty` probes `https://ix.dev/` from the caller\'s path and emits one JSON report for sharing with support.',
+      'The report records system resolver answers, per-address TCP and TLS results, parsed certificate issuers and fingerprints, native and Mozilla-root verification outcomes, headers, and a bounded response-body sample.',
+      'This is meant for cases such as `SEC_ERROR_UNKNOWN_ISSUER`, captive portals, ISP interception, stale DNS, or CDN edge differences where the failing client sees different bytes than a working client.'
+    ],
+    links: [
+      {
+        label: 'diagnostic package',
+        href: 'https://github.com/indexable-inc/index/tree/main/packages/ix-dev-diagnose'
+      },
+      {
+        label: 'flake package wiring',
+        href: 'https://github.com/indexable-inc/index/blob/main/lib/per-system.nix'
+      }
+    ]
+  },
+  {
     id: 'recorded-runner',
     date: '2026-05-25',
     title: 'Recorded command runs become a package',


### PR DESCRIPTION
## Summary
- add `ix-dev-diagnose`, a Rust JSON probe for `https://ix.dev/` reachability differences
- report system DNS answers, per-address TCP/TLS/HTTP results, certificate chain fingerprints, native and Mozilla trust verification, and bounded response-byte samples
- expose the package through `nix run .#ix-dev-diagnose` and announce it in the site update feed

## Checks
- `nix shell nixpkgs#cargo nixpkgs#rustc nixpkgs#stdenv.cc -c cargo test -p ix-dev-diagnose`
- `nix build .#ix-dev-diagnose`
- `nix run .#lint`
- `nix run .#ix-dev-diagnose -- --max-body-bytes 128`
