### PR TITLE
go-unit: reject unreadable no-sum modules

### DIFF
--- a/lib/go-unit.nix
+++ b/lib/go-unit.nix
@@ -54,7 +54,8 @@ let
           lib.hasPrefix "require(" compactLine
           || (lib.hasPrefix "require" compactLine && compactLine != "require")
         ) (lib.splitString "\n" (builtins.readFile checkedGoMod));
-      noSumModule = requestedNoSumModule && !readableGoModHasRequire;
+      unreadableNoSumModule = requestedNoSumModule && !canReadGoMod;
+      noSumModule = requestedNoSumModule && canReadGoMod && !readableGoModHasRequire;
       goSumForBuild =
         if explicitGoSum then
           args.goSum
@@ -67,8 +68,10 @@ let
           (goSumForBuild == null && noSumModule)
           || (goSumForBuild != null && builtins.pathExists goSumForBuild)
         else
-          goSumForBuild != null || noSumModule || !canReadModuleFiles;
+          goSumForBuild != null || noSumModule || (!canReadModuleFiles && !requestedNoSumModule);
       missingGoSumMessage = "goUnit.buildWorkspace requires ${builtins.toString goSum}; pass vendorHash = null only for stdlib-only modules without go.sum";
+      unreadableNoSumMessage = "goUnit.buildWorkspace cannot verify vendorHash = null against ${builtins.toString goMod}; pass a readable goMod or a real vendorHash";
+      requireNoSumMessage = "goUnit.buildWorkspace vendorHash = null is only for stdlib-only modules without require directives";
       canReadGoSum =
         goSumForBuild != null && (canReadModuleFiles || explicitGoSum) && builtins.pathExists goSumForBuild;
       canDeriveVendorHashKey = canReadGoMod && (canReadGoSum || noSumModule);
@@ -112,6 +115,8 @@ let
         );
     in
     assert lib.assertMsg goModExists missingGoModMessage;
+    assert lib.assertMsg (!unreadableNoSumModule) unreadableNoSumMessage;
+    assert lib.assertMsg (!requestedNoSumModule || !readableGoModHasRequire) requireNoSumMessage;
     assert lib.assertMsg goSumExists missingGoSumMessage;
     {
       pname = args.pname or "go-unit";

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -718,6 +718,7 @@ let
   goUnitDerivedStdlibWorkspace = ix.goUnit.buildWorkspace {
     pname = "go-unit-stdlib-derived";
     src = goUnitDerivedStdlibSource;
+    goMod = ./fixtures/go-unit-stdlib/go.mod;
     vendorHash = null;
     packages = [ "." ];
   };
@@ -732,6 +733,15 @@ let
     vendorHashFile = ./fixtures/go-unit-hello/go-modules.nix;
     packages = [ "." ];
   };
+  goUnitDerivedUnreadableNoSumEval = builtins.tryEval (
+    builtins.attrNames
+      (ix.goUnit.buildWorkspace {
+        pname = "go-unit-hello-derived-no-sum";
+        src = goUnitDerivedSource;
+        vendorHash = null;
+        packages = [ "." ];
+      }).packages
+  );
   goUnitDerivedMissingGoSumKeyEval =
     let
       workspace = ix.goUnit.buildWorkspace {
@@ -2901,14 +2911,18 @@ let
         message = "go-unit package derivations should pass null goSum for modules without go.sum";
       }
       {
-        assertion = goUnitDerivedStdlibWorkspace.vendorHashKey == null;
-        message = "go-unit workspaces should not read derivation source module files during eval";
+        assertion = goUnitDerivedStdlibWorkspace.packages.root.goUnit.goSum == null;
+        message = "go-unit derivation sources should allow no-sum modules when go.mod is readable";
       }
       {
         assertion =
           goUnitDerivedWorkspaceWithVendorHashFile.packages.root.goUnit.vendorHashKey
           == goUnitWorkspace.vendorHashKey;
         message = "go-unit derivation sources should use explicit vendor hash files by key";
+      }
+      {
+        assertion = !goUnitDerivedUnreadableNoSumEval.success;
+        message = "go-unit derivation sources should reject no-sum mode when go.mod is unreadable";
       }
       {
         assertion = !goUnitDerivedMissingGoSumKeyEval.success;


### PR DESCRIPTION
## Summary
- require `vendorHash = null` to be backed by a readable `go.mod` with no `require` directives
- keep derivation-backed stdlib modules working when callers pass an explicit readable `goMod`
- add a regression for unreadable derivation sources requesting no-sum mode

## Checks
- `nix build .#checks.x86_64-linux.eval --no-link`
- `nix run .#lint`
- `git diff --check`

Refs #187 review thread: https://github.com/indexable-inc/index/pull/187#discussion_r3305000396
