### PR TITLE
portable-services: stable key so duplicate imports dedup

### DIFF
--- a/lib/portable-services.nix
+++ b/lib/portable-services.nix
@@ -309,7 +309,7 @@ let
     `systemd.user.services` (plus `systemd.user.timers` for interval
     services). The inactive platform's tree is simply not emitted.
   */
-  homeModule =
+  homeModuleFn =
     {
       config,
       pkgs,
@@ -343,6 +343,18 @@ let
         })
       ];
     };
+
+  # A stable `key` so the module system collapses duplicate imports into one
+  # declaration. Without it, two composed modules that each `imports` this one
+  # (e.g. homeModules.andrewgazelka + homeModules.ci-bars in the same config)
+  # would each re-declare `options.services.portable` and fail with "the option
+  # `services.portable' is already declared". The key is the module's identity,
+  # so importing it from any number of sites resolves to a single module.
+  homeModule = {
+    _file = "ix.portableServices.homeModule";
+    key = "ix.portableServices.homeModule";
+    imports = [ homeModuleFn ];
+  };
 in
 {
   inherit


### PR DESCRIPTION
Composing two home modules that each `imports` the portable-services module (e.g. `homeModules.andrewgazelka` + `homeModules.ci-bars` in one config) double-declared `options.services.portable` and failed home-manager eval with "the option `services.portable' is already declared". Give the module a stable `key`/`_file` so the module system collapses the duplicate imports into one declaration.

Latent before now (any two portable-services-importing homeModules in one config would hit it); surfaced by composing ci-bars alongside the andrewgazelka watchers.

Validated: a config importing both `homeModules.portable-services` and `homeModules.ci-bars` now evaluates (was the failing shape).

Made with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate import deduplication in portable-services home module
> Wraps the home module in [portable-services.nix](https://github.com/indexable-inc/index/pull/556/files#diff-062a2f28f34f916ca6ca914b56ea9346d3fa3e96c06d05e2b510576ab2843ad3) with a stable attribute-set module that includes a `key` field. Previously, importing the module multiple times caused the module system to re-declare options and fail. Now duplicates are collapsed correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da77b63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->