### PR TITLE
site: correct update examples

### DIFF
--- a/site/src/lib/updates/agents-md-fragments.svx
+++ b/site/src/lib/updates/agents-md-fragments.svx
@@ -22,6 +22,6 @@ lib.agentsMd.render {
 Sibling repos can pull in shared guidance instead of copy-pasting it. The ix repo already publishes its agnostic sections through the same API and this repo imports them at the top of the render pipeline.
 
 ```bash
-nix run   github:indexable-inc/index#agents-md   # writes AGENTS.md
-nix flake check github:indexable-inc/index#agents-md-up-to-date
+nix run .#agents-md   # writes AGENTS.md
+nix flake check .#agents-md-up-to-date
 ```

--- a/site/src/lib/updates/ai-review-gate.svx
+++ b/site/src/lib/updates/ai-review-gate.svx
@@ -55,4 +55,4 @@ The structured output keeps each finding mechanically actionable: `title`, `body
 }
 ```
 
-Branch protection requires the `ai review approved` check, which only passes when the reviewer returns a well-formed JSON document and votes `patch is correct`. Missing or malformed output fails closed.
+Direct users can require the `ai review approved` check. Reusable-workflow callers should require GitHub's called-job check name, such as `ai-review-gate / ai review approved` for the example above. The gate only passes when the reviewer returns a well-formed JSON document and votes `patch is correct`; missing or malformed output fails closed.

--- a/site/src/lib/updates/ix-mcp-python.svx
+++ b/site/src/lib/updates/ix-mcp-python.svx
@@ -39,12 +39,19 @@ This pairs naturally with `nix run .#run`. After recording a slow build, the age
 ```python
 python_exec(source="""
 import polars as pl
+
+nix_event_dtype = pl.Struct([
+    pl.Field("action", pl.String),
+    pl.Field("id", pl.Int64),
+    pl.Field("text", pl.String),
+    pl.Field("type", pl.Int64),
+])
 events = (
     pl.read_ndjson(".ix/run/latest/lines.jsonl")
       .filter(pl.col("text").str.starts_with("@nix "))
       .select(
           "ended_elapsed_ns",
-          pl.col("text").str.slice(5).str.json_decode().alias("event"),
+          pl.col("text").str.slice(5).str.json_decode(nix_event_dtype).alias("event"),
       )
       .unnest("event")
 )

--- a/site/src/lib/updates/run-recorder.svx
+++ b/site/src/lib/updates/run-recorder.svx
@@ -48,12 +48,20 @@ The same shape works for any structured event stream you choose to record. `nix 
 Record that through `run`, drop the `@nix ` prefix, decode the rest, and join starts to stops to surface the slowest phases:
 
 ```python
+import polars as pl
+
+nix_event_dtype = pl.Struct([
+    pl.Field("action", pl.String),
+    pl.Field("id", pl.Int64),
+    pl.Field("text", pl.String),
+    pl.Field("type", pl.Int64),
+])
 events = (
     pl.read_ndjson(".ix/run/latest/lines.jsonl")
       .filter(pl.col("text").str.starts_with("@nix "))
       .select(
           "ended_elapsed_ns",
-          pl.col("text").str.slice(5).str.json_decode().alias("event"),
+          pl.col("text").str.slice(5).str.json_decode(nix_event_dtype).alias("event"),
       )
       .unnest("event")
 )


### PR DESCRIPTION
## Summary

Addresses documentation feedback from old review threads:

- clarifies that reusable AI review gate callers require GitHub's prefixed called-job check name
- gives Polars `str.json_decode` examples an explicit struct dtype in both `@nix` parsing snippets
- describes `RoomState` as the live served state while `LoroDoc` records the event log
- switches the AGENTS.md generated-output check to the caller repository's local flake output

Review threads:

- https://github.com/indexable-inc/index/pull/166#discussion_r3302751931
- https://github.com/indexable-inc/index/pull/170#discussion_r3302935950
- https://github.com/indexable-inc/index/pull/170#discussion_r3302935967
- https://github.com/indexable-inc/index/pull/170#discussion_r3302944642

The separate PR #170 comment about the broken default MCP `repl` path is a runtime bug and is intentionally left for its own code PR.

## Checks

- `nix build .#site --no-link`
- `nix build .#checks.x86_64-linux.site-test --no-link`
- `nix run .#lint`
