### PR TITLE
AGENTS: paginate review thread checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,9 +74,18 @@ AI review inline feedback lives in GitHub review threads, which `gh pr view
 PR is clear:
 
 ```sh
-gh api graphql \
+gh api graphql --paginate \
   -f owner=<owner> -f repo=<repo> -F number=<pr> \
-  -f query='query($owner:String!,$repo:String!,$number:Int!){ repository(owner:$owner,name:$repo){ pullRequest(number:$number){ reviewThreads(first:100){ nodes{ id isResolved path line comments(first:50){ nodes{ author{login} body url } } } } } } }'
+  -f query='query($owner:String!,$repo:String!,$number:Int!,$endCursor:String){ repository(owner:$owner,name:$repo){ pullRequest(number:$number){ reviewThreads(first:100,after:$endCursor){ pageInfo{ hasNextPage endCursor } nodes{ id isResolved path line comments(first:100){ pageInfo{ hasNextPage endCursor } nodes{ author{login} body url } } } } } } }'
+```
+
+If a thread reports `comments.pageInfo.hasNextPage`, page that thread's comments
+before declaring it resolved:
+
+```sh
+gh api graphql --paginate \
+  -f thread=<thread-id> \
+  -f query='query($thread:ID!,$endCursor:String){ node(id:$thread){ ... on PullRequestReviewThread{ comments(first:100,after:$endCursor){ pageInfo{ hasNextPage endCursor } nodes{ author{login} body url } } } } }'
 ```
 
 Unresolved AI review threads are immediate blockers. Do not wait on more checks

--- a/agents-md/sections/02-workflow.md
+++ b/agents-md/sections/02-workflow.md
@@ -40,9 +40,18 @@ AI review inline feedback lives in GitHub review threads, which `gh pr view
 PR is clear:
 
 ```sh
-gh api graphql \
+gh api graphql --paginate \
   -f owner=<owner> -f repo=<repo> -F number=<pr> \
-  -f query='query($owner:String!,$repo:String!,$number:Int!){ repository(owner:$owner,name:$repo){ pullRequest(number:$number){ reviewThreads(first:100){ nodes{ id isResolved path line comments(first:50){ nodes{ author{login} body url } } } } } } }'
+  -f query='query($owner:String!,$repo:String!,$number:Int!,$endCursor:String){ repository(owner:$owner,name:$repo){ pullRequest(number:$number){ reviewThreads(first:100,after:$endCursor){ pageInfo{ hasNextPage endCursor } nodes{ id isResolved path line comments(first:100){ pageInfo{ hasNextPage endCursor } nodes{ author{login} body url } } } } } } }'
+```
+
+If a thread reports `comments.pageInfo.hasNextPage`, page that thread's comments
+before declaring it resolved:
+
+```sh
+gh api graphql --paginate \
+  -f thread=<thread-id> \
+  -f query='query($thread:ID!,$endCursor:String){ node(id:$thread){ ... on PullRequestReviewThread{ comments(first:100,after:$endCursor){ pageInfo{ hasNextPage endCursor } nodes{ author{login} body url } } } } }'
 ```
 
 Unresolved AI review threads are immediate blockers. Do not wait on more checks


### PR DESCRIPTION
## Summary

Fixes the PR #128 review finding that the AGENTS review-thread inspection command could miss feedback past the first GraphQL page.

- uses `gh api graphql --paginate` for pull request review threads
- requests `pageInfo` on nested review-thread comments
- adds a second paginated command for any thread whose comments have another page

Review thread:

- https://github.com/indexable-inc/index/pull/128#discussion_r3300148595

## Checks

- `gh api graphql --paginate ...` against PR #128 returned the target thread and `commentsHasNext: false`
- `gh api graphql --paginate ...` against `PRRT_kwDOSS19YM6EooS1` returned the review comment URL
- `nix run .#lint`
