### PR TITLE
fix(skill-lint): preserve CRLF line endings in fix; add idempotency + CRLF tests

### DIFF
--- a/packages/skill-lint/src/fix.rs
+++ b/packages/skill-lint/src/fix.rs
@@ -74,8 +74,16 @@ fn insert_name(contents: &str, dir: &str) -> String {
 }
 
 /// Strip trailing whitespace from every line, drop trailing blank lines, and
-/// ensure the file ends with exactly one newline.
+/// ensure the file ends with exactly one newline. Preserves the file's existing
+/// dominant line ending so a CRLF-authored file is not silently rewritten to LF
+/// (a content-preservation violation); `str::lines()` drops `\r`, so we rejoin
+/// with the detected newline instead of a hardcoded `\n`.
 fn normalize_whitespace(contents: &str) -> String {
+    let newline = if contents.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
     let mut lines: Vec<&str> = contents.lines().map(str::trim_end).collect();
     // Collapse a run of trailing blank lines so EOF carries a single newline.
     while lines.last().is_some_and(|line| line.is_empty()) {
@@ -84,8 +92,8 @@ fn normalize_whitespace(contents: &str) -> String {
     if lines.is_empty() {
         return String::new();
     }
-    let mut out = lines.join("\n");
-    out.push('\n');
+    let mut out = lines.join(newline);
+    out.push_str(newline);
     out
 }
 
@@ -140,5 +148,69 @@ mod tests {
         let contents = "---\nname: example\ndescription: A description.\n---\nBody.\n";
         let outcome = fix_skill(&skill_path(), contents);
         assert!(outcome.contents.is_none(), "no change expected");
+    }
+
+    /// A clean CRLF-authored file must come back untouched: `str::lines()` strips
+    /// `\r`, so before the CRLF-preserving fix this silently rewrote the file to
+    /// LF. This is the regression test for that content-mutation bug.
+    #[test]
+    fn clean_crlf_file_is_left_unchanged() {
+        let contents = "---\r\nname: example\r\ndescription: A description.\r\n---\r\nBody.\r\n";
+        let outcome = fix_skill(&skill_path(), contents);
+        assert!(
+            outcome.contents.is_none(),
+            "clean CRLF file must not be rewritten, got {:?}",
+            outcome.contents
+        );
+        assert!(outcome.changes.is_empty());
+    }
+
+    /// A CRLF file that genuinely needs a fix keeps its CRLF endings rather than
+    /// being downgraded to LF.
+    #[test]
+    fn crlf_file_needing_fix_keeps_crlf() {
+        let contents =
+            "---\r\nname: example\r\ndescription: A description.\r\n---\r\nBody.   \r\n\r\n\r\n";
+        let outcome = fix_skill(&skill_path(), contents);
+        let fixed = outcome.contents.expect("fix should rewrite the file");
+        assert!(fixed.contains("\r\n"), "must keep CRLF, got {fixed:?}");
+        assert!(fixed.ends_with("Body.\r\n"), "fixed:\n{fixed:?}");
+        assert!(!fixed.contains("Body.   "), "fixed:\n{fixed:?}");
+    }
+
+    /// `fix` is idempotent: applying it to its own output yields no further
+    /// change across the full range of inputs it touches.
+    #[test]
+    fn fix_is_idempotent() {
+        let inputs = [
+            // clean LF
+            "---\nname: example\ndescription: A description.\n---\nBody.\n",
+            // missing name
+            "---\ndescription: A description.\n---\nBody.\n",
+            // trailing whitespace
+            "---\nname: example\ndescription: A description.\n---\nBody.   \n",
+            // no trailing newline
+            "---\nname: example\ndescription: A description.\n---\nBody.",
+            // clean CRLF
+            "---\r\nname: example\r\ndescription: A description.\r\n---\r\nBody.\r\n",
+            // CRLF needing a fix
+            "---\r\nname: example\r\ndescription: A description.\r\n---\r\nBody.   \r\n\r\n",
+        ];
+        for input in inputs {
+            let once = fix_skill(&skill_path(), input);
+            // Whatever the first pass produced, treat that as the current content.
+            let after_first = once.contents.clone().unwrap_or_else(|| input.to_owned());
+            let twice = fix_skill(&skill_path(), &after_first);
+            assert!(
+                twice.contents.is_none(),
+                "second fix must be a no-op for input {input:?}; got {:?}",
+                twice.contents
+            );
+            assert!(
+                twice.changes.is_empty(),
+                "second fix must report no changes for input {input:?}; got {:?}",
+                twice.changes
+            );
+        }
     }
 }

--- a/packages/skill-lint/src/main.rs
+++ b/packages/skill-lint/src/main.rs
@@ -135,6 +135,10 @@ fn find_skills(path: &Path) -> Result<Vec<PathBuf>> {
     // `WalkBuilder` respects .gitignore, global ignores, and skips hidden dirs
     // by default. Directories without a SKILL.md (submodule containers, source
     // trees) are simply walked past since we only collect matching files.
+    // Deliberate scope: we lint only tracked, non-hidden SKILL.md files
+    // (gitignore-respecting). All of index's skills live under tracked,
+    // non-hidden `skills/`, so an ignored/hidden SKILL.md is intentionally
+    // skipped, not an oversight.
     for entry in WalkBuilder::new(path).build() {
         let entry = entry.context("walking the skills tree")?;
         if entry.file_name() == SKILL_FILE_NAME && entry.path().is_file() {


### PR DESCRIPTION
Fixes the C1 content-mutation finding from the #632 review: `fix`'s `normalize_whitespace` used `str::lines()` then rejoined with `\n`, silently rewriting any CRLF-authored SKILL.md to LF on the first pass. Now it detects the dominant line ending once and preserves it, so a clean CRLF file comes back unchanged and a CRLF file needing fixes keeps CRLF.

Also adds `fix` idempotency tests across the input range and a clean-CRLF-unchanged regression test, plus a one-line comment documenting that the walk intentionally lints only tracked, non-hidden SKILL.md (gitignore-respecting).

Scope is only the fix.rs fix + doc comment + tests; not wiring skill-lint into CI and not touching the 3 flagged skills (separate follow-up).

(made with Claude / Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve CRLF line endings in `normalize_whitespace` and add idempotency tests
> - `normalize_whitespace` in [fix.rs](https://github.com/indexable-inc/index/pull/633/files#diff-9d45a2f64ef376a00ea26faa784c57db31af79c2de04220b9ecef6945fcb44aa) now detects the dominant line ending (CRLF vs LF) by scanning file contents and uses it for joins and the final trailing newline, instead of always writing LF.
> - Adds three new tests: a clean CRLF file that should not be rewritten, a CRLF file with trailing whitespace that should be fixed while keeping CRLF, and an idempotency check across LF and CRLF inputs.
> - Behavioral Change: files authored with CRLF will no longer be silently converted to LF on fix.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c465e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->