### PR TITLE
fix(optimize): crash-proof history scan + restore overlap guard (#527 follow-up)

### DIFF
--- a/skills/optimize/assets/build_history_df.py
+++ b/skills/optimize/assets/build_history_df.py
@@ -17,7 +17,7 @@ writes parquet caches, findings.json, latest.txt, and report.html.
 
 Schema verified against real transcripts:
   - usage.speed is a categorical label ("fast"), NOT tokens/sec
-  - usage.iterations is a LIST of per-iteration usage structs (count = len)
+  - usage.iterations is treated as a list of per-iteration usage structs (count = len, else 0)
   - per-command wall-clock = tool_result.ts - tool_use.ts, matched by tool_use_id
   - a REAL human prompt is a string-content user entry with a top-level promptId;
     harness-injected user messages have no promptId and must be excluded
@@ -61,9 +61,22 @@ TRUNC = re.compile(r"\[truncated\]")
 
 def parse_ts(s):
     try:
-        return datetime.fromisoformat((s or "").replace("Z", "+00:00"))
+        dt = datetime.fromisoformat((s or "").replace("Z", "+00:00"))
+        # Force timezone-aware (UTC) so naive + aware timestamps never mix in a
+        # subtraction (a single naive transcript ts would otherwise TypeError).
+        return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
     except Exception:
         return None
+
+
+def _row_schema(pl):
+    # Explicit schema so an empty scan window still yields a frame WITH columns
+    # (a schema-less pl.DataFrame([]) has no "kind" column and later filters crash).
+    return {
+        "session": pl.String, "ts": pl.Datetime("us", "UTC"), "kind": pl.String,
+        "model": pl.String, "speed": pl.String, "n_iter": pl.Int64, "out_tok": pl.Int64,
+        "n_tooluse": pl.Int64, "n_think": pl.Int64, "is_sidechain": pl.Boolean,
+    }
 
 
 def is_real_prompt(r, content) -> bool:
@@ -121,57 +134,59 @@ def build_frames(days: int = 45, full: bool = False):
         for l in lines:
             if not l.strip():
                 continue
+            # One malformed/unexpected record must not abort the whole scan.
             try:
                 r = json.loads(l)
+                t = r.get("type")
+                m = r.get("message") if isinstance(r.get("message"), dict) else {}
+                ts = parse_ts(r.get("timestamp", ""))
+                content = m.get("content")
+                if t == "assistant":
+                    blocks = content if isinstance(content, list) else []
+                    tu = [b for b in blocks if isinstance(b, dict) and b.get("type") == "tool_use"]
+                    th = sum(1 for b in blocks if isinstance(b, dict) and b.get("type") == "thinking")
+                    u = m.get("usage") or {}
+                    it = u.get("iterations")
+                    run_tools += len(tu)
+                    rows.append(dict(
+                        session=sess, ts=ts, kind="assistant", model=m.get("model"),
+                        speed=u.get("speed"), n_iter=(len(it) if isinstance(it, list) else 0),
+                        out_tok=u.get("output_tokens"), n_tooluse=len(tu), n_think=th,
+                        is_sidechain=bool(r.get("isSidechain")),
+                    ))
+                    for b in tu:
+                        inp = b.get("input") or {}
+                        label = (inp.get("command") or inp.get("file_path") or inp.get("pattern")
+                                 or inp.get("query") or inp.get("description") or "")
+                        tool_calls[b.get("id")] = (ts, b.get("name"), str(label)[:200], sess)
+                elif t == "user":
+                    blocks = content if isinstance(content, list) else None
+                    if blocks:
+                        for b in blocks:
+                            if not (isinstance(b, dict) and b.get("type") == "tool_result"):
+                                continue
+                            tid = b.get("tool_use_id")
+                            size = len(_cstr(b.get("content")))
+                            err = bool(b.get("is_error"))
+                            ts0, name, label, _ = tool_calls.get(tid, (None, "?", "", sess))
+                            tool_results.append((sess, name, label, size, err))
+                            if err:
+                                run_errs += 1
+                            if name == "Bash" and ts is not None and ts0 is not None:
+                                bash_done.append((sess, label, (ts - ts0).total_seconds(), err))
+                    elif is_real_prompt(r, content):
+                        if run_tools >= 8 and run_errs >= 1:
+                            chains.append(dict(session=sess, tools=run_tools, errors=run_errs,
+                                               next_prompt=content[:160]))
+                        if CORRECTION.search(content) and run_tools >= 1:
+                            corrections.append(dict(session=sess, ts=str(ts), prior_tools=run_tools,
+                                                    prior_errors=run_errs, prompt=content[:200]))
+                        run_tools = run_errs = 0
             except Exception:
                 continue
-            t = r.get("type")
-            m = r.get("message") if isinstance(r.get("message"), dict) else {}
-            ts = parse_ts(r.get("timestamp", ""))
-            content = m.get("content")
-            if t == "assistant":
-                blocks = content if isinstance(content, list) else []
-                tu = [b for b in blocks if isinstance(b, dict) and b.get("type") == "tool_use"]
-                th = sum(1 for b in blocks if isinstance(b, dict) and b.get("type") == "thinking")
-                u = m.get("usage") or {}
-                run_tools += len(tu)
-                rows.append(dict(
-                    session=sess, ts=ts, kind="assistant", model=m.get("model"),
-                    speed=u.get("speed"), n_iter=len(u.get("iterations") or []),
-                    out_tok=u.get("output_tokens"), n_tooluse=len(tu), n_think=th,
-                    is_sidechain=bool(r.get("isSidechain")),
-                ))
-                for b in tu:
-                    inp = b.get("input") or {}
-                    label = (inp.get("command") or inp.get("file_path") or inp.get("pattern")
-                             or inp.get("query") or inp.get("description") or "")
-                    tool_calls[b.get("id")] = (ts, b.get("name"), str(label)[:200], sess)
-            elif t == "user":
-                blocks = content if isinstance(content, list) else None
-                if blocks:
-                    for b in blocks:
-                        if not (isinstance(b, dict) and b.get("type") == "tool_result"):
-                            continue
-                        tid = b.get("tool_use_id")
-                        size = len(_cstr(b.get("content")))
-                        err = bool(b.get("is_error"))
-                        ts0, name, label, _ = tool_calls.get(tid, (None, "?", "", sess))
-                        tool_results.append((sess, name, label, size, err))
-                        if err:
-                            run_errs += 1
-                        if name == "Bash" and ts is not None and ts0 is not None:
-                            bash_done.append((sess, label, (ts - ts0).total_seconds(), err))
-                elif is_real_prompt(r, content):
-                    if run_tools >= 8 and run_errs >= 1:
-                        chains.append(dict(session=sess, tools=run_tools, errors=run_errs,
-                                           next_prompt=content[:160]))
-                    if CORRECTION.search(content) and run_tools >= 1:
-                        corrections.append(dict(session=sess, ts=str(ts), prior_tools=run_tools,
-                                                prior_errors=run_errs, prompt=content[:200]))
-                    run_tools = run_errs = 0
 
     return dict(
-        df=pl.DataFrame(rows),
+        df=pl.DataFrame(rows, schema=_row_schema(pl)),
         bash=pl.DataFrame(bash_done, schema=["session", "cmd", "seconds", "is_error"], orient="row"),
         tools=pl.DataFrame(tool_results, schema=["session", "tool", "label", "size", "is_error"], orient="row"),
         corrections=corrections, chains=chains,

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -119,10 +119,18 @@ let
     runtimeInputs = [
       pkgs.uv
       pkgs.coreutils
+      pkgs.perl # flock(2) for the non-overlap guard (no flock(1) on macOS)
     ];
     text = ''
       OUT="$HOME/.claude/optimize"
       mkdir -p "$OUT"
+      # Non-overlap guard: if a prior scan is still running, skip this fire. perl
+      # takes an exclusive non-blocking flock on fd 9, which the shell keeps open
+      # for the whole run, so the lock auto-releases on exit or crash. Prevents two
+      # uv processes racing the parquet/HTML writes when a slow scan overruns the
+      # interval (the old personal launchd agent had this via lockArgs).
+      exec 9>"$OUT/.scan.lock"
+      perl -e 'use Fcntl ":flock"; flock(STDIN, LOCK_EX | LOCK_NB) or exit 1' <&9 || exit 0
       uv run --with polars ${../../skills/optimize/assets/build_history_df.py} \
         --days 60 --out "$OUT" > "$OUT/latest.txt" 2>&1
       cp "$OUT/latest.txt" "$OUT/report-$(date +%F).txt"


### PR DESCRIPTION
fix(optimize): crash-proof the history scan + restore overlap guard (#527 review follow-up)

build_history_df.py:
- C1: explicit row schema so an empty/stale scan window yields a frame WITH columns
  (was ColumnNotFoundError on accounts with no recent ~/.claude history -> the
  default-enabled optimize-scan service would only write a traceback).
- C2: tolerate a non-list usage.iterations and wrap per-record parsing in try/except,
  so one malformed transcript line can't abort the whole 2200-file scan.
- C3: parse_ts returns timezone-aware UTC, so naive + aware timestamps never mix in a
  subtraction.

users/andrewgazelka: re-add a non-overlap flock guard to optimize-scan (perl flock on
fd 9; the prior personal launchd agent had this via lockArgs) so two slow scans can't
race the parquet/HTML writes.

Made with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix crash-prone history scan and restore overlap guard in optimize skill
> - [`build_history_df.py`](https://github.com/indexable-inc/index/pull/528/files#diff-f81bb9471f9d4c585bfb7c64a786743a7678efc9d9596dfa7a5dc3779733406d): `parse_ts` now attaches UTC tzinfo to naive datetimes, preventing `TypeError` during timestamp arithmetic.
> - `build_frames` wraps per-record processing in a try/except to skip malformed records instead of aborting the scan, and uses an explicit Polars schema so the rows DataFrame has stable columns even when empty.
> - [`home.nix`](https://github.com/indexable-inc/index/pull/528/files#diff-b9c7bb705f699ec210f648820aef5c561583845b682d07d6e1dc19de7685cb0f): adds a `flock`-based non-blocking lock (via Perl one-liner) so a scheduled scan exits immediately if a previous scan is still running, preventing concurrent writes to output files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4f9b6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->