### PR TITLE
examples: synced GitHub auth across a fleet via one declared token

### DIFF
--- a/examples/synced-github-auth/README.md
+++ b/examples/synced-github-auth/README.md
@@ -1,0 +1,82 @@
+# Synced GitHub auth
+
+Give a whole fleet of agent VMs one GitHub identity without running
+`gh auth login` on each box. The fleet declares a single token; every node
+wires `git` to use it. Adding a replica needs no extra auth step.
+
+## Run
+
+```sh
+ix up
+```
+
+## Shape
+
+- [`default.nix`](default.nix) defines the fleet: three `agent` replicas and a
+  `secrets` block that declares one `github/token` ref through `ix.secrets`.
+- [`agent.nix`](agent.nix) consumes `secretRefs."github/token"` and installs a
+  `git` credential helper that reads the token from its runtime path on demand.
+
+## How the token reaches git
+
+`ix.secrets` turns the declaration into a path, `/run/secrets/github/token`,
+that every node sees. Only that path is known at build time. The token bytes
+are written at runtime by the ix secrets manager
+([#66](https://github.com/indexable-inc/index/issues/66)), so nothing secret
+enters the Nix store or the fleet plan.
+
+[`agent.nix`](agent.nix) registers a credential helper in `/etc/gitconfig`
+scoped to `https://github.com`. When `git` needs a credential it runs the
+helper, which reads the file and prints `username=x-access-token` plus the
+token. The token is never exported into any process environment and is read
+only at the moment `git` asks. A `url.insteadOf` rule rewrites
+`git@github.com:` remotes to HTTPS so SSH-style clones use the same token.
+
+The helper is deliberately silent when the file is missing: it exits `0` with
+no output, so a node boots and anonymous fetches work even before a token is
+delivered. The [health check](agent.nix) asserts that wiring (helper resolved,
+executable, silent on empty input) rather than asserting a specific token came
+back, so it passes in CI where no real token exists.
+
+## The `gh` CLI
+
+`gh` ignores git's credential helper; it reads `GH_TOKEN`. This example does
+not export `GH_TOKEN` globally, because an exported token shows up in every
+process's `/proc/<pid>/environ` and in core dumps. To authenticate `gh` in a
+shell, point it at the same file:
+
+```sh
+export GH_TOKEN="$(cat /run/secrets/github/token)"
+```
+
+## Why not just share the host `~/.config`?
+
+A tempting shortcut is to mount the operator's whole `~/.config` (or
+`~/.config/gh`) into every VM over a shared folder, so `gh` and `git` pick up
+the host's existing login. It works, and for a single local dev VM driven by
+[`packages/macos-vm`](../../packages/macos-vm) over virtio-fs it can be
+reasonable. As a fleet primitive it has sharp edges:
+
+- It shares far more than a token. `~/.config` holds unrelated app state,
+  other services' credentials, and host-specific paths that mean nothing in a
+  guest. The blast radius of a compromised VM becomes "everything in the
+  operator's config dir."
+- The host token is usually a broad personal credential. Per-VM scoped tokens
+  (a fine-grained PAT or a GitHub App installation token) cannot be expressed
+  by copying one shared file.
+- Remote fleet VMs have no host filesystem to share in the first place. The
+  shared-folder story only exists for a co-located dev VM.
+
+Declaring one scoped secret and consuming it per node keeps the surface to a
+single credential with a single owner. Whether ix should *also* offer a
+config-sync primitive for the local dev-VM case is an open design question:
+[#465](https://github.com/indexable-inc/index/issues/465).
+
+## Bad fit if
+
+- You need per-repo or per-agent GitHub identities on the same node. One
+  system credential helper answers for all of `github.com`; split identities
+  want per-user config or separate nodes.
+- You want `gh` authenticated for non-interactive services. Wire `GH_TOKEN`
+  into that unit through `LoadCredential` from the same file rather than the
+  global environment.

--- a/examples/synced-github-auth/README.md
+++ b/examples/synced-github-auth/README.md
@@ -29,14 +29,18 @@ enters the Nix store or the fleet plan.
 scoped to `https://github.com`. When `git` needs a credential it runs the
 helper, which reads the file and prints `username=x-access-token` plus the
 token. The token is never exported into any process environment and is read
-only at the moment `git` asks. A `url.insteadOf` rule rewrites
-`git@github.com:` remotes to HTTPS so SSH-style clones use the same token.
+only at the moment `git` asks. The helper also parses the request `git` feeds
+it and emits the token only when the host is `github.com` over `https`, so it
+cannot hand the token to another host even if invoked outside its config scope.
+A `url.insteadOf` rule rewrites both `git@github.com:` and
+`ssh://git@github.com/` remotes to HTTPS so SSH-style clones use the same token.
 
 The helper is deliberately silent when the file is missing: it exits `0` with
 no output, so a node boots and anonymous fetches work even before a token is
-delivered. The [health check](agent.nix) asserts that wiring (helper resolved,
-executable, silent on empty input) rather than asserting a specific token came
-back, so it passes in CI where no real token exists.
+delivered. The [health check](agent.nix) asserts the wiring (helper resolved,
+executable, and exits `0` while emitting nothing for a request it should not
+answer) rather than asserting a specific token came back, so it passes in CI
+where no real token exists.
 
 ## The `gh` CLI
 

--- a/examples/synced-github-auth/README.md
+++ b/examples/synced-github-auth/README.md
@@ -44,10 +44,11 @@ where no real token exists.
 
 ## The `gh` CLI
 
-`gh` ignores git's credential helper; it reads `GH_TOKEN`. This example does
-not export `GH_TOKEN` globally, because an exported token shows up in every
-process's `/proc/<pid>/environ` and in core dumps. To authenticate `gh` in a
-shell, point it at the same file:
+`gh` ignores git's credential helper; it reads `GH_TOKEN` (or `GITHUB_TOKEN`).
+This example does not export it globally, because an exported token is visible
+in that process's `/proc/<pid>/environ`, is inherited by every descendant
+process, and can land in a core dump. To authenticate `gh` in a shell, point it
+at the same file:
 
 ```sh
 export GH_TOKEN="$(cat /run/secrets/github/token)"

--- a/examples/synced-github-auth/agent.nix
+++ b/examples/synced-github-auth/agent.nix
@@ -47,40 +47,48 @@ let
     printf 'password=%s\n' "$token"
   '';
 
-  # Secret-independent health probe: assert the wiring, not a returned token.
-  # git must resolve the helper path, the helper must be executable, and it must
-  # exit 0 while emitting nothing for the empty request fed here (which never
-  # matches the host guard, so no token is read even once one is delivered). The
-  # stdout redirect is belt-and-suspenders so a token can never reach the
-  # health-check log. This passes in CI and on a fresh boot with no token.
+  # Secret-independent health probe: assert THIS example's wiring, not a
+  # returned token. Credential helpers are additive across scopes, so `--get`
+  # would return whatever helper has highest priority (a user's global config
+  # could shadow it); `--get-all` plus an exact match is the honest check that
+  # the system config registered our helper for github.com. Then run that exact
+  # helper and require exit 0 with no output for the empty request fed here
+  # (which never matches the host guard, so no token is read even once one is
+  # delivered; the stdout redirect is belt-and-suspenders against a token
+  # reaching the health-check log). Passes in CI and on a fresh boot with no
+  # token.
   credentialHelperCheck = pkgs.writeShellScript "check-github-credential-helper" ''
     set -eu
-    helper=$(${lib.getExe pkgs.git} config --get 'credential.https://github.com.helper')
-    test -x "$helper"
-    "$helper" get </dev/null >/dev/null
+    ${lib.getExe pkgs.git} config --get-all 'credential.https://github.com.helper' \
+      | ${lib.getExe pkgs.gnugrep} -qxF ${credentialHelper}
+    test -x ${credentialHelper}
+    ${credentialHelper} get </dev/null >/dev/null
   '';
 in
 {
-  # System git config. It sits below any user's `~/.config/git/config`, so an
-  # operator can still override per user, but no user here defines a github
-  # helper, so this is the one that answers. git execs the helper directly
-  # because the value is an absolute path.
+  # System git config in `/etc/gitconfig`. Credential helpers are additive
+  # across scopes, so a user's `~/.config/git/config` can add its own helper but
+  # does not replace this one; no user here defines a github helper, so this is
+  # the one that answers. git execs the helper directly because the value is an
+  # absolute path.
   environment.etc."gitconfig".text = ''
     [credential "https://github.com"]
     	helper = ${credentialHelper}
 
     # Route SSH-style remotes through HTTPS so the same token authenticates
-    # `git@github.com:` and `ssh://git@github.com/` clones. Drop this block if
-    # a node should keep using SSH keys for GitHub instead.
+    # `git@github.com:` and `ssh://git@github.com/` clones. This applies to
+    # every user on the node. Drop this block if a node should keep using SSH
+    # keys for GitHub instead.
     [url "https://github.com/"]
     	insteadOf = git@github.com:
     	insteadOf = ssh://git@github.com/
   '';
 
-  # `gh` does not use git's credential helper; it reads `GH_TOKEN`. It is left
-  # out of the global environment on purpose (an exported token is visible in
-  # every process's `/proc/<pid>/environ`). Operators who want the `gh` CLI
-  # authenticated point it at the same file per shell, e.g.
+  # `gh` does not use git's credential helper; it reads `GH_TOKEN` (or
+  # `GITHUB_TOKEN`). It is left out of the global environment on purpose: an
+  # exported token is visible in that process's `/proc/<pid>/environ`, is
+  # inherited by every descendant, and can land in a core dump. Operators who
+  # want the `gh` CLI authenticated point it at the same file per shell, e.g.
   #   export GH_TOKEN="$(cat /run/secrets/github/token)"
   # See the README for why this is not baked in.
 

--- a/examples/synced-github-auth/agent.nix
+++ b/examples/synced-github-auth/agent.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  pkgs,
+  secretRefs,
+  ...
+}:
+let
+  # The fleet declares this once; every node resolves it to the same runtime
+  # path. Only the path is known at eval time. The token bytes live in the
+  # 0600 file the ix secrets manager writes at runtime.
+  tokenPath = secretRefs."github/token";
+
+  # A git credential helper that answers `get` for github.com with the token
+  # read from `tokenPath` on demand. Two properties carry the design:
+  #   1. The token never enters the store or any process environment. git
+  #      reads it from the helper's stdout only when it actually needs a
+  #      credential for a push or an authenticated fetch.
+  #   2. If the file is absent (token not delivered yet) the helper exits 0
+  #      with no output, so git falls through instead of failing. Boot and
+  #      anonymous git operations never depend on the secret being present.
+  # No external binaries: `[`, `printf`, and `$(<file)` are all bash builtins,
+  # so the helper has no runtime PATH requirement.
+  credentialHelper = pkgs.writeShellScript "github-token-credential-helper" ''
+    [ "$1" = get ] || exit 0
+    [ -r ${lib.escapeShellArg tokenPath} ] || exit 0
+    token=$(<${lib.escapeShellArg tokenPath})
+    [ -n "$token" ] || exit 0
+    printf 'username=x-access-token\n'
+    printf 'password=%s\n' "$token"
+  '';
+
+  # Secret-independent health probe: assert the wiring, not a returned token.
+  # git must resolve the helper path, the helper must be executable, and it
+  # must exit 0 on empty input (its silent-when-absent contract). This passes
+  # in CI and on a fresh boot where no token has been delivered.
+  credentialHelperCheck = pkgs.writeShellScript "check-github-credential-helper" ''
+    set -eu
+    helper=$(${lib.getExe pkgs.git} config --get 'credential.https://github.com.helper')
+    test -x "$helper"
+    "$helper" get </dev/null
+  '';
+in
+{
+  # System git config. It sits below any user's `~/.config/git/config`, so an
+  # operator can still override per user, but no user here defines a github
+  # helper, so this is the one that answers. git execs the helper directly
+  # because the value is an absolute path.
+  environment.etc."gitconfig".text = ''
+    [credential "https://github.com"]
+    	helper = ${credentialHelper}
+
+    # Route SSH-style remotes through HTTPS so the same token authenticates
+    # `git@github.com:` and `ssh://git@github.com/` clones. Drop this block if
+    # a node should keep using SSH keys for GitHub instead.
+    [url "https://github.com/"]
+    	insteadOf = git@github.com:
+    	insteadOf = ssh://git@github.com/
+  '';
+
+  # `gh` does not use git's credential helper; it reads `GH_TOKEN`. It is left
+  # out of the global environment on purpose (an exported token is visible in
+  # every process's `/proc/<pid>/environ`). Operators who want the `gh` CLI
+  # authenticated point it at the same file per shell, e.g.
+  #   export GH_TOKEN="$(cat /run/secrets/github/token)"
+  # See the README for why this is not baked in.
+
+  ix.healthChecks.github-credential-helper = {
+    description = "git is wired to the synced-token credential helper";
+    command = [ "${credentialHelperCheck}" ];
+  };
+}

--- a/examples/synced-github-auth/agent.nix
+++ b/examples/synced-github-auth/agent.nix
@@ -11,18 +11,36 @@ let
   tokenPath = secretRefs."github/token";
 
   # A git credential helper that answers `get` for github.com with the token
-  # read from `tokenPath` on demand. Two properties carry the design:
+  # read from `tokenPath` on demand. Three properties carry the design:
   #   1. The token never enters the store or any process environment. git
   #      reads it from the helper's stdout only when it actually needs a
   #      credential for a push or an authenticated fetch.
   #   2. If the file is absent (token not delivered yet) the helper exits 0
   #      with no output, so git falls through instead of failing. Boot and
   #      anonymous git operations never depend on the secret being present.
-  # No external binaries: `[`, `printf`, and `$(<file)` are all bash builtins,
-  # so the helper has no runtime PATH requirement.
+  #   3. It emits the token only for an `https`/`github.com` request. git
+  #      already scopes this helper to that host via the
+  #      `[credential "https://github.com"]` section, but re-checking the
+  #      request git feeds on stdin means the token can never be handed to
+  #      another host even if some non-git caller invokes the helper out of
+  #      scope.
+  # No external binaries: `[`, `printf`, `read`, `case`, and `$(<file)` are all
+  # bash builtins, so the helper has no runtime PATH requirement.
   credentialHelper = pkgs.writeShellScript "github-token-credential-helper" ''
     [ "$1" = get ] || exit 0
     [ -r ${lib.escapeShellArg tokenPath} ] || exit 0
+
+    # git feeds the request as `key=value` lines on stdin. The `|| [ -n "$key" ]`
+    # guard processes a final line that lacks a trailing newline.
+    proto= host=
+    while IFS='=' read -r key value || [ -n "$key" ]; do
+      case "$key" in
+        protocol) proto=$value ;;
+        host) host=$value ;;
+      esac
+    done
+    [ "$proto" = https ] && [ "$host" = github.com ] || exit 0
+
     token=$(<${lib.escapeShellArg tokenPath})
     [ -n "$token" ] || exit 0
     printf 'username=x-access-token\n'
@@ -30,14 +48,16 @@ let
   '';
 
   # Secret-independent health probe: assert the wiring, not a returned token.
-  # git must resolve the helper path, the helper must be executable, and it
-  # must exit 0 on empty input (its silent-when-absent contract). This passes
-  # in CI and on a fresh boot where no token has been delivered.
+  # git must resolve the helper path, the helper must be executable, and it must
+  # exit 0 while emitting nothing for the empty request fed here (which never
+  # matches the host guard, so no token is read even once one is delivered). The
+  # stdout redirect is belt-and-suspenders so a token can never reach the
+  # health-check log. This passes in CI and on a fresh boot with no token.
   credentialHelperCheck = pkgs.writeShellScript "check-github-credential-helper" ''
     set -eu
     helper=$(${lib.getExe pkgs.git} config --get 'credential.https://github.com.helper')
     test -x "$helper"
-    "$helper" get </dev/null
+    "$helper" get </dev/null >/dev/null
   '';
 in
 {

--- a/examples/synced-github-auth/default.nix
+++ b/examples/synced-github-auth/default.nix
@@ -1,0 +1,33 @@
+{ index }:
+
+index.lib.mkFleet {
+  defaults = [ { ix.image.tag = "synced-github-auth"; } ];
+
+  # One GitHub token, declared once for the whole fleet. `ix.secrets`
+  # normalizes this into a runtime path every node sees at the same place
+  # (`/run/secrets/github/token`). Only that path enters the Nix store; the
+  # token bytes are written at runtime by the ix secrets manager
+  # (https://github.com/indexable-inc/index/issues/66), still in progress.
+  #
+  # Point `key` at wherever the token lives in the provider. A fine-grained
+  # GitHub PAT or a GitHub App installation token scoped to the repos the
+  # agents touch is the right credential here, not a personal classic PAT.
+  secrets = {
+    provider = {
+      type = "vaultwarden";
+      client = "rbw";
+      server = "https://vaultwarden.internal.example";
+      mountRoot = "/run/secrets";
+      folder = "production";
+    };
+    "github/token".key = "github/agent-token";
+  };
+
+  # Three interchangeable agent VMs. None of them runs `gh auth login`; they
+  # all consume the same declared token, so adding a fourth replica costs
+  # nothing.
+  nodes.agent = {
+    replicas = 3;
+    modules = [ ./agent.nix ];
+  };
+}


### PR DESCRIPTION
## What

Adds `examples/synced-github-auth`: a fleet of three interchangeable agent VMs
that share one GitHub identity, so none of them runs `gh auth login` and adding
a replica costs no extra auth step.

The fleet declares a single `github/token` through `ix.secrets`. Each node
installs a `git` credential helper (in `/etc/gitconfig`, scoped to
`https://github.com`) that reads the token from its runtime path
(`/run/secrets/github/token`) on demand. Properties:

- The token never enters the Nix store or any process environment; `git` reads
  it from the helper's stdout only when it needs a credential.
- The helper is silent when the file is absent (exits 0, no output), so a node
  boots and anonymous fetches work before any token is delivered. The health
  check asserts that wiring, not a returned token, so it passes in CI.
- A `url.insteadOf` rule routes `git@github.com:` / `ssh://git@github.com/`
  remotes through HTTPS so the same token authenticates them.

Runtime delivery of the token bytes rides on the in-progress secrets manager
(#66). The README is explicit about that dependency and about the `gh` CLI
(which reads `GH_TOKEN`, deliberately not exported globally).

## Why / design question

The README contrasts this per-secret approach with the tempting shortcut of
sharing the host `~/.config` wholesale over a shared folder. That broader design
question (which primitive ix should own for fleet-wide auth) is tracked in #465.

## Validation

- `nix eval` of `agent.nix` (deepSeq): renders `/etc/gitconfig` with the helper
  store path and a string-typed health-check command. ✅
- Credential-helper bash logic tested directly: silent on missing file (exit 0),
  silent on non-`get` verbs, correct `username=x-access-token` + `password=`
  output with a token present. ✅
- `git config --get 'credential.https://github.com.helper'` (the health check's
  query) parses the URL-subsection key correctly. ✅

The full 3-node fleet eval is left to CI (cross-system NixOS eval).

---

Made with Claude (Anthropic, Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add synced GitHub auth example that distributes a single declared token across a fleet
> - Adds a new [examples/synced-github-auth](https://github.com/indexable-inc/index/pull/467/files#diff-e29fb0e42839398564bf77da601de329209af84928f0a6f49e6928a4d774c6bd) example showing how to share one GitHub token across a 3-node fleet via `ix.secrets`.
> - [agent.nix](https://github.com/indexable-inc/index/pull/467/files#diff-834c880fd1e4b22e42c558f63146478da757ab7aa73326a8d9aeb24ce9283c54) installs a system-wide `/etc/gitconfig` that registers a credential helper for `https://github.com` and rewrites SSH-style GitHub remotes to HTTPS.
> - The credential helper reads the token file at runtime and responds only to `https://github.com` requests; it exits silently when the token is absent so git falls through.
> - [default.nix](https://github.com/indexable-inc/index/pull/467/files#diff-c76dffe82a7675975b7a26cf496515f70a4a96dfaa53b2d13a11a4a5096de641) declares the fleet with a `github/token` secret sourced from Vaultwarden (rbw) and shared across all nodes.
> - A `github-credential-helper` health check validates that the helper is registered and produces no output for non-matching requests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 964c682.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->