### PR TITLE
feat(macos-vm): boot an OCI image as a guest disk (roadmap #453)

### DIFF
--- a/packages/macos-vm/README.md
+++ b/packages/macos-vm/README.md
@@ -66,8 +66,7 @@ app in, launch it, return a frame of the guest display).
 
 What is designed but not yet built (see [Roadmap](#roadmap)):
 
-- a vsock control channel and a long-lived `serve` mode,
-- booting an OCI image as a disk.
+- a vsock control channel and a long-lived `serve` mode.
 
 ## Off-screen capture
 
@@ -271,6 +270,12 @@ that surface, including the GPU path, and the maintenance cost of rebuilding it
 is not justified yet. If a single backend ever becomes a hard requirement, that
 decision should be made deliberately, not by accretion.
 
+The first option above is proven minimally: `boot-linux --disk` attaches a
+flattened OCI rootfs as a virtio-blk disk, and `examples/oci-boot.sh` boots a
+busybox OCI image to userspace over the serial console. See
+[`docs/oci-guest.md`](docs/oci-guest.md) for the build-vs-delegate decision, the
+proof, and its gaps (squashfs not ext4, externally fetched kernel).
+
 ## Build notes
 
 - This is the first workspace crate that links an Apple framework. The objc2
@@ -307,4 +312,7 @@ decision should be made deliberately, not by accretion.
    module exposes `info`, `install`, `provision`, `stage_binary`, `screenshot`,
    `screenshot_many`, `drive`, `Driver`, and `run_app`, returning PIL images that
    render inline.
-7. OCI-disk boot for Linux guests; document the libkrun handoff for microVMs.
+7. ~~OCI-disk boot for Linux guests; document the libkrun handoff for
+   microVMs.~~ Done minimally: `boot-linux --disk` + `examples/oci-boot.sh` boot
+   a flattened OCI rootfs as a virtio-blk disk; build-vs-delegate decision and
+   gaps in [`docs/oci-guest.md`](docs/oci-guest.md).

--- a/packages/macos-vm/docs/oci-guest.md
+++ b/packages/macos-vm/docs/oci-guest.md
@@ -1,0 +1,135 @@
+# OCI image as a guest: build vs. delegate
+
+Roadmap item from [issue #453](https://github.com/indexable-inc/index/issues/453):
+run an OCI image as a `macos-vm` guest, reachable by the existing capture and
+drive tooling. This note records the decision (build vs. delegate) and the
+minimal proof that backs it.
+
+## Decision
+
+Keep `macos-vm` focused on the macOS-guest plus capture/drive niche on
+[Virtualization.framework](https://developer.apple.com/documentation/virtualization),
+and delegate the general Linux-container case to a purpose-built microVM runtime
+([libkrun](https://github.com/containers/libkrun) / krunkit). `macos-vm` owns one
+small, honest OCI path: boot a flattened OCI rootfs as a virtio-blk disk through
+the existing Linux boot path, which is enough to drive a containerized Linux
+workload through the same serial console the rest of the crate already uses. It
+does not try to be a container runtime.
+
+The reasoning, grounded in what each backend can and cannot do:
+
+- **No 3D acceleration for Linux on Virtualization.framework.** VZ accelerates
+  the macOS guest (`VZMacGraphicsDeviceConfiguration`) but gives a Linux guest no
+  GPU: `wgpu` in a VZ Linux guest falls back to software (lavapipe). libkrun's
+  `libkrun-efi` adds a Venus virtio-gpu backed by
+  [MoltenVK](https://github.com/KhronosGroup/MoltenVK), so a Linux guest gets
+  real Vulkan. Any OCI workload that needs the GPU is libkrun's job, not ours;
+  rebuilding that path on VZ is not justified.
+- **Different entitlements, owned by different processes.** VZ needs
+  `com.apple.security.virtualization` (see `src/virtualization.entitlements` and
+  the self-signer in `src/main.rs`). libkrun uses Hypervisor.framework and needs
+  `com.apple.security.hypervisor`. They are separate code-signing surfaces;
+  delegating the container case keeps this crate's single entitlement and its
+  self-signing story unchanged.
+- **libkrun already owns the container surface.** It boots an OCI image as a
+  microVM in milliseconds with the image as the rootfs over virtio-fs. Matching
+  that (image pull, layer cache, fast boot, GPU) inside `macos-vm` is a large,
+  duplicative effort. The deliberate single-backend decision, if it is ever
+  forced, should be made on its own, not reached by accretion here.
+
+What `macos-vm` does own, because it costs almost nothing on top of the existing
+`boot-linux` path: attach an OCI-derived rootfs disk and reach its userspace.
+That is the proof below.
+
+## How an OCI image becomes a bootable disk
+
+The repo already turns an OCI image into a flat rootfs. `packages/oci-image-builder`
+(the `oci-image-builder` binary) and `lib/ix-oci-layer.nix` build OCI archives
+from a NixOS closure: `ix-oci-layer.nix` streams the closure into ~67 OCI layers
+with `dockerTools.streamLayeredImage` and hands the layer plan to
+`oci-image-builder`, which writes the final OCI archive. Flattening the layers of
+any OCI image (those layers, or an external image such as `busybox`) into a
+single directory tree gives a rootfs; that tree becomes a disk image with
+`mke2fs -d` (ext*) or `mksquashfs` (squashfs), neither of which needs root or a
+loopback mount.
+
+## Why this needed a new boot path
+
+Before this change, `boot-linux` accepted only a kernel `Image` and an
+initramfs. It built no storage device, so there was no way to hand a guest the
+flattened rootfs disk. Two ways to close that gap:
+
+1. **Kernel + initrd that mounts a rootfs disk** (the path taken). Attach the
+   rootfs as a virtio-blk disk and let a small initramfs `switch_root` into it,
+   or point the kernel at it with `root=/dev/vda`. This reuses
+   `VZLinuxBootLoader` unchanged; it only needs a virtio-blk device on the
+   config.
+2. **A full EFI/disk boot path.** `VZEFIBootLoader` plus
+   `VZDiskImageStorageDeviceAttachment` boots a disk that carries its own
+   bootloader and kernel (an EFI system partition), with no host-supplied kernel
+   or initramfs. This is the right shape for a self-contained bootable image, but
+   it is a larger surface (EFI variable store, a partitioned disk) than this
+   lower-priority item warrants.
+
+This change took option 1: a minimal `--disk` flag on `boot-linux` that attaches
+one or more raw disk images as virtio-blk devices
+(`VZVirtioBlockDeviceConfiguration` + `VZDiskImageStorageDeviceAttachment`, the
+same pair `macguest.rs` already uses for the macOS disk). The guest sees them as
+`/dev/vda`, `/dev/vdb`, ... in order. An EFI boot path remains available later if
+a self-contained bootable OCI disk is wanted.
+
+## The proof
+
+`examples/oci-boot.sh` runs the whole path from a clean temp dir:
+
+1. Pull `busybox:latest` (arm64) from Docker Hub with `skopeo` and flatten its
+   one layer into a rootfs tree.
+2. Drop in a tiny `/init` that prints a marker from inside the OCI userspace.
+3. Pack the tree into a read-only squashfs disk with `mksquashfs`.
+4. Fetch an Alpine aarch64 `virt` kernel, extract the raw arm64 `Image` from its
+   gzip zboot `vmlinuz` wrapper, and build a small initramfs that loads
+   `virtio_blk` and `squashfs`, mounts `/dev/vda`, and `switch_root`s into it.
+5. Boot with `macos-vm boot-linux --disk rootfs.squashfs`, streaming the serial
+   console.
+
+Observed serial console (the load-bearing lines):
+
+```
+INITRAMFS: loading virtio_blk + squashfs
+[    0.157397] virtio_blk virtio1: [vda] 3760 512-byte logical blocks (1.93 MB/1.84 MiB)
+[    0.158672] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+INITRAMFS: mounted OCI squashfs; switch_root
+OCI-GUEST-PROOF: reached userspace from OCI rootfs on /dev/vda
+uname: Linux (none) 6.12.81-0-virt #1-Alpine SMP PREEMPT_DYNAMIC ... aarch64 GNU/Linux
+root contents: bin dev etc home init lib lib64 root tmp usr var
+```
+
+The `root contents` are the busybox OCI image's directories, so the guest is
+running from the OCI-derived disk attached over the new `--disk` flag, reached
+through the same serial-console path the existing `boot-linux` smoke test uses.
+
+## Limits and remaining gaps
+
+- **squashfs, not ext4, in this proof.** The Alpine `virt` kernel builds no
+  ext2/3/4 in (its `/proc/filesystems` lists only `nodev` filesystems plus the
+  loadable squashfs and vfat modules), so the proof uses a read-only squashfs
+  disk and loads `squashfs.ko` from the Alpine initramfs. squashfs is a good fit
+  for an immutable OCI image. A writable ext4 root would need either a kernel
+  with ext4 built in or the ext4 module loaded the same way virtio_blk is.
+- **External downloads, and no nix-built aarch64 kernel.** The example fetches
+  the kernel from Alpine and the image from Docker Hub. There is no
+  aarch64-linux kernel built through nix here because this host's only remote
+  builder is x86_64-linux; producing a raw arm64 `Image` reproducibly through
+  nix is follow-up work. The raw-`Image` requirement is real: `VZLinuxBootLoader`
+  takes an uncompressed arm64 `Image`, not a gzip/zboot `vmlinuz`, which is why
+  the script extracts the inner `Image`.
+- **Capture/drive is serial-console only for Linux.** The framebuffer capture
+  and synthetic-input tooling (`boot-macos` / `drive-macos`) target the macOS
+  guest's `VZVirtualMachineView`. A Linux OCI guest is reachable here through the
+  serial console; wiring a Linux guest into the framebuffer/input surface (and
+  the GPU question above) is exactly the case that belongs to libkrun.
+- **No image pull, cache, or `root=` ergonomics in the binary.** The pull,
+  flatten, and disk build live in the example script, not in `macos-vm`. The
+  binary's contribution is the `--disk` attachment; turning an OCI reference into
+  a booted guest in one command is not built, by design (that is the runtime
+  surface we are delegating).

--- a/packages/macos-vm/examples/oci-boot.sh
+++ b/packages/macos-vm/examples/oci-boot.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Boot an OCI image as a macos-vm guest disk, end to end.
+#
+# This is the minimal honest proof for the OCI-as-guest roadmap item (issue
+# #453, see ../docs/oci-guest.md). It flattens a tiny OCI image into a read-only
+# squashfs disk, attaches that disk to a Linux guest with `macos-vm boot-linux
+# --disk`, and switches root into the OCI rootfs from a small initramfs, so the
+# serial console prints a marker from inside the OCI image's userspace.
+#
+# It downloads two things from the network and says so up front:
+#   - the busybox arm64 OCI image from Docker Hub (the guest rootfs), and
+#   - an Alpine aarch64 `virt` kernel + its modules (the kernel + virtio_blk and
+#     squashfs drivers). macos-vm's `boot-linux` takes a raw arm64 `Image`; the
+#     Alpine `vmlinuz` is a gzip zboot wrapper, so we extract the inner `Image`.
+# Everything else (mke2fs/mksquashfs/skopeo) comes from nixpkgs via `nix run`.
+#
+# Requirements: aarch64-darwin with Virtualization.framework, network access.
+#
+# Usage:
+#   packages/macos-vm/examples/oci-boot.sh [OCI_REF]
+# OCI_REF defaults to docker.io/library/busybox:latest.
+set -euo pipefail
+
+OCI_REF="${1:-docker.io/library/busybox:latest}"
+ALPINE_NETBOOT="${ALPINE_NETBOOT:-https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/aarch64/netboot}"
+WORK="$(mktemp -d -t oci-boot.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+echo "macos-vm oci-boot: workdir $WORK"
+
+# Resolve macos-vm: prefer a built result, else build it.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MACVM="$ROOT/result/bin/macos-vm"
+if [[ ! -x "$MACVM" ]]; then
+  echo "macos-vm oci-boot: building .#macos-vm"
+  nix build "$ROOT#macos-vm" -o "$WORK/macos-vm-result"
+  MACVM="$WORK/macos-vm-result/bin/macos-vm"
+fi
+
+# Run a named binary from a nixpkgs package (the package and the binary differ
+# for multi-tool packages like squashfsTools, so name both).
+nixbin() { nix shell "nixpkgs#$1" -c "${@:2}"; }
+
+# 1. Pull the OCI image (arm64) and flatten its layers into a rootfs tree.
+echo "macos-vm oci-boot: pulling OCI image $OCI_REF (arm64)"
+mkdir -p "$WORK/oci" "$WORK/root"
+echo '{ "default": [ { "type": "insecureAcceptAnything" } ] }' >"$WORK/policy.json"
+nixbin skopeo skopeo --policy "$WORK/policy.json" --override-os linux --override-arch arm64 \
+  copy "docker://$OCI_REF" "oci:$WORK/oci:img"
+python3 - "$WORK" <<'PY'
+import json, sys, subprocess, pathlib
+work = pathlib.Path(sys.argv[1])
+idx = json.load(open(work / "oci/index.json"))
+man_dig = idx["manifests"][0]["digest"].split(":")[1]
+man = json.load(open(work / "oci/blobs/sha256" / man_dig))
+for layer in man["layers"]:
+    blob = work / "oci/blobs/sha256" / layer["digest"].split(":")[1]
+    # OCI layers are (usually gzipped) tarballs; tar autodetects compression.
+    subprocess.run(["tar", "-xpf", str(blob), "-C", str(work / "root")], check=True)
+print("flattened", len(man["layers"]), "layer(s)")
+PY
+
+# 2. A tiny in-rootfs /init that proves we reached the OCI image's userspace.
+cat >"$WORK/root/init" <<'EOF'
+#!/bin/sh
+/bin/busybox mount -t proc proc /proc 2>/dev/null
+/bin/busybox mount -t sysfs sys /sys 2>/dev/null
+echo "=================================================="
+echo "OCI-GUEST-PROOF: reached userspace from OCI rootfs on /dev/vda"
+echo "uname: $(/bin/busybox uname -a)"
+echo "root contents: $(/bin/busybox ls / | /bin/busybox tr '\n' ' ')"
+echo "OCI-GUEST-PROOF-DONE"
+echo "=================================================="
+/bin/busybox poweroff -f
+EOF
+chmod +x "$WORK/root/init"
+
+# 3. Flatten the rootfs into a read-only squashfs disk. squashfs fits an
+#    immutable OCI image and is one of the few block filesystems the Alpine
+#    virt kernel can mount (it has no ext4 built in).
+echo "macos-vm oci-boot: building squashfs disk"
+nixbin squashfsTools mksquashfs "$WORK/root" "$WORK/rootfs.squashfs" \
+  -noappend -all-root -comp gzip
+
+# 4. Fetch the Alpine kernel + initramfs and extract a raw arm64 Image.
+echo "macos-vm oci-boot: fetching Alpine aarch64 kernel + modules"
+curl -fsSL -o "$WORK/vmlinuz-virt" "$ALPINE_NETBOOT/vmlinuz-virt"
+curl -fsSL -o "$WORK/initramfs-virt" "$ALPINE_NETBOOT/initramfs-virt"
+python3 - "$WORK" <<'PY'
+import zlib, sys, pathlib
+work = pathlib.Path(sys.argv[1])
+data = (work / "vmlinuz-virt").read_bytes()
+# The arm64 zboot wrapper embeds a gzip stream with trailing payload after it.
+# zlib's streaming gzip mode (wbits 16+15) decompresses the leading stream and
+# ignores the trailing bytes, where the strict gzip.decompress rejects them.
+off = 0
+while True:
+    i = data.find(b"\x1f\x8b\x08", off)
+    if i < 0:
+        sys.exit("no raw arm64 Image found inside vmlinuz zboot wrapper")
+    try:
+        raw = zlib.decompressobj(16 + zlib.MAX_WBITS).decompress(data[i:])
+    except Exception:
+        off = i + 3
+        continue
+    # arm64 raw Image header magic "ARM\x64" at offset 56 (Documentation/arm64/booting).
+    if len(raw) > 1_000_000 and raw[56:60] == b"ARM\x64":
+        (work / "Image").write_bytes(raw)
+        print("extracted raw arm64 Image:", len(raw), "bytes")
+        break
+    off = i + 3
+PY
+
+# 5. Build a minimal initramfs that insmods virtio_blk + squashfs (the Alpine
+#    virt kernel ships them as modules), mounts the OCI squashfs disk, and
+#    switch_roots into it. The busybox here is the OCI image's own (glibc), so
+#    copy its loader + libs in too.
+echo "macos-vm oci-boot: building initramfs"
+IR="$WORK/irfs"
+mkdir -p "$IR"/{bin,lib,mods,proc,sys,dev,mnt}
+cp "$WORK/root/bin/busybox" "$IR/bin/busybox"
+for lib in ld-linux-aarch64.so.1 libc.so.6 libm.so.6 libresolv.so.2; do
+  [[ -e "$WORK/root/lib/$lib" ]] && cp "$WORK/root/lib/$lib" "$IR/lib/"
+done
+# Extract the two kernel modules from the Alpine initramfs.
+( cd "$WORK" && mkdir -p aird && cd aird && zcat ../initramfs-virt | cpio -idm 2>/dev/null )
+# The kernel-version directory name is unknown, so glob it (one match expected).
+kmods=( "$WORK"/aird/lib/modules/*/kernel )
+KMOD="${kmods[0]}"
+cp "$KMOD/drivers/block/virtio_blk.ko" "$IR/mods/"
+cp "$KMOD/fs/squashfs/squashfs.ko" "$IR/mods/"
+cat >"$IR/init" <<'EOF'
+#!/bin/busybox sh
+/bin/busybox mount -t devtmpfs dev /dev 2>/dev/null
+/bin/busybox mount -t proc proc /proc 2>/dev/null
+echo "INITRAMFS: loading virtio_blk + squashfs"
+/bin/busybox insmod /mods/virtio_blk.ko
+/bin/busybox insmod /mods/squashfs.ko
+for i in 1 2 3 4 5 6 7 8 9 10; do [ -b /dev/vda ] && break; /bin/busybox sleep 0.3; done
+/bin/busybox mount -t squashfs -o ro /dev/vda /mnt || { echo "INITRAMFS: mount FAILED"; /bin/busybox poweroff -f; }
+echo "INITRAMFS: mounted OCI squashfs; switch_root"
+exec /bin/busybox switch_root /mnt /init
+EOF
+chmod +x "$IR/init"
+( cd "$IR" && find . | cpio -o -H newc 2>/dev/null | gzip -9 >"$WORK/initramfs.cpio.gz" )
+
+# 6. Boot it. The OCI disk is attached via the new --disk flag (virtio-blk).
+echo "macos-vm oci-boot: booting guest"
+"$MACVM" boot-linux \
+  --kernel "$WORK/Image" \
+  --initramfs "$WORK/initramfs.cpio.gz" \
+  --disk "$WORK/rootfs.squashfs" \
+  --memory-mib 1024 \
+  --cmdline "console=hvc0" \
+  --timeout-secs 45

--- a/packages/macos-vm/src/main.rs
+++ b/packages/macos-vm/src/main.rs
@@ -10,7 +10,9 @@
 //! `macos-vm boot-linux` boots a Linux guest from a raw kernel `Image` and
 //! initramfs, streaming the guest serial console to stdout. boot-linux is the
 //! end-to-end smoke path: a real guest reaching userspace proves the binding,
-//! the entitlement, and the boot all work.
+//! the entitlement, and the boot all work. `--disk` attaches raw disk images as
+//! virtio-blk devices, which is how a flattened OCI rootfs is booted (see
+//! `docs/oci-guest.md`).
 //!
 //! The graphics/screenshot, vsock IPC, OCI-disk, and macOS-guest paths build on
 //! the same `VZVirtualMachineConfiguration` and are tracked in the README.
@@ -52,6 +54,12 @@ enum Command {
         /// Path to an initramfs/initrd.
         #[arg(long)]
         initramfs: std::path::PathBuf,
+        /// Attach a raw disk image as a virtio-blk device, repeatable. The
+        /// guest sees these as `/dev/vda`, `/dev/vdb`, ... in order. Used to
+        /// boot a flattened OCI rootfs: pass the rootfs disk here and a matching
+        /// `root=` (or an initramfs that mounts it) in `--cmdline`.
+        #[arg(long = "disk", value_name = "PATH")]
+        disks: Vec<std::path::PathBuf>,
         /// Number of virtual CPUs.
         #[arg(long, default_value_t = 2)]
         cpus: usize,
@@ -302,9 +310,10 @@ mod imp {
     use objc2::rc::Retained;
     use objc2_foundation::{NSArray, NSError, NSFileHandle, NSPipe, NSString, NSURL};
     use objc2_virtualization::{
-        VZBootLoader, VZEntropyDeviceConfiguration, VZFileHandleSerialPortAttachment,
-        VZLinuxBootLoader, VZMemoryBalloonDeviceConfiguration, VZSerialPortAttachment,
-        VZSerialPortConfiguration, VZVirtioConsoleDeviceSerialPortConfiguration,
+        VZBootLoader, VZDiskImageStorageDeviceAttachment, VZEntropyDeviceConfiguration,
+        VZFileHandleSerialPortAttachment, VZLinuxBootLoader, VZMemoryBalloonDeviceConfiguration,
+        VZSerialPortAttachment, VZSerialPortConfiguration, VZStorageDeviceConfiguration,
+        VZVirtioBlockDeviceConfiguration, VZVirtioConsoleDeviceSerialPortConfiguration,
         VZVirtioEntropyDeviceConfiguration, VZVirtioTraditionalMemoryBalloonDeviceConfiguration,
         VZVirtualMachine, VZVirtualMachineConfiguration,
     };
@@ -330,6 +339,8 @@ mod imp {
         NoFramebuffer,
         #[snafu(display("invalid guest bundle: {message}"))]
         Bundle { message: String },
+        #[snafu(display("cannot attach disk {path:?}: {message}"))]
+        Disk { path: PathBuf, message: String },
         #[snafu(display("screenshot encode/write failed: {message}"))]
         CaptureEncode { message: String },
         #[snafu(display("staging the binary guest-portable failed: {source}"))]
@@ -344,6 +355,8 @@ mod imp {
     pub struct LinuxBoot {
         pub kernel: PathBuf,
         pub initramfs: PathBuf,
+        /// Raw disk images attached as virtio-blk devices, in `/dev/vda` order.
+        pub disks: Vec<PathBuf>,
         pub cpus: usize,
         pub memory_mib: u64,
         pub cmdline: String,
@@ -356,6 +369,7 @@ mod imp {
             Command::BootLinux {
                 kernel,
                 initramfs,
+                disks,
                 cpus,
                 memory_mib,
                 cmdline,
@@ -363,6 +377,7 @@ mod imp {
             } => boot_linux(LinuxBoot {
                 kernel,
                 initramfs,
+                disks,
                 cpus,
                 memory_mib,
                 cmdline,
@@ -564,6 +579,15 @@ mod imp {
         let entropy = unsafe { VZVirtioEntropyDeviceConfiguration::new() };
         let balloon = unsafe { VZVirtioTraditionalMemoryBalloonDeviceConfiguration::new() };
 
+        // Build the virtio-blk devices first and hold them in a Vec so the
+        // retained configs outlive the upcast refs handed to setStorageDevices.
+        // The guest exposes them as /dev/vda, /dev/vdb, ... in this order.
+        let blocks = boot
+            .disks
+            .iter()
+            .map(|path| build_block_device(path, false))
+            .collect::<Result<Vec<_>, Error>>()?;
+
         let config = unsafe { VZVirtualMachineConfiguration::new() };
         let boot_loader_ref: &VZBootLoader = &boot_loader;
         let serial_ref: &VZSerialPortConfiguration = &serial;
@@ -577,6 +601,16 @@ mod imp {
             config.setEntropyDevices(&NSArray::from_slice(&[entropy_ref]));
             config.setMemoryBalloonDevices(&NSArray::from_slice(&[balloon_ref]));
         }
+        if !blocks.is_empty() {
+            let block_refs: Vec<&VZStorageDeviceConfiguration> = blocks
+                .iter()
+                .map(|block| {
+                    let block_ref: &VZStorageDeviceConfiguration = block;
+                    block_ref
+                })
+                .collect();
+            unsafe { config.setStorageDevices(&NSArray::from_slice(&block_refs)) };
+        }
 
         // Validation surfaces a missing entitlement as a clear error rather than
         // a later crash.
@@ -587,6 +621,34 @@ mod imp {
         }
 
         Ok(config)
+    }
+
+    /// Build one virtio-blk device backed by a raw disk image. The attachment
+    /// fails up front (rather than at VM start) if the image is missing or not a
+    /// usable raw image, so the error names the offending path.
+    fn build_block_device(
+        path: &std::path::Path,
+        read_only: bool,
+    ) -> Result<Retained<VZVirtioBlockDeviceConfiguration>, Error> {
+        let url = file_url(path);
+        let attachment = unsafe {
+            VZDiskImageStorageDeviceAttachment::initWithURL_readOnly_error(
+                VZDiskImageStorageDeviceAttachment::alloc(),
+                &url,
+                read_only,
+            )
+        }
+        .map_err(|error| Error::Disk {
+            path: path.to_path_buf(),
+            message: ns_error_message(&error),
+        })?;
+        let block = unsafe {
+            VZVirtioBlockDeviceConfiguration::initWithAttachment(
+                VZVirtioBlockDeviceConfiguration::alloc(),
+                &attachment,
+            )
+        };
+        Ok(block)
     }
 
     pub fn file_url(path: &std::path::Path) -> Retained<NSURL> {


### PR DESCRIPTION
## Decision (build vs. delegate)

Keep `macos-vm` on the macOS-guest + capture/drive niche on Virtualization.framework, and delegate the general Linux-container/GPU case to libkrun/krunkit (VZ gives Linux guests no 3D acceleration; libkrun-efi does, via a Venus virtio-gpu over MoltenVK, and uses a different entitlement). `macos-vm` owns one small honest OCI path: boot a flattened OCI rootfs as a virtio-blk disk through the existing Linux boot path, reachable over the serial console. It does not try to be a container runtime. Full reasoning in `packages/macos-vm/docs/oci-guest.md`.

## What the proof demonstrates

`examples/oci-boot.sh` runs end to end from a clean temp dir: pulls `busybox:latest` (arm64) with skopeo, flattens its layer into a read-only squashfs disk with `mksquashfs`, extracts a raw arm64 `Image` from an Alpine `virt` `vmlinuz` zboot wrapper, builds a tiny initramfs that loads `virtio_blk` + `squashfs` and `switch_root`s into the OCI disk, and boots with `macos-vm boot-linux --disk`. Verified on aarch64-darwin (macOS 26.5, Apple M5 Max). Observed serial console:

```
[    0.157397] virtio_blk virtio1: [vda] 3760 512-byte logical blocks (1.93 MB/1.84 MiB)
[    0.158672] squashfs: version 4.0 (2009/01/31) Phillip Lougher
INITRAMFS: mounted OCI squashfs; switch_root
OCI-GUEST-PROOF: reached userspace from OCI rootfs on /dev/vda
root contents: bin dev etc home init lib lib64 root tmp usr var
```

The `root contents` are the busybox image's directories, so userspace is running from the OCI-derived disk attached over the new flag.

## Remaining gap

squashfs (read-only), not ext4: the Alpine `virt` kernel builds no ext* in, so the proof uses squashfs and loads `squashfs.ko`. The kernel and image are fetched externally (this host has no aarch64-linux nix builder); a nix-built arm64 kernel and a writable ext4 root are follow-up. Linux capture/drive remains serial-console only; the framebuffer/GPU path is the libkrun case.

## Change

Adds a minimal `--disk` flag to `boot-linux` (`#[cfg(target_os="macos")]`, `VZVirtioBlockDeviceConfiguration` + `VZDiskImageStorageDeviceAttachment`, snafu `Error::Disk`), mirroring the existing `macguest.rs` disk-attachment pattern; no new deps. `nix build .#macos-vm` passes; `nix run .#lint` clean for these files (pre-existing ray-cluster lint failures are unrelated). code-reviewer (high effort): no correctness or security findings.

Made with AI assistance (Claude Opus 4.8). Addresses #453.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--disk` flag to `macos-vm boot-linux` to attach OCI rootfs images as virtio-blk devices
> - Adds a repeatable `--disk <PATH>` argument to `boot-linux` in [main.rs](https://github.com/indexable-inc/index/pull/455/files#diff-b672fe3e1d10462de4efa7a75a630206a1942f074e401e2d13f411ecb6e3c47c); each disk is attached as a `VZVirtioBlockDeviceConfiguration` and appears in the guest as `/dev/vda`, `/dev/vdb`, etc. in argument order.
> - Adds a `build_block_device` helper that creates the `VZDiskImageStorageDeviceAttachment`, fails early with a path-specific `Error::Disk` if the image is invalid or unreadable.
> - Adds [examples/oci-boot.sh](https://github.com/indexable-inc/index/pull/455/files#diff-36dac10d1f4770e5fb622aafaa85592e0836664c80ed10d062f05ff717b10bd4) demonstrating the full flow: pull an arm64 OCI image, flatten it to a squashfs disk, fetch an Alpine kernel and initramfs, and boot to userspace via `--disk`.
> - Adds [docs/oci-guest.md](https://github.com/indexable-inc/index/pull/455/files#diff-e5539ac7f6841ce94ecdfa7a3be49d745d06dbbd46676b072396fe7562f9b675) documenting the approach, limitations, and the build-vs-delegate tradeoff.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8aae3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->