### PR TITLE
nix-cargo-unit: drop orphaned root workspace deps, read version from manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,6 @@ anstream = "1"
 anstyle = "1"
 anyhow = "1"
 arrow = "58"
-askama = { version = "0.16.0", default-features = false }
 ast-merge-ast = { path = "packages/ast-merge/ast" }
 ast-merge-diff = { path = "packages/ast-merge/diff" }
 ast-merge-git = { path = "packages/ast-merge/git" }
@@ -143,11 +142,6 @@ ndarray = "0.16"
 nix = "0.30"
 nix-web-monitor-parser = { path = "packages/nix-web-monitor/parser" }
 numpy = "0.28"
-object = { version = "0.37", default-features = false, features = [
-  "read",
-  "write",
-  "std",
-] }
 object_store = { version = "0.13", features = ["aws"] }
 parking_lot = "0.12"
 parquet = { version = "58", features = ["arrow"] }

--- a/packages/nix-cargo-unit/default.nix
+++ b/packages/nix-cargo-unit/default.nix
@@ -3,6 +3,9 @@
   pkgs,
 }:
 
+let
+  inherit (pkgs) lib;
+in
 # nix-cargo-unit bootstraps the unit graph, so it cannot consume ix.cargoUnit
 # and is built as a plain Rust package. It is a standalone Cargo workspace
 # (its own Cargo.toml + Cargo.lock, excluded from the root workspace), so the
@@ -12,6 +15,8 @@
 # the pname.
 ix.buildRustPackage pkgs {
   pname = "nix-cargo-unit";
-  version = "0.1.0";
+  # Single source of truth: read the version from the crate manifest rather
+  # than re-pinning it here, so the two cannot drift.
+  version = (lib.importTOML ./Cargo.toml).package.version;
   srcRoot = ./.;
 }


### PR DESCRIPTION
Follow-up cleanup to #611 (code-review nits).

After nix-cargo-unit became a standalone crate, `askama` and `object` were left in the root `[workspace.dependencies]` with no remaining consumer (nix-cargo-unit was the only one, now excluded). Both removed; `object` still enters the root lock transitively via `backtrace`, `askama` is gone entirely.

Also read the package version in `default.nix` from `Cargo.toml` instead of re-pinning `"0.1.0"`, so the Nix store-path version and the crate version cannot drift.

Validated: `nix-cargo-unit` builds, package set evaluates (152), pre-commit unit-graph rebuild + lint pass.

Made with Claude Code (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop orphaned workspace deps and read version from manifest in `nix-cargo-unit`
> - Removes `askama` and `object` from the workspace dependency list in [Cargo.toml](https://github.com/indexable-inc/index/pull/612/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542).
> - Replaces the hardcoded `"0.1.0"` version string in [default.nix](https://github.com/indexable-inc/index/pull/612/files#diff-91b71428c65b4d49618eafa91567ab00e8070c4ca1126236a2cefc670b462fa5) with a dynamic read from `Cargo.toml` via `lib.importTOML`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35d017c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->