### PR TITLE
test(blast-radius): single-image edit — expect 2 (lint+eval)

### DIFF
--- a/images/dev/neovim-ci/default.nix
+++ b/images/dev/neovim-ci/default.nix
@@ -1,4 +1,5 @@
 # Neovim Linux CI image: toolchain and test dependencies for ix-backed jobs.
+# blast-radius test: no-op comment edit to measure single-image attribution.
 { pkgs, ... }:
 let
   python = pkgs.python3.withPackages (ps: [


### PR DESCRIPTION
## Summary

Diagnostic PR #2 of 3 to verify `blast-radius` attribution for a change to a single image with no dependents. Comment-only edit to `images/dev/neovim-ci/default.nix`.

## Expected

`2 of N` checks rebuild:
- `lint` — `fs.gitTracked paths.root` includes the file
- `eval` — `linkFarmFromDrvs` over all `imageTests`, one of which closes over the neovim-ci config

If only `lint` is reported, the image's `imageTests` slot is not being plumbed through `eval`. If more than 2, something extra closes over per-image config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add no-op comment to `images/dev/neovim-ci/default.nix` to test single-image blast radius attribution
> Adds a single no-op comment to [default.nix](https://github.com/indexable-inc/index/pull/606/files#diff-f89caa71bfab920c7050e33bebefbb12e9a2ec3df6ebd4eaf32ea52cafa793ee) to verify that a single-image edit triggers exactly 2 CI jobs (lint + eval) and no others.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d8d74c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->