### PR TITLE
orb: merge XP-orb feed; pr-watch announces merges visually, not with a bell

### DIFF
--- a/packages/bossbar-overlay/app/crates/orb/src/db.rs
+++ b/packages/bossbar-overlay/app/crates/orb/src/db.rs
@@ -24,6 +24,12 @@ CREATE TABLE IF NOT EXISTS orb (
   url    TEXT    NOT NULL DEFAULT '',
   x      REAL,
   y      REAL
+);
+CREATE TABLE IF NOT EXISTS events (
+  id      INTEGER PRIMARY KEY AUTOINCREMENT,
+  text    TEXT    NOT NULL DEFAULT '',
+  amount  INTEGER NOT NULL DEFAULT 7,
+  created INTEGER NOT NULL DEFAULT (unixepoch())
 );";
 
 /// Inserted only when the DB is first created, so a fresh install shows an orb and
@@ -147,6 +153,63 @@ where
     });
 }
 
+/// One queued merge announcement: a falling/rising labelled orb to show once.
+/// `amount` picks the orb size via [`crate::scene::icon_for`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct Event {
+    pub id: i64,
+    pub text: String,
+    pub amount: i64,
+}
+
+/// Open a connection for the feed reader (schema ensured). Public so the feed
+/// overlay can poll the `events` table on its own connection.
+pub fn connect(path: &Path) -> rusqlite::Result<Connection> {
+    open(path)
+}
+
+/// Queue one announcement orb. Called by `xp-orb-overlay push` (e.g. from
+/// pr-watch on a merged PR); the running feed overlay picks it up within ~200ms.
+pub fn push_event(path: &Path, text: &str, amount: i64) -> rusqlite::Result<()> {
+    let conn = open(path)?;
+    conn.execute(
+        "INSERT INTO events (text, amount) VALUES (?1, ?2)",
+        rusqlite::params![text, amount.max(0)],
+    )?;
+    Ok(())
+}
+
+/// Highest event id present, so the feed can seed its cursor on startup and stay
+/// quiet about the existing backlog (only newly inserted events animate).
+pub fn max_event_id(conn: &Connection) -> rusqlite::Result<i64> {
+    conn.query_row("SELECT COALESCE(MAX(id), 0) FROM events", [], |r| r.get(0))
+}
+
+/// Events queued after `after` (exclusive), oldest first.
+pub fn read_events_after(conn: &Connection, after: i64) -> rusqlite::Result<Vec<Event>> {
+    let mut stmt =
+        conn.prepare("SELECT id, text, amount FROM events WHERE id > ?1 ORDER BY id ASC")?;
+    let rows = stmt.query_map([after], |r| {
+        Ok(Event {
+            id: r.get(0)?,
+            text: r.get(1)?,
+            amount: r.get::<_, i64>(2)?.max(0),
+        })
+    })?;
+    rows.collect()
+}
+
+/// Drop consumed events older than `older_than_secs` so the table stays small.
+/// Keeps a short tail so a just-restarted overlay does not miss a very recent
+/// push, while never replaying the whole history.
+pub fn prune_events(conn: &Connection, older_than_secs: i64) -> rusqlite::Result<()> {
+    conn.execute(
+        "DELETE FROM events WHERE created < unixepoch() - ?1",
+        [older_than_secs.max(0)],
+    )?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -183,6 +246,25 @@ mod tests {
         let conn = open(&path).unwrap();
         conn.execute("UPDATE orb SET amount = -5 WHERE id = 1", []).unwrap();
         assert_eq!(read(&conn).unwrap().amount, 0);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn events_queue_and_read_after_cursor() {
+        let path = temp_db("events");
+        let _ = open(&path).unwrap();
+        push_event(&path, "ix \u{b7} first", 7).unwrap();
+        push_event(&path, "index \u{b7} second", -3).unwrap();
+        let conn = open(&path).unwrap();
+        let all = read_events_after(&conn, 0).unwrap();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].text, "ix \u{b7} first");
+        assert_eq!(all[1].amount, 0, "negative amount clamps to zero");
+        // Cursor past the first returns only the newer event.
+        let rest = read_events_after(&conn, all[0].id).unwrap();
+        assert_eq!(rest.len(), 1);
+        assert_eq!(rest[0].text, "index \u{b7} second");
+        assert_eq!(max_event_id(&conn).unwrap(), all[1].id);
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 }

--- a/packages/bossbar-overlay/app/crates/orb/src/feed.rs
+++ b/packages/bossbar-overlay/app/crates/orb/src/feed.rs
@@ -1,0 +1,311 @@
+//! The merge "feed" overlay: a full-screen, transparent, always-on-top,
+//! click-through window that watches the `events` table and, for each newly
+//! queued row, floats a labelled Minecraft experience orb up from the bottom of
+//! the screen and fades it out ("rise & pop"), like collecting XP. Driven the
+//! same way as the pinned orb: anyone writes a row
+//! (`xp-orb-overlay push "ix · Fix flaky test"`) and it animates within ~200ms.
+//!
+//! Unlike the pinned orb this window spans the whole visible frame and is fully
+//! click-through (`set_cursor_hittest(false)`), so it never intercepts the
+//! desktop: it is pure output. Concurrent announcements stack into vertical
+//! slots so they never overlap, each rising and fading on its own clock.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use overlay_core::wgpu;
+use overlay_core::winit::application::ApplicationHandler;
+use overlay_core::winit::dpi::{LogicalPosition, PhysicalSize};
+use overlay_core::winit::event::WindowEvent;
+use overlay_core::winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use overlay_core::winit::window::{Window, WindowId};
+use overlay_core::{anim, window as ocwin, Gpu};
+
+use crate::db;
+use crate::scene::{self, OrbTexture};
+
+/// How long one announcement orb lives, start to fully faded.
+const LIFESPAN: Duration = Duration::from_millis(4500);
+/// Fraction of the life spent fully opaque before the fade-out begins.
+const FADE_FROM: f32 = 0.55;
+/// Logical points an orb floats up over its life.
+const RISE: f64 = 90.0;
+/// Logical points from the bottom of the visible frame to the lowest slot,
+/// clearing the Dock.
+const BOTTOM_MARGIN: f64 = 64.0;
+/// Logical points from the left edge to the orb.
+const LEFT_MARGIN: f64 = 40.0;
+/// Vertical gap between stacked slots, as a multiple of the orb sprite height.
+const ROW_MUL: f64 = 1.4;
+/// DB poll cadence: a pushed event animates within this.
+const POLL: Duration = Duration::from_millis(200);
+/// Animation frame budget while at least one orb is on screen (~30 fps).
+const FRAME: Duration = Duration::from_millis(33);
+/// One full shimmer (colour pulse) cycle, matching the pinned orb.
+const SHIMMER_PERIOD: Duration = Duration::from_millis(2000);
+/// Consumed events older than this are pruned so the table stays small.
+const PRUNE_AGE_SECS: i64 = 300;
+
+/// One in-flight announcement: a labelled orb rising in a vertical slot.
+struct Pop {
+    text: String,
+    amount: i64,
+    born: Instant,
+    /// Vertical stacking position (0 = lowest), assigned at spawn from the free
+    /// slots so concurrent pops never overlap.
+    slot: usize,
+}
+
+struct WinState {
+    window: Arc<Window>,
+    surface: wgpu::Surface<'static>,
+    config: wgpu::SurfaceConfiguration,
+    texture: OrbTexture,
+}
+
+pub struct Feed {
+    db: PathBuf,
+    base_scale: u32,
+    instance: wgpu::Instance,
+    gpu: Option<Gpu>,
+    win: Option<WinState>,
+    /// Open reader connection; reopened lazily on error.
+    conn: Option<rusqlite::Connection>,
+    /// Highest event id already consumed; seeded to the current max on startup so
+    /// the existing backlog stays quiet and only new pushes animate.
+    last_seen: i64,
+    pops: Vec<Pop>,
+    last_poll: Instant,
+    last_prune: Instant,
+    scale_factor: f64,
+    /// Physical sprite scale, `round(base_scale * scale_factor)`.
+    scale: u32,
+    start: Instant,
+    ready: bool,
+}
+
+impl Feed {
+    fn create_window(&mut self, event_loop: &ActiveEventLoop) {
+        let (left, top, vw, vh) = ocwin::visible_frame_logical().unwrap_or((0.0, 0.0, 1920.0, 1080.0));
+        let w_px = (vw * self.scale_factor).round().max(1.0) as u32;
+        let h_px = (vh * self.scale_factor).round().max(1.0) as u32;
+        let pos = LogicalPosition::new(left, top);
+        let attrs = ocwin::float_attributes("Merge Feed", w_px, h_px, Some(pos))
+            .with_inner_size(PhysicalSize::new(w_px, h_px));
+        let window = match event_loop.create_window(attrs) {
+            Ok(w) => Arc::new(w),
+            Err(e) => {
+                eprintln!("xp-orb-overlay: create feed window failed: {e}");
+                event_loop.exit();
+                return;
+            }
+        };
+        // Pure output: never intercept the desktop. The whole window is
+        // click-through, so pointer events fall to whatever is behind it.
+        let _ = window.set_cursor_hittest(false);
+        ocwin::raise_to_front(&window);
+
+        let surface = self
+            .instance
+            .create_surface(window.clone())
+            .expect("create surface");
+        let (adapter, device, queue) = ocwin::request_adapter_device(&self.instance, &surface);
+        let caps = surface.get_capabilities(&adapter);
+        let format = ocwin::srgb_format(&caps);
+        let alpha = ocwin::transparent_alpha_mode(&caps);
+
+        let mut gpu = Gpu::new(device, queue, format);
+        let texture = scene::register(&mut gpu);
+
+        let size = window.inner_size();
+        let config = ocwin::surface_config(format, alpha, size.width, size.height);
+        surface.configure(gpu.device(), &config);
+
+        self.gpu = Some(gpu);
+        self.win = Some(WinState {
+            window,
+            surface,
+            config,
+            texture,
+        });
+    }
+
+    /// Poll the DB for events queued since `last_seen`, spawning a pop for each.
+    fn poll_events(&mut self, now: Instant) {
+        if self.conn.is_none() {
+            self.conn = db::connect(&self.db).ok();
+            if let Some(c) = self.conn.as_ref() {
+                // A fresh reader skips whatever predates it.
+                self.last_seen = db::max_event_id(c).unwrap_or(self.last_seen);
+            }
+        }
+        let Some(conn) = self.conn.as_ref() else {
+            return;
+        };
+        match db::read_events_after(conn, self.last_seen) {
+            Ok(events) => {
+                for ev in events {
+                    self.last_seen = self.last_seen.max(ev.id);
+                    let slot = free_slot(&self.pops);
+                    self.pops.push(Pop {
+                        text: ev.text,
+                        amount: ev.amount,
+                        born: now,
+                        slot,
+                    });
+                }
+            }
+            Err(e) => {
+                eprintln!("xp-orb-overlay: feed read failed, reopening: {e}");
+                self.conn = None;
+            }
+        }
+
+        if now.duration_since(self.last_prune) >= Duration::from_secs(60) {
+            if let Some(c) = self.conn.as_ref() {
+                let _ = db::prune_events(c, PRUNE_AGE_SECS);
+            }
+            self.last_prune = now;
+        }
+    }
+
+    fn render(&mut self) {
+        let now = Instant::now();
+        let shimmer = (anim::breathe(now.duration_since(self.start), SHIMMER_PERIOD) + 1.0) * 0.5;
+        let (Some(gpu), Some(win)) = (self.gpu.as_ref(), self.win.as_ref()) else {
+            return;
+        };
+        let (cw, ch) = (win.config.width, win.config.height);
+
+        let orb_px = (16 * self.scale) as f32; // ORB_PX * scale
+        let row = orb_px as f64 * ROW_MUL;
+        let rise_px = RISE * self.scale_factor;
+        let left_px = LEFT_MARGIN * self.scale_factor;
+        let bottom_px = BOTTOM_MARGIN * self.scale_factor;
+
+        let mut quads = Vec::new();
+        for pop in &self.pops {
+            let p = (now.duration_since(pop.born).as_secs_f32() / LIFESPAN.as_secs_f32()).clamp(0.0, 1.0);
+            let alpha = if p < FADE_FROM {
+                1.0
+            } else {
+                1.0 - (p - FADE_FROM) / (1.0 - FADE_FROM)
+            };
+            let base_y = ch as f64 - bottom_px - orb_px as f64 - pop.slot as f64 * row;
+            let y = base_y - rise_px * anim::ease_out_cubic(p) as f64;
+            scene::build_pop(
+                gpu,
+                &win.texture,
+                &pop.text,
+                pop.amount,
+                self.scale,
+                left_px as f32,
+                y as f32,
+                alpha,
+                shimmer,
+                &mut quads,
+            );
+        }
+
+        let frame = match win.surface.get_current_texture() {
+            Ok(f) => f,
+            Err(wgpu::SurfaceError::Outdated | wgpu::SurfaceError::Lost) => {
+                win.surface.configure(gpu.device(), &win.config);
+                return;
+            }
+            Err(e) => {
+                eprintln!("xp-orb-overlay: feed surface error: {e:?}");
+                return;
+            }
+        };
+        let view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let _ = gpu.draw(&view, cw, ch, &quads);
+        frame.present();
+    }
+}
+
+/// Lowest non-negative slot not held by an active pop, so a new orb stacks above
+/// the current ones without overlapping and reuses a slot freed by a faded orb.
+fn free_slot(pops: &[Pop]) -> usize {
+    let used: HashSet<usize> = pops.iter().map(|p| p.slot).collect();
+    (0..).find(|s| !used.contains(s)).unwrap_or(0)
+}
+
+impl ApplicationHandler<()> for Feed {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.ready {
+            return;
+        }
+        let scale_factor = event_loop
+            .primary_monitor()
+            .or_else(|| event_loop.available_monitors().next())
+            .map_or(1.0, |m| m.scale_factor());
+        self.scale_factor = scale_factor;
+        self.scale = ((self.base_scale as f64) * scale_factor).round().max(1.0) as u32;
+        self.ready = true;
+        self.create_window(event_loop);
+    }
+
+    fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
+        match event {
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::Resized(size) => {
+                if let (Some(gpu), Some(win)) = (self.gpu.as_ref(), self.win.as_mut()) {
+                    win.config.width = size.width.max(1);
+                    win.config.height = size.height.max(1);
+                    win.surface.configure(gpu.device(), &win.config);
+                }
+                self.render();
+            }
+            WindowEvent::RedrawRequested => self.render(),
+            _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let now = Instant::now();
+        if now.duration_since(self.last_poll) >= POLL {
+            self.poll_events(now);
+            self.last_poll = now;
+        }
+        // Drop faded orbs; an emptying transition still needs one redraw to clear.
+        let before = self.pops.len();
+        self.pops
+            .retain(|p| now.duration_since(p.born) < LIFESPAN);
+        let changed = self.pops.len() != before;
+        let active = !self.pops.is_empty();
+        if (active || changed) && let Some(win) = self.win.as_ref() {
+            win.window.request_redraw();
+        }
+        let next = if active { FRAME } else { POLL };
+        event_loop.set_control_flow(ControlFlow::WaitUntil(now + next));
+    }
+}
+
+/// Run the merge-feed overlay event loop. Blocks until the window closes.
+pub fn run(db: PathBuf, base_scale: u32) -> Result<(), Box<dyn std::error::Error>> {
+    let event_loop: EventLoop<()> = ocwin::build_event_loop()?;
+    let now = Instant::now();
+    let mut feed = Feed {
+        db,
+        base_scale: base_scale.max(1),
+        instance: wgpu::Instance::default(),
+        gpu: None,
+        win: None,
+        conn: None,
+        last_seen: 0,
+        pops: Vec::new(),
+        last_poll: now - POLL,
+        last_prune: now,
+        scale_factor: 1.0,
+        scale: base_scale.max(1),
+        start: now,
+        ready: false,
+    };
+    event_loop.run_app(&mut feed)?;
+    Ok(())
+}

--- a/packages/bossbar-overlay/app/crates/orb/src/feed.rs
+++ b/packages/bossbar-overlay/app/crates/orb/src/feed.rs
@@ -21,7 +21,7 @@ use overlay_core::winit::dpi::{LogicalPosition, PhysicalSize};
 use overlay_core::winit::event::WindowEvent;
 use overlay_core::winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use overlay_core::winit::window::{Window, WindowId};
-use overlay_core::{anim, window as ocwin, Gpu};
+use overlay_core::{Gpu, anim, window as ocwin};
 
 use crate::db;
 use crate::scene::{self, OrbTexture};
@@ -47,6 +47,11 @@ const FRAME: Duration = Duration::from_millis(33);
 const SHIMMER_PERIOD: Duration = Duration::from_millis(2000);
 /// Consumed events older than this are pruned so the table stays small.
 const PRUNE_AGE_SECS: i64 = 300;
+/// Cap on the stacking slot used for vertical placement, so a rare burst of
+/// simultaneous merges overlaps near the top of the stack instead of marching
+/// off the top of the screen. Slots still allocate beyond this; only the drawn
+/// height is clamped.
+const MAX_SLOT: usize = 9;
 
 /// One in-flight announcement: a labelled orb rising in a vertical slot.
 struct Pop {
@@ -88,7 +93,8 @@ pub struct Feed {
 
 impl Feed {
     fn create_window(&mut self, event_loop: &ActiveEventLoop) {
-        let (left, top, vw, vh) = ocwin::visible_frame_logical().unwrap_or((0.0, 0.0, 1920.0, 1080.0));
+        let (left, top, vw, vh) =
+            ocwin::visible_frame_logical().unwrap_or((0.0, 0.0, 1920.0, 1080.0));
         let w_px = (vw * self.scale_factor).round().max(1.0) as u32;
         let h_px = (vh * self.scale_factor).round().max(1.0) as u32;
         let pos = LogicalPosition::new(left, top);
@@ -136,9 +142,14 @@ impl Feed {
     fn poll_events(&mut self, now: Instant) {
         if self.conn.is_none() {
             self.conn = db::connect(&self.db).ok();
-            if let Some(c) = self.conn.as_ref() {
-                // A fresh reader skips whatever predates it.
-                self.last_seen = db::max_event_id(c).unwrap_or(self.last_seen);
+            if let Some(c) = self.conn.as_ref()
+                && self.last_seen == 0
+            {
+                // Seed the cursor only on the FIRST successful connect, so the
+                // pre-existing backlog stays quiet. On a reconnect after a read
+                // error, keep the prior cursor so events queued during the
+                // outage are still picked up rather than silently skipped.
+                self.last_seen = db::max_event_id(c).unwrap_or(0);
             }
         }
         let Some(conn) = self.conn.as_ref() else {
@@ -187,13 +198,15 @@ impl Feed {
 
         let mut quads = Vec::new();
         for pop in &self.pops {
-            let p = (now.duration_since(pop.born).as_secs_f32() / LIFESPAN.as_secs_f32()).clamp(0.0, 1.0);
+            let p = (now.duration_since(pop.born).as_secs_f32() / LIFESPAN.as_secs_f32())
+                .clamp(0.0, 1.0);
             let alpha = if p < FADE_FROM {
                 1.0
             } else {
                 1.0 - (p - FADE_FROM) / (1.0 - FADE_FROM)
             };
-            let base_y = ch as f64 - bottom_px - orb_px as f64 - pop.slot as f64 * row;
+            let base_y =
+                ch as f64 - bottom_px - orb_px as f64 - pop.slot.min(MAX_SLOT) as f64 * row;
             let y = base_y - rise_px * anim::ease_out_cubic(p) as f64;
             scene::build_pop(
                 gpu,
@@ -274,11 +287,12 @@ impl ApplicationHandler<()> for Feed {
         }
         // Drop faded orbs; an emptying transition still needs one redraw to clear.
         let before = self.pops.len();
-        self.pops
-            .retain(|p| now.duration_since(p.born) < LIFESPAN);
+        self.pops.retain(|p| now.duration_since(p.born) < LIFESPAN);
         let changed = self.pops.len() != before;
         let active = !self.pops.is_empty();
-        if (active || changed) && let Some(win) = self.win.as_ref() {
+        if (active || changed)
+            && let Some(win) = self.win.as_ref()
+        {
             win.window.request_redraw();
         }
         let next = if active { FRAME } else { POLL };

--- a/packages/bossbar-overlay/app/crates/orb/src/main.rs
+++ b/packages/bossbar-overlay/app/crates/orb/src/main.rs
@@ -8,12 +8,16 @@
 //! `overlay-core` crate.
 //!
 //! Usage:
-//!   xp-orb-overlay                 run the overlay
+//!   xp-orb-overlay                 run the pinned single-orb overlay
+//!   xp-orb-overlay feed            run the full-screen merge "rise & pop" feed
+//!   xp-orb-overlay push TEXT       queue one labelled orb for the feed and exit
+//!                  [--amount N]
 //!   xp-orb-overlay --snapshot OUT  render the current orb to a PNG and exit
-//!                  [--scale N] [--amount N] [--hover]
+//!                  [--scale N] [--amount N] [--hover] [--label TEXT]
 
 mod assets;
 mod db;
+mod feed;
 mod orb;
 mod overlay;
 mod scene;
@@ -23,6 +27,17 @@ use std::path::PathBuf;
 /// Default logical pixel scale of the 16x16 orb sprite; overridable with
 /// `ORB_SCALE` or `--scale`.
 const DEFAULT_SCALE: u32 = 4;
+/// Default XP amount for a pushed merge orb when `--amount` is omitted: a
+/// mid-size orb (icon 2).
+const DEFAULT_PUSH_AMOUNT: i64 = 7;
+
+/// Sprite scale from `ORB_SCALE`, else the default.
+fn env_scale() -> u32 {
+    std::env::var("ORB_SCALE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_SCALE)
+}
 
 struct Args {
     snapshot: Option<PathBuf>,
@@ -31,6 +46,9 @@ struct Args {
     amount: Option<i64>,
     /// Render the snapshot in the hovered (grown) state.
     hover: bool,
+    /// Render the snapshot as a labelled merge "pop" (orb + this text) instead of
+    /// the bare pinned orb, so the feed look is verifiable from a file.
+    label: Option<String>,
     /// Run the scroll-drag cursor-follow self-test, writing a report here and
     /// exiting. Validates the fix inside the macOS guest VM, where the guest
     /// cursor is invisible to host screenshots, by reading the real cursor in-guest.
@@ -38,15 +56,12 @@ struct Args {
 }
 
 fn parse_args() -> Result<Args, String> {
-    let scale = std::env::var("ORB_SCALE")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DEFAULT_SCALE);
     let mut args = Args {
         snapshot: None,
-        scale,
+        scale: env_scale(),
         amount: None,
         hover: false,
+        label: None,
         selftest: None,
     };
     let mut it = std::env::args().skip(1);
@@ -72,14 +87,19 @@ fn parse_args() -> Result<Args, String> {
                 );
             }
             "--hover" => args.hover = true,
+            "--label" => {
+                args.label = Some(it.next().ok_or("--label needs text")?);
+            }
             "--selftest" => {
                 let p = it.next().ok_or("--selftest needs an output path")?;
                 args.selftest = Some(PathBuf::from(p));
             }
             "-h" | "--help" => {
                 println!(
-                    "xp-orb-overlay [--snapshot OUT] [--scale N] [--amount N] [--hover] \
-                     [--selftest OUT]\n\
+                    "xp-orb-overlay                 pinned single-orb overlay\n\
+                     xp-orb-overlay feed            full-screen merge rise-&-pop feed\n\
+                     xp-orb-overlay push TEXT [--amount N]   queue one feed orb\n\
+                     xp-orb-overlay --snapshot OUT [--scale N] [--amount N] [--hover] [--label TEXT]\n\
                      SQLite-driven Minecraft experience-orb overlay. DB path: ORB_DB \
                      or the per-OS app-data path."
                 );
@@ -91,7 +111,59 @@ fn parse_args() -> Result<Args, String> {
     Ok(args)
 }
 
+/// `xp-orb-overlay push TEXT... [--amount N]`: queue one labelled orb and exit.
+/// Positional words join into the label so the caller need not quote.
+fn run_push(rest: &[String], db: &std::path::Path) -> ! {
+    let mut amount = DEFAULT_PUSH_AMOUNT;
+    let mut parts: Vec<String> = Vec::new();
+    let mut it = rest.iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--amount" => match it.next().and_then(|s| s.parse().ok()) {
+                Some(n) => amount = n,
+                None => {
+                    eprintln!("xp-orb-overlay: push --amount needs a number");
+                    std::process::exit(2);
+                }
+            },
+            other => parts.push(other.to_string()),
+        }
+    }
+    let text = parts.join(" ");
+    match db::push_event(db, &text, amount) {
+        Ok(()) => std::process::exit(0),
+        Err(e) => {
+            eprintln!("xp-orb-overlay: push failed: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
 fn main() {
+    let db = db::resolve_path();
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+
+    // Subcommands precede the flag-based forms.
+    match argv.first().map(String::as_str) {
+        Some("feed") => {
+            // The feed accepts an optional `--scale N`.
+            let mut scale = env_scale();
+            let mut it = argv[1..].iter();
+            while let Some(a) = it.next() {
+                if a == "--scale" && let Some(n) = it.next().and_then(|s| s.parse().ok()) {
+                    scale = n;
+                }
+            }
+            if let Err(e) = feed::run(db, scale) {
+                eprintln!("xp-orb-overlay: {e}");
+                std::process::exit(1);
+            }
+            return;
+        }
+        Some("push") => run_push(&argv[1..], &db),
+        _ => {}
+    }
+
     let args = match parse_args() {
         Ok(a) => a,
         Err(e) => {
@@ -111,26 +183,47 @@ fn main() {
         return;
     }
 
-    let db = db::resolve_path();
-
     if let Some(out) = args.snapshot {
-        let mut orb = db::read_once(&db).unwrap_or_default();
-        if let Some(a) = args.amount {
-            orb.amount = a.max(0);
-        }
         let scale = args.scale.max(1);
-        let (w, h) = scene::orb_window_px(scale);
-        let hover = if args.hover { 1.0 } else { 0.0 };
-        // A still frame: mid-shimmer, no bob, so the PNG is deterministic.
-        let result = overlay_core::snapshot::render_to_png(
-            w,
-            h,
-            |gpu| {
-                let tex = scene::register(gpu);
-                scene::build(&tex, &orb, scale, w, h, hover, 0.5, 0.0)
-            },
-            &out,
-        );
+        // A still, mid-shimmer frame so the PNG is deterministic. With --label,
+        // render the feed "pop" (orb + label); otherwise the bare pinned orb.
+        let result = if let Some(label) = args.label.clone() {
+            let amount = args.amount.unwrap_or(DEFAULT_PUSH_AMOUNT).max(0);
+            let (pw, ph) = scene::pop_size(&label, scale);
+            // Room for the 1px*scale text shadow on the right and bottom.
+            let pad = scale;
+            let (w, h) = (pw + 2 * pad, ph + 2 * pad);
+            overlay_core::snapshot::render_to_png(
+                w,
+                h,
+                |gpu| {
+                    let tex = scene::register(gpu);
+                    let mut quads = Vec::new();
+                    scene::build_pop(
+                        gpu, &tex, &label, amount, scale, pad as f32, pad as f32, 1.0, 0.5,
+                        &mut quads,
+                    );
+                    quads
+                },
+                &out,
+            )
+        } else {
+            let mut orb = db::read_once(&db).unwrap_or_default();
+            if let Some(a) = args.amount {
+                orb.amount = a.max(0);
+            }
+            let (w, h) = scene::orb_window_px(scale);
+            let hover = if args.hover { 1.0 } else { 0.0 };
+            overlay_core::snapshot::render_to_png(
+                w,
+                h,
+                |gpu| {
+                    let tex = scene::register(gpu);
+                    scene::build(&tex, &orb, scale, w, h, hover, 0.5, 0.0)
+                },
+                &out,
+            )
+        };
         match result {
             Ok(()) => println!("xp-orb-overlay: wrote {}", out.display()),
             Err(e) => {

--- a/packages/bossbar-overlay/app/crates/orb/src/main.rs
+++ b/packages/bossbar-overlay/app/crates/orb/src/main.rs
@@ -126,6 +126,12 @@ fn run_push(rest: &[String], db: &std::path::Path) -> ! {
                     std::process::exit(2);
                 }
             },
+            // End of flags: everything after `--` is label text verbatim, so a
+            // title that itself contains `--amount` is not mis-parsed.
+            "--" => {
+                parts.extend(it.by_ref().cloned());
+                break;
+            }
             other => parts.push(other.to_string()),
         }
     }
@@ -150,7 +156,9 @@ fn main() {
             let mut scale = env_scale();
             let mut it = argv[1..].iter();
             while let Some(a) = it.next() {
-                if a == "--scale" && let Some(n) = it.next().and_then(|s| s.parse().ok()) {
+                if a == "--scale"
+                    && let Some(n) = it.next().and_then(|s| s.parse().ok())
+                {
                     scale = n;
                 }
             }

--- a/packages/bossbar-overlay/app/crates/orb/src/scene.rs
+++ b/packages/bossbar-overlay/app/crates/orb/src/scene.rs
@@ -3,7 +3,7 @@
 //! has), and let the caller bob and grow it. The orb art is one 64x64 sheet of
 //! 16x16 icons in a 4x4 grid.
 
-use overlay_core::{anim, Gpu, Quad, TexHandle};
+use overlay_core::{anim, BitmapFont, Gpu, Quad, TexHandle, SHADOW};
 
 use crate::assets;
 use crate::orb::Orb;
@@ -19,6 +19,11 @@ pub const MAX_MUL: f32 = 1.18;
 /// Bob amplitude in source pixels: the orb drifts +/- this (times `scale`) about
 /// its resting centre. Small, so it reads as a gentle float, not a bounce.
 const BOB_PX: u32 = 2;
+
+/// Label font size relative to the sprite scale, and the gap (source px) between
+/// the orb and its label in a merge "pop".
+const LABEL_SCALE: f32 = 0.6;
+const GAP_PX: u32 = 3;
 
 /// The registered orb texture handle.
 pub struct OrbTexture {
@@ -116,6 +121,54 @@ pub fn build(
     let mul = 1.0 + hover * (MAX_MUL - 1.0);
     anim::scale_quads_about(&mut quads, cx, cy, mul);
     quads
+}
+
+/// Label height (drawn glyph cell, physical px) at the given sprite scale.
+fn label_cell(scale: u32) -> f32 {
+    BitmapFont::cell_px() * (scale as f32) * LABEL_SCALE
+}
+
+/// Pixel size (physical) of one merge "pop": the orb plus a gap plus the measured
+/// label. Uses the shared static font, so the snapshot can pick a canvas that
+/// frames the whole thing before any [`Gpu`] exists.
+pub fn pop_size(text: &str, scale: u32) -> (u32, u32) {
+    let orb = (ORB_PX * scale) as f32;
+    let label_w = overlay_core::bitmap_font::shared().measure(text, (scale as f32) * LABEL_SCALE);
+    let w = orb + (GAP_PX * scale) as f32 + label_w;
+    (w.ceil() as u32, orb.ceil() as u32)
+}
+
+/// Build one announcement "pop": the orb with its top-left at `(x, y)` plus its
+/// label to the right, vertically centred on the orb, both scaled by `alpha`
+/// (1.0 opaque, 0.0 invisible). `shimmer` is the 0..=1 colour phase. Shared by
+/// the feed overlay and the labelled snapshot so they cannot drift.
+#[allow(clippy::too_many_arguments)]
+pub fn build_pop(
+    gpu: &Gpu,
+    tex: &OrbTexture,
+    text: &str,
+    amount: i64,
+    scale: u32,
+    x: f32,
+    y: f32,
+    alpha: f32,
+    shimmer: f32,
+    out: &mut Vec<Quad>,
+) {
+    let a = alpha.clamp(0.0, 1.0);
+    let size = (ORB_PX * scale) as f32;
+    let uv = icon_uv(icon_for(amount));
+    let mut tint = shimmer_tint(shimmer);
+    tint[3] *= a;
+    out.push(Quad::sub(tex.orb, x, y, size, size, uv, tint));
+
+    let label_scale = (scale as f32) * LABEL_SCALE;
+    let tx = x + size + (GAP_PX * scale) as f32;
+    let ty = y + (size - label_cell(scale)) * 0.5;
+    let fg = [1.0, 1.0, 1.0, a];
+    let mut shadow = SHADOW;
+    shadow[3] *= a;
+    gpu.text_shadow(text, tx, ty, label_scale, fg, shadow, out);
 }
 
 #[cfg(test)]

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -7,10 +7,12 @@
 #     the public Better Stack status page onto a per-service Minecraft boss bar
 #     plus an Ender Dragon growl + spoken root cause;
 #   * the boss bar overlay GUI it drives (`bossbar-overlay`);
-#   * the merged-PR + CI-failure watcher (`pr-watch`), which plays a Minecraft
-#     sound on each PR newly merged to main and, on a newly failed main Actions
+#   * the merged-PR + CI-failure watcher (`pr-watch`), which on each PR newly
+#     merged to main floats a labelled Minecraft XP orb up the screen (the
+#     `merge-orb-feed` overlay; no sound) and, on a newly failed main Actions
 #     run, speaks a one-line alert and launches a detached Opus deep dive
 #     (`ci-triage`) that files a deduped Linear ticket;
+#   * the full-screen merge feed overlay it announces onto (`merge-orb-feed`);
 #   * the token-free `/optimize` history scan (`optimize-scan`);
 #   * the shared "play a gentle sound, then speak it detached" helper
 #     (`say-detached`) the watchers announce through.
@@ -189,15 +191,17 @@ let
     ];
     text =
       builtins.replaceStrings
-        [ "@ANNOUNCE_LIB@" "@REPOS@" "@MERGE_SOUND@" "@LOG_DIR@" "@TRIAGE_COOLDOWN@" ]
+        [ "@ANNOUNCE_LIB@" "@REPOS@" "@ORB_BIN@" "@LOG_DIR@" "@TRIAGE_COOLDOWN@" ]
         [
           "${announceLib}"
-          # escapeShellArg per value: these land unquoted in `repos=(@REPOS@)` and
-          # `say-detached @MERGE_SOUND@`, so a value with a space or shell
-          # metacharacter must carry its own quoting (the options are author-set,
-          # but bake safely rather than rely on that).
+          # escapeShellArg per value: @REPOS@ lands unquoted in `repos=(@REPOS@)`,
+          # so a value with a space or shell metacharacter must carry its own
+          # quoting (the option is author-set, but bake safely rather than rely on
+          # it).
           (lib.concatMapStringsSep " " lib.escapeShellArg cfg.prWatch.repos)
-          (lib.escapeShellArg cfg.prWatch.mergeSound)
+          # The merge feed binary: a newly merged PR is announced as a labelled
+          # XP orb (`<orb> push "<repo>: <title>"`), not a sound.
+          (lib.getExe' indexPkgs.bossbar-overlay "xp-orb-overlay")
           cfg.logDir
           (toString cfg.prWatch.triageCooldown)
         ]
@@ -242,6 +246,19 @@ in
       };
     };
 
+    mergeOrbOverlay = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Run the full-screen click-through merge feed overlay (`xp-orb-overlay
+          feed`) that pr-watch announces merges onto: each merged PR floats a
+          labelled Minecraft XP orb up the screen and fades it. Needs a display,
+          so disable on headless hosts (pr-watch still queues events harmlessly).
+        '';
+      };
+    };
+
     optimize = {
       enable = lib.mkOption {
         type = lib.types.bool;
@@ -281,15 +298,6 @@ in
           "indexable-inc/index"
         ];
         description = "GitHub `owner/name` repos to watch for merges and main CI failures.";
-      };
-
-      mergeSound = lib.mkOption {
-        type = lib.types.str;
-        default = "block/bell/bell_use01";
-        description = ''
-          minecraft-sound id played (sound only, no speech) when a PR is newly
-          merged into main. See `minecraft-sound list` for the catalog.
-        '';
       };
 
       triageCooldown = lib.mkOption {
@@ -374,6 +382,19 @@ in
           restart = "always";
           standardOutPath = "${cfg.logDir}/bossbar-overlay.log";
           standardErrorPath = "${cfg.logDir}/bossbar-overlay.log";
+          # Label defaults to the space-free home convention; no escape hatch.
+        };
+      })
+      (lib.mkIf cfg.mergeOrbOverlay.enable {
+        merge-orb-feed = {
+          description = "merge XP-orb feed overlay";
+          command = [
+            (lib.getExe' indexPkgs.bossbar-overlay "xp-orb-overlay")
+            "feed"
+          ];
+          restart = "always";
+          standardOutPath = "${cfg.logDir}/merge-orb-feed.log";
+          standardErrorPath = "${cfg.logDir}/merge-orb-feed.log";
           # Label defaults to the space-free home convention; no escape hatch.
         };
       })

--- a/users/andrewgazelka/scripts/pr-watch.sh
+++ b/users/andrewgazelka/scripts/pr-watch.sh
@@ -4,15 +4,16 @@
 # runtimeInputs. The module bakes these placeholders at build time:
 #   @ANNOUNCE_LIB@     store path of announce-lib.sh (source'd below)
 #   @REPOS@            the watched repos as a quoted bash-array body
-#   @MERGE_SOUND@      the Minecraft sound id played on a newly merged PR
+#   @ORB_BIN@          absolute path to the xp-orb-overlay binary (merge feed)
 #   @LOG_DIR@          directory the detached ci-triage stage-2 log is appended to
 #   @TRIAGE_COOLDOWN@  default seconds between stage-2 deep dives per repo+workflow
 #
 # Polls each watched repo for PRs newly merged into `main`. For each newly merged
-# PR it plays a single Minecraft sound (the @MERGE_SOUND@ id, by default a bell
-# toll) and nothing else: no spoken summary, no `claude -p`, no `say`. It
-# deliberately does NOT report the still-open / pending PR queue. The first run
-# per repo only seeds the state file, so existing PRs stay quiet.
+# PR it queues a labelled Minecraft XP orb in the merge feed overlay
+# (`xp-orb-overlay push "<repo>: <title>"`), which floats up the screen and fades
+# ("rise & pop"). NO sound: the merge alert is purely visual. It deliberately
+# does NOT report the still-open / pending PR queue. The first run per repo only
+# seeds the state file, so existing PRs stay quiet.
 #
 # It ALSO polls each repo for Actions runs that newly FAILED on `main` and
 # responds in TWO stages per newly-failed run:
@@ -75,10 +76,11 @@ for repo in "${repos[@]}"; do
     short="${repo##*/}"
     echo "MERGED: [$short #$num] $title  (by $who)"
 
-    # Sound only: a single Minecraft sound (the @MERGE_SOUND@ id), detached so a
-    # reload can't clip it. No spoken summary, no `claude -p`, no `say`. Empty
-    # text => say-detached just plays the sound.
-    say-detached @MERGE_SOUND@ ""
+    # Visual only: queue a labelled XP orb in the merge feed overlay. It floats
+    # up and fades. No sound. Best-effort: if the feed overlay is not running the
+    # event just sits in the DB (pruned after a few minutes), so never fail the
+    # poll on a push error.
+    @ORB_BIN@ push "$short: $title" || true
   done < <(printf '%s' "$json" | jq -r '
     .[] | [ (.number|tostring),
             .title,


### PR DESCRIPTION
Replaces the pr-watch merge **bell** with a visual: each PR merged to main floats a labelled Minecraft XP orb up the screen and fades it ("rise & pop"). No sound on merges. CI-failure alerts keep their sound.

**orb crate** (`packages/bossbar-overlay/app/crates/orb`)
- new SQLite `events` table + `xp-orb-overlay push "<repo>: <title>" [--amount N]` to queue one orb
- new `xp-orb-overlay feed`: full-screen, click-through overlay that polls `events` and animates a labelled orb rising + fading, one per event, stacked in vertical slots (reuses overlay-core text/anim/sprite)
- `--snapshot --label TEXT` renders the look to a PNG; the pinned single-orb mode is unchanged

**users/andrewgazelka**
- `pr-watch` merge branch now `xp-orb-overlay push` (no `say`), new `merge-orb-feed` portable service + `mergeOrbOverlay` toggle, removed `mergeSound`

Verified: cargo + nix build, `orb` unit tests (incl. events round-trip), offscreen snapshot of the rendered orb+label, transparent surface (no Opaque fallback), feed runs/exits clean. The live on-screen rise/fade isn't captured here (the screenshot tool lacks macOS Screen Recording permission → black frames); it'll show on the next real merge, or via the macvm guest.

_Authored with Claude (Opus 4.8) via Claude Code._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace PR merge sound with a visual orb feed overlay in pr-watch
> - Adds a new `feed` subcommand to the `orb` binary that runs a full-screen, click-through overlay window animating labelled orbs that rise and fade as merge announcements arrive.
> - Adds a `push` subcommand to queue a labelled event into a SQLite `events` table, replacing the previous `say-detached` sound call in [pr-watch.sh](https://github.com/indexable-inc/index/pull/540/files#diff-d1e103bdff4103becb5bcb45744a10edb56341dd0c95568cf1b94db582fe3518).
> - Extends [db.rs](https://github.com/indexable-inc/index/pull/540/files#diff-ca405964b0dbd622554e3201ca331d66788d7173638fc61195065b1aa49a806a) with event queue primitives: insert, cursor-based read, max-id seeding, and age-based pruning.
> - Adds [feed.rs](https://github.com/indexable-inc/index/pull/540/files#diff-7864a529ce314a2cbfeb85c5b2664d5adf6c8a4428f46faa1e59bb0d540fb890) which polls the DB for new events, animates them as shimmering orbs at ~30 fps, and prunes consumed rows periodically.
> - Updates [home.nix](https://github.com/indexable-inc/index/pull/540/files#diff-b9c7bb705f699ec210f648820aef5c561583845b682d07d6e1dc19de7685cb0f) to register a persistent `merge-orb-feed` systemd service and removes the `mergeSound` option.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f4fc49.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->