### PR TITLE
feat(cargo-unit): expose vendorDir and vendorSources

### DIFF
--- a/lib/cargo-unit.nix
+++ b/lib/cargo-unit.nix
@@ -424,6 +424,51 @@ let
       workspace = buildWorkspace (builtins.removeAttrs args [ "binaries" ]);
     in
     lib.genAttrs binaries (binary: workspace.binaries.${binary} or workspace.default);
+
+  /**
+    Materialize a Cargo vendor directory from a `Cargo.lock` without building
+    the workspace unit graph. Callers that aren't going through
+    `buildWorkspace` (e.g. an `overrideAttrs` of a foreign Rust derivation, or
+    a non-workspace tool fetched as a single crate) can reuse the same
+    static.crates.io fetcher and git-source plumbing that `buildWorkspace`
+    uses internally.
+
+    Arguments:
+    - `cargoLock`: path to the `Cargo.lock` to vendor.
+    - `outputHashes`: attrset keyed by the exact `Cargo.lock` git source
+      string (e.g. `"git+https://github.com/owner/repo#rev"`); value is the
+      sha256 of the resolved git tree.
+    - `sourceOverrides`: optional attrset mapping `Cargo.lock` source strings
+      to pre-fetched source trees, used when a private git dependency cannot
+      be fetched from inside the build sandbox.
+    - `vendorDir`: optional pre-built vendor directory that short-circuits
+      resolution. Mirrors `buildWorkspace`'s `vendorDir` arg.
+
+    Returns a `pkgs.linkFarm` of `<name>-<version>` -> source tree, the same
+    shape `buildWorkspace` materializes.
+  */
+  vendorDir =
+    args:
+    rust.resolveVendorDir {
+      inherit (args) cargoLock;
+      outputHashes = args.outputHashes or { };
+      sourceOverrides = args.sourceOverrides or { };
+      vendorDir = args.vendorDir or null;
+    };
+
+  /**
+    Materialize the per-package source attrset used by `vendorDir`. Useful for
+    callers that need to address individual vendored crates rather than the
+    aggregate link farm. See `vendorDir` for the shared argument shape.
+  */
+  vendorSources =
+    args:
+    rust.resolveVendorSources {
+      inherit (args) cargoLock;
+      outputHashes = args.outputHashes or { };
+      sourceOverrides = args.sourceOverrides or { };
+      vendorSources = args.vendorSources or null;
+    };
 in
 {
   inherit
@@ -434,5 +479,7 @@ in
     auditCargoLock
     generateUnitGraph
     generateUnitsNix
+    vendorDir
+    vendorSources
     ;
 }


### PR DESCRIPTION
## Summary

- Adds two thin public helpers on `cargoUnit` — `vendorDir` and `vendorSources` — that call straight into the existing internal `rust.resolveVendorDir`/`resolveVendorSources`.
- Lets non-workspace callers (e.g. `overrideAttrs` of a foreign Rust derivation, or single-crate tools fetched ahead of time) reuse the same `static.crates.io` fetcher and git-source plumbing that `buildWorkspace` already uses internally.
- Motivated by ix: it had a parallel `importCargoLock` wrapper that still emitted `crates.io/api/v1/.../download` URLs and started 403'ing once that endpoint required `User-Agent`. With this helper exposed, ix can drop that wrapper and route every Rust vendoring path through index's already-patched mapping (#227).

## Test plan

- [ ] `nix flake check` stays green; the new helpers are additive and don't change `buildWorkspace` behavior.
- [ ] Downstream ix migration PR builds against this rev.