### PR TITLE
feat(development-base): retain Claude Code transcripts (cleanupPeriodDays)

### DIFF
--- a/images/dev/development-base/default.nix
+++ b/images/dev/development-base/default.nix
@@ -152,5 +152,14 @@ in
         display = "summarized";
       };
     };
+    # Keep session transcripts effectively forever (~2700 years). Claude Code
+    # otherwise deletes `~/.claude/projects/**/*.jsonl` after `cleanupPeriodDays`
+    # (default 30), which is the only on-disk record of a run's prompts, tool
+    # calls, and (with the summarized-thinking setting above) the agent's
+    # reasoning. Retention is FREE: these are local JSONL files on the guest
+    # disk — no tokens, no API calls, no Anthropic-side charge for keeping them.
+    # We'd rather pay disk than silently lose the audit trail of what an agent
+    # did inside a VM, especially for post-hoc triage of a bad run.
+    cleanupPeriodDays = 999999;
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2391,6 +2391,19 @@ let
           (extra.thinking.display or null) == "summarized";
         message = "development-base should request summarized thinking via CLAUDE_CODE_EXTRA_BODY";
       }
+      {
+        # Transcripts are the only on-disk record of a run; default cleanup is 30
+        # days. Pin a long retention so a refactor can't silently restore the
+        # 30-day window and delete the audit trail. (Free: local disk only.)
+        assertion =
+          let
+            managed =
+              builtins.fromJSON
+                developmentBase.config.environment.etc."claude-code/managed-settings.json".text;
+          in
+          (managed.cleanupPeriodDays or 0) >= 3650;
+        message = "development-base should retain Claude Code transcripts well beyond the 30-day default";
+      }
     ];
 
     vitest = [


### PR DESCRIPTION
Claude Code deletes `~/.claude/projects/**/*.jsonl` after `cleanupPeriodDays` (default **30**). Those transcripts are the only on-disk record of a run's prompts, tool calls, and — with the summarized-thinking setting (#531) — the agent's reasoning.

Sets `cleanupPeriodDays = 999999` in the dev image's `managed-settings.json` so runs are retained effectively forever.

**Costs nothing:** these are local JSONL files on the guest disk — no tokens, no API calls, no Anthropic-side charge for keeping them. We trade disk for a durable audit trail (post-hoc triage of a bad run).

Pinned by an eval test; `nix build .#development-base.passthru.tests.eval` passes (negative test with `=30` fails as expected).

_Made with Claude (Opus 4.8)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retain Claude Code session transcripts indefinitely in development-base
> Sets `cleanupPeriodDays` to `999999` in the Claude Code `managed-settings.json` for [development-base](https://github.com/indexable-inc/index/pull/533/files#diff-01ce554385daab1b0da2fd5335a0d948fe85070d30d519bb38c343d5e5b33fd4), preventing local session transcript JSONL files from being pruned after the default 30-day window. A test in [tests/default.nix](https://github.com/indexable-inc/index/pull/533/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) asserts that `cleanupPeriodDays` is at least 3650, failing the build if the retention policy is removed or reduced.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64cb582.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->