### PR TITLE
site: type the test noop component without any

### DIFF
--- a/site/src/lib/updates.test.ts
+++ b/site/src/lib/updates.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'vitest';
+import type { Component } from 'svelte';
 import { inlineTitleHtml, plainText, siteUpdates, updateScript } from './updates';
+
+const noopComponent = (() => null) as unknown as Component;
 
 describe('inlineTitleHtml', () => {
   test('wraps backtick spans in <code>', () => {
@@ -39,8 +42,7 @@ describe('updateScript', () => {
       id: 'demo',
       postedAt: '2026-05-26T01:22:16-07:00',
       title: 'a `cmd` arrived',
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      component: (() => null) as any,
+      component: noopComponent,
       rawBody: 'It does `things` well.',
       links: []
     });


### PR DESCRIPTION
Fixes `nix run .#site` / `nix build .#site` failure on main: lint trips on
`@typescript-eslint/no-unsafe-assignment` for the noop component. Cast via
`unknown` instead and drop the disable comment.