### PR TITLE
elevenlabs-say: work with a synthesis-only API key

### DIFF
--- a/packages/elevenlabs-say/src/elevenlabs_say/__init__.py
+++ b/packages/elevenlabs-say/src/elevenlabs_say/__init__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import codecs
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -254,16 +255,32 @@ def stream_client(client: ElevenLabs) -> RealtimeTextToSpeechClient:
     return tts
 
 
+# ElevenLabs voice ids are opaque 20-character base62 tokens (e.g. George's
+# "JBFqnCBsd6RMkjVDRZzb"). A human-typed name almost never collides with this
+# shape, so an input that matches it is treated as an id directly.
+_VOICE_ID_RE = re.compile(r"\A[A-Za-z0-9]{20}\Z")
+
+
 def resolve_voice_id(client: ElevenLabs, voice: str) -> str:
     """Treat ``voice`` as a name first; fall back to using it as an id verbatim.
 
-    ElevenLabs voice ids are opaque 20-character tokens, so a human-typed name
-    almost never collides with an id. Searching by name keeps the CLI usable with
-    friendly voice names while still accepting a raw id.
+    A value already shaped like a voice id is used directly without calling the
+    voices API, so the CLI works with a synthesis-only API key that lacks the
+    ``voices_read`` permission (the common case, including the default voice).
+    Resolving a friendly name still needs ``voices_read``.
     """
+    if _VOICE_ID_RE.match(voice):
+        return voice
+
     try:
         response = client.voices.search(search=voice)
     except ApiError as exc:
+        if exc.status_code in (401, 403):
+            raise SayError(
+                f"cannot resolve voice name {voice!r}: this {API_KEY_ENV} lacks the "
+                "voices_read permission. Pass a voice id with --voice instead, or "
+                "use a key that can read voices."
+            ) from exc
         raise SayError(format_api_error("resolve voice", exc)) from exc
 
     for candidate in response.voices:

--- a/packages/elevenlabs-say/tests/test_streaming.py
+++ b/packages/elevenlabs-say/tests/test_streaming.py
@@ -15,6 +15,7 @@ import time
 from pathlib import Path
 
 import elevenlabs.realtime_tts as realtime_module
+from elevenlabs.core import ApiError
 
 import elevenlabs_say as say
 
@@ -205,6 +206,50 @@ def test_say_compat_flags_parse() -> None:
     assert say.parse_args(["hello"]).rate is None
 
 
+def test_resolve_voice_id_id_shape_skips_api() -> None:
+    """A voice-id-shaped value is returned verbatim without touching the API.
+
+    Guards the synthesis-only-key path: resolving the default voice (an id) must
+    not call ``voices.search``, which needs the ``voices_read`` permission a
+    TTS-only key lacks. Accessing ``.voices`` on the sentinel would raise.
+    """
+
+    class Boom:
+        def __getattr__(self, name: str) -> object:
+            raise AssertionError(f"client.{name} must not be used for an id")
+
+    assert say.resolve_voice_id(Boom(), "JBFqnCBsd6RMkjVDRZzb") == "JBFqnCBsd6RMkjVDRZzb"
+
+
+def test_resolve_voice_id_name_searches_and_maps() -> None:
+    """A friendly name is matched case-insensitively to its id via the search."""
+
+    class FakeVoices:
+        def search(self, search: str) -> object:
+            assert search == "George"
+            voice = type("V", (), {"name": "George", "voice_id": "ID0000000000000000aa"})()
+            return type("R", (), {"voices": [voice]})()
+
+    client = type("C", (), {"voices": FakeVoices()})()
+    assert say.resolve_voice_id(client, "George") == "ID0000000000000000aa"
+
+
+def test_resolve_voice_id_missing_permission_is_actionable() -> None:
+    """A 401 while resolving a name raises a SayError naming voices_read."""
+
+    class FakeVoices:
+        def search(self, search: str) -> object:
+            raise ApiError(status_code=401, body={"detail": "nope"})
+
+    client = type("C", (), {"voices": FakeVoices()})()
+    try:
+        say.resolve_voice_id(client, "George")
+    except say.SayError as exc:
+        assert "voices_read" in str(exc)
+    else:
+        raise AssertionError("expected SayError for a 401 during name resolution")
+
+
 if __name__ == "__main__":
     test_stdin_yields_before_eof_and_rejoins_split_utf8()
     test_write_stream_writes_chunks_and_rejects_empty()
@@ -214,4 +259,7 @@ if __name__ == "__main__":
     test_stream_init_does_not_crash_on_omit_voice_settings()
     test_atempo_filter_maps_wpm_to_in_range_stages()
     test_say_compat_flags_parse()
+    test_resolve_voice_id_id_shape_skips_api()
+    test_resolve_voice_id_name_searches_and_maps()
+    test_resolve_voice_id_missing_permission_is_actionable()
     print("elevenlabs-say streaming tests passed")


### PR DESCRIPTION
`elevenlabs-say` always called `voices.search` to resolve `--voice`, which needs the `voices_read` permission. A synthesis-only `ELEVENLABS_API_KEY` (the common, more-scoped-down case) 401'd even for the default voice, which is already a voice id.

Fix: an id-shaped `--voice` (`[A-Za-z0-9]{20}`) is used verbatim with no API call; a friendly name still resolves via search, and a 401/403 there now raises an error naming the missing `voices_read` permission.

Validated: `nix run .#elevenlabs-say` synthesizes + plays with a restricted (TTS-only) key; `nix build .#elevenlabs-say.tests.{streaming,printsHelp}` green (3 new resolver tests).

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow `elevenlabs-say` to work with a synthesis-only API key by skipping voice lookup
> - `resolve_voice_id` in [`__init__.py`](https://github.com/indexable-inc/index/pull/513/files#diff-b708a982f36b4d92f2a14ab3238bebd34fdee165e4adb1aadea25551f92d9e46) now returns the input directly without calling the voices API when the voice argument already looks like a 20-character base62 voice ID.
> - When a name lookup fails with a 401/403, it raises a `SayError` with an actionable message referencing the missing `voices_read` permission and suggesting passing a voice ID instead.
> - Behavioral Change: callers passing a valid voice ID no longer trigger a voices API call, so synthesis-only keys work end-to-end without needing `voices_read` permission.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9126d0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->