### PR TITLE
elevenlabs-say: cover 403 + non-permission ApiError in resolver tests

### DIFF
--- a/packages/elevenlabs-say/tests/test_streaming.py
+++ b/packages/elevenlabs-say/tests/test_streaming.py
@@ -235,19 +235,42 @@ def test_resolve_voice_id_name_searches_and_maps() -> None:
 
 
 def test_resolve_voice_id_missing_permission_is_actionable() -> None:
-    """A 401 while resolving a name raises a SayError naming voices_read."""
+    """401 and 403 while resolving a name both raise a SayError naming voices_read."""
+
+    for status in (401, 403):
+
+        class FakeVoices:
+            def search(self, search: str) -> object:
+                raise ApiError(status_code=status, body={"detail": "nope"})
+
+        client = type("C", (), {"voices": FakeVoices()})()
+        try:
+            say.resolve_voice_id(client, "George")
+        except say.SayError as exc:
+            assert "voices_read" in str(exc), (status, exc)
+        else:
+            raise AssertionError(f"expected SayError for {status} during resolution")
+
+
+def test_resolve_voice_id_other_api_error_falls_through() -> None:
+    """A non-permission ApiError (e.g. 500) keeps the generic status message.
+
+    Pins the ``in (401, 403)`` branch: an unrelated failure must not be relabeled
+    as a permissions problem.
+    """
 
     class FakeVoices:
         def search(self, search: str) -> object:
-            raise ApiError(status_code=401, body={"detail": "nope"})
+            raise ApiError(status_code=500, body={"detail": "boom"})
 
     client = type("C", (), {"voices": FakeVoices()})()
     try:
         say.resolve_voice_id(client, "George")
     except say.SayError as exc:
-        assert "voices_read" in str(exc)
+        assert "status 500" in str(exc), exc
+        assert "voices_read" not in str(exc), exc
     else:
-        raise AssertionError("expected SayError for a 401 during name resolution")
+        raise AssertionError("expected SayError for a 500 during name resolution")
 
 
 if __name__ == "__main__":
@@ -262,4 +285,5 @@ if __name__ == "__main__":
     test_resolve_voice_id_id_shape_skips_api()
     test_resolve_voice_id_name_searches_and_maps()
     test_resolve_voice_id_missing_permission_is_actionable()
+    test_resolve_voice_id_other_api_error_falls_through()
     print("elevenlabs-say streaming tests passed")


### PR DESCRIPTION
Follow-up to #513 review (M2). Generalizes the resolver permission test to 401 and 403, and adds a 500 fall-through test asserting an unrelated ApiError keeps its generic status message rather than being relabeled as a `voices_read` problem.

`nix build .#elevenlabs-say.tests.streaming` green.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend resolver tests in `elevenlabs-say` to cover 403 and non-permission `ApiError`
> - Updates `test_resolve_voice_id_missing_permission_is_actionable` to loop over both 401 and 403 statuses, asserting that each raises a `SayError` mentioning `voices_read`.
> - Adds `test_resolve_voice_id_other_api_error_falls_through` to verify that a status 500 `ApiError` produces a `SayError` with `'status 500'` and no mention of `voices_read`.
> - Registers the new test in the `__main__` block of [test_streaming.py](https://github.com/indexable-inc/index/pull/514/files#diff-ea71be73ceac7294f8d665f3423f3301023d1cc71525f03b9c5090be033ebfbe).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3876f61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->