### PR TITLE
feat(packages): add launchk and document external Rust tool house style

### DIFF
--- a/agent-context/sections/13-dependency-intake.md
+++ b/agent-context/sections/13-dependency-intake.md
@@ -46,3 +46,35 @@ hashes, and metadata catalogs for search or browsing surfaces.
 
 Repository examples should consume those shared surfaces. Repeating URLs and
 hashes in examples creates second owners with no update story.
+
+### Packaging external Rust CLI/TUI tools
+
+Build a standalone third-party Rust binary with `pkgs.rustPlatform.buildRustPackage`
+in `packages/<name>/default.nix`, paired with a `package.nix` that carries `id`
+and the systems it builds on. Reserve [`ix.cargoUnit`](lib/cargo-unit.nix) for
+crates inside the shared workspace: its per-unit graph, nightly `RUSTC_BOOTSTRAP`,
+and workspace policy cost more than one outside tool returns, and its
+content-addressed dedup is off on macOS.
+
+Pin the source in the derivation with `pkgs.fetchFromGitHub` at a git rev. A
+flake input (the [`packages/llm-clippy`](packages/llm-clippy) shape) earns its
+top-level slot only when the source is shared across consumers or wants
+`nix flake update`. A one-off tool keeps its owner local in `default.nix`, and
+the package registry still discovers the directory.
+
+When upstream commits a `Cargo.lock`, read it with
+`cargoLock.lockFile = src + "/Cargo.lock"` so a rev bump carries the dependency
+set. Reach for `cargoHash` only when there is no committed lock. `cargoSha256`
+is banned.
+
+Two quirks recur in macOS Rust tools, each with one fix:
+- A crate that runs `bindgen` for FFI bindings needs `rustPlatform.bindgenHook`
+  in `nativeBuildInputs` for libclang.
+- A crate that reads VCS state at build time (`git_version!()`, `vergen`) fails
+  in the sandbox because the fetched tarball has no `.git`. Patch the call out in
+  `postPatch`, e.g. `--replace-fail "git_version!()" 'env!("CARGO_PKG_VERSION")'`.
+
+Set `strictDeps = true`, a typed `meta.license`, `meta.mainProgram`, and
+`meta.platforms`. A platform-bound tool gates both `meta.platforms` and the
+`package.nix` systems so `nix flake check` does not force it off-platform.
+[`packages/launchk`](packages/launchk) (Darwin-only) is the reference.

--- a/packages/launchk/default.nix
+++ b/packages/launchk/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+# Reference package for the external-Rust-tool house style: a standalone
+# third-party binary built from a pinned `fetchFromGitHub` rev with
+# `rustPlatform.buildRustPackage`. See `agent-context/sections/13-dependency-intake.md`.
+let
+  src = fetchFromGitHub {
+    owner = "mach-kernel";
+    repo = "launchk";
+    rev = "6f5f09e0dfa3fea662e859de5d7d49ac09a9dbe6";
+    hash = "sha256-yZZGCPul1Q8KBgFIG9qkevnOxqnRbK8sqIu5OUPPTFQ=";
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "launchk";
+  # No upstream release tag past the crate version; pin to the master rev with
+  # the nixpkgs unstable-version spelling so a bump reads as a dated change.
+  version = "0.3.1-unstable-2025-06-07";
+
+  inherit src;
+
+  # launchk commits a pure-crates.io Cargo.lock, so read it straight from the
+  # source: a rev bump carries the dependency set with no checked-in lock to
+  # drift and no coarse cargoHash to refresh by hand.
+  cargoLock.lockFile = src + "/Cargo.lock";
+
+  strictDeps = true;
+
+  # xpc-sys generates the XPC framework bindings with bindgen, which needs
+  # libclang on the build host.
+  nativeBuildInputs = [ rustPlatform.bindgenHook ];
+
+  # `git_version!()` shells out to `git describe` at build time; the fetched
+  # tarball has no `.git`, so resolve the about-box string to the crate version
+  # instead. --replace-fail keeps this guard honest if upstream moves the call.
+  postPatch = ''
+    substituteInPlace launchk/src/main.rs \
+      --replace-fail "git_version!()" 'env!("CARGO_PKG_VERSION")'
+  '';
+
+  cargoBuildFlags = [
+    "-p"
+    "launchk"
+  ];
+  cargoTestFlags = [
+    "-p"
+    "launchk"
+  ];
+
+  meta = {
+    description = "Cursive TUI for observing launchd agents and daemons";
+    homepage = "https://github.com/mach-kernel/launchk";
+    license = lib.licenses.mit;
+    mainProgram = "launchk";
+    platforms = lib.platforms.darwin;
+  };
+}

--- a/packages/launchk/package.nix
+++ b/packages/launchk/package.nix
@@ -1,0 +1,15 @@
+{
+  id = "launchk";
+  # launchk observes launchd jobs over XPC, so it only builds on macOS (see
+  # meta.platforms in default.nix). Advertising the flake output or a non-darwin
+  # package-set attr makes `nix flake check` force a package nixpkgs refuses to
+  # evaluate off-platform, so gate both to Darwin.
+  packageSet.systems = [
+    "aarch64-darwin"
+    "x86_64-darwin"
+  ];
+  flake.systems = [
+    "aarch64-darwin"
+    "x86_64-darwin"
+  ];
+}


### PR DESCRIPTION
## Summary

Closes #377. Settles the house style for packaging standalone external Rust CLI/TUI tools, documents it in the generated agent docs, and adds [launchk](https://github.com/mach-kernel/launchk) as the worked reference.

**Decision.** A standalone third-party tool is built with `rustPlatform.buildRustPackage` in `packages/<name>/default.nix`, its source pinned in-derivation with `fetchFromGitHub` at a rev. A flake input is reserved for sources shared across consumers or wanting `nix flake update`. When upstream commits a `Cargo.lock`, read it with `cargoLock.lockFile = src + "/Cargo.lock"`; reach for `cargoHash` only when there is no lock. `ix.cargoUnit` stays reserved for crates inside the shared workspace: its per-unit graph, nightly `RUSTC_BOOTSTRAP`, and workspace policy cost more than one outside tool returns, and content-addressed dedup is off on macOS.

**launchk** (Darwin-only Cursive TUI over launchd/XPC):
- `rustPlatform.bindgenHook` supplies libclang for xpc-sys's bindgen FFI.
- `git_version!()` is patched out in `postPatch`: the `fetchFromGitHub` tarball has no `.git`, so the about-box string resolves to the crate version.
- `package.nix` gates both `packageSet.systems` and `flake.systems` to Darwin so `nix flake check` does not force it off-platform.

**Deviations from the issue's draft derivation:**
- `lib.licenses.mit`: the upstream LICENSE is MIT ("Copyright (c) 2021 David Stancu"), so the issue's `bsd3` is an error.
- `cargoLock.lockFile` over `cargoHash`: launchk ships a pure-crates.io lock, so a rev bump carries the dependency set with no opaque fixed-output hash to refresh by hand.

## Test plan

- [x] `nix build .#launchk` green on aarch64-darwin (cargoLock vendoring, bindgenHook, and the git_version postPatch all hold).
- [x] `packages.aarch64-darwin.launchk` evaluates; `packages.x86_64-linux.launchk` is gated out.
- [x] `nix run .#lint` clean for the three files.
- [x] Binary loads and links (`otool -L` clean); panics only at the no-TTY boundary in a pipe, as expected for a Cursive TUI.
- [ ] CI: `nix flake check` on x86_64-linux (not buildable on this Darwin host).

_Authored with AI (Claude Opus 4.8)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `launchk` package and document house style for external Rust tools
> - Adds [packages/launchk/default.nix](https://github.com/indexable-inc/index/pull/518/files#diff-beec2c391e0f97e4412f6da3b7890500c2194f6fb2adc42f5f9ab61dac9bdce0) to build the `launchk` Darwin TUI binary using `rustPlatform.buildRustPackage`, pinned to a specific GitHub rev with `cargoLock.lockFile` for dependency handling.
> - Applies a `postPatch` to replace `git_version!()` macro calls with `env!("CARGO_PKG_VERSION")` so the build works without git metadata, and adds `bindgenHook` to support bindgen.
> - Gates the package to `aarch64-darwin` and `x86_64-darwin` only via [packages/launchk/package.nix](https://github.com/indexable-inc/index/pull/518/files#diff-587aea47c0105778c6f9e8c94126b38e083bbcba022f5d4be97906ec11abb51b).
> - Documents the established conventions for packaging external Rust CLI/TUI tools in [agent-context/sections/13-dependency-intake.md](https://github.com/indexable-inc/index/pull/518/files#diff-830e6f04026126c1cfd2867c2e239116786297a2733e5e8c975fe1be90ed158b), including source pinning, Cargo.lock handling, banning `cargoSha256`, and macOS-specific quirks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b948fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->