### PR TITLE
test(cargo-unit): codify cargoAudit off-by-default contract

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3016,8 +3016,13 @@ let
         message = "secret refs should reject unsafe relative names during eval";
       }
       {
-        assertion = cargoUnitWorkspace.policyChecks ? cargoAudit;
-        message = "cargo-unit workspaces should expose a cargo-audit policy check by default";
+        # cargoAudit is opt-in: lib/rust.nix's defaultPolicy leaves it disabled
+        # so a no-policy workspace never wires the advisory scan into
+        # policyChecks. The production builder (lib/rust-workspace.nix native
+        # graph) enables it explicitly. Codifying the off-by-default contract
+        # here guards against a silent flip back to the old workspace default.
+        assertion = !(cargoUnitWorkspace.policyChecks ? cargoAudit);
+        message = "cargo-unit workspaces should not expose cargo-audit unless the policy enables it";
       }
       {
         assertion = cargoUnitWorkspace.policyChecks ? clippy;


### PR DESCRIPTION
Fixes the red `.#checks.x86_64-linux.eval` (`ix-test-helpers`) on main.

The `cargoAudit.enable` refactor (1a0cca6) made `lib/rust.nix`'s `defaultPolicy` the single source of truth: cargoAudit off by default. But the helpers eval assertion still expected the no-policy `cargoUnitWorkspace` fixture to expose a cargoAudit policy check *by default* — the exact implicit default that refactor dropped — so eval went red.

Flip the assertion to the new contract: a no-policy workspace must **not** wire cargoAudit into `policyChecks`. Production (`lib/rust-workspace.nix` native graph) still opts in explicitly, so the enabled path stays covered.

Note: `cargoAuditCheck` is a lockfile-only `runCommand` (`--no-fetch --stale`, inherits just `Cargo.lock`), so it never rebuilds the workspace; this PR is about the contract, not build cost.

Validated: `nix eval .#checks.x86_64-linux.eval.drvPath` resolves with no assertion error.

Made with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Assert that `cargoAudit` is absent from `cargoUnitWorkspace.policyChecks` by default
> Updates the test in [tests/default.nix](https://github.com/indexable-inc/index/pull/546/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) to assert that `cargoAudit` is NOT present in `policyChecks` for a no-policy `cargo-unit` workspace, codifying that `cargoAudit` is opt-in and disabled by default. Adds comments explaining the opt-in nature of the check.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c70fb7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->