### PR TITLE
claude: enable mixedbread-ai/skills plugins in project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "extraKnownMarketplaces": {
+    "mixedbread-skills": {
+      "source": {
+        "source": "github",
+        "repo": "mixedbread-ai/skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "mixedbread-search@mixedbread-skills": true,
+    "mxbai-cli@mixedbread-skills": true,
+    "mixedbread-parsing@mixedbread-skills": true
+  }
+}


### PR DESCRIPTION
Adds a committed `.claude/settings.json` that registers the [`mixedbread-ai/skills`](https://github.com/mixedbread-ai/skills) marketplace and enables its three plugins (`mixedbread-search`, `mxbai-cli`, `mixedbread-parsing`) for everyone working in this repo with Claude Code.

These are markdown agent skills documenting the Mixedbread Stores/Parsing APIs and `mxbai` CLI. They load on demand, need no API key to be present (only the descriptions sit in context), and give Claude the full upstream API surface when extending our own content-addressed `search` tool (`packages/search`, `search-py`, `search_semantic`/`search_grep`).

Uses the same `extraKnownMarketplaces` + `enabledPlugins` shape already used for the `ix` marketplace in personal settings. Takes effect at the next Claude Code session start; verify with `/plugin`.

Made with AI (Claude Opus 4.8 via Claude Code).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable mixedbread-ai/skills plugins in Claude project settings
> Adds [.claude/settings.json](https://github.com/indexable-inc/index/pull/399/files#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546) to register the `mixedbread-skills` marketplace sourced from the `mixedbread-ai/skills` GitHub repo and enable three plugins: `mixedbread-search`, `mxbai-cli`, and `mixedbread-parsing`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3578417.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->