### PR TITLE
feat(indexer): index code repos (content-addressed, reuses search-core sync)

### DIFF
--- a/packages/indexer/home-module.nix
+++ b/packages/indexer/home-module.nix
@@ -66,7 +66,11 @@ let
     ++ concatMap (repo: [
       "--git-repo"
       repo
-    ]) cfg.gitRepos;
+    ]) cfg.gitRepos
+    ++ concatMap (repo: [
+      "--code-repo"
+      repo
+    ]) cfg.codeRepos;
 
   sinkFlags =
     optionals (cfg.bucket != null) (
@@ -149,6 +153,12 @@ in
       description = "Git repositories whose commit history to ingest.";
     };
 
+    codeRepos = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Code checkouts to index (content-addressed; Mixedbread only). Needs mixedbreadStore.";
+    };
+
     bucket = mkOption {
       type = types.nullOr types.str;
       default = null;
@@ -222,8 +232,9 @@ in
           || cfg.atuinDb != null
           || cfg.slackExport != null
           || cfg.linearExport != null
-          || cfg.gitRepos != [ ];
-        message = "services.indexer: select at least one source (local, a *Dir/*File/*Export path, or gitRepos).";
+          || cfg.gitRepos != [ ]
+          || cfg.codeRepos != [ ];
+        message = "services.indexer: select at least one source (local, a *Dir/*File/*Export path, gitRepos, or codeRepos).";
       }
     ];
 

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -14,6 +14,11 @@ use anyhow::Context as _;
 use clap::Parser;
 use search_core::MixedbreadStore;
 use sink_mixedbread::sync_documents;
+
+/// Manifest limits for code repos, matching `search-core`'s defaults.
+const MAX_FILE_BYTES: u64 = 1024 * 1024;
+/// Cap on new files uploaded per code sync (a runaway guard).
+const MAX_FILES: usize = 10_000;
 use source_meta::SourceAdapter;
 
 /// How long to wait for Mixedbread to finish embedding new documents.
@@ -76,6 +81,11 @@ struct Cli {
     /// Git repository to index commit history from (repeatable).
     #[arg(long = "git-repo")]
     git_repos: Vec<PathBuf>,
+
+    /// Code checkout to index (content-addressed, like a bare `search`).
+    /// Mixedbread only (code lives in git, not the parquet archive); repeatable.
+    #[arg(long = "code-repo")]
+    code_repos: Vec<PathBuf>,
 }
 
 #[tokio::main]
@@ -101,23 +111,40 @@ async fn main() -> anyhow::Result<()> {
     }
     let mixedbread = store.as_ref().zip(cli.mixedbread_store.as_deref());
 
+    let (indexed, failures) = run_sources(&cli, mixedbread, parquet.as_ref()).await;
+
+    let configured = indexed + failures;
+    if configured == 0 {
+        anyhow::bail!(
+            "no sources selected: pass --local and/or --claude-dir/--codex-file/--atuin-db/--slack-export/--linear-export/--git-repo/--code-repo"
+        );
+    }
+    if failures > 0 {
+        anyhow::bail!("{failures} of {configured} source(s) failed; {indexed} succeeded");
+    }
+    Ok(())
+}
+
+/// Resolve the selected sources and run each one independently (a failure never
+/// aborts the others), returning `(indexed, failed)` counts.
+async fn run_sources(
+    cli: &Cli,
+    mixedbread: Option<(&MixedbreadStore, &str)>,
+    parquet: Option<&sink_parquet::Config>,
+) -> (usize, usize) {
     let home = dirs::home_dir();
     let default = |suffix: &str| home.as_ref().map(|h| h.join(suffix));
     let claude = cli.claude_dir.clone().or_else(|| cli.local.then(|| default(".claude/projects")).flatten());
     let codex = cli.codex_file.clone().or_else(|| cli.local.then(|| default(".codex/history.jsonl")).flatten());
     let atuin = cli.atuin_db.clone().or_else(|| cli.local.then(|| default(".local/share/atuin/history.db")).flatten());
 
-    // Each source runs independently: a failure (an unborn git repo, a missing
-    // export) is logged and counted but never aborts the run, so one broken
-    // source cannot starve every other corpus. The process still exits non-zero
-    // at the end if any source failed.
     let mut indexed = 0_usize;
     let mut failures = 0_usize;
     if let Some(dir) = claude {
         let result = async {
             let adapter = source_claude::ClaudeHistoryExport::open(&dir)
                 .with_context(|| format!("parsing Claude transcripts at {}", dir.display()))?;
-            run_source("claude", &adapter, mixedbread, parquet.as_ref()).await
+            run_source("claude", &adapter, mixedbread, parquet).await
         }
         .await;
         record("claude", result, &mut indexed, &mut failures);
@@ -126,7 +153,7 @@ async fn main() -> anyhow::Result<()> {
         let result = async {
             let adapter = source_codex::CodexHistory::open(&file)
                 .with_context(|| format!("parsing Codex history at {}", file.display()))?;
-            run_source("codex", &adapter, mixedbread, parquet.as_ref()).await
+            run_source("codex", &adapter, mixedbread, parquet).await
         }
         .await;
         record("codex", result, &mut indexed, &mut failures);
@@ -135,7 +162,7 @@ async fn main() -> anyhow::Result<()> {
         let result = async {
             let adapter = source_atuin::AtuinHistory::open(&db)
                 .with_context(|| format!("reading atuin history at {}", db.display()))?;
-            run_source("shell", &adapter, mixedbread, parquet.as_ref()).await
+            run_source("shell", &adapter, mixedbread, parquet).await
         }
         .await;
         record("shell", result, &mut indexed, &mut failures);
@@ -144,7 +171,7 @@ async fn main() -> anyhow::Result<()> {
         let result = async {
             let adapter = source_slack::SlackExport::open(dir)
                 .with_context(|| format!("reading Slack export at {}", dir.display()))?;
-            run_source("slack", &adapter, mixedbread, parquet.as_ref()).await
+            run_source("slack", &adapter, mixedbread, parquet).await
         }
         .await;
         record("slack", result, &mut indexed, &mut failures);
@@ -153,7 +180,7 @@ async fn main() -> anyhow::Result<()> {
         let result = async {
             let adapter = source_linear::LinearExport::open(dir)
                 .with_context(|| format!("reading Linear export at {}", dir.display()))?;
-            run_source("linear", &adapter, mixedbread, parquet.as_ref()).await
+            run_source("linear", &adapter, mixedbread, parquet).await
         }
         .await;
         record("linear", result, &mut indexed, &mut failures);
@@ -163,21 +190,46 @@ async fn main() -> anyhow::Result<()> {
         let result = async {
             let adapter = source_git::GitLog::open(repo)
                 .with_context(|| format!("reading git history at {}", repo.display()))?;
-            run_source("git", &adapter, mixedbread, parquet.as_ref()).await
+            run_source("git", &adapter, mixedbread, parquet).await
         }
         .await;
         record(&label, result, &mut indexed, &mut failures);
     }
+    for repo_dir in &cli.code_repos {
+        let label = format!("code:{}", repo_dir.display());
+        let result = index_code(&label, repo_dir, mixedbread).await;
+        record(&label, result, &mut indexed, &mut failures);
+    }
+    (indexed, failures)
+}
 
-    let configured = indexed + failures;
-    if configured == 0 {
-        anyhow::bail!(
-            "no sources selected: pass --local and/or --claude-dir/--codex-file/--atuin-db/--slack-export/--linear-export/--git-repo"
-        );
+/// Index one code checkout via search-core's content-addressed reconcile
+/// (Mixedbread only — code lives in git, not the parquet archive). Reuses the
+/// exact code sync a bare `search` would run, so records are byte-identical
+/// (same hashes, same repo scoping).
+async fn index_code(
+    label: &str,
+    repo_dir: &std::path::Path,
+    mixedbread: Option<(&MixedbreadStore, &str)>,
+) -> anyhow::Result<()> {
+    let Some((store, store_name)) = mixedbread else {
+        anyhow::bail!("--code-repo requires --mixedbread-store (code is semantic-search only)");
+    };
+    let manifest = search_core::Manifest::build(repo_dir, None, MAX_FILE_BYTES)
+        .with_context(|| format!("building manifest for {}", repo_dir.display()))?;
+    let repo = search_core::repo_slug(repo_dir);
+    let report = search_core::sync(store, store_name, repo_dir, &manifest, &repo, MAX_FILES, |_, _| {})
+        .await
+        .with_context(|| format!("[{label}] code sync"))?;
+    if report.uploaded > 0 {
+        search_core::wait_until_indexed(store, store_name, INDEX_TIMEOUT, |_| {})
+            .await
+            .with_context(|| format!("[{label}] waiting for indexing"))?;
     }
-    if failures > 0 {
-        anyhow::bail!("{failures} of {configured} source(s) failed; {indexed} succeeded");
-    }
+    eprintln!(
+        "[{label}] mixedbread: uploaded {}, skipped {} of {}",
+        report.uploaded, report.skipped, report.total
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Part of #503. Gives the `indexer` ownership of code indexing — the "sync main of ix/index/linux-ix" goal.

- Adds `--code-repo <dir>` (repeatable) to the indexer + `codeRepos` to `services.indexer`.
- Each code checkout is indexed by **reusing search-core's exact content-addressed, repo-scoped code reconcile** (`Manifest::build` + `search_core::sync` + `wait_until_indexed`). So the indexer's code records are byte-identical to what a bare `search` uploads — same content hashes, same repo scoping. No perf regression (keeps the repo-scoped remote listing) and no addressing drift (a `source-code` adapter that re-implemented the hashing could silently mismatch and break code search; reusing `sync` cannot).
- Code is **Mixedbread-only** (it lives in git, not worth the parquet archive); `--code-repo` requires `--mixedbread-store`.

**Deliberately not flipping `search` to pure-query-for-code.** search's standalone code auto-index is the content-addressed feature that makes it work in *any* checkout, including ones the indexer has never seen. Removing it would regress that daily-driver UX (a fresh clone would return nothing until the indexer ran on it). Pure-query is already available per-invocation via `--no-sync`; making it the default is a product decision, not a safe refactor, so it's left to you.

Main's source dispatch was extracted into `run_sources` + `index_code` helpers to stay within the clippy line limit.

Validated: `nix build .#indexer` + `rust-indexer-{clippy, unusedCrateDependencies}` + `nix run .#lint` — all green.

_Authored with AI (Claude Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--code-repo` flag to index content-addressed code checkouts via Mixedbread
> - Adds a repeatable `--code-repo <PATH>` CLI flag that indexes local code repositories using `search_core`'s content-addressed sync, restricted to Mixedbread-configured setups.
> - Introduces `index_code` in [main.rs](https://github.com/indexable-inc/index/pull/516/files#diff-5664bac77cedfa678d477bb44bf07a8888bdbb1eb15055f1c164d6c9c131ce7d) which builds a file manifest (capped at 1 MiB per file, 10,000 files), runs `search_core::sync`, and waits for embedding completion before logging upload/skip/total counts.
> - Extends the Nix home module in [home-module.nix](https://github.com/indexable-inc/index/pull/516/files#diff-68a30c4e4329f2a96c0fe9e34f90968e1773ffd7cf1eb712a988dc729f44eb66) with a `services.indexer.codeRepos` option that passes each path as a `--code-repo` flag and satisfies the 'select at least one source' validation.
> - Risk: `--code-repo` without `--mixedbread-store` causes each such source to fail with an explicit error rather than being silently skipped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08e3d71.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->