### PR TITLE
skills/optimize: prefer enforcement (hooks) over CLAUDE.md encouragement

### DIFF
--- a/skills/optimize/SKILL.md
+++ b/skills/optimize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: optimize
-description: "Mine your own Claude Code history with polars to find where past sessions wasted time and drift, then draft the global config changes that prevent the recurrence. Surfaces slow model loops, slow commands and toolchain/CI/build-graph waste, oversized tool results that bloat or trim context, mistakes a human had to correct, and multi-turn flailing. Use when you want to make future sessions faster and more correct, audit your agent's habits, or decide what CLAUDE.md / skill / hook to add. Invoke with /optimize."
+description: "Mine your own Claude Code history with polars to find where past sessions wasted time and drift, then draft the global config changes that prevent the recurrence. Surfaces slow model loops, slow commands and toolchain/CI/build-graph waste, oversized tool results that bloat or trim context, mistakes a human had to correct, and multi-turn flailing. Use when you want to make future sessions faster and more correct, audit your agent's habits, or decide what enforcement to add — preferring a hook that blocks the bad call over a CLAUDE.md rule the model can ignore. Invoke with /optimize."
 disable-model-invocation: true
 ---
 
@@ -26,11 +26,11 @@ F["bash"]    # one row per timed Bash call (cmd, seconds, is_error)
 F["tools"]   # one row per tool_result (tool, label, size, is_error)
 ```
 
-To avoid re-scanning across questions, cache once: `o.build_frames(...)["df"].write_parquet("~/.claude/optimize/history_rows.parquet")` (and `bash`/`tools`), then `pl.read_parquet(...)` for instant re-slicing. The module also runs standalone for headless use (`python ${CLAUDE_SKILL_DIR}/assets/build_history_df.py --full --out ~/.claude/optimize`) on any interpreter that has polars — this is what the `optimize-scan` portable service runs via `uv`.
+To avoid re-scanning across questions, cache once: `o.build_frames(...)["df"].write_parquet("~/.claude/optimize/history_rows.parquet")` (and `bash`/`tools`), then `pl.read_parquet(...)` for instant re-slicing. The module also runs standalone for headless use (`python ${CLAUDE_SKILL_DIR}/assets/build_history_df.py --full --out ~/.claude/optimize`) on any interpreter with polars.
 
 Default to the **last ~45 days** (current model family — old transcripts ran retired models and teach nothing actionable). Expand to `full=True` only when a pattern needs the longer baseline.
 
-**Schema gotchas already handled by the library (do not re-derive wrong):** `usage.speed` is a coarse `"fast"` label, not tokens/sec; `usage.iterations` is a list (count, ~always 1); a *real* human prompt is a string-content user entry with a top-level `promptId` (harness messages like `<task-notification>` and compaction summaries are excluded); per-command wall-clock is the `tool_use`→`tool_result` timestamp delta; "tool too big / context trimmed" is detected by result **size**, since the literal word "truncated" in transcripts is mostly tool data, not a harness trim.
+**Schema gotchas already handled by the library (do not re-derive wrong):** `usage.speed` is a coarse `"fast"` label, not tokens/sec; `usage.iterations` is a list (count, ~always 1); a *real* human prompt is a string-content user entry with a top-level `promptId` (harness messages and compaction summaries excluded); per-command wall-clock is the `tool_use`→`tool_result` delta; context-trim is detected by result **size**, not the word "truncated" (mostly tool data, not a harness trim).
 
 ## The signals (each row carries session id + evidence)
 
@@ -40,37 +40,36 @@ Default to the **last ~45 days** (current model family — old transcripts ran r
 4. **Mistakes a human had to correct** — real prompts after assistant tool activity carrying correction language. Capture the assistant action that triggered it; classify the mistake (wrong assumption, scope creep, destructive edit, ignored instruction). These map most directly to CLAUDE.md rules.
 5. **Multi-turn flailing** — long autonomous chains (high tool count since the last real prompt) with error clusters before resolution. The durable rule is the early signal the agent should have heeded on turn 2 instead of turn 12.
 6. **Repeated cross-session tasks → reusable scripts** — the `recurring tasks across sessions` table groups commands by a canonical form (paths/numbers/hashes blanked) and counts how many *distinct sessions* run each. A task you re-derive in dozens of sessions (a multi-step setup, a lint/build/deploy incantation, a query you keep rewriting) should become one reusable thing: a script, a `just`/Makefile target, a global skill, or a CLI subcommand. Rank by `distinct_sessions × total_seconds` — high session-count means you keep paying the rediscovery and typing cost. Propose the concrete artifact (where it lives, what it wraps) and the cumulative time it reclaims. Ignore trivial one-liners (`ls`, `git status`); target the expensive or multi-step recipes.
-7. **Escape hatches & recurring jank → architecture fix** — the `escape hatches / jank` table counts workaround patterns in commands (silenced stderr, `|| true`, `--no-verify`, force pushes, `sleep` timing hacks, retry/poll loops, `--impure`/`--override-input`, `sed -i` patching, sandbox bypass) by distinct sessions. Each recurring one is the agent *compensating* for something a real fix would remove: a `sleep` poll → an event-driven wait (the Monitor tool); pervasive `--no-verify` → hooks too slow to keep; repeated `--override-input`/`sed -i` patching → a missing upstream option or config knob; constant `2>/dev/null` → tooling so noisy its output is worthless. Name the underlying gap and propose the architectural change that *retires* the workaround — not a tidier workaround. (Meta: this skill's own creation hit exactly this — launchd escape hatches in a "portable" service — and the fix was improving the abstraction, not pinning more keys.)
+7. **Escape hatches & recurring jank → architecture fix** — the `escape hatches / jank` table counts workaround patterns in commands (silenced stderr, `|| true`, `--no-verify`, force pushes, `sleep` timing hacks, retry/poll loops, `--impure`/`--override-input`, `sed -i` patching, sandbox bypass) by distinct sessions. Each recurring one is the agent *compensating* for something a real fix would remove: a `sleep` poll → an event-driven wait (the Monitor tool); pervasive `--no-verify` → hooks too slow to keep; repeated `--override-input`/`sed -i` patching → a missing upstream option or config knob; constant `2>/dev/null` → tooling so noisy its output is worthless. Name the underlying gap and propose the architectural change that *retires* the workaround — not a tidier workaround; if it is a recurring command shape, block it with a hook (below).
 
 ## From findings to durable fixes
 
-Every confirmed finding becomes a proposed artifact, chosen by what prevents the recurrence:
-- **Global CLAUDE.md edit** — a behavioral rule/guardrail/default (target `~/.claude/CLAUDE.md`). Short, imperative, in the file's voice.
-- **A new global skill** — a repeatable procedure (target `~/.claude/skills/<name>/`).
-- **A hook or setting** — something the harness must enforce automatically (target `~/.claude/settings.json`).
-- **A reusable script / CLI / `just` target** — for signal 6, the codified version of a repeated task.
+Every confirmed finding becomes a proposed artifact, chosen by **enforcement strength, not convenience**. A CLAUDE.md line is only *encouragement* the model forgets under load — the weakest fix and the last resort, never the default. Whenever a finding is a pattern over a tool call (a command shape, flag, path, or tool), prefer a mechanism the harness applies deterministically; propose the strongest that fits:
 
-Apply against whatever renders this machine's Claude config: if it is managed by a Nix flake (a personal config repo, or the index repo's `skills/` + home modules), edit the flake source that renders the file, not the live symlink, then re-switch; otherwise edit `~/.claude/` directly. Write each as a paste-ready draft tied to its evidence and estimated recurring time saved.
+1. **A hook that blocks or warns.** A `PreToolUse` hook — nix-managed `settings.json` plus a script under `claude/global/`, following the existing `cargo-guard.py` Bash guard — inspects the tool input and either hard-blocks (exit non-zero with a one-line reason the model acts on) or soft-warns (stderr / `additionalContext`, exit 0). The only fix the agent *cannot* ignore. Hard-block unambiguous patterns where a false positive is cheap to override (`grep -r`, `2>/dev/null`, `--no-verify`, bare `cargo` in a nix repo); soft-warn when the pattern is suggestive but sometimes legitimate. Put the actual hook code in the draft.
+2. **A setting.** A `permissions` deny/allow rule, allowlist, or env change the permission layer enforces without the model's cooperation.
+3. **A reusable script / CLI / `just` target.** For signal 6, codify the recipe so the right path is the shortest path.
+4. **A new global skill.** A repeatable multi-step procedure worth invoking by name.
+5. **A CLAUDE.md edit (last resort).** Only for what a hook cannot detect: judgment, taste, scoping, when-to-do-X. First ask whether it could be a hook instead; prefer the hook, or pair a terse line with a hook that enforces it. CLAUDE.md has a hard token budget a hook does not consume.
+
+Keep any CLAUDE.md line short and imperative. **Write every durable fix into the nix-managed source, never a loose file in `~/.claude/`.** This machine renders its Claude config from a Nix flake (a personal config repo, or the index repo's `skills/` + home modules): edit the flake source, then `home-manager switch` so the live path becomes a symlink into the nix store. A file hand-written into `~/.claude/` is untracked and clobbered on the next switch. Edit `~/.claude/` directly only on a host with no nix-managed config.
 
 ## Surface what needs the human
 
-Separate findings into (a) fixes you can draft mechanically and (b) decisions only the user can make, and **use AskUserQuestion for (b)** rather than guessing. Examples: "Change default X behavior?", "Is this recurring command worth a CI/build change?", "Adopt this as a new always-on CLAUDE.md rule?", "Set up a periodic run (below)?". A wrong global rule costs every future session, so confirm the judgment calls.
+Separate findings into (a) fixes you can draft mechanically and (b) decisions only the user can make, and **use AskUserQuestion for (b)** rather than guessing. Examples: "Block this command shape with a hook (hard block or warn)?", "Change default X behavior?", "Adopt this as a new always-on CLAUDE.md rule?", "Set up a periodic run (below)?". A false-positive blocking hook annoys every session and a wrong global rule costs every future one, so confirm blocking hooks and judgment calls; apply soft warns and obvious fixes directly.
 
 ## Deliverables and apply policy
 
 1. Write a dated report to `~/.claude/optimize/report-<date>.md`: ranked findings, each with evidence, the counterfactual (fastest path + divergence), and the proposed artifact.
 2. Also emit a self-contained **`~/.claude/optimize/report.html`** so the findings open in a browser. The bundled library already writes one from the raw leaderboards via `o.write_html(F, path)`; for the synthesized report, render your ranked findings + the same tables into HTML too (reuse `write_html`'s output as the data section and prepend your synthesis).
-3. Put paste-ready drafts under `~/.claude/optimize/drafts/`.
+3. Put paste-ready drafts under `~/.claude/optimize/drafts/`: for a hook, the actual script plus `settings.json` wiring; for CLAUDE.md, the exact lines.
 4. Return a tight summary: the highest-leverage fixes and total estimated time reclaimed, plus the explicit human-decision list.
 
 **Do not mutate the live global config on your own** — proposals come from heuristics over fuzzy data and change every future session. Draft, present, apply only what the user approves. When applying an approved skill/setting, run `uvx skillsaw lint --type dot-claude ~/.config/nix/claude/global` (the switch's own gate) before handing back.
 
 ## Scheduling / checking back later
 
-On index-managed hosts a token-free `optimize-scan` portable service already refreshes `~/.claude/optimize/` (launchd on macOS, a systemd timer on Linux) so the heavy data is always fresh and `/optimize` synthesis is instant. If a host has no such service and the user wants periodic runs, know the options and their limits:
-- **`/loop` and the cron tools (CronCreate)** — session-scoped: fire only while a session is open and idle, and recurring ones auto-expire in days. Good for "watch this for an hour," not durable.
-- **claude.ai Routines / Desktop scheduled tasks** — durable, but cloud routines run on a fresh clone with **no access to local `~/.claude` history**, so they cannot do this analysis.
-- **A native scheduled unit running the scan** — the durable fit: a launchd agent (macOS) or systemd timer (Linux), declared once via the index `services.portable.*` layer so it renders on both. The token-free scan is safe to run often; reserve an unattended `claude -p "/optimize"` LLM report for a daily/weekly cadence.
+On index-managed hosts a token-free `optimize-scan` portable service already refreshes `~/.claude/optimize/` (launchd on macOS, systemd timer on Linux), so the data is fresh and `/optimize` synthesis is instant. If a host lacks it and the user wants periodic runs: `/loop` and `CronCreate` are session-scoped (fire only while a session is open and idle; recurring ones expire in days). claude.ai Routines / Desktop tasks are durable but run on a fresh clone with **no access to local `~/.claude` history**, so they cannot do this analysis. The durable fit is a native scheduled unit — a launchd agent or systemd timer declared once via the index `services.portable.*` layer (renders on both); the scan is safe to run often, so reserve an unattended `claude -p "/optimize"` report for a daily/weekly cadence.
 
 ## Method discipline
 


### PR DESCRIPTION
The `/optimize` skill turned almost every finding into a CLAUDE.md line — encouragement the model forgets under load. This reframes its "From findings to durable fixes" step as an **enforcement ladder**, strongest first:

1. a `PreToolUse` hook that blocks/warns (the `cargo-guard.py` precedent) — the only fix the agent can't ignore
2. a setting (permissions deny/allow)
3. a reusable script / CLI / target
4. a new skill
5. a CLAUDE.md edit — last resort, only for what a hook can't detect (judgment, taste, scoping)

Also makes the apply default explicit: **write fixes into the nix-managed source so the live path is a nix-store symlink, then `home-manager switch` — never a loose `~/.claude/` file** (untracked, clobbered on next switch). Drafts must carry the actual hook script + `settings.json` wiring, not prose.

Prose-only; SKILL.md trimmed back under the 3000-token skillsaw budget (0 warnings).

Made with AI (Claude, claude-opus-4-8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefer hook-based enforcement over CLAUDE.md guidance in the optimize skill
> - Updates [SKILL.md](https://github.com/indexable-inc/index/pull/530/files#diff-0bea71d68ae4b922ba18e351e8cba291df6d98887b97fefe1502c4f94aa23706) to rank fixes by enforcement strength: hook > setting > script/CLI > skill > CLAUDE.md.
> - Adds concrete guidance for writing `PreToolUse` hooks, distinguishing hard-block from soft-warn, and wiring them into `settings.json`.
> - Expands "Escape hatches & recurring jank" to suggest blocking recurring bad command shapes with a hook.
> - Warns against editing loose files in `~/.claude` on nix-managed hosts; directs changes through the nix/home-manager source layer.
> - Updates deliverables to require paste-ready hook scripts and `settings.json` wiring in drafts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7759aee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->