### PR TITLE
fix(indexer): robust claude + atuin sources (skip bad lines; immutable atuin open)

### DIFF
--- a/packages/source/atuin/src/lib.rs
+++ b/packages/source/atuin/src/lib.rs
@@ -53,11 +53,28 @@ impl AtuinHistory {
     /// Open the atuin history db at `path` read-only and read every
     /// non-deleted command.
     ///
+    /// Opened as `immutable=1` via a `SQLite` URI, not just
+    /// `SQLITE_OPEN_READ_ONLY`: atuin runs in WAL mode, and a plain read-only
+    /// open still tries to touch the `-wal`/`-shm` sidecars and a lock file. When
+    /// a live shell holds the db or the home dir is not writable by this process
+    /// (the privileged fleet run reads other accounts' homes), that fails with
+    /// `SQLITE_CANTOPEN` (code 14). `immutable=1` tells `SQLite` the file cannot
+    /// change underneath it, so it skips all sidecar and locking I/O and reads
+    /// the main db file directly. The trade-off is a possibly-stale view if a
+    /// writer is mid-commit, which is fine for a periodic indexer (the next run
+    /// catches up).
+    ///
     /// # Errors
     /// Returns an error if the database cannot be opened or queried.
     pub fn open(path: &Path) -> Result<Self> {
-        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
-            .context(OpenDbSnafu { path: path.to_path_buf() })?;
+        // URI form so `immutable=1` applies; the path is the trusted db path the
+        // caller resolved (no untrusted query-string injection).
+        let uri = format!("file:{}?immutable=1", path.display());
+        let conn = Connection::open_with_flags(
+            &uri,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+        )
+        .context(OpenDbSnafu { path: path.to_path_buf() })?;
         let entries = read_entries(&conn)?;
         Ok(Self { entries })
     }

--- a/packages/source/claude/src/error.rs
+++ b/packages/source/claude/src/error.rs
@@ -28,17 +28,6 @@ pub enum Error {
         source: std::io::Error,
     },
 
-    /// A transcript line was not valid JSON.
-    #[snafu(display("transcript {} line {line} is not valid JSON", path.display()))]
-    ParseLine {
-        /// File containing the malformed line.
-        path: PathBuf,
-        /// 1-based line number of the offending line.
-        line: usize,
-        /// Underlying serde error.
-        source: serde_json::Error,
-    },
-
     /// The host name could not be resolved for record tagging.
     #[snafu(display("failed to resolve host name"))]
     HostName {

--- a/packages/source/claude/src/lib.rs
+++ b/packages/source/claude/src/lib.rs
@@ -55,8 +55,9 @@ impl ClaudeHistoryExport {
     /// per-machine; [`open`](Self::open) resolves them automatically.
     ///
     /// # Errors
-    /// Returns an error if a directory cannot be listed, a transcript cannot be
-    /// read, or a line is not valid JSON.
+    /// Returns an error if a directory cannot be listed. A transcript that
+    /// cannot be read is logged and skipped, not fatal: one unreadable file must
+    /// not drop every other transcript for this account.
     pub fn open_with(dir: &Path, host: &str, user: &str) -> Result<Self> {
         let mut files = Vec::new();
         collect_transcripts(dir, &mut files)?;
@@ -64,7 +65,10 @@ impl ClaudeHistoryExport {
         let mut messages = Vec::new();
         for file in files {
             let origin = origin_for(&file, host, user);
-            messages.extend(transcript::parse(&file, &origin)?);
+            match transcript::parse(&file, &origin) {
+                Ok(parsed) => messages.extend(parsed),
+                Err(error) => eprintln!("[claude] skipping transcript {}: {error}", file.display()),
+            }
         }
         Ok(Self { messages })
     }

--- a/packages/source/claude/src/transcript.rs
+++ b/packages/source/claude/src/transcript.rs
@@ -5,8 +5,9 @@
 //! `permission-mode`, `attachment`, ...). Every field is therefore optional,
 //! which is the one place `#[serde(default)]` is the right tool: this is an
 //! external, evolving schema, not internal config. A line with no embeddable
-//! message is skipped; a line that is not valid JSON is a typed error, because a
-//! corrupt transcript should be visible, not silently truncated.
+//! message is skipped; a line that is not valid JSON is skipped too but logged,
+//! so one truncated or corrupt line (e.g. a session still mid-write) stays
+//! visible without dropping the rest of the transcript.
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -15,15 +16,18 @@ use serde::Deserialize;
 use serde_json::Value;
 use snafu::ResultExt as _;
 
-use crate::error::{ParseLineSnafu, ReadFileSnafu, Result};
+use crate::error::{ReadFileSnafu, Result};
 use crate::record::{Message, MessageOrigin};
 
 /// Parse every embeddable message from one transcript file.
 ///
+/// Lines that are not valid JSON are skipped (and logged), not fatal: a
+/// transcript can carry a truncated final line from a session still writing, or
+/// an occasional corrupt line, and that must not drop the rest of the file.
+///
 /// # Errors
 /// Returns [`Error::ReadFile`](crate::Error::ReadFile) if the file cannot be
-/// read, or [`Error::ParseLine`](crate::Error::ParseLine) if any line is not
-/// valid JSON.
+/// read.
 pub fn parse(path: &Path, origin: &MessageOrigin) -> Result<Vec<Message>> {
     let raw = std::fs::read_to_string(path).context(ReadFileSnafu { path: path.to_path_buf() })?;
 
@@ -32,14 +36,28 @@ pub fn parse(path: &Path, origin: &MessageOrigin) -> Result<Vec<Message>> {
     // message). One document then carries the call and its output together, and
     // the standalone tool-result line renders empty and is dropped.
     let mut lines = Vec::new();
+    let mut skipped = 0usize;
+    let mut first_bad = 0usize;
     for (index, line) in raw.lines().enumerate() {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
         }
-        let parsed: RawLine = serde_json::from_str(trimmed)
-            .with_context(|_| ParseLineSnafu { path: path.to_path_buf(), line: index + 1 })?;
-        lines.push(parsed);
+        if let Ok(parsed) = serde_json::from_str::<RawLine>(trimmed) {
+            lines.push(parsed);
+        } else {
+            skipped += 1;
+            if first_bad == 0 {
+                first_bad = index + 1;
+            }
+        }
+    }
+    if skipped > 0 {
+        // Visible, not silent: one bad line is tolerated, but say so.
+        eprintln!(
+            "[claude] {}: skipped {skipped} unparseable line(s) (first at line {first_bad})",
+            path.display()
+        );
     }
 
     let tools = collect_tool_index(&lines);

--- a/packages/source/claude/tests/parse.rs
+++ b/packages/source/claude/tests/parse.rs
@@ -67,3 +67,25 @@ fn reingest_is_stable() {
     };
     assert_eq!(ids(&first), ids(&second));
 }
+
+#[test]
+fn corrupt_line_is_skipped_not_fatal() {
+    // A transcript with a truncated/corrupt line (e.g. a session still writing)
+    // must not drop the valid messages around it, and must not error the whole
+    // account's open. Regression for one bad line aborting all of a user's
+    // claude history.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let proj = dir.path().join("demo");
+    std::fs::create_dir_all(&proj).expect("mkdir");
+    let good = r#"{"type":"user","uuid":"u1","sessionId":"s","message":{"role":"user","content":"hello world"}}"#;
+    std::fs::write(
+        proj.join("s.jsonl"),
+        format!("{good}\n{{ this is not valid json\n\0\u{fffd}garbage\n"),
+    )
+    .expect("write");
+
+    let export = ClaudeHistoryExport::open_with(dir.path(), "h", "u").expect("open must not fail");
+    let docs: Vec<_> = export.documents().collect::<Result<_, _>>().expect("documents");
+    assert_eq!(docs.len(), 1, "the one valid message survives the corrupt lines");
+    assert!(String::from_utf8_lossy(&docs[0].body).contains("hello world"));
+}


### PR DESCRIPTION
Found by watching a live fleet indexer run fail mid-pass:

- **source-claude**: one unparseable JSONL line aborted the *entire* claude source for a user — a single bad line in one transcript dropped all of that account's history (`[claude:andrew] failed: ... line 271 is not valid JSON`). Now bad lines are skipped with a logged warning, and an unreadable transcript file is skipped instead of failing every other file. Removes the now-unused `ParseLine` error. Regression test added.
- **source-atuin**: read-only open of atuin's WAL db failed with `SQLITE_CANTOPEN` (code 14) when a live shell held it or the home dir wasn't writable under the privileged fleet read, so shell history indexed nothing. Open `immutable=1` via a URI to skip sidecar/lock I/O.

Validated on the builder: claude `corrupt_line_is_skipped_not_fatal` + atuin tests + clippy all green.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip bad lines and use immutable SQLite open in Claude and Atuin sources
> - Invalid JSON lines in Claude transcript files are now counted, logged to stderr, and skipped rather than aborting the parse; only file read errors are fatal ([transcript.rs](https://github.com/indexable-inc/index/pull/597/files#diff-ee208c45ac415db278ae3cc2d64354e2665d2cb49e16224804a973001c5ec508)).
> - Unreadable Claude transcript files no longer abort the full export; they are logged to stderr and skipped while other transcripts continue processing ([lib.rs](https://github.com/indexable-inc/index/pull/597/files#diff-527d14ebb29d87bfd2bee52554490b9413ca99a611ff77b2750cb0f9670f6812)).
> - The Atuin history database now opens with `immutable=1` SQLite URI flag, avoiding WAL/SHM/lock file I/O that could cause `SQLITE_CANTOPEN` in read-only or locked contexts ([lib.rs](https://github.com/indexable-inc/index/pull/597/files#diff-f718479b61f770a210e027a215165ebccc292b91ba62f7394ba382fd2b92190d)).
> - Risk: Atuin reads may reflect a stale snapshot if a writer is mid-commit when the database is opened.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d6d3ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->