### PR TITLE
run: retry nonblocking stdin reads

### DIFF
--- a/packages/run/default.nix
+++ b/packages/run/default.nix
@@ -36,6 +36,7 @@ let
         nativeBuildInputs = [
           package
           pkgs.coreutils
+          pkgs.python3
         ];
         strictDeps = true;
       }
@@ -89,6 +90,40 @@ let
         timeout 20s run ${lib.getExe pkgs.bash} -c 'stty -echo; sleep 1; cat >large-stdin-copy; wc -c <large-stdin-copy' \
           <large-stdin-input >large-stdin-stdout 2>large-stdin-stderr
         grep -q "^$large_size" large-stdin-stdout
+
+        export IX_RUN_DIR=$TMPDIR/runs-nonblocking-stdin
+        python3 - <<'PY'
+        import fcntl
+        import os
+        import subprocess
+        import time
+
+        read_fd, write_fd = os.pipe()
+        flags = fcntl.fcntl(read_fd, fcntl.F_GETFL)
+        fcntl.fcntl(read_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+        env = os.environ.copy()
+        payload = b"delayed nonblocking stdin\n"
+        proc = subprocess.Popen(
+            ["run", "${lib.getExe pkgs.bash}", "-c", "cat"],
+            stdin=read_fd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+        )
+        os.close(read_fd)
+        time.sleep(0.2)
+        os.write(write_fd, payload)
+        os.close(write_fd)
+
+        stdout, stderr = proc.communicate(timeout=10)
+        if proc.returncode != 0:
+            raise SystemExit(
+                f"run exited {proc.returncode}; stdout={stdout!r}; stderr={stderr!r}"
+            )
+        if payload.strip() not in stdout:
+            raise SystemExit(f"delayed stdin was not forwarded: stdout={stdout!r}")
+        PY
 
         export IX_RUN_DIR=$TMPDIR/runs-closed-stdin
         (

--- a/packages/run/run.py
+++ b/packages/run/run.py
@@ -534,6 +534,18 @@ def wait_master_writable(master_fd: int) -> bool:
         return False
 
 
+def wait_fd_readable(fd: int) -> bool:
+    try:
+        select.select([fd], [], [])
+        return True
+    except OSError as exc:
+        if exc.errno in EXPECTED_PTY_ERRORS:
+            return False
+        raise
+    except ValueError:
+        return False
+
+
 def write_master(master_fd: int, data: bytes) -> bool:
     remaining = memoryview(data)
     while remaining:
@@ -572,8 +584,20 @@ def forward_stdin(stdin_fd: int, master_fd: int) -> None:
     while True:
         try:
             data = os.read(stdin_fd, READ_SIZE)
+        except BlockingIOError:
+            if wait_fd_readable(stdin_fd):
+                continue
+            send_eot(master_fd)
+            return
+        except InterruptedError:
+            continue
         except OSError as exc:
             if exc.errno in {errno.EBADF, errno.EIO, errno.EINVAL}:
+                send_eot(master_fd)
+                return
+            if exc.errno in RETRYABLE_WRITE_ERRORS:
+                if wait_fd_readable(stdin_fd):
+                    continue
                 send_eot(master_fd)
                 return
             write_stderr(f"ix run: warning: stopped forwarding stdin: {exc}\n")


### PR DESCRIPTION
## Summary

Fixes the PR #127 review finding that inherited nonblocking stdin can raise `EAGAIN` and be mistaken for EOF.

- waits for stdin readability on retryable nonblocking read errors
- keeps closed/fatal stdin behavior unchanged
- adds a package test with a nonblocking pipe and delayed writer

Review thread:

- https://github.com/indexable-inc/index/pull/127#discussion_r3300136151

## Checks

- `nix build .#run.passthru.tests.recordsSession --no-link`
- `nix run .#lint`
