### PR TITLE
mcp: keep default repl environment alive

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -29,14 +29,18 @@ let
         strictDeps = true;
       }
       ''
-        export HOME=$TMPDIR/home
-        mkdir -p "$HOME"
+                export HOME=$TMPDIR/home
+                mkdir -p "$HOME"
 
-        printf 'print("ix-mcp-repl-ok")\nraise SystemExit(0)\n' | ix-mcp repl >stdout 2>stderr
-        grep -q '^ix-mcp-repl-ok$' stdout
+        	        printf 'print("ix-mcp-repl-ok")\nraise SystemExit(0)\n' | ix-mcp repl >stdout 2>stderr
+        	        grep -q '^ix-mcp-repl-ok$' stdout
+        	        if find "$TMPDIR" -maxdepth 1 -type d -name 'ix-mcp-python-repl-*' | grep -q .; then
+        	          echo "default REPL temp directory leaked" >&2
+        	          exit 1
+        	        fi
 
-        mkdir -p "$out"
-      '';
+        	        mkdir -p "$out"
+        	      '';
 in
 package.overrideAttrs (old: {
   passthru =

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -8,19 +8,44 @@ let
   unwrapped = ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
     binary = "ix-mcp";
   };
+  package =
+    pkgs.runCommand "ix-mcp"
+      {
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+        strictDeps = true;
+        meta = (unwrapped.meta or { }) // {
+          mainProgram = "ix-mcp";
+        };
+      }
+      ''
+        mkdir -p $out/bin
+        makeWrapper ${unwrapped}/bin/ix-mcp $out/bin/ix-mcp \
+          --set IX_MCP_DEFAULT_PYTHON ${lib.escapeShellArg (lib.getExe pkgs.python3)}
+      '';
+  replDefault =
+    pkgs.runCommand "ix-mcp-repl-default"
+      {
+        nativeBuildInputs = [ package ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+
+        printf 'print("ix-mcp-repl-ok")\nraise SystemExit(0)\n' | ix-mcp repl >stdout 2>stderr
+        grep -q '^ix-mcp-repl-ok$' stdout
+
+        mkdir -p "$out"
+      '';
 in
-pkgs.runCommand "ix-mcp"
-  {
-    nativeBuildInputs = [ pkgs.makeWrapper ];
-    passthru = unwrapped.passthru // {
+package.overrideAttrs (old: {
+  passthru =
+    (old.passthru or { })
+    // unwrapped.passthru
+    // {
       inherit unwrapped;
+      tests = (unwrapped.passthru.tests or { }) // {
+        inherit replDefault;
+      };
     };
-    meta = (unwrapped.meta or { }) // {
-      mainProgram = "ix-mcp";
-    };
-  }
-  ''
-    mkdir -p $out/bin
-    makeWrapper ${unwrapped}/bin/ix-mcp $out/bin/ix-mcp \
-      --set IX_MCP_DEFAULT_PYTHON ${lib.escapeShellArg (lib.getExe pkgs.python3)}
-  ''
+})

--- a/packages/mcp/src/main.rs
+++ b/packages/mcp/src/main.rs
@@ -3,7 +3,7 @@ use std::{
     fs,
     io::{BufRead, BufReader, Write},
     path::{Path, PathBuf},
-    process::{Child, ChildStdin, ChildStdout, Command, Stdio},
+    process::{Child, ChildStdin, ChildStdout, Command, ExitCode, Stdio},
     sync::{Arc, Mutex},
 };
 
@@ -403,7 +403,7 @@ fn uuid_like(sessions: &HashMap<String, PythonSession>) -> String {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<ExitCode> {
     let cli = Cli::parse();
     match cli.command.unwrap_or(CliCommand::Serve) {
         CliCommand::Serve => {
@@ -431,7 +431,11 @@ async fn main() -> Result<()> {
                 .with_context(|| {
                     format!("failed to start Python REPL command {}", command.join(" "))
                 })?;
-            std::process::exit(status.code().unwrap_or(1));
+            let code = status
+                .code()
+                .and_then(|code| u8::try_from(code).ok())
+                .unwrap_or(1);
+            return Ok(ExitCode::from(code));
         }
         CliCommand::Eval { expression } => {
             let mut manager = SessionManager::default();
@@ -455,7 +459,7 @@ async fn main() -> Result<()> {
             println!("{}", session.request("exec", json!({ "source": source }))?);
         }
     }
-    Ok(())
+    Ok(ExitCode::SUCCESS)
 }
 
 fn command_arg(command: Vec<String>) -> Option<Vec<String>> {

--- a/packages/mcp/src/main.rs
+++ b/packages/mcp/src/main.rs
@@ -411,14 +411,17 @@ async fn main() -> Result<()> {
             service.waiting().await?;
         }
         CliCommand::Repl => {
-            let command = if cli.python.is_empty() {
+            let (command, _temp_dir) = if cli.python.is_empty() {
                 let temp_dir = tempfile::Builder::new()
                     .prefix("ix-mcp-python-repl-")
                     .tempdir()
                     .context("failed to create Python REPL directory")?;
-                create_default_environment(temp_dir.path())?
+                let command = create_default_environment(temp_dir.path())?;
+                // The default command points inside the venv, so keep the temp
+                // directory alive until the interactive process exits.
+                (command, Some(temp_dir))
             } else {
-                cli.python
+                (cli.python, None)
             };
             let status = Command::new(&command[0])
                 .args(&command[1..])


### PR DESCRIPTION
## Summary

Fixes the PR #170 review finding that `nix run .#mcp -- repl` was advertised but failed on the default Python path.

- keeps the default REPL temp venv alive until the interactive Python process exits
- adds a package passthru smoke test that starts the default REPL and executes a tiny stdin script
- keeps the package wrapper on `strictDeps`

Review thread:

- https://github.com/indexable-inc/index/pull/170#discussion_r3302935964

## Checks

- `nix build .#mcp --no-link`
- `nix build .#mcp.passthru.tests.replDefault --no-link`
- `nix build .#checks.x86_64-linux.rust-mcp-replDefault --no-link`
- `nix run .#lint`
- `nix run nixpkgs#rustfmt -- --edition 2024 --check packages/mcp/src/main.rs`
