### PR TITLE
tui-dashboard: update terminal size on resize

### DIFF
--- a/packages/tui-dashboard-core/src/dashboard/hub.rs
+++ b/packages/tui-dashboard-core/src/dashboard/hub.rs
@@ -41,6 +41,8 @@ struct Slot {
     meta: LoroMap,
     screen: LoroText,
     alive: bool,
+    rows: i64,
+    cols: i64,
     cursor_row: i64,
     cursor_col: i64,
     cursor_visible: bool,
@@ -84,10 +86,7 @@ impl DocState {
                 meta.insert("command", frame.command.as_str())
                     .map_err(loro_err)?;
                 meta.insert("args", frame.args.as_str()).map_err(loro_err)?;
-                meta.insert("rows", i64::from(frame.rows))
-                    .map_err(loro_err)?;
-                meta.insert("cols", i64::from(frame.cols))
-                    .map_err(loro_err)?;
+                write_size(&meta, frame)?;
                 meta.insert("alive", frame.alive).map_err(loro_err)?;
                 write_cursor(&meta, frame)?;
                 write_exit(&meta, frame)?;
@@ -100,6 +99,8 @@ impl DocState {
                         meta,
                         screen,
                         alive: frame.alive,
+                        rows: i64::from(frame.rows),
+                        cols: i64::from(frame.cols),
                         cursor_row: i64::from(frame.cursor_row),
                         cursor_col: i64::from(frame.cursor_col),
                         cursor_visible: frame.cursor_visible,
@@ -113,6 +114,13 @@ impl DocState {
             if slot.alive != frame.alive {
                 slot.meta.insert("alive", frame.alive).map_err(loro_err)?;
                 slot.alive = frame.alive;
+            }
+            let rows = i64::from(frame.rows);
+            let cols = i64::from(frame.cols);
+            if slot.rows != rows || slot.cols != cols {
+                write_size(&slot.meta, frame)?;
+                slot.rows = rows;
+                slot.cols = cols;
             }
             let cursor_row = i64::from(frame.cursor_row);
             let cursor_col = i64::from(frame.cursor_col);
@@ -208,6 +216,15 @@ fn loro_err(source: impl std::fmt::Display) -> Error {
     Error::Dashboard {
         message: source.to_string(),
     }
+}
+
+/// Write a frame's terminal size into its meta map. One owner for the size keys
+/// so the insert and per-tick update paths cannot disagree.
+fn write_size(meta: &LoroMap, frame: &TerminalFrame) -> Result<()> {
+    meta.insert("rows", i64::from(frame.rows))
+        .map_err(loro_err)?;
+    meta.insert("cols", i64::from(frame.cols))
+        .map_err(loro_err)
 }
 
 /// Write a frame's cursor fields into its meta map. One owner for the cursor
@@ -347,6 +364,29 @@ mod tests {
         assert!(state.apply_scope("a", &[frame("1", "x")]).unwrap().is_none());
         // A screen change does produce a delta.
         assert!(state.apply_scope("a", &[frame("1", "y")]).unwrap().is_some());
+    }
+
+    /// A runtime resize must re-write `rows`/`cols` into the doc even when the
+    /// screen text is byte-identical. The hub once wrote size only on a
+    /// terminal's first appearance, so a size-only frame produced no delta: the
+    /// header froze at spawn-time size (e.g. "24×80") while the content reflowed
+    /// to the new geometry. Clients read size from the CRDT every render, so the
+    /// resize has to reach the doc, not just the cache.
+    #[test]
+    fn resize_updates_size() {
+        let mut state = DocState::new();
+        state.apply_scope("a", &[frame("1", "x")]).unwrap();
+
+        let mut resized = frame("1", "x");
+        resized.rows = 40;
+        resized.cols = 120;
+        assert!(state.apply_scope("a", &[resized]).unwrap().is_some());
+
+        let key = doc_key("a", "1");
+        let meta = &state.terminals[&key].meta;
+        let rows = meta.get("rows").unwrap().get_deep_value().into_i64().unwrap();
+        let cols = meta.get("cols").unwrap().get_deep_value().into_i64().unwrap();
+        assert_eq!((rows, cols), (40, 120));
     }
 
     /// Removing a scope that holds nothing is a no-op, not a spurious broadcast.


### PR DESCRIPTION
## Symptom

The dashboard header size label froze at a terminal's spawn-time geometry (e.g. "24×80") even after a runtime resize. The terminal content reflowed correctly to the new size, but the label never moved, so the two disagreed.

## Root cause

`DocState::apply_scope` in `packages/tui-dashboard-core/src/dashboard/hub.rs` wrote `rows`/`cols` into the Loro doc only on a terminal's first appearance. The per-tick reconcile diffed `alive`, `cursor_*`, `exit_code`, and `screen`, but never `rows`/`cols`. A resize publishes a new frame with updated `rows`/`cols`; when the screen text is unchanged, the apply produced no CRDT delta at all, so the stale size stayed in the doc. The frontend reads `rows`/`cols` from the CRDT every render, so it kept showing the spawn-time size.

## Fix

- Add a `write_size` helper next to `write_cursor`/`write_exit`, one owner for the `rows`/`cols` keys so the insert and update paths cannot disagree.
- Cache `rows`/`cols` on the `Slot` and initialize them at creation.
- In the per-tick update path, diff-and-write size the same way cursor fields are handled, so a size-only change now commits a delta.

## Test

`resize_updates_size` applies a frame at 24×80, then a frame with identical screen text at 40×120, asserts the second apply returns a delta (the core regression: a size-only change must produce one), and reads `rows`/`cols` back from the doc to confirm 40/120 reached the CRDT. It fails before the fix because the size-only frame yields no delta and the doc keeps the stale size.

`cargo test -p tui-dashboard-core`: 5 passed. `nix run .#lint`: clean.

---
Authored with AI (model: Claude Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update terminal size in CRDT metadata on resize in tui-dashboard
> - Adds `rows` and `cols` fields to the `Slot` struct in [hub.rs](https://github.com/indexable-inc/index/pull/354/files#diff-405a641658c98467fe3505534caeb636c8e1d2c753b41ebbe2f6ed59632c49e7) to cache the terminal size per slot.
> - Introduces a `write_size` helper that writes frame dimensions to the Loro metadata map, used on both slot creation and update.
> - On each `apply_scope` call, compares the incoming frame size against the cached values and writes an update if either dimension changed, producing a CRDT delta even when screen text is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4768b98.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->