### PR TITLE
progress: contiguous progress bars + shared progress-style crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
  "futures",
  "indicatif",
  "libc",
+ "progress-style",
  "serde",
  "serde_json",
  "tempfile",
@@ -3325,6 +3326,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "progress-style"
+version = "0.1.0"
+dependencies = [
+ "indicatif",
+]
+
+[[package]]
 name = "pty-process"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4095,6 +4103,7 @@ dependencies = [
  "dirs",
  "indicatif",
  "mixedbread",
+ "progress-style",
  "semantic-search-core",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "packages/nix-web-monitor/parser",
   "packages/nix-web-monitor/server",
   "packages/oci-image-builder",
+  "packages/progress-style",
   "packages/repo-walker",
   "packages/semantic-search",
   "packages/semantic-search-core",
@@ -85,6 +86,7 @@ object = { version = "0.37", default-features = false, features = [
   "std",
 ] }
 parking_lot = "0.12"
+progress-style = { path = "packages/progress-style" }
 pty-process = { version = "0.4", features = ["async"] }
 pyo3 = { version = "0.28", features = ["abi3-py311"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }

--- a/packages/dag-runner/Cargo.toml
+++ b/packages/dag-runner/Cargo.toml
@@ -15,6 +15,7 @@ indicatif.workspace = true
 # Used for `libc::kill(pid, SIGTERM)`; tokio::process::Child only exposes the
 # SIGKILL escape hatch via `start_kill`, and we want a graceful term first.
 libc.workspace = true
+progress-style.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["io-util", "macros", "process", "rt", "signal", "sync", "time"] }

--- a/packages/dag-runner/src/main.rs
+++ b/packages/dag-runner/src/main.rs
@@ -30,7 +30,7 @@ use anyhow::{Context, Result, bail};
 use clap::{Parser, ValueEnum};
 use futures::FutureExt;
 use futures::future::{BoxFuture, Shared};
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use indicatif::{MultiProgress, ProgressBar};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::process::Command;
@@ -420,15 +420,7 @@ async fn run(
 
 fn make_spinner(multi: &MultiProgress, name: &str) -> ProgressBar {
     let pb = multi.add(ProgressBar::new_spinner());
-    // The template uses indicatif's own substitution syntax, which clippy's
-    // literal-string-with-formatting-args lint mistakes for a `format!`
-    // template; allow it on this one call.
-    #[allow(clippy::literal_string_with_formatting_args)]
-    let style =
-        ProgressStyle::with_template("{spinner:.cyan} {prefix:.bold} {wide_msg} {elapsed:.dim}")
-            .expect("static template")
-            .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ ");
-    pb.set_style(style);
+    pb.set_style(progress_style::spinner());
     pb.set_prefix(name.to_string());
     pb.set_message("pending");
     pb

--- a/packages/progress-style/Cargo.toml
+++ b/packages/progress-style/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "progress-style"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Shared indicatif progress-bar and spinner styling for ix command-line tools"
+
+[lints]
+workspace = true
+
+[dependencies]
+indicatif.workspace = true

--- a/packages/progress-style/package.nix
+++ b/packages/progress-style/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "progress-style";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/progress-style/src/lib.rs
+++ b/packages/progress-style/src/lib.rs
@@ -1,0 +1,96 @@
+//! Shared terminal progress styling for ix command-line tools.
+//!
+//! One owner for the glyphs, colors, and templates every ix CLI uses to draw
+//! progress, so `semantic-search`, `dag-runner`, and future commands render the
+//! same shape instead of each hand-rolling an [`indicatif`] template. Pick a
+//! style here, then set the per-run label with [`ProgressBar::set_prefix`] and
+//! the per-run status with [`ProgressBar::set_message`].
+//!
+//! [`ProgressBar::set_prefix`]: indicatif::ProgressBar::set_prefix
+//! [`ProgressBar::set_message`]: indicatif::ProgressBar::set_message
+
+use indicatif::ProgressStyle;
+
+/// Progress-bar cell glyphs in the order `indicatif`'s `progress_chars` reads
+/// them: the first glyph fills a complete cell, the last marks an empty cell,
+/// and the middle glyphs render the partially-filled head cell from 7/8 down to
+/// 1/8.
+///
+/// A full block, seven fractional blocks, and a light-shade track make the fill
+/// advance one-eighth of a cell at a time and keep the whole bar one contiguous
+/// shape, replacing the segmented `=>-` arrow look. The empty glyph is `░`
+/// rather than a space so the track stays visible.
+const BAR_CHARS: &str = "█▉▊▋▌▍▎▏░";
+
+/// Spinner frames: a braille wheel with a trailing blank frame so the final
+/// tick clears cleanly. Shared so every ix command spins the same way.
+const TICK_CHARS: &str = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ ";
+
+/// A determinate progress bar: a green braille spinner, the caller's `{prefix}`
+/// label, a `pos/len` counter, the contiguous block bar, and elapsed time.
+///
+/// `accent` is an `indicatif` color name applied to the filled run over a
+/// `blue` track (for example `"cyan"` or `"magenta"`); callers vary it to mark
+/// distinct phases. The returned style is reusable across bars; set the label
+/// per run with [`ProgressBar::set_prefix`] so the template itself stays fixed.
+///
+/// # Panics
+///
+/// Never in practice: the template is constructed from a fixed shape and a
+/// color name, so [`ProgressStyle::with_template`] always parses it. The
+/// `expect` guards against an edit that makes the template malformed.
+///
+/// [`ProgressBar::set_prefix`]: indicatif::ProgressBar::set_prefix
+#[must_use]
+pub fn bar(accent: &str) -> ProgressStyle {
+    // Braces are doubled so `format!` emits literal `{...}` for indicatif to
+    // parse at render time; only `{accent}` is a real format argument. Building
+    // the template through `format!` rather than a string literal also sidesteps
+    // clippy's `literal_string_with_formatting_args` false positive, which reads
+    // indicatif's `{spinner:.green}` keys as stray `format!` placeholders.
+    let template = format!(
+        "{{spinner:.green}} {{prefix}} {{pos}}/{{len}} {{wide_bar:.{accent}/blue}} {{elapsed}}"
+    );
+    ProgressStyle::with_template(&template)
+        .expect("progress bar template is valid")
+        .progress_chars(BAR_CHARS)
+        .tick_chars(TICK_CHARS)
+}
+
+/// An indeterminate spinner for work with no known total.
+///
+/// Renders a cyan braille spinner, a bold `{prefix}` label, a `{wide_msg}`
+/// status line, and dimmed elapsed time, sized for one running task in a
+/// [`MultiProgress`] group. Set the label with [`ProgressBar::set_prefix`] and
+/// the status with [`ProgressBar::set_message`].
+///
+/// # Panics
+///
+/// Never in practice; see [`bar`].
+///
+/// [`MultiProgress`]: indicatif::MultiProgress
+/// [`ProgressBar::set_prefix`]: indicatif::ProgressBar::set_prefix
+/// [`ProgressBar::set_message`]: indicatif::ProgressBar::set_message
+#[must_use]
+pub fn spinner() -> ProgressStyle {
+    // See `bar` for why this clippy lint is a false positive on indicatif keys.
+    #[allow(clippy::literal_string_with_formatting_args)]
+    ProgressStyle::with_template("{spinner:.cyan} {prefix:.bold} {wide_msg} {elapsed:.dim}")
+        .expect("spinner template is valid")
+        .tick_chars(TICK_CHARS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bar, spinner};
+
+    // The `expect` calls inside `bar`/`spinner` turn a malformed template into a
+    // panic; exercising both builders proves the templates parse, which is the
+    // one invariant the type system cannot check.
+    #[test]
+    fn styles_build() {
+        let _ = bar("cyan");
+        let _ = bar("magenta");
+        let _ = spinner();
+    }
+}

--- a/packages/semantic-search/Cargo.toml
+++ b/packages/semantic-search/Cargo.toml
@@ -21,5 +21,6 @@ code-highlight.workspace = true
 dirs.workspace = true
 indicatif.workspace = true
 mixedbread.workspace = true
+progress-style.workspace = true
 semantic-search-core.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/packages/semantic-search/src/main.rs
+++ b/packages/semantic-search/src/main.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 use anstyle::{AnsiColor, Style};
 use clap::Parser;
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::ProgressBar;
 use semantic_search_core::{
     Config, DEFAULT_STORE, DisplayHit, MixedbreadStore, Query, SearchOptions, StoreStatus,
 };
@@ -116,7 +116,8 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
         .is_terminal()
         .then(ProgressBar::new_spinner);
     if let Some(bar) = &bar {
-        bar.set_style(upload_style());
+        bar.set_style(progress_style::bar("cyan"));
+        bar.set_prefix("indexing files");
     }
     let embedding = AtomicBool::new(false);
     // Captured during upload so the embedding bar knows its length: the number
@@ -141,7 +142,8 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             let remaining = (status.pending + status.in_progress).min(len);
             bar.set_position(len - remaining);
             if !embedding.swap(true, Ordering::Relaxed) {
-                bar.set_style(embed_style());
+                bar.set_style(progress_style::bar("magenta"));
+                bar.set_prefix("embedding files");
                 bar.set_length(len);
                 bar.enable_steady_tick(Duration::from_millis(120));
             }
@@ -175,22 +177,6 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-fn upload_style() -> ProgressStyle {
-    ProgressStyle::with_template(
-        "{spinner:.green} indexing {pos}/{len} files {wide_bar:.cyan/blue} {elapsed}",
-    )
-    .expect("valid progress template")
-    .progress_chars("=>-")
-}
-
-fn embed_style() -> ProgressStyle {
-    ProgressStyle::with_template(
-        "{spinner:.green} embedding {pos}/{len} files {wide_bar:.magenta/blue} {elapsed}",
-    )
-    .expect("valid progress template")
-    .progress_chars("=>-")
 }
 
 fn resolve_root(path: Option<&str>) -> anyhow::Result<PathBuf> {


### PR DESCRIPTION
## What

`semantic-search`'s progress bar drew with `=>-` progress chars: a thick `===` fill, a `>` arrow head, and a dashed `---` track joined into a segmented shape. This switches to fractional Unicode block glyphs so the fill advances one-eighth of a cell at a time and the whole bar stays one contiguous shape.

It also unifies the styling. A new `progress-style` crate owns the glyphs, colors, and templates once, and both `semantic-search` (its two phase bars) and `dag-runner` (its task spinner) consume it instead of each hand-rolling an indicatif template. The duplicated `upload_style`/`embed_style` pair collapses into one `bar(accent)` call with the phase word carried on the bar prefix.

## Bar, before and after

```
before  ⠒ embedding 5/9 files ====================>------------------ 5s
after   ⠹ embedding files 5/9 ███████████████████▌░░░░░░░░░░░░░░ 5s
```

The `▌` is a fractional head cell; the track is a contiguous `░` rather than dashes.

## Validation

- `nix build .#semantic-search .#dag-runner` — both build and link the shared crate, zero unused-crate-dependency warnings
- `nix run .#lint` — nixfmt, statix, deadnix, ast-grep all pass
- `cargo clippy` with the workspace lint set (all/pedantic/nursery/cargo denied) — clean on the touched crates
- `cargo test -p progress-style` — the template-parse test passes
- Rendered the bar to a captured buffer at several fill levels to confirm the contiguous block style

---

Made with AI (Claude Opus 4.8).
