### PR TITLE
[codex] ix-fleet dag-runner workflows

### DIFF
--- a/packages/ix-fleet/default.nix
+++ b/packages/ix-fleet/default.nix
@@ -1,10 +1,84 @@
 {
   ix,
+  lib,
   pkgs ? ix.pkgs,
 }:
 
-ix.buildUvApplication pkgs {
-  pname = "ix-fleet";
-  version = "0.1.0";
-  srcRoot = ./.;
-}
+let
+  dagRunner = pkgs.callPackage ../dag-runner { inherit ix; };
+  unwrapped = ix.buildUvApplication pkgs {
+    pname = "ix-fleet";
+    version = "0.1.0";
+    srcRoot = ./.;
+  };
+
+  jsonFormat = pkgs.formats.json { };
+  dryRunPlan = jsonFormat.generate "ix-fleet-dry-run-plan.json" {
+    order = [ "api" ];
+    nodes.api = {
+      name = "api";
+      baseName = "api";
+      system = "/nix/store/api-system";
+      switch = {
+        target = "/nix/store/api-system";
+        sourceInstallable = ".#api";
+      };
+      bootstrapImage = "registry.ix.dev/ix/base:latest";
+      replacementImage = {
+        imageName = "api";
+        imageTag = "latest";
+        destination = "registry.ix.dev/example/api:latest";
+        source = "/nix/store/api-image.tar";
+        sourceDrv = "/nix/store/api-image.drv";
+      };
+      region = "us-west-1";
+      ipv4 = false;
+      snapshot = false;
+    };
+  };
+
+  fakeIx = ix.writeNushellApplication pkgs {
+    name = "ix";
+    text = ''
+      def --wrapped main [command: string, ...args] {
+        match $command {
+          "ls" => { print "[]" }
+          "new" => { }
+          _ => {
+            print -e $"unexpected ix command: ($command) (($args | str join ' '))"
+            exit 1
+          }
+        }
+      }
+    '';
+  };
+
+  upFindsDagRunner =
+    pkgs.runCommand "ix-fleet-up-finds-dag-runner"
+      {
+        nativeBuildInputs = [
+          fakeIx
+          package
+        ];
+        strictDeps = true;
+      }
+      ''
+        ix-fleet --plan ${dryRunPlan} up --skip-push --skip-health
+        mkdir -p "$out"
+      '';
+
+  package = unwrapped.overrideAttrs (old: {
+    postInstall = ''
+      ${old.postInstall or ""}
+      wrapProgram "$out/bin/ix-fleet" \
+        --set IX_FLEET_DAG_RUNNER ${lib.escapeShellArg (lib.getExe dagRunner)}
+    '';
+
+    passthru = (old.passthru or { }) // {
+      tests = (old.passthru.tests or { }) // {
+        inherit upFindsDagRunner;
+      };
+    };
+  });
+in
+package

--- a/packages/ix-fleet/package.nix
+++ b/packages/ix-fleet/package.nix
@@ -2,4 +2,7 @@
   id = "ix-fleet";
   packageSet = true;
   flake = true;
+  passthruTests = {
+    prefix = "ix-fleet";
+  };
 }

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -5,10 +5,12 @@ import argparse
 import asyncio
 import json
 import os
+import shutil
 import shlex
 import string
 import subprocess
 import sys
+import tempfile
 import typing
 from pathlib import Path
 
@@ -682,47 +684,146 @@ async def cmd_diff(plan: FleetPlan, args: argparse.Namespace) -> None:
             print(f"{node.name}\twant {node.switch.target} ({node.switch.buildOn})")
 
 
-async def cmd_switch(plan: FleetPlan, args: argparse.Namespace) -> None:
+async def run_switch_node_workflow(node: FleetNode, args: argparse.Namespace) -> None:
     source_root = (args.source_root or default_source_root(Path.cwd())).resolve()
     source_workdir = args.source_workdir or default_source_workdir(Path.cwd(), source_root)
+    created = await ensure_node(node, dry_run=args.dry_run)
+    await ensure_node_groups(node, dry_run=args.dry_run)
+    if not created and node.snapshot and not args.no_snapshot:
+        await snapshot_node(node, dry_run=args.dry_run)
+    if node.switch.buildOn == "remote":
+        await switch_node_from_source(
+            node,
+            source_root,
+            source_workdir,
+            dry_run=args.dry_run,
+        )
+    else:
+        await switch_node(node, dry_run=args.dry_run)
+    if not args.skip_health:
+        await run_node_health_checks(node, dry_run=args.dry_run)
+
+
+async def run_replace_node_workflow(node: FleetNode, args: argparse.Namespace) -> None:
+    image = node.replacementImage.destination
+    if not args.skip_push:
+        image = await push_replacement_image(node, dry_run=args.dry_run)
+    await replace_node(node, image, dry_run=args.dry_run)
+    await ensure_node_groups(node, dry_run=args.dry_run)
+    if not args.skip_health:
+        await run_node_health_checks(node, dry_run=args.dry_run)
+
+
+async def run_up_node_workflow(node: FleetNode, args: argparse.Namespace) -> None:
+    image = node.replacementImage.destination
+    if not args.skip_push:
+        image = await push_replacement_image(node, dry_run=args.dry_run)
+    await up_node(node, image, dry_run=args.dry_run)
+    await ensure_node_groups(node, dry_run=args.dry_run)
+    if not args.skip_health:
+        await run_node_health_checks(node, dry_run=args.dry_run)
+
+
+async def run_node_workflow_dag(
+    plan: FleetPlan,
+    args: argparse.Namespace,
+    subcommand: str,
+    extra_args: list[str],
+) -> None:
+    pushes_images = subcommand in {"_up-node", "_replace-node"} and "--skip-push" not in extra_args
+    last_push_by_destination: dict[str, str] = {}
+    nodes: dict[str, dict[str, typing.Any]] = {}
     for node in selected_nodes(plan, args.on):
-        created = await ensure_node(node, dry_run=args.dry_run)
-        await ensure_node_groups(node, dry_run=args.dry_run)
-        if not created and node.snapshot and not args.no_snapshot:
-            await snapshot_node(node, dry_run=args.dry_run)
-        if node.switch.buildOn == "remote":
-            await switch_node_from_source(
-                node,
-                source_root,
-                source_workdir,
-                dry_run=args.dry_run,
-            )
-        else:
-            await switch_node(node, dry_run=args.dry_run)
-        if not args.skip_health:
-            await run_node_health_checks(node, dry_run=args.dry_run)
+        depends_on = list(node.dependsOn)
+        if pushes_images:
+            previous = last_push_by_destination.get(node.replacementImage.destination)
+            if previous is not None and previous not in depends_on:
+                depends_on.append(previous)
+            last_push_by_destination[node.replacementImage.destination] = node.name
+        nodes[node.name] = {
+            "command": [
+                sys.argv[0],
+                "--plan",
+                str(args.plan),
+                subcommand,
+                node.name,
+                *extra_args,
+            ],
+            "depends_on": depends_on,
+        }
+    await run_dag_runner({"nodes": nodes})
+
+
+async def run_dag_runner(spec: dict[str, typing.Any]) -> None:
+    dag_runner = os.environ.get("IX_FLEET_DAG_RUNNER") or shutil.which("dag-runner")
+    if dag_runner is None:
+        raise RuntimeError("dag-runner is unavailable; set IX_FLEET_DAG_RUNNER or add dag-runner to PATH")
+
+    with tempfile.TemporaryDirectory(prefix="ix-fleet-dag-") as temporary_directory:
+        spec_path = Path(temporary_directory) / "spec.json"
+        spec_path.write_text(json.dumps(spec, indent=2))
+        process = await asyncio.create_subprocess_exec(dag_runner, str(spec_path))
+        returncode = await process.wait()
+    if returncode != 0:
+        raise SystemExit(returncode)
+
+
+async def cmd_switch(plan: FleetPlan, args: argparse.Namespace) -> None:
+    if args.dry_run:
+        for node in selected_nodes(plan, args.on):
+            await run_switch_node_workflow(node, args)
+        return
+
+    extra_args: list[str] = []
+    if args.no_snapshot:
+        extra_args.append("--no-snapshot")
+    if args.skip_health:
+        extra_args.append("--skip-health")
+    if args.source_root is not None:
+        extra_args.extend(["--source-root", str(args.source_root)])
+    if args.source_workdir is not None:
+        extra_args.extend(["--source-workdir", str(args.source_workdir)])
+    await run_node_workflow_dag(plan, args, "_switch-node", extra_args)
 
 
 async def cmd_replace(plan: FleetPlan, args: argparse.Namespace) -> None:
-    for node in selected_nodes(plan, args.on):
-        image = node.replacementImage.destination
-        if not args.skip_push:
-            image = await push_replacement_image(node, dry_run=args.dry_run)
-        await replace_node(node, image, dry_run=args.dry_run)
-        await ensure_node_groups(node, dry_run=args.dry_run)
-        if not args.skip_health:
-            await run_node_health_checks(node, dry_run=args.dry_run)
+    if args.dry_run:
+        for node in selected_nodes(plan, args.on):
+            await run_replace_node_workflow(node, args)
+        return
+
+    extra_args: list[str] = []
+    if args.skip_push:
+        extra_args.append("--skip-push")
+    if args.skip_health:
+        extra_args.append("--skip-health")
+    await run_node_workflow_dag(plan, args, "_replace-node", extra_args)
 
 
 async def cmd_up(plan: FleetPlan, args: argparse.Namespace) -> None:
-    for node in selected_nodes(plan, args.on):
-        image = node.replacementImage.destination
-        if not args.skip_push:
-            image = await push_replacement_image(node, dry_run=args.dry_run)
-        await up_node(node, image, dry_run=args.dry_run)
-        await ensure_node_groups(node, dry_run=args.dry_run)
-        if not args.skip_health:
-            await run_node_health_checks(node, dry_run=args.dry_run)
+    if args.dry_run:
+        for node in selected_nodes(plan, args.on):
+            await run_up_node_workflow(node, args)
+        return
+
+    extra_args: list[str] = []
+    if args.skip_push:
+        extra_args.append("--skip-push")
+    if args.skip_health:
+        extra_args.append("--skip-health")
+    await run_node_workflow_dag(plan, args, "_up-node", extra_args)
+
+
+async def cmd_switch_node(plan: FleetPlan, args: argparse.Namespace) -> None:
+    await run_switch_node_workflow(plan.nodes[args.node], args)
+
+
+async def cmd_replace_node(plan: FleetPlan, args: argparse.Namespace) -> None:
+    await run_replace_node_workflow(plan.nodes[args.node], args)
+
+
+async def cmd_up_node(plan: FleetPlan, args: argparse.Namespace) -> None:
+    await run_up_node_workflow(plan.nodes[args.node], args)
 
 
 async def cmd_health(plan: FleetPlan, args: argparse.Namespace) -> None:
@@ -760,6 +861,9 @@ def parser() -> argparse.ArgumentParser:
             default=False if defaults else argparse.SUPPRESS,
         )
 
+    def add_dry_run_option(target: argparse.ArgumentParser) -> None:
+        target.add_argument("--dry-run", action="store_true", default=argparse.SUPPRESS)
+
     p = argparse.ArgumentParser(prog="ix-fleet")
     p.add_argument("--plan", required=True, type=Path)
     add_common_options(p, defaults=True)
@@ -789,6 +893,23 @@ def parser() -> argparse.ArgumentParser:
     add_common_options(up, defaults=False)
     up.add_argument("--skip-push", action="store_true")
     up.add_argument("--skip-health", action="store_true")
+    switch_node_parser = sub.add_parser("_switch-node", help=argparse.SUPPRESS)
+    switch_node_parser.add_argument("node")
+    add_dry_run_option(switch_node_parser)
+    switch_node_parser.add_argument("--no-snapshot", action="store_true")
+    switch_node_parser.add_argument("--skip-health", action="store_true")
+    switch_node_parser.add_argument("--source-root", type=Path)
+    switch_node_parser.add_argument("--source-workdir", type=Path)
+    replace_node_parser = sub.add_parser("_replace-node", help=argparse.SUPPRESS)
+    replace_node_parser.add_argument("node")
+    add_dry_run_option(replace_node_parser)
+    replace_node_parser.add_argument("--skip-push", action="store_true")
+    replace_node_parser.add_argument("--skip-health", action="store_true")
+    up_node_parser = sub.add_parser("_up-node", help=argparse.SUPPRESS)
+    up_node_parser.add_argument("node")
+    add_dry_run_option(up_node_parser)
+    up_node_parser.add_argument("--skip-push", action="store_true")
+    up_node_parser.add_argument("--skip-health", action="store_true")
     return p
 
 
@@ -812,6 +933,12 @@ async def main() -> None:
         await cmd_replace(plan, args)
     elif args.command == "up":
         await cmd_up(plan, args)
+    elif args.command == "_switch-node":
+        await cmd_switch_node(plan, args)
+    elif args.command == "_replace-node":
+        await cmd_replace_node(plan, args)
+    elif args.command == "_up-node":
+        await cmd_up_node(plan, args)
     else:
         raise AssertionError(args.command)
 

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -339,6 +339,228 @@ class BootstrapTests(unittest.TestCase):
         self.assertEqual(ready, ["api"])
 
 
+class NodeWorkflowDagTests(unittest.TestCase):
+    def test_up_dag_includes_transitive_dependencies_and_forwards_flags(self) -> None:
+        plan = ix_fleet.FleetPlan.model_validate(
+            fleet_plan(["db", "web"], [fleet_node("web", depends_on=["db"]), fleet_node("db")])
+        )
+        spec = captured_dag(
+            ix_fleet.cmd_up,
+            plan,
+            argparse_namespace(
+                plan=Path("fleet.json"),
+                on=["web"],
+                dry_run=False,
+                skip_push=True,
+                skip_health=True,
+            ),
+        )
+
+        self.assertEqual(list(spec["nodes"]), ["db", "web"])
+        self.assertEqual(spec["nodes"]["db"]["depends_on"], [])
+        self.assertEqual(spec["nodes"]["web"]["depends_on"], ["db"])
+        self.assertEqual(
+            spec["nodes"]["web"]["command"],
+            [
+                "/bin/ix-fleet",
+                "--plan",
+                "fleet.json",
+                "_up-node",
+                "web",
+                "--skip-push",
+                "--skip-health",
+            ],
+        )
+
+    def test_replace_dag_forwards_replace_flags(self) -> None:
+        plan = ix_fleet.FleetPlan.model_validate(fleet_plan(["api"], [fleet_node("api")]))
+        spec = captured_dag(
+            ix_fleet.cmd_replace,
+            plan,
+            argparse_namespace(
+                plan=Path("/plans/fleet.json"),
+                on=[],
+                dry_run=False,
+                skip_push=True,
+                skip_health=True,
+            ),
+        )
+
+        self.assertEqual(
+            spec["nodes"]["api"]["command"],
+            [
+                "/bin/ix-fleet",
+                "--plan",
+                "/plans/fleet.json",
+                "_replace-node",
+                "api",
+                "--skip-push",
+                "--skip-health",
+            ],
+        )
+
+    def test_push_dag_serializes_shared_image_destination(self) -> None:
+        api = fleet_node("api")
+        worker = fleet_node("worker")
+        worker["replacementImage"]["destination"] = api["replacementImage"]["destination"]
+        plan = ix_fleet.FleetPlan.model_validate(fleet_plan(["api", "worker"], [api, worker]))
+
+        spec = captured_dag(
+            ix_fleet.cmd_up,
+            plan,
+            argparse_namespace(plan=Path("fleet.json"), on=[], dry_run=False, skip_push=False, skip_health=True),
+        )
+
+        self.assertEqual(spec["nodes"]["worker"]["depends_on"], ["api"])
+
+    def test_switch_dag_forwards_switch_flags(self) -> None:
+        plan = ix_fleet.FleetPlan.model_validate(fleet_plan(["api"], [fleet_node("api")]))
+        spec = captured_dag(
+            ix_fleet.cmd_switch,
+            plan,
+            argparse_namespace(
+                plan=Path("/plans/fleet.json"),
+                on=["api"],
+                dry_run=False,
+                no_snapshot=True,
+                skip_health=True,
+                source_root=Path("/source"),
+                source_workdir=Path("subdir"),
+            ),
+        )
+
+        self.assertEqual(
+            spec["nodes"]["api"]["command"],
+            [
+                "/bin/ix-fleet",
+                "--plan",
+                "/plans/fleet.json",
+                "_switch-node",
+                "api",
+                "--no-snapshot",
+                "--skip-health",
+                "--source-root",
+                "/source",
+                "--source-workdir",
+                "subdir",
+            ],
+        )
+
+    def test_dag_runner_exit_status_becomes_process_exit_status(self) -> None:
+        plan = ix_fleet.FleetPlan.model_validate(fleet_plan(["api"], [fleet_node("api")]))
+        args = argparse_namespace(
+            plan=Path("fleet.json"),
+            on=[],
+            dry_run=False,
+            skip_push=True,
+            skip_health=True,
+        )
+
+        with TemporaryDirectory() as temporary_directory:
+            runner = Path(temporary_directory) / "dag-runner"
+            runner.write_text("#!/bin/sh\nexit 17\n")
+            runner.chmod(0o755)
+
+            with patch.dict(ix_fleet.os.environ, {"IX_FLEET_DAG_RUNNER": str(runner)}):
+                with self.assertRaises(SystemExit) as raised:
+                    asyncio.run(ix_fleet.cmd_up(plan, args))
+
+        self.assertEqual(raised.exception.code, 17)
+
+    def test_dry_run_runs_inline_so_child_output_is_visible(self) -> None:
+        plan = ix_fleet.FleetPlan.model_validate(fleet_plan(["api"], [fleet_node("api")]))
+        calls: list[str] = []
+
+        async def fail_run_dag_runner(spec: dict[str, typing.Any]) -> None:
+            self.fail("dry-run should not send child output through dag-runner")
+
+        with (
+            patch.object(ix_fleet, "run_dag_runner", fail_run_dag_runner),
+            patch.object(ix_fleet, "run_up_node_workflow", async_recorder(calls, "api")),
+        ):
+            asyncio.run(
+                ix_fleet.cmd_up(
+                    plan,
+                    argparse_namespace(plan=Path("fleet.json"), on=[], dry_run=True, skip_push=True, skip_health=True),
+                )
+            )
+
+        self.assertEqual(calls, ["api"])
+
+
+class SingleNodeWorkflowTests(unittest.TestCase):
+    def test_up_node_workflow_runs_the_existing_up_sequence(self) -> None:
+        plan = ix_fleet.FleetPlan.model_validate(fleet_plan(["api"], [fleet_node("api")]))
+        args = argparse_namespace(
+            node="api",
+            dry_run=False,
+            skip_push=False,
+            skip_health=False,
+        )
+        calls: list[str] = []
+
+        with (
+            patch.object(
+                ix_fleet,
+                "push_replacement_image",
+                async_recorder(calls, "push", "registry.ix.dev/example/api:pushed"),
+            ),
+            patch.object(ix_fleet, "up_node", async_recorder(calls, "up")),
+            patch.object(ix_fleet, "ensure_node_groups", async_recorder(calls, "groups")),
+            patch.object(ix_fleet, "run_node_health_checks", async_recorder(calls, "health")),
+        ):
+            asyncio.run(ix_fleet.cmd_up_node(plan, args))
+
+        self.assertEqual(calls, ["push", "up", "groups", "health"])
+
+    def test_replace_node_workflow_runs_the_existing_replace_sequence(self) -> None:
+        plan = ix_fleet.FleetPlan.model_validate(fleet_plan(["api"], [fleet_node("api")]))
+        args = argparse_namespace(
+            node="api",
+            dry_run=False,
+            skip_push=False,
+            skip_health=False,
+        )
+        calls: list[str] = []
+
+        with (
+            patch.object(
+                ix_fleet,
+                "push_replacement_image",
+                async_recorder(calls, "push", "registry.ix.dev/example/api:pushed"),
+            ),
+            patch.object(ix_fleet, "replace_node", async_recorder(calls, "replace")),
+            patch.object(ix_fleet, "ensure_node_groups", async_recorder(calls, "groups")),
+            patch.object(ix_fleet, "run_node_health_checks", async_recorder(calls, "health")),
+        ):
+            asyncio.run(ix_fleet.cmd_replace_node(plan, args))
+
+        self.assertEqual(calls, ["push", "replace", "groups", "health"])
+
+    def test_switch_node_workflow_runs_the_existing_switch_sequence(self) -> None:
+        plan = ix_fleet.FleetPlan.model_validate(fleet_plan(["api"], [fleet_node("api")]))
+        args = argparse_namespace(
+            node="api",
+            dry_run=False,
+            no_snapshot=False,
+            skip_health=False,
+            source_root=Path("/source"),
+            source_workdir=Path("subdir"),
+        )
+        calls: list[str] = []
+
+        with (
+            patch.object(ix_fleet, "ensure_node", async_recorder(calls, "ensure", False)),
+            patch.object(ix_fleet, "ensure_node_groups", async_recorder(calls, "groups")),
+            patch.object(ix_fleet, "snapshot_node", async_recorder(calls, "snapshot")),
+            patch.object(ix_fleet, "switch_node", async_recorder(calls, "switch")),
+            patch.object(ix_fleet, "run_node_health_checks", async_recorder(calls, "health")),
+        ):
+            asyncio.run(ix_fleet.cmd_switch_node(plan, args))
+
+        self.assertEqual(calls, ["ensure", "groups", "snapshot", "switch", "health"])
+
+
 class DownTests(unittest.TestCase):
     def test_down_continues_after_node_failure(self) -> None:
         plan = ix_fleet.FleetPlan.model_validate(
@@ -433,6 +655,38 @@ class SwitchSourceTests(unittest.TestCase):
 
 def argparse_namespace(**kwargs: typing.Any) -> typing.Any:
     return type("Args", (), kwargs)()
+
+
+def captured_dag(
+    command: typing.Callable[[ix_fleet.FleetPlan, typing.Any], typing.Coroutine[typing.Any, typing.Any, None]],
+    plan: ix_fleet.FleetPlan,
+    args: typing.Any,
+) -> dict[str, typing.Any]:
+    specs: list[dict[str, typing.Any]] = []
+
+    async def fake_run_dag_runner(spec: dict[str, typing.Any]) -> None:
+        specs.append(spec)
+
+    with (
+        patch.object(ix_fleet, "run_dag_runner", fake_run_dag_runner),
+        patch.object(ix_fleet.sys, "argv", ["/bin/ix-fleet"]),
+    ):
+        asyncio.run(command(plan, args))
+
+    return specs[0]
+
+
+def async_recorder(
+    calls: list[str],
+    name: str,
+    result: typing.Any = None,
+) -> typing.Callable[..., typing.Coroutine[typing.Any, typing.Any, typing.Any]]:
+    async def record(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+        del args, kwargs
+        calls.append(name)
+        return result
+
+    return record
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- Migrated live `ix-fleet up`, `ix-fleet replace`, and `ix-fleet switch` runs to a `dag-runner` spec from selected fleet nodes.
- Added private one-node workflow subcommands so `dag-runner` owns orchestration while the Python fleet workflows still own image pushes, VM changes, groups, snapshots, source switches, and health checks.
- Kept dry runs inline so their existing command audit output stays visible.
- Preserved fleet `dependsOn` ordering and serialized only `up`/`replace` nodes that would push to the same image destination.
- Wired the packaged `ix-fleet` wrapper to set `IX_FLEET_DAG_RUNNER` to the repo-built runner, with a PATH fallback and an operator-facing error if no runner is available.
- Added unit and package tests for the generated DAG, one-node workflows, exit propagation, shared image destinations, dry-run output behavior, and packaged wrapper lookup.

## Why

This implements #77 by replacing the sequential live per-node loops in the deploy-shaped commands with dependency-aware DAG execution. A failed node now skips its dependents while unrelated nodes can continue.

## Validation

- `uv run --project packages/ix-fleet python -m unittest discover -s packages/ix-fleet/tests`
- `nix build .#ix-fleet`
- `nix build .#ix-fleet.passthru.tests.upFindsDagRunner`
- `nix run .#lint`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add DAG runner workflow orchestration to `ix-fleet` up, replace, and switch commands
> - `up`, `replace`, and `switch` commands now delegate non-dry-run execution to an external DAG runner binary, enabling correct dependency ordering and serialized image pushes to shared destinations.
> - Three hidden internal subcommands (`_up-node`, `_replace-node`, `_switch-node`) are added to handle per-node operations invoked by the DAG runner; dry-run mode continues to execute inline.
> - The installed `ix-fleet` binary is wrapped via [default.nix](https://github.com/indexable-inc/index/pull/368/files#diff-652695031797bff850cdf5234a6a11a292b289ac6ca8701411d0d408d0345954) to set `IX_FLEET_DAG_RUNNER` pointing at the packaged `dag-runner` executable, removing the need for it to be on `PATH`.
> - A build-time test derivation (`ix-fleet-up-finds-dag-runner`) verifies that the CLI can locate `dag-runner` during `nix build`.
> - Behavioral Change: non-dry-run orchestration now goes through the external DAG runner process; its exit code is propagated directly to `ix-fleet`'s process exit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0187b7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->