### PR TITLE
claude-code: append --settings so a user CLI --settings wins (fix shadowing)

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -56,11 +56,17 @@ let
 
   # Settings-key defaults that have no env knob, shipped as a JSON the wrapper
   # injects via `--settings`. The package wraps the binary, so it can carry env
-  # vars and CLI flags but not a settings.json *key* directly; `--settings` adds
-  # a `flagSettings` source that MERGES per-key with the user's settings
-  # (precedence: managed > --settings > local > project > user; arrays concat).
-  # So these are fleet defaults that override a user's value but can still be
-  # overridden by managed settings, and they leave every other user key intact.
+  # vars and CLI flags but not a settings.json *key* directly. `--settings` adds
+  # a `flagSettings` layer that merges per-key with the other settings sources
+  # (precedence: managed > flagSettings > local > project > user; arrays concat),
+  # so it overrides a user's settings.json value but leaves every other key
+  # intact, and managed settings can still override it.
+  #
+  # IMPORTANT: between two `--settings` *flags* the CLI is first-wins (they do
+  # NOT merge with each other), so this is injected with `--append-flags` (last
+  # in argv): a user who passes their own `--settings` on the CLI wins (theirs
+  # comes first), and ours applies only when they pass none. `--add-flags` would
+  # prepend ours and silently shadow a user's `--settings`.
   #   cleanupPeriodDays: keep transcripts + the wrapper's --debug logs ~1yr for
   #     the optimize analysis and troubleshooting (CLI default 30).
   settingsDefaults = {
@@ -202,7 +208,7 @@ stdenv.mkDerivation {
     makeBinaryWrapper "$helper" $out/bin/${binName} \
       --inherit-argv0 \
       --add-flags --debug \
-      --add-flags "--settings ${settingsDefaultsFile}" \
+      --append-flags "--settings ${settingsDefaultsFile}" \
       --set DISABLE_AUTOUPDATER 1 \
       --set DISABLE_INSTALLATION_CHECKS 1 \
       --set USE_BUILTIN_RIPGREP 0 \


### PR DESCRIPTION
Follow-up to the package settings default. `--settings` is first-wins (two flags do not merge), and `--add-flags` prepended the baked one, so a user's own `claude --settings ...` was silently ignored. Switch to `--append-flags` so the user's (earlier) flag wins, while the package default still applies when none is passed. Verified: with no user flag the baked settings still load (flagSettings active); `--settings` is accepted in append position.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `--settings` flag shadowing in claude-code wrapper by appending default instead of prepending
> The [default.nix](https://github.com/indexable-inc/index/pull/554/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b) wrapper previously used `--add-flags` to inject `--settings`, which placed it before any user-supplied flags. Since Claude Code's `--settings` is first-wins, this prevented users from overriding the default settings file. Switching to `--append-flags` places the package default last in argv, so a user-supplied `--settings` takes precedence.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 94678ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->