### PR TITLE
mcp: bundle tui into the pinned interpreter (import tui by default)

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -8,6 +8,59 @@ let
   unwrapped = ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
     binary = "ix-mcp";
   };
+
+  # The PTY-driving `tui` package, baked into the pinned interpreter so every
+  # session can `import tui` with no setup. The PyO3 cdylib comes from the same
+  # shared workspace graph the binary is selected from, dropped next to the
+  # package's Python source as the `tui._tui` extension. This is the cdylib
+  # straight from the graph rather than the distributable wheel, so it also
+  # works on macOS, where the wheel packaging stays Linux-only. Store references
+  # in the cdylib are fine: this module never leaves the Nix environment.
+  tuiPythonSource = builtins.path {
+    name = "tui-py-python-source";
+    path = ../tui-py/python;
+  };
+  tuiModule = pkgs.python3.pkgs.toPythonModule (
+    pkgs.runCommand "ix-tui-python-module"
+      {
+        strictDeps = true;
+        propagatedBuildInputs = [ pkgs.python3.pkgs.numpy ];
+        meta.description = "ix-tui PyO3 module bundled into the ix-mcp interpreter";
+      }
+      ''
+        site="$out/${pkgs.python3.sitePackages}/tui"
+        mkdir -p "$site"
+        cp -r ${tuiPythonSource}/tui/. "$site/"
+
+        cdylib=""
+        for candidate in \
+          ${ix.rustWorkspace.units.libraries.tui_py}/lib/libtui_py.so \
+          ${ix.rustWorkspace.units.libraries.tui_py}/lib/libtui_py-*.so \
+          ${ix.rustWorkspace.units.libraries.tui_py}/lib/libtui_py.dylib \
+          ${ix.rustWorkspace.units.libraries.tui_py}/lib/libtui_py-*.dylib
+        do
+          if [ -f "$candidate" ]; then
+            cdylib="$candidate"
+            break
+          fi
+        done
+        if [ -z "$cdylib" ]; then
+          echo "ix-tui module: no cdylib under ${ix.rustWorkspace.units.libraries.tui_py}/lib" >&2
+          ls -la ${ix.rustWorkspace.units.libraries.tui_py}/lib >&2 || true
+          exit 1
+        fi
+        install -m555 "$cdylib" "$site/_tui.abi3.so"
+      ''
+  );
+
+  # The interpreter the wrapper pins. Sessions build their venv from this with
+  # `--system-site-packages`, so `tui` and numpy are importable by default while
+  # an in-session `pip install` still writes to the per-session venv.
+  mcpPython = pkgs.python3.withPackages (ps: [
+    ps.numpy
+    tuiModule
+  ]);
+
   package =
     pkgs.runCommand "ix-mcp"
       {
@@ -20,7 +73,7 @@ let
       ''
         mkdir -p $out/bin
         makeWrapper ${unwrapped}/bin/ix-mcp $out/bin/ix-mcp \
-          --set IX_MCP_PYTHON ${lib.escapeShellArg (lib.getExe pkgs.python3)}
+          --set IX_MCP_PYTHON ${lib.escapeShellArg (lib.getExe mcpPython)}
       '';
   replDefault =
     pkgs.runCommand "ix-mcp-repl-default"
@@ -64,6 +117,30 @@ let
 
         mkdir -p "$out"
       '';
+  tuiBundled =
+    pkgs.runCommand "ix-mcp-tui-bundled"
+      {
+        nativeBuildInputs = [ package ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+
+        # `tui` ships in the pinned interpreter, so a bare session imports it
+        # with no install step. Importing loads the PyO3 cdylib, which exercises
+        # the link (the macOS dynamic_lookup path in particular); spawning a real
+        # PTY needs device nodes the build sandbox lacks, so leave that to
+        # runtime.
+        ix-mcp exec 'import tui; print("tui-ok", tui.__version__)' >stdout 2>stderr
+        if ! grep -q '^tui-ok ' stdout; then
+          echo "tui was not importable in a default session:" >&2
+          cat stdout stderr >&2
+          exit 1
+        fi
+
+        mkdir -p "$out"
+      '';
 in
 package.overrideAttrs (old: {
   passthru =
@@ -72,7 +149,7 @@ package.overrideAttrs (old: {
     // {
       inherit unwrapped;
       tests = (unwrapped.passthru.tests or { }) // {
-        inherit replDefault sessionVenv;
+        inherit replDefault sessionVenv tuiBundled;
       };
     };
 })

--- a/packages/mcp/src/main.rs
+++ b/packages/mcp/src/main.rs
@@ -383,8 +383,11 @@ fn create_venv(temp_dir: &Path) -> Result<PathBuf> {
     let python = std::env::var("IX_MCP_PYTHON")
         .context("IX_MCP_PYTHON is unset; run ix-mcp via its Nix wrapper, which pins the interpreter")?;
     let venv_dir = temp_dir.join(".venv");
+    // `--system-site-packages` exposes the pinned interpreter's bundled
+    // packages (notably `tui`) to the session while keeping the venv writable,
+    // so an in-session `pip install` still lands in the per-session venv.
     let status = Command::new(&python)
-        .args(["-m", "venv"])
+        .args(["-m", "venv", "--system-site-packages"])
         .arg(&venv_dir)
         .status()
         .with_context(|| format!("failed to create Python environment with {python}"))?;

--- a/packages/tui-py/build.rs
+++ b/packages/tui-py/build.rs
@@ -1,0 +1,14 @@
+//! PyO3 extension modules resolve interpreter symbols at load time rather than
+//! at link time. macOS rejects undefined symbols in a dylib by default, so the
+//! cdylib link needs `-undefined dynamic_lookup` (Linux permits them, so it
+//! needs nothing). pyo3 0.28 does not emit this and the shared cargo-unit graph
+//! does not add it, so emit it here, scoped to the cdylib via the single-colon
+//! `rustc-cdylib-link-arg` directive that both cargo and nix-cargo-unit honor
+//! (the latter reads exactly this form; see nix-cargo-unit render.rs). This
+//! mirrors what `napi-build` does for the tui-node addon.
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-cdylib-link-arg=-undefined");
+        println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+    }
+}

--- a/packages/tui-py/package.nix
+++ b/packages/tui-py/package.nix
@@ -1,11 +1,13 @@
 {
   id = "tui-py";
   inRustWorkspace = true;
-  # The PyO3 extension cdylib links cleanly only where undefined symbols are
-  # allowed in a shared object (Linux), the same constraint that keeps ix's
-  # native SDK wheels Linux-only. macOS needs `-undefined dynamic_lookup`, which
-  # the shared cargo-unit graph does not thread through, so the wheel is built on
-  # Linux (manylinux). Local macOS dev uses the editable build, not this package.
+  # The cdylib links on macOS too now (build.rs emits the cdylib-scoped
+  # `-undefined dynamic_lookup` that PyO3 needs there), but this wheel's
+  # packaging is still Linux-only: it strips an ELF rpath with patchelf and
+  # stamps manylinux tags. macOS would need install-name fixups and macosx tags
+  # instead, which no caller wants yet. The mcp bundles the cdylib straight from
+  # the workspace graph (see packages/mcp) for cross-platform `import tui`, so
+  # this Linux wheel stays the distribution artifact and macOS dev uses that.
   flake.systems = [
     "x86_64-linux"
     "aarch64-linux"


### PR DESCRIPTION
Makes `import tui` work in any `ix-mcp` Python session with no setup, so the PTY-driving API is usable out of the box (e.g. drive vim/a REPL from the MCP instead of bash).

## What

- `IX_MCP_PYTHON` now points at `python3.withPackages [ numpy tui ]`. The `tui` module is assembled from the PyO3 cdylib in the shared workspace graph (`ix.rustWorkspace.units.libraries.tui_py`) dropped next to the package's Python source as `tui._tui` — the cdylib straight from the graph, not the distributable wheel, so it works on macOS too where the wheel packaging stays Linux-only. Store refs in the cdylib are fine; it never leaves the Nix env.
- Session venvs are created with `--system-site-packages`, so `tui`/numpy are importable while an in-session `pip install` still writes to the per-session venv (verified by the existing `sessionVenv` test).
- `packages/tui-py/build.rs` emits the cdylib-scoped `-undefined dynamic_lookup` that PyO3 extension modules need on macOS, via the single-colon `rustc-cdylib-link-arg` directive that both cargo and nix-cargo-unit honor (mirrors what `napi-build` does for tui-node). Without it the cdylib fails to link on darwin with undefined `_Py*` symbols. No-op on Linux.

## Why not fix nix-cargo-unit

It already handles this: it normalizes `cargo::` → `cargo:` and recognizes `cargo:rustc-cdylib-link-arg`. The earlier failure was an invalid directive name (`rustc-link-arg-cdylib` is not a real cargo directive); the correct `rustc-cdylib-link-arg` works in both. The fix belongs in the crate's build.rs, like napi-build.

## Tests

New `passthru.tests.tuiBundled`: a bare `ix-mcp exec 'import tui; ...'` session imports `tui` (loading the cdylib) with no install. `replDefault` and `sessionVenv` still pass. Verified on aarch64-darwin: `nix build .#mcp` then `ix-mcp exec 'import tui'` → `tui-ok 0.1.0`, and driving a real vim/REPL through `tui.Tui` works end to end.
