### PR TITLE
code-tokenizer: assert token position and byte offsets

### DIFF
--- a/packages/code-tokenizer/src/tests/basic.rs
+++ b/packages/code-tokenizer/src/tests/basic.rs
@@ -1,4 +1,4 @@
-use super::helpers::tokenize;
+use super::helpers::{tokenize, tokenize_full};
 
 #[test]
 fn camel_case() {
@@ -113,4 +113,58 @@ fn single_letter_prefix_etag() {
 #[test]
 fn digit_prefix_splits_on_letter() {
     assert_eq!(tokenize("3DModel"), vec!["3", "d", "model"]);
+}
+
+#[test]
+fn snake_case_token_shape() {
+    assert_eq!(
+        tokenize_full("hello_world"),
+        vec![
+            ("hello".to_string(), 0, 0, 5),
+            ("world".to_string(), 1, 6, 11),
+        ]
+    );
+}
+
+#[test]
+fn camel_case_token_shape() {
+    assert_eq!(
+        tokenize_full("helloWorld"),
+        vec![
+            ("hello".to_string(), 0, 0, 5),
+            ("world".to_string(), 1, 5, 10),
+        ]
+    );
+}
+
+#[test]
+fn kebab_case_token_shape_four_tokens() {
+    assert_eq!(
+        tokenize_full("get-user-by-id"),
+        vec![
+            ("get".to_string(), 0, 0, 3),
+            ("user".to_string(), 1, 4, 8),
+            ("by".to_string(), 2, 9, 11),
+            ("id".to_string(), 3, 12, 14),
+        ]
+    );
+}
+
+#[test]
+fn multi_byte_chars_keep_byte_offsets() {
+    // `é` and `ö` are each two UTF-8 bytes, so the second token's
+    // `offset_from` must skip both the multi-byte char inside the
+    // first token and the single-byte separator.
+    assert_eq!(
+        tokenize_full("héllo_wörld"),
+        vec![
+            ("héllo".to_string(), 0, 0, 6),
+            ("wörld".to_string(), 1, 7, 13),
+        ]
+    );
+}
+
+#[test]
+fn single_token_eof_branch_shape() {
+    assert_eq!(tokenize_full("hello"), vec![("hello".to_string(), 0, 0, 5)]);
 }

--- a/packages/code-tokenizer/src/tests/helpers.rs
+++ b/packages/code-tokenizer/src/tests/helpers.rs
@@ -11,6 +11,25 @@ pub fn tokenize(text: &str) -> Vec<String> {
     tokens
 }
 
+/// `(text, position, offset_from, offset_to)` for every emitted token, so
+/// tests can pin the byte spans that index queries and result highlighting
+/// rely on, not just the lowered token text.
+pub fn tokenize_full(text: &str) -> Vec<(String, usize, usize, usize)> {
+    let mut tokenizer = CodeTokenizer;
+    let mut stream = tokenizer.token_stream(text);
+    let mut tokens = Vec::new();
+    while stream.advance() {
+        let token = stream.token();
+        tokens.push((
+            token.text.clone(),
+            token.position,
+            token.offset_from,
+            token.offset_to,
+        ));
+    }
+    tokens
+}
+
 pub fn tokenize_stemmed(text: &str) -> Vec<String> {
     let mut analyzer = TextAnalyzer::builder(CodeTokenizer)
         .filter(LowerCaser)


### PR DESCRIPTION
## Summary

`tests/helpers.rs::tokenize` only collected `Token::text`, leaving `Token::position`, `Token::offset_from`, and `Token::offset_to` unchecked. That left `cargo mutants --package code-tokenizer --in-place` with three surviving `+= → *=` mutants on `lib.rs:113`, `lib.rs:140`, and `lib.rs:144`.

Add a `tokenize_full` helper returning `(text, position, offset_from, offset_to)` per token and pin the full shape for snake_case, camelCase, four-token kebab-case, an identifier with multi-byte UTF-8 chars, and a single-token input that exits via the lookahead-None branch.

## Mutant outcomes

After this change, `cargo mutants --package code-tokenizer --in-place` reports 2 missed (down from 3 the issue called out):

| line | mutant | status | reason |
| --- | --- | --- | --- |
| `lib.rs:144` | `self.position += 1` → `*=` in the boundary branch | now caught | `snake_case_token_shape` asserts the second token gets `position = 1` |
| `lib.rs:113` | `self.position += 1` in the lookahead-None branch | equivalent | only fires after the last token; `byte_offset == text.len()`, so the next `advance` returns `false` and `self.position` is never read again |
| `lib.rs:140` | `current_offset += ch.len_utf8()` in the separator skip | equivalent for ASCII separators | `_` and `-` are 1 byte, so `*= 1` is a no-op; the seed loop on the next `advance` re-skips the separator the same way, producing identical tokens |

Per AGENTS.md (\"equivalent-mutant write-offs\"), the two remaining survivors are acceptable: a tighter test cannot distinguish them without changing observable behavior. Killing them would require restructuring the tokenizer (lift the position increment into a single helper, drop the now-redundant separator-skip block); flagged for the package owner to weigh against the simpler diff here.

Refs #297.

## Test plan

- [x] `cargo test --package code-tokenizer` (42 passing including 5 new shape tests)
- [x] `cargo fmt --package code-tokenizer -- --check`
- [x] `cargo clippy --package code-tokenizer --tests -- -D warnings`
- [x] `nix shell nixpkgs#cargo-mutants -c cargo mutants --package code-tokenizer --in-place` (20 caught, 2 missed equivalents, 6 unviable, 3 timeouts; line 144 moved from missed to caught)