### PR TITLE
site: show ix-dev-diagnose with default args

### DIFF
--- a/site/src/lib/updates/ix-dev-diagnose.svx
+++ b/site/src/lib/updates/ix-dev-diagnose.svx
@@ -10,8 +10,10 @@ links:
 `nix run .#ix-dev-diagnose` reaches `https://ix.dev/` from the caller's network path, prints `success` or `failure`, and writes one JSON report capturing system resolver answers, per-address TCP and TLS results, parsed certificate issuers and fingerprints, native and Mozilla-root verification outcomes, response headers, and a bounded body sample.
 
 ```bash
-nix run github:indexable-inc/index#ix-dev-diagnose -- --max-body-bytes 128 --out report.json
+nix run github:indexable-inc/index#ix-dev-diagnose
 ```
+
+Defaults are sensible: the report lands at `ix-dev-diagnose-<host>-<ms>.json` in the current directory and the body sample is capped at 64 KiB. Pass `--max-body-bytes`, `--output`, `--pretty`, or `--json` to override.
 
 ```json
 {


### PR DESCRIPTION
## Summary

Drops the `-- --max-body-bytes 128 --out report.json` from the runnable example so the blog shows the no-argument copy-paste path. Adds a short note that the defaults write `ix-dev-diagnose-<host>-<ms>.json` in the cwd and cap the body sample at 64 KiB, with the override flags listed.

## Checks

- `npm run check`
- `npm test`
