### PR TITLE
feat(development-base): force summarized thinking on Opus 4.7/4.8

### DIFF
--- a/images/dev/development-base/default.nix
+++ b/images/dev/development-base/default.nix
@@ -114,8 +114,26 @@ in
   # default in ix's
   # nix/homes/modules/llm.nix (that module is per-user home-manager, so it can't
   # write /etc; moving the fleet onto a managed file is the follow-up).
+  #
+  # `env.CLAUDE_CODE_EXTRA_BODY` forces summarized thinking back on. Opus 4.7/4.8
+  # silently changed the Messages API default for `thinking.display` from
+  # "summarized" to "omitted": thinking blocks still stream, but their `thinking`
+  # field is empty (only the encrypted `signature` is returned), so the agent's
+  # reasoning is invisible in the transcript and Ctrl+O view. The in-app
+  # `showThinkingSummaries` setting does NOT fix this — it controls the transcript
+  # renderer, not the API request, and is never wired to the `display` param
+  # (anthropics/claude-code#49268). The only restore path is to send
+  # `thinking.display = "summarized"` on the request body, which Claude Code
+  # merges from this env var. We keep `type = "adaptive"` (the only mode these
+  # models support) so we override display without forcing a thinking budget.
   environment.etc."claude-code/managed-settings.json".text = builtins.toJSON {
     permissions.defaultMode = "bypassPermissions";
     skipDangerousModePermissionPrompt = true;
+    env.CLAUDE_CODE_EXTRA_BODY = builtins.toJSON {
+      thinking = {
+        type = "adaptive";
+        display = "summarized";
+      };
+    };
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2376,6 +2376,21 @@ let
           managed.permissions.defaultMode == "bypassPermissions" && managed.skipDangerousModePermissionPrompt;
         message = "development-base should enforce root's Claude Code bypass via managed-settings.json";
       }
+      {
+        # Opus 4.7/4.8 default thinking.display to "omitted"; the only way to
+        # restore summarized thinking is the request body, sent via
+        # CLAUDE_CODE_EXTRA_BODY. Pin it so a refactor can't silently drop it and
+        # blind us to the agent's reasoning again.
+        assertion =
+          let
+            managed =
+              builtins.fromJSON
+                developmentBase.config.environment.etc."claude-code/managed-settings.json".text;
+            extra = builtins.fromJSON (managed.env.CLAUDE_CODE_EXTRA_BODY or "{}");
+          in
+          (extra.thinking.display or null) == "summarized";
+        message = "development-base should request summarized thinking via CLAUDE_CODE_EXTRA_BODY";
+      }
     ];
 
     vitest = [


### PR DESCRIPTION
Opus 4.7/4.8 changed the Messages API default for `thinking.display` from `summarized` to `omitted`, so the dev image's Claude Code streams thinking blocks with an **empty** `thinking` field (signature only) — the agent's reasoning is invisible in the transcript and Ctrl+O view.

`showThinkingSummaries` does **not** fix this: it controls the renderer, not the request, and is never wired to the `display` param (anthropics/claude-code#49268).

Fix: send `thinking.display="summarized"` on the request body via `CLAUDE_CODE_EXTRA_BODY` in the shipped `managed-settings.json`. `type="adaptive"` is kept (only mode these models support) so we override display without forcing a budget. Pinned with an eval test.

Validated: `nix build .#development-base.passthru.tests.eval` passes; negative test (flip expected value) fails with the new assertion's message, confirming it reads the real rendered settings.

_Made with Claude (Opus 4.8)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force summarized thinking display for Claude Opus 4.7/4.8 in development-base
> - Sets `CLAUDE_CODE_EXTRA_BODY` in [managed-settings.json](https://github.com/indexable-inc/index/pull/531/files#diff-01ce554385daab1b0da2fd5335a0d948fe85070d30d519bb38c343d5e5b33fd4) with `thinking: { type: "adaptive", display: "summarized" }` to enable summarized thinking mode for Opus 4.7/4.8.
> - Adds a test assertion in [tests/default.nix](https://github.com/indexable-inc/index/pull/531/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) that parses the generated `managed-settings.json` and verifies `thinking.display` is set to `"summarized"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fef57c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->