### PR TITLE
feat(mcp): connect ix-mcp to Claude Code by default

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "enabledMcpjsonServers": ["ix"],
   "extraKnownMarketplaces": {
     "mixedbread-skills": {
       "source": {

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "ix": {
+      "type": "stdio",
+      "command": "nix",
+      "args": ["run", "${CLAUDE_PROJECT_DIR:-.}#mcp", "--", "serve"]
+    }
+  }
+}

--- a/agent-context/sections/21-ix-mcp.md
+++ b/agent-context/sections/21-ix-mcp.md
@@ -1,0 +1,40 @@
+---
+name: ix-mcp
+disclosure: progressive
+description: "The ix MCP server (a pinned Python interpreter with bundled search, PTY, browser, and screen modules) is wired into Claude Code by default. Use when you want to run Python with top-level await, search the codebase semantically, drive a PTY, or automate a browser from inside a session."
+---
+
+## ix MCP server
+
+Every Claude Code session in this repo gets the `ix` MCP server by default. It is
+declared in [`.mcp.json`](.mcp.json) at the repo root and pre-approved through
+`enabledMcpjsonServers` in [`.claude/settings.json`](.claude/settings.json), so
+the `mcp__ix__*` tools are connected with no per-session approval prompt. The
+server itself is the [`packages/mcp`](packages/mcp) crate (`ix-mcp`), launched
+with `nix run .#mcp -- serve`; that flakeref is the single source of truth, so
+the config tracks the current checkout with no separate build step.
+
+The server is a single pinned Python interpreter, not a grab bag of shell tools.
+Sessions are persistent and single-threaded with a live asyncio loop, so
+top-level `await` works (never call `asyncio.run()`), and any async resource
+created in one call stays alive for later calls.
+
+Tools it exposes:
+
+- `python_eval` / `python_exec` — evaluate an expression or run statements, with
+  top-level await. Open figures and objects with a `_repr_png_` come back as MCP
+  image blocks.
+- `python_session_create` / `python_session_list` / `python_session_close` /
+  `python_reset` — manage persistent named sessions.
+- `search_semantic` / `search_grep` — semantic code search and regex grep over
+  the indexed chunks, the same engine the `searching` skill describes.
+
+Bundled in the interpreter so every session imports them with no install step:
+`tui` (PTY driver for terminal automation), `search`, `playwright` (browsers
+pre-cached, async API), `numpy`, `polars`, `matplotlib`, `asyncssh`, and on
+macOS `screen` (screenshot, cursor, synthetic clicks). Each session also has a
+writable venv, so an in-session `pip install` resolves to that venv.
+
+Reach for it instead of shelling out when you want a persistent Python REPL,
+semantic search results in-context, or browser/terminal automation that keeps
+state across calls.


### PR DESCRIPTION
Every Claude Code session in this repo now connects the repo-owned **ix-mcp** server ([`packages/mcp`](packages/mcp)) automatically, with no manual approval prompt.

## What changed

- **`.mcp.json`** (new): declares the `ix` stdio server as `nix run ${CLAUDE_PROJECT_DIR:-.}#mcp -- serve`. The flakeref is the single source of truth, so the config tracks the current checkout with no separate build step (same pattern the SessionStart hook already uses with `nix build .#claude-md`).
- **`.claude/settings.json`**: pre-approve the server via `enabledMcpjsonServers: ["ix"]`. This is the named, auditable form rather than a blanket `enableAllProjectMcpServers: true`, so adding a future server to `.mcp.json` still requires an explicit opt-in.
- **`agent-context/sections/21-ix-mcp.md`** (new): a `disclosure: progressive` fragment that documents the server for every Claude/Codex session. It renders into the `ix-mcp` skill, so it costs nothing against the always-on character budget.

## What this gives a session

The `ix` server exposes, as `mcp__ix__*`:

- `python_eval` / `python_exec` — a persistent, single-threaded Python interpreter with a live asyncio loop (top-level `await`), where open figures come back as image blocks
- `python_session_create` / `python_session_list` / `python_session_close` / `python_reset`
- `search_semantic` / `search_grep` — semantic code search and regex grep over the indexed chunks

`tui`, `search`, `playwright`, `numpy`, `polars`, `matplotlib`, `asyncssh`, and (on macOS) `screen` are importable in every session with no install step.

## Verification

The exact command in `.mcp.json` completes an MCP `initialize` + `tools/list` handshake over stdio and returns all eight tools. The `skills` flake package builds with the new section and the `ix-mcp` skill lands in the farm.

## Related

The deployed side lives in indexable-inc/ix `feat/ix-mcp-default-agents`, which points operator-host Claude Code and Codex at this same `mcp` package through the `index` flake input.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Connect `ix-mcp` server to Claude Code by default via `.mcp.json`
> - Adds [.mcp.json](https://github.com/indexable-inc/index/pull/447/files#diff-d5d3368a61f8d02e085f7a4cb666ee471cf5383690a04b64c839c6ae2080ceb9) defining an MCP server named `ix` of type `stdio`, launched via `nix run .#mcp -- serve`.
> - Adds [.claude/settings.json](https://github.com/indexable-inc/index/pull/447/files#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546) enabling the `ix` server by default for Claude Code consumers that honor `enabledMcpjsonServers`.
> - Adds [agent-context/sections/21-ix-mcp.md](https://github.com/indexable-inc/index/pull/447/files#diff-43559746ae7042162646678eb5fa43945868ed5da520f25fafd8d7778cc1f866) documenting the server's session semantics and exposed tools.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1603e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->