### PR TITLE
feat(source-atuin): atuin shell-history source adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,6 +1031,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "source-atuin"
+version = "0.1.0"
+dependencies = [
+ "rusqlite",
+ "serde_json",
+ "snafu 0.9.1",
+ "source-meta",
+]
+
+[[package]]
 name = "source-claude"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "packages/ast-merge/git",
   "packages/ast-merge/langs",
   "packages/ast-merge/matcher",
+  "packages/source/atuin",
   "packages/source/claude",
   "packages/source/codex",
   "packages/claude-history-sync",
@@ -90,6 +91,7 @@ base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", default-features = false }
 clap = "4"
+source-atuin = { path = "packages/source/atuin" }
 source-claude = { path = "packages/source/claude" }
 source-codex = { path = "packages/source/codex" }
 clone-detect = { path = "packages/clone-detect/detect" }

--- a/packages/source/atuin/Cargo.toml
+++ b/packages/source/atuin/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "source-atuin"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Adapter turning atuin shell history (nushell/zsh/bash) into embeddable, tagged search documents"
+
+[lints]
+workspace = true
+
+[dependencies]
+source-meta.workspace = true
+rusqlite = { workspace = true, features = ["bundled"] }
+serde_json.workspace = true
+snafu.workspace = true

--- a/packages/source/atuin/package.nix
+++ b/packages/source/atuin/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "source-atuin";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/source/atuin/src/error.rs
+++ b/packages/source/atuin/src/error.rs
@@ -1,0 +1,39 @@
+//! Error type for the atuin shell-history adapter.
+
+use std::path::PathBuf;
+
+use snafu::Snafu;
+
+/// All failures surfaced when reading and projecting atuin history.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// The history database could not be opened.
+    #[snafu(display("failed to open atuin history db {}", path.display()))]
+    OpenDb {
+        /// Database path.
+        path: PathBuf,
+        /// Underlying sqlite error.
+        source: rusqlite::Error,
+    },
+
+    /// The history table could not be queried.
+    #[snafu(display("failed to query atuin history"))]
+    Query {
+        /// Underlying sqlite error.
+        source: rusqlite::Error,
+    },
+
+    /// A built document's metadata exceeded the store's size or key limits.
+    #[snafu(display("metadata limit exceeded for {external_id}"))]
+    Metadata {
+        /// The record whose metadata overflowed.
+        external_id: String,
+        /// Underlying limit error.
+        source: source_meta::MetadataError,
+    },
+}
+
+/// Result alias defaulting to this crate's [`Error`].
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/packages/source/atuin/src/lib.rs
+++ b/packages/source/atuin/src/lib.rs
@@ -1,0 +1,151 @@
+//! Adapter turning atuin shell history into embeddable, tagged
+//! [`source_meta`] documents for the multi-source `search` store.
+//!
+//! # Grain
+//! One [`Document`] per recorded **command**. atuin keeps one sqlite history db
+//! (default `~/.local/share/atuin/history.db`) capturing commands from every
+//! shell it wraps (nushell, zsh, bash), so they share one `shell` corpus rather
+//! than a per-shell source. `external_id = "atuin:{id}"` reuses atuin's own
+//! stable command id, so a re-sync only uploads commands the store is missing.
+//!
+//! # Tags
+//! Every document's flat metadata carries the common header (`source`,
+//! `external_id`, `content_hash`, `title`, `timestamp`) plus the shell filter
+//! tags (`host`, `user`, `cwd`, `session_id`, `exit_status`), so a query can
+//! scope to a machine, user, directory, session, or success/failure.
+
+#![forbid(unsafe_code)]
+
+mod error;
+mod record;
+
+use std::path::{Path, PathBuf};
+
+use source_meta::{Document, Source, SourceAdapter};
+use rusqlite::{Connection, OpenFlags};
+use snafu::ResultExt as _;
+
+pub use crate::error::Error;
+pub use crate::record::Entry;
+use crate::error::{OpenDbSnafu, QuerySnafu, Result};
+
+/// The `source` tag every atuin command document carries. atuin records
+/// commands from every shell (nushell, zsh, bash), so one `shell` corpus covers
+/// them rather than a per-shell tag.
+pub const SOURCE_TAG: &str = "shell";
+
+/// atuin stores timestamps as nanoseconds since the Unix epoch; the common
+/// `timestamp` tag is epoch seconds.
+const NANOS_PER_SEC: i64 = 1_000_000_000;
+
+/// A set of atuin history commands ready to project into documents.
+///
+/// Construct with [`AtuinHistory::open`], which reads the sqlite db read-only
+/// (so a live shell writing to it is never blocked). Parsing happens up front so
+/// [`SourceAdapter::documents`] is cheap to start.
+#[derive(Debug)]
+#[must_use]
+pub struct AtuinHistory {
+    entries: Vec<Entry>,
+}
+
+impl AtuinHistory {
+    /// Open the atuin history db at `path` read-only and read every
+    /// non-deleted command.
+    ///
+    /// # Errors
+    /// Returns an error if the database cannot be opened or queried.
+    pub fn open(path: &Path) -> Result<Self> {
+        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .context(OpenDbSnafu { path: path.to_path_buf() })?;
+        let entries = read_entries(&conn)?;
+        Ok(Self { entries })
+    }
+
+    /// Number of parsed commands.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether no commands were parsed.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// The default atuin history db: `~/.local/share/atuin/history.db`, or
+    /// `None` when `HOME` is unset.
+    #[must_use]
+    pub fn default_path() -> Option<PathBuf> {
+        std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".local/share/atuin/history.db"))
+    }
+}
+
+impl SourceAdapter for AtuinHistory {
+    type Error = Error;
+
+    fn source(&self) -> Source {
+        Source::new(SOURCE_TAG)
+    }
+
+    fn documents(&self) -> impl Iterator<Item = Result<Document, Error>> + Send {
+        // Clone into an owned iterator so the result is `'static + Send`,
+        // independent of `&self` (mirrors the claude/codex/slack adapters).
+        self.entries.clone().into_iter().map(Entry::into_document)
+    }
+}
+
+/// Read every non-deleted, non-empty command from the atuin `history` table.
+fn read_entries(conn: &Connection) -> Result<Vec<Entry>> {
+    let mut stmt = conn
+        .prepare(
+            "select id, timestamp, exit, command, cwd, session, hostname \
+             from history where deleted_at is null order by timestamp",
+        )
+        .context(QuerySnafu)?;
+    let rows = stmt
+        .query_map([], |row| {
+            let timestamp_ns: Option<i64> = row.get(1)?;
+            let hostname: Option<String> = row.get(6)?;
+            let (host, user) = split_host_user(hostname.as_deref());
+            Ok(Entry {
+                id: row.get(0)?,
+                command: row.get(3)?,
+                cwd: non_empty(row.get(4)?),
+                host,
+                user,
+                session: non_empty(row.get(5)?),
+                exit: row.get(2)?,
+                timestamp: timestamp_ns.map(|ns| ns / NANOS_PER_SEC),
+            })
+        })
+        .context(QuerySnafu)?;
+
+    let mut entries = Vec::new();
+    for row in rows {
+        let entry = row.context(QuerySnafu)?;
+        if entry.command.trim().is_empty() {
+            continue;
+        }
+        entries.push(entry);
+    }
+    Ok(entries)
+}
+
+/// atuin records `hostname` as `"<host>:<user>"`. Split on the first colon; fall
+/// back to the whole value as the host with no user.
+fn split_host_user(hostname: Option<&str>) -> (String, Option<String>) {
+    let Some(value) = hostname else {
+        return ("unknown".to_owned(), None);
+    };
+    value.split_once(':').map_or_else(
+        || (value.to_owned(), None),
+        |(host, user)| (host.to_owned(), non_empty(Some(user.to_owned()))),
+    )
+}
+
+/// Treat an absent or empty string column as no value.
+fn non_empty(value: Option<String>) -> Option<String> {
+    value.filter(|s| !s.is_empty())
+}

--- a/packages/source/atuin/src/record.rs
+++ b/packages/source/atuin/src/record.rs
@@ -1,0 +1,96 @@
+//! The typed per-command record and its projection to a search [`Document`].
+
+use source_meta::{Document, keys};
+use serde_json::{Map, Value, json};
+use snafu::ResultExt as _;
+
+use crate::SOURCE_TAG;
+use crate::error::{MetadataSnafu, Result};
+
+/// One recorded shell command from atuin, with its filter tags.
+#[derive(Debug, Clone)]
+pub struct Entry {
+    /// atuin's stable per-command id.
+    pub id: String,
+    /// The command line to embed.
+    pub command: String,
+    /// Working directory the command ran in, when recorded.
+    pub cwd: Option<String>,
+    /// Short hostname the command ran on.
+    pub host: String,
+    /// OS user that ran the command, when derivable.
+    pub user: Option<String>,
+    /// atuin session id grouping commands from one shell session.
+    pub session: Option<String>,
+    /// Process exit status, when recorded.
+    pub exit: Option<i64>,
+    /// Command time as epoch seconds, when recorded.
+    pub timestamp: Option<i64>,
+}
+
+impl Entry {
+    /// Stable store id: `atuin:{id}`, reusing atuin's own unique command id so a
+    /// re-sync only uploads commands not already stored.
+    #[must_use]
+    pub fn external_id(&self) -> String {
+        format!("atuin:{}", self.id)
+    }
+
+    /// Project to a [`Document`]: the command is embedded, its sha256 is the
+    /// `content_hash` (the reconcile key), and the flat metadata carries every
+    /// filter tag.
+    ///
+    /// # Errors
+    /// Returns [`Error::Metadata`](crate::Error::Metadata) if the tag object
+    /// exceeds the store's size or key limits.
+    pub fn into_document(self) -> Result<Document> {
+        let external_id = self.external_id();
+        let content_hash = source_meta::hash_body(self.command.as_bytes());
+        let title = title_for(&self.command);
+
+        let mut meta = Map::new();
+        meta.insert(keys::SOURCE.to_owned(), json!(SOURCE_TAG));
+        meta.insert("external_id".to_owned(), json!(external_id));
+        meta.insert(keys::CONTENT_HASH.to_owned(), json!(content_hash));
+        meta.insert(keys::TITLE.to_owned(), json!(title));
+        meta.insert(keys::HOST.to_owned(), json!(self.host));
+        insert_some(&mut meta, keys::USER, self.user.map(Value::from));
+        insert_some(&mut meta, keys::CWD, self.cwd.map(Value::from));
+        insert_some(&mut meta, keys::SESSION_ID, self.session.map(Value::from));
+        insert_some(&mut meta, keys::EXIT_STATUS, self.exit.map(Value::from));
+        insert_some(&mut meta, keys::TIMESTAMP, self.timestamp.map(Value::from));
+        let meta_json = Value::Object(meta);
+
+        source_meta::check_metadata(&external_id, &meta_json)
+            .context(MetadataSnafu { external_id: external_id.clone() })?;
+
+        Ok(Document {
+            external_id,
+            file_name: format!("{}.txt", self.id),
+            mime: "text/plain",
+            body: self.command.into_bytes(),
+            meta_json,
+            content_hash,
+        })
+    }
+}
+
+/// Insert `key` only when a value is present, keeping absent tags off the record
+/// rather than serializing nulls.
+fn insert_some(meta: &mut Map<String, Value>, key: &str, value: Option<Value>) {
+    if let Some(value) = value {
+        meta.insert(key.to_owned(), value);
+    }
+}
+
+/// Build a short human label from the first non-empty command line (capped).
+fn title_for(command: &str) -> String {
+    let snippet: String = command
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or_default()
+        .chars()
+        .take(80)
+        .collect();
+    format!("shell: {snippet}")
+}

--- a/packages/source/atuin/tests/parse.rs
+++ b/packages/source/atuin/tests/parse.rs
@@ -1,0 +1,69 @@
+//! Build a temporary atuin-shaped sqlite db and check the projected documents.
+
+use rusqlite::{Connection, params};
+use source_atuin::AtuinHistory;
+use source_meta::{Source, SourceAdapter as _};
+
+/// Create an atuin-schema history db at `path` with a few rows: two live
+/// commands, one soft-deleted, and one empty (both of which must be skipped).
+fn make_db(path: &std::path::Path) {
+    let conn = Connection::open(path).expect("open");
+    conn.execute_batch(
+        "create table history (
+            id text primary key, timestamp integer, duration integer, exit integer,
+            command text, cwd text, session text, hostname text, deleted_at integer,
+            author text, intent text
+        );",
+    )
+    .expect("schema");
+    let insert = |id: &str, ts: i64, exit: i64, cmd: &str, deleted: Option<i64>| {
+        conn.execute(
+            "insert into history (id, timestamp, exit, command, cwd, session, hostname, deleted_at) \
+             values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![id, ts, exit, cmd, "/home/x/proj", "sess1", "host1:andrew", deleted],
+        )
+        .expect("insert");
+    };
+    insert("id1", 1_773_725_019_000_000_000, 0, "git status", None);
+    insert("id2", 1_773_725_120_000_000_000, 1, "cargo build", None);
+    insert("id3", 1_773_725_200_000_000_000, 0, "secret", Some(1_773_725_300_000_000_000));
+    insert("id4", 1_773_725_400_000_000_000, 0, "   ", None);
+}
+
+// The repo compiles tests with bare `rustc --test` (not `cargo test`), so the
+// cargo-only `CARGO_TARGET_TMPDIR` is absent; use a runtime temp dir, unique per
+// test so parallel test processes never share a db file.
+fn open_fixture(tag: &str) -> AtuinHistory {
+    let path = std::env::temp_dir().join(format!("source-atuin-test-{tag}.db"));
+    let _ = std::fs::remove_file(&path);
+    make_db(&path);
+    AtuinHistory::open(&path).expect("open atuin db")
+}
+
+#[test]
+fn skips_deleted_and_empty_commands() {
+    let history = open_fixture("skips");
+    // id3 is soft-deleted, id4 is blank: only id1 and id2 remain.
+    assert_eq!(history.len(), 2);
+    assert!(!history.is_empty());
+}
+
+#[test]
+fn documents_carry_shell_source_and_tags() {
+    let history = open_fixture("tags");
+    assert_eq!(history.source(), Source::new("shell"));
+
+    let docs: Vec<_> = history.documents().map(|doc| doc.expect("document")).collect();
+    let first = &docs[0];
+    assert_eq!(first.external_id, "atuin:id1");
+    assert_eq!(first.meta_json["source"], "shell");
+    assert_eq!(first.meta_json["host"], "host1");
+    assert_eq!(first.meta_json["user"], "andrew");
+    assert_eq!(first.meta_json["cwd"], "/home/x/proj");
+    assert_eq!(first.meta_json["session_id"], "sess1");
+    assert_eq!(first.meta_json["exit_status"], 0);
+    // atuin nanoseconds are folded to epoch seconds.
+    assert_eq!(first.meta_json["timestamp"], 1_773_725_019_i64);
+    assert_eq!(first.content_hash, first.meta_json["content_hash"]);
+    assert_eq!(first.body, b"git status");
+}

--- a/packages/source/meta/src/keys.rs
+++ b/packages/source/meta/src/keys.rs
@@ -64,6 +64,11 @@ pub const INPUT_TOKENS: &str = "input_tokens";
 /// Assistant output token count, when recorded.
 pub const OUTPUT_TOKENS: &str = "output_tokens";
 
+// Shell history (atuin, which unifies nushell/zsh/bash). `host`, `user`, `cwd`,
+// `session_id`, and `timestamp` above are reused.
+/// Process exit status of a recorded shell command.
+pub const EXIT_STATUS: &str = "exit_status";
+
 // Linear.
 /// Linear issue identifier, e.g. `ENG-1885`.
 pub const IDENTIFIER: &str = "identifier";


### PR DESCRIPTION
Part of #503 (unified `indexer` + reusable `source-*`/`sink-*` components).

Adds `source-atuin`: a `source_meta::SourceAdapter` for shell history via [atuin](https://atuin.sh).

**Why atuin instead of per-shell adapters:** atuin already captures nushell + zsh + bash commands in one sqlite db (`~/.local/share/atuin/history.db`) with rich metadata, whereas the native plain history files are small, lossy, and (for nushell's sqlite) volatile. So one `source=shell` corpus covers every shell.

- Reads the db **read-only** (never blocks a live shell writing to it).
- One `Document` per command, tagged `source=shell` with `host`/`user`/`cwd`/`session_id`/`exit_status`/`timestamp`.
- `external_id = atuin:{id}` (atuin's own stable id) → re-sync uploads only new commands via the content-hash reconcile.
- atuin nanosecond timestamps folded to epoch seconds; the `hostname` `"host:user"` field split into `host`/`user`.
- Adds the `exit_status` key to `source-meta`.

Validated: `nix build` of `rust-source-atuin-{clippy, parse tests, unusedCrateDependencies, doctest}` on the x86_64-linux builder — all green (2 tests pass, clippy clean, no unused deps).

_Authored with AI (Claude Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Atuin shell history source adapter
> - Adds a new `source-atuin` crate that reads shell command history from the [Atuin](https://atuin.sh) SQLite database and produces search `Document` records tagged with source `"shell"`.
> - Opens the DB read-only (defaulting to `~/.local/share/atuin/history.db`), skips soft-deleted and blank commands, splits the `host:user` field, and converts nanosecond timestamps to seconds.
> - Each document gets a stable `external_id` of `atuin:{id}`, a title derived from the first non-empty line of the command (capped at 80 chars), and a content hash of the full command.
> - Adds the `EXIT_STATUS` metadata key constant to [`packages/source/meta/src/keys.rs`](https://github.com/indexable-inc/index/pull/506/files#diff-2c2b3a88424c9ff11c748ed438367ed943da8868bfa26e61205879eeeca11734) for use by shell-history documents.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ed962f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->