### PR TITLE
feat(polars-sftp): NDJSON + host-key verification; add claude-history-sftp script

### DIFF
--- a/packages/polars-sftp/Cargo.lock
+++ b/packages/polars-sftp/Cargo.lock
@@ -9,6 +9,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +606,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +827,16 @@ dependencies = [
  "num-traits",
  "serde",
  "zerocopy",
+]
+
+[[package]]
+name = "halfbrown"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
 ]
 
 [[package]]
@@ -1159,6 +1191,17 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonpath_lib_polars_vendor"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4bd9354947622f7471ff713eacaabdb683ccb13bba4edccaab9860abf480b7d"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1663,6 +1706,7 @@ dependencies = [
  "polars-compute",
  "polars-core",
  "polars-io",
+ "polars-json",
  "polars-ops",
  "polars-plan",
  "polars-row",
@@ -1712,6 +1756,7 @@ dependencies = [
  "polars-compute",
  "polars-core",
  "polars-error",
+ "polars-json",
  "polars-parquet",
  "polars-schema",
  "polars-utils",
@@ -1720,8 +1765,30 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "simd-json",
  "simdutf8",
  "tokio",
+ "zmij",
+]
+
+[[package]]
+name = "polars-json"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55581d4cc8f4122cae92d12aec997e6713ac483871391a7db09501604007be4b"
+dependencies = [
+ "chrono",
+ "fallible-streaming-iterator",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "itoa",
+ "num-traits",
+ "polars-arrow",
+ "polars-compute",
+ "polars-error",
+ "polars-utils",
+ "simd-json",
+ "streaming-iterator",
  "zmij",
 ]
 
@@ -1741,6 +1808,7 @@ dependencies = [
  "polars-core",
  "polars-expr",
  "polars-io",
+ "polars-json",
  "polars-mem-engine",
  "polars-ops",
  "polars-plan",
@@ -1763,6 +1831,7 @@ dependencies = [
  "polars-error",
  "polars-expr",
  "polars-io",
+ "polars-json",
  "polars-ops",
  "polars-plan",
  "polars-time",
@@ -1786,6 +1855,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "hex",
  "indexmap",
+ "jsonpath_lib_polars_vendor",
  "libm",
  "memchr",
  "num-traits",
@@ -1794,11 +1864,13 @@ dependencies = [
  "polars-compute",
  "polars-core",
  "polars-error",
+ "polars-json",
  "polars-schema",
  "polars-utils",
  "rayon",
  "regex",
  "regex-syntax",
+ "serde_json",
  "strum_macros",
  "unicode-normalization",
  "unicode-reverse",
@@ -1869,6 +1941,7 @@ dependencies = [
  "polars-core",
  "polars-error",
  "polars-io",
+ "polars-json",
  "polars-ops",
  "polars-parquet",
  "polars-time",
@@ -1972,6 +2045,7 @@ dependencies = [
  "polars-error",
  "polars-expr",
  "polars-io",
+ "polars-json",
  "polars-mem-engine",
  "polars-ops",
  "polars-parquet",
@@ -2378,6 +2452,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,6 +2742,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2720,6 +2815,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd-json"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3"
+dependencies = [
+ "ahash",
+ "halfbrown",
+ "once_cell",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
 
 [[package]]
 name = "simdutf8"
@@ -3189,6 +3300,18 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "value-trait"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
 ]
 
 [[package]]

--- a/packages/polars-sftp/Cargo.toml
+++ b/packages/polars-sftp/Cargo.toml
@@ -25,6 +25,7 @@ polars = { version = "0.53", default-features = false, features = [
   "parquet",
   "ipc",
   "csv",
+  "json",
 ] }
 ssh2 = "0.9"
 

--- a/packages/polars-sftp/README.md
+++ b/packages/polars-sftp/README.md
@@ -1,8 +1,8 @@
 # polars-sftp
 
 A [Polars](https://pola.rs) IO source that reads a remote file over **SFTP** and
-hands it back as a lazy `LazyFrame`. Point it at a parquet, IPC, or CSV file on
-an SSH host and query it like any other Polars source:
+hands it back as a lazy `LazyFrame`. Point it at a parquet, IPC, CSV, or NDJSON
+(`.jsonl`) file on an SSH host and query it like any other Polars source:
 
 ```python
 import polars as pl
@@ -42,11 +42,18 @@ agent. `username` defaults to `$USER`.
 
 ```python
 scan_sftp(host, path, port=22, username=None, password=None,
-          private_key="~/.ssh/id_ed25519", storage_format=None)
+          private_key="~/.ssh/id_ed25519", storage_format=None,
+          timeout_ms=30_000, check_host_key=True)
 ```
 
-`storage_format` (`"parquet"` | `"ipc"` | `"csv"`) overrides the extension-based
-format guess.
+`storage_format` (`"parquet"` | `"ipc"` | `"csv"` | `"ndjson"`) overrides the
+extension-based format guess (`.jsonl`/`.ndjson` map to NDJSON).
+
+The server's host key is checked against `~/.ssh/known_hosts` before any
+credential is sent: a recorded entry that mismatches is rejected (possible MITM),
+an unrecorded host is accepted (trust on first use). Pass `check_host_key=False`
+to skip the check. `timeout_ms` bounds the connect and read so a stuck host errors
+instead of hanging.
 
 ## Build
 
@@ -63,7 +70,6 @@ crate's Rust `polars` and your Python `polars` must be the matching release).
   decoding and output, not the bytes pulled over the wire. Selective range-reads
   over SFTP (a custom `MmapBytesReader` over `ssh2` seek) would fix that and are
   the obvious next step.
-- The host key is not verified (no `known_hosts` check) yet.
 - One chunk per scan: the reader does not stream row groups, so `batch_size` is a
   no-op and a whole file lands in memory at once.
 - The wheel links `libssh2`/`openssl` from the Nix store by rpath, so it runs in

--- a/packages/polars-sftp/python/polars_sftp/__init__.py
+++ b/packages/polars-sftp/python/polars_sftp/__init__.py
@@ -29,6 +29,7 @@ def scan_sftp(
     private_key: str | None = None,
     storage_format: str | None = None,
     timeout_ms: int = 30_000,
+    check_host_key: bool = True,
 ) -> pl.LazyFrame:
     """Lazily scan a remote file over SFTP.
 
@@ -48,6 +49,7 @@ def scan_sftp(
         "private_key": private_key,
         "storage_format": storage_format,
         "timeout_ms": timeout_ms,
+        "check_host_key": check_host_key,
     }
 
     def _schema() -> pl.Schema:

--- a/packages/polars-sftp/python/polars_sftp/_polars_sftp.pyi
+++ b/packages/polars-sftp/python/polars_sftp/_polars_sftp.pyi
@@ -16,6 +16,7 @@ def read_sftp(
     with_columns: list[str] | None = ...,
     n_rows: int | None = ...,
     timeout_ms: int = ...,
+    check_host_key: bool = ...,
 ) -> pl.DataFrame:
     """Read a remote file over SFTP into a DataFrame (see `scan_sftp`)."""
     ...

--- a/packages/polars-sftp/src/lib.rs
+++ b/packages/polars-sftp/src/lib.rs
@@ -15,7 +15,7 @@
 
 use std::io::{Cursor, Read};
 use std::net::{TcpStream, ToSocketAddrs};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use polars::prelude::*;
@@ -30,6 +30,8 @@ enum Format {
     Parquet,
     Ipc,
     Csv,
+    /// Newline-delimited JSON (one JSON object per line), e.g. Claude history.
+    Ndjson,
 }
 
 fn resolve_format(hint: Option<&str>, path: &str) -> PyResult<Format> {
@@ -40,8 +42,9 @@ fn resolve_format(hint: Option<&str>, path: &str) -> PyResult<Format> {
         Some("parquet" | "pq") => Ok(Format::Parquet),
         Some("ipc" | "arrow" | "feather") => Ok(Format::Ipc),
         Some("csv" | "tsv" | "txt") => Ok(Format::Csv),
+        Some("jsonl" | "ndjson") => Ok(Format::Ndjson),
         other => Err(PyValueError::new_err(format!(
-            "polars-sftp: cannot infer a format from {other:?}; pass storage_format=\"parquet\"|\"ipc\"|\"csv\""
+            "polars-sftp: cannot infer a format from {other:?}; pass storage_format=\"parquet\"|\"ipc\"|\"csv\"|\"ndjson\""
         ))),
     }
 }
@@ -57,6 +60,7 @@ fn fetch_bytes(
     private_key: Option<&str>,
     remote_path: &str,
     timeout_ms: u64,
+    check_host_key: bool,
 ) -> Result<Vec<u8>, String> {
     // Bound every blocking step: the TCP connect, the raw socket reads/writes,
     // and libssh2's own blocking calls. Without this a stuck or silent peer hangs
@@ -77,6 +81,14 @@ fn fetch_bytes(
     sess.set_timeout(timeout_ms.clamp(1, u32::MAX as u64) as u32);
     sess.set_tcp_stream(tcp);
     sess.handshake().map_err(|e| format!("ssh handshake: {e}"))?;
+
+    // Verify the server's host key against ~/.ssh/known_hosts BEFORE sending any
+    // credential, so a MITM of a known host is rejected rather than handed a
+    // password. An unknown host is accepted (trust on first use); a key that
+    // mismatches a recorded entry is refused.
+    if check_host_key {
+        verify_host_key(&sess, host, port)?;
+    }
 
     if let Some(pw) = password {
         sess.userauth_password(username, pw)
@@ -100,6 +112,34 @@ fn fetch_bytes(
     file.read_to_end(&mut bytes)
         .map_err(|e| format!("read {remote_path}: {e}"))?;
     Ok(bytes)
+}
+
+/// Verify the connected server's host key against `~/.ssh/known_hosts`. A recorded
+/// entry that mismatches is rejected (possible MITM); an unrecorded host is
+/// accepted (trust on first use). A missing known_hosts file means no recorded
+/// entries, so every host is first-use.
+fn verify_host_key(sess: &ssh2::Session, host: &str, port: u16) -> Result<(), String> {
+    let mut known = sess
+        .known_hosts()
+        .map_err(|e| format!("init known_hosts: {e}"))?;
+    if let Some(home) = std::env::var_os("HOME") {
+        let path = PathBuf::from(home).join(".ssh/known_hosts");
+        if path.exists() {
+            known
+                .read_file(&path, ssh2::KnownHostFileKind::OpenSSH)
+                .map_err(|e| format!("read {}: {e}", path.display()))?;
+        }
+    }
+    let (key, _) = sess
+        .host_key()
+        .ok_or_else(|| "server presented no host key".to_string())?;
+    match known.check_port(host, port, key) {
+        ssh2::CheckResult::Match | ssh2::CheckResult::NotFound => Ok(()),
+        ssh2::CheckResult::Mismatch => Err(format!(
+            "host key mismatch for {host}:{port} (possible MITM); fix ~/.ssh/known_hosts or pass check_host_key=False"
+        )),
+        ssh2::CheckResult::Failure => Err(format!("host key check failed for {host}:{port}")),
+    }
 }
 
 /// Decode `bytes` as `format`, applying column projection and a row limit. For
@@ -126,6 +166,15 @@ fn decode(
         Format::Ipc => IpcReader::new(cursor).finish()?,
         Format::Csv => CsvReadOptions::default()
             .into_reader_with_file_handle(cursor)
+            .finish()?,
+        // Infer the schema from the whole file (`None`), not a prefix: heterogeneous
+        // history files often introduce a key only on a late line, and a bounded
+        // window would silently drop it. Lines missing a key read back null; a key
+        // with conflicting types across the file surfaces as a decode error (which
+        // the caller can catch per file) rather than corrupting the frame.
+        Format::Ndjson => JsonReader::new(cursor)
+            .with_json_format(JsonFormat::JsonLines)
+            .infer_schema_len(None)
             .finish()?,
     };
 
@@ -156,6 +205,7 @@ fn decode(
     with_columns = None,
     n_rows = None,
     timeout_ms = 30_000,
+    check_host_key = true,
 ))]
 #[allow(clippy::too_many_arguments)]
 fn read_sftp(
@@ -170,6 +220,7 @@ fn read_sftp(
     with_columns: Option<Vec<String>>,
     n_rows: Option<usize>,
     timeout_ms: u64,
+    check_host_key: bool,
 ) -> PyResult<PyDataFrame> {
     let user = username
         .or_else(|| std::env::var("USER").ok())
@@ -180,7 +231,7 @@ fn read_sftp(
     // Release the GIL for the blocking network read + decode: other Python
     // threads (and Polars' own engine) keep running while we wait on the socket.
     let df = py
-        .allow_threads(|| {
+        .detach(|| {
             let bytes = fetch_bytes(
                 &host,
                 port,
@@ -189,6 +240,7 @@ fn read_sftp(
                 private_key.as_deref(),
                 &path,
                 timeout_ms,
+                check_host_key,
             )?;
             decode(bytes, format, with_columns, n_rows)
                 .map_err(|e| format!("decode {path}: {e}"))

--- a/users/andrewgazelka/scripts/claude-history-sftp.py
+++ b/users/andrewgazelka/scripts/claude-history-sftp.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Query Claude Code history across remote hosts, read over SFTP with polars-sftp.
+
+For each given SSH host it finds every Claude history file
+(`~/.claude/history.jsonl` plus the session transcripts under
+`~/.claude/projects/**/*.jsonl`; the `~/.claude/jobs/**` artifacts are skipped),
+reads each over SFTP, and aggregates them with Polars: records per host, record
+types across the transcripts, the biggest sessions, and (where a `history.jsonl`
+prompt log exists) the busiest projects and most recent prompts.
+
+This dogfoods `packages/polars-sftp`: transcripts are read eagerly with
+`read_sftp` (one fetch each), and the prompt log is queried lazily through the
+`scan_sftp` IO plugin (column projection pushed into the reader).
+
+Setup (needs Python Polars 1.40.x to match the wheel's pinned ABI):
+
+    nix build .#polars-sftp
+    python -m venv .venv
+    .venv/bin/pip install 'polars==1.40.*' result/*.whl
+    .venv/bin/python users/andrewgazelka/scripts/claude-history-sftp.py hil-compute-1 hil-compute-2
+
+Hosts are SSH aliases resolved with `ssh -G`, so your `~/.ssh/config`
+host/port/user/identity settings apply. `--limit N` caps files per host (handy
+for a quick look); without it, every history file is read.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+from collections import Counter
+
+import polars as pl
+from polars_sftp import read_sftp, scan_sftp
+
+DEFAULT_HOSTS = ["hil-compute-1", "hil-compute-2", "hil-compute-3"]
+
+
+def resolve(alias: str) -> dict[str, str]:
+    """Resolve an SSH alias to connection params with `ssh -G` (reads ssh_config)."""
+    out = subprocess.run(
+        ["ssh", "-G", alias], capture_output=True, text=True, check=True
+    ).stdout
+    cfg: dict[str, str] = {}
+    for line in out.splitlines():
+        key, _, val = line.partition(" ")
+        # `ssh -G` lists identityfile multiple times; keep the first of each key.
+        if key in ("hostname", "port", "user", "identityfile") and key not in cfg:
+            cfg[key] = val
+    return cfg
+
+
+def connection(alias: str) -> tuple[str, dict[str, object]]:
+    """`(hostname, polars-sftp kwargs)` for `alias`."""
+    cfg = resolve(alias)
+    key = cfg.get("identityfile")
+    key_path = os.path.expanduser(key) if key else None
+    conn: dict[str, object] = {
+        "port": int(cfg.get("port", "22")),
+        "username": cfg.get("user"),
+        # `ssh -G` reports default identity paths even when the file is absent;
+        # only pass one that exists, else leave it None so polars-sftp falls back
+        # to the SSH agent.
+        "private_key": key_path if (key_path and os.path.exists(key_path)) else None,
+        "storage_format": "ndjson",
+    }
+    return cfg["hostname"], conn
+
+
+def history_files(alias: str) -> list[str]:
+    """The host's real Claude history files: `history.jsonl` + project transcripts.
+
+    Deliberately excludes `~/.claude/jobs/**` (background-job timelines and event
+    artifacts), which are not conversation history.
+    """
+    remote = (
+        'ls -1 "$HOME"/.claude/history.jsonl 2>/dev/null; '
+        'find "$HOME"/.claude/projects -type f -name "*.jsonl" 2>/dev/null'
+    )
+    # Pass the whole pipeline as one argument; ssh concatenates extra argv with
+    # spaces and the remote shell re-splits, which would mangle `bash -lc <cmd>`.
+    out = subprocess.run(
+        ["ssh", alias, "bash -lc " + shlex.quote(remote)],
+        capture_output=True,
+        text=True,
+    ).stdout
+    return [p for p in out.splitlines() if p.strip()]
+
+
+def main(hosts: list[str], limit: int | None) -> None:
+    per_host: dict[str, int] = {}
+    types: Counter[str] = Counter()
+    sessions: list[dict[str, object]] = []
+    prompt_frames: list[pl.DataFrame] = []
+
+    for alias in hosts:
+        try:
+            hostname, conn = connection(alias)
+        except subprocess.CalledProcessError as exc:
+            print(f"{alias}: cannot resolve ({exc})", file=sys.stderr)
+            continue
+
+        files = history_files(alias)
+        if limit is not None:
+            files = files[:limit]
+        records = unreadable = 0
+
+        for path in files:
+            if path.endswith("history.jsonl"):
+                # Showcase the lazy IO plugin (projection pushed into the read),
+                # collected per file so one unreadable history.jsonl is skipped,
+                # not fatal to the whole multi-host run.
+                try:
+                    prompt_frames.append(
+                        scan_sftp(hostname, path, **conn)
+                        .select("display", "project", "timestamp")
+                        .with_columns(host=pl.lit(alias))
+                        .collect()
+                    )
+                except Exception as exc:
+                    unreadable += 1
+                    print(f"  ! {alias}:{os.path.basename(path)}: {exc}", file=sys.stderr)
+                continue
+            try:
+                df = read_sftp(hostname, path, **conn)  # one fetch, eager
+            except Exception as exc:  # a transcript polars can't infer; skip + report
+                unreadable += 1
+                print(f"  ! {alias}:{os.path.basename(path)}: {exc}", file=sys.stderr)
+                continue
+            records += df.height
+            if "type" in df.columns:
+                types.update(
+                    df.get_column("type").drop_nulls().cast(pl.Utf8).to_list()
+                )
+            sessions.append(
+                {
+                    "host": alias,
+                    "session": os.path.basename(path).removesuffix(".jsonl"),
+                    "records": df.height,
+                }
+            )
+
+        per_host[alias] = records
+        print(f"{alias}: {len(files)} files, {records} transcript records ({unreadable} unreadable)")
+
+    if sessions:
+        print("\n== records by transcript type ==")
+        for kind, count in types.most_common(12):
+            print(f"  {count:>8}  {kind}")
+        print("\n== biggest sessions ==")
+        with pl.Config(tbl_rows=10):
+            print(pl.DataFrame(sessions).sort("records", descending=True).head(10))
+
+    if prompt_frames:
+        hist = pl.concat(prompt_frames, how="diagonal_relaxed")
+        print(f"\n== history.jsonl: {hist.height} prompts across {hist['host'].n_unique()} host(s) ==")
+        print("\nbusiest projects:")
+        print(hist.group_by("project").len().sort("len", descending=True).head(10))
+        print("\nmost recent prompts:")
+        with pl.Config(fmt_str_lengths=60, tbl_rows=10):
+            print(
+                hist.sort("timestamp", descending=True)
+                .select("host", "project", "display")
+                .head(10)
+            )
+    elif not sessions:
+        print("\nno Claude history files found on any host")
+
+
+def parse_args(argv: list[str]) -> tuple[list[str], int | None]:
+    hosts: list[str] = []
+    limit: int | None = None
+    it = iter(argv)
+    for arg in it:
+        raw: str | None = None
+        if arg == "--limit":
+            raw = next(it, None)
+            if raw is None:
+                raise SystemExit("--limit needs a number")
+        elif arg.startswith("--limit="):
+            raw = arg.split("=", 1)[1]
+        else:
+            hosts.append(arg)
+            continue
+        try:
+            limit = int(raw)
+        except ValueError:
+            raise SystemExit(f"--limit must be an integer, got {raw!r}")
+        if limit < 0:
+            raise SystemExit("--limit must be >= 0")
+    return hosts or DEFAULT_HOSTS, limit
+
+
+if __name__ == "__main__":
+    main(*parse_args(sys.argv[1:]))


### PR DESCRIPTION
## What

Extends `polars-sftp` (from #466) and adds a remote Claude-history query script.

**polars-sftp**
- NDJSON (`.jsonl`/`.ndjson`) support, so line-delimited JSON (Claude history, logs) scans like the other formats.
- Host-key verification against `~/.ssh/known_hosts` before any credential is sent: a recorded entry that mismatches is rejected (possible MITM), an unknown host is trusted on first use. `check_host_key=True` by default; pass `False` to skip. Closes the host-key finding from the #466 review.
- `py.allow_threads` → `py.detach` (the non-deprecated pyo3 0.27 spelling).

**`users/andrewgazelka/scripts/claude-history-sftp.py`**
Finds every Claude history file on the given SSH hosts (`~/.claude/history.jsonl` + `projects/**/*.jsonl`, skipping the `jobs/` artifacts) and queries them via polars-sftp: record types across transcripts, the biggest sessions, busiest projects, and most recent prompts. Transcripts are read eagerly (`read_sftp`, one fetch each); the prompt log is queried lazily through the `scan_sftp` IO plugin with projection pushdown. Hosts are `ssh -G`-resolved aliases.

## Validation

- `nix build .#polars-sftp` → the abi3 wheel (now with the polars `json` feature).
- NDJSON + host-key end-to-end against a real `asyncssh` SFTP server (a 4-row `.jsonl` reads with the right columns; TOFU accepts the unknown test host); all prior parquet/projection/predicate/n_rows cases still pass.
- The script ran against `hil-compute-1`: 339 prompts plus session transcripts read over SFTP and aggregated (record types, biggest sessions, busiest projects, recent prompts).

Made with AI (Claude, Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add NDJSON support and host-key verification to `polars-sftp`
> - Adds `Format::Ndjson` to [src/lib.rs](https://github.com/indexable-inc/index/pull/470/files#diff-09009c95f3f61268ac9810b46098e69c8bb2f33387f68dedf553617c3291192f), accepting `.jsonl`/`.ndjson` extensions and decoding via Polars `JsonReader` with full-file schema inference.
> - Adds `verify_host_key()` in [src/lib.rs](https://github.com/indexable-inc/index/pull/470/files#diff-09009c95f3f61268ac9810b46098e69c8bb2f33387f68dedf553617c3291192f) that checks the server key against `~/.ssh/known_hosts`; mismatches are rejected, unknown hosts are allowed.
> - Exposes `check_host_key` (default `True`) in both `read_sftp` and `scan_sftp` Python APIs; verification runs before authentication.
> - Adds [claude-history-sftp.py](https://github.com/indexable-inc/index/pull/470/files#diff-26c1a3b3b07374b27ccde407317cb5f21ca93d6aca0b81e03c0de426dc2e47ba), a script that reads Claude history `.jsonl` files from remote hosts via SFTP and prints transcript summaries.
> - Behavioral Change: `check_host_key` defaults to `true`, so existing callers will now fail if the server key mismatches a `known_hosts` entry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4cc3a2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->