### PR TITLE
tui-dashboard-core: introduce Resource sum + BrowserPage variant (ENG-1865 milestone 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +132,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "append-only-bytes"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac436601d6bdde674a0d7fb593e829ffe7b3387c351b356dd20e2d40f5bf3ee5"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +160,12 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "arref"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ccd462b64c3c72f1be8305905a85d85403d768e8690c9b8bd3b9009a5761679"
 
 [[package]]
 name = "askama"
@@ -228,6 +262,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -331,6 +374,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bitpacking"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,7 +425,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -524,7 +576,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -535,6 +587,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "code-tokenizer"
@@ -648,6 +709,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,12 +790,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -746,11 +837,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -790,6 +892,23 @@ dependencies = [
  "powerfmt",
  "serde_core",
 ]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -842,10 +961,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "ensure-cov"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33753185802e107b8fa907192af1f0eca13b1fb33327a59266d650fef29b2b4e"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "equivalent"
@@ -1061,6 +1234,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,6 +1256,20 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "generic-btree"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c1bce85c110ab718fd139e0cc89c51b63bd647b14a767e24bdfc77c83df79b"
+dependencies = [
+ "arref",
+ "heapless 0.9.3",
+ "itertools 0.11.0",
+ "loro-thunderdome",
+ "proc-macro2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -1159,6 +1361,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1403,46 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32 0.3.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1482,6 +1742,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.6.4",
+ "rand_xoshiro",
+ "serde",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1807,24 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1608,6 +1901,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,6 +1968,159 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "loro"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc16ee5fdda7bff6bbbd4ff276c31aa9747bc90ad1bdccf8f0da97cd2949c8a"
+dependencies = [
+ "enum-as-inner 0.6.1",
+ "generic-btree",
+ "loro-common",
+ "loro-delta",
+ "loro-internal",
+ "loro-kv-store",
+ "rustc-hash",
+ "tracing",
+]
+
+[[package]]
+name = "loro-common"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193e88dedf3bc07f3b25ec8bb609dd461349b26942e43933cb0f599bc09d9c5b"
+dependencies = [
+ "arbitrary",
+ "enum-as-inner 0.6.1",
+ "leb128",
+ "loro-rle",
+ "nonmax",
+ "rustc-hash",
+ "serde",
+ "serde_columnar",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "loro-delta"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eafa788a72c1cbf0b7dc08a862cd7cc31b96d99c2ef749cdc94c2330f9494d3"
+dependencies = [
+ "arrayvec",
+ "enum-as-inner 0.5.1",
+ "generic-btree",
+ "heapless 0.8.0",
+]
+
+[[package]]
+name = "loro-internal"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d42db22ea93c266d5b6ef09ba94af080b6a4d131942e9a28bfa6a218b312b5f"
+dependencies = [
+ "append-only-bytes",
+ "arref",
+ "bytes",
+ "either",
+ "ensure-cov",
+ "enum-as-inner 0.6.1",
+ "enum_dispatch",
+ "generic-btree",
+ "getrandom 0.2.17",
+ "im",
+ "itertools 0.12.1",
+ "leb128",
+ "loom",
+ "loro-common",
+ "loro-delta",
+ "loro-kv-store",
+ "loro-rle",
+ "loro_fractional_index",
+ "md5",
+ "nonmax",
+ "num",
+ "num-traits",
+ "once_cell",
+ "parking_lot",
+ "pest",
+ "pest_derive",
+ "postcard",
+ "pretty_assertions",
+ "rand 0.8.6",
+ "rustc-hash",
+ "serde",
+ "serde_columnar",
+ "serde_json",
+ "smallvec",
+ "thiserror 1.0.69",
+ "thread_local",
+ "tracing",
+ "wasm-bindgen",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "loro-kv-store"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18853eed186c39e0b9d541a1f847161ad05bcf366c412068c9d257d5d981a9b5"
+dependencies = [
+ "bytes",
+ "ensure-cov",
+ "loro-common",
+ "lz4_flex 0.11.6",
+ "once_cell",
+ "quick_cache",
+ "rustc-hash",
+ "tracing",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "loro-rle"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76400c3eea6bb39b013406acce964a8db39311534e308286c8d8721baba8ee20"
+dependencies = [
+ "append-only-bytes",
+ "num",
+ "smallvec",
+]
+
+[[package]]
+name = "loro-thunderdome"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3d053a135388e6b1df14e8af1212af5064746e9b87a06a345a7a779ee9695a"
+
+[[package]]
+name = "loro_fractional_index"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c8ea186958094052b971fe7e322a934b034c3bf62f0458ccea04fcd687ba1"
+dependencies = [
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+]
+
+[[package]]
 name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,9 +2137,27 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
+name = "lz4_flex"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matchit"
@@ -1704,6 +2174,12 @@ dependencies = [
  "autocfg",
  "rawpointer",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "measure_time"
@@ -1882,6 +2358,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,6 +2417,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2076,6 +2603,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2679,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless 0.7.17",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,6 +2713,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -2227,7 +2820,7 @@ version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -2257,6 +2850,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "quick_cache"
+version = "0.6.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c821816e9b928e20e92ed59bb3ac4aab321d16ca2316871c9fe7ca739cd477"
+dependencies = [
+ "ahash",
+ "equivalent",
+ "hashbrown 0.16.1",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2412,6 +3017,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,7 +3176,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -2609,6 +3223,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rusticata-macros"
@@ -2750,6 +3373,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2812,6 +3441,31 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_columnar"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a16e404f17b16d0273460350e29b02d76ba0d70f34afdc9a4fa034c97d6c6eb"
+dependencies = [
+ "itertools 0.11.0",
+ "postcard",
+ "serde",
+ "serde_columnar_derive",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "serde_columnar_derive"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45958fce4903f67e871fbf15ac78e289269b21ebd357d6fecacdba233629112e"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2950,6 +3604,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,6 +3633,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snafu"
@@ -2985,7 +3652,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2999,6 +3666,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -3120,11 +3796,11 @@ dependencies = [
  "fnv",
  "fs4",
  "htmlescape",
- "itertools",
+ "itertools 0.14.0",
  "levenshtein_automata",
  "log",
  "lru",
- "lz4_flex",
+ "lz4_flex 0.13.1",
  "measure_time",
  "memmap2",
  "once_cell",
@@ -3169,7 +3845,7 @@ checksum = "c57166f5bcfd478f370ab8445afb4678dce44801fa5ce5c451aaf8595583c5dc"
 dependencies = [
  "downcast-rs",
  "fastdivide",
- "itertools",
+ "itertools 0.14.0",
  "serde",
  "tantivy-bitpacker",
  "tantivy-common",
@@ -3221,7 +3897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2cfc3ac5164cbadc28965ffb145a8f47582a60ae5897859ad8d4316596c606"
 dependencies = [
  "futures-util",
- "itertools",
+ "itertools 0.14.0",
  "tantivy-bitpacker",
  "tantivy-common",
  "tantivy-fst",
@@ -3550,14 +4226,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3575,6 +4269,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tui-dashboard-core"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "loro",
+ "rmp-serde",
+ "serde",
+ "snafu",
+ "url",
+]
+
+[[package]]
 name = "tui-py"
 version = "0.1.0"
 dependencies = [
@@ -3584,6 +4290,12 @@ dependencies = [
  "pyo3-async-runtimes",
  "tui",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typeid"
@@ -3620,6 +4332,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"
@@ -3667,6 +4385,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4136,7 +4855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -4147,7 +4866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
  "syn 2.0.117",
@@ -4277,6 +4996,18 @@ dependencies = [
  "libc",
  "rustix 1.1.4",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "packages/oci-image-builder",
   "packages/repo-walker",
   "packages/tui",
+  "packages/tui-dashboard-core",
   "packages/tui-py",
 ]
 resolver = "3"

--- a/packages/tui-dashboard-core/Cargo.toml
+++ b/packages/tui-dashboard-core/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "tui-dashboard-core"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Typed MCP dashboard resource model plus a Loro-backed hub that retains per-producer history"
+
+[lints]
+workspace = true
+
+[dependencies]
+base64.workspace = true
+# CRDT document that retains the dashboard's edit history; the hub never trims
+# it, so browsers can time-travel over past resource states.
+loro = { version = "1", default-features = false }
+rmp-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
+snafu.workspace = true
+url = { workspace = true, features = ["serde"] }

--- a/packages/tui-dashboard-core/package.nix
+++ b/packages/tui-dashboard-core/package.nix
@@ -1,0 +1,4 @@
+{
+  id = "tui-dashboard-core";
+  inRustWorkspace = true;
+}

--- a/packages/tui-dashboard-core/src/hub.rs
+++ b/packages/tui-dashboard-core/src/hub.rs
@@ -1,0 +1,175 @@
+//! The hub: a Loro CRDT document that stores every producer's resources under
+//! its own scope and retains the edit history so browsers can time-travel.
+//!
+//! Each producer gets a Loro map keyed by its [`ProducerId`]. Inside that map,
+//! one entry per [`ResourceId`] holds the MessagePack-encoded [`Resource`].
+//! Encoding the typed sum keeps the document shape uniform across kinds while
+//! the typed boundary lives at the Rust API. The hub never trims history, so
+//! past resource states remain reachable through the document's version graph.
+
+use loro::{LoroDoc, LoroValue, ValueOrContainer};
+use snafu::{ResultExt, Snafu};
+
+use crate::render::{RenderedResource, render};
+use crate::resource::{Resource, ResourceId};
+
+/// Identifier for one producer's scope inside the hub document.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ProducerId(String);
+
+impl ProducerId {
+    #[must_use]
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A producer's latest view of every resource it owns.
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub struct ProducerSnapshot {
+    pub resources: Vec<Resource>,
+}
+
+/// Failures applying or reading a producer snapshot against the hub document.
+#[derive(Debug, Snafu)]
+pub enum SnapshotError {
+    #[snafu(display("failed to encode resource `{id}` for the hub document"))]
+    Encode {
+        id: ResourceId,
+        source: rmp_serde::encode::Error,
+    },
+    #[snafu(display("failed to apply resource `{id}` to the hub document"))]
+    Apply {
+        id: ResourceId,
+        source: loro::LoroError,
+    },
+    #[snafu(display("failed to decode the resource at key `{key}` from the hub document"))]
+    Decode {
+        key: String,
+        source: rmp_serde::decode::Error,
+    },
+}
+
+/// The retained-history store backing the dashboard.
+pub struct Hub {
+    doc: LoroDoc,
+}
+
+impl Hub {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            doc: LoroDoc::new(),
+        }
+    }
+
+    /// Apply a producer's snapshot under its own scope and commit it as one
+    /// change, so the document's history gains a single time-travel point per
+    /// snapshot.
+    pub fn apply_snapshot(
+        &self,
+        producer: &ProducerId,
+        snapshot: &ProducerSnapshot,
+    ) -> Result<(), SnapshotError> {
+        let scope = self.doc.get_map(producer.as_str());
+        for resource in &snapshot.resources {
+            let id = resource.id();
+            let bytes = rmp_serde::to_vec(resource).context(EncodeSnafu { id: id.clone() })?;
+            scope
+                .insert(id.as_str(), bytes)
+                .context(ApplySnafu { id: id.clone() })?;
+        }
+        self.doc.commit();
+        Ok(())
+    }
+
+    /// Decode every resource currently stored under a producer's scope, ordered
+    /// by resource key for a stable render.
+    pub fn resources(&self, producer: &ProducerId) -> Result<Vec<Resource>, SnapshotError> {
+        let scope = self.doc.get_map(producer.as_str());
+        let mut keys = scope.keys().map(|key| key.to_string()).collect::<Vec<_>>();
+        keys.sort();
+
+        let mut resources = Vec::with_capacity(keys.len());
+        for key in keys {
+            let Some(ValueOrContainer::Value(LoroValue::Binary(bytes))) = scope.get(&key) else {
+                continue;
+            };
+            let resource = rmp_serde::from_slice(bytes.as_slice()).context(DecodeSnafu { key })?;
+            resources.push(resource);
+        }
+        Ok(resources)
+    }
+
+    /// Render every resource under a producer's scope for the dashboard shell.
+    pub fn render(&self, producer: &ProducerId) -> Result<Vec<RenderedResource>, SnapshotError> {
+        Ok(self.resources(producer)?.iter().map(render).collect())
+    }
+}
+
+impl Default for Hub {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::{Hub, ProducerId, ProducerSnapshot};
+    use crate::resource::{
+        BrowserPage, ImageMediaType, Resource, ResourceId, ResourceKind, Screenshot, TerminalFrame,
+        TerminalSize,
+    };
+
+    #[test]
+    fn round_trips_mixed_resources_through_loro_and_renders_each_kind() {
+        let hub = Hub::new();
+        let producer = ProducerId::new("agent-0");
+
+        let terminal = Resource::Terminal(TerminalFrame {
+            id: ResourceId::new("term-1"),
+            title: "shell".to_owned(),
+            size: TerminalSize { cols: 80, rows: 24 },
+            rows: vec!["$ echo hi".to_owned(), "hi".to_owned()],
+        });
+        let page = Resource::BrowserPage(BrowserPage {
+            id: ResourceId::new("page-1"),
+            url: Url::parse("https://example.com/docs").expect("valid url"),
+            screenshot: Screenshot {
+                media_type: ImageMediaType::Png,
+                bytes: vec![1, 2, 3, 4],
+            },
+            dom_text: Some("Example".to_owned()),
+        });
+
+        let snapshot = ProducerSnapshot {
+            resources: vec![terminal.clone(), page.clone()],
+        };
+        hub.apply_snapshot(&producer, &snapshot).expect("apply");
+
+        // Crossing the Loro boundary and decoding back must preserve both kinds.
+        let stored = hub.resources(&producer).expect("read");
+        assert_eq!(stored.len(), 2);
+        assert!(stored.contains(&terminal));
+        assert!(stored.contains(&page));
+
+        let rendered = hub.render(&producer).expect("render");
+        let kinds = rendered.iter().map(|r| r.kind).collect::<Vec<_>>();
+        assert!(kinds.contains(&ResourceKind::Terminal));
+        assert!(kinds.contains(&ResourceKind::BrowserPage));
+
+        let page_fragment = rendered
+            .iter()
+            .find(|r| r.kind == ResourceKind::BrowserPage)
+            .expect("browser page fragment");
+        assert!(page_fragment.html.contains("data:image/png;base64,"));
+        assert!(page_fragment.html.contains("https://example.com/docs"));
+    }
+}

--- a/packages/tui-dashboard-core/src/lib.rs
+++ b/packages/tui-dashboard-core/src/lib.rs
@@ -1,0 +1,28 @@
+//! Typed resource model and Loro-backed hub for the MCP dashboard.
+//!
+//! A [`Hub`] holds a Loro CRDT document and stores each producer's resources
+//! under its own scope, retaining history for time-travel. Producers publish a
+//! [`ProducerSnapshot`] of typed [`Resource`] values; [`render`] turns each
+//! resource into an HTML fragment the dashboard shell can slot in and update in
+//! place, so a new browser page auto-appears the way a terminal does today.
+//!
+//! This is milestone 1 of ENG-1865: the typed [`Resource`] sum behind the old
+//! single terminal kind, plus the [`Resource::BrowserPage`] variant and a
+//! per-kind renderer. Future `Image`, `Table`, `LogStream`, and `Text` kinds
+//! attach as new variants.
+
+#![allow(
+    clippy::missing_errors_doc,
+    reason = "fallible hub methods document their failures through the typed `SnapshotError` enum"
+)]
+
+mod hub;
+mod render;
+mod resource;
+
+pub use hub::{Hub, ProducerId, ProducerSnapshot, SnapshotError};
+pub use render::{RenderedResource, render};
+pub use resource::{
+    BrowserPage, ImageMediaType, Resource, ResourceId, ResourceKind, Screenshot, TerminalFrame,
+    TerminalSize,
+};

--- a/packages/tui-dashboard-core/src/render.rs
+++ b/packages/tui-dashboard-core/src/render.rs
@@ -1,0 +1,98 @@
+//! Per-kind rendering of a [`Resource`] into a self-contained HTML fragment.
+//!
+//! The dashboard shell slots each fragment into a container keyed by
+//! [`ResourceId`], so a new browser page auto-appears the same way a new
+//! terminal does today. [`render`] matches every kind exhaustively: a future
+//! variant cannot be added without giving it a fragment.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+
+use crate::resource::{BrowserPage, Resource, ResourceId, ResourceKind, TerminalFrame};
+
+/// A resource rendered to an HTML fragment plus the metadata the shell needs
+/// to place it and update it in place.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderedResource {
+    pub id: ResourceId,
+    pub kind: ResourceKind,
+    pub title: String,
+    pub html: String,
+}
+
+/// Render one resource for the dashboard.
+#[must_use]
+pub fn render(resource: &Resource) -> RenderedResource {
+    match resource {
+        Resource::Terminal(frame) => render_terminal(frame),
+        Resource::BrowserPage(page) => render_browser_page(page),
+    }
+}
+
+fn render_terminal(frame: &TerminalFrame) -> RenderedResource {
+    let body = frame
+        .rows
+        .iter()
+        .map(|row| escape_html(row))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let html = format!(
+        "<pre class=\"resource resource--{slug}\" data-resource-id=\"{id}\">{body}</pre>",
+        slug = ResourceKind::Terminal.slug(),
+        id = escape_html(frame.id.as_str()),
+    );
+    RenderedResource {
+        id: frame.id.clone(),
+        kind: ResourceKind::Terminal,
+        title: frame.title.clone(),
+        html,
+    }
+}
+
+fn render_browser_page(page: &BrowserPage) -> RenderedResource {
+    let data_url = format!(
+        "data:{};base64,{}",
+        page.screenshot.media_type.as_mime(),
+        STANDARD.encode(&page.screenshot.bytes),
+    );
+    let href = escape_html(page.url.as_str());
+    let caption = page
+        .dom_text
+        .as_deref()
+        .map(escape_html)
+        .map_or_else(String::new, |text| {
+            format!("<figcaption class=\"resource__text\">{text}</figcaption>")
+        });
+    let html = format!(
+        "<figure class=\"resource resource--{slug}\" data-resource-id=\"{id}\">\
+<img src=\"{data_url}\" alt=\"Screenshot of {href}\">\
+<a class=\"resource__url\" href=\"{href}\">{href}</a>\
+{caption}</figure>",
+        slug = ResourceKind::BrowserPage.slug(),
+        id = escape_html(page.id.as_str()),
+    );
+    RenderedResource {
+        id: page.id.clone(),
+        kind: ResourceKind::BrowserPage,
+        title: page.url.host_str().unwrap_or(page.url.as_str()).to_owned(),
+        html,
+    }
+}
+
+/// Escape the five characters that change meaning inside HTML text and
+/// double-quoted attribute values. Producer-supplied titles, URLs, and DOM
+/// text are untrusted, so every interpolated string passes through here.
+fn escape_html(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}

--- a/packages/tui-dashboard-core/src/resource.rs
+++ b/packages/tui-dashboard-core/src/resource.rs
@@ -1,0 +1,142 @@
+//! The typed resource sum the dashboard knows how to store and render.
+//!
+//! Before this milestone the only resource was a terminal frame. The sum sits
+//! behind that single kind so producers can publish other MCP resource kinds
+//! through one channel. Two kinds are realized here; the RFC leaves room for
+//! `Image`, `Table`, `LogStream`, and `Text` kinds. Add each as a new
+//! [`Resource`] variant and the renderer's exhaustive match forces a matching
+//! per-kind branch rather than a silent fallthrough.
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+/// Stable identifier for one resource within a single producer's scope.
+///
+/// Wrapping the string keeps callers from passing an arbitrary label where a
+/// resource key is expected, and gives the hub one place to change the key
+/// encoding later.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ResourceId(String);
+
+impl ResourceId {
+    #[must_use]
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ResourceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// One MCP resource published to the dashboard.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Resource {
+    /// A rendered terminal screen: the only kind before this milestone.
+    Terminal(TerminalFrame),
+    /// A captured browser page with a screenshot and optional extracted text.
+    BrowserPage(BrowserPage),
+}
+
+impl Resource {
+    /// The resource's identifier, regardless of kind.
+    #[must_use]
+    pub const fn id(&self) -> &ResourceId {
+        match self {
+            Self::Terminal(frame) => &frame.id,
+            Self::BrowserPage(page) => &page.id,
+        }
+    }
+
+    /// The lightweight discriminant the dashboard uses to slot a resource into
+    /// the right per-kind container.
+    #[must_use]
+    pub const fn kind(&self) -> ResourceKind {
+        match self {
+            Self::Terminal(_) => ResourceKind::Terminal,
+            Self::BrowserPage(_) => ResourceKind::BrowserPage,
+        }
+    }
+}
+
+/// The set of realized resource kinds. New [`Resource`] variants add a member
+/// here so the dashboard shell can group and style them without inspecting the
+/// full payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ResourceKind {
+    Terminal,
+    BrowserPage,
+}
+
+impl ResourceKind {
+    /// Stable slug used in CSS classes and `data-` attributes.
+    #[must_use]
+    pub const fn slug(self) -> &'static str {
+        match self {
+            Self::Terminal => "terminal",
+            Self::BrowserPage => "browser-page",
+        }
+    }
+}
+
+/// A rendered terminal screen decoded to text, one entry per row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalFrame {
+    pub id: ResourceId,
+    pub title: String,
+    pub size: TerminalSize,
+    pub rows: Vec<String>,
+}
+
+/// Terminal grid dimensions in character cells.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalSize {
+    pub cols: u16,
+    pub rows: u16,
+}
+
+/// A captured browser page: where it was, what it looked like, and optionally
+/// the extracted text for search and accessibility.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BrowserPage {
+    pub id: ResourceId,
+    pub url: Url,
+    pub screenshot: Screenshot,
+    /// Extracted DOM or text dump when the producer captured one.
+    pub dom_text: Option<String>,
+}
+
+/// Screenshot bytes tagged with their media type so the renderer can emit a
+/// correct `data:` URL without sniffing the payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Screenshot {
+    pub media_type: ImageMediaType,
+    pub bytes: Vec<u8>,
+}
+
+/// Image encodings a producer may attach to a [`BrowserPage`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ImageMediaType {
+    Png,
+    Jpeg,
+    Webp,
+}
+
+impl ImageMediaType {
+    /// The IANA media type string for a `data:` URL or `Content-Type` header.
+    #[must_use]
+    pub const fn as_mime(self) -> &'static str {
+        match self {
+            Self::Png => "image/png",
+            Self::Jpeg => "image/jpeg",
+            Self::Webp => "image/webp",
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Milestone 1 of ENG-1865 (generalized, time-travelable MCP resource dashboard). Introduces a typed `Resource` sum behind what used to be a single terminal kind, adds the `BrowserPage` variant, and a per-kind renderer so browser pages auto-appear the way terminals do.

New crate `packages/tui-dashboard-core`:

- `Resource` enum with `Terminal(TerminalFrame)` and `BrowserPage(BrowserPage)`. `BrowserPage` carries a typed `Url`, a `Screenshot { media_type, bytes }`, and optional `dom_text`. Typed `ResourceId` / `ResourceKind` boundaries instead of attrs-shaped blobs. Future `Image` / `Table` / `LogStream` / `Text` kinds attach as new variants; the renderer's exhaustive match forces a per-kind branch.
- `render(&Resource) -> RenderedResource`: per-kind HTML fragment plus the `ResourceId` / `ResourceKind` / title the dashboard shell needs to slot it in and update in place. Producer-supplied strings pass through HTML escaping; screenshots become base64 `data:` URLs.
- `Hub` holding a `loro::LoroDoc`. `apply_snapshot` writes each producer's `ProducerSnapshot { resources }` under its own Loro map scope (one MessagePack-encoded `Resource` per `ResourceId`) and commits once per snapshot, so history is retained for time-travel and never trimmed. `resources` / `render` read back from the document.

## Grounding path

Path **(c): no such crate existed.** The RFC cites `packages/tui-dashboard-core` with `serve_hub` / `ProducerSnapshot` / `TerminalFrame`, but a repo-wide search found none of those symbols and no Loro usage anywhere. The closest crates (`packages/tui`, a PTY terminal library, and `packages/nix-web-monitor/server`, a build monitor) own unrelated domains. So this scaffolds the minimal crate the RFC describes (Hub holding a Loro doc, `ProducerSnapshot`, typed `Resource` sum, per-kind render) and wires it into the cargo workspace. SSE/`serve_hub` wiring is intentionally left for a later milestone; this milestone is the typed resource boundary.

## Verified

- `cargo check -p tui-dashboard-core` - clean
- `cargo test -p tui-dashboard-core` - 1 passed (round-trips a terminal and a browser page through the Loro document and asserts both kinds render)
- `cargo clippy -p tui-dashboard-core --all-targets` - clean under the workspace `all` + `pedantic` + `nursery` + `cargo` deny gates
- `cargo fmt -p tui-dashboard-core -- --check` - clean


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Resource` sum type and `BrowserPage` variant to new `tui-dashboard-core` crate
> Introduces the `tui-dashboard-core` crate ([Cargo.toml](https://github.com/indexable-inc/index/pull/363/files#diff-b67e63a930fb6c68f8e5a6f316ebe042c547a90a8a29493447bc0488f6df1d7c)) as the foundation for milestone 1 of a generalized dashboard supporting multiple resource kinds.
>
> - Defines a `Resource` enum in [resource.rs](https://github.com/indexable-inc/index/pull/363/files#diff-f038fe8704e1dc3816946d2fbf300148c10768059e99f7d133ae9f0c2a60d6bb) with `Terminal(TerminalFrame)` and `BrowserPage(BrowserPage)` variants, replacing the previous terminal-only model with a typed sum type.
> - Adds `BrowserPage` struct carrying a URL, `Screenshot` (raw bytes + `ImageMediaType`), and optional extracted DOM text.
> - Implements per-kind HTML renderers in [render.rs](https://github.com/indexable-inc/index/pull/363/files#diff-1b13c007a9ad4eb20251408c051048bbb24f423bffe19c9fc9417975d5aa03e2): terminals render as escaped `<pre>` blocks; browser pages render as `<figure>` elements with base64-embedded screenshots and safe-escaped URLs.
> - Adds a `Hub` in [hub.rs](https://github.com/indexable-inc/index/pull/363/files#diff-021dda81299a3f4afc54d083917d1a8b8a9df55a2cf5b167561cc80471b8fea6) backed by a Loro CRDT document that stores `ProducerSnapshot` resources as MessagePack-encoded binary values and exposes `apply_snapshot`, `resources`, and `render` methods.
>
> #### 🖇️ Linked Issues
> Implements milestone 1 of [ENG-1865](https://linear.app/indexable/issue/ENG-1865), which tracks generalizing the dashboard from terminal-only to a typed multi-kind resource surface with Loro-retained history.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5afcfc3. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->