### PR TITLE
feat(macos-vm): stage-binary + provision + macvm run_app (usability chain, #448-#451)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,6 +2994,8 @@ dependencies = [
  "objc2-io-surface",
  "objc2-quartz-core",
  "objc2-virtualization",
+ "serde",
+ "serde_json",
  "snafu 0.8.9",
 ]
 

--- a/packages/macos-vm/Cargo.toml
+++ b/packages/macos-vm/Cargo.toml
@@ -35,6 +35,12 @@ objc2-app-kit = "0.3"
 objc2-quartz-core = "0.3"
 objc2-io-surface = "0.3"
 image = { version = "0.25", default-features = false, features = ["png"] }
+# `provision` parses `hdiutil`/`diskutil` plist output (converted to JSON with
+# `plutil`) to find the guest's APFS Data volume and its mount point. serde lives
+# under the macOS gate like everything else here, so the Linux stub graph stays
+# dependency-free and the unused-crate-dependencies check passes there.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [lints]
 workspace = true

--- a/packages/macos-vm/README.md
+++ b/packages/macos-vm/README.md
@@ -47,17 +47,27 @@ What works today:
 - **virtio-fs directory sharing**: `--share TAG=HOSTDIR` on `boot-macos`
   and `drive-macos` shares a host directory into the guest. Tag `auto` uses the
   macOS automount tag, mounting at `/Volumes/My Shared Files`.
+- `provision` marks a freshly installed (stopped) guest's Setup Assistant
+  complete by editing its disk from the host, so the next boot lands on a
+  logged-in desktop with no Setup Assistant clicks (see
+  [Provisioning past Setup Assistant](#provisioning-past-setup-assistant)).
+- `stage-binary` copies a nix-built macOS binary and rewrites its `/nix/store`
+  dylib references so it runs on a vanilla guest (see
+  [Staging a binary guest-portable](#staging-a-binary-guest-portable)).
 - **Automatic self-signing**: a VM command on the read-only Nix store binary
   re-execs an ad-hoc-signed copy from `$XDG_CACHE_HOME/ix/macos-vm` carrying the
   `com.apple.security.virtualization` entitlement, so `nix run .#macos-vm` and
   ix-mcp spawning work with no manual `codesign` step.
 
+The `macvm` Python module bundled into ix-mcp exposes the full surface:
+`info`, `install`, `provision`, `stage_binary`, `screenshot`,
+`screenshot_many`, `drive`, `Driver`, and the one-call `run_app` (share a host
+app in, launch it, return a frame of the guest display).
+
 What is designed but not yet built (see [Roadmap](#roadmap)):
 
 - a vsock control channel and a long-lived `serve` mode,
-- booting an OCI image as a disk,
-- the `drive-macos`/`--share` surface exposed through the `macvm` Python module
-  (today the module exposes `info`/`install`/`screenshot`).
+- booting an OCI image as a disk.
 
 ## Off-screen capture
 
@@ -110,7 +120,70 @@ Modal screens that make a network call (Apple ID, Screen Time) hang on a host
 without working guest internet. Where the goal is just a usable desktop, it is
 simpler to mark Setup Assistant complete offline by editing the guest disk
 (`.AppleSetupDone` plus the per-user `com.apple.SetupAssistant` `DidSee*` keys)
-than to click through those screens.
+than to click through those screens. The `provision` subcommand does exactly
+that edit; see the next section.
+
+## Provisioning past Setup Assistant
+
+A freshly installed guest boots into Setup Assistant. On a host whose content
+filter breaks the guest's TLS to Apple, the network-backed screens (Apple ID,
+Screen Time) hang forever with greyed buttons, so the guest cannot be clicked
+past them offline. `provision` performs the proven host-side disk edit, with the
+guest stopped, so the next boot lands on a logged-in desktop:
+
+```sh
+nix run .#macos-vm -- install-macos --ipsw ./UniversalMac_26.5_Restore.ipsw --bundle ./guest
+nix run .#macos-vm -- provision --bundle ./guest --user ix --autologin
+nix run .#macos-vm -- drive-macos --bundle ./guest   # lands on the desktop, no Setup Assistant
+```
+
+It attaches the bundle's `disk.img` read-write with no auto-mount, finds the
+synthesized container's APFS **Data** and **System** volumes, and:
+
+- ensures `private/var/db/.AppleSetupDone` exists on the Data volume (gates the
+  system Setup Assistant: language, country, account creation);
+- sets every per-user `DidSee*` key true in
+  `Users/<user>/Library/Preferences/com.apple.SetupAssistant.plist` (gates the
+  per-user MiniBuddy flow: Apple ID, Screen Time, Siri, appearance, …) and sets
+  `LastSeenCloudProductVersion`/`LastSeenBuddyBuildVersion` to the guest OS
+  version read from the System volume's `SystemVersion.plist`, so the cloud
+  screen does not re-prompt;
+- with `--autologin`, writes `/private/etc/kcpassword` and the loginwindow
+  `autoLoginUser` so the guest boots straight to the desktop with no password.
+
+It reads the OS version from the guest **System** volume directly: the System
+firmlinks do not resolve when the Data volume is mounted standalone from the
+host, so the Data and System volumes are mounted and matched within the one
+container backed by the attached image (a host System volume in
+`diskutil apfs list` is never touched). A teardown guard unmounts and detaches
+on every exit path, so a failure part-way never leaves the image attached, and
+it refuses to run if the image is already attached (editing a live filesystem
+would corrupt it).
+
+## Staging a binary guest-portable
+
+A nix-built macOS binary links its dylibs by absolute `/nix/store` path, which a
+vanilla guest does not have, so it fails to start when shared in. `stage-binary`
+copies the binary and makes the copy depend only on libraries the guest has:
+
+```sh
+nix run .#macos-vm -- stage-binary ./result/bin/myapp ./staged/myapp
+otool -L ./staged/myapp    # zero /nix/store entries
+```
+
+For each `/nix/store` dylib in `otool -L`, it repoints to the `/usr/lib` system
+equivalent when the guest ships one (libiconv, libc++, libresolv, libobjc, …) or,
+when it does not, copies the dylib next to the output and rewrites the reference
+to `@loader_path/<name>` (bundling it, re-signing the bundled copy too). The
+output is ad-hoc re-signed, since a Mach-O whose load commands changed needs a
+fresh signature. It verifies no `/nix/store` path remains and errors otherwise
+(no silent partial result). The common system libraries are an explicit
+allowlist: macOS 11+ serves them from the dyld shared cache, so they have no
+on-disk file and a naive `exists("/usr/lib/libiconv.2.dylib")` check returns
+false even though the library loads.
+
+`run_app` (Python) wires this together: stage an app into a directory, `--share`
+it in, and launch it in the guest in one call.
 
 ## Why a standalone signed binary
 
@@ -215,10 +288,16 @@ decision should be made deliberately, not by accretion.
    [Off-screen capture](#off-screen-capture)).
 2. ~~Rust `install-macos` from a local IPSW.~~ Done.
 3. ~~First-run entitlement self-signer.~~ Done (see [Signing](#signing)).
-4. Guest input injection + Vision OCR to drive the guest headlessly (past Setup
-   Assistant, then launch an app) without the host cursor.
+4. ~~Guest input injection to drive the guest headlessly without the host
+   cursor.~~ Done: `drive-macos` (see [Driving the guest](#driving-the-guest)).
+   Getting past Setup Assistant is done offline by `provision` (see
+   [Provisioning past Setup Assistant](#provisioning-past-setup-assistant))
+   rather than by driving the network-backed screens; `stage-binary` plus
+   `run_app` cover launching a nix-built app. Vision OCR for locating controls
+   from a frame is still open.
 5. vsock control channel + long-lived `serve` mode for IPC.
-6. `macvm` Python module bundled into ix-mcp (like `tui`/`screen`): spawns this
-   signed binary and exposes `boot`, `screenshot`, and input, returning PIL
-   images that render inline.
+6. ~~`macvm` Python module bundled into ix-mcp (like `tui`/`screen`).~~ Done: the
+   module exposes `info`, `install`, `provision`, `stage_binary`, `screenshot`,
+   `screenshot_many`, `drive`, `Driver`, and `run_app`, returning PIL images that
+   render inline.
 7. OCI-disk boot for Linux guests; document the libkrun handoff for microVMs.

--- a/packages/macos-vm/README.md
+++ b/packages/macos-vm/README.md
@@ -133,7 +133,9 @@ guest stopped, so the next boot lands on a logged-in desktop:
 
 ```sh
 nix run .#macos-vm -- install-macos --ipsw ./UniversalMac_26.5_Restore.ipsw --bundle ./guest
-nix run .#macos-vm -- provision --bundle ./guest --user ix --autologin
+# --autologin reads the password from stdin (keeps it out of the process table);
+# omit --password-stdin for an empty password.
+printf '%s' "$PASSWORD" | nix run .#macos-vm -- provision --bundle ./guest --user ix --autologin --password-stdin
 nix run .#macos-vm -- drive-macos --bundle ./guest   # lands on the desktop, no Setup Assistant
 ```
 
@@ -148,7 +150,8 @@ synthesized container's APFS **Data** and **System** volumes, and:
   `LastSeenCloudProductVersion`/`LastSeenBuddyBuildVersion` to the guest OS
   version read from the System volume's `SystemVersion.plist`, so the cloud
   screen does not re-prompt;
-- with `--autologin`, writes `/private/etc/kcpassword` and the loginwindow
+- with `--autologin`, writes `/private/etc/kcpassword` (the password read from
+  stdin via `--password-stdin`, never an argument) and the loginwindow
   `autoLoginUser` so the guest boots straight to the desktop with no password.
 
 It reads the OS version from the guest **System** volume directly: the System
@@ -174,13 +177,17 @@ otool -L ./staged/myapp    # zero /nix/store entries
 For each `/nix/store` dylib in `otool -L`, it repoints to the `/usr/lib` system
 equivalent when the guest ships one (libiconv, libc++, libresolv, libobjc, …) or,
 when it does not, copies the dylib next to the output and rewrites the reference
-to `@loader_path/<name>` (bundling it, re-signing the bundled copy too). The
-output is ad-hoc re-signed, since a Mach-O whose load commands changed needs a
-fresh signature. It verifies no `/nix/store` path remains and errors otherwise
-(no silent partial result). The common system libraries are an explicit
-allowlist: macOS 11+ serves them from the dyld shared cache, so they have no
-on-disk file and a naive `exists("/usr/lib/libiconv.2.dylib")` check returns
-false even though the library loads.
+to `@loader_path/<name>`. A bundled dylib is then staged in turn: its own install
+id (`LC_ID_DYLIB`) is rewritten to `@loader_path/<name>` with `install_name_tool
+-id`, and its own `/nix/store` load deps are repointed or bundled the same way,
+recursively, so the whole dependency closure is guest-portable, not just the
+top-level binary. Every artifact (the output and each bundled dylib) is ad-hoc
+re-signed, since a Mach-O whose load commands changed needs a fresh signature,
+and each is checked for a remaining `/nix/store` path, erroring otherwise (no
+silent partial result). The common system libraries are an explicit allowlist:
+macOS 11+ serves them from the dyld shared cache, so they have no on-disk file
+and a naive `exists("/usr/lib/libiconv.2.dylib")` check returns false even though
+the library loads.
 
 `run_app` (Python) wires this together: stage an app into a directory, `--share`
 it in, and launch it in the guest in one call.

--- a/packages/macos-vm/src/main.rs
+++ b/packages/macos-vm/src/main.rs
@@ -114,6 +114,40 @@ enum Command {
         #[arg(long = "share", value_name = "TAG=HOSTDIR")]
         shares: Vec<String>,
     },
+    /// Copy a nix-built macOS binary and make it guest-portable: repoint every
+    /// `/nix/store` dylib to its `/usr/lib` system equivalent (or bundle it
+    /// next to the output with an `@loader_path` reference) and ad-hoc re-sign,
+    /// so the result links only libraries a vanilla guest has. Verifies that no
+    /// `/nix/store` path remains.
+    StageBinary {
+        /// Input binary (typically a `/nix/store` path).
+        #[arg(value_name = "IN")]
+        input: std::path::PathBuf,
+        /// Output path for the staged, guest-portable binary.
+        #[arg(value_name = "OUT")]
+        output: std::path::PathBuf,
+    },
+    /// Provision a STOPPED macOS guest bundle so it boots straight past Setup
+    /// Assistant to a logged-in desktop. Host-side disk edit: attaches the
+    /// guest disk, marks system + per-user setup complete, optionally enables
+    /// auto-login, then detaches. Refuses to run if the bundle appears in use.
+    Provision {
+        /// Guest bundle directory (must be stopped).
+        #[arg(long)]
+        bundle: std::path::PathBuf,
+        /// Short name of the guest user whose per-user Setup Assistant to mark
+        /// complete (the first account created during install).
+        #[arg(long)]
+        user: String,
+        /// Also enable password-less auto-login for `--user` (writes
+        /// `kcpassword` + the loginwindow `autoLoginUser`).
+        #[arg(long)]
+        autologin: bool,
+        /// Password for `--user`, used only to encode `kcpassword` when
+        /// `--autologin` is set. Defaults to an empty password.
+        #[arg(long, default_value = "")]
+        password: String,
+    },
 }
 
 #[cfg(target_os = "macos")]
@@ -240,6 +274,12 @@ mod input;
 mod macguest;
 
 #[cfg(target_os = "macos")]
+mod provision;
+
+#[cfg(target_os = "macos")]
+mod stagebin;
+
+#[cfg(target_os = "macos")]
 mod imp {
     //! The Virtualization.framework glue.
     //!
@@ -290,6 +330,10 @@ mod imp {
         Bundle { message: String },
         #[snafu(display("screenshot encode/write failed: {message}"))]
         CaptureEncode { message: String },
+        #[snafu(display("staging the binary guest-portable failed: {source}"))]
+        StageBinary { source: crate::stagebin::Error },
+        #[snafu(display("provisioning the guest failed: {source}"))]
+        Provision { source: crate::provision::Error },
     }
 
     /// Parameters for a Linux guest boot. A named struct rather than a wide
@@ -344,6 +388,24 @@ mod imp {
                     shares: parse_shares(&shares)?,
                 })
             }
+            Command::StageBinary { input, output } => {
+                let staged = crate::stagebin::stage_binary(&input, &output)
+                    .map_err(|source| Error::StageBinary { source })?;
+                println!("{}", staged.display());
+                Ok(())
+            }
+            Command::Provision {
+                bundle,
+                user,
+                autologin,
+                password,
+            } => crate::provision::provision(crate::provision::Provision {
+                bundle,
+                user,
+                autologin,
+                password,
+            })
+            .map_err(|source| Error::Provision { source }),
         }
     }
 

--- a/packages/macos-vm/src/main.rs
+++ b/packages/macos-vm/src/main.rs
@@ -143,10 +143,12 @@ enum Command {
         /// `kcpassword` + the loginwindow `autoLoginUser`).
         #[arg(long)]
         autologin: bool,
-        /// Password for `--user`, used only to encode `kcpassword` when
-        /// `--autologin` is set. Defaults to an empty password.
-        #[arg(long, default_value = "")]
-        password: String,
+        /// With `--autologin`, read the user's password from stdin to encode
+        /// `kcpassword` (a trailing newline is stripped). Passing it on stdin
+        /// rather than as an argument keeps it out of the process table. With no
+        /// flag (or no `--autologin`) the password is empty.
+        #[arg(long)]
+        password_stdin: bool,
     },
 }
 
@@ -398,15 +400,43 @@ mod imp {
                 bundle,
                 user,
                 autologin,
-                password,
-            } => crate::provision::provision(crate::provision::Provision {
-                bundle,
-                user,
-                autologin,
-                password,
-            })
-            .map_err(|source| Error::Provision { source }),
+                password_stdin,
+            } => {
+                // Read the autologin password from stdin (never an argument, so
+                // it stays out of the process table). Only when both --autologin
+                // and --password-stdin are set; otherwise the password is empty.
+                let password = if autologin && password_stdin {
+                    read_password_stdin()?
+                } else {
+                    String::new()
+                };
+                crate::provision::provision(crate::provision::Provision {
+                    bundle,
+                    user,
+                    autologin,
+                    password,
+                })
+                .map_err(|source| Error::Provision { source })
+            }
         }
+    }
+
+    /// Read a password from stdin, stripping a single trailing newline (and an
+    /// accompanying CR). The whole of stdin is the password, so a passphrase
+    /// containing spaces or other shell-significant bytes is passed verbatim.
+    fn read_password_stdin() -> Result<String, Error> {
+        use std::io::Read;
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(|e| Error::Bundle { message: format!("read password from stdin: {e}") })?;
+        if let Some(stripped) = buf.strip_suffix('\n') {
+            buf.truncate(stripped.len());
+            if let Some(stripped) = buf.strip_suffix('\r') {
+                buf.truncate(stripped.len());
+            }
+        }
+        Ok(buf)
     }
 
     /// Parse `--share TAG=HOSTDIR` specs into [`DirShare`]s. Tag `auto` maps to

--- a/packages/macos-vm/src/provision.rs
+++ b/packages/macos-vm/src/provision.rs
@@ -1,0 +1,618 @@
+//! Offline Setup Assistant bypass for a freshly installed macOS guest.
+//!
+//! A fresh install boots into Setup Assistant. On a host whose content filter
+//! breaks the guest's TLS to Apple, the network-backed screens (Apple ID, Screen
+//! Time) hang forever with greyed buttons, so the guest cannot be clicked past
+//! them. This module performs, with the guest STOPPED, the proven host-side disk
+//! edit that marks setup complete, so the next boot lands on a logged-in desktop.
+//!
+//! There are two layers of Setup Assistant:
+//!
+//! - **System** SA (language, country, account creation) is gated by
+//!   `/var/db/.AppleSetupDone` on the guest's **Data** volume.
+//! - **Per-user** SA ("MiniBuddy": Apple ID, Screen Time, Siri, appearance, …)
+//!   is gated per user by `DidSee*` keys in
+//!   `~/Library/Preferences/com.apple.SetupAssistant.plist`, plus
+//!   `LastSeenCloudProductVersion` / `LastSeenBuddyBuildVersion` matching the OS
+//!   (else the cloud screen re-prompts).
+//!
+//! This is a host-side reconciler over `hdiutil`/`diskutil`/`plutil`: attach the
+//! guest disk read-write with no auto-mount, mount the synthesized container's
+//! **Data** volume, write the markers, then unmount and detach robustly. A guard
+//! detaches even if an edit fails part-way, so the image is never left attached.
+//! It refuses to run if the image already appears attached (editing a mounted,
+//! possibly running guest would corrupt the filesystem).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Deserialize;
+use snafu::{OptionExt, ResultExt, Snafu};
+
+/// Per-user Setup Assistant `DidSee*` keys. Each false key shows its per-user
+/// setup screen on first login; setting all true skips the whole per-user flow.
+const DID_SEE_KEYS: &[&str] = &[
+    "DidSeeScreenTime",
+    "DidSeeSiriSetup",
+    "DidSeeCloudSetup",
+    "DidSeeAppearanceSetup",
+    "DidSeeTouchIDSetup",
+    "DidSeeApplePaySetup",
+    "DidSeeSyncSetup",
+    "DidSeeSyncSetup2",
+    "DidSeeTermsOfAddress",
+    "DidSeeActivationLock",
+    "DidSeeLockdownMode",
+    "DidSeeAppStore",
+];
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("bundle {path:?} does not contain a disk.img"))]
+    NoDisk { path: PathBuf },
+    #[snafu(display(
+        "disk image {path:?} is already attached; stop the VM (and detach the image) \
+         before provisioning to avoid filesystem corruption"
+    ))]
+    ImageInUse { path: PathBuf },
+    #[snafu(display("{tool} failed to run: {source}"))]
+    Spawn {
+        tool: &'static str,
+        source: std::io::Error,
+    },
+    #[snafu(display("{tool} exited with status {status}: {stderr}"))]
+    Tool {
+        tool: &'static str,
+        status: String,
+        stderr: String,
+    },
+    #[snafu(display("could not parse {tool} plist output: {source}"))]
+    ParsePlist {
+        tool: &'static str,
+        source: serde_json::Error,
+    },
+    #[snafu(display(
+        "no APFS Data volume found on the attached guest disk (devices: {devices:?})"
+    ))]
+    NoDataVolume { devices: Vec<String> },
+    #[snafu(display("the Data volume mounted at an unexpected/empty path"))]
+    NoMountPoint,
+    #[snafu(display("could not read the guest OS version from {path:?}: {message}"))]
+    GuestVersion { path: PathBuf, message: String },
+    #[snafu(display("filesystem edit on the guest Data volume failed: {source}"))]
+    Edit { source: std::io::Error },
+    #[snafu(display("could not feed plist bytes to plutil: {source}"))]
+    PipePlutil { source: std::io::Error },
+    #[snafu(display("plutil produced no stdin pipe to write the plist to"))]
+    PlutilNoStdin,
+}
+
+/// Parameters for [`provision`].
+pub struct Provision {
+    pub bundle: PathBuf,
+    pub user: String,
+    pub autologin: bool,
+    pub password: String,
+}
+
+/// `hdiutil attach -plist` result: the devices the image attached as.
+#[derive(Deserialize)]
+struct AttachResult {
+    #[serde(rename = "system-entities")]
+    system_entities: Vec<AttachEntity>,
+}
+
+#[derive(Deserialize)]
+struct AttachEntity {
+    #[serde(rename = "dev-entry")]
+    dev_entry: Option<String>,
+}
+
+/// `diskutil apfs list -plist` result.
+#[derive(Deserialize)]
+struct ApfsList {
+    #[serde(rename = "Containers")]
+    containers: Vec<ApfsContainer>,
+}
+
+#[derive(Deserialize)]
+struct ApfsContainer {
+    #[serde(rename = "PhysicalStores")]
+    physical_stores: Vec<ApfsPhysicalStore>,
+    #[serde(rename = "Volumes")]
+    volumes: Vec<ApfsVolume>,
+}
+
+#[derive(Deserialize)]
+struct ApfsPhysicalStore {
+    #[serde(rename = "DeviceIdentifier")]
+    device_identifier: String,
+}
+
+#[derive(Deserialize)]
+struct ApfsVolume {
+    #[serde(rename = "DeviceIdentifier")]
+    device_identifier: String,
+    #[serde(rename = "Roles", default)]
+    roles: Vec<String>,
+}
+
+/// `diskutil info -plist <dev>` result (the mount point after `diskutil mount`).
+#[derive(Deserialize)]
+struct DiskInfo {
+    #[serde(rename = "MountPoint")]
+    mount_point: Option<String>,
+}
+
+/// `hdiutil info -plist` result: the disk images currently attached.
+#[derive(Deserialize)]
+struct HdiutilInfo {
+    #[serde(default)]
+    images: Vec<HdiutilImage>,
+}
+
+#[derive(Deserialize)]
+struct HdiutilImage {
+    #[serde(rename = "image-path")]
+    image_path: Option<String>,
+}
+
+/// Provision the stopped guest in `bundle`: mark Setup Assistant complete (and,
+/// with `autologin`, enable password-less login) by editing its disk.
+pub fn provision(params: Provision) -> Result<(), Error> {
+    let Provision {
+        bundle,
+        user,
+        autologin,
+        password,
+    } = params;
+
+    let disk = bundle.join("disk.img");
+    if !disk.exists() {
+        return Err(Error::NoDisk { path: bundle });
+    }
+    // Refuse if the image is already attached: editing a live filesystem (a
+    // running guest, or a stale attach) corrupts it.
+    if image_attached(&disk)? {
+        return Err(Error::ImageInUse { path: disk });
+    }
+
+    // Attach read-write with no auto-mount; APFS synthesizes the container as a
+    // further /dev/disk we discover via `diskutil apfs list`.
+    let devices = attach_disk(&disk)?;
+    // Detach on every exit path (success, edit failure, mount failure), so the
+    // image is never left attached. `Guard` runs the teardown on drop; the mount
+    // it later records is unmounted before detaching. The guard owns its own copy
+    // of the device list since `devices` is still needed to find the volumes.
+    let mut guard = Guard::new(devices.clone());
+
+    let volumes = find_guest_volumes(&devices)?;
+    let data_mount = mount_volume(&volumes.data)?;
+    guard.add_mounted(volumes.data);
+
+    // Read the guest OS version from its System volume. The Data volume does not
+    // resolve the System firmlinks when mounted standalone from the host, so the
+    // System volume must be mounted separately. Mount it read-only (we never
+    // write the system volume) and from the SAME container as the Data volume.
+    let system_mount = mount_volume_readonly(&volumes.system)?;
+    guard.add_mounted(volumes.system);
+    let version = guest_os_version(Path::new(&system_mount))?;
+
+    // The edit is the only fallible-and-leaving-state step; the guard handles
+    // unmount/detach regardless of how it ends.
+    apply_edits(Path::new(&data_mount), &user, autologin, &password, &version)?;
+    Ok(())
+}
+
+/// A RAII teardown: unmount every mounted volume and detach the attached disks,
+/// robustly, when this drops. The synthesized container plus ISC/Recovery
+/// sub-disks all hang off the physical disk, so `hdiutil detach` of each attached
+/// device tears the tree down; we `force` to override a transient busy.
+struct Guard {
+    devices: Vec<String>,
+    mounted: Vec<String>,
+}
+
+impl Guard {
+    const fn new(devices: Vec<String>) -> Self {
+        Self { devices, mounted: Vec::new() }
+    }
+
+    fn add_mounted(&mut self, dev: String) {
+        self.mounted.push(dev);
+    }
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        for dev in &self.mounted {
+            // Best-effort unmount; the detach below is what actually frees the
+            // image, but unmounting first avoids a "busy" detach.
+            let _ = Command::new("/usr/sbin/diskutil")
+                .args(["unmount", "force", dev])
+                .output();
+        }
+        // Detach the attached disks. Sort so the base /dev/diskN (the attached
+        // image) is detached; detaching it releases the synthesized container.
+        // Dedupe: an `hdiutil attach` lists the whole-disk and its partitions,
+        // but we only need to detach each whole disk once.
+        let mut bases: Vec<&str> = self.devices.iter().map(|d| base_disk(d)).collect();
+        bases.sort_unstable();
+        bases.dedup();
+        for base in bases {
+            let _ = Command::new("/usr/bin/hdiutil")
+                .args(["detach", base, "-force"])
+                .output();
+        }
+    }
+}
+
+/// Whether `disk` already appears in `hdiutil info -plist` as an attached image.
+/// Compares canonicalized paths so a symlinked or relative `disk` still matches
+/// the absolute `image-path` hdiutil reports.
+fn image_attached(disk: &Path) -> Result<bool, Error> {
+    let json = run_plist_json("hdiutil", &["info", "-plist"])?;
+    let info: HdiutilInfo =
+        serde_json::from_str(&json).context(ParsePlistSnafu { tool: "hdiutil" })?;
+    let want = std::fs::canonicalize(disk).unwrap_or_else(|_| disk.to_path_buf());
+    Ok(info.images.iter().any(|img| {
+        img.image_path.as_ref().is_some_and(|p| {
+            let have = std::fs::canonicalize(p).unwrap_or_else(|_| PathBuf::from(p));
+            have == want
+        })
+    }))
+}
+
+/// Attach `disk` read-write with no mount; return the attached `/dev/diskN`
+/// device identifiers (without the `/dev/` prefix).
+fn attach_disk(disk: &Path) -> Result<Vec<String>, Error> {
+    let json = run_plist_json(
+        "hdiutil",
+        &["attach", "-plist", "-nomount", "-owners", "on", &disk.to_string_lossy()],
+    )?;
+    let parsed: AttachResult =
+        serde_json::from_str(&json).context(ParsePlistSnafu { tool: "hdiutil" })?;
+    let devices: Vec<String> = parsed
+        .system_entities
+        .into_iter()
+        .filter_map(|e| e.dev_entry)
+        .map(|d| d.trim_start_matches("/dev/").to_owned())
+        .filter(|d| d.starts_with("disk"))
+        .collect();
+    Ok(devices)
+}
+
+/// The guest's Data and System volume device identifiers, both from the one
+/// container backed by the attached image.
+struct GuestVolumes {
+    data: String,
+    system: String,
+}
+
+/// Find the guest's Data and System volumes on the container backed by one of
+/// `devices`. Both must come from the SAME container as the attached image, so a
+/// `System` volume belonging to the host (which also appears in `diskutil apfs
+/// list`) is never matched.
+fn find_guest_volumes(devices: &[String]) -> Result<GuestVolumes, Error> {
+    let json = run_plist_json("diskutil", &["apfs", "list", "-plist"])?;
+    let list: ApfsList =
+        serde_json::from_str(&json).context(ParsePlistSnafu { tool: "diskutil" })?;
+    // Match a container whose physical store is one of our attached devices
+    // (compare on the base disk: `disk5s1` belongs to attached `disk5`).
+    let bases: Vec<&str> = devices.iter().map(|d| base_disk(d)).collect();
+    for container in list.containers {
+        let backed = container
+            .physical_stores
+            .iter()
+            .any(|store| bases.contains(&base_disk(&store.device_identifier)));
+        if !backed {
+            continue;
+        }
+        let data = container
+            .volumes
+            .iter()
+            .find(|v| v.roles.iter().any(|r| r == "Data"))
+            .map(|v| v.device_identifier.clone());
+        let system = container
+            .volumes
+            .iter()
+            .find(|v| v.roles.iter().any(|r| r == "System"))
+            .map(|v| v.device_identifier.clone());
+        if let (Some(data), Some(system)) = (data, system) {
+            return Ok(GuestVolumes { data, system });
+        }
+    }
+    Err(Error::NoDataVolume { devices: devices.to_vec() })
+}
+
+/// The base disk identifier of a device (`disk5s1` -> `disk5`, `disk5` ->
+/// `disk5`). The partition suffix is the `s<digits>` after the disk number, so
+/// search past the literal `disk` prefix to avoid the `s` inside `disk` itself.
+fn base_disk(dev: &str) -> &str {
+    let after_prefix = dev.strip_prefix("disk").unwrap_or(dev);
+    after_prefix
+        .find('s')
+        .map_or(dev, |rel| &dev[..dev.len() - (after_prefix.len() - rel)])
+}
+
+/// Mount a volume read-write and return its mount point. The caller records the
+/// device on its [`Guard`] so teardown unmounts before detaching.
+fn mount_volume(dev: &str) -> Result<String, Error> {
+    mount_volume_with(dev, &["mount", dev])
+}
+
+/// Mount a volume read-only (for the System volume, which is only read).
+fn mount_volume_readonly(dev: &str) -> Result<String, Error> {
+    mount_volume_with(dev, &["mount", "readOnly", dev])
+}
+
+fn mount_volume_with(dev: &str, args: &[&str]) -> Result<String, Error> {
+    run_checked("diskutil", args)?;
+    let json = run_plist_json("diskutil", &["info", "-plist", dev])?;
+    let info: DiskInfo =
+        serde_json::from_str(&json).context(ParsePlistSnafu { tool: "diskutil" })?;
+    let mount = info.mount_point.filter(|m| !m.is_empty()).context(NoMountPointSnafu)?;
+    Ok(mount)
+}
+
+/// Write the Setup-Assistant-complete markers (and optional auto-login) onto the
+/// mounted guest Data volume. `version` is the guest OS product version read
+/// from its System volume.
+fn apply_edits(
+    data: &Path,
+    user: &str,
+    autologin: bool,
+    password: &str,
+    version: &str,
+) -> Result<(), Error> {
+    // 1. System SA: ensure `.AppleSetupDone` exists on the Data volume.
+    let setup_done = data.join("private/var/db/.AppleSetupDone");
+    if let Some(parent) = setup_done.parent() {
+        std::fs::create_dir_all(parent).context(EditSnafu)?;
+    }
+    if !setup_done.exists() {
+        std::fs::write(&setup_done, b"").context(EditSnafu)?;
+    }
+
+    // 2. Per-user SA: set every DidSee* key true in the user's
+    //    com.apple.SetupAssistant.plist, creating it if absent.
+    let prefs = data
+        .join("Users")
+        .join(user)
+        .join("Library/Preferences/com.apple.SetupAssistant.plist");
+    if let Some(parent) = prefs.parent() {
+        std::fs::create_dir_all(parent).context(EditSnafu)?;
+    }
+    if !prefs.exists() {
+        // `plutil -replace` needs a valid plist to edit; seed an empty dict.
+        std::fs::write(&prefs, EMPTY_PLIST).context(EditSnafu)?;
+    }
+    for key in DID_SEE_KEYS {
+        plutil_replace_bool(&prefs, key, true)?;
+    }
+
+    // 3. Match the cloud/buddy version keys to the guest OS so the cloud screen
+    //    does not re-prompt. `version` was read from the guest's System volume by
+    //    the caller (the System firmlinks do not resolve on a standalone-mounted
+    //    Data volume, so it cannot be read from `data`).
+    plutil_replace_string(&prefs, "LastSeenCloudProductVersion", version)?;
+    plutil_replace_string(&prefs, "LastSeenBuddyBuildVersion", version)?;
+
+    // 4. Optional auto-login.
+    if autologin {
+        enable_autologin(data, user, password)?;
+    }
+    Ok(())
+}
+
+/// Read the guest OS product version (e.g. `26.5`) from the System volume's
+/// `SystemVersion.plist`. `system` is the System volume's mount point.
+fn guest_os_version(system: &Path) -> Result<String, Error> {
+    let plist = system.join("System/Library/CoreServices/SystemVersion.plist");
+    if !plist.exists() {
+        return Err(Error::GuestVersion {
+            path: plist,
+            message: "SystemVersion.plist not found on the guest System volume".to_owned(),
+        });
+    }
+    let out = Command::new("/usr/bin/plutil")
+        .args(["-extract", "ProductVersion", "raw", "-o", "-"])
+        .arg(&plist)
+        .output()
+        .context(SpawnSnafu { tool: "plutil" })?;
+    if !out.status.success() {
+        return Err(Error::GuestVersion {
+            path: plist,
+            message: String::from_utf8_lossy(&out.stderr).into_owned(),
+        });
+    }
+    let version = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+    if version.is_empty() {
+        return Err(Error::GuestVersion {
+            path: plist,
+            message: "ProductVersion was empty".to_owned(),
+        });
+    }
+    Ok(version)
+}
+
+/// Write `kcpassword` and the loginwindow `autoLoginUser` so the guest boots
+/// straight to `user`'s desktop with no password typing.
+fn enable_autologin(data: &Path, user: &str, password: &str) -> Result<(), Error> {
+    // /etc/kcpassword holds the obfuscated auto-login password (XOR with a fixed
+    // key, NUL-padded to the next 12-byte block). It lives on the Data volume's
+    // firmlinked /etc (-> /private/etc).
+    let kcpassword = data.join("private/etc/kcpassword");
+    std::fs::write(&kcpassword, encode_kcpassword(password)).context(EditSnafu)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // root-only, matching the real file's 0600.
+        let _ = std::fs::set_permissions(&kcpassword, std::fs::Permissions::from_mode(0o600));
+    }
+
+    // The loginwindow preference selecting the auto-login user.
+    let loginwindow = data.join("Library/Preferences/com.apple.loginwindow.plist");
+    if let Some(parent) = loginwindow.parent() {
+        std::fs::create_dir_all(parent).context(EditSnafu)?;
+    }
+    if !loginwindow.exists() {
+        std::fs::write(&loginwindow, EMPTY_PLIST).context(EditSnafu)?;
+    }
+    plutil_replace_string(&loginwindow, "autoLoginUser", user)?;
+    Ok(())
+}
+
+/// Encode an auto-login password the way macOS's `kcpassword` expects: XOR each
+/// byte with the fixed cipher key (cycling), then pad with NULs to the next
+/// 12-byte boundary. An empty password yields just the padding block.
+fn encode_kcpassword(password: &str) -> Vec<u8> {
+    const CIPHER: [u8; 11] = [0x7d, 0x89, 0x52, 0x23, 0xd2, 0xbc, 0xdd, 0xea, 0xa3, 0xb9, 0x1f];
+    let bytes = password.as_bytes();
+    // Pad the plaintext length up to a multiple of the 12-byte block (matching
+    // Apple's loginwindow, which reads in 12-byte chunks).
+    let padded_len = bytes.len().div_ceil(12) * 12;
+    let padded_len = padded_len.max(12);
+    let mut out = Vec::with_capacity(padded_len);
+    for i in 0..padded_len {
+        let plain = bytes.get(i).copied().unwrap_or(0);
+        out.push(plain ^ CIPHER[i % CIPHER.len()]);
+    }
+    out
+}
+
+/// `plutil -replace <key> -bool <value>` on `plist`.
+fn plutil_replace_bool(plist: &Path, key: &str, value: bool) -> Result<(), Error> {
+    run_checked(
+        "plutil",
+        &[
+            "-replace",
+            key,
+            "-bool",
+            if value { "true" } else { "false" },
+            &plist.to_string_lossy(),
+        ],
+    )
+}
+
+/// `plutil -replace <key> -string <value>` on `plist`.
+fn plutil_replace_string(plist: &Path, key: &str, value: &str) -> Result<(), Error> {
+    run_checked(
+        "plutil",
+        &["-replace", key, "-string", value, &plist.to_string_lossy()],
+    )
+}
+
+/// An empty binary plist (a dict with no keys), the seed for a fresh
+/// preferences file `plutil -replace` can then edit.
+const EMPTY_PLIST: &[u8] =
+    b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+      <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
+      \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+      <plist version=\"1.0\"><dict/></plist>\n";
+
+/// Run a tool that emits a plist on stdout, converting it to JSON with `plutil`
+/// so it parses with `serde_json`. Returns the JSON text.
+fn run_plist_json(tool: &'static str, args: &[&str]) -> Result<String, Error> {
+    let tool_path = tool_path(tool);
+    let out = Command::new(tool_path)
+        .args(args)
+        .output()
+        .context(SpawnSnafu { tool })?;
+    if !out.status.success() {
+        return Err(Error::Tool {
+            tool,
+            status: out.status.to_string(),
+            stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        });
+    }
+    // Pipe the plist bytes through `plutil -convert json -o - -`.
+    let mut child = Command::new("/usr/bin/plutil")
+        .args(["-convert", "json", "-o", "-", "-"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .context(SpawnSnafu { tool: "plutil" })?;
+    {
+        use std::io::Write;
+        let mut stdin = child.stdin.take().context(PlutilNoStdinSnafu)?;
+        stdin.write_all(&out.stdout).context(PipePlutilSnafu)?;
+    }
+    let converted = child.wait_with_output().context(SpawnSnafu { tool: "plutil" })?;
+    if !converted.status.success() {
+        return Err(Error::Tool {
+            tool: "plutil",
+            status: converted.status.to_string(),
+            stderr: String::from_utf8_lossy(&converted.stderr).into_owned(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&converted.stdout).into_owned())
+}
+
+/// Run a tool, mapping a spawn failure or non-zero exit to a typed error.
+fn run_checked(tool: &'static str, args: &[&str]) -> Result<(), Error> {
+    let out = Command::new(tool_path(tool))
+        .args(args)
+        .output()
+        .context(SpawnSnafu { tool })?;
+    if out.status.success() {
+        return Ok(());
+    }
+    Err(Error::Tool {
+        tool,
+        status: out.status.to_string(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    })
+}
+
+/// Absolute path for a system tool (`diskutil` is under `/usr/sbin`, the rest
+/// under `/usr/bin`), so the reconciler does not depend on the caller's `PATH`.
+fn tool_path(tool: &str) -> PathBuf {
+    match tool {
+        "diskutil" => PathBuf::from("/usr/sbin/diskutil"),
+        other => PathBuf::from("/usr/bin").join(other),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base_disk_strips_partition() {
+        assert_eq!(base_disk("disk5"), "disk5");
+        assert_eq!(base_disk("disk5s1"), "disk5");
+        assert_eq!(base_disk("disk12s3"), "disk12");
+    }
+
+    #[test]
+    fn kcpassword_empty_is_one_padded_block() {
+        // Empty password: a single 12-byte block of cipher XOR 0.
+        let enc = encode_kcpassword("");
+        assert_eq!(enc.len(), 12);
+    }
+
+    #[test]
+    fn kcpassword_roundtrips_via_xor() {
+        // XORing the encoding back with the cipher recovers the plaintext bytes
+        // (the rest is NUL padding).
+        const CIPHER: [u8; 11] =
+            [0x7d, 0x89, 0x52, 0x23, 0xd2, 0xbc, 0xdd, 0xea, 0xa3, 0xb9, 0x1f];
+        let pw = "hunter2";
+        let enc = encode_kcpassword(pw);
+        let decoded: Vec<u8> = enc
+            .iter()
+            .enumerate()
+            .map(|(i, b)| b ^ CIPHER[i % CIPHER.len()])
+            .collect();
+        assert_eq!(&decoded[..pw.len()], pw.as_bytes());
+        assert!(decoded[pw.len()..].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn kcpassword_block_size_rounds_up() {
+        // A 13-char password needs two 12-byte blocks.
+        assert_eq!(encode_kcpassword("aaaaaaaaaaaaa").len(), 24);
+    }
+}

--- a/packages/macos-vm/src/provision.rs
+++ b/packages/macos-vm/src/provision.rs
@@ -95,19 +95,6 @@ pub struct Provision {
     pub password: String,
 }
 
-/// `hdiutil attach -plist` result: the devices the image attached as.
-#[derive(Deserialize)]
-struct AttachResult {
-    #[serde(rename = "system-entities")]
-    system_entities: Vec<AttachEntity>,
-}
-
-#[derive(Deserialize)]
-struct AttachEntity {
-    #[serde(rename = "dev-entry")]
-    dev_entry: Option<String>,
-}
-
 /// `diskutil apfs list -plist` result.
 #[derive(Deserialize)]
 struct ApfsList {
@@ -179,11 +166,12 @@ pub fn provision(params: Provision) -> Result<(), Error> {
 
     // Attach read-write with no auto-mount; APFS synthesizes the container as a
     // further /dev/disk we discover via `diskutil apfs list`.
-    let devices = attach_disk(&disk)?;
-    // Detach on every exit path (success, edit failure, mount failure), so the
-    // image is never left attached. `Guard` runs the teardown on drop; the mount
-    // it later records is unmounted before detaching. The guard owns its own copy
-    // of the device list since `devices` is still needed to find the volumes.
+    let attach_json = hdiutil_attach(&disk)?;
+    // Build the teardown guard from the attached devices the instant the attach
+    // succeeds, before any further parsing, so a parse failure here still
+    // detaches the image rather than leaking it. The device scan is a lenient
+    // substring pass over the raw plist-as-JSON that cannot itself fail.
+    let devices = scan_dev_entries(&attach_json);
     let mut guard = Guard::new(devices.clone());
 
     let volumes = find_guest_volumes(&devices)?;
@@ -263,23 +251,42 @@ fn image_attached(disk: &Path) -> Result<bool, Error> {
     }))
 }
 
-/// Attach `disk` read-write with no mount; return the attached `/dev/diskN`
-/// device identifiers (without the `/dev/` prefix).
-fn attach_disk(disk: &Path) -> Result<Vec<String>, Error> {
-    let json = run_plist_json(
+/// Attach `disk` read-write with no mount and return the raw plist-as-JSON of
+/// `hdiutil attach -plist`. The caller scans this for device identifiers with
+/// [`scan_dev_entries`] and builds a teardown guard before any strict parse, so
+/// a parse error never leaks the attachment.
+fn hdiutil_attach(disk: &Path) -> Result<String, Error> {
+    run_plist_json(
         "hdiutil",
         &["attach", "-plist", "-nomount", "-owners", "on", &disk.to_string_lossy()],
-    )?;
-    let parsed: AttachResult =
-        serde_json::from_str(&json).context(ParsePlistSnafu { tool: "hdiutil" })?;
-    let devices: Vec<String> = parsed
-        .system_entities
-        .into_iter()
-        .filter_map(|e| e.dev_entry)
-        .map(|d| d.trim_start_matches("/dev/").to_owned())
-        .filter(|d| d.starts_with("disk"))
-        .collect();
-    Ok(devices)
+    )
+}
+
+/// Extract the attached `/dev/diskN[sM]` device identifiers (without the `/dev/`
+/// prefix) from the raw attach output. This is a lenient substring scan rather
+/// than a typed parse so it cannot fail after a successful attach: the guard
+/// must be buildable from it even if the structured plist is unexpected. The
+/// `plutil` JSON escapes `/` as `\/`, so match the device tokens directly.
+fn scan_dev_entries(raw: &str) -> Vec<String> {
+    // Devices appear as `/dev/diskN` or, JSON-escaped, `\/dev\/diskN`. Normalize
+    // the escaping, then pull each `diskN[sM]` run after a `/dev/` marker.
+    let normalized = raw.replace("\\/", "/");
+    let mut devices: Vec<String> = Vec::new();
+    for (idx, _) in normalized.match_indices("/dev/disk") {
+        let rest = &normalized[idx + "/dev/".len()..];
+        // A device id is `disk` followed by digits and optional `sN` partition
+        // segments: take the leading run of ASCII alphanumerics.
+        let end = rest
+            .find(|c: char| !c.is_ascii_alphanumeric())
+            .unwrap_or(rest.len());
+        let dev = &rest[..end];
+        if dev.starts_with("disk") && dev.len() > "disk".len() {
+            devices.push(dev.to_owned());
+        }
+    }
+    devices.sort_unstable();
+    devices.dedup();
+    devices
 }
 
 /// The guest's Data and System volume device identifiers, both from the one
@@ -464,15 +471,21 @@ fn enable_autologin(data: &Path, user: &str, password: &str) -> Result<(), Error
 }
 
 /// Encode an auto-login password the way macOS's `kcpassword` expects: XOR each
-/// byte with the fixed cipher key (cycling), then pad with NULs to the next
-/// 12-byte boundary. An empty password yields just the padding block.
+/// byte with the fixed cipher key (cycling), padding with NULs to a 12-byte
+/// boundary. Matching Apple's loginwindow, when the password length is already a
+/// multiple of 12 (including the empty password) a whole extra 12-byte block is
+/// appended, so there is always at least one trailing pad byte.
 fn encode_kcpassword(password: &str) -> Vec<u8> {
     const CIPHER: [u8; 11] = [0x7d, 0x89, 0x52, 0x23, 0xd2, 0xbc, 0xdd, 0xea, 0xa3, 0xb9, 0x1f];
+    const BLOCK: usize = 12;
     let bytes = password.as_bytes();
-    // Pad the plaintext length up to a multiple of the 12-byte block (matching
-    // Apple's loginwindow, which reads in 12-byte chunks).
-    let padded_len = bytes.len().div_ceil(12) * 12;
-    let padded_len = padded_len.max(12);
+    // Round up to the next block, then if the length already sits exactly on a
+    // block boundary add one more full block (Apple appends a trailing pad block
+    // in that case so the encrypted form is never an un-padded exact multiple).
+    let mut padded_len = bytes.len().div_ceil(BLOCK) * BLOCK;
+    if bytes.len().is_multiple_of(BLOCK) {
+        padded_len += BLOCK;
+    }
     let mut out = Vec::with_capacity(padded_len);
     for i in 0..padded_len {
         let plain = bytes.get(i).copied().unwrap_or(0);
@@ -588,7 +601,8 @@ mod tests {
 
     #[test]
     fn kcpassword_empty_is_one_padded_block() {
-        // Empty password: a single 12-byte block of cipher XOR 0.
+        // Empty password (length 0, a multiple of 12): one full 12-byte pad
+        // block, per Apple's append-a-block-on-exact-multiple rule.
         let enc = encode_kcpassword("");
         assert_eq!(enc.len(), 12);
     }
@@ -614,5 +628,26 @@ mod tests {
     fn kcpassword_block_size_rounds_up() {
         // A 13-char password needs two 12-byte blocks.
         assert_eq!(encode_kcpassword("aaaaaaaaaaaaa").len(), 24);
+    }
+
+    #[test]
+    fn kcpassword_exact_multiple_appends_a_block() {
+        // A length that is already a multiple of 12 gets a whole extra pad block
+        // (12 -> 24, 24 -> 36), matching Apple's loginwindow.
+        assert_eq!(encode_kcpassword(&"a".repeat(12)).len(), 24);
+        assert_eq!(encode_kcpassword(&"a".repeat(24)).len(), 36);
+        assert_eq!(encode_kcpassword(&"a".repeat(11)).len(), 12);
+    }
+
+    #[test]
+    fn scan_dev_entries_handles_escaped_and_plain() {
+        // The plutil JSON escapes `/` as `\/`; both forms must yield the base
+        // and partition devices, deduped and sorted.
+        let escaped = r#"{"system-entities":[{"dev-entry":"\/dev\/disk7"},{"dev-entry":"\/dev\/disk7s1"}]}"#;
+        assert_eq!(scan_dev_entries(escaped), vec!["disk7", "disk7s1"]);
+        let plain = r#"{"dev-entry":"/dev/disk4","x":"/dev/disk4s2"}"#;
+        assert_eq!(scan_dev_entries(plain), vec!["disk4", "disk4s2"]);
+        // No devices -> empty (e.g. a parse-failure-shaped blob).
+        assert!(scan_dev_entries("{}").is_empty());
     }
 }

--- a/packages/macos-vm/src/stagebin.rs
+++ b/packages/macos-vm/src/stagebin.rs
@@ -1,0 +1,315 @@
+//! Stage a nix-built macOS binary so it runs on a vanilla guest.
+//!
+//! A binary built under Nix links its dynamic libraries by absolute
+//! `/nix/store/...` path. Those paths do not exist on a freshly installed macOS
+//! guest, so the dynamic linker refuses to start the process ("Library not
+//! loaded"). This module copies the binary and rewrites every `/nix/store`
+//! dylib reference so the copy depends only on libraries the guest already has,
+//! then ad-hoc re-signs it (a Mach-O whose load commands changed must be
+//! re-signed or the kernel kills it for an invalid signature).
+//!
+//! Two rewrite strategies per dependency:
+//!
+//! - **Repoint to a system library.** macOS ships the common C/C++ runtime
+//!   libraries under `/usr/lib` (libiconv, libc++, libobjc, libresolv, libz, …).
+//!   When the dependency's basename matches one that exists at the canonical
+//!   `/usr/lib/<name>` on this host, rewrite the reference to that path. The
+//!   guest has the same system libraries, so the reference resolves there.
+//! - **Bundle it.** A dependency with no system equivalent (a third-party dylib
+//!   the app itself needs) is copied next to the output and the reference is
+//!   rewritten to `@loader_path/<name>`, which the linker resolves relative to
+//!   the binary's own directory. The bundled copy is itself re-signed, since it
+//!   too is a Mach-O placed at a new path.
+//!
+//! After rewriting, `otool -L` on the output must show zero `/nix/store` paths;
+//! any remaining one is a typed error (no silent partial result).
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use snafu::{ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("input binary {path:?} does not exist"))]
+    MissingInput { path: PathBuf },
+    #[snafu(display("output path {path:?} has no parent directory"))]
+    NoOutputParent { path: PathBuf },
+    #[snafu(display("could not create output directory {path:?}: {source}"))]
+    CreateOutputDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[snafu(display("could not copy {from:?} to {to:?}: {source}"))]
+    Copy {
+        from: PathBuf,
+        to: PathBuf,
+        source: std::io::Error,
+    },
+    #[snafu(display("could not make {path:?} writable: {source}"))]
+    MakeWritable {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[snafu(display("{tool} failed to run: {source}"))]
+    Spawn {
+        tool: &'static str,
+        source: std::io::Error,
+    },
+    #[snafu(display(
+        "{tool} exited with status {status}: {stderr}"
+    ))]
+    Tool {
+        tool: &'static str,
+        status: String,
+        stderr: String,
+    },
+    #[snafu(display("otool -L output for {path:?} was not valid UTF-8"))]
+    OtoolEncoding { path: PathBuf },
+    #[snafu(display(
+        "a /nix/store dependency {dep:?} has no basename, so it cannot be bundled"
+    ))]
+    DepNoBasename { dep: String },
+    #[snafu(display(
+        "staged binary {path:?} still references /nix/store after rewriting:\n{remaining}"
+    ))]
+    StorePathsRemain { path: PathBuf, remaining: String },
+}
+
+/// Stage `input` into `output`: copy it, repoint every `/nix/store` dylib to a
+/// system path or a bundled copy, ad-hoc re-sign, and verify no `/nix/store`
+/// reference survives. Returns the staged path (`output`).
+pub fn stage_binary(input: &Path, output: &Path) -> Result<PathBuf, Error> {
+    if !input.exists() {
+        return Err(Error::MissingInput { path: input.to_path_buf() });
+    }
+    let out_dir = output
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .ok_or_else(|| Error::NoOutputParent { path: output.to_path_buf() })?;
+    std::fs::create_dir_all(out_dir).context(CreateOutputDirSnafu { path: out_dir.to_path_buf() })?;
+
+    copy_writable(input, output)?;
+
+    // Collect every /nix/store dependency, then plan each one. A dependency may
+    // legitimately appear more than once in `otool -L` for an unusual binary;
+    // dedupe so we issue one rewrite per distinct path.
+    let deps = nix_store_deps(output)?;
+    let mut bundled: BTreeSet<String> = BTreeSet::new();
+    for dep in &deps {
+        if let Some(system) = system_equivalent(dep) {
+            change_dep(output, dep, &system)?;
+        } else {
+            let name = basename(dep).ok_or_else(|| Error::DepNoBasename { dep: dep.clone() })?;
+            // Copy the dylib next to the output (once per distinct basename) and
+            // re-sign it, since it now lives at a new path.
+            if bundled.insert(name.clone()) {
+                let bundled_path = out_dir.join(&name);
+                copy_writable(Path::new(dep), &bundled_path)?;
+                codesign_adhoc(&bundled_path)?;
+            }
+            change_dep(output, dep, &format!("@loader_path/{name}"))?;
+        }
+    }
+
+    // The load commands changed, so the prior signature is invalid; re-sign.
+    codesign_adhoc(output)?;
+
+    // No silent fallback: a surviving /nix/store reference means the staged
+    // binary would not start on a guest, so fail loudly with the offenders.
+    let remaining = nix_store_deps(output)?;
+    if !remaining.is_empty() {
+        return Err(Error::StorePathsRemain {
+            path: output.to_path_buf(),
+            remaining: remaining.join("\n"),
+        });
+    }
+    Ok(output.to_path_buf())
+}
+
+/// Copy `from` to `to` and make `to` writable (a Nix store source is read-only,
+/// and `install_name_tool`/`codesign` must rewrite the copy in place).
+fn copy_writable(from: &Path, to: &Path) -> Result<(), Error> {
+    std::fs::copy(from, to).context(CopySnafu {
+        from: from.to_path_buf(),
+        to: to.to_path_buf(),
+    })?;
+    let mut perms = std::fs::metadata(to)
+        .context(MakeWritableSnafu { path: to.to_path_buf() })?
+        .permissions();
+    if perms.readonly() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            // Preserve the executable bits; just add owner-write.
+            let mode = perms.mode() | 0o200;
+            perms.set_mode(mode);
+        }
+        #[cfg(not(unix))]
+        {
+            #[allow(clippy::permissions_set_readonly_false)]
+            perms.set_readonly(false);
+        }
+        std::fs::set_permissions(to, perms)
+            .context(MakeWritableSnafu { path: to.to_path_buf() })?;
+    }
+    Ok(())
+}
+
+/// Run `otool -L <path>` and return the list of `/nix/store/...` dependency
+/// paths it reports (the load-command target paths, not the install name line).
+fn nix_store_deps(path: &Path) -> Result<Vec<String>, Error> {
+    let output = Command::new("/usr/bin/otool")
+        .arg("-L")
+        .arg(path)
+        .output()
+        .context(SpawnSnafu { tool: "otool" })?;
+    if !output.status.success() {
+        return Err(Error::Tool {
+            tool: "otool",
+            status: output.status.to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        });
+    }
+    let text = String::from_utf8(output.stdout)
+        .map_err(|_| Error::OtoolEncoding { path: path.to_path_buf() })?;
+    // `otool -L` prints the file path, then one indented line per dependency:
+    //   /path/to/bin:
+    //   \t/nix/store/.../libfoo.dylib (compatibility version ...)
+    // Take the first whitespace-delimited token of each indented line.
+    Ok(text
+        .lines()
+        .filter(|line| line.starts_with('\t') || line.starts_with("    "))
+        .filter_map(|line| line.split_whitespace().next())
+        .filter(|tok| tok.starts_with("/nix/store/"))
+        .map(str::to_owned)
+        .collect())
+}
+
+/// Runtime libraries macOS ships under `/usr/lib` and a fresh guest also has.
+/// These are the C/C++/system runtimes a nix-built binary commonly links; the
+/// guest resolves `/usr/lib/<name>` for each, so a `/nix/store` copy is repointed
+/// rather than bundled.
+///
+/// macOS 11+ ships these from the dyld shared cache, so the files do **not**
+/// exist on disk: a naive `Path::exists("/usr/lib/libiconv.2.dylib")` is `false`
+/// even though the library loads. An explicit allowlist is the reliable test;
+/// the on-disk check in [`system_equivalent`] only adds anything the cache lists
+/// as a real file (so a future library outside this set is still handled).
+const SYSTEM_LIBS: &[&str] = &[
+    "libiconv.2.dylib",
+    "libiconv.dylib",
+    "libc++.1.dylib",
+    "libc++.dylib",
+    "libc++abi.dylib",
+    "libresolv.9.dylib",
+    "libresolv.dylib",
+    "libz.1.dylib",
+    "libz.dylib",
+    "libobjc.A.dylib",
+    "libobjc.dylib",
+    "libSystem.B.dylib",
+    "libcharset.1.dylib",
+    "libcompression.dylib",
+    "libbz2.1.0.dylib",
+    "liblzma.5.dylib",
+    "libsqlite3.dylib",
+    "libxml2.2.dylib",
+    "libcurl.4.dylib",
+];
+
+/// The canonical system library path for a `/nix/store` dependency, when the
+/// guest is known to ship it. macOS keeps the runtime libraries under `/usr/lib`
+/// (served from the dyld shared cache), so a reference to `/usr/lib/<name>`
+/// resolves on the guest. Returns `None` when there is no such system library
+/// (then the dependency is bundled next to the output instead).
+fn system_equivalent(dep: &str) -> Option<String> {
+    let name = basename(dep)?;
+    let candidate = format!("/usr/lib/{name}");
+    // The allowlist is the primary test (the files live in the dyld cache, not
+    // on disk); the existence check catches any further `/usr/lib` library the
+    // host actually has as a file.
+    if SYSTEM_LIBS.contains(&name.as_str()) || Path::new(&candidate).exists() {
+        Some(candidate)
+    } else {
+        None
+    }
+}
+
+/// The final path component of a dependency reference.
+fn basename(dep: &str) -> Option<String> {
+    Path::new(dep)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+}
+
+/// Rewrite a single dependency reference in `binary` from `old` to `new` via
+/// `install_name_tool -change`.
+fn change_dep(binary: &Path, old: &str, new: &str) -> Result<(), Error> {
+    run_checked(
+        "install_name_tool",
+        Command::new("/usr/bin/install_name_tool")
+            .arg("-change")
+            .arg(old)
+            .arg(new)
+            .arg(binary),
+    )
+}
+
+/// Ad-hoc code-sign (`codesign --force --sign -`) so a rewritten Mach-O has a
+/// valid signature again (the kernel kills one whose load commands no longer
+/// match its signature).
+fn codesign_adhoc(path: &Path) -> Result<(), Error> {
+    run_checked(
+        "codesign",
+        Command::new("/usr/bin/codesign")
+            .args(["--force", "--sign", "-"])
+            .arg(path),
+    )
+}
+
+/// Run a command, mapping a spawn failure or non-zero exit to a typed error.
+fn run_checked(tool: &'static str, command: &mut Command) -> Result<(), Error> {
+    let output = command.output().context(SpawnSnafu { tool })?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(Error::Tool {
+        tool,
+        status: output.status.to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basename_is_final_component() {
+        assert_eq!(basename("/nix/store/abc/lib/libiconv.2.dylib").as_deref(), Some("libiconv.2.dylib"));
+        assert_eq!(basename("libfoo.dylib").as_deref(), Some("libfoo.dylib"));
+    }
+
+    #[test]
+    fn known_runtime_libs_repoint_to_usr_lib() {
+        // The listed system runtimes repoint even though they have no on-disk
+        // file (they live in the dyld shared cache).
+        assert_eq!(
+            system_equivalent("/nix/store/x/lib/libiconv.2.dylib").as_deref(),
+            Some("/usr/lib/libiconv.2.dylib"),
+        );
+        assert_eq!(
+            system_equivalent("/nix/store/x/lib/libc++.1.dylib").as_deref(),
+            Some("/usr/lib/libc++.1.dylib"),
+        );
+    }
+
+    #[test]
+    fn unknown_third_party_lib_is_bundled() {
+        // A library the guest does not ship has no system equivalent, so it is
+        // bundled (None here).
+        assert_eq!(system_equivalent("/nix/store/x/lib/libwgpu_native.dylib"), None);
+    }
+}

--- a/packages/macos-vm/src/stagebin.rs
+++ b/packages/macos-vm/src/stagebin.rs
@@ -79,7 +79,10 @@ pub enum Error {
 
 /// Stage `input` into `output`: copy it, repoint every `/nix/store` dylib to a
 /// system path or a bundled copy, ad-hoc re-sign, and verify no `/nix/store`
-/// reference survives. Returns the staged path (`output`).
+/// reference survives. Bundled third-party dylibs are processed transitively
+/// (their own `/nix/store` deps are repointed/bundled too) and each is staged in
+/// place, so the whole dependency closure is guest-portable. Returns the staged
+/// path (`output`).
 pub fn stage_binary(input: &Path, output: &Path) -> Result<PathBuf, Error> {
     if !input.exists() {
         return Err(Error::MissingInput { path: input.to_path_buf() });
@@ -92,40 +95,74 @@ pub fn stage_binary(input: &Path, output: &Path) -> Result<PathBuf, Error> {
 
     copy_writable(input, output)?;
 
-    // Collect every /nix/store dependency, then plan each one. A dependency may
-    // legitimately appear more than once in `otool -L` for an unusual binary;
-    // dedupe so we issue one rewrite per distinct path.
-    let deps = nix_store_deps(output)?;
+    // Work a queue of artifacts. The output is first; bundling a third-party
+    // dylib enqueues that bundled copy so its own `/nix/store` deps are processed
+    // the same way (transitive closure). `bundled` dedupes by basename so each
+    // distinct dylib is copied, processed, and re-signed exactly once.
     let mut bundled: BTreeSet<String> = BTreeSet::new();
+    let mut queue: Vec<PathBuf> = vec![output.to_path_buf()];
+    while let Some(artifact) = queue.pop() {
+        stage_artifact(&artifact, out_dir, &mut bundled, &mut queue)?;
+    }
+    Ok(output.to_path_buf())
+}
+
+/// Make one Mach-O artifact (the output binary or a bundled dylib) guest-portable
+/// in place: rewrite its own `/nix/store` install id, repoint or bundle each
+/// `/nix/store` load dependency (enqueuing newly bundled dylibs for the same
+/// treatment), re-sign, and assert no `/nix/store` reference remains.
+fn stage_artifact(
+    artifact: &Path,
+    out_dir: &Path,
+    bundled: &mut BTreeSet<String>,
+    queue: &mut Vec<PathBuf>,
+) -> Result<(), Error> {
+    // A dylib carries its own install id (LC_ID_DYLIB), which `otool -L` lists as
+    // the first indented line. For a nix-built dylib that id is a `/nix/store`
+    // path, and it must be rewritten with `-id` (not `-change`, which only
+    // touches load commands). `otool -D` prints just the id (empty for an
+    // executable), so it tells the id apart from the load deps.
+    if let Some(id) = install_id(artifact)?
+        && id.starts_with("/nix/store/")
+    {
+        let name = basename(&id).ok_or_else(|| Error::DepNoBasename { dep: id.clone() })?;
+        change_id(artifact, &format!("@loader_path/{name}"))?;
+    }
+
+    // Repoint or bundle each `/nix/store` load dependency. The id was already
+    // rewritten above, so it is no longer a `/nix/store` path here and does not
+    // reappear in this list.
+    let deps = nix_store_deps(artifact)?;
     for dep in &deps {
         if let Some(system) = system_equivalent(dep) {
-            change_dep(output, dep, &system)?;
+            change_dep(artifact, dep, &system)?;
         } else {
             let name = basename(dep).ok_or_else(|| Error::DepNoBasename { dep: dep.clone() })?;
-            // Copy the dylib next to the output (once per distinct basename) and
-            // re-sign it, since it now lives at a new path.
+            // Copy the dylib next to the output (once per distinct basename),
+            // then enqueue it so its own `/nix/store` deps are staged in turn.
             if bundled.insert(name.clone()) {
                 let bundled_path = out_dir.join(&name);
                 copy_writable(Path::new(dep), &bundled_path)?;
-                codesign_adhoc(&bundled_path)?;
+                queue.push(bundled_path);
             }
-            change_dep(output, dep, &format!("@loader_path/{name}"))?;
+            change_dep(artifact, dep, &format!("@loader_path/{name}"))?;
         }
     }
 
     // The load commands changed, so the prior signature is invalid; re-sign.
-    codesign_adhoc(output)?;
+    codesign_adhoc(artifact)?;
 
-    // No silent fallback: a surviving /nix/store reference means the staged
-    // binary would not start on a guest, so fail loudly with the offenders.
-    let remaining = nix_store_deps(output)?;
+    // No silent fallback: a surviving `/nix/store` reference means this artifact
+    // would not load on a guest, so fail loudly with the offenders. Applied to
+    // every artifact, the output and each bundled dylib.
+    let remaining = nix_store_deps(artifact)?;
     if !remaining.is_empty() {
         return Err(Error::StorePathsRemain {
-            path: output.to_path_buf(),
+            path: artifact.to_path_buf(),
             remaining: remaining.join("\n"),
         });
     }
-    Ok(output.to_path_buf())
+    Ok(())
 }
 
 /// Copy `from` to `to` and make `to` writable (a Nix store source is read-only,
@@ -185,6 +222,45 @@ fn nix_store_deps(path: &Path) -> Result<Vec<String>, Error> {
         .filter(|tok| tok.starts_with("/nix/store/"))
         .map(str::to_owned)
         .collect())
+}
+
+/// The Mach-O install id (`LC_ID_DYLIB`) of `path`, or `None` if it has none (an
+/// executable). `otool -D` prints the path then, on the next line, the id; an
+/// executable prints only the path line, so there is no second line.
+fn install_id(path: &Path) -> Result<Option<String>, Error> {
+    let output = Command::new("/usr/bin/otool")
+        .arg("-D")
+        .arg(path)
+        .output()
+        .context(SpawnSnafu { tool: "otool" })?;
+    if !output.status.success() {
+        return Err(Error::Tool {
+            tool: "otool",
+            status: output.status.to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        });
+    }
+    let text = String::from_utf8(output.stdout)
+        .map_err(|_| Error::OtoolEncoding { path: path.to_path_buf() })?;
+    // First line is the file path (with a trailing `:`); the id, if any, is the
+    // next non-empty line.
+    Ok(text
+        .lines()
+        .skip(1)
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_owned))
+}
+
+/// Rewrite a dylib's own install id (`LC_ID_DYLIB`) via `install_name_tool -id`.
+fn change_id(dylib: &Path, new: &str) -> Result<(), Error> {
+    run_checked(
+        "install_name_tool",
+        Command::new("/usr/bin/install_name_tool")
+            .arg("-id")
+            .arg(new)
+            .arg(dylib),
+    )
 }
 
 /// Runtime libraries macOS ships under `/usr/lib` and a fresh guest also has.

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -351,8 +351,8 @@ let
         export HOME=$TMPDIR/home
         mkdir -p "$HOME"
 
-        ix-mcp exec 'import macvm; print("macvm-ok", *(callable(getattr(macvm, n)) for n in ("info", "install", "screenshot", "screenshot_many", "drive", "Driver")))' >stdout 2>stderr
-        if ! grep -q '^macvm-ok True True True True True True$' stdout; then
+        ix-mcp exec 'import macvm; print("macvm-ok", *(callable(getattr(macvm, n)) for n in ("info", "install", "screenshot", "screenshot_many", "drive", "Driver", "provision", "stage_binary", "run_app")))' >stdout 2>stderr
+        if ! grep -q '^macvm-ok True True True True True True True True True$' stdout; then
           echo "macvm was not importable in a default session:" >&2
           cat stdout stderr >&2
           exit 1

--- a/packages/mcp/src/macvm/macvm/__init__.py
+++ b/packages/mcp/src/macvm/macvm/__init__.py
@@ -183,6 +183,10 @@ def stage_binary(
     """
     src = pathlib.Path(path)
     if out is None:
+        # Deliberately not a TemporaryDirectory: the staged binary (and any
+        # bundled dylibs beside it) is the return value and must outlive this
+        # call, so the directory is left for the caller/OS to reap rather than
+        # deleted on return.
         tmp = tempfile.mkdtemp(prefix="ix-macvm-stage-")
         out_path = pathlib.Path(tmp) / src.name
     else:
@@ -219,8 +223,10 @@ def provision(
     bundle's ``disk.img``, marks system and per-user Setup Assistant complete for
     ``user`` (the account created during :func:`install`), and detaches. With
     ``autologin`` it also enables password-less login for ``user`` (``password``
-    is only used to encode the auto-login secret; default empty). Raises
-    :class:`MacVmError` on failure, including if the image already appears in use.
+    is only used to encode the auto-login secret; default empty). The password is
+    passed to the binary over stdin, never as a command-line argument, so it does
+    not appear in the process table. Raises :class:`MacVmError` on failure,
+    including if the image already appears in use.
     """
     args = [
         _binary(),
@@ -230,12 +236,21 @@ def provision(
         "--user",
         user,
     ]
+    # The password goes over stdin (`--password-stdin`), so it never lands in
+    # argv where another user's `ps` could read it.
+    stdin_input: str | None = None
     if autologin:
         args.append("--autologin")
-        args += ["--password", password]
+        args.append("--password-stdin")
+        stdin_input = password
     try:
         result = subprocess.run(
-            args, capture_output=True, text=True, check=False, timeout=timeout
+            args,
+            input=stdin_input,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
         )
     except subprocess.TimeoutExpired as exc:
         raise MacVmError(f"provision timed out after {timeout}s") from exc
@@ -555,8 +570,15 @@ def run_app(
     must reach the desktop); ``seconds`` is how long to wait after launching the
     command before capturing. ``timeout`` bounds the whole driver session. The
     guest must already be provisioned to a logged-in desktop (see
-    :func:`provision`). Raises :class:`MacVmError` on failure.
+    :func:`provision`). Raises :class:`MacVmError` on failure, including if
+    ``command`` contains a newline.
     """
+    # A newline in `command` would split the driver's `type` line into two stdin
+    # commands, desyncing every subsequent ack. Reject it up front rather than
+    # fail confusingly mid-run; run multiple commands with separate calls or `;`.
+    if "\n" in command or "\r" in command:
+        raise MacVmError("run_app command must not contain a newline")
+
     if shares_tag == "auto":
         share_spec = f"auto={app_dir}"
         mount = _AUTOMOUNT_DIR

--- a/packages/mcp/src/macvm/macvm/__init__.py
+++ b/packages/mcp/src/macvm/macvm/__init__.py
@@ -55,6 +55,29 @@ directly, so it needs no Screen-Recording permission.
 
 This module is macOS-only: it raises on a non-Darwin platform, and the
 ``macos-vm`` binary is only bundled into the interpreter on Darwin.
+
+End-to-end example (one-time install, then provision and run an app). This needs
+a live guest plus Apple's Virtualization.framework and the entitlement, so it is
+**not** runnable in CI; run it on a Darwin host with a bundle on disk::
+
+    import macvm
+
+    # 1. Install once from a local IPSW (~15-20 min), then provision the stopped
+    #    guest past Setup Assistant to an auto-login desktop (offline disk edit).
+    macvm.install("/path/UniversalMac_26.5_Restore.ipsw", "/path/guest")
+    macvm.provision("/path/guest", user="ix", autologin=True)
+
+    # 2. Stage a nix-built GUI app so its /nix/store dylibs resolve on the guest,
+    #    then run it in the guest and capture a frame of the running app.
+    staged = macvm.stage_binary("/path/result/bin/bossbar-overlay",
+                                "/path/app/bossbar-overlay")
+    img = macvm.run_app("/path/guest", "/path/app",
+                        "'/Volumes/My Shared Files/bossbar-overlay'")
+    img   # PIL.Image of the guest desktop with the app running, rendered inline
+
+To drive the guest step by step instead, open a :class:`Driver` against the
+provisioned bundle and exercise ``key``/``type_``/``click``/``press_down``/
+``release``/``wait``/``shot`` in lockstep, asserting the returned frames change.
 """
 
 from __future__ import annotations
@@ -77,8 +100,11 @@ __all__ = [
     "drive",
     "info",
     "install",
+    "provision",
+    "run_app",
     "screenshot",
     "screenshot_many",
+    "stage_binary",
 ]
 
 
@@ -133,6 +159,88 @@ def install(ipsw: str | os.PathLike, bundle: str | os.PathLike, disk_gib: int = 
         raise MacVmError(f"install-macos timed out after {timeout}s") from exc
     if result.returncode != 0:
         raise MacVmError(f"install-macos failed: {result.stderr.strip()}")
+
+
+def stage_binary(
+    path: str | os.PathLike,
+    out: str | os.PathLike | None = None,
+    timeout: float = 120,
+) -> str:
+    """Copy a nix-built macOS binary and make it guest-portable, returning the
+    staged path.
+
+    A nix-built binary links its dylibs by absolute ``/nix/store`` path, which a
+    vanilla guest does not have. This repoints every ``/nix/store`` dependency to
+    its ``/usr/lib`` system equivalent (libiconv, libc++, libresolv, …) or, when
+    there is none, copies the dylib next to the output and rewrites it to an
+    ``@loader_path`` reference, then ad-hoc re-signs the result. It verifies no
+    ``/nix/store`` path remains and raises :class:`MacVmError` otherwise.
+
+    With ``out`` omitted, the staged binary is written to a temp directory under
+    the same basename and that path is returned; pass ``out`` to choose the
+    location (its parent directory is created). Use the staged directory as the
+    ``app_dir`` for :func:`run_app` so a guest can run the app.
+    """
+    src = pathlib.Path(path)
+    if out is None:
+        tmp = tempfile.mkdtemp(prefix="ix-macvm-stage-")
+        out_path = pathlib.Path(tmp) / src.name
+    else:
+        out_path = pathlib.Path(out)
+    try:
+        result = subprocess.run(
+            [_binary(), "stage-binary", str(src), str(out_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise MacVmError(f"stage-binary timed out after {timeout}s") from exc
+    if result.returncode != 0:
+        raise MacVmError(f"stage-binary failed: {result.stderr.strip()}")
+    # The binary prints the staged path on stdout; fall back to the requested
+    # path if (unexpectedly) absent.
+    staged = result.stdout.strip()
+    return staged or str(out_path)
+
+
+def provision(
+    bundle: str | os.PathLike,
+    user: str,
+    autologin: bool = False,
+    password: str = "",
+    timeout: float = 300,
+) -> None:
+    """Provision a STOPPED guest ``bundle`` so it boots past Setup Assistant to a
+    logged-in desktop.
+
+    A host-side disk edit (the guest must not be running): it attaches the
+    bundle's ``disk.img``, marks system and per-user Setup Assistant complete for
+    ``user`` (the account created during :func:`install`), and detaches. With
+    ``autologin`` it also enables password-less login for ``user`` (``password``
+    is only used to encode the auto-login secret; default empty). Raises
+    :class:`MacVmError` on failure, including if the image already appears in use.
+    """
+    args = [
+        _binary(),
+        "provision",
+        "--bundle",
+        str(bundle),
+        "--user",
+        user,
+    ]
+    if autologin:
+        args.append("--autologin")
+        args += ["--password", password]
+    try:
+        result = subprocess.run(
+            args, capture_output=True, text=True, check=False, timeout=timeout
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise MacVmError(f"provision timed out after {timeout}s") from exc
+    if result.returncode != 0:
+        raise MacVmError(f"provision failed: {result.stderr.strip()}")
 
 
 def screenshot(
@@ -409,3 +517,84 @@ def drive(
     """
     with Driver(bundle, shares=shares, timeout=timeout) as d:
         return [d.send(command) for command in commands]
+
+
+# Where the macOS automount tag (`auto`) mounts a virtio-fs share inside the
+# guest.
+_AUTOMOUNT_DIR = "/Volumes/My Shared Files"
+
+
+def run_app(
+    bundle: str | os.PathLike,
+    app_dir: str | os.PathLike,
+    command: str,
+    *,
+    seconds: float = 15,
+    shares_tag: str = "auto",
+    boot_seconds: float = 30,
+    timeout: float = 300,
+) -> "Image.Image":
+    """Share a host directory into a guest, launch a command in it, and return a
+    frame of the guest display.
+
+    The convenience that collapses the headline demo (run a host GUI app inside a
+    guest, off-screen, and screenshot it) into one call. It shares ``app_dir``
+    into the guest over virtio-fs, boots and drives the guest with a
+    :class:`Driver`, opens Terminal via Spotlight, runs ``command``, waits
+    ``seconds`` for it to render, and returns a ``PIL.Image`` of the display. The
+    host cursor and desktop are never touched.
+
+    ``command`` runs in the guest shell. Reference the shared files under the
+    mount point: with ``shares_tag="auto"`` (the default) the share is at
+    ``/Volumes/My Shared Files`` and ``app_dir``'s contents appear directly
+    there, so a binary ``app_dir/myapp`` is ``"/Volumes/My Shared Files/myapp"``.
+    Stage a nix-built binary first with :func:`stage_binary` (into ``app_dir``)
+    so its dylibs resolve on the guest.
+
+    ``boot_seconds`` is how long to wait after boot before driving (the guest
+    must reach the desktop); ``seconds`` is how long to wait after launching the
+    command before capturing. ``timeout`` bounds the whole driver session. The
+    guest must already be provisioned to a logged-in desktop (see
+    :func:`provision`). Raises :class:`MacVmError` on failure.
+    """
+    if shares_tag == "auto":
+        share_spec = f"auto={app_dir}"
+        mount = _AUTOMOUNT_DIR
+    else:
+        share_spec = f"{shares_tag}={app_dir}"
+        # A named tag is mounted by the guest wherever it chooses; the caller is
+        # responsible for referencing the right path in `command`. We still pass
+        # the share through so the device exists.
+        mount = ""
+
+    with Driver(bundle, shares=[share_spec], timeout=timeout) as d:
+        # Let the guest reach the desktop before driving it.
+        if boot_seconds > 0:
+            d.wait(boot_seconds)
+        # Open Spotlight, search for Terminal, launch it.
+        d.press_down("cmd")
+        d.key("space")
+        d.release("cmd")
+        d.wait(1.5)
+        d.type_("Terminal")
+        d.wait(1.5)
+        d.key("return")
+        d.wait(3)
+        # Run the command. `cd` into the share first when using the automount so
+        # a relative `command` resolves, then run it in the background so the
+        # shell stays responsive and the app keeps running while we capture.
+        if mount:
+            d.type_(f"cd {_shell_quote(mount)}")
+            d.key("return")
+            d.wait(0.5)
+        d.type_(command)
+        d.key("return")
+        # Wait for the app to render, then capture.
+        if seconds > 0:
+            d.wait(seconds)
+        return d.shot()
+
+
+def _shell_quote(path: str) -> str:
+    """Single-quote a path for a guest POSIX shell (the driver types it as-is)."""
+    return "'" + path.replace("'", "'\\''") + "'"


### PR DESCRIPTION
Implements the macvm usability chain end to end: stage nix-built binaries guest-portable, bypass Setup Assistant offline, and a one-call `run_app`. Closes #448, #449, #450, #451.

## What each issue does

- **#451 `stage-binary`** (`packages/macos-vm/src/stagebin.rs`, `macvm.stage_binary`): copies a nix-built macOS binary and rewrites every `/nix/store` dylib reference. Repoints to the `/usr/lib` system equivalent (libiconv, libc++, libresolv, libobjc, …) via an allowlist, or bundles the dylib next to the output with an `@loader_path` reference and re-signs it. Ad-hoc re-signs the output and verifies zero `/nix/store` paths remain (typed error, no silent fallback). The allowlist is load-bearing: macOS 11+ serves system libs from the dyld shared cache, so they have no on-disk file and a naive `exists("/usr/lib/libiconv.2.dylib")` is false.
- **#448 `provision`** (`packages/macos-vm/src/provision.rs`, `macvm.provision`): offline Setup Assistant bypass, a host-side reconciler over `hdiutil`/`diskutil`/`plutil` on a STOPPED guest. Attaches `disk.img`, finds the guest container's APFS Data + System volumes, ensures `.AppleSetupDone`, sets every per-user `DidSee*` key true, sets `LastSeenCloud/BuddyVersion` to the OS version read from the System volume, and (with `--autologin`) writes `kcpassword` + `autoLoginUser`. A RAII guard unmounts/detaches on every exit path; refuses if the image is already attached.
- **#450 `run_app`** (`macvm.run_app`): shares an app dir into the guest, boots/drives it, opens Terminal via Spotlight, runs the command, returns a `PIL.Image`. Reuses `Driver` and `_share_args`.
- **#449 verification**: `macvmBundled` check asserts the full 9-callable surface (`provision`, `stage_binary`, `run_app` added to the tuple, grep string, and `__all__`); Darwin-only hardware-gated end-to-end example in the module docstring.

## Validation (real, on Apple M5 Max / macOS 26.5)

**#451 — staged binary has zero `/nix/store` and runs:**
```
$ macos-vm stage-binary <macos-vm> /tmp/fs/macos-vm
$ otool -L /tmp/fs/macos-vm | grep -c /nix/store
0
$ otool -L /tmp/fs/macos-vm | grep iconv
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
$ /tmp/fs/macos-vm info
virtualization_supported=true
```
Also staged `bossbar-overlay`: zero `/nix/store`. (Both repoint libiconv; the bundle path is covered by a unit test and was observed working before the allowlist refinement.)

**#448 — provision against a live stopped guest (user `ix`):** exit 0, clean teardown. Re-inspecting the disk read-only confirms all 12 `DidSee*` keys true, `LastSeenCloudProductVersion`/`LastSeenBuddyBuildVersion` = `26.5` (read from the System volume), `.AppleSetupDone` present; with `--autologin`, `/private/etc/kcpassword` (mode 0600) + `autoLoginUser: ix`. The refuse-if-in-use guard fires (exit 1, typed error) when the image is attached. A real bug was caught and fixed during validation: the guest OS version cannot be read through the Data volume's firmlinks when mounted standalone, so the System volume is now mounted and matched within the same container.

**#449 gap #1 — fresh ix-mcp import on Darwin:**
```
$ nix run .#mcp -- exec 'import macvm, os; print(macvm.info()); print(os.environ["IX_MACVM_BIN"])'
virtualization_supported=true
IX_MACVM_BIN= /nix/store/.../macos-vm-0.1.0/bin/macos-vm
$ ... ("info","install","screenshot","screenshot_many","drive","Driver","provision","stage_binary","run_app")
macvm-ok True True True True True True True True True
```
The `macvmBundled` nix check passes.

## Gates
- `nix build .#macos-vm` and `nix build .#mcp` succeed.
- `nix run .#lint` clean for these files (pre-existing `examples/ray-cluster` findings are unrelated).
- `clippy -p macos-vm` clean for my code (remaining findings are pre-existing `ix-vt` cargo-metadata, not in this diff).
- Rust unit tests (in `stagebin.rs`/`provision.rs`, macOS-gated) verified via rustc; `run_app` is the only piece needing a live booted guest to exercise its full Spotlight→Terminal flow end to end (the pieces it composes are individually validated).

Made with AI assistance (Claude Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `stage-binary`, `provision`, and `run_app` to the macOS VM toolchain
> - Adds `stage-binary` CLI subcommand and `macvm.stage_binary()` Python function ([stagebin.rs](https://github.com/indexable-inc/index/pull/457/files#diff-651d151ce42c4f7e0f32815ceabde299340a1b153ea4f495fbd15be0987a0e99)) to rewrite nix-built binaries, replacing `/nix/store` dylib references with system paths or `@loader_path`-relative bundles, then ad-hoc codesigns the result.
> - Adds `provision` CLI subcommand and `macvm.provision()` Python function ([provision.rs](https://github.com/indexable-inc/index/pull/457/files#diff-ba08ffa01e301d47e216a7d7688847d4ca50da4c52a29effc8f64f5a772727bf)) to offline-bypass macOS Setup Assistant on a stopped guest by attaching the disk image, writing `.AppleSetupDone` and per-user plist markers, and optionally encoding autologin credentials via `kcpassword`.
> - Adds `macvm.run_app()` Python function ([`__init__.py`](https://github.com/indexable-inc/index/pull/457/files#diff-4b9daaeca5c33e547724daa485bc9d8c0851d6a70a0fc0b49ac3fc9cbc0e3ff9)) that shares a host directory, boots a guest, opens Terminal via Spotlight, runs a command, and returns a PIL screenshot.
> - Passwords for `provision` are accepted via stdin to avoid argv exposure.
> - Risk: `provision` mutates the guest disk image directly; running it against an already-attached image is refused but other partial-write failures may leave the image in an inconsistent state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5fd9559.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->