### PR TITLE
semantic-search: content-addressed semantic code search (mgrep alternative)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,6 +1219,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastdivide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,6 +1559,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1570,6 +1591,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heapless"
@@ -1736,6 +1766,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1744,13 +1791,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1962,6 +2017,12 @@ checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_ci"
@@ -2184,6 +2245,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2539,6 +2611,18 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mixedbread"
+version = "0.1.0"
+dependencies = [
+ "dirs",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
 ]
 
 [[package]]
@@ -3604,6 +3688,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "resource-monitor-stats-writer"
 version = "0.1.0"
 
@@ -3684,6 +3808,20 @@ dependencies = [
  "cpal",
  "lewton",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -3909,6 +4047,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "semantic-search"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "dirs",
+ "futures",
+ "mixedbread",
+ "repo-walker",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "snafu",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -4224,6 +4381,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -4611,6 +4771,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4715,8 +4885,10 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4802,6 +4974,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tui"
@@ -5007,6 +5185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5050,6 +5234,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,13 @@ members = [
   "packages/minecraft/nbt",
   "packages/minecraft/sound",
   "packages/minecraft/sync-managed",
+  "packages/mixedbread",
   "packages/nix-cargo-unit",
   "packages/nix-web-monitor/parser",
   "packages/nix-web-monitor/server",
   "packages/oci-image-builder",
   "packages/repo-walker",
+  "packages/semantic-search",
   "packages/tap",
   "packages/tap/protocol",
   "packages/tap/pty",
@@ -62,6 +64,7 @@ hegeltest = { version = "0.14", default-features = false }
 ignore = "0.4"
 indicatif = "0.18"
 libc = "0.2"
+mixedbread = { path = "packages/mixedbread" }
 loro = "1.12"
 napi = { version = "3", default-features = false, features = ["napi6", "tokio_rt"] }
 napi-build = "2"
@@ -81,9 +84,15 @@ pyo3 = { version = "0.28", features = ["abi3-py311"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 quartz_nbt = "0.2.9"
 repo-walker = { path = "packages/repo-walker" }
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "rustls-tls",
+  "multipart",
+] }
 rmcp = "1.7"
 rmp-serde = "1"
 rodio = { version = "0.19", default-features = false, features = ["vorbis"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-native-certs = "0.8"
 schemars = "1"

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -210,29 +210,37 @@ let
 
   rustPackageTests =
     let
+      cargoUnit = ix.cargoUnitFor pkgs;
+      rustWorkspace = ix.rustWorkspaceFor pkgs;
+      # A crate with a `packageSet` is built through `repoPackages` and carries
+      # its own `passthru.tests`. A lib-only workspace crate has no `packageSet`
+      # and is not in `repoPackages`, so select its library straight from the
+      # shared unit graph (same path ix-vt's default.nix uses). The library unit
+      # key is the Cargo package name with dashes underscored.
+      packageTestsFor =
+        entry:
+        if entry.packageSet != null then
+          (lib.attrByPath entry.packageSet.attrPath
+            (throw "packages/${entry.relativePath}/package.nix: passthruTests needs packageSet.attrPath")
+            repoPackages
+          ).passthru.tests or { }
+        else
+          (cargoUnit.selectLibraryWithTests rustWorkspace.units {
+            library = lib.replaceStrings [ "-" ] [ "_" ] entry.id;
+            packageName = entry.id;
+          }).passthru.tests or { };
       repoRustPackageTests = lib.mergeAttrsList (
         map (
           entry:
-          let
-            package =
-              lib.attrByPath entry.packageSet.attrPath
-                (throw "packages/${entry.relativePath}/package.nix: passthruTests needs packageSet.attrPath")
-                repoPackages;
-          in
           lib.mapAttrs' (testName: test: lib.nameValuePair "${entry.passthruTests.prefix}-${testName}" test) (
-            package.passthru.tests or { }
+            packageTestsFor entry
           )
         ) (packageRegistry.passthruTestEntriesFor system)
       );
       moduleRustPackages = {
-        resource-monitor-stats-writer =
-          let
-            cargoUnit = ix.cargoUnitFor pkgs;
-            rustWorkspace = ix.rustWorkspaceFor pkgs;
-          in
-          cargoUnit.selectBinaryWithTests rustWorkspace.units {
-            binary = "resource-monitor-stats-writer";
-          };
+        resource-monitor-stats-writer = cargoUnit.selectBinaryWithTests rustWorkspace.units {
+          binary = "resource-monitor-stats-writer";
+        };
       };
       moduleRustPackageTests = lib.concatMapAttrs (
         packageName: package:

--- a/packages/mixedbread/Cargo.toml
+++ b/packages/mixedbread/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mixedbread"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Minimal async Rust client for the Mixedbread vector store API (stores, files, search, question-answering)"
+
+[lints]
+workspace = true
+
+[dependencies]
+dirs.workspace = true
+reqwest = { workspace = true, features = ["json", "rustls-tls", "multipart"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+snafu.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/packages/mixedbread/package.nix
+++ b/packages/mixedbread/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "mixedbread";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/mixedbread/src/auth.rs
+++ b/packages/mixedbread/src/auth.rs
@@ -1,0 +1,97 @@
+//! Credential resolution.
+//!
+//! Prefers the `MXBAI_API_KEY` environment variable. Otherwise it reuses the
+//! credential written by `mgrep login` at `~/.mgrep/token.json`: that file
+//! holds an OAuth access token, which is exchanged for a short-lived API JWT at
+//! the platform auth endpoint. The JWT is what authenticates against the API.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use snafu::{OptionExt as _, ResultExt as _};
+
+use crate::{
+    API_KEY_ENV, BuildClientSnafu, CredentialParseSnafu, EmptyJwtSnafu, HttpSnafu,
+    NoCredentialSnafu, ReadCredentialSnafu, Result, TokenExchangeSnafu,
+};
+
+/// Platform base URL where the stored OAuth token is exchanged for an API JWT.
+/// Matches the endpoint the `mgrep` CLI uses.
+pub const PLATFORM_URL: &str = "https://www.platform.mixedbread.com";
+
+#[derive(Deserialize)]
+struct StoredToken {
+    access_token: String,
+}
+
+#[derive(Deserialize)]
+struct JwtResponse {
+    #[serde(default)]
+    token: Option<String>,
+}
+
+/// Resolve an API bearer token, preferring `MXBAI_API_KEY`, then the
+/// `mgrep login` credential exchanged for a JWT at `platform_url`.
+///
+/// # Errors
+/// Returns an error if no credential is found, the token file cannot be read or
+/// parsed, or the exchange request fails or returns no token.
+pub async fn resolve_token(platform_url: &str) -> Result<String> {
+    if let Ok(key) = std::env::var(API_KEY_ENV)
+        && !key.is_empty()
+    {
+        return Ok(key);
+    }
+
+    let path = mgrep_token_path().context(NoCredentialSnafu)?;
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return NoCredentialSnafu.fail();
+        }
+        Err(err) => return Err(err).context(ReadCredentialSnafu { path }),
+    };
+    let stored: StoredToken =
+        serde_json::from_slice(&bytes).context(CredentialParseSnafu { path })?;
+
+    exchange_for_jwt(platform_url, &stored.access_token).await
+}
+
+/// Path to the `mgrep login` token file, `~/.mgrep/token.json`.
+#[must_use]
+pub fn mgrep_token_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".mgrep").join("token.json"))
+}
+
+async fn exchange_for_jwt(platform_url: &str, access_token: &str) -> Result<String> {
+    let client = reqwest::Client::builder()
+        .build()
+        .context(BuildClientSnafu)?;
+    let resp = client
+        .get(format!("{platform_url}/api/auth/token"))
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .context(HttpSnafu)?;
+
+    if !resp.status().is_success() {
+        let status = resp.status().as_u16();
+        let body = resp.text().await.unwrap_or_default();
+        return TokenExchangeSnafu { status, body }.fail();
+    }
+
+    let jwt: JwtResponse = resp.json().await.context(HttpSnafu)?;
+    jwt.token.context(EmptyJwtSnafu)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mgrep_token_path;
+
+    #[test]
+    fn token_path_points_at_dot_mgrep() {
+        if let Some(path) = mgrep_token_path() {
+            assert!(path.ends_with(".mgrep/token.json"));
+        }
+    }
+}

--- a/packages/mixedbread/src/lib.rs
+++ b/packages/mixedbread/src/lib.rs
@@ -1,0 +1,601 @@
+//! Minimal async client for the [Mixedbread](https://www.mixedbread.com) vector
+//! store API. It owns HTTP and JSON shapes only; it carries no domain logic, so
+//! it can back a semantic-search tool or any other consumer.
+//!
+//! Endpoints covered: store create/get (`/v1/stores`), the two-step file upload
+//! (`/v1/files` then `/v1/stores/{store}/files`), file listing and deletion,
+//! search (`/v1/stores/search`), and question-answering
+//! (`/v1/stores/question-answering`).
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use reqwest::{Client as HttpClient, StatusCode};
+use serde::Deserialize;
+use snafu::{OptionExt as _, ResultExt as _, Snafu};
+
+pub mod auth;
+
+/// Default API base URL.
+pub const DEFAULT_BASE_URL: &str = "https://api.mixedbread.com";
+
+/// Environment variable holding the API key.
+pub const API_KEY_ENV: &str = "MXBAI_API_KEY";
+
+/// Failures from the Mixedbread client.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// The HTTP client could not be constructed.
+    #[snafu(display("failed to build HTTP client: {source}"))]
+    BuildClient {
+        /// Underlying reqwest error.
+        source: reqwest::Error,
+    },
+
+    /// The API key environment variable is unset or empty.
+    #[snafu(display("{API_KEY_ENV} is not set; export a key from https://mixedbread.com"))]
+    MissingApiKey,
+
+    /// A request failed to send, or its body failed to decode.
+    #[snafu(display("Mixedbread request failed: {source}"))]
+    Http {
+        /// Underlying reqwest error.
+        source: reqwest::Error,
+    },
+
+    /// The API returned a non-success status.
+    #[snafu(display("Mixedbread API returned {status}: {body}"))]
+    Api {
+        /// HTTP status code.
+        status: u16,
+        /// Response body.
+        body: String,
+    },
+
+    /// No credential was found in the environment or from `mgrep login`.
+    #[snafu(display("no Mixedbread credential found; set {API_KEY_ENV} or run `mgrep login`"))]
+    NoCredential,
+
+    /// The `mgrep login` token file exists but could not be read.
+    #[snafu(display("failed to read mgrep credential {}: {source}", path.display()))]
+    ReadCredential {
+        /// Credential file path.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// The `mgrep login` token file could not be parsed.
+    #[snafu(display("failed to parse mgrep credential {}: {source}", path.display()))]
+    CredentialParse {
+        /// Credential file path.
+        path: PathBuf,
+        /// Underlying serde error.
+        source: serde_json::Error,
+    },
+
+    /// Exchanging the stored OAuth token for an API JWT failed.
+    #[snafu(display(
+        "failed to exchange mgrep credential for an API token ({status}: {body}); run `mgrep login`"
+    ))]
+    TokenExchange {
+        /// HTTP status code.
+        status: u16,
+        /// Response body.
+        body: String,
+    },
+
+    /// The platform returned an empty token during exchange.
+    #[snafu(display("platform returned no API token; run `mgrep login` again"))]
+    EmptyJwt,
+}
+
+/// Result alias defaulting to this crate's [`Error`].
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Search tuning forwarded to the API.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct SearchOptions {
+    /// Apply the second-stage reranker.
+    pub rerank: bool,
+    /// Let the API plan and run multiple searches.
+    pub agentic: bool,
+}
+
+/// A file as reported by the store's file listing.
+#[derive(Debug, Clone)]
+pub struct StoredFile {
+    /// Caller-assigned external id, if any.
+    pub external_id: Option<String>,
+    /// Arbitrary metadata attached at upload time.
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// One scored chunk returned by search or question-answering.
+#[derive(Debug, Clone)]
+pub struct Chunk {
+    /// Matched snippet text.
+    pub text: Option<String>,
+    /// Relevance score.
+    pub score: f32,
+    /// Filename or URL of the source.
+    pub filename: Option<String>,
+    /// Zero-based start line within the source file, when known.
+    pub start_line: Option<u32>,
+    /// Number of lines spanned, when known.
+    pub num_lines: Option<u32>,
+    /// Metadata attached to the source file at upload time.
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// A question-answering response.
+#[derive(Debug, Clone)]
+pub struct AnswerResponse {
+    /// Synthesized answer text.
+    pub answer: String,
+    /// Chunks the answer drew from.
+    pub sources: Vec<Chunk>,
+}
+
+/// Indexing progress for a store: how many files are still being processed.
+#[derive(Debug, Clone, Copy)]
+pub struct StoreStatus {
+    /// Files queued but not yet processed.
+    pub pending: u64,
+    /// Files currently being embedded.
+    pub in_progress: u64,
+}
+
+/// Async client bound to a base URL and API key.
+#[derive(Debug, Clone)]
+pub struct Client {
+    http: HttpClient,
+    base_url: String,
+    api_key: String,
+}
+
+impl Client {
+    /// Build a client for an explicit base URL and API key.
+    ///
+    /// # Errors
+    /// Returns an error if the HTTP client cannot be built.
+    pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Result<Self> {
+        let http = HttpClient::builder().build().context(BuildClientSnafu)?;
+        Ok(Self {
+            http,
+            base_url: base_url.into(),
+            api_key: api_key.into(),
+        })
+    }
+
+    /// Build a client reading the API key from [`API_KEY_ENV`].
+    ///
+    /// # Errors
+    /// Returns an error if the key is unset or empty, or the client cannot be
+    /// built.
+    pub fn from_env(base_url: impl Into<String>) -> Result<Self> {
+        let api_key = std::env::var(API_KEY_ENV)
+            .ok()
+            .filter(|value| !value.is_empty())
+            .context(MissingApiKeySnafu)?;
+        Self::new(base_url, api_key)
+    }
+
+    /// Build a client resolving the credential the way a user expects: the
+    /// `MXBAI_API_KEY` environment variable if set, otherwise the token stored
+    /// by `mgrep login` (exchanged for an API JWT). See [`auth::resolve_token`].
+    ///
+    /// # Errors
+    /// Returns an error if no credential can be resolved, the token cannot be
+    /// exchanged, or the client cannot be built.
+    pub async fn from_login(base_url: impl Into<String>) -> Result<Self> {
+        let api_key = auth::resolve_token(auth::PLATFORM_URL).await?;
+        Self::new(base_url, api_key)
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{path}", self.base_url)
+    }
+
+    /// Ensure the named store exists, creating it if absent.
+    ///
+    /// # Errors
+    /// Returns an error if the store cannot be fetched or created.
+    pub async fn ensure_store(&self, name: &str) -> Result<()> {
+        let resp = self
+            .http
+            .get(self.url(&format!("/v1/stores/{name}")))
+            .bearer_auth(&self.api_key)
+            .send()
+            .await
+            .context(HttpSnafu)?;
+        if resp.status().is_success() {
+            return Ok(());
+        }
+        if resp.status() != StatusCode::NOT_FOUND {
+            return Err(api_error(resp).await);
+        }
+        let created = self
+            .http
+            .post(self.url("/v1/stores"))
+            .bearer_auth(&self.api_key)
+            .json(&serde_json::json!({ "name": name }))
+            .send()
+            .await
+            .context(HttpSnafu)?;
+        expect_ok(created).await
+    }
+
+    /// List files in a store, following cursor pagination.
+    ///
+    /// # Errors
+    /// Returns an error if any page request fails or cannot be decoded.
+    pub async fn list_files(&self, store: &str) -> Result<Vec<StoredFile>> {
+        let mut files = Vec::new();
+        let mut after: Option<String> = None;
+        loop {
+            let request = ListRequest {
+                limit: 100,
+                after: after.as_deref(),
+            };
+            let resp = self
+                .http
+                .post(self.url(&format!("/v1/stores/{store}/files/list")))
+                .bearer_auth(&self.api_key)
+                .json(&request)
+                .send()
+                .await
+                .context(HttpSnafu)?;
+            let page: ListResponse = decode(resp).await?;
+            for item in page.data {
+                files.push(StoredFile {
+                    external_id: item.external_id,
+                    metadata: item.metadata,
+                });
+            }
+            match page.pagination {
+                Some(Pagination {
+                    has_more: true,
+                    last_cursor: Some(cursor),
+                }) => after = Some(cursor),
+                _ => break,
+            }
+        }
+        Ok(files)
+    }
+
+    /// Convenience over [`list_files`](Self::list_files): collect the set of
+    /// non-null external ids.
+    ///
+    /// # Errors
+    /// Returns an error if the listing fails.
+    pub async fn list_external_ids(&self, store: &str) -> Result<HashSet<String>> {
+        Ok(self
+            .list_files(store)
+            .await?
+            .into_iter()
+            .filter_map(|file| file.external_id)
+            .collect())
+    }
+
+    /// Upload one file: send the bytes to `/v1/files`, then attach the returned
+    /// id to the store under `external_id` with `metadata`.
+    ///
+    /// # Errors
+    /// Returns an error if either request fails.
+    pub async fn upload_file(
+        &self,
+        store: &str,
+        content: Vec<u8>,
+        file_name: &str,
+        external_id: &str,
+        metadata: serde_json::Value,
+    ) -> Result<()> {
+        let part = reqwest::multipart::Part::bytes(content)
+            .file_name(file_name.to_owned())
+            .mime_str("text/plain")
+            .context(HttpSnafu)?;
+        let form = reqwest::multipart::Form::new().part("file", part);
+
+        let resp = self
+            .http
+            .post(self.url("/v1/files"))
+            .bearer_auth(&self.api_key)
+            .multipart(form)
+            .send()
+            .await
+            .context(HttpSnafu)?;
+        let created: CreatedFile = decode(resp).await?;
+
+        let attach = AttachRequest {
+            file_id: &created.id,
+            external_id,
+            overwrite: true,
+            metadata,
+        };
+        let resp = self
+            .http
+            .post(self.url(&format!("/v1/stores/{store}/files")))
+            .bearer_auth(&self.api_key)
+            .json(&attach)
+            .send()
+            .await
+            .context(HttpSnafu)?;
+        expect_ok(resp).await
+    }
+
+    /// Delete one file by external id (or store file id).
+    ///
+    /// # Errors
+    /// Returns an error if the delete request fails.
+    pub async fn delete_file(&self, store: &str, external_id: &str) -> Result<()> {
+        let resp = self
+            .http
+            .delete(self.url(&format!("/v1/stores/{store}/files/{external_id}")))
+            .bearer_auth(&self.api_key)
+            .send()
+            .await
+            .context(HttpSnafu)?;
+        expect_ok(resp).await
+    }
+
+    /// Search one or more stores.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or cannot be decoded.
+    pub async fn search(
+        &self,
+        stores: &[String],
+        query: &str,
+        top_k: usize,
+        options: SearchOptions,
+    ) -> Result<Vec<Chunk>> {
+        let request = SearchRequest {
+            query,
+            store_identifiers: stores,
+            top_k,
+            search_options: options,
+        };
+        let resp = self
+            .http
+            .post(self.url("/v1/stores/search"))
+            .bearer_auth(&self.api_key)
+            .json(&request)
+            .send()
+            .await
+            .context(HttpSnafu)?;
+        let response: SearchResponse = decode(resp).await?;
+        Ok(response.data.into_iter().map(Chunk::from).collect())
+    }
+
+    /// Ask a natural-language question against one or more stores.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or cannot be decoded.
+    pub async fn ask(
+        &self,
+        stores: &[String],
+        query: &str,
+        top_k: usize,
+        options: SearchOptions,
+    ) -> Result<AnswerResponse> {
+        let request = SearchRequest {
+            query,
+            store_identifiers: stores,
+            top_k,
+            search_options: options,
+        };
+        let resp = self
+            .http
+            .post(self.url("/v1/stores/question-answering"))
+            .bearer_auth(&self.api_key)
+            .json(&request)
+            .send()
+            .await
+            .context(HttpSnafu)?;
+        let response: RawAnswerResponse = decode(resp).await?;
+        Ok(AnswerResponse {
+            answer: response.answer,
+            sources: response.sources.into_iter().map(Chunk::from).collect(),
+        })
+    }
+
+    /// Fetch indexing progress for a store (pending and in-progress file
+    /// counts). Zero on both means everything uploaded so far is searchable.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or cannot be decoded.
+    pub async fn store_status(&self, store: &str) -> Result<StoreStatus> {
+        let resp = self
+            .http
+            .get(self.url(&format!("/v1/stores/{store}")))
+            .bearer_auth(&self.api_key)
+            .send()
+            .await
+            .context(HttpSnafu)?;
+        let object: StoreObject = decode(resp).await?;
+        Ok(StoreStatus {
+            pending: object.file_counts.pending,
+            in_progress: object.file_counts.in_progress,
+        })
+    }
+}
+
+async fn decode<R: serde::de::DeserializeOwned>(resp: reqwest::Response) -> Result<R> {
+    if resp.status().is_success() {
+        return resp.json::<R>().await.context(HttpSnafu);
+    }
+    Err(api_error(resp).await)
+}
+
+async fn expect_ok(resp: reqwest::Response) -> Result<()> {
+    if resp.status().is_success() {
+        return Ok(());
+    }
+    Err(api_error(resp).await)
+}
+
+async fn api_error(resp: reqwest::Response) -> Error {
+    let status = resp.status().as_u16();
+    let body = resp.text().await.unwrap_or_default();
+    Error::Api { status, body }
+}
+
+#[derive(serde::Serialize)]
+struct ListRequest<'a> {
+    limit: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    after: Option<&'a str>,
+}
+
+#[derive(Deserialize)]
+struct ListResponse {
+    #[serde(default)]
+    data: Vec<ListItem>,
+    #[serde(default)]
+    pagination: Option<Pagination>,
+}
+
+#[derive(Deserialize)]
+struct ListItem {
+    #[serde(default)]
+    external_id: Option<String>,
+    #[serde(default)]
+    metadata: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct Pagination {
+    #[serde(default)]
+    has_more: bool,
+    #[serde(default)]
+    last_cursor: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+struct AttachRequest<'a> {
+    file_id: &'a str,
+    external_id: &'a str,
+    overwrite: bool,
+    metadata: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+struct CreatedFile {
+    id: String,
+}
+
+#[derive(serde::Serialize)]
+struct SearchRequest<'a> {
+    query: &'a str,
+    store_identifiers: &'a [String],
+    top_k: usize,
+    search_options: SearchOptions,
+}
+
+#[derive(Deserialize)]
+struct SearchResponse {
+    #[serde(default)]
+    data: Vec<RawChunk>,
+}
+
+// The public `AnswerResponse` is the projected shape; this is the raw wire
+// shape it is built from.
+#[derive(Deserialize)]
+struct RawAnswerResponse {
+    #[serde(default)]
+    answer: String,
+    #[serde(default)]
+    sources: Vec<RawChunk>,
+}
+
+#[derive(Deserialize)]
+struct StoreObject {
+    #[serde(default)]
+    file_counts: FileCounts,
+}
+
+#[derive(Default, Deserialize)]
+struct FileCounts {
+    #[serde(default)]
+    pending: u64,
+    #[serde(default)]
+    in_progress: u64,
+}
+
+#[derive(Deserialize)]
+struct RawChunk {
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    score: f32,
+    #[serde(default)]
+    filename: Option<String>,
+    #[serde(default)]
+    generated_metadata: Option<GeneratedMetadata>,
+    #[serde(default)]
+    metadata: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct GeneratedMetadata {
+    #[serde(default)]
+    start_line: Option<u32>,
+    #[serde(default)]
+    num_lines: Option<u32>,
+}
+
+impl From<RawChunk> for Chunk {
+    fn from(raw: RawChunk) -> Self {
+        let (start_line, num_lines) = raw
+            .generated_metadata
+            .map_or((None, None), |g| (g.start_line, g.num_lines));
+        Self {
+            text: raw.text,
+            score: raw.score,
+            filename: raw.filename,
+            start_line,
+            num_lines,
+            metadata: raw.metadata,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Chunk, RawChunk};
+
+    #[test]
+    fn raw_chunk_projects_generated_metadata() {
+        let json = serde_json::json!({
+            "text": "fn main() {}",
+            "score": 0.9,
+            "filename": "main.rs",
+            "generated_metadata": { "start_line": 4, "num_lines": 2 },
+            "metadata": { "path": "src/main.rs", "hash": "sha256:abc" }
+        });
+        let raw: RawChunk = serde_json::from_value(json).expect("parse");
+        let chunk = Chunk::from(raw);
+
+        assert_eq!(chunk.start_line, Some(4));
+        assert_eq!(chunk.num_lines, Some(2));
+        assert_eq!(chunk.text.as_deref(), Some("fn main() {}"));
+        assert_eq!(
+            chunk
+                .metadata
+                .and_then(|m| m.get("hash").and_then(|h| h.as_str()).map(str::to_owned)),
+            Some("sha256:abc".to_owned())
+        );
+    }
+
+    #[test]
+    fn missing_generated_metadata_is_none() {
+        let raw: RawChunk =
+            serde_json::from_value(serde_json::json!({ "score": 0.1 })).expect("parse");
+        let chunk = Chunk::from(raw);
+        assert_eq!(chunk.start_line, None);
+        assert_eq!(chunk.num_lines, None);
+    }
+}

--- a/packages/registry.nix
+++ b/packages/registry.nix
@@ -148,7 +148,13 @@ let
 
   passthruTestEntriesFor =
     system:
-    lib.filter (entry: enabledForSystem system entry.packageSet && entry.passthruTests != null) entries;
+    lib.filter (
+      entry:
+      entry.passthruTests != null
+      && (
+        if entry.packageSet != null then enabledForSystem system entry.packageSet else entry.inRustWorkspace
+      )
+    ) entries;
 
   rustWorkspaceEntries = lib.filter (entry: entry.inRustWorkspace) entries;
 in

--- a/packages/semantic-search/Cargo.toml
+++ b/packages/semantic-search/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "semantic-search"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Content-addressed semantic code search over a Mixedbread store, deduplicated across git worktrees"
+
+[lints]
+workspace = true
+
+[lib]
+name = "semantic_search"
+path = "src/lib.rs"
+
+[[bin]]
+name = "semantic-search"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+dirs.workspace = true
+futures.workspace = true
+mixedbread.workspace = true
+repo-walker.workspace = true
+rusqlite = { workspace = true, features = ["bundled"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sha2.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "time"] }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/packages/semantic-search/README.md
+++ b/packages/semantic-search/README.md
@@ -1,0 +1,92 @@
+# semantic-search
+
+Semantic code search over a [Mixedbread](https://www.mixedbread.com) store,
+content-addressed so it deduplicates across git worktrees and never deletes one
+checkout's files because of another. A daemon-free alternative to `mgrep` for
+the multi-worktree case.
+
+It is two crates: [`mixedbread`](../mixedbread) is a standalone async API client
+with no domain logic; this crate owns the indexing, manifest, and search logic
+and consumes that client behind a [`Store`] trait.
+
+## Why it exists
+
+`mgrep` keys each file by its absolute path and, on sync, deletes anything under
+the synced path that is missing locally. Two checkouts that resolve to the same
+path (containers, CI, devcontainers) then overwrite and delete each other, and
+twenty worktrees of one repo pay the embedding cost twenty times.
+
+This tool keys each file by the hash of its bytes instead:
+
+- **Upload only new content.** A blob already in the store is never re-uploaded
+  or re-embedded. The second through twentieth worktrees of a repo embed almost
+  nothing.
+- **Never delete during sync.** A stored entry is shared across checkouts, so
+  deletion can only be decided by reference counting across every manifest. That
+  belongs in a separate garbage-collection pass, not in ordinary sync, which
+  removes the cross-worktree deletion footgun entirely.
+- **Scope results to this checkout.** A local manifest records this worktree's
+  `path -> hash` view. Search over-fetches from the shared store and keeps only
+  hits whose hash is in the manifest, mapping each back to its local path.
+- **No daemon, no sync flag.** Every run rebuilds the manifest cheaply (an
+  unchanged file's mtime skips re-hashing), uploads only what is new, waits for
+  it to embed, then searches. New files are picked up automatically at search
+  time; `--no-sync` skips that for a pure offline search.
+
+## Authentication
+
+By default it resolves a credential the way you'd expect: `MXBAI_API_KEY` if
+set, otherwise the token written by `mgrep login` at `~/.mgrep/token.json`. That
+stored token is an OAuth access token, so it is exchanged for a short-lived API
+JWT at the platform auth endpoint (the same exchange `mgrep` itself does). If
+neither is present, it tells you to set the key or run `mgrep login`.
+
+## Storage
+
+Two places. The embeddings, file content, and metadata live remotely in the
+Mixedbread store (keyed by content hash). The only local state is the manifest,
+held in **one shared SQLite database** at `<cache>/semantic-search/index.db`
+(`~/Library/Caches/...` on macOS, `~/.cache/...` on Linux), keyed by
+`(root, rel_path)`. It is opened in WAL mode so several invocations can run at
+once (concurrent readers, one writer), and it's a rebuildable cache: delete it
+and the next run reconstructs it. SQLite was chosen over LMDB/redb/RocksDB/sled
+for multi-process safety plus in-place compaction; the reasoning is recorded in
+[`src/db.rs`](src/db.rs).
+
+## Usage
+
+```sh
+# No extra setup if you already ran `mgrep login`.
+export MXBAI_API_KEY=...           # optional, from https://mixedbread.com
+
+# Search the current checkout. New/changed files are detected, uploaded, and
+# embedded automatically before the search runs.
+semantic-search "where is the retry backoff configured"
+
+# Show matched content.
+semantic-search -c "http client construction"
+
+# Synthesize an answer with sources.
+semantic-search -a "how does sync decide what to upload"
+
+# Skip the index step and search the store as-is.
+semantic-search --no-sync "anything"
+```
+
+Flags mirror `mgrep search` where they overlap: `-c/--content`, `-m/--max-count`,
+`-a/--answer`, `--no-rerank`, `-w/--web`, `--agentic`, plus `--no-sync` to skip
+auto-indexing. The store name comes from `--store` or `MXBAI_STORE` (default
+`semantic-search`); the API base URL from `--base-url` or `MXBAI_BASE_URL`.
+
+## Known limitations
+
+- Content lives in one shared store, so without the eventual GC pass, blobs that
+  no checkout references anymore are not reclaimed. Correctness over storage.
+- When branches diverge, the differing files get distinct entries; search
+  over-fetches and filters client-side rather than asking the server for an
+  exact per-worktree set. Large divergence may need a higher `--max-count`.
+- The live network paths (the two-step `/v1/files` upload and the `mgrep login`
+  token-to-JWT exchange) need a real credential to exercise; the dedup,
+  manifest, and search logic are covered by tests against an in-memory store.
+
+[`Store`]: src/backend.rs

--- a/packages/semantic-search/default.nix
+++ b/packages/semantic-search/default.nix
@@ -1,0 +1,6 @@
+{ ix, ... }:
+
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "semantic-search";
+  meta.mainProgram = "semantic-search";
+}

--- a/packages/semantic-search/package.nix
+++ b/packages/semantic-search/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "semantic-search";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/semantic-search/src/adapter.rs
+++ b/packages/semantic-search/src/adapter.rs
@@ -1,0 +1,154 @@
+//! Adapter wiring the standalone [`mixedbread::Client`] to this crate's
+//! backend-agnostic [`Store`] trait. It does the only impedance matching
+//! needed: typed [`UploadMeta`] to JSON on the way in, and the client's
+//! [`mixedbread::Chunk`] to the domain [`SearchHit`] on the way out.
+
+use std::collections::HashSet;
+
+use snafu::ResultExt as _;
+
+use crate::backend::{Answer, SearchHit, SearchOptions, Store, StoreStatus, UploadMeta};
+use crate::error::{BackendSnafu, EncodeMetadataSnafu, Result};
+
+/// A [`Store`] backed by the Mixedbread API.
+#[derive(Debug, Clone)]
+pub struct MixedbreadStore {
+    client: mixedbread::Client,
+}
+
+impl MixedbreadStore {
+    /// Wrap an already-built client.
+    #[must_use]
+    pub const fn new(client: mixedbread::Client) -> Self {
+        Self { client }
+    }
+
+    /// Build a store from the API key in the environment.
+    ///
+    /// # Errors
+    /// Returns an error if the API key is missing or the client cannot be built.
+    pub fn from_env(base_url: impl Into<String>) -> Result<Self> {
+        let client = mixedbread::Client::from_env(base_url).context(BackendSnafu)?;
+        Ok(Self { client })
+    }
+
+    /// Build a store resolving the credential from `MXBAI_API_KEY` or, failing
+    /// that, the token stored by `mgrep login`.
+    ///
+    /// # Errors
+    /// Returns an error if no credential can be resolved or the client cannot
+    /// be built.
+    pub async fn from_login(base_url: impl Into<String>) -> Result<Self> {
+        let client = mixedbread::Client::from_login(base_url)
+            .await
+            .context(BackendSnafu)?;
+        Ok(Self { client })
+    }
+}
+
+const fn to_client_options(options: SearchOptions) -> mixedbread::SearchOptions {
+    mixedbread::SearchOptions {
+        rerank: options.rerank,
+        agentic: options.agentic,
+    }
+}
+
+fn hit_from_chunk(chunk: mixedbread::Chunk) -> SearchHit {
+    let hash = metadata_str(chunk.metadata.as_ref(), "hash");
+    let path_meta = metadata_str(chunk.metadata.as_ref(), "path");
+    SearchHit {
+        hash,
+        path: path_meta.or(chunk.filename),
+        text: chunk.text.unwrap_or_default(),
+        score: chunk.score,
+        start_line: chunk.start_line,
+        num_lines: chunk.num_lines,
+    }
+}
+
+fn metadata_str(metadata: Option<&serde_json::Value>, key: &str) -> Option<String> {
+    metadata
+        .and_then(|m| m.get(key))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+}
+
+impl Store for MixedbreadStore {
+    async fn ensure_store(&self, name: &str) -> Result<()> {
+        self.client.ensure_store(name).await.context(BackendSnafu)
+    }
+
+    async fn list_external_ids(&self, store: &str) -> Result<HashSet<String>> {
+        self.client
+            .list_external_ids(store)
+            .await
+            .context(BackendSnafu)
+    }
+
+    async fn upload(
+        &self,
+        store: &str,
+        content: Vec<u8>,
+        file_name: &str,
+        external_id: &str,
+        meta: UploadMeta,
+    ) -> Result<()> {
+        let metadata = serde_json::to_value(&meta).context(EncodeMetadataSnafu)?;
+        self.client
+            .upload_file(store, content, file_name, external_id, metadata)
+            .await
+            .context(BackendSnafu)
+    }
+
+    async fn delete(&self, store: &str, external_id: &str) -> Result<()> {
+        self.client
+            .delete_file(store, external_id)
+            .await
+            .context(BackendSnafu)
+    }
+
+    async fn search(
+        &self,
+        stores: &[String],
+        query: &str,
+        top_k: usize,
+        options: SearchOptions,
+    ) -> Result<Vec<SearchHit>> {
+        let chunks = self
+            .client
+            .search(stores, query, top_k, to_client_options(options))
+            .await
+            .context(BackendSnafu)?;
+        Ok(chunks.into_iter().map(hit_from_chunk).collect())
+    }
+
+    async fn ask(
+        &self,
+        stores: &[String],
+        query: &str,
+        top_k: usize,
+        options: SearchOptions,
+    ) -> Result<Answer> {
+        let response = self
+            .client
+            .ask(stores, query, top_k, to_client_options(options))
+            .await
+            .context(BackendSnafu)?;
+        Ok(Answer {
+            answer: response.answer,
+            sources: response.sources.into_iter().map(hit_from_chunk).collect(),
+        })
+    }
+
+    async fn store_status(&self, store: &str) -> Result<StoreStatus> {
+        let status = self
+            .client
+            .store_status(store)
+            .await
+            .context(BackendSnafu)?;
+        Ok(StoreStatus {
+            pending: status.pending,
+            in_progress: status.in_progress,
+        })
+    }
+}

--- a/packages/semantic-search/src/backend.rs
+++ b/packages/semantic-search/src/backend.rs
@@ -1,0 +1,291 @@
+//! The storage backend abstraction.
+//!
+//! Sync and search are written against the [`Store`] trait so their logic is
+//! tested against [`MemoryStore`] with no network, and the real
+//! [`MixedbreadStore`](crate::MixedbreadStore) is the production
+//! implementation.
+//!
+//! Trait methods return `impl Future + Send` rather than using `async fn`
+//! sugar: a public `async fn` trait method forbids callers from adding the
+//! `Send` bound the concurrent sync path needs, and the workspace denies that
+//! warning. Implementors satisfy these with ordinary `async fn`.
+
+use std::collections::{HashMap, HashSet};
+use std::future::Future;
+use std::sync::{Mutex, PoisonError};
+
+use crate::error::Result;
+
+/// Metadata attached to every stored file.
+///
+/// The path is repo-relative so it is stable across worktrees; the hash equals
+/// the `external_id` and lets a search result be mapped back through the local
+/// manifest.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct UploadMeta {
+    /// Repo-relative path, forward-slashed.
+    pub path: String,
+    /// Content hash, identical to the file's `external_id`.
+    pub hash: String,
+}
+
+/// Knobs forwarded to the backend's search call.
+#[derive(Debug, Clone, Copy)]
+pub struct SearchOptions {
+    /// Apply the second-stage reranker for better ordering.
+    pub rerank: bool,
+    /// Let the backend plan and run several searches itself.
+    pub agentic: bool,
+}
+
+/// One scored chunk returned by a search.
+#[derive(Debug, Clone)]
+pub struct SearchHit {
+    /// Content hash from the stored metadata, when present. Absent for web
+    /// results.
+    pub hash: Option<String>,
+    /// Path or URL reported by the backend.
+    pub path: Option<String>,
+    /// The matched text snippet.
+    pub text: String,
+    /// Relevance score in `0.0..=1.0`.
+    pub score: f32,
+    /// Zero-based start line of the chunk within its file, when known.
+    pub start_line: Option<u32>,
+    /// Number of lines the chunk spans, when known.
+    pub num_lines: Option<u32>,
+}
+
+/// A question-answering response: a synthesized answer plus its sources.
+#[derive(Debug, Clone)]
+pub struct Answer {
+    /// The synthesized answer text.
+    pub answer: String,
+    /// Chunks the answer drew from.
+    pub sources: Vec<SearchHit>,
+}
+
+/// Indexing progress for a store. Zero on both fields means everything
+/// uploaded so far has been embedded and is searchable.
+#[derive(Debug, Clone, Copy)]
+pub struct StoreStatus {
+    /// Files queued but not yet processed.
+    pub pending: u64,
+    /// Files currently being embedded.
+    pub in_progress: u64,
+}
+
+/// A vector store that holds content-addressed files and answers searches.
+pub trait Store {
+    /// Ensure the named store exists, creating it if absent.
+    ///
+    /// # Errors
+    /// Returns an error if the backend cannot be reached or the store cannot
+    /// be created.
+    fn ensure_store(&self, name: &str) -> impl Future<Output = Result<()>> + Send;
+
+    /// List the `external_id`s already present in the store. These are content
+    /// hashes; sync uploads only the ones missing from this set.
+    ///
+    /// # Errors
+    /// Returns an error if the backend cannot be reached or returns an error
+    /// status.
+    fn list_external_ids(
+        &self,
+        store: &str,
+    ) -> impl Future<Output = Result<HashSet<String>>> + Send;
+
+    /// Upload one file's content under the given `external_id` (its hash).
+    ///
+    /// # Errors
+    /// Returns an error if the upload fails at either the file or attach step.
+    fn upload(
+        &self,
+        store: &str,
+        content: Vec<u8>,
+        file_name: &str,
+        external_id: &str,
+        meta: UploadMeta,
+    ) -> impl Future<Output = Result<()>> + Send;
+
+    /// Delete one file by `external_id`. Used only by an explicit garbage
+    /// collection pass, never by ordinary sync.
+    ///
+    /// # Errors
+    /// Returns an error if the delete request fails.
+    fn delete(&self, store: &str, external_id: &str) -> impl Future<Output = Result<()>> + Send;
+
+    /// Search one or more stores for a query.
+    ///
+    /// # Errors
+    /// Returns an error if the search request fails or the response cannot be
+    /// decoded.
+    fn search(
+        &self,
+        stores: &[String],
+        query: &str,
+        top_k: usize,
+        options: SearchOptions,
+    ) -> impl Future<Output = Result<Vec<SearchHit>>> + Send;
+
+    /// Ask a natural-language question against one or more stores.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or the response cannot be decoded.
+    fn ask(
+        &self,
+        stores: &[String],
+        query: &str,
+        top_k: usize,
+        options: SearchOptions,
+    ) -> impl Future<Output = Result<Answer>> + Send;
+
+    /// Fetch indexing progress for a store, used to wait until newly uploaded
+    /// files are embedded and searchable.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or the response cannot be decoded.
+    fn store_status(&self, store: &str) -> impl Future<Output = Result<StoreStatus>> + Send;
+}
+
+/// In-memory [`Store`] for tests.
+///
+/// Keyed by `external_id` like the real store, so the dedup behavior (a
+/// repeated hash is a no-op) is exercised faithfully. It also counts upload
+/// calls so tests can assert nothing was re-uploaded.
+#[derive(Debug, Default)]
+pub struct MemoryStore {
+    inner: Mutex<Inner>,
+}
+
+#[derive(Debug, Default)]
+struct Inner {
+    files: HashMap<String, StoredFile>,
+    upload_calls: usize,
+}
+
+#[derive(Debug)]
+struct StoredFile {
+    content: Vec<u8>,
+    meta: UploadMeta,
+}
+
+impl MemoryStore {
+    /// Create an empty store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        self.inner.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// How many times [`Store::upload`] actually ran. Tests assert this stays
+    /// flat across redundant syncs.
+    #[must_use]
+    pub fn upload_count(&self) -> usize {
+        self.lock().upload_calls
+    }
+
+    /// How many distinct files are stored.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.lock().files.len()
+    }
+
+    /// Whether the store holds no files.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.lock().files.is_empty()
+    }
+}
+
+impl Store for MemoryStore {
+    async fn ensure_store(&self, _name: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn list_external_ids(&self, _store: &str) -> Result<HashSet<String>> {
+        Ok(self.lock().files.keys().cloned().collect())
+    }
+
+    async fn upload(
+        &self,
+        _store: &str,
+        content: Vec<u8>,
+        _file_name: &str,
+        external_id: &str,
+        meta: UploadMeta,
+    ) -> Result<()> {
+        let mut inner = self.lock();
+        inner.upload_calls += 1;
+        inner
+            .files
+            .insert(external_id.to_owned(), StoredFile { content, meta });
+        drop(inner);
+        Ok(())
+    }
+
+    async fn delete(&self, _store: &str, external_id: &str) -> Result<()> {
+        self.lock().files.remove(external_id);
+        Ok(())
+    }
+
+    async fn search(
+        &self,
+        _stores: &[String],
+        query: &str,
+        top_k: usize,
+        _options: SearchOptions,
+    ) -> Result<Vec<SearchHit>> {
+        let needle = query.to_lowercase();
+        let inner = self.lock();
+        let mut hits = Vec::new();
+        for file in inner.files.values() {
+            let text = String::from_utf8_lossy(&file.content);
+            for (index, line) in text.lines().enumerate() {
+                if line.to_lowercase().contains(&needle) {
+                    hits.push(SearchHit {
+                        hash: Some(file.meta.hash.clone()),
+                        path: Some(file.meta.path.clone()),
+                        text: line.to_owned(),
+                        score: 1.0,
+                        start_line: u32::try_from(index).ok(),
+                        num_lines: Some(1),
+                    });
+                }
+                if hits.len() >= top_k {
+                    break;
+                }
+            }
+            if hits.len() >= top_k {
+                break;
+            }
+        }
+        drop(inner);
+        Ok(hits)
+    }
+
+    async fn ask(
+        &self,
+        stores: &[String],
+        query: &str,
+        top_k: usize,
+        options: SearchOptions,
+    ) -> Result<Answer> {
+        let sources = self.search(stores, query, top_k, options).await?;
+        Ok(Answer {
+            answer: "mock answer from MemoryStore".to_owned(),
+            sources,
+        })
+    }
+
+    async fn store_status(&self, _store: &str) -> Result<StoreStatus> {
+        // In-memory uploads are immediately "indexed".
+        Ok(StoreStatus {
+            pending: 0,
+            in_progress: 0,
+        })
+    }
+}

--- a/packages/semantic-search/src/config.rs
+++ b/packages/semantic-search/src/config.rs
@@ -1,0 +1,29 @@
+//! Runtime configuration with conservative, production-shaped defaults. The
+//! API base URL is owned by the [`mixedbread`] crate, not duplicated here.
+
+/// Default store name. One store per account holds every worktree's content;
+/// cross-worktree isolation comes from the local manifest, not separate stores.
+pub const DEFAULT_STORE: &str = "semantic-search";
+
+/// Identifier of Mixedbread's hosted web-search store, mixed in when the
+/// caller opts into web results.
+pub const WEB_STORE: &str = "mixedbread/web";
+
+/// Tunable limits for indexing and sync.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Files larger than this are skipped during indexing. Defaults to 1 MiB.
+    pub max_file_bytes: u64,
+    /// Upper bound on how many new files one sync may upload before it refuses
+    /// to run, guarding against an accidental index of a huge tree.
+    pub max_files: usize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            max_file_bytes: 1024 * 1024,
+            max_files: 10_000,
+        }
+    }
+}

--- a/packages/semantic-search/src/content.rs
+++ b/packages/semantic-search/src/content.rs
@@ -1,0 +1,89 @@
+//! Content addressing.
+//!
+//! A file's identity is the hash of its bytes, never its path. Byte-identical
+//! files across twenty git worktrees (or branches, or repos) hash to one
+//! value, so the expensive embedding upload happens once and every other
+//! checkout reuses the existing entry instead of re-indexing.
+
+use std::fmt::{self, Write as _};
+
+use sha2::{Digest, Sha256};
+
+/// Stable content identifier for a file, formatted as `sha256:<hex>`.
+///
+/// Used directly as the Mixedbread `external_id`, which is what makes the
+/// store deduplicate: two uploads with the same content produce the same id,
+/// so the second is a no-op the sync skips entirely.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct ContentHash(String);
+
+impl ContentHash {
+    /// Compute the content hash of a byte buffer.
+    #[must_use]
+    pub fn of_bytes(bytes: &[u8]) -> Self {
+        let digest = Sha256::digest(bytes);
+        let mut hex = String::with_capacity("sha256:".len() + digest.len() * 2);
+        hex.push_str("sha256:");
+        for byte in digest {
+            // Writing a byte to a String is infallible; ignore the Result
+            // rather than introduce an unreachable panic path.
+            let _ = write!(hex, "{byte:02x}");
+        }
+        Self(hex)
+    }
+
+    /// The hash as a string slice, e.g. `sha256:abcd…`.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// The hex digest without the `sha256:` algorithm prefix. Useful as a
+    /// filesystem-safe cache key component.
+    #[must_use]
+    pub fn hex(&self) -> &str {
+        self.0.strip_prefix("sha256:").unwrap_or(&self.0)
+    }
+
+    /// Wrap a hash string read back from the manifest database.
+    #[must_use]
+    pub const fn from_raw(raw: String) -> Self {
+        Self(raw)
+    }
+}
+
+impl fmt::Display for ContentHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ContentHash;
+
+    #[test]
+    fn identical_bytes_hash_equal() {
+        let a = ContentHash::of_bytes(b"fn main() {}");
+        let b = ContentHash::of_bytes(b"fn main() {}");
+        assert_eq!(a, b, "same content must produce the same id (dedup key)");
+    }
+
+    #[test]
+    fn different_bytes_hash_differently() {
+        let a = ContentHash::of_bytes(b"one");
+        let b = ContentHash::of_bytes(b"two");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn format_is_prefixed_lowercase_hex() {
+        let h = ContentHash::of_bytes(b"");
+        // sha256 of the empty input is a known constant.
+        assert_eq!(
+            h.as_str(),
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(h.hex(), &h.as_str()["sha256:".len()..]);
+    }
+}

--- a/packages/semantic-search/src/db.rs
+++ b/packages/semantic-search/src/db.rs
@@ -1,0 +1,257 @@
+//! Manifest persistence in `SQLite`.
+//!
+//! One shared database under the cache dir holds every checkout's entries,
+//! keyed by `(root, rel_path)`. A shared DB (rather than one file per checkout)
+//! centralizes concurrency control and turns a future cross-worktree
+//! refcount-GC into a single `GROUP BY hash` query over the `files_by_hash`
+//! index.
+
+use std::path::{Path, PathBuf};
+
+use rusqlite::{Connection, params};
+use snafu::{OptionExt as _, ResultExt as _};
+
+use crate::content::ContentHash;
+use crate::error::{CreateCacheDirSnafu, DbSnafu, NoCacheDirSnafu, OpenDbSnafu, Result};
+use crate::manifest::{FileEntry, Manifest};
+
+const SCHEMA: &str = "\
+CREATE TABLE IF NOT EXISTS files (
+    root     TEXT    NOT NULL,
+    rel_path TEXT    NOT NULL,
+    hash     TEXT    NOT NULL,
+    mtime_ms INTEGER NOT NULL,
+    size     INTEGER NOT NULL,
+    PRIMARY KEY (root, rel_path)
+) WITHOUT ROWID;
+CREATE INDEX IF NOT EXISTS files_by_hash ON files (hash);";
+
+/// Handle to the shared manifest database.
+#[derive(Debug)]
+pub struct Db {
+    conn: Connection,
+}
+
+impl Db {
+    /// Open the shared database at the default cache location, creating it (and
+    /// its parent directory) if needed.
+    ///
+    /// # Errors
+    /// Returns an error if no cache dir is available, the directory cannot be
+    /// created, or the database cannot be opened or initialized.
+    pub fn open() -> Result<Self> {
+        Self::open_at(&db_path()?)
+    }
+
+    /// Open the shared database at an explicit path. Used by tests.
+    ///
+    /// # Errors
+    /// Returns an error if the parent directory cannot be created or the
+    /// database cannot be opened or initialized.
+    pub fn open_at(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).context(CreateCacheDirSnafu {
+                path: parent.to_path_buf(),
+            })?;
+        }
+        let conn = Connection::open(path).context(OpenDbSnafu {
+            path: path.to_path_buf(),
+        })?;
+
+        // WAL + a busy timeout let several `semantic-search` processes share
+        // this DB: concurrent readers plus one writer, writers serialized with
+        // retry. auto_vacuum reclaims space in place after deletes.
+        // synchronous=NORMAL is the right durability for a rebuildable cache
+        // (safe across app crashes under WAL; only power loss can drop the last
+        // commit, which a re-run reconstructs).
+        //
+        // Why SQLite, not LMDB: LMDB requires a preset map_size and its file
+        // only ever grows -- deletes never reclaim space, so shrinking needs an
+        // offline `mdb_copy -c` (http://www.lmdb.tech/doc/man1/mdb_copy_1.html,
+        // https://www.lmdb.tech/doc/group__mdb__copy.html). For a churny
+        // manifest that is exactly the wart to avoid, and SQLite's auto_vacuum
+        // sidesteps it. The alternatives fail the multi-process requirement:
+        // RocksDB and sled are single-process (sled's own docs point at LMDB
+        // for multi-process), and redb documents only in-process MVCC. SQLite
+        // and LMDB are the two with real multi-process support; SQLite wins on
+        // in-place compaction and SQL-CLI inspectability.
+        conn.execute_batch(
+            "PRAGMA auto_vacuum=FULL;\
+             PRAGMA journal_mode=WAL;\
+             PRAGMA busy_timeout=5000;\
+             PRAGMA synchronous=NORMAL;",
+        )
+        .context(DbSnafu)?;
+        conn.execute_batch(SCHEMA).context(DbSnafu)?;
+
+        Ok(Self { conn })
+    }
+
+    /// Load the stored manifest for `root`, or an empty manifest if none.
+    ///
+    /// # Errors
+    /// Returns an error if the query fails or a row cannot be decoded.
+    pub fn load(&self, root: &Path) -> Result<Manifest> {
+        let root = root.to_string_lossy();
+        let mut stmt = self
+            .conn
+            .prepare("SELECT rel_path, hash, mtime_ms, size FROM files WHERE root = ?1")
+            .context(DbSnafu)?;
+        let rows = stmt
+            .query_map([root.as_ref()], |row| {
+                let rel_path: String = row.get(0)?;
+                let hash: String = row.get(1)?;
+                let mtime: i64 = row.get(2)?;
+                let size: i64 = row.get(3)?;
+                Ok(FileEntry {
+                    rel_path,
+                    hash: ContentHash::from_raw(hash),
+                    mtime_ms: u64::try_from(mtime).unwrap_or(0),
+                    size: u64::try_from(size).unwrap_or(0),
+                })
+            })
+            .context(DbSnafu)?;
+
+        let mut entries = Vec::new();
+        for row in rows {
+            entries.push(row.context(DbSnafu)?);
+        }
+        Ok(Manifest { entries })
+    }
+
+    /// Replace the stored manifest for `root` with `manifest`, atomically.
+    ///
+    /// Stale rows (files no longer present in this checkout) are removed, so a
+    /// sibling worktree's rows under a different root are never touched.
+    ///
+    /// # Errors
+    /// Returns an error if the transaction or any statement fails.
+    pub fn save(&mut self, root: &Path, manifest: &Manifest) -> Result<()> {
+        let root = root.to_string_lossy();
+        let tx = self.conn.transaction().context(DbSnafu)?;
+        tx.execute("DELETE FROM files WHERE root = ?1", [root.as_ref()])
+            .context(DbSnafu)?;
+        {
+            let mut stmt = tx
+                .prepare(
+                    "INSERT INTO files (root, rel_path, hash, mtime_ms, size) \
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                )
+                .context(DbSnafu)?;
+            for entry in &manifest.entries {
+                stmt.execute(params![
+                    root.as_ref(),
+                    entry.rel_path,
+                    entry.hash.as_str(),
+                    i64::try_from(entry.mtime_ms).unwrap_or(i64::MAX),
+                    i64::try_from(entry.size).unwrap_or(i64::MAX),
+                ])
+                .context(DbSnafu)?;
+            }
+        }
+        tx.commit().context(DbSnafu)?;
+        Ok(())
+    }
+}
+
+/// Path to the shared manifest database, `<cache>/semantic-search/index.db`.
+///
+/// # Errors
+/// Returns an error if no user cache directory can be determined.
+pub fn db_path() -> Result<PathBuf> {
+    let base = dirs::cache_dir().context(NoCacheDirSnafu)?;
+    Ok(base.join("semantic-search").join("index.db"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::Db;
+    use crate::content::ContentHash;
+    use crate::manifest::{FileEntry, Manifest};
+
+    fn entry(rel_path: &str, content: &str) -> FileEntry {
+        FileEntry {
+            rel_path: rel_path.to_owned(),
+            hash: ContentHash::of_bytes(content.as_bytes()),
+            mtime_ms: 1,
+            size: 1,
+        }
+    }
+
+    fn manifest(entries: Vec<FileEntry>) -> Manifest {
+        Manifest { entries }
+    }
+
+    fn open(dir: &tempfile::TempDir) -> Db {
+        Db::open_at(&dir.path().join("index.db")).expect("open db")
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut db = open(&dir);
+        let root = Path::new("/repo/a");
+
+        db.save(
+            root,
+            &manifest(vec![entry("a.rs", "one"), entry("b.rs", "two")]),
+        )
+        .expect("save");
+        let loaded = db.load(root).expect("load");
+
+        assert_eq!(loaded.entries.len(), 2);
+        let by_path: Vec<&str> = loaded.entries.iter().map(|e| e.rel_path.as_str()).collect();
+        assert!(by_path.contains(&"a.rs") && by_path.contains(&"b.rs"));
+    }
+
+    #[test]
+    fn roots_are_isolated() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut db = open(&dir);
+
+        db.save(
+            Path::new("/repo/a"),
+            &manifest(vec![entry("a.rs", "x"), entry("b.rs", "y")]),
+        )
+        .expect("save a");
+        db.save(Path::new("/repo/b"), &manifest(vec![entry("a.rs", "z")]))
+            .expect("save b");
+
+        assert_eq!(db.load(Path::new("/repo/a")).expect("a").entries.len(), 2);
+        assert_eq!(db.load(Path::new("/repo/b")).expect("b").entries.len(), 1);
+    }
+
+    #[test]
+    fn save_removes_stale_rows_for_that_root() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut db = open(&dir);
+        let root = Path::new("/repo/a");
+
+        db.save(
+            root,
+            &manifest(vec![entry("a.rs", "x"), entry("b.rs", "y")]),
+        )
+        .expect("first");
+        db.save(root, &manifest(vec![entry("a.rs", "x")]))
+            .expect("second");
+
+        let loaded = db.load(root).expect("load");
+        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entries[0].rel_path, "a.rs");
+    }
+
+    #[test]
+    fn data_persists_across_reopen() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = Path::new("/repo/a");
+        {
+            let mut db = open(&dir);
+            db.save(root, &manifest(vec![entry("a.rs", "x")]))
+                .expect("save");
+        }
+        let db = open(&dir);
+        assert_eq!(db.load(root).expect("load").entries.len(), 1);
+    }
+}

--- a/packages/semantic-search/src/error.rs
+++ b/packages/semantic-search/src/error.rs
@@ -1,0 +1,97 @@
+//! Error type for the crate. Every fallible boundary returns [`Error`] so the
+//! binary can render one operator-facing message and the library never panics
+//! on expected failures (missing files, HTTP errors, malformed responses).
+
+use std::path::PathBuf;
+
+use snafu::Snafu;
+
+/// All failures surfaced by the library.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// The directory walker failed partway through enumeration.
+    #[snafu(display("failed to walk {}: {source}", root.display()))]
+    Walk {
+        /// Root the walk started from.
+        root: PathBuf,
+        /// Underlying walker error.
+        source: repo_walker::WalkError,
+    },
+
+    /// A file selected for indexing could not be read.
+    #[snafu(display("failed to read {}: {source}", path.display()))]
+    ReadFile {
+        /// File that could not be read.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// A file's metadata (size, mtime) could not be queried.
+    #[snafu(display("failed to stat {}: {source}", path.display()))]
+    Stat {
+        /// File that could not be stat'd.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// No user cache directory is available to store the manifest.
+    #[snafu(display("could not determine a cache directory for the manifest"))]
+    NoCacheDir,
+
+    /// The manifest database's parent cache directory could not be created.
+    #[snafu(display("failed to create cache directory {}: {source}", path.display()))]
+    CreateCacheDir {
+        /// Directory that could not be created.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// The manifest database could not be opened.
+    #[snafu(display("failed to open manifest database {}: {source}", path.display()))]
+    OpenDb {
+        /// Database path.
+        path: PathBuf,
+        /// Underlying `SQLite` error.
+        source: rusqlite::Error,
+    },
+
+    /// A manifest database query or update failed.
+    #[snafu(display("manifest database error: {source}"))]
+    Db {
+        /// Underlying `SQLite` error.
+        source: rusqlite::Error,
+    },
+
+    /// A sync would touch more files than the configured ceiling allows.
+    #[snafu(display(
+        "sync would upload {count} files, over the limit of {max}; nothing was uploaded"
+    ))]
+    TooManyFiles {
+        /// Number of files the sync wanted to upload.
+        count: usize,
+        /// Configured maximum.
+        max: usize,
+    },
+
+    /// A file's metadata could not be encoded for upload.
+    #[snafu(display("failed to encode file metadata: {source}"))]
+    EncodeMetadata {
+        /// Underlying serde error.
+        source: serde_json::Error,
+    },
+
+    /// The storage backend (Mixedbread client) returned an error.
+    #[snafu(display("storage backend error: {source}"))]
+    Backend {
+        /// Underlying client error.
+        source: mixedbread::Error,
+    },
+}
+
+/// Convenient result alias defaulting to this crate's [`Error`].
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/packages/semantic-search/src/lib.rs
+++ b/packages/semantic-search/src/lib.rs
@@ -1,0 +1,41 @@
+//! Content-addressed semantic code search, deduplicated across git worktrees.
+//!
+//! The design in one paragraph: files are identified by the hash of their
+//! bytes, not their path, so byte-identical files across many worktrees,
+//! branches, or repos share a single stored embedding. Sync uploads only
+//! content the store is missing and never deletes (deletion across shared
+//! entries needs reference counting, which belongs in a separate garbage
+//! collection pass). A local [`Manifest`] records this checkout's `path ->
+//! hash` view; search over-fetches from the shared store and keeps only hits
+//! whose hash is in the manifest, so results reflect the current tree. There
+//! is no daemon: each run rebuilds the manifest cheaply (mtime skips
+//! re-hashing) and uploads what is new.
+//!
+//! The [`Store`] trait abstracts the backend so sync and search are tested
+//! against [`MemoryStore`]; [`MixedbreadStore`] is the production adapter over
+//! the standalone [`mixedbread`] client crate.
+
+// `ContentHash` and `SyncReport` deliberately echo their modules (`content`,
+// `sync`). The module split is internal and everything is re-exported at the
+// crate root, so the repetition never reaches callers.
+#![allow(clippy::module_name_repetitions)]
+
+mod adapter;
+mod backend;
+mod config;
+mod content;
+mod db;
+mod error;
+mod manifest;
+mod search;
+mod sync;
+
+pub use adapter::MixedbreadStore;
+pub use backend::{Answer, MemoryStore, SearchHit, SearchOptions, Store, StoreStatus, UploadMeta};
+pub use config::{Config, DEFAULT_STORE, WEB_STORE};
+pub use content::ContentHash;
+pub use db::{Db, db_path};
+pub use error::{Error, Result};
+pub use manifest::{FileEntry, Manifest};
+pub use search::{AnswerView, DisplayHit, ask, search};
+pub use sync::{SyncReport, sync, wait_until_indexed};

--- a/packages/semantic-search/src/main.rs
+++ b/packages/semantic-search/src/main.rs
@@ -1,0 +1,186 @@
+//! `semantic-search`: a daemon-free, content-addressed semantic code search.
+//!
+//! Every run rebuilds a local manifest (cheap; unchanged files are not
+//! re-hashed), uploads only content the store is missing, waits for it to
+//! embed, then searches. No daemon, no `--sync` flag: new files are picked up
+//! and embedded automatically at search time. `--no-sync` skips that for a pure
+//! offline search. Results are scoped to the current checkout via the manifest.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use clap::Parser;
+use semantic_search::{
+    Config, DEFAULT_STORE, Db, DisplayHit, Manifest, MixedbreadStore, SearchOptions,
+};
+
+/// How long to wait for freshly uploaded files to finish embedding.
+const INDEX_TIMEOUT: Duration = Duration::from_mins(2);
+
+/// Command-line arguments. Flags mirror `mgrep search` where they overlap.
+// A CLI naturally has many independent boolean flags; a state machine would
+// obscure, not clarify, the argument surface.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Parser)]
+#[command(name = "semantic-search", about, version)]
+struct Cli {
+    /// The query to search for.
+    pattern: String,
+
+    /// Directory to search in (defaults to the current directory).
+    path: Option<String>,
+
+    /// Maximum number of results to return.
+    #[arg(short = 'm', long = "max-count", default_value_t = 10)]
+    max_count: usize,
+
+    /// Show the matched content under each result.
+    #[arg(short = 'c', long)]
+    content: bool,
+
+    /// Synthesize an answer from the results instead of listing them.
+    #[arg(short = 'a', long)]
+    answer: bool,
+
+    /// Search the store as-is: skip detecting and embedding new files.
+    #[arg(long = "no-sync")]
+    no_sync: bool,
+
+    /// Disable result reranking (on by default).
+    #[arg(long = "no-rerank")]
+    no_rerank: bool,
+
+    /// Include web results from the hosted web store.
+    #[arg(short = 'w', long)]
+    web: bool,
+
+    /// Let the backend plan and run multiple searches.
+    #[arg(long)]
+    agentic: bool,
+
+    /// Store name (one store holds every worktree's content).
+    #[arg(long, env = "MXBAI_STORE")]
+    store: Option<String>,
+
+    /// Mixedbread API base URL.
+    #[arg(long = "base-url", env = "MXBAI_BASE_URL")]
+    base_url: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    run(Cli::parse()).await
+}
+
+async fn run(cli: Cli) -> anyhow::Result<()> {
+    let root = resolve_root(cli.path.as_deref())?;
+    anyhow::ensure!(
+        !at_or_above_home(&root),
+        "refusing to index {} (it is at or above your home directory); run from a project directory",
+        root.display(),
+    );
+
+    let config = Config::default();
+    let mut db = Db::open()?;
+    let previous = db.load(&root)?;
+    let manifest = Manifest::build(&root, Some(&previous), config.max_file_bytes)?;
+    db.save(&root, &manifest)?;
+
+    let store_name = cli.store.unwrap_or_else(|| DEFAULT_STORE.to_owned());
+    let base_url = cli
+        .base_url
+        .unwrap_or_else(|| mixedbread::DEFAULT_BASE_URL.to_owned());
+    let store = MixedbreadStore::from_login(base_url).await?;
+
+    if !cli.no_sync {
+        let report =
+            semantic_search::sync(&store, &store_name, &root, &manifest, config.max_files).await?;
+        if report.uploaded > 0 {
+            eprintln!("indexing {} new file(s)...", report.uploaded);
+            let indexed =
+                semantic_search::wait_until_indexed(&store, &store_name, INDEX_TIMEOUT).await?;
+            if !indexed {
+                eprintln!(
+                    "warning: indexing still in progress after {}s; results may be incomplete",
+                    INDEX_TIMEOUT.as_secs()
+                );
+            }
+        }
+    }
+
+    let options = SearchOptions {
+        rerank: !cli.no_rerank,
+        agentic: cli.agentic,
+    };
+    let top_k = cli.max_count.max(1);
+
+    if cli.answer {
+        let view = semantic_search::ask(
+            &store,
+            &store_name,
+            &manifest,
+            &cli.pattern,
+            top_k,
+            options,
+            cli.web,
+        )
+        .await?;
+        println!("{}", view.answer);
+        if !view.sources.is_empty() {
+            println!();
+            for (index, hit) in view.sources.iter().enumerate() {
+                println!("{index}: {}", render(hit, cli.content));
+            }
+        }
+    } else {
+        let hits = semantic_search::search(
+            &store,
+            &store_name,
+            &manifest,
+            &cli.pattern,
+            top_k,
+            options,
+            cli.web,
+        )
+        .await?;
+        for hit in &hits {
+            println!("{}", render(hit, cli.content));
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_root(path: Option<&str>) -> anyhow::Result<PathBuf> {
+    let cwd = std::env::current_dir()?;
+    let root = match path {
+        Some(p) if Path::new(p).is_absolute() => PathBuf::from(p),
+        Some(p) => cwd.join(p),
+        None => cwd,
+    };
+    Ok(root.canonicalize().unwrap_or(root))
+}
+
+fn at_or_above_home(path: &Path) -> bool {
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+    let home = home.canonicalize().unwrap_or(home);
+    path == home || home.starts_with(path)
+}
+
+fn render(hit: &DisplayHit, show_content: bool) -> String {
+    let location = match (hit.start_line, hit.num_lines) {
+        (Some(start), Some(num)) => format!(":{}-{}", start + 1, start + 1 + num),
+        (Some(start), None) => format!(":{}", start + 1),
+        _ => String::new(),
+    };
+    let prefix = if hit.is_web { "" } else { "./" };
+    let percent = hit.score * 100.0;
+    let head = format!("{prefix}{}{location} ({percent:.2}% match)", hit.label);
+    if show_content && !hit.text.is_empty() {
+        format!("{head}\n{}", hit.text)
+    } else {
+        head
+    }
+}

--- a/packages/semantic-search/src/manifest.rs
+++ b/packages/semantic-search/src/manifest.rs
@@ -1,0 +1,176 @@
+//! The local manifest: this checkout's `relative path -> content hash` view,
+//! held in memory.
+//!
+//! It drives two jobs. Sync compares it against the store's existing hashes to
+//! decide what to upload. Search intersects results against it so a query only
+//! surfaces files that exist in this worktree, even though byte-identical files
+//! from other worktrees share one stored entry.
+//!
+//! Persistence lives in [`crate::db`]. Each entry records an mtime and size so
+//! the next run reuses an unchanged file's hash instead of re-reading it; a
+//! changed mtime forces a re-hash, so the skip is a cheap negative check that
+//! never produces a wrong answer.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::time::UNIX_EPOCH;
+
+use repo_walker::{FileScanner, WalkOptions};
+use snafu::ResultExt as _;
+
+use crate::content::ContentHash;
+use crate::error::{ReadFileSnafu, Result, StatSnafu, WalkSnafu};
+
+/// One indexed file's identity and change-detection metadata.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FileEntry {
+    /// Repo-relative path, forward-slashed and stable across worktrees.
+    pub rel_path: String,
+    /// Content hash, used as the store `external_id`.
+    pub hash: ContentHash,
+    /// Last-modified time in milliseconds since the Unix epoch.
+    pub mtime_ms: u64,
+    /// File size in bytes.
+    pub size: u64,
+}
+
+/// A whole checkout's worth of [`FileEntry`] values, sorted by path.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct Manifest {
+    /// Indexed files, sorted by `rel_path` for stable output and diffs.
+    pub entries: Vec<FileEntry>,
+}
+
+impl Manifest {
+    /// Build a manifest by walking `root`, honoring gitignore and skipping
+    /// binary and oversized files. When `previous` is supplied, an unchanged
+    /// file (matching mtime and size) reuses its prior hash without re-reading.
+    ///
+    /// `root` should be absolute so the walker's paths and the stored relative
+    /// paths line up.
+    ///
+    /// # Errors
+    /// Returns an error if the walk fails, or if a selected file cannot be
+    /// stat'd or read.
+    pub fn build(root: &Path, previous: Option<&Self>, max_file_bytes: u64) -> Result<Self> {
+        let prior: HashMap<&str, &FileEntry> = previous
+            .map(|m| m.entries.iter().map(|e| (e.rel_path.as_str(), e)).collect())
+            .unwrap_or_default();
+
+        let mut entries = Vec::new();
+        for item in FileScanner::new(root, WalkOptions::default()) {
+            let path = item.context(WalkSnafu {
+                root: root.to_path_buf(),
+            })?;
+            let metadata = std::fs::metadata(&path).context(StatSnafu { path: path.clone() })?;
+            let size = metadata.len();
+            if size == 0 || size > max_file_bytes {
+                continue;
+            }
+            let mtime_ms = mtime_ms(&metadata);
+            let rel_path = relative_path(root, &path);
+
+            let hash = match prior.get(rel_path.as_str()) {
+                Some(prev) if prev.mtime_ms == mtime_ms && prev.size == size => prev.hash.clone(),
+                _ => {
+                    let bytes =
+                        std::fs::read(&path).context(ReadFileSnafu { path: path.clone() })?;
+                    ContentHash::of_bytes(&bytes)
+                }
+            };
+
+            entries.push(FileEntry {
+                rel_path,
+                hash,
+                mtime_ms,
+                size,
+            });
+        }
+
+        entries.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
+        Ok(Self { entries })
+    }
+
+    /// The set of content hashes present in this checkout.
+    #[must_use]
+    pub fn hashes(&self) -> HashSet<&str> {
+        self.entries.iter().map(|e| e.hash.as_str()).collect()
+    }
+
+    /// The first relative path that maps to `hash`, if any. Identical content
+    /// at several paths is rare in practice; the first is a fine display label.
+    #[must_use]
+    pub fn path_for_hash(&self, hash: &str) -> Option<&str> {
+        self.entries
+            .iter()
+            .find(|e| e.hash.as_str() == hash)
+            .map(|e| e.rel_path.as_str())
+    }
+}
+
+fn mtime_ms(metadata: &std::fs::Metadata) -> u64 {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+}
+
+fn relative_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Manifest;
+
+    #[test]
+    fn build_indexes_files_and_skips_binaries() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        std::fs::write(dir.path().join("a.rs"), "fn main() {}").expect("write");
+        std::fs::write(dir.path().join("b.txt"), "hello world").expect("write");
+        std::fs::write(dir.path().join("image.png"), [0_u8, 1, 2, 3]).expect("write");
+
+        let manifest = Manifest::build(dir.path(), None, 1024 * 1024).expect("build");
+        let paths: Vec<&str> = manifest
+            .entries
+            .iter()
+            .map(|e| e.rel_path.as_str())
+            .collect();
+
+        assert!(paths.contains(&"a.rs"));
+        assert!(paths.contains(&"b.txt"));
+        assert!(!paths.contains(&"image.png"), "binary extension skipped");
+    }
+
+    #[test]
+    fn unchanged_file_reuses_prior_hash_object() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let file = dir.path().join("a.rs");
+        std::fs::write(&file, "fn main() {}").expect("write");
+
+        let first = Manifest::build(dir.path(), None, 1024 * 1024).expect("first");
+        let second = Manifest::build(dir.path(), Some(&first), 1024 * 1024).expect("second");
+
+        assert_eq!(first.entries.len(), 1);
+        assert_eq!(
+            first.entries[0].hash, second.entries[0].hash,
+            "stable content keeps a stable hash across builds"
+        );
+    }
+
+    #[test]
+    fn hashes_and_lookup_round_trip() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        std::fs::write(dir.path().join("a.rs"), "alpha").expect("write");
+        let manifest = Manifest::build(dir.path(), None, 1024 * 1024).expect("build");
+
+        let hash = manifest.entries[0].hash.as_str().to_owned();
+        assert!(manifest.hashes().contains(hash.as_str()));
+        assert_eq!(manifest.path_for_hash(&hash), Some("a.rs"));
+        assert_eq!(manifest.path_for_hash("sha256:nope"), None);
+    }
+}

--- a/packages/semantic-search/src/search.rs
+++ b/packages/semantic-search/src/search.rs
@@ -1,0 +1,210 @@
+//! Search orchestration. The backend stores one shared entry per unique blob,
+//! so a raw result set can include content from other worktrees or branches.
+//! We over-fetch, then keep only hits whose content hash is in this checkout's
+//! manifest, mapping each back to its local path. Web results (no hash) pass
+//! through when the caller asked for them.
+
+use crate::backend::{SearchHit, SearchOptions, Store};
+use crate::config::WEB_STORE;
+use crate::error::Result;
+use crate::manifest::Manifest;
+
+/// A search result projected onto the current checkout.
+#[derive(Debug, Clone)]
+pub struct DisplayHit {
+    /// Repo-relative path, or a URL for a web result.
+    pub label: String,
+    /// Zero-based start line within the file, when known.
+    pub start_line: Option<u32>,
+    /// Number of lines the chunk spans, when known.
+    pub num_lines: Option<u32>,
+    /// Relevance score in `0.0..=1.0`.
+    pub score: f32,
+    /// Matched snippet text.
+    pub text: String,
+    /// Whether this came from the web store rather than the local checkout.
+    pub is_web: bool,
+}
+
+/// A question-answering result projected onto the current checkout.
+#[derive(Debug, Clone)]
+pub struct AnswerView {
+    /// The synthesized answer.
+    pub answer: String,
+    /// Sources, filtered and mapped like search hits.
+    pub sources: Vec<DisplayHit>,
+}
+
+/// Search `store_name` (and optionally the web store) and return only hits
+/// present in this checkout, newest-relevance first, capped at `top_k`.
+///
+/// # Errors
+/// Returns an error if the backend search request fails.
+pub async fn search(
+    store: &(impl Store + Sync),
+    store_name: &str,
+    manifest: &Manifest,
+    query: &str,
+    top_k: usize,
+    options: SearchOptions,
+    include_web: bool,
+) -> Result<Vec<DisplayHit>> {
+    let stores = store_identifiers(store_name, include_web);
+    let hits = store
+        .search(&stores, query, overfetch(top_k), options)
+        .await?;
+    Ok(project(manifest, hits, include_web, top_k))
+}
+
+/// Ask a question against `store_name` (and optionally the web store).
+///
+/// # Errors
+/// Returns an error if the backend request fails.
+pub async fn ask(
+    store: &(impl Store + Sync),
+    store_name: &str,
+    manifest: &Manifest,
+    query: &str,
+    top_k: usize,
+    options: SearchOptions,
+    include_web: bool,
+) -> Result<AnswerView> {
+    let stores = store_identifiers(store_name, include_web);
+    let answer = store.ask(&stores, query, overfetch(top_k), options).await?;
+    Ok(AnswerView {
+        answer: answer.answer,
+        sources: project(manifest, answer.sources, include_web, top_k),
+    })
+}
+
+fn store_identifiers(store_name: &str, include_web: bool) -> Vec<String> {
+    let mut stores = vec![store_name.to_owned()];
+    if include_web {
+        stores.push(WEB_STORE.to_owned());
+    }
+    stores
+}
+
+/// Over-fetch so that client-side filtering still leaves enough results. Other
+/// checkouts' content can crowd the raw top-k, so we ask for more than we show.
+fn overfetch(top_k: usize) -> usize {
+    top_k.saturating_mul(4).max(top_k.saturating_add(10))
+}
+
+fn project(
+    manifest: &Manifest,
+    hits: Vec<SearchHit>,
+    include_web: bool,
+    top_k: usize,
+) -> Vec<DisplayHit> {
+    let local = manifest.hashes();
+    let mut out = Vec::with_capacity(top_k);
+    for hit in hits {
+        if out.len() >= top_k {
+            break;
+        }
+        match hit.hash.as_deref() {
+            Some(hash) if local.contains(hash) => {
+                let label = manifest.path_for_hash(hash).unwrap_or(hash).to_owned();
+                out.push(DisplayHit {
+                    label,
+                    start_line: hit.start_line,
+                    num_lines: hit.num_lines,
+                    score: hit.score,
+                    text: hit.text,
+                    is_web: false,
+                });
+            }
+            None if include_web => out.push(DisplayHit {
+                label: hit.path.unwrap_or_else(|| "(web)".to_owned()),
+                start_line: None,
+                num_lines: None,
+                score: hit.score,
+                text: hit.text,
+                is_web: true,
+            }),
+            // A hash absent from this checkout belongs to another worktree or
+            // branch; a non-web result with no hash is dropped too. Either way
+            // search reflects only the current tree.
+            _ => {}
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::search;
+    use crate::backend::{MemoryStore, SearchOptions, Store, UploadMeta};
+    use crate::content::ContentHash;
+    use crate::manifest::{FileEntry, Manifest};
+
+    fn opts() -> SearchOptions {
+        SearchOptions {
+            rerank: true,
+            agentic: false,
+        }
+    }
+
+    async fn put(store: &MemoryStore, path: &str, content: &str) -> ContentHash {
+        let hash = ContentHash::of_bytes(content.as_bytes());
+        store
+            .upload(
+                "s",
+                content.as_bytes().to_vec(),
+                path,
+                hash.as_str(),
+                UploadMeta {
+                    path: path.to_owned(),
+                    hash: hash.as_str().to_owned(),
+                },
+            )
+            .await
+            .expect("upload");
+        hash
+    }
+
+    fn manifest_with(entries: &[(&str, &ContentHash)]) -> Manifest {
+        Manifest {
+            entries: entries
+                .iter()
+                .map(|(path, hash)| FileEntry {
+                    rel_path: (*path).to_owned(),
+                    hash: (*hash).clone(),
+                    mtime_ms: 0,
+                    size: 0,
+                })
+                .collect(),
+        }
+    }
+
+    #[tokio::test]
+    async fn results_outside_this_checkout_are_filtered() {
+        let store = MemoryStore::new();
+        let mine = put(&store, "mine.rs", "needle in mine").await;
+        let _theirs = put(&store, "theirs.rs", "needle in theirs").await;
+
+        // Manifest only knows about `mine.rs`, so the other worktree's hit must
+        // be dropped even though both match the query in the shared store.
+        let manifest = manifest_with(&[("mine.rs", &mine)]);
+        let hits = search(&store, "s", &manifest, "needle", 10, opts(), false)
+            .await
+            .expect("search");
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].label, "mine.rs");
+        assert!(!hits[0].is_web);
+    }
+
+    #[tokio::test]
+    async fn empty_manifest_yields_no_local_hits() {
+        let store = MemoryStore::new();
+        let _ = put(&store, "a.rs", "needle").await;
+        let manifest = Manifest::default();
+
+        let hits = search(&store, "s", &manifest, "needle", 10, opts(), false)
+            .await
+            .expect("search");
+        assert!(hits.is_empty());
+    }
+}

--- a/packages/semantic-search/src/sync.rs
+++ b/packages/semantic-search/src/sync.rs
@@ -1,0 +1,216 @@
+//! Dedup-aware sync. The deliberate departure from how mgrep works:
+//!
+//! 1. Files are addressed by content hash, so a blob already in the store is
+//!    never re-uploaded or re-embedded. Twenty worktrees of one repo pay the
+//!    embedding cost once.
+//! 2. Sync never deletes. mgrep removes anything under the synced path that is
+//!    absent locally, which silently wipes another worktree's files when two
+//!    checkouts share a path. Because a stored entry is shared across
+//!    checkouts, deletion can only be decided by reference counting across
+//!    every manifest, so it lives in a separate garbage-collection pass, not
+//!    in ordinary sync.
+//!
+//! There is no daemon. Each invocation rebuilds the manifest cheaply (mtime
+//! skips re-hashing unchanged files) and uploads only what is new.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use futures::stream::{self, StreamExt as _};
+use snafu::ResultExt as _;
+use tokio::time::sleep;
+
+use crate::backend::{Store, UploadMeta};
+use crate::error::{ReadFileSnafu, Result, TooManyFilesSnafu};
+use crate::manifest::{FileEntry, Manifest};
+
+/// Maximum concurrent uploads in flight.
+const UPLOAD_CONCURRENCY: usize = 16;
+
+/// How often to poll the store for indexing progress.
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Outcome of a sync pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SyncReport {
+    /// New blobs uploaded this run.
+    pub uploaded: usize,
+    /// Files already present in the store, skipped without an upload.
+    pub skipped: usize,
+    /// Total files in the manifest.
+    pub total: usize,
+}
+
+/// Upload every file in `manifest` whose content is not already in `store`.
+///
+/// Returns once the uploads are accepted; call [`wait_until_indexed`] to block
+/// until the new content is embedded and searchable.
+///
+/// # Errors
+/// Returns an error if the store cannot be reached, if the number of new files
+/// exceeds `max_files`, or if a file selected for upload cannot be read.
+pub async fn sync(
+    store: &(impl Store + Sync),
+    store_name: &str,
+    root: &Path,
+    manifest: &Manifest,
+    max_files: usize,
+) -> Result<SyncReport> {
+    store.ensure_store(store_name).await?;
+    let remote = store.list_external_ids(store_name).await?;
+
+    // New content only: skip hashes the store already has, and collapse
+    // duplicate content within this checkout to a single upload.
+    let mut seen = HashSet::new();
+    let to_upload: Vec<&FileEntry> = manifest
+        .entries
+        .iter()
+        .filter(|e| !remote.contains(e.hash.as_str()))
+        .filter(|e| seen.insert(e.hash.as_str()))
+        .collect();
+
+    let total = manifest.entries.len();
+    let upload_target = to_upload.len();
+    let skipped = total - upload_target;
+
+    if upload_target > max_files {
+        return TooManyFilesSnafu {
+            count: upload_target,
+            max: max_files,
+        }
+        .fail();
+    }
+
+    let results: Vec<Result<()>> = stream::iter(to_upload)
+        .map(|entry| async move {
+            let abs = root.join(&entry.rel_path);
+            let content = tokio::fs::read(&abs)
+                .await
+                .context(ReadFileSnafu { path: abs })?;
+            let file_name = file_name_of(&entry.rel_path);
+            let meta = UploadMeta {
+                path: entry.rel_path.clone(),
+                hash: entry.hash.as_str().to_owned(),
+            };
+            store
+                .upload(store_name, content, file_name, entry.hash.as_str(), meta)
+                .await
+        })
+        .buffer_unordered(UPLOAD_CONCURRENCY)
+        .collect()
+        .await;
+
+    let mut uploaded = 0;
+    for result in results {
+        result?;
+        uploaded += 1;
+    }
+
+    Ok(SyncReport {
+        uploaded,
+        skipped,
+        total,
+    })
+}
+
+/// Poll the store until newly uploaded files finish embedding.
+///
+/// Returns `true` when the store reports nothing pending or in progress, or
+/// `false` if `timeout` elapses first (the caller can search anyway, accepting
+/// possibly-incomplete results).
+///
+/// # Errors
+/// Returns an error if a status request fails.
+pub async fn wait_until_indexed(
+    store: &(impl Store + Sync),
+    store_name: &str,
+    timeout: Duration,
+) -> Result<bool> {
+    let start = Instant::now();
+    loop {
+        let status = store.store_status(store_name).await?;
+        if status.pending == 0 && status.in_progress == 0 {
+            return Ok(true);
+        }
+        if start.elapsed() >= timeout {
+            return Ok(false);
+        }
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+fn file_name_of(rel_path: &str) -> &str {
+    rel_path.rsplit('/').next().unwrap_or(rel_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sync;
+    use crate::backend::MemoryStore;
+    use crate::manifest::Manifest;
+
+    fn write_repo() -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        std::fs::write(dir.path().join("a.rs"), "fn a() {}").expect("write a");
+        std::fs::write(dir.path().join("b.rs"), "fn b() {}").expect("write b");
+        dir
+    }
+
+    #[tokio::test]
+    async fn first_sync_uploads_all_then_second_uploads_nothing() {
+        let dir = write_repo();
+        let store = MemoryStore::new();
+        let manifest = Manifest::build(dir.path(), None, 1024 * 1024).expect("manifest");
+
+        let first = sync(&store, "s", dir.path(), &manifest, 1000)
+            .await
+            .expect("first sync");
+        assert_eq!(first.uploaded, 2);
+        assert_eq!(store.upload_count(), 2);
+
+        // Re-syncing the same content must not re-upload: this is the
+        // cross-worktree / re-run win that mgrep lacks.
+        let second = sync(&store, "s", dir.path(), &manifest, 1000)
+            .await
+            .expect("second sync");
+        assert_eq!(second.uploaded, 0);
+        assert_eq!(second.skipped, 2);
+        assert_eq!(store.upload_count(), 2, "no redundant re-upload");
+    }
+
+    #[tokio::test]
+    async fn second_worktree_with_same_content_reuses_store() {
+        let dir_a = write_repo();
+        let dir_b = write_repo(); // identical content, different absolute path
+        let store = MemoryStore::new();
+
+        let manifest_a = Manifest::build(dir_a.path(), None, 1024 * 1024).expect("a");
+        sync(&store, "s", dir_a.path(), &manifest_a, 1000)
+            .await
+            .expect("sync a");
+        assert_eq!(store.upload_count(), 2);
+
+        let manifest_b = Manifest::build(dir_b.path(), None, 1024 * 1024).expect("b");
+        let report_b = sync(&store, "s", dir_b.path(), &manifest_b, 1000)
+            .await
+            .expect("sync b");
+
+        assert_eq!(report_b.uploaded, 0, "identical worktree embeds nothing");
+        assert_eq!(store.upload_count(), 2, "store still holds one copy");
+        assert_eq!(store.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn over_limit_refuses_to_upload() {
+        let dir = write_repo();
+        let store = MemoryStore::new();
+        let manifest = Manifest::build(dir.path(), None, 1024 * 1024).expect("manifest");
+
+        let err = sync(&store, "s", dir.path(), &manifest, 1)
+            .await
+            .expect_err("should refuse");
+        assert!(matches!(err, crate::error::Error::TooManyFiles { .. }));
+        assert_eq!(store.upload_count(), 0);
+    }
+}


### PR DESCRIPTION
## What

A daemon-free, content-addressed semantic code search over a [Mixedbread](https://www.mixedbread.com) store — an `mgrep` alternative built for the multi-worktree case.

Files are keyed by the hash of their bytes, not their path. Byte-identical files across many git worktrees (or branches, or repos) share a single stored embedding, so the second through Nth worktree of a repo embed almost nothing. There is no daemon and no sync flag: every run rebuilds a local manifest (cheap; unchanged files skip re-hashing via mtime), uploads only content the store is missing, waits for it to embed, then searches. Results are scoped to the current checkout via the manifest, so a query reflects this tree even though entries are shared.

## Why

`mgrep` keys each file by its absolute path and, on sync, deletes anything under the synced path that is missing locally. Two checkouts that resolve to the same path (containers, CI, devcontainers) overwrite and delete each other, and twenty worktrees of one repo pay the embedding cost twenty times. This tool removes both problems by content-addressing and by never deleting during sync (cross-entry deletion needs reference counting, which belongs in a separate GC pass).

## Shape

Two crates, so the API client is reusable on its own:

- `packages/mixedbread` — standalone async Rust client for the Mixedbread vector store API (stores, two-step file upload, list/delete, search, question-answering, store status). No domain logic.
- `packages/semantic-search` — `lib.rs` + `main.rs`. Owns content addressing, the manifest, dedup sync, and search; consumes the client behind a `Store` trait so the logic is tested against an in-memory store.

Local state is one shared SQLite (WAL) database keyed by `(root, rel_path)`; the why-not-LMDB decision is recorded inline in `src/db.rs`. Credentials resolve from `MXBAI_API_KEY` or, failing that, the token written by `mgrep login` (exchanged for an API JWT).

## Validation

- `nix build .#semantic-search` green (bundled SQLite compiles in the sandbox); `nix run .#lint` 5/5.
- `cargo clippy` clean under the workspace's pedantic/nursery/deny-warnings config; `cargo fmt` clean; 18 tests (dedup, worktree isolation, manifest reuse, SQLite round-trip/persistence, chunk parsing).
- Verified live against the real API using a `mgrep login` token: one-shot `semantic-search "query"` auto-detected a new file, embedded it, and ranked it 97.56% vs unrelated files; re-sync and a second worktree both uploaded 0 (dedup confirmed).

Also fixes a pre-existing infra bug (second commit): lib-only workspace crates that set `passthruTests = true` (`mixedbread`, `tap-protocol`, `tap-pty`) were silently dropped from the `rust-package-tests` CI aggregate.

## Known limitations

- No GC yet, so blobs no checkout references are not reclaimed (correctness over storage).
- `-w/--web` and `--agentic` pass through to the API but were not exercised live.
- The client has no delete-store call yet (the live test left a throwaway `semantic-search-smoketest` store).

---

Made with Claude (Opus 4.8).
