### PR TITLE
lint(ast-grep): gate anonymous 3+-field tuples in the search subsystem

### DIFF
--- a/rust-rules-tests/no-anon-tuple-test.yml
+++ b/rust-rules-tests/no-anon-tuple-test.yml
@@ -5,6 +5,13 @@ valid:
   - "fn pairs() -> Vec<(String, usize)> { todo!() }"
   # A named struct is the desired shape.
   - "struct Counts { indexed: usize, failures: usize, skipped: usize }"
+  # Boundary cases the rule must NOT flag (locks behavior against an ast-grep
+  # upgrade): unit and one-element tuple types, and tuple *expressions* /
+  # *patterns* (the rule targets tuple *types* only, never values).
+  - "fn unit() -> () {}"
+  - "fn single() -> (i32,) { (0,) }"
+  - "fn expr() { let _ = (1, 2, 3); }"
+  - "fn pat(p: P) { let (a, b, c) = p; }"
 invalid:
   - "fn run() -> (usize, usize, usize) { todo!() }"
   - "fn build() -> (Schema, Field, Field) { todo!() }"

--- a/rust-rules-tests/no-anon-tuple-test.yml
+++ b/rust-rules-tests/no-anon-tuple-test.yml
@@ -1,0 +1,11 @@
+id: no-anon-tuple
+valid:
+  # Two-field pairs are idiomatic (key/value, parse split) and allowed.
+  - "fn split(s: &str) -> (String, Option<String>) { todo!() }"
+  - "fn pairs() -> Vec<(String, usize)> { todo!() }"
+  # A named struct is the desired shape.
+  - "struct Counts { indexed: usize, failures: usize, skipped: usize }"
+invalid:
+  - "fn run() -> (usize, usize, usize) { todo!() }"
+  - "fn build() -> (Schema, Field, Field) { todo!() }"
+  - "struct Holder { parts: (String, String, String) }"

--- a/rust-rules/no-anon-tuple.yml
+++ b/rust-rules/no-anon-tuple.yml
@@ -1,0 +1,25 @@
+id: no-anon-tuple
+language: rust
+severity: error
+message: "Anonymous tuple with 3+ fields. Promote it to a named struct so each field has a name."
+note: |
+  WHY: A 3+-field tuple carries several distinct domain values positionally, so
+  every call site re-derives what `.0`/`.1`/`.2` mean and a reorder is a silent
+  bug. A named struct documents each field once. Two-field pairs (key/value, a
+  parse split) stay idiomatic and are allowed; this rule flags 3 or more.
+  REPO: Replace `(A, B, C)` with a `struct` naming each field. See
+  packages/indexer (`Counts`, `User`, `Mixedbread`) for the pattern.
+  SCOPE: Enforced in the corpus/search subsystem (indexer, search*, source/*,
+  sink/*). To extend it elsewhere, add the crate's glob to `files:` below.
+rule:
+  kind: tuple_type
+  has:
+    nthChild: 3
+    stopBy: neighbor
+files:
+  - "packages/indexer/**/*.rs"
+  - "packages/search/**/*.rs"
+  - "packages/search-core/**/*.rs"
+  - "packages/search-py/**/*.rs"
+  - "packages/source/**/*.rs"
+  - "packages/sink/**/*.rs"

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,3 +1,4 @@
-ruleDirs: ["./nix-rules"]
+ruleDirs: ["./nix-rules", "./rust-rules"]
 testConfigs:
   - testDir: ./nix-rules-tests
+  - testDir: ./rust-rules-tests


### PR DESCRIPTION
Clippy has no anonymous-tuple lint, so this adds an ast-grep rule (new `./rust-rules` dir) flagging tuple *types* with 3+ fields — the "struct in disguise" smell. Two-field pairs (key/value, parse splits) stay idiomatic and are allowed.

Scoped via `files:` to the corpus/search subsystem (indexer, search\*, source/\*, sink/\*) where the directive was raised and there are **zero** current violations, so CI stays green. Widen the globs to extend it repo-wide later (≥3-field tuples exist in ~25 unrelated math/graphics/FFI sites today).

Validated: `ast-grep test` (6 new cases pass) and `ast-grep scan --error .` clean.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ast-grep lint rule banning anonymous 3+-field tuples in the search subsystem
> - Adds a new ast-grep rule [`no-anon-tuple`](https://github.com/indexable-inc/index/pull/560/files#diff-6e254b33e8d390d8b9a314c632c5aaf7222f005bc2733bbcd4c6ae18295061ad) that flags `tuple_type` nodes with 3 or more fields as errors, scoped to the `indexer`, `search`, `search-core`, `search-py`, `source`, and `sink` packages.
> - Registers the new rule and its tests in [`sgconfig.yml`](https://github.com/indexable-inc/index/pull/560/files#diff-8cd651443bf4b255faeca4e094b3aa925b12e8ded2998ea8f7f893572ffd8626) by adding `./rust-rules` and `./rust-rules-tests` alongside existing nix rules.
> - Two-field tuples, named structs, unit types, and single-element tuple types are explicitly allowed per the test fixtures in [`rust-rules-tests/no-anon-tuple-test.yml`](https://github.com/indexable-inc/index/pull/560/files#diff-5777b5c0a281f1c920419e0108e6a3946a4ed85ae78e8dc9c8b269652f88adac).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 668407a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->