### PR TITLE
docs(development-base): explain thinking type="adaptive" rationale

### DIFF
--- a/images/dev/development-base/default.nix
+++ b/images/dev/development-base/default.nix
@@ -124,8 +124,25 @@ in
   # renderer, not the API request, and is never wired to the `display` param
   # (anthropics/claude-code#49268). The only restore path is to send
   # `thinking.display = "summarized"` on the request body, which Claude Code
-  # merges from this env var. We keep `type = "adaptive"` (the only mode these
-  # models support) so we override display without forcing a thinking budget.
+  # merges from this env var.
+  #
+  # Why `type = "adaptive"` is here and why it's safe:
+  #   - Claude Code parses CLAUDE_CODE_EXTRA_BODY and spreads it into the request
+  #     body LAST, as a shallow top-level merge — so it REPLACES the whole
+  #     `thinking` object rather than deep-merging into it. That means we must
+  #     restate `type` here; sending `{ display = "summarized"; }` alone would
+  #     drop `type` and the API would 400 (thinking requires a type).
+  #   - `adaptive` is the only thinking type Opus 4.7/4.8 accept anyway — manual
+  #     `type = "enabled"` with a budget returns 400 on these models — so this
+  #     restates the harness's own default, it does not pick a narrower mode.
+  #   - It does NOT pin the thinking level. The effort knob (low/medium/high/
+  #     xhigh, set via /effort) is a SEPARATE top-level request field, a sibling
+  #     of `thinking`, never a property inside it. Replacing `thinking` here only
+  #     flips `display`; effort is untouched.
+  #   - Caveat: this assumes an adaptive-capable model (Opus 4.6/4.7/4.8,
+  #     Sonnet 4.6). Haiku 4.5 is manual-only and already defaults to summarized,
+  #     so it neither needs nor accepts adaptive — fine while the image defaults
+  #     to Opus.
   environment.etc."claude-code/managed-settings.json".text = builtins.toJSON {
     permissions.defaultMode = "bypassPermissions";
     skipDangerousModePermissionPrompt = true;


### PR DESCRIPTION
Follow-up to #531 (comment-only). Documents why `thinking.type = "adaptive"` is in the `CLAUDE_CODE_EXTRA_BODY` and why it's safe:

- `CLAUDE_CODE_EXTRA_BODY` is spread into the request body **last, as a shallow top-level merge** → it replaces the whole `thinking` object, so `type` must be restated (sending only `display` → API 400).
- `adaptive` is the only type Opus 4.7/4.8 accept (manual `enabled`+budget → 400), so this just restates the harness default.
- It does **not** pin the thinking level: `effort` (low/med/high/xhigh) is a separate top-level sibling field, untouched.
- Caveat noted: assumes an adaptive-capable model; Haiku 4.5 is manual-only (fine while the image defaults to Opus).

Eval test unchanged and still passes (`nix build .#development-base.passthru.tests.eval`).

_Made with Claude (Opus 4.8)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document `type="adaptive"` rationale in `CLAUDE_CODE_EXTRA_BODY` settings comment
> Expands the comment block in [default.nix](https://github.com/indexable-inc/index/pull/532/files#diff-01ce554385daab1b0da2fd5335a0d948fe85070d30d519bb38c343d5e5b33fd4) above the `managed-settings.json` environment config to explain the shallow merge behavior of `CLAUDE_CODE_EXTRA_BODY`, why `type = "adaptive"` must be explicitly included, that `effort` is a separate top-level field, and a note on model compatibility. No functional changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a1c8d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->