### PR TITLE
fix(nvim): exact status-tag strip + stop poll timer on buffer wipe

### DIFF
--- a/modules/profiles/base/nvim/plugins/agent.lua
+++ b/modules/profiles/base/nvim/plugins/agent.lua
@@ -21,7 +21,6 @@ do
   local ns = vim.api.nvim_create_namespace("claude_agent")
 
   local STATUS = { todo = "TODO", done = "DONE", fail = "FAIL" }
-  local STATUS_RE = "^%s*[TODOFAILDONE]+%s+"
 
   local SPINNER = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" }
 
@@ -45,7 +44,16 @@ do
   }
 
   local function strip_status(line)
-    return (line:gsub(STATUS_RE, ""))
+    -- Match an exact leading TODO/DONE/FAIL token, preserving indentation. A bare
+    -- char class like [TODOFAILDONE]+ also eats unrelated all-caps words (ADD,
+    -- NOTE, ...), corrupting the dispatched task, so check each literal tag.
+    for _, tag in ipairs({ STATUS.todo, STATUS.done, STATUS.fail }) do
+      local out, n = line:gsub("^(%s*)" .. tag .. "%s+", "%1")
+      if n > 0 then
+        return out
+      end
+    end
+    return line
   end
 
   local function task_dir(buf)
@@ -150,6 +158,10 @@ do
     rec.elapsed = 0
     rec.poll = vim.uv.new_timer()
     rec.poll:start(config.poll_ms, config.poll_ms, vim.schedule_wrap(function()
+      if not vim.api.nvim_buf_is_valid(rec.buf) then
+        finish(rec, "fail")
+        return
+      end
       rec.elapsed = rec.elapsed + config.poll_ms
       if rec.elapsed >= config.poll_timeout_ms then
         finish(rec, "todo", "⏱ poll timed out · " .. (rec.id or "?"))
@@ -360,6 +372,18 @@ do
       end)
     end)
   end
+
+  vim.api.nvim_create_autocmd({ "BufWipeout", "BufDelete" }, {
+    callback = function(ev)
+      for mark, rec in pairs(tasks) do
+        if rec.buf == ev.buf then
+          stop_timer(rec, "spinner")
+          stop_timer(rec, "poll")
+          tasks[mark] = nil
+        end
+      end
+    end,
+  })
 
   vim.keymap.set("n", "<leader>aa", dispatch, { desc = "Agent: dispatch current line" })
   vim.keymap.set("x", "<leader>aa", dispatch, { desc = "Agent: dispatch selection" })


### PR DESCRIPTION
Fixes the two review findings from PR #629.

- C1: strip_status used a Lua char class `[TODOFAILDONE]+`, which strips any leading all-caps word built from those letters (ADD, NOTE, ALL, ...), corrupting the dispatched task and the rewritten buffer line. Now strips only an exact leading TODO/DONE/FAIL token, preserving indentation.
- C2: the bg poll timer never stopped when the task's buffer was wiped, so it kept spawning `claude agents --json` for up to 30 min. Added a buffer-validity guard at the top of the poll callback and a BufWipeout/BufDelete autocmd that reaps tasks proactively.

(made with Claude / Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix status-tag stripping and stop poll timer on buffer wipe in nvim agent
> - Rewrites `strip_status` in [agent.lua](https://github.com/indexable-inc/index/pull/630/files#diff-8fa5084ba4771995ef78c0c200035e921fe30310e832392f9941ef5bbf94bccf) to only strip exact `TODO`, `DONE`, or `FAIL` tokens (followed by a space) from line starts, preserving indentation; previously any leading uppercase word was stripped.
> - Adds a validity guard in the poll timer callback that terminates the task with `fail` status if the associated buffer is no longer valid.
> - Adds a `BufWipeout`/`BufDelete` autocmd that stops spinner and poll timers and removes task entries when their buffer is wiped or deleted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a610f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->