### PR TITLE
fix(clippy): conform migrated ast-merge/clone-detect crates to index lints

### DIFF
--- a/packages/ast-merge/ast/src/parse.rs
+++ b/packages/ast-merge/ast/src/parse.rs
@@ -52,7 +52,7 @@ pub struct Tree {
 
 impl Tree {
     #[must_use]
-    pub fn new(source: String, tree: tree_sitter::Tree) -> Self {
+    pub const fn new(source: String, tree: tree_sitter::Tree) -> Self {
         Self { source, tree }
     }
 
@@ -94,6 +94,10 @@ pub enum Error {
     NoTree,
 }
 
+/// Parse `source` with the given tree-sitter `language`.
+///
+/// # Errors
+/// Returns an error if the language cannot be set or the parser produces no tree.
 pub fn tree(source: &str, language: &tree_sitter::Language) -> Result<Output, Error> {
     let mut parser = tree_sitter::Parser::new();
     parser.set_language(language).context(SetLanguageSnafu)?;

--- a/packages/ast-merge/ast/src/types.rs
+++ b/packages/ast-merge/ast/src/types.rs
@@ -14,7 +14,7 @@ pub enum Revision {
 
 impl Revision {
     #[must_use]
-    pub fn name(self) -> &'static str {
+    pub const fn name(self) -> &'static str {
         match self {
             Self::Base => "BASE",
             Self::Left => "LEFT",
@@ -42,17 +42,17 @@ impl<'a> Node<'a> {
     }
 
     #[must_use]
-    pub fn node(&self) -> tree_sitter::Node<'a> {
+    pub const fn node(&self) -> tree_sitter::Node<'a> {
         self.inner
     }
 
     #[must_use]
-    pub fn hash(&self) -> u64 {
+    pub const fn hash(&self) -> u64 {
         self.hash
     }
 
     #[must_use]
-    pub fn id(&self) -> NodeId {
+    pub const fn id(&self) -> NodeId {
         self.id
     }
 

--- a/packages/ast-merge/diff/src/changeset.rs
+++ b/packages/ast-merge/diff/src/changeset.rs
@@ -10,7 +10,7 @@ pub struct PcsTriple {
 
 impl PcsTriple {
     #[must_use]
-    pub fn new(parent: Option<usize>, predecessor: Option<usize>, successor: usize) -> Self {
+    pub const fn new(parent: Option<usize>, predecessor: Option<usize>, successor: usize) -> Self {
         Self {
             parent,
             predecessor,

--- a/packages/ast-merge/diff/src/children.rs
+++ b/packages/ast-merge/diff/src/children.rs
@@ -137,36 +137,33 @@ fn reconcile_named(
     let base_match = input.lookups.base.get(input.name);
     let right_match = input.lookups.right.get(input.name);
 
-    match (base_match, right_match) {
-        (Some(base_entry), Some(right_entry)) => {
-            handled_right.insert(right_entry.index);
-            let base_h = compute(input.trees.base, base_entry.node);
-            let right_h = compute(input.trees.right, right_entry.node);
+    if let (Some(base_entry), Some(right_entry)) = (base_match, right_match) {
+        handled_right.insert(right_entry.index);
+        let base_h = compute(input.trees.base, base_entry.node);
+        let right_h = compute(input.trees.right, right_entry.node);
 
-            if input.left_hash == right_h {
-                merged_children.push(input.trees.left.node_text(input.left_child).to_owned());
-            } else if input.left_hash == base_h {
-                merged_children.push(input.trees.right.node_text(right_entry.node).to_owned());
-            } else if right_h == base_h {
-                merged_children.push(input.trees.left.node_text(input.left_child).to_owned());
-            } else {
-                let merged = reconcile_single(
-                    input.trees,
-                    ThreeWayNodes {
-                        base: base_entry.node,
-                        left: input.left_child,
-                        right: right_entry.node,
-                    },
-                );
-                merged_children.push(merged);
-            }
-        }
-        _ => {
-            if let Some(right_entry) = right_match {
-                handled_right.insert(right_entry.index);
-            }
+        if input.left_hash == right_h {
             merged_children.push(input.trees.left.node_text(input.left_child).to_owned());
+        } else if input.left_hash == base_h {
+            merged_children.push(input.trees.right.node_text(right_entry.node).to_owned());
+        } else if right_h == base_h {
+            merged_children.push(input.trees.left.node_text(input.left_child).to_owned());
+        } else {
+            let merged = reconcile_single(
+                input.trees,
+                ThreeWayNodes {
+                    base: base_entry.node,
+                    left: input.left_child,
+                    right: right_entry.node,
+                },
+            );
+            merged_children.push(merged);
         }
+    } else {
+        if let Some(right_entry) = right_match {
+            handled_right.insert(right_entry.index);
+        }
+        merged_children.push(input.trees.left.node_text(input.left_child).to_owned());
     }
 }
 
@@ -217,11 +214,10 @@ fn collect_new_right(
         let right_name = get_name(right_tree, *right_child);
         let right_hash = compute(right_tree, *right_child);
 
-        let is_new = if let Some(name) = &right_name {
-            !input.base_child_names.contains_key(name)
-        } else {
-            !input.base_child_hashes.contains_key(&right_hash)
-        };
+        let is_new = right_name.as_ref().map_or_else(
+            || !input.base_child_hashes.contains_key(&right_hash),
+            |name| !input.base_child_names.contains_key(name),
+        );
 
         if is_new {
             merged_children.push(right_tree.node_text(*right_child).to_owned());

--- a/packages/ast-merge/diff/src/conflict.rs
+++ b/packages/ast-merge/diff/src/conflict.rs
@@ -14,7 +14,7 @@ pub struct Region {
 
 impl Region {
     #[must_use]
-    pub fn new(start: usize, end: usize, text: String) -> Self {
+    pub const fn new(start: usize, end: usize, text: String) -> Self {
         Self { start, end, text }
     }
 }
@@ -28,7 +28,7 @@ pub struct Result {
 
 impl Result {
     #[must_use]
-    pub fn success(content: String) -> Self {
+    pub const fn success(content: String) -> Self {
         Self {
             content,
             conflicts: Vec::new(),
@@ -37,7 +37,7 @@ impl Result {
     }
 
     #[must_use]
-    pub fn with_conflicts(content: String, conflicts: Vec<Conflict>) -> Self {
+    pub const fn with_conflicts(content: String, conflicts: Vec<Conflict>) -> Self {
         Self {
             content,
             conflicts,

--- a/packages/ast-merge/diff/src/engine.rs
+++ b/packages/ast-merge/diff/src/engine.rs
@@ -183,6 +183,10 @@ struct SuccessorEntry<'a> {
     revisions: &'a rustc_hash::FxHashSet<Revision>,
 }
 
+#[expect(
+    clippy::similar_names,
+    reason = "class_{a,b}_{left,right} form a deliberate 2x2 of revision x entry"
+)]
 fn detect_conflicts(changeset: &ChangeSet, class_mapping: &Class) -> Vec<Conflict> {
     use rustc_hash::FxHashMap;
 

--- a/packages/ast-merge/diff/src/items.rs
+++ b/packages/ast-merge/diff/src/items.rs
@@ -52,10 +52,9 @@ pub fn get_name(tree: &Tree, node: tree_sitter::Node<'_>) -> Option<String> {
 
     let name_field = match kind {
         "function_item" | "struct_item" | "enum_item" | "trait_item" | "type_item"
-        | "const_item" | "static_item" | "mod_item" => Some("name"),
+        | "const_item" | "static_item" | "mod_item" | "field_declaration"
+        | "function_signature_item" => Some("name"),
         "impl_item" => Some("type"),
-        "field_declaration" => Some("name"),
-        "function_signature_item" => Some("name"),
         "use_declaration" => {
             return Some(tree.node_text(node).to_owned());
         }
@@ -98,30 +97,28 @@ pub fn reconcile_single(trees: &ThreeWayTrees<'_>, nodes: ThreeWayNodes<'_>) -> 
     if matches!(
         kind,
         "struct_item" | "impl_item" | "enum_item" | "trait_item"
+    ) && let Some(merged) = try_reconcile(
+        trees,
+        ThreeWayNodes {
+            base: base_node,
+            left: left_node,
+            right: right_node,
+        },
     ) {
-        if let Some(merged) = try_reconcile(
-            trees,
-            ThreeWayNodes {
-                base: base_node,
-                left: left_node,
-                right: right_node,
-            },
-        ) {
-            return merged;
-        }
+        return merged;
     }
 
-    if kind == "function_item" {
-        if let Some(merged) = try_reconcile_function(
+    if kind == "function_item"
+        && let Some(merged) = try_reconcile_function(
             trees,
             ThreeWayNodes {
                 base: base_node,
                 left: left_node,
                 right: right_node,
             },
-        ) {
-            return merged;
-        }
+        )
+    {
+        return merged;
     }
 
     let left_text = left_tree.node_text(left_node);
@@ -134,10 +131,10 @@ pub fn reconcile_single(trees: &ThreeWayTrees<'_>, nodes: ThreeWayNodes<'_>) -> 
 }
 
 /// Three-way item slices for `reconcile_lists`.
-pub(crate) struct ThreeWay<'a, 'tree> {
-    pub(crate) base: &'a [tree_sitter::Node<'tree>],
-    pub(crate) left: &'a [tree_sitter::Node<'tree>],
-    pub(crate) right: &'a [tree_sitter::Node<'tree>],
+pub struct ThreeWay<'a, 'tree> {
+    pub base: &'a [tree_sitter::Node<'tree>],
+    pub left: &'a [tree_sitter::Node<'tree>],
+    pub right: &'a [tree_sitter::Node<'tree>],
 }
 
 pub fn reconcile_lists(trees: &ThreeWayTrees<'_>, items: &ThreeWay<'_, '_>) -> String {
@@ -212,18 +209,21 @@ fn build_right_to_base_map(
         .iter()
         .enumerate()
         .filter_map(|(right_idx, right_item)| {
-            if let Some(name) = get_name(right_tree, *right_item) {
-                input
-                    .base_by_name
-                    .get(&name)
-                    .map(|entry| (right_idx, entry.index))
-            } else {
-                let right_hash = compute(right_tree, *right_item);
-                input
-                    .base_hashes
-                    .get(&right_hash)
-                    .map(|&base_idx| (right_idx, base_idx))
-            }
+            get_name(right_tree, *right_item).map_or_else(
+                || {
+                    let right_hash = compute(right_tree, *right_item);
+                    input
+                        .base_hashes
+                        .get(&right_hash)
+                        .map(|&base_idx| (right_idx, base_idx))
+                },
+                |name| {
+                    input
+                        .base_by_name
+                        .get(&name)
+                        .map(|entry| (right_idx, entry.index))
+                },
+            )
         })
         .collect()
 }

--- a/packages/ast-merge/diff/src/items/left.rs
+++ b/packages/ast-merge/diff/src/items/left.rs
@@ -7,21 +7,21 @@ use crate::{
 };
 
 /// Name-map lookups for base and right items.
-pub(crate) struct NameLookups<'a, 'tree> {
-    pub(crate) base: &'a FxHashMap<String, IndexedNode<'tree>>,
-    pub(crate) right: &'a FxHashMap<String, IndexedNode<'tree>>,
+pub struct NameLookups<'a, 'tree> {
+    pub base: &'a FxHashMap<String, IndexedNode<'tree>>,
+    pub right: &'a FxHashMap<String, IndexedNode<'tree>>,
 }
 
 /// Context for merging left items against base and right.
-pub(crate) struct Context<'a, 'tree> {
-    pub(crate) trees: &'a ThreeWayTrees<'tree>,
-    pub(crate) left_items: &'a [tree_sitter::Node<'tree>],
-    pub(crate) right_items: &'a [tree_sitter::Node<'tree>],
-    pub(crate) name_lookups: &'a NameLookups<'a, 'tree>,
-    pub(crate) base_hashes: &'a FxHashMap<u64, usize>,
+pub struct Context<'a, 'tree> {
+    pub trees: &'a ThreeWayTrees<'tree>,
+    pub left_items: &'a [tree_sitter::Node<'tree>],
+    pub right_items: &'a [tree_sitter::Node<'tree>],
+    pub name_lookups: &'a NameLookups<'a, 'tree>,
+    pub base_hashes: &'a FxHashMap<u64, usize>,
 }
 
-pub(crate) fn reconcile_all(
+pub fn reconcile_all(
     ctx: &Context<'_, '_>,
     handled_right: &mut FxHashSet<usize>,
 ) -> Vec<Resolved> {

--- a/packages/ast-merge/diff/src/items/right.rs
+++ b/packages/ast-merge/diff/src/items/right.rs
@@ -4,15 +4,15 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::items::{IndexedNode, Resolved, get_name};
 
 /// Context for collecting right-only items not present in base.
-pub(crate) struct CollectNewContext<'a, 'tree> {
-    pub(crate) right_items: &'a [tree_sitter::Node<'tree>],
-    pub(crate) handled_right: &'a FxHashSet<usize>,
-    pub(crate) base_by_name: &'a FxHashMap<String, IndexedNode<'tree>>,
-    pub(crate) base_hashes: &'a FxHashMap<u64, usize>,
-    pub(crate) right_to_base: &'a FxHashMap<usize, usize>,
+pub struct CollectNewContext<'a, 'tree> {
+    pub right_items: &'a [tree_sitter::Node<'tree>],
+    pub handled_right: &'a FxHashSet<usize>,
+    pub base_by_name: &'a FxHashMap<String, IndexedNode<'tree>>,
+    pub base_hashes: &'a FxHashMap<u64, usize>,
+    pub right_to_base: &'a FxHashMap<usize, usize>,
 }
 
-pub(crate) fn collect_new(right_tree: &Tree, ctx: &CollectNewContext<'_, '_>) -> Vec<Resolved> {
+pub fn collect_new(right_tree: &Tree, ctx: &CollectNewContext<'_, '_>) -> Vec<Resolved> {
     use ast_merge_ast::compute;
 
     let mut new_right_items: Vec<Resolved> = Vec::new();
@@ -25,11 +25,10 @@ pub(crate) fn collect_new(right_tree: &Tree, ctx: &CollectNewContext<'_, '_>) ->
         let right_hash = compute(right_tree, *right_item);
         let right_kind = right_item.kind().to_owned();
 
-        let is_new = if let Some(name) = &right_name {
-            !ctx.base_by_name.contains_key(name)
-        } else {
-            !ctx.base_hashes.contains_key(&right_hash)
-        };
+        let is_new = right_name.as_ref().map_or_else(
+            || !ctx.base_hashes.contains_key(&right_hash),
+            |name| !ctx.base_by_name.contains_key(name),
+        );
 
         if is_new {
             let predecessor_base_idx = (0..right_idx)
@@ -47,19 +46,22 @@ pub(crate) fn collect_new(right_tree: &Tree, ctx: &CollectNewContext<'_, '_>) ->
     new_right_items
 }
 
-pub(crate) fn insert_new(merged_items: &mut Vec<Resolved>, new_right_items: Vec<Resolved>) {
+pub fn insert_new(merged_items: &mut Vec<Resolved>, new_right_items: Vec<Resolved>) {
     for new_item in new_right_items {
-        let insert_pos = if let Some(pred_base_idx) = new_item.right_predecessor_base_idx {
-            merged_items
-                .iter()
-                .position(|m| m.base_index == Some(pred_base_idx))
-                .map_or(merged_items.len(), |p| p + 1)
-        } else {
-            merged_items
-                .iter()
-                .position(|m| m.kind != new_item.kind)
-                .unwrap_or(0)
-        };
+        let insert_pos = new_item.right_predecessor_base_idx.map_or_else(
+            || {
+                merged_items
+                    .iter()
+                    .position(|m| m.kind != new_item.kind)
+                    .unwrap_or(0)
+            },
+            |pred_base_idx| {
+                merged_items
+                    .iter()
+                    .position(|m| m.base_index == Some(pred_base_idx))
+                    .map_or(merged_items.len(), |p| p + 1)
+            },
+        );
 
         merged_items.insert(insert_pos, new_item);
     }

--- a/packages/ast-merge/diff/src/lines.rs
+++ b/packages/ast-merge/diff/src/lines.rs
@@ -82,10 +82,10 @@ pub fn inner(base: &str, left: &str, right: &str) -> Outcome {
         let right_insert = right_insertions.get(&i);
 
         // Conflict: both sides insert different content at the same position.
-        if let (Some(li), Some(ri)) = (left_insert, right_insert) {
-            if li != ri {
-                has_conflict = true;
-            }
+        if let (Some(li), Some(ri)) = (left_insert, right_insert)
+            && li != ri
+        {
+            has_conflict = true;
         }
 
         if let Some(lines) = left_insert {
@@ -109,10 +109,10 @@ pub fn inner(base: &str, left: &str, right: &str) -> Outcome {
     // Check for conflicts in trailing insertions (after last base line).
     let left_trailing = left_insertions.get(&base_lines.len());
     let right_trailing = right_insertions.get(&base_lines.len());
-    if let (Some(lt), Some(rt)) = (left_trailing, right_trailing) {
-        if lt != rt {
-            has_conflict = true;
-        }
+    if let (Some(lt), Some(rt)) = (left_trailing, right_trailing)
+        && lt != rt
+    {
+        has_conflict = true;
     }
 
     if let Some(lines) = left_trailing {
@@ -197,20 +197,12 @@ pub fn based(base: &str, left: &str, right: &str) -> Result {
                     right: Region::new(0, r.len(), r.to_owned()),
                 });
             }
-            (Some(_), None, Some(r)) => {
+            (Some(_), None, Some(r)) | (None, None, Some(r)) => {
                 output.push_str(r);
                 output.push('\n');
             }
-            (Some(_), Some(l), None) => {
+            (Some(_), Some(l), None) | (None, Some(l), None) => {
                 output.push_str(l);
-                output.push('\n');
-            }
-            (None, Some(l), None) => {
-                output.push_str(l);
-                output.push('\n');
-            }
-            (None, None, Some(r)) => {
-                output.push_str(r);
                 output.push('\n');
             }
             _ => {}

--- a/packages/ast-merge/git/src/format.rs
+++ b/packages/ast-merge/git/src/format.rs
@@ -24,16 +24,16 @@ pub fn conflict(input: &ConflictInput<'_>, settings: &DisplaySettings) -> String
         output.push('\n');
     }
 
-    if settings.diff3_style {
-        if let Some(base_content) = base {
-            output.push_str(&"|".repeat(settings.marker_size));
-            output.push(' ');
-            output.push_str(&settings.base_name);
+    if settings.diff3_style
+        && let Some(base_content) = base
+    {
+        output.push_str(&"|".repeat(settings.marker_size));
+        output.push(' ');
+        output.push_str(&settings.base_name);
+        output.push('\n');
+        output.push_str(base_content);
+        if !base_content.ends_with('\n') && !base_content.is_empty() {
             output.push('\n');
-            output.push_str(base_content);
-            if !base_content.ends_with('\n') && !base_content.is_empty() {
-                output.push('\n');
-            }
         }
     }
 
@@ -69,12 +69,20 @@ pub enum RevisionError {
     },
 }
 
+/// Read a revision's contents from `path`.
+///
+/// # Errors
+/// Returns an error if the file cannot be read.
 pub fn read_revision(path: &std::path::Path) -> Result<String, RevisionError> {
     std::fs::read_to_string(path).context(ReadSnafu {
         path: path.display().to_string(),
     })
 }
 
+/// Write merged `content` to `path`.
+///
+/// # Errors
+/// Returns an error if the file cannot be written.
 pub fn write_result(path: &std::path::Path, content: &str) -> Result<(), RevisionError> {
     std::fs::write(path, content).context(WriteSnafu {
         path: path.display().to_string(),

--- a/packages/ast-merge/git/src/types.rs
+++ b/packages/ast-merge/git/src/types.rs
@@ -67,7 +67,7 @@ pub struct DriverResult {
 
 impl DriverResult {
     #[must_use]
-    pub fn success(content: String) -> Self {
+    pub const fn success(content: String) -> Self {
         Self {
             content,
             exit_code: 0,
@@ -76,7 +76,7 @@ impl DriverResult {
     }
 
     #[must_use]
-    pub fn with_conflicts(content: String, conflict_count: usize) -> Self {
+    pub const fn with_conflicts(content: String, conflict_count: usize) -> Self {
         Self {
             content,
             exit_code: 1,

--- a/packages/ast-merge/langs/src/lang.rs
+++ b/packages/ast-merge/langs/src/lang.rs
@@ -99,7 +99,7 @@ impl Lang {
     }
 
     #[must_use]
-    pub fn all() -> &'static [Self] {
+    pub const fn all() -> &'static [Self] {
         &[
             Self::Rust,
             Self::JavaScript,

--- a/packages/ast-merge/langs/src/profiles/compiled.rs
+++ b/packages/ast-merge/langs/src/profiles/compiled.rs
@@ -1,6 +1,6 @@
 use crate::types::Profile;
 
-pub(crate) static RUST: Profile = Profile {
+pub static RUST: Profile = Profile {
     name: "Rust",
     extensions: &["rs"],
     file_names: &[],
@@ -14,7 +14,7 @@ pub(crate) static RUST: Profile = Profile {
     comment_nodes: &["line_comment", "block_comment"],
 };
 
-pub(crate) static C: Profile = Profile {
+pub static C: Profile = Profile {
     name: "C",
     extensions: &["c", "h"],
     file_names: &[],
@@ -33,7 +33,7 @@ pub(crate) static C: Profile = Profile {
     comment_nodes: &["comment"],
 };
 
-pub(crate) static CPP: Profile = Profile {
+pub static CPP: Profile = Profile {
     name: "C++",
     extensions: &["cpp", "cc", "cxx", "hpp", "hh", "hxx", "h++", "c++"],
     file_names: &[],
@@ -53,7 +53,7 @@ pub(crate) static CPP: Profile = Profile {
     comment_nodes: &["comment"],
 };
 
-pub(crate) static CSHARP: Profile = Profile {
+pub static CSHARP: Profile = Profile {
     name: "C#",
     extensions: &["cs"],
     file_names: &[],
@@ -73,7 +73,7 @@ pub(crate) static CSHARP: Profile = Profile {
     comment_nodes: &["comment", "multiline_comment"],
 };
 
-pub(crate) static SWIFT: Profile = Profile {
+pub static SWIFT: Profile = Profile {
     name: "Swift",
     extensions: &["swift"],
     file_names: &[],
@@ -88,7 +88,7 @@ pub(crate) static SWIFT: Profile = Profile {
     comment_nodes: &["comment", "multiline_comment"],
 };
 
-pub(crate) static GO: Profile = Profile {
+pub static GO: Profile = Profile {
     name: "Go",
     extensions: &["go"],
     file_names: &[],

--- a/packages/ast-merge/langs/src/profiles/config.rs
+++ b/packages/ast-merge/langs/src/profiles/config.rs
@@ -1,6 +1,6 @@
 use crate::types::Profile;
 
-pub(crate) static JSON: Profile = Profile {
+pub static JSON: Profile = Profile {
     name: "JSON",
     extensions: &["json", "jsonc"],
     file_names: &["package.json", "tsconfig.json", "composer.json"],
@@ -9,7 +9,7 @@ pub(crate) static JSON: Profile = Profile {
     comment_nodes: &[],
 };
 
-pub(crate) static TOML: Profile = Profile {
+pub static TOML: Profile = Profile {
     name: "TOML",
     extensions: &["toml"],
     file_names: &["Cargo.toml", "pyproject.toml"],
@@ -18,7 +18,7 @@ pub(crate) static TOML: Profile = Profile {
     comment_nodes: &["comment"],
 };
 
-pub(crate) static YAML: Profile = Profile {
+pub static YAML: Profile = Profile {
     name: "YAML",
     extensions: &["yaml", "yml"],
     file_names: &[],
@@ -27,7 +27,7 @@ pub(crate) static YAML: Profile = Profile {
     comment_nodes: &["comment"],
 };
 
-pub(crate) static MARKDOWN: Profile = Profile {
+pub static MARKDOWN: Profile = Profile {
     name: "Markdown",
     extensions: &["md", "markdown", "mdown", "mkd"],
     file_names: &["README.md", "CHANGELOG.md", "CONTRIBUTING.md"],
@@ -36,7 +36,7 @@ pub(crate) static MARKDOWN: Profile = Profile {
     comment_nodes: &[],
 };
 
-pub(crate) static DOCKERFILE: Profile = Profile {
+pub static DOCKERFILE: Profile = Profile {
     name: "Dockerfile",
     extensions: &[],
     file_names: &["Dockerfile", "Containerfile"],
@@ -45,7 +45,7 @@ pub(crate) static DOCKERFILE: Profile = Profile {
     comment_nodes: &["comment_line"],
 };
 
-pub(crate) static NIX: Profile = Profile {
+pub static NIX: Profile = Profile {
     name: "Nix",
     extensions: &["nix"],
     file_names: &["flake.nix", "default.nix", "shell.nix"],

--- a/packages/ast-merge/langs/src/profiles/functional.rs
+++ b/packages/ast-merge/langs/src/profiles/functional.rs
@@ -1,6 +1,6 @@
 use crate::types::Profile;
 
-pub(crate) static HASKELL: Profile = Profile {
+pub static HASKELL: Profile = Profile {
     name: "Haskell",
     extensions: &["hs", "lhs"],
     file_names: &[],
@@ -14,7 +14,7 @@ pub(crate) static HASKELL: Profile = Profile {
     comment_nodes: &["comment", "haddock"],
 };
 
-pub(crate) static ELIXIR: Profile = Profile {
+pub static ELIXIR: Profile = Profile {
     name: "Elixir",
     extensions: &["ex", "exs"],
     file_names: &["mix.exs"],
@@ -23,7 +23,7 @@ pub(crate) static ELIXIR: Profile = Profile {
     comment_nodes: &["comment"],
 };
 
-pub(crate) static OCAML: Profile = Profile {
+pub static OCAML: Profile = Profile {
     name: "OCaml",
     extensions: &["ml", "mli"],
     file_names: &[],

--- a/packages/ast-merge/langs/src/profiles/jvm.rs
+++ b/packages/ast-merge/langs/src/profiles/jvm.rs
@@ -1,6 +1,6 @@
 use crate::types::Profile;
 
-pub(crate) static JAVA: Profile = Profile {
+pub static JAVA: Profile = Profile {
     name: "Java",
     extensions: &["java"],
     file_names: &[],
@@ -15,7 +15,7 @@ pub(crate) static JAVA: Profile = Profile {
     comment_nodes: &["line_comment", "block_comment"],
 };
 
-pub(crate) static KOTLIN: Profile = Profile {
+pub static KOTLIN: Profile = Profile {
     name: "Kotlin",
     extensions: &["kt", "kts"],
     file_names: &[],
@@ -29,7 +29,7 @@ pub(crate) static KOTLIN: Profile = Profile {
     comment_nodes: &["line_comment", "multiline_comment"],
 };
 
-pub(crate) static SCALA: Profile = Profile {
+pub static SCALA: Profile = Profile {
     name: "Scala",
     extensions: &["scala", "sc"],
     file_names: &[],

--- a/packages/ast-merge/langs/src/profiles/scripting.rs
+++ b/packages/ast-merge/langs/src/profiles/scripting.rs
@@ -1,6 +1,6 @@
 use crate::types::Profile;
 
-pub(crate) static PYTHON: Profile = Profile {
+pub static PYTHON: Profile = Profile {
     name: "Python",
     extensions: &["py", "pyi", "bzl", "bazel"],
     file_names: &["BUILD", "BUILD.bazel"],
@@ -13,7 +13,7 @@ pub(crate) static PYTHON: Profile = Profile {
     comment_nodes: &["comment"],
 };
 
-pub(crate) static RUBY: Profile = Profile {
+pub static RUBY: Profile = Profile {
     name: "Ruby",
     extensions: &["rb", "rake", "gemspec"],
     file_names: &["Rakefile", "Gemfile", "Guardfile", "Capfile"],
@@ -22,7 +22,7 @@ pub(crate) static RUBY: Profile = Profile {
     comment_nodes: &["comment"],
 };
 
-pub(crate) static PHP: Profile = Profile {
+pub static PHP: Profile = Profile {
     name: "PHP",
     extensions: &["php", "phtml", "php3", "php4", "php5", "php7", "phps"],
     file_names: &[],
@@ -37,7 +37,7 @@ pub(crate) static PHP: Profile = Profile {
     comment_nodes: &["comment"],
 };
 
-pub(crate) static BASH: Profile = Profile {
+pub static BASH: Profile = Profile {
     name: "Bash",
     extensions: &["sh", "bash", "zsh"],
     file_names: &[".bashrc", ".bash_profile", ".zshrc", ".profile"],
@@ -46,7 +46,7 @@ pub(crate) static BASH: Profile = Profile {
     comment_nodes: &["comment"],
 };
 
-pub(crate) static LUA: Profile = Profile {
+pub static LUA: Profile = Profile {
     name: "Lua",
     extensions: &["lua"],
     file_names: &[],

--- a/packages/ast-merge/langs/src/profiles/web.rs
+++ b/packages/ast-merge/langs/src/profiles/web.rs
@@ -1,6 +1,6 @@
 use crate::types::Profile;
 
-pub(crate) static JAVASCRIPT: Profile = Profile {
+pub static JAVASCRIPT: Profile = Profile {
     name: "JavaScript",
     extensions: &["js", "mjs", "cjs", "jsx"],
     file_names: &[],
@@ -9,7 +9,7 @@ pub(crate) static JAVASCRIPT: Profile = Profile {
     comment_nodes: &["comment"],
 };
 
-pub(crate) static TYPESCRIPT: Profile = Profile {
+pub static TYPESCRIPT: Profile = Profile {
     name: "TypeScript",
     extensions: &["ts", "mts", "cts"],
     file_names: &[],
@@ -31,7 +31,7 @@ pub(crate) static TYPESCRIPT: Profile = Profile {
     comment_nodes: &["comment"],
 };
 
-pub(crate) static TSX: Profile = Profile {
+pub static TSX: Profile = Profile {
     name: "TypeScript TSX",
     extensions: &["tsx"],
     file_names: &[],
@@ -53,7 +53,7 @@ pub(crate) static TSX: Profile = Profile {
     comment_nodes: &["comment"],
 };
 
-pub(crate) static HTML: Profile = Profile {
+pub static HTML: Profile = Profile {
     name: "HTML",
     extensions: &["html", "htm", "xhtml"],
     file_names: &["index.html"],
@@ -62,7 +62,7 @@ pub(crate) static HTML: Profile = Profile {
     comment_nodes: &["comment"],
 };
 
-pub(crate) static CSS: Profile = Profile {
+pub static CSS: Profile = Profile {
     name: "CSS",
     extensions: &["css"],
     file_names: &[],
@@ -71,7 +71,7 @@ pub(crate) static CSS: Profile = Profile {
     comment_nodes: &["comment"],
 };
 
-pub(crate) static SVELTE: Profile = Profile {
+pub static SVELTE: Profile = Profile {
     name: "Svelte",
     extensions: &["svelte"],
     file_names: &[],

--- a/packages/ast-merge/matcher/src/gumtree.rs
+++ b/packages/ast-merge/matcher/src/gumtree.rs
@@ -24,7 +24,7 @@ struct NodePairSlices<'a, 'b> {
 
 impl<'a> GumTree<'a> {
     #[must_use]
-    pub fn new(tree_a: &'a Tree, tree_b: &'a Tree, config: Config) -> Self {
+    pub const fn new(tree_a: &'a Tree, tree_b: &'a Tree, config: Config) -> Self {
         Self {
             tree_a,
             tree_b,
@@ -47,10 +47,10 @@ impl<'a> GumTree<'a> {
             "tree sizes"
         );
 
-        if let (Some(root_a), Some(root_b)) = (nodes_a.first(), nodes_b.first()) {
-            if root_a.kind_id() == root_b.kind_id() {
-                matching.add_match(0, 0);
-            }
+        if let (Some(root_a), Some(root_b)) = (nodes_a.first(), nodes_b.first())
+            && root_a.kind_id() == root_b.kind_id()
+        {
+            matching.add_match(0, 0);
         }
 
         let phase1_start = std::time::Instant::now();
@@ -65,14 +65,14 @@ impl<'a> GumTree<'a> {
             "top_down_phase complete"
         );
 
-        let phase15_start = std::time::Instant::now();
+        let leaf_phase_start = std::time::Instant::now();
         self.leaf_sibling_phase(NodePairSlices {
             nodes_a: &nodes_a,
             nodes_b: &nodes_b,
             matching: &mut matching,
         });
         tracing::debug!(
-            elapsed_ms = phase15_start.elapsed().as_millis(),
+            elapsed_ms = leaf_phase_start.elapsed().as_millis(),
             matches = matching.len(),
             "leaf_sibling_phase complete"
         );

--- a/packages/ast-merge/matcher/src/gumtree/bottomup.rs
+++ b/packages/ast-merge/matcher/src/gumtree/bottomup.rs
@@ -25,6 +25,10 @@ pub struct BottomUpInput<'a, 'b> {
     pub config: &'b Config,
 }
 
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "descendant counts are far below f64 mantissa precision"
+)]
 pub fn bottom_up_phase(input: &BottomUpInput<'_, '_>, matching: &mut Map) {
     let BottomUpInput {
         nodes_a,

--- a/packages/ast-merge/matcher/src/traverse.rs
+++ b/packages/ast-merge/matcher/src/traverse.rs
@@ -43,10 +43,11 @@ pub fn subtrees(input: &SubtreesInput<'_, '_>, matching: &mut Map) {
     let a_id = input.nodes_a.iter().position(|n| n.id() == node_a.id());
     let b_id = input.nodes_b.iter().position(|n| n.id() == node_b.id());
 
-    if let (Some(a_id), Some(b_id)) = (a_id, b_id) {
-        if !matching.is_matched_a(a_id) && !matching.is_matched_b(b_id) {
-            matching.add_match(a_id, b_id);
-        }
+    if let (Some(a_id), Some(b_id)) = (a_id, b_id)
+        && !matching.is_matched_a(a_id)
+        && !matching.is_matched_b(b_id)
+    {
+        matching.add_match(a_id, b_id);
     }
 
     let mut cursor_a = node_a.walk();

--- a/packages/clone-detect/cli/src/badge.rs
+++ b/packages/clone-detect/cli/src/badge.rs
@@ -16,6 +16,10 @@ const PADDING: usize = 10;
 const SVG_SCALE: f64 = 10.0;
 const HALF: f64 = 2.0;
 
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "badge widths are small positive integers, exact in f64"
+)]
 pub fn write(path: &std::path::Path, pct: f64) -> Result<(), RunError> {
     let label = "duplication";
     let value = format!("{pct:.1}%");

--- a/packages/clone-detect/detect/src/detector.rs
+++ b/packages/clone-detect/detect/src/detector.rs
@@ -9,6 +9,9 @@ use crate::{
     types::{CloneGroup, DetectConfig, DetectionResult, DetectionStats, Fragment, Kind},
 };
 
+/// Multiplier turning a ratio into a percentage.
+const PERCENT: f64 = 100.0;
+
 #[must_use]
 pub fn instances(scan: &Output, config: &DetectConfig) -> DetectionResult {
     let mut instances = Vec::new();
@@ -90,8 +93,10 @@ pub fn instances(scan: &Output, config: &DetectConfig) -> DetectionResult {
 
     let duplicated_lines = compute_duplicated_lines(&instances);
 
-    const PERCENT: f64 = 100.0;
-
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "line counts stay far below f64 mantissa precision"
+    )]
     let duplication_pct = if total_lines == 0 {
         0.0
     } else {
@@ -167,10 +172,10 @@ fn dedup_subsumed(groups: &mut Vec<CloneGroup>) {
                 break;
             };
 
-            if is_subsumed_by(inner, outer) {
-                if let Some(flag) = subsumed.get_mut(j) {
-                    *flag = true;
-                }
+            if is_subsumed_by(inner, outer)
+                && let Some(flag) = subsumed.get_mut(j)
+            {
+                *flag = true;
             }
         }
     }

--- a/packages/clone-detect/detect/src/lsh.rs
+++ b/packages/clone-detect/detect/src/lsh.rs
@@ -2,25 +2,25 @@ use std::hash::{Hash, Hasher};
 
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet, FxHasher};
 
-/// Number of hash functions in the MinHash signature.
+/// Number of hash functions in the `MinHash` signature.
 pub const NUM_HASHES: usize = 64;
 
 /// Number of bands for LSH banding.
 const NUM_BANDS: usize = 16;
 
-/// Rows per band = NUM_HASHES / NUM_BANDS.
+/// Rows per band = `NUM_HASHES` / `NUM_BANDS`.
 const ROWS_PER_BAND: usize = NUM_HASHES / NUM_BANDS;
 
 /// Maximum bucket size before we skip a bucket (too noisy to be useful).
 const MAX_BUCKET_SIZE: usize = 200;
 
-/// Seed generation multiplier (SplitMix64 gamma constant).
+/// Seed generation multiplier (`SplitMix64` gamma constant).
 const SEED_MUL: u64 = 0x517c_c1b7_2722_0a95;
 
-/// Seed generation addend (SplitMix64 increment).
+/// Seed generation addend (`SplitMix64` increment).
 const SEED_ADD: u64 = 0x6c62_272e_07bb_0142;
 
-/// Pre-generated seeds for MinHash hash functions.
+/// Pre-generated seeds for `MinHash` hash functions.
 /// Computed at compile time via const fn; indexing is safe because
 /// `i` is bounded by `NUM_HASHES` which equals the array length.
 #[expect(
@@ -37,7 +37,7 @@ const HASH_SEEDS: [u64; NUM_HASHES] = {
     seeds
 };
 
-/// Compute a MinHash signature from a set of features.
+/// Compute a `MinHash` signature from a set of features.
 #[must_use]
 pub fn minhash_signature(features: &[u64]) -> [u64; NUM_HASHES] {
     let mut signature = [u64::MAX; NUM_HASHES];
@@ -52,18 +52,18 @@ pub fn minhash_signature(features: &[u64]) -> [u64; NUM_HASHES] {
     signature
 }
 
-/// SplitMix64 finalizer constant (first multiply).
+/// `SplitMix64` finalizer constant (first multiply).
 const MIX_MUL_1: u64 = 0xff51_afd7_ed55_8ccd;
 
-/// SplitMix64 finalizer constant (second multiply).
+/// `SplitMix64` finalizer constant (second multiply).
 const MIX_MUL_2: u64 = 0xc4ce_b9fe_1a85_ec53;
 
-/// SplitMix64 shift width.
+/// `SplitMix64` shift width.
 const MIX_SHIFT: u32 = 32;
 
 /// Mix a value with a seed using splitmix64 finalizer.
 #[inline]
-fn mix(value: u64, seed: u64) -> u64 {
+const fn mix(value: u64, seed: u64) -> u64 {
     let mut h = value ^ seed;
     h = h.wrapping_mul(MIX_MUL_1);
     h ^= h >> MIX_SHIFT;
@@ -72,14 +72,14 @@ fn mix(value: u64, seed: u64) -> u64 {
     h
 }
 
-/// A node location: file_id + node_idx.
+/// A node location: `file_id` + `node_idx`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct NodeLocation {
     pub file_id: usize,
     pub node_idx: usize,
 }
 
-/// A node location paired with its MinHash signature.
+/// A node location paired with its `MinHash` signature.
 pub struct LshEntry {
     pub location: NodeLocation,
     pub signature: [u64; NUM_HASHES],
@@ -99,7 +99,7 @@ pub struct LshIndex {
 }
 
 impl LshIndex {
-    /// Build an LSH index from nodes with their MinHash signatures.
+    /// Build an LSH index from nodes with their `MinHash` signatures.
     #[must_use]
     pub fn build(entries: &[LshEntry]) -> Self {
         let mut bands: Vec<FxHashMap<u64, Vec<NodeLocation>>> = Vec::with_capacity(NUM_BANDS);
@@ -145,16 +145,20 @@ impl LshIndex {
         pairs
     }
 
-    /// Look up the MinHash signature for a node location.
+    /// Look up the `MinHash` signature for a node location.
     #[must_use]
     pub fn signature(&self, loc: &NodeLocation) -> Option<&[u64; NUM_HASHES]> {
         self.signatures.get(loc)
     }
 }
 
-/// Estimate Jaccard similarity from MinHash signatures.
+/// Estimate Jaccard similarity from `MinHash` signatures.
 /// Counts matching slots: `matches / NUM_HASHES`. Zero allocation.
 #[must_use]
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "match count and NUM_HASHES are tiny, well within f64 precision"
+)]
 pub fn estimated_jaccard(sig_a: &[u64; NUM_HASHES], sig_b: &[u64; NUM_HASHES]) -> f64 {
     let matches = sig_a
         .iter()
@@ -164,7 +168,7 @@ pub fn estimated_jaccard(sig_a: &[u64; NUM_HASHES], sig_b: &[u64; NUM_HASHES]) -
     matches as f64 / NUM_HASHES as f64
 }
 
-fn canonical_pair(a: NodeLocation, b: NodeLocation) -> NodePair {
+const fn canonical_pair(a: NodeLocation, b: NodeLocation) -> NodePair {
     if a.file_id < b.file_id || (a.file_id == b.file_id && a.node_idx <= b.node_idx) {
         NodePair {
             first: a,
@@ -246,11 +250,14 @@ mod tests {
         let index = LshIndex::build(&entries);
         let pairs = index.candidate_pairs();
 
-        let has_ab = pairs.contains(&canonical_pair(loc_a, loc_b));
-        assert!(has_ab, "Similar items A and B should be candidates");
+        let similar_pair = pairs.contains(&canonical_pair(loc_a, loc_b));
+        assert!(similar_pair, "Similar items A and B should be candidates");
 
-        let has_ac = pairs.contains(&canonical_pair(loc_a, loc_c));
-        assert!(!has_ac, "Dissimilar items A and C should not be candidates");
+        let dissimilar_pair = pairs.contains(&canonical_pair(loc_a, loc_c));
+        assert!(
+            !dissimilar_pair,
+            "Dissimilar items A and C should not be candidates"
+        );
     }
 
     #[test]

--- a/packages/clone-detect/detect/src/sequences.rs
+++ b/packages/clone-detect/detect/src/sequences.rs
@@ -217,14 +217,14 @@ fn sequence_to_fragment(scan: &Output, loc: &SeqLoc) -> Option<Fragment> {
     })
 }
 
-fn hash_kgram(hashes: &[u64], start: usize, end: usize) -> u64 {
+fn hash_kgram(values: &[u64], start: usize, end: usize) -> u64 {
     let mut hasher = FxHasher::default();
-    for h in hashes.iter().skip(start).take(end - start) {
+    for h in values.iter().skip(start).take(end - start) {
         h.hash(&mut hasher);
     }
     hasher.finish()
 }
 
-fn ranges_overlap(a: std::ops::Range<usize>, b: std::ops::Range<usize>) -> bool {
+const fn ranges_overlap(a: std::ops::Range<usize>, b: std::ops::Range<usize>) -> bool {
     a.start < b.end && b.start < a.end
 }

--- a/packages/clone-detect/detect/src/type3.rs
+++ b/packages/clone-detect/detect/src/type3.rs
@@ -9,7 +9,7 @@ use crate::{
     types::{CloneGroup, Fragment, Kind},
 };
 
-/// Margin for the MinHash estimate pre-check. The estimate approximates
+/// Margin for the `MinHash` estimate pre-check. The estimate approximates
 /// set Jaccard which can differ from multiset Jaccard, so we allow some slack.
 const ESTIMATION_MARGIN: f64 = 0.1;
 
@@ -139,6 +139,10 @@ fn try_make_group(scan: &Output, pair: &CandidatePair) -> Option<CloneGroup> {
 
 /// Compute structural similarity between two AST nodes.
 #[must_use]
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "AST node counts are far below f64 mantissa precision"
+)]
 pub fn compute_similarity(a: &NodeInfo, b: &NodeInfo) -> f64 {
     if !a.subtree_features.is_empty() && !b.subtree_features.is_empty() {
         return multiset_sorted(&a.subtree_features, &b.subtree_features);

--- a/packages/clone-detect/detect/tests/common/mod.rs
+++ b/packages/clone-detect/detect/tests/common/mod.rs
@@ -4,7 +4,7 @@ use clone_detect::{DetectConfig, DetectionResult, instances};
 use clone_scanner::Config;
 use tempfile::TempDir;
 
-pub fn test_scan_config() -> Config {
+pub const fn test_scan_config() -> Config {
     Config {
         min_lines: 1,
         min_nodes: 1,

--- a/packages/clone-detect/hash/src/extract.rs
+++ b/packages/clone-detect/hash/src/extract.rs
@@ -37,7 +37,7 @@ pub struct NodeInfo {
     /// statement-sequence clone detection (sliding-window k-grams).
     pub children: Vec<ChildInfo>,
     /// Normalized structural tokens (unigrams + bigrams) for the entire
-    /// subtree. Used as the feature set for MinHash LSH Type-3 detection.
+    /// subtree. Used as the feature set for `MinHash` LSH Type-3 detection.
     /// Much richer than direct-child hashes: captures deep structural
     /// similarity including nested patterns.
     pub subtree_features: Vec<u64>,
@@ -120,7 +120,7 @@ fn collect_children(tree: &Tree, node: tree_sitter::Node<'_>) -> Vec<ChildInfo> 
     children
 }
 
-/// Collect structural features for MinHash LSH.
+/// Collect structural features for `MinHash` LSH.
 ///
 /// Walks the subtree in preorder, producing a normalized token per AST node
 /// (kind + normalized leaf content). Then adds bigrams of consecutive tokens

--- a/packages/clone-detect/pragma/src/lib.rs
+++ b/packages/clone-detect/pragma/src/lib.rs
@@ -64,7 +64,7 @@ impl Info {
     }
 }
 
-fn ranges_overlap(a: &Range<usize>, b: &Range<usize>) -> bool {
+const fn ranges_overlap(a: &Range<usize>, b: &Range<usize>) -> bool {
     a.start < b.end && b.start < a.end
 }
 
@@ -109,11 +109,12 @@ pub fn scan(tree: &Tree) -> Info {
 fn scan_recursive(ctx: &mut ScanContext<'_>, node: tree_sitter::Node<'_>) {
     let kind = node.kind();
 
-    if let Some(comment_end) = ctx.state.ignore_next {
-        if node.start_byte() >= comment_end && !is_comment(kind) {
-            ctx.info.ignored_ranges.push(node.byte_range());
-            ctx.state.ignore_next = None;
-        }
+    if let Some(comment_end) = ctx.state.ignore_next
+        && node.start_byte() >= comment_end
+        && !is_comment(kind)
+    {
+        ctx.info.ignored_ranges.push(node.byte_range());
+        ctx.state.ignore_next = None;
     }
 
     if is_comment(kind) {

--- a/packages/clone-detect/scanner/src/scan.rs
+++ b/packages/clone-detect/scanner/src/scan.rs
@@ -79,7 +79,7 @@ pub struct Scanner {
 
 impl Scanner {
     #[must_use]
-    pub fn new(config: Config) -> Self {
+    pub const fn new(config: Config) -> Self {
         Self { config }
     }
 
@@ -88,6 +88,10 @@ impl Scanner {
         Self::new(Config::default())
     }
 
+    /// Scan every file under a directory tree for clone-relevant AST nodes.
+    ///
+    /// # Errors
+    /// Returns an error if the tree cannot be walked or a file cannot be read.
     pub fn directory(&self, path: &Path) -> Result<Output, Error> {
         let results: Mutex<Vec<File>> = Mutex::new(Vec::new());
         let error: Mutex<Option<Error>> = Mutex::new(None);
@@ -157,6 +161,10 @@ impl Scanner {
         Ok(Output { files, index })
     }
 
+    /// Scan a single file for clone-relevant AST nodes.
+    ///
+    /// # Errors
+    /// Returns an error if the file cannot be stat-ed, read, or parsed.
     pub fn file(&self, path: &Path) -> Result<Option<File>, Error> {
         let path_str = path.display().to_string();
         let metadata = std::fs::symlink_metadata(path).context(StatSnafu { path: &path_str })?;
@@ -224,7 +232,7 @@ impl Output {
     }
 
     #[must_use]
-    pub fn total_files(&self) -> usize {
+    pub const fn total_files(&self) -> usize {
         self.files.len()
     }
 }

--- a/packages/clone-detect/scanner/src/tests/file.rs
+++ b/packages/clone-detect/scanner/src/tests/file.rs
@@ -20,9 +20,9 @@ fn foo() {
     let result = scanner.file(&path).unwrap();
 
     assert!(result.is_some());
-    let scanned = result.unwrap();
-    assert_eq!(scanned.language, Lang::Rust);
-    assert!(!scanned.nodes.is_empty());
+    let scanned_file = result.unwrap();
+    assert_eq!(scanned_file.language, Lang::Rust);
+    assert!(!scanned_file.nodes.is_empty());
 }
 
 #[test]
@@ -41,8 +41,8 @@ function calculate(a, b) {
     let result = scanner.file(&path).unwrap();
 
     assert!(result.is_some());
-    let scanned = result.unwrap();
-    assert_eq!(scanned.language, Lang::JavaScript);
+    let scanned_file = result.unwrap();
+    assert_eq!(scanned_file.language, Lang::JavaScript);
 }
 
 #[test]
@@ -60,8 +60,8 @@ def calculate(a, b):
     let result = scanner.file(&path).unwrap();
 
     assert!(result.is_some());
-    let scanned = result.unwrap();
-    assert_eq!(scanned.language, Lang::Python);
+    let scanned_file = result.unwrap();
+    assert_eq!(scanned_file.language, Lang::Python);
 }
 
 #[test]
@@ -84,8 +84,8 @@ fn empty() {
     let result = scanner.file(&path).unwrap();
 
     assert!(result.is_some());
-    let scanned = result.unwrap();
-    assert!(scanned.nodes.is_empty());
+    let scanned_file = result.unwrap();
+    assert!(scanned_file.nodes.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Fixes the remaining pre-existing broken-main CI (`lint` / `rust-package-tests`): the ix→index-migrated `ast-merge-*` and `clone-detect` crates did not pass index's `pedantic`/`nursery` clippy.

Real per-lint fixes (no blanket allows):
- `redundant_pub_crate` → `pub` in private modules
- `missing_const_for_fn` → `const fn`
- `doc_markdown` → backticks
- `similar_names` → renamed bindings (one targeted `#[expect]` where a 2x2 matrix naming is clearest)
- `collapsible_if` → let-chains
- `missing_errors_doc` → `# Errors` sections
- `option_if_let_else` → `map_or_else`
- `match_same_arms` → merged arms
- `cast_precision_loss` → targeted `#[expect]` for small-integer→f64 ratios

Tracks #398. Another verification pass may follow.

---
Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Clippy lints in `ast-merge` and `clone-detect` crates
> - Marks numerous constructors and pure functions as `const fn` across both crates (e.g. `Tree::new`, `PcsTriple::new`, `Region::new`, `Scanner::new`).
> - Changes visibility of several structs and statics from `pub(crate)` to `pub` in `ast-merge/diff` and `ast-merge/langs` profile modules.
> - Refactors control flow in `children.rs`, `items.rs`, `lines.rs`, and `pragma/src/lib.rs` to satisfy lints by using `if let` guards, `matches!`, and `Option::map_or_else` — no behavioral changes.
> - Suppresses unavoidable lints (e.g. `cast_precision_loss`, `similar_names`) with `#[expect(...)]` attributes in `bottomup.rs`, `badge.rs`, `detector.rs`, and `lsh.rs`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79c29f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->