### PR TITLE
fix(minecraft-sound): error on unknown sound name; add --pitch/--volume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,12 +3085,12 @@ dependencies = [
 name = "minecraft-sound"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
  "dirs",
  "rodio",
  "serde",
  "serde_json",
+ "snafu 0.9.1",
 ]
 
 [[package]]

--- a/packages/minecraft/sound/Cargo.toml
+++ b/packages/minecraft/sound/Cargo.toml
@@ -8,9 +8,9 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 dirs.workspace = true
 rodio.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+snafu.workspace = true

--- a/packages/minecraft/sound/src/assets.rs
+++ b/packages/minecraft/sound/src/assets.rs
@@ -3,8 +3,72 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, bail};
 use serde::Deserialize;
+use snafu::{OptionExt as _, ResultExt as _, Snafu};
+
+/// Errors that can occur while locating or resolving Minecraft sound assets.
+#[derive(Debug, Snafu)]
+pub enum AssetError {
+    #[snafu(display("Could not determine home directory"))]
+    NoHomeDir,
+
+    #[snafu(display(
+        "Minecraft directory not found at {}. Set MCSOUND_ASSETS or MINECRAFT_HOME, or install Minecraft.",
+        path.display()
+    ))]
+    MinecraftDirMissing { path: PathBuf },
+
+    #[snafu(display("No asset indexes found. Have you launched Minecraft at least once?"))]
+    NoAssetIndexes,
+
+    #[snafu(display("No asset index files found in {}", dir.display()))]
+    NoIndexFiles { dir: PathBuf },
+
+    #[snafu(display("Failed to read directory {}", path.display()))]
+    ReadDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to read directory entry in {}", path.display()))]
+    ReadDirEntry {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to read file type for {}", path.display()))]
+    ReadFileType {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to read index file: {}", path.display()))]
+    ReadIndex {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to parse asset index JSON: {}", path.display()))]
+    ParseIndex {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+
+    /// The requested sound name does not match any bundled or installed sound.
+    /// The display lists the closest matches and points at `list` so a typo'd
+    /// name fails loudly instead of silently playing nothing.
+    #[snafu(display("{}", format_unknown_sound(name, suggestions)))]
+    UnknownSound {
+        name: String,
+        suggestions: Vec<String>,
+    },
+
+    #[snafu(display("Malformed hash for {name}: {hash}"))]
+    MalformedHash { name: String, hash: String },
+
+    #[snafu(display("Sound file missing from disk: {}", path.display()))]
+    SoundFileMissing { path: PathBuf },
+}
 
 #[derive(Debug, Deserialize)]
 struct AssetIndex {
@@ -37,7 +101,7 @@ impl MinecraftAssets {
     /// # Errors
     /// Returns an error if no install can be found or its asset index cannot
     /// be read or parsed.
-    pub fn load() -> Result<Self> {
+    pub fn load() -> Result<Self, AssetError> {
         if let Some(dir) = env::var_os("MCSOUND_ASSETS") {
             let root = PathBuf::from(dir);
             if root.is_dir() {
@@ -47,10 +111,10 @@ impl MinecraftAssets {
 
         let minecraft_dir = find_minecraft_dir()?;
         let index_path = find_latest_index(&minecraft_dir)?;
-        let content = fs::read_to_string(&index_path)
-            .with_context(|| format!("Failed to read index file: {}", index_path.display()))?;
+        let content =
+            fs::read_to_string(&index_path).context(ReadIndexSnafu { path: &index_path })?;
         let index: AssetIndex =
-            serde_json::from_str(&content).context("Failed to parse asset index JSON")?;
+            serde_json::from_str(&content).context(ParseIndexSnafu { path: &index_path })?;
 
         let objects = index
             .objects
@@ -71,23 +135,8 @@ impl MinecraftAssets {
     ///
     /// # Errors
     /// Returns an error if a bundled sound directory cannot be walked.
-    pub fn list_sounds(&self, pattern: Option<&str>) -> Result<Vec<String>> {
-        let mut sounds = match self {
-            Self::Bundled { root } => {
-                let mut names = Vec::new();
-                collect_bundled(root, root, &mut names)?;
-                names
-            }
-            Self::Install { objects, .. } => objects
-                .keys()
-                .filter_map(|key| {
-                    key.strip_prefix("minecraft/sounds/")?
-                        .strip_suffix(".ogg")
-                        .map(str::to_owned)
-                })
-                .collect(),
-        };
-
+    pub fn list_sounds(&self, pattern: Option<&str>) -> Result<Vec<String>, AssetError> {
+        let mut sounds = self.all_sounds()?;
         if let Some(pattern) = pattern {
             sounds.retain(|name| name.contains(pattern));
         }
@@ -95,24 +144,52 @@ impl MinecraftAssets {
         Ok(sounds)
     }
 
+    /// Every known sound name, unsorted and unfiltered.
+    fn all_sounds(&self) -> Result<Vec<String>, AssetError> {
+        match self {
+            Self::Bundled { root } => {
+                let mut names = Vec::new();
+                collect_bundled(root, root, &mut names)?;
+                Ok(names)
+            }
+            Self::Install { objects, .. } => Ok(objects
+                .keys()
+                .filter_map(|key| {
+                    key.strip_prefix("minecraft/sounds/")?
+                        .strip_suffix(".ogg")
+                        .map(str::to_owned)
+                })
+                .collect()),
+        }
+    }
+
     /// Resolve a sound name (e.g. `mob/zombie/death`) to a file on disk.
     ///
     /// # Errors
-    /// Returns an error if the sound is unknown or its file is missing.
-    pub fn resolve_sound(&self, name: &str) -> Result<PathBuf> {
+    /// Returns [`AssetError::UnknownSound`] (with close-match suggestions) when
+    /// the name matches no bundled or installed sound, and other variants when
+    /// the resolved file is missing or the install metadata is malformed.
+    pub fn resolve_sound(&self, name: &str) -> Result<PathBuf, AssetError> {
         let path = match self {
-            Self::Bundled { root } => root.join(format!("{name}.ogg")),
+            Self::Bundled { root } => {
+                let path = root.join(format!("{name}.ogg"));
+                // A bundled tree has no name index, so a missing file is the
+                // only signal that the name is bogus. Treat it as "unknown
+                // sound" with suggestions rather than a bare missing-file error.
+                if !path.exists() {
+                    return Err(self.unknown_sound(name)?);
+                }
+                path
+            }
             Self::Install {
                 minecraft_dir,
                 objects,
             } => {
                 let key = format!("minecraft/sounds/{name}.ogg");
-                let hash = objects
-                    .get(&key)
-                    .with_context(|| format!("Sound not found: {name}"))?;
-                let prefix = hash
-                    .get(..2)
-                    .with_context(|| format!("Malformed hash: {hash}"))?;
+                let Some(hash) = objects.get(&key) else {
+                    return Err(self.unknown_sound(name)?);
+                };
+                let prefix = hash.get(..2).context(MalformedHashSnafu { name, hash })?;
                 minecraft_dir
                     .join("assets")
                     .join("objects")
@@ -121,21 +198,98 @@ impl MinecraftAssets {
             }
         };
 
-        if !path.exists() {
-            bail!("Sound file missing from disk: {}", path.display());
+        if path.exists() {
+            Ok(path)
+        } else {
+            SoundFileMissingSnafu { path }.fail()
         }
-        Ok(path)
+    }
+
+    /// Build an [`AssetError::UnknownSound`] for `name`, attaching the closest
+    /// known sound names so the caller can suggest a correction. The inner
+    /// `Result` is the failure to enumerate known sounds (e.g. unreadable dir).
+    fn unknown_sound(&self, name: &str) -> Result<AssetError, AssetError> {
+        let all = self.all_sounds()?;
+        let suggestions = closest_matches(name, &all);
+        Ok(UnknownSoundSnafu {
+            name: name.to_owned(),
+            suggestions,
+        }
+        .build())
     }
 }
 
+/// Render the user-facing message for an unknown sound: name the bad input,
+/// list any close matches, and always point at `minecraft-sound list`.
+fn format_unknown_sound(name: &str, suggestions: &[String]) -> String {
+    let mut msg = format!("Unknown sound: '{name}'.");
+    if !suggestions.is_empty() {
+        msg.push_str(" Did you mean: ");
+        msg.push_str(&suggestions.join(", "));
+        msg.push('?');
+    }
+    msg.push_str(" Run `minecraft-sound list` to see available sounds.");
+    msg
+}
+
+/// Pick up to three of the closest sound names to `query`, preferring substring
+/// matches and then small edit distances. Keeps the dependency surface at zero
+/// by using a plain Levenshtein implementation.
+fn closest_matches(query: &str, candidates: &[String]) -> Vec<String> {
+    let mut scored: Vec<(usize, &String)> = candidates
+        .iter()
+        .map(|candidate| {
+            // Substring hits sort first by collapsing their distance to 0.
+            let distance = if candidate.contains(query) || query.contains(candidate.as_str()) {
+                0
+            } else {
+                levenshtein(query, candidate)
+            };
+            (distance, candidate)
+        })
+        .collect();
+
+    // Sort by distance, then name for a stable, deterministic order.
+    scored.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(b.1)));
+
+    // Only keep suggestions that are reasonably close: a distance larger than
+    // the query length is almost certainly noise.
+    let threshold = query.chars().count().max(3);
+    scored
+        .into_iter()
+        .filter(|(distance, _)| *distance <= threshold)
+        .take(3)
+        .map(|(_, name)| name.clone())
+        .collect()
+}
+
+/// Classic dynamic-programming Levenshtein edit distance over Unicode scalar
+/// values. Small inputs (sound names), so the quadratic table is fine.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let b_chars: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b_chars.len()).collect();
+    let mut curr = vec![0usize; b_chars.len() + 1];
+
+    for (i, a_char) in a.chars().enumerate() {
+        curr[0] = i + 1;
+        for (j, &b_char) in b_chars.iter().enumerate() {
+            let cost = usize::from(a_char != b_char);
+            curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+
+    prev[b_chars.len()]
+}
+
 /// Recursively collect `<name>` for every `<name>.ogg` under `root`.
-fn collect_bundled(root: &Path, dir: &Path, names: &mut Vec<String>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading entry in {}", dir.display()))?;
+fn collect_bundled(root: &Path, dir: &Path, names: &mut Vec<String>) -> Result<(), AssetError> {
+    for entry in fs::read_dir(dir).context(ReadDirSnafu { path: dir })? {
+        let entry = entry.context(ReadDirEntrySnafu { path: dir })?;
         let path = entry.path();
         let file_type = entry
             .file_type()
-            .with_context(|| format!("reading file type for {}", path.display()))?;
+            .context(ReadFileTypeSnafu { path: &path })?;
 
         if file_type.is_dir() {
             collect_bundled(root, &path, names)?;
@@ -162,7 +316,7 @@ fn is_ogg(name: &str) -> bool {
 }
 
 /// Auto-detect the Minecraft directory, honoring `MINECRAFT_HOME` first.
-fn find_minecraft_dir() -> Result<PathBuf> {
+fn find_minecraft_dir() -> Result<PathBuf, AssetError> {
     if let Some(home) = env::var_os("MINECRAFT_HOME") {
         let path = PathBuf::from(home);
         if path.exists() {
@@ -178,14 +332,11 @@ fn find_minecraft_dir() -> Result<PathBuf> {
         dirs::home_dir().map(|home| home.join(".minecraft"))
     };
 
-    let path = path.context("Could not determine home directory")?;
+    let path = path.context(NoHomeDirSnafu)?;
     if path.exists() {
         Ok(path)
     } else {
-        bail!(
-            "Minecraft directory not found at {}. Set MCSOUND_ASSETS or MINECRAFT_HOME, or install Minecraft.",
-            path.display()
-        )
+        MinecraftDirMissingSnafu { path }.fail()
     }
 }
 
@@ -199,14 +350,14 @@ fn index_version(entry: &fs::DirEntry) -> Option<u32> {
 }
 
 /// Pick the highest-versioned `assets/indexes/<n>.json`.
-fn find_latest_index(minecraft_dir: &Path) -> Result<PathBuf> {
+fn find_latest_index(minecraft_dir: &Path) -> Result<PathBuf, AssetError> {
     let indexes_dir = minecraft_dir.join("assets").join("indexes");
     if !indexes_dir.exists() {
-        bail!("No asset indexes found. Have you launched Minecraft at least once?");
+        return NoAssetIndexesSnafu.fail();
     }
 
     let indexes: Vec<fs::DirEntry> = fs::read_dir(&indexes_dir)
-        .with_context(|| format!("reading {}", indexes_dir.display()))?
+        .context(ReadDirSnafu { path: &indexes_dir })?
         .filter_map(Result::ok)
         .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "json"))
         .collect();
@@ -219,5 +370,87 @@ fn find_latest_index(minecraft_dir: &Path) -> Result<PathBuf> {
                 .then_with(|| a.file_name().cmp(&b.file_name()))
         })
         .map(|entry| entry.path())
-        .with_context(|| format!("No asset index files found in {}", indexes_dir.display()))
+        .context(NoIndexFilesSnafu { dir: indexes_dir })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    /// Monotonic counter so each `bundled_with` call gets its own temp dir even
+    /// when libtest runs cases in parallel; identical literal slices would
+    /// otherwise share an address and collide under `{:p}`.
+    static TEST_DIR_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    /// Build a `Bundled` backend over a fresh temp dir holding `.ogg` files.
+    fn bundled_with(names: &[&str]) -> (MinecraftAssets, PathBuf) {
+        let seq = TEST_DIR_SEQ.fetch_add(1, Ordering::Relaxed);
+        let unique = format!("mcsound-test-{}-{seq}", std::process::id());
+        let root = env::temp_dir().join(unique);
+        let _ = fs::remove_dir_all(&root);
+        for name in names {
+            let path = root.join(format!("{name}.ogg"));
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create dirs");
+            }
+            fs::write(&path, b"ogg").expect("write file");
+        }
+        (MinecraftAssets::Bundled { root: root.clone() }, root)
+    }
+
+    #[test]
+    fn unknown_name_is_an_error() {
+        let (assets, root) = bundled_with(&["mob/zombie/death", "block/stone/break"]);
+        let err = assets
+            .resolve_sound("this/does/not/exist")
+            .expect_err("unknown sound must error");
+        match &err {
+            AssetError::UnknownSound { name, .. } => assert_eq!(name, "this/does/not/exist"),
+            other => panic!("expected UnknownSound, got {other:?}"),
+        }
+        // Message names the input and points at `list`.
+        let msg = err.to_string();
+        assert!(msg.contains("this/does/not/exist"), "msg: {msg}");
+        assert!(msg.contains("minecraft-sound list"), "msg: {msg}");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn known_name_resolves() {
+        let (assets, root) = bundled_with(&["mob/zombie/death"]);
+        let path = assets
+            .resolve_sound("mob/zombie/death")
+            .expect("known sound resolves");
+        assert!(path.ends_with("mob/zombie/death.ogg"), "path: {path:?}");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn close_typo_is_suggested() {
+        let (assets, root) = bundled_with(&["mob/zombie/death"]);
+        let err = assets
+            .resolve_sound("mob/zombie/deaht")
+            .expect_err("typo must error");
+        match &err {
+            AssetError::UnknownSound { suggestions, .. } => {
+                assert!(
+                    suggestions.iter().any(|s| s == "mob/zombie/death"),
+                    "suggestions: {suggestions:?}"
+                );
+            }
+            other => panic!("expected UnknownSound, got {other:?}"),
+        }
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn levenshtein_basic() {
+        assert_eq!(levenshtein("", ""), 0);
+        assert_eq!(levenshtein("abc", "abc"), 0);
+        assert_eq!(levenshtein("abc", "abd"), 1);
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+    }
 }

--- a/packages/minecraft/sound/src/audio.rs
+++ b/packages/minecraft/sound/src/audio.rs
@@ -1,24 +1,89 @@
 use std::fs::File;
 use std::io::BufReader;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use rodio::source::Source as _;
 use rodio::{Decoder, OutputStream, Sink};
+use snafu::{ResultExt as _, Snafu};
+
+/// Minimum playback pitch/speed factor, matching Minecraft's clamp.
+pub const MIN_PITCH: f32 = 0.5;
+/// Maximum playback pitch/speed factor, matching Minecraft's clamp.
+pub const MAX_PITCH: f32 = 2.0;
+
+/// Errors that can occur while decoding or playing a sound file.
+#[derive(Debug, Snafu)]
+pub enum PlayError {
+    #[snafu(display("Failed to open audio output device"))]
+    OpenDevice { source: rodio::StreamError },
+
+    #[snafu(display("Failed to open sound file: {}", path.display()))]
+    OpenFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to decode OGG file: {}", path.display()))]
+    Decode {
+        path: PathBuf,
+        source: rodio::decoder::DecoderError,
+    },
+
+    #[snafu(display("Failed to create audio sink"))]
+    CreateSink { source: rodio::PlayError },
+}
+
+/// How to play a sound: Minecraft-style pitch and a linear volume multiplier.
+#[derive(Debug, Clone, Copy)]
+pub struct PlaybackOptions {
+    /// Playback speed factor. Like Minecraft, this shifts pitch and tempo
+    /// together (no resampling). Clamped to `[MIN_PITCH, MAX_PITCH]`.
+    pub pitch: f32,
+    /// Linear amplitude multiplier; `1.0` is unchanged. Clamped to `>= 0.0`.
+    pub volume: f32,
+}
+
+impl Default for PlaybackOptions {
+    fn default() -> Self {
+        Self {
+            pitch: 1.0,
+            volume: 1.0,
+        }
+    }
+}
+
+impl PlaybackOptions {
+    /// Pitch clamped to Minecraft's supported `[0.5, 2.0]` range.
+    const fn clamped_pitch(self) -> f32 {
+        self.pitch.clamp(MIN_PITCH, MAX_PITCH)
+    }
+
+    /// Volume clamped to be non-negative; a negative amplitude is meaningless.
+    const fn clamped_volume(self) -> f32 {
+        self.volume.max(0.0)
+    }
+}
 
 /// Decode and play an OGG/Vorbis file, blocking until playback finishes.
+///
+/// `pitch` shifts speed and pitch together (Minecraft semantics) and `volume`
+/// scales amplitude; both are clamped to sane ranges before use.
 ///
 /// # Errors
 /// Returns an error if the audio output device cannot be opened, the file
 /// cannot be read, or the stream cannot be decoded.
-pub fn play_ogg(path: &Path) -> Result<()> {
-    let (_stream, handle) =
-        OutputStream::try_default().context("Failed to open audio output device")?;
+pub fn play_ogg(path: &Path, options: PlaybackOptions) -> Result<(), PlayError> {
+    let (_stream, handle) = OutputStream::try_default().context(OpenDeviceSnafu)?;
 
-    let file = File::open(path)
-        .with_context(|| format!("Failed to open sound file: {}", path.display()))?;
-    let source = Decoder::new(BufReader::new(file)).context("Failed to decode OGG file")?;
+    let file = File::open(path).context(OpenFileSnafu { path })?;
+    let source = Decoder::new(BufReader::new(file)).context(DecodeSnafu { path })?;
 
-    let sink = Sink::try_new(&handle).context("Failed to create audio sink")?;
+    let sink = Sink::try_new(&handle).context(CreateSinkSnafu)?;
+    // `speed` changes play rate without resampling, so pitch and tempo move
+    // together — the same effect Minecraft's pitch parameter produces.
+    let source = source
+        .speed(options.clamped_pitch())
+        .amplify(options.clamped_volume());
     sink.append(source);
     sink.sleep_until_end();
 

--- a/packages/minecraft/sound/src/main.rs
+++ b/packages/minecraft/sound/src/main.rs
@@ -2,13 +2,14 @@ mod assets;
 mod audio;
 
 use std::env;
-use std::io::Write;
-use std::process::{Command, Stdio};
+use std::io::Write as _;
+use std::process::{Command, ExitCode, Stdio};
 
-use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
+use snafu::{ResultExt as _, Snafu};
 
-use crate::assets::MinecraftAssets;
+use crate::assets::{AssetError, MinecraftAssets};
+use crate::audio::{PlayError, PlaybackOptions};
 
 #[derive(Parser)]
 #[command(
@@ -31,60 +32,118 @@ enum Commands {
 
 #[derive(Args)]
 struct PlayArgs {
-    /// Sound path (e.g. mob/zombie/death). If empty, does nothing.
+    /// Sound path (e.g. mob/zombie/death). If empty, does nothing; an unknown
+    /// non-empty name is an error.
     sound: Option<String>,
 
     /// Wait for playback to finish instead of returning immediately
     #[arg(short, long)]
     wait: bool,
 
+    /// Playback pitch (Minecraft-style: shifts pitch and tempo together).
+    /// Clamped to [0.5, 2.0]; 1.0 is normal.
+    #[arg(long, default_value_t = 1.0)]
+    pitch: f32,
+
+    /// Linear volume multiplier; 1.0 is normal, 0.0 is silent.
+    #[arg(long, default_value_t = 1.0)]
+    volume: f32,
+
     /// Internal: run playback in the foreground (used by the background spawn)
     #[arg(long, hide = true)]
     foreground: bool,
 }
 
-fn main() -> Result<()> {
+/// Top-level CLI error, wrapping the asset and playback error domains plus the
+/// process plumbing used by the detached background spawn.
+#[derive(Debug, Snafu)]
+enum CliError {
+    #[snafu(display("{source}"), context(false))]
+    Assets { source: AssetError },
+
+    #[snafu(display("{source}"), context(false))]
+    Playback { source: PlayError },
+
+    #[snafu(display("Failed to find current executable"))]
+    CurrentExe { source: std::io::Error },
+
+    #[snafu(display("Failed to spawn background playback process"))]
+    Spawn { source: std::io::Error },
+}
+
+#[expect(
+    clippy::print_stderr,
+    reason = "top-level CLI error reporting before exit"
+)]
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("Error: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), CliError> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::List { pattern } => {
-            let assets = MinecraftAssets::load()?;
-            let mut out = std::io::stdout().lock();
-            for sound in assets.list_sounds(pattern.as_deref())? {
-                // Stop quietly when the reader goes away (e.g. `| head`)
-                // instead of panicking on a broken pipe.
-                if writeln!(out, "{sound}").is_err() {
-                    break;
-                }
-            }
-        }
-        Commands::Play(args) => play(args)?,
+        Commands::List { pattern } => list(pattern.as_deref()),
+        Commands::Play(args) => play(args),
     }
+}
 
+fn list(pattern: Option<&str>) -> Result<(), CliError> {
+    let assets = MinecraftAssets::load()?;
+    let mut out = std::io::stdout().lock();
+    for sound in assets.list_sounds(pattern)? {
+        // Stop quietly when the reader goes away (e.g. `| head`) instead of
+        // erroring on a broken pipe.
+        if writeln!(out, "{sound}").is_err() {
+            break;
+        }
+    }
     Ok(())
 }
 
-fn play(args: PlayArgs) -> Result<()> {
+fn play(args: PlayArgs) -> Result<(), CliError> {
     // Skip silently when no sound is given, so hooks can pass an empty string
-    // to disable a particular event.
+    // to disable a particular event. A non-empty unknown name is an error.
     let Some(sound) = args.sound.filter(|sound| !sound.is_empty()) else {
         return Ok(());
     };
 
+    let options = PlaybackOptions {
+        pitch: args.pitch,
+        volume: args.volume,
+    };
+
+    // Resolve the sound up front in every mode. This is the fix for the
+    // silent-failure footgun: the old default (non-`--wait`) path spawned a
+    // detached child that swallowed all errors, so a typo'd name exited 0 and
+    // played nothing. Resolving here means a bad name fails loudly before we
+    // ever spawn.
+    let assets = MinecraftAssets::load()?;
+    let path = assets.resolve_sound(&sound)?;
+
     if args.wait || args.foreground {
-        let assets = MinecraftAssets::load()?;
-        let path = assets.resolve_sound(&sound)?;
-        audio::play_ogg(&path)?;
+        audio::play_ogg(&path, options)?;
     } else {
-        // Re-spawn ourselves detached so the caller returns immediately while
-        // the sound keeps playing in the background.
-        let exe = env::current_exe()?;
-        Command::new(exe)
-            .args(["play", "--foreground", &sound])
+        // Re-spawn ourselves detached, in `--foreground` `--wait` mode, so the
+        // caller returns immediately while the sound keeps playing. The name is
+        // already validated, so this only fails on real spawn errors.
+        let exe = env::current_exe().context(CurrentExeSnafu)?;
+        let mut command = Command::new(exe);
+        command
+            .args(["play", "--foreground", "--wait"])
+            .args(["--pitch", &options.pitch.to_string()])
+            .args(["--volume", &options.volume.to_string()])
+            .arg(&sound)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()?;
+            .stderr(Stdio::null());
+        command.spawn().context(SpawnSnafu)?;
     }
 
     Ok(())


### PR DESCRIPTION
## What

- `minecraft-sound play <name>` now returns a typed `UnknownSound` error (rc 1) listing the closest matches and pointing at `minecraft-sound list`, instead of exiting 0 and silently playing nothing on a typo'd / unknown name. The empty-string case stays a no-op.
- Add `--pitch` to `play` (Minecraft-style: shifts pitch and tempo together via rodio `speed`, clamped to `[0.5, 2.0]`, default 1.0) and `--volume` (linear amplitude via rodio `amplify`, clamped `>= 0`, default 1.0).
- Convert the crate's error handling from `anyhow` to `snafu` (typed `AssetError` / `PlayError`), per repo convention.

## Why

While wiring a deploy-notification watcher that calls `minecraft-sound play`, a typo silently produced no sound and no error (`play this/does/not/exist` → exit 0, silent), which is a hard-to-notice footgun. The CLI also had no way to vary pitch (only `--wait`).

Verified on aarch64-darwin: `nix build .#minecraft-sound`, bogus name errors with suggestions, `--pitch`/`--volume` present in `--help`, and a real sound plays at `--pitch 1.6`.

Made with Claude (Opus 4.8) via Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `minecraft-sound` to error on unknown sound names and add `--pitch`/`--volume` CLI flags
> - Unknown sound names now produce a structured error with up to three close suggestions (via Levenshtein distance) and a hint to run `minecraft-sound list`.
> - Adds `--pitch` and `--volume` options to the `play` subcommand; values are clamped to valid ranges before being passed to the audio engine.
> - Sound name resolution now happens before spawning a background process, so invalid names cause an immediate non-zero exit instead of a silent failure.
> - Replaces `anyhow`-based errors throughout with `snafu`-based structured error enums (`AssetError`, `PlayError`, `CliError`) that include paths and contextual data.
> - Behavioral Change: the process now exits non-zero on any error and prints a single `Error: ...` line; previously errors could fail silently in background mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d26a25b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->