### PR TITLE
docs(claude-code): cite 1Password app-integration source for prompt name

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -139,6 +139,9 @@ stdenv.mkDerivation {
     # convention) and name it for the product so the prompt reads "Claude Code"
     # instead of ".claude-unwrapped". The basename is the human-facing product
     # label, independent of the command alias, since it is only what macOS shows.
+    # 1Password docs confirm the prompt shows "the process being authorized (for
+    # example, iTerm2 or Terminal)", not the code signature or CFBundleName:
+    # https://developer.1password.com/docs/cli/app-integration-security/
     helper="$out/libexec/Claude Code"
     install -m755 ${nativeBinary} "$helper"
 


### PR DESCRIPTION
Follow-up to #347. Adds the 1Password documentation URL to the comment explaining why the real binary is named "Claude Code", per the repo rule that non-obvious technical decisions carry a public reference near the choice.

The docs confirm the prompt shows "the process being authorized (for example, `iTerm2` or `Terminal`)", which is why the executable basename (not the code signature or embedded `CFBundleName`) drives the displayed name.

Comment-only change; package still builds and runs.

Made with Claude Code (Opus 4.8).
