### PR TITLE
lib/agents-md: expose mkApp and add craft + reply-shape general sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,35 @@ Each addition should be one or two direct sentences. Name the invariant, owner,
 or decision rule, and include a path, command, URL, or external reference only
 when it is the durable handle for that rule.
 
+## Craft standard
+
+Treat every change as work that someone else will read after the merge cools off.
+Prefer the simplest design that makes the owner obvious. Compose small named
+helpers and typed boundaries; avoid copy-pasted orchestration and anonymous
+blobs of shape.
+
+DRY up repeated mechanics when they express one domain fact. Do not hide
+legitimately different behavior behind a forced abstraction; three similar
+lines are better than a premature shared helper.
+
+Refactor after the patch works. A passing diff with awkward ownership is not
+done. Replace string-shaped domain values with typed constructors or
+declarative helpers at the owner boundary instead of pushing parsing back into
+callers.
+
+Treat lint failures as design feedback. Suppress only for a deliberate local
+invariant, a generated or external shape, or a documented tool limitation. Keep
+the suppression small and explain it next to the line.
+
+Reject fallback paths. If an owner, route, capability, config, schema, or
+transport is unavailable, return a typed error and make it observable rather
+than guessing a safe default. Sentinel values, silent retries, and hidden
+backstops trade today's reliability for tomorrow's debugging.
+
+Tests defend behavior or invariants. Skip tests that mirror implementation
+trivia; they pin the next refactor to today's shape without protecting any
+caller.
+
 ## Workflow
 
 Pull `main` before starting. Always make changes on a short-lived branch in a
@@ -176,6 +205,42 @@ split the sentence or use a colon.
 
 Avoid balanced three-part cadence when it feels manufactured. Vary the rhythm:
 two beats, four beats, a precise odd detail, or a short sentence with teeth.
+
+## Reply shape
+
+These rules cover answers written back to the user in chat, PR comments, issue
+replies, and review notes.
+
+Lead with the highest-impact concrete fact. No preamble about what you are
+about to inspect, no filler, no delayed setup.
+
+When an answer depends on repo evidence, include that evidence even for quick
+factual answers. A fast `rg` or `Read` hit is a reason to cite the owner
+snippet, not a reason to skip it. Prefer the file that directly stores or
+defines the answer; fall back to a nearby owner snippet only when the direct
+file is unavailable or would expose a secret the user has not asked to inspect.
+
+For codebase questions about where something lives, how it works, what reads
+what, why a behavior happens, or what value is configured: lead with a one-line
+answer, then the repo-relative path, then a minimal owner snippet, then the
+consequence in plain English. Skip "I'll inspect..." unless you are about to
+do a longer investigation that benefits from a stated plan.
+
+Avoid inline file paths inside prose unless the path is the answer. Use
+descriptive labels and a reference list when there are several paths. This rule
+never overrides the snippet requirement.
+
+Use numbered steps for sequences, bullets for parallel facts, and short
+paragraphs for explanations. No decorative emoji unless the user asks. No
+em dashes and no double-hyphen substitutes in human prose; split the sentence
+or change the punctuation.
+
+Avoid rhetorical tics that pattern-match as generated prose: balanced "X, not
+Y" contrasts, three-part lists for cadence rather than content, "I'll happily
+help with..." openers.
+
+Do not hard-wrap PR descriptions, issue bodies, review comments, or any
+Markdown sent to a hosted renderer. Let the renderer reflow paragraphs.
 
 ## Inline comments
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,35 @@ Each addition should be one or two direct sentences. Name the invariant, owner,
 or decision rule, and include a path, command, URL, or external reference only
 when it is the durable handle for that rule.
 
+## Craft standard
+
+Treat every change as work that someone else will read after the merge cools off.
+Prefer the simplest design that makes the owner obvious. Compose small named
+helpers and typed boundaries; avoid copy-pasted orchestration and anonymous
+blobs of shape.
+
+DRY up repeated mechanics when they express one domain fact. Do not hide
+legitimately different behavior behind a forced abstraction; three similar
+lines are better than a premature shared helper.
+
+Refactor after the patch works. A passing diff with awkward ownership is not
+done. Replace string-shaped domain values with typed constructors or
+declarative helpers at the owner boundary instead of pushing parsing back into
+callers.
+
+Treat lint failures as design feedback. Suppress only for a deliberate local
+invariant, a generated or external shape, or a documented tool limitation. Keep
+the suppression small and explain it next to the line.
+
+Reject fallback paths. If an owner, route, capability, config, schema, or
+transport is unavailable, return a typed error and make it observable rather
+than guessing a safe default. Sentinel values, silent retries, and hidden
+backstops trade today's reliability for tomorrow's debugging.
+
+Tests defend behavior or invariants. Skip tests that mirror implementation
+trivia; they pin the next refactor to today's shape without protecting any
+caller.
+
 ## Workflow
 
 Pull `main` before starting. Always make changes on a short-lived branch in a
@@ -176,6 +205,42 @@ split the sentence or use a colon.
 
 Avoid balanced three-part cadence when it feels manufactured. Vary the rhythm:
 two beats, four beats, a precise odd detail, or a short sentence with teeth.
+
+## Reply shape
+
+These rules cover answers written back to the user in chat, PR comments, issue
+replies, and review notes.
+
+Lead with the highest-impact concrete fact. No preamble about what you are
+about to inspect, no filler, no delayed setup.
+
+When an answer depends on repo evidence, include that evidence even for quick
+factual answers. A fast `rg` or `Read` hit is a reason to cite the owner
+snippet, not a reason to skip it. Prefer the file that directly stores or
+defines the answer; fall back to a nearby owner snippet only when the direct
+file is unavailable or would expose a secret the user has not asked to inspect.
+
+For codebase questions about where something lives, how it works, what reads
+what, why a behavior happens, or what value is configured: lead with a one-line
+answer, then the repo-relative path, then a minimal owner snippet, then the
+consequence in plain English. Skip "I'll inspect..." unless you are about to
+do a longer investigation that benefits from a stated plan.
+
+Avoid inline file paths inside prose unless the path is the answer. Use
+descriptive labels and a reference list when there are several paths. This rule
+never overrides the snippet requirement.
+
+Use numbered steps for sequences, bullets for parallel facts, and short
+paragraphs for explanations. No decorative emoji unless the user asks. No
+em dashes and no double-hyphen substitutes in human prose; split the sentence
+or change the punctuation.
+
+Avoid rhetorical tics that pattern-match as generated prose: balanced "X, not
+Y" contrasts, three-part lists for cadence rather than content, "I'll happily
+help with..." openers.
+
+Do not hard-wrap PR descriptions, issue bodies, review comments, or any
+Markdown sent to a hosted renderer. Let the renderer reflow paragraphs.
 
 ## Inline comments
 

--- a/agents-md/sections/01b-craft-standard.md
+++ b/agents-md/sections/01b-craft-standard.md
@@ -1,0 +1,28 @@
+## Craft standard
+
+Treat every change as work that someone else will read after the merge cools off.
+Prefer the simplest design that makes the owner obvious. Compose small named
+helpers and typed boundaries; avoid copy-pasted orchestration and anonymous
+blobs of shape.
+
+DRY up repeated mechanics when they express one domain fact. Do not hide
+legitimately different behavior behind a forced abstraction; three similar
+lines are better than a premature shared helper.
+
+Refactor after the patch works. A passing diff with awkward ownership is not
+done. Replace string-shaped domain values with typed constructors or
+declarative helpers at the owner boundary instead of pushing parsing back into
+callers.
+
+Treat lint failures as design feedback. Suppress only for a deliberate local
+invariant, a generated or external shape, or a documented tool limitation. Keep
+the suppression small and explain it next to the line.
+
+Reject fallback paths. If an owner, route, capability, config, schema, or
+transport is unavailable, return a typed error and make it observable rather
+than guessing a safe default. Sentinel values, silent retries, and hidden
+backstops trade today's reliability for tomorrow's debugging.
+
+Tests defend behavior or invariants. Skip tests that mirror implementation
+trivia; they pin the next refactor to today's shape without protecting any
+caller.

--- a/agents-md/sections/04b-reply-shape.md
+++ b/agents-md/sections/04b-reply-shape.md
@@ -1,0 +1,35 @@
+## Reply shape
+
+These rules cover answers written back to the user in chat, PR comments, issue
+replies, and review notes.
+
+Lead with the highest-impact concrete fact. No preamble about what you are
+about to inspect, no filler, no delayed setup.
+
+When an answer depends on repo evidence, include that evidence even for quick
+factual answers. A fast `rg` or `Read` hit is a reason to cite the owner
+snippet, not a reason to skip it. Prefer the file that directly stores or
+defines the answer; fall back to a nearby owner snippet only when the direct
+file is unavailable or would expose a secret the user has not asked to inspect.
+
+For codebase questions about where something lives, how it works, what reads
+what, why a behavior happens, or what value is configured: lead with a one-line
+answer, then the repo-relative path, then a minimal owner snippet, then the
+consequence in plain English. Skip "I'll inspect..." unless you are about to
+do a longer investigation that benefits from a stated plan.
+
+Avoid inline file paths inside prose unless the path is the answer. Use
+descriptive labels and a reference list when there are several paths. This rule
+never overrides the snippet requirement.
+
+Use numbered steps for sequences, bullets for parallel facts, and short
+paragraphs for explanations. No decorative emoji unless the user asks. No
+em dashes and no double-hyphen substitutes in human prose; split the sentence
+or change the punctuation.
+
+Avoid rhetorical tics that pattern-match as generated prose: balanced "X, not
+Y" contrasts, three-part lists for cadence rather than content, "I'll happily
+help with..." openers.
+
+Do not hard-wrap PR descriptions, issue bodies, review comments, or any
+Markdown sent to a hosted renderer. Let the renderer reflow paragraphs.

--- a/lib/agents-md.nix
+++ b/lib/agents-md.nix
@@ -9,10 +9,12 @@ let
   sectionList = [
     (section "intro" "00-intro.md")
     (section "scope" "01-scope-of-agents-md.md")
+    (section "craft" "01b-craft-standard.md")
     (section "workflow" "02-workflow.md")
     (section "indexGitPush" "02a-index-git-push.md")
     (section "siteUpdates" "03-site-updates.md")
     (section "writingStyle" "04-writing-style.md")
+    (section "replyShape" "04b-reply-shape.md")
     (section "inlineComments" "05-inline-comments.md")
     (section "rustStyle" "06-rust-style.md")
     (section "pythonStyle" "07-python-style.md")
@@ -42,8 +44,10 @@ let
   profiles = {
     common = [
       "scope"
+      "craft"
       "workflow"
       "writingStyle"
+      "replyShape"
       "inlineComments"
       "rustStyle"
       "pythonStyle"

--- a/lib/agents-md.nix
+++ b/lib/agents-md.nix
@@ -129,11 +129,15 @@ let
     )
     + "\n";
 
-  documentList = map (target: {
-    target = target.name;
-    inherit (target) fileName;
-    text = render { target = target.name; };
-  }) targetList;
+  documentListFor =
+    renderArgs:
+    map (target: {
+      target = target.name;
+      inherit (target) fileName;
+      text = render (renderArgs // { target = target.name; });
+    }) targetList;
+
+  documentList = documentListFor { };
 
   documents = lib.listToAttrs (
     map (document: {
@@ -141,6 +145,60 @@ let
       value = removeAttrs document [ "target" ];
     }) documentList
   );
+
+  mkApp =
+    {
+      pkgs,
+      binary,
+      enabledSections ? allSections,
+      extraSections ? [ ],
+      extraSectionsByTarget ? { },
+      targetSections ? { },
+    }:
+    let
+      customDocumentList = documentListFor {
+        inherit
+          enabledSections
+          extraSections
+          extraSectionsByTarget
+          targetSections
+          ;
+      };
+      generatedDocuments = lib.listToAttrs (
+        map (document: {
+          name = document.target;
+          value = pkgs.writeText document.fileName document.text;
+        }) customDocumentList
+      );
+      documentsConfig = pkgs.writeText "agents-md-documents.json" (
+        builtins.toJSON (
+          map (document: {
+            inherit (document) target;
+            file_name = document.fileName;
+            generated_path = "${generatedDocuments.${document.target}}";
+          }) customDocumentList
+        )
+      );
+    in
+    pkgs.runCommand "agents-md"
+      {
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+        strictDeps = true;
+        meta = (binary.meta or { }) // {
+          description = "Diff, check, and write generated Codex and Claude instruction files";
+          mainProgram = "agents-md";
+        };
+        passthru = (binary.passthru or { }) // {
+          inherit documentsConfig;
+          documentList = customDocumentList;
+        };
+      }
+      ''
+        mkdir -p "$out/bin"
+        makeWrapper ${binary}/bin/agents-md "$out/bin/agents-md" \
+          --set AGENTS_MD_DOCUMENTS ${documentsConfig} \
+          --set AGENTS_MD_DELTA ${lib.getExe pkgs.delta}
+      '';
 in
 {
   /**
@@ -196,4 +254,15 @@ in
     - `targetSections`: attrset from target name to extra named section keys.
   */
   inherit render;
+
+  /**
+    Wrap the `agents-md` CLI with a caller-specific document set.
+
+    Consumer repositories pass the unwrapped binary from
+    `index.packages.<system>.agents-md.passthru.unwrapped` plus their own
+    render arguments and get back a `nix run`-able package that writes the
+    consumer's `AGENTS.md` and `CLAUDE.md`. Arguments after `binary` mirror
+    `render` and are applied to every target.
+  */
+  inherit mkApp;
 }

--- a/packages/agents-md/default.nix
+++ b/packages/agents-md/default.nix
@@ -1,6 +1,5 @@
 {
   ix,
-  lib,
   pkgs ? ix.pkgs,
 }:
 
@@ -9,37 +8,10 @@ let
     binary = "agents-md";
     meta.mainProgram = "agents-md";
   };
-  generatedDocuments = lib.listToAttrs (
-    map (document: {
-      name = document.target;
-      value = pkgs.writeText document.fileName document.text;
-    }) ix.agentsMd.documentList
-  );
-  documentsConfig = pkgs.writeText "agents-md-documents.json" (
-    builtins.toJSON (
-      map (document: {
-        inherit (document) target;
-        file_name = document.fileName;
-        generated_path = "${generatedDocuments.${document.target}}";
-      }) ix.agentsMd.documentList
-    )
-  );
-  package =
-    pkgs.runCommand "agents-md"
-      {
-        nativeBuildInputs = [ pkgs.makeWrapper ];
-        strictDeps = true;
-        meta = (unwrapped.meta or { }) // {
-          description = "Diff, check, and write generated Codex and Claude instruction files";
-          mainProgram = "agents-md";
-        };
-      }
-      ''
-        mkdir -p "$out/bin"
-        makeWrapper ${unwrapped}/bin/agents-md "$out/bin/agents-md" \
-          --set AGENTS_MD_DOCUMENTS ${documentsConfig} \
-          --set AGENTS_MD_DELTA ${lib.getExe pkgs.delta}
-      '';
+  package = ix.agentsMd.mkApp {
+    inherit pkgs;
+    binary = unwrapped;
+  };
 in
 package.overrideAttrs (old: {
   passthru =


### PR DESCRIPTION
Exposes the agents-md document set as a reusable library so other repos can wrap the binary with their own sections.

## What

- `lib.agentsMd.mkApp { pkgs, binary, enabledSections?, extraSections?, extraSectionsByTarget?, targetSections? }` returns a `nix run`-able CLI wrapped with a caller-defined document set. The `binary` is the unwrapped derivation from `packages.agents-md.passthru.unwrapped`.
- `packages/agents-md/default.nix` now goes through `mkApp` with the default render config, so this repo's checked-in `AGENTS.md` / `CLAUDE.md` are unchanged byte-for-byte.
- Two new general sections: `craft` and `replyShape`. Both join `profiles.common` and ship in this repo's `AGENTS.md` / `CLAUDE.md`.

## Why

The ix repo (and any future ix-shaped consumer) wants `nix run .#agents-md -- --write` that pulls the general fragments from here and layers its own ix-specific sections on top. Previously the package baked in this repo's document list at build time, so consumers couldn't reuse the binary.

## Consumer shape

```nix
packages.agents-md = index.lib.agentsMd.mkApp {
  inherit pkgs;
  binary = index.packages.${system}.agents-md.passthru.unwrapped;
  enabledSections = index.lib.agentsMd.profiles.common ++ index.lib.agentsMd.profiles.nix;
  extraSections = map builtins.readFile [
    ./agents-md/sections/ix-architecture.md
    # ...
  ];
};
```

## Verification

- `nix run .#agents-md -- --check` passes on this branch (this repo's `AGENTS.md` / `CLAUDE.md` are regenerated and match).
- `nix run .#lint` passes.

The new `craft` and `replyShape` content was distilled from ix's existing `AGENTS.md` so the same prose ships to both repos once the ix consumer lands.
