### PR TITLE
site: minimal redesign with markdown rendering

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "ix-site",
       "version": "0.1.0",
+      "dependencies": {
+        "marked": "^16.4.2"
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@sveltejs/adapter-static": "^3.0.10",
@@ -2058,6 +2061,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/minimatch": {

--- a/site/package.json
+++ b/site/package.json
@@ -27,5 +27,8 @@
   },
   "overrides": {
     "cookie": "^0.7.0"
+  },
+  "dependencies": {
+    "marked": "^16.4.2"
   }
 }

--- a/site/src/app.css
+++ b/site/src/app.css
@@ -1,278 +1,233 @@
 :root {
-  --font-sans: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-  --font-mono: 'SF Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
+  color-scheme: light dark;
 
-  --background: #f6f7f8;
-  --surface: #ffffff;
-  --surface-muted: #f0f2f4;
-  --text-primary: #101214;
-  --text-secondary: #3f454b;
-  --text-tertiary: #6f7780;
-  --border: #d8dde2;
-  --border-strong: #aeb7c0;
-  --accent: #145c52;
-  --accent-soft: #e6f1ee;
-  --code-bg: #eceff2;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-mono: ui-monospace, 'SF Mono', 'JetBrains Mono', 'Fira Code', monospace;
+
+  --bg: #fbfaf8;
+  --fg: #111111;
+  --fg-muted: #6b6b6b;
+  --fg-faint: #a0a0a0;
+  --rule: #ebe7e0;
+  --code: #f1ede5;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #101214;
-    --surface: #171a1d;
-    --surface-muted: #202428;
-    --text-primary: #f3f5f6;
-    --text-secondary: #c7cdd2;
-    --text-tertiary: #929ba4;
-    --border: #2f363d;
-    --border-strong: #4b555f;
-    --accent: #75d8c8;
-    --accent-soft: #17322e;
-    --code-bg: #252a30;
+    --bg: #0c0c0c;
+    --fg: #f4f1ea;
+    --fg-muted: #9a9690;
+    --fg-faint: #5d5a55;
+    --rule: #1d1d1d;
+    --code: #1a1a1a;
   }
 }
 
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
-  margin: 0;
-  padding: 0;
 }
 
 html {
-  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
 body {
-  min-width: 320px;
-  color: var(--text-secondary);
-  background: var(--background);
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
   font-family: var(--font-sans);
-  font-size: 1rem;
-  line-height: 1.65;
+  font-size: 16px;
+  line-height: 1.6;
+  font-feature-settings: 'ss01', 'cv11';
 }
 
-main {
-  width: min(100% - 2rem, 1040px);
-  margin: 0 auto;
-  padding: 3rem 0 5rem;
+::selection {
+  background: var(--fg);
+  color: var(--bg);
 }
 
-section {
-  margin-top: 3rem;
+a {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid var(--rule);
+  transition:
+    border-color 0.15s ease,
+    color 0.15s ease;
 }
 
-.masthead {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 1.5rem;
-  align-items: start;
-  padding-bottom: 2rem;
-  border-bottom: 1px solid var(--border);
-}
-
-.eyebrow {
-  margin-bottom: 0.45rem;
-  color: var(--text-tertiary);
-  font-size: 0.76rem;
-  font-weight: 700;
-  letter-spacing: 0;
-  text-transform: uppercase;
+a:hover {
+  border-color: var(--fg);
 }
 
 h1,
 h2,
-h3 {
-  color: var(--text-primary);
-  font-weight: 650;
-  letter-spacing: 0;
-  line-height: 1.16;
-}
-
-h1 {
-  max-width: 720px;
-  font-size: clamp(2.15rem, 6vw, 4.4rem);
-}
-
-h2 {
-  font-size: 1.65rem;
-}
-
-h3 {
-  margin: 0.4rem 0 0.85rem;
-  font-size: 1.55rem;
-}
-
+h3,
 p {
-  margin-bottom: 1rem;
+  margin: 0;
 }
 
-a {
-  color: var(--accent);
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 0.18em;
-}
-
-a:hover {
-  text-decoration-thickness: 2px;
-}
-
-code {
-  padding: 0.1rem 0.32rem;
-  border-radius: 4px;
-  background: var(--code-bg);
-  color: var(--text-primary);
-  font-family: var(--font-mono);
-  font-size: 0.88em;
-}
-
-button {
-  font: inherit;
-}
-
-.top-links,
-.link-row {
+header {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem 1rem;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 2rem;
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 0;
 }
 
-.top-links {
-  justify-content: end;
-  padding-top: 0.25rem;
+.wordmark {
+  border: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
-.top-links a,
-.link-row a {
-  color: var(--text-primary);
-  font-weight: 650;
+header nav {
+  display: flex;
+  gap: 1.25rem;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--fg-muted);
 }
 
-.intro {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(16rem, 0.55fr);
-  gap: 1.5rem;
-  max-width: 900px;
-  color: var(--text-primary);
-  font-size: 1.12rem;
+header nav a {
+  border: 0;
 }
 
-.section-heading {
-  margin-bottom: 1.25rem;
+header nav a:hover {
+  color: var(--fg);
 }
 
-.update-layout {
-  display: grid;
-  grid-template-columns: minmax(16rem, 0.85fr) minmax(0, 1.15fr);
-  gap: 1rem;
-  align-items: start;
+main {
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 0 1.5rem 8rem;
 }
 
-.update-list {
-  display: grid;
-  gap: 0.5rem;
+.hero {
+  padding: 7rem 0 6rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 6vw, 3.75rem);
+  line-height: 1.02;
+  letter-spacing: -0.035em;
+  font-weight: 600;
+}
+
+.hero p {
+  margin-top: 1.5rem;
+  max-width: 30rem;
+  color: var(--fg-muted);
+  font-size: 1.0625rem;
+  line-height: 1.55;
+}
+
+.log {
   list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--rule);
 }
 
-.update-list button {
-  display: grid;
-  gap: 0.35rem;
-  width: 100%;
-  min-height: 8.75rem;
-  padding: 1rem;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--surface);
-  color: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-
-.update-list button:hover,
-.update-list button:focus-visible {
-  border-color: var(--border-strong);
-  outline: none;
-}
-
-.update-list button.selected {
-  border-color: var(--accent);
-  background: var(--accent-soft);
+.log > li {
+  padding: 3.5rem 0;
+  border-bottom: 1px solid var(--rule);
 }
 
 time {
-  color: var(--text-tertiary);
-  font-size: 0.82rem;
-  font-weight: 700;
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
 }
 
-.update-title {
-  color: var(--text-primary);
-  font-weight: 700;
-  line-height: 1.35;
+.log h2 {
+  margin-top: 0.75rem;
+  font-size: 1.5rem;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  font-weight: 600;
 }
 
-.update-summary {
-  color: var(--text-secondary);
-  font-size: 0.94rem;
-  line-height: 1.45;
+.log h2 a {
+  border: 0;
 }
 
-.update-detail {
-  min-height: 29rem;
-  padding: 1.35rem;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--surface);
+.log h2 a:hover {
+  color: var(--fg-muted);
 }
 
-.update-detail .summary {
-  color: var(--text-primary);
-  font-size: 1.08rem;
+.body {
+  margin-top: 1.25rem;
+  color: var(--fg-muted);
 }
 
-.link-row {
-  margin-top: 1.35rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--border);
+.body > * + * {
+  margin-top: 1em;
 }
 
-.repository {
-  max-width: 700px;
-  padding-top: 2rem;
-  border-top: 1px solid var(--border);
+.body p {
+  font-size: 0.9375rem;
+  line-height: 1.65;
 }
 
-.repository h2 {
-  margin-bottom: 0.5rem;
+.body code {
+  padding: 0.1em 0.35em;
+  border-radius: 3px;
+  background: var(--code);
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 0.86em;
 }
 
-@media (max-width: 780px) {
+.body a {
+  color: var(--fg);
+  border-bottom-color: var(--fg-faint);
+}
+
+.refs {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 0.65rem;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--fg-muted);
+}
+
+.refs a {
+  border: 0;
+}
+
+.refs a:hover {
+  color: var(--fg);
+}
+
+.refs span {
+  color: var(--fg-faint);
+}
+
+@media (max-width: 32rem) {
+  header,
   main {
-    width: min(100% - 1.25rem, 1040px);
-    padding-top: 2rem;
+    padding-left: 1.25rem;
+    padding-right: 1.25rem;
   }
 
-  section {
-    margin-top: 2.25rem;
+  .hero {
+    padding: 4rem 0 4rem;
   }
 
-  .masthead,
-  .intro,
-  .update-layout {
-    grid-template-columns: 1fr;
-  }
-
-  .top-links {
-    justify-content: start;
-  }
-
-  .update-list button {
-    min-height: 0;
-  }
-
-  .update-detail {
-    min-height: 0;
-    padding: 1rem;
+  .log > li {
+    padding: 2.5rem 0;
   }
 }

--- a/site/src/lib/updates.ts
+++ b/site/src/lib/updates.ts
@@ -7,8 +7,7 @@ export type SiteUpdate = {
   id: string;
   date: string;
   title: string;
-  summary: string;
-  paragraphs: string[];
+  body: string;
   links: SiteUpdateLink[];
 };
 
@@ -17,20 +16,20 @@ export const siteUpdates: SiteUpdate[] = [
     id: 'ix-dev-diagnose',
     date: '2026-05-25',
     title: 'ix.dev reachability gets a JSON probe',
-    summary:
-      '`ix-dev-diagnose` captures DNS, TLS, certificate, and response-byte clues when ix.dev behaves differently by network.',
-    paragraphs: [
-      '`nix run .#ix-dev-diagnose` probes `https://ix.dev/` from the caller\'s path, prints `success` or `failure`, and writes one JSON report for sharing with support.',
-      'The report records system resolver answers, per-address TCP and TLS results, parsed certificate issuers and fingerprints, native and Mozilla-root verification outcomes, headers, and a bounded response-body sample.',
-      'This is meant for cases such as `SEC_ERROR_UNKNOWN_ISSUER`, captive portals, ISP interception, stale DNS, or CDN edge differences where the failing client sees different bytes than a working client.'
-    ],
+    body: `\`ix-dev-diagnose\` captures DNS, TLS, certificate, and response-byte clues when ix.dev behaves differently by network.
+
+\`nix run .#ix-dev-diagnose\` probes \`https://ix.dev/\` from the caller's path, prints \`success\` or \`failure\`, and writes one JSON report for sharing with support.
+
+The report records system resolver answers, per-address TCP and TLS results, parsed certificate issuers and fingerprints, native and Mozilla-root verification outcomes, headers, and a bounded response-body sample.
+
+Meant for \`SEC_ERROR_UNKNOWN_ISSUER\`, captive portals, ISP interception, stale DNS, or CDN edge differences where the failing client sees different bytes than a working client.`,
     links: [
       {
         label: 'diagnostic package',
         href: 'https://github.com/indexable-inc/index/tree/main/packages/ix-dev-diagnose'
       },
       {
-        label: 'flake package wiring',
+        label: 'flake wiring',
         href: 'https://github.com/indexable-inc/index/blob/main/lib/per-system.nix'
       }
     ]
@@ -39,20 +38,18 @@ export const siteUpdates: SiteUpdate[] = [
     id: 'recorded-runner',
     date: '2026-05-25',
     title: 'Recorded command runs become a package',
-    summary:
-      'The new `run` package keeps long command output compact while saving replayable and queryable artifacts.',
-    paragraphs: [
-      '`nix run .#run -- <command> ...` executes the command in a PTY, prints a bounded head and tail summary, and writes the complete live stream under `./.ix/run/latest`.',
-      'Each session includes `scriptreplay` timing files, an asciinema cast, chunk-level JSONL, line-level JSONL for pandas, and a summary file with duration and exit status.',
-      'The live `output.log` and helper scripts let another shell follow a slow build before the command has finished.'
-    ],
+    body: `The new \`run\` package keeps long command output compact while saving replayable and queryable artifacts.
+
+\`nix run .#run -- <command> ...\` executes the command in a PTY, prints a bounded head and tail summary, and writes the complete live stream under \`./.ix/run/latest\`.
+
+Each session includes \`scriptreplay\` timing files, an asciinema cast, chunk-level JSONL, line-level JSONL for pandas, and a summary file with duration and exit status. The live \`output.log\` lets another shell follow a slow build before the command finishes.`,
     links: [
       {
         label: 'run package',
         href: 'https://github.com/indexable-inc/index/tree/main/packages/run'
       },
       {
-        label: 'flake package wiring',
+        label: 'flake wiring',
         href: 'https://github.com/indexable-inc/index/blob/main/lib/per-system.nix'
       }
     ]
@@ -61,20 +58,18 @@ export const siteUpdates: SiteUpdate[] = [
     id: 'fleet-secret-refs',
     date: '2026-05-24',
     title: 'Fleet secret refs become typed plan data',
-    summary:
-      'ix fleets can now declare secret references once and hand VM modules stable runtime paths.',
-    paragraphs: [
-      'Fleet specs carry a provider block plus per-secret keys, while modules read `secretRefs` instead of spelling `/run/secrets` paths by hand.',
-      'The first documented shape uses a Vaultwarden-style backend for S3 scraper credentials. The generated plan still stays pure JSON, so a future reconciler can materialize files before services start.',
-      'This does not put secret bytes in the Nix store. Services still consume runtime files through systemd credentials where the module already supports that pattern.'
-    ],
+    body: `ix fleets can now declare secret references once and hand VM modules stable runtime paths.
+
+Fleet specs carry a provider block plus per-secret keys, while modules read \`secretRefs\` instead of spelling \`/run/secrets\` paths by hand. The first documented shape uses a Vaultwarden-style backend for S3 scraper credentials.
+
+The generated plan stays pure JSON, so a future reconciler can materialize files before services start. Secret bytes never enter the Nix store; services consume runtime files through systemd credentials where the module already supports that pattern.`,
     links: [
       {
         label: 'fleet helper',
         href: 'https://github.com/indexable-inc/index/blob/main/lib/fleet.nix'
       },
       {
-        label: 'scraper secret example',
+        label: 'scraper example',
         href: 'https://github.com/indexable-inc/index/blob/main/examples/python-daily-scraper/README.md#s3-output'
       }
     ]
@@ -83,13 +78,9 @@ export const siteUpdates: SiteUpdate[] = [
     id: 'site-audio-briefs',
     date: '2026-05-23',
     title: 'A compact update feed lands on the site',
-    summary:
-      'The ix images site now has bite-size update entries with a plain RSS feed.',
-    paragraphs: [
-      'Public project notes now live as compact updates with exact repo links close to the text they explain.',
-      'GitHub Pages serves static HTML and RSS, so the site stays inspectable without browser-only media controls or runtime services.',
-      'The feed is meant for quick release notes: one short summary, the operational detail, and links to the owning source.'
-    ],
+    body: `Public project notes now live as compact updates with exact repo links close to the text they explain.
+
+GitHub Pages serves static HTML and RSS, so the site stays inspectable without browser-only media controls or runtime services. The feed is meant for quick release notes: one short summary, the operational detail, and links to the owning source.`,
     links: [
       {
         label: 'site source',
@@ -106,8 +97,18 @@ export const siteUpdates: SiteUpdate[] = [
 export const siteUrl = 'https://indexable-inc.github.io/index/';
 export const siteFeedUrl = `${siteUrl}feed.xml`;
 export const siteIntro =
-  'ix images publishes pre-built OCI images and composable NixOS modules for ix VMs.';
+  'Pre-built OCI images and composable NixOS modules for ix VMs.';
+
+export function plainText(markdown: string): string {
+  return markdown
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
 
 export function updateScript(update: SiteUpdate): string {
-  return [update.title, update.summary, ...update.paragraphs].join(' ');
+  return `${update.title}. ${plainText(update.body)}`;
 }

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -1,9 +1,23 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
-  import { marked } from 'marked';
+  import { Marked } from 'marked';
   import { siteFeedUrl, siteIntro, siteUpdates } from '$lib/updates';
 
-  marked.setOptions({ breaks: false, gfm: true });
+  const safeHrefPattern = /^(https?:|mailto:|#|\/)/i;
+
+  const marked = new Marked({
+    gfm: true,
+    breaks: false,
+    renderer: {
+      html: () => '',
+      link({ href, title, tokens }) {
+        const text = this.parser.parseInline(tokens);
+        if (!safeHrefPattern.test(href)) return text;
+        const titleAttr = title ? ` title="${title.replace(/"/g, '&quot;')}"` : '';
+        return `<a href="${href}"${titleAttr}>${text}</a>`;
+      }
+    }
+  });
 
   const feedHref = resolve('/feed.xml');
 

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
+  import { marked } from 'marked';
   import { siteFeedUrl, siteIntro, siteUpdates } from '$lib/updates';
+
+  marked.setOptions({ breaks: false, gfm: true });
+
+  const feedHref = resolve('/feed.xml');
 
   const dateFormatter = new Intl.DateTimeFormat('en', {
     month: 'short',
@@ -9,100 +14,52 @@
     timeZone: 'UTC'
   });
 
-  const feedHref = resolve('/feed.xml');
-  const latestUpdate = siteUpdates[0];
-
-  let selectedId = $state(latestUpdate.id);
-
-  const selectedUpdate = $derived(
-    siteUpdates.find((update) => update.id === selectedId) ?? latestUpdate
-  );
-
   function formatDate(date: string): string {
     return dateFormatter.format(new Date(`${date}T00:00:00Z`));
   }
+
+  const entries = siteUpdates.map((update) => ({
+    ...update,
+    html: marked.parse(update.body) as string,
+    label: formatDate(update.date)
+  }));
 </script>
 
 <svelte:head>
   <title>ix images</title>
-  <meta
-    name="description"
-    content="Pre-built OCI images and composable NixOS modules for ix VMs, with a compact RSS update feed."
-  />
-  <link rel="alternate" type="application/rss+xml" title="ix images updates" href={siteFeedUrl} />
+  <meta name="description" content={siteIntro} />
+  <link rel="alternate" type="application/rss+xml" title="ix images" href={siteFeedUrl} />
 </svelte:head>
 
-<main>
-  <header class="masthead" aria-labelledby="page-title">
-    <div>
-      <p class="eyebrow">ix images</p>
-      <h1 id="page-title">Pre-built systems for ix VMs.</h1>
-    </div>
-    <nav class="top-links" aria-label="Primary links">
-      <a href="https://github.com/indexable-inc/index">GitHub</a>
-      <a href="https://ix.dev">ix.dev</a>
-      <a href={feedHref}>RSS</a>
-    </nav>
-  </header>
+<header>
+  <a class="wordmark" href={resolve('/')}>ix images</a>
+  <nav>
+    <a href="https://github.com/indexable-inc/index">github</a>
+    <a href="https://ix.dev">ix.dev</a>
+    <a href={feedHref}>rss</a>
+  </nav>
+</header>
 
-  <section class="intro" aria-label="Project summary">
+<main>
+  <section class="hero">
+    <h1>Pre-built systems for ix VMs.</h1>
     <p>{siteIntro}</p>
-    <p>
-      This page is the public changelog: short entries, exact source links, and a feed
-      that works in any RSS reader.
-    </p>
   </section>
 
-  <section class="updates" aria-labelledby="updates-title">
-    <div class="section-heading">
-      <p class="eyebrow">Updates</p>
-      <h2 id="updates-title">Latest changes</h2>
-    </div>
-
-    <div class="update-layout">
-      <ol class="update-list" aria-label="Update list">
-        {#each siteUpdates as update (update.id)}
-          <li>
-            <button
-              type="button"
-              class:selected={update.id === selectedId}
-              aria-pressed={update.id === selectedId}
-              onclick={() => {
-                selectedId = update.id;
-              }}
-            >
-              <span class="update-meta">
-                <time datetime={update.date}>{formatDate(update.date)}</time>
-              </span>
-              <span class="update-title">{update.title}</span>
-              <span class="update-summary">{update.summary}</span>
-            </button>
-          </li>
-        {/each}
-      </ol>
-
-      <article id={selectedUpdate.id} class="update-detail" aria-labelledby="selected-update-title">
-        <time datetime={selectedUpdate.date}>{formatDate(selectedUpdate.date)}</time>
-        <h3 id="selected-update-title">{selectedUpdate.title}</h3>
-        <p class="summary">{selectedUpdate.summary}</p>
-        {#each selectedUpdate.paragraphs as paragraph (paragraph)}
-          <p>{paragraph}</p>
-        {/each}
-        <div class="link-row" aria-label="Update links">
-          {#each selectedUpdate.links as link (link.href)}
+  <ol class="log">
+    {#each entries as entry (entry.id)}
+      <li id={entry.id}>
+        <time datetime={entry.date}>{entry.label}</time>
+        <h2><a href="#{entry.id}">{entry.title}</a></h2>
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+        <div class="body">{@html entry.html}</div>
+        <div class="refs">
+          {#each entry.links as link, i (link.href)}
+            {#if i > 0}<span aria-hidden="true">·</span>{/if}
             <a href={link.href} rel="external">{link.label}</a>
           {/each}
         </div>
-      </article>
-    </div>
-  </section>
-
-  <section class="repository" aria-labelledby="repository-title">
-    <h2 id="repository-title">Source</h2>
-    <p>
-      Images are discovered from <code>images/</code>. NixOS modules live under
-      <code>modules/</code>. The repository is
-      <a href="https://github.com/indexable-inc/index">indexable-inc/index</a>.
-    </p>
-  </section>
+      </li>
+    {/each}
+  </ol>
 </main>


### PR DESCRIPTION
Complete redesign of the changelog site: single-column, generous whitespace, hairline dividers, no card chrome. The masthead eyebrow, intro grid, side-panel update picker, and source footer are gone.

Update bodies are now markdown, rendered with `marked`, so inline code, links, and emphasis render properly instead of showing literal backticks. The data shape collapses to `body: string` plus `links[]`; the RSS feed flattens markdown to a plain description through a small `plainText` helper.
