### PR TITLE
fix(clippy): nest or-patterns and map_or_else in ast-merge diff/cli

### DIFF
--- a/packages/ast-merge/cli/src/merge.rs
+++ b/packages/ast-merge/cli/src/merge.rs
@@ -83,14 +83,16 @@ pub fn resolve_language(
     language: Option<&str>,
     left: &std::path::Path,
 ) -> Result<Option<ast_merge_langs::Lang>, CliError> {
-    match language {
-        Some(name) => detect_by_name(name)
-            .map(Some)
-            .ok_or_else(|| CliError::UnknownLanguageName {
-                name: name.to_owned(),
-            }),
-        None => Ok(ast_merge_langs::detect(left)),
-    }
+    language.map_or_else(
+        || Ok(ast_merge_langs::detect(left)),
+        |name| {
+            detect_by_name(name)
+                .map(Some)
+                .ok_or_else(|| CliError::UnknownLanguageName {
+                    name: name.to_owned(),
+                })
+        },
+    )
 }
 
 struct TreeInput<'a> {

--- a/packages/ast-merge/diff/src/lines.rs
+++ b/packages/ast-merge/diff/src/lines.rs
@@ -197,11 +197,11 @@ pub fn based(base: &str, left: &str, right: &str) -> Result {
                     right: Region::new(0, r.len(), r.to_owned()),
                 });
             }
-            (Some(_), None, Some(r)) | (None, None, Some(r)) => {
+            (Some(_) | None, None, Some(r)) => {
                 output.push_str(r);
                 output.push('\n');
             }
-            (Some(_), Some(l), None) | (None, Some(l), None) => {
+            (Some(_) | None, Some(l), None) => {
                 output.push_str(l);
                 output.push('\n');
             }


### PR DESCRIPTION
Follow-up to #402 that brings the migrated crates' clippy fully green.

- `lines.rs`: the merged match arms tripped `unnested_or_patterns` → nested form `(Some(_) | None, ...)`.
- cli `merge.rs`: `resolve_language` still used `match`/if-let-else → `map_or_else` (`option_if_let_else`).

Verified: `nix build .#checks.x86_64-linux.rust-{ast-merge,clone-detect}-clippy` exits 0 (whole `cargo-unit-clippy` aggregate green). Closes #398.

---
Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix clippy warnings by using or-patterns and `map_or_else` in ast-merge diff/cli
> Applies two clippy lint fixes across the ast-merge packages with no logic changes.
>
> - In [`diff/src/lines.rs`](https://github.com/indexable-inc/index/pull/403/files#diff-5e3c3cfbd107c0e97e24f288ead35f7795c8330009a34ad04e6b24ce59070b60), consolidates redundant match arms in `based` using or-patterns (`Some(_) | None`).
> - In [`cli/src/merge.rs`](https://github.com/indexable-inc/index/pull/403/files#diff-0455254e82d1745fdafabe49dc2cab860b79d81eda772e49ac24da861d9a9bea), rewrites the `resolve_language` match on `Option<&str>` to use `Option::map_or_else`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c08bab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->