### PR TITLE
tui-dashboard: sync theme to browser color scheme via light-dark()

### DIFF
--- a/packages/tui-dashboard-core/src/dashboard/dashboard.html
+++ b/packages/tui-dashboard-core/src/dashboard/dashboard.html
@@ -3,27 +3,33 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<!-- Let the UA settle on the scheme before CSS parses; without this some
+     webviews render the light theme even when the OS is in dark mode. -->
+<meta name="color-scheme" content="light dark" />
 <title>tui</title>
 <style>
   :root {
     color-scheme: light dark;
 
-    /* Light theme, taken verbatim from the user's ghostty
-       ~/.config/nix/ghostty/themes/custom-light. Each card is a ghostty
-       surface (--panel == the theme background) on a slightly darker page.
-       Dark overrides live in the media query below. */
-    --bg: #ececec;
-    --panel: #f9f9f9;
-    --edge: #dcdcdc;
-    --edge-strong: #c4c4c4;
-    --ink: #2a2c33;
-    --ink-dim: #6a6c72;
-    --ink-faint: #8f9096;
-    --live: #42933e;
-    --dead: #db3f39;
-    --accent: #325eee;
-    --cursor: #bbbbbb;
-    --sel: #e9e9e9;
+    /* Each token carries both schemes via light-dark(): the light value is
+       taken verbatim from the user's ghostty
+       ~/.config/nix/ghostty/themes/custom-light, the dark value from
+       custom-dark. The UA picks per the resolved color-scheme above, so one
+       declaration is the single source of truth per token. Each card is a
+       ghostty surface (--panel == the theme background) on a slightly darker
+       page. */
+    --bg: light-dark(#ececec, #151515);
+    --panel: light-dark(#f9f9f9, #1e1e1e);
+    --edge: light-dark(#dcdcdc, #2a2a2a);
+    --edge-strong: light-dark(#c4c4c4, #3a3a3a);
+    --ink: light-dark(#2a2c33, #d4d4d4);
+    --ink-dim: light-dark(#6a6c72, #808080);
+    --ink-faint: light-dark(#8f9096, #585b70);
+    --live: light-dark(#42933e, #a6e3a1);
+    --dead: light-dark(#db3f39, #f38ba8);
+    --accent: light-dark(#325eee, #89b4fa);
+    --cursor: light-dark(#bbbbbb, #f5e0dc);
+    --sel: light-dark(#e9e9e9, #313244);
 
     --ui: ui-sans-serif, system-ui, -apple-system, "SF Pro Text", Segoe UI, sans-serif;
     /* Prefer Berkeley Mono (the user's ghostty font) when it is installed
@@ -31,21 +37,25 @@
     --mono: "Berkeley Mono", ui-monospace, "SF Mono", SFMono-Regular, "JetBrains Mono", Menlo, Consolas, monospace;
   }
 
-  @media (prefers-color-scheme: dark) {
-    :root {
-      /* Dark theme, taken verbatim from custom-dark. */
-      --bg: #151515;
-      --panel: #1e1e1e;
-      --edge: #2a2a2a;
-      --edge-strong: #3a3a3a;
-      --ink: #d4d4d4;
-      --ink-dim: #808080;
-      --ink-faint: #585b70;
-      --live: #a6e3a1;
-      --dead: #f38ba8;
-      --accent: #89b4fa;
-      --cursor: #f5e0dc;
-      --sel: #313244;
+  /* light-dark() is unsupported on roughly 15% of browsers as of 2026
+     (https://caniuse.com/mdn-css_types_color_light-dark). Restore the dark
+     palette there with the classic prefers-color-scheme override. */
+  @supports not (color: light-dark(#000, #fff)) {
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #151515;
+        --panel: #1e1e1e;
+        --edge: #2a2a2a;
+        --edge-strong: #3a3a3a;
+        --ink: #d4d4d4;
+        --ink-dim: #808080;
+        --ink-faint: #585b70;
+        --live: #a6e3a1;
+        --dead: #f38ba8;
+        --accent: #89b4fa;
+        --cursor: #f5e0dc;
+        --sel: #313244;
+      }
     }
   }
 

--- a/site/src/lib/updates/tui-dashboard-color-scheme.svx
+++ b/site/src/lib/updates/tui-dashboard-color-scheme.svx
@@ -1,0 +1,17 @@
+---
+id: tui-dashboard-color-scheme
+postedAt: 2026-05-30T12:00:00-07:00
+title: "tui dashboard follows the browser's light/dark scheme"
+tags: [interesting, ui, css]
+links:
+  - label: tui dashboard page
+    href: https://github.com/indexable-inc/index/blob/main/packages/tui-dashboard-core/src/dashboard/dashboard.html
+  - label: CSS light-dark()
+    href: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark
+---
+
+The tui dashboard now tracks the browser or OS color scheme. Each themeable token is a single `light-dark(lightValue, darkValue)` declaration under `color-scheme: light dark`, so the ghostty light and dark palettes live in one source of truth per token instead of a `:root` block shadowed by a `@media (prefers-color-scheme: dark)` override.
+
+A `<meta name="color-scheme" content="light dark">` in `<head>` lets the user agent settle on the scheme before CSS parses. That tag is the actual fix for webviews that rendered the light theme even in dark mode: the CSS already flipped correctly under an emulated dark scheme, so the bug was the host not advertising its scheme early enough.
+
+Browsers without `light-dark()` (roughly 15% as of 2026) fall back to the classic dark override inside `@supports not (color: light-dark(#000, #fff))`. Verified with Playwright: emulated dark resolves `--bg` to `#151515`, light to `#ececec`.


### PR DESCRIPTION
## Problem

The tui dashboard rendered the light theme even when the OS or browser was in dark mode. The CSS defined a light `:root` and a separate `@media (prefers-color-scheme: dark)` block overriding the same custom properties.

## What

- Each themeable token is now a single `light-dark(lightValue, darkValue)` declaration under `color-scheme: light dark`, collapsing the duplicated dark `@media` override into one source of truth per token. The ghostty custom-light and custom-dark palettes are preserved 1:1.
- Added `<meta name="color-scheme" content="light dark">` so the user agent settles on the scheme before CSS parses. This is the real fix for webviews that did not advertise their scheme early enough.
- Added an `@supports not (color: light-dark(#000, #fff))` fallback (classic dark override) for the roughly 15% of browsers without `light-dark()` as of 2026.
- The JS `matchMedia("(prefers-color-scheme: dark)")` path that paints terminal cell colors is unchanged.

## Validation

- `nix run .#lint` passed.
- `nix build .#tui-dashboard` passed (embedded HTML still builds).
- Playwright (real Chromium) with `emulateMedia` for both schemes against the file: computed `body` background resolves to `rgb(21,21,21)` (#151515) under dark and `rgb(236,236,236)` (#ececec) under light. Both correct.

Note: the pre-change file already flipped correctly under emulated dark, so the live "light in dark mode" symptom was the host webview not reporting its scheme, not the CSS. The `<meta>` tag addresses that; the `light-dark()` rewrite is the idiomatic single-source-of-truth cleanup.

---
Made with AI (Claude, claude-opus-4-8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync tui-dashboard theme to browser color scheme via `light-dark()`
> - Replaces separate `@media (prefers-color-scheme: dark)` CSS variable blocks in [dashboard.html](https://github.com/indexable-inc/index/pull/371/files#diff-74ca46061890da9053d5337766ed6e9f41b77ea2ad08928f93f790dede837d7e) with single-source tokens using the CSS `light-dark()` function for all color variables (`--bg`, `--panel`, `--ink`, etc.).
> - Adds `<meta name="color-scheme" content="light dark">` so webviews honor dark mode on first paint without a flash.
> - Adds a `@supports not (color: light-dark(...))` fallback that re-applies the dark palette via `prefers-color-scheme: dark` for older environments.
> - Adds an update post in [tui-dashboard-color-scheme.svx](https://github.com/indexable-inc/index/pull/371/files#diff-ee7502e0aefdffb1514c2b06aad03fe29583b8d502e3ca455cbd73d587540624) documenting the new behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cace605.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->