### PR TITLE
elevenlabs-say: stream input over a pipe with --stream

### DIFF
--- a/packages/elevenlabs-say/README.md
+++ b/packages/elevenlabs-say/README.md
@@ -31,9 +31,26 @@ nix run .#elevenlabs-say -- "save me" --output /tmp/out.mp3
 # Pick a voice by name or id, and override the model or format.
 nix run .#elevenlabs-say -- "different voice" --voice Adam
 nix run .#elevenlabs-say -- "slower model" --model eleven_multilingual_v2 --format mp3_44100_192
+
+# Stream a producer's output: forward text as it arrives and play audio as it
+# synthesizes, instead of waiting for the producer to finish.
+my-llm --prompt "tell me a story" | nix run .#elevenlabs-say -- --stream
 ```
 
 Text source precedence is positional argument, then `--file`, then stdin.
+
+## Streaming input
+
+`--stream` switches synthesis to the ElevenLabs [WebSocket input-streaming
+endpoint](https://elevenlabs.io/docs/api-reference/text-to-speech/v-1-text-to-speech-voice-id-stream-input).
+The CLI reads stdin as each read returns (rather than buffering to EOF), forwards
+the text token by token, and plays or writes audio as it comes back. Put it at the
+end of a pipe whose producer emits text over time, such as an LLM token stream.
+
+`--stream` works with `--output` too, writing audio to the file as it arrives. It
+honors `--voice`, `--model`, and `--format`; the default `eleven_flash_v2_5` model
+is the recommended low-latency choice and supports this endpoint. The model
+`eleven_v3` does not, so streaming will fail with it.
 
 ## Defaults
 
@@ -55,3 +72,6 @@ PATH. `--output` skips playback and writes the audio bytes directly.
 - A name that collides with a 20-character voice id would resolve as a name
   first. ElevenLabs voice ids are opaque tokens, so this does not happen in
   practice.
+- `--stream` plays MP3 over a pipe, so it assumes an MP3 `--format` (the
+  default). A raw PCM format has no container for `ffplay` to detect from the
+  stream and will not play; use the default or `--output` for raw formats.

--- a/packages/elevenlabs-say/default.nix
+++ b/packages/elevenlabs-say/default.nix
@@ -68,11 +68,28 @@ let
         esac
         mkdir -p "$out"
       '';
+
+  # Exercise the --stream input path offline against the installed module: the
+  # WebSocket client is constructed but never connected, so no network or audio
+  # device is needed. Guards incremental stdin reading and the realtime wiring.
+  streaming =
+    pkgs.runCommand "elevenlabs-say-streaming"
+      {
+        strictDeps = true;
+        # Constructing ElevenLabs() builds an httpx SSL context, which reads
+        # SSL_CERT_FILE. No request is sent, but the file must exist in the
+        # sandbox for the realtime-client narrowing check to run.
+        SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+      }
+      ''
+        ${unwrapped}/venv/bin/python ${./tests/test_streaming.py}
+        mkdir -p "$out"
+      '';
 in
 package.overrideAttrs (old: {
   passthru = (old.passthru or { }) // {
     tests = {
-      inherit printsHelp;
+      inherit printsHelp streaming;
     };
   };
 })

--- a/packages/elevenlabs-say/src/elevenlabs_say/__init__.py
+++ b/packages/elevenlabs-say/src/elevenlabs_say/__init__.py
@@ -4,20 +4,28 @@ Reads text from a positional argument, a file, or stdin, synthesizes speech with
 the ElevenLabs API, and either plays it through the speakers with ``ffplay`` or
 writes the audio to a file. The API key comes from ``ELEVENLABS_API_KEY``; there
 is no embedded key and no silent fallback.
+
+With ``--stream`` the CLI uses the ElevenLabs WebSocket input-streaming endpoint:
+stdin is forwarded token by token and audio is played as it arrives, so it can
+sit at the end of a pipe that emits text incrementally (for example an LLM token
+stream) instead of waiting for the whole input.
 """
 
 from __future__ import annotations
 
 import argparse
+import codecs
 import os
 import subprocess
 import sys
 import tempfile
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
 from elevenlabs import ElevenLabs
 from elevenlabs.core import ApiError
+from elevenlabs.realtime_tts import RealtimeTextToSpeechClient
 
 # Rachel is a stable ElevenLabs premade voice that is available on every account,
 # so it is a safe default for a `say` replacement.
@@ -27,6 +35,12 @@ DEFAULT_MODEL_ID = "eleven_flash_v2_5"
 DEFAULT_OUTPUT_FORMAT = "mp3_44100_128"
 
 API_KEY_ENV = "ELEVENLABS_API_KEY"
+
+# Shared so the batch and streaming playback paths report the same fix.
+FFPLAY_NOT_FOUND = (
+    "ffplay was not found on PATH; install ffmpeg to play audio, "
+    "or use --output PATH to save the audio instead"
+)
 
 
 class SayError(Exception):
@@ -41,6 +55,7 @@ class CliArgs:
     voice: str
     model: str
     output_format: str
+    stream: bool
 
 
 def parse_args(argv: list[str] | None = None) -> CliArgs:
@@ -87,6 +102,15 @@ def parse_args(argv: list[str] | None = None) -> CliArgs:
         default=DEFAULT_OUTPUT_FORMAT,
         help=f"Output audio format. Defaults to {DEFAULT_OUTPUT_FORMAT}.",
     )
+    _ = parser.add_argument(
+        "--stream",
+        action="store_true",
+        help=(
+            "Stream input over the ElevenLabs WebSocket: forward stdin as it "
+            "arrives and play or write audio incrementally. Use it at the end of "
+            "a pipe whose producer emits text over time."
+        ),
+    )
     namespace = parser.parse_args(argv)
 
     text: str | None = namespace.text
@@ -95,6 +119,7 @@ def parse_args(argv: list[str] | None = None) -> CliArgs:
     voice: str = namespace.voice
     model: str = namespace.model
     output_format: str = namespace.output_format
+    stream: bool = namespace.stream
 
     return CliArgs(
         text=text,
@@ -103,6 +128,7 @@ def parse_args(argv: list[str] | None = None) -> CliArgs:
         voice=voice,
         model=model,
         output_format=output_format,
+        stream=stream,
     )
 
 
@@ -128,6 +154,51 @@ def read_text(args: CliArgs) -> str:
     return text
 
 
+def stdin_text_chunks() -> Iterator[str]:
+    """Yield decoded text from stdin as each read returns.
+
+    ``os.read`` returns as soon as any bytes are available, so a slow producer's
+    tokens are forwarded immediately. Iterating ``sys.stdin`` line by line would
+    instead block until a newline, which a token stream may never emit. An
+    incremental UTF-8 decoder keeps multi-byte characters intact when one is split
+    across two reads.
+    """
+    decoder = codecs.getincrementaldecoder("utf-8")()
+    fd = sys.stdin.fileno()
+    while True:
+        data = os.read(fd, 4096)
+        if not data:
+            tail = decoder.decode(b"", final=True)
+            if tail:
+                yield tail
+            return
+        text = decoder.decode(data)
+        if text:
+            yield text
+
+
+def text_source(args: CliArgs) -> Iterator[str]:
+    """Yield text incrementally for streaming synthesis.
+
+    A positional argument or --file resolves to a single chunk; stdin is read in
+    small reads so a producer that streams tokens is forwarded with low latency
+    rather than buffered until EOF.
+    """
+    if args.text is not None:
+        yield args.text
+    elif args.file is not None:
+        try:
+            yield args.file.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise SayError(f"cannot read text file {args.file}: {exc}") from exc
+    elif not sys.stdin.isatty():
+        yield from stdin_text_chunks()
+    else:
+        raise SayError(
+            "no text to speak: pass TEXT, use --file PATH, or pipe text on stdin"
+        )
+
+
 def make_client() -> ElevenLabs:
     if not os.environ.get(API_KEY_ENV):
         raise SayError(
@@ -135,6 +206,23 @@ def make_client() -> ElevenLabs:
             f"for example: export {API_KEY_ENV}=sk_..."
         )
     return ElevenLabs()
+
+
+def stream_client(client: ElevenLabs) -> RealtimeTextToSpeechClient:
+    """Narrow ``client.text_to_speech`` to the realtime client.
+
+    ``ElevenLabs.__init__`` wires ``text_to_speech`` to a
+    ``RealtimeTextToSpeechClient``, but the inherited accessor is typed as the
+    base ``TextToSpeechClient``, so ``convert_realtime`` is invisible to the type
+    checker. Narrow it here and fail loudly if a future SDK drops the wiring.
+    """
+    tts = client.text_to_speech
+    if not isinstance(tts, RealtimeTextToSpeechClient):
+        raise SayError(
+            "this elevenlabs build does not expose WebSocket input streaming "
+            "(RealtimeTextToSpeechClient); --stream needs elevenlabs>=2.0"
+        )
+    return tts
 
 
 def resolve_voice_id(client: ElevenLabs, voice: str) -> str:
@@ -170,6 +258,24 @@ def synthesize(client: ElevenLabs, text: str, args: CliArgs, voice_id: str) -> b
         raise SayError(format_api_error("synthesize speech", exc)) from exc
 
 
+def stream_synthesize(
+    client: ElevenLabs, args: CliArgs, voice_id: str
+) -> Iterator[bytes]:
+    """Stream audio for stdin text over the WebSocket input-streaming endpoint.
+
+    The SDK generator interleaves sending each text chunk with a short
+    non-blocking receive, so audio comes back while later input is still being
+    typed. It pins ``chunk_length_schedule=[50]`` for low latency, which is the
+    intended trade for a pipe.
+    """
+    return stream_client(client).convert_realtime(
+        voice_id=voice_id,
+        text=text_source(args),
+        model_id=args.model,
+        output_format=args.output_format,
+    )
+
+
 def format_api_error(action: str, exc: ApiError) -> str:
     if exc.status_code is not None:
         return f"failed to {action}: ElevenLabs API returned status {exc.status_code}: {exc.body}"
@@ -181,6 +287,23 @@ def write_output(audio: bytes, output: Path) -> None:
         _ = output.write_bytes(audio)
     except OSError as exc:
         raise SayError(f"cannot write audio to {output}: {exc}") from exc
+
+
+def write_stream(chunks: Iterable[bytes], output: Path) -> None:
+    """Write audio chunks to ``output`` as they arrive, failing on empty input."""
+    wrote = False
+    try:
+        with output.open("wb") as handle:
+            for chunk in chunks:
+                _ = handle.write(chunk)
+                wrote = True
+    except OSError as exc:
+        raise SayError(f"cannot write audio to {output}: {exc}") from exc
+
+    if not wrote:
+        # An empty mp3 is worse than no file: it looks like success.
+        output.unlink(missing_ok=True)
+        raise SayError("no audio was produced; the input may have been empty")
 
 
 def play(audio: bytes) -> None:
@@ -207,17 +330,71 @@ def play(audio: bytes) -> None:
         if completed.returncode != 0:
             raise SayError(f"ffplay exited with status {completed.returncode}")
     except FileNotFoundError as exc:
-        raise SayError(
-            "ffplay was not found on PATH; install ffmpeg to play audio, "
-            "or use --output PATH to save the audio instead"
-        ) from exc
+        raise SayError(FFPLAY_NOT_FOUND) from exc
     finally:
         temp_path.unlink(missing_ok=True)
 
 
+def play_stream(chunks: Iterable[bytes]) -> None:
+    """Pipe MP3 audio chunks to ``ffplay`` as they arrive for low-latency playback.
+
+    ``ffplay`` reads from ``pipe:0`` and starts decoding before EOF, so audio
+    begins while later chunks are still synthesizing. The process starts lazily
+    on the first chunk, so empty input gives a clear error instead of an ffplay
+    "no stream found" failure.
+    """
+    proc: subprocess.Popen[bytes] | None = None
+    try:
+        for chunk in chunks:
+            if proc is None:
+                proc = _spawn_ffplay()
+            stdin = proc.stdin
+            assert stdin is not None  # PIPE is always set; narrows for the checker
+            try:
+                _ = stdin.write(chunk)
+                stdin.flush()
+            except BrokenPipeError:
+                # ffplay exited early; stop feeding and report via its exit code.
+                break
+    finally:
+        if proc is not None and proc.stdin is not None:
+            proc.stdin.close()
+
+    if proc is None:
+        raise SayError("no audio was produced; the input may have been empty")
+
+    returncode = proc.wait()
+    if returncode != 0:
+        raise SayError(f"ffplay exited with status {returncode}")
+
+
+def _spawn_ffplay() -> subprocess.Popen[bytes]:
+    try:
+        return subprocess.Popen(
+            ["ffplay", "-nodisp", "-autoexit", "-loglevel", "error", "-i", "pipe:0"],
+            stdin=subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        raise SayError(FFPLAY_NOT_FOUND) from exc
+
+
 def run(args: CliArgs) -> None:
-    text = read_text(args)
     client = make_client()
+
+    if args.stream:
+        voice_id = resolve_voice_id(client, args.voice)
+        chunks = stream_synthesize(client, args, voice_id)
+        try:
+            if args.output is not None:
+                write_stream(chunks, args.output)
+                print(f"wrote {args.output}", file=sys.stderr)
+            else:
+                play_stream(chunks)
+        except ApiError as exc:
+            raise SayError(format_api_error("stream speech", exc)) from exc
+        return
+
+    text = read_text(args)
     voice_id = resolve_voice_id(client, args.voice)
     audio = synthesize(client, text, args, voice_id)
 

--- a/packages/elevenlabs-say/tests/test_streaming.py
+++ b/packages/elevenlabs-say/tests/test_streaming.py
@@ -1,0 +1,103 @@
+"""Offline regression tests for the --stream input path.
+
+Run by the ``streaming`` passthru test with the built venv interpreter. Network
+is never touched: the WebSocket client is only constructed, not connected.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import elevenlabs_say as say
+
+
+def test_stdin_yields_before_eof_and_rejoins_split_utf8() -> None:
+    """stdin is forwarded as bytes arrive, and a byte-split char is preserved.
+
+    Guards the core streaming contract: a producer that has not closed its end
+    still gets its text spoken, and a multi-byte character split across two reads
+    is not corrupted. A regression to ``sys.stdin.read()`` or line iteration
+    would block until EOF and fail the "before close" assertion.
+    """
+    read_fd, write_fd = os.pipe()
+
+    class FakeStdin:
+        def fileno(self) -> int:
+            return read_fd
+
+        def isatty(self) -> bool:
+            return False
+
+    original = sys.stdin
+    sys.stdin = FakeStdin()  # type: ignore[assignment]
+    chunks: list[str] = []
+
+    def drain() -> None:
+        for chunk in say.stdin_text_chunks():
+            chunks.append(chunk)
+
+    worker = threading.Thread(target=drain)
+    worker.start()
+    try:
+        time.sleep(0.15)
+        os.write(write_fd, b"hello ")
+        time.sleep(0.15)
+        before_close = len(chunks)
+        # "ä" is 0xC3 0xA4; split it across two reads.
+        os.write(write_fd, b"\xc3")
+        time.sleep(0.05)
+        os.write(write_fd, b"\xa4 world")
+        time.sleep(0.1)
+        os.close(write_fd)
+        worker.join(timeout=2)
+    finally:
+        sys.stdin = original
+
+    assert before_close >= 1, f"stdin did not stream before EOF: {chunks}"
+    assert "".join(chunks) == "hello ä world", chunks
+
+
+def test_write_stream_writes_chunks_and_rejects_empty() -> None:
+    out = Path(tempfile.mktemp(suffix=".mp3"))
+    say.write_stream(iter([b"abc", b"def"]), out)
+    assert out.read_bytes() == b"abcdef"
+    out.unlink()
+
+    empty = Path(tempfile.mktemp(suffix=".mp3"))
+    try:
+        say.write_stream(iter([]), empty)
+    except say.SayError as exc:
+        assert "no audio" in str(exc), exc
+    else:
+        raise AssertionError("expected SayError on empty stream")
+    assert not empty.exists(), "an empty mp3 must not be left behind"
+
+
+def test_play_stream_rejects_empty_without_spawning_ffplay() -> None:
+    try:
+        say.play_stream(iter([]))
+    except say.SayError as exc:
+        assert "no audio" in str(exc), exc
+    else:
+        raise AssertionError("expected SayError on empty stream")
+
+
+def test_stream_client_narrows_to_realtime() -> None:
+    """The wired client exposes convert_realtime, so --stream has a transport."""
+    os.environ["ELEVENLABS_API_KEY"] = "test-key-not-used"
+    client = say.make_client()
+    realtime = say.stream_client(client)
+    assert hasattr(realtime, "convert_realtime"), realtime
+
+
+if __name__ == "__main__":
+    test_stdin_yields_before_eof_and_rejoins_split_utf8()
+    test_write_stream_writes_chunks_and_rejects_empty()
+    test_play_stream_rejects_empty_without_spawning_ffplay()
+    test_stream_client_narrows_to_realtime()
+    print("elevenlabs-say streaming tests passed")

--- a/site/src/lib/updates/elevenlabs-say-streaming-input.svx
+++ b/site/src/lib/updates/elevenlabs-say-streaming-input.svx
@@ -1,0 +1,21 @@
+---
+id: elevenlabs-say-streaming-input
+postedAt: 2026-05-29T21:00:00-07:00
+title: "`elevenlabs-say --stream` speaks a pipe as it streams"
+tags: [interesting, python, cli, audio]
+links:
+  - label: elevenlabs-say package
+    href: https://github.com/indexable-inc/index/tree/main/packages/elevenlabs-say
+  - label: WebSocket input streaming
+    href: https://elevenlabs.io/docs/api-reference/text-to-speech/v-1-text-to-speech-voice-id-stream-input
+---
+
+`elevenlabs-say` can now sit at the end of a pipe whose producer emits text over time. Pass `--stream` and stdin is forwarded as each read returns, with audio played the moment it comes back:
+
+```sh
+my-llm --prompt "tell me a story" | nix run .#elevenlabs-say -- --stream
+```
+
+Without the flag the CLI still reads all of stdin, synthesizes once, and plays. `--stream` switches to the ElevenLabs WebSocket input-streaming endpoint instead. It reads stdin with `os.read` rather than line iteration, so a token stream that never emits a newline is still spoken instead of buffering until EOF, and a multi-byte character split across two reads is rejoined. Audio chunks pipe into `ffplay` as they arrive, so playback starts before synthesis finishes.
+
+It honors `--voice`, `--model`, `--format`, and `--output` (which writes the file as audio streams in). The default `eleven_flash_v2_5` model is the low-latency choice and supports the endpoint; `eleven_v3` does not.


### PR DESCRIPTION
## What

Adds a `--stream` flag to `elevenlabs-say` so it can sit at the end of a pipe whose producer emits text over time (for example an LLM token stream) and speak it as it streams, instead of buffering all of stdin, synthesizing once, then playing.

```sh
my-llm --prompt "tell me a story" | nix run .#elevenlabs-say -- --stream
```

## How

- `--stream` switches synthesis to the ElevenLabs WebSocket [input-streaming endpoint](https://elevenlabs.io/docs/api-reference/text-to-speech/v-1-text-to-speech-voice-id-stream-input) via the SDK's `convert_realtime`, which interleaves sending text with receiving audio.
- stdin is read with `os.read` plus an incremental UTF-8 decoder rather than line iteration, so a token stream that never emits a newline is still forwarded with low latency, and a multi-byte character split across two reads is rejoined.
- Audio chunks pipe into `ffplay -i pipe:0` as they arrive, so playback starts before synthesis finishes. `--output` writes the file as audio streams in. Both fail loudly on empty input instead of leaving a misleading empty mp3.
- `client.text_to_speech` is statically typed as the base `TextToSpeechClient` (no `convert_realtime`), though `ElevenLabs.__init__` wires it to `RealtimeTextToSpeechClient`. A small `stream_client` narrows it and fails loudly if a future SDK drops that wiring.
- No new dependencies: `websockets` is already in the closure via `elevenlabs`, and playback reuses the bundled `ffmpeg`.

Default (no `--stream`) behavior is unchanged: read all of stdin, synthesize once with the batch `convert` endpoint, play.

## Tests

New `packages/elevenlabs-say/tests/test_streaming.py`, wired as `passthru.tests.streaming`, runs offline (the WebSocket client is constructed but never connected): it asserts stdin streams before EOF, a byte-split UTF-8 char is rejoined, `write_stream` writes chunks and rejects empty input, `play_stream` rejects empty input without spawning ffplay, and `stream_client` narrows to the realtime client that exposes `convert_realtime`.

## Validation

- ✅ `nix build .#elevenlabs-say` (runs `ty`)
- ✅ `nix build .#elevenlabs-say.tests.streaming` and `.tests.printsHelp`
- ✅ `nix run .#lint`
- ✅ Built binary: `--help` shows `--stream`; `--stream` with no API key gives the clean key-missing error
- ✅ Live offline run of the streaming helpers against the built venv interpreter
- Not run: a real synthesis end to end. There is no `ELEVENLABS_API_KEY` available in this environment, so the WebSocket round trip and audio playback were not exercised against the live API.

---
Made with AI (Claude Opus 4.8).
