### PR TITLE
feat(indexer): multi-user fleet mode (index every account's history)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,6 +2801,7 @@ dependencies = [
  "source-linear",
  "source-meta",
  "source-slack",
+ "tempfile",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,6 +1050,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu 0.9.1",
+ "tempfile",
 ]
 
 [[package]]
@@ -2789,6 +2790,7 @@ dependencies = [
  "clap",
  "dirs",
  "mixedbread",
+ "nix 0.30.1",
  "search-core",
  "sink-mixedbread",
  "sink-parquet",

--- a/packages/indexer/Cargo.toml
+++ b/packages/indexer/Cargo.toml
@@ -29,3 +29,6 @@ clap = { workspace = true, features = ["derive", "env"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 dirs.workspace = true
 nix = { workspace = true, features = ["hostname"] }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/packages/indexer/Cargo.toml
+++ b/packages/indexer/Cargo.toml
@@ -28,3 +28,4 @@ anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 dirs.workspace = true
+nix = { workspace = true, features = ["hostname"] }

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -7,7 +7,7 @@
 //! [`sink_parquet`] sink. Pass `--mixedbread-store` and/or `--bucket` to enable a
 //! sink, and one or more source flags to choose what to ingest.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::Context as _;
@@ -86,6 +86,18 @@ struct Cli {
     /// Mixedbread only (code lives in git, not the parquet archive); repeatable.
     #[arg(long = "code-repo")]
     code_repos: Vec<PathBuf>,
+
+    /// Index one user's local history (claude, codex, atuin) by `NAME:HOME`,
+    /// repeatable. One process indexes many users — the fleet runs this as root
+    /// over every account — tagging each user's records with `NAME`. Symlinked
+    /// history paths are skipped so a privileged run cannot be a confused deputy.
+    #[arg(long = "user", value_name = "NAME:HOME")]
+    users: Vec<String>,
+
+    /// Host name to tag `--user` records with. Defaults to the system hostname;
+    /// the fleet module passes the NixOS `networking.hostName`.
+    #[arg(long)]
+    host: Option<String>,
 }
 
 #[tokio::main]
@@ -109,20 +121,33 @@ async fn main() -> anyhow::Result<()> {
     if store.is_none() && parquet.is_none() {
         anyhow::bail!("nothing to do: pass --mixedbread-store and/or --bucket");
     }
+    if !any_source_selected(&cli) {
+        anyhow::bail!(
+            "no sources selected: pass --local, --user NAME:HOME, --claude-dir/--codex-file/--atuin-db/--slack-export/--linear-export/--git-repo, or --code-repo"
+        );
+    }
     let mixedbread = store.as_ref().zip(cli.mixedbread_store.as_deref());
 
     let (indexed, failures) = run_sources(&cli, mixedbread, parquet.as_ref()).await;
 
-    let configured = indexed + failures;
-    if configured == 0 {
-        anyhow::bail!(
-            "no sources selected: pass --local and/or --claude-dir/--codex-file/--atuin-db/--slack-export/--linear-export/--git-repo/--code-repo"
-        );
-    }
     if failures > 0 {
-        anyhow::bail!("{failures} of {configured} source(s) failed; {indexed} succeeded");
+        anyhow::bail!("{failures} of {} source(s) failed; {indexed} succeeded", indexed + failures);
     }
     Ok(())
+}
+
+/// Whether any source flag was given (a config check, independent of how many
+/// records each source ends up producing).
+fn any_source_selected(cli: &Cli) -> bool {
+    cli.local
+        || cli.claude_dir.is_some()
+        || cli.codex_file.is_some()
+        || cli.atuin_db.is_some()
+        || cli.slack_export.is_some()
+        || cli.linear_export.is_some()
+        || !cli.git_repos.is_empty()
+        || !cli.code_repos.is_empty()
+        || !cli.users.is_empty()
 }
 
 /// Resolve the selected sources and run each one independently (a failure never
@@ -200,7 +225,142 @@ async fn run_sources(
         let result = index_code(&label, repo_dir, mixedbread).await;
         record(&label, result, &mut indexed, &mut failures);
     }
+    if !cli.users.is_empty() {
+        run_users(cli, mixedbread, parquet, &mut indexed, &mut failures).await;
+    }
     (indexed, failures)
+}
+
+/// Run the `--user NAME:HOME` multi-user phase, accumulating into the shared
+/// counters. Split out of [`run_sources`] to keep each function focused.
+async fn run_users(
+    cli: &Cli,
+    mixedbread: Option<(&MixedbreadStore, &str)>,
+    parquet: Option<&sink_parquet::Config>,
+    indexed: &mut usize,
+    failures: &mut usize,
+) {
+    let host = match resolve_host(cli) {
+        Ok(host) => host,
+        Err(error) => {
+            // Without a host tag every claude/codex record would be mislabeled,
+            // so fail the whole multi-user phase rather than emit wrong metadata.
+            eprintln!("[users] failed to resolve host: {error:#}");
+            *failures += cli.users.len();
+            return;
+        }
+    };
+    for spec in &cli.users {
+        match parse_user(spec) {
+            Ok((name, home)) => {
+                index_user(&name, &home, &host, mixedbread, parquet, indexed, failures).await;
+            }
+            Err(error) => {
+                eprintln!("[users] bad --user spec: {error:#}");
+                *failures += 1;
+            }
+        }
+    }
+}
+
+/// Index one user's local agent and shell history (claude, codex, atuin),
+/// reading under `home` and tagging records with `name` and `host`.
+///
+/// Designed for the privileged fleet run: it never follows a symlinked history
+/// path (the claude adapter's traversal refuses inner symlinks; the codex/atuin
+/// single files are gated by [`is_regular_file`]), so a user-planted symlink
+/// cannot redirect a root read at another account's files. Absent sources are
+/// skipped; a parse failure in one source is recorded but does not abort the
+/// others.
+async fn index_user(
+    name: &str,
+    home: &Path,
+    host: &str,
+    mixedbread: Option<(&MixedbreadStore, &str)>,
+    parquet: Option<&sink_parquet::Config>,
+    indexed: &mut usize,
+    failures: &mut usize,
+) {
+    // The claude adapter follows the explicitly named root (a user's
+    // `~/.claude/projects` is itself a symlink in some setups) but refuses every
+    // symlink inside the tree, so passing the directory is safe even as root.
+    let claude_dir = home.join(".claude").join("projects");
+    if claude_dir.is_dir() {
+        let label = format!("claude:{name}");
+        let parquet = user_parquet(parquet, name);
+        let result = async {
+            let adapter = source_claude::ClaudeHistoryExport::open_with(&claude_dir, host, name)
+                .with_context(|| format!("parsing Claude transcripts for {name} at {}", claude_dir.display()))?;
+            run_source(&label, &adapter, mixedbread, parquet.as_ref()).await
+        }
+        .await;
+        record(&label, result, indexed, failures);
+    }
+
+    let codex_file = home.join(".codex").join("history.jsonl");
+    if is_regular_file(&codex_file) {
+        let label = format!("codex:{name}");
+        let parquet = user_parquet(parquet, name);
+        let result = async {
+            let adapter = source_codex::CodexHistory::open_with(&codex_file, host, name)
+                .with_context(|| format!("parsing Codex history for {name} at {}", codex_file.display()))?;
+            run_source(&label, &adapter, mixedbread, parquet.as_ref()).await
+        }
+        .await;
+        record(&label, result, indexed, failures);
+    }
+
+    // atuin records its own `host`/`user` in each row, so it self-tags per user
+    // regardless of who runs the process; the file is still symlink-gated.
+    let atuin_db = home.join(".local").join("share").join("atuin").join("history.db");
+    if is_regular_file(&atuin_db) {
+        let label = format!("shell:{name}");
+        let parquet = user_parquet(parquet, name);
+        let result = async {
+            let adapter = source_atuin::AtuinHistory::open(&atuin_db)
+                .with_context(|| format!("reading atuin history for {name} at {}", atuin_db.display()))?;
+            run_source(&label, &adapter, mixedbread, parquet.as_ref()).await
+        }
+        .await;
+        record(&label, result, indexed, failures);
+    }
+}
+
+/// Parse a `NAME:HOME` user spec. The name is everything before the first colon;
+/// both parts must be non-empty.
+fn parse_user(spec: &str) -> anyhow::Result<(String, PathBuf)> {
+    let (name, home) =
+        spec.split_once(':').with_context(|| format!("--user must be NAME:HOME, got {spec:?}"))?;
+    anyhow::ensure!(!name.is_empty(), "--user NAME must be non-empty in {spec:?}");
+    anyhow::ensure!(!home.is_empty(), "--user HOME must be non-empty in {spec:?}");
+    Ok((name.to_owned(), PathBuf::from(home)))
+}
+
+/// A per-user parquet config: partition each user's rows under `user=<name>` so
+/// concurrently indexed users never overwrite the one shared per-source file.
+fn user_parquet(config: Option<&sink_parquet::Config>, name: &str) -> Option<sink_parquet::Config> {
+    config.map(|config| sink_parquet::Config {
+        prefix: format!("{}/user={name}", config.prefix),
+        ..config.clone()
+    })
+}
+
+/// True only for a present, regular file that is not a symlink. Uses
+/// `symlink_metadata` so a user-planted symlink at a history path cannot redirect
+/// a privileged read at another account's files (the confused-deputy class; see
+/// ix `history-ship`).
+fn is_regular_file(path: &Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok_and(|meta| meta.is_file())
+}
+
+/// The host name to tag `--user` records with: the `--host` override, else the
+/// system hostname.
+fn resolve_host(cli: &Cli) -> anyhow::Result<String> {
+    if let Some(host) = &cli.host {
+        return Ok(host.clone());
+    }
+    let raw = nix::unistd::gethostname().context("resolving the system host name")?;
+    Ok(raw.to_string_lossy().into_owned())
 }
 
 /// Index one code checkout via search-core's content-addressed reconcile

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -138,7 +138,7 @@ async fn main() -> anyhow::Result<()> {
 
 /// Whether any source flag was given (a config check, independent of how many
 /// records each source ends up producing).
-fn any_source_selected(cli: &Cli) -> bool {
+const fn any_source_selected(cli: &Cli) -> bool {
     cli.local
         || cli.claude_dir.is_some()
         || cli.codex_file.is_some()
@@ -245,8 +245,9 @@ async fn run_users(
         Err(error) => {
             // Without a host tag every claude/codex record would be mislabeled,
             // so fail the whole multi-user phase rather than emit wrong metadata.
-            eprintln!("[users] failed to resolve host: {error:#}");
-            *failures += cli.users.len();
+            // Count it as one phase failure (no per-user work ran).
+            eprintln!("[users] failed to resolve host, skipping all --user sources: {error:#}");
+            *failures += 1;
             return;
         }
     };
@@ -266,12 +267,12 @@ async fn run_users(
 /// Index one user's local agent and shell history (claude, codex, atuin),
 /// reading under `home` and tagging records with `name` and `host`.
 ///
-/// Designed for the privileged fleet run: it never follows a symlinked history
-/// path (the claude adapter's traversal refuses inner symlinks; the codex/atuin
-/// single files are gated by [`is_regular_file`]), so a user-planted symlink
-/// cannot redirect a root read at another account's files. Absent sources are
-/// skipped; a parse failure in one source is recorded but does not abort the
-/// others.
+/// Designed for the privileged fleet run. Every history path is resolved with
+/// [`safe_path_under`], which refuses to follow a symlink at any user-controlled
+/// component, so a planted symlink cannot redirect a root read at another
+/// account's files (the claude adapter additionally refuses symlinks inside its
+/// tree). Absent sources are skipped; a parse failure in one source is recorded
+/// but does not abort the others.
 async fn index_user(
     name: &str,
     home: &Path,
@@ -281,13 +282,9 @@ async fn index_user(
     indexed: &mut usize,
     failures: &mut usize,
 ) {
-    // The claude adapter follows the explicitly named root (a user's
-    // `~/.claude/projects` is itself a symlink in some setups) but refuses every
-    // symlink inside the tree, so passing the directory is safe even as root.
-    let claude_dir = home.join(".claude").join("projects");
-    if claude_dir.is_dir() {
+    if let Some(claude_dir) = safe_path_under(home, &[".claude", "projects"], true) {
         let label = format!("claude:{name}");
-        let parquet = user_parquet(parquet, name);
+        let parquet = parquet.map(|config| user_parquet(config, name));
         let result = async {
             let adapter = source_claude::ClaudeHistoryExport::open_with(&claude_dir, host, name)
                 .with_context(|| format!("parsing Claude transcripts for {name} at {}", claude_dir.display()))?;
@@ -297,10 +294,9 @@ async fn index_user(
         record(&label, result, indexed, failures);
     }
 
-    let codex_file = home.join(".codex").join("history.jsonl");
-    if is_regular_file(&codex_file) {
+    if let Some(codex_file) = safe_path_under(home, &[".codex", "history.jsonl"], false) {
         let label = format!("codex:{name}");
-        let parquet = user_parquet(parquet, name);
+        let parquet = parquet.map(|config| user_parquet(config, name));
         let result = async {
             let adapter = source_codex::CodexHistory::open_with(&codex_file, host, name)
                 .with_context(|| format!("parsing Codex history for {name} at {}", codex_file.display()))?;
@@ -311,11 +307,10 @@ async fn index_user(
     }
 
     // atuin records its own `host`/`user` in each row, so it self-tags per user
-    // regardless of who runs the process; the file is still symlink-gated.
-    let atuin_db = home.join(".local").join("share").join("atuin").join("history.db");
-    if is_regular_file(&atuin_db) {
+    // regardless of who runs the process.
+    if let Some(atuin_db) = safe_path_under(home, &[".local", "share", "atuin", "history.db"], false) {
         let label = format!("shell:{name}");
-        let parquet = user_parquet(parquet, name);
+        let parquet = parquet.map(|config| user_parquet(config, name));
         let result = async {
             let adapter = source_atuin::AtuinHistory::open(&atuin_db)
                 .with_context(|| format!("reading atuin history for {name} at {}", atuin_db.display()))?;
@@ -333,24 +328,58 @@ fn parse_user(spec: &str) -> anyhow::Result<(String, PathBuf)> {
         spec.split_once(':').with_context(|| format!("--user must be NAME:HOME, got {spec:?}"))?;
     anyhow::ensure!(!name.is_empty(), "--user NAME must be non-empty in {spec:?}");
     anyhow::ensure!(!home.is_empty(), "--user HOME must be non-empty in {spec:?}");
+    // NAME becomes a metadata tag and a `user=<name>` parquet partition segment,
+    // so keep it to a safe charset (no `/` or `=` that could cross partitions).
+    anyhow::ensure!(
+        name.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')),
+        "--user NAME must be ascii alphanumeric plus `.`/`_`/`-`, got {name:?}"
+    );
     Ok((name.to_owned(), PathBuf::from(home)))
 }
 
 /// A per-user parquet config: partition each user's rows under `user=<name>` so
 /// concurrently indexed users never overwrite the one shared per-source file.
-fn user_parquet(config: Option<&sink_parquet::Config>, name: &str) -> Option<sink_parquet::Config> {
-    config.map(|config| sink_parquet::Config {
+fn user_parquet(config: &sink_parquet::Config, name: &str) -> sink_parquet::Config {
+    sink_parquet::Config {
         prefix: format!("{}/user={name}", config.prefix),
         ..config.clone()
-    })
+    }
 }
 
-/// True only for a present, regular file that is not a symlink. Uses
-/// `symlink_metadata` so a user-planted symlink at a history path cannot redirect
-/// a privileged read at another account's files (the confused-deputy class; see
-/// ix `history-ship`).
-fn is_regular_file(path: &Path) -> bool {
-    std::fs::symlink_metadata(path).is_ok_and(|meta| meta.is_file())
+/// Resolve a user-controlled subpath under a trusted `home`, refusing to follow
+/// a symlink at any component. Returns the joined path only if every component in
+/// `rel` is a real (non-symlink) entry — intermediate ones directories, and the
+/// final one matching `want_dir` (a directory) or `!want_dir` (a regular file).
+///
+/// `home` comes from the system user database and is trusted; everything under
+/// it is attacker-controlled when this runs as root over other accounts. lstat'ing
+/// every component (not just the leaf) is what stops a planted symlink — at the
+/// root, an ancestor, or the leaf — from redirecting the read at another
+/// account's files (the confused-deputy class; see ix `history-ship`).
+///
+/// A narrow TOCTOU remains: a component could be swapped for a symlink between
+/// this check and the adapter's open. That residual race matches `history-ship`'s
+/// posture and is tracked for a shared `openat2(RESOLVE_NO_SYMLINKS)` hardening
+/// across both readers.
+fn safe_path_under(home: &Path, rel: &[&str], want_dir: bool) -> Option<PathBuf> {
+    let last = rel.len().checked_sub(1)?;
+    let mut path = home.to_path_buf();
+    for (index, component) in rel.iter().enumerate() {
+        path.push(component);
+        let meta = std::fs::symlink_metadata(&path).ok()?;
+        if meta.file_type().is_symlink() {
+            return None;
+        }
+        let ok = if index == last {
+            if want_dir { meta.is_dir() } else { meta.is_file() }
+        } else {
+            meta.is_dir()
+        };
+        if !ok {
+            return None;
+        }
+    }
+    Some(path)
 }
 
 /// The host name to tag `--user` records with: the `--host` override, else the
@@ -431,4 +460,73 @@ async fn run_source<A: SourceAdapter + Sync>(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::expect_used, reason = "tests assert observable filesystem outcomes")]
+
+    use std::path::Path;
+
+    use super::{parse_user, safe_path_under};
+
+    #[test]
+    fn safe_path_accepts_real_nested_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(temp.path().join(".claude").join("projects")).expect("mkdir");
+        assert!(safe_path_under(temp.path(), &[".claude", "projects"], true).is_some());
+    }
+
+    #[test]
+    fn safe_path_rejects_symlinked_leaf() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path();
+        std::fs::create_dir_all(home.join(".codex")).expect("mkdir");
+        let secret = home.join("secret");
+        std::fs::write(&secret, b"x").expect("write");
+        std::os::unix::fs::symlink(&secret, home.join(".codex").join("history.jsonl")).expect("symlink");
+        assert!(safe_path_under(home, &[".codex", "history.jsonl"], false).is_none());
+    }
+
+    #[test]
+    fn safe_path_rejects_symlinked_ancestor() {
+        // The privileged threat: a user points an ancestor component at another
+        // tree so the root process reads through it.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path();
+        let victim = home.join("victim");
+        std::fs::create_dir_all(victim.join("projects")).expect("mkdir");
+        std::fs::write(victim.join("projects").join("s.jsonl"), b"{}").expect("write");
+        std::os::unix::fs::symlink(&victim, home.join(".claude")).expect("symlink");
+        assert!(
+            safe_path_under(home, &[".claude", "projects"], true).is_none(),
+            "a symlinked ancestor component must be rejected"
+        );
+    }
+
+    #[test]
+    fn safe_path_missing_is_none() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        assert!(safe_path_under(temp.path(), &[".codex", "history.jsonl"], false).is_none());
+    }
+
+    #[test]
+    fn safe_path_rejects_wrong_kind() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(temp.path().join(".claude").join("projects")).expect("mkdir");
+        // `projects` is a directory, but a file was requested.
+        assert!(safe_path_under(temp.path(), &[".claude", "projects"], false).is_none());
+    }
+
+    #[test]
+    fn parse_user_validates_name_and_spec() {
+        assert!(parse_user("a/b:/home/x").is_err(), "slash in name");
+        assert!(parse_user("a=b:/home/x").is_err(), "equals in name");
+        assert!(parse_user(":/home/x").is_err(), "empty name");
+        assert!(parse_user("alice:").is_err(), "empty home");
+        assert!(parse_user("noseparator").is_err(), "missing colon");
+        let (name, home) = parse_user("alice-1.2_3:/home/alice").expect("valid spec");
+        assert_eq!(name, "alice-1.2_3");
+        assert_eq!(home, Path::new("/home/alice"));
+    }
 }

--- a/packages/source/claude/Cargo.toml
+++ b/packages/source/claude/Cargo.toml
@@ -18,3 +18,4 @@ nix = { workspace = true, features = ["hostname"] }
 
 [dev-dependencies]
 serde_json.workspace = true
+tempfile.workspace = true

--- a/packages/source/claude/src/error.rs
+++ b/packages/source/claude/src/error.rs
@@ -9,6 +9,16 @@ use snafu::Snafu;
 #[snafu(visibility(pub(crate)))]
 #[non_exhaustive]
 pub enum Error {
+    /// A directory under the history root could not be read (a missing directory
+    /// is not an error; a permission or I/O fault is).
+    #[snafu(display("failed to read directory {}", path.display()))]
+    ReadDir {
+        /// Directory that could not be read.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
     /// A transcript file could not be read.
     #[snafu(display("failed to read transcript {}", path.display()))]
     ReadFile {

--- a/packages/source/claude/src/error.rs
+++ b/packages/source/claude/src/error.rs
@@ -9,15 +9,6 @@ use snafu::Snafu;
 #[snafu(visibility(pub(crate)))]
 #[non_exhaustive]
 pub enum Error {
-    /// A directory under the history root could not be listed.
-    #[snafu(display("failed to list directory {}", path.display()))]
-    ListDir {
-        /// Directory that could not be read.
-        path: PathBuf,
-        /// Underlying I/O error.
-        source: std::io::Error,
-    },
-
     /// A transcript file could not be read.
     #[snafu(display("failed to read transcript {}", path.display()))]
     ReadFile {

--- a/packages/source/claude/src/lib.rs
+++ b/packages/source/claude/src/lib.rs
@@ -21,7 +21,6 @@ mod error;
 mod record;
 mod transcript;
 
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use source_meta::{Document, Source, SourceAdapter};
@@ -29,7 +28,7 @@ use snafu::ResultExt as _;
 
 pub use crate::error::Error;
 pub use crate::record::Message;
-use crate::error::{HostNameSnafu, ListDirSnafu, Result};
+use crate::error::{HostNameSnafu, Result};
 use crate::record::MessageOrigin;
 
 /// The `source` tag every Claude transcript document carries.
@@ -56,8 +55,7 @@ impl ClaudeHistoryExport {
     /// read, or a line is not valid JSON.
     pub fn open_with(dir: &Path, host: &str, user: &str) -> Result<Self> {
         let mut files = Vec::new();
-        let mut visited = HashSet::new();
-        collect_transcripts(dir, &mut files, &mut visited)?;
+        collect_transcripts(dir, &mut files);
 
         let mut messages = Vec::new();
         for file in files {
@@ -117,38 +115,40 @@ impl SourceAdapter for ClaudeHistoryExport {
 
 /// Recursively collect `*.jsonl` transcript files under `dir`.
 ///
-/// Symlinks are followed because Claude's history directory is itself a symlink
-/// in some setups (`~/.claude/projects` points at the real store). `visited`
-/// holds the canonical path of every directory already entered, so a symlink
-/// cycle is broken instead of recursing forever. This is for the intended
-/// unprivileged, single-user run, reading only the invoking user's own files; a
-/// privileged or multi-user shipper must additionally reject symlinks with
-/// `O_NOFOLLOW` to avoid the confused-deputy class (see ix `history-ship`'s
-/// symlink finding).
-fn collect_transcripts(
-    dir: &Path,
-    out: &mut Vec<PathBuf>,
-    visited: &mut HashSet<PathBuf>,
-) -> Result<()> {
-    let canonical = std::fs::canonicalize(dir).context(ListDirSnafu { path: dir.to_path_buf() })?;
-    if !visited.insert(canonical) {
-        // Already walked this real directory (a symlink pointed back into the
-        // tree); stop rather than loop.
-        return Ok(());
-    }
-
-    let entries = std::fs::read_dir(dir).context(ListDirSnafu { path: dir.to_path_buf() })?;
-    for entry in entries {
-        let entry = entry.context(ListDirSnafu { path: dir.to_path_buf() })?;
+/// The top-level `dir` is followed even when it is a symlink: the operator names
+/// it explicitly, and `~/.claude/projects` is itself a symlink in some setups
+/// (it points at the real store). Inside the tree, symlinks are never followed —
+/// both symlinked directories and symlinked files are skipped. This matters when
+/// the indexer runs privileged across many users' homes (`CAP_DAC_READ_SEARCH`
+/// on the fleet): a user-planted symlink must not redirect a read at another
+/// account's files (the confused-deputy class; see ix `history-ship`'s symlink
+/// finding). No-follow traversal also means there are no symlink cycles to break.
+///
+/// A missing or unreadable directory yields nothing rather than an error.
+/// Absence is normal: most homes have no Claude history, and the privileged
+/// fleet run walks many of them. This mirrors `history-ship`'s candidate
+/// enumeration.
+fn collect_transcripts(dir: &Path, out: &mut Vec<PathBuf>) {
+    // `read_dir` follows a symlinked `dir` (the explicitly named root); the
+    // per-entry `file_type` below reports the entry itself without following, so
+    // nothing reached through the tree can be a symlink.
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
         let path = entry.path();
-        let metadata = std::fs::metadata(&path).context(ListDirSnafu { path: path.clone() })?;
-        if metadata.is_dir() {
-            collect_transcripts(&path, out, visited)?;
-        } else if metadata.is_file() && path.extension().is_some_and(|ext| ext == "jsonl") {
+        if file_type.is_dir() {
+            collect_transcripts(&path, out);
+        } else if file_type.is_file() && path.extension().is_some_and(|ext| ext == "jsonl") {
             out.push(path);
         }
     }
-    Ok(())
 }
 
 /// Derive a file's fallback identity tags: project from the parent directory
@@ -185,4 +185,86 @@ fn os_user() -> String {
     std::env::var("USER")
         .or_else(|_| std::env::var("LOGNAME"))
         .unwrap_or_else(|_| "unknown".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::expect_used, reason = "tests assert observable filesystem outcomes")]
+
+    use std::path::{Path, PathBuf};
+
+    use super::collect_transcripts;
+
+    fn collect(dir: &Path) -> Vec<PathBuf> {
+        let mut out = Vec::new();
+        collect_transcripts(dir, &mut out);
+        out.sort();
+        out
+    }
+
+    #[test]
+    fn missing_dir_yields_nothing() {
+        assert!(collect(Path::new("/nonexistent-claude-root-xyz")).is_empty());
+    }
+
+    #[test]
+    fn finds_nested_transcripts() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let nested = temp.path().join("proj").join("sess");
+        std::fs::create_dir_all(&nested).expect("mkdir");
+        std::fs::write(nested.join("a.jsonl"), b"{}").expect("write a");
+        std::fs::write(temp.path().join("b.jsonl"), b"{}").expect("write b");
+        std::fs::write(temp.path().join("notes.txt"), b"x").expect("write notes");
+
+        let found = collect(temp.path());
+        assert_eq!(found.len(), 2, "only .jsonl files, collected recursively");
+        assert!(found.iter().all(|path| path.extension().is_some_and(|ext| ext == "jsonl")));
+    }
+
+    #[test]
+    fn symlinked_leaf_transcript_is_skipped() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        // Stands in for a sensitive target the privileged walk must not follow.
+        let secret = temp.path().join("secret-target");
+        std::fs::write(&secret, b"{}").expect("write secret");
+        std::os::unix::fs::symlink(&secret, temp.path().join("leak.jsonl")).expect("symlink");
+        std::fs::write(temp.path().join("real.jsonl"), b"{}").expect("write real");
+
+        let found = collect(temp.path());
+        assert_eq!(found.len(), 1, "the symlinked transcript must not be collected");
+        assert_eq!(found[0].file_name().and_then(|name| name.to_str()), Some("real.jsonl"));
+    }
+
+    #[test]
+    fn symlinked_subdir_is_not_descended() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        // A tree outside the root that a user-planted directory symlink could
+        // otherwise redirect the privileged walk into.
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(&outside).expect("mkdir outside");
+        std::fs::write(outside.join("secret.jsonl"), b"{}").expect("write secret");
+
+        let root = temp.path().join("root");
+        std::fs::create_dir_all(&root).expect("mkdir root");
+        std::os::unix::fs::symlink(&outside, root.join("link")).expect("symlink");
+        std::fs::write(root.join("real.jsonl"), b"{}").expect("write real");
+
+        let found = collect(&root);
+        assert_eq!(found.len(), 1, "files under a symlinked subdir must not be collected");
+        assert_eq!(found[0].file_name().and_then(|name| name.to_str()), Some("real.jsonl"));
+    }
+
+    #[test]
+    fn top_level_symlinked_root_is_followed() {
+        // The user's own ~/.claude/projects is a symlink to the real store, so
+        // the explicitly named root must still be read.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let real = temp.path().join("real-store");
+        std::fs::create_dir_all(&real).expect("mkdir real");
+        std::fs::write(real.join("s.jsonl"), b"{}").expect("write s");
+        let link = temp.path().join("projects");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        assert_eq!(collect(&link).len(), 1, "a symlinked root is followed");
+    }
 }

--- a/packages/source/claude/src/lib.rs
+++ b/packages/source/claude/src/lib.rs
@@ -28,7 +28,7 @@ use snafu::ResultExt as _;
 
 pub use crate::error::Error;
 pub use crate::record::Message;
-use crate::error::{HostNameSnafu, Result};
+use crate::error::{HostNameSnafu, ReadDirSnafu, Result};
 use crate::record::MessageOrigin;
 
 /// The `source` tag every Claude transcript document carries.
@@ -55,7 +55,7 @@ impl ClaudeHistoryExport {
     /// read, or a line is not valid JSON.
     pub fn open_with(dir: &Path, host: &str, user: &str) -> Result<Self> {
         let mut files = Vec::new();
-        collect_transcripts(dir, &mut files);
+        collect_transcripts(dir, &mut files)?;
 
         let mut messages = Vec::new();
         for file in files {
@@ -115,40 +115,46 @@ impl SourceAdapter for ClaudeHistoryExport {
 
 /// Recursively collect `*.jsonl` transcript files under `dir`.
 ///
-/// The top-level `dir` is followed even when it is a symlink: the operator names
-/// it explicitly, and `~/.claude/projects` is itself a symlink in some setups
-/// (it points at the real store). Inside the tree, symlinks are never followed —
-/// both symlinked directories and symlinked files are skipped. This matters when
-/// the indexer runs privileged across many users' homes (`CAP_DAC_READ_SEARCH`
-/// on the fleet): a user-planted symlink must not redirect a read at another
-/// account's files (the confused-deputy class; see ix `history-ship`'s symlink
-/// finding). No-follow traversal also means there are no symlink cycles to break.
+/// The top-level `dir` is followed even when it is a symlink: callers name it
+/// explicitly, and `~/.claude/projects` is itself a symlink in some setups (it
+/// points at the real store). Inside the tree, symlinks are never followed —
+/// both symlinked directories and symlinked files are skipped — so a symlink
+/// planted *within* a transcript tree cannot redirect the read. No-follow
+/// traversal also means there are no symlink cycles to break.
 ///
-/// A missing or unreadable directory yields nothing rather than an error.
-/// Absence is normal: most homes have no Claude history, and the privileged
-/// fleet run walks many of them. This mirrors `history-ship`'s candidate
-/// enumeration.
-fn collect_transcripts(dir: &Path, out: &mut Vec<PathBuf>) {
+/// This does NOT vet the root or its ancestor directories. When running
+/// privileged over other accounts' homes (`CAP_DAC_READ_SEARCH` on the fleet),
+/// the caller must ensure the root path has no symlinked component, or a user
+/// could point the root itself at another account's files (the confused-deputy
+/// class; see ix `history-ship`'s symlink finding). The indexer does this with
+/// its `safe_path_under` resolver before calling in.
+///
+/// A missing directory yields nothing; a permission or I/O fault is a real error
+/// (not a silently empty success). Absence is normal: most homes have no Claude
+/// history, and the privileged fleet run walks many of them.
+fn collect_transcripts(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
     // `read_dir` follows a symlinked `dir` (the explicitly named root); the
     // per-entry `file_type` below reports the entry itself without following, so
     // nothing reached through the tree can be a symlink.
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error).context(ReadDirSnafu { path: dir.to_path_buf() }),
     };
-    for entry in entries.flatten() {
-        let Ok(file_type) = entry.file_type() else {
-            continue;
-        };
+    for entry in entries {
+        let entry = entry.context(ReadDirSnafu { path: dir.to_path_buf() })?;
+        let file_type = entry.file_type().context(ReadDirSnafu { path: dir.to_path_buf() })?;
         if file_type.is_symlink() {
             continue;
         }
         let path = entry.path();
         if file_type.is_dir() {
-            collect_transcripts(&path, out);
+            collect_transcripts(&path, out)?;
         } else if file_type.is_file() && path.extension().is_some_and(|ext| ext == "jsonl") {
             out.push(path);
         }
     }
+    Ok(())
 }
 
 /// Derive a file's fallback identity tags: project from the parent directory
@@ -197,7 +203,7 @@ mod tests {
 
     fn collect(dir: &Path) -> Vec<PathBuf> {
         let mut out = Vec::new();
-        collect_transcripts(dir, &mut out);
+        collect_transcripts(dir, &mut out).expect("collect");
         out.sort();
         out
     }

--- a/packages/source/codex/src/lib.rs
+++ b/packages/source/codex/src/lib.rs
@@ -5,10 +5,10 @@
 //! One [`Document`] per submitted **prompt**. Codex stores history as a flat
 //! append log of `{session_id, ts, text}` lines (default `~/.codex/history.jsonl`),
 //! so a record is one user prompt; there is no assistant side.
-//! `external_id = "codex:{session_id}:{seq}"`, where `seq` is the prompt's
-//! 0-based ordinal within its session in file order, so an append-only log
-//! re-ingests only its new prompts: the content-hash reconcile in `search-core`
-//! skips everything already uploaded.
+//! `external_id = "codex:{session_id}:{ts}:{content_hash}"`, so the id is stable
+//! under history compaction (it is content-derived, not positional): an
+//! append-only log re-ingests only its new prompts, and the content-hash
+//! reconcile in `search-core` skips everything already uploaded.
 //!
 //! # Tags
 //! Every document's flat metadata carries the common header (`source`,


### PR DESCRIPTION
One `indexer` process, run as root on the fleet, indexes every account's Claude/Codex/atuin history into the shared Mixedbread store.

- `--user NAME:HOME` (repeatable) + `--host`: tag each user's records; absent sources skipped; one user's failure doesn't abort the rest.
- Claude walk hardened for the privileged path: follows the named root (a user's `~/.claude/projects` is itself a symlink in some setups) but never follows a symlink inside the tree, so a planted symlink can't redirect a root read at another account's files. codex/atuin single files are `symlink_metadata`-gated. Mirrors `history-ship`'s confused-deputy defense, with tests.
- Parquet partitioned per user (`user=<name>`) so concurrent users don't clobber the shared per-source file.

Consumed by the ix `services.ix.indexer` fleet module (follow-up PR).

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add multi-user fleet mode to indexer to index every account's history
> - Adds `--user NAME:HOME` (repeatable) and `--host` CLI flags to [main.rs](https://github.com/indexable-inc/index/pull/519/files#diff-5664bac77cedfa678d477bb44bf07a8888bdbb1eb15055f1c164d6c9c131ce7d), enabling the indexer to process multiple users' local histories in a single run.
> - Each user's history is written to a `user=<name>` partitioned parquet prefix, with explicit host/user tags applied to Claude and Codex sources.
> - Symlink traversal is blocked at every path component when resolving per-user history locations; paths with symlinked components are skipped silently.
> - Symlinked files and subdirectories within the Claude history tree are also no longer followed; a missing root directory now yields no error instead of failing.
> - Risk: host resolution falls back to `gethostname()` by default — if hostname resolution fails, the entire multi-user phase is skipped and counted as a single failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ab0765.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->