### PR TITLE
fix(indexer,source-codex): content-stable codex ids; non-fatal per-source indexing

### DIFF
--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -106,50 +106,90 @@ async fn main() -> anyhow::Result<()> {
     let codex = cli.codex_file.clone().or_else(|| cli.local.then(|| default(".codex/history.jsonl")).flatten());
     let atuin = cli.atuin_db.clone().or_else(|| cli.local.then(|| default(".local/share/atuin/history.db")).flatten());
 
+    // Each source runs independently: a failure (an unborn git repo, a missing
+    // export) is logged and counted but never aborts the run, so one broken
+    // source cannot starve every other corpus. The process still exits non-zero
+    // at the end if any source failed.
     let mut indexed = 0_usize;
+    let mut failures = 0_usize;
     if let Some(dir) = claude {
-        let adapter = source_claude::ClaudeHistoryExport::open(&dir)
-            .with_context(|| format!("parsing Claude transcripts at {}", dir.display()))?;
-        run_source("claude", &adapter, mixedbread, parquet.as_ref()).await?;
-        indexed += 1;
+        let result = async {
+            let adapter = source_claude::ClaudeHistoryExport::open(&dir)
+                .with_context(|| format!("parsing Claude transcripts at {}", dir.display()))?;
+            run_source("claude", &adapter, mixedbread, parquet.as_ref()).await
+        }
+        .await;
+        record("claude", result, &mut indexed, &mut failures);
     }
     if let Some(file) = codex {
-        let adapter = source_codex::CodexHistory::open(&file)
-            .with_context(|| format!("parsing Codex history at {}", file.display()))?;
-        run_source("codex", &adapter, mixedbread, parquet.as_ref()).await?;
-        indexed += 1;
+        let result = async {
+            let adapter = source_codex::CodexHistory::open(&file)
+                .with_context(|| format!("parsing Codex history at {}", file.display()))?;
+            run_source("codex", &adapter, mixedbread, parquet.as_ref()).await
+        }
+        .await;
+        record("codex", result, &mut indexed, &mut failures);
     }
     if let Some(db) = atuin {
-        let adapter = source_atuin::AtuinHistory::open(&db)
-            .with_context(|| format!("reading atuin history at {}", db.display()))?;
-        run_source("shell", &adapter, mixedbread, parquet.as_ref()).await?;
-        indexed += 1;
+        let result = async {
+            let adapter = source_atuin::AtuinHistory::open(&db)
+                .with_context(|| format!("reading atuin history at {}", db.display()))?;
+            run_source("shell", &adapter, mixedbread, parquet.as_ref()).await
+        }
+        .await;
+        record("shell", result, &mut indexed, &mut failures);
     }
     if let Some(dir) = &cli.slack_export {
-        let adapter = source_slack::SlackExport::open(dir)
-            .with_context(|| format!("reading Slack export at {}", dir.display()))?;
-        run_source("slack", &adapter, mixedbread, parquet.as_ref()).await?;
-        indexed += 1;
+        let result = async {
+            let adapter = source_slack::SlackExport::open(dir)
+                .with_context(|| format!("reading Slack export at {}", dir.display()))?;
+            run_source("slack", &adapter, mixedbread, parquet.as_ref()).await
+        }
+        .await;
+        record("slack", result, &mut indexed, &mut failures);
     }
     if let Some(dir) = &cli.linear_export {
-        let adapter = source_linear::LinearExport::open(dir)
-            .with_context(|| format!("reading Linear export at {}", dir.display()))?;
-        run_source("linear", &adapter, mixedbread, parquet.as_ref()).await?;
-        indexed += 1;
+        let result = async {
+            let adapter = source_linear::LinearExport::open(dir)
+                .with_context(|| format!("reading Linear export at {}", dir.display()))?;
+            run_source("linear", &adapter, mixedbread, parquet.as_ref()).await
+        }
+        .await;
+        record("linear", result, &mut indexed, &mut failures);
     }
     for repo in &cli.git_repos {
-        let adapter = source_git::GitLog::open(repo)
-            .with_context(|| format!("reading git history at {}", repo.display()))?;
-        run_source("git", &adapter, mixedbread, parquet.as_ref()).await?;
-        indexed += 1;
+        let label = format!("git:{}", repo.display());
+        let result = async {
+            let adapter = source_git::GitLog::open(repo)
+                .with_context(|| format!("reading git history at {}", repo.display()))?;
+            run_source("git", &adapter, mixedbread, parquet.as_ref()).await
+        }
+        .await;
+        record(&label, result, &mut indexed, &mut failures);
     }
 
-    if indexed == 0 {
+    let configured = indexed + failures;
+    if configured == 0 {
         anyhow::bail!(
             "no sources selected: pass --local and/or --claude-dir/--codex-file/--atuin-db/--slack-export/--linear-export/--git-repo"
         );
     }
+    if failures > 0 {
+        anyhow::bail!("{failures} of {configured} source(s) failed; {indexed} succeeded");
+    }
     Ok(())
+}
+
+/// Record one source's outcome. A failure is logged and counted but does not
+/// abort the run, so one broken source cannot starve the others.
+fn record(label: &str, result: anyhow::Result<()>, indexed: &mut usize, failures: &mut usize) {
+    match result {
+        Ok(()) => *indexed += 1,
+        Err(error) => {
+            eprintln!("[{label}] failed: {error:#}");
+            *failures += 1;
+        }
+    }
 }
 
 /// Fan one source out to every enabled sink.

--- a/packages/search/src/main.rs
+++ b/packages/search/src/main.rs
@@ -171,8 +171,8 @@ fn split_csv(values: &[String]) -> Vec<String> {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Args)]
 struct SemanticArgs {
-    /// The query to search for. Required for a bare search; omitted when a
-    /// subcommand (grep/ingest/gc) is used.
+    /// The query to search for. Required for a bare search; omitted when the
+    /// `grep` subcommand is used.
     pattern: Option<String>,
 
     /// Directory to search in (defaults to the current directory).

--- a/packages/source/codex/src/lib.rs
+++ b/packages/source/codex/src/lib.rs
@@ -21,7 +21,6 @@
 mod error;
 mod record;
 
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use source_meta::{Document, Source, SourceAdapter};
@@ -65,7 +64,6 @@ impl CodexHistory {
     /// Returns an error if the file cannot be read, or a line is not valid JSON.
     pub fn open_with(path: &Path, host: &str, user: &str) -> Result<Self> {
         let contents = std::fs::read_to_string(path).context(ReadFileSnafu { path: path.to_path_buf() })?;
-        let mut seq_by_session: HashMap<String, usize> = HashMap::new();
         let mut entries = Vec::new();
         for (index, line) in contents.lines().enumerate() {
             if line.trim().is_empty() {
@@ -75,16 +73,13 @@ impl CodexHistory {
                 path: path.to_path_buf(),
                 line: index + 1,
             })?;
-            let seq = seq_by_session.entry(raw.session_id.clone()).or_insert(0);
             entries.push(Entry {
                 host: host.to_owned(),
                 user: user.to_owned(),
                 session_id: raw.session_id,
-                seq: *seq,
                 timestamp: raw.ts,
                 text: raw.text,
             });
-            *seq += 1;
         }
         Ok(Self { entries })
     }

--- a/packages/source/codex/src/record.rs
+++ b/packages/source/codex/src/record.rs
@@ -19,10 +19,6 @@ pub struct Entry {
     pub user: String,
     /// Codex session id grouping prompts from one run.
     pub session_id: String,
-    /// 0-based ordinal of this prompt within its session, in file order. Makes
-    /// the `external_id` stable across re-runs of an append-only log even when
-    /// two prompts share a timestamp.
-    pub seq: usize,
     /// Submission time as epoch seconds, when the line carried one.
     pub timestamp: Option<i64>,
     /// The submitted prompt text to embed.
@@ -30,11 +26,17 @@ pub struct Entry {
 }
 
 impl Entry {
-    /// Stable store id: `codex:{session_id}:{seq}`. Per prompt, so an
-    /// append-only history only ever uploads its new prompts.
+    /// Stable store id: `codex:{session_id}:{ts}:{content_hash}`.
+    ///
+    /// Deliberately NOT a file-position ordinal: Codex compacts its history log
+    /// (dropping the oldest lines), which would shift any positional index and
+    /// make surviving prompts look new — re-uploading them and orphaning the old
+    /// ids. Keying on the session, timestamp, and content hash is invariant to
+    /// compaction, so a prompt keeps one id for its lifetime.
     #[must_use]
-    pub fn external_id(&self) -> String {
-        format!("codex:{}:{}", self.session_id, self.seq)
+    pub fn external_id(&self, content_hash: &str) -> String {
+        let ts = self.timestamp.map_or_else(|| "na".to_owned(), |ts| ts.to_string());
+        format!("codex:{}:{}:{}", self.session_id, ts, content_hash)
     }
 
     /// Project to a [`Document`]: the prompt text is embedded, its sha256 is the
@@ -45,8 +47,8 @@ impl Entry {
     /// Returns [`Error::Metadata`](crate::Error::Metadata) if the tag object
     /// exceeds the store's size or key limits.
     pub fn into_document(self) -> Result<Document> {
-        let external_id = self.external_id();
         let content_hash = source_meta::hash_body(self.text.as_bytes());
+        let external_id = self.external_id(&content_hash);
         let title = title_for(&self.text);
 
         let mut meta = Map::new();
@@ -65,9 +67,10 @@ impl Entry {
         source_meta::check_metadata(&external_id, &meta_json)
             .context(MetadataSnafu { external_id: external_id.clone() })?;
 
+        let file_name = format!("{external_id}.txt");
         Ok(Document {
             external_id,
-            file_name: format!("{}-{}.txt", self.session_id, self.seq),
+            file_name,
             mime: "text/plain",
             body: self.text.into_bytes(),
             meta_json,

--- a/packages/source/codex/tests/parse.rs
+++ b/packages/source/codex/tests/parse.rs
@@ -16,21 +16,22 @@ fn parses_every_prompt_skipping_blank_lines() {
 }
 
 #[test]
-fn external_ids_are_per_session_sequential() {
+fn external_ids_are_content_stable_not_positional() {
     let history = CodexHistory::open_with(&fixture(), "host1", "user1").expect("parse");
     let ids: Vec<String> = history
         .documents()
         .map(|doc| doc.expect("document").external_id)
         .collect();
-    assert_eq!(
-        ids,
-        vec![
-            "codex:019cfa3f-a908-71b0-98f0-7ecb3874a8db:0",
-            "codex:019cfa3f-a908-71b0-98f0-7ecb3874a8db:1",
-            "codex:019d0102-1111-2222-3333-444455556666:0",
-            "codex:019d0102-1111-2222-3333-444455556666:1",
-        ]
-    );
+    assert_eq!(ids.len(), 4);
+    // All distinct, and keyed on session + timestamp + content hash so Codex
+    // history compaction (which shifts file positions) never re-keys a prompt.
+    let unique: std::collections::HashSet<&String> = ids.iter().collect();
+    assert_eq!(unique.len(), 4);
+    assert!(ids[0].starts_with("codex:019cfa3f-a908-71b0-98f0-7ecb3874a8db:1773725019:sha256:"));
+    assert!(ids[1].starts_with("codex:019cfa3f-a908-71b0-98f0-7ecb3874a8db:1773725086:sha256:"));
+    assert!(ids[2].starts_with("codex:019d0102-1111-2222-3333-444455556666:1773726000:sha256:"));
+    // The last prompt carried no timestamp, so the ts segment is `na`.
+    assert!(ids[3].starts_with("codex:019d0102-1111-2222-3333-444455556666:na:sha256:"));
 }
 
 #[test]


### PR DESCRIPTION
Fixes the two correctness blockers from the adversarial review of the indexer/search split (#504–#511).

**C1 — `source-codex` external_id was positional.** It was `codex:{session}:{seq}` (file-position ordinal). Codex compacts its history log by dropping the oldest lines, which shifts every surviving prompt's ordinal — so the content-hash reconcile sees them as new (re-upload + re-embed) and orphans the old ids. Now keyed on `codex:{session}:{ts}:{content_hash}`, invariant to compaction. Removed the per-session `seq` counter (and an unused `HashMap` import).

**C2 — one bad git repo aborted the whole indexer run.** An unborn/empty repo makes `git log` exit 128; under `?` that killed the entire daily sync, starving claude/codex/atuin/slack/linear. Each source now runs independently — failures are logged and counted, the run continues, and the process exits non-zero only at the end if any source failed.

Also: fixed a stale `search` doc comment that still referenced the removed `ingest`/`gc` subcommands.

Acknowledged non-blockers from the review, left as-is deliberately: the parquet full-file rewrite per change (documented; manifest-skip avoids no-ops), the in-memory materialization per source (fine at current volumes), and `--mixedbread-store` sharing the `MXBAI_STORE` env (consistent with the prior `claude-history-sync` convention; the home-module sets it explicitly).

Validated: `nix build .#indexer` + `rust-source-codex-{clippy, parse tests, unusedCrateDependencies}` + `rust-indexer-clippy` + `rust-search-clippy` on the x86_64-linux builder — all green (3 codex tests pass).

_Authored with AI (Claude Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix codex external IDs to be content-stable and make per-source indexing failures non-fatal
> - Changes `codex.Entry.external_id` to use `session_id`, timestamp, and a content hash instead of a positional sequence number, making IDs stable regardless of file position or ordering.
> - Reworks the indexer's source processing loop so each source is attempted independently; failures are logged to stderr and counted rather than aborting the run early.
> - The process exits non-zero at the end if any source failed, and the "no sources selected" error now only triggers when zero sources are configured (not when all configured sources failed).
> - Behavioral Change: existing codex documents will get new external IDs on the next index run, which may cause re-ingestion or duplicate detection depending on downstream reconciliation logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7973a40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->