### PR TITLE
feat(macos-vm): stream the live guest screen to the dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,8 +3430,10 @@ dependencies = [
 name = "macos-vm"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "block2",
  "clap",
+ "dashboard-core",
  "dispatch2",
  "image",
  "objc2",
@@ -3443,6 +3445,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu 0.8.9",
+ "tokio",
 ]
 
 [[package]]

--- a/packages/dashboard-core/src/dashboard/hub.rs
+++ b/packages/dashboard-core/src/dashboard/hub.rs
@@ -50,6 +50,46 @@ fn body_of(view: &View) -> String {
     }
 }
 
+/// Bodies up to this size are reconciled with Loro's refined text diff, which
+/// produces small deltas for the common case (a terminal screen, a tweaked HTML
+/// fragment). A larger body is replaced wholesale instead: diffing two large,
+/// dissimilar strings is quadratic, and a body that changes completely every
+/// tick (an HTML pane streaming a base64 image data URL) would otherwise stall
+/// the single aggregator and bloat the oplog with edit ops.
+const MAX_DIFF_BODY: usize = 32 * 1024;
+
+/// Ceiling on the refined diff for a small body, so a pathological input can
+/// never block the aggregator. On timeout the body falls back to a wholesale
+/// replace, same as a large body.
+const BODY_DIFF_TIMEOUT_MS: f64 = 50.0;
+
+/// Reconcile a pane's `body` text to `next`.
+///
+/// Small bodies use Loro's refined diff (cheap, small deltas) under a timeout;
+/// large bodies, and any diff that times out, are replaced wholesale: delete the
+/// current contents and insert the new ones, two bulk ops whose cost is
+/// independent of how similar the two strings are.
+fn set_body(body: &LoroText, next: &str) -> Result<()> {
+    if next.len() <= MAX_DIFF_BODY {
+        let options = loro::UpdateOptions {
+            timeout_ms: Some(BODY_DIFF_TIMEOUT_MS),
+            use_refined_diff: true,
+        };
+        if body.update(next, options).is_ok() {
+            return Ok(());
+        }
+        // The diff timed out. It may have applied partial edits before bailing,
+        // so the wholesale replace below reconciles against the container's own
+        // current length rather than any cached previous body.
+    }
+    let current_len = body.len_unicode();
+    if current_len > 0 {
+        body.delete(0, current_len).map_err(loro_err)?;
+    }
+    body.insert(0, next).map_err(loro_err)?;
+    Ok(())
+}
+
 /// The Loro handles backing one pane card, plus the scalar values already
 /// written, cached across applies so a tick only re-inserts a value that
 /// changed (an unchanged insert is still a CRDT op, so caching is what keeps an
@@ -216,11 +256,7 @@ impl DocState {
         }
         let body = body_of(&pane.view);
         if slot.body_str != body {
-            slot.body
-                .update(&body, loro::UpdateOptions::default())
-                .map_err(|source| Error::Dashboard {
-                    message: format!("body text update: {source}"),
-                })?;
+            set_body(&slot.body, &body)?;
             slot.body_str = body;
         }
         Ok(())

--- a/packages/dashboard-core/src/publish.rs
+++ b/packages/dashboard-core/src/publish.rs
@@ -122,8 +122,17 @@ impl Publisher {
         }
         reap_stale_socket(&path)?;
 
-        let listener = UnixListener::bind(&path)
-            .map_err(|source| publish_err(format!("bind {}: {source}", path.display())))?;
+        // `UnixListener::bind` registers the socket with the IO driver, which
+        // requires an active runtime context on the *calling* thread. The whole
+        // point of taking a `Handle` is to let a caller bind from a thread that
+        // is not itself a runtime worker (e.g. one driving a native run loop), so
+        // enter the handle's context for the bind. Re-entering is harmless when
+        // the caller is already inside this runtime.
+        let listener = {
+            let _enter = runtime.enter();
+            UnixListener::bind(&path)
+                .map_err(|source| publish_err(format!("bind {}: {source}", path.display())))?
+        };
         restrict_socket(&path);
 
         let initial = encode(&producer, &[]);

--- a/packages/macos-vm/Cargo.toml
+++ b/packages/macos-vm/Cargo.toml
@@ -41,6 +41,15 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 # dependency-free and the unused-crate-dependencies check passes there.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# The interactive `drive` sessions publish the live guest screen to the local
+# dashboard as an image pane. Only the lightweight `Publisher` half of
+# `dashboard-core` is used; it pulls the aggregator's deps along until that crate
+# is split. tokio runs the publisher socket (this binary otherwise drives an
+# AppKit run loop), and base64 builds the frame data URL. All macOS-gated so the
+# Linux stub graph stays dependency-free.
+dashboard-core = { path = "../dashboard-core" }
+tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util", "sync", "time"] }
+base64.workspace = true
 
 [lints]
 workspace = true

--- a/packages/macos-vm/README.md
+++ b/packages/macos-vm/README.md
@@ -127,6 +127,27 @@ capture a frame, locate a control in it (the host side can use any image
 tooling), `click` it, capture again. Modifiers via `down`/`up` give chords like
 Spotlight: `down cmd`, `key space`, `up cmd`.
 
+A `drive-macos` or `drive-linux` session also publishes the guest screen to the
+local dashboard automatically, the same way a terminal producer does: it binds a
+producer socket in the [discovery directory](../dashboard-core) and streams the
+framebuffer as a live image pane. Run the standalone `dashboard` aggregator and
+the running guest appears on the canvas next to any terminals, with no extra
+flag.
+
+The pane is a downscaled PNG (capped at 900px wide, aspect preserved) sampled
+about once a second; an unchanged frame is dropped before encoding, so an idle
+desktop publishes one frame and then nothing. The raw frame is copied off the
+`IOSurface` on the main queue and converted, scaled, and compared off it, to keep
+guest rendering and lockstep input responsive. The capture is best-effort: if the
+socket cannot be bound the driver logs one line and keeps running. Set
+`IX_MACVM_NO_DASHBOARD` (to any value) to turn it off, e.g. a lockstep automated
+driver that does not want the extra framebuffer sampling.
+
+Known limit: the dashboard keeps pane history in a CRDT, so a screen that changes
+continuously for a very long session grows the aggregator's in-memory state. For
+the interactive, mostly-static desktops this targets it stays small; a smaller
+cap or lower rate bounds it further.
+
 Modal screens that make a network call (Apple ID, Screen Time) hang on a host
 without working guest internet. Where the goal is just a usable desktop, it is
 simpler to mark Setup Assistant complete offline by editing the guest disk

--- a/packages/macos-vm/src/drive.rs
+++ b/packages/macos-vm/src/drive.rs
@@ -27,6 +27,8 @@ use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use base64::Engine as _;
+use dashboard_core::{Pane, Publisher, socket_path};
 use dispatch2::DispatchQueue;
 use objc2::MainThreadMarker;
 use objc2::rc::Retained;
@@ -35,7 +37,10 @@ use objc2_virtualization::VZVirtualMachineView;
 
 use crate::imp::Error;
 use crate::input;
-use crate::macguest::{DirShare, capture, frame_size as guest_frame_size, start_guest_offscreen};
+use crate::macguest::{
+    DirShare, bgra_to_rgba, capture, downscale_rgba, encode_png_rgba,
+    frame_size as guest_frame_size, read_frame_bgra, start_guest_offscreen,
+};
 
 /// Gap between a key's down and up, and after its release, so the guest HID
 /// stack registers discrete presses instead of coalescing them. The sleeps run
@@ -68,7 +73,7 @@ pub fn drive_macos(drive: DriveMacos) -> Result<(), Error> {
     let DriveMacos { bundle, shares } = drive;
     let mtm = MainThreadMarker::new().ok_or(Error::NotMainThread)?;
     let view = start_guest_offscreen(mtm, &bundle, &shares)?;
-    drive_view(mtm, view);
+    drive_view(mtm, view, "macOS guest");
     Ok(())
 }
 
@@ -76,8 +81,13 @@ pub fn drive_macos(drive: DriveMacos) -> Result<(), Error> {
 /// run the `AppKit` run loop until `quit`/EOF exits the process. Guest-agnostic:
 /// shared by the macOS ([`drive_macos`]) and Linux
 /// ([`crate::linuxguest::drive_linux`]) drivers, since every command operates on
-/// the `VZVirtualMachineView` regardless of guest type.
-pub(crate) fn drive_view(mtm: MainThreadMarker, view: Retained<VZVirtualMachineView>) {
+/// the `VZVirtualMachineView` regardless of guest type. `label` titles the live
+/// screen pane this session publishes to the dashboard.
+pub(crate) fn drive_view(
+    mtm: MainThreadMarker,
+    view: Retained<VZVirtualMachineView>,
+    label: &'static str,
+) {
     // Leak the view (it lives for the process) and hand the raw pointer to the
     // driver thread; the view is not `Send`, so we only re-borrow it on the main
     // queue, where it is valid.
@@ -86,11 +96,142 @@ pub(crate) fn drive_view(mtm: MainThreadMarker, view: Retained<VZVirtualMachineV
         "macos-vm: driving guest; stdin commands: \
          key/down/up/type/click/move/cursor/size/cursor-show/wait/shot/quit"
     );
+    // Stream the guest screen to the local dashboard so the session shows up on
+    // the canvas automatically, the same way a terminal producer does.
+    spawn_screen_publisher(view_ptr, label);
     std::thread::spawn(move || run_commands(view_ptr));
 
     // The view needs the `AppKit` run loop to build its layer tree and receive
     // guest frames; the driver thread exits the process on `quit` or EOF.
     NSApplication::sharedApplication(mtm).run();
+}
+
+/// How often the dashboard producer samples the guest framebuffer. ~1 fps: a
+/// remote-desktop thumbnail does not need to be smooth, and an unchanged frame is
+/// skipped anyway, so an idle desktop costs one published frame and then nothing.
+const SCREEN_PUBLISH_INTERVAL: Duration = Duration::from_millis(1000);
+/// Cap the published frame's width (aspect ratio preserved). A dashboard card is
+/// far smaller than a 1920px scanout, and the smaller PNG keeps the stream light.
+const SCREEN_MAX_WIDTH: usize = 900;
+/// Set this to disable publishing the guest screen to the dashboard (e.g. a
+/// lockstep automated driver that does not want the extra main-queue sampling).
+/// Any value disables it.
+const NO_DASHBOARD_ENV: &str = "IX_MACVM_NO_DASHBOARD";
+
+/// Publish the guest framebuffer to the local dashboard as a live image pane, so
+/// a `drive` session appears on the canvas automatically alongside terminals and
+/// other producers.
+///
+/// Best-effort: a runtime/bind failure disables the pane and never touches the
+/// VM. The work runs on its own thread because this binary drives an `AppKit`
+/// run loop, not an async one; that thread owns a small tokio runtime (for the
+/// publisher's socket) and the [`Publisher`], both kept alive for the process by
+/// the never-returning sample loop.
+///
+/// Each tick reads the raw frame on the main queue (the only main-thread work),
+/// then converts, downscales, and compares it off the queue: an unchanged frame
+/// is dropped before the expensive PNG encode and before any publish, so a static
+/// desktop adds no traffic and no aggregator state.
+fn spawn_screen_publisher(view_ptr: usize, label: &'static str) {
+    if std::env::var_os(NO_DASHBOARD_ENV).is_some() {
+        return;
+    }
+    std::thread::spawn(move || {
+        let runtime = match tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+        {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                eprintln!("macos-vm: dashboard screen disabled (runtime: {error})");
+                return;
+            }
+        };
+        let publisher = match Publisher::bind(socket_path(), runtime.handle()) {
+            Ok(publisher) => publisher,
+            Err(error) => {
+                eprintln!("macos-vm: dashboard screen disabled ({error})");
+                return;
+            }
+        };
+        eprintln!(
+            "macos-vm: publishing guest screen to dashboard ({})",
+            publisher.path().display()
+        );
+        let sink = publisher.sink();
+        // Log a persistent read/encode fault once rather than every tick.
+        let mut warned_read = false;
+        let mut warned_encode = false;
+        // The last published downscaled RGBA frame, to skip a static screen.
+        let mut last_frame: Option<Vec<u8>> = None;
+        loop {
+            std::thread::sleep(SCREEN_PUBLISH_INTERVAL);
+            // Main-queue work: copy the raw BGRA frame out.
+            let (mut bgra, width, height) = match read_bgra_on_main(view_ptr) {
+                Ok(frame) => frame,
+                // The guest has not rendered a frame yet; the pane appears once it
+                // does. Any other read error is logged once, then tolerated.
+                Err(Error::NoFramebuffer) => continue,
+                Err(error) => {
+                    if !warned_read {
+                        eprintln!("macos-vm: dashboard screen capture: {error}");
+                        warned_read = true;
+                    }
+                    continue;
+                }
+            };
+            // Off-queue work: convert, downscale, and skip an unchanged frame.
+            bgra_to_rgba(&mut bgra);
+            let (small, w, h) = match downscale_rgba(bgra, width, height, SCREEN_MAX_WIDTH) {
+                Ok(frame) => frame,
+                Err(_) => continue,
+            };
+            if last_frame.as_deref() == Some(small.as_slice()) {
+                continue;
+            }
+            let png = match encode_png_rgba(&small, w as usize, h as usize) {
+                Ok(png) => png,
+                Err(error) => {
+                    if !warned_encode {
+                        eprintln!("macos-vm: dashboard screen encode: {error}");
+                        warned_encode = true;
+                    }
+                    continue;
+                }
+            };
+            last_frame = Some(small);
+            let mut data_url = String::from("data:image/png;base64,");
+            base64::engine::general_purpose::STANDARD.encode_string(&png, &mut data_url);
+            let mut pane = Pane::html("screen", label, screen_html(&data_url));
+            pane.subtitle = format!("{w}x{h}");
+            sink.publish(std::slice::from_ref(&pane));
+        }
+        // `runtime` and `publisher` are owned here and kept alive by the loop
+        // above; the process exits via `quit`/EOF, never by leaving this thread.
+    });
+}
+
+/// The HTML body for the live screen pane: the captured frame as a data-URL
+/// image, scaled to the card width over a black field.
+fn screen_html(data_url: &str) -> String {
+    format!(
+        "<div style=\"margin:0;background:#000;line-height:0\">\
+         <img src=\"{data_url}\" alt=\"guest screen\" \
+         style=\"display:block;width:100%;height:auto;image-rendering:auto\"/></div>"
+    )
+}
+
+/// Copy the guest framebuffer (raw BGRA) on the main queue (where the view and
+/// its `IOSurface` are valid), mirroring [`shot`] and [`frame_size`]. The
+/// BGRA→RGBA conversion is left to the caller so it runs off the main queue.
+fn read_bgra_on_main(view_ptr: usize) -> Result<(Vec<u8>, usize, usize), Error> {
+    let mut result = Err(Error::NoFramebuffer);
+    DispatchQueue::main().exec_sync(|| {
+        let view: &VZVirtualMachineView = unsafe { &*(view_ptr as *const VZVirtualMachineView) };
+        result = read_frame_bgra(view);
+    });
+    result
 }
 
 /// Mutable driver state carried across commands: the last pointer position this

--- a/packages/macos-vm/src/linuxguest.rs
+++ b/packages/macos-vm/src/linuxguest.rs
@@ -116,7 +116,7 @@ pub fn drive_linux(drive: DriveLinux) -> Result<(), Error> {
     }
 
     let view = crate::macguest::start_vm_offscreen(mtm, &config);
-    crate::drive::drive_view(mtm, view);
+    crate::drive::drive_view(mtm, view, "Linux guest");
     Ok(())
 }
 

--- a/packages/macos-vm/src/macguest.rs
+++ b/packages/macos-vm/src/macguest.rs
@@ -291,13 +291,18 @@ fn draw_cursor_marker(rgba: &mut [u8], width: usize, height: usize, fx: f64, fy:
     }
 }
 
-/// Read the framebuffer `IOSurface` (BGRA) and encode a PNG. With `cursor` set
-/// (display fractions, top-left), a pointer marker is drawn into the PNG.
-pub fn capture(
+/// Copy the framebuffer `IOSurface` out as tightly-packed BGRA8 plus
+/// `(width, height)` in pixels. A guest that has not rendered a frame yet
+/// surfaces as [`Error::NoFramebuffer`].
+///
+/// Touches the view's layer and the `IOSurface` mapping, so it must run on the
+/// main queue (callers hop onto it). Does the minimal work there: a per-row
+/// memcpy that drops any stride padding. The BGRA→RGBA conversion
+/// ([`bgra_to_rgba`]) is left to the caller so the live producer can run it off
+/// the main queue and keep AppKit rendering responsive.
+pub(crate) fn read_frame_bgra(
     view: &VZVirtualMachineView,
-    path: &Path,
-    cursor: Option<(f64, f64)>,
-) -> Result<usize, Error> {
+) -> Result<(Vec<u8>, usize, usize), Error> {
     let contents = frame_contents(view).ok_or(Error::NoFramebuffer)?;
     // Verify the layer contents really is an IOSurface before any unsafe access.
     let surface_obj: Retained<IOSurface> = contents
@@ -326,30 +331,44 @@ pub fn capture(
     }
 
     // Allocate before locking so an allocation failure cannot leak the lock; the
-    // locked region below does only an in-bounds memcpy (no panics, no `?`).
-    let mut rgba = vec![0u8; width * height * 4];
+    // locked region below does only in-bounds row memcpys (no panics, no `?`).
+    let row_bytes = width * 4;
+    let mut bgra = vec![0u8; row_bytes * height];
     unsafe {
         let _ = surface.lock(IOSurfaceLockOptions::ReadOnly, std::ptr::null_mut());
         let bytes_per_row = surface.bytes_per_row();
         let base = surface.base_address().as_ptr() as *const u8;
         for y in 0..height {
-            let row = base.add(y * bytes_per_row);
-            for x in 0..width {
-                let p = row.add(x * 4);
-                let o = (y * width + x) * 4;
-                rgba[o] = *p.add(2); // R <- BGRA.R
-                rgba[o + 1] = *p.add(1); // G
-                rgba[o + 2] = *p; // B
-                rgba[o + 3] = *p.add(3); // A
-            }
+            let src = std::slice::from_raw_parts(base.add(y * bytes_per_row), row_bytes);
+            bgra[y * row_bytes..(y + 1) * row_bytes].copy_from_slice(src);
         }
         let _ = surface.unlock(IOSurfaceLockOptions::ReadOnly, std::ptr::null_mut());
     }
 
-    if let Some((fx, fy)) = cursor {
-        draw_cursor_marker(&mut rgba, width, height, fx, fy);
-    }
+    Ok((bgra, width, height))
+}
 
+/// Convert 32-bit BGRA8 pixels to RGBA8 in place (swap each pixel's B and R).
+/// Pure CPU; the live producer runs this off the main queue.
+pub(crate) fn bgra_to_rgba(pixels: &mut [u8]) {
+    for px in pixels.chunks_exact_mut(4) {
+        px.swap(0, 2);
+    }
+}
+
+/// Read the framebuffer as tightly-packed RGBA8 plus `(width, height)`.
+/// Convenience for callers already on the main queue (e.g. [`capture`]); the
+/// live producer instead reads BGRA on the main queue and converts off it.
+pub(crate) fn read_frame_rgba(
+    view: &VZVirtualMachineView,
+) -> Result<(Vec<u8>, usize, usize), Error> {
+    let (mut pixels, width, height) = read_frame_bgra(view)?;
+    bgra_to_rgba(&mut pixels);
+    Ok((pixels, width, height))
+}
+
+/// PNG-encode tightly-packed RGBA8 pixels of size `width` x `height` in memory.
+pub(crate) fn encode_png_rgba(rgba: &[u8], width: usize, height: usize) -> Result<Vec<u8>, Error> {
     let w = u32::try_from(width).map_err(|_| Error::CaptureEncode {
         message: "width too large".into(),
     })?;
@@ -359,7 +378,7 @@ pub fn capture(
     let mut buf = std::io::Cursor::new(Vec::new());
     image::ImageEncoder::write_image(
         image::codecs::png::PngEncoder::new(&mut buf),
-        &rgba,
+        rgba,
         w,
         h,
         image::ExtendedColorType::Rgba8,
@@ -367,7 +386,62 @@ pub fn capture(
     .map_err(|e| Error::CaptureEncode {
         message: e.to_string(),
     })?;
-    let png = buf.into_inner();
+    Ok(buf.into_inner())
+}
+
+/// Downscale RGBA8 pixels so the width is at most `max_width` (aspect ratio
+/// preserved), returning the scaled pixels and their `(width, height)`. A frame
+/// already within `max_width` is returned unchanged.
+///
+/// Keeps the live dashboard pane light: a desktop scanout is often 1920x1080 or
+/// larger, far more than a canvas card needs. Returning the raw pixels (not a
+/// PNG) lets the producer compare successive frames and skip re-encoding a static
+/// screen.
+pub(crate) fn downscale_rgba(
+    rgba: Vec<u8>,
+    width: usize,
+    height: usize,
+    max_width: usize,
+) -> Result<(Vec<u8>, u32, u32), Error> {
+    if width == 0 || height == 0 {
+        return Err(Error::NoFramebuffer);
+    }
+    let src_w = u32::try_from(width).map_err(|_| Error::CaptureEncode {
+        message: "width too large".into(),
+    })?;
+    let src_h = u32::try_from(height).map_err(|_| Error::CaptureEncode {
+        message: "height too large".into(),
+    })?;
+    if width <= max_width {
+        return Ok((rgba, src_w, src_h));
+    }
+    let dst_w = u32::try_from(max_width).unwrap_or(src_w);
+    // Scale height by the same ratio in u64 to avoid overflow, floored to >= 1.
+    let dst_h =
+        u32::try_from((height as u64 * max_width as u64 / width as u64).max(1)).unwrap_or(src_h);
+    let buffer = image::RgbaImage::from_raw(src_w, src_h, rgba).ok_or_else(|| {
+        Error::CaptureEncode {
+            message: "frame buffer length does not match its dimensions".into(),
+        }
+    })?;
+    let scaled =
+        image::imageops::resize(&buffer, dst_w, dst_h, image::imageops::FilterType::Triangle);
+    Ok((scaled.into_raw(), dst_w, dst_h))
+}
+
+/// Read the framebuffer `IOSurface` (BGRA), encode a full-resolution PNG, and
+/// write it to `path`, returning the bytes written. With `cursor` set (display
+/// fractions, top-left), a pointer marker is drawn into the PNG.
+pub fn capture(
+    view: &VZVirtualMachineView,
+    path: &Path,
+    cursor: Option<(f64, f64)>,
+) -> Result<usize, Error> {
+    let (mut rgba, width, height) = read_frame_rgba(view)?;
+    if let Some((fx, fy)) = cursor {
+        draw_cursor_marker(&mut rgba, width, height, fx, fy);
+    }
+    let png = encode_png_rgba(&rgba, width, height)?;
     std::fs::write(path, &png).map_err(|e| Error::CaptureEncode {
         message: e.to_string(),
     })?;


### PR DESCRIPTION
A `drive-macos` / `drive-linux` session now publishes the guest framebuffer to the local dashboard as a live image pane, so the remote-desktop VM shows up on the canvas automatically, the same way a terminal producer does. No flag needed; opt out with `IX_MACVM_NO_DASHBOARD`.

**How**
- `macos-vm`: read the framebuffer raw (BGRA) on the main queue (cheap per-row memcpy), convert + downscale (≤900px) off the queue, change-detect, and publish ~1 fps as an html `<img>` data-URL pane. An unchanged frame is dropped before encode/publish, so an idle desktop costs one frame then nothing.
- `dashboard-core/hub`: cap the pane-body text diff. A large, wholesale-changing body (a streamed image) is replaced via `delete`+`insert` instead of Loro's O(n²) refined diff, which otherwise wedged the single aggregator loop (the HTTP/SSE server stopped responding). Small bodies (terminals, html, data) keep the refined diff, now under a 50 ms timeout.
- `dashboard-core/publish`: `Publisher::bind` enters the runtime around the sync `UnixListener::bind`, so an off-runtime caller (the VM driver thread) can bind with just a `Handle` instead of panicking.

**Verified** (Apple M5 Max, real provisioned guest)
- `nix build .#macos-vm` and `.#dashboard` green.
- Drove the guest, ran the `dashboard` aggregator: it auto-discovered the VM socket and the producer published a valid downscaled PNG pane (`900×506`, magic `89504e47…`).
- Real browser (playwright) renders the pane: an `<img>` with non-zero natural dimensions under a "macOS guest" card showing the live desktop; the dashboard stays responsive (no wedge).

**Known limit:** the dashboard keeps pane history in a CRDT, so a screen that changes continuously over a very long session grows the aggregator's in-memory state. Mostly-static interactive desktops stay small; downscale + change-detection bound it.

**Follow-up:** `dashboard-core` is pulled in whole (loro/axum) just to use `Publisher`; a `publish`-only feature split or a dedicated crate would keep the signed VM binary lean.

---
Made with Claude Code (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stream live guest screen to the dashboard in macOS/Linux drive sessions
> - Adds a background publisher in [`drive.rs`](https://github.com/indexable-inc/index/pull/492/files#diff-9bce8aaf3c940d78f407c66cbd6979c6f45d793000f2e75e2416f8a8a7b16572) that samples the guest framebuffer every second, downscales to max 900px width, PNG-encodes, and publishes as a live image pane to the local dashboard.
> - Extracts reusable framebuffer helpers in [`macguest.rs`](https://github.com/indexable-inc/index/pull/492/files#diff-bf375e8c838424f343aea16a54b5727288a85d2fc009d75e928c51a796933b94): `read_frame_bgra`, `bgra_to_rgba`, `read_frame_rgba`, `encode_png_rgba`, and `downscale_rgba`.
> - Skips publishing unchanged frames; logs one-time warnings on capture/encode errors (best-effort, non-blocking).
> - Adds a `set_body` helper in [`hub.rs`](https://github.com/indexable-inc/index/pull/492/files#diff-e4fc3a57d5c551ce7b690a0c9614f160c7b44ecd9ec9240007573f4e13501219) that uses a refined Loro diff with a 50ms timeout for bodies ≤32 KiB, falling back to delete-and-insert for larger or timed-out updates.
> - Set `IX_MACVM_NO_DASHBOARD` to opt out of screen publishing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05f9f0a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->