### PR TITLE
git-log-pretty: show recent log on main, extract shared terminal-theme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,7 +1629,7 @@ dependencies = [
  "git2",
  "strip-ansi-escapes",
  "tempfile",
- "terminal-light",
+ "terminal-theme",
 ]
 
 [[package]]
@@ -4265,7 +4265,7 @@ dependencies = [
  "mixedbread",
  "progress-style",
  "semantic-search-core",
- "terminal-light",
+ "terminal-theme",
  "tokio",
 ]
 
@@ -4905,6 +4905,13 @@ dependencies = [
  "crossterm",
  "thiserror 1.0.69",
  "xterm-query",
+]
+
+[[package]]
+name = "terminal-theme"
+version = "0.1.0"
+dependencies = [
+ "terminal-light",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "packages/tap",
   "packages/tap/protocol",
   "packages/tap/pty",
+  "packages/terminal-theme",
   "packages/tui",
   "packages/tui-dashboard",
   "packages/tui-dashboard-core",
@@ -124,6 +125,7 @@ tap-pty = { path = "packages/tap/pty" }
 tar = "0.4"
 tempfile = "3"
 terminal-light = "1"
+terminal-theme = { path = "packages/terminal-theme" }
 tokio = "1"
 tokio-stream = "0.1"
 toml = { version = "1.1.2", default-features = false }

--- a/packages/git-log-pretty/Cargo.toml
+++ b/packages/git-log-pretty/Cargo.toml
@@ -21,7 +21,7 @@ devicons.workspace = true
 # pkg-config first, which would add a system dependency to the workspace build.
 git2 = { workspace = true, default-features = false, features = ["vendored-libgit2"] }
 strip-ansi-escapes.workspace = true
-terminal-light.workspace = true
+terminal-theme.workspace = true
 
 [dev-dependencies]
 git2 = { workspace = true, default-features = false, features = ["vendored-libgit2"] }

--- a/packages/git-log-pretty/src/git.rs
+++ b/packages/git-log-pretty/src/git.rs
@@ -18,6 +18,43 @@ pub fn discover() -> Result<Repository> {
     Repository::discover(".").wrap_err("failed to discover a git repository from the current directory")
 }
 
+/// The short name of the branch HEAD points at, or `None` when HEAD is detached
+/// or otherwise not on a branch. Used to decide whether to show recent history
+/// (on `main`) or the ahead-of-`main` diff (anywhere else).
+pub fn head_branch_name(repo: &Repository) -> Option<String> {
+    let head = repo.head().ok()?;
+    head.is_branch().then(|| head.shorthand().map(str::to_string))?
+}
+
+/// Pair a commit with the files it changed, the shape the display layer expects.
+fn into_ahead<'repo>(repo: &Repository, commit: Commit<'repo>) -> Result<AheadCommit<'repo>> {
+    let changed_files = changed_files(repo, &commit)?;
+    Ok(AheadCommit {
+        commit,
+        changed_files,
+    })
+}
+
+/// The most recent `limit` commits reachable from HEAD, newest-first, each
+/// paired with the files it changed. Used when HEAD is `main` and there is
+/// nothing to be ahead of.
+pub fn recent_commits(repo: &Repository, limit: usize) -> Result<Vec<AheadCommit<'_>>> {
+    let mut revwalk = repo.revwalk().wrap_err("failed to start a revwalk")?;
+    revwalk
+        .set_sorting(git2::Sort::TIME)
+        .wrap_err("failed to set revwalk sorting")?;
+    revwalk.push_head().wrap_err("failed to seed the revwalk from HEAD")?;
+
+    revwalk
+        .take(limit)
+        .map(|oid| {
+            let oid = oid.wrap_err("failed to walk commit history")?;
+            let commit = repo.find_commit(oid).wrap_err("failed to load a commit")?;
+            into_ahead(repo, commit)
+        })
+        .collect()
+}
+
 /// Resolve the single commit id a reference points at, erroring when the ref is
 /// symbolic or otherwise has no direct target.
 fn target_oid(reference: &git2::Reference, label: &str) -> Result<Oid> {
@@ -37,6 +74,10 @@ fn resolve_ref<'repo>(repo: &'repo Repository, name: &str) -> Result<git2::Refer
     let candidates = [
         format!("refs/heads/{name}"),
         format!("refs/remotes/{name}"),
+        // Single-branch clones (CI, fresh checkouts) often have only the feature
+        // branch locally while the base lives at `origin/<name>`, so fall back to
+        // the remote-tracking branch before giving up.
+        format!("refs/remotes/origin/{name}"),
         name.to_string(),
     ];
 
@@ -94,35 +135,35 @@ pub fn commits_ahead<'repo>(repo: &'repo Repository, base: &str) -> Result<Vec<A
 
     ahead.sort_by_key(|commit| std::cmp::Reverse(commit.time().seconds()));
 
-    ahead
-        .into_iter()
-        .map(|commit| {
-            let changed_files = changed_files(repo, &commit)?;
-            Ok(AheadCommit {
-                commit,
-                changed_files,
-            })
-        })
-        .collect()
+    ahead.into_iter().map(|commit| into_ahead(repo, commit)).collect()
 }
 
-/// Paths that differ between `base` and `head` trees, used by the `diff`
-/// subcommand. `head` accepts `"HEAD"` for the current head.
+/// Paths `head` changed relative to where it forked from `base`, used by the
+/// `diff` subcommand. This is the `base...head` (merge-base) view git's `diff`
+/// advertises with the triple dot: diffing the merge base against `head` so
+/// commits that landed on `base` after the fork point do not pollute the tree.
+/// `head` accepts `"HEAD"` for the current head.
 pub fn diff_stat_files(repo: &Repository, base: &str, head: &str) -> Result<Vec<String>> {
-    let base_commit = repo
-        .find_commit(target_oid(&resolve_ref(repo, base)?, base)?)
-        .wrap_err("failed to load the base commit")?;
+    let base_oid = target_oid(&resolve_ref(repo, base)?, base)?;
+    let head_oid = target_oid(&resolve_ref(repo, head)?, head)?;
+
+    let merge_base_oid = repo
+        .merge_base(base_oid, head_oid)
+        .wrap_err("failed to find the merge base of base and head")?;
+    let merge_base_commit = repo
+        .find_commit(merge_base_oid)
+        .wrap_err("failed to load the merge-base commit")?;
     let head_commit = repo
-        .find_commit(target_oid(&resolve_ref(repo, head)?, head)?)
+        .find_commit(head_oid)
         .wrap_err("failed to load the head commit")?;
 
-    let base_tree = base_commit.tree().wrap_err("failed to read base tree")?;
+    let base_tree = merge_base_commit.tree().wrap_err("failed to read merge-base tree")?;
     let head_tree = head_commit.tree().wrap_err("failed to read head tree")?;
 
     let mut options = DiffOptions::new();
     let diff = repo
         .diff_tree_to_tree(Some(&base_tree), Some(&head_tree), Some(&mut options))
-        .wrap_err("failed to diff base against head")?;
+        .wrap_err("failed to diff merge base against head")?;
 
     Ok(collect_diff_paths(&diff))
 }

--- a/packages/git-log-pretty/src/main.rs
+++ b/packages/git-log-pretty/src/main.rs
@@ -1,8 +1,10 @@
 //! `git-log-pretty`: a pretty `git log` viewer.
 //!
-//! With no subcommand it lists the commits HEAD is ahead of `main`, newest
-//! first, each as a one-line summary plus an icon tree of the files it touched.
-//! The `diff` subcommand renders just the changed-file tree between two refs.
+//! With no subcommand it shows recent history newest-first, each commit a
+//! one-line summary plus an icon tree of the files it touched. On `main` it
+//! lists `main`'s own recent commits; on any other branch it lists only the
+//! commits HEAD is ahead of `main`. The `diff` subcommand renders just the
+//! changed-file tree between two refs.
 
 use anstyle::{AnsiColor, Color};
 use clap::{Parser, Subcommand};
@@ -14,7 +16,7 @@ mod palette;
 mod time;
 mod tree;
 
-use palette::{Theme, fg, paint};
+use palette::{Theme, detect, fg, paint};
 
 /// How many ahead-of-base commits to print before summarizing the rest. The
 /// list is newest-first, so the cap keeps the common "what have I done lately"
@@ -51,19 +53,27 @@ fn main() -> Result<()> {
     }
 }
 
-/// Render the ahead-of-`main` commit log for the current repository.
+/// Render the default commit log for the current repository. On `main` this is
+/// `main`'s own recent history; on any other branch it is the commits HEAD is
+/// ahead of `main`.
 fn run_log() -> Result<()> {
     let repo = git::discover()?;
-    let ahead = git::commits_ahead(&repo, "main")?;
+    let theme = detect();
 
+    // On `main` there is nothing to be ahead of, so an ahead-of-main diff would
+    // always be empty. Show recent history instead of "All caught up".
+    if git::head_branch_name(&repo).as_deref() == Some("main") {
+        let recent = git::recent_commits(&repo, MAX_COMMITS)?;
+        return print_log("Recent commits on main", &recent, theme);
+    }
+
+    let ahead = git::commits_ahead(&repo, "main")?;
     if ahead.is_empty() {
         println!("{}", paint(fg(Color::Ansi(AnsiColor::Green)), "All caught up with main"));
         return Ok(());
     }
 
-    let theme = Theme::detect();
     let hidden = ahead.len().saturating_sub(MAX_COMMITS);
-
     let header = if hidden > 0 {
         let detail = paint(
             fg(Color::Ansi(AnsiColor::BrightBlack)),
@@ -74,12 +84,16 @@ fn run_log() -> Result<()> {
         let label = if ahead.len() == 1 { "commit" } else { "commits" };
         format!("{count} {label} ahead of main", count = ahead.len())
     };
-    println!("{}\n", paint(fg(Color::Ansi(AnsiColor::Cyan)), &header));
 
-    for commit in ahead.iter().take(MAX_COMMITS) {
+    print_log(&header, &ahead[..ahead.len().min(MAX_COMMITS)], theme)
+}
+
+/// Print a cyan header followed by each commit block.
+fn print_log(header: &str, commits: &[git::AheadCommit<'_>], theme: Theme) -> Result<()> {
+    println!("{}\n", paint(fg(Color::Ansi(AnsiColor::Cyan)), header));
+    for commit in commits {
         display::print_commit(commit, theme)?;
     }
-
     Ok(())
 }
 
@@ -93,7 +107,7 @@ fn run_diff(base: &str, head: &str) -> Result<()> {
         return Ok(());
     }
 
-    let theme = Theme::detect();
+    let theme = detect();
     let header = format!(
         "{count} files changed in {base}...{head}",
         count = files.len(),

--- a/packages/git-log-pretty/src/palette.rs
+++ b/packages/git-log-pretty/src/palette.rs
@@ -1,39 +1,22 @@
-//! Terminal color helpers and light/dark theme detection.
+//! Terminal color helpers keyed off the detected light/dark theme.
 //!
 //! Styling goes through [`anstyle`] so callers render SGR sequences the same way
-//! the rest of the repo's terminal surfaces do. Theme detection asks the
-//! terminal for its background luma via [`terminal_light`]; a dark terminal gets
+//! the rest of the repo's terminal surfaces do. The light/dark decision is owned
+//! by [`terminal_theme`] and re-exported here as [`Theme`]; a dark terminal gets
 //! brighter foregrounds and a light terminal gets darker, higher-contrast ones.
 
 use std::hash::{Hash, Hasher};
 
 use anstyle::{Color, RgbColor, Style};
 
-/// Whether the terminal background is light or dark. The variant selects file
-/// icon themes and the contrast direction for hashed conventional-commit chips.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Theme {
-    Light,
-    Dark,
-}
+pub use terminal_theme::{Theme, detect};
 
-impl Theme {
-    /// Probe the terminal background. Anything brighter than mid-gray counts as
-    /// a light theme; an unreadable or absent response falls back to `Dark`,
-    /// matching the common terminal default.
-    pub fn detect() -> Self {
-        match terminal_light::luma() {
-            Ok(luma) if luma > 0.5 => Self::Light,
-            _ => Self::Dark,
-        }
-    }
-
-    /// Map to the [`devicons`] theme so file icons pick readable glyph colors.
-    pub const fn devicons(self) -> devicons::Theme {
-        match self {
-            Self::Light => devicons::Theme::Light,
-            Self::Dark => devicons::Theme::Dark,
-        }
+/// Map a [`Theme`] to the [`devicons`] theme so file icons pick readable glyph
+/// colors against the detected background.
+pub const fn devicons(theme: Theme) -> devicons::Theme {
+    match theme {
+        Theme::Light => devicons::Theme::Light,
+        Theme::Dark => devicons::Theme::Dark,
     }
 }
 

--- a/packages/git-log-pretty/src/tree.rs
+++ b/packages/git-log-pretty/src/tree.rs
@@ -107,9 +107,11 @@ fn render_children(node: &Node, theme: Theme, prefix: &str, lines: &mut Vec<Stri
 }
 
 /// Build the styled label for one node: a gray directory name, or a file name
-/// (gray directory segments, white basename) followed by its colored icon.
+/// (gray directory segments, high-contrast basename) followed by its colored
+/// icon. The basename follows the detected theme so it stays readable on light
+/// terminals (black) as well as dark ones (white).
 fn node_label(name: &str, child: &Node, theme: Theme) -> String {
-    let white = Color::Rgb(palette::chip_foreground(Theme::Dark));
+    let basename_fg = Color::Rgb(palette::chip_foreground(theme));
     let gray = palette::fg(Color::Rgb(GRAY));
 
     if !child.is_file {
@@ -120,16 +122,16 @@ fn node_label(name: &str, child: &Node, theme: Theme) -> String {
         );
     }
 
-    let icon = icon_for_file(name, &Some(theme.devicons()));
+    let icon = icon_for_file(name, &Some(palette::devicons(theme)));
     let icon_style = palette::fg(Color::Rgb(palette::parse_hex(icon.color)));
 
     let name_part = name.rfind('/').map_or_else(
-        || palette::paint(palette::fg(white), name),
+        || palette::paint(palette::fg(basename_fg), name),
         |slash| {
             format!(
                 "{}{}",
                 palette::paint(gray, &name[..=slash]),
-                palette::paint(palette::fg(white), &name[slash + 1..]),
+                palette::paint(palette::fg(basename_fg), &name[slash + 1..]),
             )
         },
     );

--- a/packages/git-log-pretty/tests/integration.rs
+++ b/packages/git-log-pretty/tests/integration.rs
@@ -95,12 +95,65 @@ fn log_lists_commits_ahead_of_main() {
 }
 
 #[test]
-fn log_reports_caught_up_when_head_is_main() {
+fn log_shows_recent_history_on_main() {
+    // On `main` there is nothing to be ahead of, so the default view lists
+    // main's own recent commits rather than reporting "caught up".
     let (_repo, dir, _main_oid) = init_on_main();
 
     let output = run(dir.path(), &[]);
     assert!(output.status.success(), "stderr: {}", plain(&output.stderr));
+
+    let stdout = plain(&output.stdout);
+    assert!(stdout.contains("Recent commits on main"), "got: {stdout}");
+    assert!(stdout.contains("initial commit"), "missing commit: {stdout}");
+}
+
+#[test]
+fn log_reports_caught_up_off_main_when_level_with_main() {
+    // A non-main branch sitting exactly at main has no ahead commits, so the
+    // caught-up message still applies there.
+    let (repo, dir, main_oid) = init_on_main();
+    let main_commit = repo.find_commit(main_oid).unwrap();
+    repo.branch("feature", &main_commit, false).expect("create feature");
+    repo.set_head("refs/heads/feature").expect("checkout feature");
+
+    let output = run(dir.path(), &[]);
+    assert!(output.status.success(), "stderr: {}", plain(&output.stderr));
     assert!(plain(&output.stdout).contains("All caught up with main"));
+}
+
+#[test]
+fn diff_uses_merge_base_after_main_advances() {
+    // main advances past the branch point. The branch only touched src/lib.rs,
+    // so the `main...HEAD` diff must not include main-only files.
+    let (repo, dir, main_oid) = init_on_main();
+    let sig = signature();
+
+    let main_commit = repo.find_commit(main_oid).unwrap();
+    repo.branch("feature", &main_commit, false).expect("create feature");
+
+    // One commit on main after the fork point, touching a file the branch never
+    // sees.
+    std::fs::write(dir.path().join("main-only.md"), "main\n").unwrap();
+    commit(&repo, &sig, &["main-only.md"], "docs: main only", &[main_oid]);
+
+    // The feature branch diverges with its own file. Reset the shared index to
+    // the fork-point tree first; otherwise main-only.md staged above would leak
+    // into the feature commit's tree.
+    repo.set_head("refs/heads/feature").expect("checkout feature");
+    let mut index = repo.index().unwrap();
+    index.read_tree(&main_commit.tree().unwrap()).unwrap();
+    index.write().unwrap();
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/lib.rs"), "// code\n").unwrap();
+    commit(&repo, &sig, &["src/lib.rs"], "feat(core): add lib", &[main_oid]);
+
+    let output = run(dir.path(), &["diff", "main", "HEAD"]);
+    assert!(output.status.success(), "stderr: {}", plain(&output.stderr));
+
+    let stdout = plain(&output.stdout);
+    assert!(stdout.contains("src/lib.rs"), "missing branch file: {stdout}");
+    assert!(!stdout.contains("main-only.md"), "leaked main-only file: {stdout}");
 }
 
 #[test]

--- a/packages/semantic-search/Cargo.toml
+++ b/packages/semantic-search/Cargo.toml
@@ -23,5 +23,5 @@ indicatif.workspace = true
 mixedbread.workspace = true
 progress-style.workspace = true
 semantic-search-core.workspace = true
-terminal-light.workspace = true
+terminal-theme.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/packages/semantic-search/src/main.rs
+++ b/packages/semantic-search/src/main.rs
@@ -280,19 +280,17 @@ fn paint(style: Style, text: &str) -> String {
 
 /// Resolve the islands theme variant from the terminal background.
 ///
-/// Queries the background luminance once (OSC 11, via `terminal-light`) and
-/// picks the light palette above 0.5 luma, the dark palette below. Returns the
-/// dark default when color is off, stdout is not a TTY, or the terminal does not
-/// answer, so a piped or unsupported terminal never blocks on a reply that will
-/// not come.
+/// Probes the terminal background once via [`terminal_theme`] and maps it to the
+/// highlighter's palette. Returns the dark default when color is off, leaving the
+/// TTY-gating and luma probe to the shared crate so a piped or unsupported
+/// terminal never blocks on a reply that will not come.
 fn detect_theme(color: bool) -> code_highlight::Theme {
-    use code_highlight::Theme;
-    if !color || !std::io::stdout().is_terminal() {
-        return Theme::Dark;
+    if !color {
+        return code_highlight::Theme::Dark;
     }
-    match terminal_light::luma() {
-        Ok(luma) if luma > 0.5 => Theme::Light,
-        _ => Theme::Dark,
+    match terminal_theme::detect() {
+        terminal_theme::Theme::Light => code_highlight::Theme::Light,
+        terminal_theme::Theme::Dark => code_highlight::Theme::Dark,
     }
 }
 

--- a/packages/terminal-theme/Cargo.toml
+++ b/packages/terminal-theme/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "terminal-theme"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Detect whether the terminal background is light or dark, gated on stdout being a TTY so pipes and captures stay clean"
+
+[lints]
+workspace = true
+
+[dependencies]
+terminal-light.workspace = true

--- a/packages/terminal-theme/package.nix
+++ b/packages/terminal-theme/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "terminal-theme";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/terminal-theme/src/lib.rs
+++ b/packages/terminal-theme/src/lib.rs
@@ -1,0 +1,60 @@
+//! Detect whether the terminal background is light or dark.
+//!
+//! This owns one decision shared across the repo's terminal tools: probe the
+//! terminal for its background luma via [`terminal_light`] and classify it as
+//! [`Theme::Light`] or [`Theme::Dark`]. The probe writes an OSC color query and
+//! waits for the terminal to answer, so it only runs when stdout is a TTY.
+//! Under a pipe, a capture, or a test the query bytes would corrupt the output
+//! (or block on a reply that never comes), so non-interactive stdout falls back
+//! to [`Theme::Dark`], the common terminal default.
+//!
+//! Callers with their own "should I emit color at all" flag (for example a
+//! `--color` switch) keep that decision local and only call [`detect`] once
+//! they've decided color is wanted.
+
+use std::io::IsTerminal;
+
+/// Whether the terminal background reads as light or dark. Tools map this to
+/// their own palettes; the shared part is only the classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Theme {
+    /// A light background, or anything brighter than mid-gray.
+    Light,
+    /// A dark background, and the fallback when the terminal cannot be probed.
+    #[default]
+    Dark,
+}
+
+/// Probe the terminal background and classify it.
+///
+/// Returns [`Theme::Dark`] without probing when stdout is not a terminal, so
+/// the query bytes never leak into a pipe or capture. Anything brighter than
+/// mid-gray (luma above `0.5`) counts as light; an unreadable or absent
+/// response also falls back to [`Theme::Dark`].
+#[must_use]
+pub fn detect() -> Theme {
+    if !std::io::stdout().is_terminal() {
+        return Theme::Dark;
+    }
+    match terminal_light::luma() {
+        Ok(luma) if luma > 0.5 => Theme::Light,
+        _ => Theme::Dark,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_dark() {
+        assert_eq!(Theme::default(), Theme::Dark);
+    }
+
+    #[test]
+    fn non_tty_stdout_falls_back_to_dark() {
+        // The test harness captures stdout, so it is never a TTY here; detect
+        // must not probe and must return the dark fallback.
+        assert_eq!(detect(), Theme::Dark);
+    }
+}


### PR DESCRIPTION
## What

Two things, plus the AI review fixes from #372.

**Default view on `main`.** With no subcommand, `git-log-pretty` compared `HEAD` against itself when you were on `main`, so it always printed "All caught up with main". It now lists `main`'s own recent commits there. Every other branch keeps the ahead-of-main view, and a non-main branch sitting level with `main` still shows "All caught up".

**Shared `terminal-theme` crate.** The "is the terminal light or dark" probe was duplicated between `git-log-pretty` and `semantic-search`. Extracted into a new `packages/terminal-theme` library that owns the TTY-gated OSC luma probe and falls back to dark off a TTY (so pipes and captures stay clean). Both crates now depend on it; each keeps its own `--color`-style decision local.

## Review fixes folded in (from #372)

- **diff merge-base** (`git.rs`): the `diff` subcommand now diffs `merge_base(base, head)` against `head`, so commits that landed on `main` after the fork point no longer pollute the `main...HEAD` file tree.
- **`origin/main` fallback** (`git.rs`): the base ref also resolves against `refs/remotes/origin/<name>`, so single-branch clones (CI, fresh checkouts) find `main` when only the remote-tracking ref exists locally.
- **light-theme contrast** (`tree.rs`): file basenames follow the detected theme, staying readable (black) on light terminals instead of always white.
- **non-TTY probe** (was `palette.rs`, now `terminal-theme`): theme detection no longer probes when stdout is not a terminal.

## Validation

- `cargo test -p terminal-theme -p git-log-pretty -p semantic-search` (new tests: on-main shows recent log, off-main level-with-main still caught up, diff uses merge base, non-TTY falls back to dark)
- `cargo clippy` clean on the three crates (workspace pedantic/nursery/all are deny)
- `nix run .#lint`
- `nix build .#git-log-pretty`
- Live: ran the binary on `main` ("Recent commits on main" + file tree) and on a branch level with `main` ("All caught up with main")

Authored with AI (Claude, model claude-opus-4-8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show recent commits on main branch in git-log-pretty and extract shared terminal-theme crate
> - Adds a new `packages/terminal-theme` crate that centralises theme detection: returns `Dark` by default when stdout is not a TTY, otherwise probes via `terminal-light`.
> - Updates `git-log-pretty` and `semantic-search` to depend on `terminal-theme` instead of `terminal-light` directly.
> - Changes `git-log-pretty` default view: when HEAD is on `main`, shows recent commits with a 'Recent commits on main' header; off `main`, continues to show commits ahead of `main`.
> - Fixes diff semantics in `git-log-pretty` to use merge-base (`base...head`) so diffs exclude files only changed on base after the fork point.
> - Fixes `tree.node_label` to use theme-appropriate foreground color for file basenames, correcting light-terminal rendering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7cd5809.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->