### PR TITLE
feat(spark): tuned Spark 3.5 with the Gluten + Velox native engine

### DIFF
--- a/modules/services/spark/default.nix
+++ b/modules/services/spark/default.nix
@@ -32,30 +32,32 @@ let
 
   cfg = config.services.ix-spark;
   dataDir = "/var/lib/spark";
-  java = cfg.jrePackage;
-  javaHome = java.home or "${java}";
   masterUrl = "spark://${cfg.master.host}:${toString cfg.master.port}";
 
-  # nixpkgs `spark_3_5` bakes `jdk = hadoop.jdk` (JDK 11) and its bin wrappers
-  # `--set JAVA_HOME` unconditionally, which would override any JAVA_HOME we
-  # export. Gluten 1.6 only supports JDK 8 and 17, so re-point the package's jdk
-  # (the `finalAttrs` pattern threads this into the wrappers) at our JDK 17.
-  sparkPackage = cfg.package.overrideAttrs (_: {
-    jdk = cfg.jrePackage;
-  });
-  sparkClass = "${sparkPackage}/bin/spark-class";
+  # `spark-hive` is the official complete distribution (hadoop3 + Hive) pinned to
+  # JDK 17. Hive support is mandatory: Gluten's HiveTableScanExecTransformer
+  # eagerly loads Hive input-format classes during planning, so the lean
+  # nixpkgs `spark` (no hive-exec) cannot initialize it. The package's bin
+  # wrappers `--set JAVA_HOME`, so the daemons run on its JDK 17.
+  sparkClass = "${cfg.package}/bin/spark-class";
 
-  # Driver/executor JVM options for the native path. The `--add-opens` cover
-  # Arrow's JNI reflection into java.nio on JDK 17. `java.io.tmpdir` is pinned to
-  # the on-disk state dir because Gluten extracts ~270 MiB of native libraries
-  # (libvelox.so et al.) per JVM out of the jar at startup; the default `/tmp` is
-  # RAM-backed tmpfs here, so leaving it there would burn that much RAM per
-  # executor on top of the off-heap budget.
+  # Driver/executor JVM options for the native path:
+  # - `--add-opens` open the modules Arrow's JNI reflects into on JDK 17.
+  # - `io.netty.tryReflectionSetAccessible=true` is required for Arrow's off-heap
+  #   allocator: Netty (which Arrow's memory layer uses) refuses the
+  #   `DirectByteBuffer(long, int)` constructor on JDK 9+ unless this is set, even
+  #   with java.nio opened, surfacing as "sun.misc.Unsafe or
+  #   java.nio.DirectByteBuffer.<init>(long, int) not available".
+  # - `java.io.tmpdir` is pinned to the on-disk state dir because Gluten extracts
+  #   ~270 MiB of native libraries (libvelox.so et al.) per JVM out of the jar at
+  #   startup; the default `/tmp` is RAM-backed tmpfs here, so leaving it there
+  #   would burn that much RAM per executor on top of the off-heap budget.
   nativeJavaOpts = lib.concatStringsSep " " [
     "-XX:+IgnoreUnrecognizedVMOptions"
     "--add-opens=java.base/java.nio=ALL-UNNAMED"
     "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
     "--add-opens=java.base/java.lang=ALL-UNNAMED"
+    "-Dio.netty.tryReflectionSetAccessible=true"
     "-Djava.io.tmpdir=${dataDir}/tmp"
   ];
 
@@ -97,10 +99,10 @@ let
   '';
 
   # Master/worker run via `spark-class` in the foreground (Type=simple), so their
-  # logs go to the journal rather than SPARK_LOG_DIR; no log dir is set.
+  # logs go to the journal rather than SPARK_LOG_DIR; no log dir is set. JAVA_HOME
+  # is baked into the package's bin wrappers, so it is not set here.
   sparkEnv = {
-    JAVA_HOME = javaHome;
-    SPARK_HOME = "${sparkPackage}";
+    SPARK_HOME = "${cfg.package}";
     SPARK_CONF_DIR = "${confDir}";
     SPARK_WORKER_DIR = "${dataDir}/work";
     SPARK_LOCAL_DIRS = "${dataDir}/local";
@@ -129,25 +131,12 @@ in
   options.services.ix-spark = {
     enable = mkEnableOption "Apache Spark standalone cluster with the Gluten/Velox native engine";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.spark_3_5;
-      defaultText = lib.literalExpression "pkgs.spark_3_5";
-      description = ''
-        Spark distribution. Pinned to the 3.5 line because the Gluten Velox
-        bundle in {option}`services.ix-spark.nativeEngine.package` is built
-        against Spark 3.5; pairing it with another major fails to load the
-        plugin.
-      '';
-    };
-
-    jrePackage = mkOption {
-      type = types.package;
-      default = pkgs.jdk17_headless;
-      defaultText = lib.literalExpression "pkgs.jdk17_headless";
-      description = ''
-        JDK/JRE used to run the master and workers. Gluten 1.6 with Spark 3.5 is
-        tested on JDK 17; other majors are not covered upstream.
+    package = mkPackageOption pkgs "spark-hive" {
+      extraDescription = ''
+        The official complete Spark 3.5 distribution (hadoop3 + Hive) pinned to
+        JDK 17. Hive support is mandatory for the Gluten native engine, and the
+        Gluten Velox bundle in {option}`services.ix-spark.nativeEngine.package`
+        is built against Spark 3.5, so keep these versions aligned.
       '';
     };
 
@@ -241,6 +230,16 @@ in
   };
 
   config = mkIf cfg.enable {
+    # Velox (bundled in the Gluten jar) resolves the IANA tz database through its
+    # date library, which hardcodes the FHS `/usr/share/zoneinfo` and ignores
+    # $TZDIR. NixOS does not populate that path, so point it at the tzdata store
+    # path; without it every Gluten query fails with
+    # "discover_tz_dir failed to find zoneinfo". Global (not unit-scoped) so a
+    # `spark-submit` driver run outside the service units resolves it too.
+    systemd.tmpfiles.rules = [
+      "L+ /usr/share/zoneinfo - - - - ${pkgs.tzdata}/share/zoneinfo"
+    ];
+
     users.users.spark = {
       isSystemUser = true;
       group = "spark";

--- a/modules/services/spark/default.nix
+++ b/modules/services/spark/default.nix
@@ -8,6 +8,11 @@
 # `spark-defaults.conf` wires the plugin, off-heap memory, and columnar shuffle
 # together. Turn {option}`services.ix-spark.nativeEngine.enable` off to drop
 # back to stock JVM execution.
+#
+# Scoped to a single node: master and worker run on the same host and the Gluten
+# jar is referenced by its absolute store path on `extraClassPath`. A real
+# multi-node cluster would need that same store path present on every worker
+# (shared nix store or copied closure).
 {
   config,
   ix,
@@ -30,15 +35,28 @@ let
   java = cfg.jrePackage;
   javaHome = java.home or "${java}";
   masterUrl = "spark://${cfg.master.host}:${toString cfg.master.port}";
-  sparkClass = "${cfg.package}/bin/spark-class";
 
-  # Arrow's JNI bridge reflects into java.nio on JDK 17; Spark adds its own
-  # module opens, these cover the Arrow/Gluten path specifically.
-  arrowOpens = lib.concatStringsSep " " [
+  # nixpkgs `spark_3_5` bakes `jdk = hadoop.jdk` (JDK 11) and its bin wrappers
+  # `--set JAVA_HOME` unconditionally, which would override any JAVA_HOME we
+  # export. Gluten 1.6 only supports JDK 8 and 17, so re-point the package's jdk
+  # (the `finalAttrs` pattern threads this into the wrappers) at our JDK 17.
+  sparkPackage = cfg.package.overrideAttrs (_: {
+    jdk = cfg.jrePackage;
+  });
+  sparkClass = "${sparkPackage}/bin/spark-class";
+
+  # Driver/executor JVM options for the native path. The `--add-opens` cover
+  # Arrow's JNI reflection into java.nio on JDK 17. `java.io.tmpdir` is pinned to
+  # the on-disk state dir because Gluten extracts ~270 MiB of native libraries
+  # (libvelox.so et al.) per JVM out of the jar at startup; the default `/tmp` is
+  # RAM-backed tmpfs here, so leaving it there would burn that much RAM per
+  # executor on top of the off-heap budget.
+  nativeJavaOpts = lib.concatStringsSep " " [
     "-XX:+IgnoreUnrecognizedVMOptions"
     "--add-opens=java.base/java.nio=ALL-UNNAMED"
     "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
     "--add-opens=java.base/java.lang=ALL-UNNAMED"
+    "-Djava.io.tmpdir=${dataDir}/tmp"
   ];
 
   nativeSettings = optionalAttrs cfg.nativeEngine.enable {
@@ -50,8 +68,8 @@ let
     "spark.memory.offHeap.size" = cfg.nativeEngine.offHeapSize;
     "spark.driver.extraClassPath" = cfg.nativeEngine.package.jar;
     "spark.executor.extraClassPath" = cfg.nativeEngine.package.jar;
-    "spark.driver.extraJavaOptions" = arrowOpens;
-    "spark.executor.extraJavaOptions" = arrowOpens;
+    "spark.driver.extraJavaOptions" = nativeJavaOpts;
+    "spark.executor.extraJavaOptions" = nativeJavaOpts;
   };
 
   # Tuned defaults; `cfg.settings` is merged over the top so a user key wins.
@@ -78,11 +96,12 @@ let
     cp ${sparkDefaultsConf} "$out/spark-defaults.conf"
   '';
 
+  # Master/worker run via `spark-class` in the foreground (Type=simple), so their
+  # logs go to the journal rather than SPARK_LOG_DIR; no log dir is set.
   sparkEnv = {
     JAVA_HOME = javaHome;
-    SPARK_HOME = "${cfg.package}";
+    SPARK_HOME = "${sparkPackage}";
     SPARK_CONF_DIR = "${confDir}";
-    SPARK_LOG_DIR = "${dataDir}/logs";
     SPARK_WORKER_DIR = "${dataDir}/work";
     SPARK_LOCAL_DIRS = "${dataDir}/local";
   };
@@ -99,7 +118,7 @@ let
       Group = "spark";
       StateDirectory = "spark";
       WorkingDirectory = dataDir;
-      ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${dataDir}/logs ${dataDir}/work ${dataDir}/local";
+      ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${dataDir}/work ${dataDir}/local ${dataDir}/tmp";
       ExecStart = execStart;
       Restart = "on-failure";
       RestartSec = 5;

--- a/modules/services/spark/default.nix
+++ b/modules/services/spark/default.nix
@@ -1,0 +1,316 @@
+# Apache Spark 3.5 as a single-node standalone cluster, tuned and shipping the
+# Gluten + Velox native execution engine by default.
+#
+# Plain Spark runs its physical operators on the JVM. Gluten offloads them to
+# Velox, a vectorized C++ engine; that is the source of the large analytical
+# speedups. Enabling it is more than a jar on the classpath: Velox allocates its
+# buffers off-heap and needs a columnar shuffle manager, so the generated
+# `spark-defaults.conf` wires the plugin, off-heap memory, and columnar shuffle
+# together. Turn {option}`services.ix-spark.nativeEngine.enable` off to drop
+# back to stock JVM execution.
+{
+  config,
+  ix,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    optionalAttrs
+    types
+    ;
+
+  cfg = config.services.ix-spark;
+  dataDir = "/var/lib/spark";
+  java = cfg.jrePackage;
+  javaHome = java.home or "${java}";
+  masterUrl = "spark://${cfg.master.host}:${toString cfg.master.port}";
+  sparkClass = "${cfg.package}/bin/spark-class";
+
+  # Arrow's JNI bridge reflects into java.nio on JDK 17; Spark adds its own
+  # module opens, these cover the Arrow/Gluten path specifically.
+  arrowOpens = lib.concatStringsSep " " [
+    "-XX:+IgnoreUnrecognizedVMOptions"
+    "--add-opens=java.base/java.nio=ALL-UNNAMED"
+    "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+    "--add-opens=java.base/java.lang=ALL-UNNAMED"
+  ];
+
+  nativeSettings = optionalAttrs cfg.nativeEngine.enable {
+    "spark.plugins" = "org.apache.gluten.GlutenPlugin";
+    "spark.gluten.enabled" = "true";
+    "spark.gluten.sql.columnar.backend.lib" = "velox";
+    "spark.shuffle.manager" = "org.apache.spark.shuffle.sort.ColumnarShuffleManager";
+    "spark.memory.offHeap.enabled" = "true";
+    "spark.memory.offHeap.size" = cfg.nativeEngine.offHeapSize;
+    "spark.driver.extraClassPath" = cfg.nativeEngine.package.jar;
+    "spark.executor.extraClassPath" = cfg.nativeEngine.package.jar;
+    "spark.driver.extraJavaOptions" = arrowOpens;
+    "spark.executor.extraJavaOptions" = arrowOpens;
+  };
+
+  # Tuned defaults; `cfg.settings` is merged over the top so a user key wins.
+  tunedDefaults = {
+    "spark.master" = masterUrl;
+    "spark.sql.adaptive.enabled" = "true";
+    "spark.sql.adaptive.coalescePartitions.enabled" = "true";
+    "spark.serializer" = "org.apache.spark.serializer.KryoSerializer";
+    "spark.local.dir" = "${dataDir}/local";
+  }
+  // nativeSettings;
+
+  finalSettings = tunedDefaults // cfg.settings;
+
+  sparkDefaultsConf = pkgs.writeText "spark-defaults.conf" (
+    lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (key: value: "${key} ${toString value}") finalSettings
+    )
+    + "\n"
+  );
+
+  confDir = pkgs.runCommand "spark-conf" { } ''
+    mkdir -p "$out"
+    cp ${sparkDefaultsConf} "$out/spark-defaults.conf"
+  '';
+
+  sparkEnv = {
+    JAVA_HOME = javaHome;
+    SPARK_HOME = "${cfg.package}";
+    SPARK_CONF_DIR = "${confDir}";
+    SPARK_LOG_DIR = "${dataDir}/logs";
+    SPARK_WORKER_DIR = "${dataDir}/work";
+    SPARK_LOCAL_DIRS = "${dataDir}/local";
+  };
+
+  mkUnit = description: execStart: {
+    inherit description;
+    after = [ "network-online.target" ];
+    wants = [ "network-online.target" ];
+    wantedBy = [ "multi-user.target" ];
+    environment = sparkEnv;
+    serviceConfig = ix.systemdHardening // {
+      Type = "simple";
+      User = "spark";
+      Group = "spark";
+      StateDirectory = "spark";
+      WorkingDirectory = dataDir;
+      ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${dataDir}/logs ${dataDir}/work ${dataDir}/local";
+      ExecStart = execStart;
+      Restart = "on-failure";
+      RestartSec = 5;
+    };
+  };
+in
+{
+  options.services.ix-spark = {
+    enable = mkEnableOption "Apache Spark standalone cluster with the Gluten/Velox native engine";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.spark_3_5;
+      defaultText = lib.literalExpression "pkgs.spark_3_5";
+      description = ''
+        Spark distribution. Pinned to the 3.5 line because the Gluten Velox
+        bundle in {option}`services.ix-spark.nativeEngine.package` is built
+        against Spark 3.5; pairing it with another major fails to load the
+        plugin.
+      '';
+    };
+
+    jrePackage = mkOption {
+      type = types.package;
+      default = pkgs.jdk17_headless;
+      defaultText = lib.literalExpression "pkgs.jdk17_headless";
+      description = ''
+        JDK/JRE used to run the master and workers. Gluten 1.6 with Spark 3.5 is
+        tested on JDK 17; other majors are not covered upstream.
+      '';
+    };
+
+    master = {
+      host = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = "Address the master binds and workers connect to.";
+      };
+      port = mkOption {
+        type = types.port;
+        default = 7077;
+        description = "Master RPC port.";
+      };
+      webUiPort = mkOption {
+        type = types.port;
+        default = 8080;
+        description = "Master web UI port.";
+      };
+    };
+
+    worker = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Run a worker on this node, registered with the local master.";
+      };
+      webUiPort = mkOption {
+        type = types.port;
+        default = 8081;
+        description = "Worker web UI port.";
+      };
+      cores = mkOption {
+        type = types.nullOr types.ints.positive;
+        default = null;
+        description = "Cores the worker offers. Null lets Spark use every core it sees.";
+      };
+      memory = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "8g";
+        description = "Memory the worker offers (Spark size string). Null lets Spark autodetect.";
+      };
+    };
+
+    nativeEngine = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Offload execution to Velox via Apache Gluten. This is the point of the
+          module; turn it off only to compare against stock JVM execution or to
+          isolate a Gluten-specific issue.
+        '';
+      };
+      package = mkPackageOption pkgs "spark-gluten" { };
+      offHeapSize = mkOption {
+        type = types.str;
+        default = "2g";
+        description = ''
+          Off-heap memory granted to Velox (`spark.memory.offHeap.size`). Velox
+          allocates its columnar buffers here rather than on the JVM heap, so
+          this is the main native-engine memory knob. Size it together with
+          executor heap so both fit the machine.
+        '';
+      };
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Open the master RPC and web UI ports in the firewall.";
+    };
+
+    settings = mkOption {
+      type = types.attrsOf (
+        types.oneOf [
+          types.str
+          types.int
+          types.bool
+        ]
+      );
+      default = { };
+      example = lib.literalExpression ''{ "spark.sql.shuffle.partitions" = 64; }'';
+      description = ''
+        Extra `spark-defaults.conf` entries, merged over the tuned defaults this
+        module sets. Your keys win, so this is also how you override a tuned
+        default.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.spark = {
+      isSystemUser = true;
+      group = "spark";
+      home = dataDir;
+      description = "Apache Spark";
+    };
+    users.groups.spark = { };
+
+    ix.networking.portClaims = {
+      ix-spark-master = {
+        protocol = "tcp";
+        inherit (cfg.master) port;
+        description = "Spark master RPC";
+      };
+      ix-spark-master-ui = {
+        protocol = "tcp";
+        port = cfg.master.webUiPort;
+        description = "Spark master web UI";
+      };
+    }
+    // optionalAttrs cfg.worker.enable {
+      ix-spark-worker-ui = {
+        protocol = "tcp";
+        port = cfg.worker.webUiPort;
+        description = "Spark worker web UI";
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [
+      cfg.master.port
+      cfg.master.webUiPort
+    ];
+
+    ix.healthChecks.ix-spark = {
+      from = "guest";
+      description = "Spark master web UI responds";
+      command = [
+        (lib.getExe' pkgs.curl "curl")
+        "--fail"
+        "--silent"
+        "--show-error"
+        "--max-time"
+        "5"
+        "http://${cfg.master.host}:${toString cfg.master.webUiPort}/"
+      ];
+    };
+
+    systemd.services = {
+      spark-master = mkUnit "Apache Spark master" (
+        lib.escapeShellArgs [
+          sparkClass
+          "org.apache.spark.deploy.master.Master"
+          "--host"
+          cfg.master.host
+          "--port"
+          (toString cfg.master.port)
+          "--webui-port"
+          (toString cfg.master.webUiPort)
+        ]
+      );
+    }
+    // optionalAttrs cfg.worker.enable {
+      spark-worker =
+        mkUnit "Apache Spark worker" (
+          lib.escapeShellArgs (
+            [
+              sparkClass
+              "org.apache.spark.deploy.worker.Worker"
+              masterUrl
+              "--webui-port"
+              (toString cfg.worker.webUiPort)
+            ]
+            ++ lib.optionals (cfg.worker.cores != null) [
+              "--cores"
+              (toString cfg.worker.cores)
+            ]
+            ++ lib.optionals (cfg.worker.memory != null) [
+              "--memory"
+              cfg.worker.memory
+            ]
+          )
+        )
+        // {
+          after = [
+            "network-online.target"
+            "spark-master.service"
+          ];
+          requires = [ "spark-master.service" ];
+        };
+    };
+  };
+}

--- a/packages/spark-gluten/default.nix
+++ b/packages/spark-gluten/default.nix
@@ -25,9 +25,6 @@
   patchelf,
   unzip,
   zip,
-  zlib,
-  openssl,
-  numactl,
 }:
 let
   version = "1.6.0";
@@ -56,16 +53,14 @@ stdenv.mkDerivation (finalAttrs: {
     zip
   ];
 
-  # The CentOS 7 build statically links most of Velox/Arrow, so the residual
-  # dynamic deps are small: libc/libstdc++ come from the compiler runtime
-  # automatically, leaving these. autoPatchelf only adds an rpath entry for a
-  # library that is actually referenced, so an unused entry here stays out of the
-  # runtime closure.
+  # The CentOS 7 build statically links Velox/Arrow and their third-party deps
+  # (vcpkg static), so the only dynamic dependencies of the bundled `.so`s are
+  # glibc and the intra-bundle libvelox.so -> libgluten.so sibling link. glibc is
+  # provided by the host JVM's already-loaded namespace at runtime; libgcc_s /
+  # libstdc++ are kept here as a defensive rpath entry in case a future bundle
+  # links them dynamically.
   buildInputs = [
     (lib.getLib stdenv.cc.cc)
-    zlib
-    openssl
-    numactl
   ];
 
   # libvelox.so is ~246 MiB; stripping a vendored binary is slow and pointless.

--- a/packages/spark-gluten/default.nix
+++ b/packages/spark-gluten/default.nix
@@ -1,0 +1,121 @@
+# Apache Gluten Velox-backend bundle for Spark 3.5, patched to run on NixOS.
+#
+# Stock Spark executes queries on the JVM. Gluten offloads the physical
+# operators to Velox, a vectorized C++ engine, which is where the large
+# analytical speedups over plain Spark come from. Upstream ships one fat jar per
+# Spark line with the Velox and Arrow JNI native libraries (`libvelox.so`,
+# `libgluten.so`, `libarrow_*_jni.so`) packed inside; Gluten extracts them to a
+# temp dir and `dlopen()`s them at runtime.
+#
+# Those libraries are built on CentOS 7, so their ELF interpreter is
+# `/lib64/ld-linux-x86-64.so.2` and their rpath points at FHS paths that do not
+# exist on NixOS: the stock jar fails to load. We explode the jar, autoPatchelf
+# the native libs against the nix store, and repack. The patched interpreter and
+# rpath are absolute store paths, so they survive Gluten's runtime
+# re-extraction.
+#
+# Bump: change `version`, refresh `src.hash` with `nix-prefetch-url`, and check
+# the tarball against its published `.sha512` on archive.apache.org. Only a
+# linux_amd64 native build is published upstream.
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  patchelf,
+  unzip,
+  zip,
+  zlib,
+  openssl,
+  numactl,
+}:
+let
+  version = "1.6.0";
+  sparkVersion = "3.5";
+  scalaVersion = "2.12";
+  jarName = "gluten-velox-bundle.jar";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "spark-gluten";
+  inherit version;
+
+  # The archive host keeps every release. The tarball holds two files: a
+  # DISCLAIMER and the bundle jar.
+  src = fetchurl {
+    url = "https://archive.apache.org/dist/gluten/${version}/apache-gluten-${version}-bin-spark-${sparkVersion}.tar.gz";
+    hash = "sha256-kPnsaslkvNc4k8ZhqRM+Rq/Eb4svqeF8ZH+zk5uLbUM=";
+  };
+
+  dontUnpack = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    patchelf
+    unzip
+    zip
+  ];
+
+  # The CentOS 7 build statically links most of Velox/Arrow, so the residual
+  # dynamic deps are small: libc/libstdc++ come from the compiler runtime
+  # automatically, leaving these. autoPatchelf only adds an rpath entry for a
+  # library that is actually referenced, so an unused entry here stays out of the
+  # runtime closure.
+  buildInputs = [
+    (lib.getLib stdenv.cc.cc)
+    zlib
+    openssl
+    numactl
+  ];
+
+  # libvelox.so is ~246 MiB; stripping a vendored binary is slow and pointless.
+  dontStrip = true;
+
+  # We autopatch the libs inside the exploded jar and repack, so there is
+  # nothing left in $out for the automatic fixup pass to find.
+  dontAutoPatchelf = true;
+
+  buildPhase = ''
+    runHook preBuild
+    tar xzf "$src"
+    mkdir exploded
+    ( cd exploded && unzip -q ../*.jar )
+
+    # Validate every native dependency is satisfiable from buildInputs (this
+    # errors the build if one is missing) and let autoPatchelf resolve them.
+    autoPatchelf exploded
+
+    # autoPatchelf records absolute build-sandbox paths (e.g. /build/exploded)
+    # for the one intra-bundle link, libvelox.so -> libgluten.so. Those vanish
+    # once Gluten extracts the libraries to a runtime temp dir, exactly like the
+    # dangling /workspace path upstream ships. Re-root each library at $ORIGIN so
+    # a co-extracted sibling resolves, and append the store paths of the external
+    # deps so libstdc++/openssl/numa/zlib resolve wherever the libs land.
+    for so in exploded/linux/amd64/*.so exploded/x86_64/*.so; do
+      patchelf --set-rpath "\$ORIGIN:${lib.makeLibraryPath finalAttrs.buildInputs}" "$so"
+    done
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/share/java"
+    ( cd exploded && zip -q -r -1 "$out/share/java/${jarName}" . )
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit sparkVersion scalaVersion;
+    # Absolute path consumers put on the Spark driver/executor classpath.
+    jar = "${finalAttrs.finalPackage}/share/java/${jarName}";
+  };
+
+  meta = {
+    description = "Apache Gluten Velox backend bundle for Spark ${sparkVersion}, patched for NixOS";
+    homepage = "https://gluten.apache.org/";
+    license = lib.licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/packages/spark-gluten/package.nix
+++ b/packages/spark-gluten/package.nix
@@ -1,0 +1,14 @@
+{
+  id = "spark-gluten";
+  # Upstream publishes only a linux_amd64 native build of the Velox/Arrow
+  # libraries, and the package autopatchelfs ELF objects, so it builds only on
+  # x86_64-linux (see meta.platforms in default.nix). Advertising the flake
+  # output or an off-platform package-set attr makes `nix flake check` force a
+  # build nixpkgs refuses to evaluate, so gate both to x86_64-linux. The overlay
+  # stays unconditional and lazy: `pkgs.spark-gluten` is only forced inside an
+  # x86_64-linux closure (the spark service module), mirroring how `drgn` does
+  # the same for its Linux-only binary.
+  packageSet.systems = [ "x86_64-linux" ];
+  flake.systems = [ "x86_64-linux" ];
+  overlay = true;
+}

--- a/packages/spark-hive/default.nix
+++ b/packages/spark-hive/default.nix
@@ -1,0 +1,91 @@
+# Apache Spark 3.5, the official complete (hadoop3 + Hive) binary distribution,
+# packaged self-contained for NixOS and pinned to JDK 17.
+#
+# Why not nixpkgs `spark`: that package uses the lean `bin-without-hadoop`
+# tarball and injects an external hadoop classpath at runtime. It ships no
+# `hive-exec`, only `hive-storage-api`. Apache Gluten's
+# `HiveTableScanExecTransformer` companion object eagerly `classForName`s Hive's
+# ORC and Parquet input-format classes during query planning (no config gate),
+# so on the lean build Gluten fails to initialize for any query. This
+# distribution bundles hadoop and the full Hive jar set (hive-exec, hive-common,
+# hive-metastore, hive-serde, spark-hive, ...), so Gluten and other
+# Hive-dependent Spark features work with no external classpath.
+#
+# JDK 17: Spark 3.5 supports 8/11/17 and Gluten 1.6 supports 8/17; 17 is the
+# overlap the spark service module standardizes on. The bin wrappers `--set`
+# JAVA_HOME, so this is the JVM Spark actually runs on regardless of the
+# caller's environment.
+#
+# Bump: change `version`, refresh `src.hash` with `nix-prefetch-url`, and check
+# the tarball against its published `.sha512` on archive.apache.org.
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  bash,
+  coreutils,
+  python3,
+  procps,
+  tzdata,
+  # Pinned, not a parameter: a `jdk ? jdk17_headless` arg collides with the
+  # `pkgs.jdk` callPackage auto-fills (currently openjdk 21, which Spark 3.5 does
+  # not support), silently overriding the default. Spark 3.5 and Gluten 1.6 both
+  # support JDK 17.
+  jdk17_headless,
+  pysparkPython ? python3,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "spark-hive";
+  version = "3.5.5";
+
+  src = fetchurl {
+    url = "https://archive.apache.org/dist/spark/spark-${finalAttrs.version}/spark-${finalAttrs.version}-bin-hadoop3.tgz";
+    hash = "sha256-jao/f7CvJnD+Eb64oqx52QilNNcpg1PsR0YCWxAtXjE=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  strictDeps = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out"
+    mv * "$out/"
+    # The distribution's launchers carry `#!/usr/bin/env bash`. Rewrite them to a
+    # store bash so they do not depend on an FHS `env`/PATH at runtime (systemd
+    # units run with a minimal PATH).
+    patchShebangs "$out/bin" "$out/sbin"
+    # `find-spark-home` is sourced, not executed, so leave it unwrapped. Every
+    # other launcher gets JAVA_HOME pinned plus bash/coreutils/pyspark-Python and
+    # `ps` (used by `load-spark-env.sh`) on PATH, so the units are self-sufficient
+    # even when Spark's scripts re-exec each other.
+    for n in $(find "$out/bin" -type f -executable ! -name "find-spark-home"); do
+      wrapProgram "$n" \
+        --set JAVA_HOME "${jdk17_headless}" \
+        --set TZDIR "${tzdata}/share/zoneinfo" \
+        --prefix PATH : "${
+          lib.makeBinPath [
+            bash
+            coreutils
+            pysparkPython
+            procps
+          ]
+        }"
+    done
+    runHook postInstall
+  '';
+
+  # Velox (via Gluten) calls `discover_tz_dir`, which needs the IANA tz database;
+  # NixOS has none at the FHS `/usr/share/zoneinfo`, so the wrappers point TZDIR
+  # at the tzdata store path. Executors inherit it from the worker's environment.
+  passthru.jdk = jdk17_headless;
+
+  meta = {
+    description = "Apache Spark ${finalAttrs.version}, official hadoop3 + Hive distribution, JDK 17, packaged for NixOS";
+    homepage = "https://spark.apache.org/";
+    license = lib.licenses.asl20;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "spark-submit";
+  };
+})

--- a/packages/spark-hive/package.nix
+++ b/packages/spark-hive/package.nix
@@ -1,0 +1,11 @@
+{
+  id = "spark-hive";
+  # The spark service module that consumes this is x86_64-linux only (the Gluten
+  # Velox bundle has no other native build), so gate the flake output and
+  # package-set attr to x86_64-linux to keep `nix flake check` from fetching the
+  # ~400 MiB distribution on platforms nothing builds it for. Overlay stays
+  # unconditional and lazy, mirroring spark-gluten and drgn.
+  packageSet.systems = [ "x86_64-linux" ];
+  flake.systems = [ "x86_64-linux" ];
+  overlay = true;
+}


### PR DESCRIPTION
Closes #425.

Adds a Spark service module with the Gluten + Velox native execution engine, the configuration that makes Spark competitive with vectorized engines (DuckDB/Polars/Daft) on analytical workloads. Stock Spark runs on the JVM; Gluten offloads its physical operators to Velox, a C++ vectorized engine.

## What's here

**`packages/spark-gluten`** — the Apache Gluten 1.6.0 Velox bundle for Spark 3.5, patched to run on NixOS.
- `fetchurl` of `apache-gluten-1.6.0-bin-spark-3.5.tar.gz`; the published sha512 was verified before pinning the SRI hash.
- The bundle jar embeds `libvelox.so` (~246 MiB), `libgluten.so`, and the Arrow JNI libs, built on CentOS 7 with an FHS interpreter/rpath. The build explodes the jar, `autoPatchelf`s the libs, then re-roots each at `$ORIGIN` (the only intra-bundle link is `libvelox.so` -> `libgluten.so`) and pins libstdc++/zlib/openssl/numa to the store, and repacks. The `$ORIGIN` step matters because Gluten extracts the libs to a runtime temp dir, so the build-sandbox path autoPatchelf bakes in would dangle.
- x86_64-linux only (upstream publishes no other native build); the overlay stays lazy, mirroring `drgn`.

**`modules/services/spark`** (`services.ix-spark`) — single-node standalone master + worker.
- Typed options for master host/ports, worker cores/memory, `nativeEngine.{enable,offHeapSize}`, and a freeform `settings` attrset merged over the tuned defaults (user keys win).
- Generated `spark-defaults.conf`: Gluten plugin + `velox` backend, off-heap memory, `ColumnarShuffleManager`, AQE, Kryo, Arrow add-opens for JDK 17.
- Port claims (7077 / 8080 / 8081), a master web-UI health check, a dedicated `spark` user, and the `ix.systemdHardening` baseline (proven on the other JVM services).

## Validation

- `spark-gluten` builds on the x86_64-linux runner. Inspected the repacked jar: `libvelox.so`/`libgluten.so`/Arrow libs carry rpath `$ORIGIN` + the store paths for gcc-lib/zlib/openssl/numa, with zero `/build` paths remaining. The build itself is the dep check (`autoPatchelfIgnoreMissingDeps` is off, so a missing lib fails it). ✅
- Module evaluated in a full `nixosSystem` (x86_64-linux): master/worker `ExecStart`, `--cores`/`--memory`, `requires=spark-master`, the three port claims (no collision with `ix-agent`/`ix-console`), and the rendered `spark-defaults.conf` all come out correct. ✅
- `nixfmt`, `deadnix`, `statix`, `ast-grep` clean. ✅

## Not yet covered (follow-ups)

- A demo image/example under `images/` or `examples/`.
- An end-to-end TPC-H run on a live guest. This PR validates eval/build/link; it does not yet execute a Gluten query against a running cluster.

---
Authored by Claude (Anthropic claude-opus-4-8) on behalf of @andrewgazelka.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Spark 3.5 NixOS module with optional Gluten/Velox native execution engine
> - Adds a `services.ix-spark` NixOS module ([default.nix](https://github.com/indexable-inc/index/pull/426/files#diff-a2b1947d38332db6feae0231345dbceec287e5e298dc0b952aff12feb14c70f4)) that runs a Spark 3.5 standalone master and optional worker as hardened systemd services under a dedicated `spark` user, with state in `/var/lib/spark`.
> - Generates `spark-defaults.conf` by merging tuned defaults with optional native engine settings and user overrides; exposes master/worker web UIs on configurable ports with port claims and optional firewall rules.
> - Adds a [`spark-hive` derivation](https://github.com/indexable-inc/index/pull/426/files#diff-f201e271bce85367e21b79b1e21dd2c6ef8b92da7c149b6536dbd12045f7507a) packaging the official Spark 3.5.5 Hive distribution, wrapping all binaries with JDK 17, `TZDIR`, and required `PATH` entries.
> - Adds a [`spark-gluten` derivation](https://github.com/indexable-inc/index/pull/426/files#diff-21c5a27e5e3e8da03085fbb2b7bb86d7ca111828a839171935c758e76387354e) for the Gluten Velox 1.6.0 bundle jar, running `autoPatchelf` and rewriting rpath of bundled `.so` files so native libraries resolve at runtime inside NixOS.
> - When `nativeEngine.enable` is true, injects Gluten plugin config, columnar shuffle manager, off-heap memory, driver/executor `extraClassPath`, and JVM flags to open required modules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d3f589.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->