### PR TITLE
room: log listening address on startup

### DIFF
--- a/packages/room/src/main.rs
+++ b/packages/room/src/main.rs
@@ -75,6 +75,7 @@ async fn main() -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .with_context(|| format!("failed to bind {addr}"))?;
+    eprintln!("room listening on http://{addr}");
 
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())


### PR DESCRIPTION
`nix run .#room` produced no output until Ctrl-C, making it look like nothing was happening. Log the bound address to stderr right after `TcpListener::bind` so operators see the server come up.