### PR TITLE
darwin: declare Microsoft Office masApps (Word/Excel/PowerPoint/Outlook)

### DIFF
--- a/users/andrewgazelka/darwin.nix
+++ b/users/andrewgazelka/darwin.nix
@@ -85,6 +85,10 @@
       "Numbers" = 409203825;
       "Keynote" = 409183694;
       "Portal" = 1436994560;
+      "Microsoft Word" = 462054704;
+      "Microsoft Excel" = 462058435;
+      "Microsoft PowerPoint" = 462062816;
+      "Microsoft Outlook" = 985367838;
     };
   };
 }


### PR DESCRIPTION
Adds Word (462054704), Excel (462058435), PowerPoint (462062816), Outlook (985367838) to andrewgazelka's masApps. IDs verified via the iTunes lookup API. Declaring them keeps `mas` zap from removing the apps.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Microsoft Office Mac App Store apps to darwin.nix
> Adds Microsoft Word (462054704), Microsoft Excel (462058435), Microsoft PowerPoint (462062816), and Microsoft Outlook (985367838) to the managed Mac App Store applications in [darwin.nix](https://github.com/indexable-inc/index/pull/603/files#diff-8e50939d75ca47b003564ea6eb7afcd3cd3ab9bfa6b8876d3c079c94862fb7bc).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8ebf6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->