### PR TITLE
feat(bossbar-overlay): two-finger scroll-drag to move bars and the book

### DIFF
--- a/packages/bossbar-overlay/README.md
+++ b/packages/bossbar-overlay/README.md
@@ -50,7 +50,8 @@ the same way the game's `BossHealthOverlay` does (color background, color progre
 clipped to the fill, then the notch overlay). Hover one and it eases to fully
 opaque and gently grows with a slow breathing pulse; a press that moves past a few
 pixels starts the platform's native window drag, and the drop location is saved to
-the bar's `x`/`y` columns so it stays put across restarts. A press that does not
+the bar's `x`/`y` columns so it stays put across restarts. A two-finger trackpad
+scroll over a bar nudges it the same way, without pressing. A press that does not
 move is a click: it opens the bar's `url` if it has one. A bar with a
 `description` unfolds a flat panel beneath it on hover; a bar with a `since` (Unix
 epoch) shows a live elapsed timer in its title (`Build (2:05)`).
@@ -114,8 +115,8 @@ a one-page book texture; the spread is that page drawn twice, mirrored on the le
 so the spiral binding meets at the centre spine and normal on the right. Pages of
 text come from SQLite; each page shows a `Page N of M` header and its wrapped
 body. Click the page-turn arrows at the bottom outer corners to advance, drag the
-book to move it (its position is saved), and hover to raise it above other
-windows. `BOOK_SCALE=3` (or `--scale 3`) resizes it.
+book (or two-finger scroll over it) to move it (its position is saved), and hover
+to raise it above other windows. `BOOK_SCALE=3` (or `--scale 3`) resizes it.
 
 ```sh
 nix run .#book-overlay

--- a/packages/bossbar-overlay/app/crates/book/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/book/src/overlay.rs
@@ -6,7 +6,10 @@
 //! Off the window the desktop is click-through (there is no window there). On the
 //! window: hovering grabs focus order so the book sits on top; dragging moves it
 //! (the OS owns the drag via `Window::drag_window`, the position is read back and
-//! persisted); a click on a page-turn arrow flips the spread.
+//! persisted); a two-finger trackpad scroll also moves it (no button to hand to
+//! `drag_window`, so the overlay moves the window itself via
+//! [`overlay_core::scroll_drag_delta`]); a click on a page-turn arrow flips the
+//! spread.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -16,7 +19,9 @@ use overlay_core::glam::DVec2;
 use overlay_core::wgpu;
 use overlay_core::winit::application::ApplicationHandler;
 use overlay_core::winit::dpi::{LogicalPosition, PhysicalPosition};
-use overlay_core::winit::event::{ElementState, MouseButton, WindowEvent};
+use overlay_core::winit::event::{
+    ElementState, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent,
+};
 use overlay_core::winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
 use overlay_core::winit::window::{CursorIcon, Window, WindowId};
 use overlay_core::{window as ocwin, DragClick, Gpu, HoverAnim};
@@ -339,6 +344,41 @@ impl App {
             eprintln!("book-overlay: save position failed: {e}");
         }
     }
+
+    /// Move the book to follow a two-finger trackpad scroll, persisting the new
+    /// position like a drag. There is no button for `Window::drag_window` to own,
+    /// so we move the window ourselves: update `self_set` before the move so the
+    /// resulting `Moved` reads as our own echo (no double write), refresh
+    /// `last_move` so the settle guard does not snap it back from the watcher's
+    /// lagged read, and write the position straight to the DB.
+    fn scroll_move(&mut self, delta: MouseScrollDelta, phase: TouchPhase) {
+        let Some(win) = self.win.as_mut() else {
+            return;
+        };
+        let (dx, dy) = overlay_core::scroll_drag_delta(delta, win.window.scale_factor());
+        // Move the window live on every event, momentum tail included, so it feels
+        // like scrolling. `self_set` tracks where the window sits and is set after
+        // create; measure the scroll from there.
+        if (dx != 0.0 || dy != 0.0) && let Some(cur) = win.self_set {
+            let np = LogicalPosition::new(cur.x + dx, cur.y + dy);
+            win.self_set = Some(np);
+            win.window.set_outer_position(np);
+            win.last_move = Instant::now();
+            self.book.pos = Some(DVec2::new(np.x, np.y));
+        }
+        // Persist only when the gesture settles, not per frame: a trackpad flick
+        // emits a long momentum tail of `MouseWheel` events, and writing on each
+        // would open a SQLite connection per frame on the UI thread. The touch and
+        // momentum ends both carry `TouchPhase::Ended`; a discrete wheel notch
+        // (`LineDelta`) has no Ended phase but is low-frequency, so save it directly.
+        let settle = phase == TouchPhase::Ended || matches!(delta, MouseScrollDelta::LineDelta(..));
+        if settle
+            && let Some(pos) = win.self_set
+            && let Err(e) = db::set_position(&self.db, DVec2::new(pos.x, pos.y))
+        {
+            eprintln!("book-overlay: save position failed: {e}");
+        }
+    }
 }
 
 impl ApplicationHandler<Book> for App {
@@ -478,6 +518,7 @@ impl ApplicationHandler<Book> for App {
                 }
             }
             WindowEvent::Moved(pos) => self.on_moved(pos),
+            WindowEvent::MouseWheel { delta, phase, .. } => self.scroll_move(delta, phase),
             _ => {}
         }
     }

--- a/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
@@ -8,9 +8,11 @@
 //! mouse off a bar. Hovering a bar fires native `CursorEntered`/`CursorLeft` (the
 //! bar paints opaque, the cursor becomes a grab hand); pressing it hands off to
 //! the native `Window::drag_window`, so the OS owns the drag and the new position
-//! is read back from `Moved` and persisted. The press/drag/click disambiguation
-//! is [`overlay_core::DragClick`]; the GPU bring-up, surface config, and
-//! non-activating raise are [`overlay_core::window`].
+//! is read back from `Moved` and persisted. A two-finger trackpad scroll over a
+//! bar nudges it the same way: a scroll has no button for `drag_window` to own, so
+//! the overlay moves the window itself ([`overlay_core::scroll_drag_delta`]). The
+//! press/drag/click disambiguation is [`overlay_core::DragClick`]; the GPU
+//! bring-up, surface config, and non-activating raise are [`overlay_core::window`].
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -21,7 +23,9 @@ use overlay_core::glam::DVec2;
 use overlay_core::wgpu;
 use overlay_core::winit::application::ApplicationHandler;
 use overlay_core::winit::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
-use overlay_core::winit::event::{ElementState, MouseButton, WindowEvent};
+use overlay_core::winit::event::{
+    ElementState, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent,
+};
 use overlay_core::winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
 use overlay_core::winit::window::{CursorIcon, Window, WindowId};
 use overlay_core::{anim, window as ocwin, DragClick, Gpu, HoverAnim};
@@ -384,6 +388,43 @@ impl App {
         }
     }
 
+    /// Move a bar to follow a two-finger trackpad scroll, persisting the new
+    /// position like a drag. There is no button for `Window::drag_window` to own,
+    /// so we move the window ourselves: update `self_set` before the move so the
+    /// resulting `Moved` reads as our own echo (no double write), refresh
+    /// `last_move` so the reconcile guard does not snap it back from the watcher's
+    /// lagged read, and write the position straight to the DB. Scrolling a bar
+    /// pins it, exactly as dragging one does.
+    fn scroll_move(&mut self, id: i64, delta: MouseScrollDelta, phase: TouchPhase) {
+        let Some(win) = self.wins.get_mut(&id) else {
+            return;
+        };
+        let (dx, dy) = overlay_core::scroll_drag_delta(delta, win.window.scale_factor());
+        // Move the window live on every event, momentum tail included, so it feels
+        // like scrolling. `self_set` tracks where the window sits and is set after
+        // create; measure the scroll from there, and pin the bar (`bar.pos`) so the
+        // size-settle pass stops re-centering it, exactly as a drag does.
+        if (dx != 0.0 || dy != 0.0) && let Some(cur) = win.self_set {
+            let np = LogicalPosition::new(cur.x + dx, cur.y + dy);
+            win.self_set = Some(np);
+            win.window.set_outer_position(np);
+            win.last_move = Instant::now();
+            win.bar.pos = Some(DVec2::new(np.x, np.y));
+        }
+        // Persist only when the gesture settles, not per frame: a trackpad flick
+        // emits a long momentum tail of `MouseWheel` events, and writing on each
+        // would open a SQLite connection per frame on the UI thread. The touch and
+        // momentum ends both carry `TouchPhase::Ended`; a discrete wheel notch
+        // (`LineDelta`) has no Ended phase but is low-frequency, so save it directly.
+        let settle = phase == TouchPhase::Ended || matches!(delta, MouseScrollDelta::LineDelta(..));
+        if settle
+            && let Some(pos) = win.self_set
+            && let Err(e) = db::set_position(&self.db, id, DVec2::new(pos.x, pos.y))
+        {
+            eprintln!("bossbar-overlay: save position failed: {e}");
+        }
+    }
+
     /// Settle a bar's window to the size its current state asks for, resizing only
     /// when that size changes. The target is the expanded (panel-open) size while
     /// the bar is hovered or easing back, otherwise the collapsed bar size; either
@@ -581,6 +622,7 @@ impl ApplicationHandler<Vec<BossBar>> for App {
                 }
             }
             WindowEvent::Moved(pos) => self.on_moved(id, pos),
+            WindowEvent::MouseWheel { delta, phase, .. } => self.scroll_move(id, delta, phase),
             _ => {}
         }
     }

--- a/packages/bossbar-overlay/app/crates/overlay-core/src/gesture.rs
+++ b/packages/bossbar-overlay/app/crates/overlay-core/src/gesture.rs
@@ -1,12 +1,47 @@
-//! Press/drag/click disambiguation for a draggable overlay window.
+//! Press/drag/click disambiguation for a draggable overlay window, plus
+//! two-finger scroll-drag.
 //!
 //! An overlay window is both draggable (grab it to move, the OS owns the drag via
 //! `Window::drag_window`) and clickable (a stationary press-release triggers an
-//! action). This state machine watches the winit cursor and left-button events
-//! and tells the caller when to hand off to the native drag and whether a release
-//! was a click. No cursor polling, no hit-test plumbing.
+//! action). [`DragClick`] watches the winit cursor and left-button events and
+//! tells the caller when to hand off to the native drag and whether a release was
+//! a click. No cursor polling, no hit-test plumbing.
+//!
+//! A two-finger trackpad scroll over the overlay should also move it, so the user
+//! can nudge a window without pressing: [`scroll_drag_delta`] turns a winit scroll
+//! delta into the logical-point translation the caller adds to the window's
+//! position.
 
 use winit::dpi::PhysicalPosition;
+use winit::event::MouseScrollDelta;
+
+/// Logical points to move per `LineDelta` notch, for a notched mouse wheel (a
+/// trackpad reports precise `PixelDelta` instead). One notch nudges the window a
+/// readable step rather than a single point.
+const LINE_POINTS: f64 = 16.0;
+
+/// Convert a winit scroll delta into the logical-point `(dx, dy)` translation to
+/// add to a window's position so a two-finger trackpad scroll drags the window
+/// like a grab.
+///
+/// A trackpad reports a precise [`MouseScrollDelta::PixelDelta`] in physical
+/// pixels (winit builds it as `scrollingDelta * scale_factor`), so dividing by
+/// `scale_factor` recovers the logical points the window position is measured in;
+/// a notched wheel reports [`MouseScrollDelta::LineDelta`] in lines, scaled by
+/// [`LINE_POINTS`].
+///
+/// The sign is **negated**: a winit scroll delta points the way the *content*
+/// would scroll, so moving the window the opposite way makes it track the scroll
+/// gesture, grab-and-move. This also inherits the user's scroll-direction
+/// preference (so it always matches "the way I normally scroll"). Verified
+/// against the user's trackpad: the un-negated version moved the window the wrong
+/// way.
+pub fn scroll_drag_delta(delta: MouseScrollDelta, scale_factor: f64) -> (f64, f64) {
+    match delta {
+        MouseScrollDelta::PixelDelta(p) => (-p.x / scale_factor, -p.y / scale_factor),
+        MouseScrollDelta::LineDelta(x, y) => (-(x as f64) * LINE_POINTS, -(y as f64) * LINE_POINTS),
+    }
+}
 
 /// Tracks one window's left-button gesture.
 pub struct DragClick {
@@ -106,5 +141,32 @@ mod tests {
         assert!(g.dragging());
         assert!(!g.released(), "a drag is not a click");
         assert!(!g.dragging(), "release clears the drag");
+    }
+
+    #[test]
+    fn pixel_scroll_converts_physical_to_logical_points() {
+        // A trackpad PixelDelta is physical px; dividing by the scale factor gives
+        // the logical points the window position is in. The sign is negated so the
+        // window tracks the scroll gesture rather than the content direction.
+        let (dx, dy) =
+            scroll_drag_delta(MouseScrollDelta::PixelDelta(at(20.0, -8.0)), 2.0);
+        assert_eq!((dx, dy), (-10.0, 4.0));
+    }
+
+    #[test]
+    fn window_moves_opposite_the_reported_scroll() {
+        // A winit scroll delta points the way the content would scroll; the window
+        // moves the other way so it follows the gesture (grab-and-move).
+        let (dx, dy) =
+            scroll_drag_delta(MouseScrollDelta::PixelDelta(at(5.0, 7.0)), 1.0);
+        assert!(dx < 0.0 && dy < 0.0, "window moves opposite the content-scroll delta");
+    }
+
+    #[test]
+    fn line_scroll_steps_by_a_readable_amount() {
+        let (dx, dy) = scroll_drag_delta(MouseScrollDelta::LineDelta(0.0, -1.0), 2.0);
+        // LineDelta is in lines, independent of the scale factor; sign negated.
+        assert_eq!(dx, 0.0);
+        assert_eq!(dy, LINE_POINTS);
     }
 }

--- a/packages/bossbar-overlay/app/crates/overlay-core/src/lib.rs
+++ b/packages/bossbar-overlay/app/crates/overlay-core/src/lib.rs
@@ -6,7 +6,8 @@
 //!   non-activating raise ([`window`]),
 //! - one textured-quad wgpu pipeline with a texture registry, plus the vanilla
 //!   bitmap font so text is just more quads ([`gpu`], [`bitmap_font`]),
-//! - press/drag/click disambiguation for draggable windows ([`gesture`]),
+//! - press/drag/click disambiguation plus two-finger scroll-drag for draggable
+//!   windows ([`gesture`]),
 //! - a native right-click context menu to close/dismiss an overlay ([`menu`]),
 //! - a headless render-to-PNG for verification ([`snapshot`]),
 //! - the shared animation primitives the overlays drive their hovers with
@@ -27,7 +28,7 @@ pub mod window;
 
 pub use anim::HoverAnim;
 pub use bitmap_font::BitmapFont;
-pub use gesture::DragClick;
+pub use gesture::{scroll_drag_delta, DragClick};
 pub use gpu::{Gpu, Quad, TexHandle, SHADOW};
 
 // Re-export the heavy deps so consumers name the exact versions this workspace


### PR DESCRIPTION
Two-finger trackpad scroll over a boss bar or the book now moves it, like a grab, without pressing. Requested so you can nudge an overlay the way you'd normally scroll.

- Shared `overlay_core::scroll_drag_delta` converts a winit scroll delta to a logical-point translation; both binaries apply it via `set_outer_position` and persist like a drag.
- Sign is negated so the window tracks the scroll gesture (inherits your scroll-direction preference). The un-negated version went the wrong way on a real trackpad.
- Persistence is gated on the gesture settling (`TouchPhase::Ended` / a wheel notch), so a flick's momentum tail doesn't open a SQLite connection per frame on the UI thread.

Validated: `nix build .#bossbar-overlay .#book-overlay` green, 5 `gesture` unit tests pass (sign + unit conversions). Direction confirmed against the user's trackpad.

_Made with Claude (Opus 4.8)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add two-finger scroll-drag to move bossbar and book overlay windows
> - Adds `scroll_drag_delta` to `overlay-core` ([gesture.rs](https://github.com/indexable-inc/index/pull/499/files#diff-df2666f7229c8420653b9339fb6a466bb1421c1ffc81b266d81ddba163c88eac)) that converts `winit` `MouseScrollDelta` to logical dx/dy, negating the sign so the window follows the finger rather than scrolling content.
> - Bossbar windows now handle `MouseWheel` events to nudge individual bars; scrolling also pins the bar, matching drag behavior.
> - The book window handles `MouseWheel` events to reposition itself as an alternative to dragging.
> - Both handlers persist the new position to SQLite on `TouchPhase::Ended` or immediately for discrete `LineDelta` notches.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9c48fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->