### PR TITLE
go-unit: add locked module helper

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -277,6 +277,13 @@ let
       nixCargoUnit = buildIxRustTool pkgs paths.packages.nixCargoUnit;
     };
   cargoUnit = cargoUnitFor pkgs;
+  goUnitFor =
+    pkgs:
+    import ./go-unit.nix {
+      inherit lib pkgs;
+      inherit (languages) go;
+    };
+  goUnit = goUnitFor pkgs;
 
   /**
     Build a repo-owned Rust package with the shared Rust policy.
@@ -771,6 +778,7 @@ let
       buildNpmSite
       buildUvApplication
       cargoUnit
+      goUnit
       languages
       minecraft
       mkMinecraftLoader
@@ -1038,6 +1046,8 @@ let
       cargoUnit
       cargoUnitFor
       errors
+      goUnit
+      goUnitFor
       languages
       minecraft
       mkMinecraftLoader

--- a/lib/go-unit.nix
+++ b/lib/go-unit.nix
@@ -1,0 +1,180 @@
+{
+  lib,
+  pkgs,
+  go,
+}:
+let
+  sanitizePackage =
+    package:
+    let
+      raw =
+        if package == "." || package == "./" then
+          "root"
+        else
+          lib.replaceStrings
+            [
+              "./"
+              "/"
+              "."
+              "*"
+            ]
+            [
+              ""
+              "-"
+              "-"
+              "all"
+            ]
+            package;
+    in
+    if raw == "" then "root" else raw;
+
+  commonArgs =
+    args:
+    let
+      src = args.src or (throw "goUnit.buildWorkspace requires src");
+      modRoot = args.modRoot or ".";
+      moduleRoot = if modRoot == "." then src else src + "/${modRoot}";
+      goMod = args.goMod or (moduleRoot + "/go.mod");
+      goSum = args.goSum or (moduleRoot + "/go.sum");
+    in
+    assert lib.assertMsg (builtins.pathExists goMod)
+      "goUnit.buildWorkspace requires a checked-in go.mod at ${builtins.toString goMod}";
+    assert lib.assertMsg (builtins.pathExists goSum)
+      "goUnit.buildWorkspace requires a checked-in go.sum lockfile at ${builtins.toString goSum}";
+    {
+      pname = args.pname or "go-unit";
+      version = args.version or "0.0.0";
+      inherit
+        src
+        goMod
+        goSum
+        modRoot
+        moduleRoot
+        ;
+      vendorHash =
+        args.vendorHash or (throw "goUnit.buildWorkspace requires vendorHash from pkgs.buildGoModule");
+      packages =
+        let
+          packages = args.packages or [ "." ];
+        in
+        if packages == [ ] then throw "goUnit.buildWorkspace requires at least one package" else packages;
+      goToolchain = args.goToolchain or go.toolchain pkgs { version = "latest"; };
+      nativeBuildInputs = args.nativeBuildInputs or [ ];
+      buildInputs = args.buildInputs or [ ];
+      env = args.env or { };
+      ldflags = args.ldflags or [ ];
+      tags = args.tags or [ ];
+    };
+
+  buildPackage =
+    args: package:
+    let
+      buildGoModule = pkgs.buildGoModule.override { go = args.goToolchain; };
+    in
+    buildGoModule {
+      pname = "${args.pname}-${sanitizePackage package}";
+      inherit (args)
+        version
+        vendorHash
+        goSum
+        nativeBuildInputs
+        buildInputs
+        env
+        ldflags
+        tags
+        ;
+      src = args.moduleRoot;
+      modRoot = ".";
+      subPackages = [ package ];
+      doCheck = false;
+      strictDeps = true;
+      passthru.goUnit = {
+        inherit (args) goSum goToolchain env;
+        inherit package;
+      };
+    };
+
+  testPackage =
+    args: package:
+    let
+      buildGoModule = pkgs.buildGoModule.override { go = args.goToolchain; };
+    in
+    buildGoModule {
+      pname = "${args.pname}-${sanitizePackage package}-test";
+      inherit (args)
+        version
+        vendorHash
+        goSum
+        nativeBuildInputs
+        buildInputs
+        env
+        ldflags
+        tags
+        ;
+      src = args.moduleRoot;
+      modRoot = ".";
+      subPackages = [ package ];
+      doCheck = true;
+      strictDeps = true;
+      installPhase = ''
+        mkdir -p "$out"
+        touch "$out/done"
+      '';
+      passthru.goUnit = {
+        inherit (args) goSum goToolchain env;
+        inherit package;
+      };
+    };
+
+  /**
+    Build and test a locked Go module as package-shaped Nix derivations.
+
+    Go does not expose Cargo's rustc unit graph, so callers choose the package
+    patterns that deserve independent cache and test boundaries. The helper
+    requires `go.mod`, `go.sum`, and `vendorHash`.
+
+    Arguments:
+    - `src`: filtered module source.
+    - `packages`: Go package patterns to expose, default `[ "." ]`.
+    - `vendorHash`: hash accepted by `pkgs.buildGoModule`.
+    - `goToolchain`: optional Go package, default `ix.languages.go.toolchain pkgs { version = "latest"; }`.
+
+    Returns `packages`, `tests`, `default`, `checks`, and `sourceAudit`.
+  */
+  buildWorkspace =
+    rawArgs:
+    let
+      args = commonArgs rawArgs;
+      packageNames = map sanitizePackage args.packages;
+      uniquePackageNames = lib.unique packageNames;
+      packageAttrs = lib.listToAttrs (
+        lib.zipListsWith (
+          name: package: lib.nameValuePair name (buildPackage args package)
+        ) packageNames args.packages
+      );
+      testAttrs = lib.listToAttrs (
+        lib.zipListsWith (
+          name: package: lib.nameValuePair name (testPackage args package)
+        ) packageNames args.packages
+      );
+    in
+    assert lib.assertMsg (builtins.length uniquePackageNames == builtins.length packageNames)
+      "goUnit.buildWorkspace package patterns must sanitize to unique names: ${lib.concatStringsSep ", " args.packages}";
+    {
+      packages = packageAttrs;
+      tests = testAttrs;
+      checks = testAttrs;
+      default = packageAttrs.${builtins.head packageNames};
+      sourceAudit = {
+        module = {
+          base = "workspace";
+          scope = "module";
+          relative = args.modRoot;
+          lockFile = if builtins.pathExists args.goSum then "go.sum" else null;
+        };
+      };
+    };
+in
+{
+  inherit buildWorkspace;
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -604,6 +604,49 @@ let
     };
   };
 
+  goUnitFixture = fs.toSource {
+    root = ./fixtures/go-unit-hello;
+    fileset = fs.unions [
+      ./fixtures/go-unit-hello/go.mod
+      ./fixtures/go-unit-hello/go.sum
+      ./fixtures/go-unit-hello/main.go
+      ./fixtures/go-unit-hello/main_test.go
+    ];
+  };
+
+  goUnitWorkspace = ix.goUnit.buildWorkspace {
+    pname = "go-unit-hello";
+    src = goUnitFixture;
+    vendorHash = "sha256-36P4vOdzJotmVZon5Zud/d/jxzv4ad04aQT2G/EE3U8=";
+    env.GOFLAGS = "-mod=readonly";
+    packages = [ "." ];
+  };
+
+  goUnitNestedFixture = fs.toSource {
+    root = ./fixtures/go-unit-nested;
+    fileset = ./fixtures/go-unit-nested/module;
+  };
+
+  goUnitNestedWorkspace = ix.goUnit.buildWorkspace {
+    pname = "go-unit-nested";
+    src = goUnitNestedFixture;
+    modRoot = "module";
+    vendorHash = "sha256-36P4vOdzJotmVZon5Zud/d/jxzv4ad04aQT2G/EE3U8=";
+    packages = [ "." ];
+  };
+
+  goUnitPackageCollisionEval =
+    builtins.tryEval
+      (ix.goUnit.buildWorkspace {
+        pname = "go-unit-collision";
+        src = goUnitFixture;
+        vendorHash = "sha256-36P4vOdzJotmVZon5Zud/d/jxzv4ad04aQT2G/EE3U8=";
+        packages = [
+          "a.b"
+          "a/b"
+        ];
+      }).packages;
+
   cargoUnitScopePolicy = {
     denyUnusedCrateDependencies = false;
     cargoAudit.enable = false;
@@ -2539,6 +2582,40 @@ let
         message = "cargo-unit workspaces should expose an unused dependency policy check by default";
       }
       {
+        assertion = goUnitWorkspace.sourceAudit.module.lockFile == "go.sum";
+        message = "go-unit workspaces should require and report the Go module lockfile";
+      }
+      {
+        assertion = goUnitWorkspace.packages ? root;
+        message = "go-unit workspaces should expose package-shaped build derivations";
+      }
+      {
+        assertion = goUnitWorkspace.packages.root.goUnit.goSum == goUnitFixture + "/go.sum";
+        message = "go-unit package derivations should pass go.sum through to buildGoModule";
+      }
+      {
+        assertion =
+          goUnitWorkspace.packages.root.goUnit.goToolchain
+          == ix.languages.go.toolchain pkgs { version = "latest"; };
+        message = "go-unit package derivations should use the selected Go toolchain";
+      }
+      {
+        assertion = goUnitWorkspace.packages.root.goUnit.env.GOFLAGS == "-mod=readonly";
+        message = "go-unit package derivations should preserve buildGoModule env values";
+      }
+      {
+        assertion = goUnitWorkspace.tests ? root;
+        message = "go-unit workspaces should expose package-shaped test derivations";
+      }
+      {
+        assertion = goUnitNestedWorkspace.sourceAudit.module.relative == "module";
+        message = "go-unit workspaces should resolve default go.mod and go.sum below modRoot";
+      }
+      {
+        assertion = !goUnitPackageCollisionEval.success;
+        message = "go-unit workspaces should reject package patterns with colliding output names";
+      }
+      {
         assertion =
           let
             inherit (nomadSecretRefsExample) secretSet;
@@ -3222,6 +3299,12 @@ let
     test -e ${cargoUnitTangoComparison}/done
     grep -q '^cargo-unit-hello	greeting	' ${cargoUnitTangoComparison}/benchmarks.tsv
     grep -q '^greeting ' ${cargoUnitTangoComparison}/logs/cargo-unit-hello-greeting.log
+    ${goUnitWorkspace.default}/bin/go-unit-hello > go-unit-hello.out
+    grep -q 'hello from go-unit: Hello, world.' go-unit-hello.out
+    test -e ${goUnitWorkspace.tests.root}/done
+    ${goUnitNestedWorkspace.default}/bin/go-unit-nested > go-unit-nested.out
+    grep -q 'hello from nested go-unit: Hello, world.' go-unit-nested.out
+    test -e ${goUnitNestedWorkspace.tests.root}/done
 
     grep -q 'class="ix bun"' ${bunSite}/share/bun-site-fixture/index.html
     test -d ${bunSite.bunNodeModules}/node_modules/clsx

--- a/tests/fixtures/go-unit-hello/go.mod
+++ b/tests/fixtures/go-unit-hello/go.mod
@@ -1,0 +1,10 @@
+module ix.test/go-unit-hello
+
+go 1.25.0
+
+require rsc.io/quote/v4 v4.0.1
+
+require (
+	golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c // indirect
+	rsc.io/sampler v1.3.0 // indirect
+)

--- a/tests/fixtures/go-unit-hello/go.sum
+++ b/tests/fixtures/go-unit-hello/go.sum
@@ -1,0 +1,6 @@
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c h1:qgOY6WgZOaTkIIMiVjBQcw93ERBE4m30iBm00nkL0i8=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+rsc.io/quote/v4 v4.0.1 h1:i/LHLEinr65wwTCqlP4OnMoMWeCgnFIZFvifdXNK+5M=
+rsc.io/quote/v4 v4.0.1/go.mod h1:w/DafQky66grMesu3uPhdDMS3knhBippwwemZtMOyCI=
+rsc.io/sampler v1.3.0 h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/tests/fixtures/go-unit-hello/main.go
+++ b/tests/fixtures/go-unit-hello/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+
+	"rsc.io/quote/v4"
+)
+
+func Message() string {
+	return "hello from go-unit: " + quote.Hello()
+}
+
+func main() {
+	fmt.Println(Message())
+}

--- a/tests/fixtures/go-unit-hello/main_test.go
+++ b/tests/fixtures/go-unit-hello/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func TestMessage(t *testing.T) {
+	if got := Message(); got != "hello from go-unit: Hello, world." {
+		t.Fatalf("Message() = %q", got)
+	}
+}

--- a/tests/fixtures/go-unit-nested/module/go.mod
+++ b/tests/fixtures/go-unit-nested/module/go.mod
@@ -1,0 +1,10 @@
+module ix.test/go-unit-nested
+
+go 1.25.0
+
+require rsc.io/quote/v4 v4.0.1
+
+require (
+	golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c // indirect
+	rsc.io/sampler v1.3.0 // indirect
+)

--- a/tests/fixtures/go-unit-nested/module/go.sum
+++ b/tests/fixtures/go-unit-nested/module/go.sum
@@ -1,0 +1,6 @@
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c h1:qgOY6WgZOaTkIIMiVjBQcw93ERBE4m30iBm00nkL0i8=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+rsc.io/quote/v4 v4.0.1 h1:i/LHLEinr65wwTCqlP4OnMoMWeCgnFIZFvifdXNK+5M=
+rsc.io/quote/v4 v4.0.1/go.mod h1:w/DafQky66grMesu3uPhdDMS3knhBippwwemZtMOyCI=
+rsc.io/sampler v1.3.0 h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/tests/fixtures/go-unit-nested/module/main.go
+++ b/tests/fixtures/go-unit-nested/module/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+
+	"rsc.io/quote/v4"
+)
+
+func Message() string {
+	return "hello from nested go-unit: " + quote.Hello()
+}
+
+func main() {
+	fmt.Println(Message())
+}

--- a/tests/fixtures/go-unit-nested/module/main_test.go
+++ b/tests/fixtures/go-unit-nested/module/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func TestMessage(t *testing.T) {
+	if got := Message(); got != "hello from nested go-unit: Hello, world." {
+		t.Fatalf("Message() = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- add `ix.goUnit.buildWorkspace` for locked Go modules
- require `go.mod`, `go.sum`, and `vendorHash`, with an explicit stdlib-only escape hatch
- add a locked Go fixture that exercises package-shaped build and test derivations

## Checks

- `nix run .#lint`
- `nix build .#checks.x86_64-linux.eval --show-trace`
