### PR TITLE
feat(bossbar): live self-ticking elapsed timer in the title

### DIFF
--- a/packages/bossbar-overlay/README.md
+++ b/packages/bossbar-overlay/README.md
@@ -52,6 +52,11 @@ while you hover, so the area below a bar stays click-through the rest of the
 time; a bar with an empty description behaves exactly as before. See the
 seeded Ender Dragon bar for an example.
 
+A bar can also carry a `since` (Unix epoch). When set, the overlay appends a
+live elapsed timer to the title (`Build (2:05)`) and ticks it once a second on
+its own, so you write the start time once instead of rewriting the title to
+advance a clock. The seeded "Build: compiling" bar shows this.
+
 Known limitations: some Linux tiling window managers force-place or tile
 borderless windows, which can fight the free-drag placement. An auto-stacked
 bar's open panel can overlap the bar stacked below it while you hover; pin bars
@@ -109,7 +114,8 @@ CREATE TABLE bossbars (
   visible     INTEGER NOT NULL DEFAULT 1,    -- 0 hides the row
   position    INTEGER NOT NULL DEFAULT 0,    -- sort order in the auto column
   x           REAL,                          -- pinned location (logical points)
-  y           REAL                           -- NULL/NULL = auto-stacked
+  y           REAL,                          -- NULL/NULL = auto-stacked
+  since       INTEGER                        -- Unix epoch; live elapsed timer in the title
 );
 ```
 
@@ -120,6 +126,10 @@ CREATE TABLE bossbars (
 - **description**: longer text shown in the panel that unfolds below the bar on
   hover. Empty (the default) means no panel. Lines wrap to the bar's width;
   newlines start new paragraphs.
+- **since**: a Unix epoch (seconds) to count up from. When set, the overlay
+  appends a live elapsed timer to the title (`Build (2:05)`) and ticks it once a
+  second, so you write the start once instead of rewriting the title to advance a
+  clock. `NULL` or a non-positive value means no timer.
 - **x / y**: pinned screen location in logical points, written when you drag a
   bar. Leave both `NULL` (the default) to keep the bar in the auto-stacked
   top-center column ordered by `position`; setting them floats the bar free.

--- a/packages/bossbar-overlay/app/src/bars.rs
+++ b/packages/bossbar-overlay/app/src/bars.rs
@@ -101,6 +101,12 @@ pub struct BossBar {
     /// Empty means the bar has no pop-down and behaves exactly as it did before.
     /// Newlines separate paragraphs; the panel wraps long lines to its width.
     pub description: String,
+    /// Unix epoch (seconds) the bar started counting from. When set, the overlay
+    /// appends a live, self-ticking elapsed time to the title (e.g. "2:05") and
+    /// redraws once a second, so a caller writes the start once instead of
+    /// rewriting the title to advance a clock. `None` (or a non-positive value in
+    /// the DB) means no counter.
+    pub since: Option<i64>,
     /// Fill fraction, always clamped to `0.0..=1.0` at construction.
     pub progress: f32,
     pub color: Color,

--- a/packages/bossbar-overlay/app/src/db.rs
+++ b/packages/bossbar-overlay/app/src/db.rs
@@ -30,7 +30,8 @@ CREATE TABLE IF NOT EXISTS bossbars (
   visible     INTEGER NOT NULL DEFAULT 1,
   position    INTEGER NOT NULL DEFAULT 0,
   x           REAL,
-  y           REAL
+  y           REAL,
+  since       INTEGER
 );";
 
 /// Columns added after the initial schema shipped. `ALTER TABLE ADD COLUMN` is
@@ -41,16 +42,18 @@ const ADDED_COLUMNS: &[(&str, &str)] = &[
     ("x", "REAL"),
     ("y", "REAL"),
     ("description", "TEXT NOT NULL DEFAULT ''"),
+    ("since", "INTEGER"),
 ];
 
 /// Rows inserted only when the DB file is created for the first time, so a
 /// brand-new install shows something and documents the contract by example. The
-/// third bar carries a multi-paragraph description to show off the hover panel.
+/// third bar carries a multi-paragraph description (the hover panel) and a
+/// `since` of now, so its title shows a live elapsed counter from first launch.
 const SEED: &str = "\
-INSERT INTO bossbars (title, description, progress, color, overlay, position) VALUES
-  ('Ender Dragon', 'The final boss of the End. Destroy all the End Crystals on the obsidian pillars first, or it heals back to full.', 0.82, 'pink', 'notched_20', 0),
-  ('Wither', '', 0.55, 'blue', 'notched_6', 1),
-  ('Build: compiling', 'Hover any bar to read more.\n\nThe panel wraps long lines and keeps your paragraph breaks, so a bar can carry a sentence or a few.', 0.40, 'green', 'progress', 2);";
+INSERT INTO bossbars (title, description, progress, color, overlay, position, since) VALUES
+  ('Ender Dragon', 'The final boss of the End. Destroy all the End Crystals on the obsidian pillars first, or it heals back to full.', 0.82, 'pink', 'notched_20', 0, NULL),
+  ('Wither', '', 0.55, 'blue', 'notched_6', 1, NULL),
+  ('Build: compiling', 'Hover any bar to read more.\n\nThe panel wraps long lines and keeps your paragraph breaks, so a bar can carry a sentence or a few.', 0.40, 'green', 'progress', 2, strftime('%s','now'));";
 
 /// Resolve the database path: `BOSSBAR_DB` wins, otherwise the per-OS app-data
 /// path the `bossbar` CLI also computes.
@@ -112,7 +115,7 @@ pub fn set_position(path: &Path, id: i64, pos: glam::DVec2) -> rusqlite::Result<
 
 fn read(conn: &Connection) -> rusqlite::Result<Vec<BossBar>> {
     let mut stmt = conn.prepare(
-        "SELECT id, title, progress, color, overlay, position, x, y, description
+        "SELECT id, title, progress, color, overlay, position, x, y, description, since
          FROM bossbars
          WHERE visible != 0
          ORDER BY position ASC, id ASC",
@@ -120,10 +123,14 @@ fn read(conn: &Connection) -> rusqlite::Result<Vec<BossBar>> {
     let rows = stmt.query_map([], |r| {
         let x: Option<f64> = r.get(6)?;
         let y: Option<f64> = r.get(7)?;
+        // A non-positive stored value reads as "no counter", so a caller can clear
+        // the clock with `--since 0` without a NULL.
+        let since: Option<i64> = r.get::<_, Option<i64>>(9)?.filter(|s| *s > 0);
         Ok(BossBar {
             id: r.get(0)?,
             title: r.get(1)?,
             description: r.get(8)?,
+            since,
             progress: r.get::<_, f64>(2)?.clamp(0.0, 1.0) as f32,
             color: Color::parse(&r.get::<_, String>(3)?),
             overlay: Overlay::parse(&r.get::<_, String>(4)?),
@@ -217,6 +224,27 @@ mod tests {
         // The seed documents the description contract by example.
         assert!(bars[0].description.contains("End Crystals"));
         assert_eq!(bars[1].description, "", "the Wither seed has no panel");
+        // The Build seed stamps `since`, so it shows a live counter from launch.
+        assert!(bars[2].since.is_some(), "Build seed should have a live counter");
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn since_round_trips_and_nonpositive_reads_as_none() {
+        let path = temp_db("since");
+        let conn = open(&path).unwrap();
+        conn.execute("DELETE FROM bossbars", []).unwrap();
+        conn.execute(
+            "INSERT INTO bossbars (title, since) VALUES ('live', 1700000000), ('zero', 0), ('null', NULL)",
+            [],
+        )
+        .unwrap();
+        let bars = read(&conn).unwrap();
+        let by = |t: &str| bars.iter().find(|b| b.title == t).unwrap();
+        assert_eq!(by("live").since, Some(1_700_000_000));
+        // A 0 or NULL is "no counter", so the overlay shows a plain title.
+        assert_eq!(by("zero").since, None);
+        assert_eq!(by("null").since, None);
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 

--- a/packages/bossbar-overlay/app/src/overlay.rs
+++ b/packages/bossbar-overlay/app/src/overlay.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::f32::consts::TAU;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use glam::DVec2;
 use winit::application::ApplicationHandler;
@@ -43,11 +43,24 @@ const GROW_SECS: f32 = 0.16;
 const BREATHE_PERIOD: f32 = 2.6;
 /// Animation frame budget while something is moving (~60 fps).
 const FRAME: Duration = Duration::from_millis(16);
+/// Redraw cadence for a bar showing a live elapsed counter: once a second is
+/// enough to advance a clock that ticks in seconds, and lets the loop sleep the
+/// rest of the time.
+const TICK: Duration = Duration::from_secs(1);
 
 /// Ease-out cubic: fast start, soft landing. The default feedback curve.
 fn ease_out_cubic(t: f32) -> f32 {
     let u = 1.0 - t.clamp(0.0, 1.0);
     1.0 - u * u * u
+}
+
+/// Current wall-clock time as Unix seconds, for the live elapsed counter. Before
+/// the epoch (clock unset) it clamps to 0, which reads as a 0 counter.
+fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
 }
 
 /// GPU state shared by every bar window: one device/queue and one renderer
@@ -351,6 +364,7 @@ impl App {
             &view,
             win.config.width,
             win.config.height,
+            now_unix(),
             &win.bar,
             hover,
             breathe,
@@ -509,8 +523,9 @@ impl ApplicationHandler<Vec<BossBar>> for App {
     }
 
     /// Keep redrawing while any bar is animating (growing, shrinking, or
-    /// breathing), capped to ~60 fps; otherwise let the loop sleep until the
-    /// next event so an idle overlay costs nothing.
+    /// breathing), capped to ~60 fps; tick once a second while any bar shows a
+    /// live elapsed counter so its clock advances; otherwise let the loop sleep
+    /// until the next event so an idle overlay costs nothing.
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
         // Settle each window's size to its hover state first: grow for an open
         // panel, shrink back once the hover has fully eased out. Done here, off
@@ -522,14 +537,22 @@ impl ApplicationHandler<Vec<BossBar>> for App {
         }
 
         let mut animating = false;
+        let mut ticking = false;
         for win in self.wins.values() {
+            // A live counter only needs the once-a-second TICK, but anything
+            // mid-animation also wants its redraw now (the faster cadence wins).
             if win.animating() {
                 animating = true;
+                win.window.request_redraw();
+            } else if win.bar.since.is_some() {
+                ticking = true;
                 win.window.request_redraw();
             }
         }
         event_loop.set_control_flow(if animating {
             ControlFlow::WaitUntil(Instant::now() + FRAME)
+        } else if ticking {
+            ControlFlow::WaitUntil(Instant::now() + TICK)
         } else {
             ControlFlow::Wait
         });

--- a/packages/bossbar-overlay/app/src/render.rs
+++ b/packages/bossbar-overlay/app/src/render.rs
@@ -79,6 +79,30 @@ fn ramp(x: f32, lo: f32, hi: f32) -> f32 {
     t * t * (3.0 - 2.0 * t)
 }
 
+/// Compact elapsed time that ticks every second: "M:SS" under an hour, else
+/// "H:MM:SS". Drives the live counter a bar with a `since` shows in its title.
+fn fmt_elapsed(secs: i64) -> String {
+    let secs = secs.max(0);
+    let s = secs % 60;
+    let m = (secs / 60) % 60;
+    let h = secs / 3600;
+    if h > 0 {
+        format!("{h}:{m:02}:{s:02}")
+    } else {
+        format!("{m}:{s:02}")
+    }
+}
+
+/// A bar's on-screen title: the stored title plus a live elapsed counter when the
+/// bar has a `since` (e.g. "US East: VMs (2:05)"). An empty title stays empty, so
+/// a counter never appears on its own.
+fn title_with_elapsed(title: &str, since: Option<i64>, now_unix: i64) -> String {
+    match since {
+        Some(start) if !title.is_empty() => format!("{title} ({})", fmt_elapsed(now_unix - start)),
+        _ => title.to_string(),
+    }
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 struct Vertex {
@@ -428,6 +452,7 @@ impl Renderer {
         view: &wgpu::TextureView,
         width: u32,
         height: u32,
+        now_unix: i64,
         items: &[DrawItem<'_>],
     ) -> Result<(), wgpu::SurfaceError> {
         // A shaped run of text plus where, how opaque, and the rect to clip it
@@ -461,6 +486,10 @@ impl Renderer {
             let tint = [1.0, 1.0, 1.0, alpha];
 
             if bx.has_title {
+                // The title carries the live elapsed counter when the bar has a
+                // `since`; recomputed every frame so it ticks on the overlay's
+                // own redraws, with no DB write to advance it.
+                let shown = title_with_elapsed(&b.title, b.since, now_unix);
                 let mut buffer =
                     Buffer::new(&mut self.font_system, Metrics::new(bx.title_px, bx.title_px));
                 // Center the title within the bar width via cosmic-text's own
@@ -468,7 +497,7 @@ impl Renderer {
                 buffer.set_size(&mut self.font_system, Some(bx.bar_w), Some(bx.title_px * 1.5));
                 buffer.set_text(
                     &mut self.font_system,
-                    &b.title,
+                    &shown,
                     &Attrs::new().family(Family::Name(&self.font_family)),
                     Shaping::Advanced,
                     Some(glyphon::cosmic_text::Align::Center),
@@ -733,6 +762,7 @@ impl Renderer {
         view: &wgpu::TextureView,
         width: u32,
         height: u32,
+        now_unix: i64,
         bars: &[BossBar],
         highlight: Option<i64>,
     ) -> Result<(), wgpu::SurfaceError> {
@@ -767,7 +797,7 @@ impl Renderer {
                 }
             })
             .collect();
-        self.draw(view, width, height, &items)
+        self.draw(view, width, height, now_unix, &items)
     }
 
     /// Render a single bar centered in its own window. `hover` is the eased
@@ -786,6 +816,7 @@ impl Renderer {
         view: &wgpu::TextureView,
         width: u32,
         height: u32,
+        now_unix: i64,
         bar: &BossBar,
         hover: f32,
         breathe: f32,
@@ -857,7 +888,7 @@ impl Renderer {
             alpha,
             panel,
         }];
-        self.draw(view, width, height, &items)
+        self.draw(view, width, height, now_unix, &items)
     }
 
     /// Panel metrics in physical pixels at the current scale:
@@ -1048,4 +1079,33 @@ fn upload_white_pixel(
             },
         ],
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fmt_elapsed_ticks_in_seconds_then_minutes_then_hours() {
+        assert_eq!(fmt_elapsed(0), "0:00");
+        assert_eq!(fmt_elapsed(5), "0:05");
+        assert_eq!(fmt_elapsed(65), "1:05");
+        assert_eq!(fmt_elapsed(600), "10:00");
+        assert_eq!(fmt_elapsed(3661), "1:01:01");
+        // A clock that ran backwards (since in the future) clamps to zero.
+        assert_eq!(fmt_elapsed(-10), "0:00");
+    }
+
+    #[test]
+    fn title_with_elapsed_only_appends_when_counting() {
+        // since=1000, now=1125 -> 125s = 2:05.
+        assert_eq!(
+            title_with_elapsed("US East: VMs", Some(1000), 1125),
+            "US East: VMs (2:05)"
+        );
+        // No `since` leaves the title untouched.
+        assert_eq!(title_with_elapsed("Idle", None, 1125), "Idle");
+        // A counter never appears on its own when there is no title.
+        assert_eq!(title_with_elapsed("", Some(1000), 1125), "");
+    }
 }

--- a/packages/bossbar-overlay/app/src/snapshot.rs
+++ b/packages/bossbar-overlay/app/src/snapshot.rs
@@ -45,9 +45,13 @@ pub fn run(
     });
     let view = target.create_view(&wgpu::TextureViewDescriptor::default());
 
+    let now_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
     let mut renderer = Renderer::new(device.clone(), queue.clone(), FORMAT, scale);
     renderer
-        .render(&view, width, height, bars, None)
+        .render(&view, width, height, now_unix, bars, None)
         .map_err(|e| format!("render: {e:?}"))?;
 
     // Copy the texture into a readback buffer with the 256-byte row alignment

--- a/packages/bossbar-overlay/bossbar
+++ b/packages/bossbar-overlay/bossbar
@@ -32,14 +32,19 @@ ensure_db() {
     color       TEXT    NOT NULL DEFAULT 'purple',
     overlay     TEXT    NOT NULL DEFAULT 'progress',
     visible     INTEGER NOT NULL DEFAULT 1,
-    position    INTEGER NOT NULL DEFAULT 0
+    position    INTEGER NOT NULL DEFAULT 0,
+    since       INTEGER
   );"
-  # `description` shipped after the first schema; add it to a pre-existing table
-  # so `--description` works on a DB created by an older bossbar. SQLite has no
+  # Columns that shipped after the first schema; add each to a pre-existing table
+  # so its flag works on a DB created by an older bossbar. SQLite has no
   # ADD COLUMN IF NOT EXISTS, so guard on the column being absent.
-  if [ -z "$(sqlite3 "$DB" "SELECT 1 FROM pragma_table_info('bossbars') WHERE name = 'description' LIMIT 1;")" ]; then
-    sqlite3 "$DB" "ALTER TABLE bossbars ADD COLUMN description TEXT NOT NULL DEFAULT '';"
-  fi
+  add_col() {
+    if [ -z "$(sqlite3 "$DB" "SELECT 1 FROM pragma_table_info('bossbars') WHERE name = '$1' LIMIT 1;")" ]; then
+      sqlite3 "$DB" "ALTER TABLE bossbars ADD COLUMN $1 $2;"
+    fi
+  }
+  add_col description "TEXT NOT NULL DEFAULT ''"
+  add_col since "INTEGER"
 }
 
 die() {
@@ -71,10 +76,11 @@ usage() {
 bossbar - control the Minecraft boss bar overlay (SQLite-backed)
 
 Usage:
-  bossbar add <title> [--description D] [--progress P] [--color C]
-                      [--overlay O] [--position N]
-  bossbar set <id|title> [--title T] [--description D] [--progress P] [--color C]
-                         [--overlay O] [--position N] [--visible 0|1]
+  bossbar add <title> [--description D] [--since EPOCH] [--progress P]
+                      [--color C] [--overlay O] [--position N]
+  bossbar set <id|title> [--title T] [--description D] [--since EPOCH]
+                         [--progress P] [--color C] [--overlay O]
+                         [--position N] [--visible 0|1]
   bossbar rm <id|title>
   bossbar list
   bossbar clear
@@ -82,6 +88,8 @@ Usage:
 
   D        longer text shown in a panel that unfolds below the bar on hover
            (newlines start new paragraphs); pass '' to clear it
+  EPOCH    Unix seconds to count up from; the overlay appends a live elapsed
+           timer to the title (e.g. "2:05") and ticks it. 0 clears the timer
   P        fill fraction 0.0 .. 1.0
   C        pink | blue | red | green | yellow | purple | white
   O        progress | notched_6 | notched_10 | notched_12 | notched_20
@@ -89,6 +97,7 @@ Usage:
 Examples:
   bossbar add "Ender Dragon" --color pink --overlay notched_20 \
     --description "Destroy the End Crystals first or it heals to full."
+  bossbar add "US East: VMs" --color red --since "$(date +%s)"   # live timer
   bossbar set "Ender Dragon" --progress 0.5
   bossbar rm "Ender Dragon"
 EOF
@@ -106,6 +115,7 @@ parse_fields() {
     case "$flag" in
       --title)       assign="title = '$(sq "$val")'" ;;
       --description) assign="description = '$(sq "$val")'" ;;
+      --since)       assign="since = $val" ;;
       --progress)    assign="progress = $val" ;;
       --position)    assign="position = $val" ;;
       --visible)     assign="visible = $val" ;;


### PR DESCRIPTION
Adds a self-ticking elapsed timer to a boss bar's title, so a caller can show "how long X has been happening" by writing the start time once instead of rewriting the title every few seconds to advance a clock.

A new `since` column holds a Unix epoch. When set, the overlay appends a live elapsed time to the title (`Build (2:05)`) and redraws once a second to advance it. `NULL` or a non-positive value means no timer, so existing bars are unaffected.

## What changed
- **db + CLI**: new `since INTEGER` column, online-migrated for existing databases by both the Rust app and the `bossbar` wrapper; a `--since EPOCH` flag (`0` clears the timer). The seeded "Build: compiling" bar stamps `since` so the timer is visible on first launch.
- **renderer**: the displayed title is the stored title plus the formatted elapsed time (`M:SS`, then `H:MM:SS`), recomputed each frame. An empty title never grows a lone timer.
- **overlay**: a once-a-second redraw tick whenever any bar shows a timer; the loop stays idle otherwise.

## Why
The downtime watcher in my nix config was rewriting a bar's title every 30s to bump a "down for Xm" counter, which read as stuck between writes and at minute granularity. Moving the tick into the overlay gives a smooth per-second clock and lets the watcher write the start once with a stable title.

## Validation
- `nix build .#bossbar-overlay` (compiles and runs the test suite, including new `since` round-trip and elapsed-formatting tests).
- `--snapshot` of the seeded DB renders the Build bar as "Build: compiling (0:00)" with the timer appended; bars without `since` render plain.

Implemented with AI assistance (Claude, Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add live self-ticking elapsed timer to bossbar overlay titles
> - Adds an optional `since` Unix-epoch column to the `bossbars` table; bars with a positive `since` value display a live elapsed timer (e.g. `My Bar (1:23:45)`) appended to their title.
> - The event loop in [overlay.rs](https://github.com/indexable-inc/index/pull/433/files#diff-33da11ba47e085c9f1f9c87457840f96d03a66a6a925c69a6273ef76e99e251f) ticks at 1s cadence when any bar has `since` set, triggering redraws to advance the displayed time.
> - Rendering in [render.rs](https://github.com/indexable-inc/index/pull/433/files#diff-3ea9a891a2426681e39b0f386a1bf93d77bfe34709fd71ad609608526da8791f) uses `fmt_elapsed` to format seconds as `M:SS` or `H:MM:SS` and `title_with_elapsed` to compose the final title string.
> - The `bossbar` shell CLI gains a `--since EPOCH` flag (e.g. `--since $(date +%s)`) to set or clear a bar's start time; existing databases gain the column via migration.
> - Snapshots via [snapshot.rs](https://github.com/indexable-inc/index/pull/433/files#diff-26d97bb59263056d36ca1f40b40deaafe53112a0fc3ae761df3e354568eb4c16) also include the elapsed timer for consistency with the live overlay.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d061a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->