### PR TITLE
refactor(sink-mixedbread): extract the Mixedbread record-reconcile from search-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,6 +2790,7 @@ dependencies = [
  "dirs",
  "mixedbread",
  "search-core",
+ "sink-mixedbread",
  "sink-parquet",
  "source-atuin",
  "source-claude",
@@ -5701,6 +5702,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sink-mixedbread"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "mixedbread",
+ "search-core",
+ "serde_json",
+ "snafu 0.9.1",
+ "source-meta",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
   "packages/source/meta",
   "packages/search-py",
   "packages/source/slack",
+  "packages/sink/mixedbread",
   "packages/sink/parquet",
   "packages/indexer",
   "packages/tap",
@@ -164,6 +165,7 @@ serde_json = "1"
 sha2 = "0.10"
 similar = "2"
 source-slack = { path = "packages/source/slack" }
+sink-mixedbread = { path = "packages/sink/mixedbread" }
 sink-parquet = { path = "packages/sink/parquet" }
 snafu = "0.9"
 strip-ansi-escapes = "0.2"

--- a/packages/indexer/Cargo.toml
+++ b/packages/indexer/Cargo.toml
@@ -21,6 +21,7 @@ source-atuin.workspace = true
 source-slack.workspace = true
 source-linear.workspace = true
 search-core.workspace = true
+sink-mixedbread.workspace = true
 sink-parquet.workspace = true
 mixedbread.workspace = true
 anyhow.workspace = true

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -12,7 +12,8 @@ use std::time::Duration;
 
 use anyhow::Context as _;
 use clap::Parser;
-use search_core::{MixedbreadStore, sync_documents};
+use search_core::MixedbreadStore;
+use sink_mixedbread::sync_documents;
 use source_meta::SourceAdapter;
 
 /// How long to wait for Mixedbread to finish embedding new documents.

--- a/packages/search-core/src/lib.rs
+++ b/packages/search-core/src/lib.rs
@@ -47,7 +47,7 @@ pub use pipeline::{Query, index_and_answer, index_and_grep, index_and_semantic};
 pub use query_filter::{FilterSpec, build_filter};
 pub use repo::repo_slug;
 pub use search::{AnswerView, CodeScope, DisplayHit, ask, grep, hits_to_json, semantic};
-pub use sync::{GcReport, SyncReport, gc_documents, sync, sync_documents, wait_until_indexed};
+pub use sync::{SyncReport, sync, wait_until_indexed};
 
 // Re-export the shared metadata and filter types so binaries depend only on
 // search-core.

--- a/packages/search-core/src/sync.rs
+++ b/packages/search-core/src/sync.rs
@@ -13,19 +13,19 @@
 //! There is no daemon. Each invocation rebuilds the manifest cheaply (mtime
 //! skips re-hashing unchanged files) and uploads only what is new.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt as _};
 use mixedbread::Filter;
-use source_meta::{Document, RepoSlug, SourceAdapter, keys};
+use source_meta::{Document, RepoSlug, keys};
 use snafu::ResultExt as _;
 use tokio::time::sleep;
 
 use crate::backend::{Store, StoreStatus};
-use crate::error::{AdapterSnafu, MetadataLimitSnafu, ReadFileSnafu, Result, TooManyFilesSnafu};
+use crate::error::{MetadataLimitSnafu, ReadFileSnafu, Result, TooManyFilesSnafu};
 use crate::manifest::{FileEntry, Manifest};
 
 /// Maximum concurrent uploads in flight.
@@ -239,167 +239,13 @@ fn file_name_of(rel_path: &str) -> &str {
     rel_path.rsplit('/').next().unwrap_or(rel_path)
 }
 
-/// Outcome of a garbage-collection pass over one record source.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct GcReport {
-    /// Records deleted from the store (present remotely, absent from the export).
-    pub deleted: usize,
-    /// Records kept (the adapter's current desired set).
-    pub kept: usize,
-}
-
-/// The filter selecting one source's records in the shared store.
-fn source_filter(adapter: &impl SourceAdapter) -> Filter {
-    Filter::eq(keys::SOURCE, adapter.source().as_str())
-}
-
-/// Reconcile a record source (Slack, Linear, ...) into the store: upload records
-/// that are new or whose `content_hash` changed, skip the unchanged.
-///
-/// Unlike the code [`sync`], records are addressed by a source-defined
-/// `external_id`, so change detection compares each document's `content_hash`
-/// against the value stored under that id. Reconcile lists only this source's
-/// records (a `source == X` filter), so it never reads or touches another
-/// source's entries.
-///
-/// # Errors
-/// Returns an error if the store cannot be reached, a document cannot be
-/// produced by the adapter, or an upload fails.
-pub async fn sync_documents<A>(
-    adapter: &A,
-    store: &(impl Store + Sync),
-    store_name: &str,
-    index_timeout: Duration,
-    on_progress: impl Fn(usize, usize) + Send + Sync,
-) -> Result<SyncReport>
-where
-    A: SourceAdapter + Sync,
-{
-    store.ensure_store(store_name).await?;
-    let filter = source_filter(adapter);
-    let remote: HashMap<String, Option<String>> = store
-        .list_records(store_name, Some(&filter))
-        .await?
-        .into_iter()
-        .map(|record| (record.external_id, record.content_hash))
-        .collect();
-
-    // Parsing is sequential and cheap; uploading is the expensive part and runs
-    // concurrently. Collect only the documents that actually need uploading so a
-    // re-ingest of an unchanged export holds almost nothing.
-    let mut to_upload = Vec::new();
-    let mut total = 0;
-    for item in adapter.documents() {
-        let document = item.map_err(|error| {
-            AdapterSnafu {
-                message: error.to_string(),
-            }
-            .build()
-        })?;
-        total += 1;
-        // A record with no stored content_hash predates hash tracking; re-embed.
-        let unchanged = matches!(
-            remote.get(&document.external_id),
-            Some(Some(stored)) if *stored == document.content_hash
-        );
-        if !unchanged {
-            to_upload.push(document);
-        }
-    }
-
-    let upload_target = to_upload.len();
-    let skipped = total - upload_target;
-    on_progress(0, upload_target);
-    let done = AtomicUsize::new(0);
-
-    let results: Vec<Result<()>> = stream::iter(to_upload)
-        .map(|document| {
-            let done = &done;
-            let on_progress = &on_progress;
-            async move {
-                store.upload(store_name, document).await?;
-                on_progress(done.fetch_add(1, Ordering::Relaxed) + 1, upload_target);
-                Ok(())
-            }
-        })
-        .buffer_unordered(UPLOAD_CONCURRENCY)
-        .collect()
-        .await;
-
-    let mut uploaded = 0;
-    for result in results {
-        result?;
-        uploaded += 1;
-    }
-
-    if uploaded > 0 {
-        wait_until_indexed(store, store_name, index_timeout, |_| {}).await?;
-    }
-
-    Ok(SyncReport {
-        uploaded,
-        skipped,
-        total,
-    })
-}
-
-/// Delete records present in the store for this source but absent from the
-/// adapter's current desired set (a full-snapshot set-difference).
-///
-/// The remote set is listed with a `source == X` filter, so this can only ever
-/// delete that source's records: a Linear GC cannot touch a code blob or a Slack
-/// thread. Run it against a complete export, never a window slice, or it would
-/// delete records the slice simply did not include.
-///
-/// # Errors
-/// Returns an error if the store cannot be reached, a document cannot be
-/// produced, or a delete fails.
-pub async fn gc_documents<A>(
-    adapter: &A,
-    store: &(impl Store + Sync),
-    store_name: &str,
-) -> Result<GcReport>
-where
-    A: SourceAdapter + Sync,
-{
-    let filter = source_filter(adapter);
-    let remote: HashSet<String> = store
-        .list_records(store_name, Some(&filter))
-        .await?
-        .into_iter()
-        .map(|record| record.external_id)
-        .collect();
-
-    let mut desired = HashSet::new();
-    for item in adapter.documents() {
-        let document = item.map_err(|error| {
-            AdapterSnafu {
-                message: error.to_string(),
-            }
-            .build()
-        })?;
-        desired.insert(document.external_id);
-    }
-
-    let stale: Vec<&String> = remote.difference(&desired).collect();
-    let deleted = stale.len();
-    for external_id in stale {
-        store.delete(store_name, external_id).await?;
-    }
-
-    Ok(GcReport {
-        deleted,
-        kept: desired.len(),
-    })
-}
-
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
 
-    use source_meta::{Document, RepoSlug, SourceAdapter};
 
-    use super::{gc_documents, sync, sync_documents};
+    use source_meta::RepoSlug;
+
+    use super::sync;
     use crate::backend::MemoryStore;
     use crate::manifest::Manifest;
 
@@ -504,95 +350,5 @@ mod tests {
             .expect_err("should refuse");
         assert!(matches!(err, crate::error::Error::TooManyFiles { .. }));
         assert_eq!(store.upload_count(), 0);
-    }
-
-    // A fake record source for exercising the document reconcile and GC without a
-    // real parser crate. It yields Linear-shaped documents from owned data.
-    struct FakeSource {
-        docs: Vec<Document>,
-    }
-
-    #[derive(Debug, snafu::Snafu)]
-    #[snafu(display("fake source error"))]
-    struct FakeError;
-
-    impl SourceAdapter for FakeSource {
-        type Error = FakeError;
-        fn source(&self) -> source_meta::Source {
-            source_meta::Source::new("linear")
-        }
-        fn documents(&self) -> impl Iterator<Item = std::result::Result<Document, FakeError>> + Send {
-            self.docs.clone().into_iter().map(Ok)
-        }
-    }
-
-    fn linear_doc(id: &str, body: &str) -> Document {
-        let content_hash = source_meta::hash_body(body.as_bytes());
-        Document {
-            external_id: format!("linear:issue:{id}"),
-            file_name: format!("{id}.txt"),
-            mime: "text/plain",
-            body: body.as_bytes().to_vec(),
-            meta_json: serde_json::json!({
-                "source": "linear",
-                "external_id": format!("linear:issue:{id}"),
-                "content_hash": content_hash,
-                "title": id,
-            }),
-            content_hash,
-        }
-    }
-
-    #[tokio::test]
-    async fn document_sync_uploads_then_skips_unchanged_and_reuploads_changed() {
-        let store = MemoryStore::new();
-        let source = FakeSource {
-            docs: vec![linear_doc("A", "alpha body"), linear_doc("B", "beta body")],
-        };
-
-        let first = sync_documents(&source, &store, "s", Duration::from_secs(1), |_, _| {})
-            .await
-            .expect("first");
-        assert_eq!(first.uploaded, 2);
-        assert_eq!(store.upload_count(), 2);
-
-        // Re-running the same export uploads nothing (content_hash unchanged).
-        let second = sync_documents(&source, &store, "s", Duration::from_secs(1), |_, _| {})
-            .await
-            .expect("second");
-        assert_eq!(second.uploaded, 0);
-        assert_eq!(second.skipped, 2);
-        assert_eq!(store.upload_count(), 2, "no redundant re-upload");
-
-        // A changed body for A re-embeds only A.
-        let changed = FakeSource {
-            docs: vec![linear_doc("A", "alpha body EDITED"), linear_doc("B", "beta body")],
-        };
-        let third = sync_documents(&changed, &store, "s", Duration::from_secs(1), |_, _| {})
-            .await
-            .expect("third");
-        assert_eq!(third.uploaded, 1);
-        assert_eq!(store.upload_count(), 3);
-    }
-
-    #[tokio::test]
-    async fn gc_deletes_records_absent_from_the_export() {
-        let store = MemoryStore::new();
-        let full = FakeSource {
-            docs: vec![linear_doc("A", "a"), linear_doc("B", "b"), linear_doc("C", "c")],
-        };
-        sync_documents(&full, &store, "s", Duration::from_secs(1), |_, _| {})
-            .await
-            .expect("seed");
-        assert_eq!(store.len(), 3);
-
-        // A later export dropped issue C; GC removes it.
-        let trimmed = FakeSource {
-            docs: vec![linear_doc("A", "a"), linear_doc("B", "b")],
-        };
-        let report = gc_documents(&trimmed, &store, "s").await.expect("gc");
-        assert_eq!(report.deleted, 1);
-        assert_eq!(report.kept, 2);
-        assert_eq!(store.len(), 2);
     }
 }

--- a/packages/sink/mixedbread/Cargo.toml
+++ b/packages/sink/mixedbread/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "sink-mixedbread"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Mixedbread sink: reconcile a record source into a Mixedbread store (upload changed, skip unchanged, GC stale)"
+
+[lints]
+workspace = true
+
+[dependencies]
+search-core.workspace = true
+source-meta.workspace = true
+mixedbread.workspace = true
+futures.workspace = true
+snafu.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+serde_json.workspace = true

--- a/packages/sink/mixedbread/package.nix
+++ b/packages/sink/mixedbread/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "sink-mixedbread";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/sink/mixedbread/src/error.rs
+++ b/packages/sink/mixedbread/src/error.rs
@@ -1,0 +1,25 @@
+//! Error type for the Mixedbread sink.
+
+use snafu::Snafu;
+
+/// Failures from reconciling a source into a Mixedbread store.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// A source adapter failed while producing documents.
+    #[snafu(display("source adapter failed: {message}"))]
+    Adapter {
+        /// The adapter's error, rendered.
+        message: String,
+    },
+    /// A store operation (ensure, list, upload, delete, or index-wait) failed.
+    #[snafu(display("store operation failed"))]
+    Store {
+        /// Underlying search-core store error.
+        source: search_core::Error,
+    },
+}
+
+/// Result alias defaulting to this crate's [`Error`].
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/packages/sink/mixedbread/src/lib.rs
+++ b/packages/sink/mixedbread/src/lib.rs
@@ -1,0 +1,280 @@
+//! Mixedbread sink for the multi-source corpus: reconcile a record source
+//! (Slack, Linear, Claude, Codex, atuin, git, ...) into a Mixedbread store.
+//!
+//! Records are addressed by a source-defined `external_id`, so change detection
+//! compares each document's `content_hash` against the value stored under that
+//! id: upload the new or changed, skip the unchanged. Listing is scoped with a
+//! `source == X` filter, so a reconcile never reads or touches another source's
+//! records.
+//!
+//! This is the write half of the corpus, paired with `sink-parquet`. It is built
+//! on `search-core`'s [`Store`] abstraction (so it works against the production
+//! `MixedbreadStore` or the in-memory test store) and reuses
+//! [`search_core::wait_until_indexed`] to block until new content is embedded.
+
+#![forbid(unsafe_code)]
+
+mod error;
+
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use futures::stream::{self, StreamExt as _};
+use mixedbread::Filter;
+use search_core::{Store, wait_until_indexed};
+use source_meta::{SourceAdapter, keys};
+use snafu::ResultExt as _;
+
+pub use crate::error::Error;
+use crate::error::{AdapterSnafu, Result, StoreSnafu};
+
+/// Maximum concurrent uploads in flight.
+const UPLOAD_CONCURRENCY: usize = 16;
+
+/// Outcome of a reconcile pass over one record source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SyncReport {
+    /// Records uploaded this run (new or changed).
+    pub uploaded: usize,
+    /// Records skipped because their `content_hash` was unchanged.
+    pub skipped: usize,
+    /// Total records the adapter produced.
+    pub total: usize,
+}
+
+/// Outcome of a garbage-collection pass over one record source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GcReport {
+    /// Records deleted (present remotely, absent from the export).
+    pub deleted: usize,
+    /// Records kept (the adapter's current desired set).
+    pub kept: usize,
+}
+
+/// The filter selecting one source's records in the shared store.
+fn source_filter(adapter: &impl SourceAdapter) -> Filter {
+    Filter::eq(keys::SOURCE, adapter.source().as_str())
+}
+
+/// Reconcile a record source into `store`: upload records that are new or whose
+/// `content_hash` changed, skip the unchanged, and block until the new content
+/// is embedded.
+///
+/// `on_progress(uploaded_so_far, total_to_upload)` is called once with the total
+/// before uploading and again after each successful upload.
+///
+/// # Errors
+/// Returns an error if the store cannot be reached, a document cannot be
+/// produced by the adapter, or an upload fails.
+pub async fn sync_documents<A>(
+    adapter: &A,
+    store: &(impl Store + Sync),
+    store_name: &str,
+    index_timeout: Duration,
+    on_progress: impl Fn(usize, usize) + Send + Sync,
+) -> Result<SyncReport>
+where
+    A: SourceAdapter + Sync,
+{
+    store.ensure_store(store_name).await.context(StoreSnafu)?;
+    let filter = source_filter(adapter);
+    let remote: HashMap<String, Option<String>> = store
+        .list_records(store_name, Some(&filter))
+        .await
+        .context(StoreSnafu)?
+        .into_iter()
+        .map(|record| (record.external_id, record.content_hash))
+        .collect();
+
+    // Parsing is sequential and cheap; uploading is the expensive part and runs
+    // concurrently. Collect only documents that actually need uploading so a
+    // re-ingest of an unchanged export holds almost nothing.
+    let mut to_upload = Vec::new();
+    let mut total = 0;
+    for item in adapter.documents() {
+        let document = item.map_err(|error| AdapterSnafu { message: error.to_string() }.build())?;
+        total += 1;
+        // A record with no stored content_hash predates hash tracking; re-embed.
+        let unchanged = matches!(
+            remote.get(&document.external_id),
+            Some(Some(stored)) if *stored == document.content_hash
+        );
+        if !unchanged {
+            to_upload.push(document);
+        }
+    }
+
+    let upload_target = to_upload.len();
+    let skipped = total - upload_target;
+    on_progress(0, upload_target);
+    let done = AtomicUsize::new(0);
+
+    let results: Vec<Result<()>> = stream::iter(to_upload)
+        .map(|document| {
+            let done = &done;
+            let on_progress = &on_progress;
+            async move {
+                store.upload(store_name, document).await.context(StoreSnafu)?;
+                on_progress(done.fetch_add(1, Ordering::Relaxed) + 1, upload_target);
+                Ok(())
+            }
+        })
+        .buffer_unordered(UPLOAD_CONCURRENCY)
+        .collect()
+        .await;
+
+    let mut uploaded = 0;
+    for result in results {
+        result?;
+        uploaded += 1;
+    }
+
+    if uploaded > 0 {
+        wait_until_indexed(store, store_name, index_timeout, |_| {}).await.context(StoreSnafu)?;
+    }
+
+    Ok(SyncReport { uploaded, skipped, total })
+}
+
+/// Delete records present in the store for this source but absent from the
+/// adapter's current desired set (a full-snapshot set-difference).
+///
+/// The remote set is listed with a `source == X` filter, so this can only delete
+/// that source's records. Run it against a complete export, never a window
+/// slice, or it would delete records the slice simply did not include.
+///
+/// # Errors
+/// Returns an error if the store cannot be reached, a document cannot be
+/// produced, or a delete fails.
+pub async fn gc_documents<A>(
+    adapter: &A,
+    store: &(impl Store + Sync),
+    store_name: &str,
+) -> Result<GcReport>
+where
+    A: SourceAdapter + Sync,
+{
+    let filter = source_filter(adapter);
+    let remote: HashSet<String> = store
+        .list_records(store_name, Some(&filter))
+        .await
+        .context(StoreSnafu)?
+        .into_iter()
+        .map(|record| record.external_id)
+        .collect();
+
+    let mut desired = HashSet::new();
+    for item in adapter.documents() {
+        let document = item.map_err(|error| AdapterSnafu { message: error.to_string() }.build())?;
+        desired.insert(document.external_id);
+    }
+
+    let stale: Vec<&String> = remote.difference(&desired).collect();
+    let deleted = stale.len();
+    for external_id in stale {
+        store.delete(store_name, external_id).await.context(StoreSnafu)?;
+    }
+
+    Ok(GcReport { deleted, kept: desired.len() })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use search_core::MemoryStore;
+    use source_meta::{Document, SourceAdapter};
+
+    use super::{gc_documents, sync_documents};
+
+    // A fake record source for exercising the reconcile and GC without a real
+    // parser crate. It yields Linear-shaped documents from owned data.
+    struct FakeSource {
+        docs: Vec<Document>,
+    }
+
+    #[derive(Debug, snafu::Snafu)]
+    #[snafu(display("fake source error"))]
+    struct FakeError;
+
+    impl SourceAdapter for FakeSource {
+        type Error = FakeError;
+        fn source(&self) -> source_meta::Source {
+            source_meta::Source::new("linear")
+        }
+        fn documents(&self) -> impl Iterator<Item = std::result::Result<Document, FakeError>> + Send {
+            self.docs.clone().into_iter().map(Ok)
+        }
+    }
+
+    fn linear_doc(id: &str, body: &str) -> Document {
+        let content_hash = source_meta::hash_body(body.as_bytes());
+        Document {
+            external_id: format!("linear:issue:{id}"),
+            file_name: format!("{id}.txt"),
+            mime: "text/plain",
+            body: body.as_bytes().to_vec(),
+            meta_json: serde_json::json!({
+                "source": "linear",
+                "external_id": format!("linear:issue:{id}"),
+                "content_hash": content_hash,
+                "title": id,
+            }),
+            content_hash,
+        }
+    }
+
+    #[tokio::test]
+    async fn document_sync_uploads_then_skips_unchanged_and_reuploads_changed() {
+        let store = MemoryStore::new();
+        let source = FakeSource {
+            docs: vec![linear_doc("A", "alpha body"), linear_doc("B", "beta body")],
+        };
+
+        let first = sync_documents(&source, &store, "s", Duration::from_secs(1), |_, _| {})
+            .await
+            .expect("first");
+        assert_eq!(first.uploaded, 2);
+        assert_eq!(store.upload_count(), 2);
+
+        // Re-running the same export uploads nothing (content_hash unchanged).
+        let second = sync_documents(&source, &store, "s", Duration::from_secs(1), |_, _| {})
+            .await
+            .expect("second");
+        assert_eq!(second.uploaded, 0);
+        assert_eq!(second.skipped, 2);
+        assert_eq!(store.upload_count(), 2, "no redundant re-upload");
+
+        // A changed body for A re-embeds only A.
+        let changed = FakeSource {
+            docs: vec![linear_doc("A", "alpha body EDITED"), linear_doc("B", "beta body")],
+        };
+        let third = sync_documents(&changed, &store, "s", Duration::from_secs(1), |_, _| {})
+            .await
+            .expect("third");
+        assert_eq!(third.uploaded, 1);
+        assert_eq!(store.upload_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn gc_deletes_records_absent_from_the_export() {
+        let store = MemoryStore::new();
+        let full = FakeSource {
+            docs: vec![linear_doc("A", "a"), linear_doc("B", "b"), linear_doc("C", "c")],
+        };
+        sync_documents(&full, &store, "s", Duration::from_secs(1), |_, _| {})
+            .await
+            .expect("seed");
+        assert_eq!(store.len(), 3);
+
+        // A later export dropped issue C; GC removes it.
+        let trimmed = FakeSource {
+            docs: vec![linear_doc("A", "a"), linear_doc("B", "b")],
+        };
+        let report = gc_documents(&trimmed, &store, "s").await.expect("gc");
+        assert_eq!(report.deleted, 1);
+        assert_eq!(report.kept, 2);
+        assert_eq!(store.len(), 2);
+    }
+}


### PR DESCRIPTION
Part of #503. Extracts the Mixedbread record-reconcile into its own `sink-mixedbread` crate, completing the `sink-*` component scheme.

- New `sink-mixedbread` owns `sync_documents` (upload new/changed records, skip unchanged) + `gc_documents` (delete stale), with `SyncReport`/`GcReport` and the `source_filter` helper. Generic over search-core's `Store`, so it drives the production `MixedbreadStore` or the in-memory test store; reuses `search_core::wait_until_indexed`.
- The `indexer` now fans every source out to `sink-mixedbread` (semantic) + `sink-parquet` (S3 parquet) symmetrically.
- `search-core` keeps the code-sync (manifest/content-addressed) and query paths; it no longer exports `sync_documents`/`gc_documents`/`GcReport`. The record-reconcile tests moved with the code (2 tests in sink-mixedbread; search-core's 31 unit tests still pass, covering the code-sync path).

Layering note: `sink-mixedbread` depends on `search-core` for the `Store` trait and `wait_until_indexed` — the Mixedbread sink is intrinsically built on that storage abstraction (unlike `sink-parquet`, which is self-contained). This is the requested symmetry without restructuring search-core's backend.

Validated: `nix build .#indexer` + `rust-sink-mixedbread-{clippy, unit tests, unusedCrateDependencies}` + `rust-search-core-{clippy, unit tests}` + `rust-indexer-clippy` on the x86_64-linux builder — all green (sink-mixedbread 2 tests, search-core 31 tests). No dangling references to the moved functions anywhere.

_Authored with AI (Claude Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract Mixedbread record-reconcile and GC logic from `search-core` into new `sink-mixedbread` crate
> - Moves `sync_documents`, `gc_documents`, `SyncReport`, and `GcReport` out of `search-core::sync` into a new [`sink-mixedbread`](https://github.com/indexable-inc/index/pull/515/files#diff-5d69d5d223d7bff404cf70b24d57cc2d8773b4db8bdf32416943ee7d4e27c8d9) crate.
> - `search-core` no longer exposes document-level reconcile or GC APIs at its crate root; callers must now import from `sink_mixedbread`.
> - The indexer's [`main.rs`](https://github.com/indexable-inc/index/pull/515/files#diff-5664bac77cedfa678d477bb44bf07a8888bdbb1eb15055f1c164d6c9c131ce7d) is updated to import `sync_documents` from `sink_mixedbread` instead of `search_core`.
> - The new crate introduces its own [`Error`](https://github.com/indexable-inc/index/pull/515/files#diff-1bcda5c4eade79b79ee3a531ea11ec616d5e84f7de6b7d83237cf59cbca0284c) type wrapping `search_core::Error` and adapter errors via snafu.
> - Risk: any downstream crates importing `gc_documents`, `sync_documents`, or `GcReport` from `search_core` will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97aaf00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->