### PR TITLE
git-log-pretty: add crate reimplementing pretty ahead-of-main log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,6 +1148,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "devicons"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830e47e2f330cf4fdd5a958dcef921b9523ffc21ab6713aa5e77ba2cce03904b"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,6 +1616,34 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "git-log-pretty"
+version = "0.1.0"
+dependencies = [
+ "anstyle",
+ "chrono",
+ "clap",
+ "color-eyre",
+ "devicons",
+ "git2",
+ "strip-ansi-escapes",
+ "tempfile",
+ "terminal-light",
+]
+
+[[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "glob"
@@ -2335,6 +2372,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.5+1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2370,6 +2419,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "packages/dag-runner",
   "packages/file-language",
   "packages/file-search",
+  "packages/git-log-pretty",
   "packages/ix-dev-diagnose",
   "packages/mcp",
   "packages/minecraft/nbt",
@@ -66,9 +67,11 @@ clap = "4"
 code-highlight = { path = "packages/code-highlight" }
 code-tokenizer = { path = "packages/code-tokenizer" }
 color-eyre = "0.6"
+devicons = "0.6"
 dirs = "5"
 file-language = { path = "packages/file-language" }
 futures = "0.3"
+git2 = { version = "0.20", default-features = false }
 hegeltest = { version = "0.14", default-features = false }
 ignore = "0.4"
 indicatif = "0.18"

--- a/packages/git-log-pretty/Cargo.toml
+++ b/packages/git-log-pretty/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "git-log-pretty"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Pretty git log viewer that lists commits ahead of main with file-icon trees"
+
+[lints]
+workspace = true
+
+[dependencies]
+anstyle.workspace = true
+chrono = { workspace = true, features = ["clock"] }
+clap = { workspace = true, features = ["derive"] }
+color-eyre.workspace = true
+devicons.workspace = true
+# `default-features = false` drops the https/ssh transports (and their openssl /
+# libssh2 system deps) we never use for reading a local repo; `vendored-libgit2`
+# compiles the bundled libgit2 C source with `cc`, so the build needs no system
+# libgit2 or cmake. See libgit2-sys: with no `vendored` feature it probes
+# pkg-config first, which would add a system dependency to the workspace build.
+git2 = { workspace = true, default-features = false, features = ["vendored-libgit2"] }
+strip-ansi-escapes.workspace = true
+terminal-light.workspace = true
+
+[dev-dependencies]
+git2 = { workspace = true, default-features = false, features = ["vendored-libgit2"] }
+tempfile.workspace = true

--- a/packages/git-log-pretty/default.nix
+++ b/packages/git-log-pretty/default.nix
@@ -1,0 +1,10 @@
+{ ix, lib, ... }:
+
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "git-log-pretty";
+  meta = {
+    description = "Pretty git log viewer that lists commits ahead of main with file-icon trees";
+    license = lib.licenses.mit;
+    mainProgram = "git-log-pretty";
+  };
+}

--- a/packages/git-log-pretty/package.nix
+++ b/packages/git-log-pretty/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "git-log-pretty";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/git-log-pretty/src/display.rs
+++ b/packages/git-log-pretty/src/display.rs
@@ -1,0 +1,137 @@
+//! Format a commit's summary line and its changed-file tree for the terminal.
+
+use anstyle::{Ansi256Color, AnsiColor, Color, Style};
+
+use crate::palette::{self, Theme};
+use crate::tree;
+use crate::{git, time};
+
+/// A conventional-commit summary split into its `type`, optional `scope`, and
+/// description, e.g. `feat(api): add route`. The description keeps its leading
+/// space so it renders directly after the chip.
+struct Conventional<'a> {
+    commit_type: &'a str,
+    scope: Option<&'a str>,
+    description: &'a str,
+}
+
+/// Parse a conventional-commit summary of the form `type(scope): description`
+/// or `type: description`. The type must be alphabetic; anything else returns
+/// `None` so the raw summary renders unchanged.
+fn parse_conventional(summary: &str) -> Option<Conventional<'_>> {
+    let (prefix, description) = summary.split_once(':')?;
+
+    let (commit_type, scope) = match prefix.split_once('(') {
+        Some((commit_type, rest)) => (commit_type, Some(rest.strip_suffix(')')?)),
+        None => (prefix, None),
+    };
+
+    let type_ok = !commit_type.is_empty() && commit_type.chars().all(|c| c.is_ascii_alphabetic());
+    type_ok.then_some(Conventional {
+        commit_type,
+        scope,
+        description,
+    })
+}
+
+/// Render a commit summary, painting a hashed background chip on a recognized
+/// conventional-commit type and dimming any scope. Non-conventional summaries
+/// pass through unstyled.
+fn format_summary(summary: &str, theme: Theme) -> String {
+    let Some(parsed) = parse_conventional(summary) else {
+        return summary.to_string();
+    };
+
+    let chip = Style::new()
+        .bg_color(Some(Color::Rgb(palette::hashed_chip_background(
+            parsed.commit_type,
+            theme,
+        ))))
+        .fg_color(Some(Color::Rgb(palette::chip_foreground(theme))))
+        .bold();
+    let chip = palette::paint(chip, parsed.commit_type);
+
+    let chip = chip.as_str();
+    let description = parsed.description;
+    parsed.scope.map_or_else(
+        || format!("{chip}{description}"),
+        |scope| {
+            let scope = palette::paint(palette::fg(Color::Rgb(palette::GRAY)), scope);
+            format!("{chip} {scope}{description}")
+        },
+    )
+}
+
+/// Print one commit block: a `shorthash summary • relative-time` line followed
+/// by the indented changed-file tree and a trailing blank line.
+pub fn print_commit(ahead: &git::AheadCommit<'_>, theme: Theme) -> color_eyre::eyre::Result<()> {
+    let commit = &ahead.commit;
+    let short = commit
+        .id()
+        .to_string()
+        .chars()
+        .take(7)
+        .collect::<String>();
+    let summary = commit.summary().unwrap_or("<no message>").trim();
+    let when = time::relative(commit.time().seconds())?;
+
+    let yellow = palette::fg(Color::Ansi(AnsiColor::Yellow));
+    let dim = palette::fg(Color::Ansi256(Ansi256Color(8)));
+
+    println!(
+        "  {short} {summary} {bullet} {when}",
+        short = palette::paint(yellow, &short),
+        summary = format_summary(summary, theme),
+        bullet = palette::paint(dim, "•"),
+        when = palette::paint(dim, &when),
+    );
+
+    let icons = tree::render(&ahead.changed_files, theme);
+    if !icons.is_empty() {
+        println!("{icons}");
+    }
+    println!();
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plain(styled: &str) -> String {
+        String::from_utf8(strip_ansi_escapes::strip(styled)).unwrap()
+    }
+
+    #[test]
+    fn parses_type_scope_description() {
+        let parsed = parse_conventional("feat(api): add route").unwrap();
+        assert_eq!(parsed.commit_type, "feat");
+        assert_eq!(parsed.scope, Some("api"));
+        assert_eq!(parsed.description, " add route");
+    }
+
+    #[test]
+    fn parses_type_without_scope() {
+        let parsed = parse_conventional("fix: bug").unwrap();
+        assert_eq!(parsed.commit_type, "fix");
+        assert_eq!(parsed.scope, None);
+    }
+
+    #[test]
+    fn rejects_non_conventional_summaries() {
+        assert!(parse_conventional("just a message").is_none());
+        assert!(parse_conventional("123: numeric type").is_none());
+    }
+
+    #[test]
+    fn non_conventional_summary_passes_through_plain() {
+        assert_eq!(format_summary("plain message", Theme::Dark), "plain message");
+    }
+
+    #[test]
+    fn conventional_summary_keeps_its_text() {
+        let rendered = plain(&format_summary("feat(api): add route", Theme::Dark));
+        assert_eq!(rendered, "feat api add route");
+    }
+}

--- a/packages/git-log-pretty/src/git.rs
+++ b/packages/git-log-pretty/src/git.rs
@@ -1,0 +1,139 @@
+//! Repository queries built on [`git2`]: which commits are ahead of a base, and
+//! which files each commit or diff touches.
+
+use std::collections::HashSet;
+
+use color_eyre::eyre::{Result, WrapErr, eyre};
+use git2::{Commit, DiffOptions, Oid, Repository};
+
+/// A commit selected for display, paired with the paths it changed. The ahead
+/// list is sorted newest-first by commit time.
+pub struct AheadCommit<'repo> {
+    pub commit: Commit<'repo>,
+    pub changed_files: Vec<String>,
+}
+
+/// Open the repository containing the current directory.
+pub fn discover() -> Result<Repository> {
+    Repository::discover(".").wrap_err("failed to discover a git repository from the current directory")
+}
+
+/// Resolve the single commit id a reference points at, erroring when the ref is
+/// symbolic or otherwise has no direct target.
+fn target_oid(reference: &git2::Reference, label: &str) -> Result<Oid> {
+    reference
+        .target()
+        .ok_or_else(|| eyre!("{label} does not point at a commit"))
+}
+
+/// Resolve a branch-ish name to a reference, trying a local branch, then a
+/// remote-tracking branch, then the name as a fully qualified ref. `"HEAD"` is
+/// resolved against the current head.
+fn resolve_ref<'repo>(repo: &'repo Repository, name: &str) -> Result<git2::Reference<'repo>> {
+    if name == "HEAD" {
+        return repo.head().wrap_err("failed to resolve HEAD");
+    }
+
+    let candidates = [
+        format!("refs/heads/{name}"),
+        format!("refs/remotes/{name}"),
+        name.to_string(),
+    ];
+
+    candidates
+        .iter()
+        .find_map(|candidate| repo.find_reference(candidate).ok())
+        .ok_or_else(|| eyre!("failed to find branch or ref: {name}"))
+}
+
+/// Collect every commit reachable from `start`, used to diff two histories.
+fn reachable(repo: &Repository, start: Oid) -> Result<HashSet<Oid>> {
+    let mut revwalk = repo.revwalk().wrap_err("failed to start a revwalk")?;
+    revwalk.push(start).wrap_err("failed to seed the revwalk")?;
+
+    revwalk
+        .collect::<std::result::Result<HashSet<Oid>, _>>()
+        .wrap_err("failed to walk commit history")
+}
+
+/// Paths touched by `commit` relative to its first parent. A root commit (no
+/// parent) reports every file in its tree.
+pub fn changed_files(repo: &Repository, commit: &Commit) -> Result<Vec<String>> {
+    let new_tree = commit.tree().wrap_err("failed to read commit tree")?;
+
+    let old_tree = match commit.parent(0) {
+        Ok(parent) => Some(parent.tree().wrap_err("failed to read parent tree")?),
+        Err(_) => None,
+    };
+
+    let mut options = DiffOptions::new();
+    let diff = repo
+        .diff_tree_to_tree(old_tree.as_ref(), Some(&new_tree), Some(&mut options))
+        .wrap_err("failed to diff commit against its parent")?;
+
+    Ok(collect_diff_paths(&diff))
+}
+
+/// Commits reachable from HEAD but not from `base`, newest-first, each paired
+/// with its changed files. An empty vec means HEAD is not ahead of `base`.
+pub fn commits_ahead<'repo>(repo: &'repo Repository, base: &str) -> Result<Vec<AheadCommit<'repo>>> {
+    let base_oid = target_oid(&resolve_ref(repo, base)?, base)?;
+    let head_oid = target_oid(&repo.head().wrap_err("failed to resolve HEAD")?, "HEAD")?;
+
+    if base_oid == head_oid {
+        return Ok(Vec::new());
+    }
+
+    let base_set = reachable(repo, base_oid)?;
+    let head_set = reachable(repo, head_oid)?;
+
+    let mut ahead: Vec<Commit<'repo>> = head_set
+        .difference(&base_set)
+        .map(|oid| repo.find_commit(*oid).wrap_err("failed to load an ahead commit"))
+        .collect::<Result<_>>()?;
+
+    ahead.sort_by_key(|commit| std::cmp::Reverse(commit.time().seconds()));
+
+    ahead
+        .into_iter()
+        .map(|commit| {
+            let changed_files = changed_files(repo, &commit)?;
+            Ok(AheadCommit {
+                commit,
+                changed_files,
+            })
+        })
+        .collect()
+}
+
+/// Paths that differ between `base` and `head` trees, used by the `diff`
+/// subcommand. `head` accepts `"HEAD"` for the current head.
+pub fn diff_stat_files(repo: &Repository, base: &str, head: &str) -> Result<Vec<String>> {
+    let base_commit = repo
+        .find_commit(target_oid(&resolve_ref(repo, base)?, base)?)
+        .wrap_err("failed to load the base commit")?;
+    let head_commit = repo
+        .find_commit(target_oid(&resolve_ref(repo, head)?, head)?)
+        .wrap_err("failed to load the head commit")?;
+
+    let base_tree = base_commit.tree().wrap_err("failed to read base tree")?;
+    let head_tree = head_commit.tree().wrap_err("failed to read head tree")?;
+
+    let mut options = DiffOptions::new();
+    let diff = repo
+        .diff_tree_to_tree(Some(&base_tree), Some(&head_tree), Some(&mut options))
+        .wrap_err("failed to diff base against head")?;
+
+    Ok(collect_diff_paths(&diff))
+}
+
+/// Pull one display path per delta, preferring the new path and falling back to
+/// the old one for deletions.
+fn collect_diff_paths(diff: &git2::Diff) -> Vec<String> {
+    diff.deltas()
+        .filter_map(|delta| {
+            let path = delta.new_file().path().or_else(|| delta.old_file().path());
+            path.and_then(|p| p.to_str()).map(str::to_string)
+        })
+        .collect()
+}

--- a/packages/git-log-pretty/src/main.rs
+++ b/packages/git-log-pretty/src/main.rs
@@ -1,0 +1,107 @@
+//! `git-log-pretty`: a pretty `git log` viewer.
+//!
+//! With no subcommand it lists the commits HEAD is ahead of `main`, newest
+//! first, each as a one-line summary plus an icon tree of the files it touched.
+//! The `diff` subcommand renders just the changed-file tree between two refs.
+
+use anstyle::{AnsiColor, Color};
+use clap::{Parser, Subcommand};
+use color_eyre::eyre::{Result, WrapErr};
+
+mod display;
+mod git;
+mod palette;
+mod time;
+mod tree;
+
+use palette::{Theme, fg, paint};
+
+/// How many ahead-of-base commits to print before summarizing the rest. The
+/// list is newest-first, so the cap keeps the common "what have I done lately"
+/// view short.
+const MAX_COMMITS: usize = 15;
+
+#[derive(Parser)]
+#[command(name = "git-log-pretty", about = "A pretty git log viewer with file-icon trees")]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Show the changed-file tree between two refs, like `git diff --stat` with
+    /// icons.
+    Diff {
+        /// Base ref to compare against.
+        #[arg(default_value = "main")]
+        base: String,
+        /// Head ref to compare; defaults to the current HEAD.
+        #[arg(default_value = "HEAD")]
+        head: String,
+    },
+}
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    match Cli::parse().command {
+        Some(Command::Diff { base, head }) => run_diff(&base, &head).wrap_err("failed to render diff stats"),
+        None => run_log().wrap_err("failed to render git log"),
+    }
+}
+
+/// Render the ahead-of-`main` commit log for the current repository.
+fn run_log() -> Result<()> {
+    let repo = git::discover()?;
+    let ahead = git::commits_ahead(&repo, "main")?;
+
+    if ahead.is_empty() {
+        println!("{}", paint(fg(Color::Ansi(AnsiColor::Green)), "All caught up with main"));
+        return Ok(());
+    }
+
+    let theme = Theme::detect();
+    let hidden = ahead.len().saturating_sub(MAX_COMMITS);
+
+    let header = if hidden > 0 {
+        let detail = paint(
+            fg(Color::Ansi(AnsiColor::BrightBlack)),
+            &format!(" (showing first {MAX_COMMITS}, {hidden} more hidden)"),
+        );
+        format!("{count} commits ahead of main{detail}", count = ahead.len())
+    } else {
+        let label = if ahead.len() == 1 { "commit" } else { "commits" };
+        format!("{count} {label} ahead of main", count = ahead.len())
+    };
+    println!("{}\n", paint(fg(Color::Ansi(AnsiColor::Cyan)), &header));
+
+    for commit in ahead.iter().take(MAX_COMMITS) {
+        display::print_commit(commit, theme)?;
+    }
+
+    Ok(())
+}
+
+/// Render the changed-file tree between `base` and `head`.
+fn run_diff(base: &str, head: &str) -> Result<()> {
+    let repo = git::discover()?;
+    let files = git::diff_stat_files(&repo, base, head)?;
+
+    if files.is_empty() {
+        println!("{}", paint(fg(Color::Ansi(AnsiColor::Green)), "No changes found"));
+        return Ok(());
+    }
+
+    let theme = Theme::detect();
+    let header = format!(
+        "{count} files changed in {base}...{head}",
+        count = files.len(),
+    );
+    println!("{}\n", paint(fg(Color::Ansi(AnsiColor::Cyan)), &header));
+
+    println!("{}", tree::render(&files, theme));
+    println!();
+
+    Ok(())
+}

--- a/packages/git-log-pretty/src/palette.rs
+++ b/packages/git-log-pretty/src/palette.rs
@@ -1,0 +1,152 @@
+//! Terminal color helpers and light/dark theme detection.
+//!
+//! Styling goes through [`anstyle`] so callers render SGR sequences the same way
+//! the rest of the repo's terminal surfaces do. Theme detection asks the
+//! terminal for its background luma via [`terminal_light`]; a dark terminal gets
+//! brighter foregrounds and a light terminal gets darker, higher-contrast ones.
+
+use std::hash::{Hash, Hasher};
+
+use anstyle::{Color, RgbColor, Style};
+
+/// Whether the terminal background is light or dark. The variant selects file
+/// icon themes and the contrast direction for hashed conventional-commit chips.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Theme {
+    Light,
+    Dark,
+}
+
+impl Theme {
+    /// Probe the terminal background. Anything brighter than mid-gray counts as
+    /// a light theme; an unreadable or absent response falls back to `Dark`,
+    /// matching the common terminal default.
+    pub fn detect() -> Self {
+        match terminal_light::luma() {
+            Ok(luma) if luma > 0.5 => Self::Light,
+            _ => Self::Dark,
+        }
+    }
+
+    /// Map to the [`devicons`] theme so file icons pick readable glyph colors.
+    pub const fn devicons(self) -> devicons::Theme {
+        match self {
+            Self::Light => devicons::Theme::Light,
+            Self::Dark => devicons::Theme::Dark,
+        }
+    }
+}
+
+/// Neutral gray used for tree connectors and directory segments. Picked to read
+/// on both light and dark backgrounds without competing with the file colors.
+pub const GRAY: RgbColor = RgbColor(128, 128, 128);
+
+/// Build a foreground style for `color`.
+pub const fn fg(color: Color) -> Style {
+    Style::new().fg_color(Some(color))
+}
+
+/// Wrap `text` in `style`, appending the matching reset so later output is
+/// unstyled. `anstyle`'s `Display` renders the SGR prefix; `render_reset` closes
+/// it, which is the pattern used elsewhere in the repo (see `code-highlight`).
+pub fn paint(style: Style, text: &str) -> String {
+    format!("{style}{text}{reset}", reset = style.render_reset())
+}
+
+/// Pick a stable background color for a conventional-commit type by hashing the
+/// type string into a hue. Saturation and value shift with the theme so the
+/// chip stays legible under white text on dark terminals and black text on light
+/// ones.
+pub fn hashed_chip_background(label: &str, theme: Theme) -> RgbColor {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    label.hash(&mut hasher);
+    let hue = f32::from(u16::try_from(hasher.finish() % 360).unwrap_or(0));
+
+    let (saturation, value) = match theme {
+        Theme::Dark => (0.6, 0.5),
+        Theme::Light => (0.4, 0.8),
+    };
+
+    hsv_to_rgb(hue, saturation, value)
+}
+
+/// Foreground that contrasts with [`hashed_chip_background`] for the same theme.
+pub const fn chip_foreground(theme: Theme) -> RgbColor {
+    match theme {
+        Theme::Dark => RgbColor(255, 255, 255),
+        Theme::Light => RgbColor(0, 0, 0),
+    }
+}
+
+/// Parse a `#rrggbb` (or `rrggbb`) hex string into an RGB color, falling back to
+/// the neutral gray when the input is malformed. Devicons hands back colors in
+/// this shape.
+pub fn parse_hex(hex: &str) -> RgbColor {
+    let hex = hex.trim_start_matches('#');
+    let byte = |range: std::ops::Range<usize>| -> Option<u8> {
+        hex.get(range).and_then(|s| u8::from_str_radix(s, 16).ok())
+    };
+
+    match (byte(0..2), byte(2..4), byte(4..6)) {
+        (Some(r), Some(g), Some(b)) if hex.len() == 6 => RgbColor(r, g, b),
+        _ => GRAY,
+    }
+}
+
+/// Convert an HSV triple (hue in degrees, saturation and value in `0.0..=1.0`)
+/// into an 8-bit RGB color. Used to spread hashed commit-type hues across the
+/// wheel at a fixed saturation and value.
+fn hsv_to_rgb(hue: f32, saturation: f32, value: f32) -> RgbColor {
+    let chroma = value * saturation;
+    let second = chroma * (1.0 - ((hue / 60.0) % 2.0 - 1.0).abs());
+    let base = value - chroma;
+
+    let (red, green, blue) = match hue {
+        h if h < 60.0 => (chroma, second, 0.0),
+        h if h < 120.0 => (second, chroma, 0.0),
+        h if h < 180.0 => (0.0, chroma, second),
+        h if h < 240.0 => (0.0, second, chroma),
+        h if h < 300.0 => (second, 0.0, chroma),
+        _ => (chroma, 0.0, second),
+    };
+
+    // The clamp pins the value into `0..=255` before the cast, so neither
+    // truncation nor sign loss can change the result; the lints fire on the
+    // `as u8` syntax regardless.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let to_byte = |component: f32| ((component + base) * 255.0).round().clamp(0.0, 255.0) as u8;
+    RgbColor(to_byte(red), to_byte(green), to_byte(blue))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_hex_round_trips_six_digit_colors() {
+        assert_eq!(parse_hex("#114957"), RgbColor(0x11, 0x49, 0x57));
+        assert_eq!(parse_hex("ffffff"), RgbColor(0xff, 0xff, 0xff));
+    }
+
+    #[test]
+    fn parse_hex_falls_back_on_bad_input() {
+        assert_eq!(parse_hex("#xyz"), GRAY);
+        assert_eq!(parse_hex(""), GRAY);
+        assert_eq!(parse_hex("#1234"), GRAY);
+    }
+
+    #[test]
+    fn hashed_chip_background_is_stable_per_label() {
+        assert_eq!(
+            hashed_chip_background("feat", Theme::Dark),
+            hashed_chip_background("feat", Theme::Dark),
+        );
+    }
+
+    #[test]
+    fn hsv_primaries_map_to_expected_corners() {
+        assert_eq!(hsv_to_rgb(0.0, 1.0, 1.0), RgbColor(255, 0, 0));
+        assert_eq!(hsv_to_rgb(120.0, 1.0, 1.0), RgbColor(0, 255, 0));
+        assert_eq!(hsv_to_rgb(240.0, 1.0, 1.0), RgbColor(0, 0, 255));
+    }
+}

--- a/packages/git-log-pretty/src/time.rs
+++ b/packages/git-log-pretty/src/time.rs
@@ -1,0 +1,53 @@
+//! Relative timestamp formatting for commit times.
+
+use chrono::{DateTime, Utc};
+use color_eyre::eyre::{Result, eyre};
+
+/// Render a Unix timestamp (seconds) as a coarse "N units ago" string relative
+/// to now. Granularity steps down from days to hours to minutes, ending at
+/// `"just now"` for anything under a minute. Future timestamps (clock skew)
+/// also read as `"just now"`.
+pub fn relative(timestamp_secs: i64) -> Result<String> {
+    let then = DateTime::from_timestamp(timestamp_secs, 0)
+        .ok_or_else(|| eyre!("commit timestamp out of range: {timestamp_secs}"))?;
+    let elapsed = Utc::now().signed_duration_since(then);
+
+    let label = if elapsed.num_days() > 0 {
+        plural(elapsed.num_days(), "day")
+    } else if elapsed.num_hours() > 0 {
+        plural(elapsed.num_hours(), "hour")
+    } else if elapsed.num_minutes() > 0 {
+        plural(elapsed.num_minutes(), "minute")
+    } else {
+        "just now".to_string()
+    };
+
+    Ok(label)
+}
+
+/// Format `count` with `unit`, appending "ago" and pluralizing the unit.
+fn plural(count: i64, unit: &str) -> String {
+    let suffix = if count == 1 { "" } else { "s" };
+    format!("{count} {unit}{suffix} ago")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recent_timestamps_read_as_just_now() {
+        let now = Utc::now().timestamp();
+        assert_eq!(relative(now).unwrap(), "just now");
+        // Clock skew should not produce a negative count.
+        assert_eq!(relative(now + 5).unwrap(), "just now");
+    }
+
+    #[test]
+    fn singular_and_plural_units() {
+        let now = Utc::now().timestamp();
+        assert_eq!(relative(now - 3600).unwrap(), "1 hour ago");
+        assert_eq!(relative(now - 2 * 3600).unwrap(), "2 hours ago");
+        assert_eq!(relative(now - 86_400).unwrap(), "1 day ago");
+    }
+}

--- a/packages/git-log-pretty/src/tree.rs
+++ b/packages/git-log-pretty/src/tree.rs
@@ -1,0 +1,174 @@
+//! Render a set of changed file paths as a colored, icon-annotated tree.
+//!
+//! Paths are folded into a directory trie, single-child directory chains are
+//! collapsed (so `a/b/c.rs` shows as one `a/b` node), and each file gets its
+//! [`devicons`] glyph in the icon's own color. Directory segments render gray so
+//! the filename stays the focus.
+
+use std::collections::BTreeMap;
+
+use anstyle::Color;
+use devicons::icon_for_file;
+
+use crate::palette::{self, GRAY, Theme};
+
+/// Closed-folder glyph (Nerd Font `nf-md-folder`), shown for directory nodes.
+const FOLDER_GLYPH: &str = "\u{e5ff}";
+
+/// A node in the path trie. Leaves are files; interior nodes are directories.
+#[derive(Default)]
+struct Node {
+    is_file: bool,
+    children: BTreeMap<String, Self>,
+}
+
+/// Render `files` as a tree, one line per node, joined by newlines. Returns an
+/// empty string when there are no files so callers can skip printing.
+pub fn render(files: &[String], theme: Theme) -> String {
+    if files.is_empty() {
+        return String::new();
+    }
+
+    let mut root = Node::default();
+    for path in files {
+        insert(&mut root, path);
+    }
+    collapse(&mut root);
+
+    let mut lines = Vec::new();
+    render_children(&root, theme, "    ", &mut lines);
+    lines.join("\n")
+}
+
+/// Insert one slash-separated path into the trie, marking the final segment as a
+/// file.
+fn insert(root: &mut Node, path: &str) {
+    let parts: Vec<&str> = path.split('/').collect();
+    let mut node = root;
+
+    for (index, part) in parts.iter().enumerate() {
+        let is_last = index == parts.len() - 1;
+        node = node.children.entry((*part).to_string()).or_default();
+        node.is_file = node.is_file || is_last;
+    }
+}
+
+/// Collapse single-child directory chains so a deep unique path renders as one
+/// `dir/dir/leaf` node instead of nested connectors.
+fn collapse(node: &mut Node) {
+    let merges: Vec<(String, String)> = node
+        .children
+        .iter_mut()
+        .filter_map(|(name, child)| {
+            collapse(child);
+            let only_child = (!child.is_file && child.children.len() == 1)
+                .then(|| child.children.keys().next().cloned())
+                .flatten();
+            only_child.map(|child_name| (name.clone(), child_name))
+        })
+        .collect();
+
+    for (dir_name, child_name) in merges {
+        let Some(dir_node) = node.children.remove(&dir_name) else {
+            continue;
+        };
+        let Some(grandchild) = dir_node.children.into_values().next() else {
+            continue;
+        };
+        node.children.insert(format!("{dir_name}/{child_name}"), grandchild);
+    }
+}
+
+/// Render each child of `node`, drawing the `├──`/`└──` connector and recursing
+/// with an extended prefix for grandchildren.
+fn render_children(node: &Node, theme: Theme, prefix: &str, lines: &mut Vec<String>) {
+    let count = node.children.len();
+
+    for (index, (name, child)) in node.children.iter().enumerate() {
+        let is_last = index == count - 1;
+        let connector = if is_last { "└── " } else { "├── " };
+
+        let label = node_label(name, child, theme);
+        lines.push(format!(
+            "{prefix}{connector}{label}",
+            connector = palette::paint(palette::fg(Color::Rgb(GRAY)), connector),
+        ));
+
+        if !child.children.is_empty() {
+            let continuation = if is_last {
+                " ".to_string()
+            } else {
+                palette::paint(palette::fg(Color::Rgb(GRAY)), "│")
+            };
+            let next_prefix = format!("{prefix}{continuation}    ");
+            render_children(child, theme, &next_prefix, lines);
+        }
+    }
+}
+
+/// Build the styled label for one node: a gray directory name, or a file name
+/// (gray directory segments, white basename) followed by its colored icon.
+fn node_label(name: &str, child: &Node, theme: Theme) -> String {
+    let white = Color::Rgb(palette::chip_foreground(Theme::Dark));
+    let gray = palette::fg(Color::Rgb(GRAY));
+
+    if !child.is_file {
+        return format!(
+            "{} {}",
+            palette::paint(gray, FOLDER_GLYPH),
+            palette::paint(gray, name),
+        );
+    }
+
+    let icon = icon_for_file(name, &Some(theme.devicons()));
+    let icon_style = palette::fg(Color::Rgb(palette::parse_hex(icon.color)));
+
+    let name_part = name.rfind('/').map_or_else(
+        || palette::paint(palette::fg(white), name),
+        |slash| {
+            format!(
+                "{}{}",
+                palette::paint(gray, &name[..=slash]),
+                palette::paint(palette::fg(white), &name[slash + 1..]),
+            )
+        },
+    );
+
+    format!(
+        "{name_part} {icon}",
+        icon = palette::paint(icon_style, &icon.icon.to_string()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Strip SGR sequences so structural assertions ignore color.
+    fn plain(styled: &str) -> String {
+        let bytes = strip_ansi_escapes::strip(styled);
+        String::from_utf8(bytes).unwrap()
+    }
+
+    #[test]
+    fn empty_input_renders_nothing() {
+        assert_eq!(render(&[], Theme::Dark), "");
+    }
+
+    #[test]
+    fn single_chain_collapses_into_one_node() {
+        let rendered = plain(&render(&["a/b/c.rs".to_string()], Theme::Dark));
+        assert!(rendered.contains("a/b/c.rs"), "got: {rendered}");
+        assert_eq!(rendered.lines().count(), 1, "got: {rendered}");
+    }
+
+    #[test]
+    fn siblings_use_branch_and_last_connectors() {
+        let rendered = plain(&render(
+            &["src/a.rs".to_string(), "src/b.rs".to_string()],
+            Theme::Dark,
+        ));
+        assert!(rendered.contains("├── "), "got: {rendered}");
+        assert!(rendered.contains("└── "), "got: {rendered}");
+    }
+}

--- a/packages/git-log-pretty/tests/integration.rs
+++ b/packages/git-log-pretty/tests/integration.rs
@@ -1,0 +1,115 @@
+//! End-to-end checks that drive the built binary against a temporary git
+//! repository created with `git2`, so the output reflects real repo queries.
+
+use std::process::Command;
+
+use git2::{Repository, Signature};
+use tempfile::TempDir;
+
+/// Initialize a repo whose first commit sits on `main`, returning the open repo,
+/// the temp dir (kept alive for the test), the test signature, and the `main`
+/// commit oid. `git init`'s default branch name varies, so HEAD is forced to
+/// `refs/heads/main` before the first commit lands.
+fn init_on_main() -> (Repository, TempDir, git2::Oid) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = Repository::init(dir.path()).expect("init repo");
+    repo.set_head("refs/heads/main").expect("point HEAD at main");
+
+    let sig = signature();
+    std::fs::write(dir.path().join("README.md"), "hello\n").unwrap();
+    let main_oid = commit(&repo, &sig, &["README.md"], "chore: initial commit", &[]);
+
+    (repo, dir, main_oid)
+}
+
+/// Build a repo with one commit on `main` and a feature commit checked out on a
+/// branch that is one commit ahead.
+fn repo_ahead_of_main() -> TempDir {
+    let (repo, dir, main_oid) = init_on_main();
+    let sig = signature();
+
+    let main_commit = repo.find_commit(main_oid).unwrap();
+    repo.branch("feature", &main_commit, false).expect("create feature");
+    repo.set_head("refs/heads/feature").expect("checkout feature");
+
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/lib.rs"), "// code\n").unwrap();
+    commit(&repo, &sig, &["src/lib.rs"], "feat(core): add lib", &[main_oid]);
+
+    dir
+}
+
+/// A fixed test author so commits are deterministic.
+fn signature() -> Signature<'static> {
+    Signature::now("Tester", "tester@example.com").expect("signature")
+}
+
+/// Stage `paths`, write the tree, and create a commit with `parents`. Returns
+/// the new commit oid and updates HEAD.
+fn commit(
+    repo: &Repository,
+    sig: &Signature<'_>,
+    paths: &[&str],
+    message: &str,
+    parents: &[git2::Oid],
+) -> git2::Oid {
+    let mut index = repo.index().unwrap();
+    for path in paths {
+        index.add_path(std::path::Path::new(path)).unwrap();
+    }
+    index.write().unwrap();
+    let tree = repo.find_tree(index.write_tree().unwrap()).unwrap();
+
+    let parent_commits: Vec<git2::Commit> =
+        parents.iter().map(|oid| repo.find_commit(*oid).unwrap()).collect();
+    let parent_refs: Vec<&git2::Commit> = parent_commits.iter().collect();
+
+    repo.commit(Some("HEAD"), sig, sig, message, &tree, &parent_refs)
+        .unwrap()
+}
+
+/// Run the binary in `cwd` with `args`, returning its captured output.
+fn run(cwd: &std::path::Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_git-log-pretty"))
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("spawn git-log-pretty")
+}
+
+/// Strip SGR sequences so assertions can match the visible text.
+fn plain(bytes: &[u8]) -> String {
+    String::from_utf8(strip_ansi_escapes::strip(bytes)).unwrap()
+}
+
+#[test]
+fn log_lists_commits_ahead_of_main() {
+    let dir = repo_ahead_of_main();
+    let output = run(dir.path(), &[]);
+    assert!(output.status.success(), "stderr: {}", plain(&output.stderr));
+
+    let stdout = plain(&output.stdout);
+    assert!(stdout.contains("commit ahead of main"), "got: {stdout}");
+    assert!(stdout.contains("feat"), "missing chip type: {stdout}");
+    assert!(stdout.contains("src/lib.rs"), "missing file tree: {stdout}");
+}
+
+#[test]
+fn log_reports_caught_up_when_head_is_main() {
+    let (_repo, dir, _main_oid) = init_on_main();
+
+    let output = run(dir.path(), &[]);
+    assert!(output.status.success(), "stderr: {}", plain(&output.stderr));
+    assert!(plain(&output.stdout).contains("All caught up with main"));
+}
+
+#[test]
+fn diff_subcommand_renders_changed_file_tree() {
+    let dir = repo_ahead_of_main();
+    let output = run(dir.path(), &["diff", "main", "HEAD"]);
+    assert!(output.status.success(), "stderr: {}", plain(&output.stderr));
+
+    let stdout = plain(&output.stdout);
+    assert!(stdout.contains("files changed in main...HEAD"), "got: {stdout}");
+    assert!(stdout.contains("src/lib.rs"), "got: {stdout}");
+}


### PR DESCRIPTION
## Problem

The repo had no first-party pretty `git log` viewer. The standalone `git-log-pretty` tool lived in a separate personal repo with its own deps and flake, outside the workspace's shared dependency and Nix conventions.

## What

Adds `packages/git-log-pretty/`, a clean reimplementation built on the workspace's shared crates. With no subcommand it lists commits HEAD is ahead of `main` (newest first), each as a one-line summary plus an icon tree of the files it touched; conventional-commit types get a stable hashed background chip, timestamps are relative, and colors adapt to a light/dark terminal. The `diff` subcommand renders just the changed-file tree between two refs.

Implementation notes:

- Modules: `git` (libgit2 queries), `tree` (path trie + devicons), `palette` (anstyle styling, HSV chips, theme detection), `time` (relative timestamps), `display` (commit line + conventional-commit parsing). Conventional-commit parsing is hand-rolled, so `regex` is dropped; styling uses `anstyle` (repo idiom) instead of `crossterm`; theme detection uses `terminal-light`.
- `git2` is pinned to `default-features = false` with `vendored-libgit2`, so libgit2 builds from bundled C via `cc` with no system libgit2, cmake, openssl, or libssh2.

### Dependencies

Shared (already in `[workspace.dependencies]`): `anstyle`, `chrono`, `clap`, `color-eyre`, `strip-ansi-escapes`, `terminal-light`, `tempfile` (dev).

Newly added to `[workspace.dependencies]`: `git2`, `devicons`.

## Validation

- `cargo check -p git-log-pretty`
- `cargo test -p git-log-pretty` (17 tests: unit + integration against a real temp repo)
- `cargo clippy -p git-log-pretty --tests` (clean; workspace `pedantic`/`nursery`/`all` are deny)
- `nix build .#git-log-pretty`
- `nix run .#git-log-pretty -- --help` and live run against a scratch repo
- `nix run .#lint`

---

Authored with AI (Claude, model claude-opus-4-8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `git-log-pretty` crate for styled ahead-of-main commit log and diff view
> - Introduces a new binary crate at [packages/git-log-pretty](https://github.com/indexable-inc/index/pull/372/files#diff-c3d24d29c1f83c7089ede575ab50622a63556fd1d72f2a874d6c44a1ce7c68ae) that prints commits ahead of `main` with styled conventional-commit chips, relative timestamps, and per-commit file trees.
> - Adds a `diff` subcommand that renders an icon-annotated, collapsed directory tree of files changed between two refs (default `main`..`HEAD`).
> - Output caps at 15 commits, detects terminal light/dark theme for color selection, and uses hashed HSV colors for stable per-type commit chips.
> - Uses vendored libgit2 via the `git2` crate to avoid external system library dependencies at build time.
> - Adds integration tests that create temporary repos with `git2` and assert on stripped-ANSI stdout for log and diff modes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47fb2b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->