### PR TITLE
git-log-pretty: tighten the file-icon tree indentation

### DIFF
--- a/packages/git-log-pretty/src/tree.rs
+++ b/packages/git-log-pretty/src/tree.rs
@@ -36,7 +36,7 @@ pub fn render(files: &[String], theme: Theme) -> String {
     collapse(&mut root);
 
     let mut lines = Vec::new();
-    render_children(&root, theme, "    ", &mut lines);
+    render_children(&root, theme, "  ", &mut lines);
     lines.join("\n")
 }
 
@@ -79,14 +79,15 @@ fn collapse(node: &mut Node) {
     }
 }
 
-/// Render each child of `node`, drawing the `├──`/`└──` connector and recursing
-/// with an extended prefix for grandchildren.
+/// Render each child of `node`, drawing the `├`/`└` connector and recursing with
+/// an extended prefix for grandchildren. Each level adds a 2-column step so deep
+/// trees stay compact.
 fn render_children(node: &Node, theme: Theme, prefix: &str, lines: &mut Vec<String>) {
     let count = node.children.len();
 
     for (index, (name, child)) in node.children.iter().enumerate() {
         let is_last = index == count - 1;
-        let connector = if is_last { "└── " } else { "├── " };
+        let connector = if is_last { "└ " } else { "├ " };
 
         let label = node_label(name, child, theme);
         lines.push(format!(
@@ -100,7 +101,7 @@ fn render_children(node: &Node, theme: Theme, prefix: &str, lines: &mut Vec<Stri
             } else {
                 palette::paint(palette::fg(Color::Rgb(GRAY)), "│")
             };
-            let next_prefix = format!("{prefix}{continuation}    ");
+            let next_prefix = format!("{prefix}{continuation} ");
             render_children(child, theme, &next_prefix, lines);
         }
     }
@@ -170,7 +171,7 @@ mod tests {
             &["src/a.rs".to_string(), "src/b.rs".to_string()],
             Theme::Dark,
         ));
-        assert!(rendered.contains("├── "), "got: {rendered}");
-        assert!(rendered.contains("└── "), "got: {rendered}");
+        assert!(rendered.contains("├ "), "got: {rendered}");
+        assert!(rendered.contains("└ "), "got: {rendered}");
     }
 }


### PR DESCRIPTION
## What

The file-icon tree was too whitespace-heavy: a 4-space base indent plus a 5-column step per nesting level with `├── `/`└── ` connectors. Tightened to a 2-space base and a 2-column step with `├ `/`└ ` connectors. The `│` guides still line up under their parent connector.

Before / after (deep path):

```
    └── ﰍ packages/git-log-pretty       └ packages/git-log-pretty
         ├── ﰍ src                         ├ src
         │    ├── display.rs               │ ├ display.rs
         │    └── pager.rs                 │ └ pager.rs
         └── tests/integration.rs         └ tests/integration.rs
```

## Validation

- Eyeballed the real output in a PTY against this repo's recent commits
- `cargo test -p git-log-pretty` (19 unit + 6 integration), `cargo clippy` clean, `nix run .#lint`, `nix build .#git-log-pretty`

Authored with AI (Claude, model claude-opus-4-8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tighten tree indentation and connector glyphs in `git-log-pretty`
> Reduces visual width of the file-icon tree by switching from 4-space to 2-space root indentation and replacing `├── `/`└── ` connectors with `├ `/`└ `. Each depth level now advances by one space paired with a `│` for non-last siblings, producing more compact output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57c8807.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->