### PR TITLE
site: filter entries with boolean tag expressions

### DIFF
--- a/site/src/app.css
+++ b/site/src/app.css
@@ -262,6 +262,26 @@ time {
   color: var(--fg-faint);
 }
 
+.tags {
+  list-style: none;
+  margin: 0.85rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+}
+
+.tags li {
+  padding: 0.05rem 0.4rem;
+  border: 1px solid var(--rule);
+  border-radius: 3px;
+}
+
 @media (max-width: 32rem) {
   header,
   main {

--- a/site/src/lib/FilterBar.svelte
+++ b/site/src/lib/FilterBar.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+  import { highlightExpression } from './filter-expression';
+
+  type Props = {
+    value: string;
+    onChange: (next: string) => void;
+    matchCount: number;
+    totalCount: number;
+    error?: string;
+  };
+
+  const { value, onChange, matchCount, totalCount, error }: Props = $props();
+
+  const tokens = $derived(highlightExpression(value));
+
+  // Keep the highlighted overlay aligned with the input when the text scrolls
+  // horizontally (long expressions). The overlay is `overflow: hidden`; this
+  // shifts it to mirror the input's `scrollLeft`.
+  let inputEl: HTMLInputElement | undefined = $state();
+  let overlayEl: HTMLDivElement | undefined = $state();
+  function syncScroll(): void {
+    if (inputEl && overlayEl) {
+      overlayEl.scrollLeft = inputEl.scrollLeft;
+    }
+  }
+</script>
+
+<section class="filter" aria-label="Filter entries by tag">
+  <div class="row">
+    <span class="prompt" aria-hidden="true">filter</span>
+    <div class="field">
+      <div class="overlay" bind:this={overlayEl} aria-hidden="true">
+        {#each tokens as token, i (i)}<span class={`tok tok-${token.kind}`}
+            >{token.text}</span
+          >{/each}
+      </div>
+      <input
+        bind:this={inputEl}
+        type="text"
+        {value}
+        oninput={(event) => {
+          onChange(event.currentTarget.value);
+        }}
+        onscroll={syncScroll}
+        onkeyup={syncScroll}
+        spellcheck="false"
+        autocapitalize="off"
+        autocomplete="off"
+        autocorrect="off"
+        placeholder="nix & (rust | zig)"
+        aria-label="Filter expression"
+      />
+    </div>
+    <span class="count" aria-live="polite">
+      {matchCount} / {totalCount}
+    </span>
+  </div>
+  {#if error}
+    <p class="error" role="status">{error}</p>
+  {/if}
+</section>
+
+<style>
+  .filter {
+    margin-bottom: 2.5rem;
+    padding-bottom: 1.75rem;
+    border-bottom: 1px solid var(--rule);
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+  }
+
+  .prompt {
+    color: var(--fg-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .field {
+    flex: 1;
+    min-width: 0;
+    position: relative;
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    background: var(--bg);
+    transition: border-color 0.15s ease;
+  }
+
+  .field:focus-within {
+    border-color: var(--fg-muted);
+  }
+
+  /* The overlay paints the syntax-highlighted text. The input above it has
+   * transparent text and a visible caret, so users see the highlighted
+   * version of what they type. Padding, font, and line-height must match
+   * pixel-for-pixel between the two layers. */
+  .overlay,
+  input {
+    padding: 0.45rem 0.6rem;
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    line-height: 1.4;
+    letter-spacing: 0;
+  }
+
+  .overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    white-space: pre;
+    overflow: hidden;
+    color: var(--fg);
+  }
+
+  input {
+    position: relative;
+    z-index: 1;
+    display: block;
+    width: 100%;
+    border: 0;
+    background: transparent;
+    color: transparent;
+    caret-color: var(--fg);
+  }
+
+  input:focus {
+    outline: none;
+  }
+
+  input::placeholder {
+    color: var(--fg-faint);
+  }
+
+  .tok-tag {
+    color: var(--fg);
+  }
+
+  .tok-op-and {
+    color: light-dark(#0a7484, #5ec5d5);
+    font-weight: 600;
+  }
+
+  .tok-op-or {
+    color: light-dark(#a8651e, #e0a467);
+    font-weight: 600;
+  }
+
+  .tok-op-not {
+    color: light-dark(#7a3e8f, #c89be0);
+    font-weight: 600;
+  }
+
+  .tok-paren {
+    color: var(--fg-faint);
+  }
+
+  .tok-error {
+    color: light-dark(#b91c1c, #fb7185);
+    text-decoration: underline wavy;
+    text-decoration-thickness: 1px;
+  }
+
+  .count {
+    color: var(--fg-faint);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .error {
+    margin-top: 0.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--fg-muted);
+  }
+
+</style>

--- a/site/src/lib/UpdateEntry.svelte
+++ b/site/src/lib/UpdateEntry.svelte
@@ -55,4 +55,11 @@
       {/each}
     </div>
   {/if}
+  {#if update.tags.length > 0}
+    <ul class="tags" aria-label="Tags">
+      {#each update.tags as tag (tag)}
+        <li>{tag}</li>
+      {/each}
+    </ul>
+  {/if}
 </article>

--- a/site/src/lib/filter-expression.test.ts
+++ b/site/src/lib/filter-expression.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'vitest';
+import { parseFilter } from './filter-expression';
+
+function matches(expr: string, tags: string[]): boolean {
+  const result = parseFilter(expr);
+  if (!result.ok) throw new Error(`parse failed: ${result.error}`);
+  return result.matches(tags);
+}
+
+describe('parseFilter', () => {
+  test('empty input matches everything', () => {
+    expect(matches('', [])).toBe(true);
+    expect(matches('   ', ['nix'])).toBe(true);
+  });
+
+  test('single tag', () => {
+    expect(matches('nix', ['nix', 'cli'])).toBe(true);
+    expect(matches('nix', ['rust'])).toBe(false);
+  });
+
+  test('explicit AND', () => {
+    expect(matches('nix & cli', ['nix', 'cli'])).toBe(true);
+    expect(matches('nix & cli', ['nix'])).toBe(false);
+  });
+
+  test('implicit AND', () => {
+    expect(matches('nix cli', ['nix', 'cli'])).toBe(true);
+    expect(matches('nix cli', ['nix'])).toBe(false);
+  });
+
+  test('OR', () => {
+    expect(matches('rust | zig', ['zig'])).toBe(true);
+    expect(matches('rust | zig', ['nix'])).toBe(false);
+  });
+
+  test('NOT', () => {
+    expect(matches('!testing', ['nix'])).toBe(true);
+    expect(matches('!testing', ['nix', 'testing'])).toBe(false);
+  });
+
+  test('precedence: AND binds tighter than OR', () => {
+    // nix & rust | zig === (nix & rust) | zig
+    expect(matches('nix & rust | zig', ['zig'])).toBe(true);
+    expect(matches('nix & rust | zig', ['nix', 'rust'])).toBe(true);
+    expect(matches('nix & rust | zig', ['nix'])).toBe(false);
+  });
+
+  test('parentheses override precedence', () => {
+    expect(matches('nix & (rust | zig)', ['nix', 'zig'])).toBe(true);
+    expect(matches('nix & (rust | zig)', ['zig'])).toBe(false);
+  });
+
+  test('NOT binds tighter than AND', () => {
+    // !a & b means (!a) & b
+    expect(matches('!a & b', ['b'])).toBe(true);
+    expect(matches('!a & b', ['a', 'b'])).toBe(false);
+  });
+
+  test('the example from the user message', () => {
+    // abc & xyz (asdsad | asdasd)
+    const tags = ['abc', 'xyz', 'asdsad'];
+    expect(matches('abc & xyz (asdsad | asdasd)', tags)).toBe(true);
+    expect(matches('abc & xyz (asdsad | asdasd)', ['abc', 'xyz'])).toBe(false);
+  });
+
+  test('tag names are lowercased', () => {
+    expect(matches('Nix', ['nix'])).toBe(true);
+  });
+
+  test('reports an error on bad syntax', () => {
+    const result = parseFilter('nix &');
+    expect(result.ok).toBe(false);
+  });
+
+  test('reports an error on unmatched parens', () => {
+    const result = parseFilter('(nix');
+    expect(result.ok).toBe(false);
+  });
+
+  test('reports an error on unexpected character', () => {
+    const result = parseFilter('nix @ rust');
+    expect(result.ok).toBe(false);
+  });
+});

--- a/site/src/lib/filter-expression.ts
+++ b/site/src/lib/filter-expression.ts
@@ -1,0 +1,227 @@
+// A tiny flecs-style boolean tag filter.
+//
+//   nix                  // single tag
+//   nix & cli            // both
+//   nix cli              // implicit AND between adjacent terms
+//   nix | rust           // either
+//   !testing             // absent
+//   nix & (rust | zig)   // grouped
+//
+// Precedence: NOT > AND > OR. Empty input matches everything.
+
+type Token =
+  | { kind: 'tag'; name: string }
+  | { kind: 'and' }
+  | { kind: 'or' }
+  | { kind: 'not' }
+  | { kind: 'lparen' }
+  | { kind: 'rparen' };
+
+type Node =
+  | { kind: 'tag'; name: string }
+  | { kind: 'not'; expr: Node }
+  | { kind: 'and'; left: Node; right: Node }
+  | { kind: 'or'; left: Node; right: Node };
+
+export type FilterExpression =
+  | { ok: true; matches: (tags: readonly string[]) => boolean }
+  | { ok: false; error: string };
+
+const ALWAYS: FilterExpression = { ok: true, matches: () => true };
+
+export function parseFilter(input: string): FilterExpression {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) return ALWAYS;
+
+  const tokens = tokenize(trimmed);
+  if ('error' in tokens) return { ok: false, error: tokens.error };
+
+  const parser = new Parser(tokens);
+  let node: Node;
+  try {
+    node = parser.parseOr();
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+  if (!parser.done()) {
+    return { ok: false, error: `unexpected token at position ${String(parser.cursor())}` };
+  }
+
+  return {
+    ok: true,
+    matches: (tags) => evaluate(node, new Set(tags))
+  };
+}
+
+function tokenize(input: string): Token[] | { error: string } {
+  const tokens: Token[] = [];
+  let i = 0;
+  while (i < input.length) {
+    const c = input[i];
+    if (/\s/.test(c)) {
+      i++;
+      continue;
+    }
+    if (c === '&') {
+      tokens.push({ kind: 'and' });
+      i++;
+      continue;
+    }
+    if (c === '|') {
+      tokens.push({ kind: 'or' });
+      i++;
+      continue;
+    }
+    if (c === '!') {
+      tokens.push({ kind: 'not' });
+      i++;
+      continue;
+    }
+    if (c === '(') {
+      tokens.push({ kind: 'lparen' });
+      i++;
+      continue;
+    }
+    if (c === ')') {
+      tokens.push({ kind: 'rparen' });
+      i++;
+      continue;
+    }
+    if (/[a-zA-Z0-9_-]/.test(c)) {
+      let j = i;
+      while (j < input.length && /[a-zA-Z0-9_-]/.test(input[j])) j++;
+      tokens.push({ kind: 'tag', name: input.slice(i, j).toLowerCase() });
+      i = j;
+      continue;
+    }
+    return { error: `unexpected character '${c}' at position ${String(i)}` };
+  }
+  return tokens;
+}
+
+class Parser {
+  pos = 0;
+  constructor(private readonly toks: Token[]) {}
+
+  done(): boolean {
+    return this.pos >= this.toks.length;
+  }
+
+  cursor(): number {
+    return this.pos;
+  }
+
+  peek(): Token | undefined {
+    return this.toks[this.pos];
+  }
+
+  next(): Token | undefined {
+    return this.toks[this.pos++];
+  }
+
+  parseOr(): Node {
+    let left = this.parseAnd();
+    while (this.peek()?.kind === 'or') {
+      this.next();
+      const right = this.parseAnd();
+      left = { kind: 'or', left, right };
+    }
+    return left;
+  }
+
+  parseAnd(): Node {
+    let left = this.parseNot();
+    for (;;) {
+      const t = this.peek();
+      if (!t) break;
+      if (t.kind === 'and') {
+        this.next();
+      } else if (t.kind === 'tag' || t.kind === 'lparen' || t.kind === 'not') {
+        // implicit AND between adjacent terms
+      } else {
+        break;
+      }
+      const right = this.parseNot();
+      left = { kind: 'and', left, right };
+    }
+    return left;
+  }
+
+  parseNot(): Node {
+    if (this.peek()?.kind === 'not') {
+      this.next();
+      return { kind: 'not', expr: this.parseNot() };
+    }
+    return this.parseAtom();
+  }
+
+  parseAtom(): Node {
+    const t = this.next();
+    if (!t) throw new Error('unexpected end of expression');
+    if (t.kind === 'tag') return { kind: 'tag', name: t.name };
+    if (t.kind === 'lparen') {
+      const inner = this.parseOr();
+      const close = this.next();
+      if (close?.kind !== 'rparen') throw new Error("expected ')'");
+      return inner;
+    }
+    throw new Error(`unexpected '${t.kind}' token`);
+  }
+}
+
+// Tolerant tokenizer for syntax highlighting. Unlike `tokenize`, this never
+// fails: any character lands in some span so the rendered overlay always
+// matches the input character-for-character. Whitespace is preserved as its
+// own span so the spans concatenate back to the original string exactly.
+export type HighlightToken = {
+  text: string;
+  kind: 'tag' | 'op-and' | 'op-or' | 'op-not' | 'paren' | 'space' | 'error';
+};
+
+export function highlightExpression(input: string): HighlightToken[] {
+  const out: HighlightToken[] = [];
+  let i = 0;
+  while (i < input.length) {
+    const c = input[i];
+    if (/\s/.test(c)) {
+      let j = i;
+      while (j < input.length && /\s/.test(input[j])) j++;
+      out.push({ text: input.slice(i, j), kind: 'space' });
+      i = j;
+    } else if (c === '&') {
+      out.push({ text: c, kind: 'op-and' });
+      i++;
+    } else if (c === '|') {
+      out.push({ text: c, kind: 'op-or' });
+      i++;
+    } else if (c === '!') {
+      out.push({ text: c, kind: 'op-not' });
+      i++;
+    } else if (c === '(' || c === ')') {
+      out.push({ text: c, kind: 'paren' });
+      i++;
+    } else if (/[a-zA-Z0-9_-]/.test(c)) {
+      let j = i;
+      while (j < input.length && /[a-zA-Z0-9_-]/.test(input[j])) j++;
+      out.push({ text: input.slice(i, j), kind: 'tag' });
+      i = j;
+    } else {
+      out.push({ text: c, kind: 'error' });
+      i++;
+    }
+  }
+  return out;
+}
+
+function evaluate(node: Node, tags: Set<string>): boolean {
+  switch (node.kind) {
+    case 'tag':
+      return tags.has(node.name);
+    case 'not':
+      return !evaluate(node.expr, tags);
+    case 'and':
+      return evaluate(node.left, tags) && evaluate(node.right, tags);
+    case 'or':
+      return evaluate(node.left, tags) || evaluate(node.right, tags);
+  }
+}

--- a/site/src/lib/updates.test.ts
+++ b/site/src/lib/updates.test.ts
@@ -44,7 +44,8 @@ describe('updateScript', () => {
       title: 'a `cmd` arrived',
       component: noopComponent,
       rawBody: 'It does `things` well.',
-      links: []
+      links: [],
+      tags: []
     });
     expect(script).toBe('a cmd arrived. It does things well.');
   });
@@ -58,6 +59,15 @@ describe('siteUpdates', () => {
       expect(update.title.length).toBeGreaterThan(0);
       expect(typeof update.component).toBe('function');
       expect(Array.isArray(update.links)).toBe(true);
+      expect(Array.isArray(update.tags)).toBe(true);
+    }
+  });
+
+  test('tags are lowercased slugs', () => {
+    for (const update of siteUpdates) {
+      for (const tag of update.tags) {
+        expect(tag).toMatch(/^[a-z][a-z0-9-]*$/);
+      }
     }
   });
 

--- a/site/src/lib/updates.ts
+++ b/site/src/lib/updates.ts
@@ -14,6 +14,9 @@ export type SiteUpdateMeta = {
   // Markdown source: backticks for inline code, asterisks for emphasis.
   title: string;
   links: SiteUpdateLink[];
+  // Lowercased tag slugs. `interesting` is the default front-page filter; the
+  // rest are free-form axes consumed by the boolean filter expression.
+  tags: string[];
 };
 
 export type SiteUpdate = SiteUpdateMeta & {
@@ -23,7 +26,9 @@ export type SiteUpdate = SiteUpdateMeta & {
 
 type SvxModule = {
   default: Component;
-  metadata: SiteUpdateMeta;
+  // The raw frontmatter shape. `tags` is optional here because mdsvex does
+  // not validate; the loader below normalizes to a required `string[]`.
+  metadata: Omit<SiteUpdateMeta, 'tags'> & { tags?: string[] };
 };
 
 const modules = import.meta.glob<SvxModule>('./updates/*.svx', { eager: true });
@@ -36,6 +41,7 @@ const rawModules = import.meta.glob<string>('./updates/*.svx', {
 export const siteUpdates: SiteUpdate[] = Object.entries(modules)
   .map(([path, mod]) => ({
     ...mod.metadata,
+    tags: (mod.metadata.tags ?? []).map((tag) => tag.toLowerCase()),
     component: mod.default,
     rawBody: stripFrontmatter(rawModules[path] ?? '')
   }))

--- a/site/src/lib/updates/agents-md-fragments.svx
+++ b/site/src/lib/updates/agents-md-fragments.svx
@@ -2,6 +2,7 @@
 id: agents-md-fragments
 postedAt: 2026-05-25T23:51:39-07:00
 title: "`AGENTS.md` is generated from reusable fragments"
+tags: [interesting, nix, agents, cli]
 links:
   - label: agents-md helper
     href: https://github.com/indexable-inc/index/blob/main/lib/agents-md.nix

--- a/site/src/lib/updates/cargo-unit-per-test.svx
+++ b/site/src/lib/updates/cargo-unit-per-test.svx
@@ -2,6 +2,7 @@
 id: cargo-unit-per-test
 postedAt: 2026-05-26T00:19:45-07:00
 title: "cargo-unit caches Rust tests per `#[test]`"
+tags: [nix, rust, testing, builder]
 links:
   - label: nix-cargo-unit
     href: https://github.com/indexable-inc/index/tree/main/packages/nix-cargo-unit

--- a/site/src/lib/updates/ix-dev-diagnose.svx
+++ b/site/src/lib/updates/ix-dev-diagnose.svx
@@ -2,6 +2,7 @@
 id: ix-dev-diagnose
 postedAt: 2026-05-25T16:42:25-07:00
 title: "`ix-dev-diagnose` probes ix.dev reachability"
+tags: [nix, cli, diagnostics]
 links:
   - label: diagnostic package
     href: https://github.com/indexable-inc/index/tree/main/packages/ix-dev-diagnose

--- a/site/src/lib/updates/nix-run-site.svx
+++ b/site/src/lib/updates/nix-run-site.svx
@@ -2,6 +2,7 @@
 id: nix-run-site
 postedAt: 2026-05-26T01:22:16-07:00
 title: "`nix run .#site` previews the page locally"
+tags: [nix, site, cli]
 links:
   - label: per-system wiring
     href: https://github.com/indexable-inc/index/blob/main/lib/per-system.nix

--- a/site/src/lib/updates/observability-stack.svx
+++ b/site/src/lib/updates/observability-stack.svx
@@ -2,6 +2,7 @@
 id: observability-stack
 postedAt: 2026-05-23T00:25:53-07:00
 title: Self-hosted OpenTelemetry stack module
+tags: [nix, module, observability]
 links:
   - label: observability module
     href: https://github.com/indexable-inc/index/tree/main/modules/services/observability

--- a/site/src/lib/updates/run-recorder.svx
+++ b/site/src/lib/updates/run-recorder.svx
@@ -2,6 +2,7 @@
 id: run-recorder
 postedAt: 2026-05-25T15:28:13-07:00
 title: "`nix run .#run` records command sessions"
+tags: [interesting, nix, cli]
 links:
   - label: run package
     href: https://github.com/indexable-inc/index/tree/main/packages/run

--- a/site/src/lib/updates/zig-package-builder.svx
+++ b/site/src/lib/updates/zig-package-builder.svx
@@ -2,6 +2,7 @@
 id: zig-package-builder
 postedAt: 2026-05-26T02:27:07-07:00
 title: "`ix.buildZigPackage` builds `build.zig.zon` projects with a cached package store"
+tags: [nix, zig, builder]
 links:
   - label: build-zig-package
     href: https://github.com/indexable-inc/index/blob/main/lib/build-zig-package.nix

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import FilterBar from '$lib/FilterBar.svelte';
   import UpdateEntry from '$lib/UpdateEntry.svelte';
+  import { parseFilter } from '$lib/filter-expression';
   import { siteIntro, siteUpdates } from '$lib/updates';
 
   // The prerendered HTML uses UTC so every visitor's pre-hydration view
@@ -10,6 +12,16 @@
   onMount(() => {
     timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   });
+
+  // Default filter narrows to author-flagged headline items. Visitors can
+  // clear the input to see the full log or write any boolean expression.
+  let filter = $state('interesting');
+
+  const parsed = $derived(parseFilter(filter));
+  const filtered = $derived(
+    parsed.ok ? siteUpdates.filter((u) => parsed.matches(u.tags)) : siteUpdates
+  );
+  const error = $derived(parsed.ok ? undefined : parsed.error);
 </script>
 
 <svelte:head>
@@ -22,8 +34,18 @@
   <p>{siteIntro}</p>
 </section>
 
+<FilterBar
+  value={filter}
+  onChange={(next: string) => {
+    filter = next;
+  }}
+  matchCount={filtered.length}
+  totalCount={siteUpdates.length}
+  {error}
+/>
+
 <ol class="log">
-  {#each siteUpdates as update (update.id)}
+  {#each filtered as update (update.id)}
     <li>
       <UpdateEntry {update} {timeZone} />
     </li>


### PR DESCRIPTION
Adds tags to every site update via YAML frontmatter and a small boolean filter on the front page so the landing page can lead with the headline items.

## Filter expression

Flecs-style precedence: `!` > `&` > `|`. Adjacent terms get an implicit AND. Parens group.

```
interesting              # default — narrows to author-flagged headline items
nix & cli                # both tags
nix (rust | zig)         # implicit AND with a group
!testing                 # absent
nix & rust | zig         # parses as (nix & rust) | zig
```

The input is rendered with syntax highlighting (operators, parens, unknown chars get a wavy underline) by overlaying coloured spans behind a transparent input. Match count (`X / Y`) and parse errors render next to / under the field.

## Frontmatter

Each `.svx` now carries `tags: [...]`. Only `run-recorder` (`nix run .#run`) and `agents-md-fragments` carry `interesting`; the rest get topical tags (`nix`, `cli`, `rust`, `zig`, `module`, `observability`, etc.).

## Component shape

`FilterBar` is a controlled component (`value` + `onChange`) instead of using `$bindable()`. Keeps every prop `const` under the existing strict-typed lint config — no rule disables.

## Tests

`filter-expression.test.ts` covers precedence, parens, implicit AND, NOT, the example from the request, and three error paths. `updates.test.ts` gains a check that every entry's tags are lowercase slugs.
