### PR TITLE
room: add checkout dev stack

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -145,6 +145,92 @@ let
     };
 
   /**
+    Package a process-compose specification as a `nix run` application.
+
+    Generates a checked YAML config from Nix values and wraps
+    `process-compose` in a foreground command. By default the wrapper disables
+    the TUI in config and disables dotenv injection plus the process-compose
+    HTTP control server through CLI flags, so application ports remain
+    available and logs stay in the caller's terminal.
+
+    Arguments:
+    - `name`: derivation name and `/bin/<name>` executable.
+    - `processes`: attrset assigned to `processes` in the generated config.
+    - `settings`: extra top-level process-compose config fields.
+    - `runtimeInputs`: packages prepended to PATH before process-compose runs.
+    - `processComposeArgs`: argv inserted before user-provided args.
+    - `meta`: standard derivation meta, with `mainProgram` defaulted.
+  */
+  writeProcessComposeApplication =
+    pkgs:
+    {
+      name,
+      processes,
+      settings ? { },
+      runtimeInputs ? [ ],
+      processComposeArgs ? [
+        "--no-server"
+        "--ordered-shutdown"
+        "--disable-dotenv"
+      ],
+      meta ? { },
+    }:
+    let
+      format = pkgs.formats.yaml { };
+      xdgConfigHome =
+        pkgs.runCommand "${name}-process-compose-xdg-config"
+          {
+            strictDeps = true;
+          }
+          ''
+            mkdir -p "$out/process-compose"
+          '';
+      config = format.generate "${name}.process-compose.yaml" (
+        {
+          version = "0.5";
+          is_tui_disabled = true;
+        }
+        // settings
+        // {
+          inherit processes;
+        }
+      );
+      package = writeNushellApplication pkgs {
+        inherit name;
+        runtimeInputs = [ pkgs.process-compose ] ++ runtimeInputs;
+        meta = meta // {
+          mainProgram = meta.mainProgram or name;
+        };
+        text = ''
+          const process_compose_args = ${builtins.toJSON processComposeArgs}
+
+          def main [...args: string] {
+            $env.XDG_CONFIG_HOME = "${xdgConfigHome}"
+            exec process-compose --config ${config} ...$process_compose_args ...$args
+          }
+        '';
+      };
+      dryRun =
+        pkgs.runCommand "${name}-process-compose-dry-run"
+          {
+            nativeBuildInputs = [ pkgs.process-compose ];
+            strictDeps = true;
+          }
+          ''
+            process-compose --config ${config} --dry-run --no-server --disable-dotenv
+            mkdir -p "$out"
+          '';
+    in
+    package.overrideAttrs (old: {
+      passthru = (old.passthru or { }) // {
+        inherit config;
+        tests = (old.passthru.tests or { }) // {
+          inherit dryRun;
+        };
+      };
+    });
+
+  /**
     Repo-local nixpkgs overlay.
 
     Exposes the few repo-owned packages that NixOS modules expect to find
@@ -677,6 +763,60 @@ let
           port = 5174;
         };
       };
+      roomDevBackend = writeNushellApplication pkgs {
+        name = "room-dev-backend";
+        runtimeInputs = [
+          (rustNightlyToolchainFor pkgs)
+          pkgs.stdenv.cc
+        ];
+        meta.description = "Run the room Rust backend from a mutable checkout";
+        text = ''
+          const checkout_site_dir = "packages/room/site"
+
+          def main [] {
+            let root = (pwd)
+            let site_dir = ($root | path join $checkout_site_dir)
+            let index = ($site_dir | path join "index.html")
+
+            if not ($index | path exists) {
+              error make { msg: $"room-dev must run from the repository root; missing ($index)" }
+            }
+
+            exec cargo run --package room --bin room -- --host 127.0.0.1 --port 8080 --site-dir $site_dir
+          }
+        '';
+      };
+      roomDev = writeProcessComposeApplication pkgs {
+        name = "room-dev";
+        processes = {
+          backend = {
+            command = lib.escapeShellArgs [ (lib.getExe roomDevBackend) ];
+            availability.restart = "exit_on_failure";
+            readiness_probe = {
+              http_get = {
+                host = "127.0.0.1";
+                scheme = "http";
+                path = "/";
+                port = 8080;
+              };
+              initial_delay_seconds = 1;
+              period_seconds = 2;
+              timeout_seconds = 1;
+              failure_threshold = 60;
+            };
+          };
+          frontend = {
+            command = lib.escapeShellArgs [
+              (lib.getExe roomSite.passthru.devServer)
+              "--root"
+              "packages/room/site"
+            ];
+            environment = [ "ROOM_BACKEND_URL=http://127.0.0.1:8080" ];
+            availability.restart = "exit_on_failure";
+          };
+        };
+        meta.description = "Run the room Rust backend and Vite frontend together from a checkout";
+      };
       loopViewerSrc = lib.fileset.toSource {
         root = paths.packages.loop + "/site";
         fileset = lib.fileset.intersection (lib.fileset.gitTracked (paths.packages.loop + "/site")) (
@@ -710,6 +850,7 @@ let
           ix = ixForPackages;
         };
         room-site = roomSite;
+        room-dev = roomDev;
         room = pkgs.callPackage paths.packages.room {
           inherit pkgs;
           site = roomSite;
@@ -873,6 +1014,7 @@ let
       secrets
       systemdHardening
       writeNushellApplication
+      writeProcessComposeApplication
       writePythonApplication
       ;
     packages = packageSetFor pkgs;
@@ -1148,6 +1290,7 @@ let
       systemdHardening
       uvLockFor
       writeNushellApplication
+      writeProcessComposeApplication
       writePythonApplication
       ;
 

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -386,6 +386,7 @@ in
         nix-cargo-unit
         oci-image-builder
         run
+        room-dev
         room-site
         mcp
         ;
@@ -412,6 +413,7 @@ in
       '';
       cargo-unit-real-workspaces = tests.cargoUnitRealWorkspaces;
       run-records-session = repoPackages.run.passthru.tests.recordsSession;
+      room-dev-process-compose = repoPackages.room-dev.passthru.tests.dryRun;
       lint = pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ pkgs.coreutils ]; } ''
         cp -R ${lintSource} source
         chmod -R u+w source

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -1,0 +1,23 @@
+# room
+
+`room` serves a shared presence room with a Rust WebSocket backend and a Svelte
+frontend.
+
+## Run The Packaged Server
+
+```sh
+nix run .#room
+```
+
+The packaged server listens on `127.0.0.1:8080` by default and serves the built
+Svelte assets from the Nix store.
+
+## Run The Checkout Dev Stack
+
+```sh
+nix run .#room-dev
+```
+
+`room-dev` starts the Rust backend on `127.0.0.1:8080` and the Vite dev server
+on `127.0.0.1:5174`. Open the Vite URL for hot reloads; `/ws` is proxied back
+to the Rust backend.

--- a/packages/room/site/vite.config.ts
+++ b/packages/room/site/vite.config.ts
@@ -1,6 +1,16 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'vite';
 
+const roomBackendUrl = process.env.ROOM_BACKEND_URL ?? 'http://127.0.0.1:8080';
+
 export default defineConfig({
-  plugins: [svelte()]
+  plugins: [svelte()],
+  server: {
+    proxy: {
+      '/ws': {
+        target: roomBackendUrl,
+        ws: true
+      }
+    }
+  }
 });

--- a/site/src/lib/updates/process-compose-dev.svx
+++ b/site/src/lib/updates/process-compose-dev.svx
@@ -1,0 +1,32 @@
+---
+id: process-compose-dev
+postedAt: 2026-05-26T04:32:00-07:00
+title: "`nix run .#room-dev` starts the room backend and Vite together"
+tags: [interesting, nix, svelte, rust]
+links:
+  - label: room README
+    href: https://github.com/indexable-inc/index/tree/main/packages/room
+  - label: Process Compose
+    href: https://f1bonacc1.github.io/process-compose/
+  - label: devenv processes
+    href: https://devenv.sh/processes/
+---
+
+`room-dev` is the repo's first checkout-local multi-process runner. It uses a
+small Nix helper to generate a `process-compose` config, then runs the Rust room
+backend and Vite dev server in one foreground command:
+
+```bash
+nix run .#room-dev
+```
+
+The wrapper disables the process-compose TUI and control server, so the command
+keeps ordinary terminal logs and leaves `:8080` free for the room backend. The
+frontend still runs on Vite's `:5174`; its `/ws` route proxies to the Rust
+server, which keeps hot reloads and live WebSocket state in the same browser
+origin during development.
+
+Devenv was a close fit for the process model, especially readiness probes and
+service presets. For this repo, the smaller boundary won: a flake package keeps
+the existing `nix run .#...` workflow, avoids a new dev-shell layer, and leaves
+future multi-process commands with one reusable helper.


### PR DESCRIPTION
## Summary
- add `ix.writeProcessComposeApplication`, a small Nix helper that generates checked process-compose YAML for `nix run` apps with the TUI and control server disabled by default
- expose `nix run .#room-dev` to run the room Rust backend on `:8080` and the Vite frontend on `:5174`
- proxy Vite `/ws` traffic to the backend and document the packaged/dev room commands

## Choice
I compared devenv processes, raw process-compose, and a repo-owned supervisor. Devenv has a friendly process model, but it is centered on `devenv up` and a dev-shell layer; the docs also note that flake integration carries caveats around pure eval and feature support. Raw process-compose is already in pinned nixpkgs, gives the same process supervision substrate, and can be wrapped as a normal flake package. The wrapper disables the TUI and process-compose server so the UX stays close to ordinary foreground logs instead of taking over the terminal.

References:
- https://devenv.sh/processes/
- https://devenv.sh/guides/using-with-flakes/
- https://f1bonacc1.github.io/process-compose/tui/

## Tests
- `nix build .#room-dev .#checks.x86_64-linux.room-dev-process-compose`
- `nix run .#room-dev` smoke tested locally; confirmed `http://127.0.0.1:5174/`, `http://127.0.0.1:8080/`, and `ws://127.0.0.1:5174/ws`
- `nix build .#room .#room-site .#checks.x86_64-linux.room-dev-process-compose`
- `nix run .#lint`
- `nix build .#checks.x86_64-linux.site-test`
