### PR TITLE
Scope nix-cargo-unit bootstrap source

### DIFF
--- a/packages/nix-cargo-unit/default.nix
+++ b/packages/nix-cargo-unit/default.nix
@@ -3,17 +3,77 @@
   pkgs,
 }:
 
+let
+  inherit (pkgs) lib;
+  fs = lib.fileset;
+  workspaceRoot = ix.rustWorkspace.root;
+  workspaceManifest = builtins.fromTOML (builtins.readFile (workspaceRoot + "/Cargo.toml"));
+  workspaceMembers = workspaceManifest.workspace.members;
+  workspaceMemberManifests = map (member: workspaceRoot + "/${member}/Cargo.toml") workspaceMembers;
+  explicitTargetPaths =
+    targetDir: targets: map (target: target.path or "${targetDir}/${target.name}.rs") targets;
+  memberTargetStubs =
+    member:
+    let
+      manifest = builtins.fromTOML (builtins.readFile (workspaceRoot + "/${member}/Cargo.toml"));
+      relative = path: "${member}/${path}";
+    in
+    map relative (
+      lib.optional (manifest ? lib) (manifest.lib.path or "src/lib.rs")
+      ++ explicitTargetPaths "src/bin" (manifest.bin or [ ])
+      ++ explicitTargetPaths "benches" (manifest.bench or [ ])
+      ++ explicitTargetPaths "tests" (manifest.test or [ ])
+      ++ explicitTargetPaths "examples" (manifest.example or [ ])
+      ++ lib.optional (builtins.pathExists (workspaceRoot + "/${member}/src/main.rs")) "src/main.rs"
+      ++ lib.optional (builtins.pathExists (workspaceRoot + "/${member}/src/lib.rs")) "src/lib.rs"
+    );
+  siblingTargetStubs = lib.concatMap (
+    member: lib.optionals (member != "packages/nix-cargo-unit") (memberTargetStubs member)
+  ) workspaceMembers;
+
+  # nix-cargo-unit bootstraps the unit graph, so it cannot consume
+  # ix.cargoUnit. Cargo still needs each workspace member manifest to keep
+  # Cargo.lock frozen against the real workspace.
+  scopedTrackedSrc = fs.toSource {
+    root = workspaceRoot;
+    fileset = fs.intersection (fs.gitTracked workspaceRoot) (
+      fs.unions (
+        [
+          (workspaceRoot + "/Cargo.toml")
+          (workspaceRoot + "/Cargo.lock")
+        ]
+        ++ workspaceMemberManifests
+        ++ [ ./. ]
+      )
+    );
+  };
+  src = pkgs.runCommand "nix-cargo-unit-src" { } ''
+    mkdir -p "$out"
+    cp -R --no-preserve=mode,ownership ${scopedTrackedSrc}/. "$out"
+    chmod -R u+w "$out"
+    ${lib.concatMapStringsSep "\n" (
+      path: ''install -Dm0644 /dev/null "$out/${path}"''
+    ) siblingTargetStubs}
+  '';
+in
 ix.buildRustPackage pkgs {
   pname = "nix-cargo-unit";
   version = "0.1.0";
 
-  src = ix.rustWorkspace.src;
+  inherit src;
   cargoLock.lockFile = ix.rustWorkspace.cargoLock;
   buildAndTestSubdir = "packages/nix-cargo-unit";
   cargoArgs = [
     "-p"
     "nix-cargo-unit"
   ];
+  # Root-level policy checks need sibling crate targets, which would
+  # reintroduce the full workspace source closure here. The workspace unit
+  # graph still runs those policy checks for nix-cargo-unit.
+  policy = {
+    cargoMachete.enable = false;
+    clippy.enable = false;
+  };
 
   meta.mainProgram = "nix-cargo-unit";
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2996,8 +2996,7 @@ let
         message = "selectBinaryWithTests should expose only derivations in passthru.tests";
       }
       {
-        assertion =
-          builtins.hasAttr "cargo_unit_hello-tests-returns_greeting" cargoUnitSelectedHello.passthru.tests;
+        assertion = builtins.hasAttr "cargo_unit_hello-tests-returns_greeting" cargoUnitSelectedHello.passthru.tests;
         message = "selectBinaryWithTests should expose per-case test derivations by default";
       }
       {


### PR DESCRIPTION
## Summary

- Scope the nix-cargo-unit bootstrap source to root Cargo manifests, workspace member manifests, and packages/nix-cargo-unit.
- Generate empty sibling target stubs so Cargo can validate the real workspace without hashing sibling crate source contents.
- Format tests/default.nix so the repo lint gate passes on this branch.

## Checks

- nix build .#nix-cargo-unit
- nix run .#lint
