### PR TITLE
docs(ci-bars): correct prune comment after sha-dedup

### DIFF
--- a/packages/bossbar-overlay/ci-bars.sh
+++ b/packages/bossbar-overlay/ci-bars.sh
@@ -302,19 +302,19 @@ for repo in "${repos[@]}"; do
     .[] | [ .headSha, .headBranch, .status, .workflowName,
             (.startedAt // ""), (.createdAt // "") ] | @tsv')
 
-  # Branches whose LATEST commit still has in-flight work. Every such branch is
-  # recorded in active_urls (so the prune never removes a still-building branch),
-  # but only the newest $max_bars are DRAWN, so a busy moment cannot flood the
-  # screen and the rest do not flap.
+  # Commits with in-flight work, collapsed to ONE winner ref each. The per-commit
+  # counters (c_running/c_queued/...) are keyed by headSha, and a PR's head commit
+  # is reachable under TWO refs that share that sha: the source branch (e.g.
+  # `feature`) and the PR head ref (`refs/pull/<N>/head`, how some PR-event runs
+  # report headBranch). Keying eligibility on the shared sha makes BOTH refs
+  # eligible off the same in-flight runs, so one PR would draw two bars. So pick a
+  # single winner ref per sha, preferring a non-`refs/pull/*/*` ref (the source
+  # branch) so the bar heals across pushes and clicks through to the branch.
   #
-  # The per-commit counters (c_running/c_queued/...) are keyed by headSha, and a
-  # PR's head commit is reachable under TWO refs that share that sha: the source
-  # branch (e.g. `feature`) and the PR head ref (`refs/pull/<N>/head`, how some
-  # PR-event runs report headBranch). Keying eligibility on the shared sha makes
-  # BOTH refs eligible off the same in-flight runs, so one PR would draw two bars.
-  # Collapse to a single winner ref per sha, preferring a real branch name over a
-  # `refs/pull/<N>/head` ref so the bar heals across pushes and clicks through to
-  # the branch.
+  # Only the winner's url goes into active_urls, so the prune drops the bar of any
+  # other ref sharing the sha (e.g. the superseded `refs/pull/<N>/head`) by
+  # design: one in-flight commit == one bar. Of the winners only the newest
+  # $max_bars are DRAWN; the rest still sit in active_urls so prune keeps them.
   unset sha_winner
   declare -A sha_winner
   for branch in "${!b_latest_sha[@]}"; do
@@ -324,8 +324,8 @@ for repo in "${repos[@]}"; do
     if [ -z "$cur" ]; then
       sha_winner["$sha"]="$branch"
     else
-      # First ref seen for a sha wins, except a real branch always beats a
-      # refs/pull/<N>/head ref already chosen for it.
+      # First ref seen for a sha wins, except any non-refs/pull ref (the source
+      # branch in practice) always beats a refs/pull/<N>/head ref already chosen.
       case "$cur" in
         refs/pull/*/*)
           case "$branch" in


### PR DESCRIPTION
Follow-up to #586 (code-review M1/M2). The comment above the eligibility loop still claimed every eligible branch lands in active_urls so the prune never removes a still-building branch; after the sha-winner dedup only the winner ref per sha is recorded, so a non-winner ref sharing the sha is pruned by design. Reworded to match, and the inner comment now says 'any non-refs/pull ref' instead of 'real branch' (what the glob matches). Comment-only; no behavior change.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Correct inline comments for sha-dedup prune logic in `ci-bars.sh`
> Updates comments in [ci-bars.sh](https://github.com/indexable-inc/index/pull/587/files#diff-3aba65acb9a333e9dfbb82745f5f2b85a47136e34156ae144f259fa6ab803b19) around the ref-deduplication block that selects a single winner ref per commit SHA and manages `active_urls`. Clarifies the preference for non-`refs/pull` refs and documents draw vs. prune behavior. No executable code is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92bfd53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->