### PR TITLE
feat(macos-vm): Rust binding over Virtualization.framework with VM lifecycle CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ dependencies = [
  "ast-merge-langs",
  "ast-merge-matcher",
  "clap",
- "snafu",
+ "snafu 0.9.0",
  "tracing",
  "tracing-subscriber",
 ]
@@ -295,7 +295,7 @@ name = "ast-merge-ast"
 version = "0.1.0"
 dependencies = [
  "rustc-hash",
- "snafu",
+ "snafu 0.9.0",
  "tree-sitter",
  "tree-sitter-rust",
 ]
@@ -317,7 +317,7 @@ name = "ast-merge-git"
 version = "0.1.0"
 dependencies = [
  "lazy-regex",
- "snafu",
+ "snafu 0.9.0",
 ]
 
 [[package]]
@@ -549,6 +549,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bon"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,7 +766,7 @@ dependencies = [
  "glob",
  "serde",
  "serde_json",
- "snafu",
+ "snafu 0.9.0",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -806,7 +815,7 @@ dependencies = [
  "ignore",
  "parking_lot",
  "rustc-hash",
- "snafu",
+ "snafu 0.9.0",
  "tempfile",
  "tracing",
 ]
@@ -1362,6 +1371,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,7 +1552,7 @@ dependencies = [
  "clap",
  "code-tokenizer",
  "repo-walker",
- "snafu",
+ "snafu 0.9.0",
  "tango-bench",
  "tantivy",
  "tempfile",
@@ -2849,6 +2870,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "macos-vm"
+version = "0.1.0"
+dependencies = [
+ "block2",
+ "clap",
+ "dispatch2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-virtualization",
+ "snafu 0.8.9",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,7 +3021,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "snafu",
+ "snafu 0.9.0",
 ]
 
 [[package]]
@@ -3177,7 +3211,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "snafu",
+ "snafu 0.9.0",
  "strip-ansi-escapes",
 ]
 
@@ -3338,6 +3372,71 @@ dependencies = [
  "pyo3",
  "pyo3-build-config",
  "rustc-hash",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-virtualization"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8edb98625ad1f7dea2e82ab54d5bdf3f477e6645b550f4a7cced1818be9ff59d"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "dispatch2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4451,7 +4550,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "snafu",
+ "snafu 0.9.0",
  "tempfile",
  "tokio",
 ]
@@ -4723,11 +4822,32 @@ dependencies = [
 
 [[package]]
 name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive 0.8.9",
+]
+
+[[package]]
+name = "snafu"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6"
 dependencies = [
- "snafu-derive",
+ "snafu-derive 0.9.0",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5065,7 +5185,7 @@ dependencies = [
  "bytes",
  "parking_lot",
  "pty-process",
- "snafu",
+ "snafu 0.9.0",
  "tokio",
  "vt100",
 ]
@@ -5794,7 +5914,7 @@ dependencies = [
  "pty-process",
  "pyo3",
  "serde_json",
- "snafu",
+ "snafu 0.9.0",
  "tokio",
  "tui-dashboard-core",
  "uuid",
@@ -5821,7 +5941,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "snafu",
+ "snafu 0.9.0",
  "tokio",
  "tokio-stream",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "packages/file-search",
   "packages/git-log-pretty",
   "packages/ix-dev-diagnose",
+  "packages/macos-vm",
   "packages/mcp",
   "packages/minecraft/nbt",
   "packages/minecraft/sound",

--- a/packages/macos-vm/Cargo.toml
+++ b/packages/macos-vm/Cargo.toml
@@ -1,12 +1,13 @@
 # macos-vm: a thin Rust binding over Apple's Virtualization.framework
 # (`objc2-virtualization`) plus a small CLI that owns the VM lifecycle.
 #
-# This is the first crate in the workspace that links an Apple framework, so the
-# framework deps are gated to `cfg(target_os = "macos")` exactly the way the
-# unit graph gates `alsa-sys` (see lib/rust-workspace.nix): a Linux CI graph
-# never pulls objc2 and the binary still compiles there as a stub that exits
-# with a clear "macOS only" error. Linking Virtualization only happens on a
-# Darwin build.
+# This is the first crate in the workspace that links an Apple framework. ALL
+# dependencies are gated to `cfg(target_os = "macos")` (the way the unit graph
+# gates `alsa-sys`, see lib/rust-workspace.nix): on a Linux CI graph the crate
+# has zero dependencies and compiles to a one-line `main` that exits with a
+# clear "macOS only" error. Even `clap` and `snafu` are macOS-only here, because
+# everything that uses them is itself macOS-gated; leaving them unconditional
+# would trip the repo's unused-crate-dependencies check on Linux.
 [package]
 name = "macos-vm"
 version.workspace = true
@@ -18,11 +19,9 @@ description = "Drive Apple's Virtualization.framework from Rust: own a VM's life
 name = "macos-vm"
 path = "src/main.rs"
 
-[dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
 clap = { version = "4", features = ["derive"] }
 snafu = "0.8"
-
-[target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-foundation = "0.3"
 objc2-virtualization = "0.3"

--- a/packages/macos-vm/Cargo.toml
+++ b/packages/macos-vm/Cargo.toml
@@ -1,0 +1,33 @@
+# macos-vm: a thin Rust binding over Apple's Virtualization.framework
+# (`objc2-virtualization`) plus a small CLI that owns the VM lifecycle.
+#
+# This is the first crate in the workspace that links an Apple framework, so the
+# framework deps are gated to `cfg(target_os = "macos")` exactly the way the
+# unit graph gates `alsa-sys` (see lib/rust-workspace.nix): a Linux CI graph
+# never pulls objc2 and the binary still compiles there as a stub that exits
+# with a clear "macOS only" error. Linking Virtualization only happens on a
+# Darwin build.
+[package]
+name = "macos-vm"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Drive Apple's Virtualization.framework from Rust: own a VM's lifecycle"
+
+[[bin]]
+name = "macos-vm"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+snafu = "0.8"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-foundation = "0.3"
+objc2-virtualization = "0.3"
+block2 = "0.6"
+dispatch2 = "0.3"
+
+[lints]
+workspace = true

--- a/packages/macos-vm/README.md
+++ b/packages/macos-vm/README.md
@@ -1,0 +1,149 @@
+# macos-vm
+
+Drive Apple's [Virtualization.framework](https://developer.apple.com/documentation/virtualization)
+from Rust. This crate is a thin binding over
+[`objc2-virtualization`](https://docs.rs/objc2-virtualization) plus a small CLI
+that owns a virtual machine's lifecycle, so other parts of the system can start
+and control a VM without holding the virtualization entitlement themselves.
+
+The motivating use case: run a GUI app (for example the `bossbar-overlay`) inside
+a VM and inspect it remotely, so an agent can verify on-screen rendering without
+the app ever appearing on the operator's real desktop or grabbing the operator's
+cursor.
+
+```sh
+nix run .#macos-vm -- info
+nix run .#macos-vm -- boot-linux --kernel ./Image --initramfs ./initramfs
+```
+
+## Status
+
+Proven end to end on macOS 26.5 / Apple M5 Max: a signed binary boots a real
+Linux guest (raw arm64 kernel `Image` + initramfs) through Virtualization.framework
+and streams the guest serial console to stdout. The guest reaches userspace.
+
+What works today:
+
+- `info` reports `VZVirtualMachine.isSupported`.
+- `boot-linux` boots a Linux guest and streams its console, then stops on a
+  timeout.
+
+What is designed but not yet built (see [Roadmap](#roadmap)):
+
+- graphics device + offscreen screenshot,
+- a vsock control channel and a long-lived `serve` mode,
+- booting an OCI image as a disk,
+- a macOS guest installer,
+- the `macvm` Python module bundled into ix-mcp.
+
+## Why a standalone signed binary
+
+Creating a VM requires the `com.apple.security.virtualization` entitlement on the
+**running process**, and the binary must be code-signed to carry it. That shapes
+the architecture:
+
+- The ix-mcp Python interpreter is an unsigned, immutable Nix store binary. It
+  cannot gain the entitlement, and re-signing a store path is not an option. So
+  the interpreter must not drive Virtualization.framework in-process.
+- Instead, `macos-vm` is a separate signed binary that owns the VM. Callers
+  (the CLI, and later the `macvm` Python module) spawn it and talk to it over a
+  control channel. The entitlement lives only on this process.
+
+This is the same split [`go-microvm`](https://github.com/stacklok/go-microvm)
+and [`ericcurtin/vmm`](https://github.com/ericcurtin/vmm) use: a small signed
+runner that the rest of the program drives.
+
+### Signing
+
+Ad-hoc signing is enough; no paid Developer ID is required:
+
+```sh
+codesign --force --sign - --entitlements virtualization.entitlements macos-vm
+```
+
+with an entitlements plist containing `com.apple.security.virtualization`. Nix
+store outputs are read-only, so the package signs into a per-user cache on first
+run and re-execs the signed copy. (Wiring this into `default.nix` is on the
+roadmap; today the e2e signs the built binary out-of-store.)
+
+## Visual testing without taking over the host
+
+The `bossbar-overlay` is a native `winit` + `wgpu` (Metal) app: transparent,
+always-on-top, click-through windows that float over the desktop, with
+hover-to-grow and native drag. Its static rendering is already verifiable
+headless via `bossbar-overlay --snapshot out.png`. What cannot be checked
+without taking over the real screen is the **live windowed behavior**:
+always-on-top placement, the native drag, click-through, menu-bar clearance,
+multi-window stacking.
+
+That behavior is faithful only on a macOS desktop, so the test environment is a
+**macOS guest VM**, which gets GPU-accelerated graphics through
+`VZMacGraphicsDevice` (so Metal and `wgpu` render for real). Two ways to see and
+drive the guest, neither of which touches the host cursor or desktop:
+
+1. **Remote access into the guest.** Enable Screen Sharing (VNC) inside the
+   macOS guest and connect from the host. Input over VNC drives the *guest*
+   pointer, so the host cursor is never captured. This matches "use remote
+   access in it to test it visually" directly.
+2. **Offscreen framebuffer capture.** Attach a `VZVirtualMachineView` to an
+   off-screen, non-activating window and render it to an `NSBitmapImageRep`. The
+   host shows no visible window. This is the lighter path for a single
+   screenshot; it needs validation that VZ renders an off-screen view (tracked
+   in the roadmap).
+
+For a Linux guest the same applies, except Virtualization.framework gives Linux
+guests no 3D acceleration: `wgpu` would fall back to software (lavapipe). For
+GPU-accelerated Linux rendering on macOS you need a different VMM (see OCI
+below), not Virtualization.framework.
+
+## OCI images
+
+Two honest options:
+
+- **Virtualization.framework + a disk built from an OCI image.** Flatten the
+  image into a raw/ext4 disk (the repo's `oci-image-builder` can do the
+  flattening) and boot it with `VZLinuxBootLoader` or `VZEFIBootLoader`. Pure
+  Virtualization.framework, no extra dependency, but you manage kernel/initrd and
+  get no GPU acceleration in the Linux guest.
+- **[libkrun](https://github.com/containers/libkrun) / krunkit.** Purpose-built
+  to boot an OCI image as a microVM (the image is the rootfs over virtio-fs,
+  boot in milliseconds), and `libkrun-efi` adds a Venus virtio-gpu so Linux
+  guests get real Vulkan via MoltenVK. It uses Hypervisor.framework and needs
+  the `com.apple.security.hypervisor` entitlement.
+
+Recommended default: use Virtualization.framework for the macOS-guest visual
+test (the actual goal here), and reach for libkrun/krunkit for OCI microVMs
+rather than reimplementing OCI-on-Virtualization.framework. libkrun already owns
+that surface, including the GPU path, and the maintenance cost of rebuilding it
+is not justified yet. If a single backend ever becomes a hard requirement, that
+decision should be made deliberately, not by accretion.
+
+## Build notes
+
+- This is the first workspace crate that links an Apple framework. The objc2
+  dependencies are gated to `cfg(target_os = "macos")` so the Linux CI workspace
+  graph never pulls them; on Linux the binary compiles as a typed "macOS only"
+  stub. The package output is advertised only on `aarch64-darwin`.
+- All Virtualization.framework calls happen on the process main thread (the
+  queue VZ binds the VM to by default); `dispatch_main` drains that queue so
+  completion handlers fire, mirroring Apple's sample app.
+
+## Bad fit if
+
+- You need GPU-accelerated **Linux** rendering on macOS: Virtualization.framework
+  does not accelerate Linux guests; use libkrun-efi/krunkit instead.
+- You cannot code-sign: without the virtualization entitlement, configuration
+  validation fails by design.
+- You are off Apple Silicon: only `aarch64-darwin` is wired up.
+
+## Roadmap
+
+1. Graphics device + offscreen screenshot (`screenshot` subcommand returning a
+   PNG).
+2. vsock control channel + long-lived `serve` mode for IPC.
+3. `macvm` Python module bundled into ix-mcp (like `tui`/`screen`): spawns this
+   signed binary and exposes `boot`, `screenshot`, and input, returning PIL
+   images that render inline.
+4. macOS guest installer (`VZMacOSInstaller` from an IPSW) for the bossbar test.
+5. OCI-disk boot for Linux guests; document the libkrun handoff for microVMs.
+6. Nix-integrated first-run entitlement signer in `default.nix`.

--- a/packages/macos-vm/default.nix
+++ b/packages/macos-vm/default.nix
@@ -1,0 +1,11 @@
+{ ix, lib, ... }:
+
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "macos-vm";
+  meta = {
+    description = "Drive Apple's Virtualization.framework from Rust: own a VM's lifecycle";
+    license = lib.licenses.mit;
+    mainProgram = "macos-vm";
+    platforms = [ "aarch64-darwin" ];
+  };
+}

--- a/packages/macos-vm/package.nix
+++ b/packages/macos-vm/package.nix
@@ -1,0 +1,13 @@
+{
+  id = "macos-vm";
+  inRustWorkspace = true;
+  # macOS-only: the binary links Apple's Virtualization.framework. On Linux the
+  # crate still compiles (as a typed "macOS only" stub, so the workspace unit
+  # graph stays green there), but the package output and package-set attr are
+  # only advertised on Darwin so `nix flake check` never forces an off-platform
+  # build. Apple Silicon only for now: the boot path is exercised with an arm64
+  # kernel image and Hypervisor.framework on this hardware.
+  flake.systems = [ "aarch64-darwin" ];
+  packageSet.systems = [ "aarch64-darwin" ];
+  passthruTests = true;
+}

--- a/packages/macos-vm/src/main.rs
+++ b/packages/macos-vm/src/main.rs
@@ -1,0 +1,268 @@
+//! `macos-vm`: drive Apple's Virtualization.framework from Rust.
+//!
+//! This binary owns a VM's lifecycle so that callers that cannot hold the
+//! `com.apple.security.virtualization` entitlement themselves (notably the
+//! ix-mcp Python interpreter, an unsigned immutable Nix store binary) can spawn
+//! it and control a VM over IPC. The entitlement lives on *this* signed
+//! process, never on the interpreter.
+//!
+//! v1 surface:
+//!   * `macos-vm info`        — report whether virtualization is available.
+//!   * `macos-vm boot-linux`  — boot a Linux guest from a raw kernel `Image`
+//!                              and initramfs, streaming the guest serial
+//!                              console to stdout. This is the end-to-end smoke
+//!                              path: a real guest reaching userspace proves the
+//!                              binding, the entitlement, and the boot work.
+//!
+//! The graphics/screenshot, vsock IPC, OCI-disk, and macOS-guest paths build on
+//! the same `VZVirtualMachineConfiguration` and are tracked in the README.
+
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "macos-vm",
+    about = "Drive Apple's Virtualization.framework from Rust"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Report whether Virtualization.framework can run a VM on this host.
+    Info,
+    /// Boot a Linux guest from a raw arm64 kernel `Image` + initramfs and
+    /// stream its serial console to stdout until the guest stops or the timeout
+    /// elapses.
+    BootLinux {
+        /// Path to an uncompressed Linux kernel image (arm64 raw `Image`, not a
+        /// gzip/zboot `vmlinuz`).
+        #[arg(long)]
+        kernel: std::path::PathBuf,
+        /// Path to an initramfs/initrd.
+        #[arg(long)]
+        initramfs: std::path::PathBuf,
+        /// Number of virtual CPUs.
+        #[arg(long, default_value_t = 2)]
+        cpus: usize,
+        /// Guest memory in MiB.
+        #[arg(long, default_value_t = 1024)]
+        memory_mib: u64,
+        /// Kernel command line. `console=hvc0` routes the kernel console to the
+        /// virtio console VZ exposes.
+        #[arg(long, default_value = "console=hvc0")]
+        cmdline: String,
+        /// Stop the VM and exit after this many seconds.
+        #[arg(long, default_value_t = 20)]
+        timeout_secs: u64,
+    },
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    match run(cli.command) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("macos-vm: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn run(command: Command) -> Result<(), imp::Error> {
+    match command {
+        Command::Info => imp::info(),
+        Command::BootLinux {
+            kernel,
+            initramfs,
+            cpus,
+            memory_mib,
+            cmdline,
+            timeout_secs,
+        } => imp::boot_linux(imp::LinuxBoot {
+            kernel,
+            initramfs,
+            cpus,
+            memory_bytes: memory_mib * 1024 * 1024,
+            cmdline,
+            timeout: std::time::Duration::from_secs(timeout_secs),
+        }),
+    }
+}
+
+/// On non-macOS targets the binary still builds (so the Linux CI workspace graph
+/// stays green) but every command is a typed refusal rather than a silent
+/// fallback.
+#[cfg(not(target_os = "macos"))]
+fn run(_command: Command) -> Result<(), NotMacOs> {
+    Err(NotMacOs)
+}
+
+#[cfg(not(target_os = "macos"))]
+#[derive(Debug, snafu::Snafu)]
+#[snafu(display("macos-vm requires macOS and Apple's Virtualization.framework"))]
+struct NotMacOs;
+
+#[cfg(target_os = "macos")]
+mod imp {
+    //! The Virtualization.framework glue. Everything here runs on the process
+    //! main thread, which is the queue VZ binds the VM to by default; the guest
+    //! vCPUs run on framework-owned threads, and `dispatch_main` drains the main
+    //! queue so VZ's completion handlers fire (mirroring Apple's sample app,
+    //! which wraps the same calls in `dispatchMain()`).
+
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    use block2::RcBlock;
+    use objc2::AllocAnyThread;
+    use objc2_foundation::{NSArray, NSError, NSFileHandle, NSPipe, NSString, NSURL};
+    use objc2_virtualization::{
+        VZBootLoader, VZEntropyDeviceConfiguration, VZFileHandleSerialPortAttachment,
+        VZLinuxBootLoader, VZMemoryBalloonDeviceConfiguration, VZSerialPortAttachment,
+        VZSerialPortConfiguration, VZVirtioConsoleDeviceSerialPortConfiguration,
+        VZVirtioEntropyDeviceConfiguration, VZVirtioTraditionalMemoryBalloonDeviceConfiguration,
+        VZVirtualMachine, VZVirtualMachineConfiguration,
+    };
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    pub enum Error {
+        #[snafu(display("virtualization is not available on this host"))]
+        Unsupported,
+        #[snafu(display(
+            "virtual machine configuration is invalid: {message} \
+             (an unsigned binary, or one missing com.apple.security.virtualization, \
+             fails configuration validation)"
+        ))]
+        InvalidConfiguration { message: String },
+        #[snafu(display("failed to start the virtual machine: {message}"))]
+        StartFailed { message: String },
+    }
+
+    /// Parameters for a Linux guest boot. A named struct rather than a wide
+    /// tuple so callers (and the future IPC layer) name each field.
+    pub struct LinuxBoot {
+        pub kernel: PathBuf,
+        pub initramfs: PathBuf,
+        pub cpus: usize,
+        pub memory_bytes: u64,
+        pub cmdline: String,
+        pub timeout: Duration,
+    }
+
+    pub fn info() -> Result<(), Error> {
+        let supported = unsafe { VZVirtualMachine::isSupported() };
+        println!("virtualization_supported={supported}");
+        if supported {
+            Ok(())
+        } else {
+            Err(Error::Unsupported)
+        }
+    }
+
+    pub fn boot_linux(boot: LinuxBoot) -> Result<(), Error> {
+        if !unsafe { VZVirtualMachine::isSupported() } {
+            return Err(Error::Unsupported);
+        }
+
+        let config = build_linux_config(&boot)?;
+
+        // Validate before constructing the VM: this is where a missing
+        // entitlement surfaces as a clear error instead of a later crash.
+        if let Err(error) = unsafe { config.validateWithError() } {
+            return Err(Error::InvalidConfiguration {
+                message: ns_error_message(&error),
+            });
+        }
+
+        let vm = unsafe { VZVirtualMachine::initWithConfiguration(VZVirtualMachine::alloc(), &config) };
+
+        // Completion handler runs on the main queue once `dispatch_main` drains
+        // it. The error pointer is null on success.
+        let completion = RcBlock::new(|error: *mut NSError| {
+            if error.is_null() {
+                eprintln!("macos-vm: guest started");
+            } else {
+                // Safety: VZ hands us a valid, retained NSError on failure.
+                let error = unsafe { &*error };
+                eprintln!("macos-vm: guest failed to start: {}", ns_error_message(error));
+                std::process::exit(1);
+            }
+        });
+        unsafe { vm.startWithCompletionHandler(&completion) };
+
+        // Hard stop so a background invocation never hangs: a separate thread
+        // sleeps the timeout, then exits the process. The guest console has
+        // already streamed to stdout by then.
+        let timeout = boot.timeout;
+        std::thread::spawn(move || {
+            std::thread::sleep(timeout);
+            eprintln!("macos-vm: timeout reached, stopping");
+            std::process::exit(0);
+        });
+
+        // Drains the main queue forever; the timeout thread ends the process.
+        dispatch2::dispatch_main();
+    }
+
+    fn build_linux_config(boot: &LinuxBoot) -> Result<objc2::rc::Retained<VZVirtualMachineConfiguration>, Error> {
+        let kernel_url = file_url(&boot.kernel);
+        let initramfs_url = file_url(&boot.initramfs);
+
+        let boot_loader =
+            unsafe { VZLinuxBootLoader::initWithKernelURL(VZLinuxBootLoader::alloc(), &kernel_url) };
+        unsafe {
+            boot_loader.setInitialRamdiskURL(Some(&initramfs_url));
+            boot_loader.setCommandLine(&NSString::from_str(&boot.cmdline));
+        }
+
+        // Guest serial console -> our stdout. VZ rejects a null read handle, so
+        // give it the (unwritten) read end of a fresh pipe.
+        let pipe = NSPipe::pipe();
+        let read_handle = pipe.fileHandleForReading();
+        let stdout_handle = NSFileHandle::fileHandleWithStandardOutput();
+        let attachment = unsafe {
+            VZFileHandleSerialPortAttachment::initWithFileHandleForReading_fileHandleForWriting(
+                VZFileHandleSerialPortAttachment::alloc(),
+                Some(&read_handle),
+                Some(&stdout_handle),
+            )
+        };
+        let serial = unsafe { VZVirtioConsoleDeviceSerialPortConfiguration::new() };
+        let attachment_ref: &VZSerialPortAttachment = &attachment;
+        unsafe { serial.setAttachment(Some(attachment_ref)) };
+
+        let entropy = unsafe { VZVirtioEntropyDeviceConfiguration::new() };
+        let balloon = unsafe { VZVirtioTraditionalMemoryBalloonDeviceConfiguration::new() };
+
+        let config = unsafe { VZVirtualMachineConfiguration::new() };
+        let boot_loader_ref: &VZBootLoader = &boot_loader;
+        let serial_ref: &VZSerialPortConfiguration = &serial;
+        let entropy_ref: &VZEntropyDeviceConfiguration = &entropy;
+        let balloon_ref: &VZMemoryBalloonDeviceConfiguration = &balloon;
+        unsafe {
+            config.setBootLoader(Some(boot_loader_ref));
+            config.setCPUCount(boot.cpus);
+            config.setMemorySize(boot.memory_bytes);
+            config.setSerialPorts(&NSArray::from_slice(&[serial_ref]));
+            config.setEntropyDevices(&NSArray::from_slice(&[entropy_ref]));
+            config.setMemoryBalloonDevices(&NSArray::from_slice(&[balloon_ref]));
+        }
+        Ok(config)
+    }
+
+    fn file_url(path: &std::path::Path) -> objc2::rc::Retained<NSURL> {
+        let s = NSString::from_str(&path.to_string_lossy());
+        NSURL::fileURLWithPath(&s)
+    }
+
+    fn ns_error_message(error: &NSError) -> String {
+        error.localizedDescription().to_string()
+    }
+}

--- a/packages/macos-vm/src/main.rs
+++ b/packages/macos-vm/src/main.rs
@@ -16,11 +16,18 @@
 //!
 //! The graphics/screenshot, vsock IPC, OCI-disk, and macOS-guest paths build on
 //! the same `VZVirtualMachineConfiguration` and are tracked in the README.
+//!
+//! Off macOS the binary builds (so the Linux CI workspace graph stays green) but
+//! is a single typed refusal: all Virtualization.framework code lives in the
+//! `cfg(target_os = "macos")` module below, so the Linux compile sees only the
+//! `main` at the bottom of this file.
 
 use std::process::ExitCode;
 
+#[cfg(target_os = "macos")]
 use clap::{Parser, Subcommand};
 
+#[cfg(target_os = "macos")]
 #[derive(Debug, Parser)]
 #[command(
     name = "macos-vm",
@@ -31,6 +38,7 @@ struct Cli {
     command: Command,
 }
 
+#[cfg(target_os = "macos")]
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Report whether Virtualization.framework can run a VM on this host.
@@ -62,9 +70,10 @@ enum Command {
     },
 }
 
+#[cfg(target_os = "macos")]
 fn main() -> ExitCode {
     let cli = Cli::parse();
-    match run(cli.command) {
+    match imp::dispatch(cli.command) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("macos-vm: {error}");
@@ -73,54 +82,31 @@ fn main() -> ExitCode {
     }
 }
 
-#[cfg(target_os = "macos")]
-fn run(command: Command) -> Result<(), imp::Error> {
-    match command {
-        Command::Info => imp::info(),
-        Command::BootLinux {
-            kernel,
-            initramfs,
-            cpus,
-            memory_mib,
-            cmdline,
-            timeout_secs,
-        } => imp::boot_linux(imp::LinuxBoot {
-            kernel,
-            initramfs,
-            cpus,
-            memory_bytes: memory_mib * 1024 * 1024,
-            cmdline,
-            timeout: std::time::Duration::from_secs(timeout_secs),
-        }),
-    }
-}
-
-/// On non-macOS targets the binary still builds (so the Linux CI workspace graph
-/// stays green) but every command is a typed refusal rather than a silent
-/// fallback.
 #[cfg(not(target_os = "macos"))]
-fn run(_command: Command) -> Result<(), NotMacOs> {
-    Err(NotMacOs)
+fn main() -> ExitCode {
+    eprintln!("macos-vm: requires macOS and Apple's Virtualization.framework");
+    ExitCode::FAILURE
 }
-
-#[cfg(not(target_os = "macos"))]
-#[derive(Debug, snafu::Snafu)]
-#[snafu(display("macos-vm requires macOS and Apple's Virtualization.framework"))]
-struct NotMacOs;
 
 #[cfg(target_os = "macos")]
 mod imp {
-    //! The Virtualization.framework glue. Everything here runs on the process
-    //! main thread, which is the queue VZ binds the VM to by default; the guest
-    //! vCPUs run on framework-owned threads, and `dispatch_main` drains the main
-    //! queue so VZ's completion handlers fire (mirroring Apple's sample app,
-    //! which wraps the same calls in `dispatchMain()`).
+    //! The Virtualization.framework glue.
+    //!
+    //! VZ binds a VM to a dispatch queue and requires every VM operation
+    //! (`initWithConfiguration`, `start`, the completion handlers) to run on
+    //! that queue. We use the main queue: the VM is created and started inside a
+    //! block submitted to the main queue, and `dispatch_main` then drains that
+    //! queue (mirroring Apple's sample app). objc2 objects are not `Send`, so
+    //! the VM and its config must be built *inside* that block rather than moved
+    //! into it; the block captures only the `Send` boot parameters.
 
     use std::path::PathBuf;
     use std::time::Duration;
 
     use block2::RcBlock;
+    use dispatch2::{DispatchQueue, dispatch_main};
     use objc2::AllocAnyThread;
+    use objc2::rc::Retained;
     use objc2_foundation::{NSArray, NSError, NSFileHandle, NSPipe, NSString, NSURL};
     use objc2_virtualization::{
         VZBootLoader, VZEntropyDeviceConfiguration, VZFileHandleSerialPortAttachment,
@@ -131,87 +117,119 @@ mod imp {
     };
     use snafu::Snafu;
 
+    use crate::Command;
+
     #[derive(Debug, Snafu)]
     pub enum Error {
         #[snafu(display("virtualization is not available on this host"))]
         Unsupported,
+        #[snafu(display("guest memory {mib} MiB is too large to express in bytes"))]
+        MemoryTooLarge { mib: u64 },
         #[snafu(display(
             "virtual machine configuration is invalid: {message} \
              (an unsigned binary, or one missing com.apple.security.virtualization, \
              fails configuration validation)"
         ))]
         InvalidConfiguration { message: String },
-        #[snafu(display("failed to start the virtual machine: {message}"))]
-        StartFailed { message: String },
     }
 
     /// Parameters for a Linux guest boot. A named struct rather than a wide
-    /// tuple so callers (and the future IPC layer) name each field.
+    /// tuple so callers (and the future IPC layer) name each field. Every field
+    /// is `Send`, which is what lets the boot block be submitted to the queue.
     pub struct LinuxBoot {
         pub kernel: PathBuf,
         pub initramfs: PathBuf,
         pub cpus: usize,
-        pub memory_bytes: u64,
+        pub memory_mib: u64,
         pub cmdline: String,
         pub timeout: Duration,
     }
 
-    pub fn info() -> Result<(), Error> {
-        let supported = unsafe { VZVirtualMachine::isSupported() };
-        println!("virtualization_supported={supported}");
-        if supported {
-            Ok(())
-        } else {
-            Err(Error::Unsupported)
+    pub fn dispatch(command: Command) -> Result<(), Error> {
+        match command {
+            Command::Info => info(),
+            Command::BootLinux {
+                kernel,
+                initramfs,
+                cpus,
+                memory_mib,
+                cmdline,
+                timeout_secs,
+            } => boot_linux(LinuxBoot {
+                kernel,
+                initramfs,
+                cpus,
+                memory_mib,
+                cmdline,
+                timeout: Duration::from_secs(timeout_secs),
+            }),
         }
     }
 
-    pub fn boot_linux(boot: LinuxBoot) -> Result<(), Error> {
+    fn info() -> Result<(), Error> {
+        let supported = unsafe { VZVirtualMachine::isSupported() };
+        println!("virtualization_supported={supported}");
+        if supported { Ok(()) } else { Err(Error::Unsupported) }
+    }
+
+    fn boot_linux(boot: LinuxBoot) -> Result<(), Error> {
         if !unsafe { VZVirtualMachine::isSupported() } {
             return Err(Error::Unsupported);
         }
 
-        let config = build_linux_config(&boot)?;
+        let timeout = boot.timeout;
 
-        // Validate before constructing the VM: this is where a missing
-        // entitlement surfaces as a clear error instead of a later crash.
-        if let Err(error) = unsafe { config.validateWithError() } {
-            return Err(Error::InvalidConfiguration {
-                message: ns_error_message(&error),
+        // Create and start the VM on the main queue, which is the queue VZ binds
+        // the VM to by default. Building inside the block keeps every non-`Send`
+        // objc2 object on that thread; the block captures only `boot`.
+        DispatchQueue::main().exec_async(move || {
+            let config = match build_linux_config(&boot) {
+                Ok(config) => config,
+                Err(error) => {
+                    eprintln!("macos-vm: {error}");
+                    std::process::exit(1);
+                }
+            };
+            let vm = unsafe {
+                VZVirtualMachine::initWithConfiguration(VZVirtualMachine::alloc(), &config)
+            };
+            let completion = RcBlock::new(|error: *mut NSError| {
+                if error.is_null() {
+                    eprintln!("macos-vm: guest started");
+                } else {
+                    // Safety: VZ hands us a valid retained NSError on failure.
+                    let error = unsafe { &*error };
+                    eprintln!("macos-vm: guest failed to start: {}", ns_error_message(error));
+                    std::process::exit(1);
+                }
             });
-        }
-
-        let vm = unsafe { VZVirtualMachine::initWithConfiguration(VZVirtualMachine::alloc(), &config) };
-
-        // Completion handler runs on the main queue once `dispatch_main` drains
-        // it. The error pointer is null on success.
-        let completion = RcBlock::new(|error: *mut NSError| {
-            if error.is_null() {
-                eprintln!("macos-vm: guest started");
-            } else {
-                // Safety: VZ hands us a valid, retained NSError on failure.
-                let error = unsafe { &*error };
-                eprintln!("macos-vm: guest failed to start: {}", ns_error_message(error));
-                std::process::exit(1);
-            }
+            unsafe { vm.startWithCompletionHandler(&completion) };
+            // The VM must outlive this block: dropping the last `Retained` would
+            // tear the running VM down. The process runs until the timeout, so
+            // hand the VM to the process for its lifetime.
+            std::mem::forget(vm);
         });
-        unsafe { vm.startWithCompletionHandler(&completion) };
 
         // Hard stop so a background invocation never hangs: a separate thread
         // sleeps the timeout, then exits the process. The guest console has
-        // already streamed to stdout by then.
-        let timeout = boot.timeout;
+        // streamed to stdout by then.
         std::thread::spawn(move || {
             std::thread::sleep(timeout);
             eprintln!("macos-vm: timeout reached, stopping");
             std::process::exit(0);
         });
 
-        // Drains the main queue forever; the timeout thread ends the process.
-        dispatch2::dispatch_main();
+        // Drains the main queue forever (`-> !`); the timeout thread ends the
+        // process. Runs the boot block submitted above.
+        dispatch_main();
     }
 
-    fn build_linux_config(boot: &LinuxBoot) -> Result<objc2::rc::Retained<VZVirtualMachineConfiguration>, Error> {
+    fn build_linux_config(boot: &LinuxBoot) -> Result<Retained<VZVirtualMachineConfiguration>, Error> {
+        let memory_bytes = boot
+            .memory_mib
+            .checked_mul(1024 * 1024)
+            .ok_or(Error::MemoryTooLarge { mib: boot.memory_mib })?;
+
         let kernel_url = file_url(&boot.kernel);
         let initramfs_url = file_url(&boot.initramfs);
 
@@ -249,15 +267,24 @@ mod imp {
         unsafe {
             config.setBootLoader(Some(boot_loader_ref));
             config.setCPUCount(boot.cpus);
-            config.setMemorySize(boot.memory_bytes);
+            config.setMemorySize(memory_bytes);
             config.setSerialPorts(&NSArray::from_slice(&[serial_ref]));
             config.setEntropyDevices(&NSArray::from_slice(&[entropy_ref]));
             config.setMemoryBalloonDevices(&NSArray::from_slice(&[balloon_ref]));
         }
+
+        // Validation surfaces a missing entitlement as a clear error rather than
+        // a later crash.
+        if let Err(error) = unsafe { config.validateWithError() } {
+            return Err(Error::InvalidConfiguration {
+                message: ns_error_message(&error),
+            });
+        }
+
         Ok(config)
     }
 
-    fn file_url(path: &std::path::Path) -> objc2::rc::Retained<NSURL> {
+    fn file_url(path: &std::path::Path) -> Retained<NSURL> {
         let s = NSString::from_str(&path.to_string_lossy());
         NSURL::fileURLWithPath(&s)
     }

--- a/packages/macos-vm/src/main.rs
+++ b/packages/macos-vm/src/main.rs
@@ -6,13 +6,11 @@
 //! it and control a VM over IPC. The entitlement lives on *this* signed
 //! process, never on the interpreter.
 //!
-//! v1 surface:
-//!   * `macos-vm info`        — report whether virtualization is available.
-//!   * `macos-vm boot-linux`  — boot a Linux guest from a raw kernel `Image`
-//!                              and initramfs, streaming the guest serial
-//!                              console to stdout. This is the end-to-end smoke
-//!                              path: a real guest reaching userspace proves the
-//!                              binding, the entitlement, and the boot work.
+//! v1 surface. `macos-vm info` reports whether virtualization is available.
+//! `macos-vm boot-linux` boots a Linux guest from a raw kernel `Image` and
+//! initramfs, streaming the guest serial console to stdout. boot-linux is the
+//! end-to-end smoke path: a real guest reaching userspace proves the binding,
+//! the entitlement, and the boot all work.
 //!
 //! The graphics/screenshot, vsock IPC, OCI-disk, and macOS-guest paths build on
 //! the same `VZVirtualMachineConfiguration` and are tracked in the README.

--- a/packages/macos-vm/virtualization.entitlements
+++ b/packages/macos-vm/virtualization.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.virtualization</key>
+  <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## What

A new `macos-vm` package: a thin Rust binding over Apple's Virtualization.framework (`objc2-virtualization`) plus a small CLI that owns a VM's lifecycle. The motivating use case is running a GUI app (the `bossbar-overlay`) inside a VM and inspecting it remotely, so an agent can verify on-screen rendering without the app touching the operator's real desktop or cursor.

This first cut proves the mechanism end to end and lays the foundation; the graphics/screenshot, vsock IPC, OCI, macOS-guest, and ix-mcp `macvm` module pieces are scoped in the README roadmap.

## Why this shape

Creating a VM needs the `com.apple.security.virtualization` entitlement on the running, code-signed process. The ix-mcp Python interpreter is an unsigned, immutable Nix store binary and can't carry it, so VZ can't be driven in-process from the interpreter. The clean architecture is a standalone signed binary that owns the VM, which clients (the CLI, later the `macvm` Python module) spawn and control. That's the same split `go-microvm` and `ericcurtin/vmm` use.

## Validation

- ✅ Boots a real Linux guest end to end on macOS 26.5 / Apple M5 Max: ad-hoc signed with the virtualization entitlement, `VZVirtualMachine.isSupported == true`, configuration validates, `vm.start` succeeds, the arm64 kernel boots and reaches userspace, with the guest serial console streamed to stdout.
- ✅ Builds through Nix (`nix build .#macos-vm`).
- objc2 deps are gated to `cfg(target_os = "macos")` so the Linux CI workspace graph stays clean (the binary compiles there as a typed "macOS only" stub); the package output is advertised only on `aarch64-darwin`.

A real boot can't be a hermetic Nix sandbox test (no Hypervisor.framework, no entitlement, no guest image in the sandbox), so the boot e2e is a runtime step, the same way the `tui` and `screen` device tests defer to runtime.

## Notes

- `Cargo.lock` was regenerated with the toolchain's cargo for dependency resolution only (Nix has no lockfile generator and `nix-cargo-unit` requires a current lock); Nix remains the build owner.
- Entitlement signing into a per-user cache on first run (Nix store outputs are read-only) is roadmap item 6; today the e2e signs the built binary out-of-store.

See `packages/macos-vm/README.md` for the full design: visual testing the bossbar via a macOS guest (Screen Sharing/VNC or offscreen capture), and the OCI tradeoff (Virtualization.framework disk vs libkrun/krunkit).

---
_Authored by Claude (Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Rust CLI for macOS VM lifecycle management via Virtualization.framework
> - Adds a new `macos-vm` binary crate at [packages/macos-vm](https://github.com/indexable-inc/index/pull/417/files#diff-4284a34d98351ccbdf11b753c2984fdb17464b21009fe20f50e8f76e9bdd2fee) that wraps Apple's `Virtualization.framework` via `objc2-virtualization` bindings
> - Implements two CLI subcommands: `info` (prints host virtualization support status) and `boot-linux` (boots a Linux guest with a virtio console streamed to stdout)
> - `boot-linux` accepts flags for kernel path, initramfs, CPU count (default 2), memory in MiB (default 1024), kernel cmdline (default `console=hvc0`), and a timeout in seconds (default 20) after which the process exits
> - Includes Nix packaging restricted to `aarch64-darwin` and a `virtualization.entitlements` plist required for the `com.apple.security.virtualization` entitlement
> - Risk: the binary must be code-signed with the virtualization entitlement to function; unsigned or incorrectly signed builds will fail at runtime
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a065a61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->