### PR TITLE
semantic-search: cat -n content output for non-TTY (agent/LLM) consumers

### DIFF
--- a/packages/semantic-search/src/main.rs
+++ b/packages/semantic-search/src/main.rs
@@ -300,10 +300,14 @@ fn render(hit: &DisplayHit, show_content: bool, palette: &Palette, root: &Path) 
 
 /// Render the matched content as a readable block.
 ///
-/// When the hit carries a start line, each line gets its 1-based number in a
-/// right-aligned, dim gutter (ripgrep/mgrep feel); otherwise the text prints
-/// as-is (web hits). Trailing whitespace is trimmed and an empty snippet
-/// returns `None`, so nothing is printed.
+/// With color (a terminal, or `CLICOLOR_FORCE`), each line carries its 1-based
+/// number in a right-aligned, dim gutter over syntax-highlighted source
+/// (ripgrep/mgrep feel). Without color (piped to an agent, script, or file, or
+/// `NO_COLOR`), it switches to `cat -n` style: `number<tab>line`, the same shape
+/// a coding agent's file reader feeds an LLM, which tokenizes cleaner than a
+/// box-drawing gutter and drops highlighting that is noise without color. Web
+/// hits with no start line print as-is. Trailing whitespace is trimmed and an
+/// empty snippet returns `None`, so nothing is printed.
 fn render_snippet(hit: &DisplayHit, palette: &Palette, root: &Path) -> Option<String> {
     let body = hit.text.trim_end();
     if body.is_empty() {
@@ -313,6 +317,13 @@ fn render_snippet(hit: &DisplayHit, palette: &Palette, root: &Path) -> Option<St
     let Some(start) = hit.start_line else {
         return Some(body.to_owned());
     };
+
+    // Machine-readable mode: output is not a colored terminal, so a consumer is
+    // a script or an LLM. Emit `cat -n` style and skip the rich path entirely
+    // (no syntax highlighting, no aligned `│` gutter).
+    if !palette.color {
+        return Some(numbered_plain(body, start));
+    }
 
     // Prefer syntax-highlighting the real file lines: tree-sitter gets full
     // parse context and code-highlight renders its own line-number gutter. Falls
@@ -351,4 +362,56 @@ fn render_snippet(hit: &DisplayHit, palette: &Palette, root: &Path) -> Option<St
         .collect::<Vec<_>>()
         .join("\n");
     Some(rendered)
+}
+
+/// `cat -n` style numbering: `number<tab>line`, 1-based from `start`.
+///
+/// No alignment padding and no separator glyph: a tab is one token and lets a
+/// downstream reader split the number from the line trivially. `start` is the
+/// 0-based line index of the first body line, matching `DisplayHit::start_line`.
+fn numbered_plain(body: &str, start: u32) -> String {
+    let first = u64::from(start) + 1;
+    body.lines()
+        .enumerate()
+        .map(|(offset, line)| format!("{}\t{}", first + offset as u64, line.trim_end()))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use semantic_search_core::DisplayHit;
+
+    use super::{Palette, render_snippet};
+
+    /// A web hit so the snippet path renders the chunk text without reading a
+    /// real file, isolating the gutter-vs-`cat -n` decision from the filesystem.
+    fn hit(text: &str) -> DisplayHit {
+        DisplayHit {
+            label: "web://example".to_owned(),
+            start_line: Some(4),
+            num_lines: Some(2),
+            score: 0.5,
+            text: text.to_owned(),
+            is_web: true,
+        }
+    }
+
+    #[test]
+    fn piped_content_is_cat_n_style() {
+        let out = render_snippet(&hit("alpha\nbeta"), &Palette::plain(), Path::new("."))
+            .expect("snippet");
+        assert_eq!(out, "5\talpha\n6\tbeta");
+        assert!(!out.contains('│'), "machine output must drop the gutter glyph");
+    }
+
+    #[test]
+    fn terminal_content_keeps_the_gutter() {
+        let out = render_snippet(&hit("alpha\nbeta"), &Palette::colored(), Path::new("."))
+            .expect("snippet");
+        assert!(out.contains('│'), "interactive output keeps the aligned gutter");
+        assert!(!out.contains('\t'), "interactive output is not tab-numbered");
+    }
 }


### PR DESCRIPTION
## What

`semantic-search -c` (show matched content) drew a right-aligned line-number gutter with a box-drawing `│` separator in every mode, dropping only color when the output was piped. A machine reader (a script, or an LLM agent consuming the results) then paid for alignment padding and a box glyph that carry no meaning and tokenize poorly.

When color is off (piped, redirected, or `NO_COLOR`), each line now renders as `number<tab>line` instead: the same shape a coding agent's file reader feeds an LLM. It splits trivially and tokenizes clean. `CLICOLOR_FORCE` keeps the rich highlighted gutter for a human piping into a color pager, and syntax highlighting is skipped in the plain mode since it is noise without color.

## Output, piped vs terminal

Piped (agent / script):

```
./modules/profiles/base/nvim/colors/ix-islands-dark.lua:164-331 (85.20% match)
164	-- Spell --------------------------------------------------------------
165	hi("SpellBad",   { sp = c.error,   undercurl = true })
```

Terminal (unchanged): syntax-highlighted source under a dim, right-aligned `NNN │` gutter.

The header line (`path:range (score% match)`) is unchanged in both modes; only the per-line content rendering switches.

## Validation

- `cargo test -p semantic-search` — two new tests cross the boundary: plain palette yields `number<tab>line` with no `│`, colored palette keeps the `│` gutter and no tabs
- `nix build .#semantic-search` — builds clean
- Live piped run confirmed `cat -A` shows `164^I-- Spell ...` (tab-separated, no gutter glyph, no ANSI)

---

Made with AI (Claude Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Output `cat -n` style tab-numbered lines from `render_snippet` for non-TTY consumers
> When color output is disabled (`palette.color == false`), `render_snippet` in [main.rs](https://github.com/indexable-inc/index/pull/350/files#diff-6febaea171e146cd3a06ba5d2a29b2d7c1f3ed2ae73db2f9a004c54c1f6d9202) now returns lines formatted as `number<TAB>line` instead of syntax-highlighted output with the `│` gutter. A new `numbered_plain` helper handles this formatting, trimming trailing whitespace and starting line numbers from `start + 1`. Color mode output is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4cd4a93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->