### PR TITLE
rust: document clippy bootstrap path

### DIFF
--- a/lib/rust-tooling.nix
+++ b/lib/rust-tooling.nix
@@ -20,10 +20,9 @@ let
       channel = "nightly";
       version = repoRustNightlyDate;
     };
-  # ix.buildRustPackage closure handed to `callPackage`'d Rust packages.
-  # Kept minimal so it stays usable from the bootstrap path (no `cargoUnit`,
-  # no `rustWorkspace`); `buildIxRustTool` adds those for packages that need
-  # them.
+  # ix.buildRustPackage closure handed to bootstrap Rust packages. This surface
+  # intentionally omits `cargoUnit` and `rustWorkspace` so `llm-clippy` can be
+  # built before cargo-unit policy checks start depending on it.
   ixBuildSurfaceFor = _pkgs: {
     buildRustPackage = innerPkgs: (rustFor innerPkgs).buildPackage;
   };

--- a/packages/llm-clippy/default.nix
+++ b/packages/llm-clippy/default.nix
@@ -35,9 +35,9 @@ ix.buildRustPackage pkgs {
     pkgs.libiconv
   ];
   doCheck = false;
-  # llm-clippy IS the clippy that lints every other repo Rust package, so its
-  # own clippy check cannot reach for `llmClippyFor` again - it would recurse
-  # forever back into this build. Machete and other policy gates stay on.
+  # llm-clippy is the Clippy binary that cargo-unit policy checks use for the
+  # rest of the repo. Its own build stays on the bootstrap path, where a Clippy
+  # policy check would recurse through `llmClippyFor`.
   policy.clippy.enable = false;
 
   # This Clippy fork links against rustc_private crates from its Rust toolchain.


### PR DESCRIPTION
## Summary

Document why `llm-clippy` stays on the minimal `buildRustPackage` bootstrap path while cargo-unit policy checks consume it for the rest of the workspace.

## Tests

`nix run .#lint`
