### PR TITLE
cargo-unit: add package test runtime inputs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,13 @@ nix develop .#minestom-hello-server-jar   # gives gradle + JDK 25
 nix develop nixpkgs#nixfmt                # nixfmt + its deps
 ```
 
+## Cargo Unit Test Runtime Inputs
+
+Use `packageTestInputs.<cargo-package> = [ pkgs.tool ];` when a package's tests
+spawn a runtime command, and `packageTestEnv.<cargo-package>` for package-local
+test environment variables. These apply to aggregate test binaries, per-test
+case derivations, and coverage runs.
+
 ## Cargo Unit Benchmarks
 
 [`ix.cargoUnit.buildWorkspace`](lib/cargo-unit.nix) exposes Cargo `[[bench]]`

--- a/lib/cargo-unit.nix
+++ b/lib/cargo-unit.nix
@@ -36,6 +36,8 @@ let
     env = args.env or { };
     testRunPrelude = args.testRunPrelude or "";
     testArgsByPackage = args.testArgsByPackage or { };
+    packageTestInputs = args.packageTestInputs or { };
+    packageTestEnv = args.packageTestEnv or { };
     extraRustcArgs = args.extraRustcArgs or [ ];
     cargoExtraConfig = args.cargoExtraConfig or "";
     vendorDir = args.vendorDir or null;
@@ -377,7 +379,12 @@ let
         # `clippy-driver` links against.
         extraClippyNativeBuildInputs = lib.optional perUnitClippyEnabled args.policy.clippy.package;
         extraEnv = args.env;
-        inherit (args) testRunPrelude testArgsByPackage;
+        inherit (args)
+          testRunPrelude
+          testArgsByPackage
+          packageTestInputs
+          packageTestEnv
+          ;
         extraRustcArgsForPlatform = rust.rustcArgsForPolicyForPlatform args.policy;
         # Manifest-derived flags come first so per-call `policy.clippy`
         # entries land later in argv and can override them. Cargo's

--- a/lib/overlay.nix
+++ b/lib/overlay.nix
@@ -36,5 +36,5 @@ lib.listToAttrs (
   )
 )
 // {
-  symphony-room-server = symphony.packages.${packageSystem}.room-server;
+  symphony-room-server = symphony.packages."${packageSystem}".room-server;
 }

--- a/lib/rust-workspace.nix
+++ b/lib/rust-workspace.nix
@@ -60,6 +60,7 @@ let
       "test"
       "bench"
     ];
+    packageTestInputs.tui = [ workspacePkgs.vim ];
     # Every policy check runs once across the whole workspace. Selected
     # package outputs expose these as explicit tests instead of making
     # downstream binary builds depend on unrelated workspace policy.

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -3057,6 +3057,8 @@ mod tests {
         assert!(rendered.contains("/bin/hello\";"));
         assert!(rendered.contains("testRunPrelude ? \"\""));
         assert!(rendered.contains("testArgsByPackage ? {}"));
+        assert!(rendered.contains("packageTestInputs ? {}"));
+        assert!(rendered.contains("packageTestEnv ? {}"));
         assert!(rendered.contains("mkTestEntry ="));
         assert!(rendered.contains("RUST_TEST_THREADS"));
         assert!(rendered.contains("mkTestCases ="));

--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -11,6 +11,8 @@
   extraEnv ? {},
   testRunPrelude ? "",
   testArgsByPackage ? {},
+  packageTestInputs ? {},
+  packageTestEnv ? {},
   extraPolicyChecks ? {},
   extraRustcArgs ? [],
   extraRustcArgsForPlatform ? _platform: [],
@@ -165,6 +167,18 @@ let
   hostRustTarget = pkgs.stdenv.hostPlatform.rust.rustcTarget or pkgs.stdenv.hostPlatform.config;
   defaultLlvmCov = "${rustToolchain}/lib/rustlib/${hostRustTarget}/bin/llvm-cov";
   defaultLlvmProfdata = "${rustToolchain}/lib/rustlib/${hostRustTarget}/bin/llvm-profdata";
+  packageTestAttrs = packageName: {
+    nativeBuildInputs = packageTestInputs.${packageName} or [];
+    env = packageTestEnv.${packageName} or {};
+  };
+  packageTestEnvArgs =
+    packageName:
+    pkgs.lib.mapAttrsToList (name: value: "${name}=${builtins.toString value}") (
+      packageTestEnv.${packageName} or {}
+    );
+  packageTestInputsForTargets =
+    targets:
+    pkgs.lib.concatMap (target: packageTestInputs.${target.packageName} or []) targets;
 
   mkTestPlan = name:
     pkgs.runCommand name
@@ -343,7 +357,7 @@ let
       {
         __structuredAttrs = true;
         strictDeps = true;
-        nativeBuildInputs = [ pkgs.coreutils ];
+        nativeBuildInputs = [ pkgs.coreutils ] ++ packageTestInputsForTargets testTargets;
       }
       (
         ''
@@ -434,7 +448,7 @@ let
           printf '%s\n' "$test_binary" >> "$executed_test_binaries"
           (
             cd "$test_cwd"
-            "$test_binary" ${pkgs.lib.escapeShellArgs (testArgs ++ (testArgsByPackage.${target.packageName} or []))}
+            env ${pkgs.lib.escapeShellArgs (packageTestEnvArgs target.packageName)} "$test_binary" ${pkgs.lib.escapeShellArgs (testArgs ++ (testArgsByPackage.${target.packageName} or []))}
           )
         '') testTargets
         + ''
@@ -621,7 +635,7 @@ let
         value =
           pkgs.runCommand
             "cargo-unit-test-${name}-${sanitizeTestName testName}"
-            { }
+            (packageTestAttrs packageName)
             ''
               ${testRunPrelude}
               ${binary} --exact --nocapture ${runFlag}${pkgs.lib.escapeShellArgs (testArgs ++ [ testName ])}
@@ -637,7 +651,7 @@ let
     in
     {
       # Runs the whole test binary in one derivation, mirroring `cargo test`.
-      all = pkgs.runCommand "cargo-unit-test-${name}" { } ''
+      all = pkgs.runCommand "cargo-unit-test-${name}" (packageTestAttrs packageName) ''
         export RUST_TEST_THREADS="$NIX_BUILD_CORES"
         ${testRunPrelude}
         ${binary} ${pkgs.lib.escapeShellArgs testArgs}

--- a/packages/tui/src/tests.rs
+++ b/packages/tui/src/tests.rs
@@ -34,11 +34,7 @@ fn write_and_read() {
     assert_eq!(first, "hello");
 }
 
-// Requires `vim` on PATH. Run with `cargo test -- --ignored` in an environment
-// that provides it. Tracked by indexable-inc/index#261 — once nix-cargo-unit
-// supports per-package test inputs, drop both #[ignore]s and declare vim there.
 #[test]
-#[ignore = "requires vim; see #261"]
 fn vim_spawns_and_produces_output() {
     let manager = TuiManager::new();
     let instance = manager
@@ -64,7 +60,6 @@ fn vim_spawns_and_produces_output() {
 }
 
 #[test]
-#[ignore = "requires vim; see #261"]
 fn vim_help_command_changes_screen() {
     let manager = TuiManager::new();
     let instance = manager

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -593,6 +593,8 @@ let
       "test"
       "bench"
     ];
+    packageTestInputs.cargo-unit-hello = [ pkgs.hello ];
+    packageTestEnv.cargo-unit-hello.CARGO_UNIT_FIXTURE_ENV = "ok";
     cargoTargets = [
       [ "--workspace" ]
       [
@@ -628,6 +630,8 @@ let
     ];
     profile = "dev";
     extraRustcArgs = [ "-Cinstrument-coverage" ];
+    packageTestInputs.cargo-unit-hello = [ pkgs.hello ];
+    packageTestEnv.cargo-unit-hello.CARGO_UNIT_FIXTURE_ENV = "ok";
     policy = {
       denyUnusedCrateDependencies = false;
       cargoAudit.enable = false;
@@ -3573,6 +3577,9 @@ let
     grep -q 'goodbye from cargo-unit' cargo-unit-goodbye.out
     test -d ${cargoUnitWorkspace.targetSets.test.tests.cargo_unit_hello.all}
     test -d ${cargoUnitWorkspace.targetSets.test.tests.cargo_unit_hello.cases."tests::returns_greeting"}
+    test -d ${
+      cargoUnitWorkspace.targetSets.test.tests.cargo_unit_hello.cases."tests::package_test_env_and_path_are_available"
+    }
     test -d ${(builtins.head (builtins.attrValues cargoUnitWorkspace.doctests)).all}
     test -d ${(builtins.head (builtins.attrValues (builtins.head (builtins.attrValues cargoUnitWorkspace.doctests)).cases))}
     test -s ${cargoUnitWorkspace.testPlan}/packages/cargo-unit-hello/test-binaries

--- a/tests/fixtures/cargo-unit-hello/src/lib.rs
+++ b/tests/fixtures/cargo-unit-hello/src/lib.rs
@@ -21,4 +21,18 @@ mod tests {
     fn current_dir_is_writable() {
         std::fs::write(".cargo-unit-writable-cwd-check", "ok").unwrap();
     }
+
+    #[test]
+    fn package_test_env_and_path_are_available() {
+        assert_eq!(
+            std::env::var("CARGO_UNIT_FIXTURE_ENV").as_deref(),
+            Ok("ok")
+        );
+
+        let output = std::process::Command::new("hello")
+            .output()
+            .expect("hello should be on PATH");
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stdout).contains("Hello"));
+    }
 }


### PR DESCRIPTION
## Summary

- add `packageTestInputs` and `packageTestEnv` to `ix.cargoUnit.buildWorkspace` test derivations
- wire `pkgs.vim` into the repo Rust workspace for the `tui` package tests
- remove the `#[ignore]` gates from the Vim-backed `tui` integration tests
- quote the new `symphony` overlay package-system attr required by the current lint rules on `main`

Fixes #261

## Verification

- `env XDG_CACHE_HOME=/tmp/nx-cache nix --accept-flake-config build .#nix-cargo-unit --no-link`
- `cargo test -p tui`
- `env XDG_CACHE_HOME=/tmp/nx-cache nix --accept-flake-config run .#lint`