### PR TITLE
go-unit: resolve module hashes from lock artifact

### DIFF
--- a/lib/go-unit.nix
+++ b/lib/go-unit.nix
@@ -36,6 +36,20 @@ let
       moduleRoot = if modRoot == "." then src else src + "/${modRoot}";
       goMod = args.goMod or (moduleRoot + "/go.mod");
       goSum = args.goSum or (moduleRoot + "/go.sum");
+      vendorHashFile = args.vendorHashFile or (moduleRoot + "/go-modules.nix");
+      vendorHashKey = builtins.hashString "sha256" (
+        (builtins.readFile goMod) + "\n" + (builtins.readFile goSum)
+      );
+      vendorHashes =
+        args.vendorHashes or (if builtins.pathExists vendorHashFile then import vendorHashFile else { });
+      vendorHash =
+        args.vendorHash or vendorHashes.${vendorHashKey} or (throw ''
+          goUnit.buildWorkspace requires a vendor hash for go.mod/go.sum key ${vendorHashKey}.
+          Add ${builtins.toString vendorHashFile} with:
+          {
+            "${vendorHashKey}" = "sha256-...";
+          }
+        '');
     in
     assert lib.assertMsg (builtins.pathExists goMod)
       "goUnit.buildWorkspace requires a checked-in go.mod at ${builtins.toString goMod}";
@@ -50,9 +64,10 @@ let
         goSum
         modRoot
         moduleRoot
+        vendorHash
+        vendorHashFile
+        vendorHashKey
         ;
-      vendorHash =
-        args.vendorHash or (throw "goUnit.buildWorkspace requires vendorHash from pkgs.buildGoModule");
       packages =
         let
           packages = args.packages or [ "." ];
@@ -89,7 +104,13 @@ let
       doCheck = false;
       strictDeps = true;
       passthru.goUnit = {
-        inherit (args) goSum goToolchain env;
+        inherit (args)
+          goSum
+          goToolchain
+          env
+          vendorHashKey
+          vendorHashFile
+          ;
         inherit package;
       };
     };
@@ -121,7 +142,13 @@ let
         touch "$out/done"
       '';
       passthru.goUnit = {
-        inherit (args) goSum goToolchain env;
+        inherit (args)
+          goSum
+          goToolchain
+          env
+          vendorHashKey
+          vendorHashFile
+          ;
         inherit package;
       };
     };
@@ -131,12 +158,17 @@ let
 
     Go does not expose Cargo's rustc unit graph, so callers choose the package
     patterns that deserve independent cache and test boundaries. The helper
-    requires `go.mod`, `go.sum`, and `vendorHash`.
+    requires `go.mod`, `go.sum`, and a matching Nix vendor hash.
+    By default, the vendor hash comes from `go-modules.nix` next to the module,
+    keyed by the combined `go.mod` and `go.sum` contents. This keeps the Nix
+    fixed-output hash in a narrow generated artifact instead of repeating it at
+    every build call site. Callers may pass `vendorHash`, `vendorHashes`, or
+    `vendorHashFile` when the owner lives somewhere else.
 
     Arguments:
     - `src`: filtered module source.
     - `packages`: Go package patterns to expose, default `[ "." ]`.
-    - `vendorHash`: hash accepted by `pkgs.buildGoModule`.
+    - `vendorHashFile`: attrset file keyed by `vendorHashKey`, default `go-modules.nix`.
     - `goToolchain`: optional Go package, default `ix.languages.go.toolchain pkgs { version = "latest"; }`.
 
     Returns `packages`, `tests`, `default`, `checks`, and `sourceAudit`.
@@ -170,9 +202,11 @@ let
           base = "workspace";
           scope = "module";
           relative = args.modRoot;
-          lockFile = if builtins.pathExists args.goSum then "go.sum" else null;
+          lockFile = "go.sum";
+          inherit (args) vendorHashKey;
         };
       };
+      inherit (args) vendorHashKey;
     };
 in
 {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -608,6 +608,7 @@ let
     root = ./fixtures/go-unit-hello;
     fileset = fs.unions [
       ./fixtures/go-unit-hello/go.mod
+      ./fixtures/go-unit-hello/go-modules.nix
       ./fixtures/go-unit-hello/go.sum
       ./fixtures/go-unit-hello/main.go
       ./fixtures/go-unit-hello/main_test.go
@@ -617,7 +618,6 @@ let
   goUnitWorkspace = ix.goUnit.buildWorkspace {
     pname = "go-unit-hello";
     src = goUnitFixture;
-    vendorHash = "sha256-36P4vOdzJotmVZon5Zud/d/jxzv4ad04aQT2G/EE3U8=";
     env.GOFLAGS = "-mod=readonly";
     packages = [ "." ];
   };
@@ -631,7 +631,6 @@ let
     pname = "go-unit-nested";
     src = goUnitNestedFixture;
     modRoot = "module";
-    vendorHash = "sha256-36P4vOdzJotmVZon5Zud/d/jxzv4ad04aQT2G/EE3U8=";
     packages = [ "." ];
   };
 
@@ -640,7 +639,6 @@ let
       (ix.goUnit.buildWorkspace {
         pname = "go-unit-collision";
         src = goUnitFixture;
-        vendorHash = "sha256-36P4vOdzJotmVZon5Zud/d/jxzv4ad04aQT2G/EE3U8=";
         packages = [
           "a.b"
           "a/b"
@@ -2592,6 +2590,16 @@ let
       {
         assertion = goUnitWorkspace.packages.root.goUnit.goSum == goUnitFixture + "/go.sum";
         message = "go-unit package derivations should pass go.sum through to buildGoModule";
+      }
+      {
+        assertion =
+          goUnitWorkspace.vendorHashKey == "946e64650b103a2fe8d7518f522acad2ba766bd2c3700066125f33206d400b66";
+        message = "go-unit workspaces should derive the vendor hash key from go.mod and go.sum";
+      }
+      {
+        assertion =
+          goUnitWorkspace.packages.root.goUnit.vendorHashFile == goUnitFixture + "/go-modules.nix";
+        message = "go-unit package derivations should use the module-owned vendor hash file by default";
       }
       {
         assertion =

--- a/tests/fixtures/go-unit-hello/go-modules.nix
+++ b/tests/fixtures/go-unit-hello/go-modules.nix
@@ -1,0 +1,4 @@
+{
+  "946e64650b103a2fe8d7518f522acad2ba766bd2c3700066125f33206d400b66" =
+    "sha256-36P4vOdzJotmVZon5Zud/d/jxzv4ad04aQT2G/EE3U8=";
+}

--- a/tests/fixtures/go-unit-nested/module/go-modules.nix
+++ b/tests/fixtures/go-unit-nested/module/go-modules.nix
@@ -1,0 +1,4 @@
+{
+  "72b83126a08cd5a53e04abd2080631c3fb4eb9b789e7cfec845db6568c93bc03" =
+    "sha256-36P4vOdzJotmVZon5Zud/d/jxzv4ad04aQT2G/EE3U8=";
+}


### PR DESCRIPTION
## Summary

- make `goUnit.buildWorkspace` resolve `vendorHash` from module-owned `go-modules.nix`
- key the hash by combined `go.mod` and `go.sum` contents
- remove explicit fixture `vendorHash` call-site plumbing and cover the derived key path

## Checks

- `nix run .#lint`
- `nix build .#checks.x86_64-linux.eval --show-trace`
