### PR TITLE
AGENTS: document cargo-careful for unsafe paths Miri cannot run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,14 @@ When parsing, normalizing, serializing, traversing graphs, handling archives, or
 speaking protocols, start from a maintained crate. Hand-written logic is for the
 thin glue around that crate unless the dependency boundary is measurably worse.
 
+Validate `unsafe` Rust with runtime checks before trusting normal tests. Run
+Miri where it works; for blocks Miri rejects because they need FFI, platform
+syscalls, or real native execution, run [`cargo-careful`](https://github.com/RalfJung/cargo-careful)
+with `cargo +nightly careful test -p <crate>`. cargo-careful exercises code
+against a debug-assertion standard library and surfaces some unsafe-precondition
+and stdlib-invariant breakage, but it does not model aliasing, uninitialized
+reads, or data races, so it complements Miri rather than replacing it.
+
 ## Python style
 
 Default repo-owned Python apps to uv: `pyproject.toml`, committed `uv.lock`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,14 @@ When parsing, normalizing, serializing, traversing graphs, handling archives, or
 speaking protocols, start from a maintained crate. Hand-written logic is for the
 thin glue around that crate unless the dependency boundary is measurably worse.
 
+Validate `unsafe` Rust with runtime checks before trusting normal tests. Run
+Miri where it works; for blocks Miri rejects because they need FFI, platform
+syscalls, or real native execution, run [`cargo-careful`](https://github.com/RalfJung/cargo-careful)
+with `cargo +nightly careful test -p <crate>`. cargo-careful exercises code
+against a debug-assertion standard library and surfaces some unsafe-precondition
+and stdlib-invariant breakage, but it does not model aliasing, uninitialized
+reads, or data races, so it complements Miri rather than replacing it.
+
 ## Python style
 
 Default repo-owned Python apps to uv: `pyproject.toml`, committed `uv.lock`,

--- a/agents-md/sections/06-rust-style.md
+++ b/agents-md/sections/06-rust-style.md
@@ -25,3 +25,11 @@ When parsing, normalizing, serializing, traversing graphs, handling archives, or
 speaking protocols, start from a maintained crate. Hand-written logic is for the
 thin glue around that crate unless the dependency boundary is measurably worse.
 
+Validate `unsafe` Rust with runtime checks before trusting normal tests. Run
+Miri where it works; for blocks Miri rejects because they need FFI, platform
+syscalls, or real native execution, run [`cargo-careful`](https://github.com/RalfJung/cargo-careful)
+with `cargo +nightly careful test -p <crate>`. cargo-careful exercises code
+against a debug-assertion standard library and surfaces some unsafe-precondition
+and stdlib-invariant breakage, but it does not model aliasing, uninitialized
+reads, or data races, so it complements Miri rather than replacing it.
+


### PR DESCRIPTION
## Summary

Add a Rust-style entry covering `cargo-careful` as the runtime check for unsafe blocks Miri cannot run (FFI, platform syscalls, real native execution). Notes the command (`cargo +nightly careful test -p <crate>`), what it surfaces (unsafe-precondition and stdlib-invariant breakage via a debug-assertion stdlib), and what it does not (aliasing, uninitialized reads, data races), so the next package owner reaches for it as a complement to Miri rather than a replacement.

Source fragment edited in `agents-md/sections/06-rust-style.md`; `AGENTS.md` and `CLAUDE.md` regenerated via `nix run .#agents-md -- --write`.

Closes #255

## Test plan

- [x] `nix run .#lint`
- [x] `nix run .#agents-md -- --write` produces no further diff