### PR TITLE
site: harden mdsvex rendering

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -180,6 +180,7 @@ let
       fs.unions [
         (paths.site + "/package.json")
         (paths.site + "/package-lock.json")
+        (paths.site + "/mdsvex.config.js")
         (paths.site + "/svelte.config.js")
         (paths.site + "/vite.config.ts")
         (paths.site + "/vitest.config.ts")

--- a/site/mdsvex.config.js
+++ b/site/mdsvex.config.js
@@ -1,0 +1,91 @@
+import { escapeSvelte } from 'mdsvex';
+import { codeToHtml } from 'shiki';
+
+const shikiThemes = { light: 'github-light', dark: 'github-dark' };
+const safeAbsoluteLinkProtocols = new Set(['https:', 'http:', 'mailto:']);
+
+export const siteMdsvexOptions = {
+  extensions: ['.svx'],
+  rehypePlugins: [sanitizeLinks],
+  highlight: {
+    // Shiki dual-theme: each span carries both light and dark colors as
+    // CSS variables; app.css picks one based on prefers-color-scheme.
+    highlighter: highlightCode
+  }
+};
+
+export async function highlightCode(code, lang = 'text') {
+  const requestedLang = lang || 'text';
+  let html;
+
+  try {
+    html = await shikiHtml(code, requestedLang);
+  } catch (error) {
+    if (requestedLang === 'text' || !isMissingShikiLanguage(error)) {
+      throw error;
+    }
+
+    html = await shikiHtml(code, 'text');
+  }
+
+  return `{@html \`${escapeSvelte(html)}\`}`;
+}
+
+export function safeHref(value) {
+  if (typeof value !== 'string') return null;
+
+  const href = value.trim();
+  if (href.length === 0 || href.startsWith('//')) return null;
+  if (href.startsWith('/') || href.startsWith('#')) return href;
+
+  try {
+    const url = new URL(href);
+    return safeAbsoluteLinkProtocols.has(url.protocol) ? href : null;
+  } catch {
+    return null;
+  }
+}
+
+async function shikiHtml(code, lang) {
+  return codeToHtml(code, {
+    lang,
+    themes: shikiThemes,
+    defaultColor: false
+  });
+}
+
+function isMissingShikiLanguage(error) {
+  return (
+    error instanceof Error &&
+    /^Language `[^`]+` is not included in this bundle\./.test(error.message)
+  );
+}
+
+function sanitizeLinks() {
+  return (tree) => {
+    visitElements(tree, (node) => {
+      if (node.tagName !== 'a') return;
+
+      const href = safeHref(node.properties?.href);
+      if (href === null) {
+        delete node.properties?.href;
+      } else {
+        node.properties.href = href;
+      }
+    });
+  };
+}
+
+function visitElements(node, visitor) {
+  if (!node || typeof node !== 'object') return;
+
+  if (node.type === 'element') {
+    visitor(node);
+  }
+
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      visitElements(child, visitor);
+    }
+  }
+}

--- a/site/src/lib/fixtures/mdsvex-safety.svx
+++ b/site/src/lib/fixtures/mdsvex-safety.svx
@@ -1,0 +1,9 @@
+[unsafe](javascript:alert(1))
+[protocol-relative](//evil.example/path)
+[root](/index/notes)
+[fragment](#notes)
+[absolute](https://example.com/a%22b)
+
+```not-a-real-language
+plain fallback
+```

--- a/site/src/lib/mdsvex-safety.test.ts
+++ b/site/src/lib/mdsvex-safety.test.ts
@@ -1,0 +1,31 @@
+import { mount, tick, unmount } from 'svelte';
+import { describe, expect, test } from 'vitest';
+import SafetyFixture from './fixtures/mdsvex-safety.svx';
+
+describe('mdsvex rendering', () => {
+  test('keeps unsafe body links inert and falls back for unknown code languages', async () => {
+    const target = document.createElement('div');
+    document.body.append(target);
+
+    const component = mount(SafetyFixture, { target });
+    await tick();
+
+    expect(link(target, 'unsafe')?.hasAttribute('href')).toBe(false);
+    expect(link(target, 'protocol-relative')?.hasAttribute('href')).toBe(false);
+    expect(link(target, 'root')?.getAttribute('href')).toBe('/index/notes');
+    expect(link(target, 'fragment')?.getAttribute('href')).toBe('#notes');
+    expect(link(target, 'absolute')?.getAttribute('href')).toBe(
+      'https://example.com/a%22b'
+    );
+    expect(target.querySelector('pre code')?.textContent).toContain('plain fallback');
+
+    await unmount(component);
+    target.remove();
+  });
+});
+
+function link(root: ParentNode, text: string): HTMLAnchorElement | undefined {
+  return Array.from(root.querySelectorAll('a')).find(
+    (anchor) => anchor.textContent === text
+  );
+}

--- a/site/src/mdsvex.d.ts
+++ b/site/src/mdsvex.d.ts
@@ -1,0 +1,7 @@
+declare module '*.svx' {
+  import type { Component } from 'svelte';
+
+  const component: Component;
+  export default component;
+  export const metadata: Record<string, unknown>;
+}

--- a/site/svelte.config.js
+++ b/site/svelte.config.js
@@ -1,28 +1,14 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
-import { mdsvex, escapeSvelte } from 'mdsvex';
-import { codeToHtml } from 'shiki';
+import { mdsvex } from 'mdsvex';
+import { siteMdsvexOptions } from './mdsvex.config.js';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   extensions: ['.svelte', '.svx'],
   preprocess: [
     vitePreprocess(),
-    mdsvex({
-      extensions: ['.svx'],
-      highlight: {
-        // Shiki dual-theme: each span carries both light and dark colors as
-        // CSS variables; app.css picks one based on prefers-color-scheme.
-        highlighter: async (code, lang = 'text') => {
-          const html = await codeToHtml(code, {
-            lang,
-            themes: { light: 'github-light', dark: 'github-dark' },
-            defaultColor: false
-          });
-          return `{@html \`${escapeSvelte(html)}\`}`;
-        }
-      }
-    })
+    mdsvex(siteMdsvexOptions)
   ],
   kit: {
     adapter: adapter({

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -1,9 +1,9 @@
 import { fileURLToPath } from 'node:url';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { playwright } from '@vitest/browser-playwright';
-import { mdsvex, escapeSvelte } from 'mdsvex';
-import { codeToHtml } from 'shiki';
+import { mdsvex } from 'mdsvex';
 import { defineConfig } from 'vitest/config';
+import { siteMdsvexOptions } from './mdsvex.config.js';
 
 // vitest uses @sveltejs/vite-plugin-svelte directly (not the full sveltekit
 // plugin) so the browser server doesn't try to spin up a SvelteKit dev
@@ -22,19 +22,7 @@ export default defineConfig({
     svelte({
       extensions: ['.svelte', '.svx'],
       preprocess: [
-        mdsvex({
-          extensions: ['.svx'],
-          highlight: {
-            highlighter: async (code, lang = 'text') => {
-              const html = await codeToHtml(code, {
-                lang,
-                themes: { light: 'github-light', dark: 'github-dark' },
-                defaultColor: false
-              });
-              return `{@html \`${escapeSvelte(html)}\`}`;
-            }
-          }
-        })
+        mdsvex(siteMdsvexOptions)
       ]
     })
   ],


### PR DESCRIPTION
## Summary
- share the site mdsvex options between SvelteKit and Vitest
- remove unsafe markdown body hrefs while preserving safe https, http, mailto, root, and fragment links
- fall back to Shiki text highlighting when an `.svx` code fence names an unsupported language
- cover the link allowlist and code-fence fallback with an `.svx` browser fixture

## Checks
- `nix build .#site --no-link`
- `nix build .#checks.x86_64-linux.site-test --no-link`
- `nix run .#lint`

Refs #149
Refs #158
