### PR TITLE
feat(claude-code): restore summarized thinking on Opus 4.7/4.8

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -229,9 +229,30 @@ stdenv.mkDerivation {
     # `claude -p` stdout (verified). Those logs prune on the cleanupPeriodDays
     # sweep, so we also ship a long retention via --settings (see
     # `settingsDefaults` above).
+    #
+    # Opt back into summarized thinking (`--thinking-display summarized`). The
+    # API behavior here DIFFERS BY MODEL: `thinking.display` defaulted to
+    # "summarized" on Opus 4.6 / Sonnet 4.6 and earlier, but Anthropic silently
+    # flipped it to "omitted" on Opus 4.7 and Opus 4.8 (faster time-to-first-
+    # token). With "omitted" the API returns thinking blocks whose `thinking`
+    # field is empty (only the encrypted `signature` rides along), so on the
+    # latest Opus the live UI shows nothing and the transcript persists no
+    # reasoning. The harness never requests "summarized" itself, and
+    # `showThinkingSummaries` does NOT fix it (it only drives the ctrl+o
+    # renderer + a beta header, wired to nothing that sets the request's
+    # display) -- see anthropics/claude-code#49268 (root cause) and #63358
+    # (Opus 4.8). The hidden `--thinking-display summarized` flag is the only
+    # lever that works, and it is verified to restore readable Opus-4.8 thinking
+    # on 2.1.159. We want the reasoning for steering and for the optimize
+    # analysis, so we trade the TTFT win for visible thinking fleet-wide. Safe
+    # for Haiku (it already defaults to "summarized"); unlike CLAUDE_CODE_EXTRA_
+    # BODY this does not force `type:adaptive`, which Haiku rejects. Via
+    # `--add-flags` (prepended) so an explicit `--thinking-display omitted` on
+    # the CLI still wins for anyone who wants the latency back.
     makeBinaryWrapper "$helper" $out/bin/${binName} \
       --inherit-argv0 \
       --add-flags --debug \
+      --add-flags "--thinking-display summarized" \
       --append-flags "--settings ${settingsDefaultsFile}" \
       --set DISABLE_AUTOUPDATER 1 \
       --set DISABLE_INSTALLATION_CHECKS 1 \


### PR DESCRIPTION
Opus 4.7/4.8 silently flipped `thinking.display` to `omitted`, so the harness records empty thinking blocks (signature only) — no visible or persisted reasoning. The wrapper now injects the hidden `--thinking-display summarized` flag to opt back in.

- Verified on 2.1.159: wrapped binary persists readable Opus 4.8 thinking with **no** explicit flag.
- Haiku-safe (already defaults summarized; unlike `CLAUDE_CODE_EXTRA_BODY` it doesn't force `type:adaptive`, which Haiku rejects).
- `--add-flags` (prepended) so an explicit `--thinking-display omitted` still wins.
- Trades the time-to-first-token win for visible reasoning fleet-wide (steering + the optimize analysis).

Refs anthropics/claude-code#49268, #63358.

Made with Claude Code (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `--thinking-display summarized` as default flag in the `claude-code` CLI wrapper
> Adds `--thinking-display summarized` to the `makeBinaryWrapper` flags in [default.nix](https://github.com/indexable-inc/index/pull/576/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b), so every invocation of the installed CLI requests summarized thinking by default. This restores summarized thinking behavior for Opus 4.7/4.8, which opt out of it by default.
>
> Behavioral Change: all users of this Nix-wrapped binary will now get summarized thinking output unless they explicitly override the flag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0175481.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->