### PR TITLE
feat(source-codex): Codex CLI prompt-history source adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "source-codex"
+version = "0.1.0"
+dependencies = [
+ "nix 0.30.1",
+ "serde",
+ "serde_json",
+ "snafu 0.9.1",
+ "source-meta",
+]
+
+[[package]]
 name = "claude-history-sync"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "packages/ast-merge/langs",
   "packages/ast-merge/matcher",
   "packages/source/claude",
+  "packages/source/codex",
   "packages/claude-history-sync",
   "packages/clone-detect/cli",
   "packages/clone-detect/detect",
@@ -90,6 +91,7 @@ bytes = "1"
 chrono = { version = "0.4", default-features = false }
 clap = "4"
 source-claude = { path = "packages/source/claude" }
+source-codex = { path = "packages/source/codex" }
 clone-detect = { path = "packages/clone-detect/detect" }
 clone-hash = { path = "packages/clone-detect/hash" }
 clone-pragma = { path = "packages/clone-detect/pragma" }

--- a/packages/source/codex/Cargo.toml
+++ b/packages/source/codex/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "source-codex"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Adapter turning Codex CLI prompt history into embeddable, tagged search documents"
+
+[lints]
+workspace = true
+
+[dependencies]
+source-meta.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+snafu.workspace = true
+nix = { workspace = true, features = ["hostname"] }

--- a/packages/source/codex/package.nix
+++ b/packages/source/codex/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "source-codex";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/source/codex/src/error.rs
+++ b/packages/source/codex/src/error.rs
@@ -1,0 +1,50 @@
+//! Error type for the Codex history adapter.
+
+use std::path::PathBuf;
+
+use snafu::Snafu;
+
+/// All failures surfaced when reading and projecting Codex prompt history.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// The history file could not be read.
+    #[snafu(display("failed to read codex history {}", path.display()))]
+    ReadFile {
+        /// File that could not be read.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// A history line was not valid JSON.
+    #[snafu(display("codex history {} line {line} is not valid JSON", path.display()))]
+    ParseLine {
+        /// File containing the malformed line.
+        path: PathBuf,
+        /// 1-based line number of the offending line.
+        line: usize,
+        /// Underlying serde error.
+        source: serde_json::Error,
+    },
+
+    /// The host name could not be resolved for record tagging.
+    #[snafu(display("failed to resolve host name"))]
+    HostName {
+        /// Underlying OS error.
+        source: std::io::Error,
+    },
+
+    /// A built document's metadata exceeded the store's size or key limits.
+    #[snafu(display("metadata limit exceeded for {external_id}"))]
+    Metadata {
+        /// The record whose metadata overflowed.
+        external_id: String,
+        /// Underlying limit error.
+        source: source_meta::MetadataError,
+    },
+}
+
+/// Result alias defaulting to this crate's [`Error`].
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/packages/source/codex/src/lib.rs
+++ b/packages/source/codex/src/lib.rs
@@ -1,0 +1,152 @@
+//! Adapter turning Codex CLI prompt history into embeddable, tagged
+//! [`source_meta`] documents for the multi-source `search` store.
+//!
+//! # Grain
+//! One [`Document`] per submitted **prompt**. Codex stores history as a flat
+//! append log of `{session_id, ts, text}` lines (default `~/.codex/history.jsonl`),
+//! so a record is one user prompt; there is no assistant side.
+//! `external_id = "codex:{session_id}:{seq}"`, where `seq` is the prompt's
+//! 0-based ordinal within its session in file order, so an append-only log
+//! re-ingests only its new prompts: the content-hash reconcile in `search-core`
+//! skips everything already uploaded.
+//!
+//! # Tags
+//! Every document's flat metadata carries the common header (`source`,
+//! `external_id`, `content_hash`, `title`, `timestamp`) plus the agent-history
+//! filter tags (`host`, `user`, `session_id`), so a query can scope to a
+//! machine, user, or session.
+
+#![forbid(unsafe_code)]
+
+mod error;
+mod record;
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use source_meta::{Document, Source, SourceAdapter};
+use serde::Deserialize;
+use snafu::ResultExt as _;
+
+pub use crate::error::Error;
+pub use crate::record::Entry;
+use crate::error::{HostNameSnafu, ParseLineSnafu, ReadFileSnafu, Result};
+
+/// The `source` tag every Codex prompt document carries.
+pub const SOURCE_TAG: &str = "codex";
+
+/// One raw line of `~/.codex/history.jsonl`.
+#[derive(Debug, Deserialize)]
+struct RawEntry {
+    session_id: String,
+    // A missing `ts` deserializes to `None`: serde treats `Option` fields as
+    // implicitly optional.
+    ts: Option<i64>,
+    text: String,
+}
+
+/// A set of parsed Codex prompts ready to project into documents.
+///
+/// Construct with [`CodexHistory::open`], which reads the flat history log
+/// (default [`default_path`]). Parsing happens up front so
+/// [`SourceAdapter::documents`] is cheap to start.
+#[derive(Debug)]
+#[must_use]
+pub struct CodexHistory {
+    entries: Vec<Entry>,
+}
+
+impl CodexHistory {
+    /// Parse the history log at `path`, tagging each prompt with an explicit
+    /// `host` and `user`. The fleet sync binary uses this so it can tag
+    /// per-machine; [`open`](Self::open) resolves them automatically.
+    ///
+    /// # Errors
+    /// Returns an error if the file cannot be read, or a line is not valid JSON.
+    pub fn open_with(path: &Path, host: &str, user: &str) -> Result<Self> {
+        let contents = std::fs::read_to_string(path).context(ReadFileSnafu { path: path.to_path_buf() })?;
+        let mut seq_by_session: HashMap<String, usize> = HashMap::new();
+        let mut entries = Vec::new();
+        for (index, line) in contents.lines().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let raw: RawEntry = serde_json::from_str(line).context(ParseLineSnafu {
+                path: path.to_path_buf(),
+                line: index + 1,
+            })?;
+            let seq = seq_by_session.entry(raw.session_id.clone()).or_insert(0);
+            entries.push(Entry {
+                host: host.to_owned(),
+                user: user.to_owned(),
+                session_id: raw.session_id,
+                seq: *seq,
+                timestamp: raw.ts,
+                text: raw.text,
+            });
+            *seq += 1;
+        }
+        Ok(Self { entries })
+    }
+
+    /// Parse the history log at `path`, resolving `host` (via `gethostname`) and
+    /// `user` (the OS user) automatically. This is the entry point
+    /// `search ingest --source codex <file>` uses.
+    ///
+    /// # Errors
+    /// Returns an error if the host name cannot be resolved, or the file cannot
+    /// be read or parsed.
+    pub fn open(path: &Path) -> Result<Self> {
+        let host = hostname()?;
+        let user = os_user();
+        Self::open_with(path, &host, &user)
+    }
+
+    /// Number of parsed prompts.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether no prompts were parsed.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl SourceAdapter for CodexHistory {
+    type Error = Error;
+
+    fn source(&self) -> Source {
+        Source::new(SOURCE_TAG)
+    }
+
+    fn documents(&self) -> impl Iterator<Item = Result<Document, Error>> + Send {
+        // Clone into an owned iterator so the result is `'static + Send`,
+        // independent of `&self` (mirrors the claude/slack adapters).
+        self.entries.clone().into_iter().map(Entry::into_document)
+    }
+}
+
+/// The default Codex history log: `~/.codex/history.jsonl`, or `None` when
+/// `HOME` is unset.
+#[must_use]
+pub fn default_path() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".codex").join("history.jsonl"))
+}
+
+/// Resolve the host name for record tagging.
+fn hostname() -> Result<String> {
+    let raw = nix::unistd::gethostname()
+        .map_err(std::io::Error::from)
+        .context(HostNameSnafu)?;
+    Ok(raw.to_string_lossy().into_owned())
+}
+
+/// The OS user owning the process, for the `user` tag.
+fn os_user() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_else(|_| "unknown".to_owned())
+}

--- a/packages/source/codex/src/record.rs
+++ b/packages/source/codex/src/record.rs
@@ -1,0 +1,90 @@
+//! The typed per-prompt record and its projection to a search [`Document`].
+
+use source_meta::{Document, keys};
+use serde_json::{Map, Value, json};
+use snafu::ResultExt as _;
+
+use crate::SOURCE_TAG;
+use crate::error::{MetadataSnafu, Result};
+
+/// One Codex prompt entry: the text the user submitted plus its filter tags.
+///
+/// Codex history is a flat append log of user prompts (`{session_id, ts,
+/// text}`); there is no assistant side, so a record is one submitted prompt.
+#[derive(Debug, Clone)]
+pub struct Entry {
+    /// Short hostname the history was recorded on.
+    pub host: String,
+    /// OS user that owns the history.
+    pub user: String,
+    /// Codex session id grouping prompts from one run.
+    pub session_id: String,
+    /// 0-based ordinal of this prompt within its session, in file order. Makes
+    /// the `external_id` stable across re-runs of an append-only log even when
+    /// two prompts share a timestamp.
+    pub seq: usize,
+    /// Submission time as epoch seconds, when the line carried one.
+    pub timestamp: Option<i64>,
+    /// The submitted prompt text to embed.
+    pub text: String,
+}
+
+impl Entry {
+    /// Stable store id: `codex:{session_id}:{seq}`. Per prompt, so an
+    /// append-only history only ever uploads its new prompts.
+    #[must_use]
+    pub fn external_id(&self) -> String {
+        format!("codex:{}:{}", self.session_id, self.seq)
+    }
+
+    /// Project to a [`Document`]: the prompt text is embedded, its sha256 is the
+    /// `content_hash` (the reconcile key), and the flat metadata carries every
+    /// filter tag.
+    ///
+    /// # Errors
+    /// Returns [`Error::Metadata`](crate::Error::Metadata) if the tag object
+    /// exceeds the store's size or key limits.
+    pub fn into_document(self) -> Result<Document> {
+        let external_id = self.external_id();
+        let content_hash = source_meta::hash_body(self.text.as_bytes());
+        let title = title_for(&self.text);
+
+        let mut meta = Map::new();
+        meta.insert(keys::SOURCE.to_owned(), json!(SOURCE_TAG));
+        meta.insert("external_id".to_owned(), json!(external_id));
+        meta.insert(keys::CONTENT_HASH.to_owned(), json!(content_hash));
+        meta.insert(keys::TITLE.to_owned(), json!(title));
+        meta.insert(keys::HOST.to_owned(), json!(self.host));
+        meta.insert(keys::USER.to_owned(), json!(self.user));
+        meta.insert(keys::SESSION_ID.to_owned(), json!(self.session_id));
+        if let Some(timestamp) = self.timestamp {
+            meta.insert(keys::TIMESTAMP.to_owned(), json!(timestamp));
+        }
+        let meta_json = Value::Object(meta);
+
+        source_meta::check_metadata(&external_id, &meta_json)
+            .context(MetadataSnafu { external_id: external_id.clone() })?;
+
+        Ok(Document {
+            external_id,
+            file_name: format!("{}-{}.txt", self.session_id, self.seq),
+            mime: "text/plain",
+            body: self.text.into_bytes(),
+            meta_json,
+            content_hash,
+        })
+    }
+}
+
+/// Build a short human label from the first non-empty prompt line (capped), so a
+/// hit lists readably without dumping the whole prompt.
+fn title_for(text: &str) -> String {
+    let snippet: String = text
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or_default()
+        .chars()
+        .take(80)
+        .collect();
+    format!("codex: {snippet}")
+}

--- a/packages/source/codex/tests/fixtures/sample.jsonl
+++ b/packages/source/codex/tests/fixtures/sample.jsonl
@@ -1,0 +1,5 @@
+{"session_id":"019cfa3f-a908-71b0-98f0-7ecb3874a8db","ts":1773725019,"text":"clean up the README and make it succinct"}
+
+{"session_id":"019cfa3f-a908-71b0-98f0-7ecb3874a8db","ts":1773725086,"text":"greatly improve the icon: minimal, simple, inline"}
+{"session_id":"019d0102-1111-2222-3333-444455556666","ts":1773726000,"text":"add a retry to the upload path"}
+{"session_id":"019d0102-1111-2222-3333-444455556666","text":"no timestamp on this one"}

--- a/packages/source/codex/tests/parse.rs
+++ b/packages/source/codex/tests/parse.rs
@@ -1,0 +1,54 @@
+//! Parse the sample Codex history and check the projected documents.
+
+use source_codex::CodexHistory;
+use source_meta::{Source, SourceAdapter as _};
+
+fn fixture() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sample.jsonl")
+}
+
+#[test]
+fn parses_every_prompt_skipping_blank_lines() {
+    let history = CodexHistory::open_with(&fixture(), "host1", "user1").expect("parse");
+    // Four prompt lines, one blank line skipped.
+    assert_eq!(history.len(), 4);
+    assert!(!history.is_empty());
+}
+
+#[test]
+fn external_ids_are_per_session_sequential() {
+    let history = CodexHistory::open_with(&fixture(), "host1", "user1").expect("parse");
+    let ids: Vec<String> = history
+        .documents()
+        .map(|doc| doc.expect("document").external_id)
+        .collect();
+    assert_eq!(
+        ids,
+        vec![
+            "codex:019cfa3f-a908-71b0-98f0-7ecb3874a8db:0",
+            "codex:019cfa3f-a908-71b0-98f0-7ecb3874a8db:1",
+            "codex:019d0102-1111-2222-3333-444455556666:0",
+            "codex:019d0102-1111-2222-3333-444455556666:1",
+        ]
+    );
+}
+
+#[test]
+fn documents_carry_source_and_tags() {
+    let history = CodexHistory::open_with(&fixture(), "host1", "user1").expect("parse");
+    assert_eq!(history.source(), Source::new("codex"));
+
+    let docs: Vec<_> = history.documents().map(|doc| doc.expect("document")).collect();
+    let first = &docs[0];
+    assert_eq!(first.meta_json["source"], "codex");
+    assert_eq!(first.meta_json["host"], "host1");
+    assert_eq!(first.meta_json["user"], "user1");
+    assert_eq!(first.meta_json["session_id"], "019cfa3f-a908-71b0-98f0-7ecb3874a8db");
+    assert_eq!(first.meta_json["timestamp"], 1_773_725_019_i64);
+    assert_eq!(first.content_hash, first.meta_json["content_hash"]);
+    assert_eq!(first.body, b"clean up the README and make it succinct");
+
+    // The last prompt had no `ts`, so the timestamp tag is omitted, not null.
+    let last = &docs[3];
+    assert!(last.meta_json.get("timestamp").is_none());
+}


### PR DESCRIPTION
Part of #503 (unified `indexer` + reusable `source-*`/`sink-*` components).

Adds `source-codex`: a `source_meta::SourceAdapter` for Codex CLI prompt history.

- Reads the flat Codex history log (`{session_id, ts, text}` JSONL, default `~/.codex/history.jsonl`).
- One embeddable `Document` per submitted prompt, tagged `source=codex` with `host`/`user`/`session_id`/`timestamp`.
- `external_id = codex:{session_id}:{seq}` (per-session ordinal), so an append-only log re-ingests only new prompts via the existing content-hash reconcile.
- Lives at `packages/source/codex`, mirroring `source-claude`/`source-slack`.

Works with the existing `search_core::sync_documents` Mixedbread path today; the unified `indexer` will wire it in alongside the parquet sink.

Validated: `nix build` of `rust-source-codex-{clippy, parse tests, unusedCrateDependencies, doctest}` on the x86_64-linux builder — all green (3 tests pass, clippy clean, no unused deps).

_Authored with AI (Claude Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Codex CLI prompt-history source adapter
> - Adds a new `source-codex` crate ([lib.rs](https://github.com/indexable-inc/index/pull/505/files#diff-0a2a7715bfc8aff0d455a5e0d15505ca579bca49610890de565501d54b0e88b5)) that reads Codex CLI's JSONL history file (`~/.codex/history.jsonl`) and emits typed `Document` items tagged with source, host, user, session ID, and timestamp.
> - Parses each non-empty JSONL line into an `Entry` with a deterministic `external_id` (`codex:{session_id}:{seq}`) and a content hash suitable for reconciliation.
> - Implements `SourceAdapter<CodexHistory>` so the adapter integrates with the existing ingestion pipeline without custom wiring.
> - Exposes `default_path()` for path discovery and a zero-config `CodexHistory::open()` that resolves hostname and user from the OS environment automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c18511e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->