### PR TITLE
fix(bossbar-overlay): scroll-drag stops on lift; drop macOS momentum coast

### DIFF
--- a/packages/bossbar-overlay/app/Cargo.lock
+++ b/packages/bossbar-overlay/app/Cargo.lock
@@ -1406,6 +1406,7 @@ dependencies = [
 name = "overlay-core"
 version = "0.1.0"
 dependencies = [
+ "block2",
  "bytemuck",
  "glam",
  "image",

--- a/packages/bossbar-overlay/app/Cargo.toml
+++ b/packages/bossbar-overlay/app/Cargo.toml
@@ -44,6 +44,9 @@ layershellev = "0.18.1"
 # features/version are a subset of what winit 0.30 already enables, so this pulls
 # in no extra crate.
 objc2 = "0.5"
+# `RcBlock` for the `NSEvent` scroll-momentum monitor's handler block (matches
+# objc2 0.5's block ABI; enables the `block2` feature on objc2-app-kit below).
+block2 = "0.5"
 # NSString for menu labels, NSThread for `MainThreadMarker`, NSObjCRuntime for
 # `NSObjectProtocol`, NSGeometry for `NSRect`/`NSPoint`/`NSSize` (declared here
 # rather than relying on winit's feature unification).
@@ -54,6 +57,9 @@ objc2-foundation = { version = "0.2.2", features = [
   "NSThread",
 ] }
 objc2-app-kit = { version = "0.2.2", features = [
+  # `block2` exposes `NSEvent::addLocalMonitorForEventsMatchingMask_handler`,
+  # used to filter out the macOS scroll-momentum tail before winit sees it.
+  "block2",
   "NSEvent",
   "NSMenu",
   "NSMenuItem",

--- a/packages/bossbar-overlay/app/crates/book/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/book/src/overlay.rs
@@ -356,9 +356,10 @@ impl App {
             return;
         };
         let (dx, dy) = overlay_core::scroll_drag_delta(delta, win.window.scale_factor());
-        // Move the window live on every event, momentum tail included, so it feels
-        // like scrolling. `self_set` tracks where the window sits and is set after
-        // create; measure the scroll from there.
+        // Move the window live on each event. `ocwin::suppress_scroll_momentum`
+        // drops the macOS momentum coast upstream, so this only sees the physical
+        // finger drag (and the book stops on lift). `self_set` tracks where the
+        // window sits and is set after create; measure the scroll from there.
         if (dx != 0.0 || dy != 0.0) && let Some(cur) = win.self_set {
             let np = LogicalPosition::new(cur.x + dx, cur.y + dy);
             win.self_set = Some(np);
@@ -368,11 +369,11 @@ impl App {
             win.last_move = Instant::now();
             self.book.pos = Some(DVec2::new(np.x, np.y));
         }
-        // Persist only when the gesture settles, not per frame: a trackpad flick
-        // emits a long momentum tail of `MouseWheel` events, and writing on each
-        // would open a SQLite connection per frame on the UI thread. The touch and
-        // momentum ends both carry `TouchPhase::Ended`; a discrete wheel notch
-        // (`LineDelta`) has no Ended phase but is low-frequency, so save it directly.
+        // Persist only when the gesture settles, not per frame: a scroll emits a
+        // burst of `MouseWheel` events, and writing on each would open a SQLite
+        // connection per frame on the UI thread. The finger lift carries
+        // `TouchPhase::Ended`; a discrete wheel notch (`LineDelta`) has no Ended
+        // phase but is low-frequency, so save it directly.
         let settle = phase == TouchPhase::Ended || matches!(delta, MouseScrollDelta::LineDelta(..));
         if settle
             && let Some(pos) = win.self_set
@@ -388,6 +389,9 @@ impl ApplicationHandler<Book> for App {
         if self.ready {
             return;
         }
+        // A two-finger scroll-drag tracks the fingers and stops on lift; drop the
+        // macOS momentum coast so a flick does not fling the book past the gesture.
+        ocwin::suppress_scroll_momentum();
         let monitor = event_loop
             .primary_monitor()
             .or_else(|| event_loop.available_monitors().next());

--- a/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/bossbar/src/overlay.rs
@@ -490,10 +490,12 @@ impl App {
             return;
         };
         let (dx, dy) = overlay_core::scroll_drag_delta(delta, win.window.scale_factor());
-        // Move the window live on every event, momentum tail included, so it feels
-        // like scrolling. `self_set` tracks where the window sits and is set after
-        // create; measure the scroll from there, and pin the bar (`bar.pos`) so the
-        // size-settle pass stops re-centering it, exactly as a drag does.
+        // Move the window live on each event. `ocwin::suppress_scroll_momentum`
+        // drops the macOS momentum coast upstream, so this only sees the physical
+        // finger drag (and the bar stops on lift). `self_set` tracks where the
+        // window sits and is set after create; measure the scroll from there, and
+        // pin the bar (`bar.pos`) so the size-settle pass stops re-centering it,
+        // exactly as a drag does.
         if (dx != 0.0 || dy != 0.0) && let Some(cur) = win.self_set {
             let np = LogicalPosition::new(cur.x + dx, cur.y + dy);
             win.self_set = Some(np);
@@ -503,11 +505,11 @@ impl App {
             win.last_move = Instant::now();
             win.bar.pos = Some(DVec2::new(np.x, np.y));
         }
-        // Persist only when the gesture settles, not per frame: a trackpad flick
-        // emits a long momentum tail of `MouseWheel` events, and writing on each
-        // would open a SQLite connection per frame on the UI thread. The touch and
-        // momentum ends both carry `TouchPhase::Ended`; a discrete wheel notch
-        // (`LineDelta`) has no Ended phase but is low-frequency, so save it directly.
+        // Persist only when the gesture settles, not per frame: a scroll emits a
+        // burst of `MouseWheel` events, and writing on each would open a SQLite
+        // connection per frame on the UI thread. The finger lift carries
+        // `TouchPhase::Ended`; a discrete wheel notch (`LineDelta`) has no Ended
+        // phase but is low-frequency, so save it directly.
         let settle = phase == TouchPhase::Ended || matches!(delta, MouseScrollDelta::LineDelta(..));
         if settle
             && let Some(pos) = win.self_set
@@ -589,6 +591,9 @@ impl ApplicationHandler<Vec<BossBar>> for App {
         if self.ready {
             return;
         }
+        // A two-finger scroll-drag tracks the fingers and stops on lift; drop the
+        // macOS momentum coast so a flick does not fling the bar past the gesture.
+        ocwin::suppress_scroll_momentum();
         let monitor = event_loop
             .primary_monitor()
             .or_else(|| event_loop.available_monitors().next());

--- a/packages/bossbar-overlay/app/crates/orb/src/overlay.rs
+++ b/packages/bossbar-overlay/app/crates/orb/src/overlay.rs
@@ -236,8 +236,10 @@ impl App {
 
     /// Move the orb to follow a two-finger trackpad scroll, persisting like a drag.
     /// A scroll has no button for `Window::drag_window` to own, so we move the
-    /// window ourselves and persist only when the gesture settles (so a flick's
-    /// momentum tail does not open a SQLite connection per frame). See
+    /// window ourselves and persist only when the gesture settles (so the
+    /// finger-drag burst does not open a SQLite connection per frame). The macOS
+    /// momentum coast is dropped upstream by `ocwin::suppress_scroll_momentum`, so
+    /// the orb tracks the fingers and stops on lift. See
     /// [`overlay_core::scroll_drag_delta`].
     fn scroll_move(&mut self, delta: MouseScrollDelta, phase: TouchPhase) {
         let Some(win) = self.win.as_mut() else {
@@ -268,6 +270,9 @@ impl ApplicationHandler<Orb> for App {
         if self.ready {
             return;
         }
+        // A two-finger scroll-drag tracks the fingers and stops on lift; drop the
+        // macOS momentum coast so a flick does not fling the orb past the gesture.
+        ocwin::suppress_scroll_momentum();
         let monitor = event_loop
             .primary_monitor()
             .or_else(|| event_loop.available_monitors().next());

--- a/packages/bossbar-overlay/app/crates/overlay-core/Cargo.toml
+++ b/packages/bossbar-overlay/app/crates/overlay-core/Cargo.toml
@@ -17,3 +17,4 @@ glam.workspace = true
 objc2.workspace = true
 objc2-app-kit.workspace = true
 objc2-foundation.workspace = true
+block2.workspace = true

--- a/packages/bossbar-overlay/app/crates/overlay-core/src/window.rs
+++ b/packages/bossbar-overlay/app/crates/overlay-core/src/window.rs
@@ -121,6 +121,72 @@ pub fn cursor_global() -> Option<(f64, f64)> {
     None
 }
 
+/// Stop the macOS scroll-**momentum** tail from reaching the overlays, so a
+/// two-finger scroll-drag moves a window 1:1 with the fingers and then *stops on
+/// lift* instead of coasting on past the gesture.
+///
+/// Why this exists: winit already hands us the system's accelerated
+/// `scrollingDelta` (so [`crate::scroll_drag_delta`] moves the window on the
+/// native acceleration curve, no custom math), but it *collapses* the trackpad's
+/// touch phase and the OS momentum phase into one `MouseWheel` stream. Every
+/// momentum-coast event arrives as a plain `TouchPhase::Moved`, indistinguishable
+/// from a finger drag, so the overlay would keep flinging the window for the whole
+/// coast. A window has no business coasting like scrolled content.
+///
+/// `-[NSEvent momentumPhase]` is the documented, canonical way to tell the coast
+/// from a real scroll: it is non-`None` exactly for the momentum stream and
+/// `None` during the user's physical scroll (and for a notched mouse wheel). See
+/// Apple's "Handling Trackpad Events". winit does not expose it, so we install an
+/// app-wide *local* `NSEvent` monitor (no Accessibility permission needed; it only
+/// sees this app's own events) that returns `nil` for any scroll event with a
+/// momentum phase, dropping it before winit's view ever queues a `MouseWheel`.
+/// Physical-scroll and mouse-wheel events pass through untouched.
+///
+/// Call once after the event loop is running (e.g. from `resumed`), on the main
+/// thread. The monitor is intentionally leaked: it lives for the whole process,
+/// and there is no teardown point that would want it removed.
+#[cfg(target_os = "macos")]
+pub fn suppress_scroll_momentum() {
+    use block2::RcBlock;
+    use objc2::rc::Retained;
+    use objc2::runtime::AnyObject;
+    use objc2_app_kit::{NSEvent, NSEventMask};
+    use std::ptr::NonNull;
+
+    // Return the event to let it through, or null to swallow it. A scroll event
+    // whose `momentumPhase` is set (raw bits != 0) is part of the inertial coast;
+    // everything else (the physical two-finger scroll, a notched mouse wheel) is
+    // passed through so winit handles it as usual.
+    let handler = RcBlock::new(|event: NonNull<NSEvent>| -> *mut NSEvent {
+        // SAFETY: AppKit hands the monitor a live, autoreleased `NSEvent` for the
+        // duration of the callback; we only read from it. `momentumPhase` is valid
+        // for scroll-wheel events, which is all this monitor's mask selects.
+        let ev = unsafe { event.as_ref() };
+        if unsafe { ev.momentumPhase() }.0 != 0 {
+            std::ptr::null_mut()
+        } else {
+            event.as_ptr()
+        }
+    });
+
+    // SAFETY: a standard AppKit call on the main thread; the handler block is
+    // `'static` (captures nothing) and matches the documented signature.
+    let monitor: Option<Retained<AnyObject>> = unsafe {
+        NSEvent::addLocalMonitorForEventsMatchingMask_handler(NSEventMask::ScrollWheel, &handler)
+    };
+    // Keep the monitor installed for the life of the process. Dropping the
+    // returned token would tear the monitor down again.
+    if let Some(monitor) = monitor {
+        std::mem::forget(monitor);
+    }
+}
+
+/// Non-macOS: X11/Wayland deliver no momentum-coast scroll stream to suppress
+/// (kinetic scrolling, where present, is the compositor's, not extra events to a
+/// client), so this is a no-op.
+#[cfg(not(target_os = "macos"))]
+pub fn suppress_scroll_momentum() {}
+
 /// Attributes for a floating overlay window: transparent, borderless,
 /// non-resizable, always on top, sized to `(w_px, h_px)` physical pixels and
 /// placed at `pos` (logical points) when given.


### PR DESCRIPTION
Two-finger scroll-drag of an overlay (boss bar, book, xp-orb) kept gliding past where the fingers stopped. Fixed so it tracks the fingers and stops on lift.

- winit already gives us macOS's accelerated `scrollingDelta`, so per-event magnitude was already the native curve. The off feel was the **momentum coast**: we moved the window for the whole inertial tail too.
- winit 0.30 collapses the touch phase and momentum phase into one `MouseWheel` stream (both arrive as `TouchPhase::Moved`), so the app can't tell the coast from a finger drag. `-[NSEvent momentumPhase]` is the documented signal (Apple "Handling Trackpad Events") and winit doesn't expose it.
- Added `overlay_core::window::suppress_scroll_momentum()`: an app-wide local `NSEvent` monitor that returns `nil` for any scroll event with a momentum phase, dropping the coast before winit queues a `MouseWheel`. Physical scroll and notched-wheel events pass through. Called once from each overlay's `resumed()`.

Verified:
- `nix build .#bossbar-overlay .#book-overlay .#xp-orb-overlay` green; overlay-core + per-bin tests pass.
- On the real trackpad via an instrumented winit probe: with the monitor installed, a flick emits **zero** scroll events after the finger `Ended` (no coast) and no momentum `Started`, versus a long decaying tail without it.

_Made with Claude (Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop macOS momentum-phase scroll events in bossbar-overlay so scroll-drag stops on finger lift
> - Adds `suppress_scroll_momentum()` in [window.rs](https://github.com/indexable-inc/index/pull/574/files#diff-829a2ecf4cf9fab8e345c6d998edb47cb79fdc4a69943258379cfd2e3a3d296a), which installs an AppKit local event monitor that drops any scroll event whose `momentumPhase` indicates a coast (inertia) phase.
> - The monitor token is leaked with `mem::forget` so it stays active for the app's lifetime.
> - Called at startup in the `resumed` handler for all three overlay targets (book, bossbar, orb).
> - A no-op stub is provided for non-macOS targets (X11/Wayland do not emit momentum events).
> - Behavioral Change: two-finger scroll-drag on macOS now moves the window/bar/orb with the fingers and stops immediately on lift rather than coasting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 432dce7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->