### PR TITLE
bossbar: render titles in the real Minecraft font (fix silent system-font fallback)

### DIFF
--- a/packages/bossbar-overlay/app/src/assets.rs
+++ b/packages/bossbar-overlay/app/src/assets.rs
@@ -7,9 +7,9 @@
 use crate::bars::{Color, Notch};
 
 /// The Minecraft title font (tryashtar/minecraft-ttf). Its internal family name
-/// is `"Minecraft"`, which the text renderer selects by name.
+/// (`"Minecraft Default"`) is read back from the font at load time rather than
+/// hardcoded, so the renderer's family selector cannot drift from the TTF.
 pub const FONT: &[u8] = include_bytes!("../assets/fonts/MinecraftDefault-Regular.ttf");
-pub const FONT_FAMILY: &str = "Minecraft";
 
 macro_rules! sprite {
     ($name:literal) => {

--- a/packages/bossbar-overlay/app/src/render.rs
+++ b/packages/bossbar-overlay/app/src/render.rs
@@ -74,6 +74,12 @@ pub struct Renderer {
     textures: HashMap<TexId, wgpu::BindGroup>,
 
     font_system: FontSystem,
+    /// The embedded font's real family name, read back from its `name` table
+    /// rather than hardcoded. cosmic-text matches families by name and silently
+    /// substitutes a system font on a miss, so a stale literal would render a
+    /// non-Minecraft font with no error. Deriving it keeps the selector in lock
+    /// step with whatever `MinecraftDefault-Regular.ttf` actually reports.
+    font_family: String,
     swash_cache: SwashCache,
     atlas: TextAtlas,
     text_renderer: TextRenderer,
@@ -218,8 +224,21 @@ impl Renderer {
             );
         }
 
-        let mut font_system = FontSystem::new();
-        font_system.db_mut().load_font_data(assets::FONT.to_vec());
+        // Load *only* the embedded Minecraft font into an otherwise empty
+        // database. cosmic-text's default `FontSystem::new` also loads every
+        // installed system font and falls back to one when a family name does
+        // not match, which is exactly how the title silently rendered in a
+        // generic system font. With a single-font db the title is the Minecraft
+        // font or nothing, never a wrong substitute.
+        let mut db = glyphon::cosmic_text::fontdb::Database::new();
+        db.load_font_data(assets::FONT.to_vec());
+        let font_family = db
+            .faces()
+            .next()
+            .and_then(|face| face.families.first())
+            .map(|(name, _)| name.clone())
+            .expect("embedded Minecraft font is missing a family name");
+        let font_system = FontSystem::new_with_locale_and_db("en-US".to_string(), db);
         let swash_cache = SwashCache::new();
         let cache = Cache::new(&device);
         let viewport = Viewport::new(&device, &cache);
@@ -235,6 +254,7 @@ impl Renderer {
             globals_bind,
             textures,
             font_system,
+            font_family,
             swash_cache,
             atlas,
             text_renderer,
@@ -282,7 +302,7 @@ impl Renderer {
                 buffer.set_text(
                     &mut self.font_system,
                     &b.title,
-                    &Attrs::new().family(Family::Name(assets::FONT_FAMILY)),
+                    &Attrs::new().family(Family::Name(&self.font_family)),
                     Shaping::Advanced,
                     Some(glyphon::cosmic_text::Align::Center),
                 );


### PR DESCRIPTION
## What

Boss bar titles were rendering in a generic system font instead of the Minecraft font.

## Root cause

The embedded `MinecraftDefault-Regular.ttf` (tryashtar/minecraft-ttf) reports its family name as **`Minecraft Default`** in its `name` table (ID 1), but the renderer asked glyphon for family `"Minecraft"`. cosmic-text matches families by name and **silently substitutes a system font** when the name does not match, so the title rendered in a wrong font with no error.

## Fix

- Load *only* the embedded font into an otherwise-empty `fontdb` (the default `FontSystem::new` also loads every installed system font, which is what enabled the silent fallback).
- Read the family name back from the loaded face instead of hardcoding it, so the selector can never drift from the TTF on a font version bump.

Result: the title is the Minecraft font or visible tofu, never a wrong substitute. The asset-fetch mechanism (pinned `fetchurl` for the TTF, recursive-hash FOD for the sprites) is unchanged.

## Verification

Rendered headlessly with `--snapshot` before and after: titles change from smooth Arial-like glyphs to the blocky 1:1 Minecraft letterforms.

---
🤖 Authored with Claude Code (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix bossbar titles rendering in the embedded Minecraft font instead of system fonts
> The `Renderer` previously initialized `FontSystem` with system fonts loaded, causing a family name mismatch that silently fell back to a system font for bossbar titles.
>
> - `Renderer::new` now builds a `FontSystem` with only the embedded Minecraft font, reading the family name directly from the font's name table rather than using a hardcoded constant.
> - `Renderer.render` uses the dynamically derived `font_family` string when setting text attributes, ensuring cosmic-text matches the embedded font.
> - Risk: `Renderer::new` now panics at startup if the embedded font has no family name in its name table.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4bb1ccb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->