### PR TITLE
site: render markdown in titles, rebrand to 'index'

### DIFF
--- a/site/src/app.css
+++ b/site/src/app.css
@@ -162,6 +162,16 @@ time {
   border: 0;
 }
 
+.log h2 code {
+  padding: 0.05em 0.3em;
+  border-radius: 4px;
+  background: var(--code);
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
 .log h2 a:hover {
   color: var(--fg-muted);
 }

--- a/site/src/lib/updates.ts
+++ b/site/src/lib/updates.ts
@@ -119,7 +119,7 @@ An \`examples/observability-stack/\` fleet shows the smallest viable deployment.
 export const siteUrl = 'https://indexable-inc.github.io/index/';
 export const siteFeedUrl = `${siteUrl}feed.xml`;
 export const siteIntro =
-  'Pre-built OCI images and composable NixOS modules for ix VMs.';
+  'Images, NixOS modules, helpers, and notes published by ix.';
 
 export function plainText(markdown: string): string {
   return markdown

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -35,18 +35,19 @@
   const entries = siteUpdates.map((update) => ({
     ...update,
     html: marked.parse(update.body) as string,
+    titleHtml: marked.parseInline(update.title) as string,
     label: formatDate(update.date)
   }));
 </script>
 
 <svelte:head>
-  <title>ix images</title>
+  <title>index</title>
   <meta name="description" content={siteIntro} />
-  <link rel="alternate" type="application/rss+xml" title="ix images" href={siteFeedUrl} />
+  <link rel="alternate" type="application/rss+xml" title="index" href={siteFeedUrl} />
 </svelte:head>
 
 <header>
-  <a class="wordmark" href={resolve('/')}>ix images</a>
+  <a class="wordmark" href={resolve('/')}>index</a>
   <nav>
     <a href="https://github.com/indexable-inc/index">github</a>
     <a href="https://ix.dev">ix.dev</a>
@@ -56,7 +57,7 @@
 
 <main>
   <section class="hero">
-    <h1>Pre-built systems for ix VMs.</h1>
+    <h1>Open source from ix.</h1>
     <p>{siteIntro}</p>
   </section>
 
@@ -64,7 +65,10 @@
     {#each entries as entry (entry.id)}
       <li id={entry.id}>
         <time datetime={entry.date}>{entry.label}</time>
-        <h2><a href="#{entry.id}">{entry.title}</a></h2>
+        <h2>
+          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+          <a href="#{entry.id}">{@html entry.titleHtml}</a>
+        </h2>
         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
         <div class="body">{@html entry.html}</div>
         <div class="refs">

--- a/site/src/routes/feed.xml/+server.ts
+++ b/site/src/routes/feed.xml/+server.ts
@@ -56,7 +56,7 @@ export function GET(): Response {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>ix images updates</title>
+    <title>index</title>
     <link>${escapeXml(siteUrl)}</link>
     <atom:link href="${escapeXml(siteFeedUrl)}" rel="self" type="application/rss+xml" />
     <description>${escapeXml(siteIntro)}</description>


### PR DESCRIPTION
- Titles render through `marked.parseInline`, so entry titles like `` `nix run .#site` previews the page locally `` show the backticked spans as inline `<code>`. A small CSS rule sizes the mono code inside `h2` to balance against the bold text.
- Retitles the page from "ix images" to **index**: wordmark, HTML `<title>`, RSS alternate link, RSS channel title, and intro copy. The site is broader than just OCI images now (modules, helpers, tooling, notes), so the broader name fits.
