### PR TITLE
fix(ci-bars): self-heal a crashed poll via restart=on-failure

### DIFF
--- a/packages/bossbar-overlay/ci-bars-home-module.nix
+++ b/packages/bossbar-overlay/ci-bars-home-module.nix
@@ -160,6 +160,13 @@ in
         description = "GitHub Actions CI progress boss bars";
         command = [ (lib.getExe' ciBars "ci-bars") ];
         inherit (cfg) interval;
+        # Recover from a crashed poll without busy-looping. on-failure renders
+        # launchd KeepAlive.SuccessfulExit = false (and systemd Restart =
+        # on-failure): a clean exit waits for the next StartInterval, a non-zero
+        # exit relaunches (throttled). NOT restart = "always": with StartInterval
+        # that maps to KeepAlive = true, which keeps relaunching on every clean
+        # exit and collapses the interval poller into a ~10s busy-loop.
+        restart = "on-failure";
         # All tunables flow in as environment so the script stays a plain file and
         # the options are the single source of truth.
         environment = {


### PR DESCRIPTION
ci-bars had no restart policy, so a launchd agent that fell out of the user domain (booted out by a `home-manager switch` and not re-bootstrapped, or a crash) stayed dead — leaving the bossbar-overlay renderer to keep time-extrapolating stale bars that never pruned.

Set `restart = "on-failure"`, which the portable-services transform already maps to launchd `KeepAlive.SuccessfulExit = false` (and systemd `Restart = on-failure`): a clean 20s poll waits for the next `StartInterval`, a crashed poll relaunches (throttled). Deliberately **not** `restart = "always"` — with an interval service that renders `KeepAlive = true`, collapsing the poller into a ~10s busy-loop. The on-failure → `KeepAlive.SuccessfulExit` mapping for an interval poller is already covered by `tests/portable-services.nix`.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-restart ci-bars service on failure
> Adds `restart = "on-failure"` to the ci-bars systemd service in [ci-bars-home-module.nix](https://github.com/indexable-inc/index/pull/585/files#diff-9ad2a911dd8e5dc204b66ecc4d03c5dc01ea4fc043ed837d960b42176fb316d1). The service now self-heals after a crash (non-zero exit) but does not relaunch on clean exits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 980a704.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->