### PR TITLE
feat(lib): portable user-service module (launchd + systemd from one spec)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -144,6 +144,9 @@
     {
       lib = ix;
       inherit (ix) nixosModules;
+      # Workstation-facing home-manager module: declare a service once, get a
+      # native launchd agent on macOS and native systemd user units on Linux.
+      homeModules.portable-services = ix.portableServices.homeModule;
       overlays.default = ix.overlay;
       packages = collect "packages";
       checks = collect "checks";

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -62,6 +62,12 @@ let
   # `discoverImages` for symmetry; see its doc-comment for the discovery rules.
   nixosModules = discoverModules { root = paths.modules; };
 
+  # Portable user-service layer (launchd + systemd from one spec). Lives
+  # outside `modules/` on purpose: it is a home-manager module, not a NixOS
+  # module, so it must not be swept into `nixosModules` above. Exposed to
+  # consumers as `homeModules.portable-services` from the flake.
+  portableServices = import ./portable-services.nix { inherit lib; };
+
   # Flat list of module paths from the auto-discovered registry under
   # `modules/`. Pulled in unconditionally so every option is in scope; each
   # module stays inert until its `enable` flag is set.
@@ -383,6 +389,7 @@ let
       discoverImages
       discoverModules
       nixosModules
+      portableServices
       exampleFleetsFor
       artifacts
       agentsMd

--- a/lib/portable-services.nix
+++ b/lib/portable-services.nix
@@ -1,0 +1,322 @@
+# Portable user services: one declarative spec that renders to a native
+# launchd agent on macOS and native systemd user units on Linux.
+#
+# Design (synthesis of the three existing approaches):
+#
+#   * home-manager dual-schema: produce *native* init units on each OS
+#     (a real launchd plist, a real systemd unit) rather than a foreign
+#     supervisor. We keep that, but the caller writes one spec instead of
+#     two hand-synced schemas.
+#   * services-flake: one definition, cross-platform. We keep "write once",
+#     but skip the process-compose supervisor: native units integrate with
+#     the OS (boot/login, logging, restart) without a long-lived parent.
+#   * RFC-163 modular services: a portable option core with typed,
+#     feature-tested escape hatches for the bits that do not generalize.
+#     We keep that shape: `launchd.config` and `systemd.service` accept raw
+#     keys merged last, so no power is lost when the portable subset is not
+#     enough.
+#
+# The transforms (`toLaunchdConfig`, `toSystemdUnits`) are pure functions of
+# a fully-defaulted spec so they can be golden-tested without evaluating a
+# whole home-manager configuration. The home-manager module is a thin
+# platform-dispatching wrapper around them.
+{ lib }:
+let
+  inherit (lib)
+    types
+    mkOption
+    optionalAttrs
+    ;
+
+  /**
+    Submodule type for a single portable service.
+
+    The option set is deliberately the *portable subset*: every field maps
+    onto both launchd and systemd. Platform-specific keys go through the
+    `launchd.config` / `systemd.service` escape hatches, which are merged
+    over the generated unit and therefore always win.
+  */
+  serviceSubmodule = types.submodule (
+    { name, ... }:
+    {
+      options = {
+        enable = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Whether to generate and activate this service.";
+        };
+
+        description = mkOption {
+          type = types.str;
+          default = name;
+          description = "Human-readable description. Defaults to the attribute name.";
+        };
+
+        command = mkOption {
+          type = types.nonEmptyListOf types.str;
+          example = [
+            "/run/current-system/sw/bin/my-daemon"
+            "--flag"
+          ];
+          description = ''
+            Argument vector. `command` element 0 is the executable.
+
+            On systemd the executable must be an absolute path (systemd does
+            not search `PATH` for `ExecStart`). launchd has the same
+            requirement in practice, so always pass an absolute path.
+          '';
+        };
+
+        environment = mkOption {
+          type = types.attrsOf types.str;
+          default = { };
+          description = "Environment variables for the process.";
+        };
+
+        workingDirectory = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "Working directory. Null leaves it unset (the init system's default).";
+        };
+
+        runAtLoad = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Start the service when the user session loads (login on macOS,
+            `default.target` on Linux). Ignored for interval services, which
+            are driven by their schedule.
+          '';
+        };
+
+        restart = mkOption {
+          type = types.enum [
+            "no"
+            "on-failure"
+            "always"
+          ];
+          default = "no";
+          description = ''
+            Restart policy.
+
+            * `no`: run once; do not restart.
+            * `on-failure`: restart only on a non-zero exit
+              (launchd `KeepAlive.SuccessfulExit = false`, systemd
+              `Restart = on-failure`).
+            * `always`: keep the process running
+              (launchd `KeepAlive = true`, systemd `Restart = always`).
+          '';
+        };
+
+        interval = mkOption {
+          type = types.nullOr types.ints.positive;
+          default = null;
+          description = ''
+            Run the command every N seconds. On launchd this becomes
+            `StartInterval`; on systemd a companion `.timer` unit drives a
+            oneshot service. Mutually exclusive in spirit with a long-running
+            `restart = "always"` daemon.
+          '';
+        };
+
+        standardOutPath = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "File to append stdout to. Null leaves init-system defaults (journald on Linux).";
+        };
+
+        standardErrorPath = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "File to append stderr to. Null leaves init-system defaults.";
+        };
+
+        launchd.config = mkOption {
+          type = types.attrs;
+          default = { };
+          example = {
+            ProcessType = "Background";
+            Nice = 5;
+          };
+          description = ''
+            Raw launchd plist keys, deep-merged over the generated agent
+            config (escape hatch). Use for launchd-only knobs such as
+            `ProcessType`, `ThrottleInterval`, or `StartCalendarInterval`.
+          '';
+        };
+
+        systemd.service = mkOption {
+          type = types.attrs;
+          default = { };
+          example = {
+            Service.MemoryMax = "512M";
+            Unit.After = [ "network-online.target" ];
+          };
+          description = ''
+            Raw systemd unit sections (`Unit` / `Service` / `Install`),
+            deep-merged over the generated service (escape hatch). Use for
+            systemd-only knobs such as resource control or hardening.
+          '';
+        };
+      };
+    }
+  );
+
+  /**
+    Render a defaulted service spec to a launchd agent's `config` attrset
+    (the plist body home-manager writes for `launchd.agents.<name>.config`).
+  */
+  toLaunchdConfig =
+    svc:
+    let
+      keepAlive =
+        if svc.restart == "always" then
+          true
+        else if svc.restart == "on-failure" then
+          { SuccessfulExit = false; }
+        else
+          null;
+
+      generated = {
+        Label = svc.description;
+        ProgramArguments = svc.command;
+      }
+      // optionalAttrs (svc.environment != { }) { EnvironmentVariables = svc.environment; }
+      // optionalAttrs (svc.workingDirectory != null) { WorkingDirectory = svc.workingDirectory; }
+      // optionalAttrs (svc.runAtLoad && svc.interval == null) { RunAtLoad = true; }
+      // optionalAttrs (keepAlive != null) { KeepAlive = keepAlive; }
+      // optionalAttrs (svc.interval != null) { StartInterval = svc.interval; }
+      // optionalAttrs (svc.standardOutPath != null) { StandardOutPath = svc.standardOutPath; }
+      // optionalAttrs (svc.standardErrorPath != null) { StandardErrorPath = svc.standardErrorPath; };
+    in
+    lib.recursiveUpdate generated svc.launchd.config;
+
+  /**
+    Render one argv element to a systemd `ExecStart` token.
+
+    systemd does not use a shell, so `lib.escapeShellArgs` is wrong here: its
+    POSIX `'\''` idiom for embedded quotes would be mis-parsed. Tokens made of
+    a conservative safe set pass through unquoted; anything else is
+    double-quoted with `"` and `\` backslash-escaped, which systemd's own
+    parser understands.
+
+    Known gap: systemd expands `%`-specifiers even inside quotes, so an argv
+    element containing `%` is not represented faithfully. Pass such commands
+    through the `systemd.service` escape hatch.
+  */
+  systemdQuoteArg =
+    arg:
+    if builtins.match "[[:alnum:]_./:=@+-]+" arg != null then
+      arg
+    else
+      "\"" + lib.escape [ "\\" "\"" ] arg + "\"";
+
+  renderExecStart = command: lib.concatMapStringsSep " " systemdQuoteArg command;
+
+  /**
+    Render a defaulted service spec to systemd user units. Returns
+    `{ service; timer; }` where `service` is always a unit attrset
+    (`{ Unit; Service; Install; }`) and `timer` is null unless `interval`
+    is set.
+  */
+  toSystemdUnits =
+    svc:
+    let
+      isTimer = svc.interval != null;
+
+      generatedService = {
+        Unit = {
+          Description = svc.description;
+        };
+        Service = {
+          ExecStart = renderExecStart svc.command;
+          Restart = svc.restart;
+        }
+        // optionalAttrs (svc.environment != { }) {
+          Environment = lib.mapAttrsToList (key: value: "${key}=${value}") svc.environment;
+        }
+        // optionalAttrs (svc.workingDirectory != null) { WorkingDirectory = svc.workingDirectory; }
+        // optionalAttrs isTimer { Type = "oneshot"; }
+        // optionalAttrs (svc.standardOutPath != null) { StandardOutput = "append:${svc.standardOutPath}"; }
+        // optionalAttrs (svc.standardErrorPath != null) {
+          StandardError = "append:${svc.standardErrorPath}";
+        };
+        # A timer-driven service is started by its `.timer`, not wanted by a
+        # target directly; a runAtLoad service is wanted by the session.
+        Install = optionalAttrs (svc.runAtLoad && !isTimer) {
+          WantedBy = [ "default.target" ];
+        };
+      };
+
+      generatedTimer =
+        if isTimer then
+          {
+            Unit = {
+              Description = "Timer for ${svc.description}";
+            };
+            Timer = {
+              OnBootSec = svc.interval;
+              OnUnitActiveSec = svc.interval;
+            };
+            Install = {
+              WantedBy = [ "timers.target" ];
+            };
+          }
+        else
+          null;
+    in
+    {
+      service = lib.recursiveUpdate generatedService svc.systemd.service;
+      timer = generatedTimer;
+    };
+
+  /**
+    home-manager module exposing `services.portable.<name>`.
+
+    On Darwin it populates `launchd.agents`; on Linux it populates
+    `systemd.user.services` (plus `systemd.user.timers` for interval
+    services). The inactive platform's tree is simply not emitted.
+  */
+  homeModule =
+    {
+      config,
+      pkgs,
+      ...
+    }:
+    let
+      enabled = lib.filterAttrs (_: svc: svc.enable) config.services.portable;
+      timed = lib.filterAttrs (_: svc: svc.interval != null) enabled;
+    in
+    {
+      options.services.portable = mkOption {
+        type = types.attrsOf serviceSubmodule;
+        default = { };
+        description = ''
+          Portable user services. Each entry renders to a native launchd
+          agent on macOS and native systemd user units on Linux from a
+          single declarative spec.
+        '';
+      };
+
+      config = lib.mkMerge [
+        (lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && enabled != { }) {
+          launchd.agents = lib.mapAttrs (_: svc: {
+            enable = true;
+            config = toLaunchdConfig svc;
+          }) enabled;
+        })
+        (lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && enabled != { }) {
+          systemd.user.services = lib.mapAttrs (_: svc: (toSystemdUnits svc).service) enabled;
+          systemd.user.timers = lib.mapAttrs (_: svc: (toSystemdUnits svc).timer) timed;
+        })
+      ];
+    };
+in
+{
+  inherit
+    serviceSubmodule
+    toLaunchdConfig
+    toSystemdUnits
+    homeModule
+    ;
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -11,6 +11,7 @@ let
   inherit (ix) pkgs;
   fs = lib.fileset;
   repoPackages = ix.packageSetFor pkgs;
+  portableServicesTest = import ./portable-services.nix { inherit lib pkgs ix; };
   packageRegistry = import ../packages/registry.nix {
     inherit lib;
     root = ../packages;
@@ -3702,6 +3703,7 @@ in
 {
   inherit imageTests groups cargoUnitRealWorkspaceAssertions;
   cargoUnitRealWorkspaces = cargoUnitRealWorkspacesTest;
+  portableServices = portableServicesTest;
 
   # Aggregate. Pulls every per-image test into one derivation so
   # `nix flake check` covers the whole suite.
@@ -3710,6 +3712,7 @@ in
     ++ [
       fleetTest
       helperTest
+      portableServicesTest
     ]
   );
 }

--- a/tests/portable-services.nix
+++ b/tests/portable-services.nix
@@ -1,0 +1,179 @@
+# Eval tests for the portable user-service layer. Exercises the pure
+# transforms (`toLaunchdConfig` / `toSystemdUnits`) against specs evaluated
+# through the real submodule, so defaults and the escape-hatch merge are
+# covered without standing up a whole home-manager configuration.
+{
+  lib,
+  pkgs,
+  ix,
+}:
+let
+  ps = ix.portableServices;
+
+  # Evaluate a set of service specs through `attrsOf serviceSubmodule` so
+  # every default is applied exactly as a real consumer would see it.
+  evalServices =
+    services:
+    (lib.evalModules {
+      modules = [
+        {
+          options.services.portable = lib.mkOption {
+            type = lib.types.attrsOf ps.serviceSubmodule;
+            default = { };
+          };
+        }
+        { services.portable = services; }
+      ];
+    }).config.services.portable;
+
+  specs = evalServices {
+    # A long-running daemon that always restarts and logs to files.
+    daemon = {
+      description = "demo daemon";
+      command = [
+        "/run/current-system/sw/bin/demo"
+        "--serve"
+      ];
+      environment.RUST_LOG = "info";
+      restart = "always";
+      standardOutPath = "/tmp/demo.out";
+      standardErrorPath = "/tmp/demo.err";
+    };
+
+    # A one-shot triggered every 300s, plus an escape-hatch key per platform.
+    poller = {
+      command = [ "/run/current-system/sw/bin/poll" ];
+      interval = 300;
+      restart = "on-failure";
+      launchd.config.ProcessType = "Background";
+      systemd.service.Service.MemoryMax = "256M";
+    };
+
+    # An argv element with a space exercises systemd-correct quoting.
+    quoted = {
+      command = [
+        "/run/current-system/sw/bin/note"
+        "--msg=hello world"
+      ];
+    };
+  };
+
+  daemonLaunchd = ps.toLaunchdConfig specs.daemon;
+  daemonSystemd = ps.toSystemdUnits specs.daemon;
+  pollerLaunchd = ps.toLaunchdConfig specs.poller;
+  pollerSystemd = ps.toSystemdUnits specs.poller;
+  quotedSystemd = ps.toSystemdUnits specs.quoted;
+
+  assertions = [
+    # --- daemon: launchd ---
+    {
+      assertion =
+        daemonLaunchd.ProgramArguments == [
+          "/run/current-system/sw/bin/demo"
+          "--serve"
+        ];
+      message = "daemon launchd ProgramArguments mismatch";
+    }
+    {
+      assertion = daemonLaunchd.Label == "demo daemon";
+      message = "daemon launchd Label should default to description";
+    }
+    {
+      assertion = daemonLaunchd.RunAtLoad == true;
+      message = "daemon launchd RunAtLoad should be set (runAtLoad default true, no interval)";
+    }
+    {
+      assertion = daemonLaunchd.KeepAlive == true;
+      message = "daemon restart=always should map to launchd KeepAlive = true";
+    }
+    {
+      assertion = daemonLaunchd.EnvironmentVariables == { RUST_LOG = "info"; };
+      message = "daemon launchd EnvironmentVariables mismatch";
+    }
+    {
+      assertion = daemonLaunchd.StandardOutPath == "/tmp/demo.out";
+      message = "daemon launchd StandardOutPath mismatch";
+    }
+    {
+      assertion = !(daemonLaunchd ? StartInterval);
+      message = "daemon without interval must not emit StartInterval";
+    }
+
+    # --- daemon: systemd ---
+    {
+      assertion = daemonSystemd.service.Service.ExecStart == "/run/current-system/sw/bin/demo --serve";
+      message = "daemon systemd ExecStart should pass safe argv tokens through unquoted";
+    }
+    {
+      assertion = daemonSystemd.service.Service.Restart == "always";
+      message = "daemon restart=always should map to systemd Restart = always";
+    }
+    {
+      assertion = daemonSystemd.service.Service.Environment == [ "RUST_LOG=info" ];
+      message = "daemon systemd Environment should be K=V list";
+    }
+    {
+      assertion = daemonSystemd.service.Install.WantedBy == [ "default.target" ];
+      message = "runAtLoad non-timer service should be WantedBy default.target";
+    }
+    {
+      assertion = daemonSystemd.timer == null;
+      message = "daemon without interval must not produce a timer";
+    }
+
+    # --- poller: launchd (interval => StartInterval, no RunAtLoad) ---
+    {
+      assertion = pollerLaunchd.StartInterval == 300;
+      message = "poller launchd StartInterval mismatch";
+    }
+    {
+      assertion = !(pollerLaunchd ? RunAtLoad);
+      message = "interval service must not set RunAtLoad on launchd";
+    }
+    {
+      assertion = pollerLaunchd.KeepAlive == { SuccessfulExit = false; };
+      message = "restart=on-failure should map to launchd KeepAlive.SuccessfulExit = false";
+    }
+    {
+      assertion = pollerLaunchd.ProcessType == "Background";
+      message = "launchd escape-hatch key ProcessType should be merged in";
+    }
+
+    # --- poller: systemd (interval => oneshot service + timer) ---
+    {
+      assertion = pollerSystemd.service.Service.Type == "oneshot";
+      message = "interval service should be systemd Type = oneshot";
+    }
+    {
+      assertion = !(pollerSystemd.service ? Install) || pollerSystemd.service.Install == { };
+      message = "interval service must not be WantedBy default.target (driven by timer)";
+    }
+    {
+      assertion = pollerSystemd.timer != null && pollerSystemd.timer.Timer.OnUnitActiveSec == 300;
+      message = "poller should produce a timer with OnUnitActiveSec = interval";
+    }
+    {
+      assertion = pollerSystemd.timer.Install.WantedBy == [ "timers.target" ];
+      message = "poller timer should be WantedBy timers.target";
+    }
+    {
+      assertion = pollerSystemd.service.Service.MemoryMax == "256M";
+      message = "systemd escape-hatch key MemoryMax should be merged in";
+    }
+
+    # --- quoted: systemd-correct quoting of an arg with whitespace ---
+    {
+      assertion =
+        quotedSystemd.service.Service.ExecStart == "/run/current-system/sw/bin/note \"--msg=hello world\"";
+      message = "argv element with a space should be systemd double-quoted, not shell-escaped";
+    }
+  ];
+
+  failures = map (a: a.message) (lib.filter (a: !a.assertion) assertions);
+in
+assert lib.assertMsg (failures == [ ]) (
+  "portable-services:\n  " + lib.concatStringsSep "\n  " failures
+);
+pkgs.runCommand "ix-test-portable-services" { } ''
+  mkdir -p "$out"
+''


### PR DESCRIPTION
## What

Adds a home-manager module, exported as `homeModules.portable-services`, that turns one declarative spec into a native **launchd agent** on macOS and native **systemd user units** on Linux:

```nix
services.portable.pr-watch = {
  command = [ "/run/current-system/sw/bin/pr-watch" "--once" ];
  interval = 300;            # every 5 min: StartInterval on launchd, a .timer on systemd
  restart = "on-failure";
  standardOutPath = "/tmp/pr-watch.log";
};
```

home-manager is the only module system that provides both `launchd.agents` (macOS, per-user `~/Library/LaunchAgents`) and `systemd.user.services` (Linux) from one config, so it is the natural base for a cross-OS module. nix-darwin only covers the macOS half (and uses the different `launchd.daemons.<name>.serviceConfig` tree), so it can't span both.

## Why this shape

It synthesizes the three existing approaches rather than picking one:

- **home-manager dual-schema** — emit *native* units per OS (real plist, real unit), not a foreign supervisor. Kept, but you write one spec instead of two hand-synced schemas.
- **services-flake** — write-once, cross-platform. Kept; the process-compose supervisor is dropped so units integrate with login/boot, journald, and restart directly.
- **RFC-163 modular services** — a portable option core with typed escape hatches. Kept: `launchd.config` and `systemd.service` accept raw keys deep-merged *over* the generated unit, so no power is lost when the portable subset isn't enough.

The portable subset (`command`, `environment`, `workingDirectory`, `runAtLoad`, `restart`, `interval`, `standardOutPath`/`standardErrorPath`) is exactly the set that maps cleanly onto both init systems. Restart maps `no` / `on-failure` / `always` to launchd `KeepAlive` and systemd `Restart=`; `interval` becomes launchd `StartInterval` or a systemd oneshot + `.timer`.

Pure transforms (`toLaunchdConfig` / `toSystemdUnits`) live in `lib/portable-services.nix` and are golden-tested in `tests/portable-services.nix` (wired into the `eval` check).

## Known limitations (does not yet cover every case)

- **User services only.** No system-level `launchd.daemons` / `systemd.services` (root) yet.
- **Interval, not calendar.** Periodic scheduling is `interval` (every N seconds). Calendar schedules (`StartCalendarInterval` / `OnCalendar`) are escape-hatch only for now.
- **systemd `ExecStart` quoting.** Argv is rendered with systemd's own quoting (not shell), but argv elements containing `%` hit systemd specifier expansion and aren't represented faithfully — use the `systemd.service` escape hatch for those.
- **No socket/path activation, no dependency ordering** in the portable core (escape hatches cover `Unit.After` etc).
- The portable↔native mapping is best-effort; the escape hatches are the intended pressure valve when a knob doesn't generalize.

Flagging @wyattgill9 to sanity-check the launchd/systemd semantic mappings (restart, interval, quoting) and whether the portable subset is the right cut — see the linked issue.

---
Made with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add portable user-service home-manager module targeting launchd and systemd from one spec
> - Adds [lib/portable-services.nix](https://github.com/indexable-inc/index/pull/389/files#diff-062a2f28f34f916ca6ca914b56ea9346d3fa3e96c06d05e2b510576ab2843ad3) which defines a `serviceSubmodule` schema for declaring user services once, with renderers `toLaunchdConfig` and `toSystemdUnits` for macOS and Linux respectively.
> - The `homeModule` reads `options.services.portable` declarations and maps them to native `launchd.agents` on Darwin or `systemd.user.services`/`systemd.user.timers` on Linux using `lib.mkIf`.
> - Interval-based services produce a paired `.timer` unit on systemd and use `StartInterval` on launchd; restart policies, environment variables, working directories, and log paths are mapped across both platforms.
> - Platform-specific escape hatches (`launchd.config`, `systemd.service`) are deep-merged last via `lib.recursiveUpdate` to allow overriding generated fields.
> - Exposes `ix.portableServices` from [lib/default.nix](https://github.com/indexable-inc/index/pull/389/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188) and `homeModules.portable-services` from [flake.nix](https://github.com/indexable-inc/index/pull/389/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0); eval tests in [tests/portable-services.nix](https://github.com/indexable-inc/index/pull/389/files#diff-38a10fc78b6d06930821c881165083a22b5c8cfcc69fe9dff15b2554520d2416) validate quoting, timer wiring, and cross-platform field mapping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9fd5667.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->