### PR TITLE
Add single-node S3 object storage (SeaweedFS) module + example

### DIFF
--- a/examples/s3-storage/README.md
+++ b/examples/s3-storage/README.md
@@ -1,0 +1,67 @@
+# s3-storage
+
+A single-node, S3-compatible object store running in one ix VM, backed by
+[SeaweedFS](https://github.com/seaweedfs/seaweedfs). Bring it up, point any S3
+client at port 8333, and read/write buckets.
+
+## Run it
+
+```sh
+ix-fleet up ./examples/s3-storage
+```
+
+The node enables the `services.ix-seaweedfs` module, which runs a single
+`weed server -s3` process (master, volume, filer, and S3 gateway in one
+binary) and opens only the S3 port in the firewall.
+
+## Smoke test
+
+Shell into the node and run a round-trip with the bundled
+[`s5cmd`](https://github.com/peak/s5cmd). The demo endpoint and credentials
+are exported as environment variables (`S3_ENDPOINT_URL`, `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`), so the commands need no flags:
+
+```sh
+s5cmd mb s3://demo-bucket
+echo "hello from ix" > /tmp/hello.txt
+s5cmd cp /tmp/hello.txt s3://demo-bucket/hello.txt
+s5cmd cat s3://demo-bucket/hello.txt   # -> hello from ix
+s5cmd ls s3://demo-bucket/
+```
+
+Create the bucket with `mb` before the first write; SeaweedFS does not
+auto-create buckets on PUT.
+
+The module also publishes a `/healthz` readiness check on the S3 port, so
+`ix` reports the node healthy only once the gateway is actually serving.
+
+## Credentials
+
+This example bakes a demo access/secret key pair into the image on purpose so
+it runs with no setup. The keys are `ix-demo-access-key` /
+`ix-demo-secret-key`, defined in `service.nix`.
+
+For anything real, drop the demo config and point the module at a runtime
+secret file so keys never enter the Nix store:
+
+```nix
+services.ix-seaweedfs = {
+  enable = true;
+  configFile = "/run/secrets/seaweedfs-s3.json";
+};
+```
+
+The file is SeaweedFS's S3 identities format: an `identities` array of
+`{ name, credentials: [{ accessKey, secretKey }], actions }`. Running with no
+`configFile` requires setting `allowAnonymous = true`, since an unauthenticated
+S3 endpoint is otherwise refused at evaluation.
+
+## Bad fit if
+
+- **You need replication or HA.** This is one node with one copy of the data.
+  SeaweedFS scales out, but that is a multi-node deployment this example does
+  not cover.
+- **You need the full AWS S3 feature set.** Core object, bucket, and multipart
+  operations work; lifecycle, versioning, and object-lock support is partial.
+- **The data must survive node loss.** Object data lives in the node's state
+  directory; back it up or snapshot the VM.

--- a/examples/s3-storage/default.nix
+++ b/examples/s3-storage/default.nix
@@ -1,0 +1,11 @@
+{ index }:
+
+index.lib.mkFleet {
+  defaults = [ { ix.image.tag = "s3-storage"; } ];
+
+  # No `recreateOnUp`: this node holds object data, so it persists across
+  # `ix-fleet up` instead of being rebuilt each time like the nginx demo.
+  nodes.s3 = {
+    modules = [ ./service.nix ];
+  };
+}

--- a/examples/s3-storage/service.nix
+++ b/examples/s3-storage/service.nix
@@ -1,0 +1,58 @@
+{
+  pkgs,
+  ...
+}:
+let
+  # DEMO credentials, baked into the store on purpose so the example runs
+  # as-is. For anything real, point `configFile` at a runtime secret file
+  # (e.g. /run/secrets/seaweedfs-s3.json) so keys never enter the store.
+  demoAccessKey = "ix-demo-access-key";
+  demoSecretKey = "ix-demo-secret-key";
+  demoS3Config = (pkgs.formats.json { }).generate "seaweedfs-s3-demo.json" {
+    identities = [
+      {
+        name = "demo";
+        credentials = [
+          {
+            accessKey = demoAccessKey;
+            secretKey = demoSecretKey;
+          }
+        ];
+        actions = [
+          "Admin"
+          "Read"
+          "Write"
+          "List"
+          "Tagging"
+        ];
+      }
+    ];
+  };
+in
+{
+  # The module owns the port claim, firewall opening, and the `/healthz`
+  # readiness check; enabling it is all the example needs.
+  services.ix-seaweedfs = {
+    enable = true;
+    configFile = demoS3Config;
+  };
+
+  # A small S3 client for the round-trip in the README and ad-hoc pokes.
+  environment.systemPackages = [ pkgs.s5cmd ];
+
+  # Surface the demo endpoint and credentials to anyone shelled in, so the
+  # round-trip below is copy-paste ready. Production deployments would not
+  # ship credentials this way.
+  # Demo only: this puts the secret key in the guest's global
+  # /etc/set-environment, readable by every user and process in the VM.
+  # Never export real keys this way; load them from a secret file instead.
+  environment.variables = {
+    # `s5cmd` reads S3_ENDPOINT_URL; the AWS CLI reads AWS_ENDPOINT_URL.
+    # Set both so either client works against the local gateway unflagged.
+    S3_ENDPOINT_URL = "http://127.0.0.1:8333";
+    AWS_ENDPOINT_URL = "http://127.0.0.1:8333";
+    AWS_ACCESS_KEY_ID = demoAccessKey;
+    AWS_SECRET_ACCESS_KEY = demoSecretKey;
+    AWS_REGION = "us-east-1";
+  };
+}

--- a/modules/services/seaweedfs/default.nix
+++ b/modules/services/seaweedfs/default.nix
@@ -1,0 +1,164 @@
+# Single-node S3-compatible object storage via SeaweedFS.
+#
+# One `weed server -s3` process runs the master, volume, filer, and S3
+# gateway in a single binary: enabling `-s3` auto-starts the filer it
+# depends on, so a single node needs no orchestration. SeaweedFS is the
+# fastest single-node S3 surface in nixpkgs (Apache-2.0, best small-object
+# IOPS, top large-object throughput); MinIO is AGPL with a gutted OSS
+# console, Garage is AGPL and weaker on small objects.
+#
+# Listeners bind broadly (`-ip.bind`) but only the S3 port is opened in the
+# firewall, so master/volume/filer stay node-local while S3 is reachable.
+{
+  config,
+  ix,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    optional
+    types
+    ;
+  cfg = config.services.ix-seaweedfs;
+  weed = lib.getExe' cfg.package "weed";
+
+  # `weed server` refuses to start unless `-dir` already exists and is
+  # writable: it does not create it. systemd's `StateDirectory` creates and
+  # chowns this exact path to the dynamic user before ExecStart, so the two
+  # must stay equal. Tying `-dir` to the StateDirectory keeps that invariant
+  # instead of exposing a free-form path that systemd would not provision.
+  stateDir = "/var/lib/seaweedfs";
+
+  # `-ip` is the address peers advertise to each other; on one node the
+  # internal services only ever talk over loopback. `-ip.bind` is the
+  # listen address, kept wide so the S3 port is reachable off-host while
+  # the firewall (below) is what actually limits exposure to S3 alone.
+  args = [
+    "server"
+    "-dir=${stateDir}"
+    "-ip=127.0.0.1"
+    "-ip.bind=${cfg.bindAddress}"
+    "-s3"
+    "-s3.port=${toString cfg.port}"
+  ]
+  ++ optional (cfg.configFile != null) "-s3.config=${cfg.configFile}"
+  ++ cfg.extraArgs;
+in
+{
+  options.services.ix-seaweedfs = {
+    enable = mkEnableOption "SeaweedFS single-node S3 object storage";
+
+    package = mkPackageOption pkgs "seaweedfs" { };
+
+    port = mkOption {
+      type = types.port;
+      default = 8333;
+      description = "S3 gateway listen port.";
+    };
+
+    bindAddress = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      description = ''
+        Listen address for every SeaweedFS listener. Exposure is bounded
+        by the firewall, which only opens {option}`port`; the master,
+        volume, and filer ports stay closed regardless of this value.
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether to open the S3 port in the firewall.";
+    };
+
+    configFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/seaweedfs-s3.json";
+      description = ''
+        Path to the SeaweedFS S3 identities config (`-s3.config`) holding
+        access/secret key pairs and per-identity actions. Point this at a
+        runtime secret file rather than a store path so credentials never
+        enter the Nix store. When unset, set {option}`allowAnonymous`.
+      '';
+    };
+
+    allowAnonymous = mkEnableOption ''
+      unauthenticated S3 access. Without {option}`configFile` SeaweedFS
+      serves every bucket to anonymous callers; this option is the
+      explicit opt-in required to run that way'';
+
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "-volume.max=0" ];
+      description = "Extra arguments appended to `weed server`.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Refuse the dangerous silent default: an S3 endpoint with no
+    # credentials is a data-exposure footgun, so require the operator to
+    # supply identities or opt into anonymous access by name.
+    assertions = [
+      {
+        assertion = cfg.configFile != null || cfg.allowAnonymous;
+        message = ''
+          services.ix-seaweedfs: set `configFile` to an S3 identities file
+          or enable `allowAnonymous` to run without authentication.
+        '';
+      }
+    ];
+
+    ix.networking.portClaims.ix-seaweedfs = {
+      protocol = "tcp";
+      inherit (cfg) port;
+      description = "SeaweedFS S3 gateway";
+    };
+
+    networking.firewall.allowedTCPPorts = optional cfg.openFirewall cfg.port;
+
+    ix.healthChecks.ix-seaweedfs = {
+      from = "guest";
+      # `/healthz` is served unauthenticated by the S3 gateway and only
+      # responds once the gateway (and the filer it proxies) are up, so it
+      # is a real readiness probe rather than a unit-active check.
+      description = "SeaweedFS S3 gateway is serving";
+      command = [
+        (lib.getExe pkgs.curl)
+        "--fail"
+        "--silent"
+        "--show-error"
+        "--max-time"
+        "5"
+        "http://127.0.0.1:${toString cfg.port}/healthz"
+      ];
+    };
+
+    systemd.services.ix-seaweedfs = {
+      description = "SeaweedFS single-node S3 object storage";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = ix.systemdHardening // {
+        Type = "simple";
+        ExecStart = "${weed} ${lib.escapeShellArgs args}";
+        Restart = "on-failure";
+        RestartSec = 2;
+        DynamicUser = true;
+        StateDirectory = "seaweedfs";
+        # `ProtectSystem=strict` makes CWD (`/`) read-only. `weed` resolves
+        # optional config files (filer.toml, security.toml) relative to CWD,
+        # so point the working directory at the writable state dir.
+        WorkingDirectory = stateDir;
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1367,6 +1367,21 @@ let
       plan = fleet.planValue.nodes.nginx;
     };
 
+  s3StorageExample =
+    let
+      fleet = import ../examples/s3-storage {
+        index = {
+          lib = ix;
+        };
+      };
+      config = fleet.nodes.s3;
+    in
+    {
+      inherit fleet config;
+      cfg = config.services.ix-seaweedfs;
+      plan = fleet.planValue.nodes.s3;
+    };
+
   observabilityStackExample =
     let
       fleet = import ../examples/observability-stack {
@@ -2082,6 +2097,57 @@ let
               "http://127.0.0.1/"
             ];
         message = "nginx-lifecycle fleet plan should prove the service unit and HTTP loopback path";
+      }
+    ];
+
+    s3-storage = [
+      {
+        assertion = s3StorageExample.cfg.enable && s3StorageExample.cfg.configFile != null;
+        message = "s3-storage example should enable SeaweedFS with an S3 identities config";
+      }
+      {
+        assertion = !(s3StorageExample.plan.recreateOnUp or false);
+        message = "s3-storage node should persist data across ix-fleet up, not recreate";
+      }
+      {
+        # Defends the module's headline claim: only the S3 port is exposed.
+        # `samePorts` (not `elem`) fails if the master/volume/filer ports
+        # ever leak into the firewall alongside the base sidecar ports.
+        assertion =
+          let
+            claims = s3StorageExample.config.ix.networking.portClaims;
+          in
+          claims.ix-seaweedfs.protocol == "tcp"
+          && claims.ix-seaweedfs.port == 8333
+          && samePorts s3StorageExample.config.networking.firewall.allowedTCPPorts (
+            baseFirewallTcpPorts ++ [ 8333 ]
+          );
+        message = "s3-storage example should open only the S3 port, not master/volume/filer";
+      }
+      {
+        assertion =
+          let
+            check = s3StorageExample.plan.healthChecks.ix-seaweedfs;
+          in
+          check.from == "guest"
+          && lib.hasSuffix "/bin/curl" (builtins.head check.command)
+          && lib.last check.command == "http://127.0.0.1:8333/healthz";
+        message = "s3-storage health check should probe the unauthenticated S3 /healthz route";
+      }
+      {
+        # The module must refuse an S3 endpoint with neither credentials nor
+        # an explicit anonymous opt-in, rather than silently serving open.
+        assertion =
+          let
+            failures = failedAssertionsFor [ { services.ix-seaweedfs.enable = true; } ];
+          in
+          builtins.any (a: lib.hasInfix "configFile" a.message) failures;
+        message = "ix-seaweedfs should fail evaluation when run with no credentials and no allowAnonymous";
+      }
+      {
+        # The example supplies a configFile, so it must clear that gate.
+        assertion = failedAssertionsFor [ ../examples/s3-storage/service.nix ] == [ ];
+        message = "s3-storage example should satisfy the ix-seaweedfs credentials assertion";
       }
     ];
 


### PR DESCRIPTION
## What

A single-node, S3-compatible object store for ix VMs, plus the module that powers it.

- **`modules/services/seaweedfs/`** — new `services.ix-seaweedfs` module. One `weed server -s3` process runs the master, volume, filer, and S3 gateway in a single binary (enabling `-s3` auto-starts the filer it depends on), under a systemd unit with `DynamicUser`, a StateDirectory-pinned data dir, and the repo's `ix.systemdHardening` baseline.
- **`examples/s3-storage/`** — a fleet that brings the module up with clearly labeled demo credentials, ships `s5cmd`, and documents a copy-paste round-trip.
- **`tests/default.nix`** — an `s3-storage` assertion group.

## Why SeaweedFS

Picked over the alternatives for a single fast-NVMe node:

| | License | Single-node fit | nixpkgs |
|---|---|---|---|
| **SeaweedFS** | **Apache-2.0** | best small-object IOPS, top large-object throughput | `seaweedfs` 4.19 |
| MinIO | AGPLv3 | matches on big objects, but 2025 OSS console/features gutted toward paid AiStor | `minio` |
| Garage | AGPLv3 | weaker on small objects / listing | `garage` |
| Ceph RGW | LGPL/GPL | heavy, slowest single-node | `ceph` |

SeaweedFS is the only top contender that is permissively licensed, fast on both axes, and already packaged.

## Design notes

- **Firewall-narrow, bind-broad**: listeners bind on `-ip.bind` (default `0.0.0.0`) but only the S3 port is opened in the firewall, so master/volume/filer stay node-local. A test asserts this with `samePorts`, not just "8333 is present", so a leaked internal port fails CI.
- **No silent-open default**: running without `configFile` requires an explicit `allowAnonymous`, else evaluation fails. An unauthenticated S3 endpoint is never the accidental default.
- **`-dir` is pinned to the systemd `StateDirectory`**: `weed` refuses to start unless its data dir already exists, and systemd creates exactly that path. A free-form `dataDir` option would have crashed on override, so it was removed.
- **`/healthz`** (served unauthenticated by the gateway) is the readiness probe, so the node is healthy only once S3 is actually serving.

## Validation

- ✅ `nix build .#checks.x86_64-linux.eval` (the new assertion group passes)
- ✅ Lint: nixfmt, deadnix, statix, ast-grep repo rules
- ✅ **Live round-trip on a real x86_64-linux host, run under the exact systemd sandbox this module generates** (`ProtectSystem=strict` + `DynamicUser` + `StateDirectory` + `WorkingDirectory` via `systemd-run`): unit reaches `active (running)`, `/healthz` returns 200, `mb`/`cp`/`cat`/`ls` round-trip succeeds, data lands in the StateDirectory, and **wrong credentials return 403** (auth is genuinely enforced).
- ✅ Adversarial code review pass; its one blocking finding (missing `WorkingDirectory` under `ProtectSystem=strict`) is fixed and re-verified live.

---
Made with AI assistance (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add single-node SeaweedFS S3 object storage module and example
> - Adds [modules/services/seaweedfs/default.nix](https://github.com/indexable-inc/index/pull/458/files#diff-596b45839d56fa88b122224ae39b00dd7052bb2310ca9d07e58098a6aa1f75f4), a NixOS-style module that runs SeaweedFS's all-in-one server with an S3 gateway on a configurable port (default 8333), persisting state under `/var/lib/seaweedfs` via a hardened systemd unit.
> - Requires either a `configFile` (S3 identities JSON) or explicit `allowAnonymous = true`; evaluation fails otherwise to prevent accidentally open storage.
> - Adds a health check that probes `http://127.0.0.1:<port>/healthz` via `curl` and claims the S3 port via `ix.networking.portClaims` to prevent conflicts.
> - Adds [examples/s3-storage/](https://github.com/indexable-inc/index/pull/458/files#diff-bde6798742d961f41a0fbed5441e15c1575a4e00a5c041a54f92280970416c91) with a ready-to-run fleet definition, demo credentials, and `s5cmd` installed for smoke testing; the fleet omits `recreateOnUp` to persist data across restarts.
> - Adds tests in [tests/default.nix](https://github.com/indexable-inc/index/pull/458/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) covering port claims, firewall rules, health check config, and the credentials assertion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0bcfb09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->