### PR TITLE
tests: make dag-runner integration test assertion hash-agnostic

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3146,7 +3146,13 @@ let
         message = "repo Rust package outputs should not wrap unrelated workspace policy checks";
       }
       {
-        assertion = builtins.hasAttr "integration-all" repoPackages.dag-runner.passthru.tests;
+        # cargo-unit suffixes integration-test keys with -<version>-<hash> when
+        # two workspace crates both name a test crate `integration` (dag-runner's
+        # and git-log-pretty's), so the key is not a fixed `integration-all`. The
+        # hash is source-derived, so match the package-owned target by shape.
+        assertion = lib.any (n: lib.hasPrefix "integration" n && lib.hasSuffix "-all" n) (
+          builtins.attrNames repoPackages.dag-runner.passthru.tests
+        );
         message = "repo Rust package tests should include package-owned integration test targets";
       }
       {


### PR DESCRIPTION
`main` was broken: `checks.x86_64-linux.eval` failed with `ix-test-helpers: repo Rust package tests should include package-owned integration test targets`.

Root cause: the assertion hardcoded the test key `integration-all`, but cargo-unit now suffixes integration-test keys with `-<version>-<hash>` because two workspace crates (`dag-runner` and `git-log-pretty`) both name a test crate `integration`. dag-runner's key became `integration-0.1.0-<hash>-all`. The hash is source-derived and will change, so the literal key is the wrong thing to pin.

Fix: match the package-owned target by key shape (prefix `integration`, suffix `-all`) instead of the exact key.

Verified: `nix eval .#checks.x86_64-linux.eval` now passes the assertion; `nix run .#lint` is green.

Made with Claude (claude-opus-4-8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make dag-runner integration test assertion hash-agnostic in `tests/default.nix`
> The test previously checked for an exact attribute key `integration-all`, which broke when the key included a variable hash suffix. The assertion in [tests/default.nix](https://github.com/indexable-inc/index/pull/382/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) now uses `lib.any` over `builtins.attrNames` to match any key that starts with `"integration"` and ends with `"-all"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12ac4e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->