### PR TITLE
symphony: build room server with static crates

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -44,8 +44,10 @@ let
     inherit
       lib
       packageRegistry
+      rust-overlay
       symphony
       buildIxRustTool
+      buildRustPackage
       clippy-fork
       writePythonApplication
       ;

--- a/lib/overlay.nix
+++ b/lib/overlay.nix
@@ -1,14 +1,49 @@
 {
   lib,
   packageRegistry,
+  rust-overlay,
   symphony,
   buildIxRustTool,
+  buildRustPackage,
   clippy-fork,
   writePythonApplication,
 }:
 final: _prev:
 let
   packageSystem = final.stdenv.hostPlatform.system;
+  rustPkgs = final.extend rust-overlay.overlays.default;
+  symphonyRoomServerChecked = buildRustPackage rustPkgs {
+    pname = "room-server";
+    version = "0.1.0";
+    src = symphony;
+    cargoLock = {
+      lockFile = symphony + "/Cargo.nix.lock";
+    };
+    cargoBuildFlags = [
+      "-p"
+      "room-server"
+    ];
+    cargoTestFlags = [
+      "-p"
+      "room-server"
+    ];
+    meta.mainProgram = "room-server";
+  };
+  symphonyRoomServerRaw = symphonyRoomServerChecked.passthru.unchecked;
+  symphonyRoomServer =
+    final.runCommand "room-server-wrapped"
+      {
+        nativeBuildInputs = [ final.makeWrapper ];
+        meta = (symphonyRoomServerRaw.meta or { }) // {
+          mainProgram = "room-server";
+        };
+      }
+      ''
+        mkdir -p $out/bin
+        makeWrapper ${symphonyRoomServerRaw}/bin/room-server $out/bin/room-server \
+          --prefix PATH : ${lib.makeBinPath [ final.codex ]} \
+          --set-default ROOM_CODEX_BIN ${lib.getExe final.codex}
+      '';
   overlayContext = entry: {
     inherit
       entry
@@ -36,5 +71,5 @@ lib.listToAttrs (
   )
 )
 // {
-  symphony-room-server = symphony.packages.${packageSystem}.room-server;
+  symphony-room-server = symphonyRoomServer;
 }


### PR DESCRIPTION
Build the baked Symphony room server through the index Rust builder instead of importing Symphony's raw flake package directly. The index builder vendors crates through the static crate CDN path, so CI and image builds avoid the crates.io API endpoint that returns 403 on GitHub runners.

Validation:
- `nix run nixpkgs#nixfmt-rfc-style -- lib/default.nix lib/overlay.nix`
- `nix --accept-flake-config --option eval-cache false eval --raw .#lib.pkgs.symphony-room-server.name`
- `nix build --accept-flake-config .#lib.pkgs.symphony-room-server --no-link --dry-run`
