### PR TITLE
site: render post times in the visitor's local zone

### DIFF
--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { resolve } from '$app/paths';
   import { Marked } from 'marked';
   import { siteFeedUrl, siteIntro, siteUpdates } from '$lib/updates';
@@ -21,33 +22,52 @@
 
   const feedHref = resolve('/feed.xml');
 
-  // Render in UTC so the prerendered HTML reads the same in every visitor's
-  // zone. The <time datetime> attribute carries the full offset for clients
-  // that want to reformat locally.
-  const dateFormatter = new Intl.DateTimeFormat('en', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    timeZone: 'UTC'
-  });
-  const timeFormatter = new Intl.DateTimeFormat('en', {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-    timeZone: 'UTC'
+  // The prerendered HTML renders in UTC so it reads the same in every
+  // visitor's zone before JS runs. After hydration the page reformats each
+  // <time> in the visitor's local zone so the label matches their wall clock.
+  // The <time datetime> attribute always carries the full offset.
+  let timeZone = $state<string | undefined>(undefined);
+
+  onMount(() => {
+    timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   });
 
-  function formatPostedAt(postedAt: string): string {
+  function formatPostedAt(postedAt: string, zone: string | undefined): string {
     const parsed = new Date(postedAt);
-    return `${dateFormatter.format(parsed)} · ${timeFormatter.format(parsed)} UTC`;
+    const tz = zone ?? 'UTC';
+    const date = new Intl.DateTimeFormat('en', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: tz
+    }).format(parsed);
+    const time = new Intl.DateTimeFormat('en', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+      timeZone: tz
+    }).format(parsed);
+    const tzNamePart = new Intl.DateTimeFormat('en', {
+      timeZoneName: 'short',
+      timeZone: tz
+    })
+      .formatToParts(parsed)
+      .find((part) => part.type === 'timeZoneName');
+    return `${date} · ${time} ${tzNamePart?.value ?? tz}`;
   }
 
-  const entries = siteUpdates.map((update) => ({
+  const renderedEntries = siteUpdates.map((update) => ({
     ...update,
     html: marked.parse(update.body) as string,
-    titleHtml: marked.parseInline(update.title) as string,
-    label: formatPostedAt(update.postedAt)
+    titleHtml: marked.parseInline(update.title) as string
   }));
+
+  const entries = $derived(
+    renderedEntries.map((entry) => ({
+      ...entry,
+      label: formatPostedAt(entry.postedAt, timeZone)
+    }))
+  );
 </script>
 
 <svelte:head>


### PR DESCRIPTION
Follow-up to #155: after hydration, each entry's timestamp is reformatted with `Intl.DateTimeFormat().resolvedOptions().timeZone` so the page shows the visitor's wall-clock time (e.g. `May 25, 2026 · 23:22 PDT`) instead of the UTC fallback. SSR keeps rendering UTC so the no-JS / pre-hydration view stays correct, and the `<time datetime>` attribute continues to carry the full ISO offset.