### PR TITLE
svelte: add shared site builder

### DIFF
--- a/lib/build-svelte-site.nix
+++ b/lib/build-svelte-site.nix
@@ -1,0 +1,323 @@
+{
+  bunLockFor,
+  writeNushellApplication,
+}:
+
+/**
+  Build and run a Svelte/Vite site from a locked JavaScript workspace.
+
+  The build runs from a pure source closure and installs the static output
+  under `$out/<installDir>`. The preview command serves that immutable output
+  with miniserve. The dev-server command runs from a mutable checkout so Vite
+  can write `node_modules`, caches, and HMR state outside the Nix store.
+
+  Arguments:
+  - `pname`, `version`: derivation identity.
+  - `src`: project root containing `package.json` and the selected lockfile.
+  - `packageManager`: `npm` or `bun`.
+  - `buildScript`: package script for the production build.
+  - `buildFlags`: arguments passed to the build script after `--`.
+  - `preBuild`: shell code to run before the production build.
+  - `distDir`: relative build output path inside `src`.
+  - `installDir`: path under `$out` where built assets are installed.
+  - `installFlags`: extra Bun install flags when `packageManager = "bun"`.
+  - `extraNativeBuildInputs`: extra packages on PATH for the build.
+  - `serve`: static preview settings, including `name`, `host`, and `port`.
+  - `devServer`: checkout dev-server settings, including `name`,
+    `checkoutSubdir`, `host`, `port`, and `autoInstall`.
+  - `meta`: standard derivation meta.
+*/
+pkgs:
+{
+  pname,
+  version ? "0.0.0",
+  src,
+  packageManager ? "npm",
+  buildScript ? "build",
+  buildFlags ? [ ],
+  preBuild ? "",
+  distDir ? "dist",
+  installDir ? "share/${pname}",
+  installFlags ? [ ],
+  extraNativeBuildInputs ? [ ],
+  serve ? { },
+  devServer ? { },
+  meta ? { },
+}:
+let
+  inherit (pkgs) lib;
+
+  validPackageManagers = [
+    "bun"
+    "npm"
+  ];
+  checkedPackageManager =
+    if builtins.elem packageManager validPackageManagers then
+      packageManager
+    else
+      throw "ix.buildSvelteSite.packageManager must be one of ${lib.concatStringsSep ", " validPackageManagers}; got ${packageManager}";
+
+  packageManagers = {
+    bun =
+      let
+        bunLock = bunLockFor pkgs;
+        bunNodeModules = bunLock.buildNodeModules {
+          bunRoot = src;
+          inherit installFlags;
+          derivationArgs = {
+            strictDeps = true;
+          };
+        };
+      in
+      {
+        buildCommandPrefix = [
+          "bun"
+          "run"
+        ];
+        derivationAttrs = {
+          inherit bunNodeModules;
+          configurePhase = ''
+            runHook preConfigure
+
+            patchShebangs .
+            ln -s ${bunNodeModules}/node_modules node_modules
+            export PATH="$PWD/node_modules/.bin:$PATH"
+
+            runHook postConfigure
+          '';
+          passthru = {
+            inherit bunNodeModules;
+          };
+        };
+        devInstallCommand = [
+          "bun"
+          "install"
+          "--frozen-lockfile"
+        ];
+        devRunCommandPrefix = [
+          "bun"
+          "run"
+        ];
+        nativeBuildInputs = [
+          pkgs.bun
+          bunLock.nodeCompat
+        ];
+        runtimeInputs = [ pkgs.bun ];
+      };
+
+    npm =
+      let
+        npmDeps = pkgs.importNpmLock.buildNodeModules {
+          npmRoot = src;
+          inherit (pkgs) nodejs;
+          derivationArgs = {
+            strictDeps = true;
+          };
+        };
+      in
+      {
+        buildCommandPrefix = [
+          "npm"
+          "run"
+        ];
+        derivationAttrs = {
+          inherit npmDeps;
+          passthru = {
+            inherit npmDeps;
+          };
+        };
+        devInstallCommand = [
+          "npm"
+          "ci"
+        ];
+        devRunCommandPrefix = [
+          "npm"
+          "run"
+        ];
+        nativeBuildInputs = [
+          pkgs.nodejs
+          pkgs.importNpmLock.linkNodeModulesHook
+        ];
+        runtimeInputs = [ pkgs.nodejs ];
+      };
+  };
+  manager = packageManagers.${checkedPackageManager};
+
+  buildCommand =
+    manager.buildCommandPrefix
+    ++ [
+      buildScript
+    ]
+    ++ lib.optional (buildFlags != [ ]) "--"
+    ++ buildFlags;
+
+  staticSite = pkgs.stdenvNoCC.mkDerivation (
+    _:
+    {
+      inherit
+        pname
+        version
+        src
+        meta
+        ;
+
+      strictDeps = true;
+      nativeBuildInputs = manager.nativeBuildInputs ++ extraNativeBuildInputs;
+
+      buildPhase = ''
+        runHook preBuild
+        ${preBuild}
+        ${lib.escapeShellArgs buildCommand}
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+        mkdir -p "$out"/${lib.escapeShellArg installDir}
+        cp -R ${lib.escapeShellArg (distDir + "/.")} "$out"/${lib.escapeShellArg installDir}/
+        runHook postInstall
+      '';
+    }
+    // manager.derivationAttrs
+  );
+
+  serveDefaults = {
+    enable = true;
+    name = pname;
+    host = "127.0.0.1";
+    port = 8080;
+    spa = true;
+    extraFlags = [ ];
+  };
+  serveConfig = serveDefaults // serve;
+  serveArgs =
+    lib.optionals serveConfig.spa [
+      "--index"
+      "index.html"
+    ]
+    ++ [
+      "--interfaces"
+      serveConfig.host
+      "--port"
+      (toString serveConfig.port)
+    ]
+    ++ serveConfig.extraFlags
+    ++ [ "${staticSite}/${installDir}" ];
+  servePackage =
+    pkgs.runCommand "${pname}-serve"
+      {
+        nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
+        strictDeps = true;
+        meta = {
+          description = "Serve the ${pname} Svelte build on ${serveConfig.host}:${toString serveConfig.port}";
+          mainProgram = serveConfig.name;
+        };
+      }
+      ''
+        mkdir -p "$out/bin"
+        makeWrapper ${lib.getExe pkgs.miniserve} "$out/bin"/${lib.escapeShellArg serveConfig.name} \
+          --add-flags ${lib.escapeShellArg (lib.escapeShellArgs serveArgs)}
+      '';
+
+  devDefaults = {
+    enable = true;
+    name = "${pname}-dev";
+    script = "dev";
+    checkoutSubdir = null;
+    host = "127.0.0.1";
+    port = 5173;
+    autoInstall = true;
+    extraArgs = [ ];
+  };
+  devConfig = devDefaults // devServer;
+  devRunPrefix = manager.devRunCommandPrefix ++ [
+    devConfig.script
+    "--"
+  ];
+  devServerPackage = writeNushellApplication pkgs {
+    inherit (devConfig) name;
+    inherit (manager) runtimeInputs;
+    meta.description = "Run the ${pname} Svelte dev server from a mutable checkout";
+    text = ''
+      const checkout_subdir = ${builtins.toJSON devConfig.checkoutSubdir}
+      const install_argv = ${builtins.toJSON manager.devInstallCommand}
+      const run_prefix = ${builtins.toJSON devRunPrefix}
+      const auto_install = ${builtins.toJSON devConfig.autoInstall}
+      const extra_args = ${builtins.toJSON devConfig.extraArgs}
+
+      def project-root [explicit_root: any] {
+        if $explicit_root != null {
+          $explicit_root | path expand
+        } else {
+          let cwd = (pwd)
+          if ($checkout_subdir == null) or ($checkout_subdir == "") {
+            $cwd
+          } else {
+            let candidate = ($cwd | path join $checkout_subdir)
+            if ($candidate | path exists) { $candidate } else { $cwd }
+          }
+        }
+      }
+
+      def run-step [argv: list<string>] {
+        let command = ($argv | first)
+        let rest = ($argv | skip 1)
+        ^$command ...$rest
+      }
+
+      def main [
+        --root: path
+        --host: string = ${builtins.toJSON devConfig.host}
+        --port: int = ${toString devConfig.port}
+        --install
+        --skip-install
+        ...args: string
+      ] {
+        let root = (project-root $root)
+        cd $root
+
+        let package_json = ($root | path join "package.json")
+        if not ($package_json | path exists) {
+          error make { msg: $"no package.json found in ($root)" }
+        }
+
+        let node_modules = ($root | path join "node_modules")
+        if (not $skip_install) and ($install or ($auto_install and not ($node_modules | path exists))) {
+          run-step $install_argv
+        }
+
+        let dev_args = ["--host", $host, "--port", ($port | into string)] ++ $extra_args ++ $args
+        let argv = $run_prefix ++ $dev_args
+        let command = ($argv | first)
+        let rest = ($argv | skip 1)
+        exec $command ...$rest
+      }
+    '';
+  };
+
+  passthru =
+    (staticSite.passthru or { })
+    // {
+      inherit staticSite;
+    }
+    // lib.optionalAttrs serveConfig.enable {
+      serve = servePackage;
+    }
+    // lib.optionalAttrs devConfig.enable {
+      devServer = devServerPackage;
+    };
+in
+pkgs.symlinkJoin {
+  name = "${pname}-${version}";
+  paths = [
+    staticSite
+  ]
+  ++ lib.optional serveConfig.enable servePackage
+  ++ lib.optional devConfig.enable devServerPackage;
+  inherit passthru;
+  meta =
+    meta
+    // lib.optionalAttrs serveConfig.enable {
+      mainProgram = meta.mainProgram or serveConfig.name;
+    };
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -182,6 +182,9 @@ let
     inherit bunLockFor;
   };
   buildNpmSite = import ./build-npm-site.nix;
+  buildSvelteSite = import ./build-svelte-site.nix {
+    inherit bunLockFor writeNushellApplication;
+  };
   buildNpmVitest = import ./build-npm-vitest.nix;
   buildZigPackage = import ./build-zig-package.nix { };
   uvLockFor =
@@ -646,36 +649,72 @@ let
         goUnit = goUnitFor pkgs;
         rustWorkspace = rustWorkspaceFor pkgs;
       };
+      roomSiteSrc = lib.fileset.toSource {
+        root = paths.packages.room + "/site";
+        fileset = lib.fileset.intersection (lib.fileset.gitTracked (paths.packages.room + "/site")) (
+          lib.fileset.unions [
+            (paths.packages.room + "/site/package.json")
+            (paths.packages.room + "/site/package-lock.json")
+            (paths.packages.room + "/site/index.html")
+            (paths.packages.room + "/site/svelte.config.js")
+            (paths.packages.room + "/site/tsconfig.json")
+            (paths.packages.room + "/site/vite.config.ts")
+            (paths.packages.room + "/site/src")
+          ]
+        );
+      };
+      roomSite = buildSvelteSite pkgs {
+        pname = "room-site";
+        version = "0.1.0";
+        src = roomSiteSrc;
+        serve = {
+          name = "room-site";
+          port = 8081;
+        };
+        devServer = {
+          name = "room-site-dev";
+          checkoutSubdir = "packages/room/site";
+          port = 5174;
+        };
+      };
+      loopViewerSrc = lib.fileset.toSource {
+        root = paths.packages.loop + "/site";
+        fileset = lib.fileset.intersection (lib.fileset.gitTracked (paths.packages.loop + "/site")) (
+          lib.fileset.unions [
+            (paths.packages.loop + "/site/package.json")
+            (paths.packages.loop + "/site/package-lock.json")
+            (paths.packages.loop + "/site/index.html")
+            (paths.packages.loop + "/site/svelte.config.js")
+            (paths.packages.loop + "/site/tsconfig.json")
+            (paths.packages.loop + "/site/vite.config.ts")
+            (paths.packages.loop + "/site/src")
+          ]
+        );
+      };
+      loopViewer = buildSvelteSite pkgs {
+        pname = "loop-viewer";
+        version = "0.1.0";
+        src = loopViewerSrc;
+        serve = {
+          name = "loop-viewer";
+          port = 8082;
+        };
+        devServer = {
+          name = "loop-viewer-dev";
+          checkoutSubdir = "packages/loop/site";
+          port = 5175;
+        };
+      };
       basePackages = {
         dag-runner = pkgs.callPackage paths.packages.dagRunner {
           ix = ixForPackages;
         };
-        room =
-          let
-            roomSiteSrc = lib.fileset.toSource {
-              root = paths.packages.room + "/site";
-              fileset = lib.fileset.intersection (lib.fileset.gitTracked (paths.packages.room + "/site")) (
-                lib.fileset.unions [
-                  (paths.packages.room + "/site/package.json")
-                  (paths.packages.room + "/site/package-lock.json")
-                  (paths.packages.room + "/site/index.html")
-                  (paths.packages.room + "/site/svelte.config.js")
-                  (paths.packages.room + "/site/tsconfig.json")
-                  (paths.packages.room + "/site/vite.config.ts")
-                  (paths.packages.room + "/site/src")
-                ]
-              );
-            };
-            site = buildNpmSite pkgs {
-              pname = "room-site";
-              version = "0.1.0";
-              src = roomSiteSrc;
-            };
-          in
-          pkgs.callPackage paths.packages.room {
-            inherit pkgs site;
-            ix = ixForPackages;
-          };
+        room-site = roomSite;
+        room = pkgs.callPackage paths.packages.room {
+          inherit pkgs;
+          site = roomSite;
+          ix = ixForPackages;
+        };
         drgn = pkgs.callPackage paths.packages.drgn { };
         ix-fleet = pkgs.callPackage paths.packages.ixFleet {
           ix = ixForPackages;
@@ -690,32 +729,12 @@ let
           ix = ixForPackages;
         };
         llm-clippy = llmClippyFor pkgs;
-        loop =
-          let
-            loopSiteSrc = lib.fileset.toSource {
-              root = paths.packages.loop + "/site";
-              fileset = lib.fileset.intersection (lib.fileset.gitTracked (paths.packages.loop + "/site")) (
-                lib.fileset.unions [
-                  (paths.packages.loop + "/site/package.json")
-                  (paths.packages.loop + "/site/package-lock.json")
-                  (paths.packages.loop + "/site/index.html")
-                  (paths.packages.loop + "/site/svelte.config.js")
-                  (paths.packages.loop + "/site/tsconfig.json")
-                  (paths.packages.loop + "/site/vite.config.ts")
-                  (paths.packages.loop + "/site/src")
-                ]
-              );
-            };
-            viewer = buildNpmSite pkgs {
-              pname = "loop-viewer";
-              version = "0.1.0";
-              src = loopSiteSrc;
-            };
-          in
-          pkgs.callPackage paths.packages.loop {
-            inherit pkgs viewer;
-            ix = ixForPackages;
-          };
+        loop-viewer = loopViewer;
+        loop = pkgs.callPackage paths.packages.loop {
+          inherit pkgs;
+          viewer = loopViewer;
+          ix = ixForPackages;
+        };
         mc-probe = pkgs.callPackage paths.packages.minecraft.probe {
           ix = ixForPackages;
         };
@@ -838,6 +857,7 @@ let
       buildRustPackage
       buildNpmSite
       buildNpmVitest
+      buildSvelteSite
       buildUvApplication
       buildZigPackage
       cargoUnit
@@ -1106,6 +1126,7 @@ let
       buildGradleFatJar
       buildNpmSite
       buildNpmVitest
+      buildSvelteSite
       buildUvApplication
       buildZigPackage
       bunLockFor

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -191,42 +191,43 @@ let
     );
   };
 
-  siteBuild = ix.buildNpmSite pkgs {
+  siteBuild = ix.buildSvelteSite pkgs {
     pname = "ix-site";
     version = "0.1.0";
     src = siteSrc;
     distDir = "build";
+    serve.enable = false;
+    devServer = {
+      name = "ix-site-dev";
+      checkoutSubdir = "site";
+    };
   };
 
   # Local preview build: same source, but with the SvelteKit base path
   # cleared so miniserve can serve it from the URL root. The deployed
   # artifact (`siteBuild`) keeps the `/index` prefix for GitHub Pages.
-  sitePreviewBuild = ix.buildNpmSite pkgs {
+  sitePreviewBuild = ix.buildSvelteSite pkgs {
     pname = "ix-site-preview";
     version = "0.1.0";
     src = siteSrc;
     distDir = "build";
     preBuild = "export BASE_PATH=";
     installDir = "share/ix-site-preview";
+    serve.name = "ix-site";
+    devServer.enable = false;
   };
-
-  sitePreviewServe =
-    pkgs.runCommand "ix-site-serve"
-      {
-        nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
-      }
-      ''
-        mkdir -p $out/bin
-        makeWrapper ${lib.getExe pkgs.miniserve} $out/bin/ix-site \
-          --add-flags "--index index.html --interfaces 127.0.0.1 --port 8080 ${sitePreviewBuild}/share/ix-site-preview"
-      '';
 
   site = pkgs.symlinkJoin {
     name = "ix-site-0.1.0";
     paths = [
       siteBuild
-      sitePreviewServe
+      sitePreviewBuild
     ];
+    passthru = {
+      devServer = siteBuild.passthru.devServer;
+      preview = sitePreviewBuild;
+      static = siteBuild.passthru.staticSite;
+    };
     meta.mainProgram = "ix-site";
   };
 
@@ -365,6 +366,7 @@ in
       health-checks-loro = healthChecks.loro;
       health-checks-zellij = healthChecks.zellij;
       inherit lint loop site;
+      site-dev = site.passthru.devServer;
       agents-md = agentsMd;
       bench-filesystem = benchFilesystem;
       update-mods = updateMods;
@@ -376,6 +378,7 @@ in
         drgn
         ix-dev-diagnose
         ix-fleet
+        loop-viewer
         mc-probe
         minecraft-nbt
         minecraft-sync-managed
@@ -383,8 +386,11 @@ in
         nix-cargo-unit
         oci-image-builder
         run
+        room-site
         mcp
         ;
+      loop-viewer-dev = repoPackages.loop-viewer.passthru.devServer;
+      room-site-dev = repoPackages.room-site.passthru.devServer;
       minestom-hello-server-jar = repoPackages.minestom.helloServerJar;
       inherit (repoPackages) room;
     }

--- a/modules/services/resource-monitor/default.nix
+++ b/modules/services/resource-monitor/default.nix
@@ -84,11 +84,20 @@ let
     );
   };
 
-  site = ix.buildNpmSite pkgs {
+  site = ix.buildSvelteSite pkgs {
     pname = "resource-monitor-site";
     version = "0.1.0";
     src = siteSrc;
     preBuild = "cp ${pkgs.writeText "resource-monitor-vm-config.json" (builtins.toJSON metricConfig)} src/lib/vm-config.json";
+    serve = {
+      name = "resource-monitor-site";
+      port = 8083;
+    };
+    devServer = {
+      name = "resource-monitor-site-dev";
+      checkoutSubdir = "modules/services/resource-monitor/site";
+      port = 5176;
+    };
   };
 
   statsWriter = ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {

--- a/modules/services/resource-monitor/site/package.json
+++ b/modules/services/resource-monitor/site/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run check && npm run lint && vite build",
     "check": "svelte-check --tsconfig ./tsconfig.json",
-    "dev": "vite dev --host 127.0.0.1",
+    "dev": "vite dev",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/packages/loop/site/package.json
+++ b/packages/loop/site/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "dev": "vite dev",
     "build": "vite build",
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },

--- a/packages/room/site/package.json
+++ b/packages/room/site/package.json
@@ -1,6 +1,7 @@
 {
   "type": "module",
   "scripts": {
+    "dev": "vite dev",
     "build": "vite build",
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },

--- a/site/src/lib/updates/svelte-site-builder.svx
+++ b/site/src/lib/updates/svelte-site-builder.svx
@@ -1,0 +1,39 @@
+---
+id: svelte-site-builder
+postedAt: 2026-05-26T03:50:00-07:00
+title: "`ix.buildSvelteSite` packages Svelte builds, previews, and dev servers"
+tags: [interesting, nix, svelte, vite]
+links:
+  - label: Svelte builder
+    href: https://github.com/indexable-inc/index/tree/main/lib/build-svelte-site.nix
+  - label: Vite CLI
+    href: https://vite.dev/guide/cli
+  - label: OrbStack mounts
+    href: https://docs.orbstack.dev/docker/file-sharing
+---
+
+`ix.buildSvelteSite` is now the shared builder for the repo's Svelte/Vite surfaces: the docs site, room UI, loop viewer, and resource monitor site. It owns the locked production build, a static preview command, and a checkout dev-server command from one Nix call.
+
+```nix
+ix.buildSvelteSite pkgs {
+  pname = "room-site";
+  src = roomSiteSrc;
+  serve.port = 8081;
+  devServer = {
+    name = "room-site-dev";
+    checkoutSubdir = "packages/room/site";
+    port = 5174;
+  };
+}
+```
+
+The build still runs from a filtered, tracked source closure. The preview command serves the immutable output with `miniserve`, so `nix run .#room-site` or `nix run .#loop-viewer` exercises the same files the package embeds. The dev command runs from the mutable checkout instead:
+
+```bash
+nix run .#site-dev
+nix run .#room-site-dev -- --root packages/room/site --install
+```
+
+That split is deliberate. Vite's dev server writes dependency installs, caches, and HMR state, while Nix builds should stay pure and reproducible. The `-dev` wrappers install `node_modules` when missing, pass Vite's `--host` and `--port` flags, and leave ignored files in the checkout where editors and file watchers expect them.
+
+For OrbStack and VM workflows, the builder stops at the command boundary. OrbStack already provides macOS-to-Linux bind mounts, port forwarding, and faster Linux-side volumes for heavier dependency trees. When an ix shell workspace needs ignored files copied after a tracked source sync, `nix run .#ix-shell-sync-ignored -- <vm> <path>` streams only the git-ignored paths into `/work/ix`.

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -942,6 +942,26 @@ let
     ];
   };
 
+  svelteSite = ix.buildSvelteSite pkgs {
+    pname = "svelte-site-fixture";
+    version = "0.1.0";
+    src = npmSiteFixture;
+    buildFlags = [
+      "--class"
+      "ix svelte"
+    ];
+    serve = {
+      name = "svelte-site-fixture";
+      port = 8180;
+    };
+    devServer = {
+      name = "svelte-site-fixture-dev";
+      checkoutSubdir = "tests/fixtures/npm-site";
+      script = "build";
+      port = 5177;
+    };
+  };
+
   uvAppFixture = fs.toSource {
     root = ./fixtures/uv-app;
     fileset = fs.unions [
@@ -3407,6 +3427,9 @@ let
     test -d ${bunSite.bunNodeModules}/node_modules/clsx
     test -x ${bunSite.bunNodeModules.nodeCompat}/bin/node
     grep -q 'class="ix npm"' ${npmSite}/share/npm-site-fixture/index.html
+    grep -q 'class="ix svelte"' ${svelteSite}/share/svelte-site-fixture/index.html
+    test -x ${svelteSite}/bin/svelte-site-fixture
+    test -x ${svelteSite.passthru.devServer}/bin/svelte-site-fixture-dev
 
     ${uvApplication}/bin/uv-app-fixture > uv-app-fixture.out
     grep -q 'hello from uv app fixture' uv-app-fixture.out


### PR DESCRIPTION
## Summary

- add `ix.buildSvelteSite` for Svelte/Vite production builds, static previews, and mutable-checkout dev server wrappers
- move the docs site, room UI, loop viewer, and resource monitor site onto the shared helper
- expose runnable `site-dev`, `room-site`, `room-site-dev`, `loop-viewer`, and `loop-viewer-dev` packages, plus a site update documenting the OrbStack/VM dev-server boundary

## Checks

- `nix build .#site-dev .#room-site-dev .#loop-viewer-dev --no-link`
- `nix build .#room-site .#loop-viewer --no-link`
- `nix build .#checks.x86_64-linux.eval --no-link`
- `nix build .#site .#checks.x86_64-linux.site-test --no-link`
- `nix run .#lint`
