### PR TITLE
clone-detect: port clone and ast-merge tools from ix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,107 @@ dependencies = [
 ]
 
 [[package]]
+name = "ast-merge"
+version = "0.1.0"
+dependencies = [
+ "ast-merge-ast",
+ "ast-merge-diff",
+ "ast-merge-git",
+ "ast-merge-langs",
+ "ast-merge-matcher",
+ "clap",
+ "insta",
+ "snafu",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "ast-merge-ast"
+version = "0.1.0"
+dependencies = [
+ "insta",
+ "rustc-hash",
+ "snafu",
+ "tree-sitter",
+ "tree-sitter-language",
+ "tree-sitter-rust",
+]
+
+[[package]]
+name = "ast-merge-diff"
+version = "0.1.0"
+dependencies = [
+ "ast-merge-ast",
+ "ast-merge-langs",
+ "ast-merge-matcher",
+ "insta",
+ "rustc-hash",
+ "similar",
+ "tree-sitter",
+]
+
+[[package]]
+name = "ast-merge-git"
+version = "0.1.0"
+dependencies = [
+ "insta",
+ "lazy-regex",
+ "snafu",
+]
+
+[[package]]
+name = "ast-merge-langs"
+version = "0.1.0"
+dependencies = [
+ "insta",
+ "tree-sitter",
+ "tree-sitter-bash",
+ "tree-sitter-c",
+ "tree-sitter-c-sharp",
+ "tree-sitter-cpp",
+ "tree-sitter-css",
+ "tree-sitter-dockerfile-updated",
+ "tree-sitter-elixir",
+ "tree-sitter-go",
+ "tree-sitter-haskell",
+ "tree-sitter-html",
+ "tree-sitter-java",
+ "tree-sitter-javascript",
+ "tree-sitter-json",
+ "tree-sitter-kotlin-ng",
+ "tree-sitter-lua",
+ "tree-sitter-md",
+ "tree-sitter-nix",
+ "tree-sitter-ocaml",
+ "tree-sitter-php",
+ "tree-sitter-python",
+ "tree-sitter-ruby",
+ "tree-sitter-rust",
+ "tree-sitter-scala",
+ "tree-sitter-svelte-ng",
+ "tree-sitter-swift",
+ "tree-sitter-toml-ng",
+ "tree-sitter-typescript",
+ "tree-sitter-yaml",
+]
+
+[[package]]
+name = "ast-merge-matcher"
+version = "0.1.0"
+dependencies = [
+ "ast-merge-ast",
+ "insta",
+ "rayon",
+ "rustc-hash",
+ "tracing",
+ "tree-sitter",
+ "tree-sitter-language",
+ "tree-sitter-rust",
+ "tree-sitter-toml-ng",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +754,77 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clone-cli"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "clone-detect",
+ "clone-hash",
+ "clone-scanner",
+ "glob",
+ "serde",
+ "serde_json",
+ "snafu",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "clone-detect"
+version = "0.1.0"
+dependencies = [
+ "ast-merge-ast",
+ "ast-merge-langs",
+ "ast-merge-matcher",
+ "clone-hash",
+ "clone-scanner",
+ "insta",
+ "rayon",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "clone-hash"
+version = "0.1.0"
+dependencies = [
+ "ast-merge-ast",
+ "ast-merge-langs",
+ "insta",
+ "rustc-hash",
+ "tree-sitter",
+]
+
+[[package]]
+name = "clone-pragma"
+version = "0.1.0"
+dependencies = [
+ "ast-merge-ast",
+ "ast-merge-langs",
+ "tree-sitter",
+]
+
+[[package]]
+name = "clone-scanner"
+version = "0.1.0"
+dependencies = [
+ "ast-merge-ast",
+ "ast-merge-langs",
+ "clone-hash",
+ "clone-pragma",
+ "ignore",
+ "insta",
+ "parking_lot",
+ "rustc-hash",
+ "snafu",
+ "tempfile",
+ "tracing",
+]
 
 [[package]]
 name = "cobs"
@@ -2163,6 +2335,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,6 +2513,29 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5316,6 +5524,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-dockerfile-updated"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e61eb704364be179ab9be89e2891c8e77c0041eca5891a5c04164a21f6df7a0"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-elixir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5392,6 +5610,16 @@ name = "tree-sitter-json"
 version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-kotlin-ng"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e800ebbda938acfbf224f4d2c34947a31994b1295ee6e819b65226c7b51b4450"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -5498,6 +5726,16 @@ name = "tree-sitter-sequel"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d198ad3c319c02e43c21efa1ec796b837afcb96ffaef1a40c1978fbdcec7d17"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-svelte-ng"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0a71f9cf5e94373cc86c64893630c8a29bb25d3390a248268d08af2165fa37"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,17 @@
 members = [
   "modules/services/resource-monitor/stats-writer",
   "packages/agents-md",
+  "packages/ast-merge/ast",
+  "packages/ast-merge/cli",
+  "packages/ast-merge/diff",
+  "packages/ast-merge/git",
+  "packages/ast-merge/langs",
+  "packages/ast-merge/matcher",
+  "packages/clone-detect/cli",
+  "packages/clone-detect/detect",
+  "packages/clone-detect/hash",
+  "packages/clone-detect/pragma",
+  "packages/clone-detect/scanner",
   "packages/code-highlight",
   "packages/code-tokenizer",
   "packages/dag-runner",
@@ -60,11 +71,20 @@ anstream = "1"
 anstyle = "1"
 anyhow = "1"
 askama = { version = "0.16.0", default-features = false }
+ast-merge-ast = { path = "packages/ast-merge/ast" }
+ast-merge-diff = { path = "packages/ast-merge/diff" }
+ast-merge-git = { path = "packages/ast-merge/git" }
+ast-merge-langs = { path = "packages/ast-merge/langs" }
+ast-merge-matcher = { path = "packages/ast-merge/matcher" }
 axum = "0.8"
 base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", default-features = false }
 clap = "4"
+clone-detect = { path = "packages/clone-detect/detect" }
+clone-hash = { path = "packages/clone-detect/hash" }
+clone-pragma = { path = "packages/clone-detect/pragma" }
+clone-scanner = { path = "packages/clone-detect/scanner" }
 code-highlight = { path = "packages/code-highlight" }
 code-tokenizer = { path = "packages/code-tokenizer" }
 color-eyre = "0.6"
@@ -73,9 +93,12 @@ dirs = "5"
 file-language = { path = "packages/file-language" }
 futures = "0.3"
 git2 = { version = "0.20", default-features = false }
+glob = "0.3"
 hegeltest = { version = "0.14", default-features = false }
 ignore = "0.4"
 indicatif = "0.18"
+insta = { version = "1.42", features = ["json"] }
+lazy-regex = "3.4"
 libc = "0.2"
 mixedbread = { path = "packages/mixedbread" }
 loro = "1.12"
@@ -108,6 +131,7 @@ rmcp = "1.7"
 rmp-serde = "1"
 rodio = { version = "0.19", default-features = false, features = ["vorbis"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
+rustc-hash = "2.1"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-native-certs = "0.8"
 schemars = "1"
@@ -131,12 +155,15 @@ tokio-stream = "0.1"
 toml = { version = "1.1.2", default-features = false }
 tower = "0.5"
 tower-http = "0.6"
+tracing = "0.1"
+tracing-subscriber = "0.3"
 tree-sitter = "0.26"
 tree-sitter-bash = "0.25"
 tree-sitter-c = "0.24"
 tree-sitter-c-sharp = "0.23"
 tree-sitter-cpp = "0.23"
 tree-sitter-css = "0.25"
+tree-sitter-dockerfile-updated = "0.2"
 tree-sitter-elixir = "0.3"
 tree-sitter-go = "0.25"
 tree-sitter-haskell = "0.23"
@@ -145,6 +172,8 @@ tree-sitter-html = "0.23"
 tree-sitter-java = "0.23"
 tree-sitter-javascript = "0.25"
 tree-sitter-json = "0.24"
+tree-sitter-kotlin-ng = "1.1"
+tree-sitter-language = "0.1"
 tree-sitter-lua = "0.5"
 tree-sitter-md = "0.5"
 tree-sitter-nix = "0.3"
@@ -155,6 +184,7 @@ tree-sitter-ruby = "0.23"
 tree-sitter-rust = "0.24"
 tree-sitter-scala = "0.26"
 tree-sitter-sequel = "0.3"
+tree-sitter-svelte-ng = "1.0"
 tree-sitter-swift = "0.7"
 tree-sitter-toml-ng = "0.7"
 tree-sitter-typescript = "0.23"

--- a/clone.toml
+++ b/clone.toml
@@ -1,0 +1,17 @@
+# Clone-detection config for this repo, consumed by `nix run .#clone`.
+# Thresholds match the ix defaults; the ignore globs drop vendored, generated,
+# build-output, and test-fixture trees so duplication numbers reflect
+# hand-written product code.
+min_lines = 8
+min_nodes = 15
+ignore = [
+    "*/target/*",
+    "*/node_modules/*",
+    "*/.direnv/*",
+    "*/vendored/*",
+    "*/tests/*",
+    "*/test/*",
+    "**/tests.rs",
+    "*/fixtures/*",
+    "*/snapshots/*",
+]

--- a/packages/ast-merge/ast/Cargo.toml
+++ b/packages/ast-merge/ast/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ast-merge-ast"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "AST types and tree-sitter parsing for ast-merge"
+
+[dependencies]
+snafu.workspace = true
+tree-sitter.workspace = true
+rustc-hash.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+tree-sitter-rust.workspace = true
+tree-sitter-language.workspace = true
+
+[lints]
+workspace = true

--- a/packages/ast-merge/ast/package.nix
+++ b/packages/ast-merge/ast/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "ast-merge-ast";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/ast-merge/ast/src/hash.rs
+++ b/packages/ast-merge/ast/src/hash.rs
@@ -1,0 +1,25 @@
+use std::hash::{Hash, Hasher};
+
+use rustc_hash::FxHasher;
+
+use crate::Tree;
+
+#[must_use]
+pub fn compute(tree: &Tree, node: tree_sitter::Node<'_>) -> u64 {
+    let mut hasher = FxHasher::default();
+    compute_recursive(tree, node, &mut hasher);
+    hasher.finish()
+}
+
+fn compute_recursive(tree: &Tree, node: tree_sitter::Node<'_>, hasher: &mut FxHasher) {
+    node.kind().hash(hasher);
+
+    if node.child_count() == 0 {
+        tree.node_text(node).hash(hasher);
+    } else {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            compute_recursive(tree, child, hasher);
+        }
+    }
+}

--- a/packages/ast-merge/ast/src/lib.rs
+++ b/packages/ast-merge/ast/src/lib.rs
@@ -1,0 +1,111 @@
+mod hash;
+mod parse;
+mod types;
+
+pub use hash::compute;
+pub use parse::{Error, Output, PreorderIterator, SetLanguageSnafu, Tree, tree};
+pub use types::{Node, NodeId, Revision};
+
+#[cfg(test)]
+mod tests {
+    use crate::{Node, NodeId, Revision, compute, tree};
+
+    fn get_rust_language() -> tree_sitter::Language {
+        tree_sitter_rust::LANGUAGE.into()
+    }
+
+    #[test]
+    fn test_parse_simple_rust() {
+        let source = "fn main() {}";
+        let result = tree(source, &get_rust_language()).unwrap();
+
+        assert!(!result.has_errors);
+        assert_eq!(result.tree.source(), source);
+        assert_eq!(result.tree.root_node().kind(), "source_file");
+    }
+
+    #[test]
+    fn test_parse_with_errors() {
+        let source = "fn main( {}";
+        let result = tree(source, &get_rust_language()).unwrap();
+
+        assert!(result.has_errors);
+    }
+
+    #[test]
+    fn test_node_text_extraction() {
+        let source = "fn hello() { 42 }";
+        let result = tree(source, &get_rust_language()).unwrap();
+
+        let root = result.tree.root_node();
+        assert_eq!(result.tree.node_text(root), source);
+    }
+
+    #[test]
+    fn test_preorder_iteration() {
+        let source = "fn a() {} fn b() {}";
+        let result = tree(source, &get_rust_language()).unwrap();
+
+        let nodes: Vec<_> = result.tree.preorder().collect();
+        assert!(!nodes.is_empty());
+
+        assert_eq!(
+            nodes.first().map(tree_sitter::Node::kind),
+            Some("source_file")
+        );
+    }
+
+    #[test]
+    fn test_content_hash_same_content() {
+        let source1 = "fn foo() {}";
+        let source2 = "fn foo() {}";
+
+        let result1 = tree(source1, &get_rust_language()).unwrap();
+        let result2 = tree(source2, &get_rust_language()).unwrap();
+
+        let hash1 = compute(&result1.tree, result1.tree.root_node());
+        let hash2 = compute(&result2.tree, result2.tree.root_node());
+
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_content_hash_different_content() {
+        let source1 = "fn foo() {}";
+        let source2 = "fn bar() {}";
+
+        let result1 = tree(source1, &get_rust_language()).unwrap();
+        let result2 = tree(source2, &get_rust_language()).unwrap();
+
+        let hash1 = compute(&result1.tree, result1.tree.root_node());
+        let hash2 = compute(&result2.tree, result2.tree.root_node());
+
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_revision_names() {
+        assert_eq!(Revision::Base.name(), "BASE");
+        assert_eq!(Revision::Left.name(), "LEFT");
+        assert_eq!(Revision::Right.name(), "RIGHT");
+    }
+
+    #[test]
+    fn test_node_creation() {
+        let source = "let x = 1;";
+        let result = tree(source, &get_rust_language()).unwrap();
+        let root = result.tree.root_node();
+
+        let ast_node = Node::new(root, NodeId(0));
+
+        assert_eq!(ast_node.id(), NodeId(0));
+        assert_eq!(ast_node.kind(), "source_file");
+        assert!(ast_node.hash() != 0);
+    }
+
+    #[test]
+    fn test_node_id_equality() {
+        assert_eq!(NodeId(1), NodeId(1));
+        assert_ne!(NodeId(1), NodeId(2));
+    }
+}

--- a/packages/ast-merge/ast/src/parse.rs
+++ b/packages/ast-merge/ast/src/parse.rs
@@ -1,0 +1,109 @@
+use snafu::ResultExt as _;
+
+pub struct PreorderIterator<'a> {
+    cursor: tree_sitter::TreeCursor<'a>,
+    done: bool,
+}
+
+impl<'a> PreorderIterator<'a> {
+    fn new(root: tree_sitter::Node<'a>) -> Self {
+        Self {
+            cursor: root.walk(),
+            done: false,
+        }
+    }
+}
+
+impl<'a> Iterator for PreorderIterator<'a> {
+    type Item = tree_sitter::Node<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        let node = self.cursor.node();
+
+        if self.cursor.goto_first_child() {
+            return Some(node);
+        }
+
+        if self.cursor.goto_next_sibling() {
+            return Some(node);
+        }
+
+        loop {
+            if !self.cursor.goto_parent() {
+                self.done = true;
+                return Some(node);
+            }
+            if self.cursor.goto_next_sibling() {
+                return Some(node);
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Tree {
+    source: String,
+    tree: tree_sitter::Tree,
+}
+
+impl Tree {
+    #[must_use]
+    pub fn new(source: String, tree: tree_sitter::Tree) -> Self {
+        Self { source, tree }
+    }
+
+    #[must_use]
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    #[must_use]
+    pub fn root_node(&self) -> tree_sitter::Node<'_> {
+        self.tree.root_node()
+    }
+
+    #[must_use]
+    pub fn node_text(&self, node: tree_sitter::Node<'_>) -> &str {
+        let range = node.byte_range();
+        self.source.get(range).unwrap_or_default()
+    }
+
+    #[must_use]
+    pub fn preorder(&self) -> PreorderIterator<'_> {
+        PreorderIterator::new(self.tree.root_node())
+    }
+}
+
+pub struct Output {
+    pub tree: Tree,
+    /// Whether there were parse errors.
+    pub has_errors: bool,
+}
+
+#[derive(Debug, snafu::Snafu)]
+#[snafu(visibility(pub))]
+pub enum Error {
+    #[snafu(display("failed to set language: {source}"))]
+    SetLanguage { source: tree_sitter::LanguageError },
+
+    #[snafu(display("parser returned no tree (cancelled or out of memory)"))]
+    NoTree,
+}
+
+pub fn tree(source: &str, language: &tree_sitter::Language) -> Result<Output, Error> {
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(language).context(SetLanguageSnafu)?;
+
+    let tree = parser.parse(source, None).ok_or(Error::NoTree)?;
+
+    let has_errors = tree.root_node().has_error();
+
+    Ok(Output {
+        tree: Tree::new(source.to_owned(), tree),
+        has_errors,
+    })
+}

--- a/packages/ast-merge/ast/src/types.rs
+++ b/packages/ast-merge/ast/src/types.rs
@@ -1,0 +1,97 @@
+use std::hash::{Hash, Hasher};
+
+use rustc_hash::FxHasher;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NodeId(pub u32);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Revision {
+    Base,
+    Left,
+    Right,
+}
+
+impl Revision {
+    #[must_use]
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Base => "BASE",
+            Self::Left => "LEFT",
+            Self::Right => "RIGHT",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Node<'a> {
+    inner: tree_sitter::Node<'a>,
+    hash: u64,
+    id: NodeId,
+}
+
+impl<'a> Node<'a> {
+    #[must_use]
+    pub fn new(node: tree_sitter::Node<'a>, id: NodeId) -> Self {
+        let hash = compute_subtree_hash(node);
+        Self {
+            inner: node,
+            hash,
+            id,
+        }
+    }
+
+    #[must_use]
+    pub fn node(&self) -> tree_sitter::Node<'a> {
+        self.inner
+    }
+
+    #[must_use]
+    pub fn hash(&self) -> u64 {
+        self.hash
+    }
+
+    #[must_use]
+    pub fn id(&self) -> NodeId {
+        self.id
+    }
+
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        self.inner.kind()
+    }
+
+    #[must_use]
+    pub fn byte_range(&self) -> std::ops::Range<usize> {
+        self.inner.byte_range()
+    }
+
+    #[must_use]
+    pub fn is_named(&self) -> bool {
+        self.inner.is_named()
+    }
+
+    #[must_use]
+    pub fn child_count(&self) -> usize {
+        self.inner.child_count()
+    }
+}
+
+fn compute_subtree_hash(node: tree_sitter::Node<'_>) -> u64 {
+    let mut hasher = FxHasher::default();
+
+    node.kind().hash(&mut hasher);
+
+    if node.child_count() == 0 {
+        node.start_byte().hash(&mut hasher);
+        node.end_byte().hash(&mut hasher);
+    } else {
+        node.child_count().hash(&mut hasher);
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            compute_subtree_hash(child).hash(&mut hasher);
+        }
+    }
+
+    hasher.finish()
+}

--- a/packages/ast-merge/cli/Cargo.toml
+++ b/packages/ast-merge/cli/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ast-merge"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "AST-aware git merge driver using tree-sitter"
+
+[[bin]]
+name = "ast-merge"
+path = "src/main.rs"
+
+[dependencies]
+snafu.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+clap = { workspace = true, features = ["derive"] }
+ast-merge-ast.workspace = true
+ast-merge-matcher.workspace = true
+ast-merge-diff.workspace = true
+ast-merge-langs.workspace = true
+ast-merge-git.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+
+[lints]
+workspace = true

--- a/packages/ast-merge/cli/default.nix
+++ b/packages/ast-merge/cli/default.nix
@@ -1,0 +1,10 @@
+{ ix, lib, ... }:
+
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "ast-merge";
+  meta = {
+    description = "AST-aware git merge driver using tree-sitter";
+    license = lib.licenses.mit;
+    mainProgram = "ast-merge";
+  };
+}

--- a/packages/ast-merge/cli/package.nix
+++ b/packages/ast-merge/cli/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "ast-merge";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/ast-merge/cli/src/main.rs
+++ b/packages/ast-merge/cli/src/main.rs
@@ -1,0 +1,280 @@
+mod merge;
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use snafu::ResultExt as _;
+
+const EXIT_CONFLICTS: u8 = 1;
+
+#[derive(Parser)]
+#[command(name = "ast-merge")]
+#[command(version, about, long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Merge {
+        #[arg(value_name = "BASE")]
+        base: PathBuf,
+        #[arg(value_name = "LEFT")]
+        left: PathBuf,
+        #[arg(value_name = "RIGHT")]
+        right: PathBuf,
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+        #[arg(short, long)]
+        language: Option<String>,
+        #[arg(long)]
+        git: bool,
+    },
+    Solve {
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+    },
+    Languages,
+    Info,
+}
+
+#[derive(Debug, snafu::Snafu)]
+#[snafu(visibility(pub(crate)))]
+enum CliError {
+    #[snafu(display("failed to read revision"))]
+    ReadRevision {
+        source: ast_merge_git::RevisionError,
+    },
+    #[snafu(display("failed to write merge result"))]
+    WriteResult {
+        source: ast_merge_git::RevisionError,
+    },
+    #[snafu(display("failed to parse for merge"))]
+    Parse { source: ast_merge_ast::Error },
+    #[snafu(display("cannot detect language for {path} - specify with --language"))]
+    UnknownLanguage { path: String },
+    #[snafu(display("unknown language {name}"))]
+    UnknownLanguageName { name: String },
+    #[snafu(display("write failed"))]
+    Write { source: std::io::Error },
+}
+
+enum CliResult {
+    Ok,
+    Conflicts,
+    Err(CliError),
+}
+
+impl From<Result<(), CliError>> for CliResult {
+    fn from(result: Result<(), CliError>) -> Self {
+        match result {
+            Ok(()) => Self::Ok,
+            Err(e) => Self::Err(e),
+        }
+    }
+}
+
+/// Install a tracing subscriber reading filter directives from `RUST_LOG`
+/// (defaulting to `info`) and writing formatted events to stderr. Replaces the
+/// `ix` platform's `service_init::init`, which this standalone tool does not
+/// depend on.
+fn init_tracing() {
+    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt::layer().with_writer(std::io::stderr))
+        .init();
+}
+
+fn main() -> std::process::ExitCode {
+    init_tracing();
+
+    let cli = Cli::parse();
+
+    let result = match cli.command {
+        Commands::Merge {
+            base,
+            left,
+            right,
+            output,
+            language,
+            git,
+        } => merge::run(merge::Params {
+            base,
+            left,
+            right,
+            output,
+            language,
+            git_mode: git,
+        }),
+        Commands::Solve { file, output } => cmd_solve(file, output).into(),
+        Commands::Languages => cmd_languages().into(),
+        Commands::Info => cmd_info().into(),
+    };
+
+    match result {
+        CliResult::Ok => std::process::ExitCode::SUCCESS,
+        CliResult::Conflicts => std::process::ExitCode::from(EXIT_CONFLICTS),
+        CliResult::Err(e) => {
+            tracing::error!("error: {e:?}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+fn cmd_solve(file: PathBuf, output: Option<PathBuf>) -> Result<(), CliError> {
+    tracing::info!(?file, "attempting to solve conflicts");
+
+    let content = ast_merge_git::read_revision(&file).context(ReadRevisionSnafu)?;
+    let parsed = ast_merge_git::conflicts(&content);
+
+    if !parsed.has_conflicts {
+        tracing::info!("no conflicts found");
+        return Ok(());
+    }
+
+    tracing::info!(count = parsed.conflicts.len(), "found conflicts");
+
+    let lang = ast_merge_langs::detect(&file);
+    if lang.is_none() {
+        return Err(CliError::UnknownLanguage {
+            path: file.display().to_string(),
+        });
+    }
+
+    tracing::warn!("conflict solving not yet fully implemented");
+
+    let output_path = output.unwrap_or(file);
+    ast_merge_git::write_result(&output_path, &content).context(WriteResultSnafu)?;
+
+    Ok(())
+}
+
+fn cmd_languages() -> Result<(), CliError> {
+    use std::io::Write as _;
+
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+
+    writeln!(handle, "Supported languages:").context(WriteSnafu)?;
+    writeln!(handle).context(WriteSnafu)?;
+
+    for lang in ast_merge_langs::Lang::all() {
+        let profile = lang.profile();
+        writeln!(handle, "  {}", profile.name).context(WriteSnafu)?;
+        writeln!(handle, "    Extensions: {}", profile.extensions.join(", "))
+            .context(WriteSnafu)?;
+        if !profile.file_names.is_empty() {
+            writeln!(handle, "    Files: {}", profile.file_names.join(", ")).context(WriteSnafu)?;
+        }
+        writeln!(handle).context(WriteSnafu)?;
+    }
+
+    Ok(())
+}
+
+fn cmd_info() -> Result<(), CliError> {
+    use std::io::Write as _;
+
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+
+    writeln!(handle, "ast-merge {}", env!("CARGO_PKG_VERSION")).context(WriteSnafu)?;
+    writeln!(handle).context(WriteSnafu)?;
+    writeln!(handle, "AST-aware git merge driver using tree-sitter").context(WriteSnafu)?;
+    writeln!(handle).context(WriteSnafu)?;
+    writeln!(handle, "Git merge driver configuration:").context(WriteSnafu)?;
+    writeln!(handle).context(WriteSnafu)?;
+    writeln!(handle, "  1. Add to .gitattributes:").context(WriteSnafu)?;
+    writeln!(handle, "     *.rs merge=ast-merge").context(WriteSnafu)?;
+    writeln!(handle, "     *.ts merge=ast-merge").context(WriteSnafu)?;
+    writeln!(handle).context(WriteSnafu)?;
+    writeln!(handle, "  2. Configure git:").context(WriteSnafu)?;
+    writeln!(
+        handle,
+        "     git config merge.ast-merge.driver 'ast-merge merge %O %A %B --git'"
+    )
+    .context(WriteSnafu)?;
+    writeln!(handle).context(WriteSnafu)?;
+    writeln!(
+        handle,
+        "Languages supported: {}",
+        ast_merge_langs::Lang::all().len()
+    )
+    .context(WriteSnafu)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    #[test]
+    fn detect_by_name() {
+        assert!(merge::detect_by_name("rust").is_some());
+        assert!(merge::detect_by_name("Rust").is_some());
+        assert!(merge::detect_by_name("RUST").is_some());
+        assert!(merge::detect_by_name("typescript").is_some());
+        assert!(merge::detect_by_name("unknown").is_none());
+    }
+
+    #[test]
+    fn resolve_language_rejects_unknown() {
+        let result =
+            merge::resolve_language(Some("not-a-language"), std::path::Path::new("main.rs"));
+        assert!(matches!(
+            result,
+            Err(CliError::UnknownLanguageName { ref name }) if name == "not-a-language"
+        ));
+    }
+
+    #[test]
+    fn run_merge_rejects_unknown_language() {
+        let dir = test_dir();
+        let base = dir.join("base.rs");
+        let left = dir.join("left.rs");
+        let right = dir.join("right.rs");
+        let output = dir.join("merged.rs");
+        let content = "fn main() {}\n";
+
+        std::fs::write(&base, content).expect("write base");
+        std::fs::write(&left, content).expect("write left");
+        std::fs::write(&right, content).expect("write right");
+
+        let result = merge::run(merge::Params {
+            base,
+            left,
+            right,
+            output: Some(output.clone()),
+            language: Some(String::from("not-a-language")),
+            git_mode: false,
+        });
+
+        assert!(matches!(
+            result,
+            CliResult::Err(CliError::UnknownLanguageName { ref name }) if name == "not-a-language"
+        ));
+        assert!(!output.exists());
+    }
+
+    fn test_dir() -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time after unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "ast-merge-cli-tests-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp test dir");
+        dir
+    }
+}

--- a/packages/ast-merge/cli/src/merge.rs
+++ b/packages/ast-merge/cli/src/merge.rs
@@ -1,0 +1,136 @@
+use snafu::ResultExt as _;
+
+use crate::{CliError, CliResult, ParseSnafu, ReadRevisionSnafu, WriteResultSnafu};
+
+pub struct Params {
+    pub base: std::path::PathBuf,
+    pub left: std::path::PathBuf,
+    pub right: std::path::PathBuf,
+    pub output: Option<std::path::PathBuf>,
+    pub language: Option<String>,
+    pub git_mode: bool,
+}
+
+pub fn run(params: Params) -> CliResult {
+    let Params {
+        base,
+        left,
+        right,
+        output,
+        language,
+        git_mode,
+    } = params;
+    let inner = || -> Result<bool, CliError> {
+        tracing::info!(?base, ?left, ?right, "performing merge");
+
+        let lang = resolve_language(language.as_deref(), &left)?;
+
+        let base_content = ast_merge_git::read_revision(&base).context(ReadRevisionSnafu)?;
+        let left_content = ast_merge_git::read_revision(&left).context(ReadRevisionSnafu)?;
+        let right_content = ast_merge_git::read_revision(&right).context(ReadRevisionSnafu)?;
+
+        let result = if let Some(lang) = lang {
+            tracing::info!(language = lang.name(), "using AST-based merge");
+            tree_based(&TreeInput {
+                base: &base_content,
+                left: &left_content,
+                right: &right_content,
+                lang,
+            })?
+        } else {
+            tracing::info!("using line-based merge (language not detected)");
+            ast_merge_diff::based(&base_content, &left_content, &right_content)
+        };
+
+        let output_path = if git_mode {
+            left
+        } else {
+            output.unwrap_or(left)
+        };
+
+        ast_merge_git::write_result(&output_path, &result.content).context(WriteResultSnafu)?;
+
+        if result.success {
+            tracing::info!("merge successful");
+            Ok(true)
+        } else {
+            tracing::warn!(
+                conflicts = result.conflicts.len(),
+                "merge completed with conflicts"
+            );
+            Ok(false)
+        }
+    };
+
+    match inner() {
+        Ok(true) => CliResult::Ok,
+        Ok(false) => CliResult::Conflicts,
+        Err(e) => CliResult::Err(e),
+    }
+}
+
+pub fn detect_by_name(name: &str) -> Option<ast_merge_langs::Lang> {
+    let name_lower = name.to_lowercase();
+    for lang in ast_merge_langs::Lang::all() {
+        if lang.name().to_lowercase() == name_lower {
+            return Some(*lang);
+        }
+    }
+    None
+}
+
+pub fn resolve_language(
+    language: Option<&str>,
+    left: &std::path::Path,
+) -> Result<Option<ast_merge_langs::Lang>, CliError> {
+    match language {
+        Some(name) => detect_by_name(name)
+            .map(Some)
+            .ok_or_else(|| CliError::UnknownLanguageName {
+                name: name.to_owned(),
+            }),
+        None => Ok(ast_merge_langs::detect(left)),
+    }
+}
+
+struct TreeInput<'a> {
+    base: &'a str,
+    left: &'a str,
+    right: &'a str,
+    lang: ast_merge_langs::Lang,
+}
+
+fn tree_based(input: &TreeInput<'_>) -> Result<ast_merge_diff::Result, CliError> {
+    let ts_lang = input.lang.to_tree_sitter();
+
+    let base_parsed = ast_merge_ast::tree(input.base, &ts_lang).context(ParseSnafu)?;
+    let left_parsed = ast_merge_ast::tree(input.left, &ts_lang).context(ParseSnafu)?;
+    let right_parsed = ast_merge_ast::tree(input.right, &ts_lang).context(ParseSnafu)?;
+
+    if base_parsed.has_errors || left_parsed.has_errors || right_parsed.has_errors {
+        tracing::warn!("parse errors detected, falling back to line-based merge");
+        return Ok(ast_merge_diff::based(input.base, input.left, input.right));
+    }
+
+    let base_left_matching = ast_merge_matcher::compute(&base_parsed.tree, &left_parsed.tree);
+    let base_right_matching = ast_merge_matcher::compute(&base_parsed.tree, &right_parsed.tree);
+
+    tracing::debug!(
+        base_left = base_left_matching.len(),
+        base_right = base_right_matching.len(),
+        "computed matchings"
+    );
+
+    let merger = ast_merge_diff::ThreeWay::new(ast_merge_diff::ThreeWayParams {
+        trees: ast_merge_diff::ThreeWayTrees {
+            base: &base_parsed.tree,
+            left: &left_parsed.tree,
+            right: &right_parsed.tree,
+        },
+        base_left_matching,
+        base_right_matching,
+        config: ast_merge_diff::Config::default(),
+    });
+
+    Ok(merger.merge())
+}

--- a/packages/ast-merge/diff/Cargo.toml
+++ b/packages/ast-merge/diff/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ast-merge-diff"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "3DM merge algorithm and PCS changesets for ast-merge"
+
+[dependencies]
+ast-merge-ast.workspace = true
+ast-merge-matcher.workspace = true
+rustc-hash.workspace = true
+similar.workspace = true
+tree-sitter.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+ast-merge-langs.workspace = true
+
+[lints]
+workspace = true

--- a/packages/ast-merge/diff/package.nix
+++ b/packages/ast-merge/diff/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "ast-merge-diff";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/ast-merge/diff/src/changeset.rs
+++ b/packages/ast-merge/diff/src/changeset.rs
@@ -1,0 +1,68 @@
+use ast_merge_ast::Revision;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PcsTriple {
+    pub parent: Option<usize>,
+    pub predecessor: Option<usize>,
+    pub successor: usize,
+}
+
+impl PcsTriple {
+    #[must_use]
+    pub fn new(parent: Option<usize>, predecessor: Option<usize>, successor: usize) -> Self {
+        Self {
+            parent,
+            predecessor,
+            successor,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ChangeSet {
+    triples: FxHashMap<PcsTriple, FxHashSet<Revision>>,
+}
+
+/// A reference to a PCS triple and its associated revision set.
+pub struct ChangeSetEntry<'a> {
+    pub triple: &'a PcsTriple,
+    pub revisions: &'a FxHashSet<Revision>,
+}
+
+impl ChangeSet {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add(&mut self, triple: PcsTriple, revision: Revision) {
+        self.triples.entry(triple).or_default().insert(revision);
+    }
+
+    #[must_use]
+    pub fn get_revisions(&self, triple: &PcsTriple) -> Option<&FxHashSet<Revision>> {
+        self.triples.get(triple)
+    }
+
+    #[must_use]
+    pub fn contains(&self, triple: &PcsTriple) -> bool {
+        self.triples.contains_key(triple)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = ChangeSetEntry<'_>> {
+        self.triples
+            .iter()
+            .map(|(triple, revisions)| ChangeSetEntry { triple, revisions })
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.triples.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.triples.is_empty()
+    }
+}

--- a/packages/ast-merge/diff/src/children.rs
+++ b/packages/ast-merge/diff/src/children.rs
@@ -1,0 +1,288 @@
+mod body;
+
+use ast_merge_ast::Tree;
+pub use body::try_reconcile_function;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{
+    engine::{ThreeWayNodes, ThreeWayTrees},
+    items::{IndexedNode, build_name_map, get_name, reconcile_single},
+};
+
+pub fn try_reconcile(trees: &ThreeWayTrees<'_>, nodes: ThreeWayNodes<'_>) -> Option<String> {
+    let ThreeWayNodes {
+        base: base_node,
+        left: left_node,
+        right: right_node,
+    } = nodes;
+
+    let body_field = match base_node.kind() {
+        "struct_item" | "impl_item" | "enum_item" | "trait_item" => "body",
+        _ => return None,
+    };
+
+    let base_body = base_node.child_by_field_name(body_field)?;
+    let left_body = left_node.child_by_field_name(body_field)?;
+    let right_body = right_node.child_by_field_name(body_field)?;
+
+    let base_children: Vec<_> = get_meaningful(base_body);
+    let left_children: Vec<_> = get_meaningful(left_body);
+    let right_children: Vec<_> = get_meaningful(right_body);
+
+    let children = ThreeWay {
+        base: &base_children,
+        left: &left_children,
+        right: &right_children,
+    };
+    let merged_children = reconcile_lists(trees, &children);
+
+    let reconstruct = ReconstructBodyInput {
+        left_node,
+        left_body,
+        base_node,
+        merged_children: &merged_children,
+    };
+    Some(reconstruct_body(trees.left, &reconstruct))
+}
+
+struct ThreeWay<'a, 'tree> {
+    base: &'a [tree_sitter::Node<'tree>],
+    left: &'a [tree_sitter::Node<'tree>],
+    right: &'a [tree_sitter::Node<'tree>],
+}
+
+fn reconcile_lists(trees: &ThreeWayTrees<'_>, children: &ThreeWay<'_, '_>) -> Vec<String> {
+    use ast_merge_ast::compute;
+
+    let base_child_names = build_name_map(trees.base, children.base);
+    let right_child_names = build_name_map(trees.right, children.right);
+
+    let base_child_hashes: FxHashMap<u64, usize> = children
+        .base
+        .iter()
+        .enumerate()
+        .map(|(idx, node)| (compute(trees.base, *node), idx))
+        .collect();
+
+    let mut merged_children = Vec::new();
+    let mut handled_right: FxHashSet<usize> = FxHashSet::default();
+
+    let lookups = ChildNameLookups {
+        base: &base_child_names,
+        right: &right_child_names,
+    };
+
+    for left_child in children.left {
+        let left_name = get_name(trees.left, *left_child);
+        let left_hash = compute(trees.left, *left_child);
+
+        if let Some(name) = &left_name {
+            reconcile_named(
+                &NamedChildInput {
+                    trees,
+                    name,
+                    left_child: *left_child,
+                    left_hash,
+                    lookups: &lookups,
+                },
+                &mut handled_right,
+                &mut merged_children,
+            );
+        } else {
+            reconcile_unnamed(
+                &UnnamedChildInput {
+                    left_hash,
+                    left_child: *left_child,
+                    left_tree: trees.left,
+                    right_tree: trees.right,
+                    right_children: children.right,
+                },
+                &mut handled_right,
+                &mut merged_children,
+            );
+        }
+    }
+
+    let collect = CollectNewRightInput {
+        right_children: children.right,
+        handled_right: &handled_right,
+        base_child_names: &base_child_names,
+        base_child_hashes: &base_child_hashes,
+    };
+    collect_new_right(trees.right, &collect, &mut merged_children);
+
+    merged_children
+}
+
+struct ChildNameLookups<'a, 'tree> {
+    base: &'a FxHashMap<String, IndexedNode<'tree>>,
+    right: &'a FxHashMap<String, IndexedNode<'tree>>,
+}
+
+struct NamedChildInput<'a, 'tree> {
+    trees: &'a ThreeWayTrees<'tree>,
+    name: &'a str,
+    left_child: tree_sitter::Node<'tree>,
+    left_hash: u64,
+    lookups: &'a ChildNameLookups<'a, 'tree>,
+}
+
+fn reconcile_named(
+    input: &NamedChildInput<'_, '_>,
+    handled_right: &mut FxHashSet<usize>,
+    merged_children: &mut Vec<String>,
+) {
+    use ast_merge_ast::compute;
+
+    let base_match = input.lookups.base.get(input.name);
+    let right_match = input.lookups.right.get(input.name);
+
+    match (base_match, right_match) {
+        (Some(base_entry), Some(right_entry)) => {
+            handled_right.insert(right_entry.index);
+            let base_h = compute(input.trees.base, base_entry.node);
+            let right_h = compute(input.trees.right, right_entry.node);
+
+            if input.left_hash == right_h {
+                merged_children.push(input.trees.left.node_text(input.left_child).to_owned());
+            } else if input.left_hash == base_h {
+                merged_children.push(input.trees.right.node_text(right_entry.node).to_owned());
+            } else if right_h == base_h {
+                merged_children.push(input.trees.left.node_text(input.left_child).to_owned());
+            } else {
+                let merged = reconcile_single(
+                    input.trees,
+                    ThreeWayNodes {
+                        base: base_entry.node,
+                        left: input.left_child,
+                        right: right_entry.node,
+                    },
+                );
+                merged_children.push(merged);
+            }
+        }
+        _ => {
+            if let Some(right_entry) = right_match {
+                handled_right.insert(right_entry.index);
+            }
+            merged_children.push(input.trees.left.node_text(input.left_child).to_owned());
+        }
+    }
+}
+
+struct UnnamedChildInput<'a, 'tree> {
+    left_hash: u64,
+    left_child: tree_sitter::Node<'tree>,
+    left_tree: &'a Tree,
+    right_tree: &'a Tree,
+    right_children: &'a [tree_sitter::Node<'tree>],
+}
+
+fn reconcile_unnamed(
+    input: &UnnamedChildInput<'_, '_>,
+    handled_right: &mut FxHashSet<usize>,
+    merged_children: &mut Vec<String>,
+) {
+    use ast_merge_ast::compute;
+
+    let right_match = input.right_children.iter().enumerate().find(|(idx, r)| {
+        !handled_right.contains(idx) && compute(input.right_tree, **r) == input.left_hash
+    });
+
+    if let Some((right_idx, _)) = right_match {
+        handled_right.insert(right_idx);
+    }
+    merged_children.push(input.left_tree.node_text(input.left_child).to_owned());
+}
+
+struct CollectNewRightInput<'a, 'tree> {
+    right_children: &'a [tree_sitter::Node<'tree>],
+    handled_right: &'a FxHashSet<usize>,
+    base_child_names: &'a FxHashMap<String, IndexedNode<'tree>>,
+    base_child_hashes: &'a FxHashMap<u64, usize>,
+}
+
+fn collect_new_right(
+    right_tree: &Tree,
+    input: &CollectNewRightInput<'_, '_>,
+    merged_children: &mut Vec<String>,
+) {
+    use ast_merge_ast::compute;
+
+    for (idx, right_child) in input.right_children.iter().enumerate() {
+        if input.handled_right.contains(&idx) {
+            continue;
+        }
+
+        let right_name = get_name(right_tree, *right_child);
+        let right_hash = compute(right_tree, *right_child);
+
+        let is_new = if let Some(name) = &right_name {
+            !input.base_child_names.contains_key(name)
+        } else {
+            !input.base_child_hashes.contains_key(&right_hash)
+        };
+
+        if is_new {
+            merged_children.push(right_tree.node_text(*right_child).to_owned());
+        }
+    }
+}
+
+struct ReconstructBodyInput<'a, 'tree> {
+    left_node: tree_sitter::Node<'tree>,
+    left_body: tree_sitter::Node<'tree>,
+    base_node: tree_sitter::Node<'tree>,
+    merged_children: &'a [String],
+}
+
+#[expect(
+    clippy::string_slice,
+    reason = "byte offsets from tree-sitter are guaranteed to be at UTF-8 char boundaries"
+)]
+fn reconstruct_body(left_tree: &Tree, input: &ReconstructBodyInput<'_, '_>) -> String {
+    let left_text = left_tree.node_text(input.left_node);
+    let left_body_text = left_tree.node_text(input.left_body);
+
+    let body_start = input.left_body.start_byte() - input.left_node.start_byte();
+    let body_end = input.left_body.end_byte() - input.left_node.start_byte();
+
+    let prefix = &left_text[..body_start];
+    let suffix = &left_text[body_end..];
+
+    let (open, close) = if left_body_text.as_bytes().first() == Some(&b'{') {
+        ("{", "}")
+    } else {
+        ("(", ")")
+    };
+
+    let mut result = String::new();
+    result.push_str(prefix);
+    result.push_str(open);
+    result.push('\n');
+    let needs_commas = matches!(input.base_node.kind(), "struct_item" | "enum_item");
+    for child in input.merged_children {
+        result.push_str("    ");
+        result.push_str(child.trim());
+        if needs_commas && !child.trim().ends_with(',') {
+            result.push(',');
+        }
+        result.push('\n');
+    }
+    result.push_str(close);
+    result.push_str(suffix);
+    result
+}
+
+pub fn get_meaningful(node: tree_sitter::Node<'_>) -> Vec<tree_sitter::Node<'_>> {
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .filter(|n| {
+            !n.is_extra()
+                && !matches!(
+                    n.kind(),
+                    "{" | "}" | "(" | ")" | "[" | "]" | "," | ";" | "<" | ">"
+                )
+        })
+        .collect()
+}

--- a/packages/ast-merge/diff/src/children/body.rs
+++ b/packages/ast-merge/diff/src/children/body.rs
@@ -1,0 +1,73 @@
+use crate::{
+    engine::{ThreeWayNodes, ThreeWayTrees},
+    lines::inner,
+};
+
+#[expect(
+    clippy::string_slice,
+    reason = "byte offsets from tree-sitter are guaranteed to be at UTF-8 char boundaries"
+)]
+pub fn try_reconcile_function(
+    trees: &ThreeWayTrees<'_>,
+    nodes: ThreeWayNodes<'_>,
+) -> Option<String> {
+    let ThreeWayTrees {
+        base: base_tree,
+        left: left_tree,
+        right: right_tree,
+    } = trees;
+    let ThreeWayNodes {
+        base: base_node,
+        left: left_node,
+        right: right_node,
+    } = nodes;
+    let base_body = base_node.child_by_field_name("body")?;
+    let left_body = left_node.child_by_field_name("body")?;
+    let right_body = right_node.child_by_field_name("body")?;
+
+    let base_body_text = base_tree.node_text(base_body);
+    let left_body_text = left_tree.node_text(left_body);
+    let right_body_text = right_tree.node_text(right_body);
+
+    let base_inner = strip_braces(base_body_text);
+    let left_inner = strip_braces(left_body_text);
+    let right_inner = strip_braces(right_body_text);
+
+    let merge_result = inner(base_inner, left_inner, right_inner);
+
+    if merge_result.has_conflict {
+        return None;
+    }
+
+    let left_text = left_tree.node_text(left_node);
+    let body_start = left_body.start_byte() - left_node.start_byte();
+    let body_end = left_body.end_byte() - left_node.start_byte();
+
+    let prefix = &left_text[..body_start];
+    let suffix = &left_text[body_end..];
+
+    let mut result = String::new();
+    result.push_str(prefix);
+    result.push_str("{\n");
+    result.push_str(&merge_result.content);
+    if !merge_result.content.ends_with('\n') {
+        result.push('\n');
+    }
+    result.push('}');
+    result.push_str(suffix);
+
+    Some(result)
+}
+
+fn strip_braces(s: &str) -> &str {
+    let s = s.trim();
+    if s.strip_prefix('{')
+        .and_then(|rest| rest.strip_suffix('}'))
+        .is_some()
+    {
+        s.get(1..s.len() - 1)
+            .map_or(s, |inner| inner.trim_matches('\n'))
+    } else {
+        s
+    }
+}

--- a/packages/ast-merge/diff/src/conflict.rs
+++ b/packages/ast-merge/diff/src/conflict.rs
@@ -1,0 +1,47 @@
+#[derive(Debug, Clone)]
+pub struct Conflict {
+    pub base: Option<Region>,
+    pub left: Region,
+    pub right: Region,
+}
+
+#[derive(Debug, Clone)]
+pub struct Region {
+    pub start: usize,
+    pub end: usize,
+    pub text: String,
+}
+
+impl Region {
+    #[must_use]
+    pub fn new(start: usize, end: usize, text: String) -> Self {
+        Self { start, end, text }
+    }
+}
+
+#[derive(Debug)]
+pub struct Result {
+    pub content: String,
+    pub conflicts: Vec<Conflict>,
+    pub success: bool,
+}
+
+impl Result {
+    #[must_use]
+    pub fn success(content: String) -> Self {
+        Self {
+            content,
+            conflicts: Vec::new(),
+            success: true,
+        }
+    }
+
+    #[must_use]
+    pub fn with_conflicts(content: String, conflicts: Vec<Conflict>) -> Self {
+        Self {
+            content,
+            conflicts,
+            success: false,
+        }
+    }
+}

--- a/packages/ast-merge/diff/src/engine.rs
+++ b/packages/ast-merge/diff/src/engine.rs
@@ -1,0 +1,296 @@
+use ast_merge_ast::{Revision, Tree};
+use ast_merge_matcher::Map;
+
+use crate::{
+    changeset::{ChangeSet, PcsTriple},
+    conflict::{Conflict, Region, Result},
+    items::reconcile_lists,
+    mapping::{Class, RevisionNode, RevisionNodePair},
+    trees::{collect_nodes, find_predecessor},
+};
+
+/// Three-way tree references for base, left, and right revisions.
+pub struct ThreeWayTrees<'a> {
+    pub base: &'a Tree,
+    pub left: &'a Tree,
+    pub right: &'a Tree,
+}
+
+/// Three-way node references for base, left, and right revisions.
+#[derive(Clone, Copy)]
+pub struct ThreeWayNodes<'a> {
+    pub base: tree_sitter::Node<'a>,
+    pub left: tree_sitter::Node<'a>,
+    pub right: tree_sitter::Node<'a>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub marker_size: usize,
+    pub diff3_style: bool,
+}
+
+/// Standard git conflict marker size (`<<<<<<<`, `=======`, `>>>>>>>`).
+const DEFAULT_MARKER_SIZE: usize = 7;
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            marker_size: DEFAULT_MARKER_SIZE,
+            diff3_style: true,
+        }
+    }
+}
+
+/// Construction parameters for [`ThreeWay`].
+pub struct ThreeWayParams<'a> {
+    pub trees: ThreeWayTrees<'a>,
+    pub base_left_matching: Map,
+    pub base_right_matching: Map,
+    pub config: Config,
+}
+
+pub struct ThreeWay<'a> {
+    trees: ThreeWayTrees<'a>,
+    base_left_matching: Map,
+    base_right_matching: Map,
+}
+
+impl<'a> ThreeWay<'a> {
+    #[must_use]
+    pub fn new(params: ThreeWayParams<'a>) -> Self {
+        Self {
+            trees: params.trees,
+            base_left_matching: params.base_left_matching,
+            base_right_matching: params.base_right_matching,
+        }
+    }
+
+    #[must_use]
+    pub fn merge(&self) -> Result {
+        let class_mapping = self.build_class_mapping();
+
+        let changeset = self.build_changeset(&class_mapping);
+
+        let conflicts = detect_conflicts(&changeset, &class_mapping);
+
+        if conflicts.is_empty() {
+            let content = self.reconstruct_merged(&changeset, &class_mapping);
+            Result::success(content)
+        } else {
+            // Structural conflicts detected — fall back to line-based merge
+            // which produces correct Git-style conflict markers with full
+            // source text context.
+            let base_src = self.trees.base.source();
+            let left_src = self.trees.left.source();
+            let right_src = self.trees.right.source();
+            crate::lines::based(base_src, left_src, right_src)
+        }
+    }
+
+    fn build_class_mapping(&self) -> Class {
+        let mut mapping = Class::new();
+
+        for pair in self.base_left_matching.iter() {
+            mapping.merge(&RevisionNodePair {
+                a: RevisionNode {
+                    revision: Revision::Base,
+                    node_id: pair.a_id,
+                },
+                b: RevisionNode {
+                    revision: Revision::Left,
+                    node_id: pair.b_id,
+                },
+            });
+        }
+
+        for pair in self.base_right_matching.iter() {
+            mapping.merge(&RevisionNodePair {
+                a: RevisionNode {
+                    revision: Revision::Base,
+                    node_id: pair.a_id,
+                },
+                b: RevisionNode {
+                    revision: Revision::Right,
+                    node_id: pair.b_id,
+                },
+            });
+        }
+
+        mapping
+    }
+
+    fn build_changeset(&self, _class_mapping: &Class) -> ChangeSet {
+        let mut changeset = ChangeSet::new();
+
+        extract_pcs_triples(self.trees.base, Revision::Base, &mut changeset);
+        extract_pcs_triples(self.trees.left, Revision::Left, &mut changeset);
+        extract_pcs_triples(self.trees.right, Revision::Right, &mut changeset);
+
+        changeset
+    }
+
+    fn reconstruct_merged(&self, _changeset: &ChangeSet, _class_mapping: &Class) -> String {
+        let base_items = get_top_level_items(self.trees.base);
+        let left_items = get_top_level_items(self.trees.left);
+        let right_items = get_top_level_items(self.trees.right);
+
+        let items = crate::items::ThreeWay {
+            base: &base_items,
+            left: &left_items,
+            right: &right_items,
+        };
+        reconcile_lists(&self.trees, &items)
+    }
+}
+
+/// Detect structural conflicts in the three-way changeset.
+///
+/// Uses the 3DM inconsistency rule: two PCS triples conflict when they
+/// share the same (parent, predecessor) but have different successors,
+/// or the same (parent, successor) but different predecessors — AND
+/// the conflicting triples come from different non-base revisions.
+///
+/// When structural conflicts are found, we don't attempt fine-grained
+/// conflict regions (that requires full tree reconstruction per Mergiraf).
+/// Instead we return a single conflict covering the full source text of
+/// each side, letting the caller fall back to line-based merge which
+/// already produces correct Git-style conflict markers.
+/// (parent, predecessor) key for PCS position indexing.
+struct PcsPosition {
+    parent: Option<usize>,
+    predecessor: Option<usize>,
+}
+
+impl std::hash::Hash for PcsPosition {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.parent.hash(state);
+        self.predecessor.hash(state);
+    }
+}
+
+impl PartialEq for PcsPosition {
+    fn eq(&self, other: &Self) -> bool {
+        self.parent == other.parent && self.predecessor == other.predecessor
+    }
+}
+
+impl Eq for PcsPosition {}
+
+/// Successor paired with the set of revisions that contain the triple.
+struct SuccessorEntry<'a> {
+    successor: usize,
+    revisions: &'a rustc_hash::FxHashSet<Revision>,
+}
+
+fn detect_conflicts(changeset: &ChangeSet, class_mapping: &Class) -> Vec<Conflict> {
+    use rustc_hash::FxHashMap;
+
+    // Index triples by (parent, predecessor) to find successor conflicts.
+    let mut by_position: FxHashMap<PcsPosition, Vec<SuccessorEntry<'_>>> = FxHashMap::default();
+
+    for entry in changeset.iter() {
+        by_position
+            .entry(PcsPosition {
+                parent: entry.triple.parent,
+                predecessor: entry.triple.predecessor,
+            })
+            .or_default()
+            .push(SuccessorEntry {
+                successor: entry.triple.successor,
+                revisions: entry.revisions,
+            });
+    }
+
+    // Check for successor conflicts: same position, different successors,
+    // where one is left-only and the other is right-only.
+    for entries in by_position.values() {
+        if entries.len() < 2 {
+            continue;
+        }
+        for (i, entry_a) in entries.iter().enumerate() {
+            for entry_b in entries.iter().skip(i + 1) {
+                if entry_a.successor == entry_b.successor {
+                    continue; // Same successor = no conflict.
+                }
+                let a_left_only = entry_a.revisions.contains(&Revision::Left)
+                    && !entry_a.revisions.contains(&Revision::Base);
+                let b_right_only = entry_b.revisions.contains(&Revision::Right)
+                    && !entry_b.revisions.contains(&Revision::Base);
+                let a_right_only = entry_a.revisions.contains(&Revision::Right)
+                    && !entry_a.revisions.contains(&Revision::Base);
+                let b_left_only = entry_b.revisions.contains(&Revision::Left)
+                    && !entry_b.revisions.contains(&Revision::Base);
+
+                let conflict = (a_left_only && b_right_only) || (a_right_only && b_left_only);
+                if !conflict {
+                    continue;
+                }
+                // Check convergence: if both successors map to the same
+                // equivalence class, the change is convergent (not a conflict).
+                let class_a_left = class_mapping.get_class(RevisionNode {
+                    revision: Revision::Left,
+                    node_id: entry_a.successor,
+                });
+                let class_b_right = class_mapping.get_class(RevisionNode {
+                    revision: Revision::Right,
+                    node_id: entry_b.successor,
+                });
+                let class_a_right = class_mapping.get_class(RevisionNode {
+                    revision: Revision::Right,
+                    node_id: entry_a.successor,
+                });
+                let class_b_left = class_mapping.get_class(RevisionNode {
+                    revision: Revision::Left,
+                    node_id: entry_b.successor,
+                });
+                let convergent = matches!(
+                    (class_a_left, class_b_right),
+                    (Some(a), Some(b)) if a == b
+                ) || matches!(
+                    (class_a_right, class_b_left),
+                    (Some(a), Some(b)) if a == b
+                );
+                if convergent {
+                    continue;
+                }
+
+                // Structural conflict found. We don't have enough context
+                // here to extract per-node conflict regions (would need the
+                // original trees). Return an empty-text conflict as a signal
+                // to the caller that a conflict exists.
+                return vec![Conflict {
+                    base: None,
+                    left: Region::new(0, 0, String::new()),
+                    right: Region::new(0, 0, String::new()),
+                }];
+            }
+        }
+    }
+
+    Vec::new()
+}
+fn extract_pcs_triples(tree: &Tree, revision: Revision, changeset: &mut ChangeSet) {
+    let mut node_ids: Vec<tree_sitter::Node<'_>> = Vec::new();
+    collect_nodes(tree.root_node(), &mut node_ids);
+
+    for (id, &node) in node_ids.iter().enumerate() {
+        let parent = node
+            .parent()
+            .and_then(|p| node_ids.iter().position(|n| n.id() == p.id()));
+
+        let predecessor = node
+            .parent()
+            .and_then(|parent_node| find_predecessor(parent_node, node, &node_ids));
+
+        let triple = PcsTriple::new(parent, predecessor, id);
+        changeset.add(triple, revision);
+    }
+}
+fn get_top_level_items(tree: &Tree) -> Vec<tree_sitter::Node<'_>> {
+    let root = tree.root_node();
+    let mut cursor = root.walk();
+    root.children(&mut cursor)
+        .filter(|n| !n.is_extra())
+        .collect()
+}

--- a/packages/ast-merge/diff/src/items.rs
+++ b/packages/ast-merge/diff/src/items.rs
@@ -1,0 +1,229 @@
+mod left;
+mod right;
+
+use ast_merge_ast::Tree;
+use left::{Context, NameLookups, reconcile_all};
+use right::{CollectNewContext, collect_new, insert_new};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{
+    children::{try_reconcile, try_reconcile_function},
+    engine::{ThreeWayNodes, ThreeWayTrees},
+};
+
+#[derive(Debug)]
+pub struct Resolved {
+    pub text: String,
+    pub kind: String,
+    pub base_index: Option<usize>,
+    pub right_predecessor_base_idx: Option<usize>,
+}
+
+/// A tree-sitter node paired with its positional index in a child list.
+#[derive(Debug, Clone, Copy)]
+pub struct IndexedNode<'tree> {
+    pub index: usize,
+    pub node: tree_sitter::Node<'tree>,
+}
+
+pub fn build_name_map<'a>(
+    tree: &Tree,
+    items: &[tree_sitter::Node<'a>],
+) -> FxHashMap<String, IndexedNode<'a>> {
+    items
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, node)| {
+            get_name(tree, *node).map(|name| {
+                (
+                    name,
+                    IndexedNode {
+                        index: idx,
+                        node: *node,
+                    },
+                )
+            })
+        })
+        .collect()
+}
+
+pub fn get_name(tree: &Tree, node: tree_sitter::Node<'_>) -> Option<String> {
+    let kind = node.kind();
+
+    let name_field = match kind {
+        "function_item" | "struct_item" | "enum_item" | "trait_item" | "type_item"
+        | "const_item" | "static_item" | "mod_item" => Some("name"),
+        "impl_item" => Some("type"),
+        "field_declaration" => Some("name"),
+        "function_signature_item" => Some("name"),
+        "use_declaration" => {
+            return Some(tree.node_text(node).to_owned());
+        }
+        _ => None,
+    }?;
+
+    node.child_by_field_name(name_field)
+        .map(|n| tree.node_text(n).to_owned())
+}
+
+pub fn reconcile_single(trees: &ThreeWayTrees<'_>, nodes: ThreeWayNodes<'_>) -> String {
+    use ast_merge_ast::compute;
+
+    let ThreeWayTrees {
+        base: base_tree,
+        left: left_tree,
+        right: right_tree,
+    } = trees;
+    let ThreeWayNodes {
+        base: base_node,
+        left: left_node,
+        right: right_node,
+    } = nodes;
+
+    let base_hash = compute(base_tree, base_node);
+    let left_hash = compute(left_tree, left_node);
+    let right_hash = compute(right_tree, right_node);
+
+    if left_hash == right_hash {
+        return left_tree.node_text(left_node).to_owned();
+    }
+    if left_hash == base_hash {
+        return right_tree.node_text(right_node).to_owned();
+    }
+    if right_hash == base_hash {
+        return left_tree.node_text(left_node).to_owned();
+    }
+
+    let kind = base_node.kind();
+    if matches!(
+        kind,
+        "struct_item" | "impl_item" | "enum_item" | "trait_item"
+    ) {
+        if let Some(merged) = try_reconcile(
+            trees,
+            ThreeWayNodes {
+                base: base_node,
+                left: left_node,
+                right: right_node,
+            },
+        ) {
+            return merged;
+        }
+    }
+
+    if kind == "function_item" {
+        if let Some(merged) = try_reconcile_function(
+            trees,
+            ThreeWayNodes {
+                base: base_node,
+                left: left_node,
+                right: right_node,
+            },
+        ) {
+            return merged;
+        }
+    }
+
+    let left_text = left_tree.node_text(left_node);
+    let right_text = right_tree.node_text(right_node);
+    let base_text = base_tree.node_text(base_node);
+    format!(
+        "<<<<<<< LEFT\n{left_text}\n||||||| BASE\n{base_text}\n=======\n{right_text}\n>>>>>>> \
+         RIGHT"
+    )
+}
+
+/// Three-way item slices for `reconcile_lists`.
+pub(crate) struct ThreeWay<'a, 'tree> {
+    pub(crate) base: &'a [tree_sitter::Node<'tree>],
+    pub(crate) left: &'a [tree_sitter::Node<'tree>],
+    pub(crate) right: &'a [tree_sitter::Node<'tree>],
+}
+
+pub fn reconcile_lists(trees: &ThreeWayTrees<'_>, items: &ThreeWay<'_, '_>) -> String {
+    let base_by_name = build_name_map(trees.base, items.base);
+    let right_by_name = build_name_map(trees.right, items.right);
+    let base_hashes = build_hash_map(trees.base, items.base);
+    let right_to_base = build_right_to_base_map(
+        trees.right,
+        &RightToBaseInput {
+            right_items: items.right,
+            base_by_name: &base_by_name,
+            base_hashes: &base_hashes,
+        },
+    );
+
+    let mut handled_right: FxHashSet<usize> = FxHashSet::default();
+
+    let name_lookups = NameLookups {
+        base: &base_by_name,
+        right: &right_by_name,
+    };
+
+    let left_ctx = Context {
+        trees,
+        left_items: items.left,
+        right_items: items.right,
+        name_lookups: &name_lookups,
+        base_hashes: &base_hashes,
+    };
+    let mut merged_items = reconcile_all(&left_ctx, &mut handled_right);
+
+    let collect_ctx = CollectNewContext {
+        right_items: items.right,
+        handled_right: &handled_right,
+        base_by_name: &base_by_name,
+        base_hashes: &base_hashes,
+        right_to_base: &right_to_base,
+    };
+    let new_right_items = collect_new(trees.right, &collect_ctx);
+    insert_new(&mut merged_items, new_right_items);
+
+    let mut result = String::new();
+    for item in merged_items {
+        result.push_str(&item.text);
+        result.push('\n');
+    }
+    result
+}
+
+fn build_hash_map(tree: &Tree, items: &[tree_sitter::Node<'_>]) -> FxHashMap<u64, usize> {
+    use ast_merge_ast::compute;
+    items
+        .iter()
+        .enumerate()
+        .map(|(idx, node)| (compute(tree, *node), idx))
+        .collect()
+}
+
+struct RightToBaseInput<'a, 'tree> {
+    right_items: &'a [tree_sitter::Node<'tree>],
+    base_by_name: &'a FxHashMap<String, IndexedNode<'tree>>,
+    base_hashes: &'a FxHashMap<u64, usize>,
+}
+
+fn build_right_to_base_map(
+    right_tree: &Tree,
+    input: &RightToBaseInput<'_, '_>,
+) -> FxHashMap<usize, usize> {
+    use ast_merge_ast::compute;
+    input
+        .right_items
+        .iter()
+        .enumerate()
+        .filter_map(|(right_idx, right_item)| {
+            if let Some(name) = get_name(right_tree, *right_item) {
+                input
+                    .base_by_name
+                    .get(&name)
+                    .map(|entry| (right_idx, entry.index))
+            } else {
+                let right_hash = compute(right_tree, *right_item);
+                input
+                    .base_hashes
+                    .get(&right_hash)
+                    .map(|&base_idx| (right_idx, base_idx))
+            }
+        })
+        .collect()
+}

--- a/packages/ast-merge/diff/src/items/left.rs
+++ b/packages/ast-merge/diff/src/items/left.rs
@@ -1,0 +1,207 @@
+use ast_merge_ast::Tree;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{
+    engine::{ThreeWayNodes, ThreeWayTrees},
+    items::{IndexedNode, Resolved, get_name, reconcile_single},
+};
+
+/// Name-map lookups for base and right items.
+pub(crate) struct NameLookups<'a, 'tree> {
+    pub(crate) base: &'a FxHashMap<String, IndexedNode<'tree>>,
+    pub(crate) right: &'a FxHashMap<String, IndexedNode<'tree>>,
+}
+
+/// Context for merging left items against base and right.
+pub(crate) struct Context<'a, 'tree> {
+    pub(crate) trees: &'a ThreeWayTrees<'tree>,
+    pub(crate) left_items: &'a [tree_sitter::Node<'tree>],
+    pub(crate) right_items: &'a [tree_sitter::Node<'tree>],
+    pub(crate) name_lookups: &'a NameLookups<'a, 'tree>,
+    pub(crate) base_hashes: &'a FxHashMap<u64, usize>,
+}
+
+pub(crate) fn reconcile_all(
+    ctx: &Context<'_, '_>,
+    handled_right: &mut FxHashSet<usize>,
+) -> Vec<Resolved> {
+    use ast_merge_ast::compute;
+
+    let left_tree = ctx.trees.left;
+    let right_tree = ctx.trees.right;
+    let mut merged_items: Vec<Resolved> = Vec::new();
+
+    for left_item in ctx.left_items {
+        let left_hash = compute(left_tree, *left_item);
+        let left_text = left_tree.node_text(*left_item);
+        let left_name = get_name(left_tree, *left_item);
+        let left_kind = left_item.kind().to_owned();
+
+        if let Some(name) = &left_name {
+            let input = NamedInput {
+                trees: ctx.trees,
+                name,
+                left_item: *left_item,
+                left_text,
+                left_kind: &left_kind,
+                lookups: ctx.name_lookups,
+            };
+            reconcile_named(&input, handled_right, &mut merged_items);
+        } else {
+            let input = UnnamedInput {
+                left_hash,
+                left_text,
+                left_kind,
+                left_item: *left_item,
+                right_tree,
+                right_items: ctx.right_items,
+                base_hashes: ctx.base_hashes,
+            };
+            reconcile_unnamed(&input, handled_right, &mut merged_items);
+        }
+    }
+
+    merged_items
+}
+
+struct NamedInput<'a, 'tree> {
+    trees: &'a ThreeWayTrees<'tree>,
+    name: &'a str,
+    left_item: tree_sitter::Node<'tree>,
+    left_text: &'a str,
+    left_kind: &'a str,
+    lookups: &'a NameLookups<'a, 'tree>,
+}
+
+fn reconcile_named(
+    input: &NamedInput<'_, '_>,
+    handled_right: &mut FxHashSet<usize>,
+    merged_items: &mut Vec<Resolved>,
+) {
+    let base_match = input.lookups.base.get(input.name);
+    let right_match = input.lookups.right.get(input.name);
+
+    match (base_match, right_match) {
+        (Some(base_entry), Some(right_entry)) => {
+            handled_right.insert(right_entry.index);
+            let merged = reconcile_single(
+                input.trees,
+                ThreeWayNodes {
+                    base: base_entry.node,
+                    left: input.left_item,
+                    right: right_entry.node,
+                },
+            );
+            merged_items.push(Resolved {
+                text: merged,
+                kind: input.left_kind.to_owned(),
+                base_index: Some(base_entry.index),
+                right_predecessor_base_idx: None,
+            });
+        }
+        (Some(base_entry), None) => {
+            merged_items.push(Resolved {
+                text: input.left_text.to_owned(),
+                kind: input.left_kind.to_owned(),
+                base_index: Some(base_entry.index),
+                right_predecessor_base_idx: None,
+            });
+        }
+        (None, Some(right_entry)) => {
+            handled_right.insert(right_entry.index);
+            merged_items.push(Resolved {
+                text: input.left_text.to_owned(),
+                kind: input.left_kind.to_owned(),
+                base_index: None,
+                right_predecessor_base_idx: None,
+            });
+        }
+        (None, None) => {
+            merged_items.push(Resolved {
+                text: input.left_text.to_owned(),
+                kind: input.left_kind.to_owned(),
+                base_index: None,
+                right_predecessor_base_idx: None,
+            });
+        }
+    }
+}
+
+struct UnnamedInput<'a, 'tree> {
+    left_hash: u64,
+    left_text: &'a str,
+    left_kind: String,
+    left_item: tree_sitter::Node<'tree>,
+    right_tree: &'a Tree,
+    right_items: &'a [tree_sitter::Node<'tree>],
+    base_hashes: &'a FxHashMap<u64, usize>,
+}
+
+fn reconcile_unnamed(
+    input: &UnnamedInput<'_, '_>,
+    handled_right: &mut FxHashSet<usize>,
+    merged_items: &mut Vec<Resolved>,
+) {
+    use ast_merge_ast::compute;
+
+    let right_match = input.right_items.iter().enumerate().find(|(idx, r)| {
+        !handled_right.contains(idx) && compute(input.right_tree, **r) == input.left_hash
+    });
+
+    if let Some((right_idx, _)) = right_match {
+        handled_right.insert(right_idx);
+        let base_idx = input.base_hashes.get(&input.left_hash).copied();
+        merged_items.push(Resolved {
+            text: input.left_text.to_owned(),
+            kind: input.left_kind.clone(),
+            base_index: base_idx,
+            right_predecessor_base_idx: None,
+        });
+        return;
+    }
+
+    let Some(&base_idx) = input.base_hashes.get(&input.left_hash) else {
+        merged_items.push(Resolved {
+            text: input.left_text.to_owned(),
+            kind: input.left_kind.clone(),
+            base_index: None,
+            right_predecessor_base_idx: None,
+        });
+        return;
+    };
+
+    let right_candidate = input.right_items.iter().enumerate().find(|(idx, r)| {
+        !handled_right.contains(idx)
+            && r.kind() == input.left_item.kind()
+            && get_name(input.right_tree, **r).is_none()
+    });
+
+    let Some((right_idx, right_item)) = right_candidate else {
+        merged_items.push(Resolved {
+            text: input.left_text.to_owned(),
+            kind: input.left_kind.clone(),
+            base_index: Some(base_idx),
+            right_predecessor_base_idx: None,
+        });
+        return;
+    };
+
+    let right_hash = compute(input.right_tree, *right_item);
+    if input.base_hashes.contains_key(&right_hash) {
+        merged_items.push(Resolved {
+            text: input.left_text.to_owned(),
+            kind: input.left_kind.clone(),
+            base_index: Some(base_idx),
+            right_predecessor_base_idx: None,
+        });
+        return;
+    }
+
+    handled_right.insert(right_idx);
+    merged_items.push(Resolved {
+        text: input.right_tree.node_text(*right_item).to_owned(),
+        kind: input.left_kind.clone(),
+        base_index: Some(base_idx),
+        right_predecessor_base_idx: None,
+    });
+}

--- a/packages/ast-merge/diff/src/items/right.rs
+++ b/packages/ast-merge/diff/src/items/right.rs
@@ -1,0 +1,66 @@
+use ast_merge_ast::Tree;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::items::{IndexedNode, Resolved, get_name};
+
+/// Context for collecting right-only items not present in base.
+pub(crate) struct CollectNewContext<'a, 'tree> {
+    pub(crate) right_items: &'a [tree_sitter::Node<'tree>],
+    pub(crate) handled_right: &'a FxHashSet<usize>,
+    pub(crate) base_by_name: &'a FxHashMap<String, IndexedNode<'tree>>,
+    pub(crate) base_hashes: &'a FxHashMap<u64, usize>,
+    pub(crate) right_to_base: &'a FxHashMap<usize, usize>,
+}
+
+pub(crate) fn collect_new(right_tree: &Tree, ctx: &CollectNewContext<'_, '_>) -> Vec<Resolved> {
+    use ast_merge_ast::compute;
+
+    let mut new_right_items: Vec<Resolved> = Vec::new();
+    for (right_idx, right_item) in ctx.right_items.iter().enumerate() {
+        if ctx.handled_right.contains(&right_idx) {
+            continue;
+        }
+
+        let right_name = get_name(right_tree, *right_item);
+        let right_hash = compute(right_tree, *right_item);
+        let right_kind = right_item.kind().to_owned();
+
+        let is_new = if let Some(name) = &right_name {
+            !ctx.base_by_name.contains_key(name)
+        } else {
+            !ctx.base_hashes.contains_key(&right_hash)
+        };
+
+        if is_new {
+            let predecessor_base_idx = (0..right_idx)
+                .rev()
+                .find_map(|prev_idx| ctx.right_to_base.get(&prev_idx).copied());
+
+            new_right_items.push(Resolved {
+                text: right_tree.node_text(*right_item).to_owned(),
+                kind: right_kind,
+                base_index: None,
+                right_predecessor_base_idx: predecessor_base_idx,
+            });
+        }
+    }
+    new_right_items
+}
+
+pub(crate) fn insert_new(merged_items: &mut Vec<Resolved>, new_right_items: Vec<Resolved>) {
+    for new_item in new_right_items {
+        let insert_pos = if let Some(pred_base_idx) = new_item.right_predecessor_base_idx {
+            merged_items
+                .iter()
+                .position(|m| m.base_index == Some(pred_base_idx))
+                .map_or(merged_items.len(), |p| p + 1)
+        } else {
+            merged_items
+                .iter()
+                .position(|m| m.kind != new_item.kind)
+                .unwrap_or(0)
+        };
+
+        merged_items.insert(insert_pos, new_item);
+    }
+}

--- a/packages/ast-merge/diff/src/lib.rs
+++ b/packages/ast-merge/diff/src/lib.rs
@@ -1,0 +1,17 @@
+mod changeset;
+mod children;
+mod conflict;
+mod engine;
+mod items;
+mod lines;
+mod mapping;
+mod trees;
+
+pub use changeset::{ChangeSet, PcsTriple};
+pub use conflict::{Conflict, Region, Result};
+pub use engine::{Config, ThreeWay, ThreeWayNodes, ThreeWayParams, ThreeWayTrees};
+pub use lines::based;
+pub use mapping::Class;
+
+#[cfg(test)]
+mod tests;

--- a/packages/ast-merge/diff/src/lines.rs
+++ b/packages/ast-merge/diff/src/lines.rs
@@ -1,0 +1,226 @@
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::conflict::{Conflict, Region, Result};
+
+pub struct Outcome {
+    pub content: String,
+    pub has_conflict: bool,
+}
+
+struct ChangeMaps<'a> {
+    deletions: FxHashSet<usize>,
+    insertions: FxHashMap<usize, Vec<&'a str>>,
+}
+
+fn build_change_maps<'a>(
+    changes: impl Iterator<Item = similar::Change<&'a str>>,
+) -> ChangeMaps<'a> {
+    use similar::ChangeTag;
+
+    let mut deletions: FxHashSet<usize> = FxHashSet::default();
+    let mut insertions: FxHashMap<usize, Vec<&'a str>> = FxHashMap::default();
+    let mut base_idx = 0;
+
+    for change in changes {
+        match change.tag() {
+            ChangeTag::Equal => {
+                base_idx += 1;
+            }
+            ChangeTag::Delete => {
+                deletions.insert(base_idx);
+                base_idx += 1;
+            }
+            ChangeTag::Insert => {
+                insertions.entry(base_idx).or_default().push(change.value());
+            }
+        }
+    }
+
+    ChangeMaps {
+        deletions,
+        insertions,
+    }
+}
+
+pub fn inner(base: &str, left: &str, right: &str) -> Outcome {
+    use similar::{Algorithm, TextDiff};
+
+    let base_lines: Vec<&str> = base.lines().collect();
+    let left_lines: Vec<&str> = left.lines().collect();
+    let right_lines: Vec<&str> = right.lines().collect();
+
+    if left_lines == right_lines {
+        return Outcome {
+            content: left.to_owned(),
+            has_conflict: false,
+        };
+    }
+
+    let diff_base_left = TextDiff::configure()
+        .algorithm(Algorithm::Patience)
+        .diff_slices(&base_lines, &left_lines);
+    let diff_base_right = TextDiff::configure()
+        .algorithm(Algorithm::Patience)
+        .diff_slices(&base_lines, &right_lines);
+
+    let ChangeMaps {
+        deletions: left_changes,
+        insertions: left_insertions,
+    } = build_change_maps(diff_base_left.iter_all_changes());
+    let ChangeMaps {
+        deletions: right_changes,
+        insertions: right_insertions,
+    } = build_change_maps(diff_base_right.iter_all_changes());
+
+    let mut result = Vec::new();
+    let mut has_conflict = false;
+
+    for (i, base_line) in base_lines.iter().enumerate() {
+        let left_deleted = left_changes.contains(&i);
+        let right_deleted = right_changes.contains(&i);
+        let left_insert = left_insertions.get(&i);
+        let right_insert = right_insertions.get(&i);
+
+        // Conflict: both sides insert different content at the same position.
+        if let (Some(li), Some(ri)) = (left_insert, right_insert) {
+            if li != ri {
+                has_conflict = true;
+            }
+        }
+
+        if let Some(lines) = left_insert {
+            for line in lines {
+                result.push((*line).to_owned());
+            }
+        }
+        if let Some(lines) = right_insert {
+            for line in lines {
+                if left_insert.is_none_or(|li| !li.contains(line)) {
+                    result.push((*line).to_owned());
+                }
+            }
+        }
+
+        if !left_deleted && !right_deleted {
+            result.push((*base_line).to_owned());
+        }
+    }
+
+    // Check for conflicts in trailing insertions (after last base line).
+    let left_trailing = left_insertions.get(&base_lines.len());
+    let right_trailing = right_insertions.get(&base_lines.len());
+    if let (Some(lt), Some(rt)) = (left_trailing, right_trailing) {
+        if lt != rt {
+            has_conflict = true;
+        }
+    }
+
+    if let Some(lines) = left_trailing {
+        for line in lines {
+            result.push((*line).to_owned());
+        }
+    }
+    if let Some(lines) = right_trailing {
+        for line in lines {
+            if left_trailing.is_none_or(|lt| !lt.contains(line)) {
+                result.push((*line).to_owned());
+            }
+        }
+    }
+
+    Outcome {
+        content: result.join("\n"),
+        has_conflict,
+    }
+}
+
+#[must_use]
+pub fn based(base: &str, left: &str, right: &str) -> Result {
+    let base_lines: Vec<_> = base.lines().collect();
+    let left_lines: Vec<_> = left.lines().collect();
+    let right_lines: Vec<_> = right.lines().collect();
+
+    let mut output = String::new();
+    let mut conflicts = Vec::new();
+    let mut i = 0;
+
+    while i < base_lines.len() || i < left_lines.len() || i < right_lines.len() {
+        let base_line = base_lines.get(i).copied();
+        let left_line = left_lines.get(i).copied();
+        let right_line = right_lines.get(i).copied();
+
+        match (base_line, left_line, right_line) {
+            (Some(_), Some(l), Some(r)) if l == r => {
+                output.push_str(l);
+                output.push('\n');
+            }
+            (Some(b), Some(l), Some(r)) if l == b => {
+                output.push_str(r);
+                output.push('\n');
+            }
+            (Some(b), Some(l), Some(r)) if r == b => {
+                output.push_str(l);
+                output.push('\n');
+            }
+            (Some(b), Some(l), Some(r)) => {
+                output.push_str("<<<<<<< LEFT\n");
+                output.push_str(l);
+                output.push('\n');
+                output.push_str("||||||| BASE\n");
+                output.push_str(b);
+                output.push('\n');
+                output.push_str("=======\n");
+                output.push_str(r);
+                output.push('\n');
+                output.push_str(">>>>>>> RIGHT\n");
+                conflicts.push(Conflict {
+                    base: Some(Region::new(0, b.len(), b.to_owned())),
+                    left: Region::new(0, l.len(), l.to_owned()),
+                    right: Region::new(0, r.len(), r.to_owned()),
+                });
+            }
+            (None, Some(l), Some(r)) if l == r => {
+                output.push_str(l);
+                output.push('\n');
+            }
+            (None, Some(l), Some(r)) => {
+                output.push_str("<<<<<<< LEFT\n");
+                output.push_str(l);
+                output.push('\n');
+                output.push_str("=======\n");
+                output.push_str(r);
+                output.push('\n');
+                output.push_str(">>>>>>> RIGHT\n");
+                conflicts.push(Conflict {
+                    base: None,
+                    left: Region::new(0, l.len(), l.to_owned()),
+                    right: Region::new(0, r.len(), r.to_owned()),
+                });
+            }
+            (Some(_), None, Some(r)) => {
+                output.push_str(r);
+                output.push('\n');
+            }
+            (Some(_), Some(l), None) => {
+                output.push_str(l);
+                output.push('\n');
+            }
+            (None, Some(l), None) => {
+                output.push_str(l);
+                output.push('\n');
+            }
+            (None, None, Some(r)) => {
+                output.push_str(r);
+                output.push('\n');
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    if conflicts.is_empty() {
+        Result::success(output)
+    } else {
+        Result::with_conflicts(output, conflicts)
+    }
+}

--- a/packages/ast-merge/diff/src/mapping.rs
+++ b/packages/ast-merge/diff/src/mapping.rs
@@ -1,0 +1,171 @@
+use ast_merge_ast::Revision;
+use rustc_hash::FxHashMap;
+
+/// A node identified by its revision and ID within that revision.
+#[derive(Clone, Copy)]
+pub struct RevisionNode {
+    pub revision: Revision,
+    pub node_id: usize,
+}
+
+/// A pair of revision-nodes to merge into the same equivalence class.
+pub struct RevisionNodePair {
+    pub a: RevisionNode,
+    pub b: RevisionNode,
+}
+
+/// Key for looking up a node's equivalence class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct RevisionNodeKey {
+    revision: Revision,
+    node_id: usize,
+}
+
+#[derive(Debug, Default)]
+pub struct Class {
+    node_classes: FxHashMap<RevisionNodeKey, usize>,
+    members: FxHashMap<usize, FxHashMap<Revision, usize>>,
+    next: usize,
+}
+
+impl Class {
+    /// Three-way merge has exactly 3 revisions: Base, Left, Right.
+    const REVISION_COUNT: usize = 3;
+
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_singleton(&mut self, node: RevisionNode) -> usize {
+        let class_id = self.next;
+        self.next += 1;
+
+        self.node_classes.insert(
+            RevisionNodeKey {
+                revision: node.revision,
+                node_id: node.node_id,
+            },
+            class_id,
+        );
+        let mut members = FxHashMap::default();
+        members.insert(node.revision, node.node_id);
+        self.members.insert(class_id, members);
+
+        class_id
+    }
+
+    pub fn merge(&mut self, pair: &RevisionNodePair) {
+        let class_a = self
+            .node_classes
+            .get(&RevisionNodeKey {
+                revision: pair.a.revision,
+                node_id: pair.a.node_id,
+            })
+            .copied();
+        let class_b = self
+            .node_classes
+            .get(&RevisionNodeKey {
+                revision: pair.b.revision,
+                node_id: pair.b.node_id,
+            })
+            .copied();
+
+        match (class_a, class_b) {
+            (Some(ca), Some(cb)) if ca == cb => {}
+            (Some(ca), Some(cb)) => {
+                self.unify_classes(ca, cb);
+            }
+            (Some(ca), None) => {
+                self.add_to_class(ca, pair.b);
+            }
+            (None, Some(cb)) => {
+                self.add_to_class(cb, pair.a);
+            }
+            (None, None) => {
+                self.create_class_with_both(pair);
+            }
+        }
+    }
+
+    fn unify_classes(&mut self, class_a: usize, class_b: usize) {
+        let Some(members_b) = self.members.remove(&class_b) else {
+            return;
+        };
+
+        for (rev, node_id) in members_b {
+            self.node_classes.insert(
+                RevisionNodeKey {
+                    revision: rev,
+                    node_id,
+                },
+                class_a,
+            );
+            self.members
+                .entry(class_a)
+                .or_default()
+                .insert(rev, node_id);
+        }
+    }
+
+    fn add_to_class(&mut self, class_id: usize, node: RevisionNode) {
+        self.node_classes.insert(
+            RevisionNodeKey {
+                revision: node.revision,
+                node_id: node.node_id,
+            },
+            class_id,
+        );
+        self.members
+            .entry(class_id)
+            .or_default()
+            .insert(node.revision, node.node_id);
+    }
+
+    fn create_class_with_both(&mut self, pair: &RevisionNodePair) {
+        let class_id = self.next;
+        self.next += 1;
+
+        self.node_classes.insert(
+            RevisionNodeKey {
+                revision: pair.a.revision,
+                node_id: pair.a.node_id,
+            },
+            class_id,
+        );
+        self.node_classes.insert(
+            RevisionNodeKey {
+                revision: pair.b.revision,
+                node_id: pair.b.node_id,
+            },
+            class_id,
+        );
+
+        let mut members = FxHashMap::default();
+        members.insert(pair.a.revision, pair.a.node_id);
+        members.insert(pair.b.revision, pair.b.node_id);
+        self.members.insert(class_id, members);
+    }
+
+    #[must_use]
+    pub fn get_class(&self, node: RevisionNode) -> Option<usize> {
+        self.node_classes
+            .get(&RevisionNodeKey {
+                revision: node.revision,
+                node_id: node.node_id,
+            })
+            .copied()
+    }
+
+    #[must_use]
+    pub fn get_class_members(&self, class_id: usize) -> Option<&FxHashMap<Revision, usize>> {
+        self.members.get(&class_id)
+    }
+
+    #[must_use]
+    pub fn is_in_all_revisions(&self, class_id: usize) -> bool {
+        self.members
+            .get(&class_id)
+            .is_some_and(|members| members.len() == Self::REVISION_COUNT)
+    }
+}

--- a/packages/ast-merge/diff/src/tests.rs
+++ b/packages/ast-merge/diff/src/tests.rs
@@ -1,0 +1,214 @@
+use super::*;
+
+mod advanced;
+mod merge;
+
+#[test]
+fn test_pcs_triple_creation() {
+    let triple = PcsTriple::new(Some(0), None, 1);
+    assert_eq!(triple.parent, Some(0));
+    assert_eq!(triple.predecessor, None);
+    assert_eq!(triple.successor, 1);
+}
+
+#[test]
+fn test_changeset_add_and_get() {
+    use ast_merge_ast::Revision;
+
+    let mut changeset = ChangeSet::new();
+    let triple = PcsTriple::new(None, None, 0);
+
+    changeset.add(triple.clone(), Revision::Base);
+    changeset.add(triple.clone(), Revision::Left);
+
+    let revisions = changeset.get_revisions(&triple).unwrap();
+    assert!(revisions.contains(&Revision::Base));
+    assert!(revisions.contains(&Revision::Left));
+    assert!(!revisions.contains(&Revision::Right));
+}
+
+#[test]
+fn test_changeset_len() {
+    use ast_merge_ast::Revision;
+
+    let mut changeset = ChangeSet::new();
+    assert!(changeset.is_empty());
+
+    changeset.add(PcsTriple::new(None, None, 0), Revision::Base);
+    assert_eq!(changeset.len(), 1);
+
+    changeset.add(PcsTriple::new(None, None, 1), Revision::Left);
+    assert_eq!(changeset.len(), 2);
+}
+
+#[test]
+fn test_class_mapping_singleton() {
+    use ast_merge_ast::Revision;
+
+    use crate::mapping::RevisionNode;
+
+    let mut mapping = Class::new();
+    let class_id = mapping.add_singleton(RevisionNode {
+        revision: Revision::Base,
+        node_id: 0,
+    });
+
+    assert_eq!(
+        mapping.get_class(RevisionNode {
+            revision: Revision::Base,
+            node_id: 0,
+        }),
+        Some(class_id)
+    );
+    assert!(mapping.get_class_members(class_id).is_some());
+}
+
+#[test]
+fn test_class_mapping_combine() {
+    use ast_merge_ast::Revision;
+
+    use crate::mapping::{RevisionNode, RevisionNodePair};
+
+    let mut mapping = Class::new();
+    mapping.merge(&RevisionNodePair {
+        a: RevisionNode {
+            revision: Revision::Base,
+            node_id: 0,
+        },
+        b: RevisionNode {
+            revision: Revision::Left,
+            node_id: 1,
+        },
+    });
+
+    let class_base = mapping.get_class(RevisionNode {
+        revision: Revision::Base,
+        node_id: 0,
+    });
+    let class_left = mapping.get_class(RevisionNode {
+        revision: Revision::Left,
+        node_id: 1,
+    });
+
+    assert!(class_base.is_some());
+    assert_eq!(class_base, class_left);
+}
+
+#[test]
+fn test_class_mapping_is_in_all_revisions() {
+    use ast_merge_ast::Revision;
+
+    use crate::mapping::{RevisionNode, RevisionNodePair};
+
+    let mut mapping = Class::new();
+    mapping.merge(&RevisionNodePair {
+        a: RevisionNode {
+            revision: Revision::Base,
+            node_id: 0,
+        },
+        b: RevisionNode {
+            revision: Revision::Left,
+            node_id: 0,
+        },
+    });
+    mapping.merge(&RevisionNodePair {
+        a: RevisionNode {
+            revision: Revision::Base,
+            node_id: 0,
+        },
+        b: RevisionNode {
+            revision: Revision::Right,
+            node_id: 0,
+        },
+    });
+
+    let class_id = mapping
+        .get_class(RevisionNode {
+            revision: Revision::Base,
+            node_id: 0,
+        })
+        .unwrap();
+    assert!(mapping.is_in_all_revisions(class_id));
+}
+
+#[test]
+fn test_conflict_region_creation() {
+    let region = Region::new(10, 20, "hello".to_owned());
+    assert_eq!(region.start, 10);
+    assert_eq!(region.end, 20);
+    assert_eq!(region.text, "hello");
+}
+
+#[test]
+fn test_result_success() {
+    let result = Result::success("merged content".to_owned());
+    assert!(result.success);
+    assert!(result.conflicts.is_empty());
+    assert_eq!(result.content, "merged content");
+}
+
+#[test]
+fn test_config_default() {
+    let config = Config::default();
+    assert_eq!(config.marker_size, 7);
+    assert!(config.diff3_style);
+}
+
+#[test]
+fn test_line_based_no_conflict() {
+    let base = "line1\nline2\nline3\n";
+    let left = "line1\nmodified\nline3\n";
+    let right = "line1\nline2\nline3\n";
+
+    let result = based(base, left, right);
+    assert!(result.success);
+    assert!(result.content.contains("modified"));
+}
+
+#[test]
+fn test_line_based_with_conflict() {
+    let base = "line1\nline2\nline3\n";
+    let left = "line1\nleft_change\nline3\n";
+    let right = "line1\nright_change\nline3\n";
+
+    let result = based(base, left, right);
+    assert!(!result.success);
+    assert!(!result.conflicts.is_empty());
+    assert!(result.content.contains("<<<<<<<"));
+    assert!(result.content.contains(">>>>>>>"));
+}
+
+#[test]
+fn test_line_based_same_change() {
+    let base = "line1\nline2\n";
+    let left = "line1\nchanged\n";
+    let right = "line1\nchanged\n";
+
+    let result = based(base, left, right);
+    assert!(result.success);
+    assert!(result.content.contains("changed"));
+}
+
+fn rust(base: &str, left: &str, right: &str) -> Result {
+    let ts_lang = ast_merge_langs::Lang::Rust.to_tree_sitter();
+
+    let base_parsed = ast_merge_ast::tree(base, &ts_lang).expect("parse base");
+    let left_parsed = ast_merge_ast::tree(left, &ts_lang).expect("parse left");
+    let right_parsed = ast_merge_ast::tree(right, &ts_lang).expect("parse right");
+
+    let base_left_matching = ast_merge_matcher::compute(&base_parsed.tree, &left_parsed.tree);
+    let base_right_matching = ast_merge_matcher::compute(&base_parsed.tree, &right_parsed.tree);
+
+    let merger = ThreeWay::new(crate::engine::ThreeWayParams {
+        trees: crate::engine::ThreeWayTrees {
+            base: &base_parsed.tree,
+            left: &left_parsed.tree,
+            right: &right_parsed.tree,
+        },
+        base_left_matching,
+        base_right_matching,
+        config: Config::default(),
+    });
+
+    merger.merge()
+}

--- a/packages/ast-merge/diff/src/tests/advanced.rs
+++ b/packages/ast-merge/diff/src/tests/advanced.rs
@@ -1,0 +1,204 @@
+use super::rust;
+
+#[test]
+fn test_both_add_statements_same_function() {
+    let base = r"fn process() {
+    let x = 1;
+}
+";
+
+    let left = r#"fn process() {
+    let x = 1;
+    let left_var = "from left";
+}
+"#;
+
+    let right = r#"fn process() {
+    let x = 1;
+    let right_var = "from right";
+}
+"#;
+
+    let result = rust(base, left, right);
+    assert!(
+        result.success,
+        "should merge both additions to same function: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("left_var"),
+        "should have left's addition: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("right_var"),
+        "should have right's addition: {}",
+        result.content
+    );
+}
+
+#[test]
+fn test_nested_struct_fields() {
+    let base = r"struct Config {
+    name: String,
+    value: i32,
+    enabled: bool,
+}
+";
+
+    let left = r"struct Config {
+    name: String,
+    value: i64,
+    enabled: bool,
+}
+";
+
+    let right = r"struct Config {
+    name: String,
+    value: i32,
+    enabled: Option<bool>,
+}
+";
+
+    let result = rust(base, left, right);
+    assert!(
+        result.success,
+        "should merge different struct field changes: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("value: i64"),
+        "should have left's field change: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("enabled: Option<bool>"),
+        "should have right's field change: {}",
+        result.content
+    );
+}
+
+#[test]
+fn test_impl_block_different_methods() {
+    let base = r#"impl Foo {
+    fn method_a(&self) {
+        println!("a");
+    }
+
+    fn method_b(&self) {
+        println!("b");
+    }
+}
+"#;
+
+    let left = r#"impl Foo {
+    fn method_a(&self) {
+        println!("a modified by left");
+    }
+
+    fn method_b(&self) {
+        println!("b");
+    }
+}
+"#;
+
+    let right = r#"impl Foo {
+    fn method_a(&self) {
+        println!("a");
+    }
+
+    fn method_b(&self) {
+        println!("b modified by right");
+    }
+}
+"#;
+
+    let result = rust(base, left, right);
+    assert!(
+        result.success,
+        "should merge different method changes in same impl: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("a modified by left"),
+        "should have left's method_a change: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("b modified by right"),
+        "should have right's method_b change: {}",
+        result.content
+    );
+}
+
+#[test]
+fn test_reorderable_imports() {
+    let base = r"use std::io;
+
+fn main() {}
+";
+
+    let left = r"use std::io;
+use std::fs;
+
+fn main() {}
+";
+
+    let right = r"use std::io;
+use std::path;
+
+fn main() {}
+";
+
+    let result = rust(base, left, right);
+    assert!(
+        result.success,
+        "should merge different import additions: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("use std::fs;"),
+        "should have left's import: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("use std::path;"),
+        "should have right's import: {}",
+        result.content
+    );
+}
+
+/// Regression test: when both sides modify the same function body differently,
+/// the merge must produce conflict markers -- NOT silently pick one side.
+/// Before the fix (ENG-466 partial), the merge silently concatenated both
+/// sides' changes or picked left's version.
+#[test]
+fn test_conflicting_function_body_produces_conflict_markers() {
+    let base = r#"fn greet(name: &str) {
+    println!("hi {name}");
+}
+"#;
+    let left = r#"fn greet(name: &str) {
+    println!("good morning {name}");
+}
+"#;
+    let right = r#"fn greet(name: &str) {
+    println!("good evening {name}");
+}
+"#;
+
+    let result = rust(base, left, right);
+    // The structural detect_conflicts may or may not flag this (it detects
+    // tree-structure conflicts, not content conflicts). But the item-level
+    // merge must produce conflict markers in the content.
+    assert!(
+        result.content.contains("<<<<<<<") && result.content.contains(">>>>>>>"),
+        "merge output must contain conflict markers when both sides modify the same function:\n{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("good morning") && result.content.contains("good evening"),
+        "conflict markers must show both sides' content:\n{}",
+        result.content
+    );
+}

--- a/packages/ast-merge/diff/src/tests/merge.rs
+++ b/packages/ast-merge/diff/src/tests/merge.rs
@@ -1,0 +1,275 @@
+use super::rust;
+
+#[test]
+fn test_left_modifies_right_adds() {
+    let base = r#"fn original() {
+    println!("original");
+}
+"#;
+
+    let left = r#"fn original() {
+    println!("modified by left");
+}
+"#;
+
+    let right = r#"fn original() {
+    println!("original");
+}
+
+fn right_new() {
+    println!("from right");
+}
+"#;
+
+    let result = rust(base, left, right);
+    assert!(result.success, "merge should succeed without conflicts");
+
+    assert!(
+        result.content.contains("modified by left"),
+        "should contain left's modification: {}",
+        result.content
+    );
+
+    assert!(
+        result.content.contains("fn right_new()"),
+        "should contain right's new function: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("from right"),
+        "should contain right's function body: {}",
+        result.content
+    );
+}
+
+#[test]
+fn test_right_modifies_left_adds() {
+    let base = r#"fn original() {
+    println!("original");
+}
+"#;
+
+    let left = r#"fn original() {
+    println!("original");
+}
+
+fn left_new() {
+    println!("from left");
+}
+"#;
+
+    let right = r#"fn original() {
+    println!("modified by right");
+}
+"#;
+
+    let result = rust(base, left, right);
+    assert!(result.success, "merge should succeed without conflicts");
+
+    assert!(
+        result.content.contains("modified by right"),
+        "should contain right's modification: {}",
+        result.content
+    );
+
+    assert!(
+        result.content.contains("fn left_new()"),
+        "should contain left's new function: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("from left"),
+        "should contain left's function body: {}",
+        result.content
+    );
+}
+
+#[test]
+fn test_both_add_different_functions() {
+    let base = r#"fn original() {
+    println!("original");
+}
+"#;
+
+    let left = r#"fn original() {
+    println!("original");
+}
+
+fn left_new() {
+    println!("from left");
+}
+"#;
+
+    let right = r#"fn original() {
+    println!("original");
+}
+
+fn right_new() {
+    println!("from right");
+}
+"#;
+
+    let result = rust(base, left, right);
+    assert!(result.success, "merge should succeed without conflicts");
+
+    assert!(
+        result.content.contains("fn left_new()"),
+        "should contain left's new function: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("fn right_new()"),
+        "should contain right's new function: {}",
+        result.content
+    );
+}
+
+#[test]
+fn test_identical_changes() {
+    let base = r#"fn original() {
+    println!("original");
+}
+"#;
+
+    let left = r#"fn original() {
+    println!("same change");
+}
+"#;
+
+    let right = r#"fn original() {
+    println!("same change");
+}
+"#;
+
+    let result = rust(base, left, right);
+    assert!(result.success, "merge should succeed without conflicts");
+    assert!(
+        result.content.contains("same change"),
+        "should contain the common change: {}",
+        result.content
+    );
+
+    let count = result.content.matches("fn original()").count();
+    assert_eq!(count, 1, "should have exactly one original function");
+}
+
+#[test]
+fn test_no_changes() {
+    let base = r#"fn original() {
+    println!("original");
+}
+"#;
+
+    let result = rust(base, base, base);
+    assert!(result.success, "merge should succeed without conflicts");
+    assert!(
+        result.content.contains("fn original()"),
+        "should preserve original: {}",
+        result.content
+    );
+}
+
+#[test]
+fn test_multiple_functions_mixed_changes() {
+    let base = r#"fn foo() {
+    println!("foo");
+}
+
+fn bar() {
+    println!("bar");
+}
+"#;
+
+    let left = r#"fn foo() {
+    println!("foo modified by left");
+}
+
+fn bar() {
+    println!("bar");
+}
+
+fn baz() {
+    println!("baz from left");
+}
+"#;
+
+    let right = r#"fn foo() {
+    println!("foo");
+}
+
+fn bar() {
+    println!("bar modified by right");
+}
+
+fn qux() {
+    println!("qux from right");
+}
+"#;
+
+    let result = rust(base, left, right);
+    assert!(result.success, "merge should succeed without conflicts");
+
+    assert!(
+        result.content.contains("foo modified by left"),
+        "should have left's foo change: {}",
+        result.content
+    );
+
+    assert!(
+        result.content.contains("bar modified by right"),
+        "should have right's bar change: {}",
+        result.content
+    );
+
+    assert!(
+        result.content.contains("fn baz()"),
+        "should have left's new baz: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("fn qux()"),
+        "should have right's new qux: {}",
+        result.content
+    );
+}
+
+#[test]
+fn test_different_lines_same_function() {
+    let base = r"fn process() {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+}
+";
+
+    let left = r"fn process() {
+    let a = 100;
+    let b = 2;
+    let c = 3;
+}
+";
+
+    let right = r"fn process() {
+    let a = 1;
+    let b = 2;
+    let c = 300;
+}
+";
+
+    let result = rust(base, left, right);
+    assert!(
+        result.success,
+        "should merge different lines in same function without conflict: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("let a = 100;"),
+        "should have left's change to line 1: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("let c = 300;"),
+        "should have right's change to line 3: {}",
+        result.content
+    );
+}

--- a/packages/ast-merge/diff/src/trees.rs
+++ b/packages/ast-merge/diff/src/trees.rs
@@ -1,0 +1,24 @@
+pub fn collect_nodes<'a>(node: tree_sitter::Node<'a>, nodes: &mut Vec<tree_sitter::Node<'a>>) {
+    nodes.push(node);
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_nodes(child, nodes);
+    }
+}
+
+pub fn find_predecessor(
+    parent_node: tree_sitter::Node<'_>,
+    node: tree_sitter::Node<'_>,
+    node_ids: &[tree_sitter::Node<'_>],
+) -> Option<usize> {
+    let mut cursor = parent_node.walk();
+    let siblings: Vec<_> = parent_node.children(&mut cursor).collect();
+    let pos = siblings.iter().position(|s| s.id() == node.id())?;
+
+    if pos == 0 {
+        return None;
+    }
+
+    let prev = siblings.get(pos - 1)?;
+    node_ids.iter().position(|n| n.id() == prev.id())
+}

--- a/packages/ast-merge/diff/tests/common/mod.rs
+++ b/packages/ast-merge/diff/tests/common/mod.rs
@@ -1,0 +1,30 @@
+#![expect(clippy::expect_used, reason = "Test helpers - expect is acceptable")]
+
+use ast_merge_ast::Tree;
+
+pub fn parse_rust(source: &str) -> Tree {
+    let lang = ast_merge_langs::Lang::Rust.to_tree_sitter();
+    ast_merge_ast::tree(source, &lang).expect("valid rust").tree
+}
+
+pub fn rust(base: &str, left: &str, right: &str) -> ast_merge_diff::Result {
+    let base_tree = parse_rust(base);
+    let left_tree = parse_rust(left);
+    let right_tree = parse_rust(right);
+
+    let base_left = ast_merge_matcher::compute(&base_tree, &left_tree);
+    let base_right = ast_merge_matcher::compute(&base_tree, &right_tree);
+
+    let merger = ast_merge_diff::ThreeWay::new(ast_merge_diff::ThreeWayParams {
+        trees: ast_merge_diff::ThreeWayTrees {
+            base: &base_tree,
+            left: &left_tree,
+            right: &right_tree,
+        },
+        base_left_matching: base_left,
+        base_right_matching: base_right,
+        config: ast_merge_diff::Config::default(),
+    });
+
+    merger.merge()
+}

--- a/packages/ast-merge/diff/tests/merge_scenarios.rs
+++ b/packages/ast-merge/diff/tests/merge_scenarios.rs
@@ -1,0 +1,350 @@
+mod common;
+
+use common::rust;
+
+#[test]
+fn left_modifies_function_right_adds_new_function() {
+    let base = r#"fn greet() {
+    println!("Hello");
+}
+"#;
+
+    let left = r#"fn greet() {
+    println!("Hello, World!");
+}
+"#;
+
+    let right = r#"fn greet() {
+    println!("Hello");
+}
+
+fn farewell() {
+    println!("Goodbye");
+}
+"#;
+
+    let result = rust(base, left, right);
+
+    assert!(result.success);
+    assert!(
+        result.content.contains("Hello, World!"),
+        "left's modification preserved"
+    );
+    assert!(
+        result.content.contains("fn farewell()"),
+        "right's addition preserved"
+    );
+}
+
+#[test]
+fn right_modifies_function_left_adds_new_function() {
+    let base = r"fn process() {
+    do_work();
+}
+";
+
+    let left = r"fn process() {
+    do_work();
+}
+
+fn helper() {
+    assist();
+}
+";
+
+    let right = r"fn process() {
+    do_more_work();
+}
+";
+
+    let result = rust(base, left, right);
+
+    assert!(result.success);
+    assert!(
+        result.content.contains("do_more_work"),
+        "right's modification preserved"
+    );
+    assert!(
+        result.content.contains("fn helper()"),
+        "left's addition preserved"
+    );
+}
+
+#[test]
+fn both_add_different_functions() {
+    let base = r"fn main() {
+    run();
+}
+";
+
+    let left = r#"fn main() {
+    run();
+}
+
+fn feature_a() {
+    println!("Feature A");
+}
+"#;
+
+    let right = r#"fn main() {
+    run();
+}
+
+fn feature_b() {
+    println!("Feature B");
+}
+"#;
+
+    let result = rust(base, left, right);
+
+    assert!(result.success);
+    assert!(
+        result.content.contains("fn feature_a()"),
+        "left's function preserved"
+    );
+    assert!(
+        result.content.contains("fn feature_b()"),
+        "right's function preserved"
+    );
+}
+
+#[test]
+fn both_make_identical_changes() {
+    let base = r"fn calculate() -> i32 {
+    1 + 1
+}
+";
+
+    let left = r"fn calculate() -> i32 {
+    2 + 2
+}
+";
+
+    let right = r"fn calculate() -> i32 {
+    2 + 2
+}
+";
+
+    let result = rust(base, left, right);
+
+    assert!(result.success);
+    assert!(result.content.contains("2 + 2"), "change preserved");
+    assert_eq!(
+        result.content.matches("fn calculate()").count(),
+        1,
+        "no duplicate functions"
+    );
+}
+
+#[test]
+fn multiple_functions_mixed_changes() {
+    let base = r#"fn alpha() {
+    println!("alpha");
+}
+
+fn beta() {
+    println!("beta");
+}
+"#;
+
+    let left = r#"fn alpha() {
+    println!("ALPHA MODIFIED");
+}
+
+fn beta() {
+    println!("beta");
+}
+
+fn gamma() {
+    println!("gamma from left");
+}
+"#;
+
+    let right = r#"fn alpha() {
+    println!("alpha");
+}
+
+fn beta() {
+    println!("BETA MODIFIED");
+}
+
+fn delta() {
+    println!("delta from right");
+}
+"#;
+
+    let result = rust(base, left, right);
+
+    assert!(result.success);
+    assert!(
+        result.content.contains("ALPHA MODIFIED"),
+        "left's alpha change"
+    );
+    assert!(
+        result.content.contains("BETA MODIFIED"),
+        "right's beta change"
+    );
+    assert!(result.content.contains("fn gamma()"), "left's new function");
+    assert!(
+        result.content.contains("fn delta()"),
+        "right's new function"
+    );
+}
+
+#[test]
+fn different_lines_same_function() {
+    let base = r"fn configure() {
+    let timeout = 30;
+    let retries = 3;
+    let verbose = false;
+}
+";
+
+    let left = r"fn configure() {
+    let timeout = 60;
+    let retries = 3;
+    let verbose = false;
+}
+";
+
+    let right = r"fn configure() {
+    let timeout = 30;
+    let retries = 3;
+    let verbose = true;
+}
+";
+
+    let result = rust(base, left, right);
+
+    assert!(
+        result.success,
+        "should merge without conflicts: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("timeout = 60"),
+        "left's timeout change"
+    );
+    assert!(
+        result.content.contains("verbose = true"),
+        "right's verbose change"
+    );
+}
+
+#[test]
+fn struct_different_field_changes() {
+    let base = r"struct Settings {
+    name: String,
+    count: u32,
+    enabled: bool,
+}
+";
+
+    let left = r"struct Settings {
+    name: String,
+    count: u64,
+    enabled: bool,
+}
+";
+
+    let right = r"struct Settings {
+    name: String,
+    count: u32,
+    enabled: Option<bool>,
+}
+";
+
+    let result = rust(base, left, right);
+
+    assert!(
+        result.success,
+        "should merge struct changes: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("count: u64"),
+        "left's field type change"
+    );
+    assert!(
+        result.content.contains("enabled: Option<bool>"),
+        "right's field type change"
+    );
+}
+
+#[test]
+fn impl_block_different_methods() {
+    let base = r#"impl Server {
+    fn start(&self) {
+        println!("starting");
+    }
+
+    fn stop(&self) {
+        println!("stopping");
+    }
+}
+"#;
+
+    let left = r#"impl Server {
+    fn start(&self) {
+        println!("starting server...");
+    }
+
+    fn stop(&self) {
+        println!("stopping");
+    }
+}
+"#;
+
+    let right = r#"impl Server {
+    fn start(&self) {
+        println!("starting");
+    }
+
+    fn stop(&self) {
+        println!("gracefully stopping...");
+    }
+}
+"#;
+
+    let result = rust(base, left, right);
+
+    assert!(
+        result.success,
+        "should merge impl changes: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("starting server"),
+        "left's start change"
+    );
+    assert!(
+        result.content.contains("gracefully stopping"),
+        "right's stop change"
+    );
+}
+
+#[test]
+fn both_add_different_imports() {
+    let base = r"use std::io;
+
+fn main() {}
+";
+
+    let left = r"use std::io;
+use std::fs;
+
+fn main() {}
+";
+
+    let right = r"use std::io;
+use std::path;
+
+fn main() {}
+";
+
+    let result = rust(base, left, right);
+
+    assert!(result.success, "should merge imports: {}", result.content);
+    assert!(result.content.contains("use std::fs"), "left's import");
+    assert!(result.content.contains("use std::path"), "right's import");
+}

--- a/packages/ast-merge/diff/tests/quality_check.rs
+++ b/packages/ast-merge/diff/tests/quality_check.rs
@@ -1,0 +1,696 @@
+mod common;
+
+use common::rust;
+
+#[test]
+fn test_add_statements_both_ends() {
+    let base = r"fn process() {
+    middle();
+}
+";
+    let left = r"fn process() {
+    left_first();
+    middle();
+}
+";
+    let right = r"fn process() {
+    middle();
+    right_last();
+}
+";
+
+    let result = rust(base, left, right);
+    println!("Output:\n{}", result.content);
+    assert!(result.success, "Should merge without conflict");
+    assert!(
+        result.content.contains("left_first"),
+        "Missing left's addition"
+    );
+    assert!(
+        result.content.contains("right_last"),
+        "Missing right's addition"
+    );
+}
+
+#[test]
+fn test_add_different_statements_at_same_position() {
+    let base = r"fn process() {
+    let x = 1;
+}
+";
+    let left = r#"fn process() {
+    let x = 1;
+    let a = "left";
+}
+"#;
+    let right = r#"fn process() {
+    let x = 1;
+    let b = "right";
+}
+"#;
+
+    let result = rust(base, left, right);
+    println!("Output:\n{}", result.content);
+    assert!(result.success, "Should merge without conflict");
+    assert!(result.content.contains("let a"), "Missing left's addition");
+    assert!(result.content.contains("let b"), "Missing right's addition");
+}
+
+#[test]
+fn test_modify_first_and_last_lines() {
+    let base = r"fn compute() {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+}
+";
+    let left = r"fn compute() {
+    let a = 100;
+    let b = 2;
+    let c = 3;
+}
+";
+    let right = r"fn compute() {
+    let a = 1;
+    let b = 2;
+    let c = 300;
+}
+";
+
+    let result = rust(base, left, right);
+    println!("Output:\n{}", result.content);
+    assert!(result.success, "Should merge without conflict");
+    assert!(
+        result.content.contains("a = 100"),
+        "Missing left's modification"
+    );
+    assert!(
+        result.content.contains("c = 300"),
+        "Missing right's modification"
+    );
+}
+
+#[test]
+fn test_struct_different_fields() {
+    let base = r"struct Config {
+    a: i32,
+    b: i32,
+    c: i32,
+}
+";
+    let left = r"struct Config {
+    a: i64,
+    b: i32,
+    c: i32,
+}
+";
+    let right = r"struct Config {
+    a: i32,
+    b: i32,
+    c: i64,
+}
+";
+
+    let result = rust(base, left, right);
+    println!("Output:\n{}", result.content);
+    assert!(result.success, "Should merge without conflict");
+    assert!(
+        result.content.contains("a: i64"),
+        "Missing left's field change"
+    );
+    assert!(
+        result.content.contains("c: i64"),
+        "Missing right's field change"
+    );
+}
+
+#[test]
+fn test_impl_different_methods_modified() {
+    let base = r#"impl Server {
+    fn start(&self) {
+        println!("start");
+    }
+    fn stop(&self) {
+        println!("stop");
+    }
+}
+"#;
+    let left = r#"impl Server {
+    fn start(&self) {
+        println!("LEFT start");
+    }
+    fn stop(&self) {
+        println!("stop");
+    }
+}
+"#;
+    let right = r#"impl Server {
+    fn start(&self) {
+        println!("start");
+    }
+    fn stop(&self) {
+        println!("RIGHT stop");
+    }
+}
+"#;
+
+    let result = rust(base, left, right);
+    println!("Output:\n{}", result.content);
+    assert!(result.success, "Should merge without conflict");
+    assert!(
+        result.content.contains("LEFT start"),
+        "Missing left's method change"
+    );
+    assert!(
+        result.content.contains("RIGHT stop"),
+        "Missing right's method change"
+    );
+}
+
+#[test]
+fn test_both_add_imports() {
+    let base = r"use std::io;
+
+fn main() {}
+";
+    let left = r"use std::io;
+use std::fs;
+
+fn main() {}
+";
+    let right = r"use std::io;
+use std::path;
+
+fn main() {}
+";
+
+    let result = rust(base, left, right);
+    println!("Output:\n{}", result.content);
+    assert!(result.success, "Should merge without conflict");
+    assert!(
+        result.content.contains("use std::fs"),
+        "Missing left's import"
+    );
+    assert!(
+        result.content.contains("use std::path"),
+        "Missing right's import"
+    );
+
+    let fs_pos = result.content.find("use std::fs").unwrap();
+    let path_pos = result.content.find("use std::path").unwrap();
+    let main_pos = result.content.find("fn main").unwrap();
+    assert!(
+        fs_pos < main_pos,
+        "fs import should be before main, got:\n{}",
+        result.content
+    );
+    assert!(
+        path_pos < main_pos,
+        "path import should be before main, got:\n{}",
+        result.content
+    );
+}
+
+#[test]
+fn test_one_deletes_one_modifies_function() {
+    let base = r#"fn keep() {}
+
+fn disputed() {
+    println!("original");
+}
+"#;
+    let left = r"fn keep() {}
+";
+    let right = r#"fn keep() {}
+
+fn disputed() {
+    println!("modified by right");
+}
+"#;
+
+    let result = rust(base, left, right);
+    println!("One deletes one modifies:\n{}", result.content);
+}
+
+#[test]
+fn test_nested_impl_method_body_changes() {
+    let base = r"impl Parser {
+    fn parse(&mut self) {
+        self.init();
+        self.run();
+        self.cleanup();
+    }
+}
+";
+    let left = r"impl Parser {
+    fn parse(&mut self) {
+        self.init();
+        self.left_work();
+        self.run();
+        self.cleanup();
+    }
+}
+";
+    let right = r"impl Parser {
+    fn parse(&mut self) {
+        self.init();
+        self.run();
+        self.right_work();
+        self.cleanup();
+    }
+}
+";
+
+    let result = rust(base, left, right);
+    println!("Nested impl method changes:\n{}", result.content);
+    assert!(result.success, "Should merge without conflict");
+    assert!(
+        result.content.contains("left_work"),
+        "Missing left's addition:\n{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("right_work"),
+        "Missing right's addition:\n{}",
+        result.content
+    );
+}
+
+#[test]
+fn test_enum_variant_changes() {
+    let base = r"enum Status {
+    Pending,
+    Active,
+    Done,
+}
+";
+    let left = r"enum Status {
+    Pending,
+    Active,
+    Done,
+    LeftVariant,
+}
+";
+    let right = r"enum Status {
+    Pending,
+    Active,
+    Done,
+    RightVariant,
+}
+";
+
+    let result = rust(base, left, right);
+    println!("Enum variant changes:\n{}", result.content);
+    assert!(result.success, "Should merge without conflict");
+    assert!(
+        result.content.contains("LeftVariant"),
+        "Missing left's variant:\n{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("RightVariant"),
+        "Missing right's variant:\n{}",
+        result.content
+    );
+}
+
+#[test]
+fn test_trait_impl_different_methods() {
+    let base = r"trait Worker {
+    fn init(&self);
+    fn run(&self);
+}
+";
+    let left = r"trait Worker {
+    fn init(&self);
+    fn run(&self);
+    fn left_method(&self);
+}
+";
+    let right = r"trait Worker {
+    fn init(&self);
+    fn run(&self);
+    fn right_method(&self);
+}
+";
+
+    let result = rust(base, left, right);
+    println!("Trait method changes:\n{}", result.content);
+    assert!(result.success, "Should merge without conflict");
+    assert!(
+        result.content.contains("left_method"),
+        "Missing left's method:\n{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("right_method"),
+        "Missing right's method:\n{}",
+        result.content
+    );
+}
+
+#[test]
+fn test_multiline_statement_changes() {
+    let base = r"fn complex() {
+    let result = compute()
+        .with_option_a()
+        .with_option_b();
+}
+";
+    let left = r"fn complex() {
+    let result = compute()
+        .with_option_a()
+        .with_left_option()
+        .with_option_b();
+}
+";
+    let right = r"fn complex() {
+    let result = compute()
+        .with_option_a()
+        .with_option_b()
+        .with_right_option();
+}
+";
+
+    let result = rust(base, left, right);
+    println!("Multiline statement changes:\n{}", result.content);
+    assert!(result.success, "Should merge without conflict");
+    assert!(
+        result.content.contains("with_left_option"),
+        "Missing left's chain method:\n{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("with_right_option"),
+        "Missing right's chain method:\n{}",
+        result.content
+    );
+}
+
+#[test]
+fn test_attribute_changes() {
+    let base = r"fn example() {}
+";
+    let left = r"#[inline]
+fn example() {}
+";
+    let right = r"#[must_use]
+fn example() {}
+";
+
+    let result = rust(base, left, right);
+    println!("Attribute changes:\n{}", result.content);
+}
+
+#[test]
+fn test_comment_preservation() {
+    let base = r"fn foo() {
+    // Original comment
+    do_something();
+}
+";
+    let left = r"fn foo() {
+    // Left's comment
+    do_something();
+}
+";
+    let right = r"fn foo() {
+    // Right's comment
+    do_something();
+}
+";
+
+    let result = rust(base, left, right);
+    println!("Comment changes:\n{}", result.content);
+}
+
+#[test]
+fn test_complex_function_with_nested_blocks() {
+    let base = r"fn handle_request() {
+    if condition {
+        setup();
+    }
+    process();
+}
+";
+    let left = r"fn handle_request() {
+    if condition {
+        setup();
+        left_init();
+    }
+    process();
+}
+";
+    let right = r"fn handle_request() {
+    if condition {
+        setup();
+    }
+    process();
+    right_cleanup();
+}
+";
+
+    let result = rust(base, left, right);
+    println!("Complex nested blocks:\n{}", result.content);
+    assert!(result.success, "Should merge without conflict");
+    assert!(
+        result.content.contains("left_init"),
+        "Missing left's nested addition:\n{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("right_cleanup"),
+        "Missing right's addition:\n{}",
+        result.content
+    );
+}
+
+#[test]
+fn test_multiple_structs_different_changes() {
+    let base = r"struct A {
+    x: i32,
+}
+
+struct B {
+    y: i32,
+}
+";
+    let left = r"struct A {
+    x: i64,
+}
+
+struct B {
+    y: i32,
+}
+";
+    let right = r"struct A {
+    x: i32,
+}
+
+struct B {
+    y: i64,
+}
+";
+
+    let result = rust(base, left, right);
+    println!("Multiple structs:\n{}", result.content);
+    assert!(result.success, "Should merge without conflict");
+    assert!(
+        result.content.contains("x: i64"),
+        "Missing left's change to A:\n{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("y: i64"),
+        "Missing right's change to B:\n{}",
+        result.content
+    );
+}
+
+#[test]
+fn test_function_with_doc_comment_changes() {
+    let base = r"/// Original doc
+fn documented() {}
+";
+    let left = r"/// Left's doc
+fn documented() {}
+";
+    let right = r"/// Right's doc
+fn documented() {}
+";
+
+    let result = rust(base, left, right);
+    println!("Doc comment changes:\n{}", result.content);
+}
+
+#[test]
+fn test_generic_type_changes() {
+    let base = r"struct Container<T> {
+    data: T,
+}
+";
+    let left = r"struct Container<T: Clone> {
+    data: T,
+}
+";
+    let right = r"struct Container<T> {
+    data: T,
+    count: usize,
+}
+";
+
+    let result = rust(base, left, right);
+    println!("Generic type changes:\n{}", result.content);
+}
+
+#[test]
+fn test_verify_output_is_valid_rust() {
+    let base = r"fn foo() {
+    let x = 1;
+}
+
+fn bar() {
+    let y = 2;
+}
+";
+    let left = r"fn foo() {
+    let x = 100;
+}
+
+fn bar() {
+    let y = 2;
+}
+
+fn baz() {
+    let z = 3;
+}
+";
+    let right = r"fn foo() {
+    let x = 1;
+}
+
+fn bar() {
+    let y = 200;
+}
+
+fn qux() {
+    let w = 4;
+}
+";
+
+    let result = rust(base, left, right);
+    assert!(result.success, "Should merge without conflict");
+
+    let lang = ast_merge_langs::Lang::Rust.to_tree_sitter();
+    let parsed = ast_merge_ast::tree(&result.content, &lang);
+    assert!(
+        parsed.is_ok(),
+        "Output should be valid Rust: {}",
+        result.content
+    );
+    let parsed = parsed.unwrap();
+    assert!(
+        !parsed.has_errors,
+        "Output should have no parse errors:\n{}",
+        result.content
+    );
+
+    assert!(result.content.contains("fn foo()"), "Missing foo");
+    assert!(result.content.contains("fn bar()"), "Missing bar");
+    assert!(result.content.contains("fn baz()"), "Missing baz");
+    assert!(result.content.contains("fn qux()"), "Missing qux");
+    assert!(
+        result.content.contains("let x = 100"),
+        "Missing left's change to foo"
+    );
+    assert!(
+        result.content.contains("let y = 200"),
+        "Missing right's change to bar"
+    );
+}
+
+#[test]
+fn test_add_and_modify_same_impl() {
+    let base = r"impl Widget {
+    fn render(&self) {
+        draw();
+    }
+}
+";
+    let left = r"impl Widget {
+    fn render(&self) {
+        clear();
+        draw();
+    }
+    fn on_click(&self) {
+        handle();
+    }
+}
+";
+    let right = r"impl Widget {
+    fn render(&self) {
+        draw();
+        flush();
+    }
+    fn on_hover(&self) {
+        highlight();
+    }
+}
+";
+
+    let result = rust(base, left, right);
+    println!("Add and modify same impl:\n{}", result.content);
+    assert!(result.success, "Should merge without conflict");
+
+    assert!(
+        result.content.contains("clear"),
+        "Missing left's modification:\n{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("flush"),
+        "Missing right's modification:\n{}",
+        result.content
+    );
+
+    assert!(
+        result.content.contains("on_click"),
+        "Missing left's new method:\n{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("on_hover"),
+        "Missing right's new method:\n{}",
+        result.content
+    );
+}
+
+#[test]
+fn test_both_add_methods_to_impl() {
+    let base = r"impl Foo {
+    fn existing(&self) {}
+}
+";
+    let left = r#"impl Foo {
+    fn existing(&self) {}
+    fn left_method(&self) { println!("left"); }
+}
+"#;
+    let right = r#"impl Foo {
+    fn existing(&self) {}
+    fn right_method(&self) { println!("right"); }
+}
+"#;
+
+    let result = rust(base, left, right);
+    println!("Output:\n{}", result.content);
+    assert!(result.success, "Should merge without conflict");
+    assert!(
+        result.content.contains("left_method"),
+        "Missing left's new method"
+    );
+    assert!(
+        result.content.contains("right_method"),
+        "Missing right's new method"
+    );
+}

--- a/packages/ast-merge/git/Cargo.toml
+++ b/packages/ast-merge/git/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ast-merge-git"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Git merge driver integration for ast-merge"
+
+[dependencies]
+snafu.workspace = true
+lazy-regex.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+
+[lints]
+workspace = true

--- a/packages/ast-merge/git/package.nix
+++ b/packages/ast-merge/git/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "ast-merge-git";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/ast-merge/git/src/format.rs
+++ b/packages/ast-merge/git/src/format.rs
@@ -1,0 +1,91 @@
+use snafu::ResultExt as _;
+
+use crate::types::DisplaySettings;
+
+pub struct ConflictInput<'a> {
+    pub left: &'a str,
+    pub base: Option<&'a str>,
+    pub right: &'a str,
+}
+
+#[must_use]
+pub fn conflict(input: &ConflictInput<'_>, settings: &DisplaySettings) -> String {
+    let left = input.left;
+    let base = input.base;
+    let right = input.right;
+    let mut output = String::new();
+
+    output.push_str(&"<".repeat(settings.marker_size));
+    output.push(' ');
+    output.push_str(&settings.left_name);
+    output.push('\n');
+    output.push_str(left);
+    if !left.ends_with('\n') && !left.is_empty() {
+        output.push('\n');
+    }
+
+    if settings.diff3_style {
+        if let Some(base_content) = base {
+            output.push_str(&"|".repeat(settings.marker_size));
+            output.push(' ');
+            output.push_str(&settings.base_name);
+            output.push('\n');
+            output.push_str(base_content);
+            if !base_content.ends_with('\n') && !base_content.is_empty() {
+                output.push('\n');
+            }
+        }
+    }
+
+    output.push_str(&"=".repeat(settings.marker_size));
+    output.push('\n');
+
+    output.push_str(right);
+    if !right.ends_with('\n') && !right.is_empty() {
+        output.push('\n');
+    }
+
+    output.push_str(&">".repeat(settings.marker_size));
+    output.push(' ');
+    output.push_str(&settings.right_name);
+    output.push('\n');
+
+    output
+}
+
+#[derive(Debug, snafu::Snafu)]
+#[snafu(visibility(pub))]
+pub enum RevisionError {
+    #[snafu(display("failed to read revision from {path}"))]
+    Read {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("failed to write merge result to {path}"))]
+    Write {
+        path: String,
+        source: std::io::Error,
+    },
+}
+
+pub fn read_revision(path: &std::path::Path) -> Result<String, RevisionError> {
+    std::fs::read_to_string(path).context(ReadSnafu {
+        path: path.display().to_string(),
+    })
+}
+
+pub fn write_result(path: &std::path::Path, content: &str) -> Result<(), RevisionError> {
+    std::fs::write(path, content).context(WriteSnafu {
+        path: path.display().to_string(),
+    })
+}
+
+#[must_use]
+pub fn extract_oid_from_marker(marker: &str) -> Option<&str> {
+    marker
+        .strip_prefix('<')
+        .map(|s| s.trim_start_matches('<'))
+        .and_then(|s| s.trim().split(':').next())
+        .map(str::trim)
+}

--- a/packages/ast-merge/git/src/lib.rs
+++ b/packages/ast-merge/git/src/lib.rs
@@ -1,0 +1,10 @@
+mod format;
+mod parse;
+mod types;
+
+pub use format::{RevisionError, conflict, extract_oid_from_marker, read_revision, write_result};
+pub use parse::conflicts;
+pub use types::{DisplaySettings, DriverResult, ParsedConflict, ParsedFile};
+
+#[cfg(test)]
+mod tests;

--- a/packages/ast-merge/git/src/parse.rs
+++ b/packages/ast-merge/git/src/parse.rs
@@ -1,0 +1,178 @@
+use lazy_regex::regex;
+
+use crate::types::{ParsedConflict, ParsedFile};
+
+fn left_marker() -> &'static lazy_regex::Regex {
+    regex!(r"^<{7,} (.*)$")
+}
+fn base_marker() -> &'static lazy_regex::Regex {
+    regex!(r"^\|{7,} (.*)$")
+}
+fn separator() -> &'static lazy_regex::Regex {
+    regex!(r"^={7,}$")
+}
+fn right_marker() -> &'static lazy_regex::Regex {
+    regex!(r"^>{7,} (.*)$")
+}
+
+#[must_use]
+pub fn conflicts(content: &str) -> ParsedFile {
+    let mut conflicts = Vec::new();
+    let lines: Vec<&str> = content.lines().collect();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let Some(captures) = left_marker().captures(lines.get(i).copied().unwrap_or_default())
+        else {
+            i += 1;
+            continue;
+        };
+
+        let left_name = captures.get(1).map_or("LEFT", |m| m.as_str()).to_owned();
+        let conflict_start = i;
+        i += 1;
+
+        let left_result = read_left_section(&lines, i);
+        i = left_result.next_index;
+
+        let base_result = read_base_section(&lines, i, left_result.base_lines);
+        i = base_result.next_index;
+        let base_lines = base_result.base_lines;
+        let base_name = left_result.base_name;
+        let left_lines = left_result.left_lines;
+
+        let right_result = read_right_section(&lines, i);
+        i = right_result.next_index;
+
+        let before = lines
+            .get(..conflict_start)
+            .map_or(String::new(), |l| l.join("\n"));
+        let after = lines.get(i..).map_or(String::new(), |l| l.join("\n"));
+
+        conflicts.push(ParsedConflict {
+            before,
+            left: left_lines.join("\n"),
+            base: base_lines.map(|l| l.join("\n")),
+            right: right_result.right_lines.join("\n"),
+            after,
+            left_name,
+            right_name: right_result.right_name,
+            base_name,
+        });
+    }
+
+    ParsedFile {
+        has_conflicts: !conflicts.is_empty(),
+        conflicts,
+        content: content.to_owned(),
+    }
+}
+
+struct LeftSectionResult<'a> {
+    left_lines: Vec<&'a str>,
+    base_lines: Option<Vec<&'a str>>,
+    base_name: Option<String>,
+    next_index: usize,
+}
+
+fn read_left_section<'a>(lines: &[&'a str], mut i: usize) -> LeftSectionResult<'a> {
+    let mut left_lines = Vec::new();
+
+    while i < lines.len() {
+        let line = lines.get(i).copied().unwrap_or_default();
+
+        if let Some(captures) = base_marker().captures(line) {
+            let base_name = captures.get(1).map(|m| m.as_str().to_owned());
+            return LeftSectionResult {
+                left_lines,
+                base_lines: Some(Vec::new()),
+                base_name,
+                next_index: i + 1,
+            };
+        }
+
+        if separator().is_match(line) {
+            return LeftSectionResult {
+                left_lines,
+                base_lines: None,
+                base_name: None,
+                next_index: i + 1,
+            };
+        }
+
+        left_lines.push(line);
+        i += 1;
+    }
+
+    LeftSectionResult {
+        left_lines,
+        base_lines: None,
+        base_name: None,
+        next_index: i,
+    }
+}
+
+struct BaseSectionResult<'a> {
+    base_lines: Option<Vec<&'a str>>,
+    next_index: usize,
+}
+
+fn read_base_section<'a>(
+    lines: &[&'a str],
+    mut i: usize,
+    base_lines: Option<Vec<&'a str>>,
+) -> BaseSectionResult<'a> {
+    let Some(mut base) = base_lines else {
+        return BaseSectionResult {
+            base_lines: None,
+            next_index: i,
+        };
+    };
+
+    while i < lines.len() {
+        let line = lines.get(i).copied().unwrap_or_default();
+        if separator().is_match(line) {
+            return BaseSectionResult {
+                base_lines: Some(base),
+                next_index: i + 1,
+            };
+        }
+        base.push(line);
+        i += 1;
+    }
+
+    BaseSectionResult {
+        base_lines: Some(base),
+        next_index: i,
+    }
+}
+
+struct RightSectionResult<'a> {
+    right_lines: Vec<&'a str>,
+    right_name: String,
+    next_index: usize,
+}
+
+fn read_right_section<'a>(lines: &[&'a str], mut i: usize) -> RightSectionResult<'a> {
+    let mut right_lines = Vec::new();
+
+    while i < lines.len() {
+        let line = lines.get(i).copied().unwrap_or_default();
+        if let Some(captures) = right_marker().captures(line) {
+            let right_name = captures.get(1).map_or("RIGHT", |m| m.as_str()).to_owned();
+            return RightSectionResult {
+                right_lines,
+                right_name,
+                next_index: i + 1,
+            };
+        }
+        right_lines.push(line);
+        i += 1;
+    }
+
+    RightSectionResult {
+        right_lines,
+        right_name: String::from("RIGHT"),
+        next_index: i,
+    }
+}

--- a/packages/ast-merge/git/src/tests.rs
+++ b/packages/ast-merge/git/src/tests.rs
@@ -1,0 +1,155 @@
+use super::*;
+
+#[test]
+fn test_parse_simple_conflict() {
+    let content = r"before
+<<<<<<< HEAD
+left content
+=======
+right content
+>>>>>>> branch
+after";
+
+    let parsed = conflicts(content);
+    assert!(parsed.has_conflicts);
+    assert_eq!(parsed.conflicts.len(), 1);
+
+    let conflict = parsed.conflicts.first().unwrap();
+    assert_eq!(conflict.left, "left content");
+    assert_eq!(conflict.right, "right content");
+    assert!(conflict.base.is_none());
+    assert_eq!(conflict.left_name, "HEAD");
+    assert_eq!(conflict.right_name, "branch");
+}
+
+#[test]
+fn test_parse_diff3_conflict() {
+    let content = r"<<<<<<< ours
+left
+||||||| base
+original
+=======
+right
+>>>>>>> theirs";
+
+    let parsed = conflicts(content);
+    assert!(parsed.has_conflicts);
+
+    let conflict = parsed.conflicts.first().unwrap();
+    assert_eq!(conflict.left, "left");
+    assert_eq!(conflict.base.as_deref(), Some("original"));
+    assert_eq!(conflict.right, "right");
+}
+
+#[test]
+fn test_parse_no_conflicts() {
+    let content = "just normal content\nno conflicts here";
+    let parsed = conflicts(content);
+    assert!(!parsed.has_conflicts);
+    assert!(parsed.conflicts.is_empty());
+}
+
+#[test]
+fn test_format_conflict_diff2() {
+    let settings = DisplaySettings {
+        marker_size: 7,
+        diff3_style: false,
+        left_name: String::from("ours"),
+        right_name: String::from("theirs"),
+        base_name: String::from("base"),
+    };
+
+    let input = format::ConflictInput {
+        left: "left",
+        base: Some("base"),
+        right: "right",
+    };
+    let output = format::conflict(&input, &settings);
+    assert!(output.contains("<<<<<<<"));
+    assert!(output.contains("======="));
+    assert!(output.contains(">>>>>>>"));
+    assert!(!output.contains("|||||||"));
+}
+
+#[test]
+fn test_format_conflict_diff3() {
+    let settings = DisplaySettings::default();
+
+    let input = format::ConflictInput {
+        left: "left",
+        base: Some("base"),
+        right: "right",
+    };
+    let output = format::conflict(&input, &settings);
+    assert!(output.contains("<<<<<<<"));
+    assert!(output.contains("|||||||"));
+    assert!(output.contains("======="));
+    assert!(output.contains(">>>>>>>"));
+}
+
+#[test]
+fn test_display_settings_default() {
+    let settings = DisplaySettings::default();
+    assert_eq!(settings.marker_size, 7);
+    assert!(settings.diff3_style);
+}
+
+#[test]
+fn test_driver_result_success() {
+    let result = DriverResult::success(String::from("merged"));
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.conflict_count, 0);
+}
+
+#[test]
+fn test_driver_result_with_conflicts() {
+    let result = DriverResult::with_conflicts(String::from("content"), 3);
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.conflict_count, 3);
+}
+
+#[test]
+fn test_extract_oid_from_marker() {
+    assert_eq!(
+        extract_oid_from_marker("<<<<<<< HEAD:file.txt"),
+        Some("HEAD")
+    );
+    assert_eq!(
+        extract_oid_from_marker("<<<<<<< abc123:path/to/file"),
+        Some("abc123")
+    );
+    assert_eq!(extract_oid_from_marker("not a marker"), None);
+}
+
+#[test]
+fn test_parse_multiline_conflict() {
+    let content = r"<<<<<<< HEAD
+line 1
+line 2
+line 3
+=======
+other 1
+other 2
+>>>>>>> branch";
+
+    let parsed = conflicts(content);
+    let conflict = parsed.conflicts.first().unwrap();
+    assert!(conflict.left.contains("line 1"));
+    assert!(conflict.left.contains("line 2"));
+    assert!(conflict.left.contains("line 3"));
+    assert!(conflict.right.contains("other 1"));
+    assert!(conflict.right.contains("other 2"));
+}
+
+#[test]
+fn test_format_conflict_preserves_newlines() {
+    let settings = DisplaySettings::default();
+    let input = format::ConflictInput {
+        left: "line1\nline2",
+        base: None,
+        right: "other",
+    };
+    let output = format::conflict(&input, &settings);
+
+    assert!(output.lines().count() > 4);
+}

--- a/packages/ast-merge/git/src/types.rs
+++ b/packages/ast-merge/git/src/types.rs
@@ -1,0 +1,86 @@
+#[derive(Debug, Clone)]
+pub struct ParsedConflict {
+    pub before: String,
+    pub left: String,
+    pub base: Option<String>,
+    pub right: String,
+    pub after: String,
+    pub left_name: String,
+    pub right_name: String,
+    pub base_name: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct ParsedFile {
+    pub conflicts: Vec<ParsedConflict>,
+    pub has_conflicts: bool,
+    pub content: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct DisplaySettings {
+    pub marker_size: usize,
+    pub diff3_style: bool,
+    pub left_name: String,
+    pub right_name: String,
+    pub base_name: String,
+}
+
+/// Git's default conflict marker size (e.g. `<<<<<<<` is 7 characters).
+const DEFAULT_MARKER_SIZE: usize = 7;
+
+impl Default for DisplaySettings {
+    fn default() -> Self {
+        Self {
+            marker_size: DEFAULT_MARKER_SIZE,
+            diff3_style: true,
+            left_name: String::from("ours"),
+            right_name: String::from("theirs"),
+            base_name: String::from("base"),
+        }
+    }
+}
+
+impl DisplaySettings {
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self {
+            marker_size: std::env::var("GIT_MERGE_MARKER_SIZE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(DEFAULT_MARKER_SIZE),
+            diff3_style: std::env::var("GIT_DIFF3").map_or(true, |v| v != "0"),
+            left_name: std::env::var("GIT_MERGE_OURS").unwrap_or_else(|_| String::from("ours")),
+            right_name: std::env::var("GIT_MERGE_THEIRS")
+                .unwrap_or_else(|_| String::from("theirs")),
+            base_name: std::env::var("GIT_MERGE_BASE").unwrap_or_else(|_| String::from("base")),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct DriverResult {
+    pub content: String,
+    pub exit_code: i32,
+    pub conflict_count: usize,
+}
+
+impl DriverResult {
+    #[must_use]
+    pub fn success(content: String) -> Self {
+        Self {
+            content,
+            exit_code: 0,
+            conflict_count: 0,
+        }
+    }
+
+    #[must_use]
+    pub fn with_conflicts(content: String, conflict_count: usize) -> Self {
+        Self {
+            content,
+            exit_code: 1,
+            conflict_count,
+        }
+    }
+}

--- a/packages/ast-merge/langs/Cargo.toml
+++ b/packages/ast-merge/langs/Cargo.toml
@@ -1,0 +1,68 @@
+[package]
+name = "ast-merge-langs"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Language profiles and tree-sitter grammars for ast-merge"
+
+[dependencies]
+tree-sitter.workspace = true
+
+# Tree-sitter language grammars (compatible with tree-sitter 0.25)
+# Core languages
+tree-sitter-rust.workspace = true
+tree-sitter-javascript.workspace = true
+tree-sitter-typescript.workspace = true
+tree-sitter-python.workspace = true
+tree-sitter-go.workspace = true
+
+# JVM languages
+tree-sitter-java.workspace = true
+tree-sitter-kotlin-ng.workspace = true
+tree-sitter-scala.workspace = true
+
+# Systems languages
+tree-sitter-c.workspace = true
+tree-sitter-cpp.workspace = true
+
+# .NET languages
+tree-sitter-c-sharp.workspace = true
+
+# Mobile languages
+tree-sitter-swift.workspace = true
+
+# Scripting languages
+tree-sitter-ruby.workspace = true
+tree-sitter-php.workspace = true
+tree-sitter-bash.workspace = true
+tree-sitter-lua.workspace = true
+
+# Functional languages
+tree-sitter-haskell.workspace = true
+tree-sitter-elixir.workspace = true
+tree-sitter-ocaml.workspace = true
+
+# Web languages
+tree-sitter-html.workspace = true
+tree-sitter-css.workspace = true
+tree-sitter-svelte-ng.workspace = true
+
+# Data formats
+tree-sitter-json.workspace = true
+tree-sitter-toml-ng.workspace = true
+tree-sitter-yaml.workspace = true
+
+# Documentation
+tree-sitter-md.workspace = true
+
+# DevOps
+tree-sitter-dockerfile-updated.workspace = true
+
+# Configuration languages
+tree-sitter-nix.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+
+[lints]
+workspace = true

--- a/packages/ast-merge/langs/package.nix
+++ b/packages/ast-merge/langs/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "ast-merge-langs";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/ast-merge/langs/src/lang.rs
+++ b/packages/ast-merge/langs/src/lang.rs
@@ -1,0 +1,171 @@
+use std::path::Path;
+
+use crate::{profiles, types::Profile};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Lang {
+    Rust,
+    JavaScript,
+    TypeScript,
+    TypeScriptTsx,
+    Python,
+    Go,
+
+    Java,
+    Kotlin,
+    Scala,
+
+    C,
+    Cpp,
+
+    CSharp,
+
+    Swift,
+
+    Ruby,
+    Php,
+    Bash,
+    Lua,
+
+    Haskell,
+    Elixir,
+    OCaml,
+
+    Html,
+    Css,
+    Svelte,
+
+    Json,
+    Toml,
+    Yaml,
+
+    Markdown,
+
+    Dockerfile,
+
+    Nix,
+}
+
+impl Lang {
+    #[must_use]
+    pub fn to_tree_sitter(self) -> tree_sitter::Language {
+        match self {
+            Self::Rust => tree_sitter_rust::LANGUAGE.into(),
+            Self::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
+            Self::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            Self::TypeScriptTsx => tree_sitter_typescript::LANGUAGE_TSX.into(),
+            Self::Python => tree_sitter_python::LANGUAGE.into(),
+            Self::Go => tree_sitter_go::LANGUAGE.into(),
+
+            Self::Java => tree_sitter_java::LANGUAGE.into(),
+            Self::Kotlin => tree_sitter_kotlin_ng::LANGUAGE.into(),
+            Self::Scala => tree_sitter_scala::LANGUAGE.into(),
+
+            Self::C => tree_sitter_c::LANGUAGE.into(),
+            Self::Cpp => tree_sitter_cpp::LANGUAGE.into(),
+
+            Self::CSharp => tree_sitter_c_sharp::LANGUAGE.into(),
+
+            Self::Swift => tree_sitter_swift::LANGUAGE.into(),
+
+            Self::Ruby => tree_sitter_ruby::LANGUAGE.into(),
+            Self::Php => tree_sitter_php::LANGUAGE_PHP.into(),
+            Self::Bash => tree_sitter_bash::LANGUAGE.into(),
+            Self::Lua => tree_sitter_lua::LANGUAGE.into(),
+
+            Self::Haskell => tree_sitter_haskell::LANGUAGE.into(),
+            Self::Elixir => tree_sitter_elixir::LANGUAGE.into(),
+            Self::OCaml => tree_sitter_ocaml::LANGUAGE_OCAML.into(),
+
+            Self::Html => tree_sitter_html::LANGUAGE.into(),
+            Self::Css => tree_sitter_css::LANGUAGE.into(),
+            Self::Svelte => tree_sitter_svelte_ng::LANGUAGE.into(),
+
+            Self::Json => tree_sitter_json::LANGUAGE.into(),
+            Self::Toml => tree_sitter_toml_ng::LANGUAGE.into(),
+            Self::Yaml => tree_sitter_yaml::LANGUAGE.into(),
+
+            Self::Markdown => tree_sitter_md::LANGUAGE.into(),
+
+            Self::Dockerfile => tree_sitter_dockerfile_updated::language(),
+
+            Self::Nix => tree_sitter_nix::LANGUAGE.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn profile(self) -> &'static Profile {
+        profiles::get(self)
+    }
+
+    #[must_use]
+    pub fn all() -> &'static [Self] {
+        &[
+            Self::Rust,
+            Self::JavaScript,
+            Self::TypeScript,
+            Self::TypeScriptTsx,
+            Self::Python,
+            Self::Go,
+            Self::Java,
+            Self::Kotlin,
+            Self::Scala,
+            Self::C,
+            Self::Cpp,
+            Self::CSharp,
+            Self::Swift,
+            Self::Ruby,
+            Self::Php,
+            Self::Bash,
+            Self::Lua,
+            Self::Haskell,
+            Self::Elixir,
+            Self::OCaml,
+            Self::Html,
+            Self::Css,
+            Self::Svelte,
+            Self::Json,
+            Self::Toml,
+            Self::Yaml,
+            Self::Markdown,
+            Self::Dockerfile,
+            Self::Nix,
+        ]
+    }
+
+    #[must_use]
+    pub fn name(self) -> &'static str {
+        self.profile().name
+    }
+}
+
+#[must_use]
+pub fn detect(path: &Path) -> Option<Lang> {
+    if let Some(file_name) = path.file_name().and_then(|n| n.to_str()) {
+        for lang in Lang::all() {
+            if lang.profile().file_names.contains(&file_name) {
+                return Some(*lang);
+            }
+        }
+    }
+
+    let ext = path.extension()?.to_str()?;
+    for lang in Lang::all() {
+        if lang.profile().extensions.contains(&ext) {
+            return Some(*lang);
+        }
+    }
+
+    None
+}
+
+#[must_use]
+pub fn detect_from_extension(ext: &str) -> Option<Lang> {
+    let ext = ext.strip_prefix('.').unwrap_or(ext);
+    for lang in Lang::all() {
+        if lang.profile().extensions.contains(&ext) {
+            return Some(*lang);
+        }
+    }
+    None
+}

--- a/packages/ast-merge/langs/src/lib.rs
+++ b/packages/ast-merge/langs/src/lib.rs
@@ -1,0 +1,9 @@
+mod lang;
+mod profiles;
+mod types;
+
+pub use lang::{Lang, detect, detect_from_extension};
+pub use types::Profile;
+
+#[cfg(test)]
+mod tests;

--- a/packages/ast-merge/langs/src/profiles.rs
+++ b/packages/ast-merge/langs/src/profiles.rs
@@ -1,0 +1,47 @@
+use crate::{lang::Lang, types::Profile};
+
+mod compiled;
+mod config;
+mod functional;
+mod jvm;
+mod scripting;
+mod web;
+
+pub fn get(lang: Lang) -> &'static Profile {
+    match lang {
+        Lang::Rust => &compiled::RUST,
+        Lang::C => &compiled::C,
+        Lang::Cpp => &compiled::CPP,
+        Lang::CSharp => &compiled::CSHARP,
+        Lang::Swift => &compiled::SWIFT,
+        Lang::Go => &compiled::GO,
+
+        Lang::Java => &jvm::JAVA,
+        Lang::Kotlin => &jvm::KOTLIN,
+        Lang::Scala => &jvm::SCALA,
+
+        Lang::JavaScript => &web::JAVASCRIPT,
+        Lang::TypeScript => &web::TYPESCRIPT,
+        Lang::TypeScriptTsx => &web::TSX,
+        Lang::Html => &web::HTML,
+        Lang::Css => &web::CSS,
+        Lang::Svelte => &web::SVELTE,
+
+        Lang::Python => &scripting::PYTHON,
+        Lang::Ruby => &scripting::RUBY,
+        Lang::Php => &scripting::PHP,
+        Lang::Bash => &scripting::BASH,
+        Lang::Lua => &scripting::LUA,
+
+        Lang::Haskell => &functional::HASKELL,
+        Lang::Elixir => &functional::ELIXIR,
+        Lang::OCaml => &functional::OCAML,
+
+        Lang::Json => &config::JSON,
+        Lang::Toml => &config::TOML,
+        Lang::Yaml => &config::YAML,
+        Lang::Markdown => &config::MARKDOWN,
+        Lang::Dockerfile => &config::DOCKERFILE,
+        Lang::Nix => &config::NIX,
+    }
+}

--- a/packages/ast-merge/langs/src/profiles/compiled.rs
+++ b/packages/ast-merge/langs/src/profiles/compiled.rs
@@ -1,0 +1,103 @@
+use crate::types::Profile;
+
+pub(crate) static RUST: Profile = Profile {
+    name: "Rust",
+    extensions: &["rs"],
+    file_names: &[],
+    atomic_nodes: &["use_declaration", "attribute_item", "inner_attribute_item"],
+    commutative_parents: &[
+        "declaration_list",
+        "use_list",
+        "enum_variant_list",
+        "field_declaration_list",
+    ],
+    comment_nodes: &["line_comment", "block_comment"],
+};
+
+pub(crate) static C: Profile = Profile {
+    name: "C",
+    extensions: &["c", "h"],
+    file_names: &[],
+    atomic_nodes: &[
+        "preproc_include",
+        "preproc_def",
+        "preproc_ifdef",
+        "preproc_ifndef",
+        "preproc_if",
+    ],
+    commutative_parents: &[
+        "field_declaration_list",
+        "enumerator_list",
+        "declaration_list",
+    ],
+    comment_nodes: &["comment"],
+};
+
+pub(crate) static CPP: Profile = Profile {
+    name: "C++",
+    extensions: &["cpp", "cc", "cxx", "hpp", "hh", "hxx", "h++", "c++"],
+    file_names: &[],
+    atomic_nodes: &[
+        "preproc_include",
+        "preproc_def",
+        "using_declaration",
+        "namespace_definition",
+        "template_declaration",
+    ],
+    commutative_parents: &[
+        "field_declaration_list",
+        "enumerator_list",
+        "declaration_list",
+        "base_class_clause",
+    ],
+    comment_nodes: &["comment"],
+};
+
+pub(crate) static CSHARP: Profile = Profile {
+    name: "C#",
+    extensions: &["cs"],
+    file_names: &[],
+    atomic_nodes: &[
+        "using_directive",
+        "namespace_declaration",
+        "attribute",
+        "attribute_list",
+    ],
+    commutative_parents: &[
+        "class_declaration",
+        "interface_declaration",
+        "struct_declaration",
+        "enum_declaration",
+        "declaration_list",
+    ],
+    comment_nodes: &["comment", "multiline_comment"],
+};
+
+pub(crate) static SWIFT: Profile = Profile {
+    name: "Swift",
+    extensions: &["swift"],
+    file_names: &[],
+    atomic_nodes: &["import_declaration", "attribute"],
+    commutative_parents: &[
+        "class_body",
+        "struct_body",
+        "protocol_body",
+        "enum_body",
+        "extension_body",
+    ],
+    comment_nodes: &["comment", "multiline_comment"],
+};
+
+pub(crate) static GO: Profile = Profile {
+    name: "Go",
+    extensions: &["go"],
+    file_names: &[],
+    atomic_nodes: &["import_declaration", "import_spec"],
+    commutative_parents: &[
+        "import_spec_list",
+        "field_declaration_list",
+        "interface_type",
+        "struct_type",
+    ],
+    comment_nodes: &["comment"],
+};

--- a/packages/ast-merge/langs/src/profiles/config.rs
+++ b/packages/ast-merge/langs/src/profiles/config.rs
@@ -1,0 +1,55 @@
+use crate::types::Profile;
+
+pub(crate) static JSON: Profile = Profile {
+    name: "JSON",
+    extensions: &["json", "jsonc"],
+    file_names: &["package.json", "tsconfig.json", "composer.json"],
+    atomic_nodes: &[],
+    commutative_parents: &["object"],
+    comment_nodes: &[],
+};
+
+pub(crate) static TOML: Profile = Profile {
+    name: "TOML",
+    extensions: &["toml"],
+    file_names: &["Cargo.toml", "pyproject.toml"],
+    atomic_nodes: &[],
+    commutative_parents: &["table", "inline_table"],
+    comment_nodes: &["comment"],
+};
+
+pub(crate) static YAML: Profile = Profile {
+    name: "YAML",
+    extensions: &["yaml", "yml"],
+    file_names: &[],
+    atomic_nodes: &[],
+    commutative_parents: &["block_mapping", "flow_mapping"],
+    comment_nodes: &["comment"],
+};
+
+pub(crate) static MARKDOWN: Profile = Profile {
+    name: "Markdown",
+    extensions: &["md", "markdown", "mdown", "mkd"],
+    file_names: &["README.md", "CHANGELOG.md", "CONTRIBUTING.md"],
+    atomic_nodes: &["code_block", "fenced_code_block", "html_block"],
+    commutative_parents: &[],
+    comment_nodes: &[],
+};
+
+pub(crate) static DOCKERFILE: Profile = Profile {
+    name: "Dockerfile",
+    extensions: &[],
+    file_names: &["Dockerfile", "Containerfile"],
+    atomic_nodes: &["comment_line"],
+    commutative_parents: &[],
+    comment_nodes: &["comment_line"],
+};
+
+pub(crate) static NIX: Profile = Profile {
+    name: "Nix",
+    extensions: &["nix"],
+    file_names: &["flake.nix", "default.nix", "shell.nix"],
+    atomic_nodes: &["inherit", "inherit_from"],
+    commutative_parents: &["attrset_expression", "formals"],
+    comment_nodes: &["comment"],
+};

--- a/packages/ast-merge/langs/src/profiles/functional.rs
+++ b/packages/ast-merge/langs/src/profiles/functional.rs
@@ -1,0 +1,37 @@
+use crate::types::Profile;
+
+pub(crate) static HASKELL: Profile = Profile {
+    name: "Haskell",
+    extensions: &["hs", "lhs"],
+    file_names: &[],
+    atomic_nodes: &["import", "pragma", "module"],
+    commutative_parents: &[
+        "class_body",
+        "instance_body",
+        "data_constructors",
+        "record_body",
+    ],
+    comment_nodes: &["comment", "haddock"],
+};
+
+pub(crate) static ELIXIR: Profile = Profile {
+    name: "Elixir",
+    extensions: &["ex", "exs"],
+    file_names: &["mix.exs"],
+    atomic_nodes: &["alias", "import", "use", "require"],
+    commutative_parents: &["map", "keyword_list", "do_block"],
+    comment_nodes: &["comment"],
+};
+
+pub(crate) static OCAML: Profile = Profile {
+    name: "OCaml",
+    extensions: &["ml", "mli"],
+    file_names: &[],
+    atomic_nodes: &["open_statement", "include_statement"],
+    commutative_parents: &[
+        "record_expression",
+        "record_declaration",
+        "object_expression",
+    ],
+    comment_nodes: &["comment"],
+};

--- a/packages/ast-merge/langs/src/profiles/jvm.rs
+++ b/packages/ast-merge/langs/src/profiles/jvm.rs
@@ -1,0 +1,39 @@
+use crate::types::Profile;
+
+pub(crate) static JAVA: Profile = Profile {
+    name: "Java",
+    extensions: &["java"],
+    file_names: &[],
+    atomic_nodes: &["import_declaration", "package_declaration", "annotation"],
+    commutative_parents: &[
+        "class_body",
+        "interface_body",
+        "enum_body",
+        "annotation_type_body",
+        "module_body",
+    ],
+    comment_nodes: &["line_comment", "block_comment"],
+};
+
+pub(crate) static KOTLIN: Profile = Profile {
+    name: "Kotlin",
+    extensions: &["kt", "kts"],
+    file_names: &[],
+    atomic_nodes: &["import_header", "package_header", "annotation"],
+    commutative_parents: &[
+        "class_body",
+        "enum_class_body",
+        "object_literal",
+        "when_expression",
+    ],
+    comment_nodes: &["line_comment", "multiline_comment"],
+};
+
+pub(crate) static SCALA: Profile = Profile {
+    name: "Scala",
+    extensions: &["scala", "sc"],
+    file_names: &[],
+    atomic_nodes: &["import_declaration", "package_clause", "annotation"],
+    commutative_parents: &["template_body", "block", "case_block"],
+    comment_nodes: &["comment", "block_comment"],
+};

--- a/packages/ast-merge/langs/src/profiles/scripting.rs
+++ b/packages/ast-merge/langs/src/profiles/scripting.rs
@@ -1,0 +1,56 @@
+use crate::types::Profile;
+
+pub(crate) static PYTHON: Profile = Profile {
+    name: "Python",
+    extensions: &["py", "pyi", "bzl", "bazel"],
+    file_names: &["BUILD", "BUILD.bazel"],
+    atomic_nodes: &[
+        "import_statement",
+        "import_from_statement",
+        "future_import_statement",
+    ],
+    commutative_parents: &["dictionary", "set", "argument_list", "decorated_definition"],
+    comment_nodes: &["comment"],
+};
+
+pub(crate) static RUBY: Profile = Profile {
+    name: "Ruby",
+    extensions: &["rb", "rake", "gemspec"],
+    file_names: &["Rakefile", "Gemfile", "Guardfile", "Capfile"],
+    atomic_nodes: &["require", "require_relative"],
+    commutative_parents: &["hash", "class", "module", "block"],
+    comment_nodes: &["comment"],
+};
+
+pub(crate) static PHP: Profile = Profile {
+    name: "PHP",
+    extensions: &["php", "phtml", "php3", "php4", "php5", "php7", "phps"],
+    file_names: &[],
+    atomic_nodes: &["namespace_use_declaration", "namespace_definition"],
+    commutative_parents: &[
+        "declaration_list",
+        "class_declaration",
+        "interface_declaration",
+        "trait_declaration",
+        "array_creation_expression",
+    ],
+    comment_nodes: &["comment"],
+};
+
+pub(crate) static BASH: Profile = Profile {
+    name: "Bash",
+    extensions: &["sh", "bash", "zsh"],
+    file_names: &[".bashrc", ".bash_profile", ".zshrc", ".profile"],
+    atomic_nodes: &["command"],
+    commutative_parents: &["case_statement"],
+    comment_nodes: &["comment"],
+};
+
+pub(crate) static LUA: Profile = Profile {
+    name: "Lua",
+    extensions: &["lua"],
+    file_names: &[],
+    atomic_nodes: &["require_call"],
+    commutative_parents: &["table_constructor", "field_list"],
+    comment_nodes: &["comment"],
+};

--- a/packages/ast-merge/langs/src/profiles/web.rs
+++ b/packages/ast-merge/langs/src/profiles/web.rs
@@ -1,0 +1,86 @@
+use crate::types::Profile;
+
+pub(crate) static JAVASCRIPT: Profile = Profile {
+    name: "JavaScript",
+    extensions: &["js", "mjs", "cjs", "jsx"],
+    file_names: &[],
+    atomic_nodes: &["import_statement", "export_statement"],
+    commutative_parents: &["object", "named_imports", "export_clause", "class_body"],
+    comment_nodes: &["comment"],
+};
+
+pub(crate) static TYPESCRIPT: Profile = Profile {
+    name: "TypeScript",
+    extensions: &["ts", "mts", "cts"],
+    file_names: &[],
+    atomic_nodes: &[
+        "import_statement",
+        "export_statement",
+        "type_alias_declaration",
+        "interface_declaration",
+    ],
+    commutative_parents: &[
+        "object",
+        "object_type",
+        "named_imports",
+        "export_clause",
+        "class_body",
+        "interface_body",
+        "enum_body",
+    ],
+    comment_nodes: &["comment"],
+};
+
+pub(crate) static TSX: Profile = Profile {
+    name: "TypeScript TSX",
+    extensions: &["tsx"],
+    file_names: &[],
+    atomic_nodes: &[
+        "import_statement",
+        "export_statement",
+        "type_alias_declaration",
+        "interface_declaration",
+    ],
+    commutative_parents: &[
+        "object",
+        "object_type",
+        "named_imports",
+        "export_clause",
+        "class_body",
+        "interface_body",
+        "enum_body",
+    ],
+    comment_nodes: &["comment"],
+};
+
+pub(crate) static HTML: Profile = Profile {
+    name: "HTML",
+    extensions: &["html", "htm", "xhtml"],
+    file_names: &["index.html"],
+    atomic_nodes: &["script_element", "style_element", "doctype"],
+    commutative_parents: &["start_tag"],
+    comment_nodes: &["comment"],
+};
+
+pub(crate) static CSS: Profile = Profile {
+    name: "CSS",
+    extensions: &["css"],
+    file_names: &[],
+    atomic_nodes: &["import_statement", "charset_statement"],
+    commutative_parents: &["declaration_list", "keyframe_block"],
+    comment_nodes: &["comment"],
+};
+
+pub(crate) static SVELTE: Profile = Profile {
+    name: "Svelte",
+    extensions: &["svelte"],
+    file_names: &[],
+    atomic_nodes: &[
+        "script_element",
+        "style_element",
+        "import_statement",
+        "export_statement",
+    ],
+    commutative_parents: &["object", "start_tag"],
+    comment_nodes: &["comment"],
+};

--- a/packages/ast-merge/langs/src/tests.rs
+++ b/packages/ast-merge/langs/src/tests.rs
@@ -1,0 +1,203 @@
+use std::path::PathBuf;
+
+use super::*;
+
+mod validation;
+
+#[test]
+fn test_detect_rust() {
+    let path = PathBuf::from("src/main.rs");
+    assert_eq!(detect(&path), Some(Lang::Rust));
+}
+
+#[test]
+fn test_detect_javascript() {
+    assert_eq!(detect(&PathBuf::from("app.js")), Some(Lang::JavaScript));
+    assert_eq!(detect(&PathBuf::from("app.mjs")), Some(Lang::JavaScript));
+    assert_eq!(detect(&PathBuf::from("app.cjs")), Some(Lang::JavaScript));
+    assert_eq!(detect(&PathBuf::from("app.jsx")), Some(Lang::JavaScript));
+}
+
+#[test]
+fn test_detect_typescript() {
+    assert_eq!(detect(&PathBuf::from("app.ts")), Some(Lang::TypeScript));
+    assert_eq!(
+        detect(&PathBuf::from("component.tsx")),
+        Some(Lang::TypeScriptTsx)
+    );
+}
+
+#[test]
+fn test_detect_python() {
+    assert_eq!(detect(&PathBuf::from("script.py")), Some(Lang::Python));
+    assert_eq!(detect(&PathBuf::from("types.pyi")), Some(Lang::Python));
+
+    assert_eq!(detect(&PathBuf::from("BUILD")), Some(Lang::Python));
+    assert_eq!(detect(&PathBuf::from("BUILD.bazel")), Some(Lang::Python));
+    assert_eq!(detect(&PathBuf::from("rules.bzl")), Some(Lang::Python));
+}
+
+#[test]
+fn test_detect_go() {
+    let path = PathBuf::from("main.go");
+    assert_eq!(detect(&path), Some(Lang::Go));
+}
+
+#[test]
+fn test_detect_java() {
+    let path = PathBuf::from("Main.java");
+    assert_eq!(detect(&path), Some(Lang::Java));
+}
+
+#[test]
+fn test_detect_kotlin() {
+    assert_eq!(detect(&PathBuf::from("App.kt")), Some(Lang::Kotlin));
+    assert_eq!(
+        detect(&PathBuf::from("build.gradle.kts")),
+        Some(Lang::Kotlin)
+    );
+}
+
+#[test]
+fn test_detect_scala() {
+    assert_eq!(detect(&PathBuf::from("App.scala")), Some(Lang::Scala));
+    assert_eq!(detect(&PathBuf::from("script.sc")), Some(Lang::Scala));
+}
+
+#[test]
+fn test_detect_c() {
+    assert_eq!(detect(&PathBuf::from("main.c")), Some(Lang::C));
+    assert_eq!(detect(&PathBuf::from("header.h")), Some(Lang::C));
+}
+
+#[test]
+fn test_detect_cpp() {
+    assert_eq!(detect(&PathBuf::from("main.cpp")), Some(Lang::Cpp));
+    assert_eq!(detect(&PathBuf::from("main.cc")), Some(Lang::Cpp));
+    assert_eq!(detect(&PathBuf::from("header.hpp")), Some(Lang::Cpp));
+}
+
+#[test]
+fn test_detect_csharp() {
+    let path = PathBuf::from("Program.cs");
+    assert_eq!(detect(&path), Some(Lang::CSharp));
+}
+
+#[test]
+fn test_detect_swift() {
+    let path = PathBuf::from("ViewController.swift");
+    assert_eq!(detect(&path), Some(Lang::Swift));
+}
+
+#[test]
+fn test_detect_ruby() {
+    assert_eq!(detect(&PathBuf::from("app.rb")), Some(Lang::Ruby));
+    assert_eq!(detect(&PathBuf::from("Gemfile")), Some(Lang::Ruby));
+    assert_eq!(detect(&PathBuf::from("Rakefile")), Some(Lang::Ruby));
+}
+
+#[test]
+fn test_detect_php() {
+    assert_eq!(detect(&PathBuf::from("index.php")), Some(Lang::Php));
+}
+
+#[test]
+fn test_detect_bash() {
+    assert_eq!(detect(&PathBuf::from("script.sh")), Some(Lang::Bash));
+    assert_eq!(detect(&PathBuf::from("script.bash")), Some(Lang::Bash));
+    assert_eq!(detect(&PathBuf::from(".bashrc")), Some(Lang::Bash));
+}
+
+#[test]
+fn test_detect_lua() {
+    let path = PathBuf::from("init.lua");
+    assert_eq!(detect(&path), Some(Lang::Lua));
+}
+
+#[test]
+fn test_detect_haskell() {
+    assert_eq!(detect(&PathBuf::from("Main.hs")), Some(Lang::Haskell));
+    assert_eq!(detect(&PathBuf::from("Lib.lhs")), Some(Lang::Haskell));
+}
+
+#[test]
+fn test_detect_elixir() {
+    assert_eq!(detect(&PathBuf::from("app.ex")), Some(Lang::Elixir));
+    assert_eq!(detect(&PathBuf::from("mix.exs")), Some(Lang::Elixir));
+}
+
+#[test]
+fn test_detect_ocaml() {
+    assert_eq!(detect(&PathBuf::from("main.ml")), Some(Lang::OCaml));
+    assert_eq!(detect(&PathBuf::from("lib.mli")), Some(Lang::OCaml));
+}
+
+#[test]
+fn test_detect_html() {
+    assert_eq!(detect(&PathBuf::from("index.html")), Some(Lang::Html));
+    assert_eq!(detect(&PathBuf::from("page.htm")), Some(Lang::Html));
+}
+
+#[test]
+fn test_detect_css() {
+    let path = PathBuf::from("styles.css");
+    assert_eq!(detect(&path), Some(Lang::Css));
+}
+
+#[test]
+fn test_detect_svelte() {
+    assert_eq!(detect(&PathBuf::from("App.svelte")), Some(Lang::Svelte));
+    assert_eq!(detect(&PathBuf::from("+page.svelte")), Some(Lang::Svelte));
+}
+
+#[test]
+fn test_detect_json() {
+    let path = PathBuf::from("package.json");
+    assert_eq!(detect(&path), Some(Lang::Json));
+}
+
+#[test]
+fn test_detect_toml() {
+    let path = PathBuf::from("Cargo.toml");
+    assert_eq!(detect(&path), Some(Lang::Toml));
+}
+
+#[test]
+fn test_detect_yaml() {
+    assert_eq!(detect(&PathBuf::from("config.yaml")), Some(Lang::Yaml));
+    assert_eq!(detect(&PathBuf::from("config.yml")), Some(Lang::Yaml));
+}
+
+#[test]
+fn test_detect_markdown() {
+    assert_eq!(detect(&PathBuf::from("README.md")), Some(Lang::Markdown));
+    assert_eq!(
+        detect(&PathBuf::from("docs.markdown")),
+        Some(Lang::Markdown)
+    );
+}
+
+#[test]
+fn test_detect_dockerfile() {
+    assert_eq!(detect(&PathBuf::from("Dockerfile")), Some(Lang::Dockerfile));
+    assert_eq!(
+        detect(&PathBuf::from("Containerfile")),
+        Some(Lang::Dockerfile)
+    );
+}
+
+#[test]
+fn test_detect_unknown() {
+    let path = PathBuf::from("file.xyz");
+    assert_eq!(detect(&path), None);
+}
+
+#[test]
+fn test_detect_from_extension() {
+    assert_eq!(detect_from_extension("rs"), Some(Lang::Rust));
+    assert_eq!(detect_from_extension(".rs"), Some(Lang::Rust));
+    assert_eq!(detect_from_extension("java"), Some(Lang::Java));
+    assert_eq!(detect_from_extension("kt"), Some(Lang::Kotlin));
+    assert_eq!(detect_from_extension("swift"), Some(Lang::Swift));
+    assert_eq!(detect_from_extension("unknown"), None);
+}

--- a/packages/ast-merge/langs/src/tests/validation.rs
+++ b/packages/ast-merge/langs/src/tests/validation.rs
@@ -1,0 +1,277 @@
+use super::super::*;
+
+#[test]
+fn test_language_all() {
+    let all = Lang::all();
+
+    assert!(
+        all.len() >= 28,
+        "Expected at least 28 languages, got {}",
+        all.len()
+    );
+
+    assert!(all.contains(&Lang::Rust));
+    assert!(all.contains(&Lang::TypeScript));
+    assert!(all.contains(&Lang::Java));
+    assert!(all.contains(&Lang::Kotlin));
+    assert!(all.contains(&Lang::Swift));
+    assert!(all.contains(&Lang::Python));
+    assert!(all.contains(&Lang::Go));
+    assert!(all.contains(&Lang::CSharp));
+    assert!(all.contains(&Lang::Ruby));
+    assert!(all.contains(&Lang::Bash));
+}
+
+#[test]
+fn test_language_name() {
+    assert_eq!(Lang::Rust.name(), "Rust");
+    assert_eq!(Lang::TypeScript.name(), "TypeScript");
+    assert_eq!(Lang::Java.name(), "Java");
+    assert_eq!(Lang::Kotlin.name(), "Kotlin");
+    assert_eq!(Lang::Swift.name(), "Swift");
+    assert_eq!(Lang::CSharp.name(), "C#");
+}
+
+#[test]
+fn test_tree_sitter_core_languages() {
+    assert!(Lang::Rust.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::JavaScript.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::TypeScript.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::TypeScriptTsx.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::Python.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::Go.to_tree_sitter().node_kind_count() > 0);
+}
+
+#[test]
+fn test_tree_sitter_jvm_languages() {
+    assert!(Lang::Java.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::Kotlin.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::Scala.to_tree_sitter().node_kind_count() > 0);
+}
+
+#[test]
+fn test_tree_sitter_systems_languages() {
+    assert!(Lang::C.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::Cpp.to_tree_sitter().node_kind_count() > 0);
+}
+
+#[test]
+fn test_tree_sitter_dotnet_languages() {
+    assert!(Lang::CSharp.to_tree_sitter().node_kind_count() > 0);
+}
+
+#[test]
+fn test_tree_sitter_mobile_languages() {
+    assert!(Lang::Swift.to_tree_sitter().node_kind_count() > 0);
+}
+
+#[test]
+fn test_tree_sitter_scripting_languages() {
+    assert!(Lang::Ruby.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::Php.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::Bash.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::Lua.to_tree_sitter().node_kind_count() > 0);
+}
+
+#[test]
+fn test_tree_sitter_functional_languages() {
+    assert!(Lang::Haskell.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::Elixir.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::OCaml.to_tree_sitter().node_kind_count() > 0);
+}
+
+#[test]
+fn test_tree_sitter_web_languages() {
+    assert!(Lang::Html.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::Css.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::Svelte.to_tree_sitter().node_kind_count() > 0);
+}
+
+#[test]
+fn test_tree_sitter_data_formats() {
+    assert!(Lang::Json.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::Toml.to_tree_sitter().node_kind_count() > 0);
+    assert!(Lang::Yaml.to_tree_sitter().node_kind_count() > 0);
+}
+
+#[test]
+fn test_tree_sitter_documentation() {
+    assert!(Lang::Markdown.to_tree_sitter().node_kind_count() > 0);
+}
+
+#[test]
+fn test_tree_sitter_devops() {
+    assert!(Lang::Dockerfile.to_tree_sitter().node_kind_count() > 0);
+}
+
+#[test]
+fn test_rust_profile() {
+    let profile = Lang::Rust.profile();
+    assert!(profile.is_atomic("use_declaration"));
+    assert!(!profile.is_atomic("function_item"));
+    assert!(profile.is_commutative("declaration_list"));
+    assert!(profile.is_comment("line_comment"));
+}
+
+#[test]
+fn test_typescript_profile() {
+    let profile = Lang::TypeScript.profile();
+    assert!(profile.is_atomic("import_statement"));
+    assert!(profile.is_commutative("interface_body"));
+}
+
+#[test]
+fn test_python_profile() {
+    let profile = Lang::Python.profile();
+    assert!(profile.is_atomic("import_statement"));
+    assert!(profile.is_commutative("dictionary"));
+}
+
+#[test]
+fn test_java_profile() {
+    let profile = Lang::Java.profile();
+    assert!(profile.is_atomic("import_declaration"));
+    assert!(profile.is_commutative("class_body"));
+    assert!(profile.is_comment("line_comment"));
+}
+
+#[test]
+fn test_kotlin_profile() {
+    let profile = Lang::Kotlin.profile();
+    assert!(profile.is_atomic("import_header"));
+    assert!(profile.is_commutative("class_body"));
+}
+
+#[test]
+fn test_swift_profile() {
+    let profile = Lang::Swift.profile();
+    assert!(profile.is_atomic("import_declaration"));
+    assert!(profile.is_commutative("class_body"));
+}
+
+#[test]
+fn test_csharp_profile() {
+    let profile = Lang::CSharp.profile();
+    assert!(profile.is_atomic("using_directive"));
+    assert!(profile.is_commutative("class_declaration"));
+}
+
+#[test]
+fn test_bash_profile() {
+    let profile = Lang::Bash.profile();
+    assert!(profile.is_atomic("command"));
+    assert!(profile.is_commutative("case_statement"));
+    assert!(profile.is_comment("comment"));
+}
+
+#[test]
+fn test_ruby_profile() {
+    let profile = Lang::Ruby.profile();
+    assert!(profile.is_atomic("require"));
+    assert!(profile.is_commutative("hash"));
+}
+
+#[test]
+fn test_c_profile() {
+    let profile = Lang::C.profile();
+    assert!(profile.is_atomic("preproc_include"));
+    assert!(profile.is_commutative("field_declaration_list"));
+}
+
+#[test]
+fn test_cpp_profile() {
+    let profile = Lang::Cpp.profile();
+    assert!(profile.is_atomic("preproc_include"));
+    assert!(profile.is_atomic("using_declaration"));
+    assert!(profile.is_commutative("field_declaration_list"));
+}
+
+#[test]
+fn test_svelte_profile() {
+    let profile = Lang::Svelte.profile();
+    assert!(profile.is_atomic("script_element"));
+    assert!(profile.is_atomic("style_element"));
+    assert!(profile.is_commutative("start_tag"));
+}
+
+#[test]
+fn test_all_languages_have_valid_profiles() {
+    for lang in Lang::all() {
+        let profile = lang.profile();
+
+        assert!(!profile.name.is_empty(), "Lang {lang:?} has empty name");
+
+        assert!(
+            !profile.extensions.is_empty() || !profile.file_names.is_empty(),
+            "Lang {lang:?} has no extensions or file names"
+        );
+    }
+}
+
+#[test]
+fn test_all_languages_can_create_parser() {
+    for lang in Lang::all() {
+        let ts_lang = lang.to_tree_sitter();
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&ts_lang)
+            .expect("failed to set parser language");
+    }
+}
+
+#[test]
+fn test_parse_simple_code_samples() {
+    let samples = [
+        (Lang::Rust, "fn main() {}"),
+        (Lang::JavaScript, "function main() {}"),
+        (Lang::TypeScript, "function main(): void {}"),
+        (Lang::Python, "def main():\n    pass"),
+        (Lang::Go, "package main\nfunc main() {}"),
+        (
+            Lang::Java,
+            "class Main { public static void main(String[] args) {} }",
+        ),
+        (Lang::Kotlin, "fun main() {}"),
+        (Lang::Swift, "func main() {}"),
+        (Lang::CSharp, "class Program { static void Main() {} }"),
+        (Lang::Ruby, "def main\nend"),
+        (Lang::Php, "<?php function main() {}"),
+        (Lang::Bash, "#!/bin/bash\necho hello"),
+        (Lang::Lua, "function main() end"),
+        (Lang::C, "int main() { return 0; }"),
+        (Lang::Cpp, "int main() { return 0; }"),
+        (
+            Lang::Scala,
+            "object Main { def main(args: Array[String]): Unit = {} }",
+        ),
+        (Lang::Haskell, "main = return ()"),
+        (Lang::Elixir, "defmodule Main do\nend"),
+        (Lang::OCaml, "let main () = ()"),
+        (Lang::Html, "<html><body></body></html>"),
+        (Lang::Css, "body { color: red; }"),
+        (
+            Lang::Svelte,
+            "<script>let count = 0;</script>\n<button>{count}</button>",
+        ),
+        (Lang::Json, r#"{"key": "value"}"#),
+        (Lang::Toml, "[package]\nname = \"test\""),
+        (Lang::Yaml, "key: value"),
+        (Lang::Markdown, "# Hello\n\nWorld"),
+        (Lang::Dockerfile, "FROM alpine:latest\nRUN echo hello"),
+    ];
+
+    for (lang, code) in samples {
+        let ts_lang = lang.to_tree_sitter();
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&ts_lang).unwrap();
+        let tree = parser.parse(code, None);
+        assert!(tree.is_some(), "Failed to parse {lang:?} code: {code}");
+        let tree = tree.unwrap();
+
+        let root = tree.root_node();
+        assert!(
+            root.child_count() > 0 || !root.byte_range().is_empty(),
+            "Empty parse tree for {lang:?}"
+        );
+    }
+}

--- a/packages/ast-merge/langs/src/types.rs
+++ b/packages/ast-merge/langs/src/types.rs
@@ -1,0 +1,26 @@
+#[derive(Debug, Clone)]
+pub struct Profile {
+    pub name: &'static str,
+    pub extensions: &'static [&'static str],
+    pub file_names: &'static [&'static str],
+    pub atomic_nodes: &'static [&'static str],
+    pub commutative_parents: &'static [&'static str],
+    pub comment_nodes: &'static [&'static str],
+}
+
+impl Profile {
+    #[must_use]
+    pub fn is_atomic(&self, kind: &str) -> bool {
+        self.atomic_nodes.contains(&kind)
+    }
+
+    #[must_use]
+    pub fn is_commutative(&self, kind: &str) -> bool {
+        self.commutative_parents.contains(&kind)
+    }
+
+    #[must_use]
+    pub fn is_comment(&self, kind: &str) -> bool {
+        self.comment_nodes.contains(&kind)
+    }
+}

--- a/packages/ast-merge/matcher/Cargo.toml
+++ b/packages/ast-merge/matcher/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ast-merge-matcher"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "GumTree algorithm and tree matching for ast-merge"
+
+[dependencies]
+tracing.workspace = true
+ast-merge-ast.workspace = true
+rustc-hash.workspace = true
+tree-sitter.workspace = true
+rayon.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+tree-sitter-rust.workspace = true
+tree-sitter-toml-ng.workspace = true
+tree-sitter-language.workspace = true
+
+[lints]
+workspace = true

--- a/packages/ast-merge/matcher/package.nix
+++ b/packages/ast-merge/matcher/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "ast-merge-matcher";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/ast-merge/matcher/src/config.rs
+++ b/packages/ast-merge/matcher/src/config.rs
@@ -1,0 +1,23 @@
+/// Maximum subtree size for tree edit distance computation.
+/// Larger subtrees skip TED and rely on faster heuristics.
+const DEFAULT_MAX_TED_SIZE: usize = 100;
+
+/// Dice coefficient threshold for bottom-up matching.
+const DEFAULT_DICE_THRESHOLD: f64 = 0.5;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub min_height: usize,
+    pub dice_threshold: f64,
+    pub max_ted_size: usize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            min_height: 2,
+            dice_threshold: DEFAULT_DICE_THRESHOLD,
+            max_ted_size: DEFAULT_MAX_TED_SIZE,
+        }
+    }
+}

--- a/packages/ast-merge/matcher/src/gumtree.rs
+++ b/packages/ast-merge/matcher/src/gumtree.rs
@@ -1,0 +1,222 @@
+mod bottomup;
+mod siblings;
+
+use ast_merge_ast::{Tree, compute};
+use rustc_hash::FxHashMap;
+
+use crate::{
+    config::Config,
+    matching::Map,
+    traverse::{SiblingNodes, SubtreesInput, assign_node_ids, node_height, subtrees},
+};
+
+pub struct GumTree<'a> {
+    tree_a: &'a Tree,
+    tree_b: &'a Tree,
+    config: Config,
+}
+
+struct NodePairSlices<'a, 'b> {
+    nodes_a: &'b [tree_sitter::Node<'a>],
+    nodes_b: &'b [tree_sitter::Node<'a>],
+    matching: &'b mut Map,
+}
+
+impl<'a> GumTree<'a> {
+    #[must_use]
+    pub fn new(tree_a: &'a Tree, tree_b: &'a Tree, config: Config) -> Self {
+        Self {
+            tree_a,
+            tree_b,
+            config,
+        }
+    }
+
+    #[must_use]
+    pub fn compute(&self) -> Map {
+        let mut matching = Map::new();
+
+        let mut nodes_a = Vec::new();
+        let mut nodes_b = Vec::new();
+        assign_node_ids(self.tree_a.root_node(), &mut nodes_a);
+        assign_node_ids(self.tree_b.root_node(), &mut nodes_b);
+
+        tracing::debug!(
+            nodes_a = nodes_a.len(),
+            nodes_b = nodes_b.len(),
+            "tree sizes"
+        );
+
+        if let (Some(root_a), Some(root_b)) = (nodes_a.first(), nodes_b.first()) {
+            if root_a.kind_id() == root_b.kind_id() {
+                matching.add_match(0, 0);
+            }
+        }
+
+        let phase1_start = std::time::Instant::now();
+        self.top_down_phase(NodePairSlices {
+            nodes_a: &nodes_a,
+            nodes_b: &nodes_b,
+            matching: &mut matching,
+        });
+        tracing::debug!(
+            elapsed_ms = phase1_start.elapsed().as_millis(),
+            matches = matching.len(),
+            "top_down_phase complete"
+        );
+
+        let phase15_start = std::time::Instant::now();
+        self.leaf_sibling_phase(NodePairSlices {
+            nodes_a: &nodes_a,
+            nodes_b: &nodes_b,
+            matching: &mut matching,
+        });
+        tracing::debug!(
+            elapsed_ms = phase15_start.elapsed().as_millis(),
+            matches = matching.len(),
+            "leaf_sibling_phase complete"
+        );
+
+        let phase2_start = std::time::Instant::now();
+        bottomup::bottom_up_phase(
+            &bottomup::BottomUpInput {
+                nodes_a: &nodes_a,
+                nodes_b: &nodes_b,
+                config: &self.config,
+            },
+            &mut matching,
+        );
+        tracing::debug!(
+            elapsed_ms = phase2_start.elapsed().as_millis(),
+            matches = matching.len(),
+            "bottom_up_phase complete"
+        );
+
+        matching
+    }
+
+    fn top_down_phase(&self, slices: NodePairSlices<'a, '_>) {
+        let NodePairSlices {
+            nodes_a,
+            nodes_b,
+            matching,
+        } = slices;
+
+        let mut hash_to_a: FxHashMap<u64, Vec<usize>> = FxHashMap::default();
+        let mut hash_to_b: FxHashMap<u64, Vec<usize>> = FxHashMap::default();
+
+        for (id, &node) in nodes_a.iter().enumerate() {
+            if node_height(node) >= self.config.min_height {
+                let hash = compute(self.tree_a, node);
+                hash_to_a.entry(hash).or_default().push(id);
+            }
+        }
+
+        for (id, &node) in nodes_b.iter().enumerate() {
+            if node_height(node) >= self.config.min_height {
+                let hash = compute(self.tree_b, node);
+                hash_to_b.entry(hash).or_default().push(id);
+            }
+        }
+
+        for (hash, a_ids) in &hash_to_a {
+            let Some(b_ids) = hash_to_b.get(hash) else {
+                continue;
+            };
+
+            if let ([a_id], [b_id]) = (a_ids.as_slice(), b_ids.as_slice()) {
+                let a_id = *a_id;
+                let b_id = *b_id;
+
+                if matching.is_matched_a(a_id) || matching.is_matched_b(b_id) {
+                    continue;
+                }
+
+                subtrees(
+                    &SubtreesInput {
+                        node_a: nodes_a.get(a_id).copied(),
+                        node_b: nodes_b.get(b_id).copied(),
+                        nodes_a,
+                        nodes_b,
+                    },
+                    matching,
+                );
+            } else {
+                siblings::by_position(
+                    &siblings::Input {
+                        a: SiblingNodes {
+                            ids: a_ids,
+                            nodes: nodes_a,
+                        },
+                        b: SiblingNodes {
+                            ids: b_ids,
+                            nodes: nodes_b,
+                        },
+                        root_a: self.tree_a.root_node(),
+                        root_b: self.tree_b.root_node(),
+                    },
+                    matching,
+                );
+            }
+        }
+    }
+
+    fn leaf_sibling_phase(&self, slices: NodePairSlices<'a, '_>) {
+        let NodePairSlices {
+            nodes_a,
+            nodes_b,
+            matching,
+        } = slices;
+
+        let mut hash_to_a: FxHashMap<u64, Vec<usize>> = FxHashMap::default();
+        let mut hash_to_b: FxHashMap<u64, Vec<usize>> = FxHashMap::default();
+
+        for (id, &node) in nodes_a.iter().enumerate() {
+            if matching.is_matched_a(id) {
+                continue;
+            }
+            if node_height(node) < self.config.min_height {
+                let hash = compute(self.tree_a, node);
+                hash_to_a.entry(hash).or_default().push(id);
+            }
+        }
+
+        for (id, &node) in nodes_b.iter().enumerate() {
+            if matching.is_matched_b(id) {
+                continue;
+            }
+            if node_height(node) < self.config.min_height {
+                let hash = compute(self.tree_b, node);
+                hash_to_b.entry(hash).or_default().push(id);
+            }
+        }
+
+        for (hash, a_ids) in &hash_to_a {
+            let Some(b_ids) = hash_to_b.get(hash) else {
+                continue;
+            };
+
+            if let (&[a_id], &[b_id]) = (a_ids.as_slice(), b_ids.as_slice()) {
+                if !matching.is_matched_a(a_id) && !matching.is_matched_b(b_id) {
+                    matching.add_match(a_id, b_id);
+                }
+            } else {
+                siblings::by_position(
+                    &siblings::Input {
+                        a: SiblingNodes {
+                            ids: a_ids,
+                            nodes: nodes_a,
+                        },
+                        b: SiblingNodes {
+                            ids: b_ids,
+                            nodes: nodes_b,
+                        },
+                        root_a: self.tree_a.root_node(),
+                        root_b: self.tree_b.root_node(),
+                    },
+                    matching,
+                );
+            }
+        }
+    }
+}

--- a/packages/ast-merge/matcher/src/gumtree/bottomup.rs
+++ b/packages/ast-merge/matcher/src/gumtree/bottomup.rs
@@ -1,0 +1,114 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rayon::prelude::*;
+
+use crate::{
+    config::Config,
+    matching::{Map, Pair},
+    metadata::{DescendantRangeQuery, Index, build_kind_index, compute_node_meta},
+};
+
+/// Dice coefficient numerator multiplier: |2 * intersection| / |A| + |B|.
+const DICE_NUMERATOR_FACTOR: f64 = 2.0;
+
+/// Near-perfect Dice match threshold for early exit in candidate search.
+const NEAR_PERFECT_DICE: f64 = 0.999;
+
+struct Candidate {
+    b_id: usize,
+    dice: f64,
+}
+
+pub struct BottomUpInput<'a, 'b> {
+    pub nodes_a: &'b [tree_sitter::Node<'a>],
+    pub nodes_b: &'b [tree_sitter::Node<'a>],
+    pub config: &'b Config,
+}
+
+pub fn bottom_up_phase(input: &BottomUpInput<'_, '_>, matching: &mut Map) {
+    let BottomUpInput {
+        nodes_a,
+        nodes_b,
+        config,
+    } = *input;
+    let meta_a = compute_node_meta(nodes_a);
+    let meta_b = compute_node_meta(nodes_b);
+
+    let kind_index_b = build_kind_index(&meta_b);
+
+    let match_index = Index::new(matching, &meta_a, &meta_b);
+
+    let unmatched_a: Vec<usize> = (0..nodes_a.len())
+        .filter(|&id| !matching.is_matched_a(id))
+        .collect();
+
+    let matched_b: rustc_hash::FxHashSet<usize> = matching.iter().map(|pair| pair.b_id).collect();
+
+    let new_matches: Vec<Pair> = unmatched_a
+        .par_iter()
+        .filter_map(|&a_id| {
+            let ma = meta_a.get(a_id)?;
+            debug_assert!(
+                a_id < meta_a.len(),
+                "a_id {a_id} must be a valid index into meta_a"
+            );
+
+            let candidates = kind_index_b.get(&ma.kind_id)?;
+
+            let mut best: Option<Candidate> = None;
+
+            for &b_id in candidates {
+                if matched_b.contains(&b_id) {
+                    continue;
+                }
+
+                let Some(mb) = meta_b.get(b_id) else {
+                    debug_assert!(
+                        false,
+                        "b_id {b_id} from kind_index_b must be a valid index into meta_b"
+                    );
+                    continue;
+                };
+
+                let matched_count = match_index.count_descendants_in_range(&DescendantRangeQuery {
+                    a_start: ma.start,
+                    a_end: ma.end,
+                    b_start: mb.start,
+                    b_end: mb.end,
+                });
+
+                if ma.descendants == 0 || mb.descendants == 0 {
+                    continue;
+                }
+
+                let dice = (DICE_NUMERATOR_FACTOR * f64::from(matched_count))
+                    / (ma.descendants as f64 + mb.descendants as f64);
+
+                if dice < config.dice_threshold {
+                    continue;
+                }
+
+                if best.as_ref().is_none_or(|b| dice > b.dice) {
+                    best = Some(Candidate { b_id, dice });
+                }
+
+                if dice >= NEAR_PERFECT_DICE {
+                    break;
+                }
+            }
+
+            best.map(|candidate| Pair {
+                a_id,
+                b_id: candidate.b_id,
+            })
+        })
+        .collect();
+
+    let applied = AtomicUsize::new(0);
+    for pair in new_matches {
+        if !matching.is_matched_a(pair.a_id) && !matching.is_matched_b(pair.b_id) {
+            matching.add_match(pair.a_id, pair.b_id);
+            applied.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}

--- a/packages/ast-merge/matcher/src/gumtree/siblings.rs
+++ b/packages/ast-merge/matcher/src/gumtree/siblings.rs
@@ -1,0 +1,157 @@
+use rustc_hash::FxHashMap;
+
+use crate::{
+    matching::Map,
+    traverse::{SiblingNodes, SubtreesInput, subtrees},
+};
+
+#[derive(Clone)]
+struct Entry {
+    node_id: usize,
+    child_index: usize,
+}
+
+const ROOT_SENTINEL: usize = usize::MAX;
+const ROOT_CHILDREN_SENTINEL: usize = usize::MAX - 1;
+
+struct NodeClassification {
+    parent_key: usize,
+    child_index: usize,
+}
+
+fn classify_node(
+    node: tree_sitter::Node<'_>,
+    root_id: usize,
+    nodes: &[tree_sitter::Node<'_>],
+) -> NodeClassification {
+    let Some(parent) = node.parent() else {
+        return NodeClassification {
+            parent_key: ROOT_SENTINEL,
+            child_index: 0,
+        };
+    };
+
+    let child_idx = parent
+        .children(&mut parent.walk())
+        .position(|c| c.id() == node.id())
+        .unwrap_or(0);
+
+    if parent.id() == root_id {
+        NodeClassification {
+            parent_key: ROOT_CHILDREN_SENTINEL,
+            child_index: child_idx,
+        }
+    } else {
+        let parent_id = nodes
+            .iter()
+            .position(|n| n.id() == parent.id())
+            .unwrap_or(ROOT_SENTINEL);
+        NodeClassification {
+            parent_key: parent_id,
+            child_index: child_idx,
+        }
+    }
+}
+
+struct ParentIndexInput<'a, 'b, F> {
+    ids: &'b [usize],
+    nodes: &'b [tree_sitter::Node<'a>],
+    root_id: usize,
+    matching_filter: F,
+}
+
+fn build_parent_index(
+    input: &ParentIndexInput<'_, '_, impl Fn(usize) -> bool>,
+) -> FxHashMap<usize, Vec<Entry>> {
+    let mut by_parent: FxHashMap<usize, Vec<Entry>> = FxHashMap::default();
+
+    for &id in input.ids {
+        if (input.matching_filter)(id) {
+            continue;
+        }
+
+        let Some(node) = input.nodes.get(id).copied() else {
+            debug_assert!(
+                false,
+                "id {id} came from ids which must be valid node indices"
+            );
+            continue;
+        };
+
+        let classification = classify_node(node, input.root_id, input.nodes);
+        by_parent
+            .entry(classification.parent_key)
+            .or_default()
+            .push(Entry {
+                node_id: id,
+                child_index: classification.child_index,
+            });
+    }
+
+    by_parent
+}
+
+pub struct Input<'a, 'b> {
+    pub a: SiblingNodes<'a, 'b>,
+    pub b: SiblingNodes<'a, 'b>,
+    pub root_a: tree_sitter::Node<'a>,
+    pub root_b: tree_sitter::Node<'a>,
+}
+
+pub fn by_position(input: &Input<'_, '_>, matching: &mut Map) {
+    let SiblingNodes {
+        ids: a_ids,
+        nodes: nodes_a,
+    } = input.a;
+    let SiblingNodes {
+        ids: b_ids,
+        nodes: nodes_b,
+    } = input.b;
+
+    let a_by_parent = build_parent_index(&ParentIndexInput {
+        ids: a_ids,
+        nodes: nodes_a,
+        root_id: input.root_a.id(),
+        matching_filter: |id| matching.is_matched_a(id),
+    });
+    let b_by_parent = build_parent_index(&ParentIndexInput {
+        ids: b_ids,
+        nodes: nodes_b,
+        root_id: input.root_b.id(),
+        matching_filter: |id| matching.is_matched_b(id),
+    });
+
+    for (a_parent_key, a_children) in &a_by_parent {
+        let b_parent_key = match *a_parent_key {
+            ROOT_SENTINEL => ROOT_SENTINEL,
+            ROOT_CHILDREN_SENTINEL => ROOT_CHILDREN_SENTINEL,
+            parent_id => match matching.get_match_a_to_b(parent_id) {
+                Some(b_id) => b_id,
+                None => continue,
+            },
+        };
+
+        let Some(b_children) = b_by_parent.get(&b_parent_key) else {
+            continue;
+        };
+
+        let mut a_sorted: Vec<_> = a_children.clone();
+        let mut b_sorted: Vec<_> = b_children.clone();
+        a_sorted.sort_by_key(|e| e.child_index);
+        b_sorted.sort_by_key(|e| e.child_index);
+
+        for (a_entry, b_entry) in a_sorted.iter().zip(b_sorted.iter()) {
+            if !matching.is_matched_a(a_entry.node_id) && !matching.is_matched_b(b_entry.node_id) {
+                subtrees(
+                    &SubtreesInput {
+                        node_a: nodes_a.get(a_entry.node_id).copied(),
+                        node_b: nodes_b.get(b_entry.node_id).copied(),
+                        nodes_a,
+                        nodes_b,
+                    },
+                    matching,
+                );
+            }
+        }
+    }
+}

--- a/packages/ast-merge/matcher/src/lib.rs
+++ b/packages/ast-merge/matcher/src/lib.rs
@@ -1,0 +1,26 @@
+mod config;
+mod gumtree;
+mod matching;
+mod metadata;
+mod traverse;
+
+use ast_merge_ast::Tree;
+pub use config::Config;
+pub use gumtree::GumTree;
+pub use matching::{Map, Pair};
+
+#[must_use]
+pub fn compute(tree_a: &Tree, tree_b: &Tree) -> Map {
+    let start = std::time::Instant::now();
+    let matcher = GumTree::new(tree_a, tree_b, Config::default());
+    let result = matcher.compute();
+    tracing::debug!(
+        elapsed_ms = start.elapsed().as_millis(),
+        matches = result.len(),
+        "compute complete"
+    );
+    result
+}
+
+#[cfg(test)]
+mod tests;

--- a/packages/ast-merge/matcher/src/matching.rs
+++ b/packages/ast-merge/matcher/src/matching.rs
@@ -1,0 +1,59 @@
+use rustc_hash::FxHashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Pair {
+    pub a_id: usize,
+    pub b_id: usize,
+}
+
+#[derive(Debug, Default)]
+pub struct Map {
+    a_to_b: FxHashMap<usize, usize>,
+    b_to_a: FxHashMap<usize, usize>,
+}
+
+impl Map {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_match(&mut self, a_id: usize, b_id: usize) {
+        self.a_to_b.insert(a_id, b_id);
+        self.b_to_a.insert(b_id, a_id);
+    }
+
+    #[must_use]
+    pub fn get_match_a_to_b(&self, a_id: usize) -> Option<usize> {
+        self.a_to_b.get(&a_id).copied()
+    }
+
+    #[must_use]
+    pub fn get_match_b_to_a(&self, b_id: usize) -> Option<usize> {
+        self.b_to_a.get(&b_id).copied()
+    }
+
+    #[must_use]
+    pub fn is_matched_a(&self, a_id: usize) -> bool {
+        self.a_to_b.contains_key(&a_id)
+    }
+
+    #[must_use]
+    pub fn is_matched_b(&self, b_id: usize) -> bool {
+        self.b_to_a.contains_key(&b_id)
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.a_to_b.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.a_to_b.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = Pair> + '_ {
+        self.a_to_b.iter().map(|(&a_id, &b_id)| Pair { a_id, b_id })
+    }
+}

--- a/packages/ast-merge/matcher/src/metadata.rs
+++ b/packages/ast-merge/matcher/src/metadata.rs
@@ -1,0 +1,110 @@
+use rustc_hash::FxHashMap;
+
+use crate::matching::Map;
+
+pub struct NodeMeta {
+    pub start: usize,
+    pub end: usize,
+    pub descendants: usize,
+    pub kind_id: u16,
+}
+
+struct MatchedRange {
+    a_start: usize,
+    a_end: usize,
+    b_start: usize,
+    b_end: usize,
+}
+
+pub struct Index {
+    sorted_a: Vec<MatchedRange>,
+}
+
+pub struct DescendantRangeQuery {
+    pub a_start: usize,
+    pub a_end: usize,
+    pub b_start: usize,
+    pub b_end: usize,
+}
+
+impl Index {
+    pub fn new(matching: &Map, meta_a: &[NodeMeta], meta_b: &[NodeMeta]) -> Self {
+        let mut sorted_a: Vec<_> = matching
+            .iter()
+            .filter_map(|pair| {
+                let ma = meta_a.get(pair.a_id)?;
+                let mb = meta_b.get(pair.b_id)?;
+                Some(MatchedRange {
+                    a_start: ma.start,
+                    a_end: ma.end,
+                    b_start: mb.start,
+                    b_end: mb.end,
+                })
+            })
+            .collect();
+        sorted_a.sort_unstable_by_key(|r| r.a_start);
+        Self { sorted_a }
+    }
+
+    pub fn count_descendants_in_range(&self, query: &DescendantRangeQuery) -> u32 {
+        let start_idx = self.sorted_a.partition_point(|r| r.a_start < query.a_start);
+
+        let mut count = 0u32;
+        for r in self.sorted_a.get(start_idx..).unwrap_or(&[]) {
+            if r.a_start >= query.a_end {
+                break;
+            }
+
+            if r.a_end <= query.a_end && r.b_start >= query.b_start && r.b_end <= query.b_end {
+                count += 1;
+            }
+        }
+        count
+    }
+}
+
+pub fn compute_node_meta(nodes: &[tree_sitter::Node<'_>]) -> Vec<NodeMeta> {
+    let mut meta: Vec<NodeMeta> = nodes
+        .iter()
+        .map(|node| {
+            let range = node.byte_range();
+            NodeMeta {
+                start: range.start,
+                end: range.end,
+                descendants: 1,
+                kind_id: node.kind_id(),
+            }
+        })
+        .collect();
+
+    let counts: Vec<usize> = meta
+        .iter()
+        .enumerate()
+        .map(|(i, node)| {
+            let mut count = 1usize;
+            for m in meta.iter().skip(i + 1) {
+                if m.start >= node.start && m.end <= node.end {
+                    count += 1;
+                }
+                if m.start >= node.end {
+                    break;
+                }
+            }
+            count
+        })
+        .collect();
+
+    for (m, count) in meta.iter_mut().zip(counts) {
+        m.descendants = count;
+    }
+
+    meta
+}
+
+pub fn build_kind_index(meta: &[NodeMeta]) -> FxHashMap<u16, Vec<usize>> {
+    let mut index: FxHashMap<u16, Vec<usize>> = FxHashMap::default();
+    for (id, m) in meta.iter().enumerate() {
+        index.entry(m.kind_id).or_default().push(id);
+    }
+    index
+}

--- a/packages/ast-merge/matcher/src/tests.rs
+++ b/packages/ast-merge/matcher/src/tests.rs
@@ -1,0 +1,133 @@
+mod integration;
+
+use ast_merge_ast::tree;
+use rustc_hash::FxHashSet;
+
+use crate::{Map, compute, matching::Pair, traverse::node_height};
+
+fn get_rust_language() -> tree_sitter::Language {
+    tree_sitter_rust::LANGUAGE.into()
+}
+
+fn parse_rust(source: &str) -> ast_merge_ast::Tree {
+    tree(source, &get_rust_language()).unwrap().tree
+}
+
+#[test]
+fn test_matching_identical_trees() {
+    let source = "fn foo() {}";
+    let tree_a = parse_rust(source);
+    let tree_b = parse_rust(source);
+
+    let matching = compute(&tree_a, &tree_b);
+
+    assert!(!matching.is_empty());
+}
+
+#[test]
+fn test_matching_different_trees() {
+    let source_a = "fn foo() {}";
+    let source_b = "fn bar() {}";
+    let tree_a = parse_rust(source_a);
+    let tree_b = parse_rust(source_b);
+
+    let matching = compute(&tree_a, &tree_b);
+
+    assert!(!matching.is_empty());
+}
+
+#[test]
+fn test_matching_empty_matching() {
+    let matching = Map::new();
+    assert!(matching.is_empty());
+    assert_eq!(matching.len(), 0);
+}
+
+#[test]
+fn test_matching_add_and_get() {
+    let mut matching = Map::new();
+    matching.add_match(0, 5);
+    matching.add_match(1, 6);
+
+    assert_eq!(matching.get_match_a_to_b(0), Some(5));
+    assert_eq!(matching.get_match_a_to_b(1), Some(6));
+    assert_eq!(matching.get_match_b_to_a(5), Some(0));
+    assert_eq!(matching.get_match_b_to_a(6), Some(1));
+    assert_eq!(matching.len(), 2);
+}
+
+#[test]
+fn test_matching_is_matched() {
+    let mut matching = Map::new();
+    matching.add_match(0, 5);
+
+    assert!(matching.is_matched_a(0));
+    assert!(!matching.is_matched_a(1));
+    assert!(matching.is_matched_b(5));
+    assert!(!matching.is_matched_b(6));
+}
+
+#[test]
+fn test_matching_iter() {
+    let mut matching = Map::new();
+    matching.add_match(0, 5);
+    matching.add_match(1, 6);
+
+    let pairs: FxHashSet<_> = matching.iter().collect();
+    assert!(pairs.contains(&Pair { a_id: 0, b_id: 5 }));
+    assert!(pairs.contains(&Pair { a_id: 1, b_id: 6 }));
+}
+
+#[test]
+fn test_node_height() {
+    let source = "fn foo() { let x = 1; }";
+    let tree = parse_rust(source);
+    let root = tree.root_node();
+
+    let height = node_height(root);
+    assert!(height > 1);
+}
+
+#[test]
+fn test_config_default() {
+    let config = crate::Config::default();
+    assert_eq!(config.min_height, 2);
+    assert!((config.dice_threshold - 0.5).abs() < f64::EPSILON);
+    assert_eq!(config.max_ted_size, 100);
+}
+
+#[test]
+fn test_matching_with_additions() {
+    let source_a = "fn foo() {}";
+    let source_b = "fn foo() {} fn bar() {}";
+    let tree_a = parse_rust(source_a);
+    let tree_b = parse_rust(source_b);
+
+    let matching = compute(&tree_a, &tree_b);
+
+    assert!(!matching.is_empty());
+}
+
+#[test]
+fn test_matching_with_deletions() {
+    let source_a = "fn foo() {} fn bar() {}";
+    let source_b = "fn foo() {}";
+    let tree_a = parse_rust(source_a);
+    let tree_b = parse_rust(source_b);
+
+    let matching = compute(&tree_a, &tree_b);
+
+    assert!(!matching.is_empty());
+}
+
+#[test]
+fn test_matching_reordered() {
+    let source_a = "fn foo() {} fn bar() {}";
+    let source_b = "fn bar() {} fn foo() {}";
+    let tree_a = parse_rust(source_a);
+    let tree_b = parse_rust(source_b);
+
+    let matching = compute(&tree_a, &tree_b);
+
+    assert!(!matching.is_empty());
+}

--- a/packages/ast-merge/matcher/src/tests/integration.rs
+++ b/packages/ast-merge/matcher/src/tests/integration.rs
@@ -1,0 +1,221 @@
+use ast_merge_ast::tree;
+
+use crate::{compute, metadata::compute_node_meta, traverse::assign_node_ids};
+
+fn get_rust_language() -> tree_sitter::Language {
+    tree_sitter_rust::LANGUAGE.into()
+}
+
+fn parse_rust(source: &str) -> ast_merge_ast::Tree {
+    tree(source, &get_rust_language()).unwrap().tree
+}
+
+fn get_toml_language() -> tree_sitter::Language {
+    tree_sitter_toml_ng::LANGUAGE.into()
+}
+
+fn parse_toml(source: &str) -> ast_merge_ast::Tree {
+    tree(source, &get_toml_language()).unwrap().tree
+}
+
+#[test]
+fn test_matching_identical_comments_with_insertion() {
+    let source_a = r#"# Comment 1
+key1 = "value1"
+# Comment 2
+key2 = "value2"
+"#;
+    let source_b = r#"# New comment
+key0 = "value0"
+# Comment 1
+key1 = "value1"
+# Comment 2
+key2 = "value2"
+"#;
+
+    let tree_a = parse_toml(source_a);
+    let tree_b = parse_toml(source_b);
+
+    let matching = compute(&tree_a, &tree_b);
+
+    let mut nodes_a = Vec::new();
+    let mut nodes_b = Vec::new();
+    assign_node_ids(tree_a.root_node(), &mut nodes_a);
+    assign_node_ids(tree_b.root_node(), &mut nodes_b);
+
+    let comment_matches: Vec<_> = matching
+        .iter()
+        .filter(|pair| {
+            nodes_a
+                .get(pair.a_id)
+                .is_some_and(|node| node.kind() == "comment")
+        })
+        .collect();
+
+    assert!(
+        comment_matches.len() >= 2,
+        "Expected at least 2 comment matches, got {}",
+        comment_matches.len()
+    );
+}
+
+#[test]
+fn test_matching_identical_siblings_same_parent() {
+    let source_a = r#"# First
+# Second
+key = "value"
+"#;
+    let source_b = r#"# First
+# Second
+key = "value"
+"#;
+
+    let tree_a = parse_toml(source_a);
+    let tree_b = parse_toml(source_b);
+
+    let matching = compute(&tree_a, &tree_b);
+
+    let mut nodes_a = Vec::new();
+    assign_node_ids(tree_a.root_node(), &mut nodes_a);
+
+    for (a_id, node) in nodes_a.iter().enumerate() {
+        assert!(
+            matching.is_matched_a(a_id),
+            "Node {} ({}) not matched",
+            a_id,
+            node.kind()
+        );
+    }
+}
+
+#[test]
+fn test_function_rename_with_similar_body() {
+    let source_a = r#"
+fn build_line<'a>(
+    row: &DiffRow,
+    theme: &'a Theme,
+) -> Line<'a> {
+    let mut spans = Vec::new();
+    spans.push(Span::styled("test", Style::default()));
+    Line::from(spans)
+}
+"#;
+    let source_b = r#"
+/// Build a content line for a row.
+fn build_content_line<'a>(
+    row: &ContentRow,
+    theme: &'a Theme,
+) -> Line<'a> {
+    let mut spans = Vec::new();
+    spans.push(Span::styled("test", Style::default()));
+    Line::from(spans)
+}
+"#;
+
+    let tree_a = parse_rust(source_a);
+    let tree_b = parse_rust(source_b);
+
+    let matching = compute(&tree_a, &tree_b);
+
+    let mut nodes_a = Vec::new();
+    let mut nodes_b = Vec::new();
+    assign_node_ids(tree_a.root_node(), &mut nodes_a);
+    assign_node_ids(tree_b.root_node(), &mut nodes_b);
+
+    let fn_a = nodes_a
+        .iter()
+        .position(|n| n.kind() == "function_item")
+        .expect("should have function_item in A");
+    let fn_b = nodes_b
+        .iter()
+        .position(|n| n.kind() == "function_item")
+        .expect("should have function_item in B");
+
+    assert!(
+        matching.get_match_a_to_b(fn_a) == Some(fn_b),
+        "Expected build_line to match build_content_line. fn_a={fn_a} matched to {:?}, fn_b={fn_b}",
+        matching.get_match_a_to_b(fn_a)
+    );
+}
+
+fn count_descendants_recursive(node: tree_sitter::Node<'_>) -> usize {
+    let mut count = 1;
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        count += count_descendants_recursive(child);
+    }
+    count
+}
+
+#[test]
+fn test_descendant_count_matches_recursive() {
+    let source = r#"
+fn foo() {
+    let x = 1;
+    if x > 0 {
+        println!("positive");
+    } else {
+        println!("non-positive");
+    }
+}
+
+fn bar(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+impl Point {
+    fn new(x: f64, y: f64) -> Self {
+        Self { x, y }
+    }
+}
+"#;
+    let tree = parse_rust(source);
+    let mut nodes = Vec::new();
+    assign_node_ids(tree.root_node(), &mut nodes);
+
+    let meta = compute_node_meta(&nodes);
+
+    for (i, node) in nodes.iter().enumerate() {
+        let expected = count_descendants_recursive(*node);
+        let actual = meta[i].descendants;
+        assert_eq!(
+            actual,
+            expected,
+            "Node {} ({:?}) at {:?}: expected {} descendants, got {}",
+            i,
+            node.kind(),
+            node.byte_range(),
+            expected,
+            actual
+        );
+    }
+}
+
+#[test]
+fn test_descendant_count_simple() {
+    let source = "fn foo() {}";
+    let tree = parse_rust(source);
+    let mut nodes = Vec::new();
+    assign_node_ids(tree.root_node(), &mut nodes);
+
+    let meta = compute_node_meta(&nodes);
+
+    assert_eq!(meta[0].descendants, nodes.len());
+
+    for (i, node) in nodes.iter().enumerate() {
+        if node.child_count() == 0 {
+            assert_eq!(
+                meta[i].descendants,
+                1,
+                "Leaf node {} ({:?}) should have 1 descendant",
+                i,
+                node.kind()
+            );
+        }
+    }
+}

--- a/packages/ast-merge/matcher/src/traverse.rs
+++ b/packages/ast-merge/matcher/src/traverse.rs
@@ -1,0 +1,67 @@
+use crate::matching::Map;
+
+#[derive(Clone, Copy)]
+pub struct SiblingNodes<'a, 'b> {
+    pub ids: &'b [usize],
+    pub nodes: &'b [tree_sitter::Node<'a>],
+}
+
+pub struct SubtreesInput<'a, 'b> {
+    pub node_a: Option<tree_sitter::Node<'a>>,
+    pub node_b: Option<tree_sitter::Node<'a>>,
+    pub nodes_a: &'b [tree_sitter::Node<'a>],
+    pub nodes_b: &'b [tree_sitter::Node<'a>],
+}
+
+pub fn node_height(node: tree_sitter::Node<'_>) -> usize {
+    if node.child_count() == 0 {
+        return 1;
+    }
+
+    let mut max_child_height = 0;
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        max_child_height = max_child_height.max(node_height(child));
+    }
+
+    max_child_height + 1
+}
+
+pub fn assign_node_ids<'a>(node: tree_sitter::Node<'a>, ids: &mut Vec<tree_sitter::Node<'a>>) {
+    ids.push(node);
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        assign_node_ids(child, ids);
+    }
+}
+
+pub fn subtrees(input: &SubtreesInput<'_, '_>, matching: &mut Map) {
+    let (Some(node_a), Some(node_b)) = (input.node_a, input.node_b) else {
+        return;
+    };
+
+    let a_id = input.nodes_a.iter().position(|n| n.id() == node_a.id());
+    let b_id = input.nodes_b.iter().position(|n| n.id() == node_b.id());
+
+    if let (Some(a_id), Some(b_id)) = (a_id, b_id) {
+        if !matching.is_matched_a(a_id) && !matching.is_matched_b(b_id) {
+            matching.add_match(a_id, b_id);
+        }
+    }
+
+    let mut cursor_a = node_a.walk();
+    let mut cursor_b = node_b.walk();
+    let children_b: Vec<_> = node_b.children(&mut cursor_b).collect();
+
+    for (child_a, child_b) in node_a.children(&mut cursor_a).zip(children_b) {
+        subtrees(
+            &SubtreesInput {
+                node_a: Some(child_a),
+                node_b: Some(child_b),
+                nodes_a: input.nodes_a,
+                nodes_b: input.nodes_b,
+            },
+            matching,
+        );
+    }
+}

--- a/packages/clone-detect/cli/Cargo.toml
+++ b/packages/clone-detect/cli/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "clone-cli"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "CLI for code clone detection"
+
+[[bin]]
+name = "clone"
+path = "src/main.rs"
+
+[dependencies]
+snafu.workspace = true
+clone-hash.workspace = true
+clone-scanner.workspace = true
+clone-detect.workspace = true
+clap = { workspace = true, features = ["derive"] }
+glob.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+toml = { workspace = true, features = ["parse", "serde"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+
+[lints]
+workspace = true

--- a/packages/clone-detect/cli/default.nix
+++ b/packages/clone-detect/cli/default.nix
@@ -1,0 +1,11 @@
+{ ix, lib, ... }:
+
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "clone";
+  packageName = "clone-cli";
+  meta = {
+    description = "Code clone and duplication detector (Type-1/2/3) over tree-sitter ASTs";
+    license = lib.licenses.mit;
+    mainProgram = "clone";
+  };
+}

--- a/packages/clone-detect/cli/package.nix
+++ b/packages/clone-detect/cli/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "clone";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/clone-detect/cli/src/badge.rs
+++ b/packages/clone-detect/cli/src/badge.rs
@@ -1,0 +1,76 @@
+use snafu::ResultExt as _;
+
+use crate::{BadgeWriteSnafu, RunError};
+
+const GREEN_THRESHOLD: f64 = 5.0;
+const YELLOW_THRESHOLD: f64 = 15.0;
+const ORANGE_THRESHOLD: f64 = 30.0;
+
+const COLOR_GREEN: &str = "#4c1";
+const COLOR_YELLOW: &str = "#dfb317";
+const COLOR_ORANGE: &str = "#fe7d37";
+const COLOR_RED: &str = "#e05d44";
+
+const CHAR_WIDTH: usize = 7;
+const PADDING: usize = 10;
+const SVG_SCALE: f64 = 10.0;
+const HALF: f64 = 2.0;
+
+pub fn write(path: &std::path::Path, pct: f64) -> Result<(), RunError> {
+    let label = "duplication";
+    let value = format!("{pct:.1}%");
+
+    let color = if pct < GREEN_THRESHOLD {
+        COLOR_GREEN
+    } else if pct < YELLOW_THRESHOLD {
+        COLOR_YELLOW
+    } else if pct < ORANGE_THRESHOLD {
+        COLOR_ORANGE
+    } else {
+        COLOR_RED
+    };
+
+    let label_width = CHAR_WIDTH * label.len() + PADDING;
+    let value_width = CHAR_WIDTH * value.len() + PADDING;
+    let total_width = label_width + value_width;
+    let label_x = label_width as f64 / HALF;
+    let value_x = label_width as f64 + value_width as f64 / HALF;
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "SVG coordinates are always small positive values"
+    )]
+    let label_x_10 = (label_x * SVG_SCALE) as u32;
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "SVG coordinates are always small positive values"
+    )]
+    let value_x_10 = (value_x * SVG_SCALE) as u32;
+
+    let svg = format!(
+        r##"<svg xmlns="http://www.w3.org/2000/svg" width="{total_width}" height="20" role="img" aria-label="{label}: {value}">
+  <title>{label}: {value}</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="{total_width}" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="{label_width}" height="20" fill="#555"/>
+    <rect x="{label_width}" width="{value_width}" height="20" fill="{color}"/>
+    <rect width="{total_width}" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+    <text aria-hidden="true" x="{label_x_10}" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">{label}</text>
+    <text x="{label_x_10}" y="140" transform="scale(.1)">{label}</text>
+    <text aria-hidden="true" x="{value_x_10}" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">{value}</text>
+    <text x="{value_x_10}" y="140" transform="scale(.1)">{value}</text>
+  </g>
+</svg>"##,
+    );
+
+    std::fs::write(path, svg).context(BadgeWriteSnafu { path })?;
+    Ok(())
+}

--- a/packages/clone-detect/cli/src/filter.rs
+++ b/packages/clone-detect/cli/src/filter.rs
@@ -1,0 +1,65 @@
+use clone_detect::{DetectionResult, DetectionStats, Kind};
+
+const MIN_FRAGMENTS: usize = 2;
+
+pub fn by_patterns(
+    result: DetectionResult,
+    patterns: &[glob::Pattern],
+) -> Result<DetectionResult, crate::RunError> {
+    if patterns.is_empty() {
+        return Ok(result);
+    }
+
+    let mut filtered_clones = Vec::new();
+
+    for mut clone in result.instances {
+        let mut fragments = Vec::with_capacity(clone.fragments.len());
+
+        for fragment in clone.fragments {
+            let Some(path_str) = fragment.file.to_str() else {
+                return Err(crate::RunError::NonUtf8Path {
+                    path: fragment.file,
+                });
+            };
+
+            if !patterns.iter().any(|pattern| pattern.matches(path_str)) {
+                fragments.push(fragment);
+            }
+        }
+
+        clone.fragments = fragments;
+
+        if clone.fragments.len() >= MIN_FRAGMENTS {
+            filtered_clones.push(clone);
+        }
+    }
+
+    let mut type1_groups = 0;
+    let mut type2_groups = 0;
+    let mut type3_groups = 0;
+    let mut sequence_groups = 0;
+
+    for clone in &filtered_clones {
+        match clone.clone_type {
+            Kind::Type1 => type1_groups += 1,
+            Kind::Type2 => type2_groups += 1,
+            Kind::Type3 { .. } => type3_groups += 1,
+            Kind::Sequence { .. } => sequence_groups += 1,
+        }
+    }
+
+    Ok(DetectionResult {
+        instances: filtered_clones,
+        stats: DetectionStats {
+            files_scanned: result.stats.files_scanned,
+            nodes_analyzed: result.stats.nodes_analyzed,
+            total_lines: result.stats.total_lines,
+            duplicated_lines: result.stats.duplicated_lines,
+            duplication_pct: result.stats.duplication_pct,
+            type1_groups,
+            type2_groups,
+            type3_groups,
+            sequence_groups,
+        },
+    })
+}

--- a/packages/clone-detect/cli/src/main.rs
+++ b/packages/clone-detect/cli/src/main.rs
@@ -1,0 +1,280 @@
+mod badge;
+mod filter;
+
+use std::{io::Write, path::PathBuf};
+
+use clap::Parser;
+use clone_detect::{DetectConfig, DetectionResult, instances};
+use clone_scanner::{Config, Scanner};
+use snafu::ResultExt as _;
+
+/// Config file name discovered by walking up from the scan target directory.
+const CONFIG_FILENAME: &str = "clone.toml";
+
+#[derive(Parser, Debug)]
+#[command(name = "clone", version, about)]
+struct Args {
+    #[arg(default_value = ".")]
+    path: PathBuf,
+
+    #[arg(long)]
+    type3: bool,
+
+    #[arg(long)]
+    threshold: Option<f64>,
+
+    #[arg(long)]
+    min_lines: Option<usize>,
+
+    #[arg(long)]
+    min_nodes: Option<usize>,
+
+    #[arg(long)]
+    pretty: bool,
+
+    #[arg(long, action = clap::ArgAction::Append)]
+    ignore: Vec<String>,
+
+    /// Enable statement-sequence clone detection
+    #[arg(long)]
+    sequences: bool,
+
+    /// Sliding window size for sequence detection
+    #[arg(long)]
+    window_size: Option<usize>,
+
+    /// Write an SVG duplication badge to this path
+    #[arg(long)]
+    badge: Option<PathBuf>,
+}
+
+/// Project-level configuration loaded from `clone.toml`.
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileConfig {
+    min_lines: Option<usize>,
+    min_nodes: Option<usize>,
+    threshold: Option<f64>,
+    type3: Option<bool>,
+    sequences: Option<bool>,
+    window_size: Option<usize>,
+    pretty: Option<bool>,
+    ignore: Option<Vec<String>>,
+}
+
+/// Resolved configuration after merging CLI flags over file config over defaults.
+struct ResolvedConfig {
+    min_lines: usize,
+    min_nodes: usize,
+    threshold: f64,
+    type3: bool,
+    sequences: bool,
+    window_size: usize,
+    pretty: bool,
+    ignore: Vec<String>,
+}
+
+const DEFAULT_MIN_LINES: usize = 5;
+const DEFAULT_MIN_NODES: usize = 10;
+const DEFAULT_THRESHOLD: f64 = 0.7;
+const DEFAULT_WINDOW_SIZE: usize = 3;
+
+#[derive(Debug, snafu::Snafu)]
+enum RunError {
+    #[snafu(display("scan failed"))]
+    Scan { source: clone_scanner::Error },
+
+    #[snafu(display("invalid glob pattern: {pattern}"))]
+    BadGlob {
+        pattern: String,
+        source: glob::PatternError,
+    },
+
+    #[snafu(display("failed to write JSON output"))]
+    JsonWrite { source: serde_json::Error },
+
+    #[snafu(display("failed to write to stdout"))]
+    StdoutWrite { source: std::io::Error },
+
+    #[snafu(display("failed to write badge to {}", path.display()))]
+    BadgeWrite {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("failed to read config file at {}", path.display()))]
+    ConfigRead {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("failed to parse config file at {}", path.display()))]
+    ConfigParse {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+
+    #[snafu(display("path is not valid UTF-8: {}", path.display()))]
+    NonUtf8Path { path: PathBuf },
+}
+
+/// Install a tracing subscriber reading filter directives from `RUST_LOG`
+/// (defaulting to `info`) and writing formatted events to stderr. Replaces the
+/// `ix` platform's `service_init::init`, which this standalone tool does not
+/// depend on.
+fn init_tracing() {
+    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt::layer().with_writer(std::io::stderr))
+        .init();
+}
+
+#[expect(
+    clippy::print_stderr,
+    reason = "CLI error output before/after tracing init"
+)]
+fn main() -> std::process::ExitCode {
+    init_tracing();
+
+    match run() {
+        Ok(has_clones) => {
+            if has_clones {
+                std::process::ExitCode::FAILURE
+            } else {
+                std::process::ExitCode::SUCCESS
+            }
+        }
+        Err(e) => {
+            eprintln!("Error: {e:?}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<bool, RunError> {
+    let args = Args::parse();
+
+    let file_config = find_config(&args.path)?;
+    let config = resolve_config(&args, file_config);
+
+    let scan_config = Config {
+        min_lines: config.min_lines,
+        min_nodes: config.min_nodes,
+        ..Config::default()
+    };
+
+    let scanner = Scanner::new(scan_config);
+    let scan = scanner.directory(&args.path).context(ScanSnafu)?;
+
+    let detect_config = DetectConfig {
+        enable_type3: config.type3,
+        type3_threshold: config.threshold,
+        enable_sequences: config.sequences,
+        sequence_window_size: config.window_size,
+    };
+
+    let mut result = instances(&scan, &detect_config);
+
+    if !config.ignore.is_empty() {
+        let patterns: Vec<glob::Pattern> = config
+            .ignore
+            .iter()
+            .map(|p| glob::Pattern::new(p).context(BadGlobSnafu { pattern: p.clone() }))
+            .collect::<Result<_, _>>()?;
+        result = filter::by_patterns(result, &patterns)?;
+    }
+
+    let has_clones = !result.instances.is_empty();
+
+    output_json(&result, config.pretty)?;
+
+    if let Some(badge_path) = &args.badge {
+        badge::write(badge_path, result.stats.duplication_pct)?;
+    }
+
+    Ok(has_clones)
+}
+
+/// Walk up from `start` looking for `clone.toml`. Returns `None` if not found.
+fn find_config(start: &std::path::Path) -> Result<Option<FileConfig>, RunError> {
+    let start = std::fs::canonicalize(start).unwrap_or_else(|_| start.to_path_buf());
+
+    let mut dir = if start.is_file() {
+        start.parent().map(std::path::Path::to_path_buf)
+    } else {
+        Some(start)
+    };
+
+    while let Some(d) = dir {
+        let candidate = d.join(CONFIG_FILENAME);
+        if candidate.is_file() {
+            tracing::debug!(?candidate, "found clone config");
+            let content = std::fs::read_to_string(&candidate)
+                .context(ConfigReadSnafu { path: &candidate })?;
+            let parsed: FileConfig =
+                toml::from_str(&content).context(ConfigParseSnafu { path: &candidate })?;
+            return Ok(Some(parsed));
+        }
+        dir = d.parent().map(std::path::Path::to_path_buf);
+    }
+
+    Ok(None)
+}
+
+/// Merge CLI args over file config over hardcoded defaults.
+///
+/// Priority: CLI flag > clone.toml > default.
+/// Boolean flags use OR: if either CLI or config enables it, it's on.
+/// Ignore lists are combined (config + CLI).
+fn resolve_config(args: &Args, file: Option<FileConfig>) -> ResolvedConfig {
+    let file = file.unwrap_or(FileConfig {
+        min_lines: None,
+        min_nodes: None,
+        threshold: None,
+        type3: None,
+        sequences: None,
+        window_size: None,
+        pretty: None,
+        ignore: None,
+    });
+
+    let mut ignore = file.ignore.unwrap_or_default();
+    ignore.extend(args.ignore.iter().cloned());
+
+    ResolvedConfig {
+        min_lines: args
+            .min_lines
+            .or(file.min_lines)
+            .unwrap_or(DEFAULT_MIN_LINES),
+        min_nodes: args
+            .min_nodes
+            .or(file.min_nodes)
+            .unwrap_or(DEFAULT_MIN_NODES),
+        threshold: args
+            .threshold
+            .or(file.threshold)
+            .unwrap_or(DEFAULT_THRESHOLD),
+        type3: args.type3 || file.type3.unwrap_or(false),
+        sequences: args.sequences || file.sequences.unwrap_or(false),
+        window_size: args
+            .window_size
+            .or(file.window_size)
+            .unwrap_or(DEFAULT_WINDOW_SIZE),
+        pretty: args.pretty || file.pretty.unwrap_or(false),
+        ignore,
+    }
+}
+
+fn output_json(result: &DetectionResult, pretty: bool) -> Result<(), RunError> {
+    let mut stdout = std::io::stdout().lock();
+    if pretty {
+        serde_json::to_writer_pretty(&mut stdout, result).context(JsonWriteSnafu)?;
+    } else {
+        serde_json::to_writer(&mut stdout, result).context(JsonWriteSnafu)?;
+    }
+    writeln!(stdout).context(StdoutWriteSnafu)?;
+    Ok(())
+}

--- a/packages/clone-detect/detect/Cargo.toml
+++ b/packages/clone-detect/detect/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "clone-detect"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Clone detection algorithms (Type-1, Type-2, Type-3)"
+
+[dependencies]
+clone-hash.workspace = true
+clone-scanner.workspace = true
+ast-merge-ast.workspace = true
+ast-merge-langs.workspace = true
+ast-merge-matcher.workspace = true
+rayon.workspace = true
+rustc-hash.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/packages/clone-detect/detect/package.nix
+++ b/packages/clone-detect/detect/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "clone-detect";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/clone-detect/detect/src/detector.rs
+++ b/packages/clone-detect/detect/src/detector.rs
@@ -1,0 +1,226 @@
+use std::{collections::BTreeSet, path::PathBuf};
+
+use clone_scanner::{Location, Output};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{
+    sequences::sequence_instances,
+    type3::find,
+    types::{CloneGroup, DetectConfig, DetectionResult, DetectionStats, Fragment, Kind},
+};
+
+#[must_use]
+pub fn instances(scan: &Output, config: &DetectConfig) -> DetectionResult {
+    let mut instances = Vec::new();
+    let mut seen_type1: FxHashSet<u64> = FxHashSet::default();
+
+    for candidate in scan.index.type1_candidates() {
+        if candidate.locations.len() < 2 {
+            continue;
+        }
+
+        if !seen_type1.insert(*candidate.hash) {
+            continue;
+        }
+
+        let fragments = locations_to_fragments(candidate.locations, scan);
+        if fragments.len() >= 2 {
+            instances.push(CloneGroup {
+                clone_type: Kind::Type1,
+                fragments,
+            });
+        }
+    }
+
+    for candidate in scan.index.type2_candidates() {
+        if candidate.locations.len() < 2 {
+            continue;
+        }
+
+        let all_type1 = candidate.locations.iter().all(|loc| {
+            let node = &scan
+                .files
+                .get(loc.file_id)
+                .and_then(|f| f.nodes.get(loc.node_idx));
+            node.is_some_and(|n| seen_type1.contains(&n.content_hash))
+        });
+
+        if all_type1 {
+            continue;
+        }
+
+        let fragments = locations_to_fragments(candidate.locations, scan);
+        if fragments.len() >= 2 {
+            instances.push(CloneGroup {
+                clone_type: Kind::Type2,
+                fragments,
+            });
+        }
+    }
+
+    let type3_groups = if config.enable_type3 {
+        find(scan, config.type3_threshold)
+    } else {
+        Vec::new()
+    };
+
+    let sequence_groups = if config.enable_sequences {
+        sequence_instances(scan, config.sequence_window_size)
+    } else {
+        Vec::new()
+    };
+
+    let type3_count = type3_groups.len();
+    let sequence_count = sequence_groups.len();
+    instances.extend(type3_groups);
+    instances.extend(sequence_groups);
+
+    dedup_subsumed(&mut instances);
+
+    let type1_count = instances
+        .iter()
+        .filter(|c| matches!(c.clone_type, Kind::Type1))
+        .count();
+    let type2_count = instances
+        .iter()
+        .filter(|c| matches!(c.clone_type, Kind::Type2))
+        .count();
+
+    let total_lines: usize = scan.files.iter().map(|f| f.source.lines().count()).sum();
+
+    let duplicated_lines = compute_duplicated_lines(&instances);
+
+    const PERCENT: f64 = 100.0;
+
+    let duplication_pct = if total_lines == 0 {
+        0.0
+    } else {
+        (duplicated_lines as f64 / total_lines as f64) * PERCENT
+    };
+
+    DetectionResult {
+        instances,
+        stats: DetectionStats {
+            files_scanned: scan.files.len(),
+            nodes_analyzed: scan.files.iter().map(|f| f.nodes.len()).sum(),
+            total_lines,
+            duplicated_lines,
+            duplication_pct,
+            type1_groups: type1_count,
+            type2_groups: type2_count,
+            type3_groups: type3_count,
+            sequence_groups: sequence_count,
+        },
+    }
+}
+
+fn locations_to_fragments(locations: &[Location], scan: &Output) -> Vec<Fragment> {
+    locations
+        .iter()
+        .filter_map(|loc| {
+            let file = scan.files.get(loc.file_id)?;
+            let node = file.nodes.get(loc.node_idx)?;
+            Some(Fragment::from_node(file, node))
+        })
+        .collect()
+}
+
+/// Remove clone groups that are fully subsumed by a larger group.
+///
+/// A group B is subsumed by group A if every fragment in B is byte-range
+/// contained within some fragment of A (same file). This eliminates
+/// duplicate reports caused by nested AST nodes (e.g., a `function_item`
+/// and its child `block` both appearing as separate clone groups).
+fn dedup_subsumed(groups: &mut Vec<CloneGroup>) {
+    let n = groups.len();
+    if n < 2 {
+        return;
+    }
+
+    // Sort groups by total byte span (largest first) so that outer groups
+    // are checked as potential containers before inner groups.
+    groups.sort_by_key(|g| std::cmp::Reverse(total_byte_span(g)));
+
+    let mut subsumed = vec![false; n];
+
+    for i in 0..n {
+        let Some(&already) = subsumed.get(i) else {
+            break;
+        };
+        if already {
+            continue;
+        }
+
+        let Some(outer) = groups.get(i) else {
+            break;
+        };
+
+        for j in (i + 1)..n {
+            let Some(&already_j) = subsumed.get(j) else {
+                break;
+            };
+            if already_j {
+                continue;
+            }
+
+            let Some(inner) = groups.get(j) else {
+                break;
+            };
+
+            if is_subsumed_by(inner, outer) {
+                if let Some(flag) = subsumed.get_mut(j) {
+                    *flag = true;
+                }
+            }
+        }
+    }
+
+    let kept: Vec<CloneGroup> = groups
+        .drain(..)
+        .zip(subsumed)
+        .filter(|(_, is_subsumed)| !is_subsumed)
+        .map(|(group, _)| group)
+        .collect();
+    *groups = kept;
+}
+
+/// Check if every fragment in `inner` is byte-range contained within
+/// some fragment of `outer` from the same file.
+fn is_subsumed_by(inner: &CloneGroup, outer: &CloneGroup) -> bool {
+    inner.fragments.iter().all(|inner_frag| {
+        outer.fragments.iter().any(|outer_frag| {
+            outer_frag.file == inner_frag.file
+                && outer_frag.byte_range.start <= inner_frag.byte_range.start
+                && outer_frag.byte_range.end >= inner_frag.byte_range.end
+        })
+    })
+}
+
+/// Count deduplicated lines involved in clone fragments.
+///
+/// For each clone group, only count duplicated instances (all fragments except
+/// one "original"). Lines are deduplicated across groups per file using a
+/// set of line numbers.
+fn compute_duplicated_lines(instances: &[CloneGroup]) -> usize {
+    let mut dup_lines_per_file: FxHashMap<&PathBuf, BTreeSet<usize>> = FxHashMap::default();
+
+    for group in instances {
+        // Skip the first fragment (the "original"); remaining are duplicates.
+        for frag in group.fragments.iter().skip(1) {
+            let lines = dup_lines_per_file.entry(&frag.file).or_default();
+            for line in frag.lines.start..=frag.lines.end {
+                lines.insert(line);
+            }
+        }
+    }
+
+    dup_lines_per_file.values().map(BTreeSet::len).sum()
+}
+
+fn total_byte_span(group: &CloneGroup) -> usize {
+    group
+        .fragments
+        .iter()
+        .map(|f| f.byte_range.end.saturating_sub(f.byte_range.start))
+        .sum()
+}

--- a/packages/clone-detect/detect/src/jaccard.rs
+++ b/packages/clone-detect/detect/src/jaccard.rs
@@ -1,0 +1,111 @@
+/// A run of consecutive equal elements in a sorted slice.
+struct Run {
+    value: u64,
+    count: u32,
+}
+
+/// Compute exact multiset Jaccard similarity from pre-sorted feature slices.
+///
+/// Uses a two-pointer merge — zero allocation, cache-friendly O(n+m).
+#[must_use]
+pub fn multiset_sorted(a: &[u64], b: &[u64]) -> f64 {
+    debug_assert!(a.is_sorted(), "multiset_sorted: a must be sorted");
+    debug_assert!(b.is_sorted(), "multiset_sorted: b must be sorted");
+
+    if a.is_empty() && b.is_empty() {
+        return 0.0;
+    }
+
+    let mut intersection = 0u32;
+    let mut union = 0u32;
+    let mut i = 0;
+    let mut j = 0;
+
+    while i < a.len() && j < b.len() {
+        let run_a = run_length(a, i);
+        let run_b = run_length(b, j);
+
+        match run_a.value.cmp(&run_b.value) {
+            std::cmp::Ordering::Less => {
+                union += run_a.count;
+                i += run_a.count as usize;
+            }
+            std::cmp::Ordering::Greater => {
+                union += run_b.count;
+                j += run_b.count as usize;
+            }
+            std::cmp::Ordering::Equal => {
+                intersection += run_a.count.min(run_b.count);
+                union += run_a.count.max(run_b.count);
+                i += run_a.count as usize;
+                j += run_b.count as usize;
+            }
+        }
+    }
+
+    // Remaining elements in whichever slice is not exhausted
+    while i < a.len() {
+        let run = run_length(a, i);
+        union += run.count;
+        i += run.count as usize;
+    }
+    while j < b.len() {
+        let run = run_length(b, j);
+        union += run.count;
+        j += run.count as usize;
+    }
+
+    if union == 0 {
+        return 0.0;
+    }
+
+    f64::from(intersection) / f64::from(union)
+}
+
+/// Count consecutive equal elements starting at `start` in a sorted slice.
+///
+/// Callers guarantee `start < slice.len()` (guarded by the `while i < a.len()`
+/// loop condition in `multiset_sorted`).
+#[inline]
+fn run_length(slice: &[u64], start: usize) -> Run {
+    let Some(&value) = slice.get(start) else {
+        return Run { value: 0, count: 0 };
+    };
+    let mut count = 1u32;
+    while let Some(&next) = slice.get(start + count as usize) {
+        if next != value {
+            break;
+        }
+        count += 1;
+    }
+    Run { value, count }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical() {
+        let sim = multiset_sorted(&[1, 2, 3], &[1, 2, 3]);
+        assert!((sim - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn disjoint() {
+        let sim = multiset_sorted(&[1, 2, 3], &[4, 5, 6]);
+        assert!(sim.abs() < 0.001);
+    }
+
+    #[test]
+    fn with_duplicates() {
+        let sim = multiset_sorted(&[1, 1, 2], &[1, 2, 2]);
+        assert!((sim - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn empty() {
+        assert!(multiset_sorted(&[], &[]).abs() < 0.001);
+        assert!(multiset_sorted(&[1, 2], &[]).abs() < 0.001);
+    }
+}

--- a/packages/clone-detect/detect/src/lib.rs
+++ b/packages/clone-detect/detect/src/lib.rs
@@ -1,0 +1,26 @@
+mod detector;
+pub mod jaccard;
+pub mod lsh;
+pub mod sequences;
+mod type3;
+mod types;
+
+pub use detector::instances;
+pub use type3::compute_similarity;
+pub use types::{
+    ByteRange, CloneGroup, DetectConfig, DetectionResult, DetectionStats, Fragment, Kind, LineRange,
+};
+
+#[cfg(test)]
+mod tests {
+    mod config;
+    mod detection;
+    mod helpers;
+    mod multilang;
+    mod pipeline;
+    mod serialization;
+    mod similarity;
+    mod stats;
+    mod structural;
+    mod type3;
+}

--- a/packages/clone-detect/detect/src/lsh.rs
+++ b/packages/clone-detect/detect/src/lsh.rs
@@ -1,0 +1,270 @@
+use std::hash::{Hash, Hasher};
+
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet, FxHasher};
+
+/// Number of hash functions in the MinHash signature.
+pub const NUM_HASHES: usize = 64;
+
+/// Number of bands for LSH banding.
+const NUM_BANDS: usize = 16;
+
+/// Rows per band = NUM_HASHES / NUM_BANDS.
+const ROWS_PER_BAND: usize = NUM_HASHES / NUM_BANDS;
+
+/// Maximum bucket size before we skip a bucket (too noisy to be useful).
+const MAX_BUCKET_SIZE: usize = 200;
+
+/// Seed generation multiplier (SplitMix64 gamma constant).
+const SEED_MUL: u64 = 0x517c_c1b7_2722_0a95;
+
+/// Seed generation addend (SplitMix64 increment).
+const SEED_ADD: u64 = 0x6c62_272e_07bb_0142;
+
+/// Pre-generated seeds for MinHash hash functions.
+/// Computed at compile time via const fn; indexing is safe because
+/// `i` is bounded by `NUM_HASHES` which equals the array length.
+#[expect(
+    clippy::indexing_slicing,
+    reason = "const fn with i < NUM_HASHES = array len"
+)]
+const HASH_SEEDS: [u64; NUM_HASHES] = {
+    let mut seeds = [0u64; NUM_HASHES];
+    let mut i = 0;
+    while i < NUM_HASHES {
+        seeds[i] = (i as u64).wrapping_mul(SEED_MUL).wrapping_add(SEED_ADD);
+        i += 1;
+    }
+    seeds
+};
+
+/// Compute a MinHash signature from a set of features.
+#[must_use]
+pub fn minhash_signature(features: &[u64]) -> [u64; NUM_HASHES] {
+    let mut signature = [u64::MAX; NUM_HASHES];
+
+    for &feature in features {
+        for (sig, seed) in signature.iter_mut().zip(HASH_SEEDS.iter()) {
+            let h = mix(feature, *seed);
+            *sig = (*sig).min(h);
+        }
+    }
+
+    signature
+}
+
+/// SplitMix64 finalizer constant (first multiply).
+const MIX_MUL_1: u64 = 0xff51_afd7_ed55_8ccd;
+
+/// SplitMix64 finalizer constant (second multiply).
+const MIX_MUL_2: u64 = 0xc4ce_b9fe_1a85_ec53;
+
+/// SplitMix64 shift width.
+const MIX_SHIFT: u32 = 32;
+
+/// Mix a value with a seed using splitmix64 finalizer.
+#[inline]
+fn mix(value: u64, seed: u64) -> u64 {
+    let mut h = value ^ seed;
+    h = h.wrapping_mul(MIX_MUL_1);
+    h ^= h >> MIX_SHIFT;
+    h = h.wrapping_mul(MIX_MUL_2);
+    h ^= h >> MIX_SHIFT;
+    h
+}
+
+/// A node location: file_id + node_idx.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NodeLocation {
+    pub file_id: usize,
+    pub node_idx: usize,
+}
+
+/// A node location paired with its MinHash signature.
+pub struct LshEntry {
+    pub location: NodeLocation,
+    pub signature: [u64; NUM_HASHES],
+}
+
+/// An ordered pair of node locations (canonical: first <= second).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NodePair {
+    pub first: NodeLocation,
+    pub second: NodeLocation,
+}
+
+/// LSH index for efficient candidate-pair generation.
+pub struct LshIndex {
+    bands: Vec<FxHashMap<u64, Vec<NodeLocation>>>,
+    signatures: FxHashMap<NodeLocation, [u64; NUM_HASHES]>,
+}
+
+impl LshIndex {
+    /// Build an LSH index from nodes with their MinHash signatures.
+    #[must_use]
+    pub fn build(entries: &[LshEntry]) -> Self {
+        let mut bands: Vec<FxHashMap<u64, Vec<NodeLocation>>> = Vec::with_capacity(NUM_BANDS);
+        for _ in 0..NUM_BANDS {
+            bands.push(FxHashMap::default());
+        }
+
+        let mut signatures = FxHashMap::with_capacity_and_hasher(entries.len(), FxBuildHasher);
+
+        for entry in entries {
+            signatures.insert(entry.location, entry.signature);
+            for (band_idx, band_map) in bands.iter_mut().enumerate() {
+                let band_hash = hash_band(&entry.signature, band_idx);
+                band_map.entry(band_hash).or_default().push(entry.location);
+            }
+        }
+
+        Self { bands, signatures }
+    }
+
+    /// Return all candidate pairs that hash to the same bucket in at least one band.
+    #[must_use]
+    pub fn candidate_pairs(&self) -> Vec<NodePair> {
+        let mut seen: FxHashSet<NodePair> = FxHashSet::default();
+        let mut pairs = Vec::new();
+
+        for band_map in &self.bands {
+            for bucket in band_map.values() {
+                if bucket.len() < 2 || bucket.len() > MAX_BUCKET_SIZE {
+                    continue;
+                }
+                for (i, &a) in bucket.iter().enumerate() {
+                    for &b in bucket.iter().skip(i + 1) {
+                        let key = canonical_pair(a, b);
+                        if seen.insert(key) {
+                            pairs.push(key);
+                        }
+                    }
+                }
+            }
+        }
+
+        pairs
+    }
+
+    /// Look up the MinHash signature for a node location.
+    #[must_use]
+    pub fn signature(&self, loc: &NodeLocation) -> Option<&[u64; NUM_HASHES]> {
+        self.signatures.get(loc)
+    }
+}
+
+/// Estimate Jaccard similarity from MinHash signatures.
+/// Counts matching slots: `matches / NUM_HASHES`. Zero allocation.
+#[must_use]
+pub fn estimated_jaccard(sig_a: &[u64; NUM_HASHES], sig_b: &[u64; NUM_HASHES]) -> f64 {
+    let matches = sig_a
+        .iter()
+        .zip(sig_b.iter())
+        .filter(|(a, b)| a == b)
+        .count();
+    matches as f64 / NUM_HASHES as f64
+}
+
+fn canonical_pair(a: NodeLocation, b: NodeLocation) -> NodePair {
+    if a.file_id < b.file_id || (a.file_id == b.file_id && a.node_idx <= b.node_idx) {
+        NodePair {
+            first: a,
+            second: b,
+        }
+    } else {
+        NodePair {
+            first: b,
+            second: a,
+        }
+    }
+}
+
+fn hash_band(signature: &[u64; NUM_HASHES], band_idx: usize) -> u64 {
+    let start = band_idx * ROWS_PER_BAND;
+    let mut hasher = FxHasher::default();
+    for val in signature.iter().skip(start).take(ROWS_PER_BAND) {
+        val.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn minhash_identical_sets_produce_identical_signatures() {
+        let a = vec![1, 2, 3, 4, 5];
+        let sig_a = minhash_signature(&a);
+        let sig_b = minhash_signature(&a);
+        assert_eq!(sig_a, sig_b);
+    }
+
+    #[test]
+    fn minhash_different_sets_produce_different_signatures() {
+        let sig_a = minhash_signature(&[1, 2, 3]);
+        let sig_b = minhash_signature(&[100, 200, 300]);
+        assert_ne!(sig_a, sig_b);
+    }
+
+    #[test]
+    fn finds_similar_candidates() {
+        let features_a = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let features_b = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 11]; // 90% overlap
+        let features_c = vec![100, 200, 300, 400, 500, 600, 700, 800, 900, 1000];
+
+        let sig_a = minhash_signature(&features_a);
+        let sig_b = minhash_signature(&features_b);
+        let sig_c = minhash_signature(&features_c);
+
+        let loc_a = NodeLocation {
+            file_id: 0,
+            node_idx: 0,
+        };
+        let loc_b = NodeLocation {
+            file_id: 1,
+            node_idx: 0,
+        };
+        let loc_c = NodeLocation {
+            file_id: 2,
+            node_idx: 0,
+        };
+
+        let entries = vec![
+            LshEntry {
+                location: loc_a,
+                signature: sig_a,
+            },
+            LshEntry {
+                location: loc_b,
+                signature: sig_b,
+            },
+            LshEntry {
+                location: loc_c,
+                signature: sig_c,
+            },
+        ];
+        let index = LshIndex::build(&entries);
+        let pairs = index.candidate_pairs();
+
+        let has_ab = pairs.contains(&canonical_pair(loc_a, loc_b));
+        assert!(has_ab, "Similar items A and B should be candidates");
+
+        let has_ac = pairs.contains(&canonical_pair(loc_a, loc_c));
+        assert!(!has_ac, "Dissimilar items A and C should not be candidates");
+    }
+
+    #[test]
+    fn estimated_jaccard_identical() {
+        let sig = minhash_signature(&[1, 2, 3]);
+        let est = estimated_jaccard(&sig, &sig);
+        assert!((est - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn estimated_jaccard_different() {
+        let sig_a = minhash_signature(&[1, 2, 3]);
+        let sig_b = minhash_signature(&[100, 200, 300]);
+        let est = estimated_jaccard(&sig_a, &sig_b);
+        assert!(est < 0.2, "Disjoint sets should have low estimated Jaccard");
+    }
+}

--- a/packages/clone-detect/detect/src/sequences.rs
+++ b/packages/clone-detect/detect/src/sequences.rs
@@ -1,0 +1,230 @@
+use std::hash::{Hash, Hasher};
+
+use clone_scanner::Output;
+use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
+
+use crate::types::{ByteRange, CloneGroup, Fragment, Kind, LineRange};
+
+/// Default sliding window size for statement-sequence detection.
+pub const DEFAULT_WINDOW_SIZE: usize = 3;
+
+/// Minimum useful window size.
+const MIN_WINDOW_SIZE: usize = 2;
+
+/// A location within a statement sequence.
+#[derive(Debug, Clone)]
+struct SeqLoc {
+    file_id: usize,
+    node_idx: usize,
+    start: usize,
+    end: usize,
+}
+
+/// Identity key for a sequence location used in deduplication.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct SeqKey {
+    file_id: usize,
+    node_idx: usize,
+    position: usize,
+}
+
+/// A pair of matched sequence locations.
+struct SeqLocPair {
+    first: SeqLoc,
+    second: SeqLoc,
+}
+
+/// Detect duplicated statement sequences using sliding-window k-grams.
+#[must_use]
+pub fn sequence_instances(scan: &Output, window_size: usize) -> Vec<CloneGroup> {
+    let window_size = window_size.max(MIN_WINDOW_SIZE);
+    let mut kgram_index: FxHashMap<u64, Vec<SeqLoc>> = FxHashMap::default();
+
+    for (file_id, file) in scan.files.iter().enumerate() {
+        for (node_idx, node) in file.nodes.iter().enumerate() {
+            let child_hashes: Vec<u64> = node.children.iter().map(|c| c.normalized_hash).collect();
+
+            if child_hashes.len() < window_size {
+                continue;
+            }
+
+            for start in 0..=child_hashes.len() - window_size {
+                let end = start + window_size;
+                let kgram_hash = hash_kgram(&child_hashes, start, end);
+
+                kgram_index.entry(kgram_hash).or_default().push(SeqLoc {
+                    file_id,
+                    node_idx,
+                    start,
+                    end,
+                });
+            }
+        }
+    }
+
+    let mut groups = Vec::new();
+    let mut used: FxHashSet<SeqKey> = FxHashSet::default();
+
+    for locations in kgram_index.values() {
+        if locations.len() < 2 {
+            continue;
+        }
+
+        for (i, loc_a) in locations.iter().enumerate() {
+            for loc_b in locations.iter().skip(i + 1) {
+                // Skip same-node overlapping sequences
+                if loc_a.file_id == loc_b.file_id
+                    && loc_a.node_idx == loc_b.node_idx
+                    && ranges_overlap(loc_a.start..loc_a.end, loc_b.start..loc_b.end)
+                {
+                    continue;
+                }
+
+                let key_a = SeqKey {
+                    file_id: loc_a.file_id,
+                    node_idx: loc_a.node_idx,
+                    position: loc_a.start,
+                };
+                let key_b = SeqKey {
+                    file_id: loc_b.file_id,
+                    node_idx: loc_b.node_idx,
+                    position: loc_b.start,
+                };
+                if used.contains(&key_a) || used.contains(&key_b) {
+                    continue;
+                }
+
+                let extended = extend_match(scan, loc_a, loc_b);
+
+                for pos in extended.first.start..extended.first.end {
+                    used.insert(SeqKey {
+                        file_id: extended.first.file_id,
+                        node_idx: extended.first.node_idx,
+                        position: pos,
+                    });
+                }
+                for pos in extended.second.start..extended.second.end {
+                    used.insert(SeqKey {
+                        file_id: extended.second.file_id,
+                        node_idx: extended.second.node_idx,
+                        position: pos,
+                    });
+                }
+
+                let frag_a = sequence_to_fragment(scan, &extended.first);
+                let frag_b = sequence_to_fragment(scan, &extended.second);
+
+                if let (Some(fa), Some(fb)) = (frag_a, frag_b) {
+                    groups.push(CloneGroup {
+                        clone_type: Kind::Sequence {
+                            statements: extended.first.end - extended.first.start,
+                        },
+                        fragments: vec![fa, fb],
+                    });
+                }
+            }
+        }
+    }
+
+    groups
+}
+
+/// Extend a matching window in both directions as long as child hashes match.
+fn extend_match(scan: &Output, loc_a: &SeqLoc, loc_b: &SeqLoc) -> SeqLocPair {
+    let node_a = scan
+        .files
+        .get(loc_a.file_id)
+        .and_then(|f| f.nodes.get(loc_a.node_idx));
+    let node_b = scan
+        .files
+        .get(loc_b.file_id)
+        .and_then(|f| f.nodes.get(loc_b.node_idx));
+
+    debug_assert!(
+        node_a.is_some(),
+        "extend_match: file_id={} node_idx={} out of bounds",
+        loc_a.file_id,
+        loc_a.node_idx,
+    );
+    debug_assert!(
+        node_b.is_some(),
+        "extend_match: file_id={} node_idx={} out of bounds",
+        loc_b.file_id,
+        loc_b.node_idx,
+    );
+
+    let (Some(node_a), Some(node_b)) = (node_a, node_b) else {
+        return SeqLocPair {
+            first: loc_a.clone(),
+            second: loc_b.clone(),
+        };
+    };
+
+    let children_a: Vec<u64> = node_a.children.iter().map(|c| c.normalized_hash).collect();
+    let children_b: Vec<u64> = node_b.children.iter().map(|c| c.normalized_hash).collect();
+
+    let mut start_a = loc_a.start;
+    let mut start_b = loc_b.start;
+    let mut end_a = loc_a.end;
+    let mut end_b = loc_b.end;
+
+    // Extend backward
+    while start_a > 0 && start_b > 0 && children_a.get(start_a - 1) == children_b.get(start_b - 1) {
+        start_a -= 1;
+        start_b -= 1;
+    }
+
+    // Extend forward
+    while children_a.get(end_a).is_some() && children_a.get(end_a) == children_b.get(end_b) {
+        end_a += 1;
+        end_b += 1;
+    }
+
+    SeqLocPair {
+        first: SeqLoc {
+            file_id: loc_a.file_id,
+            node_idx: loc_a.node_idx,
+            start: start_a,
+            end: end_a,
+        },
+        second: SeqLoc {
+            file_id: loc_b.file_id,
+            node_idx: loc_b.node_idx,
+            start: start_b,
+            end: end_b,
+        },
+    }
+}
+
+fn sequence_to_fragment(scan: &Output, loc: &SeqLoc) -> Option<Fragment> {
+    let file = scan.files.get(loc.file_id)?;
+    let node = file.nodes.get(loc.node_idx)?;
+
+    let first_child = node.children.get(loc.start)?;
+    let last_child = node.children.get(loc.end.checked_sub(1)?)?;
+
+    Some(Fragment {
+        file: file.path.clone(),
+        byte_range: ByteRange {
+            start: first_child.byte_range.start,
+            end: last_child.byte_range.end,
+        },
+        lines: LineRange {
+            start: first_child.start_line,
+            end: last_child.end_line,
+        },
+        kind: node.kind.to_owned(),
+    })
+}
+
+fn hash_kgram(hashes: &[u64], start: usize, end: usize) -> u64 {
+    let mut hasher = FxHasher::default();
+    for h in hashes.iter().skip(start).take(end - start) {
+        h.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+fn ranges_overlap(a: std::ops::Range<usize>, b: std::ops::Range<usize>) -> bool {
+    a.start < b.end && b.start < a.end
+}

--- a/packages/clone-detect/detect/src/tests/config.rs
+++ b/packages/clone-detect/detect/src/tests/config.rs
@@ -1,0 +1,20 @@
+use crate::DetectConfig;
+
+#[test]
+fn default_cfg() {
+    let config = DetectConfig::default();
+    assert!(!config.enable_type3);
+    assert!((config.type3_threshold - 0.7).abs() < 0.001);
+    assert!(!config.enable_sequences);
+}
+
+#[test]
+fn custom_cfg() {
+    let config = DetectConfig {
+        enable_type3: true,
+        type3_threshold: 0.8,
+        ..DetectConfig::default()
+    };
+    assert!(config.enable_type3);
+    assert!((config.type3_threshold - 0.8).abs() < 0.001);
+}

--- a/packages/clone-detect/detect/src/tests/detection.rs
+++ b/packages/clone-detect/detect/src/tests/detection.rs
@@ -1,0 +1,196 @@
+use tempfile::TempDir;
+
+use super::helpers::{create_temp_file, scan_and_run};
+use crate::{DetectConfig, Kind};
+
+#[test]
+fn type1_exact_duplicates() {
+    let dir = TempDir::new().unwrap();
+
+    let code = r"
+fn calculate_sum(a: i32, b: i32) -> i32 {
+    let result = a + b;
+    result
+}
+";
+    create_temp_file(&dir, "file1.rs", code);
+    create_temp_file(&dir, "file2.rs", code);
+
+    let result = scan_and_run(&dir, &DetectConfig::default());
+
+    assert!(
+        result.stats.type1_groups > 0,
+        "Should detect Type-1 instances"
+    );
+    assert!(
+        result
+            .instances
+            .iter()
+            .any(|c| matches!(c.clone_type, Kind::Type1)),
+        "Should have Type-1 clone groups"
+    );
+}
+
+#[test]
+fn type1_same_file_duplicates() {
+    let dir = TempDir::new().unwrap();
+
+    let code = r#"
+fn calculate(a: i32, b: i32) -> i32 {
+    let result = a + b;
+    result
+}
+
+fn other_stuff() {
+    println!("hello");
+}
+
+fn calculate_again(a: i32, b: i32) -> i32 {
+    let result = a + b;
+    result
+}
+"#;
+    create_temp_file(&dir, "file.rs", code);
+
+    let result = scan_and_run(&dir, &DetectConfig::default());
+
+    assert!(result.stats.type1_groups > 0 || result.stats.type2_groups > 0);
+}
+
+#[test]
+fn type2_renamed_identifiers() {
+    let dir = TempDir::new().unwrap();
+
+    let code1 = r"
+fn calculate_sum(a: i32, b: i32) -> i32 {
+    let result = a + b;
+    result
+}
+";
+    let code2 = r"
+fn compute_total(x: i32, y: i32) -> i32 {
+    let output = x + y;
+    output
+}
+";
+    create_temp_file(&dir, "file1.rs", code1);
+    create_temp_file(&dir, "file2.rs", code2);
+
+    let result = scan_and_run(&dir, &DetectConfig::default());
+
+    let has_clones = result.stats.type1_groups > 0 || result.stats.type2_groups > 0;
+    assert!(
+        has_clones,
+        "Should detect Type-2 instances with renamed identifiers"
+    );
+}
+
+#[test]
+fn no_clones_unique_files() {
+    let dir = TempDir::new().unwrap();
+
+    let code1 = r#"
+fn function_one() {
+    println!("This is function one");
+}
+"#;
+    let code2 = r#"
+fn function_two() {
+    let x = 42;
+    let y = x * 2;
+    println!("Result: {}", y);
+}
+"#;
+    let code3 = r"
+struct MyStruct {
+    field: i32,
+}
+impl MyStruct {
+    fn new(value: i32) -> Self {
+        Self { field: value }
+    }
+}
+";
+    create_temp_file(&dir, "file1.rs", code1);
+    create_temp_file(&dir, "file2.rs", code2);
+    create_temp_file(&dir, "file3.rs", code3);
+
+    let result = scan_and_run(&dir, &DetectConfig::default());
+
+    assert_eq!(result.stats.type1_groups, 0);
+}
+
+#[test]
+fn empty_scan() {
+    let scan = clone_scanner::Output {
+        files: vec![],
+        index: clone_scanner::Hash::new(),
+    };
+
+    let result = crate::instances(&scan, &DetectConfig::default());
+
+    assert!(result.instances.is_empty());
+    assert_eq!(result.stats.files_scanned, 0);
+    assert_eq!(result.stats.nodes_analyzed, 0);
+    assert_eq!(result.stats.type1_groups, 0);
+    assert_eq!(result.stats.type2_groups, 0);
+    assert_eq!(result.stats.type3_groups, 0);
+}
+
+#[test]
+fn single_file_no_clones() {
+    let dir = TempDir::new().unwrap();
+
+    let code = r#"
+fn unique_function() {
+    println!("hello");
+}
+"#;
+    create_temp_file(&dir, "file.rs", code);
+
+    let result = scan_and_run(&dir, &DetectConfig::default());
+
+    assert_eq!(result.stats.type1_groups, 0);
+    assert_eq!(result.stats.files_scanned, 1);
+}
+
+#[test]
+fn group_has_multiple_fragments() {
+    let dir = TempDir::new().unwrap();
+
+    let code = "fn dup() { println!(\"hello\"); }";
+    create_temp_file(&dir, "file1.rs", code);
+    create_temp_file(&dir, "file2.rs", code);
+    create_temp_file(&dir, "file3.rs", code);
+
+    let result = scan_and_run(&dir, &DetectConfig::default());
+
+    let has_multi_fragment = result.instances.iter().any(|g| g.fragments.len() >= 2);
+    assert!(
+        has_multi_fragment,
+        "Clone groups should have multiple fragments"
+    );
+}
+
+#[test]
+fn fragment_contains_correct_info() {
+    let dir = TempDir::new().unwrap();
+
+    let code = r#"fn duplicate() {
+    println!("hello");
+}
+"#;
+    create_temp_file(&dir, "file1.rs", code);
+    create_temp_file(&dir, "file2.rs", code);
+
+    let result = scan_and_run(&dir, &DetectConfig::default());
+
+    if let Some(clone_group) = result.instances.first() {
+        for fragment in &clone_group.fragments {
+            assert!(fragment.byte_range.start < fragment.byte_range.end);
+            assert!(fragment.lines.start <= fragment.lines.end);
+            assert!(!fragment.kind.is_empty());
+            assert!(fragment.file.exists());
+        }
+    }
+}

--- a/packages/clone-detect/detect/src/tests/helpers.rs
+++ b/packages/clone-detect/detect/src/tests/helpers.rs
@@ -1,0 +1,33 @@
+use std::{io::Write as _, path::PathBuf};
+
+use clone_scanner::Config;
+use tempfile::TempDir;
+
+use crate::{DetectConfig, DetectionResult, instances};
+
+pub fn create_temp_file(dir: &TempDir, name: &str, content: &str) -> PathBuf {
+    let path = dir.path().join(name);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    let mut file = std::fs::File::create(&path).unwrap();
+    file.write_all(content.as_bytes()).unwrap();
+    path
+}
+
+pub fn test_scan_config() -> Config {
+    Config {
+        min_lines: 1,
+        min_nodes: 1,
+        respect_gitignore: false,
+        include_hidden: false,
+    }
+}
+
+/// Scan a directory with the default test config and detect instances with the
+/// given [`DetectConfig`].
+pub fn scan_and_run(dir: &TempDir, detect_config: &DetectConfig) -> DetectionResult {
+    let scanner = clone_scanner::Scanner::new(test_scan_config());
+    let scan = scanner.directory(dir.path()).unwrap();
+    instances(&scan, detect_config)
+}

--- a/packages/clone-detect/detect/src/tests/multilang.rs
+++ b/packages/clone-detect/detect/src/tests/multilang.rs
@@ -1,0 +1,50 @@
+use tempfile::TempDir;
+
+use super::helpers::{create_temp_file, scan_and_run};
+use crate::DetectConfig;
+
+#[test]
+fn mixed_language() {
+    let dir = TempDir::new().unwrap();
+
+    let ts_code = r"
+function calculateSum(a: number, b: number): number {
+    const result = a + b;
+    return result;
+}
+";
+
+    let js_code = r"
+function calculateSum(a, b) {
+    const result = a + b;
+    return result;
+}
+";
+    create_temp_file(&dir, "file1.ts", ts_code);
+    create_temp_file(&dir, "file2.ts", ts_code);
+    create_temp_file(&dir, "file3.js", js_code);
+
+    let result = scan_and_run(&dir, &DetectConfig::default());
+
+    assert!(result.stats.type1_groups > 0 || result.stats.type2_groups > 0);
+}
+
+#[test]
+fn python_duplicates() {
+    let dir = TempDir::new().unwrap();
+
+    let code = r"
+def calculate_sum(a, b):
+    result = a + b
+    return result
+";
+    create_temp_file(&dir, "file1.py", code);
+    create_temp_file(&dir, "file2.py", code);
+
+    let result = scan_and_run(&dir, &DetectConfig::default());
+
+    assert!(
+        result.stats.type1_groups > 0,
+        "Should detect Python duplicates"
+    );
+}

--- a/packages/clone-detect/detect/src/tests/pipeline.rs
+++ b/packages/clone-detect/detect/src/tests/pipeline.rs
@@ -1,0 +1,83 @@
+use tempfile::TempDir;
+
+use super::helpers::{create_temp_file, scan_and_run};
+use crate::DetectConfig;
+
+#[test]
+fn full_rust() {
+    let dir = TempDir::new().unwrap();
+
+    let utils_code = r"
+pub fn validate_input(input: &str) -> bool {
+    if input.is_empty() {
+        return false;
+    }
+    input.chars().all(|c| c.is_alphanumeric())
+}
+
+pub fn sanitize_string(s: &str) -> String {
+    s.trim().to_lowercase()
+}
+";
+
+    let handlers_code = r#"
+pub fn validate_input(input: &str) -> bool {
+    if input.is_empty() {
+        return false;
+    }
+    input.chars().all(|c| c.is_alphanumeric())
+}
+
+pub fn handle_request(data: &str) -> String {
+    format!("Handled: {}", data)
+}
+"#;
+
+    create_temp_file(&dir, "src/utils.rs", utils_code);
+    create_temp_file(&dir, "src/handlers.rs", handlers_code);
+
+    let result = scan_and_run(&dir, &DetectConfig::default());
+
+    assert_eq!(result.stats.files_scanned, 2);
+    assert!(
+        result.stats.type1_groups > 0,
+        "Should detect exact duplicate function"
+    );
+}
+
+#[test]
+fn full_with_type3() {
+    let dir = TempDir::new().unwrap();
+
+    let code1 = r"
+fn process_items(items: Vec<i32>) -> i32 {
+    let mut sum = 0;
+    for item in items {
+        sum += item;
+    }
+    sum
+}
+";
+
+    let code2 = r"
+fn aggregate_values(values: Vec<i32>) -> i32 {
+    let mut total = 0;
+    for value in values {
+        total += value;
+    }
+    total
+}
+";
+
+    create_temp_file(&dir, "file1.rs", code1);
+    create_temp_file(&dir, "file2.rs", code2);
+
+    let config = DetectConfig {
+        enable_type3: true,
+        type3_threshold: 0.7,
+        ..DetectConfig::default()
+    };
+    let result = scan_and_run(&dir, &config);
+
+    assert_eq!(result.stats.files_scanned, 2);
+}

--- a/packages/clone-detect/detect/src/tests/serialization.rs
+++ b/packages/clone-detect/detect/src/tests/serialization.rs
@@ -1,0 +1,89 @@
+use std::path::PathBuf;
+
+use crate::{ByteRange, CloneGroup, DetectionResult, DetectionStats, Fragment, Kind, LineRange};
+
+#[test]
+fn type_to_string() {
+    let type1 = Kind::Type1;
+    let json = serde_json::to_string(&type1).unwrap();
+    assert!(json.contains("type1"));
+
+    let type3 = Kind::Type3 { similarity: 0.85 };
+    let json = serde_json::to_string(&type3).unwrap();
+    assert!(json.contains("type3"));
+    assert!(json.contains("0.85"));
+}
+
+#[test]
+fn type_from_string() {
+    let type1: Kind = serde_json::from_str("\"type1\"").unwrap();
+    assert_eq!(type1, Kind::Type1);
+
+    let type2: Kind = serde_json::from_str("\"type2\"").unwrap();
+    assert_eq!(type2, Kind::Type2);
+
+    let type3: Kind = serde_json::from_str("{\"type3\":{\"similarity\":0.75}}").unwrap();
+    assert!(matches!(type3, Kind::Type3 { similarity } if (similarity - 0.75).abs() < 0.001));
+}
+
+#[test]
+fn fragment_roundtrip() {
+    let fragment = Fragment {
+        file: PathBuf::from("/src/main.rs"),
+        byte_range: ByteRange {
+            start: 100,
+            end: 200,
+        },
+        lines: LineRange { start: 10, end: 20 },
+        kind: "function_item".to_owned(),
+    };
+
+    let json = serde_json::to_string(&fragment).unwrap();
+    let deserialized: Fragment = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(deserialized.file, fragment.file);
+    assert_eq!(deserialized.byte_range, fragment.byte_range);
+    assert_eq!(deserialized.lines, fragment.lines);
+    assert_eq!(deserialized.kind, fragment.kind);
+}
+
+#[test]
+fn detection_result_roundtrip() {
+    let result = DetectionResult {
+        instances: vec![CloneGroup {
+            clone_type: Kind::Type1,
+            fragments: vec![
+                Fragment {
+                    file: PathBuf::from("a.rs"),
+                    byte_range: ByteRange { start: 0, end: 50 },
+                    lines: LineRange { start: 0, end: 5 },
+                    kind: "function_item".to_owned(),
+                },
+                Fragment {
+                    file: PathBuf::from("b.rs"),
+                    byte_range: ByteRange { start: 0, end: 50 },
+                    lines: LineRange { start: 0, end: 5 },
+                    kind: "function_item".to_owned(),
+                },
+            ],
+        }],
+        stats: DetectionStats {
+            files_scanned: 2,
+            nodes_analyzed: 10,
+            total_lines: 100,
+            duplicated_lines: 10,
+            duplication_pct: 10.0,
+            type1_groups: 1,
+            type2_groups: 0,
+            type3_groups: 0,
+            sequence_groups: 0,
+        },
+    };
+
+    let json = serde_json::to_string(&result).unwrap();
+    let deserialized: DetectionResult = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(deserialized.instances.len(), 1);
+    assert_eq!(deserialized.stats.files_scanned, 2);
+    assert_eq!(deserialized.stats.type1_groups, 1);
+}

--- a/packages/clone-detect/detect/src/tests/similarity.rs
+++ b/packages/clone-detect/detect/src/tests/similarity.rs
@@ -1,0 +1,102 @@
+use crate::compute_similarity;
+
+fn make_node_with_features(node_count: usize, features: Vec<u64>) -> clone_hash::NodeInfo {
+    clone_hash::NodeInfo {
+        content_hash: 1,
+        normalized_hash: 2,
+        kind: "function_item",
+        byte_range: 0..100,
+        start_line: 0,
+        end_line: 10,
+        node_count,
+        children: vec![],
+        subtree_features: features,
+    }
+}
+
+/// Two nodes with identical feature multisets should have similarity 1.0
+#[test]
+fn identical_children() {
+    let a = make_node_with_features(50, vec![100, 200, 300]);
+    let b = make_node_with_features(50, vec![100, 200, 300]);
+    let sim = compute_similarity(&a, &b);
+    assert!(
+        (sim - 1.0).abs() < 0.001,
+        "Identical features should give similarity 1.0, got {sim}"
+    );
+}
+
+/// Two nodes with completely different features should have similarity 0.0
+#[test]
+fn completely_different_children() {
+    let a = make_node_with_features(50, vec![100, 200, 300]);
+    let b = make_node_with_features(50, vec![400, 500, 600]);
+    let sim = compute_similarity(&a, &b);
+    assert!(
+        sim < 0.01,
+        "Completely different features should give similarity ~0.0, got {sim}"
+    );
+}
+
+/// Partial overlap: 2 out of 3 features match
+#[test]
+fn partial_overlap() {
+    let a = make_node_with_features(50, vec![100, 200, 300]);
+    let b = make_node_with_features(55, vec![100, 200, 400]);
+    let sim = compute_similarity(&a, &b);
+    // Jaccard of {100,200,300} and {100,200,400}: intersection=2, union=4 → 0.5
+    assert!(
+        (sim - 0.5).abs() < 0.01,
+        "2/4 Jaccard overlap should give ~0.5, got {sim}"
+    );
+}
+
+/// One node has an extra feature (superset): 3 matching, 1 extra
+#[test]
+fn one_extra_child() {
+    let a = make_node_with_features(50, vec![100, 200, 300]);
+    let b = make_node_with_features(60, vec![100, 200, 300, 400]);
+    let sim = compute_similarity(&a, &b);
+    // Jaccard: intersection=3, union=4 → 0.75
+    assert!(
+        (sim - 0.75).abs() < 0.01,
+        "3/4 Jaccard overlap should give ~0.75, got {sim}"
+    );
+}
+
+/// Both nodes have no features — fallback to node count ratio
+#[test]
+fn no_children_fallback() {
+    let a = make_node_with_features(50, vec![]);
+    let b = make_node_with_features(60, vec![]);
+    let sim = compute_similarity(&a, &b);
+    // Fallback: min/max = 50/60 ≈ 0.833
+    assert!(
+        (sim - 0.833).abs() < 0.01,
+        "Empty features should fallback to node count ratio, got {sim}"
+    );
+}
+
+/// Zero nodes in both — similarity 0.0
+#[test]
+fn zero_nodes() {
+    let a = make_node_with_features(0, vec![]);
+    let b = make_node_with_features(0, vec![]);
+    let sim = compute_similarity(&a, &b);
+    assert!(sim.abs() < 0.001, "Zero nodes should give 0.0, got {sim}");
+}
+
+/// Duplicate features should be treated as multiset (counted individually)
+#[test]
+fn multiset_duplicates() {
+    let a = make_node_with_features(50, vec![100, 100, 200]);
+    let b = make_node_with_features(50, vec![100, 200, 200]);
+    let sim = compute_similarity(&a, &b);
+    // Multiset intersection: min(2,1) for 100 = 1, min(1,2) for 200 = 1 → 2
+    // Multiset union: max(2,1) for 100 = 2, max(1,2) for 200 = 2 → 4
+    // Jaccard: 2/4 = 0.5
+    assert!(
+        (sim - 0.5).abs() < 0.01,
+        "Multiset Jaccard with duplicate features should be 0.5, got {sim}"
+    );
+}

--- a/packages/clone-detect/detect/src/tests/stats.rs
+++ b/packages/clone-detect/detect/src/tests/stats.rs
@@ -1,0 +1,37 @@
+use tempfile::TempDir;
+
+use super::helpers::{create_temp_file, scan_and_run};
+use crate::DetectConfig;
+
+#[test]
+fn files_scanned() {
+    let dir = TempDir::new().unwrap();
+
+    create_temp_file(&dir, "file1.rs", "fn a() {}");
+    create_temp_file(&dir, "file2.rs", "fn b() {}");
+    create_temp_file(&dir, "file3.rs", "fn c() {}");
+
+    let result = scan_and_run(&dir, &DetectConfig::default());
+
+    assert_eq!(result.stats.files_scanned, 3);
+}
+
+#[test]
+fn nodes_analyzed() {
+    let dir = TempDir::new().unwrap();
+
+    let code = r#"
+fn func1() {
+    println!("hello");
+}
+
+fn func2() {
+    println!("world");
+}
+"#;
+    create_temp_file(&dir, "file.rs", code);
+
+    let result = scan_and_run(&dir, &DetectConfig::default());
+
+    assert!(result.stats.nodes_analyzed >= 2);
+}

--- a/packages/clone-detect/detect/src/tests/structural.rs
+++ b/packages/clone-detect/detect/src/tests/structural.rs
@@ -1,0 +1,209 @@
+use tempfile::TempDir;
+
+use super::helpers::{create_temp_file, scan_and_run};
+use crate::DetectConfig;
+
+/// Two functions with identical structure but different variable names and one
+/// extra statement should be detected as Type 3 instances with high similarity
+/// (structure mostly the same, just one statement added).
+#[test]
+fn type3_one_extra_statement() {
+    let dir = TempDir::new().unwrap();
+
+    create_temp_file(
+        &dir,
+        "file1.rs",
+        r"
+fn process(items: Vec<i32>) -> Vec<i32> {
+    let mut result = Vec::new();
+    for item in items {
+        if item > 0 {
+            result.push(item);
+        }
+    }
+    result
+}
+",
+    );
+
+    create_temp_file(
+        &dir,
+        "file2.rs",
+        r"
+fn filter(values: Vec<i32>) -> Vec<i32> {
+    let mut output = Vec::new();
+    for val in values {
+        if val > 0 {
+            output.push(val);
+        }
+    }
+    output.sort();
+    output
+}
+",
+    );
+
+    let config = DetectConfig {
+        enable_type3: true,
+        type3_threshold: 0.6,
+        ..DetectConfig::default()
+    };
+    let result = scan_and_run(&dir, &config);
+
+    assert!(
+        result.stats.type3_groups > 0 || result.stats.type2_groups > 0,
+        "Should detect the structurally similar functions as instances"
+    );
+}
+
+/// Two completely different functions of similar size should NOT be detected
+/// as Type 3 instances. The old node-count-ratio metric would match these because
+/// they have similar node counts.
+#[test]
+fn type3_no_false_positive_same_size_different_structure() {
+    let dir = TempDir::new().unwrap();
+
+    create_temp_file(
+        &dir,
+        "file1.rs",
+        r#"
+fn render_html(items: Vec<String>) -> String {
+    let mut html = String::from("<ul>");
+    for item in items {
+        html.push_str("<li>");
+        html.push_str(&item);
+        html.push_str("</li>");
+    }
+    html.push_str("</ul>");
+    html
+}
+"#,
+    );
+
+    create_temp_file(
+        &dir,
+        "file2.rs",
+        r"
+fn compute_stats(numbers: Vec<f64>) -> (f64, f64) {
+    let mut sum = 0.0;
+    let mut count = 0.0;
+    for n in numbers {
+        sum += n;
+        count += 1.0;
+    }
+    let mean = sum / count;
+    (mean, sum)
+}
+",
+    );
+
+    let config = DetectConfig {
+        enable_type3: true,
+        type3_threshold: 0.7,
+        ..DetectConfig::default()
+    };
+    let result = scan_and_run(&dir, &config);
+
+    assert_eq!(
+        result.stats.type3_groups, 0,
+        "Should not flag structurally different functions as instances, even with similar sizes"
+    );
+}
+
+/// The exact pattern from the proxy.rs screenshot: two if-let blocks with
+/// identical structure but different header constants. This should be detected
+/// as a Type 2 clone (same structure, different identifiers).
+#[test]
+fn detects_if_let_conditional_header_pattern() {
+    let dir = TempDir::new().unwrap();
+
+    create_temp_file(
+        &dir,
+        "proxy.rs",
+        r#"
+use std::collections::HashMap;
+
+fn build_conditional_headers(cached: &HashMap<String, String>) -> HashMap<String, String> {
+    let mut headers = HashMap::new();
+
+    if let Some(etag) = cached.get("etag")
+    {
+        headers.insert("if-none-match".to_string(), etag.clone());
+    }
+
+    if let Some(last_modified) = cached.get("last-modified")
+    {
+        headers.insert("if-modified-since".to_string(), last_modified.clone());
+    }
+
+    headers
+}
+"#,
+    );
+
+    let result = scan_and_run(&dir, &DetectConfig::default());
+
+    let total = result.stats.type1_groups + result.stats.type2_groups;
+    assert!(
+        total > 0,
+        "Should detect the two if-let blocks as Type 1 or Type 2 instances"
+    );
+}
+
+/// Type 3 similarity with functions that share ~80% of their structure
+/// but have different endings should score high.
+#[test]
+fn type3_high_overlap_detected() {
+    let dir = TempDir::new().unwrap();
+
+    create_temp_file(
+        &dir,
+        "file1.rs",
+        r#"
+fn handle_request(data: &str) -> Result<String, String> {
+    let trimmed = data.trim();
+    if trimmed.is_empty() {
+        return Err("empty".to_string());
+    }
+    let parsed = trimmed.to_uppercase();
+    let validated = parsed.len() > 2;
+    if !validated {
+        return Err("too short".to_string());
+    }
+    Ok(parsed)
+}
+"#,
+    );
+
+    create_temp_file(
+        &dir,
+        "file2.rs",
+        r#"
+fn process_input(text: &str) -> Result<String, String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Err("empty".to_string());
+    }
+    let parsed = trimmed.to_lowercase();
+    let validated = parsed.len() > 2;
+    if !validated {
+        return Err("too short".to_string());
+    }
+    Ok(format!("result: {}", parsed))
+}
+"#,
+    );
+
+    let config = DetectConfig {
+        enable_type3: true,
+        type3_threshold: 0.6,
+        ..DetectConfig::default()
+    };
+    let result = scan_and_run(&dir, &config);
+
+    let total = result.stats.type2_groups + result.stats.type3_groups;
+    assert!(
+        total > 0,
+        "Functions sharing ~80% structure should be detected as instances"
+    );
+}

--- a/packages/clone-detect/detect/src/tests/type3.rs
+++ b/packages/clone-detect/detect/src/tests/type3.rs
@@ -1,0 +1,104 @@
+use tempfile::TempDir;
+
+use super::helpers::{create_temp_file, scan_and_run};
+use crate::DetectConfig;
+
+#[test]
+fn disabled_by_default() {
+    let dir = TempDir::new().unwrap();
+
+    let code1 = r"
+fn process_data(items: Vec<i32>) -> i32 {
+    let mut sum = 0;
+    for item in items {
+        sum += item;
+    }
+    sum
+}
+";
+    let code2 = r#"
+fn process_numbers(values: Vec<i32>) -> i32 {
+    let mut total = 0;
+    for value in values {
+        total += value;
+        println!("Added {}", value);
+    }
+    total
+}
+"#;
+    create_temp_file(&dir, "file1.rs", code1);
+    create_temp_file(&dir, "file2.rs", code2);
+
+    let result = scan_and_run(&dir, &DetectConfig::default());
+
+    assert_eq!(
+        result.stats.type3_groups, 0,
+        "Type-3 should be disabled by default"
+    );
+}
+
+#[test]
+fn enabled() {
+    let dir = TempDir::new().unwrap();
+
+    let code1 = r"
+fn process(items: Vec<i32>) -> i32 {
+    let mut sum = 0;
+    for item in items {
+        sum += item;
+    }
+    sum
+}
+";
+    let code2 = r"
+fn handle(values: Vec<i32>) -> i32 {
+    let mut total = 0;
+    for value in values {
+        total += value;
+    }
+    total
+}
+";
+    create_temp_file(&dir, "file1.rs", code1);
+    create_temp_file(&dir, "file2.rs", code2);
+
+    let config = DetectConfig {
+        enable_type3: true,
+        type3_threshold: 0.5,
+        ..DetectConfig::default()
+    };
+    let result = scan_and_run(&dir, &config);
+
+    let _ = result.stats.type3_groups;
+}
+
+#[test]
+fn high_threshold() {
+    let dir = TempDir::new().unwrap();
+
+    let code1 = r#"
+fn short_func() {
+    println!("hello");
+}
+"#;
+    let code2 = r#"
+fn long_func() {
+    println!("hello");
+    println!("world");
+    println!("more");
+    println!("stuff");
+    println!("here");
+}
+"#;
+    create_temp_file(&dir, "file1.rs", code1);
+    create_temp_file(&dir, "file2.rs", code2);
+
+    let config = DetectConfig {
+        enable_type3: true,
+        type3_threshold: 0.95,
+        ..DetectConfig::default()
+    };
+    let result = scan_and_run(&dir, &config);
+
+    let _ = result.stats.type3_groups;
+}

--- a/packages/clone-detect/detect/src/type3.rs
+++ b/packages/clone-detect/detect/src/type3.rs
@@ -1,0 +1,158 @@
+use clone_hash::NodeInfo;
+use clone_scanner::Output;
+use rayon::prelude::*;
+use rustc_hash::FxHashMap;
+
+use crate::{
+    jaccard::multiset_sorted,
+    lsh::{LshEntry, LshIndex, NodeLocation, estimated_jaccard, minhash_signature},
+    types::{CloneGroup, Fragment, Kind},
+};
+
+/// Margin for the MinHash estimate pre-check. The estimate approximates
+/// set Jaccard which can differ from multiset Jaccard, so we allow some slack.
+const ESTIMATION_MARGIN: f64 = 0.1;
+
+/// A scanned node with its position in the file list.
+struct IndexedNode<'a> {
+    file_id: usize,
+    node_idx: usize,
+    node: &'a NodeInfo,
+}
+
+pub fn find(scan: &Output, threshold: f64) -> Vec<CloneGroup> {
+    let mut by_kind: FxHashMap<&str, Vec<IndexedNode<'_>>> = FxHashMap::default();
+
+    for (file_id, file) in scan.files.iter().enumerate() {
+        for (node_idx, node) in file.nodes.iter().enumerate() {
+            by_kind.entry(node.kind).or_default().push(IndexedNode {
+                file_id,
+                node_idx,
+                node,
+            });
+        }
+    }
+
+    let kind_groups: Vec<_> = by_kind.into_iter().collect();
+
+    kind_groups
+        .par_iter()
+        .flat_map(|(_kind, nodes)| {
+            if nodes.len() < 2 {
+                return Vec::new();
+            }
+
+            // Deduplicate by normalized_hash: nodes with the same normalized_hash
+            // are already caught as Type-2 instances. Only send one representative
+            // per unique normalized_hash into LSH to shrink bucket sizes.
+            let mut seen_normalized: FxHashMap<u64, usize> = FxHashMap::default();
+            let entries: Vec<LshEntry> = nodes
+                .iter()
+                .filter(|indexed| !indexed.node.subtree_features.is_empty())
+                .filter(|indexed| {
+                    let count = seen_normalized
+                        .entry(indexed.node.normalized_hash)
+                        .or_insert(0);
+                    *count += 1;
+                    // Keep only the first occurrence of each normalized_hash
+                    *count == 1
+                })
+                .map(|indexed| LshEntry {
+                    location: NodeLocation {
+                        file_id: indexed.file_id,
+                        node_idx: indexed.node_idx,
+                    },
+                    signature: minhash_signature(&indexed.node.subtree_features),
+                })
+                .collect();
+
+            if entries.len() < 2 {
+                return Vec::new();
+            }
+
+            let index = LshIndex::build(&entries);
+            let mut groups = Vec::new();
+
+            for pair in index.candidate_pairs() {
+                // Fast pre-check: estimate Jaccard from MinHash signatures
+                if let (Some(sig_a), Some(sig_b)) =
+                    (index.signature(&pair.first), index.signature(&pair.second))
+                {
+                    let estimate = estimated_jaccard(sig_a, sig_b);
+                    if estimate < threshold - ESTIMATION_MARGIN {
+                        continue;
+                    }
+                }
+
+                let Some(group) = try_make_group(
+                    scan,
+                    &CandidatePair {
+                        loc_a: pair.first,
+                        loc_b: pair.second,
+                        threshold,
+                    },
+                ) else {
+                    continue;
+                };
+                groups.push(group);
+            }
+
+            groups
+        })
+        .collect()
+}
+
+struct CandidatePair {
+    loc_a: NodeLocation,
+    loc_b: NodeLocation,
+    threshold: f64,
+}
+
+/// Try to build a Type-3 clone group from two node locations.
+/// Returns `None` if they're already Type-1/Type-2 or below threshold.
+fn try_make_group(scan: &Output, pair: &CandidatePair) -> Option<CloneGroup> {
+    let file_a = scan.files.get(pair.loc_a.file_id)?;
+    let file_b = scan.files.get(pair.loc_b.file_id)?;
+    let node_a = file_a.nodes.get(pair.loc_a.node_idx)?;
+    let node_b = file_b.nodes.get(pair.loc_b.node_idx)?;
+
+    // Skip pairs already caught as Type-1 or Type-2
+    if node_a.content_hash == node_b.content_hash
+        || node_a.normalized_hash == node_b.normalized_hash
+    {
+        return None;
+    }
+
+    let similarity = compute_similarity(node_a, node_b);
+    if similarity < pair.threshold {
+        return None;
+    }
+
+    Some(CloneGroup {
+        clone_type: Kind::Type3 { similarity },
+        fragments: vec![
+            Fragment::from_node(file_a, node_a),
+            Fragment::from_node(file_b, node_b),
+        ],
+    })
+}
+
+/// Compute structural similarity between two AST nodes.
+#[must_use]
+pub fn compute_similarity(a: &NodeInfo, b: &NodeInfo) -> f64 {
+    if !a.subtree_features.is_empty() && !b.subtree_features.is_empty() {
+        return multiset_sorted(&a.subtree_features, &b.subtree_features);
+    }
+
+    let count_a = a.node_count as f64;
+    let count_b = b.node_count as f64;
+
+    let min = count_a.min(count_b);
+    let max = count_a.max(count_b);
+
+    if max == 0.0 {
+        return 0.0;
+    }
+
+    min / max
+}

--- a/packages/clone-detect/detect/src/types.rs
+++ b/packages/clone-detect/detect/src/types.rs
@@ -1,0 +1,106 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum Kind {
+    Type1,
+    Type2,
+    Type3 { similarity: f64 },
+    Sequence { statements: usize },
+}
+
+/// Byte offset range within a source file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ByteRange {
+    pub start: usize,
+    pub end: usize,
+}
+
+/// Line number range within a source file (1-indexed, inclusive).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LineRange {
+    pub start: usize,
+    pub end: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Fragment {
+    pub file: PathBuf,
+    pub byte_range: ByteRange,
+    pub lines: LineRange,
+    pub kind: String,
+}
+
+impl Fragment {
+    /// Construct a fragment from a scanned file and one of its nodes.
+    #[must_use]
+    pub fn from_node(file: &clone_scanner::File, node: &clone_hash::NodeInfo) -> Self {
+        Self {
+            file: file.path.clone(),
+            byte_range: ByteRange {
+                start: node.byte_range.start,
+                end: node.byte_range.end,
+            },
+            lines: LineRange {
+                start: node.start_line,
+                end: node.end_line,
+            },
+            kind: node.kind.to_owned(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CloneGroup {
+    pub clone_type: Kind,
+    pub fragments: Vec<Fragment>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DetectionResult {
+    pub instances: Vec<CloneGroup>,
+    pub stats: DetectionStats,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DetectionStats {
+    pub files_scanned: usize,
+    pub nodes_analyzed: usize,
+    pub total_lines: usize,
+    pub duplicated_lines: usize,
+    pub duplication_pct: f64,
+    pub type1_groups: usize,
+    pub type2_groups: usize,
+    pub type3_groups: usize,
+    pub sequence_groups: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct DetectConfig {
+    pub enable_type3: bool,
+    pub type3_threshold: f64,
+    pub enable_sequences: bool,
+    pub sequence_window_size: usize,
+}
+
+/// Default Jaccard similarity threshold for Type-3 clone detection.
+const DEFAULT_TYPE3_THRESHOLD: f64 = 0.7;
+
+impl Default for DetectConfig {
+    fn default() -> Self {
+        Self {
+            enable_type3: false,
+            type3_threshold: DEFAULT_TYPE3_THRESHOLD,
+            enable_sequences: false,
+            sequence_window_size: crate::sequences::DEFAULT_WINDOW_SIZE,
+        }
+    }
+}

--- a/packages/clone-detect/detect/tests/common/mod.rs
+++ b/packages/clone-detect/detect/tests/common/mod.rs
@@ -1,0 +1,32 @@
+use std::{io::Write as _, path::PathBuf};
+
+use clone_detect::{DetectConfig, DetectionResult, instances};
+use clone_scanner::Config;
+use tempfile::TempDir;
+
+pub fn test_scan_config() -> Config {
+    Config {
+        min_lines: 1,
+        min_nodes: 1,
+        respect_gitignore: false,
+        include_hidden: false,
+    }
+}
+
+pub fn create_temp_file(dir: &TempDir, name: &str, content: &str) -> PathBuf {
+    let path = dir.path().join(name);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    let mut file = std::fs::File::create(&path).unwrap();
+    file.write_all(content.as_bytes()).unwrap();
+    path
+}
+
+/// Scan a directory with the default test config and detect instances with the
+/// given [`DetectConfig`].
+pub fn scan_and_detect(dir: &TempDir, detect_config: &DetectConfig) -> DetectionResult {
+    let scanner = clone_scanner::Scanner::new(test_scan_config());
+    let scan = scanner.directory(dir.path()).unwrap();
+    instances(&scan, detect_config)
+}

--- a/packages/clone-detect/detect/tests/integration.rs
+++ b/packages/clone-detect/detect/tests/integration.rs
@@ -1,0 +1,404 @@
+#![expect(clippy::unwrap_used, reason = "Test code")]
+
+mod common;
+
+use clone_detect::{DetectConfig, DetectionResult, Kind};
+use clone_scanner::Config;
+use common::{create_temp_file, scan_and_detect};
+use tempfile::TempDir;
+
+#[test]
+fn full_pipeline_simple_rust_project() {
+    let dir = TempDir::new().unwrap();
+
+    create_temp_file(
+        &dir,
+        "src/lib.rs",
+        r#"
+pub mod utils;
+pub mod handlers;
+
+pub fn main_entry() {
+    println!("Main entry point");
+}
+"#,
+    );
+
+    create_temp_file(
+        &dir,
+        "src/utils.rs",
+        r"
+pub fn calculate_hash(data: &[u8]) -> u64 {
+    let mut hash = 0u64;
+    for byte in data {
+        hash = hash.wrapping_mul(31).wrapping_add(*byte as u64);
+    }
+    hash
+}
+
+pub fn validate_input(input: &str) -> bool {
+    !input.is_empty() && input.len() < 1000
+}
+",
+    );
+
+    create_temp_file(
+        &dir,
+        "src/handlers.rs",
+        r#"
+pub fn calculate_hash(data: &[u8]) -> u64 {
+    let mut hash = 0u64;
+    for byte in data {
+        hash = hash.wrapping_mul(31).wrapping_add(*byte as u64);
+    }
+    hash
+}
+
+pub fn process_request(data: &str) -> String {
+    format!("Processed: {}", data)
+}
+"#,
+    );
+
+    let result = scan_and_detect(&dir, &DetectConfig::default());
+
+    assert_eq!(result.stats.files_scanned, 3);
+    assert!(
+        result.stats.type1_groups > 0,
+        "Should detect duplicate calculate_hash function"
+    );
+
+    assert!(!result.instances.is_empty());
+
+    let type1_clones: Vec<_> = result
+        .instances
+        .iter()
+        .filter(|c| matches!(c.clone_type, Kind::Type1))
+        .collect();
+    assert!(!type1_clones.is_empty());
+
+    for clone in type1_clones {
+        assert!(clone.fragments.len() >= 2);
+        for fragment in &clone.fragments {
+            assert!(fragment.file.exists());
+        }
+    }
+}
+
+#[test]
+fn full_pipeline_multi_language_project() {
+    let dir = TempDir::new().unwrap();
+
+    create_temp_file(
+        &dir,
+        "src/main.rs",
+        r"
+fn add_numbers(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+fn multiply_numbers(a: i32, b: i32) -> i32 {
+    a * b
+}
+",
+    );
+
+    create_temp_file(
+        &dir,
+        "src/index.ts",
+        r"
+function addNumbers(a: number, b: number): number {
+    return a + b;
+}
+
+function multiplyNumbers(a: number, b: number): number {
+    return a * b;
+}
+",
+    );
+
+    create_temp_file(
+        &dir,
+        "src/main.py",
+        r"
+def add_numbers(a, b):
+    return a + b
+
+def multiply_numbers(a, b):
+    return a * b
+",
+    );
+
+    create_temp_file(
+        &dir,
+        "src/utils.rs",
+        r"
+fn add_numbers(a: i32, b: i32) -> i32 {
+    a + b
+}
+",
+    );
+
+    let result = scan_and_detect(&dir, &DetectConfig::default());
+
+    assert_eq!(result.stats.files_scanned, 4);
+
+    assert!(
+        result.stats.type1_groups > 0 || result.stats.type2_groups > 0,
+        "Should detect instances within language"
+    );
+}
+
+#[test]
+fn full_pipeline_with_subdirectories() {
+    let dir = TempDir::new().unwrap();
+
+    let code = r#"
+fn duplicate_function() {
+    let x = 1;
+    let y = 2;
+    let z = x + y;
+    println!("{}", z);
+}
+"#;
+
+    create_temp_file(&dir, "src/module_a/utils.rs", code);
+    create_temp_file(&dir, "src/module_b/helpers.rs", code);
+    create_temp_file(&dir, "src/module_c/sub/deep/file.rs", code);
+
+    let result = scan_and_detect(&dir, &DetectConfig::default());
+
+    assert_eq!(result.stats.files_scanned, 3);
+    assert!(
+        result.stats.type1_groups > 0,
+        "Should detect instances across nested directories"
+    );
+
+    let has_three_way_clone = result.instances.iter().any(|c| c.fragments.len() == 3);
+    assert!(has_three_way_clone, "Should find three-way clone");
+}
+
+#[test]
+fn full_pipeline_type3_detection() {
+    let dir = TempDir::new().unwrap();
+
+    create_temp_file(
+        &dir,
+        "file1.rs",
+        r"
+fn process_items(items: Vec<i32>) -> i32 {
+    let mut sum = 0;
+    for item in items {
+        sum += item;
+    }
+    sum
+}
+",
+    );
+
+    create_temp_file(
+        &dir,
+        "file2.rs",
+        r"
+fn process_values(values: Vec<i32>) -> i32 {
+    let mut total = 0;
+    for val in values {
+        total += val;
+    }
+    total
+}
+",
+    );
+
+    let scanner = clone_scanner::Scanner::new(common::test_scan_config());
+    let scan = scanner.directory(dir.path()).unwrap();
+
+    let result_no_type3 = clone_detect::instances(&scan, &DetectConfig::default());
+    assert_eq!(result_no_type3.stats.type3_groups, 0);
+
+    let config = DetectConfig {
+        enable_type3: true,
+        type3_threshold: 0.5,
+        ..DetectConfig::default()
+    };
+    let result_with_type3 = clone_detect::instances(&scan, &config);
+
+    assert!(
+        result_with_type3.stats.files_scanned == 2,
+        "Should scan both files"
+    );
+}
+
+#[test]
+fn full_pipeline_no_false_positives() {
+    let dir = TempDir::new().unwrap();
+
+    create_temp_file(
+        &dir,
+        "math.rs",
+        r"
+pub fn factorial(n: u64) -> u64 {
+    if n <= 1 {
+        1
+    } else {
+        n * factorial(n - 1)
+    }
+}
+",
+    );
+
+    create_temp_file(
+        &dir,
+        "strings.rs",
+        r#"
+pub fn reverse_string(s: &str) -> String {
+    s.chars().rev().collect()
+}
+
+pub fn count_vowels(s: &str) -> usize {
+    s.chars().filter(|c| "aeiou".contains(*c)).count()
+}
+"#,
+    );
+
+    create_temp_file(
+        &dir,
+        "collections.rs",
+        r"
+pub fn find_max(nums: &[i32]) -> Option<i32> {
+    nums.iter().copied().max()
+}
+
+pub fn find_min(nums: &[i32]) -> Option<i32> {
+    nums.iter().copied().min()
+}
+",
+    );
+
+    let result = scan_and_detect(&dir, &DetectConfig::default());
+
+    assert_eq!(result.stats.files_scanned, 3);
+
+    assert_eq!(
+        result.stats.type1_groups, 0,
+        "Should not have false positive Type-1 instances"
+    );
+}
+
+#[test]
+fn full_pipeline_large_project() {
+    let dir = TempDir::new().unwrap();
+
+    for i in 0..10 {
+        create_temp_file(
+            &dir,
+            &format!("src/module_{i}/lib.rs"),
+            &format!(
+                r#"
+pub fn unique_function_{i}() {{
+    println!("Function {i}", {i});
+}}
+"#
+            ),
+        );
+    }
+
+    let duplicate_code = r"
+fn shared_helper() {
+    let config = load_config();
+    process_config(config);
+}
+";
+    create_temp_file(&dir, "src/module_0/helpers.rs", duplicate_code);
+    create_temp_file(&dir, "src/module_5/helpers.rs", duplicate_code);
+    create_temp_file(&dir, "src/module_9/helpers.rs", duplicate_code);
+
+    let result = scan_and_detect(&dir, &DetectConfig::default());
+
+    assert_eq!(result.stats.files_scanned, 13);
+    assert!(
+        result.stats.type1_groups > 0,
+        "Should detect the 3 duplicate helper files"
+    );
+}
+
+#[test]
+fn full_pipeline_json_output() {
+    let dir = TempDir::new().unwrap();
+
+    let code = r#"
+fn json_test() {
+    let x = 42;
+    println!("{}", x);
+}
+"#;
+    create_temp_file(&dir, "file1.rs", code);
+    create_temp_file(&dir, "file2.rs", code);
+
+    let result = scan_and_detect(&dir, &DetectConfig::default());
+
+    let json = serde_json::to_string_pretty(&result).unwrap();
+    assert!(json.contains("instances"));
+    assert!(json.contains("stats"));
+    assert!(json.contains("files_scanned"));
+
+    let deserialized: DetectionResult = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized.stats.files_scanned, result.stats.files_scanned);
+    assert_eq!(deserialized.instances.len(), result.instances.len());
+}
+
+#[test]
+fn full_pipeline_with_gitignore() {
+    let dir = TempDir::new().unwrap();
+
+    let duplicate = r#"fn dup() { println!("hello"); }"#;
+
+    std::fs::create_dir_all(dir.path().join(".git")).unwrap();
+
+    create_temp_file(&dir, ".gitignore", "target/\nnode_modules/\n");
+
+    create_temp_file(&dir, "src/main.rs", duplicate);
+    create_temp_file(&dir, "src/lib.rs", duplicate);
+
+    create_temp_file(&dir, "target/debug/generated.rs", duplicate);
+    create_temp_file(&dir, "node_modules/dep/src/main.rs", duplicate);
+
+    let config = Config {
+        min_lines: 1,
+        min_nodes: 1,
+        respect_gitignore: true,
+        include_hidden: false,
+    };
+
+    let scanner = clone_scanner::Scanner::new(config);
+    let scan = scanner.directory(dir.path()).unwrap();
+    let result = clone_detect::instances(&scan, &DetectConfig::default());
+
+    assert_eq!(result.stats.files_scanned, 2);
+}
+
+#[test]
+fn regression_fragments_have_valid_paths() {
+    let dir = TempDir::new().unwrap();
+
+    let code = "fn test() { }";
+    create_temp_file(&dir, "a.rs", code);
+    create_temp_file(&dir, "b.rs", code);
+
+    let result = scan_and_detect(&dir, &DetectConfig::default());
+
+    for clone in &result.instances {
+        for fragment in &clone.fragments {
+            assert!(
+                fragment.file.exists(),
+                "Fragment path should exist: {:?}",
+                fragment.file
+            );
+            assert!(
+                fragment.file.is_absolute() || fragment.file.starts_with(dir.path()),
+                "Fragment path should be valid: {:?}",
+                fragment.file
+            );
+        }
+    }
+}

--- a/packages/clone-detect/hash/Cargo.toml
+++ b/packages/clone-detect/hash/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "clone-hash"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "AST hashing for code clone detection"
+
+[dependencies]
+tree-sitter.workspace = true
+rustc-hash.workspace = true
+ast-merge-ast.workspace = true
+ast-merge-langs.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+
+[lints]
+workspace = true

--- a/packages/clone-detect/hash/package.nix
+++ b/packages/clone-detect/hash/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "clone-hash";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/clone-detect/hash/src/extract.rs
+++ b/packages/clone-detect/hash/src/extract.rs
@@ -1,0 +1,186 @@
+use std::hash::{Hash, Hasher};
+
+use ast_merge_ast::Tree;
+pub use ast_merge_ast::compute;
+use rustc_hash::FxHasher;
+
+use crate::{
+    kinds::{is_identifier, is_normalizable, is_significant},
+    normalize,
+};
+
+/// Placeholder token for identifiers in subtree feature extraction.
+const TOKEN_IDENT: u64 = 0x1234_5678_AAAA_BBBB;
+/// Placeholder token for literals in subtree feature extraction.
+const TOKEN_LITERAL: u64 = 0x9876_5432_CCCC_DDDD;
+
+/// Position and hash info for a direct named child of a significant node.
+/// Used for statement-sequence clone detection.
+#[derive(Debug, Clone)]
+pub struct ChildInfo {
+    pub normalized_hash: u64,
+    pub byte_range: std::ops::Range<usize>,
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct NodeInfo {
+    pub content_hash: u64,
+    pub normalized_hash: u64,
+    pub kind: &'static str,
+    pub byte_range: std::ops::Range<usize>,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub node_count: usize,
+    /// Direct named children with position info. Ordered. Used for
+    /// statement-sequence clone detection (sliding-window k-grams).
+    pub children: Vec<ChildInfo>,
+    /// Normalized structural tokens (unigrams + bigrams) for the entire
+    /// subtree. Used as the feature set for MinHash LSH Type-3 detection.
+    /// Much richer than direct-child hashes: captures deep structural
+    /// similarity including nested patterns.
+    pub subtree_features: Vec<u64>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Dual {
+    pub content: u64,
+    pub normalized: u64,
+}
+
+#[must_use]
+pub fn dual(tree: &Tree, node: tree_sitter::Node<'_>) -> Dual {
+    Dual {
+        content: compute(tree, node),
+        normalized: normalize::hash(tree, node),
+    }
+}
+
+#[must_use]
+pub fn significant_nodes(tree: &Tree, min_lines: usize, min_nodes: usize) -> Vec<NodeInfo> {
+    let mut results = Vec::new();
+
+    for node in tree.preorder() {
+        let kind: &'static str = node.kind();
+        if !is_significant(kind) {
+            continue;
+        }
+
+        let start_line = node.start_position().row;
+        let end_line = node.end_position().row;
+        let line_count = end_line.saturating_sub(start_line) + 1;
+
+        if line_count < min_lines {
+            continue;
+        }
+
+        let node_count = count_nodes(node);
+        if node_count < min_nodes {
+            continue;
+        }
+
+        let Dual {
+            content: content_hash,
+            normalized: normalized_hash,
+        } = dual(tree, node);
+
+        let children = collect_children(tree, node);
+        let subtree_features = collect_subtree_features(tree, node);
+
+        results.push(NodeInfo {
+            content_hash,
+            normalized_hash,
+            kind,
+            byte_range: node.byte_range(),
+            start_line,
+            end_line,
+            node_count,
+            children,
+            subtree_features,
+        });
+    }
+
+    results
+}
+
+/// Collect detailed info for each direct named child of a node.
+/// Preserves ordering for statement-sequence detection.
+fn collect_children(tree: &Tree, node: tree_sitter::Node<'_>) -> Vec<ChildInfo> {
+    let mut children = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        children.push(ChildInfo {
+            normalized_hash: normalize::hash(tree, child),
+            byte_range: child.byte_range(),
+            start_line: child.start_position().row,
+            end_line: child.end_position().row,
+        });
+    }
+    children
+}
+
+/// Collect structural features for MinHash LSH.
+///
+/// Walks the subtree in preorder, producing a normalized token per AST node
+/// (kind + normalized leaf content). Then adds bigrams of consecutive tokens
+/// for structural context. The combined unigram+bigram set captures both
+/// local node types and parent-child/sibling relationships.
+///
+/// Complexity: O(n) where n = number of nodes in subtree.
+fn collect_subtree_features(tree: &Tree, node: tree_sitter::Node<'_>) -> Vec<u64> {
+    let mut tokens = Vec::new();
+    collect_tokens_recursive(tree, node, &mut tokens);
+
+    let bigram_count = tokens.len().saturating_sub(1);
+    let mut features = Vec::with_capacity(tokens.len() + bigram_count);
+    features.extend_from_slice(&tokens);
+
+    // Add bigrams for structural context (parent-child, sibling relationships)
+    for window in tokens.windows(2) {
+        let mut hasher = FxHasher::default();
+        // windows(2) guarantees exactly 2 elements per window
+        if let [a, b] = *window {
+            a.hash(&mut hasher);
+            b.hash(&mut hasher);
+        }
+        features.push(hasher.finish());
+    }
+
+    features.sort_unstable();
+    features
+}
+
+fn collect_tokens_recursive(tree: &Tree, node: tree_sitter::Node<'_>, tokens: &mut Vec<u64>) {
+    let mut hasher = FxHasher::default();
+    let kind = node.kind();
+    kind.hash(&mut hasher);
+
+    if node.child_count() == 0 {
+        if is_normalizable(kind) {
+            if is_identifier(kind) {
+                TOKEN_IDENT.hash(&mut hasher);
+            } else {
+                TOKEN_LITERAL.hash(&mut hasher);
+            }
+        } else {
+            tree.node_text(node).hash(&mut hasher);
+        }
+    }
+
+    tokens.push(hasher.finish());
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_tokens_recursive(tree, child, tokens);
+    }
+}
+
+fn count_nodes(node: tree_sitter::Node<'_>) -> usize {
+    let mut count = 1;
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        count += count_nodes(child);
+    }
+    count
+}

--- a/packages/clone-detect/hash/src/kinds.rs
+++ b/packages/clone-detect/hash/src/kinds.rs
@@ -1,0 +1,91 @@
+pub const IDENTIFIERS: &[&str] = &[
+    "identifier",
+    "type_identifier",
+    "field_identifier",
+    "property_identifier",
+    "shorthand_property_identifier",
+    "self",
+    "metavariable",
+    "private_property_identifier",
+    "attribute",
+    "package_identifier",
+    "simple_identifier",
+];
+
+pub const LITERALS: &[&str] = &[
+    "integer_literal",
+    "float_literal",
+    "number",
+    "decimal_integer_literal",
+    "hex_integer_literal",
+    "octal_integer_literal",
+    "binary_integer_literal",
+    "string_literal",
+    "string",
+    "string_fragment",
+    "string_content",
+    "raw_string_literal",
+    "char_literal",
+    "template_string",
+    "true",
+    "false",
+    "boolean",
+    "null",
+    "nil",
+    "none",
+];
+
+pub const SIGNIFICANT: &[&str] = &[
+    // Functions/methods
+    "function_item",
+    "function_definition",
+    "function_declaration",
+    "method_definition",
+    "method_declaration",
+    "arrow_function",
+    "lambda_expression",
+    "closure_expression",
+    // Types/structures
+    "class_declaration",
+    "class_definition",
+    "struct_item",
+    "impl_item",
+    "trait_item",
+    "interface_declaration",
+    "enum_item",
+    "enum_declaration",
+    // Blocks
+    "block",
+    "statement_block",
+    "compound_statement",
+    // Control flow (enables sub-block duplicate detection)
+    "if_expression",
+    "if_statement",
+    "if_let_expression",
+    "for_expression",
+    "for_statement",
+    "for_in_statement",
+    "while_expression",
+    "while_statement",
+    "match_expression",
+    "switch_statement",
+    "match_arm",
+    "switch_case",
+    "try_expression",
+    "try_statement",
+];
+
+#[must_use]
+pub fn is_normalizable(kind: &str) -> bool {
+    IDENTIFIERS.contains(&kind) || LITERALS.contains(&kind)
+}
+
+#[must_use]
+pub fn is_identifier(kind: &str) -> bool {
+    IDENTIFIERS.contains(&kind)
+}
+
+#[must_use]
+pub fn is_significant(kind: &str) -> bool {
+    SIGNIFICANT.contains(&kind)
+}

--- a/packages/clone-detect/hash/src/lib.rs
+++ b/packages/clone-detect/hash/src/lib.rs
@@ -1,0 +1,17 @@
+mod extract;
+pub mod kinds;
+mod normalize;
+
+pub use ast_merge_ast::compute;
+pub use extract::{ChildInfo, Dual, NodeInfo, dual, significant_nodes};
+pub use kinds::is_significant;
+pub use normalize::hash;
+
+#[cfg(test)]
+mod tests {
+    mod content;
+    mod extract;
+    mod helpers;
+    mod kinds;
+    mod normalized;
+}

--- a/packages/clone-detect/hash/src/normalize.rs
+++ b/packages/clone-detect/hash/src/normalize.rs
@@ -1,0 +1,69 @@
+use std::hash::{Hash, Hasher};
+
+use ast_merge_ast::Tree;
+use rustc_hash::{FxHashMap, FxHasher};
+
+use crate::kinds::{is_identifier, is_normalizable};
+
+const LITERAL_PLACEHOLDER: u64 = 0xDEAD_BEEF;
+
+#[must_use]
+pub fn hash(tree: &Tree, node: tree_sitter::Node<'_>) -> u64 {
+    let mut hasher = FxHasher::default();
+    let mut state = State::default();
+    recursive(
+        &mut Context {
+            tree,
+            hasher: &mut hasher,
+            state: &mut state,
+        },
+        node,
+    );
+    hasher.finish()
+}
+
+#[derive(Default)]
+struct State<'a> {
+    identifier_map: FxHashMap<&'a str, u32>,
+    next_id: u32,
+}
+
+impl<'a> State<'a> {
+    fn get_or_assign(&mut self, text: &'a str) -> u32 {
+        *self.identifier_map.entry(text).or_insert_with(|| {
+            let id = self.next_id;
+            self.next_id += 1;
+            id
+        })
+    }
+}
+
+struct Context<'a, 'b> {
+    tree: &'a Tree,
+    hasher: &'b mut FxHasher,
+    state: &'b mut State<'a>,
+}
+
+fn recursive(ctx: &mut Context<'_, '_>, node: tree_sitter::Node<'_>) {
+    let kind = node.kind();
+    kind.hash(ctx.hasher);
+
+    if node.child_count() == 0 {
+        if is_normalizable(kind) {
+            let text = ctx.tree.node_text(node);
+            if is_identifier(kind) {
+                let id = ctx.state.get_or_assign(text);
+                id.hash(ctx.hasher);
+            } else {
+                LITERAL_PLACEHOLDER.hash(ctx.hasher);
+            }
+        } else {
+            ctx.tree.node_text(node).hash(ctx.hasher);
+        }
+    } else {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            recursive(ctx, child);
+        }
+    }
+}

--- a/packages/clone-detect/hash/src/tests/content.rs
+++ b/packages/clone-detect/hash/src/tests/content.rs
@@ -1,0 +1,72 @@
+use super::helpers::{parse_js, parse_rust};
+use crate::compute;
+
+#[test]
+fn identical_functions_same() {
+    let source1 = "fn foo() { let x = 1; }";
+    let source2 = "fn foo() { let x = 1; }";
+
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let hash1 = compute(&tree1, tree1.root_node());
+    let hash2 = compute(&tree2, tree2.root_node());
+
+    assert_eq!(hash1, hash2);
+}
+
+#[test]
+fn renamed_functions_different() {
+    let source1 = "fn foo() { let x = 1; }";
+    let source2 = "fn bar() { let y = 1; }";
+
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let hash1 = compute(&tree1, tree1.root_node());
+    let hash2 = compute(&tree2, tree2.root_node());
+
+    assert_ne!(hash1, hash2);
+}
+
+#[test]
+fn whitespace_difference_same() {
+    let source1 = "fn foo(){let x=1;}";
+    let source2 = "fn foo() {\n    let x = 1;\n}";
+
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let hash1 = compute(&tree1, tree1.root_node());
+    let hash2 = compute(&tree2, tree2.root_node());
+
+    assert_eq!(hash1, hash2);
+}
+
+#[test]
+fn different_literals() {
+    let source1 = "fn f() { let x = 1; }";
+    let source2 = "fn f() { let x = 2; }";
+
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let hash1 = compute(&tree1, tree1.root_node());
+    let hash2 = compute(&tree2, tree2.root_node());
+
+    assert_ne!(hash1, hash2);
+}
+
+#[test]
+fn javascript_differs() {
+    let source1 = "function add(a, b) { return a + b; }";
+    let source2 = "function sum(x, y) { return x + y; }";
+
+    let tree1 = parse_js(source1);
+    let tree2 = parse_js(source2);
+
+    let hash1 = compute(&tree1, tree1.root_node());
+    let hash2 = compute(&tree2, tree2.root_node());
+
+    assert_ne!(hash1, hash2);
+}

--- a/packages/clone-detect/hash/src/tests/extract.rs
+++ b/packages/clone-detect/hash/src/tests/extract.rs
@@ -1,0 +1,116 @@
+use super::helpers::{parse_python, parse_rust};
+use crate::significant_nodes;
+
+#[test]
+fn extracts_significant_nodes() {
+    let source = r"
+fn small() {}
+
+fn larger() {
+    let x = 1;
+    let y = 2;
+    let z = x + y;
+    z
+}
+
+struct Foo {
+    a: i32,
+    b: i32,
+}
+";
+
+    let tree = parse_rust(source);
+    let nodes = significant_nodes(&tree, 3, 5);
+
+    assert!(!nodes.is_empty());
+    for node in &nodes {
+        assert!(node.end_line - node.start_line >= 2);
+        assert!(node.node_count >= 5);
+    }
+}
+
+#[test]
+fn empty_file() {
+    let source = "";
+    let tree = parse_rust(source);
+    let nodes = significant_nodes(&tree, 3, 5);
+    assert!(nodes.is_empty());
+}
+
+#[test]
+fn only_small_functions() {
+    let source = "fn a() {} fn b() {} fn c() {}";
+    let tree = parse_rust(source);
+    let nodes = significant_nodes(&tree, 5, 10);
+
+    assert!(nodes.is_empty());
+}
+
+#[test]
+fn with_impl_block() {
+    let source = r"
+impl Foo {
+    fn method1(&self) {
+        let x = 1;
+        let y = 2;
+        x + y
+    }
+
+    fn method2(&self) {
+        let a = 3;
+        let b = 4;
+        a * b
+    }
+}
+";
+
+    let tree = parse_rust(source);
+    let nodes = significant_nodes(&tree, 3, 5);
+    assert!(!nodes.is_empty());
+}
+
+#[test]
+fn node_info_fields() {
+    let source = r"
+fn test_function() {
+    let x = 1;
+    let y = 2;
+    let z = x + y;
+    z
+}
+";
+    let tree = parse_rust(source);
+    let nodes = significant_nodes(&tree, 3, 5);
+
+    assert!(!nodes.is_empty());
+    let node = nodes.first().unwrap();
+
+    assert!(node.content_hash != 0);
+    assert!(node.normalized_hash != 0);
+    assert!(!node.kind.is_empty());
+    assert!(node.byte_range.start < node.byte_range.end);
+    assert!(node.start_line <= node.end_line);
+    assert!(node.node_count > 0);
+}
+
+#[test]
+fn python_significant_nodes() {
+    let source = r"
+def small():
+    pass
+
+def larger():
+    x = 1
+    y = 2
+    z = x + y
+    return z
+
+class Foo:
+    def __init__(self):
+        self.a = 1
+        self.b = 2
+";
+    let tree = parse_python(source);
+    let nodes = significant_nodes(&tree, 3, 5);
+    assert!(!nodes.is_empty());
+}

--- a/packages/clone-detect/hash/src/tests/helpers.rs
+++ b/packages/clone-detect/hash/src/tests/helpers.rs
@@ -1,0 +1,17 @@
+use ast_merge_ast::Tree;
+use ast_merge_langs::Lang;
+
+pub fn parse_rust(source: &str) -> Tree {
+    let lang = Lang::Rust.to_tree_sitter();
+    ast_merge_ast::tree(source, &lang).unwrap().tree
+}
+
+pub fn parse_js(source: &str) -> Tree {
+    let lang = Lang::JavaScript.to_tree_sitter();
+    ast_merge_ast::tree(source, &lang).unwrap().tree
+}
+
+pub fn parse_python(source: &str) -> Tree {
+    let lang = Lang::Python.to_tree_sitter();
+    ast_merge_ast::tree(source, &lang).unwrap().tree
+}

--- a/packages/clone-detect/hash/src/tests/kinds.rs
+++ b/packages/clone-detect/hash/src/tests/kinds.rs
@@ -1,0 +1,40 @@
+use crate::kinds::{is_identifier, is_normalizable, is_significant};
+
+#[test]
+fn normalizable_identifiers() {
+    assert!(is_normalizable("identifier"));
+    assert!(is_normalizable("type_identifier"));
+    assert!(is_normalizable("field_identifier"));
+}
+
+#[test]
+fn normalizable_literals() {
+    assert!(is_normalizable("integer_literal"));
+    assert!(is_normalizable("string_literal"));
+    assert!(is_normalizable("float_literal"));
+}
+
+#[test]
+fn non_normalizable() {
+    assert!(!is_normalizable("function_item"));
+    assert!(!is_normalizable("let_declaration"));
+    assert!(!is_normalizable("binary_expression"));
+}
+
+#[test]
+fn identifier_check() {
+    assert!(is_identifier("identifier"));
+    assert!(is_identifier("type_identifier"));
+    assert!(!is_identifier("integer_literal"));
+    assert!(!is_identifier("string_literal"));
+}
+
+#[test]
+fn significant_kind_check() {
+    assert!(is_significant("function_item"));
+    assert!(is_significant("function_definition"));
+    assert!(is_significant("class_declaration"));
+    assert!(is_significant("struct_item"));
+    assert!(!is_significant("identifier"));
+    assert!(!is_significant("binary_expression"));
+}

--- a/packages/clone-detect/hash/src/tests/normalized.rs
+++ b/packages/clone-detect/hash/src/tests/normalized.rs
@@ -1,0 +1,271 @@
+use super::helpers::{parse_js, parse_python, parse_rust};
+use crate::{Dual, dual, hash as normalized};
+
+#[test]
+fn renamed_functions_same() {
+    let source1 = "fn foo() { let x = 1; }";
+    let source2 = "fn bar() { let y = 1; }";
+
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let hash1 = normalized(&tree1, tree1.root_node());
+    let hash2 = normalized(&tree2, tree2.root_node());
+
+    assert_eq!(hash1, hash2);
+}
+
+#[test]
+fn different_structure_different() {
+    let source1 = "fn foo() { let x = 1; }";
+    let source2 = "fn foo() { let x = 1; let y = 2; }";
+
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let hash1 = normalized(&tree1, tree1.root_node());
+    let hash2 = normalized(&tree2, tree2.root_node());
+
+    assert_ne!(hash1, hash2);
+}
+
+#[test]
+fn swapped_identifiers_same() {
+    let source1 = "fn f() { a + b }";
+    let source2 = "fn f() { b + a }";
+
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let hash1 = normalized(&tree1, tree1.root_node());
+    let hash2 = normalized(&tree2, tree2.root_node());
+
+    assert_eq!(hash1, hash2);
+}
+
+#[test]
+fn different_operators_different() {
+    let source1 = "fn f() { a + b }";
+    let source2 = "fn f() { a - b }";
+
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let hash1 = normalized(&tree1, tree1.root_node());
+    let hash2 = normalized(&tree2, tree2.root_node());
+
+    assert_ne!(hash1, hash2);
+}
+
+#[test]
+fn consistent_identifier_mapping() {
+    let source1 = "fn f() { x + x }";
+    let source2 = "fn f() { x + y }";
+
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let hash1 = normalized(&tree1, tree1.root_node());
+    let hash2 = normalized(&tree2, tree2.root_node());
+
+    assert_ne!(hash1, hash2);
+}
+
+#[test]
+fn complex_function() {
+    let source1 = r"
+fn calculate(a: i32, b: i32) -> i32 {
+    let sum = a + b;
+    let product = a * b;
+    sum + product
+}
+";
+    let source2 = r"
+fn compute(x: i32, y: i32) -> i32 {
+    let total = x + y;
+    let result = x * y;
+    total + result
+}
+";
+
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let hash1 = normalized(&tree1, tree1.root_node());
+    let hash2 = normalized(&tree2, tree2.root_node());
+
+    assert_eq!(hash1, hash2);
+}
+
+#[test]
+fn different_arg_count() {
+    let source1 = "fn f(a: i32) { a }";
+    let source2 = "fn f(a: i32, b: i32) { a }";
+
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let hash1 = normalized(&tree1, tree1.root_node());
+    let hash2 = normalized(&tree2, tree2.root_node());
+
+    assert_ne!(hash1, hash2);
+}
+
+#[test]
+fn different_types() {
+    let source1 = "fn f(a: i32) { a }";
+    let source2 = "fn f(a: i64) { a }";
+
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let hash1 = normalized(&tree1, tree1.root_node());
+    let hash2 = normalized(&tree2, tree2.root_node());
+
+    assert_ne!(hash1, hash2);
+}
+
+#[test]
+fn dual_returns_both() {
+    let source = "fn foo() { let x = 1; }";
+    let tree = parse_rust(source);
+
+    let Dual {
+        content,
+        normalized,
+    } = dual(&tree, tree.root_node());
+
+    assert_ne!(content, 0);
+    assert_ne!(normalized, 0);
+}
+
+#[test]
+fn dual_content_differs_same() {
+    let source1 = "fn foo() { let x = 1; }";
+    let source2 = "fn bar() { let y = 1; }";
+
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let Dual {
+        content: content1,
+        normalized: normalized1,
+    } = dual(&tree1, tree1.root_node());
+    let Dual {
+        content: content2,
+        normalized: normalized2,
+    } = dual(&tree2, tree2.root_node());
+
+    assert_ne!(content1, content2);
+    assert_eq!(normalized1, normalized2);
+}
+
+#[test]
+fn javascript() {
+    let source1 = "function add(a, b) { return a + b; }";
+    let source2 = "function sum(x, y) { return x + y; }";
+
+    let tree1 = parse_js(source1);
+    let tree2 = parse_js(source2);
+
+    let hash1 = normalized(&tree1, tree1.root_node());
+    let hash2 = normalized(&tree2, tree2.root_node());
+
+    assert_eq!(hash1, hash2);
+}
+
+#[test]
+fn python() {
+    let source1 = "def add(a, b):\n    return a + b";
+    let source2 = "def sum(x, y):\n    return x + y";
+
+    let tree1 = parse_python(source1);
+    let tree2 = parse_python(source2);
+
+    let hash1 = normalized(&tree1, tree1.root_node());
+    let hash2 = normalized(&tree2, tree2.root_node());
+
+    assert_eq!(hash1, hash2);
+}
+
+#[test]
+fn empty_function() {
+    let source = "fn empty() {}";
+    let tree = parse_rust(source);
+
+    let hash = normalized(&tree, tree.root_node());
+    assert_ne!(hash, 0);
+}
+
+#[test]
+fn nested_functions() {
+    let source1 = r"
+fn outer() {
+    fn inner() {
+        let x = 1;
+    }
+}
+";
+    let source2 = r"
+fn wrapper() {
+    fn nested() {
+        let y = 1;
+    }
+}
+";
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let hash1 = normalized(&tree1, tree1.root_node());
+    let hash2 = normalized(&tree2, tree2.root_node());
+
+    assert_eq!(hash1, hash2);
+}
+
+#[test]
+fn recursive_function() {
+    let source1 = r"
+fn factorial(n: i32) -> i32 {
+    if n <= 1 { 1 } else { n * factorial(n - 1) }
+}
+";
+    let source2 = r"
+fn fact(x: i32) -> i32 {
+    if x <= 1 { 1 } else { x * fact(x - 1) }
+}
+";
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let hash1 = normalized(&tree1, tree1.root_node());
+    let hash2 = normalized(&tree2, tree2.root_node());
+
+    assert_eq!(hash1, hash2);
+}
+
+#[test]
+fn closure() {
+    let source1 = "fn f() { let add = |a, b| a + b; }";
+    let source2 = "fn g() { let sum = |x, y| x + y; }";
+
+    let tree1 = parse_rust(source1);
+    let tree2 = parse_rust(source2);
+
+    let hash1 = normalized(&tree1, tree1.root_node());
+    let hash2 = normalized(&tree2, tree2.root_node());
+
+    assert_eq!(hash1, hash2);
+}
+
+#[test]
+fn deterministic() {
+    let source = "fn foo() { let x = 1; let y = 2; x + y }";
+    let tree = parse_rust(source);
+
+    let hash1 = normalized(&tree, tree.root_node());
+    let hash2 = normalized(&tree, tree.root_node());
+    let hash3 = normalized(&tree, tree.root_node());
+
+    assert_eq!(hash1, hash2);
+    assert_eq!(hash2, hash3);
+}

--- a/packages/clone-detect/pragma/Cargo.toml
+++ b/packages/clone-detect/pragma/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "clone-pragma"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Pragma detection for clone detection (e.g., clone:ignore comments)"
+
+[dependencies]
+ast-merge-ast.workspace = true
+tree-sitter.workspace = true
+
+[dev-dependencies]
+ast-merge-langs.workspace = true
+
+[lints]
+workspace = true

--- a/packages/clone-detect/pragma/package.nix
+++ b/packages/clone-detect/pragma/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "clone-pragma";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/clone-detect/pragma/src/lib.rs
+++ b/packages/clone-detect/pragma/src/lib.rs
@@ -1,0 +1,155 @@
+use std::ops::Range;
+
+use ast_merge_ast::Tree;
+
+const COMMENT_KINDS: &[&str] = &[
+    "comment",
+    "line_comment",
+    "block_comment",
+    "comment",
+    "comment",
+];
+
+fn is_comment(kind: &str) -> bool {
+    COMMENT_KINDS.contains(&kind)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Pragma {
+    Ignore,
+    IgnoreStart,
+    IgnoreEnd,
+    IgnoreFile,
+}
+
+pub(crate) fn parse_text(text: &str) -> Option<Pragma> {
+    let text = text
+        .trim()
+        .trim_start_matches("//")
+        .trim_start_matches('#')
+        .trim_start_matches("/*")
+        .trim_end_matches("*/")
+        .trim_start_matches("--")
+        .trim();
+
+    let pragma = text.strip_prefix("clone:")?;
+    // Reject "clone: ignore" (space after colon) — pragmas must be tight like "clone:ignore".
+    match pragma
+        .split_once(char::is_whitespace)
+        .map_or(pragma, |(word, _)| word)
+    {
+        "ignore-file" => Some(Pragma::IgnoreFile),
+        "ignore-start" => Some(Pragma::IgnoreStart),
+        "ignore-end" => Some(Pragma::IgnoreEnd),
+        "ignore" => Some(Pragma::Ignore),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Info {
+    pub ignore_file: bool,
+    pub ignored_ranges: Vec<Range<usize>>,
+}
+
+impl Info {
+    #[must_use]
+    pub fn is_ignored(&self, range: &Range<usize>) -> bool {
+        if self.ignore_file {
+            return true;
+        }
+        self.ignored_ranges
+            .iter()
+            .any(|ignored| ranges_overlap(ignored, range))
+    }
+}
+
+fn ranges_overlap(a: &Range<usize>, b: &Range<usize>) -> bool {
+    a.start < b.end && b.start < a.end
+}
+
+struct ScanState {
+    in_ignore_region: bool,
+    ignore_region_start: Option<usize>,
+    ignore_next: Option<usize>,
+}
+
+struct ScanContext<'a> {
+    tree: &'a Tree,
+    info: &'a mut Info,
+    state: &'a mut ScanState,
+}
+
+#[must_use]
+pub fn scan(tree: &Tree) -> Info {
+    let mut info = Info::default();
+    let mut state = ScanState {
+        in_ignore_region: false,
+        ignore_region_start: None,
+        ignore_next: None,
+    };
+
+    let root = tree.root_node();
+    scan_recursive(
+        &mut ScanContext {
+            tree,
+            info: &mut info,
+            state: &mut state,
+        },
+        root,
+    );
+
+    if let Some(start) = state.ignore_region_start {
+        info.ignored_ranges.push(start..tree.source().len());
+    }
+
+    info
+}
+
+fn scan_recursive(ctx: &mut ScanContext<'_>, node: tree_sitter::Node<'_>) {
+    let kind = node.kind();
+
+    if let Some(comment_end) = ctx.state.ignore_next {
+        if node.start_byte() >= comment_end && !is_comment(kind) {
+            ctx.info.ignored_ranges.push(node.byte_range());
+            ctx.state.ignore_next = None;
+        }
+    }
+
+    if is_comment(kind) {
+        let text = ctx.tree.node_text(node);
+        if let Some(pragma) = parse_text(text) {
+            match pragma {
+                Pragma::IgnoreFile => {
+                    ctx.info.ignore_file = true;
+                }
+                Pragma::Ignore => {
+                    ctx.state.ignore_next = Some(node.end_byte());
+                }
+                Pragma::IgnoreStart => {
+                    ctx.state.in_ignore_region = true;
+                    ctx.state.ignore_region_start = Some(node.end_byte());
+                }
+                Pragma::IgnoreEnd => {
+                    if let Some(start) = ctx.state.ignore_region_start.take() {
+                        ctx.info.ignored_ranges.push(start..node.start_byte());
+                    }
+                    ctx.state.in_ignore_region = false;
+                }
+            }
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        scan_recursive(ctx, child);
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::string_slice,
+    clippy::single_range_in_vec_init,
+    reason = "Test code with controlled inputs"
+)]
+mod tests;

--- a/packages/clone-detect/pragma/src/tests.rs
+++ b/packages/clone-detect/pragma/src/tests.rs
@@ -1,0 +1,271 @@
+use ast_merge_ast::{Tree, tree};
+use ast_merge_langs::Lang;
+
+use crate::{Info, Pragma, parse_text, ranges_overlap, scan};
+
+fn parse_rust(source: &str) -> Option<Tree> {
+    let lang = Lang::Rust.to_tree_sitter();
+    let result = tree(source, &lang);
+    assert!(result.is_ok());
+    match result {
+        Ok(parsed) => Some(parsed.tree),
+        Err(_) => None,
+    }
+}
+
+fn parse_python(source: &str) -> Option<Tree> {
+    let lang = Lang::Python.to_tree_sitter();
+    let result = tree(source, &lang);
+    assert!(result.is_ok());
+    match result {
+        Ok(parsed) => Some(parsed.tree),
+        Err(_) => None,
+    }
+}
+
+fn parse_js(source: &str) -> Option<Tree> {
+    let lang = Lang::JavaScript.to_tree_sitter();
+    let result = tree(source, &lang);
+    assert!(result.is_ok());
+    match result {
+        Ok(parsed) => Some(parsed.tree),
+        Err(_) => None,
+    }
+}
+
+#[test]
+fn test_parse_ignore() {
+    assert_eq!(parse_text("// clone:ignore"), Some(Pragma::Ignore));
+    assert_eq!(parse_text("# clone:ignore"), Some(Pragma::Ignore));
+    assert_eq!(parse_text("/* clone:ignore */"), Some(Pragma::Ignore));
+    assert_eq!(parse_text("-- clone:ignore"), Some(Pragma::Ignore));
+}
+
+#[test]
+fn test_parse_ignore_file() {
+    assert_eq!(parse_text("// clone:ignore-file"), Some(Pragma::IgnoreFile));
+}
+
+#[test]
+fn test_parse_ignore_region() {
+    assert_eq!(
+        parse_text("// clone:ignore-start"),
+        Some(Pragma::IgnoreStart)
+    );
+    assert_eq!(parse_text("// clone:ignore-end"), Some(Pragma::IgnoreEnd));
+}
+
+#[test]
+fn test_parse_no_match() {
+    assert_eq!(parse_text("// just a comment"), None);
+    assert_eq!(parse_text("// TODO: fix this"), None);
+    assert_eq!(parse_text("// clone: ignore"), None);
+}
+
+#[test]
+fn test_rust_ignore_file() {
+    let source = r"
+// clone:ignore-file
+
+fn foo() {
+    let x = 1;
+}
+
+fn bar() {
+    let y = 2;
+}
+";
+    let Some(tree) = parse_rust(source) else {
+        return;
+    };
+    let info = scan(&tree);
+
+    assert!(info.ignore_file);
+}
+
+#[test]
+fn test_rust_ignore_next() {
+    let source = r"
+fn keep_this() {
+    let x = 1;
+}
+
+// clone:ignore
+fn ignore_this() {
+    let y = 2;
+}
+
+fn also_keep() {
+    let z = 3;
+}
+";
+    let Some(tree) = parse_rust(source) else {
+        return;
+    };
+    let info = scan(&tree);
+
+    assert!(!info.ignore_file);
+    assert_eq!(info.ignored_ranges.len(), 1);
+
+    let Some(ignored) = info.ignored_ranges.first() else {
+        panic!("ignore pragma should produce one ignored range");
+    };
+    assert!(source[ignored.clone()].contains("ignore_this"));
+    assert!(!source[ignored.clone()].contains("keep_this"));
+    assert!(!source[ignored.clone()].contains("also_keep"));
+}
+
+#[test]
+fn test_rust_ignore_region() {
+    let source = r"
+fn keep() {}
+
+// clone:ignore-start
+fn ignored1() {}
+fn ignored2() {}
+// clone:ignore-end
+
+fn also_keep() {}
+";
+    let Some(tree) = parse_rust(source) else {
+        return;
+    };
+    let info = scan(&tree);
+
+    assert!(!info.ignore_file);
+    assert_eq!(info.ignored_ranges.len(), 1);
+
+    let Some(ignored) = info.ignored_ranges.first() else {
+        panic!("ignore region should produce one ignored range");
+    };
+    assert!(source[ignored.clone()].contains("ignored1"));
+    assert!(source[ignored.clone()].contains("ignored2"));
+    assert!(!source[ignored.clone()].contains("keep"));
+    assert!(!source[ignored.clone()].contains("also_keep"));
+}
+
+#[test]
+fn test_rust_no_pragmas() {
+    let source = r"
+fn foo() { let x = 1; }
+fn bar() { let y = 2; }
+";
+    let Some(tree) = parse_rust(source) else {
+        return;
+    };
+    let info = scan(&tree);
+
+    assert!(!info.ignore_file);
+    assert!(info.ignored_ranges.is_empty());
+}
+
+#[test]
+fn test_python_ignore_file() {
+    let source = r"
+# clone:ignore-file
+
+def foo():
+    x = 1
+
+def bar():
+    y = 2
+";
+    let Some(tree) = parse_python(source) else {
+        return;
+    };
+    let info = scan(&tree);
+
+    assert!(info.ignore_file);
+}
+
+#[test]
+fn test_python_ignore_next() {
+    let source = r"
+def keep():
+    x = 1
+
+# clone:ignore
+def ignore_me():
+    y = 2
+
+def also_keep():
+    z = 3
+";
+    let Some(tree) = parse_python(source) else {
+        return;
+    };
+    let info = scan(&tree);
+
+    assert!(!info.ignore_file);
+    assert_eq!(info.ignored_ranges.len(), 1);
+}
+
+#[test]
+fn test_js_ignore_file() {
+    let source = r"
+// clone:ignore-file
+
+function foo() {
+    const x = 1;
+}
+";
+    let Some(tree) = parse_js(source) else {
+        return;
+    };
+    let info = scan(&tree);
+
+    assert!(info.ignore_file);
+}
+
+#[test]
+fn test_js_block_comment() {
+    let source = r"
+function keep() {}
+
+/* clone:ignore */
+function ignored() {}
+
+function alsoKeep() {}
+";
+    let Some(tree) = parse_js(source) else {
+        return;
+    };
+    let info = scan(&tree);
+
+    assert!(!info.ignore_file);
+    assert_eq!(info.ignored_ranges.len(), 1);
+}
+
+#[test]
+fn test_is_ignored_file() {
+    let info = Info {
+        ignore_file: true,
+        ignored_ranges: vec![],
+    };
+
+    assert!(info.is_ignored(&(0..100)));
+    assert!(info.is_ignored(&(50..150)));
+}
+
+#[test]
+fn test_is_ignored_range() {
+    let info = Info {
+        ignore_file: false,
+        ignored_ranges: vec![50..100],
+    };
+
+    assert!(!info.is_ignored(&(0..49)));
+    assert!(info.is_ignored(&(40..60)));
+    assert!(info.is_ignored(&(60..80)));
+    assert!(info.is_ignored(&(90..110)));
+    assert!(!info.is_ignored(&(100..150)));
+}
+
+#[test]
+fn test_ranges_overlap() {
+    assert!(ranges_overlap(&(0..10), &(5..15)));
+    assert!(ranges_overlap(&(5..15), &(0..10)));
+    assert!(ranges_overlap(&(0..10), &(0..10)));
+    assert!(!ranges_overlap(&(0..10), &(10..20)));
+    assert!(!ranges_overlap(&(0..10), &(20..30)));
+}

--- a/packages/clone-detect/scanner/Cargo.toml
+++ b/packages/clone-detect/scanner/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "clone-scanner"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Multi-file scanner for code clone detection"
+
+[dependencies]
+snafu.workspace = true
+clone-hash.workspace = true
+clone-pragma.workspace = true
+ast-merge-ast.workspace = true
+ast-merge-langs.workspace = true
+rustc-hash.workspace = true
+ignore.workspace = true
+parking_lot.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/packages/clone-detect/scanner/package.nix
+++ b/packages/clone-detect/scanner/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "clone-scanner";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/clone-detect/scanner/src/index.rs
+++ b/packages/clone-detect/scanner/src/index.rs
@@ -1,0 +1,64 @@
+use clone_hash::NodeInfo;
+use rustc_hash::FxHashMap;
+
+pub struct Entry {
+    pub file_id: usize,
+    pub node_idx: usize,
+}
+
+/// A location in the clone index: file ID and node index within that file.
+#[derive(Debug, Clone, Copy)]
+pub struct Location {
+    pub file_id: usize,
+    pub node_idx: usize,
+}
+
+/// A clone candidate: a hash and all locations that share it.
+pub struct CandidateEntry<'a> {
+    pub hash: &'a u64,
+    pub locations: &'a Vec<Location>,
+}
+
+#[derive(Debug, Default)]
+pub struct Hash {
+    pub content_index: FxHashMap<u64, Vec<Location>>,
+    pub normalized_index: FxHashMap<u64, Vec<Location>>,
+}
+
+impl Hash {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add(&mut self, entry: &Entry, node: &NodeInfo) {
+        let loc = Location {
+            file_id: entry.file_id,
+            node_idx: entry.node_idx,
+        };
+
+        self.content_index
+            .entry(node.content_hash)
+            .or_default()
+            .push(loc);
+
+        self.normalized_index
+            .entry(node.normalized_hash)
+            .or_default()
+            .push(loc);
+    }
+
+    pub fn type1_candidates(&self) -> impl Iterator<Item = CandidateEntry<'_>> {
+        self.content_index
+            .iter()
+            .filter(|(_, v)| v.len() > 1)
+            .map(|(hash, locations)| CandidateEntry { hash, locations })
+    }
+
+    pub fn type2_candidates(&self) -> impl Iterator<Item = CandidateEntry<'_>> {
+        self.normalized_index
+            .iter()
+            .filter(|(_, v)| v.len() > 1)
+            .map(|(hash, locations)| CandidateEntry { hash, locations })
+    }
+}

--- a/packages/clone-detect/scanner/src/lib.rs
+++ b/packages/clone-detect/scanner/src/lib.rs
@@ -1,0 +1,14 @@
+mod index;
+mod scan;
+
+pub use index::{CandidateEntry, Entry, Hash, Location};
+pub use scan::{Config, Error, File, Output, Scanner};
+
+#[cfg(test)]
+mod tests {
+    mod directory;
+    mod file;
+    mod helpers;
+    mod indexing;
+    mod integration;
+}

--- a/packages/clone-detect/scanner/src/scan.rs
+++ b/packages/clone-detect/scanner/src/scan.rs
@@ -1,0 +1,230 @@
+use std::path::{Path, PathBuf};
+
+use ast_merge_ast::tree;
+use ast_merge_langs::{Lang, detect};
+use clone_hash::{NodeInfo, significant_nodes};
+use clone_pragma::scan;
+use ignore::WalkBuilder;
+use parking_lot::Mutex;
+use snafu::ResultExt as _;
+
+use crate::index::Hash;
+
+const ALWAYS_IGNORED_DIRS: &[&str] = &[".git"];
+
+/// cap parallel threads to avoid OOM from concurrent tree-sitter parses
+const MAX_THREADS: usize = 8;
+
+#[derive(Debug)]
+pub struct File {
+    pub path: PathBuf,
+    pub language: Lang,
+    pub source: String,
+    pub nodes: Vec<NodeInfo>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub min_lines: usize,
+    pub min_nodes: usize,
+    pub respect_gitignore: bool,
+    pub include_hidden: bool,
+}
+
+/// Minimum source lines for a fragment to be considered a clone candidate.
+const DEFAULT_MIN_LINES: usize = 5;
+
+/// Minimum AST nodes for a fragment to be considered a clone candidate.
+const DEFAULT_MIN_NODES: usize = 10;
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            min_lines: DEFAULT_MIN_LINES,
+            min_nodes: DEFAULT_MIN_NODES,
+            respect_gitignore: true,
+            include_hidden: false,
+        }
+    }
+}
+
+#[derive(Debug, snafu::Snafu)]
+#[snafu(visibility(pub))]
+pub enum Error {
+    #[snafu(display("failed to read directory entry"))]
+    WalkEntry { source: ignore::Error },
+
+    #[snafu(display("failed to stat {path}"))]
+    Stat {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("failed to read {path}"))]
+    ReadFile {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("failed to parse {path}"))]
+    Parse {
+        path: String,
+        source: ast_merge_ast::Error,
+    },
+}
+
+pub struct Scanner {
+    config: Config,
+}
+
+impl Scanner {
+    #[must_use]
+    pub fn new(config: Config) -> Self {
+        Self { config }
+    }
+
+    #[must_use]
+    pub fn with_defaults() -> Self {
+        Self::new(Config::default())
+    }
+
+    pub fn directory(&self, path: &Path) -> Result<Output, Error> {
+        let results: Mutex<Vec<File>> = Mutex::new(Vec::new());
+        let error: Mutex<Option<Error>> = Mutex::new(None);
+
+        let mut builder = WalkBuilder::new(path);
+        builder
+            .git_ignore(self.config.respect_gitignore)
+            .git_global(self.config.respect_gitignore)
+            .git_exclude(self.config.respect_gitignore)
+            .hidden(!self.config.include_hidden)
+            .ignore(self.config.respect_gitignore)
+            .threads(MAX_THREADS);
+        builder.filter_entry(|entry| {
+            let name = entry.file_name();
+            name.to_str()
+                .is_none_or(|name| !ALWAYS_IGNORED_DIRS.contains(&name))
+        });
+
+        builder.build_parallel().run(|| {
+            let results = &results;
+            let error = &error;
+            Box::new(move |entry| {
+                if error.lock().is_some() {
+                    return ignore::WalkState::Quit;
+                }
+
+                let entry = match entry {
+                    Ok(e) => e,
+                    Err(e) => {
+                        *error.lock() = Some(Error::WalkEntry { source: e });
+                        return ignore::WalkState::Quit;
+                    }
+                };
+
+                if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                    return ignore::WalkState::Continue;
+                }
+
+                match self.file(entry.path()) {
+                    Ok(Some(scanned)) => {
+                        results.lock().push(scanned);
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        *error.lock() = Some(e);
+                        return ignore::WalkState::Quit;
+                    }
+                }
+
+                ignore::WalkState::Continue
+            })
+        });
+
+        if let Some(e) = error.into_inner() {
+            return Err(e);
+        }
+
+        let mut files = results.into_inner();
+        files.sort_by(|a, b| a.path.cmp(&b.path));
+        let mut index = Hash::new();
+        for (file_id, file) in files.iter().enumerate() {
+            for (node_idx, node) in file.nodes.iter().enumerate() {
+                index.add(&crate::index::Entry { file_id, node_idx }, node);
+            }
+        }
+
+        Ok(Output { files, index })
+    }
+
+    pub fn file(&self, path: &Path) -> Result<Option<File>, Error> {
+        let path_str = path.display().to_string();
+        let metadata = std::fs::symlink_metadata(path).context(StatSnafu { path: &path_str })?;
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            return Ok(None);
+        }
+
+        let Some(language) = detect(path) else {
+            return Ok(None);
+        };
+
+        let bytes = match std::fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                let is_broken_symlink = err.kind() == std::io::ErrorKind::NotFound
+                    && std::fs::symlink_metadata(path).is_ok_and(|m| m.file_type().is_symlink());
+                if is_broken_symlink {
+                    tracing::warn!(
+                        path = %path.display(),
+                        "skipping broken symlink during clone scan",
+                    );
+                    return Ok(None);
+                }
+                return Err(err).context(ReadFileSnafu { path: path_str });
+            }
+        };
+
+        let Ok(source) = String::from_utf8(bytes) else {
+            return Ok(None);
+        };
+
+        let tree =
+            tree(&source, &language.to_tree_sitter()).context(ParseSnafu { path: path_str })?;
+
+        let pragma_info = scan(&tree.tree);
+
+        if pragma_info.ignore_file {
+            return Ok(None);
+        }
+
+        let nodes = significant_nodes(&tree.tree, self.config.min_lines, self.config.min_nodes)
+            .into_iter()
+            .filter(|node| !pragma_info.is_ignored(&node.byte_range))
+            .collect();
+
+        Ok(Some(File {
+            path: path.to_path_buf(),
+            language,
+            source,
+            nodes,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct Output {
+    pub files: Vec<File>,
+    pub index: Hash,
+}
+
+impl Output {
+    #[must_use]
+    pub fn total_nodes(&self) -> usize {
+        self.files.iter().map(|f| f.nodes.len()).sum()
+    }
+
+    #[must_use]
+    pub fn total_files(&self) -> usize {
+        self.files.len()
+    }
+}

--- a/packages/clone-detect/scanner/src/tests/directory.rs
+++ b/packages/clone-detect/scanner/src/tests/directory.rs
@@ -1,0 +1,166 @@
+use ast_merge_langs::Lang;
+
+use super::helpers::{create_temp_dir, create_temp_file};
+use crate::Scanner;
+
+#[test]
+fn single_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let content = r"
+fn foo() {
+    let x = 1;
+    let y = 2;
+    let z = x + y;
+    z
+}
+";
+    create_temp_file(dir.path(), "test.rs", content);
+
+    let scanner = Scanner::with_defaults();
+    let result = scanner.directory(dir.path()).unwrap();
+
+    assert_eq!(result.files.len(), 1);
+    assert!(!result.index.content_index.is_empty() || !result.index.normalized_index.is_empty());
+}
+
+#[test]
+fn multiple_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let content = r"
+fn foo() {
+    let x = 1;
+    let y = 2;
+    x + y
+}
+";
+    create_temp_file(dir.path(), "file1.rs", content);
+    create_temp_file(dir.path(), "file2.rs", content);
+    create_temp_file(dir.path(), "file3.rs", content);
+
+    let scanner = Scanner::with_defaults();
+    let result = scanner.directory(dir.path()).unwrap();
+
+    assert_eq!(result.files.len(), 3);
+}
+
+#[test]
+fn nested_directories() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = create_temp_dir(dir.path(), "src");
+    let lib_dir = create_temp_dir(&src_dir, "lib");
+
+    let content = r"
+fn nested() {
+    let a = 1;
+    let b = 2;
+    a + b
+}
+";
+    create_temp_file(dir.path(), "root.rs", content);
+    create_temp_file(&src_dir, "src.rs", content);
+    create_temp_file(&lib_dir, "lib.rs", content);
+
+    let scanner = Scanner::with_defaults();
+    let result = scanner.directory(dir.path()).unwrap();
+
+    assert_eq!(result.files.len(), 3);
+}
+
+#[test]
+fn ignores_node_modules() {
+    let dir = tempfile::tempdir().unwrap();
+
+    create_temp_dir(dir.path(), ".git");
+    create_temp_file(dir.path(), ".gitignore", "node_modules/\n");
+
+    let node_modules = create_temp_dir(dir.path(), "node_modules");
+
+    let content = r"
+fn foo() {
+    let x = 1;
+    let y = 2;
+    x + y
+}
+";
+    create_temp_file(dir.path(), "main.rs", content);
+    create_temp_file(&node_modules, "ignored.js", "function foo() { return 1; }");
+
+    let scanner = Scanner::with_defaults();
+    let result = scanner.directory(dir.path()).unwrap();
+
+    assert_eq!(result.files.len(), 1);
+    assert!(
+        result
+            .files
+            .first()
+            .unwrap()
+            .path
+            .file_name()
+            .is_some_and(|name| name == std::ffi::OsStr::new("main.rs"))
+    );
+}
+
+#[test]
+fn ignores_target() {
+    let dir = tempfile::tempdir().unwrap();
+
+    create_temp_dir(dir.path(), ".git");
+    create_temp_file(dir.path(), ".gitignore", "target/\n");
+
+    let target_dir = create_temp_dir(dir.path(), "target");
+
+    let content = r"
+fn foo() {
+    let x = 1;
+    let y = 2;
+    x + y
+}
+";
+    create_temp_file(dir.path(), "main.rs", content);
+    create_temp_file(&target_dir, "ignored.rs", content);
+
+    let scanner = Scanner::with_defaults();
+    let result = scanner.directory(dir.path()).unwrap();
+
+    assert_eq!(result.files.len(), 1);
+}
+
+#[test]
+fn mixed_languages() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let rust_content = r"
+fn rust_func() {
+    let x = 1;
+    let y = 2;
+    x + y
+}
+";
+    let js_content = r"
+function jsFunc() {
+    const x = 1;
+    const y = 2;
+    return x + y;
+}
+";
+    let py_content = r"
+def py_func():
+    x = 1
+    y = 2
+    return x + y
+";
+
+    create_temp_file(dir.path(), "main.rs", rust_content);
+    create_temp_file(dir.path(), "app.js", js_content);
+    create_temp_file(dir.path(), "script.py", py_content);
+
+    let scanner = Scanner::with_defaults();
+    let result = scanner.directory(dir.path()).unwrap();
+
+    assert_eq!(result.files.len(), 3);
+
+    let languages: Vec<_> = result.files.iter().map(|f| f.language).collect();
+    assert!(languages.contains(&Lang::Rust));
+    assert!(languages.contains(&Lang::JavaScript));
+    assert!(languages.contains(&Lang::Python));
+}

--- a/packages/clone-detect/scanner/src/tests/file.rs
+++ b/packages/clone-detect/scanner/src/tests/file.rs
@@ -1,0 +1,109 @@
+use ast_merge_langs::Lang;
+
+use super::helpers::create_temp_file;
+use crate::Scanner;
+
+#[test]
+fn single_rust() {
+    let dir = tempfile::tempdir().unwrap();
+    let content = r"
+fn foo() {
+    let x = 1;
+    let y = 2;
+    let z = x + y;
+    z
+}
+";
+    let path = create_temp_file(dir.path(), "test.rs", content);
+
+    let scanner = Scanner::with_defaults();
+    let result = scanner.file(&path).unwrap();
+
+    assert!(result.is_some());
+    let scanned = result.unwrap();
+    assert_eq!(scanned.language, Lang::Rust);
+    assert!(!scanned.nodes.is_empty());
+}
+
+#[test]
+fn javascript() {
+    let dir = tempfile::tempdir().unwrap();
+    let content = r"
+function calculate(a, b) {
+    const sum = a + b;
+    const product = a * b;
+    return sum + product;
+}
+";
+    let path = create_temp_file(dir.path(), "test.js", content);
+
+    let scanner = Scanner::with_defaults();
+    let result = scanner.file(&path).unwrap();
+
+    assert!(result.is_some());
+    let scanned = result.unwrap();
+    assert_eq!(scanned.language, Lang::JavaScript);
+}
+
+#[test]
+fn python() {
+    let dir = tempfile::tempdir().unwrap();
+    let content = r"
+def calculate(a, b):
+    sum_val = a + b
+    product = a * b
+    return sum_val + product
+";
+    let path = create_temp_file(dir.path(), "test.py", content);
+
+    let scanner = Scanner::with_defaults();
+    let result = scanner.file(&path).unwrap();
+
+    assert!(result.is_some());
+    let scanned = result.unwrap();
+    assert_eq!(scanned.language, Lang::Python);
+}
+
+#[test]
+fn unknown_extension() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = create_temp_file(dir.path(), "test.xyz", "some content");
+
+    let scanner = Scanner::with_defaults();
+    let result = scanner.file(&path).unwrap();
+
+    assert!(result.is_none());
+}
+
+#[test]
+fn empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = create_temp_file(dir.path(), "empty.rs", "");
+
+    let scanner = Scanner::with_defaults();
+    let result = scanner.file(&path).unwrap();
+
+    assert!(result.is_some());
+    let scanned = result.unwrap();
+    assert!(scanned.nodes.is_empty());
+}
+
+#[test]
+fn scanned_fields() {
+    let dir = tempfile::tempdir().unwrap();
+    let content = r"
+fn test_function() {
+    let x = 1;
+    let y = 2;
+    x + y
+}
+";
+    let path = create_temp_file(dir.path(), "test.rs", content);
+
+    let scanner = Scanner::with_defaults();
+    let result = scanner.file(&path).unwrap().unwrap();
+
+    assert_eq!(result.path, path);
+    assert_eq!(result.language, Lang::Rust);
+    assert!(!result.source.is_empty());
+}

--- a/packages/clone-detect/scanner/src/tests/helpers.rs
+++ b/packages/clone-detect/scanner/src/tests/helpers.rs
@@ -1,0 +1,25 @@
+use std::path::{Path, PathBuf};
+
+use crate::Config;
+
+pub fn create_temp_file(dir: &Path, name: &str, content: &str) -> PathBuf {
+    let path = dir.join(name);
+    let mut file = std::fs::File::create(&path).unwrap();
+    std::io::Write::write_all(&mut file, content.as_bytes()).unwrap();
+    path
+}
+
+pub fn create_temp_dir(parent: &Path, name: &str) -> PathBuf {
+    let path = parent.join(name);
+    std::fs::create_dir_all(&path).unwrap();
+    path
+}
+
+pub fn test_scan_config() -> Config {
+    Config {
+        min_lines: 1,
+        min_nodes: 1,
+        respect_gitignore: false,
+        include_hidden: false,
+    }
+}

--- a/packages/clone-detect/scanner/src/tests/indexing.rs
+++ b/packages/clone-detect/scanner/src/tests/indexing.rs
@@ -1,0 +1,146 @@
+use clone_hash::NodeInfo;
+
+use crate::{Hash, index::Entry};
+
+#[test]
+fn new_index_is_empty() {
+    let index = Hash::new();
+    assert!(index.content_index.is_empty());
+    assert!(index.normalized_index.is_empty());
+}
+
+#[test]
+fn add_populates_both_indexes() {
+    let mut index = Hash::new();
+    let node = NodeInfo {
+        content_hash: 123,
+        normalized_hash: 456,
+        kind: "function_item",
+        byte_range: 0..10,
+        start_line: 0,
+        end_line: 5,
+        node_count: 10,
+        children: vec![],
+        subtree_features: vec![],
+    };
+
+    index.add(
+        &Entry {
+            file_id: 0,
+            node_idx: 0,
+        },
+        &node,
+    );
+
+    assert!(index.content_index.contains_key(&123));
+    assert!(index.normalized_index.contains_key(&456));
+}
+
+fn make_node(content_hash: u64, normalized_hash: u64, byte_start: usize) -> NodeInfo {
+    NodeInfo {
+        content_hash,
+        normalized_hash,
+        kind: "function_item",
+        byte_range: byte_start..(byte_start + 10),
+        start_line: byte_start / 10,
+        end_line: byte_start / 10 + 5,
+        node_count: 10,
+        children: vec![],
+        subtree_features: vec![],
+    }
+}
+
+#[test]
+fn type1_candidates() {
+    let mut index = Hash::new();
+
+    let node1 = make_node(123, 456, 0);
+    let node2 = make_node(123, 789, 100);
+    let node3 = make_node(999, 456, 200);
+
+    index.add(
+        &Entry {
+            file_id: 0,
+            node_idx: 0,
+        },
+        &node1,
+    );
+    index.add(
+        &Entry {
+            file_id: 1,
+            node_idx: 0,
+        },
+        &node2,
+    );
+    index.add(
+        &Entry {
+            file_id: 2,
+            node_idx: 0,
+        },
+        &node3,
+    );
+
+    let candidates: Vec<_> = index.type1_candidates().collect();
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(*candidates.first().unwrap().hash, 123);
+}
+
+#[test]
+fn type2_candidates() {
+    let mut index = Hash::new();
+
+    let node1 = make_node(111, 456, 0);
+    let node2 = make_node(222, 456, 100);
+    let node3 = make_node(333, 789, 200);
+
+    index.add(
+        &Entry {
+            file_id: 0,
+            node_idx: 0,
+        },
+        &node1,
+    );
+    index.add(
+        &Entry {
+            file_id: 1,
+            node_idx: 0,
+        },
+        &node2,
+    );
+    index.add(
+        &Entry {
+            file_id: 2,
+            node_idx: 0,
+        },
+        &node3,
+    );
+
+    let candidates: Vec<_> = index.type2_candidates().collect();
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(*candidates.first().unwrap().hash, 456);
+}
+
+#[test]
+fn no_candidates() {
+    let mut index = Hash::new();
+
+    let node1 = make_node(111, 111, 0);
+    let node2 = make_node(222, 222, 100);
+
+    index.add(
+        &Entry {
+            file_id: 0,
+            node_idx: 0,
+        },
+        &node1,
+    );
+    index.add(
+        &Entry {
+            file_id: 1,
+            node_idx: 0,
+        },
+        &node2,
+    );
+    assert!(index.type1_candidates().next().is_none());
+    assert!(index.type2_candidates().next().is_none());
+}

--- a/packages/clone-detect/scanner/src/tests/integration.rs
+++ b/packages/clone-detect/scanner/src/tests/integration.rs
@@ -1,0 +1,99 @@
+use super::helpers::{create_temp_file, test_scan_config};
+use crate::{Config, Scanner};
+
+#[test]
+fn config_defaults() {
+    let config = Config::default();
+    assert_eq!(config.min_lines, 5);
+    assert_eq!(config.min_nodes, 10);
+    assert!(config.respect_gitignore);
+    assert!(!config.include_hidden);
+}
+
+#[test]
+fn config_custom() {
+    let config = Config {
+        min_lines: 10,
+        min_nodes: 20,
+        respect_gitignore: false,
+        include_hidden: true,
+    };
+
+    assert_eq!(config.min_lines, 10);
+    assert_eq!(config.min_nodes, 20);
+    assert!(!config.respect_gitignore);
+    assert!(config.include_hidden);
+}
+
+#[test]
+fn total_nodes_and_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let content = r"
+fn foo() {
+    let x = 1;
+    let y = 2;
+    x + y
+}
+
+fn bar() {
+    let a = 3;
+    let b = 4;
+    a * b
+}
+";
+    create_temp_file(dir.path(), "test.rs", content);
+
+    let scanner = Scanner::with_defaults();
+    let result = scanner.directory(dir.path()).unwrap();
+
+    assert!(result.total_nodes() > 0);
+    assert_eq!(result.total_files(), 1);
+}
+
+#[test]
+fn detects_duplicate_functions() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let content = r"
+fn duplicate_function() {
+    let x = 1;
+    let y = 2;
+    let z = x + y;
+    z
+}
+";
+    create_temp_file(dir.path(), "file1.rs", content);
+    create_temp_file(dir.path(), "file2.rs", content);
+
+    let scanner = Scanner::new(test_scan_config());
+    let result = scanner.directory(dir.path()).unwrap();
+
+    assert_eq!(result.files.len(), 2);
+    assert!(result.index.type1_candidates().next().is_some());
+}
+
+#[test]
+fn detects_renamed_functions() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let content1 = r"
+fn add(a: i32, b: i32) -> i32 {
+    let sum = a + b;
+    sum
+}
+";
+    let content2 = r"
+fn sum(x: i32, y: i32) -> i32 {
+    let result = x + y;
+    result
+}
+";
+    create_temp_file(dir.path(), "file1.rs", content1);
+    create_temp_file(dir.path(), "file2.rs", content2);
+
+    let scanner = Scanner::new(test_scan_config());
+    let result = scanner.directory(dir.path()).unwrap();
+
+    assert_eq!(result.files.len(), 2);
+    assert!(result.index.type2_candidates().next().is_some());
+}

--- a/packages/clone-detect/todo-type-4.md
+++ b/packages/clone-detect/todo-type-4.md
@@ -1,0 +1,83 @@
+# Type-4 Clone Detection (Semantic Clones)
+
+Type-4 clones are semantically equivalent code fragments that achieve the same functionality through different implementations. These cannot be detected through AST structure alone and require ML-based approaches.
+
+## Research Papers
+
+### CodeBERT
+
+- **Paper**: [CodeBERT for Code Clone Detection: A Replication Study](https://www.semanticscholar.org/paper/CodeBERT-for-Code-Clone-Detection:-A-Replication-Arshad-Abid/89a2f0c275823b4c968bfa656b8576743288807e)
+- **Performance**: 96% recall on Type-4 clones
+- **Approach**: Pre-trained transformer model that embeds code into vector space
+- **Limitation**: Recall drops 15-40% on unseen functionalities
+
+### CCStokener
+
+- **Paper**: [Fast yet accurate code clone detection with semantic token](https://www.sciencedirect.com/science/article/abs/pii/S0164121223000134)
+- **Performance**:
+  - Near 100% recall on Type-1 and Type-2
+  - Best recall on Type-3 and Type-4 compared to state-of-the-art
+- **Approach**: Semantic token representation combined with efficient matching
+
+## Implementation Considerations
+
+### Embedding-Based Detection
+
+1. **Code Embedding**: Convert code to vector representations using models like:
+   - CodeBERT
+   - GraphCodeBERT
+   - UniXcoder
+   - CodeSage V2
+
+2. **Similarity Search**: Use approximate nearest neighbor search:
+   - FAISS
+   - Annoy
+   - ScaNN
+
+3. **Threshold Tuning**: Type-4 detection requires careful threshold selection to balance precision/recall
+
+### Challenges
+
+- **Training Data**: Need large corpus of labeled semantic clones
+- **Cross-Language**: Harder to detect semantic clones across languages
+- **Scalability**: Embedding and comparison can be expensive at scale
+- **False Positives**: Common patterns (getters, setters) may be falsely flagged
+
+## Potential Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                   clone-embed                    │
+│  (Code → Vector embeddings via ML model)        │
+├─────────────────────────────────────────────────┤
+│  - Load pre-trained CodeBERT/similar model      │
+│  - Embed significant code blocks                │
+│  - Cache embeddings for incremental detection   │
+└─────────────────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────┐
+│                  clone-index                     │
+│  (Vector similarity search)                     │
+├─────────────────────────────────────────────────┤
+│  - Build FAISS/similar index                    │
+│  - Query for similar vectors                    │
+│  - Return Type-4 candidates                     │
+└─────────────────────────────────────────────────┘
+```
+
+## Dependencies to Consider
+
+```toml
+# For running ONNX models (CodeBERT export)
+ort = "2.0"
+
+# For vector similarity search
+faiss = "0.12"  # or pure-Rust alternatives
+```
+
+## Related Work
+
+- [Detecting Semantic Code Clones by Building AST-based Markov Chains Model](https://dl.acm.org/doi/10.1145/3551349.3560426) (ASE 2022)
+- [Tritor: Detecting Semantic Code Clones by Building Social Networks](https://wu-yueming.github.io/Files/FSE2023_Tritor.pdf) (FSE 2023)
+- [HAG: Hierarchical Attentive Graph Neural Network for Type-4 Detection](https://arxiv.org/html/2506.14470v1)


### PR DESCRIPTION
## What

Ports the `ast-merge` and `clone-detect` Rust crate groups from `indexable-inc/ix` into this monorepo so clone and duplication detection are available to everyone here, not just inside `ix`.

Two binaries are now exposed as flake packages:

- `nix run .#clone` — code clone and duplication detector (Type-1/2/3 plus statement-sequence clones) over tree-sitter ASTs, with `--output json`, a `clone.toml` config, and an SVG duplication badge.
- `nix run .#ast-merge` — AST-aware git merge driver using tree-sitter (29 languages).

## Layout

- `packages/ast-merge/{ast,diff,git,langs,matcher,cli}` — crates `ast-merge-ast`, `ast-merge-diff`, `ast-merge-git`, `ast-merge-langs`, `ast-merge-matcher`, and the `ast-merge` binary.
- `packages/clone-detect/{hash,pragma,scanner,detect,cli}` — crates `clone-hash`, `clone-pragma`, `clone-scanner`, `clone-detect`, and the `clone` binary (crate `clone-cli`).

All 11 crates join the root `[workspace] members` and ride the shared `ix.rustWorkspace.units` graph. The 9 library crates get a `package.nix` with `inRustWorkspace = true` (so their source lands in the workspace filter and their tests run as workspace tests); the two binary crates additionally get `flake`/`packageSet` plus a `default.nix` selecting their binary via `ix.cargoUnit.selectBinaryWithTests`.

## service-init replaced with inline tracing

`ix`'s `service_init` crate was not ported. Both CLI `main` functions now call a small local `init_tracing()` that wires a `tracing-subscriber` `EnvFilter` (from `RUST_LOG`, defaulting to `info`) plus an `fmt` layer on stderr. The `service-init` dependency is dropped from both cli crate manifests and `tracing-subscriber` (with `env-filter`/`fmt`) is added.

## Version reconciliations

The crates compiled cleanly against this repo's existing pins, so no shared crate was bumped:

- `similar`: kept this repo's `2` (ix used `3`); the diff crate only uses `TextDiff`/`Change`/`ChangeTag`/`Algorithm`, stable across both.
- `snafu`: kept registry `0.9` (ix used a git pin of the same `0.9.0`); usage is standard `Snafu`/`ResultExt`/`context`.
- `parking_lot`: kept registry `0.12` (ix used a fork); the scanner only uses `Mutex`.
- `tree-sitter-ocaml` kept at `0.25` (ix `0.24`), `tree-sitter-scala` kept at `0.26` (ix `0.25`); the `LANGUAGE`/`LANGUAGE_OCAML` constants exist in both.

New workspace deps added: `lazy-regex`, `rustc-hash`, `tracing`, `tracing-subscriber`, `insta`, `glob`, and four grammars not previously present (`tree-sitter-language`, `tree-sitter-kotlin-ng`, `tree-sitter-svelte-ng`, `tree-sitter-dockerfile-updated`).

## Validation

- `cargo build -p clone-cli -p ast-merge` — clean.
- `cargo test` across all 11 crates — all pass, 0 failures.
- `nix build .#clone` and `nix build .#ast-merge` — both build (per-unit clippy/policy run in the workspace graph).
- `nix run .#lint` — nixfmt, statix, deadnix, ast-grep all green.
- `nix run .#clone -- packages/clone-detect` reported 7.1% duplication as JSON; `nix run .#ast-merge -- info` reports 29 languages.

A `clone.toml` lives at the repo root as the live config, with ignore globs adjusted for this tree (target, node_modules, vendored, tests, fixtures, snapshots).

---
Made with AI (Claude Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Port clone-detect and ast-merge tools into the workspace
> - Adds the `ast-merge` family of crates (`ast`, `diff`, `git`, `langs`, `matcher`, `cli`) implementing a GumTree-based three-way AST merger with line-based fallback, Git conflict parsing/formatting, and language detection for 28+ languages via tree-sitter profiles.
> - Adds the `clone-detect` family of crates (`hash`, `pragma`, `scanner`, `detect`, `cli`) implementing a multi-type clone detection pipeline (Type-1/2/3 and sequence-based) using MinHash/LSH candidate generation, normalized AST hashing, and subsumption deduplication.
> - The `clone` CLI binary supports directory scanning, configurable thresholds, glob-based exclusions, JSON output, and SVG badge generation; the `ast-merge` CLI binary supports three-way file merges, conflict solving, and language listing.
> - Adds a repo-level [clone.toml](https://github.com/indexable-inc/index/pull/383/files#diff-71d9798ec940a623c1ae0813b562b8a292318681adc4a729e6243e6be7e59385) configuring detection thresholds and ignore globs for this repository.
> - Both tool families include comprehensive unit and integration test suites.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dbd68ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->