### PR TITLE
bossbar: breathing hover animation + animation skill

### DIFF
--- a/agent-context/sections/12-layout.md
+++ b/agent-context/sections/12-layout.md
@@ -12,8 +12,17 @@ flake.nix                                  # manifest: inputs + delegated output
 lib/                                       # public helpers, builders, discovery
 modules/                                   # registered NixOS modules and profiles
 images/                                    # image modules plus optional versions
+packages/                                  # repo-owned packages (Rust crates, apps, tools)
+skills/                                    # Claude Code skills, one dir per skill
+agent-context/                             # source fragments for generated AGENTS.md/CLAUDE.md
 nix-rules/                                 # ast-grep lint rules
 ```
+
+Skills are this repo's custom agent-skill system: each `skills/<name>/SKILL.md`
+(frontmatter `name` + a trigger `description`, optional `references/` and
+`assets/`) is auto-discovered by [`lib/skills.nix`](lib/skills.nix), so adding a
+directory is the only step to publish one. They surface to agents by name; reach
+for one when its description matches the task.
 
 Folders should preserve conceptual paths. When siblings share a real domain,
 nest them under that domain instead of flattening the name into repeated dashed

--- a/packages/bossbar-overlay/README.md
+++ b/packages/bossbar-overlay/README.md
@@ -37,8 +37,9 @@ tray; quit it the way you quit any foreground process (Ctrl-C from the terminal,
 or stop the service that runs it). `BOSSBAR_SCALE=3` (or `--scale 3`) enlarges
 the bars.
 
-The bars are interactive: hover one and it goes fully opaque (the cursor becomes
-a grab hand), and you can drag it anywhere on screen. Dragging uses the
+The bars are interactive: hover one and it eases to fully opaque and gently
+grows with a slow breathing pulse (the cursor becomes a grab hand), and you can
+drag it anywhere on screen. Dragging uses the
 platform's native window drag, and the drop location is saved to the bar's
 `x`/`y` columns, so it stays put across restarts. Bars without a saved position
 auto-stack in a top-center column. This works the same on macOS and Linux.

--- a/packages/bossbar-overlay/app/src/overlay.rs
+++ b/packages/bossbar-overlay/app/src/overlay.rs
@@ -12,14 +12,16 @@
 //! `set_cursor_hittest`, no coordinate reconciliation.
 
 use std::collections::HashMap;
+use std::f32::consts::TAU;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use glam::DVec2;
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use winit::event::{ElementState, MouseButton, WindowEvent};
-use winit::event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
 use winit::window::{CursorIcon, Window, WindowId, WindowLevel};
 
 use crate::bars::BossBar;
@@ -32,6 +34,21 @@ use crate::render::{self, Renderer};
 /// nudge would otherwise read as a move).
 const AUTO_TOP: f64 = 40.0;
 const AUTO_GAP: f64 = 6.0;
+
+/// Hover grow/shrink time (seconds): an ease-out tween at the responsive end of
+/// the feedback range. See the `animation` skill.
+const GROW_SECS: f32 = 0.16;
+/// Full breathing cycle (seconds) while hovered. ~2.6s reads calm and alive,
+/// near a resting heart rate, rather than urgent.
+const BREATHE_PERIOD: f32 = 2.6;
+/// Animation frame budget while something is moving (~60 fps).
+const FRAME: Duration = Duration::from_millis(16);
+
+/// Ease-out cubic: fast start, soft landing. The default feedback curve.
+fn ease_out_cubic(t: f32) -> f32 {
+    let u = 1.0 - t.clamp(0.0, 1.0);
+    1.0 - u * u * u
+}
 
 /// GPU state shared by every bar window: one device/queue and one renderer
 /// (pipeline, sprite textures, font). Each window only owns its surface.
@@ -48,7 +65,13 @@ struct BarWin {
     surface: wgpu::Surface<'static>,
     config: wgpu::SurfaceConfiguration,
     bar: BossBar,
+    /// Hover target: the pointer is currently over this bar.
     hovered: bool,
+    /// Eased hover amount in `0..=1`, animated toward `hovered` each frame. Drives
+    /// the grow + opacity; the breathing fades in with it.
+    hover_anim: f32,
+    /// Timestamp of the last animation step, for frame-rate-independent easing.
+    last: Instant,
     /// True between a left-press and its release: only then does a `Moved`
     /// count as a user drag worth persisting. Window placement nudges by the OS
     /// (e.g. clamping below the menu bar) arrive with this false and are ignored.
@@ -56,6 +79,13 @@ struct BarWin {
     /// Last position we know the window holds (logical points): what we set, or
     /// where the OS placed it. Lets `Moved` skip echoes of our own placement.
     self_set: Option<LogicalPosition<f64>>,
+}
+
+impl BarWin {
+    /// Still moving: easing toward/away from hover, or breathing while hovered.
+    fn animating(&self) -> bool {
+        self.hovered || self.hover_anim > 0.0
+    }
 }
 
 pub struct App {
@@ -73,6 +103,8 @@ pub struct App {
     scale_factor: f64,
     /// Physical sprite scale, `round(base_scale * scale_factor)`.
     scale: u32,
+    /// App start, the zero point for the continuous breathing phase.
+    start: Instant,
     ready: bool,
 }
 
@@ -193,6 +225,8 @@ impl App {
             config,
             bar,
             hovered: false,
+            hover_anim: 0.0,
+            last: Instant::now(),
             dragging: false,
             self_set: Some(pos),
         })
@@ -245,6 +279,29 @@ impl App {
     }
 
     fn render_id(&mut self, id: i64) {
+        let now = Instant::now();
+        // Continuous breathing phase: a sine over the whole run, never reset, so
+        // it never snaps when a bar starts or stops being hovered.
+        let breathe = (TAU * now.duration_since(self.start).as_secs_f32() / BREATHE_PERIOD).sin();
+
+        // Advance this bar's eased hover amount toward its target, then map it
+        // through ease-out for the visible grow/opacity.
+        let hover = {
+            let Some(win) = self.wins.get_mut(&id) else {
+                return;
+            };
+            let dt = now.duration_since(win.last).as_secs_f32().min(0.05);
+            win.last = now;
+            let target = if win.hovered { 1.0 } else { 0.0 };
+            let step = dt / GROW_SECS;
+            win.hover_anim = if win.hover_anim < target {
+                (win.hover_anim + step).min(target)
+            } else {
+                (win.hover_anim - step).max(target)
+            };
+            ease_out_cubic(win.hover_anim)
+        };
+
         let Some(core) = self.core.as_mut() else {
             return;
         };
@@ -265,9 +322,14 @@ impl App {
         let view = frame
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());
-        let _ =
-            core.renderer
-                .render_one(&view, win.config.width, win.config.height, &win.bar, win.hovered);
+        let _ = core.renderer.render_one(
+            &view,
+            win.config.width,
+            win.config.height,
+            &win.bar,
+            hover,
+            breathe,
+        );
         frame.present();
     }
 
@@ -394,6 +456,24 @@ impl ApplicationHandler<Vec<BossBar>> for App {
             _ => {}
         }
     }
+
+    /// Keep redrawing while any bar is animating (growing, shrinking, or
+    /// breathing), capped to ~60 fps; otherwise let the loop sleep until the
+    /// next event so an idle overlay costs nothing.
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let mut animating = false;
+        for win in self.wins.values() {
+            if win.animating() {
+                animating = true;
+                win.window.request_redraw();
+            }
+        }
+        event_loop.set_control_flow(if animating {
+            ControlFlow::WaitUntil(Instant::now() + FRAME)
+        } else {
+            ControlFlow::Wait
+        });
+    }
 }
 
 /// Run the overlay event loop. Blocks until the last window closes.
@@ -410,6 +490,7 @@ pub fn run(db: PathBuf, base_scale: u32) -> Result<(), Box<dyn std::error::Error
         mon_logical: (1920.0, 1080.0),
         scale_factor: 1.0,
         scale: base_scale.max(1),
+        start: Instant::now(),
         ready: false,
     };
     event_loop.run_app(&mut app)?;

--- a/packages/bossbar-overlay/app/src/render.rs
+++ b/packages/bossbar-overlay/app/src/render.rs
@@ -26,10 +26,18 @@ const BAR_H: u32 = 5;
 /// overlay by letting the desktop bleed through a little.
 const DEFAULT_OPACITY: f32 = 0.85;
 
-/// How much a hovered bar grows. A small, deliberate scale-up (on top of going
-/// opaque) so the hover is unmistakable. Each bar window reserves this headroom
-/// so the bar grows in place without the window resizing or shifting.
-const HOVER_SCALE: f32 = 1.08;
+/// How much a fully-hovered bar grows, before breathing. A small, deliberate
+/// scale-up (on top of going opaque) so the hover is unmistakable.
+const HOVER_SCALE: f32 = 1.06;
+
+/// Breathing amplitude: a hovered bar gently scales +/- this fraction around its
+/// grown size on a slow sine, so it reads as alive rather than frozen.
+const BREATHE_AMP: f32 = 0.02;
+
+/// Largest scale a bar can reach (grown + breathing in). Each window reserves
+/// this much headroom so the bar grows and breathes in place without the window
+/// resizing or shifting.
+const MAX_SCALE: f32 = HOVER_SCALE * (1.0 + BREATHE_AMP);
 
 /// Vanilla title shadow: one dark pixel offset, scaled, no blur.
 const SHADOW: GColor = GColor::rgb(0x3f, 0x3f, 0x3f);
@@ -587,19 +595,29 @@ impl Renderer {
         self.draw(view, width, height, &items)
     }
 
-    /// Render a single bar centered in its own window. `hovered` paints it
-    /// opaque and grows it by [`HOVER_SCALE`]; otherwise it sits at base size
-    /// with the hover headroom as transparent margin. The window size must come
-    /// from [`bar_window_px`] so the grown bar fits without resizing.
+    /// Render a single bar centered in its own window. `hover` is the eased
+    /// hover amount (0 = resting, 1 = fully hovered); `breathe` is a sine in
+    /// `-1..1` for the idle breathing. Together they grow the bar by up to
+    /// [`MAX_SCALE`] and fade it to opaque; at `hover == 0` the bar is base size
+    /// and translucent and the hover headroom is transparent margin. The window
+    /// size must come from [`bar_window_px`] so the grown bar fits without
+    /// resizing.
     pub fn render_one(
         &mut self,
         view: &wgpu::TextureView,
         width: u32,
         height: u32,
         bar: &BossBar,
-        hovered: bool,
+        hover: f32,
+        breathe: f32,
     ) -> Result<(), wgpu::SurfaceError> {
-        let s = self.scale as f32 * if hovered { HOVER_SCALE } else { 1.0 };
+        let hover = hover.clamp(0.0, 1.0);
+        // Grow toward HOVER_SCALE with hover, then breathe around that; the
+        // breathe fades in with hover so a resting bar is perfectly still.
+        let grow = 1.0 + (HOVER_SCALE - 1.0) * hover;
+        let scale_mul = grow * (1.0 + BREATHE_AMP * breathe * hover);
+        let alpha = self.opacity + (1.0 - self.opacity) * hover;
+        let s = self.scale as f32 * scale_mul;
         let shadow = self.scale as f32;
         let has_title = !bar.title.is_empty();
         let title_px = 8.0 * s;
@@ -624,7 +642,6 @@ impl Renderer {
             title_px,
             has_title,
         };
-        let alpha = if hovered { 1.0 } else { self.opacity };
         let items = [DrawItem { bar, geom, alpha }];
         self.draw(view, width, height, &items)
     }
@@ -635,7 +652,7 @@ impl Renderer {
 /// hovered bar grows in place. `has_title` adds the title row; plus a
 /// one-pixel-scaled shadow margin.
 pub fn bar_window_px(scale: u32, has_title: bool) -> (u32, u32) {
-    let s = scale.max(1) as f32 * HOVER_SCALE;
+    let s = scale.max(1) as f32 * MAX_SCALE;
     let bar_w = BAR_W as f32 * s;
     let bar_h = BAR_H as f32 * s;
     let title = if has_title { 8.0 * s + 1.0 * s } else { 0.0 };

--- a/skills/animation/SKILL.md
+++ b/skills/animation/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: animation
+description: >
+  Animation principles for repo-owned UIs (winit/wgpu overlays, ratatui TUIs, the web
+  dashboard): pick duration and easing by intent, ease-out for entrances and feedback,
+  springs for interruptible/user-driven motion, and gentle "breathing" loops via a
+  continuous sine clock. Includes concrete durations, cubic-bezier and spring constants,
+  reduced-motion handling, the native-Rust frame-driving pattern, and anti-patterns. Use
+  whenever you add or tune motion (hover, press, enter/exit, pulse/breathe) in any
+  repo-owned interface.
+---
+
+# Animation
+
+Animate with intent: motion is another channel the interface speaks through. The
+goal is not more motion, it is motion that earns its place and then disappears.
+Default to **not** animating; add it where it clarifies a change, guides
+attention, or makes feedback land.
+
+## Duration is the highest-leverage knob
+
+If an animation feels slow, it is almost never the curve — it is the duration.
+Shorten time before touching easing.
+
+- **Hover / press:** 120–180 ms
+- **Small state change:** 180–260 ms
+- **Larger transition:** up to 300 ms
+- **> 300 ms** reads as *intentional* (a statement), not *reactive*. Fine on
+  purpose, wrong for feedback.
+
+Entrances can run slightly longer than the matching exit (e.g. 300 ms in,
+200 ms out).
+
+## Pick the curve by role
+
+Ask first: is this motion **reacting to the user**, or is it **the system
+announcing a change**?
+
+- **Ease-out** — the default for entrances and feedback. Starts fast (feels
+  responsive), softens at the end (eye catches up). `cubic-bezier(0, 0, 0.2, 1)`.
+- **Ease-in** — exits. Accelerates away so a leaving element doesn't linger.
+  `cubic-bezier(0.4, 0, 1, 1)`.
+- **Ease-in-out** — transitions between two equally important states (view/mode
+  switch). Neutral; overusing it makes everything feel sluggish and over-polite.
+- **Spring** — user-driven, interruptible motion (drag, flick, press) where the
+  motion must survive interruption and carry velocity. Springs have no fixed
+  duration; they resolve naturally. Sweet spot to start: `stiffness 400,
+  damping 15` (snappy with a hint of overshoot). Higher stiffness = snappier;
+  lower damping = bouncier. Reserve overshoot/bounce (`cubic-bezier(0.34, 1.56,
+  0.64, 1)`) for playful, non-critical surfaces — never task-critical UI.
+
+Rule of thumb: drag/gesture → spring; "the system did X" → easing.
+
+## Breathing / ambient loops (a value that should never stop)
+
+For a pulse, a breathing idle indicator, or a hovered element that should feel
+alive, you need a loop, not an event-driven tween. The shape:
+
+- Oscillate **forward and back** (reverse on each cycle), never sawtooth-restart
+  — a snap at the peak reads as a glitch.
+- **Smooth easing** within each half-cycle (ease-in-out / sine), so the value
+  dwells near the extremes and accelerates through the middle. Linear reads
+  mechanical, like a metronome.
+- **Subtle amplitude:** ±2–5% scale around the base. Cross 1.0 in both
+  directions for a symmetric breathe.
+- **Calm period ≈ 1.2–3 s** per full cycle (near a resting heart rate) reads
+  "alive"; ~200–600 ms reads "urgent / warning."
+- Implement as `sin()` of a **continuous clock** (`base * (1 + amp * sin(2π *
+  t / period))`). Never reset the phase on state change, or it jumps.
+
+Fade the breathe in with the hover/enter progress so a resting element is
+perfectly still.
+
+## What to animate
+
+Prefer **transform (scale, translate) and opacity** — cheap and smooth.
+Avoid animating layout-driving properties (width/height/x/y of large elements);
+they are janky and expensive. Coordinate scale + opacity on the same clock so a
+pulse reads as one object, not two effects.
+
+## Honor reduced motion
+
+Respect the OS "reduce motion" setting (macOS *Reduce Motion* /
+`prefers-reduced-motion`): collapse animations to an instant state change rather
+than removing the feedback entirely.
+
+## Native Rust (winit/wgpu) frame-driving pattern
+
+Event-driven render loops are idle until something happens, so a time-based
+animation must drive its own frames:
+
+- Keep a clock (`std::time::Instant`), an app `start` for the continuous breathe
+  phase, and per-element eased progress (e.g. `hover_anim: f32`).
+- Each frame: advance progress toward its target by `dt / duration`, apply the
+  easing curve, compute scale + alpha, render.
+- In `about_to_wait`, if anything is still animating, `request_redraw` it and set
+  `ControlFlow::WaitUntil(now + ~16ms)` (≈60 fps); when everything is at rest,
+  set `ControlFlow::Wait` so the process goes fully idle. Never busy-loop with
+  `Poll`.
+
+The boss bar overlay is the worked example:
+[`packages/bossbar-overlay`](packages/bossbar-overlay) — ease-out hover grow plus
+a sine breathe while hovered, frame-driven exactly as above, with the window
+reserving the max-scale headroom so the bar grows in place.
+
+## Anti-patterns
+
+- Linear motion for anything physical — feels dead.
+- Everything ease-in-out — sluggish and over-polite.
+- Overshoot/bounce on task-critical surfaces — jarring; reserve for playful UI.
+- Reactive feedback > 300 ms — reads as lag.
+- Sawtooth-restart breathing — snaps at the peak.
+- Busy-loop redraw — cap to ~60 fps and stop when the value reaches rest.
+
+## Sources
+
+> Easing vs springs, durations, control points:
+> <https://raphaelsalaja-userinterface-wiki.mintlify.app/animation/to-spring-or-not-to-spring>
+> Duration and easing in UX: <https://www.nngroup.com/articles/animation-duration/>
+> Choosing easing (ease-out default, durations): <https://web.dev/articles/choosing-the-right-easing>
+> Spring constants (stiffness/damping): <https://tigerabrodi.blog/how-to-implement-spring-physics-buttons-with-framer-motion>
+> Breathing loop (reverse, easing, amplitude, period): <https://doveletter.dev/docs/compose-animations/pulsing-heart>


### PR DESCRIPTION
## What

Three things, driven by "make the hover a smooth breathe and capture the principles as a reusable skill":

1. **New `animation` skill** (`skills/animation/SKILL.md`) — duration/easing-by-intent, ease-out for feedback, springs for interruptible motion, the breathing-loop recipe (reverse sine, subtle amplitude, ~1.2–3s period), reduced-motion, and the native-Rust frame-driving pattern. Researched via exa (sources cited in the skill).
2. **Documented the skill system** — the Layout section (`agent-context/sections/12-layout.md`, which generates AGENTS.md/CLAUDE.md) now lists `skills/`, `packages/`, `agent-context/` and explains that each `skills/<name>/SKILL.md` is auto-discovered by `lib/skills.nix`. It was previously undocumented.
3. **Bossbar hover is now a smooth breathe** — on hover the bar eases (ease-out, 160ms) to opaque and grows, then gently breathes (±2% sine, ~2.6s period) while hovered; on leave it eases back. Frame-driven off `std::time::Instant` with `ControlFlow::WaitUntil` (~60fps) while animating and `Wait` when idle, so a resting overlay costs nothing. Each window reserves the max-scale headroom so the bar grows/breathes in place without resizing.

## Verification

- ✅ `cargo test` (5), `nix build .#bossbar-overlay`, `nix run .#lint` green
- ✅ Live: resting bars are perfectly still (steady width); on hover the bar grows ~6% and the width oscillates with the breathing sine (measured 737–761px vs 719 at rest); animation is frame-driven and stops when idle
- ✅ `animation` skill directory present and auto-discovered by `lib/skills.nix`

Note: per the user's explicit request this intentionally adds a small scale-on-hover (overriding the usual "no motion on hover" default) for this playful Minecraft HUD.

---
🤖 Authored with Claude Code (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add eased hover animation and breathing pulse to bossbar overlay
> - Replaces the instant hover state change in [`overlay.rs`](https://github.com/indexable-inc/index/pull/416/files#diff-33da11ba47e085c9f1f9c87457840f96d03a66a6a925c69a6273ef76e99e251f) with a time-based `hover_anim: f32` that eases in/out over ~0.16s using a new `ease_out_cubic` function.
> - Adds a continuous sine-based breathing pulse (amplitude 2%) applied to scale and opacity while a bar is hovered, driven by a shared `start: Instant` on `App`.
> - The event loop now self-drives redraws at ~60 fps via `about_to_wait` when any bar is animating, and sleeps when idle to avoid unnecessary CPU usage.
> - [`render.rs`](https://github.com/indexable-inc/index/pull/416/files#diff-3ea9a891a2426681e39b0f386a1bf93d77bfe34709fd71ad609608526da8791f) updates `render_one` to accept `hover: f32` and `breathe: f32` floats; `bar_window_px` now reserves headroom using `MAX_SCALE = HOVER_SCALE * (1 + BREATHE_AMP)` to prevent clipping during breathing.
> - Adds a new [`skills/animation/SKILL.md`](https://github.com/indexable-inc/index/pull/416/files#diff-566c0974f10fadd69fcf0a5cff08b201a63189332529aff90f9cdade8838c6ad) documenting animation principles, timing curves, and the frame-driving pattern used here.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5bea22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->