### PR TITLE
feat(users/andrewgazelka): own Homebrew package set as a darwin module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -148,6 +148,14 @@
     {
       lib = ix;
       inherit (ix) nixosModules;
+      darwinModules = {
+        # Personal-but-shareable nix-darwin module for github:andrewgazelka: the
+        # Homebrew package set (GUI casks, the `mas` brew, Mac App Store apps).
+        # Companion to homeModules.andrewgazelka (which owns the home-manager
+        # services); import it from a darwin host to get the casks merged in. See
+        # users/andrewgazelka/darwin.nix.
+        andrewgazelka = ./users/andrewgazelka/darwin.nix;
+      };
       homeModules = {
         # Workstation-facing home-manager module: declare a service once, get a
         # native launchd agent on macOS and native systemd user units on Linux.

--- a/users/andrewgazelka/darwin.nix
+++ b/users/andrewgazelka/darwin.nix
@@ -1,0 +1,73 @@
+# Personal-but-shareable nix-darwin module for github:andrewgazelka: the
+# Homebrew package set (GUI casks, the `mas` brew, and Mac App Store apps).
+#
+# Hoisted out of the private ~/.config/nix so the list lives in the open
+# monorepo alongside the rest of the user's workstation glue (home.nix). It is
+# the companion to homeModules.andrewgazelka: that one owns the home-manager
+# services, this one owns the system-level Homebrew packages.
+#
+# Importing this module is the opt-in: it only contributes the package lists
+# (`homebrew.casks`/`brews`/`masApps`, which nix-darwin merges across modules).
+# The consuming host keeps the policy knobs it owns: `homebrew.enable`,
+# `onActivation.cleanup`, and any taps. Because the lists merge, the consumer
+# can still add host-specific casks of its own without re-declaring these.
+#
+# These are GUI apps and Mac-App-Store apps with no usable Nix package; anything
+# that ships a real Nix package belongs in home.packages / environment, not here.
+{
+  homebrew = {
+    casks = [
+      "1password-cli"
+      "beeper"
+      "chatgpt"
+      "chatgpt-atlas"
+      "claude"
+      "codex-app"
+      "contexts"
+      "cursor"
+      "emacs-app"
+      "ghostty"
+      "google-chrome"
+      "helium-browser"
+      "linear"
+      "lm-studio"
+      "notion"
+      "obs"
+      "obsidian"
+      "orbstack"
+      "postico"
+      "prismlauncher"
+      "raycast"
+      "screen-studio"
+      "setapp"
+      "signal"
+      "skim"
+      "slack"
+      "stremio"
+      "superhuman"
+      "superwhisper"
+      "tailscale-app"
+      "tableplus"
+      "todoist-app"
+      "jetbrains-toolbox"
+      "thebrowsercompany-dia"
+      # RealVNC viewer: the ix fleet's headless remote desktop is wayvnc, which
+      # offers only RFB security type "None" (no auth); macOS Screen Sharing.app
+      # refuses no-auth servers, so a third-party client is required to reach
+      # `vnc://<host>.tail368802.ts.net:5900`. See ix nix/modules/desktop/remote-desktop.nix.
+      "vnc-viewer"
+      "zed"
+      "zoom"
+    ];
+
+    # `mas` (Mac App Store CLI) is the brew that drives `masApps` below.
+    brews = [ "mas" ];
+
+    masApps = {
+      "Things 3" = 904280696;
+      "Super Easy Timer" = 1353137878;
+      "Flighty – Live Flight Tracker" = 1358823008;
+      "Apple Configurator 2" = 1037126344;
+    };
+  };
+}


### PR DESCRIPTION
Moves the Homebrew cask/brew/masApps list out of the private `~/.config/nix` into `users/andrewgazelka/darwin.nix`, exposed as `darwinModules.andrewgazelka` (companion to `homeModules.andrewgazelka`). The consuming host imports it and keeps only policy (`enable`, `onActivation.cleanup`, taps); nix-darwin merges the lists.

Also adds the `vnc-viewer` cask: the fleet's headless remote desktop is wayvnc, which offers only RFB security type "None", and macOS Screen Sharing refuses no-auth servers, so a third-party client is needed to reach `vnc://<host>.tail368802.ts.net:5900`.

Validated: `darwinConfigurations.hydra.config.homebrew.{casks,brews,masApps}` evaluates with the consumer importing this module via local override; 37 casks merge including `vnc-viewer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Homebrew package set for andrewgazelka as a nix-darwin module
> Adds [darwin.nix](https://github.com/indexable-inc/index/pull/593/files#diff-8e50939d75ca47b003564ea6eb7afcd3cd3ab9bfa6b8876d3c079c94862fb7bc) defining `homebrew.casks`, `homebrew.brews`, and `homebrew.masApps` for the andrewgazelka user profile. Exports the module via `darwinModules.andrewgazelka` in [flake.nix](https://github.com/indexable-inc/index/pull/593/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) alongside existing `nixosModules`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b325508.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->