### PR TITLE
nix-web-monitor: surface in-flight work in activities and summary

### DIFF
--- a/packages/nix-web-monitor/server/site/src/components/SummaryBar.svelte
+++ b/packages/nix-web-monitor/server/site/src/components/SummaryBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { formatDuration } from '$lib/format';
+  import { formatDuration, formatRate } from '$lib/format';
   import { useNow } from '$lib/now.svelte';
   import {
     ACTIVITY_NAME_BUILD,
@@ -66,6 +66,44 @@
     const end = snapshot.finished ? (lastStopMs ?? now.value) : now.value;
     return Math.max(0, end - startedAtMs);
   });
+
+  /// Substituter transfers still in flight. Counted straight from the activity
+  /// list so the figure is exact even when no byte progress is reported.
+  const downloading = $derived(
+    snapshot.activities.filter(
+      (activity) => activity.activityType.name === 'file_transfer' && activity.status === 'running'
+    ).length
+  );
+
+  /// Monotonic total of bytes pulled from substituters: each file-transfer
+  /// activity's `done` counter summed. Stopped transfers keep their final value,
+  /// so the sum only grows and a time delta yields a live rate.
+  const downloadedBytes = $derived(
+    snapshot.activities.reduce(
+      (sum, activity) =>
+        activity.activityType.name === 'file_transfer' ? sum + (activity.progress?.done ?? 0) : sum,
+      0
+    )
+  );
+
+  /// Per-second samples of `downloadedBytes`, held off the reactive graph so the
+  /// effect that writes `downloadRate` never depends on its own output. The tick
+  /// gate means snapshot bursts within one second do not each compute a rate.
+  const sample = { bytes: 0, at: 0, rate: 0, seeded: false };
+  let downloadRate = $state(0);
+  $effect(() => {
+    const at = now.value;
+    const bytes = downloadedBytes;
+    if (sample.seeded && at > sample.at) {
+      const perSecond = Math.max(0, ((bytes - sample.bytes) / (at - sample.at)) * 1000);
+      // Light EWMA so the reading does not jump between snapshot bursts.
+      sample.rate = sample.rate * 0.4 + perSecond * 0.6;
+      downloadRate = sample.rate;
+    }
+    sample.bytes = bytes;
+    sample.at = at;
+    sample.seeded = true;
+  });
 </script>
 
 <header class="summary">
@@ -95,6 +133,15 @@
       <div class="kpi kpi-warn">
         <span class="kpi-num">{counts.running}</span>
         <span class="kpi-label">running</span>
+      </div>
+    {/if}
+    {#if downloading > 0}
+      <div class="kpi kpi-info">
+        <span class="kpi-num">{downloading}</span>
+        <span class="kpi-label">downloading</span>
+        {#if downloadRate > 0}
+          <span class="kpi-num kpi-faint">{formatRate(downloadRate)}</span>
+        {/if}
       </div>
     {/if}
     {#if counts.succeeded > 0}

--- a/packages/nix-web-monitor/server/site/src/lib/format.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/format.ts
@@ -58,3 +58,19 @@ export function formatDuration(ms: number): string {
   const remHours = hours % 24;
   return `${String(days)}d${String(remHours).padStart(2, '0')}h`;
 }
+
+/// Human byte-rate in decimal units (`kB`/`MB` are 1000-based, matching how
+/// substituters and browsers report download speed). One decimal below 100 so a
+/// `2.4 MB/s` reading stays legible; whole numbers above to avoid noise.
+export function formatRate(bytesPerSecond: number): string {
+  if (!Number.isFinite(bytesPerSecond) || bytesPerSecond <= 0) return '0 B/s';
+  const units = ['B/s', 'kB/s', 'MB/s', 'GB/s'];
+  let value = bytesPerSecond;
+  let unit = 0;
+  while (value >= 1000 && unit < units.length - 1) {
+    value /= 1000;
+    unit += 1;
+  }
+  const text = unit === 0 || value >= 100 ? String(Math.round(value)) : value.toFixed(1);
+  return `${text} ${units[unit]}`;
+}

--- a/packages/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix-web-monitor/server/site/src/style.css
@@ -484,8 +484,16 @@ main.dragging-v .splitter-v::after {
   white-space: nowrap;
 }
 
+/* Push finished rows well into the background so the handful of in-flight
+ * rows read as the foreground in a long, mostly-stopped list. */
 .activity-row.stopped {
-  opacity: 0.6;
+  opacity: 0.4;
+}
+
+/* Lift in-flight rows out of the muted default so active work stands out. */
+.activity-row:not(.stopped) .activity-text,
+.activity-row:not(.stopped) .drv-name {
+  color: var(--ink);
 }
 
 .activity-row:hover {
@@ -591,9 +599,13 @@ main.dragging-v .splitter-v::after {
   opacity: 0.85;
 }
 
+/* Fixed-width trailing column. The flexible name column (`.activity-text` /
+ * `.activity-drv`, `flex: 1 1 auto`) grows to absorb the slack instead, so the
+ * `where` badge and duration land in the same place on every row. An
+ * `auto` left margin here would swallow that slack first and leave the badges
+ * ragged against variable-length names. */
 .activity-dur {
-  flex: 0 0 auto;
-  margin-left: auto;
+  flex: 0 0 3.2rem;
   padding-left: 0.5rem;
   color: var(--muted);
   font-variant-numeric: tabular-nums;


### PR DESCRIPTION
Three legibility fixes for watching a live run.

## Active rows stand out in a long stopped list

Finished activity rows now dim to 0.4 opacity (was 0.6) and in-flight rows brighten their name to the foreground ink colour. A handful of running downloads no longer drown in a sea of dark stopped rows.

## Downloading count and live throughput

The summary bar gains a `downloading` KPI: the count of in-flight `file_transfer` activities plus a smoothed download rate. The count reads straight off the activity list so it is exact even when no byte progress is reported; the rate sums each transfer's `done` byte counter and takes a one-second time delta (light EWMA so it does not jump between snapshot bursts). The rate hides when zero, so it never shows a fake `0 B/s`.

## Aligned where/duration columns in the build tree

Tree rows are flex, and the duration's `margin-left: auto` was swallowing the row's slack before the flexible name column could grow, leaving the `ssh-ng://…` host badges ragged against variable-length derivation names. The duration is now a fixed-width trailing column, so the name column absorbs the slack and the badge plus duration land in the same place on every row.

## Checks

`npm run check` (svelte-check), `npm run lint` (eslint), and `vite build` all pass. `formatRate` spot-checked across B/s through GB/s.
