### PR TITLE
room: avoid crypto.randomUUID in non-secure contexts

### DIFF
--- a/packages/room/site/src/App.svelte
+++ b/packages/room/site/src/App.svelte
@@ -27,10 +27,25 @@
     if (saved) {
       return saved;
     }
-    const fresh = crypto.randomUUID();
+    const fresh = newRoomId();
     localStorage.setItem('room-id', fresh);
     return fresh;
   })();
+
+  // crypto.randomUUID is only defined in secure contexts (HTTPS or
+  // http://localhost). Fall back to getRandomValues so the room works over
+  // plain HTTP on a LAN IP or Tailscale hostname.
+  function newRoomId(): string {
+    if (typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = [...bytes].map((b) => b.toString(16).padStart(2, '0'));
+    return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
+  }
 
   const doc = new LoroDoc();
   const participants = doc.getMap('participants');


### PR DESCRIPTION
Loading the room UI over plain HTTP from a non-localhost address (LAN IP, Tailscale hostname, etc.) crashed with:

\`\`\`
Uncaught TypeError: crypto.randomUUID is not a function
\`\`\`

\`crypto.randomUUID\` is only defined in secure contexts (HTTPS or http://localhost). Add a UUIDv4 fallback built from \`crypto.getRandomValues\`, which is available in insecure contexts, so the room id keeps the same shape regardless of where the page is served from.
