### PR TITLE
macvm: add headless boot_linux Python binding

### DIFF
--- a/packages/macos-vm/README.md
+++ b/packages/macos-vm/README.md
@@ -70,9 +70,11 @@ What works today:
 The `macvm` Python module bundled into ix-mcp exposes the full surface:
 `info`, `install`, `provision`, `stage_binary`, `screenshot`,
 `screenshot_many`, `drive`, `Driver`, and the one-call `run_app` (share a host
-app in, launch it, return a frame of the guest display). For Linux GUI guests it
-adds `boot_linux_gui` (boot a raw EFI disk off-screen, return a `PIL.Image` of
-the render), `drive_linux`, and `Driver(disk=...)`.
+app in, launch it, return a frame of the guest display). For Linux guests it
+adds `boot_linux` (boot a raw kernel `Image` + initramfs headlessly, attach OCI
+rootfs disks via `disks=[...]`, return the serial console as a string),
+`boot_linux_gui` (boot a raw EFI disk off-screen, return a `PIL.Image` of the
+render), `drive_linux`, and `Driver(disk=...)`.
 
 What is designed but not yet built (see [Roadmap](#roadmap)):
 
@@ -321,7 +323,8 @@ proof, and its gaps (squashfs not ext4, externally fetched kernel).
 6. ~~`macvm` Python module bundled into ix-mcp (like `tui`/`screen`).~~ Done: the
    module exposes `info`, `install`, `provision`, `stage_binary`, `screenshot`,
    `screenshot_many`, `drive`, `Driver`, and `run_app`, returning PIL images that
-   render inline.
+   render inline, plus the Linux helpers `boot_linux` (headless serial console),
+   `boot_linux_gui`, and `drive_linux`.
 7. ~~OCI-disk boot for Linux guests; document the libkrun handoff for
    microVMs.~~ Done minimally: `boot-linux --disk` + `examples/oci-boot.sh` boot
    a flattened OCI rootfs as a virtio-blk disk; build-vs-delegate decision and

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -351,8 +351,8 @@ let
         export HOME=$TMPDIR/home
         mkdir -p "$HOME"
 
-        ix-mcp exec 'import macvm; print("macvm-ok", *(callable(getattr(macvm, n)) for n in ("info", "install", "screenshot", "screenshot_many", "drive", "Driver", "provision", "stage_binary", "run_app")))' >stdout 2>stderr
-        if ! grep -q '^macvm-ok True True True True True True True True True$' stdout; then
+        ix-mcp exec 'import macvm; print("macvm-ok", *(callable(getattr(macvm, n)) for n in ("info", "install", "provision", "stage_binary", "boot_linux", "boot_linux_gui", "drive_linux", "screenshot", "screenshot_many", "drive", "Driver", "run_app")))' >stdout 2>stderr
+        if ! grep -q '^macvm-ok True True True True True True True True True True True True$' stdout; then
           echo "macvm was not importable in a default session:" >&2
           cat stdout stderr >&2
           exit 1

--- a/packages/mcp/src/macvm/macvm/__init__.py
+++ b/packages/mcp/src/macvm/macvm/__init__.py
@@ -98,6 +98,7 @@ if TYPE_CHECKING:
 __all__ = [
     "Driver",
     "MacVmError",
+    "boot_linux",
     "boot_linux_gui",
     "drive",
     "drive_linux",
@@ -384,6 +385,62 @@ def _writable_disk(disk: str | os.PathLike, staging_dir: str) -> str:
         shutil.copyfile(src, dst)
     os.chmod(dst, 0o644)
     return dst
+
+
+def boot_linux(
+    kernel: str | os.PathLike,
+    initramfs: str | os.PathLike,
+    disks: Sequence[str | os.PathLike] | None = None,
+    cpus: int = 2,
+    memory_mib: int = 1024,
+    cmdline: str = "console=hvc0",
+    seconds: int = 20,
+    timeout: float | None = None,
+) -> str:
+    """Boot an aarch64 Linux guest headlessly from a raw kernel ``Image`` and
+    ``initramfs``, attaching each path in ``disks`` as a virtio-blk device
+    (``/dev/vda``, ``/dev/vdb``, ... in order), and return the guest serial
+    console captured until it stops or ``seconds`` elapses.
+
+    The headless, serial-only analogue of :func:`boot_linux_gui` (which renders a
+    framebuffer): no display is captured, only ``console=hvc0`` output. This is
+    how a flattened OCI rootfs is booted and inspected: pass the rootfs image in
+    ``disks`` and a matching ``root=`` (or an initramfs that mounts it) in
+    ``cmdline``. See the ``macos-vm`` package's ``examples/oci-boot.sh`` and
+    ``docs/oci-guest.md``. Raises :class:`MacVmError` if the binary fails or does
+    not stop within the deadline.
+    """
+    deadline = timeout if timeout is not None else seconds + 60
+    argv = [
+        _binary(),
+        "boot-linux",
+        "--kernel",
+        str(kernel),
+        "--initramfs",
+        str(initramfs),
+        "--cpus",
+        str(cpus),
+        "--memory-mib",
+        str(memory_mib),
+        "--cmdline",
+        cmdline,
+        "--timeout-secs",
+        str(seconds),
+    ]
+    for disk in disks or []:
+        argv += ["--disk", str(disk)]
+    try:
+        result = subprocess.run(
+            argv, capture_output=True, text=True, check=False, timeout=deadline
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise MacVmError(f"boot-linux timed out after {deadline}s") from exc
+    if result.returncode != 0:
+        raise MacVmError(
+            f"boot-linux failed (rc={result.returncode}): {result.stderr.strip()}"
+        )
+    # The guest serial console streams to stdout; boot/log lines go to stderr.
+    return result.stdout
 
 
 def boot_linux_gui(


### PR DESCRIPTION
## What

Adds `macvm.boot_linux` to the bundled `macvm` MCP module: an idiomatic Python binding for the `macos-vm` CLI's headless `boot-linux` (raw aarch64 kernel `Image` + initramfs, repeatable `--disk` as virtio-blk `/dev/vda…`, serial console streamed to stdout, exits on `--timeout-secs`). It is the serial-only analogue of the existing `boot_linux_gui`, placed immediately before it so the headless/GUI pair are adjacent. Returns the captured serial console as a `str`; raises `MacVmError` on failure or timeout. Registered in `__all__`.

Also tightens the `macvmBundled` flake check to assert the **full 12-name public callable surface** (`info, install, provision, stage_binary, boot_linux, boot_linux_gui, drive_linux, screenshot, screenshot_many, drive, Driver, run_app`). It had drifted to 9 names, omitting `boot_linux`/`boot_linux_gui`/`drive_linux`.

## Validation

- ✅ `nix build .#macos-vm` — green (crate unchanged, sanity).
- ✅ `nix build .#packages.aarch64-darwin.mcp.passthru.tests.macvmBundled` — green. The real gate: builds the pinned interpreter and asserts all 12 callables import and are callable (`macvm-ok True ×12`).
- ✅ `nix run .#lint` — clean (5/5 tasks: nixfmt, ast-grep, ast-grep-test, deadnix, statix).
- ✅ **Live boot smoke** of the new binding on aarch64-darwin. Reproduced the `examples/oci-boot.sh` flow (busybox arm64 OCI image flattened to a squashfs rootfs disk, Alpine `virt` kernel `Image` + a minimal switch-root initramfs) and booted it through the **bundled** interpreter's `macvm.boot_linux(...)`:

```
[SMOKE] type(console)=str len=1740 proof_present=True   RC=0
...
INITRAMFS: mounted OCI squashfs; switch_root
==================================================
OCI-GUEST-PROOF: reached userspace from OCI rootfs on /dev/vda
uname: Linux (none) 6.12.81-0-virt #1-Alpine SMP PREEMPT_DYNAMIC aarch64 GNU/Linux
root contents: bin dev etc home init lib lib64 root tmp usr var
OCI-GUEST-PROOF-DONE
==================================================
[    0.146658] reboot: Power down
```

`boot_linux` returned the full guest serial console (incl. the OCI userspace proof marker) as a `str`.

Code review (high effort, correctness + cleanup + altitude angles): no findings. No external callers of the new function; CLI flags + defaults verified against the `BootLinux` subcommand in `packages/macos-vm/src/main.rs`.

Made with AI assistance (Claude Opus 4.8). Follow-up to #453/#455.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `boot_linux` headless boot binding to the `macvm` Python module
> - Adds `boot_linux` to [macvm/__init__.py](https://github.com/indexable-inc/index/pull/463/files#diff-4b9daaeca5c33e547724daa485bc9d8c0851d6a70a0fc0b49ac3fc9cbc0e3ff9), which invokes the packaged binary with the `boot-linux` subcommand to boot an aarch64 Linux guest from a raw kernel Image and initramfs with optional virtio-blk disks.
> - The function enforces a timeout (`seconds + 60`), raises `MacVmError` on timeout or non-zero exit, and returns the guest serial console output as a string.
> - Updates the packaging smoke test in [mcp/default.nix](https://github.com/indexable-inc/index/pull/463/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) to verify `boot_linux`, `boot_linux_gui`, and `drive_linux` are all exported, now expecting 12 `True` values.
> - Updates [README.md](https://github.com/indexable-inc/index/pull/463/files#diff-2671007570de681003a953dfc09e2b9af6e66cc927764881cefcc2630d0f0931) to document the new headless Linux helpers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0d8fb2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->