### PR TITLE
feat(search-py): default agentic search on for the Python/MCP surface

### DIFF
--- a/packages/search-py/python/search/_search.pyi
+++ b/packages/search-py/python/search/_search.pyi
@@ -36,6 +36,7 @@ def semantic(
     user: list[str] | None = ...,
     host: list[str] | None = ...,
     project: list[str] | None = ...,
+    agentic: bool = ...,
 ) -> Awaitable[list[Hit]]: ...
 def grep(
     pattern: str,

--- a/packages/search-py/src/lib.rs
+++ b/packages/search-py/src/lib.rs
@@ -28,6 +28,12 @@ use search_core::{
 /// keys `path`, `score`, `start_line`, `num_lines`, `text`, and `source`. The
 /// scope selectors narrow the query server-side; `web` mixes in the hosted
 /// web-search store. No local checkout is read or indexed.
+///
+/// `agentic` defaults to `true`: the MCP `search` surface is interactive and
+/// recall matters more than latency there, so letting the backend plan and run
+/// multiple searches gives better results out of the box. Pass `agentic=False`
+/// for a single-shot query when speed beats recall. (The `search` CLI keeps it
+/// off by default for scripted, low-latency use.)
 #[pyfunction]
 #[pyo3(signature = (
     query,
@@ -42,6 +48,7 @@ use search_core::{
     user = None,
     host = None,
     project = None,
+    agentic = true,
 ))]
 #[allow(
     clippy::too_many_arguments,
@@ -61,14 +68,12 @@ fn semantic(
     user: Option<Vec<String>>,
     host: Option<Vec<String>>,
     project: Option<Vec<String>>,
+    agentic: bool,
 ) -> PyResult<Bound<'_, PyAny>> {
     let store_name = store.unwrap_or_else(|| DEFAULT_STORE.to_owned());
     let base = base_url.unwrap_or_else(|| mixedbread::DEFAULT_BASE_URL.to_owned());
     let filter = scope_filter(source, not_source, repo, user, host, project)?;
-    let options = SearchOptions {
-        rerank,
-        agentic: false,
-    };
+    let options = SearchOptions { rerank, agentic };
     // Keep every value the borrowed `search_core::semantic` call reads owned in
     // one frame, so the future handed to `future_into_py` stays `'static`.
     let args = SearchArgs {


### PR DESCRIPTION
The PyO3 binding hard-coded `agentic=false`, so the MCP `search` module had no way to turn on Mixedbread's multi-step retrieval. This adds an `agentic` arg (plus `.pyi` stub) defaulting to **true**.

Rationale: the MCP `search` surface is interactive, where recall matters more than latency, so letting the backend plan and run multiple searches is the better default. Pass `agentic=False` for a single-shot query. The `search` CLI keeps it off by default for scripted, low-latency use.

Validated: `nix build .#mcp` (compiles the `search_py` cdylib) green on aarch64-darwin.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default agentic search to `true` in the Python/MCP `semantic` binding
> Adds an `agentic` parameter to the Python-exposed `semantic` function in [`lib.rs`](https://github.com/indexable-inc/index/pull/631/files#diff-decd2c9fed8a6ce98d85cdd74436ec724d1685800944cba1f275453213c6fc4b), replacing the previously hardcoded `SearchOptions { agentic: false }`. The parameter defaults to `true`, so all Python and MCP callers now run in agentic mode unless explicitly opted out.
>
> Behavioral Change: existing callers that relied on agentic mode being off will now run agentic searches by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 528c8cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->