### PR TITLE
feat(macos-vm): off-screen macOS-guest screenshot via framebuffer IOSurface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,10 +599,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -1542,6 +1554,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "file-language"
 version = "0.1.0"
 
@@ -2310,6 +2331,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2876,8 +2910,12 @@ dependencies = [
  "block2",
  "clap",
  "dispatch2",
+ "image",
  "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
+ "objc2-io-surface",
+ "objc2-quartz-core",
  "objc2-virtualization",
  "snafu 0.8.9",
 ]
@@ -3022,6 +3060,16 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu 0.9.0",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -3390,6 +3438,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -3403,6 +3483,54 @@ dependencies = [
  "bitflags 2.11.1",
  "dispatch2",
  "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -3422,6 +3550,47 @@ dependencies = [
  "libc",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -3677,6 +3846,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3783,6 +3965,12 @@ dependencies = [
  "rustix 0.38.44",
  "tokio",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "pyo3"

--- a/packages/macos-vm/Cargo.toml
+++ b/packages/macos-vm/Cargo.toml
@@ -27,6 +27,14 @@ objc2-foundation = "0.3"
 objc2-virtualization = "0.3"
 block2 = "0.6"
 dispatch2 = "0.3"
+# macOS-guest boot + off-screen framebuffer screenshot. The guest frame is an
+# IOSurface in the VZVirtualMachineView's framebuffer subview's layer; we read
+# its BGRA bytes directly and encode PNG with the pure-Rust `image` crate (no
+# CoreImage, no window-server capture, no Screen-Recording permission).
+objc2-app-kit = "0.3"
+objc2-quartz-core = "0.3"
+objc2-io-surface = "0.3"
+image = { version = "0.25", default-features = false, features = ["png"] }
 
 [lints]
 workspace = true

--- a/packages/macos-vm/README.md
+++ b/packages/macos-vm/README.md
@@ -27,14 +27,43 @@ What works today:
 - `info` reports `VZVirtualMachine.isSupported`.
 - `boot-linux` boots a Linux guest and streams its console, then stops on a
   timeout.
+- `boot-macos` boots an installed macOS guest **fully off-screen** and
+  screenshots its display to PNGs, with no visible window, no
+  ScreenCaptureKit, and no Screen-Recording permission (see
+  [Off-screen capture](#off-screen-capture)). Validated end to end: captures the
+  macOS Setup Assistant from a guest whose window is parked at (-20000, -20000).
 
 What is designed but not yet built (see [Roadmap](#roadmap)):
 
-- graphics device + offscreen screenshot,
+- a Rust `install-macos` (today the bundle is produced by a reference Swift tool),
 - a vsock control channel and a long-lived `serve` mode,
 - booting an OCI image as a disk,
-- a macOS guest installer,
+- guest input injection + OCR to drive the guest headlessly (e.g. past Setup
+  Assistant) without the host cursor,
 - the `macvm` Python module bundled into ix-mcp.
+
+## Off-screen capture
+
+The guest framebuffer is an `IOSurface` living in the `VZVirtualMachineView`'s
+framebuffer subview's layer contents:
+
+```rust
+let surface = vm_view.subviews().firstObject()?.layer()?.contents(); // IOSurface
+```
+
+`boot-macos` reads that IOSurface's BGRA bytes directly and encodes a PNG with
+the pure-Rust [`image`](https://docs.rs/image) crate, entirely in-process. The
+view lives in an off-screen, non-activating window, so nothing appears on the
+host desktop and the cursor is never captured.
+
+This matters because the host-side capture paths do **not** work for a headless
+VM: the VZ display is a Metal-backed layer, so AppKit's `cacheDisplay` reads it
+black; ScreenCaptureKit needs a per-process Screen-Recording grant (a fresh
+helper gets `SCStreamError -3811`); and `screencapture -l <windowID>` cannot
+capture a fully off-screen window ("could not create image from window"). The
+IOSurface read sidesteps all of that. Technique from
+[thecrypticace/vzautomation](https://github.com/thecrypticace/vzautomation),
+which also shows keyboard injection and Vision OCR for driving the guest.
 
 ## Why a standalone signed binary
 
@@ -138,12 +167,17 @@ decision should be made deliberately, not by accretion.
 
 ## Roadmap
 
-1. Graphics device + offscreen screenshot (`screenshot` subcommand returning a
-   PNG).
-2. vsock control channel + long-lived `serve` mode for IPC.
-3. `macvm` Python module bundled into ix-mcp (like `tui`/`screen`): spawns this
+1. ~~Graphics device + off-screen screenshot.~~ Done: `boot-macos` (see
+   [Off-screen capture](#off-screen-capture)).
+2. Rust `install-macos` (`VZMacOSInstaller` from a local IPSW) so the package
+   creates its own guest bundle. Today a reference Swift tool does it; the
+   Apple restore catalog (gdmf) is fetched via mesu + the CDN because gdmf is
+   TLS-intercepted on some networks.
+3. Guest input injection + Vision OCR to drive the guest headlessly (past Setup
+   Assistant, then launch an app) without the host cursor.
+4. vsock control channel + long-lived `serve` mode for IPC.
+5. `macvm` Python module bundled into ix-mcp (like `tui`/`screen`): spawns this
    signed binary and exposes `boot`, `screenshot`, and input, returning PIL
    images that render inline.
-4. macOS guest installer (`VZMacOSInstaller` from an IPSW) for the bossbar test.
-5. OCI-disk boot for Linux guests; document the libkrun handoff for microVMs.
-6. Nix-integrated first-run entitlement signer in `default.nix`.
+6. OCI-disk boot for Linux guests; document the libkrun handoff for microVMs.
+7. Nix-integrated first-run entitlement signer in `default.nix`.

--- a/packages/macos-vm/src/macguest.rs
+++ b/packages/macos-vm/src/macguest.rs
@@ -20,10 +20,7 @@ use objc2_app_kit::{
     NSApplication, NSApplicationActivationPolicy, NSBackingStoreType, NSWindow, NSWindowStyleMask,
 };
 use objc2_foundation::{NSArray, NSData, NSError, NSPoint, NSRect, NSSize};
-use objc2_io_surface::{
-    IOSurfaceGetBaseAddress, IOSurfaceGetBytesPerRow, IOSurfaceGetHeight, IOSurfaceGetWidth,
-    IOSurfaceLock, IOSurfaceLockOptions, IOSurfaceRef, IOSurfaceUnlock,
-};
+use objc2_io_surface::{IOSurfaceLockOptions, IOSurfaceRef};
 
 /// kIOSurfaceLockReadOnly: read-only lock, no dirty tracking.
 const LOCK_READ_ONLY: IOSurfaceLockOptions = IOSurfaceLockOptions(1);
@@ -108,7 +105,7 @@ pub fn boot_macos_screenshot(boot: MacBootScreenshot) -> Result<(), Error> {
 
     // VZVirtualMachineView needs the AppKit run loop to build its layer tree and
     // receive guest frames; the capture thread exits the process when done.
-    unsafe { app.run() };
+    app.run();
     Ok(())
 }
 
@@ -153,9 +150,8 @@ fn schedule_captures(
 
 /// The guest framebuffer IOSurface object, if the view has started rendering.
 fn frame_surface(view: &VZVirtualMachineView) -> Option<Retained<AnyObject>> {
-    let subviews = unsafe { view.subviews() };
-    let first = subviews.firstObject()?;
-    let layer = unsafe { first.layer() }?;
+    let first = view.subviews().firstObject()?;
+    let layer = first.layer()?;
     unsafe { layer.contents() }
 }
 
@@ -166,11 +162,11 @@ fn capture(view: &VZVirtualMachineView, path: &Path) -> Result<usize, Error> {
     let surface: &IOSurfaceRef = unsafe { &*Retained::as_ptr(&contents).cast::<IOSurfaceRef>() };
 
     let (width, height, rgba) = unsafe {
-        let _ = IOSurfaceLock(surface, LOCK_READ_ONLY, std::ptr::null_mut());
-        let width = IOSurfaceGetWidth(surface);
-        let height = IOSurfaceGetHeight(surface);
-        let bytes_per_row = IOSurfaceGetBytesPerRow(surface);
-        let base = IOSurfaceGetBaseAddress(surface).as_ptr() as *const u8;
+        let _ = surface.lock(LOCK_READ_ONLY, std::ptr::null_mut());
+        let width = surface.width();
+        let height = surface.height();
+        let bytes_per_row = surface.bytes_per_row();
+        let base = surface.base_address().as_ptr() as *const u8;
 
         let mut rgba = vec![0u8; width * height * 4];
         for y in 0..height {
@@ -184,7 +180,7 @@ fn capture(view: &VZVirtualMachineView, path: &Path) -> Result<usize, Error> {
                 rgba[o + 3] = *p.add(3); // A
             }
         }
-        let _ = IOSurfaceUnlock(surface, LOCK_READ_ONLY, std::ptr::null_mut());
+        let _ = surface.unlock(LOCK_READ_ONLY, std::ptr::null_mut());
         (width, height, rgba)
     };
 

--- a/packages/macos-vm/src/macguest.rs
+++ b/packages/macos-vm/src/macguest.rs
@@ -21,6 +21,9 @@ use objc2_app_kit::{
 };
 use objc2_foundation::{NSArray, NSData, NSError, NSPoint, NSRect, NSSize};
 use objc2_io_surface::{IOSurfaceLockOptions, IOSurfaceRef};
+// Named explicitly so the dependency is a direct, visible use (the type is
+// otherwise only reachable through `NSView::layer()`'s return type).
+use objc2_quartz_core::CALayer;
 
 /// kIOSurfaceLockReadOnly: read-only lock, no dirty tracking.
 const LOCK_READ_ONLY: IOSurfaceLockOptions = IOSurfaceLockOptions(1);
@@ -151,7 +154,7 @@ fn schedule_captures(
 /// The guest framebuffer IOSurface object, if the view has started rendering.
 fn frame_surface(view: &VZVirtualMachineView) -> Option<Retained<AnyObject>> {
     let first = view.subviews().firstObject()?;
-    let layer = first.layer()?;
+    let layer: Retained<CALayer> = first.layer()?;
     unsafe { layer.contents() }
 }
 

--- a/packages/macos-vm/src/macguest.rs
+++ b/packages/macos-vm/src/macguest.rs
@@ -20,13 +20,10 @@ use objc2_app_kit::{
     NSApplication, NSApplicationActivationPolicy, NSBackingStoreType, NSWindow, NSWindowStyleMask,
 };
 use objc2_foundation::{NSArray, NSData, NSError, NSPoint, NSRect, NSSize};
-use objc2_io_surface::{IOSurfaceLockOptions, IOSurfaceRef};
+use objc2_io_surface::{IOSurface, IOSurfaceLockOptions, IOSurfaceRef};
 // Named explicitly so the dependency is a direct, visible use (the type is
 // otherwise only reachable through `NSView::layer()`'s return type).
 use objc2_quartz_core::CALayer;
-
-/// kIOSurfaceLockReadOnly: read-only lock, no dirty tracking.
-const LOCK_READ_ONLY: IOSurfaceLockOptions = IOSurfaceLockOptions(1);
 use objc2_virtualization::{
     VZBootLoader, VZDiskImageStorageDeviceAttachment, VZGraphicsDeviceConfiguration,
     VZKeyboardConfiguration, VZMacAuxiliaryStorage, VZMacGraphicsDeviceConfiguration,
@@ -41,17 +38,26 @@ use objc2_virtualization::{
 
 use crate::imp::{Error, file_url, ns_error_message};
 
+/// `kCVPixelFormatType_32BGRA` ('BGRA'): the layout the `IOSurface` read assumes.
+const PIXEL_FORMAT_BGRA: u32 = 0x4247_5241;
+
 /// Parameters for booting a macOS guest and screenshotting it.
 pub struct MacBootScreenshot {
     pub bundle: PathBuf,
     pub out_prefix: PathBuf,
-    pub seconds: f64,
+    pub seconds: u64,
 }
 
 pub fn boot_macos_screenshot(boot: MacBootScreenshot) -> Result<(), Error> {
+    let MacBootScreenshot {
+        bundle,
+        out_prefix,
+        seconds,
+    } = boot;
+
     let mtm = MainThreadMarker::new().ok_or(Error::NotMainThread)?;
 
-    let config = build_macos_config(&boot.bundle)?;
+    let config = build_macos_config(&bundle)?;
     if let Err(error) = unsafe { config.validateWithError() } {
         return Err(Error::InvalidConfiguration {
             message: ns_error_message(&error),
@@ -93,18 +99,19 @@ pub fn boot_macos_screenshot(boot: MacBootScreenshot) -> Result<(), Error> {
         }
     });
     // We hold a MainThreadMarker, so we are on the main thread (the VM's queue);
-    // start directly. dispatch_main below drains the queue so the completion
-    // handler fires. `vm` and `completion` live for the process because this
-    // function never returns (dispatch_main diverges), and `vm_view` retains the
-    // VM as well.
+    // start directly. `app.run()` below drives the main run loop, which services
+    // the main dispatch queue so the completion handler fires. `vm` and
+    // `completion` live for the process because this function never returns
+    // (app.run blocks until the capture thread exits the process); `vm_view`
+    // retains the VM as well.
     unsafe { vm.startWithCompletionHandler(&completion) };
 
-    // Capture loop on the main queue (AppKit objects must be touched there).
-    let seconds = boot.seconds;
-    let out_prefix = boot.out_prefix.clone();
-    let shots: Vec<f64> = vec![2.0, 18.0, 35.0, 55.0, seconds];
-    let view_for_caps = vm_view;
-    schedule_captures(view_for_caps, out_prefix, shots, seconds);
+    // Tick times for screenshots: the hardcoded ticks below the deadline, then
+    // the deadline itself, so a short `--seconds` stops on time and always takes
+    // a final shot.
+    let mut shots: Vec<u64> = [2, 18, 35, 55].into_iter().filter(|&t| t < seconds).collect();
+    shots.push(seconds);
+    schedule_captures(vm_view, out_prefix, shots);
 
     // VZVirtualMachineView needs the AppKit run loop to build its layer tree and
     // receive guest frames; the capture thread exits the process when done.
@@ -112,66 +119,82 @@ pub fn boot_macos_screenshot(boot: MacBootScreenshot) -> Result<(), Error> {
     Ok(())
 }
 
-/// Schedule screenshots on the main queue at increasing delays, then exit.
-fn schedule_captures(
-    view: Retained<VZVirtualMachineView>,
-    out_prefix: PathBuf,
-    shots: Vec<f64>,
-    deadline: f64,
-) {
-    // A background thread sleeps between shots and hops each capture onto the
-    // main queue (AppKit/IOSurface access must be on the main thread). The view
-    // is not Send, so we move only the raw pointer and re-borrow on the main
-    // queue, where it is valid.
+/// Sleep between ticks and hop each capture onto the main queue (AppKit/IOSurface
+/// access must be on the main thread), then exit the process.
+fn schedule_captures(view: Retained<VZVirtualMachineView>, out_prefix: PathBuf, shots: Vec<u64>) {
+    // The view is not `Send`, so move only the raw pointer and re-borrow on the
+    // main queue, where it is valid. The view is leaked (lives for the process)
+    // and also retained by the window, so the reborrow is never a use-after-free.
     let view_ptr = Retained::into_raw(view) as usize;
     std::thread::spawn(move || {
-        let mut elapsed = 0.0;
+        let mut elapsed = 0u64;
         for t in shots {
             if t > elapsed {
-                std::thread::sleep(Duration::from_secs_f64(t - elapsed));
+                std::thread::sleep(Duration::from_secs(t - elapsed));
                 elapsed = t;
             }
-            let path = out_prefix.with_extension(format!("{:03}.png", t as u64));
+            let path = out_prefix.with_extension(format!("{t:03}.png"));
             let p = path.clone();
             DispatchQueue::main().exec_sync(move || {
-                // Safety: the view lives for the process lifetime (leaked above)
-                // and we only touch it on the main queue.
-                let view: &VZVirtualMachineView = unsafe { &*(view_ptr as *const VZVirtualMachineView) };
+                // Safety: the view lives for the process (leaked above) and we
+                // only touch it on the main queue.
+                let view: &VZVirtualMachineView =
+                    unsafe { &*(view_ptr as *const VZVirtualMachineView) };
                 match capture(view, &p) {
                     Ok(bytes) => eprintln!("macos-vm: wrote {bytes} bytes -> {}", p.display()),
                     Err(error) => eprintln!("macos-vm: capture: {error}"),
                 }
             });
-            if elapsed >= deadline {
-                break;
-            }
         }
         eprintln!("macos-vm: done");
         std::process::exit(0);
     });
 }
 
-/// The guest framebuffer IOSurface object, if the view has started rendering.
-fn frame_surface(view: &VZVirtualMachineView) -> Option<Retained<AnyObject>> {
+/// The guest framebuffer object (an `IOSurface`), if the view has started
+/// rendering. Returns the raw layer contents; the caller verifies the type.
+fn frame_contents(view: &VZVirtualMachineView) -> Option<Retained<AnyObject>> {
     let first = view.subviews().firstObject()?;
     let layer: Retained<CALayer> = first.layer()?;
     unsafe { layer.contents() }
 }
 
-/// Read the IOSurface bytes (BGRA) and encode a PNG.
+/// Read the framebuffer `IOSurface` (BGRA) and encode a PNG.
 fn capture(view: &VZVirtualMachineView, path: &Path) -> Result<usize, Error> {
-    let contents = frame_surface(view).ok_or(Error::NoFramebuffer)?;
-    // The layer contents is an IOSurface, toll-free bridged to IOSurfaceRef.
-    let surface: &IOSurfaceRef = unsafe { &*Retained::as_ptr(&contents).cast::<IOSurfaceRef>() };
+    let contents = frame_contents(view).ok_or(Error::NoFramebuffer)?;
+    // Verify the layer contents really is an IOSurface before any unsafe access.
+    let surface_obj: Retained<IOSurface> =
+        contents.downcast::<IOSurface>().map_err(|_| Error::NoFramebuffer)?;
+    // `IOSurface` (objc) is toll-free bridged to `IOSurfaceRef` (CF), which
+    // carries the data accessors.
+    let surface: &IOSurfaceRef =
+        unsafe { &*Retained::as_ptr(&surface_obj).cast::<IOSurfaceRef>() };
 
-    let (width, height, rgba) = unsafe {
-        let _ = surface.lock(LOCK_READ_ONLY, std::ptr::null_mut());
-        let width = surface.width();
-        let height = surface.height();
+    let width = surface.width();
+    let height = surface.height();
+    // Only the single-plane 32-bit BGRA layout is handled; reject anything else
+    // rather than read past the mapping or produce garbage.
+    if surface.plane_count() > 1
+        || surface.bytes_per_element() != 4
+        || surface.pixel_format() != PIXEL_FORMAT_BGRA
+    {
+        return Err(Error::CaptureEncode {
+            message: format!(
+                "unexpected IOSurface layout: planes={} bpe={} format={:#x}",
+                surface.plane_count(),
+                surface.bytes_per_element(),
+                surface.pixel_format()
+            ),
+        });
+    }
+
+    // Allocate before locking so an allocation failure cannot leak the lock; the
+    // locked region below does only an in-bounds memcpy (no panics, no `?`).
+    let mut rgba = vec![0u8; width * height * 4];
+    unsafe {
+        let _ = surface.lock(IOSurfaceLockOptions::ReadOnly, std::ptr::null_mut());
         let bytes_per_row = surface.bytes_per_row();
         let base = surface.base_address().as_ptr() as *const u8;
-
-        let mut rgba = vec![0u8; width * height * 4];
         for y in 0..height {
             let row = base.add(y * bytes_per_row);
             for x in 0..width {
@@ -183,16 +206,17 @@ fn capture(view: &VZVirtualMachineView, path: &Path) -> Result<usize, Error> {
                 rgba[o + 3] = *p.add(3); // A
             }
         }
-        let _ = surface.unlock(LOCK_READ_ONLY, std::ptr::null_mut());
-        (width, height, rgba)
-    };
+        let _ = surface.unlock(IOSurfaceLockOptions::ReadOnly, std::ptr::null_mut());
+    }
 
+    let w = u32::try_from(width).map_err(|_| Error::CaptureEncode { message: "width too large".into() })?;
+    let h = u32::try_from(height).map_err(|_| Error::CaptureEncode { message: "height too large".into() })?;
     let mut buf = std::io::Cursor::new(Vec::new());
     image::ImageEncoder::write_image(
         image::codecs::png::PngEncoder::new(&mut buf),
         &rgba,
-        width as u32,
-        height as u32,
+        w,
+        h,
         image::ExtendedColorType::Rgba8,
     )
     .map_err(|e| Error::CaptureEncode { message: e.to_string() })?;
@@ -213,14 +237,14 @@ fn build_macos_config(bundle: &Path) -> Result<Retained<VZVirtualMachineConfigur
             &NSData::with_bytes(&hw_data),
         )
     }
-    .ok_or(Error::Bundle { message: "invalid hardware model".into() })?;
+    .ok_or_else(|| Error::Bundle { message: "invalid hardware model".into() })?;
     let machine_id = unsafe {
         VZMacMachineIdentifier::initWithDataRepresentation(
             VZMacMachineIdentifier::alloc(),
             &NSData::with_bytes(&id_data),
         )
     }
-    .ok_or(Error::Bundle { message: "invalid machine id".into() })?;
+    .ok_or_else(|| Error::Bundle { message: "invalid machine id".into() })?;
 
     let aux_url = file_url(&bundle.join("aux.img"));
     let aux = unsafe { VZMacAuxiliaryStorage::initWithURL(VZMacAuxiliaryStorage::alloc(), &aux_url) };

--- a/packages/macos-vm/src/macguest.rs
+++ b/packages/macos-vm/src/macguest.rs
@@ -1,0 +1,292 @@
+//! macOS guest support: boot an installed macOS guest fully off-screen and
+//! screenshot its display with no window and no Screen-Recording permission.
+//!
+//! The guest framebuffer is an `IOSurface` living in the
+//! `VZVirtualMachineView`'s framebuffer subview's layer contents. We read its
+//! BGRA bytes directly and encode PNG with the pure-Rust `image` crate, entirely
+//! in-process. The view lives in an off-screen, non-activating window, so the
+//! host desktop and cursor are never touched. Technique from
+//! github.com/thecrypticace/vzautomation.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use block2::RcBlock;
+use dispatch2::DispatchQueue;
+use objc2::rc::Retained;
+use objc2::runtime::AnyObject;
+use objc2::{AllocAnyThread, MainThreadMarker};
+use objc2_app_kit::{
+    NSApplication, NSApplicationActivationPolicy, NSBackingStoreType, NSWindow, NSWindowStyleMask,
+};
+use objc2_foundation::{NSArray, NSData, NSError, NSPoint, NSRect, NSSize};
+use objc2_io_surface::{
+    IOSurfaceGetBaseAddress, IOSurfaceGetBytesPerRow, IOSurfaceGetHeight, IOSurfaceGetWidth,
+    IOSurfaceLock, IOSurfaceLockOptions, IOSurfaceRef, IOSurfaceUnlock,
+};
+
+/// kIOSurfaceLockReadOnly: read-only lock, no dirty tracking.
+const LOCK_READ_ONLY: IOSurfaceLockOptions = IOSurfaceLockOptions(1);
+use objc2_virtualization::{
+    VZBootLoader, VZDiskImageStorageDeviceAttachment, VZGraphicsDeviceConfiguration,
+    VZKeyboardConfiguration, VZMacAuxiliaryStorage, VZMacGraphicsDeviceConfiguration,
+    VZMacGraphicsDisplayConfiguration, VZMacHardwareModel, VZMacMachineIdentifier,
+    VZMacOSBootLoader, VZMacPlatformConfiguration, VZNATNetworkDeviceAttachment,
+    VZNetworkDeviceConfiguration, VZPlatformConfiguration, VZPointingDeviceConfiguration,
+    VZStorageDeviceConfiguration, VZUSBKeyboardConfiguration,
+    VZUSBScreenCoordinatePointingDeviceConfiguration, VZVirtioBlockDeviceConfiguration,
+    VZVirtioNetworkDeviceConfiguration, VZVirtualMachine, VZVirtualMachineConfiguration,
+    VZVirtualMachineView,
+};
+
+use crate::imp::{Error, file_url, ns_error_message};
+
+/// Parameters for booting a macOS guest and screenshotting it.
+pub struct MacBootScreenshot {
+    pub bundle: PathBuf,
+    pub out_prefix: PathBuf,
+    pub seconds: f64,
+}
+
+pub fn boot_macos_screenshot(boot: MacBootScreenshot) -> Result<(), Error> {
+    let mtm = MainThreadMarker::new().ok_or(Error::NotMainThread)?;
+
+    let config = build_macos_config(&boot.bundle)?;
+    if let Err(error) = unsafe { config.validateWithError() } {
+        return Err(Error::InvalidConfiguration {
+            message: ns_error_message(&error),
+        });
+    }
+
+    let app = NSApplication::sharedApplication(mtm);
+    app.setActivationPolicy(NSApplicationActivationPolicy::Prohibited);
+
+    let vm = unsafe { VZVirtualMachine::initWithConfiguration(VZVirtualMachine::alloc(), &config) };
+
+    // Off-screen, borderless window. Never visible; the host cursor is never
+    // captured. We read the guest IOSurface, not the on-screen composite, so an
+    // off-screen window is fine.
+    let frame = NSRect::new(NSPoint::new(-20000.0, -20000.0), NSSize::new(1920.0, 1080.0));
+    let window = unsafe {
+        NSWindow::initWithContentRect_styleMask_backing_defer(
+            mtm.alloc(),
+            frame,
+            NSWindowStyleMask::Borderless,
+            NSBackingStoreType::Buffered,
+            false,
+        )
+    };
+    unsafe { window.setReleasedWhenClosed(false) };
+    let view_frame = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1920.0, 1080.0));
+    let vm_view = unsafe { VZVirtualMachineView::initWithFrame(mtm.alloc(), view_frame) };
+    unsafe { vm_view.setVirtualMachine(Some(&vm)) };
+    window.setContentView(Some(&vm_view));
+    window.orderFrontRegardless();
+
+    let completion = RcBlock::new(|error: *mut NSError| {
+        if error.is_null() {
+            eprintln!("macos-vm: guest started");
+        } else {
+            let error = unsafe { &*error };
+            eprintln!("macos-vm: guest failed to start: {}", ns_error_message(error));
+            std::process::exit(1);
+        }
+    });
+    // We hold a MainThreadMarker, so we are on the main thread (the VM's queue);
+    // start directly. dispatch_main below drains the queue so the completion
+    // handler fires. `vm` and `completion` live for the process because this
+    // function never returns (dispatch_main diverges), and `vm_view` retains the
+    // VM as well.
+    unsafe { vm.startWithCompletionHandler(&completion) };
+
+    // Capture loop on the main queue (AppKit objects must be touched there).
+    let seconds = boot.seconds;
+    let out_prefix = boot.out_prefix.clone();
+    let shots: Vec<f64> = vec![2.0, 18.0, 35.0, 55.0, seconds];
+    let view_for_caps = vm_view;
+    schedule_captures(view_for_caps, out_prefix, shots, seconds);
+
+    // VZVirtualMachineView needs the AppKit run loop to build its layer tree and
+    // receive guest frames; the capture thread exits the process when done.
+    unsafe { app.run() };
+    Ok(())
+}
+
+/// Schedule screenshots on the main queue at increasing delays, then exit.
+fn schedule_captures(
+    view: Retained<VZVirtualMachineView>,
+    out_prefix: PathBuf,
+    shots: Vec<f64>,
+    deadline: f64,
+) {
+    // A background thread sleeps between shots and hops each capture onto the
+    // main queue (AppKit/IOSurface access must be on the main thread). The view
+    // is not Send, so we move only the raw pointer and re-borrow on the main
+    // queue, where it is valid.
+    let view_ptr = Retained::into_raw(view) as usize;
+    std::thread::spawn(move || {
+        let mut elapsed = 0.0;
+        for t in shots {
+            if t > elapsed {
+                std::thread::sleep(Duration::from_secs_f64(t - elapsed));
+                elapsed = t;
+            }
+            let path = out_prefix.with_extension(format!("{:03}.png", t as u64));
+            let p = path.clone();
+            DispatchQueue::main().exec_sync(move || {
+                // Safety: the view lives for the process lifetime (leaked above)
+                // and we only touch it on the main queue.
+                let view: &VZVirtualMachineView = unsafe { &*(view_ptr as *const VZVirtualMachineView) };
+                match capture(view, &p) {
+                    Ok(bytes) => eprintln!("macos-vm: wrote {bytes} bytes -> {}", p.display()),
+                    Err(error) => eprintln!("macos-vm: capture: {error}"),
+                }
+            });
+            if elapsed >= deadline {
+                break;
+            }
+        }
+        eprintln!("macos-vm: done");
+        std::process::exit(0);
+    });
+}
+
+/// The guest framebuffer IOSurface object, if the view has started rendering.
+fn frame_surface(view: &VZVirtualMachineView) -> Option<Retained<AnyObject>> {
+    let subviews = unsafe { view.subviews() };
+    let first = subviews.firstObject()?;
+    let layer = unsafe { first.layer() }?;
+    unsafe { layer.contents() }
+}
+
+/// Read the IOSurface bytes (BGRA) and encode a PNG.
+fn capture(view: &VZVirtualMachineView, path: &Path) -> Result<usize, Error> {
+    let contents = frame_surface(view).ok_or(Error::NoFramebuffer)?;
+    // The layer contents is an IOSurface, toll-free bridged to IOSurfaceRef.
+    let surface: &IOSurfaceRef = unsafe { &*Retained::as_ptr(&contents).cast::<IOSurfaceRef>() };
+
+    let (width, height, rgba) = unsafe {
+        let _ = IOSurfaceLock(surface, LOCK_READ_ONLY, std::ptr::null_mut());
+        let width = IOSurfaceGetWidth(surface);
+        let height = IOSurfaceGetHeight(surface);
+        let bytes_per_row = IOSurfaceGetBytesPerRow(surface);
+        let base = IOSurfaceGetBaseAddress(surface).as_ptr() as *const u8;
+
+        let mut rgba = vec![0u8; width * height * 4];
+        for y in 0..height {
+            let row = base.add(y * bytes_per_row);
+            for x in 0..width {
+                let p = row.add(x * 4);
+                let o = (y * width + x) * 4;
+                rgba[o] = *p.add(2); // R <- BGRA.R
+                rgba[o + 1] = *p.add(1); // G
+                rgba[o + 2] = *p; // B
+                rgba[o + 3] = *p.add(3); // A
+            }
+        }
+        let _ = IOSurfaceUnlock(surface, LOCK_READ_ONLY, std::ptr::null_mut());
+        (width, height, rgba)
+    };
+
+    let mut buf = std::io::Cursor::new(Vec::new());
+    image::ImageEncoder::write_image(
+        image::codecs::png::PngEncoder::new(&mut buf),
+        &rgba,
+        width as u32,
+        height as u32,
+        image::ExtendedColorType::Rgba8,
+    )
+    .map_err(|e| Error::CaptureEncode { message: e.to_string() })?;
+    let png = buf.into_inner();
+    std::fs::write(path, &png).map_err(|e| Error::CaptureEncode { message: e.to_string() })?;
+    Ok(png.len())
+}
+
+fn build_macos_config(bundle: &Path) -> Result<Retained<VZVirtualMachineConfiguration>, Error> {
+    let hw_data = std::fs::read(bundle.join("hardware-model.bin"))
+        .map_err(|e| Error::Bundle { message: format!("hardware-model.bin: {e}") })?;
+    let id_data = std::fs::read(bundle.join("machine-id.bin"))
+        .map_err(|e| Error::Bundle { message: format!("machine-id.bin: {e}") })?;
+
+    let hw = unsafe {
+        VZMacHardwareModel::initWithDataRepresentation(
+            VZMacHardwareModel::alloc(),
+            &NSData::with_bytes(&hw_data),
+        )
+    }
+    .ok_or(Error::Bundle { message: "invalid hardware model".into() })?;
+    let machine_id = unsafe {
+        VZMacMachineIdentifier::initWithDataRepresentation(
+            VZMacMachineIdentifier::alloc(),
+            &NSData::with_bytes(&id_data),
+        )
+    }
+    .ok_or(Error::Bundle { message: "invalid machine id".into() })?;
+
+    let aux_url = file_url(&bundle.join("aux.img"));
+    let aux = unsafe { VZMacAuxiliaryStorage::initWithURL(VZMacAuxiliaryStorage::alloc(), &aux_url) };
+
+    let platform = unsafe { VZMacPlatformConfiguration::new() };
+    unsafe {
+        platform.setHardwareModel(&hw);
+        platform.setMachineIdentifier(&machine_id);
+        platform.setAuxiliaryStorage(Some(&aux));
+    }
+
+    let boot_loader = unsafe { VZMacOSBootLoader::new() };
+
+    let display = unsafe {
+        VZMacGraphicsDisplayConfiguration::initWithWidthInPixels_heightInPixels_pixelsPerInch(
+            VZMacGraphicsDisplayConfiguration::alloc(),
+            1920,
+            1080,
+            144,
+        )
+    };
+    let gfx = unsafe { VZMacGraphicsDeviceConfiguration::new() };
+    unsafe { gfx.setDisplays(&NSArray::from_slice(&[&*display])) };
+
+    let disk_url = file_url(&bundle.join("disk.img"));
+    let disk_attach = unsafe {
+        VZDiskImageStorageDeviceAttachment::initWithURL_readOnly_error(
+            VZDiskImageStorageDeviceAttachment::alloc(),
+            &disk_url,
+            false,
+        )
+    }
+    .map_err(|e| Error::Bundle { message: ns_error_message(&e) })?;
+    let block = unsafe {
+        VZVirtioBlockDeviceConfiguration::initWithAttachment(
+            VZVirtioBlockDeviceConfiguration::alloc(),
+            &disk_attach,
+        )
+    };
+
+    let net = unsafe { VZVirtioNetworkDeviceConfiguration::new() };
+    let nat = unsafe { VZNATNetworkDeviceAttachment::new() };
+    unsafe { net.setAttachment(Some(&nat)) };
+
+    let keyboard = unsafe { VZUSBKeyboardConfiguration::new() };
+    let pointing = unsafe { VZUSBScreenCoordinatePointingDeviceConfiguration::new() };
+
+    let config = unsafe { VZVirtualMachineConfiguration::new() };
+    let platform_ref: &VZPlatformConfiguration = &platform;
+    let boot_ref: &VZBootLoader = &boot_loader;
+    let gfx_ref: &VZGraphicsDeviceConfiguration = &gfx;
+    let block_ref: &VZStorageDeviceConfiguration = &block;
+    let net_ref: &VZNetworkDeviceConfiguration = &net;
+    let kbd_ref: &VZKeyboardConfiguration = &keyboard;
+    let pt_ref: &VZPointingDeviceConfiguration = &pointing;
+    unsafe {
+        config.setPlatform(platform_ref);
+        config.setBootLoader(Some(boot_ref));
+        config.setCPUCount(4);
+        config.setMemorySize(8 * 1024 * 1024 * 1024);
+        config.setGraphicsDevices(&NSArray::from_slice(&[gfx_ref]));
+        config.setStorageDevices(&NSArray::from_slice(&[block_ref]));
+        config.setNetworkDevices(&NSArray::from_slice(&[net_ref]));
+        config.setKeyboards(&NSArray::from_slice(&[kbd_ref]));
+        config.setPointingDevices(&NSArray::from_slice(&[pt_ref]));
+    }
+    Ok(config)
+}

--- a/packages/macos-vm/src/main.rs
+++ b/packages/macos-vm/src/main.rs
@@ -67,7 +67,7 @@ enum Command {
         timeout_secs: u64,
     },
     /// Boot an installed macOS guest fully off-screen and screenshot its display
-    /// to `<out-prefix>.NNN.png` via the framebuffer IOSurface (no window, no
+    /// to `<out-prefix>.NNN.png` via the framebuffer `IOSurface` (no window, no
     /// Screen-Recording permission). The bundle is a directory with
     /// `disk.img`, `aux.img`, `hardware-model.bin`, `machine-id.bin`.
     BootMacos {
@@ -194,7 +194,7 @@ mod imp {
             } => crate::macguest::boot_macos_screenshot(crate::macguest::MacBootScreenshot {
                 bundle,
                 out_prefix,
-                seconds: seconds as f64,
+                seconds,
             }),
         }
     }

--- a/packages/macos-vm/src/main.rs
+++ b/packages/macos-vm/src/main.rs
@@ -66,6 +66,21 @@ enum Command {
         #[arg(long, default_value_t = 20)]
         timeout_secs: u64,
     },
+    /// Boot an installed macOS guest fully off-screen and screenshot its display
+    /// to `<out-prefix>.NNN.png` via the framebuffer IOSurface (no window, no
+    /// Screen-Recording permission). The bundle is a directory with
+    /// `disk.img`, `aux.img`, `hardware-model.bin`, `machine-id.bin`.
+    BootMacos {
+        /// Guest bundle directory.
+        #[arg(long)]
+        bundle: std::path::PathBuf,
+        /// Output path prefix for screenshots.
+        #[arg(long)]
+        out_prefix: std::path::PathBuf,
+        /// Stop after this many seconds.
+        #[arg(long, default_value_t = 90)]
+        seconds: u64,
+    },
 }
 
 #[cfg(target_os = "macos")]
@@ -85,6 +100,9 @@ fn main() -> ExitCode {
     eprintln!("macos-vm: requires macOS and Apple's Virtualization.framework");
     ExitCode::FAILURE
 }
+
+#[cfg(target_os = "macos")]
+mod macguest;
 
 #[cfg(target_os = "macos")]
 mod imp {
@@ -129,6 +147,14 @@ mod imp {
              fails configuration validation)"
         ))]
         InvalidConfiguration { message: String },
+        #[snafu(display("must run on the main thread"))]
+        NotMainThread,
+        #[snafu(display("guest framebuffer not available yet"))]
+        NoFramebuffer,
+        #[snafu(display("invalid guest bundle: {message}"))]
+        Bundle { message: String },
+        #[snafu(display("screenshot encode/write failed: {message}"))]
+        CaptureEncode { message: String },
     }
 
     /// Parameters for a Linux guest boot. A named struct rather than a wide
@@ -160,6 +186,15 @@ mod imp {
                 memory_mib,
                 cmdline,
                 timeout: Duration::from_secs(timeout_secs),
+            }),
+            Command::BootMacos {
+                bundle,
+                out_prefix,
+                seconds,
+            } => crate::macguest::boot_macos_screenshot(crate::macguest::MacBootScreenshot {
+                bundle,
+                out_prefix,
+                seconds: seconds as f64,
             }),
         }
     }
@@ -282,12 +317,12 @@ mod imp {
         Ok(config)
     }
 
-    fn file_url(path: &std::path::Path) -> Retained<NSURL> {
+    pub fn file_url(path: &std::path::Path) -> Retained<NSURL> {
         let s = NSString::from_str(&path.to_string_lossy());
         NSURL::fileURLWithPath(&s)
     }
 
-    fn ns_error_message(error: &NSError) -> String {
+    pub fn ns_error_message(error: &NSError) -> String {
         error.localizedDescription().to_string()
     }
 }


### PR DESCRIPTION
## What

Adds `macos-vm boot-macos`: boots an installed macOS guest **fully off-screen** and screenshots its display to PNGs — no visible window, no ScreenCaptureKit, no Screen-Recording permission, host cursor untouched.

## How (the idiomatic off-screen capture)

The guest framebuffer is an `IOSurface` in the `VZVirtualMachineView`'s framebuffer subview's layer contents. `boot-macos` reads its BGRA bytes directly and encodes PNG with the pure-Rust `image` crate, entirely in-process. The view lives in an off-screen, non-activating window.

Host-side capture does not work for a headless VM, which is why this approach is needed:
- the VZ display is a Metal-backed layer, so AppKit `cacheDisplay` reads it black;
- ScreenCaptureKit needs a per-process Screen-Recording grant (a fresh helper gets `SCStreamError -3811`);
- `screencapture -l <windowID>` cannot capture a fully off-screen window.

Technique from [thecrypticace/vzautomation](https://github.com/thecrypticace/vzautomation).

## Validation

- ✅ Builds via `nix build .#macos-vm`.
- ✅ End to end on macOS 26.5 / Apple M5 Max: signed binary boots a macOS guest with its window parked at (-20000, -20000) and captures the Setup Assistant ("Hej / Fortsätt") to PNG via the IOSurface read. No window on the host, cursor untouched.
- objc2 (app-kit, quartz-core, io-surface) and `image` are macOS-gated, so the Linux workspace graph stays zero-dependency (the off-platform stub is unchanged).

## Notes / follow-ups (in README roadmap)

- The guest bundle is currently produced by a reference Swift installer; a Rust `install-macos` (`VZMacOSInstaller` from a local IPSW, since gdmf is TLS-intercepted on some networks) is the next step.
- Known darwin-only `unused_unsafe` warnings to tidy (not CI-gated; clippy runs Linux-only on the cfg'd-out stub).
- Guest input injection + OCR to drive the guest headlessly (past Setup Assistant) is tracked for the literal bossbar test.

---
_Authored by Claude (Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add off-screen macOS guest boot and framebuffer screenshot via IOSurface
> - Adds a new `boot-macos` CLI subcommand (in [main.rs](https://github.com/indexable-inc/index/pull/428/files#diff-b672fe3e1d10462de4efa7a75a630206a1942f074e401e2d13f411ecb6e3c47c)) that boots a macOS VM headlessly and saves timed PNG screenshots from the guest framebuffer.
> - Implements [macguest.rs](https://github.com/indexable-inc/index/pull/428/files#diff-bf375e8c838424f343aea16a54b5727288a85d2fc009d75e928c51a796933b94) with the full pipeline: builds a `VZVirtualMachineConfiguration` from a bundle directory (disk.img, aux.img, hardware-model.bin, machine-id.bin), creates an off-screen NSWindow with a `VZVirtualMachineView`, and starts the AppKit run loop.
> - Screenshots are taken by reading the IOSurface backing the view's CALayer, converting BGRA pixels to RGBA, and encoding to PNG via the `image` crate — no Screen Recording permission required.
> - Captures are scheduled at fixed intervals (2s, 18s, 35s, 55s, and the configured deadline, default 90s); the process exits after the final capture.
> - Risk: IOSurface access depends on the VM having begun rendering; captures before the framebuffer is populated return a `NoFramebuffer` error rather than a blank image.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f81394.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->