### PR TITLE
site: preview deployed base path

### DIFF
--- a/lib/build-svelte-site.nix
+++ b/lib/build-svelte-site.nix
@@ -22,7 +22,8 @@
   - `installDir`: path under `$out` where built assets are installed.
   - `installFlags`: extra Bun install flags when `packageManager = "bun"`.
   - `extraNativeBuildInputs`: extra packages on PATH for the build.
-  - `serve`: static preview settings, including `name`, `host`, and `port`.
+  - `serve`: static preview settings, including `name`, `host`, `port`, and
+    `routePrefix`.
   - `devServer`: checkout dev-server settings, including `name`,
     `checkoutSubdir`, `host`, `port`, and `autoInstall`.
   - `meta`: standard derivation meta.
@@ -186,6 +187,7 @@ let
     name = pname;
     host = "127.0.0.1";
     port = 8080;
+    routePrefix = null;
     spa = true;
     extraFlags = [ ];
   };
@@ -194,12 +196,17 @@ let
     lib.optionals serveConfig.spa [
       "--index"
       "index.html"
+      "--spa"
     ]
     ++ [
       "--interfaces"
       serveConfig.host
       "--port"
       (toString serveConfig.port)
+    ]
+    ++ lib.optionals (serveConfig.routePrefix != null && serveConfig.routePrefix != "") [
+      "--route-prefix"
+      serveConfig.routePrefix
     ]
     ++ serveConfig.extraFlags
     ++ [ "${staticSite}/${installDir}" ];
@@ -310,17 +317,27 @@ let
       devServer = devServerPackage;
     };
 in
-pkgs.symlinkJoin {
-  name = "${pname}-${version}";
-  paths = [
-    staticSite
-  ]
-  ++ lib.optional serveConfig.enable servePackage
-  ++ lib.optional devConfig.enable devServerPackage;
-  inherit passthru;
-  meta =
-    meta
-    // lib.optionalAttrs serveConfig.enable {
-      mainProgram = meta.mainProgram or serveConfig.name;
-    };
-}
+pkgs.runCommand "${pname}-${version}"
+  {
+    strictDeps = true;
+    inherit passthru;
+    meta =
+      meta
+      // lib.optionalAttrs serveConfig.enable {
+        mainProgram = meta.mainProgram or serveConfig.name;
+      };
+  }
+  ''
+    mkdir -p "$out"
+    cp -R -L --no-preserve=mode,ownership ${staticSite}/. "$out"/
+
+    ${lib.optionalString serveConfig.enable ''
+      mkdir -p "$out/bin"
+      ln -s ${lib.escapeShellArg "${servePackage}/bin/${serveConfig.name}"} "$out/bin"/${lib.escapeShellArg serveConfig.name}
+    ''}
+
+    ${lib.optionalString devConfig.enable ''
+      mkdir -p "$out/bin"
+      ln -s ${lib.escapeShellArg "${devServerPackage}/bin/${devConfig.name}"} "$out/bin"/${lib.escapeShellArg devConfig.name}
+    ''}
+  ''

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -197,40 +197,23 @@ let
     version = "0.1.0";
     src = siteSrc;
     distDir = "build";
-    serve.enable = false;
+    serve = {
+      name = "ix-site";
+      routePrefix = "/index";
+    };
     devServer = {
       name = "ix-site-dev";
       checkoutSubdir = "site";
     };
   };
 
-  # Local preview build: same source, but with the SvelteKit base path
-  # cleared so miniserve can serve it from the URL root. The deployed
-  # artifact (`siteBuild`) keeps the `/index` prefix for GitHub Pages.
-  sitePreviewBuild = ix.buildSvelteSite pkgs {
-    pname = "ix-site-preview";
-    version = "0.1.0";
-    src = siteSrc;
-    distDir = "build";
-    preBuild = "export BASE_PATH=";
-    installDir = "share/ix-site-preview";
-    serve.name = "ix-site";
-    devServer.enable = false;
-  };
-
-  site = pkgs.symlinkJoin {
-    name = "ix-site-0.1.0";
-    paths = [
-      siteBuild
-      sitePreviewBuild
-    ];
-    passthru = {
-      devServer = siteBuild.passthru.devServer;
-      preview = sitePreviewBuild;
+  # The local preview serves the same `/index` build that Pages deploys.
+  site = siteBuild.overrideAttrs (old: {
+    passthru = (old.passthru or { }) // {
+      preview = siteBuild.passthru.serve;
       static = siteBuild.passthru.staticSite;
     };
-    meta.mainProgram = "ix-site";
-  };
+  });
 
   siteTests = ix.buildNpmVitest pkgs {
     pname = "ix-site";

--- a/site/src/lib/updates/nix-run-site.svx
+++ b/site/src/lib/updates/nix-run-site.svx
@@ -6,24 +6,27 @@ tags: [nix, site, cli]
 links:
   - label: per-system wiring
     href: https://github.com/indexable-inc/index/blob/main/lib/per-system.nix
-  - label: build-npm-site
-    href: https://github.com/indexable-inc/index/blob/main/lib/build-npm-site.nix
+  - label: build-svelte-site
+    href: https://github.com/indexable-inc/index/blob/main/lib/build-svelte-site.nix
 ---
 
-The `site` package is now a `symlinkJoin` of the deploy artifact and a tiny `miniserve` wrapper, so `nix build .#site` still emits the GitHub Pages tree and `nix run .#site` boots a preview at `http://127.0.0.1:8080/`.
+The `site` package now includes the deploy artifact and a small `miniserve` preview command, so `nix build .#site` emits the GitHub Pages tree and `nix run .#site` boots a preview at `http://127.0.0.1:8080/index/`.
 
 ```bash
 nix build github:indexable-inc/index#site   # GitHub Pages tree under result/share/ix-site
-nix run   github:indexable-inc/index#site   # preview at http://127.0.0.1:8080/
+nix run   github:indexable-inc/index#site   # preview at http://127.0.0.1:8080/index/
 ```
 
-The wrapper points at a second `buildNpmSite` invocation whose `preBuild` exports `BASE_PATH=`, leaning on SvelteKit's own base-path plumbing instead of rewriting URLs in the server layer. `buildNpmSite` stays focused on building.
+The wrapper serves the same SvelteKit build that Pages deploys. `ix.buildSvelteSite` passes miniserve a route prefix instead of rebuilding with a different `BASE_PATH`, so local preview exercises the production `/index` URL layout.
 
 ```nix
-sitePreviewBuild = ix.buildNpmSite pkgs {
-  pname = "ix-site-preview";
+siteBuild = ix.buildSvelteSite pkgs {
+  pname = "ix-site";
   src = siteSrc;
   distDir = "build";
-  preBuild = "export BASE_PATH=";
+  serve = {
+    name = "ix-site";
+    routePrefix = "/index";
+  };
 };
 ```

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1097,6 +1097,7 @@ let
     serve = {
       name = "svelte-site-fixture";
       port = 8180;
+      routePrefix = "/fixture";
       extraFlags = [
         "--title"
         "Svelte Site Fixture"
@@ -3709,6 +3710,10 @@ let
     test -x ${bunSite.bunNodeModules.nodeCompat}/bin/node
     grep -q 'class="ix npm"' ${npmSite}/share/npm-site-fixture/index.html
     grep -q 'class="ix svelte"' ${svelteSite}/share/svelte-site-fixture/index.html
+    test ! -L ${svelteSite}/share/svelte-site-fixture
+    test ! -L ${svelteSite}/share/svelte-site-fixture/index.html
+    grep -q -- '--route-prefix' ${svelteSite.passthru.serve}/bin/svelte-site-fixture
+    grep -q -- '/fixture' ${svelteSite.passthru.serve}/bin/svelte-site-fixture
     test -x ${svelteSite}/bin/svelte-site-fixture
     grep -q -- "Svelte Site Fixture" ${svelteSite}/bin/svelte-site-fixture
     test -x ${svelteSite.passthru.devServer}/bin/svelte-site-fixture-dev


### PR DESCRIPTION
## Summary
- make `ix.buildSvelteSite` build preview commands with structured Nushell argv instead of wrapper-quoted flag strings
- add `serve.routePrefix` and use it for `.#site` so local preview serves the production `/index` build
- keep the packaged static site tree as real files and remove the second site build

## Checks
- `nix eval --raw .#site.meta.mainProgram`
- `nix build .#site --no-link`
- `nix build .#checks.x86_64-linux.eval --no-link`
- `nix build .#checks.x86_64-linux.site-test --no-link`
- `nix run .#lint`

Refs #151 review feedback.
