### PR TITLE
zig: add package builder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -473,6 +473,11 @@ Tracked Nix files should never contain fake hash helpers or placeholder hashes.
 Materialize real SRI hashes with the owning updater, lock command,
 `nix flake update`, or a checked prefetch command before committing.
 
+Use `__impure` only for explicit dependency-discovery or prefetch derivations
+that are turned into a checked hash-bearing artifact before product builds
+consume them. Keep the impure boundary named next to the updater or generated
+lock output that makes later builds pure.
+
 Generated catalogs are build inputs, not hand-edited source. If a generated file
 is wrong, change the manifest or generator that owns it.
 

--- a/agents-md/sections/13-dependency-intake.md
+++ b/agents-md/sections/13-dependency-intake.md
@@ -18,6 +18,11 @@ Tracked Nix files should never contain fake hash helpers or placeholder hashes.
 Materialize real SRI hashes with the owning updater, lock command,
 `nix flake update`, or a checked prefetch command before committing.
 
+Use `__impure` only for explicit dependency-discovery or prefetch derivations
+that are turned into a checked hash-bearing artifact before product builds
+consume them. Keep the impure boundary named next to the updater or generated
+lock output that makes later builds pure.
+
 Generated catalogs are build inputs, not hand-edited source. If a generated file
 is wrong, change the manifest or generator that owns it.
 
@@ -27,4 +32,3 @@ hashes, and metadata catalogs for search or browsing surfaces.
 
 Repository examples should consume those shared surfaces. Repeating URLs and
 hashes in examples creates second owners with no update story.
-

--- a/lib/build-zig-package.nix
+++ b/lib/build-zig-package.nix
@@ -1,0 +1,175 @@
+_:
+
+/**
+  Build a Zig package from a `build.zig` / `build.zig.zon` project.
+
+  Zig projects declare package metadata and remote dependencies in
+  `build.zig.zon`. The dependency entries are content-addressed by Zig hashes;
+  nixpkgs still needs one fixed-output hash for the realized Zig package cache,
+  so projects with remote dependencies pass `zigDepsHash` after updating
+  `build.zig.zon`.
+
+  Named Zig test steps are exposed as separate derivations under
+  `passthru.tests`. That lets flake checks schedule independent test steps in
+  parallel instead of hiding the whole test surface inside the package build.
+
+  Arguments:
+  - `pname`, `version`: derivation identity.
+  - `src`: project root containing `build.zig` and `build.zig.zon`.
+  - `zig`: Zig compiler package. Defaults to `pkgs.zig`.
+  - `zigDepsHash`: Nix hash for the Zig dependency cache, required when the
+    project has remote `build.zig.zon` dependencies.
+  - `zigBuildFlags`, `zigInstallFlags`: extra flags for `zig build` phases.
+  - `testSteps`: attrset of test names to Zig build step names.
+  - `meta`: standard derivation meta.
+*/
+pkgs:
+{
+  pname,
+  version ? "0.0.0",
+  src,
+  zig ? pkgs.zig,
+  zigDepsHash ? null,
+  zigFetchAll ? false,
+  zigBuildFlags ? [ ],
+  zigInstallFlags ? [ ],
+  zigDefaultFlags ? [
+    "-Dcpu=baseline"
+    "--release=safe"
+  ],
+  nativeBuildInputs ? [ ],
+  buildInputs ? [ ],
+  env ? { },
+  testSteps ? {
+    default = "test";
+  },
+  passthru ? { },
+  meta ? { },
+  ...
+}@rawArgs:
+let
+  inherit (pkgs) lib;
+
+  zigDepsFetcher = zig.fetchDeps or null;
+
+  zigDeps =
+    rawArgs.zigDeps or (
+      if zigDepsHash == null then
+        null
+      else if zigDepsFetcher == null then
+        throw ''
+          buildZigPackage: ${zig.name or "the selected Zig compiler"} does not expose fetchDeps.
+          Pass a Zig compiler with fetchDeps support or override zigDeps directly.
+        ''
+      else
+        zigDepsFetcher {
+          inherit pname version src;
+          fetchAll = zigFetchAll;
+          hash = zigDepsHash;
+        }
+    );
+
+  commonAttrs = builtins.removeAttrs rawArgs [
+    "env"
+    "meta"
+    "nativeBuildInputs"
+    "passthru"
+    "testSteps"
+    "zig"
+    "zigBuildFlags"
+    "zigDeps"
+    "zigDepsHash"
+    "zigFetchAll"
+    "zigDefaultFlags"
+    "zigInstallFlags"
+  ];
+
+  zigCacheScript = ''
+    export ZIG_GLOBAL_CACHE_DIR="$TMPDIR/zig-cache"
+    mkdir -p "$ZIG_GLOBAL_CACHE_DIR/p" "$ZIG_GLOBAL_CACHE_DIR/tmp"
+  ''
+  + lib.optionalString (zigDeps != null) ''
+    cp -R ${zigDeps}/. "$ZIG_GLOBAL_CACHE_DIR/p/"
+    chmod -R u+w "$ZIG_GLOBAL_CACHE_DIR/p"
+  '';
+
+  testFor =
+    name: step:
+    pkgs.runCommand "${pname}-zig-${name}"
+      (
+        {
+          inherit src buildInputs;
+          strictDeps = true;
+          nativeBuildInputs = [ zig ] ++ nativeBuildInputs;
+        }
+        // lib.optionalAttrs (rawArgs ? patches) { inherit (rawArgs) patches; }
+        // lib.optionalAttrs (rawArgs ? patchFlags) { inherit (rawArgs) patchFlags; }
+        // lib.optionalAttrs (rawArgs ? prePatch) { inherit (rawArgs) prePatch; }
+        // lib.optionalAttrs (rawArgs ? postPatch) { inherit (rawArgs) postPatch; }
+        // env
+      )
+      ''
+        unpackPhase
+        cd "$sourceRoot"
+        patchPhase
+        ${zigCacheScript}
+        export ZIG_LOCAL_CACHE_DIR="$TMPDIR/zig-local-cache"
+        zig build \
+          --global-cache-dir "$ZIG_GLOBAL_CACHE_DIR" \
+          --cache-dir "$ZIG_LOCAL_CACHE_DIR" \
+          ${lib.escapeShellArg step} \
+          ${lib.escapeShellArgs (zigBuildFlags ++ zigDefaultFlags)} \
+          --summary all
+        mkdir -p "$out"
+        touch "$out/done"
+      '';
+in
+pkgs.stdenv.mkDerivation (
+  commonAttrs
+  // env
+  // {
+    inherit pname version src;
+
+    strictDeps = true;
+
+    nativeBuildInputs = [ zig ] ++ nativeBuildInputs;
+
+    inherit buildInputs;
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      ${zigCacheScript}
+      export ZIG_LOCAL_CACHE_DIR="$TMPDIR/zig-local-cache"
+
+      buildCores=1
+      if [ "''${enableParallelBuilding-1}" ]; then
+        buildCores="$NIX_BUILD_CORES"
+      fi
+
+      zig build \
+        "-j$buildCores" \
+        --global-cache-dir "$ZIG_GLOBAL_CACHE_DIR" \
+        --cache-dir "$ZIG_LOCAL_CACHE_DIR" \
+        ${lib.escapeShellArgs (zigBuildFlags ++ zigDefaultFlags ++ zigInstallFlags)} \
+        --prefix "$out" \
+        --summary all
+
+      runHook postInstall
+    '';
+
+    doCheck = false;
+
+    passthru = passthru // {
+      inherit zig zigDeps testSteps;
+      tests = (passthru.tests or { }) // lib.mapAttrs testFor testSteps;
+    };
+
+    meta = meta // {
+      mainProgram = meta.mainProgram or pname;
+    };
+  }
+)

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -183,6 +183,7 @@ let
   };
   buildNpmSite = import ./build-npm-site.nix;
   buildNpmVitest = import ./build-npm-vitest.nix;
+  buildZigPackage = import ./build-zig-package.nix { };
   uvLockFor =
     pkgs:
     import ./uv-lock.nix {
@@ -779,6 +780,7 @@ let
       buildNpmSite
       buildNpmVitest
       buildUvApplication
+      buildZigPackage
       cargoUnit
       goUnit
       languages
@@ -1045,6 +1047,7 @@ let
       buildNpmSite
       buildNpmVitest
       buildUvApplication
+      buildZigPackage
       bunLockFor
       cargoUnit
       cargoUnitFor

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -513,6 +513,43 @@ let
     check = false;
   };
 
+  zigAppFixture = fs.toSource {
+    root = ./fixtures/zig-app;
+    fileset = fs.unions [
+      ./fixtures/zig-app/build.zig
+      ./fixtures/zig-app/build.zig.zon
+      ./fixtures/zig-app/src
+    ];
+  };
+
+  zigApplication = ix.buildZigPackage pkgs {
+    pname = "zig-app-fixture";
+    version = "0.1.0";
+    src = zigAppFixture;
+    zig = ix.languages.zig.toolchain pkgs { version = "0.14"; };
+    testSteps = {
+      lib = "test-lib";
+      exe = "test-exe";
+    };
+  };
+
+  zigDepsFixture = fs.toSource {
+    root = ./fixtures/zig-deps;
+    fileset = fs.unions [
+      ./fixtures/zig-deps/build.zig
+      ./fixtures/zig-deps/build.zig.zon
+      ./fixtures/zig-deps/src
+    ];
+  };
+
+  zigDepsApplication = ix.buildZigPackage pkgs {
+    pname = "zig-deps-fixture";
+    version = "0.1.0";
+    src = zigDepsFixture;
+    zig = ix.languages.zig.toolchain pkgs { version = "0.14"; };
+    zigDepsHash = "sha256-2eURmY4iF5iG5CdYiI7cKbrT3ymqb9UFUxO22LmsZ9s=";
+  };
+
   cargoUnitFixture = fs.toSource {
     root = ./fixtures/cargo-unit-hello;
     fileset = fs.unions [
@@ -2624,6 +2661,18 @@ let
         message = "go-unit workspaces should reject package patterns with colliding output names";
       }
       {
+        assertion = zigApplication.passthru.tests ? lib && zigApplication.passthru.tests ? exe;
+        message = "Zig packages should expose named test steps as separate derivations";
+      }
+      {
+        assertion = zigApplication.passthru.testSteps.lib == "test-lib";
+        message = "Zig packages should retain the build step names behind test derivations";
+      }
+      {
+        assertion = zigDepsApplication.passthru.zigDeps != null;
+        message = "Zig packages should materialize remote build.zig.zon dependencies through a cache derivation";
+      }
+      {
         assertion =
           let
             inherit (nomadSecretRefsExample) secretSet;
@@ -3285,6 +3334,13 @@ let
 
     ${lib.getExe pythonAppClosureProbe} > python-app-closure-probe.out
     grep -q 'python app source is in the runtime closure' python-app-closure-probe.out
+
+    ${lib.getExe zigApplication} > zig-app-fixture.out
+    grep -q 'hello from zig app fixture' zig-app-fixture.out
+    test -e ${zigApplication.passthru.tests.lib}/done
+    test -e ${zigApplication.passthru.tests.exe}/done
+    test -e ${zigDepsApplication}/bin/zig-deps-fixture
+    test -e ${zigDepsApplication.passthru.tests.default}/done
 
     ${cargoUnitHello}/bin/cargo-unit-hello > cargo-unit-hello.out
     grep -q 'hello from cargo-unit' cargo-unit-hello.out

--- a/tests/fixtures/zig-app/build.zig
+++ b/tests/fixtures/zig-app/build.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "zig-app-fixture",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    b.installArtifact(exe);
+
+    const lib_tests = b.addTest(.{
+        .root_source_file = b.path("src/lib.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const run_lib_tests = b.addRunArtifact(lib_tests);
+    const lib_test_step = b.step("test-lib", "Run library tests");
+    lib_test_step.dependOn(&run_lib_tests.step);
+
+    const exe_tests = b.addTest(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const run_exe_tests = b.addRunArtifact(exe_tests);
+    const exe_test_step = b.step("test-exe", "Run executable tests");
+    exe_test_step.dependOn(&run_exe_tests.step);
+
+    const test_step = b.step("test", "Run all tests");
+    test_step.dependOn(lib_test_step);
+    test_step.dependOn(exe_test_step);
+}

--- a/tests/fixtures/zig-app/build.zig.zon
+++ b/tests/fixtures/zig-app/build.zig.zon
@@ -1,0 +1,10 @@
+.{
+    .name = .zig_app_fixture,
+    .version = "0.1.0",
+    .fingerprint = 0x2a5bbc00a03f0d94,
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/tests/fixtures/zig-app/src/lib.zig
+++ b/tests/fixtures/zig-app/src/lib.zig
@@ -1,0 +1,8 @@
+pub fn greeting() []const u8 {
+    return "hello from zig app fixture";
+}
+
+test "greeting text is stable" {
+    const std = @import("std");
+    try std.testing.expectEqualStrings("hello from zig app fixture", greeting());
+}

--- a/tests/fixtures/zig-app/src/main.zig
+++ b/tests/fixtures/zig-app/src/main.zig
@@ -1,0 +1,11 @@
+const std = @import("std");
+const lib = @import("lib.zig");
+
+pub fn main() !void {
+    const stdout = std.io.getStdOut().writer();
+    try stdout.print("{s}\n", .{lib.greeting()});
+}
+
+test "main imports the library" {
+    try std.testing.expect(lib.greeting().len > 0);
+}

--- a/tests/fixtures/zig-deps/build.zig
+++ b/tests/fixtures/zig-deps/build.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    _ = b.dependency("known_folders", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "zig-deps-fixture",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    b.installArtifact(exe);
+
+    const exe_tests = b.addTest(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_exe_tests = b.addRunArtifact(exe_tests);
+    const test_step = b.step("test", "Run dependency fixture tests");
+    test_step.dependOn(&run_exe_tests.step);
+}

--- a/tests/fixtures/zig-deps/build.zig.zon
+++ b/tests/fixtures/zig-deps/build.zig.zon
@@ -1,0 +1,16 @@
+.{
+    .name = .zig_deps_fixture,
+    .version = "0.1.0",
+    .fingerprint = 0x15f7be3eeebd2a7c,
+    .dependencies = .{
+        .known_folders = .{
+            .url = "https://github.com/ziglibs/known-folders/archive/refs/tags/0.7.0.tar.gz",
+            .hash = "N-V-__8AAEBMAACmUnVy2ktNSZm4TZ8-sbPnRWUmlW5boAAS",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/tests/fixtures/zig-deps/src/main.zig
+++ b/tests/fixtures/zig-deps/src/main.zig
@@ -1,0 +1,6 @@
+pub fn main() void {}
+
+test "dependency fixture test runs" {
+    const std = @import("std");
+    try std.testing.expect(true);
+}


### PR DESCRIPTION
## Summary

- add `ix.buildZigPackage` for `build.zig` / `build.zig.zon` projects
- wire Zig dependency cache support through `zigDepsHash` and pinned Zig toolchains
- expose named Zig test steps as separate `passthru.tests` derivations
- add Zig fixtures for dependency-free packages and remote `build.zig.zon` dependencies
- document that `__impure` is acceptable for explicit dependency discovery/prefetch boundaries when the result is converted to a checked hash-bearing artifact before product builds consume it

## Research note

Zig's idiomatic package surface is `build.zig.zon`: dependency entries carry a Zig package hash beside the URL, and the build system fetches into Zig's package cache. That differs from Rust's `Cargo.toml` plus `Cargo.lock` split.

For Zig 0.14, the dependency hash string that matters to the cache is the `N-V-...` package hash printed by `zig fetch`. The helper uses nixpkgs' `zigPackages.<minor>.fetchDeps` to materialize the package cache as a fixed-output derivation, then copies that cache into a writable `ZIG_GLOBAL_CACHE_DIR` for package builds and each separate test derivation. The remote-dependency fixture proves the cache is consumed offline by building both the package and its `passthru.tests.default` derivation in the eval check.

`__impure` can be used for updater/prefetch derivations that discover dependency content, but the product build still consumes the checked cache artifact. That keeps the impure boundary explicit and leaves later builds pure.

## Checks

- `nix build .#checks.x86_64-linux.eval`
- `nix run .#lint`
