### PR TITLE
ci: scheduled Claude Code auto-bump workflow

### DIFF
--- a/.github/workflows/update-claude-code.yml
+++ b/.github/workflows/update-claude-code.yml
@@ -1,0 +1,94 @@
+name: Update Claude Code
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Claude Code ships several builds a week: Anthropic promotes them from the
+    # `next` tag to `latest` a few days apart, so check daily rather than the
+    # weekly cadence the flake.lock / loader jobs use. The updater tracks the
+    # `latest` pointer, and the PR step reuses one branch, so a daily run just
+    # advances the open PR instead of stacking new ones.
+    - cron: "37 9 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-claude-code
+  cancel-in-progress: false
+
+jobs:
+  update-claude-code:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Only the client-side eval knob is needed: `accept-flake-config` lets the
+      # job consume the flake's indexable-inc Cachix substituter without a
+      # prompt. No `gccarch-znver5` here (unlike the image checks) because the
+      # claude-code closure is a fetchurl plus a wrapper and pulls no znver5
+      # derivation, so claiming a feature the GitHub-hosted runner lacks would
+      # only risk a misleading build.
+      - name: Install Determinate Nix
+        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3
+        with:
+          extra-conf: |
+            accept-flake-config = true
+
+      - name: Set up Cachix
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: indexable-inc
+
+      # Tracks Anthropic's `latest` pointer (no version argument). The updater
+      # downloads the per-version manifest and its detached GPG signature,
+      # verifies that signature against the pinned release key in an isolated
+      # GNUPGHOME, and only then rewrites packages/claude-code/manifest.json. A
+      # failed signature check exits non-zero and fails this step, so no PR
+      # opens. Runs from the repo root because the updater writes a relative
+      # path.
+      - name: Refresh manifest to the latest signed release
+        run: nix run .#claude-code.updateScript
+
+      # Fail closed on the build too: prove the pinned hash actually fetches and
+      # the wrapper builds before proposing the bump. Only the x86_64-linux
+      # binary is built here, but the updater already signature-verified every
+      # platform's checksum from the same signed manifest, so the darwin and arm
+      # hashes are trustworthy without a per-platform build. A no-op run is a
+      # Cachix hit, so this stays cheap when nothing changed.
+      - name: Build the updated package
+        run: nix build .#claude-code
+
+      - name: Read pinned version
+        id: manifest
+        run: echo "version=$(jq -r .version packages/claude-code/manifest.json)" >> "$GITHUB_OUTPUT"
+
+      # Opens (or updates) a single PR, and only when manifest.json actually
+      # changed: create-pull-request no-ops on an empty diff. It reuses the
+      # `update-claude-code` branch so a daily run advances the same PR.
+      #
+      # `token`: a PR opened with the default GITHUB_TOKEN does not trigger the
+      # `pull_request` workflows (`flake-check`), so branch protection would
+      # block the merge. Set an `AUTOBUMP_TOKEN` repo secret (a PAT or GitHub
+      # App token) to make the PR run CI; without it this falls back to
+      # GITHUB_TOKEN and a maintainer must re-trigger `flake-check` (e.g. close
+      # and reopen the PR).
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.AUTOBUMP_TOKEN || github.token }}
+          base: main
+          branch: update-claude-code
+          delete-branch: true
+          commit-message: "claude-code: bump to ${{ steps.manifest.outputs.version }}"
+          title: "claude-code: bump to ${{ steps.manifest.outputs.version }}"
+          body: |
+            Automated bump of the pinned Claude Code release to `${{ steps.manifest.outputs.version }}`.
+
+            `nix run .#claude-code.updateScript` refreshed `packages/claude-code/manifest.json`. The updater verified Anthropic's detached GPG signature against the pinned release key before writing the per-platform SRI hashes, and `nix build .#claude-code` succeeded on `x86_64-linux`, so this fails closed on a bad signature or a broken build.
+
+            Auto-bump prototype, made with Claude Opus 4.8.


### PR DESCRIPTION
Closes #545.

Adds `.github/workflows/update-claude-code.yml`, a scheduled job that keeps the pinned Claude Code release current so it no longer needs a hand-bump.

## What it does

Daily (and on manual `workflow_dispatch`), on `ubuntu-latest` with Determinate Nix and the indexable-inc Cachix substituter:

1. `nix run .#claude-code.updateScript` tracks Anthropic's `latest` pointer and rewrites `packages/claude-code/manifest.json`. The updater already downloads the detached GPG signature and verifies it against the pinned release key in an isolated GNUPGHOME, so a spoofed manifest exits non-zero and fails the step.
2. `nix build .#claude-code` is the second fail-closed gate: the pinned hash must fetch and the wrapper must build. Only x86_64-linux is built, but the updater signature-verified every platform's checksum from the one signed manifest, so the darwin and arm hashes are covered without a per-platform build. A no-op day is a Cachix hit.
3. `peter-evans/create-pull-request` (SHA-pinned to v8.1.1) opens or updates one PR on branch `update-claude-code`. It no-ops on an empty diff, and the updater's deterministic JSON output means quiet days produce no spurious PR.

Scope is claude-code only. `ix` and the Minecraft updaters are untouched.

## Two repo settings needed before it can merge its own PRs

Neither can be set from the workflow file:

1. Settings -> Actions -> General -> Workflow permissions: enable "Allow GitHub Actions to create and approve pull requests", or the PR step errors.
2. A PR opened with the default `GITHUB_TOKEN` does not trigger `pull_request` workflows, so `flake-check` will not run and branch protection blocks the merge. The step reads `secrets.AUTOBUMP_TOKEN || github.token`; add an `AUTOBUMP_TOKEN` secret (PAT or GitHub App token) to make the auto-PR run CI. Without it, a maintainer re-triggers `flake-check` by closing and reopening the PR.

## Notes

Cadence is daily (`37 9 * * *`) since Claude Code ships several builds a week; the single reused branch avoids PR spam. Validated off-CI: `actionlint` is clean, `.#claude-code.updateScript` resolves, and the action SHA is current.

Auto-bump prototype, made with Claude Opus 4.8.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add scheduled GitHub Actions workflow to auto-bump Claude Code
> Adds [update-claude-code.yml](.github/workflows/update-claude-code.yml), a daily cron and manually triggered workflow that runs the Nix update script for `claude-code`, builds the package, extracts the new version from the manifest, and opens or updates a PR on the `update-claude-code` branch with the detected version. If the update script or build fails, no PR is created.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05b8e66.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->