### PR TITLE
bossbar: hover-highlight and drag-to-reposition bars (macOS)

### DIFF
--- a/packages/bossbar-overlay/README.md
+++ b/packages/bossbar-overlay/README.md
@@ -30,9 +30,16 @@ bash scripts/fetch-assets.sh   # downloads into app/assets/, no-op once present
 cargo run                      # the overlay
 ```
 
-The window covers the top of the primary monitor. There is no tray; quit it the
-way you quit any foreground process (Ctrl-C from the terminal, or stop the
-service that runs it). `BOSSBAR_SCALE=3` (or `--scale 3`) enlarges the bars.
+The window is transparent, always-on-top, and click-through, so the desktop
+underneath stays usable. There is no tray; quit it the way you quit any
+foreground process (Ctrl-C from the terminal, or stop the service that runs it).
+`BOSSBAR_SCALE=3` (or `--scale 3`) enlarges the bars.
+
+On macOS the bars are interactive: hover one and it brightens to fully opaque
+(the cursor becomes a grab hand), and you can drag it anywhere on the screen.
+The drop location is saved to the bar's `x`/`y` columns, so it stays put across
+restarts. Only the bars intercept the mouse; everywhere else the window stays
+click-through. Other platforms render the same overlay without the drag path.
 
 To verify rendering without a window, render the current bars straight to a
 transparent PNG:
@@ -77,7 +84,9 @@ CREATE TABLE bossbars (
   color     TEXT    NOT NULL DEFAULT 'purple',
   overlay   TEXT    NOT NULL DEFAULT 'progress',
   visible   INTEGER NOT NULL DEFAULT 1,      -- 0 hides the row
-  position  INTEGER NOT NULL DEFAULT 0       -- sort order, top to bottom
+  position  INTEGER NOT NULL DEFAULT 0,      -- sort order in the auto column
+  x         REAL,                            -- pinned location (logical points)
+  y         REAL                             -- NULL/NULL = auto-stacked
 );
 ```
 
@@ -85,6 +94,9 @@ CREATE TABLE bossbars (
   (Minecraft's seven boss bar colors). Unknown values fall back to `purple`.
 - **overlay**: `progress` (smooth) or `notched_6` / `notched_10` / `notched_12`
   / `notched_20` (segmented), matching Minecraft's overlay styles.
+- **x / y**: pinned screen location in logical points, written when you drag a
+  bar. Leave both `NULL` (the default) to keep the bar in the auto-stacked
+  top-center column ordered by `position`; setting them floats the bar free.
 
 This mirrors Minecraft's own boss bar API, so the fields should feel familiar.
 

--- a/packages/bossbar-overlay/app/Cargo.lock
+++ b/packages/bossbar-overlay/app/Cargo.lock
@@ -163,7 +163,9 @@ name = "bossbar-overlay"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "core-graphics 0.24.0",
  "dirs",
+ "glam",
  "glyphon",
  "image",
  "pollster",
@@ -325,6 +327,19 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
+ "core-graphics-types 0.2.0",
  "foreign-types",
  "libc",
 ]
@@ -687,6 +702,12 @@ dependencies = [
  "log",
  "xml-rs",
 ]
+
+[[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
 
 [[package]]
 name = "glow"
@@ -2797,7 +2818,7 @@ dependencies = [
  "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
- "core-graphics",
+ "core-graphics 0.23.2",
  "cursor-icon",
  "dpi",
  "js-sys",

--- a/packages/bossbar-overlay/app/Cargo.toml
+++ b/packages/bossbar-overlay/app/Cargo.toml
@@ -25,6 +25,14 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 # Bundled SQLite so users don't need a system libsqlite3.
 rusqlite = { version = "0.32", features = ["bundled"] }
 dirs = "6"
+# 2D vectors for bar positions and hit-testing, instead of bare (f64, f64).
+glam = "0.30"
+
+# Reading the global cursor location to wake the click-through overlay only when
+# the pointer is over a bar is macOS-specific (CoreGraphics). Other platforms
+# keep the non-interactive click-through overlay.
+[target.'cfg(target_os = "macos")'.dependencies]
+core-graphics = "0.24"
 
 [profile.release]
 # A desktop HUD: trim the binary, no need for fat debug info.

--- a/packages/bossbar-overlay/app/src/bars.rs
+++ b/packages/bossbar-overlay/app/src/bars.rs
@@ -87,6 +87,10 @@ pub struct BossBar {
     pub color: Color,
     pub overlay: Overlay,
     pub position: i64,
+    /// Pinned on-screen location in logical screen points (top-left origin of
+    /// the title), set once the bar is dragged. `None` keeps the bar in the
+    /// auto-stacked top-center column. Persisted to the `x`/`y` DB columns.
+    pub pos: Option<glam::DVec2>,
 }
 
 #[cfg(test)]

--- a/packages/bossbar-overlay/app/src/db.rs
+++ b/packages/bossbar-overlay/app/src/db.rs
@@ -27,8 +27,15 @@ CREATE TABLE IF NOT EXISTS bossbars (
   color     TEXT    NOT NULL DEFAULT 'purple',
   overlay   TEXT    NOT NULL DEFAULT 'progress',
   visible   INTEGER NOT NULL DEFAULT 1,
-  position  INTEGER NOT NULL DEFAULT 0
+  position  INTEGER NOT NULL DEFAULT 0,
+  x         REAL,
+  y         REAL
 );";
+
+/// Columns added after the initial schema shipped. `ALTER TABLE ADD COLUMN` is
+/// the supported online migration in SQLite, and it errors if the column
+/// already exists, so each runs through `add_column_if_missing`.
+const ADDED_COLUMNS: &[(&str, &str)] = &[("x", "REAL"), ("y", "REAL")];
 
 /// Rows inserted only when the DB file is created for the first time, so a
 /// brand-new install shows something and documents the contract by example.
@@ -61,20 +68,51 @@ fn open(path: &Path) -> rusqlite::Result<Connection> {
     // WAL lets external `sqlite3` writers commit without blocking our reader.
     conn.pragma_update(None, "journal_mode", "WAL")?;
     conn.execute_batch(SCHEMA)?;
+    for (name, ty) in ADDED_COLUMNS {
+        add_column_if_missing(&conn, name, ty)?;
+    }
     if fresh {
         conn.execute_batch(SEED)?;
     }
     Ok(conn)
 }
 
+/// Add a column to `bossbars` only when a pre-existing database lacks it, so
+/// upgrading an old DB does not error on the duplicate-column `ALTER TABLE`.
+fn add_column_if_missing(conn: &Connection, name: &str, ty: &str) -> rusqlite::Result<()> {
+    let present = conn
+        .prepare("SELECT 1 FROM pragma_table_info('bossbars') WHERE name = ?1")?
+        .exists([name])?;
+    if !present {
+        // Column names and types here are compile-time constants, never user
+        // input, so the format! cannot carry untrusted SQL.
+        conn.execute_batch(&format!("ALTER TABLE bossbars ADD COLUMN {name} {ty};"))?;
+    }
+    Ok(())
+}
+
+/// Persist a dragged bar's pinned location (logical screen points). Uses its
+/// own connection so the overlay's read/watch connection is untouched; the
+/// commit bumps `data_version`, so the watcher re-reads and the move sticks.
+pub fn set_position(path: &Path, id: i64, pos: glam::DVec2) -> rusqlite::Result<()> {
+    let conn = open(path)?;
+    conn.execute(
+        "UPDATE bossbars SET x = ?1, y = ?2 WHERE id = ?3",
+        rusqlite::params![pos.x, pos.y, id],
+    )?;
+    Ok(())
+}
+
 fn read(conn: &Connection) -> rusqlite::Result<Vec<BossBar>> {
     let mut stmt = conn.prepare(
-        "SELECT id, title, progress, color, overlay, position
+        "SELECT id, title, progress, color, overlay, position, x, y
          FROM bossbars
          WHERE visible != 0
          ORDER BY position ASC, id ASC",
     )?;
     let rows = stmt.query_map([], |r| {
+        let x: Option<f64> = r.get(6)?;
+        let y: Option<f64> = r.get(7)?;
         Ok(BossBar {
             id: r.get(0)?,
             title: r.get(1)?,
@@ -82,6 +120,9 @@ fn read(conn: &Connection) -> rusqlite::Result<Vec<BossBar>> {
             color: Color::parse(&r.get::<_, String>(3)?),
             overlay: Overlay::parse(&r.get::<_, String>(4)?),
             position: r.get(5)?,
+            // Both coordinates must be present to pin a bar; a half-written row
+            // falls back to auto-stacking rather than placing it at an edge.
+            pos: x.zip(y).map(|(x, y)| glam::DVec2::new(x, y)),
         })
     })?;
     rows.collect()

--- a/packages/bossbar-overlay/app/src/overlay.rs
+++ b/packages/bossbar-overlay/app/src/overlay.rs
@@ -1,24 +1,49 @@
-//! The live overlay: a transparent, always-on-top, click-through window
-//! spanning the top of the primary monitor. winit owns the window and event
-//! loop; the SQLite watcher runs on its own thread and wakes the loop with a
-//! fresh `Vec<BossBar>` user event whenever the database changes.
+//! The live overlay: a transparent, always-on-top window over the screen.
+//! winit owns the window and event loop; the SQLite watcher runs on its own
+//! thread and wakes the loop with a fresh `Vec<BossBar>` whenever the database
+//! changes.
+//!
+//! The window is click-through by default so the desktop underneath stays
+//! usable. On macOS a background thread polls the global cursor (CoreGraphics),
+//! and the moment it crosses a bar the window flips to capture the pointer:
+//! that bar highlights, and a drag repositions it (persisted to the DB). Off
+//! the bars the window returns to click-through, so only the bars themselves
+//! intercept the mouse. Other platforms keep the static click-through overlay.
 
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use glam::{DVec2, Vec2, vec2};
 use winit::application::ApplicationHandler;
 use winit::dpi::{PhysicalPosition, PhysicalSize};
-use winit::event::WindowEvent;
+use winit::event::{ElementState, MouseButton, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy};
-use winit::window::{Window, WindowLevel};
+use winit::window::{CursorIcon, Window, WindowLevel};
 
 use crate::bars::BossBar;
 use crate::db;
 use crate::render::Renderer;
 
-/// Fraction of the monitor height the overlay window covers from the top. The
-/// window itself is click-through; this just bounds where bars can paint.
+/// Fraction of the monitor height the overlay covers on platforms without the
+/// interactive (drag-anywhere) path; the window is click-through and this just
+/// bounds where bars can paint.
+#[cfg(not(target_os = "macos"))]
 const HEIGHT_FRACTION: f64 = 0.45;
+
+/// Loop wake-ups: a fresh set of bars from the DB watcher, or the latest global
+/// cursor position from the macOS poll thread (physical pixels).
+enum Ev {
+    Bars(Vec<BossBar>),
+    Cursor(Vec2),
+}
+
+/// An in-progress drag: which bar, and the pointer's offset from the bar's
+/// origin at grab time, so the bar tracks the cursor without jumping.
+#[derive(Clone, Copy)]
+struct Drag {
+    id: i64,
+    grab: Vec2,
+}
 
 struct Gpu {
     surface: wgpu::Surface<'static>,
@@ -32,14 +57,71 @@ pub struct App {
     /// Logical pixel scale; multiplied by the monitor scale factor so the bars
     /// look the same physical size on HiDPI and standard displays.
     base_scale: u32,
-    proxy: EventLoopProxy<Vec<BossBar>>,
+    proxy: EventLoopProxy<Ev>,
     window: Option<Arc<Window>>,
     gpu: Option<Gpu>,
     bars: Vec<BossBar>,
+
+    /// Display backing-scale factor, captured on resume (e.g. 2.0 on Retina).
+    scale_factor: f64,
+    /// Whether the window currently captures the pointer (`set_cursor_hittest`).
+    /// Default is click-through; it flips on only while the cursor is on a bar.
+    interactive: bool,
+    /// Bar under the pointer, drawn opaque for feedback.
+    hovered: Option<i64>,
+    /// Active drag, if the pointer is held down on a bar.
+    dragging: Option<Drag>,
+    /// Last known pointer position, in physical pixels.
+    cursor: Vec2,
 }
 
 impl App {
+    fn renderer(&self) -> Option<&Renderer> {
+        self.gpu.as_ref().map(|g| &g.renderer)
+    }
+
+    fn width(&self) -> f32 {
+        self.gpu.as_ref().map(|g| g.config.width as f32).unwrap_or(0.0)
+    }
+
+    fn bar_index(&self, id: i64) -> Option<usize> {
+        self.bars.iter().position(|b| b.id == id)
+    }
+
+    /// The bar under a physical-pixel point, via the renderer's shared layout.
+    fn hit_test(&self, point: Vec2) -> Option<i64> {
+        self.renderer()?.hit(&self.bars, self.width(), point)
+    }
+
+    /// Toggle pointer capture. Off (the default) lets clicks fall through to the
+    /// desktop; on lets the window receive hover, click, and drag on a bar.
+    fn set_interactive(&mut self, on: bool) {
+        if self.interactive == on {
+            return;
+        }
+        if let Some(w) = &self.window {
+            // Wayland does not support this; the error is ignored there, leaving
+            // the overlay non-interactive rather than crashing.
+            let _ = w.set_cursor_hittest(on);
+        }
+        self.interactive = on;
+    }
+
+    fn set_icon(&self, icon: CursorIcon) {
+        if let Some(w) = &self.window {
+            w.set_cursor(icon);
+        }
+    }
+
+    fn request_redraw(&self) {
+        if let Some(w) = &self.window {
+            w.request_redraw();
+        }
+    }
+
     fn render(&mut self) {
+        // The hovered (or actively dragged) bar paints opaque.
+        let highlight = self.dragging.map(|d| d.id).or(self.hovered);
         let Some(gpu) = self.gpu.as_mut() else {
             return;
         };
@@ -59,12 +141,12 @@ impl App {
             .create_view(&wgpu::TextureViewDescriptor::default());
         let _ = gpu
             .renderer
-            .render(&view, gpu.config.width, gpu.config.height, &self.bars);
+            .render(&view, gpu.config.width, gpu.config.height, &self.bars, highlight);
         frame.present();
     }
 }
 
-impl ApplicationHandler<Vec<BossBar>> for App {
+impl ApplicationHandler<Ev> for App {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         if self.window.is_some() {
             return;
@@ -77,7 +159,18 @@ impl ApplicationHandler<Vec<BossBar>> for App {
             Some(m) => (m.size().width, m.size().height, m.scale_factor()),
             None => (1920, 1080, 1.0),
         };
-        let height = ((mon_h as f64) * HEIGHT_FRACTION) as u32;
+        self.scale_factor = scale_factor;
+
+        // macOS drives the interactive path, so the window spans the whole
+        // screen and a bar can be dragged anywhere. Elsewhere it stays the
+        // click-through top strip.
+        #[cfg(target_os = "macos")]
+        let window_size = PhysicalSize::new(mon_w.max(1), mon_h.max(1));
+        #[cfg(not(target_os = "macos"))]
+        let window_size = PhysicalSize::new(
+            mon_w.max(1),
+            (((mon_h as f64) * HEIGHT_FRACTION) as u32).max(1),
+        );
 
         let attrs = Window::default_attributes()
             .with_title("Boss Bar Overlay")
@@ -85,15 +178,16 @@ impl ApplicationHandler<Vec<BossBar>> for App {
             .with_decorations(false)
             .with_resizable(false)
             .with_window_level(WindowLevel::AlwaysOnTop)
-            .with_inner_size(PhysicalSize::new(mon_w.max(1), height.max(1)))
+            .with_inner_size(window_size)
             .with_position(PhysicalPosition::new(0, 0));
         let window = Arc::new(
             event_loop
                 .create_window(attrs)
                 .expect("create overlay window"),
         );
-        // Let every click fall through to whatever is underneath. Not all
-        // backends support this (notably Wayland); ignore the error there.
+        // Start click-through: every click falls to whatever is underneath until
+        // the cursor crosses a bar. Not all backends support this (notably
+        // Wayland); ignore the error there.
         let _ = window.set_cursor_hittest(false);
 
         let instance = wgpu::Instance::default();
@@ -154,7 +248,8 @@ impl ApplicationHandler<Vec<BossBar>> for App {
         surface.configure(&device, &config);
 
         let scale = ((self.base_scale as f64) * scale_factor).round() as u32;
-        let renderer = Renderer::new(device.clone(), queue, format, scale.max(1));
+        let renderer =
+            Renderer::new(device.clone(), queue, format, scale.max(1), scale_factor as f32);
 
         self.bars = db::read_once(&self.db).unwrap_or_default();
         self.gpu = Some(Gpu {
@@ -168,15 +263,38 @@ impl ApplicationHandler<Vec<BossBar>> for App {
         // Wake the loop with fresh bars on every DB change; a send error means
         // the loop is gone, which stops the watcher thread.
         let proxy = self.proxy.clone();
-        db::spawn_watcher(self.db.clone(), move |bars| proxy.send_event(bars).is_ok());
+        db::spawn_watcher(self.db.clone(), move |bars| {
+            proxy.send_event(Ev::Bars(bars)).is_ok()
+        });
+
+        // Track the global cursor so the click-through window can wake up the
+        // instant the pointer reaches a bar (macOS only).
+        spawn_cursor_poll(self.proxy.clone(), scale_factor);
 
         window.request_redraw();
     }
 
-    fn user_event(&mut self, _event_loop: &ActiveEventLoop, bars: Vec<BossBar>) {
-        self.bars = bars;
-        if let Some(w) = &self.window {
-            w.request_redraw();
+    fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: Ev) {
+        match event {
+            Ev::Bars(bars) => {
+                self.bars = bars;
+                self.request_redraw();
+            }
+            Ev::Cursor(p) => {
+                self.cursor = p;
+                // While the window already captures the pointer, winit's own
+                // CursorMoved drives hover and drag; the poll only matters for
+                // waking the click-through window when a bar is first entered.
+                if self.interactive || self.dragging.is_some() {
+                    return;
+                }
+                if let Some(id) = self.hit_test(p) {
+                    self.hovered = Some(id);
+                    self.set_interactive(true);
+                    self.set_icon(CursorIcon::Grab);
+                    self.request_redraw();
+                }
+            }
         }
     }
 
@@ -194,11 +312,94 @@ impl ApplicationHandler<Vec<BossBar>> for App {
                     gpu.config.height = size.height.max(1);
                     gpu.surface.configure(&gpu.device, &gpu.config);
                 }
-                if let Some(w) = &self.window {
-                    w.request_redraw();
-                }
+                self.request_redraw();
             }
             WindowEvent::RedrawRequested => self.render(),
+            WindowEvent::CursorMoved { position, .. } => {
+                let p = vec2(position.x as f32, position.y as f32);
+                self.cursor = p;
+                if let Some(d) = self.dragging {
+                    // Move the dragged bar to follow the cursor, storing its new
+                    // anchor in logical points so it survives scale changes.
+                    let origin = p - d.grab;
+                    let sf = self.scale_factor as f32;
+                    if let Some(i) = self.bar_index(d.id) {
+                        self.bars[i].pos =
+                            Some(DVec2::new((origin.x / sf) as f64, (origin.y / sf) as f64));
+                        self.request_redraw();
+                    }
+                } else {
+                    match self.hit_test(p) {
+                        Some(id) => {
+                            if self.hovered != Some(id) {
+                                self.hovered = Some(id);
+                                self.request_redraw();
+                            }
+                            self.set_icon(CursorIcon::Grab);
+                        }
+                        None => {
+                            // Left every bar: hand the pointer back to the desktop.
+                            self.hovered = None;
+                            self.set_interactive(false);
+                            self.set_icon(CursorIcon::Default);
+                            self.request_redraw();
+                        }
+                    }
+                }
+            }
+            WindowEvent::MouseInput {
+                state,
+                button: MouseButton::Left,
+                ..
+            } => match state {
+                ElementState::Pressed => {
+                    if let Some(id) = self.hovered {
+                        let origin = self
+                            .renderer()
+                            .and_then(|r| r.origin_of(&self.bars, self.width(), id));
+                        if let Some(origin) = origin {
+                            self.dragging = Some(Drag {
+                                id,
+                                grab: self.cursor - origin,
+                            });
+                            self.set_icon(CursorIcon::Grabbing);
+                        }
+                    }
+                }
+                ElementState::Released => {
+                    if let Some(d) = self.dragging.take() {
+                        if let Some(i) = self.bar_index(d.id) {
+                            if let Some(pos) = self.bars[i].pos {
+                                if let Err(e) = db::set_position(&self.db, d.id, pos) {
+                                    eprintln!("bossbar-overlay: save position failed: {e}");
+                                }
+                            }
+                        }
+                        // Re-resolve hover at the drop point: stay live if still
+                        // on a bar, otherwise return to click-through.
+                        match self.hit_test(self.cursor) {
+                            Some(id) => {
+                                self.hovered = Some(id);
+                                self.set_icon(CursorIcon::Grab);
+                            }
+                            None => {
+                                self.hovered = None;
+                                self.set_interactive(false);
+                                self.set_icon(CursorIcon::Default);
+                            }
+                        }
+                        self.request_redraw();
+                    }
+                }
+            },
+            WindowEvent::CursorLeft { .. } => {
+                if self.dragging.is_none() {
+                    self.hovered = None;
+                    self.set_interactive(false);
+                    self.set_icon(CursorIcon::Default);
+                    self.request_redraw();
+                }
+            }
             _ => {}
         }
     }
@@ -215,13 +416,52 @@ pub fn run(db: PathBuf, base_scale: u32) -> Result<(), Box<dyn std::error::Error
         window: None,
         gpu: None,
         bars: Vec::new(),
+        scale_factor: 1.0,
+        interactive: false,
+        hovered: None,
+        dragging: None,
+        cursor: Vec2::ZERO,
     };
     event_loop.run_app(&mut app)?;
     Ok(())
 }
 
+/// Poll the global cursor location and forward it to the event loop so the
+/// click-through window can detect when the pointer reaches a bar. macOS only;
+/// reads the HID pointer position with no accessibility permission.
 #[cfg(target_os = "macos")]
-fn build_event_loop() -> Result<EventLoop<Vec<BossBar>>, winit::error::EventLoopError> {
+fn spawn_cursor_poll(proxy: EventLoopProxy<Ev>, scale_factor: f64) {
+    use core_graphics::event::CGEvent;
+    use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
+    use std::time::Duration;
+
+    std::thread::spawn(move || {
+        let Ok(source) = CGEventSource::new(CGEventSourceStateID::HIDSystemState) else {
+            eprintln!("bossbar-overlay: cursor source unavailable; overlay stays click-through");
+            return;
+        };
+        loop {
+            // CGEvent locations are top-left logical points; scale to the
+            // framebuffer's physical pixels to match the window/render space.
+            if let Ok(ev) = CGEvent::new(source.clone()) {
+                let p = ev.location();
+                let phys = vec2((p.x * scale_factor) as f32, (p.y * scale_factor) as f32);
+                if proxy.send_event(Ev::Cursor(phys)).is_err() {
+                    return;
+                }
+            }
+            std::thread::sleep(Duration::from_millis(16));
+        }
+    });
+}
+
+/// Non-macOS: no global cursor source wired up, so the overlay stays
+/// click-through and non-interactive.
+#[cfg(not(target_os = "macos"))]
+fn spawn_cursor_poll(_proxy: EventLoopProxy<Ev>, _scale_factor: f64) {}
+
+#[cfg(target_os = "macos")]
+fn build_event_loop() -> Result<EventLoop<Ev>, winit::error::EventLoopError> {
     use winit::platform::macos::{ActivationPolicy, EventLoopBuilderExtMacOS};
     // Accessory keeps the overlay window but drops the Dock icon and
     // app-switcher entry, so a background HUD does not take a Dock slot.
@@ -231,6 +471,6 @@ fn build_event_loop() -> Result<EventLoop<Vec<BossBar>>, winit::error::EventLoop
 }
 
 #[cfg(not(target_os = "macos"))]
-fn build_event_loop() -> Result<EventLoop<Vec<BossBar>>, winit::error::EventLoopError> {
+fn build_event_loop() -> Result<EventLoop<Ev>, winit::error::EventLoopError> {
     EventLoop::with_user_event().build()
 }

--- a/packages/bossbar-overlay/app/src/render.rs
+++ b/packages/bossbar-overlay/app/src/render.rs
@@ -34,14 +34,17 @@ const SHADOW: GColor = GColor::rgb(0x3f, 0x3f, 0x3f);
 struct Vertex {
     pos: [f32; 2],
     uv: [f32; 2],
+    /// Per-quad opacity. The hovered or dragged bar paints at 1.0 while the
+    /// rest stay at [`DEFAULT_OPACITY`], so hovering reads as the bar going
+    /// solid rather than any motion.
+    alpha: f32,
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 struct Globals {
     size: [f32; 2],
-    opacity: f32,
-    _pad: f32,
+    _pad: [f32; 2],
 }
 
 /// Which preloaded sprite a layer samples.
@@ -62,6 +65,40 @@ struct Quad {
     h: f32,
     /// UV span; fill layers narrow `u1` so the sprite is cut off, not squished.
     u1: f32,
+    /// Opacity for this quad's bar; see [`Vertex::alpha`].
+    alpha: f32,
+}
+
+/// Physical-pixel geometry of one laid-out bar. Computed by
+/// [`Renderer::layout`] so the draw pass and pointer hit-testing agree on where
+/// every bar sits, including bars pinned to a dragged location.
+#[derive(Clone, Copy)]
+pub struct BarBox {
+    pub id: i64,
+    left: f32,
+    title_top: f32,
+    track_y: f32,
+    bar_w: f32,
+    bar_h: f32,
+    title_px: f32,
+    has_title: bool,
+}
+
+impl BarBox {
+    /// Top-left of the bar's title (its drag anchor), in physical pixels.
+    pub fn origin(&self) -> glam::Vec2 {
+        glam::vec2(self.left, self.title_top)
+    }
+
+    /// Whether a physical-pixel point falls on the bar. Covers the title plus
+    /// the track so the whole visible bar is grabbable.
+    pub fn contains(&self, p: glam::Vec2) -> bool {
+        let top = if self.has_title { self.title_top } else { self.track_y };
+        p.x >= self.left
+            && p.x <= self.left + self.bar_w
+            && p.y >= top
+            && p.y <= self.track_y + self.bar_h
+    }
 }
 
 pub struct Renderer {
@@ -87,6 +124,9 @@ pub struct Renderer {
 
     /// Integer pixel scale of the native 182x5 sprites.
     scale: u32,
+    /// Display backing-scale factor (e.g. 2.0 on Retina). Converts the logical
+    /// screen points stored for pinned bars into framebuffer pixels.
+    scale_factor: f32,
     opacity: f32,
 }
 
@@ -96,6 +136,7 @@ impl Renderer {
         queue: wgpu::Queue,
         format: wgpu::TextureFormat,
         scale: u32,
+        scale_factor: f32,
     ) -> Self {
         let scale = scale.max(1);
 
@@ -156,7 +197,7 @@ impl Renderer {
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
-                    attributes: &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x2],
+                    attributes: &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x2, 2 => Float32],
                 }],
             },
             fragment: Some(wgpu::FragmentState {
@@ -260,45 +301,113 @@ impl Renderer {
             text_renderer,
             viewport,
             scale,
+            scale_factor,
             opacity: DEFAULT_OPACITY,
         }
     }
 
-    /// Draw the given bars into `view`, a `width`x`height` target.
-    pub fn render(
-        &mut self,
-        view: &wgpu::TextureView,
-        width: u32,
-        height: u32,
-        bars: &[BossBar],
-    ) -> Result<(), wgpu::SurfaceError> {
+    /// Physical-pixel geometry of every bar, in draw order. Pinned bars
+    /// (`BossBar::pos`) sit at their stored logical point scaled to pixels;
+    /// the rest auto-stack down the top-center column. Shared by the draw pass
+    /// and pointer hit-testing so they never disagree.
+    pub fn layout(&self, bars: &[BossBar], width: f32) -> Vec<BarBox> {
         let s = self.scale as f32;
+        let sf = self.scale_factor;
         let bar_w = BAR_W as f32 * s;
         let bar_h = BAR_H as f32 * s;
         let title_px = 8.0 * s;
         let title_gap = 1.0 * s;
         let bar_gap = 4.0 * s;
         let top_pad = 16.0 * s;
-        let shadow_off = s;
-        let center_x = ((width as f32) - bar_w) * 0.5;
+        let center_x = (width - bar_w) * 0.5;
 
-        // Build the sprite quads and lay out the titles in one pass so the two
-        // stay in lockstep down the screen.
-        let mut quads: Vec<Quad> = Vec::new();
-        let mut buffers: Vec<(Buffer, f32, f32, bool)> = Vec::new(); // buffer, left, top, has_text
-
-        let mut y = top_pad;
+        let mut boxes = Vec::with_capacity(bars.len());
+        let mut auto_y = top_pad;
         for b in bars {
             let has_title = !b.title.is_empty();
             let title_h = if has_title { title_px } else { 0.0 };
-            let track_y = y + title_h + if has_title { title_gap } else { 0.0 };
+            let (left, group_top) = match b.pos {
+                Some(p) => (p.x as f32 * sf, p.y as f32 * sf),
+                None => (center_x, auto_y),
+            };
+            let track_y = group_top + title_h + if has_title { title_gap } else { 0.0 };
+            boxes.push(BarBox {
+                id: b.id,
+                left,
+                title_top: group_top,
+                track_y,
+                bar_w,
+                bar_h,
+                title_px,
+                has_title,
+            });
+            // Only the auto-stacked column advances; a pinned bar floats free.
+            if b.pos.is_none() {
+                auto_y = track_y + bar_h + bar_gap;
+            }
+        }
+        boxes
+    }
 
-            if has_title {
+    /// The topmost bar under a physical-pixel point, if any. Iterates back to
+    /// front so the last-drawn (visually top) bar wins an overlap.
+    pub fn hit(&self, bars: &[BossBar], width: f32, point: glam::Vec2) -> Option<i64> {
+        self.layout(bars, width)
+            .into_iter()
+            .rev()
+            .find(|bx| bx.contains(point))
+            .map(|bx| bx.id)
+    }
+
+    /// The drag anchor (title top-left, physical pixels) of one bar by id.
+    pub fn origin_of(&self, bars: &[BossBar], width: f32, id: i64) -> Option<glam::Vec2> {
+        self.layout(bars, width)
+            .into_iter()
+            .find(|bx| bx.id == id)
+            .map(|bx| bx.origin())
+    }
+
+    /// Draw the given bars into `view`, a `width`x`height` target. `highlight`
+    /// is the id of the hovered or dragged bar, drawn opaque for feedback.
+    pub fn render(
+        &mut self,
+        view: &wgpu::TextureView,
+        width: u32,
+        height: u32,
+        bars: &[BossBar],
+        highlight: Option<i64>,
+    ) -> Result<(), wgpu::SurfaceError> {
+        // A shaped title plus where and how opaque to draw it.
+        struct Title {
+            buffer: Buffer,
+            left: f32,
+            top: f32,
+            alpha: f32,
+        }
+
+        let shadow_off = self.scale as f32;
+        let boxes = self.layout(bars, width as f32);
+
+        // Build the sprite quads and lay out the titles in one pass, walking the
+        // shared layout so draw and hit-testing agree on every bar's box.
+        let mut quads: Vec<Quad> = Vec::new();
+        let mut titles: Vec<Title> = Vec::new();
+
+        for (b, bx) in bars.iter().zip(&boxes) {
+            // The hovered/dragged bar goes solid; every other bar stays at the
+            // HUD's default translucency.
+            let alpha = if Some(b.id) == highlight {
+                1.0
+            } else {
+                self.opacity
+            };
+
+            if bx.has_title {
                 let mut buffer =
-                    Buffer::new(&mut self.font_system, Metrics::new(title_px, title_px));
+                    Buffer::new(&mut self.font_system, Metrics::new(bx.title_px, bx.title_px));
                 // Center the title within the bar width via cosmic-text's own
                 // alignment, so the buffer's left edge sits at the bar's left.
-                buffer.set_size(&mut self.font_system, Some(bar_w), Some(title_px * 1.5));
+                buffer.set_size(&mut self.font_system, Some(bx.bar_w), Some(bx.title_px * 1.5));
                 buffer.set_text(
                     &mut self.font_system,
                     &b.title,
@@ -307,51 +416,58 @@ impl Renderer {
                     Some(glyphon::cosmic_text::Align::Center),
                 );
                 buffer.shape_until_scroll(&mut self.font_system, false);
-                buffers.push((buffer, center_x, y, true));
+                titles.push(Title {
+                    buffer,
+                    left: bx.left,
+                    top: bx.title_top,
+                    alpha,
+                });
             }
 
             // Color background, then color progress clipped to the fill.
             quads.push(Quad {
                 tex: TexId::ColorBg(b.color),
-                x: center_x,
-                y: track_y,
-                w: bar_w,
-                h: bar_h,
+                x: bx.left,
+                y: bx.track_y,
+                w: bx.bar_w,
+                h: bx.bar_h,
                 u1: 1.0,
+                alpha,
             });
             if b.progress > 0.0 {
                 quads.push(Quad {
                     tex: TexId::ColorFill(b.color),
-                    x: center_x,
-                    y: track_y,
-                    w: bar_w * b.progress,
-                    h: bar_h,
+                    x: bx.left,
+                    y: bx.track_y,
+                    w: bx.bar_w * b.progress,
+                    h: bx.bar_h,
                     u1: b.progress,
+                    alpha,
                 });
             }
             // Optional notch overlay on top, same draw order.
             if let Some(n) = b.overlay.notch() {
                 quads.push(Quad {
                     tex: TexId::NotchBg(n),
-                    x: center_x,
-                    y: track_y,
-                    w: bar_w,
-                    h: bar_h,
+                    x: bx.left,
+                    y: bx.track_y,
+                    w: bx.bar_w,
+                    h: bx.bar_h,
                     u1: 1.0,
+                    alpha,
                 });
                 if b.progress > 0.0 {
                     quads.push(Quad {
                         tex: TexId::NotchFill(n),
-                        x: center_x,
-                        y: track_y,
-                        w: bar_w * b.progress,
-                        h: bar_h,
+                        x: bx.left,
+                        y: bx.track_y,
+                        w: bx.bar_w * b.progress,
+                        h: bx.bar_h,
                         u1: b.progress,
+                        alpha,
                     });
                 }
             }
-
-            y = track_y + bar_h + bar_gap;
         }
 
         // Vertex data for every quad, two triangles each.
@@ -360,9 +476,11 @@ impl Renderer {
         for q in &quads {
             let base = verts.len() as u32;
             let (x0, y0, x1, y1) = (q.x, q.y, q.x + q.w, q.y + q.h);
+            let a = q.alpha;
             let v = |px, py, u, vv| Vertex {
                 pos: [px, py],
                 uv: [u, vv],
+                alpha: a,
             };
             verts.extend_from_slice(&[
                 v(x0, y0, 0.0, 0.0),
@@ -380,8 +498,7 @@ impl Renderer {
             0,
             bytemuck::bytes_of(&Globals {
                 size: [width as f32, height as f32],
-                opacity: self.opacity,
-                _pad: 0.0,
+                _pad: [0.0, 0.0],
             }),
         );
 
@@ -395,6 +512,7 @@ impl Renderer {
                     bytemuck::cast_slice(&[Vertex {
                         pos: [0.0, 0.0],
                         uv: [0.0, 0.0],
+                        alpha: 0.0,
                     }])
                 } else {
                     bytemuck::cast_slice(&verts)
@@ -402,11 +520,8 @@ impl Renderer {
                 usage: wgpu::BufferUsages::VERTEX,
             });
 
-        // Prepare text. The alpha tracks the bar opacity so titles fade with
-        // their bars, matching the old `opacity` on the whole `.bar` element.
-        let a = (self.opacity * 255.0) as u8;
-        let fg = GColor::rgba(0xff, 0xff, 0xff, a);
-        let shadow = GColor::rgba(SHADOW.r(), SHADOW.g(), SHADOW.b(), a);
+        // Prepare text. Each title's alpha tracks its own bar, so a hovered bar
+        // goes opaque (title included) while the rest stay translucent.
         let bounds = TextBounds {
             left: 0,
             top: 0,
@@ -414,24 +529,24 @@ impl Renderer {
             bottom: height as i32,
         };
         let mut areas: Vec<TextArea> = Vec::new();
-        for (buffer, left, top, has_text) in &buffers {
-            if !has_text {
-                continue;
-            }
+        for title in &titles {
+            let a = (title.alpha * 255.0) as u8;
+            let fg = GColor::rgba(0xff, 0xff, 0xff, a);
+            let shadow = GColor::rgba(SHADOW.r(), SHADOW.g(), SHADOW.b(), a);
             // Shadow first, then the white face one pixel up-left of it.
             areas.push(TextArea {
-                buffer,
-                left: *left + shadow_off,
-                top: *top + shadow_off,
+                buffer: &title.buffer,
+                left: title.left + shadow_off,
+                top: title.top + shadow_off,
                 scale: 1.0,
                 bounds,
                 default_color: shadow,
                 custom_glyphs: &[],
             });
             areas.push(TextArea {
-                buffer,
-                left: *left,
-                top: *top,
+                buffer: &title.buffer,
+                left: title.left,
+                top: title.top,
                 scale: 1.0,
                 bounds,
                 default_color: fg,

--- a/packages/bossbar-overlay/app/src/snapshot.rs
+++ b/packages/bossbar-overlay/app/src/snapshot.rs
@@ -45,8 +45,11 @@ pub fn run(
     });
     let view = target.create_view(&wgpu::TextureViewDescriptor::default());
 
-    let mut renderer = Renderer::new(device.clone(), queue.clone(), FORMAT, scale);
-    renderer.render(&view, width, height, bars).map_err(|e| format!("render: {e:?}"))?;
+    // Snapshots have no display scaling, so logical points map 1:1 to pixels.
+    let mut renderer = Renderer::new(device.clone(), queue.clone(), FORMAT, scale, 1.0);
+    renderer
+        .render(&view, width, height, bars, None)
+        .map_err(|e| format!("render: {e:?}"))?;
 
     // Copy the texture into a readback buffer with the 256-byte row alignment
     // wgpu requires, then strip the padding before writing the PNG.

--- a/packages/bossbar-overlay/app/src/sprite.wgsl
+++ b/packages/bossbar-overlay/app/src/sprite.wgsl
@@ -5,8 +5,7 @@
 
 struct Globals {
     size: vec2<f32>,
-    opacity: f32,
-    _pad: f32,
+    _pad: vec2<f32>,
 };
 
 @group(0) @binding(0) var<uniform> globals: Globals;
@@ -16,10 +15,11 @@ struct Globals {
 struct VsOut {
     @builtin(position) pos: vec4<f32>,
     @location(0) uv: vec2<f32>,
+    @location(1) alpha: f32,
 };
 
 @vertex
-fn vs(@location(0) px: vec2<f32>, @location(1) uv: vec2<f32>) -> VsOut {
+fn vs(@location(0) px: vec2<f32>, @location(1) uv: vec2<f32>, @location(2) alpha: f32) -> VsOut {
     var out: VsOut;
     let ndc = vec2<f32>(
         px.x / globals.size.x * 2.0 - 1.0,
@@ -27,6 +27,7 @@ fn vs(@location(0) px: vec2<f32>, @location(1) uv: vec2<f32>) -> VsOut {
     );
     out.pos = vec4<f32>(ndc, 0.0, 1.0);
     out.uv = uv;
+    out.alpha = alpha;
     return out;
 }
 
@@ -35,6 +36,7 @@ fn fs(in: VsOut) -> @location(0) vec4<f32> {
     let c = textureSample(tex, samp, in.uv);
     // Straight alpha out; the pipeline's ALPHA_BLENDING state composites it into
     // the premultiplied framebuffer, the same blend glyphon uses for text, so
-    // sprites and titles layer consistently over the transparent desktop.
-    return vec4<f32>(c.rgb, c.a * globals.opacity);
+    // sprites and titles layer consistently over the transparent desktop. The
+    // per-vertex alpha lets the hovered bar paint solid over the translucent rest.
+    return vec4<f32>(c.rgb, c.a * in.alpha);
 }


### PR DESCRIPTION
## What

The boss bar overlay is now interactive on macOS: **hover** a bar and it brightens to fully opaque (cursor becomes a grab hand), and you can **drag** it anywhere on screen. The drop location persists, so bars stay where you put them across restarts.

## How click-through is preserved

The overlay was fully click-through (`set_cursor_hittest(false)`), so it got no pointer events. A background thread polls the global cursor (CoreGraphics, no accessibility permission). When the pointer crosses a bar, the window flips on hit-testing and winit delivers hover/drag for that bar; off the bars it flips back to click-through. So only the bars themselves intercept the mouse — the desktop underneath stays fully usable everywhere else.

## Details

- **Hover highlight** is a still opacity change (0.85 → 1.0) via a new per-vertex `alpha`, matching the "no motion on hover" house style. Title included.
- **Drag** persists to two new nullable `x`/`y` columns (logical points). `NULL` keeps a bar in the auto-stacked top-center column; set them and it floats free. Existing DBs migrate with `ALTER TABLE ADD COLUMN`.
- The macOS window spans the screen so a bar can be dropped anywhere. **Other platforms** keep the click-through top strip and stay non-interactive (the cursor source is macOS-only).
- Positions and hit-testing use `glam` vectors and a shared `Renderer::layout`, so the draw pass and pointer math agree on every bar's box.

## Verification

- ✅ `cargo test` (5 pass), `cargo build --release`, `nix build .#bossbar-overlay`, `nix run .#lint` all green
- ✅ Live: hovering a bar renders it opaque vs translucent (confirmed via controlled cursor-warp screenshots); dragging repositions bars to arbitrary screen locations and persists `x,y`; click-through preserved while using other apps

---
🤖 Authored with Claude Code (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hover-highlight and drag-to-reposition bars in the macOS bossbar overlay
> - On macOS, the overlay window now spans the full screen and polls the global cursor position via CoreGraphics at ~60 Hz to detect hover without requiring a click.
> - Hovering a bar makes it fully opaque (all others remain translucent) and enables window interactivity; moving away restores click-through.
> - Bars can be dragged to any screen position; the logical x/y coordinates are persisted to the SQLite DB via new nullable `x`/`y` columns on the `bossbars` table.
> - Per-bar opacity is moved from a global uniform to per-vertex alpha in [sprite.wgsl](https://github.com/indexable-inc/index/pull/404/files#diff-6ec6a5499c83f342b7d38f5da5de1768031533e48de2c5195153473bb533733d), and a new `BarBox` geometry model in [render.rs](https://github.com/indexable-inc/index/pull/404/files#diff-3ea9a891a2426681e39b0f386a1bf93d77bfe34709fd71ad609608526da8791f) handles both pinned and auto-stacked layout with hit-testing.
> - Non-macOS builds retain prior behavior (top-strip, no cursor polling, no drag).
> - Risk: existing databases are migrated with `ALTER TABLE` to add `x`/`y` columns on first run; partial coordinates (only one non-NULL) fall back to auto-stacking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c1f0f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->