### PR TITLE
feat(git-log-pretty): inline GitHub author avatars via kitty graphics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,40 +1031,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "source-atuin"
-version = "0.1.0"
-dependencies = [
- "rusqlite",
- "serde_json",
- "snafu 0.9.1",
- "source-meta",
-]
-
-[[package]]
-name = "source-claude"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "nix 0.30.1",
- "source-meta",
- "serde",
- "serde_json",
- "snafu 0.9.1",
- "tempfile",
-]
-
-[[package]]
-name = "source-codex"
-version = "0.1.0"
-dependencies = [
- "nix 0.30.1",
- "serde",
- "serde_json",
- "snafu 0.9.1",
- "source-meta",
-]
-
-[[package]]
 name = "clone-cli"
 version = "0.1.0"
 dependencies = [
@@ -1209,6 +1175,12 @@ dependencies = [
  "tracing-core",
  "tracing-error",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -2215,6 +2187,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,9 +2212,12 @@ dependencies = [
  "color-eyre",
  "devicons",
  "git2",
+ "github-avatar",
+ "kitty",
  "strip-ansi-escapes",
  "tempfile",
  "terminal-theme",
+ "tokio",
 ]
 
 [[package]]
@@ -2246,6 +2231,16 @@ dependencies = [
  "libgit2-sys",
  "log",
  "url",
+]
+
+[[package]]
+name = "github-avatar"
+version = "0.1.0"
+dependencies = [
+ "image",
+ "reqwest",
+ "serde",
+ "snafu 0.9.1",
 ]
 
 [[package]]
@@ -2771,9 +2766,24 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -3016,6 +3026,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kitty"
+version = "0.1.0"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "lazy-regex"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3204,26 +3221,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "source-git"
-version = "0.1.0"
-dependencies = [
- "serde_json",
- "snafu 0.9.1",
- "source-meta",
-]
-
-[[package]]
-name = "source-linear"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "source-meta",
- "serde",
- "serde_json",
- "snafu 0.9.1",
 ]
 
 [[package]]
@@ -4729,6 +4726,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5419,23 +5422,13 @@ dependencies = [
  "regex",
  "repo-walker",
  "rusqlite",
- "source-meta",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "snafu 0.9.1",
+ "source-meta",
  "tempfile",
  "tokio",
-]
-
-[[package]]
-name = "source-meta"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "snafu 0.9.1",
 ]
 
 [[package]]
@@ -5688,25 +5681,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
-
-[[package]]
-name = "sketches-ddsketch"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "sink-mixedbread"
 version = "0.1.0"
 dependencies = [
@@ -5734,20 +5708,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "source-slack"
-version = "0.1.0"
-dependencies = [
- "source-meta",
- "serde",
- "serde_json",
- "snafu 0.9.1",
-]
 
 [[package]]
 name = "smallvec"
@@ -5814,6 +5797,80 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "source-atuin"
+version = "0.1.0"
+dependencies = [
+ "rusqlite",
+ "serde_json",
+ "snafu 0.9.1",
+ "source-meta",
+]
+
+[[package]]
+name = "source-claude"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "nix 0.30.1",
+ "serde",
+ "serde_json",
+ "snafu 0.9.1",
+ "source-meta",
+ "tempfile",
+]
+
+[[package]]
+name = "source-codex"
+version = "0.1.0"
+dependencies = [
+ "nix 0.30.1",
+ "serde",
+ "serde_json",
+ "snafu 0.9.1",
+ "source-meta",
+]
+
+[[package]]
+name = "source-git"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "snafu 0.9.1",
+ "source-meta",
+]
+
+[[package]]
+name = "source-linear"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "snafu 0.9.1",
+ "source-meta",
+]
+
+[[package]]
+name = "source-meta"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "snafu 0.9.1",
+]
+
+[[package]]
+name = "source-slack"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "snafu 0.9.1",
+ "source-meta",
 ]
 
 [[package]]
@@ -7273,6 +7330,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8085,4 +8148,19 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,9 @@ members = [
   "packages/file-language",
   "packages/file-search",
   "packages/git-log-pretty",
+  "packages/github-avatar",
   "packages/ix-dev-diagnose",
+  "packages/kitty",
   "packages/macos-vm",
   "packages/mcp",
   "packages/minecraft/nbt",
@@ -104,6 +106,8 @@ clone-pragma = { path = "packages/clone-detect/pragma" }
 clone-scanner = { path = "packages/clone-detect/scanner" }
 code-highlight = { path = "packages/code-highlight" }
 code-tokenizer = { path = "packages/code-tokenizer" }
+github-avatar = { path = "packages/github-avatar" }
+kitty = { path = "packages/kitty" }
 color-eyre = "0.6"
 dashboard-core = { path = "packages/dashboard-core" }
 devicons = "0.6"
@@ -145,6 +149,7 @@ quartz_nbt = "0.2.9"
 rayon = "1"
 regex = "1"
 repo-walker = { path = "packages/repo-walker" }
+image = { version = "0.25", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "rustls-tls",

--- a/packages/git-log-pretty/Cargo.toml
+++ b/packages/git-log-pretty/Cargo.toml
@@ -14,14 +14,19 @@ chrono = { workspace = true, features = ["clock"] }
 clap = { workspace = true, features = ["derive"] }
 color-eyre.workspace = true
 devicons.workspace = true
+github-avatar.workspace = true
 # `default-features = false` drops the https/ssh transports (and their openssl /
 # libssh2 system deps) we never use for reading a local repo; `vendored-libgit2`
 # compiles the bundled libgit2 C source with `cc`, so the build needs no system
 # libgit2 or cmake. See libgit2-sys: with no `vendored` feature it probes
 # pkg-config first, which would add a system dependency to the workspace build.
 git2 = { workspace = true, default-features = false, features = ["vendored-libgit2"] }
+kitty.workspace = true
 strip-ansi-escapes.workspace = true
 terminal-theme.workspace = true
+# Avatars are fetched over HTTP from a sync CLI; a small current-thread tokio
+# runtime drives the async `github-avatar` client for the fetch phase only.
+tokio = { workspace = true, features = ["rt", "net", "time"] }
 
 [dev-dependencies]
 git2 = { workspace = true, default-features = false, features = ["vendored-libgit2"] }

--- a/packages/git-log-pretty/src/avatar.rs
+++ b/packages/git-log-pretty/src/avatar.rs
@@ -231,7 +231,9 @@ fn load_identities(repo: &Repository) -> HashMap<String, String> {
     let Ok(config) = repo.config() else {
         return map;
     };
-    if let Ok(entries) = config.entries(Some("githublogin.map")) {
+    // git2 treats the glob as a regex over the (lowercased) entry name; anchor
+    // it so it matches only `githublogin.map` and not other keys.
+    if let Ok(entries) = config.entries(Some("^githublogin\\.map$")) {
         let _ = entries.for_each(|entry| {
             if let Some((email, login)) = entry.value().and_then(|value| value.split_once('=')) {
                 let (email, login) = (email.trim(), login.trim());

--- a/packages/git-log-pretty/src/avatar.rs
+++ b/packages/git-log-pretty/src/avatar.rs
@@ -1,0 +1,273 @@
+//! Turn a commit author into avatar `PNG` bytes, resolving GitHub logins and
+//! caching aggressively so a single log view makes at most one network request
+//! per unique author.
+//!
+//! Resolution is cheapest-first and every step ties the email to a real account:
+//! an explicit `git config githubLogin.map` override, then the login embedded in
+//! a `noreply` email, then GitHub's record of who authored the commit. The
+//! async fetches are driven by the caller's tokio runtime; everything else is
+//! synchronous.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use git2::Repository;
+use github_avatar::Client;
+
+/// Name of the on-disk `email\tlogin` resolution cache within the cache dir.
+const LOGIN_CACHE_FILE: &str = "logins.tsv";
+
+/// An author's avatar, ready to hand to the renderer.
+pub struct Avatar {
+    /// `PNG`-encoded image bytes.
+    pub png: Vec<u8>,
+    /// A stable per-author id so repeated commits reuse one transmitted image.
+    pub id: u32,
+}
+
+/// Resolves and fetches author avatars, with in-memory and on-disk caches.
+pub struct Resolver {
+    client: Client,
+    /// `owner/repo` parsed from the `origin` remote, if it is a GitHub remote.
+    origin: Option<(String, String)>,
+    /// Explicit `email -> login` overrides from `git config githubLogin.map`.
+    identities: HashMap<String, String>,
+    size_px: u32,
+    /// Resolved `email -> login` (`None` = tried and failed), bounding requests.
+    /// Successful resolutions are also persisted to disk and reloaded next run.
+    login_cache: HashMap<String, Option<String>>,
+    /// Downloaded `login -> png` (`None` = tried and failed).
+    png_cache: HashMap<String, Option<Vec<u8>>>,
+    /// Stable display ids assigned per login.
+    login_ids: HashMap<String, u32>,
+    next_id: u32,
+    cache_dir: Option<PathBuf>,
+}
+
+impl Resolver {
+    /// Build a resolver for `repo`, reading the `origin` remote, the identity-map
+    /// overrides, a GitHub token, and the persisted login cache.
+    #[must_use]
+    pub fn new(repo: &Repository, size_px: u32) -> Self {
+        let origin = repo
+            .find_remote("origin")
+            .ok()
+            .and_then(|remote| remote.url().and_then(github_avatar::parse_remote));
+
+        let cache_dir = avatar_cache_dir();
+        let login_cache = cache_dir
+            .as_ref()
+            .map(|dir| load_login_cache(&dir.join(LOGIN_CACHE_FILE)))
+            .unwrap_or_default();
+
+        Self {
+            client: Client::new(discover_token()),
+            origin,
+            identities: load_identities(repo),
+            size_px,
+            login_cache,
+            png_cache: HashMap::new(),
+            login_ids: HashMap::new(),
+            // Seed the kitty image-id counter from the pid so concurrent tools
+            // sharing the terminal are unlikely to collide on image ids.
+            next_id: std::process::id().wrapping_mul(256).wrapping_add(1),
+            cache_dir,
+        }
+    }
+
+    /// Resolve and fetch the avatar for the author of `sha` (commit email
+    /// `email`). Returns `None` when the author cannot be mapped to a GitHub
+    /// account or the avatar cannot be fetched.
+    pub async fn avatar_for(&mut self, email: &str, sha: &str) -> Option<Avatar> {
+        let login = self.login_for(email, sha).await?;
+        let png = self.png_for(&login).await?;
+        let id = self.id_for(&login);
+        Some(Avatar { png, id })
+    }
+
+    async fn login_for(&mut self, email: &str, sha: &str) -> Option<String> {
+        let email = email.trim();
+        if email.is_empty() {
+            return None;
+        }
+        if let Some(login) = self.identities.get(email) {
+            return Some(login.clone());
+        }
+        if let Some(cached) = self.login_cache.get(email) {
+            return cached.clone();
+        }
+
+        let resolved = match github_avatar::parse_noreply(email) {
+            Some(user) => Some(user.login),
+            None => self.resolve_via_commit(sha).await,
+        };
+
+        self.login_cache.insert(email.to_string(), resolved.clone());
+        // Persist positive resolutions so later runs skip the network. Negatives
+        // stay in memory only: an unpushed commit can resolve once it lands.
+        if let Some(login) = &resolved {
+            self.persist_login(email, login);
+        }
+        resolved
+    }
+
+    async fn resolve_via_commit(&self, sha: &str) -> Option<String> {
+        let (owner, repo) = self.origin.as_ref()?;
+        self.client
+            .resolve_commit(owner, repo, sha)
+            .await
+            .ok()
+            .flatten()
+            .map(|user| user.login)
+    }
+
+    async fn png_for(&mut self, login: &str) -> Option<Vec<u8>> {
+        if let Some(cached) = self.png_cache.get(login) {
+            return cached.clone();
+        }
+        let bytes = self.load_or_fetch_png(login).await;
+        self.png_cache.insert(login.to_string(), bytes.clone());
+        bytes
+    }
+
+    /// Read the avatar from the on-disk cache, or download and cache it. Returns
+    /// `None` only when the download fails.
+    async fn load_or_fetch_png(&self, login: &str) -> Option<Vec<u8>> {
+        // A plain `is_some` check rather than `if let` / `match` on the Option:
+        // the miss path is async, which `option_if_let_else`'s `map_or_else`
+        // rewrite cannot express.
+        let cached = self.read_disk(login);
+        if cached.is_some() {
+            return cached;
+        }
+        let bytes = self.client.avatar_png(login, self.size_px).await.ok()?;
+        self.write_disk(login, &bytes);
+        Some(bytes)
+    }
+
+    fn id_for(&mut self, login: &str) -> u32 {
+        if let Some(id) = self.login_ids.get(login) {
+            return *id;
+        }
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1);
+        self.login_ids.insert(login.to_string(), id);
+        id
+    }
+
+    fn disk_path(&self, login: &str) -> Option<PathBuf> {
+        let sanitized: String = login
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+            .collect();
+        Some(
+            self.cache_dir
+                .as_ref()?
+                .join(format!("{sanitized}-{size}.png", size = self.size_px)),
+        )
+    }
+
+    fn read_disk(&self, login: &str) -> Option<Vec<u8>> {
+        std::fs::read(self.disk_path(login)?).ok()
+    }
+
+    fn write_disk(&self, login: &str, bytes: &[u8]) {
+        let Some(path) = self.disk_path(login) else {
+            return;
+        };
+        if let Some(dir) = path.parent() {
+            let _ = std::fs::create_dir_all(dir);
+        }
+        let _ = std::fs::write(path, bytes);
+    }
+
+    /// Append an `email\tlogin` line to the on-disk resolution cache.
+    /// Best-effort: failures (no cache dir, read-only fs) are ignored.
+    fn persist_login(&self, email: &str, login: &str) {
+        // Tabs and newlines would corrupt the line format; such values never
+        // come from a valid email or login, so skip them defensively.
+        if email.contains(['\t', '\n']) || login.contains(['\t', '\n']) {
+            return;
+        }
+        let Some(path) = self.cache_dir.as_ref().map(|dir| dir.join(LOGIN_CACHE_FILE)) else {
+            return;
+        };
+        if let Some(dir) = path.parent() {
+            let _ = std::fs::create_dir_all(dir);
+        }
+        if let Ok(mut file) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
+            use std::io::Write;
+            let _ = writeln!(file, "{email}\t{login}");
+        }
+    }
+}
+
+/// Find a GitHub token for the authenticated API lookups: env first, then the
+/// `gh` CLI. Returns `None` if neither is available (the avatar download itself
+/// needs no token).
+fn discover_token() -> Option<String> {
+    for key in ["GITHUB_TOKEN", "GH_TOKEN"] {
+        if let Ok(value) = std::env::var(key) {
+            let value = value.trim();
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    let output = std::process::Command::new("gh").args(["auth", "token"]).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!token.is_empty()).then_some(token)
+}
+
+/// Read `email -> login` overrides from `git config githubLogin.map`.
+///
+/// The key is a multivar where each value is `email=login`. Lets a user pin
+/// their own avatar when their commit email is not linked to a GitHub account.
+fn load_identities(repo: &Repository) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let Ok(config) = repo.config() else {
+        return map;
+    };
+    if let Ok(entries) = config.entries(Some("githublogin.map")) {
+        let _ = entries.for_each(|entry| {
+            if let Some((email, login)) = entry.value().and_then(|value| value.split_once('=')) {
+                let (email, login) = (email.trim(), login.trim());
+                if !email.is_empty() && !login.is_empty() {
+                    map.insert(email.to_string(), login.to_string());
+                }
+            }
+        });
+    }
+    map
+}
+
+/// The directory holding cached avatars and resolutions, or `None` when neither
+/// `XDG_CACHE_HOME` nor `HOME` is set.
+fn avatar_cache_dir() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".cache")))?;
+    Some(base.join("git-log-pretty").join("avatars"))
+}
+
+/// Load the persisted `email -> login` resolutions (all positive) into a map.
+/// Later lines win, so a re-resolved login supersedes an older one. Missing or
+/// unreadable files yield an empty map.
+fn load_login_cache(path: &Path) -> HashMap<String, Option<String>> {
+    let mut map = HashMap::new();
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return map;
+    };
+    for line in contents.lines() {
+        if let Some((email, login)) = line.split_once('\t')
+            && !email.is_empty()
+            && !login.is_empty()
+        {
+            map.insert(email.to_string(), Some(login.to_string()));
+        }
+    }
+    map
+}

--- a/packages/git-log-pretty/src/display.rs
+++ b/packages/git-log-pretty/src/display.rs
@@ -1,7 +1,11 @@
 //! Format a commit's summary line and its changed-file tree for the terminal.
 
+use std::collections::HashSet;
+use std::fmt::Write;
+
 use anstyle::{Ansi256Color, AnsiColor, Color, Style};
 
+use crate::avatar::Avatar;
 use crate::palette::{self, Theme};
 use crate::tree;
 use crate::{git, time};
@@ -62,6 +66,38 @@ fn format_summary(summary: &str, theme: Theme) -> String {
     )
 }
 
+/// Build a commit's two rendered pieces: the `shorthash summary • when` header
+/// line and the (possibly empty) indented changed-file tree.
+fn commit_block(ahead: &git::AheadCommit<'_>, theme: Theme) -> color_eyre::eyre::Result<(String, String)> {
+    let commit = &ahead.commit;
+    let short = commit.id().to_string().chars().take(7).collect::<String>();
+    let summary = commit.summary().unwrap_or("<no message>").trim();
+    let when = time::relative(commit.time().seconds())?;
+
+    let yellow = palette::fg(Color::Ansi(AnsiColor::Yellow));
+    let dim = palette::fg(Color::Ansi256(Ansi256Color(8)));
+
+    let header = format!(
+        "  {short} {summary} {bullet} {when}",
+        short = palette::paint(yellow, &short),
+        summary = format_summary(summary, theme),
+        bullet = palette::paint(dim, "•"),
+        when = palette::paint(dim, &when),
+    );
+    let icons = tree::render(&ahead.changed_files, theme);
+    Ok((header, icons))
+}
+
+/// Write the plain header / tree / blank-line form (no avatar).
+fn write_plain(out: &mut dyn std::io::Write, header: &str, icons: &str) -> color_eyre::eyre::Result<()> {
+    writeln!(out, "{header}")?;
+    if !icons.is_empty() {
+        writeln!(out, "{icons}")?;
+    }
+    writeln!(out)?;
+    Ok(())
+}
+
 /// Write one commit block to `out`: a `shorthash summary • relative-time` line
 /// followed by the indented changed-file tree and a trailing blank line.
 pub fn print_commit(
@@ -69,34 +105,67 @@ pub fn print_commit(
     ahead: &git::AheadCommit<'_>,
     theme: Theme,
 ) -> color_eyre::eyre::Result<()> {
-    let commit = &ahead.commit;
-    let short = commit
-        .id()
-        .to_string()
-        .chars()
-        .take(7)
-        .collect::<String>();
-    let summary = commit.summary().unwrap_or("<no message>").trim();
-    let when = time::relative(commit.time().seconds())?;
+    let (header, icons) = commit_block(ahead, theme)?;
+    write_plain(out, &header, &icons)
+}
 
-    let yellow = palette::fg(Color::Ansi(AnsiColor::Yellow));
-    let dim = palette::fg(Color::Ansi256(Ansi256Color(8)));
+/// Write one commit block with the author's avatar in the left gutter.
+///
+/// The avatar is drawn via the kitty graphics protocol and the text is shifted
+/// right to clear it; with no avatar this falls back to the plain form.
+/// `transmitted` tracks image ids already sent this run, so a repeated author is
+/// redrawn with a cheap placement instead of resending the pixels.
+pub fn print_commit_with_avatar(
+    out: &mut dyn std::io::Write,
+    ahead: &git::AheadCommit<'_>,
+    theme: Theme,
+    avatar: Option<&Avatar>,
+    transmitted: &mut HashSet<u32>,
+    rows: u32,
+) -> color_eyre::eyre::Result<()> {
+    let (header, icons) = commit_block(ahead, theme)?;
 
-    writeln!(
-        out,
-        "  {short} {summary} {bullet} {when}",
-        short = palette::paint(yellow, &short),
-        summary = format_summary(summary, theme),
-        bullet = palette::paint(dim, "•"),
-        when = palette::paint(dim, &when),
-    )?;
+    let Some(avatar) = avatar.filter(|_| rows > 0) else {
+        return write_plain(out, &header, &icons);
+    };
 
-    let icons = tree::render(&ahead.changed_files, theme);
-    if !icons.is_empty() {
-        writeln!(out, "{icons}")?;
+    // Cells are about twice as tall as wide, so double the column count to keep
+    // the avatar square; one extra column separates it from the text.
+    let cols = rows * 2;
+    let gutter = cols + 1;
+    let placement = kitty::Placement {
+        cols: Some(cols),
+        rows: Some(rows),
+        move_cursor: false,
+    };
+
+    let mut buf = String::new();
+    // Anchor at column 0, then draw without moving the cursor (C=1).
+    buf.push('\r');
+    if transmitted.insert(avatar.id) {
+        buf.push_str(&kitty::transmit(
+            &kitty::Image::Png(&avatar.png),
+            Some(avatar.id),
+            &placement,
+        ));
+    } else {
+        buf.push_str(&kitty::place(avatar.id, &placement));
     }
-    writeln!(out)?;
 
+    let mut lines = vec![header.as_str()];
+    if !icons.is_empty() {
+        lines.extend(icons.lines());
+    }
+    // Print at least `rows` lines so the text advances past the image.
+    let count = lines.len().max(usize::try_from(rows).unwrap_or(usize::MAX));
+    for index in 0..count {
+        let content = lines.get(index).copied().unwrap_or("");
+        // Return to column 0, step right past the avatar, then write the text.
+        let _ = write!(buf, "\r\x1b[{gutter}C{content}\n");
+    }
+    buf.push('\n');
+
+    write!(out, "{buf}")?;
     Ok(())
 }
 

--- a/packages/git-log-pretty/src/main.rs
+++ b/packages/git-log-pretty/src/main.rs
@@ -9,12 +9,14 @@
 //! On a terminal the output is piped through a pager (`$PAGER`, else `less`),
 //! like `git log`; redirected output skips the pager. See [`pager`].
 
-use std::io::Write;
+use std::collections::HashSet;
+use std::io::{IsTerminal, Write};
 
 use anstyle::{AnsiColor, Color};
 use clap::{Parser, Subcommand};
 use color_eyre::eyre::{Result, WrapErr};
 
+mod avatar;
 mod display;
 mod git;
 mod pager;
@@ -29,12 +31,22 @@ use palette::{Theme, detect, fg, paint};
 /// view short.
 const MAX_COMMITS: usize = 15;
 
+/// Avatar size to request from GitHub, in pixels. Larger than any cell box so
+/// the terminal downscales rather than upscales.
+const AVATAR_SIZE_PX: u32 = 128;
+
 #[derive(Parser)]
 #[command(name = "git-log-pretty", about = "A pretty git log viewer with file-icon trees")]
 struct Cli {
     /// Write directly to stdout instead of piping through a pager.
     #[arg(long, global = true)]
     no_pager: bool,
+    /// Don't draw author GitHub avatars inline (kitty graphics protocol).
+    #[arg(long, global = true)]
+    no_avatar: bool,
+    /// Height of each inline avatar in terminal rows (0 disables avatars).
+    #[arg(long, global = true, default_value_t = 2)]
+    avatar_rows: u32,
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -58,50 +70,119 @@ fn main() -> Result<()> {
 
     let cli = Cli::parse();
     let allow_pager = !cli.no_pager;
+    let want_avatars = !cli.no_avatar;
+    let avatar_rows = cli.avatar_rows;
     match cli.command {
         Some(Command::Diff { base, head }) => {
             run_diff(&base, &head, allow_pager).wrap_err("failed to render diff stats")
         }
-        None => run_log(allow_pager).wrap_err("failed to render git log"),
+        None => {
+            run_log(allow_pager, want_avatars, avatar_rows).wrap_err("failed to render git log")
+        }
     }
 }
 
 /// Render the default commit log for the current repository. On `main` this is
 /// `main`'s own recent history; on any other branch it is the commits HEAD is
 /// ahead of `main`.
-fn run_log(allow_pager: bool) -> Result<()> {
+fn run_log(allow_pager: bool, want_avatars: bool, avatar_rows: u32) -> Result<()> {
     let repo = git::discover()?;
     let theme = detect();
 
     // On `main` there is nothing to be ahead of, so an ahead-of-main diff would
     // always be empty. Show recent history instead of "All caught up".
-    if git::head_branch_name(&repo).as_deref() == Some("main") {
-        let recent = git::recent_commits(&repo, MAX_COMMITS)?;
-        return pager::paged(allow_pager, |out| {
-            print_log(out, "Recent commits on main", &recent, theme)
-        });
-    }
-
-    let ahead = git::commits_ahead(&repo, "main")?;
-    if ahead.is_empty() {
-        println!("{}", paint(fg(Color::Ansi(AnsiColor::Green)), "All caught up with main"));
-        return Ok(());
-    }
-
-    let hidden = ahead.len().saturating_sub(MAX_COMMITS);
-    let header = if hidden > 0 {
-        let detail = paint(
-            fg(Color::Ansi(AnsiColor::BrightBlack)),
-            &format!(" (showing first {MAX_COMMITS}, {hidden} more hidden)"),
-        );
-        format!("{count} commits ahead of main{detail}", count = ahead.len())
+    let (header, commits) = if git::head_branch_name(&repo).as_deref() == Some("main") {
+        ("Recent commits on main".to_string(), git::recent_commits(&repo, MAX_COMMITS)?)
     } else {
-        let label = if ahead.len() == 1 { "commit" } else { "commits" };
-        format!("{count} {label} ahead of main", count = ahead.len())
+        let mut ahead = git::commits_ahead(&repo, "main")?;
+        if ahead.is_empty() {
+            println!("{}", paint(fg(Color::Ansi(AnsiColor::Green)), "All caught up with main"));
+            return Ok(());
+        }
+
+        let hidden = ahead.len().saturating_sub(MAX_COMMITS);
+        let header = if hidden > 0 {
+            let detail = paint(
+                fg(Color::Ansi(AnsiColor::BrightBlack)),
+                &format!(" (showing first {MAX_COMMITS}, {hidden} more hidden)"),
+            );
+            format!("{count} commits ahead of main{detail}", count = ahead.len())
+        } else {
+            let label = if ahead.len() == 1 { "commit" } else { "commits" };
+            format!("{count} {label} ahead of main", count = ahead.len())
+        };
+
+        ahead.truncate(MAX_COMMITS);
+        (header, ahead)
     };
 
-    let shown = &ahead[..ahead.len().min(MAX_COMMITS)];
-    pager::paged(allow_pager, |out| print_log(out, &header, shown, theme))
+    emit_log(&repo, &header, &commits, theme, allow_pager, want_avatars, avatar_rows)
+}
+
+/// Render the header and commit blocks.
+///
+/// When avatars are enabled (a graphics terminal, a real TTY, and not opted
+/// out), the output bypasses the pager and goes straight to the terminal,
+/// because a pager like `less` would render the kitty graphics escapes as
+/// garbage. Otherwise it pages as usual.
+fn emit_log(
+    repo: &git2::Repository,
+    header: &str,
+    commits: &[git::AheadCommit<'_>],
+    theme: Theme,
+    allow_pager: bool,
+    want_avatars: bool,
+    avatar_rows: u32,
+) -> Result<()> {
+    let avatars_enabled = want_avatars
+        && avatar_rows > 0
+        && kitty::is_supported()
+        && std::io::stdout().is_terminal();
+
+    if !avatars_enabled {
+        return pager::paged(allow_pager, |out| print_log(out, header, commits, theme));
+    }
+
+    let fetched = fetch_avatars(repo, commits)?;
+    let mut out = std::io::stdout().lock();
+    writeln!(out, "{}\n", paint(fg(Color::Ansi(AnsiColor::Cyan)), header))?;
+    let mut transmitted = HashSet::new();
+    for (ahead, avatar) in commits.iter().zip(&fetched) {
+        display::print_commit_with_avatar(
+            &mut out,
+            ahead,
+            theme,
+            avatar.as_ref(),
+            &mut transmitted,
+            avatar_rows,
+        )?;
+    }
+    Ok(())
+}
+
+/// Resolve and download each commit author's avatar, one slot per commit.
+///
+/// `None` marks an author that could not be resolved. The async `github-avatar`
+/// client is driven on a short-lived current-thread runtime.
+fn fetch_avatars(
+    repo: &git2::Repository,
+    commits: &[git::AheadCommit<'_>],
+) -> Result<Vec<Option<avatar::Avatar>>> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .wrap_err("failed to build the avatar fetch runtime")?;
+    let mut resolver = avatar::Resolver::new(repo, AVATAR_SIZE_PX);
+    let fetched = runtime.block_on(async {
+        let mut fetched = Vec::with_capacity(commits.len());
+        for ahead in commits {
+            let email = ahead.commit.author().email().unwrap_or_default().to_string();
+            let sha = ahead.commit.id().to_string();
+            fetched.push(resolver.avatar_for(&email, &sha).await);
+        }
+        fetched
+    });
+    Ok(fetched)
 }
 
 /// Write a cyan header followed by each commit block to `out`.

--- a/packages/git-log-pretty/src/main.rs
+++ b/packages/git-log-pretty/src/main.rs
@@ -143,7 +143,11 @@ fn emit_log(
         return pager::paged(allow_pager, |out| print_log(out, header, commits, theme));
     }
 
-    let fetched = fetch_avatars(repo, commits)?;
+    // A runtime-build failure shouldn't sink the whole log; fall back to the
+    // plain, pageable renderer.
+    let Ok(fetched) = fetch_avatars(repo, commits) else {
+        return pager::paged(allow_pager, |out| print_log(out, header, commits, theme));
+    };
     let mut out = std::io::stdout().lock();
     writeln!(out, "{}\n", paint(fg(Color::Ansi(AnsiColor::Cyan)), header))?;
     let mut transmitted = HashSet::new();

--- a/packages/github-avatar/Cargo.toml
+++ b/packages/github-avatar/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "github-avatar"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Resolve a git commit author to a GitHub user and fetch their avatar PNG"
+
+[lints]
+workspace = true
+
+[dependencies]
+# GitHub's `<login>.png` endpoint sometimes serves the original upload (JPEG,
+# WebP, GIF, …), but kitty's f=100 format needs PNG, so decode any of those and
+# re-encode as PNG. `png` brings the encoder; the rest are input decoders.
+image = { workspace = true, features = ["png", "jpeg", "gif", "webp"] }
+reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+serde = { workspace = true, features = ["derive"] }
+snafu.workspace = true

--- a/packages/github-avatar/package.nix
+++ b/packages/github-avatar/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "github-avatar";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/github-avatar/src/lib.rs
+++ b/packages/github-avatar/src/lib.rs
@@ -1,0 +1,269 @@
+//! Resolve a git commit author to a GitHub user and fetch their avatar.
+//!
+//! Resolution is layered so the cheap, offline paths run first:
+//!
+//! 1. [`parse_noreply`] reads the login straight out of a
+//!    `…@users.noreply.github.com` commit email, with no network.
+//! 2. [`Client::resolve_commit`] asks GitHub who authored a specific commit in a
+//!    repo, which resolves any email linked to an account.
+//!
+//! Once a login is known, [`Client::avatar_png`] downloads the avatar as `PNG`
+//! from `<https://github.com/LOGIN.png>`, which always returns `PNG` regardless
+//! of the format the user originally uploaded.
+
+use std::io::Cursor;
+
+use reqwest::StatusCode;
+use serde::Deserialize;
+use snafu::{ResultExt, Snafu, ensure};
+
+/// GitHub REST API version pin (sent as `X-GitHub-Api-Version`).
+const API_VERSION: &str = "2022-11-28";
+/// `User-Agent` sent on every request; GitHub rejects requests without one.
+const USER_AGENT: &str = concat!("git-log-pretty/", env!("CARGO_PKG_VERSION"));
+
+/// A resolved GitHub account.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct User {
+    pub login: String,
+}
+
+/// Failure talking to GitHub.
+#[derive(Debug, Snafu)]
+pub enum Error {
+    /// A request failed to send, returned a non-success status, or its body
+    /// could not be decoded.
+    #[snafu(display("github request to {url} failed"))]
+    Request {
+        url: String,
+        source: reqwest::Error,
+    },
+    /// A login failed validation, so no request was made.
+    #[snafu(display("{login:?} is not a valid github login"))]
+    InvalidLogin { login: String },
+    /// The downloaded avatar could not be decoded as an image.
+    #[snafu(display("failed to decode {login}'s avatar image"))]
+    Decode {
+        login: String,
+        source: image::ImageError,
+    },
+    /// The avatar could not be re-encoded as PNG.
+    #[snafu(display("failed to encode {login}'s avatar as PNG"))]
+    Encode {
+        login: String,
+        source: image::ImageError,
+    },
+}
+
+/// Result alias for this crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Parse a GitHub `noreply` commit email into a [`User`].
+///
+/// Handles both forms GitHub issues:
+/// `49699333+octocat@users.noreply.github.com` and the older
+/// `octocat@users.noreply.github.com`. Returns `None` for any other email, or
+/// when the embedded login is not [valid](is_valid_login) (the local part is
+/// attacker-controlled, so this is what keeps stray characters out of the avatar
+/// URL later).
+#[must_use]
+pub fn parse_noreply(email: &str) -> Option<User> {
+    let local = email
+        .trim()
+        .to_ascii_lowercase()
+        .strip_suffix("@users.noreply.github.com")?
+        .to_string();
+    // Newer emails are "<id>+<login>"; the id half is not a login on its own.
+    let login = match local.split_once('+') {
+        Some((_, login)) => login,
+        None => local.as_str(),
+    };
+    is_valid_login(login).then(|| User {
+        login: login.to_string(),
+    })
+}
+
+/// Whether `login` is a syntactically valid GitHub username: 1 to 39 characters
+/// of ASCII alphanumerics and hyphens, not starting or ending with a hyphen.
+///
+/// A valid login needs no URL or path encoding, so validating here lets callers
+/// interpolate it safely. Used as a guard before any network use.
+#[must_use]
+pub fn is_valid_login(login: &str) -> bool {
+    !login.is_empty()
+        && login.len() <= 39
+        && login.bytes().next() != Some(b'-')
+        && login.bytes().next_back() != Some(b'-')
+        && login.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
+}
+
+/// Parse `owner` and `repo` from a GitHub remote URL (https or ssh forms).
+///
+/// Returns `None` for non-GitHub remotes, so callers can skip the commit-author
+/// lookup entirely off GitHub.
+#[must_use]
+pub fn parse_remote(url: &str) -> Option<(String, String)> {
+    let url = url.trim();
+    let url = url.strip_suffix(".git").unwrap_or(url);
+    let rest = url
+        .strip_prefix("https://github.com/")
+        .or_else(|| url.strip_prefix("http://github.com/"))
+        .or_else(|| url.strip_prefix("ssh://git@github.com/"))
+        .or_else(|| url.strip_prefix("git@github.com:"))?;
+    let (owner, repo) = rest.split_once('/')?;
+    (!owner.is_empty() && !repo.is_empty()).then(|| (owner.to_string(), repo.to_string()))
+}
+
+/// Authenticated response for `GET /repos/{owner}/{repo}/commits/{sha}`; only
+/// the linked author account is of interest.
+#[derive(Deserialize)]
+struct CommitResponse {
+    author: Option<Account>,
+}
+
+#[derive(Deserialize)]
+struct Account {
+    login: String,
+}
+
+/// A GitHub HTTP client.
+///
+/// Holds one connection pool and an optional token used for the authenticated
+/// API lookups (raising rate limits and reaching private repos). The avatar
+/// download itself needs no token.
+pub struct Client {
+    http: reqwest::Client,
+    token: Option<String>,
+}
+
+impl Client {
+    /// Build a client. Pass a token (e.g. from `GITHUB_TOKEN` or `gh auth
+    /// token`) to enable the API lookups; pass `None` to use only the public
+    /// avatar endpoint.
+    #[must_use]
+    pub fn new(token: Option<String>) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            token,
+        }
+    }
+
+    /// Resolve the GitHub login that authored `sha` in `owner/repo`.
+    ///
+    /// Returns `Ok(None)` when GitHub has no account linked to the commit's
+    /// author email, or when the commit is not found.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Request`] if the request fails to send, returns an
+    /// unexpected non-success status, or its body cannot be decoded.
+    pub async fn resolve_commit(&self, owner: &str, repo: &str, sha: &str) -> Result<Option<User>> {
+        let url = format!("https://api.github.com/repos/{owner}/{repo}/commits/{sha}");
+        let response = self.api_get(&url).await?;
+        // A missing commit or unprocessable ref is "no answer", not an error.
+        if matches!(response.status(), StatusCode::NOT_FOUND | StatusCode::UNPROCESSABLE_ENTITY) {
+            return Ok(None);
+        }
+        let response = response.error_for_status().context(RequestSnafu { url: url.clone() })?;
+        let parsed: CommitResponse = response.json().await.context(RequestSnafu { url })?;
+        Ok(parsed.author.map(|account| User { login: account.login }))
+    }
+
+    /// Download `login`'s avatar and return it as `PNG` bytes, a `size_px`
+    /// square.
+    ///
+    /// GitHub's `.png` endpoint sometimes serves the original upload (`JPEG`,
+    /// `WebP`, `GIF`, …) rather than `PNG`. kitty's `f=100` format needs `PNG`,
+    /// so whatever comes back is decoded, resized to a square, and re-encoded as
+    /// `PNG`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidLogin`] if `login` is not a valid username,
+    /// [`Error::Request`] if the download fails or returns a non-success status,
+    /// or [`Error::Decode`] / [`Error::Encode`] if the image cannot be
+    /// transcoded.
+    pub async fn avatar_png(&self, login: &str, size_px: u32) -> Result<Vec<u8>> {
+        ensure!(is_valid_login(login), InvalidLoginSnafu { login });
+        let url = format!("https://github.com/{login}.png?size={size_px}");
+        let bytes = self
+            .http
+            .get(&url)
+            .header(reqwest::header::USER_AGENT, USER_AGENT)
+            .send()
+            .await
+            .context(RequestSnafu { url: url.clone() })?
+            .error_for_status()
+            .context(RequestSnafu { url: url.clone() })?
+            .bytes()
+            .await
+            .context(RequestSnafu { url })?;
+
+        let img = image::load_from_memory(&bytes).context(DecodeSnafu { login })?;
+        let img = img.resize_exact(size_px, size_px, image::imageops::FilterType::Triangle);
+        let mut png = Vec::new();
+        img.write_to(&mut Cursor::new(&mut png), image::ImageFormat::Png)
+            .context(EncodeSnafu { login })?;
+        Ok(png)
+    }
+
+    /// Issue an authenticated GitHub API GET with the standard headers.
+    async fn api_get(&self, url: &str) -> Result<reqwest::Response> {
+        let mut request = self
+            .http
+            .get(url)
+            .header(reqwest::header::USER_AGENT, USER_AGENT)
+            .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", API_VERSION);
+        if let Some(token) = &self.token {
+            request = request.bearer_auth(token);
+        }
+        request.send().await.context(RequestSnafu { url: url.to_string() })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{User, is_valid_login, parse_noreply, parse_remote};
+
+    #[test]
+    fn noreply_with_and_without_id() {
+        let want = Some(User { login: "octocat".to_string() });
+        assert_eq!(parse_noreply("49699333+octocat@users.noreply.github.com"), want);
+        assert_eq!(parse_noreply("octocat@users.noreply.github.com"), want);
+        assert_eq!(parse_noreply("Octocat@Users.Noreply.GitHub.com"), want);
+    }
+
+    #[test]
+    fn non_noreply_and_unsafe_logins_are_rejected() {
+        assert_eq!(parse_noreply("drew@x.ai"), None);
+        assert_eq!(parse_noreply("nope"), None);
+        // A crafted local part must not yield a URL-injecting login.
+        assert_eq!(parse_noreply("a/b@users.noreply.github.com"), None);
+        assert_eq!(parse_noreply("a?b@users.noreply.github.com"), None);
+        assert_eq!(parse_noreply("dependabot[bot]@users.noreply.github.com"), None);
+    }
+
+    #[test]
+    fn valid_login_charset_and_edges() {
+        assert!(is_valid_login("octocat"));
+        assert!(is_valid_login("andrew-gazelka"));
+        assert!(is_valid_login("a"));
+        assert!(!is_valid_login(""));
+        assert!(!is_valid_login("-lead"));
+        assert!(!is_valid_login("trail-"));
+        assert!(!is_valid_login("has space"));
+        assert!(!is_valid_login("has/slash"));
+        assert!(!is_valid_login(&"x".repeat(40)));
+    }
+
+    #[test]
+    fn remote_https_and_ssh() {
+        let want = Some(("indexable-inc".to_string(), "index".to_string()));
+        assert_eq!(parse_remote("https://github.com/indexable-inc/index.git"), want);
+        assert_eq!(parse_remote("https://github.com/indexable-inc/index"), want);
+        assert_eq!(parse_remote("git@github.com:indexable-inc/index.git"), want);
+        assert_eq!(parse_remote("ssh://git@github.com/indexable-inc/index.git"), want);
+        assert_eq!(parse_remote("https://gitlab.com/foo/bar.git"), None);
+    }
+}

--- a/packages/github-avatar/src/lib.rs
+++ b/packages/github-avatar/src/lib.rs
@@ -12,6 +12,7 @@
 //! of the format the user originally uploaded.
 
 use std::io::Cursor;
+use std::time::Duration;
 
 use reqwest::StatusCode;
 use serde::Deserialize;
@@ -142,10 +143,14 @@ impl Client {
     /// avatar endpoint.
     #[must_use]
     pub fn new(token: Option<String>) -> Self {
-        Self {
-            http: reqwest::Client::new(),
-            token,
-        }
+        // A per-request timeout keeps a stalled api.github.com / github.com
+        // response from hanging the synchronous caller indefinitely; on a build
+        // failure (e.g. TLS init) fall back to the untimed default client.
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self { http, token }
     }
 
     /// Resolve the GitHub login that authored `sha` in `owner/repo`.

--- a/packages/kitty/Cargo.toml
+++ b/packages/kitty/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kitty"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Encoder for the kitty terminal graphics protocol (escape-sequence framing only, no image decoding or terminal IO)"
+
+[lints]
+workspace = true
+
+[dependencies]
+base64.workspace = true

--- a/packages/kitty/package.nix
+++ b/packages/kitty/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "kitty";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/kitty/src/lib.rs
+++ b/packages/kitty/src/lib.rs
@@ -1,0 +1,258 @@
+//! Encoder for the [kitty terminal graphics protocol].
+//!
+//! This crate turns image bytes into the `APC _G ... ST` escape sequences that
+//! `kitty`, `ghostty`, and `wezterm` understand, and nothing else: it does not
+//! open a terminal, decode images, or talk to the network. Callers own those
+//! concerns and decide where the returned string is written.
+//!
+//! ```
+//! let png: &[u8] = b"\x89PNG..."; // real `PNG` bytes in practice
+//! let seq = kitty::transmit(
+//!     &kitty::Image::Png(png),
+//!     None,
+//!     &kitty::Placement { rows: Some(2), cols: Some(4), move_cursor: false },
+//! );
+//! assert!(seq.starts_with("\x1b_G"));
+//! ```
+//!
+//! [kitty terminal graphics protocol]: https://sw.kovidgoyal.net/kitty/graphics-protocol/
+
+use std::fmt::Write;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+
+/// Start of an Application Programming Command carrying a graphics command.
+const APC_START: &str = "\x1b_G";
+/// String Terminator (`ESC \`) that closes each command.
+const ST: &str = "\x1b\\";
+/// The protocol requires the base64 payload be split into chunks no larger than
+/// this many bytes, each sent as its own command.
+const MAX_CHUNK: usize = 4096;
+
+/// Image data to transmit to the terminal.
+#[derive(Debug, Clone, Copy)]
+pub enum Image<'a> {
+    /// `PNG` file bytes. The terminal decodes them, so no dimensions are needed
+    /// (protocol format `f=100`).
+    Png(&'a [u8]),
+    /// Raw 8-bit `RGBA` pixels, exactly `width * height * 4` bytes, row-major
+    /// (protocol format `f=32`).
+    Rgba {
+        width: u32,
+        height: u32,
+        pixels: &'a [u8],
+    },
+}
+
+/// How the image occupies the terminal cell grid when displayed.
+#[derive(Debug, Clone, Copy)]
+pub struct Placement {
+    /// Columns to scale the image across (`c=`). `None` lets the terminal pick.
+    pub cols: Option<u32>,
+    /// Rows to scale the image across (`r=`). `None` lets the terminal pick.
+    pub rows: Option<u32>,
+    /// Whether the cursor advances past the image after display.
+    ///
+    /// When `false`, the command sets `C=1` (do not move cursor) so the caller
+    /// can position the cursor and lay out text around the image itself.
+    pub move_cursor: bool,
+}
+
+impl Default for Placement {
+    fn default() -> Self {
+        Self {
+            cols: None,
+            rows: None,
+            move_cursor: true,
+        }
+    }
+}
+
+/// Best-effort detection of whether the current terminal speaks the protocol.
+///
+/// This reads environment variables only; it never queries the terminal. A
+/// `true` result is a strong hint, not a guarantee, so callers should still
+/// offer an opt-out.
+#[must_use]
+pub fn is_supported() -> bool {
+    if std::env::var_os("KITTY_WINDOW_ID").is_some() {
+        return true;
+    }
+    let advertises = |value: &str| {
+        let value = value.to_ascii_lowercase();
+        value.contains("kitty") || value.contains("ghostty") || value.contains("wezterm")
+    };
+    std::env::var("TERM").is_ok_and(|term| advertises(&term))
+        || std::env::var("TERM_PROGRAM").is_ok_and(|program| advertises(&program))
+}
+
+/// Transmit `image` and display it at the cursor.
+///
+/// When `id` is `Some`, the terminal stores the image under that id so the same
+/// pixels can be redrawn later with [`place`] instead of resending them.
+#[must_use]
+pub fn transmit(image: &Image<'_>, id: Option<u32>, placement: &Placement) -> String {
+    let (format, payload, dimensions): (u16, &[u8], Option<(u32, u32)>) = match *image {
+        Image::Png(bytes) => (100, bytes, None),
+        Image::Rgba {
+            width,
+            height,
+            pixels,
+        } => (32, pixels, Some((width, height))),
+    };
+
+    let mut control = format!("a=T,f={format},q=2");
+    if let Some((width, height)) = dimensions {
+        let _ = write!(control, ",s={width},v={height}");
+    }
+    if let Some(id) = id {
+        let _ = write!(control, ",i={id}");
+    }
+    push_placement(&mut control, placement);
+
+    encode_chunks(&control, payload)
+}
+
+/// Display an image previously sent by [`transmit`] with the same `id`, at the
+/// cursor. Sends no pixels, so it is cheap to repeat.
+#[must_use]
+pub fn place(id: u32, placement: &Placement) -> String {
+    let mut control = format!("a=p,i={id},q=2");
+    push_placement(&mut control, placement);
+    format!("{APC_START}{control}{ST}")
+}
+
+fn push_placement(control: &mut String, placement: &Placement) {
+    if let Some(cols) = placement.cols {
+        let _ = write!(control, ",c={cols}");
+    }
+    if let Some(rows) = placement.rows {
+        let _ = write!(control, ",r={rows}");
+    }
+    if !placement.move_cursor {
+        // C=1 tells the terminal to leave the cursor where it was.
+        control.push_str(",C=1");
+    }
+}
+
+/// Base64-encode `payload` and frame it as one or more graphics commands,
+/// splitting into `m=1` continuation chunks when it exceeds [`MAX_CHUNK`].
+fn encode_chunks(control: &str, payload: &[u8]) -> String {
+    let encoded = STANDARD.encode(payload);
+
+    if encoded.len() <= MAX_CHUNK {
+        return format!("{APC_START}{control},m=0;{encoded}{ST}");
+    }
+
+    let total = encoded.len();
+    let mut out = String::with_capacity(total + (total / MAX_CHUNK + 1) * (APC_START.len() + 16));
+    let mut start = 0;
+    let mut first = true;
+    while start < total {
+        let end = (start + MAX_CHUNK).min(total);
+        // `encoded` is base64, i.e. pure ASCII, so every byte offset is also a
+        // valid char boundary and this slice never splits a code point.
+        let chunk = &encoded[start..end];
+        let last = end == total;
+
+        out.push_str(APC_START);
+        if first {
+            // The first chunk carries the real control keys; the rest carry `m`.
+            out.push_str(control);
+            out.push_str(",m=1;");
+            first = false;
+        } else if last {
+            out.push_str("m=0;");
+        } else {
+            out.push_str("m=1;");
+        }
+        out.push_str(chunk);
+        out.push_str(ST);
+
+        start = end;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{APC_START, Image, MAX_CHUNK, Placement, ST, STANDARD, place, transmit};
+    use base64::Engine;
+
+    fn single_command(sequence: &str) -> (&str, &str) {
+        let body = sequence
+            .strip_prefix(APC_START)
+            .and_then(|rest| rest.strip_suffix(ST))
+            .expect("framed as one APC command");
+        body.split_once(';').expect("control;payload")
+    }
+
+    #[test]
+    fn png_single_chunk_has_control_and_payload() {
+        let sequence = transmit(&Image::Png(b"hello"), None, &Placement::default());
+        let (control, payload) = single_command(&sequence);
+        assert!(control.contains("a=T"));
+        assert!(control.contains("f=100"));
+        assert!(control.contains("q=2"));
+        assert!(control.contains("m=0"));
+        assert_eq!(payload, STANDARD.encode(b"hello"));
+    }
+
+    #[test]
+    fn rgba_carries_dimensions_and_placement() {
+        let pixels = [0u8; 16]; // 2x2 RGBA
+        let sequence = transmit(
+            &Image::Rgba {
+                width: 2,
+                height: 2,
+                pixels: &pixels,
+            },
+            Some(7),
+            &Placement {
+                cols: Some(4),
+                rows: Some(2),
+                move_cursor: false,
+            },
+        );
+        let (control, _) = single_command(&sequence);
+        for key in ["f=32", "s=2", "v=2", "i=7", "c=4", "r=2", "C=1"] {
+            assert!(control.contains(key), "missing {key} in {control}");
+        }
+    }
+
+    #[test]
+    fn large_payload_is_chunked() {
+        // 9 KiB raw -> ~12 KiB base64 -> 3 chunks of <= 4096.
+        let big = vec![0xABu8; 9 * 1024];
+        let sequence = transmit(&Image::Png(&big), None, &Placement::default());
+        let commands: Vec<&str> = sequence.split(ST).filter(|part| !part.is_empty()).collect();
+        assert!(commands.len() >= 3, "expected multiple chunks");
+        assert!(commands[0].contains("a=T"));
+        assert!(commands[0].contains("m=1"));
+        let last = commands.last().expect("at least one command");
+        assert!(last.contains("m=0"));
+        assert!(!last.contains("a=T"));
+        for command in &commands {
+            let payload = command.rsplit_once(';').map_or("", |(_, payload)| payload);
+            assert!(payload.len() <= MAX_CHUNK);
+        }
+    }
+
+    #[test]
+    fn place_references_id_without_payload() {
+        let sequence = place(
+            7,
+            &Placement {
+                cols: Some(4),
+                rows: Some(2),
+                move_cursor: false,
+            },
+        );
+        assert!(sequence.starts_with(APC_START));
+        assert!(sequence.ends_with(ST));
+        assert!(sequence.contains("a=p"));
+        assert!(sequence.contains("i=7"));
+        assert!(!sequence.contains(';'), "a placement of an existing image sends no payload");
+    }
+}

--- a/packages/kitty/src/lib.rs
+++ b/packages/kitty/src/lib.rs
@@ -76,6 +76,11 @@ impl Default for Placement {
 /// offer an opt-out.
 #[must_use]
 pub fn is_supported() -> bool {
+    // Terminal multiplexers usually swallow graphics escapes (they render as
+    // garbage), so treat tmux/screen sessions as unsupported by default.
+    if std::env::var_os("TMUX").is_some() || std::env::var_os("STY").is_some() {
+        return false;
+    }
     if std::env::var_os("KITTY_WINDOW_ID").is_some() {
         return true;
     }


### PR DESCRIPTION
Draw each commit author's GitHub avatar inline in `git-log-pretty`, using the kitty graphics protocol (works in ghostty/kitty/wezterm).

Two new composable crates:
- `kitty` — encoder for the kitty graphics protocol (base64 chunking, PNG/RGBA, placement, transmit + place-by-id). No image decoding or terminal IO.
- `github-avatar` — resolve a commit author to a GitHub login (noreply email or the commit API) and fetch + transcode the avatar to PNG.

`git-log-pretty` resolves each author cheapest-first (identity map → noreply → commit API), caches avatars on disk + in memory, transmits each image once per run, and bypasses the pager when drawing graphics. Avatars render only on a graphics-capable TTY; `--no-avatar` / `--avatar-rows` control them. No new external deps beyond enabling `image` (already in the lock via macos-vm).

Validated: `nix build .#git-log-pretty`; `cargo test` (34 pass) and `cargo clippy` (all+pedantic+nursery clean) via `nix run .#run`. Ran the built binary in a PTY against this repo's `main` — the emitted kitty stream decodes to valid PNG avatars (incl. transcoding a JPEG-served avatar), with per-author transmit-once + cheap placements for repeats.

Made with Claude Code (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add inline GitHub author avatars to `git-log-pretty` via kitty graphics protocol
> - Adds two new crates: [`github-avatar`](https://github.com/indexable-inc/index/pull/529/files#diff-34122f3758627dfe712b33531ba09d01a6fe524a3ed2c33aeab4a9ae2e8e9fef) for resolving GitHub logins and fetching/resizing avatar PNGs via the GitHub API, and [`kitty`](https://github.com/indexable-inc/index/pull/529/files#diff-a92c23e61d1747254c967b35b08b886f045526846dd3cf35fd49b3f92be0f0a3) for encoding and transmitting images using the kitty graphics protocol.
> - Introduces [`avatar::Resolver`](https://github.com/indexable-inc/index/pull/529/files#diff-d0b0568cb680182ece785edb5c3bf86e56ab593453626f1f96a6775ce09b419d) in `git-log-pretty` that maps commit author emails to GitHub logins with multi-layer caching: in-memory, on-disk TSV (email→login), and on-disk PNG cache under `~/.cache/git-log-pretty/avatars`.
> - Adds `--no-avatar` and `--avatar-rows` CLI flags; avatars are rendered in the left gutter when stdout is a TTY and the kitty protocol is detected as supported.
> - Each unique avatar PNG is transmitted once per run; subsequent commits by the same author reuse it via kitty's image id placement.
> - Risk: avatar rendering bypasses the pager entirely (to avoid escape-sequence corruption), and is skipped in tmux/screen sessions or when kitty support is not detected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0fdfee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->