### PR TITLE
feat(indexer): index Claude debug logs + write parquet before Mixedbread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2822,6 +2822,7 @@ dependencies = [
  "source-atuin",
  "source-claude",
  "source-codex",
+ "source-debug",
  "source-git",
  "source-linear",
  "source-meta",
@@ -5878,6 +5879,16 @@ dependencies = [
  "serde_json",
  "snafu 0.9.1",
  "source-meta",
+]
+
+[[package]]
+name = "source-debug"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "snafu 0.9.1",
+ "source-meta",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "packages/source/atuin",
   "packages/source/claude",
   "packages/source/codex",
+  "packages/source/debug",
   "packages/source/git",
   "packages/clone-detect/cli",
   "packages/clone-detect/detect",
@@ -102,6 +103,7 @@ clap = "4"
 source-atuin = { path = "packages/source/atuin" }
 source-claude = { path = "packages/source/claude" }
 source-codex = { path = "packages/source/codex" }
+source-debug = { path = "packages/source/debug" }
 source-git = { path = "packages/source/git" }
 clone-detect = { path = "packages/clone-detect/detect" }
 clone-hash = { path = "packages/clone-detect/hash" }

--- a/packages/indexer/Cargo.toml
+++ b/packages/indexer/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 source-meta.workspace = true
 source-claude.workspace = true
 source-codex.workspace = true
+source-debug.workspace = true
 source-git.workspace = true
 source-atuin.workspace = true
 source-slack.workspace = true

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -354,6 +354,21 @@ async fn index_user(
         .await;
         record(&label, result, counts);
     }
+
+    // Claude debug logs (`~/.claude/debug/<session>.txt`), present only for
+    // sessions run with `--debug`. The adapter indexes regular files only, so a
+    // planted symlink in the debug dir is skipped rather than followed.
+    if let Some(debug_dir) = safe_path_under(home, &[".claude", "debug"], true) {
+        let label = format!("debug:{name}");
+        let parquet = parquet.map(|config| user_parquet(config, name));
+        let result = async {
+            let adapter = source_debug::DebugLogs::open_with(&debug_dir, host, name)
+                .with_context(|| format!("reading Claude debug logs for {name} at {}", debug_dir.display()))?;
+            run_source(&label, &adapter, mixedbread, parquet.as_ref()).await
+        }
+        .await;
+        record(&label, result, counts);
+    }
 }
 
 /// Parse a `NAME:HOME` user spec. The name is everything before the first colon;
@@ -479,31 +494,55 @@ fn record(label: &str, result: anyhow::Result<()>, counts: &mut Counts) {
 }
 
 /// Fan one source out to every enabled sink.
+///
+/// The parquet archive runs FIRST and the two sinks are INDEPENDENT: a slow or
+/// failing Mixedbread upload must not gate or skip the durable archive. The
+/// archive write is a fast local-S3 full-file put, while the Mixedbread leg is
+/// network-bound and rate-limited (429 + backoff), so ordering it first lands
+/// the queryable parquet in seconds instead of after a multi-hour upload. Each
+/// sink's error is captured separately and only combined at the end, so one
+/// sink's failure still lets the other run.
 async fn run_source<A: SourceAdapter + Sync>(
     label: &str,
     adapter: &A,
     mixedbread: Option<Mixedbread<'_>>,
     parquet: Option<&sink_parquet::Config>,
 ) -> anyhow::Result<()> {
-    if let Some(Mixedbread { store, name }) = mixedbread {
-        let report = sync_documents(adapter, store, name, INDEX_TIMEOUT, |_, _| {})
-            .await
-            .with_context(|| format!("[{label}] Mixedbread sync"))?;
-        eprintln!(
-            "[{label}] mixedbread: uploaded {}, skipped {} of {}",
-            report.uploaded, report.skipped, report.total
-        );
-    }
+    let mut errors: Vec<anyhow::Error> = Vec::new();
+
     if let Some(config) = parquet {
-        let report =
-            sink_parquet::sync(adapter, config).await.with_context(|| format!("[{label}] parquet sync"))?;
-        if report.skipped {
-            eprintln!("[{label}] parquet: skipped (unchanged)");
-        } else {
-            eprintln!("[{label}] parquet: wrote {} rows", report.rows);
+        match sink_parquet::sync(adapter, config).await {
+            Ok(report) if report.skipped => eprintln!("[{label}] parquet: skipped (unchanged)"),
+            Ok(report) => eprintln!("[{label}] parquet: wrote {} rows", report.rows),
+            Err(error) => {
+                errors.push(anyhow::Error::new(error).context(format!("[{label}] parquet sync")));
+            }
         }
     }
-    Ok(())
+
+    if let Some(Mixedbread { store, name }) = mixedbread {
+        match sync_documents(adapter, store, name, INDEX_TIMEOUT, |_, _| {}).await {
+            Ok(report) => eprintln!(
+                "[{label}] mixedbread: uploaded {}, skipped {} of {}",
+                report.uploaded, report.skipped, report.total
+            ),
+            Err(error) => {
+                errors.push(anyhow::Error::new(error).context(format!("[{label}] Mixedbread sync")));
+            }
+        }
+    }
+
+    // Surface every sink failure; a single combined error keeps the per-source
+    // failure accounting in `record` intact while not hiding the second sink.
+    match errors.len() {
+        0 => Ok(()),
+        1 => Err(errors.into_iter().next().expect("len checked")),
+        _ => {
+            let combined =
+                errors.iter().map(|error| format!("{error:#}")).collect::<Vec<_>>().join("; ");
+            Err(anyhow::anyhow!("[{label}] multiple sinks failed: {combined}"))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -132,12 +132,25 @@ async fn main() -> anyhow::Result<()> {
         }
         None => None,
     };
-    let parquet = cli.bucket.as_ref().map(|bucket| sink_parquet::Config {
-        bucket: bucket.clone(),
-        endpoint: cli.endpoint.clone(),
-        region: cli.region.clone(),
-        prefix: cli.prefix.clone(),
-    });
+    let parquet = match cli.bucket.as_ref() {
+        // Host-scope every parquet key. Many fleet hosts index the same account
+        // (notably `root`, present on every host) into one shared bucket, and
+        // the sink does a full-file overwrite per source; without `host` in the
+        // key, host B clobbers host A's `user=root/source=shell/data.parquet`
+        // and the per-host manifest skip-gate makes them ping-pong every tick.
+        // `host`/`user`/`source` are all hive partitions, matching the old
+        // history-ship layout (`host=<host>/user=<user>/...`).
+        Some(bucket) => {
+            let host = resolve_host(&cli).context("resolving host for the parquet archive prefix")?;
+            Some(sink_parquet::Config {
+                bucket: bucket.clone(),
+                endpoint: cli.endpoint.clone(),
+                region: cli.region.clone(),
+                prefix: archive_prefix(&cli.prefix, &host),
+            })
+        }
+        None => None,
+    };
     if store.is_none() && parquet.is_none() {
         anyhow::bail!("nothing to do: pass --mixedbread-store and/or --bucket");
     }
@@ -359,6 +372,15 @@ fn parse_user(spec: &str) -> anyhow::Result<User> {
     Ok(User { name: name.to_owned(), home: PathBuf::from(home) })
 }
 
+/// Host-scope the parquet archive prefix: `<base>/host=<host>`. Every fleet host
+/// writes the same shared accounts (notably `root`) into one bucket with a
+/// full-file overwrite per source, so without a `host` segment they clobber each
+/// other and ping-pong on the per-host manifest skip-gate. `host` is the
+/// outermost hive partition, matching the old history-ship layout.
+fn archive_prefix(base: &str, host: &str) -> String {
+    format!("{base}/host={host}")
+}
+
 /// A per-user parquet config: partition each user's rows under `user=<name>` so
 /// concurrently indexed users never overwrite the one shared per-source file.
 fn user_parquet(config: &sink_parquet::Config, name: &str) -> sink_parquet::Config {
@@ -490,7 +512,7 @@ mod tests {
 
     use std::path::PathBuf;
 
-    use super::{parse_user, safe_path_under};
+    use super::{archive_prefix, parse_user, safe_path_under, user_parquet};
 
     #[test]
     fn safe_path_accepts_real_nested_dir() {
@@ -550,5 +572,24 @@ mod tests {
         let user = parse_user("alice-1.2_3:/home/alice").expect("valid spec");
         assert_eq!(user.name, "alice-1.2_3");
         assert_eq!(user.home, PathBuf::from("/home/alice"));
+    }
+
+    #[test]
+    fn parquet_key_is_host_scoped() {
+        // Regression: two hosts indexing the same account (e.g. `root`) into one
+        // shared bucket must land on distinct keys, or the full-file overwrite
+        // makes them clobber each other every tick.
+        let base = "corpus";
+        let cfg = |host: &str| sink_parquet::Config {
+            bucket: "ix-history".to_owned(),
+            endpoint: None,
+            region: "auto".to_owned(),
+            prefix: archive_prefix(base, host),
+        };
+        let a = user_parquet(&cfg("hil-compute-1"), "root").prefix;
+        let b = user_parquet(&cfg("hil-compute-2"), "root").prefix;
+        assert_eq!(a, "corpus/host=hil-compute-1/user=root");
+        assert_eq!(b, "corpus/host=hil-compute-2/user=root");
+        assert_ne!(a, b, "same account on different hosts must not share a key");
     }
 }

--- a/packages/source/debug/Cargo.toml
+++ b/packages/source/debug/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "source-debug"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Adapter turning Claude Code debug logs into embeddable, tagged search documents"
+
+[lints]
+workspace = true
+
+[dependencies]
+source-meta.workspace = true
+serde_json.workspace = true
+snafu.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/packages/source/debug/package.nix
+++ b/packages/source/debug/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "source-debug";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/source/debug/src/error.rs
+++ b/packages/source/debug/src/error.rs
@@ -1,0 +1,41 @@
+//! Error type for the Claude Code debug-log adapter.
+
+use std::path::PathBuf;
+
+use snafu::Snafu;
+
+/// All failures surfaced when reading and projecting Claude debug logs.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// The debug directory could not be read.
+    #[snafu(display("failed to read Claude debug dir {}", path.display()))]
+    ReadDir {
+        /// Directory path.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// A debug log file could not be read.
+    #[snafu(display("failed to read Claude debug log {}", path.display()))]
+    ReadFile {
+        /// File path.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// A built document's metadata exceeded the store's size or key limits.
+    #[snafu(display("metadata limit exceeded for {external_id}"))]
+    Metadata {
+        /// The record whose metadata overflowed.
+        external_id: String,
+        /// Underlying limit error.
+        source: source_meta::MetadataError,
+    },
+}
+
+/// Result alias defaulting to this crate's [`Error`].
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/packages/source/debug/src/lib.rs
+++ b/packages/source/debug/src/lib.rs
@@ -1,0 +1,144 @@
+//! Adapter turning Claude Code debug logs into embeddable, tagged
+//! [`source_meta`] documents for the multi-source `search` store.
+//!
+//! # Grain
+//! One [`Document`] per session debug file. Claude Code writes one
+//! `~/.claude/debug/<session-id>.txt` per session when run with `--debug`, a
+//! line-oriented `TIMESTAMP [LEVEL] message` log of API/MCP/init/timing events.
+//! `external_id = "claude_debug:{session_id}"`, so a re-sync re-uploads a log
+//! only while its bytes keep changing (a live session grows its file); an ended
+//! session's log is stable and skipped by the content-hash gate.
+//!
+//! # Tags
+//! Every document's flat metadata carries the common header (`source`,
+//! `external_id`, `content_hash`, `title`, `timestamp`) plus `host`, `user`, and
+//! `session_id`, so a query can scope debug logs to a machine, user, or session.
+//!
+//! # Security
+//! The privileged fleet run reads other accounts' debug logs as root. Like the
+//! claude/codex adapters, the caller resolves the debug dir with a symlink-safe
+//! path check, and this adapter additionally indexes only **regular** files: a
+//! planted symlink in the debug dir (e.g. `<id>.txt -> /etc/shadow`) is reported
+//! by `read_dir` as a symlink, not a file, so it is skipped rather than followed.
+
+#![forbid(unsafe_code)]
+
+mod error;
+mod record;
+
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use source_meta::{Document, Source, SourceAdapter};
+use snafu::ResultExt as _;
+
+pub use crate::error::Error;
+pub use crate::record::Entry;
+use crate::error::{ReadDirSnafu, ReadFileSnafu, Result};
+
+/// The `source` tag every debug-log document carries.
+pub const SOURCE_TAG: &str = "claude_debug";
+
+/// A set of Claude Code debug logs ready to project into documents.
+///
+/// Construct with [`DebugLogs::open_with`]. A missing debug dir is normal (the
+/// session was not run with `--debug`) and yields an empty set, not an error.
+#[derive(Debug)]
+#[must_use]
+pub struct DebugLogs {
+    entries: Vec<Entry>,
+}
+
+impl DebugLogs {
+    /// Read every regular `*.txt` debug log under `dir`, tagging each with
+    /// `host` and `user`. The fleet sync binary uses this so it can tag logs for
+    /// the account whose home it is reading, not the process owner.
+    ///
+    /// # Errors
+    /// Returns an error if the directory or a log file cannot be read. A missing
+    /// directory is not an error: it returns an empty set.
+    pub fn open_with(dir: &Path, host: &str, user: &str) -> Result<Self> {
+        let mut entries = Vec::new();
+        let read = match std::fs::read_dir(dir) {
+            Ok(read) => read,
+            // No `--debug` runs here: nothing to index, not a failure.
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Self { entries });
+            }
+            Err(error) => return Err(error).context(ReadDirSnafu { path: dir.to_path_buf() }),
+        };
+
+        for entry in read {
+            let entry = entry.context(ReadDirSnafu { path: dir.to_path_buf() })?;
+            let file_type = entry.file_type().context(ReadDirSnafu { path: dir.to_path_buf() })?;
+            // Regular files only. `read_dir` reports the `latest` symlink (and any
+            // planted symlink) as a symlink, so `is_file()` is false and it is
+            // skipped without ever being opened or followed.
+            if !file_type.is_file() {
+                continue;
+            }
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("txt") {
+                continue;
+            }
+            let Some(session_id) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                continue;
+            };
+            if session_id.is_empty() {
+                continue;
+            }
+            let body = std::fs::read_to_string(&path).context(ReadFileSnafu { path: path.clone() })?;
+            if body.trim().is_empty() {
+                continue;
+            }
+            let timestamp = entry.metadata().ok().as_ref().and_then(mtime_secs);
+            entries.push(Entry {
+                session_id: session_id.to_owned(),
+                body,
+                host: host.to_owned(),
+                user: user.to_owned(),
+                timestamp,
+            });
+        }
+        Ok(Self { entries })
+    }
+
+    /// Number of parsed debug logs.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether no debug logs were parsed.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// The default debug dir: `~/.claude/debug`, or `None` when `HOME` is unset.
+    #[must_use]
+    pub fn default_dir() -> Option<PathBuf> {
+        std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".claude/debug"))
+    }
+}
+
+impl SourceAdapter for DebugLogs {
+    type Error = Error;
+
+    fn source(&self) -> Source {
+        Source::new(SOURCE_TAG)
+    }
+
+    fn documents(&self) -> impl Iterator<Item = Result<Document, Error>> + Send {
+        // Clone into an owned iterator so the result is `'static + Send`,
+        // independent of `&self` (mirrors the other source adapters).
+        self.entries.clone().into_iter().map(Entry::into_document)
+    }
+}
+
+/// A file's mtime as epoch seconds, when it is representable.
+fn mtime_secs(meta: &std::fs::Metadata) -> Option<i64> {
+    let modified = meta.modified().ok()?;
+    let secs = modified.duration_since(UNIX_EPOCH).ok()?.as_secs();
+    i64::try_from(secs).ok()
+}

--- a/packages/source/debug/src/record.rs
+++ b/packages/source/debug/src/record.rs
@@ -1,0 +1,79 @@
+//! The typed per-session debug record and its projection to a search [`Document`].
+
+use source_meta::{Document, keys};
+use serde_json::{Map, Value, json};
+use snafu::ResultExt as _;
+
+use crate::SOURCE_TAG;
+use crate::error::{MetadataSnafu, Result};
+
+/// One Claude Code debug log (a whole `~/.claude/debug/<session>.txt` file) with
+/// its filter tags.
+#[derive(Debug, Clone)]
+pub struct Entry {
+    /// Session id, taken from the debug file's stem.
+    pub session_id: String,
+    /// Full debug log text to embed.
+    pub body: String,
+    /// Host the session ran on.
+    pub host: String,
+    /// OS user that owns the session.
+    pub user: String,
+    /// File mtime as epoch seconds, the recency axis (debug lines are timestamped
+    /// internally, but the file mtime is a dependency-free stand-in).
+    pub timestamp: Option<i64>,
+}
+
+impl Entry {
+    /// Stable store id: `claude_debug:{session_id}`, reusing the session id so a
+    /// re-sync only re-uploads logs whose bytes changed (the content hash gates
+    /// it), and a still-growing session's log re-uploads until the session ends.
+    #[must_use]
+    pub fn external_id(&self) -> String {
+        format!("claude_debug:{}", self.session_id)
+    }
+
+    /// Project to a [`Document`]: the debug text is embedded, its sha256 is the
+    /// `content_hash` (the reconcile key), and the flat metadata carries every
+    /// filter tag.
+    ///
+    /// # Errors
+    /// Returns [`Error::Metadata`](crate::Error::Metadata) if the tag object
+    /// exceeds the store's size or key limits.
+    pub fn into_document(self) -> Result<Document> {
+        let external_id = self.external_id();
+        let content_hash = source_meta::hash_body(self.body.as_bytes());
+        let title = format!("debug: {}", self.session_id);
+
+        let mut meta = Map::new();
+        meta.insert(keys::SOURCE.to_owned(), json!(SOURCE_TAG));
+        meta.insert("external_id".to_owned(), json!(external_id));
+        meta.insert(keys::CONTENT_HASH.to_owned(), json!(content_hash));
+        meta.insert(keys::TITLE.to_owned(), json!(title));
+        meta.insert(keys::HOST.to_owned(), json!(self.host));
+        meta.insert(keys::USER.to_owned(), json!(self.user));
+        meta.insert(keys::SESSION_ID.to_owned(), json!(self.session_id));
+        insert_some(&mut meta, keys::TIMESTAMP, self.timestamp.map(Value::from));
+        let meta_json = Value::Object(meta);
+
+        source_meta::check_metadata(&external_id, &meta_json)
+            .context(MetadataSnafu { external_id: external_id.clone() })?;
+
+        Ok(Document {
+            external_id,
+            file_name: format!("{}.txt", self.session_id),
+            mime: "text/plain",
+            body: self.body.into_bytes(),
+            meta_json,
+            content_hash,
+        })
+    }
+}
+
+/// Insert `key` only when a value is present, keeping absent tags off the record
+/// rather than serializing nulls.
+fn insert_some(meta: &mut Map<String, Value>, key: &str, value: Option<Value>) {
+    if let Some(value) = value {
+        meta.insert(key.to_owned(), value);
+    }
+}

--- a/packages/source/debug/tests/parse.rs
+++ b/packages/source/debug/tests/parse.rs
@@ -1,0 +1,55 @@
+//! Behavioural tests for the Claude debug-log adapter: what it indexes, what it
+//! tags, and the symlink-skip security property.
+
+use std::fs;
+
+use source_debug::{DebugLogs, SOURCE_TAG};
+use source_meta::SourceAdapter;
+
+/// A real `*.txt` debug log is indexed as one document tagged with the session
+/// id, host, and user; an empty log and a non-`.txt` file are skipped.
+#[test]
+fn indexes_real_txt_logs_only() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(dir.path().join("sess-1.txt"), b"2026-06-02T17:20:01.816Z [DEBUG] hello\n")
+        .expect("write log");
+    fs::write(dir.path().join("empty.txt"), b"   \n").expect("write empty");
+    fs::write(dir.path().join("notes.md"), b"not a debug log").expect("write md");
+
+    let logs = DebugLogs::open_with(dir.path(), "hydra", "andrew").expect("open");
+    assert_eq!(logs.len(), 1, "only the one non-empty .txt is indexed");
+
+    let docs: Vec<_> = logs.documents().map(|d| d.expect("doc")).collect();
+    let doc = &docs[0];
+    assert_eq!(doc.external_id, "claude_debug:sess-1");
+    assert_eq!(doc.meta_json["source"], SOURCE_TAG);
+    assert_eq!(doc.meta_json["session_id"], "sess-1");
+    assert_eq!(doc.meta_json["host"], "hydra");
+    assert_eq!(doc.meta_json["user"], "andrew");
+    assert!(String::from_utf8_lossy(&doc.body).contains("hello"));
+}
+
+/// A missing debug dir is normal (no `--debug` runs) and yields an empty set.
+#[test]
+fn missing_dir_is_empty_not_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let logs = DebugLogs::open_with(&dir.path().join("nope"), "h", "u").expect("open missing");
+    assert!(logs.is_empty());
+}
+
+/// A symlinked log (the privileged confused-deputy threat) is skipped, never
+/// followed: a planted `*.txt -> secret` does not exfiltrate the target.
+#[cfg(unix)]
+#[test]
+fn skips_symlinked_logs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let secret = dir.path().join("secret");
+    fs::write(&secret, b"TOP SECRET ROOT FILE").expect("write secret");
+    std::os::unix::fs::symlink(&secret, dir.path().join("planted.txt")).expect("symlink");
+
+    let logs = DebugLogs::open_with(dir.path(), "h", "u").expect("open");
+    assert_eq!(logs.len(), 0, "a symlinked .txt must be skipped, not followed");
+    let bodies: Vec<_> =
+        logs.documents().map(|d| String::from_utf8_lossy(&d.expect("doc").body).into_owned()).collect();
+    assert!(!bodies.iter().any(|b| b.contains("SECRET")), "secret target must not be read");
+}


### PR DESCRIPTION
Two changes, driven by 'why is the archive so slow' and 'index debug + thinking traces too':

**1. Parquet-first, independent sinks.** `run_source` wrote Mixedbread (network-bound, 429-rate-limited) *before* the parquet archive, and a Mixedbread error skipped parquet entirely via `?`. Now parquet (a fast local-S3 put) runs first and the two sinks are independent — the durable archive lands in seconds instead of after a multi-hour upload, and one sink failing no longer skips the other.

**2. `source-debug` adapter.** Indexes Claude Code debug logs (`~/.claude/debug/<session>.txt`, source tag `claude_debug`), wired into the per-user phase. Regular files only, so a planted symlink in the debug dir is skipped not followed (privileged confused-deputy guard). Thinking traces were already indexed — the claude adapter renders `thinking` blocks.

Validated on the builder: debug parse / symlink-skip / missing-dir tests, indexer host-scope test, clippy + unused-deps all green.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Index Claude debug logs and write parquet before Mixedbread in the indexer
> - Adds a new `source-debug` crate ([lib.rs](https://github.com/indexable-inc/index/pull/594/files#diff-10ceddf463c8688982a42cc35e1e9f6210ab7333cd748569959d6e0c60d39c39)) that reads `.txt` files from `~/.claude/debug`, skipping empty files and symlinks, and emits documents tagged with `claude_debug` source, session ID, host, and user.
> - Integrates the new source into `index_user` in [main.rs](https://github.com/indexable-inc/index/pull/594/files#diff-5664bac77cedfa678d477bb44bf07a8888bdbb1eb15055f1c164d6c9c131ce7d), running after existing sources.
> - Reorders sink execution in `run_source` so parquet is written before Mixedbread; a failure in one sink no longer prevents the other from running.
> - Scopes parquet archive keys by host using a new `archive_prefix` helper, producing paths like `<base>/host=<host>/...`.
> - Behavioral Change: parquet files are now written to host-scoped prefixes, changing existing key layouts for multi-host deployments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4ab3f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->