### PR TITLE
feat(check): run the CI gate from one repo-owned definition

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,89 +63,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      # nix-fast-build evaluates the checks with nix-eval-jobs (parallel) and
-      # streams each derivation into a build pool as it resolves, instead of
-      # waiting for one big linkFarm to finish evaluating. `--skip-cached` drops
-      # paths already in a substituter, so a warm run does almost no work;
-      # `--no-nom` keeps plain CI logs; `--no-link` avoids leaving result
-      # symlinks. It exits nonzero iff a build or eval fails, which is the gate.
-      # Pinned by commit to nix-fast-build 1.5.0.
-      #
-      # The per-crate rust test units are now separate top-level
-      # `checks.x86_64-linux.*` attributes (one per crate test, e.g.
-      # `rust-<crate>-<test>` / `cargo-unit-real-workspaces`; see the
-      # `rustChecks` spread in lib/per-system.nix), not one `rust-package-tests`
-      # linkFarm. That single aggregate forced one nix-eval-jobs worker to hold
-      # the whole workspace test graph in its heap, which flaked this job two
-      # ways: at nix-eval-jobs' 4096 MiB default per-worker cap it was SIGKILLed
-      # by the limiter ("memory limit reached"), and with the cap raised but many
-      # workers live it instead got OS-OOM-killed ("worker pipe got closed but
-      # evaluation worker still running"). Split, each crate evaluates in its own
-      # worker, so per-worker eval memory is bounded by the single largest crate
-      # rather than the sum, and the eval parallelizes across workers like the
-      # schema-eval step below. With that, the #440/#443 stopgap is relaxed back
-      # to the schema step's 16 workers and the default per-worker cap; we keep a
-      # modest `--eval-max-memory-size 6144` headroom (above the 4 GiB default,
-      # below the old 8 GiB) as a guard rail, not a workaround.
-      #
-      # Complementary follow-up: an eval cache would skip the cold per-commit
-      # re-eval entirely. Nix keys that cache on the locked flake fingerprint,
-      # which for a git source is the commit rev, so every CI commit is a cold
-      # cache today; the `indexable-inc/nix` fork (RFC #405) makes flake eval use
-      # the cache. That is orthogonal to this split and tracked separately.
+      # Run the full gate through the repo-owned `check` app (lib/per-system.nix),
+      # so CI and a local `nix run .#check` execute the same two commands from one
+      # definition: nix-fast-build over `.#checks.x86_64-linux`, then nix-eval-jobs
+      # over `.#packages.x86_64-linux` with the JSON error-line gate. The
+      # command-specific rationale (tool choice, the worker/memory tuning, why the
+      # eval cache is off, the error-line gate) and the pinned tool revisions live
+      # next to that wrapper. The job inherits NIX_CONFIG (above), so the inner
+      # builds still see `gccarch-znver5` and the eval knobs. Branch protection
+      # requires a status named `flake-check`; this job is it, and it fails iff a
+      # check fails to build or the flake stops evaluating.
       - name: Build all flake checks
-        run: |
-          nix run github:Mic92/nix-fast-build/7f185e0ec37b65b4730f892e0de9a831b0610f3a -- \
-            --flake ".#checks.x86_64-linux" \
-            --eval-max-memory-size 6144 \
-            --eval-workers 16 \
-            --skip-cached \
-            --no-nom \
-            --no-link \
-            --option accept-flake-config true
-
-      # Schema/eval gate for the package outputs, broader than the `checks`
-      # nix-fast-build built above. This was `nix flake check -L --no-build`,
-      # which evaluates single-threaded and across all three flake systems
-      # (x86_64-linux plus two darwin), making the schema eval the CI long pole
-      # (~3min; packages.x86_64-linux alone ~47s) while this many-core host sat
-      # idle. The Nix flake eval cache cannot amortize it: Nix keys that cache on
-      # the locked flake fingerprint, which for a git source comes from the
-      # commit rev, so every CI commit is a cold cache.
-      #
-      # nix-eval-jobs is the same parallel evaluator nix-fast-build wraps. Run it
-      # eval-only over the x86_64-linux packages (the system this runner builds
-      # for), spreading the per-attribute evaluation across workers. It realizes
-      # IFD (the `site` import-npm-lock source) on demand during eval, so it
-      # needs none of the old `--no-build` pre-realize step. Workers are capped:
-      # each is a full evaluator that can grow to nix-eval-jobs' 4 GiB-per-worker
-      # cap, and this host runs many CI jobs at once; 16-way already collapses
-      # the eval toward the slowest single attribute. Darwin package outputs are
-      # intentionally not evaluated here, because a linux runner can only
-      # pure-eval cross-platform image derivations and that cross-eval is most of
-      # what made the single-threaded check slow; validate darwin on a darwin
-      # runner if that coverage is wanted.
-      #
-      # The eval cache is disabled: it is keyed per commit so it never hits on a
-      # fresh CI commit, and with it on the parallel workers all contend writing
-      # the same per-commit sqlite (`SQLite database ... is busy`). Off, the run
-      # is clean. Measured on a warm store (eval-cache off, this packages set):
-      # 342s with 1 worker, 75s with 16, 70s with 32, so 16 captures the win.
-      #
-      # nix-eval-jobs reports a per-attribute eval failure as a JSON `error` line
-      # and still exits 0, so the gate is the error-line check below; a startup
-      # or lock failure exits nonzero and trips the default `pipefail`. Pinned by
-      # commit to nix-eval-jobs v2.34.1, matching the host Nix 2.34.x.
-      - name: Validate flake schema (parallel eval)
-        run: |
-          nix run github:nix-community/nix-eval-jobs/65ebf5b7cd453a27af09cf02b1fc57b3568cc4b7 -- \
-            --flake ".#packages.x86_64-linux" \
-            --workers 16 \
-            --gc-roots-dir "$RUNNER_TEMP/flake-schema-eval-gc" \
-            --option accept-flake-config true \
-            --option eval-cache false \
-            | tee "$RUNNER_TEMP/flake-schema-eval.jsonl"
-          if grep -q '"error":' "$RUNNER_TEMP/flake-schema-eval.jsonl"; then
-            echo "flake schema evaluation failed; see the error lines above" >&2
-            exit 1
-          fi
+        run: nix run .#check

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -98,6 +98,85 @@ let
     '';
   };
 
+  # `check` is the full CI gate as one repo-owned command: check.yml runs
+  # `nix run .#check`, so the same two steps run in CI and locally from a single
+  # definition. It targets x86_64-linux explicitly because that is the system CI
+  # builds for; a linux runner can only pure-eval the cross-platform darwin
+  # images, and that cross-eval was most of what made the old single-threaded
+  # `nix flake check` slow. `nix` is taken from the ambient PATH on purpose
+  # (this is always invoked as `nix run .#check`, so the host's daemon-matched
+  # nix is already present); pinning a client nix here could mismatch the host
+  # Nix 2.34.x daemon.
+  #
+  # Step 1 (nix-fast-build) builds every `checks.x86_64-linux` derivation: it
+  # evaluates with nix-eval-jobs (parallel) and streams each drv into a build
+  # pool as it resolves. --skip-cached drops paths already in a substituter (a
+  # warm run does almost no work), --no-nom keeps plain logs, --no-link leaves no
+  # result symlinks. It exits nonzero iff a build or eval fails: that is the gate.
+  # --eval-workers 16 with --eval-max-memory-size 6144 is a headroom guard rail
+  # (above nix-eval-jobs' 4 GiB default per worker, below the old 8 GiB), not a
+  # workaround: the per-crate check split (see the `checks` block below) keeps
+  # each worker's eval bounded by the largest single crate. Pinned by commit to
+  # nix-fast-build 1.5.0.
+  #
+  # Step 2 (nix-eval-jobs) is the schema/eval gate over the package outputs,
+  # broader than the `checks` set step 1 built. nix-eval-jobs is the same
+  # parallel evaluator nix-fast-build wraps; run eval-only over
+  # packages.x86_64-linux it spreads per-attribute eval across 16 workers and
+  # realizes IFD (the `site` import-npm-lock source) on demand. Each worker is a
+  # full evaluator that can grow to the 4 GiB-per-worker cap and the host runs
+  # many CI jobs at once, so 16 both bounds memory and already collapses the eval
+  # toward the slowest single attribute (warm store, eval-cache off: 342s at 1
+  # worker, 75s at 16, 70s at 32). The eval cache is off because it is keyed per
+  # commit (it never hits on a fresh CI commit) and parallel workers otherwise
+  # contend writing the same per-commit sqlite ("database is busy"). The
+  # resulting cold per-commit re-eval is tracked separately; a flake eval cache
+  # would amortize it. nix-eval-jobs
+  # reports a per-attribute eval failure as a JSON `error` line and still exits 0,
+  # so the gate is the error-line check; a startup or lock failure exits nonzero
+  # and aborts the run (Nushell propagates external failures like bash
+  # `set -o pipefail`). Pinned by commit to nix-eval-jobs v2.34.1, matching the
+  # host Nix 2.34.x.
+  check = ix.writeNushellApplication pkgs {
+    name = "check";
+    meta.description = "Run the full CI gate: build .#checks.x86_64-linux and eval-validate .#packages.x86_64-linux";
+    text = ''
+      const fast_build = "github:Mic92/nix-fast-build/7f185e0ec37b65b4730f892e0de9a831b0610f3a"
+      const eval_jobs = "github:nix-community/nix-eval-jobs/65ebf5b7cd453a27af09cf02b1fc57b3568cc4b7"
+
+      def main [] {
+        ^nix run $fast_build -- ...[
+          "--flake" ".#checks.x86_64-linux"
+          "--eval-max-memory-size" "6144"
+          "--eval-workers" "16"
+          "--skip-cached"
+          "--no-nom"
+          "--no-link"
+          "--option" "accept-flake-config" "true"
+        ]
+
+        let tmp = (mktemp --directory --tmpdir "ix-check.XXXXXX")
+        let report = ($tmp | path join "flake-schema-eval.jsonl")
+        ^nix run $eval_jobs -- ...[
+          "--flake" ".#packages.x86_64-linux"
+          "--workers" "16"
+          "--gc-roots-dir" ($tmp | path join "flake-schema-eval-gc")
+          "--option" "accept-flake-config" "true"
+          "--option" "eval-cache" "false"
+        ] | tee { save --raw --force $report }
+
+        # nix-eval-jobs exits 0 even when an attribute fails to evaluate, so this
+        # error-line check is the gate; a nonzero exit already aborted above. The
+        # report is left in place on failure for inspection.
+        if (open --raw $report | lines | any {|line| $line | str contains '"error":' }) {
+          print --stderr "flake schema evaluation failed; see the error lines above"
+          exit 1
+        }
+        rm --recursive --force $tmp
+      }
+    '';
+  };
+
   updateMods = ix.writePythonApplication pkgs {
     name = "update-mods";
     src = paths.tools.updateMods;
@@ -394,7 +473,7 @@ in
 
       health-checks = healthChecks.dag;
       health-checks-zellij = healthChecks.zellij;
-      inherit lint site;
+      inherit check lint site;
       site-dev = site.passthru.devServer;
       bench-filesystem = benchFilesystem;
       update-mods = updateMods;

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -157,13 +157,15 @@ let
 
         let tmp = (mktemp --directory --tmpdir "ix-check.XXXXXX")
         let report = ($tmp | path join "flake-schema-eval.jsonl")
-        ^nix run $eval_jobs -- ...[
-          "--flake" ".#packages.x86_64-linux"
-          "--workers" "16"
-          "--gc-roots-dir" ($tmp | path join "flake-schema-eval-gc")
-          "--option" "accept-flake-config" "true"
-          "--option" "eval-cache" "false"
-        ] | tee { save --raw --force $report }
+        do --capture-errors {
+          ^nix run $eval_jobs -- ...[
+            "--flake" ".#packages.x86_64-linux"
+            "--workers" "16"
+            "--gc-roots-dir" ($tmp | path join "flake-schema-eval-gc")
+            "--option" "accept-flake-config" "true"
+            "--option" "eval-cache" "false"
+          ]
+        } | tee { save --raw --force $report }
 
         # nix-eval-jobs exits 0 even when an attribute fails to evaluate, so this
         # error-line check is the gate; a nonzero exit already aborted above. The


### PR DESCRIPTION
## Summary

CI ran the full gate as two commands duplicated inline in `.github/workflows/check.yml`: `nix-fast-build` over `.#checks.x86_64-linux`, then `nix-eval-jobs` over `.#packages.x86_64-linux` with a JSON `"error":`-line check. This moves both into a repo-owned `check` app, so CI and a local `nix run .#check` run the identical gate from one definition.

- `lib/per-system.nix`: new `check` package built with `writeNushellApplication` and exposed as `packages.<system>.check`. `nix run .#check` resolves through `meta.mainProgram` (the repo convention), so no `apps` entry is needed. The wrapper runs the two steps in order and applies the same error-line gate; a nonzero exit from either tool aborts the run, since Nushell propagates external failures like bash `set -o pipefail`. The command-specific rationale and the pinned tool revisions now live next to the wrapper.
- `.github/workflows/check.yml`: the two inline command steps collapse to `run: nix run .#check`. The `NIX_CONFIG` env, the one-runner rationale, and the branch-protection note are unchanged, so the inner builds still see `gccarch-znver5` and the eval knobs.

Pins are preserved verbatim: `Mic92/nix-fast-build/7f185e0ec37b65b4730f892e0de9a831b0610f3a` and `nix-community/nix-eval-jobs/65ebf5b7cd453a27af09cf02b1fc57b3568cc4b7`. The `nodePrefix` double-eval is left untouched (tracked under #393).

Refs #405

## Test plan

- [x] Wrapper builds with the real `nu --ide-check` (`writeNushellApplication` defaults `check = true`)
- [x] `nix eval .#packages.aarch64-darwin.check.meta.mainProgram` returns `check`, so `nix run .#check` resolves
- [x] `nixfmt --check` clean on `lib/per-system.nix`
- [x] `nix run .#lint` surfaces only pre-existing statix lints in unrelated files (`flake.nix`, `packages/claude-history-sync/home-module.nix`); none in the changed files
- [ ] CI `flake-check` green on this PR. The x86_64-linux build and eval cannot run on the aarch64-darwin dev host, so this PR's own CI run is the real end-to-end check.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run the CI gate from a single repo-owned `check` app
> - Replaces two inline CI steps (separate `nix-fast-build` and `nix-eval-jobs` invocations) in [check.yml](.github/workflows/check.yml) with a single `nix run .#check` call.
> - Adds a new `check` Nushell app in [per-system.nix](https://github.com/indexable-inc/index/pull/495/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) that runs both stages: builds all `.#checks.x86_64-linux` via `nix-fast-build`, then evaluates `.#packages.x86_64-linux` via `nix-eval-jobs`, scanning JSONL output for `"error":` lines and exiting 1 if any are found.
> - Exports the `check` app as a flake output alongside `lint` and `site`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8cdb568.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->