### PR TITLE
fix(cargo-unit): keep build-script-output input-addressed under CA

### DIFF
--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -1423,7 +1423,23 @@ fn render_build_script_run(
     );
     attrs.expr("buildInputs", &format!("[ {} ]", inputs.join(" ")));
     attrs.bool("dontStrip", true);
-    append_content_addressing(&mut attrs, options.content_addressed);
+    // Build-script outputs stay INPUT-addressed even when content_addressed is
+    // set, because they are frequently NOT bit-reproducible. This derivation
+    // captures the build script's `out-dir`, which for crates like `ring` embeds
+    // the build path into pre-generated perlasm `.o`/`.a` objects, so the output
+    // differs byte-for-byte between builds (briansmith/ring#715).
+    //
+    // A non-reproducible *floating content-addressed* output is a trap: once a
+    // GC deletes it, the next build produces a different output and Nix aborts
+    // with "Trying to register a realisation ... but we already have another one
+    // locally" (NixOS/nix#15649). That surfaces to dependents as
+    // "build of resolved derivation '<crate>' failed" with no underlying builder
+    // error (observed: rcgen-0.14.8, which pulls in ring; the trigger is the
+    // CI host's periodic nix-gc wiping the output between builds).
+    //
+    // Input addressing sidesteps the realisation machinery entirely, and nothing
+    // early-cuts-off on a build-script output anyway, so the crate libraries
+    // (render_unit_derivation) keep CA with no loss of incrementality.
     attrs.multiline(
         "buildPhase",
         &render_build_script_run_phase(


### PR DESCRIPTION
Floating content-addressed `*-build-script-output` derivations break cold CA builds. They capture the build script's out-dir, which for crates like `ring` embeds the build path into pre-generated perlasm `.o`/`.a` objects → not bit-reproducible ([briansmith/ring#715](https://github.com/briansmith/ring/issues/715)).

A non-reproducible CAFloating output is a trap: after a GC deletes it, the next build produces different bytes and Nix aborts with *'Trying to register a realisation … but we already have another one locally'* ([NixOS/nix#15649](https://github.com/nixos/nix/issues/15649)), surfacing to dependents as *'build of resolved derivation <crate> failed'* with no builder error (observed: rcgen-0.14.8 → ring; trigger is the CI host's periodic nix-gc wiping the output between builds).

Keep `build-script-output` **input-addressed**; nothing early-cuts-off on it, so crate libraries stay CA with no loss. Makes the `contentAddressed = true` default (#615) safe for cold builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep build-script-output derivations input-addressed under content-addressing
> Removes the `append_content_addressing` call from `render_build_script_run` in [render.rs](https://github.com/indexable-inc/index/pull/616/files#diff-da81bb79268fbaf52a96664faa4d392b9b83a48a4b3b54bb1c3a2a5f2f50f26a), replacing it with a comment. Build-script run derivations are now always input-addressed, regardless of the `content_addressed` option.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cfdf6a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->