### PR TITLE
resource-monitor/site: svelte.config.ts so the LS finds svelte 5

### DIFF
--- a/modules/services/resource-monitor/site/svelte.config.ts
+++ b/modules/services/resource-monitor/site/svelte.config.ts
@@ -1,0 +1,8 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import type { SvelteConfig } from '@sveltejs/vite-plugin-svelte';
+
+const config: SvelteConfig = {
+  preprocess: [vitePreprocess()]
+};
+
+export default config;


### PR DESCRIPTION
Adds `svelte.config.ts` to `modules/services/resource-monitor/site/` so svelte-language-server stops falling back to its bundled (pre-5) parser and resolves the workspace's Svelte 5, fixing `Expected if, each or await` false positives on `{#snippet}` blocks. Build is unaffected.