### PR TITLE
book-overlay: hover highlight + settle animation, page-flip sound, shared anim module

### DIFF
--- a/packages/bossbar-overlay/app/crates/book/src/assets.rs
+++ b/packages/bossbar-overlay/app/crates/book/src/assets.rs
@@ -10,3 +10,11 @@ pub const BOOK: &[u8] = include_bytes!("../assets/gui/book.png");
 
 pub const PAGE_FORWARD: &[u8] = include_bytes!("../assets/gui/page_forward.png");
 pub const PAGE_BACKWARD: &[u8] = include_bytes!("../assets/gui/page_backward.png");
+
+/// The hovered (brightened) variants Mojang ships for the page-turn buttons. The
+/// overlay crossfades to these as the pointer moves onto an arrow, matching the
+/// vanilla book screen's button highlight.
+pub const PAGE_FORWARD_HIGHLIGHTED: &[u8] =
+    include_bytes!("../assets/gui/page_forward_highlighted.png");
+pub const PAGE_BACKWARD_HIGHLIGHTED: &[u8] =
+    include_bytes!("../assets/gui/page_backward_highlighted.png");

--- a/packages/bossbar-overlay/app/crates/book/src/main.rs
+++ b/packages/bossbar-overlay/app/crates/book/src/main.rs
@@ -9,13 +9,14 @@
 //! Usage:
 //!   book-overlay                 run the overlay
 //!   book-overlay --snapshot OUT  render the current spread to a PNG and exit
-//!                [--scale N] [--page N]
+//!                [--scale N] [--page N] [--hover]
 
 mod assets;
 mod book;
 mod db;
 mod overlay;
 mod scene;
+mod sound;
 
 use std::path::PathBuf;
 
@@ -30,6 +31,10 @@ struct Args {
     scale: u32,
     /// Left page of the spread to snapshot (0-based; clamped to the book).
     page: usize,
+    /// Render the snapshot in the hovered state (book grown, forward arrow
+    /// highlighted), so the PNG verifies the hover styling the live overlay only
+    /// shows under the pointer.
+    hover: bool,
 }
 
 fn parse_args() -> Result<Args, String> {
@@ -41,6 +46,7 @@ fn parse_args() -> Result<Args, String> {
         snapshot: None,
         scale,
         page: 0,
+        hover: false,
     };
     let mut it = std::env::args().skip(1);
     while let Some(arg) = it.next() {
@@ -63,9 +69,10 @@ fn parse_args() -> Result<Args, String> {
                     .parse()
                     .map_err(|_| "--page must be an integer")?;
             }
+            "--hover" => args.hover = true,
             "-h" | "--help" => {
                 println!(
-                    "book-overlay [--snapshot OUT] [--scale N] [--page N]\n\
+                    "book-overlay [--snapshot OUT] [--scale N] [--page N] [--hover]\n\
                      SQLite-driven Minecraft book overlay. DB path: BOOK_DB or the \
                      per-OS app-data path."
                 );
@@ -97,6 +104,18 @@ fn main() {
         // Snapshot starts a spread on an even page, the same as the live overlay.
         let spread = (args.page - (args.page % 2)).min(book.last_spread());
         let (w, h) = scene::spread_window_px(scale);
+        // At rest by default; `--hover` showcases the hover styling (whole-book
+        // grow plus the forward arrow highlighted and popped) so the PNG can
+        // verify what the live overlay only reveals under the pointer.
+        let hover = if args.hover {
+            scene::Hover {
+                book: 1.0,
+                back: 0.0,
+                fwd: 1.0,
+            }
+        } else {
+            scene::Hover::default()
+        };
         let result = overlay_core::snapshot::render_to_png(
             w,
             h,
@@ -112,6 +131,7 @@ fn main() {
                     h,
                     spread > 0,
                     spread + 2 <= book.last_spread(),
+                    &hover,
                 )
             },
             &out,

--- a/packages/bossbar-overlay/app/crates/book/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/book/src/overlay.rs
@@ -17,9 +17,9 @@ use overlay_core::wgpu;
 use overlay_core::winit::application::ApplicationHandler;
 use overlay_core::winit::dpi::{LogicalPosition, PhysicalPosition};
 use overlay_core::winit::event::{ElementState, MouseButton, WindowEvent};
-use overlay_core::winit::event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy};
+use overlay_core::winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
 use overlay_core::winit::window::{CursorIcon, Window, WindowId};
-use overlay_core::{window as ocwin, DragClick, Gpu};
+use overlay_core::{window as ocwin, DragClick, Gpu, HoverAnim};
 
 use crate::book::Book;
 use crate::db;
@@ -31,6 +31,22 @@ const DRAG_THRESHOLD: f64 = 5.0;
 /// read position is applied again, so the watcher's lagged read-back of our own
 /// drag never snaps it back.
 const SETTLE: Duration = Duration::from_millis(700);
+/// Hover grow/shrink time: an ease-out tween at the responsive end of the
+/// feedback range, matching the boss bar. The hover animates in over this time
+/// and then holds still so the page stays readable. See the `animation` skill.
+const GROW: Duration = Duration::from_millis(160);
+/// Largest animation step a single frame may apply, so a stall (the loop slept)
+/// does not jump the hover; frames are otherwise ~16ms.
+const MAX_STEP: Duration = Duration::from_millis(50);
+/// Animation frame budget while something is moving (~60 fps).
+const FRAME: Duration = Duration::from_millis(16);
+
+/// Which page-turn arrow the pointer is over, if any.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Arrow {
+    Back,
+    Fwd,
+}
 
 struct WinState {
     window: Arc<Window>,
@@ -38,12 +54,35 @@ struct WinState {
     config: wgpu::SurfaceConfiguration,
     textures: BookTextures,
     gesture: DragClick,
+    /// The pointer is on the window: drives the whole-book grow + breathe.
     hovered: bool,
+    /// Hover amounts advanced toward their targets each frame. `book` follows
+    /// `hovered`; `back`/`fwd` follow whether the pointer is over that arrow. The
+    /// scene module applies the easing curves to their raw values.
+    book_anim: HoverAnim,
+    back_anim: HoverAnim,
+    fwd_anim: HoverAnim,
+    /// Which arrow the pointer is currently over (resting space), for the cursor
+    /// icon and to drive the per-arrow hover.
+    over_arrow: Option<Arrow>,
+    /// Last pointer position (physical px), for per-frame arrow hit-testing.
+    cursor: Option<PhysicalPosition<f64>>,
+    /// Timestamp of the last animation step, for frame-rate-independent easing.
+    last: Instant,
     /// Last position we know the window holds (logical points): what we set, or
     /// where the OS placed it. Lets `Moved` skip echoes of our own placement.
     self_set: Option<LogicalPosition<f64>>,
     /// When the window last moved during a drag, for the reconcile settle guard.
     last_move: Instant,
+}
+
+impl WinState {
+    /// Still mid-transition (the grow or an arrow easing in/out). There is no
+    /// perpetual motion, so once every hover has settled to its target this is
+    /// false and the loop sleeps, leaving the page still to read.
+    fn animating(&self) -> bool {
+        self.book_anim.is_animating() || self.back_anim.is_animating() || self.fwd_anim.is_animating()
+    }
 }
 
 pub struct App {
@@ -63,15 +102,39 @@ pub struct App {
     ready: bool,
 }
 
+/// Which page-turn arrow (if any) sits under the pointer at `c` (physical px).
+/// The whole-book grow displaces the arrows from their resting layout, so the
+/// cursor is mapped back through `mul` about the window centre before testing the
+/// resting arrow rects. The rects are the stable hit region; the visual pop grows
+/// past them without moving their centres, so a pointer inside never oscillates.
+fn arrow_under(
+    c: PhysicalPosition<f64>,
+    mul: f32,
+    scale: u32,
+    win_w: u32,
+    win_h: u32,
+    show_back: bool,
+    show_fwd: bool,
+) -> Option<Arrow> {
+    let cx = win_w as f64 * 0.5;
+    let cy = win_h as f64 * 0.5;
+    let m = mul as f64;
+    let px = cx + (c.x - cx) / m;
+    let py = cy + (c.y - cy) / m;
+    let hit = |r: (f32, f32, f32, f32)| {
+        let (x, y, rw, rh) = r;
+        px >= x as f64 && px <= (x + rw) as f64 && py >= y as f64 && py <= (y + rh) as f64
+    };
+    if show_fwd && hit(scene::fwd_arrow_rect(scale, win_w, win_h)) {
+        Some(Arrow::Fwd)
+    } else if show_back && hit(scene::back_arrow_rect(scale, win_w, win_h)) {
+        Some(Arrow::Back)
+    } else {
+        None
+    }
+}
+
 impl App {
-    fn show_back(&self) -> bool {
-        self.spread > 0
-    }
-
-    fn show_fwd(&self) -> bool {
-        self.spread + 2 <= self.book.last_spread()
-    }
-
     /// Auto-centered window position (logical points) for the spread.
     fn center_pos(&self) -> LogicalPosition<f64> {
         let (w_px, h_px) = scene::spread_window_px(self.scale);
@@ -125,13 +188,66 @@ impl App {
             textures,
             gesture: DragClick::new(DRAG_THRESHOLD),
             hovered: false,
+            book_anim: HoverAnim::default(),
+            back_anim: HoverAnim::default(),
+            fwd_anim: HoverAnim::default(),
+            over_arrow: None,
+            cursor: None,
+            last: Instant::now(),
             self_set: Some(pos),
             last_move: Instant::now() - SETTLE,
         });
     }
 
     fn render(&mut self) {
-        let (Some(gpu), Some(win)) = (self.gpu.as_ref(), self.win.as_mut()) else {
+        let now = Instant::now();
+        let show_back = self.spread > 0;
+        let show_fwd = self.spread + 2 <= self.book.last_spread();
+        let scale = self.scale;
+
+        // Advance the hover amounts toward their targets (disjoint field borrows:
+        // `win` and `gpu`/`book`/`spread` are separate fields).
+        let Some(win) = self.win.as_mut() else {
+            return;
+        };
+        let (cw, ch) = (win.config.width, win.config.height);
+        let dt = now.duration_since(win.last).min(MAX_STEP);
+        win.last = now;
+        win.book_anim
+            .approach(if win.hovered { 1.0 } else { 0.0 }, dt, GROW);
+
+        // Which arrow is the pointer over, accounting for the current whole-book
+        // grow so the target tracks the arrow where it is actually drawn.
+        let mul = scene::book_mul(win.book_anim.raw());
+        let over = win
+            .cursor
+            .and_then(|c| arrow_under(c, mul, scale, cw, ch, show_back, show_fwd));
+        win.back_anim
+            .approach(if over == Some(Arrow::Back) { 1.0 } else { 0.0 }, dt, GROW);
+        win.fwd_anim
+            .approach(if over == Some(Arrow::Fwd) { 1.0 } else { 0.0 }, dt, GROW);
+
+        // A pointer cursor over a live arrow signals it is clickable; otherwise the
+        // grab/default icon for the draggable book. Skip while the OS owns a drag.
+        if !win.gesture.dragging() && over != win.over_arrow {
+            let icon = if over.is_some() {
+                CursorIcon::Pointer
+            } else if win.hovered {
+                CursorIcon::Grab
+            } else {
+                CursorIcon::Default
+            };
+            win.window.set_cursor(icon);
+        }
+        win.over_arrow = over;
+
+        let hover = scene::Hover {
+            book: win.book_anim.raw(),
+            back: win.back_anim.raw(),
+            fwd: win.fwd_anim.raw(),
+        };
+
+        let Some(gpu) = self.gpu.as_ref() else {
             return;
         };
         let frame = match win.surface.get_current_texture() {
@@ -153,35 +269,40 @@ impl App {
             &win.textures,
             &self.book,
             self.spread,
-            self.scale,
-            win.config.width,
-            win.config.height,
-            self.spread > 0,
-            self.spread + 2 <= self.book.last_spread(),
+            scale,
+            cw,
+            ch,
+            show_back,
+            show_fwd,
+            &hover,
         );
-        let _ = gpu.draw(&view, win.config.width, win.config.height, &quads);
+        let _ = gpu.draw(&view, cw, ch, &quads);
         frame.present();
     }
 
     /// A click landed at `pos` (physical px); flip the spread if it hit an arrow.
     fn on_click(&mut self, pos: PhysicalPosition<f64>) {
+        let show_back = self.spread > 0;
+        let show_fwd = self.spread + 2 <= self.book.last_spread();
+        let scale = self.scale;
         let Some(win) = self.win.as_ref() else {
             return;
         };
+        let mul = scene::book_mul(win.book_anim.raw());
         let (w, h) = (win.config.width, win.config.height);
-        let hit = |r: (f32, f32, f32, f32)| {
-            let (x, y, rw, rh) = r;
-            pos.x as f32 >= x
-                && pos.x as f32 <= x + rw
-                && pos.y as f32 >= y
-                && pos.y as f32 <= y + rh
-        };
-        if self.show_back() && hit(scene::back_arrow_rect(self.scale, w, h)) {
-            self.spread = self.spread.saturating_sub(2);
-            self.win.as_ref().unwrap().window.request_redraw();
-        } else if self.show_fwd() && hit(scene::fwd_arrow_rect(self.scale, w, h)) {
-            self.spread = (self.spread + 2).min(self.book.last_spread());
-            self.win.as_ref().unwrap().window.request_redraw();
+        let window = win.window.clone();
+        match arrow_under(pos, mul, scale, w, h, show_back, show_fwd) {
+            Some(Arrow::Back) => {
+                self.spread = self.spread.saturating_sub(2);
+                crate::sound::page_flip();
+                window.request_redraw();
+            }
+            Some(Arrow::Fwd) => {
+                self.spread = (self.spread + 2).min(self.book.last_spread());
+                crate::sound::page_flip();
+                window.request_redraw();
+            }
+            None => {}
         }
     }
 
@@ -274,19 +395,26 @@ impl ApplicationHandler<Book> for App {
                 }
                 if let Some(win) = self.win.as_mut() {
                     win.hovered = true;
+                    win.window.request_redraw();
                 }
             }
             WindowEvent::CursorLeft { .. } => {
                 if let Some(win) = self.win.as_mut() {
                     win.hovered = false;
+                    win.cursor = None;
+                    win.over_arrow = None;
                     win.window.set_cursor(CursorIcon::Default);
+                    win.window.request_redraw();
                 }
             }
             WindowEvent::CursorMoved { position, .. } => {
-                let start_drag = self
-                    .win
-                    .as_mut()
-                    .is_some_and(|win| win.gesture.cursor_moved(position));
+                let start_drag = self.win.as_mut().is_some_and(|win| {
+                    win.cursor = Some(position);
+                    // Redraw so the arrow under the pointer updates promptly; while
+                    // animating `about_to_wait` already keeps frames coming.
+                    win.window.request_redraw();
+                    win.gesture.cursor_moved(position)
+                });
                 if start_drag {
                     if let Some(win) = self.win.as_ref() {
                         win.window.set_cursor(CursorIcon::Grabbing);
@@ -325,6 +453,21 @@ impl ApplicationHandler<Book> for App {
             }
             WindowEvent::Moved(pos) => self.on_moved(pos),
             _ => {}
+        }
+    }
+
+    /// Keep redrawing at ~60 fps while the book is animating (growing, shrinking,
+    /// breathing, or an arrow highlighting); otherwise let the loop sleep until the
+    /// next event so an idle overlay costs nothing.
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let animating = self.win.as_ref().is_some_and(WinState::animating);
+        if animating {
+            if let Some(win) = self.win.as_ref() {
+                win.window.request_redraw();
+            }
+            event_loop.set_control_flow(ControlFlow::WaitUntil(Instant::now() + FRAME));
+        } else {
+            event_loop.set_control_flow(ControlFlow::Wait);
         }
     }
 }

--- a/packages/bossbar-overlay/app/crates/book/src/scene.rs
+++ b/packages/bossbar-overlay/app/crates/book/src/scene.rs
@@ -6,6 +6,7 @@
 //! open book is real Mojang art with no synthetic texture. Page bodies render in
 //! the vanilla bitmap font; page-turn arrows sit at the bottom outer corners.
 
+use overlay_core::anim::{ease_out_back, ease_out_cubic, scale_quads_about};
 use overlay_core::{Gpu, Quad, TexHandle};
 
 use crate::book::Book;
@@ -48,28 +49,69 @@ const INK: [f32; 4] = [
     1.0,
 ];
 
-/// The overlay's textures, registered once into the shared [`Gpu`].
+/// How much the whole spread grows when the pointer is on the book. A subtle
+/// one-shot lift that animates in and then holds still: the book is for reading,
+/// so it must settle, never keep moving. See the `animation` skill (and the UI
+/// rule against perpetual hover motion).
+const BOOK_HOVER_SCALE: f32 = 1.03;
+/// Largest multiplier the spread can reach. The window reserves this much margin
+/// so the book grows in place without resizing.
+const MAX_BOOK_MUL: f32 = BOOK_HOVER_SCALE;
+
+/// How much a fully-hovered arrow pops, before its ease-out-back overshoot. A
+/// page-turn arrow is a small, playful target, so it gets a bigger, springier
+/// lift than the whole book. It is one-shot too: it pops on hover and settles.
+const ARROW_HOVER_SCALE: f32 = 1.22;
+
+/// Eased hover amounts, raw linear progress in `0..=1` (this module applies the
+/// easing curves). `book` grows the whole spread once while the pointer is on it;
+/// `back`/`fwd` add the per-arrow highlight crossfade and pop. All settle to a
+/// still state so the page text stays readable.
+#[derive(Clone, Copy, Default)]
+pub struct Hover {
+    pub book: f32,
+    pub back: f32,
+    pub fwd: f32,
+}
+
+/// Whole-spread scale multiplier for the current hover: a one-shot eased grow
+/// toward [`BOOK_HOVER_SCALE`] that holds once the hover settles. Public so the
+/// overlay can map the cursor back into resting space for arrow hit-testing while
+/// the book is grown.
+pub fn book_mul(book_hover: f32) -> f32 {
+    1.0 + (BOOK_HOVER_SCALE - 1.0) * ease_out_cubic(book_hover)
+}
+
+/// The overlay's textures, registered once into the shared [`Gpu`]. Each arrow
+/// keeps its resting sprite and Mojang's hovered (brightened) variant so the
+/// overlay can crossfade between them.
 pub struct BookTextures {
     book: TexHandle,
     fwd: TexHandle,
+    fwd_hi: TexHandle,
     bwd: TexHandle,
+    bwd_hi: TexHandle,
 }
 
-/// Register the book sheet and the page-turn arrows.
+/// Register the book sheet and the page-turn arrows (resting + highlighted).
 pub fn register(gpu: &mut Gpu) -> BookTextures {
     BookTextures {
         book: gpu.register_png(crate::assets::BOOK),
         fwd: gpu.register_png(crate::assets::PAGE_FORWARD),
+        fwd_hi: gpu.register_png(crate::assets::PAGE_FORWARD_HIGHLIGHTED),
         bwd: gpu.register_png(crate::assets::PAGE_BACKWARD),
+        bwd_hi: gpu.register_png(crate::assets::PAGE_BACKWARD_HIGHLIGHTED),
     }
 }
 
-/// Physical-pixel window size that holds one spread at `scale`.
+/// Physical-pixel window size that holds one spread at `scale`, including the
+/// hover-grow headroom so the book grows and breathes in place without the window
+/// resizing. The resting spread sits centred within this margin.
 pub fn spread_window_px(scale: u32) -> (u32, u32) {
     let s = scale.max(1) as f32;
     (
-        (2.0 * PAGE_W * s).ceil() as u32,
-        (PAGE_H * s).ceil() as u32,
+        (2.0 * PAGE_W * s * MAX_BOOK_MUL).ceil() as u32,
+        (PAGE_H * s * MAX_BOOK_MUL).ceil() as u32,
     )
 }
 
@@ -126,7 +168,10 @@ fn text_box(page_ox: f32, scale: u32, mirror: bool) -> (f32, f32) {
 }
 
 /// Build the spread for `book` showing the two pages starting at `spread`.
-/// `show_back`/`show_fwd` gate the arrows (drawn only when that turn is possible).
+/// `show_back`/`show_fwd` gate the arrows (drawn only when that turn is possible);
+/// `hover` drives the highlight crossfade, the arrow pop, and the whole-book
+/// grow/breathe.
+#[allow(clippy::too_many_arguments)]
 pub fn build(
     gpu: &Gpu,
     tex: &BookTextures,
@@ -137,6 +182,7 @@ pub fn build(
     win_h: u32,
     show_back: bool,
     show_fwd: bool,
+    hover: &Hover,
 ) -> Vec<Quad> {
     let s = scale.max(1) as f32;
     let (ox, oy) = spread_origin(scale, win_w, win_h);
@@ -151,15 +197,47 @@ pub fn build(
     page_content(gpu, &mut quads, book, spread, ox, oy, scale, true);
     page_content(gpu, &mut quads, book, spread + 1, ox + pw, oy, scale, false);
 
+    // Arrows, at rest positions; the per-arrow hover pops them and crossfades to
+    // the highlighted sprite. The whole-book transform below then carries them
+    // along with the spread.
     if show_back {
-        let (x, y, w, h) = back_arrow_rect(scale, win_w, win_h);
-        quads.push(Quad::new(tex.bwd, x, y, w, h, WHITE));
+        push_arrow(&mut quads, tex.bwd, tex.bwd_hi, back_arrow_rect(scale, win_w, win_h), hover.back);
     }
     if show_fwd {
-        let (x, y, w, h) = fwd_arrow_rect(scale, win_w, win_h);
-        quads.push(Quad::new(tex.fwd, x, y, w, h, WHITE));
+        push_arrow(&mut quads, tex.fwd, tex.fwd_hi, fwd_arrow_rect(scale, win_w, win_h), hover.fwd);
     }
+
+    // Grow the entire spread about the window centre (where the resting spread is
+    // already centred), so the book lifts as one object on hover and then holds
+    // still. No-op at rest.
+    let mul = book_mul(hover.book);
+    scale_quads_about(&mut quads, win_w as f32 * 0.5, win_h as f32 * 0.5, mul);
     quads
+}
+
+/// Append one page-turn arrow: pop it about its own centre with an ease-out-back
+/// overshoot, and crossfade from the resting sprite to Mojang's highlighted one
+/// as `hover` rises.
+fn push_arrow(
+    quads: &mut Vec<Quad>,
+    base: TexHandle,
+    highlighted: TexHandle,
+    rect: (f32, f32, f32, f32),
+    hover: f32,
+) {
+    let (x, y, w, h) = rect;
+    let mul = 1.0 + (ARROW_HOVER_SCALE - 1.0) * ease_out_back(hover);
+    let nw = w * mul;
+    let nh = h * mul;
+    let rx = x - (nw - w) * 0.5;
+    let ry = y - (nh - h) * 0.5;
+    let fade = ease_out_cubic(hover);
+    if fade < 1.0 {
+        quads.push(Quad::new(base, rx, ry, nw, nh, [1.0, 1.0, 1.0, 1.0 - fade]));
+    }
+    if fade > 0.0 {
+        quads.push(Quad::new(highlighted, rx, ry, nw, nh, [1.0, 1.0, 1.0, fade]));
+    }
 }
 
 /// Draw one page's header and wrapped body, if the page exists.

--- a/packages/bossbar-overlay/app/crates/book/src/sound.rs
+++ b/packages/bossbar-overlay/app/crates/book/src/sound.rs
@@ -1,0 +1,59 @@
+//! Best-effort Minecraft page-flip sound.
+//!
+//! Turning a page in the vanilla book plays a flip sound. The overlay reproduces
+//! that by shelling out to the `minecraft-sound` binary, which bundles Mojang's
+//! sound pack and returns immediately (it re-spawns itself detached), so no audio
+//! backend is linked into the overlay and playback never blocks the event loop.
+//!
+//! This is cosmetic: a missing binary or a failed play is logged once and then
+//! ignored, so a machine without `minecraft-sound` on `PATH` simply runs silent.
+
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Once;
+
+/// The vanilla book page-flip sounds. This asset index ships no `page_turn`
+/// event; these are the file-level names Mojang's pack exposes (and what the
+/// `minecraft-sound` pack resolves).
+const FLIP: [&str; 3] = [
+    "item/book/open_flip1",
+    "item/book/open_flip2",
+    "item/book/open_flip3",
+];
+
+/// Binary that plays a named Minecraft sound. Overridable so a package can pin an
+/// absolute store path instead of relying on `PATH`.
+fn sound_cmd() -> String {
+    std::env::var("BOOK_SOUND_CMD").unwrap_or_else(|_| "minecraft-sound".to_string())
+}
+
+/// Play a page-flip sound, cycling through the three vanilla variants so repeated
+/// turns do not sound identical. Non-blocking and best-effort.
+pub fn page_flip() {
+    static NEXT: AtomicUsize = AtomicUsize::new(0);
+    let name = FLIP[NEXT.fetch_add(1, Ordering::Relaxed) % FLIP.len()];
+    match Command::new(sound_cmd())
+        .args(["play", name])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        // Reap the launcher off the UI thread so it never zombies. The launcher
+        // parses the sound index and then daemonizes the actual playback, so this
+        // wait returns in tens of ms (off the UI thread either way).
+        Ok(mut child) => {
+            std::thread::spawn(move || {
+                let _ = child.wait();
+            });
+        }
+        Err(e) => {
+            static WARN: Once = Once::new();
+            WARN.call_once(|| {
+                eprintln!(
+                    "book-overlay: page-turn sound disabled ({e}); `minecraft-sound` not on PATH"
+                );
+            });
+        }
+    }
+}

--- a/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
@@ -13,7 +13,6 @@
 //! non-activating raise are [`overlay_core::window`].
 
 use std::collections::HashMap;
-use std::f32::consts::TAU;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -25,7 +24,7 @@ use overlay_core::winit::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use overlay_core::winit::event::{ElementState, MouseButton, WindowEvent};
 use overlay_core::winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
 use overlay_core::winit::window::{CursorIcon, Window, WindowId};
-use overlay_core::{window as ocwin, DragClick, Gpu};
+use overlay_core::{anim, window as ocwin, DragClick, Gpu, HoverAnim};
 
 use crate::bars::BossBar;
 use crate::db;
@@ -38,12 +37,15 @@ use crate::scene::{self, BarTextures};
 const AUTO_TOP: f64 = 40.0;
 const AUTO_GAP: f64 = 6.0;
 
-/// Hover grow/shrink time (seconds): an ease-out tween at the responsive end of
-/// the feedback range. See the `animation` skill.
-const GROW_SECS: f32 = 0.16;
-/// Full breathing cycle (seconds) while hovered. ~2.6s reads calm and alive,
-/// near a resting heart rate, rather than urgent.
-const BREATHE_PERIOD: f32 = 2.6;
+/// Hover grow/shrink time: an ease-out tween at the responsive end of the
+/// feedback range. See the `animation` skill.
+const GROW: Duration = Duration::from_millis(160);
+/// Full breathing cycle while hovered. ~2.6s reads calm and alive, near a resting
+/// heart rate, rather than urgent.
+const BREATHE_PERIOD: Duration = Duration::from_millis(2600);
+/// Largest animation step a single frame may apply, so a stall (the loop slept
+/// for a tick) does not jump the hover; frames are otherwise ~16ms.
+const MAX_STEP: Duration = Duration::from_millis(50);
 /// Animation frame budget while something is moving (~60 fps).
 const FRAME: Duration = Duration::from_millis(16);
 /// Redraw cadence for a bar showing a live elapsed counter: once a second is
@@ -58,12 +60,6 @@ const DRAG_THRESHOLD: f64 = 5.0;
 /// apply an externally-read position again. Must exceed the DB watch poll so the
 /// watcher's lagged read-back of our own drag never snaps the window back.
 const SETTLE: Duration = Duration::from_millis(700);
-
-/// Ease-out cubic: fast start, soft landing. The default feedback curve.
-fn ease_out_cubic(t: f32) -> f32 {
-    let u = 1.0 - t.clamp(0.0, 1.0);
-    1.0 - u * u * u
-}
 
 /// Current wall-clock time as Unix seconds, for the live elapsed counter. Before
 /// the epoch (clock unset) it clamps to 0, which reads as a 0 counter.
@@ -106,9 +102,9 @@ struct BarWin {
     bar: BossBar,
     /// Hover target: the pointer is currently over this bar.
     hovered: bool,
-    /// Eased hover amount in `0..=1`, animated toward `hovered` each frame. Drives
-    /// the grow + opacity; the breathing fades in with it.
-    hover_anim: f32,
+    /// Hover amount animated toward `hovered` each frame. Drives the grow +
+    /// opacity (via its eased value); the breathing fades in with it.
+    hover_anim: HoverAnim,
     /// Timestamp of the last animation step, for frame-rate-independent easing.
     last: Instant,
     /// Press/drag/click disambiguation for this window's left-button gesture.
@@ -130,7 +126,7 @@ struct BarWin {
 impl BarWin {
     /// Still moving: easing toward/away from hover, or breathing while hovered.
     fn animating(&self) -> bool {
-        self.hovered || self.hover_anim > 0.0
+        self.hovered || !self.hover_anim.is_resting()
     }
 
     /// The window should be grown for the panel while the bar is hovered or still
@@ -229,7 +225,7 @@ impl App {
             config,
             bar,
             hovered: false,
-            hover_anim: 0.0,
+            hover_anim: HoverAnim::default(),
             last: now,
             gesture: DragClick::new(DRAG_THRESHOLD),
             self_set: Some(pos),
@@ -305,26 +301,21 @@ impl App {
 
     fn render_id(&mut self, id: i64) {
         let now = Instant::now();
-        // Continuous breathing phase: a sine over the whole run, never reset, so it
-        // never snaps when a bar starts or stops being hovered.
-        let breathe = (TAU * now.duration_since(self.start).as_secs_f32() / BREATHE_PERIOD).sin();
+        // Continuous breathing phase over the whole run, never reset, so it never
+        // snaps when a bar starts or stops being hovered.
+        let breathe = anim::breathe(now.duration_since(self.start), BREATHE_PERIOD);
 
-        // Advance this bar's eased hover amount toward its target, then map it
-        // through ease-out for the visible grow/opacity.
+        // Advance this bar's hover amount toward its target, then read its eased
+        // value for the visible grow/opacity.
         let hover = {
             let Some(win) = self.wins.get_mut(&id) else {
                 return;
             };
-            let dt = now.duration_since(win.last).as_secs_f32().min(0.05);
+            let dt = now.duration_since(win.last).min(MAX_STEP);
             win.last = now;
-            let target = if win.hovered { 1.0 } else { 0.0 };
-            let step = dt / GROW_SECS;
-            win.hover_anim = if win.hover_anim < target {
-                (win.hover_anim + step).min(target)
-            } else {
-                (win.hover_anim - step).max(target)
-            };
-            ease_out_cubic(win.hover_anim)
+            win.hover_anim
+                .approach(if win.hovered { 1.0 } else { 0.0 }, dt, GROW);
+            win.hover_anim.eased()
         };
 
         let Some(core) = self.core.as_ref() else {

--- a/packages/bossbar-overlay/app/crates/overlay-core/src/anim.rs
+++ b/packages/bossbar-overlay/app/crates/overlay-core/src/anim.rs
@@ -1,0 +1,99 @@
+//! Shared animation primitives for the overlays.
+//!
+//! The overlays are event-driven winit loops, so time-based motion drives its own
+//! frames (advance toward a target by `dt / duration`, apply an easing curve,
+//! redraw, sleep when at rest). This module owns the reusable pieces every
+//! overlay shares: the easing curves, a per-element hover stepper
+//! ([`HoverAnim`]), a continuous breathing oscillator ([`breathe`]), and a quad
+//! scaler ([`scale_quads_about`]). The durations, amplitudes, and the rationale
+//! live in the repo `animation` skill.
+
+use std::time::Duration;
+
+use crate::Quad;
+
+/// Ease-out cubic: fast start, soft landing. The default feedback curve for
+/// hovers and entrances.
+pub fn ease_out_cubic(t: f32) -> f32 {
+    let u = 1.0 - t.clamp(0.0, 1.0);
+    1.0 - u * u * u
+}
+
+/// Ease-out with a gentle overshoot: the value springs slightly past `1.0` and
+/// settles back. Reserved for playful, non-critical surfaces (a button or arrow
+/// pop), never task-critical motion. See the `animation` skill.
+pub fn ease_out_back(t: f32) -> f32 {
+    const C1: f32 = 1.2;
+    const C3: f32 = C1 + 1.0;
+    let u = t.clamp(0.0, 1.0) - 1.0;
+    1.0 + C3 * u * u * u + C1 * u * u
+}
+
+/// A breathing oscillator: a sine in `-1..=1` driven by a continuous `elapsed`
+/// clock, so it never snaps when a hover toggles. `period` is one full cycle;
+/// fade the result in with a hover amount so a resting element stays still.
+pub fn breathe(elapsed: Duration, period: Duration) -> f32 {
+    use std::f32::consts::TAU;
+    let p = period.as_secs_f32().max(f32::EPSILON);
+    (TAU * elapsed.as_secs_f32() / p).sin()
+}
+
+/// A hover amount in `0..=1`, eased toward a target at a fixed rate. Keep one per
+/// animated element: call [`HoverAnim::approach`] each frame with the frame's
+/// `dt` and the grow/shrink `duration`, then read [`HoverAnim::raw`] or
+/// [`HoverAnim::eased`] to render. The raw value is the linear progress; `eased`
+/// maps it through [`ease_out_cubic`] for the visible curve.
+#[derive(Clone, Copy, Default)]
+pub struct HoverAnim {
+    raw: f32,
+}
+
+impl HoverAnim {
+    /// Step the linear progress toward `target` (`0.0` resting, `1.0` hovered) by
+    /// `dt / duration`, clamped so it lands exactly on the target.
+    pub fn approach(&mut self, target: f32, dt: Duration, duration: Duration) {
+        let step = dt.as_secs_f32() / duration.as_secs_f32().max(f32::EPSILON);
+        self.raw = if self.raw < target {
+            (self.raw + step).min(target)
+        } else {
+            (self.raw - step).max(target)
+        };
+    }
+
+    /// Linear progress in `0..=1`.
+    pub fn raw(&self) -> f32 {
+        self.raw
+    }
+
+    /// Progress mapped through [`ease_out_cubic`], the visible feedback curve.
+    pub fn eased(&self) -> f32 {
+        ease_out_cubic(self.raw)
+    }
+
+    /// True once fully eased back to rest, so the loop can stop redrawing it.
+    pub fn is_resting(&self) -> bool {
+        self.raw <= 0.0
+    }
+
+    /// True only while a transition is in flight (strictly between rest and fully
+    /// hovered). The two settled states are `0.0` and `1.0`, so an element with no
+    /// continuous motion lets the loop sleep once this is false, even while still
+    /// hovered.
+    pub fn is_animating(&self) -> bool {
+        self.raw > 0.0 && self.raw < 1.0
+    }
+}
+
+/// Scale every quad's rect about `(cx, cy)` by `mul`, growing a laid-out group in
+/// place. A no-op at unit scale, so a resting overlay pays nothing.
+pub fn scale_quads_about(quads: &mut [Quad], cx: f32, cy: f32, mul: f32) {
+    if (mul - 1.0).abs() < f32::EPSILON {
+        return;
+    }
+    for q in quads {
+        q.x = cx + (q.x - cx) * mul;
+        q.y = cy + (q.y - cy) * mul;
+        q.w *= mul;
+        q.h *= mul;
+    }
+}

--- a/packages/bossbar-overlay/app/crates/overlay-core/src/lib.rs
+++ b/packages/bossbar-overlay/app/crates/overlay-core/src/lib.rs
@@ -7,19 +7,23 @@
 //! - one textured-quad wgpu pipeline with a texture registry, plus the vanilla
 //!   bitmap font so text is just more quads ([`gpu`], [`bitmap_font`]),
 //! - press/drag/click disambiguation for draggable windows ([`gesture`]),
-//! - a headless render-to-PNG for verification ([`snapshot`]).
+//! - a headless render-to-PNG for verification ([`snapshot`]),
+//! - the shared animation primitives the overlays drive their hovers with
+//!   ([`anim`]: easing curves, a hover stepper, a breathe oscillator).
 //!
 //! A consumer (the boss bar, the book) builds a `Vec<`[`Quad`]`>` for its domain
 //! and hands it to [`Gpu::draw`] or [`snapshot::render_to_png`]. The Mojang art
 //! and font are sourced by the `minecraft-assets` Nix derivation; the font sheet
 //! is embedded here so every overlay renders the same text.
 
+pub mod anim;
 pub mod bitmap_font;
 pub mod gesture;
 pub mod gpu;
 pub mod snapshot;
 pub mod window;
 
+pub use anim::HoverAnim;
 pub use bitmap_font::BitmapFont;
 pub use gesture::DragClick;
 pub use gpu::{Gpu, Quad, TexHandle, SHADOW};


### PR DESCRIPTION
## What

Polishes the `book-overlay` desktop overlay's hover interaction and factors the shared animation logic out of the two overlays.

- **Page-turn arrows** crossfade to Mojang's `page_*_highlighted` sprite and pop with a gentle ease-out-back overshoot on hover, matching the vanilla book screen's button highlight. The highlighted variants were already extracted by `minecraft-assets`; this wires them in.
- **Whole-book hover**: the spread grows once on hover and then **holds still**. No perpetual breathing, so the page text stays readable. The render loop goes fully idle once the grow and arrows settle.
- **Page-flip sound**: turning a page plays the vanilla flip sound (`item/book/open_flip{1,2,3}`, cycled) by shelling out to the `minecraft-sound` binary. Non-blocking and best-effort: it logs once and runs silent if the binary is not on `PATH`.
- **Shared `overlay_core::anim` module**: the easing curves (`ease_out_cubic`, `ease_out_back`), a `HoverAnim` per-element stepper, a continuous `breathe` oscillator, and `scale_quads_about` now live in one place. Both the book and the boss bar use it; the boss bar's duplicated easing/breathe/step code is removed (verified mathematically identical).

## Validation

- `nix build .#book-overlay` passes; ran the live overlay and headless `--snapshot --hover` to confirm the highlight + grow render correctly.
- `cargo build --workspace` clean (standalone overlay workspace).
- Adversarial code review: no correctness or security findings; the cursor->resting-space hit-test transform is exact (no hover oscillation) and window headroom is sufficient (no clipping). Boss-bar refactor confirmed behavior-preserving term-for-term.

Made with Claude (claude-opus-4-8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hover highlight, settle animation, and page-flip sound to book overlay
> - Introduces a shared `anim` module in `overlay-core` with easing functions (`ease_out_cubic`, `ease_out_back`), a `breathe` oscillator, `HoverAnim` helper, and `scale_quads_about` utility; the bossbar overlay migrates to these shared primitives.
> - The book overlay now animates on hover: the whole spread subtly grows, hovered arrows pop with an overshoot ease and crossfade to highlighted sprites, and the cursor switches to pointer/grab as appropriate.
> - Arrow hit-testing in [`overlay.rs`](https://github.com/indexable-inc/index/pull/464/files#diff-25d840f9f102c25afb3dedf5a6455214d9359921759be6a821f23793bae464ba) accounts for the current book scale so clickable areas remain accurate while the book is grown.
> - A new [`sound.rs`](https://github.com/indexable-inc/index/pull/464/files#diff-298b3877869cf3c9dc7ef6ed5d6b8df7dfdc3a3ab88c7eb2128e3fb06657e21a) module plays a Minecraft page-flip sound on click by spawning an external `minecraft-sound` binary; failures log a one-time warning and are otherwise silent.
> - A `--hover` CLI flag is added to snapshot mode to render a hovered-state image with the grown book and highlighted forward arrow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8437d1f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->