### PR TITLE
infra(ci): split rust-package-tests into per-crate checks to fix flake-check eval-OOM (#452)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -71,24 +71,34 @@ jobs:
       # symlinks. It exits nonzero iff a build or eval fails, which is the gate.
       # Pinned by commit to nix-fast-build 1.5.0.
       #
-      # A single heavy attribute (`rust-package-tests`, which evaluates every
-      # workspace crate's test unit) dominates this eval and grew large enough to
-      # flake out the parallel evaluator two ways: at nix-eval-jobs' 4096 MiB
-      # default per-worker cap it was SIGKILLed by the limiter ("memory limit
-      # reached"), and with the cap raised but many workers live it instead got
-      # OS-OOM-killed ("worker pipe got closed but evaluation worker still
-      # running") because nproc-many (128) concurrent evaluators exhausted host
-      # RAM on this shared runner. Fix both: give the one heavy worker generous
-      # headroom (`--eval-max-memory-size 8192`) while keeping concurrency low
-      # (`--eval-workers 4`) so total eval memory stays bounded. The long pole is
-      # that single attribute, which cannot parallelize, so few workers barely
-      # changes wall time (see the schema-eval step below, which uses 16).
+      # The per-crate rust test units are now separate top-level
+      # `checks.x86_64-linux.*` attributes (one per crate test, e.g.
+      # `rust-<crate>-<test>` / `cargo-unit-real-workspaces`; see the
+      # `rustChecks` spread in lib/per-system.nix), not one `rust-package-tests`
+      # linkFarm. That single aggregate forced one nix-eval-jobs worker to hold
+      # the whole workspace test graph in its heap, which flaked this job two
+      # ways: at nix-eval-jobs' 4096 MiB default per-worker cap it was SIGKILLed
+      # by the limiter ("memory limit reached"), and with the cap raised but many
+      # workers live it instead got OS-OOM-killed ("worker pipe got closed but
+      # evaluation worker still running"). Split, each crate evaluates in its own
+      # worker, so per-worker eval memory is bounded by the single largest crate
+      # rather than the sum, and the eval parallelizes across workers like the
+      # schema-eval step below. With that, the #440/#443 stopgap is relaxed back
+      # to the schema step's 16 workers and the default per-worker cap; we keep a
+      # modest `--eval-max-memory-size 6144` headroom (above the 4 GiB default,
+      # below the old 8 GiB) as a guard rail, not a workaround.
+      #
+      # Complementary follow-up: an eval cache would skip the cold per-commit
+      # re-eval entirely. Nix keys that cache on the locked flake fingerprint,
+      # which for a git source is the commit rev, so every CI commit is a cold
+      # cache today; the `indexable-inc/nix` fork (RFC #405) makes flake eval use
+      # the cache. That is orthogonal to this split and tracked separately.
       - name: Build all flake checks
         run: |
           nix run github:Mic92/nix-fast-build/7f185e0ec37b65b4730f892e0de9a831b0610f3a -- \
             --flake ".#checks.x86_64-linux" \
-            --eval-max-memory-size 8192 \
-            --eval-workers 4 \
+            --eval-max-memory-size 6144 \
+            --eval-workers 16 \
             --skip-cached \
             --no-nom \
             --no-link \

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -414,69 +414,88 @@ in
 
   checks = lib.optionalAttrs (system == ix.system) (
     let
+      # Each per-crate rust test unit is its own top-level check (spread into
+      # the `checks` set below) rather than being collapsed into one aggregate
+      # linkFarm. That lets nix-eval-jobs (the evaluator CI's nix-fast-build
+      # wraps) assign each crate's test to a separate worker, so no single
+      # worker holds the whole workspace test graph in its heap. The old
+      # `rust-package-tests` linkFarm did the opposite: it forced one worker to
+      # evaluate every crate at once, and that single multi-GiB eval is what
+      # flaked the flake-check job (per-worker SIGKILL at the memory cap, and
+      # host-OOM with many workers).
       rustChecks = {
         cargo-unit-real-workspaces = tests.cargoUnitRealWorkspaces;
       }
       // rustPackageTests;
-    in
-    {
-      inherit (tests) eval;
-      # Instruction files are not committed; they are rendered live by the
-      # SessionStart hook. This gate forces the rendered always-on documents
-      # (which evaluates the always-on char cap assertion) and the combined
-      # skills link farm (which evaluates the name-collision assertion) to build.
-      agent-context = pkgs.runCommand "agent-context-check" { } ''
-        test -s ${agentContextClaudeMd}
-        test -s ${agentContextCodexMd}
-        test -d ${agentContextSkills}
-        mkdir -p "$out"
-      '';
-      # Offline schema gate for the loader manifests. `deepSeq` forces
-      # every Paper / Velocity / Fabric per-version lock through
-      # `readLoaderManifest` in `lib/artifacts.nix`, so malformed JSON or a
-      # missing key fires here before any image starts evaluating. The
-      # forced surface is the parsed-and-validated manifest data, not the
-      # wrapped `fetchurl` derivations, to keep this check pure eval.
-      loader-manifests =
-        let
-          forced = builtins.deepSeq ix.artifacts.minecraft.loaderManifests "ok";
-        in
-        pkgs.runCommand "loader-manifests-check" { } ''
-          printf '%s\n' '${forced}' > "$out"
+      explicitChecks = {
+        inherit (tests) eval;
+        # Instruction files are not committed; they are rendered live by the
+        # SessionStart hook. This gate forces the rendered always-on documents
+        # (which evaluates the always-on char cap assertion) and the combined
+        # skills link farm (which evaluates the name-collision assertion) to build.
+        agent-context = pkgs.runCommand "agent-context-check" { } ''
+          test -s ${agentContextClaudeMd}
+          test -s ${agentContextCodexMd}
+          test -d ${agentContextSkills}
+          mkdir -p "$out"
         '';
-      run-records-session = repoPackages.run.passthru.tests.recordsSession;
-      lint = pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ pkgs.coreutils ]; } ''
-        cp -R ${lintSource} source
-        chmod -R u+w source
-        cd source
-        ${lib.getExe lint}
-        mkdir -p "$out"
-      '';
-      rust-package-tests = pkgs.linkFarm "rust-package-tests" (
-        lib.mapAttrsToList (name: path: { inherit name path; }) rustChecks
-      );
-      # Proves the Linux→macOS cross toolchain actually emits a Darwin object,
-      # which a successful build alone does not assert. `file` reads the Mach-O
-      # header; a regression in the zig/SDK wiring fails here on x86_64-linux CI
-      # rather than silently shipping a wrong-arch binary.
-      cross-darwin-smoke = pkgs.runCommand "cross-darwin-smoke" { nativeBuildInputs = [ pkgs.file ]; } ''
-        bin=${crossPackages."dag-runner-aarch64-apple-darwin"}/bin/dag-runner
-        info=$(file -b "$bin")
-        echo "$info"
-        case "$info" in
-          *Mach-O*arm64*) ;;
-          *)
-            echo "expected Mach-O arm64, got: $info" >&2
-            exit 1
-            ;;
-        esac
-        mkdir -p "$out"
-      '';
-      site-case-tests = pkgs.linkFarm "site-case-tests" (
-        lib.mapAttrsToList (name: path: { inherit name path; }) siteTests.cases
-      );
-      site-test = siteTests.all;
-    }
+        # Offline schema gate for the loader manifests. `deepSeq` forces
+        # every Paper / Velocity / Fabric per-version lock through
+        # `readLoaderManifest` in `lib/artifacts.nix`, so malformed JSON or a
+        # missing key fires here before any image starts evaluating. The
+        # forced surface is the parsed-and-validated manifest data, not the
+        # wrapped `fetchurl` derivations, to keep this check pure eval.
+        loader-manifests =
+          let
+            forced = builtins.deepSeq ix.artifacts.minecraft.loaderManifests "ok";
+          in
+          pkgs.runCommand "loader-manifests-check" { } ''
+            printf '%s\n' '${forced}' > "$out"
+          '';
+        run-records-session = repoPackages.run.passthru.tests.recordsSession;
+        lint = pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ pkgs.coreutils ]; } ''
+          cp -R ${lintSource} source
+          chmod -R u+w source
+          cd source
+          ${lib.getExe lint}
+          mkdir -p "$out"
+        '';
+        # Proves the Linux→macOS cross toolchain actually emits a Darwin object,
+        # which a successful build alone does not assert. `file` reads the Mach-O
+        # header; a regression in the zig/SDK wiring fails here on x86_64-linux CI
+        # rather than silently shipping a wrong-arch binary.
+        cross-darwin-smoke = pkgs.runCommand "cross-darwin-smoke" { nativeBuildInputs = [ pkgs.file ]; } ''
+          bin=${crossPackages."dag-runner-aarch64-apple-darwin"}/bin/dag-runner
+          info=$(file -b "$bin")
+          echo "$info"
+          case "$info" in
+            *Mach-O*arm64*) ;;
+            *)
+              echo "expected Mach-O arm64, got: $info" >&2
+              exit 1
+              ;;
+          esac
+          mkdir -p "$out"
+        '';
+        site-case-tests = pkgs.linkFarm "site-case-tests" (
+          lib.mapAttrsToList (name: path: { inherit name path; }) siteTests.cases
+        );
+        site-test = siteTests.all;
+      };
+      # A rust check key is `<prefix>-<testName>`, where `prefix` defaults to
+      # `rust-<id>` but a crate may override it in its `package.nix` (e.g.
+      # `ix-fleet` uses `ix-fleet`). So the rust keys are not guaranteed to be
+      # `rust-`-prefixed, and a stray override colliding with an explicit check
+      # name would otherwise be silently swallowed by the `//` merge. Assert the
+      # two key sets are disjoint so such a collision fails loudly instead.
+      # Forcing `rustChecks`' keys realizes the cargo-unit test manifest (IFD);
+      # that is acceptable because evaluating the `checks` set at all (what CI
+      # and `nix flake check` do) already enumerates those keys.
+      checkNameCollisions = lib.intersectLists (lib.attrNames explicitChecks) (lib.attrNames rustChecks);
+    in
+    assert lib.assertMsg (checkNameCollisions == [ ])
+      "checks: rust check name(s) collide with explicit checks: ${lib.concatStringsSep ", " checkNameCollisions}";
+    explicitChecks // rustChecks
   );
 
   formatter = pkgs.nixfmt;


### PR DESCRIPTION
## Root cause

`flake-check` runs `nix-fast-build --flake .#checks.x86_64-linux`, which uses `nix-eval-jobs` to evaluate each **top-level** check attribute in its own worker. The `rust-package-tests` check was a single `pkgs.linkFarm` whose `entries` were every workspace crate's test unit. Because it is one top-level attr, `nix-eval-jobs` had to force the whole workspace test graph inside **one** worker heap. That single multi-GiB eval is what flaked the job:

- per-worker SIGKILL at `nix-eval-jobs`' 4096 MiB default cap ("memory limit reached"), and
- host-OOM with many workers ("worker pipe got closed but evaluation worker still running").

The #440/#443 stopgap (`--eval-max-memory-size 8192 --eval-workers 4`) bounded but did not eliminate it (same commit failed then passed on re-run).

## Fix: split the heavy attr

Promote each per-crate rust test unit to its own top-level `checks.x86_64-linux.*` attribute (the keys already existed inside the merged `rustChecks` set used to build the linkFarm), and **remove** the `rust-package-tests` linkFarm. Nothing depended on the aggregate name (`grep` across `*.nix`/`*.yml` found only its definition and the CI comment). Now `nix-eval-jobs` spreads each crate's test across workers, so per-worker eval memory is bounded by the largest single crate, not the sum.

A disjointness assertion guards the `explicitChecks // rustChecks` merge: rust check keys are `<prefix>-<testName>` and most default to `rust-<id>`, but a crate can override the prefix (e.g. `ix-fleet`), so a stray override colliding with an explicit check name (`eval`, `lint`, ...) would otherwise be silently swallowed by the merge. The assert makes that fail loudly.

Coverage is unchanged-or-stricter: every test that fed the linkFarm is now its own gate; nothing was dropped.

## Stopgap relaxed (`.github/workflows/check.yml`)

- `--eval-workers 4` -> `16` (matches the schema-eval step).
- `--eval-max-memory-size 8192` -> `6144` (guard rail above the 4 GiB default, no longer a cap the single attr blows).
- Rewrote the long comment to describe the split reality; documented the eval-cache (RFC #405 / `indexable-inc/nix` fork) as the complementary follow-up.

## Evidence (cross-eval to x86_64-linux on a native Linux host)

Ran the same evaluator CI uses (`nix-eval-jobs`, pinned commit `65ebf5b`) against both the parent commit (`6e1ebfb`, BEFORE) and this branch (AFTER), `--workers 16 --option eval-cache false`:

| | BEFORE (parent, linkFarm) | AFTER (this branch, split) |
|---|---|---|
| distinct top-level `checks` attrs | **9** (all rust collapsed into `rust-package-tests`) | **756** (8 explicit + per-crate, incl. 746 `rust-`/`cargo-unit-` + `ix-fleet-*`) |
| `rust-package-tests` present | yes | **gone** |
| eval `error` lines | 0 | 0 |
| OOM / SIGKILL signals in stderr | 0 | 0 |
| exit | 0 | 0 |

One un-parallelizable aggregate attr became ~750 independent worker jobs, all evaluating cleanly even at a deliberately low `--max-memory-size 512` per-worker cap.

## Honest caveat on the OOM itself

On the warm 503 GiB Linux host I used, I could **not reproduce the original per-worker OOM** even at a 512 MiB cap, in either the BEFORE or AFTER tree. The original failure was a cold-cache, contended-shared-runner phenomenon at the 4 GiB cap; its magnitude depends on eval-cache state and host RAM pressure, which I can't recreate locally. What I demonstrated is the **mechanism**: BEFORE forces all ~746 test units through one worker heap; AFTER caps each worker at one crate. The structural change is the durable fix; that `flake-check` is reliably green across N runs can only be confirmed by N green CI runs on the actual runner.

(Local validation also can't fully eval the rust checks on aarch64-darwin: they require building the x86_64-linux `cargo-unit-test-manifest` via IFD, which is why I validated on a Linux host.)

## Validation

- nix-eval-jobs cross-eval to x86_64-linux: AFTER = 756 checks, 0 errors, 0 OOM signals, exit 0 (BEFORE = 9 attrs).
- `nix run .#lint`: the touched files are clean; statix + deadnix + nixfmt pass on the Nix. (`examples/ray-cluster/*` has a pre-existing lint failure from #445, unrelated to this PR.)
- Self-review pass caught and fixed an inaccurate comment plus a dropped collision guard before opening this PR.

Made with AI assistance (Claude Opus 4.8). Closes #452.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split `rust-package-tests` into per-crate checks to fix flake-check eval OOM
> - Removes the single `rust-package-tests` linkFarm aggregate from [lib/per-system.nix](https://github.com/indexable-inc/index/pull/456/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) and exposes each per-crate Rust test as its own top-level check key.
> - Adds a collision guard (`checkNameCollisions` assert) that fails evaluation if any Rust check key conflicts with an explicit check name.
> - Updates [.github/workflows/check.yml](https://github.com/indexable-inc/index/pull/456/files#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428) to use 16 eval workers at 6 GiB each (previously 4 workers at 8 GiB) to accommodate the larger number of top-level checks.
> - Behavioral Change: CI now runs and reports each crate's tests individually rather than as a single aggregated job.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e719c0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->