### PR TITLE
fix(bossbar-overlay): raise a hovered bar above its siblings

### DIFF
--- a/packages/bossbar-overlay/app/Cargo.lock
+++ b/packages/bossbar-overlay/app/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "glam",
  "glyphon",
  "image",
+ "objc2-app-kit",
  "pollster",
  "rusqlite",
  "wgpu",

--- a/packages/bossbar-overlay/app/Cargo.toml
+++ b/packages/bossbar-overlay/app/Cargo.toml
@@ -28,6 +28,13 @@ dirs = "6"
 # 2D vectors for bar positions, instead of bare (f64, f64).
 glam = "0.30"
 
+# macOS: raise a hovered bar's window above its always-on-top siblings without
+# taking keyboard focus (`-[NSWindow orderFrontRegardless]`), so its pop-down
+# panel paints over the neighbouring bars. These features and versions are a
+# subset of what winit 0.30 already enables, so this pulls in no extra crate.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit = { version = "0.2.2", features = ["NSResponder", "NSWindow"] }
+
 [profile.release]
 # A desktop HUD: trim the binary, no need for fat debug info.
 opt-level = "s"

--- a/packages/bossbar-overlay/app/src/overlay.rs
+++ b/packages/bossbar-overlay/app/src/overlay.rs
@@ -85,6 +85,40 @@ fn open_url(url: &str) {
     }
 }
 
+/// Raise `window` above its same-level siblings without taking keyboard focus,
+/// so a hovered bar's pop-down panel paints over the neighbouring bars instead
+/// of slipping under them. Every bar is its own `WindowLevel::AlwaysOnTop`
+/// window, and windows sharing one level stack by front-to-back order, so a bar
+/// created earlier would otherwise expand beneath a later one.
+///
+/// `-[NSWindow orderFrontRegardless]` reorders the window without making it key,
+/// so the user's keyboard focus stays where it was: a passive HUD must never
+/// steal it, which rules out winit's `focus_window`. winit exposes no
+/// non-activating raise, so reach the `NSWindow` through the raw AppKit handle.
+#[cfg(target_os = "macos")]
+fn raise_to_front(window: &Window) {
+    use objc2_app_kit::NSView;
+    use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    let Ok(handle) = window.window_handle() else {
+        return;
+    };
+    let RawWindowHandle::AppKit(appkit) = handle.as_raw() else {
+        return;
+    };
+    // SAFETY: `ns_view` points at the live NSView backing this winit window, and
+    // we run inside the winit event loop on the main thread, as AppKit requires.
+    let view: &NSView = unsafe { appkit.ns_view.cast().as_ref() };
+    if let Some(ns_window) = view.window() {
+        unsafe { ns_window.orderFrontRegardless() };
+    }
+}
+
+/// Non-macOS: X11 and Wayland give an app no non-activating raise among
+/// same-level always-on-top windows, so leave stacking to the compositor.
+#[cfg(not(target_os = "macos"))]
+fn raise_to_front(_window: &Window) {}
+
 /// GPU state shared by every bar window: one device/queue and one renderer
 /// (pipeline, sprite textures, font). Each window only owns its surface.
 struct GpuCore {
@@ -533,6 +567,9 @@ impl ApplicationHandler<Vec<BossBar>> for App {
                 if let Some(win) = self.wins.get_mut(&id) {
                     win.hovered = true;
                     win.window.set_cursor(CursorIcon::Grab);
+                    // Bring this bar above its siblings so its pop-down panel
+                    // covers them instead of unfolding underneath.
+                    raise_to_front(&win.window);
                 }
                 self.render_id(id);
             }

--- a/packages/bossbar-overlay/app/src/overlay.rs
+++ b/packages/bossbar-overlay/app/src/overlay.rs
@@ -106,8 +106,10 @@ fn raise_to_front(window: &Window) {
     let RawWindowHandle::AppKit(appkit) = handle.as_raw() else {
         return;
     };
-    // SAFETY: `ns_view` points at the live NSView backing this winit window, and
-    // we run inside the winit event loop on the main thread, as AppKit requires.
+    // SAFETY: `ns_view` points at the live NSView backing this winit window, kept
+    // alive for the whole call by the caller's `Arc<Window>`, so the `&NSView`
+    // borrow stays valid (it is dropped before we return). We run inside the
+    // winit event loop on the main thread, as these MainThreadOnly types require.
     let view: &NSView = unsafe { appkit.ns_view.cast().as_ref() };
     if let Some(ns_window) = view.window() {
         unsafe { ns_window.orderFrontRegardless() };


### PR DESCRIPTION
## What

Each boss bar is its own transparent `WindowLevel::AlwaysOnTop` window. On hover the window grows downward to reveal its description panel, but because windows sharing one level stack by front-to-back order, that panel (and the bar itself) painted **under** the neighbouring bar's window. Hovering a bar now raises it above its siblings so it is always on top.

## How

On `CursorEntered`, call `-[NSWindow orderFrontRegardless]` on the hovered bar's window, reached through winit's raw AppKit window handle. `orderFrontRegardless` reorders the window without making it key, so a passive HUD never steals the user's keyboard focus (which rules out winit's `focus_window`). Non-macOS is a no-op: X11/Wayland give an app no non-activating raise among same-level always-on-top windows.

`objc2-app-kit` is added as a macOS-only dependency; its version and features (`NSResponder`, `NSWindow`) are a subset of what `winit` 0.30 already pulls in, so no new crate enters the build.

## Validation

- `nix build .#bossbar-overlay` passes (compile gate, including the new macOS objc2 code).
- Ran the patched binary against an isolated `BOSSBAR_DB`; confirmed it renders overlapping always-on-top bar windows. The full hover before/after capture was not completed because the workstation was in active interactive use at the time.

---
Made with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise a hovered bossbar window above its always-on-top siblings on macOS
> Adds a `raise_to_front` function in [overlay.rs](https://github.com/indexable-inc/index/pull/438/files#diff-33da11ba47e085c9f1f9c87457840f96d03a66a6a925c69a6273ef76e99e251f) that calls `orderFrontRegardless()` on the backing `NSWindow` when the cursor enters a bar window. This reorders the window above same-level always-on-top siblings without taking keyboard focus. Non-macOS platforms get a no-op stub.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7a2734.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->