### PR TITLE
cargo-unit: expose per-case test checks

### DIFF
--- a/lib/cargo-unit.nix
+++ b/lib/cargo-unit.nix
@@ -34,6 +34,8 @@ let
     rustToolchain = args.rustToolchain or rust.defaultRustToolchain;
     nativeBuildInputs = args.nativeBuildInputs or [ ];
     env = args.env or { };
+    testRunPrelude = args.testRunPrelude or "";
+    testArgsByPackage = args.testArgsByPackage or { };
     extraRustcArgs = args.extraRustcArgs or [ ];
     cargoExtraConfig = args.cargoExtraConfig or "";
     vendorDir = args.vendorDir or null;
@@ -375,6 +377,7 @@ let
         # `clippy-driver` links against.
         extraClippyNativeBuildInputs = lib.optional perUnitClippyEnabled args.policy.clippy.package;
         extraEnv = args.env;
+        inherit (args) testRunPrelude testArgsByPackage;
         extraRustcArgsForPlatform = rust.rustcArgsForPolicyForPlatform args.policy;
         # Manifest-derived flags come first so per-call `policy.clippy`
         # entries land later in argv and can override them. Cargo's
@@ -426,9 +429,9 @@ let
     derivations, ready for `passthru.tests` consumption.
 
     `testTargets` and `doctestTargets` default to every generated target owned
-    by `packageName`. Each target becomes one `<target>-all` test; doctests use
-    `doctest-<target>-all` names. Set `includeTestCases` only for callers that
-    deliberately want one flake-checkable derivation per discovered test case.
+    by `packageName`. Each discovered test case becomes its own derivation by
+    default; `<target>-all` remains available for callers that need the full
+    harness as a single compatibility check.
 
     Use this when the caller has one shared workspace (`ix.rustWorkspace.units`)
     so all repo-owned crates ride the same unit graph. Use `buildBinary` when
@@ -441,7 +444,7 @@ let
       packageName ? binary,
       testTargets ? null,
       doctestTargets ? null,
-      includeTestCases ? false,
+      includeTestCases ? true,
       meta ? { },
       passthru ? { },
     }:

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -2632,9 +2632,10 @@ fn render_test_entries_for(
         let binary = test_binary_expr(unit, prepared, *index);
         let _ = writeln!(
             entries,
-            "    {} = mkTestEntry {{ name = {}; binary = \"{binary}\"; }};",
+            "    {} = mkTestEntry {{ name = {}; binary = \"{binary}\"; packageName = {}; }};",
             nix_attr(&key),
             nix_attr(&key),
+            nix_attr(&unit.package_name()),
         );
     }
 
@@ -3052,7 +3053,10 @@ mod tests {
 
         assert!(rendered.contains("tests = {"));
         assert!(rendered.contains("\"hello\" = mkTestEntry { name = \"hello\";"));
+        assert!(rendered.contains("packageName = \"hello\";"));
         assert!(rendered.contains("/bin/hello\";"));
+        assert!(rendered.contains("testRunPrelude ? \"\""));
+        assert!(rendered.contains("testArgsByPackage ? {}"));
         assert!(rendered.contains("mkTestEntry ="));
         assert!(rendered.contains("RUST_TEST_THREADS"));
         assert!(rendered.contains("mkTestCases ="));

--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -9,6 +9,8 @@
   extraNativeBuildInputs ? [],
   extraClippyNativeBuildInputs ? [],
   extraEnv ? {},
+  testRunPrelude ? "",
+  testArgsByPackage ? {},
   extraPolicyChecks ? {},
   extraRustcArgs ? [],
   extraRustcArgsForPlatform ? _platform: [],
@@ -558,31 +560,60 @@ let
   # Map both to ASCII-safe runs without losing the path shape.
   sanitizeTestName = pkgs.lib.replaceStrings [ "::" ":" " " ] [ "--" "_" "_" ];
 
-  # Single IFD that depends on every test binary. Writes one
-  # `<name>.list` (non-ignored tests) and one `<name>.ignored.list`
-  # per target. Mainline Nix evaluates IFDs serially, so collapsing
-  # per-binary list drvs into one cuts eval latency proportionally
-  # to the number of test targets. The tradeoff is that touching any
-  # `cases` forces every test binary to build; consumers that only
-  # want `tests.<name>.all` skip this derivation entirely.
+  # One IFD owns test discovery because IFDs block evaluation. The builder
+  # lists binaries concurrently, then the generated attrset fans out into
+  # ordinary per-#[test] derivations.
   testManifestDrv =
     if testTargets == [] then null
     else pkgs.runCommand "cargo-unit-test-manifest" { } (
       ''
+        set -euo pipefail
+
         mkdir -p "$out"
+
+        max_jobs="''${NIX_BUILD_CORES:-1}"
+        case "$max_jobs" in
+          ""|*[!0-9]*|0) max_jobs=1 ;;
+        esac
+
+        running=0
+        failures=0
+        wait_for_one() {
+          if ! wait -n; then
+            failures=$((failures + 1))
+          fi
+          running=$((running - 1))
+        }
       ''
       + pkgs.lib.concatMapStrings (target: ''
-        ${target.binary} --list --format terse > "$out"/${pkgs.lib.escapeShellArg target.name}.list
-        ${target.binary} --list --format terse --ignored > "$out"/${pkgs.lib.escapeShellArg target.name}.ignored.list
+        (
+          ${target.binary} --list --format terse > "$out"/${pkgs.lib.escapeShellArg target.name}.list
+          ${target.binary} --list --format terse --ignored > "$out"/${pkgs.lib.escapeShellArg target.name}.ignored.list
+        ) &
+        running=$((running + 1))
+        if [ "$running" -ge "$max_jobs" ]; then
+          wait_for_one
+        fi
       '') testTargets
+      + ''
+        while [ "$running" -gt 0 ]; do
+          wait_for_one
+        done
+
+        if [ "$failures" -ne 0 ]; then
+          echo >&2 "error: cargo-unit failed to list $failures test target(s)"
+          exit 1
+        fi
+      ''
     );
 
   mkTestCases =
-    { name, binary, ignored }:
+    { name, binary, packageName, ignored }:
     let
       suffix = if ignored then ".ignored.list" else ".list";
       listPath = "${testManifestDrv}/${name}${suffix}";
       runFlag = pkgs.lib.optionalString ignored "--include-ignored ";
+      testArgs = testArgsByPackage.${packageName} or [];
     in
     pkgs.lib.listToAttrs (
       map (testName: {
@@ -592,28 +623,33 @@ let
             "cargo-unit-test-${name}-${sanitizeTestName testName}"
             { }
             ''
-              ${binary} --exact --nocapture ${runFlag}${pkgs.lib.escapeShellArg testName}
+              ${testRunPrelude}
+              ${binary} --exact --nocapture ${runFlag}${pkgs.lib.escapeShellArgs (testArgs ++ [ testName ])}
               mkdir -p "$out"
             '';
       }) (parseTestList listPath)
     );
 
   mkTestEntry =
-    { name, binary }:
+    { name, binary, packageName }:
+    let
+      testArgs = testArgsByPackage.${packageName} or [];
+    in
     {
       # Runs the whole test binary in one derivation, mirroring `cargo test`.
       all = pkgs.runCommand "cargo-unit-test-${name}" { } ''
         export RUST_TEST_THREADS="$NIX_BUILD_CORES"
-        ${binary}
+        ${testRunPrelude}
+        ${binary} ${pkgs.lib.escapeShellArgs testArgs}
         mkdir -p "$out"
       '';
       # One derivation per #[test], populated from the shared manifest.
       # First access to any binary's `cases` triggers the single manifest
       # IFD (which builds every test binary in the workspace).
       cases =
-        mkTestCases { inherit name binary; ignored = false; }
+        mkTestCases { inherit name binary packageName; ignored = false; }
         // pkgs.lib.optionalAttrs includeIgnored (
-          mkTestCases { inherit name binary; ignored = true; }
+          mkTestCases { inherit name binary packageName; ignored = true; }
         );
     };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2997,8 +2997,8 @@ let
       }
       {
         assertion =
-          !(builtins.hasAttr "cargo_unit_hello-tests-returns_greeting" cargoUnitSelectedHello.passthru.tests);
-        message = "selectBinaryWithTests should not force per-case test manifests into flake checks by default";
+          builtins.hasAttr "cargo_unit_hello-tests-returns_greeting" cargoUnitSelectedHello.passthru.tests;
+        message = "selectBinaryWithTests should expose per-case test derivations by default";
       }
       {
         assertion = builtins.all (binary: builtins.hasAttr binary cargoUnitBinaries) [


### PR DESCRIPTION
Expose per-#[test] cargo-unit checks by default while keeping discovery in one parallelized manifest IFD. Add test-run prelude and package argument plumbing so consumers can run per-case checks without bespoke harness loops.