### PR TITLE
go-unit: defer module file checks

### DIFF
--- a/lib/go-unit.nix
+++ b/lib/go-unit.nix
@@ -51,7 +51,12 @@ let
           goSum
         else
           null;
-      goSumExists = goSumForBuild != null || noSumModule || (!canReadModuleFiles && !explicitGoSum);
+      goSumExists =
+        if explicitGoSum then
+          (goSumForBuild == null && noSumModule)
+          || (goSumForBuild != null && builtins.pathExists goSumForBuild)
+        else
+          goSumForBuild != null || noSumModule || !canReadModuleFiles;
       missingGoSumMessage = "goUnit.buildWorkspace requires ${builtins.toString goSum}; pass vendorHash = null only for stdlib-only modules without go.sum";
       canReadGoSum =
         goSumForBuild != null && (canReadModuleFiles || explicitGoSum) && builtins.pathExists goSumForBuild;

--- a/lib/go-unit.nix
+++ b/lib/go-unit.nix
@@ -43,7 +43,13 @@ let
       checkedGoMod = if goModExists then goMod else throw missingGoModMessage;
       explicitGoSum = args ? goSum;
       goSum = args.goSum or (moduleRoot + "/go.sum");
-      noSumModule = (args ? vendorHash) && args.vendorHash == null;
+      requestedNoSumModule = (args ? vendorHash) && args.vendorHash == null;
+      readableGoModHasRequire =
+        canReadGoMod
+        && lib.any (line: line == "require (" || lib.hasPrefix "require " line) (
+          lib.splitString "\n" (builtins.readFile checkedGoMod)
+        );
+      noSumModule = requestedNoSumModule && !readableGoModHasRequire;
       goSumForBuild =
         if explicitGoSum then
           args.goSum

--- a/lib/go-unit.nix
+++ b/lib/go-unit.nix
@@ -36,15 +36,21 @@ let
       modRoot = args.modRoot or ".";
       moduleRoot = if modRoot == "." then src else src + "/${modRoot}";
       goMod = args.goMod or (moduleRoot + "/go.mod");
+      checkedGoMod =
+        if canReadModuleFiles && !(builtins.pathExists goMod) then
+          throw "goUnit.buildWorkspace requires ${builtins.toString goMod}"
+        else
+          goMod;
       goSum = args.goSum or (moduleRoot + "/go.sum");
       goSumForBuild =
         args.goSum or (if canReadModuleFiles && builtins.pathExists goSum then goSum else null);
+      explicitVendorHashFile = args ? vendorHashFile;
       vendorHashFile = args.vendorHashFile or (moduleRoot + "/go-modules.nix");
       vendorHashKey =
         args.vendorHashKey or (
-          if canReadModuleFiles && builtins.pathExists goMod then
+          if canReadModuleFiles then
             builtins.hashString "sha256" (
-              (builtins.readFile goMod)
+              (builtins.readFile checkedGoMod)
               + "\n"
               + (if goSumForBuild == null then "" else builtins.readFile goSumForBuild)
             )
@@ -53,7 +59,10 @@ let
         );
       vendorHashes =
         args.vendorHashes or (
-          if canReadModuleFiles && builtins.pathExists vendorHashFile then import vendorHashFile else { }
+          if (canReadModuleFiles || explicitVendorHashFile) && builtins.pathExists vendorHashFile then
+            import vendorHashFile
+          else
+            { }
         );
       vendorHash =
         args.vendorHash or (
@@ -79,13 +88,13 @@ let
       version = args.version or "0.0.0";
       inherit
         src
-        goMod
         modRoot
         moduleRoot
         vendorHash
         vendorHashFile
         vendorHashKey
         ;
+      goMod = checkedGoMod;
       goSum = goSumForBuild;
       packages =
         let

--- a/lib/go-unit.nix
+++ b/lib/go-unit.nix
@@ -60,11 +60,12 @@ let
       missingGoSumMessage = "goUnit.buildWorkspace requires ${builtins.toString goSum}; pass vendorHash = null only for stdlib-only modules without go.sum";
       canReadGoSum =
         goSumForBuild != null && (canReadModuleFiles || explicitGoSum) && builtins.pathExists goSumForBuild;
+      canDeriveVendorHashKey = canReadGoMod && (canReadGoSum || noSumModule);
       explicitVendorHashFile = args ? vendorHashFile;
       vendorHashFile = args.vendorHashFile or (moduleRoot + "/go-modules.nix");
       vendorHashKey =
         args.vendorHashKey or (
-          if canReadGoMod then
+          if canDeriveVendorHashKey then
             builtins.hashString "sha256" (
               (builtins.readFile checkedGoMod)
               + "\n"

--- a/lib/go-unit.nix
+++ b/lib/go-unit.nix
@@ -43,8 +43,16 @@ let
       checkedGoMod = if goModExists then goMod else throw missingGoModMessage;
       explicitGoSum = args ? goSum;
       goSum = args.goSum or (moduleRoot + "/go.sum");
+      noSumModule = (args ? vendorHash) && args.vendorHash == null;
       goSumForBuild =
-        args.goSum or (if canReadModuleFiles && builtins.pathExists goSum then goSum else null);
+        if explicitGoSum then
+          args.goSum
+        else if canReadModuleFiles && builtins.pathExists goSum then
+          goSum
+        else
+          null;
+      goSumExists = goSumForBuild != null || noSumModule || (!canReadModuleFiles && !explicitGoSum);
+      missingGoSumMessage = "goUnit.buildWorkspace requires ${builtins.toString goSum}; pass vendorHash = null only for stdlib-only modules without go.sum";
       canReadGoSum =
         goSumForBuild != null && (canReadModuleFiles || explicitGoSum) && builtins.pathExists goSumForBuild;
       explicitVendorHashFile = args ? vendorHashFile;
@@ -87,6 +95,7 @@ let
         );
     in
     assert lib.assertMsg goModExists missingGoModMessage;
+    assert lib.assertMsg goSumExists missingGoSumMessage;
     {
       pname = args.pname or "go-unit";
       version = args.version or "0.0.0";

--- a/lib/go-unit.nix
+++ b/lib/go-unit.nix
@@ -32,42 +32,61 @@ let
     args:
     let
       src = args.src or (throw "goUnit.buildWorkspace requires src");
+      canReadModuleFiles = !(lib.isDerivation src);
       modRoot = args.modRoot or ".";
       moduleRoot = if modRoot == "." then src else src + "/${modRoot}";
       goMod = args.goMod or (moduleRoot + "/go.mod");
       goSum = args.goSum or (moduleRoot + "/go.sum");
+      goSumForBuild =
+        args.goSum or (if canReadModuleFiles && builtins.pathExists goSum then goSum else null);
       vendorHashFile = args.vendorHashFile or (moduleRoot + "/go-modules.nix");
-      vendorHashKey = builtins.hashString "sha256" (
-        (builtins.readFile goMod) + "\n" + (builtins.readFile goSum)
-      );
+      vendorHashKey =
+        args.vendorHashKey or (
+          if canReadModuleFiles && builtins.pathExists goMod then
+            builtins.hashString "sha256" (
+              (builtins.readFile goMod)
+              + "\n"
+              + (if goSumForBuild == null then "" else builtins.readFile goSumForBuild)
+            )
+          else
+            null
+        );
       vendorHashes =
-        args.vendorHashes or (if builtins.pathExists vendorHashFile then import vendorHashFile else { });
+        args.vendorHashes or (
+          if canReadModuleFiles && builtins.pathExists vendorHashFile then import vendorHashFile else { }
+        );
       vendorHash =
-        args.vendorHash or vendorHashes.${vendorHashKey} or (throw ''
-          goUnit.buildWorkspace requires a vendor hash for go.mod/go.sum key ${vendorHashKey}.
-          Add ${builtins.toString vendorHashFile} with:
-          {
-            "${vendorHashKey}" = "sha256-...";
-          }
-        '');
+        args.vendorHash or (
+          if vendorHashKey != null && builtins.hasAttr vendorHashKey vendorHashes then
+            vendorHashes.${vendorHashKey}
+          else if vendorHashKey == null then
+            throw ''
+              goUnit.buildWorkspace cannot derive a vendor hash key from this src at eval time.
+              Pass vendorHash directly, or pass vendorHashKey with vendorHashes/vendorHashFile.
+            ''
+          else
+            throw ''
+              goUnit.buildWorkspace requires a vendor hash for go.mod/go.sum key ${vendorHashKey}.
+              Add ${builtins.toString vendorHashFile} with:
+              {
+                "${vendorHashKey}" = "sha256-...";
+              }
+            ''
+        );
     in
-    assert lib.assertMsg (builtins.pathExists goMod)
-      "goUnit.buildWorkspace requires a checked-in go.mod at ${builtins.toString goMod}";
-    assert lib.assertMsg (builtins.pathExists goSum)
-      "goUnit.buildWorkspace requires a checked-in go.sum lockfile at ${builtins.toString goSum}";
     {
       pname = args.pname or "go-unit";
       version = args.version or "0.0.0";
       inherit
         src
         goMod
-        goSum
         modRoot
         moduleRoot
         vendorHash
         vendorHashFile
         vendorHashKey
         ;
+      goSum = goSumForBuild;
       packages =
         let
           packages = args.packages or [ "." ];
@@ -158,12 +177,14 @@ let
 
     Go does not expose Cargo's rustc unit graph, so callers choose the package
     patterns that deserve independent cache and test boundaries. The helper
-    requires `go.mod`, `go.sum`, and a matching Nix vendor hash.
-    By default, the vendor hash comes from `go-modules.nix` next to the module,
-    keyed by the combined `go.mod` and `go.sum` contents. This keeps the Nix
-    fixed-output hash in a narrow generated artifact instead of repeating it at
-    every build call site. Callers may pass `vendorHash`, `vendorHashes`, or
-    `vendorHashFile` when the owner lives somewhere else.
+    requires `go.mod` and a matching Nix vendor hash. Modules with external
+    dependencies should also carry `go.sum`; stdlib-only modules may pass
+    `vendorHash = null` without one. By default, the vendor hash comes from
+    `go-modules.nix` next to local modules, keyed by the combined `go.mod` and
+    `go.sum` contents when those files are visible at eval time. This keeps the
+    Nix fixed-output hash in a narrow generated artifact instead of repeating it
+    at every build call site. Callers may pass `vendorHash`, `vendorHashKey`,
+    `vendorHashes`, or `vendorHashFile` when the owner lives somewhere else.
 
     Arguments:
     - `src`: filtered module source.
@@ -202,7 +223,7 @@ let
           base = "workspace";
           scope = "module";
           relative = args.modRoot;
-          lockFile = "go.sum";
+          lockFile = if args.goSum == null then null else "go.sum";
           inherit (args) vendorHashKey;
         };
       };

--- a/lib/go-unit.nix
+++ b/lib/go-unit.nix
@@ -35,22 +35,27 @@ let
       canReadModuleFiles = !(lib.isDerivation src);
       modRoot = args.modRoot or ".";
       moduleRoot = if modRoot == "." then src else src + "/${modRoot}";
+      explicitGoMod = args ? goMod;
       goMod = args.goMod or (moduleRoot + "/go.mod");
-      goModExists = !canReadModuleFiles || builtins.pathExists goMod;
+      canReadGoMod = (canReadModuleFiles || explicitGoMod) && builtins.pathExists goMod;
+      goModExists = canReadGoMod || (!canReadModuleFiles && !explicitGoMod);
       missingGoModMessage = "goUnit.buildWorkspace requires ${builtins.toString goMod}";
       checkedGoMod = if goModExists then goMod else throw missingGoModMessage;
+      explicitGoSum = args ? goSum;
       goSum = args.goSum or (moduleRoot + "/go.sum");
       goSumForBuild =
         args.goSum or (if canReadModuleFiles && builtins.pathExists goSum then goSum else null);
+      canReadGoSum =
+        goSumForBuild != null && (canReadModuleFiles || explicitGoSum) && builtins.pathExists goSumForBuild;
       explicitVendorHashFile = args ? vendorHashFile;
       vendorHashFile = args.vendorHashFile or (moduleRoot + "/go-modules.nix");
       vendorHashKey =
         args.vendorHashKey or (
-          if canReadModuleFiles then
+          if canReadGoMod then
             builtins.hashString "sha256" (
               (builtins.readFile checkedGoMod)
               + "\n"
-              + (if goSumForBuild == null then "" else builtins.readFile goSumForBuild)
+              + (if canReadGoSum then builtins.readFile goSumForBuild else "")
             )
           else
             null

--- a/lib/go-unit.nix
+++ b/lib/go-unit.nix
@@ -46,9 +46,14 @@ let
       requestedNoSumModule = (args ? vendorHash) && args.vendorHash == null;
       readableGoModHasRequire =
         canReadGoMod
-        && lib.any (line: line == "require (" || lib.hasPrefix "require " line) (
-          lib.splitString "\n" (builtins.readFile checkedGoMod)
-        );
+        && lib.any (
+          line:
+          let
+            compactLine = lib.replaceStrings [ " " "\t" ] [ "" "" ] line;
+          in
+          lib.hasPrefix "require(" compactLine
+          || (lib.hasPrefix "require" compactLine && compactLine != "require")
+        ) (lib.splitString "\n" (builtins.readFile checkedGoMod));
       noSumModule = requestedNoSumModule && !readableGoModHasRequire;
       goSumForBuild =
         if explicitGoSum then

--- a/lib/go-unit.nix
+++ b/lib/go-unit.nix
@@ -36,11 +36,9 @@ let
       modRoot = args.modRoot or ".";
       moduleRoot = if modRoot == "." then src else src + "/${modRoot}";
       goMod = args.goMod or (moduleRoot + "/go.mod");
-      checkedGoMod =
-        if canReadModuleFiles && !(builtins.pathExists goMod) then
-          throw "goUnit.buildWorkspace requires ${builtins.toString goMod}"
-        else
-          goMod;
+      goModExists = !canReadModuleFiles || builtins.pathExists goMod;
+      missingGoModMessage = "goUnit.buildWorkspace requires ${builtins.toString goMod}";
+      checkedGoMod = if goModExists then goMod else throw missingGoModMessage;
       goSum = args.goSum or (moduleRoot + "/go.sum");
       goSumForBuild =
         args.goSum or (if canReadModuleFiles && builtins.pathExists goSum then goSum else null);
@@ -83,6 +81,7 @@ let
             ''
         );
     in
+    assert lib.assertMsg goModExists missingGoModMessage;
     {
       pname = args.pname or "go-unit";
       version = args.version or "0.0.0";

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -707,7 +707,8 @@ let
   goUnitDerivedWorkspaceWithVendorHashFile = ix.goUnit.buildWorkspace {
     pname = "go-unit-hello-derived";
     src = goUnitDerivedSource;
-    inherit (goUnitWorkspace) vendorHashKey;
+    goMod = ./fixtures/go-unit-hello/go.mod;
+    goSum = ./fixtures/go-unit-hello/go.sum;
     vendorHashFile = ./fixtures/go-unit-hello/go-modules.nix;
     packages = [ "." ];
   };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -750,6 +750,16 @@ let
         packages = [ "." ];
       }).packages
   );
+  goUnitMissingExplicitGoSumEval = builtins.tryEval (
+    builtins.attrNames
+      (ix.goUnit.buildWorkspace {
+        pname = "go-unit-missing-explicit-go-sum";
+        src = goUnitMissingGoSumFixture;
+        goSum = goUnitMissingGoSumFixture + "/go.sum";
+        vendorHash = "sha256-36P4vOdzJotmVZon5Zud/d/jxzv4ad04aQT2G/EE3U8=";
+        packages = [ "." ];
+      }).packages
+  );
 
   goUnitPackageCollisionEval =
     builtins.tryEval
@@ -2800,6 +2810,10 @@ let
       {
         assertion = !goUnitMissingGoSumEval.success;
         message = "go-unit local sources should reject missing go.sum even with a direct vendor hash";
+      }
+      {
+        assertion = !goUnitMissingExplicitGoSumEval.success;
+        message = "go-unit explicit go.sum paths should reject filtered-out files during eval";
       }
       {
         assertion = !goUnitPackageCollisionEval.success;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -761,6 +761,15 @@ let
         packages = [ "." ];
       }).packages
   );
+  goUnitMissingGoSumNoSumEval = builtins.tryEval (
+    builtins.attrNames
+      (ix.goUnit.buildWorkspace {
+        pname = "go-unit-missing-go-sum-no-sum";
+        src = goUnitMissingGoSumFixture;
+        vendorHash = null;
+        packages = [ "." ];
+      }).packages
+  );
   goUnitMissingExplicitGoSumEval = builtins.tryEval (
     builtins.attrNames
       (ix.goUnit.buildWorkspace {
@@ -2825,6 +2834,10 @@ let
       {
         assertion = !goUnitMissingGoSumEval.success;
         message = "go-unit local sources should reject missing go.sum even with a direct vendor hash";
+      }
+      {
+        assertion = !goUnitMissingGoSumNoSumEval.success;
+        message = "go-unit local sources with external requirements should not use the no-sum path";
       }
       {
         assertion = !goUnitMissingExplicitGoSumEval.success;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -691,6 +691,13 @@ let
       ./fixtures/go-unit-hello/main_test.go
     ];
   };
+  goUnitRequireNoSpaceFixture = fs.toSource {
+    root = ./fixtures/go-unit-require-nospace;
+    fileset = fs.unions [
+      ./fixtures/go-unit-require-nospace/go.mod
+      ./fixtures/go-unit-require-nospace/main.go
+    ];
+  };
 
   goUnitStdlibWorkspace = ix.goUnit.buildWorkspace {
     pname = "go-unit-stdlib";
@@ -766,6 +773,15 @@ let
       (ix.goUnit.buildWorkspace {
         pname = "go-unit-missing-go-sum-no-sum";
         src = goUnitMissingGoSumFixture;
+        vendorHash = null;
+        packages = [ "." ];
+      }).packages
+  );
+  goUnitRequireNoSpaceNoSumEval = builtins.tryEval (
+    builtins.attrNames
+      (ix.goUnit.buildWorkspace {
+        pname = "go-unit-require-nospace-no-sum";
+        src = goUnitRequireNoSpaceFixture;
         vendorHash = null;
         packages = [ "." ];
       }).packages
@@ -2838,6 +2854,10 @@ let
       {
         assertion = !goUnitMissingGoSumNoSumEval.success;
         message = "go-unit local sources with external requirements should not use the no-sum path";
+      }
+      {
+        assertion = !goUnitRequireNoSpaceNoSumEval.success;
+        message = "go-unit no-sum detection should reject compact require blocks";
       }
       {
         assertion = !goUnitMissingExplicitGoSumEval.success;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -723,6 +723,15 @@ let
         vendorHash = null;
         packages = [ "." ];
       }).vendorHashKey;
+  goUnitMissingGoModPackagesEval = builtins.tryEval (
+    builtins.attrNames
+      (ix.goUnit.buildWorkspace {
+        pname = "go-unit-missing-go-mod";
+        src = goUnitMissingGoModFixture;
+        vendorHash = null;
+        packages = [ "." ];
+      }).packages
+  );
 
   goUnitPackageCollisionEval =
     builtins.tryEval
@@ -2765,6 +2774,10 @@ let
       {
         assertion = !goUnitMissingGoModEval.success;
         message = "go-unit local sources should reject missing go.mod during eval";
+      }
+      {
+        assertion = !goUnitMissingGoModPackagesEval.success;
+        message = "go-unit local package surfaces should reject missing go.mod during eval";
       }
       {
         assertion = !goUnitPackageCollisionEval.success;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -702,8 +702,8 @@ let
     packages = [ "." ];
   };
   goUnitDerivedSource = pkgs.runCommand "go-unit-hello-source" { } ''
-    	    cp -R ${goUnitFixture}/. "$out"
-    	  '';
+    cp -R ${goUnitFixture}/. "$out"
+  '';
   goUnitDerivedWorkspaceWithVendorHashFile = ix.goUnit.buildWorkspace {
     pname = "go-unit-hello-derived";
     src = goUnitDerivedSource;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -675,6 +675,33 @@ let
     packages = [ "." ];
   };
 
+  goUnitStdlibFixture = fs.toSource {
+    root = ./fixtures/go-unit-stdlib;
+    fileset = fs.unions [
+      ./fixtures/go-unit-stdlib/go.mod
+      ./fixtures/go-unit-stdlib/main.go
+      ./fixtures/go-unit-stdlib/main_test.go
+    ];
+  };
+
+  goUnitStdlibWorkspace = ix.goUnit.buildWorkspace {
+    pname = "go-unit-stdlib";
+    src = goUnitStdlibFixture;
+    vendorHash = null;
+    packages = [ "." ];
+  };
+
+  goUnitDerivedStdlibSource = pkgs.runCommand "go-unit-stdlib-source" { } ''
+    cp -R ${goUnitStdlibFixture}/. "$out"
+  '';
+
+  goUnitDerivedStdlibWorkspace = ix.goUnit.buildWorkspace {
+    pname = "go-unit-stdlib-derived";
+    src = goUnitDerivedStdlibSource;
+    vendorHash = null;
+    packages = [ "." ];
+  };
+
   goUnitPackageCollisionEval =
     builtins.tryEval
       (ix.goUnit.buildWorkspace {
@@ -2696,6 +2723,18 @@ let
         message = "go-unit workspaces should resolve default go.mod and go.sum below modRoot";
       }
       {
+        assertion = goUnitStdlibWorkspace.sourceAudit.module.lockFile == null;
+        message = "go-unit workspaces should allow stdlib-only modules without go.sum";
+      }
+      {
+        assertion = goUnitStdlibWorkspace.packages.root.goUnit.goSum == null;
+        message = "go-unit package derivations should pass null goSum for modules without go.sum";
+      }
+      {
+        assertion = goUnitDerivedStdlibWorkspace.vendorHashKey == null;
+        message = "go-unit workspaces should not read derivation source module files during eval";
+      }
+      {
         assertion = !goUnitPackageCollisionEval.success;
         message = "go-unit workspaces should reject package patterns with colliding output names";
       }
@@ -3437,6 +3476,12 @@ let
     ${goUnitNestedWorkspace.default}/bin/go-unit-nested > go-unit-nested.out
     grep -q 'hello from nested go-unit: Hello, world.' go-unit-nested.out
     test -e ${goUnitNestedWorkspace.tests.root}/done
+    ${goUnitStdlibWorkspace.default}/bin/go-unit-stdlib > go-unit-stdlib.out
+    grep -q 'HELLO FROM GO-UNIT STDLIB' go-unit-stdlib.out
+    test -e ${goUnitStdlibWorkspace.tests.root}/done
+    ${goUnitDerivedStdlibWorkspace.default}/bin/go-unit-stdlib > go-unit-stdlib-derived.out
+    grep -q 'HELLO FROM GO-UNIT STDLIB' go-unit-stdlib-derived.out
+    test -e ${goUnitDerivedStdlibWorkspace.tests.root}/done
 
     grep -q 'class="ix bun"' ${bunSite}/share/bun-site-fixture/index.html
     test -d ${bunSite.bunNodeModules}/node_modules/clsx

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -701,6 +701,28 @@ let
     vendorHash = null;
     packages = [ "." ];
   };
+  goUnitDerivedSource = pkgs.runCommand "go-unit-hello-source" { } ''
+    	    cp -R ${goUnitFixture}/. "$out"
+    	  '';
+  goUnitDerivedWorkspaceWithVendorHashFile = ix.goUnit.buildWorkspace {
+    pname = "go-unit-hello-derived";
+    src = goUnitDerivedSource;
+    inherit (goUnitWorkspace) vendorHashKey;
+    vendorHashFile = ./fixtures/go-unit-hello/go-modules.nix;
+    packages = [ "." ];
+  };
+  goUnitMissingGoModFixture = fs.toSource {
+    root = ./fixtures/go-unit-hello;
+    fileset = ./fixtures/go-unit-hello/main.go;
+  };
+  goUnitMissingGoModEval =
+    builtins.tryEval
+      (ix.goUnit.buildWorkspace {
+        pname = "go-unit-missing-go-mod";
+        src = goUnitMissingGoModFixture;
+        vendorHash = null;
+        packages = [ "." ];
+      }).vendorHashKey;
 
   goUnitPackageCollisionEval =
     builtins.tryEval
@@ -2733,6 +2755,16 @@ let
       {
         assertion = goUnitDerivedStdlibWorkspace.vendorHashKey == null;
         message = "go-unit workspaces should not read derivation source module files during eval";
+      }
+      {
+        assertion =
+          goUnitDerivedWorkspaceWithVendorHashFile.packages.root.goUnit.vendorHashKey
+          == goUnitWorkspace.vendorHashKey;
+        message = "go-unit derivation sources should use explicit vendor hash files by key";
+      }
+      {
+        assertion = !goUnitMissingGoModEval.success;
+        message = "go-unit local sources should reject missing go.mod during eval";
       }
       {
         assertion = !goUnitPackageCollisionEval.success;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -683,6 +683,14 @@ let
       ./fixtures/go-unit-stdlib/main_test.go
     ];
   };
+  goUnitMissingGoSumFixture = fs.toSource {
+    root = ./fixtures/go-unit-hello;
+    fileset = fs.unions [
+      ./fixtures/go-unit-hello/go.mod
+      ./fixtures/go-unit-hello/main.go
+      ./fixtures/go-unit-hello/main_test.go
+    ];
+  };
 
   goUnitStdlibWorkspace = ix.goUnit.buildWorkspace {
     pname = "go-unit-stdlib";
@@ -730,6 +738,15 @@ let
         pname = "go-unit-missing-go-mod";
         src = goUnitMissingGoModFixture;
         vendorHash = null;
+        packages = [ "." ];
+      }).packages
+  );
+  goUnitMissingGoSumEval = builtins.tryEval (
+    builtins.attrNames
+      (ix.goUnit.buildWorkspace {
+        pname = "go-unit-missing-go-sum";
+        src = goUnitMissingGoSumFixture;
+        vendorHash = "sha256-36P4vOdzJotmVZon5Zud/d/jxzv4ad04aQT2G/EE3U8=";
         packages = [ "." ];
       }).packages
   );
@@ -2779,6 +2796,10 @@ let
       {
         assertion = !goUnitMissingGoModPackagesEval.success;
         message = "go-unit local package surfaces should reject missing go.mod during eval";
+      }
+      {
+        assertion = !goUnitMissingGoSumEval.success;
+        message = "go-unit local sources should reject missing go.sum even with a direct vendor hash";
       }
       {
         assertion = !goUnitPackageCollisionEval.success;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -720,6 +720,17 @@ let
     vendorHashFile = ./fixtures/go-unit-hello/go-modules.nix;
     packages = [ "." ];
   };
+  goUnitDerivedMissingGoSumKeyEval =
+    let
+      workspace = ix.goUnit.buildWorkspace {
+        pname = "go-unit-hello-derived-missing-go-sum";
+        src = goUnitDerivedSource;
+        goMod = ./fixtures/go-unit-hello/go.mod;
+        vendorHashFile = ./fixtures/go-unit-hello/go-modules.nix;
+        packages = [ "." ];
+      };
+    in
+    builtins.tryEval workspace.default.drvPath;
   goUnitMissingGoModFixture = fs.toSource {
     root = ./fixtures/go-unit-hello;
     fileset = ./fixtures/go-unit-hello/main.go;
@@ -2798,6 +2809,10 @@ let
           goUnitDerivedWorkspaceWithVendorHashFile.packages.root.goUnit.vendorHashKey
           == goUnitWorkspace.vendorHashKey;
         message = "go-unit derivation sources should use explicit vendor hash files by key";
+      }
+      {
+        assertion = !goUnitDerivedMissingGoSumKeyEval.success;
+        message = "go-unit derivation sources should not derive vendor keys from go.mod alone";
       }
       {
         assertion = !goUnitMissingGoModEval.success;

--- a/tests/fixtures/go-unit-require-nospace/go.mod
+++ b/tests/fixtures/go-unit-require-nospace/go.mod
@@ -1,0 +1,7 @@
+module ix.test/go-unit-require-nospace
+
+go 1.25.0
+
+require(
+	rsc.io/quote/v4 v4.0.1
+)

--- a/tests/fixtures/go-unit-require-nospace/main.go
+++ b/tests/fixtures/go-unit-require-nospace/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/tests/fixtures/go-unit-stdlib/go.mod
+++ b/tests/fixtures/go-unit-stdlib/go.mod
@@ -1,0 +1,3 @@
+module example.com/go-unit-stdlib
+
+go 1.25.4

--- a/tests/fixtures/go-unit-stdlib/main.go
+++ b/tests/fixtures/go-unit-stdlib/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+func Message() string {
+	return strings.ToUpper("hello from go-unit stdlib")
+}
+
+func main() {
+	fmt.Println(Message())
+}

--- a/tests/fixtures/go-unit-stdlib/main_test.go
+++ b/tests/fixtures/go-unit-stdlib/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func TestMessage(t *testing.T) {
+	if got := Message(); got != "HELLO FROM GO-UNIT STDLIB" {
+		t.Fatalf("Message() = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the PR #147 review findings around `goUnit.buildWorkspace` rejecting valid module sources during evaluation.

- avoids probing `go.mod`, `go.sum`, or `go-modules.nix` when `src` is a derivation output
- lets stdlib-only modules use `vendorHash = null` without a `go.sum`
- keeps local-source vendor hash lookup for checked-in modules
- adds eval/build coverage for a stdlib-only module and the same source copied through a derivation

Review threads:

- https://github.com/indexable-inc/index/pull/147#discussion_r3302267376
- https://github.com/indexable-inc/index/pull/147#discussion_r3302276475

## Checks

- `nix build .#checks.x86_64-linux.eval --no-link`
- `nix run .#lint`
