### PR TITLE
refactor: migrate jq usage to jaq

### DIFF
--- a/.claude/hooks/agent-instructions.sh
+++ b/.claude/hooks/agent-instructions.sh
@@ -29,12 +29,12 @@ root=${CLAUDE_PROJECT_DIR:-}
 # for Claude Code, `codex-md` (AGENTS.md) for Codex.
 package=${1:-claude-md}
 
-# jq builds the JSON envelope and safely escapes the document. Prefer one on
+# jaq builds the JSON envelope and safely escapes the document. Prefer one on
 # PATH; fall back to nixpkgs so the hook works before direnv loads the devshell.
-if command -v jq >/dev/null 2>&1; then
-  jq() { command jq "$@"; }
+if command -v jaq >/dev/null 2>&1; then
+  jaq() { command jaq "$@"; }
 else
-  jq() { nix run nixpkgs#jq -- "$@"; }
+  jaq() { nix run nixpkgs#jaq -- "$@"; }
 fi
 
 doc=$(nix build --no-link --print-out-paths "$root#$package")
@@ -59,12 +59,12 @@ fi
 # Codex: emit the document as one value, no reloadSkills field its parser might
 # reject.
 if [ "$package" = codex-md ]; then
-  jq -n --rawfile additionalContext "$doc" \
+  jaq -n --rawfile additionalContext "$doc" \
     '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $additionalContext}}'
   exit 0
 fi
 
 # Claude Code: emit the core plus reloadSkills so the freshly repointed
 # .claude/skills is picked up this session.
-jq -n --rawfile additionalContext "$doc" \
+jaq -n --rawfile additionalContext "$doc" \
   '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $additionalContext, reloadSkills: true}}'

--- a/examples/hermes-agent/documents/SOUL.md
+++ b/examples/hermes-agent/documents/SOUL.md
@@ -2,7 +2,7 @@
 
 You are an operator inside an ix VM. You have root on this guest and a real NixOS system under you: systemd is PID 1, nushell is the default login shell, and the host CLI is not reachable from in here.
 
-The tooling that ships in the image is on PATH today: `nushell`, `gh`, `git`, `ripgrep`, `jq`, `btop`, the standard GNU utilities. For anything else, reach for `nix shell nixpkgs#<tool>`. This VM has effectively unbounded disk and the nixpkgs cache substitutes, so a fresh tool is one command away.
+The tooling that ships in the image is on PATH today: `nushell`, `gh`, `git`, `ripgrep`, `jaq`, `btop`, the standard GNU utilities. For anything else, reach for `nix shell nixpkgs#<tool>`. This VM has effectively unbounded disk and the nixpkgs cache substitutes, so a fresh tool is one command away.
 
 Constraints that survive an obvious-looking refactor:
 

--- a/images/dev/development-base/default.nix
+++ b/images/dev/development-base/default.nix
@@ -1,7 +1,7 @@
 # Default ix dev base image: agent CLIs plus a normal build toolchain.
 # The auto-enabled base profile (modules/profiles/base) supplies version
 # control, editors, the nushell workspace wrapper, gdb/lldb, strace, tcpdump,
-# jq, btop, bpftrace, lsof, ncdu, pv, file, and the gnutar/gzip/zstd trio
+# jaq, btop, bpftrace, lsof, ncdu, pv, file, and the gnutar/gzip/zstd trio
 # needed to stay `ix switch`-able.
 {
   ix,

--- a/images/dev/symphony-codex/default.nix
+++ b/images/dev/symphony-codex/default.nix
@@ -48,7 +48,7 @@
     pkgs.gnused
     pkgs.gnutar
     pkgs.gzip
-    pkgs.jq
+    pkgs.jaq
     pkgs.nodejs_24
     pkgs.openssh
     pkgs.pkg-config

--- a/lib/mutable-json.nix
+++ b/lib/mutable-json.nix
@@ -73,11 +73,11 @@ let
         ''
           ${pkgs.coreutils}/bin/mkdir -p "$(${pkgs.coreutils}/bin/dirname ${targetArg})" ${lib.escapeShellArg stateDir}
           # An absent (or unreadable) target/state file is treated as empty `{}`;
-          # malformed JSON in either makes jq fail below and aborts the switch
+          # malformed JSON in either makes jaq fail below and aborts the switch
           # rather than silently overwriting.
           _live=$([ -f ${targetArg} ] && ${pkgs.coreutils}/bin/cat ${targetArg} || ${pkgs.coreutils}/bin/echo '{}')
           _last=$([ -f ${stateArg} ] && ${pkgs.coreutils}/bin/cat ${stateArg} || ${pkgs.coreutils}/bin/echo '{}')
-          _merged=$(${pkgs.jq}/bin/jq -n \
+          _merged=$(${pkgs.jaq}/bin/jaq -n \
             --argjson last "$_last" \
             --argjson live "$_live" \
             --argjson new "$(${pkgs.coreutils}/bin/cat ${desired})" \

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -525,12 +525,12 @@ in
         # changed, prune a key Nix stopped declaring, and keep a sibling key
         # while a declared array is replaced atomically.
         mutable-json-merge =
-          pkgs.runCommand "mutable-json-merge-check" { nativeBuildInputs = [ pkgs.jq ]; }
+          pkgs.runCommand "mutable-json-merge-check" { nativeBuildInputs = [ pkgs.jaq ]; }
             ''
               prog=${ix.mutableJson.mergeProgram}
-              run() { jq -ncS --argjson last "$1" --argjson live "$2" --argjson new "$3" -f "$prog"; }
+              run() { jaq -ncS --argjson last "$1" --argjson live "$2" --argjson new "$3" -f "$prog"; }
               check() {
-                expected=$(printf '%s' "$2" | jq -cS .)
+                expected=$(printf '%s' "$2" | jaq -cS .)
                 if [ "$expected" != "$3" ]; then
                   echo "FAIL $1: expected $expected got $3" >&2
                   exit 1

--- a/lib/rust.nix
+++ b/lib/rust.nix
@@ -334,7 +334,7 @@ let
             {
               nativeBuildInputs = [
                 pkgs.cargo
-                pkgs.jq
+                pkgs.jaq
               ];
             }
             ''
@@ -343,13 +343,13 @@ let
 
               if [ -f "$tree/Cargo.toml" ]; then
                 crateCargoTOML=$(cargo metadata --format-version 1 --no-deps --manifest-path "$tree/Cargo.toml" | \
-                  jq -r '.packages[] | select(.name == "${pkg.name}") | .manifest_path' || :)
+                  jaq -r '.packages[] | select(.name == "${pkg.name}") | .manifest_path' || :)
               fi
 
               if [ -z "$crateCargoTOML" ]; then
                 while IFS= read -r manifest; do
                   crateCargoTOML=$(cargo metadata --format-version 1 --no-deps --manifest-path "$manifest" | \
-                    jq -r '.packages[] | select(.name == "${pkg.name}") | .manifest_path' || :)
+                    jaq -r '.packages[] | select(.name == "${pkg.name}") | .manifest_path' || :)
                   [ -n "$crateCargoTOML" ] && break
                 done < <(find "$tree" -name Cargo.toml)
               fi
@@ -364,7 +364,7 @@ let
               chmod -R u+w "$out"
 
               if grep -q workspace "$out/Cargo.toml"; then
-                ${lib.getExe replaceWorkspaceValues} "$out/Cargo.toml" "$(cargo metadata --format-version 1 --no-deps --manifest-path "$crateCargoTOML" | jq -r .workspace_root)/Cargo.toml"
+                ${lib.getExe replaceWorkspaceValues} "$out/Cargo.toml" "$(cargo metadata --format-version 1 --no-deps --manifest-path "$crateCargoTOML" | jaq -r .workspace_root)/Cargo.toml"
               fi
 
               printf '{"files":{},"package":null}' > "$out/.cargo-checksum.json"

--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -493,7 +493,7 @@ in
           helix
           htop
           micro
-          jq
+          jaq
           lldb
           lsof
           mgrep

--- a/modules/services/ci-runner/default.nix
+++ b/modules/services/ci-runner/default.nix
@@ -85,7 +85,7 @@ in
     packages = mkOption {
       type = types.listOf types.package;
       default = [ ];
-      example = lib.literalExpression "[ pkgs.gh pkgs.jq ]";
+      example = lib.literalExpression "[ pkgs.gh pkgs.jaq ]";
       description = ''
         Extra packages on each job's PATH, on top of the git, Nix, and Cachix
         tooling the module always provides.

--- a/packages/dag-runner/README.md
+++ b/packages/dag-runner/README.md
@@ -39,7 +39,7 @@ Nodes are spawned in topological order; siblings without a dependency relationsh
 {
   "nodes": {
     "fetch":   { "command": ["curl", "-fsSL", "https://example.test/data.json", "-o", "data.json"] },
-    "lint":    { "command": ["jq", ".", "data.json"], "depends_on": ["fetch"] },
+    "lint":    { "command": ["jaq", ".", "data.json"], "depends_on": ["fetch"] },
     "convert": { "command": ["./bin/convert", "data.json", "out.bin"], "depends_on": ["fetch"], "env": { "RUST_LOG": "debug" } },
     "upload":  { "command": ["./bin/upload", "out.bin"], "depends_on": ["lint", "convert"] }
   }

--- a/packages/minecraft-assets/default.nix
+++ b/packages/minecraft-assets/default.nix
@@ -18,9 +18,9 @@
 # Refresh recipe (when bumping `version`): resolve the new client.jar from the
 # manifest and read back the hash Nix wants:
 #   v=$(curl -fsSL https://launchermeta.mojang.com/mc/game/version_manifest_v2.json \
-#        | jq -r '.versions[]|select(.id=="VERSION").url')
-#   url=$(curl -fsSL "$v" | jq -r .downloads.client.url)
-#   nix store prefetch-file --json "$url" | jq -r .hash
+#        | jaq -r '.versions[]|select(.id=="VERSION").url')
+#   url=$(curl -fsSL "$v" | jaq -r .downloads.client.url)
+#   nix store prefetch-file --json "$url" | jaq -r .hash
 #
 # Mojang's art is NOT redistributed by this repository; it is fetched at build
 # time, the same boundary the rest of the repo uses for upstream binaries.

--- a/packages/minecraft/sound/sounds.nix
+++ b/packages/minecraft/sound/sounds.nix
@@ -15,7 +15,7 @@
   fetchurl,
   cacert,
   curl,
-  jq,
+  jaq,
 }:
 let
   lock = lib.importJSON ./sounds/lock.json;
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation {
   strictDeps = true;
   nativeBuildInputs = [
     curl
-    jq
+    jaq
   ];
 
   SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
@@ -56,7 +56,7 @@ stdenvNoCC.mkDerivation {
     runHook preBuild
 
     list="$TMPDIR/sounds.tsv"
-    jq -r --arg ex ${lib.escapeShellArg excludeRegex} '
+    jaq -r --arg ex ${lib.escapeShellArg excludeRegex} '
       .objects
       | to_entries[]
       | select((.key | startswith("minecraft/sounds/")) and (.key | endswith(".ogg")))

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -800,7 +800,7 @@ fn render_rustc_unit(
 ) -> Result<String> {
     let unit = &graph.units[index];
     let native_build_inputs = if collects_unused_crate_dependencies(unit, options) {
-        "[ rustToolchain pkgs.jq ] ++ extraNativeBuildInputs"
+        "[ rustToolchain pkgs.jaq ] ++ extraNativeBuildInputs"
     } else {
         "[ rustToolchain ] ++ extraNativeBuildInputs"
     };
@@ -1103,7 +1103,7 @@ fn append_driver_invocation(script: &mut String, driver: Driver, collect_unused_
         script.push_str("  exit \"$rustc_status\"\n");
         script.push_str("fi\n");
         script.push_str(
-            r#"jq -r 'select(."$message_type" == "unused_extern") | .unused_extern_names[]' "$rustc_diagnostics" | sort -u > build/unused-crate-dependencies
+            r#"jaq -r 'select(."$message_type" == "unused_extern") | .unused_extern_names[]' "$rustc_diagnostics" | sort -u > build/unused-crate-dependencies
 "#,
         );
     } else {

--- a/packages/nix-web-monitor/server/src/main.rs
+++ b/packages/nix-web-monitor/server/src/main.rs
@@ -203,7 +203,7 @@ fn router(site_dir: &Path, state: AppState) -> Router {
 }
 
 /// One-shot snapshot of the current monitor state as JSON, for scripts and
-/// agents that want to `curl | jq` the build tree instead of opening a
+/// agents that want to `curl | jaq` the build tree instead of opening a
 /// WebTransport session. Same payload the live stream seeds each client with.
 async fn state_snapshot(State(state): State<AppState>) -> Json<MonitorSnapshot> {
     Json(state.monitor.read().await.snapshot())

--- a/packages/tui-node/default.nix
+++ b/packages/tui-node/default.nix
@@ -29,7 +29,7 @@ pkgs.runCommand "ix-tui-node"
     strictDeps = true;
     nativeBuildInputs = [
       pkgs.coreutils
-      pkgs.jq
+      pkgs.jaq
       pkgs.patchelf
       pkgs.removeReferencesTo
     ];
@@ -59,7 +59,7 @@ pkgs.runCommand "ix-tui-node"
     cp ${npmSource}/index.js ${npmSource}/index.d.ts "$out/"
     # Stamp the artifact's arch/libc so npm refuses to install it on a host that
     # cannot dlopen this single host-built addon.
-    jq '. + { cpu: ["${npmCpu}"], libc: ["glibc"] }' \
+    jaq '. + { cpu: ["${npmCpu}"], libc: ["glibc"] }' \
       ${npmSource}/package.json >"$out/package.json"
     cp "$cdylib" "$out/native/tui_node.node"
     chmod u+w "$out/native/tui_node.node"

--- a/skills/antithesis-triage/SKILL.md
+++ b/skills/antithesis-triage/SKILL.md
@@ -5,7 +5,7 @@ description: >
   up runs, check status, investigate failed properties (assertions), view
   metadata, download logs, inspect findings, and examine environmental
   details. Load after a run completes or when investigating a failure.
-compatibility: Requires snouty (https://github.com/antithesishq/snouty), agent-browser (https://github.com/vercel-labs/agent-browser), and jq.
+compatibility: Requires snouty (https://github.com/antithesishq/snouty), agent-browser (https://github.com/vercel-labs/agent-browser), and jaq.
 metadata:
   version: "2026-05-15 a0f67a6"
 ---
@@ -21,7 +21,7 @@ Use this skill to read and triage Antithesis test reports.
 - DO NOT PROCEED if `snouty` is not installed. See `https://raw.githubusercontent.com/antithesishq/snouty/refs/heads/main/README.md` for installation options.
 - DO NOT PROCEED if `agent-browser` is not installed. See `https://raw.githubusercontent.com/vercel-labs/agent-browser/refs/heads/main/README.md` for installation options.
 - DO NOT PROCEED if `agent-browser` is older than version `v0.23.4`. You can upgrade with `agent-browser upgrade`.
-- DO NOT PROCEED if `jq` is not installed. See `https://jqlang.org/download/` for installation options.
+- DO NOT PROCEED if `jaq` is not installed. See `https://github.com/01mf02/jaq` for installation options.
 
 ## Gathering user input
 

--- a/skills/antithesis-triage/references/error-reports.md
+++ b/skills/antithesis-triage/references/error-reports.md
@@ -84,7 +84,7 @@ agent-browser --session "$SESSION" download \
   'a.sequence_printer_menu_button[data-triage-dl]' /tmp/error-logs.json
 ```
 
-Downloaded logs are minified single-line JSON — always use `jq` to inspect them, never `cat` or `wc -l`. `jq length <file>` is a good first command to start with.
+Downloaded logs are minified single-line JSON — always use `jaq` to inspect them, never `cat` or `wc -l`. `jaq length <file>` is a good first command to start with.
 
 For multiple log panes, repeat with each index.
 

--- a/skills/antithesis-triage/references/logs.md
+++ b/skills/antithesis-triage/references/logs.md
@@ -79,7 +79,7 @@ payloads directly into their log messages. These lines can be very long
 `output_text` values. When searching, be aware that keyword matches may hit
 these serialized dumps rather than meaningful log messages.
 
-## Analyzing logs with jq
+## Analyzing logs with jaq
 
 All examples below assume the log path is in `$LOG`:
 
@@ -88,7 +88,7 @@ LOG="/path/to/clean.json"
 ```
 
 **Null-safe string matching:** Many event fields are optional and may be `null`,
-including `source.name`. Use jq's `//` (coalesce) operator before string
+including `source.name`. Use jaq's `//` (coalesce) operator before string
 functions like `test()` or `startswith()` to avoid errors:
 `.output_text // "" | test("pattern")`, `(.source.name // "") | startswith("node")`.
 
@@ -100,20 +100,20 @@ These three queries orient you quickly when opening a new log.
 combinations to see what is in the log:
 
 ```bash
-jq '[.[] | {name: .source.name, container: .source.container}] | unique' "$LOG"
+jaq '[.[] | {name: .source.name, container: .source.container}] | unique' "$LOG"
 ```
 
 **2. Find failed commands** — find test commands that finished with non-zero
 exit:
 
 ```bash
-jq '[.[] | select(.command_return_code != null and .command_return_code != "0") | {vtime_seconds, command, command_return_code}]' "$LOG"
+jaq '[.[] | select(.command_return_code != null and .command_return_code != "0") | {vtime_seconds, command, command_return_code}]' "$LOG"
 ```
 
 **3. Search for errors in application logs**:
 
 ```bash
-jq '[.[] | select(.output_text // "" | test("error|panic|fatal|crash"; "i")) | {vtime_seconds, source: .source.name, text: .output_text[:200]}]' "$LOG"
+jaq '[.[] | select(.output_text // "" | test("error|panic|fatal|crash"; "i")) | {vtime_seconds, source: .source.name, text: .output_text[:200]}]' "$LOG"
 ```
 
 ### Filtering events
@@ -121,67 +121,67 @@ jq '[.[] | select(.output_text // "" | test("error|panic|fatal|crash"; "i")) | {
 Filter by source name:
 
 ```bash
-jq '[.[] | select(.source.name == "fault_injector")]' "$LOG"
+jaq '[.[] | select(.source.name == "fault_injector")]' "$LOG"
 ```
 
 Filter by stream (application stderr only):
 
 ```bash
-jq '[.[] | select(.source.stream == "error")]' "$LOG"
+jaq '[.[] | select(.source.stream == "error")]' "$LOG"
 ```
 
 Filter fault events by fault name:
 
 ```bash
-jq '[.[] | select(.fault.name == "partition")]' "$LOG"
+jaq '[.[] | select(.fault.name == "partition")]' "$LOG"
 ```
 
 Filter by fault type:
 
 ```bash
-jq '[.[] | select(.fault.type == "network")]' "$LOG"
+jaq '[.[] | select(.fault.type == "network")]' "$LOG"
 ```
 
 Search output_text for a keyword (case-insensitive):
 
 ```bash
-jq '[.[] | select(.output_text // "" | test("error"; "i"))]' "$LOG"
+jaq '[.[] | select(.output_text // "" | test("error"; "i"))]' "$LOG"
 ```
 
 Container lifecycle events:
 
 ```bash
-jq '[.[] | select(.event == "die")]' "$LOG"
+jaq '[.[] | select(.event == "die")]' "$LOG"
 ```
 
 Find failed test-template commands (non-zero exit code):
 
 ```bash
-jq '[.[] | select(.command_return_code != null and .command_return_code != "0")]' "$LOG"
+jaq '[.[] | select(.command_return_code != null and .command_return_code != "0")]' "$LOG"
 ```
 
 Find all test command completions:
 
 ```bash
-jq '[.[] | select(.command_return_code != null)]' "$LOG"
+jaq '[.[] | select(.command_return_code != null)]' "$LOG"
 ```
 
 Find all SDK assertion events:
 
 ```bash
-jq '[.[] | select(.antithesis_assert != null)]' "$LOG"
+jaq '[.[] | select(.antithesis_assert != null)]' "$LOG"
 ```
 
 Find all assertion events for a specific property:
 
 ```bash
-jq '[.[] | select(.antithesis_assert.id == "property name here")]' "$LOG"
+jaq '[.[] | select(.antithesis_assert.id == "property name here")]' "$LOG"
 ```
 
 Combine filters — fault partitions affecting a specific container:
 
 ```bash
-jq '[.[] | select(.fault.name == "partition" and (.fault.affected_nodes | index("mycontainer") or index("ALL")))]' "$LOG"
+jaq '[.[] | select(.fault.name == "partition" and (.fault.affected_nodes | index("mycontainer") or index("ALL")))]' "$LOG"
 ```
 
 ### Filtering by virtual time
@@ -189,13 +189,13 @@ jq '[.[] | select(.fault.name == "partition" and (.fault.affected_nodes | index(
 Filter events within a time range (in seconds):
 
 ```bash
-jq '[.[] | select(.vtime_seconds >= 100 and .vtime_seconds <= 110)]' "$LOG"
+jaq '[.[] | select(.vtime_seconds >= 100 and .vtime_seconds <= 110)]' "$LOG"
 ```
 
 Events after a specific time:
 
 ```bash
-jq '[.[] | select(.vtime_seconds >= 85.5)]' "$LOG"
+jaq '[.[] | select(.vtime_seconds >= 85.5)]' "$LOG"
 ```
 
 ## Interpreting logs
@@ -303,25 +303,25 @@ field is a dictionary tracking currently active fault windows. The schema:
 To find events that occurred during a network partition:
 
 ```bash
-jq '[.[] | select(.active_faults.network_partition != null)]' "$LOG"
+jaq '[.[] | select(.active_faults.network_partition != null)]' "$LOG"
 ```
 
 To find events during any node fault:
 
 ```bash
-jq '[.[] | select(.active_faults | keys[] | startswith("node_"))]' "$LOG"
+jaq '[.[] | select(.active_faults | keys[] | startswith("node_"))]' "$LOG"
 ```
 
 To find events that happened during any ongoing fault:
 
 ```bash
-jq '[.[] | select(.active_faults != {})]' "$LOG"
+jaq '[.[] | select(.active_faults != {})]' "$LOG"
 ```
 
 To find faults within a region of vtime:
 
 ```bash
-jq '[.[] | select(.fault != null and .vtime_seconds >= 85.0 and .vtime_seconds <= 86.0)]' "$LOG"
+jaq '[.[] | select(.fault != null and .vtime_seconds >= 85.0 and .vtime_seconds <= 86.0)]' "$LOG"
 ```
 
 ### Virtual time vs application timestamps

--- a/skills/antithesis-triage/references/properties.md
+++ b/skills/antithesis-triage/references/properties.md
@@ -31,31 +31,31 @@ Each entry in the `properties` array:
 
 `passingCount` and `failingCount` are comma-formatted count strings representing the total across all execution histories in the run (not just the 3-4 example rows shown in the UI).
 
-### Filtering properties with jq
+### Filtering properties with jaq
 
-Use `jq` to filter the output of `getAllProperties()` rather than calling
+Use `jaq` to filter the output of `getAllProperties()` rather than calling
 separate status-specific methods:
 
 ```bash
 # Failed properties only
 agent-browser --session "$SESSION" eval \
   "window.__antithesisTriage.report.getAllProperties()" \
-  | jq '.properties | map(select(.status == "failed"))'
+  | jaq '.properties | map(select(.status == "failed"))'
 
 # Passed properties only
 agent-browser --session "$SESSION" eval \
   "window.__antithesisTriage.report.getAllProperties()" \
-  | jq '.properties | map(select(.status == "passed"))'
+  | jaq '.properties | map(select(.status == "passed"))'
 
 # Unfound properties only
 agent-browser --session "$SESSION" eval \
   "window.__antithesisTriage.report.getAllProperties()" \
-  | jq '.properties | map(select(.status == "unfound"))'
+  | jaq '.properties | map(select(.status == "unfound"))'
 
 # Properties in a specific group
 agent-browser --session "$SESSION" eval \
   "window.__antithesisTriage.report.getAllProperties()" \
-  | jq '.properties | map(select(.group | any(test("SDK: Go"))))'
+  | jaq '.properties | map(select(.group | any(test("SDK: Go"))))'
 ```
 
 ### Using pass/fail ratios for triage prioritization
@@ -83,7 +83,7 @@ Numeric/boolean variants (e.g., `AlwaysGreaterThan`, `SometimesAll`) follow the 
 
 `report.getPropertyExamples()` returns all properties that have example tables,
 along with their example rows. All example tables are already expanded by
-`waitForReady()`, so this is a synchronous read of the DOM. Use jq to filter
+`waitForReady()`, so this is a synchronous read of the DOM. Use jaq to filter
 by status.
 
 Returns each property with `group`, `name`, `status`, and `examples` array
@@ -93,7 +93,7 @@ containing `{ index: 0, status: "failing", time: "85.75s" }` entries.
 # Failed property examples only
 agent-browser --session "$SESSION" eval \
   "window.__antithesisTriage.report.getPropertyExamples()" \
-  | jq '.properties | map(select(.status == "failed"))'
+  | jaq '.properties | map(select(.status == "failed"))'
 ```
 
 Each property may expose multiple example rows (typically 3-4), mixing failing

--- a/skills/nix/SKILL.md
+++ b/skills/nix/SKILL.md
@@ -22,7 +22,7 @@ If no changed files, audit the scope the user specifies. Default to `nix/` if un
 ### Language-Level
 
 1. **`rec` attrsets**: Cause infinite recursion when names are shadowed. `//` overrides do not propagate to self-referencing attrs. Replace with `let ... in`.
-2. **Top-level `with pkgs;` or `with lib;`**: Prevents static analysis, obscures name origins, unintuitive shadowing (outer `let` takes priority over `with`). Replace with `let inherit (pkgs) curl jq; in` or explicit `pkgs.curl`.
+2. **Top-level `with pkgs;` or `with lib;`**: Prevents static analysis, obscures name origins, unintuitive shadowing (outer `let` takes priority over `with`). Replace with `let inherit (pkgs) curl jaq; in` or explicit `pkgs.curl`.
 3. **Unquoted URLs**: Bare `https://...` works but is a maintainability hazard. Always quote.
 4. **Lookup paths (`<nixpkgs>`)**: Depend on mutable `$NIX_PATH`. Pin explicitly via flake inputs.
 5. **Shallow `//` for nested attrsets**: Only does shallow merge. Use `lib.recursiveUpdate` for deep merges.
@@ -128,16 +128,16 @@ config = lib.optionalAttrs cfg.enable {
 
 ```nix
 # ANTI-PATTERN
-with pkgs; [ curl jq ripgrep fd ]
+with pkgs; [ curl jaq ripgrep fd ]
 
 # FIX 1: inherit (small lists, clear what's used)
-let inherit (pkgs) curl jq ripgrep fd; in [ curl jq ripgrep fd ]
+let inherit (pkgs) curl jaq ripgrep fd; in [ curl jaq ripgrep fd ]
 
 # FIX 2: explicit prefix (larger lists, better for grep-ability)
-[ pkgs.curl pkgs.jq pkgs.ripgrep pkgs.fd ]
+[ pkgs.curl pkgs.jaq pkgs.ripgrep pkgs.fd ]
 
 # FIX 3: builtins.map (large generated lists)
-builtins.map (name: pkgs.${name}) [ "curl" "jq" "ripgrep" "fd" ]
+builtins.map (name: pkgs.${name}) [ "curl" "jaq" "ripgrep" "fd" ]
 ```
 
 ## Statix Linter Checks

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -94,7 +94,7 @@ let
     name = "ix-downtime";
     runtimeInputs = [
       pkgs.curl
-      pkgs.jq
+      pkgs.jaq
       pkgs.sqlite
       sayDetached
       pkgs.claude-code

--- a/users/andrewgazelka/scripts/ix-downtime.sh
+++ b/users/andrewgazelka/scripts/ix-downtime.sh
@@ -1,6 +1,6 @@
 # Body of the `ix-downtime` bash app (see users/andrewgazelka/home.nix).
 # No shebang / `set` line: the mkBashApp wrapper supplies bash + `set -euo
-# pipefail` and bakes curl/jq/sqlite/minecraft-sound/claude/coreutils + the
+# pipefail` and bakes curl/jaq/sqlite/minecraft-sound/claude/coreutils + the
 # bossbar CLI + say-detached onto PATH via runtimeInputs.
 #
 # Mirrors the PUBLIC ix.dev status page onto a boss bar + an Ender Dragon growl,
@@ -126,7 +126,7 @@ reconcile_bars() {
     [ -n "$bdb" ] || { printf ''; return; }
     sqlite3 "$bdb" "SELECT id FROM bossbars WHERE title = '$(sq "$1")' OR title LIKE '$(sq "$1") (%' ORDER BY id LIMIT 1;" 2>/dev/null || printf ''
   }
-  rows="$(jq -rn --argjson res "$res" --argjson secs "$secs" '
+  rows="$(jaq -rn --argjson res "$res" --argjson secs "$secs" '
     (($secs.data // []) | map({ (.id|tostring): .attributes.name }) | add // {}) as $sn
     | ($res.data // [])[]
     | ( ($sn[(.attributes.status_page_section_id|tostring)] // "ix")
@@ -171,11 +171,11 @@ EOF
 pages="$(api '/status-pages')" || exit 0
 # Bail on a malformed body (rate-limit text, HTML error, truncated read) rather
 # than silently treating it as all-clear and yanking the bar mid-outage.
-printf '%s' "$pages" | jq -e 'has("data")' >/dev/null 2>&1 || exit 0
-page="$(printf '%s' "$pages" | jq -r '.data[] | select(.attributes.subdomain=="ix") | .id' | head -1)"
-[ -n "$page" ] || page="$(printf '%s' "$pages" | jq -r '.data[0].id // empty')"
+printf '%s' "$pages" | jaq -e 'has("data")' >/dev/null 2>&1 || exit 0
+page="$(printf '%s' "$pages" | jaq -r '.data[] | select(.attributes.subdomain=="ix") | .id' | head -1)"
+[ -n "$page" ] || page="$(printf '%s' "$pages" | jaq -r '.data[0].id // empty')"
 [ -n "$page" ] || exit 0
-agg="$(printf '%s' "$pages" | jq -r --arg id "$page" \
+agg="$(printf '%s' "$pages" | jaq -r --arg id "$page" \
   '.data[] | select(.id==$id) | .attributes.aggregate_state // empty')"
 # An empty state means we could not read it; bail rather than false-clear.
 [ -n "$agg" ] || exit 0
@@ -183,7 +183,7 @@ agg="$(printf '%s' "$pages" | jq -r --arg id "$page" \
 # Public URL of the status page, for the bar's click action ("open Better Stack").
 # Prefer the custom domain (status.ix.dev), else the Better Stack subdomain host.
 # Derived from the API so it tracks the page rather than being hardcoded.
-status_url="$(printf '%s' "$pages" | jq -r --arg id "$page" '
+status_url="$(printf '%s' "$pages" | jaq -r --arg id "$page" '
   .data[] | select(.id==$id) | .attributes
   | if (.custom_domain // "") != "" then "https://" + .custom_domain
     elif (.subdomain // "") != "" then "https://" + .subdomain + ".betteruptime.com"
@@ -201,10 +201,10 @@ res="$(api "/status-pages/$page/resources")" || res=""
 secs="$(api "/status-pages/$page/sections")" || secs=""
 bars_ok=0
 # Require `.data` to be an ARRAY, not merely present: a valid body like
-# {"data":null} satisfies has("data") but makes the jq below iterate null and
+# {"data":null} satisfies has("data") but makes the jaq below iterate null and
 # fail, which under `set -euo pipefail` would abort the watcher mid-outage.
-if printf '%s' "$res" | jq -e '(.data | type) == "array"' >/dev/null 2>&1 \
-  && printf '%s' "$secs" | jq -e '(.data | type) == "array"' >/dev/null 2>&1; then
+if printf '%s' "$res" | jaq -e '(.data | type) == "array"' >/dev/null 2>&1 \
+  && printf '%s' "$secs" | jaq -e '(.data | type) == "array"' >/dev/null 2>&1; then
   bars_ok=1
 fi
 
@@ -222,7 +222,7 @@ bossbar rm "ix.dev down" 2>/dev/null || true
 # empty, so `grep -ve '^$'` exits 1, and under `set -o pipefail` an unguarded
 # command substitution would abort the script before the seed/recovery logic.
 if [ "$bars_ok" = 1 ]; then
-  down_names="$(jq -rn --argjson res "$res" --argjson secs "$secs" '
+  down_names="$(jaq -rn --argjson res "$res" --argjson secs "$secs" '
     (($secs.data // []) | map({ (.id|tostring): .attributes.name }) | add // {}) as $sn
     | ($res.data // [])[]
     | select((.attributes.status // "operational") != "operational")


### PR DESCRIPTION
Closes #517.

Replaces every `jq` invocation and package reference with [`jaq`](https://github.com/01mf02/jaq), the Rust reimplementation, which is already in the pinned `nixpkgs` (`jaq` 3.0.0). This aligns the repo's JSON tooling with its Rust-first preference and ships a single static binary instead of jq's C and oniguruma build.

## What changed

**Filter invocations** (behavior must match)
- `lib/per-system.nix` — `mutable-json-merge-check` build input and its `jaq -ncS … -f` / `jaq -cS .` runs
- `lib/mutable-json.nix` — activation-time merge now runs `${pkgs.jaq}/bin/jaq -n …`
- `lib/rust.nix` — `pkgs.jaq` build input plus three `jaq -r` reads over `cargo metadata`
- `packages/minecraft/sound/sounds.nix` — `jaq` callPackage input and the asset-index filter
- `packages/tui-node/default.nix` — `pkgs.jaq` input and the `package.json` rewrite
- `packages/nix-cargo-unit/src/render.rs` — the generated Nix now lists `pkgs.jaq` and runs `jaq -r 'select(…)'`
- `users/andrewgazelka/scripts/ix-downtime.sh` — all invocations
- `.claude/hooks/agent-instructions.sh` — the `command -v` probe, the nixpkgs fallback (`nix run nixpkgs#jaq`), and both envelope builders

**Package / PATH inclusions**
- `modules/profiles/base/default.nix` (system-wide), `images/dev/symphony-codex/default.nix`, `users/andrewgazelka/home.nix` (the `ix-downtime` runtime input), and the `modules/services/ci-runner` example literal

**Docs and comments**
- `skills/nix/SKILL.md`, the `skills/antithesis-triage` SKILL + `references/{logs,properties,error-reports}.md`, `packages/minecraft-assets/default.nix`, `images/dev/development-base/default.nix`, `packages/nix-web-monitor/server/src/main.rs`, `examples/hermes-agent/documents/SOUL.md`, `packages/dag-runner/README.md`
- The antithesis-triage SKILL prerequisite now points at `https://github.com/01mf02/jaq` instead of `jqlang.org/download`

The `mutable-json-merge.jq` filename is unchanged; `jaq -f` reads it as-is.

## Compatibility

`jaq` 3.0.0 produced **byte-identical** output to `jq` 1.7.1 for every filter in the repo, checked directly with both binaries:
- the six `mutable-json-merge-check` cases (first-install, preserve-app-key, enforce-changed, prune-dropped, nested-atomic-array, divergent-live-shape)
- both large `ix-downtime.sh` programs, including the `{"data":null}` / `{}` / `[]` edges
- the antithesis-triage filters: `test(…; "i")` regex, `unique`, `keys[]`, `index`, `//` coalesce, slicing, `any(test(…))`
- `select(."$message_type" == …)`, `. + {…}`, `cargo metadata` reads, identity pretty-print
- the hook's `jaq -n --rawfile` SessionStart envelope

`jaq` accepts every flag in use here (`-n -c -S -r -e -f --arg --argjson`).

## Intentional exception

`.github/workflows/ai-review-gate.yml:337` still calls `jq '.' ai-review-output.json`. That step only pretty-prints JSON into the Actions log, and it runs on an `ubuntu-latest` runner that ships `jq` but not `jaq` and has no Nix setup. The issue's "no `jq` command name on any host PATH" goal targets the ix VM images, not GitHub runners, so swapping it would mean adding a Nix install (or a non-jaq tool) to the review gate for a log printer. Left as-is by decision.

## Notes for review

- The three files migrated beyond the issue's explicit checklist (`examples/hermes-agent/documents/SOUL.md`, `packages/dag-runner/README.md`, `skills/antithesis-triage/references/error-reports.md`) are part of the 23 that referenced `jq`; updating them keeps "no stale `jq` mentions" true.
- I can't run `nix flake check` locally (this host has no x86_64-linux builder), so CI is the source of truth for the `mutable-json-merge-check` and image builds. The filter equivalence above was validated with the pinned `jaq` 3.0.0 binary directly.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `jq` with `jaq` across all build scripts, derivations, and documentation
> - Replaces `pkgs.jq` with `pkgs.jaq` in all Nix derivations, build scripts, and shell scripts, including the base profile, dev images, Rust crate builds, and Minecraft assets.
> - Updates the [agent-instructions.sh](.claude/hooks/agent-instructions.sh) hook to probe for `jaq` on PATH (falling back to `nix run nixpkgs#jaq`) and use it for all JSON construction.
> - Updates [ix-downtime.sh](users/andrewgazelka/scripts/ix-downtime.sh) to use `jaq` for JSON parsing and adds computation of `status_url` from Better Stack `custom_domain` or `subdomain` for the boss bar click action.
> - Updates skill docs and README references to use `jaq` in examples and instructions.
> - Behavioral Change: systems and derivations that previously had `jq` on PATH will now have `jaq`; `jaq` is largely compatible with `jq` but is a distinct binary with minor filter differences.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 227865f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->