### PR TITLE
ci-bars: prune legacy per-run bars (migration self-heal)

### DIFF
--- a/packages/bossbar-overlay/ci-bars.sh
+++ b/packages/bossbar-overlay/ci-bars.sh
@@ -290,4 +290,18 @@ if [ -n "$bdb" ]; then
   done <<EOF
 $existing
 EOF
+
+  # Legacy migration: an earlier version of this watcher drew one bar per
+  # workflow RUN (url .../actions/runs/<id>). The per-commit scheme never creates
+  # those, and nothing else does (pr-watch uses the xp-orb feed, ix-downtime uses
+  # the status-page url), so any such row is a stale leftover from before the
+  # upgrade. Drop them so a host that ran the old version self-heals on first poll.
+  legacy="$(sqlite3 -noheader "$bdb" \
+    "SELECT id FROM bossbars WHERE url LIKE '%/actions/runs/%';" 2>/dev/null || true)"
+  while IFS= read -r eid; do
+    [ -n "${eid:-}" ] || continue
+    bossbar rm "$eid" 2>/dev/null || true
+  done <<EOF
+$legacy
+EOF
 fi


### PR DESCRIPTION
Follow-up to #563. The per-commit rewrite never creates the old per-workflow-run bars (`.../actions/runs/<id>`); prune any leftover so a host that ran the old watcher self-heals instead of showing stale per-run bars beside the new per-commit ones. Already manually cleaned on hydra; this makes it automatic. Made with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prune legacy per-run bossbars matching `/actions/runs/` URLs on startup
> Adds a self-healing migration block to [ci-bars.sh](https://github.com/indexable-inc/index/pull/564/files#diff-3aba65acb9a333e9dfbb82745f5f2b85a47136e34156ae144f259fa6ab803b19) that queries the bossbars SQLite database for entries whose URL contains `/actions/runs/` and removes each via `bossbar rm`, ignoring errors. This cleans up stale per-run entries left over from a previous format.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38121c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->