### PR TITLE
tests: check baked room server package

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2324,7 +2324,7 @@ let
         message = "symphony-codex image should publish an immutable production tag";
       }
       {
-        assertion = builtins.elem "symphony-room-server" symphonyCodex.packageNames;
+        assertion = builtins.elem pkgs.symphony-room-server symphonyCodex.packages;
         message = "symphony-codex image should include the room-server binary it starts";
       }
       {


### PR DESCRIPTION
Fixes the merged symphony-codex eval assertion so it checks the actual package object in the rendered image package list. The baked package is exposed as `pkgs.symphony-room-server`, while its derivation name is `room-server-wrapped`.

Validation:
- `nix run nixpkgs#nixfmt-rfc-style -- --check tests/default.nix`
- `nix --accept-flake-config --option eval-cache false eval --raw .#checks.x86_64-linux.eval.drvPath`
