### PR TITLE
rust: preserve policy wrapper identity

### DIFF
--- a/lib/rust.nix
+++ b/lib/rust.nix
@@ -636,23 +636,29 @@ let
       extraTests ? { },
       extraPassthru ? { },
     }:
-    pkgs.symlinkJoin {
-      name = "${package.name}-policy-checked";
-      paths = [ package ];
-      inherit (package) meta;
-      passthru =
-        (package.passthru or { })
-        // extraPassthru
-        // {
-          unchecked = package;
-          inherit policyChecks;
-          tests = (package.passthru.tests or { }) // policyChecks // extraTests;
-        };
-      postBuild = lib.optionalString (policyChecks != { }) ''
-        mkdir -p "$out/rust-policy"
-        ${linkPolicyChecks policyChecks}
-      '';
-    };
+    pkgs.symlinkJoin (
+      {
+        name = "${package.name}-policy-checked";
+        paths = [ package ];
+        inherit (package) meta;
+        passthru =
+          (package.passthru or { })
+          // extraPassthru
+          // {
+            unchecked = package;
+            inherit policyChecks;
+            tests = (package.passthru.tests or { }) // policyChecks // extraTests;
+          };
+        postBuild = lib.optionalString (policyChecks != { }) ''
+          mkdir -p "$out/rust-policy"
+          ${linkPolicyChecks policyChecks}
+        '';
+      }
+      # The policy wrapper is still the same Rust package for eval-time callers
+      # that inspect package identity.
+      // lib.optionalAttrs (package ? pname) { inherit (package) pname; }
+      // lib.optionalAttrs (package ? version) { inherit (package) version; }
+    );
 
   # Shortcut: pass `srcRoot = ./.` for a repo-owned crate whose tracked tree
   # is the build closure. Expands to the standard `gitTracked` filter, defaults

--- a/packages/llm-clippy/default.nix
+++ b/packages/llm-clippy/default.nix
@@ -39,6 +39,10 @@ ix.buildRustPackage pkgs {
   # rest of the repo. Its own build stays on the bootstrap path, where a Clippy
   # policy check would recurse through `llmClippyFor`.
   policy.clippy.enable = false;
+  # The Clippy fork carries Cargo UI fixtures that are not build workspaces.
+  # cargo-machete walks them anyway and cargo metadata tries to write lockfiles
+  # inside the read-only Nix store.
+  policy.cargoMachete.enable = false;
 
   # This Clippy fork links against rustc_private crates from its Rust toolchain.
   env.RUSTC_BOOTSTRAP = "1";


### PR DESCRIPTION
## Summary

Preserve `pname` and `version` on Rust packages after `withPolicyChecks` wraps them in the policy-checked symlink join.

This fixes the eval assertion that checks cargo-unit's default Clippy package identity after `llm-clippy` is wrapped.

## Tests

`nix run .#lint`
`nix eval '.#checks.x86_64-linux.eval.name' --raw`

I also started `nix build .#checks.x86_64-linux.eval --show-trace`; it progressed past the previous missing-`pname` eval failure and moved into unrelated fixture builds, so I stopped it locally and left the full Linux build to CI.
