### PR TITLE
fix(ci): raise flake-check eval-worker memory (rust-package-tests OOM)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -70,10 +70,22 @@ jobs:
       # `--no-nom` keeps plain CI logs; `--no-link` avoids leaving result
       # symlinks. It exits nonzero iff a build or eval fails, which is the gate.
       # Pinned by commit to nix-fast-build 1.5.0.
+      #
+      # `--eval-max-memory-size` raises the per-worker eval-heap cap above
+      # nix-eval-jobs' 4096 MiB default: a single heavy attribute
+      # (`rust-package-tests`, which evaluates every workspace crate's test unit)
+      # grew past 4 GiB as the workspace did and got SIGKILLed mid-eval ("worker
+      # got killed by SIGKILL, maybe memory limit reached"), failing the whole
+      # check. `--eval-workers` caps concurrent evaluators (default is nproc, 128
+      # on this host) so the higher per-worker ceiling cannot multiply into host
+      # memory pressure when many CI jobs share the runner; 16 already collapses
+      # eval toward the slowest single attribute (see the schema-eval step below).
       - name: Build all flake checks
         run: |
           nix run github:Mic92/nix-fast-build/7f185e0ec37b65b4730f892e0de9a831b0610f3a -- \
             --flake ".#checks.x86_64-linux" \
+            --eval-max-memory-size 8192 \
+            --eval-workers 16 \
             --skip-cached \
             --no-nom \
             --no-link \


### PR DESCRIPTION
## Problem

`main`'s `Check` workflow has been failing since commit `416198c` with:

```
error: while reading result for attrPath 'rust-package-tests', evaluation worker got killed by SIGKILL, maybe memory limit reached?
ERROR:nix_fast_build:nix-eval-jobs exited with 1
```

The `nix-fast-build` step over `.#checks.x86_64-linux` evaluates with `nix-eval-jobs`' default **4096 MiB per-worker** eval-heap cap. The `rust-package-tests` attribute evaluates every workspace crate's test unit in one attr; as the workspace grew it crossed 4 GiB, so the eval worker is killed mid-evaluation and the whole check fails. The flake eval cache can't amortize it (keyed per-commit, always cold on CI), so it reproduces on every run and every re-run.

## Fix

- `--eval-max-memory-size 8192` — raise the per-worker eval-heap cap above the 4096 default so the one heavy attribute can finish.
- `--eval-workers 16` — cap concurrent evaluators (default is nproc = 128 here) so the higher per-worker ceiling can't multiply into host memory pressure on this shared runner. 16 already collapses eval toward the slowest single attribute (the sibling schema-eval step uses 16 for the same reason).

This is a pure CI-config change; the failing attribute itself is unchanged. The right long-term fix is making the flake check use an eval cache (tracked separately), which would remove the cold re-eval cost entirely.

This PR's own `pull_request` Check run exercises the patched workflow, so a green check here confirms the fix.

---
Made with AI assistance (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise eval worker memory and limit worker count in flake-check CI to fix OOM
> Adds `--eval-max-memory-size 8192` and `--eval-workers 16` flags to the `nix-fast-build` invocation in [check.yml](.github/workflows/check.yml) to prevent out-of-memory crashes in the `rust-package-tests` flake check. The default `nix-eval-jobs` worker count is too high for runner concurrency, causing heap exhaustion; capping workers at 16 and raising the per-worker heap to 8192 MiB addresses this.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5c0f2b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->