### PR TITLE
minecraft: preserve legacy manifest paths

### DIFF
--- a/packages/minecraft/sync-managed/src/main.rs
+++ b/packages/minecraft/sync-managed/src/main.rs
@@ -119,8 +119,10 @@ fn collect_managed_files(root: &Path, dir: &Path, files: &mut Vec<String>) -> Re
 }
 
 fn manifest_entry(line: &str) -> (&str, Option<&str>) {
-    line.rsplit_once(' ')
-        .map_or((line, None), |(rel, target)| (rel, Some(target)))
+    match line.rsplit_once(' ') {
+        Some((rel, target)) if Path::new(target).is_absolute() => (rel, Some(target)),
+        _ => (line, None),
+    }
 }
 
 fn read_manifest_lines(manifest: &Path) -> Result<Vec<String>> {
@@ -742,6 +744,10 @@ mod tests {
         assert_eq!(
             manifest_entry("plugins/Foo;Bar.yml"),
             ("plugins/Foo;Bar.yml", None)
+        );
+        assert_eq!(
+            manifest_entry("plugins/Foo Bar.yml"),
+            ("plugins/Foo Bar.yml", None)
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the PR #139 review finding that legacy managed-file manifest entries with spaces are split as if the last word were a target path.

- treats a manifest target as present only when the last field is an absolute path
- keeps generated `rel /absolute/source` manifest entries working
- adds a unit assertion for a legacy path with spaces and no target

Review thread:

- https://github.com/indexable-inc/index/pull/139#discussion_r3303339318

## Checks

- `nix run nixpkgs#rustfmt -- --edition 2024 --check packages/minecraft/sync-managed/src/main.rs`
- `nix build .#minecraft-sync-managed --no-link`
- `nix run .#lint`
