### PR TITLE
fix(mixedbread): also retry transport-level send failures

### DIFF
--- a/packages/mixedbread/Cargo.toml
+++ b/packages/mixedbread/Cargo.toml
@@ -19,4 +19,4 @@ tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
 axum.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "time"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "time", "io-util"] }

--- a/packages/mixedbread/src/lib.rs
+++ b/packages/mixedbread/src/lib.rs
@@ -273,11 +273,13 @@ impl Client {
                         .map_or_else(|| backoff(attempt), |hint| hint.max(backoff(attempt)))
                 }
                 // A transport-level failure (connection reset, HTTP/2 error,
-                // timeout) means no response arrived, so the request is safe to
+                // timeout): the send errored before a usable response, so we
                 // retry. Mixedbread sheds connections under load, so these are
                 // common during a large sync and were previously fatal per
-                // source. The non-idempotency caveat on `POST /v1/files` is the
-                // same as for a 5xx retry (documented at the call site).
+                // source. Note the send *may* have reached the server (it can
+                // error after the body was transmitted), so retrying the
+                // non-idempotent `POST /v1/files` can orphan a file object —
+                // the same caveat as the 5xx path, documented at the call site.
                 Err(err) => {
                     if attempt >= MAX_RETRIES {
                         return Err(err).context(HttpSnafu);
@@ -873,6 +875,8 @@ mod tests {
 
     #[tokio::test]
     async fn retries_transport_errors_then_succeeds() {
+        // Pays real backoff (~1s): transport errors carry no `Retry-After`, so
+        // don't raise `fail_times` expecting it to stay instant.
         let (base, calls) = spawn_flaky_tcp(2).await;
         let client = Client::new(base, "test-key").expect("client");
         client

--- a/packages/mixedbread/src/lib.rs
+++ b/packages/mixedbread/src/lib.rs
@@ -239,8 +239,10 @@ impl Client {
         format!("{}{path}", self.base_url)
     }
 
-    /// Send a request with bearer auth, retrying on `429`/`5xx` with
-    /// `Retry-After`-aware, jittered backoff.
+    /// Send a request with bearer auth, retrying on `429`/`5xx` (with
+    /// `Retry-After`-aware, jittered backoff) and on transport-level send
+    /// failures (connection reset, HTTP/2 error, timeout) where no response
+    /// arrived. All failures share one [`MAX_RETRIES`] budget per request.
     ///
     /// `build` must produce a fresh [`reqwest::RequestBuilder`] on each call: a
     /// request body (notably multipart) is consumed by `send`, so a retry needs
@@ -255,23 +257,34 @@ impl Client {
     ) -> Result<reqwest::Response> {
         let mut attempt: u32 = 0;
         loop {
-            let resp = build()?
-                .bearer_auth(&self.api_key)
-                .send()
-                .await
-                .context(HttpSnafu)?;
-            let status = resp.status();
-            let retryable =
-                status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error();
-            if !retryable || attempt >= MAX_RETRIES {
-                return Ok(resp);
-            }
-            // Honor a server `Retry-After`, but never wait less than our
-            // jittered backoff: a `Retry-After: 0`/`1` under load would
-            // otherwise make every concurrent upload retry in lockstep, the
-            // very thundering herd this exists to avoid.
-            let wait = retry_after(&resp)
-                .map_or_else(|| backoff(attempt), |hint| hint.max(backoff(attempt)));
+            let wait = match build()?.bearer_auth(&self.api_key).send().await {
+                Ok(resp) => {
+                    let status = resp.status();
+                    let retryable =
+                        status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error();
+                    if !retryable || attempt >= MAX_RETRIES {
+                        return Ok(resp);
+                    }
+                    // Honor a server `Retry-After`, but never wait less than our
+                    // jittered backoff: a `Retry-After: 0`/`1` under load would
+                    // otherwise make every concurrent upload retry in lockstep,
+                    // the very thundering herd this exists to avoid.
+                    retry_after(&resp)
+                        .map_or_else(|| backoff(attempt), |hint| hint.max(backoff(attempt)))
+                }
+                // A transport-level failure (connection reset, HTTP/2 error,
+                // timeout) means no response arrived, so the request is safe to
+                // retry. Mixedbread sheds connections under load, so these are
+                // common during a large sync and were previously fatal per
+                // source. The non-idempotency caveat on `POST /v1/files` is the
+                // same as for a 5xx retry (documented at the call site).
+                Err(err) => {
+                    if attempt >= MAX_RETRIES {
+                        return Err(err).context(HttpSnafu);
+                    }
+                    backoff(attempt)
+                }
+            };
             attempt += 1;
             tokio::time::sleep(wait).await;
         }
@@ -822,6 +835,51 @@ mod tests {
         let client = Client::new(base, "test-key").expect("client");
         client.ensure_store("store").await.expect("succeeds after retries");
         // 2 rejected + 1 accepted.
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    /// TCP server that drops the connection without a response for the first
+    /// `fail_times` requests (a transport error, no HTTP status), then answers
+    /// `200`. Returns the base URL and a counter of accepted connections.
+    async fn spawn_flaky_tcp(fail_times: usize) -> (String, Arc<AtomicUsize>) {
+        use tokio::io::AsyncWriteExt as _;
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let calls_task = Arc::clone(&calls);
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    continue;
+                };
+                let n = calls_task.fetch_add(1, Ordering::SeqCst);
+                if n < fail_times {
+                    // Close immediately: the client sees the connection drop
+                    // before a response, i.e. a transport error.
+                    drop(sock);
+                } else {
+                    let _ = sock
+                        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")
+                        .await;
+                    let _ = sock.shutdown().await;
+                }
+            }
+        });
+        (format!("http://{addr}"), calls)
+    }
+
+    #[tokio::test]
+    async fn retries_transport_errors_then_succeeds() {
+        let (base, calls) = spawn_flaky_tcp(2).await;
+        let client = Client::new(base, "test-key").expect("client");
+        client
+            .ensure_store("store")
+            .await
+            .expect("succeeds after transport retries");
+        // 2 dropped connections + 1 accepted.
         assert_eq!(calls.load(Ordering::SeqCst), 3);
     }
 


### PR DESCRIPTION
Follow-up to #579. The 429/5xx retry landed there, but a large fleet indexer sync still failed on **transport errors** — observed live on hil-compute-1: HTTP/2 `connection error received` when Mixedbread sheds connections under load. Those surface as a `reqwest` send error (no HTTP status), so `send_retrying` propagated them immediately and failed the source.

Now retries send failures (connection reset, HTTP/2 error, timeout — no response arrived, so safe to retry) under the same per-request backoff budget. Adds a flaky-TCP test (drops the connection twice, then 200).

Validated on x86_64-linux builder: `rust-mixedbread-clippy` + `rust-mixedbread-mixedbread-all` (incl. new `retries_transport_errors_then_succeeds`).

Made with Claude Code (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry transport-level send failures in mixedbread `Client.send_retrying`
> Previously, `send_retrying` only retried on HTTP 429/5xx responses. It now also retries when the underlying transport fails to receive any response (e.g. dropped connections, protocol errors).
>
> - Transport errors use the same `MAX_RETRIES` budget and jittered backoff as HTTP error retries.
> - Adds a `spawn_flaky_tcp` test helper that drops the first N connections before returning a 200 OK, and a test asserting the client recovers successfully.
> - Behavioral Change: exhausted retries on transport errors now return an `HttpSnafu` error instead of propagating immediately.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cee3582.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->