### PR TITLE
AGENTS: prefer GitHub suggestion snippets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -546,6 +546,10 @@ through a real multiline input path such as `--body-file -`, a temporary file, o
 an editor. Escaped `\n` sequences in quoted `--body` strings render literally on
 GitHub.
 
+Prefer GitHub's suggestion block syntax for proposed inline changes in PR review
+comments on changed lines. Use fenced `suggestion` blocks only when GitHub can
+apply the snippet directly.
+
 When work exposes a real bug, broken assumption, or unidiomatic pattern that
 will outlive the current task, file a GitHub issue right then. One concrete
 observation per issue.

--- a/agents-md/sections/16-issues.md
+++ b/agents-md/sections/16-issues.md
@@ -9,6 +9,10 @@ through a real multiline input path such as `--body-file -`, a temporary file, o
 an editor. Escaped `\n` sequences in quoted `--body` strings render literally on
 GitHub.
 
+Prefer GitHub's suggestion block syntax for proposed inline changes in PR review
+comments on changed lines. Use fenced `suggestion` blocks only when GitHub can
+apply the snippet directly.
+
 When work exposes a real bug, broken assumption, or unidiomatic pattern that
 will outlive the current task, file a GitHub issue right then. One concrete
 observation per issue.
@@ -17,4 +21,3 @@ Apply labels at filing time. Use labels to make the next action sortable:
 `bug`, `enhancement`, `documentation`, `rfc`, `help wanted`, `good first issue`,
 and `ai-capable` when an agent can plausibly finish the issue from the body
 alone.
-


### PR DESCRIPTION
## Summary

- add AGENTS guidance to prefer GitHub `suggestion` blocks for proposed inline changes
- regenerate the checked-in AGENTS.md from the source fragments

## Checks

- `nix run .#lint`
