### PR TITLE
fix(lint): unbreak main statix (homeModules merge + inherit)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -144,25 +144,27 @@
     {
       lib = ix;
       inherit (ix) nixosModules;
-      # Workstation-facing home-manager module: declare a service once, get a
-      # native launchd agent on macOS and native systemd user units on Linux.
-      homeModules.portable-services = ix.portableServices.homeModule;
-      # Personal-but-shareable workstation module for github:andrewgazelka: the
-      # ix.dev downtime watcher + boss bar overlay + the shared say-detached
-      # sound helper, all as portable services. Closed over the per-system flake
-      # packages so it resolves bossbar / minecraft-sound for the host it runs
-      # on. See users/andrewgazelka/home.nix.
-      homeModules.andrewgazelka = import ./users/andrewgazelka/home.nix {
-        indexPackages = system: (collect "packages").${system};
-        portableServicesModule = ix.portableServices.homeModule;
-      };
-      # Workstation-facing module to sync this user's Claude Code history to an
-      # S3/R2 parquet archive and/or Mixedbread, as a portable timer service.
-      # Closed over the per-system packages so it resolves claude-history-sync
-      # for the host. See packages/claude-history-sync/home-module.nix.
-      homeModules.claude-history-sync = import ./packages/claude-history-sync/home-module.nix {
-        indexPackages = system: (collect "packages").${system};
-        portableServicesModule = ix.portableServices.homeModule;
+      homeModules = {
+        # Workstation-facing home-manager module: declare a service once, get a
+        # native launchd agent on macOS and native systemd user units on Linux.
+        portable-services = ix.portableServices.homeModule;
+        # Personal-but-shareable workstation module for github:andrewgazelka: the
+        # ix.dev downtime watcher + boss bar overlay + the shared say-detached
+        # sound helper, all as portable services. Closed over the per-system
+        # flake packages so it resolves bossbar / minecraft-sound for the host it
+        # runs on. See users/andrewgazelka/home.nix.
+        andrewgazelka = import ./users/andrewgazelka/home.nix {
+          indexPackages = system: (collect "packages").${system};
+          portableServicesModule = ix.portableServices.homeModule;
+        };
+        # Workstation-facing module to sync this user's Claude Code history to an
+        # S3/R2 parquet archive and/or Mixedbread, as a portable timer service.
+        # Closed over the per-system packages so it resolves claude-history-sync
+        # for the host. See packages/claude-history-sync/home-module.nix.
+        claude-history-sync = import ./packages/claude-history-sync/home-module.nix {
+          indexPackages = system: (collect "packages").${system};
+          portableServicesModule = ix.portableServices.homeModule;
+        };
       };
       overlays.default = ix.overlay;
       packages = collect "packages";

--- a/packages/claude-history-sync/home-module.nix
+++ b/packages/claude-history-sync/home-module.nix
@@ -159,8 +159,7 @@ in
     services.portable.claude-history-sync = {
       description = "Sync Claude Code history to parquet + Mixedbread";
       command = [ "${cfg.package}/bin/claude-history-sync" ] ++ dirFlags ++ s3Flags ++ mixedbreadFlags;
-      environment = cfg.environment;
-      interval = cfg.interval;
+      inherit (cfg) environment interval;
     };
   };
 }


### PR DESCRIPTION
Main has been red on the `flake-check` lint since #489: `statix` flags three repeated `homeModules.*` keys in `flake.nix` and two `x = cfg.x` assignments in `packages/claude-history-sync/home-module.nix`. Because PR `flake-check` runs on merge-with-main, this fails **every** open PR.

Fix: merge the `homeModules` entries into one attrset and use `inherit (cfg) environment interval;`. No behavior change. `nix run .#lint` is green locally.

---
Made with Claude Code (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix statix lint errors in `flake.nix` and `claude-history-sync` home module
> - Consolidates separate `homeModules.*` attribute assignments in [flake.nix](https://github.com/indexable-inc/index/pull/493/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) into a single `homeModules = { ... };` attrset, which satisfies statix's lint rules.
> - Replaces explicit `environment = cfg.environment; interval = cfg.interval;` assignments in [home-module.nix](https://github.com/indexable-inc/index/pull/493/files#diff-1444c6ce2e62096b7dd03992a1482800971063be3ac3080a18bdd3d6b15ddb66) with `inherit (cfg) environment interval;`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e94018f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->