### PR TITLE
repo: add editorconfig defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{rs,py,pyi,java,kts,zig,zon}]
+indent_size = 4
+
+[{pyproject.toml,uv.lock}]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{*.go,go.mod}]
+indent_style = tab
+indent_size = tab
+tab_width = 4
+
+[{Makefile,GNUmakefile,*.mk}]
+indent_style = tab
+indent_size = tab
+tab_width = 4


### PR DESCRIPTION
Adds a root .editorconfig so editors use the repo defaults.