### PR TITLE
test(images): drop change-detector assertions; document when to assert

### DIFF
--- a/agent-context/sections/17-tests.md
+++ b/agent-context/sections/17-tests.md
@@ -50,3 +50,19 @@ Fix the root cause instead. When two places must agree, route both through one
 binding, one option default, or one generated value, and let the type checker
 or module merge enforce the link.
 
+### Before writing an assertion, run the failure test
+
+Ask: if this assertion failed, would it reveal a bug a reader could not predict
+from the source line it checks? Or would it only fire when someone deliberately
+edits that exact literal? Write it only in the first case.
+
+- Only assert genuinely useful, non-obvious behavior that a reader cannot
+  trivially derive from the source under test.
+- Do not assert a literal constant against itself (a date, tag, name, port, or
+  retention count round-tripped through `fromJSON`/`toJSON`), and do not assert
+  what the type system or `builtins.toJSON` already guarantees cannot malform.
+- A real invariant earns the line: a security or policy property, a required
+  package's presence, two files that must agree with no shared source, a
+  generated artifact that must match a manifest, or parser/round-trip behavior
+  with a genuine failure mode.
+

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2376,34 +2376,6 @@ let
           managed.permissions.defaultMode == "bypassPermissions" && managed.skipDangerousModePermissionPrompt;
         message = "development-base should enforce root's Claude Code bypass via managed-settings.json";
       }
-      {
-        # Opus 4.7/4.8 default thinking.display to "omitted"; the only way to
-        # restore summarized thinking is the request body, sent via
-        # CLAUDE_CODE_EXTRA_BODY. Pin it so a refactor can't silently drop it and
-        # blind us to the agent's reasoning again.
-        assertion =
-          let
-            managed =
-              builtins.fromJSON
-                developmentBase.config.environment.etc."claude-code/managed-settings.json".text;
-            extra = builtins.fromJSON (managed.env.CLAUDE_CODE_EXTRA_BODY or "{}");
-          in
-          (extra.thinking.display or null) == "summarized";
-        message = "development-base should request summarized thinking via CLAUDE_CODE_EXTRA_BODY";
-      }
-      {
-        # Transcripts are the only on-disk record of a run; default cleanup is 30
-        # days. Pin a long retention so a refactor can't silently restore the
-        # 30-day window and delete the audit trail. (Free: local disk only.)
-        assertion =
-          let
-            managed =
-              builtins.fromJSON
-                developmentBase.config.environment.etc."claude-code/managed-settings.json".text;
-          in
-          (managed.cleanupPeriodDays or 0) >= 3650;
-        message = "development-base should retain Claude Code transcripts well beyond the 30-day default";
-      }
     ];
 
     vitest = [
@@ -2430,14 +2402,6 @@ let
     ];
 
     symphony-codex = [
-      {
-        assertion = symphonyCodex.config.ix.image.name == "ix/symphony-codex";
-        message = "symphony-codex image should set the expected public OCI image name";
-      }
-      {
-        assertion = symphonyCodex.config.ix.image.tag == "2026-05-31";
-        message = "symphony-codex image should publish an immutable production tag";
-      }
       {
         assertion = builtins.elem pkgs.symphony-room-server symphonyCodex.packages;
         message = "symphony-codex image should include the room-server binary it starts";


### PR DESCRIPTION
Drop change-detector eval-test assertions that only re-spell a literal defined a few lines away, and document the rule so they don't come back.

Removed (all pure re-assertions of a same-eval literal; would only fail if someone edited that exact value):

- `development-base` — `cleanupPeriodDays >= 3650`: re-asserts an int literal `toJSON` can't malform; no real failure mode.
- `development-base` — `thinking.display == "summarized"`: round-trips a literal config value through JSON; behavior is derivable from source and the type system makes malformation unlikely. No non-obvious bug it uniquely catches.
- `symphony-codex` — `ix.image.name == "ix/symphony-codex"`: re-spells the literal set in the same image source.
- `symphony-codex` — `ix.image.tag == "2026-05-31"`: re-spells the literal date in the same image source.

Kept (real invariants, not change-detectors): the `development-base` bypass guardrail (`defaultMode == "bypassPermissions" && skipDangerousModePermissionPrompt`, a security property), package-presence checks, firewall/portClaim cross-boundary checks, the minecraft image-tag-vs-`versions.nix` cross-source check, and the bun/uv lock-parser round-trip checks.

Guidance added to `agent-context/sections/17-tests.md`:

> ### Before writing an assertion, run the failure test
>
> Ask: if this assertion failed, would it reveal a bug a reader could not predict from the source line it checks? Or would it only fire when someone deliberately edits that exact literal? Write it only in the first case.
>
> - Only assert genuinely useful, non-obvious behavior that a reader cannot trivially derive from the source under test.
> - Do not assert a literal constant against itself (a date, tag, name, port, or retention count round-tripped through `fromJSON`/`toJSON`), and do not assert what the type system or `builtins.toJSON` already guarantees cannot malform.
> - A real invariant earns the line: a security or policy property, a required package's presence, two files that must agree with no shared source, a generated artifact that must match a manifest, or parser/round-trip behavior with a genuine failure mode.

Validation: `nix-instantiate --parse tests/default.nix` OK; `nix build .#development-base.passthru.tests.eval` PASS; `nix run .#lint` green (deadnix confirms no dead bindings).

_Made with Claude (Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop change-detector assertions from image tests and document assertion best practices
> - Removes four assertions from [tests/default.nix](https://github.com/indexable-inc/index/pull/535/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) that restated literal config values: `CLAUDE_CODE_EXTRA_BODY` thinking mode, transcript retention days, and `symphony-codex` image name and tag.
> - Adds a new section to [agent-context/sections/17-tests.md](https://github.com/indexable-inc/index/pull/535/files#diff-4c4d5db84850fd19a354b3a3cb7ce97c50bf1c91d1e57471b393d73d3eefe8a2) documenting when to write assertions, with guidance to avoid asserting literals or type-enforced properties.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 100b902.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->