### PR TITLE
feat(rust): enable cargoAudit by default

### DIFF
--- a/lib/rust.nix
+++ b/lib/rust.nix
@@ -26,8 +26,14 @@ let
     # Opt-in: scans each unit's objects for functions that can reach a panic.
     # Off by default because it is a best-effort gate, not a soundness proof.
     denyPanics = false;
+    # On by default: cargoAuditCheck is an offline, lockfile-only runCommand
+    # (`cargo-audit audit --file Cargo.lock --no-fetch --stale` against the
+    # pinned advisory DB) that inherits only Cargo.lock, so it is decoupled from
+    # compilation and re-runs only when the lockfile or DB changes. Cheap enough
+    # to audit every workspace; opt out per-workspace with a named reason (e.g.
+    # lib/rust-workspace.nix disables it on the pure-build cross graph).
     cargoAudit = {
-      enable = false;
+      enable = true;
       db = defaultRustsecAdvisoryDb;
       deny = [ ];
       ignore = [ ];

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3016,13 +3016,11 @@ let
         message = "secret refs should reject unsafe relative names during eval";
       }
       {
-        # cargoAudit is opt-in: lib/rust.nix's defaultPolicy leaves it disabled
-        # so a no-policy workspace never wires the advisory scan into
-        # policyChecks. The production builder (lib/rust-workspace.nix native
-        # graph) enables it explicitly. Codifying the off-by-default contract
-        # here guards against a silent flip back to the old workspace default.
-        assertion = !(cargoUnitWorkspace.policyChecks ? cargoAudit);
-        message = "cargo-unit workspaces should not expose cargo-audit unless the policy enables it";
+        # cargoAudit is on by default (lib/rust.nix defaultPolicy): the advisory
+        # scan is an offline, lockfile-only runCommand, so every workspace gets
+        # it unless it opts out. A no-policy fixture must expose it.
+        assertion = cargoUnitWorkspace.policyChecks ? cargoAudit;
+        message = "cargo-unit workspaces should expose a cargo-audit policy check by default";
       }
       {
         assertion = cargoUnitWorkspace.policyChecks ? clippy;


### PR DESCRIPTION
Follow-up to #546. cargoAudit is cheap and offline, so turn it on by default.

`cargoAuditCheck` (lib/rust.nix) is a lockfile-only `runCommand`: `cargo-audit audit --file Cargo.lock --no-fetch --stale` against the pinned advisory DB, inheriting only `Cargo.lock`. It never compiles the workspace and re-runs only when the lockfile or DB changes, so there's no rebuild-the-world cost to justify keeping it off.

- Flip `lib/rust.nix` `defaultPolicy.cargoAudit.enable` false → true.
- Restore the tests assertion: a no-policy workspace exposes the cargoAudit policy check by default.

Real repo crates already audited via `lib/rust-workspace.nix`'s explicit native-graph pin, so this just makes the default match reality. Cross graph and coverage/bench fixtures still opt out explicitly.

Validated: `nix eval .#checks.x86_64-linux.eval.drvPath` (assertions green) and `nix build .#checks.x86_64-linux.rust-nix-cargo-unit-cargoAudit` (EXIT 0).

Made with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable `cargoAudit` by default in the Rust default policy
> Sets `cargoAudit.enable` to `true` in [lib/rust.nix](https://github.com/indexable-inc/index/pull/548/files#diff-48a6e5662552a99251870f1f4ee41d9ecef86c045ed1725a1f6116da5308dbd9), so all workspaces inheriting the default policy now run an offline advisory scan against `Cargo.lock` without any extra configuration. The check can be disabled explicitly per workspace. The test in [tests/default.nix](https://github.com/indexable-inc/index/pull/548/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) is updated to assert `cargoAudit` is present in `policyChecks` for a default cargo-unit workspace.
>
> Risk: existing workspaces that rely on the default policy will gain a new `cargoAudit` check; workspaces with vulnerable dependencies flagged by the advisory database may fail builds until the check is explicitly disabled or the dependency is addressed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e45400c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->