### PR TITLE
feat(indexer): unified multi-source syncer (Mixedbread + S3 parquet)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2802,6 +2802,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
+name = "indexer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "dirs",
+ "mixedbread",
+ "search-core",
+ "sink-parquet",
+ "source-atuin",
+ "source-claude",
+ "source-codex",
+ "source-linear",
+ "source-meta",
+ "source-slack",
+ "tokio",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
   "packages/search-py",
   "packages/source/slack",
   "packages/sink/parquet",
+  "packages/indexer",
   "packages/tap",
   "packages/tap/protocol",
   "packages/tap/pty",

--- a/packages/indexer/Cargo.toml
+++ b/packages/indexer/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "indexer"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Sync every configured corpus source into Mixedbread (semantic) and S3/R2 parquet"
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "indexer"
+path = "src/main.rs"
+
+[dependencies]
+source-meta.workspace = true
+source-claude.workspace = true
+source-codex.workspace = true
+source-atuin.workspace = true
+source-slack.workspace = true
+source-linear.workspace = true
+search-core.workspace = true
+sink-parquet.workspace = true
+mixedbread.workspace = true
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+dirs.workspace = true

--- a/packages/indexer/default.nix
+++ b/packages/indexer/default.nix
@@ -1,0 +1,6 @@
+{ ix, ... }:
+
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "indexer";
+  meta.mainProgram = "indexer";
+}

--- a/packages/indexer/package.nix
+++ b/packages/indexer/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "indexer";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -1,0 +1,171 @@
+//! `indexer`: sync every configured corpus source into Mixedbread (semantic
+//! search) and a self-hosted S3/R2 parquet archive (polars/duckdb-queryable).
+//!
+//! Each source is an adapter implementing [`source_meta::SourceAdapter`]; the
+//! indexer fans every selected source out to both sinks, reusing the
+//! `search-core` Mixedbread reconcile (skip-if-unchanged) and the generic
+//! [`sink_parquet`] sink. Pass `--mixedbread-store` and/or `--bucket` to enable a
+//! sink, and one or more source flags to choose what to ingest.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use clap::Parser;
+use search_core::{MixedbreadStore, sync_documents};
+use source_meta::SourceAdapter;
+
+/// How long to wait for Mixedbread to finish embedding new documents.
+const INDEX_TIMEOUT: Duration = Duration::from_mins(2);
+
+/// Sync corpus sources to Mixedbread and/or an S3/R2 parquet archive.
+#[derive(Debug, Parser)]
+#[command(name = "indexer", about, version)]
+struct Cli {
+    /// Mixedbread store name; enables the Mixedbread (semantic) sink.
+    #[arg(long, env = "MXBAI_STORE")]
+    mixedbread_store: Option<String>,
+
+    /// Mixedbread API base URL.
+    #[arg(long = "base-url", env = "MXBAI_BASE_URL")]
+    base_url: Option<String>,
+
+    /// Bucket for the parquet archive; enables the S3/R2 sink. Credentials come
+    /// from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.
+    #[arg(long, env = "INDEXER_BUCKET")]
+    bucket: Option<String>,
+
+    /// S3 endpoint URL; empty means AWS S3, for R2 pass the account endpoint.
+    #[arg(long, env = "INDEXER_S3_ENDPOINT")]
+    endpoint: Option<String>,
+
+    /// S3 region (`auto` for R2).
+    #[arg(long, env = "INDEXER_S3_REGION", default_value = "auto")]
+    region: String,
+
+    /// Key prefix under the bucket.
+    #[arg(long, env = "INDEXER_PREFIX", default_value = "corpus")]
+    prefix: String,
+
+    /// Index local agent/shell history (claude, codex, atuin) at their default
+    /// paths, in addition to any explicit `--*` overrides below.
+    #[arg(long)]
+    local: bool,
+
+    /// Claude Code transcript directory (default with `--local`: `~/.claude/projects`).
+    #[arg(long)]
+    claude_dir: Option<PathBuf>,
+
+    /// Codex history file (default with `--local`: `~/.codex/history.jsonl`).
+    #[arg(long)]
+    codex_file: Option<PathBuf>,
+
+    /// atuin history db (default with `--local`: `~/.local/share/atuin/history.db`).
+    #[arg(long)]
+    atuin_db: Option<PathBuf>,
+
+    /// Slack export directory.
+    #[arg(long)]
+    slack_export: Option<PathBuf>,
+
+    /// Linear export directory.
+    #[arg(long)]
+    linear_export: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    let store = match &cli.mixedbread_store {
+        Some(_) => {
+            let base_url =
+                cli.base_url.clone().unwrap_or_else(|| mixedbread::DEFAULT_BASE_URL.to_owned());
+            Some(MixedbreadStore::from_login(base_url).await.context("connecting to Mixedbread")?)
+        }
+        None => None,
+    };
+    let parquet = cli.bucket.as_ref().map(|bucket| sink_parquet::Config {
+        bucket: bucket.clone(),
+        endpoint: cli.endpoint.clone(),
+        region: cli.region.clone(),
+        prefix: cli.prefix.clone(),
+    });
+    if store.is_none() && parquet.is_none() {
+        anyhow::bail!("nothing to do: pass --mixedbread-store and/or --bucket");
+    }
+    let mixedbread = store.as_ref().zip(cli.mixedbread_store.as_deref());
+
+    let home = dirs::home_dir();
+    let default = |suffix: &str| home.as_ref().map(|h| h.join(suffix));
+    let claude = cli.claude_dir.clone().or_else(|| cli.local.then(|| default(".claude/projects")).flatten());
+    let codex = cli.codex_file.clone().or_else(|| cli.local.then(|| default(".codex/history.jsonl")).flatten());
+    let atuin = cli.atuin_db.clone().or_else(|| cli.local.then(|| default(".local/share/atuin/history.db")).flatten());
+
+    let mut indexed = 0_usize;
+    if let Some(dir) = claude {
+        let adapter = source_claude::ClaudeHistoryExport::open(&dir)
+            .with_context(|| format!("parsing Claude transcripts at {}", dir.display()))?;
+        run_source("claude", &adapter, mixedbread, parquet.as_ref()).await?;
+        indexed += 1;
+    }
+    if let Some(file) = codex {
+        let adapter = source_codex::CodexHistory::open(&file)
+            .with_context(|| format!("parsing Codex history at {}", file.display()))?;
+        run_source("codex", &adapter, mixedbread, parquet.as_ref()).await?;
+        indexed += 1;
+    }
+    if let Some(db) = atuin {
+        let adapter = source_atuin::AtuinHistory::open(&db)
+            .with_context(|| format!("reading atuin history at {}", db.display()))?;
+        run_source("shell", &adapter, mixedbread, parquet.as_ref()).await?;
+        indexed += 1;
+    }
+    if let Some(dir) = &cli.slack_export {
+        let adapter = source_slack::SlackExport::open(dir)
+            .with_context(|| format!("reading Slack export at {}", dir.display()))?;
+        run_source("slack", &adapter, mixedbread, parquet.as_ref()).await?;
+        indexed += 1;
+    }
+    if let Some(dir) = &cli.linear_export {
+        let adapter = source_linear::LinearExport::open(dir)
+            .with_context(|| format!("reading Linear export at {}", dir.display()))?;
+        run_source("linear", &adapter, mixedbread, parquet.as_ref()).await?;
+        indexed += 1;
+    }
+
+    if indexed == 0 {
+        anyhow::bail!(
+            "no sources selected: pass --local and/or --claude-dir/--codex-file/--atuin-db/--slack-export/--linear-export"
+        );
+    }
+    Ok(())
+}
+
+/// Fan one source out to every enabled sink.
+async fn run_source<A: SourceAdapter + Sync>(
+    label: &str,
+    adapter: &A,
+    mixedbread: Option<(&MixedbreadStore, &str)>,
+    parquet: Option<&sink_parquet::Config>,
+) -> anyhow::Result<()> {
+    if let Some((store, store_name)) = mixedbread {
+        let report = sync_documents(adapter, store, store_name, INDEX_TIMEOUT, |_, _| {})
+            .await
+            .with_context(|| format!("[{label}] Mixedbread sync"))?;
+        eprintln!(
+            "[{label}] mixedbread: uploaded {}, skipped {} of {}",
+            report.uploaded, report.skipped, report.total
+        );
+    }
+    if let Some(config) = parquet {
+        let report =
+            sink_parquet::sync(adapter, config).await.with_context(|| format!("[{label}] parquet sync"))?;
+        if report.skipped {
+            eprintln!("[{label}] parquet: skipped (unchanged)");
+        } else {
+            eprintln!("[{label}] parquet: wrote {} rows", report.rows);
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
Part of #503. The centerpiece: one binary that syncs every corpus source to **both** sinks — Mixedbread (semantic) and self-hosted **S3/R2 parquet** (polars/duckdb-queryable).

Each source is a `source_meta::SourceAdapter`; the `indexer` fans every selected source out to both sinks, reusing `search-core`'s `sync_documents` reconcile (skip-if-unchanged) and the generic `sink-parquet`.

**Sources** (pick with flags):
- `--local` → claude + codex + atuin history at default paths
- `--claude-dir` / `--codex-file` / `--atuin-db` → override those paths
- `--slack-export` / `--linear-export` → ingest those exports

**Sinks** (enable one or both): `--mixedbread-store` (+ `--base-url`) and/or `--bucket` (+ `--endpoint` / `--region` / `--prefix`). At least one sink and one source are required.

Additive: `claude-history-sync` and `search-core` are untouched. Follow-ups extract `sink-mixedbread`, strip `search` to query-only, and retire `claude-history-sync` + ix `history-ship`. A portable home-manager module to schedule it comes with the retirement of claude-history-sync's module.

Validated: `nix build .#indexer` (binary compiles + links the full adapter graph) and `nix build` of `rust-indexer-{clippy, unusedCrateDependencies}` on the x86_64-linux builder — all green.

_Authored with AI (Claude Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `indexer` binary to sync documents from multiple sources to Mixedbread and S3 parquet
> - Introduces a new `indexer` Rust crate at [packages/indexer](https://github.com/indexable-inc/index/pull/508/files#diff-0b8a6ee204c0cb265235601a189deea2352ebc148215ab642eba690bffd12ea1) with a CLI that selects sources (Claude, Codex, atuin, Slack, Linear) and sinks (Mixedbread vector store, S3 parquet).
> - The CLI accepts per-source path flags and a `--local` shorthand that fills in default paths; env vars supply credentials and endpoint defaults.
> - For each enabled source, `run_source` fans out to configured sinks, reporting upload/skip counts for Mixedbread and rows written for parquet; the binary exits with an error if no sinks or no sources are selected.
> - Mixedbread sync runs with a 2-minute timeout via `INDEX_TIMEOUT`.
> - Adds the crate to the Cargo workspace and exposes it as an installable Nix package.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c43dce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->