### PR TITLE
macvm: closed-loop driving, run_binary, deterministic login, run_oci (#473-#476)

### DIFF
--- a/packages/macos-vm/src/drive.rs
+++ b/packages/macos-vm/src/drive.rs
@@ -121,11 +121,27 @@ fn parse_fraction_pair(
     let (Ok(fx), Ok(fy)) = (fx.parse::<f64>(), fy.parse::<f64>()) else {
         return Err(format!("err {verb} fractions must be numbers 0..1 (from top-left)"));
     };
-    if !(fx.is_finite() && fy.is_finite()) || !(0.0..=1.0).contains(&fx) || !(0.0..=1.0).contains(&fy)
-    {
+    let in_range = |f: f64| f.is_finite() && (0.0..=1.0).contains(&f);
+    if !in_range(fx) || !in_range(fy) {
         return Err(format!("err {verb} fractions must be within 0..1 (from top-left)"));
     }
     Ok((fx, fy))
+}
+
+/// Apply a pointer command at display fractions `(fx, fy)` and record the new
+/// pointer position. Shared by the `click` and `move` verbs: with `do_click` the
+/// pointer is pressed there, otherwise it only moves (hover).
+fn pointer_action(view_ptr: usize, fx: f64, fy: f64, do_click: bool, state: &mut State) {
+    on_main(view_ptr, move |view| {
+        let (x, y) = view_point(view, fx, fy);
+        if do_click {
+            input::click(view, x, y);
+        } else {
+            input::mouse_move(view, x, y);
+        }
+    });
+    state.last_cursor = Some((fx, fy));
+    std::thread::sleep(KEY_GAP_AFTER);
 }
 
 /// Execute one command line, returning its acknowledgement.
@@ -154,43 +170,22 @@ fn execute(view_ptr: usize, trimmed: &str, state: &mut State) -> String {
         return "ok".to_owned();
     };
     match command {
-        "click" => {
-            let (fx, fy) = match parse_fraction_pair(&mut parts, "click") {
+        "click" | "move" => {
+            let (fx, fy) = match parse_fraction_pair(&mut parts, command) {
                 Ok(pair) => pair,
                 Err(message) => return message,
             };
-            on_main(view_ptr, move |view| {
-                let (x, y) = view_point(view, fx, fy);
-                input::click(view, x, y);
-            });
-            state.last_cursor = Some((fx, fy));
-            std::thread::sleep(KEY_GAP_AFTER);
-            format!("ok click {fx} {fy}")
-        }
-        "move" => {
-            let (fx, fy) = match parse_fraction_pair(&mut parts, "move") {
-                Ok(pair) => pair,
-                Err(message) => return message,
-            };
-            on_main(view_ptr, move |view| {
-                let (x, y) = view_point(view, fx, fy);
-                input::mouse_move(view, x, y);
-            });
-            state.last_cursor = Some((fx, fy));
-            std::thread::sleep(KEY_GAP_AFTER);
-            format!("ok move {fx} {fy}")
+            pointer_action(view_ptr, fx, fy, command == "click", state);
+            format!("ok {command} {fx} {fy}")
         }
         "cursor" => match state.last_cursor {
             Some((fx, fy)) => format!("ok cursor {fx} {fy}"),
             None => "err cursor unknown (no click/move yet)".to_owned(),
         },
-        "size" => {
-            let size = frame_size(view_ptr);
-            match size {
-                Some((w, h)) => format!("ok size {w} {h}"),
-                None => "err size guest framebuffer not available yet".to_owned(),
-            }
-        }
+        "size" => match frame_size(view_ptr) {
+            Some((w, h)) => format!("ok size {w} {h}"),
+            None => "err size guest framebuffer not available yet".to_owned(),
+        },
         "cursor-show" => match parts.next() {
             Some("on") => {
                 state.show_cursor = true;

--- a/packages/macos-vm/src/drive.rs
+++ b/packages/macos-vm/src/drive.rs
@@ -8,13 +8,20 @@
 //! - `key <name> [count]` press a named key `count` times (default 1)
 //! - `down <name>` / `up <name>` hold / release a key (e.g. a modifier)
 //! - `type <text>` type the rest of the line as characters
+//! - `click <fx> <fy>` left-click at fraction `(fx, fy)` of the display (top-left)
+//! - `move <fx> <fy>` move the pointer there without clicking (hover)
+//! - `cursor` report the last pointer fraction set by `click`/`move`
+//! - `size` report the captured framebuffer size in pixels (`ok size <w> <h>`)
+//! - `cursor-show <on|off>` draw a marker at the pointer in subsequent `shot`s
 //! - `wait <seconds>` sleep (fractional seconds allowed)
 //! - `shot <path>` screenshot the guest framebuffer to a PNG
 //! - `quit` stop the VM and exit
 //!
 //! Each command prints a one-line `ok ...` / `err ...` acknowledgement to stdout
 //! (flushed), so a caller can drive the guest in lockstep. Names accepted by
-//! `key`/`down`/`up` are in [`crate::input::named_key`].
+//! `key`/`down`/`up` are in [`crate::input::named_key`]. `click`/`move`
+//! fractions are clamped-checked to `0..=1`; the pointer is absolute, so the
+//! reported `cursor` is the last fraction this driver set, not a guest read-back.
 
 use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
@@ -28,7 +35,7 @@ use objc2_virtualization::VZVirtualMachineView;
 
 use crate::imp::Error;
 use crate::input;
-use crate::macguest::{DirShare, capture, start_guest_offscreen};
+use crate::macguest::{DirShare, capture, frame_size as guest_frame_size, start_guest_offscreen};
 
 /// Gap between a key's down and up, and after its release, so the guest HID
 /// stack registers discrete presses instead of coalescing them. The sleeps run
@@ -60,7 +67,10 @@ pub(crate) fn drive_view(mtm: MainThreadMarker, view: Retained<VZVirtualMachineV
     // driver thread; the view is not `Send`, so we only re-borrow it on the main
     // queue, where it is valid.
     let view_ptr = Retained::into_raw(view) as usize;
-    eprintln!("macos-vm: driving guest; stdin commands: key/down/up/type/click/wait/shot/quit");
+    eprintln!(
+        "macos-vm: driving guest; stdin commands: \
+         key/down/up/type/click/move/cursor/size/cursor-show/wait/shot/quit"
+    );
     std::thread::spawn(move || run_commands(view_ptr));
 
     // The view needs the `AppKit` run loop to build its layer tree and receive
@@ -68,10 +78,21 @@ pub(crate) fn drive_view(mtm: MainThreadMarker, view: Retained<VZVirtualMachineV
     NSApplication::sharedApplication(mtm).run();
 }
 
+/// Mutable driver state carried across commands: the last pointer position this
+/// driver set (fractions, top-left), and whether `shot` draws a marker there.
+/// The pointer is absolute, so this is the source of truth for `cursor`; the
+/// guest is never queried back.
+#[derive(Default)]
+struct State {
+    last_cursor: Option<(f64, f64)>,
+    show_cursor: bool,
+}
+
 /// Read and execute commands until stdin closes or `quit` exits the process.
 fn run_commands(view_ptr: usize) -> ! {
     let stdin = std::io::stdin();
     let mut stdout = std::io::stdout();
+    let mut state = State::default();
     // `lines()` yields each line without its trailing newline; trailing spaces
     // are preserved so `type` can emit them.
     for line in stdin.lock().lines() {
@@ -80,15 +101,35 @@ fn run_commands(view_ptr: usize) -> ! {
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
-        let ack = execute(view_ptr, trimmed);
+        let ack = execute(view_ptr, trimmed, &mut state);
         let _ = writeln!(stdout, "{ack}");
         let _ = stdout.flush();
     }
     std::process::exit(0);
 }
 
+/// Parse a `<fx> <fy>` pair of display fractions, validating both are finite and
+/// within `0..=1` (the pointer is absolute, so an out-of-range fraction would
+/// land off-screen and silently no-op).
+fn parse_fraction_pair(
+    parts: &mut std::str::SplitWhitespace<'_>,
+    verb: &str,
+) -> Result<(f64, f64), String> {
+    let (Some(fx), Some(fy)) = (parts.next(), parts.next()) else {
+        return Err(format!("err {verb} needs two fractions 0..1 (from top-left)"));
+    };
+    let (Ok(fx), Ok(fy)) = (fx.parse::<f64>(), fy.parse::<f64>()) else {
+        return Err(format!("err {verb} fractions must be numbers 0..1 (from top-left)"));
+    };
+    if !(fx.is_finite() && fy.is_finite()) || !(0.0..=1.0).contains(&fx) || !(0.0..=1.0).contains(&fy)
+    {
+        return Err(format!("err {verb} fractions must be within 0..1 (from top-left)"));
+    }
+    Ok((fx, fy))
+}
+
 /// Execute one command line, returning its acknowledgement.
-fn execute(view_ptr: usize, trimmed: &str) -> String {
+fn execute(view_ptr: usize, trimmed: &str, state: &mut State) -> String {
     if let Some(text) = trimmed.strip_prefix("type ") {
         let (typed, skipped) = type_text(view_ptr, text);
         return if skipped == 0 {
@@ -99,7 +140,10 @@ fn execute(view_ptr: usize, trimmed: &str) -> String {
     }
     if let Some(path) = trimmed.strip_prefix("shot ") {
         let path = Path::new(path.trim());
-        return match shot(view_ptr, path) {
+        // Draw the pointer marker only when asked, so the default `shot` stays a
+        // faithful capture of the guest framebuffer (existing callers unchanged).
+        let cursor = state.show_cursor.then_some(state.last_cursor).flatten();
+        return match shot(view_ptr, path, cursor) {
             Ok(bytes) => format!("ok shot {} {bytes}", path.display()),
             Err(error) => format!("err shot {error}"),
         };
@@ -111,23 +155,53 @@ fn execute(view_ptr: usize, trimmed: &str) -> String {
     };
     match command {
         "click" => {
-            let (Some(fx), Some(fy)) = (parts.next(), parts.next()) else {
-                return "err click needs two fractions 0..1 (from top-left)".to_owned();
-            };
-            let (Ok(fx), Ok(fy)) = (fx.parse::<f64>(), fy.parse::<f64>()) else {
-                return "err click fractions must be numbers 0..1 (from top-left)".to_owned();
+            let (fx, fy) = match parse_fraction_pair(&mut parts, "click") {
+                Ok(pair) => pair,
+                Err(message) => return message,
             };
             on_main(view_ptr, move |view| {
-                let bounds = view.bounds();
-                let x = fx * bounds.size.width;
-                // Fraction is from the top; AppKit window coordinates are
-                // bottom-left origin, so flip y.
-                let y = fy.mul_add(-bounds.size.height, bounds.size.height);
+                let (x, y) = view_point(view, fx, fy);
                 input::click(view, x, y);
             });
+            state.last_cursor = Some((fx, fy));
             std::thread::sleep(KEY_GAP_AFTER);
             format!("ok click {fx} {fy}")
         }
+        "move" => {
+            let (fx, fy) = match parse_fraction_pair(&mut parts, "move") {
+                Ok(pair) => pair,
+                Err(message) => return message,
+            };
+            on_main(view_ptr, move |view| {
+                let (x, y) = view_point(view, fx, fy);
+                input::mouse_move(view, x, y);
+            });
+            state.last_cursor = Some((fx, fy));
+            std::thread::sleep(KEY_GAP_AFTER);
+            format!("ok move {fx} {fy}")
+        }
+        "cursor" => match state.last_cursor {
+            Some((fx, fy)) => format!("ok cursor {fx} {fy}"),
+            None => "err cursor unknown (no click/move yet)".to_owned(),
+        },
+        "size" => {
+            let size = frame_size(view_ptr);
+            match size {
+                Some((w, h)) => format!("ok size {w} {h}"),
+                None => "err size guest framebuffer not available yet".to_owned(),
+            }
+        }
+        "cursor-show" => match parts.next() {
+            Some("on") => {
+                state.show_cursor = true;
+                "ok cursor-show on".to_owned()
+            }
+            Some("off") => {
+                state.show_cursor = false;
+                "ok cursor-show off".to_owned()
+            }
+            _ => "err cursor-show needs on|off".to_owned(),
+        },
         "key" => {
             let Some(name) = parts.next() else {
                 return "err key needs a name".to_owned();
@@ -211,15 +285,40 @@ fn press_key(view_ptr: usize, code: u16, shift: bool) {
 }
 
 /// Screenshot the guest framebuffer on the main queue and return bytes written.
-fn shot(view_ptr: usize, path: &Path) -> Result<usize, Error> {
+/// `cursor` (display fractions, top-left) draws a pointer marker into the PNG
+/// when set, so a caller can see where the driver's pointer is.
+fn shot(view_ptr: usize, path: &Path, cursor: Option<(f64, f64)>) -> Result<usize, Error> {
     let mut result: Result<usize, Error> = Err(Error::NoFramebuffer);
     // `exec_sync` blocks until the block finishes, so borrowing `result` and
     // `path` across the queue boundary is sound (no `'static` needed).
     DispatchQueue::main().exec_sync(|| {
         let view: &VZVirtualMachineView = unsafe { &*(view_ptr as *const VZVirtualMachineView) };
-        result = capture(view, path);
+        result = capture(view, path, cursor);
     });
     result
+}
+
+/// The captured framebuffer size in pixels, read on the main queue. `None` until
+/// the guest has rendered a frame.
+fn frame_size(view_ptr: usize) -> Option<(usize, usize)> {
+    let mut size = None;
+    DispatchQueue::main().exec_sync(|| {
+        let view: &VZVirtualMachineView = unsafe { &*(view_ptr as *const VZVirtualMachineView) };
+        size = guest_frame_size(view);
+    });
+    size
+}
+
+/// Map display fractions `(fx, fy)` (top-left origin, `0..=1`) to a point in the
+/// view's `AppKit` window coordinates (bottom-left origin). Must run on the main
+/// thread (touches the view).
+fn view_point(view: &VZVirtualMachineView, fx: f64, fy: f64) -> (f64, f64) {
+    let bounds = view.bounds();
+    let x = fx * bounds.size.width;
+    // Fraction is from the top; AppKit window coordinates are bottom-left origin,
+    // so flip y.
+    let y = fy.mul_add(-bounds.size.height, bounds.size.height);
+    (x, y)
 }
 
 /// Run `f` on the main queue with a re-borrow of the leaked view, blocking until

--- a/packages/macos-vm/src/input.rs
+++ b/packages/macos-vm/src/input.rs
@@ -54,8 +54,20 @@ pub fn click(view: &VZVirtualMachineView, x: f64, y: f64) {
     send_mouse(view, NSEventType::LeftMouseUp, x, y, 0.0);
 }
 
+/// Move the guest cursor to view point `(x, y)` (`AppKit` window coordinates,
+/// bottom-left origin) without pressing a button. The screen-coordinate pointing
+/// device maps the location to the guest's absolute cursor, so the guest's own
+/// pointer jumps there. Lets a caller hover (revealing hover-state UI) and
+/// confirm a target before committing a click. Must run on the main thread.
+pub fn mouse_move(view: &VZVirtualMachineView, x: f64, y: f64) {
+    send_mouse(view, NSEventType::MouseMoved, x, y, 0.0);
+}
+
 fn send_mouse(view: &VZVirtualMachineView, event_type: NSEventType, x: f64, y: f64, pressure: f32) {
     let window_number = view.window().map_or(0, |window| window.windowNumber());
+    // A button press carries click count 1; a bare move (no button) is 0, which
+    // is what AppKit and the HID stack expect for a `mouseMoved:`.
+    let click_count = if event_type == NSEventType::MouseMoved { 0 } else { 1 };
     let event = NSEvent::mouseEventWithType_location_modifierFlags_timestamp_windowNumber_context_eventNumber_clickCount_pressure(
         event_type,
         NSPoint::new(x, y),
@@ -64,14 +76,14 @@ fn send_mouse(view: &VZVirtualMachineView, event_type: NSEventType, x: f64, y: f
         window_number,
         None,
         0,
-        1,
+        click_count,
         pressure,
     );
     let Some(event) = event else { return };
-    if event_type == NSEventType::LeftMouseDown {
-        view.mouseDown(&event);
-    } else {
-        view.mouseUp(&event);
+    match event_type {
+        NSEventType::LeftMouseDown => view.mouseDown(&event),
+        NSEventType::MouseMoved => view.mouseMoved(&event),
+        _ => view.mouseUp(&event),
     }
 }
 

--- a/packages/macos-vm/src/input.rs
+++ b/packages/macos-vm/src/input.rs
@@ -67,7 +67,7 @@ fn send_mouse(view: &VZVirtualMachineView, event_type: NSEventType, x: f64, y: f
     let window_number = view.window().map_or(0, |window| window.windowNumber());
     // A button press carries click count 1; a bare move (no button) is 0, which
     // is what AppKit and the HID stack expect for a `mouseMoved:`.
-    let click_count = if event_type == NSEventType::MouseMoved { 0 } else { 1 };
+    let click_count = isize::from(event_type != NSEventType::MouseMoved);
     let event = NSEvent::mouseEventWithType_location_modifierFlags_timestamp_windowNumber_context_eventNumber_clickCount_pressure(
         event_type,
         NSPoint::new(x, y),

--- a/packages/macos-vm/src/macguest.rs
+++ b/packages/macos-vm/src/macguest.rs
@@ -228,40 +228,45 @@ pub fn frame_size(view: &VZVirtualMachineView) -> Option<(usize, usize)> {
     Some((surface.width(), surface.height()))
 }
 
+/// Set one opaque RGBA pixel at `(x, y)` if it is in bounds. The casts are sound:
+/// `x`/`y` are compared against `width`/`height` before any cast, so the `usize`
+/// conversion only runs on non-negative, in-range values.
+#[allow(clippy::cast_sign_loss, clippy::cast_possible_wrap)]
+fn put_pixel(rgba: &mut [u8], width: usize, height: usize, x: isize, y: isize, rgb: [u8; 3]) {
+    if x < 0 || y < 0 || x >= width as isize || y >= height as isize {
+        return;
+    }
+    let o = (y as usize * width + x as usize) * 4;
+    rgba[o..o + 4].copy_from_slice(&[rgb[0], rgb[1], rgb[2], 255]);
+}
+
 /// Draw a high-contrast pointer marker (a red cross with a white halo) into the
 /// RGBA buffer at display fraction `(fx, fy)`, top-left origin. The synthetic
 /// pointing device's cursor is not always part of the captured scanout, so this
 /// shows a caller exactly where the driver's pointer is. Fully bounds-checked.
+/// The fraction-to-pixel casts are intentional rasterization rounding; `fx`/`fy`
+/// are display fractions the driver clamps to `0..=1`, so the result is in range.
+#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
 fn draw_cursor_marker(rgba: &mut [u8], width: usize, height: usize, fx: f64, fy: f64) {
-    if width == 0 || height == 0 {
-        return;
-    }
-    fn put(rgba: &mut [u8], width: usize, height: usize, x: isize, y: isize, rgb: [u8; 3]) {
-        if x < 0 || y < 0 || x >= width as isize || y >= height as isize {
-            return;
-        }
-        let o = (y as usize * width + x as usize) * 4;
-        rgba[o] = rgb[0];
-        rgba[o + 1] = rgb[1];
-        rgba[o + 2] = rgb[2];
-        rgba[o + 3] = 255;
-    }
-    let cx = (fx * width as f64).round() as isize;
-    let cy = (fy * height as f64).round() as isize;
     const ARM: isize = 10;
     const RED: [u8; 3] = [255, 40, 40];
     const WHITE: [u8; 3] = [255, 255, 255];
+    if width == 0 || height == 0 {
+        return;
+    }
+    let cx = (fx * width as f64).round() as isize;
+    let cy = (fy * height as f64).round() as isize;
     // White halo first (the cross one pixel thick on each side), so the red cross
     // stays visible over any background colour.
     for d in -ARM..=ARM {
         for off in [-1_isize, 1] {
-            put(rgba, width, height, cx + d, cy + off, WHITE);
-            put(rgba, width, height, cx + off, cy + d, WHITE);
+            put_pixel(rgba, width, height, cx + d, cy + off, WHITE);
+            put_pixel(rgba, width, height, cx + off, cy + d, WHITE);
         }
     }
     for d in -ARM..=ARM {
-        put(rgba, width, height, cx + d, cy, RED);
-        put(rgba, width, height, cx, cy + d, RED);
+        put_pixel(rgba, width, height, cx + d, cy, RED);
+        put_pixel(rgba, width, height, cx, cy + d, RED);
     }
 }
 

--- a/packages/macos-vm/src/macguest.rs
+++ b/packages/macos-vm/src/macguest.rs
@@ -197,7 +197,7 @@ pub(crate) fn schedule_captures(
                 // only touch it on the main queue.
                 let view: &VZVirtualMachineView =
                     unsafe { &*(view_ptr as *const VZVirtualMachineView) };
-                match capture(view, &p) {
+                match capture(view, &p, None) {
                     Ok(bytes) => eprintln!("macos-vm: wrote {bytes} bytes -> {}", p.display()),
                     Err(error) => eprintln!("macos-vm: capture: {error}"),
                 }
@@ -216,8 +216,62 @@ fn frame_contents(view: &VZVirtualMachineView) -> Option<Retained<AnyObject>> {
     unsafe { layer.contents() }
 }
 
-/// Read the framebuffer `IOSurface` (BGRA) and encode a PNG.
-pub fn capture(view: &VZVirtualMachineView, path: &Path) -> Result<usize, Error> {
+/// The captured framebuffer size in pixels (`(width, height)`), or `None` until
+/// the guest has rendered an `IOSurface`. The authoritative size for mapping
+/// display fractions to pixels (the configured display size and the actual
+/// scanout can differ once the guest picks a resolution).
+pub fn frame_size(view: &VZVirtualMachineView) -> Option<(usize, usize)> {
+    let contents = frame_contents(view)?;
+    let surface_obj: Retained<IOSurface> = contents.downcast::<IOSurface>().ok()?;
+    let surface: &IOSurfaceRef =
+        unsafe { &*Retained::as_ptr(&surface_obj).cast::<IOSurfaceRef>() };
+    Some((surface.width(), surface.height()))
+}
+
+/// Draw a high-contrast pointer marker (a red cross with a white halo) into the
+/// RGBA buffer at display fraction `(fx, fy)`, top-left origin. The synthetic
+/// pointing device's cursor is not always part of the captured scanout, so this
+/// shows a caller exactly where the driver's pointer is. Fully bounds-checked.
+fn draw_cursor_marker(rgba: &mut [u8], width: usize, height: usize, fx: f64, fy: f64) {
+    if width == 0 || height == 0 {
+        return;
+    }
+    fn put(rgba: &mut [u8], width: usize, height: usize, x: isize, y: isize, rgb: [u8; 3]) {
+        if x < 0 || y < 0 || x >= width as isize || y >= height as isize {
+            return;
+        }
+        let o = (y as usize * width + x as usize) * 4;
+        rgba[o] = rgb[0];
+        rgba[o + 1] = rgb[1];
+        rgba[o + 2] = rgb[2];
+        rgba[o + 3] = 255;
+    }
+    let cx = (fx * width as f64).round() as isize;
+    let cy = (fy * height as f64).round() as isize;
+    const ARM: isize = 10;
+    const RED: [u8; 3] = [255, 40, 40];
+    const WHITE: [u8; 3] = [255, 255, 255];
+    // White halo first (the cross one pixel thick on each side), so the red cross
+    // stays visible over any background colour.
+    for d in -ARM..=ARM {
+        for off in [-1_isize, 1] {
+            put(rgba, width, height, cx + d, cy + off, WHITE);
+            put(rgba, width, height, cx + off, cy + d, WHITE);
+        }
+    }
+    for d in -ARM..=ARM {
+        put(rgba, width, height, cx + d, cy, RED);
+        put(rgba, width, height, cx, cy + d, RED);
+    }
+}
+
+/// Read the framebuffer `IOSurface` (BGRA) and encode a PNG. With `cursor` set
+/// (display fractions, top-left), a pointer marker is drawn into the PNG.
+pub fn capture(
+    view: &VZVirtualMachineView,
+    path: &Path,
+    cursor: Option<(f64, f64)>,
+) -> Result<usize, Error> {
     let contents = frame_contents(view).ok_or(Error::NoFramebuffer)?;
     // Verify the layer contents really is an IOSurface before any unsafe access.
     let surface_obj: Retained<IOSurface> = contents
@@ -264,6 +318,10 @@ pub fn capture(view: &VZVirtualMachineView, path: &Path) -> Result<usize, Error>
             }
         }
         let _ = surface.unlock(IOSurfaceLockOptions::ReadOnly, std::ptr::null_mut());
+    }
+
+    if let Some((fx, fy)) = cursor {
+        draw_cursor_marker(&mut rgba, width, height, fx, fy);
     }
 
     let w = u32::try_from(width).map_err(|_| Error::CaptureEncode {

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -351,8 +351,8 @@ let
         export HOME=$TMPDIR/home
         mkdir -p "$HOME"
 
-        ix-mcp exec 'import macvm; print("macvm-ok", *(callable(getattr(macvm, n)) for n in ("info", "install", "provision", "stage_binary", "boot_linux", "boot_linux_gui", "drive_linux", "screenshot", "screenshot_many", "drive", "Driver", "run_app")))' >stdout 2>stderr
-        if ! grep -q '^macvm-ok True True True True True True True True True True True True$' stdout; then
+        ix-mcp exec 'import macvm; print("macvm-ok", *(callable(getattr(macvm, n)) for n in ("info", "install", "provision", "stage_binary", "boot_linux", "boot_linux_gui", "drive_linux", "screenshot", "screenshot_many", "drive", "Driver", "run_app", "run_binary", "run_oci", "login", "grid")))' >stdout 2>stderr
+        if ! grep -q '^macvm-ok True True True True True True True True True True True True True True True True$' stdout; then
           echo "macvm was not importable in a default session:" >&2
           cat stdout stderr >&2
           exit 1

--- a/packages/mcp/src/macvm/macvm/__init__.py
+++ b/packages/mcp/src/macvm/macvm/__init__.py
@@ -278,8 +278,9 @@ def provision(
         raise MacVmError(f"provision timed out after {timeout}s") from exc
     if result.returncode != 0:
         raise MacVmError(f"provision failed: {result.stderr.strip()}")
-    # Record the credential beside the bundle so `login`/`run_app` can recover it
-    # without spelunking. Only when a password was given (autologin path).
+    # Record the credential beside the bundle whenever one was provided, so a
+    # later session's login()/run_app can recover it without spelunking (not only
+    # on the autologin path: a caller may record the password for login() use).
     if password:
         _write_bundle_login(bundle, user, password)
 
@@ -289,15 +290,25 @@ def _bundle_login_path(bundle: str | os.PathLike) -> pathlib.Path:
 
 
 def _write_bundle_login(bundle: str | os.PathLike, user: str, password: str) -> None:
-    """Persist ``{user, password}`` to ``<bundle>/login.json`` (mode 0600)."""
+    """Persist ``{user, password}`` to ``<bundle>/login.json`` at mode 0600.
+
+    Created 0600 from the start (no world-readable window before a later chmod),
+    since the file holds a plaintext password."""
     import json
 
     path = _bundle_login_path(bundle)
-    path.write_text(json.dumps({"user": user, "password": password}))
+    data = json.dumps({"user": user, "password": password})
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
-        os.chmod(path, 0o600)
-    except OSError:
-        pass
+        with os.fdopen(fd, "w") as handle:
+            handle.write(data)
+    finally:
+        # If the file pre-existed with looser bits, O_CREAT did not change them;
+        # narrow them now.
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
 
 
 def _bundle_login(bundle: str | os.PathLike | None) -> dict[str, str] | None:
@@ -342,6 +353,10 @@ def login(
             "no password for login (pass password=, or provision the bundle so "
             "login.json records it)"
         )
+    if "\n" in password or "\r" in password:
+        # `type_` sends one stdin line; a newline would split it and desync every
+        # subsequent ack.
+        raise MacVmError("login password must not contain a newline")
     before = driver.shot()
     driver.click(*field)
     driver.type_(password)
@@ -799,7 +814,10 @@ class Driver:
         if self._size is None:
             ack = self.send("size")  # 'ok size W H'
             parts = ack.split()
-            self._size = (int(parts[2]), int(parts[3]))
+            w, h = int(parts[2]), int(parts[3])
+            if w <= 0 or h <= 0:
+                raise MacVmError(f"guest reported a non-positive framebuffer size ({w}x{h})")
+            self._size = (w, h)
         return self._size
 
     def show_cursor(self, on: bool = True) -> str:

--- a/packages/mcp/src/macvm/macvm/__init__.py
+++ b/packages/mcp/src/macvm/macvm/__init__.py
@@ -102,10 +102,14 @@ __all__ = [
     "boot_linux_gui",
     "drive",
     "drive_linux",
+    "grid",
     "info",
     "install",
+    "login",
     "provision",
     "run_app",
+    "run_binary",
+    "run_oci",
     "screenshot",
     "screenshot_many",
     "stage_binary",
@@ -180,10 +184,12 @@ def stage_binary(
     ``@loader_path`` reference, then ad-hoc re-signs the result. It verifies no
     ``/nix/store`` path remains and raises :class:`MacVmError` otherwise.
 
-    With ``out`` omitted, the staged binary is written to a temp directory under
-    the same basename and that path is returned; pass ``out`` to choose the
-    location (its parent directory is created). Use the staged directory as the
-    ``app_dir`` for :func:`run_app` so a guest can run the app.
+    Returns the staged binary's path, which is a *file*, not a directory. With
+    ``out`` omitted it is written under a fresh temp directory using the same
+    basename; pass ``out`` to choose the path (its parent is created). Note that
+    :func:`run_app` shares a *directory*, so to run a staged binary either share
+    its parent directory or, simpler, use :func:`run_binary`, which stages and
+    runs in one call.
     """
     src = pathlib.Path(path)
     if out is None:
@@ -225,13 +231,25 @@ def provision(
 
     A host-side disk edit (the guest must not be running): it attaches the
     bundle's ``disk.img``, marks system and per-user Setup Assistant complete for
-    ``user`` (the account created during :func:`install`), and detaches. With
-    ``autologin`` it also enables password-less login for ``user`` (``password``
-    is only used to encode the auto-login secret; default empty). The password is
-    passed to the binary over stdin, never as a command-line argument, so it does
-    not appear in the process table. Raises :class:`MacVmError` on failure,
-    including if the image already appears in use.
-    """
+    ``user`` (the account created during :func:`install`), and detaches.
+
+    With ``autologin`` the guest boots straight to ``user``'s desktop with no
+    password prompt. This is the deterministic path, and it requires the *real*
+    account password (the one set for ``user`` during install/Setup Assistant):
+    macOS encodes it into ``/etc/kcpassword`` and auto-login fails to a login
+    window if it does not match (a blank password never auto-logs in). The
+    password is passed over stdin, never as an argument, so it stays out of the
+    process table.
+
+    The credential is also recorded in ``<bundle>/login.json`` (mode 0600) so a
+    later session can drive the guest with :func:`login` without rediscovering
+    it. Raises :class:`MacVmError` on failure, including if the image already
+    appears in use, or if ``autologin`` is set without a password."""
+    if autologin and not password:
+        raise MacVmError(
+            "autologin needs the account's real password (a blank password does "
+            "not auto-log in); pass password=..."
+        )
     args = [
         _binary(),
         "provision",
@@ -260,6 +278,82 @@ def provision(
         raise MacVmError(f"provision timed out after {timeout}s") from exc
     if result.returncode != 0:
         raise MacVmError(f"provision failed: {result.stderr.strip()}")
+    # Record the credential beside the bundle so `login`/`run_app` can recover it
+    # without spelunking. Only when a password was given (autologin path).
+    if password:
+        _write_bundle_login(bundle, user, password)
+
+
+def _bundle_login_path(bundle: str | os.PathLike) -> pathlib.Path:
+    return pathlib.Path(os.fspath(bundle)) / "login.json"
+
+
+def _write_bundle_login(bundle: str | os.PathLike, user: str, password: str) -> None:
+    """Persist ``{user, password}`` to ``<bundle>/login.json`` (mode 0600)."""
+    import json
+
+    path = _bundle_login_path(bundle)
+    path.write_text(json.dumps({"user": user, "password": password}))
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def _bundle_login(bundle: str | os.PathLike | None) -> dict[str, str] | None:
+    """Read ``<bundle>/login.json`` if present, else ``None``."""
+    if bundle is None:
+        return None
+    import json
+
+    path = _bundle_login_path(bundle)
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def login(
+    driver: "Driver",
+    password: str | None = None,
+    *,
+    field: tuple[float, float] = (0.5, 0.83),
+    settle: float = 8.0,
+) -> None:
+    """Log a guest in at the macOS login window through an open :class:`Driver`.
+
+    For a bundle that is *not* set up for auto-login (see :func:`provision`), call
+    this once the guest has reached the login window: it focuses the password
+    field at fraction ``field``, types the password, presses Return, waits
+    ``settle`` for the desktop, and verifies the screen changed. ``password``
+    falls back to ``<bundle>/login.json`` (written by :func:`provision`). Raises
+    :class:`MacVmError` if no password is available or the screen did not change
+    (wrong password, or the guest was not at the login window).
+
+    This types the password, so only call it when the guest is actually at the
+    login window. A provisioned auto-login bundle reaches the desktop on its own
+    and needs no :func:`login` call."""
+    if password is None:
+        creds = _bundle_login(driver._bundle)
+        password = creds.get("password") if creds else None
+    if not password:
+        raise MacVmError(
+            "no password for login (pass password=, or provision the bundle so "
+            "login.json records it)"
+        )
+    before = driver.shot()
+    driver.click(*field)
+    driver.type_(password)
+    driver.key("return")
+    if settle > 0:
+        driver.wait(settle)
+    after = driver.shot()
+    if not _frames_differ(before, after, 0.02):
+        raise MacVmError(
+            "login did not change the screen (wrong password, or the guest was "
+            "not at the login window)"
+        )
 
 
 def screenshot(
@@ -551,6 +645,8 @@ class Driver:
         self._shares = list(shares) if shares else []
         self.timeout = timeout
         self._proc: subprocess.Popen[str] | None = None
+        # Cached captured-framebuffer size in pixels (see `size()`).
+        self._size: tuple[int, int] | None = None
 
     def __enter__(self) -> "Driver":
         bin_path = _binary()
@@ -678,6 +774,80 @@ class Driver:
         (resolution-independent, both in ``0..1``)."""
         return self.send(f"click {fx} {fy}")
 
+    def move(self, fx: float, fy: float) -> str:
+        """Move the pointer to fraction ``(fx, fy)`` of the display (top-left,
+        both ``0..1``) without clicking, so hover-state UI appears and a target
+        can be confirmed before committing a :meth:`click`."""
+        return self.send(f"move {fx} {fy}")
+
+    # `hover` reads better than `move` at some call sites; same command.
+    hover = move
+
+    def cursor(self) -> tuple[float, float]:
+        """Return the last pointer fraction this driver set with
+        :meth:`click`/:meth:`move` (top-left, ``0..1``). The pointer is absolute,
+        so this is the driver's own record, not a guest read-back. Raises
+        :class:`MacVmError` if no pointer command has run yet."""
+        ack = self.send("cursor")  # 'ok cursor FX FY'
+        parts = ack.split()
+        return (float(parts[2]), float(parts[3]))
+
+    def size(self) -> tuple[int, int]:
+        """Return the captured framebuffer size in pixels ``(width, height)``,
+        cached after the first call. The authoritative size for pixel<->fraction
+        conversion (the configured and actual display sizes can differ)."""
+        if self._size is None:
+            ack = self.send("size")  # 'ok size W H'
+            parts = ack.split()
+            self._size = (int(parts[2]), int(parts[3]))
+        return self._size
+
+    def show_cursor(self, on: bool = True) -> str:
+        """Toggle drawing a pointer marker into subsequent :meth:`shot`s. Off by
+        default, so a plain ``shot`` stays a faithful framebuffer capture."""
+        return self.send(f"cursor-show {'on' if on else 'off'}")
+
+    def click_px(self, x: int, y: int) -> str:
+        """Left-click at pixel ``(x, y)`` of the captured framebuffer (top-left).
+        Converts to a fraction via :meth:`size`."""
+        w, h = self.size()
+        return self.click(x / w, y / h)
+
+    def move_px(self, x: int, y: int) -> str:
+        """Move the pointer to pixel ``(x, y)`` of the captured framebuffer
+        (top-left) without clicking. Converts to a fraction via :meth:`size`."""
+        w, h = self.size()
+        return self.move(x / w, y / h)
+
+    def click_and_verify(
+        self,
+        fx: float,
+        fy: float,
+        *,
+        settle: float = 0.4,
+        min_changed: float = 0.002,
+    ) -> bool:
+        """Click at ``(fx, fy)`` and report whether the display changed.
+
+        Positions the pointer first, captures, clicks, waits ``settle`` for the
+        UI to react, captures again, and returns ``True`` if at least
+        ``min_changed`` (fraction of pixels) differ notably. Turns a missed click
+        (a wrong target, a no-op) into an observable ``False`` instead of a silent
+        nothing. This is a heuristic: it moves the pointer to the target before
+        both captures so the cursor is identical in each (otherwise a moved cursor
+        always reads as change), but a screensaver, idle-dim, or an unrelated
+        animation can still register; tune ``min_changed`` for the surface."""
+        # Move first so the pointer sits at the target in both frames; only the
+        # click's effect differs, not the cursor's position.
+        self.move(fx, fy)
+        self.wait(0.15)
+        before = self.shot()
+        self.click(fx, fy)
+        if settle > 0:
+            self.wait(settle)
+        after = self.shot()
+        return _frames_differ(before, after, min_changed)
+
     def wait(self, seconds: float) -> str:
         """Sleep ``seconds`` in the guest driver (fractional allowed)."""
         return self.send(f"wait {seconds}")
@@ -749,6 +919,7 @@ def run_app(
     seconds: float = 15,
     shares_tag: str = "auto",
     boot_seconds: float = 30,
+    login_password: str | None = None,
     timeout: float = 300,
 ) -> "Image.Image":
     """Share a host directory into a guest, launch a command in it, and return a
@@ -770,10 +941,13 @@ def run_app(
 
     ``boot_seconds`` is how long to wait after boot before driving (the guest
     must reach the desktop); ``seconds`` is how long to wait after launching the
-    command before capturing. ``timeout`` bounds the whole driver session. The
-    guest must already be provisioned to a logged-in desktop (see
-    :func:`provision`). Raises :class:`MacVmError` on failure, including if
-    ``command`` contains a newline.
+    command before capturing. ``timeout`` bounds the whole driver session.
+
+    The guest must reach a logged-in desktop. A bundle provisioned with
+    ``autologin`` does this on its own; for a bundle that stops at the login
+    window, pass ``login_password`` (or persist it via :func:`provision`) and
+    this logs in first via :func:`login`. Raises :class:`MacVmError` on failure,
+    including if ``command`` contains a newline.
     """
     # A newline in `command` would split the driver's `type` line into two stdin
     # commands, desyncing every subsequent ack. Reject it up front rather than
@@ -792,9 +966,12 @@ def run_app(
         mount = ""
 
     with Driver(bundle, shares=[share_spec], timeout=timeout) as d:
-        # Let the guest reach the desktop before driving it.
+        # Let the guest reach the desktop (or the login window) before driving it.
         if boot_seconds > 0:
             d.wait(boot_seconds)
+        # A non-autologin bundle stops at the login window; log in first.
+        if login_password is not None:
+            login(d, login_password)
         # Open Spotlight, search for Terminal, launch it.
         d.press_down("cmd")
         d.key("space")
@@ -819,6 +996,137 @@ def run_app(
         return d.shot()
 
 
+def run_binary(
+    bundle: str | os.PathLike,
+    host_binary: str | os.PathLike,
+    args: str = "",
+    *,
+    name: str | None = None,
+    **run_app_kwargs: object,
+) -> "Image.Image":
+    """Stage a nix-built macOS binary guest-portable, run it in the guest, and
+    return a frame of the display: :func:`stage_binary` + :func:`run_app` in one
+    call.
+
+    :func:`stage_binary` writes a single *file*, but :func:`run_app` shares a
+    *directory*; this stages ``host_binary`` into a fresh directory, shares that
+    directory in, and launches the binary from it in the background, so a caller
+    never has to juggle the file-vs-directory handoff. ``args`` is appended to the
+    launch command (already shell-safe for the binary path; quote your own args).
+    ``name`` overrides the in-guest binary name (default: the host basename).
+    Extra keyword arguments pass through to :func:`run_app` (``seconds``,
+    ``boot_seconds``, ``timeout``). Raises :class:`MacVmError` on failure."""
+    src = pathlib.Path(os.fspath(host_binary))
+    app_name = name or src.name
+    # The shared directory must outlive staging but not the call: the guest only
+    # needs it while the Driver session in run_app is alive, so clean it after.
+    staged_dir = tempfile.mkdtemp(prefix="ix-macvm-app-")
+    try:
+        stage_binary(str(src), str(pathlib.Path(staged_dir) / app_name))
+        launch = _shell_quote(f"./{app_name}")
+        if args:
+            launch += f" {args}"
+        # Background it (and drop its output) so the guest shell stays responsive
+        # while we wait for the app to render, then capture.
+        command = f"{launch} >/tmp/ix-run-binary.log 2>&1 &"
+        return run_app(bundle, staged_dir, command, **run_app_kwargs)  # type: ignore[arg-type]
+    finally:
+        shutil.rmtree(staged_dir, ignore_errors=True)
+
+
+def run_oci(
+    disk: str | os.PathLike,
+    *,
+    kernel: str | os.PathLike | None = None,
+    initramfs: str | os.PathLike | None = None,
+    cmdline: str = "console=hvc0",
+    gui: bool = False,
+    seconds: int | None = None,
+    require_aarch64: bool = True,
+    **kwargs: object,
+) -> "str | Image.Image":
+    """Boot a flattened OCI / Linux guest in the VZ Linux VM, the generic entry
+    point over :func:`boot_linux` (headless) and :func:`boot_linux_gui` (GUI).
+
+    VZ runs *same-architecture* Linux guests only, so this host (aarch64) boots
+    aarch64 images; ``require_aarch64`` guards that with a typed error rather than
+    a confusing boot failure (set it false only if you know what you are doing).
+
+    - ``gui=False`` (default): headless boot of a flattened rootfs ``disk`` as
+      ``/dev/vda``. Needs ``kernel`` and ``initramfs`` (an initramfs that mounts
+      the rootfs, e.g. the artifacts built by the ``macos-vm`` package's
+      ``examples/oci-boot.sh``). Returns the guest serial console as ``str``.
+    - ``gui=True``: boot an EFI GUI ``disk`` (e.g. the ``vz-linux-guest`` image)
+      and return a ``PIL.Image`` of the framebuffer.
+
+    Turning an OCI *reference* into the rootfs (plus kernel/initramfs) is the
+    flatten step the package deliberately leaves to ``oci-boot.sh`` / a future
+    ``.#vm-run`` (see ``docs/oci-guest.md``); this owns the boot. Extra keyword
+    arguments pass through to the underlying boot function. Raises
+    :class:`MacVmError` on an arch mismatch or a missing kernel/initramfs."""
+    import platform
+
+    if require_aarch64 and not platform.machine().lower().startswith(("arm64", "aarch64")):
+        raise MacVmError(
+            f"run_oci needs an aarch64 host (this is {platform.machine()}); VZ runs "
+            "same-architecture Linux guests"
+        )
+    extra = dict(kwargs)
+    if seconds is not None:
+        extra["seconds"] = seconds
+    if gui:
+        return boot_linux_gui(disk, **extra)  # type: ignore[arg-type]
+    if kernel is None or initramfs is None:
+        raise MacVmError(
+            "headless run_oci needs kernel= and initramfs= (an initramfs that "
+            "mounts the rootfs as /dev/vda); see the macos-vm package's "
+            "examples/oci-boot.sh"
+        )
+    return boot_linux(kernel, initramfs, disks=[disk], cmdline=cmdline, **extra)  # type: ignore[arg-type]
+
+
 def _shell_quote(path: str) -> str:
     """Single-quote a path for a guest POSIX shell (the driver types it as-is)."""
     return "'" + path.replace("'", "'\\''") + "'"
+
+
+def _frames_differ(before: "Image.Image", after: "Image.Image", min_changed: float) -> bool:
+    """Whether two frames differ in at least ``min_changed`` (fraction) of pixels.
+
+    A per-pixel threshold first (ignoring tiny noise like antialiasing or a
+    blinking caret), then a histogram count of the pixels that crossed it.
+    """
+    from PIL import ImageChops
+
+    a = before.convert("RGB")
+    b = after.convert("RGB")
+    if a.size != b.size:
+        b = b.resize(a.size)
+    diff = ImageChops.difference(a, b).convert("L").point(lambda p: 255 if p > 24 else 0)
+    changed = diff.histogram()[-1]  # count of pixels at 255 (crossed the threshold)
+    total = diff.width * diff.height
+    return total > 0 and changed / total >= min_changed
+
+
+def grid(image: "Image.Image", n: int = 10) -> "Image.Image":
+    """Return a copy of ``image`` with a labelled fraction grid drawn on top.
+
+    A calibration aid for clicking: every line is annotated with its ``0..1``
+    fraction (the same coordinate space :class:`Driver` ``click``/``move`` take),
+    so a target's fraction can be read straight off a captured frame. ``n`` is
+    the number of divisions per axis (default 10, i.e. every 0.1)."""
+    from PIL import ImageDraw
+
+    out = image.convert("RGB").copy()
+    draw = ImageDraw.Draw(out)
+    w, h = out.size
+    line = (255, 40, 40)
+    for i in range(1, n):
+        f = i / n
+        x = round(f * w)
+        y = round(f * h)
+        draw.line([(x, 0), (x, h)], fill=line, width=1)
+        draw.line([(0, y), (w, y)], fill=line, width=1)
+        draw.text((x + 2, 2), f"{f:.1f}", fill=line)
+        draw.text((2, y + 2), f"{f:.1f}", fill=line)
+    return out


### PR DESCRIPTION
Fixes the four VM-testing/ergonomics issues that surfaced while running the `book-overlay` inside a guest: #473, #474, #475, #476. Everything below was validated end to end on an installed macOS guest, fully off-screen.

## #476 closed-loop clicking
The driver was open-loop (only `click`), so hitting a small target meant reverse-engineering pixel geometry. Now:
- New stdin verbs: `move`/`cursor`/`size`/`cursor-show`; `click`/`move` validate fractions to `0..1`.
- `input::mouse_move` sends a button-less `MouseMoved`; `capture()` can draw a high-contrast pointer marker into the PNG (opt-in via `cursor-show on`, so the default `shot` stays a faithful framebuffer); `frame_size()` reads the real scanout size.
- `Driver` gains `move`/`hover`, `cursor()`, `size()`, `show_cursor()`, `click_px`/`move_px`, and `click_and_verify()` (moves the pointer first so only the click's effect differs, not the cursor's position), plus a pure-PIL `grid()` calibration overlay.
- Validated: `size()`=(2048,1152); `move`/`cursor` round-trip; the marker renders as a 41-px crosshair at the target; `click_and_verify` returns False on an inert spot and True when Spotlight opens.

## #474 stage_binary / run_app file-vs-dir trap
`stage_binary` writes a *file* but `run_app` shares a *directory*. Added `run_binary()` (stage into a fresh dir, share, launch, screenshot in one call) and corrected the `stage_binary` docstring. Validated: a staged `book-overlay` renders from the share.

## #473 deterministic login
The guest stalled at the login window because `provision` wrote a blank `kcpassword`, which never auto-logs in. Now `provision()` requires the account's real password for autologin and persists the credential to `<bundle>/login.json`; added `login()` (frame-change-verified) and a `login_password` path through `run_app` for non-autologin bundles. Validated: the guest now boots straight to the desktop.

## #475 generic run-OCI-in-VM
Added `run_oci()`: an arch-checked entry point over `boot_linux` (headless rootfs) and `boot_linux_gui` (EFI disk) that refuses a non-aarch64 host with a typed error. Validated: the arch gate and missing-kernel paths raise the right errors.

## Scoped follow-ups (deliberately not in this PR)
- **#473 offline account *creation*** (install with no SA-created account): `dslocal` is `root:0700`, so a non-root provision mount cannot write it. Confirmed empirically. Needs privileged provisioning; tracked on #473.
- **#475 OCI-reference -> rootfs flatten pipeline** and a reproducible `.#vm-run` app: deliberately left to `examples/oci-boot.sh` / future work per `docs/oci-guest.md` (which delegates container runtime to libkrun/krunkit). This PR owns the boot, not the flatten.

## Validation
- ✅ `nix build .#macos-vm`
- ✅ macvm module imports; all 16 callables resolve (`macvmBundled` check updated to assert them)
- ✅ e2e on a real macOS guest as described above

Made with assistance from Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add closed-loop driving, `run_binary`, `run_oci`, and deterministic login to macvm
> - Adds `move`, `cursor`, `size`, and `cursor-show` commands to the drive protocol in [drive.rs](https://github.com/indexable-inc/index/pull/477/files#diff-9bce8aaf3c940d78f407c66cbd6979c6f45d793000f2e75e2416f8a8a7b16572), enabling pointer movement without clicking and framebuffer introspection.
> - Adds `mouse_move` to [input.rs](https://github.com/indexable-inc/index/pull/477/files#diff-f6fabb00d36a0b17a7d76aa331064f68422e675c8584f2849135ce6b1fc0b0a3) to send `MouseMoved` events without button presses, routed correctly via `mouseMoved`.
> - Extends `capture` in [macguest.rs](https://github.com/indexable-inc/index/pull/477/files#diff-bf375e8c838424f343aea16a54b5727288a85d2fc009d75e928c51a796933b94) to optionally draw a red-cross cursor marker into screenshot PNGs at a given display fraction.
> - Adds `login` to [macvm/__init__.py](https://github.com/indexable-inc/index/pull/477/files#diff-4b9daaeca5c33e547724daa485bc9d8c0851d6a70a0fc0b49ac3fc9cbc0e3ff9) to programmatically authenticate at the macOS login window using image-diff verification; credentials are persisted to `login.json` (mode 0600) during provisioning.
> - Adds `run_binary` to stage and execute a host binary inside the guest, and `run_oci` as a single entrypoint to boot OCI Linux guests (GUI or headless). Also adds `Driver.click_and_verify`, `Driver.move`, `Driver.size`, and a `grid` annotation utility.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b2c198.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->