### PR TITLE
lib: bind cargoUnit/goUnit to host pkgs in packageSetFor

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -623,6 +623,12 @@ let
       packageSystem = pkgs.stdenv.hostPlatform.system;
       ixForPackages = ixSpecialArgs // {
         inherit pkgs;
+        # Rebind the language unit builders to the caller's pkgs so repo
+        # packages built through packageSetFor (room, loop, ...) compile for
+        # the host system instead of the x86_64-linux pkgs the top-level
+        # ixSpecialArgs bundle is bound to.
+        cargoUnit = cargoUnitFor pkgs;
+        goUnit = goUnitFor pkgs;
       };
       basePackages = {
         dag-runner = pkgs.callPackage paths.packages.dagRunner {


### PR DESCRIPTION
`nix run .#room` (and `.#loop`) on darwin failed with `Exec format error`
because the wrapper derivation built natively while the inner Rust binary
was still ELF.

`ixSpecialArgs.cargoUnit` is bound to the top-level x86_64-linux `pkgs`
(`lib/default.nix:15,279`). `packageSetFor pkgs` rebinds the bundle's
`pkgs` to the caller's host pkgs so `runCommand`/`makeWrapper` follow the
host system, but it leaves `cargoUnit`/`goUnit` pointing at the Linux
binding. Repo packages (room, loop) call `ix.cargoUnit.buildBinary`, so
the binary kept building for Linux while the wrapper around it built for
darwin.

Rebind `cargoUnit` and `goUnit` to the caller's pkgs inside
`packageSetFor`. After this:

```
$ nix run .#room -- --help
Serve a multiplayer team room
Usage: room [OPTIONS]
...
```

`nix build .#packages.x86_64-linux.room` still succeeds, so image
closures are unchanged.
