### PR TITLE
fix(nix-cargo-unit): preserve split debuginfo sidecars

### DIFF
--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -788,6 +788,12 @@ fn render_unit_derivation(
         &render_driver_build_phase(graph, options, prepared, index, driver)?,
     );
     attrs.multiline("installPhase", &install_phase);
+    if driver == Driver::Rustc {
+        attrs.multiline(
+            "postFixup",
+            &render_split_debuginfo_sidecar_post_fixup(&graph.units[index]),
+        );
+    }
 
     Ok(attrs.render())
 }
@@ -1342,7 +1348,12 @@ chmod 755 $out/bin/{}
         format!(
             "\
 mkdir -p $out/lib $out/nix-support
-cp -R build/* $out/lib/
+for build_artifact in build/*; do
+  case \"$build_artifact\" in
+    *.dwo|*.dwp) continue ;;
+  esac
+  cp -R \"$build_artifact\" \"$out/lib/\"
+done
 extern_path=\"\"
 for artifact in \\
   \"$out/lib/lib{lib_name}-{hash}.rlib\" \\
@@ -1360,6 +1371,22 @@ done
 "
         )
     }
+}
+
+fn render_split_debuginfo_sidecar_post_fixup(unit: &Unit) -> String {
+    let output_dir = if unit.is_bin() || unit.is_test() {
+        "$out/bin"
+    } else {
+        "$out/lib"
+    };
+    format!(
+        "\
+for split_debuginfo_sidecar in build/*.dwo build/*.dwp; do
+  [ -e \"$split_debuginfo_sidecar\" ] || continue
+  cp \"$split_debuginfo_sidecar\" \"{output_dir}/\"
+done
+"
+    )
 }
 
 fn render_build_script_run(
@@ -3099,6 +3126,81 @@ mod tests {
         assert!(rendered.contains("extraClippyLintArgs"));
         assert!(rendered.contains("clippy = clippyPolicyAggregate;"));
         assert!(rendered.contains("clippyPolicyAggregate ="));
+    }
+
+    #[test]
+    fn installs_split_debuginfo_sidecars_after_fixup() {
+        let graph: UnitGraph = serde_json::from_str(
+            r#"{
+              "version": 1,
+              "units": [
+                {
+                  "pkg_id": "path+file:///workspace#hello@0.1.0",
+                  "target": {
+                    "kind": ["lib"],
+                    "crate_types": ["lib"],
+                    "name": "hello",
+                    "src_path": "/workspace/src/lib.rs",
+                    "edition": "2024"
+                  },
+                  "profile": {
+                    "name": "release",
+                    "opt_level": "3",
+                    "split_debuginfo": "packed"
+                  },
+                  "features": [],
+                  "mode": "build",
+                  "dependencies": []
+                },
+                {
+                  "pkg_id": "path+file:///workspace#hello@0.1.0",
+                  "target": {
+                    "kind": ["bin"],
+                    "crate_types": ["bin"],
+                    "name": "hello-cli",
+                    "src_path": "/workspace/src/main.rs",
+                    "edition": "2024"
+                  },
+                  "profile": {
+                    "name": "release",
+                    "opt_level": "3",
+                    "split_debuginfo": "packed"
+                  },
+                  "features": [],
+                  "mode": "build",
+                  "dependencies": []
+                }
+              ],
+              "roots": [0, 1]
+            }"#,
+        )
+        .unwrap();
+
+        let rendered = render_units_nix(
+            &graph,
+            &RenderOptions {
+                workspace_root: PathBuf::from("/workspace"),
+                vendor_root: None,
+                cargo_lock_sources: CargoLockSources::default(),
+                content_addressed: false,
+                toolchain_id: Some("rustc-test".to_string()),
+                deny_unused_crate_dependencies: false,
+                deny_panics: false,
+            },
+        )
+        .unwrap();
+
+        assert!(rendered.contains("rustc_args+=( 'split-debuginfo=packed' )"));
+        assert_eq!(
+            rendered
+                .matches("for split_debuginfo_sidecar in build/*.dwo build/*.dwp; do")
+                .count(),
+            2
+        );
+        assert!(rendered.contains("cp \"$split_debuginfo_sidecar\" \"$out/bin/\""));
+        assert!(rendered.contains("cp \"$split_debuginfo_sidecar\" \"$out/lib/\""));
+        assert!(rendered.contains("case \"$build_artifact\" in\n    *.dwo|*.dwp) continue ;;"));
+        assert!(!rendered.contains("cp -R build/* $out/lib/"));
     }
 
     #[test]


### PR DESCRIPTION
Install Rust split debuginfo sidecars from generated postFixup so .dwo and .dwp files are copied after Nix fixup. Filter those files out of the library installPhase so fixup does not try to process the debug sidecars as normal build artifacts.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve split debuginfo sidecar files (.dwo/.dwp) in Nix Cargo unit derivations
> - Adds a `postFixup` step in `render_unit_derivation` (for Rustc-driven units) that copies `.dwo`/`.dwp` files from `build/` into `$out/bin` for bins/tests and `$out/lib` for libraries.
> - Replaces the blanket `cp -R build/* $out/lib/` in the library `installPhase` with a per-file loop that skips `.dwo`/`.dwp` files, deferring them to `postFixup`.
> - The new `render_split_debuginfo_sidecar_post_fixup` helper in [render.rs](https://github.com/indexable-inc/index/pull/601/files#diff-da81bb79268fbaf52a96664faa4d392b9b83a48a4b3b54bb1c3a2a5f2f50f26a) generates the shell snippet for both artifact types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a24d93a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->