### PR TITLE
site: explain cargo-unit clippy sharing

### DIFF
--- a/site/src/lib/updates/cargo-unit-clippy-sharing.svx
+++ b/site/src/lib/updates/cargo-unit-clippy-sharing.svx
@@ -1,0 +1,27 @@
+---
+id: cargo-unit-clippy-sharing
+postedAt: 2026-05-26T04:22:46-07:00
+title: "`cargo-unit` shares clippy work across repo Rust packages"
+tags: [interesting, nix, rust, builder]
+links:
+  - label: Rust workspace wiring
+    href: https://github.com/indexable-inc/index/blob/main/lib/default.nix
+  - label: Cargo unit builder
+    href: https://github.com/indexable-inc/index/blob/main/lib/cargo-unit.nix
+  - label: Rust policy checks
+    href: https://github.com/indexable-inc/index/blob/main/lib/rust.nix
+---
+
+The Rust flake checks look busier than the builder really is: most package-level `cargoClippy` entries are labels for one shared workspace derivation. `rust-dag-runner-cargoClippy`, `rust-room-cargoClippy`, `rust-mcp-cargoClippy`, and the other repo-owned package checks resolve to the same `ix-rust-workspace-cargo-clippy.drv`.
+
+The derivation runs one Cargo command with one target directory:
+
+```bash
+cargo clippy --frozen --offline --workspace --all-targets -- \
+  -D warnings -D clippy::all -D clippy::pedantic -D clippy::nursery -D clippy::cargo \
+  -A clippy::multiple_crate_versions
+```
+
+That means a shared dependency such as `e` in an `a`, `b`, `c`, `d` workspace rides Cargo's normal unit sharing inside the single clippy run. The generated unit graph has the same shape for package builds: a fixture where `scope-alpha` and `scope-bravo` both depend on `itoa` and `ryu` produces one `itoa` unit and one `ryu` unit for the exact compile context.
+
+Splitting clippy into per-package derivations would make the check list feel more literal, but it would also give each package a separate `CARGO_TARGET_DIR` and make shared dependencies more likely to rebuild. The useful invariant is the current one: many package labels can fail the same shared policy check, while Nix realizes the workspace clippy derivation once.


### PR DESCRIPTION
## Summary
- document why the apparent per-package cargo clippy checks mostly share one workspace derivation
- include the evidence that repo-owned Rust package checks point at `ix-rust-workspace-cargo-clippy.drv`
- explain why splitting clippy into per-package derivations would likely rebuild shared dependencies more often

## Validation
- `nix build .#checks.x86_64-linux.site-test -L`
- `nix run .#lint`

## Investigation notes
- `rust-dag-runner-cargoClippy`, `rust-room-cargoClippy`, `rust-mcp-cargoClippy`, and the other repo-owned package clippy checks resolve to the same drv path.
- `nix derivation show` for that drv runs one `cargo clippy --workspace --all-targets` command with one `CARGO_TARGET_DIR`.
- A fixture with two workspace crates sharing `itoa` and `ryu` emits one exact unit for each shared dependency.
