### PR TITLE
ci: aggregate check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  flake-check:
+  check-group:
+    name: check / all checks and schema
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -50,5 +51,22 @@ jobs:
           name: indexable-inc
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: nix flake check
-        run: nix flake check -L
+      - name: Run checks and schema
+        run: |
+          nix build -L .#checks.x86_64-linux.all
+          nix flake check -L --no-build
+
+  flake-check:
+    needs:
+      - check-group
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all check groups
+        env:
+          CHECK_GROUP_RESULT: ${{ needs.check-group.result }}
+        run: |
+          if [ "${CHECK_GROUP_RESULT}" != "success" ]; then
+            echo "::error::One or more check groups failed (${CHECK_GROUP_RESULT})."
+            exit 1
+          fi

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -341,38 +341,54 @@ in
     // healthChecks.lifecyclePackages;
 
   checks = lib.optionalAttrs (system == ix.system) (
-    {
-      inherit (tests) eval;
-      agents-md = pkgs.runCommand "agents-md-check" { nativeBuildInputs = [ agentsMd ]; } ''
-        agents-md --check ${paths.root}
-        mkdir -p "$out"
-      '';
-      cargo-unit-real-workspaces = tests.cargoUnitRealWorkspaces;
-      # Offline schema gate for the loader manifests. `deepSeq` forces
-      # every Paper / Velocity / Fabric per-version lock through
-      # `readLoaderManifest` in `lib/artifacts.nix`, so malformed JSON or a
-      # missing key fires here before any image starts evaluating. The
-      # forced surface is the parsed-and-validated manifest data, not the
-      # wrapped `fetchurl` derivations, to keep this check pure eval.
-      loader-manifests =
-        let
-          forced = builtins.deepSeq ix.artifacts.minecraft.loaderManifests "ok";
-        in
-        pkgs.runCommand "loader-manifests-check" { } ''
-          printf '%s\n' '${forced}' > "$out"
+    let
+      rustChecks = {
+        cargo-unit-real-workspaces = tests.cargoUnitRealWorkspaces;
+      }
+      // rustPackageTests;
+
+      checkAttrs = {
+        inherit (tests) eval;
+        agents-md = pkgs.runCommand "agents-md-check" { nativeBuildInputs = [ agentsMd ]; } ''
+          agents-md --check ${paths.root}
+          mkdir -p "$out"
         '';
-      run-records-session = repoPackages.run.passthru.tests.recordsSession;
-      lint = pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ pkgs.coreutils ]; } ''
-        cp -R ${lintSource} source
-        chmod -R u+w source
-        cd source
-        ${lib.getExe lint}
-        mkdir -p "$out"
-      '';
-      site-test = siteTests.all;
+        # Offline schema gate for the loader manifests. `deepSeq` forces
+        # every Paper / Velocity / Fabric per-version lock through
+        # `readLoaderManifest` in `lib/artifacts.nix`, so malformed JSON or a
+        # missing key fires here before any image starts evaluating. The
+        # forced surface is the parsed-and-validated manifest data, not the
+        # wrapped `fetchurl` derivations, to keep this check pure eval.
+        loader-manifests =
+          let
+            forced = builtins.deepSeq ix.artifacts.minecraft.loaderManifests "ok";
+          in
+          pkgs.runCommand "loader-manifests-check" { } ''
+            printf '%s\n' '${forced}' > "$out"
+          '';
+        run-records-session = repoPackages.run.passthru.tests.recordsSession;
+        lint = pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ pkgs.coreutils ]; } ''
+          cp -R ${lintSource} source
+          chmod -R u+w source
+          cd source
+          ${lib.getExe lint}
+          mkdir -p "$out"
+        '';
+        rust-package-tests = pkgs.linkFarm "rust-package-tests" (
+          lib.mapAttrsToList (name: path: { inherit name path; }) rustChecks
+        );
+        site-case-tests = pkgs.linkFarm "site-case-tests" (
+          lib.mapAttrsToList (name: path: { inherit name path; }) siteTests.cases
+        );
+        site-test = siteTests.all;
+      };
+    in
+    checkAttrs
+    // {
+      all = pkgs.linkFarm "ix-images-checks" (
+        lib.mapAttrsToList (name: path: { inherit name path; }) checkAttrs
+      );
     }
-    // lib.mapAttrs' (caseId: drv: lib.nameValuePair "site-test-${caseId}" drv) siteTests.cases
-    // rustPackageTests
   );
 
   formatter = pkgs.nixfmt;


### PR DESCRIPTION
## What changed

- Added generated `checks.x86_64-linux.all`, built from the flake's check attrset, so CI has one source-of-truth target for the full check surface.
- Kept per-case site checks covered through a `site-case-tests` aggregate without exposing each case as a top-level flake check.
- Replaced the workflow's direct `nix flake check -L` build path with `nix build -L .#checks.x86_64-linux.all` followed by `nix flake check -L --no-build` in the same runner.
- Kept the final `flake-check` job so existing branch protection can continue to require one stable check name.

## Why

The previous single `nix flake check -L` job hid which check family was slow and forced dynamic check discovery through site test cases and Rust package tests before CI could start building useful work. The new shape materializes the generated aggregate check first, then runs flake schema/type validation without rebuilding everything through the flake frontend.

## Validation

- `nix run .#lint`
- `nix eval --accept-flake-config --json .#checks.x86_64-linux --apply builtins.attrNames`
- `nix eval --accept-flake-config --raw .#checks.x86_64-linux.all.name`
- `git diff --check`
- YAML parse for `.github/workflows/check.yml`