### PR TITLE
overlay: hover for background overlays; macvm: pointer glide + visible cursor marker; book Dock clearance

### DIFF
--- a/packages/bossbar-overlay/app/Cargo.toml
+++ b/packages/bossbar-overlay/app/Cargo.toml
@@ -54,6 +54,7 @@ objc2-app-kit = { version = "0.2.2", features = [
   "NSMenu",
   "NSMenuItem",
   "NSResponder",
+  "NSScreen",
   "NSTrackingArea",
   "NSView",
   "NSWindow",

--- a/packages/bossbar-overlay/app/Cargo.toml
+++ b/packages/bossbar-overlay/app/Cargo.toml
@@ -34,13 +34,17 @@ dirs = "6"
 glam = "0.30"
 # macOS AppKit, reached through the raw window handle for two things winit has no
 # API for: raise a hovered window above its always-on-top siblings without taking
-# keyboard focus (`-[NSWindow orderFrontRegardless]`), and a right-click context
-# menu to close an overlay (`NSMenu`/`NSMenuItem`/`NSEvent`). These features/version
-# are a subset of what winit 0.30 already enables, so this pulls in no extra crate.
+# keyboard focus (`-[NSWindow orderFrontRegardless]`), a right-click context menu
+# to close an overlay (`NSMenu`/`NSMenuItem`/`NSEvent`), and an always-active
+# `NSTrackingArea` so a background overlay still receives hover. These
+# features/version are a subset of what winit 0.30 already enables, so this pulls
+# in no extra crate.
 objc2 = "0.5"
 # NSString for menu labels, NSThread for `MainThreadMarker`, NSObjCRuntime for
-# `NSObjectProtocol` (declared here rather than relying on winit's feature unification).
+# `NSObjectProtocol`, NSGeometry for `NSRect`/`NSPoint`/`NSSize` (declared here
+# rather than relying on winit's feature unification).
 objc2-foundation = { version = "0.2.2", features = [
+  "NSGeometry",
   "NSObjCRuntime",
   "NSString",
   "NSThread",
@@ -50,6 +54,7 @@ objc2-app-kit = { version = "0.2.2", features = [
   "NSMenu",
   "NSMenuItem",
   "NSResponder",
+  "NSTrackingArea",
   "NSView",
   "NSWindow",
 ] }

--- a/packages/bossbar-overlay/app/crates/book/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/book/src/overlay.rs
@@ -162,6 +162,10 @@ impl App {
                 return;
             }
         };
+        // The book is an accessory (background) window, so hover only reaches it
+        // with an always-active tracking area; without this the page-turn arrows
+        // never highlight while another app is focused.
+        ocwin::enable_background_hover(&window);
 
         let surface = self
             .instance

--- a/packages/bossbar-overlay/app/crates/book/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/book/src/overlay.rs
@@ -400,13 +400,17 @@ impl ApplicationHandler<Book> for App {
             }
             WindowEvent::RedrawRequested => self.render(),
             WindowEvent::CursorEntered { .. } => {
-                if let Some(win) = self.win.as_ref() {
-                    win.window.set_cursor(CursorIcon::Grab);
-                    ocwin::raise_to_front(&win.window);
-                }
+                // winit's own tracking rect and the always-active NSTrackingArea
+                // (enable_background_hover) both deliver mouseEntered:, so this can
+                // arrive twice per crossing; act only on the first to avoid a
+                // redundant raise/redraw.
                 if let Some(win) = self.win.as_mut() {
-                    win.hovered = true;
-                    win.window.request_redraw();
+                    if !win.hovered {
+                        win.hovered = true;
+                        win.window.set_cursor(CursorIcon::Grab);
+                        win.window.request_redraw();
+                        ocwin::raise_to_front(&win.window);
+                    }
                 }
             }
             WindowEvent::CursorLeft { .. } => {

--- a/packages/bossbar-overlay/app/crates/book/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/book/src/overlay.rs
@@ -135,14 +135,21 @@ fn arrow_under(
 }
 
 impl App {
-    /// Auto-centered window position (logical points) for the spread.
+    /// Auto-centered window position (logical points) for the spread, within the
+    /// screen's usable area so the book and its bottom page-turn arrows clear the
+    /// menu bar and Dock. Falls back to the full display if the visible frame is
+    /// unavailable. When the spread is larger than the usable area (a small
+    /// display at a high scale) the offset clamps to zero, pinning it just below
+    /// the menu bar rather than centering it under the bar.
     fn center_pos(&self) -> LogicalPosition<f64> {
         let (w_px, h_px) = scene::spread_window_px(self.scale);
         let wl = w_px as f64 / self.scale_factor;
         let hl = h_px as f64 / self.scale_factor;
+        let (left, top, vw, vh) = ocwin::visible_frame_logical()
+            .unwrap_or((0.0, 0.0, self.mon_logical.0, self.mon_logical.1));
         LogicalPosition::new(
-            ((self.mon_logical.0 - wl) * 0.5).max(0.0),
-            ((self.mon_logical.1 - hl) * 0.5).max(0.0),
+            left + ((vw - wl) * 0.5).max(0.0),
+            top + ((vh - hl) * 0.5).max(0.0),
         )
     }
 

--- a/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
@@ -215,6 +215,9 @@ impl App {
         };
         let attrs = ocwin::float_attributes("Boss Bar", w_px, h_px, Some(pos));
         let window = Arc::new(event_loop.create_window(attrs).ok()?);
+        // Each bar is a background window, so hover (grow + breathe + description
+        // panel) only reaches it through an always-active tracking area.
+        ocwin::enable_background_hover(&window);
         let (surface, config) = self.make_surface(&window);
         window.request_redraw();
         let has_description = !bar.description.trim().is_empty();

--- a/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
@@ -467,14 +467,23 @@ impl ApplicationHandler<Vec<BossBar>> for App {
             }
             WindowEvent::RedrawRequested => self.render_id(id),
             WindowEvent::CursorEntered { .. } => {
-                if let Some(win) = self.wins.get_mut(&id) {
-                    win.hovered = true;
-                    win.window.set_cursor(CursorIcon::Grab);
-                    // Bring this bar above its siblings so its pop-down panel covers
-                    // them instead of unfolding underneath.
-                    ocwin::raise_to_front(&win.window);
+                // winit's own tracking rect and the always-active NSTrackingArea
+                // (enable_background_hover) both deliver mouseEntered:, so this can
+                // arrive twice per crossing; act only on the first.
+                let entered = self.wins.get_mut(&id).is_some_and(|win| {
+                    let first = !win.hovered;
+                    if first {
+                        win.hovered = true;
+                        win.window.set_cursor(CursorIcon::Grab);
+                        // Bring this bar above its siblings so its pop-down panel
+                        // covers them instead of unfolding underneath.
+                        ocwin::raise_to_front(&win.window);
+                    }
+                    first
+                });
+                if entered {
+                    self.render_id(id);
                 }
-                self.render_id(id);
             }
             WindowEvent::CursorLeft { .. } => {
                 if let Some(win) = self.wins.get_mut(&id) {

--- a/packages/bossbar-overlay/app/crates/overlay-core/src/window.rs
+++ b/packages/bossbar-overlay/app/crates/overlay-core/src/window.rs
@@ -185,6 +185,9 @@ pub fn enable_background_hover(window: &Window) {
     // thread inside the winit event loop, as these AppKit types require. The same
     // pointer yields both the typed `&NSView` (to add the area) and the
     // `&AnyObject` owner the area records (that view, which handles the events).
+    // The two shared `&` borrows aliasing one Objective-C object is sound: objc2
+    // objects are interior-mutable, so `&`-aliasing carries no exclusivity claim
+    // (this mirrors `raise_to_front` above).
     let view: &NSView = unsafe { appkit.ns_view.cast().as_ref() };
     let owner: &AnyObject = unsafe { appkit.ns_view.cast().as_ref() };
 

--- a/packages/bossbar-overlay/app/crates/overlay-core/src/window.rs
+++ b/packages/bossbar-overlay/app/crates/overlay-core/src/window.rs
@@ -218,3 +218,29 @@ pub fn enable_background_hover(window: &Window) {
 /// active-app gate, so winit's default tracking already drives hover.
 #[cfg(not(target_os = "macos"))]
 pub fn enable_background_hover(_window: &Window) {}
+
+/// The main screen's usable area (excluding the menu bar and Dock) in winit's
+/// top-left logical points as `(left, top, width, height)`, or `None` off macOS
+/// or with no screen. Auto-placing an overlay within this rather than the full
+/// display keeps it clear of the menu bar and Dock.
+#[cfg(target_os = "macos")]
+pub fn visible_frame_logical() -> Option<(f64, f64, f64, f64)> {
+    use objc2_app_kit::NSScreen;
+    use objc2_foundation::MainThreadMarker;
+
+    // AppKit screen geometry is main-thread only; we are called from the winit
+    // event loop, which is the main thread. Decline rather than risk UB if not.
+    let mtm = MainThreadMarker::new()?;
+    let screen = NSScreen::mainScreen(mtm)?;
+    let full = screen.frame();
+    let visible = screen.visibleFrame();
+    // Cocoa frames use a bottom-left origin; convert the visible region's top edge
+    // to a top-left inset (the menu bar height) for winit's coordinate space.
+    let top = full.size.height - (visible.origin.y + visible.size.height);
+    Some((visible.origin.x, top, visible.size.width, visible.size.height))
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn visible_frame_logical() -> Option<(f64, f64, f64, f64)> {
+    None
+}

--- a/packages/bossbar-overlay/app/crates/overlay-core/src/window.rs
+++ b/packages/bossbar-overlay/app/crates/overlay-core/src/window.rs
@@ -150,3 +150,71 @@ pub fn raise_to_front(window: &Window) {
 /// same-level always-on-top windows, so stacking is left to the compositor.
 #[cfg(not(target_os = "macos"))]
 pub fn raise_to_front(_window: &Window) {}
+
+/// Make `window` react to pointer hover even when another application is the
+/// active one. An overlay runs under the Accessory activation policy, so it is
+/// never the active app and never owns a key window. winit's built-in mouse
+/// tracking uses a legacy `addTrackingRect:`, whose `mouseEntered:` /
+/// `mouseMoved:` / `mouseExited:` only reach the active app's key window, so a
+/// background overlay receives no `CursorEntered`/`CursorMoved`/`CursorLeft` and
+/// its hover state (the whole-book grow, the page-turn arrow highlight, the boss
+/// bar panel) never fires while the user works in another app: the normal case
+/// for a desktop HUD. A button event still reaches a background window, which is
+/// why a click worked while hover did not.
+///
+/// Adding an `NSTrackingArea` with `NSTrackingActiveAlways` to winit's content
+/// view (which already implements those responder methods) routes hover to the
+/// overlay regardless of which app is active. `NSTrackingInVisibleRect` makes the
+/// area track the view's visible rect, so it follows resizes with no re-add.
+#[cfg(target_os = "macos")]
+pub fn enable_background_hover(window: &Window) {
+    use objc2::runtime::AnyObject;
+    use objc2::ClassType;
+    use objc2_app_kit::{NSTrackingArea, NSTrackingAreaOptions, NSView};
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+    use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    let Ok(handle) = window.window_handle() else {
+        return;
+    };
+    let RawWindowHandle::AppKit(appkit) = handle.as_raw() else {
+        return;
+    };
+    // SAFETY: `ns_view` points at the live NSView backing this winit window, kept
+    // alive for the whole call by the caller's `Arc<Window>`. We run on the main
+    // thread inside the winit event loop, as these AppKit types require. The same
+    // pointer yields both the typed `&NSView` (to add the area) and the
+    // `&AnyObject` owner the area records (that view, which handles the events).
+    let view: &NSView = unsafe { appkit.ns_view.cast().as_ref() };
+    let owner: &AnyObject = unsafe { appkit.ns_view.cast().as_ref() };
+
+    // A tracking area with `NSTrackingMouseMoved` delivers moves within it, but a
+    // background window still needs to accept mouse-moved events for them to flow.
+    if let Some(ns_window) = view.window() {
+        ns_window.setAcceptsMouseMovedEvents(true);
+    }
+
+    let options = NSTrackingAreaOptions::NSTrackingMouseEnteredAndExited
+        | NSTrackingAreaOptions::NSTrackingMouseMoved
+        | NSTrackingAreaOptions::NSTrackingActiveAlways
+        | NSTrackingAreaOptions::NSTrackingInVisibleRect;
+    // The rect is ignored because of `NSTrackingInVisibleRect`.
+    let rect = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(0.0, 0.0));
+    // SAFETY: a standard `NSTrackingArea` init; `view.addTrackingArea` retains the
+    // area, so it outlives this `Retained` going out of scope.
+    let area = unsafe {
+        NSTrackingArea::initWithRect_options_owner_userInfo(
+            NSTrackingArea::alloc(),
+            rect,
+            options,
+            Some(owner),
+            None,
+        )
+    };
+    unsafe { view.addTrackingArea(&area) };
+}
+
+/// Non-macOS: X11/Wayland deliver pointer-motion events to a window without an
+/// active-app gate, so winit's default tracking already drives hover.
+#[cfg(not(target_os = "macos"))]
+pub fn enable_background_hover(_window: &Window) {}

--- a/packages/macos-vm/src/drive.rs
+++ b/packages/macos-vm/src/drive.rs
@@ -49,10 +49,13 @@ const KEY_GAP_AFTER: Duration = Duration::from_millis(24);
 /// per intermediate step; `GLIDE_GAP` paces them on the driver thread (~60 fps)
 /// so the guest renders the motion; the step count is clamped so a long sweep
 /// stays smooth and a short one stays quick. A hop under `GLIDE_MIN` just jumps.
+///
+/// The cap bounds the added latency before a `move`/`click` acks: a full-screen
+/// sweep is `GLIDE_MAX_STEPS * GLIDE_GAP` ≈ 384 ms (most moves are far shorter).
 const GLIDE_MIN: f64 = 0.012;
 const GLIDE_STEP: f64 = 0.03;
 const GLIDE_MIN_STEPS: usize = 4;
-const GLIDE_MAX_STEPS: usize = 40;
+const GLIDE_MAX_STEPS: usize = 24;
 const GLIDE_GAP: Duration = Duration::from_millis(16);
 
 /// Parameters for the interactive driver.

--- a/packages/macos-vm/src/drive.rs
+++ b/packages/macos-vm/src/drive.rs
@@ -43,6 +43,18 @@ use crate::macguest::{DirShare, capture, frame_size as guest_frame_size, start_g
 const KEY_GAP_DOWN: Duration = Duration::from_millis(8);
 const KEY_GAP_AFTER: Duration = Duration::from_millis(24);
 
+/// Pointer-glide tuning: a `move`/`click` sweeps the pointer from its last
+/// position to the target through intermediate `mouseMoved` events instead of
+/// teleporting (see [`glide`]). `GLIDE_STEP` is the travel (in display fractions)
+/// per intermediate step; `GLIDE_GAP` paces them on the driver thread (~60 fps)
+/// so the guest renders the motion; the step count is clamped so a long sweep
+/// stays smooth and a short one stays quick. A hop under `GLIDE_MIN` just jumps.
+const GLIDE_MIN: f64 = 0.012;
+const GLIDE_STEP: f64 = 0.03;
+const GLIDE_MIN_STEPS: usize = 4;
+const GLIDE_MAX_STEPS: usize = 40;
+const GLIDE_GAP: Duration = Duration::from_millis(16);
+
 /// Parameters for the interactive driver.
 pub struct DriveMacos {
     pub bundle: PathBuf,
@@ -132,6 +144,12 @@ fn parse_fraction_pair(
 /// pointer position. Shared by the `click` and `move` verbs: with `do_click` the
 /// pointer is pressed there, otherwise it only moves (hover).
 fn pointer_action(view_ptr: usize, fx: f64, fy: f64, do_click: bool, state: &mut State) {
+    // Glide the pointer from its last position to the target rather than
+    // teleporting: a real pointer sweeps across the screen, and the trail of
+    // intermediate moves reliably drives motion-sensitive UI a single jump can
+    // miss (a boundary-crossing hover, velocity, and especially drags). The
+    // endpoint is set exactly below, so this only shapes the path taken there.
+    glide(view_ptr, state.last_cursor, (fx, fy));
     on_main(view_ptr, move |view| {
         let (x, y) = view_point(view, fx, fy);
         if do_click {
@@ -142,6 +160,39 @@ fn pointer_action(view_ptr: usize, fx: f64, fy: f64, do_click: bool, state: &mut
     });
     state.last_cursor = Some((fx, fy));
     std::thread::sleep(KEY_GAP_AFTER);
+}
+
+/// Sweep the pointer from `start` to `end` (display fractions, top-left) with a
+/// short series of eased `mouseMoved` events, so the motion looks human and
+/// touches every point in between. Does nothing without a known `start` (the
+/// first pointer command of a session simply teleports) or for a hop under
+/// [`GLIDE_MIN`] (already effectively on target). The endpoint is left to the
+/// caller, which places the pointer there exactly (and may click).
+fn glide(view_ptr: usize, start: Option<(f64, f64)>, end: (f64, f64)) {
+    let Some((sx, sy)) = start else {
+        return;
+    };
+    let (dx, dy) = (end.0 - sx, end.1 - sy);
+    let dist = dx.hypot(dy);
+    if dist < GLIDE_MIN {
+        return;
+    }
+    // One step per `GLIDE_STEP` of travel, clamped to the smooth/quick range.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let steps = ((dist / GLIDE_STEP).ceil() as usize).clamp(GLIDE_MIN_STEPS, GLIDE_MAX_STEPS);
+    for i in 1..steps {
+        #[allow(clippy::cast_precision_loss)]
+        let t = i as f64 / steps as f64;
+        // Smoothstep ease-in-out: accelerate off the start, decelerate into the
+        // target, like a hand moving a pointer.
+        let e = t * t * (3.0 - 2.0 * t);
+        let (fx, fy) = (sx + dx * e, sy + dy * e);
+        on_main(view_ptr, move |view| {
+            let (x, y) = view_point(view, fx, fy);
+            input::mouse_move(view, x, y);
+        });
+        std::thread::sleep(GLIDE_GAP);
+    }
 }
 
 /// Execute one command line, returning its acknowledgement.

--- a/packages/macos-vm/src/drive.rs
+++ b/packages/macos-vm/src/drive.rs
@@ -184,9 +184,9 @@ fn glide(view_ptr: usize, start: Option<(f64, f64)>, end: (f64, f64)) {
         #[allow(clippy::cast_precision_loss)]
         let t = i as f64 / steps as f64;
         // Smoothstep ease-in-out: accelerate off the start, decelerate into the
-        // target, like a hand moving a pointer.
-        let e = t * t * (3.0 - 2.0 * t);
-        let (fx, fy) = (sx + dx * e, sy + dy * e);
+        // target, like a hand moving a pointer (`3 - 2t` via mul_add).
+        let e = t * t * 2.0f64.mul_add(-t, 3.0);
+        let (fx, fy) = (dx.mul_add(e, sx), dy.mul_add(e, sy));
         on_main(view_ptr, move |view| {
             let (x, y) = view_point(view, fx, fy);
             input::mouse_move(view, x, y);

--- a/packages/macos-vm/src/macguest.rs
+++ b/packages/macos-vm/src/macguest.rs
@@ -240,15 +240,20 @@ fn put_pixel(rgba: &mut [u8], width: usize, height: usize, x: isize, y: isize, r
     rgba[o..o + 4].copy_from_slice(&[rgb[0], rgb[1], rgb[2], 255]);
 }
 
-/// Draw a high-contrast pointer marker (a red cross with a white halo) into the
-/// RGBA buffer at display fraction `(fx, fy)`, top-left origin. The synthetic
-/// pointing device's cursor is not always part of the captured scanout, so this
-/// shows a caller exactly where the driver's pointer is. Fully bounds-checked.
-/// The fraction-to-pixel casts are intentional rasterization rounding; `fx`/`fy`
-/// are display fractions the driver clamps to `0..=1`, so the result is in range.
+/// Draw a high-contrast reticle (red crosshair with a white halo and a centre
+/// dot) into the RGBA buffer at display fraction `(fx, fy)`, top-left origin. The
+/// synthetic pointing device's cursor is not always part of the captured scanout,
+/// so this shows a caller exactly where the driver's pointer is. Fully
+/// bounds-checked. The fraction-to-pixel casts are intentional rasterization
+/// rounding; `fx`/`fy` are display fractions the driver clamps to `0..=1`, so the
+/// result is in range.
+///
+/// The reticle is sized to the framebuffer, not a fixed pixel count: a thin 1px
+/// cross on a 2048px capture vanishes when the shot is viewed at ~600px, so the
+/// arms scale with the display and are several pixels thick. A small centre gap
+/// keeps the exact target pixel readable, and the centre dot marks it precisely.
 #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
 fn draw_cursor_marker(rgba: &mut [u8], width: usize, height: usize, fx: f64, fy: f64) {
-    const ARM: isize = 10;
     const RED: [u8; 3] = [255, 40, 40];
     const WHITE: [u8; 3] = [255, 255, 255];
     if width == 0 || height == 0 {
@@ -256,17 +261,29 @@ fn draw_cursor_marker(rgba: &mut [u8], width: usize, height: usize, fx: f64, fy:
     }
     let cx = (fx * width as f64).round() as isize;
     let cy = (fy * height as f64).round() as isize;
-    // White halo first (the cross one pixel thick on each side), so the red cross
-    // stays visible over any background colour.
-    for d in -ARM..=ARM {
-        for off in [-1_isize, 1] {
-            put_pixel(rgba, width, height, cx + d, cy + off, WHITE);
-            put_pixel(rgba, width, height, cx + off, cy + d, WHITE);
+    let dim = width.min(height) as isize;
+    let arm = (dim / 48).max(14); // length of each crosshair arm
+    let gap = (dim / 200).max(4); // empty centre so the exact target shows
+    let half = (dim / 360).max(2); // half-thickness of each arm
+
+    // Filled axis-aligned span helper (inclusive ranges), used for the arms and
+    // the centre dot. `put_pixel` is bounds-checked, so off-screen spans clip.
+    let mut fill = |x0: isize, x1: isize, y0: isize, y1: isize, color: [u8; 3]| {
+        for y in y0..=y1 {
+            for x in x0..=x1 {
+                put_pixel(rgba, width, height, x, y, color);
+            }
         }
-    }
-    for d in -ARM..=ARM {
-        put_pixel(rgba, width, height, cx + d, cy, RED);
-        put_pixel(rgba, width, height, cx, cy + d, RED);
+    };
+    // White halo (one pixel fatter) under a red core, so the reticle reads over
+    // any background. Each pass draws four arms, leaving `gap` clear at the centre.
+    for (color, pad) in [(WHITE, 1_isize), (RED, 0)] {
+        let t = half + pad;
+        fill(cx + gap, cx + gap + arm, cy - t, cy + t, color); // right arm
+        fill(cx - gap - arm, cx - gap, cy - t, cy + t, color); // left arm
+        fill(cx - t, cx + t, cy + gap, cy + gap + arm, color); // down arm
+        fill(cx - t, cx + t, cy - gap - arm, cy - gap, color); // up arm
+        fill(cx - t, cx + t, cy - t, cy + t, color); // centre dot
     }
 }
 

--- a/packages/macos-vm/src/macguest.rs
+++ b/packages/macos-vm/src/macguest.rs
@@ -252,7 +252,11 @@ fn put_pixel(rgba: &mut [u8], width: usize, height: usize, x: isize, y: isize, r
 /// cross on a 2048px capture vanishes when the shot is viewed at ~600px, so the
 /// arms scale with the display and are several pixels thick. A small centre gap
 /// keeps the exact target pixel readable, and the centre dot marks it precisely.
-#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
 fn draw_cursor_marker(rgba: &mut [u8], width: usize, height: usize, fx: f64, fy: f64) {
     const RED: [u8; 3] = [255, 40, 40];
     const WHITE: [u8; 3] = [255, 255, 255];


### PR DESCRIPTION
## Why

While re-testing the Minecraft book overlay inside a macOS guest VM (via the `macvm` MCP driver), the page-turn arrows never highlighted on hover, even though clicking them turned the page. Investigation surfaced one real product bug and a few rough edges, all fixed here and validated end-to-end in the guest (off-screen, host cursor untouched).

## What

**1. Background overlays now receive hover (the actual bug).** An overlay runs under the Accessory activation policy, so it is never the active app and never owns a key window. winit 0.30 tracks the pointer with a legacy `addTrackingRect:`, whose `mouseEntered:`/`mouseMoved:`/`mouseExited:` only reach the active app's key window. So a background overlay got no `CursorEntered`/`CursorMoved`/`CursorLeft`, and its hover state (book grow + arrow highlight, boss bar description panel) never fired while another app was focused, the normal case for a desktop HUD. A button event still reaches a background window, which is why a click worked but hover did not.

`overlay_core::window::enable_background_hover` adds an `NSTrackingArea` with `NSTrackingActiveAlways` to winit's content view (which already implements the responder methods), wired into the book and boss bar windows at creation.

**2. macvm pointer glide.** `move`/`click` now sweep the pointer from its last position to the target through a short eased series of `mouseMoved` events instead of teleporting. A real pointer travels, and the intermediate moves reliably drive motion-sensitive UI a single jump can miss (boundary-crossing hover, velocity, drags). The endpoint is still set exactly; only the path changes. Bounded to <=40 steps (~640ms full-screen).

**3. Visible cursor marker.** `show_cursor`'s marker was a 10px, 1px-thick cross: invisible once a 2048px capture is viewed at ~600px. It is now a framebuffer-scaled reticle (thick arms, white halo, centre dot, small centre gap), readable at preview scale while still marking the exact pixel.

**4. Book Dock clearance.** The book auto-centered in the full display, putting its bottom arrows behind the Dock and its title under the menu bar. It now centers within `NSScreen.visibleFrame`; an oversized spread clamps just below the menu bar rather than under it.

## Validation (macOS 26.5 / M5 Max, off-screen guest)

- Hover over a page-turn arrow now highlights it (grey -> bright orange + pop) and grows the spread; moving away de-highlights and shrinks. Previously identical before/after frames.
- Click still turns pages (forward + back); navigation intact.
- Cursor marker clearly visible at full and downscaled preview scale.
- Book at scale 2 centers clear of the Dock and menu bar.
- Glide: a ~0.9-screen eased move lands exactly on the arrow with hover firing.
- `nix build .#book-overlay` / `.#macos-vm`, `cargo check`/`clippy` on changed crates, `nix run .#lint` all pass.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add background hover support for overlay windows and pointer glide for macOS VM
> - Adds `enable_background_hover` in [window.rs](https://github.com/indexable-inc/index/pull/479/files#diff-829a2ecf4cf9fab8e345c6d998edb47cb79fdc4a69943258379cfd2e3a3d296a) which installs an always-active `NSTrackingArea` on macOS, so bossbar and book overlay windows receive hover events even when the app is not focused.
> - Adds `visible_frame_logical` to return the screen's usable area (excluding menu bar/Dock) on macOS; book window centering now uses this to position within the visible frame instead of the full display.
> - Adds a `glide` function in [drive.rs](https://github.com/indexable-inc/index/pull/479/files#diff-9bce8aaf3c940d78f407c66cbd6979c6f45d793000f2e75e2416f8a8a7b16572) that emits smoothstep-interpolated `mouseMoved` events between consecutive pointer positions, replacing teleport-style cursor jumps.
> - Replaces the fixed 1px red cross cursor marker in [macguest.rs](https://github.com/indexable-inc/index/pull/479/files#diff-bf375e8c838424f343aea16a54b5727288a85d2fc009d75e928c51a796933b94) with a scalable reticle (crosshair, white halo, center dot) sized relative to the framebuffer dimensions.
> - Behavioral Change: `CursorEntered` handling in both bossbar and book now deduplicates events from winit and the always-active `NSTrackingArea`, so raise-to-front and render fire only once per crossing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 781ff40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->