### PR TITLE
feat(symphony-codex): back /workspace with tmpfs to fix ixVM checkout timeout

### DIFF
--- a/images/dev/symphony-codex/default.nix
+++ b/images/dev/symphony-codex/default.nix
@@ -2,10 +2,32 @@
 {
   ix.image = {
     name = "ix/symphony-codex";
-    tag = "2026-05-28";
+    tag = "2026-05-31";
   };
 
   networking.hostName = "symphony-codex";
+
+  # Symphony clones each run's repo checkouts under /workspace (Symphony's
+  # Codex.Provision @ix_workspace_root = "/workspace/symphony"). The VM's
+  # writable root is virtiofs-from-CAS served by the host vmfsd, whose
+  # small-file write path caps at ~5-6k files/s and collapses to single
+  # digits under host load, so a full-tree `git checkout` of the ~9k-file ix
+  # repo onto the root never finishes inside the provision timeout and the
+  # run falls back to host placement (ENG-2007, ENG-2004). Back /workspace
+  # with tmpfs: the checkout writes into guest RAM (~36k files/s, immune to
+  # host vmfsd contention) and the node-agent virtio-mem autoscaler grows
+  # guest RAM on demand to cover it. size= is a ceiling, not a reservation
+  # (pages are allocated lazily on write); 32 GiB comfortably fits the
+  # ~2.5 GiB of checkouts plus a scoped `cargo check` target/ while bounding
+  # a runaway run far below the VM's addressable memory cap.
+  fileSystems."/workspace" = {
+    device = "tmpfs";
+    fsType = "tmpfs";
+    options = [
+      "size=32g"
+      "mode=0755"
+    ];
+  };
 
   environment.systemPackages = [
     pkgs.ast-grep

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2392,7 +2392,7 @@ let
         message = "symphony-codex image should set the expected public OCI image name";
       }
       {
-        assertion = symphonyCodex.config.ix.image.tag == "2026-05-28";
+        assertion = symphonyCodex.config.ix.image.tag == "2026-05-31";
         message = "symphony-codex image should publish an immutable production tag";
       }
       {
@@ -2436,6 +2436,16 @@ let
           && claims.symphony-room-webtransport.protocol == "udp"
           && claims.symphony-room-webtransport.port == 4433;
         message = "symphony-codex image should register Room listener port claims";
+      }
+      {
+        assertion =
+          let
+            workspace = symphonyCodex.config.fileSystems."/workspace" or null;
+          in
+          workspace != null
+          && workspace.fsType == "tmpfs"
+          && builtins.elem "size=32g" workspace.options;
+        message = "symphony-codex image should back /workspace with a sized tmpfs so the per-run checkout skips the vmfsd write path";
       }
     ];
 


### PR DESCRIPTION
## Problem

VM-backed Codex DAGs (`quality`, `idiomatic`) on symphony.ix.dev fail at provision. Each run shells into the booted ixVM and clones the catalog repos into `/workspace` under one 600s timeout. The ixVM writable root is virtiofs-from-CAS served by the host `vmfsd`, whose small-file write path caps at ~5-6k files/s on a quiet host and collapses to single digits under host load. A full working-tree checkout of the ~9k-file `ix` repo never finishes, so Codex never starts and the run falls back to host placement.

## Fix

Mount `/workspace` as a sized tmpfs in the symphony-codex image. The per-run checkout then writes into guest RAM (~36k files/s, immune to host vmfsd contention) instead of the vmfsd path, and the node-agent virtio-mem autoscaler grows guest RAM on demand to cover it. `size=` is a ceiling, not a reservation (pages allocate lazily on write); 32 GiB comfortably fits the ~2.5 GiB of checkouts plus a scoped per-crate build target while bounding a runaway run far below the VM's addressable memory cap.

Bumps the immutable image tag `2026-05-28` -> `2026-05-31` since image contents changed, and adds a test asserting `/workspace` is a sized tmpfs.

## Deploy

Images publish via the image-push path, not CI. After merge, push `ix/symphony-codex:2026-05-31` to the us-west-1 registry, then bump the reference in indexable-inc/ix and redeploy symphony.

Part of ENG-2007


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Back /workspace with tmpfs in symphony-codex VM to fix ixVM checkout timeout
> Mounts `/workspace` as a tmpfs with a 32 GiB size ceiling and mode `0755` in the [symphony-codex image config](https://github.com/indexable-inc/index/pull/481/files#diff-fa98741b6cea42742963877e10afa3971317522ac8a23331307fedfee04b1101). Also bumps the image tag to `2026-05-31`. Tests in [tests/default.nix](https://github.com/indexable-inc/index/pull/481/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) are updated to assert the new tmpfs mount config and tag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb68945.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->