### PR TITLE
ci: guard ai review gate by base branch

### DIFF
--- a/.github/workflows/ai-review-gate.yml
+++ b/.github/workflows/ai-review-gate.yml
@@ -831,6 +831,7 @@ jobs:
     name: >-
       ${{
         github.event.pull_request.draft == false &&
+        github.event.pull_request.base.ref == 'main' &&
         (
           (inputs.caller_event_name || github.event_name) == 'pull_request' ||
           (inputs.caller_event_name || github.event_name) == 'pull_request_target' ||
@@ -849,6 +850,7 @@ jobs:
     if: >-
       always() &&
       github.event.pull_request.draft == false &&
+      github.event.pull_request.base.ref == 'main' &&
       (
         (inputs.caller_event_name || github.event_name) == 'pull_request' ||
         (inputs.caller_event_name || github.event_name) == 'pull_request_target' ||


### PR DESCRIPTION
## Summary
- skip the required AI review gate for PR events whose base branch is not `main`
- keep the existing event, fork, draft, and Dependabot gating intact for `main` PRs

## Checks
- `nix run nixpkgs#actionlint -- .github/workflows/ai-review-gate.yml`
- `nix run .#lint`

Refs #137 review feedback.
