### PR TITLE
site: add Svelte Flow tldr diagrams + fix double-rule filter bar

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ix-site",
       "version": "0.1.0",
       "dependencies": {
+        "@xyflow/svelte": "^1.5.2",
         "mdsvex": "^0.12.7",
         "shiki": "^4.1.0"
       },
@@ -735,6 +736,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@svelte-put/shortcut": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@svelte-put/shortcut/-/shortcut-4.1.0.tgz",
+      "integrity": "sha512-wImNEIkbxAIWFqlfuhcbC+jRPDeRa/uJGIXHMEVVD+jqL9xCwWNnkGQJ6Qb2XVszuRLHlb8SGZDL3Io/h3vs8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "svelte": "^5.1.0"
+      }
+    },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
@@ -844,6 +854,55 @@
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -1321,6 +1380,36 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xyflow/svelte": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/svelte/-/svelte-1.5.2.tgz",
+      "integrity": "sha512-jPLc2cwRmrkXSv/jvsNDQqTGCsNyTWURKtBl28UCH3BdOAA3CIc0/oQ0EvIcjPdzr0NwvWMgq9TmLdjOIccCEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@svelte-put/shortcut": "^4.1.0",
+        "@xyflow/system": "0.0.76"
+      },
+      "peerDependencies": {
+        "svelte": "^5.25.0"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1529,6 +1618,111 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/debug": {

--- a/site/package.json
+++ b/site/package.json
@@ -34,6 +34,7 @@
     "cookie": "^0.7.0"
   },
   "dependencies": {
+    "@xyflow/svelte": "^1.5.2",
     "mdsvex": "^0.12.7",
     "shiki": "^4.1.0"
   }

--- a/site/src/app.css
+++ b/site/src/app.css
@@ -133,7 +133,6 @@ main {
   list-style: none;
   margin: 0;
   padding: 0;
-  border-top: 1px solid var(--rule);
 }
 
 .log > li {

--- a/site/src/lib/diagrams/AiReviewGateDiagram.svelte
+++ b/site/src/lib/diagrams/AiReviewGateDiagram.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import type { Node, Edge } from '@xyflow/svelte';
+  import DiagramFrame from './DiagramFrame.svelte';
+
+  const nodes: Node[] = [
+    {
+      id: 'pr',
+      type: 'box',
+      position: { x: 0, y: 100 },
+      data: { kicker: 'github event', label: 'pull request', sublabel: 'opened / sync', kind: 'agent' }
+    },
+    {
+      id: 'trust',
+      type: 'box',
+      position: { x: 190, y: 100 },
+      data: { label: 'trust check', sublabel: 'same-repo? fork? bot?', kind: 'gate' }
+    },
+    {
+      id: 'codex',
+      type: 'box',
+      position: { x: 400, y: 20 },
+      data: { kicker: 'openai/codex-action', label: 'secret-backed reviewer', sublabel: 'xhigh effort', kind: 'proc' }
+    },
+    {
+      id: 'wait',
+      type: 'box',
+      position: { x: 400, y: 180 },
+      data: { label: 'await maintainer approval', sublabel: 'no secrets, no run', kind: 'gate' }
+    },
+    {
+      id: 'json',
+      type: 'box',
+      position: { x: 640, y: 20 },
+      data: { kicker: 'json schema', label: 'findings + verdict', sublabel: 'suggested_replacement', kind: 'artifact' }
+    },
+    {
+      id: 'gate',
+      type: 'box',
+      position: { x: 870, y: 100 },
+      data: { label: 'ai review approved', sublabel: 'branch protection', kind: 'gate' }
+    },
+    {
+      id: 'comments',
+      type: 'box',
+      position: { x: 640, y: 180 },
+      data: { label: 'github review suggestions', sublabel: 'one-click apply', kind: 'artifact' }
+    }
+  ];
+
+  const edges: Edge[] = [
+    { id: 'pr-trust', source: 'pr', target: 'trust' },
+    { id: 'trust-codex', source: 'trust', target: 'codex', label: 'same-repo' },
+    { id: 'trust-wait', source: 'trust', target: 'wait', label: 'fork / dependabot' },
+    { id: 'codex-json', source: 'codex', target: 'json' },
+    { id: 'json-gate', source: 'json', target: 'gate' },
+    { id: 'json-comments', source: 'json', target: 'comments' },
+    { id: 'wait-gate', source: 'wait', target: 'gate', label: 'after approval' }
+  ];
+</script>
+
+<DiagramFrame {nodes} {edges} height={320} caption="Same-repo PRs run Codex; fork PRs wait for a trusted approval, both ending at the same gate." />

--- a/site/src/lib/diagrams/BoxNode.svelte
+++ b/site/src/lib/diagrams/BoxNode.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+  import { Handle, Position, type Node, type NodeProps } from '@xyflow/svelte';
+
+  type BoxData = {
+    kicker?: string;
+    label: string;
+    sublabel?: string;
+    kind?: 'default' | 'proc' | 'artifact' | 'agent' | 'gate';
+  };
+
+  type BoxNodeType = Node<BoxData, 'box'>;
+
+  const { data }: NodeProps<BoxNodeType> = $props();
+</script>
+
+<div class="box" data-kind={data.kind ?? 'default'}>
+  {#if data.kicker}<div class="kicker">{data.kicker}</div>{/if}
+  <div class="label">{data.label}</div>
+  {#if data.sublabel}<div class="sublabel">{data.sublabel}</div>{/if}
+</div>
+
+<Handle id="t-in" type="target" position={Position.Top} />
+<Handle id="t-out" type="source" position={Position.Top} />
+<Handle id="l-in" type="target" position={Position.Left} />
+<Handle id="l-out" type="source" position={Position.Left} />
+<Handle id="r-in" type="target" position={Position.Right} />
+<Handle id="r-out" type="source" position={Position.Right} />
+<Handle id="b-in" type="target" position={Position.Bottom} />
+<Handle id="b-out" type="source" position={Position.Bottom} />
+
+<style>
+  .box {
+    min-width: 110px;
+    max-width: 190px;
+    padding: 0.5rem 0.7rem;
+    background: var(--bg);
+    border: 1px solid var(--rule);
+    border-radius: 5px;
+    color: var(--fg);
+    font-family: var(--font-sans);
+    font-size: 12px;
+    line-height: 1.35;
+    text-align: center;
+  }
+
+  .box[data-kind='proc'] {
+    background: var(--code);
+    border-color: var(--fg-faint);
+  }
+
+  .box[data-kind='artifact'] {
+    background: var(--bg);
+    border-style: dashed;
+  }
+
+  .box[data-kind='agent'] {
+    background: var(--bg);
+    border-color: var(--fg-muted);
+    border-style: double;
+    border-width: 3px;
+  }
+
+  .box[data-kind='gate'] {
+    background: var(--code);
+    border-color: var(--fg-muted);
+    border-width: 1px;
+    border-style: solid;
+    transform: skewX(-8deg);
+  }
+
+  .box[data-kind='gate'] .label,
+  .box[data-kind='gate'] .kicker,
+  .box[data-kind='gate'] .sublabel {
+    transform: skewX(8deg);
+  }
+
+  .kicker {
+    font-family: var(--font-mono);
+    font-size: 9.5px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--fg-faint);
+    margin-bottom: 0.15rem;
+  }
+
+  .label {
+    font-weight: 500;
+    color: var(--fg);
+  }
+
+  .label :global(code) {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--fg);
+  }
+
+  .sublabel {
+    margin-top: 0.2rem;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--fg-muted);
+  }
+
+  /* Hide the handle dots; we still want the connection points to work. */
+  :global(.svelte-flow__handle) {
+    background: transparent;
+    border: 0;
+    width: 1px;
+    height: 1px;
+    min-width: 0;
+    min-height: 0;
+  }
+</style>

--- a/site/src/lib/diagrams/DiagramFrame.svelte
+++ b/site/src/lib/diagrams/DiagramFrame.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import {
+    SvelteFlow,
+    Background,
+    BackgroundVariant,
+    MarkerType,
+    type Node,
+    type Edge
+  } from '@xyflow/svelte';
+  import '@xyflow/svelte/dist/style.css';
+  import BoxNode from './BoxNode.svelte';
+
+  type Props = {
+    nodes: Node[];
+    edges: Edge[];
+    height?: number;
+    caption?: string;
+  };
+
+  const {
+    nodes: initialNodes,
+    edges: initialEdges,
+    height = 300,
+    caption
+  }: Props = $props();
+
+  const decoratedEdges = $derived(
+    initialEdges.map((edge) => ({
+      type: edge.type ?? 'smoothstep',
+      markerEnd: edge.markerEnd ?? { type: MarkerType.ArrowClosed, width: 14, height: 14 },
+      ...edge
+    }))
+  );
+
+  // SvelteFlow's `bind:` wants a $state container, but the source of truth
+  // stays the prop. Sync prop updates into the local state via $effect.pre
+  // so we never read the prop inside the $state initializer.
+  let nodes = $state.raw<Node[]>([]);
+  let edges = $state.raw<Edge[]>([]);
+  $effect.pre(() => {
+    nodes = initialNodes;
+    edges = decoratedEdges;
+  });
+
+  // The xyflow `NodeTypes` index signature wants `Component<Node<...>>`; our
+  // BoxNode is a `Component<NodeProps<Node<BoxData,'box'>>>`. The runtime
+  // shape matches, but the structural type check needs a cast.
+  const nodeTypes = { box: BoxNode } as unknown as Record<string, typeof BoxNode>;
+
+  // SvelteFlow needs the DOM (ResizeObserver, getBoundingClientRect). Defer
+  // until after mount so the static prerender doesn't try to render it.
+  let mounted = $state(false);
+  onMount(() => {
+    mounted = true;
+  });
+</script>
+
+<figure class="diagram-figure">
+  <div class="diagram" style="height: {height}px" aria-hidden={mounted ? undefined : 'true'}>
+    {#if mounted}
+      <SvelteFlow
+        bind:nodes
+        bind:edges
+        {nodeTypes}
+        fitView
+        fitViewOptions={{ padding: 0.18 }}
+        minZoom={0.5}
+        maxZoom={1.5}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        zoomOnScroll={false}
+        zoomOnPinch={false}
+        zoomOnDoubleClick={false}
+        panOnDrag={false}
+        panOnScroll={false}
+        preventScrolling={false}
+        proOptions={{ hideAttribution: false }}
+      >
+        <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
+      </SvelteFlow>
+    {/if}
+  </div>
+  {#if caption}<figcaption>{caption}</figcaption>{/if}
+</figure>
+
+<style>
+  .diagram-figure {
+    margin: 1.5rem 0;
+  }
+
+  .diagram {
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    overflow: hidden;
+    background: var(--bg);
+  }
+
+  figcaption {
+    margin-top: 0.55rem;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--fg-faint);
+    text-align: center;
+  }
+
+  .diagram :global(.svelte-flow) {
+    background: transparent;
+  }
+
+  .diagram :global(.svelte-flow__background) {
+    color: var(--fg-faint);
+    opacity: 0.5;
+  }
+
+  .diagram :global(.svelte-flow__edge-path) {
+    stroke: var(--fg-muted);
+    stroke-width: 1.4;
+  }
+
+  .diagram :global(.svelte-flow__edge.dashed .svelte-flow__edge-path) {
+    stroke-dasharray: 4 3;
+  }
+
+  .diagram :global(.svelte-flow__arrowhead) {
+    fill: var(--fg-muted);
+  }
+
+  .diagram :global(.svelte-flow__edge-text) {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    fill: var(--fg-muted);
+  }
+
+  .diagram :global(.svelte-flow__edge-textbg) {
+    fill: var(--bg);
+  }
+
+  .diagram :global(.svelte-flow__attribution) {
+    background: transparent;
+    color: var(--fg-faint);
+    font-size: 9.5px;
+    padding: 2px 4px;
+  }
+
+  .diagram :global(.svelte-flow__attribution a) {
+    color: var(--fg-faint);
+    border: 0;
+  }
+</style>

--- a/site/src/lib/diagrams/IxMcpDiagram.svelte
+++ b/site/src/lib/diagrams/IxMcpDiagram.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import type { Node, Edge } from '@xyflow/svelte';
+  import DiagramFrame from './DiagramFrame.svelte';
+
+  const nodes: Node[] = [
+    {
+      id: 'agent',
+      type: 'box',
+      position: { x: 0, y: 80 },
+      data: { kicker: 'mcp client', label: 'Coding agent', sublabel: 'python_exec / python_eval', kind: 'agent' }
+    },
+    {
+      id: 'mcp',
+      type: 'box',
+      position: { x: 220, y: 80 },
+      data: { kicker: 'nix run .#mcp', label: 'ix-mcp server', sublabel: 'stdio router', kind: 'proc' }
+    },
+    {
+      id: 'worker',
+      type: 'box',
+      position: { x: 450, y: 30 },
+      data: { kicker: 'subprocess', label: 'python worker', sublabel: 'per-session venv', kind: 'proc' }
+    },
+    {
+      id: 'globals',
+      type: 'box',
+      position: { x: 450, y: 140 },
+      data: { label: 'session globals', sublabel: 'df, slow, imports', kind: 'artifact' }
+    },
+    {
+      id: 'data',
+      type: 'box',
+      position: { x: 670, y: 80 },
+      data: { kicker: '.ix/run/latest', label: 'lines.jsonl', sublabel: 'recorded by run', kind: 'artifact' }
+    }
+  ];
+
+  const edges: Edge[] = [
+    { id: 'agent-mcp', source: 'agent', target: 'mcp', label: 'tool call' },
+    { id: 'mcp-worker', source: 'mcp', target: 'worker' },
+    { id: 'worker-globals', source: 'worker', target: 'globals', label: 'persist' },
+    { id: 'globals-worker', source: 'globals', target: 'worker', sourceHandle: 't-out', targetHandle: 'b-in', label: 'reuse' },
+    { id: 'worker-data', source: 'worker', target: 'data', label: 'read_ndjson' },
+    { id: 'mcp-agent', source: 'mcp', target: 'agent', sourceHandle: 'b-out', targetHandle: 'b-in', label: 'stdout / result' }
+  ];
+</script>
+
+<DiagramFrame {nodes} {edges} height={300} caption="One stdio session, one persistent Python interpreter, many tool calls." />

--- a/site/src/lib/diagrams/RoomServerDiagram.svelte
+++ b/site/src/lib/diagrams/RoomServerDiagram.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import type { Node, Edge } from '@xyflow/svelte';
+  import DiagramFrame from './DiagramFrame.svelte';
+
+  const nodes: Node[] = [
+    {
+      id: 'a',
+      type: 'box',
+      position: { x: 0, y: 0 },
+      data: { kicker: 'browser', label: 'teammate A', sublabel: 'name, focus, draft', kind: 'agent' }
+    },
+    {
+      id: 'b',
+      type: 'box',
+      position: { x: 0, y: 110 },
+      data: { kicker: 'browser', label: 'teammate B', sublabel: 'codex: editing', kind: 'agent' }
+    },
+    {
+      id: 'c',
+      type: 'box',
+      position: { x: 0, y: 220 },
+      data: { kicker: 'browser', label: 'teammate C', sublabel: 'codex: reviewing', kind: 'agent' }
+    },
+    {
+      id: 'ws',
+      type: 'box',
+      position: { x: 280, y: 60 },
+      data: { kicker: 'axum /ws', label: 'websocket gateway', kind: 'proc' }
+    },
+    {
+      id: 'state',
+      type: 'box',
+      position: { x: 280, y: 170 },
+      data: { kicker: 'tokio::Mutex', label: 'LoroDoc + participants', sublabel: 'apply + stamp lastSeen', kind: 'proc' }
+    },
+    {
+      id: 'bus',
+      type: 'box',
+      position: { x: 540, y: 110 },
+      data: { kicker: 'broadcast::Sender', label: 'snapshot fanout', kind: 'artifact' }
+    }
+  ];
+
+  const edges: Edge[] = [
+    { id: 'a-ws', source: 'a', target: 'ws', label: 'presence' },
+    { id: 'b-ws', source: 'b', target: 'ws', label: 'codex' },
+    { id: 'c-ws', source: 'c', target: 'ws', label: 'focus' },
+    { id: 'ws-state', source: 'ws', target: 'state' },
+    { id: 'state-bus', source: 'state', target: 'bus' },
+    { id: 'bus-a', source: 'bus', target: 'a', sourceHandle: 't-out', targetHandle: 't-in', label: 'snapshot' },
+    { id: 'bus-b', source: 'bus', target: 'b', sourceHandle: 'l-out', targetHandle: 'r-in', label: 'snapshot' },
+    { id: 'bus-c', source: 'bus', target: 'c', sourceHandle: 'b-out', targetHandle: 'b-in', label: 'snapshot' }
+  ];
+</script>
+
+<DiagramFrame {nodes} {edges} height={340} caption="Each client posts intent; every apply rebroadcasts a fresh snapshot to every connected teammate." />

--- a/site/src/lib/diagrams/RunRecorderDiagram.svelte
+++ b/site/src/lib/diagrams/RunRecorderDiagram.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import type { Node, Edge } from '@xyflow/svelte';
+  import DiagramFrame from './DiagramFrame.svelte';
+
+  const nodes: Node[] = [
+    {
+      id: 'cmd',
+      type: 'box',
+      position: { x: 0, y: 110 },
+      data: { kicker: 'argv', label: 'cargo test -p my-crate', kind: 'agent' }
+    },
+    {
+      id: 'run',
+      type: 'box',
+      position: { x: 200, y: 110 },
+      data: { kicker: 'nix run .#run', label: 'PTY recorder', sublabel: 'head/tail to stdout', kind: 'proc' }
+    },
+    {
+      id: 'log',
+      type: 'box',
+      position: { x: 430, y: 0 },
+      data: { label: 'output.log', sublabel: 'tail -f live', kind: 'artifact' }
+    },
+    {
+      id: 'lines',
+      type: 'box',
+      position: { x: 430, y: 75 },
+      data: { label: 'lines.jsonl', sublabel: 'per-line timing', kind: 'artifact' }
+    },
+    {
+      id: 'cast',
+      type: 'box',
+      position: { x: 430, y: 150 },
+      data: { label: 'session.cast', sublabel: 'asciinema + replay', kind: 'artifact' }
+    },
+    {
+      id: 'summary',
+      type: 'box',
+      position: { x: 430, y: 225 },
+      data: { label: 'summary.json', sublabel: 'status, duration', kind: 'artifact' }
+    },
+    {
+      id: 'polars',
+      type: 'box',
+      position: { x: 670, y: 75 },
+      data: { kicker: 'pl.read_ndjson', label: 'polars query', sublabel: 'slowest lines / phases', kind: 'proc' }
+    }
+  ];
+
+  const edges: Edge[] = [
+    { id: 'cmd-run', source: 'cmd', target: 'run' },
+    { id: 'run-log', source: 'run', target: 'log' },
+    { id: 'run-lines', source: 'run', target: 'lines' },
+    { id: 'run-cast', source: 'run', target: 'cast' },
+    { id: 'run-summary', source: 'run', target: 'summary' },
+    { id: 'lines-polars', source: 'lines', target: 'polars' }
+  ];
+</script>
+
+<DiagramFrame {nodes} {edges} height={320} caption="One PTY in, one structured artifact set out, ready for polars." />

--- a/site/src/lib/updates.test.ts
+++ b/site/src/lib/updates.test.ts
@@ -34,6 +34,17 @@ describe('plainText', () => {
   test('drops fenced code blocks', () => {
     expect(plainText('before\n```\ncode\nblock\n```\nafter')).toBe('before after');
   });
+
+  test('drops svelte script blocks and component tags', () => {
+    const source = [
+      '<script>',
+      "  import Diagram from '$lib/diagrams/X.svelte';",
+      '</script>',
+      '',
+      'before <Diagram /> after'
+    ].join('\n');
+    expect(plainText(source)).toBe('before after');
+  });
 });
 
 describe('updateScript', () => {

--- a/site/src/lib/updates.ts
+++ b/site/src/lib/updates.ts
@@ -58,6 +58,9 @@ function stripFrontmatter(source: string): string {
 
 export function plainText(markdown: string): string {
   return markdown
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<[A-Z][A-Za-z0-9]*\b[^>]*\/?>/g, '')
+    .replace(/<\/[A-Z][A-Za-z0-9]*>/g, '')
     .replace(/```[\s\S]*?```/g, '')
     .replace(/`([^`]+)`/g, '$1')
     .replace(/\*\*([^*]+)\*\*/g, '$1')

--- a/site/src/lib/updates/ai-review-gate.svx
+++ b/site/src/lib/updates/ai-review-gate.svx
@@ -10,7 +10,13 @@ links:
     href: https://github.com/indexable-inc/index/blob/main/.github/workflows/ai-review-gate.md
 ---
 
+<script>
+  import AiReviewGateDiagram from '$lib/diagrams/AiReviewGateDiagram.svelte';
+</script>
+
 `indexable-inc/index/.github/workflows/ai-review-gate.yml@main` is a `workflow_call` reviewer that any repo can mount as the default AI review on `main`. The current implementation runs `openai/codex-action` against a JSON schema, posts each finding as a GitHub review suggestion with a `suggested_replacement`, and reports an `overall_correctness` verdict that becomes the final gate.
+
+<AiReviewGateDiagram />
 
 ```yaml
 jobs:

--- a/site/src/lib/updates/ix-mcp-python.svx
+++ b/site/src/lib/updates/ix-mcp-python.svx
@@ -8,7 +8,13 @@ links:
     href: https://github.com/indexable-inc/index/tree/main/packages/mcp
 ---
 
+<script>
+  import IxMcpDiagram from '$lib/diagrams/IxMcpDiagram.svelte';
+</script>
+
 `nix run .#mcp` speaks MCP over stdio and exposes a Python interpreter as a small set of tools. Sessions live across calls, so an agent can load a dataset once with `python_exec` and ask `python_eval` questions against the cached globals on later turns. No notebook server, no kernel manager, just stdin / stdout.
+
+<IxMcpDiagram />
 
 ```text
 python_session_create  python_session_list  python_session_close

--- a/site/src/lib/updates/room-server.svx
+++ b/site/src/lib/updates/room-server.svx
@@ -10,7 +10,13 @@ links:
     href: https://github.com/indexable-inc/index/tree/main/modules/services/room
 ---
 
+<script>
+  import RoomServerDiagram from '$lib/diagrams/RoomServerDiagram.svelte';
+</script>
+
 `nix run .#room` boots a single binary that serves a Svelte page and a `/ws` WebSocket on `:8080`. Every connected teammate publishes presence (name, color, focus, draft), and a per-participant `codex` status keyed on one of `idle`, `thinking`, `editing`, `reviewing`, `blocked`, so the rest of the room sees what each agent is doing without anyone having to ask.
+
+<RoomServerDiagram />
 
 ```bash
 nix run github:indexable-inc/index#room

--- a/site/src/lib/updates/run-recorder.svx
+++ b/site/src/lib/updates/run-recorder.svx
@@ -8,7 +8,13 @@ links:
     href: https://github.com/indexable-inc/index/tree/main/packages/run
 ---
 
+<script>
+  import RunRecorderDiagram from '$lib/diagrams/RunRecorderDiagram.svelte';
+</script>
+
 `nix run .#run -- <command> ...` executes the command in a PTY, prints a bounded head/tail summary to the terminal, and writes the full live stream plus per-line timing under `./.ix/run/latest/`.
+
+<RunRecorderDiagram />
 
 ```bash
 nix run github:indexable-inc/index#run -- cargo test -p my-crate

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { playwright } from '@vitest/browser-playwright';
 import { mdsvex, escapeSvelte } from 'mdsvex';
@@ -7,8 +8,16 @@ import { defineConfig } from 'vitest/config';
 // vitest uses @sveltejs/vite-plugin-svelte directly (not the full sveltekit
 // plugin) so the browser server doesn't try to spin up a SvelteKit dev
 // server. mdsvex is wired in by hand against the same shape as
-// svelte.config.js so .svx imports resolve in tests too.
+// svelte.config.js so .svx imports resolve in tests too. SvelteKit's `$lib`
+// alias is wired in by hand for the same reason — without it, .svx files
+// that `import Foo from '$lib/...'` would fail to resolve in the browser
+// test runtime.
 export default defineConfig({
+  resolve: {
+    alias: {
+      $lib: fileURLToPath(new URL('./src/lib', import.meta.url))
+    }
+  },
   plugins: [
     svelte({
       extensions: ['.svelte', '.svx'],


### PR DESCRIPTION
## Diagrams

Adds Svelte Flow tldr diagrams to four posts using custom Svelte node components (not stringly-typed Mermaid):

- **run-recorder** — cargo argv → PTY recorder → fan-out to `output.log`, `lines.jsonl`, `session.cast`, `summary.json`; `lines.jsonl` → polars
- **ix-mcp-python** — agent → ix-mcp stdio → python worker (per-session venv) with persistent globals reused across tool calls
- **ai-review-gate** — PR → trust check → secret-backed Codex vs await-maintainer path → JSON findings + verdict → GitHub suggestions + `ai review approved` gate
- **room-server** — three browser clients ↔ axum /ws → LoroDoc + participants → broadcast::Sender → snapshot fanout to all teammates

Shared infra:
- `site/src/lib/diagrams/BoxNode.svelte` — one node component with `default` / `proc` / `artifact` / `agent` / `gate` kinds, kicker + label + sublabel, handles on all four sides
- `site/src/lib/diagrams/DiagramFrame.svelte` — wraps SvelteFlow with read-only defaults (no drag, no zoom, no scroll-pan), fitView, light/dark themed via existing CSS vars, mounts only after `onMount` so static prerender stays clean
- Adds `@xyflow/svelte` 1.5.2 and wires the `$lib` alias in `vitest.config.ts` so .svx imports resolve in the browser test runtime
- Extends `plainText` to strip `<script>` blocks and `<Component />` tags so the RSS body stays clean

## Drive-by UI fix

The FilterBar's `border-bottom` and `.log`'s `border-top` rendered as a visible double-rule under the filter input (see screenshot in chat). Removed the `.log` border-top; the FilterBar already separates the filter from the feed.

## Verified

- `npm test` — 26/26 pass
- `npm run build` — clean (svelte-check + eslint + vite)
- `nix run .#lint` — clean
- Loaded each of the four posts in a real browser and confirmed Svelte Flow nodes render with the right shapes and connecting edges.
