### PR TITLE
fix(deps): drop unused dev-dependencies in migrated ast-merge/clone-detect crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,6 @@ dependencies = [
  "ast-merge-langs",
  "ast-merge-matcher",
  "clap",
- "insta",
  "snafu",
  "tracing",
  "tracing-subscriber",
@@ -295,11 +294,9 @@ dependencies = [
 name = "ast-merge-ast"
 version = "0.1.0"
 dependencies = [
- "insta",
  "rustc-hash",
  "snafu",
  "tree-sitter",
- "tree-sitter-language",
  "tree-sitter-rust",
 ]
 
@@ -310,7 +307,6 @@ dependencies = [
  "ast-merge-ast",
  "ast-merge-langs",
  "ast-merge-matcher",
- "insta",
  "rustc-hash",
  "similar",
  "tree-sitter",
@@ -320,7 +316,6 @@ dependencies = [
 name = "ast-merge-git"
 version = "0.1.0"
 dependencies = [
- "insta",
  "lazy-regex",
  "snafu",
 ]
@@ -329,7 +324,6 @@ dependencies = [
 name = "ast-merge-langs"
 version = "0.1.0"
 dependencies = [
- "insta",
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-c",
@@ -366,12 +360,10 @@ name = "ast-merge-matcher"
 version = "0.1.0"
 dependencies = [
  "ast-merge-ast",
- "insta",
  "rayon",
  "rustc-hash",
  "tracing",
  "tree-sitter",
- "tree-sitter-language",
  "tree-sitter-rust",
  "tree-sitter-toml-ng",
 ]
@@ -761,7 +753,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clone-detect",
- "clone-hash",
  "clone-scanner",
  "glob",
  "serde",
@@ -776,12 +767,8 @@ dependencies = [
 name = "clone-detect"
 version = "0.1.0"
 dependencies = [
- "ast-merge-ast",
- "ast-merge-langs",
- "ast-merge-matcher",
  "clone-hash",
  "clone-scanner",
- "insta",
  "rayon",
  "rustc-hash",
  "serde",
@@ -795,7 +782,6 @@ version = "0.1.0"
 dependencies = [
  "ast-merge-ast",
  "ast-merge-langs",
- "insta",
  "rustc-hash",
  "tree-sitter",
 ]
@@ -818,7 +804,6 @@ dependencies = [
  "clone-hash",
  "clone-pragma",
  "ignore",
- "insta",
  "parking_lot",
  "rustc-hash",
  "snafu",
@@ -2332,19 +2317,6 @@ dependencies = [
  "unicode-width",
  "unit-prefix",
  "web-time",
-]
-
-[[package]]
-name = "insta"
-version = "1.47.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
-dependencies = [
- "console",
- "once_cell",
- "serde",
- "similar",
- "tempfile",
 ]
 
 [[package]]

--- a/packages/ast-merge/ast/Cargo.toml
+++ b/packages/ast-merge/ast/Cargo.toml
@@ -11,9 +11,7 @@ tree-sitter.workspace = true
 rustc-hash.workspace = true
 
 [dev-dependencies]
-insta.workspace = true
 tree-sitter-rust.workspace = true
-tree-sitter-language.workspace = true
 
 [lints]
 workspace = true

--- a/packages/ast-merge/cli/Cargo.toml
+++ b/packages/ast-merge/cli/Cargo.toml
@@ -20,8 +20,5 @@ ast-merge-diff.workspace = true
 ast-merge-langs.workspace = true
 ast-merge-git.workspace = true
 
-[dev-dependencies]
-insta.workspace = true
-
 [lints]
 workspace = true

--- a/packages/ast-merge/diff/Cargo.toml
+++ b/packages/ast-merge/diff/Cargo.toml
@@ -13,7 +13,6 @@ similar.workspace = true
 tree-sitter.workspace = true
 
 [dev-dependencies]
-insta.workspace = true
 ast-merge-langs.workspace = true
 
 [lints]

--- a/packages/ast-merge/git/Cargo.toml
+++ b/packages/ast-merge/git/Cargo.toml
@@ -9,8 +9,5 @@ description = "Git merge driver integration for ast-merge"
 snafu.workspace = true
 lazy-regex.workspace = true
 
-[dev-dependencies]
-insta.workspace = true
-
 [lints]
 workspace = true

--- a/packages/ast-merge/langs/Cargo.toml
+++ b/packages/ast-merge/langs/Cargo.toml
@@ -61,8 +61,5 @@ tree-sitter-dockerfile-updated.workspace = true
 # Configuration languages
 tree-sitter-nix.workspace = true
 
-[dev-dependencies]
-insta.workspace = true
-
 [lints]
 workspace = true

--- a/packages/ast-merge/matcher/Cargo.toml
+++ b/packages/ast-merge/matcher/Cargo.toml
@@ -13,10 +13,8 @@ tree-sitter.workspace = true
 rayon.workspace = true
 
 [dev-dependencies]
-insta.workspace = true
 tree-sitter-rust.workspace = true
 tree-sitter-toml-ng.workspace = true
-tree-sitter-language.workspace = true
 
 [lints]
 workspace = true

--- a/packages/clone-detect/cli/Cargo.toml
+++ b/packages/clone-detect/cli/Cargo.toml
@@ -11,7 +11,6 @@ path = "src/main.rs"
 
 [dependencies]
 snafu.workspace = true
-clone-hash.workspace = true
 clone-scanner.workspace = true
 clone-detect.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/packages/clone-detect/detect/Cargo.toml
+++ b/packages/clone-detect/detect/Cargo.toml
@@ -8,16 +8,12 @@ description = "Clone detection algorithms (Type-1, Type-2, Type-3)"
 [dependencies]
 clone-hash.workspace = true
 clone-scanner.workspace = true
-ast-merge-ast.workspace = true
-ast-merge-langs.workspace = true
-ast-merge-matcher.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 
 [dev-dependencies]
-insta.workspace = true
 tempfile.workspace = true
 
 [lints]

--- a/packages/clone-detect/hash/Cargo.toml
+++ b/packages/clone-detect/hash/Cargo.toml
@@ -11,8 +11,5 @@ rustc-hash.workspace = true
 ast-merge-ast.workspace = true
 ast-merge-langs.workspace = true
 
-[dev-dependencies]
-insta.workspace = true
-
 [lints]
 workspace = true

--- a/packages/clone-detect/scanner/Cargo.toml
+++ b/packages/clone-detect/scanner/Cargo.toml
@@ -17,7 +17,6 @@ parking_lot.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-insta.workspace = true
 tempfile.workspace = true
 
 [lints]


### PR DESCRIPTION
## What

Fixes **pre-existing broken `main` CI**: the `lint` and `rust-package-tests` checks fail because `cargo-machete` reports unused dependencies in the `ast-merge-*` and `clone-detect` crates that landed via the ix→index migration.

Removed (each verified unused by grep + `cargo-machete --with-metadata`):
- `insta` (dev-dep) from every ast-merge/clone-detect crate — it was declared workspace-wide but referenced by no member; pruned from `Cargo.lock`.
- `tree-sitter-language` (dev-dep) from `ast-merge/ast` and `ast-merge/matcher` — stays in the lock as a transitive grammar dep.
- unused internal crate deps: `ast-merge-ast`/`ast-merge-langs`/`ast-merge-matcher` from `clone-detect/detect`, and `clone-hash` from `clone-detect/cli`.

`Cargo.lock` re-resolves with **deletions only, no version bumps**.

## Validation
`cargo-machete --with-metadata` on `packages/ast-merge` and `packages/clone-detect` now reports no unused dependencies. (Independent of, and unblocks, PR #389.)

---
Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop unused dev-dependencies from `ast-merge` and `clone-detect` crates
> Removes unused `insta`, `tree-sitter-language`, and other stale dependencies from `Cargo.toml` files across the `ast-merge` and `clone-detect` packages following their migration. Also removes unused runtime dependencies `clone-hash` from `clone-detect/cli` and `ast-merge-ast`/`ast-merge-langs`/`ast-merge-matcher` from `clone-detect/detect`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78f2201.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->