### PR TITLE
fix(claude-code): label 1Password CLI prompt "Claude Code"

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -131,14 +131,21 @@ stdenv.mkDerivation {
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/bin
+    mkdir -p $out/bin $out/libexec
 
-    install -m755 ${nativeBinary} $out/bin/.${binName}-unwrapped
+    # 1Password's "CLI access requested" prompt labels the request with the
+    # basename of the process that spawns `op`, which is this real binary rather
+    # than the wrapper. Keep it in libexec (off PATH, no leading-dot wrapper
+    # convention) and name it for the product so the prompt reads "Claude Code"
+    # instead of ".claude-unwrapped". The basename is the human-facing product
+    # label, independent of the command alias, since it is only what macOS shows.
+    helper="$out/libexec/Claude Code"
+    install -m755 ${nativeBinary} "$helper"
 
     # The store output is read-only, so the bundled self-updater can never
     # write; disable it and the install checks, and pin the bundled ripgrep to
     # the Nix one so PATH stays reproducible. The wrapper owns the version pin.
-    makeBinaryWrapper $out/bin/.${binName}-unwrapped $out/bin/${binName} \
+    makeBinaryWrapper "$helper" $out/bin/${binName} \
       --inherit-argv0 \
       --set DISABLE_AUTOUPDATER 1 \
       --set DISABLE_INSTALLATION_CHECKS 1 \


### PR DESCRIPTION
## What

When the Claude Code CLI shells out to `op`, 1Password's "CLI access requested" prompt read **"Allow .claude-unwrapped to get CLI access"** with a generic document icon.

1Password labels the prompt with the **executable file basename** of the process that spawns `op`. That process is the real Bun binary, which `makeBinaryWrapper` installs as `.claude-unwrapped` (the wrapper just sets env pins and execs it). 1Password ignores the code-signing identity and the binary's embedded `CFBundleName` (which already reads "Claude Code").

This moves the real binary to `libexec/Claude Code` so the prompt now reads **"Allow Claude Code to get CLI access"**. Side benefit: `bin/` contains only the `claude` wrapper, so the helper no longer sits on `PATH`.

## Not addressed

The generic document **icon** is unchanged. 1Password resolves icons through macOS LaunchServices, which only pulls an icon from a real `.app` bundle. A bare CLI Mach-O always gets the generic icon, and there is no 1Password-side setting to register one. Getting the Claude icon would require shipping the binary inside a `Claude Code.app` bundle with an `AppIcon.icns`, which is out of scope here.

## Verify

```
nix build .#claude-code
ls result/bin result/libexec        # bin: claude ; libexec: "Claude Code"
result/bin/claude --version         # 2.1.157 (Claude Code)
```

Then trigger any `op` call from Claude Code and confirm the prompt text.

Made with Claude Code (Opus 4.8).
