### PR TITLE
ix-fleet: replace existing nodes on up

### DIFF
--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -658,26 +658,29 @@ async def replace_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
 
 
 async def up_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
-    if dry_run:
-        verb = "recreate" if node.recreateOnUp else "ensure"
-        step(f"{verb} {node.name} from uploaded image {image}")
-        return
-
     existing = find_node(await list_nodes(), node.name)
     if existing is not None and node.recreateOnUp:
+        if dry_run:
+            step(f"recreate existing {node.name} from uploaded image {image}")
         run_cli(["ix", "rm", "--force", node.name], dry_run=dry_run)
         await create_node(node, image, dry_run=dry_run)
         return
 
     if existing is None:
+        if dry_run:
+            step(f"create missing {node.name} from uploaded image {image}")
         await create_node(node, image, dry_run=dry_run)
         return
 
     if existing.get("status") == "failed":
+        if dry_run:
+            step(f"replace failed {node.name} from uploaded image {image}")
         run_cli(["ix", "rm", "--force", node.name], dry_run=dry_run)
         await create_node(node, image, dry_run=dry_run)
         return
 
+    if dry_run:
+        step(f"replace existing {node.name} from uploaded image {image}")
     await replace_node(node, image, dry_run=dry_run)
 
 

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -678,8 +678,7 @@ async def up_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
         await create_node(node, image, dry_run=dry_run)
         return
 
-    if existing.get("status") != "running":
-        run_cli(["ix", "start", node.name], dry_run=dry_run)
+    await replace_node(node, image, dry_run=dry_run)
 
 
 async def cmd_diff(plan: FleetPlan, args: argparse.Namespace) -> None:

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -658,29 +658,31 @@ async def replace_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
 
 
 async def up_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
+    if dry_run:
+        if node.recreateOnUp:
+            step(f"recreate {node.name} from uploaded image {image}")
+            run_cli(["ix", "rm", "--force", node.name], dry_run=dry_run)
+            await create_node(node, image, dry_run=dry_run)
+        else:
+            step(f"create or replace {node.name} from uploaded image {image}")
+            await replace_node(node, image, dry_run=dry_run)
+        return
+
     existing = find_node(await list_nodes(), node.name)
     if existing is not None and node.recreateOnUp:
-        if dry_run:
-            step(f"recreate existing {node.name} from uploaded image {image}")
         run_cli(["ix", "rm", "--force", node.name], dry_run=dry_run)
         await create_node(node, image, dry_run=dry_run)
         return
 
     if existing is None:
-        if dry_run:
-            step(f"create missing {node.name} from uploaded image {image}")
         await create_node(node, image, dry_run=dry_run)
         return
 
     if existing.get("status") == "failed":
-        if dry_run:
-            step(f"replace failed {node.name} from uploaded image {image}")
         run_cli(["ix", "rm", "--force", node.name], dry_run=dry_run)
         await create_node(node, image, dry_run=dry_run)
         return
 
-    if dry_run:
-        step(f"replace existing {node.name} from uploaded image {image}")
     await replace_node(node, image, dry_run=dry_run)
 
 

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -200,13 +200,13 @@ class UpNodeTests(unittest.TestCase):
         self.assertEqual(calls[0][:3], ["ix", "new", "registry.ix.dev/example/web:new"])
         self.assertNotIn(["ix", "start", "web"], calls)
 
-    def test_dry_run_shows_existing_node_replacement(self) -> None:
+    def test_dry_run_shows_possible_node_replacement_without_live_lookup(self) -> None:
         calls: list[list[str]] = []
         steps: list[str] = []
         node = ix_fleet.FleetNode.model_validate(fleet_node("web"))
 
-        async def fake_list_nodes() -> list[dict[str, typing.Any]]:
-            return [{"name": "web", "status": "running"}]
+        async def fail_list_nodes() -> list[dict[str, typing.Any]]:
+            self.fail("dry-run up should not require live node state")
 
         def fake_run_cli(command: list[str], *, dry_run: bool, timeout: int | None = None) -> str:
             del timeout
@@ -215,13 +215,13 @@ class UpNodeTests(unittest.TestCase):
             return ""
 
         with (
-            patch.object(ix_fleet, "list_nodes", fake_list_nodes),
+            patch.object(ix_fleet, "list_nodes", fail_list_nodes),
             patch.object(ix_fleet, "run_cli", fake_run_cli),
             patch.object(ix_fleet, "step", steps.append),
         ):
             asyncio.run(ix_fleet.up_node(node, "registry.ix.dev/example/web:new", dry_run=True))
 
-        self.assertEqual(steps, ["replace existing web from uploaded image registry.ix.dev/example/web:new"])
+        self.assertEqual(steps, ["create or replace web from uploaded image registry.ix.dev/example/web:new"])
         self.assertEqual(calls[0][:3], ["ix", "new", "registry.ix.dev/example/web:new"])
 
 

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -142,6 +142,65 @@ class PushReplacementImageTests(unittest.TestCase):
             self.assertEqual(image, "registry.ix.dev/example/health-check-nginx:nginx-lifecycle")
 
 
+class UpNodeTests(unittest.TestCase):
+    def test_replaces_existing_running_node_with_uploaded_image(self) -> None:
+        calls: list[list[str]] = []
+        node = ix_fleet.FleetNode.model_validate(fleet_node("web"))
+
+        async def fake_list_nodes() -> list[dict[str, typing.Any]]:
+            return [{"name": "web", "status": "running"}]
+
+        def fake_run_cli(command: list[str], *, dry_run: bool, timeout: int | None = None) -> str:
+            del timeout
+            self.assertFalse(dry_run)
+            calls.append(command)
+            return ""
+
+        with (
+            patch.object(ix_fleet, "list_nodes", fake_list_nodes),
+            patch.object(ix_fleet, "run_cli", fake_run_cli),
+        ):
+            asyncio.run(ix_fleet.up_node(node, "registry.ix.dev/example/web:new", dry_run=False))
+
+        self.assertEqual(
+            calls,
+            [
+                [
+                    "ix",
+                    "new",
+                    "registry.ix.dev/example/web:new",
+                    "--name",
+                    "web",
+                    "--region",
+                    "us-west-1",
+                    "--no-shell",
+                ]
+            ],
+        )
+
+    def test_replaces_existing_stopped_node_instead_of_starting_old_image(self) -> None:
+        calls: list[list[str]] = []
+        node = ix_fleet.FleetNode.model_validate(fleet_node("web"))
+
+        async def fake_list_nodes() -> list[dict[str, typing.Any]]:
+            return [{"name": "web", "status": "stopped"}]
+
+        def fake_run_cli(command: list[str], *, dry_run: bool, timeout: int | None = None) -> str:
+            del timeout
+            self.assertFalse(dry_run)
+            calls.append(command)
+            return ""
+
+        with (
+            patch.object(ix_fleet, "list_nodes", fake_list_nodes),
+            patch.object(ix_fleet, "run_cli", fake_run_cli),
+        ):
+            asyncio.run(ix_fleet.up_node(node, "registry.ix.dev/example/web:new", dry_run=False))
+
+        self.assertEqual(calls[0][:3], ["ix", "new", "registry.ix.dev/example/web:new"])
+        self.assertNotIn(["ix", "start", "web"], calls)
+
+
 class EastWestGroupTests(unittest.TestCase):
     def test_ensures_group_before_adding_node(self) -> None:
         calls: list[list[str]] = []

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -200,6 +200,30 @@ class UpNodeTests(unittest.TestCase):
         self.assertEqual(calls[0][:3], ["ix", "new", "registry.ix.dev/example/web:new"])
         self.assertNotIn(["ix", "start", "web"], calls)
 
+    def test_dry_run_shows_existing_node_replacement(self) -> None:
+        calls: list[list[str]] = []
+        steps: list[str] = []
+        node = ix_fleet.FleetNode.model_validate(fleet_node("web"))
+
+        async def fake_list_nodes() -> list[dict[str, typing.Any]]:
+            return [{"name": "web", "status": "running"}]
+
+        def fake_run_cli(command: list[str], *, dry_run: bool, timeout: int | None = None) -> str:
+            del timeout
+            self.assertTrue(dry_run)
+            calls.append(command)
+            return ""
+
+        with (
+            patch.object(ix_fleet, "list_nodes", fake_list_nodes),
+            patch.object(ix_fleet, "run_cli", fake_run_cli),
+            patch.object(ix_fleet, "step", steps.append),
+        ):
+            asyncio.run(ix_fleet.up_node(node, "registry.ix.dev/example/web:new", dry_run=True))
+
+        self.assertEqual(steps, ["replace existing web from uploaded image registry.ix.dev/example/web:new"])
+        self.assertEqual(calls[0][:3], ["ix", "new", "registry.ix.dev/example/web:new"])
+
 
 class EastWestGroupTests(unittest.TestCase):
     def test_ensures_group_before_adding_node(self) -> None:


### PR DESCRIPTION
## Summary
- make `ix-fleet up` replace existing non-failed nodes with the uploaded replacement image
- keep missing and failed-node bootstrap behavior unchanged
- add regression coverage for running and stopped nodes so `up` no longer starts an old image after pushing a new one

## Validation
- `nix build .#ix-fleet --no-link`
- `nix run nixpkgs#uv -- --directory packages/ix-fleet run python -m unittest discover tests`
- `nix run .#lint`

Addresses the unresolved `ix-fleet up` rollout review thread from #20.
