### PR TITLE
bossbar: poof on removal, per-bar box opt-out, one CI bar per commit

### DIFF
--- a/packages/bossbar-overlay/app/crates/bossbar/src/bars.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/bars.rs
@@ -110,6 +110,12 @@ pub struct BossBar {
     /// A URL (or any URI/path the OS opener accepts) opened when the bar is
     /// clicked without dragging. Empty means a click does nothing.
     pub url: String,
+    /// Whether hovering may unfold the description panel below the bar. `true`
+    /// (the default) keeps the old behavior; `false` makes the bar stay bar-sized
+    /// on hover with no pop-down box, even if it carries a `description`. Lets a
+    /// caller draw many compact bars (e.g. one per CI run) without each growing a
+    /// panel. Persisted to the `expandable` DB column.
+    pub expandable: bool,
     /// Fill fraction, always clamped to `0.0..=1.0` at construction.
     pub progress: f32,
     pub color: Color,

--- a/packages/bossbar-overlay/app/crates/bossbar/src/db.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/db.rs
@@ -32,7 +32,8 @@ CREATE TABLE IF NOT EXISTS bossbars (
   x           REAL,
   y           REAL,
   since       INTEGER,
-  url         TEXT    NOT NULL DEFAULT ''
+  url         TEXT    NOT NULL DEFAULT '',
+  expandable  INTEGER NOT NULL DEFAULT 1
 );";
 
 /// Columns added after the initial schema shipped. `ALTER TABLE ADD COLUMN` is
@@ -45,6 +46,7 @@ const ADDED_COLUMNS: &[(&str, &str)] = &[
     ("description", "TEXT NOT NULL DEFAULT ''"),
     ("since", "INTEGER"),
     ("url", "TEXT NOT NULL DEFAULT ''"),
+    ("expandable", "INTEGER NOT NULL DEFAULT 1"),
 ];
 
 /// Rows inserted only when the DB file is created for the first time, so a
@@ -120,7 +122,7 @@ pub fn set_position(path: &Path, id: i64, pos: glam::DVec2) -> rusqlite::Result<
 
 fn read(conn: &Connection) -> rusqlite::Result<Vec<BossBar>> {
     let mut stmt = conn.prepare(
-        "SELECT id, title, progress, color, overlay, position, x, y, description, since, url
+        "SELECT id, title, progress, color, overlay, position, x, y, description, since, url, expandable
          FROM bossbars
          WHERE visible != 0
          ORDER BY position ASC, id ASC",
@@ -137,6 +139,8 @@ fn read(conn: &Connection) -> rusqlite::Result<Vec<BossBar>> {
             description: r.get(8)?,
             since,
             url: r.get(10)?,
+            // Default-1 column; any non-zero value keeps the hover panel enabled.
+            expandable: r.get::<_, i64>(11)? != 0,
             progress: r.get::<_, f64>(2)?.clamp(0.0, 1.0) as f32,
             color: Color::parse(&r.get::<_, String>(3)?),
             overlay: Overlay::parse(&r.get::<_, String>(4)?),
@@ -275,6 +279,27 @@ mod tests {
     }
 
     #[test]
+    fn expandable_round_trips_and_defaults_true() {
+        let path = temp_db("expandable");
+        let conn = open(&path).unwrap();
+        conn.execute("DELETE FROM bossbars", []).unwrap();
+        conn.execute(
+            "INSERT INTO bossbars (title, expandable) VALUES ('boxed', 1), ('boxless', 0)",
+            [],
+        )
+        .unwrap();
+        // A row that never set the column reads as expandable (default 1).
+        conn.execute("INSERT INTO bossbars (title) VALUES ('default')", [])
+            .unwrap();
+        let bars = read(&conn).unwrap();
+        let by = |t: &str| bars.iter().find(|b| b.title == t).unwrap();
+        assert!(by("boxed").expandable);
+        assert!(!by("boxless").expandable, "expandable=0 reads as no box");
+        assert!(by("default").expandable, "missing value defaults to a box");
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
     fn legacy_db_without_description_is_migrated_and_round_trips() {
         // A database created before `description` shipped (no description, x, or
         // y columns) must gain the column on open and read back as empty, then
@@ -304,6 +329,10 @@ mod tests {
         assert_eq!(bars.len(), 1);
         assert_eq!(bars[0].title, "old");
         assert_eq!(bars[0].description, "", "migrated column defaults to empty");
+        assert!(
+            bars[0].expandable,
+            "the migrated expandable column defaults to a box"
+        );
 
         conn.execute(
             "UPDATE bossbars SET description = ?1 WHERE id = ?2",

--- a/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
@@ -65,6 +65,14 @@ const DRAG_THRESHOLD: f64 = 5.0;
 /// watcher's lagged read-back of our own drag never snaps the window back.
 const SETTLE: Duration = Duration::from_millis(700);
 
+/// How long the "poof" despawn animation runs before the window is actually
+/// removed. A bar that leaves the DB shrinks toward its center and fades out over
+/// this window (ease-out) instead of vanishing in a single frame.
+const POOF_DUR: Duration = Duration::from_millis(280);
+/// How far the bar shrinks at the end of the poof (1.0 - this), so it implodes to
+/// ~55% as it fades. Kept under 1.0 and centered, so it never clips the window.
+const POOF_SHRINK: f32 = 0.45;
+
 /// Current wall-clock time as Unix seconds, for the live elapsed counter. Before
 /// the epoch (clock unset) it clamps to 0, which reads as a 0 counter.
 fn now_unix() -> i64 {
@@ -127,18 +135,26 @@ struct BarWin {
     /// ignores externally-read positions until the window has been still for
     /// SETTLE, so the watcher's lagged read-back never snaps a live drag back.
     last_move: Instant,
+    /// Set when the bar has left the DB and the window is playing its poof
+    /// despawn. While `Some`, the window shrinks+fades from this instant and is
+    /// removed once `POOF_DUR` elapses; it is cleared back to `None` if the bar
+    /// reappears before the poof finishes.
+    poof: Option<Instant>,
 }
 
 impl BarWin {
-    /// Still moving: easing toward/away from hover, or breathing while hovered.
+    /// Still moving: easing toward/away from hover, breathing while hovered, or
+    /// playing the poof despawn (which must keep redrawing until it finishes).
     fn animating(&self) -> bool {
-        self.hovered || !self.hover_anim.is_resting()
+        self.hovered || !self.hover_anim.is_resting() || self.poof.is_some()
     }
 
     /// The window should be grown for the panel while the bar is hovered or still
-    /// easing back from a hover, but only when it has a description.
+    /// easing back from a hover, but only when it has a description AND the bar
+    /// opts into the pop-down (`expandable`). A non-expandable bar stays bar-sized
+    /// on hover with no box, even if it carries description text.
     fn wants_expanded(&self) -> bool {
-        self.has_description && self.animating()
+        self.has_description && self.bar.expandable && self.animating()
     }
 }
 
@@ -249,6 +265,7 @@ impl App {
             // Far enough in the past that a fresh window accepts an external
             // position immediately (the SETTLE guard only fires after a real move).
             last_move: now - SETTLE,
+            poof: None,
         })
     }
 
@@ -256,7 +273,16 @@ impl App {
     /// bars, create them for new bars, update data and (externally changed)
     /// position for existing ones.
     fn reconcile(&mut self, event_loop: &ActiveEventLoop, bars: Vec<BossBar>) {
-        self.wins.retain(|id, _| bars.iter().any(|b| b.id == *id));
+        // A bar that left the DB is not dropped instantly: mark its window
+        // poofing so it shrinks+fades, and remove it once the poof finishes (in
+        // `about_to_wait`). request_redraw kicks the animation off now.
+        let now_i = Instant::now();
+        for (id, win) in self.wins.iter_mut() {
+            if win.poof.is_none() && !bars.iter().any(|b| b.id == *id) {
+                win.poof = Some(now_i);
+                win.window.request_redraw();
+            }
+        }
 
         let mut slot = 0usize;
         for b in &bars {
@@ -269,6 +295,11 @@ impl App {
             };
 
             if let Some(win) = self.wins.get_mut(&b.id) {
+                // The bar is back in the DB; if it was mid-poof (removed then
+                // re-added before the despawn finished), cancel the poof.
+                if win.poof.take().is_some() {
+                    win.window.request_redraw();
+                }
                 win.has_description = !b.description.trim().is_empty();
                 win.bar = b.clone();
                 // Honor a position set in the DB by something other than our own
@@ -342,7 +373,7 @@ impl App {
         let view = frame
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());
-        let quads = scene::build_one(
+        let mut quads = scene::build_one(
             &core.gpu,
             &core.textures,
             self.scale,
@@ -353,6 +384,21 @@ impl App {
             hover,
             breathe,
         );
+        // Poof despawn: shrink the whole bar toward the window center and fade it
+        // out over POOF_DUR (ease-out), so a removed bar implodes instead of
+        // blinking off. Applied as a post-pass on the laid-out quads, so the
+        // scene builder stays unaware of the despawn.
+        if let Some(t0) = win.poof {
+            let t = (now.duration_since(t0).as_secs_f32() / POOF_DUR.as_secs_f32()).clamp(0.0, 1.0);
+            let e = anim::ease_out_cubic(t);
+            let cx = win.config.width as f32 * 0.5;
+            let cy = win.config.height as f32 * 0.5;
+            anim::scale_quads_about(&mut quads, cx, cy, 1.0 - POOF_SHRINK * e);
+            let fade = 1.0 - e;
+            for q in &mut quads {
+                q.color[3] *= fade;
+            }
+        }
         let _ = core.gpu.draw(&view, win.config.width, win.config.height, &quads);
         frame.present();
     }
@@ -446,6 +492,11 @@ impl App {
         let Some(win) = self.wins.get_mut(&id) else {
             return;
         };
+        // A poofing window is on its way out; leave its size fixed so it shrinks
+        // cleanly via the render transform instead of also resizing the window.
+        if win.poof.is_some() {
+            return;
+        }
         let expand = win.wants_expanded();
         let (w_px, h_px) = if expand {
             scene::expanded_window_px(&core.gpu, &win.bar, self.scale, now)
@@ -642,6 +693,13 @@ impl ApplicationHandler<Vec<BossBar>> for App {
         for id in ids {
             self.settle_window_size(id);
         }
+
+        // Remove any window whose poof despawn has finished. Dropping the BarWin
+        // closes its window. Parity with the old instant-removal: the overlay
+        // stays alive with zero bars (the watcher re-adds them), so no exit here.
+        let now_i = Instant::now();
+        self.wins
+            .retain(|_, w| w.poof.is_none_or(|t0| now_i.duration_since(t0) < POOF_DUR));
 
         let mut animating = false;
         let mut ticking = false;

--- a/packages/bossbar-overlay/app/crates/bossbar/src/scene.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/scene.rs
@@ -463,9 +463,13 @@ pub fn build_one(
         has_title,
     };
 
-    // Only build the panel when the window was actually grown for it; a collapsed
-    // window (height == top_region_h) has no room and skips it.
-    let panel = if height as f32 > collapsed_h + 0.5 {
+    // Only build the panel when the bar opts into the box (`expandable`) and the
+    // window was actually grown for it; a collapsed window (height ==
+    // top_region_h) has no room and skips it. The expandable check is also the
+    // live gate (via the overlay's window sizing); repeating it here keeps a
+    // non-expandable bar boxless even if something grows its window (e.g. a
+    // snapshot rendered at expanded size).
+    let panel = if bar.expandable && height as f32 > collapsed_h + 0.5 {
         panel_size(gpu, &bar.description, scale).map(|(panel_w, panel_h)| {
             let (border, pad, font_px, line_px, gap) = panel_metrics(scale);
             PanelBox {
@@ -514,9 +518,17 @@ pub fn build_all(
     let scale = scale.max(1);
     let opacity = DEFAULT_OPACITY;
     let (border, pad, font_px, line_px, gap) = panel_metrics(scale);
+    // A non-expandable bar has no box, so it reserves no panel size (and so no
+    // layout gap and no panel quads), matching the live per-window path.
     let sizes: Vec<Option<(f32, f32)>> = bars
         .iter()
-        .map(|b| panel_size(gpu, &b.description, scale))
+        .map(|b| {
+            if b.expandable {
+                panel_size(gpu, &b.description, scale)
+            } else {
+                None
+            }
+        })
         .collect();
     let boxes = layout(scale, bars, width as f32, &sizes, gap);
 
@@ -633,6 +645,7 @@ mod tests {
             overlay: Overlay::None,
             position: 0,
             pos: None,
+            expandable: true,
         }
     }
 

--- a/packages/bossbar-overlay/bossbar
+++ b/packages/bossbar-overlay/bossbar
@@ -34,7 +34,8 @@ ensure_db() {
     visible     INTEGER NOT NULL DEFAULT 1,
     position    INTEGER NOT NULL DEFAULT 0,
     since       INTEGER,
-    url         TEXT    NOT NULL DEFAULT ''
+    url         TEXT    NOT NULL DEFAULT '',
+    expandable  INTEGER NOT NULL DEFAULT 1
   );"
   # Columns that shipped after the first schema; add each to a pre-existing table
   # so its flag works on a DB created by an older bossbar. SQLite has no
@@ -47,6 +48,7 @@ ensure_db() {
   add_col description "TEXT NOT NULL DEFAULT ''"
   add_col since "INTEGER"
   add_col url "TEXT NOT NULL DEFAULT ''"
+  add_col expandable "INTEGER NOT NULL DEFAULT 1"
 }
 
 die() {
@@ -79,10 +81,10 @@ bossbar - control the Minecraft boss bar overlay (SQLite-backed)
 
 Usage:
   bossbar add <title> [--description D] [--since EPOCH] [--url U] [--progress P]
-                      [--color C] [--overlay O] [--position N]
+                      [--color C] [--overlay O] [--position N] [--box 0|1]
   bossbar set <id|title> [--title T] [--description D] [--since EPOCH] [--url U]
                          [--progress P] [--color C] [--overlay O]
-                         [--position N] [--visible 0|1]
+                         [--position N] [--visible 0|1] [--box 0|1]
   bossbar rm <id|title>
   bossbar list
   bossbar clear
@@ -97,6 +99,8 @@ Usage:
   P        fill fraction 0.0 .. 1.0
   C        pink | blue | red | green | yellow | purple | white
   O        progress | notched_6 | notched_10 | notched_12 | notched_20
+  --box    1 (default) lets hover unfold the description panel; 0 keeps the bar
+           bar-sized on hover with no pop-down box
 
 Examples:
   bossbar add "Ender Dragon" --color pink --overlay notched_20 \
@@ -125,6 +129,9 @@ parse_fields() {
       --progress)    assign="progress = $val" ;;
       --position)    assign="position = $val" ;;
       --visible)     assign="visible = $val" ;;
+      --box)
+        case "$val" in 0|1) ;; *) die "--box must be 0 or 1" ;; esac
+        assign="expandable = $val" ;;
       --color)
         in_list "$val" "$COLORS" || die "color must be one of: $COLORS"
         assign="color = '$val'" ;;

--- a/packages/bossbar-overlay/ci-bars.sh
+++ b/packages/bossbar-overlay/ci-bars.sh
@@ -9,32 +9,33 @@
 #   CI_BARS_MAX          max bars per repo per poll (12)
 #   CI_BARS_STATE        state dir for the average cache + lock ($HOME/.cache/ci-bars)
 #
-# Draws a Minecraft boss bar PER in-flight GitHub Actions run across the watched
-# repos, so a glance says what CI is doing right now. This is the live-progress
-# companion to the [[ix-downtime]] outage bars (red/yellow/blue) and the
-# [[pr-watch]] karma feed (merge orb / failure villager): those react to discrete
-# events, this one reconciles a continuous "what's running" view. It is SILENT,
-# because pr-watch already owns the success/failure sound; here the bar fill is
-# the whole signal.
+# Draws ONE Minecraft boss bar per in-flight HEAD COMMIT across the watched repos
+# (not one per workflow run), so a commit with five checks shows a single bar that
+# fills as its checks complete. This is the live-progress companion to the
+# [[ix-downtime]] outage bars (red/yellow/blue) and the [[pr-watch]] karma feed
+# (merge orb / failure villager): those react to discrete events, this one
+# reconciles a continuous "what's building" view. It is SILENT, because pr-watch
+# already owns the success/failure sound; here the bar fill is the whole signal.
 #
-# Color is deliberately OUTSIDE the downtime palette so the two never read as the
-# same thing:
-#   - in_progress -> green, progress = elapsed / historical-average duration;
-#   - queued/waiting -> purple, a thin bar (no runner yet, so no elapsed clock).
+# Color is deliberately OUTSIDE the downtime palette so the two never read alike:
+#   - any check running or finished -> green;
+#   - all of the commit's checks still queued / unpicked -> purple, a thin bar.
 #
-# Progress for a running job is estimated from the mean wall-clock of the last
-# few SUCCESSFUL runs of that same workflow (cached in SQLite, refreshed at most
-# once per CI_BARS_AVG_TTL), clamped to [0.02, 0.97] so a bar never shows empty
-# and never shows full until the run actually finishes. The overlay also ticks a
-# live elapsed timer in the title from the bar's `since` (set to the run's start),
-# so the human sees both "about this far" and "for this long".
+# A commit's fill = (finished checks + summed partial progress of the running
+# ones) / total checks. Each running check's partial is elapsed / the mean
+# wall-clock of recent SUCCESSFUL runs of that workflow (cached in SQLite,
+# refreshed at most once per CI_BARS_AVG_TTL), clamped so the bar never shows
+# empty or full until the commit's CI actually finishes. The overlay ticks a live
+# elapsed timer from the bar's `since` (the earliest running check's start).
 #
-# A bar's identity is the run URL (unique per run), so CI bars never collide with
-# the downtime bars (which point at the status page) and a run heals in place
-# across polls. When a run leaves the in-flight set (it completed, was cancelled,
-# or fell off the list) its bar is removed on the next poll: we enumerate every
-# overlay row whose url is an Actions run and drop any not in the current active
-# set. pr-watch handles the completion sound, so this just clears the visual.
+# A bar's identity is the commit URL (https://github.com/<repo>/commit/<sha>), so
+# all of a commit's checks share one bar, CI bars never collide with the downtime
+# bars (status-page url), and a commit heals in place across polls. When a commit
+# leaves the in-flight set (all its checks finished or were cancelled) its bar is
+# removed on the next poll: we enumerate every overlay row whose url is a commit
+# page and drop any not in the current active set (the overlay poofs it out).
+# pr-watch handles the completion sound, so this just clears the visual. The bars
+# are boxless (--box 0): many compact commit bars with no hover pop-down.
 
 state_dir="${CI_BARS_STATE:-$HOME/.cache/ci-bars}"
 mkdir -p "$state_dir"
@@ -147,93 +148,127 @@ EOF
   printf '%s' "$avg"
 }
 
-# Active run urls seen this poll (newline-separated), used to prune finished bars.
+# Commit urls drawn this poll (newline-separated), used to prune finished bars.
+# Identity is the commit, so all of a commit's checks share ONE bar.
 active_urls=""
 
 for repo in "${repos[@]}"; do
   short="${repo##*/}"
   # One list call per repo per poll: every recent run, all branches, all
-  # workflows. Non-completed runs are filtered client-side and capped to the most
-  # recent $max_bars so a busy moment cannot flood the screen with bars.
+  # workflows, grouped below by head commit (headSha).
   runs="$(gh run list --repo "$repo" --limit 100 \
-    --json databaseId,workflowName,displayTitle,headBranch,status,startedAt,createdAt,url \
+    --json workflowName,headBranch,headSha,status,conclusion,startedAt,createdAt,url \
     2>/dev/null)" || continue
   [ -n "$runs" ] || continue
 
-  while IFS=$'\t' read -r run_id wf title branch status started created url; do
-    [ -n "${run_id:-}" ] || continue
-    [ -n "$url" ] || url="https://github.com/$repo/actions/runs/$run_id"
+  # Aggregate every run by its head commit. One bar per commit: total checks,
+  # how many have finished, and the summed partial progress of the running ones,
+  # so the fill is the commit's overall CI progress rather than a single check's.
+  # Reset before declaring: `declare -A` does NOT clear an already-set assoc
+  # array, so a prior repo's entries would otherwise leak into this one.
+  unset c_total c_done c_running c_queued c_branch c_minstart c_partmilli c_created
+  declare -A c_total c_done c_running c_queued c_branch c_minstart c_partmilli c_created
+  while IFS=$'\t' read -r sha branch status wf started created; do
+    [ -n "$sha" ] || continue
+    c_total["$sha"]=$((${c_total["$sha"]:-0} + 1))
+    [ -n "${c_branch[$sha]:-}" ] || c_branch["$sha"]="$branch"
+    cc="$(iso_to_epoch "${created:-}")"
+    [ "${cc:-0}" -gt "${c_created[$sha]:-0}" ] 2>/dev/null && c_created["$sha"]="$cc"
+    case "$status" in
+      completed)
+        c_done["$sha"]=$((${c_done["$sha"]:-0} + 1))
+        ;;
+      queued | requested | waiting | pending)
+        c_queued["$sha"]=$((${c_queued["$sha"]:-0} + 1))
+        ;;
+      *) # in_progress (and any other non-terminal state)
+        c_running["$sha"]=$((${c_running["$sha"]:-0} + 1))
+        st="$(iso_to_epoch "${started:-}")"
+        [ "${st:-0}" -gt 0 ] 2>/dev/null || st="$(iso_to_epoch "${created:-}")"
+        avg="$(get_avg "$repo" "$wf")"
+        [ "${avg:-0}" -gt 0 ] 2>/dev/null || avg="$default_avg"
+        el=$((now - st))
+        [ "$el" -ge 0 ] || el=0
+        pm=$((el * 1000 / avg))
+        [ "$pm" -lt 0 ] && pm=0
+        [ "$pm" -gt 970 ] && pm=970
+        c_partmilli["$sha"]=$((${c_partmilli["$sha"]:-0} + pm))
+        cm="${c_minstart[$sha]:-0}"
+        if [ "$cm" -eq 0 ] || { [ "${st:-0}" -gt 0 ] && [ "$st" -lt "$cm" ]; }; then
+          c_minstart["$sha"]="$st"
+        fi
+        ;;
+    esac
+  done < <(printf '%s' "$runs" | jq -r '
+    .[] | [ .headSha, .headBranch, .status, .workflowName,
+            (.startedAt // ""), (.createdAt // "") ] | @tsv')
+
+  # Select commits that still have in-flight work (running or queued), newest
+  # first, capped to $max_bars so a busy moment cannot flood the screen. Commits
+  # whose checks have all finished get no bar and are pruned below.
+  eligible=()
+  for sha in "${!c_total[@]}"; do
+    if [ $((${c_running[$sha]:-0} + ${c_queued[$sha]:-0})) -gt 0 ]; then
+      eligible+=("${c_created[$sha]:-0}	$sha")
+    fi
+  done
+  selected=""
+  [ "${#eligible[@]}" -gt 0 ] && selected="$(printf '%s\n' "${eligible[@]}" | sort -rn -k1 | head -n "$max_bars" | cut -f2)"
+
+  while IFS= read -r sha; do
+    [ -n "$sha" ] || continue
+    running=${c_running[$sha]:-0}
+    done_n=${c_done[$sha]:-0}
+    total=${c_total[$sha]:-1}
+    branch="${c_branch[$sha]:-?}"
+    sha7="${sha:0:7}"
+    url="https://github.com/$repo/commit/$sha"
     active_urls="$active_urls
 $url"
 
-    # Title carries the bitmap (ASCII-only) font, so stick to ASCII separators.
-    bar_title="$short: $wf ($branch)"
+    # Fill = (finished checks + summed partial of running ones) / total checks.
+    progmilli=$(((done_n * 1000 + ${c_partmilli[$sha]:-0}) / total))
+    [ "$progmilli" -lt 20 ] && progmilli=20
+    [ "$progmilli" -gt 970 ] && progmilli=970
+    prog="$(printf '0.%03d' "$progmilli")"
 
-    startsec=0
-    case "$status" in
-      queued | requested | waiting | pending)
-        color="purple"
-        prog="0.02"
-        desc="Queued on GitHub Actions, waiting for a runner.
+    # Green once any check is running or finished; purple while the commit's
+    # checks are all still queued / not yet picked up by a runner.
+    if [ "$running" -gt 0 ] || [ "$done_n" -gt 0 ]; then color="green"; else color="purple"; fi
+    minstart=${c_minstart[$sha]:-0}
 
-$title"
-        ;;
-      *) # in_progress (and any other non-terminal state)
-        color="green"
-        startsec="$(iso_to_epoch "${started:-}")"
-        [ "${startsec:-0}" -gt 0 ] 2>/dev/null || startsec="$(iso_to_epoch "${created:-}")"
-        avg="$(get_avg "$repo" "$wf")"
-        [ "${avg:-0}" -gt 0 ] 2>/dev/null || avg="$default_avg"
-        elapsed=$((now - startsec))
-        [ "$elapsed" -ge 0 ] || elapsed=0
-        # Integer math to avoid an awk/gawk dependency: fill in thousandths,
-        # clamped to [0.020, 0.970]. prog_milli is always < 1000, so the "0."
-        # prefix is correct.
-        prog_milli=$((elapsed * 1000 / avg))
-        [ "$prog_milli" -lt 20 ] && prog_milli=20
-        [ "$prog_milli" -gt 970 ] && prog_milli=970
-        prog="$(printf '0.%03d' "$prog_milli")"
-        desc="Running on GitHub Actions.
-
-Progress is estimated from the average of recent successful runs of this workflow. The title shows elapsed time; it clears when the run finishes."
-        ;;
-    esac
+    # ASCII-only title (bitmap font): repo, branch, finished/total, short sha.
+    bar_title="$short: $branch ($done_n/$total) $sha7"
 
     id="$(bar_id_for_url "$url")"
     if [ -z "$id" ]; then
-      if [ "${startsec:-0}" -gt 0 ] 2>/dev/null; then
-        bossbar add "$bar_title" --color "$color" --overlay progress --progress "$prog" --position -1 --since "$startsec" --url "$url" --description "$desc" 2>/dev/null || true
+      if [ "${minstart:-0}" -gt 0 ] 2>/dev/null; then
+        bossbar add "$bar_title" --color "$color" --overlay progress --progress "$prog" --position -1 --since "$minstart" --url "$url" --box 0 2>/dev/null || true
       else
-        bossbar add "$bar_title" --color "$color" --overlay progress --progress "$prog" --position -1 --url "$url" --description "$desc" 2>/dev/null || true
+        bossbar add "$bar_title" --color "$color" --overlay progress --progress "$prog" --position -1 --url "$url" --box 0 2>/dev/null || true
       fi
     else
-      # Existing bar: refresh fill/color/title in place. A run first seen while
-      # QUEUED was added with no `since` (purple, no clock); once it starts
-      # running we must stamp `since` so the live elapsed timer begins. Only stamp
-      # when the bar has none yet, so an already-ticking clock survives polls and
-      # restarts (mirrors ix-downtime.sh's heal-in-place rule).
+      # Heal in place: refresh fill/color/title. Stamp `since` only once (when the
+      # commit's first check starts running) so the live timer survives polls.
       cur_since="$(sqlite3 "$bdb" "SELECT COALESCE(since,0) FROM bossbars WHERE id = $id;" 2>/dev/null || printf '0')"
-      if [ "${startsec:-0}" -gt 0 ] 2>/dev/null && [ "${cur_since:-0}" -le 0 ] 2>/dev/null; then
-        bossbar set "$id" --title "$bar_title" --color "$color" --progress "$prog" --since "$startsec" --description "$desc" 2>/dev/null || true
+      if [ "${minstart:-0}" -gt 0 ] 2>/dev/null && [ "${cur_since:-0}" -le 0 ] 2>/dev/null; then
+        bossbar set "$id" --title "$bar_title" --color "$color" --progress "$prog" --since "$minstart" --box 0 2>/dev/null || true
       else
-        bossbar set "$id" --title "$bar_title" --color "$color" --progress "$prog" --description "$desc" 2>/dev/null || true
+        bossbar set "$id" --title "$bar_title" --color "$color" --progress "$prog" --box 0 2>/dev/null || true
       fi
     fi
-  done < <(printf '%s' "$runs" | jq -r --argjson max "$max_bars" '
-    [ .[] | select((.status // "completed") != "completed") ]
-    | sort_by(.createdAt) | reverse | .[0:$max]
-    | .[]
-    | [ (.databaseId|tostring), .workflowName, .displayTitle, .headBranch,
-        .status, (.startedAt // ""), (.createdAt // ""), (.url // "") ] | @tsv')
+  done <<EOF
+$selected
+EOF
 done
 
-# Prune bars for runs no longer in flight: any overlay row whose url is an Actions
-# run but is not in this poll's active set has completed (or was cancelled), so
-# drop it. Scoped to /actions/runs/ urls so downtime bars (status-page url) and
-# any hand-added bars are never touched.
+# Prune bars for commits no longer in flight: any overlay row whose url is a
+# commit page but is not in this poll's active set has finished all its checks
+# (or was cancelled), so drop it (the overlay poofs it out). Scoped to commit
+# urls so downtime bars (status-page url) and hand-added bars are never touched.
 if [ -n "$bdb" ]; then
   existing="$(sqlite3 -noheader -separator "	" "$bdb" \
-    "SELECT id, url FROM bossbars WHERE url LIKE '%/actions/runs/%';" 2>/dev/null || true)"
+    "SELECT id, url FROM bossbars WHERE url LIKE 'https://github.com/%/commit/%';" 2>/dev/null || true)"
   while IFS=$'\t' read -r eid eurl; do
     [ -n "${eid:-}" ] || continue
     if ! printf '%s\n' "$active_urls" | grep -qxF "$eurl"; then

--- a/packages/bossbar-overlay/ci-bars.sh
+++ b/packages/bossbar-overlay/ci-bars.sh
@@ -115,10 +115,17 @@ CREATE TABLE IF NOT EXISTS wf_avg(
 SQL
 
 get_avg() {
-  local repo="$1" wf="$2" cached upd rows st en se ee d total count avg
-  cached="$(sqlite3 "$db" "SELECT avg_secs FROM wf_avg WHERE repo='$(sq "$repo")' AND wf='$(sq "$wf")';" 2>/dev/null || printf '')"
-  upd="$(sqlite3 "$db" "SELECT updated_at FROM wf_avg WHERE repo='$(sq "$repo")' AND wf='$(sq "$wf")';" 2>/dev/null || printf '0')"
-  upd="${upd:-0}"
+  local repo="$1" wf="$2" row cached upd rows st en se ee d total count avg
+  # One read for both cached value and its age (tab-separated), not two.
+  row="$(sqlite3 -noheader -separator "	" "$db" \
+    "SELECT avg_secs, updated_at FROM wf_avg WHERE repo='$(sq "$repo")' AND wf='$(sq "$wf")';" 2>/dev/null || printf '')"
+  if [ -n "$row" ]; then
+    cached="${row%%	*}"
+    upd="${row#*	}"
+  else
+    cached=""
+    upd=0
+  fi
   if [ -n "$cached" ] && [ "$((now - upd))" -lt "$avg_ttl" ]; then
     printf '%s' "$cached"
     return
@@ -148,15 +155,18 @@ EOF
   printf '%s' "$avg"
 }
 
-# Commit urls drawn this poll (newline-separated), used to prune finished bars.
-# Identity is the commit, so all of a commit's checks share ONE bar.
+# Commit urls with in-flight checks this poll (newline-separated), used to prune
+# bars for commits whose CI has finished. Identity is the commit, so all of a
+# commit's checks share ONE bar.
 active_urls=""
 
 for repo in "${repos[@]}"; do
   short="${repo##*/}"
-  # One list call per repo per poll: every recent run, all branches, all
-  # workflows, grouped below by head commit (headSha).
-  runs="$(gh run list --repo "$repo" --limit 100 \
+  # One list call per repo per poll: recent runs across all branches and
+  # workflows, grouped below by head commit (headSha). The window must hold all
+  # of an in-flight commit's checks (completed + running) for its done/total to be
+  # right; an in-flight commit's runs are recent, so 200 is comfortably enough.
+  runs="$(gh run list --repo "$repo" --limit 200 \
     --json workflowName,headBranch,headSha,status,conclusion,startedAt,createdAt,url \
     2>/dev/null)" || continue
   [ -n "$runs" ] || continue
@@ -203,13 +213,18 @@ for repo in "${repos[@]}"; do
     .[] | [ .headSha, .headBranch, .status, .workflowName,
             (.startedAt // ""), (.createdAt // "") ] | @tsv')
 
-  # Select commits that still have in-flight work (running or queued), newest
-  # first, capped to $max_bars so a busy moment cannot flood the screen. Commits
-  # whose checks have all finished get no bar and are pruned below.
+  # Commits that still have in-flight work (running or queued). EVERY such commit
+  # is recorded in active_urls (so the prune below never removes a still-building
+  # commit), but we only DRAW the newest $max_bars of them, so a busy moment
+  # cannot flood the screen. A commit past the cap simply keeps whatever bar it
+  # had (or none) without flapping; it gets drawn once it re-enters the top N, and
+  # pruned only once its checks all finish (it leaves active_urls).
   eligible=()
   for sha in "${!c_total[@]}"; do
     if [ $((${c_running[$sha]:-0} + ${c_queued[$sha]:-0})) -gt 0 ]; then
       eligible+=("${c_created[$sha]:-0}	$sha")
+      active_urls="$active_urls
+https://github.com/$repo/commit/$sha"
     fi
   done
   selected=""
@@ -223,8 +238,6 @@ for repo in "${repos[@]}"; do
     branch="${c_branch[$sha]:-?}"
     sha7="${sha:0:7}"
     url="https://github.com/$repo/commit/$sha"
-    active_urls="$active_urls
-$url"
 
     # Fill = (finished checks + summed partial of running ones) / total checks.
     progmilli=$(((done_n * 1000 + ${c_partmilli[$sha]:-0}) / total))


### PR DESCRIPTION
Three boss-bar UX changes (overlay app + ci-bars watcher):

- **Poof despawn** — a bar that leaves the DB shrinks toward its center and fades out (ease-out, 280ms) before its window closes, instead of blinking off. Cancels if the bar reappears mid-poof.
- **Per-bar hover box** — new `expandable` column (default 1) + `bossbar --box 0|1`. A non-expandable bar stays bar-sized on hover with no pop-down panel even if it has description text. Gated in the live path and both scene builders; migrated by db.rs and the CLI.
- **One CI bar per commit** — `ci-bars` now aggregates all of a commit's in-flight checks into a single bar titled `(done/total)`, filled by `(finished + running-partial)/total`, green if any check is running/done else purple. Identity = commit URL; bars are boxless.

Validated: overlay build + crate tests (incl. new `expandable` round-trip); commit grouping run live against GitHub (one bar/commit, `(done/total)`, box=0); box gating by snapshot (box=1 panel, box=0 none); `nix run .#lint` clean; shellcheck/`bash -n` clean. Also fixes a statix `inherit` nit on main.

Made with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add poof removal animation, per-bar box opt-out, and one CI bar per commit
> - Bars removed from the DB now play a 280ms shrink-and-fade animation before their windows close; bars reappearing mid-poof cancel the animation ([overlay.rs](https://github.com/indexable-inc/index/pull/563/files#diff-be0c00f68d255b3fe86ea924fe83d030d2a948a7e2d919b45eb19a51fa82ae26)).
> - Adds a new `expandable` DB column (default 1) and `--box 0|1` CLI flag to suppress the hover description panel on a per-bar basis ([bossbar](https://github.com/indexable-inc/index/pull/563/files#diff-1fad49b8441816629a2092d448fa6c404ca357583ccfc12f8267b2182599e708), [db.rs](https://github.com/indexable-inc/index/pull/563/files#diff-42684612e79f72369cee1c08d7d35ca68b866728adf9582f6c95e2900cdc589b)).
> - CI bars now aggregate by HEAD commit instead of workflow run: one bar per commit, progress summed across checks, color green if any running/done and purple if all queued, bars created with `--box 0` ([ci-bars.sh](https://github.com/indexable-inc/index/pull/563/files#diff-ce117a27b79163dcb46088405043eaf6ac8b357c7c6a0c7687b4c2d0fb0de853)).
> - Behavioral Change: existing CI bars keyed by Actions run URL will be replaced by bars keyed by commit URL on next run; old bars must be pruned manually or will be cleaned up by the new prune logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 539fc7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->