### PR TITLE
feat(bossbar): hover pop-down description panel

### DIFF
--- a/packages/bossbar-overlay/README.md
+++ b/packages/bossbar-overlay/README.md
@@ -44,15 +44,29 @@ platform's native window drag, and the drop location is saved to the bar's
 `x`/`y` columns, so it stays put across restarts. Bars without a saved position
 auto-stack in a top-center column. This works the same on macOS and Linux.
 
-Known limitation: some Linux tiling window managers force-place or tile
-borderless windows, which can fight the free-drag placement.
+A bar can carry a longer `description`. When it does, hovering unfolds a flat
+panel below the bar with the description wrapped to the bar's width, in the same
+Minecraft font, with a one-pixel border tinted to the bar's color. Newlines in
+the description start new paragraphs. The window only grows to fit the panel
+while you hover, so the area below a bar stays click-through the rest of the
+time; a bar with an empty description behaves exactly as before. See the
+seeded Ender Dragon bar for an example.
+
+Known limitations: some Linux tiling window managers force-place or tile
+borderless windows, which can fight the free-drag placement. An auto-stacked
+bar's open panel can overlap the bar stacked below it while you hover; pin bars
+apart by dragging if that bothers you. A panel on a bar pinned near the bottom
+of the screen unfolds off-screen.
 
 To verify rendering without a window, render the current bars straight to a
 transparent PNG:
 
 ```sh
-nix run .#bossbar-overlay -- --snapshot out.png --scale 3 --size 700x260
+nix run .#bossbar-overlay -- --snapshot out.png --scale 3 --size 760x620
 ```
+
+The snapshot draws every described bar with its panel fully open, so it doubles
+as a way to proof-read a description's wrapping without hovering.
 
 ## CLI
 
@@ -61,9 +75,11 @@ you don't have to hand-write SQL. It works whether or not the app is running and
 creates the schema on demand.
 
 ```sh
-./bossbar add "Ender Dragon" --color pink --overlay notched_20 --progress 0.8
+./bossbar add "Ender Dragon" --color pink --overlay notched_20 --progress 0.8 \
+  --description "Destroy the End Crystals first or it heals back to full."
 ./bossbar set "Ender Dragon" --progress 0.5      # match by title ...
 ./bossbar set 1 --color red --visible 1          # ... or by id
+./bossbar set 1 --description ''                 # clear the hover panel
 ./bossbar list
 ./bossbar rm "Ender Dragon"
 ./bossbar clear
@@ -84,15 +100,16 @@ three example bars so you can see it working.
 
 ```sql
 CREATE TABLE bossbars (
-  id        INTEGER PRIMARY KEY,
-  title     TEXT    NOT NULL DEFAULT '',     -- text shown above the bar
-  progress  REAL    NOT NULL DEFAULT 1.0,    -- fill fraction, 0.0 .. 1.0
-  color     TEXT    NOT NULL DEFAULT 'purple',
-  overlay   TEXT    NOT NULL DEFAULT 'progress',
-  visible   INTEGER NOT NULL DEFAULT 1,      -- 0 hides the row
-  position  INTEGER NOT NULL DEFAULT 0,      -- sort order in the auto column
-  x         REAL,                            -- pinned location (logical points)
-  y         REAL                             -- NULL/NULL = auto-stacked
+  id          INTEGER PRIMARY KEY,
+  title       TEXT    NOT NULL DEFAULT '',   -- text shown above the bar
+  description TEXT    NOT NULL DEFAULT '',   -- hover pop-down body (may wrap/paragraph)
+  progress    REAL    NOT NULL DEFAULT 1.0,  -- fill fraction, 0.0 .. 1.0
+  color       TEXT    NOT NULL DEFAULT 'purple',
+  overlay     TEXT    NOT NULL DEFAULT 'progress',
+  visible     INTEGER NOT NULL DEFAULT 1,    -- 0 hides the row
+  position    INTEGER NOT NULL DEFAULT 0,    -- sort order in the auto column
+  x           REAL,                          -- pinned location (logical points)
+  y           REAL                           -- NULL/NULL = auto-stacked
 );
 ```
 
@@ -100,6 +117,9 @@ CREATE TABLE bossbars (
   (Minecraft's seven boss bar colors). Unknown values fall back to `purple`.
 - **overlay**: `progress` (smooth) or `notched_6` / `notched_10` / `notched_12`
   / `notched_20` (segmented), matching Minecraft's overlay styles.
+- **description**: longer text shown in the panel that unfolds below the bar on
+  hover. Empty (the default) means no panel. Lines wrap to the bar's width;
+  newlines start new paragraphs.
 - **x / y**: pinned screen location in logical points, written when you drag a
   bar. Leave both `NULL` (the default) to keep the bar in the auto-stacked
   top-center column ordered by `position`; setting them floats the bar free.
@@ -125,16 +145,21 @@ off the repo's main graph):
 - `app/src/db.rs` — opens the DB (bundled SQLite via `rusqlite`), polls
   `data_version` four times a second, and hands fresh bars to the UI thread on
   every change.
-- `app/src/overlay.rs` — the winit event loop and window: transparent,
-  always-on-top, click-through (`set_cursor_hittest(false)`), spanning the top
-  of the primary monitor. macOS runs as an `Accessory` app (no Dock icon). The
-  watcher wakes the loop with a user event, so a DB write triggers a redraw.
+- `app/src/overlay.rs` — the winit event loop: one transparent, always-on-top,
+  borderless window **per bar**, each sized to just that bar, so the desktop is
+  click-through everywhere off a bar with no `set_cursor_hittest`. macOS runs as
+  an `Accessory` app (no Dock icon). Hover fires native `CursorEntered`/`Left`
+  (the bar grows; a described bar grows its window to make room for the panel and
+  shrinks back once the hover eases out); pressing calls the native
+  `Window::drag_window`. The watcher wakes the loop on every DB write.
 - `app/src/render.rs` — the wgpu renderer: one textured-quad pipeline draws the
   same layer stack Minecraft uses, clipping the progress layers to the fill
-  fraction with nearest sampling (crisp pixels). Titles are drawn with
-  [`glyphon`](https://github.com/grovesNL/glyphon) in a pixel-accurate Minecraft
-  TTF ([tryashtar/minecraft-ttf](https://github.com/tryashtar/minecraft-ttf)),
-  with the vanilla one-pixel drop shadow.
+  fraction with nearest sampling (crisp pixels). Titles and the description panel
+  are drawn with [`glyphon`](https://github.com/grovesNL/glyphon) in a
+  pixel-accurate Minecraft TTF
+  ([tryashtar/minecraft-ttf](https://github.com/tryashtar/minecraft-ttf)), with
+  the vanilla one-pixel drop shadow. The same pipeline draws the panel's flat
+  fill and border via a 1x1 white texture tinted by a per-vertex color.
 - `app/src/snapshot.rs` — runs the identical renderer headlessly into a PNG, so
   the transparent overlay can be verified from a file.
 

--- a/packages/bossbar-overlay/app/src/bars.rs
+++ b/packages/bossbar-overlay/app/src/bars.rs
@@ -31,6 +31,21 @@ impl Color {
             _ => Self::Purple,
         }
     }
+
+    /// Representative RGB for this bar color (0..=255), approximating the vanilla
+    /// boss bar sprite hue. Used to tint the hover panel's border so the pop-down
+    /// reads as belonging to its bar; the bar sprites themselves stay textured.
+    pub fn accent_rgb(self) -> [u8; 3] {
+        match self {
+            Self::Pink => [0xE0, 0x6A, 0xB8],
+            Self::Blue => [0x46, 0x6C, 0xE6],
+            Self::Red => [0xD8, 0x3A, 0x32],
+            Self::Green => [0x5A, 0xC0, 0x3A],
+            Self::Yellow => [0xE6, 0xC8, 0x3A],
+            Self::Purple => [0x9B, 0x59, 0xD6],
+            Self::White => [0xD8, 0xD8, 0xD8],
+        }
+    }
 }
 
 /// The notch overlays Minecraft draws on top of the color bar. `None` is the
@@ -82,6 +97,10 @@ pub enum Notch {
 pub struct BossBar {
     pub id: i64,
     pub title: String,
+    /// Longer free text revealed in a panel that unfolds below the bar on hover.
+    /// Empty means the bar has no pop-down and behaves exactly as it did before.
+    /// Newlines separate paragraphs; the panel wraps long lines to its width.
+    pub description: String,
     /// Fill fraction, always clamped to `0.0..=1.0` at construction.
     pub progress: f32,
     pub color: Color,

--- a/packages/bossbar-overlay/app/src/db.rs
+++ b/packages/bossbar-overlay/app/src/db.rs
@@ -21,29 +21,36 @@ pub const POLL: Duration = Duration::from_millis(200);
 
 const SCHEMA: &str = "\
 CREATE TABLE IF NOT EXISTS bossbars (
-  id        INTEGER PRIMARY KEY,
-  title     TEXT    NOT NULL DEFAULT '',
-  progress  REAL    NOT NULL DEFAULT 1.0,
-  color     TEXT    NOT NULL DEFAULT 'purple',
-  overlay   TEXT    NOT NULL DEFAULT 'progress',
-  visible   INTEGER NOT NULL DEFAULT 1,
-  position  INTEGER NOT NULL DEFAULT 0,
-  x         REAL,
-  y         REAL
+  id          INTEGER PRIMARY KEY,
+  title       TEXT    NOT NULL DEFAULT '',
+  description TEXT    NOT NULL DEFAULT '',
+  progress    REAL    NOT NULL DEFAULT 1.0,
+  color       TEXT    NOT NULL DEFAULT 'purple',
+  overlay     TEXT    NOT NULL DEFAULT 'progress',
+  visible     INTEGER NOT NULL DEFAULT 1,
+  position    INTEGER NOT NULL DEFAULT 0,
+  x           REAL,
+  y           REAL
 );";
 
 /// Columns added after the initial schema shipped. `ALTER TABLE ADD COLUMN` is
 /// the supported online migration in SQLite, and it errors if the column
-/// already exists, so each runs through `add_column_if_missing`.
-const ADDED_COLUMNS: &[(&str, &str)] = &[("x", "REAL"), ("y", "REAL")];
+/// already exists, so each runs through `add_column_if_missing`. A constant
+/// default keeps the migration legal on an existing table.
+const ADDED_COLUMNS: &[(&str, &str)] = &[
+    ("x", "REAL"),
+    ("y", "REAL"),
+    ("description", "TEXT NOT NULL DEFAULT ''"),
+];
 
 /// Rows inserted only when the DB file is created for the first time, so a
-/// brand-new install shows something and documents the contract by example.
+/// brand-new install shows something and documents the contract by example. The
+/// third bar carries a multi-paragraph description to show off the hover panel.
 const SEED: &str = "\
-INSERT INTO bossbars (title, progress, color, overlay, position) VALUES
-  ('Ender Dragon',  0.82, 'pink',   'notched_20', 0),
-  ('Wither',        0.55, 'blue',   'notched_6',  1),
-  ('Build: compiling', 0.40, 'green', 'progress',  2);";
+INSERT INTO bossbars (title, description, progress, color, overlay, position) VALUES
+  ('Ender Dragon', 'The final boss of the End. Destroy all the End Crystals on the obsidian pillars first, or it heals back to full.', 0.82, 'pink', 'notched_20', 0),
+  ('Wither', '', 0.55, 'blue', 'notched_6', 1),
+  ('Build: compiling', 'Hover any bar to read more.\n\nThe panel wraps long lines and keeps your paragraph breaks, so a bar can carry a sentence or a few.', 0.40, 'green', 'progress', 2);";
 
 /// Resolve the database path: `BOSSBAR_DB` wins, otherwise the per-OS app-data
 /// path the `bossbar` CLI also computes.
@@ -105,7 +112,7 @@ pub fn set_position(path: &Path, id: i64, pos: glam::DVec2) -> rusqlite::Result<
 
 fn read(conn: &Connection) -> rusqlite::Result<Vec<BossBar>> {
     let mut stmt = conn.prepare(
-        "SELECT id, title, progress, color, overlay, position, x, y
+        "SELECT id, title, progress, color, overlay, position, x, y, description
          FROM bossbars
          WHERE visible != 0
          ORDER BY position ASC, id ASC",
@@ -116,6 +123,7 @@ fn read(conn: &Connection) -> rusqlite::Result<Vec<BossBar>> {
         Ok(BossBar {
             id: r.get(0)?,
             title: r.get(1)?,
+            description: r.get(8)?,
             progress: r.get::<_, f64>(2)?.clamp(0.0, 1.0) as f32,
             color: Color::parse(&r.get::<_, String>(3)?),
             overlay: Overlay::parse(&r.get::<_, String>(4)?),
@@ -206,6 +214,50 @@ mod tests {
         assert_eq!(bars[0].color, Color::Pink);
         assert_eq!(bars[0].overlay, Overlay::Notched20);
         assert!((bars[0].progress - 0.82).abs() < 1e-6);
+        // The seed documents the description contract by example.
+        assert!(bars[0].description.contains("End Crystals"));
+        assert_eq!(bars[1].description, "", "the Wither seed has no panel");
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn legacy_db_without_description_is_migrated_and_round_trips() {
+        // A database created before `description` shipped (no description, x, or
+        // y columns) must gain the column on open and read back as empty, then
+        // accept a written description.
+        let path = temp_db("legacy-desc");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        {
+            let legacy = Connection::open(&path).unwrap();
+            legacy
+                .execute_batch(
+                    "CREATE TABLE bossbars (
+                       id       INTEGER PRIMARY KEY,
+                       title    TEXT    NOT NULL DEFAULT '',
+                       progress REAL    NOT NULL DEFAULT 1.0,
+                       color    TEXT    NOT NULL DEFAULT 'purple',
+                       overlay  TEXT    NOT NULL DEFAULT 'progress',
+                       visible  INTEGER NOT NULL DEFAULT 1,
+                       position INTEGER NOT NULL DEFAULT 0
+                     );
+                     INSERT INTO bossbars (title) VALUES ('old');",
+                )
+                .unwrap();
+        }
+
+        let conn = open(&path).unwrap();
+        let bars = read(&conn).unwrap();
+        assert_eq!(bars.len(), 1);
+        assert_eq!(bars[0].title, "old");
+        assert_eq!(bars[0].description, "", "migrated column defaults to empty");
+
+        conn.execute(
+            "UPDATE bossbars SET description = ?1 WHERE id = ?2",
+            rusqlite::params!["line one\n\nline two", bars[0].id],
+        )
+        .unwrap();
+        let bars = read(&conn).unwrap();
+        assert_eq!(bars[0].description, "line one\n\nline two");
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 

--- a/packages/bossbar-overlay/app/src/overlay.rs
+++ b/packages/bossbar-overlay/app/src/overlay.rs
@@ -79,12 +79,23 @@ struct BarWin {
     /// Last position we know the window holds (logical points): what we set, or
     /// where the OS placed it. Lets `Moved` skip echoes of our own placement.
     self_set: Option<LogicalPosition<f64>>,
+    /// This bar carries a description, so it has a hover pop-down panel.
+    has_description: bool,
+    /// The window is currently grown to fit the open panel. Collapsed otherwise,
+    /// so the empty area below the bar never intercepts the mouse (click-through).
+    expanded: bool,
 }
 
 impl BarWin {
     /// Still moving: easing toward/away from hover, or breathing while hovered.
     fn animating(&self) -> bool {
         self.hovered || self.hover_anim > 0.0
+    }
+
+    /// The window should be grown for the panel while the bar is hovered or
+    /// still easing back from a hover, but only when it has a description.
+    fn wants_expanded(&self) -> bool {
+        self.has_description && self.animating()
     }
 }
 
@@ -219,6 +230,7 @@ impl App {
         let window = Arc::new(event_loop.create_window(attrs).ok()?);
         let (surface, config) = self.make_surface(&window);
         window.request_redraw();
+        let has_description = !bar.description.trim().is_empty();
         Some(BarWin {
             window,
             surface,
@@ -229,6 +241,10 @@ impl App {
             last: Instant::now(),
             dragging: false,
             self_set: Some(pos),
+            has_description,
+            // Windows are created at the collapsed (bar-only) size; the panel
+            // grows them on hover.
+            expanded: false,
         })
     }
 
@@ -249,7 +265,12 @@ impl App {
             };
 
             if let Some(win) = self.wins.get_mut(&b.id) {
-                let title_presence_changed = win.bar.title.is_empty() != b.title.is_empty();
+                // A change to title presence or the description (while open)
+                // changes the window's collapsed or expanded size.
+                let size_affecting_changed = win.bar.title.is_empty() != b.title.is_empty()
+                    || win.bar.description.trim().is_empty() != b.description.trim().is_empty()
+                    || (win.expanded && win.bar.description != b.description);
+                win.has_description = !b.description.trim().is_empty();
                 win.bar = b.clone();
                 // Honor a position set in the DB by something other than our own
                 // drag (e.g. the CLI), but ignore the echo of our last move.
@@ -260,7 +281,11 @@ impl App {
                         win.self_set = Some(lp);
                     }
                 }
-                if title_presence_changed {
+                if size_affecting_changed {
+                    // Reset to the resting size; if the bar is still hovered the
+                    // settle pass in `about_to_wait` re-expands it to the new
+                    // panel height on the next tick.
+                    win.expanded = false;
                     let (w_px, h_px) = render::bar_window_px(self.scale, !b.title.is_empty());
                     let _ = win.window.request_inner_size(PhysicalSize::new(w_px, h_px));
                 }
@@ -356,6 +381,32 @@ impl App {
         if let Err(e) = db::set_position(&self.db, id, dv) {
             eprintln!("bossbar-overlay: save position failed: {e}");
         }
+    }
+
+    /// Grow or shrink a bar's window to match its hover state. Expanding makes
+    /// room for the description panel to unfold; collapsing restores the bar-only
+    /// size so the area below the bar stops intercepting the mouse, keeping the
+    /// desktop click-through everywhere off a bar. No-op when already in the
+    /// target state or when the bar has no panel.
+    fn set_window_expanded(&mut self, id: i64, expand: bool) {
+        let Some(core) = self.core.as_mut() else {
+            return;
+        };
+        let Some(win) = self.wins.get_mut(&id) else {
+            return;
+        };
+        if win.expanded == expand || (expand && !win.has_description) {
+            return;
+        }
+        let (w_px, h_px) = if expand {
+            core.renderer.expanded_window_px(&win.bar)
+        } else {
+            render::bar_window_px(self.scale, !win.bar.title.is_empty())
+        };
+        win.expanded = expand;
+        // Rely on the resulting `Resized` event to reconfigure the surface, the
+        // same way a title-presence change in `reconcile` does.
+        let _ = win.window.request_inner_size(PhysicalSize::new(w_px, h_px));
     }
 }
 
@@ -461,6 +512,15 @@ impl ApplicationHandler<Vec<BossBar>> for App {
     /// breathing), capped to ~60 fps; otherwise let the loop sleep until the
     /// next event so an idle overlay costs nothing.
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        // Settle each window's size to its hover state first: grow for an open
+        // panel, shrink back once the hover has fully eased out. Done here, off
+        // the per-frame easing, so the window resizes only twice per hover.
+        let ids: Vec<i64> = self.wins.keys().copied().collect();
+        for id in ids {
+            let want = self.wins.get(&id).is_some_and(BarWin::wants_expanded);
+            self.set_window_expanded(id, want);
+        }
+
         let mut animating = false;
         for win in self.wins.values() {
             if win.animating() {

--- a/packages/bossbar-overlay/app/src/render.rs
+++ b/packages/bossbar-overlay/app/src/render.rs
@@ -42,15 +42,53 @@ const MAX_SCALE: f32 = HOVER_SCALE * (1.0 + BREATHE_AMP);
 /// Vanilla title shadow: one dark pixel offset, scaled, no blur.
 const SHADOW: GColor = GColor::rgb(0x3f, 0x3f, 0x3f);
 
+/// Description pop-down panel, in native (unscaled) pixels. Everything is
+/// multiplied by the integer sprite `scale`, so the panel stays pixel-crisp and
+/// proportional to the bars at any display scale.
+mod panel {
+    /// Body font size and line advance (leading). The face matches the title's
+    /// Minecraft font; the extra leading gives wrapped paragraphs room.
+    pub const FONT: f32 = 8.0;
+    pub const LINE: f32 = 10.0;
+    /// Inner text padding and the flat one-pixel border frame.
+    pub const PAD: f32 = 5.0;
+    pub const BORDER: f32 = 1.0;
+    /// Gap between the bar's reserved (hover-headroom) area and the panel top.
+    pub const GAP: f32 = 3.0;
+    /// Flat dark-slate fill, kept slightly translucent so the desktop bleeds
+    /// through like the bars. Straight (non-premultiplied) RGBA in 0..=1.
+    pub const BG: [f32; 4] = [0x12 as f32 / 255.0, 0x0f as f32 / 255.0, 0x1a as f32 / 255.0, 0.92];
+    /// Border opacity; its RGB comes from the bar color's accent.
+    pub const BORDER_ALPHA: f32 = 0.95;
+}
+
+/// Straight-alpha RGBA in 0..=1 from an 8-bit RGB triple and an alpha.
+fn rgba(rgb: [u8; 3], a: f32) -> [f32; 4] {
+    [
+        rgb[0] as f32 / 255.0,
+        rgb[1] as f32 / 255.0,
+        rgb[2] as f32 / 255.0,
+        a,
+    ]
+}
+
+/// Smoothstep ramp: 0 below `lo`, 1 above `hi`, eased between. Lets the panel
+/// text fade in only after the box has begun to unfold.
+fn ramp(x: f32, lo: f32, hi: f32) -> f32 {
+    let t = ((x - lo) / (hi - lo)).clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 struct Vertex {
     pos: [f32; 2],
     uv: [f32; 2],
-    /// Per-quad opacity. The hovered or dragged bar paints at 1.0 while the
-    /// rest stay at [`DEFAULT_OPACITY`], so hovering reads as the bar going
-    /// solid rather than any motion.
-    alpha: f32,
+    /// Straight-alpha RGBA tint multiplied into the sampled texel. Bars pass
+    /// white so they show unchanged (the alpha lets a hovered bar paint solid
+    /// over the translucent rest); the panel samples a 1x1 white texture, so the
+    /// tint *is* its flat fill or border color.
+    color: [f32; 4],
 }
 
 #[repr(C)]
@@ -60,13 +98,15 @@ struct Globals {
     _pad: [f32; 2],
 }
 
-/// Which preloaded sprite a layer samples.
+/// Which preloaded sprite a layer samples. `Solid` is a 1x1 white texture used
+/// by the description panel's flat fill and border, tinted via the vertex color.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 enum TexId {
     ColorBg(Color),
     ColorFill(Color),
     NotchBg(Notch),
     NotchFill(Notch),
+    Solid,
 }
 
 /// One textured quad to draw, in physical pixels.
@@ -78,8 +118,8 @@ struct Quad {
     h: f32,
     /// UV span; fill layers narrow `u1` so the sprite is cut off, not squished.
     u1: f32,
-    /// Opacity for this quad's bar; see [`Vertex::alpha`].
-    alpha: f32,
+    /// Straight-alpha RGBA tint for this quad; see [`Vertex::color`].
+    color: [f32; 4],
 }
 
 /// Physical-pixel geometry of one laid-out bar, in the target's local space.
@@ -96,11 +136,36 @@ struct BarBox {
     has_title: bool,
 }
 
-/// One bar to paint: which bar, its box in target-local pixels, and its opacity.
+/// Physical-pixel geometry of the description pop-down panel, plus its current
+/// reveal. The box unfolds downward as `reveal` goes 0..1; the text fades in via
+/// `text_alpha` slightly behind it. Width matches the bar; produced by
+/// [`Renderer::render_one`] (hover-driven) and [`Renderer::render`] (fully open,
+/// for the `--snapshot` PNG).
+#[derive(Clone, Copy)]
+struct PanelBox {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+    border: f32,
+    pad: f32,
+    font_px: f32,
+    line_px: f32,
+    /// Vertical unfold of the box in `0..=1`, anchored at the top edge.
+    reveal: f32,
+    /// Text fade in `0..=1`, lagged behind `reveal` so the box opens first.
+    text_alpha: f32,
+    /// Border RGB (the bar color's accent), 0..=255; the fill is [`panel::BG`].
+    border_rgb: [u8; 3],
+}
+
+/// One bar to paint: which bar, its box in target-local pixels, its opacity, and
+/// an optional description panel unfolding beneath it.
 struct DrawItem<'a> {
     bar: &'a BossBar,
     geom: BarBox,
     alpha: f32,
+    panel: Option<PanelBox>,
 }
 
 pub struct Renderer {
@@ -195,7 +260,7 @@ impl Renderer {
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
-                    attributes: &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x2, 2 => Float32],
+                    attributes: &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x2, 2 => Float32x4],
                 }],
             },
             fragment: Some(wgpu::FragmentState {
@@ -262,6 +327,12 @@ impl Renderer {
                 upload_png(&device, &queue, &tex_layout, &sampler, fill),
             );
         }
+        // A single white texel the panel quads sample so the vertex color tints
+        // them directly: white * color = color (a flat fill or border).
+        textures.insert(
+            TexId::Solid,
+            upload_white_pixel(&device, &queue, &tex_layout, &sampler),
+        );
 
         // Load *only* the embedded Minecraft font into an otherwise empty
         // database. cosmic-text's default `FontSystem::new` also loads every
@@ -305,8 +376,16 @@ impl Renderer {
 
     /// Physical-pixel geometry of every bar auto-stacked down the top-center
     /// column, in draw order. Used by the multi-bar `--snapshot` render; the
-    /// live overlay gives each bar its own window and uses `render_one`.
-    fn layout(&self, bars: &[BossBar], width: f32) -> Vec<BarBox> {
+    /// live overlay gives each bar its own window and uses `render_one`. `panels`
+    /// is the per-bar panel size (parallel to `bars`); a bar with a panel
+    /// reserves `gap + panel_h` extra vertical space so the next bar clears it.
+    fn layout(
+        &self,
+        bars: &[BossBar],
+        width: f32,
+        panels: &[Option<(f32, f32)>],
+        gap: f32,
+    ) -> Vec<BarBox> {
         let s = self.scale as f32;
         let bar_w = BAR_W as f32 * s;
         let bar_h = BAR_H as f32 * s;
@@ -318,7 +397,7 @@ impl Renderer {
 
         let mut boxes = Vec::with_capacity(bars.len());
         let mut y = top_pad;
-        for b in bars {
+        for (b, panel) in bars.iter().zip(panels) {
             let has_title = !b.title.is_empty();
             let title_h = if has_title { title_px } else { 0.0 };
             let track_y = y + title_h + if has_title { title_gap } else { 0.0 };
@@ -332,6 +411,9 @@ impl Renderer {
                 has_title,
             });
             y = track_y + bar_h + bar_gap;
+            if let Some((_, panel_h)) = panel {
+                y += gap + panel_h + bar_gap;
+            }
         }
         boxes
     }
@@ -345,23 +427,35 @@ impl Renderer {
         height: u32,
         items: &[DrawItem<'_>],
     ) -> Result<(), wgpu::SurfaceError> {
-        // A shaped title plus where and how opaque to draw it.
-        struct Title {
+        // A shaped run of text plus where, how opaque, and the rect to clip it
+        // to. Titles span the whole target; description lines clip to the
+        // unfolding panel so they reveal with the box.
+        struct Text {
             buffer: Buffer,
             left: f32,
             top: f32,
             alpha: f32,
+            clip: TextBounds,
         }
 
         let shadow_off = self.scale as f32;
+        let full_bounds = TextBounds {
+            left: 0,
+            top: 0,
+            right: width as i32,
+            bottom: height as i32,
+        };
 
         let mut quads: Vec<Quad> = Vec::new();
-        let mut titles: Vec<Title> = Vec::new();
+        let mut texts: Vec<Text> = Vec::new();
 
         for item in items {
             let b = item.bar;
             let bx = item.geom;
             let alpha = item.alpha;
+            // Bars sample real sprites, so the tint is white with the bar's
+            // opacity; only the alpha channel matters for them.
+            let tint = [1.0, 1.0, 1.0, alpha];
 
             if bx.has_title {
                 let mut buffer =
@@ -377,11 +471,12 @@ impl Renderer {
                     Some(glyphon::cosmic_text::Align::Center),
                 );
                 buffer.shape_until_scroll(&mut self.font_system, false);
-                titles.push(Title {
+                texts.push(Text {
                     buffer,
                     left: bx.left,
                     top: bx.title_top,
                     alpha,
+                    clip: full_bounds,
                 });
             }
 
@@ -393,7 +488,7 @@ impl Renderer {
                 w: bx.bar_w,
                 h: bx.bar_h,
                 u1: 1.0,
-                alpha,
+                color: tint,
             });
             if b.progress > 0.0 {
                 quads.push(Quad {
@@ -403,7 +498,7 @@ impl Renderer {
                     w: bx.bar_w * b.progress,
                     h: bx.bar_h,
                     u1: b.progress,
-                    alpha,
+                    color: tint,
                 });
             }
             // Optional notch overlay on top, same draw order.
@@ -415,7 +510,7 @@ impl Renderer {
                     w: bx.bar_w,
                     h: bx.bar_h,
                     u1: 1.0,
-                    alpha,
+                    color: tint,
                 });
                 if b.progress > 0.0 {
                     quads.push(Quad {
@@ -425,7 +520,68 @@ impl Renderer {
                         w: bx.bar_w * b.progress,
                         h: bx.bar_h,
                         u1: b.progress,
-                        alpha,
+                        color: tint,
+                    });
+                }
+            }
+
+            // Description pop-down: a flat bordered box that unfolds downward,
+            // with the wrapped paragraph fading in behind it.
+            if let Some(p) = item.panel.filter(|p| p.reveal > 0.001) {
+                let revealed_h = (p.h * p.reveal).max(0.0);
+                // Border frame first, then the fill inset by the border. While
+                // unfolding (revealed_h < 2*border) only the accent strip shows,
+                // so the box reads as opening from a thin line.
+                quads.push(Quad {
+                    tex: TexId::Solid,
+                    x: p.x,
+                    y: p.y,
+                    w: p.w,
+                    h: revealed_h,
+                    u1: 1.0,
+                    color: rgba(p.border_rgb, panel::BORDER_ALPHA),
+                });
+                let inner_x = p.x + p.border;
+                let inner_w = (p.w - 2.0 * p.border).max(0.0);
+                let inner_y = p.y + p.border;
+                let inner_h = (revealed_h - 2.0 * p.border).max(0.0);
+                quads.push(Quad {
+                    tex: TexId::Solid,
+                    x: inner_x,
+                    y: inner_y,
+                    w: inner_w,
+                    h: inner_h,
+                    u1: 1.0,
+                    color: panel::BG,
+                });
+
+                if p.text_alpha > 0.001 && !b.description.trim().is_empty() {
+                    let text_w = (p.w - 2.0 * (p.border + p.pad)).max(1.0);
+                    let mut buffer =
+                        Buffer::new(&mut self.font_system, Metrics::new(p.font_px, p.line_px));
+                    buffer.set_size(&mut self.font_system, Some(text_w), None);
+                    buffer.set_text(
+                        &mut self.font_system,
+                        &b.description,
+                        &Attrs::new().family(Family::Name(&self.font_family)),
+                        Shaping::Advanced,
+                        None,
+                    );
+                    buffer.shape_until_scroll(&mut self.font_system, false);
+                    // Clip to the revealed inner area so lines wipe in with the
+                    // box rather than popping in fully formed.
+                    let clip = TextBounds {
+                        left: inner_x as i32,
+                        top: inner_y as i32,
+                        right: (inner_x + inner_w) as i32,
+                        bottom: (p.y + revealed_h - p.border) as i32,
+                    };
+                    texts.push(Text {
+                        buffer,
+                        left: inner_x + p.pad,
+                        top: inner_y + p.pad,
+                        alpha: p.text_alpha,
+                        clip,
                     });
                 }
             }
@@ -437,11 +593,11 @@ impl Renderer {
         for q in &quads {
             let base = verts.len() as u32;
             let (x0, y0, x1, y1) = (q.x, q.y, q.x + q.w, q.y + q.h);
-            let a = q.alpha;
+            let color = q.color;
             let v = |px, py, u, vv| Vertex {
                 pos: [px, py],
                 uv: [u, vv],
-                alpha: a,
+                color,
             };
             verts.extend_from_slice(&[
                 v(x0, y0, 0.0, 0.0),
@@ -473,7 +629,7 @@ impl Renderer {
                     bytemuck::cast_slice(&[Vertex {
                         pos: [0.0, 0.0],
                         uv: [0.0, 0.0],
-                        alpha: 0.0,
+                        color: [0.0, 0.0, 0.0, 0.0],
                     }])
                 } else {
                     bytemuck::cast_slice(&verts)
@@ -481,35 +637,29 @@ impl Renderer {
                 usage: wgpu::BufferUsages::VERTEX,
             });
 
-        // Prepare text. Each title's alpha tracks its own bar, so a hovered bar
-        // goes opaque (title included) while the rest stay translucent.
-        let bounds = TextBounds {
-            left: 0,
-            top: 0,
-            right: width as i32,
-            bottom: height as i32,
-        };
+        // Prepare text. Each run's alpha tracks its own bar (a hovered bar goes
+        // opaque, title and description included) and clips to its own rect.
         let mut areas: Vec<TextArea> = Vec::new();
-        for title in &titles {
-            let a = (title.alpha * 255.0) as u8;
+        for text in &texts {
+            let a = (text.alpha * 255.0) as u8;
             let fg = GColor::rgba(0xff, 0xff, 0xff, a);
             let shadow = GColor::rgba(SHADOW.r(), SHADOW.g(), SHADOW.b(), a);
             // Shadow first, then the white face one pixel up-left of it.
             areas.push(TextArea {
-                buffer: &title.buffer,
-                left: title.left + shadow_off,
-                top: title.top + shadow_off,
+                buffer: &text.buffer,
+                left: text.left + shadow_off,
+                top: text.top + shadow_off,
                 scale: 1.0,
-                bounds,
+                bounds: text.clip,
                 default_color: shadow,
                 custom_glyphs: &[],
             });
             areas.push(TextArea {
-                buffer: &title.buffer,
-                left: title.left,
-                top: title.top,
+                buffer: &text.buffer,
+                left: text.left,
+                top: text.top,
                 scale: 1.0,
-                bounds,
+                bounds: text.clip,
                 default_color: fg,
                 custom_glyphs: &[],
             });
@@ -572,7 +722,9 @@ impl Renderer {
     }
 
     /// Render all bars auto-stacked into one target (the `--snapshot` PNG path).
-    /// `highlight` is the id of a bar to paint opaque.
+    /// `highlight` is the id of a bar to paint opaque. Every bar with a
+    /// description shows its panel fully open, so the snapshot verifies the
+    /// pop-down the live overlay only reveals on hover.
     pub fn render(
         &mut self,
         view: &wgpu::TextureView,
@@ -582,14 +734,34 @@ impl Renderer {
         highlight: Option<i64>,
     ) -> Result<(), wgpu::SurfaceError> {
         let opacity = self.opacity;
-        let boxes = self.layout(bars, width as f32);
+        let (border, pad, font_px, line_px, gap) = self.panel_metrics();
+        let sizes: Vec<Option<(f32, f32)>> =
+            bars.iter().map(|b| self.panel_size(&b.description)).collect();
+        let boxes = self.layout(bars, width as f32, &sizes, gap);
         let items: Vec<DrawItem<'_>> = bars
             .iter()
             .zip(boxes)
-            .map(|(bar, geom)| DrawItem {
-                bar,
-                geom,
-                alpha: if Some(bar.id) == highlight { 1.0 } else { opacity },
+            .zip(&sizes)
+            .map(|((bar, geom), size)| {
+                let panel = size.map(|(panel_w, panel_h)| PanelBox {
+                    x: (width as f32 - panel_w) * 0.5,
+                    y: geom.track_y + geom.bar_h + gap,
+                    w: panel_w,
+                    h: panel_h,
+                    border,
+                    pad,
+                    font_px,
+                    line_px,
+                    reveal: 1.0,
+                    text_alpha: 1.0,
+                    border_rgb: bar.color.accent_rgb(),
+                });
+                DrawItem {
+                    bar,
+                    geom,
+                    alpha: if Some(bar.id) == highlight { 1.0 } else { opacity },
+                    panel,
+                }
             })
             .collect();
         self.draw(view, width, height, &items)
@@ -602,6 +774,10 @@ impl Renderer {
     /// and translucent and the hover headroom is transparent margin. The window
     /// size must come from [`bar_window_px`] so the grown bar fits without
     /// resizing.
+    ///
+    /// When the bar has a description and the window has grown tall enough (the
+    /// overlay enlarges it on hover, see [`Renderer::expanded_window_px`]), a
+    /// description panel unfolds beneath the bar, revealing with `hover`.
     pub fn render_one(
         &mut self,
         view: &wgpu::TextureView,
@@ -626,12 +802,18 @@ impl Renderer {
         let bar_w = BAR_W as f32 * s;
         let bar_h = BAR_H as f32 * s;
 
-        // Center the content (plus its shadow offset) in the window so growth on
-        // hover expands evenly from the middle rather than shifting a corner.
+        // The bar lives in the top region: the collapsed window size, which holds
+        // it plus its grow/breathe headroom. Any extra window height below that
+        // is the panel's drop area, so the bar stays put as the panel unfolds.
+        let collapsed_h = bar_window_px(self.scale, has_title).1 as f32;
+        let top_region_h = collapsed_h.min(height as f32);
+
+        // Center the content (plus its shadow offset) in the top region so growth
+        // on hover expands evenly from the middle rather than shifting a corner.
         let content_w = bar_w + shadow;
         let content_h = title_h + title_gap + bar_h + shadow;
         let left = ((width as f32 - content_w) * 0.5).max(0.0);
-        let top = ((height as f32 - content_h) * 0.5).max(0.0);
+        let top = ((top_region_h - content_h) * 0.5).max(0.0);
 
         let geom = BarBox {
             left,
@@ -642,8 +824,99 @@ impl Renderer {
             title_px,
             has_title,
         };
-        let items = [DrawItem { bar, geom, alpha }];
+
+        // Only build the panel when the window was actually grown for it; a
+        // collapsed window (height == top_region_h) has no room and skips it.
+        let panel = if height as f32 > collapsed_h + 0.5 {
+            self.panel_size(&bar.description).map(|(panel_w, panel_h)| {
+                let (border, pad, font_px, line_px, gap) = self.panel_metrics();
+                PanelBox {
+                    x: ((width as f32 - panel_w) * 0.5).max(0.0),
+                    y: collapsed_h + gap,
+                    w: panel_w,
+                    h: panel_h,
+                    border,
+                    pad,
+                    font_px,
+                    line_px,
+                    reveal: hover,
+                    text_alpha: ramp(hover, 0.35, 1.0),
+                    border_rgb: bar.color.accent_rgb(),
+                }
+            })
+        } else {
+            None
+        };
+
+        let items = [DrawItem {
+            bar,
+            geom,
+            alpha,
+            panel,
+        }];
         self.draw(view, width, height, &items)
+    }
+
+    /// Panel metrics in physical pixels at the current scale:
+    /// `(border, pad, font, line, gap)`.
+    fn panel_metrics(&self) -> (f32, f32, f32, f32, f32) {
+        let s = self.scale as f32;
+        (
+            panel::BORDER * s,
+            panel::PAD * s,
+            panel::FONT * s,
+            panel::LINE * s,
+            panel::GAP * s,
+        )
+    }
+
+    /// Physical-pixel size `(width, height)` of the description panel for
+    /// `description` at the current scale: width matches the bar, height fits the
+    /// wrapped, padded text. `None` for an empty description (no panel).
+    fn panel_size(&mut self, description: &str) -> Option<(f32, f32)> {
+        if description.trim().is_empty() {
+            return None;
+        }
+        let (border, pad, font_px, line_px, _gap) = self.panel_metrics();
+        let panel_w = BAR_W as f32 * self.scale as f32;
+        let text_w = (panel_w - 2.0 * (border + pad)).max(1.0);
+        let lines = self.measure_lines(description, text_w, font_px, line_px).max(1);
+        let panel_h = 2.0 * (border + pad) + lines as f32 * line_px;
+        Some((panel_w, panel_h))
+    }
+
+    /// Count the wrapped visual lines `description` shapes to at `text_w`. Drives
+    /// panel height, so it uses the same font, size, and wrap width as the draw.
+    fn measure_lines(&mut self, description: &str, text_w: f32, font_px: f32, line_px: f32) -> usize {
+        let mut buffer = Buffer::new(&mut self.font_system, Metrics::new(font_px, line_px));
+        buffer.set_size(&mut self.font_system, Some(text_w), None);
+        buffer.set_text(
+            &mut self.font_system,
+            description,
+            &Attrs::new().family(Family::Name(&self.font_family)),
+            Shaping::Advanced,
+            None,
+        );
+        buffer.shape_until_scroll(&mut self.font_system, false);
+        buffer.layout_runs().count()
+    }
+
+    /// Physical-pixel window size for `bar` with its hover panel open: the
+    /// collapsed bar window grown downward by the gap plus the panel. Returns the
+    /// collapsed size when the bar has no description. The overlay grows the
+    /// window to this on hover so the panel has room to unfold.
+    pub fn expanded_window_px(&mut self, bar: &BossBar) -> (u32, u32) {
+        let (cw, ch) = bar_window_px(self.scale, !bar.title.is_empty());
+        match self.panel_size(&bar.description) {
+            Some((panel_w, panel_h)) => {
+                let gap = panel::GAP * self.scale as f32;
+                (
+                    cw.max(panel_w.ceil() as u32),
+                    ch + (gap + panel_h).ceil() as u32,
+                )
+            }
+            None => (cw, ch),
+        }
     }
 }
 
@@ -705,6 +978,61 @@ fn upload_png(
     let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
     device.create_bind_group(&wgpu::BindGroupDescriptor {
         label: Some("bossbar.sprite.bind"),
+        layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(&view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::Sampler(sampler),
+            },
+        ],
+    })
+}
+
+/// Upload a 1x1 opaque-white sRGB texel with its own bind group. The panel quads
+/// sample it so the per-vertex color becomes a flat fill: white * color = color.
+fn upload_white_pixel(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    layout: &wgpu::BindGroupLayout,
+    sampler: &wgpu::Sampler,
+) -> wgpu::BindGroup {
+    let size = wgpu::Extent3d {
+        width: 1,
+        height: 1,
+        depth_or_array_layers: 1,
+    };
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("bossbar.solid.tex"),
+        size,
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8UnormSrgb,
+        usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+        view_formats: &[],
+    });
+    queue.write_texture(
+        wgpu::TexelCopyTextureInfo {
+            texture: &texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        &[0xff, 0xff, 0xff, 0xff],
+        wgpu::TexelCopyBufferLayout {
+            offset: 0,
+            bytes_per_row: Some(4),
+            rows_per_image: Some(1),
+        },
+        size,
+    );
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("bossbar.solid.bind"),
         layout,
         entries: &[
             wgpu::BindGroupEntry {

--- a/packages/bossbar-overlay/app/src/render.rs
+++ b/packages/bossbar-overlay/app/src/render.rs
@@ -410,10 +410,13 @@ impl Renderer {
                 title_px,
                 has_title,
             });
-            y = track_y + bar_h + bar_gap;
-            if let Some((_, panel_h)) = panel {
-                y += gap + panel_h + bar_gap;
-            }
+            // Advance past whatever this bar drew last: its panel bottom when it
+            // has one (sitting `gap` below the bar), otherwise the bar bottom.
+            let bottom = match panel {
+                Some((_, panel_h)) => track_y + bar_h + gap + panel_h,
+                None => track_y + bar_h,
+            };
+            y = bottom + bar_gap;
         }
         boxes
     }
@@ -744,7 +747,7 @@ impl Renderer {
             .zip(&sizes)
             .map(|((bar, geom), size)| {
                 let panel = size.map(|(panel_w, panel_h)| PanelBox {
-                    x: (width as f32 - panel_w) * 0.5,
+                    x: ((width as f32 - panel_w) * 0.5).max(0.0),
                     y: geom.track_y + geom.bar_h + gap,
                     w: panel_w,
                     h: panel_h,

--- a/packages/bossbar-overlay/app/src/sprite.wgsl
+++ b/packages/bossbar-overlay/app/src/sprite.wgsl
@@ -15,11 +15,11 @@ struct Globals {
 struct VsOut {
     @builtin(position) pos: vec4<f32>,
     @location(0) uv: vec2<f32>,
-    @location(1) alpha: f32,
+    @location(1) color: vec4<f32>,
 };
 
 @vertex
-fn vs(@location(0) px: vec2<f32>, @location(1) uv: vec2<f32>, @location(2) alpha: f32) -> VsOut {
+fn vs(@location(0) px: vec2<f32>, @location(1) uv: vec2<f32>, @location(2) color: vec4<f32>) -> VsOut {
     var out: VsOut;
     let ndc = vec2<f32>(
         px.x / globals.size.x * 2.0 - 1.0,
@@ -27,7 +27,7 @@ fn vs(@location(0) px: vec2<f32>, @location(1) uv: vec2<f32>, @location(2) alpha
     );
     out.pos = vec4<f32>(ndc, 0.0, 1.0);
     out.uv = uv;
-    out.alpha = alpha;
+    out.color = color;
     return out;
 }
 
@@ -37,6 +37,9 @@ fn fs(in: VsOut) -> @location(0) vec4<f32> {
     // Straight alpha out; the pipeline's ALPHA_BLENDING state composites it into
     // the premultiplied framebuffer, the same blend glyphon uses for text, so
     // sprites and titles layer consistently over the transparent desktop. The
-    // per-vertex alpha lets the hovered bar paint solid over the translucent rest.
-    return vec4<f32>(c.rgb, c.a * in.alpha);
+    // per-vertex color tints the sampled texel: sprites pass white (so they show
+    // unchanged, with the tint's alpha letting a hovered bar paint solid), while
+    // the description panel samples a 1x1 white texture so the tint *is* the
+    // flat fill or border color.
+    return vec4<f32>(c.rgb * in.color.rgb, c.a * in.color.a);
 }

--- a/packages/bossbar-overlay/bossbar
+++ b/packages/bossbar-overlay/bossbar
@@ -94,30 +94,34 @@ Examples:
 EOF
 }
 
-# Parse --flags into SET-style "col = value" assignments.
-# Echoes one assignment per line; validates enums and ranges.
+# Parse --flags into a single comma-joined SET clause ("a = 1, b = '...'").
+# Validates enums and ranges. Joined here rather than echoed one-per-line so a
+# value may itself contain newlines (a multi-paragraph --description) without the
+# caller splitting it apart; command substitution preserves interior newlines.
 parse_fields() {
-  local assigns=""
+  local clause="" sep="" assign
   while [ "$#" -gt 0 ]; do
     local flag="$1" val="${2:-}"
     [ "$#" -ge 2 ] || die "missing value for $flag"
     case "$flag" in
-      --title)       assigns+="title = '$(sq "$val")'"$'\n' ;;
-      --description) assigns+="description = '$(sq "$val")'"$'\n' ;;
-      --progress) assigns+="progress = $val"$'\n' ;;
-      --position) assigns+="position = $val"$'\n' ;;
-      --visible)  assigns+="visible = $val"$'\n' ;;
+      --title)       assign="title = '$(sq "$val")'" ;;
+      --description) assign="description = '$(sq "$val")'" ;;
+      --progress)    assign="progress = $val" ;;
+      --position)    assign="position = $val" ;;
+      --visible)     assign="visible = $val" ;;
       --color)
         in_list "$val" "$COLORS" || die "color must be one of: $COLORS"
-        assigns+="color = '$val'"$'\n' ;;
+        assign="color = '$val'" ;;
       --overlay)
         in_list "$val" "$OVERLAYS" || die "overlay must be one of: $OVERLAYS"
-        assigns+="overlay = '$val'"$'\n' ;;
+        assign="overlay = '$val'" ;;
       *) die "unknown flag: $flag" ;;
     esac
+    clause+="$sep$assign"
+    sep=", "
     shift 2
   done
-  printf '%s' "$assigns"
+  printf '%s' "$clause"
 }
 
 cmd="${1:-}"
@@ -128,9 +132,11 @@ case "$cmd" in
     [ "$#" -ge 1 ] || die "add needs a <title>"
     title="$1"; shift
     ensure_db
-    assigns="$(parse_fields "$@")"
     set_clause="title = '$(sq "$title")'"
-    while IFS= read -r line; do [ -n "$line" ] && set_clause+=", $line"; done <<< "$assigns"
+    extra="$(parse_fields "$@")"
+    if [ -n "$extra" ]; then
+      set_clause+=", $extra"
+    fi
     sqlite3 "$DB" "INSERT INTO bossbars DEFAULT VALUES;
                    UPDATE bossbars SET $set_clause WHERE id = last_insert_rowid();"
     ;;
@@ -139,13 +145,7 @@ case "$cmd" in
     sel="$(selector "$1")"; shift
     [ "$#" -ge 1 ] || die "set needs at least one field flag"
     ensure_db
-    assigns="$(parse_fields "$@")"
-    set_clause=""
-    while IFS= read -r line; do
-      [ -n "$line" ] || continue
-      [ -n "$set_clause" ] && set_clause+=", "
-      set_clause+="$line"
-    done <<< "$assigns"
+    set_clause="$(parse_fields "$@")"
     sqlite3 "$DB" "UPDATE bossbars SET $set_clause WHERE $sel;"
     ;;
   rm)

--- a/packages/bossbar-overlay/bossbar
+++ b/packages/bossbar-overlay/bossbar
@@ -25,14 +25,21 @@ DB="$(db_path)"
 ensure_db() {
   mkdir -p "$(dirname "$DB")"
   sqlite3 "$DB" "CREATE TABLE IF NOT EXISTS bossbars (
-    id        INTEGER PRIMARY KEY,
-    title     TEXT    NOT NULL DEFAULT '',
-    progress  REAL    NOT NULL DEFAULT 1.0,
-    color     TEXT    NOT NULL DEFAULT 'purple',
-    overlay   TEXT    NOT NULL DEFAULT 'progress',
-    visible   INTEGER NOT NULL DEFAULT 1,
-    position  INTEGER NOT NULL DEFAULT 0
+    id          INTEGER PRIMARY KEY,
+    title       TEXT    NOT NULL DEFAULT '',
+    description TEXT    NOT NULL DEFAULT '',
+    progress    REAL    NOT NULL DEFAULT 1.0,
+    color       TEXT    NOT NULL DEFAULT 'purple',
+    overlay     TEXT    NOT NULL DEFAULT 'progress',
+    visible     INTEGER NOT NULL DEFAULT 1,
+    position    INTEGER NOT NULL DEFAULT 0
   );"
+  # `description` shipped after the first schema; add it to a pre-existing table
+  # so `--description` works on a DB created by an older bossbar. SQLite has no
+  # ADD COLUMN IF NOT EXISTS, so guard on the column being absent.
+  if [ -z "$(sqlite3 "$DB" "SELECT 1 FROM pragma_table_info('bossbars') WHERE name = 'description' LIMIT 1;")" ]; then
+    sqlite3 "$DB" "ALTER TABLE bossbars ADD COLUMN description TEXT NOT NULL DEFAULT '';"
+  fi
 }
 
 die() {
@@ -64,20 +71,24 @@ usage() {
 bossbar - control the Minecraft boss bar overlay (SQLite-backed)
 
 Usage:
-  bossbar add <title> [--progress P] [--color C] [--overlay O] [--position N]
-  bossbar set <id|title> [--title T] [--progress P] [--color C]
+  bossbar add <title> [--description D] [--progress P] [--color C]
+                      [--overlay O] [--position N]
+  bossbar set <id|title> [--title T] [--description D] [--progress P] [--color C]
                          [--overlay O] [--position N] [--visible 0|1]
   bossbar rm <id|title>
   bossbar list
   bossbar clear
   bossbar db                 print the database path
 
+  D        longer text shown in a panel that unfolds below the bar on hover
+           (newlines start new paragraphs); pass '' to clear it
   P        fill fraction 0.0 .. 1.0
   C        pink | blue | red | green | yellow | purple | white
   O        progress | notched_6 | notched_10 | notched_12 | notched_20
 
 Examples:
-  bossbar add "Ender Dragon" --color pink --overlay notched_20
+  bossbar add "Ender Dragon" --color pink --overlay notched_20 \
+    --description "Destroy the End Crystals first or it heals to full."
   bossbar set "Ender Dragon" --progress 0.5
   bossbar rm "Ender Dragon"
 EOF
@@ -91,7 +102,8 @@ parse_fields() {
     local flag="$1" val="${2:-}"
     [ "$#" -ge 2 ] || die "missing value for $flag"
     case "$flag" in
-      --title)    assigns+="title = '$(sq "$val")'"$'\n' ;;
+      --title)       assigns+="title = '$(sq "$val")'"$'\n' ;;
+      --description) assigns+="description = '$(sq "$val")'"$'\n' ;;
       --progress) assigns+="progress = $val"$'\n' ;;
       --position) assigns+="position = $val"$'\n' ;;
       --visible)  assigns+="visible = $val"$'\n' ;;


### PR DESCRIPTION
Adds a per-bar `description` to the Minecraft boss bar overlay. When a bar has one, hovering unfolds a flat panel below it: the text wrapped to the bar's width in the Minecraft font, a one-pixel border tinted to the bar's color, and paragraph breaks preserved. A bar with an empty description behaves exactly as before.

The window grows to fit the panel only while hovered and shrinks back once the hover eases out, so the area below a bar stays click-through the rest of the time (two resizes per hover cycle, off the per-frame easing).

## What changed
- **db + CLI**: new `description TEXT NOT NULL DEFAULT ''` column, online-migrated for existing databases by both the Rust app and the `bossbar` shell wrapper; a `--description` flag on `add`/`set` (pass `''` to clear).
- **renderer**: per-vertex RGBA tint plus a 1×1 white texture so the existing sprite pipeline also draws the panel's flat fill and border; the panel is measured, laid out below the bar, and revealed by the hover amount. `--snapshot` now renders every described bar with its panel fully open, so you can proof-read wrapping without hovering.
- **overlay**: hover-driven window resize; collapsed back to bar-only size when not hovered to preserve the click-through invariant.

## Validation
- `nix build .#bossbar-overlay` (compiles and runs the crate's test suite, including a new legacy-DB migration plus description round-trip test).
- `--snapshot` of the seeded DB at scale 3 renders the panels correctly: per-color border, wrapped multi-paragraph text, and bars with no description draw unchanged.

## Known limitations
- An auto-stacked bar's open panel can overlap the bar stacked below it while hovering (drag bars apart to avoid).
- A panel on a bar pinned near the bottom of the screen unfolds off-screen.

Implemented with AI assistance (Claude, Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hover pop-down description panel to bossbar overlay
> - Each `BossBar` gains a `description` field (stored in SQLite with auto-migration) that displays as a panel unfolding beneath the bar on hover.
> - The overlay window resizes dynamically on hover: expands to fit the panel when hovered and collapses after hover easing ends, with at most one expand/collapse resize per hover cycle.
> - The renderer draws a bordered, flat-filled rectangle with wrapped, paragraph-preserving text that fades in slightly after the box begins revealing; the border is tinted by the bar's accent color.
> - The WGSL shader and vertex format are updated to carry a full RGBA tint color instead of a scalar alpha, enabling solid-color quads via a 1×1 white texture.
> - The `bossbar` CLI shell script gains `--description` support for `add` and `set` commands, handling multi-line values correctly, and migrates older databases on first run.
> - Snapshot renders show all panels fully open; `Renderer::layout` accounts for open panels so bars do not overlap them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5f681e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->