### PR TITLE
feat(mcp): stream python exec stdout to the dashboard live

### DIFF
--- a/packages/mcp/src/exec_board.rs
+++ b/packages/mcp/src/exec_board.rs
@@ -30,6 +30,13 @@ use serde_json::Value;
 /// bound; older cards scroll off the live board but survive in the recording.
 const MAX_PANES: usize = 100;
 
+/// Cap on a live pane's streamed stdout. An unbounded producer (a `while True`
+/// loop) would otherwise grow every republished snapshot without bound, so the
+/// in-flight preview keeps only the most recent bytes. The final worker response
+/// carries the authoritative, separately-capped text (see `python_worker.py`),
+/// so this trim only affects the live view, never what the model receives.
+const STREAM_STDOUT_CAP: usize = 100_000;
+
 /// The process-global exec board, bound on first use. `None` once a bind was
 /// attempted and failed, so the failure is logged once rather than per call.
 static BOARD: OnceLock<Option<ExecBoard>> = OnceLock::new();
@@ -115,6 +122,36 @@ impl ExecBoard {
         id
     }
 
+    /// Stream a stdout chunk into a still-running pane and republish, so the
+    /// dashboard shows output as it is produced instead of only at completion.
+    /// A chunk for a pane that has already finished (a late partial racing the
+    /// final response) is dropped, and so is one for an unknown id.
+    pub fn append(&self, id: &str, stdout_chunk: &str) {
+        {
+            let mut panes = self.panes.lock();
+            let Some(View::Exec(view)) =
+                panes.iter_mut().find(|pane| pane.id == id).map(|pane| &mut pane.view)
+            else {
+                return;
+            };
+            if !view.running {
+                return;
+            }
+            view.stdout.push_str(stdout_chunk);
+            if view.stdout.len() > STREAM_STDOUT_CAP {
+                // Keep the most recent `STREAM_STDOUT_CAP` bytes, advancing the
+                // cut to the next char boundary so the removal never splits a
+                // multi-byte sequence and leaves invalid UTF-8.
+                let mut cut = view.stdout.len() - STREAM_STDOUT_CAP;
+                while !view.stdout.is_char_boundary(cut) {
+                    cut += 1;
+                }
+                view.stdout.replace_range(..cut, "");
+            }
+        }
+        self.publish();
+    }
+
     /// Record a finished call from the worker response: fill in the captured
     /// output and flip the pane out of its running state.
     pub fn finish_from_response(&self, id: &str, response: &Value) {
@@ -140,9 +177,21 @@ impl ExecBoard {
     }
 
     /// Record a transport failure (timeout, cancel, worker death): the call
-    /// produced no worker response, so surface the error as the pane's stderr.
+    /// produced no worker response. Preserve any stdout already streamed into the
+    /// pane (e.g. a long-running loop that ran to the timeout) and surface the
+    /// error as the pane's stderr, so the live output is not erased on failure.
     pub fn finish_error(&self, id: &str, error: &str) {
-        self.finish(id, String::new(), error.to_owned(), String::new(), false, Vec::new());
+        {
+            let mut panes = self.panes.lock();
+            if let Some(View::Exec(view)) =
+                panes.iter_mut().find(|pane| pane.id == id).map(|pane| &mut pane.view)
+            {
+                error.clone_into(&mut view.stderr);
+                view.running = false;
+                view.ok = Some(false);
+            }
+        }
+        self.publish();
     }
 
     fn finish(

--- a/packages/mcp/src/main.rs
+++ b/packages/mcp/src/main.rs
@@ -85,6 +85,11 @@ const HTTP_MCP_PATH: &str = "/mcp";
 // `python_*` tool description.
 const SERVER_INSTRUCTIONS: &str = include_str!("server_instructions.txt");
 
+/// Sink for interim stdout streamed from a running cell: each chunk is handed to
+/// this callback as it arrives, before the final response. `call_content` points
+/// it at the dashboard pane; other callers stream nowhere and pass `None`.
+type PartialSink = Box<dyn FnMut(&str) + Send>;
+
 /// A token that is never cancelled, for internal round-trips (startup ping,
 /// reset, close, and every CLI call) that are not tied to a client request.
 fn uncancellable() -> CancellationToken {
@@ -372,6 +377,7 @@ impl McpServer {
         payload: Value,
         timeout: Duration,
         cancel: CancellationToken,
+        on_partial: Option<PartialSink>,
     ) -> Result<Value> {
         let sessions = self.sessions.clone();
         tokio::task::spawn_blocking(move || -> Result<Value> {
@@ -384,7 +390,15 @@ impl McpServer {
             let mut session = session
                 .lock()
                 .map_err(|error| anyhow!("Python session lock failed: {error}"))?;
-            session.request_raw(op, payload, timeout, &cancel)
+            // A `None` handler means this call does not stream (control ops,
+            // search); a no-op stands in so `request_raw` always has a sink.
+            let mut handler = on_partial;
+            let mut noop = |_: &str| {};
+            let partial: &mut dyn FnMut(&str) = match handler.as_mut() {
+                Some(boxed) => boxed.as_mut(),
+                None => &mut noop,
+            };
+            session.request_raw(op, payload, timeout, &cancel, partial)
         })
         .await
         .context("Python worker task panicked")?
@@ -410,7 +424,16 @@ impl McpServer {
             board.start(session, "python", op, exec_source(op, &payload))
         });
 
-        let outcome = self.run_on_session(session_id, op, payload, timeout, cancel).await;
+        // While the call runs, stream each stdout chunk into its dashboard pane
+        // so output is visible live, not only when the call returns.
+        let on_partial: Option<PartialSink> = match (self.board, exec_id.clone()) {
+            (Some(board), Some(id)) => Some(Box::new(move |chunk: &str| board.append(&id, chunk))),
+            _ => None,
+        };
+
+        let outcome = self
+            .run_on_session(session_id, op, payload, timeout, cancel, on_partial)
+            .await;
 
         if let (Some(board), Some(id)) = (self.board, &exec_id) {
             match &outcome {
@@ -434,7 +457,7 @@ impl McpServer {
         timeout: Duration,
         cancel: CancellationToken,
     ) -> String {
-        match self.run_on_session(session_id, op, payload, timeout, cancel).await {
+        match self.run_on_session(session_id, op, payload, timeout, cancel, None).await {
             Ok(response) => format_worker_response(&response),
             Err(error) => format!("stderr:\n{error:#}"),
         }
@@ -687,8 +710,9 @@ impl PythonSession {
         payload: Value,
         timeout: Duration,
         cancel: &CancellationToken,
+        on_partial: &mut dyn FnMut(&str),
     ) -> Result<Value> {
-        match self.conn.roundtrip(op, payload, timeout, cancel) {
+        match self.conn.roundtrip(op, payload, timeout, cancel, on_partial) {
             Ok(value) => Ok(value),
             Err(error) => {
                 let error = error.context(format!("Python session {}", self.id));
@@ -710,6 +734,7 @@ impl PythonSession {
             payload,
             timeout,
             &uncancellable(),
+            &mut |_: &str| {},
         )?))
     }
 
@@ -736,7 +761,7 @@ impl PythonSession {
     /// for the connection's Drop to kill.
     fn close_worker(&mut self) {
         if self.conn.child.try_wait().ok().flatten().is_none() {
-            let _ = self.conn.roundtrip("close", json!({}), CONTROL_TIMEOUT, &uncancellable());
+            let _ = self.conn.roundtrip("close", json!({}), CONTROL_TIMEOUT, &uncancellable(), &mut |_: &str| {});
             let _ = self.conn.child.wait();
         }
     }
@@ -822,7 +847,7 @@ impl WorkerConn {
             next_id: 0,
         };
         // Confirm the worker's read loop is live before handing the session out.
-        conn.roundtrip("ping", json!({}), CONTROL_TIMEOUT, &uncancellable())
+        conn.roundtrip("ping", json!({}), CONTROL_TIMEOUT, &uncancellable(), &mut |_: &str| {})
             .context("Python worker did not become ready")?;
         Ok(conn)
     }
@@ -833,6 +858,7 @@ impl WorkerConn {
         mut payload: Value,
         timeout: Duration,
         cancel: &CancellationToken,
+        on_partial: &mut dyn FnMut(&str),
     ) -> Result<Value> {
         let request_id = self.next_id;
         self.next_id += 1;
@@ -867,7 +893,21 @@ impl WorkerConn {
                 Ok(line) => {
                     let response: Value = serde_json::from_str(&line)
                         .context("failed to decode Python worker response")?;
-                    if response.get("id").and_then(Value::as_u64) != Some(request_id) {
+                    let id_matches = response.get("id").and_then(Value::as_u64) == Some(request_id);
+                    // A `partial` message streams interim stdout for this call and
+                    // never terminates the wait; only the final response (no
+                    // `partial` flag) returns. A partial for another id is ignored
+                    // defensively (calls on one session are serial, so it should
+                    // not happen).
+                    if response.get("partial").and_then(Value::as_bool) == Some(true) {
+                        if id_matches
+                            && let Some(chunk) = response.get("stdout").and_then(Value::as_str)
+                        {
+                            on_partial(chunk);
+                        }
+                        continue;
+                    }
+                    if !id_matches {
                         bail!("Python worker returned a response for the wrong request");
                     }
                     return Ok(response);
@@ -1261,6 +1301,7 @@ mod tests {
             json!({ "source": "while True:\n    pass" }),
             Duration::from_millis(500),
             &uncancellable(),
+            &mut |_: &str| {},
         );
         assert!(timed_out.is_err(), "a never-returning cell must report an error");
         assert!(
@@ -1294,6 +1335,7 @@ mod tests {
             json!({ "source": "while True:\n    pass" }),
             Duration::from_mins(1),
             &cancel,
+            &mut |_: &str| {},
         );
         assert!(cancelled.is_err(), "a cancelled call must report an error");
         assert!(

--- a/packages/mcp/src/python_worker.py
+++ b/packages/mcp/src/python_worker.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import ast
 import asyncio
 import base64
+import codecs
 import io
 import json
 import os
 import sys
 import tempfile
+import threading
 import traceback
 from collections.abc import Callable
 from typing import Any
@@ -27,6 +29,14 @@ MAX_OUTPUT_CHARS = 100_000
 # over the character cap and let `_truncate` mark the clip.
 MAX_CAPTURE_BYTES = 4 * MAX_OUTPUT_CHARS
 
+# How often the streaming watcher polls the capture file for new output while a
+# cell is still running, in seconds. Fast enough to feel live on the dashboard,
+# slow enough that a chatty loop does not flood the RPC channel with tiny
+# partials. The watcher exists so a long-running or never-returning cell (e.g. a
+# `while True` loop) shows output as it is produced; the final response, sent
+# when the cell returns, still carries the complete captured output.
+STREAM_INTERVAL_SECS = 0.2
+
 # Compile every snippet with this flag so `await` is legal at the top level.
 # Without it, `await x` outside a function raises SyntaxError. CPython's own
 # `python -m asyncio` REPL drives top-level await the same way: compile with the
@@ -38,6 +48,12 @@ _AWAIT_FLAG = ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
 # is line-attributed only when the writing frame belongs to the user's code, not a
 # library it called.
 _USER_FILES = frozenset({"<ix-mcp eval>", "<ix-mcp exec>"})
+
+# Sends one JSON message to the Rust server. The same callback delivers both the
+# interim `partial` chunks (from the streaming watcher) and the final response,
+# all serialized under one lock so concurrent writes never interleave on the
+# wire. See `main`.
+Emit = Callable[[dict[str, object]], None]
 
 
 class _LineTee:
@@ -92,6 +108,47 @@ def _coalesce_trace(trace: list[tuple[int, str]]) -> list[dict[str, object]]:
     return out
 
 
+def _stream_capture(fd: int, stop: threading.Event, emit: Emit, request_id: object) -> None:
+    """Tail the stdout capture file while a cell runs, emitting each new chunk as
+    a `partial` message so the dashboard renders output live.
+
+    Reads with ``os.pread`` at an explicit offset: ``fd`` is the same open file
+    description that ``capture`` has ``dup2``'d onto fd 1, and a positional read
+    never moves the shared write offset, so tailing cannot disturb the canonical
+    capture. Decoding is incremental so a multi-byte character split across two
+    polls is not mangled. Streaming stops at ``MAX_OUTPUT_CHARS`` — the same cap
+    the final response uses — so a runaway producer cannot flood the channel.
+    """
+    decoder = codecs.getincrementaldecoder("utf-8")("replace")
+    offset = 0
+    streamed = 0
+
+    def drain() -> None:
+        nonlocal offset, streamed
+        try:
+            size = os.fstat(fd).st_size
+        except OSError:
+            return
+        while offset < size and streamed < MAX_OUTPUT_CHARS:
+            chunk = os.pread(fd, min(size - offset, 65536), offset)
+            if not chunk:
+                break
+            offset += len(chunk)
+            text = decoder.decode(chunk)
+            if not text:
+                continue
+            if streamed + len(text) > MAX_OUTPUT_CHARS:
+                text = text[: MAX_OUTPUT_CHARS - streamed]
+            streamed += len(text)
+            emit({"id": request_id, "partial": True, "stdout": text})
+
+    # Poll until the cell finishes (`stop` is set), then drain once more so the
+    # tail written between the last poll and completion is not lost.
+    while not stop.wait(STREAM_INTERVAL_SECS):
+        drain()
+    drain()
+
+
 class PythonSession:
     def __init__(self) -> None:
         self.globals: dict[str, object] = {}
@@ -125,22 +182,26 @@ class PythonSession:
         images.extend(_matplotlib_pngs())
         return images[:MAX_IMAGES]
 
-    def evaluate(self, expression: str) -> dict[str, object]:
+    def evaluate(
+        self, expression: str, emit: Emit | None = None, request_id: object = None
+    ) -> dict[str, object]:
         def run() -> str:
             code = compile(expression, "<ix-mcp eval>", "eval", flags=_AWAIT_FLAG)
             result = self._drive(eval(code, self.globals))
             self._last_result = result
             return repr(result)
 
-        return self.capture(run)
+        return self.capture(run, emit, request_id)
 
-    def execute(self, source: str) -> dict[str, object]:
+    def execute(
+        self, source: str, emit: Emit | None = None, request_id: object = None
+    ) -> dict[str, object]:
         def run() -> str:
             code = compile(source, "<ix-mcp exec>", "exec", flags=_AWAIT_FLAG)
             self._drive(eval(code, self.globals))
             return ""
 
-        return self.capture(run)
+        return self.capture(run, emit, request_id)
 
     def _drive(self, value: object) -> object:
         # Code compiled with the await flag returns a coroutine only when it
@@ -163,7 +224,9 @@ class PythonSession:
         if not self.loop.is_closed():
             self.loop.close()
 
-    def capture(self, run: Callable[[], str]) -> dict[str, object]:
+    def capture(
+        self, run: Callable[[], str], emit: Emit | None = None, request_id: object = None
+    ) -> dict[str, object]:
         # Capture at the file-descriptor level, not just `sys.stdout`: redirect
         # fds 1 and 2 to temp files so a subprocess the cell spawns
         # (`subprocess.run(["echo", "hi"])`) is captured in order alongside
@@ -187,12 +250,34 @@ class PythonSession:
         saved_out = os.dup(1)
         saved_err = os.dup(2)
         saved_stdout = sys.stdout
+        # Stream stdout to the caller while the cell runs, so a long-running or
+        # never-returning cell is visible live instead of only on completion. The
+        # watcher tails `out_file` (which fd 1 is redirected to) and emits chunks.
+        stop = threading.Event()
+        watcher: threading.Thread | None = None
         try:
             os.dup2(out_file.fileno(), 1)
             os.dup2(err_file.fileno(), 2)
             # Tee for line attribution; writes still pass through to fd 1, so the
             # canonical capture below (and subprocess output) is unaffected.
             sys.stdout = _LineTee(saved_stdout, trace)
+            if emit is not None:
+                # Flush each printed line to the capture file promptly so the
+                # watcher can tail it. fd 1 is not a tty here, so the TextIOWrapper
+                # is block-buffered by default and a `print` per second would sit
+                # in the buffer, never reaching disk until the cell ends. Line
+                # buffering makes each newline flush through to `out_file`.
+                # (Subprocess output goes straight to fd 1, so it already streams.)
+                try:
+                    saved_stdout.reconfigure(line_buffering=True)
+                except (ValueError, OSError):
+                    pass
+                watcher = threading.Thread(
+                    target=_stream_capture,
+                    args=(out_file.fileno(), stop, emit, request_id),
+                    daemon=True,
+                )
+                watcher.start()
             try:
                 value = run()
             except Exception:
@@ -200,8 +285,13 @@ class PythonSession:
                 value = ""
                 traceback.print_exc()
             finally:
+                # Flush user output to the capture file before stopping the
+                # watcher, so its final drain sees everything the cell wrote.
                 sys.stdout.flush()
                 sys.stderr.flush()
+                stop.set()
+                if watcher is not None:
+                    watcher.join(timeout=1.0)
                 sys.stdout = saved_stdout
         finally:
             os.dup2(saved_out, 1)
@@ -319,16 +409,26 @@ def main() -> None:
         os.dup2(devnull_in.fileno(), sys.stdin.fileno())
         os.dup2(devnull_out.fileno(), sys.stdout.fileno())
 
+    # One lock guards every write to the RPC channel: the streaming watcher
+    # (running on its own thread during a cell) and the main loop's final
+    # response both go through `emit`, so their JSON lines never interleave.
+    write_lock = threading.Lock()
+
+    def emit(payload: dict[str, object]) -> None:
+        line = json.dumps(payload)
+        with write_lock:
+            rpc_out.write(line + "\n")
+            rpc_out.flush()
+
     session = PythonSession()
     for line in rpc_in:
-        response = handle_request(session, line)
-        rpc_out.write(json.dumps(response) + "\n")
-        rpc_out.flush()
+        response = handle_request(session, line, emit)
+        emit(response)
         if response.get("close", False):
             return
 
 
-def handle_request(session: PythonSession, line: str) -> dict[str, object]:
+def handle_request(session: PythonSession, line: str, emit: Emit) -> dict[str, object]:
     try:
         request = json.loads(line)
         if not isinstance(request, dict):
@@ -339,9 +439,9 @@ def handle_request(session: PythonSession, line: str) -> dict[str, object]:
             case "ping":
                 response: dict[str, object] = {"ok": True, "stdout": "", "stderr": "", "result": "session ready"}
             case "eval":
-                response = session.evaluate(_string_field(request, "expression"))
+                response = session.evaluate(_string_field(request, "expression"), emit, request_id)
             case "exec":
-                response = session.execute(_string_field(request, "source"))
+                response = session.execute(_string_field(request, "source"), emit, request_id)
             case "reset":
                 response = session.reset()
             case "close":


### PR DESCRIPTION
The Python worker captured a cell's stdout to a temp file and read it back only after the cell returned, so a long-running or never-returning cell (a `while True` loop) showed nothing on the dashboard until completion.

Now a watcher thread tails the capture file and emits interim `partial` messages while the cell runs; the Rust roundtrip forwards each chunk to the exec board, which appends it to the running pane and republishes. The model still receives one batched final result, so only the live dashboard view changes. `finish_error` preserves already-streamed stdout on timeout instead of erasing it.

Made with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stream Python exec stdout to the dashboard live during cell execution
> - The Python worker ([python_worker.py](https://github.com/indexable-inc/index/pull/584/files#diff-7b8e5b0bdf4c09edaf2161e0febc9542d3e5e3b12a8d6f3f3525437b7e0b1710)) spawns a daemon watcher thread that tails the stdout capture file every 200ms and emits interim `partial` JSON messages with `stdout` chunks while a cell is running.
> - [WorkerConn.roundtrip](https://github.com/indexable-inc/index/pull/584/files#diff-2dcd58b645a00e14633156b2ff05a7c89ce38e7844a856b655d1dd28aee46777) detects these `partial` messages and invokes a caller-provided `on_partial` sink with stdout chunks before the final response arrives.
> - [ExecBoard.append](https://github.com/indexable-inc/index/pull/584/files#diff-fcca76810c5524985f09bfc153b76b5b86969d89ca524dbd5b4d6fba1a1e9a92) receives those chunks, appends them to the running pane's live stdout, and republishes; live stdout is capped at the most recent ~100k bytes to prevent unbounded growth.
> - `finish_error` now preserves already-streamed stdout when a transport failure occurs, filling only stderr with the error and marking the pane as failed.
> - Behavioral Change: the worker now serializes all RPC writes through a shared lock to prevent partial and final messages from interleaving on stdout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a08fbf8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->