### PR TITLE
feat(bossbar): smooth drag + click-to-open URL

### DIFF
--- a/packages/bossbar-overlay/README.md
+++ b/packages/bossbar-overlay/README.md
@@ -38,11 +38,12 @@ or stop the service that runs it). `BOSSBAR_SCALE=3` (or `--scale 3`) enlarges
 the bars.
 
 The bars are interactive: hover one and it eases to fully opaque and gently
-grows with a slow breathing pulse (the cursor becomes a grab hand), and you can
-drag it anywhere on screen. Dragging uses the
-platform's native window drag, and the drop location is saved to the bar's
-`x`/`y` columns, so it stays put across restarts. Bars without a saved position
-auto-stack in a top-center column. This works the same on macOS and Linux.
+grows with a slow breathing pulse (the cursor becomes a grab hand). A press that
+moves past a few pixels starts a drag (the platform's native window drag); the
+drop location is saved to the bar's `x`/`y` columns, so it stays put across
+restarts. A press that does not move is a click: it opens the bar's `url` if it
+has one. Bars without a saved position auto-stack in a top-center column. This
+works the same on macOS and Linux.
 
 A bar can carry a longer `description`. When it does, hovering unfolds a flat
 panel below the bar with the description wrapped to the bar's width, in the same
@@ -56,6 +57,10 @@ A bar can also carry a `since` (Unix epoch). When set, the overlay appends a
 live elapsed timer to the title (`Build (2:05)`) and ticks it once a second on
 its own, so you write the start time once instead of rewriting the title to
 advance a clock. The seeded "Build: compiling" bar shows this.
+
+A bar can carry a `url`. Clicking the bar (a press without a drag) opens it with
+the system opener (`open` on macOS, `xdg-open` on Linux), so a status bar can
+link straight to its dashboard. The seeded Ender Dragon bar links to the wiki.
 
 Known limitations: some Linux tiling window managers force-place or tile
 borderless windows, which can fight the free-drag placement. An auto-stacked
@@ -115,7 +120,8 @@ CREATE TABLE bossbars (
   position    INTEGER NOT NULL DEFAULT 0,    -- sort order in the auto column
   x           REAL,                          -- pinned location (logical points)
   y           REAL,                          -- NULL/NULL = auto-stacked
-  since       INTEGER                        -- Unix epoch; live elapsed timer in the title
+  since       INTEGER,                       -- Unix epoch; live elapsed timer in the title
+  url         TEXT    NOT NULL DEFAULT ''    -- opened with the system opener on click
 );
 ```
 
@@ -130,6 +136,9 @@ CREATE TABLE bossbars (
   appends a live elapsed timer to the title (`Build (2:05)`) and ticks it once a
   second, so you write the start once instead of rewriting the title to advance a
   clock. `NULL` or a non-positive value means no timer.
+- **url**: opened with the system opener (`open` / `xdg-open`) when the bar is
+  clicked without dragging. Empty (the default) means a click does nothing. Any
+  URI, file, or path the opener accepts works.
 - **x / y**: pinned screen location in logical points, written when you drag a
   bar. Leave both `NULL` (the default) to keep the bar in the auto-stacked
   top-center column ordered by `position`; setting them floats the bar free.

--- a/packages/bossbar-overlay/app/src/bars.rs
+++ b/packages/bossbar-overlay/app/src/bars.rs
@@ -107,6 +107,9 @@ pub struct BossBar {
     /// rewriting the title to advance a clock. `None` (or a non-positive value in
     /// the DB) means no counter.
     pub since: Option<i64>,
+    /// A URL (or any URI/path the OS opener accepts) opened when the bar is
+    /// clicked without dragging. Empty means a click does nothing.
+    pub url: String,
     /// Fill fraction, always clamped to `0.0..=1.0` at construction.
     pub progress: f32,
     pub color: Color,

--- a/packages/bossbar-overlay/app/src/db.rs
+++ b/packages/bossbar-overlay/app/src/db.rs
@@ -31,7 +31,8 @@ CREATE TABLE IF NOT EXISTS bossbars (
   position    INTEGER NOT NULL DEFAULT 0,
   x           REAL,
   y           REAL,
-  since       INTEGER
+  since       INTEGER,
+  url         TEXT    NOT NULL DEFAULT ''
 );";
 
 /// Columns added after the initial schema shipped. `ALTER TABLE ADD COLUMN` is
@@ -43,17 +44,18 @@ const ADDED_COLUMNS: &[(&str, &str)] = &[
     ("y", "REAL"),
     ("description", "TEXT NOT NULL DEFAULT ''"),
     ("since", "INTEGER"),
+    ("url", "TEXT NOT NULL DEFAULT ''"),
 ];
 
 /// Rows inserted only when the DB file is created for the first time, so a
 /// brand-new install shows something and documents the contract by example. The
-/// third bar carries a multi-paragraph description (the hover panel) and a
-/// `since` of now, so its title shows a live elapsed counter from first launch.
+/// Ender Dragon bar carries a hover panel and a click URL; the Build bar stamps
+/// `since` so its title shows a live elapsed counter from first launch.
 const SEED: &str = "\
-INSERT INTO bossbars (title, description, progress, color, overlay, position, since) VALUES
-  ('Ender Dragon', 'The final boss of the End. Destroy all the End Crystals on the obsidian pillars first, or it heals back to full.', 0.82, 'pink', 'notched_20', 0, NULL),
-  ('Wither', '', 0.55, 'blue', 'notched_6', 1, NULL),
-  ('Build: compiling', 'Hover any bar to read more.\n\nThe panel wraps long lines and keeps your paragraph breaks, so a bar can carry a sentence or a few.', 0.40, 'green', 'progress', 2, strftime('%s','now'));";
+INSERT INTO bossbars (title, description, progress, color, overlay, position, since, url) VALUES
+  ('Ender Dragon', 'The final boss of the End. Destroy all the End Crystals on the obsidian pillars first, or it heals back to full.', 0.82, 'pink', 'notched_20', 0, NULL, 'https://minecraft.wiki/w/Ender_Dragon'),
+  ('Wither', '', 0.55, 'blue', 'notched_6', 1, NULL, ''),
+  ('Build: compiling', 'Hover any bar to read more.\n\nThe panel wraps long lines and keeps your paragraph breaks, so a bar can carry a sentence or a few.', 0.40, 'green', 'progress', 2, strftime('%s','now'), '');";
 
 /// Resolve the database path: `BOSSBAR_DB` wins, otherwise the per-OS app-data
 /// path the `bossbar` CLI also computes.
@@ -101,11 +103,14 @@ fn add_column_if_missing(conn: &Connection, name: &str, ty: &str) -> rusqlite::R
     Ok(())
 }
 
-/// Persist a dragged bar's pinned location (logical screen points). Uses its
-/// own connection so the overlay's read/watch connection is untouched; the
-/// commit bumps `data_version`, so the watcher re-reads and the move sticks.
+/// Persist a dragged bar's pinned location (logical screen points). Uses its own
+/// connection so the overlay's read/watch connection is untouched; the commit
+/// bumps `data_version`, so the watcher re-reads and the move sticks. This runs
+/// on the UI thread during a drag, so it deliberately skips the schema/migration
+/// setup `open` does: by drag time the table exists, and WAL is a persistent DB
+/// property, so a bare connection plus the `UPDATE` keeps each write cheap.
 pub fn set_position(path: &Path, id: i64, pos: glam::DVec2) -> rusqlite::Result<()> {
-    let conn = open(path)?;
+    let conn = Connection::open(path)?;
     conn.execute(
         "UPDATE bossbars SET x = ?1, y = ?2 WHERE id = ?3",
         rusqlite::params![pos.x, pos.y, id],
@@ -115,7 +120,7 @@ pub fn set_position(path: &Path, id: i64, pos: glam::DVec2) -> rusqlite::Result<
 
 fn read(conn: &Connection) -> rusqlite::Result<Vec<BossBar>> {
     let mut stmt = conn.prepare(
-        "SELECT id, title, progress, color, overlay, position, x, y, description, since
+        "SELECT id, title, progress, color, overlay, position, x, y, description, since, url
          FROM bossbars
          WHERE visible != 0
          ORDER BY position ASC, id ASC",
@@ -131,6 +136,7 @@ fn read(conn: &Connection) -> rusqlite::Result<Vec<BossBar>> {
             title: r.get(1)?,
             description: r.get(8)?,
             since,
+            url: r.get(10)?,
             progress: r.get::<_, f64>(2)?.clamp(0.0, 1.0) as f32,
             color: Color::parse(&r.get::<_, String>(3)?),
             overlay: Overlay::parse(&r.get::<_, String>(4)?),
@@ -226,6 +232,26 @@ mod tests {
         assert_eq!(bars[1].description, "", "the Wither seed has no panel");
         // The Build seed stamps `since`, so it shows a live counter from launch.
         assert!(bars[2].since.is_some(), "Build seed should have a live counter");
+        // The Ender Dragon seed carries a click URL; the others none.
+        assert!(bars[0].url.contains("minecraft.wiki"));
+        assert_eq!(bars[1].url, "");
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn url_round_trips() {
+        let path = temp_db("url");
+        let conn = open(&path).unwrap();
+        conn.execute("DELETE FROM bossbars", []).unwrap();
+        conn.execute(
+            "INSERT INTO bossbars (title, url) VALUES ('link', 'https://example.com/x'), ('plain', '')",
+            [],
+        )
+        .unwrap();
+        let bars = read(&conn).unwrap();
+        let by = |t: &str| bars.iter().find(|b| b.title == t).unwrap();
+        assert_eq!(by("link").url, "https://example.com/x");
+        assert_eq!(by("plain").url, "");
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 

--- a/packages/bossbar-overlay/app/src/overlay.rs
+++ b/packages/bossbar-overlay/app/src/overlay.rs
@@ -47,6 +47,14 @@ const FRAME: Duration = Duration::from_millis(16);
 /// enough to advance a clock that ticks in seconds, and lets the loop sleep the
 /// rest of the time.
 const TICK: Duration = Duration::from_secs(1);
+/// Pointer travel (physical px) past which a press becomes a drag rather than a
+/// click. Below it, the press-release opens the bar's URL; at or above it, the
+/// native window drag takes over.
+const DRAG_THRESHOLD: f64 = 5.0;
+/// How long a window must sit still after its last move before the overlay will
+/// apply an externally-read position again. Must exceed the DB watch poll so the
+/// watcher's lagged read-back of our own drag never snaps the window back.
+const SETTLE: Duration = Duration::from_millis(700);
 
 /// Ease-out cubic: fast start, soft landing. The default feedback curve.
 fn ease_out_cubic(t: f32) -> f32 {
@@ -61,6 +69,20 @@ fn now_unix() -> i64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0)
+}
+
+/// Open a bar's click URL with the platform's opener (a URL, file, or any URI it
+/// accepts), detached so the overlay never blocks on the browser launch. A
+/// spawn failure is reported but not fatal: a bad URL should not take down the HUD.
+fn open_url(url: &str) {
+    let opener = if cfg!(target_os = "macos") {
+        "open"
+    } else {
+        "xdg-open"
+    };
+    if let Err(e) = std::process::Command::new(opener).arg(url).spawn() {
+        eprintln!("bossbar-overlay: failed to open {url}: {e}");
+    }
 }
 
 /// GPU state shared by every bar window: one device/queue and one renderer
@@ -85,9 +107,8 @@ struct BarWin {
     hover_anim: f32,
     /// Timestamp of the last animation step, for frame-rate-independent easing.
     last: Instant,
-    /// True between a left-press and its release: only then does a `Moved`
-    /// count as a user drag worth persisting. Window placement nudges by the OS
-    /// (e.g. clamping below the menu bar) arrive with this false and are ignored.
+    /// True once a press has moved past the drag threshold and the native window
+    /// drag has taken over. Drives the grabbing cursor; cleared on release.
     dragging: bool,
     /// Last position we know the window holds (logical points): what we set, or
     /// where the OS placed it. Lets `Moved` skip echoes of our own placement.
@@ -97,6 +118,17 @@ struct BarWin {
     /// The window is currently grown to fit the open panel. Collapsed otherwise,
     /// so the empty area below the bar never intercepts the mouse (click-through).
     expanded: bool,
+    /// Last cursor position within the window (physical px), tracked so a press
+    /// can measure drag distance and tell a click from a drag.
+    cursor: Option<PhysicalPosition<f64>>,
+    /// Cursor position at the left-press while the gesture is still ambiguous
+    /// (button down, not yet past the drag threshold). `None` once it became a
+    /// drag or the button is up. A release with this still set is a click.
+    press: Option<PhysicalPosition<f64>>,
+    /// When the window last moved (a `Moved` during a drag). The reconcile guard
+    /// ignores externally-read positions until the window has been still for
+    /// SETTLE, so the watcher's lagged read-back never snaps a live drag back.
+    last_move: Instant,
 }
 
 impl BarWin {
@@ -244,6 +276,7 @@ impl App {
         let (surface, config) = self.make_surface(&window);
         window.request_redraw();
         let has_description = !bar.description.trim().is_empty();
+        let now = Instant::now();
         Some(BarWin {
             window,
             surface,
@@ -251,13 +284,18 @@ impl App {
             bar,
             hovered: false,
             hover_anim: 0.0,
-            last: Instant::now(),
+            last: now,
             dragging: false,
             self_set: Some(pos),
             has_description,
             // Windows are created at the collapsed (bar-only) size; the panel
             // grows them on hover.
             expanded: false,
+            cursor: None,
+            press: None,
+            // Far enough in the past that a fresh window accepts an external
+            // position immediately (the SETTLE guard only fires after a real move).
+            last_move: now - SETTLE,
         })
     }
 
@@ -286,10 +324,15 @@ impl App {
                 win.has_description = !b.description.trim().is_empty();
                 win.bar = b.clone();
                 // Honor a position set in the DB by something other than our own
-                // drag (e.g. the CLI), but ignore the echo of our last move.
+                // drag (e.g. the CLI), but do not fight a live drag: while the
+                // user is moving the window the DB still holds an older value (the
+                // watcher reads it ~200ms behind), and forcing it would snap the
+                // window back. So only apply an external position once the window
+                // has been still for SETTLE, and skip the echo of our own move.
                 if let Some(p) = b.pos {
                     let lp = LogicalPosition::new(p.x, p.y);
-                    if win.self_set != Some(lp) {
+                    let settled = Instant::now().duration_since(win.last_move) >= SETTLE;
+                    if settled && win.self_set != Some(lp) {
                         win.window.set_outer_position(lp);
                         win.self_set = Some(lp);
                     }
@@ -375,6 +418,9 @@ impl App {
     /// A window moved. Persist it only when the move came from a user drag;
     /// otherwise (initial placement, OS menu-bar clamp) just record where the
     /// window actually sits so a later drag is measured from the right spot.
+    /// `Moved` arrives at roughly the refresh rate during a drag and the write is
+    /// cheap (see `db::set_position`), so every drag move is saved; the last one
+    /// is the exact drop position.
     fn on_moved(&mut self, id: i64, pos: PhysicalPosition<i32>) {
         let Some(win) = self.wins.get_mut(&id) else {
             return;
@@ -390,6 +436,9 @@ impl App {
         if !win.dragging {
             return; // OS-initiated placement, not a user drag
         }
+        // Mark the window as moving now, so the reconcile guard keeps the
+        // watcher's lagged read-back from snapping it back mid-drag.
+        win.last_move = Instant::now();
         let dv = DVec2::new(logical.x, logical.y);
         win.bar.pos = Some(dv);
         if let Err(e) = db::set_position(&self.db, id, dv) {
@@ -490,17 +539,37 @@ impl ApplicationHandler<Vec<BossBar>> for App {
                 }
                 self.render_id(id);
             }
+            WindowEvent::CursorMoved { position, .. } => {
+                if let Some(win) = self.wins.get_mut(&id) {
+                    win.cursor = Some(position);
+                    // While a press is still ambiguous, watch for travel past the
+                    // threshold: that turns the gesture into a drag and hands off
+                    // to the native window drag (which then drives `Moved`).
+                    if let Some(p) = win.press {
+                        let dx = position.x - p.x;
+                        let dy = position.y - p.y;
+                        if (dx * dx + dy * dy).sqrt() >= DRAG_THRESHOLD {
+                            win.press = None;
+                            win.dragging = true;
+                            win.window.set_cursor(CursorIcon::Grabbing);
+                            if let Err(e) = win.window.drag_window() {
+                                eprintln!("bossbar-overlay: drag failed: {e}");
+                            }
+                        }
+                    }
+                }
+            }
             WindowEvent::MouseInput {
                 state: ElementState::Pressed,
                 button: MouseButton::Left,
                 ..
             } => {
                 if let Some(win) = self.wins.get_mut(&id) {
-                    win.dragging = true;
-                    win.window.set_cursor(CursorIcon::Grabbing);
-                    if let Err(e) = win.window.drag_window() {
-                        eprintln!("bossbar-overlay: drag failed: {e}");
-                    }
+                    // Defer the native drag until the pointer travels past the
+                    // threshold (see CursorMoved), so a stationary press stays a
+                    // click whose mouse-up we actually receive.
+                    win.press = win.cursor;
+                    win.dragging = false;
                 }
             }
             WindowEvent::MouseInput {
@@ -508,13 +577,22 @@ impl ApplicationHandler<Vec<BossBar>> for App {
                 button: MouseButton::Left,
                 ..
             } => {
-                if let Some(win) = self.wins.get_mut(&id) {
+                // A release while the press never became a drag is a click: open
+                // the bar's URL if it has one. (A drag swallows its own mouse-up
+                // on macOS, but by then `press` is already cleared.)
+                let url = self.wins.get_mut(&id).and_then(|win| {
+                    let clicked = win.press.is_some() && !win.dragging;
+                    win.press = None;
                     win.dragging = false;
                     win.window.set_cursor(if win.hovered {
                         CursorIcon::Grab
                     } else {
                         CursorIcon::Default
                     });
+                    (clicked && !win.bar.url.trim().is_empty()).then(|| win.bar.url.clone())
+                });
+                if let Some(url) = url {
+                    open_url(&url);
                 }
             }
             WindowEvent::Moved(pos) => self.on_moved(id, pos),

--- a/packages/bossbar-overlay/app/src/overlay.rs
+++ b/packages/bossbar-overlay/app/src/overlay.rs
@@ -121,9 +121,12 @@ struct BarWin {
     /// Last cursor position within the window (physical px), tracked so a press
     /// can measure drag distance and tell a click from a drag.
     cursor: Option<PhysicalPosition<f64>>,
-    /// Cursor position at the left-press while the gesture is still ambiguous
-    /// (button down, not yet past the drag threshold). `None` once it became a
-    /// drag or the button is up. A release with this still set is a click.
+    /// The left button is down. A release while this is set and the gesture never
+    /// became a drag is a click. Independent of `press` so a press with no prior
+    /// cursor sample still registers a click.
+    pressing: bool,
+    /// The anchor a drag's distance is measured from (cursor at press, or the
+    /// first move after a press that had no cursor yet). `None` until anchored.
     press: Option<PhysicalPosition<f64>>,
     /// When the window last moved (a `Moved` during a drag). The reconcile guard
     /// ignores externally-read positions until the window has been still for
@@ -292,6 +295,7 @@ impl App {
             // grows them on hover.
             expanded: false,
             cursor: None,
+            pressing: false,
             press: None,
             // Far enough in the past that a fresh window accepts an external
             // position immediately (the SETTLE guard only fires after a real move).
@@ -542,14 +546,16 @@ impl ApplicationHandler<Vec<BossBar>> for App {
             WindowEvent::CursorMoved { position, .. } => {
                 if let Some(win) = self.wins.get_mut(&id) {
                     win.cursor = Some(position);
-                    // While a press is still ambiguous, watch for travel past the
-                    // threshold: that turns the gesture into a drag and hands off
-                    // to the native window drag (which then drives `Moved`).
-                    if let Some(p) = win.press {
-                        let dx = position.x - p.x;
-                        let dy = position.y - p.y;
+                    // While the button is down and not yet dragging, measure travel
+                    // from the anchor (the cursor at press, or this first move if
+                    // the press had no cursor sample). Past the threshold it becomes
+                    // a drag and hands off to the native window drag, which then
+                    // drives `Moved`.
+                    if win.pressing && !win.dragging {
+                        let origin = *win.press.get_or_insert(position);
+                        let dx = position.x - origin.x;
+                        let dy = position.y - origin.y;
                         if (dx * dx + dy * dy).sqrt() >= DRAG_THRESHOLD {
-                            win.press = None;
                             win.dragging = true;
                             win.window.set_cursor(CursorIcon::Grabbing);
                             if let Err(e) = win.window.drag_window() {
@@ -568,6 +574,7 @@ impl ApplicationHandler<Vec<BossBar>> for App {
                     // Defer the native drag until the pointer travels past the
                     // threshold (see CursorMoved), so a stationary press stays a
                     // click whose mouse-up we actually receive.
+                    win.pressing = true;
                     win.press = win.cursor;
                     win.dragging = false;
                 }
@@ -577,11 +584,12 @@ impl ApplicationHandler<Vec<BossBar>> for App {
                 button: MouseButton::Left,
                 ..
             } => {
-                // A release while the press never became a drag is a click: open
-                // the bar's URL if it has one. (A drag swallows its own mouse-up
-                // on macOS, but by then `press` is already cleared.)
+                // A release where the button-down gesture never became a drag is a
+                // click: open the bar's URL if it has one. (A drag swallows its own
+                // mouse-up on macOS, but `dragging` is already set by then.)
                 let url = self.wins.get_mut(&id).and_then(|win| {
-                    let clicked = win.press.is_some() && !win.dragging;
+                    let clicked = win.pressing && !win.dragging;
+                    win.pressing = false;
                     win.press = None;
                     win.dragging = false;
                     win.window.set_cursor(if win.hovered {

--- a/packages/bossbar-overlay/bossbar
+++ b/packages/bossbar-overlay/bossbar
@@ -33,7 +33,8 @@ ensure_db() {
     overlay     TEXT    NOT NULL DEFAULT 'progress',
     visible     INTEGER NOT NULL DEFAULT 1,
     position    INTEGER NOT NULL DEFAULT 0,
-    since       INTEGER
+    since       INTEGER,
+    url         TEXT    NOT NULL DEFAULT ''
   );"
   # Columns that shipped after the first schema; add each to a pre-existing table
   # so its flag works on a DB created by an older bossbar. SQLite has no
@@ -45,6 +46,7 @@ ensure_db() {
   }
   add_col description "TEXT NOT NULL DEFAULT ''"
   add_col since "INTEGER"
+  add_col url "TEXT NOT NULL DEFAULT ''"
 }
 
 die() {
@@ -76,9 +78,9 @@ usage() {
 bossbar - control the Minecraft boss bar overlay (SQLite-backed)
 
 Usage:
-  bossbar add <title> [--description D] [--since EPOCH] [--progress P]
+  bossbar add <title> [--description D] [--since EPOCH] [--url U] [--progress P]
                       [--color C] [--overlay O] [--position N]
-  bossbar set <id|title> [--title T] [--description D] [--since EPOCH]
+  bossbar set <id|title> [--title T] [--description D] [--since EPOCH] [--url U]
                          [--progress P] [--color C] [--overlay O]
                          [--position N] [--visible 0|1]
   bossbar rm <id|title>
@@ -90,13 +92,16 @@ Usage:
            (newlines start new paragraphs); pass '' to clear it
   EPOCH    Unix seconds to count up from; the overlay appends a live elapsed
            timer to the title (e.g. "2:05") and ticks it. 0 clears the timer
+  U        URL (or any URI/path the system opener accepts) opened when the bar
+           is clicked without dragging; pass '' to clear it
   P        fill fraction 0.0 .. 1.0
   C        pink | blue | red | green | yellow | purple | white
   O        progress | notched_6 | notched_10 | notched_12 | notched_20
 
 Examples:
   bossbar add "Ender Dragon" --color pink --overlay notched_20 \
-    --description "Destroy the End Crystals first or it heals to full."
+    --description "Destroy the End Crystals first or it heals to full." \
+    --url "https://minecraft.wiki/w/Ender_Dragon"
   bossbar add "US East: VMs" --color red --since "$(date +%s)"   # live timer
   bossbar set "Ender Dragon" --progress 0.5
   bossbar rm "Ender Dragon"
@@ -116,6 +121,7 @@ parse_fields() {
       --title)       assign="title = '$(sq "$val")'" ;;
       --description) assign="description = '$(sq "$val")'" ;;
       --since)       assign="since = $val" ;;
+      --url)         assign="url = '$(sq "$val")'" ;;
       --progress)    assign="progress = $val" ;;
       --position)    assign="position = $val" ;;
       --visible)     assign="visible = $val" ;;


### PR DESCRIPTION
Two related fixes to boss bar mouse interaction.

## Drag glitch
Dragging a bar sometimes snapped it backward for a moment. Cause: every `Moved` event persisted the position through `db::set_position`, which re-ran the full schema/migration setup each call (heavy), and the overlay's DB watcher then read that position back ~200ms later (its poll interval) and called `set_outer_position` to force the window there. During a fast drag that read-back is stale, so the window jumped to where it was 200ms ago, then the native drag pulled it forward again.

- `set_position` is now a bare `Connection::open` + `UPDATE` (the table exists by drag time and WAL is a persistent DB property), so each drag write is cheap.
- `reconcile` only applies an externally-read position once the window has been still for `SETTLE` (700ms, longer than the 200ms watch poll), so the watcher's own lagged read-back never fights a live drag. External position changes (e.g. from the CLI) still apply once the window settles.

## Click to open a URL
A press that does not move past a small threshold is now a click, which opens the bar's new `url` with the system opener (`open` on macOS, `xdg-open` on Linux). A press that moves past the threshold becomes the native drag as before. Deferring the native drag until the threshold is what makes the click's mouse-up reliably observable (a native drag swallows its own mouse-up on macOS).

- New `url` column, online-migrated for existing databases by both the Rust app and the `bossbar` wrapper; a `--url U` flag (`''` clears it). The seeded Ender Dragon bar links to the wiki.

## Validation
- `nix build .#bossbar-overlay` (compiles and runs the suite, including new `url` round-trip and updated seed assertions).
- The drag-smoothness and click-open behaviors are interactive (cursor + on-screen window) and were validated by code/logic, not a headless run; confirmed live after deploy.

Implemented with AI assistance (Claude, Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add click-to-open URL and smooth drag threshold to bossbar overlay
> - Adds a `url` field to bossbars (DB schema, CLI `--url` flag, and `BossBar` struct) that is opened via the system launcher when a bar is clicked without dragging.
> - Introduces a 5px `DRAG_THRESHOLD` to distinguish clicks from drags; native window drag only begins once the threshold is crossed.
> - Adds a 700ms `SETTLE` guard in `reconcile` so externally-read DB positions don't snap a window back during an active drag.
> - Position is now persisted on every drag move (not just on drop) so the final resting position is always exact.
> - `set_position` opens a bare `rusqlite::Connection` directly to avoid running schema migration on the UI thread.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6aabd3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->