### PR TITLE
ix-fleet: pass override inputs separately

### DIFF
--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -621,7 +621,7 @@ async def switch_node_from_source(
     if node.switch.buildVm is not None:
         command.extend(["--build-vm", node.switch.buildVm])
     for name, path in sorted(node.switch.overrideInputs.items()):
-        command.extend(["--override-input", f"{name}={path}"])
+        command.extend(["--override-input", name, path])
 
     for attempt in range(1, MAX_SWITCH_RETRIES + 1):
         try:

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -294,6 +294,60 @@ class DownTests(unittest.TestCase):
             asyncio.run(ix_fleet.remove_node(node, dry_run=False))
 
 
+class SwitchSourceTests(unittest.TestCase):
+    def test_override_inputs_are_separate_nix_flag_arguments(self) -> None:
+        calls: list[list[str]] = []
+        node_data = fleet_node("api")
+        node_data["switch"]["buildVm"] = "builder"
+        node_data["switch"]["overrideInputs"] = {
+            "ix": "github:indexable-inc/ix",
+            "ix-images": "path:/workspace/index",
+        }
+        node = ix_fleet.FleetNode.model_validate(node_data)
+
+        def fake_run_cli(command: list[str], *, dry_run: bool, timeout: int | None = None) -> str:
+            del timeout
+            self.assertFalse(dry_run)
+            calls.append(command)
+            return ""
+
+        with patch.object(ix_fleet, "run_cli", fake_run_cli):
+            asyncio.run(
+                ix_fleet.switch_node_from_source(
+                    node,
+                    Path("/source"),
+                    Path("/source/subdir"),
+                    dry_run=False,
+                )
+            )
+
+        self.assertEqual(
+            calls,
+            [
+                [
+                    "ix",
+                    "switch",
+                    "api",
+                    ".#api",
+                    "--build-on",
+                    "remote",
+                    "--source",
+                    "/source",
+                    "--source-workdir",
+                    "/source/subdir",
+                    "--build-vm",
+                    "builder",
+                    "--override-input",
+                    "ix",
+                    "github:indexable-inc/ix",
+                    "--override-input",
+                    "ix-images",
+                    "path:/workspace/index",
+                ],
+            ],
+        )
+
+
 def argparse_namespace(**kwargs: typing.Any) -> typing.Any:
     return type("Args", (), kwargs)()
 


### PR DESCRIPTION
## Summary

Fixes the PR #4 review finding that `ix-fleet` passed flake override inputs as a single `name=path` token.

- serializes each override as `--override-input <input> <flake-url>`
- adds a unit test for source switching with multiple override inputs

Review thread:

- https://github.com/indexable-inc/index/pull/4#discussion_r3215466074

## Checks

- `nix build .#ix-fleet --no-link`
- `nix run .#lint`
