### PR TITLE
fix(cargo-unit): input-address test and benchmark units

### DIFF
--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -796,7 +796,19 @@ fn render_unit_derivation(
         &render_build_inputs(graph, prepared, index, unit_build_script_run(graph, index)),
     );
     attrs.bool("dontStrip", true);
-    append_content_addressing(&mut attrs, options.content_addressed);
+    // Content-address libraries and binaries -- that is where CA's "early
+    // cutoff" pays off: a byte-identical rebuild lets dependents skip rebuilding.
+    // Tests and benchmarks are leaf derivations that nothing consumes, so CA
+    // buys them no early cutoff; it only adds floating-realisation fragility. A
+    // stale or GC'd test realisation on a shared store resurfaces as a silent
+    // "build of resolved derivation '<...>-cargo-unit-test-manifest' failed: N
+    // dependencies failed" with no builder error (NixOS/nix#15649) -- exactly
+    // the failures seen on the shared CI store. Keep tests and benches
+    // input-addressed; they still benefit from upstream CA on their inputs.
+    let unit = &graph.units[index];
+    let content_addressed =
+        options.content_addressed && !unit.is_test() && !unit.is_benchmark();
+    append_content_addressing(&mut attrs, content_addressed);
     attrs.multiline(
         "buildPhase",
         &render_driver_build_phase(graph, options, prepared, index, driver)?,
@@ -4705,6 +4717,56 @@ version = "4.6.1"
 
         assert!(rendered.contains("__contentAddressed = true"));
         assert!(rendered.contains("outputHashMode = \"recursive\""));
+    }
+
+    #[test]
+    fn tests_stay_input_addressed_even_with_content_addressing() {
+        // Tests are leaf derivations nothing consumes, so they get no CA early
+        // cutoff, only floating-realisation fragility. They must stay
+        // input-addressed even when content_addressed is on (libraries remain
+        // CA -- see content_addressed_is_explicitly_opt_in).
+        let graph: UnitGraph = serde_json::from_str(
+            r#"{
+              "version": 1,
+              "units": [
+                {
+                  "pkg_id": "hello 0.1.0 (path+file:///workspace)",
+                  "target": {
+                    "kind": ["test"],
+                    "crate_types": ["bin"],
+                    "name": "hello",
+                    "src_path": "/workspace/src/lib.rs",
+                    "edition": "2024",
+                    "test": true
+                  },
+                  "profile": { "name": "test", "opt_level": "0" },
+                  "mode": "test",
+                  "dependencies": []
+                }
+              ],
+              "roots": [0]
+            }"#,
+        )
+        .unwrap();
+
+        let rendered = render_units_nix(
+            &graph,
+            &RenderOptions {
+                workspace_root: PathBuf::from("/workspace"),
+                vendor_root: None,
+                cargo_lock_sources: CargoLockSources::default(),
+                content_addressed: true,
+                toolchain_id: None,
+                deny_unused_crate_dependencies: false,
+                deny_panics: false,
+            },
+        )
+        .unwrap();
+
+        assert!(
+            !rendered.contains("__contentAddressed = true"),
+            "test units must be input-addressed even with content_addressed = true"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Content-address only libraries and binaries; keep **test and benchmark** derivations **input-addressed**, even when \`contentAddressed = true\`.

## Why

Tests/benches are leaf derivations — nothing consumes their output — so CA buys them **no early cutoff**. It only adds floating-realisation fragility. On the shared ix CI store, a stale/GC'd test realisation resurfaced as a **silent** failure:

```
error: build of resolved derivation '<...>-cargo-unit-test-manifest.drv' failed
       Reason: N dependencies failed.   # no builder error, no rustc output
```

This blocked the entire \`required-ci-checks\` build even though **every crate compiled fine** and a **direct** build of the manifest succeeded (RC 0) — i.e. CA itself works; the failure was realisation fragility (NixOS/nix#15649) on the CA *test* binaries the manifest aggregates. The failure count even varied run-to-run (2 → 1), the classic stale-state signature.

Libraries/binaries stay CA (rustc output is reproducible, and that's where early cutoff pays off). Tests/benches still benefit from upstream CA on their inputs.

## Test

`cargo test` passes (51); adds `tests_stay_input_addressed_even_with_content_addressing` and keeps `content_addressed_is_explicitly_opt_in` (libraries remain CA). End-to-end validation via the ix index-lock bump (#4141).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix test and benchmark units to render as input-addressed when content addressing is enabled
> In [render.rs](https://github.com/indexable-inc/index/pull/626/files#diff-da81bb79268fbaf52a96664faa4d392b9b83a48a4b3b54bb1c3a2a5f2f50f26a), `render_unit_derivation` now skips content addressing attributes for test and benchmark units, even when `options.content_addressed` is true. Only library and binary units receive `__contentAddressed` attributes. A new unit test verifies that a test unit rendered with `content_addressed = true` does not contain `__contentAddressed = true` in the output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9849e1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->