### PR TITLE
nix-rules: fix no-builtins-path-without-name so it can be enforced

### DIFF
--- a/nix-rules/no-builtins-path-without-name.yml
+++ b/nix-rules/no-builtins-path-without-name.yml
@@ -13,6 +13,18 @@ note: |
 rule:
   pattern: builtins.path { $$$ATTRS }
   not:
+    # A bare `name = $_` does not parse as a Nix binding node, so the old
+    # `has: { pattern: name = $_ }` never matched and the rule flagged every
+    # call. Walk the literal argument attrset's own bindings instead and look
+    # for one whose attrpath is exactly `name`. Scoping to the argument's
+    # binding_set (rather than `stopBy: end`) avoids counting a `name` binding
+    # nested inside some value attrset.
     has:
-      pattern: name = $_
-      stopBy: end
+      field: argument
+      has:
+        kind: binding_set
+        has:
+          kind: binding
+          has:
+            field: attrpath
+            regex: '^name$'


### PR DESCRIPTION
`no-builtins-path-without-name` flagged every `builtins.path { ... }` call, including compliant ones that already pass `name`. The relational predicate was:

```yaml
not:
  has:
    pattern: name = $_
    stopBy: end
```

A bare `name = $_` does not parse as a Nix binding node (`name` is grammar-special; the snippet parses as an apply with an ERROR node), so the inner `has` never matched a real `name` binding and the `not` was always true. The rule was effectively "flag all `builtins.path` literals."

Fix: walk the literal argument attrset's own `binding_set` for a binding whose `attrpath` is exactly `name`, using the tree-sitter-nix node shape (`apply_expression` → `argument: attrset_expression` → `binding_set` → `binding` → `attrpath`):

```yaml
not:
  has:
    field: argument
    has:
      kind: binding_set
      has:
        kind: binding
        has:
          field: attrpath
          regex: '^name$'
```

Scoping to the argument's own `binding_set` (instead of `stopBy: end`) means a `name` binding nested inside some value attrset does not falsely satisfy the check.

Verified against minimal fixtures: `builtins.path { name = "x"; path = ./.; }` is no longer flagged (either attr order), `builtins.path { path = ./.; }` still is, and `builtins.path { path = ./.; opts = { name = "y"; }; }` is correctly still flagged. `ast-grep scan --error .` over the whole index tree is clean (every existing `builtins.path` already passes `name`).

A follow-up PR will add an `ast-grep test` harness (valid/invalid fixtures per rule) so this class of silently-broken rule is caught mechanically, plus fixes for any other rules the audit surfaces.
