### PR TITLE
AGENTS: discourage assertions and tests that restate the source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -660,6 +660,36 @@ When a change tightens source filtering, dependency identity, generated
 derivations, or cache behavior, add a test that changes one small input and
 proves the unrelated output remains unchanged.
 
+### Delete checks that restate the source
+
+Do not write, and proactively delete, checks whose only job is to re-spell a
+constant that lives a few lines away. A check is restating code when changing
+the source forces the same edit in the check, or when the check could only fail
+if someone hand-edited it to disagree with itself. These add maintenance cost
+without ruling out any real bug. Concrete shapes to remove:
+
+- NixOS module `assertions = [ { assertion = ...; message = ...; } ]` entries
+  that compare an option to the literal value the same module or a sibling file
+  sets (pinned versions, dates, image tags, derivation names, enum variants
+  routed through `mkDefault`).
+- Flake `checks`, `passthru.tests`, or `installCheckPhase` blocks that re-grep
+  a hash, version string, or filename out of a derivation that the build
+  already pinned.
+- Unit tests, Rust `assert_eq!`s, or Python `assert`s that compare a constant
+  to itself through an indirection, mirror the function body line-for-line, or
+  pin an enum's `Display` impl to its own variant names.
+
+Keep an assertion or test when it crosses a real boundary: two files that must
+agree but have no shared source of truth, a generated artifact that must match
+a manifest, a runtime invariant that the type system cannot express, or a
+regression you can name with a failing reproduction. If the failure mode you
+are guarding against is "someone edited both halves to lie in unison," the
+check is not earning its keep.
+
+Fix the root cause instead. When two places must agree, route both through one
+binding, one option default, or one generated value, and let the type checker
+or module merge enforce the link.
+
 ## Searching
 
 Use exact text search for exact questions and semantic search for fuzzy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -660,6 +660,36 @@ When a change tightens source filtering, dependency identity, generated
 derivations, or cache behavior, add a test that changes one small input and
 proves the unrelated output remains unchanged.
 
+### Delete checks that restate the source
+
+Do not write, and proactively delete, checks whose only job is to re-spell a
+constant that lives a few lines away. A check is restating code when changing
+the source forces the same edit in the check, or when the check could only fail
+if someone hand-edited it to disagree with itself. These add maintenance cost
+without ruling out any real bug. Concrete shapes to remove:
+
+- NixOS module `assertions = [ { assertion = ...; message = ...; } ]` entries
+  that compare an option to the literal value the same module or a sibling file
+  sets (pinned versions, dates, image tags, derivation names, enum variants
+  routed through `mkDefault`).
+- Flake `checks`, `passthru.tests`, or `installCheckPhase` blocks that re-grep
+  a hash, version string, or filename out of a derivation that the build
+  already pinned.
+- Unit tests, Rust `assert_eq!`s, or Python `assert`s that compare a constant
+  to itself through an indirection, mirror the function body line-for-line, or
+  pin an enum's `Display` impl to its own variant names.
+
+Keep an assertion or test when it crosses a real boundary: two files that must
+agree but have no shared source of truth, a generated artifact that must match
+a manifest, a runtime invariant that the type system cannot express, or a
+regression you can name with a failing reproduction. If the failure mode you
+are guarding against is "someone edited both halves to lie in unison," the
+check is not earning its keep.
+
+Fix the root cause instead. When two places must agree, route both through one
+binding, one option default, or one generated value, and let the type checker
+or module merge enforce the link.
+
 ## Searching
 
 Use exact text search for exact questions and semantic search for fuzzy

--- a/agents-md/sections/17-tests.md
+++ b/agents-md/sections/17-tests.md
@@ -14,3 +14,33 @@ When a change tightens source filtering, dependency identity, generated
 derivations, or cache behavior, add a test that changes one small input and
 proves the unrelated output remains unchanged.
 
+### Delete checks that restate the source
+
+Do not write, and proactively delete, checks whose only job is to re-spell a
+constant that lives a few lines away. A check is restating code when changing
+the source forces the same edit in the check, or when the check could only fail
+if someone hand-edited it to disagree with itself. These add maintenance cost
+without ruling out any real bug. Concrete shapes to remove:
+
+- NixOS module `assertions = [ { assertion = ...; message = ...; } ]` entries
+  that compare an option to the literal value the same module or a sibling file
+  sets (pinned versions, dates, image tags, derivation names, enum variants
+  routed through `mkDefault`).
+- Flake `checks`, `passthru.tests`, or `installCheckPhase` blocks that re-grep
+  a hash, version string, or filename out of a derivation that the build
+  already pinned.
+- Unit tests, Rust `assert_eq!`s, or Python `assert`s that compare a constant
+  to itself through an indirection, mirror the function body line-for-line, or
+  pin an enum's `Display` impl to its own variant names.
+
+Keep an assertion or test when it crosses a real boundary: two files that must
+agree but have no shared source of truth, a generated artifact that must match
+a manifest, a runtime invariant that the type system cannot express, or a
+regression you can name with a failing reproduction. If the failure mode you
+are guarding against is "someone edited both halves to lie in unison," the
+check is not earning its keep.
+
+Fix the root cause instead. When two places must agree, route both through one
+binding, one option default, or one generated value, and let the type checker
+or module merge enforce the link.
+


### PR DESCRIPTION
Adds a "Delete checks that restate the source" subsection under Tests in
`agents-md/sections/17-tests.md` (and regenerates `AGENTS.md` / `CLAUDE.md`).

Motivation: the recent nightly bump exposed Nix module `assertions` and
sibling test entries whose only job is to re-spell a constant a few lines
away (e.g. asserting `lib.hasInfix "nightly-2026-05-27"` against the same
pin set in `lib/languages/rust.nix`). These tighten nothing — changing the
source forces the same edit in the check, and the only way they fail is if
someone hand-edits one half to disagree with itself.

The new guidance:

- names the three concrete shapes to remove (module `assertions`, flake
  `checks`/`passthru.tests` that re-grep pinned derivation outputs, and
  unit/Rust/Python tests that compare a constant to itself), and
- tells agents to proactively delete them rather than letting them accrete,
- keeps room for assertions that cross a real boundary (two files with no
  shared source of truth, generated artifact vs. manifest, runtime
  invariants the type system cannot express),
- and points at the root-cause fix: route both halves through one binding
  so module merge or the type checker enforces the link.
