### PR TITLE
fix(bossbar-overlay): size each bar window to its title, not just the bar

### DIFF
--- a/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
@@ -114,9 +114,11 @@ struct BarWin {
     self_set: Option<LogicalPosition<f64>>,
     /// This bar carries a description, so it has a hover pop-down panel.
     has_description: bool,
-    /// The window is currently grown to fit the open panel. Collapsed otherwise,
-    /// so the empty area below the bar never intercepts the mouse (click-through).
-    expanded: bool,
+    /// The window size (physical px) last requested for this bar. The size-settle
+    /// pass recomputes the target each tick and resizes only when it changes, so
+    /// growing for the hover panel and widening as a title (or its live counter)
+    /// grows both flow through one place without per-frame resize churn.
+    last_size: (u32, u32),
     /// When the window last moved (a `Moved` during a drag). The reconcile guard
     /// ignores externally-read positions until the window has been still for
     /// SETTLE, so the watcher's lagged read-back never snaps a live drag back.
@@ -207,8 +209,12 @@ impl App {
         bar: BossBar,
         slot: usize,
     ) -> Option<BarWin> {
-        let has_title = !bar.title.is_empty();
-        let (w_px, h_px) = scene::bar_window_px(self.scale, has_title);
+        // Size the window to the title, not just the 182px bar: a long downtime
+        // title is wider than the bar and would otherwise be clipped at the window
+        // edge. Measured on the CPU font, so this works before the GPU core exists
+        // (the first window is created before its surface).
+        let title_w = scene::title_extent_px(&bar, self.scale, now_unix());
+        let (w_px, h_px) = scene::bar_window_px(self.scale, title_w);
         let pos = match bar.pos {
             Some(p) => LogicalPosition::new(p.x, p.y),
             None => self.auto_pos(slot, w_px, h_px),
@@ -233,9 +239,9 @@ impl App {
             gesture: DragClick::new(DRAG_THRESHOLD),
             self_set: Some(pos),
             has_description,
-            // Windows are created at the collapsed (bar-only) size; the panel
-            // grows them on hover.
-            expanded: false,
+            // The window was just created at this size; the settle pass grows it
+            // for the panel on hover and tracks any later title-width changes.
+            last_size: (w_px, h_px),
             // Far enough in the past that a fresh window accepts an external
             // position immediately (the SETTLE guard only fires after a real move).
             last_move: now - SETTLE,
@@ -259,11 +265,6 @@ impl App {
             };
 
             if let Some(win) = self.wins.get_mut(&b.id) {
-                // A change to title presence or the description (while open)
-                // changes the window's collapsed or expanded size.
-                let size_affecting_changed = win.bar.title.is_empty() != b.title.is_empty()
-                    || win.bar.description.trim().is_empty() != b.description.trim().is_empty()
-                    || (win.expanded && win.bar.description != b.description);
                 win.has_description = !b.description.trim().is_empty();
                 win.bar = b.clone();
                 // Honor a position set in the DB by something other than our own
@@ -280,14 +281,10 @@ impl App {
                         win.self_set = Some(lp);
                     }
                 }
-                if size_affecting_changed {
-                    // Reset to the resting size; if the bar is still hovered the
-                    // settle pass in `about_to_wait` re-expands it to the new panel
-                    // height on the next tick.
-                    win.expanded = false;
-                    let (w_px, h_px) = scene::bar_window_px(self.scale, !b.title.is_empty());
-                    let _ = win.window.request_inner_size(PhysicalSize::new(w_px, h_px));
-                }
+                // A title or description change can alter the window size (wider for
+                // a longer title, taller for a panel). The settle pass in
+                // `about_to_wait` recomputes the target from the new bar and
+                // resizes if needed; the redraw wakes the loop so it runs now.
                 win.window.request_redraw();
             } else if let Some(win) = self.create_win(event_loop, b.clone(), this_slot) {
                 self.wins.insert(b.id, win);
@@ -387,30 +384,65 @@ impl App {
         }
     }
 
-    /// Grow or shrink a bar's window to match its hover state. Expanding makes room
-    /// for the description panel to unfold; collapsing restores the bar-only size
-    /// so the area below the bar stops intercepting the mouse, keeping the desktop
-    /// click-through everywhere off a bar. No-op when already in the target state
-    /// or when the bar has no panel.
-    fn set_window_expanded(&mut self, id: i64, expand: bool) {
+    /// Settle a bar's window to the size its current state asks for, resizing only
+    /// when that size changes. The target is the expanded (panel-open) size while
+    /// the bar is hovered or easing back, otherwise the collapsed bar size; either
+    /// way it is widened to hold the title (which a live elapsed counter can lengthen
+    /// mid-session). Doing it here, off the per-frame easing, keeps the window from
+    /// resizing every frame: it only resizes when the bar opens, closes, or the
+    /// title's width actually changes.
+    ///
+    /// An auto-stacked bar (no pinned position) is re-centered as its width changes
+    /// so the column stays centered; a pinned bar keeps its dragged top-left and
+    /// grows rightward.
+    fn settle_window_size(&mut self, id: i64) {
         let Some(core) = self.core.as_ref() else {
             return;
         };
+        let now = now_unix();
         let Some(win) = self.wins.get_mut(&id) else {
             return;
         };
-        if win.expanded == expand || (expand && !win.has_description) {
+        let expand = win.wants_expanded();
+        let (w_px, h_px) = if expand {
+            scene::expanded_window_px(&core.gpu, &win.bar, self.scale, now)
+        } else {
+            let title_w = scene::title_extent_px(&win.bar, self.scale, now);
+            scene::bar_window_px(self.scale, title_w)
+        };
+        let (prev_w, _) = win.last_size;
+        if win.last_size == (w_px, h_px) {
             return;
         }
-        let (w_px, h_px) = if expand {
-            scene::expanded_window_px(&core.gpu, &win.bar, self.scale)
-        } else {
-            scene::bar_window_px(self.scale, !win.bar.title.is_empty())
-        };
-        win.expanded = expand;
-        // Rely on the resulting `Resized` event to reconfigure the surface, the
-        // same way a title-presence change in `reconcile` does.
-        let _ = win.window.request_inner_size(PhysicalSize::new(w_px, h_px));
+        win.last_size = (w_px, h_px);
+        // Apply the resize. winit returns `Some(new)` when it resized the window
+        // synchronously, in which case no `Resized` event follows (notably on a 1x
+        // display in winit 0.30), so reconfigure the surface here; otherwise the
+        // `Resized` handler does it. Without this an unmatched synchronous resize
+        // leaves `config` stale and the title clips against the old surface extent.
+        if let Some(new) = win.window.request_inner_size(PhysicalSize::new(w_px, h_px)) {
+            win.config.width = new.width.max(1);
+            win.config.height = new.height.max(1);
+            win.surface.configure(core.gpu.device(), &win.config);
+        }
+
+        // Keep an auto-stacked bar centered as it widens: shift its window left by
+        // half the width change. winit grows the window from its top-left, so
+        // without this the centered bar would drift right each time the counter
+        // gains a digit. Record the new position in `self_set` first so the
+        // resulting `Moved` reads as our own echo (no DB write, no snap-back). Skip
+        // while a drag is in flight so the re-center never moves the window out from
+        // under the OS-owned drag.
+        if win.bar.pos.is_none()
+            && !win.gesture.dragging()
+            && w_px != prev_w
+            && let Some(ss) = win.self_set
+        {
+            let dx = (w_px as f64 - prev_w as f64) / 2.0 / self.scale_factor;
+            let np = LogicalPosition::new((ss.x - dx).max(0.0), ss.y);
+            win.self_set = Some(np);
+            win.window.set_outer_position(np);
+        }
     }
 }
 
@@ -558,13 +590,13 @@ impl ApplicationHandler<Vec<BossBar>> for App {
     /// elapsed counter so its clock advances; otherwise let the loop sleep until
     /// the next event so an idle overlay costs nothing.
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
-        // Settle each window's size to its hover state first: grow for an open
-        // panel, shrink back once the hover has fully eased out. Done here, off the
-        // per-frame easing, so the window resizes only twice per hover.
+        // Settle each window's size first: grow for an open panel, shrink back once
+        // the hover has fully eased out, and widen as the title (or its live
+        // counter) grows. Done here, off the per-frame easing, so the window
+        // resizes only when its target size actually changes.
         let ids: Vec<i64> = self.wins.keys().copied().collect();
         for id in ids {
-            let want = self.wins.get(&id).is_some_and(BarWin::wants_expanded);
-            self.set_window_expanded(id, want);
+            self.settle_window_size(id);
         }
 
         let mut animating = false;

--- a/packages/bossbar-overlay/app/crates/bossbar/src/scene.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/scene.rs
@@ -346,25 +346,48 @@ fn panel_size(gpu: &Gpu, description: &str, scale: u32) -> Option<(f32, f32)> {
     Some((panel_w, panel_h))
 }
 
+/// Physical-pixel advance width of `bar`'s on-screen title (the stored title plus
+/// its live elapsed counter) at the fully grown hover scale, where it is widest,
+/// or 0 when the bar has no title. [`bar_window_px`] reserves at least this width
+/// so a title longer than the 182px bar is never clipped at the window edge. It
+/// measures through the shared CPU font, so the first window can be sized before
+/// any GPU surface exists.
+pub fn title_extent_px(bar: &BossBar, scale: u32, now_unix: i64) -> f32 {
+    if bar.title.is_empty() {
+        return 0.0;
+    }
+    let shown = title_with_elapsed(&bar.title, bar.since, now_unix);
+    // The grown title row is `8 * scale * MAX_SCALE` px tall, so each glyph samples
+    // at `scale * MAX_SCALE` source-px (the `title_px / 8` of `build_one`, maxed).
+    let glyph_scale = scale.max(1) as f32 * MAX_SCALE;
+    overlay_core::bitmap_font::shared().measure(&shown, glyph_scale)
+}
+
 /// Physical-pixel size of the window that holds one bar at `scale` (base scale
 /// times the display factor), including the [`HOVER_SCALE`] headroom so a hovered
-/// bar grows in place. `has_title` adds the title row; plus a one-pixel-scaled
-/// shadow margin.
-pub fn bar_window_px(scale: u32, has_title: bool) -> (u32, u32) {
+/// bar grows in place. `title_w` is the grown title advance (see
+/// [`title_extent_px`]); the window widens to hold a title longer than the bar,
+/// and a nonzero `title_w` adds the title row. Plus a one-pixel-scaled shadow
+/// margin on the right and bottom.
+pub fn bar_window_px(scale: u32, title_w: f32) -> (u32, u32) {
     let s = scale.max(1) as f32 * MAX_SCALE;
     let bar_w = BAR_W as f32 * s;
     let bar_h = BAR_H as f32 * s;
+    let has_title = title_w > 0.0;
     let title = if has_title { 8.0 * s + 1.0 * s } else { 0.0 };
     let shadow = scale.max(1) as f32;
-    ((bar_w + shadow).ceil() as u32, (title + bar_h + shadow).ceil() as u32)
+    // Hold whichever is wider, the bar sprite or the title text; both trail the
+    // one-pixel shadow down-right, so the shadow margin covers the right edge too.
+    let content_w = bar_w.max(title_w) + shadow;
+    (content_w.ceil() as u32, (title + bar_h + shadow).ceil() as u32)
 }
 
 /// Physical-pixel window size for `bar` with its hover panel open: the collapsed
 /// bar window grown downward by the gap plus the panel. Returns the collapsed
 /// size when the bar has no description. The overlay grows the window to this on
 /// hover so the panel has room to unfold.
-pub fn expanded_window_px(gpu: &Gpu, bar: &BossBar, scale: u32) -> (u32, u32) {
-    let (cw, ch) = bar_window_px(scale, !bar.title.is_empty());
+pub fn expanded_window_px(gpu: &Gpu, bar: &BossBar, scale: u32, now_unix: i64) -> (u32, u32) {
+    let (cw, ch) = bar_window_px(scale, title_extent_px(bar, scale, now_unix));
     match panel_size(gpu, &bar.description, scale) {
         Some((panel_w, panel_h)) => {
             let gap = panel::GAP * scale.max(1) as f32;
@@ -418,8 +441,9 @@ pub fn build_one(
 
     // The bar lives in the top region: the collapsed window size, which holds it
     // plus its grow/breathe headroom. Any extra window height below that is the
-    // panel's drop area, so the bar stays put as the panel unfolds.
-    let collapsed_h = bar_window_px(scale, has_title).1 as f32;
+    // panel's drop area, so the bar stays put as the panel unfolds. Only the
+    // height is read here, so the title width need not be exact.
+    let collapsed_h = bar_window_px(scale, title_extent_px(bar, scale, now_unix)).1 as f32;
     let top_region_h = collapsed_h.min(height as f32);
 
     // Center the content (plus its shadow offset) in the top region so growth on
@@ -571,6 +595,7 @@ fn layout(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bars::Overlay;
 
     #[test]
     fn fmt_elapsed_ticks_in_seconds_then_minutes_then_hours() {
@@ -594,5 +619,103 @@ mod tests {
         assert_eq!(title_with_elapsed("Idle", None, 1125), "Idle");
         // A counter never appears on its own when there is no title.
         assert_eq!(title_with_elapsed("", Some(1000), 1125), "");
+    }
+
+    fn bar_with_title(title: &str, since: Option<i64>) -> BossBar {
+        BossBar {
+            id: 1,
+            title: title.to_string(),
+            description: String::new(),
+            since,
+            url: String::new(),
+            progress: 0.5,
+            color: Color::Purple,
+            overlay: Overlay::None,
+            position: 0,
+            pos: None,
+        }
+    }
+
+    /// The whole point of the title-aware window: a title longer than the 182px
+    /// bar must fit inside the window the overlay reserves for it, at the widest
+    /// the bar ever draws (fully hovered and breathing in). This mirrors the
+    /// placement math in `build_one`, so a regression there that re-clips the
+    /// title (the bug this fixes) trips the assert. The pre-fix `bar_window_px`
+    /// sized to the bar alone, so this would have failed.
+    #[test]
+    fn long_title_fits_reserved_window() {
+        // A real downtime title plus a live H:MM:SS counter, far wider than 182px.
+        let bar = bar_with_title("US East: Health lifecycle image", Some(0));
+        let now = 6815; // 1:53:35
+
+        for scale in [1u32, 2, 3, 4] {
+            let text_w = title_extent_px(&bar, scale, now);
+            let (width, _h) = bar_window_px(scale, text_w);
+            let width = width as f32;
+
+            // The title overflows the bar, so the window must be widened for it.
+            let s_max = scale as f32 * MAX_SCALE;
+            let bar_w = BAR_W as f32 * s_max;
+            assert!(
+                text_w > bar_w,
+                "test title should exceed the bar at scale {scale}: {text_w} vs {bar_w}",
+            );
+            let bar_only = bar_window_px(scale, 0.0).0 as f32;
+            assert!(width > bar_only, "window must grow past bar-only at scale {scale}");
+
+            // Reproduce build_one's widest layout (hover = breathe = 1 → MAX_SCALE).
+            let shadow = scale as f32;
+            let content_w = bar_w + shadow;
+            let left = ((width - content_w) * 0.5).max(0.0);
+            let tx = left + (bar_w - text_w) * 0.5;
+            // Drawn extent runs from the foreground left edge to the shadow's right
+            // edge (one scaled pixel past the glyphs). Both must lie in [0, width].
+            assert!(tx >= -0.01, "title left edge clipped at scale {scale}: tx={tx}");
+            let right = tx + text_w + shadow;
+            assert!(
+                right <= width + 0.01,
+                "title right edge clipped at scale {scale}: right={right} width={width}",
+            );
+        }
+    }
+
+    /// Visual check (run with `--ignored`): render `build_one` for a long-titled
+    /// bar into the exact window the overlay reserves, both at rest and fully
+    /// grown, so the title can be eyeballed for clipping. Writes PNGs under the
+    /// system temp dir and prints their paths.
+    #[test]
+    #[ignore = "renders PNGs for manual inspection; needs a GPU adapter"]
+    fn render_long_title_window() {
+        let bar = bar_with_title("US East: Health lifecycle image", Some(0));
+        let now = 6815; // 1:53:35
+        let scale = 3;
+        let (width, height) = bar_window_px(scale, title_extent_px(&bar, scale, now));
+        let dir = std::env::temp_dir();
+        for (tag, hover, breathe) in [("rest", 0.0f32, 0.0f32), ("grown", 1.0, 1.0)] {
+            let out = dir.join(format!("bossbar_title_{tag}_{width}x{height}.png"));
+            overlay_core::snapshot::render_to_png(
+                width,
+                height,
+                |gpu| {
+                    let tex = register(gpu);
+                    build_one(gpu, &tex, scale, width, height, now, &bar, hover, breathe)
+                },
+                &out,
+            )
+            .expect("render");
+            println!("wrote {} ({width}x{height})", out.display());
+        }
+    }
+
+    /// A bar with no title reserves no title row and stays bar-width, exactly as
+    /// before, so the title-aware path does not bloat untitled bars.
+    #[test]
+    fn untitled_bar_is_bar_width() {
+        let bar = bar_with_title("", None);
+        let scale = 3;
+        assert_eq!(title_extent_px(&bar, scale, 1234), 0.0);
+        let s_max = scale as f32 * MAX_SCALE;
+        let expected_w = (BAR_W as f32 * s_max + scale as f32).ceil() as u32;
+        assert_eq!(bar_window_px(scale, 0.0).0, expected_w);
     }
 }

--- a/packages/bossbar-overlay/app/crates/overlay-core/src/bitmap_font.rs
+++ b/packages/bossbar-overlay/app/crates/overlay-core/src/bitmap_font.rs
@@ -10,6 +10,28 @@
 //! sampling its cell, so titles and page text flow through the same wgpu pipeline
 //! as every sprite.
 
+use std::sync::LazyLock;
+
+/// `ascii.png`, extracted from the official Minecraft jar by the
+/// `minecraft-assets` Nix derivation and dropped here before the build (see
+/// `app/scripts/fetch-assets.sh` for the local-dev copy step). The font module
+/// owns the sheet; [`crate::gpu`] borrows it for the glyph texture.
+pub const ASCII_PNG: &[u8] = include_bytes!("../assets/ascii.png");
+
+/// The basic-Latin face, decoded once from the embedded sheet. Layout that has no
+/// GPU yet (sizing a window to its title before the wgpu surface exists) measures
+/// through this; the live [`crate::gpu::Gpu`] shares the same metrics.
+pub fn shared() -> &'static BitmapFont {
+    static FONT: LazyLock<BitmapFont> = LazyLock::new(|| {
+        let ascii = image::load_from_memory(ASCII_PNG)
+            .expect("decode embedded ascii.png")
+            .to_rgba8();
+        let (w, h) = ascii.dimensions();
+        BitmapFont::from_ascii_rgba(&ascii, w, h)
+    });
+    &FONT
+}
+
 /// Glyph cell side, in source pixels.
 const CELL: u32 = 8;
 /// Cells per row/column in the sheet.

--- a/packages/bossbar-overlay/app/crates/overlay-core/src/gpu.rs
+++ b/packages/bossbar-overlay/app/crates/overlay-core/src/gpu.rs
@@ -7,14 +7,9 @@
 //! overlays build a `Vec<Quad>` and hand it to [`Gpu::draw`] (live window) or
 //! [`crate::snapshot`] (headless PNG).
 
-use crate::bitmap_font::BitmapFont;
+use crate::bitmap_font::{self, BitmapFont};
 
 use wgpu::util::DeviceExt;
-
-/// `ascii.png`, extracted from the official Minecraft jar by the
-/// `minecraft-assets` Nix derivation and dropped here before the build (see
-/// `app/scripts/fetch-assets.sh` for the local-dev copy step).
-const ASCII_PNG: &[u8] = include_bytes!("../assets/ascii.png");
 
 /// Vanilla title-shadow grey: one scaled pixel down-right of the glyph.
 pub const SHADOW: [f32; 4] = [
@@ -108,7 +103,6 @@ pub struct Gpu {
     tex_layout: wgpu::BindGroupLayout,
     sampler: wgpu::Sampler,
     textures: Vec<wgpu::BindGroup>,
-    font: BitmapFont,
     font_tex: TexHandle,
     white_tex: TexHandle,
 }
@@ -218,10 +212,13 @@ impl Gpu {
             ..Default::default()
         });
 
-        // Register the well-known textures before constructing self, so there is
-        // no placeholder font to replace: a 1x1 white pixel, then the Minecraft
-        // font sheet. ascii.png is decoded once, feeding both the glyph metrics
-        // and the texture.
+        // Register the well-known textures before constructing self: a 1x1 white
+        // pixel, then the Minecraft font sheet. The glyph metrics come from the
+        // shared CPU face ([`bitmap_font::shared`]), which retains only the widths,
+        // so the sheet is decoded again here for the texture's pixels. Both read
+        // the same embedded `ASCII_PNG`, so metrics and texture never disagree;
+        // this decode is intentionally separate, not a candidate to fold into
+        // `shared()` (doing so would couple GPU bring-up to the lazy metrics init).
         let mut textures = Vec::new();
         let white_tex = {
             let bind =
@@ -230,11 +227,10 @@ impl Gpu {
             textures.push(bind);
             h
         };
-        let ascii = image::load_from_memory(ASCII_PNG)
+        let ascii = image::load_from_memory(bitmap_font::ASCII_PNG)
             .expect("decode embedded ascii.png")
             .to_rgba8();
         let (fw, fh) = ascii.dimensions();
-        let font = BitmapFont::from_ascii_rgba(&ascii, fw, fh);
         let font_tex = {
             let bind = upload_texture(&device, &queue, &tex_layout, &sampler, &ascii, fw, fh);
             let h = TexHandle(textures.len() as u32);
@@ -251,7 +247,6 @@ impl Gpu {
             tex_layout,
             sampler,
             textures,
-            font,
             font_tex,
             white_tex,
         }
@@ -265,9 +260,11 @@ impl Gpu {
         &self.queue
     }
 
-    /// The Minecraft bitmap font, for measuring text and laying out wraps.
-    pub fn font(&self) -> &BitmapFont {
-        &self.font
+    /// The Minecraft bitmap font, for measuring text and laying out wraps. Same
+    /// shared face window sizing measures with, so on-CPU layout and the drawn
+    /// glyphs always agree.
+    pub fn font(&self) -> &'static BitmapFont {
+        bitmap_font::shared()
     }
 
     /// A 1x1 opaque-white texture; tint a quad sampling it to paint a flat fill.
@@ -303,13 +300,14 @@ impl Gpu {
     /// Lay out `text` as glyph quads at `(x, y)` top-left, `scale` px per source
     /// pixel, tinted `color`. Returns the advance width drawn.
     pub fn text(&self, text: &str, x: f32, y: f32, scale: f32, color: [f32; 4], out: &mut Vec<Quad>) -> f32 {
+        let font = bitmap_font::shared();
         let cell = BitmapFont::cell_px() * scale;
         let mut pen = x;
         for c in text.chars() {
-            if let Some(uv) = self.font.glyph_uv(c) {
+            if let Some(uv) = font.glyph_uv(c) {
                 out.push(Quad::sub(self.font_tex, pen, y, cell, cell, uv, color));
             }
-            pen += self.font.advance(c, scale);
+            pen += font.advance(c, scale);
         }
         pen - x
     }
@@ -332,7 +330,7 @@ impl Gpu {
 
     /// Measure `text`'s advance width at `scale` without drawing.
     pub fn measure(&self, text: &str, scale: f32) -> f32 {
-        self.font.measure(text, scale)
+        bitmap_font::shared().measure(text, scale)
     }
 
     /// Paint `quads` into `view` over a transparent clear. Quads draw in order, so


### PR DESCRIPTION
Long boss bar titles were getting cut off at the left and right. Each bar is its own transparent window sized to the 182px bar sprite, but the title is centered over the bar and is usually wider (a downtime title plus a live H:MM:SS counter), so the overflow spilled past the window edges and was clipped.

## Fix
Size each window to the title, not the bar.

- `overlay-core` exposes a shared CPU-decoded bitmap font (`bitmap_font::shared`) so a title's width can be measured before the GPU surface exists (the first window is created before its surface). `Gpu` delegates `font`/`measure`/`text` to it, so on-CPU layout and the drawn glyphs use one face.
- `scene::title_extent_px` measures the grown title (including the live counter) at `MAX_SCALE`; `bar_window_px` reserves `max(bar_w, title_w) + shadow`.
- Window sizing is unified in `overlay::settle_window_size`: it resizes only when the target changes, reconfigures the surface eagerly on a synchronous resize (winit 0.30 returns `Some` and fires no `Resized` event on 1x displays), and re-centers auto-stacked bars as the counter widens them so the bar does not drift right. Pinned bars keep their dragged top-left.

## Before / after
Before: `…3 East: Health lifecycle image (1:53:35…` (both ends clipped).
After (rendered `build_one` at the reserved window size): `US East: Health lifecycle image (1:53:35)` fully visible.

## Validation
- `nix build .#bossbar-overlay` ✅
- `cargo test --workspace` ✅ (adds `long_title_fits_reserved_window` + `untitled_bar_is_bar_width`)
- `cargo clippy --workspace` ✅ (no new warnings)
- Real GPU render of a long title at rest and fully grown: title fits with no clipping
- Adversarial review pass: no blocking findings; the one real edge (synchronous-resize surface staleness on 1x displays) is fixed in this PR

Made with Claude Opus 4.8.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Size bossbar overlay windows to fit their title text width
> - Window width at creation and each settle tick now expands to the max of the fixed bar width and the measured title advance width (including live elapsed counters), rather than using a fixed bar-width with a boolean title flag.
> - Adds `title_extent_px` in [scene.rs](https://github.com/indexable-inc/index/pull/494/files#diff-931bed67bf8f80a801e6031355b33a1774390f15740bd97d8a54a25229c734ab) for CPU-side title measurement before a GPU surface exists, and updates `bar_window_px` and `expanded_window_px` signatures accordingly.
> - Introduces `bitmap_font::shared()` in [bitmap_font.rs](https://github.com/indexable-inc/index/pull/494/files#diff-a6018c28c705ed95359abc9a7bec0960120dda70ac03299e0adbc9879d67ef25) so font metrics are available globally without a GPU context; the `Gpu` struct no longer owns a private font instance.
> - Size changes are now deferred from `reconcile` to a unified `settle_window_size` pass each tick; auto-stacked bars without a pinned position are recentered horizontally when their width changes.
> - Behavioral Change: windows may now be wider than before when bars have long titles or live counters, and resize events fire incrementally as counter text grows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d81a92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->