### PR TITLE
docs(cargo-unit): note CA early-cutoff limits + rustc Relink-don't-Rebuild

### DIFF
--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -736,6 +736,19 @@ impl Driver {
 // CA-derivation attributes Nix needs to content-address a unit's output.
 // Opt-in: callers pass `--content-addressed`, otherwise units stay input
 // addressed.
+//
+// Why content-address: it buys "early cutoff" — when a crate is rebuilt but its
+// output is byte-identical, Nix reuses the existing path and dependents are not
+// re-derived. How often that fires is bounded by rustc itself: a crate's rmeta
+// is oversensitive (a comment / private-body / formatting change still changes
+// it, forcing reverse-dependency rebuilds), and link targets (bins/cdylibs)
+// always relink when any transitive rlib changed because rlibs aren't byte-stable
+// under `-C incremental`. Upstream is working to narrow exactly this — see the
+// "Relink, don't Rebuild" rustc project goal
+// (rust-lang/rust-project-goals 2025h2) — after which CA early cutoff will fire
+// on more non-interface changes. (Build-script outputs are deliberately excluded
+// from CA in render_build_script_run_derivation: see the note there re ring's
+// non-reproducible debug-info paths, briansmith/ring#715 + NixOS/nix#15649.)
 fn append_content_addressing(attrs: &mut Attrs, content_addressed: bool) {
     if !content_addressed {
         return;


### PR DESCRIPTION
Comment-only. Records why content-addressing gives early cutoff and what limits it (rustc rmeta oversensitivity; link targets relink under `-C incremental`), pointing at the upstream ["Relink, don't Rebuild"](https://rust-lang.github.io/rust-project-goals/2025h2/relink-dont-rebuild.html) rustc goal, plus a cross-ref to the build-script-output CA exclusion (ring#715 / nix#15649).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document content-addressing rationale and early-cutoff limits in `append_content_addressing`
> Adds a block comment above `append_content_addressing` in [render.rs](https://github.com/indexable-inc/index/pull/617/files#diff-da81bb79268fbaf52a96664faa4d392b9b83a48a4b3b54bb1c3a2a5f2f50f26a) explaining why content-addressing is used, how rustc's rmeta/linking sensitivity affects early-cutoff behavior, and why build-script outputs are explicitly excluded (with references to the `ring` crate and a related Nix issue). References the rustc 'Relink, don't Rebuild' project goal. No code changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3bc40fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->