### PR TITLE
fix(indexer): host-scope the parquet archive key

### DIFF
--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -132,12 +132,25 @@ async fn main() -> anyhow::Result<()> {
         }
         None => None,
     };
-    let parquet = cli.bucket.as_ref().map(|bucket| sink_parquet::Config {
-        bucket: bucket.clone(),
-        endpoint: cli.endpoint.clone(),
-        region: cli.region.clone(),
-        prefix: cli.prefix.clone(),
-    });
+    let parquet = match cli.bucket.as_ref() {
+        // Host-scope every parquet key. Many fleet hosts index the same account
+        // (notably `root`, present on every host) into one shared bucket, and
+        // the sink does a full-file overwrite per source; without `host` in the
+        // key, host B clobbers host A's `user=root/source=shell/data.parquet`
+        // and the per-host manifest skip-gate makes them ping-pong every tick.
+        // `host`/`user`/`source` are all hive partitions, matching the old
+        // history-ship layout (`host=<host>/user=<user>/...`).
+        Some(bucket) => {
+            let host = resolve_host(&cli).context("resolving host for the parquet archive prefix")?;
+            Some(sink_parquet::Config {
+                bucket: bucket.clone(),
+                endpoint: cli.endpoint.clone(),
+                region: cli.region.clone(),
+                prefix: archive_prefix(&cli.prefix, &host),
+            })
+        }
+        None => None,
+    };
     if store.is_none() && parquet.is_none() {
         anyhow::bail!("nothing to do: pass --mixedbread-store and/or --bucket");
     }
@@ -359,6 +372,15 @@ fn parse_user(spec: &str) -> anyhow::Result<User> {
     Ok(User { name: name.to_owned(), home: PathBuf::from(home) })
 }
 
+/// Host-scope the parquet archive prefix: `<base>/host=<host>`. Every fleet host
+/// writes the same shared accounts (notably `root`) into one bucket with a
+/// full-file overwrite per source, so without a `host` segment they clobber each
+/// other and ping-pong on the per-host manifest skip-gate. `host` is the
+/// outermost hive partition, matching the old history-ship layout.
+fn archive_prefix(base: &str, host: &str) -> String {
+    format!("{base}/host={host}")
+}
+
 /// A per-user parquet config: partition each user's rows under `user=<name>` so
 /// concurrently indexed users never overwrite the one shared per-source file.
 fn user_parquet(config: &sink_parquet::Config, name: &str) -> sink_parquet::Config {
@@ -490,7 +512,7 @@ mod tests {
 
     use std::path::PathBuf;
 
-    use super::{parse_user, safe_path_under};
+    use super::{archive_prefix, parse_user, safe_path_under, user_parquet};
 
     #[test]
     fn safe_path_accepts_real_nested_dir() {
@@ -550,5 +572,24 @@ mod tests {
         let user = parse_user("alice-1.2_3:/home/alice").expect("valid spec");
         assert_eq!(user.name, "alice-1.2_3");
         assert_eq!(user.home, PathBuf::from("/home/alice"));
+    }
+
+    #[test]
+    fn parquet_key_is_host_scoped() {
+        // Regression: two hosts indexing the same account (e.g. `root`) into one
+        // shared bucket must land on distinct keys, or the full-file overwrite
+        // makes them clobber each other every tick.
+        let base = "corpus";
+        let cfg = |host: &str| sink_parquet::Config {
+            bucket: "ix-history".to_owned(),
+            endpoint: None,
+            region: "auto".to_owned(),
+            prefix: archive_prefix(base, host),
+        };
+        let a = user_parquet(&cfg("hil-compute-1"), "root").prefix;
+        let b = user_parquet(&cfg("hil-compute-2"), "root").prefix;
+        assert_eq!(a, "corpus/host=hil-compute-1/user=root");
+        assert_eq!(b, "corpus/host=hil-compute-2/user=root");
+        assert_ne!(a, b, "same account on different hosts must not share a key");
     }
 }


### PR DESCRIPTION
The parquet sink keyed objects as `corpus/user=<name>/source=<source>/data.parquet` with **no host segment**. Every fleet host indexes the same shared accounts (notably `root`) into one shared bucket with a full-file overwrite per source, so hosts clobber each other's `user=root/source=shell/data.parquet` and ping-pong on the per-host manifest skip-gate every tick.

Fix: host the prefix as `corpus/host=<host>/user=<name>/source=<source>/data.parquet` (host/user/source all hive partitions), matching the old history-ship layout. Adds a regression test.

Found by adversarial review of the ix history-ship cutover (indexable-inc/ix#4082), which enables this sink fleet-wide. Validated: `rust-indexer-indexer-tests-parquet_key_is_host_scoped` + `rust-indexer-clippy` green on the builder.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope parquet archive keys by host in the indexer
> - Adds an `archive_prefix` helper in [main.rs](https://github.com/indexable-inc/index/pull/588/files#diff-5664bac77cedfa678d477bb44bf07a8888bdbb1eb15055f1c164d6c9c131ce7d) that builds a prefix of the form `<base>/host=<host>`, so parquet files written to S3 are partitioned by host.
> - When `--bucket` is provided, the indexer now resolves the current host and incorporates it into the sink prefix instead of using the raw CLI prefix directly.
> - A regression test (`parquet_key_is_host_scoped`) verifies that the same user on different hosts produces distinct, correctly formatted prefixes.
> - Risk: if host resolution fails at startup, the indexer will now exit with an error rather than writing to an unscoped prefix.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fabe54c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->