### PR TITLE
search-eval: Exa-style eval harness for `search`, plus `search --json`

### DIFF
--- a/packages/search-core/src/lib.rs
+++ b/packages/search-core/src/lib.rs
@@ -46,7 +46,7 @@ pub use manifest::{FileEntry, Manifest};
 pub use pipeline::{Query, index_and_answer, index_and_grep, index_and_semantic};
 pub use query_filter::{FilterSpec, build_filter};
 pub use repo::repo_slug;
-pub use search::{AnswerView, CodeScope, DisplayHit, ask, grep, semantic};
+pub use search::{AnswerView, CodeScope, DisplayHit, ask, grep, hits_to_json, semantic};
 pub use sync::{GcReport, SyncReport, gc_documents, sync, sync_documents, wait_until_indexed};
 
 // Re-export the shared metadata and filter types so binaries depend only on

--- a/packages/search-core/src/search.rs
+++ b/packages/search-core/src/search.rs
@@ -22,9 +22,14 @@ use crate::error::Result;
 use crate::manifest::Manifest;
 
 /// A search result projected for display.
-#[derive(Debug, Clone)]
+///
+/// Serializes to the stable `search --json` object. `label` is renamed to `path`
+/// there to match the [`search-py`](../search-py) binding's dict, the other
+/// established machine-readable contract over the same hits.
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct DisplayHit {
     /// Repo-relative path, record title, or a URL for a web result.
+    #[serde(rename = "path")]
     pub label: String,
     /// Which corpus the hit came from.
     pub source: Source,
@@ -36,6 +41,19 @@ pub struct DisplayHit {
     pub score: f32,
     /// Matched snippet text.
     pub text: String,
+}
+
+/// Serialize hits as the machine-readable JSON array `search --json` prints.
+///
+/// Lives here, at the owner of [`DisplayHit`], so both the CLI and any other
+/// consumer share one serialization and the JSON shape stays defined in one
+/// place.
+///
+/// # Errors
+/// Returns an error if serialization fails, which is not expected for these
+/// scalar/string fields.
+pub fn hits_to_json(hits: &[DisplayHit]) -> serde_json::Result<String> {
+    serde_json::to_string(hits)
 }
 
 /// A question-answering result projected for display.

--- a/packages/search-eval/README.md
+++ b/packages/search-eval/README.md
@@ -89,16 +89,23 @@ analog of the GPT-4.1 grader Exa reports; override with `--judge-model`.
 
 The agent runs behind a pluggable backend:
 
-- `--backend local` (default) runs each `claude -p` in a throwaway temp
-  directory whose only tool is a generated `corpus-search` wrapper. The empty
-  working directory plus a tool allowlist means the agent cannot read or grep the
-  corpus directly: it must search.
-- `--backend ixvm` is the typed seam for running each agent inside a disposable
-  ix VM, the production isolation boundary (the same shape Symphony uses to run
-  Codex). It is not implemented yet and returns an explicit error rather than
-  silently falling back: ix VMs run on x86_64-linux compute nodes, so wiring this
-  up belongs in a follow-up. The interface lives in
-  [`agent.py`](src/search_eval/agent.py).
+- `--backend local` (default) runs each `claude -p` in a throwaway empty temp
+  directory whose only declared tool is a one-tool MCP search server
+  ([`mcp_server.py`](src/search_eval/mcp_server.py)), with Bash and every
+  file/web reader denied and the corpus path kept out of the agent's view (the
+  MCP config lives outside the working directory; the prompt never names a path).
+  This is **best-effort isolation for a cooperative agent, not a security
+  boundary.** Claude Code still executes read-only shell regardless of the tool
+  allow/deny lists, so an adversarial agent that hunts the filesystem could read
+  the corpus without searching. For a cooperative agent answering a question it
+  has only the search tool and no path, so the number reflects search; treat it
+  accordingly and use the airtight backend below when the isolation must hold.
+- `--backend ixvm` is the typed seam for the **airtight** boundary: run each
+  agent inside a disposable ix VM whose only view of the corpus is the search
+  tool (the same shape Symphony uses to run Codex). It is not implemented yet and
+  returns an explicit error rather than silently falling back: ix VMs run on
+  x86_64-linux compute nodes, so wiring this up belongs in a follow-up. The
+  interface lives in [`agent.py`](src/search_eval/agent.py).
 
 ## Why Python here
 

--- a/packages/search-eval/README.md
+++ b/packages/search-eval/README.md
@@ -1,0 +1,124 @@
+# search-eval
+
+Measure how good [`search`](../search) is, the way the search-eval community
+actually measures retrieval. `search-eval` runs a versioned query set against the
+real `search` engine over a fixed corpus and scores it, in two tiers that mirror
+how [Exa](https://exa.ai) runs its "open evals":
+
+- **Tier A — retrieval grading.** Rank the corpus for each query and score the
+  ranking against gold labels (nDCG@10, Recall@k, MRR), plus an optional
+  label-free LLM relevance judge. This is the cheap, reproducible signal you can
+  gate on.
+- **Tier B — agentic downstream.** Give a headless `claude -p` agent exactly one
+  tool, a corpus-scoped search, and a question it cannot answer from memory; then
+  grade whether it answered correctly. This is the "does our search actually help
+  an agent" signal, Exa's RAG/SimpleQA mode.
+
+```sh
+# Tier A: grade rankings against the gold query set (LLM judge on by default).
+nix run .#search-eval -- retrieval
+
+# Tier A without the judge (rank metrics only, no API key needed for grading).
+nix run .#search-eval -- retrieval --no-judge
+
+# Tier B: run claude -p with only search, grade the answers.
+nix run .#search-eval -- agentic
+
+# Both, plus write the JSON report.
+nix run .#search-eval -- all --json-out report.json
+```
+
+## What you need
+
+- A Mixedbread credential for `search`: `MXBAI_API_KEY`, or a `mgrep login`
+  token. Without it `search` cannot index or query.
+- `ANTHROPIC_API_KEY` for the LLM judge (both tiers) and the `claude -p` agent
+  (Tier B). Pass `--no-judge` to skip grading in Tier A.
+
+These are live, networked evals run on demand or nightly, not hermetic unit
+tests. The one part that *is* hermetic, the ranking metrics, is unit-tested
+offline and is what CI gates (`passthru.tests.metrics`).
+
+## The corpus and the query sets
+
+The corpus is a small committed fixture under [`corpus/`](corpus): a dozen tiny
+modules on distinct topics (retry backoff, rate limiting, an LRU cache, a
+connection pool, ...) with **specific, made-up constants**. That last part is
+deliberate: per Exa's anti-contamination recipe, the answers cannot be guessed
+from a model's parametric memory, so a correct answer is evidence the *retrieval*
+worked, not that the model already knew it.
+
+The query sets are data, one JSON object per line so a diff shows exactly what
+changed:
+
+- [`datasets/retrieval.jsonl`](datasets/retrieval.jsonl): `{id, query, relevant}`
+  where `relevant` maps a corpus path to a graded relevance (`1` binary, or a
+  small integer). Because we own the corpus we use real gold labels here, which
+  Exa prefers over LLM grading wherever enumerating the relevant docs is
+  feasible.
+- [`datasets/tasks.jsonl`](datasets/tasks.jsonl): `{id, task, answer}` for the
+  agentic tier.
+
+Point either tier at your own set with `--dataset`, or at any checkout with
+`--corpus`.
+
+## Metrics
+
+| Metric | What it tells you |
+| --- | --- |
+| **nDCG@10** | The headline ranking metric (graded, position-discounted), the BEIR/MTEB standard Exa and the community report. |
+| **Recall@5 / @10** | Coverage: did the relevant docs land in the top k. |
+| **MRR** | Reciprocal rank of the first relevant doc; the single-answer view. |
+| **jNDCG** | Label-free cross-check: nDCG computed over an LLM judge's per-result relevance scores. A flat mean would punish a perfect ranking that has one relevant result and an off-topic tail, so we discount by rank like Exa. |
+| **accuracy** (Tier B) | Fraction of tasks the agent answered correctly using only search. |
+
+Use `--fail-under <x>` to make a tier exit non-zero when the headline metric
+(nDCG@10 for `retrieval`, accuracy for `agentic`) falls below a threshold, for a
+CI gate once numbers are baselined.
+
+## The LLM judge
+
+Grading follows the robustness measures from the LLM-as-judge literature: a
+forced tool call for structured output, `temperature=0`, an explicit calibrated
+rubric, and a `reasoning` field emitted before the score so verdicts are
+chain-of-thought-grounded. Grading is pointwise (one result at a time), so
+position bias does not apply. The default judge model is a mid-tier Claude, the
+analog of the GPT-4.1 grader Exa reports; override with `--judge-model`.
+
+## Isolation backends (Tier B)
+
+The agent runs behind a pluggable backend:
+
+- `--backend local` (default) runs each `claude -p` in a throwaway temp
+  directory whose only tool is a generated `corpus-search` wrapper. The empty
+  working directory plus a tool allowlist means the agent cannot read or grep the
+  corpus directly: it must search.
+- `--backend ixvm` is the typed seam for running each agent inside a disposable
+  ix VM, the production isolation boundary (the same shape Symphony uses to run
+  Codex). It is not implemented yet and returns an explicit error rather than
+  silently falling back: ix VMs run on x86_64-linux compute nodes, so wiring this
+  up belongs in a follow-up. The interface lives in
+  [`agent.py`](src/search_eval/agent.py).
+
+## Why Python here
+
+Core search logic stays in Rust (`search-core`); this is an evaluation harness,
+not domain logic. It is iteration-heavy, grades by calling an LLM, and drives
+`claude -p` as a subprocess, all of which Python expresses directly, and the
+reference harness it borrows from ([`exa-labs/benchmarks`](https://github.com/exa-labs/benchmarks),
+MIT) is Python. The machine-readable contract it consumes, `search --json`, lives
+at the owner (the `search` CLI), so this harness adds no domain logic of its own.
+
+## Background
+
+The methodology here is drawn from Exa's writing on how they evaluate neural
+search:
+
+- [Evals at Exa](https://exa.ai/blog/evals-at-exa): the open-eval philosophy
+  (a query list graded by an LLM), the grading rubric, and aggregation choices.
+- [WebCode](https://exa.ai/blog/webcode): the code-search harness that separates
+  retrieval quality from answer quality and grades groundedness
+  discriminatively.
+- [Evaluating Exa search](https://exa.ai/docs/reference/evaluating-exa-search):
+  fairness controls (compare within a latency class, use each engine's real
+  returned content, document every config).

--- a/packages/search-eval/corpus/crypto.py
+++ b/packages/search-eval/corpus/crypto.py
@@ -1,0 +1,17 @@
+"""Envelope encryption of secrets at rest using AES-256-GCM."""
+
+# AES-GCM nonce length in bytes; 12 is the standard for GCM.
+NONCE_LENGTH_BYTES = 12
+# Data-encryption-key length in bytes (256-bit AES).
+DEK_LENGTH_BYTES = 32
+# Authentication tag length in bytes.
+TAG_LENGTH_BYTES = 16
+
+
+def envelope_layout() -> dict[str, int]:
+    """Byte layout of a sealed envelope: nonce || ciphertext || tag."""
+    return {
+        "nonce_bytes": NONCE_LENGTH_BYTES,
+        "dek_bytes": DEK_LENGTH_BYTES,
+        "tag_bytes": TAG_LENGTH_BYTES,
+    }

--- a/packages/search-eval/corpus/dbpool.py
+++ b/packages/search-eval/corpus/dbpool.py
@@ -1,0 +1,19 @@
+"""Database connection pool sizing and checkout policy."""
+
+# Minimum warm connections kept open even when idle.
+MIN_POOL_SIZE = 4
+# Hard ceiling on concurrent connections to the primary.
+MAX_POOL_SIZE = 32
+# Fail a checkout that waits longer than this for a free connection.
+CHECKOUT_TIMEOUT_SECONDS = 5.0
+# Recycle a connection after this many seconds to dodge stale TCP state.
+MAX_CONNECTION_LIFETIME_SECONDS = 1_800
+
+
+def pool_settings() -> dict[str, float]:
+    return {
+        "min_size": MIN_POOL_SIZE,
+        "max_size": MAX_POOL_SIZE,
+        "checkout_timeout": CHECKOUT_TIMEOUT_SECONDS,
+        "max_lifetime": MAX_CONNECTION_LIFETIME_SECONDS,
+    }

--- a/packages/search-eval/corpus/envconfig.py
+++ b/packages/search-eval/corpus/envconfig.py
@@ -1,0 +1,20 @@
+"""Load and validate service configuration from environment variables."""
+
+import os
+
+# Prefix every recognized variable shares, e.g. IXSVC_PORT.
+ENV_PREFIX = "IXSVC_"
+# Default listen port when IXSVC_PORT is unset.
+DEFAULT_PORT = 8787
+
+
+def load_config() -> dict[str, object]:
+    """Read the recognized variables, applying defaults and basic validation."""
+    port = int(os.environ.get(f"{ENV_PREFIX}PORT", DEFAULT_PORT))
+    if not (1 <= port <= 65_535):
+        raise ValueError(f"{ENV_PREFIX}PORT out of range: {port}")
+    return {
+        "port": port,
+        "log_level": os.environ.get(f"{ENV_PREFIX}LOG_LEVEL", "info"),
+        "region": os.environ.get(f"{ENV_PREFIX}REGION", "us-east-1"),
+    }

--- a/packages/search-eval/corpus/events.py
+++ b/packages/search-eval/corpus/events.py
@@ -1,0 +1,17 @@
+"""Serialize domain events to the wire format the bus expects."""
+
+import json
+
+# Bumped whenever the on-the-wire event shape changes incompatibly.
+SCHEMA_VERSION = 3
+
+
+def encode_event(kind: str, payload: dict[str, object], occurred_at_ms: int) -> bytes:
+    """Encode one event as a compact UTF-8 JSON line for the message bus."""
+    envelope = {
+        "v": SCHEMA_VERSION,
+        "kind": kind,
+        "ts_ms": occurred_at_ms,
+        "data": payload,
+    }
+    return json.dumps(envelope, separators=(",", ":"), sort_keys=True).encode("utf-8")

--- a/packages/search-eval/corpus/featureflags.py
+++ b/packages/search-eval/corpus/featureflags.py
@@ -1,0 +1,17 @@
+"""Evaluate feature flags with deterministic percentage rollouts."""
+
+import hashlib
+
+# Salt mixed into the hash so rollouts differ per flag, not globally aligned.
+ROLLOUT_SALT = "ixsvc-flags-v1"
+
+
+def is_enabled(flag: str, user_id: str, rollout_percent: int) -> bool:
+    """True when `user_id` falls inside `flag`'s rollout bucket (0..100).
+
+    Hashing (flag, salt, user) gives a stable 0..99 bucket, so a user keeps the
+    same answer across calls and a higher percent only ever adds users.
+    """
+    digest = hashlib.sha256(f"{flag}:{ROLLOUT_SALT}:{user_id}".encode("utf-8")).digest()
+    bucket = digest[0] % 100
+    return bucket < rollout_percent

--- a/packages/search-eval/corpus/http_client.py
+++ b/packages/search-eval/corpus/http_client.py
@@ -1,0 +1,19 @@
+"""Outbound HTTP client construction and timeout policy."""
+
+# Time to establish a TCP connection before failing.
+CONNECT_TIMEOUT_SECONDS = 3.5
+# Time to wait for the full response body once connected.
+READ_TIMEOUT_SECONDS = 30.0
+# Reuse this many idle keep-alive connections per host.
+MAX_KEEPALIVE_PER_HOST = 16
+USER_AGENT = "ix-fetch/0.4 (+https://ix.dev)"
+
+
+def build_client_config() -> dict[str, object]:
+    """The settings handed to the underlying transport when a client is built."""
+    return {
+        "connect_timeout": CONNECT_TIMEOUT_SECONDS,
+        "read_timeout": READ_TIMEOUT_SECONDS,
+        "max_keepalive": MAX_KEEPALIVE_PER_HOST,
+        "headers": {"user-agent": USER_AGENT},
+    }

--- a/packages/search-eval/corpus/lru_cache.py
+++ b/packages/search-eval/corpus/lru_cache.py
@@ -1,0 +1,25 @@
+"""Fixed-size LRU cache with least-recently-used eviction."""
+
+from collections import OrderedDict
+
+# Maximum number of entries before the oldest is evicted.
+MAX_ENTRIES = 1024
+
+
+class LruCache:
+    """Evicts the least-recently-used key once MAX_ENTRIES is exceeded."""
+
+    def __init__(self) -> None:
+        self._store: OrderedDict[str, bytes] = OrderedDict()
+
+    def get(self, key: str) -> bytes | None:
+        if key not in self._store:
+            return None
+        self._store.move_to_end(key)
+        return self._store[key]
+
+    def put(self, key: str, value: bytes) -> None:
+        self._store[key] = value
+        self._store.move_to_end(key)
+        if len(self._store) > MAX_ENTRIES:
+            self._store.popitem(last=False)

--- a/packages/search-eval/corpus/pagination.py
+++ b/packages/search-eval/corpus/pagination.py
@@ -1,0 +1,19 @@
+"""Opaque cursor pagination over an ordered result set."""
+
+import base64
+
+# Maximum page size a caller may request; larger requests are clamped.
+MAX_PAGE_SIZE = 200
+# Page size used when the caller does not specify one.
+DEFAULT_PAGE_SIZE = 50
+
+
+def encode_cursor(last_id: int) -> str:
+    """Encode the last seen id as an opaque base64 cursor token."""
+    return base64.urlsafe_b64encode(f"after:{last_id}".encode("utf-8")).decode("ascii")
+
+
+def decode_cursor(cursor: str) -> int:
+    """Recover the last seen id from an opaque cursor token."""
+    raw = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8")
+    return int(raw.removeprefix("after:"))

--- a/packages/search-eval/corpus/ratelimit.py
+++ b/packages/search-eval/corpus/ratelimit.py
@@ -1,0 +1,24 @@
+"""Token-bucket rate limiter guarding the authentication endpoint."""
+
+# Sustained request rate, tokens added per second.
+REFILL_RATE_PER_SEC = 12
+# Burst ceiling: the bucket never holds more than this many tokens.
+BUCKET_CAPACITY = 40
+
+
+class TokenBucket:
+    """Allow a request when a token is available, else reject it."""
+
+    def __init__(self) -> None:
+        self._tokens = float(BUCKET_CAPACITY)
+
+    def refill(self, elapsed_seconds: float) -> None:
+        self._tokens = min(
+            BUCKET_CAPACITY, self._tokens + elapsed_seconds * REFILL_RATE_PER_SEC
+        )
+
+    def try_acquire(self) -> bool:
+        if self._tokens >= 1.0:
+            self._tokens -= 1.0
+            return True
+        return False

--- a/packages/search-eval/corpus/retry.py
+++ b/packages/search-eval/corpus/retry.py
@@ -1,0 +1,16 @@
+"""Exponential backoff retry policy for outbound RPC calls."""
+
+# Base delay before the first retry, in milliseconds.
+BASE_DELAY_MS = 250
+# Each subsequent attempt waits BASE_DELAY_MS * (BACKOFF_FACTOR ** attempt).
+BACKOFF_FACTOR = 2.0
+# Give up after this many total attempts.
+MAX_ATTEMPTS = 5
+# Cap any single sleep so a long backoff never exceeds this ceiling.
+MAX_DELAY_MS = 8_000
+
+
+def delay_for_attempt(attempt: int) -> float:
+    """Milliseconds to sleep before `attempt` (0-based), capped at MAX_DELAY_MS."""
+    raw = BASE_DELAY_MS * (BACKOFF_FACTOR**attempt)
+    return min(raw, MAX_DELAY_MS)

--- a/packages/search-eval/corpus/scheduler.py
+++ b/packages/search-eval/corpus/scheduler.py
@@ -1,0 +1,21 @@
+"""Cron-like periodic task scheduler."""
+
+# How often the scheduler wakes to check for due tasks, in seconds.
+TICK_INTERVAL_SECONDS = 0.5
+# Skip a run (rather than stacking) if the previous one is still going.
+SKIP_IF_OVERLAPPING = True
+
+
+class PeriodicTask:
+    """A task that becomes due every `period_seconds`."""
+
+    def __init__(self, name: str, period_seconds: float) -> None:
+        self.name = name
+        self.period_seconds = period_seconds
+        self._next_due = 0.0
+
+    def is_due(self, now: float) -> bool:
+        if now >= self._next_due:
+            self._next_due = now + self.period_seconds
+            return True
+        return False

--- a/packages/search-eval/corpus/telemetry.py
+++ b/packages/search-eval/corpus/telemetry.py
@@ -1,0 +1,22 @@
+"""Register and increment Prometheus-style counters for request telemetry."""
+
+# Fully-qualified counter name scraped by the metrics endpoint.
+REQUESTS_TOTAL = "ixsvc_requests_total"
+# Histogram of request latency; buckets are in seconds.
+LATENCY_BUCKETS_SECONDS = (0.005, 0.025, 0.1, 0.5, 2.5)
+
+
+class CounterRegistry:
+    """A minimal label-free counter registry."""
+
+    def __init__(self) -> None:
+        self._counters: dict[str, int] = {}
+
+    def register(self, name: str) -> None:
+        self._counters.setdefault(name, 0)
+
+    def incr(self, name: str, amount: int = 1) -> None:
+        self._counters[name] = self._counters.get(name, 0) + amount
+
+    def value(self, name: str) -> int:
+        return self._counters.get(name, 0)

--- a/packages/search-eval/datasets/retrieval.jsonl
+++ b/packages/search-eval/datasets/retrieval.jsonl
@@ -1,0 +1,15 @@
+{"id": "retry-backoff", "query": "where is the exponential backoff retry delay configured", "relevant": {"retry.py": 1}}
+{"id": "retry-max-attempts", "query": "how many times do we retry a failed RPC before giving up", "relevant": {"retry.py": 1}}
+{"id": "auth-ratelimit", "query": "how is the authentication endpoint rate limited", "relevant": {"ratelimit.py": 1}}
+{"id": "ratelimit-burst", "query": "what is the burst capacity of the rate limiter", "relevant": {"ratelimit.py": 1}}
+{"id": "cache-eviction", "query": "how does the cache decide what to evict when it is full", "relevant": {"lru_cache.py": 1}}
+{"id": "http-timeouts", "query": "what connect and read timeouts does the outbound HTTP client use", "relevant": {"http_client.py": 1}}
+{"id": "env-config", "query": "where are service settings loaded from environment variables", "relevant": {"envconfig.py": 1}}
+{"id": "db-pool-size", "query": "what is the maximum database connection pool size", "relevant": {"dbpool.py": 1}}
+{"id": "event-encoding", "query": "how are domain events serialized for the message bus", "relevant": {"events.py": 1}}
+{"id": "metrics-counters", "query": "where are prometheus request counters registered", "relevant": {"telemetry.py": 1}}
+{"id": "task-scheduling", "query": "how does the periodic task scheduler decide a task is due", "relevant": {"scheduler.py": 1}}
+{"id": "encryption-at-rest", "query": "how are secrets encrypted at rest with AES-GCM", "relevant": {"crypto.py": 1}}
+{"id": "cursor-pagination", "query": "how does opaque cursor pagination encode the cursor token", "relevant": {"pagination.py": 1}}
+{"id": "feature-flag-rollout", "query": "how is a percentage feature flag rollout evaluated per user", "relevant": {"featureflags.py": 1}}
+{"id": "connection-limits", "query": "what configuration values control connection and pool limits", "relevant": {"dbpool.py": 2, "http_client.py": 1, "ratelimit.py": 1}}

--- a/packages/search-eval/datasets/tasks.jsonl
+++ b/packages/search-eval/datasets/tasks.jsonl
@@ -1,0 +1,8 @@
+{"id": "base-delay", "task": "What is the base delay in milliseconds before the first retry?", "answer": "250 milliseconds"}
+{"id": "max-attempts", "task": "How many total attempts does the retry policy make before giving up?", "answer": "5 attempts"}
+{"id": "bucket-capacity", "task": "What is the token bucket capacity (burst ceiling) for the auth rate limiter?", "answer": "40 tokens"}
+{"id": "cache-size", "task": "How many entries can the LRU cache hold before it evicts the oldest?", "answer": "1024 entries"}
+{"id": "connect-timeout", "task": "What is the HTTP client connect timeout in seconds?", "answer": "3.5 seconds"}
+{"id": "pool-max", "task": "What is the maximum database connection pool size?", "answer": "32 connections"}
+{"id": "schema-version", "task": "What is the current event wire schema version number?", "answer": "3"}
+{"id": "nonce-length", "task": "How many bytes long is the AES-GCM nonce used for envelope encryption?", "answer": "12 bytes"}

--- a/packages/search-eval/default.nix
+++ b/packages/search-eval/default.nix
@@ -13,12 +13,11 @@ let
 
   # Corpus and eval sets ship as plain files (not wheel data): `search` needs a
   # real directory to index. The wrapper points SEARCH_EVAL_DATA_DIR here.
-  data =
-    pkgs.runCommand "search-eval-data" { strictDeps = true; } ''
-      mkdir -p "$out/corpus" "$out/datasets"
-      cp -r ${./corpus}/. "$out/corpus/"
-      cp -r ${./datasets}/. "$out/datasets/"
-    '';
+  data = pkgs.runCommand "search-eval-data" { strictDeps = true; } ''
+    mkdir -p "$out/corpus" "$out/datasets"
+    cp -r ${./corpus}/. "$out/corpus/"
+    cp -r ${./datasets}/. "$out/datasets/"
+  '';
 
   unwrapped = ix.buildUvApplication pkgs {
     pname = "search-eval";
@@ -46,7 +45,12 @@ let
       ''
         mkdir -p $out/bin
         makeWrapper ${lib.getExe unwrapped} $out/bin/search-eval \
-          --prefix PATH : ${lib.makeBinPath [ searchBin claudeBin ]} \
+          --prefix PATH : ${
+            lib.makeBinPath [
+              searchBin
+              claudeBin
+            ]
+          } \
           --set SEARCH_EVAL_DATA_DIR ${data}
       '';
 

--- a/packages/search-eval/default.nix
+++ b/packages/search-eval/default.nix
@@ -1,0 +1,91 @@
+{
+  ix,
+  lib,
+  pkgs,
+}:
+
+let
+  # The real `search` binary under test, from the shared cargo workspace graph,
+  # and the `claude` CLI for the agentic tier. Both go on the wrapper's PATH so
+  # the harness drives the same artifacts a developer uses.
+  searchBin = ix.rustWorkspace.units.binaries.search;
+  claudeBin = pkgs.claude-code;
+
+  # Corpus and eval sets ship as plain files (not wheel data): `search` needs a
+  # real directory to index. The wrapper points SEARCH_EVAL_DATA_DIR here.
+  data =
+    pkgs.runCommand "search-eval-data" { strictDeps = true; } ''
+      mkdir -p "$out/corpus" "$out/datasets"
+      cp -r ${./corpus}/. "$out/corpus/"
+      cp -r ${./datasets}/. "$out/datasets/"
+    '';
+
+  unwrapped = ix.buildUvApplication pkgs {
+    pname = "search-eval";
+    version = "0.1.0";
+    srcRoot = ./.;
+    mainProgram = "search-eval";
+    meta = {
+      description = "Exa-style evaluation harness for the `search` engine";
+      license = lib.licenses.mit;
+      mainProgram = "search-eval";
+    };
+  };
+
+  package =
+    pkgs.runCommand "search-eval"
+      {
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+        strictDeps = true;
+        meta = {
+          description = "Exa-style evaluation harness for the `search` engine";
+          license = lib.licenses.mit;
+          mainProgram = "search-eval";
+        };
+      }
+      ''
+        mkdir -p $out/bin
+        makeWrapper ${lib.getExe unwrapped} $out/bin/search-eval \
+          --prefix PATH : ${lib.makeBinPath [ searchBin claudeBin ]} \
+          --set SEARCH_EVAL_DATA_DIR ${data}
+      '';
+
+  # Offline, deterministic: the ranking metrics are the CI-gating signal, so
+  # they are unit-tested against the installed package with no network or key.
+  metrics =
+    pkgs.runCommand "search-eval-metrics"
+      {
+        strictDeps = true;
+      }
+      ''
+        ${unwrapped}/venv/bin/python ${./tests/test_metrics.py}
+        mkdir -p "$out"
+      '';
+
+  # No network and no API key: `--help` must exit 0 and name the program.
+  printsHelp =
+    pkgs.runCommand "search-eval-prints-help"
+      {
+        nativeBuildInputs = [ package ];
+        strictDeps = true;
+      }
+      ''
+        help=$(search-eval --help)
+        case "$help" in
+          *"search-eval"*) ;;
+          *)
+            echo "search-eval --help did not print usage" >&2
+            printf '%s\n' "$help" >&2
+            exit 1
+            ;;
+        esac
+        mkdir -p "$out"
+      '';
+in
+package.overrideAttrs (old: {
+  passthru = (old.passthru or { }) // {
+    tests = {
+      inherit metrics printsHelp;
+    };
+  };
+})

--- a/packages/search-eval/package.nix
+++ b/packages/search-eval/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "search-eval";
+  packageSet = true;
+  flake = true;
+}

--- a/packages/search-eval/pyproject.toml
+++ b/packages/search-eval/pyproject.toml
@@ -5,6 +5,7 @@ description = "Exa-style evaluation harness for the `search` engine"
 requires-python = ">=3.13"
 dependencies = [
     "anthropic>=0.40.0",
+    "mcp>=1.0.0",
 ]
 
 [project.scripts]

--- a/packages/search-eval/pyproject.toml
+++ b/packages/search-eval/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "search-eval"
+version = "0.1.0"
+description = "Exa-style evaluation harness for the `search` engine"
+requires-python = ">=3.13"
+dependencies = [
+    "anthropic>=0.40.0",
+]
+
+[project.scripts]
+search-eval = "search_eval.cli:main"
+
+[build-system]
+requires = ["uv_build>=0.11.0,<0.12.0"]
+build-backend = "uv_build"

--- a/packages/search-eval/src/search_eval/__init__.py
+++ b/packages/search-eval/src/search_eval/__init__.py
@@ -1,0 +1,3 @@
+"""search-eval: an Exa-style evaluation harness for the `search` engine."""
+
+__version__ = "0.1.0"

--- a/packages/search-eval/src/search_eval/__main__.py
+++ b/packages/search-eval/src/search_eval/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point so `python -m search_eval` mirrors the `search-eval` console script."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/search-eval/src/search_eval/agent.py
+++ b/packages/search-eval/src/search_eval/agent.py
@@ -8,14 +8,18 @@ command, so a correct answer is evidence the retrieval surfaced the fact.
 Isolation is a pluggable backend:
 
 - [`LocalBackend`] runs the agent in a fresh empty temp directory with a
-  generated ``corpus-search`` wrapper on PATH. The empty cwd plus a tool
-  allowlist means the agent cannot read or grep the corpus directly; it must
-  search. This is the default and is what runs in CI-style local runs.
-- [`IxVmBackend`] is the typed seam for running each agent inside a disposable
-  ix VM (the production isolation boundary, the same pattern Symphony uses for
-  Codex). It is not wired up yet: ix VMs run on x86_64-linux compute nodes, so
-  this backend is implemented as an explicit, observable error rather than a
-  silent fallback to local.
+  one-tool MCP search server (see [`mcp_server`]) and Bash plus every file/web
+  reader denied, and keeps the corpus path out of the agent's view (the MCP
+  config lives outside the working directory and the prompt never names a path).
+  This is **best-effort isolation for a cooperative agent**, not a security
+  boundary: Claude Code still executes read-only shell regardless of the tool
+  allow/deny lists, so an adversarial agent that goes hunting on the filesystem
+  could read the corpus without searching. It is the default for local runs.
+- [`IxVmBackend`] is the typed seam for the **airtight** boundary: run each
+  agent inside a disposable ix VM whose only view of the corpus is the search
+  tool (the same pattern Symphony uses for Codex). It is not wired up yet: ix
+  VMs run on x86_64-linux compute nodes, so this backend is implemented as an
+  explicit, observable error rather than a silent fallback to local.
 """
 
 from __future__ import annotations
@@ -23,17 +27,26 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
 from .model import TaskCase
 
+# The MCP tool id Claude Code exposes for the `search` tool on the `corpus`
+# server (see mcp_server.py): `mcp__<server>__<tool>`.
+_SEARCH_TOOL = "mcp__corpus__search"
+
+# Tools the agent must not have, so the only way to read the corpus is the MCP
+# search tool. Bash is denied (a Bash allowlist does not reliably restrict
+# commands), along with every direct file/web reader.
+_DENIED_TOOLS = "Bash,Read,Grep,Glob,Edit,Write,WebSearch,WebFetch,Task,NotebookEdit"
+
 _PROMPT = """\
 You are answering a question about a small codebase. You have exactly ONE tool: \
-the shell command `corpus-search "<query>"`, which runs a semantic search over \
-the codebase and prints matching files with their contents. You cannot read or \
-list files any other way.
+a semantic `search` over the codebase that returns matching files with their \
+contents. You cannot read, list, or grep files any other way.
 
 Question: {task}
 
@@ -66,38 +79,51 @@ class LocalBackend:
     timeout_seconds: float = 300.0
 
     def run_task(self, case: TaskCase) -> str:
-        with tempfile.TemporaryDirectory(prefix="search-eval-") as sandbox:
-            bin_dir = Path(sandbox) / "bin"
-            bin_dir.mkdir()
-            self._write_wrapper(bin_dir / "corpus-search")
-            env = dict(os.environ)
-            env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+        # Two temp dirs: an empty working directory for the agent, and a separate
+        # config directory the agent's cwd cannot see, so `ls`/`cat` in the cwd
+        # never reveals the corpus path that the MCP config carries.
+        with (
+            tempfile.TemporaryDirectory(prefix="search-eval-cwd-") as cwd,
+            tempfile.TemporaryDirectory(prefix="search-eval-cfg-") as cfg_dir,
+        ):
+            config = Path(cfg_dir) / "mcp.json"
+            config.write_text(self._mcp_config(), encoding="utf-8")
             args = [
                 self.claude_bin,
                 "-p",
                 _PROMPT.format(task=case.task),
                 "--output-format",
                 "json",
+                "--mcp-config",
+                str(config),
                 "--allowedTools",
-                "Bash(corpus-search:*)",
+                _SEARCH_TOOL,
                 "--disallowedTools",
-                "Read,Grep,Glob,Edit,Write,WebSearch,WebFetch,Task",
+                _DENIED_TOOLS,
             ]
             if self.agent_model:
                 args += ["--model", self.agent_model]
-            return self._invoke(args, cwd=sandbox, env=env)
+            return self._invoke(args, cwd=cwd, env=dict(os.environ))
 
-    def _write_wrapper(self, path: Path) -> None:
-        # The agent calls `corpus-search "<query>"`; the wrapper pins the corpus
-        # path, code-only scope, and content display so the model sees snippets.
-        path.write_text(
-            "#!/usr/bin/env bash\n"
-            "set -euo pipefail\n"
-            f'exec {self.search_bin} --source code -c --no-sync -m {self.max_results} '
-            f'"$1" {self.corpus}\n',
-            encoding="utf-8",
+    def _mcp_config(self) -> str:
+        # Spawn the one-tool MCP search server with this interpreter so it shares
+        # the installed `search_eval` + `mcp` packages; `search` resolves from
+        # the inherited PATH. Corpus and scope travel via the environment.
+        return json.dumps(
+            {
+                "mcpServers": {
+                    "corpus": {
+                        "command": sys.executable,
+                        "args": ["-m", "search_eval.mcp_server"],
+                        "env": {
+                            "SEARCH_EVAL_CORPUS": str(self.corpus),
+                            "SEARCH_EVAL_SEARCH_BIN": self.search_bin,
+                            "SEARCH_EVAL_MAX_RESULTS": str(self.max_results),
+                        },
+                    }
+                }
+            }
         )
-        path.chmod(0o755)
 
     def _invoke(self, args: list[str], *, cwd: str, env: dict[str, str]) -> str:
         try:

--- a/packages/search-eval/src/search_eval/agent.py
+++ b/packages/search-eval/src/search_eval/agent.py
@@ -1,0 +1,145 @@
+"""Tier B: drive a headless `claude -p` agent whose only tool is search.
+
+This measures the downstream question Exa frames as RAG/SimpleQA: does our search
+actually let an agent answer a question it cannot answer from memory? Each task
+runs an isolated `claude -p` whose *only* capability is a corpus-scoped search
+command, so a correct answer is evidence the retrieval surfaced the fact.
+
+Isolation is a pluggable backend:
+
+- [`LocalBackend`] runs the agent in a fresh empty temp directory with a
+  generated ``corpus-search`` wrapper on PATH. The empty cwd plus a tool
+  allowlist means the agent cannot read or grep the corpus directly; it must
+  search. This is the default and is what runs in CI-style local runs.
+- [`IxVmBackend`] is the typed seam for running each agent inside a disposable
+  ix VM (the production isolation boundary, the same pattern Symphony uses for
+  Codex). It is not wired up yet: ix VMs run on x86_64-linux compute nodes, so
+  this backend is implemented as an explicit, observable error rather than a
+  silent fallback to local.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from .model import TaskCase
+
+_PROMPT = """\
+You are answering a question about a small codebase. You have exactly ONE tool: \
+the shell command `corpus-search "<query>"`, which runs a semantic search over \
+the codebase and prints matching files with their contents. You cannot read or \
+list files any other way.
+
+Question: {task}
+
+Search as many times as you need, then end with a single final line of the form:
+ANSWER: <your concise answer>"""
+
+
+class AgentError(RuntimeError):
+    """The agent process failed to produce a usable answer."""
+
+
+def _extract_answer(text: str) -> str:
+    """Pull the ``ANSWER:`` line if present, else return the trimmed text."""
+    for line in reversed(text.splitlines()):
+        stripped = line.strip()
+        if stripped.upper().startswith("ANSWER:"):
+            return stripped[len("ANSWER:") :].strip()
+    return text.strip()
+
+
+@dataclass(frozen=True, slots=True)
+class LocalBackend:
+    """Run each agent locally in a throwaway sandbox directory."""
+
+    corpus: Path
+    search_bin: str = "search"
+    claude_bin: str = "claude"
+    max_results: int = 8
+    agent_model: str | None = None
+    timeout_seconds: float = 300.0
+
+    def run_task(self, case: TaskCase) -> str:
+        with tempfile.TemporaryDirectory(prefix="search-eval-") as sandbox:
+            bin_dir = Path(sandbox) / "bin"
+            bin_dir.mkdir()
+            self._write_wrapper(bin_dir / "corpus-search")
+            env = dict(os.environ)
+            env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+            args = [
+                self.claude_bin,
+                "-p",
+                _PROMPT.format(task=case.task),
+                "--output-format",
+                "json",
+                "--allowedTools",
+                "Bash(corpus-search:*)",
+                "--disallowedTools",
+                "Read,Grep,Glob,Edit,Write,WebSearch,WebFetch,Task",
+            ]
+            if self.agent_model:
+                args += ["--model", self.agent_model]
+            return self._invoke(args, cwd=sandbox, env=env)
+
+    def _write_wrapper(self, path: Path) -> None:
+        # The agent calls `corpus-search "<query>"`; the wrapper pins the corpus
+        # path, code-only scope, and content display so the model sees snippets.
+        path.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            f'exec {self.search_bin} --source code -c --no-sync -m {self.max_results} '
+            f'"$1" {self.corpus}\n',
+            encoding="utf-8",
+        )
+        path.chmod(0o755)
+
+    def _invoke(self, args: list[str], *, cwd: str, env: dict[str, str]) -> str:
+        try:
+            proc = subprocess.run(
+                args,
+                cwd=cwd,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise AgentError(f"`{self.claude_bin}` not found on PATH") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise AgentError(f"agent timed out after {self.timeout_seconds}s") from exc
+        if proc.returncode != 0:
+            raise AgentError(
+                f"claude exited {proc.returncode}: {proc.stderr.strip()[:400] or '(no stderr)'}"
+            )
+        try:
+            envelope = json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise AgentError(f"agent output was not JSON: {proc.stdout[:300]!r}") from exc
+        if envelope.get("is_error"):
+            raise AgentError(f"agent reported an error: {envelope.get('result', '')[:300]}")
+        return _extract_answer(str(envelope.get("result", "")))
+
+
+@dataclass(frozen=True, slots=True)
+class IxVmBackend:
+    """Deferred: run each agent inside a disposable ix VM.
+
+    The production isolation boundary. Creating it would: ``ix new`` a VM from a
+    claude-code image, mount or clone the corpus in, run the same headless
+    ``claude -p`` against an in-VM ``corpus-search``, collect the answer, then
+    destroy the VM by id. ix VMs run on x86_64-linux compute nodes, so this
+    cannot run from a macOS host and is left as an explicit error.
+    """
+
+    def run_task(self, case: TaskCase) -> str:  # noqa: ARG002 - interface stub
+        raise AgentError(
+            "the ixvm backend is not implemented yet; run with --backend local. "
+            "See packages/search-eval/README.md for the design."
+        )

--- a/packages/search-eval/src/search_eval/backend.py
+++ b/packages/search-eval/src/search_eval/backend.py
@@ -1,0 +1,89 @@
+"""Run the `search` CLI and parse its machine-readable output.
+
+The harness evaluates the real `search` binary through its ``--json`` mode rather
+than reimplementing retrieval. Results come back as a JSON array of hits, parsed
+into [`Hit`][search_eval.model.Hit] in rank order.
+
+Authentication is the binary's concern: it reads ``MXBAI_API_KEY`` or the token
+written by ``mgrep login``. A failed search raises [`SearchError`] with the
+binary's stderr, never a silent empty result.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from .model import Hit
+
+
+class SearchError(RuntimeError):
+    """The `search` binary failed or returned output that did not parse."""
+
+
+@dataclass(frozen=True, slots=True)
+class SearchBackend:
+    """Invoke `search --json` against a fixed corpus directory."""
+
+    corpus: Path
+    search_bin: str = "search"
+    sources: tuple[str, ...] = ("code",)
+    store: str | None = None
+    max_count: int = 10
+    rerank: bool = True
+    timeout_seconds: float = 180.0
+
+    def _base_args(self, no_sync: bool) -> list[str]:
+        args = [self.search_bin, "--json", "-m", str(self.max_count)]
+        for source in self.sources:
+            args += ["--source", source]
+        if not self.rerank:
+            args.append("--no-rerank")
+        if no_sync:
+            args.append("--no-sync")
+        if self.store:
+            args += ["--store", self.store]
+        return args
+
+    def warmup(self) -> None:
+        """Index the corpus once so later ``--no-sync`` searches are fast.
+
+        Embedding is content-addressed, so this only pays the upload/embed cost
+        for content the store has not seen before.
+        """
+        self._run(self._base_args(no_sync=False) + ["warm up the index", str(self.corpus)])
+
+    def search(self, query: str, *, no_sync: bool = False) -> list[Hit]:
+        """Return the ranked hits for ``query`` over the corpus."""
+        out = self._run(self._base_args(no_sync) + [query, str(self.corpus)])
+        try:
+            raw = json.loads(out or "[]")
+        except json.JSONDecodeError as exc:
+            raise SearchError(f"search did not return JSON: {exc}\noutput: {out[:400]!r}") from exc
+        if not isinstance(raw, list):
+            raise SearchError(f"expected a JSON array, got {type(raw).__name__}")
+        return [Hit.from_json(obj) for obj in raw]
+
+    def _run(self, args: list[str]) -> str:
+        try:
+            proc = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise SearchError(
+                f"`{self.search_bin}` not found on PATH; build it with `nix build .#search` "
+                "or pass --search-bin"
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise SearchError(f"search timed out after {self.timeout_seconds}s") from exc
+        if proc.returncode != 0:
+            raise SearchError(
+                f"search exited {proc.returncode}: {proc.stderr.strip() or '(no stderr)'}"
+            )
+        return proc.stdout.strip()

--- a/packages/search-eval/src/search_eval/cli.py
+++ b/packages/search-eval/src/search_eval/cli.py
@@ -109,7 +109,7 @@ def _emit(report: dict[str, object], table: str, json_out: Path | None) -> None:
 
 def _run_retrieval(args: argparse.Namespace) -> dict[str, float]:
     cases = data.load_retrieval(args.dataset)
-    if args.limit:
+    if args.limit is not None:
         cases = cases[: args.limit]
     judge = None if getattr(args, "no_judge", False) else Judge(model=args.judge_model)
     results = run_retrieval(
@@ -121,7 +121,7 @@ def _run_retrieval(args: argparse.Namespace) -> dict[str, float]:
 
 def _run_agentic(args: argparse.Namespace) -> dict[str, float]:
     cases = data.load_tasks(getattr(args, "dataset", None))
-    if args.limit:
+    if args.limit is not None:
         cases = cases[: args.limit]
     backend = _agent_backend(args)
     # The agent's search tool runs with --no-sync, so the corpus must be indexed

--- a/packages/search-eval/src/search_eval/cli.py
+++ b/packages/search-eval/src/search_eval/cli.py
@@ -1,0 +1,170 @@
+"""`search-eval`: an Exa-style evaluation harness for the `search` engine.
+
+Two tiers:
+
+- ``retrieval`` grades `search` rankings against a gold query set (nDCG@10,
+  Recall@k, MRR) plus an optional LLM relevance judge.
+- ``agentic`` runs a headless ``claude -p`` whose only tool is search, then
+  grades whether it answered correctly.
+
+Both run against a committed fixture corpus, so results are reproducible and
+free of training-data contamination.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from . import data
+from .agent import IxVmBackend, LocalBackend
+from .backend import SearchBackend
+from .judge import DEFAULT_JUDGE_MODEL, Judge
+from .paths import corpus_dir
+from .report import (
+    agentic_report,
+    render_agentic_table,
+    render_retrieval_table,
+    retrieval_report,
+    summarize_agentic,
+    summarize_retrieval,
+)
+from .runner import run_agentic, run_retrieval
+
+
+def _progress(message: str) -> None:
+    print(f"  … {message}", file=sys.stderr, flush=True)
+
+
+def _add_common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--search-bin", default="search", help="`search` binary (default: PATH)")
+    parser.add_argument(
+        "--corpus", type=Path, default=None, help="corpus dir (default: packaged fixture)"
+    )
+    parser.add_argument("--store", default=None, help="Mixedbread store name (default: search's)")
+    parser.add_argument("--max-count", type=int, default=10, help="results per query")
+    parser.add_argument("--limit", type=int, default=None, help="only run the first N cases")
+    parser.add_argument("--json-out", type=Path, default=None, help="write the JSON report here")
+    parser.add_argument("--judge-model", default=DEFAULT_JUDGE_MODEL, help="LLM judge model")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="search-eval", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    retr = sub.add_parser("retrieval", help="Tier A: grade search rankings vs gold")
+    _add_common(retr)
+    retr.add_argument("--no-rerank", action="store_true", help="disable the second-stage reranker")
+    retr.add_argument("--no-judge", action="store_true", help="skip the LLM relevance judge")
+    retr.add_argument("--judge-top-n", type=int, default=3, help="hits to LLM-grade per query")
+    retr.add_argument("--dataset", type=Path, default=None, help="override retrieval.jsonl")
+    retr.add_argument("--fail-under", type=float, default=None, help="exit 1 if mean nDCG@10 below")
+
+    agen = sub.add_parser("agentic", help="Tier B: claude -p with only search, graded")
+    _add_common(agen)
+    agen.add_argument("--claude-bin", default="claude", help="`claude` binary (default: PATH)")
+    agen.add_argument("--backend", choices=("local", "ixvm"), default="local")
+    agen.add_argument("--agent-model", default=None, help="model for the claude -p agent")
+    agen.add_argument("--dataset", type=Path, default=None, help="override tasks.jsonl")
+    agen.add_argument("--fail-under", type=float, default=None, help="exit 1 if accuracy below")
+
+    allp = sub.add_parser("all", help="run both tiers")
+    _add_common(allp)
+    allp.add_argument("--claude-bin", default="claude")
+    allp.add_argument("--backend", choices=("local", "ixvm"), default="local")
+
+    return parser
+
+
+def _search_backend(args: argparse.Namespace) -> SearchBackend:
+    return SearchBackend(
+        corpus=args.corpus or corpus_dir(),
+        search_bin=args.search_bin,
+        store=args.store,
+        max_count=args.max_count,
+        rerank=not getattr(args, "no_rerank", False),
+    )
+
+
+def _agent_backend(args: argparse.Namespace) -> LocalBackend | IxVmBackend:
+    if args.backend == "ixvm":
+        return IxVmBackend()
+    return LocalBackend(
+        corpus=args.corpus or corpus_dir(),
+        search_bin=args.search_bin,
+        claude_bin=args.claude_bin,
+        max_results=args.max_count,
+        agent_model=getattr(args, "agent_model", None),
+    )
+
+
+def _emit(report: dict[str, object], table: str, json_out: Path | None) -> None:
+    print(table)
+    if json_out is not None:
+        json_out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        print(f"\nwrote {json_out}", file=sys.stderr)
+
+
+def _run_retrieval(args: argparse.Namespace) -> dict[str, float]:
+    cases = data.load_retrieval(args.dataset)
+    if args.limit:
+        cases = cases[: args.limit]
+    judge = None if getattr(args, "no_judge", False) else Judge(model=args.judge_model)
+    results = run_retrieval(
+        cases, _search_backend(args), judge, judge_top_n=args.judge_top_n, progress=_progress
+    )
+    _emit(retrieval_report(results), render_retrieval_table(results), args.json_out)
+    return summarize_retrieval(results)
+
+
+def _run_agentic(args: argparse.Namespace) -> dict[str, float]:
+    cases = data.load_tasks(getattr(args, "dataset", None))
+    if args.limit:
+        cases = cases[: args.limit]
+    backend = _agent_backend(args)
+    # The agent's search tool runs with --no-sync, so the corpus must be indexed
+    # first. (The ixvm backend indexes inside the VM, so skip it here.)
+    if isinstance(backend, LocalBackend):
+        _progress("indexing corpus")
+        _search_backend(args).warmup()
+    results = run_agentic(
+        cases, backend, Judge(model=args.judge_model), progress=_progress
+    )
+    _emit(agentic_report(results), render_agentic_table(results), args.json_out)
+    return summarize_agentic(results)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if args.command == "retrieval":
+        summary = _run_retrieval(args)
+        if args.fail_under is not None and summary.get("ndcg@10", 0.0) < args.fail_under:
+            print(f"FAIL: nDCG@10 {summary.get('ndcg@10', 0.0):.3f} < {args.fail_under}", file=sys.stderr)
+            return 1
+        return 0
+
+    if args.command == "agentic":
+        summary = _run_agentic(args)
+        if args.fail_under is not None and summary.get("accuracy", 0.0) < args.fail_under:
+            print(f"FAIL: accuracy {summary.get('accuracy', 0.0):.3f} < {args.fail_under}", file=sys.stderr)
+            return 1
+        return 0
+
+    # `all`: run both tiers, no thresholds.
+    args.no_rerank = False
+    args.no_judge = False
+    args.judge_top_n = 3
+    args.dataset = None
+    print("== Tier A: retrieval ==")
+    _run_retrieval(args)
+    print("\n== Tier B: agentic ==")
+    args.json_out = None  # the per-tier reports already emitted; avoid clobber
+    _run_agentic(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/search-eval/src/search_eval/data.py
+++ b/packages/search-eval/src/search_eval/data.py
@@ -1,0 +1,49 @@
+"""Load the versioned eval sets from JSONL.
+
+The datasets are data, not code: one JSON object per line so a diff shows
+exactly which query or task changed. See ``datasets/retrieval.jsonl`` and
+``datasets/tasks.jsonl``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .model import RetrievalCase, TaskCase
+from .paths import dataset_path
+
+
+def _read_lines(name: str, override: Path | None) -> list[dict[str, Any]]:
+    """Read a JSONL dataset, from an explicit path or the packaged default."""
+    path = override if override is not None else dataset_path(name)
+    rows: list[dict[str, Any]] = []
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{name}:{lineno}: invalid JSON: {exc}") from exc
+    return rows
+
+
+def load_retrieval(override: Path | None = None) -> list[RetrievalCase]:
+    """Load the Tier A retrieval cases."""
+    cases: list[RetrievalCase] = []
+    for row in _read_lines("retrieval.jsonl", override):
+        relevant = {str(k): float(v) for k, v in dict(row["relevant"]).items()}
+        cases.append(
+            RetrievalCase(id=str(row["id"]), query=str(row["query"]), relevant=relevant)
+        )
+    return cases
+
+
+def load_tasks(override: Path | None = None) -> list[TaskCase]:
+    """Load the Tier B agentic task cases."""
+    return [
+        TaskCase(id=str(row["id"]), task=str(row["task"]), answer=str(row["answer"]))
+        for row in _read_lines("tasks.jsonl", override)
+    ]

--- a/packages/search-eval/src/search_eval/judge.py
+++ b/packages/search-eval/src/search_eval/judge.py
@@ -86,7 +86,13 @@ class Judge:
         )
         for block in resp.content:
             if isinstance(block, anthropic.types.ToolUseBlock):
-                return cast("dict[str, Any]", block.input)
+                out = cast("dict[str, Any]", block.input)
+                missing = [key for key in schema if key not in out]
+                if missing:
+                    # A grade missing required fields is an error, not a default:
+                    # silently treating it as 0/false would hide a broken judge.
+                    raise RuntimeError(f"judge omitted required fields: {missing}")
+                return out
         raise RuntimeError("judge returned no tool call")
 
     def grade_relevance(self, query: str, hit: Hit) -> RelevanceGrade:

--- a/packages/search-eval/src/search_eval/judge.py
+++ b/packages/search-eval/src/search_eval/judge.py
@@ -1,0 +1,125 @@
+"""LLM-as-judge grading, following Exa's open-eval rubric.
+
+Two grading modes, matching how the retrieval community separates concerns:
+
+- **Pointwise relevance** (Tier A): score each ``(query, result)`` pair on a
+  0-1 scale with an explicit rubric. This is Exa's "result grading" mode.
+- **Correctness** (Tier B): a yes/no verdict on whether an agent's final answer
+  matches the gold answer. This is the generative half of Exa's WebCode split.
+
+Robustness measures from the LLM-judge literature: a forced tool call for
+structured output, ``temperature=0`` for determinism, and a ``reasoning`` field
+emitted before the score so the verdict is chain-of-thought-grounded rather than
+a bare number. Position bias is moot here because grading is pointwise (one item
+at a time), not pairwise.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+import anthropic
+
+from .model import BinaryVerdict, Hit, RelevanceGrade
+
+# A capable mid-tier judge, the analog of the GPT-4.1 grader Exa reports.
+DEFAULT_JUDGE_MODEL = "claude-sonnet-4-6"
+
+_RELEVANCE_RUBRIC = """\
+You grade how well a single search RESULT answers a developer's QUERY over a code \
+search index. Be strict and calibrated.
+
+Score on a 0.0-1.0 scale:
+- 1.0: the result directly and fully answers the query (the right file/section).
+- 0.6-0.9: relevant and useful, but partial or adjacent.
+- 0.1-0.5: loosely related; shares vocabulary but does not answer the query.
+- 0.0: irrelevant.
+
+Fill `reasoning` first with one or two sentences, then `score`, then your \
+`confidence` (0.0-1.0) that another careful grader would agree."""
+
+_CORRECTNESS_RUBRIC = """\
+You grade whether a candidate ANSWER is factually correct given the GOLD answer \
+to a question about a codebase. Judge meaning, not wording: a different phrasing, \
+unit, or rounding that conveys the same fact is correct. A missing, hedged, or \
+wrong value is incorrect.
+
+Fill `reasoning` first with one sentence, then `passed` (true/false)."""
+
+
+@dataclass(frozen=True, slots=True)
+class Judge:
+    """A thin wrapper over the Anthropic Messages API for grading."""
+
+    model: str = DEFAULT_JUDGE_MODEL
+
+    def _client(self) -> anthropic.Anthropic:
+        try:
+            return anthropic.Anthropic()
+        except Exception as exc:  # noqa: BLE001 - surface a clear setup error
+            raise RuntimeError(
+                "could not construct the Anthropic client; set ANTHROPIC_API_KEY"
+            ) from exc
+
+    def _call(
+        self, system: str, user: str, schema: dict[str, object]
+    ) -> dict[str, Any]:
+        resp = self._client().messages.create(
+            model=self.model,
+            max_tokens=512,
+            temperature=0,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+            tools=[
+                {
+                    "name": "record_grade",
+                    "description": "Record the grading verdict.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": schema,
+                        "required": list(schema.keys()),
+                    },
+                }
+            ],
+            tool_choice={"type": "tool", "name": "record_grade"},
+        )
+        for block in resp.content:
+            if isinstance(block, anthropic.types.ToolUseBlock):
+                return cast("dict[str, Any]", block.input)
+        raise RuntimeError("judge returned no tool call")
+
+    def grade_relevance(self, query: str, hit: Hit) -> RelevanceGrade:
+        """Pointwise relevance of one hit to the query (Tier A)."""
+        user = f"QUERY:\n{query}\n\nRESULT (path: {hit.path}):\n{hit.text[:2000]}"
+        out = self._call(
+            _RELEVANCE_RUBRIC,
+            user,
+            {
+                "reasoning": {"type": "string"},
+                "score": {"type": "number", "minimum": 0, "maximum": 1},
+                "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+            },
+        )
+        return RelevanceGrade(
+            score=_clamp(float(out.get("score", 0.0))),
+            confidence=_clamp(float(out.get("confidence", 0.0))),
+            reasoning=str(out.get("reasoning", "")),
+        )
+
+    def grade_correctness(self, question: str, gold: str, answer: str) -> BinaryVerdict:
+        """Whether ``answer`` conveys the gold fact (Tier B)."""
+        user = f"QUESTION:\n{question}\n\nGOLD ANSWER:\n{gold}\n\nCANDIDATE ANSWER:\n{answer}"
+        out = self._call(
+            _CORRECTNESS_RUBRIC,
+            user,
+            {"reasoning": {"type": "string"}, "passed": {"type": "boolean"}},
+        )
+        return BinaryVerdict(
+            passed=bool(out.get("passed", False)),
+            reasoning=str(out.get("reasoning", "")),
+        )
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, value))

--- a/packages/search-eval/src/search_eval/mcp_server.py
+++ b/packages/search-eval/src/search_eval/mcp_server.py
@@ -1,0 +1,62 @@
+"""A one-tool MCP server exposing corpus-scoped search to the Tier B agent.
+
+This is the airtight version of the agent's tool boundary. A Bash-command
+wrapper cannot work: Claude Code's Bash allowlist is additive and does not
+reliably restrict other commands, so an agent allowed `Bash(corpus-search:*)`
+can still `cat` the corpus and read the answer without searching. The robust
+fix is to expose search as an MCP tool and *deny* Bash (and the file-reading
+tools) entirely, so the only way to learn anything about the corpus is to call
+this tool.
+
+The server is spawned by `claude -p` over stdio (see [`agent.py`]). It reads its
+configuration from the environment so the config file carries no logic:
+
+- ``SEARCH_EVAL_CORPUS``: the corpus directory to search (required).
+- ``SEARCH_EVAL_SEARCH_BIN``: the `search` binary (default ``search``).
+- ``SEARCH_EVAL_MAX_RESULTS``: results per query (default ``8``).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from .backend import SearchBackend
+
+mcp = FastMCP("corpus")
+
+
+def _backend() -> SearchBackend:
+    corpus = os.environ.get("SEARCH_EVAL_CORPUS")
+    if not corpus:
+        raise RuntimeError("SEARCH_EVAL_CORPUS is not set")
+    return SearchBackend(
+        corpus=Path(corpus),
+        search_bin=os.environ.get("SEARCH_EVAL_SEARCH_BIN", "search"),
+        max_count=int(os.environ.get("SEARCH_EVAL_MAX_RESULTS", "8")),
+    )
+
+
+@mcp.tool()
+def search(query: str) -> str:
+    """Semantic search over the codebase. Returns matching files with snippets.
+
+    This is the only way to read the codebase. Call it with a natural-language
+    query describing what you are looking for.
+    """
+    hits = _backend().search(query, no_sync=True)
+    if not hits:
+        return "No results."
+    return "\n\n".join(
+        f"### {hit.path} (score {hit.score:.2f})\n{hit.text}" for hit in hits
+    )
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/search-eval/src/search_eval/metrics.py
+++ b/packages/search-eval/src/search_eval/metrics.py
@@ -1,0 +1,148 @@
+"""Ranking metrics for retrieval evaluation.
+
+Pure functions over a ranked list of retrieved document ids and a `gold` map of
+`doc_id -> graded relevance`. No I/O, no network, no clock: this module is the
+deterministic, unit-tested core of the harness and the only part that gates CI.
+
+Conventions follow BEIR/TREC (the reference points Exa and the wider retrieval
+community report against):
+
+- **nDCG@k** uses exponential gain ``2**rel - 1`` with a ``log2(rank + 1)``
+  position discount, normalized by the ideal ranking. Binary relevance
+  (``rel = 1``) reduces to the familiar ``1 / log2(rank + 1)`` gain.
+- **Recall@k / Precision@k / MRR** treat any ``rel > 0`` doc as relevant.
+
+A `gold` value is a relevance grade: ``1`` for binary "relevant", or a small
+integer (e.g. ``0..3``) for graded relevance. Graded labels give nDCG its
+discriminative power (a perfect hit outranks a loosely related one); see the
+ZeroEntropy MTEB re-annotation argument referenced in the README.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+
+__all__ = [
+    "dcg",
+    "ndcg_at_k",
+    "ndcg_from_scores",
+    "recall_at_k",
+    "precision_at_k",
+    "mrr",
+    "RetrievalScores",
+    "score_ranking",
+]
+
+from dataclasses import dataclass
+
+
+def _gain(rel: float) -> float:
+    """Exponential gain ``2**rel - 1``; ``rel <= 0`` contributes nothing."""
+    if rel <= 0:
+        return 0.0
+    return (2.0**rel) - 1.0
+
+
+def dcg(relevances: Sequence[float]) -> float:
+    """Discounted cumulative gain of a ranked relevance sequence.
+
+    Rank is 1-based, so position ``i`` (0-based) is discounted by
+    ``log2(i + 2)``.
+    """
+    return sum(_gain(rel) / math.log2(i + 2) for i, rel in enumerate(relevances))
+
+
+def ndcg_at_k(retrieved: Sequence[str], gold: Mapping[str, float], k: int) -> float:
+    """Normalized DCG over the top ``k`` retrieved ids.
+
+    Returns ``0.0`` when no relevant documents exist (an empty `gold`), matching
+    the convention that an undefined ideal DCG scores zero rather than raising.
+    """
+    if k <= 0:
+        return 0.0
+    ranked = [gold.get(doc_id, 0.0) for doc_id in retrieved[:k]]
+    actual = dcg(ranked)
+    ideal_rels = sorted((rel for rel in gold.values() if rel > 0), reverse=True)[:k]
+    ideal = dcg(ideal_rels)
+    if ideal == 0.0:
+        return 0.0
+    return actual / ideal
+
+
+def ndcg_from_scores(scores: Sequence[float], k: int = 10) -> float:
+    """Label-free nDCG over per-result relevance scores (e.g. an LLM judge's).
+
+    Treats ``scores`` as the graded relevance of the ranking in order, and
+    normalizes by the same scores sorted descending. A ranking that puts its
+    most relevant result first scores near ``1.0``; burying it discounts the
+    result. Returns ``0.0`` when every score is zero.
+
+    This is the aggregation Exa uses for label-free grading: a flat mean would
+    punish a perfect ranking that has one relevant result and an off-topic tail.
+    """
+    if k <= 0:
+        return 0.0
+    actual = dcg(list(scores)[:k])
+    ideal = dcg(sorted(scores, reverse=True)[:k])
+    if ideal == 0.0:
+        return 0.0
+    return actual / ideal
+
+
+def recall_at_k(retrieved: Sequence[str], gold: Mapping[str, float], k: int) -> float:
+    """Fraction of all relevant docs that appear in the top ``k``."""
+    relevant = {doc_id for doc_id, rel in gold.items() if rel > 0}
+    if not relevant:
+        return 0.0
+    found = relevant.intersection(retrieved[:k])
+    return len(found) / len(relevant)
+
+
+def precision_at_k(retrieved: Sequence[str], gold: Mapping[str, float], k: int) -> float:
+    """Fraction of the top ``k`` retrieved docs that are relevant."""
+    if k <= 0:
+        return 0.0
+    relevant = {doc_id for doc_id, rel in gold.items() if rel > 0}
+    found = sum(1 for doc_id in retrieved[:k] if doc_id in relevant)
+    return found / k
+
+
+def mrr(retrieved: Sequence[str], gold: Mapping[str, float]) -> float:
+    """Reciprocal rank of the first relevant doc; ``0.0`` if none is retrieved."""
+    relevant = {doc_id for doc_id, rel in gold.items() if rel > 0}
+    for rank, doc_id in enumerate(retrieved, start=1):
+        if doc_id in relevant:
+            return 1.0 / rank
+    return 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalScores:
+    """The standard metric bundle for one query's ranking."""
+
+    ndcg_at_10: float
+    recall_at_5: float
+    recall_at_10: float
+    mrr: float
+    precision_at_5: float
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "ndcg@10": self.ndcg_at_10,
+            "recall@5": self.recall_at_5,
+            "recall@10": self.recall_at_10,
+            "mrr": self.mrr,
+            "precision@5": self.precision_at_5,
+        }
+
+
+def score_ranking(retrieved: Sequence[str], gold: Mapping[str, float]) -> RetrievalScores:
+    """Compute the full metric bundle for one ranked result list."""
+    return RetrievalScores(
+        ndcg_at_10=ndcg_at_k(retrieved, gold, 10),
+        recall_at_5=recall_at_k(retrieved, gold, 5),
+        recall_at_10=recall_at_k(retrieved, gold, 10),
+        mrr=mrr(retrieved, gold),
+        precision_at_5=precision_at_k(retrieved, gold, 5),
+    )

--- a/packages/search-eval/src/search_eval/model.py
+++ b/packages/search-eval/src/search_eval/model.py
@@ -1,0 +1,102 @@
+"""Shared data types for the eval harness.
+
+Small frozen dataclasses for the values that flow between the backend, the
+judge, and the report. Domain data is named, not anonymous tuples.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class Hit:
+    """One search result, mirroring the `search --json` object shape."""
+
+    path: str
+    source: str
+    score: float
+    start_line: int | None
+    num_lines: int | None
+    text: str
+
+    @classmethod
+    def from_json(cls, obj: dict[str, Any]) -> "Hit":
+        return cls(
+            path=str(obj["path"]),
+            source=str(obj.get("source", "code")),
+            score=float(obj.get("score", 0.0)),
+            start_line=_opt_int(obj.get("start_line")),
+            num_lines=_opt_int(obj.get("num_lines")),
+            text=str(obj.get("text", "")),
+        )
+
+
+def _opt_int(value: object) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float, str)):
+        return int(value)
+    raise TypeError(f"expected an int-like value, got {type(value).__name__}")
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalCase:
+    """A Tier A case: a query and its graded gold documents.
+
+    `relevant` maps a corpus-relative path to a relevance grade (``1`` binary,
+    or a small integer for graded relevance).
+    """
+
+    id: str
+    query: str
+    relevant: dict[str, float]
+
+
+@dataclass(frozen=True, slots=True)
+class TaskCase:
+    """A Tier B case: an agent task whose answer is only in the corpus."""
+
+    id: str
+    task: str
+    answer: str
+
+
+@dataclass(frozen=True, slots=True)
+class RelevanceGrade:
+    """An LLM judge's pointwise relevance verdict for one (query, hit) pair."""
+
+    score: float
+    confidence: float
+    reasoning: str
+
+
+@dataclass(frozen=True, slots=True)
+class BinaryVerdict:
+    """An LLM judge's yes/no verdict with its reasoning (correctness/groundedness)."""
+
+    passed: bool
+    reasoning: str
+
+
+@dataclass(slots=True)
+class RetrievalResult:
+    """Per-case Tier A outcome: ranking metrics plus the judge's mean relevance."""
+
+    case: RetrievalCase
+    retrieved: list[str]
+    metrics: dict[str, float]
+    judge_relevance: float | None = None
+    grades: list[RelevanceGrade] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class TaskResult:
+    """Per-case Tier B outcome: the agent's answer and the correctness verdict."""
+
+    case: TaskCase
+    answer: str
+    correct: bool
+    reasoning: str
+    error: str | None = None

--- a/packages/search-eval/src/search_eval/paths.py
+++ b/packages/search-eval/src/search_eval/paths.py
@@ -1,0 +1,34 @@
+"""Resolve the on-disk locations of the corpus and datasets.
+
+The corpus and eval sets ship as plain files at the package root, not as
+importable resources, because `search` needs a real directory to index. Two
+resolution paths:
+
+- ``SEARCH_EVAL_DATA_DIR``: set by the Nix wrapper to the installed data tree.
+- source layout: when running from a checkout, derive the package root from this
+  file's location (``.../packages/search-eval``).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def data_root() -> Path:
+    """Directory holding ``corpus/`` and ``datasets/``."""
+    env = os.environ.get("SEARCH_EVAL_DATA_DIR")
+    if env:
+        return Path(env)
+    # src/search_eval/paths.py -> packages/search-eval
+    return Path(__file__).resolve().parents[2]
+
+
+def corpus_dir() -> Path:
+    """The fixture corpus `search` indexes and searches over."""
+    return data_root() / "corpus"
+
+
+def dataset_path(name: str) -> Path:
+    """A packaged dataset file under ``datasets/``."""
+    return data_root() / "datasets" / name

--- a/packages/search-eval/src/search_eval/report.py
+++ b/packages/search-eval/src/search_eval/report.py
@@ -1,0 +1,117 @@
+"""Aggregate results and render them as a table and a JSON report.
+
+The JSON report is the durable artifact (pin it in CI, diff it across runs); the
+table is the at-a-glance human view. Metric names are spelled with their `@k`
+cutoff so a number is never ambiguous.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from .model import RetrievalResult, TaskResult
+
+_METRIC_ORDER = ["ndcg@10", "recall@5", "recall@10", "mrr", "precision@5"]
+
+
+def summarize_retrieval(results: Sequence[RetrievalResult]) -> dict[str, float]:
+    """Mean of each metric (and judge relevance, if graded) over all cases."""
+    if not results:
+        return {}
+    summary = {
+        name: sum(r.metrics.get(name, 0.0) for r in results) / len(results)
+        for name in _METRIC_ORDER
+    }
+    graded = [r.judge_relevance for r in results if r.judge_relevance is not None]
+    if graded:
+        summary["judge_relevance"] = sum(graded) / len(graded)
+    return summary
+
+
+def summarize_agentic(results: Sequence[TaskResult]) -> dict[str, float]:
+    """Agentic accuracy: fraction of tasks the agent answered correctly."""
+    if not results:
+        return {}
+    correct = sum(1 for r in results if r.correct)
+    errored = sum(1 for r in results if r.error)
+    return {
+        "accuracy": correct / len(results),
+        "correct": float(correct),
+        "errored": float(errored),
+        "total": float(len(results)),
+    }
+
+
+def retrieval_report(results: Sequence[RetrievalResult]) -> dict[str, object]:
+    return {
+        "tier": "retrieval",
+        "summary": summarize_retrieval(results),
+        "cases": [
+            {
+                "id": r.case.id,
+                "query": r.case.query,
+                "retrieved": r.retrieved[:10],
+                "metrics": r.metrics,
+                "judge_relevance": r.judge_relevance,
+            }
+            for r in results
+        ],
+    }
+
+
+def agentic_report(results: Sequence[TaskResult]) -> dict[str, object]:
+    return {
+        "tier": "agentic",
+        "summary": summarize_agentic(results),
+        "cases": [
+            {
+                "id": r.case.id,
+                "task": r.case.task,
+                "gold": r.case.answer,
+                "answer": r.answer,
+                "correct": r.correct,
+                "reasoning": r.reasoning,
+                "error": r.error,
+            }
+            for r in results
+        ],
+    }
+
+
+def render_retrieval_table(results: Sequence[RetrievalResult]) -> str:
+    """A fixed-width table: one row per case, then the mean row."""
+    header = f"{'case':<22} {'nDCG@10':>8} {'R@5':>6} {'R@10':>6} {'MRR':>6} {'jNDCG':>6}"
+    lines = [header, "-" * len(header)]
+    for r in results:
+        jr = "-" if r.judge_relevance is None else f"{r.judge_relevance:.2f}"
+        lines.append(
+            f"{r.case.id:<22} {r.metrics['ndcg@10']:>8.3f} {r.metrics['recall@5']:>6.2f} "
+            f"{r.metrics['recall@10']:>6.2f} {r.metrics['mrr']:>6.2f} {jr:>6}"
+        )
+    summary = summarize_retrieval(results)
+    if summary:
+        jr = f"{summary['judge_relevance']:.2f}" if "judge_relevance" in summary else "-"
+        lines.append("-" * len(header))
+        lines.append(
+            f"{'MEAN':<22} {summary['ndcg@10']:>8.3f} {summary['recall@5']:>6.2f} "
+            f"{summary['recall@10']:>6.2f} {summary['mrr']:>6.2f} {jr:>6}"
+        )
+    return "\n".join(lines)
+
+
+def render_agentic_table(results: Sequence[TaskResult]) -> str:
+    header = f"{'task':<22} {'correct':>8}  answer"
+    lines = [header, "-" * len(header)]
+    for r in results:
+        mark = "ERROR" if r.error else ("yes" if r.correct else "no")
+        detail = r.error if r.error else r.answer
+        lines.append(f"{r.case.id:<22} {mark:>8}  {detail[:48]}")
+    summary = summarize_agentic(results)
+    if summary:
+        lines.append("-" * len(header))
+        lines.append(
+            f"{'ACCURACY':<22} {summary['accuracy']:>8.2f}  "
+            f"({int(summary['correct'])}/{int(summary['total'])}, "
+            f"{int(summary['errored'])} errored)"
+        )
+    return "\n".join(lines)

--- a/packages/search-eval/src/search_eval/runner.py
+++ b/packages/search-eval/src/search_eval/runner.py
@@ -36,7 +36,10 @@ def run_retrieval(
     for case in cases:
         progress(f"retrieval: {case.id}")
         hits = backend.search(case.query, no_sync=True)
-        retrieved = [hit.path for hit in hits]
+        # De-duplicate by path, keeping the best (first) rank: a real checkout
+        # can return several chunks of one file, which would otherwise count a
+        # relevant doc more than once and miscalibrate nDCG/precision.
+        retrieved = list(dict.fromkeys(hit.path for hit in hits))
         result = RetrievalResult(
             case=case,
             retrieved=retrieved,

--- a/packages/search-eval/src/search_eval/runner.py
+++ b/packages/search-eval/src/search_eval/runner.py
@@ -1,0 +1,81 @@
+"""Orchestrate a tier: search/agent, then grade, then collect results.
+
+Kept free of presentation and argument parsing so it can be driven from the CLI
+or a notebook. The two entry points mirror Exa's two evaluation modes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+from .agent import LocalBackend, IxVmBackend
+from .backend import SearchBackend
+from .judge import Judge
+from .metrics import ndcg_from_scores, score_ranking
+from .model import RetrievalCase, RetrievalResult, TaskCase, TaskResult
+
+Progress = Callable[[str], None]
+
+
+def _noop(_: str) -> None:
+    return None
+
+
+def run_retrieval(
+    cases: Sequence[RetrievalCase],
+    backend: SearchBackend,
+    judge: Judge | None,
+    *,
+    judge_top_n: int = 3,
+    progress: Progress = _noop,
+) -> list[RetrievalResult]:
+    """Tier A: rank with `search`, score against gold, optionally LLM-grade hits."""
+    progress("indexing corpus")
+    backend.warmup()
+    results: list[RetrievalResult] = []
+    for case in cases:
+        progress(f"retrieval: {case.id}")
+        hits = backend.search(case.query, no_sync=True)
+        retrieved = [hit.path for hit in hits]
+        result = RetrievalResult(
+            case=case,
+            retrieved=retrieved,
+            metrics=score_ranking(retrieved, case.relevant).as_dict(),
+        )
+        if judge is not None and hits:
+            grades = [judge.grade_relevance(case.query, hit) for hit in hits[:judge_top_n]]
+            result.grades = grades
+            # Rank-aware, label-free: nDCG over the judge's per-result scores.
+            result.judge_relevance = ndcg_from_scores([g.score for g in grades])
+        results.append(result)
+    return results
+
+
+def run_agentic(
+    cases: Sequence[TaskCase],
+    agent: LocalBackend | IxVmBackend,
+    judge: Judge,
+    *,
+    progress: Progress = _noop,
+) -> list[TaskResult]:
+    """Tier B: answer each task via `claude -p`, then grade correctness."""
+    results: list[TaskResult] = []
+    for case in cases:
+        progress(f"agentic: {case.id}")
+        try:
+            answer = agent.run_task(case)
+        except Exception as exc:  # noqa: BLE001 - record, don't abort the suite
+            results.append(
+                TaskResult(case=case, answer="", correct=False, reasoning="", error=str(exc))
+            )
+            continue
+        verdict = judge.grade_correctness(case.task, case.answer, answer)
+        results.append(
+            TaskResult(
+                case=case,
+                answer=answer,
+                correct=verdict.passed,
+                reasoning=verdict.reasoning,
+            )
+        )
+    return results

--- a/packages/search-eval/tests/test_metrics.py
+++ b/packages/search-eval/tests/test_metrics.py
@@ -1,0 +1,90 @@
+"""Offline, deterministic checks for the ranking metrics.
+
+Runnable as a plain script (``python tests/test_metrics.py``) so the Nix build
+can exercise it against the installed package with no test runner or network.
+"""
+
+from __future__ import annotations
+
+import math
+
+from search_eval.metrics import (
+    mrr,
+    ndcg_at_k,
+    ndcg_from_scores,
+    precision_at_k,
+    recall_at_k,
+    score_ranking,
+)
+
+
+def test_perfect_ranking() -> None:
+    gold = {"a.py": 1.0}
+    assert ndcg_at_k(["a.py", "b.py"], gold, 10) == 1.0
+    assert mrr(["a.py", "b.py"], gold) == 1.0
+    assert recall_at_k(["a.py"], gold, 10) == 1.0
+
+
+def test_rank_discount() -> None:
+    gold = {"a.py": 1.0}
+    # Relevant doc at rank 2: gain 1 / log2(3).
+    expected = (1.0 / math.log2(3)) / 1.0
+    assert math.isclose(ndcg_at_k(["x.py", "a.py"], gold, 10), expected, rel_tol=1e-9)
+    assert mrr(["x.py", "a.py"], gold) == 0.5
+
+
+def test_missing_relevant() -> None:
+    gold = {"a.py": 1.0}
+    assert ndcg_at_k(["x.py", "y.py"], gold, 10) == 0.0
+    assert recall_at_k(["x.py"], gold, 10) == 0.0
+    assert mrr(["x.py"], gold) == 0.0
+
+
+def test_empty_gold_is_zero() -> None:
+    assert ndcg_at_k(["a.py"], {}, 10) == 0.0
+    assert recall_at_k(["a.py"], {}, 10) == 0.0
+
+
+def test_graded_relevance_orders_by_gain() -> None:
+    # A high-grade doc above a low-grade doc beats the reverse order.
+    gold = {"hi.py": 2.0, "lo.py": 1.0}
+    good = ndcg_at_k(["hi.py", "lo.py"], gold, 10)
+    worse = ndcg_at_k(["lo.py", "hi.py"], gold, 10)
+    assert good == 1.0
+    assert worse < good
+
+
+def test_precision_and_recall_at_k() -> None:
+    gold = {"a.py": 1.0, "b.py": 1.0}
+    ranked = ["a.py", "x.py", "b.py", "y.py"]
+    assert precision_at_k(ranked, gold, 2) == 0.5
+    assert recall_at_k(ranked, gold, 2) == 0.5
+    assert recall_at_k(ranked, gold, 3) == 1.0
+
+
+def test_ndcg_from_scores() -> None:
+    # A relevant result at rank 1 with an off-topic tail still scores 1.0.
+    assert ndcg_from_scores([1.0, 0.0, 0.0]) == 1.0
+    # Burying the relevant result discounts it below 1.0.
+    assert ndcg_from_scores([0.0, 1.0, 0.0]) < 1.0
+    # All-zero scores are 0.0, not a divide-by-zero.
+    assert ndcg_from_scores([0.0, 0.0]) == 0.0
+
+
+def test_score_ranking_bundle() -> None:
+    scores = score_ranking(["a.py"], {"a.py": 1.0})
+    d = scores.as_dict()
+    assert set(d) == {"ndcg@10", "recall@5", "recall@10", "mrr", "precision@5"}
+    assert d["ndcg@10"] == 1.0
+    assert d["mrr"] == 1.0
+
+
+def _main() -> None:
+    tests = [v for name, v in sorted(globals().items()) if name.startswith("test_")]
+    for test in tests:
+        test()
+    print(f"ok: {len(tests)} metric tests passed")
+
+
+if __name__ == "__main__":
+    _main()

--- a/packages/search-eval/uv.lock
+++ b/packages/search-eval/uv.lock
@@ -1,0 +1,282 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.105.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/46/47581b8c689c743ceabf6a0f9ff48472160900ce802d26c0fb50423997b3/anthropic-0.105.2.tar.gz", hash = "sha256:0e26b90841c2dced7cc6e98d21d5517d0be33f1876b8e779f478202e28bcaa07", size = 853789, upload-time = "2026-05-29T00:21:14.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/75/be0c357e33a5a56c8f9db5b4212f886138d2bf59c0952d858f6b75d710ef/anthropic-0.105.2-py3-none-any.whl", hash = "sha256:e53ed5f6bf36fb1ecb9b25d8634cfd30e02fab9fb3374a0c2d5c585874757230", size = 837507, upload-time = "2026-05-29T00:21:15.528Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829, upload-time = "2026-05-19T10:07:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445, upload-time = "2026-05-19T10:08:01.184Z" },
+    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181, upload-time = "2026-05-19T10:08:02.688Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985, upload-time = "2026-05-19T10:08:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292, upload-time = "2026-05-19T10:08:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501, upload-time = "2026-05-19T10:08:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683, upload-time = "2026-05-19T10:08:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892, upload-time = "2026-05-19T10:08:11.352Z" },
+    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723, upload-time = "2026-05-19T10:08:12.912Z" },
+    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648, upload-time = "2026-05-19T10:08:14.808Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382, upload-time = "2026-05-19T10:08:16.927Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845, upload-time = "2026-05-19T10:08:18.401Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842, upload-time = "2026-05-19T10:08:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212, upload-time = "2026-05-19T10:08:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065, upload-time = "2026-05-19T10:08:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444, upload-time = "2026-05-19T10:08:24.701Z" },
+    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779, upload-time = "2026-05-19T10:08:26.408Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395, upload-time = "2026-05-19T10:08:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516, upload-time = "2026-05-19T10:08:29.35Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
+    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+]
+
+[[package]]
+name = "search-eval"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "anthropic" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "anthropic", specifier = ">=0.40.0" }]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]

--- a/packages/search-eval/uv.lock
+++ b/packages/search-eval/uv.lock
@@ -43,12 +43,140 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
 ]
 
 [[package]]
@@ -104,6 +232,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]
@@ -167,6 +304,67 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
     { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
     { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -241,15 +439,186 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
+    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/99/4638f672ab356682d633ee0da9255f5b67ce6efd0b85eb94ad3e255e65a5/rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46", size = 405059, upload-time = "2026-05-28T11:59:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/7b3388c796fcf471bd17194242d4dc1a7608567c0fa422bcc1c5e79f9c1e/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f", size = 618975, upload-time = "2026-05-28T11:59:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/74/e758c03a5ef46f04c37f2651a2893db846d569ba8a7bca469d4b58939bcd/rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842", size = 212481, upload-time = "2026-05-28T11:59:53.148Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ec/a2aca432db9c7359b40fa393eeeaa0d166c2f70175be956e75fa24197c44/rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf", size = 228519, upload-time = "2026-05-28T11:59:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/29/60/a73bfdd45b096574556acf303bbd9fa9eed36ca8a818b514e2a5d5fe2b9d/rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd", size = 223446, upload-time = "2026-05-28T11:59:56.081Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e2/408105fd611823f00882aea810f3989a30d26b1bab8b6beb20f98c724e0e/rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600", size = 355287, upload-time = "2026-05-28T11:59:57.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b4/db7aaabdda6d020afc87d981bcc2f57a434c7dec60ecfc2ab3dd50b20351/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2", size = 408578, upload-time = "2026-05-28T12:00:10.779Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ab/1a71ea3589c4345dac0a0518f0e6a031cb42689277851b683c46d27463a5/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1", size = 620861, upload-time = "2026-05-28T12:00:14.09Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/3b2c0a75c9e04125696f84ebdbbf304acf5a40b58ba4481cdb98a922c3ba/rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc", size = 210074, upload-time = "2026-05-28T12:00:17.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8b/609157d5a25d37d4f29f92840ba531f416907c34ae5c5739dd21fc2bef98/rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55", size = 228635, upload-time = "2026-05-28T12:00:18.73Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
+]
+
+[[package]]
 name = "search-eval"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "mcp" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "anthropic", specifier = ">=0.40.0" }]
+requires-dist = [
+    { name = "anthropic", specifier = ">=0.40.0" },
+    { name = "mcp", specifier = ">=1.0.0" },
+]
 
 [[package]]
 name = "sniffio"
@@ -258,6 +627,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]
@@ -279,4 +673,17 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
 ]

--- a/packages/search/src/main.rs
+++ b/packages/search/src/main.rs
@@ -198,6 +198,9 @@ struct SemanticArgs {
 
 /// Arguments for the `grep` subcommand. Grep is local-corpus only (no web
 /// store) and shares the connection flags with the semantic path.
+// Like `SemanticArgs`, this is a flat surface of independent boolean flags; a
+// state machine would obscure rather than clarify it.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Args)]
 struct GrepArgs {
     /// The regular expression to match against the indexed chunks.
@@ -436,15 +439,7 @@ async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
         if let Some(bar) = &bar {
             bar.finish_and_clear();
         }
-        if cli.json {
-            // Machine-readable mode: one JSON array on stdout for the eval
-            // harness and any other consumer, instead of the human listing.
-            println!("{}", search_core::hits_to_json(&hits)?);
-        } else {
-            for hit in &hits {
-                println!("{}", render(hit, cli.content, &palette, &root, theme));
-            }
-        }
+        print_hits(&hits, cli.json, cli.content, &palette, &root, theme)?;
     }
 
     Ok(())
@@ -542,15 +537,7 @@ async fn run_grep(cli: GrepArgs) -> anyhow::Result<()> {
         bar.finish_and_clear();
     }
 
-    if cli.json {
-        // Machine-readable mode: one JSON array on stdout, same shape as the
-        // semantic path.
-        println!("{}", search_core::hits_to_json(&hits)?);
-    } else {
-        for hit in &hits {
-            println!("{}", render(hit, cli.content, &palette, &root, theme));
-        }
-    }
+    print_hits(&hits, cli.json, cli.content, &palette, &root, theme)?;
 
     Ok(())
 }
@@ -659,6 +646,33 @@ fn detect_theme(color: bool) -> code_highlight::Theme {
         terminal_theme::Theme::Light => code_highlight::Theme::Light,
         terminal_theme::Theme::Dark => code_highlight::Theme::Dark,
     }
+}
+
+/// Print hits as a JSON array (`--json`) or the human listing.
+///
+/// Shared by the semantic and grep paths so the machine-readable contract is
+/// emitted in exactly one place.
+///
+/// # Errors
+/// Returns an error if JSON serialization of the hits fails.
+fn print_hits(
+    hits: &[DisplayHit],
+    json: bool,
+    show_content: bool,
+    palette: &Palette,
+    root: &Path,
+    theme: code_highlight::Theme,
+) -> anyhow::Result<()> {
+    if json {
+        // Machine-readable mode: one JSON array on stdout for the eval harness
+        // and any other consumer, instead of the human listing.
+        println!("{}", search_core::hits_to_json(hits)?);
+    } else {
+        for hit in hits {
+            println!("{}", render(hit, show_content, palette, root, theme));
+        }
+    }
+    Ok(())
 }
 
 fn render(

--- a/packages/search/src/main.rs
+++ b/packages/search/src/main.rs
@@ -178,6 +178,11 @@ struct SemanticArgs {
     #[arg(long)]
     agentic: bool,
 
+    /// Emit results as a JSON array on stdout instead of the human listing.
+    /// Each element is `{path, source, start_line, num_lines, score, text}`.
+    #[arg(long)]
+    json: bool,
+
     /// Source and repo scope selectors.
     #[command(flatten)]
     scope: ScopeArgs,
@@ -216,6 +221,11 @@ struct GrepArgs {
     /// Search the store as-is: skip detecting and embedding new files.
     #[arg(long = "no-sync")]
     no_sync: bool,
+
+    /// Emit results as a JSON array on stdout instead of the human listing.
+    /// Each element is `{path, source, start_line, num_lines, score, text}`.
+    #[arg(long)]
+    json: bool,
 
     /// Source and repo scope selectors.
     #[command(flatten)]
@@ -402,6 +412,10 @@ async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
     };
 
     if cli.answer {
+        anyhow::ensure!(
+            !cli.json,
+            "--json is not supported with --answer; pass one or the other",
+        );
         let view =
             search_core::index_and_answer(&store, &query, &config, on_upload, on_poll)
                 .await?;
@@ -422,8 +436,14 @@ async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
         if let Some(bar) = &bar {
             bar.finish_and_clear();
         }
-        for hit in &hits {
-            println!("{}", render(hit, cli.content, &palette, &root, theme));
+        if cli.json {
+            // Machine-readable mode: one JSON array on stdout for the eval
+            // harness and any other consumer, instead of the human listing.
+            println!("{}", search_core::hits_to_json(&hits)?);
+        } else {
+            for hit in &hits {
+                println!("{}", render(hit, cli.content, &palette, &root, theme));
+            }
         }
     }
 
@@ -522,8 +542,14 @@ async fn run_grep(cli: GrepArgs) -> anyhow::Result<()> {
         bar.finish_and_clear();
     }
 
-    for hit in &hits {
-        println!("{}", render(hit, cli.content, &palette, &root, theme));
+    if cli.json {
+        // Machine-readable mode: one JSON array on stdout, same shape as the
+        // semantic path.
+        println!("{}", search_core::hits_to_json(&hits)?);
+    } else {
+        for hit in &hits {
+            println!("{}", render(hit, cli.content, &palette, &root, theme));
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## What

`packages/search-eval`: a two-tier evaluation harness for the [`search`](../search) engine, following how [Exa](https://exa.ai) runs its "open evals". Plus a small `search --json` machine-readable mode the harness consumes.

**Tier A — retrieval grading.** Rank a committed fixture corpus per query and score the ranking against gold labels (nDCG@10, Recall@k, MRR), plus an optional label-free LLM relevance judge (jNDCG: rank-aware nDCG over the judge's per-result scores). Cheap, reproducible, gateable.

**Tier B — agentic downstream.** Run a headless `claude -p` whose only tool is a corpus-scoped search, then grade whether it answered correctly. This is the "does our search actually help an agent" signal (Exa's RAG/SimpleQA mode). The local sandbox backend ships; an ix-VM backend is a typed, deferred seam.

## Run

```
nix run .#search-eval -- retrieval        # Tier A (LLM judge on by default)
nix run .#search-eval -- retrieval --no-judge
nix run .#search-eval -- agentic          # Tier B (claude -p)
nix run .#search-eval -- all --json-out report.json
```

Needs a Mixedbread credential for `search` and `ANTHROPIC_API_KEY` for grading and the agent. These are live, networked evals run on demand or nightly; the ranking metrics are pure and unit-tested as the CI-gating signal.

## `search --json`

`search` and `search grep` gain `--json`, emitting a JSON array of `{path, source, start_line, num_lines, score, text}` instead of the human listing. The serialization is owned by `search-core` (`DisplayHit: Serialize`, `hits_to_json`) so the shape is defined once; `--json --answer` is a typed error rather than a silent ignore. This is the contract the harness parses instead of scraping human output, and it helps any agent consuming `search`.

## Methodology

Drawn from Exa's writing on evaluating neural search: [Evals at Exa](https://exa.ai/blog/evals-at-exa), [WebCode](https://exa.ai/blog/webcode), [Evaluating Exa search](https://exa.ai/docs/reference/evaluating-exa-search). Highlights: real gold labels where the corpus is ours (Exa's preference where enumerating relevant docs is feasible); LLM judge with forced tool-use, `temperature=0`, and reasoning-before-score; the corpus uses specific made-up constants so a correct answer is evidence of retrieval, not parametric memory.

## Design notes for review

- **Python (uv), not Rust.** This is an iteration-heavy eval harness, not domain logic; `search` already exposes a Python binding and the reference harness ([exa-labs/benchmarks](https://github.com/exa-labs/benchmarks)) is Python. Core search logic stays in Rust, and the only machine-readable contract lives at its owner (`search --json`). Push back if you'd rather this be Rust.
- **ix-VM backend deferred.** ix VMs run on x86_64-linux compute nodes, so the agent-in-VM path can't be exercised from a macOS host. It is wired as a typed error, not a silent fallback to local.

## Validation

- `nix build .#search-eval` (runs `ty`)
- `passthru.tests.metrics` (offline metric unit tests) and `passthru.tests.printsHelp`
- live Tier A run: nDCG@10 / Recall / MRR / jNDCG all 1.0 on the fixture set
- live Tier B run: `claude -p` answered 2/2 correctly using only search

---
Made with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `search --json` flag and an Exa-style eval harness for search quality
> - Adds a `--json` flag to the `search` CLI (both semantic and grep paths) that emits results as a JSON array via a new `hits_to_json` function; combining `--json` with `--answer` is rejected with an error.
> - Introduces the `search-eval` package: a Python evaluation harness with two tiers — Tier A (retrieval metrics: nDCG, Recall, MRR) and Tier B (agentic tasks via `claude` constrained to a search MCP tool).
> - The harness uses `search --json` as its backend, ships bundled corpus/dataset files, and includes an LLM-based judge for label-free relevance and correctness grading.
> - A Nix derivation packages `search-eval` as a distributable binary with embedded data and offline metric tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb31c77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->