### PR TITLE
fix(rust): read repo nightly pin from rust-toolchain

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -130,6 +130,7 @@ let
         rustWorkspaceFor
         clippy-fork
         ;
+      repoRoot = paths.root;
     })
     buildIxRustTool
     cargoUnitFor

--- a/lib/languages/rust.nix
+++ b/lib/languages/rust.nix
@@ -16,16 +16,6 @@ let
   ];
 
   /**
-    Repo-wide pinned nightly date. Exposed below as
-    `ix.languages.rust.defaultNightlyDate` so the internal
-    `rustNightlyToolchainFor` in `lib/default.nix` can grep-stably
-    forward it through `toolchain`. Bumping this advances every
-    consumer that calls `toolchain pkgs { channel = "nightly"; version
-    = languages.rust.defaultNightlyDate; }`.
-  */
-  defaultNightlyDate = "2026-05-27";
-
-  /**
     Toolchain components everyone gets by default. The shape mirrors
     the `minimal` profile so the override surface is the same whether
     a caller selects `profile = "minimal"` or accepts the default
@@ -67,8 +57,6 @@ let
       "${channel}-${version}";
 in
 {
-  inherit defaultNightlyDate;
-
   /**
     Build a rust-overlay toolchain.
 
@@ -82,8 +70,6 @@ in
     - `channel`: required, one of `"stable" | "beta" | "nightly"`.
     - `version`: required, `"latest"`, a semver like `"1.83.0"`, or an
       ISO date like `"2025-12-01"` (date is only valid on nightly).
-      The repo's `rustNightlyToolchainFor` passes the pinned date
-      `${defaultNightlyDate}` so that pin stays grep-able.
     - `components`: rustup components to include. Defaults to the
       minimal `[ "cargo" "rust-std" "rustc" ]` set; pass an extended
       list (for example `[ ... "rust-src" "rust-analyzer" ]`) when the

--- a/lib/rust-tooling.nix
+++ b/lib/rust-tooling.nix
@@ -5,13 +5,20 @@
   writePythonApplication,
   rustWorkspaceFor,
   clippy-fork,
+  repoRoot,
 }:
 let
+  repoRustToolchainFile = builtins.fromTOML (builtins.readFile (repoRoot + "/rust-toolchain.toml"));
+  repoRustChannel = repoRustToolchainFile.toolchain.channel;
+  repoRustNightlyDate =
+    assert lib.assertMsg (lib.hasPrefix "nightly-" repoRustChannel)
+      "rust-toolchain.toml must pin a nightly channel for repo-owned Rust packages";
+    lib.removePrefix "nightly-" repoRustChannel;
   rustNightlyToolchainFor =
     pkgs:
     languages.rust.toolchain pkgs {
       channel = "nightly";
-      version = languages.rust.defaultNightlyDate;
+      version = repoRustNightlyDate;
     };
   # ix.buildRustPackage closure handed to `callPackage`'d Rust packages.
   # Kept minimal so it stays usable from the bootstrap path (no `cargoUnit`,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+# Rust toolchain pin used by repo-owned Rust package builds.
+[toolchain]
+channel = "nightly-2026-05-27"
+components = ["rust-src", "rust-analyzer"]

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -25,6 +25,8 @@ let
   };
   defaultMinecraftVersion = versions.default;
   defaultMinecraftModule = versions.${defaultMinecraftVersion};
+  rustToolchainFile = builtins.fromTOML (builtins.readFile ../rust-toolchain.toml);
+  rustPinnedNightlyDate = lib.removePrefix "nightly-" rustToolchainFile.toolchain.channel;
 
   # Thin wrapper to keep call sites as plain lists; delegates to ix.evalImageConfig
   # so tests exercise the same evaluation path as production image builds.
@@ -606,7 +608,7 @@ let
 
   cargoUnitCoverageRustToolchain = ix.languages.rust.toolchain pkgs {
     channel = "nightly";
-    version = ix.languages.rust.defaultNightlyDate;
+    version = rustPinnedNightlyDate;
     components = [
       "cargo"
       "llvm-tools"
@@ -1628,11 +1630,11 @@ let
     );
     rustPinnedNightly = ix.languages.rust.toolchain pkgs {
       channel = "nightly";
-      version = ix.languages.rust.defaultNightlyDate;
+      version = rustPinnedNightlyDate;
     };
     rustExtraComponents = ix.languages.rust.toolchain pkgs {
       channel = "nightly";
-      version = ix.languages.rust.defaultNightlyDate;
+      version = rustPinnedNightlyDate;
       components = [
         "cargo"
         "rust-std"


### PR DESCRIPTION
## Summary
- Add a repo-owned `rust-toolchain.toml` pin for nightly 2026-05-27.
- Stop exposing `ix.languages.rust.defaultNightlyDate`; internal Rust package tooling reads the repo toolchain file and callers continue to pass `version` explicitly.

## Test plan
- `direnv exec . nix eval .#lib.languages.rust.toolchain --apply 'f: builtins.isFunction f'`
- `direnv exec . nix run .#lint`


Made with [Cursor](https://cursor.com)