### PR TITLE
bossbar: fractional sprite scale; andrew default 1.25 (25% larger)

### DIFF
--- a/packages/bossbar-overlay/app/crates/bossbar/src/layer_shell.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/layer_shell.rs
@@ -107,7 +107,7 @@ struct BarWin {
     has_description: bool,
     last_size: (u32, u32),
     scale_factor: f64,
-    scale: u32,
+    scale: f32,
     scroll_dirty: bool,
     scroll_last: Option<Instant>,
     last_move: Instant,
@@ -132,7 +132,7 @@ impl BarWin {
 
 struct App {
     db: PathBuf,
-    base_scale: u32,
+    base_scale: f32,
     instance: wgpu::Instance,
     core: Option<GpuCore>,
     wins: HashMap<i64, BarWin>,
@@ -201,10 +201,10 @@ fn axis_stopped(horizontal: AxisScroll, vertical: AxisScroll) -> bool {
 }
 
 impl App {
-    fn new(db: PathBuf, base_scale: u32) -> Self {
+    fn new(db: PathBuf, base_scale: f32) -> Self {
         Self {
             db,
-            base_scale: base_scale.max(1),
+            base_scale: base_scale.max(1.0),
             instance: wgpu::Instance::default(),
             core: None,
             wins: HashMap::new(),
@@ -212,10 +212,10 @@ impl App {
         }
     }
 
-    fn scale(&self, scale_factor: f64) -> u32 {
-        ((self.base_scale as f64) * scale_factor.max(1.0))
-            .round()
-            .max(1.0) as u32
+    // Fractional scale is preserved (no integer rounding) so a non-integer
+    // `base_scale` like 1.25 grows the bars by exactly that fraction.
+    fn scale(&self, scale_factor: f64) -> f32 {
+        ((self.base_scale as f64) * scale_factor.max(1.0)).max(1.0) as f32
     }
 
     fn logical_size(size_px: (u32, u32), scale_factor: f64) -> (u32, u32) {
@@ -1035,7 +1035,7 @@ impl App {
     }
 }
 
-pub fn run(db: PathBuf, base_scale: u32) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run(db: PathBuf, base_scale: f32) -> Result<(), Box<dyn std::error::Error>> {
     let ev = WindowState::<i64>::new("bossbar-overlay")
         .with_background()
         .with_use_display_handle(true)

--- a/packages/bossbar-overlay/app/crates/bossbar/src/main.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/main.rs
@@ -22,12 +22,13 @@ mod snapshot;
 use std::path::PathBuf;
 
 /// Default logical pixel scale of the 182x5 sprites; overridable with
-/// `BOSSBAR_SCALE` or `--scale`.
-const DEFAULT_SCALE: u32 = 2;
+/// `BOSSBAR_SCALE` or `--scale`. Fractional values are honored, so `1.25` makes
+/// the bars 25% larger than `1.0`.
+const DEFAULT_SCALE: f32 = 2.0;
 
 struct Args {
     snapshot: Option<PathBuf>,
-    scale: u32,
+    scale: f32,
     width: u32,
     height: u32,
 }
@@ -55,7 +56,7 @@ fn parse_args() -> Result<Args, String> {
                     .next()
                     .ok_or("--scale needs a number")?
                     .parse()
-                    .map_err(|_| "--scale must be an integer")?;
+                    .map_err(|_| "--scale must be a number")?;
             }
             "--size" => {
                 let v = it.next().ok_or("--size needs WxH")?;
@@ -90,7 +91,7 @@ fn main() {
 
     if let Some(out) = args.snapshot {
         let bars = db::read_once(&db).unwrap_or_default();
-        match snapshot::run(args.scale.max(1), args.width, args.height, &bars, &out) {
+        match snapshot::run(args.scale.max(1.0), args.width, args.height, &bars, &out) {
             Ok(()) => println!("bossbar-overlay: wrote {}", out.display()),
             Err(e) => {
                 eprintln!("bossbar-overlay: snapshot failed: {e}");

--- a/packages/bossbar-overlay/app/crates/bossbar/src/main.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/main.rs
@@ -33,10 +33,20 @@ struct Args {
     height: u32,
 }
 
+/// Parse a scale string as a finite, positive `f32`. Rejects `inf`/`nan`/`<= 0`
+/// so a hostile `--scale inf` can't saturate `(BAR_W * scale).ceil() as u32` to
+/// `u32::MAX` and request a multi-billion-pixel window.
+fn parse_scale(s: &str) -> Result<f32, String> {
+    match s.parse::<f32>() {
+        Ok(v) if v.is_finite() && v > 0.0 => Ok(v),
+        _ => Err("--scale must be a positive, finite number".to_string()),
+    }
+}
+
 fn parse_args() -> Result<Args, String> {
     let scale = std::env::var("BOSSBAR_SCALE")
         .ok()
-        .and_then(|s| s.parse().ok())
+        .and_then(|s| parse_scale(&s).ok())
         .unwrap_or(DEFAULT_SCALE);
     let mut args = Args {
         snapshot: None,
@@ -52,11 +62,8 @@ fn parse_args() -> Result<Args, String> {
                 args.snapshot = Some(PathBuf::from(p));
             }
             "--scale" => {
-                args.scale = it
-                    .next()
-                    .ok_or("--scale needs a number")?
-                    .parse()
-                    .map_err(|_| "--scale must be a number")?;
+                let raw = it.next().ok_or("--scale needs a number")?;
+                args.scale = parse_scale(&raw)?;
             }
             "--size" => {
                 let v = it.next().ok_or("--size needs WxH")?;

--- a/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
@@ -193,8 +193,9 @@ impl BarWin {
 pub struct App {
     db: PathBuf,
     /// Logical pixel scale; multiplied by the monitor scale factor so the bars
-    /// look the same physical size on HiDPI and standard displays.
-    base_scale: u32,
+    /// look the same physical size on HiDPI and standard displays. Fractional
+    /// values are honored (e.g. 1.25 for 25% larger bars).
+    base_scale: f32,
     proxy: EventLoopProxy<Vec<BossBar>>,
     instance: wgpu::Instance,
     core: Option<GpuCore>,
@@ -203,8 +204,9 @@ pub struct App {
     /// Monitor logical size, for centering auto-stacked bars.
     mon_logical: (f64, f64),
     scale_factor: f64,
-    /// Physical sprite scale, `round(base_scale * scale_factor)`.
-    scale: u32,
+    /// Physical sprite scale, `base_scale * scale_factor`. Kept fractional so a
+    /// non-integer `base_scale` produces exactly the requested size.
+    scale: f32,
     /// App start, the zero point for the continuous breathing phase.
     start: Instant,
     ready: bool,
@@ -595,7 +597,10 @@ impl ApplicationHandler<Vec<BossBar>> for App {
             None => (1920, 1080, 1.0),
         };
         self.scale_factor = scale_factor;
-        self.scale = ((self.base_scale as f64) * scale_factor).round().max(1.0) as u32;
+        // No integer rounding: a fractional `base_scale` (e.g. 1.25) must reach
+        // the renderer intact so the bars grow by exactly the requested fraction
+        // rather than snapping to the nearest whole sprite scale.
+        self.scale = ((self.base_scale as f64) * scale_factor).max(1.0) as f32;
         self.mon_logical = (mon_w as f64 / scale_factor, mon_h as f64 / scale_factor);
         self.ready = true;
 
@@ -767,7 +772,7 @@ impl ApplicationHandler<Vec<BossBar>> for App {
 }
 
 /// Run the overlay event loop. Blocks until the last window closes.
-pub fn run(db: PathBuf, base_scale: u32) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run(db: PathBuf, base_scale: f32) -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_os = "linux")]
     if std::env::var_os("WAYLAND_DISPLAY").is_some()
         && std::env::var_os("BOSSBAR_WINIT").is_none()
@@ -784,14 +789,14 @@ pub fn run(db: PathBuf, base_scale: u32) -> Result<(), Box<dyn std::error::Error
     let proxy = event_loop.create_proxy();
     let mut app = App {
         db,
-        base_scale: base_scale.max(1),
+        base_scale: base_scale.max(1.0),
         proxy,
         instance: wgpu::Instance::default(),
         core: None,
         wins: HashMap::new(),
         mon_logical: (1920.0, 1080.0),
         scale_factor: 1.0,
-        scale: base_scale.max(1),
+        scale: base_scale.max(1.0),
         start: Instant::now(),
         ready: false,
     };

--- a/packages/bossbar-overlay/app/crates/bossbar/src/scene.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/scene.rs
@@ -74,8 +74,8 @@ fn title_row_h(glyph_px: f32, has_icon: bool) -> f32 {
 pub const ICON_MAX_PX: u32 = 96;
 
 /// Description pop-down panel, in native (unscaled) pixels. Everything is
-/// multiplied by the integer sprite `scale`, so the panel stays pixel-crisp and
-/// proportional to the bars at any display scale.
+/// multiplied by the sprite `scale`, so the panel stays proportional to the bars
+/// at any display scale.
 mod panel {
     /// Body glyph size (source px) and line advance (leading). The face matches
     /// the title's bitmap font; the extra leading gives wrapped paragraphs room.
@@ -234,7 +234,7 @@ fn live_progress(b: &BossBar, now_unix: i64) -> f32 {
 }
 
 /// Append one draw item's quads (bar layers, title, optional panel) to `quads`.
-fn build_item(gpu: &Gpu, tex: &BarTextures, scale: u32, now_unix: i64, item: &DrawItem<'_>, quads: &mut Vec<Quad>) {
+fn build_item(gpu: &Gpu, tex: &BarTextures, scale: f32, now_unix: i64, item: &DrawItem<'_>, quads: &mut Vec<Quad>) {
     let b = item.bar;
     let bx = item.geom;
     let alpha = item.alpha;
@@ -244,7 +244,7 @@ fn build_item(gpu: &Gpu, tex: &BarTextures, scale: u32, now_unix: i64, item: &Dr
     // Bars sample real sprites, so the tint is white with the bar's opacity; only
     // the alpha channel matters for them.
     let tint = [1.0, 1.0, 1.0, alpha];
-    let shadow_off = scale.max(1) as f32;
+    let shadow_off = scale.max(1.0);
 
     if bx.has_title {
         // The title carries the live elapsed counter when the bar has a `since`;
@@ -391,8 +391,8 @@ fn wrap(gpu: &Gpu, text: &str, max_w: f32, scale: f32) -> Vec<String> {
 }
 
 /// Panel metrics in physical pixels at `scale`: `(border, pad, font, line, gap)`.
-fn panel_metrics(scale: u32) -> (f32, f32, f32, f32, f32) {
-    let s = scale.max(1) as f32;
+fn panel_metrics(scale: f32) -> (f32, f32, f32, f32, f32) {
+    let s = scale.max(1.0);
     (
         panel::BORDER * s,
         panel::PAD * s,
@@ -405,12 +405,12 @@ fn panel_metrics(scale: u32) -> (f32, f32, f32, f32, f32) {
 /// Physical-pixel size `(width, height)` of the description panel for
 /// `description` at `scale`: width matches the bar, height fits the wrapped,
 /// padded text. `None` for an empty description (no panel).
-fn panel_size(gpu: &Gpu, description: &str, scale: u32) -> Option<(f32, f32)> {
+fn panel_size(gpu: &Gpu, description: &str, scale: f32) -> Option<(f32, f32)> {
     if description.trim().is_empty() {
         return None;
     }
     let (border, pad, font_px, line_px, _gap) = panel_metrics(scale);
-    let panel_w = BAR_W as f32 * scale.max(1) as f32;
+    let panel_w = BAR_W as f32 * scale.max(1.0);
     let text_w = (panel_w - 2.0 * (border + pad)).max(1.0);
     let lines = wrap(gpu, description, text_w, font_px / 8.0).len().max(1);
     let panel_h = 2.0 * (border + pad) + lines as f32 * line_px;
@@ -423,14 +423,14 @@ fn panel_size(gpu: &Gpu, description: &str, scale: u32) -> Option<(f32, f32)> {
 /// so a title longer than the 182px bar is never clipped at the window edge. It
 /// measures through the shared CPU font, so the first window can be sized before
 /// any GPU surface exists.
-pub fn title_extent_px(bar: &BossBar, scale: u32, now_unix: i64) -> f32 {
+pub fn title_extent_px(bar: &BossBar, scale: f32, now_unix: i64) -> f32 {
     if bar.title.is_empty() {
         return 0.0;
     }
     let shown = title_with_elapsed(&bar.title, bar.since, now_unix);
     // The grown title row is `8 * scale * MAX_SCALE` px tall, so each glyph samples
     // at `scale * MAX_SCALE` source-px (the `title_px / 8` of `build_one`, maxed).
-    let glyph_scale = scale.max(1) as f32 * MAX_SCALE;
+    let glyph_scale = scale.max(1.0) * MAX_SCALE;
     let text_w = overlay_core::bitmap_font::shared().measure(&shown, glyph_scale);
     // Reserve room for the square avatar (a row-height square, so `ICON_SCALE`
     // glyphs wide) plus its gap, so the window holds `[icon][gap]title` without
@@ -450,8 +450,8 @@ pub fn title_extent_px(bar: &BossBar, scale: u32, now_unix: i64) -> f32 {
 /// [`title_extent_px`]); the window widens to hold a title longer than the bar,
 /// and a nonzero `title_w` adds the title row. Plus a one-pixel-scaled shadow
 /// margin on the right and bottom.
-pub fn bar_window_px(scale: u32, title_w: f32, has_icon: bool) -> (u32, u32) {
-    let s = scale.max(1) as f32 * MAX_SCALE;
+pub fn bar_window_px(scale: f32, title_w: f32, has_icon: bool) -> (u32, u32) {
+    let s = scale.max(1.0) * MAX_SCALE;
     let bar_w = BAR_W as f32 * s;
     let bar_h = BAR_H as f32 * s;
     let has_title = title_w > 0.0;
@@ -462,7 +462,7 @@ pub fn bar_window_px(scale: u32, title_w: f32, has_icon: bool) -> (u32, u32) {
     } else {
         0.0
     };
-    let shadow = scale.max(1) as f32;
+    let shadow = scale.max(1.0);
     // Hold whichever is wider, the bar sprite or the title text; both trail the
     // one-pixel shadow down-right, so the shadow margin covers the right edge too.
     let content_w = bar_w.max(title_w) + shadow;
@@ -473,11 +473,11 @@ pub fn bar_window_px(scale: u32, title_w: f32, has_icon: bool) -> (u32, u32) {
 /// bar window grown downward by the gap plus the panel. Returns the collapsed
 /// size when the bar has no description. The overlay grows the window to this on
 /// hover so the panel has room to unfold.
-pub fn expanded_window_px(gpu: &Gpu, bar: &BossBar, scale: u32, now_unix: i64) -> (u32, u32) {
+pub fn expanded_window_px(gpu: &Gpu, bar: &BossBar, scale: f32, now_unix: i64) -> (u32, u32) {
     let (cw, ch) = bar_window_px(scale, title_extent_px(bar, scale, now_unix), !bar.icon.is_empty());
     match panel_size(gpu, &bar.description, scale) {
         Some((panel_w, panel_h)) => {
-            let gap = panel::GAP * scale.max(1) as f32;
+            let gap = panel::GAP * scale.max(1.0);
             (
                 cw.max(panel_w.ceil() as u32),
                 ch + (gap + panel_h).ceil() as u32,
@@ -502,7 +502,7 @@ pub fn build_one(
     gpu: &Gpu,
     tex: &BarTextures,
     icon: Option<TexHandle>,
-    scale: u32,
+    scale: f32,
     width: u32,
     height: u32,
     now_unix: i64,
@@ -510,7 +510,7 @@ pub fn build_one(
     hover: f32,
     breathe: f32,
 ) -> Vec<Quad> {
-    let scale = scale.max(1);
+    let scale = scale.max(1.0);
     let opacity = DEFAULT_OPACITY;
     let hover = hover.clamp(0.0, 1.0);
     // Grow toward HOVER_SCALE with hover, then breathe around that; the breathe
@@ -518,8 +518,8 @@ pub fn build_one(
     let grow = 1.0 + (HOVER_SCALE - 1.0) * hover;
     let scale_mul = grow * (1.0 + BREATHE_AMP * breathe * hover);
     let alpha = opacity + (1.0 - opacity) * hover;
-    let s = scale as f32 * scale_mul;
-    let shadow = scale as f32;
+    let s = scale * scale_mul;
+    let shadow = scale;
     let has_title = !bar.title.is_empty();
     let has_icon = !bar.icon.is_empty();
     let title_px = GLYPH_PX * s;
@@ -606,13 +606,13 @@ pub fn build_all(
     gpu: &Gpu,
     tex: &BarTextures,
     icons: &[Option<TexHandle>],
-    scale: u32,
+    scale: f32,
     width: u32,
     now_unix: i64,
     bars: &[BossBar],
     highlight: Option<i64>,
 ) -> Vec<Quad> {
-    let scale = scale.max(1);
+    let scale = scale.max(1.0);
     let opacity = DEFAULT_OPACITY;
     let (border, pad, font_px, line_px, gap) = panel_metrics(scale);
     // A non-expandable bar has no box, so it reserves no panel size (and so no
@@ -666,13 +666,13 @@ pub fn build_all(
 /// with a panel reserves `gap + panel_h` extra vertical space so the next bar
 /// clears it.
 fn layout(
-    scale: u32,
+    scale: f32,
     bars: &[BossBar],
     width: f32,
     panels: &[Option<(f32, f32)>],
     gap: f32,
 ) -> Vec<BarBox> {
-    let s = scale.max(1) as f32;
+    let s = scale.max(1.0);
     let bar_w = BAR_W as f32 * s;
     let bar_h = BAR_H as f32 * s;
     let title_px = 8.0 * s;
@@ -772,13 +772,13 @@ mod tests {
         let bar = bar_with_title("US East: Health lifecycle image", Some(0));
         let now = 6815; // 1:53:35
 
-        for scale in [1u32, 2, 3, 4] {
+        for scale in [1.0f32, 2.0, 3.0, 4.0] {
             let text_w = title_extent_px(&bar, scale, now);
             let (width, _h) = bar_window_px(scale, text_w, false);
             let width = width as f32;
 
             // The title overflows the bar, so the window must be widened for it.
-            let s_max = scale as f32 * MAX_SCALE;
+            let s_max = scale * MAX_SCALE;
             let bar_w = BAR_W as f32 * s_max;
             assert!(
                 text_w > bar_w,
@@ -788,7 +788,7 @@ mod tests {
             assert!(width > bar_only, "window must grow past bar-only at scale {scale}");
 
             // Reproduce build_one's widest layout (hover = breathe = 1 → MAX_SCALE).
-            let shadow = scale as f32;
+            let shadow = scale;
             let content_w = bar_w + shadow;
             let left = ((width - content_w) * 0.5).max(0.0);
             let tx = left + (bar_w - text_w) * 0.5;
@@ -812,7 +812,7 @@ mod tests {
     fn render_long_title_window() {
         let bar = bar_with_title("US East: Health lifecycle image", Some(0));
         let now = 6815; // 1:53:35
-        let scale = 3;
+        let scale = 3.0f32;
         let (width, height) = bar_window_px(scale, title_extent_px(&bar, scale, now), false);
         let dir = std::env::temp_dir();
         for (tag, hover, breathe) in [("rest", 0.0f32, 0.0f32), ("grown", 1.0, 1.0)] {
@@ -836,10 +836,10 @@ mod tests {
     #[test]
     fn untitled_bar_is_bar_width() {
         let bar = bar_with_title("", None);
-        let scale = 3;
+        let scale = 3.0f32;
         assert_eq!(title_extent_px(&bar, scale, 1234), 0.0);
-        let s_max = scale as f32 * MAX_SCALE;
-        let expected_w = (BAR_W as f32 * s_max + scale as f32).ceil() as u32;
+        let s_max = scale * MAX_SCALE;
+        let expected_w = (BAR_W as f32 * s_max + scale).ceil() as u32;
         assert_eq!(bar_window_px(scale, 0.0, false).0, expected_w);
     }
 }

--- a/packages/bossbar-overlay/app/crates/bossbar/src/snapshot.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/snapshot.rs
@@ -12,13 +12,13 @@ use crate::scene;
 
 /// Render `bars` at `scale` into a `width`x`height` transparent PNG at `out`.
 pub fn run(
-    scale: u32,
+    scale: f32,
     width: u32,
     height: u32,
     bars: &[BossBar],
     out: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let scale = scale.max(1);
+    let scale = scale.max(1.0);
     let now_unix = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -258,12 +258,13 @@ in
         description = "Run the always-on-top Minecraft boss bar overlay GUI the watcher draws onto.";
       };
       scale = lib.mkOption {
-        type = lib.types.ints.positive;
-        default = 1;
+        type = lib.types.numbers.positive;
+        default = 1.25;
         description = ''
-          Integer pixel scale for the boss bar sprites (and, proportionally,
-          their title text and pop-down panels). The overlay binary defaults to
-          2; 1 renders everything at half that size.
+          Pixel scale for the boss bar sprites (and, proportionally, their title
+          text and pop-down panels), multiplied by the monitor scale factor.
+          Fractional values are honored, so 1.25 renders the bars 25% larger than
+          1.0. The overlay binary's own default is 2.
         '';
       };
     };


### PR DESCRIPTION
Makes the boss bar overlay scale fractional so it can grow by 25%.

Scale was integer-only (`u32`) and the live overlay snapped physical scale to `round(base_scale * scale_factor)`, so from andrew's effective scale 2 the only steps were 2 or 3 (+50%). This retypes scale to `f32` through the bossbar crate and drops the integer snap; integer base scales still land on integer physical scales (crisp), only an explicitly fractional value renders fractional.

Sets `users/andrewgazelka` `bossbarOverlay.scale` default to 1.25 (was 1).

Verified:
- `nix build .#bossbar-overlay` (darwin) ok
- 14 bossbar unit tests pass (scale math at 1.0–4.0)
- snapshot at scale 1.25 measures 225px tall vs 180px at 1.0 = exactly 1.25×

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support fractional sprite scale in bossbar overlay with 1.25x default for andrewgazelka
> - Changes the `scale` type from `u32` to `f32` throughout the bossbar codebase, allowing non-integer scale values (e.g. 1.25x instead of only 1x or 2x).
> - Updates all geometry, layout, and rendering functions in [scene.rs](https://github.com/indexable-inc/index/pull/573/files#diff-931bed67bf8f80a801e6031355b33a1774390f15740bd97d8a54a25229c734ab), [overlay.rs](https://github.com/indexable-inc/index/pull/573/files#diff-be0c00f68d255b3fe86ea924fe83d030d2a948a7e2d919b45eb19a51fa82ae26), [layer_shell.rs](https://github.com/indexable-inc/index/pull/573/files#diff-bee6ec89f3761680cf80a3e80f957daeed7fb98956a2badab31c139d32b05a08), and [snapshot.rs](https://github.com/indexable-inc/index/pull/573/files#diff-c39b51b96ff45f9beeda279ce851c80b26a5fcf234b9a8ea6a3ffb44b09c586a) to operate in `f32`.
> - Adds a `parse_scale` helper in [main.rs](https://github.com/indexable-inc/index/pull/573/files#diff-2c53c8e5b0f18a643c192f051078074dc061d5f06d366bffd7525b0e8affd93e) that rejects NaN, infinity, and non-positive values.
> - Sets the default scale for andrewgazelka to `1.25` in [home.nix](https://github.com/indexable-inc/index/pull/573/files#diff-b9c7bb705f699ec210f648820aef5c561583845b682d07d6e1dc19de7685cb0f), changing the NixOS option type from `ints.positive` to `numbers.positive`.
> - Behavioral Change: bar sizes and positions are now computed continuously in `f32`, so any integer-aligned rendering guarantees from before no longer apply.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a7a3e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->