### PR TITLE
symphony: bake room server into codex image

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -432,7 +432,8 @@
         "hermes-agent": "hermes-agent",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs_3",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay",
+        "symphony": "symphony"
       }
     },
     "rust-overlay": {
@@ -450,6 +451,30 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "symphony": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779984756,
+        "narHash": "sha256-6iGw1s1ql6mpIEehl4roIlDm2QQzuTzqbfYYE4rqNec=",
+        "owner": "indexable-inc",
+        "repo": "symphony",
+        "rev": "29d5c3b5f485c4990b129bcc4c3ae32f884ed9b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "indexable-inc",
+        "ref": "main",
+        "repo": "symphony",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,12 @@
       url = "github:NousResearch/hermes-agent/v2026.5.16";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    symphony = {
+      url = "github:indexable-inc/symphony/main";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.rust-overlay.follows = "rust-overlay";
+    };
   };
 
   outputs =
@@ -58,6 +64,7 @@
       determinate,
       home-manager,
       hermes-agent,
+      symphony,
       clippy-fork,
       ...
     }:
@@ -101,6 +108,7 @@
           determinate
           home-manager
           hermes-agent
+          symphony
           clippy-fork
           ;
       };

--- a/images/dev/symphony-codex/default.nix
+++ b/images/dev/symphony-codex/default.nix
@@ -2,7 +2,7 @@
 {
   ix.image = {
     name = "ix/symphony-codex";
-    tag = "2026-05-27";
+    tag = "2026-05-28";
   };
 
   networking.hostName = "symphony-codex";
@@ -32,6 +32,7 @@
     pkgs.pkg-config
     pkgs.python3
     pkgs.ripgrep
+    pkgs.symphony-room-server
     pkgs.unzip
     pkgs.which
     pkgs.zstd

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -7,6 +7,7 @@
   determinate,
   home-manager,
   hermes-agent,
+  symphony,
   clippy-fork,
   cliArtifacts ? { },
 }:
@@ -43,6 +44,7 @@ let
     inherit
       lib
       packageRegistry
+      symphony
       buildIxRustTool
       clippy-fork
       writePythonApplication

--- a/lib/overlay.nix
+++ b/lib/overlay.nix
@@ -1,6 +1,7 @@
 {
   lib,
   packageRegistry,
+  symphony,
   buildIxRustTool,
   clippy-fork,
   writePythonApplication,
@@ -34,3 +35,6 @@ lib.listToAttrs (
     packageRegistry.overlayEntriesFor packageSystem
   )
 )
+// {
+  symphony-room-server = symphony.packages.${packageSystem}.room-server;
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2320,12 +2320,12 @@ let
         message = "symphony-codex image should set the expected public OCI image name";
       }
       {
-        assertion = symphonyCodex.config.ix.image.tag == "2026-05-27";
+        assertion = symphonyCodex.config.ix.image.tag == "2026-05-28";
         message = "symphony-codex image should publish an immutable production tag";
       }
       {
-        assertion = !(builtins.elem "symphony-room-server" symphonyCodex.packageNames);
-        message = "symphony-codex image should let Symphony choose the live room-server source";
+        assertion = builtins.elem "symphony-room-server" symphonyCodex.packageNames;
+        message = "symphony-codex image should include the room-server binary it starts";
       }
       {
         assertion = builtins.elem pkgs.codex symphonyCodex.packages;


### PR DESCRIPTION
## Summary
- Add Symphony as an image-input flake dependency so index can bake the room-server package.
- Include symphony-room-server in the ix/symphony-codex image and bump the image tag to 2026-05-28.
- Flip the eval invariant so the image must carry the room-server binary it starts.

## Validation
- nix run nixpkgs#nixfmt-rfc-style -- --check flake.nix lib/default.nix lib/overlay.nix images/dev/symphony-codex/default.nix tests/default.nix
- nix --option eval-cache false eval --raw .#lib.pkgs.symphony-room-server.name
- nix --option eval-cache false eval --json .#packages.x86_64-linux.symphony-codex.name

## Note
- Full x86_64 eval checks cannot build on spark's aarch64-linux host; they stop on platform mismatch before this image assertion can run.
