### PR TITLE
tui-node: mark napi-build used for cargo-machete

### DIFF
--- a/packages/tui-node/Cargo.toml
+++ b/packages/tui-node/Cargo.toml
@@ -18,3 +18,10 @@ tui = { workspace = true, features = ["dashboard"] }
 
 [build-dependencies]
 napi-build.workspace = true
+
+# napi-build is used only in build.rs (`napi_build::setup()`), which cargo-machete
+# with --with-metadata does not attribute, so it false-positives as unused. The
+# dep is load-bearing: setup() emits the link args (including macOS
+# `-undefined dynamic_lookup`) the cdylib needs.
+[package.metadata.cargo-machete]
+ignored = ["napi-build"]


### PR DESCRIPTION
## What

Add `[package.metadata.cargo-machete] ignored = ["napi-build"]` to `tui-node`.

## Why

The workspace `cargo-machete` check (run with `--with-metadata`) flags `napi-build` as unused and fails `flake-check` on `main`. It's a false positive: `napi-build` is used in `build.rs` via `napi_build::setup()`, which cargo-machete's metadata mode doesn't attribute. The dependency is load-bearing — `setup()` emits the cdylib link args (including the macOS `-undefined dynamic_lookup` flags the crate's README documents), so removing it breaks the build.

This currently breaks every PR's `flake-check`, so it's a main-unblocker.

## Verification

`cargo-machete --with-metadata --skip-target-dir .` on the workspace: clean after the change (flagged `tui-node -- napi-build` before).
