### PR TITLE
mcp: add Streamable HTTP transport alongside stdio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,6 +2429,7 @@ name = "ix-mcp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
  "clap",
  "rmcp",
  "schemars",
@@ -2436,6 +2437,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4163,18 +4165,27 @@ checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64",
+ "bytes",
  "chrono",
  "futures",
+ "http",
+ "http-body",
+ "http-body-util",
  "pastey",
  "pin-project-lite",
+ "rand 0.10.1",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4776,6 +4787,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c5e6deb40826033bd7b11c7ef25ef71193fabd71f680f40dd16538a2704d2f4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ terminal-light = "1"
 terminal-theme = { path = "packages/terminal-theme" }
 tokio = "1"
 tokio-stream = "0.1"
+tokio-util = "0.7"
 toml = { version = "1.1.2", default-features = false }
 tower = "0.5"
 tower-http = "0.6"

--- a/packages/mcp/Cargo.toml
+++ b/packages/mcp/Cargo.toml
@@ -9,10 +9,12 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
+axum.workspace = true
 clap = { workspace = true, features = ["derive"] }
-rmcp = { workspace = true, features = ["transport-io"] }
+rmcp = { workspace = true, features = ["transport-io", "transport-streamable-http-server"] }
 schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["io-std", "macros", "process", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["io-std", "macros", "net", "process", "rt-multi-thread", "signal"] }
+tokio-util.workspace = true

--- a/packages/mcp/src/main.rs
+++ b/packages/mcp/src/main.rs
@@ -15,7 +15,12 @@ use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
     model::{CallToolResult, Content, ServerCapabilities, ServerInfo},
     tool, tool_handler, tool_router,
-    transport::stdio,
+    transport::{
+        stdio,
+        streamable_http_server::{
+            StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+        },
+    },
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -24,6 +29,15 @@ use tempfile::TempDir;
 
 const DEFAULT_SESSION_ID: &str = "default";
 const WORKER_SOURCE: &str = include_str!("python_worker.py");
+
+/// Address bound when `serve --http` is passed without an explicit value. Loopback
+/// only, matching the Streamable HTTP server's default loopback `Host` allowlist
+/// (DNS-rebinding guard); a public bind needs both a routable address here and a
+/// matching `allowed_hosts` override.
+const DEFAULT_HTTP_ADDRESS: &str = "127.0.0.1:8000";
+
+/// Path the Streamable HTTP endpoint is mounted at, the de facto MCP convention.
+const HTTP_MCP_PATH: &str = "/mcp";
 
 // Surfaced to clients on initialize so an agent discovers the preinstalled
 // packages without reading the build. `tui` is the bundled PTY driver; naming
@@ -47,7 +61,19 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum CliCommand {
-    Serve,
+    Serve {
+        /// Serve over Streamable HTTP instead of stdio. Pass the flag bare to
+        /// bind the loopback default, or give an explicit `host:port`. Stdio
+        /// stays the default when the flag is absent, so existing MCP clients
+        /// that launch `ix-mcp` over a pipe are unaffected.
+        #[arg(
+            long,
+            value_name = "ADDR",
+            num_args = 0..=1,
+            default_missing_value = DEFAULT_HTTP_ADDRESS,
+        )]
+        http: Option<String>,
+    },
     Repl,
     Eval { expression: String },
     Exec { source: String },
@@ -594,11 +620,42 @@ fn uuid_like(sessions: &HashMap<String, PythonSession>) -> String {
     unreachable!("unbounded session id search exhausted")
 }
 
+/// Serve over Streamable HTTP, the spec's HTTP transport (POST for requests,
+/// SSE for streamed responses), at `addr`. Each MCP session gets a fresh
+/// [`McpServer`] from the factory, so its Python sessions are owned by that
+/// session and torn down when it ends, mirroring the one-owner lifecycle stdio
+/// already has. The cancellation token tied to ctrl-c terminates in-flight SSE
+/// sessions on shutdown rather than leaving them hanging.
+async fn serve_http(addr: &str) -> Result<()> {
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let service = StreamableHttpService::new(
+        || Ok(McpServer::new()),
+        Arc::new(LocalSessionManager::default()),
+        StreamableHttpServerConfig::default().with_cancellation_token(cancel.child_token()),
+    );
+
+    let router = axum::Router::new().nest_service(HTTP_MCP_PATH, service);
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("failed to bind Streamable HTTP listener on {addr}"))?;
+    eprintln!("ix-mcp Streamable HTTP listening on http://{addr}{HTTP_MCP_PATH}");
+
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async move {
+            let _ = tokio::signal::ctrl_c().await;
+            cancel.cancel();
+        })
+        .await
+        .context("Streamable HTTP server error")?;
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<ExitCode> {
     let cli = Cli::parse();
-    match cli.command.unwrap_or(CliCommand::Serve) {
-        CliCommand::Serve => {
+    match cli.command.unwrap_or(CliCommand::Serve { http: None }) {
+        CliCommand::Serve { http: Some(addr) } => serve_http(&addr).await?,
+        CliCommand::Serve { http: None } => {
             let service = McpServer::new().serve(stdio()).await?;
             service.waiting().await?;
         }


### PR DESCRIPTION
## What

Adds the MCP Streamable HTTP transport to `ix-mcp` alongside the existing stdio transport.

- `ix-mcp serve` still serves over **stdio** by default, so every MCP client that launches the binary over a pipe is unaffected.
- `ix-mcp serve --http [ADDR]` serves over **Streamable HTTP** (spec's HTTP transport: POST for requests, SSE for streamed responses), mounted at `/mcp`. Pass `--http` bare to bind the loopback default `127.0.0.1:8000`, or give an explicit `host:port`.

## Design

Each MCP session gets a fresh `McpServer` from the service factory, so its Python sessions are owned by that session and torn down when it ends, mirroring the one-owner lifecycle stdio already has. A cancellation token tied to ctrl-c terminates in-flight SSE sessions on shutdown.

Host validation keeps the rmcp default loopback allowlist (DNS-rebinding guard). A public bind needs both a routable `ADDR` here and a matching `allowed_hosts` override, called out in the `DEFAULT_HTTP_ADDRESS` doc comment.

## Validation

- `nix build .#mcp` ✅
- `cargo test -p ix-mcp` ✅ (4 stdio worker-protocol tests pass)
- Manual HTTP smoke ✅: `initialize` returns a session id + server instructions over SSE; `tools/list` returns all 8 tools (`python_eval`, `python_exec`, `python_reset`, `python_session_*`, `search_grep`, `search_semantic`).

Note: the repo `lint` flake check is currently red on `main` from pre-existing `types.attrs` uses in `lib/portable-services.nix` (PR #389), unrelated to this change. Tracked/fixed separately.

---
Made with AI (Claude, claude-opus-4-8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Streamable HTTP transport to the MCP server alongside stdio
> - Adds a `--http [ADDR]` flag to the `Serve` CLI subcommand; when omitted the server uses stdio as before, when provided (with no value) it defaults to `127.0.0.1:8000`.
> - Introduces `serve_http` in [main.rs](https://github.com/indexable-inc/index/pull/397/files#diff-2dcd58b645a00e14633156b2ff05a7c89ce38e7844a856b655d1dd28aee46777), which mounts a `StreamableHttpService` at `/mcp` using axum, with a fresh `McpServer` per session and a `LocalSessionManager`.
> - Graceful shutdown on ctrl-c cancels in-flight SSE sessions via a `CancellationToken`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a4f568.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->