### PR TITLE
AGENTS: protect user-authored PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,10 @@ on auto-merge. The AI review gate is the default code review signal for
 agent-authored PRs; do not add or preserve a separate GitHub code-quality lane
 unless the user asks for it.
 
+Check the PR author before pushing to, closing, merging, enabling auto-merge for,
+or otherwise modifying a PR. Do not change PRs authored by another GitHub user
+unless that user or the operator explicitly authorizes it.
+
 AI review inline feedback lives in GitHub review threads, which `gh pr view
 --comments` does not show. Inspect unresolved threads directly before deciding a
 PR is clear:

--- a/agents-md/sections/02-workflow.md
+++ b/agents-md/sections/02-workflow.md
@@ -35,6 +35,10 @@ on auto-merge. The AI review gate is the default code review signal for
 agent-authored PRs; do not add or preserve a separate GitHub code-quality lane
 unless the user asks for it.
 
+Check the PR author before pushing to, closing, merging, enabling auto-merge for,
+or otherwise modifying a PR. Do not change PRs authored by another GitHub user
+unless that user or the operator explicitly authorizes it.
+
 AI review inline feedback lives in GitHub review threads, which `gh pr view
 --comments` does not show. Inspect unresolved threads directly before deciding a
 PR is clear:


### PR DESCRIPTION
## Summary
- document that agents must check PR authors before changing PRs
- require explicit user/operator authorization before modifying or merging another GitHub user's PR

## Checks
- `nix run .#lint`
- `git diff --check`
