### PR TITLE
feat(andrewgazelka): halve boss bar overlay size

### DIFF
--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -257,6 +257,15 @@ in
         default = true;
         description = "Run the always-on-top Minecraft boss bar overlay GUI the watcher draws onto.";
       };
+      scale = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 1;
+        description = ''
+          Integer pixel scale for the boss bar sprites (and, proportionally,
+          their title text and pop-down panels). The overlay binary defaults to
+          2; 1 renders everything at half that size.
+        '';
+      };
     };
 
     mergeOrbOverlay = {
@@ -409,7 +418,11 @@ in
       (lib.mkIf cfg.bossbarOverlay.enable {
         bossbar-overlay = {
           description = "Minecraft boss bar overlay";
-          command = [ (lib.getExe' indexPkgs.bossbar-overlay "bossbar-overlay") ];
+          command = [
+            (lib.getExe' indexPkgs.bossbar-overlay "bossbar-overlay")
+            "--scale"
+            (toString cfg.bossbarOverlay.scale)
+          ];
           restart = "always";
           standardOutPath = "${cfg.logDir}/bossbar-overlay.log";
           standardErrorPath = "${cfg.logDir}/bossbar-overlay.log";


### PR DESCRIPTION
Make the boss bars render at 50% — andrew asked for much smaller bars.

Adds `bossbarOverlay.scale` (default 1) on the andrewgazelka home module and passes it as `--scale` to the single overlay process that renders every boss bar (CI bars, downtime, pr-watch). The binary defaults to scale 2; scale 1 halves the sprites, title text, and pop-down panels uniformly (the scene multiplies all metrics by the integer sprite scale).

Made with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Halve boss bar overlay size by setting default scale to 1
> Adds a `--scale` flag to the `bossbar-overlay` systemd service command, sourced from a new `bossbarOverlay.scale` Nix option in [home.nix](https://github.com/indexable-inc/index/pull/567/files#diff-b9c7bb705f699ec210f648820aef5c561583845b682d07d6e1dc19de7685cb0f). The option defaults to `1`, halving the effective size compared to the binary's previous default of `2`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca47455.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->