### PR TITLE
tui-py: fix clippy::significant_drop_tightening in ensure_published

### DIFF
--- a/packages/tui-py/src/publish.rs
+++ b/packages/tui-py/src/publish.rs
@@ -158,6 +158,9 @@ pub fn ensure_published(py: Python<'_>, poll_ms: u64) {
     });
     if let Ok(publisher) = publisher {
         *guard = Some(publisher);
+        // Release the bind lock before the atomic store, which needs no lock;
+        // holding the guard across it trips `clippy::significant_drop_tightening`.
+        drop(guard);
         PROCESS_PUBLISHED.store(true, Ordering::Release);
     }
 }


### PR DESCRIPTION
Hotfix for a regression merged in #331: the auto-publish coordination flag (`PROCESS_PUBLISHED`) was stored while the `AUTOPUBLISHER` mutex guard was still alive, which the workspace's denied `clippy::nursery` group rejects via `significant_drop_tightening`, leaving `tui_py-clippy` (and therefore `rust-package-tests` / `flake-check`) red on `main`.

Drop the guard before the lock-free atomic store. Verified locally: `nix build .#checks.x86_64-linux.rust-package-tests` passes.

Made with Claude (claude-opus-4-8).