### PR TITLE
nix-rules(no-unquoted-splice): point to the idiomatic fix + add self-test

### DIFF
--- a/nix-rules-tests/no-unquoted-splice-test.yml
+++ b/nix-rules-tests/no-unquoted-splice-test.yml
@@ -1,0 +1,10 @@
+id: no-unquoted-splice
+valid:
+  # Preferred: avoid the splice entirely by importing nixpkgs per system.
+  - 'import nixpkgs { inherit system; }'
+  # Acceptable: quoted antiquote when a dynamic index is unavoidable.
+  - 'nixpkgs.legacyPackages."${system}"'
+  - 'inputs.foo.packages."${system}".default'
+invalid:
+  - 'nixpkgs.legacyPackages.${system}'
+  - 'self.packages.${system}.default'

--- a/nix-rules/no-unquoted-splice.yml
+++ b/nix-rules/no-unquoted-splice.yml
@@ -1,14 +1,19 @@
 id: no-unquoted-splice
 language: nix
 severity: warning
-message: "`legacyPackages.${system}` interpolates outside a string. Wrap the antiquote in quotes: `legacyPackages.\"${system}\"`."
+message: "`legacyPackages.${system}` interpolates outside a string. Prefer `import nixpkgs { inherit system; }` to get a package set; if you must index dynamically, quote the antiquote: `legacyPackages.\"${system}\"`."
 note: |
   WHY: Dynamic attribute names at the parser level evaluate the antiquote and
   use the result as the attribute name. They look just like string-interpolated
   names but bypass the string parser — tools that walk the AST often disagree on
   the semantics. The quoted form is what most parsers and formatters expect.
+
+  FIX (in order of preference):
+    1. Avoid the splice. To get a package set for a system, use
+       `pkgs = import nixpkgs { inherit system; };` (see lib/per-system.nix).
+    2. Quote the antiquote when a dynamic index is unavoidable, e.g.
+       `inputs.foo.packages."${system}"`. `set."${dynamic}"` is the canonical form.
   NIXPKGS: statix `unquoted_splice`.
-  REPO: Quote the antiquote. `set."${dynamic}"` is the canonical form.
 rule:
   any:
     - pattern: $X.legacyPackages.${$Y}


### PR DESCRIPTION
## What

Improve the `no-unquoted-splice` lint message so it points at the fix this repo
actually prefers, and add a self-test fixture for the rule.

## Why

The old message only suggested quoting the antiquote:

> Wrap the antiquote in quotes: `legacyPackages."${system}"`.

That reads oddly and hides the idiomatic fix. The repo's own convention (see
`lib/per-system.nix`) is to **avoid the splice entirely**:

```nix
pkgs = import nixpkgs { inherit system; };
```

Following the message literally produces `legacyPackages."${system}"`, which is
semantically identical to the unquoted form but visually noisier — and it left a
reviewer (me) unsure which form was actually wanted. (Surfaced while wiring up
`packages/cuda-hello` in #421.)

## Change

- Message + note now lead with `import nixpkgs { inherit system; }`, and keep
  quoting as the fallback for an unavoidable dynamic index
  (e.g. `inputs.foo.packages."${system}"`).
- Add `nix-rules-tests/no-unquoted-splice-test.yml` — this was one of the rules
  with no fixture. It asserts the import form and both quoted forms pass and the
  two unquoted splices are flagged.

The `rule:` patterns are unchanged, so this is message/docs + test only — no
behavior change.

## Verification

`ast-grep test --skip-snapshot-tests`: **13 passed, 0 failed** (incl. the new
fixture). Confirmed the rendered message on a violating snippet.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `no-unquoted-splice` rule to point to idiomatic fix and add self-tests
> - Updates the rule message in [no-unquoted-splice.yml](https://github.com/indexable-inc/index/pull/422/files#diff-ec74f327a8a2b6dc4cb747e98f2db1ad52431006804d142486e3644770389a3c) to prefer importing nixpkgs with `{ inherit system; }` and suggests quoting the antiquote when dynamic indexing is unavoidable.
> - Adds a 'FIX' section to the rule's note enumerating two remediation steps, replacing the previous single-line `REPO: Quote the antiquote.` guidance.
> - Adds [no-unquoted-splice-test.yml](https://github.com/indexable-inc/index/pull/422/files#diff-6bf869471dcc09149240c7931fa751c4f7915f52b037e269b35f20eddd53818c) with valid and invalid test cases covering per-system import, quoted antiquote, and unquoted splices.
> - Behavioral Change: diagnostics text changes but matching logic and severity are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 521c693.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->