### PR TITLE
fix(nix-cargo-unit): scope builder xtrace to the driver invocation

### DIFF
--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -1107,11 +1107,19 @@ fn append_driver_invocation(script: &mut String, driver: Driver, collect_unused_
 "#,
         );
     } else {
+        // Echo the exact driver invocation, then turn xtrace back off so the
+        // trailing stdenv fixupPhase (compressManPages et al.) does not stream
+        // its own `set -x` trace into the build log. Under `set -e` a failed
+        // driver aborts before the `set +x`, which is fine: the build stops with
+        // the compiler error and no fixup runs. Mirrors the scoped trace in the
+        // rustc-diagnostics branch above. Without this, every successful rust
+        // derivation floods CI logs (and GitHub truncates the step).
         script.push_str("set -x\n");
         let _ = writeln!(
             script,
             "env \"''${{rustc_env[@]}}\" {binary} \"''${{rustc_args[@]}}\""
         );
+        script.push_str("set +x\n");
     }
 }
 
@@ -2633,6 +2641,9 @@ fn render_doctest_command(
             script.push_str("rustdoc \"''${rustdoc_args[@]}\"\n");
         }
     }
+    // Scope xtrace to the rustdoc invocation so the stdenv fixupPhase that runs
+    // afterward does not stream its own trace into the log. See the rustc branch.
+    script.push_str("set +x\n");
     Ok(script)
 }
 


### PR DESCRIPTION
**Symptom:** CI build steps (e.g. `cas_fabric_client-clippy`, `registry_core-clippy`) flood with hundreds of `+++ fixupPhase / compressManPages / noBrokenSymlinksInAllOutputs` xtrace lines per derivation, bloating the step until GitHub truncates it ("This step has been truncated due to its large size") — so the real compiler/clippy error is unfindable.

**Cause:** the generated builder turns on `set -x` to echo the exact rustc/clippy/rustdoc invocation, but only the rustc-diagnostics path turned it back off. The normal rustc/clippy path and the doctest path left xtrace on, so it leaked into the stdenv `fixupPhase` running afterward in the same shell. Every *successful* rust derivation then streamed its whole fixup phase as trace.

**Fix:** emit a matching `set +x` after the driver invocation in both paths, mirroring the existing scoped trace. The exact-command echo (the useful part) stays; the post-build phase noise is gone. Under `set -e` a failed driver aborts before the `set +x`, so a real failure still stops the build with its error visible.

Validated: `nix build .#nix-cargo-unit` (darwin compile) green; all 49 `nix-cargo-unit` render unit tests pass under the pinned nightly. No test asserts on `set -x`/`set +x`.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope xtrace to driver and rustdoc invocations in generated shell scripts
> Adds `set +x` after the driver invocation in `append_driver_invocation` and after the rustdoc call in `render_doctest_command` in [render.rs](https://github.com/indexable-inc/index/pull/589/files#diff-da81bb79268fbaf52a96664faa4d392b9b83a48a4b3b54bb1c3a2a5f2f50f26a). This ensures xtrace is disabled after each command, so subsequent shell script commands are not traced.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a975740.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->