### PR TITLE
feat(macos-vm): drive guest off-screen (keyboard/mouse) + virtio-fs sharing

### DIFF
--- a/packages/macos-vm/README.md
+++ b/packages/macos-vm/README.md
@@ -18,9 +18,14 @@ nix run .#macos-vm -- boot-linux --kernel ./Image --initramfs ./initramfs
 
 ## Status
 
-Proven end to end on macOS 26.5 / Apple M5 Max: a signed binary boots a real
-Linux guest (raw arm64 kernel `Image` + initramfs) through Virtualization.framework
-and streams the guest serial console to stdout. The guest reaches userspace.
+Proven end to end on macOS 26.5 / Apple M5 Max. The headline run: a signed
+binary boots an installed macOS guest fully off-screen, an operator drives it
+through Setup Assistant to a logged-in desktop with synthetic keyboard and mouse
+input (no host cursor), shares a host directory in over virtio-fs, launches a
+wgpu GUI app (the `bossbar-overlay`) from that share, and screenshots the running
+overlay by reading the guest framebuffer. Nothing appears on the host desktop and
+the host cursor is never touched. A Linux guest also boots to userspace with its
+serial console streamed to stdout.
 
 What works today:
 
@@ -33,8 +38,15 @@ What works today:
 - `boot-macos` boots an installed macOS guest **fully off-screen** and
   screenshots its display to PNGs, with no visible window, no
   ScreenCaptureKit, and no Screen-Recording permission (see
-  [Off-screen capture](#off-screen-capture)). Validated end to end: captures the
-  macOS Setup Assistant from a guest whose window is parked at (-20000, -20000).
+  [Off-screen capture](#off-screen-capture)).
+- `drive-macos` boots the guest off-screen and reads newline commands from
+  stdin to drive it: synthetic keyboard (`key`/`down`/`up`/`type`), mouse
+  (`click`), `wait`, and on-demand `shot`, with a one-line ack per command (see
+  [Driving the guest](#driving-the-guest)). Input goes straight to the guest's
+  keyboard/pointing device, so the host cursor never moves.
+- **virtio-fs directory sharing**: `--share TAG=HOSTDIR[:ro]` on `boot-macos`
+  and `drive-macos` shares a host directory into the guest. Tag `auto` uses the
+  macOS automount tag, mounting at `/Volumes/My Shared Files`.
 - **Automatic self-signing**: a VM command on the read-only Nix store binary
   re-execs an ad-hoc-signed copy from `$XDG_CACHE_HOME/ix/macos-vm` carrying the
   `com.apple.security.virtualization` entitlement, so `nix run .#macos-vm` and
@@ -44,9 +56,8 @@ What is designed but not yet built (see [Roadmap](#roadmap)):
 
 - a vsock control channel and a long-lived `serve` mode,
 - booting an OCI image as a disk,
-- guest input injection + OCR to drive the guest headlessly (e.g. past Setup
-  Assistant) without the host cursor,
-- the `macvm` Python module bundled into ix-mcp.
+- the `drive-macos`/`--share` surface exposed through the `macvm` Python module
+  (today the module exposes `info`/`install`/`screenshot`).
 
 ## Off-screen capture
 
@@ -70,6 +81,36 @@ capture a fully off-screen window ("could not create image from window"). The
 IOSurface read sidesteps all of that. Technique from
 [thecrypticace/vzautomation](https://github.com/thecrypticace/vzautomation),
 which also shows keyboard injection and Vision OCR for driving the guest.
+
+## Driving the guest
+
+`drive-macos` boots the guest off-screen and then reads commands from stdin, one
+per line, acking each on stdout. Synthetic events are delivered straight to the
+guest's USB keyboard and screen-coordinate pointing device by handing built
+`NSEvent`s to the `VZVirtualMachineView` (the technique
+[thecrypticace/vzautomation](https://github.com/thecrypticace/vzautomation)
+uses), so the host event system and cursor are never involved.
+
+Commands:
+
+- `key <name> [count]` press a named key (`return`, `tab`, `space`, `esc`,
+  arrows, `delete`, `f1`..`f12`, modifiers) `count` times
+- `down <name>` / `up <name>` hold / release a key, e.g. to chord a modifier
+- `type <text>` type the rest of the line (US-layout printable ASCII)
+- `click <fx> <fy>` left-click at a fraction `0..1` of the display, from the
+  top-left (resolution-independent, so it survives display-mode changes)
+- `wait <seconds>` sleep; `shot <path>` screenshot the framebuffer; `quit` exit
+
+Because every command acks, a controller can drive the guest in lockstep:
+capture a frame, locate a control in it (the host side can use any image
+tooling), `click` it, capture again. Modifiers via `down`/`up` give chords like
+Spotlight: `down cmd`, `key space`, `up cmd`.
+
+Modal screens that make a network call (Apple ID, Screen Time) hang on a host
+without working guest internet. Where the goal is just a usable desktop, it is
+simpler to mark Setup Assistant complete offline by editing the guest disk
+(`.AppleSetupDone` plus the per-user `com.apple.SetupAssistant` `DidSee*` keys)
+than to click through those screens.
 
 ## Why a standalone signed binary
 

--- a/packages/macos-vm/src/drive.rs
+++ b/packages/macos-vm/src/drive.rs
@@ -1,0 +1,219 @@
+//! Interactive driver for a macOS guest: boot it off-screen, then read newline
+//! commands from stdin and apply them (synthetic keyboard input + framebuffer
+//! screenshots). A caller drives the guest UI (Setup Assistant, launching an
+//! app) and verifies rendering without ever touching the host cursor or desktop.
+//!
+//! Commands (one per line; blank lines and `#` comments are ignored):
+//!
+//! - `key <name> [count]` press a named key `count` times (default 1)
+//! - `down <name>` / `up <name>` hold / release a key (e.g. a modifier)
+//! - `type <text>` type the rest of the line as characters
+//! - `wait <seconds>` sleep (fractional seconds allowed)
+//! - `shot <path>` screenshot the guest framebuffer to a PNG
+//! - `quit` stop the VM and exit
+//!
+//! Each command prints a one-line `ok ...` / `err ...` acknowledgement to stdout
+//! (flushed), so a caller can drive the guest in lockstep. Names accepted by
+//! `key`/`down`/`up` are in [`crate::input::named_key`].
+
+use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use dispatch2::DispatchQueue;
+use objc2::MainThreadMarker;
+use objc2::rc::Retained;
+use objc2_app_kit::{NSApplication, NSEventType};
+use objc2_virtualization::VZVirtualMachineView;
+
+use crate::imp::Error;
+use crate::input;
+use crate::macguest::{DirShare, capture, start_guest_offscreen};
+
+/// Gap between a key's down and up, and after its release, so the guest HID
+/// stack registers discrete presses instead of coalescing them. The sleeps run
+/// on the driver thread, leaving the main queue free to render between events.
+const KEY_GAP_DOWN: Duration = Duration::from_millis(8);
+const KEY_GAP_AFTER: Duration = Duration::from_millis(24);
+
+/// Parameters for the interactive driver.
+pub struct DriveMacos {
+    pub bundle: PathBuf,
+    pub shares: Vec<DirShare>,
+}
+
+pub fn drive_macos(drive: DriveMacos) -> Result<(), Error> {
+    let DriveMacos { bundle, shares } = drive;
+    let mtm = MainThreadMarker::new().ok_or(Error::NotMainThread)?;
+    let view = start_guest_offscreen(mtm, &bundle, &shares)?;
+    // Leak the view (it lives for the process) and hand the raw pointer to the
+    // driver thread; the view is not `Send`, so we only re-borrow it on the main
+    // queue, where it is valid.
+    let view_ptr = Retained::into_raw(view) as usize;
+    eprintln!("macos-vm: driving guest; stdin commands: key/down/up/type/wait/shot/quit");
+    std::thread::spawn(move || run_commands(view_ptr));
+
+    // The view needs the `AppKit` run loop to build its layer tree and receive
+    // guest frames; the driver thread exits the process on `quit` or EOF.
+    NSApplication::sharedApplication(mtm).run();
+    Ok(())
+}
+
+/// Read and execute commands until stdin closes or `quit` exits the process.
+fn run_commands(view_ptr: usize) -> ! {
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout();
+    // `lines()` yields each line without its trailing newline; trailing spaces
+    // are preserved so `type` can emit them.
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else { break };
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let ack = execute(view_ptr, trimmed);
+        let _ = writeln!(stdout, "{ack}");
+        let _ = stdout.flush();
+    }
+    std::process::exit(0);
+}
+
+/// Execute one command line, returning its acknowledgement.
+fn execute(view_ptr: usize, trimmed: &str) -> String {
+    if let Some(text) = trimmed.strip_prefix("type ") {
+        let (typed, skipped) = type_text(view_ptr, text);
+        return if skipped == 0 {
+            format!("ok type {typed} chars")
+        } else {
+            format!("ok type {typed} chars ({skipped} unmapped)")
+        };
+    }
+    if let Some(path) = trimmed.strip_prefix("shot ") {
+        let path = Path::new(path.trim());
+        return match shot(view_ptr, path) {
+            Ok(bytes) => format!("ok shot {} {bytes}", path.display()),
+            Err(error) => format!("err shot {error}"),
+        };
+    }
+
+    let mut parts = trimmed.split_whitespace();
+    let Some(command) = parts.next() else {
+        return "ok".to_owned();
+    };
+    match command {
+        "click" => {
+            let fx = parts.next().and_then(|s| s.parse::<f64>().ok());
+            let fy = parts.next().and_then(|s| s.parse::<f64>().ok());
+            let (Some(fx), Some(fy)) = (fx, fy) else {
+                return "err click needs two fractions 0..1 (from top-left)".to_owned();
+            };
+            on_main(view_ptr, move |view| {
+                let bounds = view.bounds();
+                let x = fx * bounds.size.width;
+                // Fraction is from the top; AppKit window coordinates are
+                // bottom-left origin, so flip y.
+                let y = fy.mul_add(-bounds.size.height, bounds.size.height);
+                input::click(view, x, y);
+            });
+            std::thread::sleep(KEY_GAP_AFTER);
+            format!("ok click {fx} {fy}")
+        }
+        "key" => {
+            let Some(name) = parts.next() else {
+                return "err key needs a name".to_owned();
+            };
+            let Some(code) = input::named_key(name) else {
+                return format!("err unknown key {name:?}");
+            };
+            let count = parts.next().and_then(|c| c.parse::<u32>().ok()).unwrap_or(1);
+            for _ in 0..count {
+                press_key(view_ptr, code, false);
+            }
+            format!("ok key {name} x{count}")
+        }
+        "down" | "up" => {
+            let Some(name) = parts.next() else {
+                return format!("err {command} needs a name");
+            };
+            let Some(code) = input::named_key(name) else {
+                return format!("err unknown key {name:?}");
+            };
+            let event_type = if command == "down" {
+                NSEventType::KeyDown
+            } else {
+                NSEventType::KeyUp
+            };
+            on_main(view_ptr, move |view| input::send_event(view, event_type, code));
+            std::thread::sleep(KEY_GAP_AFTER);
+            format!("ok {command} {name}")
+        }
+        "wait" => {
+            let Some(secs) = parts.next().and_then(|s| s.parse::<f64>().ok()) else {
+                return "err wait needs seconds".to_owned();
+            };
+            if secs.is_finite() && secs > 0.0 {
+                std::thread::sleep(Duration::from_secs_f64(secs));
+            }
+            format!("ok wait {secs}")
+        }
+        "quit" => {
+            std::process::exit(0);
+        }
+        other => format!("err unknown command {other:?}"),
+    }
+}
+
+/// Type a string, returning `(typed, unmapped)` character counts.
+fn type_text(view_ptr: usize, text: &str) -> (usize, usize) {
+    let mut typed = 0;
+    let mut unmapped = 0;
+    for c in text.chars() {
+        match input::char_to_stroke(c) {
+            Some(stroke) => {
+                press_key(view_ptr, stroke.code, stroke.shift);
+                typed += 1;
+            }
+            None => unmapped += 1,
+        }
+    }
+    (typed, unmapped)
+}
+
+/// Press a key (down then up), holding Shift around it when requested.
+fn press_key(view_ptr: usize, code: u16, shift: bool) {
+    on_main(view_ptr, move |view| {
+        if shift {
+            input::send_event(view, NSEventType::KeyDown, input::SHIFT);
+        }
+        input::send_event(view, NSEventType::KeyDown, code);
+    });
+    std::thread::sleep(KEY_GAP_DOWN);
+    on_main(view_ptr, move |view| {
+        input::send_event(view, NSEventType::KeyUp, code);
+        if shift {
+            input::send_event(view, NSEventType::KeyUp, input::SHIFT);
+        }
+    });
+    std::thread::sleep(KEY_GAP_AFTER);
+}
+
+/// Screenshot the guest framebuffer on the main queue and return bytes written.
+fn shot(view_ptr: usize, path: &Path) -> Result<usize, Error> {
+    let mut result: Result<usize, Error> = Err(Error::NoFramebuffer);
+    // `exec_sync` blocks until the block finishes, so borrowing `result` and
+    // `path` across the queue boundary is sound (no `'static` needed).
+    DispatchQueue::main().exec_sync(|| {
+        let view: &VZVirtualMachineView = unsafe { &*(view_ptr as *const VZVirtualMachineView) };
+        result = capture(view, path);
+    });
+    result
+}
+
+/// Run `f` on the main queue with a re-borrow of the leaked view, blocking until
+/// it returns. `AppKit` and the VM view must be touched only on the main thread.
+fn on_main(view_ptr: usize, f: impl FnOnce(&VZVirtualMachineView) + Send) {
+    DispatchQueue::main().exec_sync(move || {
+        let view: &VZVirtualMachineView = unsafe { &*(view_ptr as *const VZVirtualMachineView) };
+        f(view);
+    });
+}

--- a/packages/macos-vm/src/input.rs
+++ b/packages/macos-vm/src/input.rs
@@ -1,0 +1,210 @@
+//! Synthetic keyboard input to a macOS guest with no host event system and no
+//! host cursor: we build `NSEvent` key events and hand them straight to the
+//! `VZVirtualMachineView`, which forwards them to the guest's USB keyboard
+//! device. Modifiers are sent as their own key events (we never set `AppKit`
+//! modifier flags); the guest keyboard device reads the HID key reports. Key-code
+//! map and technique from github.com/thecrypticace/vzautomation.
+
+use objc2_app_kit::{NSEvent, NSEventModifierFlags, NSEventType};
+use objc2_foundation::{NSPoint, NSString};
+use objc2_virtualization::VZVirtualMachineView;
+
+/// `kVK_Shift`: held around a keystroke to type its shifted character.
+pub const SHIFT: u16 = 0x38;
+
+/// One key in a keystroke: a Carbon virtual key code and whether Shift is held.
+#[derive(Clone, Copy)]
+pub struct KeyStroke {
+    pub code: u16,
+    pub shift: bool,
+}
+
+/// Send a single key-down or key-up to the guest. Must run on the main thread
+/// (the VM view's thread). A null event (`AppKit` declined to build one) is a
+/// no-op rather than a panic.
+pub fn send_event(view: &VZVirtualMachineView, event_type: NSEventType, keycode: u16) {
+    let empty = NSString::from_str("");
+    let window_number = view.window().map_or(0, |window| window.windowNumber());
+    let event = NSEvent::keyEventWithType_location_modifierFlags_timestamp_windowNumber_context_characters_charactersIgnoringModifiers_isARepeat_keyCode(
+        event_type,
+        NSPoint::new(0.0, 0.0),
+        NSEventModifierFlags::empty(),
+        0.0,
+        window_number,
+        None,
+        &empty,
+        &empty,
+        false,
+        keycode,
+    );
+    let Some(event) = event else { return };
+    if event_type == NSEventType::KeyDown {
+        view.keyDown(&event);
+    } else {
+        view.keyUp(&event);
+    }
+}
+
+/// Click the guest at view point `(x, y)` in `AppKit` window coordinates
+/// (bottom-left origin). Sends a left mouse down then up; the screen-coordinate
+/// pointing device maps the location to the guest's absolute cursor, so only the
+/// guest cursor moves. Must run on the main thread.
+pub fn click(view: &VZVirtualMachineView, x: f64, y: f64) {
+    send_mouse(view, NSEventType::LeftMouseDown, x, y, 1.0);
+    send_mouse(view, NSEventType::LeftMouseUp, x, y, 0.0);
+}
+
+fn send_mouse(view: &VZVirtualMachineView, event_type: NSEventType, x: f64, y: f64, pressure: f32) {
+    let window_number = view.window().map_or(0, |window| window.windowNumber());
+    let event = NSEvent::mouseEventWithType_location_modifierFlags_timestamp_windowNumber_context_eventNumber_clickCount_pressure(
+        event_type,
+        NSPoint::new(x, y),
+        NSEventModifierFlags::empty(),
+        0.0,
+        window_number,
+        None,
+        0,
+        1,
+        pressure,
+    );
+    let Some(event) = event else { return };
+    if event_type == NSEventType::LeftMouseDown {
+        view.mouseDown(&event);
+    } else {
+        view.mouseUp(&event);
+    }
+}
+
+/// Carbon virtual key code for a named key (navigation, editing, modifiers).
+/// Modifiers are returned too so the driver can hold them with `down`/`up`.
+pub fn named_key(name: &str) -> Option<u16> {
+    let code = match name {
+        "return" | "enter" => 0x24,
+        "tab" => 0x30,
+        "space" => 0x31,
+        "delete" | "backspace" => 0x33,
+        "escape" | "esc" => 0x35,
+        "forward-delete" => 0x75,
+        "up" => 0x7E,
+        "down" => 0x7D,
+        "left" => 0x7B,
+        "right" => 0x7C,
+        "home" => 0x73,
+        "end" => 0x77,
+        "pageup" => 0x74,
+        "pagedown" => 0x79,
+        "f1" => 0x7A,
+        "f2" => 0x78,
+        "f3" => 0x63,
+        "f4" => 0x76,
+        "f5" => 0x60,
+        "f6" => 0x61,
+        "f7" => 0x62,
+        "f8" => 0x64,
+        "f9" => 0x65,
+        "f10" => 0x6D,
+        "f11" => 0x67,
+        "f12" => 0x6F,
+        // Modifiers, held via `down <mod>` / released via `up <mod>`.
+        "command" | "cmd" => 0x37,
+        "shift" => 0x38,
+        "option" | "alt" => 0x3A,
+        "control" | "ctrl" => 0x3B,
+        "function" | "fn" => 0x3F,
+        _ => return None,
+    };
+    Some(code)
+}
+
+/// Key code for an ASCII letter `a`..=`z`.
+const fn letter_code(lower: char) -> Option<u16> {
+    let code = match lower {
+        'a' => 0x00,
+        'b' => 0x0B,
+        'c' => 0x08,
+        'd' => 0x02,
+        'e' => 0x0E,
+        'f' => 0x03,
+        'g' => 0x05,
+        'h' => 0x04,
+        'i' => 0x22,
+        'j' => 0x26,
+        'k' => 0x28,
+        'l' => 0x25,
+        'm' => 0x2E,
+        'n' => 0x2D,
+        'o' => 0x1F,
+        'p' => 0x23,
+        'q' => 0x0C,
+        'r' => 0x0F,
+        's' => 0x01,
+        't' => 0x11,
+        'u' => 0x20,
+        'v' => 0x09,
+        'w' => 0x0D,
+        'x' => 0x07,
+        'y' => 0x10,
+        'z' => 0x06,
+        _ => return None,
+    };
+    Some(code)
+}
+
+/// The keystroke that types a single character, or `None` if unmapped. Covers
+/// printable ASCII (letters, digits, and the US-layout symbols), enough to type
+/// usernames, passwords, and shell commands.
+pub fn char_to_stroke(c: char) -> Option<KeyStroke> {
+    if c.is_ascii_alphabetic() {
+        let code = letter_code(c.to_ascii_lowercase())?;
+        return Some(KeyStroke { code, shift: c.is_ascii_uppercase() });
+    }
+    let (code, shift) = match c {
+        '1' => (0x12, false),
+        '!' => (0x12, true),
+        '2' => (0x13, false),
+        '@' => (0x13, true),
+        '3' => (0x14, false),
+        '#' => (0x14, true),
+        '4' => (0x15, false),
+        '$' => (0x15, true),
+        '5' => (0x17, false),
+        '%' => (0x17, true),
+        '6' => (0x16, false),
+        '^' => (0x16, true),
+        '7' => (0x1A, false),
+        '&' => (0x1A, true),
+        '8' => (0x1C, false),
+        '*' => (0x1C, true),
+        '9' => (0x19, false),
+        '(' => (0x19, true),
+        '0' => (0x1D, false),
+        ')' => (0x1D, true),
+        ' ' => (0x31, false),
+        '\t' => (0x30, false),
+        '\n' => (0x24, false),
+        '-' => (0x1B, false),
+        '_' => (0x1B, true),
+        '=' => (0x18, false),
+        '+' => (0x18, true),
+        '[' => (0x21, false),
+        '{' => (0x21, true),
+        ']' => (0x1E, false),
+        '}' => (0x1E, true),
+        '\\' => (0x2A, false),
+        '|' => (0x2A, true),
+        ';' => (0x29, false),
+        ':' => (0x29, true),
+        '\'' => (0x27, false),
+        '"' => (0x27, true),
+        ',' => (0x2B, false),
+        '<' => (0x2B, true),
+        '.' => (0x2F, false),
+        '>' => (0x2F, true),
+        '/' => (0x2C, false),
+        '?' => (0x2C, true),
+        '`' => (0x32, false),
+        '~' => (0x32, true),
+        _ => return None,
+    };
+    Some(KeyStroke { code, shift })
+}

--- a/packages/macos-vm/src/macguest.rs
+++ b/packages/macos-vm/src/macguest.rs
@@ -19,22 +19,23 @@ use objc2::{AllocAnyThread, MainThreadMarker};
 use objc2_app_kit::{
     NSApplication, NSApplicationActivationPolicy, NSBackingStoreType, NSWindow, NSWindowStyleMask,
 };
-use objc2_foundation::{NSArray, NSData, NSError, NSPoint, NSRect, NSSize};
+use objc2_foundation::{NSArray, NSData, NSError, NSPoint, NSRect, NSSize, NSString};
 use objc2_io_surface::{IOSurface, IOSurfaceLockOptions, IOSurfaceRef};
 // Named explicitly so the dependency is a direct, visible use (the type is
 // otherwise only reachable through `NSView::layer()`'s return type).
 use objc2_quartz_core::CALayer;
 use objc2_virtualization::{
-    VZBootLoader, VZDiskImageStorageDeviceAttachment, VZGraphicsDeviceConfiguration,
-    VZKeyboardConfiguration, VZMacAuxiliaryStorage, VZMacGraphicsDeviceConfiguration,
-    VZMacGraphicsDisplayConfiguration, VZMacHardwareModel, VZMacMachineIdentifier,
-    VZMacAuxiliaryStorageInitializationOptions, VZMacOSBootLoader, VZMacOSInstaller,
-    VZMacOSRestoreImage, VZMacPlatformConfiguration, VZNATNetworkDeviceAttachment,
-    VZNetworkDeviceConfiguration, VZPlatformConfiguration, VZPointingDeviceConfiguration,
+    VZBootLoader, VZDirectoryShare, VZDirectorySharingDeviceConfiguration,
+    VZDiskImageStorageDeviceAttachment, VZGraphicsDeviceConfiguration, VZKeyboardConfiguration,
+    VZMacAuxiliaryStorage, VZMacGraphicsDeviceConfiguration, VZMacGraphicsDisplayConfiguration,
+    VZMacHardwareModel, VZMacMachineIdentifier, VZMacAuxiliaryStorageInitializationOptions,
+    VZMacOSBootLoader, VZMacOSInstaller, VZMacOSRestoreImage, VZMacPlatformConfiguration,
+    VZNATNetworkDeviceAttachment, VZNetworkDeviceConfiguration, VZPlatformConfiguration,
+    VZPointingDeviceConfiguration, VZSharedDirectory, VZSingleDirectoryShare,
     VZStorageDeviceConfiguration, VZUSBKeyboardConfiguration,
     VZUSBScreenCoordinatePointingDeviceConfiguration, VZVirtioBlockDeviceConfiguration,
-    VZVirtioNetworkDeviceConfiguration, VZVirtualMachine, VZVirtualMachineConfiguration,
-    VZVirtualMachineView,
+    VZVirtioFileSystemDeviceConfiguration, VZVirtioNetworkDeviceConfiguration, VZVirtualMachine,
+    VZVirtualMachineConfiguration, VZVirtualMachineView,
 };
 
 use crate::imp::{Error, file_url, ns_error_message};
@@ -42,23 +43,39 @@ use crate::imp::{Error, file_url, ns_error_message};
 /// `kCVPixelFormatType_32BGRA` ('BGRA'): the layout the `IOSurface` read assumes.
 const PIXEL_FORMAT_BGRA: u32 = 0x4247_5241;
 
+/// A host directory shared into the guest over virtio-fs.
+pub struct DirShare {
+    pub tag: ShareTag,
+    pub host_dir: PathBuf,
+    pub read_only: bool,
+}
+
+/// The virtio-fs mount tag. `Automount` uses the special macOS tag that mounts
+/// the share automatically at `/Volumes/My Shared Files` with no guest-side
+/// `mount`; `Named` requires the guest to mount the tag explicitly.
+pub enum ShareTag {
+    Automount,
+    Named(String),
+}
+
 /// Parameters for booting a macOS guest and screenshotting it.
 pub struct MacBootScreenshot {
     pub bundle: PathBuf,
     pub out_prefix: PathBuf,
     pub seconds: u64,
+    pub shares: Vec<DirShare>,
 }
 
-pub fn boot_macos_screenshot(boot: MacBootScreenshot) -> Result<(), Error> {
-    let MacBootScreenshot {
-        bundle,
-        out_prefix,
-        seconds,
-    } = boot;
-
-    let mtm = MainThreadMarker::new().ok_or(Error::NotMainThread)?;
-
-    let config = build_macos_config(&bundle)?;
+/// Build the off-screen window + `VZVirtualMachineView`, create the VM, and
+/// start it. Returns the view (retained; the caller leaks it for the process
+/// lifetime and drives the `AppKit` run loop). Shared by the screenshot path and
+/// the interactive driver, which differ only in what they do with the run loop.
+pub fn start_guest_offscreen(
+    mtm: MainThreadMarker,
+    bundle: &Path,
+    shares: &[DirShare],
+) -> Result<Retained<VZVirtualMachineView>, Error> {
+    let config = build_macos_config(bundle, shares)?;
     if let Err(error) = unsafe { config.validateWithError() } {
         return Err(Error::InvalidConfiguration {
             message: ns_error_message(&error),
@@ -100,12 +117,26 @@ pub fn boot_macos_screenshot(boot: MacBootScreenshot) -> Result<(), Error> {
         }
     });
     // We hold a MainThreadMarker, so we are on the main thread (the VM's queue);
-    // start directly. `app.run()` below drives the main run loop, which services
-    // the main dispatch queue so the completion handler fires. `vm` and
-    // `completion` live for the process because this function never returns
-    // (app.run blocks until the capture thread exits the process); `vm_view`
-    // retains the VM as well.
+    // start directly. The caller's `app.run()` drives the main run loop, which
+    // services the main dispatch queue so the completion handler fires. The
+    // window retains the view, which retains the VM; the caller keeps the view
+    // (and thus the VM) alive for the process by leaking it.
     unsafe { vm.startWithCompletionHandler(&completion) };
+    std::mem::forget(window);
+    std::mem::forget(completion);
+    Ok(vm_view)
+}
+
+pub fn boot_macos_screenshot(boot: MacBootScreenshot) -> Result<(), Error> {
+    let MacBootScreenshot {
+        bundle,
+        out_prefix,
+        seconds,
+        shares,
+    } = boot;
+
+    let mtm = MainThreadMarker::new().ok_or(Error::NotMainThread)?;
+    let vm_view = start_guest_offscreen(mtm, &bundle, &shares)?;
 
     // Tick times for screenshots: the hardcoded ticks below the deadline, then
     // the deadline itself, so a short `--seconds` stops on time and always takes
@@ -114,14 +145,14 @@ pub fn boot_macos_screenshot(boot: MacBootScreenshot) -> Result<(), Error> {
     shots.push(seconds);
     schedule_captures(vm_view, out_prefix, shots);
 
-    // VZVirtualMachineView needs the AppKit run loop to build its layer tree and
+    // VZVirtualMachineView needs the `AppKit` run loop to build its layer tree and
     // receive guest frames; the capture thread exits the process when done.
-    app.run();
+    NSApplication::sharedApplication(mtm).run();
     Ok(())
 }
 
-/// Sleep between ticks and hop each capture onto the main queue (AppKit/IOSurface
-/// access must be on the main thread), then exit the process.
+/// Sleep between ticks and hop each capture onto the main queue (`AppKit` and
+/// `IOSurface` access must be on the main thread), then exit the process.
 fn schedule_captures(view: Retained<VZVirtualMachineView>, out_prefix: PathBuf, shots: Vec<u64>) {
     // The view is not `Send`, so move only the raw pointer and re-borrow on the
     // main queue, where it is valid. The view is leaked (lives for the process)
@@ -161,7 +192,7 @@ fn frame_contents(view: &VZVirtualMachineView) -> Option<Retained<AnyObject>> {
 }
 
 /// Read the framebuffer `IOSurface` (BGRA) and encode a PNG.
-fn capture(view: &VZVirtualMachineView, path: &Path) -> Result<usize, Error> {
+pub fn capture(view: &VZVirtualMachineView, path: &Path) -> Result<usize, Error> {
     let contents = frame_contents(view).ok_or(Error::NoFramebuffer)?;
     // Verify the layer contents really is an IOSurface before any unsafe access.
     let surface_obj: Retained<IOSurface> =
@@ -310,7 +341,7 @@ fn start_install(bundle: &Path, ipsw: &Path, hw_data: &[u8], disk_gib: u64) -> R
     }
     .map_err(|e| Error::Bundle { message: format!("create aux storage: {}", ns_error_message(&e)) })?;
 
-    let config = build_macos_config(bundle)?;
+    let config = build_macos_config(bundle, &[])?;
     if let Err(error) = unsafe { config.validateWithError() } {
         return Err(Error::InvalidConfiguration {
             message: ns_error_message(&error),
@@ -343,7 +374,10 @@ fn start_install(bundle: &Path, ipsw: &Path, hw_data: &[u8], disk_gib: u64) -> R
     Ok(())
 }
 
-fn build_macos_config(bundle: &Path) -> Result<Retained<VZVirtualMachineConfiguration>, Error> {
+fn build_macos_config(
+    bundle: &Path,
+    shares: &[DirShare],
+) -> Result<Retained<VZVirtualMachineConfiguration>, Error> {
     let hw_data = std::fs::read(bundle.join("hardware-model.bin"))
         .map_err(|e| Error::Bundle { message: format!("hardware-model.bin: {e}") })?;
     let id_data = std::fs::read(bundle.join("machine-id.bin"))
@@ -410,6 +444,13 @@ fn build_macos_config(bundle: &Path) -> Result<Retained<VZVirtualMachineConfigur
     let keyboard = unsafe { VZUSBKeyboardConfiguration::new() };
     let pointing = unsafe { VZUSBScreenCoordinatePointingDeviceConfiguration::new() };
 
+    // virtio-fs directory shares (held in a Vec so the retained devices outlive
+    // the upcast refs handed to `setDirectorySharingDevices`).
+    let fs_devices = shares
+        .iter()
+        .map(build_fs_device)
+        .collect::<Result<Vec<_>, Error>>()?;
+
     let config = unsafe { VZVirtualMachineConfiguration::new() };
     let platform_ref: &VZPlatformConfiguration = &platform;
     let boot_ref: &VZBootLoader = &boot_loader;
@@ -429,5 +470,54 @@ fn build_macos_config(bundle: &Path) -> Result<Retained<VZVirtualMachineConfigur
         config.setKeyboards(&NSArray::from_slice(&[kbd_ref]));
         config.setPointingDevices(&NSArray::from_slice(&[pt_ref]));
     }
+    if !fs_devices.is_empty() {
+        let dev_refs: Vec<&VZDirectorySharingDeviceConfiguration> = fs_devices
+            .iter()
+            .map(|device| {
+                let device_ref: &VZDirectorySharingDeviceConfiguration = device;
+                device_ref
+            })
+            .collect();
+        unsafe { config.setDirectorySharingDevices(&NSArray::from_slice(&dev_refs)) };
+    }
     Ok(config)
+}
+
+/// Build one virtio-fs device for a shared host directory.
+fn build_fs_device(
+    share: &DirShare,
+) -> Result<Retained<VZVirtioFileSystemDeviceConfiguration>, Error> {
+    let tag = match &share.tag {
+        ShareTag::Automount => unsafe {
+            VZVirtioFileSystemDeviceConfiguration::macOSGuestAutomountTag()
+        },
+        ShareTag::Named(name) => {
+            let tag = NSString::from_str(name);
+            unsafe { VZVirtioFileSystemDeviceConfiguration::validateTag_error(&tag) }.map_err(
+                |error| Error::Bundle {
+                    message: format!("invalid share tag {name:?}: {}", ns_error_message(&error)),
+                },
+            )?;
+            tag
+        }
+    };
+    let dir_url = file_url(&share.host_dir);
+    let shared = unsafe {
+        VZSharedDirectory::initWithURL_readOnly(
+            VZSharedDirectory::alloc(),
+            &dir_url,
+            share.read_only,
+        )
+    };
+    let single =
+        unsafe { VZSingleDirectoryShare::initWithDirectory(VZSingleDirectoryShare::alloc(), &shared) };
+    let device = unsafe {
+        VZVirtioFileSystemDeviceConfiguration::initWithTag(
+            VZVirtioFileSystemDeviceConfiguration::alloc(),
+            &tag,
+        )
+    };
+    let share_ref: &VZDirectoryShare = &single;
+    unsafe { device.setShare(Some(share_ref)) };
+    Ok(device)
 }

--- a/packages/macos-vm/src/main.rs
+++ b/packages/macos-vm/src/main.rs
@@ -93,6 +93,25 @@ enum Command {
         /// Stop after this many seconds.
         #[arg(long, default_value_t = 90)]
         seconds: u64,
+        /// Share a host directory into the guest over virtio-fs, repeatable.
+        /// Spec: `TAG=HOSTDIR` (append `:ro` for read-only). Tag `auto` uses the
+        /// macOS automount tag, mounting at `/Volumes/My Shared Files`.
+        #[arg(long = "share", value_name = "TAG=HOSTDIR")]
+        shares: Vec<String>,
+    },
+    /// Boot an installed macOS guest fully off-screen and drive it from stdin:
+    /// synthetic keyboard input and on-demand framebuffer screenshots, with no
+    /// host cursor or visible window. Reads newline commands
+    /// (`key`/`down`/`up`/`type`/`wait`/`shot`/`quit`) and acks each on stdout.
+    DriveMacos {
+        /// Guest bundle directory.
+        #[arg(long)]
+        bundle: std::path::PathBuf,
+        /// Share a host directory into the guest over virtio-fs, repeatable.
+        /// Spec: `TAG=HOSTDIR` (append `:ro` for read-only). Tag `auto` uses the
+        /// macOS automount tag, mounting at `/Volumes/My Shared Files`.
+        #[arg(long = "share", value_name = "TAG=HOSTDIR")]
+        shares: Vec<String>,
     },
 }
 
@@ -211,6 +230,12 @@ fn main() -> ExitCode {
 }
 
 #[cfg(target_os = "macos")]
+mod drive;
+
+#[cfg(target_os = "macos")]
+mod input;
+
+#[cfg(target_os = "macos")]
 mod macguest;
 
 #[cfg(target_os = "macos")]
@@ -305,12 +330,52 @@ mod imp {
                 bundle,
                 out_prefix,
                 seconds,
+                shares,
             } => crate::macguest::boot_macos_screenshot(crate::macguest::MacBootScreenshot {
                 bundle,
                 out_prefix,
                 seconds,
+                shares: parse_shares(&shares)?,
             }),
+            Command::DriveMacos { bundle, shares } => {
+                crate::drive::drive_macos(crate::drive::DriveMacos {
+                    bundle,
+                    shares: parse_shares(&shares)?,
+                })
+            }
         }
+    }
+
+    /// Parse `--share TAG=HOSTDIR[:ro]` specs into [`DirShare`]s. Tag `auto` maps
+    /// to the macOS automount tag.
+    fn parse_shares(specs: &[String]) -> Result<Vec<crate::macguest::DirShare>, Error> {
+        use crate::macguest::{DirShare, ShareTag};
+
+        specs
+            .iter()
+            .map(|spec| {
+                let (tag, dir) = spec.split_once('=').ok_or_else(|| Error::Bundle {
+                    message: format!("share {spec:?} must be TAG=HOSTDIR"),
+                })?;
+                let (dir, read_only) =
+                    dir.strip_suffix(":ro").map_or((dir, false), |dir| (dir, true));
+                if dir.is_empty() {
+                    return Err(Error::Bundle {
+                        message: format!("share {spec:?} has an empty host directory"),
+                    });
+                }
+                let tag = if tag == "auto" {
+                    ShareTag::Automount
+                } else {
+                    ShareTag::Named(tag.to_owned())
+                };
+                Ok(DirShare {
+                    tag,
+                    host_dir: PathBuf::from(dir),
+                    read_only,
+                })
+            })
+            .collect()
     }
 
     fn info() -> Result<(), Error> {


### PR DESCRIPTION
## What

Adds two reusable primitives to `macos-vm`, then uses them to run a real GUI app inside a macOS guest and screenshot it, all off-screen with the host cursor untouched.

- **`drive-macos`**: boots an installed macOS guest fully off-screen and reads newline commands from stdin to drive it, acking each on stdout:
  - `key <name> [count]`, `down <name>`, `up <name>` (named keys incl. arrows, `f1`..`f12`, modifiers)
  - `type <text>` (US-layout printable ASCII)
  - `click <fx> <fy>` (left-click at a `0..1` fraction of the display, top-left origin)
  - `wait <seconds>`, `shot <path>`, `quit`

  Synthetic events are handed straight to the guest's USB keyboard and screen-coordinate pointing device via `NSEvent`s on the `VZVirtualMachineView`, so the host event system and cursor are never involved. The ack-per-command design lets a controller drive the guest in lockstep (capture frame → locate control → click → recapture).

- **`--share TAG=HOSTDIR[:ro]`** (on `boot-macos` and `drive-macos`): shares a host directory into the guest over virtio-fs. Tag `auto` uses the macOS automount tag, mounting at `/Volumes/My Shared Files`.

`input.rs` (key-code map + `NSEvent` injection) and `drive.rs` (the stdin loop) are new; `macguest.rs` gains the virtio-fs device wiring and a shared `start_guest_offscreen` used by both boot modes.

## Proven end to end

On macOS 26.5 / Apple M5 Max, fully off-screen (host cursor never moved):

1. Boot an installed macOS guest off-screen.
2. Drive Setup Assistant to a logged-in desktop with `click`/`type`/`key`.
3. Share the `bossbar-overlay` (a winit + wgpu app) into the guest with `--share auto=...`.
4. Launch it from `/Volumes/My Shared Files` and screenshot the running overlay — Minecraft boss bars render on the guest desktop.

(Once at a desktop, Apple ID / Screen Time screens hang without working guest internet; for a usable desktop it is simpler to mark Setup Assistant done offline by editing the guest disk — see the README. The screen-driving primitives here are the reusable part.)

## Validation

- `nix build .#macos-vm` ✅
- clippy clean for `macos-vm` (pedantic + nursery) ✅
- end-to-end run captured off-screen ✅

---
Made with AI assistance (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `drive-macos` CLI command to boot and control a macOS guest off-screen with virtio-fs sharing
> - Adds a new `drive-macos` subcommand in [main.rs](https://github.com/indexable-inc/index/pull/436/files#diff-b672fe3e1d10462de4efa7a75a630206a1942f074e401e2d13f411ecb6e3c47c) that boots an installed macOS guest off-screen and drives it via a stdin command protocol (key/down/up/type/click/wait/shot/quit), writing lockstep acks to stdout.
> - Implements keyboard and mouse input injection in [input.rs](https://github.com/indexable-inc/index/pull/436/files#diff-f6fabb00d36a0b17a7d76aa331064f68422e675c8584f2849135ce6b1fc0b0a3) by synthesizing `NSEvent` key and mouse events dispatched directly to `VZVirtualMachineView`, with a `char_to_stroke` mapper for printable ASCII on a US layout.
> - Adds virtio-fs directory sharing support via `--share TAG=HOSTDIR[:ro]` to both `boot-macos` and `drive-macos`, building `VZVirtioFileSystemDeviceConfiguration` devices in [macguest.rs](https://github.com/indexable-inc/index/pull/436/files#diff-bf375e8c838424f343aea16a54b5727288a85d2fc009d75e928c51a796933b94).
> - Extracts `start_guest_offscreen` and makes `capture` public in [macguest.rs](https://github.com/indexable-inc/index/pull/436/files#diff-bf375e8c838424f343aea16a54b5727288a85d2fc009d75e928c51a796933b94) so the driver and screenshot paths share the same boot logic.
> - Risk: key events use fixed `KEY_GAP_DOWN`/`KEY_GAP_AFTER` timing delays to avoid HID coalescing; excessively fast command streams may still drop events on slower guests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93e1465.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->