### PR TITLE
Add reusable CI progress boss bars (services.ciBars)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -164,6 +164,16 @@
           indexPackages = system: (collect "packages").${system};
           portableServicesModule = ix.portableServices.homeModule;
         };
+        # Reusable workstation module: draw one Minecraft boss bar per in-flight
+        # GitHub Actions run across a set of repos (green = running, filled by
+        # elapsed / average duration; purple = queued/unpicked). Import it and set
+        # `services.ciBars = { enable = true; repos = [ ... ]; }`. Closed over the
+        # per-system packages so it resolves the `bossbar` CLI for the host. See
+        # packages/bossbar-overlay/ci-bars-home-module.nix.
+        ci-bars = import ./packages/bossbar-overlay/ci-bars-home-module.nix {
+          indexPackages = system: (collect "packages").${system};
+          portableServicesModule = ix.portableServices.homeModule;
+        };
         # Workstation-facing module to sync corpus sources (agent/shell history,
         # Slack/Linear exports, git repos) to an S3/R2 parquet archive and/or
         # Mixedbread, as a portable timer service. Closed over the per-system

--- a/packages/bossbar-overlay/ci-bars-home-module.nix
+++ b/packages/bossbar-overlay/ci-bars-home-module.nix
@@ -1,0 +1,163 @@
+# home-manager module exposing `services.ciBars`: draw one Minecraft boss bar per
+# in-flight GitHub Actions run across a set of repos, as the current user.
+#
+# This is a reusable, self-contained component: anyone who imports it and sets
+#   services.ciBars = { enable = true; repos = [ "owner/name" ]; };
+# gets a live CI dashboard on the boss bar overlay, with no personal glue. A
+# running run shows a GREEN bar filled by elapsed / the workflow's recent average
+# duration; a queued or not-yet-picked-up run shows a thin PURPLE bar. Bars clear
+# as runs finish. The palette is deliberately outside the ix-downtime outage
+# palette (red/yellow/blue) so CI progress and outages never read alike. It is
+# silent by design: the bar fill is the signal.
+#
+# Closed over the per-system flake package set (to resolve the `bossbar` CLI for
+# the host) and the portable-services home module (so one spec renders a native
+# launchd agent on macOS and a native systemd user unit + timer on Linux). Same
+# shape as packages/indexer/home-module.nix.
+#
+# Needs `gh` authenticated for the host user, and the boss bar overlay running to
+# be visible (on a headless host it just writes harmless overlay rows). The watch
+# script itself is the plain, env-driven ./ci-bars.sh.
+{
+  indexPackages,
+  portableServicesModule,
+}:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkOption
+    mkEnableOption
+    mkIf
+    types
+    ;
+
+  cfg = config.services.ciBars;
+
+  defaultBossbar = (indexPackages pkgs.stdenv.hostPlatform.system).bossbar;
+
+  # Checked replacement for the lint-banned writeShellApplication: writeTextFile
+  # gives a real bash script, runtimeInputs are prepended to PATH like
+  # writeShellApplication does, and `bash -n` + shellcheck run in the build so a
+  # syntax or shellcheck-class bug fails the derivation instead of surfacing at
+  # runtime. The body assumes `set -euo pipefail` + runtimeInputs on PATH. Same
+  # escape hatch as lib/apple-sdk-toolchain.nix's `mkScript`; kept inline so this
+  # module is self-contained and copy-pasteable for other people.
+  mkBashApp =
+    {
+      name,
+      text,
+      runtimeInputs ? [ ],
+    }:
+    pkgs.writeTextFile {
+      inherit name;
+      executable = true;
+      destination = "/bin/${name}";
+      text = ''
+        #!${pkgs.runtimeShell}
+        set -euo pipefail
+        export PATH=${lib.makeBinPath runtimeInputs}''${PATH:+:$PATH}
+        ${text}
+      '';
+      checkPhase = ''
+        ${lib.getExe' pkgs.bash "bash"} -n "$out/bin/${name}"
+        ${lib.getExe pkgs.shellcheck} --shell=bash --severity=warning "$out/bin/${name}"
+      '';
+    };
+
+  ciBars = mkBashApp {
+    name = "ci-bars";
+    runtimeInputs = [
+      pkgs.gh
+      pkgs.jq
+      pkgs.sqlite
+      pkgs.coreutils
+      pkgs.perl # the intrinsic flock(2) non-overlap guard (no flock(1) on macOS)
+      cfg.package
+    ];
+    text = builtins.readFile ./ci-bars.sh;
+  };
+in
+{
+  imports = [ portableServicesModule ];
+
+  options.services.ciBars = {
+    enable = mkEnableOption "the GitHub Actions CI progress boss bars (one bar per in-flight run)";
+
+    package = mkOption {
+      type = types.package;
+      default = defaultBossbar;
+      defaultText = lib.literalExpression "index.packages.\${system}.bossbar";
+      description = "The `bossbar` CLI the watcher writes the overlay rows with.";
+    };
+
+    repos = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [
+        "indexable-inc/ix"
+        "indexable-inc/index"
+      ];
+      description = "GitHub `owner/name` repos to draw in-flight CI progress bars for.";
+    };
+
+    interval = mkOption {
+      type = types.ints.positive;
+      default = 20;
+      description = "Poll each watched repo for in-flight runs every N seconds.";
+    };
+
+    avgTtl = mkOption {
+      type = types.ints.positive;
+      default = 3600;
+      description = "Seconds to cache a workflow's average successful-run duration before re-deriving it.";
+    };
+
+    defaultAvg = mkOption {
+      type = types.ints.positive;
+      default = 300;
+      description = "Fallback average duration (seconds) for a workflow with no green history yet, so its bar still advances at a sane rate.";
+    };
+
+    maxBars = mkOption {
+      type = types.ints.positive;
+      default = 12;
+      description = "Cap on the number of bars drawn per repo per poll, so a busy moment cannot flood the screen.";
+    };
+
+    logDir = mkOption {
+      type = types.str;
+      default =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "${config.home.homeDirectory}/Library/Logs"
+        else
+          "${config.home.homeDirectory}/.local/state";
+      defaultText = lib.literalMD "`~/Library/Logs` on macOS, `~/.local/state` on Linux";
+      description = "Directory the watcher appends its stdout/stderr log to.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.portable.ci-bars = {
+      description = "GitHub Actions CI progress boss bars";
+      command = [ (lib.getExe' ciBars "ci-bars") ];
+      inherit (cfg) interval;
+      # All tunables flow in as environment so the script stays a plain file and
+      # the options are the single source of truth.
+      environment = {
+        CI_BARS_REPOS = lib.concatStringsSep " " cfg.repos;
+        CI_BARS_AVG_TTL = toString cfg.avgTtl;
+        CI_BARS_DEFAULT_AVG = toString cfg.defaultAvg;
+        CI_BARS_MAX = toString cfg.maxBars;
+      };
+      standardOutPath = "${cfg.logDir}/ci-bars.log";
+      standardErrorPath = "${cfg.logDir}/ci-bars.log";
+      # runAtLoad (default true) draws the bars on load; the script's own flock
+      # guard prevents overlap; the Label defaults to the space-free convention.
+    };
+  };
+}

--- a/packages/bossbar-overlay/ci-bars.sh
+++ b/packages/bossbar-overlay/ci-bars.sh
@@ -41,6 +41,10 @@ mkdir -p "$state_dir"
 db="$state_dir/state.db" # historical per-workflow average cache (not the overlay DB)
 avg_ttl="${CI_BARS_AVG_TTL:-3600}"
 default_avg="${CI_BARS_DEFAULT_AVG:-300}"
+# `:-` only defaults unset/empty, so an explicit CI_BARS_DEFAULT_AVG=0 would slip
+# through and later divide-by-zero (set -e aborts the watcher). Clamp to a sane
+# floor so the standalone/env-driven path can't be wedged by a 0.
+[ "${default_avg:-0}" -gt 0 ] 2>/dev/null || default_avg=300
 max_bars="${CI_BARS_MAX:-12}"
 
 # Non-overlap guard, intrinsic to the watcher so the portable service can fire it
@@ -71,9 +75,16 @@ sq() { printf "%s" "${1//\'/\'\'}"; }
 # SELECTs) to find a bar by url and to enumerate stale CI bars, but every write
 # still goes through the CLI, which owns the schema.
 bdb="$(bossbar db 2>/dev/null || true)"
+# `bossbar db` computes the path even when the file does not exist yet, so an
+# empty result means the `bossbar` binary itself is missing/broken. Bail rather
+# than fall through: without the DB path we cannot match a run to its existing
+# bar, so `add` would re-INSERT a duplicate row every poll (a bar storm).
+if [ -z "$bdb" ]; then
+  echo "ci-bars: cannot resolve the overlay DB (bossbar db); nothing to do"
+  exit 0
+fi
 
 bar_id_for_url() {
-  [ -n "$bdb" ] || { printf ''; return; }
   sqlite3 "$bdb" "SELECT id FROM bossbars WHERE url = '$(sq "$1")' ORDER BY id LIMIT 1;" 2>/dev/null || printf ''
 }
 
@@ -196,9 +207,17 @@ Progress is estimated from the average of recent successful runs of this workflo
         bossbar add "$bar_title" --color "$color" --overlay progress --progress "$prog" --position -1 --url "$url" --description "$desc" 2>/dev/null || true
       fi
     else
-      # Existing bar: refresh fill/color/title in place. Leave `since` alone so an
-      # already-ticking clock survives polls and restarts.
-      bossbar set "$id" --title "$bar_title" --color "$color" --progress "$prog" --description "$desc" 2>/dev/null || true
+      # Existing bar: refresh fill/color/title in place. A run first seen while
+      # QUEUED was added with no `since` (purple, no clock); once it starts
+      # running we must stamp `since` so the live elapsed timer begins. Only stamp
+      # when the bar has none yet, so an already-ticking clock survives polls and
+      # restarts (mirrors ix-downtime.sh's heal-in-place rule).
+      cur_since="$(sqlite3 "$bdb" "SELECT COALESCE(since,0) FROM bossbars WHERE id = $id;" 2>/dev/null || printf '0')"
+      if [ "${startsec:-0}" -gt 0 ] 2>/dev/null && [ "${cur_since:-0}" -le 0 ] 2>/dev/null; then
+        bossbar set "$id" --title "$bar_title" --color "$color" --progress "$prog" --since "$startsec" --description "$desc" 2>/dev/null || true
+      else
+        bossbar set "$id" --title "$bar_title" --color "$color" --progress "$prog" --description "$desc" 2>/dev/null || true
+      fi
     fi
   done < <(printf '%s' "$runs" | jq -r --argjson max "$max_bars" '
     [ .[] | select((.status // "completed") != "completed") ]

--- a/packages/bossbar-overlay/ci-bars.sh
+++ b/packages/bossbar-overlay/ci-bars.sh
@@ -1,8 +1,13 @@
-# Body of the `ci-bars` bash app (see users/andrewgazelka/home.nix).
+# Body of the `ci-bars` bash app (see ci-bars-home-module.nix).
 # No shebang / `set` line: the mkBashApp wrapper supplies bash + `set -euo
 # pipefail` and bakes gh/jq/sqlite/coreutils/perl + the bossbar CLI onto PATH via
-# runtimeInputs. The module bakes one placeholder at build time:
-#   @REPOS@   the watched repos as a quoted bash-array body
+# runtimeInputs. Everything tunable comes from the environment so the script is a
+# plain, testable file with no build-time string baking:
+#   CI_BARS_REPOS        space-separated `owner/name` repos to watch (required)
+#   CI_BARS_AVG_TTL      seconds to cache a workflow's average duration (3600)
+#   CI_BARS_DEFAULT_AVG  fallback average when a workflow has no green history (300)
+#   CI_BARS_MAX          max bars per repo per poll (12)
+#   CI_BARS_STATE        state dir for the average cache + lock ($HOME/.cache/ci-bars)
 #
 # Draws a Minecraft boss bar PER in-flight GitHub Actions run across the watched
 # repos, so a glance says what CI is doing right now. This is the live-progress
@@ -47,7 +52,14 @@ max_bars="${CI_BARS_MAX:-12}"
 exec 9>"$state_dir/poll.lock"
 perl -e 'use Fcntl ":flock"; flock(STDIN, LOCK_EX | LOCK_NB) or exit 1' <&9 || exit 0
 
-repos=(@REPOS@)
+# Repos to watch come from the environment (the module sets CI_BARS_REPOS from its
+# `repos` option). `owner/name` slugs never contain spaces, so a plain word-split
+# is safe and keeps the script free of build-time baking.
+read -ra repos <<<"${CI_BARS_REPOS:-}"
+if [ "${#repos[@]}" -eq 0 ]; then
+  echo "ci-bars: no repos configured (set CI_BARS_REPOS); nothing to do"
+  exit 0
+fi
 
 now="$(date +%s)"
 

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -16,6 +16,13 @@
 #     Nothing is spoken;
 #   * the full-screen karma feed overlay it announces onto (`merge-orb-feed`),
 #     which renders both pop kinds and plays their per-kind sounds;
+#   * the CI progress watcher (`ci-bars`), which draws one Minecraft boss bar per
+#     in-flight GitHub Actions run across the watched repos (green, filled by
+#     elapsed / average-duration; purple while a run is still queued or not yet
+#     picked up by a runner) and clears each as the run finishes. It is silent:
+#     pr-watch owns the CI sounds, so the bar fill is the whole signal.
+#     Deliberately a different palette from the ix-downtime outage bars
+#     (red/yellow/blue) so the two never read alike;
 #   * the token-free `/optimize` history scan (`optimize-scan`);
 #   * the shared "play a gentle sound, then speak it detached" helper
 #     (`say-detached`), now used only by the ix-downtime watcher.
@@ -202,6 +209,30 @@ let
         ]
         (builtins.readFile ./scripts/pr-watch.sh);
   };
+
+  # The CI progress watcher: one green progress boss bar per in-flight GitHub
+  # Actions run across the watched repos (purple while a run is still queued or
+  # unpicked), the fill estimated from each workflow's recent average duration.
+  # Silent (pr-watch owns the CI success/failure sounds); it only reconciles the
+  # overlay's CI bars. gh/jq read the runs, sqlite caches the per-workflow
+  # averages, coreutils provides date/printf, perl the flock guard, and the
+  # bossbar CLI writes the bars. @REPOS@ is baked from the option.
+  ciBars = mkBashApp {
+    name = "ci-bars";
+    runtimeInputs = [
+      pkgs.gh
+      pkgs.jq
+      pkgs.sqlite
+      pkgs.coreutils
+      pkgs.perl
+      indexPkgs.bossbar
+    ];
+    text =
+      builtins.replaceStrings
+        [ "@REPOS@" ]
+        [ (lib.concatMapStringsSep " " lib.escapeShellArg cfg.ciBars.repos) ]
+        (builtins.readFile ./scripts/ci-bars.sh);
+  };
 in
 {
   imports = [ portableServicesModule ];
@@ -306,6 +337,35 @@ in
       };
     };
 
+    ciBars = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Run the CI progress watcher: one green boss bar per in-flight GitHub
+          Actions run across `repos` (purple while a run is still queued or not
+          yet picked up by a runner), filled by elapsed / average duration. Needs
+          `gh` authenticated for the host user and the boss bar overlay running to
+          be visible. Harmless on a headless host (it just writes overlay rows).
+        '';
+      };
+
+      interval = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 20;
+        description = "Poll each watched repo for in-flight runs every N seconds.";
+      };
+
+      repos = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [
+          "indexable-inc/ix"
+          "indexable-inc/index"
+        ];
+        description = "GitHub `owner/name` repos to draw in-flight CI progress bars for.";
+      };
+    };
+
     sound.linuxSayCommand = lib.mkOption {
       type = lib.types.str;
       default = "spd-say";
@@ -382,6 +442,18 @@ in
           # runAtLoad (default true) fires the first poll immediately; the
           # Label defaults to the space-free home convention. Overlap is handled
           # intrinsically by the script's own flock guard, so no escape hatch.
+        };
+      })
+      (lib.mkIf cfg.ciBars.enable {
+        ci-bars = {
+          description = "GitHub Actions CI progress boss bars";
+          command = [ (lib.getExe' ciBars "ci-bars") ];
+          interval = cfg.ciBars.interval;
+          standardOutPath = "${cfg.logDir}/ci-bars.log";
+          standardErrorPath = "${cfg.logDir}/ci-bars.log";
+          # runAtLoad (default true) draws the bars on load; the script's own
+          # flock guard prevents overlap; the Label defaults to the space-free
+          # home convention. No launchd/systemd escape hatch needed.
         };
       })
       (lib.mkIf cfg.bossbarOverlay.enable {

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -16,13 +16,14 @@
 #     Nothing is spoken;
 #   * the full-screen karma feed overlay it announces onto (`merge-orb-feed`),
 #     which renders both pop kinds and plays their per-kind sounds;
-#   * the CI progress watcher (`ci-bars`), which draws one Minecraft boss bar per
-#     in-flight GitHub Actions run across the watched repos (green, filled by
+#   * the CI progress bars (`services.ciBars`, the reusable
+#     packages/bossbar-overlay/ci-bars-home-module.nix), which draw one Minecraft
+#     boss bar per in-flight GitHub Actions run across our repos (green, filled by
 #     elapsed / average-duration; purple while a run is still queued or not yet
-#     picked up by a runner) and clears each as the run finishes. It is silent:
-#     pr-watch owns the CI sounds, so the bar fill is the whole signal.
-#     Deliberately a different palette from the ix-downtime outage bars
-#     (red/yellow/blue) so the two never read alike;
+#     picked up by a runner) and clear each as the run finishes. Silent (pr-watch
+#     owns the CI sounds) and a different palette from the ix-downtime outage bars
+#     (red/yellow/blue) so the two never read alike. This module just imports that
+#     component and turns it on with our repos;
 #   * the token-free `/optimize` history scan (`optimize-scan`);
 #   * the shared "play a gentle sound, then speak it detached" helper
 #     (`say-detached`), now used only by the ix-downtime watcher.
@@ -210,32 +211,18 @@ let
         (builtins.readFile ./scripts/pr-watch.sh);
   };
 
-  # The CI progress watcher: one green progress boss bar per in-flight GitHub
-  # Actions run across the watched repos (purple while a run is still queued or
-  # unpicked), the fill estimated from each workflow's recent average duration.
-  # Silent (pr-watch owns the CI success/failure sounds); it only reconciles the
-  # overlay's CI bars. gh/jq read the runs, sqlite caches the per-workflow
-  # averages, coreutils provides date/printf, perl the flock guard, and the
-  # bossbar CLI writes the bars. @REPOS@ is baked from the option.
-  ciBars = mkBashApp {
-    name = "ci-bars";
-    runtimeInputs = [
-      pkgs.gh
-      pkgs.jq
-      pkgs.sqlite
-      pkgs.coreutils
-      pkgs.perl
-      indexPkgs.bossbar
-    ];
-    text =
-      builtins.replaceStrings
-        [ "@REPOS@" ]
-        [ (lib.concatMapStringsSep " " lib.escapeShellArg cfg.ciBars.repos) ]
-        (builtins.readFile ./scripts/ci-bars.sh);
+  # The CI progress bars are a standalone reusable component, not personal glue:
+  # this just composes it (imported below, turned on in config). Anyone can do
+  # the same with `services.ciBars = { enable = true; repos = [ ... ]; }`.
+  ciBarsModule = import ../../packages/bossbar-overlay/ci-bars-home-module.nix {
+    inherit indexPackages portableServicesModule;
   };
 in
 {
-  imports = [ portableServicesModule ];
+  imports = [
+    portableServicesModule
+    ciBarsModule
+  ];
 
   options.users.andrewgazelka = {
     enable = lib.mkEnableOption "andrewgazelka's personal services (ix-downtime watcher + boss bar overlay)";
@@ -337,34 +324,9 @@ in
       };
     };
 
-    ciBars = {
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = ''
-          Run the CI progress watcher: one green boss bar per in-flight GitHub
-          Actions run across `repos` (purple while a run is still queued or not
-          yet picked up by a runner), filled by elapsed / average duration. Needs
-          `gh` authenticated for the host user and the boss bar overlay running to
-          be visible. Harmless on a headless host (it just writes overlay rows).
-        '';
-      };
-
-      interval = lib.mkOption {
-        type = lib.types.ints.positive;
-        default = 20;
-        description = "Poll each watched repo for in-flight runs every N seconds.";
-      };
-
-      repos = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        default = [
-          "indexable-inc/ix"
-          "indexable-inc/index"
-        ];
-        description = "GitHub `owner/name` repos to draw in-flight CI progress bars for.";
-      };
-    };
+    # CI progress bars are configured through the reusable `services.ciBars`
+    # module (imported above); this module just turns it on with our repos in
+    # `config`. No personal options needed here.
 
     sound.linuxSayCommand = lib.mkOption {
       type = lib.types.str;
@@ -444,18 +406,6 @@ in
           # intrinsically by the script's own flock guard, so no escape hatch.
         };
       })
-      (lib.mkIf cfg.ciBars.enable {
-        ci-bars = {
-          description = "GitHub Actions CI progress boss bars";
-          command = [ (lib.getExe' ciBars "ci-bars") ];
-          interval = cfg.ciBars.interval;
-          standardOutPath = "${cfg.logDir}/ci-bars.log";
-          standardErrorPath = "${cfg.logDir}/ci-bars.log";
-          # runAtLoad (default true) draws the bars on load; the script's own
-          # flock guard prevents overlap; the Label defaults to the space-free
-          # home convention. No launchd/systemd escape hatch needed.
-        };
-      })
       (lib.mkIf cfg.bossbarOverlay.enable {
         bossbar-overlay = {
           description = "Minecraft boss bar overlay";
@@ -484,5 +434,15 @@ in
         };
       })
     ];
+
+    # Compose the reusable CI progress bars (the `services.ciBars` module imported
+    # above): one boss bar per in-flight Actions run on our repos. Everything else
+    # (script, palette, average-duration logic) lives in that shared component, so
+    # this is the whole personal config for it.
+    services.ciBars = {
+      enable = true;
+      repos = cfg.prWatch.repos;
+      logDir = cfg.logDir;
+    };
   };
 }

--- a/users/andrewgazelka/scripts/ci-bars.sh
+++ b/users/andrewgazelka/scripts/ci-bars.sh
@@ -1,0 +1,214 @@
+# Body of the `ci-bars` bash app (see users/andrewgazelka/home.nix).
+# No shebang / `set` line: the mkBashApp wrapper supplies bash + `set -euo
+# pipefail` and bakes gh/jq/sqlite/coreutils/perl + the bossbar CLI onto PATH via
+# runtimeInputs. The module bakes one placeholder at build time:
+#   @REPOS@   the watched repos as a quoted bash-array body
+#
+# Draws a Minecraft boss bar PER in-flight GitHub Actions run across the watched
+# repos, so a glance says what CI is doing right now. This is the live-progress
+# companion to the [[ix-downtime]] outage bars (red/yellow/blue) and the
+# [[pr-watch]] karma feed (merge orb / failure villager): those react to discrete
+# events, this one reconciles a continuous "what's running" view. It is SILENT,
+# because pr-watch already owns the success/failure sound; here the bar fill is
+# the whole signal.
+#
+# Color is deliberately OUTSIDE the downtime palette so the two never read as the
+# same thing:
+#   - in_progress -> green, progress = elapsed / historical-average duration;
+#   - queued/waiting -> purple, a thin bar (no runner yet, so no elapsed clock).
+#
+# Progress for a running job is estimated from the mean wall-clock of the last
+# few SUCCESSFUL runs of that same workflow (cached in SQLite, refreshed at most
+# once per CI_BARS_AVG_TTL), clamped to [0.02, 0.97] so a bar never shows empty
+# and never shows full until the run actually finishes. The overlay also ticks a
+# live elapsed timer in the title from the bar's `since` (set to the run's start),
+# so the human sees both "about this far" and "for this long".
+#
+# A bar's identity is the run URL (unique per run), so CI bars never collide with
+# the downtime bars (which point at the status page) and a run heals in place
+# across polls. When a run leaves the in-flight set (it completed, was cancelled,
+# or fell off the list) its bar is removed on the next poll: we enumerate every
+# overlay row whose url is an Actions run and drop any not in the current active
+# set. pr-watch handles the completion sound, so this just clears the visual.
+
+state_dir="${CI_BARS_STATE:-$HOME/.cache/ci-bars}"
+mkdir -p "$state_dir"
+db="$state_dir/state.db" # historical per-workflow average cache (not the overlay DB)
+avg_ttl="${CI_BARS_AVG_TTL:-3600}"
+default_avg="${CI_BARS_DEFAULT_AVG:-300}"
+max_bars="${CI_BARS_MAX:-12}"
+
+# Non-overlap guard, intrinsic to the watcher so the portable service can fire it
+# on a fixed interval with no external lock wrapper. Take a NON-BLOCKING
+# exclusive flock on fd 9; if a previous fire still holds it, skip this one
+# silently. bash keeps fd 9 open for the whole run, so the lock is held until
+# exit/crash (the kernel drops it the instant the holder dies). perl is always
+# present on macOS (/usr/bin/perl) and on Linux; there is no flock(1) on macOS.
+exec 9>"$state_dir/poll.lock"
+perl -e 'use Fcntl ":flock"; flock(STDIN, LOCK_EX | LOCK_NB) or exit 1' <&9 || exit 0
+
+repos=(@REPOS@)
+
+now="$(date +%s)"
+
+# Double single quotes so a value carrying an apostrophe (a branch or workflow
+# name can) cannot break out of a SQL string literal in the read-only lookups.
+sq() { printf "%s" "${1//\'/\'\'}"; }
+
+# The overlay DB the `bossbar` CLI writes; we read it directly (read-only
+# SELECTs) to find a bar by url and to enumerate stale CI bars, but every write
+# still goes through the CLI, which owns the schema.
+bdb="$(bossbar db 2>/dev/null || true)"
+
+bar_id_for_url() {
+  [ -n "$bdb" ] || { printf ''; return; }
+  sqlite3 "$bdb" "SELECT id FROM bossbars WHERE url = '$(sq "$1")' ORDER BY id LIMIT 1;" 2>/dev/null || printf ''
+}
+
+# ISO-8601 (e.g. 2026-06-01T22:10:05Z) -> epoch. coreutils' GNU `date` is on
+# PATH ahead of macOS's BSD date via runtimeInputs, so `-d` works on both; keep
+# the BSD form as a belt-and-braces fallback in case PATH ordering ever shifts.
+iso_to_epoch() {
+  local s="${1:-}"
+  [ -n "$s" ] || { printf '0'; return; }
+  date -u -d "$s" +%s 2>/dev/null && return
+  date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$s" +%s 2>/dev/null || printf '0'
+}
+
+# Average wall-clock of recent successful runs of one workflow, cached so we do
+# not re-derive it every poll. Falls back to $default_avg when the workflow has
+# no green history yet (a brand-new or always-red workflow), so a bar still
+# advances at a sane rate instead of pinning to the floor.
+sqlite3 "$db" >/dev/null <<'SQL'
+PRAGMA journal_mode=WAL;
+CREATE TABLE IF NOT EXISTS wf_avg(
+  repo       TEXT NOT NULL,
+  wf         TEXT NOT NULL,
+  avg_secs   INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (repo, wf)
+);
+SQL
+
+get_avg() {
+  local repo="$1" wf="$2" cached upd rows st en se ee d total count avg
+  cached="$(sqlite3 "$db" "SELECT avg_secs FROM wf_avg WHERE repo='$(sq "$repo")' AND wf='$(sq "$wf")';" 2>/dev/null || printf '')"
+  upd="$(sqlite3 "$db" "SELECT updated_at FROM wf_avg WHERE repo='$(sq "$repo")' AND wf='$(sq "$wf")';" 2>/dev/null || printf '0')"
+  upd="${upd:-0}"
+  if [ -n "$cached" ] && [ "$((now - upd))" -lt "$avg_ttl" ]; then
+    printf '%s' "$cached"
+    return
+  fi
+  rows="$(gh run list --repo "$repo" --workflow "$wf" --status success \
+    --json startedAt,updatedAt --limit 20 2>/dev/null \
+    | jq -r '.[] | [.startedAt, .updatedAt] | @tsv')" || rows=""
+  total=0
+  count=0
+  while IFS=$'\t' read -r st en; do
+    [ -n "$st" ] && [ -n "$en" ] || continue
+    se="$(iso_to_epoch "$st")"
+    ee="$(iso_to_epoch "$en")"
+    d=$((ee - se))
+    [ "$d" -gt 0 ] || continue
+    total=$((total + d))
+    count=$((count + 1))
+  done <<EOF
+$rows
+EOF
+  if [ "$count" -gt 0 ]; then
+    avg=$((total / count))
+  else
+    avg="$default_avg"
+  fi
+  sqlite3 "$db" "INSERT INTO wf_avg(repo,wf,avg_secs,updated_at) VALUES('$(sq "$repo")','$(sq "$wf")',$avg,$now) ON CONFLICT(repo,wf) DO UPDATE SET avg_secs=excluded.avg_secs, updated_at=excluded.updated_at;" 2>/dev/null || true
+  printf '%s' "$avg"
+}
+
+# Active run urls seen this poll (newline-separated), used to prune finished bars.
+active_urls=""
+
+for repo in "${repos[@]}"; do
+  short="${repo##*/}"
+  # One list call per repo per poll: every recent run, all branches, all
+  # workflows. Non-completed runs are filtered client-side and capped to the most
+  # recent $max_bars so a busy moment cannot flood the screen with bars.
+  runs="$(gh run list --repo "$repo" --limit 100 \
+    --json databaseId,workflowName,displayTitle,headBranch,status,startedAt,createdAt,url \
+    2>/dev/null)" || continue
+  [ -n "$runs" ] || continue
+
+  while IFS=$'\t' read -r run_id wf title branch status started created url; do
+    [ -n "${run_id:-}" ] || continue
+    [ -n "$url" ] || url="https://github.com/$repo/actions/runs/$run_id"
+    active_urls="$active_urls
+$url"
+
+    # Title carries the bitmap (ASCII-only) font, so stick to ASCII separators.
+    bar_title="$short: $wf ($branch)"
+
+    startsec=0
+    case "$status" in
+      queued | requested | waiting | pending)
+        color="purple"
+        prog="0.02"
+        desc="Queued on GitHub Actions, waiting for a runner.
+
+$title"
+        ;;
+      *) # in_progress (and any other non-terminal state)
+        color="green"
+        startsec="$(iso_to_epoch "${started:-}")"
+        [ "${startsec:-0}" -gt 0 ] 2>/dev/null || startsec="$(iso_to_epoch "${created:-}")"
+        avg="$(get_avg "$repo" "$wf")"
+        [ "${avg:-0}" -gt 0 ] 2>/dev/null || avg="$default_avg"
+        elapsed=$((now - startsec))
+        [ "$elapsed" -ge 0 ] || elapsed=0
+        # Integer math to avoid an awk/gawk dependency: fill in thousandths,
+        # clamped to [0.020, 0.970]. prog_milli is always < 1000, so the "0."
+        # prefix is correct.
+        prog_milli=$((elapsed * 1000 / avg))
+        [ "$prog_milli" -lt 20 ] && prog_milli=20
+        [ "$prog_milli" -gt 970 ] && prog_milli=970
+        prog="$(printf '0.%03d' "$prog_milli")"
+        desc="Running on GitHub Actions.
+
+Progress is estimated from the average of recent successful runs of this workflow. The title shows elapsed time; it clears when the run finishes."
+        ;;
+    esac
+
+    id="$(bar_id_for_url "$url")"
+    if [ -z "$id" ]; then
+      if [ "${startsec:-0}" -gt 0 ] 2>/dev/null; then
+        bossbar add "$bar_title" --color "$color" --overlay progress --progress "$prog" --position -1 --since "$startsec" --url "$url" --description "$desc" 2>/dev/null || true
+      else
+        bossbar add "$bar_title" --color "$color" --overlay progress --progress "$prog" --position -1 --url "$url" --description "$desc" 2>/dev/null || true
+      fi
+    else
+      # Existing bar: refresh fill/color/title in place. Leave `since` alone so an
+      # already-ticking clock survives polls and restarts.
+      bossbar set "$id" --title "$bar_title" --color "$color" --progress "$prog" --description "$desc" 2>/dev/null || true
+    fi
+  done < <(printf '%s' "$runs" | jq -r --argjson max "$max_bars" '
+    [ .[] | select((.status // "completed") != "completed") ]
+    | sort_by(.createdAt) | reverse | .[0:$max]
+    | .[]
+    | [ (.databaseId|tostring), .workflowName, .displayTitle, .headBranch,
+        .status, (.startedAt // ""), (.createdAt // ""), (.url // "") ] | @tsv')
+done
+
+# Prune bars for runs no longer in flight: any overlay row whose url is an Actions
+# run but is not in this poll's active set has completed (or was cancelled), so
+# drop it. Scoped to /actions/runs/ urls so downtime bars (status-page url) and
+# any hand-added bars are never touched.
+if [ -n "$bdb" ]; then
+  existing="$(sqlite3 -noheader -separator "	" "$bdb" \
+    "SELECT id, url FROM bossbars WHERE url LIKE '%/actions/runs/%';" 2>/dev/null || true)"
+  while IFS=$'\t' read -r eid eurl; do
+    [ -n "${eid:-}" ] || continue
+    if ! printf '%s\n' "$active_urls" | grep -qxF "$eurl"; then
+      bossbar rm "$eid" 2>/dev/null || true
+    fi
+  done <<EOF
+$existing
+EOF
+fi


### PR DESCRIPTION
A green Minecraft boss bar per in-flight GitHub Actions run across a set of repos, filled by `elapsed / the workflow's recent average duration` (purple while queued / not yet picked up by a runner). Companion to the red/yellow/blue ix-downtime outage bars; deliberately a different palette so the two never read alike. Clears each bar as its run finishes. Silent (pr-watch owns the CI sounds).

Built as a reusable, self-contained component, so anyone gets it with:

```nix
services.ciBars = { enable = true; repos = [ "indexable-inc/ix" "indexable-inc/index" ]; };
```

`users/andrewgazelka` now just imports `homeModules.ci-bars` and turns it on — three lines.

- `packages/bossbar-overlay/ci-bars.sh` — env-driven watcher (gh + jq + sqlite; per-workflow average cached in its own SQLite; reconcile keyed on the run URL; prunes only `/actions/runs/` rows so downtime bars are safe).
- `packages/bossbar-overlay/ci-bars-home-module.nix` — `services.ciBars`, renders `services.portable.ci-bars`.
- `flake.nix` — `homeModules.ci-bars`.

Validated against live GitHub + the real `bossbar` CLI on a throwaway overlay DB: bars created with computed fills, heal in place across polls, concurrent same-branch runs stay distinct, stale bars pruned, seeded downtime bar untouched. `nix run .#lint` clean; shellcheck/`bash -n` clean.

Made with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `services.ciBars` home-manager module for CI progress boss bars
> - Adds a reusable home-manager module ([ci-bars-home-module.nix](https://github.com/indexable-inc/index/pull/555/files#diff-9ad2a911dd8e5dc204b66ecc4d03c5dc01ea4fc043ed837d960b42176fb316d1)) that defines `services.ciBars` options: `enable`, `repos`, `interval`, `avgTtl`, `defaultAvg`, `maxBars`, and `logDir`.
> - Adds [ci-bars.sh](https://github.com/indexable-inc/index/pull/555/files#diff-3aba65acb9a333e9dfbb82745f5f2b85a47136e34156ae144f259fa6ab803b19), a bash script that polls GitHub Actions via `gh run list`, computes per-workflow average durations cached in SQLite, and updates bossbar overlay rows to reflect queued and in-progress runs.
> - Introduces a `mkBashApp` helper that wraps bash scripts with strict options (`set -euo pipefail`), runtime PATH injection, and build-time `shellcheck` validation.
> - Wires the module into the `andrewgazelka` home config ([home.nix](https://github.com/indexable-inc/index/pull/555/files#diff-b9c7bb705f699ec210f648820aef5c561583845b682d07d6e1dc19de7685cb0f)), enabling the portable service with repos from `cfg.prWatch.repos`.
> - Registers the module as a top-level `ci-bars` binding in [flake.nix](https://github.com/indexable-inc/index/pull/555/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0), mirroring the pattern used for other home modules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ad5f1d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->