### PR TITLE
agents: name mgrep/rg/fd in the searching guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -854,6 +854,16 @@ Use exact text search for exact questions and semantic search for fuzzy
 questions. Prefer machine-readable output when available, then inspect the narrow
 source files that own the behavior.
 
+Reach for semantic search first on conceptual or natural-language questions:
+`mgrep search -c "<query>" <path>` returns ranked files with the matched
+snippets. Add `-r` to recurse into subdirectories, `-m N` to raise the
+ten-result cap, `-a` to synthesize an answer from the hits, `-w` to fold in web
+results, and `--agentic` to let mgrep refine the query across several searches.
+Pass `-s` to sync local edits into the store before searching when files changed
+since the last index, or run `mgrep watch` to keep the store live. Use `rg` for
+exact strings and known symbols, and `fd` or a glob tool for known file-path
+patterns.
+
 Avoid broad agent delegation for simple search. The codebase is usually small
 enough that direct search plus a focused read gives better signal.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -854,6 +854,16 @@ Use exact text search for exact questions and semantic search for fuzzy
 questions. Prefer machine-readable output when available, then inspect the narrow
 source files that own the behavior.
 
+Reach for semantic search first on conceptual or natural-language questions:
+`mgrep search -c "<query>" <path>` returns ranked files with the matched
+snippets. Add `-r` to recurse into subdirectories, `-m N` to raise the
+ten-result cap, `-a` to synthesize an answer from the hits, `-w` to fold in web
+results, and `--agentic` to let mgrep refine the query across several searches.
+Pass `-s` to sync local edits into the store before searching when files changed
+since the last index, or run `mgrep watch` to keep the store live. Use `rg` for
+exact strings and known symbols, and `fd` or a glob tool for known file-path
+patterns.
+
 Avoid broad agent delegation for simple search. The codebase is usually small
 enough that direct search plus a focused read gives better signal.
 

--- a/agents-md/sections/18-searching.md
+++ b/agents-md/sections/18-searching.md
@@ -4,6 +4,16 @@ Use exact text search for exact questions and semantic search for fuzzy
 questions. Prefer machine-readable output when available, then inspect the narrow
 source files that own the behavior.
 
+Reach for semantic search first on conceptual or natural-language questions:
+`mgrep search -c "<query>" <path>` returns ranked files with the matched
+snippets. Add `-r` to recurse into subdirectories, `-m N` to raise the
+ten-result cap, `-a` to synthesize an answer from the hits, `-w` to fold in web
+results, and `--agentic` to let mgrep refine the query across several searches.
+Pass `-s` to sync local edits into the store before searching when files changed
+since the last index, or run `mgrep watch` to keep the store live. Use `rg` for
+exact strings and known symbols, and `fd` or a glob tool for known file-path
+patterns.
+
 Avoid broad agent delegation for simple search. The codebase is usually small
 enough that direct search plus a focused read gives better signal.
 


### PR DESCRIPTION
Folds concrete search-tool selection into the shared `searching` fragment so consumers (including ix) inherit it: semantic/natural-language questions go through `mgrep search -c "<query>" <path>`, exact strings and symbols use `rg`, and known file-path patterns use `fd` or a glob tool. Documents the flags an agent actually reaches for (`-r`, `-m N`, `-a`, `-w`, `--agentic`, `-s`/`mgrep watch`) based on the real `mgrep search` CLI surface.

This generalizes the ix-only "ix search invariants" note; ix keeps only its repo-specific invariant (run mgrep from the main checkout) once it picks this up via `nix flake update index`.

Regenerated `AGENTS.md` and `CLAUDE.md` via `nix run .#agents-md -- --write`.
