### PR TITLE
lib: expose default ix cli

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -764,10 +764,14 @@ let
           port = 5175;
         };
       };
+      ixCliArgs = lib.optionalAttrs (builtins.hasAttr packageSystem cliArtifacts) {
+        binarySrc = cliArtifacts.${packageSystem};
+      };
       basePackages = {
         dag-runner = pkgs.callPackage paths.packages.dagRunner {
           ix = ixForPackages;
         };
+        ix = pkgs.callPackage paths.packages.ix ixCliArgs;
         drgn = pkgs.callPackage paths.packages.drgn { };
         ix-fleet = pkgs.callPackage paths.packages.ixFleet {
           ix = ixForPackages;
@@ -809,13 +813,8 @@ let
         };
         tonbo-artifacts = pkgs.callPackage paths.packages.tonboArtifacts { };
       };
-      cliPackages = lib.optionalAttrs (builtins.hasAttr packageSystem cliArtifacts) {
-        ix = pkgs.callPackage paths.packages.ix {
-          src = cliArtifacts.${packageSystem};
-        };
-      };
     in
-    basePackages // cliPackages;
+    basePackages;
 
   /**
     Shared Rust workspace source and unit graph for repo-owned crates.

--- a/packages/ix/default.nix
+++ b/packages/ix/default.nix
@@ -1,13 +1,14 @@
 {
   stdenvNoCC,
   fetchurl,
+  binarySrc ? null,
 }:
 
 let
   sources = {
     x86_64-linux = fetchurl {
       url = "https://ix.dev/cli/linux-x86_64/ix";
-      hash = "sha256-U5vAZ1AKsk5XIwXoNwM4Bz7FJ1firsZddY9fwfChsNY=";
+      hash = "sha256-aqPw2lpMcr91M6MleCtmNLDG1hy0B6B3XL0NaWdaeSM=";
     };
     aarch64-darwin = fetchurl {
       url = "https://ix.dev/cli/darwin-arm64/ix";
@@ -20,12 +21,17 @@ let
   };
 
   inherit (stdenvNoCC.hostPlatform) system;
+  selectedSrc =
+    if binarySrc == null then
+      sources.${system} or (throw "ix CLI: no precompiled binary for ${system}")
+    else
+      binarySrc;
 in
 stdenvNoCC.mkDerivation {
   pname = "ix";
   version = "precompiled";
 
-  src = sources.${system} or (throw "ix CLI: no precompiled binary for ${system}");
+  src = selectedSrc;
 
   dontUnpack = true;
   dontBuild = true;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2951,6 +2951,10 @@ let
         message = "repo Rust package builds should be exposed as flake-checkable tests";
       }
       {
+        assertion = repoPackages ? ix && repoPackages.ix.meta.mainProgram == "ix";
+        message = "repo package set should expose the ix CLI package by default";
+      }
+      {
         assertion = repoPackages.minecraft-nbt.passthru.tests ? cargoMachete;
         message = "repo Rust policy checks should be exposed as flake-checkable tests";
       }


### PR DESCRIPTION
## Summary

Fixes the PR #55 review finding that `packages.<system>.ix` disappears when the flake is imported without injected `cliArtifacts`.

- exposes the default ix CLI package from `ix.packageSetFor`
- keeps injected CLI artifacts as an explicit `binarySrc` override
- refreshes the Linux prebuilt CLI hash so `nix build .#ix` works
- adds an eval assertion that the repo package set includes `ix`

Review thread:

- https://github.com/indexable-inc/index/pull/55#discussion_r3263313257

## Checks

- `nix eval --json .#packages.x86_64-linux --apply 'p: builtins.hasAttr "ix" p'`
- `nix build .#ix --no-link`
- `nix build .#checks.x86_64-linux.eval --no-link`
- `nix run .#lint`
