### PR TITLE
feat(nix-output-monitor): parse content-addressed derivations

### DIFF
--- a/packages/nix-output-monitor/ca-empty-output-path.patch
+++ b/packages/nix-output-monitor/ca-empty-output-path.patch
@@ -1,0 +1,17 @@
+diff --git a/src/Nix/Derivation/Parser.hs b/src/Nix/Derivation/Parser.hs
+index 3aac359..f92e807 100644
+--- a/src/Nix/Derivation/Parser.hs
++++ b/src/Nix/Derivation/Parser.hs
+@@ -136,6 +136,12 @@ filepathParser = do
+     text <- textParser
+     let str = Data.Text.unpack text
+     case (Data.Text.uncons text, System.FilePath.isValid str) of
++        -- An empty path is a floating content-addressed or deferred output
++        -- (`("out","","r:sha256","")` / `("out","","","")`); the store path is
++        -- only assigned after realisation. Accept it instead of failing so
++        -- consumers can parse CA derivations. https://github.com/Gabriella439/Haskell-Nix-Derivation-Library/issues/28
++        (Nothing, _) -> do
++            return str
+         (Just ('/', _), True) -> do
+             return str
+         _ -> do

--- a/packages/nix-output-monitor/default.nix
+++ b/packages/nix-output-monitor/default.nix
@@ -1,0 +1,70 @@
+{
+  pkgs,
+}:
+let
+  inherit (pkgs.haskell.lib) compose;
+
+  # `nom build` reads every .drv with the `nix-derivation` Haskell library. Its
+  # 1.1.3 parser runs each output path through `filepathParser`, which fails on
+  # an empty string, but a floating content-addressed (or deferred) output is
+  # exactly `("out","","r:sha256","")` with an empty path. So nom spams
+  # `DerivationParseError "string"` (attoparsec's `string` combinator failing on
+  # the next `]`/`,` literal after the output parser backtracks) and renders no
+  # dependency graph for CA derivations, which the index repo builds heavily.
+  #
+  # The patch keeps the single-constructor `DerivationOutput` record and only
+  # widens `filepathParser` to accept an empty path. nom is then unchanged:
+  # `insertDerivation` calls `parseStorePath ""`, which returns `Nothing`, so the
+  # still-unrealised floating output is dropped via `traverseMaybeWithKey`
+  # instead of crashing on a partial field selector. This is deliberately
+  # smaller than upstream PR #26, which turns `DerivationOutput` into a sum type
+  # and would force a matching nom source patch.
+  #
+  # nixpkgs builds nom as `haskellPackages.callPackage ./generated-package.nix`
+  # (top-level, not in the haskellPackages set), so feed the override through the
+  # top-level package's `haskellPackages` argument rather than rebuilding the
+  # by-name pipeline (postInstall symlinks, completions) here.
+  #
+  # Upstream: https://github.com/maralorn/nix-output-monitor/issues/122
+  #           https://github.com/Gabriella439/Haskell-Nix-Derivation-Library/issues/28
+  haskellPackages = pkgs.haskellPackages.extend (
+    _hfinal: hprev: {
+      nix-derivation = compose.appendPatch ./ca-empty-output-path.patch hprev.nix-derivation;
+    }
+  );
+
+  package = pkgs.nix-output-monitor.override { inherit haskellPackages; };
+
+  # The override's real risk is the Haskell rebuild linking at all, so the smoke
+  # test runs the binary. `nom --help` exits 0 and prints usage without spawning
+  # `nix` (`--version` shells out to `nix`, absent in the sandbox).
+  smoke =
+    pkgs.runCommand "nix-output-monitor-smoke"
+      {
+        nativeBuildInputs = [ package ];
+        strictDeps = true;
+      }
+      ''
+        help=$(nom --help 2>&1) || true
+        case "$help" in
+          *"nix-output-monitor usages"*) ;;
+          *)
+            echo "nom --help did not print usage" >&2
+            printf '%s\n' "$help" >&2
+            exit 1
+            ;;
+        esac
+        mkdir -p "$out"
+      '';
+in
+package.overrideAttrs (old: {
+  passthru = (old.passthru or { }) // {
+    tests = {
+      inherit smoke;
+    };
+  };
+  meta = (old.meta or { }) // {
+    description = "nix-output-monitor with nix-derivation patched to parse content-addressed derivations";
+    mainProgram = "nom";
+  };
+})

--- a/packages/nix-output-monitor/package.nix
+++ b/packages/nix-output-monitor/package.nix
@@ -1,0 +1,6 @@
+{
+  id = "nix-output-monitor";
+  packageSet = true;
+  flake = true;
+  passthruTests = true;
+}


### PR DESCRIPTION
`nom build` spams `DerivationParseError "string"` on the repo's content-addressed (cargo-unit) crates. Root cause is the `nix-derivation` Haskell lib, not nom: its `filepathParser` rejects the empty output path in a floating CA output `("out","","r:sha256","")`.

This adds `packages/nix-output-monitor` that patches `nix-derivation` to accept empty output paths (keeps the single-constructor record), via `pkgs.nix-output-monitor.override { haskellPackages = patched }`. nom stays unpatched and drops the still-unrealised floating output through `parseStorePath` instead of crashing. Deliberately smaller than upstream PR #26 (sum type), which would force a matching nom source patch.

Validated: patched nom builds `.#dashboard` (CA crates loro/dashboard_core/etc.) and renders the full dependency graph with 0 `DerivationParseError`.

Refs maralorn/nix-output-monitor#122, Gabriella439/Haskell-Nix-Derivation-Library#28

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add nix-output-monitor package with content-addressed derivation support
> - Adds a new `nix-output-monitor` package definition in [default.nix](https://github.com/indexable-inc/index/pull/620/files#diff-1b6e4ac78a441c6ab48d0470e561011419e490b209868907e0622ac69673eafd) that builds `nom` with a patched `nix-derivation` dependency and exposes a smoke test that runs `nom --help`.
> - Patches `filepathParser` in `nix-derivation` via [ca-empty-output-path.patch](https://github.com/indexable-inc/index/pull/620/files#diff-5ff234d5105dcda32b99c3192ebc024122c513ed6614398c667d78e6ac90e8c3) to accept empty output paths, enabling parsing of content-addressed derivations that omit the output path.
> - Adds [package.nix](https://github.com/indexable-inc/index/pull/620/files#diff-0d0b28d505c3085ccccc50edfe5cd67c1039e45d06cd8b05bf9afc701e36bbf3) metadata marking the package as a flake-based package set entry with passthru tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3fd604f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->