### PR TITLE
lib: type portable-service escape hatches, green main lint

### DIFF
--- a/lib/portable-services.nix
+++ b/lib/portable-services.nix
@@ -132,7 +132,10 @@ let
         };
 
         launchd.config = mkOption {
-          type = types.attrs;
+          # Foreign-format boundary: a launchd plist is an arbitrary nested
+          # attrset of plist values, so this is a typed freeform escape hatch
+          # rather than `types.attrs` (which loses merge semantics and docs).
+          type = types.attrsOf types.anything;
           default = { };
           example = {
             ProcessType = "Background";
@@ -146,7 +149,10 @@ let
         };
 
         systemd.service = mkOption {
-          type = types.attrs;
+          # Foreign-format boundary: systemd unit sections are an arbitrary
+          # nested attrset (`Unit` / `Service` / `Install`), so this is a typed
+          # freeform escape hatch rather than `types.attrs`.
+          type = types.attrsOf types.anything;
           default = { };
           example = {
             Service.MemoryMax = "512M";
@@ -189,6 +195,11 @@ let
       // optionalAttrs (svc.standardOutPath != null) { StandardOutPath = svc.standardOutPath; }
       // optionalAttrs (svc.standardErrorPath != null) { StandardErrorPath = svc.standardErrorPath; };
     in
+    # Deliberate deep merge: the escape hatch must override generated keys at the
+    # leaf (e.g. add `Service.MemoryMax` without dropping the generated
+    # `Service.ExecStart`). A shallow `//` would replace whole sections, so
+    # recursiveUpdate's leaf-level override is the wanted behavior here, not a bug.
+    # ast-grep-ignore: no-recursive-update
     lib.recursiveUpdate generated svc.launchd.config;
 
   /**
@@ -266,6 +277,10 @@ let
           null;
     in
     {
+      # Deliberate deep merge: the escape hatch must override generated unit keys
+      # at the leaf (e.g. add `Service.MemoryMax` while keeping the generated
+      # `Service.ExecStart`). A shallow `//` would replace whole sections.
+      # ast-grep-ignore: no-recursive-update
       service = lib.recursiveUpdate generatedService svc.systemd.service;
       timer = generatedTimer;
     };


### PR DESCRIPTION
## What

Greens the `lint` flake check on `main`, which has been red since #389 with four ast-grep errors in `lib/portable-services.nix`.

- `launchd.config` and `systemd.service` change from `types.attrs` to `types.attrsOf types.anything`: a typed freeform escape hatch that keeps merge semantics and docs (clears `no-types-attrs`).
- The two `lib.recursiveUpdate generated <escape-hatch>` merges get a reasoned `# ast-grep-ignore: no-recursive-update`. The deep merge is the intended behavior: an escape-hatch key like `Service.MemoryMax` must override at the leaf without dropping the generated `Service.ExecStart`. A shallow `//` would replace whole sections.

## Validation

- `nix run .#lint` ✅ all five stages green (was: 4 errors)
- Portable-services golden assertions ✅ pass with the new types (forced the eval-time `assert` in `tests/portable-services.nix`, including the escape-hatch `MemoryMax` merge case)

CI `flake-check` was failing only on `lint` with these four errors; this clears them.

---
Made with AI (Claude, claude-opus-4-8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Type portable-service escape hatch options with `types.attrsOf types.anything`
> Changes the `launchd.config` and `systemd.service` escape hatch options in [portable-services.nix](https://github.com/indexable-inc/index/pull/400/files#diff-062a2f28f34f916ca6ca914b56ea9346d3fa3e96c06d05e2b510576ab2843ad3) from the untyped `types.attrs` to `types.attrsOf types.anything`, bringing them in line with NixOS conventions for foreign-format boundaries. Also adds comments explaining the deliberate use of `lib.recursiveUpdate` for deep-merging generated keys with user-provided overrides.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6457dfb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->