### PR TITLE
modules: tolerate unsupported xattrs

### DIFF
--- a/modules/profiles/extended-attributes.nix
+++ b/modules/profiles/extended-attributes.nix
@@ -50,6 +50,26 @@ let
   setfattr = "${pkgs.attr}/bin/setfattr";
   mkdir = "${pkgs.coreutils}/bin/mkdir";
 
+  applyAttributeFunction = ''
+    ix_set_xattr() {
+      ix_xattr_path=$1
+      ix_xattr_name=$2
+      ix_xattr_value=$3
+
+      ix_xattr_error=$(${setfattr} --name "$ix_xattr_name" --value "$ix_xattr_value" -- "$ix_xattr_path" 2>&1) && return 0
+
+      case "$ix_xattr_error" in
+        *"Operation not supported"* | *"Not supported"* | *"Function not implemented"*)
+          printf '%s\n' "warning: filesystem does not support extended attributes on $ix_xattr_path; skipped $ix_xattr_name" >&2
+          return 0
+          ;;
+      esac
+
+      printf '%s\n' "$ix_xattr_error" >&2
+      return 1
+    }
+  '';
+
   applyPath =
     path: entry:
     let
@@ -63,8 +83,7 @@ let
         else
           lib.concatStringsSep "\n" (
             lib.mapAttrsToList (
-              name: value:
-              "${setfattr} --name ${lib.escapeShellArg name} --value ${lib.escapeShellArg value} -- ${escapedPath}"
+              name: value: "ix_set_xattr ${escapedPath} ${lib.escapeShellArg name} ${lib.escapeShellArg value}"
             ) entry.attributes
           );
     in
@@ -80,7 +99,9 @@ let
       fi
     '';
 
-  applyScript = lib.concatStringsSep "\n" (lib.mapAttrsToList applyPath cfg);
+  applyScript = lib.concatStringsSep "\n" (
+    [ applyAttributeFunction ] ++ lib.mapAttrsToList applyPath cfg
+  );
 in
 {
   options.ix.extendedAttributes = mkOption {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2093,6 +2093,10 @@ let
         assertion = lib.hasInfix "refusing to set extended attributes on symlink" extendedAttributes.activationScript;
         message = "generic ix.extendedAttributes should avoid following symlinks";
       }
+      {
+        assertion = lib.hasInfix "filesystem does not support extended attributes" extendedAttributes.activationScript;
+        message = "generic ix.extendedAttributes should warn instead of failing on unsupported filesystems";
+      }
     ];
 
     kernel-dev = [


### PR DESCRIPTION
## Summary

Fixes the PR #50 review finding that optional runtime xattrs could make activation fail on filesystems without `user.*` xattr support.

- routes activation through an `ix_set_xattr` helper
- keeps symlink refusal and unexpected `setfattr` errors fatal
- downgrades known unsupported-xattr errors to warnings
- adds an eval assertion for the warning path

Review thread:

- https://github.com/indexable-inc/index/pull/50#discussion_r3254617516

## Checks

- `nix build .#checks.x86_64-linux.eval --no-link`
- `nix run .#lint`
