### PR TITLE
mcp: harden the python session for unattended agent use

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -228,6 +228,31 @@ let
 
         mkdir -p "$out"
       '';
+  sessionSubprocessStdin =
+    pkgs.runCommand "ix-mcp-session-subprocess-stdin"
+      {
+        nativeBuildInputs = [ package ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+
+        # A child spawned inside a session inherits fd 0. The worker speaks
+        # JSON-RPC over its own stdin, so an inherited fd 0 pointing at that pipe
+        # lets a stdin-reading child (a path-less `cat`/`rg`) steal the protocol
+        # channel and hang the session forever. The worker detaches fd 0 to
+        # /dev/null, so `cat` with no path reads EOF and returns at once. The
+        # timeout turns a regression into a failure instead of a hung build.
+        timeout 60 ix-mcp exec 'import subprocess; print("cat-rc", subprocess.run(["cat"], capture_output=True, text=True).returncode)' >stdout 2>stderr
+        if ! grep -q '^cat-rc 0$' stdout; then
+          echo "session subprocess inherited the RPC stdin (hang regression):" >&2
+          cat stdout stderr >&2
+          exit 1
+        fi
+
+        mkdir -p "$out"
+      '';
 in
 package.overrideAttrs (old: {
   passthru =
@@ -241,6 +266,7 @@ package.overrideAttrs (old: {
           sessionVenv
           tuiBundled
           semanticSearchBundled
+          sessionSubprocessStdin
           ;
       };
     };

--- a/packages/mcp/src/python_worker.py
+++ b/packages/mcp/src/python_worker.py
@@ -16,6 +16,12 @@ from typing import Any
 # balloon one response. The Rust side enforces the same ceiling.
 MAX_IMAGES = 8
 
+# Cap on characters returned per text field (stdout, stderr, result). A cell
+# that prints a large file or reprs a huge object would otherwise stream
+# straight into the caller's context window. Truncation is explicit: the marker
+# names the dropped count so a clipped field never reads as complete.
+MAX_OUTPUT_CHARS = 100_000
+
 # Compile every snippet with this flag so `await` is legal at the top level.
 # Without it, `await x` outside a function raises SyntaxError. CPython's own
 # `python -m asyncio` REPL drives top-level await the same way: compile with the
@@ -112,11 +118,17 @@ class PythonSession:
 
         return {
             "ok": ok,
-            "stdout": stdout.getvalue(),
-            "stderr": stderr.getvalue(),
-            "result": value,
+            "stdout": _truncate(stdout.getvalue()),
+            "stderr": _truncate(stderr.getvalue()),
+            "result": _truncate(value),
             "images": self._collect_images(),
         }
+
+
+def _truncate(text: str, limit: int = MAX_OUTPUT_CHARS) -> str:
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}\n... [ix-mcp truncated {len(text) - limit} chars]"
 
 
 def _object_png(obj: object) -> dict[str, str] | None:

--- a/packages/mcp/src/python_worker.py
+++ b/packages/mcp/src/python_worker.py
@@ -6,6 +6,7 @@ import base64
 import contextlib
 import io
 import json
+import os
 import sys
 import traceback
 from collections.abc import Callable
@@ -185,8 +186,18 @@ def _matplotlib_pngs() -> list[dict[str, str]]:
 
 
 def main() -> None:
+    # Detach the JSON-RPC channel from fd 0 before any session code runs. The
+    # Rust server talks to this worker over stdin/stdout, but a child process
+    # spawned from a session (subprocess.run([...])) inherits fd 0, so a
+    # path-less `rg`/`cat`/`grep` would read this RPC pipe and block the whole
+    # session forever. Read requests from a dup and point fd 0 at /dev/null so
+    # inherited stdin returns EOF immediately instead of stealing the pipe.
+    rpc_in = os.fdopen(os.dup(sys.stdin.fileno()), "r", encoding="utf-8")
+    with open(os.devnull, "rb") as devnull:
+        os.dup2(devnull.fileno(), sys.stdin.fileno())
+
     session = PythonSession()
-    for line in sys.stdin:
+    for line in rpc_in:
         response = handle_request(session, line)
         sys.stdout.write(json.dumps(response) + "\n")
         sys.stdout.flush()


### PR DESCRIPTION
Hardens the `ix-mcp` Python session against the failure modes a tool-restricted ("code mode") agent hits when the session is its only shell. All three came out of a benchmark run where an agent drove a real task with `Bash`/`Glob`/`Grep` denied.

- **Detach the worker's stdin.** The Rust server speaks JSON-RPC to the worker over stdin/stdout, and a child process spawned in a session inherits fd 0. A path-less `rg`/`cat`/`grep` then read the RPC pipe and hung the whole session until killed. `main()` now reads requests from a dup of fd 0 and points fd 0 at `/dev/null`, so inherited stdin returns EOF immediately.
- **Bound per-call text output.** `stdout`, `stderr`, and the eval result were returned unbounded, so one cell printing a large file streamed straight into the caller's context window. Each field is capped at 100k chars with an explicit truncation marker, mirroring the existing `MAX_IMAGES` ceiling.
- **Regression test.** A new `passthru.tests.sessionSubprocessStdin` asserts a path-less `cat` inside a session returns rc 0 instead of hanging, with a build timeout so a regression fails loudly.

Verified locally on the built binary: the path-less subprocess returns at once (`cat-rc 0`), and a 150k-char print comes back truncated with the marker. Could not run `nix run .#lint` or the package tests on this host (aarch64; the package targets x86_64), so CI is the gate for those.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden MCP Python worker stdin handling and truncate large execution outputs
> - Detaches fd 0 to `/dev/null` in [python_worker.py](https://github.com/indexable-inc/index/pull/364/files#diff-7b8e5b0bdf4c09edaf2161e0febc9542d3e5e3b12a8d6f3f3525437b7e0b1710) before the RPC loop starts, so child processes spawned inside a session see EOF on stdin instead of blocking on the JSON-RPC pipe.
> - Adds a `_truncate()` helper that caps stdout, stderr, and result values at 100,000 characters, appending a `... [ix-mcp truncated N chars]` marker when the limit is exceeded.
> - Adds a build-time test (`ix-mcp-session-subprocess-stdin`) in [default.nix](https://github.com/indexable-inc/index/pull/364/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) that verifies a subprocess (`cat`) exits 0 (stdin detached) rather than hanging.
> - Behavioral Change: execution responses that previously returned unbounded output will now be silently truncated at 100,000 characters.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5db3df5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->