### PR TITLE
users/andrewgazelka: own pr-watch + ci-triage as a portable service

### DIFF
--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -7,19 +7,25 @@
 #     the public Better Stack status page onto a per-service Minecraft boss bar
 #     plus an Ender Dragon growl + spoken root cause;
 #   * the boss bar overlay GUI it drives (`bossbar-overlay`);
+#   * the merged-PR + CI-failure watcher (`pr-watch`), which plays a Minecraft
+#     sound on each PR newly merged to main and, on a newly failed main Actions
+#     run, speaks a one-line alert and launches a detached Opus deep dive
+#     (`ci-triage`) that files a deduped Linear ticket;
+#   * the token-free `/optimize` history scan (`optimize-scan`);
 #   * the shared "play a gentle sound, then speak it detached" helper
-#     (`say-detached`) the watcher announces through.
+#     (`say-detached`) the watchers announce through.
 #
-# All three are declared as `services.portable.<name>` so they render to a
-# native launchd agent on macOS and a native systemd user unit on Linux from one
-# spec (index lib/portable-services.nix, imported below). The module is a
-# function over the index flake's per-system package set so it can resolve the
-# `bossbar` / `bossbar-overlay` / `minecraft-sound` derivations (flake outputs,
-# not all in the nixpkgs overlay) for the host it is evaluated on.
+# Each is declared as `services.portable.<name>` so they render to a native
+# launchd agent on macOS and a native systemd user unit on Linux from one spec
+# (index lib/portable-services.nix, imported below). The module is a function
+# over the index flake's per-system package set so it can resolve the `bossbar` /
+# `bossbar-overlay` / `minecraft-sound` derivations (flake outputs, not all in
+# the nixpkgs overlay) for the host it is evaluated on.
 #
 # Host-specific glue stays in the consuming config: the Better Stack API token
-# (seeded into the macOS Keychain, or exported as IX_BETTERSTACK_TOKEN) and any
-# absolute log paths beyond the defaults here.
+# and the pr-watch Linear key (both seeded into the macOS Keychain, or exported
+# as env), `gh` auth for pr-watch, and any absolute log paths beyond the defaults
+# here.
 #
 # Closed over the index flake's per-system package set (`indexPackages system`)
 # and the portable-services home-manager module, so the consumer imports just
@@ -139,6 +145,60 @@ let
         | while read -r f; do rm -f "$f"; done
     '';
   };
+
+  # Shared "summarize -> speak with sound" helper sourced by pr-watch's stage-1
+  # CI-failure alert. Kept as a standalone store file so its absolute path can be
+  # baked into the pr-watch body via @ANNOUNCE_LIB@ (sourcing a sibling script by
+  # relative path is not safe under launchd's minimal environment).
+  announceLib = pkgs.writeText "announce-lib.sh" (builtins.readFile ./scripts/announce-lib.sh);
+
+  # Stage-2 of the pr-watch CI response: a per-run DEEP DIVE into a main-branch
+  # Actions failure. Launched DETACHED by pr-watch (own session + `timeout`), it
+  # uses `claude -p` with Opus 4.8 + the Bash tool to fetch the failed logs,
+  # diagnose the root cause, speak it, and file (or dedupe) a Linear ENG ticket
+  # when the failure is a genuine code break. The Linear API key is read at
+  # runtime from the login Keychain (service `pr-watch-linear`); see the script
+  # header. CI_TRIAGE_DRY_RUN makes it non-destructive for testing.
+  ciTriage = mkBashApp {
+    name = "ci-triage";
+    runtimeInputs = [
+      pkgs.gh
+      pkgs.jq
+      sayDetached
+      pkgs.claude-code
+      pkgs.coreutils
+    ];
+    text = builtins.readFile ./scripts/ci-triage.sh;
+  };
+
+  # The merged-PR + CI-failure watcher itself. say-detached plays the merge
+  # sound / failure cue + carries stage-1 speech; ci-triage is the detached
+  # stage-2 deep dive; claude-code summarizes a failure into one spoken line;
+  # coreutils provides `timeout`/`date`; perl supplies the intrinsic flock guard
+  # and the setsid detach. The @PLACEHOLDERS@ are baked from the options.
+  prWatch = mkBashApp {
+    name = "pr-watch";
+    runtimeInputs = [
+      pkgs.gh
+      pkgs.jq
+      sayDetached
+      ciTriage
+      pkgs.claude-code
+      pkgs.coreutils
+      pkgs.perl
+    ];
+    text =
+      builtins.replaceStrings
+        [ "@ANNOUNCE_LIB@" "@REPOS@" "@MERGE_SOUND@" "@LOG_DIR@" "@TRIAGE_COOLDOWN@" ]
+        [
+          "${announceLib}"
+          (lib.concatMapStringsSep " " (r: ''"${r}"'') cfg.prWatch.repos)
+          cfg.prWatch.mergeSound
+          cfg.logDir
+          (toString cfg.prWatch.triageCooldown)
+        ]
+        (builtins.readFile ./scripts/pr-watch.sh);
+  };
 in
 {
   imports = [ portableServicesModule ];
@@ -192,6 +252,53 @@ in
       };
     };
 
+    prWatch = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Run the merged-PR + CI-failure watcher (polls each repo's main for
+          newly merged PRs and newly failed Actions runs). Needs `gh` to be
+          authenticated for the host user; the stage-2 deep dive additionally
+          needs the `pr-watch-linear` Keychain entry to file tickets (optional).
+        '';
+      };
+
+      interval = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 30;
+        description = "Poll each watched repo every N seconds.";
+      };
+
+      repos = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [
+          "indexable-inc/ix"
+          "indexable-inc/index"
+        ];
+        description = "GitHub `owner/name` repos to watch for merges and main CI failures.";
+      };
+
+      mergeSound = lib.mkOption {
+        type = lib.types.str;
+        default = "block/bell/bell_use01";
+        description = ''
+          minecraft-sound id played (sound only, no speech) when a PR is newly
+          merged into main. See `minecraft-sound list` for the catalog.
+        '';
+      };
+
+      triageCooldown = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 1800;
+        description = ''
+          Minimum seconds between stage-2 Opus deep dives per repo+workflow, so a
+          sustained red main can't spawn a storm of Opus runs or near-duplicate
+          tickets. Overridable at runtime via CI_TRIAGE_COOLDOWN.
+        '';
+      };
+    };
+
     sound.linuxSayCommand = lib.mkOption {
       type = lib.types.str;
       default = "spd-say";
@@ -242,6 +349,18 @@ in
           standardErrorPath = "${cfg.logDir}/optimize-scan.log";
           # runAtLoad (default true) gives an immediate first scan on load;
           # Label defaults to the space-free home convention. No escape hatch.
+        };
+      })
+      (lib.mkIf cfg.prWatch.enable {
+        pr-watch = {
+          description = "merged-PR + CI-failure watcher";
+          command = [ (lib.getExe' prWatch "pr-watch") ];
+          interval = cfg.prWatch.interval;
+          standardOutPath = "${cfg.logDir}/pr-watch.log";
+          standardErrorPath = "${cfg.logDir}/pr-watch.log";
+          # runAtLoad (default true) fires the first poll immediately; the
+          # Label defaults to the space-free home convention. Overlap is handled
+          # intrinsically by the script's own flock guard, so no escape hatch.
         };
       })
       (lib.mkIf cfg.bossbarOverlay.enable {

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -192,8 +192,12 @@ let
         [ "@ANNOUNCE_LIB@" "@REPOS@" "@MERGE_SOUND@" "@LOG_DIR@" "@TRIAGE_COOLDOWN@" ]
         [
           "${announceLib}"
-          (lib.concatMapStringsSep " " (r: ''"${r}"'') cfg.prWatch.repos)
-          cfg.prWatch.mergeSound
+          # escapeShellArg per value: these land unquoted in `repos=(@REPOS@)` and
+          # `say-detached @MERGE_SOUND@`, so a value with a space or shell
+          # metacharacter must carry its own quoting (the options are author-set,
+          # but bake safely rather than rely on that).
+          (lib.concatMapStringsSep " " lib.escapeShellArg cfg.prWatch.repos)
+          (lib.escapeShellArg cfg.prWatch.mergeSound)
           cfg.logDir
           (toString cfg.prWatch.triageCooldown)
         ]

--- a/users/andrewgazelka/scripts/announce-lib.sh
+++ b/users/andrewgazelka/scripts/announce-lib.sh
@@ -1,0 +1,36 @@
+# Sourced library for pr-watch (see users/andrewgazelka/home.nix). Not a
+# standalone program: no shebang / `set` line; it is `source`d into a mkBashApp
+# that already supplies bash + `set -euo pipefail` and bakes claude/coreutils/
+# say-detached onto PATH.
+#
+# Factors out the "isolated headless `claude -p` summarize -> speak it with a
+# Minecraft sound" block the stage-1 CI-failure announcement uses. Call
+# announce() with a system prompt, context, sound, and fallback.
+
+# announce <sound> <system_prompt> <user_prompt> <context> <fallback> [model]
+#
+# Runs an isolated, headless claude (no settings/memory/hooks, no tools) over
+# <context> with <system_prompt>/<user_prompt>, then speaks the result with
+# say-detached and <sound>. Falls back to <fallback> if claude returns nothing.
+# <model> defaults to the fast haiku model used elsewhere. Echoes "SAY: ..." for
+# the agent log. Detaches via say-detached so a launchd/systemd reload can't clip
+# the speech.
+announce() {
+  local sound="$1" sys="$2" user="$3" ctx="$4" fallback="$5"
+  local model="${6:-claude-haiku-4-5-20251001}"
+  local summary
+
+  # Isolated, headless summarizer: no settings/memory/hooks, no tools.
+  summary="$(cd "$HOME" && printf '%s' "$ctx" \
+    | timeout 90 claude -p \
+        --model "$model" \
+        --allowedTools "" \
+        --setting-sources "" \
+        --system-prompt "$sys" \
+        "$user" 2>/dev/null)" || summary=""
+
+  [ -n "$summary" ] || summary="$fallback"
+
+  echo "SAY: $summary"
+  say-detached "$sound" "$summary"
+}

--- a/users/andrewgazelka/scripts/ci-triage.sh
+++ b/users/andrewgazelka/scripts/ci-triage.sh
@@ -1,0 +1,111 @@
+# Body of the `ci-triage` bash app (see users/andrewgazelka/home.nix).
+# No shebang / `set` line: the mkBashApp wrapper supplies bash + `set -euo
+# pipefail` and bakes gh/jq/claude/coreutils + say-detached onto PATH.
+#
+# Stage-2 of the pr-watch CI response: a per-run DEEP DIVE into one GitHub
+# Actions run that just FAILED on main. pr-watch (stage 1) already played the
+# failure sound and spoke a fast haiku of the failure; this script is launched
+# DETACHED (own session, see the ci-triage invocation in pr-watch) so it never
+# blocks stage 1 for the next failure and survives a launchd/systemd reload, and
+# it is wrapped in `timeout` so a stuck Opus run can't pile up.
+#
+# It uses `claude -p` with Opus 4.8 and the Bash tool (it needs tools to read
+# the failed logs and file a ticket). The agent:
+#   1. Fetches failed logs itself (gh run view --log-failed, capped).
+#   2. Diagnoses the ROOT CAUSE.
+#   3. SPEAKS a concise 2-3 sentence root cause via say-detached (sound + voice).
+#   4. Decides if it's a genuine, actionable code failure vs transient/infra/flaky.
+#   5. If actionable: searches Linear for an existing matching open issue first
+#      (dedupe), and only creates a new ENG ticket via issueCreate if none.
+#
+# Linear auth: LINEAR_API_KEY is read at runtime from the login Keychain
+# (service `pr-watch-linear`) — no secret in the Nix store, the plist, or git.
+# Seed it (idempotent, from 1Password) with the host's `seed-launchd-secrets`.
+# If the entry is missing the deep dive still speaks the root cause; it just
+# tells the agent it cannot file a ticket.
+#
+# CI_TRIAGE_DRY_RUN=1 makes this NON-DESTRUCTIVE for testing: no sound, no
+# speech, and NO real Linear ticket — the agent prints the GraphQL mutation it
+# WOULD send instead. Logs are still fetched and Opus still analyses.
+#
+# Usage: ci-triage <repo> <runId> <url> <workflow> <jobs>
+#   e.g. ci-triage indexable-inc/ix 123 https://... ci "build (step: clippy)"
+
+repo="${1:?ci-triage: missing <repo>}"
+run_id="${2:?ci-triage: missing <runId>}"
+run_url="${3:?ci-triage: missing <url>}"
+workflow="${4:?ci-triage: missing <workflow>}"
+jobs="${5:-(unknown jobs)}"
+short="${repo##*/}"
+
+dry="${CI_TRIAGE_DRY_RUN:-}"
+
+# Linear API key from the login Keychain (best-effort: tickets are optional).
+linear_key="$(security find-generic-password -s pr-watch-linear -w 2>/dev/null)" || linear_key=""
+
+# Sound id used by stage 1 too; the deep dive reuses it before the spoken cause.
+# Low note-block bass: a gentle "down" cue, not a harsh alarm.
+sound="note/bass"
+
+# ENG team id (from the repo's linear skill). Linear auth header is the raw key
+# (NOT "Bearer ...").
+eng_team_id="a8845362-21c7-4283-ba80-cea987a3ee74"
+
+# Compose the agent's task. Everything the agent needs is inlined; it fetches
+# logs and (maybe) files the ticket via its Bash tool.
+ticket_clause=""
+if [ -n "$dry" ]; then
+  ticket_clause="DRY RUN MODE: Do NOT play any sound. Do NOT speak (do NOT call say-detached). Do NOT create a real Linear ticket. Instead, after your analysis, PRINT to stdout: the spoken root-cause text you WOULD have said (prefixed \"WOULD SAY: \"), your applicable/not-applicable decision with one-line reason (prefixed \"DECISION: \"), and if applicable the exact Linear GraphQL issueCreate mutation JSON you WOULD POST (prefixed \"WOULD POST: \"). Do not run any curl/POST to Linear."
+elif [ -n "$linear_key" ]; then
+  ticket_clause="You CAN file a Linear ticket. The Linear API key is in the login Keychain; read it in Bash with: LINEAR_API_KEY=\$(security find-generic-password -s pr-watch-linear -w). The Linear GraphQL endpoint is https://api.linear.app/graphql (POST, Content-Type: application/json, Authorization header is the RAW key, NOT Bearer)."
+else
+  ticket_clause="You CANNOT file a Linear ticket right now (no key in the Keychain). Do your analysis and speak the root cause as usual, but instead of filing, briefly add to the spoken sentence that you could not open a ticket because the Linear key is missing."
+fi
+
+read -r -d '' task <<EOF || true
+A GitHub Actions run just FAILED on the main branch of $repo. Triage it end to end.
+
+Facts:
+- Repo: $repo (say this short name: $short)
+- Run id: $run_id
+- Run URL: $run_url
+- Workflow: $workflow
+- Failed job(s)/step(s): $jobs
+
+Do the following, in order, using your Bash tool:
+
+1. Fetch the failed logs yourself:
+     gh run view $run_id --repo $repo --log-failed 2>/dev/null | tail -n 400 | head -c 16000
+   (Cap the output as shown so it stays bounded. If empty, note that and rely on the job/step names.)
+
+2. Diagnose the ROOT CAUSE in detail from the logs.
+
+3. SPEAK a concise root cause (2-3 sentences, plain spoken English, no markdown) by running:
+     say-detached $sound "<your 2-3 sentence root cause>"
+   Begin like: The main build broke in $short because ... . Keep the full detail for the ticket; the voice is just the gist.
+
+4. Decide if this is a GENUINE, ACTIONABLE code failure: a real test, build, or lint break caused by a change. If it is clearly transient/infra/flaky (runner lost, network error, cache miss, timeout with no code signal, cancelled), it is NOT actionable: do not file a ticket, and say so briefly (you may include that in your spoken sentence).
+
+5. If ACTIONABLE: FIRST search Linear for an existing OPEN issue matching this failure (same workflow+job signature, or the same run url in the description) to avoid duplicates. Use the searchIssues query with the "term" argument (NOT "query"): searchIssues(term: "main CI failed: $workflow", first: 10) { nodes { identifier title url } } and inspect titles/descriptions. Only if NONE matches, create one with issueCreate:
+     - teamId: "$eng_team_id" (the ENG / Engineering team)
+     - title: "main CI failed: $workflow/<failing job> ($repo)"
+     - description (markdown): the run URL ($run_url), the failing job/step ($jobs), and your full root-cause analysis. End the description with this exact footer on its own line:
+         _Filed automatically by pr-watch via Claude Opus 4.8._
+   After creating (or matching), SPEAK one short follow-up with the ticket identifier, e.g.:
+     say-detached "" "Filed ticket ENG-1234." (or "Matched existing ticket ENG-1234.")
+
+$ticket_clause
+
+Output a short plain-text summary of what you did (root cause, decision, ticket id or none). No preamble.
+EOF
+
+echo "CI-TRIAGE: [$short run $run_id] workflow=$workflow dry=${dry:-0}"
+
+# Isolated, headless deep dive: Opus 4.8 with the Bash tool. Bounded by timeout
+# in the caller too, but cap here as well so a direct invocation is also safe.
+cd "$HOME" || exit 1
+timeout 280 claude -p \
+  --model claude-opus-4-8 \
+  --allowedTools "Bash" \
+  --setting-sources "" \
+  "$task" </dev/null 2>&1 || echo "CI-TRIAGE: claude exited non-zero (timeout or error) for run $run_id"

--- a/users/andrewgazelka/scripts/ci-triage.sh
+++ b/users/andrewgazelka/scripts/ci-triage.sh
@@ -18,11 +18,11 @@
 #   5. If actionable: searches Linear for an existing matching open issue first
 #      (dedupe), and only creates a new ENG ticket via issueCreate if none.
 #
-# Linear auth: LINEAR_API_KEY is read at runtime from the login Keychain
-# (service `pr-watch-linear`) — no secret in the Nix store, the plist, or git.
-# Seed it (idempotent, from 1Password) with the host's `seed-launchd-secrets`.
-# If the entry is missing the deep dive still speaks the root cause; it just
-# tells the agent it cannot file a ticket.
+# Linear auth: the key is read at runtime from $PR_WATCH_LINEAR_KEY, else the
+# macOS login Keychain (service `pr-watch-linear`) — no secret in the Nix store,
+# the plist, or git. Seed the Keychain (idempotent, from 1Password) with the
+# host's `seed-launchd-secrets`. If neither is present the deep dive still speaks
+# the root cause; it just tells the agent it cannot file a ticket.
 #
 # CI_TRIAGE_DRY_RUN=1 makes this NON-DESTRUCTIVE for testing: no sound, no
 # speech, and NO real Linear ticket — the agent prints the GraphQL mutation it
@@ -40,8 +40,16 @@ short="${repo##*/}"
 
 dry="${CI_TRIAGE_DRY_RUN:-}"
 
-# Linear API key from the login Keychain (best-effort: tickets are optional).
-linear_key="$(security find-generic-password -s pr-watch-linear -w 2>/dev/null)" || linear_key=""
+# Linear API key (best-effort: tickets are optional). Resolution order, mirroring
+# ix-downtime's token lookup:
+#   1. $PR_WATCH_LINEAR_KEY, if the consuming config exports one (e.g. a Linux
+#      host that seeds it from its own secret store).
+#   2. the macOS login Keychain (service `pr-watch-linear`), seeded by the host's
+#      `seed-launchd-secrets`. `security` is macOS-only, so guard on its presence.
+linear_key="${PR_WATCH_LINEAR_KEY:-}"
+if [ -z "$linear_key" ] && command -v security >/dev/null 2>&1; then
+  linear_key="$(security find-generic-password -s pr-watch-linear -w 2>/dev/null)" || linear_key=""
+fi
 
 # Sound id used by stage 1 too; the deep dive reuses it before the spoken cause.
 # Low note-block bass: a gentle "down" cue, not a harsh alarm.

--- a/users/andrewgazelka/scripts/pr-watch.sh
+++ b/users/andrewgazelka/scripts/pr-watch.sh
@@ -29,6 +29,10 @@
 
 state_dir="${PR_WATCH_STATE:-$HOME/.cache/pr-watch}"
 mkdir -p "$state_dir"
+# The detached stage-2 appends to @LOG_DIR@/ci-triage.log; ensure the dir exists
+# (launchd pre-creates it for the agent's own StandardOutPath on macOS, but
+# systemd does not guarantee a custom logDir parent).
+mkdir -p "@LOG_DIR@"
 
 # Non-overlap guard, intrinsic to the watcher so the portable service can fire it
 # on a fixed interval with no external lock wrapper. Take a NON-BLOCKING
@@ -156,7 +160,7 @@ Failed job(s): $failed_jobs"
     # deep dive can't hold the lock past this poll. CI_TRIAGE_DRY_RUN passes
     # through, so dry-run testing skips sound/voice/ticket here too.
     [ -n "$run_url" ] || run_url="https://github.com/$repo/actions/runs/$run_id"
-    /usr/bin/perl -e 'use POSIX qw(setsid); setsid() or exit 1; exec @ARGV or exit 1' \
+    perl -e 'use POSIX qw(setsid); setsid() or exit 1; exec @ARGV or exit 1' \
       -- timeout 300 ci-triage "$repo" "$run_id" "$run_url" "$run_wf" "$failed_jobs" \
       >>"@LOG_DIR@/ci-triage.log" 2>&1 9>&- &
     # Don't wait on the backgrounded detached job; let stage 1 proceed.

--- a/users/andrewgazelka/scripts/pr-watch.sh
+++ b/users/andrewgazelka/scripts/pr-watch.sh
@@ -1,0 +1,170 @@
+# Body of the `pr-watch` bash app (see users/andrewgazelka/home.nix).
+# No shebang / `set` line: the mkBashApp wrapper supplies bash + `set -euo
+# pipefail` and bakes gh/jq/say-detached/ci-triage/claude/coreutils onto PATH via
+# runtimeInputs. The module bakes these placeholders at build time:
+#   @ANNOUNCE_LIB@     store path of announce-lib.sh (source'd below)
+#   @REPOS@            the watched repos as a quoted bash-array body
+#   @MERGE_SOUND@      the Minecraft sound id played on a newly merged PR
+#   @LOG_DIR@          directory the detached ci-triage stage-2 log is appended to
+#   @TRIAGE_COOLDOWN@  default seconds between stage-2 deep dives per repo+workflow
+#
+# Polls each watched repo for PRs newly merged into `main`. For each newly merged
+# PR it plays a single Minecraft sound (the @MERGE_SOUND@ id, by default a bell
+# toll) and nothing else: no spoken summary, no `claude -p`, no `say`. It
+# deliberately does NOT report the still-open / pending PR queue. The first run
+# per repo only seeds the state file, so existing PRs stay quiet.
+#
+# It ALSO polls each repo for Actions runs that newly FAILED on `main` and
+# responds in TWO stages per newly-failed run:
+#   Stage 1 (immediate): play the failure sound + speak a SHORT haiku of the
+#     failure right away, via an isolated `claude -p` summarizer (announce()).
+#   Stage 2 (deep dive): launch `ci-triage` DETACHED (own session, like
+#     say-detached, wrapped in `timeout`) so it never blocks stage 1 for the
+#     next failure and survives a reload. ci-triage fetches the failed logs, has
+#     Opus 4.8 diagnose the root cause, speaks it, and files (or dedupes) a
+#     Linear ENG ticket when the failure is a genuine code break.
+# A separate per-repo state file dedupes on the run's databaseId, and the first
+# run per repo seeds it quietly so the existing backlog of past failures stays
+# silent (no stage 1 and no stage 2 for already-seen runs).
+
+state_dir="${PR_WATCH_STATE:-$HOME/.cache/pr-watch}"
+mkdir -p "$state_dir"
+
+# Non-overlap guard, intrinsic to the watcher so the portable service can fire it
+# on a fixed interval with no external lock wrapper. Take a NON-BLOCKING
+# exclusive flock on fd 9; if a previous fire still holds it, skip this one
+# silently. bash keeps fd 9 open for the whole run, so the lock is held until
+# exit/crash (the kernel drops it the instant the holder dies). The detached
+# stage-2 ci-triage launch closes fd 9 (`9>&-`) so a long deep dive can never
+# keep the lock and starve the next poll.
+exec 9>"$state_dir/poll.lock"
+perl -e 'use Fcntl ":flock"; flock(STDIN, LOCK_EX | LOCK_NB) or exit 1' <&9 || exit 0
+
+# Shared "summarize -> speak with sound" helper (announce()), used by the stage-1
+# CI-failure alert. @ANNOUNCE_LIB@ is the store path of announce-lib.sh.
+# shellcheck source=/dev/null
+. "@ANNOUNCE_LIB@"
+
+repos=(@REPOS@)
+
+ci_sys='You are a spoken alert for a busy engineer who cannot see the screen. You are told that a GitHub Actions run just FAILED on the main branch of one of their repos. You are given the repo name, the workflow name, the commit title that broke it, and the name(s) of the job(s) that failed (and possibly the failing step). In one casual spoken sentence, tell them that the main build broke in that repo, name the workflow, and name which job or jobs failed; if you are given a failing step, you may mention it. Begin like: Heads up, the main build just failed in I X. Use the repo name you are given. When the repo name is ix, write it as "I X" (two separate letters), never "ix", so it is not read aloud as the Roman numeral nine. Never mention a PR number. Plain English, spoken aloud, no preamble, no questions, no markdown, no code.'
+
+for repo in "${repos[@]}"; do
+  slug="${repo//\//_}"
+  seen="$state_dir/$slug.seen"
+  first_run=0
+  if [ ! -f "$seen" ]; then
+    first_run=1
+    : >"$seen"
+  fi
+
+  json="$(gh pr list --repo "$repo" --state merged --base main \
+            --json number,title,author --limit 50 2>/dev/null)" || continue
+
+  while IFS=$'\t' read -r num title who; do
+    [ -n "${num:-}" ] || continue
+    grep -qxF "$num" "$seen" && continue
+    echo "$num" >>"$seen"
+
+    [ "$first_run" -eq 1 ] && continue
+
+    short="${repo##*/}"
+    echo "MERGED: [$short #$num] $title  (by $who)"
+
+    # Sound only: a single Minecraft sound (the @MERGE_SOUND@ id), detached so a
+    # reload can't clip it. No spoken summary, no `claude -p`, no `say`. Empty
+    # text => say-detached just plays the sound.
+    say-detached @MERGE_SOUND@ ""
+  done < <(printf '%s' "$json" | jq -r '
+    .[] | [ (.number|tostring),
+            .title,
+            (if (.author.name // "") != "" then .author.name else .author.login end)
+          ] | @tsv')
+
+  # --- Newly FAILED Actions runs on main -----------------------------------
+  # Same pattern as merges: a separate per-repo state file keyed on the run's
+  # databaseId, seeded quietly on first run so old failures stay silent.
+  runs_seen="$state_dir/$slug.runs.seen"
+  runs_first_run=0
+  if [ ! -f "$runs_seen" ]; then
+    runs_first_run=1
+    : >"$runs_seen"
+  fi
+
+  # --status failure means completed AND failed, so nothing in-progress here.
+  runs_json="$(gh run list --repo "$repo" --branch main --status failure \
+                 --json databaseId,displayTitle,workflowName,headSha,createdAt,url \
+                 --limit 30 2>/dev/null)" || runs_json=""
+  [ -n "$runs_json" ] || runs_json="[]"
+
+  while IFS=$'\t' read -r run_id run_title run_wf run_url; do
+    [ -n "${run_id:-}" ] || continue
+    grep -qxF "$run_id" "$runs_seen" && continue
+    echo "$run_id" >>"$runs_seen"
+
+    [ "$runs_first_run" -eq 1 ] && continue
+
+    short="${repo##*/}"
+    echo "CI FAILED: [$short run $run_id] $run_wf  -  $run_title"
+
+    # Names of jobs that failed (and any failed step), robust to empty jobs.
+    failed_jobs="$(gh run view "$run_id" --repo "$repo" --json jobs 2>/dev/null \
+                   | jq -r '
+        [ (.jobs // [])[]
+          | select((.conclusion // "" | ascii_downcase) == "failure")
+          | (.name) as $job
+          | ([ (.steps // [])[]
+               | select((.conclusion // "" | ascii_downcase) == "failure")
+               | .name ] | join(", ")) as $steps
+          | if $steps == "" then $job else "\($job) (step: \($steps))" end ]
+        | join("; ")')" || failed_jobs=""
+    [ -n "$failed_jobs" ] || failed_jobs="(unknown jobs)"
+
+    # --- Stage 1: immediate, fast spoken haiku of the failure --------------
+    ctx="A GitHub Actions run just failed on main.
+Repo (say this name): $short
+Workflow: $run_wf
+Commit that broke it: $run_title
+Failed job(s): $failed_jobs"
+
+    # Shared summarize -> speak: distinct (negative) sound, detached. This must
+    # happen promptly for each failure, before the heavy stage-2 work. Low
+    # note-block bass reads as "down" without being a harsh alarm.
+    announce note/bass "$ci_sys" 'Announce this CI failure.' \
+      "$ctx" "Heads up, the main build just failed in $short. Workflow $run_wf, failed job: $failed_jobs."
+
+    # --- Stage 2: detached Opus deep dive (root cause + Linear ticket) ------
+    # Cost/noise guard: when main stays red, runs fail back-to-back. Stage 1
+    # (cheap) fires for each, but the expensive Opus deep dive + Linear ticket is
+    # rate-limited to one per repo+workflow per cooldown window, so a sustained
+    # outage can't spawn a storm of Opus runs or near-duplicate tickets.
+    cooldown="${CI_TRIAGE_COOLDOWN:-@TRIAGE_COOLDOWN@}"
+    wf_slug="$(printf '%s' "$run_wf" | tr -c '[:alnum:]' '_')"
+    triage_ts="$state_dir/$slug.$wf_slug.triage.ts"
+    now_ts="$(date +%s)"
+    last_ts="$(cat "$triage_ts" 2>/dev/null)"; [ -n "$last_ts" ] || last_ts=0
+    if [ "$((now_ts - last_ts))" -lt "$cooldown" ]; then
+      echo "STAGE2 SKIPPED (cooldown ${cooldown}s): $short $run_wf run $run_id"
+      continue
+    fi
+    printf '%s' "$now_ts" >"$triage_ts"
+
+    # Launch ci-triage in its own session (POSIX setsid via perl, same
+    # mechanism say-detached uses) so it never blocks stage 1 for the next
+    # failure and survives a `bootout`/reload; `timeout` caps a stuck Opus run.
+    # `9>&-` closes the inherited overlap-lock fd in the detached child so a long
+    # deep dive can't hold the lock past this poll. CI_TRIAGE_DRY_RUN passes
+    # through, so dry-run testing skips sound/voice/ticket here too.
+    [ -n "$run_url" ] || run_url="https://github.com/$repo/actions/runs/$run_id"
+    /usr/bin/perl -e 'use POSIX qw(setsid); setsid() or exit 1; exec @ARGV or exit 1' \
+      -- timeout 300 ci-triage "$repo" "$run_id" "$run_url" "$run_wf" "$failed_jobs" \
+      >>"@LOG_DIR@/ci-triage.log" 2>&1 9>&- &
+    # Don't wait on the backgrounded detached job; let stage 1 proceed.
+    disown 2>/dev/null || true
+  done < <(printf '%s' "$runs_json" | jq -r '
+    .[] | [ (.databaseId|tostring),
+            .displayTitle,
+            .workflowName,
+            (.url // "")
+          ] | @tsv')
+done


### PR DESCRIPTION
Moves my personal `pr-watch` agent (merged-PR + main-CI-failure watcher) plus its detached Opus stage-2 (`ci-triage`) and the `announce` helper out of my private `~/.config/nix` into this shared module, so my config becomes a thin consumer.

- New `services.portable.pr-watch` with typed options: `enable`, `interval`, `repos`, `mergeSound`, `triageCooldown`.
- Replaces the old external `with-lock` wrapper with an intrinsic fd-9 `flock` guard; the detached `ci-triage` closes the lock fd (`9>&-`) so a long deep dive can't starve the next poll.
- Merge alert is sound-only (default `block/bell/bell_use01`); no `claude`/`say` on merges.
- `mkBashApp` runs `bash -n` + shellcheck at build; consumer validated end-to-end (agent renders + reloads, binary polls clean).

Host glue stays in the consumer: `gh` auth and the `pr-watch-linear` Keychain key for ticket filing.

_Authored with Claude (Opus 4.8) via Claude Code._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pr-watch and ci-triage as portable services to andrewgazelka's home config
> - Adds a `pr-watch` portable service ([pr-watch.sh](https://github.com/indexable-inc/index/pull/537/files#diff-d1e103bdff4103becb5bcb45744a10edb56341dd0c95568cf1b94db582fe3518)) that polls configured GitHub repos for newly merged PRs (plays a Minecraft sound) and newly failed main-branch CI runs (speaks a brief summary, triggers a deep-dive analysis).
> - Adds a `ci-triage` app ([ci-triage.sh](https://github.com/indexable-inc/index/pull/537/files#diff-7c358aaf39b67b7d95ad93e68598e916dc86f7ac8ca5ab3cc1150df971fe960d)) that runs an Opus-based analysis of a failed Actions run, speaks a concise failure cause via `say-detached`, and optionally files or dedupes a Linear ENG ticket using the Linear API.
> - Adds an `announce-lib.sh` sourced library that wraps `claude -p` to synthesize short summaries and speak them with a Minecraft sound via `say-detached`.
> - Module options in [home.nix](https://github.com/indexable-inc/index/pull/537/files#diff-b9c7bb705f699ec210f648820aef5c561583845b682d07d6e1dc19de7685cb0f) expose `enable`, `interval`, `repos`, `mergeSound`, and `triageCooldown`; both services run on macOS (launchd) and Linux (systemd user) via the portable service abstraction.
> - Risk: `ci-triage` requires a Linear API key in env or macOS Keychain and a valid `gh` auth session; missing credentials will silently skip ticket creation but speech/sound still fires.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1bdc565.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->