### PR TITLE
claude-code: default --debug + fold agent-teams into wrapper env defaults

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -28,27 +28,29 @@ let
   manifest = lib.importJSON ./manifest.json;
   inherit (manifest) version;
 
-  # Tool-output truncation caps, declared as data (single source) and derived
-  # into wrapper flags below, rather than hand-written into the install phase. We
-  # run a trusted config (our own CLAUDE.md / AGENTS.md / hooks / MCP servers),
-  # so raise the CLI's own output knobs to its built-in maxima instead of letting
-  # output be silently pruned:
-  #   BASH_MAX_OUTPUT_LENGTH: default 30000 chars, binary clamp 150000
-  #   TASK_MAX_OUTPUT_LENGTH: default 32000 chars, clamp 160000
-  #   MAX_MCP_OUTPUT_TOKENS:  default ~25000 tokens, no clamp
-  outputCaps = {
+  # Env defaults applied through the wrapper, declared as data (single source)
+  # and derived into flags below rather than hand-written into the install phase.
+  # `--set-default` (not `--set`) so an explicit env or settings.json `env` value
+  # still overrides per machine. Two groups:
+  #  - Output-truncation caps raised to the CLI's built-in maxima: we run a
+  #    trusted config (our own CLAUDE.md / AGENTS.md / hooks / MCP servers), so
+  #    prefer full output over pruning. BASH_MAX_OUTPUT_LENGTH default 30000
+  #    chars (binary clamp 150000); TASK_MAX_OUTPUT_LENGTH default 32000 (clamp
+  #    160000); MAX_MCP_OUTPUT_TOKENS default ~25000 tokens (no clamp).
+  #  - Feature toggles on by default fleet-wide: agent teams, still gated behind
+  #    the EXPERIMENTAL_ env var in this build.
+  wrapperEnvDefaults = {
     BASH_MAX_OUTPUT_LENGTH = 150000;
     TASK_MAX_OUTPUT_LENGTH = 160000;
     MAX_MCP_OUTPUT_TOKENS = 200000;
+    CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = 1;
   };
-  # `--set-default` (not `--set`) so an explicit env or settings.json `env` value
-  # still overrides per machine.
-  outputCapFlags = lib.concatLists (
+  envDefaultFlags = lib.concatLists (
     lib.mapAttrsToList (name: value: [
       "--set-default"
       name
       (toString value)
-    ]) outputCaps
+    ]) wrapperEnvDefaults
   );
 
   inherit (stdenv.hostPlatform) system;
@@ -171,14 +173,21 @@ stdenv.mkDerivation {
     # The store output is read-only, so the bundled self-updater can never
     # write; disable it and the install checks, and pin the bundled ripgrep to
     # the Nix one so PATH stays reproducible. The wrapper owns the version pin.
-    # Raise the output-truncation caps to trusted-config maxima (see `outputCaps`
-    # above).
+    # Apply our env defaults (see `wrapperEnvDefaults` above).
+    #
+    # Start in debug mode by default (`--debug`): the CLI writes operational
+    # telemetry (HTTP/API timings, auto-mode classifier, MCP/LSP lifecycle,
+    # startup phases, permission decisions) to ~/.claude/debug/ for
+    # troubleshooting and the optimize history analysis. It does not pollute
+    # `claude -p` stdout (verified), and those logs are pruned on the normal
+    # cleanupPeriodDays sweep, so set a long retention in settings to keep them.
     makeBinaryWrapper "$helper" $out/bin/${binName} \
       --inherit-argv0 \
+      --add-flags --debug \
       --set DISABLE_AUTOUPDATER 1 \
       --set DISABLE_INSTALLATION_CHECKS 1 \
       --set USE_BUILTIN_RIPGREP 0 \
-      ${lib.escapeShellArgs outputCapFlags} \
+      ${lib.escapeShellArgs envDefaultFlags} \
       --prefix PATH : ${
         lib.makeBinPath (
           [


### PR DESCRIPTION
Start `claude` in `--debug` by default (operational telemetry to ~/.claude/debug for troubleshooting + the optimize analysis; verified it does not pollute `claude -p` stdout). Move `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` into the declarative `wrapperEnvDefaults` (still gated behind the experimental env var in 2.1.159, so kept and defaulted fleet-wide). Debug logs prune on the normal `cleanupPeriodDays` sweep — pair with a long retention in settings.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable `--debug` by default and add `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` to claude-code wrapper defaults
> - Adds `--add-flags --debug` to the `makeBinaryWrapper` invocation in [default.nix](https://github.com/indexable-inc/index/pull/551/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b), enabling debug logging for all wrapped binary invocations.
> - Folds `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` into `wrapperEnvDefaults` (renamed from `outputCaps`), alongside the existing output truncation vars (`BASH_MAX_OUTPUT_LENGTH`, `TASK_MAX_OUTPUT_LENGTH`, `MAX_MCP_OUTPUT_TOKENS`).
> - Renames `outputCapFlags` to `envDefaultFlags` to reflect its broader scope.
> - Behavioral Change: `--debug` is now always passed; users who want to suppress debug output must explicitly override this flag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96eb112.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->