### PR TITLE
feat(tui-dashboard): minimal ghostty-themed dashboard

### DIFF
--- a/packages/tui-dashboard-core/src/dashboard/dashboard.html
+++ b/packages/tui-dashboard-core/src/dashboard/dashboard.html
@@ -6,86 +6,112 @@
 <title>tui</title>
 <style>
   :root {
-    color-scheme: dark;
-    --bg: #08090b;
-    --panel: #0c0d10;
-    --panel-edge: #1b1d22;
-    --panel-edge-hover: #2b2e36;
-    --ink: #e7e9ee;
-    --ink-dim: #6b7078;
-    --ink-faint: #41454d;
-    --live: #4ade80;
-    --dead: #f4636b;
+    color-scheme: light dark;
+
+    /* Light theme, taken verbatim from the user's ghostty
+       ~/.config/nix/ghostty/themes/custom-light. Each card is a ghostty
+       surface (--panel == the theme background) on a slightly darker page.
+       Dark overrides live in the media query below. */
+    --bg: #ececec;
+    --panel: #f9f9f9;
+    --edge: #dcdcdc;
+    --edge-strong: #c4c4c4;
+    --ink: #2a2c33;
+    --ink-dim: #6a6c72;
+    --ink-faint: #8f9096;
+    --live: #42933e;
+    --dead: #db3f39;
+    --accent: #325eee;
+    --cursor: #bbbbbb;
+    --sel: #e9e9e9;
+
     --ui: ui-sans-serif, system-ui, -apple-system, "SF Pro Text", Segoe UI, sans-serif;
-    --mono: ui-monospace, "SF Mono", SFMono-Regular, "JetBrains Mono", Menlo, Consolas, monospace;
+    /* Prefer Berkeley Mono (the user's ghostty font) when it is installed
+       locally; fall through the usual system monospaces otherwise. */
+    --mono: "Berkeley Mono", ui-monospace, "SF Mono", SFMono-Regular, "JetBrains Mono", Menlo, Consolas, monospace;
   }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      /* Dark theme, taken verbatim from custom-dark. */
+      --bg: #151515;
+      --panel: #1e1e1e;
+      --edge: #2a2a2a;
+      --edge-strong: #3a3a3a;
+      --ink: #d4d4d4;
+      --ink-dim: #808080;
+      --ink-faint: #585b70;
+      --live: #a6e3a1;
+      --dead: #f38ba8;
+      --accent: #89b4fa;
+      --cursor: #f5e0dc;
+      --sel: #313244;
+    }
+  }
+
   * { box-sizing: border-box; }
   html, body { height: 100%; }
+  ::selection { background: var(--sel); }
+
   body {
     margin: 0;
-    padding: 28px clamp(20px, 4vw, 56px) 56px;
-    background:
-      radial-gradient(1200px 600px at 50% -10%, #101218 0%, transparent 60%),
-      var(--bg);
+    padding: 26px clamp(18px, 4vw, 52px) 52px;
+    background: var(--bg);
     color: var(--ink);
     font: 13px/1.5 var(--ui);
     -webkit-font-smoothing: antialiased;
   }
+
+  /* A single hairline anchors the header to the page; no chrome beyond it. */
   header {
-    display: flex; align-items: center; gap: 14px;
-    margin: 0 2px 24px;
+    display: flex; align-items: center; gap: 12px;
+    margin: 0 0 22px; padding: 0 1px 15px;
+    border-bottom: 1px solid var(--edge);
   }
   header .mark {
-    font-family: var(--mono); font-weight: 600; font-size: 14px;
-    letter-spacing: 0.5px; color: var(--ink);
+    font-family: var(--mono); font-weight: 600; font-size: 13.5px;
+    letter-spacing: 0.3px; color: var(--ink);
   }
-  header .mark .accent { color: var(--ink-dim); }
+  header .mark .accent { color: var(--ink-faint); font-weight: 500; }
   header .spacer { flex: 1; }
   header .stat {
     color: var(--ink-dim); font-variant-numeric: tabular-nums;
-    font-size: 12px; letter-spacing: 0.2px;
+    font-family: var(--mono); font-size: 11.5px; letter-spacing: 0.2px;
   }
+  /* Connection state: a small flat dot, lit when the event stream is open. */
   header .dot {
     width: 7px; height: 7px; border-radius: 50%;
-    background: var(--ink-faint); transition: background 0.3s, box-shadow 0.3s;
+    background: var(--ink-faint);
   }
-  header .dot.live {
-    background: var(--live);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--live) 18%, transparent);
-  }
+  header .dot.live { background: var(--live); }
 
   #grid {
-    display: grid; gap: 18px;
+    display: grid; gap: 14px;
     grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
     align-items: start;
   }
 
+  /* Flat, square terminal cards. A hairline border gives separation: no
+     rounding, no shadow, no hover reaction. The card stays still. */
   .term {
     position: relative;
     background: var(--panel);
-    border: 1px solid var(--panel-edge);
-    border-radius: 14px;
+    border: 1px solid var(--edge);
     overflow: hidden;
-    box-shadow:
-      0 1px 0 rgba(255,255,255,0.02) inset,
-      0 12px 30px -18px rgba(0,0,0,0.9);
-    transition: border-color 0.2s;
   }
-  /* Border color reacts to hover; the up/down motion was removed deliberately. */
-  .term:hover { border-color: var(--panel-edge-hover); }
-  .term.dead { opacity: 0.5; }
+  .term.dead { opacity: 0.55; }
 
   .term .head {
-    display: flex; align-items: center; gap: 10px;
-    padding: 11px 14px;
-    border-bottom: 1px solid var(--panel-edge);
+    display: flex; align-items: center; gap: 9px;
+    padding: 9px 13px;
+    border-bottom: 1px solid var(--edge);
   }
+  /* Run state: a small flat dot, green while live, red once exited. */
   .term .led {
-    flex: none; width: 8px; height: 8px; border-radius: 50%;
+    flex: none; width: 7px; height: 7px; border-radius: 50%;
     background: var(--live);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--live) 16%, transparent);
   }
-  .term.dead .led { background: var(--dead); box-shadow: none; }
+  .term.dead .led { background: var(--dead); }
   .term .cmd {
     font-family: var(--mono); font-size: 12.5px; font-weight: 500;
     color: var(--ink); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
@@ -101,18 +127,18 @@
   }
 
   .term pre {
-    margin: 0; padding: 14px 16px;
-    font-family: var(--mono); font-size: 12px; line-height: 1.38;
+    margin: 0; padding: 12px 14px;
+    font-family: var(--mono); font-size: 12px; line-height: 1.4;
     color: var(--ink);
     white-space: pre; overflow: auto;
     /* A stable floor so an empty or one-line screen does not collapse the card. */
-    min-height: 3.6em;
+    min-height: 3.4em;
     max-height: 60vh; tab-size: 8;
-    scrollbar-width: thin; scrollbar-color: var(--panel-edge-hover) transparent;
+    scrollbar-width: thin; scrollbar-color: var(--edge-strong) transparent;
   }
   .term pre::-webkit-scrollbar { width: 9px; height: 9px; }
   .term pre::-webkit-scrollbar-thumb {
-    background: var(--panel-edge-hover); border-radius: 9px;
+    background: var(--edge-strong);
     border: 2px solid var(--panel);
   }
   /* Style attributes carried by the SGR runs. */
@@ -120,16 +146,17 @@
   .term pre .i { font-style: italic; }
   .term pre .u { text-decoration: underline; }
 
-  /* Cursor overlays. Inline so the cell text stays selectable underneath. */
+  /* Cursor overlays in the ghostty cursor color. Inline so the cell text stays
+     selectable underneath. */
   .term pre .cur { position: relative; }
   .term pre .cur::after {
     content: ""; position: absolute; pointer-events: none;
     left: 0; top: 0; right: 0; bottom: 0;
   }
-  .term pre .cur.block::after { background: var(--ink); mix-blend-mode: difference; }
-  .term pre .cur.hollow::after { box-shadow: inset 0 0 0 1px var(--ink); }
-  .term pre .cur.bar::after { right: auto; width: 1px; background: var(--ink); }
-  .term pre .cur.underline::after { top: auto; height: 1px; background: var(--ink); }
+  .term pre .cur.block::after { background: var(--cursor); mix-blend-mode: difference; }
+  .term pre .cur.hollow::after { box-shadow: inset 0 0 0 1px var(--cursor); }
+  .term pre .cur.bar::after { right: auto; width: 1px; background: var(--cursor); }
+  .term pre .cur.underline::after { top: auto; height: 1px; background: var(--cursor); }
 
   .placeholder {
     color: var(--ink-faint); font-style: italic;
@@ -169,16 +196,28 @@ function b64ToBytes(b64) {
 
 // ----- color -------------------------------------------------------------- //
 
-// The 256-color palette: 16 base ANSI, a 6x6x6 cube, then a 24-step gray ramp.
-// Matches the standard xterm layout the tui crate's SGR encoder targets.
-const PALETTE = (() => {
-  const base = [
-    [0, 0, 0], [205, 0, 0], [0, 205, 0], [205, 205, 0],
-    [0, 0, 238], [205, 0, 205], [0, 205, 205], [229, 229, 229],
-    [127, 127, 127], [255, 0, 0], [0, 255, 0], [255, 255, 0],
-    [92, 92, 255], [255, 0, 255], [0, 255, 255], [255, 255, 255],
-  ];
-  const table = base.slice();
+// The terminal's 16 base ANSI colors mirror the user's ghostty themes
+// (~/.config/nix/ghostty/themes/custom-{light,dark}), so rendered output here
+// matches what they see in ghostty. Colors 16-255 are the theme-independent
+// xterm 6x6x6 cube and 24-step gray ramp that the tui crate's SGR encoder
+// targets. The whole table is rebuilt when the system flips light/dark.
+const ANSI_16 = {
+  light: [
+    [0, 0, 0], [219, 63, 57], [66, 147, 62], [133, 85, 4],
+    [50, 94, 238], [147, 0, 147], [14, 112, 174], [143, 144, 150],
+    [42, 44, 51], [219, 63, 57], [66, 147, 62], [133, 85, 4],
+    [50, 94, 238], [147, 0, 147], [14, 112, 174], [255, 255, 255],
+  ],
+  dark: [
+    [0, 0, 0], [243, 139, 168], [166, 227, 161], [249, 226, 175],
+    [137, 180, 250], [203, 166, 247], [148, 226, 213], [224, 216, 192],
+    [88, 91, 112], [243, 139, 168], [166, 227, 161], [249, 226, 175],
+    [137, 180, 250], [203, 166, 247], [148, 226, 213], [250, 240, 200],
+  ],
+};
+
+function buildPalette(base16) {
+  const table = base16.slice();
   const cube = [0, 95, 135, 175, 215, 255];
   for (let r = 0; r < 6; r++)
     for (let g = 0; g < 6; g++)
@@ -188,7 +227,16 @@ const PALETTE = (() => {
     table.push([v, v, v]);
   }
   return table;
-})();
+}
+
+const darkScheme = matchMedia("(prefers-color-scheme: dark)");
+let PALETTE = buildPalette(darkScheme.matches ? ANSI_16.dark : ANSI_16.light);
+// Repaint on a live OS theme switch so chrome (CSS tokens) and terminal
+// content (this palette) never disagree.
+darkScheme.addEventListener("change", () => {
+  PALETTE = buildPalette(darkScheme.matches ? ANSI_16.dark : ANSI_16.light);
+  render();
+});
 
 // Resolve an SGR color descriptor to a CSS color, or null for the terminal
 // default (which inherits the panel ink / background).


### PR DESCRIPTION
Redo the `tui` web dashboard to look minimal and still instead of the gradient/rounded/glow "AI dashboard" look.

## What changed
- **Flat**: drop the radial-gradient page background for a solid surface.
- **Square**: remove `border-radius` from the terminal cards (and the scrollbar thumb). A 1px hairline gives separation.
- **Still**: remove the card drop shadow, the `.term:hover` border reaction, the status-dot glow halos, and the dot transition. Nothing moves or lights up on hover.
- **Ghostty colors, light + dark**: every chrome token and the terminal's ANSI-16 palette come verbatim from the user's ghostty themes (`custom-light` / `custom-dark`), switched via `prefers-color-scheme`. The palette repaints on a live OS theme switch so chrome and rendered terminal output never disagree. Each card is a ghostty surface (`--panel` = the theme background) on a slightly darker page.
- **Berkeley Mono**: first in the mono stack, so the user's ghostty font is used when installed; falls through the system monospaces otherwise.

Pure styling change to `dashboard.html` (served via `include_str!`); no Rust or behavior change.

---
Made with AI (Claude, Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Ghostty-themed light/dark mode to the TUI dashboard
> - Introduces a dual light/dark design system in [dashboard.html](https://github.com/indexable-inc/index/pull/353/files#diff-74ca46061890da9053d5337766ed6e9f41b77ea2ad08928f93f790dede837d7e) using CSS custom properties, with a `@media (prefers-color-scheme: dark)` override replacing the previous dark-only token set.
> - Adds `ANSI_16` base color tables for both themes and a `buildPalette` function that constructs the full 256-color xterm palette from the theme-specific 16-color base.
> - The terminal color palette now selects the correct base at load time and rebuilds on live OS theme changes via a `matchMedia` listener.
> - Terminal cards switch to a flat, square style with hairline borders and no hover reaction; cursor and selection colors now reflect the active theme.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d119ca4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->