### PR TITLE
fix(ci-bars): collapse the branch and PR-head-ref bars for one commit

### DIFF
--- a/packages/bossbar-overlay/ci-bars.sh
+++ b/packages/bossbar-overlay/ci-bars.sh
@@ -306,14 +306,42 @@ for repo in "${repos[@]}"; do
   # recorded in active_urls (so the prune never removes a still-building branch),
   # but only the newest $max_bars are DRAWN, so a busy moment cannot flood the
   # screen and the rest do not flap.
-  eligible=()
+  #
+  # The per-commit counters (c_running/c_queued/...) are keyed by headSha, and a
+  # PR's head commit is reachable under TWO refs that share that sha: the source
+  # branch (e.g. `feature`) and the PR head ref (`refs/pull/<N>/head`, how some
+  # PR-event runs report headBranch). Keying eligibility on the shared sha makes
+  # BOTH refs eligible off the same in-flight runs, so one PR would draw two bars.
+  # Collapse to a single winner ref per sha, preferring a real branch name over a
+  # `refs/pull/<N>/head` ref so the bar heals across pushes and clicks through to
+  # the branch.
+  unset sha_winner
+  declare -A sha_winner
   for branch in "${!b_latest_sha[@]}"; do
     sha="${b_latest_sha[$branch]}"
-    if [ $((${c_running[$sha]:-0} + ${c_queued[$sha]:-0})) -gt 0 ]; then
-      eligible+=("${c_created[$sha]:-0}	$branch")
-      active_urls="$active_urls
-https://github.com/$repo/commits/$branch"
+    [ $((${c_running[$sha]:-0} + ${c_queued[$sha]:-0})) -gt 0 ] || continue
+    cur="${sha_winner[$sha]:-}"
+    if [ -z "$cur" ]; then
+      sha_winner["$sha"]="$branch"
+    else
+      # First ref seen for a sha wins, except a real branch always beats a
+      # refs/pull/<N>/head ref already chosen for it.
+      case "$cur" in
+        refs/pull/*/*)
+          case "$branch" in
+            refs/pull/*/*) : ;; # two PR refs for one sha: keep the first
+            *) sha_winner["$sha"]="$branch" ;;
+          esac
+          ;;
+      esac
     fi
+  done
+  eligible=()
+  for sha in "${!sha_winner[@]}"; do
+    branch="${sha_winner[$sha]}"
+    eligible+=("${c_created[$sha]:-0}	$branch")
+    active_urls="$active_urls
+https://github.com/$repo/commits/$branch"
   done
   selected=""
   [ "${#eligible[@]}" -gt 0 ] && selected="$(printf '%s\n' "${eligible[@]}" | sort -rn -k1 | head -n "$max_bars" | cut -f2-)"


### PR DESCRIPTION
**Symptom:** one open PR with in-flight CI drew **two** boss bars — one for the branch (e.g. `feature`) and one for `refs/pull/<N>/head`.

**Cause:** a PR's head commit is reachable under two refs that share its sha (the source branch and `refs/pull/<N>/head`, how some PR-event runs report `headBranch`). The per-commit counters (`c_running`/`c_queued`/…) are keyed by `headSha`, so the in-flight runs on the branch also made the PR-head ref eligible off the same sha → two bars.

**Fix:** collapse to a single winner ref per sha before drawing, preferring a real branch name over `refs/pull/<N>/head` so the bar still heals across pushes and clicks through to the branch. After merge, `main` carries a different sha (the squash commit) and stays its own bar.

Verified with a mock-`gh` harness feeding two refs at one sha: main draws `commits/refs/pull/42/head` **and** `commits/feature`; patched draws only `commits/feature`. Build gate (`bash -n` + `shellcheck --severity=warning`) clean.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collapse duplicate CI bars when a branch and PR head ref share the same commit
> In [ci-bars.sh](https://github.com/indexable-inc/index/pull/586/files#diff-3aba65acb9a333e9dfbb82745f5f2b85a47136e34156ae144f259fa6ab803b19), when a PR's latest commit is reachable by both a source branch ref and a `refs/pull/<N>/head` ref, the script previously drew two bars for the same commit. A deduplication pass now selects one representative ref per commit SHA, preferring the branch ref over the PR ref, so at most one bar is drawn per in-flight commit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2021ffe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->