### PR TITLE
room: sync state via loro crdt over websocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,8 +2446,6 @@ dependencies = [
  "clap",
  "futures",
  "loro",
- "serde",
- "serde_json",
  "tokio",
  "tower-http",
 ]
@@ -3130,7 +3128,6 @@ dependencies = [
  "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/packages/room/Cargo.toml
+++ b/packages/room/Cargo.toml
@@ -10,7 +10,5 @@ axum = { workspace = true, features = ["ws"] }
 clap = { workspace = true, features = ["derive", "env"] }
 futures.workspace = true
 loro.workspace = true
-serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
-tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
-tower-http = { workspace = true, features = ["fs", "trace"] }
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
+tower-http = { workspace = true, features = ["fs"] }

--- a/packages/room/site/package-lock.json
+++ b/packages/room/site/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
+        "loro-crdt": "^1.12.3",
         "svelte": "^5.39.8",
         "typescript": "^5.9.3",
         "vite": "^7.1.11"
@@ -1075,6 +1076,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "license": "MIT"
+    },
+    "node_modules/loro-crdt": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/loro-crdt/-/loro-crdt-1.12.3.tgz",
+      "integrity": "sha512-ZCeW0e/bo2lP4/zxSlVrJlMrX3hq9tXpeANbBDkdVS0bxoPHYx5Za3yS/A1+aWEFPJpzzI3Eac4K20cL9+BtXw==",
       "license": "MIT"
     },
     "node_modules/magic-string": {

--- a/packages/room/site/package.json
+++ b/packages/room/site/package.json
@@ -7,9 +7,10 @@
   },
   "dependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
-    "vite": "^7.1.11",
+    "loro-crdt": "^1.12.3",
     "svelte": "^5.39.8",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vite": "^7.1.11"
   },
   "devDependencies": {
     "svelte-check": "^4.3.2"

--- a/packages/room/site/src/App.svelte
+++ b/packages/room/site/src/App.svelte
@@ -47,6 +47,7 @@
   let socket: WebSocket | null = null;
   let reconnectTimer: number | null = null;
   let suppressMirror = false;
+  let destroyed = false;
 
   const unsubscribeDoc = doc.subscribe(() => {
     refreshFromDoc();
@@ -59,8 +60,11 @@
   });
 
   onDestroy(() => {
+    destroyed = true;
+    removeSelf();
     unsubscribeDoc();
     unsubscribeLocal();
+    window.removeEventListener('pagehide', removeSelf);
     if (reconnectTimer !== null) {
       window.clearTimeout(reconnectTimer);
     }
@@ -68,6 +72,7 @@
   });
 
   connect();
+  window.addEventListener('pagehide', removeSelf);
 
   $effect(() => {
     if (suppressMirror) {
@@ -91,11 +96,21 @@
     next.binaryType = 'arraybuffer';
     next.addEventListener('open', () => {
       connected = true;
-      publishSelf();
+      next.send(`room-id:${selfId}`);
+      publishSelf(true);
     });
     next.addEventListener('close', () => {
       connected = false;
-      reconnectTimer = window.setTimeout(connect, 1000);
+      if (socket === next) {
+        socket = null;
+      }
+      if (destroyed || reconnectTimer !== null) {
+        return;
+      }
+      reconnectTimer = window.setTimeout(() => {
+        reconnectTimer = null;
+        connect();
+      }, 1000);
     });
     next.addEventListener('message', (event) => {
       if (!(event.data instanceof ArrayBuffer)) {
@@ -110,7 +125,7 @@
     socket = next;
   }
 
-  function publishSelf() {
+  function publishSelf(force = false) {
     const previous = participants.get(selfId) as ParticipantRecord | undefined;
     const record: ParticipantRecord = {
       name,
@@ -121,7 +136,7 @@
       codexStatus: status,
       lastSeenMs: Date.now()
     };
-    if (previous && shallowEqualExceptLastSeen(previous, record)) {
+    if (!force && previous && shallowEqualExceptLastSeen(previous, record)) {
       return;
     }
     participants.set(selfId, record);
@@ -130,17 +145,18 @@
   }
 
   function refreshFromDoc() {
-    const snapshot = participants.toJSON() as Record<string, ParticipantRecord>;
+    const snapshot = participants.toJSON() as Record<string, unknown>;
     const next: ParticipantView[] = [];
-    for (const [id, record] of Object.entries(snapshot)) {
-      if (record && typeof record === 'object') {
+    for (const [id, value] of Object.entries(snapshot)) {
+      const record = parseParticipantRecord(value);
+      if (record) {
         next.push({ id, record });
       }
     }
     next.sort((a, b) => a.record.name.localeCompare(b.record.name));
     participantViews = next;
 
-    const mine = snapshot[selfId];
+    const mine = parseParticipantRecord(snapshot[selfId]);
     if (mine) {
       suppressMirror = true;
       try {
@@ -177,6 +193,42 @@
       left.codexTask === right.codexTask &&
       left.codexStatus === right.codexStatus
     );
+  }
+
+  function removeSelf() {
+    participants.delete(selfId);
+    doc.commit();
+  }
+
+  function parseParticipantRecord(value: unknown): ParticipantRecord | null {
+    if (!value || typeof value !== 'object') {
+      return null;
+    }
+    const record = value as Record<string, unknown>;
+    if (
+      typeof record.name !== 'string' ||
+      typeof record.color !== 'string' ||
+      typeof record.focus !== 'string' ||
+      typeof record.draft !== 'string' ||
+      typeof record.codexTask !== 'string' ||
+      !isAgentStatus(record.codexStatus) ||
+      typeof record.lastSeenMs !== 'number'
+    ) {
+      return null;
+    }
+    return {
+      name: record.name,
+      color: record.color,
+      focus: record.focus,
+      draft: record.draft,
+      codexTask: record.codexTask,
+      codexStatus: record.codexStatus,
+      lastSeenMs: record.lastSeenMs
+    };
+  }
+
+  function isAgentStatus(value: unknown): value is AgentStatus {
+    return typeof value === 'string' && statuses.includes(value as AgentStatus);
   }
 
   function hash(value: string) {

--- a/packages/room/site/src/App.svelte
+++ b/packages/room/site/src/App.svelte
@@ -1,93 +1,182 @@
 <script lang="ts">
+  import { LoroDoc } from 'loro-crdt';
+  import { onDestroy } from 'svelte';
+
   type AgentStatus = 'idle' | 'thinking' | 'editing' | 'reviewing' | 'blocked';
 
-  type Participant = {
-    id: string;
+  type ParticipantRecord = {
     name: string;
     color: string;
     focus: string;
     draft: string;
-    codex: {
-      task: string;
-      status: AgentStatus;
-    };
+    codexTask: string;
+    codexStatus: AgentStatus;
     lastSeenMs: number;
   };
 
-  type SnapshotEvent = {
-    type: 'snapshot';
-    state: {
-      participants: Record<string, Participant>;
-    };
+  type ParticipantView = {
+    id: string;
+    record: ParticipantRecord;
   };
 
   const colors = ['#2f80ed', '#15a46e', '#c05621', '#8b5cf6', '#d12b6a'];
   const statuses: AgentStatus[] = ['idle', 'thinking', 'editing', 'reviewing', 'blocked'];
-  const savedId = localStorage.getItem('room-id');
-  const selfId = savedId ?? crypto.randomUUID();
-  localStorage.setItem('room-id', selfId);
+
+  const selfId = (() => {
+    const saved = localStorage.getItem('room-id');
+    if (saved) {
+      return saved;
+    }
+    const fresh = crypto.randomUUID();
+    localStorage.setItem('room-id', fresh);
+    return fresh;
+  })();
+
+  const doc = new LoroDoc();
+  const participants = doc.getMap('participants');
+
+  let connected = $state(false);
+  let participantViews = $state<ParticipantView[]>([]);
+  let name = $state(localStorage.getItem('room-name') ?? 'Teammate');
+  let color = $state(colors[Math.abs(hash(selfId)) % colors.length]);
+  let focus = $state('overview');
+  let draft = $state('');
+  let task = $state('reviewing the current branch');
+  let status = $state<AgentStatus>('thinking');
 
   let socket: WebSocket | null = null;
-  let connected = false;
-  let name = localStorage.getItem('room-name') ?? 'Teammate';
-  let color = colors[Math.abs(hash(selfId)) % colors.length];
-  let focus = 'overview';
-  let draft = '';
-  let task = 'reviewing the current branch';
-  let status: AgentStatus = 'thinking';
-  let participants: Participant[] = [];
+  let reconnectTimer: number | null = null;
+  let suppressMirror = false;
 
-  $: self = participants.find((participant) => participant.id === selfId);
-  $: others = participants.filter((participant) => participant.id !== selfId);
+  const unsubscribeDoc = doc.subscribe(() => {
+    refreshFromDoc();
+  });
+
+  const unsubscribeLocal = doc.subscribeLocalUpdates((bytes) => {
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.send(bytes);
+    }
+  });
+
+  onDestroy(() => {
+    unsubscribeDoc();
+    unsubscribeLocal();
+    if (reconnectTimer !== null) {
+      window.clearTimeout(reconnectTimer);
+    }
+    socket?.close();
+  });
 
   connect();
 
+  $effect(() => {
+    if (suppressMirror) {
+      return;
+    }
+    void name;
+    void color;
+    void focus;
+    void draft;
+    void task;
+    void status;
+    publishSelf();
+  });
+
+  const selfRecord = $derived(participantViews.find((view) => view.id === selfId)?.record);
+  const otherViews = $derived(participantViews.filter((view) => view.id !== selfId));
+
   function connect() {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    socket = new WebSocket(`${protocol}//${window.location.host}/ws`);
-    socket.addEventListener('open', () => {
+    const next = new WebSocket(`${protocol}//${window.location.host}/ws`);
+    next.binaryType = 'arraybuffer';
+    next.addEventListener('open', () => {
       connected = true;
-      sendPresence();
-      sendCodex();
-      sendFocus();
-      sendDraft();
+      publishSelf();
     });
-    socket.addEventListener('close', () => {
+    next.addEventListener('close', () => {
       connected = false;
-      window.setTimeout(connect, 1000);
+      reconnectTimer = window.setTimeout(connect, 1000);
     });
-    socket.addEventListener('message', (message) => {
-      const event = JSON.parse(message.data) as SnapshotEvent;
-      if (event.type === 'snapshot') {
-        participants = Object.values(event.state.participants).sort((left, right) =>
-          left.name.localeCompare(right.name)
-        );
+    next.addEventListener('message', (event) => {
+      if (!(event.data instanceof ArrayBuffer)) {
+        return;
+      }
+      try {
+        doc.import(new Uint8Array(event.data));
+      } catch {
+        // Skip frames the server sent before our state caught up.
       }
     });
-    window.addEventListener('beforeunload', () => send({ type: 'leave', id: selfId }));
+    socket = next;
   }
 
-  function send(event: object) {
-    if (socket?.readyState === WebSocket.OPEN) {
-      socket.send(JSON.stringify(event));
+  function publishSelf() {
+    const previous = participants.get(selfId) as ParticipantRecord | undefined;
+    const record: ParticipantRecord = {
+      name,
+      color,
+      focus,
+      draft,
+      codexTask: task,
+      codexStatus: status,
+      lastSeenMs: Date.now()
+    };
+    if (previous && shallowEqualExceptLastSeen(previous, record)) {
+      return;
+    }
+    participants.set(selfId, record);
+    doc.commit();
+    localStorage.setItem('room-name', name);
+  }
+
+  function refreshFromDoc() {
+    const snapshot = participants.toJSON() as Record<string, ParticipantRecord>;
+    const next: ParticipantView[] = [];
+    for (const [id, record] of Object.entries(snapshot)) {
+      if (record && typeof record === 'object') {
+        next.push({ id, record });
+      }
+    }
+    next.sort((a, b) => a.record.name.localeCompare(b.record.name));
+    participantViews = next;
+
+    const mine = snapshot[selfId];
+    if (mine) {
+      suppressMirror = true;
+      try {
+        if (mine.name !== name) {
+          name = mine.name;
+        }
+        if (mine.color !== color) {
+          color = mine.color;
+        }
+        if (mine.focus !== focus) {
+          focus = mine.focus;
+        }
+        if (mine.draft !== draft) {
+          draft = mine.draft;
+        }
+        if (mine.codexTask !== task) {
+          task = mine.codexTask;
+        }
+        if (mine.codexStatus !== status) {
+          status = mine.codexStatus;
+        }
+      } finally {
+        suppressMirror = false;
+      }
     }
   }
 
-  function sendPresence() {
-    localStorage.setItem('room-name', name);
-    send({ type: 'presence', id: selfId, name, color });
-  }
-
-  function sendFocus() {
-    send({ type: 'focus', id: selfId, focus });
-  }
-
-  function sendDraft() {
-    send({ type: 'draft', id: selfId, draft });
-  }
-
-  function sendCodex() {
-    send({ type: 'codex', id: selfId, task, status });
+  function shallowEqualExceptLastSeen(left: ParticipantRecord, right: ParticipantRecord) {
+    return (
+      left.name === right.name &&
+      left.color === right.color &&
+      left.focus === right.focus &&
+      left.draft === right.draft &&
+      left.codexTask === right.codexTask &&
+      left.codexStatus === right.codexStatus
+    );
   }
 
   function hash(value: string) {
@@ -99,25 +188,27 @@
   <section class="toolbar">
     <div>
       <h1>Room</h1>
-      <p>{connected ? 'live multiplayer session' : 'reconnecting'}</p>
+      <p>{connected ? 'live Loro session' : 'reconnecting'}</p>
     </div>
     <label>
       <span>Name</span>
-      <input bind:value={name} on:input={sendPresence} />
+      <input bind:value={name} />
     </label>
   </section>
 
   <section class="workspace">
     <aside>
       <div class="panel-title">Team</div>
-      {#each participants as participant}
-        <article class:self={participant.id === selfId}>
-          <div class="avatar" style={`background:${participant.color}`}>{participant.name.slice(0, 1)}</div>
-          <div>
-            <strong>{participant.name}</strong>
-            <span>{participant.focus}</span>
+      {#each participantViews as view (view.id)}
+        <article class:self={view.id === selfId}>
+          <div class="avatar" style={`background:${view.record.color}`}>
+            {view.record.name.slice(0, 1)}
           </div>
-          <small>{participant.codex.status}</small>
+          <div>
+            <strong>{view.record.name}</strong>
+            <span>{view.record.focus}</span>
+          </div>
+          <small>{view.record.codexStatus}</small>
         </article>
       {/each}
     </aside>
@@ -126,16 +217,16 @@
       <div class="field-grid">
         <label>
           <span>Viewing</span>
-          <input bind:value={focus} on:input={sendFocus} placeholder="packages/room/src/main.rs" />
+          <input bind:value={focus} placeholder="packages/room/src/main.rs" />
         </label>
         <label>
           <span>Codex task</span>
-          <input bind:value={task} on:input={sendCodex} />
+          <input bind:value={task} />
         </label>
         <label>
           <span>Status</span>
-          <select bind:value={status} on:change={sendCodex}>
-            {#each statuses as item}
+          <select bind:value={status}>
+            {#each statuses as item (item)}
               <option value={item}>{item}</option>
             {/each}
           </select>
@@ -144,23 +235,23 @@
 
       <label class="draft">
         <span>Typing</span>
-        <textarea bind:value={draft} on:input={sendDraft} placeholder="Share the prompt or note you are composing."></textarea>
+        <textarea bind:value={draft} placeholder="Share the prompt or note you are composing."></textarea>
       </label>
 
       <div class="board">
-        {#if self}
+        {#if selfRecord}
           <div class="lane active">
             <span class="eyebrow">You</span>
-            <h2>{self.codex.task}</h2>
-            <p>{self.draft || 'No draft text yet.'}</p>
+            <h2>{selfRecord.codexTask}</h2>
+            <p>{selfRecord.draft || 'No draft text yet.'}</p>
           </div>
         {/if}
-        {#each others as participant}
+        {#each otherViews as view (view.id)}
           <div class="lane">
-            <span class="eyebrow" style={`color:${participant.color}`}>{participant.name}</span>
-            <h2>{participant.codex.task}</h2>
-            <p>{participant.draft || `${participant.name} is not typing right now.`}</p>
-            <footer>{participant.focus}</footer>
+            <span class="eyebrow" style={`color:${view.record.color}`}>{view.record.name}</span>
+            <h2>{view.record.codexTask}</h2>
+            <p>{view.record.draft || `${view.record.name} is not typing right now.`}</p>
+            <footer>{view.record.focus}</footer>
           </div>
         {/each}
       </div>

--- a/packages/room/src/main.rs
+++ b/packages/room/src/main.rs
@@ -1,9 +1,10 @@
 use std::{
-    collections::BTreeMap,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
-    sync::Arc,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use anyhow::Context;
@@ -18,14 +19,12 @@ use axum::{
 };
 use clap::Parser;
 use futures::{SinkExt, StreamExt};
-use loro::LoroDoc;
-use serde::{Deserialize, Serialize};
-use serde_json::json;
+use loro::{ExportMode, LoroDoc};
 use tokio::sync::{Mutex, broadcast};
 use tower_http::services::{ServeDir, ServeFile};
 
 #[derive(Parser, Debug)]
-#[command(about = "Serve a multiplayer team room")]
+#[command(about = "Serve a multiplayer team room backed by a Loro CRDT document")]
 struct Args {
     #[arg(long, env = "ROOM_HOST", default_value_t = IpAddr::V4(Ipv4Addr::UNSPECIFIED))]
     host: IpAddr,
@@ -39,90 +38,33 @@ struct Args {
 
 #[derive(Clone)]
 struct AppState {
-    room: Arc<Mutex<RoomState>>,
     doc: Arc<Mutex<LoroDoc>>,
-    events: broadcast::Sender<ServerEvent>,
+    updates: broadcast::Sender<Broadcast>,
 }
 
-#[derive(Default, Serialize, Clone)]
-#[serde(rename_all = "camelCase")]
-struct RoomState {
-    participants: BTreeMap<String, Participant>,
+#[derive(Clone)]
+struct Broadcast {
+    // Connection that produced the update. Receivers skip frames they sent
+    // themselves so a client's own edit is not echoed back across the wire.
+    origin: u64,
+    bytes: Arc<[u8]>,
 }
 
-#[derive(Serialize, Clone)]
-#[serde(rename_all = "camelCase")]
-struct Participant {
-    id: String,
-    name: String,
-    color: String,
-    focus: String,
-    draft: String,
-    codex: CodexStatus,
-    last_seen_ms: u128,
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-struct CodexStatus {
-    task: String,
-    status: AgentStatus,
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all = "kebab-case")]
-enum AgentStatus {
-    Idle,
-    Thinking,
-    Editing,
-    Reviewing,
-    Blocked,
-}
-
-#[derive(Deserialize, Serialize)]
-#[serde(tag = "type", rename_all = "kebab-case")]
-enum ClientEvent {
-    Presence {
-        id: String,
-        name: String,
-        color: String,
-    },
-    Focus {
-        id: String,
-        focus: String,
-    },
-    Draft {
-        id: String,
-        draft: String,
-    },
-    Codex {
-        id: String,
-        task: String,
-        status: AgentStatus,
-    },
-    Leave {
-        id: String,
-    },
-}
-
-#[derive(Serialize, Clone)]
-#[serde(tag = "type", rename_all = "kebab-case")]
-enum ServerEvent {
-    Snapshot { state: RoomState },
-}
+static NEXT_CLIENT_ID: AtomicU64 = AtomicU64::new(1);
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let site_dir = args.site_dir.or_else(|| std::env::var_os("ROOM_SITE_DIR").map(PathBuf::from));
     let site_dir = site_dir.context("set --site-dir or ROOM_SITE_DIR to the built Svelte site")?;
-    let (events, _) = broadcast::channel(128);
     let doc = LoroDoc::new();
+    // Server peer id is fixed; clients pick their own random peer id so concurrent
+    // ops from different sessions do not collide.
     doc.set_peer_id(1).context("failed to set room document peer id")?;
+    let (updates, _) = broadcast::channel(256);
     let state = AppState {
-        room: Arc::new(Mutex::new(RoomState::default())),
         doc: Arc::new(Mutex::new(doc)),
-        events,
+        updates,
     };
     let index = site_dir.join("index.html");
     let app = Router::new()
@@ -145,117 +87,50 @@ async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl
 }
 
 async fn handle_socket(socket: WebSocket, state: AppState) {
+    let client_id = NEXT_CLIENT_ID.fetch_add(1, Ordering::Relaxed);
     let (mut sender, mut receiver) = socket.split();
-    let mut events = state.events.subscribe();
-    send_snapshot(&state).await;
 
+    let snapshot = {
+        let doc = state.doc.lock().await;
+        doc.export(ExportMode::Snapshot)
+    };
+    let Ok(snapshot) = snapshot else {
+        return;
+    };
+    if sender.send(Message::Binary(snapshot.into())).await.is_err() {
+        return;
+    }
+
+    let mut updates = state.updates.subscribe();
     let send_task = tokio::spawn(async move {
-        while let Ok(event) = events.recv().await {
-            let Ok(text) = serde_json::to_string(&event) else {
+        while let Ok(broadcast) = updates.recv().await {
+            if broadcast.origin == client_id {
                 continue;
-            };
-            if sender.send(Message::Text(text.into())).await.is_err() {
+            }
+            let payload = broadcast.bytes.as_ref().to_vec();
+            if sender.send(Message::Binary(payload.into())).await.is_err() {
                 break;
             }
         }
     });
 
     while let Some(Ok(message)) = receiver.next().await {
-        if let Message::Text(text) = message {
-            let Ok(event) = serde_json::from_str::<ClientEvent>(&text) else {
+        let Message::Binary(bytes) = message else {
+            continue;
+        };
+        {
+            let doc = state.doc.lock().await;
+            if doc.import(&bytes).is_err() {
                 continue;
-            };
-            apply_event(&state, event).await;
+            }
         }
+        let _ = state.updates.send(Broadcast {
+            origin: client_id,
+            bytes: Arc::from(bytes.as_ref()),
+        });
     }
 
     send_task.abort();
-}
-
-async fn apply_event(state: &AppState, event: ClientEvent) {
-    record_event(state, &event).await;
-
-    let mut room = state.room.lock().await;
-    match event {
-        ClientEvent::Presence { id, name, color } => {
-            room.participants
-                .entry(id.clone())
-                .and_modify(|participant| {
-                    participant.name.clone_from(&name);
-                    participant.color.clone_from(&color);
-                    participant.last_seen_ms = now_ms();
-                })
-                .or_insert_with(|| Participant {
-                    id,
-                    name,
-                    color,
-                    focus: "overview".to_owned(),
-                    draft: String::new(),
-                    codex: CodexStatus {
-                        task: "waiting for a task".to_owned(),
-                        status: AgentStatus::Idle,
-                    },
-                    last_seen_ms: now_ms(),
-                });
-        }
-        ClientEvent::Focus { id, focus } => {
-            if let Some(participant) = room.participants.get_mut(&id) {
-                participant.focus = focus;
-                participant.last_seen_ms = now_ms();
-            }
-        }
-        ClientEvent::Draft { id, draft } => {
-            if let Some(participant) = room.participants.get_mut(&id) {
-                participant.draft = draft;
-                participant.last_seen_ms = now_ms();
-            }
-        }
-        ClientEvent::Codex { id, task, status } => {
-            if let Some(participant) = room.participants.get_mut(&id) {
-                participant.codex = CodexStatus { task, status };
-                participant.last_seen_ms = now_ms();
-            }
-        }
-        ClientEvent::Leave { id } => {
-            room.participants.remove(&id);
-        }
-    }
-
-    let _ = state.events.send(ServerEvent::Snapshot {
-        state: room.clone(),
-    });
-}
-
-async fn record_event(state: &AppState, event: &ClientEvent) {
-    let Ok(value) = serde_json::to_value(event) else {
-        return;
-    };
-    let doc = state.doc.lock().await;
-    let events = doc.get_list("events");
-    if events
-        .insert(
-            events.len(),
-            json!({
-                "atMs": now_ms(),
-                "event": value,
-            }),
-        )
-        .is_ok()
-    {
-        doc.commit();
-    }
-}
-
-async fn send_snapshot(state: &AppState) {
-    let room = state.room.lock().await.clone();
-    let _ = state.events.send(ServerEvent::Snapshot { state: room });
-}
-
-fn now_ms() -> u128 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or(Duration::ZERO)
-        .as_millis()
 }
 
 async fn shutdown_signal() {

--- a/packages/room/src/main.rs
+++ b/packages/room/src/main.rs
@@ -20,8 +20,10 @@ use axum::{
 use clap::Parser;
 use futures::{SinkExt, StreamExt};
 use loro::{ExportMode, LoroDoc};
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::{Mutex, broadcast, broadcast::error::RecvError};
 use tower_http::services::{ServeDir, ServeFile};
+
+const HELLO_PREFIX: &str = "room-id:";
 
 #[derive(Parser, Debug)]
 #[command(about = "Serve a multiplayer team room backed by a Loro CRDT document")]
@@ -55,12 +57,15 @@ static NEXT_CLIENT_ID: AtomicU64 = AtomicU64::new(1);
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-    let site_dir = args.site_dir.or_else(|| std::env::var_os("ROOM_SITE_DIR").map(PathBuf::from));
+    let site_dir = args
+        .site_dir
+        .or_else(|| std::env::var_os("ROOM_SITE_DIR").map(PathBuf::from));
     let site_dir = site_dir.context("set --site-dir or ROOM_SITE_DIR to the built Svelte site")?;
     let doc = LoroDoc::new();
     // Server peer id is fixed; clients pick their own random peer id so concurrent
     // ops from different sessions do not collide.
-    doc.set_peer_id(1).context("failed to set room document peer id")?;
+    doc.set_peer_id(1)
+        .context("failed to set room document peer id")?;
     let (updates, _) = broadcast::channel(256);
     let state = AppState {
         doc: Arc::new(Mutex::new(doc)),
@@ -89,6 +94,8 @@ async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl
 async fn handle_socket(socket: WebSocket, state: AppState) {
     let client_id = NEXT_CLIENT_ID.fetch_add(1, Ordering::Relaxed);
     let (mut sender, mut receiver) = socket.split();
+    let mut updates = state.updates.subscribe();
+    let mut participant_id: Option<String> = None;
 
     let snapshot = {
         let doc = state.doc.lock().await;
@@ -101,22 +108,46 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
         return;
     }
 
-    let mut updates = state.updates.subscribe();
+    let doc = Arc::clone(&state.doc);
     let send_task = tokio::spawn(async move {
-        while let Ok(broadcast) = updates.recv().await {
-            if broadcast.origin == client_id {
-                continue;
-            }
-            let payload = broadcast.bytes.as_ref().to_vec();
-            if sender.send(Message::Binary(payload.into())).await.is_err() {
-                break;
+        loop {
+            match updates.recv().await {
+                Ok(broadcast) => {
+                    if broadcast.origin == client_id {
+                        continue;
+                    }
+                    let payload = broadcast.bytes.as_ref().to_vec();
+                    if sender.send(Message::Binary(payload.into())).await.is_err() {
+                        break;
+                    }
+                }
+                Err(RecvError::Lagged(_)) => {
+                    let snapshot = {
+                        let doc = doc.lock().await;
+                        doc.export(ExportMode::Snapshot)
+                    };
+                    let Ok(snapshot) = snapshot else {
+                        break;
+                    };
+                    if sender.send(Message::Binary(snapshot.into())).await.is_err() {
+                        break;
+                    }
+                }
+                Err(RecvError::Closed) => break,
             }
         }
     });
 
     while let Some(Ok(message)) = receiver.next().await {
-        let Message::Binary(bytes) = message else {
-            continue;
+        let bytes = match message {
+            Message::Binary(bytes) => bytes,
+            Message::Text(text) => {
+                if participant_id.is_none() {
+                    participant_id = parse_participant_id(&text);
+                }
+                continue;
+            }
+            _ => continue,
         };
         {
             let doc = state.doc.lock().await;
@@ -131,6 +162,40 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
     }
 
     send_task.abort();
+    if let Some(participant_id) = participant_id {
+        remove_participant(&state, client_id, &participant_id).await;
+    }
+}
+
+fn parse_participant_id(text: &str) -> Option<String> {
+    let id = text.strip_prefix(HELLO_PREFIX)?;
+    let is_safe = !id.is_empty()
+        && id.len() <= 128
+        && id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'));
+    is_safe.then(|| id.to_owned())
+}
+
+async fn remove_participant(state: &AppState, client_id: u64, participant_id: &str) {
+    let snapshot = {
+        let doc = state.doc.lock().await;
+        let participants = doc.get_map("participants");
+        if participants.get(participant_id).is_none()
+            || participants.delete(participant_id).is_err()
+        {
+            return;
+        }
+        doc.commit();
+        doc.export(ExportMode::Snapshot)
+    };
+    let Ok(snapshot) = snapshot else {
+        return;
+    };
+    let _ = state.updates.send(Broadcast {
+        origin: client_id,
+        bytes: Arc::from(snapshot),
+    });
 }
 
 async fn shutdown_signal() {
@@ -140,7 +205,9 @@ async fn shutdown_signal() {
 
     #[cfg(unix)]
     let terminate = async {
-        if let Ok(mut signal) = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+        if let Ok(mut signal) =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        {
             signal.recv().await;
         }
     };


### PR DESCRIPTION
Replace the room presence protocol with real two-way Loro CRDT sync.

- Server sends the full doc snapshot on each `/ws` connect, then relays every incoming update to the other connected peers. The bespoke `ClientEvent` / `ServerEvent` JSON wire format is gone; `Cargo.toml` drops `serde`, `serde_json`, the `time` tokio feature, and the unused `trace` tower-http feature.
- Svelte client holds its own `LoroDoc` (`loro-crdt@^1.12.3`), wires `subscribeLocalUpdates` straight into the WebSocket, imports incoming binary frames, and mirrors the `participants` map into reactive state. Each participant edits their own record; LWW resolves any field-level collisions.
- Smoke-tested with `nix build .#room` + a live server: snapshot frame delivered on connect, assets and `index.html` served, edits round-trip without console errors.
