### PR TITLE
RFC 0003: MCP capabilities as composable CLIs

### DIFF
--- a/rfcs/0003-mcp-composable-clis.html
+++ b/rfcs/0003-mcp-composable-clis.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>RFC 0003: MCP capabilities as composable CLIs · ix images</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #fdfdfc;
+    --fg: #1a1a1a;
+    --fg-dim: #5b5b5b;
+    --link: #0050b3;
+    --code-bg: #f3f3ef;
+    --rule: #e4e2dc;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #161614;
+      --fg: #e8e6df;
+      --fg-dim: #9b9890;
+      --link: #79b8ff;
+      --code-bg: #22221f;
+      --rule: #2e2d2a;
+    }
+  }
+  html { background: var(--bg); color: var(--fg); }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    max-width: 720px;
+    margin: 3rem auto;
+    padding: 0 1.25rem 4rem;
+    font-size: 17px;
+    line-height: 1.55;
+  }
+  h1, h2, h3 { line-height: 1.25; font-weight: 600; }
+  h1 { font-size: 1.9rem; margin: 0 0 0.25rem; }
+  .subtitle { color: var(--fg-dim); font-size: 1rem; margin: 0 0 2rem; }
+  h2 { font-size: 1.35rem; margin-top: 2.5rem; padding-top: 1rem; border-top: 1px solid var(--rule); }
+  h3 { font-size: 1.1rem; margin-top: 1.75rem; }
+  p { margin: 0.85rem 0; }
+  a { color: var(--link); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code, pre {
+    font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    font-size: 0.92em;
+  }
+  code { background: var(--code-bg); padding: 0.08em 0.3em; border-radius: 3px; }
+  pre {
+    background: var(--code-bg);
+    padding: 0.85rem 1rem;
+    border-radius: 6px;
+    overflow-x: auto;
+    line-height: 1.45;
+  }
+  pre code { background: transparent; padding: 0; }
+  ul, ol { padding-left: 1.4rem; }
+  li { margin: 0.3rem 0; }
+  blockquote {
+    border-left: 3px solid var(--rule);
+    margin: 1rem 0;
+    padding: 0.1rem 0 0.1rem 1rem;
+    color: var(--fg-dim);
+  }
+  dl.frontmatter {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.25rem 1rem;
+    margin: 0 0 2rem;
+    font-size: 0.95rem;
+  }
+  dl.frontmatter dt { font-weight: 600; color: var(--fg-dim); }
+  dl.frontmatter dd { margin: 0; }
+  strong { font-weight: 600; }
+</style>
+</head>
+<body>
+
+<h1>RFC 0003: MCP capabilities as composable CLIs</h1>
+<p class="subtitle"><a href="index.html">RFC index</a></p>
+
+<dl class="frontmatter">
+  <dt>Number</dt><dd>0003</dd>
+  <dt>Title</dt><dd>MCP capabilities as composable CLIs</dd>
+  <dt>Status</dt><dd>Draft</dd>
+  <dt>Authors</dt><dd>andrewgazelka</dd>
+  <dt>Created</dt><dd>2026-06-02</dd>
+  <dt>Updated</dt><dd>2026-06-02</dd>
+  <dt>Tracking issue</dt><dd><a href="https://github.com/indexable-inc/index/issues/598">#598</a></dd>
+  <dt>Supersedes</dt><dd>&mdash;</dd>
+  <dt>Superseded by</dt><dd>&mdash;</dd>
+</dl>
+
+<h2>Summary</h2>
+<p>Adopt a contract for every integration we reach over MCP: the behavior lives in a Rust core crate, and that crate is exposed through two thin surfaces, an MCP server binding and an <code>index</code> subcommand. Anything an agent can call as an MCP tool is then also a process that a human can pipe in a shell and a script can run in CI, with no second implementation. New integrations start as a core crate, not as an MCP-only server. The first concrete target is email, tracked separately in <a href="https://github.com/indexable-inc/index/issues/599">#599</a>.</p>
+
+<h2>Motivation</h2>
+<p>The daily MCP set is roughly six servers: <code>exa</code>, <code>index</code>, <code>linear</code>, <code>notion</code>, <code>slack</code>, and <code>superhuman-mail</code>. They are uneven. <code>index</code> already ships its capability as a CLI and a tool: <code>search.semantic</code> is reachable as the <code>search_semantic</code> MCP tool and as <code>nix run .#search</code>, backed by one <code>search</code>/<code>search-core</code> crate. <code>notion</code> has the official <code>ntn</code> CLI. At the other end, <code>exa</code> and <code>superhuman-mail</code> are MCP-only: the capability exists solely behind the MCP transport.</p>
+<p>An MCP-only capability has three costs. It is not pipeable, so a human cannot compose it with the rest of the shell and a CI job cannot script it. It is awkward to test, because exercising the behavior means standing up an MCP client rather than running a binary and asserting on stdout. And it pushes us toward per-surface reimplementation: when we later want the same behavior on the command line, the path of least resistance is a second client against the same upstream rather than one owned core.</p>
+<p>This cuts against the repo's stated direction. <code>AGENTS.md</code> says to implement core logic once in Rust and expose it to other ecosystems through thin bindings that carry no domain logic of their own. <code>index</code>/<code>search</code> already proves the shape works for one capability. This RFC generalizes it so the next integration does not relearn it.</p>
+
+<h2>Detailed design</h2>
+
+<h3>One core, two thin surfaces</h3>
+<p>Each integration is one crate that owns the domain logic: the upstream API client, the request and response types, auth, retries, and error mapping. That crate exposes a typed in-process API and nothing user-facing. Two thin layers depend on it:</p>
+<ul>
+  <li><strong>CLI.</strong> An <code>index</code> subcommand (for example <code>index mail</code>, <code>index web</code>) that parses arguments, calls the core, and prints human or machine-readable output per the <code>user-facing-commands</code> conventions. It carries no domain logic beyond argument shaping.</li>
+  <li><strong>MCP binding.</strong> A server that maps each tool call onto the same core API. Tool input and output schemas are derived from the core types, so the tool surface and the CLI surface cannot drift.</li>
+</ul>
+<p>The rule for new work: write the core crate first. An MCP server or a CLI that contains domain logic directly, rather than wrapping a core crate, does not pass review. This mirrors how <code>search</code>/<code>search-core</code> is split today.</p>
+
+<h3>Composability is the point</h3>
+<p>Once the capability is a process, it joins the shell. <code>index web "query" --json | jq ...</code> and <code>... | index linear create</code> become ordinary pipelines, and the same binary is callable from a CI step. The agent gains a choice rather than losing one: it can invoke the capability over MCP, or run the CLI through Bash, whichever fits the task. Notably, Claude Code streams Bash output live but collapses MCP output until the call returns (issues 31893, 51713), so for long-running or progress-heavy operations the CLI path is strictly better for the operator watching it.</p>
+
+<h3>Auth and secrets</h3>
+<p>Both surfaces read the same credential from the same place, so there is one auth story per integration, not one per surface. Credentials follow the existing split: shared team keys in <code>rbw</code> (Vaultwarden), personal keys in <code>op</code> (1Password), referenced not inlined. Where an integration runs on the fleet, per-person identity follows the pattern the Slack MCP already uses (a per-user OAuth token) rather than a single shared bearer, unless a shared service identity is explicitly intended.</p>
+
+<h3>What changes for the existing six</h3>
+<p>Nothing is forced to migrate at once. The contract applies to new integrations immediately and gives a ranking for retrofitting the current set. <code>index</code> already conforms. <code>exa</code> and <code>superhuman-mail</code> are the widest gaps because they have no CLI today, so they are the natural first retrofits. <code>linear</code>, <code>notion</code>, and <code>slack</code> have partial CLI stories already and can follow.</p>
+
+<h3>First concrete case: email</h3>
+<p>Email is the motivating instance and is specified in its own issue, <a href="https://github.com/indexable-inc/index/issues/599">#599</a>, so this RFC does not duplicate it. In short: a <code>mail-core</code> crate over the Gmail and Calendar APIs with OAuth, a thin MCP binding matching the surface <code>superhuman-mail</code> exposes today, and an <code>index mail</code> CLI over the same crate. It is the proof that the contract in this RFC produces a real, dogfoodable integration and not just a principle.</p>
+
+<h2>Drawbacks</h2>
+<ul>
+  <li><strong>More upfront cost per integration.</strong> A core crate plus two bindings is more scaffolding than a single MCP server wrapping a vendor SDK. The payoff only arrives once the capability is used from more than one surface, which is not every integration.</li>
+  <li><strong>We own more code.</strong> Going direct to an upstream API (rather than brokering through a vendor MCP) means we own the client, the auth refresh, and the error mapping. For a capability where a maintained vendor MCP already exists and we never want a CLI, wrapping it is genuinely cheaper, and the RFC should not pretend otherwise.</li>
+  <li><strong>Schema-derivation coupling.</strong> Deriving MCP tool schemas from core types keeps the surfaces in sync but couples the tool wire format to internal type shape. Renaming a core field becomes a tool-surface change.</li>
+</ul>
+
+<h2>Alternatives</h2>
+<ul>
+  <li><strong>Do nothing.</strong> Keep adding MCP-only servers. Cheapest per server, but every capability stays locked behind the MCP transport, untestable as a binary and impossible to pipe, and the per-surface reimplementation pressure stays.</li>
+  <li><strong>CLI-only, no MCP.</strong> Ship only the <code>index</code> subcommand and let the agent shell out. Simpler, and it preserves composability, but it gives up structured tool schemas, typed arguments, and the MCP affordances the agent already uses well for high-frequency calls.</li>
+  <li><strong>MCP-only, generate a CLI later if needed.</strong> The status quo for <code>exa</code> and <code>superhuman-mail</code>. "Later" tends to mean a second client against the same upstream, which is the reimplementation this RFC exists to avoid.</li>
+  <li><strong>Wrap vendor MCPs uniformly.</strong> Standardize on brokering every capability through a third-party MCP. Lowest code ownership, but no CLI, vendor in the hot path, and identity tied to the vendor account.</li>
+</ul>
+
+<h2>Prior art</h2>
+<ul>
+  <li><strong><code>search</code> / <code>search-core</code> in this repo.</strong> One core crate, exposed as both the <code>search_semantic</code> MCP tool and <code>nix run .#search</code>. This RFC generalizes that existing split.</li>
+  <li><strong>RFC 0002.</strong> The two-layer "generic primitive plus thin lowering modules" topology for third-party integrations is the same instinct applied to billable partner services: own the contract once, keep the per-provider surface thin.</li>
+  <li><strong><code>ntn</code> (Notion) and the hosted Slack MCP.</strong> Existing examples of the same capability reachable from more than one surface, and of the per-user-OAuth identity model on the fleet.</li>
+  <li><strong>The <code>git</code> and <code>gh</code> CLIs.</strong> Long-lived proof that a capability exposed as a composable command outlives any single client wrapped around it.</li>
+</ul>
+
+<h2>Unresolved questions</h2>
+<ol>
+  <li><strong>Retrofit scope.</strong> Do we commit to retrofitting <code>exa</code> and <code>superhuman-mail</code> to the contract, or only apply it to new integrations and leave the existing six as-is until each is touched for another reason?</li>
+  <li><strong>Schema derivation.</strong> Derive MCP tool schemas from core types automatically, accepting the coupling, or hand-write tool schemas per integration to decouple the wire format from internal types?</li>
+  <li><strong>Crate granularity.</strong> One core crate per integration, or per capability within a vendor (for example <code>mail-core</code> versus splitting calendar into its own crate)?</li>
+  <li><strong>Fleet identity default.</strong> Per-person OAuth by default for fleet-delivered integrations, or a shared service identity unless per-person is requested?</li>
+</ol>
+
+<h2>Future possibilities</h2>
+<ul>
+  <li>A small shared helper crate for the MCP-binding boilerplate (tool registration, schema derivation, error mapping) so each integration's binding is only its tool list.</li>
+  <li>A conformance check that fails CI if an integration ships an MCP tool with no corresponding CLI subcommand, or vice versa, keeping the two surfaces honest over time.</li>
+  <li>Folding the resulting CLIs into the same machine-readable output conventions so agent and human pipelines share one parsing story.</li>
+</ul>
+
+</body>
+</html>

--- a/rfcs/index.html
+++ b/rfcs/index.html
@@ -86,6 +86,7 @@
 <ul>
   <li><a href="0001-router-vm.html">RFC 0001 — User-built router VM for fleet networking policy</a> <span class="status">· Draft</span></li>
   <li><a href="0002-third-party-integrations.html">RFC 0002: Third-party integrations for partner-mediated services</a> <span class="status">· Draft</span></li>
+  <li><a href="0003-mcp-composable-clis.html">RFC 0003: MCP capabilities as composable CLIs</a> <span class="status">· Draft</span></li>
 </ul>
 
 <h2>When to write one</h2>


### PR DESCRIPTION
RFC 0003 proposing a contract for MCP integrations: one Rust core crate per integration, exposed as both a thin MCP binding and an `index` CLI subcommand, so anything the agent reaches over MCP is also pipeable in a shell and scriptable in CI. Generalizes the existing `search`/`search-core` split.

Per the RFC process, merging while it's coherent enough to read; review happens as line comments and follow-up edits land against the same file.

Tracking issue #598. First concrete case (email) is #599.

@wyattgill9 for review.

Drafted with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add RFC 0003 proposing MCP capabilities as composable CLIs
> Adds [0003-mcp-composable-clis.html](https://github.com/indexable-inc/index/pull/600/files#diff-6587949472d93706974372679936cdddb3fabc427984216f53ebf5eb05571938), a new draft RFC covering the design, motivation, drawbacks, alternatives, and open questions for exposing MCP capabilities as composable CLI tools. Updates the [RFC index](https://github.com/indexable-inc/index/pull/600/files#diff-1f7db30276be0d5a72b534628860e36df48cdb4fb668d1e8f1f226756a71bd72) to list RFC 0003 with a Draft status.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18c5076.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->