### PR TITLE
feat(cargo-unit): default contentAddressed = true

### DIFF
--- a/lib/rust/cargo-unit.nix
+++ b/lib/rust/cargo-unit.nix
@@ -56,7 +56,12 @@ let
     # sandboxed fetchers to see a developer SSH agent or GitHub credentials.
     sourceOverrides = args.sourceOverrides or { };
     outputHashes = args.outputHashes or { };
-    contentAddressed = args.contentAddressed or false;
+    # Default ON: workspace units emit floating content-addressed outputs so an
+    # output-invariant rebuild of a low-level crate early-cuts off instead of
+    # cascading through its whole reverse-dependency closure. Consumers may still
+    # pass `contentAddressed = false` to opt out. (ca-derivations must be enabled
+    # in the daemon; ix CI enables it.)
+    contentAddressed = args.contentAddressed or true;
     policy = rust.resolvePolicy (args.policy or { });
   };
 


### PR DESCRIPTION
Workspace units now emit floating content-addressed outputs **by default**, so an output-invariant rebuild of a low-level crate early-cuts off instead of cascading a rebuild through its entire reverse-dependency closure.

Measured in ix: a 1-line change to a foundational crate (`codec`, 33 dependents) re-derived **~28% of a 14.5k-derivation closure**; a leaf change was 0.4%. CA early-cutoff collapses the foundational case toward the leaf case for output-invariant edits.

Requires `ca-derivations` in the daemon (enabled on ix CI hosts). Consumers without it (or without a CA-aware cache) can opt out via `contentAddressed = false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `contentAddressed` to `true` in `cargo-unit`
> Changes the default value of `contentAddressed` in [lib/cargo-unit.nix](https://github.com/indexable-inc/index/pull/615/files#diff-b67db90fa4e2a55cd44c0d25d820f7c6b0ce11cca15cf9b3e56d5d2017affc6c) from `false` to `true`. Callers that do not explicitly set `contentAddressed` will now produce content-addressed derivations by default. Behavioral Change: existing builds that rely on the previous default will now be content-addressed unless they explicitly opt out by setting `contentAddressed = false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0096f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->