### PR TITLE
nix-web-monitor: nest builds by dependency in a tree view

### DIFF
--- a/packages/nix-web-monitor/parser/src/lib.rs
+++ b/packages/nix-web-monitor/parser/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::module_name_repetitions)]
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -186,6 +186,11 @@ pub struct MonitorState {
     pub expected: BTreeMap<String, i64>,
     pub exit_code: Option<i32>,
     pub finished: bool,
+    /// Direct input `.drv` paths per derivation, learned out-of-band from
+    /// `nix-store --query --references` (the internal-json stream carries no
+    /// dependency edges). The snapshot turns this into the rendered DAG; the
+    /// raw adjacency stays server-side and never rides the wire.
+    direct_deps: BTreeMap<String, Vec<String>>,
     /// Monotonic counter for `LogEntry.index`. Kept independent of
     /// `logs.len()` so retention pruning never reuses an index.
     log_counter: u64,
@@ -195,6 +200,7 @@ impl MonitorState {
     #[must_use]
     pub fn snapshot(&self) -> MonitorSnapshot {
         let log_tail_start = self.logs.len().saturating_sub(SNAPSHOT_LOG_LIMIT);
+        let observed: BTreeSet<&str> = self.builds.keys().map(String::as_str).collect();
         MonitorSnapshot {
             activities: self.activities.values().cloned().collect(),
             builds: self.builds.values().cloned().collect(),
@@ -202,9 +208,19 @@ impl MonitorState {
             errors: self.errors.clone(),
             progress: self.progress,
             expected: self.expected.clone(),
+            dependencies: dependency_edges(&self.direct_deps, &observed),
             exit_code: self.exit_code,
             finished: self.finished,
         }
+    }
+
+    /// Record the direct input derivations of one built derivation, learned
+    /// from `nix-store --query --references`. Only the `.drv` inputs matter for
+    /// the dependency DAG; the caller filters source paths out before calling.
+    /// Stored unfiltered by observation status so a dependency that starts
+    /// building later still produces its edge on the next snapshot.
+    pub fn record_direct_dependencies(&mut self, derivation: String, input_drvs: Vec<String>) {
+        self.direct_deps.insert(derivation, input_drvs);
     }
 
     pub fn apply_line(&mut self, line: &str) -> ParsedLine {
@@ -445,6 +461,76 @@ fn truncate_head<T>(items: &mut Vec<T>, max: usize) {
     }
 }
 
+/// Build the minimal dependency DAG over the derivations Nix actually built.
+///
+/// `direct_deps` maps a derivation to the input `.drv` paths it directly
+/// requires. An edge survives only when both endpoints are `observed` (a real
+/// build, so it has a row to attach to); a link bridged entirely through a
+/// cached, never-built derivation is intentionally absent. The result is
+/// transitively reduced, so a chain `a -> b -> c` never also keeps the
+/// redundant `a -> c`, and sorted for a stable wire order.
+fn dependency_edges(
+    direct_deps: &BTreeMap<String, Vec<String>>,
+    observed: &BTreeSet<&str>,
+) -> Vec<DerivationEdge> {
+    let mut adjacency: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    for (from, inputs) in direct_deps {
+        if !observed.contains(from.as_str()) {
+            continue;
+        }
+        for to in inputs {
+            if from != to && observed.contains(to.as_str()) {
+                adjacency.entry(from).or_default().insert(to);
+            }
+        }
+    }
+
+    let mut edges = Vec::new();
+    for (&from, targets) in &adjacency {
+        for &to in targets {
+            if !reachable_via_detour(&adjacency, from, to) {
+                edges.push(DerivationEdge {
+                    from: from.to_owned(),
+                    to: to.to_owned(),
+                });
+            }
+        }
+    }
+    edges.sort();
+    edges
+}
+
+/// Whether `to` is reachable from `from` through a path of length two or more,
+/// i.e. via some neighbour other than `to` itself. Such a `from -> to` edge is
+/// implied by the longer path and is dropped in transitive reduction.
+fn reachable_via_detour(adjacency: &BTreeMap<&str, BTreeSet<&str>>, from: &str, to: &str) -> bool {
+    let Some(neighbours) = adjacency.get(from) else {
+        return false;
+    };
+    neighbours
+        .iter()
+        .any(|&next| next != to && reaches(adjacency, next, to))
+}
+
+/// Depth-first reachability from `start` to `target`. The `visited` guard keeps
+/// the walk finite even though derivation graphs are acyclic by construction.
+fn reaches(adjacency: &BTreeMap<&str, BTreeSet<&str>>, start: &str, target: &str) -> bool {
+    let mut stack = vec![start];
+    let mut visited: BTreeSet<&str> = BTreeSet::new();
+    while let Some(node) = stack.pop() {
+        if node == target {
+            return true;
+        }
+        if !visited.insert(node) {
+            continue;
+        }
+        if let Some(neighbours) = adjacency.get(node) {
+            stack.extend(neighbours.iter().copied());
+        }
+    }
+    false
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MonitorSnapshot {
@@ -454,8 +540,22 @@ pub struct MonitorSnapshot {
     pub errors: Vec<String>,
     pub progress: Option<ActivityProgress>,
     pub expected: BTreeMap<String, i64>,
+    /// Minimal dependency DAG over derivations Nix actually built: each edge's
+    /// `from` directly requires `to`. Derived from `direct_deps` at snapshot
+    /// time, restricted to built derivations and transitively reduced.
+    pub dependencies: Vec<DerivationEdge>,
     pub exit_code: Option<i32>,
     pub finished: bool,
+}
+
+/// One directed dependency edge: `from` directly requires `to`. Both endpoints
+/// are `derivation` paths matching a [`BuildNode`], so the UI can join edges to
+/// build rows by string identity.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DerivationEdge {
+    pub from: String,
+    pub to: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -608,8 +708,8 @@ fn parse_result(raw: &Value) -> Result<ResultAction, ParseError> {
         },
         result_code::SET_EXPECTED => {
             let (activity_type_code, expected) = two_numbers(&fields)?;
-            let activity_type_code = u64::try_from(activity_type_code)
-                .map_err(|_| ParseError::NegativeActivityType)?;
+            let activity_type_code =
+                u64::try_from(activity_type_code).map_err(|_| ParseError::NegativeActivityType)?;
             ActivityResult::SetExpected {
                 activity_type: activity_type_for(activity_type_code),
                 expected,
@@ -926,9 +1026,7 @@ mod tests {
     #[test]
     fn error_level_message_is_recorded_as_error() {
         let mut state = MonitorState::default();
-        state.apply_line(
-            r#"@nix {"action":"msg","level":0,"msg":"something went wrong"}"#,
-        );
+        state.apply_line(r#"@nix {"action":"msg","level":0,"msg":"something went wrong"}"#);
         assert_eq!(state.snapshot().errors, vec!["something went wrong"]);
     }
 
@@ -1037,5 +1135,84 @@ mod tests {
             ));
         }
         assert_eq!(state.snapshot().errors.len(), STATE_ERROR_RETAIN);
+    }
+
+    fn edge(from: &str, to: &str) -> DerivationEdge {
+        DerivationEdge {
+            from: from.to_owned(),
+            to: to.to_owned(),
+        }
+    }
+
+    fn deps(pairs: &[(&str, &[&str])]) -> BTreeMap<String, Vec<String>> {
+        pairs
+            .iter()
+            .map(|(drv, inputs)| {
+                (
+                    (*drv).to_owned(),
+                    inputs.iter().map(|s| (*s).to_owned()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn dependency_edges_drop_redundant_transitive_links() {
+        // a -> b -> c with a direct a -> c shortcut. Reduction keeps the chain
+        // and drops the shortcut.
+        let direct = deps(&[("a", &["b", "c"]), ("b", &["c"])]);
+        let observed = BTreeSet::from(["a", "b", "c"]);
+        assert_eq!(
+            dependency_edges(&direct, &observed),
+            vec![edge("a", "b"), edge("b", "c")]
+        );
+    }
+
+    #[test]
+    fn dependency_edges_keep_both_arms_of_a_diamond() {
+        // a depends on b and c, both of which depend on d. Neither arm is
+        // implied by the other, so all four edges survive.
+        let direct = deps(&[("a", &["b", "c"]), ("b", &["d"]), ("c", &["d"])]);
+        let observed = BTreeSet::from(["a", "b", "c", "d"]);
+        assert_eq!(
+            dependency_edges(&direct, &observed),
+            vec![
+                edge("a", "b"),
+                edge("a", "c"),
+                edge("b", "d"),
+                edge("c", "d")
+            ]
+        );
+    }
+
+    #[test]
+    fn dependency_edges_ignore_unbuilt_endpoints() {
+        // `x` was never built (not observed), so the a -> x edge vanishes and a
+        // is left depending only on the observed b.
+        let direct = deps(&[("a", &["b", "x"])]);
+        let observed = BTreeSet::from(["a", "b"]);
+        assert_eq!(dependency_edges(&direct, &observed), vec![edge("a", "b")]);
+    }
+
+    #[test]
+    fn snapshot_exposes_recorded_dependency_dag() {
+        let mut state = MonitorState::default();
+        for (id, drv) in [
+            (1u64, "/nix/store/aaa-app.drv"),
+            (2, "/nix/store/bbb-lib.drv"),
+        ] {
+            state.apply_line(&format!(
+                r#"@nix {{"action":"start","fields":["{drv}","local",1,1],"id":{id},"level":3,"text":"building","type":105}}"#
+            ));
+        }
+        state.record_direct_dependencies(
+            "/nix/store/aaa-app.drv".to_owned(),
+            vec!["/nix/store/bbb-lib.drv".to_owned()],
+        );
+
+        assert_eq!(
+            state.snapshot().dependencies,
+            vec![edge("/nix/store/aaa-app.drv", "/nix/store/bbb-lib.drv")]
+        );
     }
 }

--- a/packages/nix-web-monitor/server/site/src/App.svelte
+++ b/packages/nix-web-monitor/server/site/src/App.svelte
@@ -178,6 +178,7 @@
     >
       <BuildTable
         builds={snapshot.builds}
+        dependencies={snapshot.dependencies}
         expected={snapshot.expected}
         {selectedActivityId}
         onselect={(id: number | null) => {

--- a/packages/nix-web-monitor/server/site/src/components/BuildTable.svelte
+++ b/packages/nix-web-monitor/server/site/src/components/BuildTable.svelte
@@ -1,20 +1,32 @@
 <script lang="ts">
+  import { SvelteSet } from 'svelte/reactivity';
   import PanelHeader from '$lib/PanelHeader.svelte';
+  import BuildTree from '$components/BuildTree.svelte';
   import { splitDerivation, formatDuration } from '$lib/format';
+  import { buildDependencyTree } from '$lib/build-tree';
   import { useNow } from '$lib/now.svelte';
-  import { ACTIVITY_NAME_BUILD, type BuildNode, type BuildStatus } from '$lib/types';
+  import {
+    ACTIVITY_NAME_BUILD,
+    type BuildNode,
+    type BuildStatus,
+    type DerivationEdge
+  } from '$lib/types';
 
   type Props = {
     builds: BuildNode[];
+    dependencies: DerivationEdge[];
     expected: Record<string, number>;
     selectedActivityId: number | null;
     onselect: (activityId: number | null) => void;
   };
 
-  const { builds, expected, selectedActivityId, onselect }: Props = $props();
+  const { builds, dependencies, expected, selectedActivityId, onselect }: Props = $props();
 
   const now = useNow();
 
+  /// Running first, then failed, stopped, and finally succeeded; ties broken by
+  /// derivation path. Shared by the flat list and the dependency tree so both
+  /// views rank builds the same way.
   const STATUS_ORDER: Record<BuildStatus, number> = {
     running: 0,
     failed: 1,
@@ -22,12 +34,17 @@
     succeeded: 3
   };
 
-  const ordered = $derived(
-    builds.toSorted((left, right) => {
-      const byStatus = STATUS_ORDER[left.status] - STATUS_ORDER[right.status];
-      return byStatus !== 0 ? byStatus : left.derivation.localeCompare(right.derivation);
-    })
-  );
+  function compareBuilds(left: BuildNode, right: BuildNode): number {
+    const byStatus = STATUS_ORDER[left.status] - STATUS_ORDER[right.status];
+    return byStatus !== 0 ? byStatus : left.derivation.localeCompare(right.derivation);
+  }
+
+  /// Tree view nests builds by dependency; flat view is the plain sorted list.
+  let layout = $state<'flat' | 'tree'>('flat');
+
+  const ordered = $derived(builds.toSorted(compareBuilds));
+  const tree = $derived(buildDependencyTree(builds, dependencies, compareBuilds));
+  const collapsed = new SvelteSet<string>();
 
   const expectedBuilds = $derived(expected[ACTIVITY_NAME_BUILD] ?? 0);
 
@@ -53,49 +70,86 @@
 
 <section class="panel builds-panel">
   <PanelHeader title="builds">
+    <div class="filter-chips">
+      <button type="button" class="chip" class:active={layout === 'flat'} onclick={() => (layout = 'flat')}>
+        flat
+      </button>
+      <button
+        type="button"
+        class="chip"
+        class:active={layout === 'tree'}
+        title={tree.hasEdges ? 'nest builds by dependency' : 'no dependency edges resolved yet'}
+        onclick={() => (layout = 'tree')}
+      >
+        tree
+      </button>
+    </div>
     <span class="panel-meta">
       {String(builds.length)}{#if expectedBuilds > 0} / {String(expectedBuilds)}{/if}
     </span>
   </PanelHeader>
-  <div class="build-table">
-    {#each ordered as build (build.derivation)}
-      {@const parts = splitDerivation(build.derivation)}
-      {@const selected = build.activityId !== null && build.activityId === selectedActivityId}
-      <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-      <div
-        class="build-row"
-        class:selected
-        class:clickable={build.activityId !== null}
-        role={build.activityId !== null ? 'button' : undefined}
-        tabindex={build.activityId !== null ? 0 : undefined}
-        aria-pressed={build.activityId !== null ? selected : undefined}
-        onclick={() => { toggleSelect(build); }}
-        onkeydown={(event) => {
-          if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            toggleSelect(build);
-          }
-        }}
-      >
-        <div class="state" data-state={build.status} title={build.status}></div>
-        <div class="drv" title={build.derivation}>
-          <span class="drv-hash">{parts.hash}</span><span class="drv-name">{parts.name}</span>
-        </div>
-        <div class="where" class:remote={whereIsRemote(build.host)} title={whereLabel(build.host)}>
-          {whereLabel(build.host)}
-        </div>
-        <div class="phase">{build.phase ?? ''}</div>
-        <div class="duration">{formatDuration(elapsedMs(build))}</div>
-        <div class="right">{String(build.logCount)}</div>
-      </div>
+  <div class="build-table" class:tree={layout === 'tree'}>
+    {#if layout === 'tree'}
+      {#each tree.roots as rootDrv, index (rootDrv)}
+        <BuildTree
+          drv={rootDrv}
+          {tree}
+          {collapsed}
+          ontoggle={(drv: string) => {
+            if (collapsed.has(drv)) collapsed.delete(drv);
+            else collapsed.add(drv);
+          }}
+          now={now.value}
+          {selectedActivityId}
+          {onselect}
+          guideLines={[]}
+          isLast={index === tree.roots.length - 1}
+          isRoot={true}
+          ancestors={new Set()}
+        />
+      {:else}
+        <div class="empty wide">waiting for build phase</div>
+      {/each}
     {:else}
-      <div class="empty wide">
-        {#if expectedBuilds > 0}
-          waiting for {String(expectedBuilds)} build{expectedBuilds === 1 ? '' : 's'}
-        {:else}
-          waiting for build phase
-        {/if}
-      </div>
-    {/each}
+      {#each ordered as build (build.derivation)}
+        {@const parts = splitDerivation(build.derivation)}
+        {@const selected = build.activityId !== null && build.activityId === selectedActivityId}
+        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+        <div
+          class="build-row"
+          class:selected
+          class:clickable={build.activityId !== null}
+          role={build.activityId !== null ? 'button' : undefined}
+          tabindex={build.activityId !== null ? 0 : undefined}
+          aria-pressed={build.activityId !== null ? selected : undefined}
+          onclick={() => { toggleSelect(build); }}
+          onkeydown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              toggleSelect(build);
+            }
+          }}
+        >
+          <div class="state" data-state={build.status} title={build.status}></div>
+          <div class="drv" title={build.derivation}>
+            <span class="drv-hash">{parts.hash}</span><span class="drv-name">{parts.name}</span>
+          </div>
+          <div class="where" class:remote={whereIsRemote(build.host)} title={whereLabel(build.host)}>
+            {whereLabel(build.host)}
+          </div>
+          <div class="phase">{build.phase ?? ''}</div>
+          <div class="duration">{formatDuration(elapsedMs(build))}</div>
+          <div class="right">{String(build.logCount)}</div>
+        </div>
+      {:else}
+        <div class="empty wide">
+          {#if expectedBuilds > 0}
+            waiting for {String(expectedBuilds)} build{expectedBuilds === 1 ? '' : 's'}
+          {:else}
+            waiting for build phase
+          {/if}
+        </div>
+      {/each}
+    {/if}
   </div>
 </section>

--- a/packages/nix-web-monitor/server/site/src/components/BuildTree.svelte
+++ b/packages/nix-web-monitor/server/site/src/components/BuildTree.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  import type { SvelteSet } from 'svelte/reactivity';
+  import Self from '$components/BuildTree.svelte';
+  import { formatDuration, splitDerivation } from '$lib/format';
+  import type { BuildTree } from '$lib/build-tree';
+  import type { BuildNode } from '$lib/types';
+
+  type Props = {
+    drv: string;
+    tree: BuildTree;
+    collapsed: SvelteSet<string>;
+    ontoggle: (drv: string) => void;
+    now: number;
+    selectedActivityId: number | null;
+    onselect: (activityId: number | null) => void;
+    /// Vertical-line flags for each ancestor column (true = ancestor has a
+    /// following sibling, so its column keeps a `│`). Empty for roots.
+    guideLines: boolean[];
+    /// Whether this node is the last among its siblings (picks `└` vs `├`).
+    isLast: boolean;
+    isRoot: boolean;
+    /// Derivations on the path from the root to here. Guards against re-entering
+    /// a node already above us, which a malformed cyclic edge set could induce.
+    ancestors: ReadonlySet<string>;
+  };
+
+  const {
+    drv,
+    tree,
+    collapsed,
+    ontoggle,
+    now,
+    selectedActivityId,
+    onselect,
+    guideLines,
+    isLast,
+    isRoot,
+    ancestors
+  }: Props = $props();
+
+  const node = $derived(tree.nodeByDrv.get(drv));
+  const parts = $derived(splitDerivation(drv));
+  const children = $derived((tree.childrenByDrv.get(drv) ?? []).filter((dep) => !ancestors.has(dep)));
+  const isCollapsed = $derived(collapsed.has(drv));
+  const childGuideLines = $derived(isRoot ? [] : [...guideLines, !isLast]);
+  const childAncestors = $derived(new Set([...ancestors, drv]));
+
+  function elapsedMs(build: BuildNode): number {
+    return Math.max(0, (build.stoppedAtMs ?? now) - build.startedAtMs);
+  }
+
+  function whereLabel(host: string | null): string {
+    return host === null || host.length === 0 ? 'local' : host;
+  }
+
+  function toggleSelect(build: BuildNode): void {
+    if (build.activityId === null) return;
+    onselect(selectedActivityId === build.activityId ? null : build.activityId);
+  }
+</script>
+
+{#if node !== undefined}
+  {@const selected = node.activityId !== null && node.activityId === selectedActivityId}
+  {@const clickable = node.activityId !== null}
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+  <div
+    class="activity-row dep-row"
+    class:stopped={node.status === 'stopped'}
+    class:clickable
+    class:selected
+    role={clickable ? 'button' : undefined}
+    tabindex={clickable ? 0 : undefined}
+    aria-pressed={clickable ? selected : undefined}
+    onclick={() => {
+      toggleSelect(node);
+    }}
+    onkeydown={(event) => {
+      if (clickable && (event.key === 'Enter' || event.key === ' ')) {
+        event.preventDefault();
+        toggleSelect(node);
+      }
+    }}
+  >
+    {#if !isRoot}
+      <span class="guides" aria-hidden="true"
+        >{#each guideLines as line, level (level)}<span class="guide">{line ? '│' : ' '}</span
+          >{/each}<span class="guide connector">{isLast ? '└' : '├'}</span></span
+      >
+    {/if}
+    <button
+      type="button"
+      class="twirl"
+      class:hidden={children.length === 0}
+      aria-label={isCollapsed ? 'expand' : 'collapse'}
+      aria-expanded={children.length === 0 ? undefined : !isCollapsed}
+      tabindex={children.length === 0 ? -1 : 0}
+      onclick={(event) => {
+        event.stopPropagation();
+        ontoggle(drv);
+      }}
+    >
+      {children.length === 0 ? '' : isCollapsed ? '▸' : '▾'}
+    </button>
+    <span class="state" data-state={node.status} title={node.status}></span>
+    <span class="drv activity-drv" title={drv}>
+      <span class="drv-hash">{parts.hash}</span><span class="drv-name">{parts.name}</span>
+    </span>
+    <span class="where" class:remote={whereLabel(node.host) !== 'local'} title={whereLabel(node.host)}>
+      {whereLabel(node.host)}
+    </span>
+    {#if node.phase !== null}
+      <span class="phase">{node.phase}</span>
+    {/if}
+    {#if isCollapsed && children.length > 0}
+      <span class="subtree-count">+{String(children.length)}</span>
+    {/if}
+    <span class="activity-dur">{formatDuration(elapsedMs(node))}</span>
+  </div>
+
+  {#if !isCollapsed}
+    {#each children as childDrv, index (childDrv)}
+      <Self
+        drv={childDrv}
+        {tree}
+        {collapsed}
+        {ontoggle}
+        {now}
+        {selectedActivityId}
+        {onselect}
+        guideLines={childGuideLines}
+        isLast={index === children.length - 1}
+        isRoot={false}
+        ancestors={childAncestors}
+      />
+    {/each}
+  {/if}
+{/if}

--- a/packages/nix-web-monitor/server/site/src/lib/build-tree.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/build-tree.ts
@@ -1,0 +1,59 @@
+/// Turns the flat build list plus the dependency edge set into a renderable
+/// forest. Each edge `from -> to` means `from` directly requires `to`, so a
+/// node's children are its dependencies and the roots are the top-level
+/// targets (built derivations nothing else depends on).
+///
+/// The edge set is already transitively reduced server-side, so the tree is
+/// minimal. A diamond still unfolds its shared dependency under each dependent;
+/// that mirrors how `nix-output-monitor` prints and is fine for the small
+/// graphs a single build produces.
+
+import type { BuildNode, DerivationEdge } from '$lib/types';
+
+export type BuildTree = Readonly<{
+  nodeByDrv: ReadonlyMap<string, BuildNode>;
+  /// Direct dependencies per derivation, in display order.
+  childrenByDrv: ReadonlyMap<string, readonly string[]>;
+  /// Top-level derivations nothing else depends on.
+  roots: readonly string[];
+  /// Whether any dependency edge survived. Distinguishes "no edges resolved
+  /// yet" from a genuinely independent set of builds in the empty state.
+  hasEdges: boolean;
+}>;
+
+export function buildDependencyTree(
+  builds: readonly BuildNode[],
+  dependencies: readonly DerivationEdge[],
+  compare: (left: BuildNode, right: BuildNode) => number
+): BuildTree {
+  const nodeByDrv = new Map(builds.map((build) => [build.derivation, build]));
+  const children = new Map<string, string[]>();
+  const hasParent = new Set<string>();
+
+  for (const { from, to } of dependencies) {
+    // Ignore edges whose endpoints have no build row; the server only emits
+    // edges between built derivations, but this keeps the view honest if that
+    // ever drifts.
+    if (!nodeByDrv.has(from) || !nodeByDrv.has(to)) continue;
+    const deps = children.get(from) ?? [];
+    deps.push(to);
+    children.set(from, deps);
+    hasParent.add(to);
+  }
+
+  const order = (drvs: readonly string[]): string[] =>
+    drvs.toSorted((left, right) => {
+      const a = nodeByDrv.get(left);
+      const b = nodeByDrv.get(right);
+      return a === undefined || b === undefined ? left.localeCompare(right) : compare(a, b);
+    });
+
+  const childrenByDrv = new Map<string, readonly string[]>();
+  for (const [from, deps] of children) childrenByDrv.set(from, order(deps));
+
+  const roots = order(
+    builds.map((build) => build.derivation).filter((drv) => !hasParent.has(drv))
+  );
+
+  return { nodeByDrv, childrenByDrv, roots, hasEdges: dependencies.length > 0 };
+}

--- a/packages/nix-web-monitor/server/site/src/lib/types.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/types.ts
@@ -53,6 +53,14 @@ export const logEntrySchema = v.object({
   text: v.string()
 });
 
+/// One directed dependency edge in the build DAG: `from` directly requires
+/// `to`. Both are `derivation` paths matching a `BuildNode`, so the tree view
+/// joins edges to build rows by string identity.
+export const derivationEdgeSchema = v.object({
+  from: v.string(),
+  to: v.string()
+});
+
 export const snapshotSchema = v.object({
   activities: v.array(activityNodeSchema),
   builds: v.array(buildNodeSchema),
@@ -60,6 +68,7 @@ export const snapshotSchema = v.object({
   errors: v.array(v.string()),
   progress: v.nullable(activityProgressSchema),
   expected: v.record(v.string(), v.number()),
+  dependencies: v.array(derivationEdgeSchema),
   exitCode: v.nullable(v.number()),
   finished: v.boolean()
 });
@@ -71,6 +80,7 @@ export type ActivityProgress = v.InferOutput<typeof activityProgressSchema>;
 export type ActivityNode = v.InferOutput<typeof activityNodeSchema>;
 export type BuildNode = v.InferOutput<typeof buildNodeSchema>;
 export type LogEntry = v.InferOutput<typeof logEntrySchema>;
+export type DerivationEdge = v.InferOutput<typeof derivationEdgeSchema>;
 export type MonitorSnapshot = v.InferOutput<typeof snapshotSchema>;
 
 /// Purely client-side, never received over the wire.
@@ -92,6 +102,7 @@ export const EMPTY_SNAPSHOT: MonitorSnapshot = Object.freeze({
   errors: [],
   progress: null,
   expected: {},
+  dependencies: [],
   exitCode: null,
   finished: false
 });

--- a/packages/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix-web-monitor/server/site/src/style.css
@@ -492,6 +492,30 @@ main.dragging-v .splitter-v::after {
   background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
+/* Dependency-tree rows reuse the activity-row layout but are selectable like
+ * build rows, so they carry the same affordances as the flat build list. */
+.dep-row.clickable {
+  cursor: pointer;
+}
+
+.dep-row.clickable:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+}
+
+.dep-row.selected {
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+}
+
+.dep-row .where {
+  flex: 0 0 auto;
+}
+
+.dep-row .phase {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
 /* Box-drawing guides. Fixed-width cells keep the vertical stems aligned
  * column-to-column so a child's connector meets its ancestor's line. */
 .guides {

--- a/packages/nix-web-monitor/server/src/dependencies.rs
+++ b/packages/nix-web-monitor/server/src/dependencies.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+
+use anyhow::{Context, Result, bail};
+use nix_web_monitor_parser::MonitorState;
+use tokio::process::Command;
+use tokio::sync::{RwLock, broadcast, mpsc};
+
+use crate::publish_snapshot;
+
+/// Suffix Nix uses for derivation files. A built derivation also references
+/// source paths; only the `.drv` references are edges in the build DAG.
+const DRV_SUFFIX: &str = ".drv";
+
+/// Resolve dependency edges for built derivations out-of-band.
+///
+/// The internal-json stream names each derivation Nix builds but carries no
+/// edges between them. For every derivation reported, we ask `nix-store
+/// --query --references` for its direct inputs and feed them back into the
+/// monitor, where [`MonitorState::snapshot`] turns the adjacency into the
+/// rendered DAG. Runs as its own task so the per-derivation process spawn never
+/// stalls stderr parsing. The task exits when `derivations` closes, which the
+/// stderr reader does by dropping its sender once Nix's stderr ends.
+pub async fn resolve_dependencies(
+    mut derivations: mpsc::UnboundedReceiver<String>,
+    monitor: Arc<RwLock<MonitorState>>,
+    snapshots: broadcast::Sender<String>,
+) -> Result<()> {
+    while let Some(derivation) = derivations.recv().await {
+        let inputs = match direct_input_derivations(&derivation).await {
+            Ok(inputs) => inputs,
+            // A derivation whose references cannot be queried simply has no
+            // edges. Surface it on stderr and keep resolving the rest rather
+            // than tearing down the whole graph for one missing node.
+            Err(error) => {
+                eprintln!("nix-web-monitor: dependency query failed for {derivation}: {error:#}");
+                continue;
+            }
+        };
+
+        monitor
+            .write()
+            .await
+            .record_direct_dependencies(derivation, inputs);
+        publish_snapshot(&monitor, &snapshots).await?;
+    }
+    Ok(())
+}
+
+/// Direct input derivations of `derivation`, via the decade-stable
+/// `nix-store --query --references` interface (plain newline-separated store
+/// paths, unlike the version-dependent `nix derivation show` JSON).
+async fn direct_input_derivations(derivation: &str) -> Result<Vec<String>> {
+    let output = Command::new("nix-store")
+        .arg("--query")
+        .arg("--references")
+        .arg(derivation)
+        .output()
+        .await
+        .context("spawning nix-store --query --references")?;
+
+    if !output.status.success() {
+        bail!(
+            "nix-store exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|path| path.ends_with(DRV_SUFFIX))
+        .map(ToOwned::to_owned)
+        .collect())
+}

--- a/packages/nix-web-monitor/server/src/main.rs
+++ b/packages/nix-web-monitor/server/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
@@ -15,9 +16,12 @@ use futures::{Stream, StreamExt};
 use nix_web_monitor_parser::{MonitorState, NixEvent, ParsedLine, strip_ansi};
 use tokio::io::{self, AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::process::Command;
-use tokio::sync::{RwLock, broadcast};
+use tokio::sync::{RwLock, broadcast, mpsc};
 use tokio_stream::wrappers::BroadcastStream;
 use tower_http::services::{ServeDir, ServeFile};
+
+mod dependencies;
+use dependencies::resolve_dependencies;
 
 #[derive(Parser)]
 #[command(
@@ -184,17 +188,31 @@ async fn run_nix_command(
     let stdout = child.stdout.take().context("nix stdout was not captured")?;
     let stderr = child.stderr.take().context("nix stderr was not captured")?;
 
+    // The dependency resolver runs alongside parsing: the stderr reader hands
+    // it each newly-seen build derivation, it queries the edges, and drops its
+    // sender when stderr ends so the resolver drains and exits.
+    let (deps_tx, deps_rx) = mpsc::unbounded_channel();
+    let resolver_task = tokio::spawn(resolve_dependencies(
+        deps_rx,
+        Arc::clone(&monitor),
+        snapshots.clone(),
+    ));
+
     let stdout_task = tokio::spawn(forward_stdout(stdout, terminal_output));
     let stderr_task = tokio::spawn(parse_stderr(
         stderr,
         Arc::clone(&monitor),
         snapshots.clone(),
         terminal_output,
+        deps_tx,
     ));
 
     let status = child.wait().await.context("waiting for nix")?;
     stdout_task.await.context("joining stdout reader")??;
     stderr_task.await.context("joining stderr reader")??;
+    resolver_task
+        .await
+        .context("joining dependency resolver")??;
 
     let exit_code = status.code();
     monitor.write().await.finish(exit_code);
@@ -233,10 +251,13 @@ async fn parse_stderr<R>(
     monitor: Arc<RwLock<MonitorState>>,
     snapshots: broadcast::Sender<String>,
     terminal_output: TerminalOutput,
+    deps_tx: mpsc::UnboundedSender<String>,
 ) -> Result<()>
 where
     R: AsyncRead + Unpin,
 {
+    // Derivations already handed to the resolver, so each is queried once.
+    let mut requested: HashSet<String> = HashSet::new();
     // Read raw bytes per line, then decode lossily. `BufReader::lines()`
     // would error out on the first non-UTF-8 byte and stop draining stderr,
     // which would block the child once the pipe filled. Lossy decode keeps
@@ -260,7 +281,22 @@ where
             buf.pop();
         }
         let line = String::from_utf8_lossy(&buf);
-        let parsed = monitor.write().await.apply_line(&line);
+        let mut state = monitor.write().await;
+        let parsed = state.apply_line(&line);
+        // Collect derivations not yet queried while still holding the lock,
+        // then resolve their edges off the parse path.
+        let new_derivations: Vec<String> = state
+            .builds
+            .keys()
+            .filter(|derivation| requested.insert((*derivation).clone()))
+            .cloned()
+            .collect();
+        drop(state);
+        for derivation in new_derivations {
+            // Send failure means the resolver task is gone (shutdown); dropping
+            // the edge request is the right behaviour then.
+            let _ = deps_tx.send(derivation);
+        }
         if let Some(rendered) = render_for(terminal_output, &parsed) {
             eprintln!("{rendered}");
         }
@@ -269,7 +305,7 @@ where
     Ok(())
 }
 
-async fn publish_snapshot(
+pub(crate) async fn publish_snapshot(
     monitor: &Arc<RwLock<MonitorState>>,
     snapshots: &broadcast::Sender<String>,
 ) -> Result<()> {

--- a/site/src/lib/updates/nix-web-monitor-dependency-tree.svx
+++ b/site/src/lib/updates/nix-web-monitor-dependency-tree.svx
@@ -1,0 +1,15 @@
+---
+id: nix-web-monitor-dependency-tree
+postedAt: 2026-05-28T11:30:00-07:00
+title: "`nix-web-monitor` builds panel can nest derivations by dependency"
+tags: [nix, tooling, observability]
+links:
+  - label: nix-web-monitor
+    href: https://github.com/indexable-inc/index/tree/main/packages/nix-web-monitor
+---
+
+The builds panel now has a `flat` / `tree` toggle. Tree mode nests each built derivation under the derivation that depends on it, so you can read which build is waiting on which instead of scanning a flat list.
+
+Nix's `internal-json` log stream names every derivation it builds but carries no edges between them, so the monitor learns the structure out of band: for each built derivation it queries `nix-store --query --references` for the direct input `.drv` paths, keeps the edges between derivations that actually built this run, and transitively reduces them so a chain `a → b → c` never also draws the redundant `a → c`.
+
+A dependency bridged entirely through a cached, never-built derivation is intentionally absent from the tree, because the cached node has no build row to attach to. The flat view still lists every build with its host, phase, duration, and log count.


### PR DESCRIPTION
## What

The builds panel now has a `flat` / `tree` toggle. Tree mode nests each built derivation under the derivation that depends on it, so you can read which build is waiting on which instead of scanning a flat list.

## Why this needed work

Nix's `--log-format internal-json` stream names every derivation it builds but carries no edges between them. There is no `A needs B` event in the protocol, which is exactly why the monitor only had a flat builds list and an *activity* tree (coordination nesting, not dependencies). `nix-output-monitor` solves the same gap by reading derivation inputs out of band; this PR does the same with a stable, version-independent interface.

## How

- For each derivation Nix actually builds, the server queries `nix-store --query --references` for its direct input `.drv` paths. This is the decade-stable CLI (plain newline output), avoiding the version-dependent `nix derivation show` JSON schema and a hand-rolled ATerm parser.
- Edges are kept only between derivations that built this run, then **transitively reduced** so a chain `a → b → c` never also draws the redundant `a → c`.
- All graph logic (`dependency_edges`, transitive reduction) is pure in the `nix-web-monitor-parser` crate and unit-tested there. The server only does the `nix-store` I/O, on a dedicated resolver task fed by the stderr reader, so the per-derivation process spawn never stalls parsing.
- The DAG rides the existing SSE snapshot as a new `dependencies: { from, to }[]` field; the frontend builds the forest and renders it with the existing tree-row visuals.

## Known limit

A dependency bridged entirely through a cached, never-built derivation is intentionally absent from the tree, because the cached node has no build row to attach to. Documented in the site update entry and in the code.

## Verification

- `cargo test -p nix-web-monitor-parser` (graph reduction, edge filtering, snapshot integration), `cargo clippy`, `cargo fmt --check`.
- Site `svelte-check`, `eslint`, `vite build`.
- End-to-end: ran the binary against two dependent `runCommand` derivations; the snapshot emitted the single correct edge `b → a` with no query failures.
- `nix run .#lint` clean.
