### PR TITLE
site: add four interesting posts (run-recorder, ix-mcp, ai-review-gate, room)

### DIFF
--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -27,7 +27,7 @@ Each session writes:
 - `events.jsonl`: one JSON object per PTY output chunk, including elapsed time,
   byte count, decoded text, and base64 bytes.
 - `lines.jsonl`: one JSON object per completed output line, shaped for
-  `pandas.read_json(path, lines=True)`.
+  `polars.read_ndjson(path)` (or `pandas.read_json(path, lines=True)`).
 - `summary.json`: command, cwd, terminal metadata, artifact paths, duration, and
   exit status. This starts as `running` and is replaced with the final result.
 

--- a/site/src/lib/updates/ai-review-gate.svx
+++ b/site/src/lib/updates/ai-review-gate.svx
@@ -1,0 +1,52 @@
+---
+id: ai-review-gate
+postedAt: 2026-05-26T02:55:00-07:00
+title: "Reusable Codex AI review gate for any repo"
+tags: [interesting, ci, agents, github]
+links:
+  - label: workflow source
+    href: https://github.com/indexable-inc/index/blob/main/.github/workflows/ai-review-gate.yml
+  - label: caller documentation
+    href: https://github.com/indexable-inc/index/blob/main/.github/workflows/ai-review-gate.md
+---
+
+`indexable-inc/index/.github/workflows/ai-review-gate.yml@main` is a `workflow_call` reviewer that any repo can mount as the default AI review on `main`. The current implementation runs `openai/codex-action` against a JSON schema, posts each finding as a GitHub review suggestion with a `suggested_replacement`, and reports an `overall_correctness` verdict that becomes the final gate.
+
+```yaml
+jobs:
+  ai-review-gate:
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      issues: write
+      pull-requests: write
+    uses: indexable-inc/index/.github/workflows/ai-review-gate.yml@main
+    with:
+      caller_event_name: ${{ github.event_name }}
+      required_check_name: ai review approved
+    secrets:
+      openai_api_key:   ${{ secrets.OPENAI_API_KEY }}
+      repository_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Same-repo PRs from regular users run the secret-backed reviewer. Fork and Dependabot PRs stay on a no-secret path until a trusted maintainer approves the current head SHA, so a forked PR cannot edit the prompt and reach the OpenAI key. The reviewer instruction files (`AGENTS.md`) are restored from the trusted base commit before Codex runs, so a PR that rewrites `AGENTS.md` cannot bend the reviewer's rules.
+
+The structured output keeps each finding mechanically actionable: `title`, `body`, `confidence_score`, `priority`, `code_location.{relative_file_path, line_range}`, and a `suggested_replacement` GitHub renders as a one-click apply. `AI_REVIEW_MODEL` and `AI_REVIEW_EFFORT` are repo variables, with `xhigh` reasoning effort as the default.
+
+```jsonc
+{
+  "findings": [
+    {
+      "title": "fork PRs can leak OPENAI_API_KEY",
+      "priority": 0,
+      "code_location": { "relative_file_path": ".github/workflows/foo.yml", "line_range": {"start": 12, "end": 18} },
+      "suggested_replacement": "...",
+      "confidence_score": 0.92
+    }
+  ],
+  "overall_correctness": "patch is incorrect"
+}
+```
+
+Branch protection requires the `ai review approved` check, which only passes when the reviewer returns a well-formed JSON document and votes `patch is correct`. Missing or malformed output fails closed.

--- a/site/src/lib/updates/ix-mcp-python.svx
+++ b/site/src/lib/updates/ix-mcp-python.svx
@@ -1,0 +1,58 @@
+---
+id: ix-mcp-python
+postedAt: 2026-05-26T02:50:00-07:00
+title: "`ix-mcp` serves a persistent Python session over MCP"
+tags: [interesting, mcp, agents, python, polars]
+links:
+  - label: mcp package
+    href: https://github.com/indexable-inc/index/tree/main/packages/mcp
+---
+
+`nix run .#mcp` speaks MCP over stdio and exposes a Python interpreter as a small set of tools. Sessions live across calls, so an agent can load a dataset once with `python_exec` and ask `python_eval` questions against the cached globals on later turns. No notebook server, no kernel manager, just stdin / stdout.
+
+```text
+python_session_create  python_session_list  python_session_close
+python_eval            python_exec          python_reset
+```
+
+By default each session boots its own venv under a temp dir using the host's `python3`. Pass `command` to `python_session_create` for a project-aware interpreter, e.g. `["uv", "run", "python"]` so the worker inherits the project's `pyproject.toml` and `uv.lock`:
+
+```json
+{
+  "name": "python_session_create",
+  "arguments": {
+    "session_id": "build-analysis",
+    "command": ["uv", "run", "python"],
+    "cwd": "/Users/me/Projects/indexable-inc/index"
+  }
+}
+```
+
+This pairs naturally with `nix run .#run`. After recording a slow build, the agent can ask the MCP session to load `.ix/run/latest/lines.jsonl` into polars and rank the longest gaps, without paging tens of MB of log through its own context window:
+
+```python
+python_exec(source="""
+import polars as pl
+events = (
+    pl.read_ndjson(".ix/run/latest/lines.jsonl")
+      .filter(pl.col("text").str.starts_with("@nix "))
+      .select(
+          "ended_elapsed_ns",
+          pl.col("text").str.slice(5).str.json_decode().alias("event"),
+      )
+      .unnest("event")
+)
+starts = events.filter(pl.col('action') == 'start').select('id', 'text', pl.col('ended_elapsed_ns').alias('t0'))
+stops  = events.filter(pl.col('action') == 'stop' ).select('id',         pl.col('ended_elapsed_ns').alias('t1'))
+slow = (starts.join(stops, on='id')
+              .with_columns(((pl.col('t1') - pl.col('t0')) / 1e9).alias('seconds'))
+              .sort('seconds', descending=True))
+""")
+
+python_eval(expression="slow.head(20)")
+python_eval(expression="slow.filter(pl.col('text').str.contains('rust')).head(20)")
+```
+
+The follow-up `python_eval` calls reuse `slow`, so the agent can ask several questions of the same dataframe instead of re-parsing the log each turn. `python_reset` clears the globals, `python_session_close` ends the worker.
+
+The same binary is also a normal CLI: `nix run .#mcp -- repl` opens an interactive Python session, `nix run .#mcp -- exec '<source>'` and `nix run .#mcp -- eval '<expression>'` run a one-shot through the same worker. The MCP tools and the CLI subcommands share one implementation, so what works at the shell works the same when an agent drives it.

--- a/site/src/lib/updates/room-server.svx
+++ b/site/src/lib/updates/room-server.svx
@@ -1,0 +1,41 @@
+---
+id: room-server
+postedAt: 2026-05-26T02:56:00-07:00
+title: "`nix run .#room` runs a shared team presence room"
+tags: [interesting, rust, websocket, agents]
+links:
+  - label: room package
+    href: https://github.com/indexable-inc/index/tree/main/packages/room
+  - label: services.room module
+    href: https://github.com/indexable-inc/index/tree/main/modules/services/room
+---
+
+`nix run .#room` boots a single binary that serves a Svelte page and a `/ws` WebSocket on `:8080`. Every connected teammate publishes presence (name, color, focus, draft), and a per-participant `codex` status keyed on one of `idle`, `thinking`, `editing`, `reviewing`, `blocked`, so the rest of the room sees what each agent is doing without anyone having to ask.
+
+```bash
+nix run github:indexable-inc/index#room
+open http://localhost:8080
+```
+
+State is a `loro::LoroDoc` behind a `tokio::Mutex`, fanned out over a `broadcast::Sender<ServerEvent>` so every socket receives a full `snapshot` on connect and after each apply. Clients send `presence`, `focus`, `draft`, `codex`, or `leave` events; the server merges them into the participants map, stamps `lastSeenMs`, and re-broadcasts:
+
+```rust
+enum ClientEvent {
+    Presence { id, name, color },
+    Focus    { id, focus },
+    Draft    { id, draft },
+    Codex    { id, task, status },
+    Leave    { id },
+}
+```
+
+The Svelte page persists the teammate id in `localStorage`, reconnects on socket drop with a one-second backoff, and tabs cleanly over `wss://` when the room sits behind TLS termination. The build is a normal `npm` site; the Nix wrapper bakes the built assets into `ROOM_SITE_DIR` so the server is one closure with no separate static-asset deploy step.
+
+```nix
+services.room = {
+  enable = true;
+  port   = 8080;
+};
+```
+
+The NixOS module registers a port claim under `ix.networking.portClaims.room`, runs the binary as a `DynamicUser` systemd service with the shared `ix.systemdHardening` profile, and opens the firewall port unless `openFirewall = false`. Drop it into any image and the room comes up alongside the rest of the fleet.

--- a/site/src/lib/updates/run-recorder.svx
+++ b/site/src/lib/updates/run-recorder.svx
@@ -1,24 +1,68 @@
 ---
 id: run-recorder
-postedAt: 2026-05-25T15:28:13-07:00
+postedAt: 2026-05-26T02:49:00-07:00
 title: "`nix run .#run` records command sessions"
-tags: [interesting, nix, cli]
+tags: [interesting, nix, cli, polars]
 links:
   - label: run package
     href: https://github.com/indexable-inc/index/tree/main/packages/run
 ---
 
-`nix run .#run -- <command> ...` executes the command in a PTY, prints a bounded head/tail summary to the terminal, and writes the full live stream under `./.ix/run/latest/`.
+`nix run .#run -- <command> ...` executes the command in a PTY, prints a bounded head/tail summary to the terminal, and writes the full live stream plus per-line timing under `./.ix/run/latest/`.
 
 ```bash
 nix run github:indexable-inc/index#run -- cargo test -p my-crate
 ls .ix/run/latest/
-# manifest.json  output.log  output.cast  output.timing
-# stdout.jsonl   lines.jsonl
+# events.jsonl  lines.jsonl  live          output.log  replay
+# session.cast  summary.json  timing.log   typescript
 ```
 
-Each session captures `scriptreplay` timing files, an asciinema cast, chunk-level JSONL, line-level JSONL ready for pandas, and a summary manifest with duration and exit status. A second shell can `tail -f output.log` while the original command is still running, which is useful for slow Nix builds and long test suites.
+A second shell can `tail -f .ix/run/latest/output.log` while the original command is still running, useful for slow Nix builds and long test suites. `./.ix/run/latest/replay [divisor]` reads `timing.log` and `typescript` through `scriptreplay` to play the session back, and `session.cast` is a valid asciinema v2 file.
 
-```bash
-tail -f .ix/run/latest/output.log   # live stream, even while the build runs
+`lines.jsonl` carries one JSON object per completed output line with `started_elapsed_ns`, `ended_elapsed_ns`, `delta_since_previous_line_ns`, and `byte_count`. Polars reads it with no schema work and keeps the elapsed-time columns as integer nanoseconds, so ranking the lines that gapped longest before printing is one expression:
+
+```python
+import polars as pl
+
+df = pl.read_ndjson(".ix/run/latest/lines.jsonl")
+(
+    df.sort("delta_since_previous_line_ns", descending=True)
+      .select("line_no", "delta_since_previous_line_ns", "text")
+      .head(20)
+)
 ```
+
+The same shape works for any structured event stream you choose to record. `nix build .#someBadAttr --log-format internal-json` emits one `@nix {...}` line per phase, with `start` / `stop` pairs keyed on `id`:
+
+```
+@nix {"action":"start","id":12,"text":"querying info about missing paths","type":105,...}
+@nix {"action":"stop","id":12}
+```
+
+Record that through `run`, drop the `@nix ` prefix, decode the rest, and join starts to stops to surface the slowest phases:
+
+```python
+events = (
+    pl.read_ndjson(".ix/run/latest/lines.jsonl")
+      .filter(pl.col("text").str.starts_with("@nix "))
+      .select(
+          "ended_elapsed_ns",
+          pl.col("text").str.slice(5).str.json_decode().alias("event"),
+      )
+      .unnest("event")
+)
+starts = events.filter(pl.col("action") == "start").select(
+    "id", "text", pl.col("ended_elapsed_ns").alias("t0"),
+)
+stops = events.filter(pl.col("action") == "stop").select(
+    "id", pl.col("ended_elapsed_ns").alias("t1"),
+)
+(
+    starts.join(stops, on="id")
+          .with_columns(((pl.col("t1") - pl.col("t0")) / 1e9).alias("seconds"))
+          .sort("seconds", descending=True)
+          .head(20)
+)
+```
+
+`pl.read_ndjson` replaces the older `pandas.read_json(path, lines=True)` recipe in the README. The columnar layout keeps the elapsed-time columns as Int64 nanoseconds without coercion, and swapping to `pl.scan_ndjson` lets the same expression run as a streaming query when a build session grows past memory.


### PR DESCRIPTION
## Posts added

- **`nix run .#run` records command sessions** — expanded the existing entry: corrected artifact list and added two polars examples (slowest output lines from `lines.jsonl`, then `start`/`stop` joins on `nix build --log-format internal-json` output).
- **`ix-mcp` serves a persistent Python session over MCP** — announces the Rust MCP server that exposes a stdio Python REPL; worked example loads the recorder output into polars across multiple `python_eval` calls.
- **Reusable Codex AI review gate for any repo** — announces `indexable-inc/index/.github/workflows/ai-review-gate.yml@main` as a `workflow_call` reviewer, including the trust separation for fork / Dependabot PRs and the JSON schema with `suggested_replacement`.
- **`nix run .#room` runs a shared team presence room** — announces the axum + loro WebSocket server with per-participant `codex` status and the `services.room` NixOS module.

## Drive-by

- Swapped `pandas` for `polars` (kept as a fallback) in `packages/run/README.md` so the post and the package match.
