### PR TITLE
Use layer-shell for bossbar overlay on Wayland

### DIFF
--- a/packages/bossbar-overlay/app/Cargo.lock
+++ b/packages/bossbar-overlay/app/Cargo.lock
@@ -169,11 +169,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
 name = "bossbar"
 version = "0.1.0"
 dependencies = [
  "dirs",
  "glam",
+ "layershellev",
  "overlay-core",
  "rusqlite",
 ]
@@ -231,13 +242,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "calloop"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
+dependencies = [
+ "bitflags 2.11.1",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "tracing",
+]
+
+[[package]]
 name = "calloop-wayland-source"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
- "calloop",
+ "calloop 0.13.0",
  "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
+dependencies = [
+ "calloop 0.14.4",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-client",
 ]
@@ -468,6 +504,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fdeflate"
@@ -834,6 +876,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyboard-types"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbe853b403ae61a04233030ae8a79d94975281ed9770a1f9e246732b534b28d"
+dependencies = [
+ "bitflags 2.11.1",
+ "serde",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +901,28 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "layershellev"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f48eaa0c702d491d6411620eca91eae3beecc018e79402708f97e1cc948ad8"
+dependencies = [
+ "calloop 0.14.4",
+ "calloop-wayland-source 0.4.1",
+ "log",
+ "raw-window-handle",
+ "smithay-client-toolkit 0.20.0",
+ "tempfile",
+ "thiserror 2.0.18",
+ "waycrate_xkbkeycode",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
+]
 
 [[package]]
 name = "libc"
@@ -1680,7 +1754,7 @@ dependencies = [
  "ab_glyph",
  "log",
  "memmap2",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2",
  "tiny-skia",
 ]
 
@@ -1776,8 +1850,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
  "bitflags 2.11.1",
- "calloop",
- "calloop-wayland-source",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
  "cursor-icon",
  "libc",
  "log",
@@ -1795,12 +1869,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "smithay-client-toolkit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytemuck",
+ "calloop 0.14.4",
+ "calloop-wayland-source 0.4.1",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "pkg-config",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkbcommon",
+ "xkeysym",
+]
+
+[[package]]
 name = "smol_str"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
 ]
 
 [[package]]
@@ -1833,6 +1947,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1945,6 +2072,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -2072,6 +2200,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "waycrate_xkbkeycode"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8b2edb13e0c700b910f62ba561c80bd1d5f881dd66efbfe254a221c35ad26c"
+dependencies = [
+ "calloop 0.14.4",
+ "log",
+ "memmap2",
+ "wayland-backend",
+ "wayland-client",
+ "winit-common",
+ "winit-core",
+ "xkbcommon-dl",
+]
+
+[[package]]
 name = "wayland-backend"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,6 +2272,32 @@ dependencies = [
  "bitflags 2.11.1",
  "wayland-backend",
  "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -2572,7 +2742,7 @@ dependencies = [
  "bitflags 2.11.1",
  "block2",
  "bytemuck",
- "calloop",
+ "calloop 0.13.0",
  "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
@@ -2594,8 +2764,8 @@ dependencies = [
  "redox_syscall 0.4.1",
  "rustix 0.38.44",
  "sctk-adwaita",
- "smithay-client-toolkit",
- "smol_str",
+ "smithay-client-toolkit 0.19.2",
+ "smol_str 0.2.2",
  "tracing",
  "unicode-segmentation",
  "wasm-bindgen",
@@ -2610,6 +2780,34 @@ dependencies = [
  "x11-dl",
  "x11rb",
  "xkbcommon-dl",
+]
+
+[[package]]
+name = "winit-common"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45375fbac4cbb77260d83a30b1f9d8105880dbac99a9ae97f56656694680ff69"
+dependencies = [
+ "memmap2",
+ "smol_str 0.3.6",
+ "tracing",
+ "winit-core",
+ "xkbcommon-dl",
+]
+
+[[package]]
+name = "winit-core"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4f0ccd7abb43740e2c6124ac7cae7d865ecec74eec63783e8922577ac232583"
+dependencies = [
+ "bitflags 2.11.1",
+ "cursor-icon",
+ "dpi",
+ "keyboard-types",
+ "raw-window-handle",
+ "smol_str 0.3.6",
+ "web-time",
 ]
 
 [[package]]
@@ -2666,6 +2864,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
 
 [[package]]
+name = "xkbcommon"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d66ca9352cbd4eecbbc40871d8a11b4ac8107cfc528a6e14d7c19c69d0e1ac9"
+dependencies = [
+ "libc",
+ "memmap2",
+ "xkeysym",
+]
+
+[[package]]
 name = "xkbcommon-dl"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,6 +2892,9 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "xml-rs"

--- a/packages/bossbar-overlay/app/Cargo.toml
+++ b/packages/bossbar-overlay/app/Cargo.toml
@@ -33,6 +33,9 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 dirs = "6"
 # 2D vectors for window positions, instead of bare (f64, f64).
 glam = "0.30"
+# Wayland layer-shell backend for compositor-owned overlay placement on wlroots
+# compositors such as Hyprland.
+layershellev = "0.18.1"
 # macOS AppKit, reached through the raw window handle for two things winit has no
 # API for: raise a hovered window above its always-on-top siblings without taking
 # keyboard focus (`-[NSWindow orderFrontRegardless]`), a right-click context menu

--- a/packages/bossbar-overlay/app/crates/bossbar/Cargo.toml
+++ b/packages/bossbar-overlay/app/crates/bossbar/Cargo.toml
@@ -18,3 +18,6 @@ overlay-core.workspace = true
 glam.workspace = true
 rusqlite.workspace = true
 dirs.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+layershellev.workspace = true

--- a/packages/bossbar-overlay/app/crates/bossbar/src/layer_shell.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/layer_shell.rs
@@ -1,0 +1,1018 @@
+//! Wayland layer-shell backend for the live boss bar overlay.
+//!
+//! Normal Wayland toplevel windows cannot choose their own global position:
+//! compositors such as Hyprland are free to center new floating windows and ignore
+//! winit's requested top-left. Layer-shell is the compositor-owned protocol for
+//! panels and overlays, so each boss bar is represented as a small top-layer
+//! surface anchored to the top of the output. Auto-stacked bars use a top-only
+//! anchor, letting the compositor keep them horizontally centered; when a bar is
+//! dragged, the xdg-output size gives us the centered left edge before switching
+//! it to top-left anchoring with persisted margins.
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use layershellev::calloop::channel;
+use layershellev::id::Id as ShellId;
+// layershellev re-exports wl_pointer at this level; it does not expose
+// wayland_client::protocol through its wrapper module.
+use layershellev::reexport::wayland_client::WEnum;
+use layershellev::reexport::wayland_client::wl_pointer::ButtonState;
+use layershellev::reexport::{Anchor, KeyboardInteractivity, Layer};
+use layershellev::{
+    AxisScroll, DispatchMessage, LayerShellEvent, NewLayerShellSettings, OutputOption,
+    RefreshRequest, ReturnData, WindowState,
+};
+use overlay_core::glam::DVec2;
+use overlay_core::wgpu;
+use overlay_core::winit::dpi::PhysicalPosition;
+use overlay_core::{DragClick, Gpu, HoverAnim, anim, window as ocwin};
+
+use crate::bars::BossBar;
+use crate::db;
+use crate::scene::{self, BarTextures};
+
+const AUTO_TOP: f64 = 40.0;
+const AUTO_GAP: f64 = 6.0;
+const GROW: Duration = Duration::from_millis(160);
+const BREATHE_PERIOD: Duration = Duration::from_millis(2600);
+const MAX_STEP: Duration = Duration::from_millis(50);
+const FRAME: Duration = Duration::from_millis(16);
+const TICK: Duration = Duration::from_secs(1);
+const SETTLE: Duration = Duration::from_millis(700);
+const SCROLL_SAVE_AFTER: Duration = Duration::from_millis(150);
+const DRAG_THRESHOLD: f64 = 5.0;
+const LINE_POINTS: f64 = 16.0;
+const BTN_LEFT: u32 = 0x110;
+const BTN_RIGHT: u32 = 0x111;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Pos {
+    x: f64,
+    y: f64,
+}
+
+impl Pos {
+    fn new(x: f64, y: f64) -> Self {
+        Self { x, y }
+    }
+}
+
+struct GpuCore {
+    gpu: Gpu,
+    textures: BarTextures,
+    format: wgpu::TextureFormat,
+    alpha_mode: wgpu::CompositeAlphaMode,
+}
+
+struct BarWin {
+    shell_id: ShellId,
+    surface: Option<wgpu::Surface<'static>>,
+    config: Option<wgpu::SurfaceConfiguration>,
+    bar: BossBar,
+    hovered: bool,
+    hover_anim: HoverAnim,
+    last: Instant,
+    gesture: DragClick,
+    self_set: Pos,
+    press_cursor: Option<PhysicalPosition<f64>>,
+    press_pos: Option<Pos>,
+    has_description: bool,
+    last_size: (u32, u32),
+    scale_factor: f64,
+    scale: u32,
+    scroll_dirty: bool,
+    scroll_last: Option<Instant>,
+    last_move: Instant,
+    layer: Layer,
+}
+
+impl BarWin {
+    fn animating(&self) -> bool {
+        self.hovered || !self.hover_anim.is_resting()
+    }
+
+    fn wants_expanded(&self) -> bool {
+        self.has_description && self.animating()
+    }
+
+    fn local_position_active(&self, now: Instant) -> bool {
+        self.gesture.dragging()
+            || self.scroll_dirty
+            || now.saturating_duration_since(self.last_move) < SETTLE
+    }
+}
+
+struct App {
+    db: PathBuf,
+    base_scale: u32,
+    instance: wgpu::Instance,
+    core: Option<GpuCore>,
+    wins: HashMap<i64, BarWin>,
+    start: Instant,
+}
+
+fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn open_url(url: &str) {
+    if let Err(e) = std::process::Command::new("xdg-open").arg(url).spawn() {
+        eprintln!("bossbar-overlay: failed to open {url}: {e}");
+    }
+}
+
+fn shell_margin(pos: Pos, pinned: bool) -> (i32, i32, i32, i32) {
+    let top = pos.y.max(0.0).round() as i32;
+    let left = if pinned {
+        pos.x.max(0.0).round() as i32
+    } else {
+        0
+    };
+    (top, 0, 0, left)
+}
+
+fn shell_anchor(pinned: bool) -> Anchor {
+    if pinned {
+        Anchor::Top | Anchor::Left
+    } else {
+        Anchor::Top
+    }
+}
+
+fn axis_drag_delta(horizontal: AxisScroll, vertical: AxisScroll, scale_factor: f64) -> (f64, f64) {
+    let scale_factor = scale_factor.max(1.0);
+    let dx = if horizontal.absolute != 0.0 {
+        -horizontal.absolute / scale_factor
+    } else {
+        -(horizontal.discrete as f64) * LINE_POINTS
+    };
+    let dy = if vertical.absolute != 0.0 {
+        -vertical.absolute / scale_factor
+    } else {
+        -(vertical.discrete as f64) * LINE_POINTS
+    };
+    (dx, dy)
+}
+
+fn axis_has_delta(horizontal: AxisScroll, vertical: AxisScroll) -> bool {
+    horizontal.absolute != 0.0
+        || vertical.absolute != 0.0
+        || horizontal.discrete != 0
+        || vertical.discrete != 0
+}
+
+fn axis_is_discrete(horizontal: AxisScroll, vertical: AxisScroll) -> bool {
+    horizontal.discrete != 0 || vertical.discrete != 0
+}
+
+fn axis_stopped(horizontal: AxisScroll, vertical: AxisScroll) -> bool {
+    horizontal.stop || vertical.stop
+}
+
+impl App {
+    fn new(db: PathBuf, base_scale: u32) -> Self {
+        Self {
+            db,
+            base_scale: base_scale.max(1),
+            instance: wgpu::Instance::default(),
+            core: None,
+            wins: HashMap::new(),
+            start: Instant::now(),
+        }
+    }
+
+    fn scale(&self, scale_factor: f64) -> u32 {
+        ((self.base_scale as f64) * scale_factor.max(1.0))
+            .round()
+            .max(1.0) as u32
+    }
+
+    fn logical_size(size_px: (u32, u32), scale_factor: f64) -> (u32, u32) {
+        let scale_factor = scale_factor.max(1.0);
+        (
+            ((size_px.0 as f64) / scale_factor).ceil().max(1.0) as u32,
+            ((size_px.1 as f64) / scale_factor).ceil().max(1.0) as u32,
+        )
+    }
+
+    fn configured_surface_px(
+        configured: (u32, u32),
+        requested_px: (u32, u32),
+        scale_factor: f64,
+    ) -> (u32, u32) {
+        let scale_factor = scale_factor.max(1.0);
+        let px = |configured: u32, requested: u32| {
+            if configured == 0 {
+                requested.max(1)
+            } else {
+                ((configured as f64) * scale_factor).ceil().max(1.0) as u32
+            }
+        };
+        (
+            px(configured.0, requested_px.0),
+            px(configured.1, requested_px.1),
+        )
+    }
+
+    fn centered_x(w_px: u32, scale_factor: f64, output_width: f64) -> f64 {
+        let wl = w_px as f64 / scale_factor.max(1.0);
+        ((output_width - wl) / 2.0).max(0.0)
+    }
+
+    fn output_logical_width(ev: &WindowState<i64>, shell_id: ShellId) -> Option<f64> {
+        let (w, _) = ev
+            .get_unit_with_id(shell_id)?
+            .get_xdgoutput_info()?
+            .get_logical_size();
+        (w > 0).then_some(w as f64)
+    }
+
+    fn auto_pos(
+        slot: usize,
+        w_px: u32,
+        h_px: u32,
+        scale_factor: f64,
+        output_width: Option<f64>,
+    ) -> Pos {
+        let hl = h_px as f64 / scale_factor.max(1.0);
+        // Auto surfaces are compositor-centered by using only a top anchor. Before
+        // the first configure we may not have xdg-output details yet, so the
+        // fallback x is temporary and is replaced before a drag/scroll pins the bar.
+        let x = output_width
+            .map(|output_width| Self::centered_x(w_px, scale_factor, output_width))
+            .unwrap_or(0.0);
+        Pos::new(x, AUTO_TOP + slot as f64 * (hl + AUTO_GAP))
+    }
+
+    fn sync_auto_x(&mut self, ev: &WindowState<i64>, shell_id: ShellId, bar_id: i64) -> bool {
+        let Some(auto) = self.wins.get(&bar_id).map(|win| win.bar.pos.is_none()) else {
+            return false;
+        };
+        if !auto {
+            return true;
+        }
+        let Some(output_width) = Self::output_logical_width(ev, shell_id) else {
+            return false;
+        };
+        if let Some(win) = self.wins.get_mut(&bar_id) {
+            win.self_set.x = Self::centered_x(win.last_size.0, win.scale_factor, output_width);
+        }
+        true
+    }
+
+    fn layer_settings(
+        size_px: (u32, u32),
+        scale_factor: f64,
+        pos: Pos,
+        pinned: bool,
+        layer: Layer,
+    ) -> NewLayerShellSettings {
+        NewLayerShellSettings {
+            size: Some(Self::logical_size(size_px, scale_factor)),
+            layer,
+            anchor: shell_anchor(pinned),
+            exclusive_zone: None,
+            margin: Some(shell_margin(pos, pinned)),
+            keyboard_interactivity: KeyboardInteractivity::None,
+            output_option: OutputOption::None,
+            events_transparent: false,
+            namespace: Some("bossbar-overlay".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn apply_geometry(
+        ev: &WindowState<i64>,
+        shell_id: ShellId,
+        size_px: (u32, u32),
+        scale_factor: f64,
+        pos: Pos,
+        pinned: bool,
+    ) {
+        if let Some(unit) = ev.get_unit_with_id(shell_id) {
+            unit.set_anchor_with_size(
+                shell_anchor(pinned),
+                Self::logical_size(size_px, scale_factor),
+            );
+            unit.set_margin(shell_margin(pos, pinned));
+        }
+    }
+
+    fn create_win(&mut self, ev: &mut WindowState<i64>, bar: BossBar, slot: usize, layer: Layer) {
+        let scale_factor = 1.0;
+        let scale = self.scale(scale_factor);
+        let title_w = scene::title_extent_px(&bar, scale, now_unix());
+        let size = scene::bar_window_px(scale, title_w);
+        let pinned = bar.pos.is_some();
+        let pos = bar
+            .pos
+            .map(|p| Pos::new(p.x, p.y))
+            .unwrap_or_else(|| Self::auto_pos(slot, size.0, size.1, scale_factor, None));
+        let shell_id = ShellId::unique();
+        let now = Instant::now();
+        let has_description = !bar.description.trim().is_empty();
+        self.wins.insert(
+            bar.id,
+            BarWin {
+                shell_id,
+                surface: None,
+                config: None,
+                bar: bar.clone(),
+                hovered: false,
+                hover_anim: HoverAnim::default(),
+                last: now,
+                gesture: DragClick::new(DRAG_THRESHOLD),
+                self_set: pos,
+                press_cursor: None,
+                press_pos: None,
+                has_description,
+                last_size: size,
+                scale_factor,
+                scale,
+                scroll_dirty: false,
+                scroll_last: None,
+                last_move: now - SETTLE,
+                layer,
+            },
+        );
+        ev.append_return_data(ReturnData::NewLayerShell((
+            Self::layer_settings(size, scale_factor, pos, pinned, layer),
+            shell_id,
+            Some(bar.id),
+        )));
+    }
+
+    fn active_panel_bar(&self) -> Option<i64> {
+        self.wins
+            .iter()
+            .find_map(|(id, win)| (win.has_description && win.hovered).then_some(*id))
+            .or_else(|| {
+                self.wins
+                    .iter()
+                    .find_map(|(id, win)| win.wants_expanded().then_some(*id))
+            })
+    }
+
+    fn sync_layers(&mut self, ev: &WindowState<i64>) {
+        let active = self.active_panel_bar();
+        for (id, win) in &mut self.wins {
+            let target = if active.is_some() && active != Some(*id) {
+                Layer::Top
+            } else {
+                Layer::Overlay
+            };
+            if win.layer != target {
+                win.layer = target;
+                if let Some(unit) = ev.get_unit_with_id(win.shell_id) {
+                    unit.set_layer(target);
+                }
+            }
+        }
+    }
+
+    fn reconcile(&mut self, ev: &mut WindowState<i64>, bars: Vec<BossBar>) {
+        let live: HashSet<i64> = bars.iter().map(|bar| bar.id).collect();
+        let removed: Vec<i64> = self
+            .wins
+            .keys()
+            .copied()
+            .filter(|id| !live.contains(id))
+            .collect();
+        for id in removed {
+            self.close_win(ev, id);
+        }
+
+        let now = Instant::now();
+        let mut slot = 0usize;
+        for bar in bars {
+            let this_slot = if bar.pos.is_none() {
+                let s = slot;
+                slot += 1;
+                s
+            } else {
+                0
+            };
+
+            let output_width = self
+                .wins
+                .get(&bar.id)
+                .and_then(|win| Self::output_logical_width(ev, win.shell_id));
+            if let Some(win) = self.wins.get_mut(&bar.id) {
+                win.has_description = !bar.description.trim().is_empty();
+                let local_position_active = win.local_position_active(now);
+                let local_pinned = win.bar.pos.is_some();
+                let local_pos = win.self_set;
+                let db_pos = bar.pos.map(|p| Pos::new(p.x, p.y));
+                win.bar = bar;
+                let (pos, pinned) = if local_position_active && local_pinned {
+                    win.bar.pos = Some(DVec2::new(local_pos.x, local_pos.y));
+                    (local_pos, true)
+                } else {
+                    let pos = db_pos.unwrap_or_else(|| {
+                        Self::auto_pos(
+                            this_slot,
+                            win.last_size.0,
+                            win.last_size.1,
+                            win.scale_factor,
+                            output_width,
+                        )
+                    });
+                    (pos, db_pos.is_some())
+                };
+                win.self_set = pos;
+                Self::apply_geometry(
+                    ev,
+                    win.shell_id,
+                    win.last_size,
+                    win.scale_factor,
+                    pos,
+                    pinned,
+                );
+                ev.request_refresh(win.shell_id, RefreshRequest::NextFrame);
+            } else {
+                let layer = if self.active_panel_bar().is_some() {
+                    Layer::Top
+                } else {
+                    Layer::Overlay
+                };
+                self.create_win(ev, bar, this_slot, layer);
+            }
+        }
+        self.sync_layers(ev);
+    }
+
+    fn close_win(&mut self, ev: &mut WindowState<i64>, bar_id: i64) {
+        if let Some(mut win) = self.wins.remove(&bar_id) {
+            let shell_id = win.shell_id;
+            // The wgpu surface borrows raw handles from the layer-shell unit.
+            // Drop it before asking layershellev to tear that unit down.
+            drop(win.surface.take());
+            ev.request_close(shell_id);
+        }
+    }
+
+    fn drop_surfaces(&mut self) {
+        for win in self.wins.values_mut() {
+            drop(win.surface.take());
+        }
+    }
+
+    fn bar_id_for_shell(&self, ev: &WindowState<i64>, shell_id: ShellId) -> Option<i64> {
+        ev.get_unit_with_id(shell_id)
+            .and_then(|unit| unit.get_binding().copied())
+    }
+
+    fn ensure_surface(
+        &mut self,
+        ev: &WindowState<i64>,
+        shell_id: ShellId,
+        width: u32,
+        height: u32,
+    ) -> bool {
+        let Some(bar_id) = self.bar_id_for_shell(ev, shell_id) else {
+            return false;
+        };
+        if self
+            .wins
+            .get(&bar_id)
+            .is_none_or(|win| win.surface.is_some())
+        {
+            return self.wins.contains_key(&bar_id);
+        }
+
+        let Some(unit) = ev.get_unit_with_id(shell_id) else {
+            return false;
+        };
+        // SAFETY: the raw Wayland display and surface handles come from the live
+        // layershellev unit. `BarWin` drops its wgpu surface before requesting
+        // that unit's close, and compositor-initiated closes remove `BarWin`
+        // before layershellev destroys the unit.
+        let target = match unsafe { wgpu::SurfaceTargetUnsafe::from_window(unit) } {
+            Ok(target) => target,
+            Err(e) => {
+                eprintln!("bossbar-overlay: layer-shell raw handle failed: {e}");
+                return false;
+            }
+        };
+        // SAFETY: see the handle lifetime note above.
+        let surface = match unsafe { self.instance.create_surface_unsafe(target) } {
+            Ok(surface) => surface,
+            Err(e) => {
+                eprintln!("bossbar-overlay: create layer-shell surface failed: {e}");
+                return false;
+            }
+        };
+
+        if self.core.is_none() {
+            let (adapter, device, queue) = ocwin::request_adapter_device(&self.instance, &surface);
+            let caps = surface.get_capabilities(&adapter);
+            let format = ocwin::srgb_format(&caps);
+            let alpha_mode = ocwin::transparent_alpha_mode(&caps);
+
+            let mut gpu = Gpu::new(device, queue, format);
+            let textures = scene::register(&mut gpu);
+            self.core = Some(GpuCore {
+                gpu,
+                textures,
+                format,
+                alpha_mode,
+            });
+        }
+
+        let core = self.core.as_ref().expect("core just initialized");
+        let config = ocwin::surface_config(core.format, core.alpha_mode, width, height);
+        surface.configure(core.gpu.device(), &config);
+        if let Some(win) = self.wins.get_mut(&bar_id) {
+            win.surface = Some(surface);
+            win.config = Some(config);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn settle_window_size(&mut self, ev: &mut WindowState<i64>, bar_id: i64) -> bool {
+        let now = now_unix();
+        let Some(win) = self.wins.get_mut(&bar_id) else {
+            return false;
+        };
+        let size = if win.wants_expanded() {
+            match self.core.as_ref() {
+                Some(core) => scene::expanded_window_px(&core.gpu, &win.bar, win.scale, now),
+                None => {
+                    let title_w = scene::title_extent_px(&win.bar, win.scale, now);
+                    scene::bar_window_px(win.scale, title_w)
+                }
+            }
+        } else {
+            let title_w = scene::title_extent_px(&win.bar, win.scale, now);
+            scene::bar_window_px(win.scale, title_w)
+        };
+
+        if win.last_size == size {
+            return false;
+        }
+
+        win.last_size = size;
+        let pinned = win.bar.pos.is_some();
+        if !pinned && let Some(output_width) = Self::output_logical_width(ev, win.shell_id) {
+            win.self_set.x = Self::centered_x(size.0, win.scale_factor, output_width);
+        }
+        Self::apply_geometry(
+            ev,
+            win.shell_id,
+            size,
+            win.scale_factor,
+            win.self_set,
+            pinned,
+        );
+        true
+    }
+
+    fn configure_surface(&mut self, bar_id: i64, width: u32, height: u32) {
+        let Some(core) = self.core.as_ref() else {
+            return;
+        };
+        let Some(win) = self.wins.get_mut(&bar_id) else {
+            return;
+        };
+        let Some(surface) = win.surface.as_ref() else {
+            return;
+        };
+        let needs_config = win
+            .config
+            .as_ref()
+            .is_none_or(|cfg| cfg.width != width || cfg.height != height);
+        if needs_config {
+            let config = ocwin::surface_config(core.format, core.alpha_mode, width, height);
+            surface.configure(core.gpu.device(), &config);
+            win.config = Some(config);
+        }
+    }
+
+    fn render(
+        &mut self,
+        ev: &mut WindowState<i64>,
+        shell_id: ShellId,
+        width: u32,
+        height: u32,
+        scale_factor: f64,
+    ) {
+        let Some(bar_id) = self.bar_id_for_shell(ev, shell_id) else {
+            return;
+        };
+        let scale = self.scale(scale_factor);
+        if let Some(win) = self.wins.get_mut(&bar_id) {
+            win.scale_factor = scale_factor.max(1.0);
+            win.scale = scale;
+        }
+        let _ = self.sync_auto_x(ev, shell_id, bar_id);
+        if self.settle_window_size(ev, bar_id) {
+            return;
+        }
+        let Some(requested_size) = self.wins.get(&bar_id).map(|win| win.last_size) else {
+            return;
+        };
+        let render_size =
+            Self::configured_surface_px((width, height), requested_size, scale_factor);
+        if !self.ensure_surface(ev, shell_id, render_size.0, render_size.1) {
+            return;
+        }
+        self.configure_surface(bar_id, render_size.0, render_size.1);
+
+        let now = Instant::now();
+        let unix_now = now_unix();
+        let breathe = anim::breathe(now.duration_since(self.start), BREATHE_PERIOD);
+        let (hover, needs_final_settle) = {
+            let Some(win) = self.wins.get_mut(&bar_id) else {
+                return;
+            };
+            let dt = now.duration_since(win.last).min(MAX_STEP);
+            win.last = now;
+            win.hover_anim
+                .approach(if win.hovered { 1.0 } else { 0.0 }, dt, GROW);
+            let hover = win.hover_anim.eased();
+            // If this frame just eased a leaving hover to rest, the size-settle
+            // pass above kept the expanded surface. Queue one more pass to shrink it.
+            let title_w = scene::title_extent_px(&win.bar, win.scale, unix_now);
+            let collapsed_size = scene::bar_window_px(win.scale, title_w);
+            (
+                hover,
+                !win.wants_expanded() && win.last_size != collapsed_size,
+            )
+        };
+
+        let Some(core) = self.core.as_ref() else {
+            return;
+        };
+        let Some(win) = self.wins.get_mut(&bar_id) else {
+            return;
+        };
+        let Some(surface) = win.surface.as_ref() else {
+            return;
+        };
+        let frame = match surface.get_current_texture() {
+            Ok(frame) => frame,
+            Err(wgpu::SurfaceError::Outdated | wgpu::SurfaceError::Lost) => {
+                if let Some(config) = win.config.as_ref() {
+                    surface.configure(core.gpu.device(), config);
+                }
+                return;
+            }
+            Err(e) => {
+                eprintln!("bossbar-overlay: layer-shell surface error: {e:?}");
+                return;
+            }
+        };
+        let Some(config) = win.config.as_ref() else {
+            return;
+        };
+        let view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let quads = scene::build_one(
+            &core.gpu,
+            &core.textures,
+            win.scale,
+            config.width,
+            config.height,
+            unix_now,
+            &win.bar,
+            hover,
+            breathe,
+        );
+        let _ = core.gpu.draw(&view, config.width, config.height, &quads);
+        frame.present();
+
+        let (shell_id, next) = {
+            let next = if needs_final_settle {
+                Some(RefreshRequest::NextFrame)
+            } else if win.animating() {
+                Some(RefreshRequest::At(Instant::now() + FRAME))
+            } else if win.bar.since.is_some() {
+                Some(RefreshRequest::At(Instant::now() + TICK))
+            } else {
+                None
+            };
+            (win.shell_id, next)
+        };
+        self.sync_layers(ev);
+        if let Some(next) = next {
+            ev.request_refresh(shell_id, next);
+        }
+        if let Some(next) = self.settle_scroll_save(bar_id) {
+            ev.request_refresh(shell_id, next);
+        }
+    }
+
+    fn move_bar(&mut self, ev: &mut WindowState<i64>, bar_id: i64, pos: Pos, persist: bool) {
+        let Some(win) = self.wins.get_mut(&bar_id) else {
+            return;
+        };
+        win.self_set = pos;
+        win.bar.pos = Some(DVec2::new(pos.x, pos.y));
+        win.last_move = Instant::now();
+        Self::apply_geometry(ev, win.shell_id, win.last_size, win.scale_factor, pos, true);
+        ev.request_refresh(win.shell_id, RefreshRequest::NextFrame);
+        if persist {
+            self.save_position(bar_id, pos);
+            self.clear_scroll_dirty(bar_id);
+        }
+    }
+
+    fn save_position(&self, bar_id: i64, pos: Pos) {
+        if let Err(e) = db::set_position(&self.db, bar_id, DVec2::new(pos.x, pos.y)) {
+            eprintln!("bossbar-overlay: save position failed: {e}");
+        }
+    }
+
+    fn clear_scroll_dirty(&mut self, bar_id: i64) {
+        if let Some(win) = self.wins.get_mut(&bar_id) {
+            win.scroll_dirty = false;
+            win.scroll_last = None;
+        }
+    }
+
+    fn mark_scroll_dirty(&mut self, ev: &mut WindowState<i64>, bar_id: i64) {
+        let now = Instant::now();
+        if let Some(win) = self.wins.get_mut(&bar_id) {
+            win.scroll_dirty = true;
+            win.scroll_last = Some(now);
+            ev.request_refresh(win.shell_id, RefreshRequest::At(now + SCROLL_SAVE_AFTER));
+        }
+    }
+
+    fn save_scroll_now(&mut self, bar_id: i64) {
+        let pos = self.wins.get_mut(&bar_id).and_then(|win| {
+            win.scroll_dirty.then(|| {
+                win.scroll_dirty = false;
+                win.scroll_last = None;
+                win.self_set
+            })
+        });
+        if let Some(pos) = pos {
+            self.save_position(bar_id, pos);
+        }
+    }
+
+    fn settle_scroll_save(&mut self, bar_id: i64) -> Option<RefreshRequest> {
+        let now = Instant::now();
+        let mut save = None;
+        let mut next = None;
+        if let Some(win) = self.wins.get_mut(&bar_id)
+            && win.scroll_dirty
+        {
+            let due = win.scroll_last.unwrap_or(now) + SCROLL_SAVE_AFTER;
+            if now >= due {
+                win.scroll_dirty = false;
+                win.scroll_last = None;
+                save = Some(win.self_set);
+            } else {
+                next = Some(RefreshRequest::At(due));
+            }
+        }
+        if let Some(pos) = save {
+            self.save_position(bar_id, pos);
+        }
+        next
+    }
+
+    fn handle_dispatch(
+        &mut self,
+        msg: &DispatchMessage,
+        ev: &mut WindowState<i64>,
+        shell_id: ShellId,
+    ) -> ReturnData<i64> {
+        let Some(bar_id) = self.bar_id_for_shell(ev, shell_id) else {
+            return ReturnData::None;
+        };
+        match msg {
+            DispatchMessage::RequestRefresh {
+                width,
+                height,
+                scale_float,
+                ..
+            } => {
+                self.render(ev, shell_id, *width, *height, *scale_float);
+                ReturnData::None
+            }
+            DispatchMessage::PreferredScale { scale_float, .. } => {
+                let scale = self.scale(*scale_float);
+                if let Some(win) = self.wins.get_mut(&bar_id) {
+                    win.scale_factor = (*scale_float).max(1.0);
+                    win.scale = scale;
+                    let pinned = win.bar.pos.is_some();
+                    Self::apply_geometry(
+                        ev,
+                        win.shell_id,
+                        win.last_size,
+                        win.scale_factor,
+                        win.self_set,
+                        pinned,
+                    );
+                    ev.request_refresh(win.shell_id, RefreshRequest::NextFrame);
+                }
+                ReturnData::None
+            }
+            DispatchMessage::MouseEnter {
+                pointer,
+                surface_x,
+                surface_y,
+                ..
+            } => {
+                if let Some(win) = self.wins.get_mut(&bar_id) {
+                    win.hovered = true;
+                    let _ = win
+                        .gesture
+                        .cursor_moved(PhysicalPosition::new(*surface_x, *surface_y));
+                    ev.request_refresh(win.shell_id, RefreshRequest::NextFrame);
+                }
+                self.sync_layers(ev);
+                ReturnData::RequestSetCursorShape(("grab".to_string(), pointer.clone()))
+            }
+            DispatchMessage::MouseLeave => {
+                if let Some(win) = self.wins.get_mut(&bar_id) {
+                    win.hovered = false;
+                    ev.request_refresh(win.shell_id, RefreshRequest::NextFrame);
+                }
+                self.sync_layers(ev);
+                ReturnData::None
+            }
+            DispatchMessage::MouseMotion {
+                surface_x,
+                surface_y,
+                ..
+            } => {
+                let pos = PhysicalPosition::new(*surface_x, *surface_y);
+                let mut drag_to = None;
+                let mut refresh = None;
+                if let Some(win) = self.wins.get_mut(&bar_id) {
+                    let started_drag = win.gesture.cursor_moved(pos);
+                    if win.gesture.dragging() {
+                        if win.press_pos.is_some() {
+                            if let (Some(press), Some(cursor)) =
+                                (win.press_cursor, win.gesture.cursor())
+                            {
+                                // Wayland pointer motion is surface-local. Once the
+                                // layer surface moves, the next cursor sample is
+                                // relative to the moved surface, so keep the press
+                                // anchor fixed and advance from the current margin.
+                                drag_to = Some(Pos::new(
+                                    (win.self_set.x + cursor.x - press.x).max(0.0),
+                                    (win.self_set.y + cursor.y - press.y).max(0.0),
+                                ));
+                            }
+                        }
+                    } else if started_drag {
+                        refresh = Some(win.shell_id);
+                    }
+                }
+                if let Some(pos) = drag_to {
+                    self.move_bar(ev, bar_id, pos, false);
+                } else if let Some(shell_id) = refresh {
+                    ev.request_refresh(shell_id, RefreshRequest::NextFrame);
+                }
+                ReturnData::None
+            }
+            DispatchMessage::MouseButton { state, button, .. } if *button == BTN_LEFT => {
+                match state {
+                    WEnum::Value(ButtonState::Pressed) => {
+                        let can_pin = self.sync_auto_x(ev, shell_id, bar_id);
+                        if let Some(win) = self.wins.get_mut(&bar_id) {
+                            win.gesture.pressed();
+                            win.press_cursor = win.gesture.cursor();
+                            win.press_pos = can_pin.then_some(win.self_set);
+                        }
+                    }
+                    WEnum::Value(ButtonState::Released) => {
+                        let mut drag_to = None;
+                        let mut click_url = None;
+                        if let Some(win) = self.wins.get_mut(&bar_id) {
+                            let was_dragging = win.gesture.dragging();
+                            let clicked = win.gesture.released();
+                            if clicked {
+                                if !win.bar.url.trim().is_empty() {
+                                    click_url = Some(win.bar.url.clone());
+                                }
+                            } else if was_dragging && win.press_pos.is_some() {
+                                drag_to = Some(win.self_set);
+                            }
+                            win.press_cursor = None;
+                            win.press_pos = None;
+                        }
+                        if let Some(url) = click_url {
+                            open_url(&url);
+                        }
+                        if let Some(pos) = drag_to {
+                            self.move_bar(ev, bar_id, pos, true);
+                        }
+                    }
+                    _ => {}
+                }
+                ReturnData::None
+            }
+            DispatchMessage::MouseButton { state, button, .. } if *button == BTN_RIGHT => {
+                if matches!(state, WEnum::Value(ButtonState::Pressed)) {
+                    self.drop_surfaces();
+                    ReturnData::RequestExit
+                } else {
+                    ReturnData::None
+                }
+            }
+            DispatchMessage::Axis {
+                horizontal,
+                vertical,
+                ..
+            } => {
+                if axis_stopped(*horizontal, *vertical) {
+                    self.save_scroll_now(bar_id);
+                    return ReturnData::None;
+                }
+                if !axis_has_delta(*horizontal, *vertical) {
+                    return ReturnData::None;
+                }
+                if !self.sync_auto_x(ev, shell_id, bar_id) {
+                    return ReturnData::None;
+                }
+                if let Some(win) = self.wins.get(&bar_id) {
+                    let (dx, dy) = axis_drag_delta(*horizontal, *vertical, win.scale_factor);
+                    if dx != 0.0 || dy != 0.0 {
+                        let pos = Pos::new(
+                            (win.self_set.x + dx).max(0.0),
+                            (win.self_set.y + dy).max(0.0),
+                        );
+                        let persist = axis_is_discrete(*horizontal, *vertical);
+                        self.move_bar(ev, bar_id, pos, persist);
+                        if !persist {
+                            self.mark_scroll_dirty(ev, bar_id);
+                        }
+                    }
+                }
+                ReturnData::None
+            }
+            DispatchMessage::Closed => {
+                if self
+                    .wins
+                    .get(&bar_id)
+                    .is_some_and(|win| win.shell_id == shell_id)
+                {
+                    self.wins.remove(&bar_id);
+                }
+                ReturnData::None
+            }
+            _ => ReturnData::None,
+        }
+    }
+
+    fn handle_event(
+        &mut self,
+        event: LayerShellEvent<i64, Vec<BossBar>>,
+        ev: &mut WindowState<i64>,
+        shell_id: Option<ShellId>,
+    ) -> ReturnData<i64> {
+        match event {
+            LayerShellEvent::InitRequest => {
+                let bars = db::read_once(&self.db).unwrap_or_default();
+                self.reconcile(ev, bars);
+                ReturnData::None
+            }
+            LayerShellEvent::UserEvent(bars) => {
+                self.reconcile(ev, bars);
+                ReturnData::None
+            }
+            LayerShellEvent::RequestMessages(msg) => match shell_id {
+                Some(shell_id) => self.handle_dispatch(msg, ev, shell_id),
+                None => ReturnData::None,
+            },
+            _ => ReturnData::None,
+        }
+    }
+}
+
+pub fn run(db: PathBuf, base_scale: u32) -> Result<(), Box<dyn std::error::Error>> {
+    let ev = WindowState::<i64>::new("bossbar-overlay")
+        .with_background()
+        .with_use_display_handle(true)
+        .build()?;
+
+    let _ = db::read_once(&db);
+
+    // layershellev::WindowState::running_with_proxy consumes calloop's channel.
+    let (sender, receiver): (
+        channel::Sender<Vec<BossBar>>,
+        channel::Channel<Vec<BossBar>>,
+    ) = channel::channel();
+    let watcher_sender = sender.clone();
+    db::spawn_watcher(db.clone(), move |bars| watcher_sender.send(bars).is_ok());
+
+    let mut app = App::new(db, base_scale);
+    ev.running_with_proxy(receiver, move |event, ev, shell_id| {
+        app.handle_event(event, ev, shell_id)
+    })?;
+    Ok(())
+}

--- a/packages/bossbar-overlay/app/crates/bossbar/src/main.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/main.rs
@@ -13,6 +13,8 @@
 mod assets;
 mod bars;
 mod db;
+#[cfg(target_os = "linux")]
+mod layer_shell;
 mod overlay;
 mod scene;
 mod snapshot;

--- a/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
@@ -668,6 +668,18 @@ impl ApplicationHandler<Vec<BossBar>> for App {
 
 /// Run the overlay event loop. Blocks until the last window closes.
 pub fn run(db: PathBuf, base_scale: u32) -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("WAYLAND_DISPLAY").is_some()
+        && std::env::var_os("BOSSBAR_WINIT").is_none()
+    {
+        match crate::layer_shell::run(db.clone(), base_scale) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                eprintln!("bossbar-overlay: layer-shell unavailable, falling back to winit: {e}");
+            }
+        }
+    }
+
     let event_loop: EventLoop<Vec<BossBar>> = ocwin::build_event_loop()?;
     let proxy = event_loop.create_proxy();
     let mut app = App {

--- a/packages/bossbar-overlay/app/default.nix
+++ b/packages/bossbar-overlay/app/default.nix
@@ -3,11 +3,13 @@
   stdenv,
   rustPlatform,
   makeWrapper,
+  pkg-config,
   # The Minecraft art (boss bar sprites, book texture, bitmap font) extracted from
   # Mojang's official client jar by a reproducible Nix derivation.
   minecraft-assets,
-  # Linux runtime libraries. winit dlopens X11/Wayland/xkbcommon and wgpu dlopens
-  # the Vulkan loader, so they must be on the runtime library path.
+  # Linux runtime libraries. winit/layer-shell dlopen or link
+  # X11/Wayland/xkbcommon and wgpu dlopens the Vulkan loader, so they must be on
+  # the runtime library path.
   wayland,
   libxkbcommon,
   vulkan-loader,
@@ -65,7 +67,7 @@ rustPlatform.buildRustPackage {
 
   strictDeps = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optional stdenv.hostPlatform.isLinux pkg-config;
   buildInputs = runtimeLibs;
 
   preBuild = ''

--- a/packages/bossbar-overlay/ci-bars-home-module.nix
+++ b/packages/bossbar-overlay/ci-bars-home-module.nix
@@ -31,8 +31,10 @@
 let
   inherit (lib)
     mkOption
+    mkOptionDefault
     mkEnableOption
     mkIf
+    mkMerge
     types
     ;
 
@@ -140,33 +142,36 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    # Seed the platform-conditional log directory at option-default precedence,
-    # so a downstream override still wins and the option declaration stays a
-    # self-contained literal.
-    services.ciBars.logDir = lib.mkOptionDefault (
-      if pkgs.stdenv.hostPlatform.isDarwin then
-        "${config.home.homeDirectory}/Library/Logs"
-      else
-        "${config.home.homeDirectory}/.local/state"
-    );
-
-    services.portable.ci-bars = {
-      description = "GitHub Actions CI progress boss bars";
-      command = [ (lib.getExe' ciBars "ci-bars") ];
-      inherit (cfg) interval;
-      # All tunables flow in as environment so the script stays a plain file and
-      # the options are the single source of truth.
-      environment = {
-        CI_BARS_REPOS = lib.concatStringsSep " " cfg.repos;
-        CI_BARS_AVG_TTL = toString cfg.avgTtl;
-        CI_BARS_DEFAULT_AVG = toString cfg.defaultAvg;
-        CI_BARS_MAX = toString cfg.maxBars;
+  config = mkMerge [
+    {
+      # Seed the platform-conditional log directory at option-default precedence,
+      # so a downstream override still wins and the option declaration stays a
+      # self-contained literal.
+      services.ciBars.logDir = mkOptionDefault (
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "${config.home.homeDirectory}/Library/Logs"
+        else
+          "${config.home.homeDirectory}/.local/state"
+      );
+    }
+    (mkIf cfg.enable {
+      services.portable.ci-bars = {
+        description = "GitHub Actions CI progress boss bars";
+        command = [ (lib.getExe' ciBars "ci-bars") ];
+        inherit (cfg) interval;
+        # All tunables flow in as environment so the script stays a plain file and
+        # the options are the single source of truth.
+        environment = {
+          CI_BARS_REPOS = lib.concatStringsSep " " cfg.repos;
+          CI_BARS_AVG_TTL = toString cfg.avgTtl;
+          CI_BARS_DEFAULT_AVG = toString cfg.defaultAvg;
+          CI_BARS_MAX = toString cfg.maxBars;
+        };
+        standardOutPath = "${cfg.logDir}/ci-bars.log";
+        standardErrorPath = "${cfg.logDir}/ci-bars.log";
+        # runAtLoad (default true) draws the bars on load; the script's own flock
+        # guard prevents overlap; the Label defaults to the space-free convention.
       };
-      standardOutPath = "${cfg.logDir}/ci-bars.log";
-      standardErrorPath = "${cfg.logDir}/ci-bars.log";
-      # runAtLoad (default true) draws the bars on load; the script's own flock
-      # guard prevents overlap; the Label defaults to the space-free convention.
-    };
-  };
+    })
+  ];
 }

--- a/packages/mcp/src/main.rs
+++ b/packages/mcp/src/main.rs
@@ -326,7 +326,12 @@ fn scope_kwargs(
     if let Some(repo) = repo.filter(|repo| !repo.is_empty()) {
         parts.push(format!("repo={}", json!(repo)));
     }
-    parts.iter().map(|part| format!(", {part}")).collect()
+    let mut suffix = String::new();
+    if !parts.is_empty() {
+        suffix.push_str(", ");
+        suffix.push_str(&parts.join(", "));
+    }
+    suffix
 }
 
 impl McpServer {
@@ -462,8 +467,8 @@ struct SemanticSearchRequest {
     query: String,
     /// Maximum number of results to return (default 10).
     top_k: Option<usize>,
-    /// Restrict to these sources: code, claude_history, codex, shell, slack,
-    /// linear, web. Omit to search every source.
+    /// Restrict to these sources: `code`, `claude_history`, `codex`, `shell`,
+    /// `slack`, `linear`, `web`. Omit to search every source.
     source: Option<Vec<String>>,
     /// Restrict to records authored by these users. Omit for every user.
     user: Option<Vec<String>>,
@@ -490,8 +495,8 @@ struct GrepSearchRequest {
     top_k: Option<usize>,
     /// Match the pattern case-sensitively (default false).
     case_sensitive: Option<bool>,
-    /// Restrict to these sources: code, claude_history, codex, shell, slack,
-    /// linear, web. Omit to search every source.
+    /// Restrict to these sources: `code`, `claude_history`, `codex`, `shell`,
+    /// `slack`, `linear`, `web`. Omit to search every source.
     source: Option<Vec<String>>,
     /// Restrict to records authored by these users. Omit for every user.
     user: Option<Vec<String>>,

--- a/packages/search-core/src/config.rs
+++ b/packages/search-core/src/config.rs
@@ -1,8 +1,9 @@
 //! Runtime configuration with conservative, production-shaped defaults. The
 //! API base URL is owned by the [`mixedbread`] crate, not duplicated here.
 
-/// Default store name: the shared corpus the `indexer` populates (code plus
-/// agent/shell history across the fleet). One store holds everything; queries
+/// Default store name: the shared corpus the `indexer` populates.
+///
+/// One store holds code plus agent/shell history across the fleet. Queries
 /// scope it server-side with a metadata filter rather than using separate stores.
 pub const DEFAULT_STORE: &str = "index";
 


### PR DESCRIPTION
## Summary
- Add a Linux layer-shell backend for `bossbar-overlay` so Hyprland/wlroots compositors own overlay placement instead of treating bars as normal centered toplevel windows.
- Keep the existing winit backend as the non-Wayland path and as an escape hatch with `BOSSBAR_WINIT=1`.
- Add the Nix build input needed by the new Wayland dependency chain.

## Verification
- `nix build .#bossbar-overlay --print-build-logs`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use layer-shell for bossbar overlay on Wayland
> - Adds a new [`layer_shell`](https://github.com/indexable-inc/index/pull/536/files#diff-bee6ec89f3761680cf80a3e80f957daeed7fb98956a2badab31c139d32b05a08) backend for the bossbar overlay on Linux Wayland, using `layershellev` to create compositor-managed layer-shell surfaces anchored to the top edge.
> - Supports drag-to-pin, scroll nudge with debounced save, hover expansion/animation, URL click handling, and per-bar wgpu rendering on layer-shell surfaces.
> - In [`overlay.rs`](https://github.com/indexable-inc/index/pull/536/files#diff-be0c00f68d255b3fe86ea924fe83d030d2a948a7e2d919b45eb19a51fa82ae26), prefers the layer-shell backend when `WAYLAND_DISPLAY` is set and `BOSSBAR_WINIT` is unset, falling back to the existing winit path on error.
> - Adds `layershellev` as a Linux-only workspace dependency and `pkg-config` to the Nix build inputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33fa157.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->