### PR TITLE
feat(cuda-hello): minimal cuda-oxide Rust->PTX hello-world

### DIFF
--- a/packages/cuda-hello/Cargo.toml
+++ b/packages/cuda-hello/Cargo.toml
@@ -1,10 +1,11 @@
 # Standalone crate: deliberately NOT a member of the index cargo workspace.
 #
 # cuda-oxide is a custom rustc codegen backend. It needs its own pinned nightly
-# (see rust-toolchain.toml), the `cargo oxide` driver, LLVM 21 with the NVPTX
+# (see rust-toolchain.toml), the `cargo oxide` driver, LLVM 22 with the NVPTX
 # backend, and the CUDA toolkit. The index workspace pins a different stable
 # toolchain, so this crate builds on its own through `cargo oxide`, not the repo
-# build. Wiring it in as a nix-cargo-unit is tracked separately (see README).
+# build. The crate-local flake.nix provides that toolchain (`nix develop`);
+# wiring it in as a nix-cargo-unit is tracked separately (see README).
 [package]
 name = "cuda-hello"
 version = "0.1.0"

--- a/packages/cuda-hello/Cargo.toml
+++ b/packages/cuda-hello/Cargo.toml
@@ -1,0 +1,23 @@
+# Standalone crate: deliberately NOT a member of the index cargo workspace.
+#
+# cuda-oxide is a custom rustc codegen backend. It needs its own pinned nightly
+# (see rust-toolchain.toml), the `cargo oxide` driver, LLVM 21 with the NVPTX
+# backend, and the CUDA toolkit. The index workspace pins a different stable
+# toolchain, so this crate builds on its own through `cargo oxide`, not the repo
+# build. Wiring it in as a nix-cargo-unit is tracked separately (see README).
+[package]
+name = "cuda-hello"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[workspace]
+
+[dependencies]
+# Device-side intrinsics: thread indexing, the `#[kernel]` / `#[cuda_module]`
+# attributes, and the bounds-checked `DisjointSlice` device pointer.
+cuda-device = { git = "https://github.com/NVlabs/cuda-oxide", rev = "d22af5f29738fce099ae38262faa7ab59828865f" }
+# Host-side launch glue (the generated typed module's `CudaKernel` machinery).
+cuda-host = { git = "https://github.com/NVlabs/cuda-oxide", rev = "d22af5f29738fce099ae38262faa7ab59828865f" }
+# Host-side CUDA runtime: context, stream, device buffers, launch config.
+cuda-core = { git = "https://github.com/NVlabs/cuda-oxide", rev = "d22af5f29738fce099ae38262faa7ab59828865f" }

--- a/packages/cuda-hello/README.md
+++ b/packages/cuda-hello/README.md
@@ -1,0 +1,68 @@
+# cuda-hello
+
+A minimal CUDA kernel written in pure, idiomatic Rust and compiled to PTX with
+[cuda-oxide](https://github.com/NVlabs/cuda-oxide), NVIDIA's experimental
+Rust-to-CUDA compiler backend. Host and device code share one file
+([`src/main.rs`](src/main.rs)); the kernel just writes `i*i` for each thread, the
+GPU "hello, world".
+
+This is the seed for first-class CUDA-in-Rust support in this repo. It is a draft:
+the crate is written against cuda-oxide's real API, but it is not yet wired into
+the Nix build (see [Status](#status)).
+
+## Compiling vs running
+
+Compiling CUDA needs no GPU. `rustc-codegen-cuda` turns the `#[kernel]` function
+into PTX as a normal compile step, so the build runs anywhere, including CI.
+
+Running the binary needs an NVIDIA GPU and driver, because `main` opens a CUDA
+context and launches the kernel. Without a GPU you can still build and inspect the
+emitted PTX; you just cannot execute it.
+
+## Build
+
+cuda-oxide is its own toolchain, not a library you drop into a normal build. From
+this directory:
+
+```sh
+cargo oxide run        # build to PTX, then launch on the GPU
+cargo oxide build      # build only (no GPU required)
+```
+
+`cargo oxide` is the driver from the cuda-oxide repo; it sets the custom codegen
+backend and emits a `.ptx` next to the host binary.
+
+### Requirements
+
+cuda-oxide is Linux-only today (tested on Ubuntu 24.04) and pins an exact
+toolchain. You need all of:
+
+- Rust `nightly-2026-04-03` with `rust-src`, `rustc-dev`, `llvm-tools` (see
+  [`rust-toolchain.toml`](rust-toolchain.toml)).
+- The `cargo oxide` subcommand from cuda-oxide.
+- LLVM 21+ with the NVPTX backend (`llc` on `PATH`).
+- CUDA Toolkit 12.x+ and Clang/libclang headers.
+
+The cuda-oxide dependencies are pinned by git rev in
+[`Cargo.toml`](Cargo.toml); bump the rev and the toolchain channel together.
+
+## Status
+
+Done:
+
+- Idiomatic single-source kernel + host launch against cuda-oxide's API.
+- Pinned toolchain and dependency revs.
+
+Not done (the work to carry this to a real `nix run .#cuda-hello`):
+
+- Package the cuda-oxide toolchain in Nix: the nightly with `rustc-dev`, the
+  `cargo oxide` driver and `librustc_codegen_cuda` backend, LLVM 21 NVPTX, and
+  the CUDA toolkit, then build this crate as a nix-cargo-unit.
+- A compile-only CI check that asserts the kernel still lowers to PTX (no GPU),
+  so regressions in the cuda-oxide rev surface here.
+
+See the tracking issue linked from the pull request.
+
+---
+
+Drafted with AI (Claude Opus 4.8) via Claude Code.

--- a/packages/cuda-hello/README.md
+++ b/packages/cuda-hello/README.md
@@ -3,12 +3,13 @@
 A minimal CUDA kernel written in pure, idiomatic Rust and compiled to PTX with
 [cuda-oxide](https://github.com/NVlabs/cuda-oxide), NVIDIA's experimental
 Rust-to-CUDA compiler backend. Host and device code share one file
-([`src/main.rs`](src/main.rs)); the kernel just writes `i*i` for each thread, the
-GPU "hello, world".
+([`src/main.rs`](src/main.rs)); the kernel writes `i*i` for each thread, the GPU
+"hello, world".
 
-This is the seed for first-class CUDA-in-Rust support in this repo. It is a draft:
-the crate is written against cuda-oxide's real API, but it is not yet wired into
-the Nix build (see [Status](#status)).
+This is the seed for first-class CUDA-in-Rust support in this repo. The kernel is
+written against cuda-oxide's real API (a faithful subset of upstream's `vecadd`
+example) and is verified to lower to PTX; the crate is deliberately standalone
+(see [Why standalone](#why-standalone)).
 
 ## Compiling vs running
 
@@ -21,45 +22,59 @@ emitted PTX; you just cannot execute it.
 
 ## Build
 
-cuda-oxide is its own toolchain, not a library you drop into a normal build. From
-this directory:
+The crate-local [`flake.nix`](flake.nix) inherits cuda-oxide's dev shell, so you
+get the exact toolchain (the `cargo oxide` driver, the pinned nightly, LLVM 22
+with NVPTX, CUDA 13, and libclang) with no manual setup. From this directory:
 
 ```sh
-cargo oxide run        # build to PTX, then launch on the GPU
-cargo oxide build      # build only (no GPU required)
+nix develop            # enter the cuda-oxide toolchain (Linux only)
+cargo oxide build      # compile to PTX (no GPU required)
+cargo oxide run        # compile to PTX, then launch on the GPU
 ```
 
-`cargo oxide` is the driver from the cuda-oxide repo; it sets the custom codegen
-backend and emits a `.ptx` next to the host binary.
+`cargo oxide` is cuda-oxide's driver: it sets the custom codegen backend and emits
+a `.ptx` next to the host binary. On a standalone crate like this one it
+auto-fetches and builds `librustc_codegen_cuda.so` on first use and caches it, so
+the first build is much slower than later ones.
 
-### Requirements
+### Without Nix
 
-cuda-oxide is Linux-only today (tested on Ubuntu 24.04) and pins an exact
-toolchain. You need all of:
+cuda-oxide is Linux-only today. Outside the dev shell you need all of:
 
 - Rust `nightly-2026-04-03` with `rust-src`, `rustc-dev`, `llvm-tools` (see
   [`rust-toolchain.toml`](rust-toolchain.toml)).
 - The `cargo oxide` subcommand from cuda-oxide.
-- LLVM 21+ with the NVPTX backend (`llc` on `PATH`).
-- CUDA Toolkit 12.x+ and Clang/libclang headers.
+- LLVM 22 with the NVPTX backend (`llc` on `PATH`).
+- CUDA Toolkit 13.x and Clang/libclang headers.
 
-The cuda-oxide dependencies are pinned by git rev in
-[`Cargo.toml`](Cargo.toml); bump the rev and the toolchain channel together.
+The cuda-oxide rev is pinned in lockstep in both [`Cargo.toml`](Cargo.toml) and
+[`flake.nix`](flake.nix); bump the rev and the toolchain channel together.
+
+## Why standalone
+
+The crate is intentionally not a member of the index cargo workspace (note the
+empty `[workspace]` table in `Cargo.toml`) and has no `package.nix`, so the repo's
+stable toolchain never tries to build it and the root `nix flake check` is
+untouched. cuda-oxide is its own toolchain on a pinned nightly that the workspace
+toolchain cannot build; the crate-local flake keeps that toolchain self-contained.
 
 ## Status
 
 Done:
 
-- Idiomatic single-source kernel + host launch against cuda-oxide's API.
-- Pinned toolchain and dependency revs.
+- Idiomatic single-source kernel + host launch against cuda-oxide's real API.
+- Toolchain and dependency revs pinned in lockstep, provided by `nix develop`.
+- Verified end to end on the compile path: the kernel lowers to PTX via
+  `cargo oxide build` (no GPU). The run path needs an NVIDIA device.
 
-Not done (the work to carry this to a real `nix run .#cuda-hello`):
+Not done (the work to carry this to a pure `nix build .#cuda-hello`):
 
-- Package the cuda-oxide toolchain in Nix: the nightly with `rustc-dev`, the
-  `cargo oxide` driver and `librustc_codegen_cuda` backend, LLVM 21 NVPTX, and
-  the CUDA toolkit, then build this crate as a nix-cargo-unit.
-- A compile-only CI check that asserts the kernel still lowers to PTX (no GPU),
-  so regressions in the cuda-oxide rev surface here.
+- Package the cuda-oxide backend in a pure derivation and build this crate as a
+  nix-cargo-unit. cuda-oxide itself does not yet ship a pure build
+  (`librustc_codegen_cuda.so` is built on first use and cached outside the Nix
+  store), so this is upstream work as much as repo work.
+- A compile-only CI check that asserts the kernel still lowers to PTX, so a bad
+  cuda-oxide rev bump surfaces here.
 
 See the tracking issue linked from the pull request.
 

--- a/packages/cuda-hello/flake.lock
+++ b/packages/cuda-hello/flake.lock
@@ -1,0 +1,122 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1779130139,
+        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "cuda-oxide": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1780164855,
+        "narHash": "sha256-423mecB3GJrFKA8SIrBskbkbRWYBIjlNOjtQq2As9yg=",
+        "owner": "NVlabs",
+        "repo": "cuda-oxide",
+        "rev": "d22af5f29738fce099ae38262faa7ab59828865f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NVlabs",
+        "repo": "cuda-oxide",
+        "rev": "d22af5f29738fce099ae38262faa7ab59828865f",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "cuda-oxide": "cuda-oxide",
+        "nixpkgs": [
+          "cuda-oxide",
+          "nixpkgs"
+        ]
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "cuda-oxide",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778296574,
+        "narHash": "sha256-DVmg1JCjG0VJTa+FF6tH6tkQChaxzK1EzPL98RiRWU0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "1d634a90dffb59ec9ba52652de311b15528c1595",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/packages/cuda-hello/flake.nix
+++ b/packages/cuda-hello/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "cuda-hello: a minimal cuda-oxide Rust->PTX kernel";
+
+  # Pinned to the exact cuda-oxide rev used in Cargo.toml so the toolchain
+  # (the `cargo oxide` driver, the nightly, LLVM 22 with NVPTX, CUDA 13, and
+  # libclang) and the device/host crates always move together. Bump both in
+  # lockstep. nixpkgs follows cuda-oxide so there is one shared closure.
+  inputs = {
+    cuda-oxide.url = "github:NVlabs/cuda-oxide/d22af5f29738fce099ae38262faa7ab59828865f";
+    nixpkgs.follows = "cuda-oxide/nixpkgs";
+  };
+
+  outputs =
+    { cuda-oxide, nixpkgs, ... }:
+    let
+      inherit (nixpkgs) lib;
+      # cuda-oxide is Linux-only; mirror the systems it builds for.
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      eachSystem = lib.genAttrs systems;
+    in
+    {
+      # `cd packages/cuda-hello && nix develop` drops you into cuda-oxide's full
+      # CUDA + Rust environment (inherited verbatim, including the host-driver
+      # shellHook), then `cargo oxide build` lowers the kernel to PTX and
+      # `cargo oxide run` launches it. Building needs no GPU; running does.
+      devShells = eachSystem (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShell {
+            inputsFrom = [ cuda-oxide.devShells.${system}.default ];
+          };
+        }
+      );
+    };
+}

--- a/packages/cuda-hello/rust-toolchain.toml
+++ b/packages/cuda-hello/rust-toolchain.toml
@@ -1,0 +1,6 @@
+# Pinned to match cuda-oxide: it hooks unstable rustc internals, so the nightly
+# and the `rustc-dev` / `rust-src` / `llvm-tools` components are not optional.
+# Keep this in lockstep with the cuda-oxide rev pinned in Cargo.toml.
+[toolchain]
+channel = "nightly-2026-04-03"
+components = ["rust-src", "rustc-dev", "rust-analyzer", "clippy", "llvm-tools"]

--- a/packages/cuda-hello/src/main.rs
+++ b/packages/cuda-hello/src/main.rs
@@ -27,12 +27,13 @@ mod kernels {
     #[kernel]
     pub fn squares(mut out: DisjointSlice<u32>) {
         let idx = thread::index_1d();
+        // Read the raw index before `get_mut` consumes the (non-`Copy`)
+        // `ThreadIndex`. It stays well under `u32::MAX` for any realistic
+        // launch, so the square below cannot overflow.
+        let i = idx.get() as u32;
         // `get_mut` returns `None` for threads past the buffer end, so an
         // over-launched grid can never write out of bounds.
         if let Some(slot) = out.get_mut(idx) {
-            // `idx.get()` stays well under `u32::MAX` for any realistic launch,
-            // so the square cannot overflow here.
-            let i = idx.get() as u32;
             *slot = i * i;
         }
     }

--- a/packages/cuda-hello/src/main.rs
+++ b/packages/cuda-hello/src/main.rs
@@ -1,0 +1,69 @@
+//! The smallest interesting cuda-oxide program: one kernel, written in plain
+//! Rust, compiled straight to PTX and launched on the GPU.
+//!
+//! Host code and device code live in this one file. `rustc-codegen-cuda` routes
+//! the `#[kernel]` function through the Rust -> MIR -> PTX pipeline and leaves
+//! `main` to the normal host backend, so a single `cargo oxide run` produces a
+//! host binary with the PTX embedded.
+//!
+//! Compiling needs no GPU (it is pure CPU work, fine for CI). Running `main`
+//! needs an NVIDIA GPU and driver, because that is where the kernel executes.
+
+use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
+use cuda_device::{DisjointSlice, cuda_module, kernel, thread};
+
+/// How many threads to launch, one per output element.
+const THREADS: usize = 256;
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    /// Each thread writes the square of its own global index.
+    ///
+    /// No inputs: the work is derived entirely from the thread index, which
+    /// makes this the GPU equivalent of "hello, world" while still doing real
+    /// arithmetic and a bounds-checked device write.
+    #[kernel]
+    pub fn squares(mut out: DisjointSlice<u32>) {
+        let idx = thread::index_1d();
+        // `get_mut` returns `None` for threads past the buffer end, so an
+        // over-launched grid can never write out of bounds.
+        if let Some(slot) = out.get_mut(idx) {
+            // `idx.get()` stays well under `u32::MAX` for any realistic launch,
+            // so the square cannot overflow here.
+            let i = idx.get() as u32;
+            *slot = i * i;
+        }
+    }
+}
+
+fn main() {
+    let ctx = CudaContext::new(0).expect("open CUDA device 0");
+    let stream = ctx.default_stream();
+
+    let mut out = DeviceBuffer::<u32>::zeroed(&stream, THREADS).expect("allocate output buffer");
+
+    let module = kernels::load(&ctx).expect("load embedded PTX module");
+    module
+        .squares(
+            &stream,
+            LaunchConfig::for_num_elems(THREADS as u32),
+            &mut out,
+        )
+        .expect("launch squares kernel");
+
+    let host = out.to_host_vec(&stream).expect("copy results back to host");
+
+    for i in 0..5 {
+        println!("thread {i}: {i}^2 = {}", host[i]);
+    }
+
+    let correct = host
+        .iter()
+        .enumerate()
+        .all(|(i, &value)| value == (i as u32) * (i as u32));
+    assert!(correct, "GPU result did not match i*i");
+
+    println!("hello from {THREADS} GPU threads");
+}


### PR DESCRIPTION
## What

`packages/cuda-hello`: a minimal CUDA kernel in pure, idiomatic Rust, compiled to
PTX with [cuda-oxide](https://github.com/NVlabs/cuda-oxide), NVIDIA's experimental
Rust-to-CUDA compiler backend. Host and device code live in one file; the kernel
writes `i*i` per thread — the GPU "hello, world".

## What changed since the draft

This began as a draft written against cuda-oxide's API but **never actually built**.
It is now verified end to end on the compile path:

- **Fixed a real compile error.** `out.get_mut(idx)` moves the non-`Copy`
  `ThreadIndex`, so the later `idx.get()` was a use-after-move (`E0382`) — the
  draft would not compile. Read the raw index *before* the move, matching
  upstream's `vecadd` idiom.
- **Verified Rust → PTX.** Built with cuda-oxide's real toolchain (rev `d22af5f`):
  `cargo oxide build` emits `cuda_hello.ptx`, and the kernel body lowers to
  `mul.lo.s32 %r,%r,%r` (i*i) under `.entry squares`. No GPU is needed to compile.
- **Wired up the toolchain.** Added a crate-local `flake.nix` that inherits
  cuda-oxide's dev shell, pinned to the same rev as `Cargo.toml`. So
  `cd packages/cuda-hello && nix develop` gives the exact toolchain (`cargo oxide`
  + nightly + LLVM 22 NVPTX + CUDA 13 + libclang). The crate stays standalone
  (no `package.nix`; the root `nix flake check` is untouched).
- **Doc/version fixes.** cuda-oxide pins LLVM 22 and CUDA 13 (the docs said 21/12).

## Verification

- ✅ `cargo oxide build` (cuda-oxide `d22af5f`, in its Nix dev shell) →
  `cuda_hello.ptx` with `i*i` lowered to a PTX multiply.
- ✅ `flake.nix` evaluates on `x86_64-linux` and `aarch64-linux`; passes
  nixfmt / statix / deadnix / ast-grep (repo rules).
- ⏳ Run path (`cargo oxide run`, the actual kernel launch) needs an NVIDIA GPU —
  not verified here (no GPU on the build box).

## Still tracked (#419)

A pure `nix build .#cuda-hello` PTX build remains. cuda-oxide itself does not yet
ship a pure build (`librustc_codegen_cuda.so` is built on first use and cached
outside the Nix store), so this is upstream work as much as repo work. A
compile-only CI check should follow once that lands.

## Related

- Tracking issue: #419
- Research issue: #420
- Follow-up: a small PR clarifies the `no-unquoted-splice` lint message, which
  nudged toward `legacyPackages."${system}"` instead of this repo's
  `import nixpkgs { inherit system; }` idiom.

---

Drafted with AI, then verified and revised with Claude Opus 4.8 via Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add minimal cuda-oxide Rust-to-PTX hello-world example
> - Adds a new standalone `cuda-hello` crate under [packages/cuda-hello](https://github.com/indexable-inc/index/pull/421/files#diff-29ace6fc0d48fd9a2b56552c00fc4790db6dcf9b09cc9897b366dd5903fcd4db) that demonstrates end-to-end GPU kernel execution using the cuda-oxide library.
> - A `squares` kernel computes `i*i` for each thread index and writes results into a 256-element `DeviceBuffer<u32>`; the host then copies results back and asserts correctness.
> - A Nix flake pins cuda-oxide at a fixed rev and reuses its dev shell, providing the full CUDA + nightly Rust toolchain via `nix develop`.
> - The crate is marked `publish = false` and described as a draft/proof-of-concept in the README.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82357e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->