### PR TITLE
perf(search): skip the worktree walk for record-only queries

### DIFF
--- a/packages/search-core/src/pipeline.rs
+++ b/packages/search-core/src/pipeline.rs
@@ -45,6 +45,11 @@ pub struct Query<'a> {
     /// How code hits are scoped: worktree-exact (manifest intersection) or
     /// server-filtered (a repo / all-repos query).
     pub code_scope: CodeScope,
+    /// Whether `code` is among the queried sources. When false (e.g. a
+    /// `--source slack` query) the local checkout is never consulted, so the
+    /// worktree walk, manifest persistence, and code sync are all skipped: they
+    /// would be pure latency. Record sources still resolve entirely server-side.
+    pub index_code: bool,
     /// How long to wait for new files to embed before querying anyway.
     pub index_timeout: Duration,
 }
@@ -59,6 +64,15 @@ async fn prepare(
     on_upload: impl Fn(usize, usize) + Send + Sync,
     on_poll: impl Fn(StoreStatus) + Send + Sync,
 ) -> Result<Manifest> {
+    // A query that does not include the `code` source never reads the worktree:
+    // record-source hits (slack/linear/claude_history) are scoped purely by the
+    // server-side metadata filter, not the manifest. Skip the walk + sync
+    // entirely and hand back an empty manifest, so a `--source slack` query in a
+    // large repo does not pay to enumerate and hash the whole checkout.
+    if !query.index_code {
+        return Ok(Manifest::default());
+    }
+
     // Identity of the store this checkout is synced against: the same store name
     // on a different API endpoint is a different store, so both must key the
     // "already synced" gate, or pointing at a fresh instance would be skipped.

--- a/packages/search-py/src/lib.rs
+++ b/packages/search-py/src/lib.rs
@@ -190,6 +190,8 @@ async fn run_search(args: SearchArgs) -> search_core::Result<Vec<DisplayHit>> {
         include_web: args.include_web,
         filters: None,
         code_scope: CodeScope::WorktreeExact,
+        // The Python/MCP binding searches a checkout (code is always in scope).
+        index_code: true,
         index_timeout: INDEX_TIMEOUT,
     };
 
@@ -233,6 +235,8 @@ async fn run_grep(args: GrepArgs) -> search_core::Result<Vec<DisplayHit>> {
         include_web: false,
         filters: None,
         code_scope: CodeScope::WorktreeExact,
+        // The Python/MCP binding searches a checkout (code is always in scope).
+        index_code: true,
         index_timeout: INDEX_TIMEOUT,
     };
 

--- a/packages/search/src/main.rs
+++ b/packages/search/src/main.rs
@@ -120,9 +120,18 @@ struct ScopeArgs {
 
 /// Resolve scope selectors into a server-side metadata filter and the code
 /// scoping mode.
-fn resolve_scope(scope: &ScopeArgs, root: &Path) -> anyhow::Result<(Option<Filter>, CodeScope)> {
+fn resolve_scope(
+    scope: &ScopeArgs,
+    root: &Path,
+) -> anyhow::Result<(Option<Filter>, CodeScope, bool)> {
     let sources = parse_sources(&scope.sources)?;
     let exclude_sources = parse_sources(&scope.not_sources)?;
+
+    // The local checkout is read only when `code` is in scope: no source
+    // selector (every source) or an explicit `code`, and not excluded. A
+    // record-only query (slack/linear/claude_history) skips the worktree walk.
+    let index_code = (sources.is_empty() || sources.iter().any(Source::is_code))
+        && !exclude_sources.iter().any(Source::is_code);
 
     // A repo / all-repos / all-worktrees query is server-filtered: the manifest
     // can only answer "files checked out here", so anything coarser must trust
@@ -154,7 +163,7 @@ fn resolve_scope(scope: &ScopeArgs, root: &Path) -> anyhow::Result<(Option<Filte
         hosts: split_csv(&scope.hosts),
         projects: split_csv(&scope.projects),
     };
-    Ok((build_filter(&spec), code_scope))
+    Ok((build_filter(&spec), code_scope, index_code))
 }
 
 fn parse_sources(values: &[String]) -> anyhow::Result<Vec<Source>> {
@@ -391,11 +400,6 @@ async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
         .clone()
         .ok_or_else(|| anyhow::anyhow!("a query is required: `search <pattern> [path]`"))?;
     let root = resolve_root(cli.path.as_deref())?;
-    anyhow::ensure!(
-        !at_or_above_home(&root),
-        "refusing to index {} (it is at or above your home directory); run from a project directory",
-        root.display(),
-    );
 
     // Color is decided once on stdout, where results print. `anstream` folds in
     // TTY detection, `NO_COLOR`, and `CLICOLOR_FORCE`, so piped output and
@@ -418,7 +422,17 @@ async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
         .unwrap_or_else(|| mixedbread::DEFAULT_BASE_URL.to_owned());
     let store = MixedbreadStore::from_login(base_url.clone()).await?;
 
-    let (filter, code_scope) = resolve_scope(&cli.scope, &root)?;
+    let (filter, code_scope, index_code) = resolve_scope(&cli.scope, &root)?;
+    // Only a code query reads the local checkout, so guard the home-directory
+    // check on it: a record-source query (e.g. `--source slack`) consults the
+    // store alone and must work from any directory, including `$HOME`.
+    if index_code {
+        anyhow::ensure!(
+            !at_or_above_home(&root),
+            "refusing to index {} (it is at or above your home directory); run from a project directory",
+            root.display(),
+        );
+    }
     let query = Query {
         root: &root,
         store_name: &store_name,
@@ -433,6 +447,7 @@ async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
         include_web: cli.web,
         filters: filter.as_ref(),
         code_scope,
+        index_code,
         index_timeout: INDEX_TIMEOUT,
     };
 
@@ -559,11 +574,6 @@ impl IndexProgress {
 
 async fn run_grep(cli: GrepArgs) -> anyhow::Result<()> {
     let root = resolve_root(cli.path.as_deref())?;
-    anyhow::ensure!(
-        !at_or_above_home(&root),
-        "refusing to index {} (it is at or above your home directory); run from a project directory",
-        root.display(),
-    );
 
     let palette = Palette::for_stdout();
     let theme = if cli.content {
@@ -581,7 +591,14 @@ async fn run_grep(cli: GrepArgs) -> anyhow::Result<()> {
 
     // Grep reuses the shared `Query` shape; its semantic-only knobs (rerank,
     // agentic, web) are inert here, and the grep pattern travels in `text`.
-    let (filter, code_scope) = resolve_scope(&cli.scope, &root)?;
+    let (filter, code_scope, index_code) = resolve_scope(&cli.scope, &root)?;
+    if index_code {
+        anyhow::ensure!(
+            !at_or_above_home(&root),
+            "refusing to index {} (it is at or above your home directory); run from a project directory",
+            root.display(),
+        );
+    }
     let query = Query {
         root: &root,
         store_name: &store_name,
@@ -596,6 +613,7 @@ async fn run_grep(cli: GrepArgs) -> anyhow::Result<()> {
         include_web: false,
         filters: filter.as_ref(),
         code_scope,
+        index_code,
         index_timeout: INDEX_TIMEOUT,
     };
     let grep_options = GrepOptions {


### PR DESCRIPTION
A `--source slack` (or linear / claude_history) query never consults the local code manifest, but `prepare()` always walked + hashed the whole checkout and reconciled it against the store before querying. On a large repo that walk is the dominant latency; from `$HOME` it errored outright.

Add `Query.index_code`: when code isn't among the queried sources, return an empty manifest and skip the walk + sync entirely, and guard the at-or-above-home check on it so a record-source query works from any directory. Record sources resolve purely server-side.

Verified on hil-compute-1: `search --source slack` from `/home/andrew` (previously a hard error) now returns in ~1.3s with no walk. clippy + search-core tests green on the Linux builder; search-py compiles.

_(Made with AI assistance — Claude Opus 4.8.)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip worktree walk and local indexing for record-only search queries
> - Adds an `index_code` boolean field to the `Query` struct in [pipeline.rs](https://github.com/indexable-inc/index/pull/496/files#diff-0ddc237eba7aa082343371b6a7515b69d3239f2ef6e857e9d06cde988dccfe57); when `false`, `prepare` returns an empty manifest immediately, skipping the worktree walk, manifest persistence, and code sync.
> - Updates `resolve_scope` in [main.rs](https://github.com/indexable-inc/index/pull/496/files#diff-c7e98141f8760d905ae6b359cdbc66c7e8000cc2ab9fd7889d7728ba9b666af4) to compute `index_code` based on whether `code` is among the selected sources, and gates the home-directory safety check on this flag.
> - The Python/MCP bindings in [lib.rs](https://github.com/indexable-inc/index/pull/496/files#diff-decd2c9fed8a6ce98d85cdd74436ec724d1685800944cba1f275453213c6fc4b) always set `index_code: true` since they operate on a checkout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b9025b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->