### PR TITLE
dev: fix development base contract

### DIFF
--- a/images/dev/development-base/default.nix
+++ b/images/dev/development-base/default.nix
@@ -1,9 +1,8 @@
 # Default ix dev base image: agent CLIs plus a normal build toolchain.
-# The auto-enabled base profile (modules/profiles/base.nix) supplies the
-# nushell workspace wrapper, gdb/lldb, strace, tcpdump, jq, btop, bpftrace,
-# lsof, ncdu, pv, file, and the gnutar/gzip/zstd trio needed to stay
-# `ix switch`-able. Editors and version control are not in base, so they
-# live here.
+# The auto-enabled base profile (modules/profiles/base.nix) supplies version
+# control, editors, the nushell workspace wrapper, gdb/lldb, strace, tcpdump,
+# jq, btop, bpftrace, lsof, ncdu, pv, file, and the gnutar/gzip/zstd trio
+# needed to stay `ix switch`-able.
 { lib, pkgs, ... }:
 {
   ix.image.name = "development-base";


### PR DESCRIPTION
## Summary

Resolves the PR #61 review thread by making the development-base image comment match the current base profile contract.

The runtime concern is already fixed on `main`: `modules/profiles/base/default.nix` enables Home Manager `programs.git`, Neovim as the default editor, and alternative editors (`helix`, `micro`). The stale development-base header still said editors and version control were not in base, so this updates the durable comment instead of duplicating packages into the image.

Review thread:

- https://github.com/indexable-inc/index/pull/61#discussion_r3265158879

## Checks

- `nix run .#lint`
- `NIXPKGS_ALLOW_UNFREE=1 nix build --impure .#development-base --no-link`

Plain `nix build .#development-base --no-link` stops at the existing local unfree-license gate for `claude-code` before reaching this image build.
