### PR TITLE
test(blast-radius): shared image lib edit — expect ~2, predict collapse to eval

### DIFF
--- a/lib/image/platform.nix
+++ b/lib/image/platform.nix
@@ -1,4 +1,5 @@
 # Baseline platform applied to every image.
+# blast-radius test: no-op comment edit to measure cross-image fanout.
 {
   config,
   lib,


### PR DESCRIPTION
## Summary

Diagnostic PR #3 of 3. Comment-only edit to `lib/image/platform.nix`, which is loaded by every image through `lib/image/default.nix:evalImageConfig`.

## Prediction

`2 of N` checks rebuild:
- `lint` — `fs.gitTracked paths.root`
- `eval` — `linkFarmFromDrvs` over `imageTests` (every grouped image's evaluated config closes over `platform.nix`)

The interesting bit isn't the number — it's that the actual *work* if this landed would rebuild every image in `.#packages`, but blast-radius reports against `.#checks` only and `imageTests` collapse into a single `eval` linkFarm. So the metric will not reflect the real-world cost of a foundational change.

If the result is `1`, that means `platform.nix` is somehow not closed over by `imageTests` — worth investigating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add no-op comment to `lib/image/platform.nix` for blast-radius testing
> Adds a comment to [platform.nix](https://github.com/indexable-inc/index/pull/607/files#diff-4e9f8a1975e02453aa569916bd7b0c3a25baa581602e105115a45921f41bf7d7) with no functional effect. The change is intended to test blast-radius tooling, expecting ~2 affected targets and a collapse to eval.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19af137.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->