### PR TITLE
fix(test-cluster-bootstrap): drop unreachable cache.ix.dev substituter

### DIFF
--- a/images/system/test-cluster-bootstrap/default.nix
+++ b/images/system/test-cluster-bootstrap/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   ix.image = {
     name = "ix/test-cluster-bootstrap";
     tag = "zstd-tools-2026-05-12";

--- a/images/system/test-cluster-bootstrap/default.nix
+++ b/images/system/test-cluster-bootstrap/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ ... }:
 {
   ix.image = {
     name = "ix/test-cluster-bootstrap";
@@ -6,19 +6,4 @@
   };
 
   networking.hostName = "test-cluster-bootstrap";
-
-  nix.settings = {
-    experimental-features = [
-      "nix-command"
-      "flakes"
-    ];
-    substituters = [
-      "http://cache.ix.dev:8501"
-      "https://cache.nixos.org/"
-    ];
-    trusted-public-keys = [
-      "hil-compute-1:eu2JX3qkNaxdO0/ane+bTmOIKOtR5P/quLlTHBqqIpM="
-      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-    ];
-  };
 }

--- a/images/system/test-cluster-bootstrap/default.nix
+++ b/images/system/test-cluster-bootstrap/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+_:
 {
   ix.image = {
     name = "ix/test-cluster-bootstrap";


### PR DESCRIPTION
## Summary

The `test-cluster-bootstrap` image overrode `nix.settings.substituters` to pin `http://cache.ix.dev:8501` as the first substituter. The leader owns that hostname, and VMs in the leader's region SNAT through the leader's public IPv4 — so a VM SYN to `cache.ix.dev:8501` has `src=dst=leader-public-IP` and hairpins. Effect: ~80s of dead boot time on every fresh bootstrap VM (≈18s determinate-nixd FlakeHub auth retries + ≈63s libfetch TCP-connect timeout), ending with the home-manager activate script crashing on `$USER` anyway.

The image doesn't need a substituter at runtime: its role is to land a `nixos-rebuild switch --target-host` from the deploy host, which ships closures over SSH. Dropping the override returns to the same default every other index image uses (`cache.nixos.org`).

## Measurements

| image | userspace boot |
| --- | --- |
| `test-cluster-bootstrap` before | 1m29.9s |
| `test-cluster-bootstrap` after (expected) | ~11s, matching peers |
| `development-base` | 11.8s |
| `minestom` | 11.4s |

Critical-chain offender was `home-manager-root.service` (1m22.9s `systemd-analyze blame`); the unit took that long to *fail* because its activate script's `nix-build --quiet --expr '{}'` sanity-pinged the unreachable substituter via determinate-nixd before reaching the `$USER`-unbound crash. Removing the substituter collapses that wait without touching home-manager.

## Test plan

- [ ] CI builds the image
- [ ] Push the new tag to `us-west-1`, boot a fresh bootstrap VM, confirm `systemd-analyze` userspace drops to ~11s and `home-manager-root.service` blame drops to single-digit seconds