### PR TITLE
test(blast-radius): semantic shared-lib edit — predict 1, expose .#packages gap

### DIFF
--- a/lib/image/platform.nix
+++ b/lib/image/platform.nix
@@ -227,6 +227,8 @@ in
 
     nixpkgs.hostPlatform.system = "x86_64-linux";
 
+    environment.etc."ix-blast-radius-marker".text = "diagnostic\n";
+
     # YourKit is the only unfree we currently allow into images, and only
     # because `ix.languages.java.yourkit` is an opt-in profiler agent that
     # an operator turns on for performance work. The predicate keeps every


### PR DESCRIPTION
## Summary

Diagnostic PR #4 of 4. Real semantic NixOS config change to `lib/image/platform.nix` (adds `environment.etc."ix-blast-radius-marker"`), in contrast to the comment-only edit in #607.

## Prediction

**`1 of N` checks rebuild — still only `lint`.**

Reasoning: this change shifts every image's `system.build.toplevel` derivation in `.#packages`, but no derivation in `.#checks.x86_64-linux` actually closes over it.

- `tests.eval` is `linkFarmFromDrvs` over `imageTests`.
- Each `imageTest` is `pkgs.runCommand` whose drvPath depends on `extraScript`'s string content.
- The 5 imageTests with non-empty `extraScript` (factions, survival, observability-stack, extended-attributes, minecraft) interpolate Minecraft-service-specific derivation paths (e.g. `${factionsExample.managed.dropins}`), not `config.system.build.toplevel` or `config.environment.etc`.
- Therefore: even a real semantic change to platform.nix doesn't move any `eval`-input drvPath.

If the result is `1`, that's the missing-coverage finding to act on: blast-radius reports against `.#checks` only, but `flake-check` builds `.#packages` too (per-system.nix:148, 161). A foundational change that rebuilds every image is invisible.

If the result is `>1`, my dependency model is incomplete — list the extras.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/etc/ix-blast-radius-marker` diagnostic file to image.platform NixOS module
> Adds a single `environment.etc` entry in [lib/image/platform.nix](https://github.com/indexable-inc/index/pull/608/files#diff-4e9f8a1975e02453aa569916bd7b0c3a25baa581602e105115a45921f41bf7d7) that writes `/etc/ix-blast-radius-marker` with the content `"diagnostic\n"`. This is a test change to measure the blast radius of shared-library edits and expose gaps in package prediction coverage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8b2cc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->