### PR TITLE
site: expand-to-modal diagram view; hide Svelte Flow watermark

### DIFF
--- a/site/src/lib/diagrams/DiagramFrame.svelte
+++ b/site/src/lib/diagrams/DiagramFrame.svelte
@@ -4,6 +4,7 @@
     SvelteFlow,
     Background,
     BackgroundVariant,
+    Controls,
     MarkerType,
     type Node,
     type Edge
@@ -36,11 +37,15 @@
   // SvelteFlow's `bind:` wants a $state container, but the source of truth
   // stays the prop. Sync prop updates into the local state via $effect.pre
   // so we never read the prop inside the $state initializer.
-  let nodes = $state.raw<Node[]>([]);
-  let edges = $state.raw<Edge[]>([]);
+  let inlineNodes = $state.raw<Node[]>([]);
+  let inlineEdges = $state.raw<Edge[]>([]);
+  let modalNodes = $state.raw<Node[]>([]);
+  let modalEdges = $state.raw<Edge[]>([]);
   $effect.pre(() => {
-    nodes = initialNodes;
-    edges = decoratedEdges;
+    inlineNodes = initialNodes;
+    inlineEdges = decoratedEdges;
+    modalNodes = initialNodes;
+    modalEdges = decoratedEdges;
   });
 
   // The xyflow `NodeTypes` index signature wants `Component<Node<...>>`; our
@@ -54,14 +59,46 @@
   onMount(() => {
     mounted = true;
   });
+
+  let expanded = $state(false);
+  let expandButton: HTMLButtonElement | undefined = $state();
+  let closeButton: HTMLButtonElement | undefined = $state();
+
+  function openExpanded(): void {
+    expanded = true;
+  }
+
+  function closeExpanded(): void {
+    expanded = false;
+    // Return focus to the trigger for keyboard users.
+    queueMicrotask(() => expandButton?.focus());
+  }
+
+  function onModalKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeExpanded();
+    }
+  }
+
+  $effect(() => {
+    if (!expanded) return;
+    // Prevent body scroll while the overlay is open.
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    queueMicrotask(() => closeButton?.focus());
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  });
 </script>
 
 <figure class="diagram-figure">
   <div class="diagram" style="height: {height}px" aria-hidden={mounted ? undefined : 'true'}>
     {#if mounted}
       <SvelteFlow
-        bind:nodes
-        bind:edges
+        bind:nodes={inlineNodes}
+        bind:edges={inlineEdges}
         {nodeTypes}
         fitView
         fitViewOptions={{ padding: 0.18 }}
@@ -76,14 +113,96 @@
         panOnDrag={false}
         panOnScroll={false}
         preventScrolling={false}
-        proOptions={{ hideAttribution: false }}
+        proOptions={{ hideAttribution: true }}
       >
         <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
       </SvelteFlow>
+      <button
+        type="button"
+        class="expand-button"
+        aria-label="Expand diagram"
+        title="Expand"
+        onclick={openExpanded}
+        bind:this={expandButton}
+      >
+        <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+          <path
+            d="M2 6V2h4M14 6V2h-4M2 10v4h4M14 10v4h-4"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
     {/if}
   </div>
   {#if caption}<figcaption>{caption}</figcaption>{/if}
 </figure>
+
+{#if mounted && expanded}
+  <div
+    class="overlay"
+    role="dialog"
+    aria-modal="true"
+    aria-label={caption ?? 'Expanded diagram'}
+    onkeydown={onModalKeydown}
+    tabindex="-1"
+  >
+    <button
+      type="button"
+      class="backdrop"
+      aria-label="Close expanded diagram"
+      onclick={closeExpanded}
+    ></button>
+    <div class="modal" role="presentation">
+      <header class="modal-header">
+        <span class="modal-caption">{caption ?? ''}</span>
+        <button
+          type="button"
+          class="close-button"
+          aria-label="Close expanded diagram"
+          onclick={closeExpanded}
+          bind:this={closeButton}
+        >
+          <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+            <path
+              d="M4 4l8 8M12 4l-8 8"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+            />
+          </svg>
+        </button>
+      </header>
+      <div class="modal-body">
+        <SvelteFlow
+          bind:nodes={modalNodes}
+          bind:edges={modalEdges}
+          {nodeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.1 }}
+          minZoom={0.25}
+          maxZoom={3}
+          nodesDraggable
+          nodesConnectable={false}
+          elementsSelectable={false}
+          zoomOnScroll
+          zoomOnPinch
+          zoomOnDoubleClick
+          panOnDrag
+          panOnScroll={false}
+          preventScrolling
+          proOptions={{ hideAttribution: true }}
+        >
+          <Background variant={BackgroundVariant.Dots} gap={20} size={1} />
+          <Controls showLock={false} />
+        </SvelteFlow>
+      </div>
+    </div>
+  </div>
+{/if}
 
 <style>
   .diagram-figure {
@@ -91,6 +210,7 @@
   }
 
   .diagram {
+    position: relative;
     border: 1px solid var(--rule);
     border-radius: 6px;
     overflow: hidden;
@@ -105,47 +225,176 @@
     text-align: center;
   }
 
-  .diagram :global(.svelte-flow) {
+  .expand-button {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    z-index: 5;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    background: var(--bg);
+    color: var(--fg-muted);
+    cursor: pointer;
+    transition:
+      color 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .expand-button:hover,
+  .expand-button:focus-visible {
+    color: var(--fg);
+    border-color: var(--fg-muted);
+    outline: none;
+  }
+
+  .expand-button svg {
+    width: 0.95rem;
+    height: 0.95rem;
+  }
+
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+  }
+
+  .backdrop {
+    position: absolute;
+    inset: 0;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    background: color-mix(in srgb, var(--bg) 78%, transparent);
+    backdrop-filter: blur(6px);
+    cursor: zoom-out;
+  }
+
+  .modal {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    width: min(100%, 1100px);
+    height: min(100%, 720px);
+    background: var(--bg);
+    border: 1px solid var(--rule);
+    border-radius: 8px;
+    box-shadow: 0 14px 38px rgb(0 0 0 / 0.18);
+    overflow: hidden;
+  }
+
+  .modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.55rem 0.75rem 0.55rem 1rem;
+    border-bottom: 1px solid var(--rule);
+  }
+
+  .modal-caption {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--fg-muted);
+  }
+
+  .close-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.85rem;
+    height: 1.85rem;
+    padding: 0;
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    background: var(--bg);
+    color: var(--fg-muted);
+    cursor: pointer;
+  }
+
+  .close-button:hover,
+  .close-button:focus-visible {
+    color: var(--fg);
+    border-color: var(--fg-muted);
+    outline: none;
+  }
+
+  .close-button svg {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .modal-body {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .diagram :global(.svelte-flow),
+  .modal-body :global(.svelte-flow) {
     background: transparent;
   }
 
-  .diagram :global(.svelte-flow__background) {
+  .diagram :global(.svelte-flow__background),
+  .modal-body :global(.svelte-flow__background) {
     color: var(--fg-faint);
     opacity: 0.5;
   }
 
-  .diagram :global(.svelte-flow__edge-path) {
+  .diagram :global(.svelte-flow__edge-path),
+  .modal-body :global(.svelte-flow__edge-path) {
     stroke: var(--fg-muted);
     stroke-width: 1.4;
   }
 
-  .diagram :global(.svelte-flow__edge.dashed .svelte-flow__edge-path) {
+  .diagram :global(.svelte-flow__edge.dashed .svelte-flow__edge-path),
+  .modal-body :global(.svelte-flow__edge.dashed .svelte-flow__edge-path) {
     stroke-dasharray: 4 3;
   }
 
-  .diagram :global(.svelte-flow__arrowhead) {
+  .diagram :global(.svelte-flow__arrowhead),
+  .modal-body :global(.svelte-flow__arrowhead) {
     fill: var(--fg-muted);
   }
 
-  .diagram :global(.svelte-flow__edge-text) {
+  .diagram :global(.svelte-flow__edge-text),
+  .modal-body :global(.svelte-flow__edge-text) {
     font-family: var(--font-mono);
     font-size: 10.5px;
     fill: var(--fg-muted);
   }
 
-  .diagram :global(.svelte-flow__edge-textbg) {
+  .diagram :global(.svelte-flow__edge-textbg),
+  .modal-body :global(.svelte-flow__edge-textbg) {
     fill: var(--bg);
   }
 
-  .diagram :global(.svelte-flow__attribution) {
-    background: transparent;
-    color: var(--fg-faint);
-    font-size: 9.5px;
-    padding: 2px 4px;
+  .modal-body :global(.svelte-flow__controls) {
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    overflow: hidden;
+    box-shadow: none;
   }
 
-  .diagram :global(.svelte-flow__attribution a) {
-    color: var(--fg-faint);
-    border: 0;
+  .modal-body :global(.svelte-flow__controls-button) {
+    background: var(--bg);
+    color: var(--fg-muted);
+    border-bottom: 1px solid var(--rule);
+    fill: currentColor;
+  }
+
+  .modal-body :global(.svelte-flow__controls-button:hover) {
+    background: var(--code);
+    color: var(--fg);
   }
 </style>


### PR DESCRIPTION
## Changes

- `proOptions: { hideAttribution: true }` on both inline and modal SvelteFlow instances — no more "Svelte Flow" watermark.
- New expand button in the top-right corner of every inline diagram. Click it (or focus + Enter) to open the diagram in a fullscreen modal.
- Modal: backdrop blur, header with caption and X button, pan-on-drag, zoom-on-scroll, zoom-on-pinch, double-click zoom, draggable nodes, plus a `Controls` overlay (zoom +/-/fitView).
- Escape, X button, and backdrop click all close. Focus returns to the expand button. Body scroll is locked while open.
- The inline view stays read-only and fitView as before, so the in-feed reading experience doesn't change.

## Verified

- `npm test` — 26/26 pass
- `npm run build` — clean
- `nix run .#lint` — clean
- Live browser: opened expand modal, confirmed pan/zoom work, Escape closes and returns focus.

Screenshot of the expanded view in chat.
