### PR TITLE
claude-code: raise tool-output truncation caps to trusted-config maxima

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -28,6 +28,29 @@ let
   manifest = lib.importJSON ./manifest.json;
   inherit (manifest) version;
 
+  # Tool-output truncation caps, declared as data (single source) and derived
+  # into wrapper flags below, rather than hand-written into the install phase. We
+  # run a trusted config (our own CLAUDE.md / AGENTS.md / hooks / MCP servers),
+  # so raise the CLI's own output knobs to its built-in maxima instead of letting
+  # output be silently pruned:
+  #   BASH_MAX_OUTPUT_LENGTH: default 30000 chars, binary clamp 150000
+  #   TASK_MAX_OUTPUT_LENGTH: default 32000 chars, clamp 160000
+  #   MAX_MCP_OUTPUT_TOKENS:  default ~25000 tokens, no clamp
+  outputCaps = {
+    BASH_MAX_OUTPUT_LENGTH = 150000;
+    TASK_MAX_OUTPUT_LENGTH = 160000;
+    MAX_MCP_OUTPUT_TOKENS = 200000;
+  };
+  # `--set-default` (not `--set`) so an explicit env or settings.json `env` value
+  # still overrides per machine.
+  outputCapFlags = lib.concatLists (
+    lib.mapAttrsToList (name: value: [
+      "--set-default"
+      name
+      (toString value)
+    ]) outputCaps
+  );
+
   inherit (stdenv.hostPlatform) system;
   target =
     manifest.platforms.${system}
@@ -148,11 +171,14 @@ stdenv.mkDerivation {
     # The store output is read-only, so the bundled self-updater can never
     # write; disable it and the install checks, and pin the bundled ripgrep to
     # the Nix one so PATH stays reproducible. The wrapper owns the version pin.
+    # Raise the output-truncation caps to trusted-config maxima (see `outputCaps`
+    # above).
     makeBinaryWrapper "$helper" $out/bin/${binName} \
       --inherit-argv0 \
       --set DISABLE_AUTOUPDATER 1 \
       --set DISABLE_INSTALLATION_CHECKS 1 \
       --set USE_BUILTIN_RIPGREP 0 \
+      ${lib.escapeShellArgs outputCapFlags} \
       --prefix PATH : ${
         lib.makeBinPath (
           [


### PR DESCRIPTION
Wrap `claude-code` to raise the CLI's own output-truncation caps via `--set-default` (declared as `outputCaps` data, derived into wrapper flags): BASH_MAX_OUTPUT_LENGTH 150000, TASK_MAX_OUTPUT_LENGTH 160000, MAX_MCP_OUTPUT_TOKENS 200000. We run a trusted config, so prefer full tool/MCP output over pruning; `--set-default` keeps per-machine env / settings.json overrides.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise claude-code tool output truncation caps to trusted-config maxima
> Sets default environment variables `BASH_MAX_OUTPUT_LENGTH=150000`, `TASK_MAX_OUTPUT_LENGTH=160000`, and `MAX_MCP_OUTPUT_TOKENS=200000` via `--set-default` in the [default.nix](https://github.com/indexable-inc/index/pull/550/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b) binary wrapper. These defaults can be overridden by explicit environment variables or `settings.json` values at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b38a71f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->