### PR TITLE
nix-web-monitor: break down running activity by kind in the summary

### DIFF
--- a/packages/nix-web-monitor/server/site/src/components/SummaryBar.svelte
+++ b/packages/nix-web-monitor/server/site/src/components/SummaryBar.svelte
@@ -67,13 +67,21 @@
     return Math.max(0, end - startedAtMs);
   });
 
-  /// Substituter transfers still in flight. Counted straight from the activity
-  /// list so the figure is exact even when no byte progress is reported.
-  const downloading = $derived(
-    snapshot.activities.filter(
-      (activity) => activity.activityType.name === 'file_transfer' && activity.status === 'running'
-    ).length
-  );
+  /// Running activities by kind. This is the breakdown that explains a run whose
+  /// build rows look busy while the host CPU sits idle: the wall-clock is going
+  /// into substituter transfers, store copies, and path-info queries, not
+  /// compute. Nix's stream does not link an input download to the specific build
+  /// that needs it, so this is the honest fleet-wide view rather than a per-build
+  /// attribution.
+  function runningOfType(name: string): number {
+    return snapshot.activities.filter(
+      (activity) => activity.activityType.name === name && activity.status === 'running'
+    ).length;
+  }
+
+  const downloading = $derived(runningOfType('file_transfer'));
+  const copying = $derived(runningOfType('copy_path') + runningOfType('copy_paths'));
+  const querying = $derived(runningOfType('query_path_info'));
 
   /// Monotonic total of bytes pulled from substituters: each file-transfer
   /// activity's `done` counter summed. Stopped transfers keep their final value,
@@ -142,6 +150,18 @@
         {#if downloadRate > 0}
           <span class="kpi-num kpi-faint">{formatRate(downloadRate)}</span>
         {/if}
+      </div>
+    {/if}
+    {#if copying > 0}
+      <div class="kpi kpi-info">
+        <span class="kpi-num">{copying}</span>
+        <span class="kpi-label">copying</span>
+      </div>
+    {/if}
+    {#if querying > 0}
+      <div class="kpi kpi-info">
+        <span class="kpi-num">{querying}</span>
+        <span class="kpi-label">querying</span>
       </div>
     {/if}
     {#if counts.succeeded > 0}


### PR DESCRIPTION
Surfaces running `file_transfer` / `copy_path` / `query_path_info` counts in the summary bar next to the running-builds figure.

## Why

A run can show many "running" build rows while the host CPU sits near idle (e.g. 20 builds dispatched to a remote builder). The wall-clock is going into substituter transfers, store copies, and path-info queries, not compute. The summary previously showed only running builds and a download count, so the cause was not legible at a glance.

## What

Adds `copying` (running `copy_path` + `copy_paths`) and `querying` (running `query_path_info`) chips alongside the existing `downloading` chip, all counted straight from the activity list.

## Design note

Nix's internal-json stream does not link an input download to the specific build that needs it: substitutions are parented to the global `realise` / `copy_paths` coordinators, not to a build activity. So a truthful per-build "this row is slow because of these downloads" attribution is not derivable from the stream. This change gives the honest fleet-wide breakdown instead. A deeper panel correlation (merging the builds and activities trees, bidirectional selection highlight) is a good follow-up that benefits from visual iteration.

Third of three PRs (after #287 and #288).
