### PR TITLE
drgn: gate Linux-only package off darwin flake outputs

### DIFF
--- a/packages/drgn/package.nix
+++ b/packages/drgn/package.nix
@@ -1,6 +1,20 @@
 {
   id = "drgn";
-  packageSet = true;
-  flake = true;
+  # drgn debugs live processes and the kernel over /proc/kcore, so it only
+  # builds on Linux (see meta.platforms in default.nix). Advertising the flake
+  # output or the darwin package-set attr makes `nix flake check` force a
+  # package nixpkgs refuses to evaluate off-platform, so gate both to Linux.
+  # The overlay stays unconditional: an `overlay.systems` filter would force
+  # `final.stdenv.hostPlatform.system` while building the overlay's own
+  # attrset spine and infinite-loops. `pkgs.drgn` on darwin is lazy and only
+  # the Linux base profile (an x86_64-linux closure) ever forces it.
+  packageSet.systems = [
+    "x86_64-linux"
+    "aarch64-linux"
+  ];
+  flake.systems = [
+    "x86_64-linux"
+    "aarch64-linux"
+  ];
   overlay = true;
 }


### PR DESCRIPTION
## Problem

`nix flake check` (and `nix build .#drgn` / any darwin package eval) fails on aarch64-darwin and x86_64-darwin:

```
error: Refusing to evaluate package 'drgn-0.2.0' ... because it is not available on the requested hostPlatform:
  hostPlatform.system = "aarch64-darwin"
  package.meta.platforms = [ "x86_64-linux" "aarch64-linux" ]
```

drgn debugs live processes and the kernel over `/proc/kcore`, so `packages/drgn/default.nix` correctly sets `meta.platforms` to Linux only. But `packages/drgn/package.nix` declared `flake = true` and `packageSet = true` unconditionally, so the registry exposed `packages.<darwin>.drgn` as a flake output. `nix flake check` forces every package's `drvPath`, and nixpkgs refuses to evaluate the off-platform package, aborting the whole check.

This was the **only** failure: a `nix flake check --keep-going` on the current system surfaces drgn and nothing else.

## Fix

Gate drgn's `flake` and `packageSet` registry entries to Linux via the existing `systems` field, matching the precedent already used by `search-py`, `tui-py`, `tui-node`, and `tonbo-artifacts`.

The overlay entry stays unconditional (`overlay = true`). An `overlay.systems` filter forces `final.stdenv.hostPlatform.system` while constructing the overlay's own attrset spine in `lib/overlay.nix`, which infinite-loops; this is why no entry sets it. `pkgs.drgn` on darwin stays lazy and is only ever forced by the Linux base profile (an `x86_64-linux` closure), so removing it from the darwin flake/package set is safe.

## Validation

- ✅ `nix flake check --keep-going --no-build` on aarch64-darwin: clean (exit 0), drgn no longer in `packages.aarch64-darwin`
- ✅ `nix eval .#packages.x86_64-linux.drgn.drvPath`: still resolves
- ✅ `nix run .#lint`: all 5 stages pass

---
Made with Claude Code (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate drgn flake and package-set outputs to Linux systems only
> Updates [package.nix](https://github.com/indexable-inc/index/pull/388/files#diff-dceb45cb01d3152cd4cd6c718c776683fc4631ae1dcebbf8dbbb140b329861ca) to restrict `packageSet.systems` and `flake.systems` to `["x86_64-linux", "aarch64-linux"]`, preventing drgn from being exposed or evaluated on Darwin and other non-Linux platforms. The `overlay` output remains enabled for all systems.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6ac52c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->