### PR TITLE
ci: ignore publisher identity url errors

### DIFF
--- a/.github/workflows/ai-review-gate.yml
+++ b/.github/workflows/ai-review-gate.yml
@@ -409,7 +409,7 @@ jobs:
           def try_request_api_json(method: str, path: str, data: dict[str, Any] | None = None) -> Any:
               try:
                   return request_api_json(method, path, data)
-              except RuntimeError as error:
+              except (RuntimeError, urllib.error.URLError) as error:
                   print(f"warning: could not resolve publisher identity from {path}: {error}", file=sys.stderr)
                   return None
 


### PR DESCRIPTION
## Summary
- keep publisher identity discovery optional when urllib raises `URLError`
- preserve the existing RuntimeError handling for API failures

## Checks
- embedded workflow Python blocks compiled with `nix run nixpkgs#python3 -- -m py_compile ...`
- `git diff --check`
- `nix run .#lint`

Refs #202 review thread: https://github.com/indexable-inc/index/pull/202#discussion_r3305551959
