### PR TITLE
platform: self-hosted ci-runner module with warm nix cache

### DIFF
--- a/modules/services/ci-runner/README.md
+++ b/modules/services/ci-runner/README.md
@@ -1,0 +1,71 @@
+# ci-runner
+
+Self-hosted GitHub Actions runners for this repository, registered as a small
+static pool on a persistent NixOS host. The point is cache locality: jobs share
+the host's `/nix/store` and the indexable-inc Cachix substituter, so a
+`nix build .#...` step substitutes warm artifacts instead of rebuilding from a
+cold store on a throwaway cloud VM.
+
+This is the simple counterpart to the [`ix`](https://github.com/indexable-inc/ix)
+repo's webhook dispatcher, which mints just-in-time ephemeral runners per job.
+Here the runners are a fixed pool that re-register themselves, with no webhook
+service and no per-job VM.
+
+## Use it
+
+Import is automatic: the module is discovered as `nixosModules.ci-runner`. On a
+host config:
+
+```nix
+{
+  services.ci-runner = {
+    enable = true;
+    url = "https://github.com/indexable-inc/index";
+    tokenFile = "/run/secrets/ci-runner/token";  # one line, a fine-grained PAT
+    count = 4;                                     # job concurrency
+  };
+}
+```
+
+`tokenFile` must hold a fine-grained PAT with read and write access to the
+repository's self-hosted runners. A one-hour registration token does not work
+because ephemeral runners mint a new registration on every restart.
+
+The module wraps NixOS [`services.github-runners`][upstream] and adds the
+indexable-inc Cachix substituter and trusted key to `nix.settings`, plus `git`,
+`gh`, `cachix`, and the host's Nix on each job's PATH.
+
+## Opt a workflow in
+
+Set `runs-on` to `self-hosted` plus the configured `labels` (default `nix`):
+
+```yaml
+jobs:
+  build:
+    runs-on: [self-hosted, nix]
+```
+
+The checked-in workflows still target `ubuntu-latest`; switch one only once a
+runner host is actually deployed, or the required `check` gate will hang waiting
+for a runner that does not exist.
+
+## Options
+
+| Option      | Default                | Purpose                                      |
+| ----------- | ---------------------- | -------------------------------------------- |
+| `url`       | (required)             | Repo or org URL the runners register against |
+| `tokenFile` | (required)             | One-line file holding a fine-grained PAT     |
+| `count`     | `2`                    | Number of parallel single-job runners        |
+| `labels`    | `[ "nix" ]`            | Extra `runs-on` labels                        |
+| `ephemeral` | `true`                 | Single-use runners; store cache still warm   |
+| `packages`  | `[ ]`                  | Extra tools on each job's PATH               |
+
+## Bad fit if
+
+- You need per-job VM isolation against a hostile workflow. A persistent host
+  shares one kernel and one store across jobs; use the ix dispatcher's
+  VM-per-job model for that boundary.
+- You only run a handful of cheap jobs a month. GitHub-hosted `ubuntu-latest`
+  is simpler when the cold-store rebuild cost is not the bottleneck.
+
+[upstream]: https://search.nixos.org/options?query=services.github-runners

--- a/modules/services/ci-runner/default.nix
+++ b/modules/services/ci-runner/default.nix
@@ -38,7 +38,10 @@ in
     };
 
     tokenFile = mkOption {
-      type = types.path;
+      # A runtime path string, not `types.path`: a path literal like `./token`
+      # would copy the PAT into the world-readable Nix store, which this option
+      # explicitly promises not to do.
+      type = types.str;
       example = "/run/secrets/ci-runner/token";
       description = ''
         Path to a file holding a fine-grained GitHub PAT with read and write
@@ -92,17 +95,25 @@ in
 
   config = mkIf cfg.enable {
     # A warm shared cache is the whole point of a persistent runner: let the
-    # daemon substitute index artifacts so jobs skip cold rebuilds. These list
-    # settings merge with whatever the host already declares.
+    # daemon substitute index artifacts so jobs skip cold rebuilds. Every key
+    # uses the `extra-*` form so it adds to Nix's defaults and any host config
+    # rather than replacing them (keeping cache.nixos.org, kvm, etc.).
     nix.settings = {
-      experimental-features = [
+      extra-experimental-features = [
         "nix-command"
         "flakes"
       ];
-      substituters = [ "https://indexable-inc.cachix.org" ];
-      trusted-public-keys = [
+      # Consume the repo flake's nixConfig substituters without the interactive
+      # prompt; `nix flake check` otherwise stalls waiting for confirmation.
+      accept-flake-config = true;
+      extra-substituters = [ "https://indexable-inc.cachix.org" ];
+      extra-trusted-public-keys = [
         "indexable-inc.cachix.org-1:HQ5mjdOyhgNjLVhjv0qgVMJ5YiO1zEEVMAtF9mTcpiI="
       ];
+      # Index images pin `gcc.arch = znver5`, so every derivation in the closure
+      # requires this builder feature; advertise it or the daemon refuses the
+      # builds before they evaluate.
+      extra-system-features = [ "gccarch-znver5" ];
     };
 
     services.github-runners = lib.genAttrs runnerNames (_name: {

--- a/modules/services/ci-runner/default.nix
+++ b/modules/services/ci-runner/default.nix
@@ -1,0 +1,124 @@
+# Self-hosted GitHub Actions runners for this repository, meant to run on a
+# persistent NixOS host instead of an ephemeral cloud VM. The win is cache
+# locality: jobs reuse the host's global /nix/store and the indexable-inc
+# Cachix substituter, so `nix build .#...` pulls warm artifacts instead of
+# rebuilding from a cold store every run. The per-job work directory is still
+# wiped (see `ephemeral`); only the shared store survives, which is exactly the
+# state that is safe to keep between jobs.
+#
+# This is the small counterpart to the ix repo's webhook dispatcher: a static
+# pool of registered runners, no just-in-time minting and no per-job VM.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
+  cfg = config.services.ci-runner;
+  runnerNames = map (index: "index-${toString index}") (lib.range 1 cfg.count);
+in
+{
+  options.services.ci-runner = {
+    enable = mkEnableOption "self-hosted GitHub Actions runners for this repository";
+
+    url = mkOption {
+      type = types.str;
+      example = "https://github.com/indexable-inc/index";
+      description = ''
+        Repository or organization URL the runners register against, the same
+        value you would pass to {option}`services.github-runners.<name>.url`.
+      '';
+    };
+
+    tokenFile = mkOption {
+      type = types.path;
+      example = "/run/secrets/ci-runner/token";
+      description = ''
+        Path to a file holding a fine-grained GitHub PAT with read and write
+        access to the repository's self-hosted runners. A PAT (not a one-hour
+        registration token) is required because {option}`ephemeral` runners
+        mint a fresh registration on every restart. The file must contain
+        exactly one line and never enters the Nix store.
+      '';
+    };
+
+    count = mkOption {
+      type = types.ints.positive;
+      default = 2;
+      description = ''
+        How many runners register in parallel. Each processes one job at a
+        time, so this is the host's CI job concurrency.
+      '';
+    };
+
+    labels = mkOption {
+      type = types.listOf types.str;
+      default = [ "nix" ];
+      description = ''
+        Extra labels appended to every runner. A workflow opts in by setting
+        {option}`runs-on` to `self-hosted` plus these labels.
+      '';
+    };
+
+    ephemeral = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Register single-use runners that de-register after one job and
+        re-register on restart. This isolates jobs from each other while the
+        host's `/nix/store` cache survives the per-job wipe, so caching is
+        unaffected. Requires {option}`tokenFile` to hold a PAT. Disable only
+        for a deliberate long-lived runner.
+      '';
+    };
+
+    packages = mkOption {
+      type = types.listOf types.package;
+      default = [ ];
+      example = lib.literalExpression "[ pkgs.gh pkgs.jq ]";
+      description = ''
+        Extra packages on each job's PATH, on top of the git, Nix, and Cachix
+        tooling the module always provides.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # A warm shared cache is the whole point of a persistent runner: let the
+    # daemon substitute index artifacts so jobs skip cold rebuilds. These list
+    # settings merge with whatever the host already declares.
+    nix.settings = {
+      experimental-features = [
+        "nix-command"
+        "flakes"
+      ];
+      substituters = [ "https://indexable-inc.cachix.org" ];
+      trusted-public-keys = [
+        "indexable-inc.cachix.org-1:HQ5mjdOyhgNjLVhjv0qgVMJ5YiO1zEEVMAtF9mTcpiI="
+      ];
+    };
+
+    services.github-runners = lib.genAttrs runnerNames (_name: {
+      enable = true;
+      inherit (cfg) url tokenFile ephemeral;
+      extraLabels = cfg.labels;
+      # Re-register under the same name after a host config change instead of
+      # failing on a name clash with the already-registered runner.
+      replace = true;
+      extraPackages = [
+        pkgs.cachix
+        pkgs.gh
+        pkgs.git
+        config.nix.package
+      ]
+      ++ cfg.packages;
+    });
+  };
+}


### PR DESCRIPTION
Adds a composable NixOS module, `nixosModules.ci-runner`, that registers a small static pool of self-hosted GitHub Actions runners for this repo on a persistent host.

## Why

The checked-in workflows run on GitHub-hosted `ubuntu-latest`, which is a throwaway VM with a cold `/nix/store` every run, so `nix build .#...` rebuilds from scratch. A persistent runner host keeps the store warm and adds the indexable-inc Cachix substituter, so jobs substitute instead of rebuilding. This is the simple counterpart to the ix repo's webhook dispatcher: a fixed pool, no just-in-time minting, no per-job VM.

## What

- `services.ci-runner` wraps NixOS `services.github-runners`, spawning `count` ephemeral single-job runners that re-register themselves.
- Wires `https://indexable-inc.cachix.org` and its public key into `nix.settings`, and puts `git`, `gh`, `cachix`, and the host Nix on each job's PATH.
- Ephemeral by default: the per-job work dir is wiped while the shared `/nix/store` cache survives, so isolation and caching coexist. Requires a fine-grained PAT in `tokenFile`.

The existing workflows are left on `ubuntu-latest`; a `runs-on: [self-hosted, nix]` switch should land only once a runner host is deployed, otherwise the required `check` gate would hang. The README documents the opt-in.

## Verification

- Module discovered as `nixosModules.ci-runner`.
- Evaluated inside a `nixosSystem` with `count = 3`: produces `index-1..3`, `ephemeral = true`, labels `[ "nix" ]`, and the Cachix substituter present in `nix.settings.substituters`.
- `nix run .#lint` passes.
