### PR TITLE
screencast: stream the Mac desktop as H.265 to an ingest server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5389,6 +5389,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "screencast"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "clap",
+ "color-eyre",
+ "reqwest",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "screencast-ingest"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "clap",
+ "color-eyre",
+ "serde",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "scroll"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6531,6 +6559,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ members = [
   "packages/progress-style",
   "packages/reel",
   "packages/repo-walker",
+  "packages/screencast",
+  "packages/screencast-ingest",
   "packages/source/linear",
   "packages/search",
   "packages/search-core",

--- a/packages/screencast-ingest/Cargo.toml
+++ b/packages/screencast-ingest/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "screencast-ingest"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "HTTP server that ingests H.265 HLS screen streams from the screencast client, stores every segment per user/session, and serves them back for replay, live view, and indexing"
+
+[lints]
+workspace = true
+
+[dependencies]
+axum = { workspace = true, features = ["http1", "tokio", "json"] }
+clap = { workspace = true, features = ["derive", "env"] }
+color-eyre.workspace = true
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = [
+  "macros",
+  "rt-multi-thread",
+  "fs",
+  "net",
+  "signal",
+  "io-util",
+] }
+tower-http = { workspace = true, features = ["trace"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+[[bin]]
+name = "screencast-ingest"
+path = "src/main.rs"

--- a/packages/screencast-ingest/default.nix
+++ b/packages/screencast-ingest/default.nix
@@ -1,0 +1,45 @@
+{
+  ix,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  meta = {
+    description = "HTTP server that ingests H.265 HLS screen streams, stores every segment per user/session, and serves them back for replay, live view, and indexing";
+    license = lib.licenses.mit;
+    mainProgram = "screencast-ingest";
+  };
+
+  server = ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+    binary = "screencast-ingest";
+    inherit meta;
+  };
+
+  printsHelp =
+    pkgs.runCommand "screencast-ingest-prints-help"
+      {
+        nativeBuildInputs = [ server ];
+        strictDeps = true;
+      }
+      ''
+        help=$(screencast-ingest --help)
+        case "$help" in
+          *"Usage: screencast-ingest"*) ;;
+          *)
+            echo "screencast-ingest --help did not print usage" >&2
+            printf '%s\n' "$help" >&2
+            exit 1
+            ;;
+        esac
+        mkdir -p "$out"
+      '';
+in
+server.overrideAttrs (old: {
+  passthru = (old.passthru or { }) // {
+    tests = (server.passthru.tests or { }) // {
+      inherit printsHelp;
+    };
+  };
+})

--- a/packages/screencast-ingest/package.nix
+++ b/packages/screencast-ingest/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "screencast-ingest";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/screencast-ingest/src/dashboard.html
+++ b/packages/screencast-ingest/src/dashboard.html
@@ -1,0 +1,218 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>screencast</title>
+    <script src="https://cdn.jsdelivr.net/npm/hls.js@1.5.18/dist/hls.min.js"></script>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #ffffff;
+        --fg: #1a1a1a;
+        --muted: #6b6b6b;
+        --line: #d8d8d8;
+        --panel: #f5f5f5;
+        --sel: #e6e6e6;
+        --live: #c0392b;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0e0e0e;
+          --fg: #e6e6e6;
+          --muted: #8a8a8a;
+          --line: #2a2a2a;
+          --panel: #161616;
+          --sel: #242424;
+          --live: #e74c3c;
+        }
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: "Berkeley Mono", ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 13px;
+        line-height: 1.5;
+        height: 100vh;
+        display: grid;
+        grid-template-columns: 320px 1fr;
+      }
+      aside {
+        border-right: 1px solid var(--line);
+        overflow-y: auto;
+        background: var(--panel);
+      }
+      header {
+        padding: 12px 14px;
+        border-bottom: 1px solid var(--line);
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+      }
+      header b {
+        font-weight: 600;
+        letter-spacing: 0.5px;
+      }
+      header span {
+        color: var(--muted);
+      }
+      ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      li {
+        padding: 10px 14px;
+        border-bottom: 1px solid var(--line);
+        cursor: pointer;
+      }
+      li[aria-selected="true"] {
+        background: var(--sel);
+      }
+      .user {
+        font-weight: 600;
+      }
+      .sess {
+        color: var(--muted);
+        word-break: break-all;
+      }
+      .row {
+        display: flex;
+        justify-content: space-between;
+        gap: 8px;
+        margin-top: 2px;
+      }
+      .stat {
+        color: var(--muted);
+        font-size: 11px;
+      }
+      .badge {
+        font-size: 10px;
+        letter-spacing: 0.5px;
+        border: 1px solid var(--line);
+        padding: 0 5px;
+      }
+      .badge.live {
+        color: var(--bg);
+        background: var(--live);
+        border-color: var(--live);
+      }
+      main {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+      }
+      .vidwrap {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #000;
+        min-height: 0;
+      }
+      video {
+        max-width: 100%;
+        max-height: 100%;
+      }
+      footer {
+        padding: 8px 14px;
+        border-top: 1px solid var(--line);
+        color: var(--muted);
+        font-size: 11px;
+        word-break: break-all;
+      }
+      .empty {
+        padding: 24px 14px;
+        color: var(--muted);
+      }
+    </style>
+  </head>
+  <body>
+    <aside>
+      <header><b>SCREENCAST</b><span id="count">—</span></header>
+      <ul id="list"></ul>
+      <div class="empty" id="empty" hidden>No streams yet. Start the client:<br /><br />screencast --server &lt;this&gt;</div>
+    </aside>
+    <main>
+      <div class="vidwrap"><video id="video" controls playsinline muted></video></div>
+      <footer id="info">Select a stream.</footer>
+    </main>
+    <script>
+      const esc = (s) =>
+        String(s).replace(
+          /[&<>"']/g,
+          (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c],
+        );
+      const fmtBytes = (n) => {
+        const u = ["B", "KB", "MB", "GB", "TB"];
+        let i = 0;
+        while (n >= 1024 && i < u.length - 1) {
+          n /= 1024;
+          i++;
+        }
+        return `${n.toFixed(i ? 1 : 0)} ${u[i]}`;
+      };
+      const fmtTime = (s) => (s ? new Date(s * 1000).toLocaleString() : "—");
+      const fmtDur = (a, b) => {
+        const d = Math.max(0, b - a);
+        const m = Math.floor(d / 60),
+          sec = d % 60;
+        return `${m}m${String(sec).padStart(2, "0")}s`;
+      };
+
+      const video = document.getElementById("video");
+      const list = document.getElementById("list");
+      let hls = null;
+      let current = null;
+
+      function play(s) {
+        current = s.playlist;
+        document.querySelectorAll("li").forEach((li) =>
+          li.setAttribute("aria-selected", String(li.dataset.playlist === s.playlist)),
+        );
+        document.getElementById("info").textContent =
+          `${s.user} / ${s.session} · ${fmtTime(s.started)} · ${fmtDur(s.started, s.updated)} · ${s.segments} seg · ${fmtBytes(s.bytes)}${s.live ? " · LIVE" : s.complete ? " · VOD" : ""}`;
+        if (hls) {
+          hls.destroy();
+          hls = null;
+        }
+        if (video.canPlayType("application/vnd.apple.mpegurl")) {
+          video.src = s.playlist; // Safari plays HLS natively.
+        } else if (window.Hls && Hls.isSupported()) {
+          hls = new Hls({ liveSyncDurationCount: 3 });
+          hls.loadSource(s.playlist);
+          hls.attachMedia(video);
+        }
+        video.play().catch(() => {});
+      }
+
+      async function refresh() {
+        let sessions = [];
+        try {
+          sessions = await (await fetch("/api/sessions")).json();
+        } catch (_) {}
+        document.getElementById("count").textContent = sessions.length;
+        document.getElementById("empty").hidden = sessions.length > 0;
+        list.innerHTML = "";
+        for (const s of sessions) {
+          const li = document.createElement("li");
+          li.dataset.playlist = s.playlist;
+          li.setAttribute("aria-selected", String(s.playlist === current));
+          li.innerHTML = `
+            <div class="row"><span class="user">${esc(s.user)}</span>${s.live ? '<span class="badge live">LIVE</span>' : s.complete ? '<span class="badge">VOD</span>' : ""}</div>
+            <div class="sess">${esc(s.session)}</div>
+            <div class="row"><span class="stat">${fmtDur(s.started, s.updated)} · ${s.segments} seg</span><span class="stat">${fmtBytes(s.bytes)}</span></div>`;
+          li.onclick = () => play(s);
+          list.appendChild(li);
+        }
+      }
+
+      refresh();
+      setInterval(refresh, 5000);
+    </script>
+  </body>
+</html>

--- a/packages/screencast-ingest/src/main.rs
+++ b/packages/screencast-ingest/src/main.rs
@@ -1,0 +1,407 @@
+//! `screencast-ingest`: receive H.265 HLS screen streams and keep them.
+//!
+//! The `screencast` client pushes a fragmented-MP4 HLS stream by `PUT`-ing the
+//! init segment, each media segment, and the rolling playlist to
+//! `/ingest/{user}/{session}/{file}`. This server writes those files under a
+//! root directory, one folder per user and session, and serves them back so the
+//! same URLs play in any HLS client (Safari natively, others via hls.js). The
+//! filesystem is the single source of truth: the session index and dashboard
+//! are derived from what is on disk, nothing is tracked separately.
+//!
+//! Everything is retained. A finished session is a complete VOD ready to feed
+//! into downstream data and context pipelines (frame sampling, OCR, indexing);
+//! a live session is the same files mid-write.
+//!
+//! Cross-platform, so it deploys on the Linux fleet. There is no transcoding:
+//! segments are stored exactly as the hardware encoder produced them.
+
+use std::cmp::Reverse;
+use std::net::SocketAddr;
+use std::path::{Path as FsPath, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use axum::Json;
+use axum::Router;
+use axum::body::{Body, to_bytes};
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
+use axum::response::{Html, IntoResponse, Response};
+use axum::routing::{get, put};
+use clap::Parser;
+use color_eyre::eyre::{Result, WrapErr};
+use serde::Serialize;
+use tracing::{info, warn};
+
+/// Largest single upload accepted. A segment is bitrate times segment length; 64
+/// MiB covers a long, high-bitrate segment (e.g. 10s at 50 Mbit/s) with room to
+/// spare while bounding the memory a single request can pin.
+const MAX_UPLOAD: usize = 64 * 1024 * 1024;
+
+/// A session is considered live if its newest file changed within this window.
+const LIVE_WINDOW_SECS: u64 = 30;
+
+/// How long a `/api/sessions` filesystem scan is reused. Bounds the cost of the
+/// dashboard's polling (many open tabs share one scan) and of unauthenticated
+/// callers, so a poll storm cannot amplify into a per-request full-tree walk.
+const SCAN_CACHE_TTL: Duration = Duration::from_secs(2);
+
+/// Ingest and serve H.265 HLS screen streams.
+#[derive(Debug, Parser)]
+#[command(version, about)]
+struct Args {
+    /// Directory under which streams are stored as `{user}/{session}/...`.
+    #[arg(long, env = "SCREENCAST_ROOT", default_value = "./screencast-data")]
+    root: PathBuf,
+
+    /// Address to listen on.
+    #[arg(long, env = "SCREENCAST_ADDR", default_value = "0.0.0.0:8080")]
+    addr: SocketAddr,
+
+    /// If set, uploads must carry `Authorization: Bearer <token>`. Playback and
+    /// the dashboard stay open; this guards writes, not reads.
+    #[arg(long, env = "SCREENCAST_TOKEN")]
+    token: Option<String>,
+}
+
+#[derive(Clone)]
+struct AppState(Arc<Inner>);
+
+struct Inner {
+    root: PathBuf,
+    token: Option<String>,
+    scan: Mutex<ScanCache>,
+}
+
+/// Short-lived cache of the last `/api/sessions` scan.
+#[derive(Default)]
+struct ScanCache {
+    at: Option<Instant>,
+    data: Arc<Vec<SessionInfo>>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let args = Args::parse();
+    tokio::fs::create_dir_all(&args.root)
+        .await
+        .wrap_err_with(|| format!("creating root {}", args.root.display()))?;
+    let root = args
+        .root
+        .canonicalize()
+        .wrap_err_with(|| format!("resolving root {}", args.root.display()))?;
+    if args.token.is_some() {
+        info!("upload authentication enabled");
+    }
+    let state = AppState(Arc::new(Inner {
+        root: root.clone(),
+        token: args.token,
+        scan: Mutex::new(ScanCache::default()),
+    }));
+
+    let app = Router::new()
+        .route("/", get(dashboard))
+        .route("/healthz", get(|| async { "ok" }))
+        .route("/api/sessions", get(api_sessions))
+        .route(
+            "/ingest/{user}/{session}/{file}",
+            put(upload).get(serve).delete(remove),
+        )
+        .layer(tower_http::trace::TraceLayer::new_for_http())
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(args.addr)
+        .await
+        .wrap_err_with(|| format!("binding {}", args.addr))?;
+    info!(addr = %args.addr, root = %root.display(), "screencast-ingest listening");
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async {
+            let _ = tokio::signal::ctrl_c().await;
+            info!("shutting down");
+        })
+        .await
+        .wrap_err("server error")
+}
+
+/// A single path segment is safe when it is a plain name: non-empty, not a
+/// directory-traversal token, and built only from the conservative charset the
+/// client also sanitizes to. This is the sole guard standing between a client
+/// path and a write, so it rejects anything it does not positively recognize.
+fn safe_component(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 128
+        && s != "."
+        && s != ".."
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
+}
+
+/// Map a stored file's extension to its HLS content type.
+fn content_type(file: &str) -> &'static str {
+    match file.rsplit('.').next() {
+        Some("m3u8") => "application/vnd.apple.mpegurl",
+        Some("m4s" | "mp4") => "video/mp4",
+        Some("ts") => "video/mp2t",
+        _ => "application/octet-stream",
+    }
+}
+
+/// Resolve `{user}/{session}/{file}` to an on-disk path, rejecting any segment
+/// that is not a safe plain name. Returns the validated directory and full path.
+fn resolve(
+    root: &FsPath,
+    user: &str,
+    session: &str,
+    file: &str,
+) -> Result<(PathBuf, PathBuf), (StatusCode, String)> {
+    if !(safe_component(user) && safe_component(session) && safe_component(file)) {
+        return Err((StatusCode::BAD_REQUEST, "invalid path component".to_owned()));
+    }
+    let dir = root.join(user).join(session);
+    let path = dir.join(file);
+    Ok((dir, path))
+}
+
+/// Enforce the bearer token on a mutating request when one is configured. The
+/// token compare is constant-time so a timing side channel cannot recover it
+/// byte by byte (the length is allowed to leak, which is conventional).
+fn check_auth(state: &AppState, headers: &HeaderMap) -> Result<(), (StatusCode, String)> {
+    let Some(expected) = &state.0.token else {
+        return Ok(());
+    };
+    let presented = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "));
+    if presented.is_some_and(|p| ct_eq(p.as_bytes(), expected.as_bytes())) {
+        Ok(())
+    } else {
+        Err((StatusCode::UNAUTHORIZED, "missing or invalid bearer token".to_owned()))
+    }
+}
+
+/// Constant-time byte-slice equality (short-circuits only on length).
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// `PUT` a playlist or segment. Auth is checked before the body is read, so an
+/// unauthenticated request never buffers a large upload. The body is written to
+/// a temp file in the destination directory and renamed into place, so a reader
+/// (a player polling the playlist) never observes a half-written file.
+async fn upload(
+    State(state): State<AppState>,
+    Path((user, session, file)): Path<(String, String, String)>,
+    headers: HeaderMap,
+    body: Body,
+) -> Result<StatusCode, (StatusCode, String)> {
+    check_auth(&state, &headers)?;
+    let (dir, path) = resolve(&state.0.root, &user, &session, &file)?;
+    if !matches!(file.rsplit('.').next(), Some("m3u8" | "m4s" | "mp4" | "ts")) {
+        return Err((StatusCode::BAD_REQUEST, "unsupported file type".to_owned()));
+    }
+
+    let bytes = to_bytes(body, MAX_UPLOAD)
+        .await
+        .map_err(|_| (StatusCode::PAYLOAD_TOO_LARGE, "upload too large".to_owned()))?;
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .map_err(|e| internal(&format!("create dir: {e}")))?;
+    let tmp = dir.join(format!(".{file}.tmp"));
+    tokio::fs::write(&tmp, &bytes)
+        .await
+        .map_err(|e| internal(&format!("write: {e}")))?;
+    tokio::fs::rename(&tmp, &path)
+        .await
+        .map_err(|e| internal(&format!("rename: {e}")))?;
+    Ok(StatusCode::CREATED)
+}
+
+/// `GET` a stored playlist or segment for playback.
+async fn serve(
+    State(state): State<AppState>,
+    Path((user, session, file)): Path<(String, String, String)>,
+) -> Response {
+    let (_, path) = match resolve(&state.0.root, &user, &session, &file) {
+        Ok(p) => p,
+        Err(e) => return e.into_response(),
+    };
+    tokio::fs::read(&path).await.map_or_else(
+        |_| (StatusCode::NOT_FOUND, "not found").into_response(),
+        |bytes| {
+            let ct = HeaderValue::from_static(content_type(&file));
+            ([(header::CONTENT_TYPE, ct)], bytes).into_response()
+        },
+    )
+}
+
+/// `DELETE` a stored file. Supports HLS muxers configured to expire old
+/// segments; the default client keeps everything, so this is rarely used.
+async fn remove(
+    State(state): State<AppState>,
+    Path((user, session, file)): Path<(String, String, String)>,
+    headers: HeaderMap,
+) -> Result<StatusCode, (StatusCode, String)> {
+    check_auth(&state, &headers)?;
+    let (_, path) = resolve(&state.0.root, &user, &session, &file)?;
+    match tokio::fs::remove_file(&path).await {
+        Ok(()) => Ok(StatusCode::NO_CONTENT),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(StatusCode::NO_CONTENT),
+        Err(e) => Err(internal(&format!("remove: {e}"))),
+    }
+}
+
+/// Log the detailed cause and return a generic 500, so an OS error string
+/// (which can include absolute server paths) never reaches the client.
+fn internal(detail: &str) -> (StatusCode, String) {
+    warn!("{detail}");
+    (StatusCode::INTERNAL_SERVER_ERROR, "internal error".to_owned())
+}
+
+/// One stream's summary, derived entirely from its directory on disk.
+#[derive(Clone, Debug, Serialize)]
+struct SessionInfo {
+    user: String,
+    session: String,
+    /// URL of the HLS playlist for this session.
+    playlist: String,
+    /// Earliest file mtime (epoch seconds): when capture began.
+    started: u64,
+    /// Latest file mtime (epoch seconds): last write seen.
+    updated: u64,
+    /// Number of media segments stored.
+    segments: u64,
+    /// Total bytes on disk for the session.
+    bytes: u64,
+    /// True if the session was written within the live window.
+    live: bool,
+    /// True once the playlist carries `#EXT-X-ENDLIST` (a finished VOD).
+    complete: bool,
+}
+
+/// Scan the root directory and summarize every session. Errors on individual
+/// entries are skipped rather than failing the whole listing, so one unreadable
+/// folder cannot blank the dashboard.
+async fn scan_sessions(root: &FsPath) -> Vec<SessionInfo> {
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+    let mut out = Vec::new();
+
+    let Ok(mut users) = tokio::fs::read_dir(root).await else {
+        return out;
+    };
+    while let Ok(Some(user_ent)) = users.next_entry().await {
+        if !user_ent.file_type().await.is_ok_and(|t| t.is_dir()) {
+            continue;
+        }
+        let user = user_ent.file_name().to_string_lossy().into_owned();
+        let Ok(mut sessions) = tokio::fs::read_dir(user_ent.path()).await else {
+            continue;
+        };
+        while let Ok(Some(sess_ent)) = sessions.next_entry().await {
+            if !sess_ent.file_type().await.is_ok_and(|t| t.is_dir()) {
+                continue;
+            }
+            let session = sess_ent.file_name().to_string_lossy().into_owned();
+            if let Some(info) = summarize(sess_ent.path(), &user, &session, now).await {
+                out.push(info);
+            }
+        }
+    }
+    // Most recently active first.
+    out.sort_by_key(|s| Reverse(s.updated));
+    out
+}
+
+/// Summarize one session directory, or `None` if it has no playlist yet.
+async fn summarize(dir: PathBuf, user: &str, session: &str, now: u64) -> Option<SessionInfo> {
+    let mut started = u64::MAX;
+    let mut updated = 0u64;
+    let mut segments = 0u64;
+    let mut bytes = 0u64;
+    let mut has_playlist = false;
+
+    let mut entries = tokio::fs::read_dir(&dir).await.ok()?;
+    while let Ok(Some(ent)) = entries.next_entry().await {
+        let name = ent.file_name().to_string_lossy().into_owned();
+        if name.starts_with('.') {
+            continue; // in-flight temp file
+        }
+        let Ok(meta) = ent.metadata().await else { continue };
+        if !meta.is_file() {
+            continue;
+        }
+        bytes += meta.len();
+        let ext = name.rsplit('.').next().unwrap_or_default();
+        if ext.eq_ignore_ascii_case("m4s") || ext.eq_ignore_ascii_case("ts") {
+            segments += 1;
+        }
+        if name == "index.m3u8" {
+            has_playlist = true;
+        }
+        if let Ok(modified) = meta.modified()
+            && let Ok(since_epoch) = modified.duration_since(UNIX_EPOCH)
+        {
+            let secs = since_epoch.as_secs();
+            started = started.min(secs);
+            updated = updated.max(secs);
+        }
+    }
+
+    if !has_playlist {
+        return None;
+    }
+    let complete = tokio::fs::read_to_string(dir.join("index.m3u8"))
+        .await
+        .is_ok_and(|p| p.contains("#EXT-X-ENDLIST"));
+
+    Some(SessionInfo {
+        user: user.to_owned(),
+        session: session.to_owned(),
+        playlist: format!("/ingest/{user}/{session}/index.m3u8"),
+        started: if started == u64::MAX { updated } else { started },
+        updated,
+        segments,
+        bytes,
+        live: !complete && now.saturating_sub(updated) <= LIVE_WINDOW_SECS,
+        complete,
+    })
+}
+
+/// JSON list of all sessions, for the dashboard and downstream consumers. The
+/// scan is cached for `SCAN_CACHE_TTL` so polling (many dashboard tabs, or an
+/// unauthenticated caller) cannot turn each request into a full-tree walk.
+async fn api_sessions(State(state): State<AppState>) -> Json<Vec<SessionInfo>> {
+    let fresh = state.0.scan.lock().ok().and_then(|cache| {
+        (cache.at.is_some_and(|at| at.elapsed() < SCAN_CACHE_TTL)).then(|| (*cache.data).clone())
+    });
+    if let Some(data) = fresh {
+        return Json(data);
+    }
+    let data = scan_sessions(&state.0.root).await;
+    if let Ok(mut cache) = state.0.scan.lock() {
+        cache.at = Some(Instant::now());
+        cache.data = Arc::new(data.clone());
+    }
+    Json(data)
+}
+
+/// The single-page dashboard. It fetches `/api/sessions` itself, so the HTML is
+/// fully static and needs no server-side templating.
+async fn dashboard() -> Html<&'static str> {
+    Html(include_str!("dashboard.html"))
+}

--- a/packages/screencast/Cargo.toml
+++ b/packages/screencast/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "screencast"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Capture the macOS desktop as hardware-encoded H.265 (VideoToolbox) and stream it as fragmented-MP4 HLS to a screencast-ingest server"
+
+[lints]
+workspace = true
+
+[dependencies]
+chrono = { workspace = true, features = ["clock"] }
+clap = { workspace = true, features = ["derive", "env"] }
+color-eyre.workspace = true
+reqwest.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = [
+  "macros",
+  "rt-multi-thread",
+  "process",
+  "signal",
+  "time",
+  "fs",
+  "io-util",
+] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+[[bin]]
+name = "screencast"
+path = "src/main.rs"

--- a/packages/screencast/README.md
+++ b/packages/screencast/README.md
@@ -1,0 +1,60 @@
+# screencast
+
+Stream a Mac's screen to a central server as hardware-encoded H.265, so a whole
+team can push their screens to one place that stores every session for replay and
+for downstream data and context use.
+
+Two pieces:
+
+- **`screencast`** (this crate): the macOS client. Captures the desktop, encodes
+  it with `hevc_videotoolbox` (the Apple media engine, so it stays near-free on
+  CPU and battery), and uploads the stream to the server.
+- **`screencast-ingest`** (sibling crate): the server. Accepts uploads, stores
+  every session on disk, and serves them back for live view, replay, and
+  indexing.
+
+The wire format is plain fragmented-MP4 HLS over HTTP, so a stored session plays
+in Safari directly and in any browser through hls.js. Nothing is transcoded: the
+bytes the hardware encoder produced are what land on disk.
+
+## Run the server
+
+    nix run .#screencast-ingest -- --root /var/lib/screencast --addr 0.0.0.0:8080
+
+Open `http://<host>:8080/` for the dashboard (a session list plus a player).
+`GET /api/sessions` returns the same data as JSON for scripts and indexers.
+
+To require auth on uploads (reads stay open), pass `--token <secret>` (or set
+`SCREENCAST_TOKEN`). Run it behind a private network or tailnet; there is no
+transport encryption of its own.
+
+## Stream from a Mac
+
+    nix run .#screencast -- --server http://<host>:8080
+
+That auto-detects the display, captures at 30 fps and 6 Mbit/s H.265, and streams
+under `<you>/<timestamp>`. Stop with Ctrl-C, which finalizes the session into a
+complete VOD. Grant Screen Recording permission to the terminal first, or the
+capture is a black frame with no error.
+
+Useful flags: `--user`, `--screen N` (`--list-screens` to enumerate displays),
+`--fps`, `--bitrate 10M`, `--segment-seconds`, `--max-height 1440` (downscale to
+cut bandwidth on Retina displays), `--no-cursor`, `--token`.
+
+## How it streams
+
+ffmpeg writes HLS segments to a local scratch directory; the client uploads each
+segment the playlist has finalized, then the playlist itself, with ordinary sized
+HTTP `PUT`s. This is deliberate: ffmpeg can `PUT` HLS directly, but its HTTP muxer
+holds connections open without finalizing each request body, which a strict
+HTTP/1.1 server leaves hanging. Uploading from the client also means a failed
+`PUT` is just retried on the next sync, so a brief network blip does not drop the
+stream.
+
+## Bad fit if
+
+- You need sub-second live latency. HLS buffers a few segments; this targets
+  reliable capture and replay, not real-time control. Reach for WebRTC or SRT if
+  glass-to-glass latency matters.
+- You are not on macOS. Capture uses `avfoundation` + VideoToolbox. The server is
+  cross-platform; only the client is Mac-only.

--- a/packages/screencast/default.nix
+++ b/packages/screencast/default.nix
@@ -1,0 +1,63 @@
+{
+  ix,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  meta = {
+    description = "Stream the macOS desktop to a screencast-ingest server as hardware-encoded H.265 (VideoToolbox) over fragmented-MP4 HLS";
+    license = lib.licenses.mit;
+    mainProgram = "screencast";
+    # avfoundation capture and hevc_videotoolbox are macOS-only.
+    platforms = lib.platforms.darwin;
+  };
+
+  unwrapped = ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+    binary = "screencast";
+    inherit meta;
+  };
+
+  # screencast shells out to ffmpeg to capture, encode, and upload, so ffmpeg
+  # must be on PATH at runtime. nixpkgs ffmpeg is built with VideoToolbox on
+  # darwin, so it carries the required hevc_videotoolbox encoder.
+  wrapped =
+    pkgs.runCommand "screencast"
+      {
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+        strictDeps = true;
+        inherit meta;
+      }
+      ''
+        mkdir -p $out/bin
+        makeWrapper ${lib.getExe unwrapped} $out/bin/screencast \
+          --prefix PATH : ${lib.makeBinPath [ pkgs.ffmpeg ]}
+      '';
+
+  printsHelp =
+    pkgs.runCommand "screencast-prints-help"
+      {
+        nativeBuildInputs = [ wrapped ];
+        strictDeps = true;
+      }
+      ''
+        help=$(screencast --help)
+        case "$help" in
+          *"Usage: screencast"*) ;;
+          *)
+            echo "screencast --help did not print usage" >&2
+            printf '%s\n' "$help" >&2
+            exit 1
+            ;;
+        esac
+        mkdir -p "$out"
+      '';
+in
+wrapped.overrideAttrs (old: {
+  passthru = (old.passthru or { }) // {
+    tests = (unwrapped.passthru.tests or { }) // {
+      inherit printsHelp;
+    };
+  };
+})

--- a/packages/screencast/package.nix
+++ b/packages/screencast/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "screencast";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/screencast/src/main.rs
+++ b/packages/screencast/src/main.rs
@@ -1,0 +1,537 @@
+//! `screencast`: stream the macOS desktop to a `screencast-ingest` server as
+//! hardware-encoded H.265.
+//!
+//! ffmpeg does the capture and encode (the same way `reel` wraps ffmpeg for
+//! terminal reels); this binary configures it, supervises it, and ships its
+//! output. The pipeline is:
+//!
+//! 1. capture the desktop through the `avfoundation` input device,
+//! 2. encode it with `hevc_videotoolbox`, the Apple media-engine H.265 encoder
+//!    (hardware, so it stays near-free on battery and CPU),
+//! 3. mux to fragmented-MP4 HLS written to a local scratch directory, and
+//! 4. upload each finalized segment plus the rolling playlist to the ingest
+//!    server with ordinary sized HTTP `PUT`s.
+//!
+//! ffmpeg can `PUT` HLS directly, but its HTTP muxer keeps connections open and
+//! does not finalize each request body in a way a strict HTTP/1.1 server
+//! accepts, so segments hang server-side. Writing locally and uploading from
+//! here sidesteps that and buys retries: a failed upload is simply retried on
+//! the next sync, so a brief network or server blip does not drop the stream.
+//!
+//! The HLS playlist uses `event` type with an unbounded list, so a session is a
+//! live stream while recording and a complete, replayable VOD once ffmpeg
+//! finishes. Only segments the local playlist already lists are uploaded, so the
+//! server's playlist never references a segment that has not landed yet.
+//!
+//! macOS only. Screen Recording permission must be granted to the terminal (or
+//! whatever process) running this binary, or `avfoundation` captures a black
+//! frame with no error.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use chrono::Utc;
+use clap::Parser;
+use color_eyre::eyre::{Result, bail, eyre};
+use tokio::io::AsyncWriteExt;
+use tokio::process::{Child, Command};
+use tokio::signal;
+use tokio::time::{MissedTickBehavior, interval, sleep};
+use tracing::{error, info, warn};
+
+/// The fixed name of the HLS playlist and init segment within a session.
+const PLAYLIST: &str = "index.m3u8";
+const INIT: &str = "init.mp4";
+
+/// Capture this Mac's screen as H.265 and stream it to an ingest server.
+#[derive(Debug, Parser)]
+#[command(version, about)]
+struct Args {
+    /// Base URL of the `screencast-ingest` server, e.g. `http://ingest.host:8080`.
+    #[arg(long, env = "SCREENCAST_SERVER")]
+    server: String,
+
+    /// Stream owner; becomes the top-level folder on the server. Defaults to
+    /// `$USER`.
+    #[arg(long, env = "SCREENCAST_USER")]
+    user: Option<String>,
+
+    /// `avfoundation` video device index for the display to capture. Defaults to
+    /// auto-detecting the first "Capture screen" device, since the index differs
+    /// per machine (device 0 is often a camera). Run with `--list-screens` to
+    /// see the options.
+    #[arg(long)]
+    screen: Option<u32>,
+
+    /// List the capturable `avfoundation` video devices and exit.
+    #[arg(long)]
+    list_screens: bool,
+
+    /// Capture frame rate.
+    #[arg(long, default_value_t = 30)]
+    fps: u32,
+
+    /// Target H.265 bitrate, passed to ffmpeg `-b:v` (e.g. `6M`, `10M`).
+    #[arg(long, default_value = "6M")]
+    bitrate: String,
+
+    /// HLS segment length in seconds. Also drives the keyframe interval so
+    /// segments split on clean boundaries.
+    #[arg(long, default_value_t = 4)]
+    segment_seconds: u32,
+
+    /// Upload sync interval in milliseconds: how often the scratch directory is
+    /// checked for finalized segments to push.
+    #[arg(long, default_value_t = 1000)]
+    sync_ms: u64,
+
+    /// Downscale so the output is at most this tall (keeps aspect, even width).
+    /// Retina displays are large; capping height cuts bandwidth a lot. Omit to
+    /// capture at native resolution.
+    #[arg(long)]
+    max_height: Option<u32>,
+
+    /// Exclude the mouse cursor from the capture.
+    #[arg(long)]
+    no_cursor: bool,
+
+    /// Bearer token sent as `Authorization: Bearer <token>` on every upload, to
+    /// match a server started with `--token`.
+    #[arg(long, env = "SCREENCAST_TOKEN")]
+    token: Option<String>,
+
+    /// ffmpeg binary to invoke.
+    #[arg(long, default_value = "ffmpeg")]
+    ffmpeg: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    if args.list_screens {
+        return list_screens(&args.ffmpeg).await;
+    }
+
+    preflight(&args.ffmpeg).await?;
+
+    let user = sanitize(&args.user.clone().unwrap_or_else(default_user));
+    if user.is_empty() {
+        bail!("could not determine a user name; pass --user");
+    }
+    let server = args.server.trim_end_matches('/').to_owned();
+
+    let screen = resolve_screen(&args).await?;
+    info!(server = %server, user = %user, screen, "streaming desktop as H.265 to ingest server");
+
+    let scratch = tempfile::tempdir().map_err(|e| eyre!("creating scratch dir: {e}"))?;
+    supervise(&args, &server, &user, screen, scratch.path()).await
+}
+
+/// Resolve the avfoundation device index for the display: the explicit
+/// `--screen` if given, otherwise the first auto-detected "Capture screen"
+/// device. Bails with the device list if no screen is found.
+async fn resolve_screen(args: &Args) -> Result<u32> {
+    if let Some(n) = args.screen {
+        return Ok(n);
+    }
+    let out = Command::new(&args.ffmpeg)
+        .args(["-hide_banner", "-f", "avfoundation", "-list_devices", "true", "-i", ""])
+        .output()
+        .await
+        .map_err(|e| eyre!("listing avfoundation devices: {e}"))?;
+    let devices = String::from_utf8_lossy(&out.stderr);
+    parse_screen_index(&devices).ok_or_else(|| {
+        eyre!("no 'Capture screen' device found; pass --screen with one of:\n{devices}")
+    })
+}
+
+/// Find the index of the first `[N] Capture screen ...` entry in ffmpeg's
+/// avfoundation device listing. The line carries two bracketed fields
+/// (`[AVFoundation indev @ ..] [N] Capture screen 0`); the wanted index is the
+/// bracket immediately before the label.
+fn parse_screen_index(devices: &str) -> Option<u32> {
+    for line in devices.lines() {
+        let Some(pos) = line.find("] Capture screen") else {
+            continue;
+        };
+        let before = &line[..pos];
+        if let Some(open) = before.rfind('[')
+            && let Ok(n) = before[open + 1..].trim().parse::<u32>()
+        {
+            return Some(n);
+        }
+    }
+    None
+}
+
+/// Default stream owner, taken from the environment.
+fn default_user() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("SUDO_USER"))
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_default()
+}
+
+/// Reduce a string to the URL- and path-safe charset the server accepts,
+/// folding everything else to `-`.
+fn sanitize(raw: &str) -> String {
+    raw.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// Verify ffmpeg exists and exposes the hardware H.265 encoder, failing with a
+/// clear message rather than a black stream or a cryptic ffmpeg error later.
+async fn preflight(ffmpeg: &str) -> Result<()> {
+    let out = Command::new(ffmpeg)
+        .args(["-hide_banner", "-encoders"])
+        .output()
+        .await
+        .map_err(|e| eyre!("could not run {ffmpeg:?} (is ffmpeg installed?): {e}"))?;
+    if !out.status.success() {
+        bail!("{ffmpeg} -encoders failed: {}", String::from_utf8_lossy(&out.stderr));
+    }
+    if !String::from_utf8_lossy(&out.stdout).contains("hevc_videotoolbox") {
+        bail!(
+            "this ffmpeg has no hevc_videotoolbox encoder; rebuild ffmpeg with VideoToolbox \
+             support (the nix wrapper provides one)"
+        );
+    }
+    Ok(())
+}
+
+/// Print the `avfoundation` capture devices (the `[N] Capture screen M` lines
+/// are the displays).
+async fn list_screens(ffmpeg: &str) -> Result<()> {
+    // `-list_devices true` writes the device table to stderr and exits non-zero
+    // by design, so the status is ignored and stderr is the payload.
+    let out = Command::new(ffmpeg)
+        .args(["-hide_banner", "-f", "avfoundation", "-list_devices", "true", "-i", ""])
+        .output()
+        .await
+        .map_err(|e| eyre!("could not run {ffmpeg:?}: {e}"))?;
+    print!("{}", String::from_utf8_lossy(&out.stderr));
+    Ok(())
+}
+
+/// Run ffmpeg, restarting it under a fresh session id if it dies, until the
+/// user interrupts with Ctrl-C. Each (re)start is its own server-side session so
+/// a crash never reuses or corrupts an earlier session's segment numbering.
+async fn supervise(args: &Args, server: &str, user: &str, screen: u32, scratch: &Path) -> Result<()> {
+    let mut backoff = Duration::from_secs(1);
+    let mut attempt: u32 = 0;
+
+    loop {
+        let session = format!("{}-{attempt:02}", Utc::now().format("%Y%m%dT%H%M%SZ"));
+        let dir = scratch.join(&session);
+        tokio::fs::create_dir_all(&dir)
+            .await
+            .map_err(|e| eyre!("creating session scratch {}: {e}", dir.display()))?;
+        let base = format!("{server}/ingest/{user}/{session}/");
+        let mut uploader = Uploader::new(&base, args.token.clone(), dir.clone());
+
+        info!(session = %session, "starting capture");
+        let mut child = Command::new(&args.ffmpeg)
+            .args(build_ffmpeg_args(args, screen, &dir))
+            .stdin(Stdio::piped())
+            .spawn()
+            .map_err(|e| eyre!("failed to spawn ffmpeg: {e}"))?;
+        let started = std::time::Instant::now();
+
+        let mut tick = interval(Duration::from_millis(args.sync_ms.max(100)));
+        tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        let restart = loop {
+            tokio::select! {
+                _ = tick.tick() => {
+                    uploader.sync().await;
+                }
+                status = child.wait() => {
+                    // Push whatever ffmpeg managed to finalize before dying.
+                    uploader.sync().await;
+                    error!(?status, "ffmpeg exited unexpectedly");
+                    break true;
+                }
+                _ = signal::ctrl_c() => {
+                    info!("interrupt received; stopping ffmpeg so the playlist finalizes");
+                    stop_gracefully(&mut child).await;
+                    uploader.sync().await; // ship the final segments and ENDLIST playlist
+                    info!(uploaded = uploader.count(), "stream finalized");
+                    break false;
+                }
+            }
+        };
+
+        if !restart {
+            return Ok(());
+        }
+        if started.elapsed() > Duration::from_secs(30) {
+            backoff = Duration::from_secs(1); // a long run was healthy; reset
+        }
+        warn!("retrying in {:?}", backoff);
+        sleep(backoff).await;
+        backoff = (backoff * 2).min(Duration::from_secs(30));
+        attempt = attempt.saturating_add(1);
+    }
+}
+
+/// Ask ffmpeg to quit cleanly (write `q` to its stdin, the documented
+/// interactive stop) so it flushes the final segment and writes the HLS
+/// `#EXT-X-ENDLIST` that turns the session into a finished VOD. Falls back to a
+/// kill if it does not exit promptly.
+async fn stop_gracefully(child: &mut Child) {
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(b"q").await;
+        let _ = stdin.flush().await;
+    }
+    match tokio::time::timeout(Duration::from_secs(10), child.wait()).await {
+        Ok(Ok(status)) => info!(?status, "ffmpeg stopped"),
+        Ok(Err(e)) => warn!("error waiting for ffmpeg: {e}"),
+        Err(_) => {
+            warn!("ffmpeg did not exit within 10s; killing");
+            let _ = child.kill().await;
+        }
+    }
+}
+
+/// Uploads a session's local HLS output to the ingest server, segment by
+/// segment, never re-sending a file it has already shipped.
+struct Uploader {
+    client: reqwest::Client,
+    base: String,
+    token: Option<String>,
+    dir: PathBuf,
+    sent: HashSet<String>,
+    last_playlist: Vec<u8>,
+}
+
+impl Uploader {
+    fn new(base: &str, token: Option<String>, dir: PathBuf) -> Self {
+        // Bounded timeouts matter: sync() is awaited inside the supervisor's
+        // select arm, so an upload that hangs would otherwise stall the whole
+        // loop (no further ticks, no Ctrl-C). On timeout the PUT errors and is
+        // retried on the next sync instead.
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_default();
+        Self {
+            client,
+            base: base.to_owned(),
+            token,
+            dir,
+            sent: HashSet::new(),
+            last_playlist: Vec::new(),
+        }
+    }
+
+    /// Number of media files (init + segments) successfully uploaded so far.
+    fn count(&self) -> usize {
+        self.sent.len()
+    }
+
+    /// Upload anything new: the init segment, every media segment the local
+    /// playlist now lists, then the playlist itself (only when it changed). The
+    /// playlist is shipped last so the server never advertises a segment that
+    /// has not been uploaded yet. Files that are listed but not yet on disk, and
+    /// uploads that fail, are simply retried on the next sync.
+    async fn sync(&mut self) {
+        let Ok(playlist) = tokio::fs::read(self.dir.join(PLAYLIST)).await else {
+            return; // ffmpeg has not written the playlist yet
+        };
+
+        // Track whether every file the playlist references is now uploaded. The
+        // playlist is shipped only when that holds, so the server never
+        // advertises a segment that has not landed (a failed or not-yet-flushed
+        // segment defers the playlist to the next sync).
+        let mut all_ready = true;
+        if !self.sent.contains(INIT) {
+            all_ready &= self.put_file(INIT).await;
+        }
+        for seg in parse_segments(&playlist) {
+            if !self.sent.contains(&seg) {
+                all_ready &= self.put_file(&seg).await;
+            }
+        }
+        if all_ready
+            && playlist != self.last_playlist
+            && self.put_bytes(PLAYLIST, playlist.clone()).await.is_ok()
+        {
+            self.last_playlist = playlist;
+        }
+    }
+
+    /// Read a local file and upload it, marking it sent on success. Returns
+    /// whether the file is now on the server. A file that is listed in the
+    /// playlist but not yet flushed to disk, or whose upload failed, returns
+    /// `false` and is retried on the next sync.
+    async fn put_file(&mut self, name: &str) -> bool {
+        if let Ok(bytes) = tokio::fs::read(self.dir.join(name)).await
+            && self.put_bytes(name, bytes).await.is_ok()
+        {
+            self.sent.insert(name.to_owned());
+            return true;
+        }
+        false
+    }
+
+    /// `PUT` a body to `{base}{name}`. Returns `Err` on any transport or status
+    /// failure so the caller leaves it unmarked for retry.
+    async fn put_bytes(&self, name: &str, bytes: Vec<u8>) -> Result<()> {
+        let mut req = self.client.put(format!("{}{name}", self.base)).body(bytes);
+        if let Some(token) = &self.token {
+            req = req.bearer_auth(token);
+        }
+        match req.send().await {
+            Ok(resp) if resp.status().is_success() => Ok(()),
+            Ok(resp) => {
+                warn!(name, status = %resp.status(), "upload rejected");
+                bail!("status {}", resp.status())
+            }
+            Err(e) => {
+                warn!(name, "upload failed: {e}");
+                Err(e.into())
+            }
+        }
+    }
+}
+
+/// Extract the media-segment file names listed in an HLS playlist: the lines
+/// that are neither blank nor directives.
+fn parse_segments(playlist: &[u8]) -> Vec<String> {
+    String::from_utf8_lossy(playlist)
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+/// Build the ffmpeg argument vector that captures, hardware-encodes to H.265,
+/// and writes fMP4 HLS into the local `dir`.
+fn build_ffmpeg_args(args: &Args, screen: u32, dir: &Path) -> Vec<String> {
+    let mut a: Vec<String> = Vec::new();
+    let mut push = |s: &str| a.push(s.to_owned());
+
+    push("-hide_banner");
+    push("-loglevel");
+    push("warning");
+
+    // Input: the avfoundation screen device, no audio (`:none`).
+    push("-f");
+    push("avfoundation");
+    push("-capture_cursor");
+    push(if args.no_cursor { "0" } else { "1" });
+    push("-framerate");
+    push(&args.fps.to_string());
+    push("-i");
+    push(&format!("{screen}:none"));
+
+    // Optional downscale before encoding.
+    if let Some(h) = args.max_height {
+        push("-vf");
+        push(&format!("scale=-2:{h}"));
+    }
+
+    // Hardware H.265. `-realtime 1` tells VideoToolbox to favor latency, and the
+    // `hvc1` tag is the fMP4/Apple-compatible HEVC sample entry (without it some
+    // players refuse the stream).
+    push("-c:v");
+    push("hevc_videotoolbox");
+    push("-realtime");
+    push("1");
+    push("-b:v");
+    push(&args.bitrate);
+    push("-tag:v");
+    push("hvc1");
+    push("-pix_fmt");
+    push("yuv420p");
+    // Keyframe interval == segment length so HLS splits on IDR boundaries.
+    push("-g");
+    push(&(args.fps * args.segment_seconds).to_string());
+
+    // fMP4 HLS to local disk. `event` + unbounded list keeps the whole session
+    // in the playlist (live now, replayable later); ffmpeg writes ENDLIST on a
+    // clean exit, marking the VOD complete.
+    push("-f");
+    push("hls");
+    push("-hls_time");
+    push(&args.segment_seconds.to_string());
+    push("-hls_playlist_type");
+    push("event");
+    push("-hls_list_size");
+    push("0");
+    push("-hls_flags");
+    push("independent_segments");
+    push("-hls_segment_type");
+    push("fmp4");
+    push("-hls_fmp4_init_filename");
+    push(INIT);
+    push("-hls_segment_filename");
+    push(&dir.join("seg_%05d.m4s").to_string_lossy());
+    push(&dir.join(PLAYLIST).to_string_lossy());
+
+    a
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_screen_index, parse_segments, sanitize};
+
+    #[test]
+    fn finds_first_capture_screen_index() {
+        let listing = "[AVFoundation indev @ 0x1] AVFoundation video devices:\n\
+            [AVFoundation indev @ 0x1] [0] FaceTime HD Camera\n\
+            [AVFoundation indev @ 0x1] [4] Capture screen 0\n\
+            [AVFoundation indev @ 0x1] [5] Capture screen 1\n";
+        assert_eq!(parse_screen_index(listing), Some(4));
+    }
+
+    #[test]
+    fn no_screen_device_returns_none() {
+        assert_eq!(parse_screen_index("[x] [0] FaceTime HD Camera\n"), None);
+    }
+
+    #[test]
+    fn parses_only_segment_lines() {
+        let playlist = b"#EXTM3U\n\
+            #EXT-X-VERSION:7\n\
+            #EXT-X-MAP:URI=\"init.mp4\"\n\
+            #EXTINF:2.000,\n\
+            seg_00000.m4s\n\
+            #EXTINF:2.000,\n\
+            seg_00001.m4s\n\
+            #EXT-X-ENDLIST\n";
+        assert_eq!(parse_segments(playlist), ["seg_00000.m4s", "seg_00001.m4s"]);
+    }
+
+    #[test]
+    fn empty_playlist_has_no_segments() {
+        assert!(parse_segments(b"#EXTM3U\n#EXT-X-VERSION:7\n").is_empty());
+    }
+
+    #[test]
+    fn sanitize_folds_unsafe_chars() {
+        assert_eq!(sanitize("ok.name_-1"), "ok.name_-1");
+        assert_eq!(sanitize("a/b c"), "a-b-c");
+        assert_eq!(sanitize("../evil"), "..-evil");
+    }
+}


### PR DESCRIPTION
Two small crates so the whole team can stream screens to one place that stores every session for replay and downstream data/context use.

- **screencast** (macOS client): captures the desktop, hardware-encodes H.265 via ffmpeg `hevc_videotoolbox`, writes fMP4 HLS to a scratch dir, and uploads finalized segments + the playlist to the server with sized PUTs (retried on failure). Auto-detects the screen device; supervises/restarts ffmpeg; Ctrl-C finalizes the VOD.
- **screencast-ingest** (server, Linux-deployable): stores uploads atomically per `user/session`, serves them back as HLS (Safari native, others via hls.js), exposes `GET /api/sessions` (JSON, cached) and a flat dashboard. Optional bearer-token auth on writes; path-traversal guarded; auth runs before the body is buffered.

Run: `nix run .#screencast-ingest -- --addr 0.0.0.0:8080` then `nix run .#screencast -- --server http://<host>:8080`.

Why client-side upload instead of ffmpeg's direct HLS PUT: ffmpeg's HTTP muxer holds connections open without finalizing each request body, which a strict HTTP/1.1 server leaves hanging; uploading from the client also buys retries.

Validated: `nix build` of both packages; clippy (all+pedantic+nursery) clean; unit tests; end-to-end encode → upload → store → serve, decoding 120 HEVC frames back over HTTP. Live `avfoundation` capture needs the macOS Screen Recording grant (a one-time System Settings toggle); the device opens and is auto-selected correctly.

Not for sub-second live latency (HLS buffers a few segments); targets reliable capture + replay.

Made with AI (Claude, claude-opus-4-8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Mac desktop screencast client and ingest server streaming H.265 over HLS
> - Adds `packages/screencast`, a macOS-only Rust binary that captures the screen via `avfoundation`, encodes with `hevc_videotoolbox`, and produces fMP4 HLS segments uploaded via HTTP PUT to the ingest server.
> - Adds `packages/screencast-ingest`, a Rust/Axum HTTP server that accepts HLS artifact uploads under `/ingest/{user}/{session}/{file}`, serves them back for playback, and exposes `/api/sessions` with a 2-second cache.
> - The ingest server serves a self-contained dashboard at `/` that polls `/api/sessions` and plays streams via native HLS or hls.js.
> - The client supervises ffmpeg with retry/backoff, segments each restart into a new session, and finalizes the HLS playlist to VOD on graceful shutdown.
> - Optional bearer token guards PUT/DELETE endpoints using constant-time comparison; uploads are capped at 64 MiB and written atomically via temp file rename.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4aa441.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->