### PR TITLE
feat(claude-history-sync): unified S3 parquet + Mixedbread syncer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -49,6 +50,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -188,6 +204,222 @@ name = "arref"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ccd462b64c3c72f1be8305905a85d85403d768e8690c9b8bd3b9009a5761679"
+
+[[package]]
+name = "arrow"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de"
+dependencies = [
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "chrono",
+ "half",
+ "indexmap",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+
+[[package]]
+name = "arrow-select"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
 
 [[package]]
 name = "askama"
@@ -377,6 +609,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -583,6 +824,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +1043,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "claude-history-sync"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "arrow",
+ "clap",
+ "claude-history",
+ "dirs",
+ "mixedbread",
+ "nix 0.30.1",
+ "object_store",
+ "parquet",
+ "search-core",
+ "serde_json",
+ "sha2 0.10.9",
+ "snafu 0.9.1",
+ "tokio",
+]
+
+[[package]]
 name = "clone-cli"
 version = "0.1.0"
 dependencies = [
@@ -968,6 +1250,26 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "convert_case"
@@ -1169,6 +1471,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1654,6 +1977,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustc_version",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,6 +1994,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1949,6 +2283,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,6 +2309,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -2161,6 +2515,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,6 +2539,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2200,6 +2561,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2444,6 +2806,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,6 +3049,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,6 +3142,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2982,6 +3413,9 @@ name = "lz4_flex"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "mach2"
@@ -3034,6 +3468,16 @@ checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3479,6 +3923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3718,6 +4163,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "humantime",
+ "hyper",
+ "itertools 0.14.0",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.10.1",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "oboe"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3808,6 +4291,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
@@ -3851,6 +4343,39 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parquet"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "half",
+ "hashbrown 0.17.1",
+ "lz4_flex 0.13.1",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "twox-hash",
+ "zstd",
 ]
 
 [[package]]
@@ -4167,6 +4692,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quick_cache"
 version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4476,6 +5011,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -4489,6 +5025,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4496,12 +5033,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -4906,6 +5445,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5098,6 +5643,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5188,6 +5739,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -5444,7 +6001,7 @@ checksum = "dfadb8526b6da90704feb293b0701a6aae62ea14983143344be2dc5ce30f1d82"
 dependencies = [
  "fnv",
  "nom",
- "ordered-float",
+ "ordered-float 5.3.0",
  "serde",
  "serde_json",
 ]
@@ -5622,6 +6179,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float 2.10.1",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5650,6 +6218,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -6582,6 +7159,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7396,6 +7986,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "packages/ast-merge/langs",
   "packages/ast-merge/matcher",
   "packages/claude-history",
+  "packages/claude-history-sync",
   "packages/clone-detect/cli",
   "packages/clone-detect/detect",
   "packages/clone-detect/hash",
@@ -76,6 +77,7 @@ multiple_crate_versions = "allow"
 anstream = "1"
 anstyle = "1"
 anyhow = "1"
+arrow = "58"
 askama = { version = "0.16.0", default-features = false }
 ast-merge-ast = { path = "packages/ast-merge/ast" }
 ast-merge-diff = { path = "packages/ast-merge/diff" }
@@ -124,7 +126,9 @@ object = { version = "0.37", default-features = false, features = [
   "write",
   "std",
 ] }
+object_store = { version = "0.13", features = ["aws"] }
 parking_lot = "0.12"
+parquet = { version = "58", features = ["arrow"] }
 progress-style = { path = "packages/progress-style" }
 pty-process = { version = "0.4", features = ["async"] }
 pyo3 = { version = "0.28", features = ["abi3-py311"] }

--- a/packages/claude-history-sync/Cargo.toml
+++ b/packages/claude-history-sync/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "claude-history-sync"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Sync Claude Code agent transcripts to S3/R2 parquet (polars-queryable) and Mixedbread"
+
+[lints]
+workspace = true
+
+[dependencies]
+claude-history.workspace = true
+search-core.workspace = true
+mixedbread.workspace = true
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+dirs.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+snafu.workspace = true
+nix = { workspace = true, features = ["hostname"] }
+object_store = { workspace = true, features = ["aws"] }
+arrow.workspace = true
+parquet = { workspace = true, features = ["arrow"] }

--- a/packages/claude-history-sync/default.nix
+++ b/packages/claude-history-sync/default.nix
@@ -1,0 +1,6 @@
+{ ix, ... }:
+
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "claude-history-sync";
+  meta.mainProgram = "claude-history-sync";
+}

--- a/packages/claude-history-sync/package.nix
+++ b/packages/claude-history-sync/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "claude-history-sync";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/claude-history-sync/src/main.rs
+++ b/packages/claude-history-sync/src/main.rs
@@ -1,0 +1,113 @@
+//! `claude-history-sync`: sync Claude Code transcripts to R2 parquet (queryable
+//! with polars) and Mixedbread (semantic search). One parse pass feeds both
+//! sinks; each is opt-in by config, and both skip content already uploaded.
+
+mod parquet_sink;
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use claude_history::ClaudeHistoryExport;
+use clap::Parser;
+use search_core::{MixedbreadStore, sync_documents};
+
+/// How long to wait for Mixedbread to finish embedding new documents.
+const INDEX_TIMEOUT: Duration = Duration::from_mins(2);
+
+/// Sync Claude Code agent transcripts to an S3/R2 parquet archive and/or a
+/// Mixedbread store.
+#[derive(Debug, Parser)]
+#[command(name = "claude-history-sync", about, version)]
+struct Cli {
+    /// Transcript directory (default: `~/.claude/projects`).
+    #[arg(long)]
+    dir: Option<PathBuf>,
+
+    /// Bucket for the parquet archive; enables the S3/R2 sink. Credentials come
+    /// from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.
+    #[arg(long, env = "CLAUDE_HISTORY_R2_BUCKET")]
+    r2_bucket: Option<String>,
+
+    /// S3 endpoint URL; empty means AWS S3, for R2 pass the account endpoint.
+    #[arg(long, env = "CLAUDE_HISTORY_R2_ENDPOINT")]
+    r2_endpoint: Option<String>,
+
+    /// S3 region (`auto` for R2).
+    #[arg(long, env = "CLAUDE_HISTORY_R2_REGION", default_value = "auto")]
+    r2_region: String,
+
+    /// Key prefix under the bucket.
+    #[arg(long, env = "CLAUDE_HISTORY_PREFIX", default_value = "claude-history")]
+    prefix: String,
+
+    /// Mixedbread store name; enables the Mixedbread sink.
+    #[arg(long, env = "MXBAI_STORE")]
+    mixedbread_store: Option<String>,
+
+    /// Mixedbread API base URL.
+    #[arg(long = "base-url", env = "MXBAI_BASE_URL")]
+    base_url: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    if cli.r2_bucket.is_none() && cli.mixedbread_store.is_none() {
+        anyhow::bail!("nothing to do: pass --r2-bucket and/or --mixedbread-store");
+    }
+
+    let dir = match cli.dir {
+        Some(dir) => dir,
+        None => default_dir()?,
+    };
+    let export = ClaudeHistoryExport::open(&dir).context("parsing Claude transcripts")?;
+    eprintln!("parsed {} messages from {}", export.len(), dir.display());
+
+    if let Some(store_name) = &cli.mixedbread_store {
+        let base_url = cli
+            .base_url
+            .clone()
+            .unwrap_or_else(|| mixedbread::DEFAULT_BASE_URL.to_owned());
+        let store = MixedbreadStore::from_login(base_url)
+            .await
+            .context("connecting to Mixedbread")?;
+        let report = sync_documents(&export, &store, store_name, INDEX_TIMEOUT, |_, _| {})
+            .await
+            .context("Mixedbread sync")?;
+        eprintln!(
+            "mixedbread: uploaded {}, skipped {} of {}",
+            report.uploaded, report.skipped, report.total
+        );
+    }
+
+    if let Some(bucket) = &cli.r2_bucket {
+        let config = parquet_sink::Config {
+            bucket: bucket.clone(),
+            endpoint: cli.r2_endpoint.clone(),
+            region: cli.r2_region.clone(),
+            prefix: cli.prefix.clone(),
+            host: hostname(),
+        };
+        let report = parquet_sink::sync(export.messages(), &config)
+            .await
+            .context("R2 parquet sync")?;
+        eprintln!("r2: uploaded {} sessions, skipped {}", report.uploaded, report.skipped);
+    }
+
+    Ok(())
+}
+
+/// Default transcript directory: `~/.claude/projects`.
+fn default_dir() -> anyhow::Result<PathBuf> {
+    let home = dirs::home_dir().context("no home directory")?;
+    Ok(home.join(".claude").join("projects"))
+}
+
+/// Short hostname for the manifest key and the `host=` parquet partition.
+fn hostname() -> String {
+    nix::unistd::gethostname()
+        .ok()
+        .map_or_else(|| "unknown".to_owned(), |name| name.to_string_lossy().into_owned())
+}

--- a/packages/claude-history-sync/src/parquet_sink.rs
+++ b/packages/claude-history-sync/src/parquet_sink.rs
@@ -1,0 +1,298 @@
+//! Write Claude transcript messages to an S3-compatible bucket (Cloudflare R2)
+//! as hive-partitioned parquet, one file per session, so polars and duckdb can
+//! query the whole tree (`scan_parquet("s3://.../claude-history/**/*.parquet")`).
+//!
+//! A per-host manifest object (`<prefix>/_manifest/<host>.json`) records each
+//! session's content hash, so a re-run only re-uploads sessions whose
+//! transcript actually changed. The layout is
+//! `<prefix>/host=<h>/user=<u>/project=<p>/session=<sid>.parquet`; partition
+//! values are sanitized so a `cwd`-derived project never injects path
+//! separators.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use claude_history::Message;
+use object_store::aws::{AmazonS3, AmazonS3Builder};
+use object_store::path::Path as ObjectPath;
+use object_store::{ObjectStoreExt, PutPayload};
+use parquet::arrow::ArrowWriter;
+use sha2::{Digest as _, Sha256};
+use snafu::{IntoError as _, ResultExt as _, Snafu};
+
+/// Connection and layout for the S3/R2 archive sink.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Target bucket name.
+    pub bucket: String,
+    /// S3 endpoint URL. `None` uses AWS S3; for R2 pass the account endpoint.
+    pub endpoint: Option<String>,
+    /// Region (`auto` for R2).
+    pub region: String,
+    /// Key prefix under the bucket (e.g. `claude-history`).
+    pub prefix: String,
+    /// Short hostname, the manifest key and the `host=` partition value.
+    pub host: String,
+}
+
+/// Failures from the S3 parquet sink.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum Error {
+    /// The S3 client could not be built from the config and environment.
+    #[snafu(display("failed to build the S3 client for bucket {bucket}"))]
+    BuildStore {
+        /// Bucket the client targeted.
+        bucket: String,
+        /// Underlying object-store error.
+        source: object_store::Error,
+    },
+    /// An object could not be read.
+    #[snafu(display("failed to read object {path}"))]
+    Get {
+        /// Object key.
+        path: String,
+        /// Underlying object-store error.
+        source: object_store::Error,
+    },
+    /// An object could not be written.
+    #[snafu(display("failed to write object {path}"))]
+    Put {
+        /// Object key.
+        path: String,
+        /// Underlying object-store error.
+        source: object_store::Error,
+    },
+    /// The manifest object did not parse as JSON.
+    #[snafu(display("failed to parse the manifest {path}"))]
+    Manifest {
+        /// Manifest key.
+        path: String,
+        /// Underlying serde error.
+        source: serde_json::Error,
+    },
+    /// The manifest could not be serialized.
+    #[snafu(display("failed to serialize the manifest"))]
+    SerializeManifest {
+        /// Underlying serde error.
+        source: serde_json::Error,
+    },
+    /// A record batch could not be assembled from a session.
+    #[snafu(display("failed to build the record batch"))]
+    Batch {
+        /// Underlying arrow error.
+        source: arrow::error::ArrowError,
+    },
+    /// Parquet encoding failed.
+    #[snafu(display("failed to encode parquet"))]
+    Encode {
+        /// Underlying parquet error.
+        source: parquet::errors::ParquetError,
+    },
+}
+
+/// Result alias defaulting to this module's [`Error`].
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Outcome of one S3 sync pass.
+#[derive(Debug, Clone, Copy)]
+pub struct Report {
+    /// Sessions whose parquet was (re)uploaded.
+    pub uploaded: usize,
+    /// Sessions skipped because their content hash was unchanged.
+    pub skipped: usize,
+}
+
+/// Sync `messages` to the bucket as per-session parquet, skipping sessions whose
+/// content hash matches the per-host manifest.
+///
+/// # Errors
+/// Returns an error if the client cannot be built, the manifest or any object
+/// cannot be read or written, or a batch cannot be encoded.
+pub async fn sync(messages: &[Message], config: &Config) -> Result<Report> {
+    let store = build_store(config)?;
+    let manifest_path =
+        ObjectPath::from(format!("{}/_manifest/{}.json", config.prefix, sanitize(&config.host)));
+    let mut manifest = load_manifest(&store, &manifest_path).await?;
+
+    // Group by session, preserving transcript order within each session so the
+    // content hash is stable for an unchanged session.
+    let mut by_session: BTreeMap<&str, Vec<&Message>> = BTreeMap::new();
+    for message in messages {
+        by_session.entry(message.session_id.as_str()).or_default().push(message);
+    }
+
+    let mut uploaded = 0;
+    let mut skipped = 0;
+    for (session_id, session) in &by_session {
+        let Some(first) = session.first().copied() else {
+            continue;
+        };
+        let hash = session_hash(session);
+        if manifest.get(*session_id).is_some_and(|existing| existing == &hash) {
+            skipped += 1;
+            continue;
+        }
+
+        let batch = record_batch(session)?;
+        let bytes = encode_parquet(&batch)?;
+        let key = object_key(config, first, session_id);
+        store
+            .put(&key, PutPayload::from(bytes))
+            .await
+            .context(PutSnafu { path: key.to_string() })?;
+        manifest.insert((*session_id).to_owned(), hash);
+        uploaded += 1;
+    }
+
+    save_manifest(&store, &manifest_path, &manifest).await?;
+    Ok(Report { uploaded, skipped })
+}
+
+/// Build the S3 client. Credentials come from the environment
+/// (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`).
+fn build_store(config: &Config) -> Result<AmazonS3> {
+    let mut builder = AmazonS3Builder::from_env()
+        .with_bucket_name(&config.bucket)
+        .with_region(&config.region);
+    if let Some(endpoint) = &config.endpoint {
+        builder = builder.with_endpoint(endpoint);
+    }
+    builder
+        .build()
+        .context(BuildStoreSnafu { bucket: config.bucket.clone() })
+}
+
+/// Object key for one session's parquet, hive-partitioned by host/user/project.
+fn object_key(config: &Config, first: &Message, session_id: &str) -> ObjectPath {
+    ObjectPath::from(format!(
+        "{}/host={}/user={}/project={}/session={}.parquet",
+        config.prefix,
+        sanitize(&first.host),
+        sanitize(&first.user),
+        sanitize(&first.project),
+        sanitize(session_id),
+    ))
+}
+
+/// Load the per-host manifest, or an empty map when it does not exist yet.
+async fn load_manifest(store: &AmazonS3, path: &ObjectPath) -> Result<BTreeMap<String, String>> {
+    let result = match store.get(path).await {
+        Ok(result) => result,
+        Err(object_store::Error::NotFound { .. }) => return Ok(BTreeMap::new()),
+        Err(source) => return Err(GetSnafu { path: path.to_string() }.into_error(source)),
+    };
+    let bytes = result.bytes().await.context(GetSnafu { path: path.to_string() })?;
+    serde_json::from_slice(&bytes).context(ManifestSnafu { path: path.to_string() })
+}
+
+/// Write the manifest back.
+async fn save_manifest(
+    store: &AmazonS3,
+    path: &ObjectPath,
+    manifest: &BTreeMap<String, String>,
+) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(manifest).context(SerializeManifestSnafu)?;
+    store
+        .put(path, PutPayload::from(bytes))
+        .await
+        .context(PutSnafu { path: path.to_string() })?;
+    Ok(())
+}
+
+/// The arrow schema: every transcript tag as a nullable column.
+fn schema() -> Schema {
+    let text = |name: &str| Field::new(name, DataType::Utf8, true);
+    let int = |name: &str| Field::new(name, DataType::Int64, true);
+    Schema::new(vec![
+        text("host"),
+        text("user"),
+        text("project"),
+        text("session_id"),
+        text("message_uuid"),
+        text("parent_uuid"),
+        text("role"),
+        text("record_type"),
+        text("model"),
+        text("cwd"),
+        text("git_branch"),
+        text("tool_name"),
+        int("input_tokens"),
+        int("output_tokens"),
+        int("timestamp"),
+        text("body"),
+    ])
+}
+
+/// Build one session's record batch (one row per message).
+fn record_batch(session: &[&Message]) -> Result<RecordBatch> {
+    let columns: Vec<ArrayRef> = vec![
+        text_column(session, |m| Some(m.host.as_str())),
+        text_column(session, |m| Some(m.user.as_str())),
+        text_column(session, |m| Some(m.project.as_str())),
+        text_column(session, |m| Some(m.session_id.as_str())),
+        text_column(session, |m| Some(m.uuid.as_str())),
+        text_column(session, |m| m.parent_uuid.as_deref()),
+        text_column(session, |m| Some(m.role.as_str())),
+        text_column(session, |m| Some(m.record_type.as_str())),
+        text_column(session, |m| m.model.as_deref()),
+        text_column(session, |m| m.cwd.as_deref()),
+        text_column(session, |m| m.git_branch.as_deref()),
+        text_column(session, |m| m.tool_name.as_deref()),
+        int_column(session, |m| m.input_tokens),
+        int_column(session, |m| m.output_tokens),
+        int_column(session, |m| m.timestamp),
+        text_column(session, |m| Some(m.body.as_str())),
+    ];
+    RecordBatch::try_new(Arc::new(schema()), columns).context(BatchSnafu)
+}
+
+/// A nullable UTF-8 column projected from each message.
+fn text_column(session: &[&Message], project: impl Fn(&Message) -> Option<&str>) -> ArrayRef {
+    Arc::new(session.iter().copied().map(project).collect::<StringArray>())
+}
+
+/// A nullable i64 column projected from each message.
+fn int_column(session: &[&Message], project: impl Fn(&Message) -> Option<i64>) -> ArrayRef {
+    Arc::new(session.iter().copied().map(project).collect::<Int64Array>())
+}
+
+/// Encode a record batch to parquet bytes in memory.
+fn encode_parquet(batch: &RecordBatch) -> Result<Vec<u8>> {
+    let mut buffer = Vec::new();
+    let mut writer = ArrowWriter::try_new(&mut buffer, batch.schema(), None).context(EncodeSnafu)?;
+    writer.write(batch).context(EncodeSnafu)?;
+    writer.close().context(EncodeSnafu)?;
+    Ok(buffer)
+}
+
+/// Content hash of a session: sha256 over each message's uuid and body, in
+/// transcript order. Appending a message changes the hash, triggering a
+/// re-upload; an unchanged session hashes identically and is skipped.
+fn session_hash(session: &[&Message]) -> String {
+    let mut digest = Sha256::new();
+    for message in session.iter().copied() {
+        digest.update(message.uuid.as_bytes());
+        digest.update([0]);
+        digest.update(message.body.as_bytes());
+        digest.update([0]);
+    }
+    format!("{:x}", digest.finalize())
+}
+
+/// Make a partition value safe for an object key: keep alphanumerics and
+/// `.`/`_`/`-`, replace everything else (notably `/` from a `cwd` path) with `_`.
+fn sanitize(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}

--- a/packages/claude-history-sync/src/parquet_sink.rs
+++ b/packages/claude-history-sync/src/parquet_sink.rs
@@ -126,6 +126,7 @@ pub async fn sync(messages: &[Message], config: &Config) -> Result<Report> {
 
     let mut uploaded = 0;
     let mut skipped = 0;
+    let mut failure = None;
     for (session_id, session) in &by_session {
         let Some(first) = session.first().copied() else {
             continue;
@@ -139,15 +140,25 @@ pub async fn sync(messages: &[Message], config: &Config) -> Result<Report> {
         let batch = record_batch(session)?;
         let bytes = encode_parquet(&batch)?;
         let key = object_key(config, first, session_id);
-        store
-            .put(&key, PutPayload::from(bytes))
-            .await
-            .context(PutSnafu { path: key.to_string() })?;
-        manifest.insert((*session_id).to_owned(), hash);
-        uploaded += 1;
+        // Record each success in the manifest as it lands, and persist the
+        // manifest even if a later put fails, so a re-run does not re-upload the
+        // sessions that already succeeded this pass.
+        match store.put(&key, PutPayload::from(bytes)).await {
+            Ok(_) => {
+                manifest.insert((*session_id).to_owned(), hash);
+                uploaded += 1;
+            }
+            Err(source) => {
+                failure = Some(PutSnafu { path: key.to_string() }.into_error(source));
+                break;
+            }
+        }
     }
 
     save_manifest(&store, &manifest_path, &manifest).await?;
+    if let Some(failure) = failure {
+        return Err(failure);
+    }
     Ok(Report { uploaded, skipped })
 }
 
@@ -202,14 +213,19 @@ async fn save_manifest(
     Ok(())
 }
 
-/// The arrow schema: every transcript tag as a nullable column.
+/// The arrow schema: the per-message fields as nullable columns.
+///
+/// `host`/`user`/`project`/`session` are intentionally NOT columns: they are the
+/// hive partition keys in the object path. Polars `hive_partitioning=True` would
+/// otherwise drop a same-named file column and substitute the (sanitized) path
+/// value, which for `project` loses the real `/`-bearing path. The authoritative
+/// per-message working directory is kept in `cwd` (not a partition key, so it
+/// survives), and `session_id` is kept too (the `session=` key uses a different
+/// name, so there is no clobber).
 fn schema() -> Schema {
     let text = |name: &str| Field::new(name, DataType::Utf8, true);
     let int = |name: &str| Field::new(name, DataType::Int64, true);
     Schema::new(vec![
-        text("host"),
-        text("user"),
-        text("project"),
         text("session_id"),
         text("message_uuid"),
         text("parent_uuid"),
@@ -221,6 +237,7 @@ fn schema() -> Schema {
         text("tool_name"),
         int("input_tokens"),
         int("output_tokens"),
+        // Epoch seconds (matches the Mixedbread `timestamp` tag).
         int("timestamp"),
         text("body"),
     ])
@@ -229,9 +246,6 @@ fn schema() -> Schema {
 /// Build one session's record batch (one row per message).
 fn record_batch(session: &[&Message]) -> Result<RecordBatch> {
     let columns: Vec<ArrayRef> = vec![
-        text_column(session, |m| Some(m.host.as_str())),
-        text_column(session, |m| Some(m.user.as_str())),
-        text_column(session, |m| Some(m.project.as_str())),
         text_column(session, |m| Some(m.session_id.as_str())),
         text_column(session, |m| Some(m.uuid.as_str())),
         text_column(session, |m| m.parent_uuid.as_deref()),
@@ -295,4 +309,79 @@ fn sanitize(value: &str) -> String {
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, object_key, record_batch, sanitize, schema, session_hash};
+    use claude_history::Message;
+
+    fn sample(uuid: &str, body: &str) -> Message {
+        Message {
+            host: "host1".to_owned(),
+            user: "user1".to_owned(),
+            project: "/Users/x/proj".to_owned(),
+            session_id: "sess1".to_owned(),
+            uuid: uuid.to_owned(),
+            parent_uuid: None,
+            role: "user".to_owned(),
+            record_type: "user".to_owned(),
+            model: None,
+            cwd: Some("/Users/x/proj".to_owned()),
+            git_branch: None,
+            tool_name: None,
+            input_tokens: None,
+            output_tokens: None,
+            timestamp: Some(1),
+            body: body.to_owned(),
+        }
+    }
+
+    #[test]
+    fn sanitize_replaces_path_unsafe_chars() {
+        assert_eq!(sanitize("/Users/x/a-b.c"), "_Users_x_a-b.c");
+        assert_eq!(sanitize("plain"), "plain");
+        assert_eq!(sanitize("a b/c=d"), "a_b_c_d");
+    }
+
+    #[test]
+    fn session_hash_is_stable_and_body_sensitive() {
+        let first = sample("u1", "hello");
+        let same = sample("u1", "hello");
+        let changed = sample("u1", "changed");
+        assert_eq!(session_hash(&[&first]), session_hash(&[&same]));
+        assert_ne!(session_hash(&[&first]), session_hash(&[&changed]));
+    }
+
+    #[test]
+    fn distinct_messages_do_not_collide() {
+        let a = sample("u1", "x");
+        let b = sample("u2", "y");
+        assert_ne!(session_hash(&[&a]), session_hash(&[&b]));
+    }
+
+    #[test]
+    fn object_key_is_hive_partitioned_and_sanitized() {
+        let config = Config {
+            bucket: "b".to_owned(),
+            endpoint: None,
+            region: "auto".to_owned(),
+            prefix: "claude-history".to_owned(),
+            host: "host1".to_owned(),
+        };
+        let key = object_key(&config, &sample("u1", "x"), "sess1");
+        assert_eq!(
+            key.to_string(),
+            "claude-history/host=host1/user=user1/project=_Users_x_proj/session=sess1.parquet"
+        );
+    }
+
+    #[test]
+    fn record_batch_columns_match_schema() {
+        let a = sample("u1", "x");
+        let b = sample("u2", "y");
+        let batch = record_batch(&[&a, &b]).expect("batch");
+        assert_eq!(batch.num_columns(), schema().fields().len());
+        assert_eq!(batch.num_rows(), 2);
+    }
 }

--- a/packages/claude-history/src/lib.rs
+++ b/packages/claude-history/src/lib.rs
@@ -28,8 +28,9 @@ use search_meta::{Document, Source, SourceAdapter};
 use snafu::ResultExt as _;
 
 pub use crate::error::Error;
+pub use crate::record::Message;
 use crate::error::{HostNameSnafu, ListDirSnafu, Result};
-use crate::record::{Message, MessageOrigin};
+use crate::record::MessageOrigin;
 
 /// The `source` tag every Claude transcript document carries.
 pub const SOURCE_TAG: &str = "claude_history";
@@ -89,6 +90,14 @@ impl ClaudeHistoryExport {
     #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.messages.is_empty()
+    }
+
+    /// The parsed messages, in transcript order across all sessions. The R2
+    /// parquet sink consumes these as rows; the Mixedbread sink uses the
+    /// [`SourceAdapter`] projection instead.
+    #[must_use]
+    pub fn messages(&self) -> &[Message] {
+        &self.messages
     }
 }
 


### PR DESCRIPTION
Adds `claude-history-sync`: the unified syncer that lands Claude Code transcripts in **both** sinks from one parse pass — R2/S3 as hive-partitioned **parquet** (polars-queryable) and **Mixedbread** (semantic search). Builds on #485's `claude-history` adapter.

- **S3 sink**: one parquet file per session under `host=/user=/project=/session=`, with a per-host manifest so unchanged sessions are skipped. `object_store` + `arrow` + `parquet`, wired through `[workspace.dependencies]`.
- **Mixedbread sink**: reuses `search-core::sync_documents` (content-hash dedup).
- Each sink is opt-in by flag (`--r2-bucket`, `--mixedbread-store`).

Verified: `nix build .#claude-history-sync` and the Linux clippy check. Live R2 round-trip is pending a bucket + token.

Follow-ups: codex/shell adapters, the portable launchd/systemd module, then delete ix `history-ship`.

_(Made with AI assistance — Claude Opus 4.8.)_


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `claude-history-sync` CLI to sync Claude transcripts to S3 parquet and Mixedbread
> - Introduces a new `claude-history-sync` binary that reads Claude transcript exports from `~/.claude/projects` and syncs them to two optional sinks: an S3-compatible parquet archive and a Mixedbread vector store.
> - The S3 sink writes hive-partitioned parquet files (`host/user/project/session.parquet`) and maintains a per-host manifest under `<prefix>/_manifest/<host>.json` to skip unchanged sessions using SHA-256 content hashes.
> - The Mixedbread sink uses `search_core::MixedbreadStore` with a 2-minute embedding timeout (`INDEX_TIMEOUT`) to wait for indexing to complete.
> - Adds `arrow`, `parquet`, and `object_store` workspace dependencies and exposes `claude_history::Message` publicly from the crate root.
> - Risk: if neither sink is configured via flags or env vars, the binary exits with an error rather than a no-op.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af4ec0f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->