### PR TITLE
claude-code: ship cleanupPeriodDays via --settings (package settings default)

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -10,6 +10,7 @@
   socat,
   nix,
   gnupg,
+  writeText,
   binName ? "claude",
   # Only the flake package set injects the Nushell writer; the overlay eval
   # context does not. The updater is a maintainer-facing flake output, so the
@@ -51,6 +52,22 @@ let
       name
       (toString value)
     ]) wrapperEnvDefaults
+  );
+
+  # Settings-key defaults that have no env knob, shipped as a JSON the wrapper
+  # injects via `--settings`. The package wraps the binary, so it can carry env
+  # vars and CLI flags but not a settings.json *key* directly; `--settings` adds
+  # a `flagSettings` source that MERGES per-key with the user's settings
+  # (precedence: managed > --settings > local > project > user; arrays concat).
+  # So these are fleet defaults that override a user's value but can still be
+  # overridden by managed settings, and they leave every other user key intact.
+  #   cleanupPeriodDays: keep transcripts + the wrapper's --debug logs ~1yr for
+  #     the optimize analysis and troubleshooting (CLI default 30).
+  settingsDefaults = {
+    cleanupPeriodDays = 365;
+  };
+  settingsDefaultsFile = writeText "claude-code-default-settings.json" (
+    builtins.toJSON settingsDefaults
   );
 
   inherit (stdenv.hostPlatform) system;
@@ -179,11 +196,13 @@ stdenv.mkDerivation {
     # telemetry (HTTP/API timings, auto-mode classifier, MCP/LSP lifecycle,
     # startup phases, permission decisions) to ~/.claude/debug/ for
     # troubleshooting and the optimize history analysis. It does not pollute
-    # `claude -p` stdout (verified), and those logs are pruned on the normal
-    # cleanupPeriodDays sweep, so set a long retention in settings to keep them.
+    # `claude -p` stdout (verified). Those logs prune on the cleanupPeriodDays
+    # sweep, so we also ship a long retention via --settings (see
+    # `settingsDefaults` above).
     makeBinaryWrapper "$helper" $out/bin/${binName} \
       --inherit-argv0 \
       --add-flags --debug \
+      --add-flags "--settings ${settingsDefaultsFile}" \
       --set DISABLE_AUTOUPDATER 1 \
       --set DISABLE_INSTALLATION_CHECKS 1 \
       --set USE_BUILTIN_RIPGREP 0 \


### PR DESCRIPTION
Carry a settings.json key in the package: ship `settingsDefaults` as a JSON (`writeText`) and inject via `--settings`. Merges per-key at `flagSettings` precedence (above user, below managed) so other user settings stay intact. `cleanupPeriodDays=365` keeps transcripts + the wrapper's `--debug` logs ~1yr for the optimize analysis.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `cleanupPeriodDays` to 365 by default in the claude-code package via `--settings`
> Creates a JSON settings file in the Nix store containing `cleanupPeriodDays = 365` and passes it to the wrapped `claude` binary via `--add-flags "--settings ..."` in [default.nix](https://github.com/indexable-inc/index/pull/553/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b). This ensures the retention period is set package-wide without requiring user configuration. Risk: the `--settings` flag is always injected, so user-supplied `--settings` flags may conflict depending on how Claude merges `flagSettings`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d1c587.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->