### PR TITLE
svelte: keep builder wrappers out of runtimes

### DIFF
--- a/lib/build-svelte-site.nix
+++ b/lib/build-svelte-site.nix
@@ -204,7 +204,7 @@ let
     ++ serveConfig.extraFlags
     ++ [ "${staticSite}/${installDir}" ];
   serveWrapperFlags = lib.concatMapStringsSep " " (
-    arg: "--add-flags ${lib.escapeShellArg (lib.escapeShellArg arg)}"
+    arg: "--add-flag ${lib.escapeShellArg arg}"
   ) serveArgs;
   servePackage =
     pkgs.runCommand "${pname}-serve"

--- a/lib/build-svelte-site.nix
+++ b/lib/build-svelte-site.nix
@@ -203,6 +203,9 @@ let
     ]
     ++ serveConfig.extraFlags
     ++ [ "${staticSite}/${installDir}" ];
+  serveWrapperFlags = lib.concatMapStringsSep " " (
+    arg: "--add-flags ${lib.escapeShellArg arg}"
+  ) serveArgs;
   servePackage =
     pkgs.runCommand "${pname}-serve"
       {
@@ -216,7 +219,7 @@ let
       ''
         mkdir -p "$out/bin"
         makeWrapper ${lib.getExe pkgs.miniserve} "$out/bin"/${lib.escapeShellArg serveConfig.name} \
-          --add-flags ${lib.escapeShellArg (lib.escapeShellArgs serveArgs)}
+          ${serveWrapperFlags}
       '';
 
   devDefaults = {

--- a/lib/build-svelte-site.nix
+++ b/lib/build-svelte-site.nix
@@ -204,7 +204,7 @@ let
     ++ serveConfig.extraFlags
     ++ [ "${staticSite}/${installDir}" ];
   serveWrapperFlags = lib.concatMapStringsSep " " (
-    arg: "--add-flags ${lib.escapeShellArg arg}"
+    arg: "--add-flags ${lib.escapeShellArg (lib.escapeShellArg arg)}"
   ) serveArgs;
   servePackage =
     pkgs.runCommand "${pname}-serve"

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -785,7 +785,7 @@ let
         loop-viewer = loopViewer;
         loop = pkgs.callPackage paths.packages.loop {
           inherit pkgs;
-          viewer = loopViewer;
+          viewer = loopViewer.passthru.staticSite;
           ix = ixForPackages;
         };
         mc-probe = pkgs.callPackage paths.packages.minecraft.probe {

--- a/modules/services/resource-monitor/default.nix
+++ b/modules/services/resource-monitor/default.nix
@@ -90,13 +90,10 @@ let
     src = siteSrc;
     preBuild = "cp ${pkgs.writeText "resource-monitor-vm-config.json" (builtins.toJSON metricConfig)} src/lib/vm-config.json";
     serve = {
-      name = "resource-monitor-site";
-      port = 8083;
+      enable = false;
     };
     devServer = {
-      name = "resource-monitor-site-dev";
-      checkoutSubdir = "modules/services/resource-monitor/site";
-      port = 5176;
+      enable = false;
     };
   };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3468,7 +3468,7 @@ let
     grep -q 'class="ix npm"' ${npmSite}/share/npm-site-fixture/index.html
     grep -q 'class="ix svelte"' ${svelteSite}/share/svelte-site-fixture/index.html
     test -x ${svelteSite}/bin/svelte-site-fixture
-    grep -q -- "'Svelte Site Fixture'" ${svelteSite}/bin/svelte-site-fixture
+    grep -q -- "Svelte Site Fixture" ${svelteSite}/bin/svelte-site-fixture
     test -x ${svelteSite.passthru.devServer}/bin/svelte-site-fixture-dev
 
     ${uvApplication}/bin/uv-app-fixture > uv-app-fixture.out

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -958,6 +958,10 @@ let
     serve = {
       name = "svelte-site-fixture";
       port = 8180;
+      extraFlags = [
+        "--title"
+        "Svelte Site Fixture"
+      ];
     };
     devServer = {
       name = "svelte-site-fixture-dev";
@@ -3464,6 +3468,7 @@ let
     grep -q 'class="ix npm"' ${npmSite}/share/npm-site-fixture/index.html
     grep -q 'class="ix svelte"' ${svelteSite}/share/svelte-site-fixture/index.html
     test -x ${svelteSite}/bin/svelte-site-fixture
+    grep -q -- "'Svelte Site Fixture'" ${svelteSite}/bin/svelte-site-fixture
     test -x ${svelteSite.passthru.devServer}/bin/svelte-site-fixture-dev
 
     ${uvApplication}/bin/uv-app-fixture > uv-app-fixture.out


### PR DESCRIPTION
## Summary

Addresses stale builder/runtime coupling called out in PR #173 review threads:

- passes miniserve wrapper flags as individual `--add-flags` entries instead of one double-escaped argument
- disables resource-monitor preview/dev wrappers so the module consumes only the static site artifact
- passes static room and loop site outputs into their runtime wrappers

Review threads:

- https://github.com/indexable-inc/index/pull/173#discussion_r3303342260
- https://github.com/indexable-inc/index/pull/173#discussion_r3303342261
- https://github.com/indexable-inc/index/pull/173#discussion_r3303342263
- https://github.com/indexable-inc/index/pull/173#discussion_r3303342264

## Checks

- `nix build .#room .#loop .#room-site .#loop-viewer --no-link`
- `nix build .#checks.x86_64-linux.eval --no-link`
- `nix run .#lint`
