### PR TITLE
images/dev: default Claude Code to bypassPermissions in the dev VM

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -148,6 +148,9 @@
         # Workstation-facing home-manager module: declare a service once, get a
         # native launchd agent on macOS and native systemd user units on Linux.
         portable-services = ix.portableServices.homeModule;
+        # Declarative-but-writable JSON config files (last-applied 3-way merge),
+        # for config an app rewrites at runtime. See lib/mutable-json.nix.
+        mutable-json = ix.mutableJson.homeModule;
         # Personal-but-shareable workstation module for github:andrewgazelka: the
         # ix.dev downtime watcher + boss bar overlay + the shared say-detached
         # sound helper, all as portable services. Closed over the per-system

--- a/images/dev/development-base/default.nix
+++ b/images/dev/development-base/default.nix
@@ -3,7 +3,33 @@
 # control, editors, the nushell workspace wrapper, gdb/lldb, strace, tcpdump,
 # jq, btop, bpftrace, lsof, ncdu, pv, file, and the gnutar/gzip/zstd trio
 # needed to stay `ix switch`-able.
-{ lib, pkgs, ... }:
+{
+  ix,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  # Claude Code refuses bypass-permissions mode for the root user unless it is
+  # told it is sandboxed. The shipped 2.x bundle guards both
+  # `--dangerously-skip-permissions` and a settings.json
+  # `permissions.defaultMode = "bypassPermissions"` behind
+  # `getuid() === 0 && IS_SANDBOX !== "1" && !CLAUDE_CODE_BUBBLEWRAP`, and
+  # otherwise exits with "cannot be used with root/sudo privileges". The agent
+  # runs as root in this guest, so without the signal the bypass default below
+  # is silently rejected. The guest VM is precisely the sandbox that guard asks
+  # about, so bake IS_SANDBOX=1 into the claude binary. A wrapper (rather than a
+  # global `environment.variables`) keeps the blast radius to claude and reaches
+  # every launch path, including non-login `ssh root@vm -- claude` and `ix
+  # shell` exec, which never source the login-shell environment. Named with the
+  # upstream version so `lib.getName` stays "claude-code".
+  claude-code =
+    pkgs.runCommand "claude-code-${pkgs.claude-code.version}"
+      { nativeBuildInputs = [ pkgs.makeWrapper ]; }
+      ''
+        makeWrapper ${pkgs.claude-code}/bin/claude "$out/bin/claude" --set IS_SANDBOX 1
+      '';
+in
 {
   ix.image.name = "development-base";
 
@@ -15,34 +41,82 @@
   nixpkgs.config.allowUnfreePredicate =
     pkg: builtins.elem (pkg.pname or (lib.getName pkg)) [ "claude-code" ];
 
-  environment.systemPackages = builtins.attrValues {
-    inherit (pkgs)
-      # Coding agents. Both authenticate at first use inside the VM; no
-      # API keys are baked into the image per the trust model.
+  environment.systemPackages =
+    builtins.attrValues {
+      inherit (pkgs)
+        # Coding agent. codex authenticates at first use inside the VM; no API
+        # keys are baked into the image per the trust model. Claude Code rides
+        # along below, wrapped for sandbox mode.
+        codex
+
+        # Browser automation for agents. `agent-browser` (vercel-labs) is the
+        # CLI surface; `chromium` is the actual browser it drives. agent-browser
+        # auto-detects a Chromium binary on PATH so no extra wiring is needed.
+        # Kept local-only (no Browserbase / cloud provider) so sandboxes work
+        # offline and don't need outbound API keys.
+        agent-browser
+        chromium
+
+        # Build toolchain. Most ecosystems lean on cmake / make / ninja and
+        # pkg-config; rustup keeps the toolchain pinnable per-project rather
+        # than locking the image to one rustc.
+        cmake
+        gcc
+        gnumake
+        ninja
+        pkg-config
+        rustup
+
+        # Default language runtimes that show up across most dev sessions.
+        nodejs
+        python3
+        ;
+    }
+    ++ [
+      # Claude Code, wrapped to advertise the sandbox (IS_SANDBOX=1) so the
+      # bypass-permissions default below is honored for root. Same first-use
+      # auth, no baked keys.
       claude-code
-      codex
+    ];
 
-      # Browser automation for agents. `agent-browser` (vercel-labs) is the
-      # CLI surface; `chromium` is the actual browser it drives. agent-browser
-      # auto-detects a Chromium binary on PATH so no extra wiring is needed.
-      # Kept local-only (no Browserbase / cloud provider) so sandboxes work
-      # offline and don't need outbound API keys.
-      agent-browser
-      chromium
-
-      # Build toolchain. Most ecosystems lean on cmake / make / ninja and
-      # pkg-config; rustup keeps the toolchain pinnable per-project rather
-      # than locking the image to one rustc.
-      cmake
-      gcc
-      gnumake
-      ninja
-      pkg-config
-      rustup
-
-      # Default language runtimes that show up across most dev sessions.
-      nodejs
-      python3
-      ;
+  # Claude Code defaults for the dev image: a writable, Nix-generated
+  # settings.json.
+  #
+  # This image only ever runs inside a per-tenant ix VM (or an `ix shell` user
+  # on one), which is the real trust boundary: the agent can touch nothing but
+  # this guest's disposable filesystem, network, and processes. Per-tool
+  # approval prompts buy nothing here and only stall an agent that has nowhere
+  # unsafe to go, so inside the guest we hand Claude full authority. The
+  # enforcement that actually matters belongs to the sandbox that owns the
+  # guest, whether that is the VM boundary or the OS user the agent runs as,
+  # not to a confirmation dialog the agent answers itself.
+  #
+  # `permissions.defaultMode = "bypassPermissions"` runs every tool without an
+  # approval prompt; `skipDangerousModePermissionPrompt` pre-accepts the
+  # one-time bypass-mode warning so a fresh interactive launch does not stall on
+  # the confirmation dialog (both honored only in user-scope settings.json,
+  # which this is). Mirrors the ix fleet default in ix's
+  # nix/homes/modules/llm.nix. Root additionally needs the IS_SANDBOX=1 signal
+  # from the wrapped claude-code above, or this mode is rejected.
+  #
+  # Delivered as a WRITABLE file, not a read-only /nix/store symlink (what
+  # home.file and home-manager's programs.claude-code emit): Claude's in-app
+  # settings pane writes back to settings.json, and other agents (Codex, ...)
+  # rewrite their own config too, so a read-only symlink would make every such
+  # write fail with a permission error. The mutable-json module keeps it both
+  # Nix-declared (so the defaults stay composable, unlike mkOutOfStoreSymlink's
+  # raw file) and writable, reconciling with a last-applied 3-way merge on each
+  # switch: our keys are enforced, the app's own keys are preserved. See
+  # lib/mutable-json.nix.
+  home-manager.users.root = {
+    imports = [ ix.mutableJson.homeModule ];
+    home.mutableJsonFiles.claude-code = {
+      target = ".claude/settings.json";
+      value = {
+        "$schema" = "https://json.schemastore.org/claude-code-settings.json";
+        permissions.defaultMode = "bypassPermissions";
+        skipDangerousModePermissionPrompt = true;
+      };
+    };
   };
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -68,6 +68,11 @@ let
   # consumers as `homeModules.portable-services` from the flake.
   portableServices = import ./portable-services.nix { inherit lib; };
 
+  # Declarative-but-writable JSON config files (last-applied 3-way merge for
+  # files an app rewrites at runtime). Also a home-manager module, not a NixOS
+  # one, so it stays outside `modules/`. Exposed as `homeModules.mutable-json`.
+  mutableJson = import ./mutable-json.nix { inherit lib; };
+
   # Flat list of module paths from the auto-discovered registry under
   # `modules/`. Pulled in unconditionally so every option is in scope; each
   # module stays inert until its `enable` flag is set.
@@ -321,6 +326,7 @@ let
       mkMinecraftLoader
       mkMinecraftNbtFormat
       mkMinecraftSyncManaged
+      mutableJson
       relativePath
       rustWorkspace
       rustWorkspaceFor
@@ -390,6 +396,7 @@ let
       discoverModules
       nixosModules
       portableServices
+      mutableJson
       exampleFleetsFor
       artifacts
       agentContext

--- a/lib/mutable-json-merge.jq
+++ b/lib/mutable-json-merge.jq
@@ -1,0 +1,47 @@
+# Last-applied 3-way merge for a JSON config file that an app also writes to.
+#
+#   result = deepmerge( prune(live, last \ new), new )
+#
+#   * prune     drop keys we previously declared (`last`) but no longer declare
+#               (`new`), compared as leaf-path sets so a key whose type changed
+#               between declarations is handled without indexing errors. If the
+#               live file diverged in shape at a pruned path (e.g. the app
+#               replaced an object with a scalar), that path is left as-is rather
+#               than failing the activation. A leaf that was the last child of an
+#               object leaves an empty `{}` parent behind (harmless).
+#   * deepmerge our declared keys (`new`) win; objects merge recursively, arrays
+#               are atomic (a declared array replaces the live one wholesale).
+#   * preserve  every other key in `live` (the app's own writes) survives.
+#
+# This is the kubectl-apply "last-applied" model: the previous declaration is the
+# merge base, so dropping a key from Nix prunes it without clobbering app state.
+# Single declarative owner only; for multiple Nix-side owners of one file you
+# want per-field ownership (Server-Side Apply), which this does not implement.
+#
+# Inputs via --argjson: $last (previous declaration, {} if none), $live (current
+# file, {} if absent), $new (desired declaration). Emits the merged object.
+
+# Paths to "managed leaves": recurse through objects only, so arrays and scalars
+# are treated as atomic leaf values (a declared array is owned as a unit).
+def managedLeaves($prefix):
+  to_entries[]
+  | .key as $k
+  | .value as $v
+  | ($prefix + [$k]) as $p
+  | if ($v | type) == "object" then ($v | managedLeaves($p)) else $p end;
+
+def deepmerge($a; $b):
+  if ($a | type) == "object" and ($b | type) == "object"
+  then reduce ($b | keys_unsorted[]) as $k ($a; .[$k] = deepmerge($a[$k]; $b[$k]))
+  else $b
+  end;
+
+# Compare managed-leaf path sets (never feeds a bad path to getpath), prune the
+# paths we dropped, and leave the live shape untouched at any path delpaths
+# cannot follow (try/catch) instead of aborting the activation.
+( [ $last | managedLeaves([]) ] ) as $lastPaths
+| ( [ $new | managedLeaves([]) ] ) as $newPaths
+| ( reduce ($lastPaths - $newPaths)[] as $p
+      ($live; . as $acc | try delpaths([$p]) catch $acc)
+  ) as $pruned
+| deepmerge($pruned; $new)

--- a/lib/mutable-json.nix
+++ b/lib/mutable-json.nix
@@ -1,0 +1,114 @@
+# Declarative-but-writable JSON config files.
+#
+# Some apps (Claude Code's settings pane, Codex, ...) rewrite their own config at
+# runtime, so a read-only `/nix/store` symlink (`home.file`) makes those writes
+# fail with a permission error. The usual escape hatches each give something up:
+# `mkOutOfStoreSymlink` hands you a raw working-copy file with no Nix algebra
+# (no merge of contributions across modules, no types), and a plain
+# activation-copy overwrites the app's runtime writes on every switch.
+#
+# This module keeps the file writable AND Nix-declared by reconciling with a
+# last-applied 3-way merge (the kubectl-apply model): on activation it computes
+#
+#   result = deepmerge( prune(live, last \ new), new )
+#
+# so Nix enforces the keys it declares, prunes keys it stops declaring, and
+# preserves everything the app wrote itself. The previous declaration is recorded
+# under `xdg.stateHome` so "what Nix used to own" is known across switches. The
+# merge itself lives in the sidecar `mutable-json-merge.jq`.
+#
+# Scope: a single declarative owner per file. Multiple Nix-side owners of one
+# file would need per-field ownership (Server-Side Apply), which this is not.
+#
+# Exposed from the flake as `homeModules.mutable-json`; see
+# `images/dev/development-base` for a consumer and `tests/` for the merge cases.
+{ lib }:
+let
+  inherit (lib) types mkOption;
+
+  homeModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.home.mutableJsonFiles;
+      jsonFormat = pkgs.formats.json { };
+      mergeProgram = ./mutable-json-merge.jq;
+      stateDir = "${config.xdg.stateHome}/home-manager/mutable-json";
+
+      resolveTarget =
+        target: if lib.hasPrefix "/" target then target else "${config.home.homeDirectory}/${target}";
+
+      # One reconcile step: deep-merge the Nix-declared `value` over the live file
+      # (3-way against the recorded last-applied), write it back atomically, then
+      # record the new declaration as the next last-applied. Store paths are
+      # interpolated raw; caller-influenced paths go through escapeShellArg.
+      mkReconcile =
+        name: entry:
+        let
+          target = resolveTarget entry.target;
+          desired = jsonFormat.generate "mutable-json-${name}.json" entry.value;
+          # One state file per target, keyed by a hash so odd paths stay safe.
+          state = "${stateDir}/${builtins.hashString "sha256" target}.json";
+          targetArg = lib.escapeShellArg target;
+          stateArg = lib.escapeShellArg state;
+        in
+        ''
+          ${pkgs.coreutils}/bin/mkdir -p "$(${pkgs.coreutils}/bin/dirname ${targetArg})" ${lib.escapeShellArg stateDir}
+          # An absent (or unreadable) target/state file is treated as empty `{}`;
+          # malformed JSON in either makes jq fail below and aborts the switch
+          # rather than silently overwriting.
+          _live=$([ -f ${targetArg} ] && ${pkgs.coreutils}/bin/cat ${targetArg} || ${pkgs.coreutils}/bin/echo '{}')
+          _last=$([ -f ${stateArg} ] && ${pkgs.coreutils}/bin/cat ${stateArg} || ${pkgs.coreutils}/bin/echo '{}')
+          _merged=$(${pkgs.jq}/bin/jq -n \
+            --argjson last "$_last" \
+            --argjson live "$_live" \
+            --argjson new "$(${pkgs.coreutils}/bin/cat ${desired})" \
+            -f ${mergeProgram})
+          ${pkgs.coreutils}/bin/printf '%s\n' "$_merged" > ${targetArg}.hm-mutable-json-tmp
+          ${pkgs.coreutils}/bin/mv -f ${targetArg}.hm-mutable-json-tmp ${targetArg}
+          ${pkgs.coreutils}/bin/install -m644 ${desired} ${stateArg}
+        '';
+    in
+    {
+      options.home.mutableJsonFiles = mkOption {
+        default = { };
+        description = ''
+          JSON config files that Nix declares but the owning app may also write
+          to at runtime. Each entry's `value` is reconciled into a writable
+          `target` with a last-applied 3-way merge on activation: declared keys
+          are enforced, keys Nix stops declaring are pruned, and the app's own
+          keys are preserved.
+        '';
+        type = types.attrsOf (
+          types.submodule {
+            options = {
+              target = mkOption {
+                type = types.str;
+                example = ".claude/settings.json";
+                description = "Destination file, absolute or relative to the home directory.";
+              };
+              value = mkOption {
+                inherit (jsonFormat) type;
+                description = "The keys Nix owns. Rendered to JSON and merged into `target`.";
+              };
+            };
+          }
+        );
+      };
+
+      config = lib.mkIf (cfg != { }) {
+        home.activation.mutableJsonFiles = lib.hm.dag.entryAfter [ "writeBoundary" ] (
+          lib.concatStringsSep "\n" (lib.mapAttrsToList mkReconcile cfg)
+        );
+      };
+    };
+in
+{
+  inherit homeModule;
+  # The merge program, exposed so tests can exercise it directly on fixtures.
+  mergeProgram = ./mutable-json-merge.jq;
+}

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -439,6 +439,39 @@ in
           test -d ${agentContextSkills}
           mkdir -p "$out"
         '';
+        # Pins the last-applied 3-way merge behind homeModules.mutable-json:
+        # first-install, preserve an app-written key, enforce a key the app
+        # changed, prune a key Nix stopped declaring, and keep a sibling key
+        # while a declared array is replaced atomically.
+        mutable-json-merge =
+          pkgs.runCommand "mutable-json-merge-check" { nativeBuildInputs = [ pkgs.jq ]; }
+            ''
+              prog=${ix.mutableJson.mergeProgram}
+              run() { jq -ncS --argjson last "$1" --argjson live "$2" --argjson new "$3" -f "$prog"; }
+              check() {
+                expected=$(printf '%s' "$2" | jq -cS .)
+                if [ "$expected" != "$3" ]; then
+                  echo "FAIL $1: expected $expected got $3" >&2
+                  exit 1
+                fi
+                echo "ok $1"
+              }
+              check first-install '{"permissions":{"defaultMode":"bypass"}}' \
+                "$(run '{}' '{}' '{"permissions":{"defaultMode":"bypass"}}')"
+              check preserve-app-key '{"permissions":{"defaultMode":"bypass"},"theme":"dark"}' \
+                "$(run '{"permissions":{"defaultMode":"bypass"}}' '{"permissions":{"defaultMode":"bypass"},"theme":"dark"}' '{"permissions":{"defaultMode":"bypass"}}')"
+              check enforce-changed '{"permissions":{"defaultMode":"bypass"},"theme":"dark"}' \
+                "$(run '{"permissions":{"defaultMode":"bypass"}}' '{"permissions":{"defaultMode":"off"},"theme":"dark"}' '{"permissions":{"defaultMode":"bypass"}}')"
+              check prune-dropped '{"a":1,"c":3}' \
+                "$(run '{"a":1,"b":2}' '{"a":1,"b":2,"c":3}' '{"a":1}')"
+              check nested-atomic-array '{"p":{"allow":["x"]},"t":1}' \
+                "$(run '{"p":{"allow":["x"]}}' '{"p":{"allow":["x","y"]},"t":1}' '{"p":{"allow":["x"]}}')"
+              # Divergent live shape at a path we stop declaring must not abort:
+              # the app replaced object `permissions` with a scalar, Nix dropped it.
+              check divergent-live-shape '{"permissions":"all"}' \
+                "$(run '{"permissions":{"defaultMode":"x"}}' '{"permissions":"all"}' '{}')"
+              mkdir -p "$out"
+            '';
         # Offline schema gate for the loader manifests. `deepSeq` forces
         # every Paper / Velocity / Fabric per-version lock through
         # `readLoaderManifest` in `lib/artifacts.nix`, so malformed JSON or a

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2361,6 +2361,15 @@ let
         assertion = !(builtins.elem "cursor-cli" developmentBase.packageNames);
         message = "development-base should keep unrelated unfree CLIs out of the image";
       }
+      {
+        # The bypass-permissions default is reconciled into root's settings.json
+        # via the mutable-json module. A refactor that drops it would silently
+        # restore per-tool prompts, so pin the declared value.
+        assertion =
+          developmentBase.config.home-manager.users.root.home.mutableJsonFiles.claude-code.value.permissions.defaultMode
+          == "bypassPermissions";
+        message = "development-base should default root's Claude Code to bypassPermissions";
+      }
     ];
 
     vitest = [


### PR DESCRIPTION
`development-base` bundled `claude-code` with no defaults, so every tool call prompted. The image only runs inside a disposable per-tenant ix VM (the real trust boundary), so per-tool prompts buy nothing: hand the agent full authority inside the guest and enforce at the sandbox (VM / OS user) layer.

**New: `homeModules.mutable-json`** (`lib/mutable-json.nix`)
Declare a JSON config file that the owning app also writes to at runtime. It is delivered as a **writable** file, not a read-only `/nix/store` symlink (which would make the app's own writes fail with a permission error: Claude's settings pane, Codex, etc. rewrite their config). On activation it reconciles with a **last-applied 3-way merge**: `result = deepmerge(prune(live, last \ new), new)` — Nix enforces the keys it declares, prunes keys it stops declaring, and preserves the app's own keys. Merge logic in `lib/mutable-json-merge.jq`, pinned by the `mutable-json-merge` flake check (5 fixtures). This is the kubectl-apply model; single declarative owner (not Server-Side Apply). See #491 for the design rationale.

**Dev image**
- Uses the module for root's `~/.claude/settings.json`: `permissions.defaultMode = bypassPermissions` + `skipDangerousModePermissionPrompt`, matching the ix fleet default (`nix/homes/modules/llm.nix`).
- Wraps `claude-code` with `IS_SANDBOX=1`: Claude refuses bypass mode for uid 0 unless told it is sandboxed (`getuid()==0 && IS_SANDBOX!="1" && !CLAUDE_CODE_BUBBLEWRAP`), and the agent runs as root. The wrapper covers every launch path including non-login `ssh root@vm -- claude`.

Validated: `nix run .#lint` clean; `mutable-json-merge` fixtures pass; reconcile simulated end-to-end (fresh install, then app writes `theme` + flips `defaultMode` → re-switch enforces `bypassPermissions` and keeps `theme`); dev image evaluates with the declared value.

Closes #491.

Made with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default Claude Code to bypassPermissions mode in the dev VM
> - Wraps the `claude` binary in the dev image to set `IS_SANDBOX=1` on every invocation, satisfying Claude Code's check before enabling bypass-permissions mode.
> - Adds a new `mutableJson` home-manager module ([lib/mutable-json.nix](https://github.com/indexable-inc/index/pull/487/files#diff-0e6084fa06e2632e7b50266763ce86db5734133ae4fcd86779e301ac54353fdd)) that declaratively manages writable JSON files using a last-applied 3-way merge via a jq script ([lib/mutable-json-merge.jq](https://github.com/indexable-inc/index/pull/487/files#diff-7566b43ec4f2de715e4c617ed11972532093b1093d0e70f684a42bf6337278c8)).
> - Uses this module to write `~/.claude/settings.json` for the root user with `permissions.defaultMode="bypassPermissions"` and `skipDangerousModePermissionPrompt=true`, while preserving any app-written keys.
> - Risk: malformed JSON in an existing live or last-applied file will abort home-manager activation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8451b78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->