### PR TITLE
[codex] use ty for Python helper checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,8 +351,8 @@ without PyPI dependencies or multiple source files. Once a script needs
 dependencies, console entry points, or a package layout, give it the uv project
 shape.
 
-The Python helpers run basedpyright in `standard` mode by default. Change the
-type-checking mode only when the package has a deliberate reason.
+The Python helpers run `ty` by default. Disable the check only when the package
+has a deliberate reason.
 
 ## Sane defaults
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,8 +351,8 @@ without PyPI dependencies or multiple source files. Once a script needs
 dependencies, console entry points, or a package layout, give it the uv project
 shape.
 
-The Python helpers run basedpyright in `standard` mode by default. Change the
-type-checking mode only when the package has a deliberate reason.
+The Python helpers run `ty` by default. Disable the check only when the package
+has a deliberate reason.
 
 ## Sane defaults
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ The full style guide lives in [AGENTS.md](AGENTS.md). Skim the section that matc
 - [Writing style](AGENTS.md#writing-style) — prose in docs, READMEs, comments, issues, PR descriptions.
 - [Inline comments](AGENTS.md#inline-comments) — when a comment earns its place and when to delete it.
 - [Rust style](AGENTS.md#rust-style) — naming, module layout, type annotations.
-- [Python style](AGENTS.md#python-style) — uv project shape, basedpyright defaults.
+- [Python style](AGENTS.md#python-style) — uv project shape, `ty` defaults.
 - [Nix style (ast-grep enforced)](AGENTS.md#nix-style-ast-grep-enforced) — the hard rules `nix run .#lint` checks.
 - [Module conventions](AGENTS.md#module-conventions) and [Image conventions](AGENTS.md#image-conventions) — option shape, registry placement, no `..` paths.
 - [Dependency intake](AGENTS.md#dependency-intake) — how new external artifacts enter the repo (lockfiles, generated catalogs, fetcher choice).

--- a/agents-md/sections/07-python-style.md
+++ b/agents-md/sections/07-python-style.md
@@ -9,6 +9,5 @@ without PyPI dependencies or multiple source files. Once a script needs
 dependencies, console entry points, or a package layout, give it the uv project
 shape.
 
-The Python helpers run basedpyright in `standard` mode by default. Change the
-type-checking mode only when the package has a deliberate reason.
-
+The Python helpers run `ty` by default. Disable the check only when the package
+has a deliberate reason.

--- a/lib/build-uv-application.nix
+++ b/lib/build-uv-application.nix
@@ -1,8 +1,4 @@
-{
-  errors,
-  uvLockFor,
-  validTypeCheckingModes,
-}:
+{ uvLockFor }:
 
 /**
   Build a Python application from a uv project.
@@ -11,8 +7,8 @@
   `uv lock` and do not maintain a separate Nix dependency hash. Locked
   distributions are fetched into a wheelhouse, installed offline into a virtual
   environment, and the local project is built as a wheel before installation.
-  Type checking runs by default in basedpyright `standard` mode after install
-  against the installed virtual environment, matching `writePythonApplication`.
+  Type checking runs by default with `ty` after install against the installed
+  virtual environment, matching `writePythonApplication`.
 
   The default path supports registry packages with `wheels` or `sdist` entries
   in `uv.lock`. Projects that use a non-uv build backend may need to pass a
@@ -27,8 +23,7 @@
   - `groups`, `extras`: uv dependency groups and extras to install.
   - `dev`, `allGroups`, `allExtras`: dependency selection shortcuts.
   - `exportFlags`, `pipInstallFlags`, `buildFlags`: extra uv flags.
-  - `check`, `typeCheckingMode`, `pythonPlatform`, `typeCheckPaths`:
-    basedpyright knobs.
+  - `check`, `pythonPlatform`, `typeCheckPaths`, `typeCheckArgs`: ty knobs.
   - `extraNativeBuildInputs`: extra packages on PATH for the build.
   - `runtimeLibraryInputs`: shared libraries made visible to binary wheels.
   - `fetcherOpts`: per-package fetcher overrides for locked distributions.
@@ -68,8 +63,7 @@ pkgs:
   pipInstallFlags ? [ ],
   buildFlags ? [ ],
   check ? true,
-  typeCheckingMode ? "standard",
-  pythonPlatform ? "Linux",
+  pythonPlatform ? "linux",
   typeCheckPaths ? [ "." ],
   extraPaths ? [ ],
   typeCheckArgs ? [ ],
@@ -80,12 +74,6 @@ pkgs:
 }:
 let
   inherit (pkgs) lib;
-
-  checkedTypeCheckingMode = errors.assertEnum {
-    name = "buildUvApplication.typeCheckingMode";
-    value = typeCheckingMode;
-    valid = validTypeCheckingModes;
-  };
 
   uvLock = uvLockFor pkgs;
   uvWheelhouse = uvLock.buildWheelhouse {
@@ -101,12 +89,23 @@ let
     "--extra"
     extra
   ]) extras;
-  pyrightConfig = (pkgs.formats.json { }).generate "basedpyright-${pname}.json" {
-    include = typeCheckPaths;
-    inherit extraPaths pythonPlatform;
-    typeCheckingMode = checkedTypeCheckingMode;
-    inherit (python) pythonVersion;
-  };
+  extraSearchPathArgs = lib.concatMap (path: [
+    "--extra-search-path"
+    path
+  ]) extraPaths;
+  tyCheckArgs = [
+    "--python-platform"
+    pythonPlatform
+    "--python-version"
+    python.pythonVersion
+    "--output-format"
+    "concise"
+    "--no-progress"
+    "--error-on-warning"
+  ]
+  ++ extraSearchPathArgs
+  ++ typeCheckArgs
+  ++ typeCheckPaths;
   exportArgs = [
     "--frozen"
     "--no-emit-project"
@@ -162,7 +161,7 @@ pkgs.stdenvNoCC.mkDerivation (_: {
   ]
   ++ extraNativeBuildInputs;
 
-  nativeInstallCheckInputs = [ pkgs.basedpyright ];
+  nativeInstallCheckInputs = [ pkgs.ty ];
 
   dontConfigure = true;
   dontBuild = true;
@@ -199,12 +198,7 @@ pkgs.stdenvNoCC.mkDerivation (_: {
   installCheckPhase = ''
     runHook preInstallCheck
 
-    basedpyright \
-      --project ${pyrightConfig} \
-      --pythonpath "$out/venv/bin/python" \
-      --level warning \
-      --warnings \
-      ${lib.escapeShellArgs (typeCheckPaths ++ typeCheckArgs)}
+    ty check --python "$out/venv/bin/python" ${lib.escapeShellArgs tyCheckArgs}
 
     runHook postInstallCheck
   '';

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -26,7 +26,7 @@ let
     in
     entry.path;
 
-  inherit (import ./writers.nix { inherit lib errors basedpyrightTypeCheckingModes; })
+  inherit (import ./writers.nix { inherit lib; })
     writePythonApplication
     writeNushellApplication
     writeProcessComposeApplication
@@ -84,18 +84,7 @@ let
     import ./uv-lock.nix {
       inherit lib pkgs;
     };
-  basedpyrightTypeCheckingModes = [
-    "off"
-    "basic"
-    "standard"
-    "strict"
-    "recommended"
-    "all"
-  ];
-  buildUvApplication = import ./build-uv-application.nix {
-    inherit errors uvLockFor;
-    validTypeCheckingModes = basedpyrightTypeCheckingModes;
-  };
+  buildUvApplication = import ./build-uv-application.nix { inherit uvLockFor; };
   buildGradleFatJar = import ./build-gradle-fat-jar.nix { inherit lib; };
   secrets = import ./secrets.nix {
     inherit lib pkgs writeNushellApplication;

--- a/lib/rust-workspace.nix
+++ b/lib/rust-workspace.nix
@@ -63,10 +63,15 @@ let
     packageTestInputs.tui = [ workspacePkgs.vim ];
     packageTestInputs.ix-mcp = [ workspacePkgs.python3 ];
     # `rodio` (packages/minecraft/sound) pulls `cpal`/`alsa-sys`, whose build
-    # script needs ALSA's pkg-config metadata to link `libasound` on Linux.
+    # script needs ALSA's pkg-config metadata and the final rustc link needs
+    # libasound's search path on Linux.
     # Scoped to the whole workspace because the unit graph compiles every
     # member on every system; darwin uses CoreAudio and needs nothing extra.
     nativeBuildInputs = lib.optional workspacePkgs.stdenv.hostPlatform.isLinux workspacePkgs.pkg-config;
+    extraRustcArgs = lib.optionals workspacePkgs.stdenv.hostPlatform.isLinux [
+      "-L"
+      "native=${workspacePkgs.alsa-lib}/lib"
+    ];
     env = lib.optionalAttrs workspacePkgs.stdenv.hostPlatform.isLinux {
       PKG_CONFIG_PATH = "${workspacePkgs.alsa-lib.dev}/lib/pkgconfig";
     };

--- a/lib/rust-workspace.nix
+++ b/lib/rust-workspace.nix
@@ -63,8 +63,7 @@ let
     packageTestInputs.tui = [ workspacePkgs.vim ];
     packageTestInputs.ix-mcp = [ workspacePkgs.python3 ];
     # `rodio` (packages/minecraft/sound) pulls `cpal`/`alsa-sys`, whose build
-    # script needs ALSA's pkg-config metadata and the final rustc link needs
-    # libasound's search path on Linux.
+    # script needs ALSA's pkg-config metadata to link `libasound` on Linux.
     # Scoped to the whole workspace because the unit graph compiles every
     # member on every system; darwin uses CoreAudio and needs nothing extra.
     #
@@ -75,10 +74,6 @@ let
     # every unit's rustc link search directly so the final binary link resolves
     # it. Harmless for crates that never reference `libasound`.
     nativeBuildInputs = lib.optional workspacePkgs.stdenv.hostPlatform.isLinux workspacePkgs.pkg-config;
-    extraRustcArgs = lib.optionals workspacePkgs.stdenv.hostPlatform.isLinux [
-      "-L"
-      "native=${workspacePkgs.alsa-lib}/lib"
-    ];
     env = lib.optionalAttrs workspacePkgs.stdenv.hostPlatform.isLinux {
       PKG_CONFIG_PATH = "${workspacePkgs.alsa-lib.dev}/lib/pkgconfig";
     };

--- a/lib/rust.nix
+++ b/lib/rust.nix
@@ -278,9 +278,8 @@ let
   # Flatten workspace inheritance in a vendored Cargo.toml before rustc sees it.
   # Vendored from nixpkgs so a downstream rename of
   # `pkgs/build-support/rust/replace-workspace-values.py` doesn't surface as a
-  # `readFile` error here; `ix.writePythonApplication` also runs basedpyright on
-  # the body at build time, which the upstream `pkgs.writers.writePython3` path
-  # did not.
+  # `readFile` error here; `ix.writePythonApplication` also runs ty on the body
+  # at build time, which the upstream `pkgs.writers.writePython3` path did not.
   replaceWorkspaceValues = writePythonApplication {
     name = "replace-workspace-values";
     src = ./rust-replace-workspace-values.py;

--- a/lib/writers.nix
+++ b/lib/writers.nix
@@ -1,17 +1,12 @@
-{
-  lib,
-  errors,
-  basedpyrightTypeCheckingModes,
-}:
+{ lib }:
 let
   /**
     Package a Python entrypoint as a standalone executable.
 
     Wraps `src` in a launcher script that prepends `runtimeInputs` to PATH
     and runs the file under `python`. When `check` is true (default), the
-    derivation also runs `basedpyright` over `src` in `standard` mode during
-    the build, so type regressions fail the build instead of surfacing at
-    runtime.
+    derivation also runs `ty` over `src` during the build, so type regressions
+    fail the build instead of surfacing at runtime.
 
     Arguments:
     - `name`: derivation name and `/bin/<name>` executable.
@@ -19,8 +14,8 @@ let
     - `args`: literal argv prefix prepended to user args at runtime.
     - `runtimeInputs`: extra packages prepended to PATH at runtime.
     - `python`: Python interpreter package. Defaults to `pkgs.python314`.
-    - `check`, `typeCheckingMode`, `pythonPlatform`: basedpyright knobs.
-    - `extraPaths`: extra import roots for basedpyright.
+    - `check`, `pythonPlatform`: ty knobs.
+    - `extraPaths`: extra import roots for ty.
     - `meta`: standard derivation meta, with `mainProgram` defaulted.
   */
   writePythonApplication =
@@ -32,8 +27,7 @@ let
       runtimeInputs ? [ ],
       python ? pkgs.python314,
       check ? true,
-      typeCheckingMode ? "standard",
-      pythonPlatform ? "Linux",
+      pythonPlatform ? "linux",
       extraPaths ? [ "${python}/${python.sitePackages}" ],
       meta ? { },
     }:
@@ -41,22 +35,25 @@ let
       runtimePath = lib.makeBinPath ([ python ] ++ runtimeInputs);
       srcPath = src;
       argv = builtins.toJSON ([ "${srcPath}" ] ++ args);
-      checkedTypeCheckingMode = errors.assertEnum {
-        name = "writePythonApplication.typeCheckingMode";
-        value = typeCheckingMode;
-        valid = basedpyrightTypeCheckingModes;
-      };
-      # `"${src}"` (not `builtins.toString src`) so the generated JSON
-      # carries Nix string context for the source derivation; otherwise
-      # the file references a store path with no recorded dependency
-      # and Nix prints a "without a proper context" eval warning on
-      # every consumer evaluation.
-      pyrightConfig = (pkgs.formats.json { }).generate "basedpyright-${name}.json" {
-        include = [ "${src}" ];
-        inherit extraPaths pythonPlatform;
-        typeCheckingMode = checkedTypeCheckingMode;
-        inherit (python) pythonVersion;
-      };
+      extraSearchPathArgs = lib.concatMap (path: [
+        "--extra-search-path"
+        path
+      ]) extraPaths;
+      tyCheckArgs = [
+        "check"
+        "--python"
+        (lib.getExe python)
+        "--python-platform"
+        pythonPlatform
+        "--python-version"
+        python.pythonVersion
+        "--output-format"
+        "concise"
+        "--no-progress"
+        "--error-on-warning"
+      ]
+      ++ extraSearchPathArgs
+      ++ [ "${src}" ];
     in
     pkgs.writeTextFile {
       inherit name;
@@ -75,7 +72,7 @@ let
         runpy.run_path("${srcPath}", run_name="__main__")
       '';
       checkPhase = lib.optionalString check ''
-        ${lib.getExe pkgs.basedpyright} --project ${pyrightConfig} --level warning --warnings ${src}
+        ${lib.getExe pkgs.ty} ${lib.escapeShellArgs tyCheckArgs}
       '';
       meta = meta // {
         mainProgram = meta.mainProgram or name;

--- a/packages/minecraft/rcon/minecraft-rcon.py
+++ b/packages/minecraft/rcon/minecraft-rcon.py
@@ -29,7 +29,7 @@ def read_packet(sock: socket.socket) -> tuple[int, int, str]:
     header = sock.recv(4)
     if len(header) != 4:
         raise RuntimeError("short RCON length header")
-    (length,) = cast(tuple[int], struct.unpack("<i", header))
+    (length,) = struct.unpack("<i", header)
     body = b""
     while len(body) < length:
         chunk = sock.recv(length - len(body))

--- a/packages/run/run.py
+++ b/packages/run/run.py
@@ -761,7 +761,7 @@ def run(argv: list[str]) -> int:
         stderr_fd=stdio_fd("stderr", 2),
         stdout_fd=stdio_fd("stdout", 1),
     )
-    terminal = {
+    terminal: dict[str, object] = {
         "columns": columns,
         "rows": rows,
         "started_epoch_seconds": int(started.timestamp()),


### PR DESCRIPTION
## Summary

- switch `ix.buildUvApplication` and `ix.writePythonApplication` from `basedpyright` to `ty check`
- remove the pyright-specific `typeCheckingMode` helper plumbing
- update the generated Python style guidance and related references
- add local Python cleanups for diagnostics that `ty --error-on-warning` reports

## Validation

- `nix build .#run .#ix-fleet --no-link`
- `ty check --python "$(command -v python3)" --python-platform linux --python-version 3.13 --output-format concise --no-progress --error-on-warning packages/minecraft/rcon/minecraft-rcon.py`
- `nix run .#lint`
- `git diff --check`

## Notes

- Tried `nix build .#checks.x86_64-linux.rust-package-tests --no-link` locally, but this aarch64-darwin machine has no eligible x86_64-linux builder configured. GitHub Actions is the Linux verification for that check.
- After `main` was merged into this PR, the coworker ALSA fix owns the `minecraft-sound` Linux link path; this branch only drops its now-duplicate local workaround.