### PR TITLE
fix(ci): unbreak main (screencast darwin gate + ci-bars logDir)

### DIFF
--- a/packages/bossbar-overlay/ci-bars-home-module.nix
+++ b/packages/bossbar-overlay/ci-bars-home-module.nix
@@ -131,17 +131,26 @@ in
 
     logDir = mkOption {
       type = types.str;
-      default =
-        if pkgs.stdenv.hostPlatform.isDarwin then
-          "${config.home.homeDirectory}/Library/Logs"
-        else
-          "${config.home.homeDirectory}/.local/state";
+      # The platform-conditional resting value is seeded in `config` with
+      # mkOptionDefault, keeping this declaration a self-contained option whose
+      # docs come from defaultText (a conditional `default` here would make the
+      # rendered docs resolve to one branch).
       defaultText = lib.literalMD "`~/Library/Logs` on macOS, `~/.local/state` on Linux";
       description = "Directory the watcher appends its stdout/stderr log to.";
     };
   };
 
   config = mkIf cfg.enable {
+    # Seed the platform-conditional log directory at option-default precedence,
+    # so a downstream override still wins and the option declaration stays a
+    # self-contained literal.
+    services.ciBars.logDir = lib.mkOptionDefault (
+      if pkgs.stdenv.hostPlatform.isDarwin then
+        "${config.home.homeDirectory}/Library/Logs"
+      else
+        "${config.home.homeDirectory}/.local/state"
+    );
+
     services.portable.ci-bars = {
       description = "GitHub Actions CI progress boss bars";
       command = [ (lib.getExe' ciBars "ci-bars") ];

--- a/packages/screencast/package.nix
+++ b/packages/screencast/package.nix
@@ -1,7 +1,17 @@
 {
   id = "screencast";
-  packageSet = true;
-  flake = true;
+  # macOS-only: avfoundation capture and hevc_videotoolbox are Darwin APIs (the
+  # crate's meta.platforms is lib.platforms.darwin). Advertise the package output,
+  # package-set attr, and passthru checks only on Darwin so `nix flake check` on
+  # x86_64-linux never forces the off-platform build. Mirrors macos-vm.
+  packageSet.systems = [
+    "aarch64-darwin"
+    "x86_64-darwin"
+  ];
+  flake.systems = [
+    "aarch64-darwin"
+    "x86_64-darwin"
+  ];
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -442,7 +442,7 @@ in
     services.ciBars = {
       enable = true;
       repos = cfg.prWatch.repos;
-      logDir = cfg.logDir;
+      inherit (cfg) logDir;
     };
   };
 }


### PR DESCRIPTION
main's flake-check is red on x86_64-linux from two recently-merged changes; this unblocks all PRs.

- **screencast** (#558) is darwin-only (avfoundation + hevc_videotoolbox) but its package output and passthru `printsHelp` check evaluated on linux (`Refusing to evaluate package 'screencast' ... not available on the requested hostPlatform`). Gate `flake.systems`/`packageSet.systems` to darwin, mirroring `macos-vm`.
- **ci-bars** `logDir` used a conditional `mkOption.default`, tripping `no-mkoption-conditional-default`. Seed the platform value in `config` via `mkOptionDefault`.

Validated locally: `ast-grep scan --error .` clean, `nixfmt` clean.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI by restricting screencast to Darwin and moving `ciBars.logDir` default
> - Restricts the `screencast` package to Darwin systems by replacing `packageSet = true` and `flake = true` with explicit `aarch64-darwin` and `x86_64-darwin` system lists in [package.nix](https://github.com/indexable-inc/index/pull/561/files#diff-13310629f2bd92ab6dbf00b8a67278cbdefb19c88f05aff0d080ab60b9a38d38), preventing off-platform builds during flake checks.
> - Moves the platform-conditional `logDir` default out of the option declaration in [ci-bars-home-module.nix](https://github.com/indexable-inc/index/pull/561/files#diff-9ad2a911dd8e5dc204b66ecc4d03c5dc01ea4fc043ed837d960b42176fb316d1) and into a `mkOptionDefault` assignment scoped to when `services.ciBars` is enabled, so the default is only applied when the module is active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a726e9c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->