### PR TITLE
elevenlabs-say: stream piped stdin by default

### DIFF
--- a/packages/elevenlabs-say/README.md
+++ b/packages/elevenlabs-say/README.md
@@ -22,8 +22,12 @@ nix run .#elevenlabs-say -- "the first move sets everything in motion"
 # Speak the contents of a file.
 nix run .#elevenlabs-say -- --file notes.txt
 
-# Speak text piped on stdin.
-echo "hello from index" | nix run .#elevenlabs-say
+# Pipe text on stdin. This streams by default: a producer that emits text over
+# time is spoken as it arrives, instead of waiting for it to finish.
+my-llm --prompt "tell me a story" | nix run .#elevenlabs-say
+
+# Force the batch path on a pipe (buffer all stdin, then synthesize once).
+cat notes.txt | nix run .#elevenlabs-say -- --no-stream
 
 # Save audio instead of playing it.
 nix run .#elevenlabs-say -- "save me" --output /tmp/out.mp3
@@ -31,26 +35,28 @@ nix run .#elevenlabs-say -- "save me" --output /tmp/out.mp3
 # Pick a voice by name or id, and override the model or format.
 nix run .#elevenlabs-say -- "different voice" --voice Adam
 nix run .#elevenlabs-say -- "slower model" --model eleven_multilingual_v2 --format mp3_44100_192
-
-# Stream a producer's output: forward text as it arrives and play audio as it
-# synthesizes, instead of waiting for the producer to finish.
-my-llm --prompt "tell me a story" | nix run .#elevenlabs-say -- --stream
 ```
 
 Text source precedence is positional argument, then `--file`, then stdin.
 
 ## Streaming input
 
-`--stream` switches synthesis to the ElevenLabs [WebSocket input-streaming
-endpoint](https://elevenlabs.io/docs/api-reference/text-to-speech/v-1-text-to-speech-voice-id-stream-input).
-The CLI reads stdin as each read returns (rather than buffering to EOF), forwards
-the text token by token, and plays or writes audio as it comes back. Put it at the
-end of a pipe whose producer emits text over time, such as an LLM token stream.
+When text is piped on stdin, the CLI streams by default: it reads stdin as each
+read returns (rather than buffering to EOF), forwards the text token by token over
+the ElevenLabs [WebSocket input-streaming
+endpoint](https://elevenlabs.io/docs/api-reference/text-to-speech/v-1-text-to-speech-voice-id-stream-input),
+and plays or writes audio as it comes back. This is what you want at the end of a
+pipe whose producer emits text over time, such as an LLM token stream.
 
-`--stream` works with `--output` too, writing audio to the file as it arrives. It
+A positional `TEXT` argument or `--file` stays on the batch path, since the whole
+text is already in hand and the plain `convert` endpoint gives slightly better
+prosody. Override either way with `--stream` or `--no-stream`. Use `--no-stream` on
+a pipe when you are feeding a complete document and prefer the batch quality.
+
+Streaming works with `--output` too, writing audio to the file as it arrives. It
 honors `--voice`, `--model`, and `--format`; the default `eleven_flash_v2_5` model
-is the recommended low-latency choice and supports this endpoint. The model
-`eleven_v3` does not, so streaming will fail with it.
+is the low-latency choice and supports this endpoint. The model `eleven_v3` does
+not, so forcing `--stream` with it will fail.
 
 ## Defaults
 

--- a/packages/elevenlabs-say/src/elevenlabs_say/__init__.py
+++ b/packages/elevenlabs-say/src/elevenlabs_say/__init__.py
@@ -58,7 +58,8 @@ class CliArgs:
     voice: str
     model: str
     output_format: str
-    stream: bool
+    # None means auto: stream when text is piped on stdin, batch otherwise.
+    stream: bool | None
 
 
 def parse_args(argv: list[str] | None = None) -> CliArgs:
@@ -107,11 +108,13 @@ def parse_args(argv: list[str] | None = None) -> CliArgs:
     )
     _ = parser.add_argument(
         "--stream",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=None,
         help=(
             "Stream input over the ElevenLabs WebSocket: forward stdin as it "
-            "arrives and play or write audio incrementally. Use it at the end of "
-            "a pipe whose producer emits text over time."
+            "arrives and play or write audio incrementally. Defaults on when text "
+            "is piped on stdin and off for TEXT or --file; pass --stream or "
+            "--no-stream to force it."
         ),
     )
     namespace = parser.parse_args(argv)
@@ -122,7 +125,7 @@ def parse_args(argv: list[str] | None = None) -> CliArgs:
     voice: str = namespace.voice
     model: str = namespace.model
     output_format: str = namespace.output_format
-    stream: bool = namespace.stream
+    stream: bool | None = namespace.stream
 
     return CliArgs(
         text=text,
@@ -381,10 +384,23 @@ def _spawn_ffplay() -> subprocess.Popen[bytes]:
         raise SayError(FFPLAY_NOT_FOUND) from exc
 
 
+def should_stream(args: CliArgs) -> bool:
+    """Decide whether to take the streaming path.
+
+    An explicit --stream/--no-stream wins. Otherwise stream when text is piped on
+    stdin, the case where incremental playback matters, and stay on the batch path
+    for a positional argument or --file, where the whole text is already in hand
+    and the higher-quality convert endpoint costs nothing extra.
+    """
+    if args.stream is not None:
+        return args.stream
+    return args.text is None and args.file is None and not sys.stdin.isatty()
+
+
 def run(args: CliArgs) -> None:
     client = make_client()
 
-    if args.stream:
+    if should_stream(args):
         voice_id = resolve_voice_id(client, args.voice)
         chunks = stream_synthesize(client, args, voice_id)
         try:

--- a/packages/elevenlabs-say/tests/test_streaming.py
+++ b/packages/elevenlabs-say/tests/test_streaming.py
@@ -95,9 +95,36 @@ def test_stream_client_narrows_to_realtime() -> None:
     assert hasattr(realtime, "convert_realtime"), realtime
 
 
+def test_should_stream_auto_and_overrides() -> None:
+    """Pipe auto-streams, TEXT/--file batch, explicit --stream/--no-stream win."""
+
+    class FakeStdin:
+        def __init__(self, tty: bool) -> None:
+            self._tty = tty
+
+        def isatty(self) -> bool:
+            return self._tty
+
+    original = sys.stdin
+    try:
+        sys.stdin = FakeStdin(tty=False)  # type: ignore[assignment]
+        assert say.should_stream(say.parse_args([])) is True
+        assert say.should_stream(say.parse_args(["--no-stream"])) is False
+        assert say.should_stream(say.parse_args(["hello"])) is False
+        assert say.should_stream(say.parse_args(["hello", "--stream"])) is True
+        assert say.should_stream(say.parse_args(["--file", "notes.txt"])) is False
+
+        sys.stdin = FakeStdin(tty=True)  # type: ignore[assignment]
+        assert say.should_stream(say.parse_args([])) is False
+        assert say.should_stream(say.parse_args(["--stream"])) is True
+    finally:
+        sys.stdin = original
+
+
 if __name__ == "__main__":
     test_stdin_yields_before_eof_and_rejoins_split_utf8()
     test_write_stream_writes_chunks_and_rejects_empty()
     test_play_stream_rejects_empty_without_spawning_ffplay()
     test_stream_client_narrows_to_realtime()
+    test_should_stream_auto_and_overrides()
     print("elevenlabs-say streaming tests passed")

--- a/site/src/lib/updates/elevenlabs-say-streaming-input.svx
+++ b/site/src/lib/updates/elevenlabs-say-streaming-input.svx
@@ -1,7 +1,7 @@
 ---
 id: elevenlabs-say-streaming-input
 postedAt: 2026-05-29T21:00:00-07:00
-title: "`elevenlabs-say --stream` speaks a pipe as it streams"
+title: "`elevenlabs-say` speaks a pipe as it streams"
 tags: [interesting, python, cli, audio]
 links:
   - label: elevenlabs-say package
@@ -10,12 +10,14 @@ links:
     href: https://elevenlabs.io/docs/api-reference/text-to-speech/v-1-text-to-speech-voice-id-stream-input
 ---
 
-`elevenlabs-say` can now sit at the end of a pipe whose producer emits text over time. Pass `--stream` and stdin is forwarded as each read returns, with audio played the moment it comes back:
+`elevenlabs-say` now sits at the end of a pipe whose producer emits text over time and speaks it as it arrives. Piped stdin streams by default, no flag needed:
 
 ```sh
-my-llm --prompt "tell me a story" | nix run .#elevenlabs-say -- --stream
+my-llm --prompt "tell me a story" | nix run .#elevenlabs-say
 ```
 
-Without the flag the CLI still reads all of stdin, synthesizes once, and plays. `--stream` switches to the ElevenLabs WebSocket input-streaming endpoint instead. It reads stdin with `os.read` rather than line iteration, so a token stream that never emits a newline is still spoken instead of buffering until EOF, and a multi-byte character split across two reads is rejoined. Audio chunks pipe into `ffplay` as they arrive, so playback starts before synthesis finishes.
+Piped input goes over the ElevenLabs WebSocket input-streaming endpoint. The CLI reads stdin with `os.read` rather than line iteration, so a token stream that never emits a newline is still spoken instead of buffering until EOF, and a multi-byte character split across two reads is rejoined. Audio chunks pipe into `ffplay` as they arrive, so playback starts before synthesis finishes.
+
+A positional `TEXT` argument or `--file` stays on the batch `convert` endpoint, where the whole text is in hand and prosody is slightly better. Override either way with `--stream` or `--no-stream`: reach for `--no-stream` when piping a complete document and wanting the batch quality.
 
 It honors `--voice`, `--model`, `--format`, and `--output` (which writes the file as audio streams in). The default `eleven_flash_v2_5` model is the low-latency choice and supports the endpoint; `eleven_v3` does not.


### PR DESCRIPTION
## What

Make `elevenlabs-say` stream by default when text is piped on stdin, so a producer that emits text over time is spoken as it arrives without any flag:

```sh
my-llm --prompt "tell me a story" | nix run .#elevenlabs-say
```

Follows up #338, which shipped streaming behind an opt-in `--stream`. Piping is exactly the case where streaming matters, so it should be the default there.

## Behavior

- Piped stdin: streams over the WebSocket input-streaming endpoint (incremental read + incremental playback).
- Positional `TEXT` or `--file`: stays on the batch `convert` endpoint, where the whole text is in hand and prosody is slightly better.
- `--stream` is now `--stream` / `--no-stream` (argparse `BooleanOptionalAction`, default auto). Explicit flags win: `--no-stream` forces batch on a pipe (feeding a complete document and wanting batch quality), `--stream` forces streaming for `TEXT` / `--file`.

The decision lives in one small `should_stream(args)` helper. `eleven_v3` still does not support the streaming endpoint, so forcing `--stream` with it fails.

## Tests

Extended the offline `streaming` passthru test with `should_stream` cases: pipe auto-streams, `TEXT` and `--file` batch, and `--stream` / `--no-stream` override both ways.

## Validation

- ✅ `nix build .#elevenlabs-say` (runs `ty`)
- ✅ `nix build .#elevenlabs-say.tests.streaming` and `.tests.printsHelp`
- ✅ `nix run .#lint`
- ✅ Built binary `--help` shows `--stream | --no-stream`
- Not run: live synthesis. No `ELEVENLABS_API_KEY` in this environment, so the WebSocket round trip and audio were not exercised against the API. Confirm with `echo hi | nix run .#elevenlabs-say` (streams) and `cat notes.txt | nix run .#elevenlabs-say -- --no-stream` (batch).

---
Made with AI (Claude Opus 4.8).
