### PR TITLE
nix-rules: fix 11 silently-dead rules + add ast-grep self-test harness

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -34,7 +34,7 @@ let
   # up in the `lint` derivation build, not at `nix run` time.
   lintStage = ix.writeNushellApplication pkgs {
     name = "lint-stage";
-    meta.description = "One lint stage (nixfmt | statix | deadnix | ast-grep); driven by `lint`";
+    meta.description = "One lint stage (nixfmt | statix | deadnix | ast-grep | ast-grep-test); driven by `lint`";
     runtimeInputs = [
       pkgs.ast-grep
       pkgs.deadnix
@@ -50,8 +50,14 @@ let
       def "main statix" [] { statix check . }
       def "main deadnix" [] { deadnix --fail --no-lambda-pattern-names . }
       def "main ast-grep" [] { ast-grep scan --error . }
+      # Rule self-test: every fixture under nix-rules-tests must flag its
+      # invalid cases and ignore its valid ones. Catches rules whose pattern
+      # silently stops matching (e.g. a bare `attr = val` that parses as an
+      # expression, not a binding). --skip-snapshot-tests keeps it to match
+      # presence/absence without baseline snapshot files.
+      def "main ast-grep-test" [] { ast-grep test --skip-snapshot-tests }
       def main [] {
-        error make { msg: "specify a stage: nixfmt | statix | deadnix | ast-grep" }
+        error make { msg: "specify a stage: nixfmt | statix | deadnix | ast-grep | ast-grep-test" }
       }
     '';
   };
@@ -73,6 +79,10 @@ let
       "ast-grep".command = [
         (lib.getExe lintStage)
         "ast-grep"
+      ];
+      "ast-grep-test".command = [
+        (lib.getExe lintStage)
+        "ast-grep-test"
       ];
     };
   };

--- a/nix-rules-tests/no-abort-test.yml
+++ b/nix-rules-tests/no-abort-test.yml
@@ -1,0 +1,7 @@
+id: no-abort
+valid:
+  - 'a: throw "ix.area: boom"'
+  - 'a: lib.assertMsg (x == 1) "must be one"'
+invalid:
+  - 'a: abort "boom"'
+  - 'a: builtins.abort "boom"'

--- a/nix-rules-tests/no-buildphase-pure-default-test.yml
+++ b/nix-rules-tests/no-buildphase-pure-default-test.yml
@@ -1,0 +1,6 @@
+id: no-buildphase-pure-default
+valid:
+  - '{ preBuild = "make"; postInstall = "make install"; }'
+invalid:
+  - '{ buildPhase = "make"; }'
+  - '{ installPhase = "make install"; }'

--- a/nix-rules-tests/no-derivation-name-version-interp-test.yml
+++ b/nix-rules-tests/no-derivation-name-version-interp-test.yml
@@ -1,0 +1,6 @@
+id: no-derivation-name-version-interp
+valid:
+  - '{ pname = "foo"; version = "1.0"; }'
+invalid:
+  - '{ name = "${pname}-${version}"; }'
+  - '{ name = "${finalAttrs.pname}-${finalAttrs.version}"; }'

--- a/nix-rules-tests/no-fixup-phase-override-test.yml
+++ b/nix-rules-tests/no-fixup-phase-override-test.yml
@@ -1,0 +1,5 @@
+id: no-fixup-phase-override
+valid:
+  - '{ preFixup = "patchShebangs ."; postFixup = "echo done"; }'
+invalid:
+  - '{ fixupPhase = "patchShebangs ."; }'

--- a/nix-rules-tests/no-import-in-imports-test.yml
+++ b/nix-rules-tests/no-import-in-imports-test.yml
@@ -1,0 +1,5 @@
+id: no-import-in-imports
+valid:
+  - '{ imports = [ ./foo.nix ]; }'
+invalid:
+  - '{ imports = [ (import ./foo.nix) ]; }'

--- a/nix-rules-tests/no-impure-test.yml
+++ b/nix-rules-tests/no-impure-test.yml
@@ -1,0 +1,5 @@
+id: no-impure
+valid:
+  - '{ name = "x"; builder = "/bin/sh"; }'
+invalid:
+  - '{ __impure = true; }'

--- a/nix-rules-tests/no-old-go-vendorsha256-test.yml
+++ b/nix-rules-tests/no-old-go-vendorsha256-test.yml
@@ -1,0 +1,5 @@
+id: no-old-go-vendorsha256
+valid:
+  - '{ vendorHash = "sha256-AAAA"; }'
+invalid:
+  - '{ vendorSha256 = "sha256-AAAA"; }'

--- a/nix-rules-tests/no-old-npm-depssha256-test.yml
+++ b/nix-rules-tests/no-old-npm-depssha256-test.yml
@@ -1,0 +1,5 @@
+id: no-old-npm-depssha256
+valid:
+  - '{ npmDepsHash = "sha256-AAAA"; }'
+invalid:
+  - '{ npmDepsSha256 = "sha256-AAAA"; }'

--- a/nix-rules-tests/no-old-rust-cargosha256-test.yml
+++ b/nix-rules-tests/no-old-rust-cargosha256-test.yml
@@ -1,0 +1,5 @@
+id: no-old-rust-cargosha256
+valid:
+  - '{ cargoHash = "sha256-AAAA"; }'
+invalid:
+  - '{ cargoSha256 = "sha256-AAAA"; }'

--- a/nix-rules-tests/no-pname-finalattrs-self-ref-test.yml
+++ b/nix-rules-tests/no-pname-finalattrs-self-ref-test.yml
@@ -1,0 +1,6 @@
+id: no-pname-finalattrs-self-ref
+valid:
+  - '{ owner = "someorg"; repo = "my-tool"; }'
+invalid:
+  - '{ repo = finalAttrs.pname; }'
+  - '{ owner = finalAttrs.pname; }'

--- a/nix-rules-tests/no-stringly-flags-test.yml
+++ b/nix-rules-tests/no-stringly-flags-test.yml
@@ -1,0 +1,6 @@
+id: no-stringly-flags
+valid:
+  - '{ configureFlags = [ "--enable-foo" "--disable-bar" ]; }'
+invalid:
+  - '{ configureFlags = "--enable-foo --disable-bar"; }'
+  - '{ mesonFlags = "-Dfoo=bar"; }'

--- a/nix-rules/no-abort.yml
+++ b/nix-rules/no-abort.yml
@@ -9,6 +9,8 @@ note: |
   `assert` so the failure names the invariant.
   REPO: Use `throw "ix.<area>: ..."` for user-facing failure and `assert lib.assertMsg cond "..."` for invariants.
 rule:
+  # A bare `$_` argument makes `abort $_` parse as an apply with an ERROR node,
+  # so the pattern never matched a real call. A named metavariable parses.
   any:
-    - pattern: abort $_
-    - pattern: builtins.abort $_
+    - pattern: abort $ARG
+    - pattern: builtins.abort $ARG

--- a/nix-rules/no-buildphase-pure-default.yml
+++ b/nix-rules/no-buildphase-pure-default.yml
@@ -11,8 +11,12 @@ note: |
   REPO: Drop the override. If you must override, use `preBuild`/`postBuild`/
   `preInstall`/`postInstall` to add work around the default.
 rule:
+  # `buildPhase = "make"` is not a standalone expression; it must be matched as
+  # a binding via a parseable context with `selector: binding`.
   any:
-    - pattern: buildPhase = "make"
-    - pattern: installPhase = "make install"
-    - pattern: buildPhase = "make "
-    - pattern: installPhase = "make install "
+    - pattern:
+        context: '{ buildPhase = "make"; }'
+        selector: binding
+    - pattern:
+        context: '{ installPhase = "make install"; }'
+        selector: binding

--- a/nix-rules/no-derivation-name-version-interp.yml
+++ b/nix-rules/no-derivation-name-version-interp.yml
@@ -9,6 +9,11 @@ note: |
   NIXPKGS: nixpkgs-hammering `name-and-version`.
   REPO: Drop the manual `name = "${pname}-${version}";`.
 rule:
+  # `name = "..."` only parses as a binding inside an attrset context.
   any:
-    - pattern: name = "${pname}-${version}"
-    - pattern: name = "${finalAttrs.pname}-${finalAttrs.version}"
+    - pattern:
+        context: '{ name = "${pname}-${version}"; }'
+        selector: binding
+    - pattern:
+        context: '{ name = "${finalAttrs.pname}-${finalAttrs.version}"; }'
+        selector: binding

--- a/nix-rules/no-fixup-phase-override.yml
+++ b/nix-rules/no-fixup-phase-override.yml
@@ -13,4 +13,7 @@ note: |
   `fixupPhase` only when you really mean to bypass shebang and RPATH handling,
   and document the reason inline.
 rule:
-  pattern: fixupPhase = $X
+  # `fixupPhase = $X` parses as a binding only inside an attrset context.
+  pattern:
+    context: "{ fixupPhase = $X; }"
+    selector: binding

--- a/nix-rules/no-import-in-imports.yml
+++ b/nix-rules/no-import-in-imports.yml
@@ -11,4 +11,7 @@ note: |
   system documentation explicitly says to use paths, not import calls.
   REPO: Banned in AGENTS.md.
 rule:
-  pattern: imports = [ $$$PRE (import $PATH) $$$POST ]
+  # `imports = [ ... ]` parses as a binding only inside an attrset context.
+  pattern:
+    context: "{ imports = [ $$$PRE (import $PATH) $$$POST ]; }"
+    selector: binding

--- a/nix-rules/no-impure.yml
+++ b/nix-rules/no-impure.yml
@@ -12,4 +12,7 @@ note: |
   PREFER: FODs for network fetch, __mounts for sandbox mounts,
   ix.writeNushellApplication for orchestrators.
 rule:
-  pattern: __impure = true
+  # `__impure = true` parses as a binding only inside an attrset context.
+  pattern:
+    context: "{ __impure = true; }"
+    selector: binding

--- a/nix-rules/no-old-go-vendorsha256.yml
+++ b/nix-rules/no-old-go-vendorsha256.yml
@@ -9,4 +9,8 @@ note: |
   REPO: Use `vendorHash = "sha256-...=";`. Set `vendorHash = null;` for vendored
   modules.
 rule:
-  pattern: vendorSha256 = $_
+  # Match the binding by attrpath; the old `vendorSha256 = $_` never parsed.
+  kind: binding
+  has:
+    field: attrpath
+    regex: '^vendorSha256$'

--- a/nix-rules/no-old-npm-depssha256.yml
+++ b/nix-rules/no-old-npm-depssha256.yml
@@ -10,4 +10,8 @@ note: |
   REPO: Use `npmDepsHash` with SRI. The pnpm-build equivalent is
   `pnpmDeps.hash` / `pnpmDepsHash` (current name — do not flag).
 rule:
-  pattern: npmDepsSha256 = $_
+  # Match the binding by attrpath; the old `npmDepsSha256 = $_` never parsed.
+  kind: binding
+  has:
+    field: attrpath
+    regex: '^npmDepsSha256$'

--- a/nix-rules/no-old-rust-cargosha256.yml
+++ b/nix-rules/no-old-rust-cargosha256.yml
@@ -9,4 +9,8 @@ note: |
   NIXPKGS: PR #259603 removed the legacy attribute.
   REPO: Use `cargoHash` (with SRI) or the typed `cargoLock` form.
 rule:
-  pattern: cargoSha256 = $_
+  # Match the binding by attrpath; the old `cargoSha256 = $_` never parsed.
+  kind: binding
+  has:
+    field: attrpath
+    regex: '^cargoSha256$'

--- a/nix-rules/no-pname-finalattrs-self-ref.yml
+++ b/nix-rules/no-pname-finalattrs-self-ref.yml
@@ -11,7 +11,14 @@ note: |
   REPO: Use the literal string. Save `finalAttrs.*` self-reference for values that
   must move with overrides (like `version` inside `src.url`).
 rule:
+  # `repo = finalAttrs.pname` parses as a binding only inside an attrset context.
   any:
-    - pattern: repo = finalAttrs.pname
-    - pattern: owner = finalAttrs.pname
-    - pattern: pname = finalAttrs.pname
+    - pattern:
+        context: '{ repo = finalAttrs.pname; }'
+        selector: binding
+    - pattern:
+        context: '{ owner = finalAttrs.pname; }'
+        selector: binding
+    - pattern:
+        context: '{ pname = finalAttrs.pname; }'
+        selector: binding

--- a/nix-rules/no-stringly-flags.yml
+++ b/nix-rules/no-stringly-flags.yml
@@ -12,9 +12,13 @@ note: |
   REPO: Pass a Nix list. Use `lib.optional` / `lib.optionals` for conditional
   flags so each flag is its own element.
 rule:
-  any:
-    - pattern: configureFlags = "$_"
-    - pattern: cmakeFlags = "$_"
-    - pattern: mesonFlags = "$_"
-    - pattern: makeFlags = "$_"
-    - pattern: ninjaFlags = "$_"
+  # Match the binding directly: a flag attr whose value is a single string
+  # literal. The old `configureFlags = "$_"` patterns never parsed as bindings.
+  kind: binding
+  all:
+    - has:
+        field: attrpath
+        regex: '^(configureFlags|cmakeFlags|mesonFlags|makeFlags|ninjaFlags|xorgserverFlags)$'
+    - has:
+        field: expression
+        kind: string_expression

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,1 +1,3 @@
 ruleDirs: ["./nix-rules"]
+testConfigs:
+  - testDir: ./nix-rules-tests


### PR DESCRIPTION
Follow-up to #283. An audit of all 63 index ast-grep rules found that **13 matched nothing** — they looked like they enforced a policy but their pattern never matched a real node, so they were decorative. #283 fixed one (`no-builtins-path-without-name`); this fixes 11 more and adds a test harness so this class of bug is caught mechanically.

## Root cause

ast-grep parses a rule `pattern:` as a standalone Nix expression. A bare `attr = value` (e.g. `__impure = true`, `fixupPhase = $X`, `cargoSha256 = $_`) or `abort $_` does not parse as the binding/apply node it targets — tree-sitter-nix produces an `apply_expression` wrapping an ERROR node — so the compiled query matched nothing.

## Rules fixed (11)

Rewrote each with a parseable form and verified it flags a real violation and ignores compliant code:

- `context:`+`selector: binding` — `no-impure`, `no-fixup-phase-override`, `no-import-in-imports`, `no-buildphase-pure-default`, `no-derivation-name-version-interp`, `no-pname-finalattrs-self-ref`
- `kind: binding` + `has: { field: attrpath; regex }` — `no-old-rust-cargosha256`, `no-old-go-vendorsha256`, `no-old-npm-depssha256`, `no-stringly-flags` (plus an expression-kind check for the string-vs-list case)
- named metavariable — `no-abort` (`abort $ARG`)

Reviving these surfaced **no** real violations in the index tree (`ast-grep scan --error .` is clean).

## Self-test harness

Added an `ast-grep test` stage so a rule that stops matching fails CI:

- `testConfigs` in `sgconfig.yml` pointing at `nix-rules-tests/`
- one `<rule>-test.yml` (valid + invalid fixtures) per fixed rule
- an `ast-grep-test` subcommand in the lint stage plus a DAG node, run with `--skip-snapshot-tests` (presence/absence checks, no snapshot files)

`nix run .#lint` runs 5 stages now (nixfmt, statix, deadnix, ast-grep, ast-grep-test), all green.

## Deferred (1): `no-mkoption-conditional-default`

This rule is also dead, but reviving it surfaces **2 genuine violations** in `modules/services/observability/default.nix` — `listenAddress` options whose `default` is `if cfg.… then "0.0.0.0" else …`. Those bind-address conditionals need a behavior-preserving `config`+`mkDefault` refactor with eval verification, so they belong in their own reviewed PR rather than riding this rule-correctness change. Tracking separately.

## Follow-up

Backfill `nix-rules-tests/` fixtures for the other ~50 rules the audit reported as already-working, so every rule has a self-test.
