### PR TITLE
cargo-unit: route repo crates through shared workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "toml",
  "url",
 ]

--- a/lib/cargo-unit.nix
+++ b/lib/cargo-unit.nix
@@ -331,6 +331,86 @@ let
     workspace.binaries.${binary} or workspace.default;
 
   /**
+    Pick a binary out of a pre-built `buildWorkspace` plus its test
+    derivations, ready for `passthru.tests` consumption.
+
+    `testTargets` and `doctestTargets` default to every generated target owned
+    by `packageName`. Each target becomes one `<target>-all` test; doctests use
+    `doctest-<target>-all` names. Set `includeTestCases` only for callers that
+    deliberately want one flake-checkable derivation per discovered test case.
+
+    Use this when the caller has one shared workspace (`ix.rustWorkspace.units`)
+    so all repo-owned crates ride the same unit graph. Use `buildBinary` when
+    a crate needs its own workspace (different policy, fetched source, etc).
+  */
+  selectBinaryWithTests =
+    workspace:
+    {
+      binary,
+      packageName ? binary,
+      testTargets ? null,
+      doctestTargets ? null,
+      includeTestCases ? false,
+      meta ? { },
+      passthru ? { },
+    }:
+    let
+      binaryDrv = workspace.binaries.${binary} or workspace.default;
+      uncheckedBinary = binaryDrv.passthru.unchecked or binaryDrv;
+      namesForPackage =
+        attrName: fallback:
+        if builtins.hasAttr attrName workspace && builtins.hasAttr packageName workspace.${attrName} then
+          workspace.${attrName}.${packageName}
+        else
+          fallback;
+      selectedTestTargets =
+        if testTargets == null then namesForPackage "testTargetNamesByPackage" [ binary ] else testTargets;
+      selectedDoctestTargets =
+        if doctestTargets == null then
+          namesForPackage "doctestTargetNamesByPackage" [ ]
+        else
+          doctestTargets;
+      flattenAllTargets =
+        prefix: targetNames: targets:
+        lib.mapAttrs' (targetName: target: lib.nameValuePair "${prefix}${targetName}-all" target.all) (
+          lib.getAttrs (builtins.filter (name: targets ? ${name}) targetNames) targets
+        );
+      flattenCaseTargets =
+        prefix: targetNames: targets:
+        lib.concatMapAttrs (
+          targetName: target:
+          lib.mapAttrs' (
+            case: drv:
+            lib.nameValuePair "${prefix}${targetName}-${lib.replaceStrings [ "::" ] [ "-" ] case}" drv
+          ) (target.cases or { })
+        ) (lib.getAttrs (builtins.filter (name: targets ? ${name}) targetNames) targets);
+      testCases =
+        flattenCaseTargets "" selectedTestTargets (workspace.tests or { })
+        // flattenCaseTargets "doctest-" selectedDoctestTargets (workspace.doctests or { });
+      tests = {
+        package = uncheckedBinary;
+      }
+      // flattenAllTargets "" selectedTestTargets (workspace.tests or { })
+      // flattenAllTargets "doctest-" selectedDoctestTargets (workspace.doctests or { })
+      // lib.optionalAttrs includeTestCases testCases;
+    in
+    binaryDrv
+    // {
+      meta = (binaryDrv.meta or { }) // meta;
+      passthru =
+        (binaryDrv.passthru or { })
+        // passthru
+        // {
+          tests =
+            (binaryDrv.passthru.tests or { })
+            // (binaryDrv.passthru.policyChecks or { })
+            // (passthru.tests or { })
+            // tests;
+          inherit (workspace) policy;
+        };
+    };
+
+  /**
     Select several binary targets from one workspace unit graph.
 
     Use `cargoTargets` on `buildWorkspace` when the same import should expose
@@ -352,6 +432,7 @@ in
     buildBinary
     buildBinaries
     buildWorkspace
+    selectBinaryWithTests
     auditCargoLock
     generateUnitGraph
     generateUnitsNix

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -256,21 +256,34 @@ let
       rustToolchain = rustNightlyToolchainFor pkgs;
       writePythonApplication = writePythonApplication pkgs;
     };
-  # Build a repo-owned Rust tool whose default.nix calls `ix.buildRustPackage`.
+  # Build a repo-owned Rust tool while keeping nix-cargo-unit itself on the
+  # pre-cargo-unit bootstrap path.
   # Returns the policy-unchecked variant when present, so generators that
   # only need the binary do not drag the policy-check graph into their closure.
   buildIxRustTool =
     hostPkgs: path:
     let
+      usesCargoUnit = builtins.toString path != builtins.toString paths.packages.nixCargoUnit;
+      hostRustWorkspace = rustWorkspaceFor hostPkgs;
       checked = hostPkgs.callPackage path {
         pkgs = hostPkgs;
         ix = {
           buildRustPackage = pkgs: (rustFor pkgs).buildPackage;
-          inherit rustWorkspace;
+          rustWorkspace = hostRustWorkspace;
+        }
+        // lib.optionalAttrs usesCargoUnit {
+          cargoUnit = cargoUnitFor hostPkgs;
         };
       };
+      unchecked = checked.passthru.unchecked or null;
     in
-    checked.passthru.unchecked or checked;
+    if unchecked == null then
+      checked
+    else
+      unchecked
+      // {
+        meta = (unchecked.meta or { }) // (checked.meta or { });
+      };
   cargoUnitFor =
     pkgs:
     import ./cargo-unit.nix {
@@ -631,10 +644,10 @@ let
         # ixSpecialArgs bundle is bound to.
         cargoUnit = cargoUnitFor pkgs;
         goUnit = goUnitFor pkgs;
+        rustWorkspace = rustWorkspaceFor pkgs;
       };
       basePackages = {
         dag-runner = pkgs.callPackage paths.packages.dagRunner {
-          inherit pkgs;
           ix = ixForPackages;
         };
         room =
@@ -668,14 +681,12 @@ let
           ix = ixForPackages;
         };
         ix-dev-diagnose = pkgs.callPackage paths.packages.ixDevDiagnose {
-          inherit pkgs;
           ix = ixForPackages;
         };
         minestom.helloServerJar = pkgs.callPackage paths.packages.minestom.servers.hello {
           ix = ixForPackages;
         };
         minecraft-nbt = pkgs.callPackage paths.packages.minecraft.nbt {
-          inherit pkgs;
           ix = ixForPackages;
         };
         llm-clippy = llmClippyFor pkgs;
@@ -709,7 +720,6 @@ let
           ix = ixForPackages;
         };
         minecraft-sync-managed = pkgs.callPackage paths.packages.minecraft.syncManaged {
-          inherit pkgs;
           ix = ixForPackages;
         };
         nix-cargo-unit = pkgs.callPackage paths.packages.nixCargoUnit {
@@ -717,7 +727,6 @@ let
           ix = ixForPackages;
         };
         oci-image-builder = pkgs.callPackage paths.packages.ociImageBuilder {
-          inherit pkgs;
           ix = ixForPackages;
         };
         run = pkgs.callPackage paths.packages.run {
@@ -737,19 +746,20 @@ let
     basePackages // cliPackages;
 
   /**
-    Shared Rust workspace source for repo-owned crates.
+    Shared Rust workspace source and unit graph for repo-owned crates.
 
     The root Cargo.toml and Cargo.lock are the source of truth for IDEs,
     dependency versions, and package builds. The filtered source keeps the Nix
     closure to Rust workspace inputs instead of the full repository.
+
+    `rustWorkspaceFor pkgs` returns `{ root; src; cargoLock; units; }` for the
+    caller's package set. The default `rustWorkspace` uses the repo's
+    `x86_64-linux` package set for image and module evaluation.
   */
-  rustWorkspace =
+  rustWorkspaceFor =
+    workspacePkgs:
     let
       inherit (paths) root;
-    in
-    {
-      inherit root;
-      cargoLock = root + "/Cargo.lock";
       src = lib.fileset.toSource {
         inherit root;
         fileset = lib.fileset.intersection (lib.fileset.gitTracked root) (
@@ -769,7 +779,50 @@ let
           ]
         );
       };
+      cargoLock = root + "/Cargo.lock";
+      # One workspace-wide unit graph for every repo-owned Rust crate. Each
+      # crate's `default.nix` picks its binary and test targets out of this
+      # via `ix.cargoUnit.selectBinaryWithTests`, so the unit graph + vendor
+      # closure get generated once instead of per crate. `nix-cargo-unit`
+      # itself stays on the bootstrap path (it's what builds this graph).
+      units = (cargoUnitFor workspacePkgs).buildWorkspace {
+        pname = "ix-rust-workspace";
+        inherit src;
+        cargoLock.lockFile = cargoLock;
+        workspaceRoot = root;
+        cargoArgs = [ "--workspace" ];
+        cargoTargets = [
+          [ "--workspace" ]
+          [
+            "--workspace"
+            "--tests"
+          ]
+        ];
+        cargoTargetNames = [
+          "build"
+          "test"
+        ];
+        # Every policy check runs once across the whole workspace: a
+        # regression in any single crate fails the workspace selection.
+        # `cargoUnit.buildWorkspace`'s defaults already enable each check;
+        # this block makes the contract explicit at the workspace root.
+        policy = {
+          denyUnusedCrateDependencies = true;
+          cargoAudit.enable = true;
+          cargoMachete.enable = true;
+          clippy.enable = true;
+        };
+      };
+    in
+    {
+      inherit
+        root
+        src
+        cargoLock
+        units
+        ;
     };
+  rustWorkspace = rustWorkspaceFor pkgs;
 
   /**
     Cross-cutting helpers handed to every module through `specialArgs.ix`.
@@ -796,6 +849,7 @@ let
       mkMinecraftSyncManaged
       relativePath
       rustWorkspace
+      rustWorkspaceFor
       secrets
       systemdHardening
       writeNushellApplication
@@ -1068,6 +1122,7 @@ let
       packageSetFor
       relativePath
       rustWorkspace
+      rustWorkspaceFor
       secrets
       systemdHardening
       uvLockFor

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -244,18 +244,33 @@ let
   rustPackageTests =
     let
       rustPackages = lib.getAttrs [
+        "dag-runner"
+        "ix-dev-diagnose"
+        "loop"
+        "mcp"
         "minecraft-nbt"
         "minecraft-sync-managed"
         "nix-cargo-unit"
         "oci-image-builder"
+        "room"
       ] repoPackages;
+      moduleRustPackages = {
+        resource-monitor-stats-writer =
+          let
+            cargoUnit = ix.cargoUnitFor pkgs;
+            rustWorkspace = ix.rustWorkspaceFor pkgs;
+          in
+          cargoUnit.selectBinaryWithTests rustWorkspace.units {
+            binary = "resource-monitor-stats-writer";
+          };
+      };
     in
     lib.concatMapAttrs (
       packageName: package:
       lib.mapAttrs' (testName: test: lib.nameValuePair "rust-${packageName}-${testName}" test) (
         package.passthru.tests or { }
       )
-    ) rustPackages;
+    ) (rustPackages // moduleRustPackages);
 
   lintSource = fs.toSource {
     inherit (paths) root;

--- a/lib/rust.nix
+++ b/lib/rust.nix
@@ -496,10 +496,11 @@ let
     let
       args = commonArgs rawArgs;
       inherit (args.policy) cargoAudit;
+      lockFile = cargoLockFile args.cargoLock;
       auditFlags = [
         "audit"
         "--file"
-        (builtins.toString (cargoLockFile args.cargoLock))
+        "Cargo.lock"
         "--db"
         (builtins.toString cargoAudit.db)
         "--no-fetch"
@@ -517,10 +518,16 @@ let
     pkgs.runCommand "${args.pname}-cargo-audit"
       {
         nativeBuildInputs = [ pkgs.cargo-audit ];
+        # Stage the lockfile through a derivation input so its store path
+        # is realized in every builder's sandbox, not just the one that
+        # evaluated the expression.
+        inherit lockFile;
       }
       ''
         export CARGO_HOME="$TMPDIR/cargo-home"
         mkdir -p "$CARGO_HOME"
+        cp "$lockFile" "$TMPDIR/Cargo.lock"
+        cd "$TMPDIR"
         cargo-audit ${lib.escapeShellArgs auditFlags}
         ${mkdirOut}
       '';

--- a/modules/services/resource-monitor/default.nix
+++ b/modules/services/resource-monitor/default.nix
@@ -91,16 +91,8 @@ let
     preBuild = "cp ${pkgs.writeText "resource-monitor-vm-config.json" (builtins.toJSON metricConfig)} src/lib/vm-config.json";
   };
 
-  statsWriter = ix.buildRustPackage pkgs {
-    pname = "resource-monitor-stats-writer";
-    version = "0.1.0";
-    src = ix.rustWorkspace.src;
-    cargoLock.lockFile = ix.rustWorkspace.cargoLock;
-    buildAndTestSubdir = "modules/services/resource-monitor/stats-writer";
-    cargoArgs = [
-      "-p"
-      "resource-monitor-stats-writer"
-    ];
+  statsWriter = ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+    binary = "resource-monitor-stats-writer";
     meta.mainProgram = "resource-monitor-stats-writer";
   };
 

--- a/modules/services/resource-monitor/stats-writer/src/main.rs
+++ b/modules/services/resource-monitor/stats-writer/src/main.rs
@@ -1,3 +1,14 @@
+// Numeric arithmetic here is metric/billing math (bytes, seconds, USD) where
+// f64 precision and i64↔u32 date conversions are intentional and bounded by
+// domain. Allow the pedantic cast lints at the crate level rather than
+// peppering call sites.
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_wrap,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+
 use std::env;
 use std::error::Error;
 use std::fs;
@@ -31,7 +42,8 @@ struct CpuSample {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let config = parse_args(env::args().skip(1).collect())?;
+    let args: Vec<String> = env::args().skip(1).collect();
+    let config = parse_args(&args)?;
     fs::create_dir_all(&config.output_dir)?;
 
     loop {
@@ -40,7 +52,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-fn parse_args(args: Vec<String>) -> Result<Config, Box<dyn Error>> {
+fn parse_args(args: &[String]) -> Result<Config, Box<dyn Error>> {
     let mut config = Config {
         output_dir: PathBuf::from("/run/resource-monitor"),
         df: PathBuf::from("df"),
@@ -70,13 +82,13 @@ fn parse_args(args: Vec<String>) -> Result<Config, Box<dyn Error>> {
             "--total-memory-gib" => config.total_memory_gib = parse_positive(value, flag)?,
             "--total-storage-tib" => config.total_storage_tib = parse_positive(value, flag)?,
             "--cpu-usd-per-vcpu-month" => {
-                config.cpu_usd_per_vcpu_month = parse_positive(value, flag)?
+                config.cpu_usd_per_vcpu_month = parse_positive(value, flag)?;
             }
             "--memory-usd-per-gib-hour" => {
-                config.memory_usd_per_gib_hour = parse_positive(value, flag)?
+                config.memory_usd_per_gib_hour = parse_positive(value, flag)?;
             }
             "--storage-usd-per-tib-hour" => {
-                config.storage_usd_per_tib_hour = parse_positive(value, flag)?
+                config.storage_usd_per_tib_hour = parse_positive(value, flag)?;
             }
             "--margin-multiplier" => config.margin_multiplier = parse_positive(value, flag)?,
             _ => return Err(format!("unknown argument: {flag}").into()),
@@ -242,7 +254,7 @@ fn iso_timestamp(time: SystemTime) -> Result<String, Box<dyn Error>> {
     ))
 }
 
-fn civil_from_days(days_since_epoch: i64) -> (i64, u32, u32) {
+const fn civil_from_days(days_since_epoch: i64) -> (i64, u32, u32) {
     let z = days_since_epoch + 719_468;
     let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
     let day_of_era = z - era * 146_097;
@@ -253,7 +265,7 @@ fn civil_from_days(days_since_epoch: i64) -> (i64, u32, u32) {
     let month_prime = (5 * day_of_year + 2) / 153;
     let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
     let month = month_prime + if month_prime < 10 { 3 } else { -9 };
-    let year = year + if month <= 2 { 1 } else { 0 };
+    let year = year + (month <= 2) as i64;
 
     (year, month as u32, day as u32)
 }

--- a/packages/dag-runner/default.nix
+++ b/packages/dag-runner/default.nix
@@ -1,19 +1,6 @@
-{
-  ix,
-  pkgs,
-}:
+{ ix, ... }:
 
-ix.buildRustPackage pkgs {
-  pname = "dag-runner";
-  version = "0.1.0";
-
-  src = ix.rustWorkspace.src;
-  cargoLock.lockFile = ix.rustWorkspace.cargoLock;
-  buildAndTestSubdir = "packages/dag-runner";
-  cargoArgs = [
-    "-p"
-    "dag-runner"
-  ];
-
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "dag-runner";
   meta.mainProgram = "dag-runner";
 }

--- a/packages/ix-dev-diagnose/default.nix
+++ b/packages/ix-dev-diagnose/default.nix
@@ -1,19 +1,6 @@
-{
-  ix,
-  pkgs,
-}:
+{ ix, ... }:
 
-ix.buildRustPackage pkgs {
-  pname = "ix-dev-diagnose";
-  version = "0.1.0";
-
-  src = ix.rustWorkspace.src;
-  cargoLock.lockFile = ix.rustWorkspace.cargoLock;
-  buildAndTestSubdir = "packages/ix-dev-diagnose";
-  cargoArgs = [
-    "-p"
-    "ix-dev-diagnose"
-  ];
-
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "ix-dev-diagnose";
   meta.mainProgram = "ix-dev-diagnose";
 }

--- a/packages/loop/default.nix
+++ b/packages/loop/default.nix
@@ -6,28 +6,16 @@
 }:
 
 let
-  loop.binary = ix.cargoUnit.buildBinary {
-    pname = "loop";
-    src = ix.rustWorkspace.src;
-    workspaceRoot = ix.rustWorkspace.root;
-    cargoLock = ix.rustWorkspace.cargoLock;
-    cargoArgs = [
-      "-p"
-      "loop"
-    ];
+  unwrapped = ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
     binary = "loop";
-    policy = {
-      denyUnusedCrateDependencies = false;
-      cargoAudit.enable = false;
-      cargoMachete.enable = false;
-      clippy.enable = false;
-    };
   };
 in
 pkgs.runCommand "loop"
   {
     nativeBuildInputs = [ pkgs.makeWrapper ];
-    passthru.unwrapped = loop.binary;
+    passthru = unwrapped.passthru // {
+      inherit unwrapped;
+    };
     meta = {
       description = "Run agent loops and health checks with a Loro-backed web UI";
       mainProgram = "loop";
@@ -36,6 +24,6 @@ pkgs.runCommand "loop"
   }
   ''
     mkdir -p "$out/bin"
-    makeWrapper "${loop.binary}/bin/loop" "$out/bin/loop" \
+    makeWrapper "${unwrapped}/bin/loop" "$out/bin/loop" \
       --set LOOP_VIEWER_DIR "${viewer}/share/loop-viewer"
   ''

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -4,24 +4,23 @@
   pkgs ? ix.pkgs,
 }:
 
-ix.buildRustPackage pkgs {
-  pname = "mcp";
-  version = "0.1.0";
-
-  src = ix.rustWorkspace.src;
-  cargoLock.lockFile = ix.rustWorkspace.cargoLock;
-  buildAndTestSubdir = "packages/mcp";
-  cargoArgs = [
-    "-p"
-    "ix-mcp"
-  ];
-
-  nativeBuildInputs = [ pkgs.makeWrapper ];
-
-  postInstall = ''
-    wrapProgram "$out/bin/ix-mcp" \
+let
+  unwrapped = ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+    binary = "ix-mcp";
+  };
+in
+pkgs.runCommand "ix-mcp"
+  {
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    passthru = unwrapped.passthru // {
+      inherit unwrapped;
+    };
+    meta = (unwrapped.meta or { }) // {
+      mainProgram = "ix-mcp";
+    };
+  }
+  ''
+    mkdir -p $out/bin
+    makeWrapper ${unwrapped}/bin/ix-mcp $out/bin/ix-mcp \
       --set IX_MCP_DEFAULT_PYTHON ${lib.escapeShellArg (lib.getExe pkgs.python3)}
-  '';
-
-  meta.mainProgram = "ix-mcp";
-}
+  ''

--- a/packages/minecraft/nbt/default.nix
+++ b/packages/minecraft/nbt/default.nix
@@ -1,19 +1,6 @@
-{
-  ix,
-  pkgs,
-}:
+{ ix, ... }:
 
-ix.buildRustPackage pkgs {
-  pname = "minecraft-nbt";
-  version = "0.1.0";
-
-  src = ix.rustWorkspace.src;
-  cargoLock.lockFile = ix.rustWorkspace.cargoLock;
-  buildAndTestSubdir = "packages/minecraft/nbt";
-  cargoArgs = [
-    "-p"
-    "minecraft-nbt"
-  ];
-
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "minecraft-nbt";
   meta.mainProgram = "minecraft-nbt";
 }

--- a/packages/minecraft/sync-managed/default.nix
+++ b/packages/minecraft/sync-managed/default.nix
@@ -1,19 +1,6 @@
-{
-  ix,
-  pkgs,
-}:
+{ ix, ... }:
 
-ix.buildRustPackage pkgs {
-  pname = "minecraft-sync-managed";
-  version = "0.1.0";
-
-  src = ix.rustWorkspace.src;
-  cargoLock.lockFile = ix.rustWorkspace.cargoLock;
-  buildAndTestSubdir = "packages/minecraft/sync-managed";
-  cargoArgs = [
-    "-p"
-    "minecraft-sync-managed"
-  ];
-
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "minecraft-sync-managed";
   meta.mainProgram = "minecraft-sync-managed";
 }

--- a/packages/nix-cargo-unit/Cargo.toml
+++ b/packages/nix-cargo-unit/Cargo.toml
@@ -15,3 +15,6 @@ serde_json.workspace = true
 sha2.workspace = true
 toml = { workspace = true, default-features = false, features = ["parse", "serde"] }
 url = { workspace = true, default-features = false }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -633,6 +633,44 @@ fn render_build_inputs(
     }
 }
 
+// Cargo sets `CARGO_BIN_EXE_<name>` for integration tests and benchmarks.
+// The unit graph exposes same-package build-mode bin targets as dependencies;
+// test-harness bin units and integration-test binaries are runnable outputs too,
+// but they are not the executable Cargo points this variable at.
+fn same_package_bins(graph: &UnitGraph, index: usize) -> Vec<(String, usize)> {
+    let unit = &graph.units[index];
+    if !needs_bin_exe_env(unit) {
+        return Vec::new();
+    }
+    graph
+        .units
+        .iter()
+        .enumerate()
+        .filter_map(|(i, other)| {
+            if i == index || !is_bin_exe_candidate(unit, other) {
+                return None;
+            }
+            Some((other.target.name.clone(), i))
+        })
+        .collect()
+}
+
+fn needs_bin_exe_env(unit: &Unit) -> bool {
+    matches!(unit.mode, UnitMode::Test)
+        && unit
+            .target
+            .kind
+            .iter()
+            .any(|kind| matches!(kind.as_str(), "test" | "bench"))
+}
+
+fn is_bin_exe_candidate(unit: &Unit, candidate: &Unit) -> bool {
+    candidate.pkg_id == unit.pkg_id
+        && candidate.mode == UnitMode::Build
+        && candidate.target.has_kind("bin")
+        && candidate.platform == unit.platform
+}
+
 fn render_rustc_build_phase(
     graph: &UnitGraph,
     options: &RenderOptions,
@@ -645,6 +683,7 @@ fn render_rustc_build_phase(
 
     script.push_str("mkdir -p build\n");
     script.push_str("build_script_flags=()\n");
+    script.push_str("rustc_env=()\n");
     script.push_str("rustc_args=()\n\n");
     script.push_str(&cargo_package_exports(unit)?);
     writeln!(
@@ -652,6 +691,7 @@ fn render_rustc_build_phase(
         "export CARGO_MANIFEST_DIR={}",
         shell::double_quote(&source_path_expr(source, &crate_root_for_unit(unit))?)
     )?;
+    append_bin_exe_env(&mut script, graph, prepared, index)?;
 
     if let Some(run_index) = unit_build_script_run(graph, index) {
         let run_ref = format!("${{units.{}}}", nix_attr(&prepared.names[run_index]));
@@ -719,11 +759,43 @@ fn render_rustc_build_phase(
     }
 
     script.push_str("rustc_args+=( \"''${build_script_flags[@]}\" )\n");
-    if collects_unused_crate_dependencies(unit, options) {
+    append_rustc_invocation(
+        &mut script,
+        collects_unused_crate_dependencies(unit, options),
+    );
+
+    Ok(script)
+}
+
+fn append_bin_exe_env(
+    script: &mut String,
+    graph: &UnitGraph,
+    prepared: &PreparedGraph,
+    index: usize,
+) -> Result<()> {
+    for (bin_name, bin_index) in same_package_bins(graph, index) {
+        let env_name = format!("CARGO_BIN_EXE_{bin_name}");
+        writeln!(
+            script,
+            "rustc_env+=( {} )",
+            shell::quote(&format!(
+                "{env_name}=${{units.{}}}/bin/{bin_name}",
+                nix_attr(&prepared.names[bin_index])
+            ))
+        )?;
+    }
+
+    Ok(())
+}
+
+fn append_rustc_invocation(script: &mut String, collect_unused_deps: bool) {
+    if collect_unused_deps {
         script.push_str("rustc_diagnostics=build/rustc-diagnostics.jsonl\n");
         script.push_str("set +e\n");
         script.push_str("set -x\n");
-        script.push_str("rustc \"''${rustc_args[@]}\" 2> \"$rustc_diagnostics\"\n");
+        script.push_str(
+            "env \"''${rustc_env[@]}\" rustc \"''${rustc_args[@]}\" 2> \"$rustc_diagnostics\"\n",
+        );
         script.push_str("rustc_status=$?\n");
         script.push_str("set +x\n");
         script.push_str("set -e\n");
@@ -737,10 +809,8 @@ fn render_rustc_build_phase(
         );
     } else {
         script.push_str("set -x\n");
-        script.push_str("rustc \"''${rustc_args[@]}\"\n");
+        script.push_str("env \"''${rustc_env[@]}\" rustc \"''${rustc_args[@]}\"\n");
     }
-
-    Ok(script)
 }
 
 fn collects_unused_crate_dependencies(unit: &Unit, options: &RenderOptions) -> bool {
@@ -1263,7 +1333,14 @@ fn cargo_package_exports(unit: &Unit) -> Result<String> {
         .map(cargo_manifest_package_metadata)
         .unwrap_or_default();
 
+    // CARGO_CRATE_NAME is the rust identifier rustc receives via `--crate-name`.
+    // Cargo normalizes the target's name (`-` → `_`); crates like rmcp read this
+    // via `env!()` at compile time.
+    let crate_name = unit.target.name.replace('-', "_");
+    let is_bin = unit.target.kind.iter().any(|kind| kind == "bin");
+
     for (name, value) in [
+        ("CARGO_CRATE_NAME", crate_name.as_str()),
         ("CARGO_PKG_NAME", package_name.as_ref()),
         ("CARGO_PKG_VERSION", version),
         ("CARGO_PKG_VERSION_MAJOR", major),
@@ -1279,6 +1356,14 @@ fn cargo_package_exports(unit: &Unit) -> Result<String> {
         ("CARGO_PKG_RUST_VERSION", metadata.rust_version.as_str()),
     ] {
         let _ = writeln!(script, "export {name}={}", shell_env_value(value));
+    }
+
+    if is_bin {
+        let _ = writeln!(
+            script,
+            "export CARGO_BIN_NAME={}",
+            shell_env_value(&unit.target.name)
+        );
     }
 
     Ok(script)
@@ -2432,11 +2517,24 @@ fn render_doctest_target_entries(graph: &UnitGraph, prepared: &PreparedGraph) ->
         if by_key.contains_key(key) {
             continue;
         }
+        let unit = &graph.units[index];
+        let source = prepared
+            .source_entry(index)
+            .expect("prepared graph has source entries for every doctest target");
+        let package_root = if source.relative.is_empty() {
+            "."
+        } else {
+            source.relative.as_str()
+        };
         by_key.insert(
             key.clone(),
             format!(
-                "{{ name = {}; listCommand = {}; allCommand = {}; runCommand = {}; }}",
+                "{{ name = {}; packageName = {}; packageVersion = {}; packageRoot = {}; sourceStoreName = {}; listCommand = {}; allCommand = {}; runCommand = {}; }}",
                 nix_attr(key),
+                nix_attr(&unit.package_name()),
+                nix_attr(unit.package_version()),
+                nix_attr(package_root),
+                nix_attr(&source.name),
                 nix_indented_string(&render_doctest_command(
                     graph,
                     prepared,
@@ -2678,6 +2776,9 @@ mod tests {
         assert!(rendered.contains("RUST_TEST_THREADS"));
         assert!(rendered.contains("mkTestCases ="));
         assert!(rendered.contains("testTargets = ["));
+        assert!(rendered.contains("testTargetNamesByPackage ="));
+        assert!(rendered.contains("pkgs.lib.groupBy (target: target.packageName) testTargets"));
+        assert!(rendered.contains("doctestTargetNamesByPackage ="));
         assert!(rendered.contains("{ name = \"hello\"; binary ="));
         assert!(!rendered.contains("units.\\\""));
         assert!(rendered.contains("packageName = \"hello\";"));
@@ -2697,6 +2798,107 @@ mod tests {
         assert!(rendered.contains("source-roots.tsv"));
         assert!(rendered.contains("testManifestDrv ="));
         assert!(rendered.contains("cargo-unit-test-manifest"));
+    }
+
+    #[test]
+    fn bin_exe_env_uses_build_bins_for_integration_tests() {
+        let workspace = tempfile::tempdir().unwrap();
+        fs::create_dir_all(workspace.path().join("src")).unwrap();
+        fs::create_dir_all(workspace.path().join("tests")).unwrap();
+        fs::write(
+            workspace.path().join("Cargo.toml"),
+            r#"[package]
+name = "dag-runner"
+version = "0.1.0"
+"#,
+        )
+        .unwrap();
+        let main_rs = workspace.path().join("src/main.rs");
+        let integration_rs = workspace.path().join("tests/integration.rs");
+        fs::write(&main_rs, "fn main() {}\n").unwrap();
+        fs::write(&integration_rs, "#[test]\nfn runs() {}\n").unwrap();
+        let main_rs = main_rs.display().to_string();
+        let integration_rs = integration_rs.display().to_string();
+        let pkg_id = format!(
+            "path+file://{}#dag-runner@0.1.0",
+            workspace.path().display()
+        );
+
+        let graph: UnitGraph = serde_json::from_value(serde_json::json!({
+          "version": 1,
+          "units": [
+            {
+              "pkg_id": pkg_id,
+              "target": {
+                "kind": ["bin"],
+                "crate_types": ["bin"],
+                "name": "dag-runner",
+                "src_path": main_rs,
+                "edition": "2024"
+              },
+              "profile": { "name": "release", "opt_level": "3" },
+              "features": [],
+              "mode": "build",
+              "dependencies": []
+            },
+            {
+              "pkg_id": pkg_id,
+              "target": {
+                "kind": ["bin"],
+                "crate_types": ["bin"],
+                "name": "dag-runner",
+                "src_path": main_rs,
+                "edition": "2024"
+              },
+              "profile": { "name": "test", "opt_level": "0" },
+              "features": [],
+              "mode": "test",
+              "dependencies": []
+            },
+            {
+              "pkg_id": pkg_id,
+              "target": {
+                "kind": ["test"],
+                "crate_types": ["bin"],
+                "name": "integration",
+                "src_path": integration_rs,
+                "edition": "2024"
+              },
+              "profile": { "name": "test", "opt_level": "0" },
+              "features": [],
+              "mode": "test",
+              "dependencies": [
+                { "index": 0, "extern_crate_name": "dag_runner" }
+              ]
+            }
+          ],
+          "roots": [0, 1, 2]
+        }))
+        .unwrap();
+
+        assert!(same_package_bins(&graph, 1).is_empty());
+        assert_eq!(
+            same_package_bins(&graph, 2),
+            vec![("dag-runner".to_string(), 0)]
+        );
+
+        let rendered = render_units_nix(
+            &graph,
+            &RenderOptions {
+                workspace_root: workspace.path().to_path_buf(),
+                vendor_root: None,
+                cargo_lock_sources: CargoLockSources::default(),
+                content_addressed: false,
+                toolchain_id: None,
+                deny_unused_crate_dependencies: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(rendered.matches("CARGO_BIN_EXE_dag-runner=").count(), 1);
+        assert!(rendered.contains("rustc_env+=( 'CARGO_BIN_EXE_dag-runner=${units."));
+        assert!(!rendered.contains("export CARGO_BIN_EXE_dag-runner"));
+        assert!(rendered.contains("env \"''${rustc_env[@]}\" rustc \"''${rustc_args[@]}\""));
     }
 
     #[test]

--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -115,9 +115,17 @@ let
   # The shared manifest derivation depends on every binary listed here.
   testTargets = [
 {{ test_target_entries }}  ];
+  testTargetNamesByPackage =
+    pkgs.lib.mapAttrs (_: targets: map (target: target.name) targets) (
+      pkgs.lib.groupBy (target: target.packageName) testTargets
+    );
 
   doctestTargets = [
 {{ doctest_target_entries }}  ];
+  doctestTargetNamesByPackage =
+    pkgs.lib.mapAttrs (_: targets: map (target: target.name) targets) (
+      pkgs.lib.groupBy (target: target.packageName) doctestTargets
+    );
 
   benchmarkTargets = [
 {{ benchmark_target_entries }}  ];
@@ -634,7 +642,13 @@ let
     };
 in
 {
-  inherit policyChecks sourceAudit units;
+  inherit
+    doctestTargetNamesByPackage
+    policyChecks
+    sourceAudit
+    testTargetNamesByPackage
+    units
+    ;
   testPlan = mkTestPlan "cargo-unit-test-plan";
   benchmarkPlan = mkBenchmarkPlan "cargo-unit-benchmark-plan";
   coverageReport = mkCoverageReport {};

--- a/packages/oci-image-builder/default.nix
+++ b/packages/oci-image-builder/default.nix
@@ -1,19 +1,6 @@
-{
-  ix,
-  pkgs,
-}:
+{ ix, ... }:
 
-ix.buildRustPackage pkgs {
-  pname = "oci-image-builder";
-  version = "0.1.0";
-
-  src = ix.rustWorkspace.src;
-  cargoLock.lockFile = ix.rustWorkspace.cargoLock;
-  buildAndTestSubdir = "packages/oci-image-builder";
-  cargoArgs = [
-    "-p"
-    "oci-image-builder"
-  ];
-
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "oci-image-builder";
   meta.mainProgram = "oci-image-builder";
 }

--- a/packages/room/default.nix
+++ b/packages/room/default.nix
@@ -6,28 +6,16 @@
 }:
 
 let
-  binary = ix.cargoUnit.buildBinary {
-    pname = "room";
-    src = ix.rustWorkspace.src;
-    workspaceRoot = ix.rustWorkspace.root;
-    cargoLock = ix.rustWorkspace.cargoLock;
-    cargoArgs = [
-      "-p"
-      "room"
-    ];
+  unwrapped = ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
     binary = "room";
-    policy = {
-      denyUnusedCrateDependencies = false;
-      cargoAudit.enable = false;
-      cargoMachete.enable = false;
-      clippy.enable = false;
-    };
   };
 in
 pkgs.runCommand "room"
   {
     nativeBuildInputs = [ pkgs.makeWrapper ];
-    passthru.unwrapped = binary;
+    passthru = unwrapped.passthru // {
+      inherit unwrapped;
+    };
     meta = {
       description = "Serve a multiplayer team room with shared presence and agent state";
       mainProgram = "room";
@@ -36,6 +24,6 @@ pkgs.runCommand "room"
   }
   ''
     mkdir -p "$out/bin"
-    makeWrapper "${binary}/bin/room" "$out/bin/room" \
+    makeWrapper "${unwrapped}/bin/room" "$out/bin/room" \
       --set ROOM_SITE_DIR "${site}/share/room-site"
   ''

--- a/packages/room/src/main.rs
+++ b/packages/room/src/main.rs
@@ -181,8 +181,8 @@ async fn apply_event(state: &AppState, event: ClientEvent) {
             room.participants
                 .entry(id.clone())
                 .and_modify(|participant| {
-                    participant.name = name.clone();
-                    participant.color = color.clone();
+                    participant.name.clone_from(&name);
+                    participant.color.clone_from(&color);
                     participant.last_seen_ms = now_ms();
                 })
                 .or_insert_with(|| Participant {
@@ -230,7 +230,7 @@ async fn record_event(state: &AppState, event: &ClientEvent) {
     let Ok(value) = serde_json::to_value(event) else {
         return;
     };
-    let mut doc = state.doc.lock().await;
+    let doc = state.doc.lock().await;
     let events = doc.get_list("events");
     if events
         .insert(
@@ -274,7 +274,7 @@ async fn shutdown_signal() {
     let terminate = std::future::pending::<()>();
 
     tokio::select! {
-        _ = ctrl_c => {},
-        _ = terminate => {},
+        () = ctrl_c => {},
+        () = terminate => {},
     }
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -613,6 +613,10 @@ let
   };
 
   cargoUnitHello = cargoUnitWorkspace.binaries.cargo-unit-hello;
+  cargoUnitSelectedHello = ix.cargoUnit.selectBinaryWithTests cargoUnitWorkspace {
+    binary = "cargo-unit-hello";
+    packageName = "cargo-unit-hello";
+  };
   cargoUnitTangoComparison = cargoUnitWorkspace.compareTangoBenchmarks {
     baseline = cargoUnitWorkspace;
     args = [
@@ -2768,6 +2772,15 @@ let
         message = "cargo-unit package outputs should be wrapped by policy checks by default";
       }
       {
+        assertion = builtins.hasAttr "cargo_unit_hello-all" cargoUnitSelectedHello.passthru.tests;
+        message = "selectBinaryWithTests should schedule package-owned test binaries";
+      }
+      {
+        assertion =
+          !(builtins.hasAttr "cargo_unit_hello-tests-returns_greeting" cargoUnitSelectedHello.passthru.tests);
+        message = "selectBinaryWithTests should not force per-case test manifests into flake checks by default";
+      }
+      {
         assertion = builtins.all (binary: builtins.hasAttr binary cargoUnitBinaries) [
           "cargo-unit-goodbye"
           "cargo-unit-hello"
@@ -2892,6 +2905,26 @@ let
       {
         assertion = repoPackages.minecraft-nbt.passthru.tests ? package;
         message = "repo Rust package builds should be exposed as flake-checkable tests";
+      }
+      {
+        assertion = repoPackages.minecraft-nbt.passthru.tests ? cargoMachete;
+        message = "repo Rust policy checks should be exposed as flake-checkable tests";
+      }
+      {
+        assertion = builtins.hasAttr "integration-all" repoPackages.dag-runner.passthru.tests;
+        message = "repo Rust package tests should include package-owned integration test targets";
+      }
+      {
+        assertion = builtins.hasAttr "minecraft_nbt-all" repoPackages.minecraft-nbt.passthru.tests;
+        message = "repo Rust package tests should include package-owned library test targets";
+      }
+      {
+        assertion = builtins.hasAttr "property-all" repoPackages.minecraft-nbt.passthru.tests;
+        message = "repo Rust package tests should include package-owned property test targets";
+      }
+      {
+        assertion = builtins.hasAttr "doctest-minecraft_nbt-all" repoPackages.minecraft-nbt.passthru.tests;
+        message = "repo Rust package tests should include package-owned doctest targets";
       }
       {
         assertion =


### PR DESCRIPTION
## Summary

- Route repo-owned Rust crates through the shared cargo-unit workspace while preserving package-owned test targets, doctests, and policy gates in flake checks.
- Fix `CARGO_BIN_EXE_<name>` generation so integration tests use the build-mode binary without creating a dag-runner/integration recursion, including dashed binary names.
- Bind Rust workspaces to the caller's `pkgs` via `rustWorkspaceFor pkgs` so non-Linux package sets do not reuse Linux units.
- Keep `selectBinaryWithTests` flake-check output to `*-all` test derivations by default; per-case expansion is now explicit with `includeTestCases` so listing checks does not force cargo-unit test-manifest IFDs.
- Move loop, room, and resource-monitor stats writer onto the shared workspace path and keep policy checks enabled.
- Clean up Rust clippy/machete fallout across the migrated crates.

## Validation

- `nix build .#packages.x86_64-linux.nix-cargo-unit --print-build-logs`
- `nix eval --show-trace .#packages.x86_64-linux.dag-runner.drvPath`
- `nix eval --json .#packages.x86_64-linux.dag-runner.passthru.tests --apply 'builtins.attrNames'`
- `nix eval --json .#packages.x86_64-linux.minecraft-nbt.passthru.tests --apply 'builtins.attrNames'`
- `nix build .#checks.x86_64-linux.eval --print-build-logs`
- `nix build .#packages.x86_64-linux.dag-runner .#packages.x86_64-linux.loop .#packages.x86_64-linux.room --print-build-logs`
- `nix run .#lint`
- `nix build .#site --print-build-logs`
- `nix flake check --print-build-logs`
- Fresh clone of `codex/cargo-unit-all` at the pushed head: `nix run .#lint`, `nix build .#site --print-build-logs`

`nix flake check` reports the expected incompatible-system omission for `aarch64-darwin` and `x86_64-darwin` on this Linux host.
