### PR TITLE
AGENTS: correct dag-runner spec shape in rationale

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,8 +422,9 @@ The switch landed in
 [`d9e2fa1`](https://github.com/indexable-inc/index/commit/d9e2fa1) ("lib: add
 dag-runner and switch nix run .#health-checks to use it"). Lifecycle scripts
 per example (rm-then-up-then-rm) were unchanged; only the orchestrator swapped.
-The JSON spec is a flat map of `{ name → { command, depends_on, ... } }` owned
-by this repo, documented in [`packages/dag-runner/README.md`](packages/dag-runner/README.md).
+The JSON spec is a top-level `nodes` map of `{ name → { command, depends_on?,
+env?, timeout_secs? } }`, owned by this repo and documented in
+[`packages/dag-runner/README.md`](packages/dag-runner/README.md).
 
 If a third consumer arrives needing something dag-runner does not, extend the
 runner. Pulling in `process-compose` or `devenv-tasks` alongside it for "the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,8 +422,9 @@ The switch landed in
 [`d9e2fa1`](https://github.com/indexable-inc/index/commit/d9e2fa1) ("lib: add
 dag-runner and switch nix run .#health-checks to use it"). Lifecycle scripts
 per example (rm-then-up-then-rm) were unchanged; only the orchestrator swapped.
-The JSON spec is a flat map of `{ name → { command, depends_on, ... } }` owned
-by this repo, documented in [`packages/dag-runner/README.md`](packages/dag-runner/README.md).
+The JSON spec is a top-level `nodes` map of `{ name → { command, depends_on?,
+env?, timeout_secs? } }`, owned by this repo and documented in
+[`packages/dag-runner/README.md`](packages/dag-runner/README.md).
 
 If a third consumer arrives needing something dag-runner does not, extend the
 runner. Pulling in `process-compose` or `devenv-tasks` alongside it for "the

--- a/agents-md/sections/08b-why-dag-runner.md
+++ b/agents-md/sections/08b-why-dag-runner.md
@@ -25,8 +25,9 @@ The switch landed in
 [`d9e2fa1`](https://github.com/indexable-inc/index/commit/d9e2fa1) ("lib: add
 dag-runner and switch nix run .#health-checks to use it"). Lifecycle scripts
 per example (rm-then-up-then-rm) were unchanged; only the orchestrator swapped.
-The JSON spec is a flat map of `{ name → { command, depends_on, ... } }` owned
-by this repo, documented in [`packages/dag-runner/README.md`](packages/dag-runner/README.md).
+The JSON spec is a top-level `nodes` map of `{ name → { command, depends_on?,
+env?, timeout_secs? } }`, owned by this repo and documented in
+[`packages/dag-runner/README.md`](packages/dag-runner/README.md).
 
 If a third consumer arrives needing something dag-runner does not, extend the
 runner. Pulling in `process-compose` or `devenv-tasks` alongside it for "the


### PR DESCRIPTION
## Summary

Follow-up to #366. The AI review on that PR caught that the rationale section described the dag-runner JSON spec as a flat `name → node` map, but the real schema (per `packages/dag-runner/README.md`) wraps the per-node map under a top-level `nodes` key and supports optional `env` / `timeout_secs` fields too. The earlier PR landed before the AI finding propagated to the merge gate, so this PR brings the doc back in line with the actual contract.

- Updates `agents-md/sections/08b-why-dag-runner.md` to say: `nodes` map of `{ name → { command, depends_on?, env?, timeout_secs? } }`.
- Regenerates `AGENTS.md` and `CLAUDE.md`.

## Test plan

- [x] `nix run .#agents-md -- --check` is clean on the branch.
- [ ] Verify the dag-runner section in `AGENTS.md` now matches the schema table in `packages/dag-runner/README.md`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Correct dag-runner JSON spec shape in agent documentation
> Updates the dag-runner spec description in [AGENTS.md](https://github.com/indexable-inc/index/pull/367/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9), [CLAUDE.md](https://github.com/indexable-inc/index/pull/367/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7), and [agents-md/sections/08b-why-dag-runner.md](https://github.com/indexable-inc/index/pull/367/files#diff-4c9f33ed55a843228a554846e5f75ce60061c4359e3503ae9a982aa77ad79df4) to reflect a top-level `nodes` map instead of a flat map. Each node now lists fields `{ command, depends_on?, env?, timeout_secs? }` with a reference to [packages/dag-runner/README.md](https://github.com/indexable-inc/index/pull/367/files#diff-23b6c6ae293ccb925a5cab1159028c1a7450f9a12e2fcab0b484b2bee21f3793) as the canonical source.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4c96eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->