### PR TITLE
elevenlabs-say: fix 402 on free tier by defaulting to a usable voice

### DIFF
--- a/packages/elevenlabs-say/README.md
+++ b/packages/elevenlabs-say/README.md
@@ -54,9 +54,11 @@ is the recommended low-latency choice and supports this endpoint. The model
 
 ## Defaults
 
-- Voice: Rachel (`21m00Tcm4TlvDq8ikWAM`), a premade voice on every account. A
-  `--voice` value that matches a voice name is resolved to its id; otherwise it
-  is used as a literal id.
+- Voice: George (`JBFqnCBsd6RMkjVDRZzb`), a current ElevenLabs default voice that
+  works on every tier including free. A `--voice` value that matches a voice name
+  is resolved to its id; otherwise it is used as a literal id. The legacy premade
+  voices (such as Rachel) are now Voice Library voices, which the API refuses for
+  free accounts with `402 paid_plan_required`.
 - Model: `eleven_flash_v2_5`, chosen for low latency.
 - Format: `mp3_44100_128`.
 

--- a/packages/elevenlabs-say/src/elevenlabs_say/__init__.py
+++ b/packages/elevenlabs-say/src/elevenlabs_say/__init__.py
@@ -27,10 +27,13 @@ from elevenlabs import ElevenLabs
 from elevenlabs.core import ApiError
 from elevenlabs.realtime_tts import RealtimeTextToSpeechClient
 
-# Rachel is a stable ElevenLabs premade voice that is available on every account,
-# so it is a safe default for a `say` replacement.
-# https://elevenlabs.io/docs/api-reference/voices/get
-DEFAULT_VOICE_ID = "21m00Tcm4TlvDq8ikWAM"
+# George is a current ElevenLabs default voice and the one the official quickstart
+# ships, so it works on every tier including free. The legacy premade voices (such
+# as Rachel, 21m00Tcm4TlvDq8ikWAM) became Voice Library voices, which the API
+# refuses for free accounts with HTTP 402 paid_plan_required. Default voices are
+# scheduled to retire on 2026-12-31, so this id may need refreshing then.
+# https://elevenlabs.io/docs/quickstart
+DEFAULT_VOICE_ID = "JBFqnCBsd6RMkjVDRZzb"
 DEFAULT_MODEL_ID = "eleven_flash_v2_5"
 DEFAULT_OUTPUT_FORMAT = "mp3_44100_128"
 
@@ -88,7 +91,7 @@ def parse_args(argv: list[str] | None = None) -> CliArgs:
         default=DEFAULT_VOICE_ID,
         help=(
             "Voice name or id. A value that matches a voice name is resolved to "
-            f"its id; otherwise it is used verbatim. Defaults to Rachel ({DEFAULT_VOICE_ID})."
+            f"its id; otherwise it is used verbatim. Defaults to George ({DEFAULT_VOICE_ID})."
         ),
     )
     _ = parser.add_argument(


### PR DESCRIPTION
## Problem

`echo hi | nix run .#elevenlabs-say` fails for free-tier ElevenLabs accounts:

```
elevenlabs-say: failed to synthesize speech: ElevenLabs API returned status 402:
{'detail': {'code': 'paid_plan_required', 'message': 'Free users cannot use library voices via the API. Please upgrade your subscription to use this voice.'}}
```

The default voice was Rachel (`21m00Tcm4TlvDq8ikWAM`). ElevenLabs reclassified its original premade voices as Voice Library voices, and the API blocks library voices for free accounts. The docs state plainly: "Voice Library voices are not available via the API to free tier users." Default voices remain usable on every tier.

## Fix

Default to George (`JBFqnCBsd6RMkjVDRZzb`), a current ElevenLabs default voice. It is the voice the [official quickstart](https://elevenlabs.io/docs/quickstart) ships as the first request a new account makes, so it is the safest "works out of the box" choice and does not trip `paid_plan_required`. `--voice` still overrides. README and the `--voice` help text updated; an inline comment records why and notes that default voices are scheduled to retire on 2026-12-31.

This is a one-line default change; the resolution flow and everything else are unchanged.

## Validation

- ✅ `nix build .#elevenlabs-say` (runs `ty`)
- ✅ `nix build .#elevenlabs-say.tests.streaming` and `.tests.printsHelp`
- ✅ `nix run .#lint`
- ✅ Built binary `--help` now shows `Defaults to George (JBFqnCBsd6RMkjVDRZzb)`
- Not run: a live free-tier synthesis. No `ELEVENLABS_API_KEY` is available in this environment, so the 402-free 200 was verified from ElevenLabs docs and the official quickstart rather than a live call. Confirm with `echo hi | nix run .#elevenlabs-say` on a free key.

---
Made with AI (Claude Opus 4.8).
