### PR TITLE
mcp: run top-level await in persistent python sessions

### DIFF
--- a/lib/rust-workspace.nix
+++ b/lib/rust-workspace.nix
@@ -61,6 +61,7 @@ let
       "bench"
     ];
     packageTestInputs.tui = [ workspacePkgs.vim ];
+    packageTestInputs.ix-mcp = [ workspacePkgs.python3 ];
     # Every policy check runs once across the whole workspace. Selected
     # package outputs expose these as explicit tests instead of making
     # downstream binary builds depend on unrelated workspace policy.

--- a/packages/mcp/src/main.rs
+++ b/packages/mcp/src/main.rs
@@ -493,6 +493,43 @@ mod tests {
         Ok(())
     }
 
+    fn python_session(id: &str) -> Result<PythonSession> {
+        // The test derivation puts `python3` on PATH via
+        // `packageTestInputs.ix-mcp` in lib/rust-workspace.nix. A bare command
+        // skips the default venv build, which the worker does not need.
+        PythonSession::start(id.to_string(), Some(vec!["python3".to_string()]), None)
+    }
+
+    #[test]
+    fn top_level_await_persists_async_state_across_calls() -> Result<()> {
+        let mut session = python_session("await-persist")?;
+
+        // An async primitive created with top-level await in one call must stay
+        // usable in the next call. A fresh asyncio.run() loop per call would
+        // close the loop the queue is bound to before the second call runs, so
+        // this guards the persistent-loop design rather than await syntax alone.
+        let put = session.request(
+            "exec",
+            json!({ "source": "import asyncio\nq = asyncio.Queue()\nawait q.put(123)" }),
+        )?;
+        assert_eq!(put, "ok");
+
+        let got = session.request("eval", json!({ "expression": "await q.get()" }))?;
+        assert_eq!(got, "result:\n123");
+
+        Ok(())
+    }
+
+    #[test]
+    fn synchronous_expressions_still_evaluate() -> Result<()> {
+        // Compiling with PyCF_ALLOW_TOP_LEVEL_AWAIT must not change plain code:
+        // snippets without await run eagerly and return their value.
+        let mut session = python_session("await-sync")?;
+        let sum = session.request("eval", json!({ "expression": "1 + 1" }))?;
+        assert_eq!(sum, "result:\n2");
+        Ok(())
+    }
+
     fn run_worker_stderr_burst_session() -> Result<String> {
         let script = r#"
 i=0

--- a/packages/mcp/src/main.rs
+++ b/packages/mcp/src/main.rs
@@ -99,7 +99,9 @@ impl McpServer {
         self.with_sessions(|sessions| sessions.close(&request.session_id))
     }
 
-    #[tool(description = "Evaluate a Python expression in a persistent session.")]
+    #[tool(
+        description = "Evaluate a Python expression in a persistent session. Top-level await works (e.g. `await client.get(url)`); the session keeps one event loop, so async clients and pools created in one call stay usable in later calls."
+    )]
     fn python_eval(&self, Parameters(request): Parameters<EvalRequest>) -> String {
         self.with_sessions(|sessions| {
             let session = sessions.get_or_create(request.session_id.as_deref())?;
@@ -107,7 +109,9 @@ impl McpServer {
         })
     }
 
-    #[tool(description = "Execute Python statements in a persistent session.")]
+    #[tool(
+        description = "Execute Python statements in a persistent session. Top-level await works (e.g. `await pool.fetch(sql)`); the session keeps one event loop, so async resources created in one call stay usable in later calls."
+    )]
     fn python_exec(&self, Parameters(request): Parameters<ExecRequest>) -> String {
         self.with_sessions(|sessions| {
             let session = sessions.get_or_create(request.session_id.as_deref())?;

--- a/packages/mcp/src/python_worker.py
+++ b/packages/mcp/src/python_worker.py
@@ -1,36 +1,69 @@
 from __future__ import annotations
 
+import ast
+import asyncio
 import contextlib
 import io
 import json
 import sys
 import traceback
 from collections.abc import Callable
-from typing import Any, cast
+from typing import Any
+
+# Compile every snippet with this flag so `await` is legal at the top level.
+# Without it, `await x` outside a function raises SyntaxError. CPython's own
+# `python -m asyncio` REPL drives top-level await the same way: compile with the
+# flag, then run the resulting coroutine on a loop.
+# https://docs.python.org/3/library/asyncio-runner.html#asyncio-cli
+_AWAIT_FLAG = ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
 
 
 class PythonSession:
     def __init__(self) -> None:
         self.globals: dict[str, object] = {"__name__": "__ix_mcp__"}
+        # One persistent loop for the whole session. asyncio.run() would create
+        # and close a fresh loop per call, orphaning any async resource (client,
+        # connection pool, socket) bound to it; keeping one loop lets those
+        # survive across requests, which is the point of a persistent session.
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
 
     def evaluate(self, expression: str) -> dict[str, object]:
         def run() -> str:
-            value = cast(object, eval(compile(expression, "<ix-mcp eval>", "eval"), self.globals))
-            return repr(value)
+            code = compile(expression, "<ix-mcp eval>", "eval", flags=_AWAIT_FLAG)
+            return repr(self._drive(eval(code, self.globals)))
 
         return self.capture(run)
 
     def execute(self, source: str) -> dict[str, object]:
         def run() -> str:
-            exec(compile(source, "<ix-mcp exec>", "exec"), self.globals)
+            code = compile(source, "<ix-mcp exec>", "exec", flags=_AWAIT_FLAG)
+            self._drive(eval(code, self.globals))
             return ""
 
         return self.capture(run)
 
+    def _drive(self, value: object) -> object:
+        # Code compiled with the await flag returns a coroutine only when it
+        # actually contains top-level await; otherwise it runs eagerly and
+        # returns its normal value (None for exec-mode statements). Driving the
+        # coroutine on the session loop makes top-level await block until the
+        # result is ready, the same way synchronous code blocks the worker.
+        if asyncio.iscoroutine(value):
+            return self.loop.run_until_complete(value)
+        return value
+
     def reset(self) -> dict[str, object]:
         self.globals.clear()
         self.globals["__name__"] = "__ix_mcp__"
+        # Keep the loop. Clearing globals already drops the caller's async
+        # resources, and recreating the loop would invalidate any reference the
+        # caller stored elsewhere.
         return {"ok": True, "stdout": "", "stderr": "", "result": "session reset"}
+
+    def close(self) -> None:
+        if not self.loop.is_closed():
+            self.loop.close()
 
     def capture(self, run: Callable[[], str]) -> dict[str, object]:
         stdout = io.StringIO()
@@ -80,6 +113,7 @@ def handle_request(session: PythonSession, line: str) -> dict[str, object]:
             case "reset":
                 response = session.reset()
             case "close":
+                session.close()
                 response = {"ok": True, "stdout": "", "stderr": "", "result": "session closed", "close": True}
             case _:
                 raise ValueError(f"unknown operation: {op}")

--- a/site/src/lib/updates/ix-mcp-top-level-await.svx
+++ b/site/src/lib/updates/ix-mcp-top-level-await.svx
@@ -1,0 +1,24 @@
+---
+id: ix-mcp-top-level-await
+postedAt: 2026-05-29T13:30:00-07:00
+title: "`ix-mcp` Python sessions accept top-level `await`"
+tags: [interesting, mcp, agents, python, async]
+links:
+  - label: mcp package
+    href: https://github.com/indexable-inc/index/tree/main/packages/mcp
+---
+
+`python_eval` and `python_exec` now run `await` at the top level, no `asyncio.run` wrapper. Each session keeps one event loop for its whole life, so an async resource created in one call is still live in the next:
+
+```python
+python_exec(source="""
+import httpx
+client = httpx.AsyncClient()
+r = await client.get("https://example.com")
+""")
+python_eval(expression="r.status_code")  # 200, same client, same loop
+```
+
+This is the loop that `asyncio.run` cannot give you: it opens and closes a fresh loop per call, so a client or pool created on one turn is bound to a loop that is already closed by the next. The worker compiles every snippet with `ast.PyCF_ALLOW_TOP_LEVEL_AWAIT` and drives the resulting coroutine on the kept loop, the same mechanism as CPython's `python -m asyncio` REPL.
+
+Known limitation: a coroutine that never resolves blocks the worker, exactly the way a synchronous `while True` already does. Bound long awaits yourself with `asyncio.wait_for` when you need a ceiling.


### PR DESCRIPTION
## What

`python_eval` / `python_exec` (and the `ix-mcp eval` / `exec` CLI) now accept top-level `await`. Before, `compile(..., "exec")` ran without the top-level-await flag, so `await foo()` outside a function raised `SyntaxError: 'await' outside function`, and there was no event loop.

## Why

The real problem was not ergonomics, it was the persistent session contract. The only documented workaround was `asyncio.run(...)`, which opens and closes a fresh loop every call. Any async resource bound to that loop (an `httpx.AsyncClient`, an `asyncpg` pool, a websocket) is dead the moment the call returns, so the next call hits `RuntimeError: ... attached to a different loop`. A persistent session that cannot hold an open async resource across calls is half a session.

## How

Each session keeps one `asyncio` event loop for its whole life. Snippets are compiled with `ast.PyCF_ALLOW_TOP_LEVEL_AWAIT`; code that actually contains top-level await evaluates to a coroutine, which is driven on the kept loop, while plain code still runs eagerly. This is the same mechanism as CPython's own `python -m asyncio` REPL. `close` shuts the loop down; `reset` keeps it (clearing globals already drops the caller's resources).

## Tests

Two Rust cases over a real `python3` (wired in through `packageTestInputs.ix-mcp` in `lib/rust-workspace.nix`, mirroring the existing `tui`/`vim` pattern):

- `top_level_await_persists_async_state_across_calls`: `await q.put(123)` in one `exec`, `await q.get()` in a later `eval` returns `123`. This is the regression test for the persistent-loop design, not just await syntax.
- `synchronous_expressions_still_evaluate`: `1 + 1` still returns `2`, proving the await flag does not change non-await code.

Validated end-to-end by driving the worker over its JSON protocol with `python3` (cross-call persistence, sync, eval-await, async def, error tracebacks, reset clearing globals, loop alive after reset).

## Known limitation

A coroutine that never resolves blocks the single-threaded worker, exactly the way a synchronous `while True` already does. There is no default timeout; bound long awaits with `asyncio.wait_for` when you need a ceiling. A unified per-op timeout covering both the sync and async paths is a separate, pre-existing concern.
