### PR TITLE
fix(lib): unbreak lint on main (nixfmt + statix)

### DIFF
--- a/lib/deep-merge.nix
+++ b/lib/deep-merge.nix
@@ -16,7 +16,12 @@
 { lib }:
 let
   inherit (lib) concatStringsSep isDerivation;
-  inherit (builtins) attrNames foldl' hasAttr isAttrs;
+  inherit (builtins)
+    attrNames
+    foldl'
+    hasAttr
+    isAttrs
+    ;
 
   bothMergeable = a: b: isAttrs a && isAttrs b && !(isDerivation a) && !(isDerivation b);
 
@@ -44,11 +49,15 @@ let
     in
     go [ ];
 
-  strict = mergeWith (
-    path: _l: _r: throw "ix.deepMerge.strict: leaf collision at `${concatStringsSep "." path}`"
+  strictMerge = mergeWith (
+    path: _l: _r:
+    throw "ix.deepMerge.strict: leaf collision at `${concatStringsSep "." path}`"
   );
 
-  rhs = mergeWith (_path: _l: r: r);
+  rhsMerge = mergeWith (
+    _path: _l: r:
+    r
+  );
 in
 {
   /**
@@ -57,7 +66,7 @@ in
     supposed to contribute disjoint subtrees: an accidental overlap is a bug
     in the caller, not a value to silently resolve.
   */
-  strict = strict;
+  strict = strictMerge;
 
   /**
     Recursively merge two attrsets, with rhs winning at any leaf collision.
@@ -65,12 +74,12 @@ in
     override of the first (vanilla defaults plus user fields, generated unit
     plus escape-hatch keys).
   */
-  rhs = rhs;
+  rhs = rhsMerge;
 
   /**
     Strict deep-merge folded over a list of attrsets. The N-ary shape that
     `discoverModules` needs (each module tree contributes a subset of the
     final attrset; any overlap is a duplicate-output bug).
   */
-  strictList = parts: foldl' strict { } parts;
+  strictList = parts: foldl' strictMerge { } parts;
 }

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -47,7 +47,7 @@ let
         let nix_files = (fd --extension nix | lines)
         nixfmt --check ...$nix_files
       }
-      def "main statix" [] { statix check . }
+      def "main statix" [] { statix check --ignore '.claude/worktrees' . }
       def "main deadnix" [] { deadnix --fail --no-lambda-pattern-names . }
       def "main ast-grep" [] { ast-grep scan --error . }
       # Rule self-test: every fixture under nix-rules-tests must flag its

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3274,23 +3274,48 @@ let
       }
       {
         assertion =
-          ix.deepMerge.strict { a = { x = 1; }; b = 2; } { a = { y = 3; }; c = 4; }
-          == { a = { x = 1; y = 3; }; b = 2; c = 4; };
+          ix.deepMerge.strict
+            {
+              a = {
+                x = 1;
+              };
+              b = 2;
+            }
+            {
+              a = {
+                y = 3;
+              };
+              c = 4;
+            } == {
+            a = {
+              x = 1;
+              y = 3;
+            };
+            b = 2;
+            c = 4;
+          };
         message = "deepMerge.strict should recursively union disjoint subtrees";
       }
       {
         assertion =
-          !(builtins.tryEval (
-            builtins.deepSeq (ix.deepMerge.strict { a.b = 1; } { a.b = 2; }) null
-          )).success;
+          !(builtins.tryEval (builtins.deepSeq (ix.deepMerge.strict { a.b = 1; } { a.b = 2; }) null)).success;
         message = "deepMerge.strict should throw on a colliding leaf";
       }
       {
         assertion =
           ix.deepMerge.rhs
-            { Service = { ExecStart = "/run/wrapped"; Restart = "on-failure"; }; }
-            { Service = { Restart = "always"; MemoryMax = "512M"; }; }
-          == {
+            {
+              Service = {
+                ExecStart = "/run/wrapped";
+                Restart = "on-failure";
+              };
+            }
+            {
+              Service = {
+                Restart = "always";
+                MemoryMax = "512M";
+              };
+            } == {
             Service = {
               ExecStart = "/run/wrapped";
               Restart = "always";
@@ -3317,7 +3342,13 @@ let
             { a.x = 1; }
             { a.y = 2; }
             { b = 3; }
-          ] == { a = { x = 1; y = 2; }; b = 3; };
+          ] == {
+            a = {
+              x = 1;
+              y = 2;
+            };
+            b = 3;
+          };
         message = "deepMerge.strictList should fold strict over a list of disjoint trees";
       }
     ];


### PR DESCRIPTION
main is red on `nix run .#lint`: the deep-merge refactor (#a9e0173) landed unformatted with `x = x` bindings, and statix walks the gitignored `.claude/worktrees` (nested worktrees defeat gitignore), so any present worktree fails local lint too.

- reformat `lib/deep-merge.nix` + `tests/default.nix` with pinned nixfmt
- rename internal `strict`/`rhs` → `strictMerge`/`rhsMerge` so the public attrs keep their doc comments and the manual-inherit lint clears at the source
- `statix check --ignore '.claude/worktrees'` (nixfmt already skips it via `fd`)

`nix run .#lint` ✅ all 5 stages.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix lint errors in `lib/deep-merge.nix` by renaming internal bindings for nixfmt and statix compliance
> - Renames internal `strict` and `rhs` bindings to `strictMerge` and `rhsMerge` in [lib/deep-merge.nix](https://github.com/indexable-inc/index/pull/541/files#diff-1fe40db38ab94fd26362fcc213ba1f4f4924ef7e602a3a9ba2e78685eb0c7348) to satisfy statix lint rules; exported attribute names (`strict`, `rhs`) are unchanged.
> - Reformats code across multiple lines for nixfmt compliance; no semantic changes.
> - Updates the `main statix` devshell command in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/541/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) to ignore `.claude/worktrees` paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a89d7fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->