### PR TITLE
tui-node: Node.js N-API binding for the tui crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,6 +666,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +781,12 @@ checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
+
+[[package]]
+name = "ctor"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
 
 [[package]]
 name = "dag-runner"
@@ -1935,6 +1950,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,6 +2300,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
+name = "napi"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d395473824516f38dd1071a1a37bc57daa7be65b293ebba4ead5f7abb017a2"
+dependencies = [
+ "bitflags",
+ "ctor",
+ "futures",
+ "napi-build",
+ "napi-sys",
+ "nohash-hasher",
+ "rustc-hash",
+ "tokio",
+]
+
+[[package]]
+name = "napi-build"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
+
+[[package]]
+name = "napi-derive"
+version = "3.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b3f766e04667e6da0e181e2da4f85475d5a6513b7cf6a80bea184e224a5b42"
+dependencies = [
+ "convert_case",
+ "ctor",
+ "napi-derive-backend",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "napi-derive-backend"
+version = "5.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "napi-sys"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
+dependencies = [
+ "libloading 0.9.0",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,6 +2429,12 @@ dependencies = [
  "snafu",
  "strip-ansi-escapes",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -3765,7 +3854,7 @@ dependencies = [
  "glob-match",
  "goblin",
  "libc",
- "libloading",
+ "libloading 0.8.9",
  "log",
  "num-traits",
  "rand 0.8.6",
@@ -4286,6 +4375,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tui-node"
+version = "0.1.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "tui",
+]
+
+[[package]]
 name = "tui-py"
 version = "0.1.0"
 dependencies = [
@@ -4356,6 +4455,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "packages/oci-image-builder",
   "packages/repo-walker",
   "packages/tui",
+  "packages/tui-node",
   "packages/tui-py",
 ]
 resolver = "3"
@@ -53,6 +54,9 @@ ignore = "0.4"
 indicatif = "0.18"
 libc = "0.2"
 loro = "1.12"
+napi = { version = "3", default-features = false, features = ["napi6", "tokio_rt"] }
+napi-build = "2"
+napi-derive = "3"
 ndarray = "0.16"
 nix-web-monitor-parser = { path = "packages/nix-web-monitor/parser" }
 numpy = "0.28"

--- a/packages/tui-node/Cargo.toml
+++ b/packages/tui-node/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tui-node"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Node.js (N-API) bindings for the tui PTY-backed terminal UI management library"
+
+[lib]
+crate-type = ["cdylib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+napi.workspace = true
+napi-derive.workspace = true
+tui = { workspace = true, features = ["dashboard"] }
+
+[build-dependencies]
+napi-build.workspace = true

--- a/packages/tui-node/README.md
+++ b/packages/tui-node/README.md
@@ -1,0 +1,71 @@
+# tui (Node.js)
+
+Node.js bindings for the [`tui`](../tui) Rust crate. Spawn and drive multiple
+PTY-backed processes (vim, a REPL, a shell) from Node with full VT100
+emulation, then watch them all in a browser through a Loro-backed web dashboard.
+
+This is a thin N-API binding built with [napi-rs]: the `tui` crate owns every
+behavior, and this package only exposes it. It is the Node sibling of the Python
+[`tui-py`](../tui-py) package and shares the same process-wide manager
+semantics.
+
+npm name: `@indexable/tui`. Native addon: `tui_node.node`.
+
+## Quick start
+
+```js
+import { Tui, Key, waitFor } from "@indexable/tui";
+
+const t = new Tui("vim", ["-u", "NONE", "file.txt"], { rows: 24, cols: 80 });
+await waitFor(t, "~");
+await t.write("ihello from node" + Key.ESC + ":wq" + Key.ENTER);
+console.log("vim exit code:", await t.wait());
+```
+
+Every I/O method returns a `Promise` and runs on the tui actor, so it never
+blocks the event loop. Identity (`id`, `command`, `rows`, ...) and instant state
+(`isAlive()`, `exitCode()`) are synchronous.
+
+## Process lifecycle
+
+```js
+const t = new Tui("bash", ["-c", "echo hi; exit 7"]);
+console.log(await t.wait());   // 7  (null if killed by a signal)
+console.log(t.isAlive());      // false
+```
+
+`kill()` sends `SIGKILL`, which a program that traps interrupts cannot ignore.
+`close()` force-kills and drops the terminal from `Tui.listAll()` and the
+dashboard. `resize(rows, cols)` delivers `SIGWINCH` and is visible from every
+handle to the same process.
+
+## Web dashboard
+
+```js
+import { serve } from "@indexable/tui";
+
+const dash = serve("127.0.0.1", 8080);
+console.log(dash.url);   // open in a browser to see a live grid of every Tui
+dash.stop();
+```
+
+The server, the Loro CRDT document, and the SSE stream all live in Rust; the
+browser imports updates with `loro-crdt` and paints each terminal's viewport.
+
+## Build
+
+The native addon and npm package are built by Nix (no `napi build`, no
+`node-gyp`):
+
+```sh
+nix build .#tui-node     # writes an npm package tree: package.json, index.js, index.d.ts, native/
+```
+
+Linux-only, like [`tui-py`](../tui-py): the addon cdylib is carved from the
+shared `cargo-unit` workspace graph, which does not thread macOS's
+`-undefined dynamic_lookup` through to the link step. From a macOS checkout,
+build it on a Linux builder with `nix build .#packages.x86_64-linux.tui-node`.
+For local macOS iteration, plain `cargo build -p tui-node` produces a loadable
+`.dylib` (napi-build sets the macOS link args).
+
+[napi-rs]: https://napi.rs/

--- a/packages/tui-node/build.rs
+++ b/packages/tui-node/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/packages/tui-node/default.nix
+++ b/packages/tui-node/default.nix
@@ -1,0 +1,61 @@
+{
+  ix,
+  lib,
+  pkgs ? ix.pkgs,
+}:
+let
+  # The N-API addon is already built as a workspace cdylib library, so this is
+  # just packaging: rename the shared object to `tui_node.node`, sanitize it,
+  # and lay it next to the hand-written JS wrapper and TypeScript types.
+  library = ix.rustWorkspace.units.libraries.tui_node;
+
+  npmSource = builtins.path {
+    name = "tui-node-npm-source";
+    path = ./npm;
+  };
+in
+pkgs.runCommand "ix-tui-node"
+  {
+    strictDeps = true;
+    nativeBuildInputs = [
+      pkgs.coreutils
+      pkgs.patchelf
+      pkgs.removeReferencesTo
+    ];
+    passthru = { inherit library; };
+    meta.description = "ix tui Node.js package (N-API bindings for the tui PTY manager)";
+  }
+  ''
+    set -euo pipefail
+
+    cdylib=""
+    for candidate in \
+      ${library}/lib/libtui_node.so \
+      ${library}/lib/libtui_node-*.so
+    do
+      if [ -f "$candidate" ]; then
+        cdylib="$candidate"
+        break
+      fi
+    done
+    if [ -z "$cdylib" ]; then
+      echo "tui-node: no cdylib under ${library}/lib" >&2
+      ls -la ${library}/lib >&2 || true
+      exit 1
+    fi
+
+    mkdir -p "$out/native"
+    cp ${npmSource}/package.json ${npmSource}/index.js ${npmSource}/index.d.ts "$out/"
+    cp "$cdylib" "$out/native/tui_node.node"
+    chmod u+w "$out/native/tui_node.node"
+
+    # Strip the build-time rpath and nixpkgs toolchain references so the package
+    # is not pinned to this store path.
+    if patchelf --print-rpath "$out/native/tui_node.node" >/dev/null 2>&1; then
+      patchelf --remove-rpath "$out/native/tui_node.node"
+    fi
+    remove-references-to \
+      -t ${pkgs.glibc} \
+      -t ${pkgs.stdenv.cc.cc.lib} \
+      "$out/native/tui_node.node"
+  ''

--- a/packages/tui-node/default.nix
+++ b/packages/tui-node/default.nix
@@ -13,12 +13,23 @@ let
     name = "tui-node-npm-source";
     path = ./npm;
   };
+
+  # npm's `cpu`/`libc` fields gate installation. The addon is host-built, so
+  # stamp the arch of this build; a nixpkgs build is always glibc.
+  npmCpu =
+    {
+      x86_64-linux = "x64";
+      aarch64-linux = "arm64";
+    }
+    .${pkgs.stdenv.hostPlatform.system}
+      or (throw "tui-node: unsupported platform ${pkgs.stdenv.hostPlatform.system}");
 in
 pkgs.runCommand "ix-tui-node"
   {
     strictDeps = true;
     nativeBuildInputs = [
       pkgs.coreutils
+      pkgs.jq
       pkgs.patchelf
       pkgs.removeReferencesTo
     ];
@@ -45,7 +56,11 @@ pkgs.runCommand "ix-tui-node"
     fi
 
     mkdir -p "$out/native"
-    cp ${npmSource}/package.json ${npmSource}/index.js ${npmSource}/index.d.ts "$out/"
+    cp ${npmSource}/index.js ${npmSource}/index.d.ts "$out/"
+    # Stamp the artifact's arch/libc so npm refuses to install it on a host that
+    # cannot dlopen this single host-built addon.
+    jq '. + { cpu: ["${npmCpu}"], libc: ["glibc"] }' \
+      ${npmSource}/package.json >"$out/package.json"
     cp "$cdylib" "$out/native/tui_node.node"
     chmod u+w "$out/native/tui_node.node"
 

--- a/packages/tui-node/npm/index.d.ts
+++ b/packages/tui-node/npm/index.d.ts
@@ -1,0 +1,109 @@
+/**
+ * Node.js bindings for the `tui` PTY-backed terminal manager.
+ *
+ * Spawn child processes attached to real pseudo-terminals, drive them with
+ * keystrokes, and read back a VT100-rendered viewport. Every I/O method returns
+ * a `Promise` and runs on the tui actor, so it never blocks the event loop.
+ */
+
+/** Spawn-time terminal configuration. Unset fields use 80x24 / 10,000 lines. */
+export interface SpawnOptions {
+  rows?: number;
+  cols?: number;
+  scrollbackLines?: number;
+}
+
+/** Scrollback history plus the visible viewport, read together. */
+export interface FullOutput {
+  scrollback: Array<string>;
+  viewport: Array<string>;
+}
+
+/** A single spawned PTY-backed process. */
+export declare class Tui {
+  /** Spawn `command` on a fresh PTY and start tracking it. */
+  constructor(command: string, args?: Array<string>, options?: SpawnOptions);
+
+  /** Every instance the process is currently tracking. */
+  static listAll(): Array<Tui>;
+
+  readonly id: string;
+  readonly command: string;
+  readonly args: Array<string>;
+  /** Current terminal height in rows. */
+  readonly rows: number;
+  /** Current terminal width in columns. */
+  readonly cols: number;
+  readonly scrollbackLimit: number;
+
+  /** Send `data` to the PTY exactly as given. */
+  write(data: string): Promise<void>;
+  /** The current viewport, one string per visible row. */
+  readViewport(): Promise<Array<string>>;
+  /** Lines that have scrolled above the viewport, oldest first. */
+  readScrollback(): Promise<Array<string>>;
+  /** Scrollback and viewport read together. */
+  readFull(): Promise<FullOutput>;
+  /** Read the viewport, waiting up to `timeoutMs` for first content. */
+  readBlocking(timeoutMs: number): Promise<Array<string>>;
+
+  /** Whether the child process is still running. */
+  isAlive(): boolean;
+  /** The exit code, or `null` while running or if terminated by a signal. */
+  exitCode(): number | null;
+  /** Resolve once the child exits, returning its exit code (`null` if signaled). */
+  wait(): Promise<number | null>;
+  /** Force-terminate the child with SIGKILL. A no-op if already exited. */
+  kill(): Promise<void>;
+  /** Resize the terminal (delivers SIGWINCH to the child). */
+  resize(rows: number, cols: number): Promise<void>;
+  /** Force-kill the child and stop tracking it. */
+  close(): void;
+}
+
+/** Handle to a running web dashboard. */
+export declare class Dashboard {
+  /** The URL to open in a browser. */
+  readonly url: string;
+  /** The bound `host:port`. */
+  readonly addr: string;
+  /** Stop the server and its poll loop. Idempotent. */
+  stop(): void;
+}
+
+/**
+ * Start the Loro-backed web dashboard for every live terminal in this process.
+ * `host` must be an IP literal; pass `port = 0` for an ephemeral port.
+ */
+export declare function serve(host?: string, port?: number, pollMs?: number): Dashboard;
+
+/** A pattern for {@link waitFor}: substring, RegExp, or viewport predicate. */
+export type WaitPattern = string | RegExp | ((viewport: Array<string>) => boolean);
+
+/** Common keystrokes as ANSI byte sequences, plus `ctrl`/`alt` helpers. */
+export declare const Key: {
+  readonly ENTER: string;
+  readonly TAB: string;
+  readonly ESC: string;
+  readonly BACKSPACE: string;
+  readonly DELETE: string;
+  readonly UP: string;
+  readonly DOWN: string;
+  readonly RIGHT: string;
+  readonly LEFT: string;
+  readonly HOME: string;
+  readonly END: string;
+  readonly PAGE_UP: string;
+  readonly PAGE_DOWN: string;
+  readonly CTRL_C: string;
+  readonly CTRL_D: string;
+  ctrl(letter: string): string;
+  alt(letter: string): string;
+};
+
+/** Poll a terminal's viewport until `pattern` matches; returns the lines. */
+export declare function waitFor(
+  tui: Tui,
+  pattern: WaitPattern,
+  options?: { timeoutMs?: number; pollMs?: number },
+): Promise<Array<string>>;

--- a/packages/tui-node/npm/index.js
+++ b/packages/tui-node/npm/index.js
@@ -67,4 +67,10 @@ async function waitFor(tui, pattern, { timeoutMs = 5000, pollMs = 50 } = {}) {
   }
 }
 
-module.exports = { Tui, Dashboard, serve, Key, waitFor };
+// Assign each binding as its own property so Node's cjs-module-lexer detects
+// them as named exports; `import { Tui, Key, waitFor }` then works from ESM.
+exports.Tui = Tui;
+exports.Dashboard = Dashboard;
+exports.serve = serve;
+exports.Key = Key;
+exports.waitFor = waitFor;

--- a/packages/tui-node/npm/index.js
+++ b/packages/tui-node/npm/index.js
@@ -1,0 +1,70 @@
+"use strict";
+
+// Thin JS layer over the native N-API addon. The addon (the `tui` Rust crate)
+// owns all PTY behavior; this file only adds keystroke constants and a
+// poll-based `waitFor`, mirroring the Python package's ergonomics.
+
+const native = require("./native/tui_node.node");
+
+const { Tui, Dashboard, serve } = native;
+
+/** Common keystrokes as ANSI byte sequences, plus `ctrl`/`alt` helpers. */
+const Key = Object.freeze({
+  ENTER: "\r",
+  TAB: "\t",
+  ESC: "\x1b",
+  BACKSPACE: "\x7f",
+  DELETE: "\x1b[3~",
+  UP: "\x1b[A",
+  DOWN: "\x1b[B",
+  RIGHT: "\x1b[C",
+  LEFT: "\x1b[D",
+  HOME: "\x1b[H",
+  END: "\x1b[F",
+  PAGE_UP: "\x1b[5~",
+  PAGE_DOWN: "\x1b[6~",
+  CTRL_C: "\x03",
+  CTRL_D: "\x04",
+  /** Ctrl+<letter> as a single control byte. */
+  ctrl(letter) {
+    const ch = String(letter).toLowerCase();
+    if (ch.length !== 1 || ch < "a" || ch > "z") {
+      throw new RangeError(`Key.ctrl expects one ASCII letter a-z, got ${letter}`);
+    }
+    return String.fromCharCode(ch.charCodeAt(0) - 96);
+  },
+  /** Alt+<letter> as ESC followed by the character. */
+  alt(letter) {
+    if (String(letter).length !== 1) {
+      throw new RangeError(`Key.alt expects a single character, got ${letter}`);
+    }
+    return "\x1b" + letter;
+  },
+});
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Poll a terminal's viewport until it matches, returning the matching lines.
+ * `pattern` is a substring, a RegExp, or a predicate over the viewport lines.
+ */
+async function waitFor(tui, pattern, { timeoutMs = 5000, pollMs = 50 } = {}) {
+  const matches =
+    typeof pattern === "function"
+      ? pattern
+      : pattern instanceof RegExp
+        ? (lines) => pattern.test(lines.join("\n"))
+        : (lines) => lines.join("\n").includes(String(pattern));
+
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const lines = await tui.readViewport();
+    if (matches(lines)) return lines;
+    if (Date.now() >= deadline) {
+      throw new Error(`waitFor: ${tui.command} did not match within ${timeoutMs}ms`);
+    }
+    await sleep(pollMs);
+  }
+}
+
+module.exports = { Tui, Dashboard, serve, Key, waitFor };

--- a/packages/tui-node/npm/package.json
+++ b/packages/tui-node/npm/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@indexable/tui",
+  "version": "0.1.0",
+  "description": "Node.js bindings for the tui PTY-backed terminal manager (spawn and drive vim, a REPL, a shell) with a Loro-backed web dashboard.",
+  "license": "UNLICENSED",
+  "private": false,
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "./native/tui_node.node": "./native/tui_node.node"
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "native"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "os": [
+    "linux"
+  ]
+}

--- a/packages/tui-node/package.nix
+++ b/packages/tui-node/package.nix
@@ -1,0 +1,16 @@
+{
+  id = "tui-node";
+  inRustWorkspace = true;
+  # Linux-only, like tui-py: the N-API addon is a cdylib carved from the shared
+  # cargo-unit graph, and that graph does not thread macOS's
+  # `-undefined dynamic_lookup` through to the link step. Local macOS dev builds
+  # the addon with plain `cargo build`, which honors napi-build's link args.
+  flake.systems = [
+    "x86_64-linux"
+    "aarch64-linux"
+  ];
+  packageSet.systems = [
+    "x86_64-linux"
+    "aarch64-linux"
+  ];
+}

--- a/packages/tui-node/src/lib.rs
+++ b/packages/tui-node/src/lib.rs
@@ -26,7 +26,7 @@
     reason = "napi-derive resolves exported return types by their concrete name"
 )]
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
@@ -274,9 +274,13 @@ impl Dashboard {
 pub fn serve(host: Option<String>, port: Option<u32>, poll_ms: Option<u32>) -> Result<Dashboard> {
     let host = host.unwrap_or_else(|| "127.0.0.1".to_owned());
     let port = narrow_u16("port", port.unwrap_or(8080))?;
-    let addr: SocketAddr = format!("{host}:{port}")
+    // Parse the host as a bare IP so IPv4 and IPv6 literals both work (an
+    // IPv6 address has its own colons, so `format!("{host}:{port}")` would be
+    // ambiguous). Hostnames are not resolved and fail closed here.
+    let ip: IpAddr = host
         .parse()
-        .map_err(|source| err(format!("invalid address {host}:{port}: {source}")))?;
+        .map_err(|source| err(format!("invalid host {host}: {source}")))?;
+    let addr = SocketAddr::new(ip, port);
 
     // Clamp the poll interval to at least 1ms so a `0` does not spin the
     // dashboard's sample loop, matching the Python wrapper.

--- a/packages/tui-node/src/lib.rs
+++ b/packages/tui-node/src/lib.rs
@@ -1,0 +1,287 @@
+//! Node.js (N-API) bindings for the `tui` PTY-backed terminal manager.
+//!
+//! This is a thin binding: every method delegates to the `tui` crate, which
+//! owns the behavior. I/O methods are async (they return a `Promise` and run on
+//! the tui actor without blocking the Node event loop); identity and instant
+//! state are synchronous getters.
+
+#![allow(
+    clippy::missing_const_for_fn,
+    reason = "napi methods are dispatched through the generated addon vtable and cannot be const"
+)]
+#![allow(
+    clippy::must_use_candidate,
+    reason = "these values are consumed across the JS boundary, not by Rust callers"
+)]
+#![allow(
+    clippy::missing_errors_doc,
+    reason = "fallible methods surface as rejected JS promises; errors are documented in index.d.ts"
+)]
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "JS numbers cross in as u32; terminal dimensions and scrollback fit u16/u32 in practice"
+)]
+#![allow(
+    clippy::use_self,
+    reason = "napi-derive resolves exported return types by their concrete name"
+)]
+
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+/// One process-wide manager owning the tokio runtime that drives every PTY,
+/// mirrored on the Python binding so both share the same lifecycle semantics.
+static MANAGER: OnceLock<Arc<tui::TuiManager>> = OnceLock::new();
+
+fn manager() -> Arc<tui::TuiManager> {
+    MANAGER
+        .get_or_init(|| Arc::new(tui::TuiManager::new()))
+        .clone()
+}
+
+fn err(source: impl std::fmt::Display) -> Error {
+    Error::from_reason(source.to_string())
+}
+
+/// Spawn-time terminal configuration. Unset fields fall back to the core
+/// defaults (80x24, 10,000 lines of scrollback).
+#[napi(object)]
+pub struct SpawnOptions {
+    pub rows: Option<u32>,
+    pub cols: Option<u32>,
+    pub scrollback_lines: Option<u32>,
+}
+
+/// Scrollback history plus the visible viewport, read together.
+#[napi(object)]
+pub struct FullOutput {
+    pub scrollback: Vec<String>,
+    pub viewport: Vec<String>,
+}
+
+/// A single spawned PTY-backed process.
+#[napi]
+pub struct Tui {
+    inner: tui::TuiInstance,
+}
+
+#[napi]
+impl Tui {
+    /// Spawn `command` on a fresh PTY and start tracking it.
+    #[napi(constructor)]
+    pub fn new(
+        command: String,
+        args: Option<Vec<String>>,
+        options: Option<SpawnOptions>,
+    ) -> Result<Self> {
+        let mut config = tui::SpawnConfig::default();
+        if let Some(options) = options {
+            if let Some(rows) = options.rows {
+                config.rows = rows as u16;
+            }
+            if let Some(cols) = options.cols {
+                config.cols = cols as u16;
+            }
+            if let Some(scrollback) = options.scrollback_lines {
+                config.scrollback_lines = scrollback as usize;
+            }
+        }
+        let inner = manager()
+            .spawn(command, args.unwrap_or_default(), config)
+            .map_err(err)?;
+        Ok(Self { inner })
+    }
+
+    /// Every instance the process is currently tracking.
+    #[napi]
+    pub fn list_all() -> Vec<Tui> {
+        manager()
+            .list()
+            .into_iter()
+            .map(|inner| Self { inner })
+            .collect()
+    }
+
+    // -- identity / shape -------------------------------------------------
+
+    #[napi(getter)]
+    pub fn id(&self) -> String {
+        self.inner.id.to_string()
+    }
+
+    #[napi(getter)]
+    pub fn command(&self) -> String {
+        self.inner.command.clone()
+    }
+
+    #[napi(getter)]
+    pub fn args(&self) -> Vec<String> {
+        self.inner.args.clone()
+    }
+
+    #[napi(getter)]
+    pub fn rows(&self) -> u32 {
+        u32::from(self.inner.rows())
+    }
+
+    #[napi(getter)]
+    pub fn cols(&self) -> u32 {
+        u32::from(self.inner.cols())
+    }
+
+    #[napi(getter)]
+    pub fn scrollback_limit(&self) -> u32 {
+        self.inner.scrollback_limit as u32
+    }
+
+    // -- I/O (async: runs on the actor, never blocks the event loop) ------
+
+    /// Send `data` to the PTY exactly as given.
+    #[napi]
+    pub async fn write(&self, data: String) -> Result<()> {
+        self.inner.write_async(&data).await.map_err(err)
+    }
+
+    /// The current viewport, one string per visible row.
+    #[napi]
+    pub async fn read_viewport(&self) -> Result<Vec<String>> {
+        self.inner.read_viewport_async().await.map_err(err)
+    }
+
+    /// Lines that have scrolled above the viewport, oldest first.
+    #[napi]
+    pub async fn read_scrollback(&self) -> Result<Vec<String>> {
+        self.inner.read_scrollback_async().await.map_err(err)
+    }
+
+    /// Scrollback and viewport read together.
+    #[napi]
+    pub async fn read_full(&self) -> Result<FullOutput> {
+        let full = self.inner.read_full_async().await.map_err(err)?;
+        Ok(FullOutput {
+            scrollback: full.scrollback,
+            viewport: full.viewport,
+        })
+    }
+
+    /// Read the viewport, waiting up to `timeoutMs` for first content.
+    #[napi]
+    pub async fn read_blocking(&self, timeout_ms: u32) -> Result<Vec<String>> {
+        self.inner
+            .read_blocking_async(Duration::from_millis(u64::from(timeout_ms)))
+            .await
+            .map_err(err)
+    }
+
+    // -- lifecycle --------------------------------------------------------
+
+    /// Whether the child process is still running.
+    #[napi]
+    pub fn is_alive(&self) -> bool {
+        self.inner.is_alive()
+    }
+
+    /// The exit code, or `null` while running or if terminated by a signal.
+    #[napi]
+    pub fn exit_code(&self) -> Option<i32> {
+        match self.inner.exit_state() {
+            tui::ExitState::Exited(code) => code,
+            tui::ExitState::Running => None,
+        }
+    }
+
+    /// Resolve once the child exits, returning its exit code (`null` if it was
+    /// terminated by a signal).
+    #[napi]
+    pub async fn wait(&self) -> Result<Option<i32>> {
+        Ok(match self.inner.wait_async().await {
+            tui::ExitState::Exited(code) => code,
+            tui::ExitState::Running => None,
+        })
+    }
+
+    /// Force-terminate the child with `SIGKILL`. A no-op if already exited.
+    #[napi]
+    pub async fn kill(&self) -> Result<()> {
+        self.inner.kill_async().await.map_err(err)
+    }
+
+    /// Resize the terminal (delivers `SIGWINCH` to the child).
+    #[napi]
+    pub async fn resize(&self, rows: u32, cols: u32) -> Result<()> {
+        self.inner
+            .resize_async(rows as u16, cols as u16)
+            .await
+            .map_err(err)
+    }
+
+    /// Force-kill the child and stop tracking it, dropping it from `listAll`
+    /// and the dashboard.
+    #[napi]
+    pub fn close(&self) {
+        let _ = self.inner.kill();
+        let _ = manager().remove(&self.inner.id);
+    }
+}
+
+/// Handle to a running web dashboard. Stop with `stop()`.
+#[napi]
+pub struct Dashboard {
+    url_value: String,
+    addr_value: String,
+    inner: Mutex<Option<tui::Dashboard>>,
+}
+
+#[napi]
+impl Dashboard {
+    #[napi(getter)]
+    pub fn url(&self) -> String {
+        self.url_value.clone()
+    }
+
+    #[napi(getter)]
+    pub fn addr(&self) -> String {
+        self.addr_value.clone()
+    }
+
+    /// Stop the server and its poll loop. Idempotent.
+    #[napi]
+    pub fn stop(&self) {
+        if let Ok(mut guard) = self.inner.lock()
+            && let Some(mut dashboard) = guard.take()
+        {
+            dashboard.stop();
+        }
+    }
+}
+
+/// Start the Loro-backed web dashboard for every live terminal in this process.
+///
+/// `host` must be an IP literal (a hostname is not resolved). Pass `port = 0`
+/// for an ephemeral port, read back from `Dashboard.url`. `pollMs` is the
+/// viewport sampling interval in milliseconds.
+#[napi]
+pub fn serve(host: Option<String>, port: Option<u32>, poll_ms: Option<u32>) -> Result<Dashboard> {
+    let host = host.unwrap_or_else(|| "127.0.0.1".to_owned());
+    let port = port.unwrap_or(8080) as u16;
+    let addr: SocketAddr = format!("{host}:{port}")
+        .parse()
+        .map_err(|source| err(format!("invalid address {host}:{port}: {source}")))?;
+
+    let dashboard = tui::serve(
+        &manager(),
+        addr,
+        Duration::from_millis(u64::from(poll_ms.unwrap_or(100))),
+    )
+    .map_err(err)?;
+
+    Ok(Dashboard {
+        url_value: dashboard.url(),
+        addr_value: dashboard.addr().to_string(),
+        inner: Mutex::new(Some(dashboard)),
+    })
+}

--- a/packages/tui-node/src/lib.rs
+++ b/packages/tui-node/src/lib.rs
@@ -47,6 +47,13 @@ fn err(source: impl std::fmt::Display) -> Error {
     Error::from_reason(source.to_string())
 }
 
+/// JS numbers arrive as `u32`; terminal dimensions and ports are `u16`. Reject
+/// out-of-range values instead of silently wrapping them.
+fn narrow_u16(name: &str, value: u32) -> Result<u16> {
+    u16::try_from(value)
+        .map_err(|_| Error::from_reason(format!("{name} must be in 0..=65535, got {value}")))
+}
+
 /// Spawn-time terminal configuration. Unset fields fall back to the core
 /// defaults (80x24, 10,000 lines of scrollback).
 #[napi(object)]
@@ -81,10 +88,10 @@ impl Tui {
         let mut config = tui::SpawnConfig::default();
         if let Some(options) = options {
             if let Some(rows) = options.rows {
-                config.rows = rows as u16;
+                config.rows = narrow_u16("rows", rows)?;
             }
             if let Some(cols) = options.cols {
-                config.cols = cols as u16;
+                config.cols = narrow_u16("cols", cols)?;
             }
             if let Some(scrollback) = options.scrollback_lines {
                 config.scrollback_lines = scrollback as usize;
@@ -213,10 +220,9 @@ impl Tui {
     /// Resize the terminal (delivers `SIGWINCH` to the child).
     #[napi]
     pub async fn resize(&self, rows: u32, cols: u32) -> Result<()> {
-        self.inner
-            .resize_async(rows as u16, cols as u16)
-            .await
-            .map_err(err)
+        let rows = narrow_u16("rows", rows)?;
+        let cols = narrow_u16("cols", cols)?;
+        self.inner.resize_async(rows, cols).await.map_err(err)
     }
 
     /// Force-kill the child and stop tracking it, dropping it from `listAll`
@@ -267,17 +273,15 @@ impl Dashboard {
 #[napi]
 pub fn serve(host: Option<String>, port: Option<u32>, poll_ms: Option<u32>) -> Result<Dashboard> {
     let host = host.unwrap_or_else(|| "127.0.0.1".to_owned());
-    let port = port.unwrap_or(8080) as u16;
+    let port = narrow_u16("port", port.unwrap_or(8080))?;
     let addr: SocketAddr = format!("{host}:{port}")
         .parse()
         .map_err(|source| err(format!("invalid address {host}:{port}: {source}")))?;
 
-    let dashboard = tui::serve(
-        &manager(),
-        addr,
-        Duration::from_millis(u64::from(poll_ms.unwrap_or(100))),
-    )
-    .map_err(err)?;
+    // Clamp the poll interval to at least 1ms so a `0` does not spin the
+    // dashboard's sample loop, matching the Python wrapper.
+    let poll = Duration::from_millis(u64::from(poll_ms.unwrap_or(100)).max(1));
+    let dashboard = tui::serve(&manager(), addr, poll).map_err(err)?;
 
     Ok(Dashboard {
         url_value: dashboard.url(),


### PR DESCRIPTION
Adds `packages/tui-node`, a Node.js binding for the `tui` PTY crate built with [napi-rs]. It is the Node sibling of `tui-py`: the Rust crate owns all PTY behavior and this package only exposes it (per the "implement once in Rust, expose through thin bindings" rule).

## Surface
- `Tui` class: spawn, `write`, `readViewport` / `readScrollback` / `readFull` / `readBlocking`, `isAlive` / `exitCode` / `wait` / `kill` / `close`, `resize`, static `listAll`.
- `serve(...)` → `Dashboard`: the same Loro-backed web dashboard the Python package exposes.
- I/O methods are async (return a `Promise`, run on the tui actor, never block the event loop); identity and instant state are synchronous.
- The npm package `@indexable/tui` ships the native addon plus a hand-written `index.js` (`Key` constants + a poll-based `waitFor`) and `index.d.ts`.

## Build
Built by Nix through the shared `cargo-unit` workspace graph, no `napi build` / node-gyp: `default.nix` renames the workspace cdylib to `tui_node.node`, sanitizes it, and lays it beside the JS wrapper.

```sh
nix build .#tui-node
```

Verified on the Linux remote builder: the package tree is `package.json`, `index.js`, `index.d.ts`, `native/tui_node.node` (ELF x86-64). The binding behavior was validated locally via a plain `cargo build` `.node` under Node — driving vim (exit 0, correct file), bash exit codes, `resize` (child reports the new `$COLUMNS`), and `serve`.

## Known limitations
- Linux-only, like `tui-py`: the `cargo-unit` graph does not thread macOS's `-undefined dynamic_lookup` to the link step. Local macOS dev uses plain `cargo build -p tui-node`, which honors `napi-build`'s link args.
- The addon still carries nix-store references (glibc/interpreter); a full manylinux-portable scrub for public npm distribution is a follow-up, same as the wheel.

[napi-rs]: https://napi.rs/
