### PR TITLE
fix(bossbar): reject an empty-title add instead of inserting a phantom bar

### DIFF
--- a/packages/bossbar-overlay/bossbar
+++ b/packages/bossbar-overlay/bossbar
@@ -177,6 +177,11 @@ cmd="${1:-}"
 case "$cmd" in
   add)
     [ "$#" -ge 1 ] || die "add needs a <title>"
+    # Reject an empty/whitespace title, not just a missing arg: `add ""` would
+    # otherwise INSERT DEFAULT VALUES and leave a title-less, url-less bar that
+    # no prune reaps (ci-bars only prunes github.com bars, downtime matches by
+    # title), so a stray empty add accumulates phantom purple bars forever.
+    [ -n "${1//[[:space:]]/}" ] || die "add needs a non-empty <title>"
     title="$1"; shift
     ensure_db
     set_clause="title = '$(sq "$title")'"


### PR DESCRIPTION
**Symptom:** the overlay accumulates title-less purple bars (empty title, no url, progress 1.0) that never go away.

**Cause:** `bossbar add` only checked that a title *argument* was present (`[ "$#" -ge 1 ]`), not that it was non-empty. So `bossbar add ""` runs `INSERT INTO bossbars DEFAULT VALUES` then sets an empty title — a phantom bar with all defaults. Nothing reaps it: ci-bars prunes only `github.com` bars, ix-downtime matches by title.

**Fix:** require a non-empty (non-whitespace) title, mirroring the existing missing-arg guard. A caller that computes an empty title now gets a clear error its `|| true` swallows (draws nothing) instead of leaving a permanent ghost bar.

Validated: `bash -n` + `shellcheck --severity=warning` clean; `add ""` and `add "   "` now rejected (rc=1, no row), a real `add "ix: main" --url …` still works.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject empty or whitespace-only titles in the `bossbar add` command
> Previously, invoking `bossbar add` with an empty or whitespace-only title would silently insert a phantom bar. Now the command exits early with the error `add needs a non-empty <title>` when the first argument is blank after stripping whitespace.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c4acd5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->