### PR TITLE
site: use github: flake refs in copyable examples

### DIFF
--- a/site/src/lib/updates/agents-md-fragments.svx
+++ b/site/src/lib/updates/agents-md-fragments.svx
@@ -21,6 +21,6 @@ lib.agentsMd.render {
 Sibling repos can pull in shared guidance instead of copy-pasting it. The ix repo already publishes its agnostic sections through the same API and this repo imports them at the top of the render pipeline.
 
 ```bash
-nix run   .#agents-md             # writes AGENTS.md
-nix flake check .#agents-md-up-to-date
+nix run   github:indexable-inc/index#agents-md   # writes AGENTS.md
+nix flake check github:indexable-inc/index#agents-md-up-to-date
 ```

--- a/site/src/lib/updates/ix-dev-diagnose.svx
+++ b/site/src/lib/updates/ix-dev-diagnose.svx
@@ -10,7 +10,7 @@ links:
 `nix run .#ix-dev-diagnose` reaches `https://ix.dev/` from the caller's network path, prints `success` or `failure`, and writes one JSON report capturing system resolver answers, per-address TCP and TLS results, parsed certificate issuers and fingerprints, native and Mozilla-root verification outcomes, response headers, and a bounded body sample.
 
 ```bash
-nix run .#ix-dev-diagnose -- --max-body-bytes 128 --out report.json
+nix run github:indexable-inc/index#ix-dev-diagnose -- --max-body-bytes 128 --out report.json
 ```
 
 ```json

--- a/site/src/lib/updates/nix-run-site.svx
+++ b/site/src/lib/updates/nix-run-site.svx
@@ -12,8 +12,8 @@ links:
 The `site` package is now a `symlinkJoin` of the deploy artifact and a tiny `miniserve` wrapper, so `nix build .#site` still emits the GitHub Pages tree and `nix run .#site` boots a preview at `http://127.0.0.1:8080/`.
 
 ```bash
-nix build .#site   # GitHub Pages tree under result/share/ix-site
-nix run   .#site   # preview at http://127.0.0.1:8080/
+nix build github:indexable-inc/index#site   # GitHub Pages tree under result/share/ix-site
+nix run   github:indexable-inc/index#site   # preview at http://127.0.0.1:8080/
 ```
 
 The wrapper points at a second `buildNpmSite` invocation whose `preBuild` exports `BASE_PATH=`, leaning on SvelteKit's own base-path plumbing instead of rewriting URLs in the server layer. `buildNpmSite` stays focused on building.

--- a/site/src/lib/updates/run-recorder.svx
+++ b/site/src/lib/updates/run-recorder.svx
@@ -10,7 +10,7 @@ links:
 `nix run .#run -- <command> ...` executes the command in a PTY, prints a bounded head/tail summary to the terminal, and writes the full live stream under `./.ix/run/latest/`.
 
 ```bash
-nix run .#run -- cargo test -p my-crate
+nix run github:indexable-inc/index#run -- cargo test -p my-crate
 ls .ix/run/latest/
 # manifest.json  output.log  output.cast  output.timing
 # stdout.jsonl   lines.jsonl


### PR DESCRIPTION
## Summary

- changes copyable `nix run .#…` / `nix build .#…` / `nix flake check .#…` examples on the site to the `github:indexable-inc/index#…` form

Visitors no longer need to clone the repo before pasting any of the commands. Titles and inline prose still use the short `.#` form because they describe the package name, not a copy-paste step.

## Checks

- `npm run check`
- `npm test`
