### PR TITLE
bossbar: nix run CLI, semi-transparent bars, macOS menu-bar-only

### DIFF
--- a/packages/bossbar-overlay/cli.nix
+++ b/packages/bossbar-overlay/cli.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenvNoCC,
+  makeWrapper,
+  sqlite,
+  coreutils,
+}:
+# `nix run .#bossbar -- <cmd>` wrapper around the hand-written `bossbar` script,
+# which speaks to the overlay's SQLite DB. The script shells out to `sqlite3`
+# and a few coreutils (`uname`, `mkdir`, `dirname`), so wrap them onto PATH
+# instead of trusting the caller's environment.
+stdenvNoCC.mkDerivation {
+  pname = "bossbar";
+  version = "0.1.0";
+
+  src = ./bossbar;
+  dontUnpack = true;
+
+  strictDeps = true;
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 $src $out/bin/bossbar
+    patchShebangs $out/bin/bossbar
+    wrapProgram $out/bin/bossbar \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          sqlite
+          coreutils
+        ]
+      }
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "CLI for the Minecraft Boss Bar Overlay's SQLite database";
+    mainProgram = "bossbar";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/packages/bossbar-overlay/package.nix
+++ b/packages/bossbar-overlay/package.nix
@@ -1,0 +1,8 @@
+{
+  id = "bossbar";
+  flake = true;
+  packageSet = true;
+  # The flake output builds the CLI wrapper, not the Tauri overlay app; the
+  # desktop app stays a `bun run tauri dev`/`build` target.
+  path = ./cli.nix;
+}

--- a/packages/bossbar-overlay/src-tauri/src/lib.rs
+++ b/packages/bossbar-overlay/src-tauri/src/lib.rs
@@ -269,6 +269,11 @@ pub fn run() {
         .manage(db.clone())
         .invoke_handler(tauri::generate_handler![get_bars])
         .setup(move |app| {
+            // Live in the menu bar only: Accessory keeps the tray icon and the
+            // overlay window but drops the Dock icon and app-switcher entry, so
+            // a background HUD does not take a Dock slot.
+            #[cfg(target_os = "macos")]
+            app.set_activation_policy(tauri::ActivationPolicy::Accessory);
             configure_overlay(app);
             build_tray(app, db.clone())?;
             spawn_watcher(app.handle().clone(), db.clone());

--- a/packages/bossbar-overlay/src/styles.css
+++ b/packages/bossbar-overlay/src/styles.css
@@ -7,6 +7,10 @@
 :root {
   /* Integer pixel scale of the native 182x5 vanilla sprites. 2 = 364x10. */
   --scale: 2;
+  /* Bars sit on top of whatever is on screen; let the desktop bleed through a
+   * little so they read as an overlay, the way Minecraft's HUD boss bar is
+   * translucent over the world. Tune 0.0 (invisible) .. 1.0 (fully opaque). */
+  --bar-opacity: 0.85;
 }
 
 html,
@@ -37,6 +41,7 @@ body {
   --w: calc(182px * var(--scale));
   --h: calc(5px * var(--scale));
   width: var(--w);
+  opacity: var(--bar-opacity);
 }
 
 .bar__title {


### PR DESCRIPTION
Three changes to `packages/bossbar-overlay/`, the Minecraft-style boss bar overlay.

## `nix run .#bossbar`
The hand-written `bossbar` CLI (edits the overlay's SQLite DB) is now a flake output. `package.nix` registers it (`flake = true; packageSet = true;`) and `cli.nix` installs the script with `sqlite3` + coreutils wrapped onto PATH via `makeWrapper` (no `writeShellApplication`, per repo lint). `nix run .#bossbar -- add/set/rm/list/...` works from anywhere and drives the same DB the running overlay reads.

## Semi-transparent bars
`styles.css` gains a `--bar-opacity` custom property (default `0.85`) applied to `.bar`, so the bars read as a translucent overlay over the desktop, closer to the in-game HUD feel. Tunable in one place.

## macOS: menu bar only, no Dock icon
The overlay already builds a tray icon. The Tauri `setup` now calls `app.set_activation_policy(ActivationPolicy::Accessory)` on macOS, which drops the Dock icon and app-switcher entry while keeping the tray icon and the overlay window.

## Validation
- `nix run .#bossbar -- list` / `--help` / `add` / `rm` against the live DB
- `nix run .#lint` clean
- `cargo check` on `src-tauri` (dock change compiles)
- `bunx tsc --noEmit` clean

Live title updates already worked (the watcher emits on every DB change and the renderer rewrites the title each tick), so nothing was added for that.

Made with AI (Claude Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `nix run` CLI, semi-transparent bars, and macOS menu-bar-only mode to bossbar
> - Adds a Nix derivation in [cli.nix](https://github.com/indexable-inc/index/pull/385/files#diff-221bf0d77ccd5afd48f7d6137e17d07d98e4a9dd881b0abcb0915ed4a378dd0d) that wraps the `bossbar` script into an installable CLI with `sqlite3` and `coreutils` on PATH, exposed as a flake output via [package.nix](https://github.com/indexable-inc/index/pull/385/files#diff-60437f5c194b268142af7da6a2fa816fbb85810a3f2f748130b33c6987cf2b57).
> - Sets `ActivationPolicy::Accessory` on macOS in [lib.rs](https://github.com/indexable-inc/index/pull/385/files#diff-4441ed0033fd10108f4e92e77045a53ba6e782aabeeca901d9b8d4d2b082de04), removing the Dock icon and app-switcher entry while keeping the tray icon and overlay window.
> - Adds a `--bar-opacity` CSS variable defaulting to `0.85` in [styles.css](https://github.com/indexable-inc/index/pull/385/files#diff-493e8fefc43b43fa983a802befead93d0e4b45c38d1f6beb14c56f2077af7cf2), making bars semi-transparent by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad59094.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->