### PR TITLE
feat(optimize): polars thinking_traces() helper + reading example

### DIFF
--- a/skills/optimize/SKILL.md
+++ b/skills/optimize/SKILL.md
@@ -27,6 +27,19 @@ F["tools"]   # one row per tool_result (tool, label, size, is_error)
 F["debug"]   # one row per --debug timing/error event (kind, tool, model, ms, level, msg)
 ```
 
+**Reading actual thinking traces.** `F["df"]` only *counts* reasoning per turn (`n_think` = all blocks incl. Opus's signature-only ones, `n_think_text`/`think_chars` = visible text), and the `model loop profile` aggregate exposes the omitted-vs-summarized split via `frac_visible_think`. To read the *text* of the reasoning, use the scoped helper — it is kept out of `build_frames` on purpose so raw thinking never bloats the aggregate frames:
+
+```python
+import polars as pl
+T = o.thinking_traces(session="<session-id>")     # one row per block: session, ts, model, idx, text_len, sig_len, text
+# or a time-boxed sweep across sessions (heavier — pulls text):
+T = o.thinking_traces(days=7, model="claude-opus-4-8")
+T.filter(pl.col("text_len") > 0).select("ts", "model", "text")             # readable summarized reasoning
+T.group_by("model").agg((pl.col("text_len") > 0).mean().alias("frac_visible"), pl.len())  # who persists text
+```
+
+Opus 4.7/4.8 store only an encrypted `signature` (`text_len=0`) unless the harness passes `--thinking-display summarized` (the index `claude-code` wrapper does by default, PR #576), in which case summarized `text` is present; Haiku 4.5 always stores text. It is always the API's summary, never raw CoT. Pass `with_text=False` for a lengths-only frame.
+
 To avoid re-scanning across questions, cache once: `o.build_frames(...)["df"].write_parquet("~/.claude/optimize/history_rows.parquet")` (and `bash`/`tools`/`debug`), then `pl.read_parquet(...)` for instant re-slicing. The module also runs standalone for headless use (`python ${CLAUDE_SKILL_DIR}/assets/build_history_df.py --full --out ~/.claude/optimize`) on any interpreter with polars.
 
 Default to the **last ~45 days** (current model family — old transcripts ran retired models and teach nothing actionable). Expand to `full=True` only when a pattern needs the longer baseline.

--- a/skills/optimize/assets/build_history_df.py
+++ b/skills/optimize/assets/build_history_df.py
@@ -334,6 +334,77 @@ def build_frames(days: int = 45, full: bool = False):
     )
 
 
+def thinking_traces(session: str | None = None, *, days: int = 45, full: bool = False,
+                    model: str | None = None, with_text: bool = True,
+                    projects: str = PROJECTS):
+    """One row per thinking block as a polars frame: session, ts, model, idx,
+    text_len, sig_len, and (when with_text) the summarized reasoning `text` itself.
+
+    Kept OUT of build_frames on purpose: build_frames only TALLIES thinking
+    (n_think / n_think_text / think_chars) so raw reasoning never bloats the
+    aggregate frames. Reach here when you actually want to READ the reasoning,
+    and SCOPE it — pass `session=` for one transcript (recommended) or a tight
+    `days` window — because the text column is exactly the context cost the rest
+    of the library avoids. Pass with_text=False for a lengths-only frame.
+
+    Persistence is model- and harness-dependent (see the model loop profile's
+    frac_visible_think): Opus 4.7/4.8 store only an encrypted `signature`
+    (text_len=0, display=omitted) UNLESS the harness passes
+    `--thinking-display summarized` (the index claude-code wrapper does by
+    default, PR #576), in which case summarized `text` is present; Haiku 4.5
+    always stores text. Either way it is the API's SUMMARY, never raw CoT.
+    """
+    import polars as pl
+    files = glob.glob(os.path.join(projects, "*", "*.jsonl"))
+    if session:
+        files = [f for f in files if os.path.basename(f)[:-6] == session]
+    elif not full:
+        cutoff = datetime.now(timezone.utc).timestamp() - days * 86400
+        files = [f for f in files if os.path.getmtime(f) >= cutoff]
+    rows = []
+    for f in files:
+        sess = os.path.basename(f)[:-6]
+        try:
+            lines = open(f, encoding="utf-8").read().splitlines()
+        except Exception:
+            continue
+        for l in lines:
+            # Cheap prefilter: a thinking block's line always contains the
+            # substring; skip the json.loads on the ~majority of lines without one.
+            if '"thinking"' not in l:
+                continue
+            try:
+                r = json.loads(l)
+                if r.get("type") != "assistant":
+                    continue
+                m = r.get("message") if isinstance(r.get("message"), dict) else {}
+                if not isinstance(m.get("content"), list):
+                    continue
+                mdl = m.get("model")
+                if model and mdl != model:
+                    continue
+                ts = parse_ts(r.get("timestamp", ""))
+                idx = 0
+                for b in m["content"]:
+                    if not (isinstance(b, dict) and b.get("type") == "thinking"):
+                        continue
+                    txt = b.get("thinking") if isinstance(b.get("thinking"), str) else ""
+                    sig = b.get("signature") if isinstance(b.get("signature"), str) else ""
+                    row = dict(session=sess, ts=ts, model=mdl, idx=idx,
+                               text_len=len(txt), sig_len=len(sig))
+                    if with_text:
+                        row["text"] = txt
+                    rows.append(row)
+                    idx += 1
+            except Exception:
+                continue
+    schema = {"session": pl.String, "ts": pl.Datetime("us", "UTC"), "model": pl.String,
+              "idx": pl.Int64, "text_len": pl.Int64, "sig_len": pl.Int64}
+    if with_text:
+        schema["text"] = pl.String
+    return pl.DataFrame(rows, schema=schema).sort(["session", "ts", "idx"])
+
+
 def summary_line(F):
     df = F["df"]
     dbg = F.get("debug")


### PR DESCRIPTION
Adds a scoped `thinking_traces()` helper to the `/optimize` polars library and a worked example to SKILL.md, so the actual reasoning *text* is queryable.

- `build_frames` only **tallies** thinking (`n_think`/`n_think_text`/`think_chars`) to keep raw reasoning out of the aggregate frames; there was no way to read the text via the library.
- `thinking_traces(session=… | days=…, model=…, with_text=…)` returns one polars row per thinking block (`session, ts, model, idx, text_len, sig_len, text`). Scope by session (cheap) or a tight window (heavier, pulls text). `with_text=False` → lengths-only coverage frame.
- Documents the omitted-vs-summarized split: Opus 4.7/4.8 are signature-only unless `--thinking-display summarized` (the index `claude-code` wrapper passes it by default, #576); Haiku 4.5 always stores text. Always the API summary, never raw CoT.

Validated in the index MCP python session: scoped (20 blocks, frac_visible=1.0), lengths-only mode, 7d Opus window (16,650 blocks at frac_visible=0.001 — confirms pre-wrapper signature-only at population scale), and empty/bogus-session safety (0 rows, schema intact). `py_compile` clean, CLI `--help` intact, `skillsaw lint` 0 errors.

Made with Claude Code (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `thinking_traces()` helper to return per-block thinking traces as a Polars DataFrame
> - Adds `thinking_traces(session, days, full, model, with_text, projects)` in [`build_history_df.py`](https://github.com/indexable-inc/index/pull/577/files#diff-f81bb9471f9d4c585bfb7c64a786743a7678efc9d9596dfa7a5dc3779733406d) that scans project JSONL transcripts and returns one row per thinking block.
> - Filters files by session or modification time (`days`) unless `full=True`; optionally filters by model and omits trace text when `with_text=False`.
> - Updates [`SKILL.md`](https://github.com/indexable-inc/index/pull/577/files#diff-0bea71d68ae4b922ba18e351e8cba291df6d98887b97fefe1502c4f94aa23706) with a usage section covering the scoped helper pattern, filter parameters, and model-specific persistence behavior (Opus vs Haiku).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 087e4ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->