### PR TITLE
feat(users/andrewgazelka): declare all Mac App Store apps in masApps

### DIFF
--- a/users/andrewgazelka/darwin.nix
+++ b/users/andrewgazelka/darwin.nix
@@ -63,11 +63,28 @@
     # `mas` (Mac App Store CLI) is the brew that drives `masApps` below.
     brews = [ "mas" ];
 
+    # Every Mac App Store app installed on the workstation must be listed here:
+    # onActivation.cleanup = "zap" uninstalls any MAS app not declared, so an
+    # omission deletes the app on the next switch (it lost Final Cut/Logic/Xcode
+    # once before this list was completed). IDs come from `mas list`.
     masApps = {
       "Things 3" = 904280696;
       "Super Easy Timer" = 1353137878;
       "Flighty – Live Flight Tracker" = 1358823008;
       "Apple Configurator 2" = 1037126344;
+      "Final Cut Pro" = 424389933;
+      "Logic Pro" = 634148309;
+      "GarageBand" = 682658836;
+      "iMovie" = 408981434;
+      "Xcode" = 497799835;
+      "TestFlight" = 899247664;
+      "Apple Developer" = 640199958;
+      "Fantastical" = 975937182;
+      "WireGuard" = 1451685025;
+      "Pages" = 409201541;
+      "Numbers" = 409203825;
+      "Keynote" = 409183694;
+      "Portal" = 1436994560;
     };
   };
 }


### PR DESCRIPTION
Completes the masApps list so `onActivation.cleanup = "zap"` stops deleting App Store apps. The prior 4-entry list meant a `darwin-rebuild switch` uninstalled Final Cut Pro, Logic Pro, Xcode, GarageBand, iMovie, Pages/Numbers/Keynote, Fantastical, WireGuard, and more (they were recovered from the Trash). Lists all 17 installed apps; IDs from `mas list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Declare Mac App Store apps in `masApps` for andrewgazelka's Darwin config
> Adds entries to the `masApps` attribute set in [darwin.nix](https://github.com/indexable-inc/index/pull/595/files#diff-8e50939d75ca47b003564ea6eb7afcd3cd3ab9bfa6b8876d3c079c94862fb7bc) for Final Cut Pro, Logic Pro, GarageBand, iMovie, Xcode, TestFlight, Apple Developer, Fantastical, WireGuard, Pages, Numbers, Keynote, and Portal. Also adds comments explaining the purpose of the `masApps` block.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee58bcd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->