### PR TITLE
nix-web-monitor: trim dead state and add tree, errors, and timing UI

### DIFF
--- a/packages/nix-web-monitor/parser/src/lib.rs
+++ b/packages/nix-web-monitor/parser/src/lib.rs
@@ -22,9 +22,9 @@ const SNAPSHOT_LOG_LIMIT: usize = 500;
 /// hold every line the wrapped Nix process emitted in memory forever.
 const STATE_LOG_RETAIN: usize = 5_000;
 
-/// Same idea for `messages` and `errors`; these grow once per `msg` event,
+/// Same idea for `errors`; these grow once per error-level `msg` event,
 /// which is bounded but unfriendly for warning-heavy evals or long fetches.
-const STATE_MESSAGE_RETAIN: usize = 2_000;
+const STATE_ERROR_RETAIN: usize = 2_000;
 
 mod result_code {
     pub const FILE_LINKED: u64 = 100;
@@ -181,7 +181,6 @@ pub struct MonitorState {
     pub activities: BTreeMap<u64, ActivityNode>,
     pub builds: BTreeMap<String, BuildNode>,
     pub logs: Vec<LogEntry>,
-    pub messages: Vec<String>,
     pub errors: Vec<String>,
     pub progress: Option<ActivityProgress>,
     pub expected: BTreeMap<String, i64>,
@@ -200,7 +199,6 @@ impl MonitorState {
             activities: self.activities.values().cloned().collect(),
             builds: self.builds.values().cloned().collect(),
             logs: self.logs[log_tail_start..].to_vec(),
-            messages: self.messages.clone(),
             errors: self.errors.clone(),
             progress: self.progress,
             expected: self.expected.clone(),
@@ -282,7 +280,6 @@ impl MonitorState {
                 progress: None,
                 status: ActivityStatus::Running,
                 started_tick: now,
-                stopped_tick: None,
                 started_at_ms: now_ms,
                 stopped_at_ms: None,
                 build: build.clone(),
@@ -315,7 +312,6 @@ impl MonitorState {
         let now_ms = current_unix_ms();
         if let Some(activity) = self.activities.get_mut(&id) {
             activity.status = ActivityStatus::Stopped;
-            activity.stopped_tick = Some(next_tick(self.logs.len()));
             activity.stopped_at_ms = Some(now_ms);
             if let Some(build) = &activity.build
                 && let Some(build_node) = self.builds.get_mut(build)
@@ -356,7 +352,11 @@ impl MonitorState {
                 self.expected.insert(activity_type.name.clone(), *expected);
             }
             ActivityResult::FetchStatus { status } => {
-                self.messages.push(status.clone());
+                // Surface substituter fetch status in the log stream. It used
+                // to land in a `messages` bin the UI never rendered, so the
+                // operator never saw "downloading ..." progress.
+                let cleaned = strip_ansi(status);
+                self.push_log(Some(action.id), None, &cleaned);
             }
             ActivityResult::FileLinked { .. } | ActivityResult::Other { .. } => {}
         }
@@ -364,11 +364,9 @@ impl MonitorState {
 
     fn apply_message(&mut self, action: &MessageAction) {
         let cleaned = Self::cleaned_message(action);
-        self.messages.push(cleaned.clone());
-        truncate_head(&mut self.messages, STATE_MESSAGE_RETAIN);
         if action.level == Some(NIX_LEVEL_ERROR) {
             self.errors.push(cleaned.clone());
-            truncate_head(&mut self.errors, STATE_MESSAGE_RETAIN);
+            truncate_head(&mut self.errors, STATE_ERROR_RETAIN);
         }
         // Surface operator messages in the UI log panel too; otherwise an
         // eval failure shows up as an empty log with only an exit code.
@@ -453,7 +451,6 @@ pub struct MonitorSnapshot {
     pub activities: Vec<ActivityNode>,
     pub builds: Vec<BuildNode>,
     pub logs: Vec<LogEntry>,
-    pub messages: Vec<String>,
     pub errors: Vec<String>,
     pub progress: Option<ActivityProgress>,
     pub expected: BTreeMap<String, i64>,
@@ -473,7 +470,6 @@ pub struct ActivityNode {
     pub progress: Option<ActivityProgress>,
     pub status: ActivityStatus,
     pub started_tick: u64,
-    pub stopped_tick: Option<u64>,
     /// Unix epoch milliseconds when the activity started, stamped by the
     /// parser at apply time. Lets the UI render live durations without
     /// needing the original event timestamps from Nix.
@@ -1033,13 +1029,13 @@ mod tests {
     }
 
     #[test]
-    fn message_retention_caps_messages_array() {
+    fn error_retention_caps_errors_array() {
         let mut state = MonitorState::default();
-        for i in 0..(STATE_MESSAGE_RETAIN + 25) {
+        for i in 0..(STATE_ERROR_RETAIN + 25) {
             state.apply_line(&format!(
-                "@nix {{\"action\":\"msg\",\"level\":3,\"msg\":\"warn {i}\"}}"
+                "@nix {{\"action\":\"msg\",\"level\":0,\"msg\":\"boom {i}\"}}"
             ));
         }
-        assert_eq!(state.snapshot().messages.len(), STATE_MESSAGE_RETAIN);
+        assert_eq!(state.snapshot().errors.len(), STATE_ERROR_RETAIN);
     }
 }

--- a/packages/nix-web-monitor/server/site/src/App.svelte
+++ b/packages/nix-web-monitor/server/site/src/App.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, onMount } from 'svelte';
   import ActivityGraph from '$components/ActivityGraph.svelte';
   import BuildTable from '$components/BuildTable.svelte';
+  import ErrorPanel from '$components/ErrorPanel.svelte';
   import LogPanel from '$components/LogPanel.svelte';
   import SummaryBar from '$components/SummaryBar.svelte';
   import Splitter from '$lib/Splitter.svelte';
@@ -30,7 +31,21 @@
   /// build's activity. Clicking the same build again or hitting the clear
   /// chip in the log panel resets it.
   let selectedActivityId = $state<number | null>(null);
+  /// Log panel instance, used to drive its filter from the errors panel. Typed
+  /// to the imperative surface we call so the binding stays checked rather than
+  /// collapsing to `any`.
+  type LogPanelApi = { inspect: (text: string) => void };
+  let logPanel = $state<LogPanelApi | null>(null);
+  /// Number of errors the operator has dismissed; the panel reappears only when
+  /// a newer error pushes the count past this watermark.
+  let errorsDismissed = $state(0);
   let closeEvents: (() => void) | null = null;
+
+  const showErrors = $derived(snapshot.errors.length > errorsDismissed);
+
+  function dismissErrors(): void {
+    errorsDismissed = snapshot.errors.length;
+  }
 
   onMount(() => {
     closeEvents = openMonitorEvents(
@@ -129,11 +144,21 @@
   class:dragging-h={draggingAxis === 'horizontal'}
   class:dragging-v={draggingAxis === 'vertical'}
 >
-  <SummaryBar {snapshot} {status} />
+  <div class="topbar">
+    <SummaryBar {snapshot} {status} />
+    {#if showErrors}
+      <ErrorPanel
+        errors={snapshot.errors}
+        onclose={dismissErrors}
+        oninspect={(text: string) => logPanel?.inspect(text)}
+      />
+    {/if}
+  </div>
 
   <section class="workspace" style="--sidebar-width: {String(sidebarWidth)}px">
     <section class="main-pane">
       <LogPanel
+        bind:this={logPanel}
         logs={snapshot.logs}
         {selectedActivityId}
         onclearselection={() => (selectedActivityId = null)}

--- a/packages/nix-web-monitor/server/site/src/components/ActivityGraph.svelte
+++ b/packages/nix-web-monitor/server/site/src/components/ActivityGraph.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+  import { SvelteSet } from 'svelte/reactivity';
   import PanelHeader from '$lib/PanelHeader.svelte';
+  import ActivityTreeRow from '$components/ActivityTreeRow.svelte';
+  import { buildActivityTree } from '$lib/activity-tree';
+  import { useNow } from '$lib/now.svelte';
   import type { ActivityNode, BuildNode } from '$lib/types';
 
   type Props = {
@@ -9,92 +13,50 @@
 
   const { activities, builds }: Props = $props();
 
-  const MAX_DEPTH = 8;
+  const now = useNow();
+  const collapsed = new SvelteSet<number>();
 
-  const buildActivityIds = $derived(
-    new Set(builds.flatMap((build) => (build.activityId === null ? [] : [build.activityId])))
+  const tree = $derived(buildActivityTree(activities, builds));
+  const collapsible = $derived(
+    [...tree.childrenById.entries()].flatMap(([id, kids]) => (kids.length > 0 ? [id] : []))
   );
+  const allCollapsed = $derived(collapsible.length > 0 && collapsed.size >= collapsible.length);
 
-  const byId = $derived(new Map(activities.map((activity) => [activity.id, activity])));
-
-  const rows = $derived(
-    activities
-      .filter((activity) => visibleRow(activity, buildActivityIds))
-      .toSorted((left, right) => left.startedTick - right.startedTick)
-      .map((activity) => ({
-        activity,
-        depth: depthFor(activity, byId),
-        isBuild: buildActivityIds.has(activity.id),
-        kind: kindLabel(activity),
-        display: rowText(activity)
-      }))
-  );
-
-  const hiddenCount = $derived(activities.length - rows.length);
-
-  function visibleRow(activity: ActivityNode, buildIds: ReadonlySet<number>): boolean {
-    // Build activities are always interesting, even if Nix gives them empty
-    // text. Everything else needs phase or text to be worth a row.
-    if (buildIds.has(activity.id)) return true;
-    return activity.text.length > 0 || activity.phase !== null;
+  function toggle(id: number): void {
+    if (collapsed.has(id)) collapsed.delete(id);
+    else collapsed.add(id);
   }
 
-  function rowText(activity: ActivityNode): string {
-    if (activity.phase !== null) return activity.phase;
-    return activity.text;
-  }
-
-  /// Nix tags many real activities with type `unknown` (code 0). The text
-  /// usually leads with an action verb (\"evaluating\", \"copying\",
-  /// \"querying\", \"downloading\"). Synthesize the kind label from that
-  /// verb so the column actually classifies the row.
-  function kindLabel(activity: ActivityNode): string {
-    const declared = activity.activityType.name;
-    if (declared !== 'unknown') return declared;
-    const verb = /^([a-zA-Z]+)/.exec(activity.text)?.[1];
-    return verb === undefined ? 'note' : verb.toLowerCase();
-  }
-
-  function depthFor(activity: ActivityNode, lookup: ReadonlyMap<number, ActivityNode>): number {
-    let depth = 0;
-    let parent = activity.parent;
-    while (parent !== null && depth < MAX_DEPTH) {
-      const next = lookup.get(parent);
-      if (next === undefined) break;
-      depth += 1;
-      parent = next.parent;
-    }
-    return depth;
-  }
-
-  /// Keep both the head and tail of long strings visible. Most rows are file
-  /// paths and the tail (filename) is more identifying than the prefix.
-  function middleTruncate(text: string, max: number): string {
-    if (text.length <= max) return text;
-    const head = Math.ceil((max - 1) / 2);
-    const tail = Math.floor((max - 1) / 2);
-    return `${text.slice(0, head)}…${text.slice(text.length - tail)}`;
+  function toggleAll(): void {
+    if (allCollapsed) collapsed.clear();
+    else for (const id of collapsible) collapsed.add(id);
   }
 </script>
 
 <section class="panel graph-panel">
   <PanelHeader title="activities">
+    {#if collapsible.length > 0}
+      <button type="button" class="chip tree-toggle" onclick={toggleAll}>
+        {allCollapsed ? 'expand all' : 'collapse all'}
+      </button>
+    {/if}
     <span class="panel-meta">
-      {String(rows.length)} shown{#if hiddenCount > 0} &middot; {String(hiddenCount)} hidden{/if}
+      {String(tree.shown)} shown{#if tree.hidden > 0} &middot; {String(tree.hidden)} hidden{/if}
     </span>
   </PanelHeader>
   <div class="graph">
-    {#each rows as row (row.activity.id)}
-      <div
-        class="activity-row"
-        class:build={row.isBuild}
-        class:stopped={row.activity.status === 'stopped'}
-        style="--depth: {String(row.depth)}"
-        title={row.display}
-      >
-        <span class="activity-kind">{row.kind}</span>
-        <span class="activity-text">{middleTruncate(row.display, 80)}</span>
-      </div>
+    {#each tree.roots as rootId, index (rootId)}
+      <ActivityTreeRow
+        id={rootId}
+        rowMeta={tree.rowMeta}
+        childrenById={tree.childrenById}
+        {collapsed}
+        ontoggle={toggle}
+        now={now.value}
+        guideLines={[]}
+        isLast={index === tree.roots.length - 1}
+        isRoot={true}
+      />
     {:else}
       <div class="empty">waiting for events</div>
     {/each}

--- a/packages/nix-web-monitor/server/site/src/components/ActivityTreeRow.svelte
+++ b/packages/nix-web-monitor/server/site/src/components/ActivityTreeRow.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import type { SvelteSet } from 'svelte/reactivity';
+  import Self from '$components/ActivityTreeRow.svelte';
+  import { formatDuration, middleTruncate } from '$lib/format';
+  import type { ActivityRowMeta } from '$lib/activity-tree';
+
+  type Props = {
+    id: number;
+    rowMeta: ReadonlyMap<number, ActivityRowMeta>;
+    childrenById: ReadonlyMap<number, readonly number[]>;
+    collapsed: SvelteSet<number>;
+    ontoggle: (id: number) => void;
+    now: number;
+    /// Vertical-line flags for each ancestor column (true = ancestor has a
+    /// following sibling, so its column keeps a `│`). Empty for roots.
+    guideLines: boolean[];
+    /// Whether this node is the last among its siblings (picks `└` vs `├`).
+    isLast: boolean;
+    isRoot: boolean;
+  };
+
+  const { id, rowMeta, childrenById, collapsed, ontoggle, now, guideLines, isLast, isRoot }: Props =
+    $props();
+
+  const meta = $derived(rowMeta.get(id));
+  const children = $derived(childrenById.get(id) ?? []);
+  const isCollapsed = $derived(collapsed.has(id));
+  const childGuideLines = $derived(isRoot ? [] : [...guideLines, !isLast]);
+
+  function elapsed(row: ActivityRowMeta): number {
+    return Math.max(0, (row.stoppedAtMs ?? now) - row.startedAtMs);
+  }
+</script>
+
+{#if meta !== undefined}
+  <div class="activity-row" class:stopped={meta.state === 'stopped'}>
+    {#if !isRoot}
+      <span class="guides" aria-hidden="true"
+        >{#each guideLines as line, level (level)}<span class="guide">{line ? '│' : ' '}</span
+          >{/each}<span class="guide connector">{isLast ? '└' : '├'}</span></span
+      >
+    {/if}
+    <button
+      type="button"
+      class="twirl"
+      class:hidden={children.length === 0}
+      aria-label={isCollapsed ? 'expand' : 'collapse'}
+      aria-expanded={children.length === 0 ? undefined : !isCollapsed}
+      tabindex={children.length === 0 ? -1 : 0}
+      onclick={() => {
+        ontoggle(id);
+      }}
+    >
+      {children.length === 0 ? '' : isCollapsed ? '▸' : '▾'}
+    </button>
+    <span class="state" data-state={meta.state} title={meta.state}></span>
+    <span class="activity-kind">{meta.kind}</span>
+    {#if meta.derivation !== null}
+      <span class="drv activity-drv" title={meta.derivation.hash + meta.derivation.name}>
+        <span class="drv-hash">{meta.derivation.hash}</span><span class="drv-name"
+          >{meta.derivation.name}</span
+        >
+      </span>
+    {:else}
+      <span class="activity-text" title={meta.text}>{middleTruncate(meta.text, 80)}</span>
+    {/if}
+    {#if isCollapsed && children.length > 0}
+      <span class="subtree-count">+{String(children.length)}</span>
+    {/if}
+    <span class="activity-dur">{formatDuration(elapsed(meta))}</span>
+  </div>
+
+  {#if !isCollapsed}
+    {#each children as childId, index (childId)}
+      <Self
+        id={childId}
+        {rowMeta}
+        {childrenById}
+        {collapsed}
+        {ontoggle}
+        {now}
+        guideLines={childGuideLines}
+        isLast={index === children.length - 1}
+        isRoot={false}
+      />
+    {/each}
+  {/if}
+{/if}

--- a/packages/nix-web-monitor/server/site/src/components/ErrorPanel.svelte
+++ b/packages/nix-web-monitor/server/site/src/components/ErrorPanel.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  /// Surfaces the actual error text Nix emitted. The summary bar only shows a
+  /// count; without this panel the operator has to hunt the red lines out of
+  /// the log stream. Clicking an error focuses the log view on it.
+
+  type Props = {
+    errors: string[];
+    onclose: () => void;
+    oninspect: (text: string) => void;
+  };
+
+  const { errors, onclose, oninspect }: Props = $props();
+
+  /// Cap the rendered rows: an error-heavy eval can produce thousands, and the
+  /// newest are the ones the operator acts on.
+  const MAX_ROWS = 50;
+
+  const recent = $derived.by(() => {
+    const start = Math.max(0, errors.length - MAX_ROWS);
+    return errors
+      .slice(start)
+      .map((text, offset) => ({ key: start + offset, text }))
+      .toReversed();
+  });
+  const overflow = $derived(errors.length - recent.length);
+
+  function firstLine(text: string): string {
+    const newline = text.indexOf('\n');
+    return (newline === -1 ? text : text.slice(0, newline)).trim();
+  }
+</script>
+
+<section class="error-panel" role="alert" aria-label="errors">
+  <div class="error-head">
+    <span class="error-title">
+      {String(errors.length)} error{errors.length === 1 ? '' : 's'}
+    </span>
+    {#if overflow > 0}
+      <span class="error-overflow">showing last {String(recent.length)}</span>
+    {/if}
+    <button type="button" class="chip error-dismiss" onclick={onclose}>dismiss &times;</button>
+  </div>
+  <ul class="error-list">
+    {#each recent as item (item.key)}
+      <li>
+        <button
+          type="button"
+          class="error-item"
+          title="show in logs"
+          onclick={() => {
+            oninspect(firstLine(item.text));
+          }}
+        >
+          {item.text}
+        </button>
+      </li>
+    {/each}
+  </ul>
+</section>

--- a/packages/nix-web-monitor/server/site/src/components/LogPanel.svelte
+++ b/packages/nix-web-monitor/server/site/src/components/LogPanel.svelte
@@ -2,7 +2,7 @@
   import { tick } from 'svelte';
   import { SvelteSet } from 'svelte/reactivity';
   import PanelHeader from '$lib/PanelHeader.svelte';
-  import type { LogEntry } from '$lib/types';
+  import { LOG_LEVEL_FILTERS, type LogEntry, type LogLevelFilter } from '$lib/types';
 
   type Props = {
     logs: LogEntry[];
@@ -14,11 +14,18 @@
 
   const { logs, selectedActivityId, onclearselection }: Props = $props();
 
-  const LEVEL_FILTERS = ['all', 'error', 'warn', 'info'] as const;
-  type LevelFilter = (typeof LEVEL_FILTERS)[number];
-  let levelFilter = $state<LevelFilter>('all');
+  let level = $state<LogLevelFilter>('all');
   let search = $state('');
   let stream = $state<HTMLDivElement | null>(null);
+  let searchInput = $state<HTMLInputElement | null>(null);
+
+  /// Imperative entry point for the errors panel: pin the log view to a single
+  /// error line. Exposed through `bind:this` so the panel can drive the filter
+  /// without the shell having to own log-view state.
+  export function inspect(text: string): void {
+    level = 'error';
+    search = text;
+  }
   /// When true, append-on-update keeps the view glued to the bottom. The
   /// scroll handler flips this off the moment the user scrolls up, and back
   /// on if they scroll back to the end.
@@ -27,7 +34,7 @@
   /// single-line truncation.
   const expanded = new SvelteSet<number>();
 
-  const filtered = $derived(filterLogs(logs, levelFilter, search, selectedActivityId));
+  const filtered = $derived(filterLogs(logs, level, search, selectedActivityId));
   const visible = $derived(filtered.slice(-RECENT_LOG_LIMIT));
   const hiddenCount = $derived(logs.length - visible.length);
 
@@ -42,24 +49,24 @@
 
   function filterLogs(
     items: LogEntry[],
-    level: LevelFilter,
+    filter: LogLevelFilter,
     query: string,
     activityId: number | null
   ): LogEntry[] {
     const lower = query.trim().toLowerCase();
     return items.filter((entry) => {
       if (activityId !== null && entry.activityId !== activityId) return false;
-      if (!matchesLevel(entry.level, level)) return false;
+      if (!matchesLevel(entry.level, filter)) return false;
       if (lower.length === 0) return true;
       return entry.text.toLowerCase().includes(lower);
     });
   }
 
-  function matchesLevel(level: number | null, filter: LevelFilter): boolean {
+  function matchesLevel(entryLevel: number | null, filter: LogLevelFilter): boolean {
     if (filter === 'all') return true;
-    if (filter === 'error') return level === 0;
-    if (filter === 'warn') return level === 0 || level === 1;
-    return level === null || level <= 3;
+    if (filter === 'error') return entryLevel === 0;
+    if (filter === 'warn') return entryLevel === 0 || entryLevel === 1;
+    return entryLevel === null || entryLevel <= 3;
   }
 
   function lineClass(level: number | null): string {
@@ -96,18 +103,51 @@
     follow = true;
     if (stream !== null) stream.scrollTop = stream.scrollHeight;
   }
+
+  /// Power-user shortcuts: `/` focuses the filter, `Esc` peels back the current
+  /// filter then the build selection, `g`/`G` jumps to the live tail. Typing in
+  /// a field is left alone except for `Esc`, which still clears the filter.
+  function onWindowKeydown(event: KeyboardEvent): void {
+    const target = event.target;
+    const typing =
+      target instanceof HTMLElement &&
+      (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
+
+    if (event.key === '/' && !typing) {
+      event.preventDefault();
+      searchInput?.focus();
+      searchInput?.select();
+      return;
+    }
+    if (event.key === 'Escape') {
+      if (search.length > 0) {
+        search = '';
+      } else if (selectedActivityId !== null) {
+        onclearselection();
+      } else if (target === searchInput) {
+        searchInput?.blur();
+      }
+      return;
+    }
+    if ((event.key === 'g' || event.key === 'G') && !typing) {
+      event.preventDefault();
+      jumpToEnd();
+    }
+  }
 </script>
+
+<svelte:window onkeydown={onWindowKeydown} />
 
 <section class="panel logs-panel">
   <PanelHeader title="logs">
     <div class="log-controls">
       <div class="filter-chips" role="tablist" aria-label="log level filter">
-        {#each LEVEL_FILTERS as choice (choice)}
+        {#each LOG_LEVEL_FILTERS as choice (choice)}
           <button
             type="button"
             class="chip"
-            class:active={levelFilter === choice}
-            onclick={() => (levelFilter = choice)}
+            class:active={level === choice}
+            onclick={() => (level = choice)}
           >
             {choice}
           </button>
@@ -116,7 +156,8 @@
       <input
         class="search"
         type="search"
-        placeholder="filter"
+        placeholder="filter  (/)"
+        bind:this={searchInput}
         bind:value={search}
       />
       {#if selectedActivityId !== null}

--- a/packages/nix-web-monitor/server/site/src/components/SummaryBar.svelte
+++ b/packages/nix-web-monitor/server/site/src/components/SummaryBar.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { formatDuration } from '$lib/format';
+  import { useNow } from '$lib/now.svelte';
   import {
     ACTIVITY_NAME_BUILD,
     type BuildStatus,
@@ -12,6 +14,8 @@
   };
 
   const { snapshot, status }: Props = $props();
+
+  const now = useNow();
 
   type StatusCounts = Readonly<Record<BuildStatus, number>>;
 
@@ -35,6 +39,33 @@
   );
 
   const exit = $derived(snapshot.exitCode);
+
+  /// Overall run wall-clock: earliest activity start to last activity stop
+  /// while running, frozen at the final span once the run finishes. The
+  /// snapshot carries no finish timestamp, so the last observed stop is the
+  /// best end marker; it falls back to the live clock only if nothing stopped.
+  const startedAtMs = $derived(
+    snapshot.activities.reduce<number | null>(
+      (min, activity) => (min === null ? activity.startedAtMs : Math.min(min, activity.startedAtMs)),
+      null
+    )
+  );
+  const lastStopMs = $derived(
+    snapshot.activities.reduce<number | null>(
+      (max, activity) =>
+        activity.stoppedAtMs === null
+          ? max
+          : max === null
+            ? activity.stoppedAtMs
+            : Math.max(max, activity.stoppedAtMs),
+      null
+    )
+  );
+  const elapsedMs = $derived.by(() => {
+    if (startedAtMs === null) return null;
+    const end = snapshot.finished ? (lastStopMs ?? now.value) : now.value;
+    return Math.max(0, end - startedAtMs);
+  });
 </script>
 
 <header class="summary">
@@ -52,6 +83,13 @@
       <span class="kpi-num kpi-faint">{expectedBuilds}</span>
       <span class="kpi-label">builds</span>
     </div>
+
+    {#if elapsedMs !== null}
+      <div class="kpi" class:kpi-good={snapshot.finished && exit === 0}>
+        <span class="kpi-num">{formatDuration(elapsedMs)}</span>
+        <span class="kpi-label">{snapshot.finished ? 'total' : 'elapsed'}</span>
+      </div>
+    {/if}
 
     {#if counts.running > 0}
       <div class="kpi kpi-warn">

--- a/packages/nix-web-monitor/server/site/src/lib/activity-tree.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/activity-tree.ts
@@ -1,0 +1,116 @@
+/// Builds a renderable hierarchy from the flat activity list.
+///
+/// Nix's internal-json stream gives each activity a `parent` pointer, which
+/// forms the *activity* tree (a `builds` coordinator parents the individual
+/// `build` activities it spawns, a `realise` parents its substitutions, and so
+/// on). That tree is the only dependency structure the protocol exposes: there
+/// is no edge that says "derivation A needs derivation B", so this is a faithful
+/// view of what Nix reports, not a reconstructed derivation DAG.
+///
+/// Uninteresting intermediate activities (no text, no phase, not a build) are
+/// dropped, and their visible descendants are re-parented onto the nearest
+/// interesting ancestor. That keeps the rendered tree connected without empty
+/// filler rows.
+
+import { activityKind, splitDerivation, type DerivationParts } from '$lib/format';
+import type { ActivityNode, ActivityStatus, BuildNode, BuildStatus } from '$lib/types';
+
+export type ActivityRowMeta = Readonly<{
+  id: number;
+  kind: string;
+  /// Build status when this activity is a derivation build, otherwise the
+  /// raw activity status. Drives the status dot colour.
+  state: BuildStatus | ActivityStatus;
+  /// Present only for build activities; lets the row dim the store-path hash.
+  derivation: DerivationParts | null;
+  /// Display text for non-build rows (phase preferred over raw text).
+  text: string;
+  startedAtMs: number;
+  stoppedAtMs: number | null;
+}>;
+
+export type ActivityTree = Readonly<{
+  rowMeta: ReadonlyMap<number, ActivityRowMeta>;
+  childrenById: ReadonlyMap<number, readonly number[]>;
+  roots: readonly number[];
+  shown: number;
+  hidden: number;
+}>;
+
+function isInteresting(activity: ActivityNode, buildIds: ReadonlySet<number>): boolean {
+  // Build activities are always worth a row, even when Nix gives them empty
+  // text. Everything else needs a phase or text to earn one.
+  return buildIds.has(activity.id) || activity.text.length > 0 || activity.phase !== null;
+}
+
+export function buildActivityTree(activities: ActivityNode[], builds: BuildNode[]): ActivityTree {
+  const byId = new Map(activities.map((activity) => [activity.id, activity]));
+  const buildIds = new Set(
+    builds.flatMap((build) => (build.activityId === null ? [] : [build.activityId]))
+  );
+  const buildStatusByActivity = new Map(
+    builds.flatMap((build) => (build.activityId === null ? [] : [[build.activityId, build.status]]))
+  );
+
+  const visible = activities.filter((activity) => isInteresting(activity, buildIds));
+  const visibleIds = new Set(visible.map((activity) => activity.id));
+
+  /// Nearest ancestor that is itself visible, or null when this row is a root.
+  function displayParent(activity: ActivityNode): number | null {
+    let parent = activity.parent;
+    while (parent !== null) {
+      if (visibleIds.has(parent)) return parent;
+      const next = byId.get(parent);
+      if (next === undefined) break;
+      parent = next.parent;
+    }
+    return null;
+  }
+
+  const childrenById = new Map<number, number[]>();
+  const roots: number[] = [];
+  for (const activity of visible) {
+    const parent = displayParent(activity);
+    if (parent === null) {
+      roots.push(activity.id);
+    } else {
+      const siblings = childrenById.get(parent) ?? [];
+      siblings.push(activity.id);
+      childrenById.set(parent, siblings);
+    }
+  }
+
+  const byStartTick = (left: number, right: number): number => {
+    const a = byId.get(left);
+    const b = byId.get(right);
+    return (a?.startedTick ?? 0) - (b?.startedTick ?? 0);
+  };
+  roots.sort(byStartTick);
+  for (const siblings of childrenById.values()) siblings.sort(byStartTick);
+
+  const rowMeta = new Map<number, ActivityRowMeta>(
+    visible.map((activity) => {
+      const isBuild = buildIds.has(activity.id);
+      return [
+        activity.id,
+        {
+          id: activity.id,
+          kind: activityKind(activity.activityType.name, activity.text),
+          state: buildStatusByActivity.get(activity.id) ?? activity.status,
+          derivation: isBuild && activity.build !== null ? splitDerivation(activity.build) : null,
+          text: activity.phase ?? activity.text,
+          startedAtMs: activity.startedAtMs,
+          stoppedAtMs: activity.stoppedAtMs
+        }
+      ];
+    })
+  );
+
+  return {
+    rowMeta,
+    childrenById,
+    roots,
+    shown: visible.length,
+    hidden: activities.length - visible.length
+  };
+}

--- a/packages/nix-web-monitor/server/site/src/lib/format.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/format.ts
@@ -21,6 +21,25 @@ export function splitDerivation(path: string): DerivationParts {
   };
 }
 
+/// Keep both the head and tail of long strings visible. Most activity rows are
+/// file paths and the tail (filename) is more identifying than the prefix.
+export function middleTruncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  const head = Math.ceil((max - 1) / 2);
+  const tail = Math.floor((max - 1) / 2);
+  return `${text.slice(0, head)}…${text.slice(text.length - tail)}`;
+}
+
+/// Nix tags many real activities with type `unknown` (code 0). The text usually
+/// leads with an action verb ("evaluating", "copying", "querying",
+/// "downloading"). Synthesize the kind label from that verb so the column
+/// actually classifies the row instead of repeating "unknown".
+export function activityKind(typeName: string, text: string): string {
+  if (typeName !== 'unknown') return typeName;
+  const verb = /^([a-zA-Z]+)/.exec(text)?.[1];
+  return verb === undefined ? 'note' : verb.toLowerCase();
+}
+
 /// Compact duration formatter: `42s`, `3m04s`, `2h11m`, `1d04h`. Sub-second
 /// resolution would just flicker; the UI ticks once per second anyway.
 export function formatDuration(ms: number): string {

--- a/packages/nix-web-monitor/server/site/src/lib/types.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/types.ts
@@ -29,7 +29,6 @@ export const activityNodeSchema = v.object({
   progress: v.nullable(activityProgressSchema),
   status: activityStatusSchema,
   startedTick: v.number(),
-  stoppedTick: v.nullable(v.number()),
   startedAtMs: v.number(),
   stoppedAtMs: v.nullable(v.number()),
   build: v.nullable(v.string())
@@ -58,7 +57,6 @@ export const snapshotSchema = v.object({
   activities: v.array(activityNodeSchema),
   builds: v.array(buildNodeSchema),
   logs: v.array(logEntrySchema),
-  messages: v.array(v.string()),
   errors: v.array(v.string()),
   progress: v.nullable(activityProgressSchema),
   expected: v.record(v.string(), v.number()),
@@ -78,6 +76,11 @@ export type MonitorSnapshot = v.InferOutput<typeof snapshotSchema>;
 /// Purely client-side, never received over the wire.
 export type ConnectionStatus = 'connecting' | 'live' | 'closed' | 'error';
 
+/// Log-level filter choices for the log panel. Shared with the app shell so
+/// the errors panel and keyboard shortcuts can drive the same filter state.
+export const LOG_LEVEL_FILTERS = ['all', 'error', 'warn', 'info'] as const;
+export type LogLevelFilter = (typeof LOG_LEVEL_FILTERS)[number];
+
 /// Mirrors `activity_code::BUILD` in the parser; the protocol's name for an
 /// individual derivation build activity.
 export const ACTIVITY_NAME_BUILD = 'build';
@@ -86,7 +89,6 @@ export const EMPTY_SNAPSHOT: MonitorSnapshot = Object.freeze({
   activities: [],
   builds: [],
   logs: [],
-  messages: [],
   errors: [],
   progress: null,
   expected: {},

--- a/packages/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix-web-monitor/server/site/src/style.css
@@ -239,6 +239,80 @@ main {
   font-size: inherit !important;
 }
 
+/* ---------- error panel ---------- */
+
+.topbar {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.error-panel {
+  display: flex;
+  flex-direction: column;
+  max-height: 11rem;
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--red) 9%, var(--panel));
+}
+
+.error-head {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.75rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--red) 25%, var(--line));
+}
+
+.error-title {
+  color: var(--red);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.error-overflow {
+  color: var(--muted);
+}
+
+.error-dismiss {
+  margin-left: auto;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+
+.error-list {
+  margin: 0;
+  padding: 0.25rem 0;
+  list-style: none;
+  min-height: 0;
+  overflow: auto;
+}
+
+.error-item {
+  display: block;
+  width: 100%;
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--red);
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  padding: 0.1rem 0.75rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.error-item:hover {
+  background: color-mix(in srgb, var(--red) 14%, transparent);
+}
+
+.tree-toggle {
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+
 /* ---------- workspace layout ---------- */
 
 .workspace {
@@ -400,29 +474,70 @@ main.dragging-v .splitter-v::after {
 }
 
 .activity-row {
-  display: grid;
-  grid-template-columns: max-content minmax(0, 1fr);
+  display: flex;
   align-items: center;
-  column-gap: 0.5rem;
-  padding: 0.15rem 0.5rem 0.15rem calc(var(--depth) * 0.75rem + 0.5rem);
+  gap: 0.4rem;
+  padding: 0.12rem 0.5rem;
   color: var(--muted);
   border-bottom: 1px solid var(--line-soft);
   line-height: 1.3;
-}
-
-.activity-row.build {
-  color: var(--ink);
+  white-space: nowrap;
 }
 
 .activity-row.stopped {
-  opacity: 0.55;
+  opacity: 0.6;
 }
 
 .activity-row:hover {
   background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
+/* Box-drawing guides. Fixed-width cells keep the vertical stems aligned
+ * column-to-column so a child's connector meets its ancestor's line. */
+.guides {
+  flex: 0 0 auto;
+  color: var(--faint);
+  white-space: pre;
+  user-select: none;
+}
+
+.guide {
+  display: inline-block;
+  width: 1.1ch;
+}
+
+.guide.connector {
+  color: var(--line);
+}
+
+.twirl {
+  flex: 0 0 auto;
+  width: 1.1rem;
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--faint);
+  cursor: pointer;
+  padding: 0;
+  font-family: inherit;
+  line-height: 1;
+}
+
+.twirl:hover {
+  color: var(--ink);
+}
+
+.twirl.hidden {
+  visibility: hidden;
+  cursor: default;
+}
+
+.state {
+  flex: 0 0 auto;
+}
+
 .activity-kind {
+  flex: 0 0 auto;
   color: var(--accent);
   font-variant-numeric: tabular-nums;
   text-transform: lowercase;
@@ -430,10 +545,28 @@ main.dragging-v .splitter-v::after {
   min-width: 4.5rem;
 }
 
-.activity-text {
+.activity-text,
+.activity-drv {
+  flex: 1 1 auto;
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.subtree-count {
+  flex: 0 0 auto;
+  color: var(--faint);
+  font-variant-numeric: tabular-nums;
+}
+
+.activity-dur {
+  flex: 0 0 auto;
+  margin-left: auto;
+  padding-left: 0.5rem;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
 }
 
 /* ---------- builds ---------- */
@@ -504,8 +637,19 @@ main.dragging-v .splitter-v::after {
   white-space: nowrap;
 }
 
+/* The store-path hash is opaque noise; keep it collapsed so the package name
+ * leads, and reveal it only when the operator hovers, focuses, or selects the
+ * row (the full path is always in the row's title for copy/inspect). */
 .drv-hash {
+  display: none;
   color: var(--faint);
+}
+
+.build-row:hover .drv-hash,
+.build-row:focus-visible .drv-hash,
+.build-row.selected .drv-hash,
+.activity-row:hover .drv-hash {
+  display: inline;
 }
 
 .drv-name {


### PR DESCRIPTION
Makes `nix-web-monitor` more idiomatic and adds the UI affordances an operator actually wants while watching a build.

## Parser / wire trim

- Drop `stopped_tick` from `ActivityNode`: nothing read it, and it was computed inconsistently (`next_tick(self.logs.len())` while `started_tick` used `activities.len()`) — dead data plus a latent bug.
- Drop the `messages` buffer: it was cloned, serialized, and broadcast on every stderr line but the UI never rendered it. Removing it shrinks the per-line snapshot payload on a hot path.
- Fetch-status results now flow into the log stream instead of that dead buffer, so substituter "downloading…" progress is finally visible.
- Retention test rewritten to assert the surviving `errors` cap.

## UI

- **Dependency tree.** The activities panel is now a real hierarchy (`activity-tree.ts` builder plus a recursive `ActivityTreeRow`) with box-drawing guides, collapsible subtrees, status dots, and per-row durations. Uninteresting intermediate activities are dropped and their children re-parented onto the nearest visible ancestor so the tree stays connected. Nix's internal-json only exposes the activity parent tree, not a derivation dependency DAG, so this renders the structure the protocol actually reports.
- **Errors panel.** Surfaces the actual error text (newest first, capped at 50) with click-to-filter into the logs; dismissible, and reappears when a newer error arrives.
- **Run timer.** Live `elapsed` in the summary bar, frozen to `total` once the run finishes.
- **Hash on hover.** Store-path hashes collapse so the package name leads, in both the builds table and the tree; the full path stays in the row title.
- **Log shortcuts.** `/` focuses search, `Esc` peels back the filter then the build selection, `g`/`G` jumps to the live tail.

## Verification

`cargo test` + `cargo clippy` (parser and server), `svelte-check` (0 errors), `eslint`, `vite build`, and a full `nix build .#nix-web-monitor` all pass. The built artifact's CSS contains the new classes.
