### PR TITLE
cargo-unit: decouple workspace policy from packages

### DIFF
--- a/lib/cargo-unit.nix
+++ b/lib/cargo-unit.nix
@@ -384,6 +384,7 @@ let
             lib.nameValuePair "${prefix}${targetName}-${lib.replaceStrings [ "::" ] [ "-" ] case}" drv
           ) (target.cases or { })
         ) (lib.getAttrs (builtins.filter (name: targets ? ${name}) targetNames) targets);
+      policyChecks = workspace.policyChecks or { };
       testCases =
         flattenCaseTargets "" selectedTestTargets (workspace.tests or { })
         // flattenCaseTargets "doctest-" selectedDoctestTargets (workspace.doctests or { });
@@ -401,11 +402,8 @@ let
         (binaryDrv.passthru or { })
         // passthru
         // {
-          tests =
-            (binaryDrv.passthru.tests or { })
-            // (binaryDrv.passthru.policyChecks or { })
-            // (passthru.tests or { })
-            // tests;
+          tests = (binaryDrv.passthru.tests or { }) // policyChecks // (passthru.tests or { }) // tests;
+          inherit policyChecks;
           inherit (workspace) policy;
         };
     };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -831,21 +831,31 @@ let
     workspacePkgs:
     let
       inherit (paths) root;
+      rustPackageFiles =
+        packagePath:
+        lib.fileset.intersection (lib.fileset.gitTracked packagePath) (
+          lib.fileset.unions [
+            (packagePath + "/Cargo.toml")
+            (packagePath + "/src")
+            (lib.fileset.maybeMissing (packagePath + "/tests"))
+            (lib.fileset.maybeMissing (packagePath + "/templates"))
+          ]
+        );
       src = lib.fileset.toSource {
         inherit root;
         fileset = lib.fileset.intersection (lib.fileset.gitTracked root) (
           lib.fileset.unions [
             (root + "/Cargo.toml")
             (root + "/Cargo.lock")
-            (paths.modules + "/services/resource-monitor/stats-writer")
-            paths.packages.dagRunner
-            paths.packages.ixDevDiagnose
-            paths.packages.loop
-            paths.packages.mcp
-            paths.packages.minecraft.nbt
-            paths.packages.minecraft.syncManaged
-            paths.packages.nixCargoUnit
-            paths.packages.ociImageBuilder
+            (rustPackageFiles (paths.modules + "/services/resource-monitor/stats-writer"))
+            (rustPackageFiles paths.packages.dagRunner)
+            (rustPackageFiles paths.packages.ixDevDiagnose)
+            (rustPackageFiles paths.packages.loop)
+            (rustPackageFiles paths.packages.mcp)
+            (rustPackageFiles paths.packages.minecraft.nbt)
+            (rustPackageFiles paths.packages.minecraft.syncManaged)
+            (rustPackageFiles paths.packages.nixCargoUnit)
+            (rustPackageFiles paths.packages.ociImageBuilder)
           ]
         );
       };
@@ -872,10 +882,9 @@ let
           "build"
           "test"
         ];
-        # Every policy check runs once across the whole workspace: a
-        # regression in any single crate fails the workspace selection.
-        # `cargoUnit.buildWorkspace`'s defaults already enable each check;
-        # this block makes the contract explicit at the workspace root.
+        # Every policy check runs once across the whole workspace. Selected
+        # package outputs expose these as explicit tests instead of making
+        # downstream binary builds depend on unrelated workspace policy.
         policy = {
           denyUnusedCrateDependencies = true;
           cargoAudit.enable = true;

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -2138,7 +2138,7 @@ fn render_root_entries_for(
         }
         let _ = writeln!(
             entries,
-            "    {} = withPolicyChecks units.{};",
+            "    {} = units.{};",
             nix_attr(&unit.target.name),
             nix_attr(&prepared.names[*index])
         );
@@ -3030,12 +3030,7 @@ version = "0.1.0"
 
         assert!(rendered.contains("targetSets = ["));
         assert_eq!(rendered.matches("binaries = {").count(), 3);
-        assert_eq!(
-            rendered
-                .matches("\"hello\" = withPolicyChecks units.")
-                .count(),
-            4
-        );
+        assert_eq!(rendered.matches("\"hello\" = units.").count(), 4);
     }
 
     #[test]

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2803,8 +2803,8 @@ let
         message = "cargo-unit workspaces should expose a cargo-machete policy check by default";
       }
       {
-        assertion = cargoUnitWorkspace.binaries.cargo-unit-hello ? unchecked;
-        message = "cargo-unit package outputs should be wrapped by policy checks by default";
+        assertion = !(cargoUnitWorkspace.binaries.cargo-unit-hello ? unchecked);
+        message = "cargo-unit package outputs should stay independent from aggregate policy checks";
       }
       {
         assertion = builtins.hasAttr "cargo_unit_hello-all" cargoUnitSelectedHello.passthru.tests;
@@ -2944,6 +2944,16 @@ let
       {
         assertion = repoPackages.minecraft-nbt.passthru.tests ? cargoMachete;
         message = "repo Rust policy checks should be exposed as flake-checkable tests";
+      }
+      {
+        assertion = !(repoPackages.dag-runner.passthru ? unchecked);
+        message = "repo Rust package outputs should not wrap unrelated workspace policy checks";
+      }
+      {
+        assertion =
+          builtins.pathExists (ix.rustWorkspace.src + "/packages/loop/src/main.rs")
+          && !(builtins.pathExists (ix.rustWorkspace.src + "/packages/loop/site/package.json"));
+        message = "repo Rust workspace source should exclude loop viewer site files";
       }
       {
         assertion = builtins.hasAttr "integration-all" repoPackages.dag-runner.passthru.tests;


### PR DESCRIPTION
## Summary
- keep generated cargo-unit package/binary outputs independent from aggregate workspace policy checks
- continue exposing workspace policy checks through `passthru.policyChecks` and `passthru.tests`
- narrow the repo Rust workspace source to Cargo files, Rust sources, tests, and templates so web site files do not perturb Rust package source closures

## Validation
- `nix run nixpkgs#rustfmt -- --edition 2024 packages/nix-cargo-unit/src/render.rs`
- `nix build .#checks.x86_64-linux.rust-nix-cargo-unit-package --no-link`
- `nix build .#checks.x86_64-linux.eval --no-link`
- `nix eval --raw .#dag-runner.name`
- `nix eval --raw .#dag-runner.passthru.policyChecks.cargoMachete.name`
- `nix eval --json .#dag-runner.passthru.tests --apply 'builtins.attrNames'`
- `nix build .#dag-runner --no-link`
- `nix build .#checks.x86_64-linux.rust-dag-runner-package --no-link`
- `nix run .#lint`

Addresses the two unresolved Rust workspace review threads from #125.
