### PR TITLE
refactor(images/dev): enforce Claude bypass via managed-settings, not a merged settings.json

### DIFF
--- a/images/dev/development-base/default.nix
+++ b/images/dev/development-base/default.nix
@@ -93,7 +93,8 @@ in
   #
   # Claude Code reads `/etc/claude-code/managed-settings.json` as its
   # highest-precedence, enforced layer (above user, project, local, and CLI), and
-  # only ever READS it. That makes a read-only /nix/store file the right delivery:
+  # only ever READS it. That makes a read-only /nix/store file (delivered by
+  # environment.etc as an /etc symlink to the 0444 store copy) the right delivery:
   # no activation copy, no last-applied 3-way merge, no mutable generated file.
   # `~/.claude/settings.json` is left entirely app-owned, so Claude's in-app
   # settings pane can write theme/etc. with nothing for Nix to collide with. This
@@ -107,8 +108,10 @@ in
   # warning, which managed bypass alone does not suppress. That key is ignored
   # only in *project* scope (a guard against untrusted repos), and is honored in
   # managed scope. Root additionally needs the IS_SANDBOX=1 signal from the
-  # wrapped claude-code above, or the guard rejects bypass mode regardless of
-  # which layer sets it. Mirrors the intent of the ix fleet default in ix's
+  # wrapped claude-code above (the uid-0 bypass guard rejects bypass mode for
+  # root without it); the wrapper sets it unconditionally, so the guard is
+  # satisfied however bypass is configured. Mirrors the intent of the ix fleet
+  # default in ix's
   # nix/homes/modules/llm.nix (that module is per-user home-manager, so it can't
   # write /etc; moving the fleet onto a managed file is the follow-up).
   environment.etc."claude-code/managed-settings.json".text = builtins.toJSON {

--- a/images/dev/development-base/default.nix
+++ b/images/dev/development-base/default.nix
@@ -79,44 +79,40 @@ in
       claude-code
     ];
 
-  # Claude Code defaults for the dev image: a writable, Nix-generated
-  # settings.json.
+  # Claude Code policy for the dev image: enforce the bypass keys through
+  # Claude's own managed-settings layer, not by writing the user's settings.json.
   #
-  # This image only ever runs inside a per-tenant ix VM (or an `ix shell` user
-  # on one), which is the real trust boundary: the agent can touch nothing but
-  # this guest's disposable filesystem, network, and processes. Per-tool
-  # approval prompts buy nothing here and only stall an agent that has nowhere
-  # unsafe to go, so inside the guest we hand Claude full authority. The
-  # enforcement that actually matters belongs to the sandbox that owns the
-  # guest, whether that is the VM boundary or the OS user the agent runs as,
-  # not to a confirmation dialog the agent answers itself.
+  # This image only ever runs inside a per-tenant ix VM (or an `ix shell` user on
+  # one), which is the real trust boundary: the agent can touch nothing but this
+  # guest's disposable filesystem, network, and processes. Per-tool approval
+  # prompts buy nothing here and only stall an agent that has nowhere unsafe to
+  # go, so inside the guest we hand Claude full authority. The enforcement that
+  # actually matters belongs to the sandbox that owns the guest, whether that is
+  # the VM boundary or the OS user the agent runs as, not to a confirmation
+  # dialog the agent answers itself.
   #
-  # `permissions.defaultMode = "bypassPermissions"` runs every tool without an
-  # approval prompt; `skipDangerousModePermissionPrompt` pre-accepts the
-  # one-time bypass-mode warning so a fresh interactive launch does not stall on
-  # the confirmation dialog (both honored only in user-scope settings.json,
-  # which this is). Mirrors the ix fleet default in ix's
-  # nix/homes/modules/llm.nix. Root additionally needs the IS_SANDBOX=1 signal
-  # from the wrapped claude-code above, or this mode is rejected.
+  # Claude Code reads `/etc/claude-code/managed-settings.json` as its
+  # highest-precedence, enforced layer (above user, project, local, and CLI), and
+  # only ever READS it. That makes a read-only /nix/store file the right delivery:
+  # no activation copy, no last-applied 3-way merge, no mutable generated file.
+  # `~/.claude/settings.json` is left entirely app-owned, so Claude's in-app
+  # settings pane can write theme/etc. with nothing for Nix to collide with. This
+  # is the model #491 landed on after anna's note that layered, app-native config
+  # (a read-only managed scope merged at load time) beats consumer-side merge
+  # logic wherever the app provides it.
   #
-  # Delivered as a WRITABLE file, not a read-only /nix/store symlink (what
-  # home.file and home-manager's programs.claude-code emit): Claude's in-app
-  # settings pane writes back to settings.json, and other agents (Codex, ...)
-  # rewrite their own config too, so a read-only symlink would make every such
-  # write fail with a permission error. The mutable-json module keeps it both
-  # Nix-declared (so the defaults stay composable, unlike mkOutOfStoreSymlink's
-  # raw file) and writable, reconciling with a last-applied 3-way merge on each
-  # switch: our keys are enforced, the app's own keys are preserved. See
-  # lib/mutable-json.nix.
-  home-manager.users.root = {
-    imports = [ ix.mutableJson.homeModule ];
-    home.mutableJsonFiles.claude-code = {
-      target = ".claude/settings.json";
-      value = {
-        "$schema" = "https://json.schemastore.org/claude-code-settings.json";
-        permissions.defaultMode = "bypassPermissions";
-        skipDangerousModePermissionPrompt = true;
-      };
-    };
+  # Both keys must live in this managed file: `permissions.defaultMode =
+  # "bypassPermissions"` runs every tool without a prompt, and
+  # `skipDangerousModePermissionPrompt = true` pre-accepts the one-time bypass
+  # warning, which managed bypass alone does not suppress. That key is ignored
+  # only in *project* scope (a guard against untrusted repos), and is honored in
+  # managed scope. Root additionally needs the IS_SANDBOX=1 signal from the
+  # wrapped claude-code above, or the guard rejects bypass mode regardless of
+  # which layer sets it. Mirrors the intent of the ix fleet default in ix's
+  # nix/homes/modules/llm.nix (that module is per-user home-manager, so it can't
+  # write /etc; moving the fleet onto a managed file is the follow-up).
+  environment.etc."claude-code/managed-settings.json".text = builtins.toJSON {
+    permissions.defaultMode = "bypassPermissions";
+    skipDangerousModePermissionPrompt = true;
   };
 }

--- a/lib/mutable-json.nix
+++ b/lib/mutable-json.nix
@@ -1,8 +1,22 @@
-# Declarative-but-writable JSON config files.
+# Declarative-but-writable JSON config files: the fallback for app config that
+# Nix can't deliver read-only.
 #
-# Some apps (Claude Code's settings pane, Codex, ...) rewrite their own config at
-# runtime, so a read-only `/nix/store` symlink (`home.file`) makes those writes
-# fail with a permission error. The usual escape hatches each give something up:
+# PREFER the app's own managed/policy layer for any key you want to ENFORCE.
+# Many apps already merge several config layers at load time with a read-only,
+# highest-precedence "managed" scope on top: Claude Code reads
+# /etc/claude-code/managed-settings.json, Codex reads /etc/codex/requirements.toml,
+# Firefox has managed policies, etc. Enforcing a key there needs no merge logic
+# and no mutable generated file: ship a read-only /nix/store file and leave the
+# app's own config fully app-owned. That is the right tool whenever the app
+# provides it (see issue #491 and images/dev/development-base, which enforces
+# Claude's bypass keys through the managed layer rather than this module).
+#
+# This module is for what's left: a key that must live in a file the app ALSO
+# writes to and that has no managed layer, or a value you want to SEED as an
+# overridable default rather than enforce (a managed layer always wins, so it
+# can't express "default the user may change"). For those, a read-only
+# `/nix/store` symlink (`home.file`) makes the app's own writes fail with a
+# permission error, and the usual escape hatches each give something up:
 # `mkOutOfStoreSymlink` hands you a raw working-copy file with no Nix algebra
 # (no merge of contributions across modules, no types), and a plain
 # activation-copy overwrites the app's runtime writes on every switch.
@@ -20,8 +34,8 @@
 # Scope: a single declarative owner per file. Multiple Nix-side owners of one
 # file would need per-field ownership (Server-Side Apply), which this is not.
 #
-# Exposed from the flake as `homeModules.mutable-json`; see
-# `images/dev/development-base` for a consumer and `tests/` for the merge cases.
+# Exposed from the flake as `homeModules.mutable-json`; see `tests/` and the
+# `mutable-json-merge` flake check for the merge cases.
 { lib }:
 let
   inherit (lib) types mkOption;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2362,13 +2362,19 @@ let
         message = "development-base should keep unrelated unfree CLIs out of the image";
       }
       {
-        # The bypass-permissions default is reconciled into root's settings.json
-        # via the mutable-json module. A refactor that drops it would silently
-        # restore per-tool prompts, so pin the declared value.
+        # Bypass-permissions is enforced through Claude's managed-settings layer
+        # (/etc/claude-code/managed-settings.json): read-only, highest precedence,
+        # leaving ~/.claude/settings.json app-owned. Pin both keys so a refactor
+        # that drops them can't silently restore per-tool prompts. `.text` is a
+        # plain string (no IFD) so fromJSON can read it in eval.
         assertion =
-          developmentBase.config.home-manager.users.root.home.mutableJsonFiles.claude-code.value.permissions.defaultMode
-          == "bypassPermissions";
-        message = "development-base should default root's Claude Code to bypassPermissions";
+          let
+            managed =
+              builtins.fromJSON
+                developmentBase.config.environment.etc."claude-code/managed-settings.json".text;
+          in
+          managed.permissions.defaultMode == "bypassPermissions" && managed.skipDangerousModePermissionPrompt;
+        message = "development-base should enforce root's Claude Code bypass via managed-settings.json";
       }
     ];
 


### PR DESCRIPTION
Enforce the dev image's Claude bypass keys through Claude's own **managed-settings** layer (`/etc/claude-code/managed-settings.json`) instead of 3-way-merging them into `~/.claude/settings.json`.

- Read-only `/nix/store` file, highest precedence, Claude only ever reads it → no activation copy, no merge, no mutable generated file. `~/.claude/settings.json` is left fully app-owned.
- Both keys kept: managed bypass alone does **not** suppress the one-time warning; `skipDangerousModePermissionPrompt` is honored in managed scope (ignored only in *project* scope).
- `mutable-json` stays as the documented fallback for keys with no managed layer / values seeded as overridable defaults.

Closes the loop on anna's note in #491. The ix fleet (`llm.nix`) is the natural next consumer but needs a NixOS-level module — it's per-user home-manager and can't write `/etc`.

Validated: `nix eval` (managed file carries both keys, root has no `mutableJsonFiles`), `nix run .#lint` green. Eval-test assertion updated to pin the managed file.

Made with AI (Claude Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce Claude Code bypass settings via managed-settings.json instead of mutable home config
> - Replaces the `~/.claude/settings.json` mutation approach (via `home-manager` + `mutableJson`) with a read-only policy file at `/etc/claude-code/managed-settings.json` in [development-base/default.nix](https://github.com/indexable-inc/index/pull/498/files#diff-01ce554385daab1b0da2fd5335a0d948fe85070d30d519bb38c343d5e5b33fd4).
> - The managed file sets `permissions.defaultMode = "bypassPermissions"` and `skipDangerousModePermissionPrompt = true`, delivered at highest precedence by Claude Code's managed-settings layer.
> - Updates [tests/default.nix](https://github.com/indexable-inc/index/pull/498/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) to assert against the new `environment.etc` path instead of the old `home.mutableJsonFiles` path.
> - Updates [lib/mutable-json.nix](https://github.com/indexable-inc/index/pull/498/files#diff-0e6084fa06e2632e7b50266763ce86db5734133ae4fcd86779e301ac54353fdd) docs to clarify when to prefer app-native policy layers over mutable JSON.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3492bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->