### PR TITLE
fix(cargo-unit): respect workspace clippy lints and review feedback

### DIFF
--- a/lib/cargo-unit.nix
+++ b/lib/cargo-unit.nix
@@ -66,6 +66,72 @@ let
       Fetched or patched sources pass workspaceRoot = src.
     '');
 
+  # Cargo only emits `[lints.clippy]` into the unit graph's `lint_rustflags`
+  # when invoked as `cargo clippy`, not `cargo build`. Our unit graph is built
+  # with `cargo build --unit-graph`, so per-unit clippy never sees the
+  # workspace lint policy unless we resolve it ourselves. Parse the workspace
+  # manifest and emit the equivalent `-D|-W|-A clippy::<lint>` flags.
+  #
+  # Per-package overrides (a package with its own `[lints.clippy]` and
+  # `workspace = false`) are not yet honored; most workspaces in practice use
+  # `[lints] workspace = true` per crate, which inherits the workspace table.
+  #
+  # `clippy::cargo` group lints and the individual members of that group
+  # invoke the `cargo` binary to read workspace metadata. Per-unit clippy
+  # runs in a sandboxed build directory without a discoverable Cargo.toml
+  # (the unit's source closure is package-shaped, not workspace-shaped), so
+  # those lints error out with "could not find Cargo.toml". They only make
+  # sense at workspace scope; skip them here and leave a workspace-level
+  # cargo-clippy check as the future home for that subset.
+  cargoGroupClippyLints = [
+    "cargo"
+    "cargo_common_metadata"
+    "multiple_crate_versions"
+    "negative_feature_names"
+    "redundant_feature_names"
+    "wildcard_dependencies"
+  ];
+  clippyLintFlagsFromManifest =
+    manifestPath:
+    let
+      manifest = builtins.fromTOML (builtins.readFile manifestPath);
+      raw = manifest.workspace.lints.clippy or manifest.lints.clippy or { };
+      filtered = builtins.removeAttrs raw cargoGroupClippyLints;
+      entryFor =
+        name: value:
+        if builtins.isString value then
+          {
+            inherit name;
+            level = value;
+            priority = 0;
+          }
+        else
+          {
+            inherit name;
+            level = value.level;
+            priority = value.priority or 0;
+          };
+      entries = lib.mapAttrsToList entryFor filtered;
+      # Cargo applies args in ascending-priority order so higher-priority lints
+      # appear later on the command line and win as overrides. Mirror that here
+      # so a per-lint allow can override a group-wide deny.
+      sorted = lib.sort (left: right: left.priority < right.priority) entries;
+      flagFor =
+        level:
+        if level == "deny" || level == "forbid" then
+          "-D"
+        else if level == "warn" then
+          "-W"
+        else if level == "allow" then
+          "-A"
+        else
+          throw "cargoUnit: unknown clippy lint level '${level}' in ${manifestPath}";
+    in
+    lib.concatMap (entry: [
+      (flagFor entry.level)
+      "clippy::${entry.name}"
+    ]) sorted;
+
   renderCargoArgs =
     args: cargoTarget:
     lib.escapeShellArgs (
@@ -310,7 +376,14 @@ let
         extraClippyNativeBuildInputs = lib.optional perUnitClippyEnabled args.policy.clippy.package;
         extraEnv = args.env;
         extraRustcArgsForPlatform = rust.rustcArgsForPolicyForPlatform args.policy;
-        extraClippyLintArgs = rust.clippyLintArgs args.policy;
+        # Manifest-derived flags come first so per-call `policy.clippy`
+        # entries land later in argv and can override them. Cargo's
+        # `[lints.clippy]` resolution is the load-bearing source for most
+        # workspaces; `policy.clippy.deniedLints` stays as an escape hatch
+        # for callers without a Cargo.toml policy.
+        extraClippyLintArgs =
+          clippyLintFlagsFromManifest (args.src + "/Cargo.toml")
+          ++ rust.clippyLintArgs args.policy;
         clippyEnabled = perUnitClippyEnabled;
         extraPolicyChecks = extraPolicyChecksFromRust;
       };

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -350,11 +350,14 @@ fn render_clippy_unit_entries(
     Ok(entries)
 }
 
-// Clippy only lints workspace-owned code. Build-script artifacts and vendored
-// crates (registry, sparse, git) compile under `--cap-lints warn` for a
-// reason — we don't want a churning upstream to break the workspace lint gate.
+// Clippy only lints workspace-owned code. Vendored crates (registry, sparse,
+// git) compile under `--cap-lints warn` for a reason: we don't want a churning
+// upstream to break the workspace lint gate. The run-custom-build unit
+// executes `build.rs` (no source to lint), but the custom-build compile unit
+// IS workspace Rust and the old `cargo clippy` workspace gate covered it, so
+// it must keep getting clippy here.
 fn is_clippy_unit_candidate(unit: &Unit) -> bool {
-    !unit.is_run_custom_build() && !unit.is_custom_build_compile() && !unit.is_external()
+    !unit.is_run_custom_build() && !unit.is_external()
 }
 
 fn render_policy_check_entries(
@@ -2947,7 +2950,8 @@ mod tests {
         assert!(rendered.contains("mkClippyUnit"));
         assert!(rendered.contains("env \"''${rustc_env[@]}\" clippy-driver"));
         assert!(rendered.contains("extraClippyLintArgs"));
-        assert!(rendered.contains("clippy = clippyUnits;"));
+        assert!(rendered.contains("clippy = clippyPolicyAggregate;"));
+        assert!(rendered.contains("clippyPolicyAggregate ="));
     }
 
     #[test]

--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -666,11 +666,22 @@ let
       cases = mkDoctestCases { inherit name runCommand; };
     };
 
+  # `policyChecks` is consumed by `withPolicyChecks`, `selectBinaryWithTests`,
+  # and the per-system flake check lift, all of which expect each value to be
+  # a single derivation (they string-interpolate it). The per-unit fan-out
+  # lives at `clippyUnits` for callers that want individual units; the policy
+  # surface wraps every clippy unit into one symlinkJoin so the gate is one
+  # store path that depends on every per-unit clippy build.
+  clippyPolicyAggregate =
+    pkgs.symlinkJoin {
+      name = "cargo-unit-clippy";
+      paths = pkgs.lib.attrValues clippyUnits;
+    };
   policyChecks =
     {
 {{ policy_check_entries }}    }
     // pkgs.lib.optionalAttrs (clippyEnabled && clippyUnits != {}) {
-      clippy = clippyUnits;
+      clippy = clippyPolicyAggregate;
     }
     // extraPolicyChecks;
   withPolicyChecks = package:

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2950,32 +2950,36 @@ let
       }
       {
         assertion = cargoUnitWorkspace.policyChecks ? clippy;
-        message = "cargo-unit workspaces should expose per-unit clippy checks under policyChecks.clippy";
+        message = "cargo-unit workspaces should expose a clippy policy check derivation";
       }
       {
         assertion = !(cargoUnitWorkspace.policyChecks ? cargoClippy);
         message = "cargo-unit buildWorkspace should suppress the legacy workspace-level cargoClippy when per-unit clippy is on";
       }
       {
-        assertion = builtins.isAttrs cargoUnitWorkspace.policyChecks.clippy;
-        message = "cargo-unit policyChecks.clippy should be a fan-out attrset, one entry per linted unit";
+        # `policyChecks.clippy` is one aggregate derivation so
+        # `withPolicyChecks` and `selectBinaryWithTests` can string-coerce it
+        # like every other policy check. The aggregate transitively depends on
+        # every per-unit clippy derivation.
+        assertion = lib.isDerivation cargoUnitWorkspace.policyChecks.clippy;
+        message = "cargo-unit policyChecks.clippy should be a single aggregate derivation";
       }
       {
-        assertion = builtins.length (builtins.attrNames cargoUnitWorkspace.policyChecks.clippy) >= 2;
-        message = "cargo-unit policyChecks.clippy should produce multiple per-unit derivations for a multi-target fixture";
+        # The per-unit fan-out lives at `clippyUnits` for callers that want
+        # individual unit derivations (e.g. exposing one flake check per
+        # crate).
+        assertion = builtins.isAttrs cargoUnitWorkspace.clippyUnits;
+        message = "cargo-unit clippyUnits should be a fan-out attrset, one entry per linted unit";
+      }
+      {
+        assertion = builtins.length (builtins.attrNames cargoUnitWorkspace.clippyUnits) >= 2;
+        message = "cargo-unit clippyUnits should produce multiple per-unit derivations for a multi-target fixture";
       }
       {
         assertion = builtins.all (unit: lib.isDerivation unit) (
-          builtins.attrValues cargoUnitWorkspace.policyChecks.clippy
+          builtins.attrValues cargoUnitWorkspace.clippyUnits
         );
-        message = "cargo-unit policyChecks.clippy entries should each be a derivation";
-      }
-      {
-        # clippyUnits sits at the top of the units attrset so callers that
-        # don't want the policyChecks aggregator can still pick individual
-        # units by their unit attribute name (matches `units.<name>`).
-        assertion = cargoUnitWorkspace.clippyUnits == cargoUnitWorkspace.policyChecks.clippy;
-        message = "cargo-unit should expose clippyUnits at the top level identical to policyChecks.clippy";
+        message = "cargo-unit clippyUnits entries should each be a derivation";
       }
       {
         assertion = cargoUnitWorkspace.policy.clippy.package.unchecked.pname == "llm-clippy";


### PR DESCRIPTION
## Summary

Three follow-ups to #244 that the AI/Codex bot reviews caught and one bigger issue that surfaced testing on the ix repo:

1. **Workspace `[lints.clippy]` is now actually enforced** (the load-bearing fix). The unit graph is generated via `cargo build --unit-graph`, which never populates `lint_rustflags` with clippy lints — cargo only emits those when invoked as `cargo clippy`. The per-unit `clippy-driver` therefore ran with zero `-D clippy::*` flags, so workspaces relying on the workspace `[lints.clippy]` table (the standard place to configure clippy levels) saw every lint demoted to a `warn`. `lib/cargo-unit.nix` now parses the workspace `Cargo.toml`'s `[workspace.lints.clippy]` table, sorts by ascending priority (so per-lint allows win over group denies, matching cargo's behavior), and prepends the resolved `-D|-W|-A clippy::<lint>` flags to `extraClippyLintArgs`. `policy.clippy.{denied,allowed}Lints` still appends afterward as the nix-level escape hatch. Verified end-to-end: building `ix-admin-clippy-0.1.0` on the ix workspace shows `-D clippy::pedantic -D clippy::nursery -D clippy::cast_possible_truncation -A clippy::cast_precision_loss ...` reach clippy-driver, with priority -1 group denies appearing before priority 0 per-lint overrides as cargo would order them.

2. **P0 from `github-actions` and `chatgpt-codex-connector` review:** `policyChecks.clippy` was a raw attrset of derivations, which breaks `withPolicyChecks`, `selectBinaryWithTests`, and the per-system flake check lift — they all string-coerce every `policyChecks` value via `${check}`. The template now wraps `clippyUnits` into a single `pkgs.symlinkJoin` named `cargo-unit-clippy` for the policy surface; the per-unit fan-out stays at the top-level `clippyUnits` for callers (like ix) that want individual unit access.

3. **P1 from both bot reviews:** `is_clippy_unit_candidate` excluded `is_custom_build_compile()`, dropping workspace-owned `build.rs` files from the lint gate. The old `cargo clippy` workspace gate covered them. Now only `is_run_custom_build()` (the execution unit, which has no source) is excluded.

## Cargo group lints (known limitation)

`clippy::cargo` group members (`wildcard_dependencies`, `multiple_crate_versions`, `cargo_common_metadata`, etc.) invoke the `cargo` binary to read workspace metadata. Per-unit clippy runs in a sandboxed build directory without a discoverable Cargo.toml (the unit's source closure is package-shaped, not workspace-shaped), so those lints error with `could not find Cargo.toml`. They only make sense at workspace scope.

This PR strips them from `clippyLintFlagsFromManifest` so per-unit clippy doesn't crash on them. A future change can add a small workspace-level `cargo-clippy-cargo-group` derivation that runs only the cargo-group lints once across the whole workspace.

## Tests

- All 36 nix-cargo-unit render tests pass; `renders_one_derivation_per_build_unit` now asserts `policyChecks.clippy = clippyPolicyAggregate;` and the aggregate definition appears in the rendered file.
- `tests/default.nix` assertions updated: `policyChecks.clippy` is now `lib.isDerivation`; the fan-out lives at `cargoUnitWorkspace.clippyUnits` (asserted to be an attrset of ≥2 derivations).
- Verified against ix at `git+file:/home/andrew/index?ref=per-unit-clippy-followup`: `nix-store --realise` of `ix-admin-clippy-0.1.0` succeeds and the build log shows the full set of `-D clippy::*` flags reaching clippy-driver, with cargo-group lints absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
