### PR TITLE
fix(search): stop indexing from stalling on large repos / busy stores

### DIFF
--- a/packages/mixedbread/src/lib.rs
+++ b/packages/mixedbread/src/lib.rs
@@ -7,7 +7,6 @@
 //! search (`/v1/stores/search`), regex grep (`/v1/stores/grep`), and
 //! question-answering (`/v1/stores/question-answering`).
 
-use std::collections::HashSet;
 use std::path::PathBuf;
 
 use reqwest::{Client as HttpClient, StatusCode};
@@ -292,20 +291,6 @@ impl Client {
             }
         }
         Ok(files)
-    }
-
-    /// Convenience over [`list_files`](Self::list_files): collect the set of
-    /// non-null external ids.
-    ///
-    /// # Errors
-    /// Returns an error if the listing fails.
-    pub async fn list_external_ids(&self, store: &str) -> Result<HashSet<String>> {
-        Ok(self
-            .list_files(store, None)
-            .await?
-            .into_iter()
-            .filter_map(|file| file.external_id)
-            .collect())
     }
 
     /// Upload one file: send the bytes to `/v1/files`, then attach the returned

--- a/packages/mixedbread/src/lib.rs
+++ b/packages/mixedbread/src/lib.rs
@@ -22,6 +22,13 @@ pub use filter::{Condition, Filter, Group, Operator};
 /// Default API base URL.
 pub const DEFAULT_BASE_URL: &str = "https://api.mixedbread.com";
 
+/// Page size for paginated `files/list` requests. The API rejects anything
+/// over 100 (HTTP 422), so this is the ceiling; listing follows a cursor and is
+/// therefore inherently sequential. Callers that must reconcile against a large
+/// store should avoid listing when local state already says nothing changed,
+/// rather than expecting a bigger page.
+const LIST_PAGE_SIZE: u32 = 100;
+
 /// Environment variable holding the API key.
 pub const API_KEY_ENV: &str = "MXBAI_API_KEY";
 
@@ -257,7 +264,7 @@ impl Client {
         let mut after: Option<String> = None;
         loop {
             let request = ListRequest {
-                limit: 100,
+                limit: LIST_PAGE_SIZE,
                 after: after.as_deref(),
                 filters,
             };

--- a/packages/search-core/src/adapter.rs
+++ b/packages/search-core/src/adapter.rs
@@ -100,11 +100,20 @@ impl Store for MixedbreadStore {
         self.client.ensure_store(name).await.context(BackendSnafu)
     }
 
-    async fn list_external_ids(&self, store: &str) -> Result<std::collections::HashSet<String>> {
-        self.client
-            .list_external_ids(store)
+    async fn list_external_ids(
+        &self,
+        store: &str,
+        filters: Option<&Filter>,
+    ) -> Result<std::collections::HashSet<String>> {
+        let files = self
+            .client
+            .list_files(store, filters)
             .await
-            .context(BackendSnafu)
+            .context(BackendSnafu)?;
+        Ok(files
+            .into_iter()
+            .filter_map(|file| file.external_id)
+            .collect())
     }
 
     async fn list_records(

--- a/packages/search-core/src/backend.rs
+++ b/packages/search-core/src/backend.rs
@@ -121,8 +121,11 @@ pub trait Store {
     /// created.
     fn ensure_store(&self, name: &str) -> impl Future<Output = Result<()>> + Send;
 
-    /// List the `external_id`s already present in the store. Used by the code
-    /// sync path, where the id is the content hash.
+    /// List the `external_id`s already present in the store, optionally scoped
+    /// by `filters`. Used by the code sync path, where the id is the content
+    /// hash; passing a `source == code AND repo == <slug>` filter keeps the
+    /// listing proportional to the repo being synced rather than the whole
+    /// shared store.
     ///
     /// # Errors
     /// Returns an error if the backend cannot be reached or returns an error
@@ -130,6 +133,7 @@ pub trait Store {
     fn list_external_ids(
         &self,
         store: &str,
+        filters: Option<&Filter>,
     ) -> impl Future<Output = Result<HashSet<String>>> + Send;
 
     /// List records matching `filters` (typically `source == X`) with their
@@ -281,8 +285,18 @@ impl Store for MemoryStore {
         Ok(())
     }
 
-    async fn list_external_ids(&self, _store: &str) -> Result<HashSet<String>> {
-        Ok(self.lock().files.keys().cloned().collect())
+    async fn list_external_ids(
+        &self,
+        _store: &str,
+        filters: Option<&Filter>,
+    ) -> Result<HashSet<String>> {
+        let inner = self.lock();
+        Ok(inner
+            .files
+            .values()
+            .filter(|stored| filters.is_none_or(|f| matches_filter(&stored.document.meta_json, f)))
+            .map(|stored| stored.document.external_id.clone())
+            .collect())
     }
 
     async fn list_records(

--- a/packages/search-core/src/db.rs
+++ b/packages/search-core/src/db.rs
@@ -24,7 +24,13 @@ CREATE TABLE IF NOT EXISTS files (
     size     INTEGER NOT NULL,
     PRIMARY KEY (root, rel_path)
 ) WITHOUT ROWID;
-CREATE INDEX IF NOT EXISTS files_by_hash ON files (hash);";
+CREATE INDEX IF NOT EXISTS files_by_hash ON files (hash);
+CREATE TABLE IF NOT EXISTS synced (
+    root      TEXT NOT NULL,
+    store     TEXT NOT NULL,
+    signature TEXT NOT NULL,
+    PRIMARY KEY (root, store)
+) WITHOUT ROWID;";
 
 /// Handle to the shared manifest database.
 #[derive(Debug)]
@@ -152,6 +158,46 @@ impl Db {
         tx.commit().context(DbSnafu)?;
         Ok(())
     }
+
+    /// The content signature last successfully synced for `root` to `store`, if
+    /// any. A match against the current manifest's signature means the store
+    /// already holds this checkout's content, so sync can skip the network.
+    ///
+    /// # Errors
+    /// Returns an error if the query fails.
+    pub fn synced_signature(&self, root: &Path, store: &str) -> Result<Option<String>> {
+        let root = root.to_string_lossy();
+        self.conn
+            .query_row(
+                "SELECT signature FROM synced WHERE root = ?1 AND store = ?2",
+                params![root.as_ref(), store],
+                |row| row.get::<_, String>(0),
+            )
+            .map(Some)
+            .or_else(|err| match err {
+                rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                other => Err(other),
+            })
+            .context(DbSnafu)
+    }
+
+    /// Record that `root` was successfully synced to `store` at `signature`.
+    /// Keyed by `(root, store)`, so switching stores forces a fresh sync rather
+    /// than trusting another store's state.
+    ///
+    /// # Errors
+    /// Returns an error if the upsert fails.
+    pub fn mark_synced(&mut self, root: &Path, store: &str, signature: &str) -> Result<()> {
+        let root = root.to_string_lossy();
+        self.conn
+            .execute(
+                "INSERT INTO synced (root, store, signature) VALUES (?1, ?2, ?3) \
+                 ON CONFLICT(root, store) DO UPDATE SET signature = excluded.signature",
+                params![root.as_ref(), store, signature],
+            )
+            .context(DbSnafu)?;
+        Ok(())
+    }
 }
 
 /// Path to the shared manifest database, `<cache>/semantic-search/index.db`.
@@ -240,6 +286,32 @@ mod tests {
         let loaded = db.load(root).expect("load");
         assert_eq!(loaded.entries.len(), 1);
         assert_eq!(loaded.entries[0].rel_path, "a.rs");
+    }
+
+    #[test]
+    fn synced_signature_round_trips_and_is_store_scoped() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut db = open(&dir);
+        let root = Path::new("/repo/a");
+
+        // Absent until recorded.
+        assert_eq!(db.synced_signature(root, "s1").expect("query"), None);
+
+        db.mark_synced(root, "s1", "sig-1").expect("mark");
+        assert_eq!(
+            db.synced_signature(root, "s1").expect("query").as_deref(),
+            Some("sig-1")
+        );
+        // A different store does not inherit s1's state, so switching stores
+        // forces a fresh sync.
+        assert_eq!(db.synced_signature(root, "s2").expect("query"), None);
+
+        // Re-marking the same (root, store) overwrites in place.
+        db.mark_synced(root, "s1", "sig-2").expect("re-mark");
+        assert_eq!(
+            db.synced_signature(root, "s1").expect("query").as_deref(),
+            Some("sig-2")
+        );
     }
 
     #[test]

--- a/packages/search-core/src/manifest.rs
+++ b/packages/search-core/src/manifest.rs
@@ -124,6 +124,30 @@ impl Manifest {
         self.entries.iter().map(|e| e.hash.as_str()).collect()
     }
 
+    /// A stable digest of this checkout's content: a hash over the sorted,
+    /// deduplicated set of file content hashes. Two builds with identical
+    /// content produce the same signature regardless of file paths, so a pure
+    /// rename (which needs no re-upload, since blobs are content-addressed) does
+    /// not change it. Sync compares it against the last successfully synced
+    /// signature to decide whether anything could need uploading; an unchanged
+    /// signature means the store already holds this content and the listing and
+    /// upload round-trips can be skipped entirely.
+    #[must_use]
+    pub fn signature(&self) -> String {
+        use sha2::{Digest as _, Sha256};
+
+        let mut hashes: Vec<&str> = self.entries.iter().map(|e| e.hash.as_str()).collect();
+        hashes.sort_unstable();
+        hashes.dedup();
+
+        let mut hasher = Sha256::new();
+        for hash in hashes {
+            hasher.update(hash.as_bytes());
+            hasher.update(b"\n");
+        }
+        format!("{:x}", hasher.finalize())
+    }
+
     /// The first relative path that maps to `hash`, if any. Identical content
     /// at several paths is rare in practice; the first is a fine display label.
     #[must_use]
@@ -186,6 +210,33 @@ mod tests {
         assert_eq!(
             first.entries[0].hash, second.entries[0].hash,
             "stable content keeps a stable hash across builds"
+        );
+    }
+
+    #[test]
+    fn signature_is_content_addressed_not_path_addressed() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        std::fs::write(dir.path().join("a.rs"), "alpha").expect("write");
+        std::fs::write(dir.path().join("b.rs"), "beta").expect("write");
+        let first = Manifest::build(dir.path(), None, 1024 * 1024).expect("build");
+
+        // Renaming a file (same content) leaves the signature unchanged: a
+        // content-addressed store needs no re-upload for a pure move.
+        std::fs::rename(dir.path().join("a.rs"), dir.path().join("renamed.rs")).expect("rename");
+        let renamed = Manifest::build(dir.path(), None, 1024 * 1024).expect("rebuild");
+        assert_eq!(
+            first.signature(),
+            renamed.signature(),
+            "rename keeps signature"
+        );
+
+        // Changing content changes the signature, so sync re-runs.
+        std::fs::write(dir.path().join("renamed.rs"), "alpha EDITED").expect("edit");
+        let edited = Manifest::build(dir.path(), None, 1024 * 1024).expect("rebuild");
+        assert_ne!(
+            first.signature(),
+            edited.signature(),
+            "edit changes signature"
         );
     }
 

--- a/packages/search-core/src/pipeline.rs
+++ b/packages/search-core/src/pipeline.rs
@@ -56,15 +56,26 @@ async fn prepare(
 ) -> Result<Manifest> {
     // Scope the database handle so it is dropped before any await: rusqlite's
     // connection is not Sync, and the returned future must be Send.
-    let manifest = {
+    let (manifest, signature, already_synced) = {
         let mut db = Db::open()?;
         let previous = db.load(query.root)?;
         let manifest = Manifest::build(query.root, Some(&previous), config.max_file_bytes)?;
         db.save(query.root, &manifest)?;
-        manifest
+        let signature = manifest.signature();
+        // If this exact content was already synced to this store, skip the sync
+        // round-trips entirely. Code sync never deletes (the module is
+        // append-only; deletion is a separate GC pass), so an unchanged
+        // signature means every blob is still present and listing the store to
+        // rediscover that is pure latency. This is what turns a repeated search
+        // on an already-indexed checkout from "re-list every file" into a no-op.
+        let already_synced = db
+            .synced_signature(query.root, query.store_name)?
+            .as_deref()
+            == Some(signature.as_str());
+        (manifest, signature, already_synced)
     };
 
-    if query.sync {
+    if query.sync && !already_synced {
         let repo = repo_slug(query.root);
         let report = sync(
             store,
@@ -79,6 +90,10 @@ async fn prepare(
         if report.uploaded > 0 {
             wait_until_indexed(store, query.store_name, query.index_timeout, on_poll).await?;
         }
+        // Record success so the next unchanged run takes the skip path above.
+        // Open a fresh handle: the one above was dropped before this await to
+        // keep the future Send.
+        Db::open()?.mark_synced(query.root, query.store_name, &signature)?;
     }
 
     Ok(manifest)

--- a/packages/search-core/src/pipeline.rs
+++ b/packages/search-core/src/pipeline.rs
@@ -23,6 +23,11 @@ pub struct Query<'a> {
     pub root: &'a Path,
     /// Store name (one store holds every worktree's content).
     pub store_name: &'a str,
+    /// API base URL of the backend the store lives on. Part of the store's
+    /// identity: the same store name on two different endpoints is two different
+    /// stores, so the "already synced" gate must distinguish them or it would
+    /// skip uploading to a freshly pointed-at instance.
+    pub base_url: &'a str,
     /// The query text: a natural-language query for semantic search, or a
     /// regular expression for grep.
     pub text: &'a str,
@@ -54,6 +59,11 @@ async fn prepare(
     on_upload: impl Fn(usize, usize) + Send + Sync,
     on_poll: impl Fn(StoreStatus) + Send + Sync,
 ) -> Result<Manifest> {
+    // Identity of the store this checkout is synced against: the same store name
+    // on a different API endpoint is a different store, so both must key the
+    // "already synced" gate, or pointing at a fresh instance would be skipped.
+    let synced_store = format!("{}\u{1f}{}", query.base_url, query.store_name);
+
     // Scope the database handle so it is dropped before any await: rusqlite's
     // connection is not Sync, and the returned future must be Send.
     let (manifest, signature, already_synced) = {
@@ -69,7 +79,7 @@ async fn prepare(
         // rediscover that is pure latency. This is what turns a repeated search
         // on an already-indexed checkout from "re-list every file" into a no-op.
         let already_synced = db
-            .synced_signature(query.root, query.store_name)?
+            .synced_signature(query.root, &synced_store)?
             .as_deref()
             == Some(signature.as_str());
         (manifest, signature, already_synced)
@@ -90,10 +100,15 @@ async fn prepare(
         if report.uploaded > 0 {
             wait_until_indexed(store, query.store_name, query.index_timeout, on_poll).await?;
         }
-        // Record success so the next unchanged run takes the skip path above.
-        // Open a fresh handle: the one above was dropped before this await to
-        // keep the future Send.
-        Db::open()?.mark_synced(query.root, query.store_name, &signature)?;
+        // Record success once the uploads are accepted, not once embedding
+        // finishes. Upload acceptance is the durable fact the gate cares about
+        // (the blobs are in the store, addressed by hash); embedding completes
+        // asynchronously server-side. Gating the mark on embedding instead would
+        // force the full repo re-list on every run until a slow embed catches
+        // up, and a re-upload of identical content cannot fix a server-side
+        // embed failure anyway. Open a fresh handle: the one above was dropped
+        // before this await to keep the future Send.
+        Db::open()?.mark_synced(query.root, &synced_store, &signature)?;
     }
 
     Ok(manifest)

--- a/packages/search-core/src/sync.rs
+++ b/packages/search-core/src/sync.rs
@@ -67,7 +67,26 @@ pub async fn sync(
     on_progress: impl Fn(usize, usize) + Send + Sync,
 ) -> Result<SyncReport> {
     store.ensure_store(store_name).await?;
-    let remote = store.list_external_ids(store_name).await?;
+
+    // Scope the "what's already there" listing to this repo's code records.
+    // The shared store also holds every other repo, every worktree, and the
+    // non-code sources (Slack, Linear, ...); listing it unfiltered means one
+    // sync paginates the whole world before a single byte uploads, which is the
+    // dominant first-run stall on an established store.
+    //
+    // A blob is addressed by its content hash and upload overwrites by that id,
+    // so a too-narrow scope never duplicates or corrupts: the worst case is a
+    // file whose content is byte-identical across two repos getting re-uploaded
+    // (a cheap, idempotent overwrite) the first time each repo syncs it. The
+    // default worktree search intersects by content hash and is unaffected; only
+    // a `--repo`/`--all-worktrees` query for such a shared blob sees its repo
+    // attribution follow the most recent sync. That is rare (shared content is
+    // usually boilerplate) and was already arbitrary under the unfiltered list.
+    let scope = Filter::all(vec![
+        Filter::eq(keys::SOURCE, search_meta::Source::Code.as_str()),
+        Filter::eq(keys::REPO, repo.as_str()),
+    ]);
+    let remote = store.list_external_ids(store_name, Some(&scope)).await?;
 
     // New content only: skip hashes the store already has, and collapse
     // duplicate content within this checkout to a single upload.
@@ -437,6 +456,41 @@ mod tests {
         assert_eq!(report_b.uploaded, 0, "identical worktree embeds nothing");
         assert_eq!(store.upload_count(), 2, "store still holds one copy");
         assert_eq!(store.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn dedup_listing_is_scoped_per_repo() {
+        // The dedup listing is scoped to the syncing repo, so a blob already in
+        // the store under a *different* repo is not seen and is uploaded again
+        // (an idempotent overwrite, keyed by content hash). This is the cost of
+        // not paginating the whole shared store on every sync; the win is that
+        // one repo's sync never reads another repo's (or Slack's, Linear's...)
+        // records.
+        let dir = write_repo();
+        let store = MemoryStore::new();
+        let manifest = Manifest::build(dir.path(), None, 1024 * 1024).expect("manifest");
+        let repo_a = RepoSlug::Remote("org/a".to_owned());
+        let repo_b = RepoSlug::Remote("org/b".to_owned());
+
+        let a = sync(&store, "s", dir.path(), &manifest, &repo_a, 1000, |_, _| {})
+            .await
+            .expect("sync a");
+        assert_eq!(a.uploaded, 2);
+
+        // Identical content under repo B: B's repo-scoped listing does not see
+        // A's copies, so B re-uploads. The store still holds one entry per hash.
+        let b = sync(&store, "s", dir.path(), &manifest, &repo_b, 1000, |_, _| {})
+            .await
+            .expect("sync b");
+        assert_eq!(b.uploaded, 2, "different repo re-uploads identical content");
+        assert_eq!(store.len(), 2, "overwrite by content hash, no duplicates");
+
+        // A second B sync is a no-op: its own records now match the scope.
+        let b_again = sync(&store, "s", dir.path(), &manifest, &repo_b, 1000, |_, _| {})
+            .await
+            .expect("sync b again");
+        assert_eq!(b_again.uploaded, 0);
+        assert_eq!(b_again.skipped, 2);
     }
 
     #[tokio::test]

--- a/packages/search-py/src/lib.rs
+++ b/packages/search-py/src/lib.rs
@@ -177,11 +177,12 @@ struct SearchArgs {
 async fn run_search(args: SearchArgs) -> search_core::Result<Vec<DisplayHit>> {
     let root: PathBuf =
         std::fs::canonicalize(&args.path).unwrap_or_else(|_| PathBuf::from(&args.path));
-    let store = MixedbreadStore::from_login(args.base).await?;
+    let store = MixedbreadStore::from_login(args.base.clone()).await?;
 
     let query = Query {
         root: &root,
         store_name: &args.store_name,
+        base_url: &args.base,
         text: &args.query,
         top_k: args.top_k,
         options: args.options,
@@ -214,13 +215,14 @@ struct GrepArgs {
 async fn run_grep(args: GrepArgs) -> search_core::Result<Vec<DisplayHit>> {
     let root: PathBuf =
         std::fs::canonicalize(&args.path).unwrap_or_else(|_| PathBuf::from(&args.path));
-    let store = MixedbreadStore::from_login(args.base).await?;
+    let store = MixedbreadStore::from_login(args.base.clone()).await?;
 
     // Grep ignores semantic-only knobs (`options`, `include_web`); they are set
     // to inert defaults so the shared `Query` shape stays reusable.
     let query = Query {
         root: &root,
         store_name: &args.store_name,
+        base_url: &args.base,
         text: &args.pattern,
         top_k: args.top_k,
         options: SearchOptions {

--- a/packages/search/src/main.rs
+++ b/packages/search/src/main.rs
@@ -355,12 +355,13 @@ async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
     let base_url = cli
         .base_url
         .unwrap_or_else(|| mixedbread::DEFAULT_BASE_URL.to_owned());
-    let store = MixedbreadStore::from_login(base_url).await?;
+    let store = MixedbreadStore::from_login(base_url.clone()).await?;
 
     let (filter, code_scope) = resolve_scope(&cli.scope, &root)?;
     let query = Query {
         root: &root,
         store_name: &store_name,
+        base_url: &base_url,
         text: &pattern,
         top_k: cli.max_count.max(1),
         options: SearchOptions {
@@ -515,7 +516,7 @@ async fn run_grep(cli: GrepArgs) -> anyhow::Result<()> {
     let base_url = cli
         .base_url
         .unwrap_or_else(|| mixedbread::DEFAULT_BASE_URL.to_owned());
-    let store = MixedbreadStore::from_login(base_url).await?;
+    let store = MixedbreadStore::from_login(base_url.clone()).await?;
 
     // Grep reuses the shared `Query` shape; its semantic-only knobs (rerank,
     // agentic, web) are inert here, and the grep pattern travels in `text`.
@@ -523,6 +524,7 @@ async fn run_grep(cli: GrepArgs) -> anyhow::Result<()> {
     let query = Query {
         root: &root,
         store_name: &store_name,
+        base_url: &base_url,
         text: &cli.pattern,
         top_k: cli.max_count.max(1),
         options: SearchOptions {

--- a/packages/search/src/main.rs
+++ b/packages/search/src/main.rs
@@ -374,57 +374,25 @@ async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
         index_timeout: INDEX_TIMEOUT,
     };
 
-    // Progress UI, terminal only: an upload bar that flips to an embedding
-    // bar on the first poll. Piped output stays clean (no bar).
-    let bar = std::io::stderr()
-        .is_terminal()
-        .then(ProgressBar::new_spinner);
-    if let Some(bar) = &bar {
-        bar.set_style(progress_style::bar("cyan"));
-        bar.set_prefix("indexing files");
-    }
-    let embedding = AtomicBool::new(false);
-    // Captured during upload so the embedding bar knows its length: the number
-    // of files uploaded is exactly the number that will embed.
-    let embed_total = AtomicU64::new(0);
-    let on_upload = |done: usize, total: usize| {
-        if let (Some(bar), true) = (&bar, total > 0) {
-            let total = u64::try_from(total).unwrap_or(u64::MAX);
-            embed_total.store(total, Ordering::Relaxed);
-            bar.set_length(total);
-            bar.set_position(u64::try_from(done).unwrap_or(u64::MAX));
-        }
-    };
-    let on_poll = |status: StoreStatus| {
-        if let Some(bar) = &bar {
-            let len = embed_total.load(Ordering::Relaxed);
-            // store_status is store-wide, so the pending count can exceed our
-            // batch; clamp to len so the bar never reads past full. Set the
-            // position before any style flip so the first embedding draw shows
-            // the real position, not the carried-over full upload position
-            // (which would flash as "len/len" for one frame).
-            let remaining = (status.pending + status.in_progress).min(len);
-            bar.set_position(len - remaining);
-            if !embedding.swap(true, Ordering::Relaxed) {
-                bar.set_style(progress_style::bar("magenta"));
-                bar.set_prefix("embedding files");
-                bar.set_length(len);
-                bar.enable_steady_tick(Duration::from_millis(120));
-            }
-        }
-    };
+    // Progress UI, terminal only: an animated spinner during the manifest +
+    // store-listing phase, flipping to determinate upload then embedding bars.
+    // Piped output stays clean (no bar).
+    let progress = IndexProgress::new();
 
     if cli.answer {
         anyhow::ensure!(
             !cli.json,
             "--json is not supported with --answer; pass one or the other",
         );
-        let view =
-            search_core::index_and_answer(&store, &query, &config, on_upload, on_poll)
-                .await?;
-        if let Some(bar) = &bar {
-            bar.finish_and_clear();
-        }
+        let view = search_core::index_and_answer(
+            &store,
+            &query,
+            &config,
+            |done, total| progress.on_upload(done, total),
+            |status| progress.on_poll(status),
+        )
+        .await?;
+        progress.finish();
         println!("{}", view.answer);
         if !view.sources.is_empty() {
             println!();
@@ -433,16 +401,98 @@ async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
             }
         }
     } else {
-        let hits =
-            search_core::index_and_semantic(&store, &query, &config, on_upload, on_poll)
-                .await?;
-        if let Some(bar) = &bar {
-            bar.finish_and_clear();
-        }
+        let hits = search_core::index_and_semantic(
+            &store,
+            &query,
+            &config,
+            |done, total| progress.on_upload(done, total),
+            |status| progress.on_poll(status),
+        )
+        .await?;
+        progress.finish();
         print_hits(&hits, cli.json, cli.content, &palette, &root, theme)?;
     }
 
     Ok(())
+}
+
+/// Terminal progress for the index-then-query flow. The phases before any
+/// upload (building the manifest, listing what the store already holds) have no
+/// known total, so the bar starts as an animated spinner instead of a frozen
+/// `0/0`; it flips to a determinate "uploading" bar once new files start
+/// uploading, then to an "embedding" bar while the store embeds them. A
+/// non-terminal stderr (piped output) gets no bar at all.
+struct IndexProgress {
+    bar: Option<ProgressBar>,
+    /// Files uploaded this run, captured so the embedding bar knows its length.
+    embed_total: AtomicU64,
+    /// Whether the spinner has already flipped to the determinate upload bar.
+    uploading: AtomicBool,
+    /// Whether the upload bar has already flipped to the embedding bar.
+    embedding: AtomicBool,
+}
+
+impl IndexProgress {
+    /// Start an animated spinner (terminal only) for the pre-upload phase, so a
+    /// slow manifest build or store listing reads as working, not hung.
+    fn new() -> Self {
+        let bar = std::io::stderr().is_terminal().then(ProgressBar::new_spinner);
+        if let Some(bar) = &bar {
+            bar.set_style(progress_style::spinner());
+            bar.set_prefix("indexing");
+            bar.set_message("scanning files, checking store");
+            bar.enable_steady_tick(Duration::from_millis(120));
+        }
+        Self {
+            bar,
+            embed_total: AtomicU64::new(0),
+            uploading: AtomicBool::new(false),
+            embedding: AtomicBool::new(false),
+        }
+    }
+
+    /// Upload-phase callback: `(uploaded_so_far, total_to_upload)`. The first
+    /// call with a real total flips the spinner to a determinate bar.
+    fn on_upload(&self, done: usize, total: usize) {
+        let (Some(bar), true) = (&self.bar, total > 0) else {
+            return;
+        };
+        let total = u64::try_from(total).unwrap_or(u64::MAX);
+        self.embed_total.store(total, Ordering::Relaxed);
+        if !self.uploading.swap(true, Ordering::Relaxed) {
+            bar.set_style(progress_style::bar("cyan"));
+            bar.set_prefix("uploading files");
+        }
+        bar.set_length(total);
+        bar.set_position(u64::try_from(done).unwrap_or(u64::MAX));
+    }
+
+    /// Embedding-phase callback: flip to the embedding bar on first poll and
+    /// track how many uploaded files remain to embed.
+    fn on_poll(&self, status: StoreStatus) {
+        let Some(bar) = &self.bar else {
+            return;
+        };
+        let len = self.embed_total.load(Ordering::Relaxed);
+        // store_status is store-wide, so the pending count can exceed our batch;
+        // clamp to len so the bar never reads past full. Set the position before
+        // any style flip so the first embedding draw shows the real position,
+        // not the carried-over full upload position (a one-frame "len/len").
+        let remaining = (status.pending + status.in_progress).min(len);
+        bar.set_position(len - remaining);
+        if !self.embedding.swap(true, Ordering::Relaxed) {
+            bar.set_style(progress_style::bar("magenta"));
+            bar.set_prefix("embedding files");
+            bar.set_length(len);
+        }
+    }
+
+    /// Clear the bar once the flow finishes.
+    fn finish(&self) {
+        if let Some(bar) = &self.bar {
+            bar.finish_and_clear();
+        }
+    }
 }
 
 async fn run_grep(cli: GrepArgs) -> anyhow::Result<()> {
@@ -490,52 +540,20 @@ async fn run_grep(cli: GrepArgs) -> anyhow::Result<()> {
         targets: GrepTargets::Text,
     };
 
-    // Progress UI, terminal only: an upload bar that flips to an embedding bar
-    // on the first poll. Identical to the semantic path so a grep on a fresh
-    // tree shows the same indexing feedback. Piped output stays clean (no bar).
-    let bar = std::io::stderr()
-        .is_terminal()
-        .then(ProgressBar::new_spinner);
-    if let Some(bar) = &bar {
-        bar.set_style(progress_style::bar("cyan"));
-        bar.set_prefix("indexing files");
-    }
-    let embedding = AtomicBool::new(false);
-    let embed_total = AtomicU64::new(0);
-    let on_upload = |done: usize, total: usize| {
-        if let (Some(bar), true) = (&bar, total > 0) {
-            let total = u64::try_from(total).unwrap_or(u64::MAX);
-            embed_total.store(total, Ordering::Relaxed);
-            bar.set_length(total);
-            bar.set_position(u64::try_from(done).unwrap_or(u64::MAX));
-        }
-    };
-    let on_poll = |status: StoreStatus| {
-        if let Some(bar) = &bar {
-            let len = embed_total.load(Ordering::Relaxed);
-            let remaining = (status.pending + status.in_progress).min(len);
-            bar.set_position(len - remaining);
-            if !embedding.swap(true, Ordering::Relaxed) {
-                bar.set_style(progress_style::bar("magenta"));
-                bar.set_prefix("embedding files");
-                bar.set_length(len);
-                bar.enable_steady_tick(Duration::from_millis(120));
-            }
-        }
-    };
+    // Progress UI, terminal only: identical to the semantic path so a grep on a
+    // fresh tree shows the same indexing feedback. Piped output stays clean.
+    let progress = IndexProgress::new();
 
     let hits = search_core::index_and_grep(
         &store,
         &query,
         grep_options,
         &config,
-        on_upload,
-        on_poll,
+        |done, total| progress.on_upload(done, total),
+        |status| progress.on_poll(status),
     )
     .await?;
-    if let Some(bar) = &bar {
-        bar.finish_and_clear();
-    }
+    progress.finish();
 
     print_hits(&hits, cli.json, cli.content, &palette, &root, theme)?;
 


### PR DESCRIPTION
## Problem

`search` (and the MCP `search_semantic`/`search_grep` tools) sat at `indexing files 0/0` for a long time — sometimes seemingly forever — on a large repo or an established store. Traced from a debug log: the first call dispatched and ran until it was cancelled, never moving off `0/0`.

## Root causes

1. **The dedup listing enumerated the whole world.** Before uploading, sync called `list_external_ids` → `list_files(store, None)`, which paginates the **entire shared store** (every repo, every worktree, plus Slack/Linear/... records) at 100 rows/page sequentially, *before a single byte uploads*. Syncing one small repo paid to list everything.
2. **Every run re-listed even when nothing changed.** No record of what had already been synced, so a repeated search on an unchanged checkout re-enumerated the repo every time.
3. **The progress bar only moved during upload.** The long pre-upload phase (manifest build + store listing) showed a frozen `0/0` with no spinner, so a slow phase looked like a hang.

## Fix

1. **Scope the dedup listing to this repo's code records** (`source == code AND repo == <slug>`). Uploads attach by content hash with `overwrite: true`, so a too-narrow scope can only cause a cheap idempotent re-upload of a blob shared across repos, never a duplicate or wrong result. The default worktree search intersects by content hash and is unaffected.
2. **Skip the network entirely when the working tree is unchanged since the last successful sync to this store.** A content signature (hash over the sorted set of file hashes) is recorded per `(root, store)` after a successful sync; an unchanged signature short-circuits listing and upload. Code sync never deletes, so unchanged signature ⇒ every blob is still present. New `synced` table via `CREATE TABLE IF NOT EXISTS` (no migration).
3. **Honest progress.** Animate a spinner through scan/list, then flip to determinate upload/embedding bars. The duplicated bar wiring across the semantic and grep paths is factored into one `IndexProgress` helper.

## Why the cold path is still bounded, not instant

The API caps `files/list` page size at 100 (HTTP 422 above that) and listing is cursor-sequential, so the *first* reconcile of a large already-populated repo is still N/100 round-trips. Fixes (1) and (2) keep that to once per checkout; repeated runs are free.

## Validation

- `cargo test -p search-core`: 31 pass (added: per-repo dedup scoping, content signature is rename-stable, synced gate is store-scoped). ✅
- Local-only manifest build on linux (93k files, cold): 8.7s — bounded, not the stall. ✅
- End-to-end A/B on the `index` repo (~6k records in store): cold `grep` **52.2s** → warm `grep` **0.87s**, identical results. ✅

## Notes

- CI has no `cargo fmt --check` gate; local rustfmt is a different build than the pin and flags unrelated files, so it was not run (would churn untouched code).
- Commit is unsigned: the 1Password SSH signing agent was locked at commit time.

Made with AI (Claude, Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip re-indexing when repo content is unchanged and scope dedup listing per repo
> - Adds a `Manifest.signature` method (SHA-256 over sorted content hashes) and `Db.synced_signature`/`Db.mark_synced` helpers to record the last synced signature per `(base_url, store_name, root)`; the `prepare` function skips upload entirely when the signature matches.
> - Scopes `Store::list_external_ids` to a `source=code` + repo filter so dedup listing only fetches records for the current repo instead of the entire shared store.
> - Replaces ad-hoc progress bar logic in the CLI with a phased `IndexProgress` helper: spinner during scan/list, cyan bar during upload, magenta bar during embedding.
> - Behavioral Change: repos that haven't changed since last sync produce no network traffic; first run after this change will always upload (no prior signature recorded).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d7d451.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->