### PR TITLE
fix(git-log-pretty): bound --avatar-rows, degrade on transmit failure

### DIFF
--- a/packages/git-log-pretty/src/avatar.rs
+++ b/packages/git-log-pretty/src/avatar.rs
@@ -25,7 +25,8 @@ const ID_MASK: u32 = 0x00FF_FFFF;
 pub struct Avatar {
     /// `PNG`-encoded image bytes.
     pub png: Vec<u8>,
-    /// A stable per-author id so repeated commits reuse one transmitted image.
+    /// A per-author id, stable within this process run, so repeated commits
+    /// reuse one transmitted image. Re-derived (not persisted) on each run.
     pub id: u32,
 }
 

--- a/packages/git-log-pretty/src/main.rs
+++ b/packages/git-log-pretty/src/main.rs
@@ -45,7 +45,11 @@ struct Cli {
     #[arg(long, global = true)]
     no_avatar: bool,
     /// Height of each inline avatar in terminal rows (0 disables avatars).
-    #[arg(long, global = true, default_value_t = 2)]
+    ///
+    /// Capped at 64: the width is `2 * rows` columns, which must stay within the
+    /// kitty placeholder diacritic table, and an avatar taller than a screen is
+    /// never wanted. The bound also keeps `2 * rows` from overflowing.
+    #[arg(long, global = true, default_value_t = 2, value_parser = clap::value_parser!(u32).range(0..=64))]
     avatar_rows: u32,
     #[command(subcommand)]
     command: Option<Command>,
@@ -142,12 +146,16 @@ fn emit_log(
 
     // A fetch or runtime-build failure shouldn't sink the whole log; fall back
     // to the plain, still-paged renderer.
-    let fetched = avatars_enabled.then(|| fetch_avatars(repo, commits).ok()).flatten();
+    let mut fetched = avatars_enabled.then(|| fetch_avatars(repo, commits).ok()).flatten();
 
     // Transmit the pixels before the pager starts drawing, so the placeholder
-    // cells it later prints have an image to resolve against.
-    if let Some(fetched) = &fetched {
-        transmit_avatars(fetched, avatar_rows)?;
+    // cells it later prints have an image to resolve against. If that write to
+    // the terminal fails, drop the avatars and page the plain log rather than
+    // erroring out, matching the fetch-failure fallback above.
+    if let Some(images) = &fetched
+        && transmit_avatars(images, avatar_rows).is_err()
+    {
+        fetched = None;
     }
 
     pager::paged(allow_pager, |out| {


### PR DESCRIPTION
Follow-up to #538's review. No behavior change for normal use.

- Cap `--avatar-rows` at 64 (clap range). `avatar_cols` is `2 * rows`, an unchecked `u32` multiply on CLI input: huge values panicked in debug / produced garbage geometry in release. Also keeps the column count inside the kitty placeholder diacritic table.
- If the up-front avatar transmit to the terminal fails, drop avatars and page the plain log instead of erroring the whole command (matches the existing fetch-failure fallback).
- Doc: an avatar id is stable within a process run, not across runs.

Validated: workspace clippy (Linux), git-log-pretty unit + integration tests (darwin), and `--avatar-rows 99` now rejected with a usage error.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `git-log-pretty` avatar rendering to use kitty Unicode placeholders and bound `--avatar-rows` to 64
> - Replaces cursor-anchored avatar placement with kitty Unicode placeholder rendering: images are transmitted once via virtual placement, then rendered as ordinary text cells using `transmit_virtual` and `placeholder_row` in the new `kitty` APIs.
> - Avatar image ids are now constrained to 24-bit non-zero values derived from a hashed pid, wrapping safely instead of potentially exceeding kitty's encoding limits.
> - `--avatar-rows` is now validated at parse time to reject values above 64.
> - On any avatar fetch or transmit failure, `emit_log` falls back to plain paged output instead of erroring or skipping the pager.
> - Behavioral Change: avatar output now scrolls correctly through the pager; the `transmitted` id set parameter is removed from `print_commit_with_avatar`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4102757.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->