### PR TITLE
feat(search): multi-source search — metadata filters + typed envelope (phases 0-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4443,17 +4443,29 @@ version = "0.1.0"
 dependencies = [
  "dirs",
  "futures",
+ "git2",
  "mixedbread",
  "rayon",
  "regex",
  "repo-walker",
  "rusqlite",
+ "search-meta",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "snafu",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "search-meta"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "snafu",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2618,6 +2618,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "linear-export"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "search-meta",
+ "serde",
+ "serde_json",
+ "snafu",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4430,9 +4441,11 @@ dependencies = [
  "code-highlight",
  "dirs",
  "indicatif",
+ "linear-export",
  "mixedbread",
  "progress-style",
  "search-core",
+ "slack-export",
  "terminal-theme",
  "tokio",
 ]
@@ -4723,6 +4736,16 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slack-export"
+version = "0.1.0"
+dependencies = [
+ "search-meta",
+ "serde",
+ "serde_json",
+ "snafu",
+]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,12 +482,12 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.117",
 ]
 
@@ -603,14 +603,14 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -1230,6 +1230,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashu-base"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fab3f0756c8585395280bd81b384cd28bbd66d6b00e66124ecfd1f644938b38c"
+
+[[package]]
+name = "dashu-int"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a93d93dc2aca9a071e6ecb2af883441e8b34357a1037bc536e1c52b0d3c713"
+dependencies = [
+ "cfg-if",
+ "dashu-base",
+ "num-modular",
+ "rustversion",
+ "static_assertions",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1959,15 +1978,14 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hegeltest"
-version = "0.14.11"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07139a99a99446106a40d993990df57d5db780c5d95824a9995e9055644600"
+checksum = "c715ed6eeec8dd5a2026d30afd1128ee361e79ad03f4b57ee4cb47f95dd1cd33"
 dependencies = [
  "ciborium",
  "crc32fast",
+ "dashu-int",
  "hegeltest-macros",
- "num-bigint",
- "num-traits",
  "parking_lot",
  "paste",
  "rand 0.10.1",
@@ -1977,9 +1995,9 @@ dependencies = [
 
 [[package]]
 name = "hegeltest-macros"
-version = "0.14.11"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307842ae143e6aec45aa01c04de02fa2a08c57bc27bc624dbd64a6ede09e7bb3"
+checksum = "55b400114078d699688a43895a64e1475f6f185fa4a9d9b68c4b32cad632cb5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2060,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2366,6 +2384,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2607,9 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -2901,9 +2928,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -2980,9 +3007,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -3292,6 +3319,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-modular"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
 
 [[package]]
 name = "num-rational"
@@ -3857,7 +3890,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4670,6 +4703,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4758,18 +4797,18 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6"
+checksum = "d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
+checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4779,9 +4818,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4798,9 +4837,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e6deb40826033bd7b11c7ef25ef71193fabd71f680f40dd16538a2704d2f4"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
 dependencies = [
  "bytes",
  "futures-util",
@@ -4814,6 +4853,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streaming-iterator"
@@ -5898,9 +5943,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"
@@ -6006,9 +6051,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6424,6 +6469,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6470,11 +6524,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6505,6 +6576,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6521,6 +6598,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6541,10 +6624,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6565,6 +6660,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6581,6 +6682,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6601,6 +6708,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6617,6 +6730,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -6848,18 +6967,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,12 @@ members = [
   "packages/oci-image-builder",
   "packages/progress-style",
   "packages/repo-walker",
+  "packages/linear-export",
   "packages/search",
   "packages/search-core",
   "packages/search-meta",
   "packages/search-py",
+  "packages/slack-export",
   "packages/tap",
   "packages/tap/protocol",
   "packages/tap/pty",
@@ -101,6 +103,7 @@ indicatif = "0.18"
 insta = { version = "1.42", features = ["json"] }
 lazy-regex = "3.4"
 libc = "0.2"
+linear-export = { path = "packages/linear-export" }
 mixedbread = { path = "packages/mixedbread" }
 loro = "1.12"
 napi = { version = "3", default-features = false, features = ["napi6", "tokio_rt"] }
@@ -143,6 +146,7 @@ serde = "1"
 serde_json = "1"
 sha2 = "0.10"
 similar = "2"
+slack-export = { path = "packages/slack-export" }
 snafu = "0.9"
 strip-ansi-escapes = "0.2"
 tango-bench = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
   "packages/repo-walker",
   "packages/search",
   "packages/search-core",
+  "packages/search-meta",
   "packages/search-py",
   "packages/tap",
   "packages/tap/protocol",
@@ -137,6 +138,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 rustls-native-certs = "0.8"
 schemars = "1"
 search-core = { path = "packages/search-core" }
+search-meta = { path = "packages/search-meta" }
 serde = "1"
 serde_json = "1"
 sha2 = "0.10"

--- a/packages/linear-export/Cargo.toml
+++ b/packages/linear-export/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "linear-export"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Adapter turning a Linear issue export into embeddable search documents"
+
+[lints]
+workspace = true
+
+[dependencies]
+search-meta.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+snafu.workspace = true
+# The workspace pins chrono with `default-features = false`; `alloc` re-enables
+# the RFC3339 parser (`DateTime::parse_from_rfc3339`) without pulling in `clock`
+# or `std` time, which this crate never needs.
+chrono = { workspace = true, features = ["alloc"] }
+
+[dev-dependencies]
+# fixture-based tests

--- a/packages/linear-export/package.nix
+++ b/packages/linear-export/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "linear-export";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/linear-export/src/lib.rs
+++ b/packages/linear-export/src/lib.rs
@@ -1,0 +1,517 @@
+//! Adapter turning a Linear issue export into embeddable [`search_meta`]
+//! documents.
+//!
+//! A Linear export is a directory of JSON written by the team's exporter:
+//! `metadata.json` (organization, team key/name, counts) and `issues.json` (an
+//! array of issue objects, description and comments inline). This crate reads
+//! that directory and projects each issue into one [`search_meta::Document`]:
+//! the embedded body is a human-readable rendering of the issue (title, status
+//! line, description, and every comment, oldest first), and the flat metadata is
+//! the common [`search_meta`] envelope merged with Linear-specific filter keys
+//! (`identifier`, `team_key`, `state_type`, labels, `has_pr`, ...).
+//!
+//! Grain is one document per issue. Comments in the export are newest-first, so
+//! they are sorted ascending by `createdAt` before rendering, which keeps the
+//! body (and therefore its `content_hash`) stable for an unchanged issue.
+//!
+//! The crate is pure: it reads two files in [`LinearExport::open`] and otherwise
+//! does no I/O. It depends only on [`search_meta`], serde, snafu, and chrono.
+
+#![forbid(unsafe_code)]
+
+use std::path::{Path, PathBuf};
+
+use chrono::DateTime;
+use search_meta::{Document, Source, SourceAdapter, keys};
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+use snafu::{ResultExt as _, Snafu};
+
+/// All failures surfaced by this crate.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// An export file (`metadata.json` or `issues.json`) could not be read.
+    #[snafu(display("failed to read export file {}", path.display()))]
+    ReadFile {
+        /// File that could not be read.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// An export file did not parse as the expected JSON shape.
+    #[snafu(display("failed to parse export file {}", path.display()))]
+    ParseJson {
+        /// File that failed to parse.
+        path: PathBuf,
+        /// Underlying serde error.
+        source: serde_json::Error,
+    },
+
+    /// A built document's metadata exceeded the store's size or key limits.
+    #[snafu(display("metadata limit exceeded for issue {external_id}"))]
+    Metadata {
+        /// The record whose metadata overflowed.
+        external_id: String,
+        /// Underlying limit error.
+        source: search_meta::MetadataError,
+    },
+}
+
+/// Convenient result alias defaulting to this crate's [`Error`].
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// A parsed Linear export directory, ready to project into documents.
+///
+/// Construct with [`LinearExport::open`]; the heavy work (parsing
+/// `issues.json`) happens there, so [`SourceAdapter::documents`] only renders
+/// already-parsed issues.
+#[derive(Debug)]
+pub struct LinearExport {
+    team_key: String,
+    issues: Vec<Issue>,
+}
+
+impl LinearExport {
+    /// Open an export directory: read `metadata.json` for the team key and
+    /// eagerly parse `issues.json` into owned issues.
+    ///
+    /// Linear is small (low thousands of issues), so parsing eagerly keeps
+    /// [`SourceAdapter::documents`] cheap and infallible to start iterating.
+    ///
+    /// # Errors
+    /// Returns [`Error::ReadFile`] if either file cannot be read and
+    /// [`Error::ParseJson`] if either does not match the expected JSON shape.
+    pub fn open(dir: &Path) -> Result<Self> {
+        let metadata_path = dir.join("metadata.json");
+        let metadata_bytes = std::fs::read(&metadata_path).context(ReadFileSnafu {
+            path: metadata_path.clone(),
+        })?;
+        let metadata: ExportMetadata =
+            serde_json::from_slice(&metadata_bytes).context(ParseJsonSnafu {
+                path: metadata_path,
+            })?;
+
+        let issues_path = dir.join("issues.json");
+        let issues_bytes = std::fs::read(&issues_path).context(ReadFileSnafu {
+            path: issues_path.clone(),
+        })?;
+        let issues: Vec<Issue> =
+            serde_json::from_slice(&issues_bytes).context(ParseJsonSnafu { path: issues_path })?;
+
+        Ok(Self {
+            team_key: metadata.team.key,
+            issues,
+        })
+    }
+
+    /// The team key (e.g. `ENG`) read from `metadata.json`.
+    #[must_use]
+    pub fn team_key(&self) -> &str {
+        &self.team_key
+    }
+
+    /// Number of issues parsed from the export.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.issues.len()
+    }
+
+    /// Whether the export contained no issues.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.issues.is_empty()
+    }
+}
+
+impl SourceAdapter for LinearExport {
+    type Error = Error;
+
+    fn source(&self) -> Source {
+        Source::Linear
+    }
+
+    fn documents(&self) -> impl Iterator<Item = Result<Document, Error>> + Send {
+        // Clone the parsed issues into an owned `Vec` so the returned iterator
+        // is `'static` and `Send`, independent of `&self`'s lifetime.
+        let team_key = self.team_key.clone();
+        self.issues
+            .clone()
+            .into_iter()
+            .map(move |issue| issue.into_document(&team_key))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Export schema (serde mirror of the JSON the exporter writes).
+// ---------------------------------------------------------------------------
+
+/// `metadata.json` shape; only the team block is consumed.
+#[derive(Debug, Deserialize)]
+struct ExportMetadata {
+    team: TeamMeta,
+}
+
+/// The `team` block of `metadata.json`.
+#[derive(Debug, Deserialize)]
+struct TeamMeta {
+    key: String,
+}
+
+/// One issue object from `issues.json`. Optional JSON fields use
+/// `#[serde(default)]` since this is an external schema, not runtime config.
+/// The exporter emits camelCase keys, mirrored here to snake_case fields.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Issue {
+    id: String,
+    identifier: String,
+    title: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    priority: i64,
+    #[serde(default)]
+    priority_label: Option<String>,
+    #[serde(default)]
+    estimate: Option<f64>,
+    url: String,
+    created_at: String,
+    updated_at: String,
+    #[serde(default)]
+    completed_at: Option<String>,
+    #[serde(default)]
+    canceled_at: Option<String>,
+    #[serde(default)]
+    archived_at: Option<String>,
+    state: State,
+    #[serde(default)]
+    assignee: Option<User>,
+    #[serde(default)]
+    creator: Option<User>,
+    #[serde(default)]
+    labels: NodeList<Label>,
+    #[serde(default)]
+    project: Option<Project>,
+    #[serde(default)]
+    project_milestone: Option<Milestone>,
+    #[serde(default)]
+    cycle: Option<Cycle>,
+    #[serde(default)]
+    parent: Option<Parent>,
+    #[serde(default)]
+    attachments: NodeList<Attachment>,
+    #[serde(default)]
+    comments: NodeList<Comment>,
+}
+
+/// A Linear workflow state. `type` is the stable filter axis; `name` is display.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct State {
+    name: String,
+    #[serde(rename = "type")]
+    state_type: String,
+}
+
+/// A Linear user (assignee, creator, or comment author).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct User {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    display_name: Option<String>,
+    #[serde(default)]
+    email: Option<String>,
+}
+
+/// A label on an issue.
+#[derive(Debug, Clone, Deserialize)]
+struct Label {
+    name: String,
+}
+
+/// The project an issue belongs to.
+#[derive(Debug, Clone, Deserialize)]
+struct Project {
+    name: String,
+}
+
+/// A project milestone.
+#[derive(Debug, Clone, Deserialize)]
+struct Milestone {
+    name: String,
+}
+
+/// A cycle an issue is in.
+#[derive(Debug, Clone, Deserialize)]
+struct Cycle {
+    number: i64,
+}
+
+/// The parent issue, when this is a sub-issue.
+#[derive(Debug, Clone, Deserialize)]
+struct Parent {
+    identifier: String,
+}
+
+/// An attachment (link) on an issue.
+#[derive(Debug, Clone, Deserialize)]
+struct Attachment {
+    #[serde(default)]
+    title: Option<String>,
+    url: String,
+}
+
+/// A comment on an issue.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Comment {
+    #[serde(default)]
+    body: Option<String>,
+    created_at: String,
+    #[serde(default)]
+    user: Option<User>,
+}
+
+/// Linear's relay-style `{ "nodes": [...] }` wrapper.
+#[derive(Debug, Clone, Deserialize)]
+struct NodeList<T> {
+    #[serde(default = "Vec::new")]
+    nodes: Vec<T>,
+}
+
+// A manual `Default` (rather than `#[derive(Default)]`) so an empty `NodeList`
+// needs no `T: Default` bound: an absent `labels`/`comments`/`attachments`
+// field deserializes to an empty list whatever the element type is.
+impl<T> Default for NodeList<T> {
+    fn default() -> Self {
+        Self { nodes: Vec::new() }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Projection: issue -> Document.
+// ---------------------------------------------------------------------------
+
+impl Issue {
+    /// Render this issue into a [`Document`]: build the body, the flat metadata,
+    /// validate the metadata against the store limits, then assemble.
+    fn into_document(self, team_key: &str) -> Result<Document> {
+        let external_id = format!("linear:issue:{}", self.id);
+        let body = self.render_body(team_key).into_bytes();
+        let content_hash = search_meta::hash_body(&body);
+        let title = format!("{}: {}", self.identifier, self.title);
+
+        let timestamp = parse_epoch_seconds(&self.updated_at);
+        let meta_json = self.build_meta(&external_id, team_key, &content_hash, &title, timestamp);
+
+        search_meta::check_metadata(&external_id, &meta_json).context(MetadataSnafu {
+            external_id: external_id.clone(),
+        })?;
+
+        Ok(Document {
+            external_id,
+            file_name: format!("{}.txt", self.identifier),
+            mime: "text/plain",
+            body,
+            meta_json,
+            content_hash,
+        })
+    }
+
+    /// Build the flat metadata object: common envelope + Linear extras.
+    fn build_meta(
+        &self,
+        external_id: &str,
+        team_key: &str,
+        content_hash: &str,
+        title: &str,
+        timestamp: Option<i64>,
+    ) -> Value {
+        let mut meta = Map::new();
+
+        // Common envelope.
+        meta.insert(keys::SOURCE.to_owned(), json!(Source::Linear.as_str()));
+        meta.insert("external_id".to_owned(), json!(external_id));
+        meta.insert(keys::CONTENT_HASH.to_owned(), json!(content_hash));
+        meta.insert(keys::TITLE.to_owned(), json!(title));
+        meta.insert("url".to_owned(), json!(self.url));
+        if let Some(ts) = timestamp {
+            meta.insert(keys::TIMESTAMP.to_owned(), json!(ts));
+        }
+
+        // Linear extras.
+        meta.insert(keys::IDENTIFIER.to_owned(), json!(self.identifier));
+        meta.insert(keys::TEAM_KEY.to_owned(), json!(team_key));
+        meta.insert(keys::STATE_TYPE.to_owned(), json!(self.state.state_type));
+        meta.insert("state_name".to_owned(), json!(self.state.name));
+        meta.insert("priority".to_owned(), json!(self.priority));
+
+        if let Some(email) = self.assignee.as_ref().and_then(|u| u.email.as_deref()) {
+            meta.insert(keys::ASSIGNEE_EMAIL.to_owned(), json!(email));
+        }
+
+        let labels: Vec<&str> = self.labels.nodes.iter().map(|l| l.name.as_str()).collect();
+        meta.insert(keys::LABELS.to_owned(), json!(labels));
+
+        if let Some(project) = self.project.as_ref() {
+            meta.insert("project_name".to_owned(), json!(project.name));
+        }
+        if let Some(cycle) = self.cycle.as_ref() {
+            meta.insert("cycle_number".to_owned(), json!(cycle.number));
+        }
+        if let Some(parent) = self.parent.as_ref() {
+            meta.insert("parent_identifier".to_owned(), json!(parent.identifier));
+        }
+
+        let is_archived = self.archived_at.is_some();
+        meta.insert(keys::IS_ARCHIVED.to_owned(), json!(is_archived));
+
+        let pr_urls: Vec<&str> = self
+            .attachments
+            .nodes
+            .iter()
+            .map(|a| a.url.as_str())
+            .filter(|url| url.contains("/pull/"))
+            .collect();
+        meta.insert("has_pr".to_owned(), json!(!pr_urls.is_empty()));
+        meta.insert("pr_urls".to_owned(), json!(pr_urls));
+
+        Value::Object(meta)
+    }
+
+    /// Render the human-readable body that gets embedded.
+    fn render_body(&self, team_key: &str) -> String {
+        // `write!`/`writeln!` into a `String` is infallible, so the returned
+        // `fmt::Result`s are deliberately ignored; this avoids the
+        // `format_push_string` lint that `push_str(&format!(..))` would trip.
+        use std::fmt::Write as _;
+
+        let mut out = String::new();
+
+        // Header line.
+        let _ = writeln!(out, "{}: {}", self.identifier, self.title);
+
+        // Status line.
+        let priority_label = self.priority_label.as_deref().unwrap_or("No priority");
+        let assignee = self
+            .assignee
+            .as_ref()
+            .and_then(display_user)
+            .unwrap_or_else(|| "unassigned".to_owned());
+        // Rust's float `Display` prints whole estimates without a trailing
+        // `.0` (`3.0` -> "3") and keeps fractional ones (`1.5` -> "1.5").
+        let estimate = self
+            .estimate
+            .map_or_else(|| "-".to_owned(), |value| value.to_string());
+        let _ = writeln!(
+            out,
+            "State: {} ({}) | Priority: {priority_label} | Assignee: {assignee} | Estimate: {estimate}",
+            self.state.name, self.state.state_type,
+        );
+
+        // Context line.
+        let project = self.project.as_ref().map_or("-", |p| p.name.as_str());
+        let milestone = self
+            .project_milestone
+            .as_ref()
+            .map_or("-", |m| m.name.as_str());
+        let cycle = self
+            .cycle
+            .as_ref()
+            .map_or_else(|| "-".to_owned(), |c| c.number.to_string());
+        let parent = self.parent.as_ref().map_or("-", |p| p.identifier.as_str());
+        let _ = writeln!(
+            out,
+            "Team: {team_key} | Project: {project} | Milestone: {milestone} | Cycle: {cycle} | Parent: {parent}",
+        );
+
+        // Labels line.
+        let labels: Vec<&str> = self.labels.nodes.iter().map(|l| l.name.as_str()).collect();
+        let _ = writeln!(out, "Labels: {}", labels.join(", "));
+
+        // Provenance line.
+        let creator = self
+            .creator
+            .as_ref()
+            .and_then(display_user)
+            .unwrap_or_else(|| "unknown".to_owned());
+        let _ = write!(
+            out,
+            "Created by {creator} on {} | Updated {}",
+            self.created_at, self.updated_at,
+        );
+        if let Some(ts) = self.completed_at.as_deref() {
+            let _ = write!(out, " | Completed {ts}");
+        }
+        if let Some(ts) = self.canceled_at.as_deref() {
+            let _ = write!(out, " | Canceled {ts}");
+        }
+        if let Some(ts) = self.archived_at.as_deref() {
+            let _ = write!(out, " | Archived {ts}");
+        }
+        out.push('\n');
+
+        // Links line.
+        let links: Vec<String> = self
+            .attachments
+            .nodes
+            .iter()
+            .map(|a| {
+                let label = a.title.as_deref().unwrap_or("link");
+                format!("{label} -> {}", a.url)
+            })
+            .collect();
+        let _ = writeln!(out, "Links: {}", links.join(", "));
+
+        // Description block. The leading blank line separates it from the
+        // header; `writeln!` keeps each `write!` string free of a trailing
+        // newline (which would trip `write_with_newline`).
+        let description = self
+            .description
+            .as_deref()
+            .map(str::trim)
+            .filter(|d| !d.is_empty())
+            .unwrap_or("(no description)");
+        out.push('\n');
+        let _ = writeln!(out, "Description:");
+        let _ = writeln!(out, "{description}");
+
+        // Comments block, sorted ascending by createdAt (export is newest-first).
+        let mut comments: Vec<&Comment> = self.comments.nodes.iter().collect();
+        comments.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        out.push('\n');
+        let _ = writeln!(out, "Comments ({}):", comments.len());
+        for comment in comments {
+            let author = comment
+                .user
+                .as_ref()
+                .and_then(|u| u.display_name.clone())
+                .unwrap_or_else(|| "unknown".to_owned());
+            let comment_body = comment.body.as_deref().unwrap_or("");
+            let _ = writeln!(out, "[{author} @ {}]", comment.created_at);
+            let _ = writeln!(out, "{comment_body}");
+            let _ = writeln!(out, "---");
+        }
+
+        out
+    }
+}
+
+/// A user's best display name: prefer `name`, then `displayName`, then email.
+fn display_user(user: &User) -> Option<String> {
+    user.name
+        .clone()
+        .or_else(|| user.display_name.clone())
+        .or_else(|| user.email.clone())
+}
+
+/// Parse an RFC3339 timestamp into epoch seconds, or `None` if it does not parse.
+fn parse_epoch_seconds(timestamp: &str) -> Option<i64> {
+    let parsed = DateTime::parse_from_rfc3339(timestamp).ok()?;
+    Some(parsed.timestamp())
+}

--- a/packages/linear-export/src/lib.rs
+++ b/packages/linear-export/src/lib.rs
@@ -162,7 +162,7 @@ struct TeamMeta {
 
 /// One issue object from `issues.json`. Optional JSON fields use
 /// `#[serde(default)]` since this is an external schema, not runtime config.
-/// The exporter emits camelCase keys, mirrored here to snake_case fields.
+/// The exporter emits `camelCase` keys, mirrored here to `snake_case` fields.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct Issue {

--- a/packages/linear-export/tests/fixture.rs
+++ b/packages/linear-export/tests/fixture.rs
@@ -1,0 +1,188 @@
+//! Fixture-driven tests for the Linear export adapter.
+//!
+//! These run entirely against the synthetic, anonymized fixture under
+//! `tests/fixture/` and never touch the private production export.
+#![expect(
+    clippy::expect_used,
+    reason = "Test code: a failed expectation is a test failure"
+)]
+
+use std::path::PathBuf;
+
+use linear_export::LinearExport;
+use search_meta::{Document, Source, SourceAdapter, hash_body};
+use serde_json::Value;
+
+/// Path to the synthetic fixture directory shipped with this crate.
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixture")
+}
+
+/// Open the fixture and collect every document, failing the test on any error.
+fn collect_docs() -> Vec<Document> {
+    let export = LinearExport::open(&fixture_dir()).expect("open fixture export");
+    export
+        .documents()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("project all fixture issues into documents")
+}
+
+/// Read a metadata key as a JSON value, asserting it is present.
+fn meta<'a>(doc: &'a Document, key: &str) -> &'a Value {
+    doc.meta_json.get(key).expect("metadata key present")
+}
+
+/// Read a metadata key as a string, asserting presence and type.
+fn meta_str<'a>(doc: &'a Document, key: &str) -> &'a str {
+    meta(doc, key).as_str().expect("metadata value is a string")
+}
+
+/// The body decoded as UTF-8 text.
+fn body_text(doc: &Document) -> String {
+    String::from_utf8(doc.body.clone()).expect("utf8 body")
+}
+
+/// Look up a document by its issue identifier in the metadata.
+fn doc_for(docs: &[Document], identifier: &str) -> Document {
+    docs.iter()
+        .find(|d| d.meta_json.get("identifier").and_then(Value::as_str) == Some(identifier))
+        .cloned()
+        .expect("a document for the requested identifier")
+}
+
+/// The fixture has exactly four issues, so the adapter yields four documents.
+#[test]
+fn yields_one_document_per_issue() {
+    let docs = collect_docs();
+    assert_eq!(docs.len(), 4, "one document per fixture issue");
+}
+
+/// The adapter reports the Linear source and the team key from `metadata.json`.
+#[test]
+fn reports_source_and_team_key() {
+    let export = LinearExport::open(&fixture_dir()).expect("open fixture export");
+    assert_eq!(export.source(), Source::Linear);
+    assert_eq!(export.team_key(), "FIX");
+    assert_eq!(export.len(), 4);
+    assert!(!export.is_empty());
+}
+
+/// Every document's identity and common-envelope metadata are well formed.
+#[test]
+fn documents_have_stable_identity_and_envelope() {
+    for doc in collect_docs() {
+        assert!(
+            doc.external_id.starts_with("linear:issue:"),
+            "external_id is namespaced: {}",
+            doc.external_id
+        );
+        assert_eq!(doc.mime, "text/plain");
+
+        assert!(doc.meta_json.is_object(), "meta_json is a flat object");
+        assert_eq!(meta_str(&doc, "source"), "linear");
+        assert_eq!(meta_str(&doc, "external_id"), doc.external_id);
+        assert_eq!(meta_str(&doc, "content_hash"), doc.content_hash);
+        assert!(
+            doc.meta_json.get("state_type").is_some(),
+            "state_type present"
+        );
+        assert!(doc.meta_json.get("title").is_some());
+
+        // content_hash is the hash of the exact embedded bytes.
+        assert_eq!(doc.content_hash, hash_body(&doc.body));
+    }
+}
+
+/// FIX-1 links a `/pull/` attachment, so `has_pr` is true and `pr_urls` lists it.
+#[test]
+fn detects_pull_request_attachments() {
+    let docs = collect_docs();
+    let fix1 = doc_for(&docs, "FIX-1");
+    assert_eq!(meta(&fix1, "has_pr"), &Value::Bool(true));
+    let prs = meta(&fix1, "pr_urls").as_array().expect("pr_urls array");
+    assert_eq!(prs.len(), 1, "only the /pull/ url counts");
+    assert_eq!(
+        prs.first().and_then(Value::as_str),
+        Some("https://github.com/acme/repo/pull/42")
+    );
+
+    // A non-PR issue has has_pr=false and an empty pr_urls list.
+    let fix2 = doc_for(&docs, "FIX-2");
+    assert_eq!(meta(&fix2, "has_pr"), &Value::Bool(false));
+    assert!(meta(&fix2, "pr_urls").as_array().expect("array").is_empty());
+}
+
+/// Comments are rendered oldest-first even though the export is newest-first.
+#[test]
+fn comments_are_sorted_ascending() {
+    let docs = collect_docs();
+    let fix1 = doc_for(&docs, "FIX-1");
+    let body = body_text(&fix1);
+
+    assert!(body.contains("Comments (2):"), "comment count line present");
+    let first = body
+        .find("First comment in time")
+        .expect("first comment present");
+    let second = body
+        .find("Second comment in time")
+        .expect("second comment present");
+    assert!(
+        first < second,
+        "the chronologically earlier comment renders before the later one"
+    );
+    // A null comment author renders as "unknown" rather than panicking.
+    assert!(body.contains("[unknown @ "), "null comment user handled");
+}
+
+/// The archived issue is still indexed and flagged `is_archived`.
+#[test]
+fn archived_issue_is_indexed_and_flagged() {
+    let docs = collect_docs();
+    let fix2 = doc_for(&docs, "FIX-2");
+    assert_eq!(meta(&fix2, "is_archived"), &Value::Bool(true));
+    assert_eq!(meta_str(&fix2, "state_type"), "completed");
+    assert_eq!(meta_str(&fix2, "parent_identifier"), "FIX-1");
+
+    // Non-archived issues are flagged false.
+    let fix1 = doc_for(&docs, "FIX-1");
+    assert_eq!(meta(&fix1, "is_archived"), &Value::Bool(false));
+}
+
+/// A null assignee omits `assignee_email` and renders "unassigned" in the body.
+#[test]
+fn null_assignee_is_handled() {
+    let docs = collect_docs();
+    let fix3 = doc_for(&docs, "FIX-3");
+    assert!(
+        fix3.meta_json.get("assignee_email").is_none(),
+        "assignee_email omitted when there is no assignee"
+    );
+    assert!(body_text(&fix3).contains("Assignee: unassigned"));
+
+    // An assigned issue carries the email.
+    let fix1 = doc_for(&docs, "FIX-1");
+    assert_eq!(meta_str(&fix1, "assignee_email"), "alex@acme.test");
+}
+
+/// A null description renders the placeholder but the issue is still indexed.
+#[test]
+fn null_description_uses_placeholder() {
+    let docs = collect_docs();
+    let fix4 = doc_for(&docs, "FIX-4");
+    let body = body_text(&fix4);
+    assert!(body.contains("Description:\n(no description)"));
+    // A null creator renders as "unknown" rather than panicking.
+    assert!(body.contains("Created by unknown on "));
+}
+
+/// Re-running the adapter over the same export yields identical content hashes.
+#[test]
+fn content_hash_is_deterministic() {
+    let first = collect_docs();
+    let second = collect_docs();
+    assert_eq!(first.len(), second.len());
+    for (a, b) in first.iter().zip(second.iter()) {
+        assert_eq!(a.external_id, b.external_id);
+        assert_eq!(a.content_hash, b.content_hash, "stable hash across runs");
+    }
+}

--- a/packages/linear-export/tests/fixture/issues.json
+++ b/packages/linear-export/tests/fixture/issues.json
@@ -1,0 +1,206 @@
+[
+  {
+    "id": "aaaaaaaa-0000-0000-0000-000000000001",
+    "identifier": "FIX-1",
+    "number": 1,
+    "title": "First issue with comments and a PR",
+    "description": "This issue links a pull request and has two comments.",
+    "priority": 2,
+    "priorityLabel": "High",
+    "estimate": 3,
+    "url": "https://linear.app/acme/issue/FIX-1/first-issue-with-comments-and-a-pr",
+    "branchName": "alex/fix-1-first-issue",
+    "createdAt": "2026-01-02T10:00:00.000Z",
+    "updatedAt": "2026-01-03T12:30:00.000Z",
+    "startedAt": "2026-01-02T10:05:00.000Z",
+    "completedAt": null,
+    "canceledAt": null,
+    "archivedAt": null,
+    "dueDate": null,
+    "state": {
+      "id": "s1",
+      "name": "In Progress",
+      "type": "started",
+      "color": "#f2c94c"
+    },
+    "assignee": {
+      "id": "u-alex",
+      "name": "Alex",
+      "displayName": "alex",
+      "email": "alex@acme.test"
+    },
+    "creator": {
+      "id": "u-alex",
+      "name": "Alex",
+      "displayName": "alex",
+      "email": "alex@acme.test"
+    },
+    "labels": {
+      "nodes": [
+        { "id": "l-bug", "name": "bug", "color": "#eb5757" },
+        { "id": "l-stab", "name": "stability", "color": "#bec2c8" }
+      ]
+    },
+    "project": { "id": "p1", "name": "Launch" },
+    "projectMilestone": { "id": "m1", "name": "Beta" },
+    "cycle": { "id": "c1", "name": "Cycle 4", "number": 4 },
+    "parent": null,
+    "subscribers": { "nodes": [] },
+    "attachments": {
+      "nodes": [
+        {
+          "id": "a1",
+          "title": "First issue with comments and a PR",
+          "url": "https://github.com/acme/repo/pull/42",
+          "sourceType": "github"
+        },
+        {
+          "id": "a2",
+          "title": "Design doc",
+          "url": "https://docs.acme.test/design",
+          "sourceType": "link"
+        }
+      ]
+    },
+    "comments": {
+      "nodes": [
+        {
+          "id": "cmt-2",
+          "body": "Second comment in time, but first in the export array.",
+          "createdAt": "2026-01-03T11:00:00.000Z",
+          "updatedAt": "2026-01-03T11:00:00.000Z",
+          "user": { "id": "u-alex", "displayName": "alex", "email": "alex@acme.test" }
+        },
+        {
+          "id": "cmt-1",
+          "body": "First comment in time, last in the export array.",
+          "createdAt": "2026-01-02T15:00:00.000Z",
+          "updatedAt": "2026-01-02T15:00:00.000Z",
+          "user": null
+        }
+      ]
+    }
+  },
+  {
+    "id": "aaaaaaaa-0000-0000-0000-000000000002",
+    "identifier": "FIX-2",
+    "number": 2,
+    "title": "Archived issue",
+    "description": "An issue that has been archived.",
+    "priority": 0,
+    "priorityLabel": "No priority",
+    "estimate": null,
+    "url": "https://linear.app/acme/issue/FIX-2/archived-issue",
+    "branchName": "alex/fix-2-archived-issue",
+    "createdAt": "2025-12-01T10:00:00.000Z",
+    "updatedAt": "2025-12-10T10:00:00.000Z",
+    "startedAt": null,
+    "completedAt": "2025-12-09T10:00:00.000Z",
+    "canceledAt": null,
+    "archivedAt": "2025-12-10T10:00:00.000Z",
+    "dueDate": null,
+    "state": {
+      "id": "s2",
+      "name": "Done",
+      "type": "completed",
+      "color": "#5e6ad2"
+    },
+    "assignee": {
+      "id": "u-bo",
+      "name": "Bo",
+      "displayName": "bo",
+      "email": "bo@acme.test"
+    },
+    "creator": {
+      "id": "u-bo",
+      "name": "Bo",
+      "displayName": "bo",
+      "email": "bo@acme.test"
+    },
+    "labels": { "nodes": [] },
+    "project": null,
+    "projectMilestone": null,
+    "cycle": null,
+    "parent": { "id": "aaaaaaaa-0000-0000-0000-000000000001", "identifier": "FIX-1" },
+    "subscribers": { "nodes": [] },
+    "attachments": { "nodes": [] },
+    "comments": { "nodes": [] }
+  },
+  {
+    "id": "aaaaaaaa-0000-0000-0000-000000000003",
+    "identifier": "FIX-3",
+    "number": 3,
+    "title": "Unassigned issue",
+    "description": "Nobody is assigned to this one.",
+    "priority": 1,
+    "priorityLabel": "Urgent",
+    "estimate": 1.5,
+    "url": "https://linear.app/acme/issue/FIX-3/unassigned-issue",
+    "branchName": "fix-3-unassigned-issue",
+    "createdAt": "2026-01-04T10:00:00.000Z",
+    "updatedAt": "2026-01-04T10:00:00.000Z",
+    "startedAt": null,
+    "completedAt": null,
+    "canceledAt": null,
+    "archivedAt": null,
+    "dueDate": null,
+    "state": {
+      "id": "s3",
+      "name": "Triage",
+      "type": "backlog",
+      "color": "#95a2b3"
+    },
+    "assignee": null,
+    "creator": {
+      "id": "u-alex",
+      "name": "Alex",
+      "displayName": "alex",
+      "email": "alex@acme.test"
+    },
+    "labels": {
+      "nodes": [{ "id": "l-feat", "name": "feature", "color": "#0e8a16" }]
+    },
+    "project": null,
+    "projectMilestone": null,
+    "cycle": null,
+    "parent": null,
+    "subscribers": { "nodes": [] },
+    "attachments": { "nodes": [] },
+    "comments": { "nodes": [] }
+  },
+  {
+    "id": "aaaaaaaa-0000-0000-0000-000000000004",
+    "identifier": "FIX-4",
+    "number": 4,
+    "title": "Issue with no description",
+    "description": null,
+    "priority": 3,
+    "priorityLabel": "Medium",
+    "estimate": null,
+    "url": "https://linear.app/acme/issue/FIX-4/issue-with-no-description",
+    "branchName": "fix-4-issue-with-no-description",
+    "createdAt": "2026-01-05T10:00:00.000Z",
+    "updatedAt": "2026-01-06T10:00:00.000Z",
+    "startedAt": null,
+    "completedAt": null,
+    "canceledAt": "2026-01-06T10:00:00.000Z",
+    "archivedAt": null,
+    "dueDate": null,
+    "state": {
+      "id": "s4",
+      "name": "Won't do",
+      "type": "canceled",
+      "color": "#95a2b3"
+    },
+    "assignee": null,
+    "creator": null,
+    "labels": { "nodes": [] },
+    "project": null,
+    "projectMilestone": null,
+    "cycle": null,
+    "parent": null,
+    "subscribers": { "nodes": [] },
+    "attachments": { "nodes": [] },
+    "comments": { "nodes": [] }
+  }
+]

--- a/packages/linear-export/tests/fixture/metadata.json
+++ b/packages/linear-export/tests/fixture/metadata.json
@@ -1,0 +1,20 @@
+{
+  "exported_at": "2026-01-01T00:00:00.000000",
+  "source": "synthetic fixture for tests",
+  "organization": {
+    "name": "Acme",
+    "urlKey": "acme",
+    "id": "00000000-0000-0000-0000-000000000000"
+  },
+  "team": {
+    "key": "FIX",
+    "name": "Fixtures",
+    "id": "11111111-1111-1111-1111-111111111111"
+  },
+  "counts": {
+    "issues": 4,
+    "projects": 1,
+    "cycles": 1
+  },
+  "includes_archived": true
+}

--- a/packages/mixedbread/src/filter.rs
+++ b/packages/mixedbread/src/filter.rs
@@ -1,0 +1,215 @@
+//! Metadata filters for store search, grep, question-answering, and file
+//! listing.
+//!
+//! The wire shape mirrors the Mixedbread API's recursive filter: a leaf
+//! [`Condition`] (`{key, operator, value}`) or a [`Group`] combining nested
+//! filters with `all` (AND), `any` (OR), or `none` (NOT). The same `filters`
+//! field is accepted by `/v1/stores/search`, `/v1/stores/grep`,
+//! `/v1/stores/question-answering`, and the file-list endpoint, so one type
+//! serves them all.
+//!
+//! This type is serialize-only: the client sends filters but never parses them
+//! back. [`Filter`] is `#[serde(untagged)]` because a leaf and a group have
+//! disjoint key sets, so a serializer always emits the right shape.
+
+use serde::Serialize;
+
+/// A comparison operator on a metadata key.
+///
+/// Serializes to the exact lowercase tokens the API expects (`eq`, `not_eq`,
+/// `gt`, ...). The variant set matches the SDK's `SearchFilterCondition`
+/// operator union, which is the source of truth (the prose docs omit a few).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Operator {
+    /// Equal.
+    Eq,
+    /// Not equal.
+    NotEq,
+    /// Greater than.
+    Gt,
+    /// Greater than or equal.
+    Gte,
+    /// Less than.
+    Lt,
+    /// Less than or equal.
+    Lte,
+    /// Member of the given array.
+    In,
+    /// Not a member of the given array.
+    NotIn,
+    /// SQL-style `LIKE` match.
+    Like,
+    /// Negated SQL-style `LIKE` match.
+    NotLike,
+    /// Value starts with the given prefix.
+    StartsWith,
+    /// Regular-expression match.
+    Regex,
+}
+
+/// A single leaf condition: a metadata `key` compared to `value` by `operator`.
+#[derive(Debug, Clone, Serialize)]
+pub struct Condition {
+    /// Metadata key, dot-notated for nested fields (e.g. `generated_metadata.language`).
+    pub key: String,
+    /// Comparison operator.
+    pub operator: Operator,
+    /// Right-hand value: a scalar for most operators, an array for `in`/`not_in`.
+    pub value: serde_json::Value,
+}
+
+/// A logical group combining nested filters. Exactly one combinator is set in
+/// practice; all are optional so the wire shape carries only what is used.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct Group {
+    /// All nested filters must match (AND).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub all: Option<Vec<Filter>>,
+    /// At least one nested filter must match (OR).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub any: Option<Vec<Filter>>,
+    /// No nested filter may match (NOT).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub none: Option<Vec<Filter>>,
+}
+
+/// A metadata filter: either a leaf [`Condition`] or a nested [`Group`].
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum Filter {
+    /// A leaf comparison.
+    Condition(Condition),
+    /// A logical combination of nested filters.
+    Group(Group),
+}
+
+impl Filter {
+    /// A leaf condition `key <op> value`. `value` is anything serializable
+    /// (string, number, bool, or array for `in`/`not_in`).
+    #[must_use]
+    pub fn condition(key: impl Into<String>, operator: Operator, value: impl Into<serde_json::Value>) -> Self {
+        Self::Condition(Condition {
+            key: key.into(),
+            operator,
+            value: value.into(),
+        })
+    }
+
+    /// Shorthand for `key == value`.
+    #[must_use]
+    pub fn eq(key: impl Into<String>, value: impl Into<serde_json::Value>) -> Self {
+        Self::condition(key, Operator::Eq, value)
+    }
+
+    /// Shorthand for `key IN [values]`.
+    #[must_use]
+    pub fn any_of(key: impl Into<String>, values: impl Into<serde_json::Value>) -> Self {
+        Self::condition(key, Operator::In, values)
+    }
+
+    /// All of `filters` must match (AND).
+    #[must_use]
+    pub fn all(filters: Vec<Self>) -> Self {
+        Self::Group(Group {
+            all: Some(filters),
+            ..Group::default()
+        })
+    }
+
+    /// At least one of `filters` must match (OR).
+    #[must_use]
+    pub fn any(filters: Vec<Self>) -> Self {
+        Self::Group(Group {
+            any: Some(filters),
+            ..Group::default()
+        })
+    }
+
+    /// None of `filters` may match (NOT).
+    #[must_use]
+    pub fn none(filters: Vec<Self>) -> Self {
+        Self::Group(Group {
+            none: Some(filters),
+            ..Group::default()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Filter, Operator};
+
+    #[test]
+    fn operators_serialize_to_exact_lowercase_tokens() {
+        let cases = [
+            (Operator::Eq, "\"eq\""),
+            (Operator::NotEq, "\"not_eq\""),
+            (Operator::Gt, "\"gt\""),
+            (Operator::Gte, "\"gte\""),
+            (Operator::Lt, "\"lt\""),
+            (Operator::Lte, "\"lte\""),
+            (Operator::In, "\"in\""),
+            (Operator::NotIn, "\"not_in\""),
+            (Operator::Like, "\"like\""),
+            (Operator::NotLike, "\"not_like\""),
+            (Operator::StartsWith, "\"starts_with\""),
+            (Operator::Regex, "\"regex\""),
+        ];
+        for (op, expected) in cases {
+            assert_eq!(serde_json::to_string(&op).expect("serialize"), expected);
+        }
+    }
+
+    #[test]
+    fn leaf_condition_matches_documented_shape() {
+        let filter = Filter::eq("source", "code");
+        let value = serde_json::to_value(&filter).expect("serialize");
+        assert_eq!(
+            value,
+            serde_json::json!({ "key": "source", "operator": "eq", "value": "code" })
+        );
+    }
+
+    #[test]
+    fn nested_group_matches_documented_example() {
+        // Mirrors the docs example: status published AND (priority>=3 OR (category
+        // important AND reviewed true)). Asserts the exact all/any/none nesting.
+        let filter = Filter::all(vec![
+            Filter::eq("status", "published"),
+            Filter::any(vec![
+                Filter::condition("priority", Operator::Gte, 3),
+                Filter::all(vec![
+                    Filter::eq("category", "important"),
+                    Filter::eq("reviewed", true),
+                ]),
+            ]),
+        ]);
+        let value = serde_json::to_value(&filter).expect("serialize");
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "all": [
+                    { "key": "status", "operator": "eq", "value": "published" },
+                    { "any": [
+                        { "key": "priority", "operator": "gte", "value": 3 },
+                        { "all": [
+                            { "key": "category", "operator": "eq", "value": "important" },
+                            { "key": "reviewed", "operator": "eq", "value": true }
+                        ] }
+                    ] }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn none_excludes_a_source() {
+        let filter = Filter::none(vec![Filter::eq("source", "slack")]);
+        let value = serde_json::to_value(&filter).expect("serialize");
+        assert_eq!(
+            value,
+            serde_json::json!({ "none": [ { "key": "source", "operator": "eq", "value": "slack" } ] })
+        );
+    }
+}

--- a/packages/mixedbread/src/lib.rs
+++ b/packages/mixedbread/src/lib.rs
@@ -15,6 +15,9 @@ use serde::Deserialize;
 use snafu::{OptionExt as _, ResultExt as _, Snafu};
 
 pub mod auth;
+pub mod filter;
+
+pub use filter::{Condition, Filter, Group, Operator};
 
 /// Default API base URL.
 pub const DEFAULT_BASE_URL: &str = "https://api.mixedbread.com";
@@ -96,12 +99,23 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Search tuning forwarded to the API.
+///
+/// `score_threshold` and `return_metadata` are skipped when unset, so a caller
+/// that only sets `rerank`/`agentic` produces the same wire body as before.
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 pub struct SearchOptions {
     /// Apply the second-stage reranker.
     pub rerank: bool,
     /// Let the API plan and run multiple searches.
     pub agentic: bool,
+    /// Drop hits scoring below this threshold (`0.0..=1.0`). Used to keep a
+    /// low-relevance source from crowding a multi-source result list.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score_threshold: Option<f32>,
+    /// Ask the API to return each chunk's file metadata, so a result can be
+    /// mapped back to its source. Skipped when `None` (API default applies).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub return_metadata: Option<bool>,
 }
 
 /// A file as reported by the store's file listing.
@@ -234,13 +248,18 @@ impl Client {
     ///
     /// # Errors
     /// Returns an error if any page request fails or cannot be decoded.
-    pub async fn list_files(&self, store: &str) -> Result<Vec<StoredFile>> {
+    pub async fn list_files(
+        &self,
+        store: &str,
+        filters: Option<&filter::Filter>,
+    ) -> Result<Vec<StoredFile>> {
         let mut files = Vec::new();
         let mut after: Option<String> = None;
         loop {
             let request = ListRequest {
                 limit: 100,
                 after: after.as_deref(),
+                filters,
             };
             let resp = self
                 .http
@@ -275,7 +294,7 @@ impl Client {
     /// Returns an error if the listing fails.
     pub async fn list_external_ids(&self, store: &str) -> Result<HashSet<String>> {
         Ok(self
-            .list_files(store)
+            .list_files(store, None)
             .await?
             .into_iter()
             .filter_map(|file| file.external_id)
@@ -293,11 +312,12 @@ impl Client {
         content: Vec<u8>,
         file_name: &str,
         external_id: &str,
+        mime: &str,
         metadata: serde_json::Value,
     ) -> Result<()> {
         let part = reqwest::multipart::Part::bytes(content)
             .file_name(file_name.to_owned())
-            .mime_str("text/plain")
+            .mime_str(mime)
             .context(HttpSnafu)?;
         let form = reqwest::multipart::Form::new().part("file", part);
 
@@ -353,12 +373,14 @@ impl Client {
         query: &str,
         top_k: usize,
         options: SearchOptions,
+        filters: Option<&filter::Filter>,
     ) -> Result<Vec<Chunk>> {
         let request = SearchRequest {
             query,
             store_identifiers: stores,
             top_k,
             search_options: options,
+            filters,
         };
         let resp = self
             .http
@@ -391,6 +413,7 @@ impl Client {
         top_k: usize,
         case_sensitive: bool,
         targets: &[&str],
+        filters: Option<&filter::Filter>,
     ) -> Result<Vec<Chunk>> {
         let request = GrepRequest {
             store_identifiers: stores,
@@ -398,6 +421,7 @@ impl Client {
             top_k,
             case_sensitive,
             targets,
+            filters,
         };
         let resp = self
             .http
@@ -421,12 +445,14 @@ impl Client {
         query: &str,
         top_k: usize,
         options: SearchOptions,
+        filters: Option<&filter::Filter>,
     ) -> Result<AnswerResponse> {
         let request = SearchRequest {
             query,
             store_identifiers: stores,
             top_k,
             search_options: options,
+            filters,
         };
         let resp = self
             .http
@@ -489,6 +515,8 @@ struct ListRequest<'a> {
     limit: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     after: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    filters: Option<&'a filter::Filter>,
 }
 
 #[derive(Deserialize)]
@@ -534,6 +562,8 @@ struct SearchRequest<'a> {
     store_identifiers: &'a [String],
     top_k: usize,
     search_options: SearchOptions,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    filters: Option<&'a filter::Filter>,
 }
 
 #[derive(serde::Serialize)]
@@ -543,6 +573,8 @@ struct GrepRequest<'a> {
     top_k: usize,
     case_sensitive: bool,
     targets: &'a [&'a str],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    filters: Option<&'a filter::Filter>,
 }
 
 #[derive(Deserialize)]

--- a/packages/search-core/Cargo.toml
+++ b/packages/search-core/Cargo.toml
@@ -15,11 +15,13 @@ path = "src/lib.rs"
 [dependencies]
 dirs.workspace = true
 futures.workspace = true
+git2 = { workspace = true, default-features = false, features = ["vendored-libgit2"] }
 mixedbread.workspace = true
 rayon.workspace = true
 regex.workspace = true
 repo-walker.workspace = true
 rusqlite = { workspace = true, features = ["bundled"] }
+search-meta.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2.workspace = true

--- a/packages/search-core/src/adapter.rs
+++ b/packages/search-core/src/adapter.rs
@@ -1,16 +1,17 @@
 //! Adapter wiring the standalone [`mixedbread::Client`] to this crate's
-//! backend-agnostic [`Store`] trait. It does the only impedance matching
-//! needed: typed [`UploadMeta`] to JSON on the way in, and the client's
-//! [`mixedbread::Chunk`] to the domain [`SearchHit`] on the way out.
+//! backend-agnostic [`Store`] trait. It maps a [`Document`] to the client's
+//! upload call on the way in, and the client's [`mixedbread::Chunk`] to the
+//! domain [`SearchHit`] on the way out, reading the typed envelope's `source`
+//! and `content_hash` from each chunk's metadata.
 
-use std::collections::HashSet;
-
+use mixedbread::Filter;
+use search_meta::{Document, Source};
 use snafu::ResultExt as _;
 
 use crate::backend::{
-    Answer, GrepOptions, SearchHit, SearchOptions, Store, StoreStatus, UploadMeta,
+    Answer, GrepOptions, SearchHit, SearchOptions, StoreStatus, StoredRecord, Store,
 };
-use crate::error::{BackendSnafu, EncodeMetadataSnafu, Result};
+use crate::error::{BackendSnafu, Result};
 
 /// A [`Store`] backed by the Mixedbread API.
 #[derive(Debug, Clone)]
@@ -52,19 +53,32 @@ const fn to_client_options(options: SearchOptions) -> mixedbread::SearchOptions 
     mixedbread::SearchOptions {
         rerank: options.rerank,
         agentic: options.agentic,
+        score_threshold: None,
+        // Always request metadata so each hit's `source` and `content_hash` come
+        // back; the projection needs `source` to scope correctly.
+        return_metadata: Some(true),
     }
 }
 
 fn hit_from_chunk(chunk: mixedbread::Chunk) -> SearchHit {
-    let hash = metadata_str(chunk.metadata.as_ref(), "hash");
-    let path_meta = metadata_str(chunk.metadata.as_ref(), "path");
+    let metadata = chunk.metadata.as_ref();
+    // Legacy code records (uploaded before the typed envelope) carry `hash`/`path`
+    // and no `source`; the old store was code-only, so treat an absent source as
+    // Code. New records carry `source` and `content_hash`.
+    let source = metadata_str(metadata, search_meta::keys::SOURCE)
+        .and_then(|s| s.parse::<Source>().ok())
+        .unwrap_or(Source::Code);
+    let hash = metadata_str(metadata, search_meta::keys::CONTENT_HASH).or_else(|| metadata_str(metadata, "hash"));
+    // Code records carry `path`; record sources carry `title`. Either is the
+    // display label.
+    let path_meta = metadata_str(metadata, search_meta::keys::PATH)
+        .or_else(|| metadata_str(metadata, search_meta::keys::TITLE));
     // The mixedbread API reports `start_line` 1-based and `num_lines` as a line
     // span (end - start), so an N-line chunk arrives as (start=1, num=N-1). The
-    // rest of this crate (and the local backend) use a 0-based start and a line
-    // count, so normalize at this boundary: shift the start down by one and turn
-    // the span into a count. Without this the renderer drops the chunk's first
-    // line and empties single-line chunks, which then fall back to plain text.
+    // rest of this crate uses a 0-based start and a line count, so normalize at
+    // this boundary: shift the start down by one and turn the span into a count.
     SearchHit {
+        source,
         hash,
         path: path_meta.or(chunk.filename),
         text: chunk.text.unwrap_or_default(),
@@ -86,24 +100,44 @@ impl Store for MixedbreadStore {
         self.client.ensure_store(name).await.context(BackendSnafu)
     }
 
-    async fn list_external_ids(&self, store: &str) -> Result<HashSet<String>> {
+    async fn list_external_ids(&self, store: &str) -> Result<std::collections::HashSet<String>> {
         self.client
             .list_external_ids(store)
             .await
             .context(BackendSnafu)
     }
 
-    async fn upload(
+    async fn list_records(
         &self,
         store: &str,
-        content: Vec<u8>,
-        file_name: &str,
-        external_id: &str,
-        meta: UploadMeta,
-    ) -> Result<()> {
-        let metadata = serde_json::to_value(&meta).context(EncodeMetadataSnafu)?;
+        filters: Option<&Filter>,
+    ) -> Result<Vec<StoredRecord>> {
+        let files = self
+            .client
+            .list_files(store, filters)
+            .await
+            .context(BackendSnafu)?;
+        Ok(files
+            .into_iter()
+            .filter_map(|file| {
+                file.external_id.map(|external_id| StoredRecord {
+                    content_hash: metadata_str(file.metadata.as_ref(), search_meta::keys::CONTENT_HASH),
+                    external_id,
+                })
+            })
+            .collect())
+    }
+
+    async fn upload(&self, store: &str, document: Document) -> Result<()> {
         self.client
-            .upload_file(store, content, file_name, external_id, metadata)
+            .upload_file(
+                store,
+                document.body,
+                &document.file_name,
+                &document.external_id,
+                document.mime,
+                document.meta_json,
+            )
             .await
             .context(BackendSnafu)
     }
@@ -121,10 +155,11 @@ impl Store for MixedbreadStore {
         query: &str,
         top_k: usize,
         options: SearchOptions,
+        filters: Option<&Filter>,
     ) -> Result<Vec<SearchHit>> {
         let chunks = self
             .client
-            .search(stores, query, top_k, to_client_options(options))
+            .search(stores, query, top_k, to_client_options(options), filters)
             .await
             .context(BackendSnafu)?;
         Ok(chunks.into_iter().map(hit_from_chunk).collect())
@@ -136,6 +171,7 @@ impl Store for MixedbreadStore {
         pattern: &str,
         top_k: usize,
         options: GrepOptions,
+        filters: Option<&Filter>,
     ) -> Result<Vec<SearchHit>> {
         let chunks = self
             .client
@@ -145,6 +181,7 @@ impl Store for MixedbreadStore {
                 top_k,
                 options.case_sensitive,
                 options.targets.api_targets(),
+                filters,
             )
             .await
             .context(BackendSnafu)?;
@@ -157,10 +194,11 @@ impl Store for MixedbreadStore {
         query: &str,
         top_k: usize,
         options: SearchOptions,
+        filters: Option<&Filter>,
     ) -> Result<Answer> {
         let response = self
             .client
-            .ask(stores, query, top_k, to_client_options(options))
+            .ask(stores, query, top_k, to_client_options(options), filters)
             .await
             .context(BackendSnafu)?;
         Ok(Answer {
@@ -179,44 +217,5 @@ impl Store for MixedbreadStore {
             pending: status.pending,
             in_progress: status.in_progress,
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn chunk(start_line: Option<u32>, num_lines: Option<u32>) -> mixedbread::Chunk {
-        mixedbread::Chunk {
-            text: Some("body".to_owned()),
-            score: 0.5,
-            filename: Some("a.rs".to_owned()),
-            start_line,
-            num_lines,
-            metadata: None,
-        }
-    }
-
-    #[test]
-    fn normalizes_one_based_span_to_zero_based_count() {
-        // The API's (start=1, span=N-1) for an N-line chunk becomes the internal
-        // (start=0, count=N): a whole 6-line file reported as (1, 5).
-        let hit = hit_from_chunk(chunk(Some(1), Some(5)));
-        assert_eq!(hit.start_line, Some(0));
-        assert_eq!(hit.num_lines, Some(6));
-
-        // A single-line chunk arrives as (start=1, span=0) and must become a
-        // count of 1 line, not 0, so the renderer emits it instead of an empty
-        // window that falls back to plain text.
-        let single = hit_from_chunk(chunk(Some(1), Some(0)));
-        assert_eq!(single.start_line, Some(0));
-        assert_eq!(single.num_lines, Some(1));
-    }
-
-    #[test]
-    fn missing_line_metadata_stays_none() {
-        let hit = hit_from_chunk(chunk(None, None));
-        assert_eq!(hit.start_line, None);
-        assert_eq!(hit.num_lines, None);
     }
 }

--- a/packages/search-core/src/backend.rs
+++ b/packages/search-core/src/backend.rs
@@ -14,23 +14,12 @@ use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::sync::{Mutex, PoisonError};
 
+use mixedbread::{Condition, Filter, Operator};
 use regex::RegexBuilder;
-use snafu::ResultExt as _;
+use search_meta::{Document, Source};
+use snafu::{OptionExt as _, ResultExt as _};
 
-use crate::error::{InvalidPatternSnafu, Result};
-
-/// Metadata attached to every stored file.
-///
-/// The path is repo-relative so it is stable across worktrees; the hash equals
-/// the `external_id` and lets a search result be mapped back through the local
-/// manifest.
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct UploadMeta {
-    /// Repo-relative path, forward-slashed.
-    pub path: String,
-    /// Content hash, identical to the file's `external_id`.
-    pub hash: String,
-}
+use crate::error::{InvalidMetadataSnafu, InvalidPatternSnafu, Result};
 
 /// Knobs forwarded to the backend's search call.
 #[derive(Debug, Clone, Copy)]
@@ -63,8 +52,7 @@ pub enum GrepTargets {
 
 impl GrepTargets {
     /// The API target strings for this selection: `Text` maps to `["text"]`,
-    /// `Generated` maps to `["generated"]`. Returned as a borrowed slice of
-    /// static strings so it can be passed straight to the client's `grep` call.
+    /// `Generated` maps to `["generated"]`.
     #[must_use]
     pub const fn api_targets(self) -> &'static [&'static str] {
         match self {
@@ -77,10 +65,12 @@ impl GrepTargets {
 /// One scored chunk returned by a search.
 #[derive(Debug, Clone)]
 pub struct SearchHit {
-    /// Content hash from the stored metadata, when present. Absent for web
-    /// results.
+    /// Which corpus the hit came from.
+    pub source: Source,
+    /// Content hash from the stored metadata, when present. Code hits carry it
+    /// (it is the manifest key); web hits do not.
     pub hash: Option<String>,
-    /// Path or URL reported by the backend.
+    /// Path, title, or URL reported by the backend, for display.
     pub path: Option<String>,
     /// The matched text snippet.
     pub text: String,
@@ -111,17 +101,28 @@ pub struct StoreStatus {
     pub in_progress: u64,
 }
 
-/// A vector store that holds content-addressed files and answers searches.
+/// One record's identity and change-detection hash, as listed from the store
+/// during a per-source reconcile.
+#[derive(Debug, Clone)]
+pub struct StoredRecord {
+    /// The record's `external_id`.
+    pub external_id: String,
+    /// The `content_hash` stored in its metadata, when present. Absent means the
+    /// record predates content-hash tracking and must be treated as changed.
+    pub content_hash: Option<String>,
+}
+
+/// A vector store that holds documents and answers searches.
 pub trait Store {
     /// Ensure the named store exists, creating it if absent.
     ///
     /// # Errors
-    /// Returns an error if the backend cannot be reached or the store cannot
-    /// be created.
+    /// Returns an error if the backend cannot be reached or the store cannot be
+    /// created.
     fn ensure_store(&self, name: &str) -> impl Future<Output = Result<()>> + Send;
 
-    /// List the `external_id`s already present in the store. These are content
-    /// hashes; sync uploads only the ones missing from this set.
+    /// List the `external_id`s already present in the store. Used by the code
+    /// sync path, where the id is the content hash.
     ///
     /// # Errors
     /// Returns an error if the backend cannot be reached or returns an error
@@ -131,27 +132,34 @@ pub trait Store {
         store: &str,
     ) -> impl Future<Output = Result<HashSet<String>>> + Send;
 
-    /// Upload one file's content under the given `external_id` (its hash).
+    /// List records matching `filters` (typically `source == X`) with their
+    /// `content_hash`, for the per-source reconcile that decides what to
+    /// re-embed.
+    ///
+    /// # Errors
+    /// Returns an error if the backend cannot be reached or returns an error
+    /// status.
+    fn list_records(
+        &self,
+        store: &str,
+        filters: Option<&Filter>,
+    ) -> impl Future<Output = Result<Vec<StoredRecord>>> + Send;
+
+    /// Upload one document under its `external_id`.
     ///
     /// # Errors
     /// Returns an error if the upload fails at either the file or attach step.
-    fn upload(
-        &self,
-        store: &str,
-        content: Vec<u8>,
-        file_name: &str,
-        external_id: &str,
-        meta: UploadMeta,
-    ) -> impl Future<Output = Result<()>> + Send;
+    fn upload(&self, store: &str, document: Document) -> impl Future<Output = Result<()>> + Send;
 
-    /// Delete one file by `external_id`. Used only by an explicit garbage
-    /// collection pass, never by ordinary sync.
+    /// Delete one record by `external_id`. Used by an explicit garbage
+    /// collection pass, never by ordinary code sync.
     ///
     /// # Errors
     /// Returns an error if the delete request fails.
     fn delete(&self, store: &str, external_id: &str) -> impl Future<Output = Result<()>> + Send;
 
-    /// Search one or more stores for a query.
+    /// Search one or more stores for a query, optionally constrained by
+    /// metadata `filters`.
     ///
     /// # Errors
     /// Returns an error if the search request fails or the response cannot be
@@ -162,11 +170,11 @@ pub trait Store {
         query: &str,
         top_k: usize,
         options: SearchOptions,
+        filters: Option<&Filter>,
     ) -> impl Future<Output = Result<Vec<SearchHit>>> + Send;
 
     /// Grep one or more stores with a regular expression over the same chunks
-    /// search covers. `pattern` is the regex, `top_k` caps the matches, and
-    /// `options` carries case sensitivity and the matched target field.
+    /// search covers, optionally constrained by metadata `filters`.
     ///
     /// # Errors
     /// Returns an error if the pattern is not a valid regular expression, or if
@@ -177,9 +185,11 @@ pub trait Store {
         pattern: &str,
         top_k: usize,
         options: GrepOptions,
+        filters: Option<&Filter>,
     ) -> impl Future<Output = Result<Vec<SearchHit>>> + Send;
 
-    /// Ask a natural-language question against one or more stores.
+    /// Ask a natural-language question against one or more stores, optionally
+    /// constrained by metadata `filters`.
     ///
     /// # Errors
     /// Returns an error if the request fails or the response cannot be decoded.
@@ -189,6 +199,7 @@ pub trait Store {
         query: &str,
         top_k: usize,
         options: SearchOptions,
+        filters: Option<&Filter>,
     ) -> impl Future<Output = Result<Answer>> + Send;
 
     /// Fetch indexing progress for a store, used to wait until newly uploaded
@@ -201,9 +212,10 @@ pub trait Store {
 
 /// In-memory [`Store`] for tests.
 ///
-/// Keyed by `external_id` like the real store, so the dedup behavior (a
-/// repeated hash is a no-op) is exercised faithfully. It also counts upload
-/// calls so tests can assert nothing was re-uploaded.
+/// Keyed by `external_id` like the real store, so the dedup behavior (a repeated
+/// id is an overwrite) is exercised faithfully. It evaluates metadata filters
+/// and reports each hit's [`Source`], so the source-aware projection and filter
+/// wiring are testable with no network.
 #[derive(Debug, Default)]
 pub struct MemoryStore {
     inner: Mutex<Inner>,
@@ -211,14 +223,14 @@ pub struct MemoryStore {
 
 #[derive(Debug, Default)]
 struct Inner {
-    files: HashMap<String, StoredFile>,
+    files: HashMap<String, Stored>,
     upload_calls: usize,
 }
 
 #[derive(Debug)]
-struct StoredFile {
-    content: Vec<u8>,
-    meta: UploadMeta,
+struct Stored {
+    document: Document,
+    source: Source,
 }
 
 impl MemoryStore {
@@ -239,17 +251,29 @@ impl MemoryStore {
         self.lock().upload_calls
     }
 
-    /// How many distinct files are stored.
+    /// How many distinct records are stored.
     #[must_use]
     pub fn len(&self) -> usize {
         self.lock().files.len()
     }
 
-    /// Whether the store holds no files.
+    /// Whether the store holds no records.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.lock().files.is_empty()
     }
+}
+
+fn source_of(document: &Document) -> Result<Source> {
+    document
+        .meta_json
+        .get(search_meta::keys::SOURCE)
+        .and_then(serde_json::Value::as_str)
+        .and_then(|s| s.parse::<Source>().ok())
+        .context(InvalidMetadataSnafu {
+            external_id: document.external_id.clone(),
+            key: search_meta::keys::SOURCE,
+        })
 }
 
 impl Store for MemoryStore {
@@ -261,19 +285,32 @@ impl Store for MemoryStore {
         Ok(self.lock().files.keys().cloned().collect())
     }
 
-    async fn upload(
+    async fn list_records(
         &self,
         _store: &str,
-        content: Vec<u8>,
-        _file_name: &str,
-        external_id: &str,
-        meta: UploadMeta,
-    ) -> Result<()> {
+        filters: Option<&Filter>,
+    ) -> Result<Vec<StoredRecord>> {
+        let inner = self.lock();
+        let records = inner
+            .files
+            .values()
+            .filter(|stored| filters.is_none_or(|f| matches_filter(&stored.document.meta_json, f)))
+            .map(|stored| StoredRecord {
+                external_id: stored.document.external_id.clone(),
+                content_hash: Some(stored.document.content_hash.clone()),
+            })
+            .collect();
+        drop(inner);
+        Ok(records)
+    }
+
+    async fn upload(&self, _store: &str, document: Document) -> Result<()> {
+        let source = source_of(&document)?;
         let mut inner = self.lock();
         inner.upload_calls += 1;
         inner
             .files
-            .insert(external_id.to_owned(), StoredFile { content, meta });
+            .insert(document.external_id.clone(), Stored { document, source });
         drop(inner);
         Ok(())
     }
@@ -289,33 +326,10 @@ impl Store for MemoryStore {
         query: &str,
         top_k: usize,
         _options: SearchOptions,
+        filters: Option<&Filter>,
     ) -> Result<Vec<SearchHit>> {
         let needle = query.to_lowercase();
-        let inner = self.lock();
-        let mut hits = Vec::new();
-        for file in inner.files.values() {
-            let text = String::from_utf8_lossy(&file.content);
-            for (index, line) in text.lines().enumerate() {
-                if line.to_lowercase().contains(&needle) {
-                    hits.push(SearchHit {
-                        hash: Some(file.meta.hash.clone()),
-                        path: Some(file.meta.path.clone()),
-                        text: line.to_owned(),
-                        score: 1.0,
-                        start_line: u32::try_from(index).ok(),
-                        num_lines: Some(1),
-                    });
-                }
-                if hits.len() >= top_k {
-                    break;
-                }
-            }
-            if hits.len() >= top_k {
-                break;
-            }
-        }
-        drop(inner);
-        Ok(hits)
+        Ok(self.scan(top_k, filters, |line| line.to_lowercase().contains(&needle)))
     }
 
     async fn grep(
@@ -324,6 +338,7 @@ impl Store for MemoryStore {
         pattern: &str,
         top_k: usize,
         options: GrepOptions,
+        filters: Option<&Filter>,
     ) -> Result<Vec<SearchHit>> {
         let regex = RegexBuilder::new(pattern)
             .case_insensitive(!options.case_sensitive)
@@ -331,32 +346,7 @@ impl Store for MemoryStore {
             .with_context(|_| InvalidPatternSnafu {
                 pattern: pattern.to_owned(),
             })?;
-
-        let inner = self.lock();
-        let mut hits = Vec::new();
-        for file in inner.files.values() {
-            let text = String::from_utf8_lossy(&file.content);
-            for (index, line) in text.lines().enumerate() {
-                if regex.is_match(line) {
-                    hits.push(SearchHit {
-                        hash: Some(file.meta.hash.clone()),
-                        path: Some(file.meta.path.clone()),
-                        text: line.to_owned(),
-                        score: 1.0,
-                        start_line: u32::try_from(index).ok(),
-                        num_lines: Some(1),
-                    });
-                }
-                if hits.len() >= top_k {
-                    break;
-                }
-            }
-            if hits.len() >= top_k {
-                break;
-            }
-        }
-        drop(inner);
-        Ok(hits)
+        Ok(self.scan(top_k, filters, |line| regex.is_match(line)))
     }
 
     async fn ask(
@@ -365,8 +355,9 @@ impl Store for MemoryStore {
         query: &str,
         top_k: usize,
         options: SearchOptions,
+        filters: Option<&Filter>,
     ) -> Result<Answer> {
-        let sources = self.search(stores, query, top_k, options).await?;
+        let sources = self.search(stores, query, top_k, options, filters).await?;
         Ok(Answer {
             answer: "mock answer from MemoryStore".to_owned(),
             sources,
@@ -374,10 +365,102 @@ impl Store for MemoryStore {
     }
 
     async fn store_status(&self, _store: &str) -> Result<StoreStatus> {
-        // In-memory uploads are immediately "indexed".
         Ok(StoreStatus {
             pending: 0,
             in_progress: 0,
         })
     }
+}
+
+impl MemoryStore {
+    /// Shared line scan for search and grep: match each stored record's body
+    /// lines with `line_matches`, honoring the metadata `filters`, and report
+    /// each hit with its source and content hash.
+    fn scan(
+        &self,
+        top_k: usize,
+        filters: Option<&Filter>,
+        line_matches: impl Fn(&str) -> bool,
+    ) -> Vec<SearchHit> {
+        let inner = self.lock();
+        let mut hits = Vec::new();
+        for stored in inner.files.values() {
+            if !filters.is_none_or(|f| matches_filter(&stored.document.meta_json, f)) {
+                continue;
+            }
+            let text = String::from_utf8_lossy(&stored.document.body);
+            for (index, line) in text.lines().enumerate() {
+                if hits.len() >= top_k {
+                    break;
+                }
+                if line_matches(line) {
+                    hits.push(SearchHit {
+                        source: stored.source,
+                        hash: Some(stored.document.content_hash.clone()),
+                        path: stored
+                            .document
+                            .meta_json
+                            .get(search_meta::keys::PATH)
+                            .and_then(serde_json::Value::as_str)
+                            .map(str::to_owned),
+                        text: line.to_owned(),
+                        score: 1.0,
+                        start_line: u32::try_from(index).ok(),
+                        num_lines: Some(1),
+                    });
+                }
+            }
+            if hits.len() >= top_k {
+                break;
+            }
+        }
+        drop(inner);
+        hits
+    }
+}
+
+/// Evaluate a metadata filter against a flat metadata object. Covers the
+/// operators the offline test double needs; comparison operators it does not
+/// model evaluate to `false` so a test never silently passes on an unsupported
+/// shape.
+fn matches_filter(meta: &serde_json::Value, filter: &Filter) -> bool {
+    match filter {
+        Filter::Condition(condition) => matches_condition(meta, condition),
+        Filter::Group(group) => {
+            group.all.as_ref().is_none_or(|fs| fs.iter().all(|f| matches_filter(meta, f)))
+                && group.any.as_ref().is_none_or(|fs| fs.iter().any(|f| matches_filter(meta, f)))
+                && group
+                    .none
+                    .as_ref()
+                    .is_none_or(|fs| !fs.iter().any(|f| matches_filter(meta, f)))
+        }
+    }
+}
+
+fn matches_condition(meta: &serde_json::Value, condition: &Condition) -> bool {
+    let actual = meta.get(&condition.key);
+    match condition.operator {
+        Operator::Eq => actual == Some(&condition.value),
+        Operator::NotEq => actual != Some(&condition.value),
+        Operator::In => json_contains(&condition.value, actual),
+        Operator::NotIn => !json_contains(&condition.value, actual),
+        Operator::StartsWith => match (actual.and_then(serde_json::Value::as_str), condition.value.as_str()) {
+            (Some(value), Some(prefix)) => value.starts_with(prefix),
+            _ => false,
+        },
+        Operator::Like => match (actual.and_then(serde_json::Value::as_str), condition.value.as_str()) {
+            (Some(value), Some(needle)) => value.contains(needle),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+/// Whether `needle` (the actual metadata value) is an element of `haystack`
+/// (the filter's array value), or equals it when `haystack` is a scalar.
+fn json_contains(haystack: &serde_json::Value, needle: Option<&serde_json::Value>) -> bool {
+    let Some(needle) = needle else { return false };
+    haystack
+        .as_array()
+        .map_or_else(|| haystack == needle, |items| items.iter().any(|item| item == needle))
 }

--- a/packages/search-core/src/backend.rs
+++ b/packages/search-core/src/backend.rs
@@ -397,10 +397,12 @@ impl MemoryStore {
                     hits.push(SearchHit {
                         source: stored.source,
                         hash: Some(stored.document.content_hash.clone()),
+                        // Code records label by `path`; record sources by `title`.
                         path: stored
                             .document
                             .meta_json
                             .get(search_meta::keys::PATH)
+                            .or_else(|| stored.document.meta_json.get(search_meta::keys::TITLE))
                             .and_then(serde_json::Value::as_str)
                             .map(str::to_owned),
                         text: line.to_owned(),

--- a/packages/search-core/src/error.rs
+++ b/packages/search-core/src/error.rs
@@ -85,6 +85,29 @@ pub enum Error {
         source: serde_json::Error,
     },
 
+    /// A stored or built document had missing or malformed metadata.
+    #[snafu(display("document {external_id} has invalid metadata: missing or bad key {key:?}"))]
+    InvalidMetadata {
+        /// The record whose metadata was invalid.
+        external_id: String,
+        /// The metadata key that was missing or unparseable.
+        key: &'static str,
+    },
+
+    /// A document's metadata exceeded the store's size or key limits.
+    #[snafu(display("metadata limit exceeded: {source}"))]
+    MetadataLimit {
+        /// Underlying limit error.
+        source: search_meta::MetadataError,
+    },
+
+    /// A source adapter failed while producing a document.
+    #[snafu(display("source adapter failed: {message}"))]
+    Adapter {
+        /// The adapter's error, rendered.
+        message: String,
+    },
+
     /// The storage backend (Mixedbread client) returned an error.
     #[snafu(display("storage backend error: {source}"))]
     Backend {

--- a/packages/search-core/src/lib.rs
+++ b/packages/search-core/src/lib.rs
@@ -28,13 +28,15 @@ mod db;
 mod error;
 mod manifest;
 mod pipeline;
+mod query_filter;
+mod repo;
 mod search;
 mod sync;
 
 pub use adapter::MixedbreadStore;
 pub use backend::{
     Answer, GrepOptions, GrepTargets, MemoryStore, SearchHit, SearchOptions, Store, StoreStatus,
-    UploadMeta,
+    StoredRecord,
 };
 pub use config::{Config, DEFAULT_STORE, WEB_STORE};
 pub use content::ContentHash;
@@ -42,5 +44,12 @@ pub use db::{Db, db_path};
 pub use error::{Error, Result};
 pub use manifest::{FileEntry, Manifest};
 pub use pipeline::{Query, index_and_answer, index_and_grep, index_and_semantic};
-pub use search::{AnswerView, DisplayHit, ask, grep, semantic};
+pub use query_filter::{FilterSpec, build_filter};
+pub use repo::repo_slug;
+pub use search::{AnswerView, CodeScope, DisplayHit, ask, grep, semantic};
 pub use sync::{SyncReport, sync, wait_until_indexed};
+
+// Re-export the shared metadata and filter types so binaries depend only on
+// search-core.
+pub use mixedbread::{Condition, Filter, Group, Operator};
+pub use search_meta::{Document, RepoSlug, Source, SourceAdapter};

--- a/packages/search-core/src/lib.rs
+++ b/packages/search-core/src/lib.rs
@@ -47,7 +47,7 @@ pub use pipeline::{Query, index_and_answer, index_and_grep, index_and_semantic};
 pub use query_filter::{FilterSpec, build_filter};
 pub use repo::repo_slug;
 pub use search::{AnswerView, CodeScope, DisplayHit, ask, grep, semantic};
-pub use sync::{SyncReport, sync, wait_until_indexed};
+pub use sync::{GcReport, SyncReport, gc_documents, sync, sync_documents, wait_until_indexed};
 
 // Re-export the shared metadata and filter types so binaries depend only on
 // search-core.

--- a/packages/search-core/src/pipeline.rs
+++ b/packages/search-core/src/pipeline.rs
@@ -5,12 +5,15 @@
 use std::path::Path;
 use std::time::Duration;
 
+use mixedbread::Filter;
+
 use crate::backend::{GrepOptions, SearchOptions, Store, StoreStatus};
 use crate::config::Config;
 use crate::db::Db;
 use crate::error::Result;
 use crate::manifest::Manifest;
-use crate::search::{AnswerView, DisplayHit, ask, grep, semantic};
+use crate::repo::repo_slug;
+use crate::search::{AnswerView, CodeScope, DisplayHit, ask, grep, semantic};
 use crate::sync::{sync, wait_until_indexed};
 
 /// What to query and how, independent of the backend and progress reporting.
@@ -31,6 +34,12 @@ pub struct Query<'a> {
     pub sync: bool,
     /// Mix in web results.
     pub include_web: bool,
+    /// Metadata filter applied server-side (source/repo/channel/...). `None`
+    /// means all sources.
+    pub filters: Option<&'a Filter>,
+    /// How code hits are scoped: worktree-exact (manifest intersection) or
+    /// server-filtered (a repo / all-repos query).
+    pub code_scope: CodeScope,
     /// How long to wait for new files to embed before querying anyway.
     pub index_timeout: Duration,
 }
@@ -56,11 +65,13 @@ async fn prepare(
     };
 
     if query.sync {
+        let repo = repo_slug(query.root);
         let report = sync(
             store,
             query.store_name,
             query.root,
             &manifest,
+            &repo,
             config.max_files,
             on_upload,
         )
@@ -94,6 +105,8 @@ pub async fn index_and_semantic(
         query.top_k,
         query.options,
         query.include_web,
+        query.filters,
+        query.code_scope,
     )
     .await
 }
@@ -123,6 +136,8 @@ pub async fn index_and_grep(
         query.text,
         query.top_k,
         options,
+        query.filters,
+        query.code_scope,
     )
     .await
 }
@@ -148,6 +163,8 @@ pub async fn index_and_answer(
         query.top_k,
         query.options,
         query.include_web,
+        query.filters,
+        query.code_scope,
     )
     .await
 }

--- a/packages/search-core/src/query_filter.rs
+++ b/packages/search-core/src/query_filter.rs
@@ -21,7 +21,7 @@ pub struct FilterSpec {
 impl FilterSpec {
     /// Whether any selector is set.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.sources.is_empty() && self.exclude_sources.is_empty() && self.repo.is_none()
     }
 }

--- a/packages/search-core/src/query_filter.rs
+++ b/packages/search-core/src/query_filter.rs
@@ -1,0 +1,114 @@
+//! Building a server-side metadata [`Filter`] from a query's scope selectors.
+//!
+//! One builder, shared by the CLI, the Python binding, and the MCP tool, so the
+//! mapping from "the user asked for these sources, this repo" to the wire filter
+//! lives in exactly one place.
+
+use mixedbread::Filter;
+use search_meta::{Source, keys};
+
+/// The scope selectors a caller can apply, before they become a [`Filter`].
+#[derive(Debug, Default, Clone)]
+pub struct FilterSpec {
+    /// Restrict to these sources. Empty means all sources.
+    pub sources: Vec<Source>,
+    /// Exclude these sources.
+    pub exclude_sources: Vec<Source>,
+    /// Restrict code to this repository slug.
+    pub repo: Option<String>,
+}
+
+impl FilterSpec {
+    /// Whether any selector is set.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.sources.is_empty() && self.exclude_sources.is_empty() && self.repo.is_none()
+    }
+}
+
+/// Build the metadata filter for a [`FilterSpec`], or `None` when nothing is
+/// constrained (search all sources).
+#[must_use]
+pub fn build_filter(spec: &FilterSpec) -> Option<Filter> {
+    let mut clauses = Vec::new();
+
+    if !spec.sources.is_empty() {
+        let values: Vec<serde_json::Value> =
+            spec.sources.iter().map(|s| s.as_str().into()).collect();
+        clauses.push(Filter::any_of(keys::SOURCE, serde_json::Value::Array(values)));
+    }
+    if !spec.exclude_sources.is_empty() {
+        let excluded: Vec<Filter> = spec
+            .exclude_sources
+            .iter()
+            .map(|s| Filter::eq(keys::SOURCE, s.as_str()))
+            .collect();
+        clauses.push(Filter::none(excluded));
+    }
+    if let Some(repo) = &spec.repo {
+        clauses.push(Filter::eq(keys::REPO, repo.clone()));
+    }
+
+    match clauses.len() {
+        0 => None,
+        1 => clauses.pop(),
+        _ => Some(Filter::all(clauses)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FilterSpec, build_filter};
+    use search_meta::Source;
+
+    #[test]
+    fn empty_spec_builds_no_filter() {
+        assert!(build_filter(&FilterSpec::default()).is_none());
+    }
+
+    #[test]
+    fn single_source_builds_an_in_filter() {
+        let spec = FilterSpec {
+            sources: vec![Source::Slack],
+            ..FilterSpec::default()
+        };
+        let filter = build_filter(&spec).expect("filter");
+        let value = serde_json::to_value(&filter).expect("ser");
+        assert_eq!(
+            value,
+            serde_json::json!({ "key": "source", "operator": "in", "value": ["slack"] })
+        );
+    }
+
+    #[test]
+    fn exclude_builds_a_none_filter() {
+        let spec = FilterSpec {
+            exclude_sources: vec![Source::Slack],
+            ..FilterSpec::default()
+        };
+        let filter = build_filter(&spec).expect("filter");
+        let value = serde_json::to_value(&filter).expect("ser");
+        assert_eq!(
+            value,
+            serde_json::json!({ "none": [ { "key": "source", "operator": "eq", "value": "slack" } ] })
+        );
+    }
+
+    #[test]
+    fn source_and_repo_combine_under_all() {
+        let spec = FilterSpec {
+            sources: vec![Source::Code],
+            repo: Some("indexable-inc/index".to_owned()),
+            ..FilterSpec::default()
+        };
+        let filter = build_filter(&spec).expect("filter");
+        let value = serde_json::to_value(&filter).expect("ser");
+        assert_eq!(
+            value,
+            serde_json::json!({ "all": [
+                { "key": "source", "operator": "in", "value": ["code"] },
+                { "key": "repo", "operator": "eq", "value": "indexable-inc/index" }
+            ] })
+        );
+    }
+}

--- a/packages/search-core/src/repo.rs
+++ b/packages/search-core/src/repo.rs
@@ -1,0 +1,86 @@
+//! Repository identity for code records.
+//!
+//! Cross-repo vs single-repo scoping needs a stable name per checkout. We derive
+//! it from the `origin` remote (so every worktree of one repo shares a slug like
+//! `indexable-inc/index`) and fall back to the checkout's directory name when
+//! there is no remote. The fallback is observable as [`RepoSlug::Local`], never a
+//! silent empty string.
+
+use std::path::Path;
+
+use search_meta::RepoSlug;
+
+/// Resolve the repository slug for the checkout rooted at `root`.
+///
+/// Uses the `origin` remote URL when present (any worktree resolves to the same
+/// slug), otherwise the directory name.
+#[must_use]
+pub fn repo_slug(root: &Path) -> RepoSlug {
+    if let Some(slug) = origin_slug(root) {
+        return RepoSlug::Remote(slug);
+    }
+    let name = root
+        .file_name()
+        .map_or_else(|| root.to_string_lossy().into_owned(), |n| n.to_string_lossy().into_owned());
+    RepoSlug::Local(name)
+}
+
+fn origin_slug(root: &Path) -> Option<String> {
+    let repo = git2::Repository::discover(root).ok()?;
+    let remote = repo.find_remote("origin").ok()?;
+    slug_from_url(remote.url()?)
+}
+
+/// Extract `owner/repo` from a git remote URL, dropping a trailing `.git`.
+///
+/// Handles both `https://host/owner/repo(.git)` and `git@host:owner/repo(.git)`.
+fn slug_from_url(url: &str) -> Option<String> {
+    // Split off the host: everything after the last ':' (scp form) or the path
+    // after the host in URL form. Normalizing both to a '/'-joined path tail.
+    let after_host = url
+        .rsplit_once("://")
+        .map_or(url, |(_, rest)| rest)
+        .split_once('/')
+        .map_or_else(
+            || url.rsplit_once(':').map_or(url, |(_, rest)| rest),
+            |(_, path)| path,
+        );
+    let trimmed = after_host.trim_end_matches('/').strip_suffix(".git").unwrap_or_else(|| after_host.trim_end_matches('/'));
+    let mut segments: Vec<&str> = trimmed.split('/').filter(|s| !s.is_empty()).collect();
+    if segments.len() < 2 {
+        return None;
+    }
+    let repo = segments.pop()?;
+    let owner = segments.pop()?;
+    Some(format!("{owner}/{repo}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::slug_from_url;
+
+    #[test]
+    fn https_url() {
+        assert_eq!(
+            slug_from_url("https://github.com/indexable-inc/index.git").as_deref(),
+            Some("indexable-inc/index")
+        );
+        assert_eq!(
+            slug_from_url("https://github.com/indexable-inc/index").as_deref(),
+            Some("indexable-inc/index")
+        );
+    }
+
+    #[test]
+    fn scp_url() {
+        assert_eq!(
+            slug_from_url("git@github.com:indexable-inc/index.git").as_deref(),
+            Some("indexable-inc/index")
+        );
+    }
+
+    #[test]
+    fn too_short_is_none() {
+        assert_eq!(slug_from_url("https://example.com/justone"), None);
+    }
+}

--- a/packages/search-core/src/repo.rs
+++ b/packages/search-core/src/repo.rs
@@ -35,23 +35,18 @@ fn origin_slug(root: &Path) -> Option<String> {
 ///
 /// Handles both `https://host/owner/repo(.git)` and `git@host:owner/repo(.git)`.
 fn slug_from_url(url: &str) -> Option<String> {
-    // Split off the host: everything after the last ':' (scp form) or the path
-    // after the host in URL form. Normalizing both to a '/'-joined path tail.
-    let after_host = url
-        .rsplit_once("://")
-        .map_or(url, |(_, rest)| rest)
-        .split_once('/')
-        .map_or_else(
-            || url.rsplit_once(':').map_or(url, |(_, rest)| rest),
-            |(_, path)| path,
-        );
-    let trimmed = after_host.trim_end_matches('/').strip_suffix(".git").unwrap_or_else(|| after_host.trim_end_matches('/'));
-    let mut segments: Vec<&str> = trimmed.split('/').filter(|s| !s.is_empty()).collect();
-    if segments.len() < 2 {
-        return None;
-    }
-    let repo = segments.pop()?;
-    let owner = segments.pop()?;
+    let url = url.trim();
+    let url = url.strip_suffix(".git").unwrap_or(url);
+    // Reduce to the path after the host. The URL form `scheme://host/owner/repo`
+    // drops the leading host segment; the scp form `user@host:owner/repo` takes
+    // the part after the colon.
+    let path = match url.split_once("://") {
+        Some((_, after)) => after.split_once('/').map(|(_, path)| path)?,
+        None => url.split_once(':').map_or(url, |(_, after)| after),
+    };
+    let mut segments = path.rsplit('/').filter(|segment| !segment.is_empty());
+    let repo = segments.next()?;
+    let owner = segments.next()?;
     Some(format!("{owner}/{repo}"))
 }
 

--- a/packages/search-core/src/search.rs
+++ b/packages/search-core/src/search.rs
@@ -1,19 +1,33 @@
-//! Search orchestration. The backend stores one shared entry per unique blob,
-//! so a raw result set can include content from other worktrees or branches.
-//! We over-fetch, then keep only hits whose content hash is in this checkout's
-//! manifest, mapping each back to its local path. Web results (no hash) pass
-//! through when the caller asked for them.
+//! Search orchestration and projection onto displayable hits.
+//!
+//! The backend holds one shared entry per unique record across every source. A
+//! raw result set can therefore include code from other worktrees. Projection
+//! decides what survives, per source:
+//!
+//! - **Code** in worktree-exact scope is kept only when its content hash is in
+//!   this checkout's manifest, then mapped back to the local path. In a coarser
+//!   scope (a repo or all-repos filter), the server filter already decided, so
+//!   code passes through labeled by its stored path.
+//! - **Slack / Linear** records have no checkout; the server-side metadata filter
+//!   is authoritative, so they always pass through (an absent manifest hash is
+//!   not a reason to drop them).
+//! - **Web** results pass through only when the caller asked for them.
+
+use mixedbread::Filter;
+use search_meta::Source;
 
 use crate::backend::{GrepOptions, SearchHit, SearchOptions, Store};
 use crate::config::WEB_STORE;
 use crate::error::Result;
 use crate::manifest::Manifest;
 
-/// A search result projected onto the current checkout.
+/// A search result projected for display.
 #[derive(Debug, Clone)]
 pub struct DisplayHit {
-    /// Repo-relative path, or a URL for a web result.
+    /// Repo-relative path, record title, or a URL for a web result.
     pub label: String,
+    /// Which corpus the hit came from.
+    pub source: Source,
     /// Zero-based start line within the file, when known.
     pub start_line: Option<u32>,
     /// Number of lines in the chunk (a count, not a span), when known.
@@ -22,11 +36,9 @@ pub struct DisplayHit {
     pub score: f32,
     /// Matched snippet text.
     pub text: String,
-    /// Whether this came from the web store rather than the local checkout.
-    pub is_web: bool,
 }
 
-/// A question-answering result projected onto the current checkout.
+/// A question-answering result projected for display.
 #[derive(Debug, Clone)]
 pub struct AnswerView {
     /// The synthesized answer.
@@ -35,11 +47,22 @@ pub struct AnswerView {
     pub sources: Vec<DisplayHit>,
 }
 
-/// Search `store_name` (and optionally the web store) and return only hits
-/// present in this checkout, newest-relevance first, capped at `top_k`.
+/// How code hits are scoped. Record sources are always scoped by the server-side
+/// metadata filter, so this only governs code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodeScope {
+    /// Keep only code whose content hash is in this checkout's manifest.
+    WorktreeExact,
+    /// Trust the server-side filter (a repo or all-repos query); do not intersect
+    /// with the manifest.
+    ServerFiltered,
+}
+
+/// Search `store_name` (and optionally the web store) and project the hits.
 ///
 /// # Errors
 /// Returns an error if the backend search request fails.
+#[allow(clippy::too_many_arguments, reason = "thin pass-through of the query surface")]
 pub async fn semantic(
     store: &(impl Store + Sync),
     store_name: &str,
@@ -48,24 +71,22 @@ pub async fn semantic(
     top_k: usize,
     options: SearchOptions,
     include_web: bool,
+    filters: Option<&Filter>,
+    code_scope: CodeScope,
 ) -> Result<Vec<DisplayHit>> {
     let stores = store_identifiers(store_name, include_web);
     let hits = store
-        .search(&stores, query, overfetch(top_k), options)
+        .search(&stores, query, overfetch(top_k), options, filters)
         .await?;
-    Ok(project(manifest, hits, include_web, top_k))
+    Ok(project(manifest, hits, include_web, top_k, code_scope))
 }
 
-/// Grep `store_name` with a regular expression, scoped to this checkout.
-///
-/// Runs the pattern over the same chunks [`semantic`] searches, returning only
-/// hits present in this checkout, capped at `top_k`. Grep is local-corpus only:
-/// the web store is never queried, so the projection runs with `include_web`
-/// false.
+/// Grep `store_name` with a regular expression and project the hits.
 ///
 /// # Errors
 /// Returns an error if the pattern is not a valid regular expression or the
 /// backend grep request fails.
+#[allow(clippy::too_many_arguments, reason = "thin pass-through of the query surface")]
 pub async fn grep(
     store: &(impl Store + Sync),
     store_name: &str,
@@ -73,18 +94,21 @@ pub async fn grep(
     pattern: &str,
     top_k: usize,
     options: GrepOptions,
+    filters: Option<&Filter>,
+    code_scope: CodeScope,
 ) -> Result<Vec<DisplayHit>> {
     let stores = store_identifiers(store_name, false);
     let hits = store
-        .grep(&stores, pattern, overfetch(top_k), options)
+        .grep(&stores, pattern, overfetch(top_k), options, filters)
         .await?;
-    Ok(project(manifest, hits, false, top_k))
+    Ok(project(manifest, hits, false, top_k, code_scope))
 }
 
 /// Ask a question against `store_name` (and optionally the web store).
 ///
 /// # Errors
 /// Returns an error if the backend request fails.
+#[allow(clippy::too_many_arguments, reason = "thin pass-through of the query surface")]
 pub async fn ask(
     store: &(impl Store + Sync),
     store_name: &str,
@@ -93,12 +117,16 @@ pub async fn ask(
     top_k: usize,
     options: SearchOptions,
     include_web: bool,
+    filters: Option<&Filter>,
+    code_scope: CodeScope,
 ) -> Result<AnswerView> {
     let stores = store_identifiers(store_name, include_web);
-    let answer = store.ask(&stores, query, overfetch(top_k), options).await?;
+    let answer = store
+        .ask(&stores, query, overfetch(top_k), options, filters)
+        .await?;
     Ok(AnswerView {
         answer: answer.answer,
-        sources: project(manifest, answer.sources, include_web, top_k),
+        sources: project(manifest, answer.sources, include_web, top_k, code_scope),
     })
 }
 
@@ -111,7 +139,7 @@ fn store_identifiers(store_name: &str, include_web: bool) -> Vec<String> {
 }
 
 /// Over-fetch so that client-side filtering still leaves enough results. Other
-/// checkouts' content can crowd the raw top-k, so we ask for more than we show.
+/// checkouts' code can crowd the raw top-k, so we ask for more than we show.
 fn overfetch(top_k: usize) -> usize {
     top_k.saturating_mul(4).max(top_k.saturating_add(10))
 }
@@ -121,6 +149,7 @@ fn project(
     hits: Vec<SearchHit>,
     include_web: bool,
     top_k: usize,
+    code_scope: CodeScope,
 ) -> Vec<DisplayHit> {
     let local = manifest.hashes();
     let mut out = Vec::with_capacity(top_k);
@@ -128,30 +157,55 @@ fn project(
         if out.len() >= top_k {
             break;
         }
-        match hit.hash.as_deref() {
-            Some(hash) if local.contains(hash) => {
-                let label = manifest.path_for_hash(hash).unwrap_or(hash).to_owned();
+        match hit.source {
+            Source::Web => {
+                if include_web {
+                    out.push(DisplayHit {
+                        label: hit.path.unwrap_or_else(|| "(web)".to_owned()),
+                        source: Source::Web,
+                        start_line: None,
+                        num_lines: None,
+                        score: hit.score,
+                        text: hit.text,
+                    });
+                }
+            }
+            Source::Code => {
+                let in_manifest = hit.hash.as_deref().is_some_and(|hash| local.contains(hash));
+                // Worktree-exact keeps only this checkout's code; a server-filtered
+                // scope (a repo / all-repos query) trusts the backend filter.
+                if code_scope == CodeScope::WorktreeExact && !in_manifest {
+                    continue;
+                }
+                let label = hit
+                    .hash
+                    .as_deref()
+                    .and_then(|hash| manifest.path_for_hash(hash))
+                    .map(str::to_owned)
+                    .or(hit.path)
+                    .or(hit.hash)
+                    .unwrap_or_default();
                 out.push(DisplayHit {
                     label,
+                    source: Source::Code,
                     start_line: hit.start_line,
                     num_lines: hit.num_lines,
                     score: hit.score,
                     text: hit.text,
-                    is_web: false,
                 });
             }
-            None if include_web => out.push(DisplayHit {
-                label: hit.path.unwrap_or_else(|| "(web)".to_owned()),
-                start_line: None,
-                num_lines: None,
-                score: hit.score,
-                text: hit.text,
-                is_web: true,
-            }),
-            // A hash absent from this checkout belongs to another worktree or
-            // branch; a non-web result with no hash is dropped too. Either way
-            // search reflects only the current tree.
-            _ => {}
+            source @ (Source::Slack | Source::Linear) => {
+                // No checkout to scope against; the server-side metadata filter is
+                // authoritative, so the record passes through.
+                out.push(DisplayHit {
+                    label: hit.path.unwrap_or_default(),
+                    source,
+                    start_line: hit.start_line,
+                    num_lines: hit.num_lines,
+                    score: hit.score,
+                    text: hit.text,
+                });
+            }
         }
     }
     out
@@ -159,10 +213,10 @@ fn project(
 
 #[cfg(test)]
 mod tests {
-    use super::{grep, semantic};
-    use crate::backend::{
-        GrepOptions, GrepTargets, MemoryStore, SearchOptions, Store, UploadMeta,
-    };
+    use search_meta::{Document, Source};
+
+    use super::{CodeScope, grep, semantic};
+    use crate::backend::{GrepOptions, GrepTargets, MemoryStore, SearchOptions, Store};
     use crate::content::ContentHash;
     use crate::manifest::{FileEntry, Manifest};
 
@@ -173,22 +227,56 @@ mod tests {
         }
     }
 
-    async fn put(store: &MemoryStore, path: &str, content: &str) -> ContentHash {
+    async fn put_code(store: &MemoryStore, path: &str, content: &str) -> ContentHash {
         let hash = ContentHash::of_bytes(content.as_bytes());
+        let meta = serde_json::json!({
+            "source": "code",
+            "external_id": hash.as_str(),
+            "content_hash": hash.as_str(),
+            "title": path,
+            "repo": "indexable-inc/index",
+            "path": path,
+        });
         store
             .upload(
                 "s",
-                content.as_bytes().to_vec(),
-                path,
-                hash.as_str(),
-                UploadMeta {
-                    path: path.to_owned(),
-                    hash: hash.as_str().to_owned(),
+                Document {
+                    external_id: hash.as_str().to_owned(),
+                    file_name: path.to_owned(),
+                    mime: "text/plain",
+                    body: content.as_bytes().to_vec(),
+                    meta_json: meta,
+                    content_hash: hash.as_str().to_owned(),
                 },
             )
             .await
             .expect("upload");
         hash
+    }
+
+    async fn put_slack(store: &MemoryStore, external_id: &str, title: &str, content: &str) {
+        let hash = search_meta::hash_body(content.as_bytes());
+        let meta = serde_json::json!({
+            "source": "slack",
+            "external_id": external_id,
+            "content_hash": hash,
+            "title": title,
+            "channel_name": "craft",
+        });
+        store
+            .upload(
+                "s",
+                Document {
+                    external_id: external_id.to_owned(),
+                    file_name: "thread.txt".to_owned(),
+                    mime: "text/plain",
+                    body: content.as_bytes().to_vec(),
+                    meta_json: meta,
+                    content_hash: hash,
+                },
+            )
+            .await
+            .expect("upload");
     }
 
     fn manifest_with(entries: &[(&str, &ContentHash)]) -> Manifest {
@@ -206,33 +294,82 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn results_outside_this_checkout_are_filtered() {
+    async fn code_outside_this_checkout_is_filtered() {
         let store = MemoryStore::new();
-        let mine = put(&store, "mine.rs", "needle in mine").await;
-        let _theirs = put(&store, "theirs.rs", "needle in theirs").await;
+        let mine = put_code(&store, "mine.rs", "needle in mine").await;
+        let _theirs = put_code(&store, "theirs.rs", "needle in theirs").await;
 
-        // Manifest only knows about `mine.rs`, so the other worktree's hit must
-        // be dropped even though both match the query in the shared store.
         let manifest = manifest_with(&[("mine.rs", &mine)]);
-        let hits = semantic(&store, "s", &manifest, "needle", 10, opts(), false)
-            .await
-            .expect("search");
+        let hits = semantic(
+            &store,
+            "s",
+            &manifest,
+            "needle",
+            10,
+            opts(),
+            false,
+            None,
+            CodeScope::WorktreeExact,
+        )
+        .await
+        .expect("search");
 
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].label, "mine.rs");
-        assert!(!hits[0].is_web);
+        assert_eq!(hits[0].source, Source::Code);
     }
 
     #[tokio::test]
-    async fn empty_manifest_yields_no_local_hits() {
+    async fn slack_passes_through_without_a_manifest_hash() {
         let store = MemoryStore::new();
-        let _ = put(&store, "a.rs", "needle").await;
+        put_slack(&store, "slack:C0:1.2", "craft: ship it", "needle decision in slack").await;
+        // The manifest knows no code; the Slack thread must still surface, because
+        // record sources are scoped by the server filter, not the manifest.
         let manifest = Manifest::default();
+        let hits = semantic(
+            &store,
+            "s",
+            &manifest,
+            "needle",
+            10,
+            opts(),
+            false,
+            None,
+            CodeScope::WorktreeExact,
+        )
+        .await
+        .expect("search");
 
-        let hits = semantic(&store, "s", &manifest, "needle", 10, opts(), false)
-            .await
-            .expect("search");
-        assert!(hits.is_empty());
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].source, Source::Slack);
+        assert_eq!(hits[0].label, "craft: ship it");
+    }
+
+    #[tokio::test]
+    async fn source_filter_excludes_a_source() {
+        let store = MemoryStore::new();
+        let mine = put_code(&store, "mine.rs", "needle in code").await;
+        put_slack(&store, "slack:C0:1.2", "craft", "needle in slack").await;
+        let manifest = manifest_with(&[("mine.rs", &mine)]);
+
+        // Exclude slack: only the code hit should survive.
+        let filter = mixedbread::Filter::none(vec![mixedbread::Filter::eq("source", "slack")]);
+        let hits = semantic(
+            &store,
+            "s",
+            &manifest,
+            "needle",
+            10,
+            opts(),
+            false,
+            Some(&filter),
+            CodeScope::WorktreeExact,
+        )
+        .await
+        .expect("search");
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].source, Source::Code);
     }
 
     fn grep_opts(case_sensitive: bool) -> GrepOptions {
@@ -245,66 +382,85 @@ mod tests {
     #[tokio::test]
     async fn grep_matches_regex_and_projects_to_local_paths() {
         let store = MemoryStore::new();
-        let alpha = put(&store, "alpha.rs", "fn handler() {}\nlet other = 1;").await;
-        let beta = put(&store, "beta.rs", "struct Thing;\nfn render() {}").await;
+        let alpha = put_code(&store, "alpha.rs", "fn handler() {}\nlet other = 1;").await;
+        let beta = put_code(&store, "beta.rs", "struct Thing;\nfn render() {}").await;
 
         let manifest = manifest_with(&[("alpha.rs", &alpha), ("beta.rs", &beta)]);
-        let hits = grep(&store, "s", &manifest, r"fn \w+\(\)", 10, grep_opts(false))
-            .await
-            .expect("grep");
+        let hits = grep(
+            &store,
+            "s",
+            &manifest,
+            r"fn \w+\(\)",
+            10,
+            grep_opts(false),
+            None,
+            CodeScope::WorktreeExact,
+        )
+        .await
+        .expect("grep");
 
-        // The regex matches the two `fn name()` lines, one per file, and each
-        // hit projects back to its local repo-relative path.
         assert_eq!(hits.len(), 2);
         let mut labels: Vec<&str> = hits.iter().map(|hit| hit.label.as_str()).collect();
         labels.sort_unstable();
         assert_eq!(labels, vec!["alpha.rs", "beta.rs"]);
-        assert!(hits.iter().all(|hit| !hit.is_web));
+        assert!(hits.iter().all(|hit| hit.source == Source::Code));
     }
 
     #[tokio::test]
     async fn grep_case_sensitive_excludes_differently_cased_match() {
         let store = MemoryStore::new();
-        let lower = put(&store, "lower.rs", "let token = read();").await;
-        let upper = put(&store, "upper.rs", "let TOKEN = read();").await;
+        let lower = put_code(&store, "lower.rs", "let token = read();").await;
+        let upper = put_code(&store, "upper.rs", "let TOKEN = read();").await;
 
         let manifest = manifest_with(&[("lower.rs", &lower), ("upper.rs", &upper)]);
 
-        // Case-insensitive grep catches both spellings of the word.
-        let insensitive = grep(&store, "s", &manifest, "token", 10, grep_opts(false))
-            .await
-            .expect("grep");
+        let insensitive = grep(
+            &store,
+            "s",
+            &manifest,
+            "token",
+            10,
+            grep_opts(false),
+            None,
+            CodeScope::WorktreeExact,
+        )
+        .await
+        .expect("grep");
         assert_eq!(insensitive.len(), 2);
 
-        // Case-sensitive grep keeps only the lowercase line.
-        let sensitive = grep(&store, "s", &manifest, "token", 10, grep_opts(true))
-            .await
-            .expect("grep");
+        let sensitive = grep(
+            &store,
+            "s",
+            &manifest,
+            "token",
+            10,
+            grep_opts(true),
+            None,
+            CodeScope::WorktreeExact,
+        )
+        .await
+        .expect("grep");
         assert_eq!(sensitive.len(), 1);
         assert_eq!(sensitive[0].label, "lower.rs");
     }
 
     #[tokio::test]
-    async fn grep_respects_top_k() {
-        let store = MemoryStore::new();
-        let many = put(&store, "many.rs", "fn a() {}\nfn b() {}\nfn c() {}").await;
-        let manifest = manifest_with(&[("many.rs", &many)]);
-
-        let hits = grep(&store, "s", &manifest, r"fn \w", 2, grep_opts(false))
-            .await
-            .expect("grep");
-        assert_eq!(hits.len(), 2);
-    }
-
-    #[tokio::test]
     async fn grep_invalid_pattern_is_an_error() {
         let store = MemoryStore::new();
-        let only = put(&store, "only.rs", "anything").await;
+        let only = put_code(&store, "only.rs", "anything").await;
         let manifest = manifest_with(&[("only.rs", &only)]);
 
-        // An unbalanced group is not a valid regex, so grep must surface a typed
-        // error rather than panic.
-        let result = grep(&store, "s", &manifest, "fn (", 10, grep_opts(false)).await;
+        let result = grep(
+            &store,
+            "s",
+            &manifest,
+            "fn (",
+            10,
+            grep_opts(false),
+            None,
+            CodeScope::WorktreeExact,
+        )
+        .await;
         assert!(result.is_err());
     }
 }

--- a/packages/search-core/src/sync.rs
+++ b/packages/search-core/src/sync.rs
@@ -13,18 +13,19 @@
 //! There is no daemon. Each invocation rebuilds the manifest cheaply (mtime
 //! skips re-hashing unchanged files) and uploads only what is new.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt as _};
-use search_meta::{Document, RepoSlug};
+use mixedbread::Filter;
+use search_meta::{Document, RepoSlug, SourceAdapter, keys};
 use snafu::ResultExt as _;
 use tokio::time::sleep;
 
 use crate::backend::{Store, StoreStatus};
-use crate::error::{MetadataLimitSnafu, ReadFileSnafu, Result, TooManyFilesSnafu};
+use crate::error::{AdapterSnafu, MetadataLimitSnafu, ReadFileSnafu, Result, TooManyFilesSnafu};
 use crate::manifest::{FileEntry, Manifest};
 
 /// Maximum concurrent uploads in flight.
@@ -103,19 +104,17 @@ pub async fn sync(
     // be `Send + 'static`. Owning the entry per task removes the borrow and the
     // clone is one small struct per uploaded file, paid only for new content.
     let to_upload: Vec<FileEntry> = to_upload.into_iter().cloned().collect();
+    let ctx = UploadContext {
+        store,
+        store_name,
+        root,
+        repo,
+        upload_target,
+        done: &done,
+        on_progress: &on_progress,
+    };
     let results: Vec<Result<()>> = stream::iter(to_upload)
-        .map(|entry| {
-            upload_entry(
-                store,
-                store_name,
-                root,
-                repo,
-                entry,
-                upload_target,
-                &done,
-                &on_progress,
-            )
-        })
+        .map(|entry| upload_entry(&ctx, entry))
         .buffer_unordered(UPLOAD_CONCURRENCY)
         .collect()
         .await;
@@ -133,27 +132,33 @@ pub async fn sync(
     })
 }
 
-/// Read one file and upload it under its content hash, then report progress.
-/// Factored out of [`sync`] so the per-entry future has a named, concrete type
-/// (see the call site for why an inline closure breaks higher-ranked lifetime
-/// unification for `Send + 'static` consumers).
-async fn upload_entry(
-    store: &(impl Store + Sync),
-    store_name: &str,
-    root: &Path,
-    repo: &RepoSlug,
-    entry: FileEntry,
+/// Shared, per-run context borrowed by every [`upload_entry`] task. Bundling the
+/// invariant uploader state keeps the per-entry future a named, concrete type
+/// (see the [`sync`] call site for why an inline closure breaks higher-ranked
+/// lifetime unification for `Send + 'static` consumers) without threading eight
+/// separate arguments through each task.
+struct UploadContext<'a, S: Store + Sync, P: Fn(usize, usize) + Send + Sync> {
+    store: &'a S,
+    store_name: &'a str,
+    root: &'a Path,
+    repo: &'a RepoSlug,
     upload_target: usize,
-    done: &AtomicUsize,
-    on_progress: &(impl Fn(usize, usize) + Send + Sync),
+    done: &'a AtomicUsize,
+    on_progress: &'a P,
+}
+
+/// Read one file and upload it under its content hash, then report progress.
+async fn upload_entry<S: Store + Sync, P: Fn(usize, usize) + Send + Sync>(
+    ctx: &UploadContext<'_, S, P>,
+    entry: FileEntry,
 ) -> Result<()> {
-    let abs = root.join(&entry.rel_path);
+    let abs = ctx.root.join(&entry.rel_path);
     let content = tokio::fs::read(&abs)
         .await
         .context(ReadFileSnafu { path: abs })?;
-    let document = code_document(repo, &entry, content)?;
-    store.upload(store_name, document).await?;
-    on_progress(done.fetch_add(1, Ordering::Relaxed) + 1, upload_target);
+    let document = code_document(ctx.repo, &entry, content)?;
+    ctx.store.upload(ctx.store_name, document).await?;
+    (ctx.on_progress)(ctx.done.fetch_add(1, Ordering::Relaxed) + 1, ctx.upload_target);
     Ok(())
 }
 
@@ -215,11 +220,167 @@ fn file_name_of(rel_path: &str) -> &str {
     rel_path.rsplit('/').next().unwrap_or(rel_path)
 }
 
+/// Outcome of a garbage-collection pass over one record source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GcReport {
+    /// Records deleted from the store (present remotely, absent from the export).
+    pub deleted: usize,
+    /// Records kept (the adapter's current desired set).
+    pub kept: usize,
+}
+
+/// The filter selecting one source's records in the shared store.
+fn source_filter(adapter: &impl SourceAdapter) -> Filter {
+    Filter::eq(keys::SOURCE, adapter.source().as_str())
+}
+
+/// Reconcile a record source (Slack, Linear, ...) into the store: upload records
+/// that are new or whose `content_hash` changed, skip the unchanged.
+///
+/// Unlike the code [`sync`], records are addressed by a source-defined
+/// `external_id`, so change detection compares each document's `content_hash`
+/// against the value stored under that id. Reconcile lists only this source's
+/// records (a `source == X` filter), so it never reads or touches another
+/// source's entries.
+///
+/// # Errors
+/// Returns an error if the store cannot be reached, a document cannot be
+/// produced by the adapter, or an upload fails.
+pub async fn sync_documents<A>(
+    adapter: &A,
+    store: &(impl Store + Sync),
+    store_name: &str,
+    index_timeout: Duration,
+    on_progress: impl Fn(usize, usize) + Send + Sync,
+) -> Result<SyncReport>
+where
+    A: SourceAdapter + Sync,
+{
+    store.ensure_store(store_name).await?;
+    let filter = source_filter(adapter);
+    let remote: HashMap<String, Option<String>> = store
+        .list_records(store_name, Some(&filter))
+        .await?
+        .into_iter()
+        .map(|record| (record.external_id, record.content_hash))
+        .collect();
+
+    // Parsing is sequential and cheap; uploading is the expensive part and runs
+    // concurrently. Collect only the documents that actually need uploading so a
+    // re-ingest of an unchanged export holds almost nothing.
+    let mut to_upload = Vec::new();
+    let mut total = 0;
+    for item in adapter.documents() {
+        let document = item.map_err(|error| {
+            AdapterSnafu {
+                message: error.to_string(),
+            }
+            .build()
+        })?;
+        total += 1;
+        // A record with no stored content_hash predates hash tracking; re-embed.
+        let unchanged = matches!(
+            remote.get(&document.external_id),
+            Some(Some(stored)) if *stored == document.content_hash
+        );
+        if !unchanged {
+            to_upload.push(document);
+        }
+    }
+
+    let upload_target = to_upload.len();
+    let skipped = total - upload_target;
+    on_progress(0, upload_target);
+    let done = AtomicUsize::new(0);
+
+    let results: Vec<Result<()>> = stream::iter(to_upload)
+        .map(|document| {
+            let done = &done;
+            let on_progress = &on_progress;
+            async move {
+                store.upload(store_name, document).await?;
+                on_progress(done.fetch_add(1, Ordering::Relaxed) + 1, upload_target);
+                Ok(())
+            }
+        })
+        .buffer_unordered(UPLOAD_CONCURRENCY)
+        .collect()
+        .await;
+
+    let mut uploaded = 0;
+    for result in results {
+        result?;
+        uploaded += 1;
+    }
+
+    if uploaded > 0 {
+        wait_until_indexed(store, store_name, index_timeout, |_| {}).await?;
+    }
+
+    Ok(SyncReport {
+        uploaded,
+        skipped,
+        total,
+    })
+}
+
+/// Delete records present in the store for this source but absent from the
+/// adapter's current desired set (a full-snapshot set-difference).
+///
+/// The remote set is listed with a `source == X` filter, so this can only ever
+/// delete that source's records: a Linear GC cannot touch a code blob or a Slack
+/// thread. Run it against a complete export, never a window slice, or it would
+/// delete records the slice simply did not include.
+///
+/// # Errors
+/// Returns an error if the store cannot be reached, a document cannot be
+/// produced, or a delete fails.
+pub async fn gc_documents<A>(
+    adapter: &A,
+    store: &(impl Store + Sync),
+    store_name: &str,
+) -> Result<GcReport>
+where
+    A: SourceAdapter + Sync,
+{
+    let filter = source_filter(adapter);
+    let remote: HashSet<String> = store
+        .list_records(store_name, Some(&filter))
+        .await?
+        .into_iter()
+        .map(|record| record.external_id)
+        .collect();
+
+    let mut desired = HashSet::new();
+    for item in adapter.documents() {
+        let document = item.map_err(|error| {
+            AdapterSnafu {
+                message: error.to_string(),
+            }
+            .build()
+        })?;
+        desired.insert(document.external_id);
+    }
+
+    let stale: Vec<&String> = remote.difference(&desired).collect();
+    let deleted = stale.len();
+    for external_id in stale {
+        store.delete(store_name, external_id).await?;
+    }
+
+    Ok(GcReport {
+        deleted,
+        kept: desired.len(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use search_meta::RepoSlug;
+    use std::time::Duration;
 
-    use super::sync;
+    use search_meta::{Document, RepoSlug, SourceAdapter};
+
+    use super::{gc_documents, sync, sync_documents};
     use crate::backend::MemoryStore;
     use crate::manifest::Manifest;
 
@@ -289,5 +450,95 @@ mod tests {
             .expect_err("should refuse");
         assert!(matches!(err, crate::error::Error::TooManyFiles { .. }));
         assert_eq!(store.upload_count(), 0);
+    }
+
+    // A fake record source for exercising the document reconcile and GC without a
+    // real parser crate. It yields Linear-shaped documents from owned data.
+    struct FakeSource {
+        docs: Vec<Document>,
+    }
+
+    #[derive(Debug, snafu::Snafu)]
+    #[snafu(display("fake source error"))]
+    struct FakeError;
+
+    impl SourceAdapter for FakeSource {
+        type Error = FakeError;
+        fn source(&self) -> search_meta::Source {
+            search_meta::Source::Linear
+        }
+        fn documents(&self) -> impl Iterator<Item = std::result::Result<Document, FakeError>> + Send {
+            self.docs.clone().into_iter().map(Ok)
+        }
+    }
+
+    fn linear_doc(id: &str, body: &str) -> Document {
+        let content_hash = search_meta::hash_body(body.as_bytes());
+        Document {
+            external_id: format!("linear:issue:{id}"),
+            file_name: format!("{id}.txt"),
+            mime: "text/plain",
+            body: body.as_bytes().to_vec(),
+            meta_json: serde_json::json!({
+                "source": "linear",
+                "external_id": format!("linear:issue:{id}"),
+                "content_hash": content_hash,
+                "title": id,
+            }),
+            content_hash,
+        }
+    }
+
+    #[tokio::test]
+    async fn document_sync_uploads_then_skips_unchanged_and_reuploads_changed() {
+        let store = MemoryStore::new();
+        let source = FakeSource {
+            docs: vec![linear_doc("A", "alpha body"), linear_doc("B", "beta body")],
+        };
+
+        let first = sync_documents(&source, &store, "s", Duration::from_secs(1), |_, _| {})
+            .await
+            .expect("first");
+        assert_eq!(first.uploaded, 2);
+        assert_eq!(store.upload_count(), 2);
+
+        // Re-running the same export uploads nothing (content_hash unchanged).
+        let second = sync_documents(&source, &store, "s", Duration::from_secs(1), |_, _| {})
+            .await
+            .expect("second");
+        assert_eq!(second.uploaded, 0);
+        assert_eq!(second.skipped, 2);
+        assert_eq!(store.upload_count(), 2, "no redundant re-upload");
+
+        // A changed body for A re-embeds only A.
+        let changed = FakeSource {
+            docs: vec![linear_doc("A", "alpha body EDITED"), linear_doc("B", "beta body")],
+        };
+        let third = sync_documents(&changed, &store, "s", Duration::from_secs(1), |_, _| {})
+            .await
+            .expect("third");
+        assert_eq!(third.uploaded, 1);
+        assert_eq!(store.upload_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn gc_deletes_records_absent_from_the_export() {
+        let store = MemoryStore::new();
+        let full = FakeSource {
+            docs: vec![linear_doc("A", "a"), linear_doc("B", "b"), linear_doc("C", "c")],
+        };
+        sync_documents(&full, &store, "s", Duration::from_secs(1), |_, _| {})
+            .await
+            .expect("seed");
+        assert_eq!(store.len(), 3);
+
+        // A later export dropped issue C; GC removes it.
+        let trimmed = FakeSource {
+            docs: vec![linear_doc("A", "a"), linear_doc("B", "b")],
+        };
+        let report = gc_documents(&trimmed, &store, "s").await.expect("gc");
+        assert_eq!(report.deleted, 1);
+        assert_eq!(report.kept, 2);
+        assert_eq!(store.len(), 2);
     }
 }

--- a/packages/search-core/src/sync.rs
+++ b/packages/search-core/src/sync.rs
@@ -19,11 +19,12 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt as _};
+use search_meta::{Document, RepoSlug};
 use snafu::ResultExt as _;
 use tokio::time::sleep;
 
-use crate::backend::{Store, StoreStatus, UploadMeta};
-use crate::error::{ReadFileSnafu, Result, TooManyFilesSnafu};
+use crate::backend::{Store, StoreStatus};
+use crate::error::{MetadataLimitSnafu, ReadFileSnafu, Result, TooManyFilesSnafu};
 use crate::manifest::{FileEntry, Manifest};
 
 /// Maximum concurrent uploads in flight.
@@ -60,6 +61,7 @@ pub async fn sync(
     store_name: &str,
     root: &Path,
     manifest: &Manifest,
+    repo: &RepoSlug,
     max_files: usize,
     on_progress: impl Fn(usize, usize) + Send + Sync,
 ) -> Result<SyncReport> {
@@ -107,6 +109,7 @@ pub async fn sync(
                 store,
                 store_name,
                 root,
+                repo,
                 entry,
                 upload_target,
                 &done,
@@ -138,6 +141,7 @@ async fn upload_entry(
     store: &(impl Store + Sync),
     store_name: &str,
     root: &Path,
+    repo: &RepoSlug,
     entry: FileEntry,
     upload_target: usize,
     done: &AtomicUsize,
@@ -147,16 +151,35 @@ async fn upload_entry(
     let content = tokio::fs::read(&abs)
         .await
         .context(ReadFileSnafu { path: abs })?;
-    let file_name = file_name_of(&entry.rel_path);
-    let meta = UploadMeta {
-        path: entry.rel_path.clone(),
-        hash: entry.hash.as_str().to_owned(),
-    };
-    store
-        .upload(store_name, content, file_name, entry.hash.as_str(), meta)
-        .await?;
+    let document = code_document(repo, &entry, content)?;
+    store.upload(store_name, document).await?;
     on_progress(done.fetch_add(1, Ordering::Relaxed) + 1, upload_target);
     Ok(())
+}
+
+/// Build the [`Document`] for one code file: the file bytes are the body, the
+/// content hash is the manifest hash (sha256 of those bytes) and doubles as the
+/// `external_id`, and the flat metadata carries the typed code envelope so a
+/// query can filter by `source` and `repo`.
+fn code_document(repo: &RepoSlug, entry: &FileEntry, body: Vec<u8>) -> Result<Document> {
+    let hash = entry.hash.as_str().to_owned();
+    let meta_json = serde_json::json!({
+        "source": "code",
+        "external_id": hash,
+        "content_hash": hash,
+        "title": entry.rel_path,
+        "repo": repo.as_str(),
+        "path": entry.rel_path,
+    });
+    search_meta::check_metadata(&hash, &meta_json).context(MetadataLimitSnafu)?;
+    Ok(Document {
+        external_id: hash.clone(),
+        file_name: file_name_of(&entry.rel_path).to_owned(),
+        mime: "text/plain",
+        body,
+        meta_json,
+        content_hash: hash,
+    })
 }
 
 /// Poll the store until newly uploaded files finish embedding.
@@ -194,9 +217,15 @@ fn file_name_of(rel_path: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
+    use search_meta::RepoSlug;
+
     use super::sync;
     use crate::backend::MemoryStore;
     use crate::manifest::Manifest;
+
+    fn repo() -> RepoSlug {
+        RepoSlug::Local("test".to_owned())
+    }
 
     fn write_repo() -> tempfile::TempDir {
         let dir = tempfile::TempDir::new().expect("tempdir");
@@ -211,7 +240,7 @@ mod tests {
         let store = MemoryStore::new();
         let manifest = Manifest::build(dir.path(), None, 1024 * 1024).expect("manifest");
 
-        let first = sync(&store, "s", dir.path(), &manifest, 1000, |_, _| {})
+        let first = sync(&store, "s", dir.path(), &manifest, &repo(), 1000, |_, _| {})
             .await
             .expect("first sync");
         assert_eq!(first.uploaded, 2);
@@ -219,7 +248,7 @@ mod tests {
 
         // Re-syncing the same content must not re-upload: this is the
         // cross-worktree / re-run win that mgrep lacks.
-        let second = sync(&store, "s", dir.path(), &manifest, 1000, |_, _| {})
+        let second = sync(&store, "s", dir.path(), &manifest, &repo(), 1000, |_, _| {})
             .await
             .expect("second sync");
         assert_eq!(second.uploaded, 0);
@@ -234,13 +263,13 @@ mod tests {
         let store = MemoryStore::new();
 
         let manifest_a = Manifest::build(dir_a.path(), None, 1024 * 1024).expect("a");
-        sync(&store, "s", dir_a.path(), &manifest_a, 1000, |_, _| {})
+        sync(&store, "s", dir_a.path(), &manifest_a, &repo(), 1000, |_, _| {})
             .await
             .expect("sync a");
         assert_eq!(store.upload_count(), 2);
 
         let manifest_b = Manifest::build(dir_b.path(), None, 1024 * 1024).expect("b");
-        let report_b = sync(&store, "s", dir_b.path(), &manifest_b, 1000, |_, _| {})
+        let report_b = sync(&store, "s", dir_b.path(), &manifest_b, &repo(), 1000, |_, _| {})
             .await
             .expect("sync b");
 
@@ -255,7 +284,7 @@ mod tests {
         let store = MemoryStore::new();
         let manifest = Manifest::build(dir.path(), None, 1024 * 1024).expect("manifest");
 
-        let err = sync(&store, "s", dir.path(), &manifest, 1, |_, _| {})
+        let err = sync(&store, "s", dir.path(), &manifest, &repo(), 1, |_, _| {})
             .await
             .expect_err("should refuse");
         assert!(matches!(err, crate::error::Error::TooManyFiles { .. }));

--- a/packages/search-meta/Cargo.toml
+++ b/packages/search-meta/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "search-meta"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Shared typed metadata envelope and source-adapter trait for multi-source search"
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sha2.workspace = true
+snafu.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/packages/search-meta/package.nix
+++ b/packages/search-meta/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "search-meta";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/search-meta/src/keys.rs
+++ b/packages/search-meta/src/keys.rs
@@ -1,0 +1,49 @@
+//! Canonical metadata key names, the single source of truth shared by adapters
+//! (which write them) and the filter builder (which queries them).
+//!
+//! Keeping them as `const`s, rather than string literals scattered across
+//! crates, means a query can never target a key an adapter never writes without
+//! the mismatch being visible in one place.
+
+/// Which corpus a record came from. The primary scope filter key.
+pub const SOURCE: &str = "source";
+/// sha256 of the embedded body; drives skip-if-unchanged reconcile.
+pub const CONTENT_HASH: &str = "content_hash";
+/// Human display label for a record.
+pub const TITLE: &str = "title";
+
+// Code.
+/// Repository slug (git remote, or directory name when there is no remote).
+pub const REPO: &str = "repo";
+/// Repo-relative path of a code file.
+pub const PATH: &str = "path";
+
+// Common.
+/// Epoch-second timestamp, the primary recency axis.
+pub const TIMESTAMP: &str = "timestamp";
+
+// Slack.
+/// Slack channel id (stable across renames).
+pub const CHANNEL_ID: &str = "channel_id";
+/// Slack channel name (display).
+pub const CHANNEL_NAME: &str = "channel_name";
+/// Slack author display names in a thread.
+pub const AUTHORS: &str = "authors";
+/// Whether the thread is in an external / Slack-Connect channel.
+pub const IS_EXTERNAL: &str = "is_external";
+/// Whether every message in the thread is from a bot/integration.
+pub const IS_BOT_THREAD: &str = "is_bot_thread";
+
+// Linear.
+/// Linear issue identifier, e.g. `ENG-1885`.
+pub const IDENTIFIER: &str = "identifier";
+/// Linear team key, e.g. `ENG`.
+pub const TEAM_KEY: &str = "team_key";
+/// Stable Linear workflow-state type (`backlog`/`started`/`completed`/...).
+pub const STATE_TYPE: &str = "state_type";
+/// Linear assignee email.
+pub const ASSIGNEE_EMAIL: &str = "assignee_email";
+/// Linear labels.
+pub const LABELS: &str = "labels";
+/// Whether the issue is archived.
+pub const IS_ARCHIVED: &str = "is_archived";

--- a/packages/search-meta/src/lib.rs
+++ b/packages/search-meta/src/lib.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use snafu::{ResultExt as _, Snafu, ensure};
 
-/// Which corpus a record came from. Serializes to the snake_case tag stored
+/// Which corpus a record came from. Serializes to the `snake_case` tag stored
 /// under [`keys::SOURCE`] and used as the primary scope filter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -44,7 +44,7 @@ pub enum Source {
 }
 
 impl Source {
-    /// The snake_case tag, matching the serialized form.
+    /// The `snake_case` tag, matching the serialized form.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {

--- a/packages/search-meta/src/lib.rs
+++ b/packages/search-meta/src/lib.rs
@@ -1,0 +1,297 @@
+//! Shared metadata model for multi-source search.
+//!
+//! Every record uploaded to the store, whatever its source, carries a common
+//! [`DocumentMeta`] header (flattened to top-level metadata keys so each is a
+//! filter key) plus source-specific extras the adapter projects in. A
+//! [`SourceAdapter`] turns one corpus (a code checkout, a Slack export, a Linear
+//! export) into a stream of [`Document`]s ready to embed.
+//!
+//! Two invariants this crate enforces by construction:
+//!
+//! 1. **`content_hash` is the hash of the embedded bytes.** [`hash_body`] is the
+//!    only way to make one, so a record's change-detection key can never drift
+//!    from what was actually embedded. Re-ingesting an unchanged export is a
+//!    no-op; a genuinely changed record re-embeds.
+//! 2. **Metadata stays inside the store's limits.** [`check_metadata`] is a
+//!    typed gate, so an over-budget record fails observably before upload rather
+//!    than as an opaque 400 mid-bulk-ingest.
+//!
+//! This crate is pure data and traits: serde, a hash helper, and the trait. It
+//! has no network or filesystem dependency, so both `search-core` and each
+//! source adapter can depend on it without pulling in a client.
+
+pub mod keys;
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use snafu::{ResultExt as _, Snafu, ensure};
+
+/// Which corpus a record came from. Serializes to the snake_case tag stored
+/// under [`keys::SOURCE`] and used as the primary scope filter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Source {
+    /// A file in a git checkout.
+    Code,
+    /// A Slack thread.
+    Slack,
+    /// A Linear issue.
+    Linear,
+    /// A hosted web-search result (no local record).
+    Web,
+}
+
+impl Source {
+    /// The snake_case tag, matching the serialized form.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Code => "code",
+            Self::Slack => "slack",
+            Self::Linear => "linear",
+            Self::Web => "web",
+        }
+    }
+}
+
+impl fmt::Display for Source {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A source string that did not name a known [`Source`].
+#[derive(Debug, Snafu)]
+#[snafu(display("unknown source {value:?}; expected one of code, slack, linear, web"))]
+pub struct ParseSourceError {
+    /// The string that failed to parse.
+    pub value: String,
+}
+
+impl std::str::FromStr for Source {
+    type Err = ParseSourceError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "code" => Ok(Self::Code),
+            "slack" => Ok(Self::Slack),
+            "linear" => Ok(Self::Linear),
+            "web" => Ok(Self::Web),
+            other => ParseSourceSnafu {
+                value: other.to_owned(),
+            }
+            .fail(),
+        }
+    }
+}
+
+/// The repository a code record belongs to, used for cross-repo vs single-repo
+/// scoping. There is no silent empty-string fallback: a checkout with no git
+/// remote is named by its directory, observably [`RepoSlug::Local`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "value")]
+pub enum RepoSlug {
+    /// Derived from the git remote (e.g. `indexable-inc/index`).
+    Remote(String),
+    /// No remote; the checkout's directory name.
+    Local(String),
+}
+
+impl RepoSlug {
+    /// The slug string, regardless of origin.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Remote(slug) | Self::Local(slug) => slug,
+        }
+    }
+}
+
+impl fmt::Display for RepoSlug {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The common header on every stored record, flattened to top-level metadata.
+///
+/// Each field is a filter key. Significant fields are required (no
+/// `serde(default)`); only genuinely optional ones are skipped when absent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocumentMeta {
+    /// Which corpus this came from.
+    pub source: Source,
+    /// Stable per-record id; equals the store `external_id` (<= 256 chars).
+    pub external_id: String,
+    /// sha256 of the embedded body; drives skip-if-unchanged reconcile.
+    pub content_hash: String,
+    /// Human label for display (`rel_path`, `#craft: subject`, `ENG-1885: title`).
+    pub title: String,
+    /// Deep link back to the source, when one exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Primary recency axis, epoch seconds, when the record has a time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<i64>,
+}
+
+/// One record ready to upload: its identity, the bytes to embed, and the flat
+/// metadata object (common header merged with source extras).
+#[derive(Debug, Clone)]
+pub struct Document {
+    /// Stable per-record id; the store `external_id`.
+    pub external_id: String,
+    /// File name for the upload's `/v1/files` leg.
+    pub file_name: String,
+    /// MIME type the adapter chose for the body.
+    pub mime: &'static str,
+    /// The UTF-8 text that gets embedded.
+    pub body: Vec<u8>,
+    /// Flat metadata: [`DocumentMeta`] plus the adapter's source-specific extras.
+    pub meta_json: serde_json::Value,
+    /// sha256 of `body`; equals `meta_json["content_hash"]`.
+    pub content_hash: String,
+}
+
+/// Turns one corpus into a stream of [`Document`]s.
+///
+/// `documents` returns an iterator, not a `Vec`, so a large export (a 344 MB
+/// Slack tree) is streamed channel by channel. A record that cannot be parsed
+/// is a typed `Err`, never silently dropped.
+pub trait SourceAdapter {
+    /// Adapter-specific failure type.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Which corpus this adapter ingests. Used to scope reconcile and GC to one
+    /// source's records in the shared store.
+    fn source(&self) -> Source;
+
+    /// The current desired-state documents for this corpus.
+    fn documents(&self) -> impl Iterator<Item = Result<Document, Self::Error>> + Send;
+}
+
+/// The `content_hash` of a body: `sha256:<hex>` over the exact bytes embedded.
+///
+/// This is the only constructor, so a record's change-detection hash is always
+/// the hash of what was embedded. For code, the body is the file bytes, so this
+/// equals the existing content-addressed id.
+#[must_use]
+pub fn hash_body(body: &[u8]) -> String {
+    let digest = Sha256::digest(body);
+    let mut out = String::with_capacity("sha256:".len() + digest.len() * 2);
+    out.push_str("sha256:");
+    for byte in digest {
+        use fmt::Write as _;
+        // Writing hex to a String is infallible; no panic path.
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+/// Maximum serialized size of one record's metadata object, in bytes.
+pub const MAX_METADATA_BYTES: usize = 128 * 1024;
+/// Maximum number of top-level metadata keys on one record.
+pub const MAX_METADATA_KEYS: usize = 256;
+
+/// A record's metadata exceeded a store limit.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum MetadataError {
+    /// Serialized metadata is larger than [`MAX_METADATA_BYTES`].
+    #[snafu(display("metadata for {external_id} is {bytes} bytes, over the metadata size limit"))]
+    TooLarge {
+        /// The record whose metadata overflowed.
+        external_id: String,
+        /// Serialized byte length.
+        bytes: usize,
+    },
+    /// Metadata has more than [`MAX_METADATA_KEYS`] top-level keys.
+    #[snafu(display("metadata for {external_id} has {count} keys, over the metadata key limit"))]
+    TooManyKeys {
+        /// The record whose metadata overflowed.
+        external_id: String,
+        /// Top-level key count.
+        count: usize,
+    },
+    /// Metadata serialization failed.
+    #[snafu(display("failed to serialize metadata for {external_id}: {source}"))]
+    Encode {
+        /// The record whose metadata could not be encoded.
+        external_id: String,
+        /// Underlying serde error.
+        source: serde_json::Error,
+    },
+}
+
+/// Verify a record's flat metadata fits the store's limits before upload.
+///
+/// Returns the serialized bytes on success so the caller does not serialize
+/// twice. Fails observably rather than letting an over-budget record become an
+/// opaque 400 in the middle of a bulk ingest.
+///
+/// # Errors
+/// Returns [`MetadataError`] if the metadata is too large, has too many keys, or
+/// cannot be serialized.
+pub fn check_metadata(external_id: &str, meta: &serde_json::Value) -> Result<Vec<u8>, MetadataError> {
+    if let Some(object) = meta.as_object() {
+        ensure!(
+            object.len() <= MAX_METADATA_KEYS,
+            TooManyKeysSnafu {
+                external_id,
+                count: object.len(),
+            }
+        );
+    }
+    let bytes = serde_json::to_vec(meta).context(EncodeSnafu { external_id })?;
+    ensure!(
+        bytes.len() <= MAX_METADATA_BYTES,
+        TooLargeSnafu {
+            external_id,
+            bytes: bytes.len(),
+        }
+    );
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Source, check_metadata, hash_body};
+
+    #[test]
+    fn source_round_trips_through_str() {
+        for source in [Source::Code, Source::Slack, Source::Linear, Source::Web] {
+            let parsed: Source = source.as_str().parse().expect("parse");
+            assert_eq!(parsed, source);
+        }
+        assert!("notes".parse::<Source>().is_err());
+    }
+
+    #[test]
+    fn source_serializes_to_snake_case() {
+        assert_eq!(serde_json::to_string(&Source::Linear).expect("ser"), "\"linear\"");
+    }
+
+    #[test]
+    fn hash_is_stable_and_prefixed() {
+        let a = hash_body(b"hello world");
+        let b = hash_body(b"hello world");
+        assert_eq!(a, b);
+        assert!(a.starts_with("sha256:"));
+        assert_ne!(a, hash_body(b"hello worlds"));
+    }
+
+    #[test]
+    fn metadata_within_limits_passes() {
+        let meta = serde_json::json!({ "source": "code", "path": "a.rs" });
+        assert!(check_metadata("sha256:x", &meta).is_ok());
+    }
+
+    #[test]
+    fn oversized_metadata_is_rejected() {
+        let big = "x".repeat(super::MAX_METADATA_BYTES + 1);
+        let meta = serde_json::json!({ "source": "slack", "blob": big });
+        assert!(check_metadata("slack:c:1", &meta).is_err());
+    }
+}

--- a/packages/search-meta/src/lib.rs
+++ b/packages/search-meta/src/lib.rs
@@ -87,9 +87,11 @@ impl std::str::FromStr for Source {
     }
 }
 
-/// The repository a code record belongs to, used for cross-repo vs single-repo
-/// scoping. There is no silent empty-string fallback: a checkout with no git
-/// remote is named by its directory, observably [`RepoSlug::Local`].
+/// The repository a code record belongs to.
+///
+/// Used for cross-repo vs single-repo scoping. There is no silent empty-string
+/// fallback: a checkout with no git remote is named by its directory, observably
+/// [`RepoSlug::Local`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "kind", content = "value")]
 pub enum RepoSlug {

--- a/packages/search-py/python/search/__init__.py
+++ b/packages/search-py/python/search/__init__.py
@@ -21,7 +21,8 @@ this package is a thin PyO3 binding over it.
 Each awaitable is a native asyncio coroutine bridged from Rust via
 pyo3-async-runtimes, so ``await`` it on your own event loop. Each hit is a dict
 with keys ``path``, ``score``, ``start_line``, ``num_lines``, ``text``, and
-``is_web``. Authentication mirrors the ``search`` CLI: ``MXBAI_API_KEY``,
+``source`` (one of ``code``, ``slack``, ``linear``, ``web``). Authentication
+mirrors the ``search`` CLI: ``MXBAI_API_KEY``,
 or the token written by ``mgrep login``.
 """
 

--- a/packages/search-py/python/search/_search.pyi
+++ b/packages/search-py/python/search/_search.pyi
@@ -21,7 +21,7 @@ class Hit(TypedDict):
     start_line: int | None
     num_lines: int | None
     text: str
-    is_web: bool
+    source: str
 
 def semantic(
     query: str,

--- a/packages/search-py/src/lib.rs
+++ b/packages/search-py/src/lib.rs
@@ -16,7 +16,7 @@ use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use search_core::{
-    Config, DEFAULT_STORE, DisplayHit, GrepOptions, GrepTargets, MixedbreadStore, Query,
+    CodeScope, Config, DEFAULT_STORE, DisplayHit, GrepOptions, GrepTargets, MixedbreadStore, Query,
     SearchOptions,
 };
 
@@ -187,6 +187,8 @@ async fn run_search(args: SearchArgs) -> search_core::Result<Vec<DisplayHit>> {
         options: args.options,
         sync: args.sync,
         include_web: args.include_web,
+        filters: None,
+        code_scope: CodeScope::WorktreeExact,
         index_timeout: INDEX_TIMEOUT,
     };
 
@@ -227,6 +229,8 @@ async fn run_grep(args: GrepArgs) -> search_core::Result<Vec<DisplayHit>> {
         },
         sync: args.sync,
         include_web: false,
+        filters: None,
+        code_scope: CodeScope::WorktreeExact,
         index_timeout: INDEX_TIMEOUT,
     };
 
@@ -249,7 +253,7 @@ fn hit_to_dict<'py>(py: Python<'py>, hit: &DisplayHit) -> PyResult<Bound<'py, Py
     dict.set_item("start_line", hit.start_line)?;
     dict.set_item("num_lines", hit.num_lines)?;
     dict.set_item("text", &hit.text)?;
-    dict.set_item("is_web", hit.is_web)?;
+    dict.set_item("source", hit.source.as_str())?;
     Ok(dict)
 }
 

--- a/packages/search/Cargo.toml
+++ b/packages/search/Cargo.toml
@@ -20,8 +20,10 @@ clap = { workspace = true, features = ["derive", "env"] }
 code-highlight.workspace = true
 dirs.workspace = true
 indicatif.workspace = true
+linear-export.workspace = true
 mixedbread.workspace = true
 progress-style.workspace = true
 search-core.workspace = true
+slack-export.workspace = true
 terminal-theme.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/packages/search/src/main.rs
+++ b/packages/search/src/main.rs
@@ -16,7 +16,8 @@ use clap::{Args, Parser, Subcommand};
 use indicatif::ProgressBar;
 use search_core::{
     CodeScope, Config, DEFAULT_STORE, DisplayHit, Filter, FilterSpec, GrepOptions, GrepTargets,
-    MixedbreadStore, Query, SearchOptions, Source, StoreStatus, build_filter, repo_slug,
+    MixedbreadStore, Query, SearchOptions, Source, SourceAdapter, StoreStatus, build_filter,
+    repo_slug,
 };
 
 /// How long to wait for freshly uploaded files to finish embedding.
@@ -46,6 +47,30 @@ struct Cli {
 enum Command {
     /// Grep the indexed chunks with a regular expression.
     Grep(GrepArgs),
+    /// Ingest a non-code source (slack, linear) from an export directory.
+    Ingest(IngestArgs),
+    /// Garbage-collect a non-code source: delete store records absent from the
+    /// export (a full-snapshot reconcile, never a window slice).
+    Gc(IngestArgs),
+}
+
+/// Arguments for `ingest` and `gc`. Code is indexed by an ordinary `search`, so
+/// these cover the record sources only.
+#[derive(Debug, Args)]
+struct IngestArgs {
+    /// Which source to ingest: slack or linear.
+    source: String,
+
+    /// Path to the export directory.
+    dir: String,
+
+    /// Store name (one store holds every source's content).
+    #[arg(long, env = "MXBAI_STORE")]
+    store: Option<String>,
+
+    /// Mixedbread API base URL.
+    #[arg(long = "base-url", env = "MXBAI_BASE_URL")]
+    base_url: Option<String>,
 }
 
 /// Scope selectors shared by the semantic and grep paths. With no selector the
@@ -209,8 +234,78 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Some(Command::Grep(args)) => run_grep(args).await,
+        Some(Command::Ingest(args)) => run_ingest(args, false).await,
+        Some(Command::Gc(args)) => run_ingest(args, true).await,
         None => run(cli.semantic).await,
     }
+}
+
+/// Ingest (or, with `gc`, garbage-collect) a record source into the store.
+async fn run_ingest(cli: IngestArgs, gc: bool) -> anyhow::Result<()> {
+    let store_name = cli.store.unwrap_or_else(|| DEFAULT_STORE.to_owned());
+    let base_url = cli
+        .base_url
+        .unwrap_or_else(|| mixedbread::DEFAULT_BASE_URL.to_owned());
+    let store = MixedbreadStore::from_login(base_url).await?;
+    let dir = Path::new(&cli.dir);
+    let source: Source = cli.source.parse()?;
+
+    match source {
+        Source::Linear => {
+            let adapter = linear_export::LinearExport::open(dir)?;
+            run_one_source(&adapter, &store, &store_name, gc).await
+        }
+        Source::Slack => {
+            let adapter = slack_export::SlackExport::open(dir)?;
+            run_one_source(&adapter, &store, &store_name, gc).await
+        }
+        Source::Code | Source::Web => anyhow::bail!(
+            "ingest covers record sources (slack, linear); code is indexed by a normal `search`"
+        ),
+    }
+}
+
+async fn run_one_source(
+    adapter: &(impl SourceAdapter + Sync),
+    store: &MixedbreadStore,
+    store_name: &str,
+    gc: bool,
+) -> anyhow::Result<()> {
+    if gc {
+        let report = search_core::gc_documents(adapter, store, store_name).await?;
+        println!(
+            "gc {}: deleted {} stale records, kept {}",
+            adapter.source(),
+            report.deleted,
+            report.kept
+        );
+        return Ok(());
+    }
+
+    let bar = std::io::stderr().is_terminal().then(ProgressBar::new_spinner);
+    if let Some(bar) = &bar {
+        bar.set_style(progress_style::bar("cyan"));
+        bar.set_prefix("uploading records");
+    }
+    let on_progress = |done: usize, total: usize| {
+        if let (Some(bar), true) = (&bar, total > 0) {
+            bar.set_length(u64::try_from(total).unwrap_or(u64::MAX));
+            bar.set_position(u64::try_from(done).unwrap_or(u64::MAX));
+        }
+    };
+    let report =
+        search_core::sync_documents(adapter, store, store_name, INDEX_TIMEOUT, on_progress).await?;
+    if let Some(bar) = &bar {
+        bar.finish_and_clear();
+    }
+    println!(
+        "ingest {}: uploaded {}, skipped {}, total {}",
+        adapter.source(),
+        report.uploaded,
+        report.skipped,
+        report.total
+    );
+    Ok(())
 }
 
 async fn run(cli: SemanticArgs) -> anyhow::Result<()> {

--- a/packages/search/src/main.rs
+++ b/packages/search/src/main.rs
@@ -143,8 +143,9 @@ fn parse_sources(values: &[String]) -> anyhow::Result<Vec<Source>> {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Args)]
 struct SemanticArgs {
-    /// The query to search for.
-    pattern: String,
+    /// The query to search for. Required for a bare search; omitted when a
+    /// subcommand (grep/ingest/gc) is used.
+    pattern: Option<String>,
 
     /// Directory to search in (defaults to the current directory).
     path: Option<String>,
@@ -309,6 +310,12 @@ async fn run_one_source(
 }
 
 async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
+    // `pattern` is optional at the clap layer so a subcommand can be given
+    // without it; a bare search still requires one.
+    let pattern = cli
+        .pattern
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("a query is required: `search <pattern> [path]`"))?;
     let root = resolve_root(cli.path.as_deref())?;
     anyhow::ensure!(
         !at_or_above_home(&root),
@@ -341,7 +348,7 @@ async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
     let query = Query {
         root: &root,
         store_name: &store_name,
-        text: &cli.pattern,
+        text: &pattern,
         top_k: cli.max_count.max(1),
         options: SearchOptions {
             rerank: !cli.no_rerank,

--- a/packages/search/src/main.rs
+++ b/packages/search/src/main.rs
@@ -15,8 +15,8 @@ use anstyle::{AnsiColor, Style};
 use clap::{Args, Parser, Subcommand};
 use indicatif::ProgressBar;
 use search_core::{
-    Config, DEFAULT_STORE, DisplayHit, GrepOptions, GrepTargets, MixedbreadStore, Query,
-    SearchOptions, StoreStatus,
+    CodeScope, Config, DEFAULT_STORE, DisplayHit, Filter, FilterSpec, GrepOptions, GrepTargets,
+    MixedbreadStore, Query, SearchOptions, Source, StoreStatus, build_filter, repo_slug,
 };
 
 /// How long to wait for freshly uploaded files to finish embedding.
@@ -46,6 +46,69 @@ struct Cli {
 enum Command {
     /// Grep the indexed chunks with a regular expression.
     Grep(GrepArgs),
+}
+
+/// Scope selectors shared by the semantic and grep paths. With no selector the
+/// default is all sources, with code scoped to the current worktree.
+#[derive(Debug, Args)]
+struct ScopeArgs {
+    /// Restrict to these sources (repeatable): code, slack, linear, web.
+    #[arg(long = "source", value_name = "SOURCE")]
+    sources: Vec<String>,
+
+    /// Exclude these sources (repeatable).
+    #[arg(long = "not-source", value_name = "SOURCE")]
+    not_sources: Vec<String>,
+
+    /// Restrict code to a repository slug (e.g. indexable-inc/index).
+    #[arg(long)]
+    repo: Option<String>,
+
+    /// Search code across all repositories, not just this checkout.
+    #[arg(long = "all-repos")]
+    all_repos: bool,
+
+    /// Search this repository across all worktrees, not just files checked out
+    /// here.
+    #[arg(long = "all-worktrees")]
+    all_worktrees: bool,
+}
+
+/// Resolve scope selectors into a server-side metadata filter and the code
+/// scoping mode.
+fn resolve_scope(scope: &ScopeArgs, root: &Path) -> anyhow::Result<(Option<Filter>, CodeScope)> {
+    let sources = parse_sources(&scope.sources)?;
+    let exclude_sources = parse_sources(&scope.not_sources)?;
+
+    // A repo / all-repos / all-worktrees query is server-filtered: the manifest
+    // can only answer "files checked out here", so anything coarser must trust
+    // the metadata filter instead.
+    let (repo, code_scope) = if scope.all_repos {
+        (None, CodeScope::ServerFiltered)
+    } else if let Some(repo) = scope.repo.clone() {
+        (Some(repo), CodeScope::ServerFiltered)
+    } else if scope.all_worktrees {
+        (Some(repo_slug(root).as_str().to_owned()), CodeScope::ServerFiltered)
+    } else {
+        (None, CodeScope::WorktreeExact)
+    };
+
+    let spec = FilterSpec {
+        sources,
+        exclude_sources,
+        repo,
+    };
+    Ok((build_filter(&spec), code_scope))
+}
+
+fn parse_sources(values: &[String]) -> anyhow::Result<Vec<Source>> {
+    values
+        .iter()
+        // A source may arrive comma-joined (`--source code,slack`) or repeated.
+        .flat_map(|value| value.split(','))
+        .filter(|value| !value.is_empty())
+        .map(|value| value.parse::<Source>().map_err(anyhow::Error::from))
+        .collect()
 }
 
 /// Arguments for the default search path. Flags mirror `mgrep search`
@@ -89,6 +152,10 @@ struct SemanticArgs {
     #[arg(long)]
     agentic: bool,
 
+    /// Source and repo scope selectors.
+    #[command(flatten)]
+    scope: ScopeArgs,
+
     /// Store name (one store holds every worktree's content).
     #[arg(long, env = "MXBAI_STORE")]
     store: Option<String>,
@@ -123,6 +190,10 @@ struct GrepArgs {
     /// Search the store as-is: skip detecting and embedding new files.
     #[arg(long = "no-sync")]
     no_sync: bool,
+
+    /// Source and repo scope selectors.
+    #[command(flatten)]
+    scope: ScopeArgs,
 
     /// Store name (one store holds every worktree's content).
     #[arg(long, env = "MXBAI_STORE")]
@@ -171,6 +242,7 @@ async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
         .unwrap_or_else(|| mixedbread::DEFAULT_BASE_URL.to_owned());
     let store = MixedbreadStore::from_login(base_url).await?;
 
+    let (filter, code_scope) = resolve_scope(&cli.scope, &root)?;
     let query = Query {
         root: &root,
         store_name: &store_name,
@@ -182,6 +254,8 @@ async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
         },
         sync: !cli.no_sync,
         include_web: cli.web,
+        filters: filter.as_ref(),
+        code_scope,
         index_timeout: INDEX_TIMEOUT,
     };
 
@@ -278,6 +352,7 @@ async fn run_grep(cli: GrepArgs) -> anyhow::Result<()> {
 
     // Grep reuses the shared `Query` shape; its semantic-only knobs (rerank,
     // agentic, web) are inert here, and the grep pattern travels in `text`.
+    let (filter, code_scope) = resolve_scope(&cli.scope, &root)?;
     let query = Query {
         root: &root,
         store_name: &store_name,
@@ -289,6 +364,8 @@ async fn run_grep(cli: GrepArgs) -> anyhow::Result<()> {
         },
         sync: !cli.no_sync,
         include_web: false,
+        filters: filter.as_ref(),
+        code_scope,
         index_timeout: INDEX_TIMEOUT,
     };
     let grep_options = GrepOptions {
@@ -463,7 +540,9 @@ fn render(
     root: &Path,
     theme: code_highlight::Theme,
 ) -> String {
-    let prefix = if hit.is_web { "" } else { "./" };
+    // Only local code gets the `./path` prefix; web URLs and record titles
+    // (Slack threads, Linear issues) print as-is.
+    let prefix = if hit.source == Source::Code { "./" } else { "" };
     let path = paint(palette.path, &format!("{prefix}{}", hit.label));
 
     // `start_line` is 0-based and `num_lines` is a line count, so the displayed
@@ -533,10 +612,10 @@ fn render_snippet(
     }
 
     // Prefer syntax-highlighting the real file lines: tree-sitter gets full
-    // parse context and code-highlight renders its own line-number gutter. Falls
-    // through to a plain gutter over the chunk text if the file is unreadable
-    // (e.g. a web hit or a file changed since indexing).
-    if !hit.is_web
+    // parse context and code-highlight renders its own line-number gutter. Only
+    // local code has a readable file; web/Slack/Linear hits fall through to a
+    // plain gutter over the chunk text.
+    if hit.source == Source::Code
         && let Some(num) = hit.num_lines
         && let Ok(source) = std::fs::read_to_string(root.join(&hit.label))
     {
@@ -590,7 +669,7 @@ fn numbered_plain(body: &str, start: u32) -> String {
 mod tests {
     use std::path::Path;
 
-    use search_core::DisplayHit;
+    use search_core::{DisplayHit, Source};
 
     use super::{Palette, render_snippet};
 
@@ -599,11 +678,11 @@ mod tests {
     fn hit(text: &str) -> DisplayHit {
         DisplayHit {
             label: "web://example".to_owned(),
+            source: Source::Web,
             start_line: Some(4),
             num_lines: Some(2),
             score: 0.5,
             text: text.to_owned(),
-            is_web: true,
         }
     }
 

--- a/packages/slack-export/Cargo.toml
+++ b/packages/slack-export/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "slack-export"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Adapter turning a Slack export into per-thread embeddable search documents"
+
+[lints]
+workspace = true
+
+[dependencies]
+search-meta.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+snafu.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/packages/slack-export/package.nix
+++ b/packages/slack-export/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "slack-export";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/slack-export/src/channel.rs
+++ b/packages/slack-export/src/channel.rs
@@ -1,0 +1,239 @@
+//! Channel discovery and per-channel message loading.
+//!
+//! The export has one directory per channel, named either `C0...--name`,
+//! `C0...-name`, or just `name` (no id prefix). The leading `C0...` token, when
+//! present, is the channel id; otherwise the id is resolved from `channels.json`
+//! by name. Each directory holds `YYYY-MM-DD.json` files, every one an array of
+//! message objects. Replies of a thread can live in different day files, so a
+//! caller that wants whole threads must read the whole directory.
+
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use snafu::ResultExt as _;
+
+use crate::{
+    error::{Error, ListDirSnafu, ParseSnafu, ReadSnafu},
+    model::{ChannelEntry, Message},
+};
+
+/// The resolved facts about one channel needed to build its thread documents.
+#[derive(Debug, Clone)]
+pub struct ChannelInfo {
+    /// Stable channel id, e.g. `C0AGC8VFVQV`.
+    pub id: String,
+    /// Display name with any id prefix stripped, e.g. `alerts`.
+    pub name: String,
+    /// Whether the channel is archived.
+    pub is_archived: bool,
+    /// Whether this is an external / Slack-Connect channel (heuristic; see
+    /// [`is_external_name`]).
+    pub is_external: bool,
+    /// Channel topic text, possibly empty.
+    pub topic: String,
+    /// Absolute path of the channel's directory.
+    pub dir: PathBuf,
+}
+
+/// A directory entry whose name encodes (optionally) a channel id and a name.
+#[derive(Debug, Clone)]
+pub struct ChannelDir {
+    /// Channel id parsed from the prefix, if the directory had one.
+    pub id_from_prefix: Option<String>,
+    /// The directory name with any leading `C0...` token removed.
+    pub display_name: String,
+    /// The full original directory name, used for the external heuristic.
+    pub raw_dir_name: String,
+    /// Absolute path of the directory.
+    pub path: PathBuf,
+}
+
+/// Files at the export root that are not channel directories and must be skipped
+/// when discovering channels.
+const NON_CHANNEL_DIRS: &[&str] = &["__files__", "agent-traces"];
+
+/// Discover every channel directory under the export root.
+///
+/// A subdirectory is treated as a channel unless it is a known auxiliary
+/// directory. Auxiliary top-level JSON files are ignored because we only list
+/// directories here.
+///
+/// # Errors
+/// Returns [`Error::ListDir`] if the export root cannot be listed.
+pub fn discover_channel_dirs(root: &Path) -> Result<Vec<ChannelDir>, Error> {
+    let mut dirs = Vec::new();
+    let entries = fs::read_dir(root).context(ListDirSnafu { path: root.to_path_buf() })?;
+    for entry in entries {
+        let entry = entry.context(ListDirSnafu { path: root.to_path_buf() })?;
+        let file_type = entry.file_type().context(ListDirSnafu { path: root.to_path_buf() })?;
+        if !file_type.is_dir() {
+            continue;
+        }
+        let raw = entry.file_name().to_string_lossy().into_owned();
+        if NON_CHANNEL_DIRS.contains(&raw.as_str()) {
+            continue;
+        }
+        let (id_from_prefix, display_name) = split_id_prefix(&raw);
+        dirs.push(ChannelDir {
+            id_from_prefix,
+            display_name,
+            raw_dir_name: raw,
+            path: entry.path(),
+        });
+    }
+    dirs.sort_by(|a, b| a.raw_dir_name.cmp(&b.raw_dir_name));
+    Ok(dirs)
+}
+
+/// Split a `C0...` id prefix from a directory name.
+///
+/// Recognizes `C0XYZ--name`, `C0XYZ-name`, and a bare `C0XYZ`. A name with no
+/// id prefix returns `(None, name)`. The id token is a `C` followed by
+/// uppercase alphanumerics.
+#[must_use]
+fn split_id_prefix(raw: &str) -> (Option<String>, String) {
+    if !raw.starts_with('C') {
+        return (None, raw.to_owned());
+    }
+    let id_len = raw
+        .char_indices()
+        .take_while(|(_, ch)| ch.is_ascii_uppercase() || ch.is_ascii_digit())
+        .map(|(idx, ch)| idx + ch.len_utf8())
+        .last()
+        .unwrap_or(0);
+    // A real id is more than just "C"; require at least a few chars.
+    if id_len < 4 {
+        return (None, raw.to_owned());
+    }
+    let (id, rest) = raw.split_at(id_len);
+    let name = rest.trim_start_matches('-');
+    if name.is_empty() {
+        // Directory was just the id; use the id as the display name.
+        (Some(id.to_owned()), id.to_owned())
+    } else {
+        (Some(id.to_owned()), name.to_owned())
+    }
+}
+
+/// Heuristic for whether a channel is external / Slack-Connect.
+///
+/// Slack-Connect channels in this export are named with an `ext-` segment
+/// (e.g. `ext-softmachine`, `C0...-ext-nu`). We flag a channel external when
+/// its name (id prefix stripped) starts with `ext-` or contains `-ext-`. This
+/// is a documented name heuristic, not a schema field: the export's
+/// `channels.json` carries no `is_ext_shared`/`is_shared` flag.
+#[must_use]
+pub fn is_external_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower.starts_with("ext-") || lower.contains("-ext-") || lower == "ext"
+}
+
+/// Resolve a [`ChannelDir`] to a full [`ChannelInfo`], filling id, topic, and
+/// archived flag from `channels.json` when available.
+///
+/// Resolution order for the id: the directory-name prefix, else a lookup by
+/// display name in `channels.json`, else a synthetic id derived from the name
+/// (so a channel with no metadata entry still gets a stable `external_id`).
+#[must_use]
+pub fn resolve_channel(dir: &ChannelDir, by_id: &HashMap<String, ChannelEntry>, by_name: &HashMap<String, ChannelEntry>) -> ChannelInfo {
+    let entry = dir
+        .id_from_prefix
+        .as_deref()
+        .and_then(|id| by_id.get(id))
+        .or_else(|| by_name.get(&dir.display_name));
+
+    let id = dir
+        .id_from_prefix
+        .clone()
+        .or_else(|| entry.map(|entry| entry.id.clone()))
+        .unwrap_or_else(|| format!("name:{}", dir.display_name));
+
+    let name = dir.display_name.clone();
+    let is_archived = entry.is_some_and(|entry| entry.is_archived);
+    let topic = entry.map(|entry| entry.topic.value.clone()).unwrap_or_default();
+    let is_external = is_external_name(&name) || is_external_name(&dir.raw_dir_name);
+
+    ChannelInfo {
+        id,
+        name,
+        is_archived,
+        is_external,
+        topic,
+        dir: dir.path.clone(),
+    }
+}
+
+/// Read and parse every `YYYY-MM-DD.json` day file in a channel directory into
+/// a single flat list of messages.
+///
+/// Files are read in sorted name order for determinism, but ordering within a
+/// thread is re-established later by ts, so the read order does not affect the
+/// final body.
+///
+/// # Errors
+/// Returns [`Error::ListDir`] / [`Error::Read`] / [`Error::Parse`] if the
+/// directory cannot be listed or a day file cannot be read or parsed.
+pub fn read_channel_messages(dir: &Path) -> Result<Vec<Message>, Error> {
+    let mut day_files: Vec<PathBuf> = Vec::new();
+    let entries = fs::read_dir(dir).context(ListDirSnafu { path: dir.to_path_buf() })?;
+    for entry in entries {
+        let entry = entry.context(ListDirSnafu { path: dir.to_path_buf() })?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("json") {
+            day_files.push(path);
+        }
+    }
+    day_files.sort();
+
+    let mut messages = Vec::new();
+    for path in day_files {
+        let bytes = fs::read(&path).context(ReadSnafu { path: path.clone() })?;
+        let day: Vec<Message> = serde_json::from_slice(&bytes).context(ParseSnafu { path: path.clone() })?;
+        messages.extend(day);
+    }
+    Ok(messages)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_external_name, split_id_prefix};
+
+    #[test]
+    fn splits_double_dash_id_prefix() {
+        let (id, name) = split_id_prefix("C0AGC8VFVQV--alerts");
+        assert_eq!(id.as_deref(), Some("C0AGC8VFVQV"));
+        assert_eq!(name, "alerts");
+    }
+
+    #[test]
+    fn splits_single_dash_id_prefix() {
+        let (id, name) = split_id_prefix("C0AQELZ5H3N-ext-nu");
+        assert_eq!(id.as_deref(), Some("C0AQELZ5H3N"));
+        assert_eq!(name, "ext-nu");
+    }
+
+    #[test]
+    fn leaves_plain_name_alone() {
+        let (id, name) = split_id_prefix("p-billing");
+        assert_eq!(id, None);
+        assert_eq!(name, "p-billing");
+    }
+
+    #[test]
+    fn bare_id_directory_uses_id_as_name() {
+        let (id, name) = split_id_prefix("C0AHW2W3V7W");
+        assert_eq!(id.as_deref(), Some("C0AHW2W3V7W"));
+        assert_eq!(name, "C0AHW2W3V7W");
+    }
+
+    #[test]
+    fn external_heuristic() {
+        assert!(is_external_name("ext-softmachine"));
+        assert!(is_external_name("C0AQELZ5H3N-ext-nu"));
+        assert!(!is_external_name("p-billing"));
+        assert!(!is_external_name("context"));
+    }
+}

--- a/packages/slack-export/src/error.rs
+++ b/packages/slack-export/src/error.rs
@@ -1,0 +1,55 @@
+//! The single error type for the adapter.
+//!
+//! Every fallible step (reading a file, parsing JSON, checking metadata) maps
+//! into one [`Error`] variant so the [`SourceAdapter`](search_meta::SourceAdapter)
+//! contract is satisfied with a single `Send + Sync + 'static` type.
+
+use std::path::PathBuf;
+
+use snafu::Snafu;
+
+/// A failure while opening or iterating a Slack export.
+///
+/// Each variant carries the path or id it concerns so a failure mid-ingest
+/// names the offending file or record rather than failing opaquely.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// A required file (`channels.json`, `users.json`) or a channel day file
+    /// could not be read.
+    #[snafu(display("failed to read {}", path.display()))]
+    Read {
+        /// The file that could not be read.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// A channel directory could not be listed.
+    #[snafu(display("failed to list channel directory {}", path.display()))]
+    ListDir {
+        /// The directory that could not be listed.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// A JSON file did not parse into the expected shape.
+    #[snafu(display("failed to parse JSON in {}", path.display()))]
+    Parse {
+        /// The file whose contents did not parse.
+        path: PathBuf,
+        /// Underlying serde error.
+        source: serde_json::Error,
+    },
+
+    /// A record's flattened metadata exceeded a store limit.
+    #[snafu(display("metadata rejected for {external_id}"))]
+    Metadata {
+        /// The record whose metadata was rejected.
+        external_id: String,
+        /// Underlying limit error from `search-meta`.
+        source: search_meta::MetadataError,
+    },
+}

--- a/packages/slack-export/src/lib.rs
+++ b/packages/slack-export/src/lib.rs
@@ -1,0 +1,176 @@
+//! Turn a Slack export directory into per-thread embeddable [`Document`]s for
+//! the multi-source `search` tool.
+//!
+//! # Grain
+//!
+//! One [`Document`] per **thread**. A thread is every message sharing a
+//! `(channel_id, thread_ts)`; a standalone message (no `thread_ts`) is its own
+//! single-message thread keyed on its `ts`. A thread's replies can be scattered
+//! across several `YYYY-MM-DD.json` day files, so the adapter reads a whole
+//! channel directory before grouping. Administrative/system messages
+//! (`channel_join`, `channel_leave`, and similar) are dropped.
+//!
+//! # Streaming
+//!
+//! [`SlackExport::open`] reads only the small `channels.json` and `users.json`
+//! up front. [`SlackExport::documents`](search_meta::SourceAdapter::documents)
+//! then iterates **channel by channel**: it loads one channel's day files,
+//! assembles and yields that channel's thread documents, and only then moves to
+//! the next channel. The whole 344 MB export is never held in memory at once.
+//!
+//! # Identity and hashing
+//!
+//! - `external_id = "slack:{channel_id}:{thread_ts}"`.
+//! - `content_hash = search_meta::hash_body(body)` over the exact embedded
+//!   bytes, so re-ingesting an unchanged export is a no-op and a record
+//!   re-embeds only when its rendered body actually changes.
+//! - `timestamp` is the root message's `ts` integer part, epoch seconds.
+//!
+//! The flat `meta_json` carries the common header (`source`, `external_id`,
+//! `content_hash`, `title`, `timestamp`) plus the Slack extras (`channel_id`,
+//! `channel_name`, `authors`, `is_archived`, `is_external`, `is_bot_thread`,
+//! `message_count`, `has_files`, `thread_ts`). Each is a top-level filter key.
+
+mod channel;
+mod error;
+mod model;
+mod render;
+mod thread;
+mod users;
+
+use std::{collections::HashMap, fs, path::Path};
+
+use search_meta::{Document, Source, SourceAdapter};
+use snafu::ResultExt as _;
+
+pub use crate::error::Error;
+use crate::{
+    channel::{ChannelDir, ChannelInfo, discover_channel_dirs, read_channel_messages, resolve_channel},
+    error::{ParseSnafu, ReadSnafu},
+    model::{ChannelEntry, UserEntry},
+    thread::documents_for_channel,
+    users::UserMap,
+};
+
+/// Default name of the channel-metadata file at the export root.
+const CHANNELS_FILE: &str = "channels.json";
+/// Default name of the users-map file at the export root.
+const USERS_FILE: &str = "users.json";
+
+/// An opened Slack export ready to stream into per-thread documents.
+///
+/// Holds only the small in-memory indices (channel metadata, the user map, the
+/// list of channel directories); message bodies are read lazily, one channel at
+/// a time, when [`documents`](SourceAdapter::documents) is iterated.
+#[derive(Debug)]
+#[must_use]
+pub struct SlackExport {
+    channel_dirs: Vec<ChannelDir>,
+    by_id: HashMap<String, ChannelEntry>,
+    by_name: HashMap<String, ChannelEntry>,
+    users: UserMap,
+}
+
+impl SlackExport {
+    /// Open an export rooted at `dir`, reading `channels.json` and `users.json`
+    /// and listing the channel directories.
+    ///
+    /// `users.json` is optional: when it is absent the adapter falls back to the
+    /// `user_profile` embedded on each message for name resolution.
+    ///
+    /// # Errors
+    /// Returns [`Error::Read`] / [`Error::Parse`] if `channels.json` (or a
+    /// present `users.json`) cannot be read or parsed, or [`Error::ListDir`] if
+    /// the export root cannot be listed.
+    pub fn open(dir: &Path) -> Result<Self, Error> {
+        let channels = read_channels(&dir.join(CHANNELS_FILE))?;
+        let mut by_id = HashMap::with_capacity(channels.len());
+        let mut by_name = HashMap::with_capacity(channels.len());
+        for entry in channels {
+            by_name.entry(entry.name.clone()).or_insert_with(|| entry.clone());
+            by_id.insert(entry.id.clone(), entry);
+        }
+
+        let users = read_users(&dir.join(USERS_FILE))?;
+        let channel_dirs = discover_channel_dirs(dir)?;
+
+        Ok(Self {
+            channel_dirs,
+            by_id,
+            by_name,
+            users,
+        })
+    }
+
+    /// Resolve one channel directory to its full [`ChannelInfo`].
+    fn channel_info(&self, channel_dir: &ChannelDir) -> ChannelInfo {
+        resolve_channel(channel_dir, &self.by_id, &self.by_name)
+    }
+}
+
+impl SourceAdapter for SlackExport {
+    type Error = Error;
+
+    fn source(&self) -> Source {
+        Source::Slack
+    }
+
+    fn documents(&self) -> impl Iterator<Item = Result<Document, Error>> + Send {
+        // Each channel's day files are read only when its turn comes, then the
+        // documents for that channel are flattened out before the next channel
+        // is touched. The owned `users` clone lets the streaming iterator hold
+        // the user map without re-borrowing `self` per channel.
+        let users = self.users.clone();
+
+        self.channel_dirs.iter().flat_map(move |channel_dir| {
+            let info = self.channel_info(channel_dir);
+            let result = read_channel_messages(&info.dir)
+                .and_then(|messages| documents_for_channel(&info, &users, messages));
+            match result {
+                Ok(documents) => DocumentBatch::Items(documents.into_iter()),
+                Err(error) => DocumentBatch::Error(Some(error)),
+            }
+        })
+    }
+}
+
+/// One channel's yield: either its documents or the single error that aborted
+/// the channel. Keeping this as a concrete `Send` iterator avoids boxing while
+/// still letting one channel's failure surface as a typed `Err`.
+enum DocumentBatch {
+    /// The channel's successfully built documents.
+    Items(std::vec::IntoIter<Document>),
+    /// The channel failed; yield the error exactly once.
+    Error(Option<Error>),
+}
+
+impl Iterator for DocumentBatch {
+    type Item = Result<Document, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Items(items) => items.next().map(Ok),
+            Self::Error(slot) => slot.take().map(Err),
+        }
+    }
+}
+
+/// Read and parse `channels.json`.
+fn read_channels(path: &Path) -> Result<Vec<ChannelEntry>, Error> {
+    let bytes = fs::read(path).context(ReadSnafu { path: path.to_path_buf() })?;
+    serde_json::from_slice(&bytes).context(ParseSnafu { path: path.to_path_buf() })
+}
+
+/// Read and parse the users map, returning an empty map when the file is
+/// absent (the adapter then resolves names from message-embedded profiles).
+fn read_users(path: &Path) -> Result<UserMap, Error> {
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(UserMap::default());
+        }
+        Err(error) => return Err(error).context(ReadSnafu { path: path.to_path_buf() }),
+    };
+    let entries: Vec<UserEntry> = serde_json::from_slice(&bytes).context(ParseSnafu { path: path.to_path_buf() })?;
+    Ok(UserMap::from_entries(entries))
+}

--- a/packages/slack-export/src/model.rs
+++ b/packages/slack-export/src/model.rs
@@ -1,0 +1,235 @@
+//! Named `Deserialize` shapes for the slices of the Slack export this adapter
+//! reads.
+//!
+//! The export's JSON has far more fields than we use; every struct keeps only
+//! what the adapter needs and uses `#[serde(default)]` so an optional field
+//! absent from a given record (or a future schema change) parses rather than
+//! erroring. Fields we deliberately ignore (avatars, image URLs, huddle state,
+//! the heterogeneous `members` field that is sometimes an int and sometimes an
+//! array) are simply not declared.
+
+use serde::Deserialize;
+
+/// One entry in `channels.json`.
+///
+/// `name` may or may not carry the channel-id prefix that the on-disk
+/// directory uses; we treat the directory name as canonical for resolution and
+/// use this only to fill in metadata (topic, archived flag) by id.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChannelEntry {
+    /// Stable channel id, e.g. `C0AGC8VFVQV`.
+    pub id: String,
+    /// Channel name as recorded in the export.
+    #[serde(default)]
+    pub name: String,
+    /// Whether the channel is archived.
+    #[serde(default)]
+    pub is_archived: bool,
+    /// Channel topic; only `value` is used.
+    #[serde(default)]
+    pub topic: TextValue,
+}
+
+/// A `{ "value": "..." }` wrapper used by both `topic` and `purpose`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct TextValue {
+    /// The human text, possibly empty.
+    #[serde(default)]
+    pub value: String,
+}
+
+/// One entry in `users.json`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct UserEntry {
+    /// Stable user id, e.g. `U0A5CNC980Z`.
+    pub id: String,
+    /// The handle (`name`), used as a last resort before the raw id.
+    #[serde(default)]
+    pub name: String,
+    /// Whether this user is a bot/integration account.
+    #[serde(default)]
+    pub is_bot: bool,
+    /// Profile holding the display and real names.
+    #[serde(default)]
+    pub profile: UserProfile,
+}
+
+/// The subset of a user (or message-embedded) profile we resolve names from.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct UserProfile {
+    /// Preferred display name; frequently empty in exports.
+    #[serde(default)]
+    pub display_name: String,
+    /// Fallback real name when the display name is empty.
+    #[serde(default)]
+    pub real_name: String,
+}
+
+impl UserProfile {
+    /// The best non-empty name in this profile, if any: display name, else
+    /// real name. Returns `None` when both are empty so the caller can fall
+    /// through to a further fallback.
+    #[must_use]
+    pub fn best_name(&self) -> Option<&str> {
+        let display = self.display_name.trim();
+        if !display.is_empty() {
+            return Some(display);
+        }
+        let real = self.real_name.trim();
+        if real.is_empty() { None } else { Some(real) }
+    }
+}
+
+/// One Slack message object from a `YYYY-MM-DD.json` day file.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Message {
+    /// Message timestamp, the per-message key, e.g. `"1775413663.871359"`.
+    #[serde(default)]
+    pub ts: String,
+    /// Thread root timestamp; present on both replies and thread roots.
+    #[serde(default)]
+    pub thread_ts: Option<String>,
+    /// Message subtype; `None`/absent for a regular human message.
+    #[serde(default)]
+    pub subtype: Option<String>,
+    /// Author user id, e.g. `U0A5CNC980Z`; absent on some bot messages.
+    #[serde(default)]
+    pub user: Option<String>,
+    /// Raw message text with Slack markup still present.
+    #[serde(default)]
+    pub text: String,
+    /// Bot id, present on integration/bot messages.
+    #[serde(default)]
+    pub bot_id: Option<String>,
+    /// App id, present on some app messages.
+    #[serde(default)]
+    pub app_id: Option<String>,
+    /// Bot profile, the name source for a bot message.
+    #[serde(default)]
+    pub bot_profile: Option<BotProfile>,
+    /// Profile embedded on the message, the fallback name source when the
+    /// author id is missing from `users.json`.
+    #[serde(default)]
+    pub user_profile: Option<UserProfile>,
+    /// Reactions on the message.
+    #[serde(default)]
+    pub reactions: Vec<Reaction>,
+    /// Files attached to the message.
+    #[serde(default)]
+    pub files: Vec<FileRef>,
+    /// Message attachments (link unfurls, bot cards).
+    #[serde(default)]
+    pub attachments: Vec<Attachment>,
+}
+
+impl Message {
+    /// The grouping key for this message: its `thread_ts` if it is part of a
+    /// thread, otherwise its own `ts` (a standalone single-message thread).
+    #[must_use]
+    pub fn thread_key(&self) -> &str {
+        match &self.thread_ts {
+            Some(root) if !root.is_empty() => root,
+            _ => &self.ts,
+        }
+    }
+
+    /// Whether this message originates from a bot or integration.
+    #[must_use]
+    pub fn is_bot(&self) -> bool {
+        self.bot_id.is_some() || self.app_id.is_some() || self.subtype.as_deref() == Some("bot_message")
+    }
+}
+
+/// A bot's display profile on a message.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BotProfile {
+    /// The bot's display name, e.g. `Better Stack`.
+    #[serde(default)]
+    pub name: String,
+}
+
+/// A single reaction tally.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Reaction {
+    /// Emoji short name, e.g. `+1`.
+    #[serde(default)]
+    pub name: String,
+    /// How many people reacted.
+    #[serde(default)]
+    pub count: u32,
+}
+
+/// A file attached to a message. We index its name and type, never its bytes.
+#[derive(Debug, Clone, Deserialize)]
+pub struct FileRef {
+    /// File name, e.g. `image.png`.
+    #[serde(default)]
+    pub name: String,
+    /// Title, used when `name` is empty.
+    #[serde(default)]
+    pub title: String,
+    /// Human-readable type, e.g. `PNG`.
+    #[serde(default)]
+    pub pretty_type: String,
+    /// Machine type, e.g. `png`; fallback when `pretty_type` is empty.
+    #[serde(default)]
+    pub filetype: String,
+}
+
+impl FileRef {
+    /// The best label for the file: its name, else its title, else `"file"`.
+    #[must_use]
+    pub fn label(&self) -> &str {
+        let name = self.name.trim();
+        if !name.is_empty() {
+            return name;
+        }
+        let title = self.title.trim();
+        if title.is_empty() { "file" } else { title }
+    }
+
+    /// The best type string: `pretty_type`, else `filetype`. May be empty.
+    #[must_use]
+    pub fn type_str(&self) -> &str {
+        let pretty = self.pretty_type.trim();
+        if pretty.is_empty() { self.filetype.trim() } else { pretty }
+    }
+}
+
+/// A message attachment (link unfurl or bot card). We pull whatever prose it
+/// carries into the body.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Attachment {
+    /// Plain-text fallback Slack provides for the attachment.
+    #[serde(default)]
+    pub fallback: String,
+    /// The attachment body text, when richer than the fallback.
+    #[serde(default)]
+    pub text: String,
+    /// The attachment title.
+    #[serde(default)]
+    pub title: String,
+}
+
+impl Attachment {
+    /// The best prose for this attachment: its text, then title, then a
+    /// fallback that is not Slack's placeholder noise. Empty when nothing
+    /// useful is present.
+    #[must_use]
+    pub fn prose(&self) -> &str {
+        let text = self.text.trim();
+        if !text.is_empty() {
+            return text;
+        }
+        let title = self.title.trim();
+        if !title.is_empty() {
+            return title;
+        }
+        let fallback = self.fallback.trim();
+        if fallback.is_empty() || fallback == "[no preview available]" {
+            ""
+        } else {
+            fallback
+        }
+    }
+}

--- a/packages/slack-export/src/render.rs
+++ b/packages/slack-export/src/render.rs
@@ -1,0 +1,164 @@
+//! Rendering Slack message text into the plain prose that gets embedded.
+//!
+//! Slack stores entities as angle-bracket tokens (`<@U123>`, `<#C1|name>`,
+//! `<url|label>`, `<!here>`) and HTML-escapes `&`, `<`, `>`. This module turns
+//! those into readable text before the body is hashed and embedded. It scans
+//! the string once rather than pulling in a regex engine; the grammar is small
+//! and unnested.
+//!
+//! Mentions are resolved through the [`UserMap`], so a `<@U123>` becomes
+//! `@Display Name`. The id is never dropped: an unknown id renders as `@U123`.
+
+use crate::{model::UserProfile, users::UserMap};
+
+/// Render one message's raw text into embeddable prose.
+///
+/// `users` resolves `<@U..>` mentions; `message_profile` is the author's
+/// message-embedded profile, used as a mention fallback for the author's own
+/// id when it is missing from the users map.
+#[must_use]
+pub fn render_text(raw: &str, users: &UserMap, message_profile: Option<&UserProfile>) -> String {
+    let expanded = expand_entities(raw, users, message_profile);
+    let unescaped = unescape_html(&expanded);
+    collapse_blank_lines(&unescaped)
+}
+
+/// Walk the string once, replacing each `<...>` entity. Text outside brackets
+/// is copied verbatim, so `*bold*` and `` `code` `` survive as literal words.
+fn expand_entities(raw: &str, users: &UserMap, message_profile: Option<&UserProfile>) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut rest = raw;
+    while let Some(open) = rest.find('<') {
+        out.push_str(&rest[..open]);
+        let after_open = &rest[open + 1..];
+        let Some(close) = after_open.find('>') else {
+            // Unterminated `<`: keep it literally and stop scanning entities.
+            out.push('<');
+            out.push_str(after_open);
+            return out;
+        };
+        let token = &after_open[..close];
+        out.push_str(&render_entity(token, users, message_profile));
+        rest = &after_open[close + 1..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Render the inside of one `<...>` token (the angle brackets already stripped).
+fn render_entity(token: &str, users: &UserMap, message_profile: Option<&UserProfile>) -> String {
+    if let Some(rest) = token.strip_prefix('@') {
+        // User mention: `@U123` or `@U123|label`.
+        let id = rest.split('|').next().unwrap_or(rest);
+        return format!("@{}", users.resolve(id, message_profile));
+    }
+    if let Some(rest) = token.strip_prefix('#') {
+        // Channel mention: `#C123|name` -> `#name`; `#C123` -> `#C123`.
+        return match rest.split_once('|') {
+            Some((_id, name)) if !name.is_empty() => format!("#{name}"),
+            _ => format!("#{rest}"),
+        };
+    }
+    if let Some(rest) = token.strip_prefix('!') {
+        // Broadcast: `!here`, `!channel`, `!everyone`, or `!subteam^..|@grp`.
+        return render_broadcast(rest);
+    }
+    // Link: `url|label` -> `label`; bare `url` -> `url`.
+    match token.split_once('|') {
+        Some((_url, label)) if !label.is_empty() => label.to_owned(),
+        Some((url, _)) => url.to_owned(),
+        None => token.to_owned(),
+    }
+}
+
+/// Render a `<!...>` broadcast token to an `@`-prefixed word.
+fn render_broadcast(rest: &str) -> String {
+    let keyword = match rest.split_once('|') {
+        // `subteam^S123|@group` -> keep the human label after the pipe.
+        Some((_id, label)) if !label.is_empty() => {
+            return label.to_owned();
+        }
+        Some((id, _)) => id,
+        None => rest,
+    };
+    let word = keyword.split('^').next().unwrap_or(keyword);
+    format!("@{word}")
+}
+
+/// Reverse Slack's HTML escaping of `&`, `<`, `>`.
+///
+/// Order matters: `&amp;` is decoded last so an escaped `&lt;` cannot be
+/// double-decoded into a real `<`.
+fn unescape_html(text: &str) -> String {
+    text.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
+}
+
+/// Collapse any run of three or more consecutive newlines down to two, so a
+/// message body never has more than one blank line in a row.
+fn collapse_blank_lines(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut newline_run: usize = 0;
+    for ch in text.chars() {
+        if ch == '\n' {
+            newline_run += 1;
+            if newline_run <= 2 {
+                out.push('\n');
+            }
+        } else {
+            newline_run = 0;
+            out.push(ch);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_text;
+    use crate::{model::UserEntry, users::UserMap};
+
+    fn user_map() -> UserMap {
+        let json = serde_json::json!([
+            { "id": "U0A5CNC980Z", "name": "andrew",
+              "profile": { "display_name": "andrew", "real_name": "Andrew Gazelka" } },
+            { "id": "U0AH08A8V5G", "name": "wyatt",
+              "profile": { "display_name": "", "real_name": "wyatt" } },
+        ]);
+        let entries: Vec<UserEntry> = serde_json::from_value(json).expect("parse fixture users");
+        UserMap::from_entries(entries)
+    }
+
+    #[test]
+    fn resolves_user_mention_to_display_name() {
+        let out = render_text("hey <@U0A5CNC980Z> look", &user_map(), None);
+        assert_eq!(out, "hey @andrew look");
+    }
+
+    #[test]
+    fn falls_back_to_real_name_then_id() {
+        assert_eq!(render_text("<@U0AH08A8V5G>", &user_map(), None), "@wyatt");
+        assert_eq!(render_text("<@U0UNKNOWN1>", &user_map(), None), "@U0UNKNOWN1");
+    }
+
+    #[test]
+    fn renders_channel_and_link_and_broadcast() {
+        let out = render_text("see <#C0X|craft> at <https://ix.dev|ix> <!here>", &user_map(), None);
+        assert_eq!(out, "see #craft at ix @here");
+    }
+
+    #[test]
+    fn keeps_bare_link_and_markup_literals() {
+        let out = render_text("read <https://ix.dev> with *bold* `code`", &user_map(), None);
+        assert_eq!(out, "read https://ix.dev with *bold* `code`");
+    }
+
+    #[test]
+    fn unescapes_html_entities() {
+        assert_eq!(render_text("sdk &gt;&gt;&gt; cli &amp; more", &user_map(), None), "sdk >>> cli & more");
+    }
+
+    #[test]
+    fn collapses_three_or_more_blank_lines() {
+        assert_eq!(render_text("a\n\n\n\nb", &user_map(), None), "a\n\nb");
+    }
+}

--- a/packages/slack-export/src/thread.rs
+++ b/packages/slack-export/src/thread.rs
@@ -1,0 +1,388 @@
+//! Assembling a channel's messages into per-thread documents.
+//!
+//! A thread is `(channel_id, thread_ts)` where `thread_ts` is the root ts; a
+//! standalone message keys on its own ts. Replies of one thread can be
+//! scattered across several `YYYY-MM-DD.json` files, so the caller must hand
+//! this module every message in the channel directory at once; we group across
+//! all of them, sort each thread by ts, and emit one [`Document`] per thread.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use search_meta::{Document, hash_body, keys};
+use serde_json::{Map, Value, json};
+use snafu::ResultExt as _;
+
+use crate::{
+    channel::ChannelInfo,
+    error::{Error, MetadataSnafu},
+    model::Message,
+    render::render_text,
+    users::UserMap,
+};
+
+/// MIME type chosen for the rendered thread body: it is plain prose.
+const BODY_MIME: &str = "text/plain; charset=utf-8";
+
+/// Subtypes that are administrative / system noise and never carry thread
+/// content. Messages with one of these are dropped before grouping.
+const DROP_SUBTYPES: &[&str] = &[
+    "channel_join",
+    "channel_leave",
+    "channel_name",
+    "channel_archive",
+    "channel_topic",
+    "channel_purpose",
+    "channel_convert_to_public",
+    "channel_convert_to_private",
+    "bot_add",
+    "bot_remove",
+    "reminder_add",
+    "automatic_ai_huddle_notes_enabled",
+    "huddle_thread",
+];
+
+/// Whether a message should be kept for embedding.
+///
+/// Drops system/admin subtypes and any message with no usable ts (it cannot be
+/// keyed or ordered). `thread_broadcast` is kept: it is a real reply that was
+/// also broadcast to the channel, and grouping by `thread_ts` plus ts-dedup
+/// makes it a single thread member rather than a duplicate standalone.
+#[must_use]
+fn is_content_message(message: &Message) -> bool {
+    if message.ts.is_empty() {
+        return false;
+    }
+    message
+        .subtype
+        .as_deref()
+        .is_none_or(|subtype| !DROP_SUBTYPES.contains(&subtype))
+}
+
+/// Parse the integer (epoch-seconds) part of a Slack `ts` string like
+/// `"1775413663.871359"`. Returns `None` when there is no leading integer.
+#[must_use]
+fn ts_epoch_seconds(ts: &str) -> Option<i64> {
+    let seconds = ts.split('.').next().unwrap_or(ts);
+    seconds.parse::<i64>().ok()
+}
+
+/// Format epoch seconds as a `YYYY-MM-DD` UTC date without pulling in a date
+/// crate: a plain civil-calendar conversion of the day number.
+#[must_use]
+fn iso_date(epoch_seconds: i64) -> String {
+    // Days since the Unix epoch (floor division so pre-1970 would still work).
+    let days = epoch_seconds.div_euclid(86_400);
+    // Convert a day number to a Gregorian date (Howard Hinnant's civil_from_days).
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if month <= 2 { year + 1 } else { year };
+    format!("{year:04}-{month:02}-{day:02}")
+}
+
+/// Build every thread document for one channel from all its messages.
+///
+/// Messages may arrive in any order and from any day file. They are filtered,
+/// grouped by thread key, each thread sorted by ts and de-duplicated by ts
+/// (handling `thread_broadcast`), then rendered. Threads are emitted in
+/// ascending root-ts order for deterministic output.
+///
+/// # Errors
+/// Returns [`Error::Metadata`] if a thread's flattened metadata exceeds a store
+/// limit.
+pub fn documents_for_channel(
+    channel: &ChannelInfo,
+    users: &UserMap,
+    messages: Vec<Message>,
+) -> Result<Vec<Document>, Error> {
+    // Group by thread key. BTreeMap keeps roots in ascending ts order; the
+    // inner BTreeMap keys by ts so duplicates (broadcasts re-seen) collapse and
+    // members come out time-ordered.
+    let mut threads: BTreeMap<String, BTreeMap<String, Message>> = BTreeMap::new();
+    for message in messages {
+        if !is_content_message(&message) {
+            continue;
+        }
+        let key = message.thread_key().to_owned();
+        threads.entry(key).or_default().insert(message.ts.clone(), message);
+    }
+
+    let mut documents = Vec::with_capacity(threads.len());
+    for (thread_ts, members) in threads {
+        let ordered: Vec<Message> = members.into_values().collect();
+        if ordered.is_empty() {
+            continue;
+        }
+        documents.push(build_document(channel, users, &thread_ts, &ordered)?);
+    }
+    Ok(documents)
+}
+
+/// Build one thread's [`Document`] from its time-ordered members.
+fn build_document(
+    channel: &ChannelInfo,
+    users: &UserMap,
+    thread_ts: &str,
+    ordered: &[Message],
+) -> Result<Document, Error> {
+    let root = &ordered[0];
+    let root_epoch = ts_epoch_seconds(&root.ts);
+
+    let mut authors: Vec<String> = Vec::new();
+    let mut has_files = false;
+    let mut all_bot = true;
+
+    let mut body = String::new();
+    write_header(&mut body, channel, root_epoch, ordered, users, &mut authors);
+
+    for message in ordered {
+        let bot = message.is_bot() || message.user.as_deref().is_some_and(|id| users.is_bot(id));
+        if !bot {
+            all_bot = false;
+        }
+        if !message.files.is_empty() {
+            has_files = true;
+        }
+        write_message_block(&mut body, message, users, bot);
+    }
+
+    let external_id = format!("slack:{}:{thread_ts}", channel.id);
+    let body_bytes = body.into_bytes();
+    let content_hash = hash_body(&body_bytes);
+
+    let title = thread_title(channel, root, users);
+    let meta = build_meta(&BuildMeta {
+        external_id: &external_id,
+        content_hash: &content_hash,
+        title: &title,
+        timestamp: root_epoch,
+        channel,
+        authors: &authors,
+        is_bot_thread: all_bot,
+        message_count: ordered.len(),
+        has_files,
+        thread_ts,
+    });
+
+    search_meta::check_metadata(&external_id, &meta).context(MetadataSnafu {
+        external_id: external_id.clone(),
+    })?;
+
+    Ok(Document {
+        external_id,
+        file_name: format!("slack/{}/{thread_ts}.txt", channel.id),
+        mime: BODY_MIME,
+        body: body_bytes,
+        meta_json: meta,
+        content_hash,
+    })
+}
+
+/// Write the channel/date/participants header into `body` and collect the
+/// distinct resolved author names (in first-seen order) into `authors`.
+fn write_header(
+    body: &mut String,
+    channel: &ChannelInfo,
+    root_epoch: Option<i64>,
+    ordered: &[Message],
+    users: &UserMap,
+    authors: &mut Vec<String>,
+) {
+    for message in ordered {
+        let name = author_name(message, users).to_owned();
+        if !authors.iter().any(|existing| existing == &name) {
+            authors.push(name);
+        }
+    }
+
+    body.push_str("Channel: #");
+    body.push_str(&channel.name);
+    if channel.is_archived {
+        body.push_str(" (archived)");
+    }
+    body.push('\n');
+
+    if let Some(epoch) = root_epoch {
+        body.push_str("Date: ");
+        body.push_str(&iso_date(epoch));
+        body.push('\n');
+    }
+
+    body.push_str("Participants: ");
+    body.push_str(&authors.join(", "));
+    body.push('\n');
+
+    let topic = channel.topic.trim();
+    if !topic.is_empty() {
+        body.push_str("Topic: ");
+        body.push_str(topic);
+        body.push('\n');
+    }
+    body.push('\n');
+}
+
+/// Write one message block (author line, rendered text, files, attachment
+/// prose, reactions) into `body`.
+fn write_message_block(body: &mut String, message: &Message, users: &UserMap, bot: bool) {
+    let author = author_name(message, users);
+    body.push('[');
+    body.push_str(author);
+    if bot {
+        body.push_str(" (bot)");
+    }
+    body.push_str("] ");
+
+    let rendered = render_text(&message.text, users, message.user_profile.as_ref());
+    body.push_str(rendered.trim_end());
+    body.push('\n');
+
+    for file in &message.files {
+        // Infallible writes into a `String`.
+        let type_str = file.type_str();
+        if type_str.is_empty() {
+            let _ = writeln!(body, "  attached: {}", file.label());
+        } else {
+            let _ = writeln!(body, "  attached: {} ({type_str})", file.label());
+        }
+    }
+
+    // Attachment prose (link unfurls, bot cards) is the only text source when a
+    // bot message has no top-level text, and supplements it otherwise.
+    for attachment in &message.attachments {
+        let prose = attachment.prose();
+        if !prose.is_empty() {
+            let rendered_prose = render_text(prose, users, message.user_profile.as_ref());
+            for line in rendered_prose.lines() {
+                let line = line.trim_end();
+                if !line.is_empty() {
+                    body.push_str("  ");
+                    body.push_str(line);
+                    body.push('\n');
+                }
+            }
+        }
+    }
+
+    if !message.reactions.is_empty() {
+        let parts: Vec<String> = message
+            .reactions
+            .iter()
+            .map(|reaction| format!("{}×{}", reaction.name, reaction.count))
+            .collect();
+        body.push_str("  reactions: ");
+        body.push_str(&parts.join(", "));
+        body.push('\n');
+    }
+}
+
+/// The display name for a message's author, following the resolution chain.
+///
+/// For a human message the author is `user`; for a bot message with no `user`
+/// we prefer the bot profile name, then fall back to the embedded profile, then
+/// a generic `bot` label.
+fn author_name<'a>(message: &'a Message, users: &'a UserMap) -> &'a str {
+    if let Some(id) = message.user.as_deref().filter(|id| !id.is_empty()) {
+        return users.resolve(id, message.user_profile.as_ref());
+    }
+    if let Some(name) = message
+        .bot_profile
+        .as_ref()
+        .map(|profile| profile.name.trim())
+        .filter(|name| !name.is_empty())
+    {
+        return name;
+    }
+    if let Some(name) = message.user_profile.as_ref().and_then(crate::model::UserProfile::best_name) {
+        return name;
+    }
+    "bot"
+}
+
+/// A short human title for the thread: `#channel: first non-empty rendered
+/// line`, truncated to a sane length.
+fn thread_title(channel: &ChannelInfo, root: &Message, users: &UserMap) -> String {
+    let rendered = render_text(&root.text, users, root.user_profile.as_ref());
+    let snippet = rendered
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("(no text)");
+    let snippet = truncate_chars(snippet, 80);
+    format!("#{}: {snippet}", channel.name)
+}
+
+/// Truncate to at most `max` characters on a char boundary, appending an
+/// ellipsis when shortened.
+fn truncate_chars(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_owned();
+    }
+    let mut out: String = text.chars().take(max).collect();
+    out.push('…');
+    out
+}
+
+/// Arguments for [`build_meta`], grouped to keep the call site readable and
+/// satisfy the clippy `too_many_arguments` lint.
+struct BuildMeta<'a> {
+    external_id: &'a str,
+    content_hash: &'a str,
+    title: &'a str,
+    timestamp: Option<i64>,
+    channel: &'a ChannelInfo,
+    authors: &'a [String],
+    is_bot_thread: bool,
+    message_count: usize,
+    has_files: bool,
+    thread_ts: &'a str,
+}
+
+/// Build the flat metadata object: the common header keys plus the Slack
+/// extras. Every key is top-level so each is a filter key.
+fn build_meta(args: &BuildMeta<'_>) -> Value {
+    let mut map = Map::new();
+    map.insert(keys::SOURCE.to_owned(), json!(search_meta::Source::Slack.as_str()));
+    map.insert("external_id".to_owned(), json!(args.external_id));
+    map.insert(keys::CONTENT_HASH.to_owned(), json!(args.content_hash));
+    map.insert(keys::TITLE.to_owned(), json!(args.title));
+    if let Some(timestamp) = args.timestamp {
+        map.insert(keys::TIMESTAMP.to_owned(), json!(timestamp));
+    }
+    map.insert(keys::CHANNEL_ID.to_owned(), json!(args.channel.id));
+    map.insert(keys::CHANNEL_NAME.to_owned(), json!(args.channel.name));
+    map.insert(keys::AUTHORS.to_owned(), json!(args.authors));
+    map.insert(keys::IS_ARCHIVED.to_owned(), json!(args.channel.is_archived));
+    map.insert(keys::IS_EXTERNAL.to_owned(), json!(args.channel.is_external));
+    map.insert(keys::IS_BOT_THREAD.to_owned(), json!(args.is_bot_thread));
+    map.insert("message_count".to_owned(), json!(args.message_count));
+    map.insert("has_files".to_owned(), json!(args.has_files));
+    map.insert("thread_ts".to_owned(), json!(args.thread_ts));
+    Value::Object(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{iso_date, ts_epoch_seconds};
+
+    #[test]
+    fn parses_ts_epoch_seconds() {
+        assert_eq!(ts_epoch_seconds("1775413663.871359"), Some(1_775_413_663));
+        assert_eq!(ts_epoch_seconds("1775413663"), Some(1_775_413_663));
+        assert_eq!(ts_epoch_seconds("nope"), None);
+    }
+
+    #[test]
+    fn formats_iso_date_utc() {
+        // 2026-04-05 (a ts seen in the real export).
+        assert_eq!(iso_date(1_775_413_663), "2026-04-05");
+        // Unix epoch day zero.
+        assert_eq!(iso_date(0), "1970-01-01");
+    }
+}

--- a/packages/slack-export/src/users.rs
+++ b/packages/slack-export/src/users.rs
@@ -1,0 +1,75 @@
+//! User-id resolution.
+//!
+//! Mentions and authors are stored as ids (`U0...`); we render and record the
+//! human display name. Resolution follows a fixed fallback chain so a mention
+//! is never dropped: the export-wide users map, then the profile embedded on
+//! the message, then the raw id.
+
+use std::collections::HashMap;
+
+use crate::model::{UserEntry, UserProfile};
+
+/// An index from user id to resolved display name and bot flag, built once from
+/// `users.json`.
+#[derive(Debug, Clone, Default)]
+pub struct UserMap {
+    by_id: HashMap<String, ResolvedUser>,
+}
+
+/// A user's resolved presentation: the name to show and whether it is a bot.
+#[derive(Debug, Clone)]
+pub struct ResolvedUser {
+    /// The display name to render (never empty).
+    pub name: String,
+    /// Whether this user is a bot/integration account.
+    pub is_bot: bool,
+}
+
+impl UserMap {
+    /// Build a map from the parsed `users.json` entries.
+    #[must_use]
+    pub fn from_entries(entries: Vec<UserEntry>) -> Self {
+        let mut by_id = HashMap::with_capacity(entries.len());
+        for entry in entries {
+            let name = entry
+                .profile
+                .best_name()
+                .map_or_else(|| fallback_name(&entry.name, &entry.id).to_owned(), str::to_owned);
+            by_id.insert(
+                entry.id,
+                ResolvedUser {
+                    name,
+                    is_bot: entry.is_bot,
+                },
+            );
+        }
+        Self { by_id }
+    }
+
+    /// Resolve a mention or author id to a display name, falling back to the
+    /// message-embedded profile and finally the raw id. Never returns the empty
+    /// string and never drops the id.
+    #[must_use]
+    pub fn resolve<'a>(&'a self, id: &'a str, message_profile: Option<&'a UserProfile>) -> &'a str {
+        if let Some(user) = self.by_id.get(id) {
+            return &user.name;
+        }
+        if let Some(name) = message_profile.and_then(UserProfile::best_name) {
+            return name;
+        }
+        id
+    }
+
+    /// Whether the given id is a known bot account in the users map.
+    #[must_use]
+    pub fn is_bot(&self, id: &str) -> bool {
+        self.by_id.get(id).is_some_and(|user| user.is_bot)
+    }
+}
+
+/// The name to use when a profile has no usable display or real name: the
+/// handle if present, otherwise the raw id (never empty).
+fn fallback_name<'a>(handle: &'a str, id: &'a str) -> &'a str {
+    let handle = handle.trim();
+    if handle.is_empty() { id } else { handle }
+}

--- a/packages/slack-export/tests/adapter.rs
+++ b/packages/slack-export/tests/adapter.rs
@@ -1,0 +1,185 @@
+//! Integration tests against a tiny synthetic, anonymized fixture export.
+//!
+//! The fixture lives under `tests/fixture/` and deliberately exercises the
+//! hard cases: a thread whose root is in one day file and whose reply is in
+//! another (cross-file assembly), a standalone message, a bot message with no
+//! top-level text, and `channel_join` / `channel_leave` system messages that
+//! must be dropped. No private export data is used.
+
+use std::{collections::HashMap, path::PathBuf};
+
+use search_meta::{Document, SourceAdapter};
+use slack_export::SlackExport;
+
+/// Absolute path to the synthetic fixture export root.
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixture")
+}
+
+/// Collect all documents, asserting none errored.
+fn collect_documents() -> Vec<Document> {
+    let export = SlackExport::open(&fixture_dir()).expect("open synthetic fixture");
+    export
+        .documents()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("iterate fixture documents without error")
+}
+
+/// Index documents by external id for targeted assertions.
+fn by_external_id(documents: &[Document]) -> HashMap<&str, &Document> {
+    documents.iter().map(|doc| (doc.external_id.as_str(), doc)).collect()
+}
+
+/// The cross-file thread (root in day 1, reply in day 2) must assemble into one
+/// document with both messages, the right id, resolved mentions, and a content
+/// hash that matches its body.
+#[test]
+fn cross_file_thread_assembled_into_one_document() {
+    let documents = collect_documents();
+    let index = by_external_id(&documents);
+
+    let thread = index
+        .get("slack:C0SYNTH001:1735689700.000200")
+        .expect("cross-file thread document present");
+
+    // Root + the day-2 reply == 2 messages.
+    assert_eq!(thread.meta_json["message_count"], 2, "root + cross-file reply");
+
+    // external_id == slack:<cid>:<thread_ts>.
+    assert_eq!(thread.external_id, "slack:C0SYNTH001:1735689700.000200");
+    assert_eq!(thread.meta_json["thread_ts"], "1735689700.000200");
+
+    let body = String::from_utf8(thread.body.clone()).expect("body is utf-8");
+
+    // Mention <@U0SYNTHBBB> resolved to a display/real name, never left as raw id.
+    assert!(body.contains("@Bob Builder"), "mention resolved to name, body:\n{body}");
+    assert!(!body.contains("U0SYNTHBBB"), "raw mention id must not survive, body:\n{body}");
+
+    // Both messages present, in ascending ts order (root question before reply).
+    let root_pos = body.find("what docker image").expect("root text present");
+    let reply_pos = body.find("itzg/minecraft-server").expect("reply text present");
+    assert!(root_pos < reply_pos, "messages ordered by ts");
+
+    // HTML entity unescaped and link label rendered.
+    assert!(body.contains("& the demo"), "&amp; unescaped, body:\n{body}");
+
+    // Header carries channel, date, participants, topic.
+    assert!(body.contains("Channel: #craft"));
+    assert!(body.contains("Topic: where the building happens"));
+    assert!(body.contains("Date: 2025-01-01"), "root-date header, body:\n{body}");
+
+    // File indexed by name+type, sets has_files.
+    assert!(body.contains("attached: diagram.png (PNG)"), "file rendered, body:\n{body}");
+    assert_eq!(thread.meta_json["has_files"], true);
+
+    // Reactions rendered.
+    assert!(body.contains("reactions: eyes×2"), "reactions rendered, body:\n{body}");
+
+    // source == slack and content_hash == hash_body(body) == meta content_hash.
+    assert_eq!(thread.meta_json["source"], "slack");
+    assert_eq!(thread.content_hash, search_meta::hash_body(&thread.body));
+    assert_eq!(thread.meta_json["content_hash"], thread.content_hash);
+
+    // Authors metadata holds both resolved names.
+    let authors = thread.meta_json["authors"].as_array().expect("authors array");
+    let names: Vec<&str> = authors.iter().filter_map(|value| value.as_str()).collect();
+    assert!(names.contains(&"ada"));
+    assert!(names.contains(&"Bob Builder"));
+
+    // A two-human thread is not a bot thread, and craft is not external/archived.
+    assert_eq!(thread.meta_json["is_bot_thread"], false);
+    assert_eq!(thread.meta_json["is_external"], false);
+    assert_eq!(thread.meta_json["is_archived"], false);
+    assert_eq!(thread.meta_json["channel_id"], "C0SYNTH001");
+    assert_eq!(thread.meta_json["channel_name"], "craft");
+
+    // timestamp is the root ts integer part, epoch seconds.
+    assert_eq!(thread.meta_json["timestamp"], 1_735_689_700_i64);
+}
+
+/// The standalone message becomes its own single-message thread keyed on its ts.
+#[test]
+fn standalone_message_is_its_own_thread() {
+    let documents = collect_documents();
+    let index = by_external_id(&documents);
+
+    let standalone = index
+        .get("slack:C0SYNTH001:1735689900.000300")
+        .expect("standalone document present");
+    assert_eq!(standalone.meta_json["message_count"], 1);
+
+    let body = String::from_utf8(standalone.body.clone()).expect("utf-8");
+    // Link label rendered, channel ref rendered, no raw markup tokens.
+    assert!(body.contains("see the docs"), "link label, body:\n{body}");
+    assert!(body.contains("#old-stuff"), "channel ref, body:\n{body}");
+    assert!(!body.contains("<#"), "no raw channel tokens, body:\n{body}");
+}
+
+/// The bot message (no top-level text) becomes a bot thread, pulling prose from
+/// its attachment and marking the author with `(bot)`.
+#[test]
+fn bot_message_marked_and_prose_from_attachment() {
+    let documents = collect_documents();
+    let index = by_external_id(&documents);
+
+    let bot = index
+        .get("slack:C0SYNTH001:1735690000.000400")
+        .expect("bot document present");
+    assert_eq!(bot.meta_json["is_bot_thread"], true);
+
+    let body = String::from_utf8(bot.body.clone()).expect("utf-8");
+    assert!(body.contains("[Better Stack (bot)]"), "bot author labelled, body:\n{body}");
+    assert!(body.contains("Monitor *ix.dev* recovered"), "attachment prose, body:\n{body}");
+}
+
+/// `channel_join` / `channel_leave` system messages are never emitted.
+#[test]
+fn join_and_leave_messages_dropped() {
+    let documents = collect_documents();
+    let index = by_external_id(&documents);
+
+    // Join/leave ts values must not appear as their own documents.
+    assert!(!index.contains_key("slack:C0SYNTH001:1735689600.000100"), "join not a document");
+    assert!(!index.contains_key("slack:C0SYNTH001:1735776100.000600"), "leave not a document");
+
+    for doc in &documents {
+        let body = String::from_utf8(doc.body.clone()).expect("utf-8");
+        assert!(!body.contains("has joined the channel"), "no join text in {}", doc.external_id);
+        assert!(!body.contains("has left the channel"), "no leave text in {}", doc.external_id);
+    }
+
+    // craft has exactly three real threads: cross-file thread, standalone, bot.
+    let craft = documents
+        .iter()
+        .filter(|doc| doc.meta_json["channel_id"] == "C0SYNTH001")
+        .count();
+    assert_eq!(craft, 3, "join/leave dropped; 3 content threads remain");
+}
+
+/// Re-running the adapter over an unchanged export yields byte-identical bodies
+/// and content hashes (deterministic, so re-ingest is a no-op).
+#[test]
+fn output_is_deterministic_across_runs() {
+    let first = collect_documents();
+    let second = collect_documents();
+    assert_eq!(first.len(), second.len());
+
+    let first_index = by_external_id(&first);
+    for doc in &second {
+        let prior = first_index.get(doc.external_id.as_str()).expect("same ids on re-run");
+        assert_eq!(prior.content_hash, doc.content_hash, "stable hash for {}", doc.external_id);
+        assert_eq!(prior.body, doc.body, "stable body for {}", doc.external_id);
+    }
+}
+
+/// An archived channel surfaces its archived flag in both body and metadata,
+/// even when it has only system messages and so produces no documents — here we
+/// just confirm the empty archived channel does not crash iteration.
+#[test]
+fn empty_channel_produces_no_documents_without_error() {
+    // old-stuff (C0SYNTH002) has no day files in the fixture, so it contributes
+    // nothing; the iteration must still succeed and ignore it.
+    let documents = collect_documents();
+    let from_old = documents.iter().any(|doc| doc.meta_json["channel_id"] == "C0SYNTH002");
+    assert!(!from_old, "empty channel yields nothing");
+}

--- a/packages/slack-export/tests/fixture/C0SYNTH001--craft/2026-01-01.json
+++ b/packages/slack-export/tests/fixture/C0SYNTH001--craft/2026-01-01.json
@@ -1,0 +1,35 @@
+[
+  {
+    "type": "message",
+    "subtype": "channel_join",
+    "ts": "1735689600.000100",
+    "user": "U0SYNTHBBB",
+    "text": "<@U0SYNTHBBB> has joined the channel"
+  },
+  {
+    "type": "message",
+    "ts": "1735689700.000200",
+    "thread_ts": "1735689700.000200",
+    "user": "U0SYNTHAAA",
+    "text": "what docker image should we use for <@U0SYNTHBBB> &amp; the demo?",
+    "reactions": [{ "name": "eyes", "count": 2 }]
+  },
+  {
+    "type": "message",
+    "ts": "1735689900.000300",
+    "user": "U0SYNTHBBB",
+    "text": "standalone note: see <https://ix.dev|the docs> and <#C0SYNTH002|old-stuff>"
+  },
+  {
+    "type": "message",
+    "subtype": "bot_message",
+    "ts": "1735690000.000400",
+    "bot_id": "B0SYNTH",
+    "app_id": "A0SYNTH",
+    "bot_profile": { "name": "Better Stack" },
+    "text": "",
+    "attachments": [
+      { "fallback": "Monitor recovered", "text": "Monitor *ix.dev* recovered after 3m", "title": "Recovery" }
+    ]
+  }
+]

--- a/packages/slack-export/tests/fixture/C0SYNTH001--craft/2026-01-02.json
+++ b/packages/slack-export/tests/fixture/C0SYNTH001--craft/2026-01-02.json
@@ -1,0 +1,19 @@
+[
+  {
+    "type": "message",
+    "ts": "1735776000.000500",
+    "thread_ts": "1735689700.000200",
+    "user": "U0SYNTHBBB",
+    "text": "use itzg/minecraft-server, it just works",
+    "files": [
+      { "name": "diagram.png", "title": "diagram.png", "filetype": "png", "pretty_type": "PNG" }
+    ]
+  },
+  {
+    "type": "message",
+    "subtype": "channel_leave",
+    "ts": "1735776100.000600",
+    "user": "U0SYNTHBBB",
+    "text": "<@U0SYNTHBBB> has left the channel"
+  }
+]

--- a/packages/slack-export/tests/fixture/channels.json
+++ b/packages/slack-export/tests/fixture/channels.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "C0SYNTH001",
+    "name": "craft",
+    "created": 1700000000,
+    "creator": "U0SYNTHAAA",
+    "is_archived": false,
+    "is_general": false,
+    "members": 3,
+    "topic": { "value": "where the building happens", "creator": "", "last_set": 0 },
+    "purpose": { "value": "", "creator": "", "last_set": 0 }
+  },
+  {
+    "id": "C0SYNTH002",
+    "name": "old-stuff",
+    "created": 1699000000,
+    "creator": "U0SYNTHAAA",
+    "is_archived": true,
+    "is_general": false,
+    "members": ["U0SYNTHAAA", "U0SYNTHBBB"],
+    "topic": { "value": "", "creator": "", "last_set": 0 },
+    "purpose": { "value": "", "creator": "", "last_set": 0 }
+  }
+]

--- a/packages/slack-export/tests/fixture/users.json
+++ b/packages/slack-export/tests/fixture/users.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "U0SYNTHAAA",
+    "name": "ada",
+    "deleted": false,
+    "is_bot": false,
+    "is_app_user": false,
+    "team_id": "T0SYNTH",
+    "profile": { "display_name": "ada", "real_name": "Ada Synthetic" }
+  },
+  {
+    "id": "U0SYNTHBBB",
+    "name": "bob",
+    "deleted": false,
+    "is_bot": false,
+    "is_app_user": false,
+    "team_id": "T0SYNTH",
+    "profile": { "display_name": "", "real_name": "Bob Builder" }
+  },
+  {
+    "id": "U0SYNTHBOT",
+    "name": "robot",
+    "deleted": false,
+    "is_bot": true,
+    "is_app_user": true,
+    "team_id": "T0SYNTH",
+    "profile": { "display_name": "", "real_name": "Synthetic Bot" }
+  }
+]


### PR DESCRIPTION
Implements the foundation of the multi-source search RFC (#362): the metadata-filter wiring and the typed document envelope, with code as the first adapter. Slack and Linear adapters follow on this branch.

## What landed

**Phase 0 (#410) — filters in the `mixedbread` client**
- Recursive `Filter` (`Condition` + `all`/`any`/`none`; operators `eq, not_eq, gt, gte, lt, lte, in, not_in, like, not_like, starts_with, regex`) mirroring the SDK wire shape, serialize-only.
- Threaded `filters` through `/stores/search`, `/stores/grep`, `/stores/question-answering`, and file-list; added `score_threshold` + `return_metadata` options and a per-upload MIME arg.
- Serde round-trip tests assert the documented `all/any/none` JSON and exact lowercase operators.

**Phase 1 (#411) — typed envelope + source-aware projection**
- New `search-meta` crate: `Source`, `DocumentMeta`, per-source extras, `RepoSlug`, a streaming `SourceAdapter` trait, `hash_body` (content_hash is the hash of the embedded bytes), and a `check_metadata` limit guard.
- `Store` trait now takes a `Document` and optional `Filter`; `SearchHit` carries its `source`; `StoredRecord` supports per-source reconcile.
- Projection is source-aware: code stays worktree-scoped via the manifest; Slack/Linear pass through the server-side filter (an absent manifest hash is not a drop). Legacy code records (no `source`) are read as code for a no-re-embed migration.
- Code uploads carry the typed envelope (`source`/`repo`/`path`), so cross-repo and per-source filtering work. Repo slug comes from the git remote (`git2`), with an observable `Local(dirname)` fallback.
- Shared `build_filter` + CLI scope flags: `--source`, `--not-source`, `--repo`, `--all-repos`, `--all-worktrees`.

## Validation

- ✅ `nix build .#search` and `.#mcp` green on darwin.
- ✅ Live Mixedbread API: the `filters` wire shape is accepted; after syncing this worktree, `--source code` returns the code hits and `--source slack` returns nothing, so the server-side metadata filter discriminates correctly end to end.
- Unit tests (filter serde, envelope, projection per source, build_filter, repo slug) run in the Linux `rust-package-tests` check on CI (darwin `checks` are intentionally empty).

Note on crates: `search-meta` is its own crate because the envelope + trait are reused by ≥2 adapters; the Slack/Linear parsers will be separate crates per the modular-crate preference. Behavior change is intentional and repo-wide (`DisplayHit.is_web` → `source`); no compat shim.

Refs #362. Closes #410, #411.

Made with Claude (claude-opus-4-8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add multi-source search with metadata filters, typed source envelope, and Slack/Linear ingest adapters
> - Introduces a `search-meta` crate defining shared metadata keys, a `Source` enum (`code`, `slack`, `linear`, `web`), `RepoSlug`, and `Document`/`SourceAdapter` types used across all adapters.
> - Adds `mixedbread` filter builder (`Filter`, `Condition`, `Group`, `Operator`) and propagates optional server-side metadata filters through `Store.search`, `.grep`, `.ask`, and `.list_files`.
> - Replaces `is_web: bool` on `SearchHit`/`DisplayHit` with a typed `source: Source` field; projection logic now routes code hits through manifest intersection or server-filtered scoping, while Slack/Linear hits always pass through.
> - Adds `slack-export` and `linear-export` crates implementing `SourceAdapter`, including Slack thread assembly, entity rendering, and Linear issue document construction.
> - Adds `sync_documents` and `gc_documents` to `search-core` for incremental upload and source-scoped garbage collection of external records.
> - Exposes `ingest` and `gc` CLI subcommands in `search` with `--source`, `--not-source`, `--repo`, and `--all-repos` scope flags for filtering queries and managing non-code sources.
> - Risk: `is_web` is removed from `SearchHit`; the Python binding ([_search.pyi](https://github.com/indexable-inc/index/pull/424/files#diff-cbf94b7eb416187ae2fc8731d0058fa0bfcfeb7d0dda5e3c7752273dc83ce088)) and any downstream consumers must switch to the `source` string field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4b7ae8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->