### PR TITLE
git-log-pretty: page output through $PAGER like git log

### DIFF
--- a/packages/git-log-pretty/src/display.rs
+++ b/packages/git-log-pretty/src/display.rs
@@ -62,9 +62,13 @@ fn format_summary(summary: &str, theme: Theme) -> String {
     )
 }
 
-/// Print one commit block: a `shorthash summary • relative-time` line followed
-/// by the indented changed-file tree and a trailing blank line.
-pub fn print_commit(ahead: &git::AheadCommit<'_>, theme: Theme) -> color_eyre::eyre::Result<()> {
+/// Write one commit block to `out`: a `shorthash summary • relative-time` line
+/// followed by the indented changed-file tree and a trailing blank line.
+pub fn print_commit(
+    out: &mut dyn std::io::Write,
+    ahead: &git::AheadCommit<'_>,
+    theme: Theme,
+) -> color_eyre::eyre::Result<()> {
     let commit = &ahead.commit;
     let short = commit
         .id()
@@ -78,19 +82,20 @@ pub fn print_commit(ahead: &git::AheadCommit<'_>, theme: Theme) -> color_eyre::e
     let yellow = palette::fg(Color::Ansi(AnsiColor::Yellow));
     let dim = palette::fg(Color::Ansi256(Ansi256Color(8)));
 
-    println!(
+    writeln!(
+        out,
         "  {short} {summary} {bullet} {when}",
         short = palette::paint(yellow, &short),
         summary = format_summary(summary, theme),
         bullet = palette::paint(dim, "•"),
         when = palette::paint(dim, &when),
-    );
+    )?;
 
     let icons = tree::render(&ahead.changed_files, theme);
     if !icons.is_empty() {
-        println!("{icons}");
+        writeln!(out, "{icons}")?;
     }
-    println!();
+    writeln!(out)?;
 
     Ok(())
 }

--- a/packages/git-log-pretty/src/main.rs
+++ b/packages/git-log-pretty/src/main.rs
@@ -5,6 +5,11 @@
 //! lists `main`'s own recent commits; on any other branch it lists only the
 //! commits HEAD is ahead of `main`. The `diff` subcommand renders just the
 //! changed-file tree between two refs.
+//!
+//! On a terminal the output is piped through a pager (`$PAGER`, else `less`),
+//! like `git log`; redirected output skips the pager. See [`pager`].
+
+use std::io::Write;
 
 use anstyle::{AnsiColor, Color};
 use clap::{Parser, Subcommand};
@@ -12,6 +17,7 @@ use color_eyre::eyre::{Result, WrapErr};
 
 mod display;
 mod git;
+mod pager;
 mod palette;
 mod time;
 mod tree;
@@ -26,6 +32,9 @@ const MAX_COMMITS: usize = 15;
 #[derive(Parser)]
 #[command(name = "git-log-pretty", about = "A pretty git log viewer with file-icon trees")]
 struct Cli {
+    /// Write directly to stdout instead of piping through a pager.
+    #[arg(long, global = true)]
+    no_pager: bool,
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -47,16 +56,20 @@ enum Command {
 fn main() -> Result<()> {
     color_eyre::install()?;
 
-    match Cli::parse().command {
-        Some(Command::Diff { base, head }) => run_diff(&base, &head).wrap_err("failed to render diff stats"),
-        None => run_log().wrap_err("failed to render git log"),
+    let cli = Cli::parse();
+    let allow_pager = !cli.no_pager;
+    match cli.command {
+        Some(Command::Diff { base, head }) => {
+            run_diff(&base, &head, allow_pager).wrap_err("failed to render diff stats")
+        }
+        None => run_log(allow_pager).wrap_err("failed to render git log"),
     }
 }
 
 /// Render the default commit log for the current repository. On `main` this is
 /// `main`'s own recent history; on any other branch it is the commits HEAD is
 /// ahead of `main`.
-fn run_log() -> Result<()> {
+fn run_log(allow_pager: bool) -> Result<()> {
     let repo = git::discover()?;
     let theme = detect();
 
@@ -64,7 +77,9 @@ fn run_log() -> Result<()> {
     // always be empty. Show recent history instead of "All caught up".
     if git::head_branch_name(&repo).as_deref() == Some("main") {
         let recent = git::recent_commits(&repo, MAX_COMMITS)?;
-        return print_log("Recent commits on main", &recent, theme);
+        return pager::paged(allow_pager, |out| {
+            print_log(out, "Recent commits on main", &recent, theme)
+        });
     }
 
     let ahead = git::commits_ahead(&repo, "main")?;
@@ -85,20 +100,21 @@ fn run_log() -> Result<()> {
         format!("{count} {label} ahead of main", count = ahead.len())
     };
 
-    print_log(&header, &ahead[..ahead.len().min(MAX_COMMITS)], theme)
+    let shown = &ahead[..ahead.len().min(MAX_COMMITS)];
+    pager::paged(allow_pager, |out| print_log(out, &header, shown, theme))
 }
 
-/// Print a cyan header followed by each commit block.
-fn print_log(header: &str, commits: &[git::AheadCommit<'_>], theme: Theme) -> Result<()> {
-    println!("{}\n", paint(fg(Color::Ansi(AnsiColor::Cyan)), header));
+/// Write a cyan header followed by each commit block to `out`.
+fn print_log(out: &mut dyn Write, header: &str, commits: &[git::AheadCommit<'_>], theme: Theme) -> Result<()> {
+    writeln!(out, "{}\n", paint(fg(Color::Ansi(AnsiColor::Cyan)), header))?;
     for commit in commits {
-        display::print_commit(commit, theme)?;
+        display::print_commit(out, commit, theme)?;
     }
     Ok(())
 }
 
 /// Render the changed-file tree between `base` and `head`.
-fn run_diff(base: &str, head: &str) -> Result<()> {
+fn run_diff(base: &str, head: &str, allow_pager: bool) -> Result<()> {
     let repo = git::discover()?;
     let files = git::diff_stat_files(&repo, base, head)?;
 
@@ -112,10 +128,11 @@ fn run_diff(base: &str, head: &str) -> Result<()> {
         "{count} files changed in {base}...{head}",
         count = files.len(),
     );
-    println!("{}\n", paint(fg(Color::Ansi(AnsiColor::Cyan)), &header));
 
-    println!("{}", tree::render(&files, theme));
-    println!();
-
-    Ok(())
+    pager::paged(allow_pager, |out| {
+        writeln!(out, "{}\n", paint(fg(Color::Ansi(AnsiColor::Cyan)), &header))?;
+        writeln!(out, "{}", tree::render(&files, theme))?;
+        writeln!(out)?;
+        Ok(())
+    })
 }

--- a/packages/git-log-pretty/src/pager.rs
+++ b/packages/git-log-pretty/src/pager.rs
@@ -1,0 +1,109 @@
+//! Route long output through a pager, the way `git log` does.
+//!
+//! When stdout is a terminal we spawn a pager and write the rendered output to
+//! its stdin, leaving our own stdout pointed at the terminal so theme detection
+//! still sees a TTY. Off a TTY (a pipe, a capture, a test) we write straight to
+//! stdout, so machine consumers get the exact bytes with no pager in the way.
+//!
+//! The pager is `$PAGER` when set (run through `sh -c`, so `PAGER="less -R"`
+//! and pipelines work), falling back to `less`. An empty `$PAGER` disables
+//! paging, matching git. We default `$LESS` to `FRX` when unset: quit if the
+//! output fits one screen, keep ANSI color, and leave the text in scrollback
+//! instead of an alternate screen.
+
+use std::io::{self, IsTerminal, Write};
+use std::process::{Child, Command, Stdio};
+
+use color_eyre::eyre::{Result, WrapErr};
+
+/// Run `render` with a writer that is the pager's stdin on a TTY, or stdout
+/// otherwise.
+///
+/// `paged` is `true` to allow paging (the default for log views); pass `false`
+/// for `--no-pager`. A pager that the reader quits early closes the pipe, which
+/// surfaces as [`io::ErrorKind::BrokenPipe`]; that is a normal "I've seen
+/// enough" exit, so it is swallowed rather than reported as a failure.
+pub fn paged<F>(allow: bool, render: F) -> Result<()>
+where
+    F: FnOnce(&mut dyn Write) -> Result<()>,
+{
+    if allow && io::stdout().is_terminal()
+        && let Some(mut child) = spawn()
+    {
+        let result = {
+            let mut stdin = child.stdin.take().expect("pager spawned with piped stdin");
+            render(&mut stdin)
+            // `stdin` drops here, closing the pipe so the pager sees EOF.
+        };
+        let result = swallow_broken_pipe(result);
+        child.wait().wrap_err("failed to wait for the pager")?;
+        return result;
+    }
+
+    let mut stdout = io::stdout().lock();
+    swallow_broken_pipe(render(&mut stdout))
+}
+
+/// Map a broken-pipe error to success; pass every other result through.
+fn swallow_broken_pipe(result: Result<()>) -> Result<()> {
+    match result {
+        Err(report)
+            if report
+                .downcast_ref::<io::Error>()
+                .is_some_and(|err| err.kind() == io::ErrorKind::BrokenPipe) =>
+        {
+            Ok(())
+        }
+        other => other,
+    }
+}
+
+/// Spawn the configured pager with piped stdin, or `None` when paging is
+/// disabled (empty `$PAGER`) or the pager cannot be launched.
+fn spawn() -> Option<Child> {
+    let command = match std::env::var("PAGER") {
+        Ok(value) if value.trim().is_empty() => return None,
+        Ok(value) => value,
+        Err(_) => "less".to_string(),
+    };
+
+    if std::env::var_os("LESS").is_none() {
+        // Match git's defaults: -F quit if one screen, -R keep color, -X stay in
+        // scrollback. SAFETY note: set before spawning, single-threaded here.
+        unsafe { std::env::set_var("LESS", "FRX") };
+    }
+
+    let child = Command::new("sh")
+        .arg("-c")
+        .arg(&command)
+        .stdin(Stdio::piped())
+        .spawn();
+
+    // A missing or unlaunchable pager should not fail the command; fall back to
+    // writing directly to stdout instead.
+    child.ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use color_eyre::eyre::eyre;
+
+    use super::*;
+
+    #[test]
+    fn broken_pipe_becomes_ok() {
+        let err = io::Error::new(io::ErrorKind::BrokenPipe, "reader quit");
+        assert!(swallow_broken_pipe(Err(err.into())).is_ok());
+    }
+
+    #[test]
+    fn other_io_error_passes_through() {
+        let err = io::Error::new(io::ErrorKind::PermissionDenied, "nope");
+        assert!(swallow_broken_pipe(Err(err.into())).is_err());
+    }
+
+    #[test]
+    fn non_io_error_passes_through() {
+        assert!(swallow_broken_pipe(Err(eyre!("unrelated"))).is_err());
+    }
+}

--- a/packages/git-log-pretty/tests/integration.rs
+++ b/packages/git-log-pretty/tests/integration.rs
@@ -95,6 +95,19 @@ fn log_lists_commits_ahead_of_main() {
 }
 
 #[test]
+fn no_pager_flag_is_accepted_and_renders_log() {
+    // The pager only engages on a TTY, which the test harness never is, so this
+    // mainly guards that `--no-pager` parses and the writer path still renders.
+    let dir = repo_ahead_of_main();
+    let output = run(dir.path(), &["--no-pager"]);
+    assert!(output.status.success(), "stderr: {}", plain(&output.stderr));
+
+    let stdout = plain(&output.stdout);
+    assert!(stdout.contains("commit ahead of main"), "got: {stdout}");
+    assert!(stdout.contains("src/lib.rs"), "missing file tree: {stdout}");
+}
+
+#[test]
 fn log_shows_recent_history_on_main() {
     // On `main` there is nothing to be ahead of, so the default view lists
     // main's own recent commits rather than reporting "caught up".


### PR DESCRIPTION
## What

`git-log-pretty` now pages its output like `git log`. On a terminal the log and diff views pipe through a pager; redirected or captured output writes straight to stdout, so scripts and tests are unaffected.

- **Pager selection**: `$PAGER` when set (run through `sh -c`, so `PAGER="less -R"` and pipelines work), else `less`. An empty `$PAGER` disables paging. `--no-pager` forces direct output.
- **`$LESS` default** `FRX` when unset: quit if the output fits one screen, keep ANSI color, stay in scrollback (no alternate screen).
- **Theme detection stays correct**: the pager is a child process reading our rendered output from its stdin, so our own stdout still points at the terminal and the light/dark probe still sees a TTY.
- **Broken-pipe fix**: output now flows through a writer instead of `println!`, so quitting the pager early (closed pipe) is a clean "seen enough" exit instead of the panic the old println path produced when piped to `head`/`less`.

## Validation

- `cargo test -p git-log-pretty` (17 unit + 6 integration; new: `--no-pager` renders, broken-pipe maps to Ok, other io errors pass through)
- `cargo clippy -p git-log-pretty --tests` clean
- `nix run .#lint`, `nix build .#git-log-pretty`
- Live in a real PTY (via the repo's `tui` driver):
  - default → `less` engages (interactive `:` prompt); quitting with `q` exits cleanly (code 0, no panic)
  - `--no-pager` → direct output, no prompt, exits on its own (code 0)
  - `PAGER=cat` → honored, dumps non-interactively (code 0)

Authored with AI (Claude, model claude-opus-4-8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Page `git-log-pretty` output through `$PAGER` like `git log`
> - Adds a new [pager.rs](https://github.com/indexable-inc/index/pull/378/files#diff-10650a865361889b2f216dcfd8420fea80f9a71a2cd51d46d78c8838efec06ed) module with a `paged()` function that spawns `$PAGER` (defaulting to `less -FRX`) when stdout is a TTY, otherwise writes directly to stdout.
> - Updates `run_log` and `run_diff` in [main.rs](https://github.com/indexable-inc/index/pull/378/files#diff-2a594331dccf67cb7e63d967ddf4c2ebfd6c2fc106c16d75b3622335b4e10d3e) to route output through the pager, and updates `print_commit` in [display.rs](https://github.com/indexable-inc/index/pull/378/files#diff-76291c981f7bcc274d017871d42155470d90f8ebe8f4faa3aa44680c50f69379) to write to an arbitrary `&mut dyn Write` instead of stdout.
> - Adds a `--no-pager` CLI flag to bypass paging unconditionally.
> - Broken pipe errors (from the user quitting the pager early) are silently swallowed.
> - Behavioral Change: output is now paged by default on TTYs; scripts or tools capturing stdout should use `--no-pager`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48821ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->