### PR TITLE
fix(ci-bars): resolve merged/closed PR titles for refs/pull/N/head

### DIFF
--- a/packages/bossbar-overlay/ci-bars.sh
+++ b/packages/bossbar-overlay/ci-bars.sh
@@ -346,6 +346,7 @@ https://github.com/$repo/commits/$branch"
     # commit author's face. Titles are squeezed to one clean ASCII line for the
     # bitmap font.
     pr_key=""
+    num=""
     case "$branch" in
       refs/pull/*/*)
         num="${branch#refs/pull/}"
@@ -356,10 +357,25 @@ https://github.com/$repo/commits/$branch"
     esac
     title="${pr_title[$pr_key]:-}"
     login="${pr_login[$pr_key]:-}"
+    # A `refs/pull/<N>/head` ref whose PR is already merged/closed is not in the
+    # open-PR list, but the number is right there, so resolve #N directly (any
+    # state). This is the common eyesore: a merged PR still running post-merge CI
+    # would otherwise show the raw ref. Cache the lookup in the same per-poll maps.
+    if [ -z "$title" ] && [ -n "$num" ]; then
+      prow="$(gh pr view "$num" --repo "$repo" --json title,author \
+        --jq '[.title, (.author.login // "")] | @tsv' 2>/dev/null || printf '')"
+      if [ -n "$prow" ]; then
+        title="${prow%%	*}"
+        login="${prow#*	}"
+        pr_title["$pr_key"]="$title"
+        pr_login["$pr_key"]="$login"
+      fi
+    fi
     if [ -n "$title" ]; then
       bar_title="$(clean_title "$title")"
     else
-      # No PR: fall back to the readable branch label and the commit author's face.
+      # No PR at all (e.g. a push to main): fall back to the readable branch label
+      # and the commit author's face.
       bar_title="$short: $branch"
       [ -n "$sha" ] && login="$(commit_login "$repo" "$sha")"
     fi


### PR DESCRIPTION
Follow-up to #570. Open-PR-only matching left merged PRs still showing the raw `index: refs/pull/557/head` ref (the exact eyesore). A pull ref carries its number, so resolve #N directly via `gh pr view` for any PR state, and use that author's avatar. Resets `num` per bar.

Made with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI bars to resolve titles for merged/closed PRs via `gh pr view`
> When a branch matches `refs/pull/<N>/*` but the PR is not in the open-PR map (e.g. merged or closed), [ci-bars.sh](https://github.com/indexable-inc/index/pull/571/files#diff-3aba65acb9a333e9dfbb82745f5f2b85a47136e34156ae144f259fa6ab803b19) now calls `gh pr view <N>` to fetch the title and author, then caches them for use in the bossbar display. Previously, these PRs would fall back to the raw branch label.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aaa404f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->