### PR TITLE
feat(optimize): /optimize history skill + portable scan; better portable-services

### DIFF
--- a/lib/portable-services.nix
+++ b/lib/portable-services.nix
@@ -84,8 +84,24 @@ let
           default = true;
           description = ''
             Start the service when the user session loads (login on macOS,
-            `default.target` on Linux). Ignored for interval services, which
-            are driven by their schedule.
+            `default.target` on Linux). For an interval service this means an
+            immediate first run on load in addition to the schedule: launchd
+            `RunAtLoad` alongside `StartInterval`, and a systemd timer that also
+            fires shortly after activation (`OnActiveSec`) rather than waiting a
+            full interval.
+          '';
+        };
+
+        label = mkOption {
+          type = types.str;
+          default = "org.nix-community.home.${name}";
+          defaultText = lib.literalExpression ''"org.nix-community.home.''${name}"'';
+          description = ''
+            launchd Label, which is also the plist filename. Defaults to the
+            home-manager reverse-DNS convention keyed on the service name, so it
+            is space-free and a switch updates the existing agent in place. This
+            is launchd-only: on systemd the unit name is the attribute name, so
+            this option has no effect there.
           '';
         };
 
@@ -184,12 +200,16 @@ let
           null;
 
       generated = {
-        Label = svc.description;
+        Label = svc.label;
         ProgramArguments = svc.command;
       }
       // optionalAttrs (svc.environment != { }) { EnvironmentVariables = svc.environment; }
       // optionalAttrs (svc.workingDirectory != null) { WorkingDirectory = svc.workingDirectory; }
-      // optionalAttrs (svc.runAtLoad && svc.interval == null) { RunAtLoad = true; }
+      # RunAtLoad fires an immediate run on load. For an interval service this
+      # rides alongside StartInterval (load now, then every interval); the older
+      # behavior of suppressing it for interval services forced every poller to
+      # re-add RunAtLoad through the escape hatch.
+      // optionalAttrs svc.runAtLoad { RunAtLoad = true; }
       // optionalAttrs (keepAlive != null) { KeepAlive = keepAlive; }
       // optionalAttrs (svc.interval != null) { StartInterval = svc.interval; }
       // optionalAttrs (svc.standardOutPath != null) { StandardOutPath = svc.standardOutPath; }
@@ -266,9 +286,14 @@ let
               Description = "Timer for ${svc.description}";
             };
             Timer = {
-              OnBootSec = svc.interval;
               OnUnitActiveSec = svc.interval;
-            };
+            }
+            // (
+              # runAtLoad => fire ~immediately after the timer activates at login
+              # (portable analogue of launchd RunAtLoad); otherwise wait one full
+              # interval from boot before the first run.
+              if svc.runAtLoad then { OnActiveSec = "1s"; } else { OnBootSec = svc.interval; }
+            );
             Install = {
               WantedBy = [ "timers.target" ];
             };

--- a/skills/optimize/SKILL.md
+++ b/skills/optimize/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: optimize
+description: "Mine your own Claude Code history with polars to find where past sessions wasted time and drift, then draft the global config changes that prevent the recurrence. Surfaces slow model loops, slow commands and toolchain/CI/build-graph waste, oversized tool results that bloat or trim context, mistakes a human had to correct, and multi-turn flailing. Use when you want to make future sessions faster and more correct, audit your agent's habits, or decide what CLAUDE.md / skill / hook to add. Invoke with /optimize."
+disable-model-invocation: true
+---
+
+# Optimize
+
+Analyze the user's Claude Code history to make every future session faster and more correct. You review *how the agent worked* across thousands of past sessions, find the recurring failure modes, and turn each into a durable fix to the global config.
+
+The governing question for every episode: **if you were the agent in that session, what was the fastest correct path, where exactly did it diverge, and what one durable rule would have kept it on that path?** A finding that does not end in a concrete, reusable rule has failed.
+
+## Run the analysis (bundled polars library, no uv)
+
+The skill bundles `build_history_df.py` — a small polars library that scans `~/.claude/projects/*/*.jsonl` (~2200 files, ~800 MB) and returns compact aggregate frames, so the raw history stays out of your context. **Run it in the index MCP python session** (polars is preinstalled there — `mcp__index__python_exec`):
+
+```python
+import sys; sys.path.insert(0, "${CLAUDE_SKILL_DIR}/assets")
+import build_history_df as o
+F = o.build_frames(days=45)          # default window; full=True for all history
+o.report(F)                           # prints every leaderboard below
+o.write_html(F, "~/.claude/optimize/report.html")   # self-contained browser report
+# go deeper — these are polars DataFrames, slice freely:
+F["df"]      # one row per assistant turn / prompt (model, out_tok, n_tooluse, n_think, speed, ts)
+F["bash"]    # one row per timed Bash call (cmd, seconds, is_error)
+F["tools"]   # one row per tool_result (tool, label, size, is_error)
+```
+
+To avoid re-scanning across questions, cache once: `o.build_frames(...)["df"].write_parquet("~/.claude/optimize/history_rows.parquet")` (and `bash`/`tools`), then `pl.read_parquet(...)` for instant re-slicing. The module also runs standalone for headless use (`python ${CLAUDE_SKILL_DIR}/assets/build_history_df.py --full --out ~/.claude/optimize`) on any interpreter that has polars — this is what the `optimize-scan` portable service runs via `uv`.
+
+Default to the **last ~45 days** (current model family — old transcripts ran retired models and teach nothing actionable). Expand to `full=True` only when a pattern needs the longer baseline.
+
+**Schema gotchas already handled by the library (do not re-derive wrong):** `usage.speed` is a coarse `"fast"` label, not tokens/sec; `usage.iterations` is a list (count, ~always 1); a *real* human prompt is a string-content user entry with a top-level `promptId` (harness messages like `<task-notification>` and compaction summaries are excluded); per-command wall-clock is the `tool_use`→`tool_result` timestamp delta; "tool too big / context trimmed" is detected by result **size**, since the literal word "truncated" in transcripts is mostly tool data, not a harness trim.
+
+## The signals (each row carries session id + evidence)
+
+1. **Slow model loops** — per model, `output_tokens` / `n_tooluse` / wall-clock; episodes where a heavy model burned many high-tool-use, low-`thinking` turns on mechanical work (a script, a batched call, or a faster model would win). Caveat: long wall-clock can be a permission wait or the 600 s timeout, not compute — confirm against the command.
+2. **Slow commands & toolchain waste** — rank commands by `seconds × frequency`. For each long pole, ask what makes the *class* slow every time. Big: a CI stage that should be instant on a warm runner, an uncached `nix flake check`, a build worth splitting or reimplementing. Structural: a build/DAG recompiling unchanged inputs, missing eval/artifact cache, the same heavy artifact rebuilt across sessions. Small: `rg` over `grep`, a scoped build over a whole-workspace one, a flag that skips work. Treat anything repeatedly over ~1 minute as a defect to fix at its owner.
+3. **Oversized tool results / context bloat** — the `context bloat by tool` and `biggest single results` tables. Large results get trimmed (losing info) or just eat context. The fix is usually scope: `Read` with offset/limit instead of whole-file, Bash piped to `head`/filtered, a `--limit`, a narrower query. Attribute each to the tool that produced it.
+4. **Mistakes a human had to correct** — real prompts after assistant tool activity carrying correction language. Capture the assistant action that triggered it; classify the mistake (wrong assumption, scope creep, destructive edit, ignored instruction). These map most directly to CLAUDE.md rules.
+5. **Multi-turn flailing** — long autonomous chains (high tool count since the last real prompt) with error clusters before resolution. The durable rule is the early signal the agent should have heeded on turn 2 instead of turn 12.
+6. **Repeated cross-session tasks → reusable scripts** — the `recurring tasks across sessions` table groups commands by a canonical form (paths/numbers/hashes blanked) and counts how many *distinct sessions* run each. A task you re-derive in dozens of sessions (a multi-step setup, a lint/build/deploy incantation, a query you keep rewriting) should become one reusable thing: a script, a `just`/Makefile target, a global skill, or a CLI subcommand. Rank by `distinct_sessions × total_seconds` — high session-count means you keep paying the rediscovery and typing cost. Propose the concrete artifact (where it lives, what it wraps) and the cumulative time it reclaims. Ignore trivial one-liners (`ls`, `git status`); target the expensive or multi-step recipes.
+7. **Escape hatches & recurring jank → architecture fix** — the `escape hatches / jank` table counts workaround patterns in commands (silenced stderr, `|| true`, `--no-verify`, force pushes, `sleep` timing hacks, retry/poll loops, `--impure`/`--override-input`, `sed -i` patching, sandbox bypass) by distinct sessions. Each recurring one is the agent *compensating* for something a real fix would remove: a `sleep` poll → an event-driven wait (the Monitor tool); pervasive `--no-verify` → hooks too slow to keep; repeated `--override-input`/`sed -i` patching → a missing upstream option or config knob; constant `2>/dev/null` → tooling so noisy its output is worthless. Name the underlying gap and propose the architectural change that *retires* the workaround — not a tidier workaround. (Meta: this skill's own creation hit exactly this — launchd escape hatches in a "portable" service — and the fix was improving the abstraction, not pinning more keys.)
+
+## From findings to durable fixes
+
+Every confirmed finding becomes a proposed artifact, chosen by what prevents the recurrence:
+- **Global CLAUDE.md edit** — a behavioral rule/guardrail/default (target `~/.claude/CLAUDE.md`). Short, imperative, in the file's voice.
+- **A new global skill** — a repeatable procedure (target `~/.claude/skills/<name>/`).
+- **A hook or setting** — something the harness must enforce automatically (target `~/.claude/settings.json`).
+- **A reusable script / CLI / `just` target** — for signal 6, the codified version of a repeated task.
+
+Apply against whatever renders this machine's Claude config: if it is managed by a Nix flake (a personal config repo, or the index repo's `skills/` + home modules), edit the flake source that renders the file, not the live symlink, then re-switch; otherwise edit `~/.claude/` directly. Write each as a paste-ready draft tied to its evidence and estimated recurring time saved.
+
+## Surface what needs the human
+
+Separate findings into (a) fixes you can draft mechanically and (b) decisions only the user can make, and **use AskUserQuestion for (b)** rather than guessing. Examples: "Change default X behavior?", "Is this recurring command worth a CI/build change?", "Adopt this as a new always-on CLAUDE.md rule?", "Set up a periodic run (below)?". A wrong global rule costs every future session, so confirm the judgment calls.
+
+## Deliverables and apply policy
+
+1. Write a dated report to `~/.claude/optimize/report-<date>.md`: ranked findings, each with evidence, the counterfactual (fastest path + divergence), and the proposed artifact.
+2. Also emit a self-contained **`~/.claude/optimize/report.html`** so the findings open in a browser. The bundled library already writes one from the raw leaderboards via `o.write_html(F, path)`; for the synthesized report, render your ranked findings + the same tables into HTML too (reuse `write_html`'s output as the data section and prepend your synthesis).
+3. Put paste-ready drafts under `~/.claude/optimize/drafts/`.
+4. Return a tight summary: the highest-leverage fixes and total estimated time reclaimed, plus the explicit human-decision list.
+
+**Do not mutate the live global config on your own** — proposals come from heuristics over fuzzy data and change every future session. Draft, present, apply only what the user approves. When applying an approved skill/setting, run `uvx skillsaw lint --type dot-claude ~/.config/nix/claude/global` (the switch's own gate) before handing back.
+
+## Scheduling / checking back later
+
+On index-managed hosts a token-free `optimize-scan` portable service already refreshes `~/.claude/optimize/` (launchd on macOS, a systemd timer on Linux) so the heavy data is always fresh and `/optimize` synthesis is instant. If a host has no such service and the user wants periodic runs, know the options and their limits:
+- **`/loop` and the cron tools (CronCreate)** — session-scoped: fire only while a session is open and idle, and recurring ones auto-expire in days. Good for "watch this for an hour," not durable.
+- **claude.ai Routines / Desktop scheduled tasks** — durable, but cloud routines run on a fresh clone with **no access to local `~/.claude` history**, so they cannot do this analysis.
+- **A native scheduled unit running the scan** — the durable fit: a launchd agent (macOS) or systemd timer (Linux), declared once via the index `services.portable.*` layer so it renders on both. The token-free scan is safe to run often; reserve an unattended `claude -p "/optimize"` LLM report for a daily/weekly cadence.
+
+## Method discipline
+
+Practice what you preach. Build the frames once and reuse them; don't re-scan 800 MB per question. Reach for the strongest signal first (errors, correction prompts, size, recurrence counts) before reading raw transcripts; read full sessions only to confirm a pattern the aggregates already flagged. Report what you measured; mark estimates as estimates.

--- a/skills/optimize/assets/build_history_df.py
+++ b/skills/optimize/assets/build_history_df.py
@@ -1,0 +1,305 @@
+"""Normalize Claude Code history into polars frames + the aggregates /optimize reasons over.
+
+No third-party deps beyond polars. Designed to run in the index MCP python session
+(polars preinstalled), so the heavy 800 MB scan stays out of the model's context and
+only compact aggregates come back. Interactive:
+
+    import sys; sys.path.insert(0, "<CLAUDE_SKILL_DIR>/assets")
+    import build_history_df as o
+    F = o.build_frames(days=45)        # or full=True
+    o.report(F)                         # print the leaderboards
+    o.write_html(F, "~/.claude/optimize/report.html")   # browser report
+    F["df"]; F["bash"]; F["tools"]      # slice further with polars
+
+Standalone / headless (the `optimize-scan` portable service runs this via uv):
+    python build_history_df.py --days 60 --out ~/.claude/optimize
+writes parquet caches, findings.json, latest.txt, and report.html.
+
+Schema verified against real transcripts:
+  - usage.speed is a categorical label ("fast"), NOT tokens/sec
+  - usage.iterations is a LIST of per-iteration usage structs (count = len)
+  - per-command wall-clock = tool_result.ts - tool_use.ts, matched by tool_use_id
+  - a REAL human prompt is a string-content user entry with a top-level promptId;
+    harness-injected user messages have no promptId and must be excluded
+  - "tool too big / context trimmed" is detected by RESULT SIZE, not a marker string
+"""
+from __future__ import annotations
+import argparse, glob, html, json, os, re, sys
+from datetime import datetime, timezone
+
+PROJECTS = os.path.expanduser("~/.claude/projects")
+CORRECTION = re.compile(
+    r"\b(no|nope|wrong|don'?t|stop|wait|actually|revert|undo|that'?s not|not what i|"
+    r"you (broke|deleted|removed|changed)|why did you|i (said|asked)|incorrect|misread)\b",
+    re.I,
+)
+HARNESS_PREFIXES = ("<task-notification", "<system-reminder", "<local-command",
+                    "[request interrupted", "caveat:", "<command-",
+                    "a session-scoped", "this session is being continued",
+                    "the user opened", "the user's message")
+
+# Escape hatches / jank: workaround patterns in commands. A pattern recurring
+# across many sessions is a candidate for a proper architecture fix (the thing
+# the workaround compensates for). Signal 7.
+JANK = [
+    ("silenced stderr (2>/dev/null)", re.compile(r"2>\s*/dev/null")),
+    ("swallowed failure (|| true)", re.compile(r"\|\|\s*(true|:)\b")),
+    ("skipped hooks (--no-verify)", re.compile(r"--no-verify\b")),
+    ("force git (--force/-f)", re.compile(r"\b(push|commit|checkout)\b[^|;&]*(--force(-with-lease)?\b|\s-f\b)")),
+    ("sleep timing hack", re.compile(r"\bsleep\s+\d")),
+    ("retry/poll loop (while !)", re.compile(r"\bwhile\s*!")),
+    ("insecure TLS (curl -k/--insecure)", re.compile(r"\bcurl\b[^|;&]*(\s-k\b|--insecure)")),
+    ("nix --impure", re.compile(r"--impure\b")),
+    ("flake override (--override-input)", re.compile(r"--override-input\b")),
+    ("in-place patch (sed -i)", re.compile(r"\bsed\s+-i\b")),
+    ("chmod 777", re.compile(r"\bchmod\s+(-R\s+)?777\b")),
+    ("sandbox bypass", re.compile(r"(--no-sandbox|--dangerously|dangerouslyDisable)")),
+    ("disable/skip toggle", re.compile(r"\b([A-Z_]*(DISABLE|SKIP)[A-Z_]*)=")),
+]
+TRUNC = re.compile(r"\[truncated\]")
+
+
+def parse_ts(s):
+    try:
+        return datetime.fromisoformat((s or "").replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def is_real_prompt(r, content) -> bool:
+    if not isinstance(content, str) or not r.get("promptId"):
+        return False
+    return not content.lstrip().lower().startswith(HARNESS_PREFIXES)
+
+
+def strip_prefix(cmd: str) -> str:
+    c = cmd.strip()
+    c = re.sub(r"^(cd\s+\S+\s*(&&|;)\s*)+", "", c)
+    c = re.sub(r"^([A-Z_][A-Z0-9_]*=\S+\s+)+", "", c)
+    return c.strip()
+
+
+def klass(cmd: str) -> str:
+    c = strip_prefix(cmd)
+    for k in ("nix build", "nix run", "nix flake", "nix develop", "home-manager",
+              "darwin-rebuild", "cargo", "just", "git", "gh", "claude", "rg", "grep",
+              "fd", "npm", "pnpm", "bun", "python", "uv", "ssh", "docker", "kubectl"):
+        if c == k or c.startswith(k + " "):
+            return k
+    return (c.split() or ["?"])[0][:24]
+
+
+def norm_cmd(cmd: str) -> str:
+    """Canonicalize a command so the same task across sessions collapses to one key."""
+    c = strip_prefix(cmd)
+    c = re.sub(r"/[\w./-]+", "<path>", c)
+    c = re.sub(r"\b[0-9a-f]{7,40}\b", "<hash>", c)
+    c = re.sub(r"\b\d+\b", "#", c)
+    c = re.sub(r"\s+", " ", c).strip()
+    return c[:90]
+
+
+def _cstr(c) -> str:
+    return c if isinstance(c, str) else json.dumps(c, default=str)
+
+
+def build_frames(days: int = 45, full: bool = False):
+    import polars as pl
+    files = glob.glob(os.path.join(PROJECTS, "*", "*.jsonl"))
+    if not full:
+        cutoff = datetime.now(timezone.utc).timestamp() - days * 86400
+        files = [f for f in files if os.path.getmtime(f) >= cutoff]
+
+    rows, tool_calls, bash_done, tool_results, corrections, chains = [], {}, [], [], [], []
+    for f in files:
+        sess = os.path.basename(f)[:-6]
+        try:
+            lines = open(f, encoding="utf-8").read().splitlines()
+        except Exception:
+            continue
+        run_tools = run_errs = 0
+        for l in lines:
+            if not l.strip():
+                continue
+            try:
+                r = json.loads(l)
+            except Exception:
+                continue
+            t = r.get("type")
+            m = r.get("message") if isinstance(r.get("message"), dict) else {}
+            ts = parse_ts(r.get("timestamp", ""))
+            content = m.get("content")
+            if t == "assistant":
+                blocks = content if isinstance(content, list) else []
+                tu = [b for b in blocks if isinstance(b, dict) and b.get("type") == "tool_use"]
+                th = sum(1 for b in blocks if isinstance(b, dict) and b.get("type") == "thinking")
+                u = m.get("usage") or {}
+                run_tools += len(tu)
+                rows.append(dict(
+                    session=sess, ts=ts, kind="assistant", model=m.get("model"),
+                    speed=u.get("speed"), n_iter=len(u.get("iterations") or []),
+                    out_tok=u.get("output_tokens"), n_tooluse=len(tu), n_think=th,
+                    is_sidechain=bool(r.get("isSidechain")),
+                ))
+                for b in tu:
+                    inp = b.get("input") or {}
+                    label = (inp.get("command") or inp.get("file_path") or inp.get("pattern")
+                             or inp.get("query") or inp.get("description") or "")
+                    tool_calls[b.get("id")] = (ts, b.get("name"), str(label)[:200], sess)
+            elif t == "user":
+                blocks = content if isinstance(content, list) else None
+                if blocks:
+                    for b in blocks:
+                        if not (isinstance(b, dict) and b.get("type") == "tool_result"):
+                            continue
+                        tid = b.get("tool_use_id")
+                        size = len(_cstr(b.get("content")))
+                        err = bool(b.get("is_error"))
+                        ts0, name, label, _ = tool_calls.get(tid, (None, "?", "", sess))
+                        tool_results.append((sess, name, label, size, err))
+                        if err:
+                            run_errs += 1
+                        if name == "Bash" and ts is not None and ts0 is not None:
+                            bash_done.append((sess, label, (ts - ts0).total_seconds(), err))
+                elif is_real_prompt(r, content):
+                    if run_tools >= 8 and run_errs >= 1:
+                        chains.append(dict(session=sess, tools=run_tools, errors=run_errs,
+                                           next_prompt=content[:160]))
+                    if CORRECTION.search(content) and run_tools >= 1:
+                        corrections.append(dict(session=sess, ts=str(ts), prior_tools=run_tools,
+                                                prior_errors=run_errs, prompt=content[:200]))
+                    run_tools = run_errs = 0
+
+    return dict(
+        df=pl.DataFrame(rows),
+        bash=pl.DataFrame(bash_done, schema=["session", "cmd", "seconds", "is_error"], orient="row"),
+        tools=pl.DataFrame(tool_results, schema=["session", "tool", "label", "size", "is_error"], orient="row"),
+        corrections=corrections, chains=chains,
+        files=len(files), window=("full" if full else f"{days}d"),
+    )
+
+
+def summary_line(F):
+    df = F["df"]
+    return (f"window: {F['window']} | files={F['files']} | rows={df.height} "
+            f"| timed_bash={F['bash'].height} | tool_results={F['tools'].height}")
+
+
+def aggregates(F, top: int = 15, oversize: int = 20000):
+    """Return an ordered list of (title, polars-frame) sections shared by the text
+    report and the HTML report, so the two never drift."""
+    import polars as pl
+    df, bash, tools = F["df"], F["bash"], F["tools"]
+    out = []
+
+    a = df.filter((pl.col("kind") == "assistant") & pl.col("model").is_not_null()
+                  & (pl.col("model") != "<synthetic>"))
+    if a.height:
+        out.append(("model loop profile", a.group_by("model").agg(
+            pl.len().alias("turns"), pl.col("out_tok").median().alias("med_out_tok"),
+            pl.col("n_tooluse").mean().round(2).alias("avg_tooluse"),
+            pl.col("n_think").mean().round(2).alias("avg_think"),
+            (pl.col("speed") == "fast").mean().round(3).alias("frac_fast"),
+        ).sort("turns", descending=True)))
+
+    if bash.height:
+        bb = bash.with_columns(pl.col("cmd").map_elements(klass, return_dtype=pl.String).alias("class"))
+        out.append(("command classes by cumulative wall-clock (s)", bb.group_by("class").agg(
+            pl.len().alias("n"), pl.col("seconds").sum().round(0).alias("total_s"),
+            pl.col("seconds").median().round(1).alias("med_s"),
+            pl.col("seconds").max().round(0).alias("max_s"),
+            pl.col("is_error").sum().alias("errs"),
+        ).sort("total_s", descending=True).head(top)))
+        out.append(("slowest single commands", bash.sort("seconds", descending=True)
+                    .select("seconds", "is_error", "cmd").head(top)))
+        out.append(("most repeated error-producing commands", bash.filter("is_error")
+                    .with_columns(pl.col("cmd").map_elements(strip_prefix, return_dtype=pl.String).str.slice(0, 60).alias("c"))
+                    .group_by("c").agg(pl.len().alias("fails"), pl.col("seconds").sum().round(0).alias("wasted_s"))
+                    .sort("fails", descending=True).head(top)))
+        out.append(("recurring tasks across sessions (candidates to script)",
+                    bash.with_columns(pl.col("cmd").map_elements(norm_cmd, return_dtype=pl.String).alias("task"))
+                    .group_by("task").agg(pl.col("session").n_unique().alias("sessions"), pl.len().alias("runs"),
+                                          pl.col("seconds").sum().round(0).alias("total_s"))
+                    .filter(pl.col("sessions") >= 3).sort(["sessions", "total_s"], descending=True).head(top)))
+        # signal 7: escape hatches / jank -> arch-fix candidates
+        jrows = []
+        for label, pat in JANK:
+            mask = bash.filter(pl.col("cmd").map_elements(lambda c, p=pat: bool(p.search(c)), return_dtype=pl.Boolean))
+            if mask.height:
+                jrows.append((label, mask.height, mask["session"].n_unique(), round(mask["seconds"].sum())))
+        if jrows:
+            out.append(("escape hatches / jank (arch-fix candidates)",
+                        pl.DataFrame(jrows, schema=["jank", "runs", "sessions", "total_s"], orient="row")
+                        .sort(["sessions", "runs"], descending=True)))
+
+    if tools.height:
+        out.append(("context bloat by tool", tools.group_by("tool").agg(
+            pl.len().alias("calls"), (pl.col("size") >= oversize).sum().alias("oversized"),
+            pl.col("size").max().alias("max_bytes"), pl.col("size").sum().alias("total_bytes"),
+        ).sort("total_bytes", descending=True).head(top)))
+        out.append(("biggest single results (scope these)", tools.sort("size", descending=True)
+                    .select("tool", "size", "label").head(top)))
+
+    if F["corrections"]:
+        out.append((f"human corrections ({len(F['corrections'])} total)",
+                    pl.DataFrame(F["corrections"]).sort("prior_tools", descending=True)
+                    .select("session", "prior_tools", "prior_errors", "prompt").head(top)))
+    if F["chains"]:
+        out.append((f"long autonomous chains w/ errors ({len(F['chains'])} total)",
+                    pl.DataFrame(F["chains"]).sort(["errors", "tools"], descending=True).head(top)))
+    return out
+
+
+def report(F, top: int = 15, oversize: int = 20000):
+    import polars as pl
+    print(summary_line(F))
+    for title, frame in aggregates(F, top, oversize):
+        print(f"\n=== {title} ===")
+        with pl.Config(tbl_rows=top, tbl_cols=20, fmt_str_lengths=70, tbl_width_chars=160):
+            print(frame)
+
+
+def write_html(F, path, top: int = 15, oversize: int = 20000):
+    import polars as pl
+    path = os.path.expanduser(path)
+    css = ("body{font:13px ui-monospace,SFMono-Regular,Menlo,monospace;margin:2rem;"
+           "background:#fff;color:#111}h1{font-size:18px}h2{font-size:14px;margin-top:2rem;"
+           "border-bottom:1px solid #ddd;padding-bottom:.3rem}table{border-collapse:collapse;"
+           "font-size:12px}th,td{border:1px solid #ddd;padding:3px 8px;text-align:left}"
+           "th{background:#f4f4f4}@media(prefers-color-scheme:dark){body{background:#0d0d0d;"
+           "color:#ddd}h2{border-color:#333}th,td{border-color:#333}th{background:#1a1a1a}}")
+    parts = [f"<!doctype html><html><head><meta charset=utf-8><title>optimize report</title>"
+             f"<style>{css}</style></head><body>",
+             f"<h1>optimize report</h1><p>{html.escape(summary_line(F))}</p>"]
+    with pl.Config(tbl_rows=top, fmt_str_lengths=120):
+        for title, frame in aggregates(F, top, oversize):
+            parts.append(f"<h2>{html.escape(title)}</h2>")
+            parts.append(frame._repr_html_())
+    parts.append("</body></html>")
+    with open(path, "w") as fh:
+        fh.write("".join(parts))
+    return path
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--days", type=int, default=45)
+    ap.add_argument("--full", action="store_true")
+    ap.add_argument("--out", default=os.path.expanduser("~/.claude/optimize"))
+    ap.add_argument("--top", type=int, default=15)
+    ap.add_argument("--oversize", type=int, default=20000)
+    args = ap.parse_args()
+    os.makedirs(args.out, exist_ok=True)
+    F = build_frames(days=args.days, full=args.full)
+    report(F, top=args.top, oversize=args.oversize)
+    F["df"].write_parquet(os.path.join(args.out, "history_rows.parquet"))
+    F["bash"].write_parquet(os.path.join(args.out, "history_bash.parquet"))
+    F["tools"].write_parquet(os.path.join(args.out, "history_tools.parquet"))
+    with open(os.path.join(args.out, "findings.json"), "w") as fh:
+        json.dump({k: F[k] for k in ("window", "files", "corrections", "chains")}, fh, indent=2)
+    write_html(F, os.path.join(args.out, "report.html"), top=args.top, oversize=args.oversize)
+    print(f"\nwrote parquet caches + findings.json + report.html to {args.out}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/portable-services.nix
+++ b/tests/portable-services.nix
@@ -56,6 +56,15 @@ let
         "--msg=hello world"
       ];
     };
+
+    # runAtLoad = false on an interval service + an explicit label override:
+    # exercises the negative path of both portable improvements.
+    quiet = {
+      command = [ "/run/current-system/sw/bin/q" ];
+      interval = 600;
+      runAtLoad = false;
+      label = "com.example.quiet";
+    };
   };
 
   daemonLaunchd = ps.toLaunchdConfig specs.daemon;
@@ -63,6 +72,8 @@ let
   pollerLaunchd = ps.toLaunchdConfig specs.poller;
   pollerSystemd = ps.toSystemdUnits specs.poller;
   quotedSystemd = ps.toSystemdUnits specs.quoted;
+  quietLaunchd = ps.toLaunchdConfig specs.quiet;
+  quietSystemd = ps.toSystemdUnits specs.quiet;
 
   assertions = [
     # --- daemon: launchd ---
@@ -75,8 +86,8 @@ let
       message = "daemon launchd ProgramArguments mismatch";
     }
     {
-      assertion = daemonLaunchd.Label == "demo daemon";
-      message = "daemon launchd Label should default to description";
+      assertion = daemonLaunchd.Label == "org.nix-community.home.daemon";
+      message = "daemon launchd Label should default to the name-based home convention";
     }
     {
       assertion = daemonLaunchd.RunAtLoad == true;
@@ -121,14 +132,14 @@ let
       message = "daemon without interval must not produce a timer";
     }
 
-    # --- poller: launchd (interval => StartInterval, no RunAtLoad) ---
+    # --- poller: launchd (interval => StartInterval + RunAtLoad via runAtLoad) ---
     {
       assertion = pollerLaunchd.StartInterval == 300;
       message = "poller launchd StartInterval mismatch";
     }
     {
-      assertion = !(pollerLaunchd ? RunAtLoad);
-      message = "interval service must not set RunAtLoad on launchd";
+      assertion = pollerLaunchd.RunAtLoad == true;
+      message = "interval service should honor runAtLoad (default true) alongside StartInterval";
     }
     {
       assertion = pollerLaunchd.KeepAlive == { SuccessfulExit = false; };
@@ -153,6 +164,11 @@ let
       message = "poller should produce a timer with OnUnitActiveSec = interval";
     }
     {
+      assertion =
+        pollerSystemd.timer.Timer.OnActiveSec == "1s" && !(pollerSystemd.timer.Timer ? OnBootSec);
+      message = "runAtLoad interval service: timer fires promptly via OnActiveSec, not OnBootSec";
+    }
+    {
       assertion = pollerSystemd.timer.Install.WantedBy == [ "timers.target" ];
       message = "poller timer should be WantedBy timers.target";
     }
@@ -166,6 +182,20 @@ let
       assertion =
         quotedSystemd.service.Service.ExecStart == "/run/current-system/sw/bin/note \"--msg=hello world\"";
       message = "argv element with a space should be systemd double-quoted, not shell-escaped";
+    }
+
+    # --- quiet: runAtLoad=false interval + explicit label override ---
+    {
+      assertion = quietLaunchd.Label == "com.example.quiet";
+      message = "explicit label should override the name-based default";
+    }
+    {
+      assertion = !(quietLaunchd ? RunAtLoad);
+      message = "runAtLoad=false must not set RunAtLoad on launchd";
+    }
+    {
+      assertion = quietSystemd.timer.Timer.OnBootSec == 600 && !(quietSystemd.timer.Timer ? OnActiveSec);
+      message = "runAtLoad=false timer should wait OnBootSec, not fire via OnActiveSec";
     }
   ];
 

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -104,6 +104,33 @@ let
     ];
     text = builtins.readFile ./scripts/ix-downtime.sh;
   };
+
+  # Token-free periodic refresh of the /optimize history analysis. Runs the
+  # `optimize` skill's own bundled polars library headless via `uv run --with
+  # polars` (no index MCP session under launchd/systemd, and uv is the clean way
+  # to get polars off-session; uv manages its own python). The script path is
+  # baked from the skill's asset so the service and the skill share one source of
+  # truth. It scans the last 60 days of ~/.claude history into
+  # ~/.claude/optimize/{latest.txt, *.parquet} — NO LLM, NO sound — so it is safe
+  # to run often; `/optimize` reads these fresh caches for the synthesized report.
+  # coreutils provides ls/cp/date/tail for the dated-snapshot rotation.
+  optimizeScan = mkBashApp {
+    name = "optimize-scan";
+    runtimeInputs = [
+      pkgs.uv
+      pkgs.coreutils
+    ];
+    text = ''
+      OUT="$HOME/.claude/optimize"
+      mkdir -p "$OUT"
+      uv run --with polars ${../../skills/optimize/assets/build_history_df.py} \
+        --days 60 --out "$OUT" > "$OUT/latest.txt" 2>&1
+      cp "$OUT/latest.txt" "$OUT/report-$(date +%F).txt"
+      # keep only the 14 most recent dated snapshots
+      { ls -1t "$OUT"/report-*.txt 2>/dev/null || true; } | tail -n +15 \
+        | while read -r f; do rm -f "$f"; done
+    '';
+  };
 in
 {
   imports = [ portableServicesModule ];
@@ -133,18 +160,6 @@ in
         default = 30;
         description = "Poll the status page every N seconds.";
       };
-
-      label = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = "org.nix-community.home.ix-downtime";
-        description = ''
-          launchd Label for the watcher agent. Pinned to the home-manager
-          reverse-DNS convention: it keeps the plist filename
-          (`<Label>.plist`) free of spaces and lets a switch update the
-          existing agent in place. Null leaves the portable layer's default
-          (`description`), which would otherwise be the human title.
-        '';
-      };
     };
 
     bossbarOverlay = {
@@ -153,15 +168,19 @@ in
         default = true;
         description = "Run the always-on-top Minecraft boss bar overlay GUI the watcher draws onto.";
       };
+    };
 
-      label = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = "org.nix-community.home.bossbar-overlay";
-        description = ''
-          launchd Label for the overlay agent. Pinned to the home-manager
-          convention so this updates an existing agent in place instead of
-          orphaning the old plist. Null leaves the portable layer's default.
-        '';
+    optimize = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Run the token-free /optimize history scan on a schedule (refreshes ~/.claude/optimize for the /optimize skill).";
+      };
+
+      interval = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 3600;
+        description = "Re-scan ~/.claude history every N seconds.";
       };
     };
 
@@ -200,18 +219,21 @@ in
           interval = cfg.downtime.interval;
           standardOutPath = "${cfg.logDir}/ix-downtime.log";
           standardErrorPath = "${cfg.logDir}/ix-downtime.log";
-          # Pin the launchd Label (off `description`, which has spaces) to the
-          # home-manager convention so the plist filename stays space-free and a
-          # switch updates the existing agent in place. RunAtLoad fires the first
-          # poll immediately on switch/login instead of waiting one interval
-          # (the portable layer omits it for interval services); the script's
-          # own flock guard keeps a slow poll from overlapping the next fire.
-          launchd.config = {
-            RunAtLoad = true;
-          }
-          // lib.optionalAttrs (cfg.downtime.label != null) {
-            Label = cfg.downtime.label;
-          };
+          # No launchd escape hatch needed: the portable layer's `runAtLoad`
+          # (default true) fires the first poll immediately even for interval
+          # services, and the launchd Label defaults to the space-free home
+          # convention. The script's own flock guard prevents overlap.
+        };
+      })
+      (lib.mkIf cfg.optimize.enable {
+        optimize-scan = {
+          description = "optimize history scan";
+          command = [ (lib.getExe' optimizeScan "optimize-scan") ];
+          interval = cfg.optimize.interval;
+          standardOutPath = "${cfg.logDir}/optimize-scan.log";
+          standardErrorPath = "${cfg.logDir}/optimize-scan.log";
+          # runAtLoad (default true) gives an immediate first scan on load;
+          # Label defaults to the space-free home convention. No escape hatch.
         };
       })
       (lib.mkIf cfg.bossbarOverlay.enable {
@@ -221,11 +243,7 @@ in
           restart = "always";
           standardOutPath = "${cfg.logDir}/bossbar-overlay.log";
           standardErrorPath = "${cfg.logDir}/bossbar-overlay.log";
-          # Pin the launchd Label so this updates the existing agent in place
-          # instead of orphaning the old `org.nix-community.home.*` plist.
-          launchd.config = lib.optionalAttrs (cfg.bossbarOverlay.label != null) {
-            Label = cfg.bossbarOverlay.label;
-          };
+          # Label defaults to the space-free home convention; no escape hatch.
         };
       })
     ];


### PR DESCRIPTION
Adds a fleet-wide `/optimize` skill that mines `~/.claude` history with polars (runs in the index MCP python session, no uv) and reports where past sessions wasted time, then drafts the CLAUDE.md / skill / hook fixes.

Signals: slow model loops, command/CI/build-graph waste, oversized tool results (context bloat), human-corrected mistakes, multi-turn flailing, recurring-task→reusable-script, and escape-hatch/jank→architecture-fix. Emits a text + a self-contained HTML report.

Also:
- `users/andrewgazelka`: token-free `optimize-scan` portable service (launchd + systemd timer) that refreshes the caches hourly.
- `lib/portable-services`: honor `runAtLoad` for interval services and default the launchd `Label` to `org.nix-community.home.<name>`, so services need **no** `RunAtLoad`/`Label` escape hatch. `ix-downtime` / `bossbar-overlay` / `optimize-scan` simplified; golden test updated.

Validated end-to-end via a hydra `home-manager switch` against this branch: golden test + lint green, the launchd agent fires on load and writes `report.html`, and the existing services' plists update in place (no orphans).

Made with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add optimize history skill and improve portable-services label and runAtLoad behavior
> - Adds [build_history_df.py](https://github.com/indexable-inc/index/pull/527/files#diff-f81bb9471f9d4c585bfb7c64a786743a7678efc9d9596dfa7a5dc3779733406d), a CLI that parses `~/.claude/projects/*/*.jsonl` transcripts and produces leaderboard tables, parquet caches, `findings.json`, and an HTML report without invoking an LLM.
> - Wires an `optimize-scan` portable interval service in [users/andrewgazelka/home.nix](https://github.com/indexable-inc/index/pull/527/files#diff-b9c7bb705f699ec210f648820aef5c561583845b682d07d6e1dc19de7685cb0f) that runs the scan on load and at a configurable interval (default 3600s).
> - Adds a `label` option to [lib/portable-services.nix](https://github.com/indexable-inc/index/pull/527/files#diff-062a2f28f34f916ca6ca914b56ea9346d3fa3e96c06d05e2b510576ab2843ad3) so launchd Label defaults to a deterministic reverse-DNS string (`org.nix-community.home.<name>`) instead of the human description.
> - Reworks `runAtLoad` semantics for interval services: launchd now emits `RunAtLoad=true` alongside `StartInterval`; systemd uses `OnActiveSec=1s` when `runAtLoad=true` and `OnBootSec=<interval>` otherwise.
> - Behavioral Change: existing launchd interval agents will run immediately on load by default (previously waited for the first interval); launchd Label values change to the new reverse-DNS default, affecting plist filenames.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d29aefe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->