### PR TITLE
feat(bossbar-overlay): add a floating Minecraft experience-orb overlay

### DIFF
--- a/packages/bossbar-overlay/README.md
+++ b/packages/bossbar-overlay/README.md
@@ -1,22 +1,24 @@
 # Minecraft Desktop Overlays
 
-Two transparent, always-on-top, click-through desktop overlays drawn in the
-Minecraft style with [`wgpu`](https://github.com/gfx-rs/wgpu): a **boss bar** HUD
-and an open **book**. Both are driven entirely by a single SQLite file each: write
-rows from anything (a shell, a script, a cron job, another program) and the change
-appears on screen within ~200ms.
+Three transparent, always-on-top, click-through desktop overlays drawn in the
+Minecraft style with [`wgpu`](https://github.com/gfx-rs/wgpu): a **boss bar** HUD,
+an open **book**, and a floating **experience orb**. Each is driven entirely by a
+single SQLite file: write rows from anything (a shell, a script, a cron job,
+another program) and the change appears on screen within ~200ms.
 
-Both share one engine, [`overlay-core`](app/crates/overlay-core), which owns the
-float window (transparent, borderless, always-on-top, click-through, drag-to-move)
-and a single textured-quad wgpu pipeline. Text is the real Minecraft bitmap font
-rendered as glyph quads through that same pipeline, so titles and page text are
-just more sprites. The two apps ([`bossbar`](app/crates/bossbar),
-[`book`](app/crates/book)) are thin domain layers on top.
+They share one engine, [`overlay-core`](app/crates/overlay-core), which owns the
+float window (transparent, borderless, always-on-top, click-through, drag-to-move,
+two-finger scroll-to-move) and a single textured-quad wgpu pipeline. Text is the
+real Minecraft bitmap font rendered as glyph quads through that same pipeline, so
+titles and page text are just more sprites. The apps
+([`bossbar`](app/crates/bossbar), [`book`](app/crates/book),
+[`orb`](app/crates/orb)) are thin domain layers on top.
 
-All Minecraft art (boss bar sprites, the book texture and page widgets, the font
-sheet) is extracted from Mojang's official `client.jar` by the
-[`minecraft-assets`](../minecraft-assets) Nix derivation, pinned by Mojang's own
-hash. Nothing is vendored into the repo or pulled from a third-party mirror.
+All Minecraft art (boss bar sprites, the book texture and page widgets, the
+experience-orb sheet, the font sheet) is extracted from Mojang's official
+`client.jar` by the [`minecraft-assets`](../minecraft-assets) Nix derivation,
+pinned by Mojang's own hash. Nothing is vendored into the repo or pulled from a
+third-party mirror.
 
 ![preview](docs/preview.png)
 
@@ -25,6 +27,7 @@ hash. Nothing is vendored into the repo or pulled from a third-party mirror.
 ```sh
 nix run .#bossbar-overlay     # the boss bar HUD across the top of the screen
 nix run .#book-overlay        # a floating open book
+nix run .#xp-orb-overlay      # a floating, bobbing experience orb
 ```
 
 For local Rust development, populate the gitignored art once (it is copied out of

--- a/packages/bossbar-overlay/app/Cargo.lock
+++ b/packages/bossbar-overlay/app/Cargo.lock
@@ -1319,6 +1319,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "orb"
+version = "0.1.0"
+dependencies = [
+ "dirs",
+ "glam",
+ "overlay-core",
+ "rusqlite",
+]
+
+[[package]]
 name = "overlay-core"
 version = "0.1.0"
 dependencies = [

--- a/packages/bossbar-overlay/app/Cargo.lock
+++ b/packages/bossbar-overlay/app/Cargo.lock
@@ -1300,6 +1300,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "orb"
+version = "0.1.0"
+dependencies = [
+ "dirs",
+ "glam",
+ "overlay-core",
+ "rusqlite",
+]
+
+[[package]]
 name = "orbclient"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,16 +1326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "orb"
-version = "0.1.0"
-dependencies = [
- "dirs",
- "glam",
- "overlay-core",
- "rusqlite",
 ]
 
 [[package]]

--- a/packages/bossbar-overlay/app/Cargo.toml
+++ b/packages/bossbar-overlay/app/Cargo.toml
@@ -4,8 +4,8 @@
 # otherwise trip the repo's restriction lints and darwin platform-gating, and
 # their heavy deps would slow every workspace build.
 #
-# `overlay-core` owns the reusable float window + wgpu pixel/text engine; the two
-# binaries (`bossbar`, `book`) are thin domain layers on top. One vendored
+# `overlay-core` owns the reusable float window + wgpu pixel/text engine; the
+# binaries (`bossbar`, `book`, `orb`) are thin domain layers on top. One vendored
 # `Cargo.lock` is shared, and `app/default.nix` builds the whole workspace.
 [workspace]
 resolver = "2"
@@ -13,6 +13,7 @@ members = [
   "crates/overlay-core",
   "crates/bossbar",
   "crates/book",
+  "crates/orb",
 ]
 
 [workspace.package]

--- a/packages/bossbar-overlay/app/crates/orb/Cargo.toml
+++ b/packages/bossbar-overlay/app/crates/orb/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "orb"
+description = "Minecraft-style floating experience-orb desktop overlay driven by an SQLite file"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[[bin]]
+name = "xp-orb-overlay"
+path = "src/main.rs"
+
+[dependencies]
+# winit/wgpu/the bitmap font come through overlay-core's re-exports; only the
+# domain deps are direct here.
+overlay-core.workspace = true
+glam.workspace = true
+rusqlite.workspace = true
+dirs.workspace = true

--- a/packages/bossbar-overlay/app/crates/orb/src/assets.rs
+++ b/packages/bossbar-overlay/app/crates/orb/src/assets.rs
@@ -1,0 +1,10 @@
+//! Embedded Mojang art for the experience-orb overlay. The orb sprite sheet is
+//! extracted from the official Minecraft client jar by the `minecraft-assets` Nix
+//! derivation and dropped into `assets/entity/` before the build (gitignored; see
+//! the workspace `.gitignore`). `include_bytes!` bakes it into the binary, so
+//! there is no runtime asset path to resolve.
+
+/// The experience-orb sheet: a 64x64 image holding the 16x16 orb icons in a 4x4
+/// grid, larger/brighter for more XP. The art is grey; the renderer tints it a
+/// pulsing green-yellow, the shimmer the vanilla orb has. See [`crate::scene`].
+pub const EXPERIENCE_ORB: &[u8] = include_bytes!("../assets/entity/experience_orb.png");

--- a/packages/bossbar-overlay/app/crates/orb/src/db.rs
+++ b/packages/bossbar-overlay/app/crates/orb/src/db.rs
@@ -1,0 +1,188 @@
+//! SQLite is the experience-orb overlay's only data source, mirroring the boss bar
+//! and book overlays: anyone can write the single `orb` row
+//! (`sqlite3 orb.db "UPDATE orb SET amount = 137"`) and the change shows up within
+//! ~200ms. Cross-process writes are detected with `PRAGMA data_version`, which
+//! bumps whenever another connection commits.
+
+use std::{
+    path::{Path, PathBuf},
+    thread,
+    time::Duration,
+};
+
+use rusqlite::{Connection, OptionalExtension};
+
+use crate::orb::Orb;
+
+/// Watcher poll interval; an external write lands on screen within ~200ms.
+pub const POLL: Duration = Duration::from_millis(200);
+
+const SCHEMA: &str = "\
+CREATE TABLE IF NOT EXISTS orb (
+  id     INTEGER PRIMARY KEY CHECK (id = 1),
+  amount INTEGER NOT NULL DEFAULT 0,
+  url    TEXT    NOT NULL DEFAULT '',
+  x      REAL,
+  y      REAL
+);";
+
+/// Inserted only when the DB is first created, so a fresh install shows an orb and
+/// documents the contract by example.
+const SEED: &str = "\
+INSERT INTO orb (id, amount, url) VALUES (1, 137, '');";
+
+/// Resolve the database path: `ORB_DB` wins, else the per-OS app-data path.
+pub fn resolve_path() -> PathBuf {
+    if let Ok(p) = std::env::var("ORB_DB") {
+        if !p.trim().is_empty() {
+            return PathBuf::from(p);
+        }
+    }
+    let base = dirs::data_dir()
+        .or_else(dirs::home_dir)
+        .unwrap_or_else(|| PathBuf::from("."));
+    base.join("xp-orb-overlay").join("orb.db")
+}
+
+fn open(path: &Path) -> rusqlite::Result<Connection> {
+    let fresh = !path.exists();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let conn = Connection::open(path)?;
+    // WAL lets external `sqlite3` writers commit without blocking our reader.
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    conn.execute_batch(SCHEMA)?;
+    if fresh {
+        conn.execute_batch(SEED)?;
+    }
+    Ok(conn)
+}
+
+/// Persist the orb's pinned location (logical screen points). Its own connection
+/// keeps the overlay's read/watch connection untouched; the commit bumps
+/// `data_version`, so the watcher re-reads and the move sticks.
+pub fn set_position(path: &Path, pos: glam::DVec2) -> rusqlite::Result<()> {
+    let conn = Connection::open(path)?;
+    conn.execute(
+        "UPDATE orb SET x = ?1, y = ?2 WHERE id = 1",
+        rusqlite::params![pos.x, pos.y],
+    )?;
+    Ok(())
+}
+
+fn read(conn: &Connection) -> rusqlite::Result<Orb> {
+    conn.query_row(
+        "SELECT amount, url, x, y FROM orb WHERE id = 1",
+        [],
+        |r| {
+            let amount: i64 = r.get(0)?;
+            let url: String = r.get(1)?;
+            let x: Option<f64> = r.get(2)?;
+            let y: Option<f64> = r.get(3)?;
+            Ok(Orb {
+                amount: amount.max(0),
+                url,
+                // Both coordinates must be present to pin the orb; a half-written
+                // row falls back to centering rather than placing it at an edge.
+                pos: x.zip(y).map(|(x, y)| glam::DVec2::new(x, y)),
+            })
+        },
+    )
+    .optional()
+    .map(Option::unwrap_or_default)
+}
+
+fn data_version(conn: &Connection) -> rusqlite::Result<i64> {
+    conn.query_row("PRAGMA data_version", [], |r| r.get(0))
+}
+
+/// Read the current orb once, for the first paint before the watcher ticks.
+pub fn read_once(path: &Path) -> rusqlite::Result<Orb> {
+    let conn = open(path)?;
+    read(&conn)
+}
+
+/// Background loop: re-read the orb whenever the DB changes and hand it to `sink`.
+/// Exits as soon as `sink` returns `false` (the window closed).
+pub fn spawn_watcher<F>(db: PathBuf, mut sink: F)
+where
+    F: FnMut(Orb) -> bool + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut conn = match open(&db) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                eprintln!("xp-orb-overlay: failed to open {}: {e}", db.display());
+                None
+            }
+        };
+        let mut last_version: Option<i64> = None;
+
+        loop {
+            match conn.as_ref() {
+                Some(c) => match data_version(c) {
+                    Ok(v) if Some(v) != last_version => {
+                        last_version = Some(v);
+                        match read(c) {
+                            Ok(orb) => {
+                                if !sink(orb) {
+                                    return;
+                                }
+                            }
+                            Err(e) => eprintln!("xp-orb-overlay: read failed: {e}"),
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        eprintln!("xp-orb-overlay: poll failed, reopening: {e}");
+                        conn = None;
+                        last_version = None;
+                    }
+                },
+                None => conn = open(&db).ok(),
+            }
+            thread::sleep(POLL);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_db(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("orb-test-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir.join("orb.db")
+    }
+
+    #[test]
+    fn fresh_db_seeds_one_orb() {
+        let path = temp_db("seed");
+        let conn = open(&path).unwrap();
+        let orb = read(&conn).unwrap();
+        assert_eq!(orb.amount, 137);
+        assert_eq!(orb.pos, None);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn position_round_trips() {
+        let path = temp_db("pos");
+        let _ = open(&path).unwrap();
+        set_position(&path, glam::DVec2::new(12.0, 34.0)).unwrap();
+        let conn = open(&path).unwrap();
+        assert_eq!(read(&conn).unwrap().pos, Some(glam::DVec2::new(12.0, 34.0)));
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn negative_amount_clamps_to_zero() {
+        let path = temp_db("neg");
+        let conn = open(&path).unwrap();
+        conn.execute("UPDATE orb SET amount = -5 WHERE id = 1", []).unwrap();
+        assert_eq!(read(&conn).unwrap().amount, 0);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+}

--- a/packages/bossbar-overlay/app/crates/orb/src/main.rs
+++ b/packages/bossbar-overlay/app/crates/orb/src/main.rs
@@ -1,0 +1,128 @@
+//! Minecraft-style floating experience-orb desktop overlay.
+//!
+//! A native winit + wgpu overlay (no webview): a transparent, always-on-top,
+//! click-through window holding a single Minecraft experience orb that gently bobs
+//! and shimmers, driven entirely by a single SQLite file. Set its XP `amount`
+//! (which picks the orb's size) and it updates within ~200ms. Shares the float
+//! window and the wgpu pixel engine with the boss bar and book overlays via the
+//! `overlay-core` crate.
+//!
+//! Usage:
+//!   xp-orb-overlay                 run the overlay
+//!   xp-orb-overlay --snapshot OUT  render the current orb to a PNG and exit
+//!                  [--scale N] [--amount N] [--hover]
+
+mod assets;
+mod db;
+mod orb;
+mod overlay;
+mod scene;
+
+use std::path::PathBuf;
+
+/// Default logical pixel scale of the 16x16 orb sprite; overridable with
+/// `ORB_SCALE` or `--scale`.
+const DEFAULT_SCALE: u32 = 4;
+
+struct Args {
+    snapshot: Option<PathBuf>,
+    scale: u32,
+    /// XP amount to snapshot (overrides the DB), so a PNG can show any orb size.
+    amount: Option<i64>,
+    /// Render the snapshot in the hovered (grown) state.
+    hover: bool,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let scale = std::env::var("ORB_SCALE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_SCALE);
+    let mut args = Args {
+        snapshot: None,
+        scale,
+        amount: None,
+        hover: false,
+    };
+    let mut it = std::env::args().skip(1);
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--snapshot" => {
+                let p = it.next().ok_or("--snapshot needs a path")?;
+                args.snapshot = Some(PathBuf::from(p));
+            }
+            "--scale" => {
+                args.scale = it
+                    .next()
+                    .ok_or("--scale needs a number")?
+                    .parse()
+                    .map_err(|_| "--scale must be an integer")?;
+            }
+            "--amount" => {
+                args.amount = Some(
+                    it.next()
+                        .ok_or("--amount needs a number")?
+                        .parse()
+                        .map_err(|_| "--amount must be an integer")?,
+                );
+            }
+            "--hover" => args.hover = true,
+            "-h" | "--help" => {
+                println!(
+                    "xp-orb-overlay [--snapshot OUT] [--scale N] [--amount N] [--hover]\n\
+                     SQLite-driven Minecraft experience-orb overlay. DB path: ORB_DB \
+                     or the per-OS app-data path."
+                );
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown argument: {other}")),
+        }
+    }
+    Ok(args)
+}
+
+fn main() {
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("xp-orb-overlay: {e}");
+            std::process::exit(2);
+        }
+    };
+
+    let db = db::resolve_path();
+
+    if let Some(out) = args.snapshot {
+        let mut orb = db::read_once(&db).unwrap_or_default();
+        if let Some(a) = args.amount {
+            orb.amount = a.max(0);
+        }
+        let scale = args.scale.max(1);
+        let (w, h) = scene::orb_window_px(scale);
+        let hover = if args.hover { 1.0 } else { 0.0 };
+        // A still frame: mid-shimmer, no bob, so the PNG is deterministic.
+        let result = overlay_core::snapshot::render_to_png(
+            w,
+            h,
+            |gpu| {
+                let tex = scene::register(gpu);
+                scene::build(&tex, &orb, scale, w, h, hover, 0.5, 0.0)
+            },
+            &out,
+        );
+        match result {
+            Ok(()) => println!("xp-orb-overlay: wrote {}", out.display()),
+            Err(e) => {
+                eprintln!("xp-orb-overlay: snapshot failed: {e}");
+                std::process::exit(1);
+            }
+        }
+        return;
+    }
+
+    println!("xp-orb-overlay: database at {}", db.display());
+    if let Err(e) = overlay::run(db, args.scale) {
+        eprintln!("xp-orb-overlay: {e}");
+        std::process::exit(1);
+    }
+}

--- a/packages/bossbar-overlay/app/crates/orb/src/orb.rs
+++ b/packages/bossbar-overlay/app/crates/orb/src/orb.rs
@@ -1,0 +1,31 @@
+//! The typed experience-orb domain: a floating orb whose size mirrors an XP
+//! amount, an optional click URL, and a pinned position. Strings are untrusted but
+//! carry no enums to parse; the amount is clamped non-negative so a malformed row
+//! still renders the smallest orb.
+
+use glam::DVec2;
+
+/// One experience orb, ready to render.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Orb {
+    /// XP the orb represents. Larger amounts pick a bigger, brighter vanilla orb
+    /// icon (see [`crate::scene::icon_for`]). Never negative.
+    pub amount: i64,
+    /// Opened with the platform opener on a click that was not a drag. Empty means
+    /// the orb has no click action.
+    pub url: String,
+    /// Pinned on-screen location in logical screen points (window top-left), set
+    /// once the orb is dragged or scrolled. `None` keeps it centered. Persisted to
+    /// the `x`/`y` columns.
+    pub pos: Option<DVec2>,
+}
+
+impl Default for Orb {
+    fn default() -> Self {
+        Self {
+            amount: 0,
+            url: String::new(),
+            pos: None,
+        }
+    }
+}

--- a/packages/bossbar-overlay/app/crates/orb/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/orb/src/overlay.rs
@@ -1,0 +1,427 @@
+//! The live experience-orb overlay: one transparent, always-on-top, borderless
+//! window holding a single Minecraft orb that gently bobs and shimmers. winit owns
+//! the window and event loop; the SQLite watcher runs on its own thread and wakes
+//! the loop with a fresh [`Orb`] on any DB change.
+//!
+//! Off the window the desktop is click-through (there is no window there). On it:
+//! hovering grows the orb and raises it above other overlays; dragging moves it
+//! (the OS owns the drag via `Window::drag_window`, the position is read back and
+//! persisted); a two-finger trackpad scroll also moves it
+//! ([`overlay_core::scroll_drag_delta`]); a click that was not a drag opens the
+//! orb's URL if it has one; right-click closes it. The orb bobs and shimmers
+//! continuously, so the loop animates at a gentle ~30 fps rather than sleeping.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use overlay_core::glam::DVec2;
+use overlay_core::wgpu;
+use overlay_core::winit::application::ApplicationHandler;
+use overlay_core::winit::dpi::{LogicalPosition, PhysicalPosition};
+use overlay_core::winit::event::{
+    ElementState, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent,
+};
+use overlay_core::winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
+use overlay_core::winit::window::{CursorIcon, Window, WindowId};
+use overlay_core::{anim, window as ocwin, DragClick, Gpu, HoverAnim};
+
+use crate::db;
+use crate::orb::Orb;
+use crate::scene::{self, OrbTexture};
+
+/// Pointer travel (physical px) past which a press becomes a window drag.
+const DRAG_THRESHOLD: f64 = 5.0;
+/// How long the window must sit still after its last move before an externally
+/// read position is applied again, so the watcher's lagged read-back of our own
+/// drag never snaps it back.
+const SETTLE: Duration = Duration::from_millis(700);
+/// Hover grow/shrink time: an ease-out tween at the responsive end, matching the
+/// other overlays.
+const GROW: Duration = Duration::from_millis(160);
+/// Largest animation step a single frame may apply, so a stall does not jump the
+/// motion; frames are otherwise ~33ms.
+const MAX_STEP: Duration = Duration::from_millis(50);
+/// Frame budget for the continuous bob + shimmer (~30 fps). The orb is alive by
+/// nature, so it animates always; a gentle 30 fps keeps the cost of one small
+/// quad negligible.
+const FRAME: Duration = Duration::from_millis(33);
+/// One full shimmer (colour pulse) cycle.
+const SHIMMER_PERIOD: Duration = Duration::from_millis(2000);
+/// One full bob (vertical float) cycle; offset from the shimmer so the two never
+/// lock into one motion.
+const BOB_PERIOD: Duration = Duration::from_millis(2600);
+
+/// Open the orb's click URL with the platform opener, detached so the overlay
+/// never blocks on the launch. A spawn failure is reported but not fatal.
+fn open_url(url: &str) {
+    let opener = if cfg!(target_os = "macos") {
+        "open"
+    } else {
+        "xdg-open"
+    };
+    if let Err(e) = std::process::Command::new(opener).arg(url).spawn() {
+        eprintln!("xp-orb-overlay: failed to open {url}: {e}");
+    }
+}
+
+struct WinState {
+    window: Arc<Window>,
+    surface: wgpu::Surface<'static>,
+    config: wgpu::SurfaceConfiguration,
+    texture: OrbTexture,
+    /// Press/drag/click disambiguation for the left-button gesture.
+    gesture: DragClick,
+    /// The pointer is on the orb: drives the grow.
+    hovered: bool,
+    /// Hover amount advanced toward `hovered` each frame.
+    hover_anim: HoverAnim,
+    /// Timestamp of the last animation step, for frame-rate-independent easing.
+    last: Instant,
+    /// Last position we know the window holds (logical points): what we set, or
+    /// where the OS placed it. Lets `Moved` skip echoes of our own placement.
+    self_set: Option<LogicalPosition<f64>>,
+    /// When the window last moved during a drag/scroll, for the settle guard.
+    last_move: Instant,
+}
+
+pub struct App {
+    db: PathBuf,
+    base_scale: u32,
+    proxy: EventLoopProxy<Orb>,
+    instance: wgpu::Instance,
+    gpu: Option<Gpu>,
+    win: Option<WinState>,
+    orb: Orb,
+    mon_logical: (f64, f64),
+    scale_factor: f64,
+    /// Physical sprite scale, `round(base_scale * scale_factor)`.
+    scale: u32,
+    /// App start, the zero point for the continuous shimmer/bob phases.
+    start: Instant,
+    ready: bool,
+}
+
+impl App {
+    /// Auto-centered window position (logical points) within the screen's usable
+    /// area so the orb clears the menu bar and Dock.
+    fn center_pos(&self) -> LogicalPosition<f64> {
+        let (w_px, h_px) = scene::orb_window_px(self.scale);
+        let wl = w_px as f64 / self.scale_factor;
+        let hl = h_px as f64 / self.scale_factor;
+        let (left, top, vw, vh) = ocwin::visible_frame_logical()
+            .unwrap_or((0.0, 0.0, self.mon_logical.0, self.mon_logical.1));
+        LogicalPosition::new(
+            left + ((vw - wl) * 0.5).max(0.0),
+            top + ((vh - hl) * 0.5).max(0.0),
+        )
+    }
+
+    fn create_window(&mut self, event_loop: &ActiveEventLoop) {
+        let (w_px, h_px) = scene::orb_window_px(self.scale);
+        let pos = self
+            .orb
+            .pos
+            .map(|p| LogicalPosition::new(p.x, p.y))
+            .unwrap_or_else(|| self.center_pos());
+        let attrs = ocwin::float_attributes("XP Orb", w_px, h_px, Some(pos));
+        let window = match event_loop.create_window(attrs) {
+            Ok(w) => Arc::new(w),
+            Err(e) => {
+                eprintln!("xp-orb-overlay: create window failed: {e}");
+                event_loop.exit();
+                return;
+            }
+        };
+        // The orb is a background (accessory) window, so hover only reaches it with
+        // an always-active tracking area.
+        ocwin::enable_background_hover(&window);
+
+        let surface = self
+            .instance
+            .create_surface(window.clone())
+            .expect("create surface");
+        let (adapter, device, queue) = ocwin::request_adapter_device(&self.instance, &surface);
+        let caps = surface.get_capabilities(&adapter);
+        let format = ocwin::srgb_format(&caps);
+        let alpha = ocwin::transparent_alpha_mode(&caps);
+
+        let mut gpu = Gpu::new(device, queue, format);
+        let texture = scene::register(&mut gpu);
+
+        let size = window.inner_size();
+        let config = ocwin::surface_config(format, alpha, size.width, size.height);
+        surface.configure(gpu.device(), &config);
+        window.request_redraw();
+
+        self.gpu = Some(gpu);
+        self.win = Some(WinState {
+            window,
+            surface,
+            config,
+            texture,
+            gesture: DragClick::new(DRAG_THRESHOLD),
+            hovered: false,
+            hover_anim: HoverAnim::default(),
+            last: Instant::now(),
+            self_set: Some(pos),
+            last_move: Instant::now() - SETTLE,
+        });
+    }
+
+    fn render(&mut self) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.start);
+        // Continuous phases over the whole run so they never snap: shimmer in
+        // 0..=1, bob in -1..=1.
+        let shimmer = (anim::breathe(elapsed, SHIMMER_PERIOD) + 1.0) * 0.5;
+        let bob = anim::breathe(elapsed, BOB_PERIOD);
+
+        let Some(win) = self.win.as_mut() else {
+            return;
+        };
+        let (cw, ch) = (win.config.width, win.config.height);
+        let dt = now.duration_since(win.last).min(MAX_STEP);
+        win.last = now;
+        win.hover_anim
+            .approach(if win.hovered { 1.0 } else { 0.0 }, dt, GROW);
+        let hover = win.hover_anim.eased();
+
+        let Some(gpu) = self.gpu.as_ref() else {
+            return;
+        };
+        let frame = match win.surface.get_current_texture() {
+            Ok(f) => f,
+            Err(wgpu::SurfaceError::Outdated | wgpu::SurfaceError::Lost) => {
+                win.surface.configure(gpu.device(), &win.config);
+                return;
+            }
+            Err(e) => {
+                eprintln!("xp-orb-overlay: surface error: {e:?}");
+                return;
+            }
+        };
+        let view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let quads = scene::build(&win.texture, &self.orb, self.scale, cw, ch, hover, shimmer, bob);
+        let _ = gpu.draw(&view, cw, ch, &quads);
+        frame.present();
+    }
+
+    /// A window moved. Persist it only when the move came from a user drag;
+    /// otherwise just record where the window sits so a later drag measures right.
+    fn on_moved(&mut self, pos: PhysicalPosition<i32>) {
+        let Some(win) = self.win.as_mut() else {
+            return;
+        };
+        let logical: LogicalPosition<f64> = pos.to_logical(win.window.scale_factor());
+        let echo = win
+            .self_set
+            .is_some_and(|ss| (ss.x - logical.x).abs() < 0.5 && (ss.y - logical.y).abs() < 0.5);
+        if echo {
+            return;
+        }
+        win.self_set = Some(logical);
+        if !win.gesture.dragging() {
+            return; // OS-initiated placement, not a user drag
+        }
+        win.last_move = Instant::now();
+        let dv = DVec2::new(logical.x, logical.y);
+        self.orb.pos = Some(dv);
+        if let Err(e) = db::set_position(&self.db, dv) {
+            eprintln!("xp-orb-overlay: save position failed: {e}");
+        }
+    }
+
+    /// Move the orb to follow a two-finger trackpad scroll, persisting like a drag.
+    /// A scroll has no button for `Window::drag_window` to own, so we move the
+    /// window ourselves and persist only when the gesture settles (so a flick's
+    /// momentum tail does not open a SQLite connection per frame). See
+    /// [`overlay_core::scroll_drag_delta`].
+    fn scroll_move(&mut self, delta: MouseScrollDelta, phase: TouchPhase) {
+        let Some(win) = self.win.as_mut() else {
+            return;
+        };
+        let (dx, dy) = overlay_core::scroll_drag_delta(delta, win.window.scale_factor());
+        if (dx != 0.0 || dy != 0.0) && let Some(cur) = win.self_set {
+            let np = LogicalPosition::new(cur.x + dx, cur.y + dy);
+            win.self_set = Some(np);
+            win.window.set_outer_position(np);
+            win.last_move = Instant::now();
+            self.orb.pos = Some(DVec2::new(np.x, np.y));
+        }
+        let settle = phase == TouchPhase::Ended || matches!(delta, MouseScrollDelta::LineDelta(..));
+        if settle
+            && let Some(pos) = win.self_set
+            && let Err(e) = db::set_position(&self.db, DVec2::new(pos.x, pos.y))
+        {
+            eprintln!("xp-orb-overlay: save position failed: {e}");
+        }
+    }
+}
+
+impl ApplicationHandler<Orb> for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.ready {
+            return;
+        }
+        let monitor = event_loop
+            .primary_monitor()
+            .or_else(|| event_loop.available_monitors().next());
+        let (mon_w, mon_h, scale_factor) = match &monitor {
+            Some(m) => (m.size().width, m.size().height, m.scale_factor()),
+            None => (1920, 1080, 1.0),
+        };
+        self.scale_factor = scale_factor;
+        self.scale = ((self.base_scale as f64) * scale_factor).round().max(1.0) as u32;
+        self.mon_logical = (mon_w as f64 / scale_factor, mon_h as f64 / scale_factor);
+        self.ready = true;
+
+        self.orb = db::read_once(&self.db).unwrap_or_default();
+        self.create_window(event_loop);
+
+        let proxy = self.proxy.clone();
+        db::spawn_watcher(self.db.clone(), move |orb| proxy.send_event(orb).is_ok());
+    }
+
+    fn user_event(&mut self, _event_loop: &ActiveEventLoop, orb: Orb) {
+        self.orb = orb;
+        // Honor an externally set position once the window has settled, skipping
+        // the echo of our own drag/scroll.
+        if let (Some(p), Some(win)) = (self.orb.pos, self.win.as_mut()) {
+            let lp = LogicalPosition::new(p.x, p.y);
+            let settled = Instant::now().duration_since(win.last_move) >= SETTLE;
+            if settled && win.self_set != Some(lp) {
+                win.window.set_outer_position(lp);
+                win.self_set = Some(lp);
+            }
+        }
+        if let Some(win) = self.win.as_ref() {
+            win.window.request_redraw();
+        }
+    }
+
+    fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
+        match event {
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::Resized(size) => {
+                if let (Some(gpu), Some(win)) = (self.gpu.as_ref(), self.win.as_mut()) {
+                    win.config.width = size.width.max(1);
+                    win.config.height = size.height.max(1);
+                    win.surface.configure(gpu.device(), &win.config);
+                }
+                self.render();
+            }
+            WindowEvent::RedrawRequested => self.render(),
+            WindowEvent::CursorEntered { .. } => {
+                // winit's own tracking rect and the always-active NSTrackingArea
+                // both deliver mouseEntered:, so this can arrive twice; act once.
+                if let Some(win) = self.win.as_mut()
+                    && !win.hovered
+                {
+                    win.hovered = true;
+                    win.window.set_cursor(CursorIcon::Grab);
+                    win.window.request_redraw();
+                    ocwin::raise_to_front(&win.window);
+                }
+            }
+            WindowEvent::CursorLeft { .. } => {
+                if let Some(win) = self.win.as_mut() {
+                    win.hovered = false;
+                    win.window.set_cursor(CursorIcon::Default);
+                    win.window.request_redraw();
+                }
+            }
+            WindowEvent::CursorMoved { position, .. } => {
+                let start_drag = self
+                    .win
+                    .as_mut()
+                    .is_some_and(|win| win.gesture.cursor_moved(position));
+                if start_drag
+                    && let Some(win) = self.win.as_ref()
+                {
+                    win.window.set_cursor(CursorIcon::Grabbing);
+                    if let Err(e) = win.window.drag_window() {
+                        eprintln!("xp-orb-overlay: drag failed: {e}");
+                    }
+                }
+            }
+            WindowEvent::MouseInput {
+                state: ElementState::Pressed,
+                button: MouseButton::Left,
+                ..
+            } => {
+                if let Some(win) = self.win.as_mut() {
+                    win.gesture.pressed();
+                }
+            }
+            WindowEvent::MouseInput {
+                state: ElementState::Released,
+                button: MouseButton::Left,
+                ..
+            } => {
+                // A release where the press never became a drag is a click: open
+                // the orb's URL if it has one.
+                let clicked = if let Some(win) = self.win.as_mut() {
+                    let c = win.gesture.released();
+                    win.window.set_cursor(if win.hovered {
+                        CursorIcon::Grab
+                    } else {
+                        CursorIcon::Default
+                    });
+                    c
+                } else {
+                    false
+                };
+                if clicked && !self.orb.url.trim().is_empty() {
+                    open_url(&self.orb.url);
+                }
+            }
+            WindowEvent::MouseInput {
+                state: ElementState::Pressed,
+                button: MouseButton::Right,
+                ..
+            } => {
+                // Right-click opens a native menu to dismiss the orb (its one
+                // window, so closing it quits the overlay).
+                if overlay_core::menu::popup(&["Close"]) == Some(0) {
+                    event_loop.exit();
+                }
+            }
+            WindowEvent::Moved(pos) => self.on_moved(pos),
+            WindowEvent::MouseWheel { delta, phase, .. } => self.scroll_move(delta, phase),
+            _ => {}
+        }
+    }
+
+    /// The orb bobs and shimmers continuously, so keep frames coming at ~30 fps.
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        if let Some(win) = self.win.as_ref() {
+            win.window.request_redraw();
+        }
+        event_loop.set_control_flow(ControlFlow::WaitUntil(Instant::now() + FRAME));
+    }
+}
+
+/// Run the experience-orb overlay event loop. Blocks until the window closes.
+pub fn run(db: PathBuf, base_scale: u32) -> Result<(), Box<dyn std::error::Error>> {
+    let event_loop: EventLoop<Orb> = ocwin::build_event_loop()?;
+    let proxy = event_loop.create_proxy();
+    let mut app = App {
+        db,
+        base_scale: base_scale.max(1),
+        proxy,
+        instance: wgpu::Instance::default(),
+        gpu: None,
+        win: None,
+        orb: Orb::default(),
+        mon_logical: (1920.0, 1080.0),
+        scale_factor: 1.0,
+        scale: base_scale.max(1),
+        start: Instant::now(),
+        ready: false,
+    };
+    event_loop.run_app(&mut app)?;
+    Ok(())
+}

--- a/packages/bossbar-overlay/app/crates/orb/src/scene.rs
+++ b/packages/bossbar-overlay/app/crates/orb/src/scene.rs
@@ -1,0 +1,149 @@
+//! Turning an [`Orb`] into textured quads: pick the vanilla orb icon for its XP
+//! amount, tint the grey sprite a pulsing green-yellow (the shimmer the real orb
+//! has), and let the caller bob and grow it. The orb art is one 64x64 sheet of
+//! 16x16 icons in a 4x4 grid.
+
+use overlay_core::{anim, Gpu, Quad, TexHandle};
+
+use crate::assets;
+use crate::orb::Orb;
+
+/// Source cell size (px) in the orb sheet, the sheet width (px), and its columns.
+const ORB_PX: u32 = 16;
+const SHEET: f32 = 64.0;
+const COLS: u32 = 4;
+
+/// Largest the orb grows to on hover.
+pub const MAX_MUL: f32 = 1.18;
+
+/// Bob amplitude in source pixels: the orb drifts +/- this (times `scale`) about
+/// its resting centre. Small, so it reads as a gentle float, not a bounce.
+const BOB_PX: u32 = 2;
+
+/// The registered orb texture handle.
+pub struct OrbTexture {
+    orb: TexHandle,
+}
+
+pub fn register(gpu: &mut Gpu) -> OrbTexture {
+    OrbTexture {
+        orb: gpu.register_png(assets::EXPERIENCE_ORB),
+    }
+}
+
+/// Vanilla XP-amount -> orb icon (0..=10): the same thresholds Minecraft uses to
+/// pick a bigger, brighter orb for more experience.
+pub fn icon_for(amount: i64) -> u32 {
+    const THRESHOLDS: [(i64, u32); 11] = [
+        (2477, 10),
+        (1237, 9),
+        (617, 8),
+        (307, 7),
+        (149, 6),
+        (73, 5),
+        (37, 4),
+        (17, 3),
+        (7, 2),
+        (3, 1),
+        (0, 0),
+    ];
+    for (min, icon) in THRESHOLDS {
+        if amount >= min {
+            return icon;
+        }
+    }
+    0
+}
+
+/// UV sub-rect for icon `i` within the 4x4 sheet.
+fn icon_uv(i: u32) -> [f32; 4] {
+    let i = i.min(COLS * COLS - 1);
+    let s = ORB_PX as f32;
+    let x = (i % COLS) as f32 * s;
+    let y = (i / COLS) as f32 * s;
+    [x / SHEET, y / SHEET, (x + s) / SHEET, (y + s) / SHEET]
+}
+
+/// Square window (physical px) holding the orb at its hovered size plus room for
+/// the bob, kept tight so the desktop stays click-through around it.
+pub fn orb_window_px(scale: u32) -> (u32, u32) {
+    let orb = ORB_PX * scale;
+    let grow = ((orb as f32) * (MAX_MUL - 1.0)).ceil() as u32;
+    let margin = BOB_PX * scale + grow + scale;
+    let side = orb + 2 * margin;
+    (side, side)
+}
+
+fn lerp(a: f32, b: f32, t: f32) -> f32 {
+    a + (b - a) * t
+}
+
+/// The pulsing green-yellow tint for shimmer phase `t` in `0..=1`. The orb art is
+/// mid-grey, so the tint is overdriven past 1.0 to glow: green stays high while a
+/// little red and blue breathe in and out, swinging green <-> yellow-green.
+fn shimmer_tint(t: f32) -> [f32; 4] {
+    [
+        lerp(0.55, 1.05, t) * 1.4,
+        lerp(0.95, 1.05, t) * 1.5,
+        lerp(0.15, 0.35, t) * 1.4,
+        1.0,
+    ]
+}
+
+/// Build the orb's quads. `hover` is the eased 0..=1 grow amount, `shimmer` the
+/// 0..=1 colour phase, and `bob` a -1..=1 vertical oscillation.
+pub fn build(
+    tex: &OrbTexture,
+    orb: &Orb,
+    scale: u32,
+    win_w: u32,
+    win_h: u32,
+    hover: f32,
+    shimmer: f32,
+    bob: f32,
+) -> Vec<Quad> {
+    let size = (ORB_PX * scale) as f32;
+    let bob_off = bob * (BOB_PX * scale) as f32;
+    let cx = win_w as f32 * 0.5;
+    let cy = win_h as f32 * 0.5;
+    let x = cx - size * 0.5;
+    let y = cy - size * 0.5 + bob_off;
+
+    let uv = icon_uv(icon_for(orb.amount));
+    let mut quads = vec![Quad::sub(tex.orb, x, y, size, size, uv, shimmer_tint(shimmer))];
+
+    // Grow the whole orb about the window centre on hover, like the book.
+    let mul = 1.0 + hover * (MAX_MUL - 1.0);
+    anim::scale_quads_about(&mut quads, cx, cy, mul);
+    quads
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn icon_grows_with_amount() {
+        assert_eq!(icon_for(0), 0);
+        assert_eq!(icon_for(1), 0);
+        assert_eq!(icon_for(7), 2);
+        assert_eq!(icon_for(2477), 10);
+        assert_eq!(icon_for(i64::MAX), 10);
+    }
+
+    #[test]
+    fn icon_uv_stays_in_unit_square() {
+        for i in 0..16 {
+            let [u0, v0, u1, v1] = icon_uv(i);
+            assert!((0.0..=1.0).contains(&u0) && (0.0..=1.0).contains(&v1));
+            assert!(u1 > u0 && v1 > v0);
+        }
+    }
+
+    #[test]
+    fn window_is_square_and_holds_the_grown_orb() {
+        let (w, h) = orb_window_px(4);
+        assert_eq!(w, h);
+        assert!(w >= (16 * 4) + 2, "leaves margin around the orb");
+    }
+}

--- a/packages/bossbar-overlay/app/default.nix
+++ b/packages/bossbar-overlay/app/default.nix
@@ -36,6 +36,7 @@ let
   bins = [
     "bossbar-overlay"
     "book-overlay"
+    "xp-orb-overlay"
   ];
 in
 rustPlatform.buildRustPackage {
@@ -55,6 +56,8 @@ rustPlatform.buildRustPackage {
       ./crates/bossbar/src
       ./crates/book/Cargo.toml
       ./crates/book/src
+      ./crates/orb/Cargo.toml
+      ./crates/orb/src
     ];
   };
 
@@ -68,10 +71,12 @@ rustPlatform.buildRustPackage {
   preBuild = ''
     # Drop the extracted Minecraft art where each crate's `include_bytes!` expects
     # it: the shared font into overlay-core, the sprites into each app.
-    mkdir -p crates/overlay-core/assets crates/bossbar/assets/boss_bar crates/book/assets/gui
+    mkdir -p crates/overlay-core/assets crates/bossbar/assets/boss_bar \
+      crates/book/assets/gui crates/orb/assets/entity
     cp ${minecraft-assets}/font/ascii.png crates/overlay-core/assets/ascii.png
     cp ${minecraft-assets}/boss_bar/*.png crates/bossbar/assets/boss_bar/
     cp ${minecraft-assets}/gui/*.png crates/book/assets/gui/
+    cp ${minecraft-assets}/entity/experience_orb.png crates/orb/assets/entity/
     chmod -R u+w crates
   '';
 

--- a/packages/bossbar-overlay/app/scripts/fetch-assets.sh
+++ b/packages/bossbar-overlay/app/scripts/fetch-assets.sh
@@ -17,13 +17,15 @@ repo_root="$(cd "$here/../../.." && pwd)"                  # repo flake root
 assets="$(nix build "${repo_root}#minecraft-assets" --no-link --print-out-paths)"
 echo "fetch-assets: minecraft-assets at $assets"
 
-# overlay-core embeds the shared bitmap font; the two apps embed their sprites.
+# overlay-core embeds the shared bitmap font; the apps embed their sprites.
 mkdir -p "$here/crates/overlay-core/assets" \
          "$here/crates/bossbar/assets/boss_bar" \
-         "$here/crates/book/assets/gui"
+         "$here/crates/book/assets/gui" \
+         "$here/crates/orb/assets/entity"
 
 cp -f "$assets/font/ascii.png" "$here/crates/overlay-core/assets/ascii.png"
 cp -f "$assets"/boss_bar/*.png "$here/crates/bossbar/assets/boss_bar/"
 cp -f "$assets"/gui/*.png "$here/crates/book/assets/gui/"
+cp -f "$assets"/entity/experience_orb.png "$here/crates/orb/assets/entity/"
 
-echo "fetch-assets: assets ready (font -> overlay-core, boss_bar -> bossbar, gui -> book)"
+echo "fetch-assets: assets ready (font -> overlay-core, boss_bar -> bossbar, gui -> book, entity -> orb)"

--- a/packages/bossbar-overlay/xp-orb-overlay/orb.nix
+++ b/packages/bossbar-overlay/xp-orb-overlay/orb.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  runCommand,
+  bossbar-overlay,
+}:
+# `.#xp-orb-overlay` reuses the single workspace build (which produces *all* the
+# overlay binaries) and just exposes the experience-orb binary as the main
+# program. It must not re-derive `bossbar-overlay`: `meta.mainProgram` is injected
+# as the `NIX_MAIN_PROGRAM` build env var, so overriding it would change the
+# derivation hash and force a full second compile of the whole wgpu/winit
+# workspace. Instead this is a trivial symlink derivation depending on the
+# already-built package, so there is genuinely no second build.
+runCommand "xp-orb-overlay"
+  {
+    meta = bossbar-overlay.meta // {
+      description = "Minecraft-style floating experience-orb desktop overlay (wgpu, SQLite-driven)";
+      mainProgram = "xp-orb-overlay";
+    };
+  }
+  ''
+    mkdir -p "$out/bin"
+    ln -s ${lib.getExe' bossbar-overlay "xp-orb-overlay"} "$out/bin/xp-orb-overlay"
+  ''

--- a/packages/bossbar-overlay/xp-orb-overlay/package.nix
+++ b/packages/bossbar-overlay/xp-orb-overlay/package.nix
@@ -1,0 +1,6 @@
+{
+  id = "xp-orb-overlay";
+  flake = true;
+  packageSet = true;
+  path = ./orb.nix;
+}

--- a/packages/minecraft-assets/default.nix
+++ b/packages/minecraft-assets/default.nix
@@ -49,9 +49,13 @@ stdenvNoCC.mkDerivation {
   buildPhase = ''
     runHook preBuild
 
-    mkdir -p "$out/boss_bar" "$out/gui" "$out/font"
+    mkdir -p "$out/boss_bar" "$out/gui" "$out/font" "$out/entity"
 
     unzip -j -o ${clientJar} '${tex}/gui/sprites/boss_bar/*.png' -d "$out/boss_bar"
+
+    # The experience-orb sprite sheet (16x16 icons in a 4x4 grid) for the XP orb
+    # overlay. It lives under `entity/`, not the GUI sprites.
+    unzip -j -o ${clientJar} '${tex}/entity/experience_orb.png' -d "$out/entity"
 
     unzip -j -o ${clientJar} \
       '${tex}/gui/book.png' \
@@ -83,7 +87,8 @@ stdenvNoCC.mkDerivation {
     description = "Authentic Minecraft GUI textures and bitmap font, extracted from Mojang's official client jar";
     longDescription = ''
       A reproducible extraction of the boss bar sprites, the book GUI texture and
-      page widgets, and the vanilla bitmap font from the official Minecraft
+      page widgets, the experience-orb sheet, and the vanilla bitmap font from the
+      official Minecraft
       ${version} client jar. Consumed by the desktop overlays so they render real
       Mojang art instead of a hand-vendored or mirrored copy.
     '';


### PR DESCRIPTION
A third desktop overlay alongside the boss bar and book: a floating Minecraft **experience orb** that gently bobs and shimmers green-yellow. `nix run .#xp-orb-overlay`.

- SQLite-driven (one `orb` row: `amount`, `url`, `x`, `y`); set `amount` and it picks the vanilla orb icon (bigger orb for more XP) within ~200ms.
- Reuses the shared `overlay-core` engine: float window, wgpu quad pipeline, `DragClick` + two-finger `scroll_drag_delta` to move it, right-click close menu, the `breathe` oscillator for shimmer/bob, headless snapshot. New crate `app/crates/orb` is a thin domain layer modeled on `book`.
- Orb sprite extracted from Mojang's client jar by `minecraft-assets`, like the rest of the art.

Validated headlessly (no window popped): `nix build .#bossbar-overlay .#xp-orb-overlay` green, orb + gesture unit tests pass, and `--snapshot` PNGs confirm a bright green-yellow orb that scales with amount (opaque px 3840 -> 9984 -> 14336 for amount 1 -> 137 -> 2477).

_Made with Claude (Opus 4.8)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a floating Minecraft experience-orb overlay (`xp-orb-overlay`)
> - Adds a new `orb` crate producing the `xp-orb-overlay` binary, a transparent always-on-top window that renders an animated Minecraft XP orb using wgpu via the shared `overlay-core`.
> - The orb's amount, URL, and position are read from a SQLite DB (path configurable via `ORB_DB` env var), with a background watcher thread polling `PRAGMA data_version` every 200ms to reflect external writes within ~200ms.
> - Renders at ~30fps with bobbing, shimmer, and hover grow/shrink animations; supports drag and two-finger scroll to reposition, with position persisted to the DB.
> - Clicking the orb opens a configured URL via the OS default handler; right-click shows a close menu.
> - A `--snapshot` CLI mode renders a deterministic PNG and exits without opening a window.
> - The `minecraft-assets` derivation is extended to extract `entity/experience_orb.png` from the Minecraft client jar for use as the embedded sprite sheet.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3979d37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->