### PR TITLE
feat(source-git): git commit-history adapter, wired into indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2814,6 +2814,7 @@ dependencies = [
  "source-atuin",
  "source-claude",
  "source-codex",
+ "source-git",
  "source-linear",
  "source-meta",
  "source-slack",
@@ -3219,6 +3220,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "source-git"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "snafu 0.9.1",
+ "source-meta",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "packages/source/atuin",
   "packages/source/claude",
   "packages/source/codex",
+  "packages/source/git",
   "packages/claude-history-sync",
   "packages/clone-detect/cli",
   "packages/clone-detect/detect",
@@ -96,6 +97,7 @@ clap = "4"
 source-atuin = { path = "packages/source/atuin" }
 source-claude = { path = "packages/source/claude" }
 source-codex = { path = "packages/source/codex" }
+source-git = { path = "packages/source/git" }
 clone-detect = { path = "packages/clone-detect/detect" }
 clone-hash = { path = "packages/clone-detect/hash" }
 clone-pragma = { path = "packages/clone-detect/pragma" }

--- a/packages/indexer/Cargo.toml
+++ b/packages/indexer/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 source-meta.workspace = true
 source-claude.workspace = true
 source-codex.workspace = true
+source-git.workspace = true
 source-atuin.workspace = true
 source-slack.workspace = true
 source-linear.workspace = true

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -71,6 +71,10 @@ struct Cli {
     /// Linear export directory.
     #[arg(long)]
     linear_export: Option<PathBuf>,
+
+    /// Git repository to index commit history from (repeatable).
+    #[arg(long = "git-repo")]
+    git_repos: Vec<PathBuf>,
 }
 
 #[tokio::main]
@@ -133,10 +137,16 @@ async fn main() -> anyhow::Result<()> {
         run_source("linear", &adapter, mixedbread, parquet.as_ref()).await?;
         indexed += 1;
     }
+    for repo in &cli.git_repos {
+        let adapter = source_git::GitLog::open(repo)
+            .with_context(|| format!("reading git history at {}", repo.display()))?;
+        run_source("git", &adapter, mixedbread, parquet.as_ref()).await?;
+        indexed += 1;
+    }
 
     if indexed == 0 {
         anyhow::bail!(
-            "no sources selected: pass --local and/or --claude-dir/--codex-file/--atuin-db/--slack-export/--linear-export"
+            "no sources selected: pass --local and/or --claude-dir/--codex-file/--atuin-db/--slack-export/--linear-export/--git-repo"
         );
     }
     Ok(())

--- a/packages/source/git/Cargo.toml
+++ b/packages/source/git/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "source-git"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Adapter turning a git repository's commit history into embeddable, tagged search documents"
+
+[lints]
+workspace = true
+
+[dependencies]
+source-meta.workspace = true
+serde_json.workspace = true
+snafu.workspace = true

--- a/packages/source/git/package.nix
+++ b/packages/source/git/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "source-git";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/source/git/src/error.rs
+++ b/packages/source/git/src/error.rs
@@ -1,0 +1,48 @@
+//! Error type for the git commit-history adapter.
+
+use std::path::PathBuf;
+
+use snafu::Snafu;
+
+/// All failures surfaced when reading and projecting git history.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// The `git` command could not be spawned.
+    #[snafu(display("failed to run git in {}", repo.display()))]
+    Spawn {
+        /// Repository the command targeted.
+        repo: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// The `git log` invocation exited non-zero.
+    #[snafu(display("git log failed in {}: {stderr}", repo.display()))]
+    GitFailed {
+        /// Repository the command targeted.
+        repo: PathBuf,
+        /// Captured standard error.
+        stderr: String,
+    },
+
+    /// A `git log` record did not have the expected field layout.
+    #[snafu(display("malformed git log record: {detail}"))]
+    Parse {
+        /// What was wrong with the record.
+        detail: String,
+    },
+
+    /// A built document's metadata exceeded the store's size or key limits.
+    #[snafu(display("metadata limit exceeded for {external_id}"))]
+    Metadata {
+        /// The record whose metadata overflowed.
+        external_id: String,
+        /// Underlying limit error.
+        source: source_meta::MetadataError,
+    },
+}
+
+/// Result alias defaulting to this crate's [`Error`].
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/packages/source/git/src/lib.rs
+++ b/packages/source/git/src/lib.rs
@@ -1,0 +1,203 @@
+//! Adapter turning a git repository's commit history into embeddable, tagged
+//! [`source_meta`] documents for the multi-source `search` store.
+//!
+//! # Grain
+//! One [`Document`] per **commit**, embedding the commit message (subject +
+//! body). The diff is intentionally not embedded: across full history it is
+//! huge and costly, and it already lives in git, reachable via the `commit` tag.
+//! `external_id = "git:{repo}:{sha}"`, so re-ingesting a repo only uploads its
+//! new commits via the content-hash reconcile.
+//!
+//! # Tags
+//! Every document carries the common header (`source`, `external_id`,
+//! `content_hash`, `title`, `timestamp`) plus `repo`, `commit`, `author_name`,
+//! and `author_email`, so a query can scope to a repo, author, or time.
+
+#![forbid(unsafe_code)]
+
+mod error;
+mod record;
+
+use std::path::Path;
+use std::process::Command;
+
+use source_meta::{Document, Source, SourceAdapter};
+
+pub use crate::error::Error;
+pub use crate::record::Commit;
+use crate::error::{GitFailedSnafu, ParseSnafu, Result, SpawnSnafu};
+use snafu::ResultExt as _;
+
+/// The `source` tag every commit document carries.
+pub const SOURCE_TAG: &str = "git";
+
+/// `git log` pretty format: fields separated by US (`0x1f`), commits by NUL
+/// (via `-z`). Order: full SHA, author name, author email, author epoch
+/// seconds, subject, body.
+const FORMAT: &str = "%H%x1f%an%x1f%ae%x1f%at%x1f%s%x1f%b";
+
+/// A repository's parsed commit history ready to project into documents.
+///
+/// Construct with [`GitLog::open`], which shells out to `git log` once. Parsing
+/// happens up front so [`SourceAdapter::documents`] is cheap to start.
+#[derive(Debug)]
+#[must_use]
+pub struct GitLog {
+    commits: Vec<Commit>,
+}
+
+impl GitLog {
+    /// Read every commit reachable from the repository's current `HEAD`.
+    ///
+    /// # Errors
+    /// Returns an error if `git` cannot be spawned, `git log` exits non-zero, or
+    /// its output cannot be parsed.
+    pub fn open(repo: &Path) -> Result<Self> {
+        let repo_slug = slug(repo);
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["log", "--no-color", "-z", &format!("--format={FORMAT}")])
+            .output()
+            .context(SpawnSnafu { repo: repo.to_path_buf() })?;
+        if !output.status.success() {
+            return GitFailedSnafu {
+                repo: repo.to_path_buf(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            }
+            .fail();
+        }
+        let commits = parse_log(&output.stdout, &repo_slug)?;
+        Ok(Self { commits })
+    }
+
+    /// Number of parsed commits.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.commits.len()
+    }
+
+    /// Whether no commits were parsed.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.commits.is_empty()
+    }
+}
+
+impl SourceAdapter for GitLog {
+    type Error = Error;
+
+    fn source(&self) -> Source {
+        Source::new(SOURCE_TAG)
+    }
+
+    fn documents(&self) -> impl Iterator<Item = Result<Document, Error>> + Send {
+        self.commits.clone().into_iter().map(Commit::into_document)
+    }
+}
+
+/// Parse `git log -z --format=<FORMAT>` output into commits. Records are
+/// NUL-separated; fields within a record are US-separated.
+fn parse_log(bytes: &[u8], repo: &str) -> Result<Vec<Commit>> {
+    let text = String::from_utf8_lossy(bytes);
+    let mut commits = Vec::new();
+    for raw in text.split('\0') {
+        // The body of the previous commit can end in newlines before the NUL;
+        // strip any leading newline so the SHA field starts clean.
+        let record = raw.trim_start_matches('\n');
+        if record.is_empty() {
+            continue;
+        }
+        let mut fields = record.splitn(6, '\u{1f}');
+        let sha = field(&mut fields, "sha")?;
+        let author_name = field(&mut fields, "author_name")?;
+        let author_email = field(&mut fields, "author_email")?;
+        let at = field(&mut fields, "timestamp")?;
+        let subject = field(&mut fields, "subject")?;
+        let body = fields.next().unwrap_or("");
+        let timestamp = at
+            .trim()
+            .parse::<i64>()
+            .map_err(|_err| ParseSnafu { detail: format!("bad timestamp {at:?}") }.build())?;
+        commits.push(Commit {
+            repo: repo.to_owned(),
+            sha: sha.trim().to_owned(),
+            author_name: author_name.to_owned(),
+            author_email: author_email.to_owned(),
+            timestamp,
+            subject: subject.to_owned(),
+            body: body.trim_end().to_owned(),
+        });
+    }
+    Ok(commits)
+}
+
+/// Take the next US-separated field, or fail with a layout error.
+fn field<'a>(fields: &mut impl Iterator<Item = &'a str>, name: &str) -> Result<&'a str> {
+    fields.next().ok_or_else(|| ParseSnafu { detail: format!("missing field {name}") }.build())
+}
+
+/// Derive a repo slug from the `origin` remote (`org/repo`), falling back to the
+/// directory name when there is no remote.
+fn slug(repo: &Path) -> String {
+    let from_remote = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| slug_from_url(String::from_utf8_lossy(&output.stdout).trim()));
+    from_remote.unwrap_or_else(|| {
+        repo.file_name().map_or_else(|| "local".to_owned(), |name| name.to_string_lossy().into_owned())
+    })
+}
+
+/// Reduce a remote URL to `org/repo`, handling both `git@host:org/repo.git` and
+/// `https://host/org/repo.git` forms.
+fn slug_from_url(url: &str) -> Option<String> {
+    let trimmed = url.trim_end_matches('/').trim_end_matches(".git");
+    let parts: Vec<&str> = trimmed.split(['/', ':']).filter(|part| !part.is_empty()).collect();
+    let len = parts.len();
+    (len >= 2).then(|| format!("{}/{}", parts[len - 2], parts[len - 1]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_log, slug_from_url};
+
+    #[test]
+    fn parses_nul_separated_records() {
+        let bytes = b"abc123def\x1fAlice\x1falice@x.com\x1f1700000000\x1fFix bug\x1fLonger\nbody\x00\
+                      fff999000\x1fBob\x1fbob@y.com\x1f1700000100\x1fAdd feature\x1f\x00";
+        let commits = parse_log(bytes, "org/repo").expect("parse");
+        assert_eq!(commits.len(), 2);
+        assert_eq!(commits[0].sha, "abc123def");
+        assert_eq!(commits[0].author_name, "Alice");
+        assert_eq!(commits[0].timestamp, 1_700_000_000);
+        assert_eq!(commits[0].subject, "Fix bug");
+        assert_eq!(commits[0].body, "Longer\nbody");
+        assert_eq!(commits[1].body, "");
+    }
+
+    #[test]
+    fn projects_document_with_git_tags() {
+        let bytes = b"abc123def456\x1fAlice\x1falice@x.com\x1f1700000000\x1fFix bug\x1f\x00";
+        let doc = parse_log(bytes, "org/repo").expect("parse")[0].clone().into_document().expect("doc");
+        assert_eq!(doc.external_id, "git:org/repo:abc123def456");
+        assert_eq!(doc.meta_json["source"], "git");
+        assert_eq!(doc.meta_json["repo"], "org/repo");
+        assert_eq!(doc.meta_json["commit"], "abc123def456");
+        assert_eq!(doc.meta_json["author_email"], "alice@x.com");
+        assert_eq!(doc.meta_json["timestamp"], 1_700_000_000_i64);
+        // Empty body → the embedded message is just the subject.
+        assert_eq!(doc.body, b"Fix bug");
+    }
+
+    #[test]
+    fn slug_from_both_url_forms() {
+        assert_eq!(slug_from_url("git@github.com:org/repo.git").as_deref(), Some("org/repo"));
+        assert_eq!(slug_from_url("https://github.com/org/repo.git").as_deref(), Some("org/repo"));
+        assert_eq!(slug_from_url("https://github.com/org/repo/").as_deref(), Some("org/repo"));
+    }
+}

--- a/packages/source/git/src/record.rs
+++ b/packages/source/git/src/record.rs
@@ -1,0 +1,80 @@
+//! The typed per-commit record and its projection to a search [`Document`].
+
+use source_meta::{Document, keys};
+use serde_json::{Map, Value, json};
+use snafu::ResultExt as _;
+
+use crate::SOURCE_TAG;
+use crate::error::{MetadataSnafu, Result};
+
+/// One git commit: the message to embed plus its filter tags.
+#[derive(Debug, Clone)]
+pub struct Commit {
+    /// Repository slug (git remote, or directory name when there is no remote).
+    pub repo: String,
+    /// Full commit SHA.
+    pub sha: String,
+    /// Commit author name.
+    pub author_name: String,
+    /// Commit author email.
+    pub author_email: String,
+    /// Author time as epoch seconds.
+    pub timestamp: i64,
+    /// First line of the commit message.
+    pub subject: String,
+    /// Remaining commit message body (may be empty).
+    pub body: String,
+}
+
+impl Commit {
+    /// Stable store id: `git:{repo}:{sha}`. Per commit, so re-ingesting a repo
+    /// only ever uploads its new commits.
+    #[must_use]
+    pub fn external_id(&self) -> String {
+        format!("git:{}:{}", self.repo, self.sha)
+    }
+
+    /// Project to a [`Document`]: the commit message (subject + body) is
+    /// embedded, its sha256 is the `content_hash`, and the flat metadata carries
+    /// every filter tag. The diff is intentionally not embedded (too large and
+    /// costly across full history); it lives in git, keyed by the `commit` tag.
+    ///
+    /// # Errors
+    /// Returns [`Error::Metadata`](crate::Error::Metadata) if the tag object
+    /// exceeds the store's size or key limits.
+    pub fn into_document(self) -> Result<Document> {
+        let external_id = self.external_id();
+        let message = if self.body.trim().is_empty() {
+            self.subject.clone()
+        } else {
+            format!("{}\n\n{}", self.subject, self.body)
+        };
+        let content_hash = source_meta::hash_body(message.as_bytes());
+        let short = self.sha.get(..12).unwrap_or(&self.sha);
+        let title = format!("{}@{}: {}", self.repo, short, self.subject);
+
+        let mut meta = Map::new();
+        meta.insert(keys::SOURCE.to_owned(), json!(SOURCE_TAG));
+        meta.insert("external_id".to_owned(), json!(external_id));
+        meta.insert(keys::CONTENT_HASH.to_owned(), json!(content_hash));
+        meta.insert(keys::TITLE.to_owned(), json!(title));
+        meta.insert(keys::REPO.to_owned(), json!(self.repo));
+        meta.insert(keys::COMMIT.to_owned(), json!(self.sha));
+        meta.insert(keys::AUTHOR_NAME.to_owned(), json!(self.author_name));
+        meta.insert(keys::AUTHOR_EMAIL.to_owned(), json!(self.author_email));
+        meta.insert(keys::TIMESTAMP.to_owned(), json!(self.timestamp));
+        let meta_json = Value::Object(meta);
+
+        source_meta::check_metadata(&external_id, &meta_json)
+            .context(MetadataSnafu { external_id: external_id.clone() })?;
+
+        Ok(Document {
+            external_id,
+            file_name: format!("{}.txt", self.sha),
+            mime: "text/plain",
+            body: message.into_bytes(),
+            meta_json,
+            content_hash,
+        })
+    }
+}

--- a/packages/source/meta/src/keys.rs
+++ b/packages/source/meta/src/keys.rs
@@ -18,6 +18,14 @@ pub const REPO: &str = "repo";
 /// Repo-relative path of a code file.
 pub const PATH: &str = "path";
 
+// Git commits. `repo` and `timestamp` above are reused.
+/// Full commit SHA.
+pub const COMMIT: &str = "commit";
+/// Commit author name.
+pub const AUTHOR_NAME: &str = "author_name";
+/// Commit author email.
+pub const AUTHOR_EMAIL: &str = "author_email";
+
 // Common.
 /// Epoch-second timestamp, the primary recency axis.
 pub const TIMESTAMP: &str = "timestamp";


### PR DESCRIPTION
Part of #503. Adds the git source and wires it into the `indexer`.

`source-git`: a `source_meta::SourceAdapter` over a repo's commit history.

- **One Document per commit**, embedding the commit message (subject + body). The **diff is not embedded** — across full history it's huge and costly, and it already lives in git, reachable via the `commit` tag. (This is the cost decision flagged earlier; gate large repos like a kernel fork by simply not pointing `--git-repo` at them.)
- `external_id = git:{repo}:{sha}`, tagged `source=git` with `repo`/`commit`/`author_name`/`author_email`/`timestamp`.
- Shells out to `git log -z --format=...` once; the NUL/US record parsing is a **pure, unit-tested function** (no git invocation in tests). Repo slug derives from the `origin` remote, falling back to the directory name.
- Wired into `indexer` via repeatable `--git-repo <dir>`.
- Adds `commit`/`author_name`/`author_email` keys to `source-meta`.

`git-log-pretty` wasn't reused: it's a display *binary*, not a parsing library, so shelling out to `git` directly is the smaller, self-contained surface.

Validated: `nix build .#indexer` + `rust-source-git-{clippy, unit tests, unusedCrateDependencies, doctest}` + `rust-indexer-clippy` on the x86_64-linux builder — all green (3 tests pass).

_Authored with AI (Claude Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add git commit-history source adapter wired into the indexer
> - Introduces a new `source-git` crate that shells out to `git log` to read commit history, parsing NUL-separated records into structured `Commit` values.
> - Implements `SourceAdapter` for `GitLog`, yielding each commit as a `Document` with metadata keys for repo, SHA, author name/email, and timestamp.
> - Adds a `--git-repo <path>` CLI flag (repeatable) to the indexer so users can select one or more local repositories as input sources.
> - Derives a stable repo slug from `git remote get-url origin`, falling back to the directory name when the remote is unavailable.
> - Adds `COMMIT`, `AUTHOR_NAME`, and `AUTHOR_EMAIL` metadata key constants to [`source-meta`](https://github.com/indexable-inc/index/pull/509/files#diff-2c2b3a88424c9ff11c748ed438367ed943da8868bfa26e61205879eeeca11734).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 797bcf1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->