### PR TITLE
bossbar: one window per bar — native drag, grow-on-hover, no cursor poll

### DIFF
--- a/packages/bossbar-overlay/README.md
+++ b/packages/bossbar-overlay/README.md
@@ -30,16 +30,21 @@ bash scripts/fetch-assets.sh   # downloads into app/assets/, no-op once present
 cargo run                      # the overlay
 ```
 
-The window is transparent, always-on-top, and click-through, so the desktop
-underneath stays usable. There is no tray; quit it the way you quit any
-foreground process (Ctrl-C from the terminal, or stop the service that runs it).
-`BOSSBAR_SCALE=3` (or `--scale 3`) enlarges the bars.
+Each bar is its own small transparent, always-on-top, borderless window sized to
+just that bar. Because there is no window except over a bar, the desktop stays
+fully usable everywhere else: only the bars intercept the mouse. There is no
+tray; quit it the way you quit any foreground process (Ctrl-C from the terminal,
+or stop the service that runs it). `BOSSBAR_SCALE=3` (or `--scale 3`) enlarges
+the bars.
 
-On macOS the bars are interactive: hover one and it brightens to fully opaque
-(the cursor becomes a grab hand), and you can drag it anywhere on the screen.
-The drop location is saved to the bar's `x`/`y` columns, so it stays put across
-restarts. Only the bars intercept the mouse; everywhere else the window stays
-click-through. Other platforms render the same overlay without the drag path.
+The bars are interactive: hover one and it goes fully opaque (the cursor becomes
+a grab hand), and you can drag it anywhere on screen. Dragging uses the
+platform's native window drag, and the drop location is saved to the bar's
+`x`/`y` columns, so it stays put across restarts. Bars without a saved position
+auto-stack in a top-center column. This works the same on macOS and Linux.
+
+Known limitation: some Linux tiling window managers force-place or tile
+borderless windows, which can fight the free-drag placement.
 
 To verify rendering without a window, render the current bars straight to a
 transparent PNG:

--- a/packages/bossbar-overlay/app/Cargo.lock
+++ b/packages/bossbar-overlay/app/Cargo.lock
@@ -163,7 +163,6 @@ name = "bossbar-overlay"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
- "core-graphics 0.24.0",
  "dirs",
  "glam",
  "glyphon",
@@ -327,19 +326,6 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
- "foreign-types",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.10.1",
- "core-graphics-types 0.2.0",
  "foreign-types",
  "libc",
 ]
@@ -2818,7 +2804,7 @@ dependencies = [
  "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
- "core-graphics 0.23.2",
+ "core-graphics",
  "cursor-icon",
  "dpi",
  "js-sys",

--- a/packages/bossbar-overlay/app/Cargo.toml
+++ b/packages/bossbar-overlay/app/Cargo.toml
@@ -25,14 +25,8 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 # Bundled SQLite so users don't need a system libsqlite3.
 rusqlite = { version = "0.32", features = ["bundled"] }
 dirs = "6"
-# 2D vectors for bar positions and hit-testing, instead of bare (f64, f64).
+# 2D vectors for bar positions, instead of bare (f64, f64).
 glam = "0.30"
-
-# Reading the global cursor location to wake the click-through overlay only when
-# the pointer is over a bar is macOS-specific (CoreGraphics). Other platforms
-# keep the non-interactive click-through overlay.
-[target.'cfg(target_os = "macos")'.dependencies]
-core-graphics = "0.24"
 
 [profile.release]
 # A desktop HUD: trim the binary, no need for fat debug info.

--- a/packages/bossbar-overlay/app/src/overlay.rs
+++ b/packages/bossbar-overlay/app/src/overlay.rs
@@ -1,55 +1,61 @@
-//! The live overlay: a transparent, always-on-top window over the screen.
-//! winit owns the window and event loop; the SQLite watcher runs on its own
-//! thread and wakes the loop with a fresh `Vec<BossBar>` whenever the database
-//! changes.
+//! The live overlay: one transparent, always-on-top, borderless window **per
+//! bar**, each sized to just that bar. winit owns the windows and event loop;
+//! the SQLite watcher runs on its own thread and wakes the loop with a fresh
+//! `Vec<BossBar>` whenever the database changes.
 //!
-//! The window is click-through by default so the desktop underneath stays
-//! usable. On macOS a background thread polls the global cursor (CoreGraphics),
-//! and the moment it crosses a bar the window flips to capture the pointer:
-//! that bar highlights, and a drag repositions it (persisted to the DB). Off
-//! the bars the window returns to click-through, so only the bars themselves
-//! intercept the mouse. Other platforms keep the static click-through overlay.
+//! Because each window covers only its bar, the desktop is click-through
+//! everywhere else automatically: there is simply no window to intercept the
+//! mouse off a bar. Hovering a bar fires native `CursorEntered`/`CursorLeft`
+//! (the bar paints opaque, the cursor becomes a grab hand); pressing it calls
+//! the native `Window::drag_window`, so the OS owns the drag and the new
+//! position is read back from `Moved` and persisted. No cursor polling, no
+//! `set_cursor_hittest`, no coordinate reconciliation.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use glam::{DVec2, Vec2, vec2};
+use glam::DVec2;
 use winit::application::ApplicationHandler;
-use winit::dpi::{PhysicalPosition, PhysicalSize};
+use winit::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use winit::event::{ElementState, MouseButton, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy};
-use winit::window::{CursorIcon, Window, WindowLevel};
+use winit::window::{CursorIcon, Window, WindowId, WindowLevel};
 
 use crate::bars::BossBar;
 use crate::db;
-use crate::render::Renderer;
+use crate::render::{self, Renderer};
 
-/// Fraction of the monitor height the overlay covers on platforms without the
-/// interactive (drag-anywhere) path; the window is click-through and this just
-/// bounds where bars can paint.
-#[cfg(not(target_os = "macos"))]
-const HEIGHT_FRACTION: f64 = 0.45;
+/// Top margin and vertical gap (logical points) for bars that have no pinned
+/// position and fall back to the auto-stacked top-center column. `AUTO_TOP`
+/// clears the macOS menu bar so the system does not nudge the window down (a
+/// nudge would otherwise read as a move).
+const AUTO_TOP: f64 = 40.0;
+const AUTO_GAP: f64 = 6.0;
 
-/// Loop wake-ups: a fresh set of bars from the DB watcher, or the latest global
-/// cursor position from the macOS poll thread (physical pixels).
-enum Ev {
-    Bars(Vec<BossBar>),
-    Cursor(Vec2),
-}
-
-/// An in-progress drag: which bar, and the pointer's offset from the bar's
-/// origin at grab time, so the bar tracks the cursor without jumping.
-#[derive(Clone, Copy)]
-struct Drag {
-    id: i64,
-    grab: Vec2,
-}
-
-struct Gpu {
-    surface: wgpu::Surface<'static>,
+/// GPU state shared by every bar window: one device/queue and one renderer
+/// (pipeline, sprite textures, font). Each window only owns its surface.
+struct GpuCore {
     device: wgpu::Device,
-    config: wgpu::SurfaceConfiguration,
+    format: wgpu::TextureFormat,
+    alpha_mode: wgpu::CompositeAlphaMode,
     renderer: Renderer,
+}
+
+/// One bar's window and its surface.
+struct BarWin {
+    window: Arc<Window>,
+    surface: wgpu::Surface<'static>,
+    config: wgpu::SurfaceConfiguration,
+    bar: BossBar,
+    hovered: bool,
+    /// True between a left-press and its release: only then does a `Moved`
+    /// count as a user drag worth persisting. Window placement nudges by the OS
+    /// (e.g. clamping below the menu bar) arrive with this false and are ignored.
+    dragging: bool,
+    /// Last position we know the window holds (logical points): what we set, or
+    /// where the OS placed it. Lets `Moved` skip echoes of our own placement.
+    self_set: Option<LogicalPosition<f64>>,
 }
 
 pub struct App {
@@ -57,78 +63,198 @@ pub struct App {
     /// Logical pixel scale; multiplied by the monitor scale factor so the bars
     /// look the same physical size on HiDPI and standard displays.
     base_scale: u32,
-    proxy: EventLoopProxy<Ev>,
-    window: Option<Arc<Window>>,
-    gpu: Option<Gpu>,
-    bars: Vec<BossBar>,
+    proxy: EventLoopProxy<Vec<BossBar>>,
+    instance: wgpu::Instance,
+    core: Option<GpuCore>,
+    wins: HashMap<i64, BarWin>,
 
-    /// Display backing-scale factor, captured on resume (e.g. 2.0 on Retina).
+    /// Monitor logical size, for centering auto-stacked bars.
+    mon_logical: (f64, f64),
     scale_factor: f64,
-    /// Whether the window currently captures the pointer (`set_cursor_hittest`).
-    /// Default is click-through; it flips on only while the cursor is on a bar.
-    interactive: bool,
-    /// Bar under the pointer, drawn opaque for feedback.
-    hovered: Option<i64>,
-    /// Active drag, if the pointer is held down on a bar.
-    dragging: Option<Drag>,
-    /// Last known pointer position, in physical pixels.
-    cursor: Vec2,
+    /// Physical sprite scale, `round(base_scale * scale_factor)`.
+    scale: u32,
+    ready: bool,
 }
 
 impl App {
-    fn renderer(&self) -> Option<&Renderer> {
-        self.gpu.as_ref().map(|g| &g.renderer)
-    }
+    /// Build a surface for `window`, creating the shared GPU core on first use.
+    fn make_surface(
+        &mut self,
+        window: &Arc<Window>,
+    ) -> (wgpu::Surface<'static>, wgpu::SurfaceConfiguration) {
+        let surface = self
+            .instance
+            .create_surface(window.clone())
+            .expect("create surface");
 
-    fn width(&self) -> f32 {
-        self.gpu.as_ref().map(|g| g.config.width as f32).unwrap_or(0.0)
-    }
+        if self.core.is_none() {
+            let adapter = pollster::block_on(self.instance.request_adapter(
+                &wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::default(),
+                    compatible_surface: Some(&surface),
+                    force_fallback_adapter: false,
+                },
+            ))
+            .expect("request wgpu adapter");
+            let (device, queue) = pollster::block_on(adapter.request_device(
+                &wgpu::DeviceDescriptor {
+                    label: Some("bossbar.device"),
+                    ..Default::default()
+                },
+            ))
+            .expect("request device");
 
-    fn bar_index(&self, id: i64) -> Option<usize> {
-        self.bars.iter().position(|b| b.id == id)
-    }
+            let caps = surface.get_capabilities(&adapter);
+            let format = caps
+                .formats
+                .iter()
+                .copied()
+                .find(|f| f.is_srgb())
+                .unwrap_or(caps.formats[0]);
+            // Must composite over the desktop, so never `Opaque` (which paints a
+            // black box). Metal only offers `[Opaque, PostMultiplied]`.
+            let alpha_mode = [
+                wgpu::CompositeAlphaMode::PostMultiplied,
+                wgpu::CompositeAlphaMode::PreMultiplied,
+                wgpu::CompositeAlphaMode::Inherit,
+            ]
+            .into_iter()
+            .find(|m| caps.alpha_modes.contains(m))
+            .unwrap_or(caps.alpha_modes[0]);
+            if alpha_mode == wgpu::CompositeAlphaMode::Opaque {
+                eprintln!(
+                    "bossbar-overlay: no transparent surface alpha mode available \
+                     ({:?}); bars will have an opaque background",
+                    caps.alpha_modes
+                );
+            }
 
-    /// The bar under a physical-pixel point, via the renderer's shared layout.
-    fn hit_test(&self, point: Vec2) -> Option<i64> {
-        self.renderer()?.hit(&self.bars, self.width(), point)
-    }
-
-    /// Toggle pointer capture. Off (the default) lets clicks fall through to the
-    /// desktop; on lets the window receive hover, click, and drag on a bar.
-    fn set_interactive(&mut self, on: bool) {
-        if self.interactive == on {
-            return;
+            let renderer = Renderer::new(device.clone(), queue, format, self.scale.max(1));
+            self.core = Some(GpuCore {
+                device,
+                format,
+                alpha_mode,
+                renderer,
+            });
         }
-        if let Some(w) = &self.window {
-            // Wayland does not support this; the error is ignored there, leaving
-            // the overlay non-interactive rather than crashing.
-            let _ = w.set_cursor_hittest(on);
-        }
-        self.interactive = on;
+
+        let core = self.core.as_ref().expect("core just initialized");
+        let size = window.inner_size();
+        let config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format: core.format,
+            width: size.width.max(1),
+            height: size.height.max(1),
+            present_mode: wgpu::PresentMode::Fifo,
+            alpha_mode: core.alpha_mode,
+            view_formats: vec![],
+            desired_maximum_frame_latency: 2,
+        };
+        surface.configure(&core.device, &config);
+        (surface, config)
     }
 
-    fn set_icon(&self, icon: CursorIcon) {
-        if let Some(w) = &self.window {
-            w.set_cursor(icon);
+    /// Auto-stacked default position (logical points) for the `slot`-th bar that
+    /// has no pinned location.
+    fn auto_pos(&self, slot: usize, w_px: u32, h_px: u32) -> LogicalPosition<f64> {
+        let wl = w_px as f64 / self.scale_factor;
+        let hl = h_px as f64 / self.scale_factor;
+        let x = ((self.mon_logical.0 - wl) / 2.0).max(0.0);
+        let y = AUTO_TOP + slot as f64 * (hl + AUTO_GAP);
+        LogicalPosition::new(x, y)
+    }
+
+    fn create_win(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        bar: BossBar,
+        slot: usize,
+    ) -> Option<BarWin> {
+        let has_title = !bar.title.is_empty();
+        let (w_px, h_px) = render::bar_window_px(self.scale, has_title);
+        let pos = match bar.pos {
+            Some(p) => LogicalPosition::new(p.x, p.y),
+            None => self.auto_pos(slot, w_px, h_px),
+        };
+        let attrs = Window::default_attributes()
+            .with_title("Boss Bar")
+            .with_transparent(true)
+            .with_decorations(false)
+            .with_resizable(false)
+            .with_window_level(WindowLevel::AlwaysOnTop)
+            .with_inner_size(PhysicalSize::new(w_px, h_px))
+            .with_position(pos);
+        let window = Arc::new(event_loop.create_window(attrs).ok()?);
+        let (surface, config) = self.make_surface(&window);
+        window.request_redraw();
+        Some(BarWin {
+            window,
+            surface,
+            config,
+            bar,
+            hovered: false,
+            dragging: false,
+            self_set: Some(pos),
+        })
+    }
+
+    /// Diff the DB's visible bars against the live windows: drop windows for
+    /// gone bars, create them for new bars, update data and (externally changed)
+    /// position for existing ones.
+    fn reconcile(&mut self, event_loop: &ActiveEventLoop, bars: Vec<BossBar>) {
+        self.wins.retain(|id, _| bars.iter().any(|b| b.id == *id));
+
+        let mut slot = 0usize;
+        for b in &bars {
+            let this_slot = if b.pos.is_none() {
+                let s = slot;
+                slot += 1;
+                s
+            } else {
+                0
+            };
+
+            if let Some(win) = self.wins.get_mut(&b.id) {
+                let title_presence_changed = win.bar.title.is_empty() != b.title.is_empty();
+                win.bar = b.clone();
+                // Honor a position set in the DB by something other than our own
+                // drag (e.g. the CLI), but ignore the echo of our last move.
+                if let Some(p) = b.pos {
+                    let lp = LogicalPosition::new(p.x, p.y);
+                    if win.self_set != Some(lp) {
+                        win.window.set_outer_position(lp);
+                        win.self_set = Some(lp);
+                    }
+                }
+                if title_presence_changed {
+                    let (w_px, h_px) = render::bar_window_px(self.scale, !b.title.is_empty());
+                    let _ = win.window.request_inner_size(PhysicalSize::new(w_px, h_px));
+                }
+                win.window.request_redraw();
+            } else if let Some(win) = self.create_win(event_loop, b.clone(), this_slot) {
+                self.wins.insert(b.id, win);
+            }
         }
     }
 
-    fn request_redraw(&self) {
-        if let Some(w) = &self.window {
-            w.request_redraw();
-        }
+    fn bar_id_for(&self, wid: WindowId) -> Option<i64> {
+        self.wins
+            .iter()
+            .find(|(_, w)| w.window.id() == wid)
+            .map(|(id, _)| *id)
     }
 
-    fn render(&mut self) {
-        // The hovered (or actively dragged) bar paints opaque.
-        let highlight = self.dragging.map(|d| d.id).or(self.hovered);
-        let Some(gpu) = self.gpu.as_mut() else {
+    fn render_id(&mut self, id: i64) {
+        let Some(core) = self.core.as_mut() else {
             return;
         };
-        let frame = match gpu.surface.get_current_texture() {
+        let Some(win) = self.wins.get_mut(&id) else {
+            return;
+        };
+        let frame = match win.surface.get_current_texture() {
             Ok(f) => f,
             Err(wgpu::SurfaceError::Outdated | wgpu::SurfaceError::Lost) => {
-                gpu.surface.configure(&gpu.device, &gpu.config);
+                win.surface.configure(&core.device, &win.config);
                 return;
             }
             Err(e) => {
@@ -139,19 +265,43 @@ impl App {
         let view = frame
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());
-        let _ = gpu
-            .renderer
-            .render(&view, gpu.config.width, gpu.config.height, &self.bars, highlight);
+        let _ =
+            core.renderer
+                .render_one(&view, win.config.width, win.config.height, &win.bar, win.hovered);
         frame.present();
+    }
+
+    /// A window moved. Persist it only when the move came from a user drag;
+    /// otherwise (initial placement, OS menu-bar clamp) just record where the
+    /// window actually sits so a later drag is measured from the right spot.
+    fn on_moved(&mut self, id: i64, pos: PhysicalPosition<i32>) {
+        let Some(win) = self.wins.get_mut(&id) else {
+            return;
+        };
+        let logical: LogicalPosition<f64> = pos.to_logical(win.window.scale_factor());
+        let echo = win
+            .self_set
+            .is_some_and(|ss| (ss.x - logical.x).abs() < 0.5 && (ss.y - logical.y).abs() < 0.5);
+        if echo {
+            return;
+        }
+        win.self_set = Some(logical);
+        if !win.dragging {
+            return; // OS-initiated placement, not a user drag
+        }
+        let dv = DVec2::new(logical.x, logical.y);
+        win.bar.pos = Some(dv);
+        if let Err(e) = db::set_position(&self.db, id, dv) {
+            eprintln!("bossbar-overlay: save position failed: {e}");
+        }
     }
 }
 
-impl ApplicationHandler<Ev> for App {
+impl ApplicationHandler<Vec<BossBar>> for App {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
-        if self.window.is_some() {
+        if self.ready {
             return;
         }
-
         let monitor = event_loop
             .primary_monitor()
             .or_else(|| event_loop.available_monitors().next());
@@ -160,252 +310,93 @@ impl ApplicationHandler<Ev> for App {
             None => (1920, 1080, 1.0),
         };
         self.scale_factor = scale_factor;
+        self.scale = ((self.base_scale as f64) * scale_factor).round().max(1.0) as u32;
+        self.mon_logical = (mon_w as f64 / scale_factor, mon_h as f64 / scale_factor);
+        self.ready = true;
 
-        // macOS drives the interactive path, so the window spans the whole
-        // screen and a bar can be dragged anywhere. Elsewhere it stays the
-        // click-through top strip.
-        #[cfg(target_os = "macos")]
-        let window_size = PhysicalSize::new(mon_w.max(1), mon_h.max(1));
-        #[cfg(not(target_os = "macos"))]
-        let window_size = PhysicalSize::new(
-            mon_w.max(1),
-            (((mon_h as f64) * HEIGHT_FRACTION) as u32).max(1),
-        );
-
-        let attrs = Window::default_attributes()
-            .with_title("Boss Bar Overlay")
-            .with_transparent(true)
-            .with_decorations(false)
-            .with_resizable(false)
-            .with_window_level(WindowLevel::AlwaysOnTop)
-            .with_inner_size(window_size)
-            .with_position(PhysicalPosition::new(0, 0));
-        let window = Arc::new(
-            event_loop
-                .create_window(attrs)
-                .expect("create overlay window"),
-        );
-        // Start click-through: every click falls to whatever is underneath until
-        // the cursor crosses a bar. Not all backends support this (notably
-        // Wayland); ignore the error there.
-        let _ = window.set_cursor_hittest(false);
-
-        let instance = wgpu::Instance::default();
-        let surface = instance
-            .create_surface(window.clone())
-            .expect("create surface");
-        let adapter =
-            pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-                power_preference: wgpu::PowerPreference::default(),
-                compatible_surface: Some(&surface),
-                force_fallback_adapter: false,
-            }))
-            .expect("request wgpu adapter");
-        let (device, queue) =
-            pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-                label: Some("bossbar.device"),
-                ..Default::default()
-            }))
-            .expect("request device");
-
-        let caps = surface.get_capabilities(&adapter);
-        let format = caps
-            .formats
-            .iter()
-            .copied()
-            .find(|f| f.is_srgb())
-            .unwrap_or(caps.formats[0]);
-        // The framebuffer must composite over the desktop, so we must NOT pick
-        // `Opaque` (which makes the surface layer opaque and paints a black box
-        // behind the bars). Metal only offers `[Opaque, PostMultiplied]`, so
-        // prefer any non-opaque mode in preference order.
-        let alpha_mode = [
-            wgpu::CompositeAlphaMode::PostMultiplied,
-            wgpu::CompositeAlphaMode::PreMultiplied,
-            wgpu::CompositeAlphaMode::Inherit,
-        ]
-        .into_iter()
-        .find(|m| caps.alpha_modes.contains(m))
-        .unwrap_or(caps.alpha_modes[0]);
-        if alpha_mode == wgpu::CompositeAlphaMode::Opaque {
-            eprintln!(
-                "bossbar-overlay: no transparent surface alpha mode available \
-                 ({:?}); the overlay background will be opaque",
-                caps.alpha_modes
-            );
-        }
-        let size = window.inner_size();
-        let config = wgpu::SurfaceConfiguration {
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            format,
-            width: size.width.max(1),
-            height: size.height.max(1),
-            present_mode: wgpu::PresentMode::Fifo,
-            alpha_mode,
-            view_formats: vec![],
-            desired_maximum_frame_latency: 2,
-        };
-        surface.configure(&device, &config);
-
-        let scale = ((self.base_scale as f64) * scale_factor).round() as u32;
-        let renderer =
-            Renderer::new(device.clone(), queue, format, scale.max(1), scale_factor as f32);
-
-        self.bars = db::read_once(&self.db).unwrap_or_default();
-        self.gpu = Some(Gpu {
-            surface,
-            device,
-            config,
-            renderer,
-        });
-        self.window = Some(window.clone());
+        let bars = db::read_once(&self.db).unwrap_or_default();
+        self.reconcile(event_loop, bars);
 
         // Wake the loop with fresh bars on every DB change; a send error means
         // the loop is gone, which stops the watcher thread.
         let proxy = self.proxy.clone();
-        db::spawn_watcher(self.db.clone(), move |bars| {
-            proxy.send_event(Ev::Bars(bars)).is_ok()
-        });
-
-        // Track the global cursor so the click-through window can wake up the
-        // instant the pointer reaches a bar (macOS only).
-        spawn_cursor_poll(self.proxy.clone(), scale_factor);
-
-        window.request_redraw();
+        db::spawn_watcher(self.db.clone(), move |bars| proxy.send_event(bars).is_ok());
     }
 
-    fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: Ev) {
-        match event {
-            Ev::Bars(bars) => {
-                self.bars = bars;
-                self.request_redraw();
-            }
-            Ev::Cursor(p) => {
-                self.cursor = p;
-                // While the window already captures the pointer, winit's own
-                // CursorMoved drives hover and drag; the poll only matters for
-                // waking the click-through window when a bar is first entered.
-                if self.interactive || self.dragging.is_some() {
-                    return;
-                }
-                if let Some(id) = self.hit_test(p) {
-                    self.hovered = Some(id);
-                    self.set_interactive(true);
-                    self.set_icon(CursorIcon::Grab);
-                    self.request_redraw();
-                }
-            }
-        }
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, bars: Vec<BossBar>) {
+        self.reconcile(event_loop, bars);
     }
 
-    fn window_event(
-        &mut self,
-        event_loop: &ActiveEventLoop,
-        _id: winit::window::WindowId,
-        event: WindowEvent,
-    ) {
+    fn window_event(&mut self, event_loop: &ActiveEventLoop, wid: WindowId, event: WindowEvent) {
+        let Some(id) = self.bar_id_for(wid) else {
+            return;
+        };
         match event {
-            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::CloseRequested => {
+                self.wins.remove(&id);
+                if self.wins.is_empty() {
+                    event_loop.exit();
+                }
+            }
             WindowEvent::Resized(size) => {
-                if let Some(gpu) = self.gpu.as_mut() {
-                    gpu.config.width = size.width.max(1);
-                    gpu.config.height = size.height.max(1);
-                    gpu.surface.configure(&gpu.device, &gpu.config);
-                }
-                self.request_redraw();
-            }
-            WindowEvent::RedrawRequested => self.render(),
-            WindowEvent::CursorMoved { position, .. } => {
-                let p = vec2(position.x as f32, position.y as f32);
-                self.cursor = p;
-                if let Some(d) = self.dragging {
-                    // Move the dragged bar to follow the cursor, storing its new
-                    // anchor in logical points so it survives scale changes.
-                    let origin = p - d.grab;
-                    let sf = self.scale_factor as f32;
-                    if let Some(i) = self.bar_index(d.id) {
-                        self.bars[i].pos =
-                            Some(DVec2::new((origin.x / sf) as f64, (origin.y / sf) as f64));
-                        self.request_redraw();
+                if let Some(win) = self.wins.get_mut(&id) {
+                    win.config.width = size.width.max(1);
+                    win.config.height = size.height.max(1);
+                    if let Some(core) = self.core.as_ref() {
+                        win.surface.configure(&core.device, &win.config);
                     }
-                } else {
-                    match self.hit_test(p) {
-                        Some(id) => {
-                            if self.hovered != Some(id) {
-                                self.hovered = Some(id);
-                                self.request_redraw();
-                            }
-                            self.set_icon(CursorIcon::Grab);
-                        }
-                        None => {
-                            // Left every bar: hand the pointer back to the desktop.
-                            self.hovered = None;
-                            self.set_interactive(false);
-                            self.set_icon(CursorIcon::Default);
-                            self.request_redraw();
-                        }
+                }
+                self.render_id(id);
+            }
+            WindowEvent::RedrawRequested => self.render_id(id),
+            WindowEvent::CursorEntered { .. } => {
+                if let Some(win) = self.wins.get_mut(&id) {
+                    win.hovered = true;
+                    win.window.set_cursor(CursorIcon::Grab);
+                }
+                self.render_id(id);
+            }
+            WindowEvent::CursorLeft { .. } => {
+                if let Some(win) = self.wins.get_mut(&id) {
+                    win.hovered = false;
+                    win.window.set_cursor(CursorIcon::Default);
+                }
+                self.render_id(id);
+            }
+            WindowEvent::MouseInput {
+                state: ElementState::Pressed,
+                button: MouseButton::Left,
+                ..
+            } => {
+                if let Some(win) = self.wins.get_mut(&id) {
+                    win.dragging = true;
+                    win.window.set_cursor(CursorIcon::Grabbing);
+                    if let Err(e) = win.window.drag_window() {
+                        eprintln!("bossbar-overlay: drag failed: {e}");
                     }
                 }
             }
             WindowEvent::MouseInput {
-                state,
+                state: ElementState::Released,
                 button: MouseButton::Left,
                 ..
-            } => match state {
-                ElementState::Pressed => {
-                    if let Some(id) = self.hovered {
-                        let origin = self
-                            .renderer()
-                            .and_then(|r| r.origin_of(&self.bars, self.width(), id));
-                        if let Some(origin) = origin {
-                            self.dragging = Some(Drag {
-                                id,
-                                grab: self.cursor - origin,
-                            });
-                            self.set_icon(CursorIcon::Grabbing);
-                        }
-                    }
-                }
-                ElementState::Released => {
-                    if let Some(d) = self.dragging.take() {
-                        if let Some(i) = self.bar_index(d.id) {
-                            if let Some(pos) = self.bars[i].pos {
-                                if let Err(e) = db::set_position(&self.db, d.id, pos) {
-                                    eprintln!("bossbar-overlay: save position failed: {e}");
-                                }
-                            }
-                        }
-                        // Re-resolve hover at the drop point: stay live if still
-                        // on a bar, otherwise return to click-through.
-                        match self.hit_test(self.cursor) {
-                            Some(id) => {
-                                self.hovered = Some(id);
-                                self.set_icon(CursorIcon::Grab);
-                            }
-                            None => {
-                                self.hovered = None;
-                                self.set_interactive(false);
-                                self.set_icon(CursorIcon::Default);
-                            }
-                        }
-                        self.request_redraw();
-                    }
-                }
-            },
-            WindowEvent::CursorLeft { .. } => {
-                if self.dragging.is_none() {
-                    self.hovered = None;
-                    self.set_interactive(false);
-                    self.set_icon(CursorIcon::Default);
-                    self.request_redraw();
+            } => {
+                if let Some(win) = self.wins.get_mut(&id) {
+                    win.dragging = false;
+                    win.window.set_cursor(if win.hovered {
+                        CursorIcon::Grab
+                    } else {
+                        CursorIcon::Default
+                    });
                 }
             }
+            WindowEvent::Moved(pos) => self.on_moved(id, pos),
             _ => {}
         }
     }
 }
 
-/// Run the overlay event loop. Blocks until the window closes.
+/// Run the overlay event loop. Blocks until the last window closes.
 pub fn run(db: PathBuf, base_scale: u32) -> Result<(), Box<dyn std::error::Error>> {
     let event_loop = build_event_loop()?;
     let proxy = event_loop.create_proxy();
@@ -413,57 +404,22 @@ pub fn run(db: PathBuf, base_scale: u32) -> Result<(), Box<dyn std::error::Error
         db,
         base_scale: base_scale.max(1),
         proxy,
-        window: None,
-        gpu: None,
-        bars: Vec::new(),
+        instance: wgpu::Instance::default(),
+        core: None,
+        wins: HashMap::new(),
+        mon_logical: (1920.0, 1080.0),
         scale_factor: 1.0,
-        interactive: false,
-        hovered: None,
-        dragging: None,
-        cursor: Vec2::ZERO,
+        scale: base_scale.max(1),
+        ready: false,
     };
     event_loop.run_app(&mut app)?;
     Ok(())
 }
 
-/// Poll the global cursor location and forward it to the event loop so the
-/// click-through window can detect when the pointer reaches a bar. macOS only;
-/// reads the HID pointer position with no accessibility permission.
 #[cfg(target_os = "macos")]
-fn spawn_cursor_poll(proxy: EventLoopProxy<Ev>, scale_factor: f64) {
-    use core_graphics::event::CGEvent;
-    use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
-    use std::time::Duration;
-
-    std::thread::spawn(move || {
-        let Ok(source) = CGEventSource::new(CGEventSourceStateID::HIDSystemState) else {
-            eprintln!("bossbar-overlay: cursor source unavailable; overlay stays click-through");
-            return;
-        };
-        loop {
-            // CGEvent locations are top-left logical points; scale to the
-            // framebuffer's physical pixels to match the window/render space.
-            if let Ok(ev) = CGEvent::new(source.clone()) {
-                let p = ev.location();
-                let phys = vec2((p.x * scale_factor) as f32, (p.y * scale_factor) as f32);
-                if proxy.send_event(Ev::Cursor(phys)).is_err() {
-                    return;
-                }
-            }
-            std::thread::sleep(Duration::from_millis(16));
-        }
-    });
-}
-
-/// Non-macOS: no global cursor source wired up, so the overlay stays
-/// click-through and non-interactive.
-#[cfg(not(target_os = "macos"))]
-fn spawn_cursor_poll(_proxy: EventLoopProxy<Ev>, _scale_factor: f64) {}
-
-#[cfg(target_os = "macos")]
-fn build_event_loop() -> Result<EventLoop<Ev>, winit::error::EventLoopError> {
+fn build_event_loop() -> Result<EventLoop<Vec<BossBar>>, winit::error::EventLoopError> {
     use winit::platform::macos::{ActivationPolicy, EventLoopBuilderExtMacOS};
-    // Accessory keeps the overlay window but drops the Dock icon and
+    // Accessory keeps the overlay windows but drops the Dock icon and
     // app-switcher entry, so a background HUD does not take a Dock slot.
     EventLoop::with_user_event()
         .with_activation_policy(ActivationPolicy::Accessory)
@@ -471,6 +427,6 @@ fn build_event_loop() -> Result<EventLoop<Ev>, winit::error::EventLoopError> {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn build_event_loop() -> Result<EventLoop<Ev>, winit::error::EventLoopError> {
+fn build_event_loop() -> Result<EventLoop<Vec<BossBar>>, winit::error::EventLoopError> {
     EventLoop::with_user_event().build()
 }

--- a/packages/bossbar-overlay/app/src/render.rs
+++ b/packages/bossbar-overlay/app/src/render.rs
@@ -26,6 +26,11 @@ const BAR_H: u32 = 5;
 /// overlay by letting the desktop bleed through a little.
 const DEFAULT_OPACITY: f32 = 0.85;
 
+/// How much a hovered bar grows. A small, deliberate scale-up (on top of going
+/// opaque) so the hover is unmistakable. Each bar window reserves this headroom
+/// so the bar grows in place without the window resizing or shifting.
+const HOVER_SCALE: f32 = 1.08;
+
 /// Vanilla title shadow: one dark pixel offset, scaled, no blur.
 const SHADOW: GColor = GColor::rgb(0x3f, 0x3f, 0x3f);
 
@@ -69,12 +74,11 @@ struct Quad {
     alpha: f32,
 }
 
-/// Physical-pixel geometry of one laid-out bar. Computed by
-/// [`Renderer::layout`] so the draw pass and pointer hit-testing agree on where
-/// every bar sits, including bars pinned to a dragged location.
+/// Physical-pixel geometry of one laid-out bar, in the target's local space.
+/// Produced by [`Renderer::layout`] (multi-bar, for the `--snapshot` PNG) and by
+/// [`Renderer::render_one`] (a single bar filling its own window).
 #[derive(Clone, Copy)]
-pub struct BarBox {
-    pub id: i64,
+struct BarBox {
     left: f32,
     title_top: f32,
     track_y: f32,
@@ -84,21 +88,11 @@ pub struct BarBox {
     has_title: bool,
 }
 
-impl BarBox {
-    /// Top-left of the bar's title (its drag anchor), in physical pixels.
-    pub fn origin(&self) -> glam::Vec2 {
-        glam::vec2(self.left, self.title_top)
-    }
-
-    /// Whether a physical-pixel point falls on the bar. Covers the title plus
-    /// the track so the whole visible bar is grabbable.
-    pub fn contains(&self, p: glam::Vec2) -> bool {
-        let top = if self.has_title { self.title_top } else { self.track_y };
-        p.x >= self.left
-            && p.x <= self.left + self.bar_w
-            && p.y >= top
-            && p.y <= self.track_y + self.bar_h
-    }
+/// One bar to paint: which bar, its box in target-local pixels, and its opacity.
+struct DrawItem<'a> {
+    bar: &'a BossBar,
+    geom: BarBox,
+    alpha: f32,
 }
 
 pub struct Renderer {
@@ -124,9 +118,6 @@ pub struct Renderer {
 
     /// Integer pixel scale of the native 182x5 sprites.
     scale: u32,
-    /// Display backing-scale factor (e.g. 2.0 on Retina). Converts the logical
-    /// screen points stored for pinned bars into framebuffer pixels.
-    scale_factor: f32,
     opacity: f32,
 }
 
@@ -136,7 +127,6 @@ impl Renderer {
         queue: wgpu::Queue,
         format: wgpu::TextureFormat,
         scale: u32,
-        scale_factor: f32,
     ) -> Self {
         let scale = scale.max(1);
 
@@ -301,18 +291,15 @@ impl Renderer {
             text_renderer,
             viewport,
             scale,
-            scale_factor,
             opacity: DEFAULT_OPACITY,
         }
     }
 
-    /// Physical-pixel geometry of every bar, in draw order. Pinned bars
-    /// (`BossBar::pos`) sit at their stored logical point scaled to pixels;
-    /// the rest auto-stack down the top-center column. Shared by the draw pass
-    /// and pointer hit-testing so they never disagree.
-    pub fn layout(&self, bars: &[BossBar], width: f32) -> Vec<BarBox> {
+    /// Physical-pixel geometry of every bar auto-stacked down the top-center
+    /// column, in draw order. Used by the multi-bar `--snapshot` render; the
+    /// live overlay gives each bar its own window and uses `render_one`.
+    fn layout(&self, bars: &[BossBar], width: f32) -> Vec<BarBox> {
         let s = self.scale as f32;
-        let sf = self.scale_factor;
         let bar_w = BAR_W as f32 * s;
         let bar_h = BAR_H as f32 * s;
         let title_px = 8.0 * s;
@@ -322,60 +309,33 @@ impl Renderer {
         let center_x = (width - bar_w) * 0.5;
 
         let mut boxes = Vec::with_capacity(bars.len());
-        let mut auto_y = top_pad;
+        let mut y = top_pad;
         for b in bars {
             let has_title = !b.title.is_empty();
             let title_h = if has_title { title_px } else { 0.0 };
-            let (left, group_top) = match b.pos {
-                Some(p) => (p.x as f32 * sf, p.y as f32 * sf),
-                None => (center_x, auto_y),
-            };
-            let track_y = group_top + title_h + if has_title { title_gap } else { 0.0 };
+            let track_y = y + title_h + if has_title { title_gap } else { 0.0 };
             boxes.push(BarBox {
-                id: b.id,
-                left,
-                title_top: group_top,
+                left: center_x,
+                title_top: y,
                 track_y,
                 bar_w,
                 bar_h,
                 title_px,
                 has_title,
             });
-            // Only the auto-stacked column advances; a pinned bar floats free.
-            if b.pos.is_none() {
-                auto_y = track_y + bar_h + bar_gap;
-            }
+            y = track_y + bar_h + bar_gap;
         }
         boxes
     }
 
-    /// The topmost bar under a physical-pixel point, if any. Iterates back to
-    /// front so the last-drawn (visually top) bar wins an overlap.
-    pub fn hit(&self, bars: &[BossBar], width: f32, point: glam::Vec2) -> Option<i64> {
-        self.layout(bars, width)
-            .into_iter()
-            .rev()
-            .find(|bx| bx.contains(point))
-            .map(|bx| bx.id)
-    }
-
-    /// The drag anchor (title top-left, physical pixels) of one bar by id.
-    pub fn origin_of(&self, bars: &[BossBar], width: f32, id: i64) -> Option<glam::Vec2> {
-        self.layout(bars, width)
-            .into_iter()
-            .find(|bx| bx.id == id)
-            .map(|bx| bx.origin())
-    }
-
-    /// Draw the given bars into `view`, a `width`x`height` target. `highlight`
-    /// is the id of the hovered or dragged bar, drawn opaque for feedback.
-    pub fn render(
+    /// Low-level draw: paint each item (a bar, its box, its opacity) into
+    /// `view`. Shared by the multi-bar snapshot render and the per-window render.
+    fn draw(
         &mut self,
         view: &wgpu::TextureView,
         width: u32,
         height: u32,
-        bars: &[BossBar],
-        highlight: Option<i64>,
+        items: &[DrawItem<'_>],
     ) -> Result<(), wgpu::SurfaceError> {
         // A shaped title plus where and how opaque to draw it.
         struct Title {
@@ -386,21 +346,14 @@ impl Renderer {
         }
 
         let shadow_off = self.scale as f32;
-        let boxes = self.layout(bars, width as f32);
 
-        // Build the sprite quads and lay out the titles in one pass, walking the
-        // shared layout so draw and hit-testing agree on every bar's box.
         let mut quads: Vec<Quad> = Vec::new();
         let mut titles: Vec<Title> = Vec::new();
 
-        for (b, bx) in bars.iter().zip(&boxes) {
-            // The hovered/dragged bar goes solid; every other bar stays at the
-            // HUD's default translucency.
-            let alpha = if Some(b.id) == highlight {
-                1.0
-            } else {
-                self.opacity
-            };
+        for item in items {
+            let b = item.bar;
+            let bx = item.geom;
+            let alpha = item.alpha;
 
             if bx.has_title {
                 let mut buffer =
@@ -609,6 +562,85 @@ impl Renderer {
         self.atlas.trim();
         Ok(())
     }
+
+    /// Render all bars auto-stacked into one target (the `--snapshot` PNG path).
+    /// `highlight` is the id of a bar to paint opaque.
+    pub fn render(
+        &mut self,
+        view: &wgpu::TextureView,
+        width: u32,
+        height: u32,
+        bars: &[BossBar],
+        highlight: Option<i64>,
+    ) -> Result<(), wgpu::SurfaceError> {
+        let opacity = self.opacity;
+        let boxes = self.layout(bars, width as f32);
+        let items: Vec<DrawItem<'_>> = bars
+            .iter()
+            .zip(boxes)
+            .map(|(bar, geom)| DrawItem {
+                bar,
+                geom,
+                alpha: if Some(bar.id) == highlight { 1.0 } else { opacity },
+            })
+            .collect();
+        self.draw(view, width, height, &items)
+    }
+
+    /// Render a single bar centered in its own window. `hovered` paints it
+    /// opaque and grows it by [`HOVER_SCALE`]; otherwise it sits at base size
+    /// with the hover headroom as transparent margin. The window size must come
+    /// from [`bar_window_px`] so the grown bar fits without resizing.
+    pub fn render_one(
+        &mut self,
+        view: &wgpu::TextureView,
+        width: u32,
+        height: u32,
+        bar: &BossBar,
+        hovered: bool,
+    ) -> Result<(), wgpu::SurfaceError> {
+        let s = self.scale as f32 * if hovered { HOVER_SCALE } else { 1.0 };
+        let shadow = self.scale as f32;
+        let has_title = !bar.title.is_empty();
+        let title_px = 8.0 * s;
+        let title_h = if has_title { title_px } else { 0.0 };
+        let title_gap = if has_title { 1.0 * s } else { 0.0 };
+        let bar_w = BAR_W as f32 * s;
+        let bar_h = BAR_H as f32 * s;
+
+        // Center the content (plus its shadow offset) in the window so growth on
+        // hover expands evenly from the middle rather than shifting a corner.
+        let content_w = bar_w + shadow;
+        let content_h = title_h + title_gap + bar_h + shadow;
+        let left = ((width as f32 - content_w) * 0.5).max(0.0);
+        let top = ((height as f32 - content_h) * 0.5).max(0.0);
+
+        let geom = BarBox {
+            left,
+            title_top: top,
+            track_y: top + title_h + title_gap,
+            bar_w,
+            bar_h,
+            title_px,
+            has_title,
+        };
+        let alpha = if hovered { 1.0 } else { self.opacity };
+        let items = [DrawItem { bar, geom, alpha }];
+        self.draw(view, width, height, &items)
+    }
+}
+
+/// Physical-pixel size of the window that holds one bar at `scale` (base scale
+/// times the display factor), including the [`HOVER_SCALE`] headroom so a
+/// hovered bar grows in place. `has_title` adds the title row; plus a
+/// one-pixel-scaled shadow margin.
+pub fn bar_window_px(scale: u32, has_title: bool) -> (u32, u32) {
+    let s = scale.max(1) as f32 * HOVER_SCALE;
+    let bar_w = BAR_W as f32 * s;
+    let bar_h = BAR_H as f32 * s;
+    let title = if has_title { 8.0 * s + 1.0 * s } else { 0.0 };
+    let shadow = scale.max(1) as f32;
+    ((bar_w + shadow).ceil() as u32, (title + bar_h + shadow).ceil() as u32)
 }
 
 /// Decode a PNG and upload it as an sRGB texture with its own bind group.

--- a/packages/bossbar-overlay/app/src/snapshot.rs
+++ b/packages/bossbar-overlay/app/src/snapshot.rs
@@ -45,8 +45,7 @@ pub fn run(
     });
     let view = target.create_view(&wgpu::TextureViewDescriptor::default());
 
-    // Snapshots have no display scaling, so logical points map 1:1 to pixels.
-    let mut renderer = Renderer::new(device.clone(), queue.clone(), FORMAT, scale, 1.0);
+    let mut renderer = Renderer::new(device.clone(), queue.clone(), FORMAT, scale);
     renderer
         .render(&view, width, height, bars, None)
         .map_err(|e| format!("render: {e:?}"))?;


### PR DESCRIPTION
## Why

Drag was unreliable. The overlay was a single full-screen, click-through window that, to receive any pointer event, ran a 16ms CoreGraphics cursor-poll thread and toggled `set_cursor_hittest` as the cursor crossed a bar. That poll↔winit handoff (and `set_cursor_hittest` being unsupported on Wayland) is what made dragging "sometimes do nothing."

## What

Each visible bar is now its **own small borderless, transparent, always-on-top window** sized to just that bar.

- The desktop is click-through everywhere **automatically** — there is no window except over a bar, so nothing else intercepts the mouse. No cursor poll, no `set_cursor_hittest`, no coordinate reconciliation.
- **Hover** is native `CursorEntered`/`CursorLeft`. The hovered bar goes opaque **and grows by 8%** (`HOVER_SCALE`) so the hover is unmistakable; each window reserves that headroom so the bar grows centered in place, no resize or shift. Cursor becomes a grab hand.
- **Drag** is the platform-native `Window::drag_window()`. The drop position is read from `Moved` and persisted to the bar's `x`/`y` columns, guarded so OS placement nudges (e.g. menu-bar clamp) and our own programmatic moves aren't mistaken for a user drag.
- `reconcile()` diffs the DB's visible bars against the live windows on each watcher wake (add/remove/update within ~200ms).

Removes the poll thread, the hittest logic, the `core-graphics` dependency, and the `#[cfg(target_os = "macos")]` split — the design is now uniform on macOS and Linux. The renderer factors quad/title building into one `draw()` shared by the multi-bar `--snapshot` render and the per-window `render_one`.

## Verification

- ✅ `cargo test` (5), `cargo build --release`, `nix build .#bossbar-overlay`, `nix run .#lint` all green
- ✅ Live (macOS): two bars render as separate stacked windows; hovering grows + opaques the bar (confirmed via cursor-warp screenshots); positions persist to `x,y` only on real drags (no false-persist from OS placement); `bossbar add/rm` makes windows appear/disappear; the `ix-downtime` Raid bar path still works

## Known limitation

Some Linux tiling WMs force-place borderless windows, which can fight free-drag placement (noted in the README).

---
🤖 Authored with Claude Code (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace single full-screen overlay with one borderless window per bossbar
> - Each bar gets its own borderless, always-on-top window, replacing the single click-through overlay. Bars can be dragged natively without cursor polling or hit-testing.
> - Hovering a bar changes the cursor, scales the bar up slightly (`HOVER_SCALE`), and raises opacity; the window is pre-sized with hover headroom so it never resizes on hover.
> - Bar positions persist to the DB only when a user-initiated drag ends; OS-driven or programmatic moves are ignored via echo detection in `on_moved`.
> - Bars without saved positions are auto-placed in a top-centered column. Live DB changes reconcile windows: new bars appear, removed bars close, and title/size changes apply immediately.
> - Behavioral Change: the app now exits when the last bar window closes rather than on a single window close; macOS-specific cursor polling and global hit-testing are removed entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca6a1ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->