### PR TITLE
tui-node: mark napi-build as cargo-machete-ignored (build.rs-only dep)

### DIFF
--- a/packages/tui-node/Cargo.toml
+++ b/packages/tui-node/Cargo.toml
@@ -18,3 +18,8 @@ tui = { workspace = true, features = ["dashboard"] }
 
 [build-dependencies]
 napi-build.workspace = true
+
+[package.metadata.cargo-machete]
+# napi-build is consumed only by build.rs (`napi_build::setup()`), which
+# cargo-machete does not scan, so it reports a false-positive unused dependency.
+ignored = ["napi-build"]


### PR DESCRIPTION
`napi-build` is consumed only by `tui-node/build.rs` (`napi_build::setup()`). cargo-machete does not scan build scripts, so it false-positives `napi-build` as an unused dependency and the workspace `cargo-machete` check fails.

This surfaced when index CI moved to the self-hosted runner: on the GitHub-hosted runner the cargo-machete check was being substituted from cache (`nix-fast-build --skip-cached`), so it never actually ran; the self-hosted host produced a different derivation hash, got a cache miss, ran cargo-machete for real, and caught the long-standing false positive.

Fix: add `[package.metadata.cargo-machete] ignored = ["napi-build"]`, the mechanism cargo-machete itself recommends for build-only deps. Verified locally: `cargo-machete packages/tui-node` now reports no unused dependencies.
