### PR TITLE
site: prerendered permalink page per entry

### DIFF
--- a/site/src/lib/UpdateEntry.svelte
+++ b/site/src/lib/UpdateEntry.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { formatPostedAt } from './format-posted-at';
+  import { inlineTitleHtml, type SiteUpdate } from './updates';
+
+  type Props = {
+    update: SiteUpdate;
+    timeZone: string | undefined;
+    // `h1` for standalone permalink pages, `h2` (default) on the feed.
+    titleTag?: 'h1' | 'h2';
+    // The feed wants each title to link back to its permalink; the
+    // permalink page itself does not need to link to itself.
+    titleLinksToPermalink?: boolean;
+  };
+
+  const {
+    update,
+    timeZone,
+    titleTag = 'h2',
+    titleLinksToPermalink = true
+  }: Props = $props();
+
+  const Body = $derived(update.component);
+  const titleHtml = $derived(inlineTitleHtml(update.title));
+  const label = $derived(formatPostedAt(update.postedAt, timeZone));
+  const permalink = $derived(resolve('/[id]', { id: update.id }));
+</script>
+
+<article id={update.id}>
+  <time datetime={update.postedAt}>{label}</time>
+  {#if titleTag === 'h1'}
+    <h1>
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      {@html titleHtml}
+    </h1>
+  {:else if titleLinksToPermalink}
+    <h2>
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      <a href={permalink}>{@html titleHtml}</a>
+    </h2>
+  {:else}
+    <h2>
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      {@html titleHtml}
+    </h2>
+  {/if}
+  <div class="body">
+    <Body />
+  </div>
+  {#if update.links.length > 0}
+    <div class="refs">
+      {#each update.links as link, i (link.href)}
+        {#if i > 0}<span aria-hidden="true">·</span>{/if}
+        <a href={link.href} rel="external">{link.label}</a>
+      {/each}
+    </div>
+  {/if}
+</article>

--- a/site/src/lib/format-posted-at.ts
+++ b/site/src/lib/format-posted-at.ts
@@ -1,0 +1,26 @@
+// Format an ISO 8601 timestamp for display. SSR passes no zone, so the
+// prerendered HTML reads identically in every visitor's zone; after
+// hydration callers pass the resolved local zone.
+export function formatPostedAt(postedAt: string, zone: string | undefined): string {
+  const parsed = new Date(postedAt);
+  const tz = zone ?? 'UTC';
+  const date = new Intl.DateTimeFormat('en', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: tz
+  }).format(parsed);
+  const time = new Intl.DateTimeFormat('en', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: tz
+  }).format(parsed);
+  const tzNamePart = new Intl.DateTimeFormat('en', {
+    timeZoneName: 'short',
+    timeZone: tz
+  })
+    .formatToParts(parsed)
+    .find((part) => part.type === 'timeZoneName');
+  return `${date} · ${time} ${tzNamePart?.value ?? tz}`;
+}

--- a/site/src/lib/updates.ts
+++ b/site/src/lib/updates.ts
@@ -81,3 +81,9 @@ function escapeHtml(value: string): string {
 export function updateScript(update: SiteUpdate): string {
   return `${plainText(update.title)}. ${plainText(update.rawBody)}`;
 }
+
+// Absolute URL for one entry. The base path lives in `siteUrl`, which
+// already carries the trailing slash, so the slug just appends.
+export function updateUrl(id: string): string {
+  return `${siteUrl}${id}`;
+}

--- a/site/src/routes/+layout.svelte
+++ b/site/src/routes/+layout.svelte
@@ -1,8 +1,28 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
+  import { resolve } from '$app/paths';
+  import { siteFeedUrl } from '$lib/updates';
   import '../app.css';
 
   const { children }: { children: Snippet } = $props();
+
+  const homeHref = resolve('/');
+  const feedHref = resolve('/feed.xml');
 </script>
 
-{@render children()}
+<svelte:head>
+  <link rel="alternate" type="application/rss+xml" title="index" href={siteFeedUrl} />
+</svelte:head>
+
+<header>
+  <a class="wordmark" href={homeHref}>index</a>
+  <nav>
+    <a href="https://github.com/indexable-inc/index">github</a>
+    <a href="https://ix.dev">ix.dev</a>
+    <a href={feedHref}>rss</a>
+  </nav>
+</header>
+
+<main>
+  {@render children()}
+</main>

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -1,97 +1,31 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { resolve } from '$app/paths';
-  import {
-    inlineTitleHtml,
-    siteFeedUrl,
-    siteIntro,
-    siteUpdates
-  } from '$lib/updates';
+  import UpdateEntry from '$lib/UpdateEntry.svelte';
+  import { siteIntro, siteUpdates } from '$lib/updates';
 
-  const feedHref = resolve('/feed.xml');
-
-  // The prerendered HTML renders in UTC so it reads the same in every
-  // visitor's zone before JS runs. After hydration the page reformats each
-  // <time> in the visitor's local zone so the label matches their wall clock.
-  // The <time datetime> attribute always carries the full ISO offset.
+  // The prerendered HTML uses UTC so every visitor's pre-hydration view
+  // matches. After mount, we re-render each <time> in the visitor's local
+  // zone. The `<time datetime>` attribute always carries the full ISO offset.
   let timeZone = $state<string | undefined>(undefined);
-
   onMount(() => {
     timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   });
-
-  function formatPostedAt(postedAt: string, zone: string | undefined): string {
-    const parsed = new Date(postedAt);
-    const tz = zone ?? 'UTC';
-    const date = new Intl.DateTimeFormat('en', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      timeZone: tz
-    }).format(parsed);
-    const time = new Intl.DateTimeFormat('en', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-      timeZone: tz
-    }).format(parsed);
-    const tzNamePart = new Intl.DateTimeFormat('en', {
-      timeZoneName: 'short',
-      timeZone: tz
-    })
-      .formatToParts(parsed)
-      .find((part) => part.type === 'timeZoneName');
-    return `${date} · ${time} ${tzNamePart?.value ?? tz}`;
-  }
-
-  const entries = siteUpdates.map((update) => ({
-    ...update,
-    titleHtml: inlineTitleHtml(update.title)
-  }));
 </script>
 
 <svelte:head>
   <title>index</title>
   <meta name="description" content={siteIntro} />
-  <link rel="alternate" type="application/rss+xml" title="index" href={siteFeedUrl} />
 </svelte:head>
 
-<header>
-  <a class="wordmark" href={resolve('/')}>index</a>
-  <nav>
-    <a href="https://github.com/indexable-inc/index">github</a>
-    <a href="https://ix.dev">ix.dev</a>
-    <a href={feedHref}>rss</a>
-  </nav>
-</header>
+<section class="hero">
+  <h1>Open source from ix.</h1>
+  <p>{siteIntro}</p>
+</section>
 
-<main>
-  <section class="hero">
-    <h1>Open source from ix.</h1>
-    <p>{siteIntro}</p>
-  </section>
-
-  <ol class="log">
-    {#each entries as entry (entry.id)}
-      {@const Entry = entry.component}
-      <li id={entry.id}>
-        <time datetime={entry.postedAt}>
-          {formatPostedAt(entry.postedAt, timeZone)}
-        </time>
-        <h2>
-          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-          <a href="#{entry.id}">{@html entry.titleHtml}</a>
-        </h2>
-        <div class="body">
-          <Entry />
-        </div>
-        <div class="refs">
-          {#each entry.links as link, i (link.href)}
-            {#if i > 0}<span aria-hidden="true">·</span>{/if}
-            <a href={link.href} rel="external">{link.label}</a>
-          {/each}
-        </div>
-      </li>
-    {/each}
-  </ol>
-</main>
+<ol class="log">
+  {#each siteUpdates as update (update.id)}
+    <li>
+      <UpdateEntry {update} {timeZone} />
+    </li>
+  {/each}
+</ol>

--- a/site/src/routes/[id]/+page.svelte
+++ b/site/src/routes/[id]/+page.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import UpdateEntry from '$lib/UpdateEntry.svelte';
+  import { plainText } from '$lib/updates';
+  import type { PageData } from './$types';
+
+  const { data }: { data: PageData } = $props();
+
+  let timeZone = $state<string | undefined>(undefined);
+  onMount(() => {
+    timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  });
+
+  const titleText = $derived(plainText(data.update.title));
+</script>
+
+<svelte:head>
+  <title>{titleText} · index</title>
+  <meta name="description" content={titleText} />
+</svelte:head>
+
+<article class="entry">
+  <UpdateEntry update={data.update} {timeZone} titleTag="h1" />
+</article>

--- a/site/src/routes/[id]/+page.ts
+++ b/site/src/routes/[id]/+page.ts
@@ -1,0 +1,14 @@
+import { error } from '@sveltejs/kit';
+import { siteUpdates } from '$lib/updates';
+import type { EntryGenerator, PageLoad } from './$types';
+
+export const prerender = true;
+
+export const entries: EntryGenerator = () =>
+  siteUpdates.map((update) => ({ id: update.id }));
+
+export const load: PageLoad = ({ params }) => {
+  const update = siteUpdates.find((u) => u.id === params.id);
+  if (!update) error(404, `Unknown update: ${params.id}`);
+  return { update };
+};

--- a/site/src/routes/feed.xml/+server.ts
+++ b/site/src/routes/feed.xml/+server.ts
@@ -4,7 +4,8 @@ import {
   siteIntro,
   siteUpdates,
   siteUrl,
-  updateScript
+  updateScript,
+  updateUrl
 } from '$lib/updates';
 
 export const prerender = true;
@@ -30,10 +31,6 @@ function escapeXml(value: string): string {
 
 function rssDate(postedAt: string): string {
   return new Date(postedAt).toUTCString();
-}
-
-function updateUrl(updateId: string): string {
-  return `${siteUrl}#${encodeURIComponent(updateId)}`;
 }
 
 function itemXml(update: (typeof siteUpdates)[number]): string {


### PR DESCRIPTION
Each update entry is now its own prerendered page at `/<id>` (e.g. `/ix-dev-diagnose`) instead of an in-page fragment (`/#ix-dev-diagnose`). adapter-static enumerates the dynamic `[id]` route via `export const entries = () => siteUpdates.map(u => ({ id: u.id }))`, materializing one `.html` per entry at build time. The home feed's titles and the RSS feed both link to these path permalinks.