### PR TITLE
tests: defer repo clippy lint levels to Cargo.toml

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3113,14 +3113,8 @@ let
           let
             denied = repoPackages.minecraft-nbt.passthru.policy.clippy.deniedLints;
           in
-          builtins.all (lint: builtins.elem lint denied) [
-            "warnings"
-            "clippy::all"
-            "clippy::pedantic"
-            "clippy::nursery"
-            "clippy::cargo"
-          ];
-        message = "repo Rust clippy checks should deny the shared strict lint set by default";
+          denied == [ ];
+        message = "repo Rust clippy policy should defer default lint levels to Cargo.toml";
       }
       {
         assertion = repoPackages.minecraft-nbt.passthru.tests ? package;


### PR DESCRIPTION
## Summary

Fixes the failing `checks.x86_64-linux.eval` assertion after #239 moved the Rust lint policy out of `lib/rust.nix` and into `[workspace.lints]` in `Cargo.toml`. That PR updated the parallel `cargoUnitWorkspace.policy.clippy.deniedLints` assertion (tests/default.nix:2978) but missed the equivalent `repoPackages.minecraft-nbt.passthru.policy.clippy.deniedLints` assertion, so the eval check started failing with:

```
error: ix-test-helpers:
  repo Rust clippy checks should deny the shared strict lint set by default
```

Both Nix policies now expose `deniedLints = [ ]` because the lint levels live in `Cargo.toml`. The assertion is updated to mirror the already-fixed sibling: it checks `denied == [ ]` and the message now reads "repo Rust clippy policy should defer default lint levels to Cargo.toml".

## Validation

- `nix run .#lint`
