### PR TITLE
base profile: don't try to save btop config on exit

### DIFF
--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -193,7 +193,7 @@ in
             selected_battery = "Auto";
             show_battery_watts = true;
             log_level = "WARNING";
-            save_config_on_exit = true;
+            save_config_on_exit = false;
             nvml_measure_pcie_speeds = true;
             rsmi_measure_pcie_speeds = true;
             gpu_mirror_graph = true;


### PR DESCRIPTION
Follow-up to #471. The shipped btop.conf is a read-only HM store symlink, so `save_config_on_exit = true` makes btop attempt a write that silently fails on exit — any in-TUI change is lost with no feedback. Set it to `false` so the declarative-config contract is honest.

Caught by the post-merge adversarial review of #471.

Made with Claude Code (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set btop `save_config_on_exit` to false in base profile
> Prevents btop from writing its config file on exit, so any runtime setting changes are not persisted. This keeps the NixOS-managed config as the source of truth.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 634f3df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->