### PR TITLE
feat(bossbar): human-readable PR titles + author avatars on CI bars

### DIFF
--- a/packages/bossbar-overlay/app/crates/bossbar/src/bars.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/bars.rs
@@ -132,6 +132,12 @@ pub struct BossBar {
     /// the title), set once the bar is dragged. `None` keeps the bar in the
     /// auto-stacked top-center column. Persisted to the `x`/`y` DB columns.
     pub pos: Option<glam::DVec2>,
+    /// Filesystem path to a small image (PNG/JPEG) drawn as a square icon to the
+    /// left of the title, e.g. the GitHub avatar of whoever opened a PR. Empty
+    /// means no icon. The overlay loads and caches it by path; a path that does
+    /// not exist or fails to decode is simply skipped (the bar still draws).
+    /// Persisted to the `icon` DB column.
+    pub icon: String,
 }
 
 #[cfg(test)]

--- a/packages/bossbar-overlay/app/crates/bossbar/src/db.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/db.rs
@@ -34,7 +34,8 @@ CREATE TABLE IF NOT EXISTS bossbars (
   since       INTEGER,
   url         TEXT    NOT NULL DEFAULT '',
   expandable  INTEGER NOT NULL DEFAULT 1,
-  eta         INTEGER
+  eta         INTEGER,
+  icon        TEXT    NOT NULL DEFAULT ''
 );";
 
 /// Columns added after the initial schema shipped. `ALTER TABLE ADD COLUMN` is
@@ -49,6 +50,7 @@ const ADDED_COLUMNS: &[(&str, &str)] = &[
     ("url", "TEXT NOT NULL DEFAULT ''"),
     ("expandable", "INTEGER NOT NULL DEFAULT 1"),
     ("eta", "INTEGER"),
+    ("icon", "TEXT NOT NULL DEFAULT ''"),
 ];
 
 /// Rows inserted only when the DB file is created for the first time, so a
@@ -124,7 +126,7 @@ pub fn set_position(path: &Path, id: i64, pos: glam::DVec2) -> rusqlite::Result<
 
 fn read(conn: &Connection) -> rusqlite::Result<Vec<BossBar>> {
     let mut stmt = conn.prepare(
-        "SELECT id, title, progress, color, overlay, position, x, y, description, since, url, expandable, eta
+        "SELECT id, title, progress, color, overlay, position, x, y, description, since, url, expandable, eta, icon
          FROM bossbars
          WHERE visible != 0
          ORDER BY position ASC, id ASC",
@@ -153,6 +155,7 @@ fn read(conn: &Connection) -> rusqlite::Result<Vec<BossBar>> {
             // Both coordinates must be present to pin a bar; a half-written row
             // falls back to auto-stacking rather than placing it at an edge.
             pos: x.zip(y).map(|(x, y)| glam::DVec2::new(x, y)),
+            icon: r.get(13)?,
         })
     })?;
     rows.collect()

--- a/packages/bossbar-overlay/app/crates/bossbar/src/layer_shell.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/layer_shell.rs
@@ -78,9 +78,13 @@ impl GpuCore {
         if let Some(cached) = self.icon_cache.get(path) {
             return *cached;
         }
-        let handle = std::fs::read(path)
-            .ok()
-            .and_then(|bytes| self.gpu.register_image_scaled(&bytes, scene::ICON_MAX_PX));
+        // Read failure is transient (writer may not have created the file yet) so
+        // is not cached; a decode result is cached. This is what lets the
+        // `reconcile` retry below actually pick up an avatar that appeared late.
+        let Ok(bytes) = std::fs::read(path) else {
+            return None;
+        };
+        let handle = self.gpu.register_image_scaled(&bytes, scene::ICON_MAX_PX);
         self.icon_cache.insert(path.to_string(), handle);
         handle
     }

--- a/packages/bossbar-overlay/app/crates/bossbar/src/layer_shell.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/layer_shell.rs
@@ -27,7 +27,7 @@ use layershellev::{
 use overlay_core::glam::DVec2;
 use overlay_core::wgpu;
 use overlay_core::winit::dpi::PhysicalPosition;
-use overlay_core::{DragClick, Gpu, HoverAnim, anim, window as ocwin};
+use overlay_core::{DragClick, Gpu, HoverAnim, TexHandle, anim, window as ocwin};
 
 use crate::bars::BossBar;
 use crate::db;
@@ -64,6 +64,26 @@ struct GpuCore {
     textures: BarTextures,
     format: wgpu::TextureFormat,
     alpha_mode: wgpu::CompositeAlphaMode,
+    /// Icon path -> uploaded texture, memoized so a bar's avatar uploads once.
+    /// `None` records a path that failed to load, so it is tried once then skipped.
+    icon_cache: HashMap<String, Option<TexHandle>>,
+}
+
+impl GpuCore {
+    /// Resolve an icon path to its texture, loading and caching on first use.
+    fn icon(&mut self, path: &str) -> Option<TexHandle> {
+        if path.is_empty() {
+            return None;
+        }
+        if let Some(cached) = self.icon_cache.get(path) {
+            return *cached;
+        }
+        let handle = std::fs::read(path)
+            .ok()
+            .and_then(|bytes| self.gpu.register_image_scaled(&bytes, scene::ICON_MAX_PX));
+        self.icon_cache.insert(path.to_string(), handle);
+        handle
+    }
 }
 
 struct BarWin {
@@ -75,6 +95,8 @@ struct BarWin {
     hover_anim: HoverAnim,
     last: Instant,
     gesture: DragClick,
+    /// Resolved texture for `bar.icon`; re-resolved when the icon path changes.
+    icon_tex: Option<TexHandle>,
     self_set: Pos,
     press_cursor: Option<PhysicalPosition<f64>>,
     press_pos: Option<Pos>,
@@ -307,7 +329,7 @@ impl App {
         let scale_factor = 1.0;
         let scale = self.scale(scale_factor);
         let title_w = scene::title_extent_px(&bar, scale, now_unix());
-        let size = scene::bar_window_px(scale, title_w);
+        let size = scene::bar_window_px(scale, title_w, !bar.icon.is_empty());
         let pinned = bar.pos.is_some();
         let pos = bar
             .pos
@@ -316,6 +338,10 @@ impl App {
         let shell_id = ShellId::unique();
         let now = Instant::now();
         let has_description = !bar.description.trim().is_empty();
+        // The GPU core is created lazily on the first layer surface, so it may not
+        // exist yet here; `icon` returns None in that case and `reconcile`
+        // resolves the avatar once the core is up.
+        let icon_tex = self.core.as_mut().and_then(|c| c.icon(&bar.icon));
         self.wins.insert(
             bar.id,
             BarWin {
@@ -323,6 +349,7 @@ impl App {
                 surface: None,
                 config: None,
                 bar: bar.clone(),
+                icon_tex,
                 hovered: false,
                 hover_anim: HoverAnim::default(),
                 last: now,
@@ -404,6 +431,14 @@ impl App {
                 .and_then(|win| Self::output_logical_width(ev, win.shell_id));
             if let Some(win) = self.wins.get_mut(&bar.id) {
                 win.has_description = !bar.description.trim().is_empty();
+                // Resolve the avatar when the icon path changed, or when it was not
+                // yet resolved (e.g. the GPU core came up after this bar was first
+                // created). Disjoint field borrows (`wins` vs `core`) are fine.
+                let need_icon =
+                    win.bar.icon != bar.icon || (win.icon_tex.is_none() && !bar.icon.is_empty());
+                if need_icon {
+                    win.icon_tex = self.core.as_mut().and_then(|c| c.icon(&bar.icon));
+                }
                 let local_position_active = win.local_position_active(now);
                 let local_pinned = win.bar.pos.is_some();
                 let local_pos = win.self_set;
@@ -521,6 +556,7 @@ impl App {
                 textures,
                 format,
                 alpha_mode,
+                icon_cache: HashMap::new(),
             });
         }
 
@@ -546,12 +582,12 @@ impl App {
                 Some(core) => scene::expanded_window_px(&core.gpu, &win.bar, win.scale, now),
                 None => {
                     let title_w = scene::title_extent_px(&win.bar, win.scale, now);
-                    scene::bar_window_px(win.scale, title_w)
+                    scene::bar_window_px(win.scale, title_w, !win.bar.icon.is_empty())
                 }
             }
         } else {
             let title_w = scene::title_extent_px(&win.bar, win.scale, now);
-            scene::bar_window_px(win.scale, title_w)
+            scene::bar_window_px(win.scale, title_w, !win.bar.icon.is_empty())
         };
 
         if win.last_size == size {
@@ -640,7 +676,7 @@ impl App {
             // If this frame just eased a leaving hover to rest, the size-settle
             // pass above kept the expanded surface. Queue one more pass to shrink it.
             let title_w = scene::title_extent_px(&win.bar, win.scale, unix_now);
-            let collapsed_size = scene::bar_window_px(win.scale, title_w);
+            let collapsed_size = scene::bar_window_px(win.scale, title_w, !win.bar.icon.is_empty());
             (
                 hover,
                 !win.wants_expanded() && win.last_size != collapsed_size,
@@ -678,6 +714,7 @@ impl App {
         let quads = scene::build_one(
             &core.gpu,
             &core.textures,
+            win.icon_tex,
             win.scale,
             config.width,
             config.height,

--- a/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
@@ -28,7 +28,7 @@ use overlay_core::winit::event::{
 };
 use overlay_core::winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
 use overlay_core::winit::window::{CursorIcon, Window, WindowId};
-use overlay_core::{anim, window as ocwin, DragClick, Gpu, HoverAnim};
+use overlay_core::{anim, window as ocwin, DragClick, Gpu, HoverAnim, TexHandle};
 
 use crate::bars::BossBar;
 use crate::db;
@@ -104,6 +104,29 @@ struct GpuCore {
     textures: BarTextures,
     format: wgpu::TextureFormat,
     alpha_mode: wgpu::CompositeAlphaMode,
+    /// Icon path -> uploaded texture, memoized so a bar's avatar uploads once
+    /// rather than every reconcile. `None` records a path that did not exist or
+    /// failed to decode, so a broken icon is tried once and then skipped.
+    icon_cache: HashMap<String, Option<TexHandle>>,
+}
+
+impl GpuCore {
+    /// Resolve an icon path to its texture, loading and caching on first use.
+    /// Empty path or a read/decode failure yields `None` (the bar draws without
+    /// an icon). Cached by path, so re-resolving across reconciles is free.
+    fn icon(&mut self, path: &str) -> Option<TexHandle> {
+        if path.is_empty() {
+            return None;
+        }
+        if let Some(cached) = self.icon_cache.get(path) {
+            return *cached;
+        }
+        let handle = std::fs::read(path)
+            .ok()
+            .and_then(|bytes| self.gpu.register_image_scaled(&bytes, scene::ICON_MAX_PX));
+        self.icon_cache.insert(path.to_string(), handle);
+        handle
+    }
 }
 
 /// One bar's window and its surface.
@@ -112,6 +135,10 @@ struct BarWin {
     surface: wgpu::Surface<'static>,
     config: wgpu::SurfaceConfiguration,
     bar: BossBar,
+    /// Resolved texture for `bar.icon` (the square avatar), re-resolved whenever
+    /// the bar's icon path changes. `None` when the bar has no icon or it failed
+    /// to load.
+    icon_tex: Option<TexHandle>,
     /// Hover target: the pointer is currently over this bar.
     hovered: bool,
     /// Hover amount animated toward `hovered` each frame. Drives the grow +
@@ -203,6 +230,7 @@ impl App {
                 textures,
                 format,
                 alpha_mode,
+                icon_cache: HashMap::new(),
             });
         }
 
@@ -234,7 +262,7 @@ impl App {
         // edge. Measured on the CPU font, so this works before the GPU core exists
         // (the first window is created before its surface).
         let title_w = scene::title_extent_px(&bar, self.scale, now_unix());
-        let (w_px, h_px) = scene::bar_window_px(self.scale, title_w);
+        let (w_px, h_px) = scene::bar_window_px(self.scale, title_w, !bar.icon.is_empty());
         let pos = match bar.pos {
             Some(p) => LogicalPosition::new(p.x, p.y),
             None => self.auto_pos(slot, w_px, h_px),
@@ -247,12 +275,15 @@ impl App {
         let (surface, config) = self.make_surface(&window);
         window.request_redraw();
         let has_description = !bar.description.trim().is_empty();
+        // `make_surface` guarantees the GPU core exists, so the icon can upload now.
+        let icon_tex = self.core.as_mut().and_then(|c| c.icon(&bar.icon));
         let now = Instant::now();
         Some(BarWin {
             window,
             surface,
             config,
             bar,
+            icon_tex,
             hovered: false,
             hover_anim: HoverAnim::default(),
             last: now,
@@ -301,6 +332,11 @@ impl App {
                     win.window.request_redraw();
                 }
                 win.has_description = !b.description.trim().is_empty();
+                // Re-resolve the avatar only when the icon path actually changed,
+                // so a steady bar does not re-touch the cache each reconcile.
+                if win.bar.icon != b.icon {
+                    win.icon_tex = self.core.as_mut().and_then(|c| c.icon(&b.icon));
+                }
                 win.bar = b.clone();
                 // Honor a position set in the DB by something other than our own
                 // drag (e.g. the CLI), but do not fight a live drag: while the
@@ -376,6 +412,7 @@ impl App {
         let mut quads = scene::build_one(
             &core.gpu,
             &core.textures,
+            win.icon_tex,
             self.scale,
             win.config.width,
             win.config.height,
@@ -502,7 +539,7 @@ impl App {
             scene::expanded_window_px(&core.gpu, &win.bar, self.scale, now)
         } else {
             let title_w = scene::title_extent_px(&win.bar, self.scale, now);
-            scene::bar_window_px(self.scale, title_w)
+            scene::bar_window_px(self.scale, title_w, !win.bar.icon.is_empty())
         };
         let (prev_w, _) = win.last_size;
         if win.last_size == (w_px, h_px) {

--- a/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
@@ -121,9 +121,14 @@ impl GpuCore {
         if let Some(cached) = self.icon_cache.get(path) {
             return *cached;
         }
-        let handle = std::fs::read(path)
-            .ok()
-            .and_then(|bytes| self.gpu.register_image_scaled(&bytes, scene::ICON_MAX_PX));
+        // A read failure is transient (the writer may not have created the file
+        // yet), so do NOT cache it: returning None unmemoized lets a later
+        // reconcile pick the avatar up once it exists. A decode result (success or
+        // a genuinely undecodable file) is cached, since re-reading won't change it.
+        let Ok(bytes) = std::fs::read(path) else {
+            return None;
+        };
+        let handle = self.gpu.register_image_scaled(&bytes, scene::ICON_MAX_PX);
         self.icon_cache.insert(path.to_string(), handle);
         handle
     }

--- a/packages/bossbar-overlay/app/crates/bossbar/src/scene.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/scene.rs
@@ -40,6 +40,39 @@ const MAX_SCALE: f32 = HOVER_SCALE * (1.0 + BREATHE_AMP);
 /// White tint: a sprite shows its texture unchanged.
 const WHITE: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
 
+/// Gap (source px) between a bar's square icon and its title text. The icon is
+/// drawn as a square the height of the title row, so `[icon][gap]title` reads as
+/// one centered unit above the bar.
+const ICON_GAP: f32 = 2.0;
+
+/// How tall the title row grows when a bar has an icon, as a multiple of the
+/// glyph height. The square avatar fills the row, so a value > 1 makes the face
+/// large enough to recognize while the text stays centered beside it. The bar
+/// track and the rest of the layout shift down to keep the avatar from
+/// overlapping the bar.
+const ICON_SCALE: f32 = 2.0;
+
+/// Glyph height (source px) of one title row. The avatar is a square of the row
+/// height; with an icon the row is [`ICON_SCALE`] glyphs tall, else one glyph.
+const GLYPH_PX: f32 = 8.0;
+
+/// Title-row height in physical px: `ICON_SCALE` glyphs when the bar carries an
+/// icon (room for the square avatar), one glyph otherwise. `glyph_px` is the
+/// glyph height at the current scale (`GLYPH_PX * s`). Shared by the live and
+/// snapshot layout paths and the window-sizing helpers so geometry stays in sync.
+fn title_row_h(glyph_px: f32, has_icon: bool) -> f32 {
+    if has_icon {
+        glyph_px * ICON_SCALE
+    } else {
+        glyph_px
+    }
+}
+
+/// Largest dimension (px) an icon texture is downscaled to on upload. The icon
+/// draws at roughly the title-row height (tens of px), so a small cap keeps the
+/// nearest-sampled avatar legible without holding a full-size photo on the GPU.
+pub const ICON_MAX_PX: u32 = 96;
+
 /// Description pop-down panel, in native (unscaled) pixels. Everything is
 /// multiplied by the integer sprite `scale`, so the panel stays pixel-crisp and
 /// proportional to the bars at any display scale.
@@ -179,6 +212,9 @@ struct DrawItem<'a> {
     geom: BarBox,
     alpha: f32,
     panel: Option<PanelBox>,
+    /// Loaded texture for the bar's square icon, if it has one and it decoded.
+    /// Drawn left of the title; `None` draws the title alone, as before.
+    icon: Option<TexHandle>,
 }
 
 /// The fill fraction to draw: extrapolated live from `since`/`eta` when both are
@@ -219,14 +255,30 @@ fn build_item(gpu: &Gpu, tex: &BarTextures, scale: u32, now_unix: i64, item: &Dr
         // means a scale of `title_px / 8`.
         let glyph_scale = bx.title_px / 8.0;
         let text_w = gpu.measure(&shown, glyph_scale);
-        // Center the title within the bar width.
-        let tx = bx.left + (bx.bar_w - text_w) * 0.5;
+        // A square avatar (when present and loaded) leads the title: lay them out
+        // as one `[icon][gap]title` unit centered within the bar width, so the
+        // title stays visually centered with the face beside it. The avatar fills
+        // the title row, which is taller (see `title_row_h`) when the bar has an
+        // icon; the text is vertically centered in that row beside the face. The
+        // row height tracks `b.icon` (what the geometry reserved) so the layout is
+        // stable even if the image failed to decode and no avatar is drawn.
+        let has_icon = !b.icon.is_empty();
+        let row_h = title_row_h(bx.title_px, has_icon);
+        let text_y = bx.title_top + (row_h - bx.title_px) * 0.5;
+        let icon_side = if item.icon.is_some() { row_h } else { 0.0 };
+        let icon_gap = if item.icon.is_some() { ICON_GAP * glyph_scale } else { 0.0 };
+        let unit_w = icon_side + icon_gap + text_w;
+        let unit_left = bx.left + (bx.bar_w - unit_w) * 0.5;
+        if let Some(icon) = item.icon {
+            quads.push(Quad::new(icon, unit_left, bx.title_top, icon_side, icon_side, tint));
+        }
+        let tx = unit_left + icon_side + icon_gap;
         let shadow = with_alpha(SHADOW, alpha);
         let fg = with_alpha(WHITE, alpha);
         // The shadow offset is a fixed (unscaled) pixel, matching the old
         // glyphon path which offset by `self.scale`, not the grown glyph scale.
-        let _ = gpu.text(&shown, tx + shadow_off, bx.title_top + shadow_off, glyph_scale, shadow, quads);
-        let _ = gpu.text(&shown, tx, bx.title_top, glyph_scale, fg, quads);
+        let _ = gpu.text(&shown, tx + shadow_off, text_y + shadow_off, glyph_scale, shadow, quads);
+        let _ = gpu.text(&shown, tx, text_y, glyph_scale, fg, quads);
     }
 
     // Color background, then color progress cropped to the fill.
@@ -379,7 +431,17 @@ pub fn title_extent_px(bar: &BossBar, scale: u32, now_unix: i64) -> f32 {
     // The grown title row is `8 * scale * MAX_SCALE` px tall, so each glyph samples
     // at `scale * MAX_SCALE` source-px (the `title_px / 8` of `build_one`, maxed).
     let glyph_scale = scale.max(1) as f32 * MAX_SCALE;
-    overlay_core::bitmap_font::shared().measure(&shown, glyph_scale)
+    let text_w = overlay_core::bitmap_font::shared().measure(&shown, glyph_scale);
+    // Reserve room for the square avatar (a row-height square, so `ICON_SCALE`
+    // glyphs wide) plus its gap, so the window holds `[icon][gap]title` without
+    // the title being clipped. Over-reserves harmlessly if the icon later fails
+    // to load.
+    let icon_w = if bar.icon.is_empty() {
+        0.0
+    } else {
+        (GLYPH_PX * ICON_SCALE + ICON_GAP) * glyph_scale
+    };
+    text_w + icon_w
 }
 
 /// Physical-pixel size of the window that holds one bar at `scale` (base scale
@@ -388,12 +450,18 @@ pub fn title_extent_px(bar: &BossBar, scale: u32, now_unix: i64) -> f32 {
 /// [`title_extent_px`]); the window widens to hold a title longer than the bar,
 /// and a nonzero `title_w` adds the title row. Plus a one-pixel-scaled shadow
 /// margin on the right and bottom.
-pub fn bar_window_px(scale: u32, title_w: f32) -> (u32, u32) {
+pub fn bar_window_px(scale: u32, title_w: f32, has_icon: bool) -> (u32, u32) {
     let s = scale.max(1) as f32 * MAX_SCALE;
     let bar_w = BAR_W as f32 * s;
     let bar_h = BAR_H as f32 * s;
     let has_title = title_w > 0.0;
-    let title = if has_title { 8.0 * s + 1.0 * s } else { 0.0 };
+    // The title row grows for the square avatar when the bar has an icon; reserve
+    // that height plus the one-px title gap so the taller row is never clipped.
+    let title = if has_title {
+        title_row_h(GLYPH_PX * s, has_icon) + 1.0 * s
+    } else {
+        0.0
+    };
     let shadow = scale.max(1) as f32;
     // Hold whichever is wider, the bar sprite or the title text; both trail the
     // one-pixel shadow down-right, so the shadow margin covers the right edge too.
@@ -406,7 +474,7 @@ pub fn bar_window_px(scale: u32, title_w: f32) -> (u32, u32) {
 /// size when the bar has no description. The overlay grows the window to this on
 /// hover so the panel has room to unfold.
 pub fn expanded_window_px(gpu: &Gpu, bar: &BossBar, scale: u32, now_unix: i64) -> (u32, u32) {
-    let (cw, ch) = bar_window_px(scale, title_extent_px(bar, scale, now_unix));
+    let (cw, ch) = bar_window_px(scale, title_extent_px(bar, scale, now_unix), !bar.icon.is_empty());
     match panel_size(gpu, &bar.description, scale) {
         Some((panel_w, panel_h)) => {
             let gap = panel::GAP * scale.max(1) as f32;
@@ -430,9 +498,11 @@ pub fn expanded_window_px(gpu: &Gpu, bar: &BossBar, scale: u32, now_unix: i64) -
 /// overlay enlarges it on hover, see [`expanded_window_px`]), a description panel
 /// unfolds beneath the bar, revealing with `hover`.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub fn build_one(
     gpu: &Gpu,
     tex: &BarTextures,
+    icon: Option<TexHandle>,
     scale: u32,
     width: u32,
     height: u32,
@@ -452,8 +522,15 @@ pub fn build_one(
     let s = scale as f32 * scale_mul;
     let shadow = scale as f32;
     let has_title = !bar.title.is_empty();
-    let title_px = 8.0 * s;
-    let title_h = if has_title { title_px } else { 0.0 };
+    let has_icon = !bar.icon.is_empty();
+    let title_px = GLYPH_PX * s;
+    // The row grows to fit a square avatar when the bar has an icon; the title
+    // text is vertically centered within it (see `build_item`).
+    let title_h = if has_title {
+        title_row_h(title_px, has_icon)
+    } else {
+        0.0
+    };
     let title_gap = if has_title { 1.0 * s } else { 0.0 };
     let bar_w = BAR_W as f32 * s;
     let bar_h = BAR_H as f32 * s;
@@ -462,7 +539,7 @@ pub fn build_one(
     // plus its grow/breathe headroom. Any extra window height below that is the
     // panel's drop area, so the bar stays put as the panel unfolds. Only the
     // height is read here, so the title width need not be exact.
-    let collapsed_h = bar_window_px(scale, title_extent_px(bar, scale, now_unix)).1 as f32;
+    let collapsed_h = bar_window_px(scale, title_extent_px(bar, scale, now_unix), has_icon).1 as f32;
     let top_region_h = collapsed_h.min(height as f32);
 
     // Center the content (plus its shadow offset) in the top region so growth on
@@ -514,6 +591,7 @@ pub fn build_one(
         geom,
         alpha,
         panel,
+        icon,
     };
     let mut quads = Vec::new();
     build_item(gpu, tex, scale, now_unix, &item, &mut quads);
@@ -528,6 +606,7 @@ pub fn build_one(
 pub fn build_all(
     gpu: &Gpu,
     tex: &BarTextures,
+    icons: &[Option<TexHandle>],
     scale: u32,
     width: u32,
     now_unix: i64,
@@ -552,7 +631,12 @@ pub fn build_all(
     let boxes = layout(scale, bars, width as f32, &sizes, gap);
 
     let mut quads = Vec::new();
-    for ((bar, geom), size) in bars.iter().zip(boxes).zip(&sizes) {
+    for (((bar, geom), size), icon) in bars
+        .iter()
+        .zip(boxes)
+        .zip(&sizes)
+        .zip(icons.iter().copied().chain(std::iter::repeat(None)))
+    {
         let panel = size.map(|(panel_w, panel_h)| PanelBox {
             x: ((width as f32 - panel_w) * 0.5).max(0.0),
             y: geom.track_y + geom.bar_h + gap,
@@ -571,6 +655,7 @@ pub fn build_all(
             geom,
             alpha: if Some(bar.id) == highlight { 1.0 } else { opacity },
             panel,
+            icon,
         };
         build_item(gpu, tex, scale, now_unix, &item, &mut quads);
     }
@@ -601,7 +686,13 @@ fn layout(
     let mut y = top_pad;
     for (b, panel) in bars.iter().zip(panels) {
         let has_title = !b.title.is_empty();
-        let title_h = if has_title { title_px } else { 0.0 };
+        // Same icon-aware taller row as the live path, so the snapshot reserves
+        // room for the avatar and matches what the overlay draws.
+        let title_h = if has_title {
+            title_row_h(title_px, !b.icon.is_empty())
+        } else {
+            0.0
+        };
         let track_y = y + title_h + if has_title { title_gap } else { 0.0 };
         boxes.push(BarBox {
             left: center_x,
@@ -666,6 +757,7 @@ mod tests {
             pos: None,
             expandable: true,
             eta: None,
+            icon: String::new(),
         }
     }
 
@@ -683,7 +775,7 @@ mod tests {
 
         for scale in [1u32, 2, 3, 4] {
             let text_w = title_extent_px(&bar, scale, now);
-            let (width, _h) = bar_window_px(scale, text_w);
+            let (width, _h) = bar_window_px(scale, text_w, false);
             let width = width as f32;
 
             // The title overflows the bar, so the window must be widened for it.
@@ -693,7 +785,7 @@ mod tests {
                 text_w > bar_w,
                 "test title should exceed the bar at scale {scale}: {text_w} vs {bar_w}",
             );
-            let bar_only = bar_window_px(scale, 0.0).0 as f32;
+            let bar_only = bar_window_px(scale, 0.0, false).0 as f32;
             assert!(width > bar_only, "window must grow past bar-only at scale {scale}");
 
             // Reproduce build_one's widest layout (hover = breathe = 1 → MAX_SCALE).
@@ -722,7 +814,7 @@ mod tests {
         let bar = bar_with_title("US East: Health lifecycle image", Some(0));
         let now = 6815; // 1:53:35
         let scale = 3;
-        let (width, height) = bar_window_px(scale, title_extent_px(&bar, scale, now));
+        let (width, height) = bar_window_px(scale, title_extent_px(&bar, scale, now), false);
         let dir = std::env::temp_dir();
         for (tag, hover, breathe) in [("rest", 0.0f32, 0.0f32), ("grown", 1.0, 1.0)] {
             let out = dir.join(format!("bossbar_title_{tag}_{width}x{height}.png"));
@@ -731,7 +823,7 @@ mod tests {
                 height,
                 |gpu| {
                     let tex = register(gpu);
-                    build_one(gpu, &tex, scale, width, height, now, &bar, hover, breathe)
+                    build_one(gpu, &tex, None, scale, width, height, now, &bar, hover, breathe)
                 },
                 &out,
             )
@@ -749,6 +841,6 @@ mod tests {
         assert_eq!(title_extent_px(&bar, scale, 1234), 0.0);
         let s_max = scale as f32 * MAX_SCALE;
         let expected_w = (BAR_W as f32 * s_max + scale as f32).ceil() as u32;
-        assert_eq!(bar_window_px(scale, 0.0).0, expected_w);
+        assert_eq!(bar_window_px(scale, 0.0, false).0, expected_w);
     }
 }

--- a/packages/bossbar-overlay/app/crates/bossbar/src/scene.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/scene.rs
@@ -498,7 +498,6 @@ pub fn expanded_window_px(gpu: &Gpu, bar: &BossBar, scale: u32, now_unix: i64) -
 /// overlay enlarges it on hover, see [`expanded_window_px`]), a description panel
 /// unfolds beneath the bar, revealing with `hover`.
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 pub fn build_one(
     gpu: &Gpu,
     tex: &BarTextures,

--- a/packages/bossbar-overlay/app/crates/bossbar/src/snapshot.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/snapshot.rs
@@ -28,7 +28,20 @@ pub fn run(
         height,
         |gpu| {
             let tex = scene::register(gpu);
-            scene::build_all(gpu, &tex, scale, width, now_unix, bars, None)
+            // Resolve each bar's icon to a texture (or None when absent/unreadable)
+            // so the snapshot draws avatars exactly as the live overlay does.
+            let icons: Vec<Option<overlay_core::TexHandle>> = bars
+                .iter()
+                .map(|b| {
+                    if b.icon.is_empty() {
+                        return None;
+                    }
+                    std::fs::read(&b.icon)
+                        .ok()
+                        .and_then(|bytes| gpu.register_image_scaled(&bytes, scene::ICON_MAX_PX))
+                })
+                .collect();
+            scene::build_all(gpu, &tex, &icons, scale, width, now_unix, bars, None)
         },
         out,
     )

--- a/packages/bossbar-overlay/app/crates/overlay-core/src/gpu.rs
+++ b/packages/bossbar-overlay/app/crates/overlay-core/src/gpu.rs
@@ -281,6 +281,25 @@ impl Gpu {
         self.register_rgba(&img, w, h)
     }
 
+    /// Decode arbitrary image bytes (PNG/JPEG/...), downscale so the longest side
+    /// is at most `max_px`, and register the result. Unlike [`Self::register_png`]
+    /// this is fallible: it returns `None` when the bytes do not decode, so a
+    /// caller drawing user-supplied art (e.g. an avatar fetched off the network)
+    /// can skip a broken image instead of panicking. The downscale uses a quality
+    /// filter once at upload time so the nearest-sampled draw of a photo stays
+    /// legible at small sizes.
+    pub fn register_image_scaled(&mut self, bytes: &[u8], max_px: u32) -> Option<TexHandle> {
+        let img = image::load_from_memory(bytes).ok()?;
+        let img = if img.width().max(img.height()) > max_px {
+            img.resize(max_px, max_px, image::imageops::FilterType::Triangle)
+        } else {
+            img
+        };
+        let img = img.to_rgba8();
+        let (w, h) = img.dimensions();
+        Some(self.register_rgba(&img, w, h))
+    }
+
     /// Register raw sRGB RGBA8 pixels as a nearest-sampled texture.
     pub fn register_rgba(&mut self, rgba: &[u8], width: u32, height: u32) -> TexHandle {
         let bind = upload_texture(

--- a/packages/bossbar-overlay/app/crates/overlay-core/src/gpu.rs
+++ b/packages/bossbar-overlay/app/crates/overlay-core/src/gpu.rs
@@ -281,13 +281,16 @@ impl Gpu {
         self.register_rgba(&img, w, h)
     }
 
-    /// Decode arbitrary image bytes (PNG/JPEG/...), downscale so the longest side
-    /// is at most `max_px`, and register the result. Unlike [`Self::register_png`]
-    /// this is fallible: it returns `None` when the bytes do not decode, so a
-    /// caller drawing user-supplied art (e.g. an avatar fetched off the network)
-    /// can skip a broken image instead of panicking. The downscale uses a quality
-    /// filter once at upload time so the nearest-sampled draw of a photo stays
-    /// legible at small sizes.
+    /// Decode image bytes (PNG/JPEG/...), downscale so the longest side is at most
+    /// `max_px`, and register the result. Unlike [`Self::register_png`] this is
+    /// fallible: it returns `None` when the bytes do not decode, so a caller can
+    /// skip a broken image (e.g. an avatar that arrived corrupt) instead of
+    /// panicking. The downscale uses a quality filter once at upload time so the
+    /// nearest-sampled draw of a photo stays legible at small sizes.
+    ///
+    /// Note: `max_px` bounds the *uploaded* texture, not decode work — the image
+    /// is fully decoded into RAM before the resize. Pass bytes from a trusted
+    /// source (or pre-validate dimensions) rather than arbitrary untrusted input.
     pub fn register_image_scaled(&mut self, bytes: &[u8], max_px: u32) -> Option<TexHandle> {
         let img = image::load_from_memory(bytes).ok()?;
         let img = if img.width().max(img.height()) > max_px {

--- a/packages/bossbar-overlay/bossbar
+++ b/packages/bossbar-overlay/bossbar
@@ -36,7 +36,8 @@ ensure_db() {
     since       INTEGER,
     url         TEXT    NOT NULL DEFAULT '',
     expandable  INTEGER NOT NULL DEFAULT 1,
-    eta         INTEGER
+    eta         INTEGER,
+    icon        TEXT    NOT NULL DEFAULT ''
   );"
   # Columns that shipped after the first schema; add each to a pre-existing table
   # so its flag works on a DB created by an older bossbar. SQLite has no
@@ -51,6 +52,7 @@ ensure_db() {
   add_col url "TEXT NOT NULL DEFAULT ''"
   add_col expandable "INTEGER NOT NULL DEFAULT 1"
   add_col eta "INTEGER"
+  add_col icon "TEXT NOT NULL DEFAULT ''"
 }
 
 die() {
@@ -83,10 +85,11 @@ bossbar - control the Minecraft boss bar overlay (SQLite-backed)
 
 Usage:
   bossbar add <title> [--description D] [--since EPOCH] [--eta SECS] [--url U]
-                      [--progress P] [--color C] [--overlay O] [--position N] [--box 0|1]
+                      [--icon PATH] [--progress P] [--color C] [--overlay O]
+                      [--position N] [--box 0|1]
   bossbar set <id|title> [--title T] [--description D] [--since EPOCH] [--eta SECS]
-                         [--url U] [--progress P] [--color C] [--overlay O]
-                         [--position N] [--visible 0|1] [--box 0|1]
+                         [--url U] [--icon PATH] [--progress P] [--color C]
+                         [--overlay O] [--position N] [--visible 0|1] [--box 0|1]
   bossbar rm <id|title>
   bossbar list
   bossbar clear
@@ -101,6 +104,8 @@ Usage:
            and ticking each second. 0 clears it (back to the static --progress)
   U        URL (or any URI/path the system opener accepts) opened when the bar
            is clicked without dragging; pass '' to clear it
+  PATH     path to a small image (PNG/JPEG) drawn as a square icon left of the
+           title, e.g. a GitHub avatar; pass '' to clear it
   P        fill fraction 0.0 .. 1.0
   C        pink | blue | red | green | yellow | purple | white
   O        progress | notched_6 | notched_10 | notched_12 | notched_20
@@ -138,6 +143,7 @@ parse_fields() {
         [[ "$val" =~ ^-?[0-9]+$ ]] || die "--eta must be an integer"
         assign="eta = $val" ;;
       --url)         assign="url = '$(sq "$val")'" ;;
+      --icon)        assign="icon = '$(sq "$val")'" ;;
       --progress)
         [[ "$val" =~ ^-?[0-9]+([.][0-9]+)?$ ]] || die "--progress must be a number"
         assign="progress = $val" ;;

--- a/packages/bossbar-overlay/ci-bars-home-module.nix
+++ b/packages/bossbar-overlay/ci-bars-home-module.nix
@@ -78,6 +78,7 @@ let
       pkgs.jq
       pkgs.sqlite
       pkgs.coreutils
+      pkgs.curl # download GitHub avatars for the bar faces
       pkgs.perl # the intrinsic flock(2) non-overlap guard (no flock(1) on macOS)
       cfg.package
     ];

--- a/packages/bossbar-overlay/ci-bars.sh
+++ b/packages/bossbar-overlay/ci-bars.sh
@@ -158,6 +158,60 @@ EOF
   printf '%s' "$avg"
 }
 
+# GitHub avatars are cached on disk and reused across polls so a steady bar does
+# not re-download a face every ~20s. One PNG per login under avatars/, refreshed
+# only when older than this many seconds.
+avatar_dir="$state_dir/avatars"
+mkdir -p "$avatar_dir"
+avatar_ttl=604800 # 7 days
+
+# Resolve a GitHub login to a local avatar PNG path, downloading (and caching) it
+# on first use. Prints the path on success, nothing on failure (an empty --icon
+# clears the bar's icon, so a missing avatar just draws the bar without a face).
+# `https://github.com/<login>.png` redirects to the user's avatar at the asked
+# size; curl follows it (-L). Logins are [A-Za-z0-9-], safe as a filename.
+avatar_for_login() {
+  local login="$1" f
+  [ -n "$login" ] || return 0
+  case "$login" in *[!A-Za-z0-9-]*) return 0 ;; esac # paranoia: never a path
+  f="$avatar_dir/$login.png"
+  if [ ! -s "$f" ] || [ "$((now - $(date -r "$f" +%s 2>/dev/null || echo 0)))" -ge "$avatar_ttl" ]; then
+    # Download to a temp then move, so a torn/failed download never leaves a
+    # half-written PNG the overlay would fail to decode. -f: no body on HTTP error.
+    if curl -fsSL "https://github.com/$login.png?size=128" -o "$f.tmp" 2>/dev/null; then
+      mv -f "$f.tmp" "$f"
+    else
+      rm -f "$f.tmp"
+      [ -s "$f" ] || return 0 # no fresh copy and no usable old one
+    fi
+  fi
+  printf '%s' "$f"
+}
+
+# Squeeze a PR/commit title into one clean ASCII line for the bitmap font, which
+# has no glyphs outside printable ASCII: drop non-ASCII (emoji, accents), collapse
+# runs of whitespace, trim, and clip to a width that fits a boss bar without
+# wrapping. Keeps the human-readable head of a long title with an ellipsis.
+clean_title() {
+  perl -CS -pe 's/[^\x20-\x7E]//g; s/\s+/ /g; s/^ //; s/ $//;' <<<"${1:-}" \
+    | { read -r line || true; if [ "${#line}" -gt 56 ]; then printf '%s...' "${line:0:53}"; else printf '%s' "$line"; fi; }
+}
+
+# Login of the author of a commit, cached per sha for the poll (a main-branch bar
+# has no PR, so its face comes from whoever pushed the commit). Empty on failure.
+declare -A sha_login_cache
+commit_login() {
+  local repo="$1" sha="$2" login
+  local key="$repo@$sha"
+  if [ -n "${sha_login_cache[$key]+x}" ]; then
+    printf '%s' "${sha_login_cache[$key]}"
+    return
+  fi
+  login="$(gh api "repos/$repo/commits/$sha" --jq '.author.login // ""' 2>/dev/null || printf '')"
+  sha_login_cache["$key"]="$login"
+  printf '%s' "$login"
+}
+
 # Branch urls with in-flight CI this poll (newline-separated), used to prune bars
 # for branches whose latest commit has finished. Identity is the branch, so a
 # branch's checks (across pushes) share ONE bar.
@@ -179,6 +233,26 @@ for repo in "${repos[@]}"; do
   # assoc array, so a prior repo's entries would otherwise leak into this one.
   unset c_total c_done c_running c_queued c_minstart c_partmilli c_created c_maxavg b_latest_sha b_latest_created
   declare -A c_total c_done c_running c_queued c_minstart c_partmilli c_created c_maxavg b_latest_sha b_latest_created
+
+  # Open PRs for this repo, so a CI bar can show the PR title + author face
+  # instead of an opaque ref. Keyed both by head branch name (for branch runs)
+  # and by "#<number>" (for the `refs/pull/<N>/head` refs that PR-event runs
+  # report as their branch). One list call per repo; failure leaves the maps
+  # empty and the bars fall back to the branch label with no face.
+  unset pr_title pr_login
+  declare -A pr_title pr_login
+  while IFS=$'\t' read -r prnum prhead prlogin prtitle; do
+    [ -n "$prnum" ] || continue
+    pr_title["#$prnum"]="$prtitle"
+    pr_login["#$prnum"]="$prlogin"
+    if [ -n "$prhead" ]; then
+      pr_title["$prhead"]="$prtitle"
+      pr_login["$prhead"]="$prlogin"
+    fi
+  done < <(gh pr list --repo "$repo" --state open --limit 200 \
+    --json number,title,headRefName,author 2>/dev/null \
+    | jq -r '.[] | [(.number|tostring), .headRefName, (.author.login // ""), .title] | @tsv' \
+    2>/dev/null || true)
   while IFS=$'\t' read -r sha branch status wf started created; do
     [ -n "$sha" ] || continue
     c_total["$sha"]=$((${c_total["$sha"]:-0} + 1))
@@ -265,8 +339,32 @@ https://github.com/$repo/commits/$branch"
     eta=${c_maxavg[$sha]:-0}
     [ "$eta" -gt 0 ] 2>/dev/null || eta="$default_avg"
 
-    # ASCII-only title (bitmap font): repo + branch, nothing else.
-    bar_title="$short: $branch"
+    # Human-readable title + author face. A `refs/pull/<N>/head` ref (how PR-event
+    # runs report their branch) maps to PR #N; a plain branch maps to an open PR
+    # by head name. With a PR we show its title and the author's avatar; without
+    # one (e.g. a push to main) we keep the "<repo>: <branch>" label and use the
+    # commit author's face. Titles are squeezed to one clean ASCII line for the
+    # bitmap font.
+    pr_key=""
+    case "$branch" in
+      refs/pull/*/*)
+        num="${branch#refs/pull/}"
+        num="${num%%/*}"
+        [ -n "$num" ] && pr_key="#$num"
+        ;;
+      *) pr_key="$branch" ;;
+    esac
+    title="${pr_title[$pr_key]:-}"
+    login="${pr_login[$pr_key]:-}"
+    if [ -n "$title" ]; then
+      bar_title="$(clean_title "$title")"
+    else
+      # No PR: fall back to the readable branch label and the commit author's face.
+      bar_title="$short: $branch"
+      [ -n "$sha" ] && login="$(commit_login "$repo" "$sha")"
+    fi
+    [ -n "$bar_title" ] || bar_title="$short: $branch"
+    icon="$(avatar_for_login "$login")"
 
     # Always pass --eta, and --since once the commit's CI has started, so the
     # overlay extrapolates the fill live; both update if a newer commit lands on
@@ -278,9 +376,9 @@ https://github.com/$repo/commits/$branch"
     # empty `"${a[@]}"`; the Nix wrapper's bash 5 does not).
     id="$(bar_id_for_url "$url")"
     if [ -z "$id" ]; then
-      bossbar add "$bar_title" --color "$color" --overlay progress --progress "$prog" --position -1 --eta "$eta" ${since_args[@]+"${since_args[@]}"} --url "$url" --box 0 2>/dev/null || true
+      bossbar add "$bar_title" --color "$color" --overlay progress --progress "$prog" --position -1 --eta "$eta" ${since_args[@]+"${since_args[@]}"} --url "$url" --icon "$icon" --box 0 2>/dev/null || true
     else
-      bossbar set "$id" --title "$bar_title" --color "$color" --progress "$prog" --eta "$eta" ${since_args[@]+"${since_args[@]}"} --box 0 2>/dev/null || true
+      bossbar set "$id" --title "$bar_title" --color "$color" --progress "$prog" --eta "$eta" ${since_args[@]+"${since_args[@]}"} --icon "$icon" --box 0 2>/dev/null || true
     fi
   done <<EOF
 $selected


### PR DESCRIPTION
The CI progress boss bars showed an opaque ref (`index: refs/pull/557/head`). Andrew asked for the PR title instead, and for the bar to show the GitHub avatar of whoever opened the PR/commit.

**Now:** each CI bar shows the PR title (or commit subject) and a square avatar of the author, left of the title.

- `bossbar`: new `icon` column + `--icon PATH` flag (bash CLI + Rust schema, same ADD COLUMN migration as other late columns).
- overlay: load + cache an icon texture by path (fallible decode via new `register_image_scaled`, downscaled once), drawn as a square avatar filling the title row left of a vertically-centered title. `ICON_SCALE` grows the row so the face is recognizable; window-size / snapshot / winit + layer-shell geometry all reserve the taller row.
- ci-bars: resolve `refs/pull/N/head` -> PR #N, and a branch -> its open PR, for title + author login (commit author for non-PR branches like main); download+cache the avatar, pass `--icon`; titles squeezed to one clean ASCII line for the bitmap font.

Validated: `nix build .#bossbar-overlay` (incl. test compile) + snapshot render at scale 1 and 2 (faces recognizable, long titles un-clipped). Linux crate tests run in CI.

Made with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add PR titles and author avatar icons to CI bossbars
> - CI bars now display human-readable PR titles (cleaned to ASCII, truncated to 56 chars) instead of branch names, and show the PR/commit author's GitHub avatar as a square icon to the left of the title.
> - GitHub avatars are downloaded at 128px and cached on disk under `avatars/` with a 7-day TTL via `avatar_for_login` in [ci-bars.sh](https://github.com/indexable-inc/index/pull/570/files#diff-3aba65acb9a333e9dfbb82745f5f2b85a47136e34156ae144f259fa6ab803b19).
> - A new `icon` field is added to the `BossBar` struct and database schema; the CLI accepts `--icon PATH` to set it.
> - Icon images are decoded, downscaled, and uploaded to the GPU once per path via `Gpu::register_image_scaled`, then cached by path in `GpuCore.icon_cache` for both the layer shell and windowed overlay renderers.
> - The scene renderer reserves extra title-row height and width when an icon is present, and draws the avatar quad left of the title text in `build_item`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36efcc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->