### PR TITLE
[codex] document concurrency scheduler tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,6 +304,13 @@ against a debug-assertion standard library and surfaces some unsafe-precondition
 and stdlib-invariant breakage, but it does not model aliasing, uninitialized
 reads, or data races, so it complements Miri rather than replacing it.
 
+Use [`loom`](https://docs.rs/loom/latest/loom/) for small deterministic
+concurrency primitives whose state fits inside modeled threads, atomics, and
+`std::sync` replacements. Use [`shuttle`](https://docs.rs/shuttle/latest/shuttle/)
+for larger randomized scheduler tests, especially Tokio-shaped workflows; skip
+both when the test would mainly prove a dependency's lock, channel, or runtime
+works instead of a repo-owned invariant.
+
 When auditing a crate with deterministic, fast tests, run
 [`cargo-mutants`](https://mutants.rs/) with
 `nix shell nixpkgs#cargo-mutants -c cargo mutants --package <name>` to surface

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,13 @@ against a debug-assertion standard library and surfaces some unsafe-precondition
 and stdlib-invariant breakage, but it does not model aliasing, uninitialized
 reads, or data races, so it complements Miri rather than replacing it.
 
+Use [`loom`](https://docs.rs/loom/latest/loom/) for small deterministic
+concurrency primitives whose state fits inside modeled threads, atomics, and
+`std::sync` replacements. Use [`shuttle`](https://docs.rs/shuttle/latest/shuttle/)
+for larger randomized scheduler tests, especially Tokio-shaped workflows; skip
+both when the test would mainly prove a dependency's lock, channel, or runtime
+works instead of a repo-owned invariant.
+
 When auditing a crate with deterministic, fast tests, run
 [`cargo-mutants`](https://mutants.rs/) with
 `nix shell nixpkgs#cargo-mutants -c cargo mutants --package <name>` to surface

--- a/agents-md/sections/06-rust-style.md
+++ b/agents-md/sections/06-rust-style.md
@@ -33,6 +33,13 @@ against a debug-assertion standard library and surfaces some unsafe-precondition
 and stdlib-invariant breakage, but it does not model aliasing, uninitialized
 reads, or data races, so it complements Miri rather than replacing it.
 
+Use [`loom`](https://docs.rs/loom/latest/loom/) for small deterministic
+concurrency primitives whose state fits inside modeled threads, atomics, and
+`std::sync` replacements. Use [`shuttle`](https://docs.rs/shuttle/latest/shuttle/)
+for larger randomized scheduler tests, especially Tokio-shaped workflows; skip
+both when the test would mainly prove a dependency's lock, channel, or runtime
+works instead of a repo-owned invariant.
+
 When auditing a crate with deterministic, fast tests, run
 [`cargo-mutants`](https://mutants.rs/) with
 `nix shell nixpkgs#cargo-mutants -c cargo mutants --package <name>` to surface
@@ -43,4 +50,3 @@ candidates for tighter assertions, equivalent-mutant write-offs, or
 unreachable-by-test code, and keep cargo-mutants a package-owner tool rather
 than a CI gate: equivalent mutants need human judgment, runtime scales with
 mutant count, and a survivor is a prompt to look, not a regression to block.
-


### PR DESCRIPTION
## What changed

Documented the repo rule for Loom and Shuttle in the Rust style guidance, then regenerated `AGENTS.md` and `CLAUDE.md` from `agents-md/sections/06-rust-style.md`.

The rule keeps Loom for small deterministic primitives that fit modeled threads, atomics, and `std::sync`, and keeps Shuttle for larger randomized scheduler tests, especially Tokio-shaped workflows. It also says to skip both when the test would only prove a dependency lock, channel, or runtime instead of a repo-owned invariant.

## Why

Issue #253 asks for a clear decision rule. I checked the current shared-state candidates and avoided adding a synthetic scheduler test because the small available target would mostly test `Mutex` behavior rather than repo logic.

Fixes #253

## Validation

- `AGENTS_MD_DOCUMENTS=/tmp/index-agents-md-documents.json cargo run -p agents-md -- --check`
- `cargo test -p agents-md`
- `git diff --check`
- `nix run .#lint`