### PR TITLE
chore(lint): nixfmt tests/default.nix to unbreak main

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2442,9 +2442,7 @@ let
           let
             workspace = symphonyCodex.config.fileSystems."/workspace" or null;
           in
-          workspace != null
-          && workspace.fsType == "tmpfs"
-          && builtins.elem "size=32g" workspace.options;
+          workspace != null && workspace.fsType == "tmpfs" && builtins.elem "size=32g" workspace.options;
         message = "symphony-codex image should back /workspace with a sized tmpfs so the per-run checkout skips the vmfsd write path";
       }
     ];


### PR DESCRIPTION
`#481` merged `tests/default.nix` without running nixfmt, so `.#checks.x86_64-linux.lint` (`nixfmt --check`) fails on `main` (776 successes, 1 failure) — and because PR checks build the merge with `main`, it fails on every open PR too.

Formatting-only change (`nix fmt tests/default.nix`); `nixfmt --check` is clean. No behavior change.

Made with AI (Claude, Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Format `tests/default.nix` to fix nixfmt lint check on main
> Collapses a three-line boolean expression in [tests/default.nix](https://github.com/indexable-inc/index/pull/484/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) into a single line to satisfy the nixfmt linter. No logic is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d45eda8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->