### PR TITLE
base profile: tuned btop config + starship across bash/zsh/fish

### DIFF
--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -92,6 +92,120 @@ in
             $env.IX_WORKDIR = "${cfg.shellWorkspace.directory}"
           '';
         };
+        # Let Home Manager own root's bash/zsh/fish rc files. Without this
+        # the `enable*Integration` flags below (starship, atuin, zoxide,
+        # direnv, fzf) are inert for these shells: Home Manager only writes
+        # the init snippets into a shell's rc when that shell's module is
+        # enabled, so an operator who `chsh`-ed into bash or zsh would land
+        # at a bare prompt with none of the wiring. Nushell (the login
+        # default) already gets all of it via its module above. The NixOS
+        # `programs.zsh`/`programs.fish` modules further down handle
+        # system-wide registration; these are the per-user HM counterparts.
+        bash.enable = true;
+        zsh.enable = true;
+        fish.enable = true;
+        # btop resource monitor, configured natively through the Home
+        # Manager module (no opaque btop.conf to hand-maintain) so every
+        # VM opens btop with the same tuned layout: 500 ms refresh, just
+        # the proc+cpu boxes, process tree, vim keys, Fahrenheit temps.
+        # `color_theme = "gotham"` is a bare name, which btop resolves
+        # against its bundled themes dir ($out/share/btop/themes, found
+        # relative to the binary) at startup, so no absolute store path is
+        # baked in. btop is also in environment.systemPackages below so
+        # non-root users get the binary; both reference the same
+        # derivation, so there is no second copy in the store.
+        btop = {
+          enable = true;
+          settings = {
+            color_theme = "gotham";
+            theme_background = false;
+            truecolor = true;
+            force_tty = false;
+            disable_presets = "Off";
+            presets = "cpu:1:default,proc:0:default cpu:0:default,mem:0:default,net:0:default cpu:0:block,net:0:tty";
+            vim_keys = true;
+            disable_mouse = false;
+            rounded_corners = true;
+            terminal_sync = true;
+            graph_symbol = "block";
+            graph_symbol_cpu = "default";
+            graph_symbol_gpu = "default";
+            graph_symbol_mem = "default";
+            graph_symbol_net = "default";
+            graph_symbol_proc = "default";
+            shown_boxes = "proc cpu";
+            update_ms = 500;
+            proc_sorting = "cpu lazy";
+            proc_reversed = false;
+            proc_tree = true;
+            proc_colors = true;
+            proc_gradient = true;
+            proc_per_core = true;
+            proc_mem_bytes = true;
+            proc_cpu_graphs = true;
+            proc_info_smaps = false;
+            proc_left = false;
+            proc_filter_kernel = false;
+            proc_follow_detailed = true;
+            proc_aggregate = true;
+            keep_dead_proc_usage = false;
+            cpu_graph_upper = "total";
+            cpu_graph_lower = "total";
+            show_gpu_info = "Auto";
+            cpu_invert_lower = true;
+            cpu_single_graph = false;
+            cpu_bottom = false;
+            show_uptime = true;
+            show_cpu_watts = true;
+            check_temp = true;
+            cpu_sensor = "Auto";
+            show_coretemp = true;
+            cpu_core_map = "";
+            temp_scale = "fahrenheit";
+            base_10_sizes = false;
+            show_cpu_freq = true;
+            clock_format = "%X";
+            background_update = true;
+            custom_cpu_name = "";
+            disks_filter = "/";
+            mem_graphs = true;
+            mem_below_net = false;
+            zfs_arc_cached = true;
+            show_swap = true;
+            swap_disk = true;
+            show_disks = false;
+            only_physical = true;
+            use_fstab = true;
+            zfs_hide_datasets = false;
+            disk_free_priv = false;
+            show_io_stat = true;
+            io_mode = false;
+            io_graph_combined = false;
+            io_graph_speeds = "";
+            swap_upload_download = false;
+            net_download = 100;
+            net_upload = 100;
+            net_auto = false;
+            net_sync = true;
+            net_iface = "";
+            base_10_bitrate = "Auto";
+            show_battery = true;
+            selected_battery = "Auto";
+            show_battery_watts = true;
+            log_level = "WARNING";
+            save_config_on_exit = true;
+            nvml_measure_pcie_speeds = true;
+            rsmi_measure_pcie_speeds = true;
+            gpu_mirror_graph = true;
+            shown_gpus = "nvidia amd intel apple";
+            custom_gpu_name0 = "";
+            custom_gpu_name1 = "";
+            custom_gpu_name2 = "";
+            custom_gpu_name3 = "";
+            custom_gpu_name4 = "";
+            custom_gpu_name5 = "";
+          };
+        };
         # Shared prompt across every shell on the system, so the same
         # rendering follows the operator whether they stay in Nushell or
         # chsh into bash/zsh/fish.


### PR DESCRIPTION
## What

Two operator-experience defaults baked into the auto-enabled base profile (`modules/profiles/base`), so every ix VM behaves the same:

- **btop**, configured natively through the Home Manager module (`programs.btop.settings`) rather than a hand-maintained `btop.conf`. Mirrors the operator's local setup: 500 ms refresh, proc+cpu boxes only, process tree, vim keys, Fahrenheit, gotham theme.
- **starship across bash/zsh/fish** for root: enable `programs.bash/zsh/fish` under `home-manager.users.root`.

## Why the shell change

The `enable*Integration` flags for starship/atuin/zoxide/direnv/fzf were already `true`, but **inert for bash/zsh/fish** — Home Manager only writes the init snippets into a shell's rc when that shell's module is enabled. Only nushell (the login default) was getting them. Now an operator who `chsh`-es into bash or zsh lands on the same prompt + history + jump + direnv wiring.

## Theme path

`color_theme = "gotham"` is a bare name. btop resolves it against its bundled themes dir (`$out/share/btop/themes`, found relative to the binary) at startup, so no absolute store path is baked into the rendered config.

## Validation

- ✅ Real-context eval of the `development-base` image config (`evalImageConfig`): `btop.enable=true, update_ms=500, color_theme="gotham", vim_keys=true`, and `bash/zsh/fish` all enabled under root.
- ✅ Drove **real btop** in a PTY against the exact HM-rendered config (capitalized `True`/`False`, sorted keys): gotham palette renders (`main_fg #99d1ce`, `title #2aa889` present; absent under a bogus theme name → confirms name resolution), only cpu+proc boxes, `- 500ms +` in the header. btop accepts HM's capitalized booleans.
- ✅ Built a standalone HM config from the same pinned home-manager input: `.bashrc`/`.zshrc`/`config.fish` all contain `starship init <shell>` (plus atuin/zoxide/direnv) — confirming the previously-inert integrations now fire.

Made with Claude Code (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add btop config and enable shell management for bash, zsh, and fish in base profile
> - Enables Home Manager management of bash, zsh, and fish shells in [modules/profiles/base/default.nix](https://github.com/indexable-inc/index/pull/471/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e), activating any HM-provided shell integrations for those shells.
> - Adds a btop configuration with the gotham theme, 500ms update interval, `shown_boxes = "proc cpu"`, process tree, vim keys, and Fahrenheit temperatures.
> - Behavioral Change: Home Manager will now own the rc/init files for all three shells, which may overwrite manual customizations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f8a191.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->