### PR TITLE
lib: restore public helper exports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,8 @@ threshold with Tango's `--fail-threshold` flag.
 contains tests. Build the workspace with `extraRustcArgs` passing
 `-Cinstrument-coverage`; the report derivation runs each test binary, merges the
 LLVM profiles, and writes normalized LCOV to `$out/lcov.info`.
+Coverage tests run from writable package-source copies by default, matching
+Cargo's expectation that tests can create package-local runtime files.
 The selected Rust toolchain must include matching LLVM tools, or
 `makeCoverageReport` must receive explicit `llvmCov` and `llvmProfdata` paths.
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -998,6 +998,7 @@ let
       evalImageConfig
       mkImage
       mkFleet
+      mkFleetFor
       discoverImages
       exampleFleetsFor
       artifacts
@@ -1006,7 +1007,10 @@ let
       buildGradleFatJar
       buildNpmSite
       buildUvApplication
+      bunLockFor
       cargoUnit
+      cargoUnitFor
+      errors
       languages
       minecraft
       mkMinecraftLoader
@@ -1017,6 +1021,7 @@ let
       rustWorkspace
       secrets
       systemdHardening
+      uvLockFor
       writeNushellApplication
       writePythonApplication
       ;

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -2485,6 +2485,8 @@ mod tests {
         assert!(rendered.contains("testPlan = mkTestPlan \"cargo-unit-test-plan\";"));
         assert!(rendered.contains("coverageReport = mkCoverageReport {};"));
         assert!(rendered.contains("makeCoverageReport = mkCoverageReport;"));
+        assert!(rendered.contains("writableTestCwd ? true"));
+        assert!(rendered.contains(".cargo-unit-writable-cwd-ready"));
         assert!(rendered.contains("llvm-profdata"));
         assert!(rendered.contains("llvm-cov"));
         assert!(!rendered.contains("fallbackLlvmCov"));

--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -288,6 +288,7 @@ let
       name ? "cargo-unit-coverage",
       testArgs ? [],
       testArgsByPackage ? {},
+      writableTestCwd ? true,
       llvmCov ? null,
       llvmProfdata ? null,
     }:
@@ -308,11 +309,12 @@ let
           coverage_root="$TMPDIR/cargo-unit-coverage"
           profile_dir="$coverage_root/profiles"
           source_roots="$coverage_root/source-roots.tsv"
+          writable_cwd_root="$coverage_root/writable-cwds"
           executed_test_binaries="$coverage_root/executed-test-binaries"
           merged_profile="$out/merged.profdata"
           raw_lcov="$out/raw.lcov"
 
-          mkdir -p "$out" "$profile_dir"
+          mkdir -p "$out" "$profile_dir" "$writable_cwd_root"
           : > "$source_roots"
           : > "$executed_test_binaries"
           export LLVM_PROFILE_FILE="$profile_dir/%p-%m.profraw"
@@ -361,11 +363,22 @@ let
           in
           ''
           test_binary=${pkgs.lib.escapeShellArg target.binary}
-          test_cwd=${pkgs.lib.escapeShellArg packageCwd}
+          test_source_cwd=${pkgs.lib.escapeShellArg packageCwd}
+          test_cwd="$test_source_cwd"
           if [ ! -x "$test_binary" ]; then
             echo >&2 "error: cargo-unit coverage test binary is missing or not executable: $test_binary"
             exit 1
           fi
+          ${pkgs.lib.optionalString writableTestCwd ''
+          test_cwd="$writable_cwd_root"/${pkgs.lib.escapeShellArg target.sourceStoreName}
+          if [ ! -e "$test_cwd/.cargo-unit-writable-cwd-ready" ]; then
+            rm -rf "$test_cwd"
+            mkdir -p "$test_cwd"
+            cp -R "$test_source_cwd"/. "$test_cwd"/
+            chmod -R u+w "$test_cwd"
+            touch "$test_cwd/.cargo-unit-writable-cwd-ready"
+          fi
+          ''}
           echo "running coverage target $test_binary"
           printf '%s\n' "$test_binary" >> "$executed_test_binaries"
           (

--- a/tests/fixtures/cargo-unit-hello/src/lib.rs
+++ b/tests/fixtures/cargo-unit-hello/src/lib.rs
@@ -11,4 +11,9 @@ mod tests {
     fn returns_greeting() {
         assert_eq!(greeting(), "hello from cargo-unit");
     }
+
+    #[test]
+    fn current_dir_is_writable() {
+        std::fs::write(".cargo-unit-writable-cwd-check", "ok").unwrap();
+    }
 }


### PR DESCRIPTION
## Summary
- restore public `lib` exports for helper constructors still consumed by ix
- keep the current index main changes intact while making `cargoUnitFor` and `mkFleetFor` available again

## Validation
- `direnv exec . nix eval .#lib --apply 'lib: builtins.toJSON { cargoUnitFor = builtins.hasAttr "cargoUnitFor" lib; mkFleetFor = builtins.hasAttr "mkFleetFor" lib; }'`
- `direnv exec . nix run .#lint`
