### PR TITLE
AGENTS: restore why-dag-runner rationale section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,6 +395,40 @@ make the safe path harder to see.
 When adding a non-obvious workaround, policy exception, or operational guard,
 put the reason near the choice and cite a durable source when one exists.
 
+## Why `dag-runner` (and not `process-compose` or `devenv-tasks`)
+
+The repo-owned [`dag-runner`](packages/dag-runner/) is the task runner that
+powers `nix run .#health-checks` and is the planned replacement for the
+sequential per-node loops in [`ix-fleet`](packages/ix-fleet/src/ix_fleet/__init__.py)
+(`cmd_up`, `cmd_switch`, `cmd_replace`). It exists despite the
+ecosystem-already-provides rule because neither upstream candidate fits the use
+case cleanly.
+
+`process-compose` is a long-running supervisor whose default TUI takes over the
+alt-screen and clears it on exit, so a fast failure renders as a silent no-op in
+scrollback. Inline-progress support was requested upstream and rejected
+([F1bonacc1/process-compose#362](https://github.com/F1bonacc1/process-compose/issues/362)).
+`dag-runner` uses inline `indicatif` spinners that stay in scrollback after a
+run, plus an `--output json` NDJSON event stream, so failures remain visible
+and machine-readable.
+
+`devenv-tasks` has the right interactive UX shape, but its task spec is part of
+devenv's internal module interface rather than a standalone schema we can pin,
+and the binary is not packaged in `nixpkgs` independently of the devenv flake.
+Adopting it as an orchestrator would couple us to devenv's release cycle for a
+tool that needs to own a small, stable JSON contract.
+
+The switch landed in
+[`d9e2fa1`](https://github.com/indexable-inc/index/commit/d9e2fa1) ("lib: add
+dag-runner and switch nix run .#health-checks to use it"). Lifecycle scripts
+per example (rm-then-up-then-rm) were unchanged; only the orchestrator swapped.
+The JSON spec is a flat map of `{ name → { command, depends_on, ... } }` owned
+by this repo, documented in [`packages/dag-runner/README.md`](packages/dag-runner/README.md).
+
+If a third consumer arrives needing something dag-runner does not, extend the
+runner. Pulling in `process-compose` or `devenv-tasks` alongside it for "the
+part dag-runner does not do" would defeat the consolidation.
+
 ## User-facing commands
 
 Keep protocol emitters separate from product workflow code. Workflows should

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,6 +395,40 @@ make the safe path harder to see.
 When adding a non-obvious workaround, policy exception, or operational guard,
 put the reason near the choice and cite a durable source when one exists.
 
+## Why `dag-runner` (and not `process-compose` or `devenv-tasks`)
+
+The repo-owned [`dag-runner`](packages/dag-runner/) is the task runner that
+powers `nix run .#health-checks` and is the planned replacement for the
+sequential per-node loops in [`ix-fleet`](packages/ix-fleet/src/ix_fleet/__init__.py)
+(`cmd_up`, `cmd_switch`, `cmd_replace`). It exists despite the
+ecosystem-already-provides rule because neither upstream candidate fits the use
+case cleanly.
+
+`process-compose` is a long-running supervisor whose default TUI takes over the
+alt-screen and clears it on exit, so a fast failure renders as a silent no-op in
+scrollback. Inline-progress support was requested upstream and rejected
+([F1bonacc1/process-compose#362](https://github.com/F1bonacc1/process-compose/issues/362)).
+`dag-runner` uses inline `indicatif` spinners that stay in scrollback after a
+run, plus an `--output json` NDJSON event stream, so failures remain visible
+and machine-readable.
+
+`devenv-tasks` has the right interactive UX shape, but its task spec is part of
+devenv's internal module interface rather than a standalone schema we can pin,
+and the binary is not packaged in `nixpkgs` independently of the devenv flake.
+Adopting it as an orchestrator would couple us to devenv's release cycle for a
+tool that needs to own a small, stable JSON contract.
+
+The switch landed in
+[`d9e2fa1`](https://github.com/indexable-inc/index/commit/d9e2fa1) ("lib: add
+dag-runner and switch nix run .#health-checks to use it"). Lifecycle scripts
+per example (rm-then-up-then-rm) were unchanged; only the orchestrator swapped.
+The JSON spec is a flat map of `{ name → { command, depends_on, ... } }` owned
+by this repo, documented in [`packages/dag-runner/README.md`](packages/dag-runner/README.md).
+
+If a third consumer arrives needing something dag-runner does not, extend the
+runner. Pulling in `process-compose` or `devenv-tasks` alongside it for "the
+part dag-runner does not do" would defeat the consolidation.
+
 ## User-facing commands
 
 Keep protocol emitters separate from product workflow code. Workflows should

--- a/agents-md/sections/08b-why-dag-runner.md
+++ b/agents-md/sections/08b-why-dag-runner.md
@@ -1,0 +1,33 @@
+## Why `dag-runner` (and not `process-compose` or `devenv-tasks`)
+
+The repo-owned [`dag-runner`](packages/dag-runner/) is the task runner that
+powers `nix run .#health-checks` and is the planned replacement for the
+sequential per-node loops in [`ix-fleet`](packages/ix-fleet/src/ix_fleet/__init__.py)
+(`cmd_up`, `cmd_switch`, `cmd_replace`). It exists despite the
+ecosystem-already-provides rule because neither upstream candidate fits the use
+case cleanly.
+
+`process-compose` is a long-running supervisor whose default TUI takes over the
+alt-screen and clears it on exit, so a fast failure renders as a silent no-op in
+scrollback. Inline-progress support was requested upstream and rejected
+([F1bonacc1/process-compose#362](https://github.com/F1bonacc1/process-compose/issues/362)).
+`dag-runner` uses inline `indicatif` spinners that stay in scrollback after a
+run, plus an `--output json` NDJSON event stream, so failures remain visible
+and machine-readable.
+
+`devenv-tasks` has the right interactive UX shape, but its task spec is part of
+devenv's internal module interface rather than a standalone schema we can pin,
+and the binary is not packaged in `nixpkgs` independently of the devenv flake.
+Adopting it as an orchestrator would couple us to devenv's release cycle for a
+tool that needs to own a small, stable JSON contract.
+
+The switch landed in
+[`d9e2fa1`](https://github.com/indexable-inc/index/commit/d9e2fa1) ("lib: add
+dag-runner and switch nix run .#health-checks to use it"). Lifecycle scripts
+per example (rm-then-up-then-rm) were unchanged; only the orchestrator swapped.
+The JSON spec is a flat map of `{ name → { command, depends_on, ... } }` owned
+by this repo, documented in [`packages/dag-runner/README.md`](packages/dag-runner/README.md).
+
+If a third consumer arrives needing something dag-runner does not, extend the
+runner. Pulling in `process-compose` or `devenv-tasks` alongside it for "the
+part dag-runner does not do" would defeat the consolidation.

--- a/lib/agents-md.nix
+++ b/lib/agents-md.nix
@@ -19,6 +19,7 @@ let
     (section "rustStyle" "06-rust-style.md")
     (section "pythonStyle" "07-python-style.md")
     (section "saneDefaults" "08-sane-defaults.md")
+    (section "whyDagRunner" "08b-why-dag-runner.md")
     (section "userFacingCommands" "08a-user-facing-commands.md")
     (section "nixPhilosophy" "09-nix-philosophy.md")
     (section "moduleConventions" "10-module-conventions.md")
@@ -70,6 +71,7 @@ let
       "intro"
       "indexGitPush"
       "siteUpdates"
+      "whyDagRunner"
       "moduleConventions"
       "imageConventions"
       "layout"


### PR DESCRIPTION
## Summary

`packages/dag-runner/README.md` links to `AGENTS.md#why-dag-runner-and-not-process-compose-or-devenv-tasks`, but the rendered file had no such heading. This restores the section.

- Adds `agents-md/sections/08b-why-dag-runner.md` and registers it in `lib/agents-md.nix` between `saneDefaults` and `userFacingCommands` (also added to `profiles.index` since the content is ix/images-specific).
- Regenerates `AGENTS.md` and `CLAUDE.md` via `nix run .#agents-md -- --write`.
- Content tracks the rationale originally captured in `d9e2fa1` (when dag-runner replaced the `process-compose` wrapper for `nix run .#health-checks`), with claims pared back to what the current tree can verify. Drops the historical "~400 lines of Rust" line because the runner is now ~970 LOC after `timeout`, output streaming, Ctrl-C cancellation, and `--only` landed.

The README link anchor is unchanged; the new heading's GFM slug matches it verbatim.

## Test plan

- [x] `nix run .#agents-md -- --check` is clean on the branch.
- [ ] After merge, click the link from `packages/dag-runner/README.md` and confirm it lands on the new heading.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore `why-dag-runner` rationale section to agent documentation
> Adds back a section explaining the choice of `dag-runner` over `process-compose` and `devenv-tasks` to both [AGENTS.md](https://github.com/indexable-inc/index/pull/366/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) and [CLAUDE.md](https://github.com/indexable-inc/index/pull/366/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7). The section is sourced from [08b-why-dag-runner.md](https://github.com/indexable-inc/index/pull/366/files#diff-4c9f33ed55a843228a554846e5f75ce60061c4359e3503ae9a982aa77ad79df4) and registered in [lib/agents-md.nix](https://github.com/indexable-inc/index/pull/366/files#diff-6a7d12ea0130077c77675709c58114291063aabb1c0952aa873c7b2a1715f585) at the appropriate position in the document order.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 679dec0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->