### PR TITLE
[codex] remove package callPackageArgs adapters

### DIFF
--- a/lib/overlay.nix
+++ b/lib/overlay.nix
@@ -24,11 +24,12 @@ let
     entry:
     let
       context = overlayContext entry;
+      autoArgs = final // context;
     in
     if entry.overlay ? build then
       entry.overlay.build context
     else
-      final.callPackage entry.path (entry.overlay.callPackageArgs context);
+      lib.callPackageWith autoArgs entry.path { };
 in
 lib.listToAttrs (
   map (entry: lib.nameValuePair entry.overlay.attrName (buildOverlayPackage entry)) (
@@ -36,5 +37,5 @@ lib.listToAttrs (
   )
 )
 // {
-  symphony-room-server = symphony.packages.${packageSystem}.room-server;
+  symphony-room-server = symphony.packages."${packageSystem}".room-server;
 }

--- a/lib/packages.nix
+++ b/lib/packages.nix
@@ -55,7 +55,11 @@ let
         acc // { ${name} = rightValue; }
     ) left (builtins.attrNames right);
   buildEntry =
-    entry: pkgs.callPackage entry.path (entry.callPackageArgs (context // { inherit entry; }));
+    entry:
+    let
+      autoArgs = pkgs // context // { inherit entry; };
+    in
+    lib.callPackageWith autoArgs entry.path { };
   packageTreeFor = entry: lib.setAttrByPath entry.packageSet.attrPath (buildEntry entry);
 in
 lib.foldl' mergePackageTrees { } (

--- a/packages/agents-md/package.nix
+++ b/packages/agents-md/package.nix
@@ -4,9 +4,4 @@
   flake = true;
   inRustWorkspace = true;
   passthruTests = true;
-  callPackageArgs =
-    { ix, ... }:
-    {
-      inherit ix;
-    };
 }

--- a/packages/dag-runner/package.nix
+++ b/packages/dag-runner/package.nix
@@ -4,9 +4,4 @@
   flake = true;
   inRustWorkspace = true;
   passthruTests = true;
-  callPackageArgs =
-    { ix, ... }:
-    {
-      inherit ix;
-    };
 }

--- a/packages/file-search/package.nix
+++ b/packages/file-search/package.nix
@@ -4,9 +4,4 @@
   flake = true;
   inRustWorkspace = true;
   passthruTests = true;
-  callPackageArgs =
-    { ix, ... }:
-    {
-      inherit ix;
-    };
 }

--- a/packages/ix-dev-diagnose/package.nix
+++ b/packages/ix-dev-diagnose/package.nix
@@ -4,9 +4,4 @@
   flake = true;
   inRustWorkspace = true;
   passthruTests = true;
-  callPackageArgs =
-    { ix, ... }:
-    {
-      inherit ix;
-    };
 }

--- a/packages/ix-fleet/package.nix
+++ b/packages/ix-fleet/package.nix
@@ -2,9 +2,4 @@
   id = "ix-fleet";
   packageSet = true;
   flake = true;
-  callPackageArgs =
-    { ix, ... }:
-    {
-      inherit ix;
-    };
 }

--- a/packages/ix/default.nix
+++ b/packages/ix/default.nix
@@ -1,6 +1,8 @@
 {
   stdenvNoCC,
   fetchurl,
+  cliArtifacts ? { },
+  packageSystem ? stdenvNoCC.hostPlatform.system,
   binarySrc ? null,
 }:
 
@@ -21,11 +23,14 @@ let
   };
 
   inherit (stdenvNoCC.hostPlatform) system;
+  artifactSrc = cliArtifacts.${packageSystem} or null;
   selectedSrc =
-    if binarySrc == null then
-      sources.${system} or (throw "ix CLI: no precompiled binary for ${system}")
+    if binarySrc != null then
+      binarySrc
+    else if artifactSrc != null then
+      artifactSrc
     else
-      binarySrc;
+      sources.${system} or (throw "ix CLI: no precompiled binary for ${system}");
 in
 stdenvNoCC.mkDerivation {
   pname = "ix";

--- a/packages/ix/package.nix
+++ b/packages/ix/package.nix
@@ -2,12 +2,4 @@
   id = "ix";
   packageSet = true;
   flake = true;
-  callPackageArgs =
-    { cliArtifacts, packageSystem, ... }:
-    if builtins.hasAttr packageSystem cliArtifacts then
-      {
-        binarySrc = cliArtifacts.${packageSystem};
-      }
-    else
-      { };
 }

--- a/packages/llm-clippy/default.nix
+++ b/packages/llm-clippy/default.nix
@@ -3,15 +3,17 @@
   lib,
   makeWrapper,
   pkgs,
-  src,
+  clippy-fork ? null,
+  src ? clippy-fork,
 }:
 
 let
+  source = if src == null then throw "llm-clippy: src is required" else src;
   # Drive the toolchain from the fork's `rust-toolchain.toml` so a
   # `nix flake update clippy-fork` advances the rustc/rustc_private ABI in
   # lockstep with the source. If a future fork commit needs different
   # components, edit that file in the fork, not this one.
-  toolchain = pkgs.rust-bin.fromRustupToolchainFile (src + "/rust-toolchain.toml");
+  toolchain = pkgs.rust-bin.fromRustupToolchainFile (source + "/rust-toolchain.toml");
 
   rustcLibPathVar =
     if pkgs.stdenv.hostPlatform.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
@@ -20,12 +22,12 @@ ix.buildRustPackage pkgs {
   pname = "llm-clippy";
   version = "0.1.97";
 
-  inherit src;
+  src = source;
   rustToolchain = toolchain;
   # Read both the lockfile and the cargo-vendor inputs straight from the fork
   # so `nix flake update clippy-fork` brings dependency changes along with the
   # source commit. No checked-in lockfile to drift.
-  cargoLock.lockFile = src + "/Cargo.lock";
+  cargoLock.lockFile = source + "/Cargo.lock";
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [

--- a/packages/llm-clippy/package.nix
+++ b/packages/llm-clippy/package.nix
@@ -2,14 +2,4 @@
   id = "llm-clippy";
   packageSet = true;
   flake = true;
-  callPackageArgs =
-    {
-      ixForPackages,
-      clippy-fork,
-      ...
-    }:
-    {
-      ix = ixForPackages;
-      src = clippy-fork;
-    };
 }

--- a/packages/mcp/package.nix
+++ b/packages/mcp/package.nix
@@ -4,9 +4,4 @@
   flake = true;
   inRustWorkspace = true;
   passthruTests = true;
-  callPackageArgs =
-    { ix, ... }:
-    {
-      inherit ix;
-    };
 }

--- a/packages/minecraft/nbt/package.nix
+++ b/packages/minecraft/nbt/package.nix
@@ -4,9 +4,4 @@
   flake = true;
   inRustWorkspace = true;
   passthruTests = true;
-  callPackageArgs =
-    { ix, ... }:
-    {
-      inherit ix;
-    };
 }

--- a/packages/minecraft/probe/package.nix
+++ b/packages/minecraft/probe/package.nix
@@ -2,9 +2,4 @@
   id = "mc-probe";
   packageSet = true;
   flake = true;
-  callPackageArgs =
-    { ix, ... }:
-    {
-      inherit ix;
-    };
 }

--- a/packages/minecraft/rcon/package.nix
+++ b/packages/minecraft/rcon/package.nix
@@ -2,10 +2,5 @@
   id = "minecraft-rcon";
   overlay = {
     attrName = "minecraft-rcon";
-    callPackageArgs =
-      { writePythonApplication, ... }:
-      {
-        inherit writePythonApplication;
-      };
   };
 }

--- a/packages/minecraft/sync-managed/package.nix
+++ b/packages/minecraft/sync-managed/package.nix
@@ -4,9 +4,4 @@
   flake = true;
   inRustWorkspace = true;
   passthruTests = true;
-  callPackageArgs =
-    { ix, ... }:
-    {
-      inherit ix;
-    };
 }

--- a/packages/minestom/servers/hello/package.nix
+++ b/packages/minestom/servers/hello/package.nix
@@ -5,9 +5,4 @@
     "helloServerJar"
   ];
   flake = true;
-  callPackageArgs =
-    { ix, ... }:
-    {
-      inherit ix;
-    };
 }

--- a/packages/nix-cargo-unit/package.nix
+++ b/packages/nix-cargo-unit/package.nix
@@ -4,9 +4,4 @@
   flake = true;
   inRustWorkspace = true;
   passthruTests = true;
-  callPackageArgs =
-    { ix, pkgs, ... }:
-    {
-      inherit ix pkgs;
-    };
 }

--- a/packages/nix-web-monitor/server/package.nix
+++ b/packages/nix-web-monitor/server/package.nix
@@ -4,9 +4,4 @@
   flake = true;
   inRustWorkspace = true;
   passthruTests = true;
-  callPackageArgs =
-    { ix, pkgs, ... }:
-    {
-      inherit ix pkgs;
-    };
 }

--- a/packages/oci-image-builder/package.nix
+++ b/packages/oci-image-builder/package.nix
@@ -4,11 +4,6 @@
   flake = true;
   inRustWorkspace = true;
   passthruTests = true;
-  callPackageArgs =
-    { ix, ... }:
-    {
-      inherit ix;
-    };
   overlay = {
     attrName = "oci-image-builder";
     build =

--- a/packages/registry.nix
+++ b/packages/registry.nix
@@ -25,10 +25,28 @@ let
     dir: !(builtins.pathExists (dir + "/package.nix"))
   ) defaultPackageDirs;
 
-  normalizeArgs = value: if builtins.isFunction value then value else (_: value);
+  allowedMetadataKeys = [
+    "flake"
+    "id"
+    "inRustWorkspace"
+    "overlay"
+    "packageSet"
+    "passthruTests"
+    "path"
+  ];
+
+  assertKnownKeys =
+    label: allowedKeys: value:
+    let
+      unknownKeys = lib.subtractLists allowedKeys (builtins.attrNames value);
+    in
+    assert lib.assertMsg (
+      unknownKeys == [ ]
+    ) "${label}: unsupported keys: ${lib.concatStringsSep ", " unknownKeys}";
+    value;
 
   normalizePackageSet =
-    id: value:
+    label: id: value:
     if value == null || value == false then
       null
     else if value == true then
@@ -37,14 +55,14 @@ let
         systems = null;
       }
     else
-      value
+      assertKnownKeys "${label}: packageSet" [ "attrPath" "systems" ] value
       // {
         attrPath = value.attrPath or [ id ];
         systems = value.systems or null;
       };
 
   normalizeFlake =
-    id: value:
+    label: id: value:
     if value == null || value == false then
       null
     else if value == true then
@@ -53,32 +71,30 @@ let
         systems = null;
       }
     else
-      value
+      assertKnownKeys "${label}: flake" [ "attrName" "systems" ] value
       // {
         attrName = value.attrName or id;
         systems = value.systems or null;
       };
 
   normalizeOverlay =
-    id: value:
+    label: id: value:
     if value == null || value == false then
       null
     else if value == true then
       {
         attrName = id;
         systems = null;
-        callPackageArgs = _: { };
       }
     else
-      value
+      assertKnownKeys "${label}: overlay" [ "attrName" "build" "systems" ] value
       // {
         attrName = value.attrName or id;
         systems = value.systems or null;
-        callPackageArgs = normalizeArgs (value.callPackageArgs or { });
       };
 
   normalizePassthruTests =
-    id: value:
+    label: id: value:
     if value == null || value == false then
       null
     else if value == true then
@@ -86,7 +102,7 @@ let
         prefix = "rust-${id}";
       }
     else
-      value
+      assertKnownKeys "${label}: passthruTests" [ "prefix" ] value
       // {
         prefix = value.prefix or "rust-${id}";
       };
@@ -97,20 +113,20 @@ let
       metadataFile = dir + "/package.nix";
       imported = import metadataFile;
       raw = if builtins.isFunction imported then imported { inherit lib; } else imported;
+      label = "packages/${relativePath dir}/package.nix";
       id = raw.id or (throw "packages/${relativePath dir}/package.nix: missing required `id`");
     in
-    raw
+    assertKnownKeys label allowedMetadataKeys raw
     // {
       inherit id;
       path = raw.path or dir;
       metadataPath = metadataFile;
       relativePath = relativePath dir;
-      callPackageArgs = normalizeArgs (raw.callPackageArgs or { });
-      packageSet = normalizePackageSet id (raw.packageSet or null);
-      flake = normalizeFlake id (raw.flake or null);
-      overlay = normalizeOverlay id (raw.overlay or null);
+      packageSet = normalizePackageSet label id (raw.packageSet or null);
+      flake = normalizeFlake label id (raw.flake or null);
+      overlay = normalizeOverlay label id (raw.overlay or null);
       inRustWorkspace = raw.inRustWorkspace or false;
-      passthruTests = normalizePassthruTests id (raw.passthruTests or null);
+      passthruTests = normalizePassthruTests label id (raw.passthruTests or null);
     };
 
   entries = map importMetadata packageDirs;

--- a/packages/run/package.nix
+++ b/packages/run/package.nix
@@ -2,9 +2,4 @@
   id = "run";
   packageSet = true;
   flake = true;
-  callPackageArgs =
-    { ix, pkgs, ... }:
-    {
-      inherit ix pkgs;
-    };
 }


### PR DESCRIPTION
## Summary

- remove the per-package `callPackageArgs` adapter layer from the package registry
- pass shared package context through `lib.callPackageWith` for package-set and overlay builds
- move `ix` binary artifact selection and `llm-clippy` fork source selection into the owning derivations
- reject unknown package metadata keys, including nested exposure metadata, so stale adapter fields fail at eval time

## Validation

- `nix eval --json .#packages.aarch64-darwin --apply builtins.attrNames`
- `nix eval --json .#packages.aarch64-darwin.llm-clippy.meta.mainProgram`
- `nix eval --json .#packages.aarch64-darwin.ix.meta.mainProgram`
- `nix run .#lint`
- `nix flake check`

## Notes

This keeps the registry as the exposure manifest and leaves build arguments with each package `default.nix`. Net diff is 55 insertions and 120 deletions.