### PR TITLE
cargo-unit: per-unit panic-freedom check via relocation scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,6 +2311,7 @@ dependencies = [
  "askama",
  "clap",
  "color-eyre",
+ "object",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2473,6 +2474,9 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap",
  "memchr",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,11 @@ loro = "1.12"
 ndarray = "0.16"
 nix-web-monitor-parser = { path = "packages/nix-web-monitor/parser" }
 numpy = "0.28"
+object = { version = "0.37", default-features = false, features = [
+  "read",
+  "write",
+  "std",
+] }
 parking_lot = "0.12"
 pty-process = { version = "0.4", features = ["async"] }
 pyo3 = { version = "0.28", features = ["abi3-py311"] }

--- a/lib/cargo-unit.nix
+++ b/lib/cargo-unit.nix
@@ -256,7 +256,8 @@ let
         toolchainId
       ]
       ++ lib.optional args.contentAddressed "--content-addressed"
-      ++ lib.optional args.policy.denyUnusedCrateDependencies "--deny-unused-crate-dependencies";
+      ++ lib.optional args.policy.denyUnusedCrateDependencies "--deny-unused-crate-dependencies"
+      ++ lib.optional args.policy.denyPanics "--deny-panics";
     in
     pkgs.runCommand "cargo-units.nix"
       {
@@ -372,6 +373,9 @@ let
           rustToolchain
           ;
         inherit workspaceRoot;
+        # Scanner for the opt-in panic-freedom policy. The rendered check
+        # asserts this is non-null when `policy.denyPanics` is set.
+        cargoUnit = nixCargoUnit;
         extraNativeBuildInputs = args.nativeBuildInputs ++ rust.nativeBuildInputsForPolicy args.policy;
         # `clippy-driver` ships in the clippy package; `rustToolchain` only
         # guarantees rustc + cargo. Adding the resolved clippy package keeps

--- a/lib/rust.nix
+++ b/lib/rust.nix
@@ -23,6 +23,9 @@ let
 
   defaultPolicy = {
     denyUnusedCrateDependencies = true;
+    # Opt-in: scans each unit's objects for functions that can reach a panic.
+    # Off by default because it is a best-effort gate, not a soundness proof.
+    denyPanics = false;
     cargoAudit = {
       enable = false;
       db = defaultRustsecAdvisoryDb;
@@ -63,6 +66,7 @@ let
     {
       denyUnusedCrateDependencies =
         rawPolicy.denyUnusedCrateDependencies or defaultPolicy.denyUnusedCrateDependencies;
+      denyPanics = rawPolicy.denyPanics or defaultPolicy.denyPanics;
       cargoAudit = {
         enable = cargoAudit.enable or defaultPolicy.cargoAudit.enable;
         db = cargoAudit.db or defaultPolicy.cargoAudit.db;

--- a/packages/nix-cargo-unit/Cargo.toml
+++ b/packages/nix-cargo-unit/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 askama = { workspace = true, default-features = false, features = ["derive", "std"] }
 clap = { workspace = true, features = ["derive"] }
 color-eyre.workspace = true
+object.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2.workspace = true

--- a/packages/nix-cargo-unit/src/main.rs
+++ b/packages/nix-cargo-unit/src/main.rs
@@ -1,5 +1,6 @@
 mod hash;
 mod model;
+mod panic_scan;
 mod render;
 mod shell;
 
@@ -28,6 +29,22 @@ enum Command {
 
     /// Render generated Nix from Cargo unit-graph JSON on stdin.
     Render(RenderArgs),
+
+    /// Scan compiled rlib artifacts for functions that can reach a panic.
+    ScanPanics(ScanPanicsArgs),
+}
+
+#[derive(Debug, clap::Args)]
+struct ScanPanicsArgs {
+    /// Restrict findings to functions of this crate (Cargo target name). Other
+    /// crates' monomorphized helpers in the same artifact are ignored.
+    #[arg(long, value_name = "NAME")]
+    crate_name: Option<String>,
+
+    /// Rlib artifacts or directories to scan. Directories are searched for
+    /// `*.rlib` recursively.
+    #[arg(required = true, value_name = "PATH")]
+    paths: Vec<PathBuf>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -62,6 +79,11 @@ struct RenderArgs {
     /// Collect and fail builds on dependencies unused across all local package units.
     #[arg(long)]
     deny_unused_crate_dependencies: bool,
+
+    /// Emit a per-unit panic-freedom policy check that scans each local unit's
+    /// compiled artifact for reachable panic machinery and fails if any is found.
+    #[arg(long)]
+    deny_panics: bool,
 }
 
 fn merge(args: MergeArgs) -> color_eyre::Result<()> {
@@ -103,6 +125,7 @@ fn render(args: RenderArgs) -> color_eyre::Result<()> {
             content_addressed: args.content_addressed,
             toolchain_id: args.toolchain_id,
             deny_unused_crate_dependencies: args.deny_unused_crate_dependencies,
+            deny_panics: args.deny_panics,
         },
     )
     .wrap_err("rendering Cargo unit graph as Nix")?;
@@ -111,11 +134,35 @@ fn render(args: RenderArgs) -> color_eyre::Result<()> {
     Ok(())
 }
 
+fn scan_panics(args: ScanPanicsArgs) -> color_eyre::Result<()> {
+    let ScanPanicsArgs { crate_name, paths } = args;
+    let rlibs = panic_scan::collect_rlibs(&paths)?;
+    let crate_token = crate_name.as_deref().map(panic_scan::crate_token);
+    let findings = panic_scan::scan_paths(&rlibs, crate_token.as_deref())?;
+
+    if findings.is_empty() {
+        return Ok(());
+    }
+
+    let scope = crate_name
+        .as_deref()
+        .map_or_else(String::new, |name| format!(" in {name}"));
+    eprintln!(
+        "error: cargo-unit panic-freedom: {} function(s){scope} can reach panic machinery",
+        findings.len()
+    );
+    for finding in &findings {
+        eprintln!("  {} -> {}", finding.function, finding.panic_entrypoint);
+    }
+    std::process::exit(1);
+}
+
 fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
 
     match Cli::parse().command {
         Command::Merge(args) => merge(args),
         Command::Render(args) => render(args),
+        Command::ScanPanics(args) => scan_panics(args),
     }
 }

--- a/packages/nix-cargo-unit/src/main.rs
+++ b/packages/nix-cargo-unit/src/main.rs
@@ -36,13 +36,15 @@ enum Command {
 
 #[derive(Debug, clap::Args)]
 struct ScanPanicsArgs {
-    /// Restrict findings to functions of this crate (Cargo target name). Other
-    /// crates' monomorphized helpers in the same artifact are ignored.
-    #[arg(long, value_name = "NAME")]
-    crate_name: Option<String>,
+    /// Workspace crate (Cargo target name) whose functions findings are scoped
+    /// to. Repeat for the full workspace set so a library generic monomorphized
+    /// in another unit's object is still attributed. Omit to report every
+    /// panic-reaching function.
+    #[arg(long = "crate-name", value_name = "NAME")]
+    crate_names: Vec<String>,
 
-    /// Rlib artifacts or directories to scan. Directories are searched for
-    /// `*.rlib` recursively.
+    /// Rlib or object artifacts, or directories to scan. Directories are
+    /// searched for `*.rlib` and `*.o` recursively.
     #[arg(required = true, value_name = "PATH")]
     paths: Vec<PathBuf>,
 }
@@ -135,18 +137,23 @@ fn render(args: RenderArgs) -> color_eyre::Result<()> {
 }
 
 fn scan_panics(args: ScanPanicsArgs) -> color_eyre::Result<()> {
-    let ScanPanicsArgs { crate_name, paths } = args;
-    let rlibs = panic_scan::collect_rlibs(&paths)?;
-    let crate_token = crate_name.as_deref().map(panic_scan::crate_token);
-    let findings = panic_scan::scan_paths(&rlibs, crate_token.as_deref())?;
+    let ScanPanicsArgs { crate_names, paths } = args;
+    let artifacts = panic_scan::collect_artifacts(&paths)?;
+    let crate_tokens: Vec<String> = crate_names
+        .iter()
+        .map(|name| panic_scan::crate_token(name))
+        .collect();
+    let findings = panic_scan::scan_paths(&artifacts, &crate_tokens)?;
 
     if findings.is_empty() {
         return Ok(());
     }
 
-    let scope = crate_name
-        .as_deref()
-        .map_or_else(String::new, |name| format!(" in {name}"));
+    let scope = if crate_names.is_empty() {
+        String::new()
+    } else {
+        format!(" in {}", crate_names.join(", "))
+    };
     eprintln!(
         "error: cargo-unit panic-freedom: {} function(s){scope} can reach panic machinery",
         findings.len()

--- a/packages/nix-cargo-unit/src/main.rs
+++ b/packages/nix-cargo-unit/src/main.rs
@@ -139,6 +139,18 @@ fn render(args: RenderArgs) -> color_eyre::Result<()> {
 fn scan_panics(args: ScanPanicsArgs) -> color_eyre::Result<()> {
     let ScanPanicsArgs { crate_names, paths } = args;
     let artifacts = panic_scan::collect_artifacts(&paths)?;
+    // Fail closed: a panic gate that finds nothing to inspect must error, not
+    // report success, or a wrong path or empty object set would pass open.
+    if artifacts.is_empty() {
+        color_eyre::eyre::bail!(
+            "cargo-unit panic-freedom: no .rlib or .o artifacts found under {}",
+            paths
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
     let crate_tokens: Vec<String> = crate_names
         .iter()
         .map(|name| panic_scan::crate_token(name))

--- a/packages/nix-cargo-unit/src/panic_scan.rs
+++ b/packages/nix-cargo-unit/src/panic_scan.rs
@@ -226,14 +226,18 @@ fn at_crate_boundary(symbol: &str, sink: &str) -> bool {
 }
 
 // A function belongs to the workspace if its mangled symbol carries one of the
-// workspace crate tokens, or if it is not Rust-mangled at all: an
-// `#[unsafe(no_mangle)]` export keeps a plain C name with no crate token, yet it
-// is still defined in this crate's object, so excluding it would hide panics in
-// FFI entrypoints. An empty token slice disables filtering.
+// workspace crate tokens at a crate-root boundary, or if it is not Rust-mangled
+// at all: an `#[unsafe(no_mangle)]` export keeps a plain C name with no crate
+// token, yet it is still defined in this crate's object, so excluding it would
+// hide panics in FFI entrypoints. The boundary check (not a bare substring)
+// keeps a short crate name like `de` from matching a dependency symbol such as
+// `serde2de`. An empty token slice disables filtering.
 fn belongs_to_workspace(function: &str, crate_tokens: &[String]) -> bool {
     crate_tokens.is_empty()
         || !is_rust_mangled(function)
-        || crate_tokens.iter().any(|token| function.contains(token))
+        || crate_tokens
+            .iter()
+            .any(|token| at_crate_boundary(function, token))
 }
 
 fn is_rust_mangled(symbol: &str) -> bool {
@@ -438,6 +442,17 @@ mod tests {
         // Fail closed: a corrupt or unsupported artifact must not scan as clean.
         let mut findings = BTreeSet::new();
         assert!(scan_bytes(b"not an object or archive", &[], &mut findings).is_err());
+    }
+
+    #[test]
+    fn short_crate_token_does_not_match_dependency_substring() {
+        // crate `de` (token `2de`) must not match serde's `de` module symbol,
+        // which only contains the token mid-path, not at the crate boundary.
+        let bytes = object_calling(
+            "_ZN5serde2de9from_slice17habcdefgEhh",
+            Some("_ZN4core9panicking5panic17habcdefgEhh"),
+        );
+        assert!(scan(&bytes, &["de"]).is_empty());
     }
 
     #[test]

--- a/packages/nix-cargo-unit/src/panic_scan.rs
+++ b/packages/nix-cargo-unit/src/panic_scan.rs
@@ -1,0 +1,285 @@
+//! Relocation-based panic-reachability scan for compiled units.
+//!
+//! A function that can panic emits a call to a `core::panicking::*` entrypoint.
+//! In a relocatable object (the `.o` members inside an rlib) that call survives
+//! as a relocation whose target is the undefined panic symbol, located at an
+//! offset inside the calling function's text range. Reading symbols and
+//! relocations with the `object` crate attributes each panic call to its
+//! containing function without disassembling instructions, so the same logic
+//! covers ELF and Mach-O.
+//!
+//! This operates on relocatable objects, which is why it targets library rlibs:
+//! a fully linked binary has its panic calls resolved to direct branches with
+//! no relocation left to read, and recovering them needs disassembly. Scanning
+//! linked bin/test units is deliberately out of scope here.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Result, WrapErr as _};
+use object::read::archive::ArchiveFile;
+use object::{Object as _, ObjectSection as _, ObjectSymbol as _, RelocationTarget, SymbolSection};
+
+/// One function that reaches panic machinery, with the entrypoint it calls.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct PanicFinding {
+    /// Mangled symbol of the function whose body holds the panic call.
+    pub function: String,
+    /// Mangled `core::panicking::*` symbol the function references.
+    pub panic_entrypoint: String,
+}
+
+/// Scans every artifact path for functions that reach panic machinery.
+///
+/// When `crate_token` is `Some`, only functions whose mangled symbol carries
+/// that crate's length-prefixed name component are reported, so the gate covers
+/// the unit's own code rather than monomorphized helpers from its dependencies.
+pub fn scan_paths(paths: &[PathBuf], crate_token: Option<&str>) -> Result<Vec<PanicFinding>> {
+    let mut findings = BTreeSet::new();
+    for path in paths {
+        let data = fs::read(path)
+            .wrap_err_with(|| format!("reading artifact {} for panic scan", path.display()))?;
+        scan_bytes(&data, crate_token, &mut findings)
+            .wrap_err_with(|| format!("scanning artifact {} for panic calls", path.display()))?;
+    }
+    Ok(findings.into_iter().collect())
+}
+
+/// Length-prefixed crate token shared by legacy (`_ZN7n_hello`) and v0
+/// (`_RNvCs..._7n_hello`) mangling. Cargo normalizes `-` to `_` in crate names.
+pub fn crate_token(crate_name: &str) -> String {
+    let normalized = crate_name.replace('-', "_");
+    format!("{}{normalized}", normalized.len())
+}
+
+fn scan_bytes(
+    data: &[u8],
+    crate_token: Option<&str>,
+    findings: &mut BTreeSet<PanicFinding>,
+) -> Result<()> {
+    // An rlib is an `ar` archive of object members; a bare `.o` is parsed
+    // directly. `ArchiveFile::parse` only succeeds on the archive magic, so a
+    // failed parse means this is a single object, not a silent fallback.
+    if let Ok(archive) = ArchiveFile::parse(data) {
+        for member in archive.members() {
+            let member = member.wrap_err("reading rlib archive member")?;
+            let member_data = member.data(data).wrap_err("reading rlib member data")?;
+            if let Ok(object) = object::File::parse(member_data) {
+                scan_object(&object, crate_token, findings);
+            }
+        }
+    } else if let Ok(object) = object::File::parse(data) {
+        scan_object(&object, crate_token, findings);
+    }
+    Ok(())
+}
+
+struct FunctionRange {
+    start: u64,
+    end: u64,
+    name: String,
+}
+
+fn scan_object(
+    object: &object::File,
+    crate_token: Option<&str>,
+    findings: &mut BTreeSet<PanicFinding>,
+) {
+    for section in object.sections() {
+        let functions = function_ranges(object, section.index());
+        for (offset, relocation) in section.relocations() {
+            let RelocationTarget::Symbol(symbol_index) = relocation.target() else {
+                continue;
+            };
+            let Ok(target) = object.symbol_by_index(symbol_index) else {
+                continue;
+            };
+            let Ok(target_name) = target.name() else {
+                continue;
+            };
+            if !is_panic_entrypoint(target_name) {
+                continue;
+            }
+            if let Some(function) = containing_function(&functions, offset)
+                && crate_token.is_none_or(|token| function.name.contains(token))
+            {
+                findings.insert(PanicFinding {
+                    function: function.name.clone(),
+                    panic_entrypoint: target_name.to_string(),
+                });
+            }
+        }
+    }
+}
+
+// Text symbols defined in this section, sorted by address with each function's
+// end clamped to the next function's start. Mach-O omits symbol sizes, so the
+// neighbor's address is the only reliable upper bound.
+fn function_ranges(object: &object::File, section: object::SectionIndex) -> Vec<FunctionRange> {
+    let mut ranges: Vec<FunctionRange> = object
+        .symbols()
+        .filter(|symbol| symbol.section() == SymbolSection::Section(section))
+        .filter(|symbol| symbol.kind() == object::SymbolKind::Text)
+        .filter_map(|symbol| {
+            let name = symbol.name().ok()?.to_string();
+            let start = symbol.address();
+            let end = start.checked_add(symbol.size()).filter(|end| *end > start);
+            Some(FunctionRange {
+                start,
+                end: end.unwrap_or(u64::MAX),
+                name,
+            })
+        })
+        .collect();
+
+    ranges.sort_by_key(|range| range.start);
+    for index in 0..ranges.len() {
+        if let Some(next_start) = ranges.get(index + 1).map(|next| next.start) {
+            ranges[index].end = ranges[index].end.min(next_start);
+        }
+    }
+    ranges
+}
+
+fn containing_function(functions: &[FunctionRange], offset: u64) -> Option<&FunctionRange> {
+    functions
+        .iter()
+        .find(|function| offset >= function.start && offset < function.end)
+}
+
+// Both legacy and v0 mangling encode the path component `core::panicking` as the
+// length-prefixed run `9panicking`, so the substring identifies every panic
+// entrypoint (`panic`, `panic_fmt`, `panic_bounds_check`, ...) regardless of
+// mangling scheme or the Mach-O leading-underscore prefix.
+fn is_panic_entrypoint(symbol: &str) -> bool {
+    symbol.contains("9panicking")
+}
+
+/// Collects `*.rlib` artifacts under each input path. A path that is itself a
+/// file is taken as-is so callers can pass exact artifacts.
+pub fn collect_rlibs(roots: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let mut rlibs = Vec::new();
+    for root in roots {
+        collect_rlibs_into(root, &mut rlibs)?;
+    }
+    rlibs.sort();
+    Ok(rlibs)
+}
+
+fn collect_rlibs_into(root: &Path, rlibs: &mut Vec<PathBuf>) -> Result<()> {
+    let metadata = fs::symlink_metadata(root)
+        .wrap_err_with(|| format!("inspecting panic-scan path {}", root.display()))?;
+    if metadata.is_file() {
+        rlibs.push(root.to_path_buf());
+        return Ok(());
+    }
+    if metadata.is_dir() {
+        for entry in
+            fs::read_dir(root).wrap_err_with(|| format!("reading directory {}", root.display()))?
+        {
+            let entry =
+                entry.wrap_err_with(|| format!("reading entry under {}", root.display()))?;
+            let path = entry.path();
+            if path.is_dir() || path.extension().is_some_and(|ext| ext == "rlib") {
+                collect_rlibs_into(&path, rlibs)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object::write::{
+        Object, Relocation, RelocationFlags, StandardSection, Symbol, SymbolSection as WriteSection,
+    };
+    use object::{
+        Architecture, BinaryFormat, Endianness, RelocationEncoding, RelocationKind, SymbolFlags,
+        SymbolKind, SymbolScope,
+    };
+
+    // Builds a relocatable ELF object with one text function `func_bytes` long.
+    // When `panic` is set, a relocation at offset 4 targets an undefined
+    // `core::panicking` symbol, modelling a panic call inside the function.
+    fn object_with_function(function: &str, panic: bool) -> Vec<u8> {
+        let mut object = Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
+        let text = object.section_id(StandardSection::Text);
+        object.append_section_data(text, &[0u8; 16], 1);
+        object.add_symbol(Symbol {
+            name: function.as_bytes().to_vec(),
+            value: 0,
+            size: 16,
+            kind: SymbolKind::Text,
+            scope: SymbolScope::Linkage,
+            weak: false,
+            section: WriteSection::Section(text),
+            flags: SymbolFlags::None,
+        });
+        if panic {
+            let panic_symbol = object.add_symbol(Symbol {
+                name: b"_ZN4core9panicking18panic_bounds_check17hababababababababE".to_vec(),
+                value: 0,
+                size: 0,
+                kind: SymbolKind::Text,
+                scope: SymbolScope::Dynamic,
+                weak: false,
+                section: WriteSection::Undefined,
+                flags: SymbolFlags::None,
+            });
+            object
+                .add_relocation(
+                    text,
+                    Relocation {
+                        offset: 4,
+                        symbol: panic_symbol,
+                        addend: 0,
+                        flags: RelocationFlags::Generic {
+                            kind: RelocationKind::PltRelative,
+                            encoding: RelocationEncoding::X86Branch,
+                            size: 32,
+                        },
+                    },
+                )
+                .expect("add panic relocation");
+        }
+        object.write().expect("serialize fixture object")
+    }
+
+    fn scan(data: &[u8], crate_token: Option<&str>) -> Vec<PanicFinding> {
+        let mut findings = BTreeSet::new();
+        scan_bytes(data, crate_token, &mut findings).expect("scan fixture");
+        findings.into_iter().collect()
+    }
+
+    #[test]
+    fn flags_function_that_calls_panic_entrypoint() {
+        let bytes = object_with_function("_ZN7n_hello3get17habcdefgEhh", true);
+        let findings = scan(&bytes, None);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].function, "_ZN7n_hello3get17habcdefgEhh");
+        assert!(findings[0].panic_entrypoint.contains("panic_bounds_check"));
+    }
+
+    #[test]
+    fn clean_function_produces_no_findings() {
+        let bytes = object_with_function("_ZN7n_hello5clean17habcdefgEhh", false);
+        assert!(scan(&bytes, None).is_empty());
+    }
+
+    #[test]
+    fn crate_filter_excludes_foreign_functions() {
+        // A panic call lives in a `serde`-named function. Scoping the scan to
+        // the `n_hello` crate token must drop it; the matching token keeps it.
+        let bytes = object_with_function("_ZN5serde2de17habcdefgEhh", true);
+        assert!(scan(&bytes, Some(&crate_token("n-hello"))).is_empty());
+        assert_eq!(scan(&bytes, Some(&crate_token("serde"))).len(), 1);
+    }
+
+    #[test]
+    fn crate_token_normalizes_dashes() {
+        assert_eq!(crate_token("n-hello"), "7n_hello");
+        assert_eq!(crate_token("serde"), "5serde");
+    }
+}

--- a/packages/nix-cargo-unit/src/panic_scan.rs
+++ b/packages/nix-cargo-unit/src/panic_scan.rs
@@ -12,6 +12,24 @@
 //! a fully linked binary has its panic calls resolved to direct branches with
 //! no relocation left to read, and recovering them needs disassembly. Scanning
 //! linked bin/test units is deliberately out of scope here.
+//!
+//! This is a best-effort detector, not a soundness proof. A clean result means
+//! "no detected panic call from this crate's monomorphic code," not "cannot
+//! panic." Two classes slip through by construction:
+//!
+//! - Uninstantiated generics. A generic function is stored as metadata in the
+//!   defining rlib and only codegened where a downstream crate monomorphizes
+//!   it, so `pub fn first<T>(xs: &[T]) -> &T { &xs[0] }` carries no relocation
+//!   here even though it can panic. Catching it requires analysis at the linked
+//!   binary where the instantiation lives.
+//! - Panics through uncatalogued helpers. [`PANIC_SINKS`] lists the common std
+//!   sinks (`core::panicking`, `unwrap_failed`, `expect_failed`); a panic that
+//!   routes through some other std/alloc cold path is missed until its symbol
+//!   is added.
+//!
+//! Proving total panic-freedom needs call-graph reachability over the linked,
+//! monomorphized binary (what `findpanics` does); that is the sound successor to
+//! this per-unit check, not a tweak to it.
 
 use std::collections::BTreeSet;
 use std::fs;
@@ -102,7 +120,7 @@ fn scan_object(
                 continue;
             }
             if let Some(function) = containing_function(&functions, offset)
-                && crate_token.is_none_or(|token| function.name.contains(token))
+                && crate_token.is_none_or(|token| belongs_to_crate(&function.name, token))
             {
                 findings.insert(PanicFinding {
                     function: function.name.clone(),
@@ -148,12 +166,45 @@ fn containing_function(functions: &[FunctionRange], offset: u64) -> Option<&Func
         .find(|function| offset >= function.start && offset < function.end)
 }
 
-// Both legacy and v0 mangling encode the path component `core::panicking` as the
-// length-prefixed run `9panicking`, so the substring identifies every panic
-// entrypoint (`panic`, `panic_fmt`, `panic_bounds_check`, ...) regardless of
-// mangling scheme or the Mach-O leading-underscore prefix.
+// Curated set of std panic sinks, matched as length-prefixed path fragments so
+// the same needles hit legacy (`_ZN4core9panicking...`) and v0
+// (`_RNvNt...4core9panicking...`) mangling and ignore the Mach-O leading
+// underscore. Requiring the `4core` / `3std` prefix avoids matching an
+// unrelated user module literally named `panicking`.
+//
+// `core::panicking::*` is the leaf for `panic!`, formatting panics, bounds
+// checks, overflow, and asserts. `unwrap`/`expect` reach a panic through the
+// cold `unwrap_failed` / `expect_failed` helpers first (confirmed by inspecting
+// the relocations rustc emits at opt-level 0 and 3), so those are listed too.
+// This catalog is deliberately incomplete: see the false-negative note in the
+// module docs.
+const PANIC_SINKS: &[&str] = &[
+    "4core9panicking",
+    "3std9panicking",
+    "4core6option13unwrap_failed",
+    "4core6option13expect_failed",
+    "4core6result13unwrap_failed",
+    "4core6result13expect_failed",
+];
+
 fn is_panic_entrypoint(symbol: &str) -> bool {
-    symbol.contains("9panicking")
+    PANIC_SINKS.iter().any(|sink| symbol.contains(sink))
+}
+
+// A function symbol is the unit's own code if it carries the crate's mangled
+// token, or if it is not Rust-mangled at all: an `#[unsafe(no_mangle)]` export
+// keeps a plain C name with no crate token, yet it is still defined in this
+// crate's object, so excluding it would hide panics in FFI entrypoints.
+fn belongs_to_crate(function: &str, crate_token: &str) -> bool {
+    function.contains(crate_token) || !is_rust_mangled(function)
+}
+
+fn is_rust_mangled(symbol: &str) -> bool {
+    let stripped = symbol
+        .strip_prefix("__")
+        .or_else(|| symbol.strip_prefix('_'))
+        .unwrap_or(symbol);
+    stripped.starts_with("ZN") || stripped.starts_with('R')
 }
 
 /// Collects `*.rlib` artifacts under each input path. A path that is itself a
@@ -200,10 +251,10 @@ mod tests {
         SymbolKind, SymbolScope,
     };
 
-    // Builds a relocatable ELF object with one text function `func_bytes` long.
-    // When `panic` is set, a relocation at offset 4 targets an undefined
-    // `core::panicking` symbol, modelling a panic call inside the function.
-    fn object_with_function(function: &str, panic: bool) -> Vec<u8> {
+    // Builds a relocatable ELF object with one 16-byte text function. When
+    // `callee` is set, a relocation at offset 4 targets that undefined symbol,
+    // modelling a call from the function into the named callee.
+    fn object_calling(function: &str, callee: Option<&str>) -> Vec<u8> {
         let mut object = Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
         let text = object.section_id(StandardSection::Text);
         object.append_section_data(text, &[0u8; 16], 1);
@@ -217,9 +268,9 @@ mod tests {
             section: WriteSection::Section(text),
             flags: SymbolFlags::None,
         });
-        if panic {
-            let panic_symbol = object.add_symbol(Symbol {
-                name: b"_ZN4core9panicking18panic_bounds_check17hababababababababE".to_vec(),
+        if let Some(callee) = callee {
+            let target = object.add_symbol(Symbol {
+                name: callee.as_bytes().to_vec(),
                 value: 0,
                 size: 0,
                 kind: SymbolKind::Text,
@@ -233,7 +284,7 @@ mod tests {
                     text,
                     Relocation {
                         offset: 4,
-                        symbol: panic_symbol,
+                        symbol: target,
                         addend: 0,
                         flags: RelocationFlags::Generic {
                             kind: RelocationKind::PltRelative,
@@ -242,9 +293,14 @@ mod tests {
                         },
                     },
                 )
-                .expect("add panic relocation");
+                .expect("add relocation");
         }
         object.write().expect("serialize fixture object")
+    }
+
+    fn object_with_function(function: &str, panic: bool) -> Vec<u8> {
+        let callee = panic.then_some("_ZN4core9panicking18panic_bounds_check17hababababababababE");
+        object_calling(function, callee)
     }
 
     fn scan(data: &[u8], crate_token: Option<&str>) -> Vec<PanicFinding> {
@@ -281,5 +337,38 @@ mod tests {
     fn crate_token_normalizes_dashes() {
         assert_eq!(crate_token("n-hello"), "7n_hello");
         assert_eq!(crate_token("serde"), "5serde");
+    }
+
+    #[test]
+    fn flags_unwrap_and_expect_cold_paths() {
+        // unwrap/expect reach a panic through the *_failed helpers, not
+        // core::panicking directly, so the catalog must catch them.
+        for callee in [
+            "_ZN4core6option13unwrap_failed17habcdefgEhh",
+            "_ZN4core6result13unwrap_failed17habcdefgEhh",
+            "_ZN4core6option13expect_failed17habcdefgEhh",
+        ] {
+            let bytes = object_calling("_ZN7n_hello3run17habcdefgEhh", Some(callee));
+            assert_eq!(scan(&bytes, None).len(), 1, "missed cold path {callee}");
+        }
+    }
+
+    #[test]
+    fn user_panicking_module_is_not_a_panic_sink() {
+        // A crate's own `panicking` module mangles with its crate prefix, not
+        // `4core` / `3std`, so calling it must not trip the gate.
+        let bytes = object_calling(
+            "_ZN7n_hello3run17habcdefgEhh",
+            Some("_ZN7n_hello9panicking6record17habcdefgEhh"),
+        );
+        assert!(scan(&bytes, None).is_empty());
+    }
+
+    #[test]
+    fn unmangled_export_is_scanned_under_crate_filter() {
+        // An `#[unsafe(no_mangle)]` export carries no crate token; scoping to a
+        // crate must still scan it, since it is defined in this crate's object.
+        let bytes = object_calling("ffi_entry", Some("_ZN4core9panicking5panic17habcdefgEhh"));
+        assert_eq!(scan(&bytes, Some(&crate_token("n-hello"))).len(), 1);
     }
 }

--- a/packages/nix-cargo-unit/src/panic_scan.rs
+++ b/packages/nix-cargo-unit/src/panic_scan.rs
@@ -8,20 +8,24 @@
 //! containing function without disassembling instructions, so the same logic
 //! covers ELF and Mach-O.
 //!
-//! This operates on relocatable objects, which is why it targets library rlibs:
-//! a fully linked binary has its panic calls resolved to direct branches with
-//! no relocation left to read, and recovering them needs disassembly. Scanning
-//! linked bin/test units is deliberately out of scope here.
+//! This operates on relocatable objects (the `--emit obj` output of each unit),
+//! not on linked binaries: a linked binary resolves its panic calls to direct
+//! branches with no relocation left to read, which would need disassembly.
+//! Generic functions are codegened where they are monomorphized, so a generic
+//! that carries no relocation in its defining library's objects does carry one
+//! in the bin or test object that instantiates it. Scanning every unit's
+//! objects and scoping findings to the workspace crate set therefore attributes
+//! a monomorphized library generic back to its defining crate.
 //!
 //! This is a best-effort detector, not a soundness proof. A clean result means
-//! "no detected panic call from this crate's monomorphic code," not "cannot
-//! panic." Two classes slip through by construction:
+//! "no detected panic call from workspace code reachable through the scanned
+//! units," not "cannot panic." Two classes slip through by construction:
 //!
-//! - Uninstantiated generics. A generic function is stored as metadata in the
-//!   defining rlib and only codegened where a downstream crate monomorphizes
-//!   it, so `pub fn first<T>(xs: &[T]) -> &T { &xs[0] }` carries no relocation
-//!   here even though it can panic. Catching it requires analysis at the linked
-//!   binary where the instantiation lives.
+//! - Generics no workspace unit instantiates. A public generic that no bin,
+//!   test, or bench in the workspace ever monomorphizes is never codegened, so
+//!   it carries no relocation anywhere here. It is also not reachable from the
+//!   workspace's own entrypoints, but an external downstream consumer could
+//!   still hit a panic in it.
 //! - Panics through uncatalogued helpers. [`PANIC_SINKS`] lists the common std
 //!   sinks (`core::panicking`, `unwrap_failed`, `expect_failed`); a panic that
 //!   routes through some other std/alloc cold path is missed until its symbol
@@ -50,15 +54,19 @@ pub struct PanicFinding {
 
 /// Scans every artifact path for functions that reach panic machinery.
 ///
-/// When `crate_token` is `Some`, only functions whose mangled symbol carries
-/// that crate's length-prefixed name component are reported, so the gate covers
-/// the unit's own code rather than monomorphized helpers from its dependencies.
-pub fn scan_paths(paths: &[PathBuf], crate_token: Option<&str>) -> Result<Vec<PanicFinding>> {
+/// When `crate_tokens` is non-empty, a finding is kept only if the function's
+/// mangled symbol carries one of those crate tokens, or if it is unmangled (an
+/// FFI export defined here). This is the set of workspace crate tokens, so a
+/// library generic monomorphized inside a bin or test object is attributed to
+/// its defining workspace crate and caught, while third-party and std
+/// instantiations in the same object are ignored. An empty slice disables the
+/// filter and reports every panic-reaching function.
+pub fn scan_paths(paths: &[PathBuf], crate_tokens: &[String]) -> Result<Vec<PanicFinding>> {
     let mut findings = BTreeSet::new();
     for path in paths {
         let data = fs::read(path)
             .wrap_err_with(|| format!("reading artifact {} for panic scan", path.display()))?;
-        scan_bytes(&data, crate_token, &mut findings)
+        scan_bytes(&data, crate_tokens, &mut findings)
             .wrap_err_with(|| format!("scanning artifact {} for panic calls", path.display()))?;
     }
     Ok(findings.into_iter().collect())
@@ -73,7 +81,7 @@ pub fn crate_token(crate_name: &str) -> String {
 
 fn scan_bytes(
     data: &[u8],
-    crate_token: Option<&str>,
+    crate_tokens: &[String],
     findings: &mut BTreeSet<PanicFinding>,
 ) -> Result<()> {
     // An rlib is an `ar` archive of object members; a bare `.o` is parsed
@@ -84,11 +92,11 @@ fn scan_bytes(
             let member = member.wrap_err("reading rlib archive member")?;
             let member_data = member.data(data).wrap_err("reading rlib member data")?;
             if let Ok(object) = object::File::parse(member_data) {
-                scan_object(&object, crate_token, findings);
+                scan_object(&object, crate_tokens, findings);
             }
         }
     } else if let Ok(object) = object::File::parse(data) {
-        scan_object(&object, crate_token, findings);
+        scan_object(&object, crate_tokens, findings);
     }
     Ok(())
 }
@@ -101,7 +109,7 @@ struct FunctionRange {
 
 fn scan_object(
     object: &object::File,
-    crate_token: Option<&str>,
+    crate_tokens: &[String],
     findings: &mut BTreeSet<PanicFinding>,
 ) {
     for section in object.sections() {
@@ -120,7 +128,7 @@ fn scan_object(
                 continue;
             }
             if let Some(function) = containing_function(&functions, offset)
-                && crate_token.is_none_or(|token| belongs_to_crate(&function.name, token))
+                && belongs_to_workspace(&function.name, crate_tokens)
             {
                 findings.insert(PanicFinding {
                     function: function.name.clone(),
@@ -191,12 +199,15 @@ fn is_panic_entrypoint(symbol: &str) -> bool {
     PANIC_SINKS.iter().any(|sink| symbol.contains(sink))
 }
 
-// A function symbol is the unit's own code if it carries the crate's mangled
-// token, or if it is not Rust-mangled at all: an `#[unsafe(no_mangle)]` export
-// keeps a plain C name with no crate token, yet it is still defined in this
-// crate's object, so excluding it would hide panics in FFI entrypoints.
-fn belongs_to_crate(function: &str, crate_token: &str) -> bool {
-    function.contains(crate_token) || !is_rust_mangled(function)
+// A function belongs to the workspace if its mangled symbol carries one of the
+// workspace crate tokens, or if it is not Rust-mangled at all: an
+// `#[unsafe(no_mangle)]` export keeps a plain C name with no crate token, yet it
+// is still defined in this crate's object, so excluding it would hide panics in
+// FFI entrypoints. An empty token slice disables filtering.
+fn belongs_to_workspace(function: &str, crate_tokens: &[String]) -> bool {
+    crate_tokens.is_empty()
+        || !is_rust_mangled(function)
+        || crate_tokens.iter().any(|token| function.contains(token))
 }
 
 fn is_rust_mangled(symbol: &str) -> bool {
@@ -207,22 +218,23 @@ fn is_rust_mangled(symbol: &str) -> bool {
     stripped.starts_with("ZN") || stripped.starts_with('R')
 }
 
-/// Collects `*.rlib` artifacts under each input path. A path that is itself a
-/// file is taken as-is so callers can pass exact artifacts.
-pub fn collect_rlibs(roots: &[PathBuf]) -> Result<Vec<PathBuf>> {
-    let mut rlibs = Vec::new();
+/// Collects scannable artifacts (`*.rlib` archives and `*.o` objects) under each
+/// input path. A path that is itself a file is taken as-is so callers can pass
+/// exact artifacts.
+pub fn collect_artifacts(roots: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let mut artifacts = Vec::new();
     for root in roots {
-        collect_rlibs_into(root, &mut rlibs)?;
+        collect_artifacts_into(root, &mut artifacts)?;
     }
-    rlibs.sort();
-    Ok(rlibs)
+    artifacts.sort();
+    Ok(artifacts)
 }
 
-fn collect_rlibs_into(root: &Path, rlibs: &mut Vec<PathBuf>) -> Result<()> {
+fn collect_artifacts_into(root: &Path, artifacts: &mut Vec<PathBuf>) -> Result<()> {
     let metadata = fs::symlink_metadata(root)
         .wrap_err_with(|| format!("inspecting panic-scan path {}", root.display()))?;
     if metadata.is_file() {
-        rlibs.push(root.to_path_buf());
+        artifacts.push(root.to_path_buf());
         return Ok(());
     }
     if metadata.is_dir() {
@@ -232,8 +244,12 @@ fn collect_rlibs_into(root: &Path, rlibs: &mut Vec<PathBuf>) -> Result<()> {
             let entry =
                 entry.wrap_err_with(|| format!("reading entry under {}", root.display()))?;
             let path = entry.path();
-            if path.is_dir() || path.extension().is_some_and(|ext| ext == "rlib") {
-                collect_rlibs_into(&path, rlibs)?;
+            if path.is_dir()
+                || path
+                    .extension()
+                    .is_some_and(|ext| ext == "rlib" || ext == "o")
+            {
+                collect_artifacts_into(&path, artifacts)?;
             }
         }
     }
@@ -303,16 +319,19 @@ mod tests {
         object_calling(function, callee)
     }
 
-    fn scan(data: &[u8], crate_token: Option<&str>) -> Vec<PanicFinding> {
+    // Scans with the given crate names as the workspace filter (empty = no
+    // filter), mirroring how the renderer passes the workspace crate set.
+    fn scan(data: &[u8], crate_names: &[&str]) -> Vec<PanicFinding> {
+        let tokens: Vec<String> = crate_names.iter().map(|name| crate_token(name)).collect();
         let mut findings = BTreeSet::new();
-        scan_bytes(data, crate_token, &mut findings).expect("scan fixture");
+        scan_bytes(data, &tokens, &mut findings).expect("scan fixture");
         findings.into_iter().collect()
     }
 
     #[test]
     fn flags_function_that_calls_panic_entrypoint() {
         let bytes = object_with_function("_ZN7n_hello3get17habcdefgEhh", true);
-        let findings = scan(&bytes, None);
+        let findings = scan(&bytes, &[]);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].function, "_ZN7n_hello3get17habcdefgEhh");
         assert!(findings[0].panic_entrypoint.contains("panic_bounds_check"));
@@ -321,16 +340,29 @@ mod tests {
     #[test]
     fn clean_function_produces_no_findings() {
         let bytes = object_with_function("_ZN7n_hello5clean17habcdefgEhh", false);
-        assert!(scan(&bytes, None).is_empty());
+        assert!(scan(&bytes, &[]).is_empty());
     }
 
     #[test]
-    fn crate_filter_excludes_foreign_functions() {
-        // A panic call lives in a `serde`-named function. Scoping the scan to
-        // the `n_hello` crate token must drop it; the matching token keeps it.
+    fn workspace_filter_excludes_foreign_functions() {
+        // A panic call lives in a `serde`-named function. A workspace set that
+        // does not include serde must drop it; one that does keeps it.
         let bytes = object_with_function("_ZN5serde2de17habcdefgEhh", true);
-        assert!(scan(&bytes, Some(&crate_token("n-hello"))).is_empty());
-        assert_eq!(scan(&bytes, Some(&crate_token("serde"))).len(), 1);
+        assert!(scan(&bytes, &["n-hello"]).is_empty());
+        assert_eq!(scan(&bytes, &["serde"]).len(), 1);
+    }
+
+    #[test]
+    fn workspace_set_catches_library_generic_in_consumer_object() {
+        // A library generic monomorphized in a consumer object keeps the
+        // library's crate token. Scanning the consumer with only the consumer
+        // crate misses it; the full workspace set catches it.
+        let bytes = object_calling(
+            "_ZN6thelib5first17habcdefgEhh",
+            Some("_ZN4core9panicking18panic_bounds_check17habcdefgEhh"),
+        );
+        assert!(scan(&bytes, &["app"]).is_empty());
+        assert_eq!(scan(&bytes, &["app", "thelib"]).len(), 1);
     }
 
     #[test]
@@ -349,7 +381,7 @@ mod tests {
             "_ZN4core6option13expect_failed17habcdefgEhh",
         ] {
             let bytes = object_calling("_ZN7n_hello3run17habcdefgEhh", Some(callee));
-            assert_eq!(scan(&bytes, None).len(), 1, "missed cold path {callee}");
+            assert_eq!(scan(&bytes, &[]).len(), 1, "missed cold path {callee}");
         }
     }
 
@@ -361,14 +393,14 @@ mod tests {
             "_ZN7n_hello3run17habcdefgEhh",
             Some("_ZN7n_hello9panicking6record17habcdefgEhh"),
         );
-        assert!(scan(&bytes, None).is_empty());
+        assert!(scan(&bytes, &[]).is_empty());
     }
 
     #[test]
-    fn unmangled_export_is_scanned_under_crate_filter() {
-        // An `#[unsafe(no_mangle)]` export carries no crate token; scoping to a
-        // crate must still scan it, since it is defined in this crate's object.
+    fn unmangled_export_is_scanned_under_workspace_filter() {
+        // An `#[unsafe(no_mangle)]` export carries no crate token; a workspace
+        // filter must still scan it, since it is defined in this crate's object.
         let bytes = object_calling("ffi_entry", Some("_ZN4core9panicking5panic17habcdefgEhh"));
-        assert_eq!(scan(&bytes, Some(&crate_token("n-hello"))).len(), 1);
+        assert_eq!(scan(&bytes, &["n-hello"]).len(), 1);
     }
 }

--- a/packages/nix-cargo-unit/src/panic_scan.rs
+++ b/packages/nix-cargo-unit/src/panic_scan.rs
@@ -91,14 +91,28 @@ fn scan_bytes(
         for member in archive.members() {
             let member = member.wrap_err("reading rlib archive member")?;
             let member_data = member.data(data).wrap_err("reading rlib member data")?;
-            if let Ok(object) = object::File::parse(member_data) {
+            // Archives carry non-object members (rmeta, symbol index); those are
+            // not objects and are skipped, but a member that claims to be an
+            // object and fails to parse is a real error.
+            if is_object_member(member.name()) {
+                let object = object::File::parse(member_data)
+                    .wrap_err("parsing rlib object member for panic scan")?;
                 scan_object(&object, crate_tokens, findings);
             }
         }
-    } else if let Ok(object) = object::File::parse(data) {
-        scan_object(&object, crate_tokens, findings);
+        return Ok(());
     }
+    // A collected artifact that is neither an archive nor a parseable object is
+    // a corrupt or unsupported input. Fail closed: the panic gate must not pass
+    // just because it could not read what it was handed.
+    let object = object::File::parse(data)
+        .wrap_err("artifact is neither an rlib archive nor a parseable object")?;
+    scan_object(&object, crate_tokens, findings);
     Ok(())
+}
+
+fn is_object_member(name: &[u8]) -> bool {
+    name.ends_with(b".o") || name.ends_with(b".rcgu.o")
 }
 
 struct FunctionRange {
@@ -174,11 +188,9 @@ fn containing_function(functions: &[FunctionRange], offset: u64) -> Option<&Func
         .find(|function| offset >= function.start && offset < function.end)
 }
 
-// Curated set of std panic sinks, matched as length-prefixed path fragments so
-// the same needles hit legacy (`_ZN4core9panicking...`) and v0
-// (`_RNvNt...4core9panicking...`) mangling and ignore the Mach-O leading
-// underscore. Requiring the `4core` / `3std` prefix avoids matching an
-// unrelated user module literally named `panicking`.
+// Curated set of std panic sinks, matched as length-prefixed path fragments
+// rooted at the `core` / `std` crate so the same needles hit legacy
+// (`_ZN4core9panicking...`) and v0 (`_RNvNt...4core9panicking...`) mangling.
 //
 // `core::panicking::*` is the leaf for `panic!`, formatting panics, bounds
 // checks, overflow, and asserts. `unwrap`/`expect` reach a panic through the
@@ -196,7 +208,21 @@ const PANIC_SINKS: &[&str] = &[
 ];
 
 fn is_panic_entrypoint(symbol: &str) -> bool {
-    PANIC_SINKS.iter().any(|sink| symbol.contains(sink))
+    PANIC_SINKS
+        .iter()
+        .any(|sink| at_crate_boundary(symbol, sink))
+}
+
+// `core` / `std` only count as a panic sink when they are the crate root, not a
+// nested user module. In v0 mangling the crate name follows the `Cs<id>_`
+// disambiguator, so it is preceded by `_`; in legacy mangling the crate is the
+// first path component after `_ZN`. A user path like `crate::core::panicking`
+// puts `4core` after a crate-name character instead, so it never matches.
+fn at_crate_boundary(symbol: &str, sink: &str) -> bool {
+    symbol.match_indices(sink).any(|(index, _)| {
+        let prefix = &symbol[..index];
+        prefix.ends_with('_') || prefix.ends_with("ZN")
+    })
 }
 
 // A function belongs to the workspace if its mangled symbol carries one of the
@@ -394,6 +420,24 @@ mod tests {
             Some("_ZN7n_hello9panicking6record17habcdefgEhh"),
         );
         assert!(scan(&bytes, &[]).is_empty());
+    }
+
+    #[test]
+    fn nested_user_core_module_is_not_a_panic_sink() {
+        // `crate::core::panicking::helper` mangles with the user crate as root,
+        // so `4core` sits after a crate-name character, not the crate boundary.
+        let bytes = object_calling(
+            "_ZN7n_hello3run17habcdefgEhh",
+            Some("_ZN7n_hello4core9panicking6helper17habcdefgEhh"),
+        );
+        assert!(scan(&bytes, &[]).is_empty());
+    }
+
+    #[test]
+    fn unparseable_artifact_is_an_error() {
+        // Fail closed: a corrupt or unsupported artifact must not scan as clean.
+        let mut findings = BTreeSet::new();
+        assert!(scan_bytes(b"not an object or archive", &[], &mut findings).is_err());
     }
 
     #[test]

--- a/packages/nix-cargo-unit/src/panic_scan.rs
+++ b/packages/nix-cargo-unit/src/panic_scan.rs
@@ -13,19 +13,20 @@
 //! branches with no relocation left to read, which would need disassembly.
 //! Generic functions are codegened where they are monomorphized, so a generic
 //! that carries no relocation in its defining library's objects does carry one
-//! in the bin or test object that instantiates it. Scanning every unit's
+//! in the bin object that instantiates it. Scanning every production unit's
 //! objects and scoping findings to the workspace crate set therefore attributes
-//! a monomorphized library generic back to its defining crate.
+//! a monomorphized library generic back to its defining crate. Test and bench
+//! units are not scanned: their bodies legitimately panic.
 //!
 //! This is a best-effort detector, not a soundness proof. A clean result means
 //! "no detected panic call from workspace code reachable through the scanned
 //! units," not "cannot panic." Two classes slip through by construction:
 //!
-//! - Generics no workspace unit instantiates. A public generic that no bin,
-//!   test, or bench in the workspace ever monomorphizes is never codegened, so
-//!   it carries no relocation anywhere here. It is also not reachable from the
-//!   workspace's own entrypoints, but an external downstream consumer could
-//!   still hit a panic in it.
+//! - Generics no production unit instantiates. A public generic that no bin in
+//!   the workspace ever monomorphizes is never codegened, so it carries no
+//!   relocation anywhere here. It is also not reachable from the workspace's own
+//!   production entrypoints, but an external downstream consumer could still hit
+//!   a panic in it.
 //! - Panics through uncatalogued helpers. [`PANIC_SINKS`] lists the common std
 //!   sinks (`core::panicking`, `unwrap_failed`, `expect_failed`); a panic that
 //!   routes through some other std/alloc cold path is missed until its symbol

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -418,23 +418,28 @@ fn render_policy_check_entries(
     Ok(entries)
 }
 
-// Units the panic-freedom scan inspects. Every workspace Rust compile is a
-// candidate (lib, bin, test, bench): each contributes a panic-objects
-// derivation whose monomorphized objects the scan reads. Build-script runs have
-// no compile of their own, external crates compile under `--cap-lints warn` and
-// are not the workspace's invariant to hold, and proc-macro / custom-build
-// compile units are host build tooling rather than the shipped surface.
+// Production units the panic-freedom scan inspects: workspace lib and bin
+// compiles, each contributing a panic-objects derivation whose monomorphized
+// objects the scan reads. Test and bench bodies legitimately panic (`assert!`,
+// `unwrap`, explicit `panic!`), so they are excluded; a library generic that
+// only a test instantiates is consequently not covered, which is correct because
+// it is not on a production code path. Build-script runs have no compile of their
+// own, external crates compile under `--cap-lints warn` and are not the
+// workspace's invariant to hold, and proc-macro / custom-build compile units are
+// host build tooling rather than the shipped surface.
 fn is_panic_freedom_candidate(unit: &Unit) -> bool {
     !unit.is_external()
         && !unit.is_proc_macro()
         && !unit.is_run_custom_build()
         && !unit.is_custom_build_compile()
+        && !unit.is_test()
+        && !unit.is_benchmark()
 }
 
 // Every workspace crate name that can appear as a mangled symbol prefix, used to
-// scope findings. A library generic monomorphized inside a bin or test object
-// keeps the library's crate token, so the scan needs the whole set, not just the
-// unit under inspection.
+// scope findings. A library generic monomorphized inside a bin object keeps the
+// library's crate token, so the scan needs the whole set, not just the unit
+// under inspection.
 fn workspace_crate_names(graph: &UnitGraph) -> Vec<String> {
     let mut names: BTreeSet<String> = BTreeSet::new();
     for unit in &graph.units {
@@ -3163,6 +3168,68 @@ mod tests {
         let unchecked = render_units_nix(&graph, &options(false)).unwrap();
         assert!(!unchecked.contains("panicFreedom"));
         assert!(!unchecked.contains("panic-objects"));
+    }
+
+    #[test]
+    fn deny_panics_skips_test_units() {
+        // Test bodies legitimately panic, so a test target must not become a
+        // panic-objects candidate even though it is workspace-owned.
+        let graph: UnitGraph = serde_json::from_str(
+            r#"{
+              "version": 1,
+              "units": [
+                {
+                  "pkg_id": "path+file:///workspace#hello@0.1.0",
+                  "target": {
+                    "kind": ["lib"],
+                    "crate_types": ["lib"],
+                    "name": "hello",
+                    "src_path": "/workspace/src/lib.rs",
+                    "edition": "2024"
+                  },
+                  "profile": { "name": "release", "opt_level": "3" },
+                  "features": [],
+                  "mode": "build",
+                  "dependencies": []
+                },
+                {
+                  "pkg_id": "path+file:///workspace#hello@0.1.0",
+                  "target": {
+                    "kind": ["test"],
+                    "crate_types": ["bin"],
+                    "name": "helloit",
+                    "src_path": "/workspace/tests/it.rs",
+                    "edition": "2024",
+                    "test": true
+                  },
+                  "profile": { "name": "test", "opt_level": "0" },
+                  "features": [],
+                  "mode": "test",
+                  "dependencies": []
+                }
+              ],
+              "roots": [0, 1]
+            }"#,
+        )
+        .unwrap();
+
+        let rendered = render_units_nix(
+            &graph,
+            &RenderOptions {
+                workspace_root: PathBuf::from("/workspace"),
+                vendor_root: None,
+                cargo_lock_sources: CargoLockSources::default(),
+                content_addressed: false,
+                toolchain_id: None,
+                deny_unused_crate_dependencies: false,
+                deny_panics: true,
+            },
+        )
+        .unwrap();
+
+        assert!(rendered.contains("pname = \"hello-panic-objects\""));
+        assert!(!rendered.contains("helloit-panic-objects"));
+        assert!(!rendered.contains("(scanUnit \"helloit-"));
     }
 
     #[test]

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -396,16 +396,25 @@ fn render_policy_check_entries(
 // Library units the panic-freedom scan inspects. The scan is relocation-based,
 // so it needs the relocatable objects inside an rlib: a linked bin/test has its
 // panic calls resolved to direct branches with no relocation left to read, and
-// recovering those needs disassembly (tracked as follow-up). Build-script runs
-// have no artifact of their own, external crates compile under `--cap-lints
-// warn` and are not the workspace's invariant to hold, and proc-macro /
-// custom-build-compile units are host build tooling, not the shipped surface.
+// recovering those needs disassembly (tracked as follow-up). The candidate must
+// actually emit an rlib, so a `cdylib` / `staticlib` / `dylib` library unit is
+// excluded rather than passing the gate against an artifact the scanner cannot
+// read. Build-script runs have no artifact of their own, external crates compile
+// under `--cap-lints warn` and are not the workspace's invariant to hold, and
+// proc-macro / custom-build-compile units are host build tooling.
 fn is_panic_freedom_candidate(unit: &Unit) -> bool {
-    unit.is_library()
+    produces_rlib(unit)
         && !unit.is_external()
         && !unit.is_proc_macro()
         && !unit.is_run_custom_build()
         && !unit.is_custom_build_compile()
+}
+
+fn produces_rlib(unit: &Unit) -> bool {
+    unit.target
+        .crate_types
+        .iter()
+        .any(|crate_type| matches!(crate_type.as_str(), "lib" | "rlib"))
 }
 
 // Renders one panic-freedom derivation per library unit, joined under a single

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -267,6 +267,7 @@ struct UnitsNixTemplate {
     source_audit_entries: String,
     unit_entries: String,
     clippy_unit_entries: String,
+    panic_object_unit_entries: String,
     policy_check_entries: String,
     roots: String,
     checked_roots: String,
@@ -291,6 +292,7 @@ pub fn render_units_nix(graph: &UnitGraph, options: &RenderOptions) -> Result<St
         source_audit_entries: render_source_audit_entries(&prepared),
         unit_entries: render_unit_entries(graph, options, &prepared)?,
         clippy_unit_entries: render_clippy_unit_entries(graph, options, &prepared)?,
+        panic_object_unit_entries: render_panic_object_unit_entries(graph, options, &prepared)?,
         policy_check_entries: render_policy_check_entries(graph, options, &prepared)?,
         roots: render_roots(graph, &prepared),
         checked_roots: render_checked_roots(graph, &prepared),
@@ -371,6 +373,29 @@ fn is_clippy_unit_candidate(unit: &Unit) -> bool {
     !unit.is_run_custom_build() && !unit.is_external()
 }
 
+fn render_panic_object_unit_entries(
+    graph: &UnitGraph,
+    options: &RenderOptions,
+    prepared: &PreparedGraph,
+) -> Result<String> {
+    let mut entries = String::new();
+    if !options.deny_panics {
+        return Ok(entries);
+    }
+    for (index, unit) in graph.units.iter().enumerate() {
+        if !is_panic_freedom_candidate(unit) {
+            continue;
+        }
+        write!(
+            entries,
+            "    {} = mkUnit {};\n\n",
+            prepared.unit_attr(index),
+            render_panic_object_unit(graph, options, prepared, index)?
+        )?;
+    }
+    Ok(entries)
+}
+
 fn render_policy_check_entries(
     graph: &UnitGraph,
     options: &RenderOptions,
@@ -393,35 +418,38 @@ fn render_policy_check_entries(
     Ok(entries)
 }
 
-// Library units the panic-freedom scan inspects. The scan is relocation-based,
-// so it needs the relocatable objects inside an rlib: a linked bin/test has its
-// panic calls resolved to direct branches with no relocation left to read, and
-// recovering those needs disassembly (tracked as follow-up). The candidate must
-// actually emit an rlib, so a `cdylib` / `staticlib` / `dylib` library unit is
-// excluded rather than passing the gate against an artifact the scanner cannot
-// read. Build-script runs have no artifact of their own, external crates compile
-// under `--cap-lints warn` and are not the workspace's invariant to hold, and
-// proc-macro / custom-build-compile units are host build tooling.
+// Units the panic-freedom scan inspects. Every workspace Rust compile is a
+// candidate (lib, bin, test, bench): each contributes a panic-objects
+// derivation whose monomorphized objects the scan reads. Build-script runs have
+// no compile of their own, external crates compile under `--cap-lints warn` and
+// are not the workspace's invariant to hold, and proc-macro / custom-build
+// compile units are host build tooling rather than the shipped surface.
 fn is_panic_freedom_candidate(unit: &Unit) -> bool {
-    produces_rlib(unit)
-        && !unit.is_external()
+    !unit.is_external()
         && !unit.is_proc_macro()
         && !unit.is_run_custom_build()
         && !unit.is_custom_build_compile()
 }
 
-fn produces_rlib(unit: &Unit) -> bool {
-    unit.target
-        .crate_types
-        .iter()
-        .any(|crate_type| matches!(crate_type.as_str(), "lib" | "rlib"))
+// Every workspace crate name that can appear as a mangled symbol prefix, used to
+// scope findings. A library generic monomorphized inside a bin or test object
+// keeps the library's crate token, so the scan needs the whole set, not just the
+// unit under inspection.
+fn workspace_crate_names(graph: &UnitGraph) -> Vec<String> {
+    let mut names: BTreeSet<String> = BTreeSet::new();
+    for unit in &graph.units {
+        if !unit.is_external() && !unit.is_run_custom_build() {
+            names.insert(unit.target.name.clone());
+        }
+    }
+    names.into_iter().collect()
 }
 
-// Renders one panic-freedom derivation per library unit, joined under a single
+// Renders one panic-freedom derivation per candidate unit, joined under a single
 // aggregate so a touched unit only re-scans itself. Each scan runs
-// `nix-cargo-unit scan-panics` over the unit's rlib, scoped to the unit's own
-// crate, and fails if any of the crate's functions reference a
-// `core::panicking` entrypoint. The scanner is the `cargoUnit` package, asserted
+// `nix-cargo-unit scan-panics` over the unit's panic-objects derivation, scoped
+// to the whole workspace crate set, and fails if any workspace function
+// references a panic sink. The scanner is the `cargoUnit` package, asserted
 // non-null so enabling the policy without wiring the scanner fails loudly rather
 // than silently passing.
 fn render_panic_freedom_check(graph: &UnitGraph, prepared: &PreparedGraph) -> Option<String> {
@@ -432,10 +460,9 @@ fn render_panic_freedom_check(graph: &UnitGraph, prepared: &PreparedGraph) -> Op
         }
         let _ = writeln!(
             scans,
-            "          (scanUnit {} {} {})",
+            "          (scanUnit {} panicObjectUnits.{})",
             nix_attr(&prepared.names[index]),
-            nix_attr(&unit.target.name),
-            prepared.unit_ref(index),
+            prepared.unit_attr(index),
         );
     }
 
@@ -443,15 +470,22 @@ fn render_panic_freedom_check(graph: &UnitGraph, prepared: &PreparedGraph) -> Op
         return None;
     }
 
+    let mut scan_args: Vec<String> = Vec::new();
+    for name in workspace_crate_names(graph) {
+        scan_args.push("--crate-name".to_string());
+        scan_args.push(name);
+    }
+    let scan_args_nix = nix_string_list(&scan_args);
+
     Some(format!(
         r#"assert pkgs.lib.assertMsg (cargoUnit != null) "cargo-unit panic-freedom needs the cargoUnit scanner package; pass it through buildWorkspace.";
       let
-        scanUnit = drvName: crateName: unit:
+        scanUnit = drvName: objects:
           pkgs.runCommand "cargo-unit-panic-freedom-${{drvName}}"
             {{ nativeBuildInputs = [ cargoUnit ]; }}
             ''
               set -euo pipefail
-              nix-cargo-unit scan-panics --crate-name ${{pkgs.lib.escapeShellArg crateName}} "${{unit}}"
+              nix-cargo-unit scan-panics ${{pkgs.lib.escapeShellArgs {scan_args_nix}}} "${{objects}}"
               mkdir -p "$out"
             '';
       in
@@ -673,19 +707,23 @@ fn collect_transitive_unit_deps(
 }
 
 // `Rustc` produces the build artifacts (rlib, bin, test binary).
-// `ClippyDriver` runs the same compilation through `clippy-driver` so lints
+// `Clippy` runs the same compilation through `clippy-driver` so lints
 // fire per unit, emitting metadata only — no link step, no binary output.
+// `ObjectEmit` runs `rustc` with the same flags but emits relocatable objects
+// only (`--emit obj`, no link), giving the panic-freedom scan the monomorphized
+// objects a linked binary would otherwise hide behind resolved branches.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Driver {
     Rustc,
-    ClippyDriver,
+    Clippy,
+    ObjectEmit,
 }
 
 impl Driver {
     const fn binary(self) -> &'static str {
         match self {
-            Self::Rustc => "rustc",
-            Self::ClippyDriver => "clippy-driver",
+            Self::Rustc | Self::ObjectEmit => "rustc",
+            Self::Clippy => "clippy-driver",
         }
     }
 }
@@ -702,23 +740,37 @@ fn append_content_addressing(attrs: &mut Attrs, content_addressed: bool) {
     attrs.string("outputHashAlgo", "sha256");
 }
 
-fn render_rustc_unit(
+// The per-unit derivation fields that vary by role; everything else (version,
+// source, dependency rlibs, `dontStrip`, content addressing) is shared.
+struct UnitDerivation<'a> {
+    pname: String,
+    native_build_inputs: &'a str,
+    driver: Driver,
+    install_phase: String,
+}
+
+// Shared scaffold for the build, clippy, and panic-object derivations. They
+// compile the same unit source against the same dependency rlibs and differ only
+// in name, the driver/emit, the extra native inputs, and how the result is
+// installed.
+fn render_unit_derivation(
     graph: &UnitGraph,
     options: &RenderOptions,
     prepared: &PreparedGraph,
     index: usize,
+    spec: UnitDerivation<'_>,
 ) -> Result<String> {
-    let unit = &graph.units[index];
+    let UnitDerivation {
+        pname,
+        native_build_inputs,
+        driver,
+        install_phase,
+    } = spec;
     let mut attrs = Attrs::new();
 
-    attrs.string("pname", &unit.target.name);
-    attrs.string("version", unit.package_version());
+    attrs.string("pname", &pname);
+    attrs.string("version", graph.units[index].package_version());
     attrs.expr("src", &prepared.source_ref(index));
-    let native_build_inputs = if collects_unused_crate_dependencies(unit, options) {
-        "[ rustToolchain pkgs.jq ] ++ extraNativeBuildInputs"
-    } else {
-        "[ rustToolchain ] ++ extraNativeBuildInputs"
-    };
     attrs.expr("nativeBuildInputs", native_build_inputs);
     attrs.expr(
         "buildInputs",
@@ -728,14 +780,37 @@ fn render_rustc_unit(
     append_content_addressing(&mut attrs, options.content_addressed);
     attrs.multiline(
         "buildPhase",
-        &render_driver_build_phase(graph, options, prepared, index, Driver::Rustc)?,
+        &render_driver_build_phase(graph, options, prepared, index, driver)?,
     );
-    attrs.multiline(
-        "installPhase",
-        &render_install_phase(unit, options, &prepared.hashes[index]),
-    );
+    attrs.multiline("installPhase", &install_phase);
 
     Ok(attrs.render())
+}
+
+fn render_rustc_unit(
+    graph: &UnitGraph,
+    options: &RenderOptions,
+    prepared: &PreparedGraph,
+    index: usize,
+) -> Result<String> {
+    let unit = &graph.units[index];
+    let native_build_inputs = if collects_unused_crate_dependencies(unit, options) {
+        "[ rustToolchain pkgs.jq ] ++ extraNativeBuildInputs"
+    } else {
+        "[ rustToolchain ] ++ extraNativeBuildInputs"
+    };
+    render_unit_derivation(
+        graph,
+        options,
+        prepared,
+        index,
+        UnitDerivation {
+            pname: unit.target.name.clone(),
+            native_build_inputs,
+            driver: Driver::Rustc,
+            install_phase: render_install_phase(unit, options, &prepared.hashes[index]),
+        },
+    )
 }
 
 fn render_clippy_unit(
@@ -744,36 +819,48 @@ fn render_clippy_unit(
     prepared: &PreparedGraph,
     index: usize,
 ) -> Result<String> {
-    let unit = &graph.units[index];
-    let mut attrs = Attrs::new();
-
-    attrs.string("pname", &format!("{}-clippy", unit.target.name));
-    attrs.string("version", unit.package_version());
-    attrs.expr("src", &prepared.source_ref(index));
     // `clippy-driver` rides the rustToolchain (which carries the matching
     // rustc); the clippy package only needs to be on PATH for the driver
-    // binary. Callers append it via `extraClippyNativeBuildInputs`.
-    attrs.expr(
-        "nativeBuildInputs",
-        "[ rustToolchain ] ++ extraNativeBuildInputs ++ extraClippyNativeBuildInputs",
-    );
-    // Clippy units link metadata-only against the build units' rlibs, just
-    // like the build units do. They never depend on other clippy units, so a
-    // touched source file only invalidates that unit's clippy plus everything
-    // downstream that links its rlib.
-    attrs.expr(
-        "buildInputs",
-        &render_build_inputs(graph, prepared, index, unit_build_script_run(graph, index)),
-    );
-    attrs.bool("dontStrip", true);
-    append_content_addressing(&mut attrs, options.content_addressed);
-    attrs.multiline(
-        "buildPhase",
-        &render_driver_build_phase(graph, options, prepared, index, Driver::ClippyDriver)?,
-    );
-    attrs.multiline("installPhase", "mkdir -p $out\n");
+    // binary. Callers append it via `extraClippyNativeBuildInputs`. Clippy units
+    // link metadata-only against the build units' rlibs, so a touched source
+    // file only invalidates that unit's clippy plus its downstream.
+    render_unit_derivation(
+        graph,
+        options,
+        prepared,
+        index,
+        UnitDerivation {
+            pname: format!("{}-clippy", graph.units[index].target.name),
+            native_build_inputs: "[ rustToolchain ] ++ extraNativeBuildInputs ++ extraClippyNativeBuildInputs",
+            driver: Driver::Clippy,
+            install_phase: "mkdir -p $out\n".to_string(),
+        },
+    )
+}
 
-    Ok(attrs.render())
+// Recompiles the unit with `--emit obj` so the panic-freedom scan has the
+// relocatable objects (including monomorphized generics) that the linked build
+// unit hides.
+fn render_panic_object_unit(
+    graph: &UnitGraph,
+    options: &RenderOptions,
+    prepared: &PreparedGraph,
+    index: usize,
+) -> Result<String> {
+    render_unit_derivation(
+        graph,
+        options,
+        prepared,
+        index,
+        UnitDerivation {
+            pname: format!("{}-panic-objects", graph.units[index].target.name),
+            native_build_inputs: "[ rustToolchain ] ++ extraNativeBuildInputs",
+            driver: Driver::ObjectEmit,
+            install_phase:
+                "mkdir -p $out\nfind build -maxdepth 1 -name '*.o' -exec cp {} \"$out/\" ';'\n"
+                    .to_string(),
+        },
+    )
 }
 
 fn unit_build_script_run(graph: &UnitGraph, index: usize) -> Option<usize> {
@@ -943,15 +1030,22 @@ fn render_driver_build_phase(
                 }
             }
         }
-        Driver::ClippyDriver => {
+        Driver::Clippy => {
             // Clippy only needs MIR. Skip codegen and linking entirely.
             script.push_str("rustc_args+=( --out-dir build )\n");
             script.push_str("rustc_args+=( --emit dep-info,metadata )\n");
         }
+        Driver::ObjectEmit => {
+            // Emit relocatable objects only, no link. `--out-dir` keeps every
+            // codegen unit's object; a single `obj=<file>` path is rejected for
+            // codegen-units > 1, so the directory form is the portable one.
+            script.push_str("rustc_args+=( --out-dir build )\n");
+            script.push_str("rustc_args+=( --emit obj )\n");
+        }
     }
 
     script.push_str("rustc_args+=( \"''${build_script_flags[@]}\" )\n");
-    if driver == Driver::ClippyDriver {
+    if driver == Driver::Clippy {
         // Inject the workspace's clippy lint policy (-D/-W/-A clippy::...)
         // at the rustc-args end so they override any earlier defaults.
         script.push_str("rustc_args+=( ${pkgs.lib.escapeShellArgs extraClippyLintArgs} )\n");
@@ -3051,18 +3145,24 @@ mod tests {
         let rendered = render_units_nix(&graph, &options(true)).unwrap();
         assert!(rendered.contains("panicFreedom ="));
         assert!(rendered.contains("name = \"cargo-unit-panic-freedom\";"));
-        assert!(rendered.contains("nix-cargo-unit scan-panics --crate-name"));
+        assert!(rendered.contains("nix-cargo-unit scan-panics ${pkgs.lib.escapeShellArgs"));
+        // The workspace crate set is baked into the scan args.
+        assert!(rendered.contains("\"--crate-name\" \"hello\""));
         // Fail closed when the scanner package is not wired through.
         assert!(rendered.contains("assertMsg (cargoUnit != null)"));
-        // The local library is scanned with its own crate name; the vendored
-        // crate is not scanned at all.
+        // The local library gets a panic-objects derivation and is scanned; the
+        // vendored crate gets neither.
+        assert!(rendered.contains("pname = \"hello-panic-objects\""));
         assert!(rendered.contains("(scanUnit \"hello-0.1.0-"));
-        assert!(rendered.contains("\"hello\" units."));
+        assert!(rendered.contains("panicObjectUnits.\"hello-0.1.0-"));
+        assert!(!rendered.contains("serde-panic-objects"));
         assert!(!rendered.contains("(scanUnit \"serde-1.0.0-"));
 
-        // Off by default: no flag, no panic-freedom policy entry.
+        // Off by default: no flag, no panic-freedom policy entry and no
+        // panic-objects derivations.
         let unchecked = render_units_nix(&graph, &options(false)).unwrap();
         assert!(!unchecked.contains("panicFreedom"));
+        assert!(!unchecked.contains("panic-objects"));
     }
 
     #[test]

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -17,6 +17,7 @@ pub struct RenderOptions {
     pub content_addressed: bool,
     pub toolchain_id: Option<String>,
     pub deny_unused_crate_dependencies: bool,
+    pub deny_panics: bool,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -383,8 +384,74 @@ fn render_policy_check_entries(
             render_unused_crate_dependencies_check(graph, options, prepared)
         )?;
     }
+    if options.deny_panics
+        && let Some(check) = render_panic_freedom_check(graph, prepared)
+    {
+        writeln!(entries, "    panicFreedom = {check};")?;
+    }
 
     Ok(entries)
+}
+
+// Library units the panic-freedom scan inspects. The scan is relocation-based,
+// so it needs the relocatable objects inside an rlib: a linked bin/test has its
+// panic calls resolved to direct branches with no relocation left to read, and
+// recovering those needs disassembly (tracked as follow-up). Build-script runs
+// have no artifact of their own, external crates compile under `--cap-lints
+// warn` and are not the workspace's invariant to hold, and proc-macro /
+// custom-build-compile units are host build tooling, not the shipped surface.
+fn is_panic_freedom_candidate(unit: &Unit) -> bool {
+    unit.is_library()
+        && !unit.is_external()
+        && !unit.is_proc_macro()
+        && !unit.is_run_custom_build()
+        && !unit.is_custom_build_compile()
+}
+
+// Renders one panic-freedom derivation per library unit, joined under a single
+// aggregate so a touched unit only re-scans itself. Each scan runs
+// `nix-cargo-unit scan-panics` over the unit's rlib, scoped to the unit's own
+// crate, and fails if any of the crate's functions reference a
+// `core::panicking` entrypoint. The scanner is the `cargoUnit` package, asserted
+// non-null so enabling the policy without wiring the scanner fails loudly rather
+// than silently passing.
+fn render_panic_freedom_check(graph: &UnitGraph, prepared: &PreparedGraph) -> Option<String> {
+    let mut scans = String::new();
+    for (index, unit) in graph.units.iter().enumerate() {
+        if !is_panic_freedom_candidate(unit) {
+            continue;
+        }
+        let _ = writeln!(
+            scans,
+            "          (scanUnit {} {} {})",
+            nix_attr(&prepared.names[index]),
+            nix_attr(&unit.target.name),
+            prepared.unit_ref(index),
+        );
+    }
+
+    if scans.is_empty() {
+        return None;
+    }
+
+    Some(format!(
+        r#"assert pkgs.lib.assertMsg (cargoUnit != null) "cargo-unit panic-freedom needs the cargoUnit scanner package; pass it through buildWorkspace.";
+      let
+        scanUnit = drvName: crateName: unit:
+          pkgs.runCommand "cargo-unit-panic-freedom-${{drvName}}"
+            {{ nativeBuildInputs = [ cargoUnit ]; }}
+            ''
+              set -euo pipefail
+              nix-cargo-unit scan-panics --crate-name ${{pkgs.lib.escapeShellArg crateName}} "${{unit}}"
+              mkdir -p "$out"
+            '';
+      in
+      pkgs.symlinkJoin {{
+        name = "cargo-unit-panic-freedom";
+        paths = [
+{scans}        ];
+      }}"#
+    ))
 }
 
 fn render_source_entries(prepared: &PreparedGraph) -> String {
@@ -2887,6 +2954,7 @@ mod tests {
                 content_addressed: false,
                 toolchain_id: Some("rustc-test".to_string()),
                 deny_unused_crate_dependencies: true,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -2912,6 +2980,80 @@ mod tests {
         assert!(rendered.contains("extraClippyLintArgs"));
         assert!(rendered.contains("clippy = clippyPolicyAggregate;"));
         assert!(rendered.contains("clippyPolicyAggregate ="));
+    }
+
+    #[test]
+    fn deny_panics_scans_local_units_and_skips_externals() {
+        // One workspace library plus one external dependency. The panic-freedom
+        // check must scan the local unit's compiled artifact and leave the
+        // vendored crate alone, mirroring how clippy and unused-dependency
+        // policy stay scoped to workspace-owned code.
+        let graph: UnitGraph = serde_json::from_str(
+            r#"{
+              "version": 1,
+              "units": [
+                {
+                  "pkg_id": "path+file:///workspace#hello@0.1.0",
+                  "target": {
+                    "kind": ["lib"],
+                    "crate_types": ["lib"],
+                    "name": "hello",
+                    "src_path": "/workspace/src/lib.rs",
+                    "edition": "2024"
+                  },
+                  "profile": { "name": "release", "opt_level": "3" },
+                  "features": [],
+                  "mode": "build",
+                  "dependencies": [{ "index": 1, "extern_crate_name": "serde" }]
+                },
+                {
+                  "pkg_id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0",
+                  "target": {
+                    "kind": ["lib"],
+                    "crate_types": ["lib"],
+                    "name": "serde",
+                    "src_path": "/vendor/serde/src/lib.rs",
+                    "edition": "2021"
+                  },
+                  "profile": { "name": "release", "opt_level": "3" },
+                  "mode": "build",
+                  "dependencies": []
+                }
+              ],
+              "roots": [0]
+            }"#,
+        )
+        .unwrap();
+
+        let options = |deny_panics| RenderOptions {
+            workspace_root: PathBuf::from("/workspace"),
+            vendor_root: Some(PathBuf::from("/vendor")),
+            cargo_lock_sources: cargo_lock_sources(&[(
+                "serde",
+                "1.0.0",
+                "registry+https://github.com/rust-lang/crates.io-index",
+            )]),
+            content_addressed: false,
+            toolchain_id: None,
+            deny_unused_crate_dependencies: false,
+            deny_panics,
+        };
+
+        let rendered = render_units_nix(&graph, &options(true)).unwrap();
+        assert!(rendered.contains("panicFreedom ="));
+        assert!(rendered.contains("name = \"cargo-unit-panic-freedom\";"));
+        assert!(rendered.contains("nix-cargo-unit scan-panics --crate-name"));
+        // Fail closed when the scanner package is not wired through.
+        assert!(rendered.contains("assertMsg (cargoUnit != null)"));
+        // The local library is scanned with its own crate name; the vendored
+        // crate is not scanned at all.
+        assert!(rendered.contains("(scanUnit \"hello-0.1.0-"));
+        assert!(rendered.contains("\"hello\" units."));
+        assert!(!rendered.contains("(scanUnit \"serde-1.0.0-"));
+
+        // Off by default: no flag, no panic-freedom policy entry.
+        let unchecked = render_units_nix(&graph, &options(false)).unwrap();
+        assert!(!unchecked.contains("panicFreedom"));
     }
 
     #[test]
@@ -2956,6 +3098,7 @@ mod tests {
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -3006,6 +3149,7 @@ mod tests {
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -3140,6 +3284,7 @@ version = "0.1.0"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -3209,6 +3354,7 @@ version = "0.1.0"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -3280,6 +3426,7 @@ version = "0.1.0"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -3339,6 +3486,7 @@ version = "0.1.0"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -3432,6 +3580,7 @@ version = "0.1.0"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -3559,6 +3708,7 @@ version = "0.1.0"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: true,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -3640,6 +3790,7 @@ version = "0.1.0"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -3714,6 +3865,7 @@ version = "0.1.0"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -3763,6 +3915,7 @@ version = "0.1.0"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -3810,6 +3963,7 @@ version = "0.1.0"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -3875,6 +4029,7 @@ version = "0.1.0"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -3959,6 +4114,7 @@ const CRLF: &str = include_str!("../../testdata/crlf.toml");
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -4042,6 +4198,7 @@ version = "4.6.1"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -4115,6 +4272,7 @@ version = "4.6.1"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap_err()
@@ -4157,6 +4315,7 @@ version = "4.6.1"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap_err()
@@ -4199,6 +4358,7 @@ version = "4.6.1"
                 content_addressed: true,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -4242,6 +4402,7 @@ version = "4.6.1"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -4307,6 +4468,7 @@ version = "4.6.1"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -4435,6 +4597,7 @@ links = "native_ffi"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -4528,6 +4691,7 @@ links = "nested_native"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -4650,6 +4814,7 @@ version = "0.1.0"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();
@@ -4719,6 +4884,7 @@ version = "0.1.0"
                 content_addressed: false,
                 toolchain_id: None,
                 deny_unused_crate_dependencies: false,
+                deny_panics: false,
             },
         )
         .unwrap();

--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -149,6 +149,9 @@ let
   clippyUnits = rec {
 {{ clippy_unit_entries }}  };
 
+  panicObjectUnits = rec {
+{{ panic_object_unit_entries }}  };
+
   # Every test target in the graph, keyed the same way `tests.<name>` is.
   # The shared manifest derivation depends on every binary listed here.
   testTargets = [

--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -8,6 +8,10 @@
   vendorSources ? {},
   extraNativeBuildInputs ? [],
   extraClippyNativeBuildInputs ? [],
+  # The nix-cargo-unit package, used by the optional panic-freedom policy check
+  # to run `scan-panics` over each library unit's rlib. Only required when that
+  # check was rendered (`--deny-panics`); the rendered check asserts non-null.
+  cargoUnit ? null,
   extraEnv ? {},
   testRunPrelude ? "",
   testArgsByPackage ? {},


### PR DESCRIPTION
Adds an opt-in `--deny-panics` policy check to cargo-unit that fails a build when a workspace function can reach a panic. Refs #307.

## Approach

Detection is relocation-based. rustc lowers a panic call to a relocation whose target is an undefined panic sink (`core::panicking::*`, plus the `unwrap_failed` / `expect_failed` cold helpers that `unwrap`/`expect` route through, confirmed against the relocations rustc emits at opt-level 0 and 3). The new `scan-panics` subcommand reads symbols and relocations with the `object` crate and attributes each panic call to its containing function, with no disassembler and no demangler, so one path covers ELF and Mach-O.

To cover generics, the scan reads the relocatable objects of every workspace unit, not just library rlibs. A generic carries no relocation in its defining rlib because it is codegened where it is monomorphized; the bin or test object that instantiates it does carry the relocation, and the symbol keeps the defining crate's mangled token. Each unit therefore gets a `panic-objects` derivation (a recompile with `--emit obj`, mirroring the clippy units), and findings are scoped to the whole workspace crate set so a library generic monomorphized inside another unit is attributed back to its crate.

This was the deliberate design after ruling out the naive alternative: a trivial clean std binary already carries ~36 `panicking` symbols from std's runtime, so a whole-artifact symbol grep is always-red for std code. Relocation attribution scoped to the workspace crate set is the signal that actually means "this workspace's code can panic."

## What it does

- `--deny-panics` renders `policyChecks.panicFreedom`: one scan derivation per workspace unit, joined under one aggregate, so a touched unit only re-scans itself.
- Each scan runs `nix-cargo-unit scan-panics --crate-name ...` over the unit's `panic-objects` derivation, scoped to the workspace crate set.
- The scanner is the `cargoUnit` package, threaded through a new `cargoUnit` template argument and asserted non-null, so enabling the policy without wiring the scanner fails loudly instead of silently passing.

## Validation

- 45 Rust tests pass (hermetic scanner tests synthesize objects via `object::write`, no rustc dependency), clippy clean, fmt clean, generated Nix parses.
- End-to-end on real crates: `unwrap`/`expect`/indexing are flagged with their exact entrypoints; a generic `pub fn first<T>(xs:&[T])->T{xs[3]}` invisible in its own rlib is caught via a consumer's objects and attributed to its defining crate; a clean crate and a crate with its own `panicking` module both pass.

## Known limitations (documented in code)

- Best-effort, not a soundness proof. The residual gap is a public generic that no workspace bin/test ever instantiates (never codegened anywhere here, and also unreachable from the workspace's own entrypoints). The sound successor is call-graph reachability over the linked, monomorphized binary (what `findpanics` does).
- The panic-sink catalog is curated; a panic routed through some other std/alloc cold path is missed until its symbol is added.
- The `ix.cargoUnit.buildWorkspace` `policy` toggle that passes `cargoUnit` and sets `--deny-panics` lives in the `ix` repo and is the remaining integration step before this runs in a real workspace.
