### PR TITLE
chore(claude-code): bump to 2.1.159

### DIFF
--- a/packages/claude-code/manifest.json
+++ b/packages/claude-code/manifest.json
@@ -1,21 +1,21 @@
 {
-  "version": "2.1.157",
+  "version": "2.1.159",
   "platforms": {
     "aarch64-darwin": {
       "slug": "darwin-arm64",
-      "hash": "sha256-EPOYUQ8Oa9fGd+4lz8aYYBv4seyJZY+CP6I6L4Copz8="
+      "hash": "sha256-Wt97TTSfdD1mnNWt8s5227XhRtirmbOmPFrvLvFVlfk="
     },
     "x86_64-darwin": {
       "slug": "darwin-x64",
-      "hash": "sha256-M7DmDkA1EhDxu7NqlHjOElR0GEzgtocfaF9Yfwvhspo="
+      "hash": "sha256-q6vWx1T34CirXkvXTU1tOoAsr7V8nUHqkXjol2VcF70="
     },
     "x86_64-linux": {
       "slug": "linux-x64",
-      "hash": "sha256-MhVQH4z+6acGAcL7wshOnQIOTnFIoLi4Jk9NjAJrxks="
+      "hash": "sha256-4hJsrwDtPsCTcaKZR2WMfpsxGFJWsqxXKCY72V9+NUE="
     },
     "aarch64-linux": {
       "slug": "linux-arm64",
-      "hash": "sha256-VyIzZcvhZUb7TA4okSs/jLYcrCtczKhLcXGdnxMyhr8="
+      "hash": "sha256-vv0FTwLBfkthpqkrMChqFHyoxcG784uR3RTLpvux4H0="
     }
   }
 }


### PR DESCRIPTION
Bump pinned Claude Code from 2.1.157 to 2.1.159 (latest).

Regenerated via `nix run .#claude-code.updateScript -- 2.1.159`; the updater verifies Anthropic's detached GPG signature before rewriting the manifest. Built on aarch64-darwin and `claude --version` reports 2.1.159.

Made with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `claude-code` package version to 2.1.159
> Updates [manifest.json](https://github.com/indexable-inc/index/pull/542/files#diff-07231a29e842291cdba811cc694c7fe37386a88958609a48480b263aa9dca446) to version 2.1.159 (from 2.1.157) and refreshes the four associated sha256 hashes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4174832.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->