### PR TITLE
fix(blast-radius): grant pull-requests: write so comment job can post

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
+      pull-requests: write
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Replaces the unused `issues: write` permission on the `comment` job with `pull-requests: write`. The job posts to `/repos/{owner}/{repo}/issues/{pr_number}/comments`, but when the issue number resolves to a PR, GitHub gates the write on `pull-requests: write` and returns 403 otherwise. Since the workflow is `pull_request`-triggered, this job only ever comments on PRs, so `issues: write` was both insufficient (for PRs) and unused (no plain-issue codepath).

Closes #582.

## Test plan

- [ ] `comment` check on this PR turns green (was 403 on every prior PR)
- [ ] sticky comment with `<!-- blast-radius -->` marker appears
- [ ] re-running the workflow updates (PATCH) the same comment rather than posting a duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix comment job permissions in blast-radius workflow to use `pull-requests: write`
> The `comment` job in [blast-radius.yml](.github/workflows/blast-radius.yml) had `issues: write` instead of `pull-requests: write`, preventing it from posting comments on pull requests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf9c3f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->