### PR TITLE
ci: harden codex review merge gate

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -724,7 +724,7 @@ jobs:
           PY
 
   required-review-gate:
-    name: chatgpt-codex-connector reviewed head
+    name: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || ((github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review') && github.event.pull_request.head.repo.full_name != github.repository)) && 'chatgpt-codex-connector reviewed head' || 'codex review gate skipped' }}
     if: >-
       always() &&
       github.event.pull_request.draft == false &&

--- a/packages/room/site/src/main.ts
+++ b/packages/room/site/src/main.ts
@@ -1,8 +1,13 @@
+import { mount } from 'svelte';
 import App from './App.svelte';
 import './style.css';
 
-const app = new App({
-  target: document.getElementById('app') as HTMLElement
-});
+const target = document.getElementById('app');
+
+if (!(target instanceof HTMLElement)) {
+  throw new Error('Missing #app mount target');
+}
+
+const app = mount(App, { target });
 
 export default app;


### PR DESCRIPTION
## Summary

Fixes the Svelte 5 startup issue Codex found after #145 merged and hardens the Codex review gate so skipped duplicate jobs do not satisfy the required reviewed-head context.

## Details

- mounts the room Svelte app with `mount` from Svelte 5
- gives skipped Codex gate jobs a non-required check name
- keeps the active `main` ruleset requiring `flake-check` and `chatgpt-codex-connector reviewed head`

## Validation

- `npm ci && npm run build && npm run check` in `packages/room/site`
- `nix build .#room`
- `nix run .#lint`
