### PR TITLE
examples: probe samba service unit

### DIFF
--- a/examples/multi-client-file-sharing/server.nix
+++ b/examples/multi-client-file-sharing/server.nix
@@ -81,7 +81,7 @@ in
       (lib.getExe' config.systemd.package "systemctl")
       "is-active"
       "--quiet"
-      "smbd.service"
+      "samba-smbd.service"
     ];
   };
 }


### PR DESCRIPTION
## Summary

Fixes the PR #83 review finding that the multi-client file-sharing example health check probes the wrong Samba unit.

- checks `samba-smbd.service`, the unit managed by NixOS `services.samba`
- keeps the check scoped to the example server health gate

Review thread:

- https://github.com/indexable-inc/index/pull/83#discussion_r3271021801

## Checks

- `nix build .#checks.x86_64-linux.eval --no-link`
- `nix run .#lint`
