### PR TITLE
docs: link ix.dev and refresh README scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,15 @@
   <!-- <a href="https://scorecard.dev/viewer/?uri=github.com/indexable-inc/index"><img src="https://api.scorecard.dev/projects/github.com/indexable-inc/index/badge" alt="OpenSSF Scorecard" /></a> -->
 </p>
 
+<p align="center">
+  <a href="https://ix.dev">ix.dev</a>
+</p>
+
 # Index
 
 `index` builds ready-to-run VM images from NixOS modules. Every image targets
-x86_64 Linux and ships as an OCI archive.
+x86_64 Linux and ships as an OCI archive. It is the open-source layer over the
+[ix](https://ix.dev) sandbox platform.
 
 Use it for runnable images and reusable service modules.
 

--- a/README.md
+++ b/README.md
@@ -15,17 +15,20 @@
 
 # Index
 
-`index` builds ready-to-run VM images from NixOS modules. Every image targets
-x86_64 Linux and ships as an OCI archive. It is the open-source layer over the
-[ix](https://ix.dev) sandbox platform.
+`index` is the open-source layer [ix](https://ix.dev) publishes on top of its
+closed-source VM primitives: ready-to-run OCI images, reusable NixOS service
+modules, agent and developer tooling, and the Nix library that builds them all.
 
-Use it for runnable images and reusable service modules.
+Every image targets x86_64 Linux and ships as an OCI archive. The same outputs
+are a library, so you can build your own images, import the helpers, or drive
+the bundled agent tools from a Python MCP server.
 
 ## Quick Check
 
 ```sh
-nix build .#minecraft
-nix run .#lint
+nix build .#minecraft   # realize one image closure
+nix run .#lint          # nixfmt, statix, deadnix, ast-grep
+nix flake show          # list every package, module, and check
 ```
 
 The first image build may be slow while Nix realizes the image closure. Later
@@ -34,13 +37,28 @@ substituters.
 
 ## What Is Here
 
-- [`images/`](images/) contains runnable systems.
-- [`modules/`](modules/) contains opt-in NixOS service modules.
-- [`examples/`](examples/) contains standalone consumer fleets, including a
-  daily Python scraper.
-- [`packages/`](packages/) contains repo-owned tools such as
+- [`images/`](images/) holds runnable NixOS systems packaged as OCI archives:
+  Minecraft servers, development environments, and a remote desktop.
+- [`modules/`](modules/) holds opt-in NixOS service modules, auto-discovered so
+  a new directory needs no registry edit.
+- [`packages/`](packages/) holds repo-owned tools, including the
+  [`mcp`](packages/mcp/) Python agent server, the [`tui`](packages/tui/) PTY
+  driver, [`semantic-search`](packages/semantic-search/), and
   [`llm-clippy`](packages/llm-clippy/).
-- [`lib/`](lib/) contains the shared helper API used by the repo and consumers.
+- [`lib/`](lib/) holds the shared helper and builder API used by the repo and by
+  consumers.
+- [`examples/`](examples/) holds standalone consumer fleets, including a daily
+  Python scraper.
+- [`site/`](site/) holds the public update log that tracks operator-facing
+  changes.
+
+## Agent Tooling
+
+The [`mcp`](packages/mcp/) package is a Python MCP server on a pinned
+interpreter. Sessions `import tui` to spawn and drive PTY-backed processes with
+full vt100 emulation, and `import semantic_search` for content-addressed code
+search, with no install step. It is how an agent reaches the same primitives
+this repo ships.
 
 ## Bad Fit If
 


### PR DESCRIPTION
Links the ix.dev website in the README header and reframes the README to match what the repo actually is now.

The old README sold `index` as just a VM-image builder. It has grown into the open-source layer over the ix platform: ~35 packages (the `mcp` Python agent server, the `tui` PTY driver, `semantic-search`, `llm-clippy`, and more), reusable NixOS modules, runnable images, and the shared Nix library.

## Changes
- Add an `ix.dev` link to the centered header block.
- Rewrite the intro to frame `index` as ix's OSS layer that is also a library and a Python MCP surface.
- Broaden "What Is Here" to surface `packages/`, `lib/`, and `site/` accurately.
- Add a short "Agent Tooling" section for the `mcp` package (`import tui`, `import semantic_search`).

## Related
The GitHub repo description and homepage were also updated out-of-band (description was the stale "ix-owned NixOS and image composition inputs"; homepage now points to ix.dev).

---
Made with AI (Claude Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh README to add ix.dev link and expand project scope documentation
> - Adds a centered link to [ix.dev](ix.dev) below the badges section in [README.md](https://github.com/indexable-inc/index/pull/355/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).
> - Rewrites the project overview to describe `index` as ix's open-source layer, covering OCI images, NixOS service modules, agent tooling, and the Nix library.
> - Expands the "What Is Here" section with descriptions of `images/`, `modules/`, `packages/` (listing `mcp`, `tui`, `semantic-search`, `llm-clippy`), `lib/`, `examples/`, and a new `site/` entry.
> - Adds a new "Agent Tooling" section describing the `mcp` Python MCP server and its runtime imports (`tui`, `semantic_search`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6972cca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->