### PR TITLE
AGENTS: prefer Rust for core logic with thin language bindings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,12 @@ DRY up repeated mechanics when they express one domain fact. Do not hide
 legitimately different behavior behind a forced abstraction; three similar
 lines are better than a premature shared helper.
 
+Implement core backend and domain logic once in Rust, then expose it to other
+ecosystems through thin bindings rather than reimplementing it per language. A
+Python, Wasm, or FFI surface should wrap a Rust crate that owns the behavior and
+carry no domain logic of its own, so every caller shares one tested
+implementation.
+
 Refactor after the patch works. A passing diff with awkward ownership is not
 done. Replace string-shaped domain values with typed constructors or
 declarative helpers at the owner boundary instead of pushing parsing back into

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,12 @@ DRY up repeated mechanics when they express one domain fact. Do not hide
 legitimately different behavior behind a forced abstraction; three similar
 lines are better than a premature shared helper.
 
+Implement core backend and domain logic once in Rust, then expose it to other
+ecosystems through thin bindings rather than reimplementing it per language. A
+Python, Wasm, or FFI surface should wrap a Rust crate that owns the behavior and
+carry no domain logic of its own, so every caller shares one tested
+implementation.
+
 Refactor after the patch works. A passing diff with awkward ownership is not
 done. Replace string-shaped domain values with typed constructors or
 declarative helpers at the owner boundary instead of pushing parsing back into

--- a/agents-md/sections/01b-craft-standard.md
+++ b/agents-md/sections/01b-craft-standard.md
@@ -9,6 +9,12 @@ DRY up repeated mechanics when they express one domain fact. Do not hide
 legitimately different behavior behind a forced abstraction; three similar
 lines are better than a premature shared helper.
 
+Implement core backend and domain logic once in Rust, then expose it to other
+ecosystems through thin bindings rather than reimplementing it per language. A
+Python, Wasm, or FFI surface should wrap a Rust crate that owns the behavior and
+carry no domain logic of its own, so every caller shares one tested
+implementation.
+
 Refactor after the patch works. A passing diff with awkward ownership is not
 done. Replace string-shaped domain values with typed constructors or
 declarative helpers at the owner boundary instead of pushing parsing back into


### PR DESCRIPTION
Adds one durable rule to the craft standard: implement core backend and domain logic once in Rust, then expose it to other ecosystems through thin bindings (pyo3, Wasm, FFI) rather than reimplementing per language.

The general principle is that a binding surface should wrap a Rust crate that owns the behavior and carry no domain logic of its own, so every caller shares one tested implementation.

Edited the source fragment `agents-md/sections/01b-craft-standard.md` and regenerated `AGENTS.md` and `CLAUDE.md` via `nix run .#agents-md -- --write`. `nix run .#agents-md -- --check` passes.
