### PR TITLE
cargo-unit: add per-target miri checks

### DIFF
--- a/lib/cargo-unit.nix
+++ b/lib/cargo-unit.nix
@@ -38,6 +38,7 @@ let
     cargoExtraConfig = args.cargoExtraConfig or "";
     vendorDir = args.vendorDir or null;
     vendorSources = args.vendorSources or null;
+    miriTests = args.miriTests or { };
     # Maps exact Cargo.lock source strings to already-fetched source trees.
     # This keeps private Git dependencies reproducible without requiring
     # sandboxed fetchers to see a developer SSH agent or GitHub credentials.
@@ -160,6 +161,7 @@ let
     rawArgs:
     let
       args = commonArgs rawArgs;
+      rootSetCargoArgs = map (targetArgs: profileArgs args.profile ++ targetArgs) args.cargoTargets;
       vendorDir = rust.resolveVendorDir {
         inherit (args)
           cargoLock
@@ -175,6 +177,7 @@ let
           nativeBuildInputs = [
             args.rustToolchain
             pkgs.cacert
+            pkgs.jq
             nixCargoUnit
           ]
           ++ args.nativeBuildInputs;
@@ -217,7 +220,10 @@ let
           lib.concatMapStringsSep " " (
             targetIndex: "$TMPDIR/unit-graph-${builtins.toString targetIndex}.json"
           ) (lib.range 0 ((builtins.length args.cargoTargets) - 1))
-        } > "$out"
+        } > "$TMPDIR/merged-unit-graph.json"
+        jq --argjson root_set_cargo_args ${lib.escapeShellArg (builtins.toJSON rootSetCargoArgs)} \
+          '.root_set_cargo_args = $root_set_cargo_args' \
+          "$TMPDIR/merged-unit-graph.json" > "$out"
       '';
 
   /**
@@ -308,9 +314,12 @@ let
     generated `$out/lcov.info`. The selected Rust toolchain must provide matching
     `llvm-cov` and `llvm-profdata`, or callers must pass explicit tool paths to
     `makeCoverageReport`.
+    Miri runs are per test target under `miriUnits`; `makeMiriTest` only joins
+    selected target derivations so callers can publish one named check without
+    losing the per-target rebuild boundary.
 
     Returns the generated attrset with `sourceAudit`, `units`, `roots`, `checkedRoots`,
-    `packages`, `binaries`, `libraries`, `benchmarks`, `coverageReport`, `default`,
+    `packages`, `binaries`, `libraries`, `benchmarks`, `miriUnits`, `coverageReport`, `default`,
     `policyChecks`, plus the intermediate `unitGraphJson`, `unitsNix`, and `vendorDir`
     derivations for inspection.
   */
@@ -385,6 +394,14 @@ let
           clippyLintFlagsFromManifest (args.src + "/Cargo.toml") ++ rust.clippyLintArgs args.policy;
         clippyEnabled = perUnitClippyEnabled;
         extraPolicyChecks = extraPolicyChecksFromRust;
+        miriCargoSetupScript = rust.vendorConfigScript {
+          inherit vendorDir;
+          cargoLock = rust.cargoLockFile args.cargoLock;
+          inherit (args) cargoExtraConfig;
+        };
+        miriPackage = (rawArgs.miri or { }).package or pkgs.miri;
+        miriRustToolchain = (rawArgs.miri or { }).rustToolchain or args.rustToolchain;
+        defaultMiriFlags = (rawArgs.miri or { }).flags or [ ];
       };
       targetSetNames =
         if args.cargoTargetNames == null then
@@ -399,10 +416,53 @@ let
           lib.nameValuePair targetName (builtins.elemAt units.targetSets (targetIndex - 1))
         ) targetSetNames
       );
+      makeMiriTest =
+        {
+          name ? "${rawArgs.pname or "cargo-unit"}-miri",
+          targets ? null,
+          ...
+        }@miriArgs:
+        let
+          miriUnits = units.mkMiriUnits (
+            builtins.removeAttrs miriArgs [
+              "name"
+              "targets"
+            ]
+          );
+          missingTargets =
+            if targets == null then
+              [ ]
+            else
+              builtins.filter (target: !(builtins.hasAttr target miriUnits)) targets;
+          selectedUnits =
+            if missingTargets != [ ] then
+              throw "cargoUnit.makeMiriTest unknown Miri targets: ${lib.concatStringsSep ", " missingTargets}"
+            else if targets == null then
+              miriUnits
+            else
+              lib.getAttrs targets miriUnits;
+        in
+        assert lib.assertMsg (selectedUnits != { }) ''
+          cargoUnit.makeMiriTest requires at least one Miri target.
+          Include `--tests`, `--all-targets`, or a specific test target in cargoTargets.
+        '';
+        pkgs.symlinkJoin {
+          inherit name;
+          paths = builtins.attrValues selectedUnits;
+        };
+      miriTests = lib.mapAttrs (
+        name: testArgs: makeMiriTest ({ inherit name; } // testArgs)
+      ) args.miriTests;
     in
     units
     // {
-      inherit unitGraphJson unitsNix vendorDir;
+      inherit
+        makeMiriTest
+        miriTests
+        unitGraphJson
+        unitsNix
+        vendorDir
+        ;
       targetSets = namedTargetSets;
       inherit (args) policy;
     };

--- a/packages/nix-cargo-unit/src/model.rs
+++ b/packages/nix-cargo-unit/src/model.rs
@@ -14,6 +14,8 @@ pub struct UnitGraph {
     pub roots: Vec<usize>,
     #[serde(default)]
     pub root_sets: Vec<Vec<usize>>,
+    #[serde(default)]
+    pub root_set_cargo_args: Vec<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -302,6 +304,7 @@ impl UnitGraph {
             units: Vec::new(),
             roots: Vec::new(),
             root_sets: Vec::new(),
+            root_set_cargo_args: Vec::new(),
         };
         let mut merged_by_hash = BTreeMap::new();
 
@@ -335,6 +338,13 @@ impl UnitGraph {
                 }
             }
             merged.root_sets.push(root_set);
+            merged.root_set_cargo_args.push(
+                graph
+                    .root_set_cargo_args
+                    .first()
+                    .cloned()
+                    .unwrap_or_default(),
+            );
         }
 
         merged.validate()?;

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -2510,9 +2510,7 @@ fn append_doctest_builder_args(
     script.push_str(
         "  doctest_runtime_library_path=$(IFS=:; printf '%s' \"''${doctest_runtime_library_paths[*]}\")\n",
     );
-    script.push_str(
-        "  doctest_runtime_library_path_host=$(rustc -vV | sed -n 's/^host: //p')\n",
-    );
+    script.push_str("  doctest_runtime_library_path_host=$(rustc -vV | sed -n 's/^host: //p')\n");
     script.push_str("  case \"$doctest_runtime_library_path_host\" in\n");
     script.push_str(
         "    *apple-darwin*)\n      doctest_runtime_library_path_var=DYLD_FALLBACK_LIBRARY_PATH\n      doctest_runtime_library_path_default=\"$HOME/lib:/usr/local/lib:/usr/lib\"\n      ;;\n",
@@ -2710,13 +2708,14 @@ fn render_test_target_entries(graph: &UnitGraph, prepared: &PreparedGraph) -> St
         by_key.insert(
             key.clone(),
             format!(
-                "{{ name = {}; binary = \"{}\"; packageName = {}; packageVersion = {}; packageRoot = {}; sourceStoreName = {}; }}",
+                "{{ name = {}; binary = \"{}\"; packageName = {}; packageVersion = {}; packageRoot = {}; sourceStoreName = {}; cargoArgs = {}; }}",
                 nix_attr(key),
                 test_binary_expr(unit, prepared, index),
                 nix_attr(&unit.package_name()),
                 nix_attr(unit.package_version()),
                 nix_attr(package_root),
                 nix_attr(&source.name),
+                nix_string_list(&cargo_miri_target_args(graph, index, unit)),
             ),
         );
     }
@@ -2725,6 +2724,64 @@ fn render_test_target_entries(graph: &UnitGraph, prepared: &PreparedGraph) -> St
         let _ = writeln!(entries, "    {target}");
     }
     entries
+}
+
+fn cargo_miri_target_args(graph: &UnitGraph, index: usize, unit: &Unit) -> Vec<String> {
+    let package_name = unit.package_name();
+    let mut args = cargo_miri_base_args(graph, index);
+    args.push("--package".to_string());
+    args.push(package_name.into_owned());
+
+    if unit.target.has_kind("test") {
+        args.push("--test".to_string());
+        args.push(unit.target.name.clone());
+    } else if unit.target.has_kind("example") {
+        args.push("--example".to_string());
+        args.push(unit.target.name.clone());
+    } else if unit.target.has_kind("bin") || unit.target.has_crate_type("bin") {
+        args.push("--bin".to_string());
+        args.push(unit.target.name.clone());
+    } else {
+        args.push("--lib".to_string());
+    }
+
+    args
+}
+
+fn cargo_miri_base_args(graph: &UnitGraph, index: usize) -> Vec<String> {
+    let root_set_index = graph
+        .root_sets
+        .iter()
+        .position(|roots| roots.contains(&index))
+        .unwrap_or(0);
+    let raw_args = graph
+        .root_set_cargo_args
+        .get(root_set_index)
+        .cloned()
+        .unwrap_or_default();
+    strip_cargo_target_selectors(raw_args)
+}
+
+fn strip_cargo_target_selectors(args: Vec<String>) -> Vec<String> {
+    let mut filtered = Vec::new();
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--workspace" | "--all" | "--all-targets" | "--lib" | "--bins" | "--examples"
+            | "--tests" | "--benches" => {}
+            "-p" | "--package" | "--exclude" | "--bin" | "--example" | "--test" | "--bench" => {
+                let _ = iter.next();
+            }
+            _ if arg.starts_with("--package=")
+                || arg.starts_with("--exclude=")
+                || arg.starts_with("--bin=")
+                || arg.starts_with("--example=")
+                || arg.starts_with("--test=")
+                || arg.starts_with("--bench=") => {}
+            _ => filtered.push(arg),
+        }
+    }
+    filtered
 }
 
 fn render_doctest_target_entries(graph: &UnitGraph, prepared: &PreparedGraph) -> Result<String> {
@@ -2913,7 +2970,9 @@ mod tests {
                   "dependencies": []
                 }
               ],
-              "roots": [0]
+              "roots": [0],
+              "root_sets": [[0]],
+              "root_set_cargo_args": [["--workspace", "--tests", "--features", "miri-mode"]]
             }"#,
         )
         .unwrap();
@@ -2978,7 +3037,9 @@ mod tests {
                   "dependencies": []
                 }
               ],
-              "roots": [0]
+              "roots": [0],
+              "root_sets": [[0]],
+              "root_set_cargo_args": [["--workspace", "--tests", "--features", "miri-mode"]]
             }"#,
         )
         .unwrap();
@@ -3032,7 +3093,9 @@ mod tests {
                   "dependencies": []
                 }
               ],
-              "roots": [0]
+              "roots": [0],
+              "root_sets": [[0]],
+              "root_set_cargo_args": [["--workspace", "--tests", "--features", "miri-mode"]]
             }"#,
         )
         .unwrap();
@@ -3065,6 +3128,11 @@ mod tests {
         assert!(rendered.contains("packageName = \"hello\";"));
         assert!(rendered.contains("packageRoot = \".\";"));
         assert!(rendered.contains("sourceStoreName = \"cargo-unit-source-hello-0.1.0-"));
+        assert!(rendered.contains(
+            "cargoArgs = [ \"--features\" \"miri-mode\" \"--package\" \"hello\" \"--lib\" ];"
+        ));
+        assert!(rendered.contains("miriUnits = mkMiriUnits {};"));
+        assert!(rendered.contains("mkMiriUnits ="));
         assert!(rendered.contains("sourcePackageRoot ="));
         assert!(rendered.contains("test_cwd="));
         assert!(rendered.contains("cd \"$test_cwd\""));
@@ -3079,6 +3147,55 @@ mod tests {
         assert!(rendered.contains("source-roots.tsv"));
         assert!(rendered.contains("testManifestDrv ="));
         assert!(rendered.contains("cargo-unit-test-manifest"));
+    }
+
+    #[test]
+    fn miri_args_select_examples_and_strip_workspace_exclusions() {
+        let graph: UnitGraph = serde_json::from_str(
+            r#"{
+              "version": 1,
+              "units": [
+                {
+                  "pkg_id": "path+file:///workspace#hello@0.1.0",
+                  "target": {
+                    "kind": ["example"],
+                    "crate_types": ["bin"],
+                    "name": "sample",
+                    "src_path": "/workspace/examples/sample.rs",
+                    "edition": "2024",
+                    "test": true
+                  },
+                  "profile": { "name": "test", "opt_level": "0" },
+                  "features": [],
+                  "mode": "test",
+                  "dependencies": []
+                }
+              ],
+              "roots": [0],
+              "root_sets": [[0]],
+              "root_set_cargo_args": [["--workspace", "--exclude", "skip-me", "--examples", "--no-default-features"]]
+            }"#,
+        )
+        .unwrap();
+
+        let rendered = render_units_nix(
+            &graph,
+            &RenderOptions {
+                workspace_root: PathBuf::from("/workspace"),
+                vendor_root: None,
+                cargo_lock_sources: CargoLockSources::default(),
+                content_addressed: false,
+                toolchain_id: None,
+                deny_unused_crate_dependencies: false,
+            },
+        )
+        .unwrap();
+
+        assert!(rendered.contains(
+            "cargoArgs = [ \"--no-default-features\" \"--package\" \"hello\" \"--example\" \"sample\" ];"
+        ));
+        assert!(!rendered.contains("--exclude"));
+        assert!(!rendered.contains("\"--bin\" \"sample\""));
     }
 
     #[test]
@@ -3187,7 +3304,9 @@ version = "0.1.0"
         assert!(rendered.contains("rustc_env+=( 'CARGO_BIN_EXE_dag-runner=${units."));
         assert!(!rendered.contains("export CARGO_BIN_EXE_dag-runner"));
         assert!(rendered.contains("env \"''${rustc_env[@]}\" rustc \"''${rustc_args[@]}\""));
-        assert!(rendered.contains("env \"''${rustc_env[@]}\" clippy-driver \"''${rustc_args[@]}\""));
+        assert!(
+            rendered.contains("env \"''${rustc_env[@]}\" clippy-driver \"''${rustc_args[@]}\"")
+        );
     }
 
     #[test]
@@ -3485,21 +3604,20 @@ version = "0.1.0"
         assert!(rendered.contains("rustdoc_args+=( 'cfg(docsrs,test)' )"));
         assert!(rendered.contains("rustdoc_args+=( --doctest-build-arg \"$doctest_build_arg\" )"));
         assert!(rendered.contains("case \"$link_search_path\" in"));
-        assert!(rendered.contains(
-            "/out-dir|\"${units."
-        ));
-        assert!(rendered.contains(
-            "/out-dir/*) doctest_runtime_library_paths+=( \"$link_search_path\" ) ;;"
-        ));
+        assert!(rendered.contains("/out-dir|\"${units."));
+        assert!(
+            rendered.contains(
+                "/out-dir/*) doctest_runtime_library_paths+=( \"$link_search_path\" ) ;;"
+            )
+        );
         assert!(!rendered.contains(
             "[ -n \"$link_search_path\" ] && doctest_runtime_library_paths+=( \"$link_search_path\" )"
         ));
-        assert!(rendered.contains(
-            "doctest_runtime_library_path_host=$(rustc -vV | sed -n 's/^host: //p')"
-        ));
-        assert!(rendered.contains(
-            "doctest_runtime_library_path_var=DYLD_FALLBACK_LIBRARY_PATH"
-        ));
+        assert!(
+            rendered
+                .contains("doctest_runtime_library_path_host=$(rustc -vV | sed -n 's/^host: //p')")
+        );
+        assert!(rendered.contains("doctest_runtime_library_path_var=DYLD_FALLBACK_LIBRARY_PATH"));
         assert!(rendered.contains(
             "doctest_runtime_library_path_default=\"$HOME/lib:/usr/local/lib:/usr/lib\""
         ));
@@ -3507,9 +3625,11 @@ version = "0.1.0"
         assert!(rendered.contains(
             "doctest_runtime_library_path_current=\"''${!doctest_runtime_library_path_var-}\""
         ));
-        assert!(rendered.contains(
-            "export \"$doctest_runtime_library_path_var=$doctest_runtime_library_path"
-        ));
+        assert!(
+            rendered.contains(
+                "export \"$doctest_runtime_library_path_var=$doctest_runtime_library_path"
+            )
+        );
         assert!(!rendered.contains("done < \"${units.native-run}/rustc-link-lib"));
         assert!(!rendered.contains(
             "doctest_build_args+=( -C \"link-arg=$line\" )\n  done < \"${units.native-run}/rustc-cdylib-link-arg"

--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -617,7 +617,11 @@ let
               ${pkgs.lib.optionalString (miriRustFlags != "") ''
               export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }${miriRustFlags}"
               ''}
-              cd ${src}
+              miri_src="$TMPDIR/cargo-unit-miri-src"
+              mkdir -p "$miri_src"
+              cp -R ${src}/. "$miri_src"/
+              chmod -R u+w "$miri_src"
+              cd "$miri_src"
               ${testRunPrelude}
               cargo ${pkgs.lib.escapeShellArgs cargoMiriArgs}
               mkdir -p "$out"

--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -617,9 +617,9 @@ let
               ${pkgs.lib.optionalString (miriRustFlags != "") ''
               export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }${miriRustFlags}"
               ''}
-              miri_src="$TMPDIR/cargo-unit-miri-workspace"
+              miri_src="$TMPDIR/cargo-unit-miri-src"
               mkdir -p "$miri_src"
-              cp -R ${workspaceRoot}/. "$miri_src"/
+              cp -R ${src}/. "$miri_src"/
               chmod -R u+w "$miri_src"
               cd "$miri_src"
               ${testRunPrelude}

--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -12,6 +12,10 @@
   extraPolicyChecks ? {},
   extraRustcArgs ? [],
   extraRustcArgsForPlatform ? _platform: [],
+  miriCargoSetupScript ? "",
+  miriPackage ? pkgs.miri,
+  miriRustToolchain ? rustToolchain,
+  defaultMiriFlags ? [],
   # `-D clippy::xxx` / `-A clippy::xxx` flags appended to every per-unit
   # clippy-driver invocation. Empty by default so the rendered units file
   # is policy-agnostic; cargo-unit.nix derives these from the workspace
@@ -558,6 +562,67 @@ let
   # Map both to ASCII-safe runs without losing the path shape.
   sanitizeTestName = pkgs.lib.replaceStrings [ "::" ":" " " ] [ "--" "_" "_" ];
 
+  mkMiriUnits =
+    {
+      cargoArgsByTarget ? {},
+      env ? {},
+      miriFlags ? defaultMiriFlags,
+      testArgs ? [],
+      testArgsByTarget ? {},
+    }:
+    pkgs.lib.listToAttrs (
+      map (
+        target:
+        let
+          cargoArgs = cargoArgsByTarget.${target.name} or target.cargoArgs;
+          targetTestArgs = testArgs ++ (testArgsByTarget.${target.name} or []);
+          miriRustFlags = pkgs.lib.concatStringsSep " " (extraRustcArgs ++ extraRustcArgsForPlatform null);
+          cargoMiriArgs = [
+            "miri"
+            "test"
+          ]
+          ++ cargoArgs
+          ++ [
+            "--frozen"
+            "--offline"
+          ]
+          ++ pkgs.lib.optionals (targetTestArgs != []) ([ "--" ] ++ targetTestArgs);
+        in
+        {
+          name = target.name;
+          value = pkgs.runCommand "cargo-unit-miri-${target.name}"
+            (
+              {
+                __structuredAttrs = true;
+                strictDeps = true;
+                nativeBuildInputs = [
+                  miriRustToolchain
+                  miriPackage
+                  pkgs.cacert
+                ] ++ extraNativeBuildInputs;
+                SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+                MIRIFLAGS = pkgs.lib.concatStringsSep " " miriFlags;
+              }
+              // extraEnv
+              // env
+            )
+            ''
+              set -euo pipefail
+
+              ${miriCargoSetupScript}
+
+              export CARGO_TARGET_DIR="$TMPDIR/cargo-target"
+              ${pkgs.lib.optionalString (miriRustFlags != "") ''
+              export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }${miriRustFlags}"
+              ''}
+              cd ${src}
+              cargo ${pkgs.lib.escapeShellArgs cargoMiriArgs}
+              mkdir -p "$out"
+            '';
+        }
+      ) testTargets
+    );
+
   # Single IFD that depends on every test binary. Writes one
   # `<name>.list` (non-ignored tests) and one `<name>.ignored.list`
   # per target. Mainline Nix evaluates IFDs serially, so collapsing
@@ -704,6 +769,8 @@ in
     testTargetNamesByPackage
     units
     ;
+  inherit mkMiriUnits;
+  miriUnits = mkMiriUnits {};
   testPlan = mkTestPlan "cargo-unit-test-plan";
   benchmarkPlan = mkBenchmarkPlan "cargo-unit-benchmark-plan";
   coverageReport = mkCoverageReport {};

--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -618,6 +618,7 @@ let
               export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }${miriRustFlags}"
               ''}
               cd ${src}
+              ${testRunPrelude}
               cargo ${pkgs.lib.escapeShellArgs cargoMiriArgs}
               mkdir -p "$out"
             '';

--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -617,9 +617,9 @@ let
               ${pkgs.lib.optionalString (miriRustFlags != "") ''
               export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }${miriRustFlags}"
               ''}
-              miri_src="$TMPDIR/cargo-unit-miri-src"
+              miri_src="$TMPDIR/cargo-unit-miri-workspace"
               mkdir -p "$miri_src"
-              cp -R ${src}/. "$miri_src"/
+              cp -R ${workspaceRoot}/. "$miri_src"/
               chmod -R u+w "$miri_src"
               cd "$miri_src"
               ${testRunPrelude}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -636,6 +636,44 @@ let
     };
   };
 
+  cargoUnitFakeMiriToolchain = pkgs.runCommand "cargo-unit-fake-miri-toolchain" { } ''
+    mkdir -p "$out/bin"
+    cat > "$out/bin/cargo" <<'EOF'
+    #!${pkgs.runtimeShell}
+    set -eu
+    : "''${CARGO_UNIT_FAKE_CARGO_LOG:=$out/cargo-miri-argv}"
+    mkdir -p "$(dirname "$CARGO_UNIT_FAKE_CARGO_LOG")"
+    printf '%s\n' "$*" > "$CARGO_UNIT_FAKE_CARGO_LOG"
+    EOF
+    chmod +x "$out/bin/cargo"
+  '';
+
+  cargoUnitMiriWorkspace = ix.cargoUnit.buildWorkspace {
+    src = cargoUnitFixture;
+    workspaceRoot = ./fixtures/cargo-unit-hello;
+    cargoTargets = [
+      [
+        "--workspace"
+        "--tests"
+      ]
+    ];
+    miri = {
+      package = pkgs.runCommand "cargo-unit-empty-miri-package" { } "mkdir -p $out";
+      rustToolchain = cargoUnitFakeMiriToolchain;
+      flags = [ "-Zmiri-disable-isolation" ];
+    };
+    miriTests.tagged = {
+      targets = [ "cargo_unit_hello" ];
+      testArgs = [ ":miri:" ];
+    };
+    policy = {
+      denyUnusedCrateDependencies = false;
+      cargoAudit.enable = false;
+      cargoMachete.enable = false;
+      clippy.enable = false;
+    };
+  };
+
   cargoUnitHello = cargoUnitWorkspace.binaries.cargo-unit-hello;
   cargoUnitSelectedHello = ix.cargoUnit.selectBinaryWithTests cargoUnitWorkspace {
     binary = "cargo-unit-hello";
@@ -3040,6 +3078,22 @@ let
         message = "cargo-unit workspaces should expose a customizable coverage report builder";
       }
       {
+        assertion = cargoUnitWorkspace ? makeMiriTest;
+        message = "cargo-unit workspaces should expose a customizable Miri test aggregate builder";
+      }
+      {
+        assertion = builtins.isAttrs cargoUnitWorkspace.miriUnits;
+        message = "cargo-unit workspaces should expose per-target Miri derivations";
+      }
+      {
+        assertion = builtins.hasAttr "cargo_unit_hello" cargoUnitWorkspace.miriUnits;
+        message = "cargo-unit Miri derivations should be keyed by test target";
+      }
+      {
+        assertion = cargoUnitMiriWorkspace.miriTests ? tagged;
+        message = "cargo-unit workspaces should expose named Miri test presets";
+      }
+      {
         assertion = cargoUnitWorkspace ? benchmarkPlan;
         message = "cargo-unit workspaces should expose a reusable benchmark plan";
       }
@@ -3584,6 +3638,7 @@ let
     test -s ${cargoUnitCoverageWorkspace.coverageReport}/merged.profdata
     grep -q '^SF:src/lib.rs$' ${cargoUnitCoverageWorkspace.coverageReport}/lcov.info
     grep -q '^DA:' ${cargoUnitCoverageWorkspace.coverageReport}/lcov.info
+    grep -qx 'miri test --release --package cargo-unit-hello --lib --frozen --offline -- :miri:' ${cargoUnitMiriWorkspace.miriTests.tagged}/cargo-miri-argv
     test -x ${cargoUnitWorkspace.benchmarkPlan}/packages/cargo-unit-hello/benchmarks/greeting
     grep -q '^cargo-unit-hello	greeting	.*/bin/greeting$' ${cargoUnitWorkspace.benchmarkPlan}/benchmarks.tsv
     test -e ${cargoUnitTangoComparison}/done


### PR DESCRIPTION
## Summary

- add per-target `miriUnits` derivations to rendered cargo-unit workspaces
- add `makeMiriTest` / `miriTests` as aggregate surfaces over selected Miri units
- cover the shape with renderer assertions and an eval fixture that proves a named Miri preset stays a join over a target derivation

## Checks

- `nix shell nixpkgs#cargo nixpkgs#rustc nixpkgs#stdenv.cc -c cargo test -p nix-cargo-unit exposes_test_roots_as_runnable_checks`
- `nix eval .#checks.x86_64-linux.eval --json`
- `nix build .#checks.x86_64-linux.eval`
- `nix run .#lint`
