### PR TITLE
git-log-pretty: render Nerd Font icons in the pager with less -r

### DIFF
--- a/packages/git-log-pretty/src/pager.rs
+++ b/packages/git-log-pretty/src/pager.rs
@@ -7,9 +7,10 @@
 //!
 //! The pager is `$PAGER` when set (run through `sh -c`, so `PAGER="less -R"`
 //! and pipelines work), falling back to `less`. An empty `$PAGER` disables
-//! paging, matching git. We default `$LESS` to `FRX` when unset: quit if the
-//! output fits one screen, keep ANSI color, and leave the text in scrollback
-//! instead of an alternate screen.
+//! paging, matching git. We default `$LESS` to `FrX` when unset: quit if the
+//! output fits one screen, pass raw bytes through so Nerd Font icons render
+//! (and color with them), and leave the text in scrollback instead of an
+//! alternate screen.
 
 use std::io::{self, IsTerminal, Write};
 use std::process::{Child, Command, Stdio};
@@ -67,11 +68,19 @@ fn spawn() -> Option<Child> {
         Err(_) => "less".to_string(),
     };
 
-    if std::env::var_os("LESS").is_none() {
-        // Match git's defaults: -F quit if one screen, -R keep color, -X stay in
-        // scrollback. SAFETY note: set before spawning, single-threaded here.
-        unsafe { std::env::set_var("LESS", "FRX") };
-    }
+    // When paging with less, force raw mode plus scrollback-friendly defaults:
+    // -F quit if it fits one screen, -r pass raw bytes through, -X stay in
+    // scrollback. The file-icon tree uses Nerd Font glyphs in the Unicode
+    // Private Use Area, which less renders as literal `<U+E5FF>` escapes under
+    // -R; -r passes them to the terminal font instead. Appending after any user
+    // flags and `$LESS` means our -r wins over an inherited -R, and our output
+    // is only SGR color plus printable glyphs (no cursor motion), so raw is
+    // safe. Non-less pagers are left exactly as the user configured them.
+    let command = if is_less(&command) {
+        format!("{command} -F -r -X")
+    } else {
+        command
+    };
 
     let child = Command::new("sh")
         .arg("-c")
@@ -82,6 +91,16 @@ fn spawn() -> Option<Child> {
     // A missing or unlaunchable pager should not fail the command; fall back to
     // writing directly to stdout instead.
     child.ok()
+}
+
+/// Whether `command` invokes `less`, by the program's basename, so an inherited
+/// `PAGER=/usr/bin/less` or `PAGER="less -S"` is still recognized.
+fn is_less(command: &str) -> bool {
+    command
+        .split_whitespace()
+        .next()
+        .map(|prog| prog.rsplit('/').next().unwrap_or(prog))
+        == Some("less")
 }
 
 #[cfg(test)]
@@ -105,5 +124,20 @@ mod tests {
     #[test]
     fn non_io_error_passes_through() {
         assert!(swallow_broken_pipe(Err(eyre!("unrelated"))).is_err());
+    }
+
+    #[test]
+    fn recognizes_less_invocations() {
+        assert!(is_less("less"));
+        assert!(is_less("less -S"));
+        assert!(is_less("/usr/bin/less"));
+        assert!(is_less("/opt/homebrew/bin/less -R"));
+    }
+
+    #[test]
+    fn other_pagers_are_left_alone() {
+        assert!(!is_less("bat"));
+        assert!(!is_less("moar"));
+        assert!(!is_less("/usr/bin/cat"));
     }
 }


### PR DESCRIPTION
## Problem

In the paged view, the file-icon tree showed `<U+E5FF>` where direct (`--no-pager`) output drew the actual icon. The icons are Nerd Font glyphs in the Unicode Private Use Area; `less` renders PUA as literal `<U+XXXX>` escapes under `-R` (and as raw byte hex under a non-UTF-8 locale). The renderer was correct; the pager invocation was the issue.

## Fix

When the pager is `less`, append `-F -r -X` on its command line. `-r` (raw) passes the glyph bytes through to the terminal font instead of escaping them. Appending after the user's flags and `$LESS` means our `-r` wins over an inherited `-R` — which the previous "set `$LESS` only when unset" approach could not do once the environment already had `LESS`/`PAGER` set (the real-world case: `LESS=-RF --mouse`, `PAGER=less`). Non-`less` pagers are left exactly as configured. Our output is only SGR color plus printable glyphs (no cursor motion), so raw mode is safe.

## Validation

Live in a real PTY (via the repo's `tui` driver), under a hostile `LESS=-RF --mouse` / `PAGER=less` environment:

- before: paged output showed `<U+E5FF>`
- after: glyphs pass through raw (``), color intact, no escapes

Also: `cargo test -p git-log-pretty` (19 unit + 6 integration; new `is_less` tests), `cargo clippy` clean, `nix run .#lint`, `nix build .#git-log-pretty`.

Authored with AI (Claude, model claude-opus-4-8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render Nerd Font icons in `git-log-pretty` pager by passing `-r` to `less`
> - Replaces setting the `LESS` env variable with directly appending `-F -r -X` to the `less` command, ensuring quit-if-one-screen, raw byte pass-through (so Nerd Font icons render), and scrollback behavior.
> - Adds `is_less` helper in [pager.rs](https://github.com/indexable-inc/index/pull/380/files#diff-10650a865361889b2f216dcfd8420fea80f9a71a2cd51d46d78c8838efec06ed) to detect whether the configured pager resolves to `less` by checking the basename of the first token; non-`less` pagers are invoked unchanged.
> - Behavioral Change: the `LESS` env variable is no longer set by the pager; users relying on the previous `FRX` env default will now get flags only when `less` is the active pager.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0463a8b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->