### PR TITLE
feat(skill-lint): Rust skill linter with real YAML frontmatter parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5539,6 +5539,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5642,6 +5655,18 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "skill-lint"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ignore",
+ "serde",
+ "serde_json",
+ "serde_norway",
 ]
 
 [[package]]
@@ -7051,6 +7076,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
   "packages/search-core",
   "packages/source/meta",
   "packages/search-py",
+  "packages/skill-lint",
   "packages/source/slack",
   "packages/sink/mixedbread",
   "packages/sink/parquet",
@@ -171,6 +172,7 @@ search-core = { path = "packages/search-core" }
 source-meta = { path = "packages/source/meta" }
 serde = "1"
 serde_json = "1"
+serde_norway = "0.9"
 sha2 = "0.10"
 similar = "2"
 source-slack = { path = "packages/source/slack" }

--- a/packages/skill-lint/Cargo.toml
+++ b/packages/skill-lint/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "skill-lint"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+ignore.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_norway.workspace = true

--- a/packages/skill-lint/default.nix
+++ b/packages/skill-lint/default.nix
@@ -1,0 +1,10 @@
+{ ix, lib, ... }:
+
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "skill-lint";
+  meta = {
+    description = "Lint and autofix SKILL.md files with real YAML frontmatter parsing";
+    license = lib.licenses.mit;
+    mainProgram = "skill-lint";
+  };
+}

--- a/packages/skill-lint/package.nix
+++ b/packages/skill-lint/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "skill-lint";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/skill-lint/src/fix.rs
+++ b/packages/skill-lint/src/fix.rs
@@ -1,0 +1,160 @@
+//! Pure safe autofixes for SKILL.md. Each fix is conservative: it never tries
+//! to repair malformed YAML (that is reported as a lint error instead), and it
+//! never rewrites a file whose frontmatter fails to parse.
+
+use std::path::Path;
+
+/// What a fix pass produced for one file.
+pub struct FixOutcome {
+    /// New file contents, or `None` when the file must be left untouched
+    /// (frontmatter missing or unparseable).
+    pub contents: Option<String>,
+    /// Human-readable descriptions of each change applied.
+    pub changes: Vec<String>,
+}
+
+/// Apply safe autofixes to a SKILL.md's contents. Pure: no IO.
+pub fn fix_skill(path: &Path, contents: &str) -> FixOutcome {
+    // Refuse to touch a file with missing or unparseable frontmatter; surface
+    // it through the linter instead so we never corrupt a broken document.
+    let Some((yaml, yaml_is_mapping)) = parse_frontmatter(contents) else {
+        return FixOutcome {
+            contents: None,
+            changes: Vec::new(),
+        };
+    };
+    if !yaml_is_mapping {
+        return FixOutcome {
+            contents: None,
+            changes: Vec::new(),
+        };
+    }
+
+    let mut changes = Vec::new();
+    let mut result = contents.to_owned();
+
+    if !yaml.contains_key("name")
+        && let Some(dir) = parent_dir_name(path)
+    {
+        result = insert_name(&result, dir);
+        changes.push(format!("inserted `name: {dir}`"));
+    }
+
+    let normalized = normalize_whitespace(&result);
+    if normalized != result {
+        changes.push("stripped trailing whitespace / fixed trailing newline".to_owned());
+        result = normalized;
+    }
+
+    FixOutcome {
+        contents: (result != contents).then_some(result),
+        changes,
+    }
+}
+
+/// Parse the frontmatter block; returns the mapping (for key lookups) and
+/// whether it was a mapping. `None` means no usable frontmatter.
+fn parse_frontmatter(contents: &str) -> Option<(serde_norway::Mapping, bool)> {
+    let yaml = frontmatter_block(contents)?;
+    let value: serde_norway::Value = serde_norway::from_str(yaml).ok()?;
+    match value {
+        serde_norway::Value::Mapping(mapping) => Some((mapping, true)),
+        _ => Some((serde_norway::Mapping::new(), false)),
+    }
+}
+
+/// Borrow the YAML text between leading `---` delimiters, if present.
+fn frontmatter_block(contents: &str) -> Option<&str> {
+    let mut lines = contents.lines();
+    if lines.next()?.trim_end() != "---" {
+        return None;
+    }
+    let after_open = contents.split_once('\n')?.1;
+    let mut offset = 0usize;
+    for line in after_open.lines() {
+        if line.trim_end() == "---" {
+            return Some(&after_open[..offset]);
+        }
+        offset += line.len() + 1;
+    }
+    None
+}
+
+/// Insert a `name:` line as the first frontmatter field (right after the
+/// opening `---`).
+fn insert_name(contents: &str, dir: &str) -> String {
+    match contents.split_once('\n') {
+        Some((first, rest)) => format!("{first}\nname: {dir}\n{rest}"),
+        None => contents.to_owned(),
+    }
+}
+
+/// Strip trailing whitespace from every line, drop trailing blank lines, and
+/// ensure the file ends with exactly one newline.
+fn normalize_whitespace(contents: &str) -> String {
+    let mut lines: Vec<&str> = contents.lines().map(str::trim_end).collect();
+    // Collapse a run of trailing blank lines so EOF carries a single newline.
+    while lines.last().is_some_and(|line| line.is_empty()) {
+        lines.pop();
+    }
+    if lines.is_empty() {
+        return String::new();
+    }
+    let mut out = lines.join("\n");
+    out.push('\n');
+    out
+}
+
+/// Helper mirroring the linter's directory-name lookup.
+fn parent_dir_name(path: &Path) -> Option<&str> {
+    path.parent()?.file_name()?.to_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lint::{Severity, lint_skill};
+
+    fn skill_path() -> std::path::PathBuf {
+        std::path::PathBuf::from("/repo/skills/example/SKILL.md")
+    }
+
+    #[test]
+    fn inserts_missing_name_and_relint_is_clean() {
+        let contents = "---\ndescription: A description.\n---\nBody.\n";
+        let outcome = fix_skill(&skill_path(), contents);
+        let fixed = outcome.contents.expect("fix should rewrite the file");
+        assert!(fixed.contains("name: example"), "fixed:\n{fixed}");
+
+        let diagnostics = lint_skill(&skill_path(), &fixed);
+        assert!(
+            !diagnostics.iter().any(|d| d.severity == Severity::Error),
+            "re-lint should be clean, got {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn strips_trailing_whitespace_and_fixes_newline() {
+        let contents = "---\nname: example\ndescription: A description.\n---\nBody.   \n\n\n";
+        let outcome = fix_skill(&skill_path(), contents);
+        let fixed = outcome.contents.expect("fix should rewrite the file");
+        assert!(fixed.ends_with("Body.\n"), "fixed:\n{fixed:?}");
+        assert!(!fixed.contains("Body.   "), "fixed:\n{fixed:?}");
+    }
+
+    #[test]
+    fn refuses_to_touch_malformed_yaml() {
+        let contents =
+            "---\ndescription: it does not block: it launches more work\n---\nBody.\n";
+        let outcome = fix_skill(&skill_path(), contents);
+        assert!(outcome.contents.is_none(), "must not rewrite broken YAML");
+        assert!(outcome.changes.is_empty());
+    }
+
+    #[test]
+    fn clean_file_is_left_unchanged() {
+        let contents = "---\nname: example\ndescription: A description.\n---\nBody.\n";
+        let outcome = fix_skill(&skill_path(), contents);
+        assert!(outcome.contents.is_none(), "no change expected");
+    }
+}

--- a/packages/skill-lint/src/fix.rs
+++ b/packages/skill-lint/src/fix.rs
@@ -53,31 +53,15 @@ pub fn fix_skill(path: &Path, contents: &str) -> FixOutcome {
 }
 
 /// Parse the frontmatter block; returns the mapping (for key lookups) and
-/// whether it was a mapping. `None` means no usable frontmatter.
+/// whether it was a mapping. `None` means no usable frontmatter. Reuses the
+/// linter's splitter so fix and lint agree on what frontmatter is.
 fn parse_frontmatter(contents: &str) -> Option<(serde_norway::Mapping, bool)> {
-    let yaml = frontmatter_block(contents)?;
-    let value: serde_norway::Value = serde_norway::from_str(yaml).ok()?;
+    let frontmatter = crate::lint::split_frontmatter(contents)?;
+    let value: serde_norway::Value = serde_norway::from_str(frontmatter.yaml).ok()?;
     match value {
         serde_norway::Value::Mapping(mapping) => Some((mapping, true)),
         _ => Some((serde_norway::Mapping::new(), false)),
     }
-}
-
-/// Borrow the YAML text between leading `---` delimiters, if present.
-fn frontmatter_block(contents: &str) -> Option<&str> {
-    let mut lines = contents.lines();
-    if lines.next()?.trim_end() != "---" {
-        return None;
-    }
-    let after_open = contents.split_once('\n')?.1;
-    let mut offset = 0usize;
-    for line in after_open.lines() {
-        if line.trim_end() == "---" {
-            return Some(&after_open[..offset]);
-        }
-        offset += line.len() + 1;
-    }
-    None
 }
 
 /// Insert a `name:` line as the first frontmatter field (right after the

--- a/packages/skill-lint/src/lint.rs
+++ b/packages/skill-lint/src/lint.rs
@@ -1,0 +1,342 @@
+//! Pure SKILL.md analysis: no IO, no panics on bad input.
+//!
+//! The skillsaw Python tool we are replacing panicked whenever a line-attached
+//! violation occurred, and reported malformed YAML opaquely. This core parses
+//! the frontmatter with a real YAML parser (`serde_norway`) and turns every
+//! failure into a [`Diagnostic`] rather than an abort.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+/// Description longer than this many characters is flagged. Skills are injected
+/// into the model context verbatim, so an overlong description is wasted budget.
+pub const DESCRIPTION_MAX_CHARS: usize = 1024;
+
+/// Whole-file estimated-token ceiling. We approximate tokens as `len / 4`, the
+/// rough bytes-per-token ratio for English/Markdown, to avoid pulling in a
+/// tokenizer dependency for a soft budget warning.
+pub const FILE_TOKEN_BUDGET: usize = 3000;
+
+/// Bytes-per-token divisor for the rough estimate above.
+const BYTES_PER_TOKEN: usize = 4;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Error,
+    Warning,
+    // `Info` is intentionally omitted: no rule emits it today, and the
+    // workspace denies dead-code, so an unused variant would fail the build.
+    // Add it back alongside the first informational rule that needs it.
+}
+
+impl Severity {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warning => "warning",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub path: String,
+    /// 1-based line number when the diagnostic points at a specific line.
+    pub line: Option<usize>,
+    pub rule_id: String,
+    pub message: String,
+}
+
+impl Diagnostic {
+    fn new(
+        severity: Severity,
+        path: &str,
+        line: Option<usize>,
+        rule_id: &str,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            severity,
+            path: path.to_owned(),
+            line,
+            rule_id: rule_id.to_owned(),
+            message: message.into(),
+        }
+    }
+
+    /// Human-readable single line: `severity path:line rule_id: message`.
+    pub fn render(&self) -> String {
+        let location = self
+            .line
+            .map_or_else(|| self.path.clone(), |line| format!("{}:{line}", self.path));
+        format!(
+            "{} {location} {}: {}",
+            self.severity.label(),
+            self.rule_id,
+            self.message
+        )
+    }
+}
+
+/// Result of splitting leading frontmatter from the body.
+struct Frontmatter<'a> {
+    /// YAML text between the delimiters.
+    yaml: &'a str,
+    /// 1-based line where the YAML block starts (the line after the opening
+    /// `---`). Used to offset parser line numbers back to file lines.
+    yaml_start_line: usize,
+}
+
+/// Split a leading `---` … `---` frontmatter block. Returns `None` when the
+/// file does not begin with a frontmatter delimiter or has no closing one.
+fn split_frontmatter(contents: &str) -> Option<Frontmatter<'_>> {
+    let mut lines = contents.lines();
+    // A leading delimiter must be the very first line (bare `---`).
+    if lines.next()?.trim_end() != "---" {
+        return None;
+    }
+
+    // Find the closing delimiter and the byte span of the YAML block.
+    let after_open = contents.split_once('\n')?.1;
+    let mut offset = 0usize;
+    for line in after_open.lines() {
+        if line.trim_end() == "---" {
+            return Some(Frontmatter {
+                yaml: &after_open[..offset],
+                // File line 1 = opening `---`; YAML block begins on file line 2.
+                yaml_start_line: 2,
+            });
+        }
+        // Advance past this line plus its newline so the slice stays correct.
+        offset += line.len() + 1;
+    }
+    None
+}
+
+/// Lint a single SKILL.md given its path and contents. Pure: never reads the
+/// filesystem and never panics on malformed input.
+pub fn lint_skill(path: &Path, contents: &str) -> Vec<Diagnostic> {
+    let path_str = path.display().to_string();
+    let mut diagnostics = Vec::new();
+
+    let Some(frontmatter) = split_frontmatter(contents) else {
+        diagnostics.push(Diagnostic::new(
+            Severity::Error,
+            &path_str,
+            Some(1),
+            "skill-frontmatter",
+            "missing frontmatter (expected a leading `---` … `---` block)",
+        ));
+        return diagnostics;
+    };
+
+    // THE feature: a real YAML parse, with the parser's own message and a file
+    // line number, instead of skillsaw's opaque "malformed YAML" string. The
+    // motivating trigger is a `description:` value containing a bare `: `,
+    // which YAML reads as a nested mapping and breaks the document.
+    let value: serde_norway::Value = match serde_norway::from_str(frontmatter.yaml) {
+        Ok(value) => value,
+        Err(error) => {
+            // serde_norway line numbers are 1-based within the parsed block;
+            // offset back to the file by the block's start line.
+            let line = error
+                .location()
+                .map(|location| location.line() + frontmatter.yaml_start_line - 1);
+            diagnostics.push(Diagnostic::new(
+                Severity::Error,
+                &path_str,
+                line,
+                "skill-frontmatter",
+                format!("invalid YAML frontmatter: {error}"),
+            ));
+            return diagnostics;
+        }
+    };
+
+    let serde_norway::Value::Mapping(mapping) = &value else {
+        diagnostics.push(Diagnostic::new(
+            Severity::Error,
+            &path_str,
+            Some(frontmatter.yaml_start_line),
+            "skill-frontmatter",
+            "frontmatter must be a YAML mapping (key: value pairs)",
+        ));
+        return diagnostics;
+    };
+
+    let name = string_field(mapping, "name");
+    let description = string_field(mapping, "description");
+
+    if name.is_none_or(str::is_empty) {
+        diagnostics.push(Diagnostic::new(
+            Severity::Error,
+            &path_str,
+            None,
+            "skill-name",
+            "frontmatter is missing a non-empty `name` string",
+        ));
+    }
+
+    if description.is_none_or(str::is_empty) {
+        diagnostics.push(Diagnostic::new(
+            Severity::Error,
+            &path_str,
+            None,
+            "skill-description",
+            "frontmatter is missing a non-empty `description` string",
+        ));
+    }
+
+    if let (Some(name), Some(dir)) = (name, parent_dir_name(path))
+        && !name.is_empty()
+        && name != dir
+    {
+        diagnostics.push(Diagnostic::new(
+            Severity::Warning,
+            &path_str,
+            None,
+            "skill-name-matches-dir",
+            format!("`name` is \"{name}\" but the skill directory is \"{dir}\""),
+        ));
+    }
+
+    if let Some(description) = description {
+        let chars = description.chars().count();
+        if chars > DESCRIPTION_MAX_CHARS {
+            diagnostics.push(Diagnostic::new(
+                Severity::Warning,
+                &path_str,
+                None,
+                "skill-description-length",
+                format!(
+                    "description is {chars} chars, over the {DESCRIPTION_MAX_CHARS}-char threshold"
+                ),
+            ));
+        }
+    }
+
+    let estimated_tokens = contents.len() / BYTES_PER_TOKEN;
+    if estimated_tokens > FILE_TOKEN_BUDGET {
+        diagnostics.push(Diagnostic::new(
+            Severity::Warning,
+            &path_str,
+            None,
+            "skill-file-budget",
+            format!(
+                "file is ~{estimated_tokens} estimated tokens, over the {FILE_TOKEN_BUDGET}-token budget"
+            ),
+        ));
+    }
+
+    diagnostics
+}
+
+/// Read a mapping field as a borrowed string, ignoring non-string values.
+fn string_field<'a>(mapping: &'a serde_norway::Mapping, key: &str) -> Option<&'a str> {
+    mapping
+        .get(serde_norway::Value::String(key.to_owned()))
+        .and_then(serde_norway::Value::as_str)
+}
+
+/// Name of the directory that directly contains the SKILL.md.
+fn parent_dir_name(path: &Path) -> Option<&str> {
+    path.parent()?.file_name()?.to_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn skill_path() -> std::path::PathBuf {
+        std::path::PathBuf::from("/repo/skills/example/SKILL.md")
+    }
+
+    #[test]
+    fn valid_skill_has_no_diagnostics() {
+        let contents = "---\nname: example\ndescription: A short, valid description.\n---\nBody.\n";
+        let diagnostics = lint_skill(&skill_path(), contents);
+        assert!(diagnostics.is_empty(), "expected clean, got {diagnostics:?}");
+    }
+
+    #[test]
+    fn malformed_yaml_bare_colon_space_is_one_error_with_line() {
+        // The exact skillsaw trigger: a bare `: ` inside the description value
+        // makes YAML read a nested mapping and the document fails to parse.
+        let contents = concat!(
+            "---\n",
+            "name: example\n",
+            "description: it does not block: it launches more work\n",
+            "---\n",
+            "Body.\n",
+        );
+        let diagnostics = lint_skill(&skill_path(), contents);
+        assert_eq!(diagnostics.len(), 1, "got {diagnostics:?}");
+        let diagnostic = &diagnostics[0];
+        assert_eq!(diagnostic.severity, Severity::Error);
+        assert_eq!(diagnostic.rule_id, "skill-frontmatter");
+        assert!(diagnostic.line.is_some(), "expected a line number");
+        assert!(
+            diagnostic.message.contains("invalid YAML"),
+            "message: {}",
+            diagnostic.message
+        );
+    }
+
+    #[test]
+    fn missing_name_yields_skill_name_error() {
+        let contents = "---\ndescription: A description.\n---\nBody.\n";
+        let diagnostics = lint_skill(&skill_path(), contents);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.rule_id == "skill-name" && d.severity == Severity::Error),
+            "got {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn name_not_matching_dir_is_warning_only() {
+        let contents = "---\nname: other\ndescription: A description.\n---\nBody.\n";
+        let diagnostics = lint_skill(&skill_path(), contents);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.rule_id == "skill-name-matches-dir" && d.severity == Severity::Warning),
+            "got {diagnostics:?}"
+        );
+        assert!(
+            !diagnostics.iter().any(|d| d.severity == Severity::Error),
+            "no errors expected, got {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn overlong_description_is_warning_only() {
+        let long = "x".repeat(DESCRIPTION_MAX_CHARS + 1);
+        let contents = format!("---\nname: example\ndescription: {long}\n---\nBody.\n");
+        let diagnostics = lint_skill(&skill_path(), &contents);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.rule_id == "skill-description-length"
+                    && d.severity == Severity::Warning),
+            "got {diagnostics:?}"
+        );
+        assert!(
+            !diagnostics.iter().any(|d| d.severity == Severity::Error),
+            "no errors expected, got {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn missing_frontmatter_is_error() {
+        let contents = "Just a body, no frontmatter.\n";
+        let diagnostics = lint_skill(&skill_path(), contents);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule_id, "skill-frontmatter");
+        assert_eq!(diagnostics[0].severity, Severity::Error);
+    }
+}

--- a/packages/skill-lint/src/lint.rs
+++ b/packages/skill-lint/src/lint.rs
@@ -81,37 +81,45 @@ impl Diagnostic {
     }
 }
 
-/// Result of splitting leading frontmatter from the body.
-struct Frontmatter<'a> {
+/// Result of splitting leading frontmatter from the body. Shared with the fix
+/// path so both agree on exactly what counts as frontmatter.
+pub struct Frontmatter<'a> {
     /// YAML text between the delimiters.
-    yaml: &'a str,
+    pub yaml: &'a str,
     /// 1-based line where the YAML block starts (the line after the opening
     /// `---`). Used to offset parser line numbers back to file lines.
-    yaml_start_line: usize,
+    pub yaml_start_line: usize,
 }
 
 /// Split a leading `---` … `---` frontmatter block. Returns `None` when the
 /// file does not begin with a frontmatter delimiter or has no closing one.
-fn split_frontmatter(contents: &str) -> Option<Frontmatter<'_>> {
+///
+/// The YAML is sliced from the original string by tracking each line's byte
+/// span via `split_inclusive`, so the slice stays exact (no reconstruction of
+/// the terminator width that could drift on `\r\n`).
+pub fn split_frontmatter(contents: &str) -> Option<Frontmatter<'_>> {
     let mut lines = contents.lines();
     // A leading delimiter must be the very first line (bare `---`).
     if lines.next()?.trim_end() != "---" {
         return None;
     }
 
-    // Find the closing delimiter and the byte span of the YAML block.
-    let after_open = contents.split_once('\n')?.1;
+    // Byte offset just past the opening `---` line and its newline.
+    let yaml_begin = contents.find('\n')? + 1;
+    let rest = &contents[yaml_begin..];
+
+    // `split_inclusive` keeps each line's terminator, so the running offset is
+    // always an exact byte position into `rest`.
     let mut offset = 0usize;
-    for line in after_open.lines() {
-        if line.trim_end() == "---" {
+    for chunk in rest.split_inclusive('\n') {
+        if chunk.trim_end() == "---" {
             return Some(Frontmatter {
-                yaml: &after_open[..offset],
+                yaml: &rest[..offset],
                 // File line 1 = opening `---`; YAML block begins on file line 2.
                 yaml_start_line: 2,
             });
         }
-        // Advance past this line plus its newline so the slice stays correct.
-        offset += line.len() + 1;
+        offset += chunk.len();
     }
     None
 }

--- a/packages/skill-lint/src/main.rs
+++ b/packages/skill-lint/src/main.rs
@@ -1,0 +1,150 @@
+//! `skill-lint`: a non-panicking replacement for the `skillsaw` Python linter.
+//!
+//! It recursively finds every `SKILL.md` under a path, parses each file's
+//! frontmatter with a real YAML parser, and reports diagnostics. Unlike
+//! skillsaw it never panics on bad input and it surfaces the precise YAML
+//! parser error with a file line number.
+
+mod fix;
+mod lint;
+
+use std::{fs, path::Path, path::PathBuf, process::ExitCode};
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand, ValueEnum};
+use ignore::WalkBuilder;
+
+use crate::lint::{Diagnostic, Severity, lint_skill};
+
+const SKILL_FILE_NAME: &str = "SKILL.md";
+
+#[derive(Debug, Parser)]
+#[command(version, about = "Lint and autofix SKILL.md files")]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Subcommands>,
+
+    /// Path to lint (file or directory). Defaults to the current directory.
+    #[arg(default_value = ".")]
+    path: PathBuf,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = Format::Human)]
+    format: Format,
+}
+
+#[derive(Debug, Subcommand)]
+enum Subcommands {
+    /// Apply safe autofixes (insert missing `name`, normalize whitespace).
+    Fix {
+        /// Path to fix (file or directory). Defaults to the current directory.
+        #[arg(default_value = ".")]
+        path: PathBuf,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum Format {
+    Human,
+    Json,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let result = match cli.command {
+        Some(Subcommands::Fix { path }) => run_fix(&path),
+        None => run_lint(&cli.path, cli.format),
+    };
+
+    match result {
+        Ok(code) => code,
+        Err(error) => {
+            // Operational failures (unreadable path, etc.) are distinct from
+            // lint findings; report them and exit non-zero.
+            eprintln!("skill-lint: {error:#}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run_lint(path: &Path, format: Format) -> Result<ExitCode> {
+    let skills = find_skills(path)?;
+    let mut diagnostics = Vec::new();
+    for skill in &skills {
+        let contents = read_skill(skill)?;
+        diagnostics.extend(lint_skill(skill, &contents));
+    }
+
+    let errors = diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .count();
+    let warnings = diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Warning)
+        .count();
+
+    match format {
+        Format::Json => print_json(&diagnostics)?,
+        Format::Human => {
+            for diagnostic in &diagnostics {
+                println!("{}", diagnostic.render());
+            }
+            println!("Errors: {errors}  Warnings: {warnings}");
+        }
+    }
+
+    // Exit non-zero only on errors; warnings and info never fail the gate.
+    Ok(if errors > 0 {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    })
+}
+
+fn run_fix(path: &Path) -> Result<ExitCode> {
+    let skills = find_skills(path)?;
+    for skill in &skills {
+        let contents = read_skill(skill)?;
+        let outcome = fix::fix_skill(skill, &contents);
+        if let Some(fixed) = outcome.contents {
+            fs::write(skill, &fixed)
+                .with_context(|| format!("writing {}", skill.display()))?;
+            for change in &outcome.changes {
+                println!("fixed {}: {change}", skill.display());
+            }
+        }
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+fn print_json(diagnostics: &[Diagnostic]) -> Result<()> {
+    let json = serde_json::to_string_pretty(diagnostics).context("serializing diagnostics")?;
+    println!("{json}");
+    Ok(())
+}
+
+/// Find every `SKILL.md` under `path`. A single `SKILL.md` file path is
+/// accepted directly; a directory is walked gitignore-aware.
+fn find_skills(path: &Path) -> Result<Vec<PathBuf>> {
+    if path.is_file() {
+        return Ok(vec![path.to_path_buf()]);
+    }
+
+    let mut skills = Vec::new();
+    // `WalkBuilder` respects .gitignore, global ignores, and skips hidden dirs
+    // by default. Directories without a SKILL.md (submodule containers, source
+    // trees) are simply walked past since we only collect matching files.
+    for entry in WalkBuilder::new(path).build() {
+        let entry = entry.context("walking the skills tree")?;
+        if entry.file_name() == SKILL_FILE_NAME && entry.path().is_file() {
+            skills.push(entry.path().to_path_buf());
+        }
+    }
+    skills.sort();
+    Ok(skills)
+}
+
+fn read_skill(path: &Path) -> Result<String> {
+    fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))
+}


### PR DESCRIPTION
Replaces the `uvx skillsaw lint` gate with a small in-workspace Rust crate.

Fixes two skillsaw bugs:
- it panicked (`AttributeError: 'SkillBlock' object has no attribute 'file_line'`) on any line-attached violation, aborting the home-manager switch.
- it reported malformed frontmatter opaquely. `skill-lint` parses with a real YAML parser (serde_norway) and surfaces the file, 1-based line, and the parser's own message. The trigger is a `description:` with a bare colon-space.

Adds `packages/skill-lint` (binary + flake attr `skill-lint`), `lint` (default) and `fix` subcommands, `--format json`, and unit/integration tests wired via passthruTests. Pure `lint_skill`/`fix_skill` cores with thin IO wrappers.

Validated: `nix build .#skill-lint`, `.#skill-lint.passthru.tests.skill-lint-all` (10 pass), per-crate clippy + unused-deps clean, `nix run .#lint` green. Runs clean against the repo's own `skills/` (catches the existing ix SKILL.md malformed-YAML and two missing-name skills) without panicking.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `skill-lint` Rust binary to lint and autofix SKILL.md frontmatter
> - Introduces a new `skill-lint` binary crate in [packages/skill-lint](https://github.com/indexable-inc/index/pull/632/files#diff-3089ac2de6eaa23327f72c4b0b693cbdf27207ae2df45125645a1c712cc6263e) that discovers `SKILL.md` files (gitignore-aware) and validates their YAML frontmatter using `serde_norway`.
> - The linter reports structured diagnostics (errors and warnings) for missing/empty `name` and `description` fields, name/directory mismatches, overlong descriptions, and token budget overruns; output supports human-readable and JSON formats.
> - A `fix` subcommand auto-inserts a missing `name` field (derived from the parent directory) and normalizes trailing whitespace, refusing to modify files with absent or unparseable frontmatter.
> - The workspace [Cargo.toml](https://github.com/indexable-inc/index/pull/632/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) and [Nix](https://github.com/indexable-inc/index/pull/632/files#diff-04fdd1025d2456aff6c6bc5c20e63de5be2e5560578e9797ebb4f34f6620eabf) build files are updated to include the new package.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9db4242.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->