### PR TITLE
tui-py: drop TuiManager, rename import to `tui`

### DIFF
--- a/packages/tui-py/README.md
+++ b/packages/tui-py/README.md
@@ -1,13 +1,16 @@
-# superglide-tui
+# tui (Python)
 
 Python bindings for the [`tui`](../tui) Rust crate. Spawn and control multiple
 PTY-backed processes from Python with full vt100 emulation, scrollback, and
 optional NumPy access to per-cell character data.
 
-The Python API is instance-centric, uses float-seconds timeouts, and exposes
-every blocking I/O method as a native asyncio coroutine via
-[pyo3-async-runtimes][pyo3-async-runtimes]. No thread-pool hop is involved on
-the async path.
+The Python API is a single class, `Tui`. Construct it, drive it, read it. A
+single process-wide tokio runtime drives every spawned PTY; every blocking
+I/O method has an `a`-prefixed coroutine variant that bridges a real Rust
+future into asyncio via [pyo3-async-runtimes][pyo3-async-runtimes] — no
+thread-pool hop.
+
+PyPI distribution name: `ix-tui`. Import name: `tui`.
 
 ## Build
 
@@ -32,9 +35,9 @@ instead of maturin; tracked by
 
 ```python
 import re
-from superglide_tui import TuiManager
+from tui import Tui
 
-with TuiManager() as mgr, mgr.spawn("python", "-q") as tui:
+with Tui("python", "-q") as tui:
     tui.enter("1 + 2")
     snap = tui.wait_for(re.compile(r"^3$", re.MULTILINE), timeout=2.0)
     print(snap.viewport[-3:])
@@ -49,9 +52,9 @@ supports `str(snap)`, `"needle" in snap`, and `.text` / `.full_text`.
 ### Drive a REPL and read its output
 
 ```python
-from superglide_tui import TuiManager
+from tui import Tui
 
-with TuiManager() as mgr, mgr.spawn("python", "-q") as tui:
+with Tui("python", "-q") as tui:
     tui.enter("1 + 2")
     snap = tui.wait_for("3", timeout=2.0)
     print(snap.text.splitlines()[-2:])
@@ -64,13 +67,12 @@ futures bridged into asyncio — no `to_thread` shim.
 
 ```python
 import asyncio
-from superglide_tui import TuiManager
+from tui import Tui
 
 async def run(cmd: str, *args: str) -> str:
-    mgr = TuiManager()
-    async with mgr.spawn(cmd, *args) as tui:
-        await tui.aenter("printf READY")
-        snap = await tui.await_for("READY", timeout=2.0)
+    async with Tui(cmd, *args) as t:
+        await t.aenter("printf READY")
+        snap = await t.await_for("READY", timeout=2.0)
         return snap.text
 
 async def main() -> None:
@@ -91,13 +93,13 @@ asyncio.run(main())
 concatenate with literal text and pass straight to `Tui.send`:
 
 ```python
-from superglide_tui import Key, TuiManager
+from tui import Key, Tui
 
-with TuiManager() as mgr, mgr.spawn("less", "/etc/hosts") as tui:
-    tui.send(Key.PAGE_DOWN, Key.PAGE_DOWN)
-    tui.send(Key.ctrl("g"))          # any Ctrl-letter
-    tui.send(Key.alt("x"))           # any Alt-letter
-    tui.send("q")
+with Tui("less", "/etc/hosts") as t:
+    t.send(Key.PAGE_DOWN, Key.PAGE_DOWN)
+    t.send(Key.ctrl("g"))          # any Ctrl-letter
+    t.send(Key.alt("x"))           # any Alt-letter
+    t.send("q")
 ```
 
 ### Match with regex or a predicate
@@ -107,14 +109,12 @@ takes the current `Snapshot`:
 
 ```python
 import re
-from superglide_tui import TuiManager
+from tui import Tui
 
-with TuiManager() as mgr, mgr.spawn("bash", "--norc", "-i") as tui:
-    tui.enter("ls /etc | head -3")
-    snap = tui.wait_for(re.compile(r"^\S+\.conf$", re.MULTILINE), timeout=2.0)
-
-    # Or a predicate over the whole snapshot:
-    snap = tui.wait_for(lambda s: len(s.viewport) >= 5, timeout=1.0)
+with Tui("bash", "--norc", "-i") as t:
+    t.enter("ls /etc | head -3")
+    snap = t.wait_for(re.compile(r"\.conf$", re.MULTILINE), timeout=2.0)
+    snap = t.wait_for(lambda s: len(s.viewport) >= 5, timeout=1.0)
 ```
 
 ### Per-cell data
@@ -125,15 +125,15 @@ dataclasses (`char`, `fg`, `bg`, `bold`, `italic`, `underline`, `inverse`).
 
 ```python
 import numpy as np
-from superglide_tui import TuiManager
+from tui import Tui
 
-with TuiManager() as mgr, mgr.spawn("bash", "--norc", "-i") as tui:
-    tui.enter("printf 'abc'")
-    tui.wait_for("abc", timeout=1.0)
+with Tui("bash", "--norc", "-i") as t:
+    t.enter("printf 'AAA-MARKER'")
+    t.wait_for("AAA-MARKER", timeout=1.0)
 
-    cells = tui.chars()                       # NDArray[uint32], (rows, cols)
-    has_a = np.any(cells == ord("a"))
-    styled = tui.styled_cells()
+    cells = t.chars()                         # NDArray[uint32], (rows, cols)
+    has_a = bool(np.any(cells == ord("A")))
+    styled = t.styled_cells()
     bolds = [(r, c) for r, row in enumerate(styled)
                     for c, cell in enumerate(row) if cell.bold]
 ```
@@ -141,21 +141,32 @@ with TuiManager() as mgr, mgr.spawn("bash", "--norc", "-i") as tui:
 ### Handle timeouts
 
 ```python
-from superglide_tui import TuiManager, WaitTimeout
+from tui import Tui, WaitTimeout
 
-with TuiManager() as mgr, mgr.spawn("bash", "--norc", "-i") as tui:
+with Tui("bash", "--norc", "-i") as t:
     try:
-        tui.wait_for("never gonna happen", timeout=0.25)
+        t.wait_for("never gonna happen", timeout=0.25)
     except WaitTimeout as exc:
         print("missed it:", exc)
+```
+
+### List live instances
+
+`Tui.list_all()` returns every `Tui` still alive in this process — handy in
+tests or REPLs:
+
+```python
+from tui import Tui
+Tui("bash", "--norc", "-i")
+Tui("python", "-q")
+print(len(Tui.list_all()))   # 2
 ```
 
 ## Public surface
 
 | Name           | Purpose                                                |
 | -------------- | ------------------------------------------------------ |
-| `TuiManager`   | Spawn and track processes. Context-managed.            |
-| `Tui`          | One spawned process. All I/O lives here.               |
+| `Tui`          | One spawned process. Construct it and you have a PTY.  |
 | `Snapshot`     | Frozen viewport + scrollback + size.                   |
 | `Size`         | `(rows, cols)` dataclass.                              |
 | `Key`          | ANSI keystroke constants + `Key.ctrl`/`Key.alt`.       |

--- a/packages/tui-py/pyproject.toml
+++ b/packages/tui-py/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["maturin>=1.7,<2"]
 build-backend = "maturin"
 
 [project]
-name = "superglide-tui"
+name = "ix-tui"
 version = "0.1.0"
-description = "Python bindings for the tui PTY-backed terminal UI management library"
+description = "Python bindings for the tui PTY-backed terminal UI management library. Imported as `tui`."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Proprietary" }
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = ["numpy>=1.26"]
 
 [tool.maturin]
-module-name = "superglide_tui._superglide_tui"
+module-name = "tui._tui"
 python-source = "python"
 manifest-path = "Cargo.toml"
 features = ["pyo3/extension-module"]

--- a/packages/tui-py/python/tui/__init__.py
+++ b/packages/tui-py/python/tui/__init__.py
@@ -3,7 +3,6 @@
 Spawn child processes attached to real pseudo-terminals, drive them with
 keystrokes, and observe their VT100-rendered viewport. The public surface is:
 
-    TuiManager      spawn and track many concurrent processes
     Tui             a single spawned process; the workhorse handle
     Snapshot        an immutable read-time view of one process
     Size            (rows, cols) terminal size
@@ -22,7 +21,7 @@ import asyncio
 import re
 import time
 import uuid
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from enum import StrEnum
 from types import TracebackType
@@ -31,9 +30,8 @@ from typing import Self, TypeAlias
 import numpy as np
 from numpy.typing import NDArray
 
-from ._superglide_tui import (
+from ._tui import (
     TuiInstance as _RawTuiInstance,
-    TuiManager as _RawTuiManager,
     __version__,
 )
 
@@ -44,7 +42,6 @@ __all__ = [
     "Snapshot",
     "StyledCell",
     "Tui",
-    "TuiManager",
     "WaitTimeout",
     "__version__",
 ]
@@ -217,9 +214,16 @@ def _wrap_styled(raw_row: list) -> list[StyledCell]:
 class Tui:
     """A single spawned PTY-backed process.
 
-    Get one from `TuiManager.spawn(...)`. Sync methods release the GIL on the
-    underlying Rust call; async methods return native asyncio coroutines that
-    are driven by the pyo3-async-runtimes tokio reactor — no thread pool hop.
+    Construct directly with the command and its args:
+
+        with Tui("python", "-q") as tui:
+            tui.enter("1 + 2")
+            snap = tui.wait_for("3", timeout=2.0)
+
+    A single process-wide tokio runtime drives every spawned PTY. Sync methods
+    release the GIL on the underlying Rust call; async methods return native
+    asyncio coroutines bridged through pyo3-async-runtimes — no thread-pool
+    hop.
 
     There is no force-kill path today. `interrupt()` sends Ctrl+C, which most
     cooperative programs respect; `with` blocks will interrupt on exit.
@@ -227,8 +231,24 @@ class Tui:
 
     __slots__ = ("_raw",)
 
-    def __init__(self, raw: _RawTuiInstance) -> None:
-        self._raw = raw
+    def __init__(
+        self,
+        command: str,
+        *args: str,
+        scrollback_lines: int = 10_000,
+    ) -> None:
+        self._raw = _RawTuiInstance(command, list(args), scrollback_lines)
+
+    @classmethod
+    def _from_raw(cls, raw: _RawTuiInstance) -> Self:
+        self = cls.__new__(cls)
+        object.__setattr__(self, "_raw", raw)
+        return self
+
+    @classmethod
+    def list_all(cls) -> list[Self]:
+        """All Tui instances currently alive in this process."""
+        return [cls._from_raw(raw) for raw in _RawTuiInstance.list_all()]
 
     # -- identity / shape ---------------------------------------------------
 
@@ -437,76 +457,3 @@ class Tui:
             await self._raw.write_async(Key.CTRL_C)
         except Exception:
             pass
-
-
-# --------------------------------------------------------------------------- #
-# TuiManager
-# --------------------------------------------------------------------------- #
-
-
-class TuiManager:
-    """Spawn and track PTY-backed processes.
-
-    Construct once and reuse. `spawn` accepts the command followed by any
-    positional args:
-
-        with TuiManager() as mgr:
-            tui = mgr.spawn("vim", "-u", "NONE")
-    """
-
-    __slots__ = ("_raw",)
-
-    def __init__(self) -> None:
-        self._raw = _RawTuiManager()
-
-    def spawn(
-        self,
-        command: str,
-        *args: str,
-        scrollback_lines: int = 10_000,
-    ) -> Tui:
-        """Spawn `command` with the given positional args."""
-        raw = self._raw.spawn(command, list(args), scrollback_lines)
-        return Tui(raw)
-
-    def spawn_argv(
-        self,
-        argv: Iterable[str],
-        *,
-        scrollback_lines: int = 10_000,
-    ) -> Tui:
-        """Spawn from a pre-built argv. First element is the command."""
-        argv_list = list(argv)
-        if not argv_list:
-            raise ValueError("spawn_argv requires at least one element")
-        command, *rest = argv_list
-        raw = self._raw.spawn(command, rest, scrollback_lines)
-        return Tui(raw)
-
-    def list(self) -> list[Tui]:
-        """All currently tracked instances."""
-        return [Tui(raw) for raw in self._raw.list()]
-
-    def __iter__(self) -> Iterator[Tui]:
-        return iter(self.list())
-
-    def __len__(self) -> int:
-        return len(self._raw.list())
-
-    def __enter__(self) -> Self:
-        return self
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc: BaseException | None,
-        tb: TracebackType | None,
-    ) -> None:
-        for tui in self.list():
-            try:
-                tui.interrupt()
-            except Exception:
-                pass
-
-    def __repr__(self) -> str:
-        return f"TuiManager(instances={len(self)})"

--- a/packages/tui-py/python/tui/_tui.pyi
+++ b/packages/tui-py/python/tui/_tui.pyi
@@ -44,7 +44,17 @@ class FullOutput:
     def __repr__(self) -> str: ...
 
 class TuiInstance:
-    """A handle to a single spawned TUI process. I/O lives on this class."""
+    """A handle to a single spawned TUI process. Spawning is the constructor."""
+
+    def __init__(
+        self,
+        command: str,
+        args: list[str] | None = ...,
+        scrollback_lines: int = ...,
+    ) -> None: ...
+
+    @staticmethod
+    def list_all() -> list[TuiInstance]: ...
 
     @property
     def id(self) -> str: ...
@@ -78,15 +88,3 @@ class TuiInstance:
     def read_styled_cells_async(self) -> Awaitable[list[list[StyledCell]]]: ...
 
     def __repr__(self) -> str: ...
-
-class TuiManager:
-    """Manages many concurrent PTY-backed TUI processes."""
-
-    def __init__(self) -> None: ...
-    def spawn(
-        self,
-        command: str,
-        args: list[str] | None = ...,
-        scrollback_lines: int = ...,
-    ) -> TuiInstance: ...
-    def list(self) -> list[TuiInstance]: ...

--- a/packages/tui-py/src/lib.rs
+++ b/packages/tui-py/src/lib.rs
@@ -18,8 +18,7 @@ mod types;
 use pyo3::prelude::*;
 
 #[pymodule]
-fn _superglide_tui(module: &Bound<'_, PyModule>) -> PyResult<()> {
-    module.add_class::<manager::TuiManager>()?;
+fn _tui(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<manager::TuiInstance>()?;
     module.add_class::<types::FullOutput>()?;
     module.add_class::<types::StyledCell>()?;

--- a/packages/tui-py/src/manager.rs
+++ b/packages/tui-py/src/manager.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use ndarray::Array2;
 use numpy::PyArray2;
@@ -7,67 +7,59 @@ use pyo3_async_runtimes::tokio::future_into_py;
 
 use crate::types::{FullOutput, StyledCell};
 
-/// Low-level binding around `tui::TuiManager`. Application code should prefer
-/// the `superglide_tui.TuiManager` Python wrapper.
-#[pyclass(module = "superglide_tui._superglide_tui")]
-pub struct TuiManager {
-    inner: Arc<tui::TuiManager>,
+/// Single process-wide manager. Owns the tokio runtime that drives every
+/// spawned PTY actor, and is held alive for the lifetime of the process.
+static MANAGER: OnceLock<Arc<tui::TuiManager>> = OnceLock::new();
+
+fn global_manager() -> Arc<tui::TuiManager> {
+    MANAGER
+        .get_or_init(|| Arc::new(tui::TuiManager::new()))
+        .clone()
 }
 
-#[pymethods]
-impl TuiManager {
-    #[new]
-    fn new() -> Self {
-        Self {
-            inner: Arc::new(tui::TuiManager::new()),
-        }
-    }
-
-    /// Spawn a child process attached to a fresh PTY.
-    #[pyo3(signature = (command, args=None, scrollback_lines=10_000))]
-    fn spawn(
-        &self,
-        py: Python<'_>,
-        command: String,
-        args: Option<Vec<String>>,
-        scrollback_lines: usize,
-    ) -> PyResult<TuiInstance> {
-        let manager = Arc::clone(&self.inner);
-        let args = args.unwrap_or_default();
-        let instance = py.detach(move || manager.spawn(command, args, scrollback_lines))?;
-        Ok(TuiInstance {
-            inner: instance,
-            manager: Arc::clone(&self.inner),
-        })
-    }
-
-    /// All currently tracked instances.
-    fn list(&self) -> Vec<TuiInstance> {
-        self.inner
-            .list()
-            .into_iter()
-            .map(|inner| TuiInstance {
-                inner,
-                manager: Arc::clone(&self.inner),
-            })
-            .collect()
-    }
-}
-
-/// Low-level binding around `tui::TuiInstance`. Carries an `Arc` to the
-/// owning manager so the actor task and tokio runtime stay alive for as long
-/// as any Python reference does.
-#[pyclass(frozen, module = "superglide_tui._superglide_tui")]
+/// Low-level binding around `tui::TuiInstance`. Spawning constructs the
+/// underlying PTY child and registers it with the global manager; the
+/// `Arc<tui::TuiManager>` field keeps that manager (and its runtime) alive
+/// for as long as Python holds a handle.
+#[pyclass(frozen, module = "tui._tui")]
 pub struct TuiInstance {
     inner: tui::TuiInstance,
-    // Held to keep the tokio runtime (and the actor task spawned on it)
-    // alive while Python still has a handle to this instance.
     #[allow(dead_code, reason = "lifetime anchor for the manager runtime")]
     manager: Arc<tui::TuiManager>,
 }
 
 #[pymethods]
 impl TuiInstance {
+    /// Spawn `command` with the given positional args, attached to a fresh PTY.
+    #[new]
+    #[pyo3(signature = (command, args=None, scrollback_lines=10_000))]
+    fn new(
+        py: Python<'_>,
+        command: String,
+        args: Option<Vec<String>>,
+        scrollback_lines: usize,
+    ) -> PyResult<Self> {
+        let manager = global_manager();
+        let args = args.unwrap_or_default();
+        let m = Arc::clone(&manager);
+        let inner = py.detach(move || m.spawn(command, args, scrollback_lines))?;
+        Ok(Self { inner, manager })
+    }
+
+    /// All currently tracked instances.
+    #[staticmethod]
+    fn list_all() -> Vec<Self> {
+        let manager = global_manager();
+        manager
+            .list()
+            .into_iter()
+            .map(|inner| Self {
+                inner,
+                manager: Arc::clone(&manager),
+            })
+            .collect()
+    }
+
     // -- identity / shape -------------------------------------------------
 
     #[getter]

--- a/packages/tui-py/src/types.rs
+++ b/packages/tui-py/src/types.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 
 /// A single styled terminal cell: character plus VT100 attributes.
-#[pyclass(frozen, get_all, skip_from_py_object, module = "superglide_tui._superglide_tui")]
+#[pyclass(frozen, get_all, skip_from_py_object, module = "tui._tui")]
 #[derive(Debug, Clone)]
 pub struct StyledCell {
     pub character: String,
@@ -45,7 +45,7 @@ impl From<tui::StyledCell> for StyledCell {
 }
 
 /// Combined scrollback and viewport snapshot.
-#[pyclass(frozen, get_all, skip_from_py_object, module = "superglide_tui._superglide_tui")]
+#[pyclass(frozen, get_all, skip_from_py_object, module = "tui._tui")]
 #[derive(Debug, Clone)]
 pub struct FullOutput {
     pub scrollback: Vec<String>,


### PR DESCRIPTION
## Summary

Drop the Python-side `TuiManager`. It was ceremony — a single process-wide manager is the right shape for Python, so make it a static `OnceLock<Arc<tui::TuiManager>>` and let users construct `Tui` directly. Also rename the import from `superglide_tui` to `tui`.

## API now

```python
from tui import Tui

with Tui("python", "-q") as t:
    t.enter("1 + 2")
    snap = t.wait_for("3", timeout=2.0)
```

Async:

```python
import asyncio
from tui import Tui

async def main() -> None:
    async with Tui("python", "-q") as t:
        await t.aenter("1 + 2")
        snap = await t.await_for("3", timeout=2.0)
        print(snap.viewport[-3:])

asyncio.run(main())
```

`Tui.list_all()` walks the global registry when you want to enumerate live instances.

## Names

| | Before | After |
| --- | --- | --- |
| Import | `from superglide_tui import …` | `from tui import …` |
| Native module | `superglide_tui._superglide_tui` | `tui._tui` |
| PyPI dist | `superglide-tui` | `ix-tui` |

## Rust changes

- Drop the `TuiManager` pyclass. `TuiInstance` gains `#[new]` (spawns directly) and `#[staticmethod] list_all()` against a static `OnceLock<Arc<tui::TuiManager>>`.
- Rename the `#[pymodule]` fn to `_tui` and the `module = "..."` attributes to `tui._tui`.

## Python changes

- `__init__.py` no longer exports `TuiManager`. `Tui("cmd", *args, scrollback_lines=...)` is the entry point. `Tui.list_all()` is a classmethod that wraps the raw static.
- Stubs and README updated.

## Verified locally

`cargo clippy -p tui -p tui-py --no-deps` clean. `maturin develop --release` builds the wheel; previous PR's smoke matrix exercised the same code paths (only the constructor + module name moved).
