### PR TITLE
feat(macos-vm): drive `scroll` to inject scroll-wheel events into the guest

### DIFF
--- a/packages/macos-vm/src/drive.rs
+++ b/packages/macos-vm/src/drive.rs
@@ -10,6 +10,8 @@
 //! - `type <text>` type the rest of the line as characters
 //! - `click <fx> <fy>` left-click at fraction `(fx, fy)` of the display (top-left)
 //! - `move <fx> <fy>` move the pointer there without clicking (hover)
+//! - `scroll <fx> <fy> <dy_px> [count]` move the pointer there, then post `count`
+//!   vertical pixel-scroll events of `dy_px` (drives a scroll-drag)
 //! - `cursor` report the last pointer fraction set by `click`/`move`
 //! - `size` report the captured framebuffer size in pixels (`ok size <w> <h>`)
 //! - `cursor-show <on|off>` draw a marker at the pointer in subsequent `shot`s
@@ -94,7 +96,7 @@ pub(crate) fn drive_view(
     let view_ptr = Retained::into_raw(view) as usize;
     eprintln!(
         "macos-vm: driving guest; stdin commands: \
-         key/down/up/type/click/move/cursor/size/cursor-show/wait/shot/quit"
+         key/down/up/type/click/move/scroll/cursor/size/cursor-show/wait/shot/quit"
     );
     // Stream the guest screen to the local dashboard so the session shows up on
     // the canvas automatically, the same way a terminal producer does.
@@ -372,6 +374,25 @@ fn execute(view_ptr: usize, trimmed: &str, state: &mut State) -> String {
             };
             pointer_action(view_ptr, fx, fy, command == "click", state);
             format!("ok {command} {fx} {fy}")
+        }
+        "scroll" => {
+            // scroll <fx> <fy> <dy_px> [count]: move the pointer over the target
+            // (the absolute device routes scroll to whatever is under it), then post
+            // `count` vertical pixel-scroll events of `dy_px`. Drives a scroll-drag.
+            let (fx, fy) = match parse_fraction_pair(&mut parts, "scroll") {
+                Ok(pair) => pair,
+                Err(message) => return message,
+            };
+            let Some(Ok(dy)) = parts.next().map(str::parse::<f64>) else {
+                return "err scroll needs <fx> <fy> <dy_px> [count]".to_owned();
+            };
+            let count: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(1);
+            pointer_action(view_ptr, fx, fy, false, state);
+            for _ in 0..count {
+                on_main(view_ptr, move |view| input::scroll(view, 0.0, dy));
+                std::thread::sleep(KEY_GAP_AFTER);
+            }
+            format!("ok scroll {fx} {fy} {dy} x{count}")
         }
         "cursor" => match state.last_cursor {
             Some((fx, fy)) => format!("ok cursor {fx} {fy}"),

--- a/packages/macos-vm/src/input.rs
+++ b/packages/macos-vm/src/input.rs
@@ -101,13 +101,20 @@ pub fn scroll(view: &VZVirtualMachineView, dx: f64, dy: f64) {
     // kCGScrollEventUnitPixel; wheel1 = vertical, wheel2 = horizontal.
     const PIXEL_UNIT: u32 = 0;
 
+    // Use the NON-variadic `CGEventCreateScrollWheelEvent2`: in the variadic
+    // `...Event`, `wheel1` is a fixed (register) parameter and only wheel2/wheel3
+    // are variadic, but Apple's AArch64 ABI passes variadic args on the stack, so
+    // declaring `wheel1` variadic misroutes the vertical delta. The `2` variant
+    // takes all three wheels as fixed params, matching the `core-graphics` crate.
     #[link(name = "CoreGraphics", kind = "framework")]
     unsafe extern "C" {
-        fn CGEventCreateScrollWheelEvent(
+        fn CGEventCreateScrollWheelEvent2(
             source: *mut c_void,
             units: u32,
             wheel_count: u32,
-            ...
+            wheel1: i32,
+            wheel2: i32,
+            wheel3: i32,
         ) -> *mut c_void;
     }
     #[link(name = "CoreFoundation", kind = "framework")]
@@ -117,10 +124,10 @@ pub fn scroll(view: &VZVirtualMachineView, dx: f64, dy: f64) {
 
     #[allow(clippy::cast_possible_truncation)]
     let (wheel1, wheel2) = (dy as i32, dx as i32);
-    // SAFETY: standard CoreGraphics variadic call; a null source means the event
-    // uses the current cursor location. Returns a +1 CGEvent we release below.
+    // SAFETY: standard CoreGraphics call; a null source means the event uses the
+    // current cursor location. Returns a +1 CGEvent we release below.
     let cg = unsafe {
-        CGEventCreateScrollWheelEvent(std::ptr::null_mut(), PIXEL_UNIT, 2, wheel1, wheel2)
+        CGEventCreateScrollWheelEvent2(std::ptr::null_mut(), PIXEL_UNIT, 2, wheel1, wheel2, 0)
     };
     if cg.is_null() {
         return;

--- a/packages/macos-vm/src/input.rs
+++ b/packages/macos-vm/src/input.rs
@@ -5,6 +5,8 @@
 //! modifier flags); the guest keyboard device reads the HID key reports. Key-code
 //! map and technique from github.com/thecrypticace/vzautomation.
 
+use objc2::rc::Retained;
+use objc2::{msg_send, ClassType};
 use objc2_app_kit::{NSEvent, NSEventModifierFlags, NSEventType};
 use objc2_foundation::{NSPoint, NSString};
 use objc2_virtualization::VZVirtualMachineView;
@@ -85,6 +87,52 @@ fn send_mouse(view: &VZVirtualMachineView, event_type: NSEventType, x: f64, y: f
         NSEventType::MouseMoved => view.mouseMoved(&event),
         _ => view.mouseUp(&event),
     }
+}
+
+/// Scroll the guest by `(dx, dy)` pixels at the current pointer location (move the
+/// pointer first to target a window). AppKit has no scroll-wheel `NSEvent`
+/// constructor, so we build a pixel-unit scroll `CGEvent` and wrap it with
+/// `+[NSEvent eventWithCGEvent:]`, then hand it to the view, which forwards it to
+/// the guest's pointing device. Must run on the main thread. A null event is a
+/// no-op rather than a panic.
+pub fn scroll(view: &VZVirtualMachineView, dx: f64, dy: f64) {
+    use std::ffi::c_void;
+
+    // kCGScrollEventUnitPixel; wheel1 = vertical, wheel2 = horizontal.
+    const PIXEL_UNIT: u32 = 0;
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    unsafe extern "C" {
+        fn CGEventCreateScrollWheelEvent(
+            source: *mut c_void,
+            units: u32,
+            wheel_count: u32,
+            ...
+        ) -> *mut c_void;
+    }
+    #[link(name = "CoreFoundation", kind = "framework")]
+    unsafe extern "C" {
+        fn CFRelease(cf: *const c_void);
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    let (wheel1, wheel2) = (dy as i32, dx as i32);
+    // SAFETY: standard CoreGraphics variadic call; a null source means the event
+    // uses the current cursor location. Returns a +1 CGEvent we release below.
+    let cg = unsafe {
+        CGEventCreateScrollWheelEvent(std::ptr::null_mut(), PIXEL_UNIT, 2, wheel1, wheel2)
+    };
+    if cg.is_null() {
+        return;
+    }
+    // SAFETY: `+[NSEvent eventWithCGEvent:]` wraps the CGEvent (it does not take
+    // ownership), returning an autoreleased NSEvent that `msg_send!` retains.
+    let event: Option<Retained<NSEvent>> = unsafe { msg_send![NSEvent::class(), eventWithCGEvent: cg] };
+    if let Some(event) = event {
+        view.scrollWheel(&event);
+    }
+    // SAFETY: balances the +1 from `CGEventCreateScrollWheelEvent`.
+    unsafe { CFRelease(cg.cast()) };
 }
 
 /// Carbon virtual key code for a named key (navigation, editing, modifiers).


### PR DESCRIPTION
Adds scroll-wheel injection to the macOS guest driver (a #476-class follow-up): the driver could click/move but not scroll, so a guest app's scroll handler couldn't be exercised.

- `input::scroll`: AppKit has no scroll-wheel `NSEvent` constructor, so build a pixel-unit scroll `CGEvent` and wrap it with `+[NSEvent eventWithCGEvent:]`, then forward via `VZVirtualMachineView::scrollWheel`.
- drive command `scroll <fx> <fy> <dy_px> [count]`: move the pointer over the target, then post `count` vertical pixel-scroll events.

**Caveat:** the guest's absolute USB pointing-device path coalesces/drops rapid scroll events, so it's best-effort for fast streams (enough to trigger a scroll handler, not a faithful high-rate trackpad). Verified the events reach a guest app (the `xp-orb-overlay` moved in response).

Built `nix build .#macos-vm` green.

_Made with Claude (Opus 4.8)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `scroll` stdin command to inject scroll-wheel events into the macOS VM guest
> - Adds a new `scroll <fx> <fy> <dy_px> [count]` command to the stdin driver in [drive.rs](https://github.com/indexable-inc/index/pull/502/files#diff-9bce8aaf3c940d78f407c66cbd6979c6f45d793000f2e75e2416f8a8a7b16572); moves the pointer to the given fractional coordinates and posts `count` vertical pixel-scroll events with a `KEY_GAP_AFTER` sleep between each.
> - Adds a `scroll` function in [input.rs](https://github.com/indexable-inc/index/pull/502/files#diff-f6fabb00d36a0b17a7d76aa331064f68422e675c8584f2849135ce6b1fc0b0a3) that constructs a pixel-unit `CGEvent` via `CGEventCreateScrollWheelEvent2`, wraps it into an `NSEvent`, and forwards it to the `VZVirtualMachineView` via `scrollWheel`.
> - The command returns an `ok scroll {fx} {fy} {dy} x{count}` acknowledgement or an error if arguments are missing or invalid.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76c83ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->