### PR TITLE
feat(tap): terminal session manager with multiplayer attach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2654,6 +2654,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nix-cargo-unit"
 version = "0.1.0"
 dependencies = [
@@ -4382,6 +4394,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac258c2c6390673f2685813afeeafcb8c4e0ee7de8dd3fc46838dcc37263f98"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tap"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "dirs",
+ "nix",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "tap-protocol",
+ "tap-pty",
+ "tempfile",
+ "tokio",
+ "toml",
+ "tui",
+]
+
+[[package]]
+name = "tap-protocol"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "dirs",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tap-pty"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "parking_lot",
+ "pty-process",
+ "snafu",
+ "tokio",
+ "vt100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ members = [
   "packages/nix-web-monitor/server",
   "packages/oci-image-builder",
   "packages/repo-walker",
+  "packages/tap",
+  "packages/tap/protocol",
+  "packages/tap/pty",
   "packages/tui",
   "packages/tui-dashboard",
   "packages/tui-node",
@@ -61,6 +64,7 @@ napi = { version = "3", default-features = false, features = ["napi6", "tokio_rt
 napi-build = "2"
 napi-derive = "3"
 ndarray = "0.16"
+nix = "0.30"
 nix-web-monitor-parser = { path = "packages/nix-web-monitor/parser" }
 numpy = "0.28"
 object = { version = "0.37", default-features = false, features = [
@@ -88,6 +92,8 @@ snafu = "0.9"
 strip-ansi-escapes = "0.2"
 tango-bench = "0.7"
 tantivy = "0.26"
+tap-protocol = { path = "packages/tap/protocol" }
+tap-pty = { path = "packages/tap/pty" }
 tar = "0.4"
 tempfile = "3"
 tokio = "1"

--- a/lib/rust-workspace.nix
+++ b/lib/rust-workspace.nix
@@ -60,8 +60,13 @@ let
       "test"
       "bench"
     ];
-    packageTestInputs.tui = [ workspacePkgs.vim ];
-    packageTestInputs.ix-mcp = [ workspacePkgs.python3 ];
+    packageTestInputs = {
+      tui = [ workspacePkgs.vim ];
+      ix-mcp = [ workspacePkgs.python3 ];
+      # tap's integration tests drive the `tap` binary on a PTY and run `bash`
+      # as the session child; the daemon resolves `bash` from PATH at runtime.
+      tap = [ workspacePkgs.bash ];
+    };
     # `rodio` (packages/minecraft/sound) pulls `cpal`/`alsa-sys`, whose build
     # script needs ALSA's pkg-config metadata to link `libasound` on Linux.
     # Scoped to the whole workspace because the unit graph compiles every

--- a/packages/tap/Cargo.toml
+++ b/packages/tap/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "tap"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Minimal terminal session manager for tiling-WM users: detach, attach, share"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+dirs.workspace = true
+nix = { workspace = true, features = ["term", "process"] }
+parking_lot.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tap-protocol.workspace = true
+tap-pty.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = ["io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
+toml = { workspace = true, features = ["parse", "serde"] }
+
+[dev-dependencies]
+# Drive the built `tap` binary on a real PTY and assert on its rendered screen.
+tui.workspace = true

--- a/packages/tap/README.md
+++ b/packages/tap/README.md
@@ -1,0 +1,119 @@
+# tap
+
+A terminal session manager for tiling-WM users. Start a command, detach from it,
+and reattach later from any terminal, with no in-terminal tiling layer to fight
+your window manager. Multiple people can attach to one session at once.
+
+```sh
+nix run .#tap                 # start a session in the current terminal
+nix run .#tap -- attach       # reattach to the most recent session
+```
+
+## Why not tmux
+
+If you use a tiling window manager (i3, Sway, Aerospace, yabai) you already tile
+windows. tmux then runs a second tiling system inside the terminal: competing
+keybinds, nested navigation, panes that duplicate what your WM windows already
+do. tap keeps the one feature you actually came for, session persistence, and
+drops the rest. Your WM tiles; tap persists.
+
+## Commands
+
+```sh
+tap                       # start a session (interactive $SHELL)
+tap start <cmd...>        # start a session running a command
+tap start -d <cmd...>     # start in the background, do not attach
+tap attach [id]           # attach to a session (most recent if omitted)
+tap list                  # list live sessions
+tap kill [id]             # stop a session and its child
+tap scrollback [-s id]    # print the session's screen as text
+tap cursor [-s id]        # print the cursor position
+tap size [-s id]          # print the negotiated size
+tap inject [-s id] <text> # type text into a session without attaching
+tap subscribe [-s id]     # stream the session's raw output
+```
+
+Detach from an attached session with `Ctrl-\`. Open the scrollback in `$EDITOR`
+with `Alt-e`. Both keybinds are configurable (see Configuration).
+
+## Multiplayer
+
+Several clients can attach to the same session and see the same screen live.
+Input from any client reaches the shared child, so two people can drive one
+terminal. The session is sized to the **smallest** attached client (the
+element-wise minimum of every client's rows and columns), the same rule tmux
+uses, so no client ever sees clipped output. A client whose own terminal is
+larger than the negotiated size gets a dim warning on its bottom row noting that
+the extra space is unused.
+
+```sh
+# terminal A
+tap start --id pair bash
+# terminal B (anywhere on the same machine)
+tap attach pair
+```
+
+## Running it
+
+tap is a package in this repository's Cargo workspace, exposed as a flake app:
+
+```sh
+nix run .#tap -- <args>     # run
+nix build .#tap             # build the binary
+```
+
+## Architecture
+
+tap is one daemon per session plus any number of thin clients, connected over a
+per-session Unix socket speaking newline-delimited JSON (binary payloads ride as
+base64). Every interactive `tap`, even for a single user, is a client of a
+daemon. That uniformity is what makes resize-while-attached and multi-client
+sharing work: the daemon owns the PTY and the screen, and clients only render it
+and forward keystrokes.
+
+The code is three composable crates:
+
+- [`tap-pty`](pty) is the reusable session engine: it spawns a child on a real
+  PTY (via [`pty-process`](https://docs.rs/pty-process)), mirrors it in a
+  [`vt100`](https://docs.rs/vt100) emulator, and fans the raw output out to many
+  subscribers. A new subscriber gets an atomic resync snapshot (the escape
+  sequences that reproduce the current screen) joined to the live stream with no
+  gap and no duplicated byte, which is what makes attaching to a running
+  full-screen TUI paint correctly.
+- [`tap-protocol`](protocol) is the wire types and runtime paths, with no I/O.
+- `tap` (this crate) is the CLI, the daemon, and the attach client.
+
+Integration tests in [`tests/integration.rs`](tests/integration.rs) drive the
+real `tap` binary on a PTY using this repository's [`tui`](../tui) driver and
+assert on the rendered grid: round-trip input, full-screen resync on a second
+attach, multiplayer min-size negotiation, and resize-while-attached.
+
+## Configuration
+
+Optional, at `~/.config/tap/config.toml`:
+
+```toml
+editor = "nvim"            # overrides $EDITOR / $VISUAL for the Alt-e keybind
+
+[keybinds]
+editor = "Alt-e"
+detach = "Ctrl-\\"
+
+[timing]
+escape_timeout_ms = 50     # window to tell a lone ESC from an Alt- sequence
+```
+
+Session sockets and the session index live under `$XDG_RUNTIME_DIR/tap` (falling
+back to `~/.tap`). Set `TAP_RUNTIME_DIR` to relocate them, for example to isolate
+test state.
+
+## Known limitations
+
+- Unix only (Linux and macOS). It relies on PTYs, `SIGWINCH`, and `setsid`.
+- Sessions are local to one machine and one user; there is no network transport
+  or cross-user access. The socket lives in the user's runtime directory.
+- A client that falls far behind the output stream is resynced from a fresh
+  snapshot rather than a byte-exact replay, so a burst can skip intermediate
+  frames on a slow link.
+- The `Alt-e` editor keybind is detected with a short escape timeout; on a slow
+  or split input read a literal `Alt-e` can be delayed by `escape_timeout_ms`.

--- a/packages/tap/default.nix
+++ b/packages/tap/default.nix
@@ -1,0 +1,6 @@
+{ ix, ... }:
+
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "tap";
+  meta.mainProgram = "tap";
+}

--- a/packages/tap/package.nix
+++ b/packages/tap/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "tap";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/tap/protocol/Cargo.toml
+++ b/packages/tap/protocol/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tap-protocol"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Wire protocol and runtime paths for tap terminal sessions"
+
+[lints]
+workspace = true
+
+[dependencies]
+base64.workspace = true
+dirs.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true

--- a/packages/tap/protocol/package.nix
+++ b/packages/tap/protocol/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "tap-protocol";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/tap/protocol/src/lib.rs
+++ b/packages/tap/protocol/src/lib.rs
@@ -1,0 +1,227 @@
+//! Wire protocol and runtime paths for [`tap`](https://github.com/indexable-inc/index)
+//! terminal sessions.
+//!
+//! A `tap` client and the session daemon speak newline-delimited JSON over a
+//! Unix domain socket: one [`Request`] or [`Response`] object per line. Binary
+//! payloads (raw PTY bytes, resync snapshots) ride as base64 strings so a frame
+//! never contains a literal newline and the stream stays line-splittable.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Environment variable that overrides the directory holding session sockets and
+/// the session index. Set it to isolate state (tests use this).
+pub const RUNTIME_DIR_ENV: &str = "TAP_RUNTIME_DIR";
+
+/// Session metadata persisted in the session index file.
+///
+/// `started_unix` is seconds since the Unix epoch, recorded by the daemon at
+/// spawn. Readers resolve liveness from `pid` and `socket` rather than trusting
+/// this record, so a crashed daemon's stale entry is ignored, not shown.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Session {
+    /// Human-readable session id, also the socket file stem.
+    pub id: String,
+    /// PID of the owning daemon process.
+    pub pid: u32,
+    /// Seconds since the Unix epoch when the session started.
+    pub started_unix: u64,
+    /// The command (argv) the session runs.
+    pub command: Vec<String>,
+    /// Absolute path to the session's Unix socket.
+    pub socket: PathBuf,
+}
+
+/// A request from a client to the session daemon. One JSON object per line.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Request {
+    /// Take over the session as an interactive client of the given terminal
+    /// size. The connection then streams [`Response`] events until detach.
+    Attach {
+        /// Client terminal rows.
+        rows: u16,
+        /// Client terminal columns.
+        cols: u16,
+    },
+    /// Leave an attached session, keeping the daemon and child alive.
+    Detach,
+    /// Forward keystrokes from an attached client to the child.
+    Input {
+        /// Raw input bytes (base64 on the wire).
+        #[serde(with = "b64")]
+        data: Vec<u8>,
+    },
+    /// Report a new client terminal size (drives min-size negotiation).
+    Resize {
+        /// New client terminal rows.
+        rows: u16,
+        /// New client terminal columns.
+        cols: u16,
+    },
+    /// Write text into the child without attaching (scripting hook).
+    Inject {
+        /// UTF-8 text to feed to the child.
+        data: String,
+    },
+    /// Stream raw output without contributing to size negotiation or input.
+    Subscribe,
+    /// Read the current screen as plain text, optionally the last `lines` rows.
+    GetScrollback {
+        /// Limit to the last N rows, or the whole screen when `None`.
+        lines: Option<usize>,
+    },
+    /// Read the current cursor position.
+    GetCursor,
+    /// Read the negotiated session size.
+    GetSize,
+    /// Terminate the session: kill the child and shut the daemon down.
+    Kill,
+}
+
+/// A response or event from the daemon to a client. One JSON object per line.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Response {
+    /// Attach accepted. `snapshot` reproduces the current screen (colors and
+    /// cursor) so the freshly attached terminal paints correctly; `rows`/`cols`
+    /// are the negotiated session size.
+    Attached {
+        /// Negotiated session rows.
+        rows: u16,
+        /// Negotiated session columns.
+        cols: u16,
+        /// Escape-sequence snapshot of the current screen (base64 on the wire).
+        #[serde(with = "b64")]
+        snapshot: Vec<u8>,
+    },
+    /// Live child output (base64 on the wire).
+    Output {
+        /// Raw output bytes.
+        #[serde(with = "b64")]
+        data: Vec<u8>,
+    },
+    /// The negotiated session size changed. `snapshot` is a fresh repaint of the
+    /// resized screen so every client converges without waiting for the child.
+    Resized {
+        /// New negotiated session rows.
+        rows: u16,
+        /// New negotiated session columns.
+        cols: u16,
+        /// Escape-sequence snapshot of the resized screen (base64 on the wire).
+        #[serde(with = "b64")]
+        snapshot: Vec<u8>,
+    },
+    /// Plain-text screen contents.
+    Scrollback {
+        /// The requested screen text.
+        content: String,
+    },
+    /// Cursor position (0-indexed row, col).
+    Cursor {
+        /// Cursor row.
+        row: u16,
+        /// Cursor column.
+        col: u16,
+    },
+    /// Negotiated session size.
+    Size {
+        /// Session rows.
+        rows: u16,
+        /// Session columns.
+        cols: u16,
+    },
+    /// Subscription confirmed; `Output` events follow.
+    Subscribed,
+    /// The child exited; the daemon is shutting the session down.
+    SessionEnded {
+        /// Resolved child exit code (128 + signal when signalled).
+        exit_code: i32,
+    },
+    /// A control request succeeded.
+    Ok,
+    /// A request failed.
+    Error {
+        /// Operator-facing message.
+        message: String,
+    },
+}
+
+/// Directory holding session sockets and the session index.
+///
+/// Honors [`RUNTIME_DIR_ENV`], then the XDG runtime dir, then `~/.tap`, then a
+/// temp-dir fallback so the path resolves even without a session bus.
+#[must_use]
+pub fn runtime_dir() -> PathBuf {
+    if let Some(dir) = std::env::var_os(RUNTIME_DIR_ENV) {
+        return PathBuf::from(dir);
+    }
+    dirs::runtime_dir()
+        .map(|d| d.join("tap"))
+        .or_else(|| dirs::home_dir().map(|h| h.join(".tap")))
+        .unwrap_or_else(|| std::env::temp_dir().join("tap"))
+}
+
+/// Socket path for a session id.
+#[must_use]
+pub fn socket_path(session_id: &str) -> PathBuf {
+    runtime_dir().join(format!("{session_id}.sock"))
+}
+
+/// Path to the JSON session index.
+#[must_use]
+pub fn sessions_file() -> PathBuf {
+    runtime_dir().join("sessions.json")
+}
+
+/// Serde adapter that stores a byte vector as a base64 string on the wire.
+mod b64 {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD;
+    use serde::{Deserialize as _, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&STANDARD.encode(bytes))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
+        let encoded = String::deserialize(deserializer)?;
+        STANDARD
+            .decode(encoded.as_bytes())
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_round_trips_arbitrary_bytes_through_base64() {
+        let original = Response::Output {
+            data: vec![0x00, 0x1b, b'[', b'3', b'1', b'm', 0xff, b'\n'],
+        };
+        let line = serde_json::to_string(&original).unwrap();
+
+        // A frame must stay on one line so newline-splitting the stream is safe.
+        assert!(!line.trim_end().contains('\n'));
+
+        let decoded: Response = serde_json::from_str(&line).unwrap();
+        match decoded {
+            Response::Output { data } => {
+                assert_eq!(data, vec![0x00, 0x1b, b'[', b'3', b'1', b'm', 0xff, b'\n']);
+            }
+            other => panic!("expected Output, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn runtime_dir_honors_env_override() {
+        // Safe in a single-threaded unit test; documents the test-isolation hook.
+        unsafe { std::env::set_var(RUNTIME_DIR_ENV, "/tmp/tap-test-xyz") };
+        assert_eq!(runtime_dir(), PathBuf::from("/tmp/tap-test-xyz"));
+        assert_eq!(socket_path("s1"), PathBuf::from("/tmp/tap-test-xyz/s1.sock"));
+        unsafe { std::env::remove_var(RUNTIME_DIR_ENV) };
+    }
+}

--- a/packages/tap/pty/Cargo.toml
+++ b/packages/tap/pty/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tap-pty"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Multiplexable PTY session engine: spawn a child on a PTY, mirror it with vt100, and fan raw output out to many subscribers with atomic resync snapshots"
+
+[lints]
+workspace = true
+
+[dependencies]
+bytes.workspace = true
+parking_lot.workspace = true
+pty-process.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["io-util", "macros", "process", "rt", "sync", "time"] }
+vt100.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/packages/tap/pty/package.nix
+++ b/packages/tap/pty/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "tap-pty";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/tap/pty/src/lib.rs
+++ b/packages/tap/pty/src/lib.rs
@@ -1,0 +1,418 @@
+//! Multiplexable PTY session engine.
+//!
+//! [`PtySession::spawn`] runs a child on a real PTY and mirrors its output into
+//! a [`vt100`] emulator. Any number of subscribers can [`subscribe`] to the live
+//! raw byte stream, and each subscription starts with a `snapshot`: the escape
+//! sequences that reproduce the current screen (colors, attributes, cursor) so a
+//! freshly attached terminal paints the right thing instead of a blank rectangle.
+//!
+//! The snapshot and the live stream are handed out atomically: the actor holds
+//! the emulator lock across both the `process` of new bytes and their broadcast,
+//! so a subscriber that snapshots under the same lock can never miss or duplicate
+//! a byte across the join. That property is what makes late attach correct, which
+//! is the bug a session manager has to get right.
+//!
+//! [`subscribe`]: PtySession::subscribe
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use parking_lot::Mutex;
+use snafu::{OptionExt as _, ResultExt as _, Snafu};
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::sync::{broadcast, mpsc, watch};
+
+/// How many output chunks the broadcast buffers before a slow subscriber lags.
+/// A lagged subscriber resyncs from a fresh snapshot, so this only bounds memory.
+const OUTPUT_CHANNEL_CAP: usize = 1024;
+
+/// PTY read buffer size, matching the engine in `packages/tui`.
+const READ_BUFFER_SIZE: usize = 8192;
+
+/// Errors from the PTY session engine.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum Error {
+    /// The command (argv) was empty, so there is no program to run.
+    #[snafu(display("cannot spawn a session with an empty command"))]
+    EmptyCommand,
+    /// Opening the PTY master failed.
+    #[snafu(display("failed to open PTY: {source}"))]
+    OpenPty {
+        /// Underlying OS error.
+        source: std::io::Error,
+    },
+    /// Acquiring the PTY slave failed.
+    #[snafu(display("failed to get PTY slave: {source}"))]
+    Pts {
+        /// Underlying OS error.
+        source: std::io::Error,
+    },
+    /// Sizing the PTY failed.
+    #[snafu(display("failed to size PTY: {source}"))]
+    Resize {
+        /// Underlying OS error.
+        source: std::io::Error,
+    },
+    /// Spawning the child process failed.
+    #[snafu(display("failed to spawn `{program}`: {source}"))]
+    Spawn {
+        /// The program that failed to start.
+        program: String,
+        /// Underlying OS error.
+        source: std::io::Error,
+    },
+    /// The session actor has stopped, so the request cannot be served.
+    #[snafu(display("session has stopped"))]
+    Stopped,
+}
+
+/// Result alias for this crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Parameters for [`PtySession::spawn`].
+#[derive(Debug, Clone)]
+pub struct SessionConfig {
+    /// Command to run as argv; `command[0]` is the program.
+    pub command: Vec<String>,
+    /// Initial terminal rows.
+    pub rows: u16,
+    /// Initial terminal columns.
+    pub cols: u16,
+    /// Lines of scrollback the emulator retains.
+    pub scrollback_lines: usize,
+}
+
+/// A live attachment: a resync `snapshot` plus the raw output stream.
+///
+/// The snapshot reproduces the screen at the moment of attach; `output` carries
+/// every byte the child emits after that, with no gap and no overlap.
+pub struct Attachment {
+    /// Escape sequences reproducing the current screen.
+    pub snapshot: Vec<u8>,
+    /// Live raw output following the snapshot.
+    pub output: broadcast::Receiver<Bytes>,
+}
+
+/// Commands sent from a [`PtySession`] handle to its owning actor task. Only the
+/// actor touches the PTY fd, so writes and PTY resizes serialize through here.
+enum Command {
+    Write(Vec<u8>),
+    ResizePty { rows: u16, cols: u16 },
+    Kill,
+}
+
+/// A running PTY-backed session. Clone-free handle whose methods talk to the
+/// actor; cheap reads (screen, cursor, size) go straight to the shared emulator.
+pub struct PtySession {
+    emulator: Arc<Mutex<vt100::Parser>>,
+    output_tx: broadcast::Sender<Bytes>,
+    commands: mpsc::UnboundedSender<Command>,
+    exit_rx: watch::Receiver<Option<i32>>,
+}
+
+impl PtySession {
+    /// Spawn `config.command` on a fresh PTY sized `rows`×`cols`.
+    ///
+    /// Must be called from within a Tokio runtime: it starts the actor task and
+    /// creates a [`tokio::process::Child`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error`] if the command is empty or the PTY/child cannot be
+    /// created.
+    pub fn spawn(config: SessionConfig) -> Result<Self> {
+        let SessionConfig {
+            command,
+            rows,
+            cols,
+            scrollback_lines,
+        } = config;
+        let (program, args) = command.split_first().context(EmptyCommandSnafu)?;
+
+        let pty = pty_process::Pty::new()
+            .map_err(std::io::Error::other)
+            .context(OpenPtySnafu)?;
+        let pts = pty
+            .pts()
+            .map_err(std::io::Error::other)
+            .context(PtsSnafu)?;
+        pty.resize(pty_process::Size::new(rows, cols))
+            .map_err(std::io::Error::other)
+            .context(ResizeSnafu)?;
+        let child = pty_process::Command::new(program)
+            .args(args)
+            .spawn(&pts)
+            .map_err(std::io::Error::other)
+            .context(SpawnSnafu {
+                program: program.clone(),
+            })?;
+
+        let emulator = Arc::new(Mutex::new(vt100::Parser::new(rows, cols, scrollback_lines)));
+        let (output_tx, _) = broadcast::channel(OUTPUT_CHANNEL_CAP);
+        let (commands, command_rx) = mpsc::unbounded_channel();
+        let (exit_tx, exit_rx) = watch::channel(None);
+
+        let actor_emulator = Arc::clone(&emulator);
+        let actor_output = output_tx.clone();
+        tokio::spawn(async move {
+            actor(pty, child, actor_emulator, actor_output, command_rx, exit_tx).await;
+        });
+
+        Ok(Self {
+            emulator,
+            output_tx,
+            commands,
+            exit_rx,
+        })
+    }
+
+    /// Start a live attachment: the current screen as a resync snapshot plus the
+    /// raw output stream that follows it with no gap.
+    #[must_use]
+    pub fn subscribe(&self) -> Attachment {
+        // Snapshot and subscribe under the emulator lock the actor also holds
+        // across process+broadcast, so the join is exactly once: no byte is both
+        // in the snapshot and the first stream item, and none is dropped between.
+        let emulator = self.emulator.lock();
+        let snapshot = emulator.screen().contents_formatted();
+        let output = self.output_tx.subscribe();
+        drop(emulator);
+        Attachment { snapshot, output }
+    }
+
+    /// Escape sequences reproducing the current screen.
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<u8> {
+        self.emulator.lock().screen().contents_formatted()
+    }
+
+    /// Forward raw input bytes to the child.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Stopped`] if the session actor has exited.
+    pub fn write_input(&self, data: Vec<u8>) -> Result<()> {
+        self.commands
+            .send(Command::Write(data))
+            .map_err(|_| StoppedSnafu.build())
+    }
+
+    /// Resize the session. Updates the emulator immediately so a snapshot taken
+    /// right after reflects the new geometry, and queues the kernel PTY resize
+    /// (which delivers `SIGWINCH` to the child) on the actor.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Stopped`] if the session actor has exited.
+    pub fn resize(&self, rows: u16, cols: u16) -> Result<()> {
+        self.emulator.lock().screen_mut().set_size(rows, cols);
+        self.commands
+            .send(Command::ResizePty { rows, cols })
+            .map_err(|_| StoppedSnafu.build())
+    }
+
+    /// Terminate the child (SIGKILL). The session shuts down once it is reaped.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Stopped`] if the session actor has exited.
+    pub fn kill(&self) -> Result<()> {
+        self.commands
+            .send(Command::Kill)
+            .map_err(|_| StoppedSnafu.build())
+    }
+
+    /// Current screen as plain text, optionally only the last `lines` rows.
+    #[must_use]
+    pub fn scrollback(&self, lines: Option<usize>) -> String {
+        let emulator = self.emulator.lock();
+        let contents = emulator.screen().contents();
+        drop(emulator);
+        match lines {
+            Some(n) => {
+                let rows: Vec<&str> = contents.lines().collect();
+                let start = rows.len().saturating_sub(n);
+                rows.into_iter().skip(start).collect::<Vec<_>>().join("\n")
+            }
+            None => contents,
+        }
+    }
+
+    /// Cursor position as `(row, col)`, both 0-indexed.
+    #[must_use]
+    pub fn cursor(&self) -> (u16, u16) {
+        self.emulator.lock().screen().cursor_position()
+    }
+
+    /// Current emulator size as `(rows, cols)`.
+    #[must_use]
+    pub fn size(&self) -> (u16, u16) {
+        self.emulator.lock().screen().size()
+    }
+
+    /// Whether the child has switched to the alternate screen (full-screen TUI).
+    #[must_use]
+    pub fn alternate_screen(&self) -> bool {
+        self.emulator.lock().screen().alternate_screen()
+    }
+
+    /// A watch receiver that becomes `Some(exit_code)` when the child exits.
+    #[must_use]
+    pub fn exit_watch(&self) -> watch::Receiver<Option<i32>> {
+        self.exit_rx.clone()
+    }
+
+    /// The child's resolved exit code, or `None` while it is still running.
+    #[must_use]
+    pub fn exit_code(&self) -> Option<i32> {
+        *self.exit_rx.borrow()
+    }
+}
+
+/// Resolve a child's wait status into a conventional exit code: the raw code, or
+/// `128 + signal` when it was signalled, or `-1` when the status is unavailable.
+fn resolve_exit_code(status: std::io::Result<std::process::ExitStatus>) -> i32 {
+    use std::os::unix::process::ExitStatusExt as _;
+    status.map_or(-1, |status| {
+        status
+            .code()
+            .or_else(|| status.signal().map(|signal| 128 + signal))
+            .unwrap_or(-1)
+    })
+}
+
+/// The single task that owns the PTY master and the child. Every PTY read, write,
+/// resize, and the child reap serialize here, which keeps the emulator mirror and
+/// the broadcast stream consistent for all subscribers.
+async fn actor(
+    mut pty: pty_process::Pty,
+    mut child: tokio::process::Child,
+    emulator: Arc<Mutex<vt100::Parser>>,
+    output_tx: broadcast::Sender<Bytes>,
+    mut commands: mpsc::UnboundedReceiver<Command>,
+    exit_tx: watch::Sender<Option<i32>>,
+) {
+    let mut read_buffer = [0u8; READ_BUFFER_SIZE];
+    let mut pty_active = true;
+    let mut child_exited = false;
+    let mut commands_open = true;
+
+    loop {
+        tokio::select! {
+            biased;
+
+            command = commands.recv(), if commands_open => match command {
+                Some(Command::Write(data)) => if pty_active {
+                    let _ = pty.write_all(&data).await;
+                },
+                Some(Command::ResizePty { rows, cols }) => if pty_active {
+                    let _ = pty.resize(pty_process::Size::new(rows, cols));
+                },
+                Some(Command::Kill) => {
+                    // Harmless no-op if already reaped, so a redundant kill is fine.
+                    let _ = child.start_kill();
+                },
+                None => commands_open = false,
+            },
+
+            result = pty.read(&mut read_buffer), if pty_active => match result {
+                Ok(0) | Err(_) => pty_active = false,
+                Ok(n) => {
+                    let chunk = Bytes::copy_from_slice(&read_buffer[..n]);
+                    // Hold the emulator lock across process+broadcast so a
+                    // concurrent subscribe() snapshots a consistent screen and
+                    // joins the stream exactly once. send() is non-blocking.
+                    let mut guard = emulator.lock();
+                    guard.process(&chunk);
+                    let _ = output_tx.send(chunk);
+                    drop(guard);
+                }
+            },
+
+            status = child.wait(), if !child_exited => {
+                child_exited = true;
+                let _ = exit_tx.send(Some(resolve_exit_code(status)));
+            },
+
+            else => break,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    async fn wait_until<F: Fn() -> bool>(predicate: F) -> bool {
+        for _ in 0..200 {
+            if predicate() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        predicate()
+    }
+
+    #[tokio::test]
+    async fn mirrors_child_output_into_the_screen() {
+        let session = PtySession::spawn(SessionConfig {
+            command: vec!["sh".into(), "-c".into(), "printf 'hello from pty'".into()],
+            rows: 24,
+            cols: 80,
+            scrollback_lines: 1000,
+        })
+        .expect("spawn session");
+
+        assert!(
+            wait_until(|| session.scrollback(None).contains("hello from pty")).await,
+            "screen never showed child output: {:?}",
+            session.scrollback(None)
+        );
+    }
+
+    #[tokio::test]
+    async fn late_subscriber_gets_a_snapshot_of_prior_output() {
+        let session = PtySession::spawn(SessionConfig {
+            command: vec!["sh".into(), "-c".into(), "printf 'before attach'; sleep 5".into()],
+            rows: 24,
+            cols: 80,
+            scrollback_lines: 1000,
+        })
+        .expect("spawn session");
+
+        assert!(wait_until(|| session.scrollback(None).contains("before attach")).await);
+
+        // A subscriber that joins after the output was produced still sees it,
+        // because subscribe() carries a snapshot of the current screen.
+        let attachment = session.subscribe();
+        let snapshot = String::from_utf8_lossy(&attachment.snapshot);
+        assert!(
+            snapshot.contains("before attach"),
+            "snapshot missing prior output: {snapshot:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reports_child_exit_code() {
+        let session = PtySession::spawn(SessionConfig {
+            command: vec!["sh".into(), "-c".into(), "exit 7".into()],
+            rows: 24,
+            cols: 80,
+            scrollback_lines: 100,
+        })
+        .expect("spawn session");
+
+        let mut exit = session.exit_watch();
+        let code = tokio::time::timeout(Duration::from_secs(5), async {
+            exit.wait_for(Option::is_some).await.map(|v| v.unwrap())
+        })
+        .await
+        .expect("child exited in time")
+        .expect("exit watch open");
+
+        assert_eq!(code, 7);
+    }
+}

--- a/packages/tap/src/attach.rs
+++ b/packages/tap/src/attach.rs
@@ -1,0 +1,258 @@
+//! The interactive attach client.
+//!
+//! It runs the controlling terminal in raw mode, forwards keystrokes (minus its
+//! own keybinds) to the daemon, and renders the daemon's output. Two behaviors
+//! the original tap lacked: a `SIGWINCH` here sends a `Resize` so the session
+//! tracks the live window, and the daemon's `Attached`/`Resized` snapshots are
+//! repainted so a full-screen TUI shows up correctly on (re)attach. When the
+//! negotiated session size differs from this terminal (a smaller client is
+//! sharing the session), a dim warning is drawn on the bottom row.
+
+use std::io::Write as _;
+use std::path::Path;
+
+use anyhow::{Context as _, Result, bail};
+use tap_protocol::{Request, Response};
+use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _, BufReader, Lines, Stdout};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::signal::unix::{SignalKind, signal};
+
+use crate::client::{self, resolve_socket};
+use crate::config;
+use crate::editor;
+use crate::input::{InputProcessor, InputResult, KeybindAction};
+use crate::term::{self, RawGuard};
+
+const INPUT_BUFFER_SIZE: usize = 4096;
+
+/// The established attach connection plus the negotiated session size.
+struct AttachConn {
+    reader: Lines<BufReader<OwnedReadHalf>>,
+    writer: OwnedWriteHalf,
+    sess_rows: u16,
+    sess_cols: u16,
+}
+
+/// What to do after handling one server frame.
+enum Event {
+    Continue,
+    Ended(i32),
+}
+
+/// Attach to a session and run until detach or session end.
+///
+/// On session end this exits the process with the child's exit code; on detach
+/// it returns so the CLI exits cleanly.
+///
+/// # Errors
+///
+/// Returns an error if the session cannot be reached or the attach handshake
+/// fails.
+// The attach client owns the controlling terminal through a raw-mode guard held
+// across the whole loop, so its future is intentionally thread-bound; it only
+// ever runs on the main thread via the runtime's block_on, never spawned.
+#[allow(clippy::future_not_send, reason = "owns the tty; runs only on the main thread")]
+pub async fn run(session: Option<String>) -> Result<()> {
+    let (label, socket) = resolve_socket(session)?;
+    let (mut my_rows, mut my_cols) = term::current_winsize();
+    // Held for the whole session; restores the terminal on every exit path.
+    let raw = RawGuard::enter();
+    let mut stdout = tokio::io::stdout();
+
+    let AttachConn {
+        mut reader,
+        mut writer,
+        mut sess_rows,
+        mut sess_cols,
+    } = handshake(&socket, &label, my_rows, my_cols, &mut stdout).await?;
+    draw_size_warning(my_rows, my_cols, sess_rows, sess_cols);
+
+    let config = config::load()?;
+    let mut input = InputProcessor::new(&config)?;
+    let editor_cmd = config::editor_command(&config);
+
+    let mut winch = signal(SignalKind::window_change()).context("installing SIGWINCH handler")?;
+    let mut stdin = tokio::io::stdin();
+    let mut stdin_buf = [0u8; INPUT_BUFFER_SIZE];
+
+    let mut ended: Option<i32> = None;
+    let mut detached = false;
+
+    loop {
+        tokio::select! {
+            line = reader.next_line() => match line {
+                Ok(Some(line)) => {
+                    match handle_server_frame(&line, &mut stdout, (my_rows, my_cols), (&mut sess_rows, &mut sess_cols)).await? {
+                        Event::Continue => {}
+                        Event::Ended(code) => {
+                            ended = Some(code);
+                            break;
+                        }
+                    }
+                }
+                Ok(None) | Err(_) => break,
+            },
+            read = stdin.read(&mut stdin_buf) => match read {
+                Ok(0) | Err(_) => break,
+                Ok(n) => match input.process(&stdin_buf[..n]) {
+                    InputResult::Passthrough(bytes) => {
+                        if !bytes.is_empty() {
+                            send_request(&mut writer, &Request::Input { data: bytes }).await?;
+                        }
+                    }
+                    InputResult::Action(KeybindAction::Detach) => {
+                        detached = true;
+                        break;
+                    }
+                    InputResult::Action(KeybindAction::OpenEditor) => {
+                        if let Some(guard) = raw.as_ref() {
+                            open_editor(&socket, &editor_cmd, guard, &mut writer, my_rows, my_cols).await;
+                        }
+                    }
+                    InputResult::NeedMore => {}
+                },
+            },
+            _ = winch.recv() => {
+                let (rows, cols) = term::current_winsize();
+                my_rows = rows;
+                my_cols = cols;
+                send_request(&mut writer, &Request::Resize { rows, cols }).await?;
+            }
+            () = tokio::time::sleep(input.escape_timeout()), if input.has_pending_escape() => {
+                if let InputResult::Passthrough(bytes) = input.timeout_escape()
+                    && !bytes.is_empty()
+                {
+                    send_request(&mut writer, &Request::Input { data: bytes }).await?;
+                }
+            }
+        }
+    }
+
+    if detached {
+        let _ = send_request(&mut writer, &Request::Detach).await;
+    }
+    // Restore the terminal before printing the closing line.
+    drop(raw);
+    if let Some(code) = ended {
+        println!("[session ended]");
+        std::process::exit(code);
+    }
+    println!("[detached]");
+    Ok(())
+}
+
+/// Open the connection, send `Attach`, and paint the initial snapshot.
+async fn handshake(
+    socket: &Path,
+    label: &str,
+    my_rows: u16,
+    my_cols: u16,
+    stdout: &mut Stdout,
+) -> Result<AttachConn> {
+    let stream = UnixStream::connect(socket)
+        .await
+        .with_context(|| format!("connecting to session '{label}'"))?;
+    let (read_half, mut writer) = stream.into_split();
+    let mut reader = BufReader::new(read_half).lines();
+
+    send_request(&mut writer, &Request::Attach { rows: my_rows, cols: my_cols }).await?;
+    let first = reader
+        .next_line()
+        .await?
+        .context("session closed before attaching")?;
+    let (sess_rows, sess_cols) =
+        match serde_json::from_str::<Response>(&first).context("parsing attach response")? {
+            Response::Attached { rows, cols, snapshot } => {
+                paint(stdout, &snapshot).await?;
+                (rows, cols)
+            }
+            Response::Error { message } => bail!("attach failed: {message}"),
+            other => bail!("unexpected attach response: {other:?}"),
+        };
+    Ok(AttachConn { reader, writer, sess_rows, sess_cols })
+}
+
+/// Render one server frame; report whether the session has ended.
+async fn handle_server_frame(
+    line: &str,
+    stdout: &mut Stdout,
+    mine: (u16, u16),
+    session: (&mut u16, &mut u16),
+) -> Result<Event> {
+    let Ok(response) = serde_json::from_str::<Response>(line) else {
+        return Ok(Event::Continue);
+    };
+    match response {
+        Response::Output { data } => {
+            stdout.write_all(&data).await?;
+            stdout.flush().await?;
+        }
+        Response::Resized { rows, cols, snapshot } => {
+            *session.0 = rows;
+            *session.1 = cols;
+            paint(stdout, &snapshot).await?;
+            draw_size_warning(mine.0, mine.1, rows, cols);
+        }
+        Response::SessionEnded { exit_code } => return Ok(Event::Ended(exit_code)),
+        _ => {}
+    }
+    Ok(Event::Continue)
+}
+
+/// Clear the screen and paint a daemon snapshot (full screen with colors/cursor).
+async fn paint(stdout: &mut Stdout, snapshot: &[u8]) -> Result<()> {
+    stdout.write_all(b"\x1b[2J\x1b[H").await?;
+    stdout.write_all(snapshot).await?;
+    stdout.flush().await?;
+    Ok(())
+}
+
+/// Draw a dim warning on the bottom row when this terminal does not match the
+/// negotiated session size. Best-effort: a full-screen app may overwrite it, and
+/// it is redrawn on the next resize.
+fn draw_size_warning(my_rows: u16, my_cols: u16, sess_rows: u16, sess_cols: u16) {
+    if (my_rows, my_cols) == (sess_rows, sess_cols) {
+        return;
+    }
+    let detail = if my_rows < sess_rows || my_cols < sess_cols {
+        "content may be clipped"
+    } else {
+        "extra space is unused"
+    };
+    let message =
+        format!("[tap] terminal {my_rows}x{my_cols} != session {sess_rows}x{sess_cols} (smallest client wins); {detail}");
+    let message: String = message.chars().take(my_cols as usize).collect();
+    // Save cursor, go to the bottom row, dim + clear line, print, restore cursor.
+    let mut out = std::io::stdout();
+    let _ = write!(out, "\x1b7\x1b[{my_rows};1H\x1b[2m\x1b[K{message}\x1b[0m\x1b8");
+    let _ = out.flush();
+}
+
+/// Open the scrollback in the editor, then ask the daemon to repaint.
+// Holds the raw-mode guard across the scrollback fetch; like `run`, this is a
+// main-thread-only future by construction.
+#[allow(clippy::future_not_send, reason = "holds the tty guard; runs only on the main thread")]
+async fn open_editor(
+    socket: &Path,
+    editor_cmd: &str,
+    guard: &RawGuard,
+    writer: &mut OwnedWriteHalf,
+    my_rows: u16,
+    my_cols: u16,
+) {
+    let content = client::fetch_scrollback(socket).await.unwrap_or_default();
+    // The editor owns the tty while it runs; the guard restores raw mode after.
+    let _ = editor::open(&content, editor_cmd, guard, None);
+    // Reassert our size to make the daemon send a fresh repaint snapshot.
+    let _ = send_request(writer, &Request::Resize { rows: my_rows, cols: my_cols }).await;
+}
+
+/// Write one newline-delimited JSON request frame.
+async fn send_request(writer: &mut OwnedWriteHalf, request: &Request) -> Result<()> {
+    let mut line = serde_json::to_string(request).context("serializing request")?;
+    line.push('\n');
+    writer.write_all(line.as_bytes()).await?;
+    writer.flush().await?;
+    Ok(())
+}

--- a/packages/tap/src/client.rs
+++ b/packages/tap/src/client.rs
@@ -1,0 +1,311 @@
+//! Client commands: starting sessions, listing them, and one-shot control
+//! queries. The interactive attach loop lives in [`crate::attach`].
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context as _, Result, anyhow, bail};
+use tap_protocol::{Request, Response};
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::OwnedWriteHalf;
+
+use crate::{attach, index, names};
+
+const SHELL_FALLBACK: &str = "/bin/sh";
+/// How long to wait for a freshly spawned daemon to bind its socket.
+const DAEMON_STARTUP_POLLS: u32 = 300;
+const DAEMON_STARTUP_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Start a session and either attach to it or, when `detached`, return.
+///
+/// # Errors
+///
+/// Returns an error if the daemon cannot be spawned or, in the attached case, if
+/// attach fails.
+// Awaits the attach client, whose future is thread-bound by design; this runs
+// only on the main thread via the runtime's block_on.
+#[allow(clippy::future_not_send, reason = "delegates to the main-thread attach loop")]
+pub async fn start(command: Vec<String>, detached: bool, id: Option<String>) -> Result<()> {
+    let session_id = id.unwrap_or_else(names::generate);
+    let argv = resolve_command(command);
+    spawn_daemon(&session_id, &argv).await?;
+
+    if detached {
+        println!("started session {session_id}");
+        println!("attach with: tap attach {session_id}");
+        Ok(())
+    } else {
+        attach::run(Some(session_id)).await
+    }
+}
+
+/// Resolve the command to run, defaulting to an interactive `$SHELL`.
+fn resolve_command(command: Vec<String>) -> Vec<String> {
+    if !command.is_empty() {
+        return command;
+    }
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| SHELL_FALLBACK.to_string());
+    // Force interactive/login mode so the shell loads its config in the session.
+    if shell.ends_with("/nu") || shell.ends_with("/nushell") {
+        vec![shell, "-l".to_string()]
+    } else if shell.ends_with("/bash") || shell.ends_with("/zsh") {
+        vec![shell, "-i".to_string()]
+    } else {
+        vec![shell]
+    }
+}
+
+/// Spawn the session daemon detached from the controlling terminal and wait for
+/// its socket to appear.
+async fn spawn_daemon(id: &str, argv: &[String]) -> Result<PathBuf> {
+    use std::process::Stdio;
+
+    let exe = std::env::current_exe().context("locating the tap executable")?;
+    let runtime_dir = tap_protocol::runtime_dir();
+    std::fs::create_dir_all(&runtime_dir)
+        .with_context(|| format!("creating runtime dir {}", runtime_dir.display()))?;
+    let socket = tap_protocol::socket_path(id);
+    let _ = std::fs::remove_file(&socket);
+
+    // Daemon diagnostics land in a per-session log so a failed start is not
+    // silent; stdin/stdout are detached from the terminal.
+    let log = std::fs::File::create(runtime_dir.join(format!("{id}.log")))
+        .with_context(|| format!("creating daemon log for session '{id}'"))?;
+
+    let mut command = std::process::Command::new(exe);
+    command
+        .arg("daemon")
+        .arg("--id")
+        .arg(id)
+        .arg("--socket")
+        .arg(&socket)
+        .arg("--")
+        .args(argv);
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(log));
+    // The daemon detaches itself with setsid *after* spawning its PTY child (see
+    // `daemon::run`): macOS rejects the child's TIOCSCTTY when the parent is
+    // already a session leader, so we must not setsid before the child spawns.
+    command.spawn().context("spawning session daemon")?;
+
+    for _ in 0..DAEMON_STARTUP_POLLS {
+        if socket.exists() {
+            return Ok(socket);
+        }
+        tokio::time::sleep(DAEMON_STARTUP_POLL_INTERVAL).await;
+    }
+    bail!("session daemon did not come up in time")
+}
+
+/// Resolve a session selector to its `(id, socket)`, defaulting to the most
+/// recently started live session.
+///
+/// # Errors
+///
+/// Returns an error if the named session is missing or there are no sessions.
+pub fn resolve_socket(session: Option<String>) -> Result<(String, PathBuf)> {
+    let Some(id) = session else {
+        let latest =
+            index::latest_live().ok_or_else(|| anyhow!("no active sessions; start one with `tap`"))?;
+        return Ok((latest.id, latest.socket));
+    };
+    let socket = tap_protocol::socket_path(&id);
+    if socket.exists() {
+        Ok((id, socket))
+    } else {
+        bail!("session '{id}' not found; run `tap list`")
+    }
+}
+
+/// Print the live sessions as a table.
+pub fn list() {
+    let sessions = index::list_live();
+    if sessions.is_empty() {
+        println!("No active sessions");
+        return;
+    }
+    println!("{:<24} {:<8} {:<12} COMMAND", "ID", "PID", "STARTED");
+    for session in sessions {
+        println!(
+            "{:<24} {:<8} {:<12} {}",
+            session.id,
+            session.pid,
+            format_started(session.started_unix),
+            session.command.join(" ")
+        );
+    }
+}
+
+/// Print the session's screen as plain text.
+///
+/// # Errors
+///
+/// Returns an error if the session cannot be reached.
+pub async fn scrollback(session: Option<String>, lines: Option<usize>) -> Result<()> {
+    let (_id, socket) = resolve_socket(session)?;
+    match request_once(&socket, &Request::GetScrollback { lines }).await? {
+        Response::Scrollback { content } => {
+            print!("{content}");
+            Ok(())
+        }
+        Response::Error { message } => bail!("{message}"),
+        other => bail!("unexpected response: {other:?}"),
+    }
+}
+
+/// Print the cursor position.
+///
+/// # Errors
+///
+/// Returns an error if the session cannot be reached.
+pub async fn cursor(session: Option<String>) -> Result<()> {
+    let (_id, socket) = resolve_socket(session)?;
+    match request_once(&socket, &Request::GetCursor).await? {
+        Response::Cursor { row, col } => {
+            println!("row {row}, col {col}");
+            Ok(())
+        }
+        Response::Error { message } => bail!("{message}"),
+        other => bail!("unexpected response: {other:?}"),
+    }
+}
+
+/// Print the negotiated session size.
+///
+/// # Errors
+///
+/// Returns an error if the session cannot be reached.
+pub async fn size(session: Option<String>) -> Result<()> {
+    let (_id, socket) = resolve_socket(session)?;
+    match request_once(&socket, &Request::GetSize).await? {
+        Response::Size { rows, cols } => {
+            println!("{rows}x{cols}");
+            Ok(())
+        }
+        Response::Error { message } => bail!("{message}"),
+        other => bail!("unexpected response: {other:?}"),
+    }
+}
+
+/// Inject text into the session's child without attaching.
+///
+/// # Errors
+///
+/// Returns an error if the session cannot be reached or rejects the write.
+pub async fn inject(session: Option<String>, text: String) -> Result<()> {
+    let (_id, socket) = resolve_socket(session)?;
+    match request_once(&socket, &Request::Inject { data: text }).await? {
+        Response::Ok => {
+            println!("injected");
+            Ok(())
+        }
+        Response::Error { message } => bail!("{message}"),
+        other => bail!("unexpected response: {other:?}"),
+    }
+}
+
+/// Terminate a session: kill its child and shut down its daemon.
+///
+/// # Errors
+///
+/// Returns an error if the session cannot be reached or rejects the request.
+pub async fn kill(session: Option<String>) -> Result<()> {
+    let (id, socket) = resolve_socket(session)?;
+    match request_once(&socket, &Request::Kill).await? {
+        Response::Ok => {
+            println!("killed session {id}");
+            Ok(())
+        }
+        Response::Error { message } => bail!("{message}"),
+        other => bail!("unexpected response: {other:?}"),
+    }
+}
+
+/// Stream the session's raw output to stdout until it ends.
+///
+/// # Errors
+///
+/// Returns an error if the session cannot be reached.
+pub async fn subscribe(session: Option<String>) -> Result<()> {
+    let (_id, socket) = resolve_socket(session)?;
+    let stream = UnixStream::connect(&socket)
+        .await
+        .with_context(|| format!("connecting to {}", socket.display()))?;
+    let (read_half, mut write_half) = stream.into_split();
+    write_request(&mut write_half, &Request::Subscribe).await?;
+
+    let mut reader = BufReader::new(read_half).lines();
+    let mut stdout = tokio::io::stdout();
+    while let Some(line) = reader.next_line().await? {
+        let Ok(response) = serde_json::from_str::<Response>(&line) else {
+            continue;
+        };
+        match response {
+            Response::Output { data } => {
+                stdout.write_all(&data).await?;
+                stdout.flush().await?;
+            }
+            Response::SessionEnded { .. } => break,
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Fetch the session's full screen as text over a fresh connection.
+///
+/// # Errors
+///
+/// Returns an error if the session cannot be reached or responds unexpectedly.
+pub async fn fetch_scrollback(socket: &Path) -> Result<String> {
+    match request_once(socket, &Request::GetScrollback { lines: None }).await? {
+        Response::Scrollback { content } => Ok(content),
+        Response::Error { message } => bail!("{message}"),
+        other => bail!("unexpected response: {other:?}"),
+    }
+}
+
+/// Connect, send one request, and read one response.
+async fn request_once(socket: &Path, request: &Request) -> Result<Response> {
+    let stream = UnixStream::connect(socket)
+        .await
+        .with_context(|| format!("connecting to {}", socket.display()))?;
+    let (read_half, mut write_half) = stream.into_split();
+    write_request(&mut write_half, request).await?;
+
+    let mut line = String::new();
+    BufReader::new(read_half).read_line(&mut line).await?;
+    if line.is_empty() {
+        bail!("session closed the connection without responding");
+    }
+    serde_json::from_str(&line).context("parsing response")
+}
+
+/// Write one newline-delimited JSON request frame.
+async fn write_request(writer: &mut OwnedWriteHalf, request: &Request) -> Result<()> {
+    let mut line = serde_json::to_string(request).context("serializing request")?;
+    line.push('\n');
+    writer.write_all(line.as_bytes()).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Render a start time as a short relative string for `tap list`.
+fn format_started(started_unix: u64) -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    let secs = now.saturating_sub(started_unix);
+    if secs < 60 {
+        format!("{secs}s ago")
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else if secs < 86_400 {
+        format!("{}h ago", secs / 3600)
+    } else {
+        format!("{}d ago", secs / 86_400)
+    }
+}

--- a/packages/tap/src/config.rs
+++ b/packages/tap/src/config.rs
@@ -1,0 +1,216 @@
+//! User configuration and keybind parsing.
+//!
+//! Config lives at `~/.config/tap/config.toml` and is optional; defaults give a
+//! working session with no file. Keybinds match both legacy terminal byte
+//! sequences and Kitty keyboard-protocol CSI-u, so a bind fires whether or not
+//! an inner app has negotiated Kitty input on the client's terminal.
+
+use anyhow::{Context as _, Result, bail};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_EDITOR_KEYBIND: &str = "Alt-e";
+const DEFAULT_DETACH_KEYBIND: &str = "Ctrl-\\";
+const DEFAULT_ESCAPE_TIMEOUT_MS: u64 = 50;
+const DEFAULT_EDITOR: &str = "vi";
+
+/// Top-level configuration.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct Config {
+    /// Editor for the scrollback keybind. Falls back to `$EDITOR`, `$VISUAL`,
+    /// then `vi`.
+    pub editor: Option<String>,
+    /// Keybinds.
+    pub keybinds: Keybinds,
+    /// Timing knobs.
+    pub timing: Timing,
+}
+
+/// Keybind strings, parsed into [`Keybind`] at load.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct Keybinds {
+    /// Open the scrollback in an editor.
+    pub editor: String,
+    /// Detach from the session.
+    pub detach: String,
+}
+
+/// Timing configuration.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct Timing {
+    /// Milliseconds to wait distinguishing a lone `ESC` from an `Alt-` sequence.
+    pub escape_timeout_ms: u64,
+}
+
+impl Default for Keybinds {
+    fn default() -> Self {
+        Self {
+            editor: DEFAULT_EDITOR_KEYBIND.to_string(),
+            detach: DEFAULT_DETACH_KEYBIND.to_string(),
+        }
+    }
+}
+
+impl Default for Timing {
+    fn default() -> Self {
+        Self {
+            escape_timeout_ms: DEFAULT_ESCAPE_TIMEOUT_MS,
+        }
+    }
+}
+
+/// Path to the config file: `~/.config/tap/config.toml`.
+#[must_use]
+pub fn config_path() -> std::path::PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from(".config"))
+        .join("tap")
+        .join("config.toml")
+}
+
+/// Load configuration, falling back to defaults when no file exists.
+///
+/// # Errors
+///
+/// Returns an error if the file exists but cannot be read or parsed.
+pub fn load() -> Result<Config> {
+    let path = config_path();
+    if !path.exists() {
+        return Ok(Config::default());
+    }
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading config {}", path.display()))?;
+    toml::from_str(&content).with_context(|| format!("parsing config {}", path.display()))
+}
+
+/// Resolve the effective editor command.
+#[must_use]
+pub fn editor_command(config: &Config) -> String {
+    config
+        .editor
+        .clone()
+        .or_else(|| std::env::var("EDITOR").ok())
+        .or_else(|| std::env::var("VISUAL").ok())
+        .unwrap_or_else(|| DEFAULT_EDITOR.to_string())
+}
+
+/// A modifier + key combination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Keybind {
+    /// `Alt-<char>`.
+    Alt(char),
+    /// `Ctrl-<char>`.
+    Ctrl(char),
+}
+
+impl Keybind {
+    /// Parse a string like `Alt-e`, `Ctrl-e`, or `Ctrl-\`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an unrecognized shape or modifier.
+    pub fn parse(s: &str) -> Result<Self> {
+        if s.eq_ignore_ascii_case("ctrl-\\") {
+            return Ok(Self::Ctrl('\\'));
+        }
+        let (modifier, key) = s
+            .split_once('-')
+            .with_context(|| format!("invalid keybind '{s}'; expected 'Alt-<key>' or 'Ctrl-<key>'"))?;
+        let key = key
+            .chars()
+            .next()
+            .with_context(|| format!("missing key in keybind '{s}'"))?;
+        match modifier.to_ascii_lowercase().as_str() {
+            "alt" => Ok(Self::Alt(key)),
+            "ctrl" => Ok(Self::Ctrl(key.to_ascii_lowercase())),
+            other => bail!("unknown modifier '{other}'; expected 'Alt' or 'Ctrl'"),
+        }
+    }
+
+    /// If `bytes` begins with this keybind, return how many bytes it consumed.
+    /// Tries Kitty CSI-u first, then legacy sequences.
+    #[must_use]
+    pub fn matches(self, bytes: &[u8]) -> Option<usize> {
+        if let Some(consumed) = self.matches_kitty(bytes) {
+            return Some(consumed);
+        }
+        match self {
+            Self::Alt(c) => {
+                let byte = u8::try_from(c).ok()?;
+                (bytes.len() >= 2 && bytes[0] == 0x1b && bytes[1] == byte).then_some(2)
+            }
+            Self::Ctrl(c) => {
+                let ctrl_byte = u8::try_from(c).ok()? & 0x1f;
+                (!bytes.is_empty() && bytes[0] == ctrl_byte).then_some(1)
+            }
+        }
+    }
+
+    /// Match a Kitty keyboard-protocol sequence `CSI <codepoint>;<modifiers> u`.
+    fn matches_kitty(self, bytes: &[u8]) -> Option<usize> {
+        const ALT_MODIFIER: u32 = 3;
+        const CTRL_MODIFIER: u32 = 5;
+
+        if bytes.len() < 4 || bytes[0] != 0x1b || bytes[1] != b'[' {
+            return None;
+        }
+        let u_pos = bytes.iter().position(|&b| b == b'u')?;
+        if u_pos < 3 {
+            return None;
+        }
+        let seq = std::str::from_utf8(bytes.get(2..u_pos)?).ok()?;
+        let mut parts = seq.split(';');
+        let codepoint: u32 = parts.next()?.parse().ok()?;
+        let modifiers: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(1);
+
+        let expected = match self {
+            Self::Alt(c) | Self::Ctrl(c) => u32::from(c),
+        };
+        if codepoint != expected {
+            return None;
+        }
+        let wanted = match self {
+            Self::Alt(_) => ALT_MODIFIER,
+            Self::Ctrl(_) => CTRL_MODIFIER,
+        };
+        (modifiers == wanted).then_some(u_pos + 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_alt_and_ctrl() {
+        assert_eq!(Keybind::parse("Alt-e").unwrap(), Keybind::Alt('e'));
+        assert_eq!(Keybind::parse("Ctrl-c").unwrap(), Keybind::Ctrl('c'));
+        assert_eq!(Keybind::parse("Ctrl-\\").unwrap(), Keybind::Ctrl('\\'));
+    }
+
+    #[test]
+    fn matches_legacy_sequences() {
+        assert_eq!(Keybind::Alt('e').matches(&[0x1b, b'e']), Some(2));
+        assert_eq!(Keybind::Alt('e').matches(&[0x1b, b'x']), None);
+        assert_eq!(Keybind::Ctrl('c').matches(&[0x03]), Some(1));
+        assert_eq!(Keybind::Ctrl('\\').matches(&[0x1c]), Some(1));
+    }
+
+    #[test]
+    fn matches_kitty_csi_u() {
+        // Alt-e is codepoint 101 (e), modifier 3 (alt).
+        assert_eq!(Keybind::Alt('e').matches(b"\x1b[101;3u"), Some(8));
+        // Wrong modifier does not match.
+        assert_eq!(Keybind::Alt('e').matches(b"\x1b[101;5u"), None);
+    }
+
+    #[test]
+    fn defaults_are_sane() {
+        let config = Config::default();
+        assert_eq!(config.keybinds.editor, DEFAULT_EDITOR_KEYBIND);
+        assert_eq!(config.keybinds.detach, DEFAULT_DETACH_KEYBIND);
+        assert_eq!(config.timing.escape_timeout_ms, DEFAULT_ESCAPE_TIMEOUT_MS);
+    }
+}

--- a/packages/tap/src/daemon.rs
+++ b/packages/tap/src/daemon.rs
@@ -1,0 +1,453 @@
+//! The session daemon: owns one [`PtySession`], serves clients over a Unix
+//! socket, and negotiates a shared screen size for multiplayer attach.
+//!
+//! The daemon is the only model in tap: every interactive `tap` (and `tap
+//! attach`) is a client of a daemon, even a single user. That uniformity is what
+//! makes resize-while-attached and multi-client sharing fall out for free, where
+//! the original tap embedded the server in the foreground process and could
+//! neither resize a second attacher nor admit one.
+//!
+//! Size negotiation is element-wise min over all attached clients (tmux's rule):
+//! the session is as large as the smallest participant so no client sees clipped
+//! output, and every other client is told the negotiated size so it can warn
+//! that part of its terminal is unused.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context as _, Result};
+use parking_lot::Mutex;
+
+use crate::index;
+use tap_protocol::{Request, Response, Session};
+use tap_pty::{Attachment, PtySession, SessionConfig};
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader, Lines};
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::mpsc;
+
+const DEFAULT_ROWS: u16 = 24;
+const DEFAULT_COLS: u16 = 80;
+const SCROLLBACK_LINES: usize = 10_000;
+/// Time to let client writers flush `SessionEnded` before the socket is removed.
+const SHUTDOWN_GRACE: Duration = Duration::from_millis(50);
+
+/// A repaint pushed to one attached client when the negotiated size changes.
+struct ResizeNotice {
+    rows: u16,
+    cols: u16,
+    snapshot: Vec<u8>,
+}
+
+/// Per-client bookkeeping for size negotiation and out-of-band repaints.
+struct ClientReg {
+    control: mpsc::UnboundedSender<ResizeNotice>,
+    rows: u16,
+    cols: u16,
+    /// Attached clients drive size negotiation and send input; observers (from
+    /// `Subscribe`) only read output.
+    attached: bool,
+}
+
+struct Inner {
+    next_id: u64,
+    session_size: (u16, u16),
+    clients: HashMap<u64, ClientReg>,
+}
+
+/// Shared daemon state: the PTY session plus the client registry.
+struct DaemonState {
+    session: PtySession,
+    inner: Mutex<Inner>,
+}
+
+impl DaemonState {
+    fn new(session: PtySession, size: (u16, u16)) -> Self {
+        Self {
+            session,
+            inner: Mutex::new(Inner {
+                next_id: 0,
+                session_size: size,
+                clients: HashMap::new(),
+            }),
+        }
+    }
+
+    fn session_size(&self) -> (u16, u16) {
+        self.inner.lock().session_size
+    }
+
+    /// Register an attached client, renegotiate size, and start its output feed.
+    fn attach(
+        &self,
+        rows: u16,
+        cols: u16,
+        control: mpsc::UnboundedSender<ResizeNotice>,
+    ) -> (u64, (u16, u16), Attachment) {
+        let mut inner = self.inner.lock();
+        let id = inner.next_id;
+        inner.next_id += 1;
+        inner.clients.insert(
+            id,
+            ClientReg {
+                control,
+                rows,
+                cols,
+                attached: true,
+            },
+        );
+        // Exclude this client: it learns its size from the Attached response,
+        // not a Resized notice.
+        self.recompute(&mut inner, Some(id));
+        let size = inner.session_size;
+        let attachment = self.session.subscribe();
+        drop(inner);
+        (id, size, attachment)
+    }
+
+    /// Register a read-only observer that does not affect size negotiation.
+    fn add_observer(&self, control: mpsc::UnboundedSender<ResizeNotice>) -> (u64, Attachment) {
+        let mut inner = self.inner.lock();
+        let id = inner.next_id;
+        inner.next_id += 1;
+        inner.clients.insert(
+            id,
+            ClientReg {
+                control,
+                rows: 0,
+                cols: 0,
+                attached: false,
+            },
+        );
+        let attachment = self.session.subscribe();
+        drop(inner);
+        (id, attachment)
+    }
+
+    /// Record a client's new terminal size, renegotiate, and repaint it.
+    fn update_size(&self, id: u64, rows: u16, cols: u16) {
+        let mut inner = self.inner.lock();
+        if let Some(client) = inner.clients.get_mut(&id) {
+            client.rows = rows;
+            client.cols = cols;
+        }
+        self.recompute(&mut inner, None);
+        // Always hand the requester a fresh snapshot so it repaints on its own
+        // resize (and after the editor keybind, which fakes a resize to refresh).
+        let (s_rows, s_cols) = inner.session_size;
+        let snapshot = self.session.snapshot();
+        if let Some(client) = inner.clients.get(&id) {
+            let _ = client.control.send(ResizeNotice {
+                rows: s_rows,
+                cols: s_cols,
+                snapshot,
+            });
+        }
+        drop(inner);
+    }
+
+    fn remove(&self, id: u64) {
+        let mut inner = self.inner.lock();
+        inner.clients.remove(&id);
+        self.recompute(&mut inner, None);
+        drop(inner);
+    }
+
+    /// Set the session size to the element-wise min over attached clients. On a
+    /// change, resize the PTY and push a repaint to every attached client except
+    /// `exclude`.
+    fn recompute(&self, inner: &mut Inner, exclude: Option<u64>) {
+        let sizes: Vec<(u16, u16)> = inner
+            .clients
+            .values()
+            .filter(|c| c.attached)
+            .map(|c| (c.rows, c.cols))
+            .collect();
+        if sizes.is_empty() {
+            return;
+        }
+        let rows = sizes.iter().map(|s| s.0).min().unwrap_or(DEFAULT_ROWS).max(1);
+        let cols = sizes.iter().map(|s| s.1).min().unwrap_or(DEFAULT_COLS).max(1);
+        let new = (rows, cols);
+        if new == inner.session_size {
+            return;
+        }
+
+        let _ = self.session.resize(rows, cols);
+        inner.session_size = new;
+        let snapshot = self.session.snapshot();
+        for (client_id, client) in &inner.clients {
+            if !client.attached || Some(*client_id) == exclude {
+                continue;
+            }
+            let _ = client.control.send(ResizeNotice {
+                rows,
+                cols,
+                snapshot: snapshot.clone(),
+            });
+        }
+    }
+}
+
+/// Run the session daemon until the child exits.
+///
+/// # Errors
+///
+/// Returns an error if the PTY child cannot be spawned or the socket cannot bind.
+pub async fn run(id: String, socket: PathBuf, command: Vec<String>) -> Result<()> {
+    let runtime_dir = tap_protocol::runtime_dir();
+    std::fs::create_dir_all(&runtime_dir)
+        .with_context(|| format!("creating runtime dir {}", runtime_dir.display()))?;
+
+    let session = PtySession::spawn(SessionConfig {
+        command: command.clone(),
+        rows: DEFAULT_ROWS,
+        cols: DEFAULT_COLS,
+        scrollback_lines: SCROLLBACK_LINES,
+    })
+    .context("spawning session child")?;
+
+    // Detach from the launching client's session so closing the client does not
+    // SIGHUP the daemon. This runs after the child spawns on purpose: macOS
+    // rejects the child's TIOCSCTTY when its parent is already a session leader.
+    // Best-effort: failure (EPERM if already a leader) leaves the daemon usable.
+    if let Err(error) = nix::unistd::setsid() {
+        eprintln!("tap daemon: setsid failed ({error}); session may not survive client exit");
+    }
+
+    let started_unix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    index::add(Session {
+        id: id.clone(),
+        pid: std::process::id(),
+        started_unix,
+        command,
+        socket: socket.clone(),
+    })
+    .context("recording session in index")?;
+
+    let _ = std::fs::remove_file(&socket);
+    let listener =
+        UnixListener::bind(&socket).with_context(|| format!("binding socket {}", socket.display()))?;
+
+    let state = Arc::new(DaemonState::new(session, (DEFAULT_ROWS, DEFAULT_COLS)));
+    let mut exit = state.session.exit_watch();
+
+    loop {
+        tokio::select! {
+            accepted = listener.accept() => {
+                if let Ok((stream, _addr)) = accepted {
+                    let state = Arc::clone(&state);
+                    tokio::spawn(async move {
+                        let _ = handle_conn(stream, state).await;
+                    });
+                }
+            }
+            changed = exit.changed() => {
+                if changed.is_err() || state.session.exit_code().is_some() {
+                    break;
+                }
+            }
+        }
+    }
+
+    // The child exited. Client writers send SessionEnded off their own exit
+    // watch; give them a moment to flush before the socket disappears.
+    tokio::time::sleep(SHUTDOWN_GRACE).await;
+    let _ = std::fs::remove_file(&socket);
+    let _ = std::fs::remove_file(runtime_dir.join(format!("{id}.log")));
+    let _ = index::remove(&id);
+    Ok(())
+}
+
+/// Handle one client connection: dispatch control queries, or hand the
+/// connection to the attach/subscribe streaming paths.
+async fn handle_conn(stream: UnixStream, state: Arc<DaemonState>) -> Result<()> {
+    let (read_half, mut write_half) = stream.into_split();
+    let mut lines = BufReader::new(read_half).lines();
+
+    while let Some(line) = lines.next_line().await? {
+        let Ok(request) = serde_json::from_str::<Request>(&line) else {
+            continue;
+        };
+        match request {
+            Request::Attach { rows, cols } => {
+                return handle_attach(state, lines, write_half, rows, cols).await;
+            }
+            Request::Subscribe => return handle_subscribe(state, write_half).await,
+            Request::GetScrollback { lines: count } => {
+                let content = state.session.scrollback(count);
+                send_line(&mut write_half, &Response::Scrollback { content }).await?;
+            }
+            Request::GetCursor => {
+                let (row, col) = state.session.cursor();
+                send_line(&mut write_half, &Response::Cursor { row, col }).await?;
+            }
+            Request::GetSize => {
+                let (rows, cols) = state.session_size();
+                send_line(&mut write_half, &Response::Size { rows, cols }).await?;
+            }
+            Request::Inject { data } => {
+                let _ = state.session.write_input(data.into_bytes());
+                send_line(&mut write_half, &Response::Ok).await?;
+            }
+            Request::Kill => {
+                let _ = state.session.kill();
+                send_line(&mut write_half, &Response::Ok).await?;
+            }
+            Request::Input { .. } | Request::Resize { .. } | Request::Detach => {
+                let message = "request only valid on an attached connection".to_string();
+                send_line(&mut write_half, &Response::Error { message }).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Drive an attached client: stream output and resizes out, take input back in.
+async fn handle_attach(
+    state: Arc<DaemonState>,
+    mut lines: Lines<BufReader<OwnedReadHalf>>,
+    mut write_half: OwnedWriteHalf,
+    rows: u16,
+    cols: u16,
+) -> Result<()> {
+    let (control_tx, mut control_rx) = mpsc::unbounded_channel();
+    let (id, (s_rows, s_cols), attachment) = state.attach(rows, cols, control_tx);
+    send_line(
+        &mut write_half,
+        &Response::Attached {
+            rows: s_rows,
+            cols: s_cols,
+            snapshot: attachment.snapshot,
+        },
+    )
+    .await?;
+
+    let mut output = attachment.output;
+    let mut exit = state.session.exit_watch();
+    let lag_state = Arc::clone(&state);
+
+    let writer = tokio::spawn(async move {
+        // Copy out so the watch guard does not cross the await below.
+        let already_exited = *exit.borrow();
+        if let Some(code) = already_exited {
+            let _ = send_line(&mut write_half, &Response::SessionEnded { exit_code: code }).await;
+            return;
+        }
+        loop {
+            tokio::select! {
+                biased;
+                notice = control_rx.recv() => {
+                    let Some(notice) = notice else { break };
+                    let resized = Response::Resized { rows: notice.rows, cols: notice.cols, snapshot: notice.snapshot };
+                    if send_line(&mut write_half, &resized).await.is_err() {
+                        break;
+                    }
+                }
+                received = output.recv() => match received {
+                    Ok(bytes) => {
+                        if send_line(&mut write_half, &Response::Output { data: bytes.to_vec() }).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(RecvError::Lagged(_)) => {
+                        // Fell behind: resync from a fresh snapshot instead of
+                        // replaying a torn byte stream.
+                        let (r, c) = lag_state.session_size();
+                        let snapshot = lag_state.session.snapshot();
+                        let resized = Response::Resized { rows: r, cols: c, snapshot };
+                        if send_line(&mut write_half, &resized).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(RecvError::Closed) => break,
+                },
+                changed = exit.changed() => {
+                    if changed.is_err() {
+                        break;
+                    }
+                    let exited = *exit.borrow();
+                    if let Some(code) = exited {
+                        let _ = send_line(&mut write_half, &Response::SessionEnded { exit_code: code }).await;
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    while let Ok(Some(line)) = lines.next_line().await {
+        let Ok(request) = serde_json::from_str::<Request>(&line) else {
+            continue;
+        };
+        match request {
+            Request::Input { data } => {
+                let _ = state.session.write_input(data);
+            }
+            Request::Resize { rows, cols } => state.update_size(id, rows, cols),
+            Request::Detach => break,
+            _ => {}
+        }
+    }
+
+    state.remove(id);
+    writer.abort();
+    Ok(())
+}
+
+/// Drive a read-only observer: an initial paint, then the live output stream.
+async fn handle_subscribe(state: Arc<DaemonState>, mut write_half: OwnedWriteHalf) -> Result<()> {
+    let (control_tx, _control_rx) = mpsc::unbounded_channel();
+    let (id, attachment) = state.add_observer(control_tx);
+    send_line(&mut write_half, &Response::Subscribed).await?;
+    send_line(
+        &mut write_half,
+        &Response::Output {
+            data: attachment.snapshot,
+        },
+    )
+    .await?;
+
+    let mut output = attachment.output;
+    let mut exit = state.session.exit_watch();
+    loop {
+        tokio::select! {
+            received = output.recv() => match received {
+                Ok(bytes) => {
+                    if send_line(&mut write_half, &Response::Output { data: bytes.to_vec() }).await.is_err() {
+                        break;
+                    }
+                }
+                Err(RecvError::Lagged(_)) => {}
+                Err(RecvError::Closed) => break,
+            },
+            changed = exit.changed() => {
+                if changed.is_err() {
+                    break;
+                }
+                let exited = *exit.borrow();
+                if let Some(code) = exited {
+                    let _ = send_line(&mut write_half, &Response::SessionEnded { exit_code: code }).await;
+                    break;
+                }
+            }
+        }
+    }
+
+    state.remove(id);
+    Ok(())
+}
+
+/// Write one newline-delimited JSON response frame.
+async fn send_line(writer: &mut OwnedWriteHalf, message: &Response) -> Result<()> {
+    let mut line = serde_json::to_string(message).context("serializing response")?;
+    line.push('\n');
+    writer.write_all(line.as_bytes()).await?;
+    writer.flush().await?;
+    Ok(())
+}

--- a/packages/tap/src/editor.rs
+++ b/packages/tap/src/editor.rs
@@ -1,0 +1,155 @@
+//! Open the session scrollback in the user's editor.
+//!
+//! The keybind drops the terminal back to cooked mode (via [`RawGuard`]), writes
+//! the scrollback to a temp file, runs the editor at the cursor line when the
+//! editor's argument syntax is known, then re-enters raw mode. The attach loop
+//! repaints afterward.
+
+use std::path::Path;
+
+use anyhow::{Context as _, Result, bail};
+
+use crate::term::RawGuard;
+
+/// Editors whose line/column argument syntax we know.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditorKind {
+    /// vim, nvim, vi: `+{line}` before the file.
+    Vim,
+    /// VS Code, Cursor: `-g {file}:{line}:{col}`.
+    VsCode,
+    /// nano: `+{line},{col}` before the file.
+    Nano,
+    /// emacs: `+{line}:{col}` before the file.
+    Emacs,
+    /// helix: `{file}:{line}`.
+    Helix,
+    /// Anything else: open the file with no position.
+    Unknown,
+}
+
+impl EditorKind {
+    /// Detect the editor kind from a command name or path.
+    #[must_use]
+    pub fn detect(cmd: &str) -> Self {
+        let name = Path::new(cmd)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or(cmd);
+        match name {
+            "vim" | "nvim" | "vi" | "view" | "vimdiff" => Self::Vim,
+            "code" | "cursor" | "code-insiders" | "codium" | "vscodium" => Self::VsCode,
+            "nano" | "pico" => Self::Nano,
+            "emacs" | "emacsclient" => Self::Emacs,
+            "hx" | "helix" => Self::Helix,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// A 1-indexed file position.
+#[derive(Debug, Clone, Copy)]
+pub struct Position {
+    /// 1-indexed line.
+    pub line: usize,
+    /// 1-indexed column, if known.
+    pub col: Option<usize>,
+}
+
+/// Build `(args_before_file, file_argument)` for opening `file_path` at `pos`.
+#[must_use]
+pub fn build_args(editor_cmd: &str, file_path: &Path, pos: Option<Position>) -> (Vec<String>, String) {
+    let file = file_path.display().to_string();
+    let Some(pos) = pos else {
+        return (vec![], file);
+    };
+    match EditorKind::detect(editor_cmd) {
+        EditorKind::Vim => (vec![format!("+{}", pos.line)], file),
+        EditorKind::VsCode => {
+            let col = pos.col.unwrap_or(1);
+            (vec!["-g".to_string()], format!("{file}:{}:{col}", pos.line))
+        }
+        EditorKind::Nano => {
+            let arg = pos
+                .col
+                .map_or_else(|| format!("+{}", pos.line), |col| format!("+{},{col}", pos.line));
+            (vec![arg], file)
+        }
+        EditorKind::Emacs => {
+            let arg = pos
+                .col
+                .map_or_else(|| format!("+{}", pos.line), |col| format!("+{}:{col}", pos.line));
+            (vec![arg], file)
+        }
+        EditorKind::Helix => (vec![], format!("{file}:{}", pos.line)),
+        EditorKind::Unknown => (vec![], file),
+    }
+}
+
+/// Open `content` in `editor_cmd`, restoring raw mode afterward.
+///
+/// # Errors
+///
+/// Returns an error if the temp file cannot be written or the editor cannot be
+/// spawned. Raw mode is restored on every path.
+pub fn open(content: &str, editor_cmd: &str, raw: &RawGuard, pos: Option<Position>) -> Result<()> {
+    use std::io::Write as _;
+
+    let mut temp = tempfile::Builder::new()
+        .prefix("tap-scrollback-")
+        .suffix(".txt")
+        .tempfile()
+        .context("creating scrollback temp file")?;
+    temp.write_all(content.as_bytes())
+        .context("writing scrollback temp file")?;
+    temp.flush().context("flushing scrollback temp file")?;
+
+    let parts: Vec<&str> = editor_cmd.split_whitespace().collect();
+    let (program, leading) = parts
+        .split_first()
+        .context("empty editor command; set $EDITOR or configure tap")?;
+    let (pos_args, file_arg) = build_args(program, temp.path(), pos);
+
+    // Hand the tty to the editor in cooked mode, then take it back.
+    raw.suspend();
+    let status = std::process::Command::new(program)
+        .args(leading)
+        .args(pos_args)
+        .arg(&file_arg)
+        .status();
+    raw.resume();
+
+    let status = status.with_context(|| format!("spawning editor '{program}'"))?;
+    if !status.success() {
+        bail!("editor '{program}' exited with {status}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_known_editors() {
+        assert_eq!(EditorKind::detect("/usr/bin/nvim"), EditorKind::Vim);
+        assert_eq!(EditorKind::detect("cursor"), EditorKind::VsCode);
+        assert_eq!(EditorKind::detect("hx"), EditorKind::Helix);
+        assert_eq!(EditorKind::detect("mystery"), EditorKind::Unknown);
+    }
+
+    #[test]
+    fn builds_position_args_per_editor() {
+        let (args, file) = build_args("vim", Path::new("/t.txt"), Some(Position { line: 42, col: None }));
+        assert_eq!(args, vec!["+42"]);
+        assert_eq!(file, "/t.txt");
+
+        let (args, file) = build_args(
+            "cursor",
+            Path::new("/t.txt"),
+            Some(Position { line: 42, col: Some(10) }),
+        );
+        assert_eq!(args, vec!["-g"]);
+        assert_eq!(file, "/t.txt:42:10");
+    }
+}

--- a/packages/tap/src/index.rs
+++ b/packages/tap/src/index.rs
@@ -1,0 +1,111 @@
+//! The session index: a JSON list of live sessions under the runtime dir.
+//!
+//! Writers take an exclusive file lock so two daemons starting at once cannot
+//! lose each other's record. Readers never trust a record blindly: a session
+//! counts as live only if its socket still exists and its daemon PID is alive,
+//! so a crashed daemon's stale entry is filtered out instead of shown or dialed.
+
+use std::io::{Read as _, Seek as _, Write as _};
+
+use anyhow::{Context as _, Result};
+use tap_protocol::Session;
+
+/// Apply `f` to the session list under an exclusive lock, then persist it.
+fn modify(f: impl FnOnce(&mut Vec<Session>)) -> Result<()> {
+    let path = tap_protocol::sessions_file();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating runtime dir {}", parent.display()))?;
+    }
+
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)
+        .with_context(|| format!("opening session index {}", path.display()))?;
+    file.lock().context("locking session index")?;
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .context("reading session index")?;
+    let mut sessions: Vec<Session> = if content.trim().is_empty() {
+        Vec::new()
+    } else {
+        serde_json::from_str(&content).unwrap_or_default()
+    };
+
+    f(&mut sessions);
+
+    let rendered = serde_json::to_string_pretty(&sessions).context("serializing session index")?;
+    file.set_len(0).context("truncating session index")?;
+    file.seek(std::io::SeekFrom::Start(0))
+        .context("rewinding session index")?;
+    file.write_all(rendered.as_bytes())
+        .context("writing session index")?;
+    Ok(())
+}
+
+/// Record a session, replacing any stale entry with the same id.
+///
+/// # Errors
+///
+/// Returns an error if the index cannot be read or written.
+pub fn add(session: Session) -> Result<()> {
+    modify(|sessions| {
+        sessions.retain(|s| s.id != session.id);
+        sessions.push(session);
+    })
+}
+
+/// Remove a session by id.
+///
+/// # Errors
+///
+/// Returns an error if the index cannot be read or written.
+pub fn remove(id: &str) -> Result<()> {
+    modify(|sessions| sessions.retain(|s| s.id != id))
+}
+
+/// All recorded sessions, including any stale ones.
+fn read_all() -> Vec<Session> {
+    let content = std::fs::read_to_string(tap_protocol::sessions_file()).unwrap_or_default();
+    if content.trim().is_empty() {
+        return Vec::new();
+    }
+    serde_json::from_str(&content).unwrap_or_default()
+}
+
+/// Whether a process is still alive (`kill(pid, 0)`).
+#[must_use]
+pub fn pid_alive(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
+    if pid <= 0 {
+        return false;
+    }
+    // 0 => signalable, EPERM => exists but not ours, ESRCH => gone.
+    if unsafe { nix::libc::kill(pid, 0) } == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() == Some(nix::libc::EPERM)
+}
+
+/// Sessions whose socket exists and whose daemon is still running.
+#[must_use]
+pub fn list_live() -> Vec<Session> {
+    read_all()
+        .into_iter()
+        .filter(|s| s.socket.exists() && pid_alive(s.pid))
+        .collect()
+}
+
+/// The most recently started live session, if any.
+#[must_use]
+pub fn latest_live() -> Option<Session> {
+    let mut live = list_live();
+    live.sort_by_key(|s| s.started_unix);
+    live.pop()
+}

--- a/packages/tap/src/input.rs
+++ b/packages/tap/src/input.rs
@@ -1,0 +1,173 @@
+//! Client-side input processing: detach and editor keybind detection.
+//!
+//! The attach client passes keystrokes straight through to the session except
+//! for its own keybinds. A lone `ESC` is held briefly so an `Alt-` sequence that
+//! arrives as `ESC` then a letter can be recognized; if nothing follows before
+//! the timeout, the `ESC` is released unchanged.
+
+use anyhow::Result;
+
+use crate::config::{Config, Keybind};
+
+const ESC: u8 = 0x1b;
+
+/// What to do with a chunk of input.
+#[derive(Debug)]
+pub enum InputResult {
+    /// Forward these bytes to the session.
+    Passthrough(Vec<u8>),
+    /// A keybind fired.
+    Action(KeybindAction),
+    /// Hold for more input or the escape timeout.
+    NeedMore,
+}
+
+/// A bound action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeybindAction {
+    /// Open the scrollback in an editor.
+    OpenEditor,
+    /// Detach from the session.
+    Detach,
+}
+
+/// Keybind-detecting input state machine.
+pub struct InputProcessor {
+    binds: Vec<(Keybind, KeybindAction)>,
+    escape_timeout: std::time::Duration,
+    pending_escape: bool,
+}
+
+impl InputProcessor {
+    /// Build from config, parsing the keybind strings.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a configured keybind string does not parse.
+    pub fn new(config: &Config) -> Result<Self> {
+        let binds = vec![
+            (Keybind::parse(&config.keybinds.editor)?, KeybindAction::OpenEditor),
+            (Keybind::parse(&config.keybinds.detach)?, KeybindAction::Detach),
+        ];
+        Ok(Self {
+            binds,
+            escape_timeout: std::time::Duration::from_millis(config.timing.escape_timeout_ms),
+            pending_escape: false,
+        })
+    }
+
+    /// How long to wait for an `Alt-` sequence after a lone `ESC`.
+    #[must_use]
+    pub const fn escape_timeout(&self) -> std::time::Duration {
+        self.escape_timeout
+    }
+
+    /// Whether a lone `ESC` is currently being held.
+    #[must_use]
+    pub const fn has_pending_escape(&self) -> bool {
+        self.pending_escape
+    }
+
+    /// Process a chunk of input bytes.
+    pub fn process(&mut self, bytes: &[u8]) -> InputResult {
+        if bytes.is_empty() {
+            return if self.take_pending_escape() {
+                InputResult::Passthrough(vec![ESC])
+            } else {
+                InputResult::Passthrough(vec![])
+            };
+        }
+
+        let effective = if self.take_pending_escape() {
+            let mut v = Vec::with_capacity(bytes.len() + 1);
+            v.push(ESC);
+            v.extend_from_slice(bytes);
+            v
+        } else {
+            bytes.to_vec()
+        };
+
+        for (bind, action) in &self.binds {
+            if bind.matches(&effective).is_some() {
+                return InputResult::Action(*action);
+            }
+        }
+
+        if effective == [ESC] {
+            self.pending_escape = true;
+            return InputResult::NeedMore;
+        }
+
+        InputResult::Passthrough(effective)
+    }
+
+    /// Release a held `ESC` when its timeout expires.
+    pub fn timeout_escape(&mut self) -> InputResult {
+        if self.take_pending_escape() {
+            InputResult::Passthrough(vec![ESC])
+        } else {
+            InputResult::Passthrough(vec![])
+        }
+    }
+
+    fn take_pending_escape(&mut self) -> bool {
+        std::mem::take(&mut self.pending_escape)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn processor() -> InputProcessor {
+        InputProcessor::new(&Config::default()).unwrap()
+    }
+
+    #[test]
+    fn passes_normal_input_through() {
+        match processor().process(b"hello") {
+            InputResult::Passthrough(bytes) => assert_eq!(bytes, b"hello"),
+            other => panic!("expected passthrough, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lone_escape_is_held_then_released() {
+        let mut p = processor();
+        assert!(matches!(p.process(&[ESC]), InputResult::NeedMore));
+        assert!(p.has_pending_escape());
+        match p.timeout_escape() {
+            InputResult::Passthrough(bytes) => assert_eq!(bytes, vec![ESC]),
+            other => panic!("expected ESC release, got {other:?}"),
+        }
+        assert!(!p.has_pending_escape());
+    }
+
+    #[test]
+    fn alt_e_fires_editor_across_split_reads() {
+        let mut p = processor();
+        assert!(matches!(p.process(&[ESC]), InputResult::NeedMore));
+        assert!(matches!(
+            p.process(b"e"),
+            InputResult::Action(KeybindAction::OpenEditor)
+        ));
+    }
+
+    #[test]
+    fn ctrl_backslash_detaches() {
+        assert!(matches!(
+            processor().process(&[0x1c]),
+            InputResult::Action(KeybindAction::Detach)
+        ));
+    }
+
+    #[test]
+    fn escape_then_other_key_passes_both() {
+        let mut p = processor();
+        assert!(matches!(p.process(&[ESC]), InputResult::NeedMore));
+        match p.process(b"x") {
+            InputResult::Passthrough(bytes) => assert_eq!(bytes, vec![ESC, b'x']),
+            other => panic!("expected passthrough, got {other:?}"),
+        }
+    }
+}

--- a/packages/tap/src/main.rs
+++ b/packages/tap/src/main.rs
@@ -1,0 +1,131 @@
+//! `tap`: a minimal terminal session manager for tiling-WM users.
+//!
+//! Detach and reattach to sessions without tmux's tiling layer, and share a
+//! session with others (the screen sizes to the smallest attached client). See
+//! the crate README for the design; the daemon/client split lives in
+//! [`daemon`] and [`attach`].
+
+mod attach;
+mod client;
+mod config;
+mod daemon;
+mod editor;
+mod index;
+mod input;
+mod names;
+mod term;
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+/// Terminal session manager for tiling-WM users.
+#[derive(Parser)]
+#[command(name = "tap", version, about = "Terminal session manager for tiling-WM users")]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Start a new session (the default when no subcommand is given).
+    Start {
+        /// Command to run; defaults to an interactive `$SHELL`.
+        #[arg(trailing_var_arg = true)]
+        command: Vec<String>,
+        /// Start in the background without attaching.
+        #[arg(short, long)]
+        detached: bool,
+        /// Use a specific session id instead of a generated one.
+        #[arg(long)]
+        id: Option<String>,
+    },
+    /// Attach to a running session (the most recent one if unspecified).
+    Attach {
+        /// Session id.
+        session: Option<String>,
+    },
+    /// List active sessions.
+    List,
+    /// Print a session's screen as text.
+    Scrollback {
+        /// Session id (defaults to the most recent).
+        #[arg(short, long)]
+        session: Option<String>,
+        /// Limit to the last N rows.
+        #[arg(short, long)]
+        lines: Option<usize>,
+    },
+    /// Print a session's cursor position.
+    Cursor {
+        /// Session id (defaults to the most recent).
+        #[arg(short, long)]
+        session: Option<String>,
+    },
+    /// Print a session's negotiated size.
+    Size {
+        /// Session id (defaults to the most recent).
+        #[arg(short, long)]
+        session: Option<String>,
+    },
+    /// Type text into a session without attaching.
+    Inject {
+        /// Session id (defaults to the most recent).
+        #[arg(short, long)]
+        session: Option<String>,
+        /// Text to inject.
+        text: String,
+    },
+    /// Stream a session's raw output to stdout.
+    Subscribe {
+        /// Session id (defaults to the most recent).
+        #[arg(short, long)]
+        session: Option<String>,
+    },
+    /// Terminate a session and its child process.
+    Kill {
+        /// Session id (defaults to the most recent).
+        session: Option<String>,
+    },
+    /// Internal: run the session daemon. Spawned by `start`; not for direct use.
+    #[command(hide = true)]
+    Daemon {
+        /// Session id.
+        #[arg(long)]
+        id: String,
+        /// Socket path to bind.
+        #[arg(long)]
+        socket: PathBuf,
+        /// Command to run, after `--`.
+        #[arg(last = true)]
+        command: Vec<String>,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let command = cli.command.unwrap_or(Command::Start {
+        command: Vec::new(),
+        detached: false,
+        id: None,
+    });
+
+    match command {
+        Command::Start { command, detached, id } => client::start(command, detached, id).await,
+        Command::Attach { session } => attach::run(session).await,
+        Command::List => {
+            client::list();
+            Ok(())
+        }
+        Command::Scrollback { session, lines } => client::scrollback(session, lines).await,
+        Command::Cursor { session } => client::cursor(session).await,
+        Command::Size { session } => client::size(session).await,
+        Command::Inject { session, text } => client::inject(session, text).await,
+        Command::Subscribe { session } => client::subscribe(session).await,
+        Command::Kill { session } => client::kill(session).await,
+        Command::Daemon { id, socket, command } => daemon::run(id, socket, command).await,
+    }
+}

--- a/packages/tap/src/names.rs
+++ b/packages/tap/src/names.rs
@@ -1,0 +1,46 @@
+//! Human-readable session id generation.
+//!
+//! Ids look like `amber-otter-3f`: an adjective, a noun, and a short suffix from
+//! the daemon PID so two sessions started in the same instant still differ. No
+//! crypto-grade randomness is needed; this is a friendly label, not a secret.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const ADJECTIVES: &[&str] = &[
+    "amber", "brave", "calm", "clever", "cosmic", "dapper", "eager", "fuzzy", "gentle", "glossy",
+    "humble", "jolly", "keen", "lively", "mellow", "nimble", "polished", "quiet", "rapid", "sly",
+    "snug", "spry", "sunny", "swift", "tidy", "vivid", "witty", "zesty",
+];
+
+const NOUNS: &[&str] = &[
+    "otter", "falcon", "maple", "comet", "harbor", "lynx", "pebble", "quartz", "raven", "willow",
+    "badger", "cedar", "dolphin", "ember", "fjord", "glade", "heron", "ibex", "juniper", "koala",
+    "marlin", "nebula", "orchid", "puffin", "robin", "spruce", "thistle", "walrus",
+];
+
+/// Generate a fresh, human-readable session id.
+#[must_use]
+pub fn generate() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.subsec_nanos());
+    let pid = std::process::id();
+
+    let adjective = ADJECTIVES[(nanos as usize) % ADJECTIVES.len()];
+    let noun = NOUNS[(nanos as usize / ADJECTIVES.len() + pid as usize) % NOUNS.len()];
+    let suffix = pid % 256;
+
+    format!("{adjective}-{noun}-{suffix:02x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generates_three_dashed_segments() {
+        let id = generate();
+        assert_eq!(id.split('-').count(), 3, "unexpected id shape: {id}");
+        assert!(id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'));
+    }
+}

--- a/packages/tap/src/term.rs
+++ b/packages/tap/src/term.rs
@@ -1,0 +1,70 @@
+//! Controlling-terminal helpers for the attach client: window size and raw mode.
+//!
+//! Raw mode is wrapped in [`RawGuard`], which restores the original terminal
+//! settings on drop, so every exit path (detach, session end, error, panic
+//! unwind) leaves the user's shell usable. The original tap restored only on the
+//! happy path; an RAII guard removes that whole class of "terminal left in raw
+//! mode" bugs.
+
+use std::os::fd::BorrowedFd;
+
+use nix::sys::termios::{SetArg, Termios};
+
+const STDIN_FD: std::os::fd::RawFd = nix::libc::STDIN_FILENO;
+
+/// Current controlling-terminal size as `(rows, cols)`.
+///
+/// Falls back to 80×24 when stdin is not a terminal or the ioctl fails, so a
+/// session started without a tty still has a sane geometry.
+#[must_use]
+pub fn current_winsize() -> (u16, u16) {
+    // SAFETY: `ws` is fully written by a successful TIOCGWINSZ; on failure we
+    // discard it and use the fallback.
+    let mut ws: nix::libc::winsize = unsafe { std::mem::zeroed() };
+    let ret = unsafe { nix::libc::ioctl(STDIN_FD, nix::libc::TIOCGWINSZ, &raw mut ws) };
+    if ret != 0 || ws.ws_row == 0 || ws.ws_col == 0 {
+        return (24, 80);
+    }
+    (ws.ws_row, ws.ws_col)
+}
+
+/// Raw-mode guard for stdin. Restores the original termios on drop.
+pub struct RawGuard {
+    original: Termios,
+}
+
+impl RawGuard {
+    /// Put stdin into raw mode, returning a guard that restores it on drop.
+    ///
+    /// Returns `None` when stdin is not a terminal (for example under a test
+    /// harness or a pipe), in which case there is nothing to restore.
+    #[must_use]
+    pub fn enter() -> Option<Self> {
+        let fd = unsafe { BorrowedFd::borrow_raw(STDIN_FD) };
+        let original = nix::sys::termios::tcgetattr(fd).ok()?;
+        let mut raw = original.clone();
+        nix::sys::termios::cfmakeraw(&mut raw);
+        nix::sys::termios::tcsetattr(fd, SetArg::TCSANOW, &raw).ok()?;
+        Some(Self { original })
+    }
+
+    /// Temporarily restore cooked mode (used while a child editor owns the tty).
+    pub fn suspend(&self) {
+        let fd = unsafe { BorrowedFd::borrow_raw(STDIN_FD) };
+        let _ = nix::sys::termios::tcsetattr(fd, SetArg::TCSANOW, &self.original);
+    }
+
+    /// Re-enter raw mode after [`suspend`](Self::suspend).
+    pub fn resume(&self) {
+        let fd = unsafe { BorrowedFd::borrow_raw(STDIN_FD) };
+        let mut raw = self.original.clone();
+        nix::sys::termios::cfmakeraw(&mut raw);
+        let _ = nix::sys::termios::tcsetattr(fd, SetArg::TCSANOW, &raw);
+    }
+}
+
+impl Drop for RawGuard {
+    fn drop(&mut self) {
+        self.suspend();
+    }
+}

--- a/packages/tap/tests/integration.rs
+++ b/packages/tap/tests/integration.rs
@@ -1,0 +1,252 @@
+//! End-to-end tests that drive the real `tap` binary on a PTY and assert on its
+//! rendered screen, reusing the workspace's `tui` PTY driver as the harness.
+//!
+//! Each test starts a session with `tap start`, attaches more clients with `tap
+//! attach`, types into them, and reads back the vt100 grid the client paints.
+//! This is the layer the original tap broke at: attaching to a running
+//! full-screen TUI, resizing while attached, and sharing a session. The four
+//! tests below pin exactly those behaviors.
+//!
+//! State is isolated under a per-process `TAP_RUNTIME_DIR`; every test uses a
+//! distinct session id and tears its session down with a [`SessionGuard`] so a
+//! detached daemon never outlives the test.
+
+use std::sync::Once;
+use std::time::{Duration, Instant};
+
+use tui::{SpawnConfig, TuiInstance, TuiManager};
+
+/// The env var tap reads for its runtime dir (kept in sync with `tap-protocol`).
+const RUNTIME_DIR_ENV: &str = "TAP_RUNTIME_DIR";
+
+/// Path to the `tap` binary under test (set by cargo for integration tests).
+fn tap_bin() -> String {
+    env!("CARGO_BIN_EXE_tap").to_string()
+}
+
+/// Point tap at an isolated runtime dir once, before any session is spawned.
+fn init() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let dir = std::env::temp_dir().join(format!("tap-it-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create runtime dir");
+        // Single-threaded init; inherited by every spawned tap/daemon process.
+        unsafe { std::env::set_var(RUNTIME_DIR_ENV, dir) };
+    });
+}
+
+const fn config(rows: u16, cols: u16) -> SpawnConfig {
+    SpawnConfig {
+        rows,
+        cols,
+        scrollback_lines: 1000,
+    }
+}
+
+fn session_id(prefix: &str) -> String {
+    format!("it-{prefix}-{}", std::process::id())
+}
+
+/// Kills the session's daemon on drop so a detached daemon never leaks.
+struct SessionGuard {
+    id: String,
+}
+
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new(tap_bin())
+            .args(["kill", &self.id])
+            .output();
+    }
+}
+
+/// Poll a client's rendered viewport until `needle` appears or time runs out.
+fn wait_for(client: &TuiInstance, needle: &str, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(rows) = client.read_viewport()
+            && rows.iter().any(|row| row.contains(needle))
+        {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Run `tap <args>` and return its stdout.
+fn tap_command(args: &[&str]) -> String {
+    let output = std::process::Command::new(tap_bin())
+        .args(args)
+        .output()
+        .expect("run tap subcommand");
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// Poll `tap <args>` until its stdout contains `needle` or time runs out. The
+/// per-attempt connection can transiently fail under heavy parallel load, so
+/// queries are retried rather than asserted one-shot.
+fn wait_for_command(args: &[&str], needle: &str, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if tap_command(args).contains(needle) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[test]
+fn session_round_trips_input_and_serves_scrollback() {
+    init();
+    let id = session_id("roundtrip");
+    let _guard = SessionGuard { id: id.clone() };
+    let manager = TuiManager::new();
+
+    let client = manager
+        .spawn(
+            tap_bin(),
+            vec!["start".into(), "--id".into(), id.clone(), "bash".into()],
+            config(24, 80),
+        )
+        .expect("start session");
+
+    client.write("echo round-trip-OK\n").expect("type command");
+    assert!(
+        wait_for(&client, "round-trip-OK", Duration::from_secs(10)),
+        "attached client never showed the command output"
+    );
+
+    // A separate process can read the same session's screen over the socket.
+    assert!(
+        wait_for_command(
+            &["scrollback", "--session", &id],
+            "round-trip-OK",
+            Duration::from_secs(10),
+        ),
+        "scrollback query never returned the session output"
+    );
+}
+
+#[test]
+fn second_attach_resyncs_a_full_screen_tui() {
+    init();
+    let id = session_id("altscreen");
+    let _guard = SessionGuard { id: id.clone() };
+    let manager = TuiManager::new();
+
+    // Enter the alternate screen, draw colored text, then block so the session
+    // stays in its full-screen state while a second client attaches.
+    let script = "printf '\\033[?1049h\\033[2J\\033[H\\033[31mRED-TUI-BODY\\033[0m'; read ignored";
+    let first = manager
+        .spawn(
+            tap_bin(),
+            vec![
+                "start".into(),
+                "--id".into(),
+                id.clone(),
+                "bash".into(),
+                "-c".into(),
+                script.into(),
+            ],
+            config(24, 80),
+        )
+        .expect("start full-screen session");
+    assert!(
+        wait_for(&first, "RED-TUI-BODY", Duration::from_secs(10)),
+        "first client never rendered the full-screen body"
+    );
+
+    // The original tap dumped colorless plain text with no redraw here; the
+    // resync snapshot must reproduce the alternate-screen content instead.
+    let second = manager
+        .spawn(tap_bin(), vec!["attach".into(), id], config(24, 80))
+        .expect("attach second client");
+    assert!(
+        wait_for(&second, "RED-TUI-BODY", Duration::from_secs(10)),
+        "second client did not resync the full-screen content on attach"
+    );
+}
+
+#[test]
+fn multiplayer_shares_output_and_sizes_to_smallest_client() {
+    init();
+    let id = session_id("multiplayer");
+    let _guard = SessionGuard { id: id.clone() };
+    let manager = TuiManager::new();
+
+    let small = manager
+        .spawn(
+            tap_bin(),
+            vec!["start".into(), "--id".into(), id.clone(), "bash".into()],
+            config(24, 80),
+        )
+        .expect("start session");
+    // Let the shell come up before a second client joins.
+    std::thread::sleep(Duration::from_millis(400));
+
+    let large = manager
+        .spawn(
+            tap_bin(),
+            vec!["attach".into(), id.clone()],
+            config(30, 100),
+        )
+        .expect("attach larger client");
+
+    // The larger client is told the session is sized to the smaller one, and
+    // warns that its extra space is unused.
+    assert!(
+        wait_for(&large, "smallest client wins", Duration::from_secs(10)),
+        "larger client showed no size-mismatch warning"
+    );
+
+    // Output typed in one client reaches both.
+    small.write("echo SHARED-OUTPUT\n").expect("type in small client");
+    assert!(
+        wait_for(&small, "SHARED-OUTPUT", Duration::from_secs(10)),
+        "originating client missing shared output"
+    );
+    assert!(
+        wait_for(&large, "SHARED-OUTPUT", Duration::from_secs(10)),
+        "second client missing shared output"
+    );
+
+    // The negotiated size is the element-wise min of both clients.
+    assert!(
+        wait_for_command(&["size", "--session", &id], "24x80", Duration::from_secs(10)),
+        "session not sized to the smallest client; got {:?}",
+        tap_command(&["size", "--session", &id])
+    );
+}
+
+#[test]
+fn resize_while_attached_reaches_the_session() {
+    init();
+    let id = session_id("resize");
+    let _guard = SessionGuard { id: id.clone() };
+    let manager = TuiManager::new();
+
+    let client = manager
+        .spawn(
+            tap_bin(),
+            vec!["start".into(), "--id".into(), id.clone(), "bash".into()],
+            config(24, 80),
+        )
+        .expect("start session");
+    std::thread::sleep(Duration::from_millis(400));
+
+    // Resizing the client's terminal delivers SIGWINCH to the attached tap,
+    // which must forward the new size to the daemon (the original tap dropped
+    // resizes from an attached client entirely).
+    client.resize(40, 100).expect("resize client terminal");
+    assert!(
+        wait_for_command(&["size", "--session", &id], "40x100", Duration::from_secs(10)),
+        "resize while attached never reached the session; got {:?}",
+        tap_command(&["size", "--session", &id])
+    );
+}


### PR DESCRIPTION
## What

Brings the `tap` terminal session manager (formerly `andrewgazelka/tap`) into this workspace as `nix run .#tap`, as a ground-up daemon/client rewrite.

`tap` gives you tmux-style session persistence without the in-terminal tiling layer: start a command, detach, reattach later from any terminal, and share a session with others. It is meant for tiling-WM users whose WM already handles window layout.

## Why a rewrite

The original embedded the server inside the foreground process. That made three things impossible, all of which this PR fixes and tests:

- **Attaching to a running full-screen TUI** repainted nothing useful (it dumped colorless plain text with no cursor or alternate-screen state). Now the daemon hands every new client an escape-sequence resync snapshot of the live screen, joined to the output stream with no gap.
- **Resizing while attached** was dropped entirely (no client `SIGWINCH` handler). Now the attach client forwards resizes; the session renegotiates.
- **Multiplayer** was hard-rejected (one attached client max). Now any number of clients can attach; the session is sized to the smallest one (element-wise min of every client's rows and cols), and larger clients get a dim bottom-row warning that their extra space is unused.

Also fixed: line-framed protocol (the old one dropped coalesced reads), real child exit codes, stale-session cleanup via PID liveness checks, and proper daemonization.

## Shape

Three composable crates under `packages/tap/`:

- `tap-pty`: the reusable PTY session engine. Spawns a child on a real PTY via `pty-process`, mirrors it with `vt100`, and fans raw output out to many subscribers. A subscriber's resync snapshot and live stream are handed out under one emulator lock, so a late attach joins exactly once (no missed or duplicated bytes). This is the bug a session manager has to get right.
- `tap-protocol`: wire types and runtime paths, no I/O.
- `tap`: the CLI, daemon, and attach client.

Commands: `start` / `attach` / `list` / `kill` / `scrollback` / `cursor` / `size` / `inject` / `subscribe`. Detach with `Ctrl-\`, open scrollback in `$EDITOR` with `Alt-e`.

## Tests

Integration tests in `packages/tap/tests/integration.rs` drive the real `tap` binary on a PTY using this repo's [`tui`](../tree/main/packages/tui) driver and assert on the rendered grid: input round-trip, full-screen resync on a second attach, multiplayer min-size negotiation, and resize-while-attached. They run in the nix sandbox (`bash` registered as a test input).

## Validation

- `nix build .#tap`
- `nix run .#tap -- --help`
- `nix run .#lint` (all 5 tasks)
- `nix build .#tap.passthru.tests.{clippy,tap-all,cargoMachete,unusedCrateDependencies}` (workspace clippy covers all three crates)
- `nix build '.#tap.passthru.tests."integration-*-all"'` (the four PTY integration tests pass in the sandbox)

## Notes

Unix only (PTYs, `SIGWINCH`, `setsid`); sessions are local to one machine and user. macOS detail: the daemon `setsid`s after spawning its PTY child, because macOS rejects the child's `TIOCSCTTY` when its parent is already a leaderless session.

Made with AI (Anthropic Claude, model `claude-opus-4-8`).
