### PR TITLE
lib: validate process-compose runtime args

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -195,6 +195,7 @@ let
           inherit processes;
         }
       );
+      processComposeArgsText = lib.escapeShellArgs processComposeArgs;
       package = writeNushellApplication pkgs {
         inherit name;
         runtimeInputs = [ pkgs.process-compose ] ++ runtimeInputs;
@@ -217,7 +218,7 @@ let
             strictDeps = true;
           }
           ''
-            process-compose --config ${config} --dry-run --no-server --disable-dotenv
+            process-compose --config ${config} ${processComposeArgsText} --dry-run
             mkdir -p "$out"
           '';
     in

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -513,6 +513,11 @@ let
     check = false;
   };
 
+  processComposeApplication = ix.writeProcessComposeApplication pkgs {
+    name = "process-compose-fixture";
+    processes.hello.command = "true";
+  };
+
   zigAppFixture = fs.toSource {
     root = ./fixtures/zig-app;
     fileset = fs.unions [
@@ -2656,6 +2661,10 @@ let
         message = "cargo-unit workspaces should expose an unused dependency policy check by default";
       }
       {
+        assertion = lib.hasInfix "--ordered-shutdown" processComposeApplication.passthru.tests.dryRun.buildCommand;
+        message = "process-compose dry-run checks should include runtime wrapper arguments";
+      }
+      {
         assertion = goUnitWorkspace.sourceAudit.module.lockFile == "go.sum";
         message = "go-unit workspaces should require and report the Go module lockfile";
       }
@@ -3412,6 +3421,7 @@ let
 
     ${lib.getExe pythonAppClosureProbe} > python-app-closure-probe.out
     grep -q 'python app source is in the runtime closure' python-app-closure-probe.out
+    test -e ${processComposeApplication.passthru.tests.dryRun}
 
     ${lib.getExe zigApplication} > zig-app-fixture.out
     grep -q 'hello from zig app fixture' zig-app-fixture.out


### PR DESCRIPTION
## Summary
- pass configured `processComposeArgs` through the process-compose dry-run derivation
- add a helper fixture that asserts the default runtime-only `--ordered-shutdown` flag is covered
- build the fixture dry-run in the eval helper test

## Tests
- `nix build .#checks.x86_64-linux.eval --no-link`
- `nix run .#lint`
- `git diff --check`

Fixes review thread from #181.
