### PR TITLE
gitignore: cover svelte-kit, terraform, python, editor, and macOS artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,52 @@
+# Nix
 result
-.direnv
+result-*
+.direnv/
+
+# ix CLI local state
 .ix/
-.gradle
-build
-target
+
+# Build outputs
+.gradle/
+build/
+target/
+buck-out/
+dist/
+
+# Node / pnpm
+node_modules/
+.pnpm-store/
+
+# SvelteKit / Vite
+.svelte-kit/
+.vite/
+
+# Python
 __pycache__/
 *.py[cod]
 *$py.class
-packages/loop/site/dist/
-packages/loop/site/node_modules/
+.venv/
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.basedpyright/
+
+# Terraform / OpenTofu local state
+.terraform/
+*.tfstate
+*.tfstate.*
+
+# Local caches and scratch
+.tmp/
+.hegel/
+.worktrees/
+
+# Editors
+.idea/
+
+# Claude Code per-machine overrides
+.claude/settings.local.json
+
+# macOS
+.DS_Store


### PR DESCRIPTION
Local builds and tooling were leaving the working tree dirty with paths the existing `.gitignore` did not cover. Rather than relying on each contributor's global ignore, fold the common ones into the repo file.

New coverage:

- `result-*` for additional Nix profile symlinks alongside `result`.
- `node_modules/`, `dist/`, `.svelte-kit/`, `.vite/` for the JS/TS workspaces (replaces the obsolete `packages/loop/site/*` entries — that path no longer exists).
- Python: `.venv/`, `*.egg-info/`, `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`, `.basedpyright/`.
- Terraform/OpenTofu local state: `.terraform/`, `*.tfstate`, `*.tfstate.*`. `.terraform.lock.hcl` is left tracked per the usual Terraform recommendation.
- Local scratch: `.tmp/`, `.hegel/`, `.worktrees/`, `buck-out/`.
- Editor: `.idea/` (`.vscode/` and `.zed/` keep their tracked shared settings).
- `.claude/settings.local.json` for per-machine Claude Code overrides.
- macOS `.DS_Store`.

Verified no currently tracked file becomes ignored, and `nix run .#lint` passes.
