### PR TITLE
feat(search): scope search by user/host/project

### DIFF
--- a/packages/search-core/src/query_filter.rs
+++ b/packages/search-core/src/query_filter.rs
@@ -16,13 +16,26 @@ pub struct FilterSpec {
     pub exclude_sources: Vec<Source>,
     /// Restrict code to this repository slug.
     pub repo: Option<String>,
+    /// Restrict to records authored by these users. Empty means all users; one
+    /// value (e.g. the current `$USER`) is "only my messages".
+    pub users: Vec<String>,
+    /// Restrict to records recorded on these hosts. Empty means all hosts.
+    pub hosts: Vec<String>,
+    /// Restrict to these project slugs (the per-source project tag, e.g. the
+    /// directory a Claude transcript was recorded under). Empty means all.
+    pub projects: Vec<String>,
 }
 
 impl FilterSpec {
     /// Whether any selector is set.
     #[must_use]
     pub const fn is_empty(&self) -> bool {
-        self.sources.is_empty() && self.exclude_sources.is_empty() && self.repo.is_none()
+        self.sources.is_empty()
+            && self.exclude_sources.is_empty()
+            && self.repo.is_none()
+            && self.users.is_empty()
+            && self.hosts.is_empty()
+            && self.projects.is_empty()
     }
 }
 
@@ -48,12 +61,25 @@ pub fn build_filter(spec: &FilterSpec) -> Option<Filter> {
     if let Some(repo) = &spec.repo {
         clauses.push(Filter::eq(keys::REPO, repo.clone()));
     }
+    clauses.extend(any_of_strings(keys::USER, &spec.users));
+    clauses.extend(any_of_strings(keys::HOST, &spec.hosts));
+    clauses.extend(any_of_strings(keys::PROJECT, &spec.projects));
 
     match clauses.len() {
         0 => None,
         1 => clauses.pop(),
         _ => Some(Filter::all(clauses)),
     }
+}
+
+/// An `in` filter over `key` for a set of string values, or `None` when the set
+/// is empty (no constraint on that key).
+fn any_of_strings(key: &str, values: &[String]) -> Option<Filter> {
+    if values.is_empty() {
+        return None;
+    }
+    let array: Vec<serde_json::Value> = values.iter().map(|v| v.as_str().into()).collect();
+    Some(Filter::any_of(key, serde_json::Value::Array(array)))
 }
 
 #[cfg(test)]
@@ -91,6 +117,40 @@ mod tests {
         assert_eq!(
             value,
             serde_json::json!({ "none": [ { "key": "source", "operator": "eq", "value": "slack" } ] })
+        );
+    }
+
+    #[test]
+    fn single_user_builds_an_in_filter() {
+        let spec = FilterSpec {
+            users: vec!["andrew".to_owned()],
+            ..FilterSpec::default()
+        };
+        let filter = build_filter(&spec).expect("filter");
+        let value = serde_json::to_value(&filter).expect("ser");
+        assert_eq!(
+            value,
+            serde_json::json!({ "key": "user", "operator": "in", "value": ["andrew"] })
+        );
+    }
+
+    #[test]
+    fn user_host_project_combine_under_all() {
+        let spec = FilterSpec {
+            users: vec!["andrew".to_owned()],
+            hosts: vec!["hydra".to_owned()],
+            projects: vec!["ix".to_owned(), "index".to_owned()],
+            ..FilterSpec::default()
+        };
+        let filter = build_filter(&spec).expect("filter");
+        let value = serde_json::to_value(&filter).expect("ser");
+        assert_eq!(
+            value,
+            serde_json::json!({ "all": [
+                { "key": "user", "operator": "in", "value": ["andrew"] },
+                { "key": "host", "operator": "in", "value": ["hydra"] },
+                { "key": "project", "operator": "in", "value": ["ix", "index"] }
+            ] })
         );
     }
 

--- a/packages/search/src/main.rs
+++ b/packages/search/src/main.rs
@@ -97,6 +97,25 @@ struct ScopeArgs {
     /// here.
     #[arg(long = "all-worktrees")]
     all_worktrees: bool,
+
+    /// Restrict to records authored by these users (repeatable, comma-joined).
+    /// Default: every user.
+    #[arg(long = "user", value_name = "USER")]
+    users: Vec<String>,
+
+    /// Restrict to your own records (the current `$USER`); shorthand for
+    /// `--user "$USER"`.
+    #[arg(long)]
+    mine: bool,
+
+    /// Restrict to records recorded on these hosts (repeatable, comma-joined).
+    #[arg(long = "host", value_name = "HOST")]
+    hosts: Vec<String>,
+
+    /// Restrict non-code sources to these project slugs (repeatable,
+    /// comma-joined), e.g. a Claude transcript's project directory.
+    #[arg(long = "project", value_name = "PROJECT")]
+    projects: Vec<String>,
 }
 
 /// Resolve scope selectors into a server-side metadata filter and the code
@@ -118,10 +137,22 @@ fn resolve_scope(scope: &ScopeArgs, root: &Path) -> anyhow::Result<(Option<Filte
         (None, CodeScope::WorktreeExact)
     };
 
+    let mut users = split_csv(&scope.users);
+    if scope.mine {
+        let me = std::env::var("USER")
+            .map_err(|_| anyhow::anyhow!("--mine needs the USER environment variable set"))?;
+        if !users.contains(&me) {
+            users.push(me);
+        }
+    }
+
     let spec = FilterSpec {
         sources,
         exclude_sources,
         repo,
+        users,
+        hosts: split_csv(&scope.hosts),
+        projects: split_csv(&scope.projects),
     };
     Ok((build_filter(&spec), code_scope))
 }
@@ -133,6 +164,18 @@ fn parse_sources(values: &[String]) -> anyhow::Result<Vec<Source>> {
         .flat_map(|value| value.split(','))
         .filter(|value| !value.is_empty())
         .map(|value| value.parse::<Source>().map_err(anyhow::Error::from))
+        .collect()
+}
+
+/// Flatten repeatable, comma-joined string selectors (`--user a,b --user c`)
+/// into one list, trimming surrounding whitespace and dropping blanks.
+fn split_csv(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .flat_map(|value| value.split(','))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
         .collect()
 }
 


### PR DESCRIPTION
Scope semantic and grep search to your own records vs everyone's, by host, or by project/repo.

- `--mine` (current `$USER`), `--user a,b` — restrict by author. Default stays all users.
- `--host h`, `--project slug` — restrict by machine / per-source project (e.g. a Claude transcript's directory).

Records already carry `user`/`host`/`project` tags; this exposes them through the shared `FilterSpec` (in-filters combined under `all`) so the CLI, Python binding, and MCP tool share one mapping. Verified: `rust-search-core-clippy`, `rust-search-clippy`, `rust-search-core` unit tests green on the Linux builder.

_(Made with AI assistance — Claude Opus 4.8.)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope search results by user, host, and project via CLI flags
> - Adds `--user`, `--mine`, `--host`, and `--project` flags to the search CLI in [main.rs](https://github.com/indexable-inc/index/pull/488/files#diff-c7e98141f8760d905ae6b359cdbc66c7e8000cc2ab9fd7889d7728ba9b666af4); flags accept repeated values or comma-separated lists.
> - `--mine` resolves to the current `USER` environment variable and errors if `USER` is unset.
> - Extends `FilterSpec` in [query_filter.rs](https://github.com/indexable-inc/index/pull/488/files#diff-b24a2a8821c0eb537bf88f338cb9009f6b0e7cdfb598fdf4133fe86095df0fc7) with `users`, `hosts`, and `projects` fields that generate server-side `in` filters combined under an `all` clause.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1eb1fe9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->