### PR TITLE
fix(optimize): make thinking_traces idx a real per-session ordinal

### DIFF
--- a/skills/optimize/assets/build_history_df.py
+++ b/skills/optimize/assets/build_history_df.py
@@ -339,6 +339,8 @@ def thinking_traces(session: str | None = None, *, days: int = 45, full: bool = 
                     projects: str = PROJECTS):
     """One row per thinking block as a polars frame: session, ts, model, idx,
     text_len, sig_len, and (when with_text) the summarized reasoning `text` itself.
+    `idx` is a per-session monotonic counter in transcript (chronological) order,
+    so it gives a stable total order even across blocks that share a `ts`.
 
     Kept OUT of build_frames on purpose: build_frames only TALLIES thinking
     (n_think / n_think_text / think_chars) so raw reasoning never bloats the
@@ -356,7 +358,7 @@ def thinking_traces(session: str | None = None, *, days: int = 45, full: bool = 
     """
     import polars as pl
     files = glob.glob(os.path.join(projects, "*", "*.jsonl"))
-    if session:
+    if session is not None:  # "" is a valid (if nonsensical) id, NOT a fall-through to the window scan
         files = [f for f in files if os.path.basename(f)[:-6] == session]
     elif not full:
         cutoff = datetime.now(timezone.utc).timestamp() - days * 86400
@@ -368,6 +370,11 @@ def thinking_traces(session: str | None = None, *, days: int = 45, full: bool = 
             lines = open(f, encoding="utf-8").read().splitlines()
         except Exception:
             continue
+        # Per-session monotonic block counter in transcript order. Claude Code
+        # writes one thinking block per record, so a per-RECORD index would be
+        # always-0 and useless; counting across the session makes idx a real,
+        # collision-free ordinal that disambiguates same-timestamp blocks.
+        idx = 0
         for l in lines:
             # Cheap prefilter: a thinking block's line always contains the
             # substring; skip the json.loads on the ~majority of lines without one.
@@ -384,7 +391,6 @@ def thinking_traces(session: str | None = None, *, days: int = 45, full: bool = 
                 if model and mdl != model:
                     continue
                 ts = parse_ts(r.get("timestamp", ""))
-                idx = 0
                 for b in m["content"]:
                     if not (isinstance(b, dict) and b.get("type") == "thinking"):
                         continue
@@ -402,7 +408,8 @@ def thinking_traces(session: str | None = None, *, days: int = 45, full: bool = 
               "idx": pl.Int64, "text_len": pl.Int64, "sig_len": pl.Int64}
     if with_text:
         schema["text"] = pl.String
-    return pl.DataFrame(rows, schema=schema).sort(["session", "ts", "idx"])
+    # (session, idx) is unique + monotonic, so the sort is deterministic.
+    return pl.DataFrame(rows, schema=schema).sort(["session", "idx"])
 
 
 def summary_line(F):


### PR DESCRIPTION
Follow-up to #577 addressing the code-review finding.

`idx` was always `0` — Claude Code writes one thinking block per JSONL record, so the per-record counter never advanced. That made it a dead column that also couldn't disambiguate same-timestamp blocks under polars' non-stable default sort.

- Count `idx` monotonically across the session in transcript order → `(session, idx)` is unique + chronological; sort by it deterministically.
- Guard `session=""` (falsy) from silently falling through to the `days`-window scan.

Validated: this session → 29 blocks, idx 0..28 contiguous/unique; `session=""` → 0 rows; model filter intact; `py_compile` clean.

Made with Claude Code (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `thinking_traces` idx to be a per-session monotonic ordinal in build_history_df
> - `idx` previously reset to `0` for each assistant record; it now increments monotonically across the entire session transcript, providing a stable total order.
> - The session filter condition changes from `if session:` to `if session is not None`, so passing `session=""` now correctly restricts results to that session instead of falling back to a time-window scan.
> - The final sort changes from `(session, ts, idx)` to `(session, idx)`, making row order fully deterministic by the session-wide ordinal.
> - Behavioral Change: callers relying on the old per-record `idx` reset or on `session=""` falling through will see different results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ac1d1d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->