### PR TITLE
velocity: probe configured bind address

### DIFF
--- a/modules/services/velocity.nix
+++ b/modules/services/velocity.nix
@@ -25,6 +25,12 @@ let
   propertiesFormat = pkgs.formats.keyValue { };
   formatValueType = jsonFormat.type;
   fileExt = path: lib.last (lib.splitString "." path);
+  hostPort =
+    address: port:
+    let
+      host = if lib.hasInfix ":" address && !lib.hasPrefix "[" address then "[${address}]" else address;
+    in
+    "${host}:${toString port}";
 
   pluginType = types.submodule (
     { name, ... }:
@@ -176,6 +182,14 @@ let
       '') pluginJars
     );
   };
+  wildcardClientAddresses = [
+    "0.0.0.0"
+    "::"
+    "[::]"
+  ];
+  velocityProbeAddress =
+    if builtins.elem cfg.address wildcardClientAddresses then "127.0.0.1" else cfg.address;
+  velocityProbeTarget = hostPort velocityProbeAddress cfg.port;
 
   installManagedConfigFiles = lib.concatMapStringsSep "\n" (
     path:
@@ -655,13 +669,14 @@ in
           + lib.optionalString (
             cfg.health.motdContains != [ ]
           ) " and the MOTD contains the configured substrings";
-        # Probes loopback inside the guest. Velocity speaks the standard
-        # Java SLP handshake even though it routes traffic to backends, so
-        # an SLP success here proves Velocity itself is healthy independent
-        # of any individual Paper backend's state.
+        # Probe the actual bind address for concrete listeners, and loopback
+        # for wildcard binds. Velocity speaks the standard Java SLP handshake
+        # even though it routes traffic to backends, so an SLP success here
+        # proves Velocity itself is healthy independent of any individual Paper
+        # backend's state.
         command = [
           (lib.getExe ix.packages.mc-probe)
-          "127.0.0.1:${toString cfg.port}"
+          velocityProbeTarget
         ]
         ++ lib.concatMap (needle: [
           "--motd-contains"

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1377,6 +1377,16 @@ let
       };
     }
   ];
+  velocityConcreteAddress = evalConfig [
+    {
+      services.velocity = {
+        enable = true;
+        address = "10.0.0.5";
+        port = 25570;
+        openFirewall = false;
+      };
+    }
+  ];
 
   relativePathUnsafeShellEval = builtins.tryEval (
     builtins.deepSeq (ix.relativePath.shellPath "$out" "../bad") true
@@ -2166,6 +2176,14 @@ let
         assertion =
           minecraft.cfg.properties."online-mode" && minecraft.cfg.properties."enforce-secure-profile";
         message = "default minecraft image should keep account authentication and secure profiles explicit";
+      }
+      {
+        assertion =
+          velocityConcreteAddress.ix.healthChecks.velocity-status.command == [
+            (lib.getExe repoPackages.mc-probe)
+            "10.0.0.5:25570"
+          ];
+        message = "velocity SLP health checks should probe concrete bind addresses";
       }
       {
         assertion =


### PR DESCRIPTION
## Summary

Fixes the PR #55 review finding that Velocity health checks always probe `127.0.0.1` even when `services.velocity.address` is a concrete bind address.

- formats the SLP probe target from the configured bind address for concrete listeners
- keeps loopback probing for wildcard binds
- adds an eval assertion for a non-loopback bind address

Review thread:

- https://github.com/indexable-inc/index/pull/55#discussion_r3263357874

## Checks

- `nix build .#checks.x86_64-linux.eval --no-link`
- `nix run .#lint`
