### PR TITLE
dashboard feed: newest at bottom, red-only dots

### DIFF
--- a/packages/dashboard-core/site/src/components/FeedView.svelte
+++ b/packages/dashboard-core/site/src/components/FeedView.svelte
@@ -8,7 +8,8 @@
   import InlineTrace from './InlineTrace.svelte';
   import type { Pane } from '$lib/types';
 
-  // The feed: a chronological timeline of panes, newest first. Each block puts the
+  // The feed: a chronological timeline of panes, oldest first (newest at the
+  // bottom, so it reads as a live log growing downward). Each block puts the
   // input on the left and its execution/output on the right — for an exec that is
   // source | output. The output is the larger, fuller column; the code is the
   // supporting one. Each block leads with the pane title, which for an exec is the
@@ -87,7 +88,9 @@
     showCode[key] = !showCode[key];
   }
 
-  // Panes newest-first. created_at is the stamp; ties break by key for stability.
+  // Panes oldest-first, so the newest run lands at the bottom and the list reads
+  // as a live log that grows downward. created_at is the stamp; ties break by key
+  // for stability.
   const items = $derived(
     Object.keys(store.panes)
       .map((key) => {
@@ -97,7 +100,7 @@
       })
       .sort(
         (a, b) =>
-          (b.pane.created_at ?? 0) - (a.pane.created_at ?? 0) || (a.key < b.key ? -1 : 1),
+          (a.pane.created_at ?? 0) - (b.pane.created_at ?? 0) || (a.key < b.key ? -1 : 1),
       ),
   );
 
@@ -107,9 +110,19 @@
   let selectedKey: string | null = $state(null);
   const selected = $derived(items.find((it) => it.key === selectedKey) ?? null);
   $effect(() => {
-    // Keep the selection valid as panes come and go; default to the first row.
-    if (items.length === 0) selectedKey = null;
-    else if (!items.some((it) => it.key === selectedKey)) selectedKey = items[0].key;
+    // Keep the selection valid as panes come and go; default to the newest row
+    // (now the last, since the list grows downward) and scroll it into view.
+    if (items.length === 0) {
+      selectedKey = null;
+    } else if (!items.some((it) => it.key === selectedKey)) {
+      selectedKey = items[items.length - 1].key;
+      const key = selectedKey;
+      queueMicrotask(() =>
+        document
+          .querySelector(`li.entry[data-key="${CSS.escape(key)}"]`)
+          ?.scrollIntoView({ block: 'nearest' }),
+      );
+    }
   });
   function move(delta: number): void {
     if (!items.length) return;

--- a/packages/dashboard-core/site/src/style.css
+++ b/packages/dashboard-core/site/src/style.css
@@ -396,11 +396,13 @@ body {
 .entry.selected > .entry-row { background: light-dark(rgba(0, 0, 0, 0.08), rgba(255, 255, 255, 0.09)); }
 .entry.selected > .entry-row .entry-title { color: var(--ink); }
 
+/* Only failure (red) and the transient running pulse (amber) get a dot. Success
+   and idle panes show nothing — the rail threads them, so a green column of "fine"
+   doesn't compete with the few states that actually want the eye. */
 .entry-dot {
   grid-column: 1; align-self: center; justify-self: center; z-index: 1;
-  width: 9px; height: 9px; border-radius: 50%; background: var(--ink-faint);
+  width: 9px; height: 9px; border-radius: 50%; background: transparent;
 }
-.entry-dot.live { background: var(--live); }
 .entry-dot.err { background: var(--dead); }
 .entry-dot.run { background: light-dark(#d68a00, #e5c07b); animation: led-pulse 1.1s ease-in-out infinite; }
 


### PR DESCRIPTION
Two sidebar feed tweaks:

- **Newest at bottom**: feed now sorts oldest-first so it reads as a live log growing downward; the newest run is auto-selected and scrolled into view.
- **Red-only dots**: success/idle panes show no dot, only failures get the red dot (running keeps the amber pulse). A green column of "fine" no longer competes with the states that want the eye.

Verified in `?demo` via playwright: oldest at top, newest selected at bottom, single red dot on the failing run.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show feed items oldest-first with red-only status dots in dashboard
> - Reverses feed ordering in [FeedView.svelte](https://github.com/indexable-inc/index/pull/621/files#diff-78efb5ebd6c72ecf149c6db5f83d3226d1df16b5d517fd1f813afe1ad8c7587c) so the newest pane appears at the bottom, matching a log-style layout.
> - Auto-selection now targets the last (newest) item and scrolls it into view via `scrollIntoView({ block: 'nearest' })` using `queueMicrotask`.
> - Status dots in [style.css](https://github.com/indexable-inc/index/pull/621/files#diff-44e3e8358edb308d06622224230b9eb8d07683d2f280425d4ce181431cbd6566) are now visible only for error and running states; idle and live states no longer show a dot.
> - Behavioral Change: feed previously rendered newest-first; live dot is no longer displayed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4293353.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->