### PR TITLE
polars-mixedbread: a Polars IO source over Mixedbread search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4469,6 +4469,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "polars-mixedbread"
+version = "0.1.0"
+dependencies = [
+ "mixedbread",
+ "pyo3",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
   "packages/nix-web-monitor/parser",
   "packages/nix-web-monitor/server",
   "packages/oci-image-builder",
+  "packages/polars-mixedbread",
   "packages/progress-style",
   "packages/reel",
   "packages/repo-walker",

--- a/packages/mixedbread/src/filter.rs
+++ b/packages/mixedbread/src/filter.rs
@@ -8,18 +8,23 @@
 //! `/v1/stores/question-answering`, and the file-list endpoint, so one type
 //! serves them all.
 //!
-//! This type is serialize-only: the client sends filters but never parses them
-//! back. [`Filter`] is `#[serde(untagged)]` because a leaf and a group have
-//! disjoint key sets, so a serializer always emits the right shape.
+//! The client only ever sends filters, but the type is also `Deserialize` so a
+//! caller that hands the API a filter as JSON (e.g. the `polars-mixedbread`
+//! binding, which forwards a Python-built filter) parses it into this typed DSL
+//! rather than passing an unchecked blob. [`Filter`] is `#[serde(untagged)]`
+//! because a leaf and a group have disjoint key sets: a serializer always emits
+//! the right shape, and on the way back [`Condition`] is tried first while
+//! [`Group`] denies unknown fields, so a leaf deserializes as a condition and a
+//! mistyped one errors instead of silently collapsing to an empty group.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// A comparison operator on a metadata key.
 ///
 /// Serializes to the exact lowercase tokens the API expects (`eq`, `not_eq`,
 /// `gt`, ...). The variant set matches the SDK's `SearchFilterCondition`
 /// operator union, which is the source of truth (the prose docs omit a few).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Operator {
     /// Equal.
@@ -49,7 +54,8 @@ pub enum Operator {
 }
 
 /// A single leaf condition: a metadata `key` compared to `value` by `operator`.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Condition {
     /// Metadata key, dot-notated for nested fields (e.g. `generated_metadata.language`).
     pub key: String,
@@ -61,7 +67,8 @@ pub struct Condition {
 
 /// A logical group combining nested filters. Exactly one combinator is set in
 /// practice; all are optional so the wire shape carries only what is used.
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Group {
     /// All nested filters must match (AND).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -75,7 +82,7 @@ pub struct Group {
 }
 
 /// A metadata filter: either a leaf [`Condition`] or a nested [`Group`].
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Filter {
     /// A leaf comparison.
@@ -211,5 +218,35 @@ mod tests {
             value,
             serde_json::json!({ "none": [ { "key": "source", "operator": "eq", "value": "slack" } ] })
         );
+    }
+
+    #[test]
+    fn deserializes_nested_filter_back_to_the_same_wire_shape() {
+        // A caller (e.g. the polars-mixedbread binding) hands us a filter as JSON.
+        // It must round-trip: parse into the typed DSL, then re-serialize to the
+        // identical wire body the API expects. The untagged `Filter` resolves a
+        // leaf to `Condition` (tried first) and a combinator to `Group`.
+        let wire = serde_json::json!({
+            "all": [
+                { "key": "source", "operator": "eq", "value": "code" },
+                { "any": [
+                    { "key": "language", "operator": "in", "value": ["rust", "python"] },
+                    { "key": "priority", "operator": "gte", "value": 3 }
+                ] }
+            ]
+        });
+        let parsed: Filter = serde_json::from_value(wire.clone()).expect("deserialize");
+        assert!(matches!(parsed, Filter::Group(_)));
+        assert_eq!(serde_json::to_value(&parsed).expect("serialize"), wire);
+    }
+
+    #[test]
+    fn a_mistyped_condition_errors_rather_than_collapsing_to_an_empty_group() {
+        // `deny_unknown_fields` on `Group` is what makes this fail: without it the
+        // untagged enum would fall through to `Group`, ignore the stray keys, and
+        // silently send an empty (match-everything) filter. A bad operator must
+        // surface as an error instead.
+        let bad = serde_json::json!({ "key": "source", "operator": "nope", "value": "code" });
+        assert!(serde_json::from_value::<Filter>(bad).is_err());
     }
 }

--- a/packages/polars-mixedbread/Cargo.toml
+++ b/packages/polars-mixedbread/Cargo.toml
@@ -1,0 +1,28 @@
+# PyO3 binding for a Mixedbread-backed Polars source. This crate is deliberately
+# thin: it reuses the workspace `mixedbread` client (HTTP, retry, auth, and the
+# filter DSL) and hands results back to Python as plain columnar data. Polars
+# itself stays entirely on the Python side (`polars_mixedbread/__init__.py`),
+# where the runtime Polars lives, so there is no Rust<->Python Polars version
+# coupling and no `pyo3-polars` Arrow-FFI lockstep to maintain.
+[package]
+name = "polars-mixedbread"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "PyO3 binding behind scan_mixedbread: run a Mixedbread store search and return columnar rows to Polars"
+
+[lib]
+name = "polars_mixedbread"
+crate-type = ["cdylib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+mixedbread.workspace = true
+pyo3 = { workspace = true, features = ["extension-module"] }
+serde_json.workspace = true
+# `rt` + `net` + `time` is the minimum for a current-thread runtime with the IO
+# and timer drivers reqwest (in `mixedbread`) needs: the search call is async but
+# a Polars IO-source callback is synchronous, so we block on it here.
+tokio = { workspace = true, features = ["rt", "net", "time"] }

--- a/packages/polars-mixedbread/README.md
+++ b/packages/polars-mixedbread/README.md
@@ -1,0 +1,99 @@
+# polars-mixedbread
+
+A Polars IO source backed by [Mixedbread](https://www.mixedbread.com) store
+search. `scan_mixedbread(query, store=...)` returns a lazy `pl.LazyFrame` whose
+rows are the hits of one search, with file metadata flattened into typed columns,
+so you can do in Polars everything Mixedbread does not, above all `group_by`.
+
+```python
+import polars as pl
+from polars_mixedbread import scan_mixedbread
+
+lf = scan_mixedbread("how does retry backoff work", store="index", top_k=500)
+(
+    lf.filter(pl.col("source") == "code")  # pushed down to Mixedbread
+    .group_by("repo")                       # runs in Polars
+    .agg(pl.len(), pl.col("score").mean())
+    .sort("len", descending=True)
+    .collect()
+)
+```
+
+## One unified API: filter in Polars, push down to Mixedbread
+
+You filter with ordinary Polars expressions. The source parses the predicate and
+pushes the parts that map to a Mixedbread metadata filter (string `==`/`!=` on a
+metadata column, combined with `&` / `|` / `~`) server-side, so Mixedbread ranks
+a smaller, more relevant set. Anything else (a `score` threshold, `is_in`, a
+substring match) runs client-side in Polars.
+
+The full predicate is always re-applied locally, so every returned row satisfies
+it. But pushdown is not transparent, and that is the point of a search source: a
+pushed filter is applied by Mixedbread *before* ranking and `top_k`, so you get
+the `top_k` best hits *within* the filter. The same predicate written so it
+cannot push (`pl.col("source").is_in(["code"])` instead of `== "code"`) filters
+the `top_k` *after* ranking, so it can return a different set of rows. Both are
+correct (every row matches); they differ in which candidates were ranked. Keep
+filters in pushable form for the tightest relevance. `query` / `top_k` are not
+predicates; they parameterize the search itself.
+
+```python
+# `source == "code"` goes to the server; `score > 0.9` is applied in Polars:
+scan_mixedbread("auth", store="index", top_k=500).filter(
+    (pl.col("source") == "code") & (pl.col("score") > 0.9)
+)
+```
+
+## `top_k` is retrieval depth, not a row count
+
+`top_k` is how many ranked hits the search returns: think of the source as
+"`top_k` hits for `query`, as a table". It is not the final row count, and where
+it sits relative to a filter depends on whether the filter pushed down:
+
+- a **server-pushed** filter (string `==`/`!=`) is applied *before* `top_k`:
+  Mixedbread filters, ranks, then returns `top_k`, so you get up to `top_k` of
+  the filtered set (`filter(source=="code")` with `top_k=30` → 30 code rows).
+- a **client-side** filter is applied *after* `top_k`: it trims the table, so it
+  can leave fewer than `top_k` rows (`filter(score>0.8)` with `top_k=30` → 15).
+
+For a final row cap use Polars' own `.head(n)` / `.limit(n)` (applied last).
+`top_k` only controls how deep the search goes; raise it when a client-side
+filter is discarding too much of the window.
+
+## Columns
+
+`text` (str), `score` (f64), `filename` (str), `start_line` (u32), `num_lines`
+(u32), `metadata` (str, the raw JSON), plus one typed column per entry in
+`metadata_columns`. The default surfaces the keys the `index` store carries:
+`source`, `repo`, `path`, `title`. Point it at another store by passing the keys
+that store uses:
+
+```python
+scan_mixedbread("...", store="my-store",
+                metadata_columns={"author": pl.String, "year": pl.Int64})
+```
+
+Only string columns push down (string equality is unambiguous server-side); a
+non-string column still filters and groups, just in Polars. The raw `metadata`
+column is always present, so keys you did not declare stay reachable with
+`pl.col("metadata").str.json_decode()`.
+
+## Authentication
+
+Mirrors the `search` surface: `MXBAI_API_KEY` if set, otherwise the token
+written by `mgrep login`.
+
+## How it is built
+
+The Rust crate is a thin PyO3 binding that reuses the workspace `mixedbread`
+client (HTTP, retry, auth, and the filter DSL) and returns hits as plain columnar
+data. Flattening, predicate pushdown, projection, and the row limit live in the
+Python wrapper, where the runtime Polars is, so there is no Rust/Python Polars
+version coupling. Build the wheel with `nix build .#polars-mixedbread`.
+
+## Bad fit if
+
+You need a full table scan or store-wide aggregation. This is top-`k` retrieval:
+a `group_by` aggregates only the retrieved window, not the whole store. Raise
+`top_k` and lean on a pushed-down `filter` to keep that window relevant when you
+need wider coverage.

--- a/packages/polars-mixedbread/build.rs
+++ b/packages/polars-mixedbread/build.rs
@@ -1,0 +1,12 @@
+//! Emit the macOS-only `-undefined dynamic_lookup` link flag that `PyO3`
+//! extension modules need: macOS rejects undefined symbols in a dylib, while
+//! Linux allows them. `pyo3` does not emit it and the shared cargo-unit graph
+//! does not add it, so emit it here, scoped to the cdylib via the single-colon
+//! `rustc-cdylib-link-arg` directive that both `cargo` and `nix-cargo-unit`
+//! honor. This mirrors what search-py and tui-py do.
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-cdylib-link-arg=-undefined");
+        println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+    }
+}

--- a/packages/polars-mixedbread/default.nix
+++ b/packages/polars-mixedbread/default.nix
@@ -1,0 +1,118 @@
+{
+  ix,
+  lib,
+  pkgs ? ix.pkgs,
+}:
+let
+  pyproject = lib.importTOML ./pyproject.toml;
+  inherit (pyproject.project) version;
+
+  # The PyO3 cdylib is already built by the shared workspace unit graph (the same
+  # one mcp selects its binary from), so the wheel is just packaging: no maturin,
+  # no second compile.
+  library = ix.rustWorkspace.units.libraries.polars_mixedbread;
+
+  inherit (pkgs.stdenv.hostPlatform) isDarwin system;
+
+  # The wheel is consumed inside this nix env (the MCP Python session imports
+  # it), so it is not a portable manylinux/macosx wheel; the tag only has to name
+  # the host platform. On Linux we still strip the rpath/toolchain refs (cheap,
+  # keeps the closure honest); on darwin a dlopen'd module needs no install-name
+  # fixups, so the dylib ships as-is.
+  platformTag =
+    {
+      x86_64-linux = "manylinux_2_34_x86_64";
+      aarch64-linux = "manylinux_2_34_aarch64";
+      x86_64-darwin = "macosx_10_12_x86_64";
+      aarch64-darwin = "macosx_11_0_arm64";
+    }
+    .${system} or (throw "polars-mixedbread: unsupported system ${system}");
+
+  pythonSource = builtins.path {
+    name = "polars-mixedbread-python-source";
+    path = ./python;
+  };
+
+  wheel =
+    pkgs.runCommand "polars-mixedbread-wheel"
+      {
+        strictDeps = true;
+        nativeBuildInputs = [
+          pkgs.coreutils
+          pkgs.python3
+        ]
+        ++ lib.optionals (!isDarwin) [
+          pkgs.patchelf
+          pkgs.removeReferencesTo
+        ];
+        passthru = { inherit library; };
+        meta.description = "polars-mixedbread Python wheel (PyO3 IO source over Mixedbread search)";
+      }
+      ''
+        set -euo pipefail
+
+        cdylib=""
+        for candidate in \
+          ${library}/lib/libpolars_mixedbread.so \
+          ${library}/lib/libpolars_mixedbread-*.so \
+          ${library}/lib/libpolars_mixedbread.dylib \
+          ${library}/lib/libpolars_mixedbread-*.dylib
+        do
+          if [ -f "$candidate" ]; then
+            cdylib="$candidate"
+            break
+          fi
+        done
+        if [ -z "$cdylib" ]; then
+          echo "polars-mixedbread: no cdylib under ${library}/lib" >&2
+          ls -la ${library}/lib >&2 || true
+          exit 1
+        fi
+
+        sanitized="$TMPDIR/$(basename "$cdylib")"
+        cp "$cdylib" "$sanitized"
+        chmod u+w "$sanitized"
+
+        ${lib.optionalString (!isDarwin) ''
+          # Strip the build-time rpath and nixpkgs toolchain references so the wheel
+          # is not pinned to this store path.
+          if patchelf --print-rpath "$sanitized" >/dev/null 2>&1; then
+            patchelf --remove-rpath "$sanitized"
+          fi
+          remove-references-to \
+            -t ${pkgs.glibc} \
+            -t ${pkgs.stdenv.cc.cc.lib} \
+            "$sanitized"
+        ''}
+
+        mkdir -p "$out"
+        python3 ${./wheel/mkwheel.py} \
+          --cdylib "$sanitized" \
+          --python-src ${pythonSource} \
+          --version ${version} \
+          --platform-tag ${platformTag} \
+          --out "$out"
+      '';
+
+  # Predicate pushdown is the riskiest logic (a polarity bug here silently drops
+  # rows), and it is pure Python: it depends only on Polars, not the cdylib. So
+  # gate it with an offline test that loads the `_pushdown` module by path and
+  # asserts the superset invariant, no built wheel or network required.
+  pushdownTest =
+    pkgs.runCommand "polars-mixedbread-pushdown-test"
+      {
+        strictDeps = true;
+        nativeBuildInputs = [ (pkgs.python3.withPackages (ps: [ ps.polars ])) ];
+      }
+      ''
+        python3 ${./tests/test_pushdown.py} ${./python/polars_mixedbread/_pushdown.py}
+        mkdir -p "$out"
+      '';
+in
+wheel.overrideAttrs (old: {
+  passthru = (old.passthru or { }) // {
+    tests = (old.passthru.tests or { }) // {
+      pushdown = pushdownTest;
+    };
+  };
+})

--- a/packages/polars-mixedbread/package.nix
+++ b/packages/polars-mixedbread/package.nix
@@ -1,0 +1,17 @@
+{
+  id = "polars-mixedbread";
+  # The cdylib is built by the shared workspace unit graph (it reuses the
+  # `mixedbread` client crate), and default.nix only packages it into a wheel.
+  inRustWorkspace = true;
+  # Cross-platform unlike search-py/tui-py: the wheel is consumed inside the nix
+  # env (the MCP Python session imports it), not redistributed, so darwin needs
+  # no install-name fixups, and the cdylib links on macOS via build.rs. That lets
+  # `nix build .#polars-mixedbread` work on darwin for local validation.
+  flake = true;
+  packageSet = true;
+  # Gate the pure-Python predicate-pushdown test (default.nix passthru.tests) in
+  # CI as `checks.<system>.polars-mixedbread-pushdown`.
+  passthruTests = {
+    prefix = "polars-mixedbread";
+  };
+}

--- a/packages/polars-mixedbread/pyproject.toml
+++ b/packages/polars-mixedbread/pyproject.toml
@@ -1,0 +1,24 @@
+# Metadata only: the wheel is assembled by Nix (default.nix takes the cdylib the
+# shared workspace unit graph already built and wheel/mkwheel.py packages it),
+# not a PEP 517 backend. There is no [build-system]; build with
+# `nix build .#polars-mixedbread`.
+[project]
+name = "polars-mixedbread"
+version = "0.1.0"
+description = "Polars IO source backed by Mixedbread store search. Imported as polars_mixedbread; use scan_mixedbread()."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "Proprietary" }
+authors = [{ name = "indexable" }]
+classifiers = [
+  "License :: Other/Proprietary License",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Rust",
+]
+
+[tool.pyright]
+include = ["python"]
+pythonVersion = "3.11"
+typeCheckingMode = "strict"
+useLibraryCodeForTypes = false
+reportMissingModuleSource = "none"

--- a/packages/polars-mixedbread/python/polars_mixedbread/__init__.py
+++ b/packages/polars-mixedbread/python/polars_mixedbread/__init__.py
@@ -1,0 +1,179 @@
+"""A Polars IO source backed by Mixedbread store search.
+
+``scan_mixedbread(query, store=...)`` returns a lazy ``pl.LazyFrame`` whose rows
+are the hits of one Mixedbread search, with file metadata flattened into typed
+columns. It is registered through Polars' official IO-plugin hook
+(``register_io_source``), so it composes with the rest of a lazy query and, most
+importantly, lets you do in Polars everything Mixedbread does not, above all
+``group_by``.
+
+The point is a single, unified API: you filter with ordinary Polars expressions
+and the source pushes what it can down to Mixedbread for you.
+
+    import polars as pl
+    from polars_mixedbread import scan_mixedbread
+
+    lf = scan_mixedbread("how does retry backoff work", store="index", top_k=500)
+    (
+        lf.filter(pl.col("source") == "code")  # pushed down to Mixedbread
+        .group_by("repo")                       # runs in Polars
+        .agg(pl.len(), pl.col("score").mean())
+        .sort("len", descending=True)
+        .collect()
+    )
+
+Predicate pushdown: a ``.filter(...)`` you add is parsed, and the parts that map
+to a Mixedbread metadata filter (string ``==``/``!=`` on a metadata column,
+combined with ``&``/``|``/``~``) are sent server-side so Mixedbread ranks a
+smaller, more relevant set. Anything else (score thresholds, ``is_in``,
+substring matches) runs client-side in Polars. The full predicate is always
+re-applied locally, so every returned row satisfies it.
+
+Pushdown is not transparent, though, and that is the point of a search source: a
+pushed filter is applied by Mixedbread *before* ranking and ``top_k``, so you get
+the ``top_k`` best hits *within* the filter. The same predicate written so it
+cannot push (e.g. ``pl.col("source").is_in(["code"])`` instead of ``== "code"``)
+filters the ``top_k`` *after* ranking, so it can return a different set of rows.
+Both are correct (every row matches the predicate); they differ in which
+candidates were ranked. Keep filters in pushable form (string ``==``/``!=``) for
+the tightest relevance, and raise ``top_k`` if a client-side filter is discarding
+too much of the window.
+
+``query`` and ``top_k`` are not predicates: they parameterize the search itself.
+``top_k`` is *retrieval depth*, the number of ranked hits the search returns, so
+think of the source as "``top_k`` hits for ``query``, as a table". It is not a
+final row count:
+
+* a server-pushed filter is applied *before* ``top_k`` (Mixedbread filters, then
+  ranks, then returns ``top_k``), so you get up to ``top_k`` of the filtered set;
+* a client-side filter is applied *after* ``top_k``, so it trims the table and
+  can leave fewer than ``top_k`` rows.
+
+For a final row cap use Polars' own ``.head(n)`` / ``.limit(n)`` (applied last);
+``top_k`` only controls how deep the search goes. Raise ``top_k`` when a
+client-side filter is throwing away too much of the window.
+
+Columns: ``text`` (str), ``score`` (f64), ``filename`` (str), ``start_line``
+(u32), ``num_lines`` (u32), ``metadata`` (str, the raw JSON), plus one typed
+column per entry in ``metadata_columns`` (default: ``source``, ``repo``,
+``path``, ``title``, the keys the ``index`` store carries). Point it at another
+store by passing ``metadata_columns={...}`` for that store's keys. Only string
+columns push down; declare a non-string dtype and that column still filters and
+groups, just client-side.
+
+Authentication mirrors the ``search`` surface: ``MXBAI_API_KEY`` if set,
+otherwise the token written by ``mgrep login``.
+
+Known limitation: this is top-``k`` retrieval, not a full table scan. A
+``group_by`` aggregates only the retrieved window, not the whole store. Raise
+``top_k`` (a pushed-down ``filter`` keeps that window relevant) when you need
+wider coverage.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Iterator
+
+import polars as pl
+from polars.io.plugins import register_io_source
+
+from ._polars_mixedbread import __version__, search_mixedbread
+from ._pushdown import pushdown
+
+__all__ = ["__version__", "scan_mixedbread"]
+
+# Intrinsic columns every search returns, with the dtypes the Rust side produces.
+_INTRINSIC: dict[str, pl.DataType] = {
+    "text": pl.String(),
+    "score": pl.Float64(),
+    "filename": pl.String(),
+    "start_line": pl.UInt32(),
+    "num_lines": pl.UInt32(),
+    "metadata": pl.String(),
+}
+
+# Metadata keys the shared `index` store carries, surfaced as typed columns by
+# default so the headline `filter(pl.col("source") == ...)` works out of the box.
+# Override with `metadata_columns=` for a store with different keys.
+_DEFAULT_METADATA_COLUMNS: dict[str, pl.DataType] = {
+    "source": pl.String(),
+    "repo": pl.String(),
+    "path": pl.String(),
+    "title": pl.String(),
+}
+
+def scan_mixedbread(
+    query: str,
+    *,
+    store: str | list[str] = "index",
+    top_k: int = 10,
+    base_url: str | None = None,
+    rerank: bool = True,
+    agentic: bool = False,
+    score_threshold: float | None = None,
+    metadata_columns: dict[str, pl.DataType] | None = None,
+) -> pl.LazyFrame:
+    """Lazily scan one Mixedbread store search as a Polars ``LazyFrame``.
+
+    ``query`` parameterizes the search; ``top_k`` is the retrieval depth (how
+    many ranked hits the source returns, not a final row count, see the module
+    docstring). ``store`` is one store name or a list of them (default
+    ``"index"``). ``metadata_columns`` maps metadata keys to dtypes to surface as
+    typed columns (default: the ``index`` keys).
+    ``rerank``/``agentic``/``score_threshold`` tune retrieval.
+
+    Filter with ordinary Polars expressions; string equality on a metadata
+    column is pushed to Mixedbread and everything else runs in Polars. See the
+    module docstring.
+    """
+    stores = [store] if isinstance(store, str) else list(store)
+    meta_cols = _DEFAULT_METADATA_COLUMNS if metadata_columns is None else metadata_columns
+    schema = pl.Schema({**_INTRINSIC, **meta_cols})
+    # Only string columns are safe to push down (see `_pushdown.PUSHABLE_OPS`).
+    pushable = {name for name, dtype in meta_cols.items() if dtype == pl.String()}
+
+    def _source(
+        with_columns: list[str] | None,
+        predicate: pl.Expr | None,
+        n_rows: int | None,
+        batch_size: int | None,  # noqa: ARG001 - single-shot source ignores the hint
+    ) -> Iterator[pl.DataFrame]:
+        pushed = None if predicate is None else pushdown(predicate, pushable)
+        columns = search_mixedbread(
+            stores,
+            query,
+            top_k=top_k,
+            base_url=base_url,
+            rerank=rerank,
+            agentic=agentic,
+            score_threshold=score_threshold,
+            filters=None if pushed is None else json.dumps(pushed),
+        )
+        df = pl.DataFrame(columns, schema=_INTRINSIC)
+        # Flatten the declared metadata keys out of the JSON column into typed
+        # columns. A missing key reads back null; a non-string dtype is cast
+        # leniently so a bad value is null rather than an error.
+        if meta_cols:
+            df = df.with_columns(
+                _metadata_column(name, dtype) for name, dtype in meta_cols.items()
+            )
+        # The source owns predicate application: Polars does not re-apply it, so
+        # this is what makes a partial (or empty) pushdown correct.
+        if predicate is not None:
+            df = df.filter(predicate)
+        if with_columns is not None:
+            df = df.select(with_columns)
+        if n_rows is not None:
+            df = df.head(n_rows)
+        yield df
+
+    return register_io_source(_source, schema=schema)
+
+
+def _metadata_column(name: str, dtype: pl.DataType) -> pl.Expr:
+    """Extract metadata key ``name`` from the JSON ``metadata`` column as ``dtype``."""
+    expr = pl.col("metadata").str.json_path_match(f"$.{name}")
+    if dtype != pl.String():
+        expr = expr.cast(dtype, strict=False)
+    return expr.alias(name)

--- a/packages/polars-mixedbread/python/polars_mixedbread/_polars_mixedbread.pyi
+++ b/packages/polars-mixedbread/python/polars_mixedbread/_polars_mixedbread.pyi
@@ -1,0 +1,22 @@
+"""Type stub for the PyO3 extension module backing `polars_mixedbread`."""
+
+from typing import Any
+
+__version__: str
+
+def search_mixedbread(
+    stores: list[str],
+    query: str,
+    top_k: int = ...,
+    base_url: str | None = ...,
+    rerank: bool = ...,
+    agentic: bool = ...,
+    score_threshold: float | None = ...,
+    filters: str | None = ...,
+) -> dict[str, list[Any]]:
+    """Run a Mixedbread store search, returning a dict of the six source columns.
+
+    `filters` is the metadata filter as a JSON string. The wrapper
+    `scan_mixedbread` builds it from the Polars predicate; see that function.
+    """
+    ...

--- a/packages/polars-mixedbread/python/polars_mixedbread/_pushdown.py
+++ b/packages/polars-mixedbread/python/polars_mixedbread/_pushdown.py
@@ -1,0 +1,117 @@
+"""Translate a Polars predicate into a Mixedbread metadata filter.
+
+Kept separate from the package's ``__init__`` (which imports the compiled
+extension) so this pure logic, the part most worth testing, can be exercised
+with only Polars and no built cdylib (see ``tests/test_pushdown.py``).
+
+The translation is best-effort: an untranslatable node contributes no
+constraint, because the caller always re-applies the full predicate client-side.
+The hard invariant: the emitted filter F must be a *superset* of the predicate P
+(F keeps every row P keeps), since the client re-apply can only remove rows,
+never add them back. Negation is the trap: complementing a superset yields a
+*subset*, which would silently drop rows. So instead of emitting a ``none``
+group, ``_walk`` threads polarity and pushes negation down to the leaves via De
+Morgan (``And`` <-> ``Or``, ``eq`` <-> ``not_eq``). In a given polarity the rule
+is then simple: the "any"-shaped node must have both sides pushable (dropping one
+would narrow it), while the "all"-shaped node may drop unpushable sides (that
+only widens it). A ``None`` child means "no constraint" (match everything),
+always a safe superset.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import polars as pl
+
+# Polars comparison ops we can push to Mixedbread. Restricted to equality on its
+# own: string equality is unambiguous, so a server-side `eq`/`not_eq` can never
+# exclude a row the Polars predicate would keep (the failure mode that would lose
+# data, since the client re-apply cannot add rows back). Range ops would risk a
+# string-vs-number coercion mismatch server-side, so they stay client-side.
+PUSHABLE_OPS = {"Eq": "eq", "NotEq": "not_eq"}
+
+
+def pushdown(predicate: pl.Expr, pushable: set[str]) -> dict[str, Any] | None:
+    """Return a Mixedbread filter dict for the pushable part of ``predicate``.
+
+    ``pushable`` is the set of (string-typed) metadata column names that map 1:1
+    to Mixedbread metadata keys. Returns ``None`` when nothing pushes.
+    """
+    try:
+        ast = json.loads(predicate.meta.serialize(format="json"))
+        return _walk(ast, pushable, negated=False)
+    except Exception:
+        # The expression AST is a Polars-internal format; if it ever changes
+        # shape (an unexpected node, a missing field), degrade to no pushdown
+        # rather than break the query. Correctness still holds: the full
+        # predicate is re-applied client-side regardless.
+        return None
+
+
+def _walk(node: Any, pushable: set[str], *, negated: bool) -> dict[str, Any] | None:
+    if not isinstance(node, dict):
+        return None
+    if "BinaryExpr" in node:
+        binary = node["BinaryExpr"]
+        op = binary.get("op")
+        if op in ("And", "Or"):
+            # De Morgan: under negation And and Or swap.
+            conjunctive = (op == "And") != negated
+            left = _walk(binary["left"], pushable, negated=negated)
+            right = _walk(binary["right"], pushable, negated=negated)
+            if conjunctive:
+                # "all": a dropped (None) side only widens the result, so keep
+                # whatever pushed.
+                parts = [p for p in (left, right) if p is not None]
+                if not parts:
+                    return None
+                return parts[0] if len(parts) == 1 else {"all": parts}
+            # "any": dropping a side would narrow the result, so push only whole.
+            if left is None or right is None:
+                return None
+            return {"any": [left, right]}
+        if op in PUSHABLE_OPS:
+            return _condition(binary, op, pushable, negated=negated)
+        return None
+    if "Function" in node:
+        function = node["Function"]
+        if function.get("function") == {"Boolean": "Not"}:
+            return _walk(function["input"][0], pushable, negated=not negated)
+    return None
+
+
+def _condition(
+    binary: dict[str, Any], op: str, pushable: set[str], *, negated: bool
+) -> dict[str, Any] | None:
+    """Map a `col == lit` / `col != lit` leaf to a Mixedbread condition.
+
+    Under ``negated`` the operator is flipped (``eq`` <-> ``not_eq``), which is
+    exact for equality, so a negated leaf carries no approximation up the tree.
+    """
+    column = _column_name(binary["left"])
+    value = _string_literal(binary["right"])
+    if column is None:  # Polars usually puts the column on the left, but allow lit == col.
+        column = _column_name(binary["right"])
+        value = _string_literal(binary["left"])
+    if column not in pushable or value is None:
+        return None
+    operator = PUSHABLE_OPS[op]
+    if negated:
+        operator = "not_eq" if operator == "eq" else "eq"
+    return {"key": column, "operator": operator, "value": value}
+
+
+def _column_name(node: Any) -> str | None:
+    return node.get("Column") if isinstance(node, dict) else None
+
+
+def _string_literal(node: Any) -> str | None:
+    """The string value of a literal scalar node, or None if it is not a string."""
+    if isinstance(node, dict):
+        scalar = node.get("Literal", {}).get("Scalar") if "Literal" in node else None
+        if isinstance(scalar, dict) and "String" in scalar:
+            return scalar["String"]
+    return None

--- a/packages/polars-mixedbread/src/lib.rs
+++ b/packages/polars-mixedbread/src/lib.rs
@@ -1,0 +1,151 @@
+//! The Rust core behind `scan_mixedbread`: run one Mixedbread store search and
+//! hand the hits back to Python as plain columnar data.
+//!
+//! This is deliberately thin. All HTTP, retry, auth, and the metadata filter DSL
+//! live in the workspace [`mixedbread`] client; this module only blocks on the
+//! async search and converts the resulting [`mixedbread::Chunk`]s into a dict of
+//! column-name to list. Everything else, the lazy plumbing, the fixed schema,
+//! flattening metadata into columns, predicate pushdown, projection, and the row
+//! limit, lives in the Python wrapper (`polars_mixedbread/__init__.py`), because
+//! Polars' IO-plugin interface is Python by design.
+//!
+//! Polars never appears on the Rust side: the wrapper builds the `DataFrame` with
+//! the *runtime* Polars, so there is no Rust/Python Polars version coupling and
+//! no `pyo3-polars` Arrow-FFI lockstep to keep in sync (unlike `polars-sftp`,
+//! which decodes files in Rust and so must pin both).
+
+use mixedbread::{Client, SearchOptions, filter::Filter};
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+
+/// Run a Mixedbread store search and return its hits as a dict of column lists.
+///
+/// `stores` are store identifiers to search; `query` is the natural-language
+/// query; `top_k` caps hits. `filters` is the Mixedbread metadata filter as a
+/// JSON string (the recursive `{key, operator, value}` / `all`/`any`/`none`
+/// shape), pushed server-side; the wrapper builds it from the Polars predicate.
+/// Authentication mirrors the `search` surface: `MXBAI_API_KEY`, else the
+/// `mgrep login` token.
+///
+/// The returned dict always has the same six columns: `text`, `score`,
+/// `filename`, `start_line`, `num_lines`, `metadata` (the last a JSON string).
+/// Projection, the row limit, and flattening metadata into typed columns are the
+/// wrapper's job, so this stays a straight search-to-columns conversion.
+#[pyfunction]
+#[pyo3(signature = (
+    stores,
+    query,
+    top_k = 10,
+    base_url = None,
+    rerank = true,
+    agentic = false,
+    score_threshold = None,
+    filters = None,
+))]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "thin PyO3 binding mirrors scan_mixedbread's search + options surface"
+)]
+fn search_mixedbread(
+    py: Python<'_>,
+    stores: Vec<String>,
+    query: String,
+    top_k: usize,
+    base_url: Option<String>,
+    rerank: bool,
+    agentic: bool,
+    score_threshold: Option<f32>,
+    filters: Option<String>,
+) -> PyResult<Py<PyDict>> {
+    if stores.is_empty() {
+        return Err(PyValueError::new_err(
+            "polars-mixedbread: at least one store identifier is required",
+        ));
+    }
+    let base = base_url.unwrap_or_else(|| mixedbread::DEFAULT_BASE_URL.to_owned());
+    // Parse the caller's filter JSON into the typed owner DSL, so a malformed
+    // filter is a `ValueError` here rather than a silently-wrong query later.
+    let filter = filters
+        .map(|json| serde_json::from_str::<Filter>(&json))
+        .transpose()
+        .map_err(|error| {
+            PyValueError::new_err(format!("polars-mixedbread: invalid filters JSON: {error}"))
+        })?;
+    let options = SearchOptions {
+        rerank,
+        agentic,
+        score_threshold,
+        // Always ask for file metadata: the wrapper flattens it into columns, and
+        // group-by/filter on those columns is the whole point.
+        return_metadata: Some(true),
+    };
+
+    // Release the GIL for the blocking network round-trip: a current-thread
+    // runtime drives the async client to completion while other Python threads
+    // (and Polars' engine) keep running.
+    let chunks = py
+        .detach(|| {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|error| format!("build runtime: {error}"))?;
+            runtime.block_on(async {
+                let client = Client::from_login(base)
+                    .await
+                    .map_err(|error| format!("authenticate: {error}"))?;
+                client
+                    .search(&stores, &query, top_k, options, filter.as_ref())
+                    .await
+                    .map_err(|error| format!("search: {error}"))
+            })
+        })
+        .map_err(|error| PyRuntimeError::new_err(format!("polars-mixedbread: {error}")))?;
+
+    columns_to_dict(py, &chunks)
+}
+
+/// Build the `{column: [values...]}` dict with all six source columns.
+fn columns_to_dict(py: Python<'_>, chunks: &[mixedbread::Chunk]) -> PyResult<Py<PyDict>> {
+    let dict = PyDict::new(py);
+
+    let text: Vec<Option<&str>> = chunks.iter().map(|c| c.text.as_deref()).collect();
+    dict.set_item("text", PyList::new(py, text)?)?;
+
+    let score: Vec<f64> = chunks.iter().map(|c| f64::from(c.score)).collect();
+    dict.set_item("score", PyList::new(py, score)?)?;
+
+    let filename: Vec<Option<&str>> = chunks.iter().map(|c| c.filename.as_deref()).collect();
+    dict.set_item("filename", PyList::new(py, filename)?)?;
+
+    let start_line: Vec<Option<u32>> = chunks.iter().map(|c| c.start_line).collect();
+    dict.set_item("start_line", PyList::new(py, start_line)?)?;
+
+    // `Chunk::num_lines` is the API's `end_line - start_line` span, so an N-line
+    // chunk reports `N - 1`; expose a line *count* by adding one (the same
+    // normalization search-core applies), so a Polars consumer can sum it.
+    let num_lines: Vec<Option<u32>> = chunks
+        .iter()
+        .map(|c| c.num_lines.map(|span| span.saturating_add(1)))
+        .collect();
+    dict.set_item("num_lines", PyList::new(py, num_lines)?)?;
+
+    // Metadata is arbitrary nested JSON, so it crosses as a JSON string and the
+    // wrapper flattens the declared keys into typed columns (and leaves the rest
+    // queryable via `.str.json_decode()`), rather than guessing a struct schema
+    // that varies per store.
+    let metadata: Vec<Option<String>> = chunks
+        .iter()
+        .map(|c| c.metadata.as_ref().map(ToString::to_string))
+        .collect();
+    dict.set_item("metadata", PyList::new(py, metadata)?)?;
+
+    Ok(dict.unbind())
+}
+
+#[pymodule]
+fn _polars_mixedbread(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_function(wrap_pyfunction!(search_mixedbread, module)?)?;
+    module.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    Ok(())
+}

--- a/packages/polars-mixedbread/tests/test_pushdown.py
+++ b/packages/polars-mixedbread/tests/test_pushdown.py
@@ -1,0 +1,149 @@
+"""Offline, deterministic checks for predicate pushdown.
+
+Runnable as a plain script (``python tests/test_pushdown.py``) so the Nix build
+can exercise it with only Polars and no built extension. It loads the pure
+``_pushdown`` module by path (it never imports the ``polars_mixedbread`` package,
+which would pull in the compiled cdylib): pass the module path in
+``POLARS_MIXEDBREAD_PUSHDOWN`` or rely on the in-repo default.
+
+The point of these tests is the safety invariant the reviewer caught us
+violating once: the pushed-down filter must be a *superset* of the predicate, so
+that re-applying the full predicate client-side (which can only remove rows)
+yields exactly the predicate. The trap is negation over a partial subtree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import sys
+
+import polars as pl
+
+# Locate the pure `_pushdown` module: an explicit path (argv[1] or the
+# POLARS_MIXEDBREAD_PUSHDOWN env var) wins, else fall back to the in-repo layout
+# for a plain `python tests/test_pushdown.py` run from the package directory.
+_DEFAULT = pathlib.Path(__file__).resolve().parent.parent / "python" / "polars_mixedbread" / "_pushdown.py"
+_explicit = (sys.argv[1] if len(sys.argv) > 1 else None) or os.environ.get("POLARS_MIXEDBREAD_PUSHDOWN")
+_MODULE_PATH = pathlib.Path(_explicit) if _explicit else _DEFAULT
+
+_spec = importlib.util.spec_from_file_location("polars_mixedbread_pushdown", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None, f"cannot load {_MODULE_PATH}"
+_pushdown = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_pushdown)
+
+PUSHABLE = {"source", "repo", "path", "title"}
+
+
+def push(expr: pl.Expr) -> dict | None:
+    return _pushdown.pushdown(expr, PUSHABLE)
+
+
+def test_equality_pushes() -> None:
+    assert push(pl.col("source") == "code") == {"key": "source", "operator": "eq", "value": "code"}
+    assert push(pl.col("source") != "slack") == {
+        "key": "source",
+        "operator": "not_eq",
+        "value": "slack",
+    }
+
+
+def test_literal_on_left_is_handled() -> None:
+    # `"code" == col` should translate the same as `col == "code"`.
+    assert push(pl.lit("code") == pl.col("source")) == {
+        "key": "source",
+        "operator": "eq",
+        "value": "code",
+    }
+
+
+def test_and_keeps_pushable_conjuncts() -> None:
+    both = (pl.col("source") == "code") & (pl.col("repo") == "ix")
+    assert push(both) == {
+        "all": [
+            {"key": "source", "operator": "eq", "value": "code"},
+            {"key": "repo", "operator": "eq", "value": "ix"},
+        ]
+    }
+    # A non-pushable conjunct (a score range) only widens the server result, so
+    # the pushable side is still sent.
+    mixed = (pl.col("source") == "code") & (pl.col("score") > 0.9)
+    assert push(mixed) == {"key": "source", "operator": "eq", "value": "code"}
+
+
+def test_or_pushes_only_when_whole() -> None:
+    whole = (pl.col("source") == "code") | (pl.col("source") == "slack")
+    assert push(whole) == {
+        "any": [
+            {"key": "source", "operator": "eq", "value": "code"},
+            {"key": "source", "operator": "eq", "value": "slack"},
+        ]
+    }
+    # A partial Or would drop rows the predicate keeps, so it must not push.
+    partial = (pl.col("source") == "code") | (pl.col("score") > 0.9)
+    assert push(partial) is None
+
+
+def test_not_uses_de_morgan() -> None:
+    assert push(~(pl.col("source") == "code")) == {
+        "key": "source",
+        "operator": "not_eq",
+        "value": "code",
+    }
+    # ~(A | B) -> ~A AND ~B
+    assert push(~((pl.col("source") == "code") | (pl.col("repo") == "ix"))) == {
+        "all": [
+            {"key": "source", "operator": "not_eq", "value": "code"},
+            {"key": "repo", "operator": "not_eq", "value": "ix"},
+        ]
+    }
+    # ~(A & B) -> ~A OR ~B (both pushable here)
+    assert push(~((pl.col("source") == "code") & (pl.col("repo") == "ix"))) == {
+        "any": [
+            {"key": "source", "operator": "not_eq", "value": "code"},
+            {"key": "repo", "operator": "not_eq", "value": "ix"},
+        ]
+    }
+    assert push(~~(pl.col("source") == "code")) == {
+        "key": "source",
+        "operator": "eq",
+        "value": "code",
+    }
+
+
+def test_negation_of_partial_and_must_not_push() -> None:
+    # The regression: ~((source==code) & (score>0.5)) == (source!=code) OR (score<=0.5).
+    # The pushable side under negation becomes an Or branch (`source != code`),
+    # but the score branch cannot push, so the whole Or must collapse to no
+    # pushdown. Emitting `none[source==code]` here would tell the server to drop
+    # every source==code row, silently losing the kept (source==code, score<=0.5)
+    # rows that the client re-apply can never add back.
+    expr = ~((pl.col("source") == "code") & (pl.col("score") > 0.5))
+    assert push(expr) is None
+
+
+def test_non_pushable_predicates_return_none() -> None:
+    assert push(pl.col("score") > 0.9) is None  # not a metadata column
+    assert push(pl.col("source").is_in(["code", "slack"])) is None  # opaque list literal
+    assert push(pl.col("source").str.starts_with("co")) is None  # unsupported op
+    assert push(pl.col("source") == pl.col("repo")) is None  # column == column, no literal
+    assert push(pl.col("title") == "x") == {"key": "title", "operator": "eq", "value": "x"}
+
+
+def test_non_string_literal_does_not_push() -> None:
+    # A column declared/compared as non-string must not push (string-eq only),
+    # so an int/float/bool literal is left to the client.
+    assert push(pl.col("source") == 3) is None
+    assert push(pl.col("source") == True) is None  # noqa: E712 - exercising a bool literal
+
+
+def main() -> None:
+    tests = [v for name, v in sorted(globals().items()) if name.startswith("test_") and callable(v)]
+    for test in tests:
+        test()
+    print(f"ok: {len(tests)} pushdown tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/polars-mixedbread/wheel/mkwheel.py
+++ b/packages/polars-mixedbread/wheel/mkwheel.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Package a pre-built PyO3 cdylib plus the Python source into a PEP 427 wheel.
+
+Nix builds the `polars-mixedbread` cdylib through cargo-unit and calls this to
+assemble the wheel, so there is no maturin / PEP 517 backend in the loop. The
+extension is abi3 (`pyo3/abi3-py311`), hence the `cp311-abi3` tag: one wheel
+loads on CPython 3.11+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import pathlib
+import zipfile
+
+# Import package vs. PyPI distribution: `import polars_mixedbread`, and the wheel
+# and dist-info carry the same (already-normalized) distribution name.
+PKG = "polars_mixedbread"
+DIST = "polars_mixedbread"
+DIST_NAME = "polars-mixedbread"
+SO_NAME = "_polars_mixedbread.abi3.so"
+# Files copied verbatim from the Python source tree into the wheel.
+SOURCE_FILES = ["__init__.py", "_pushdown.py", "_polars_mixedbread.pyi", "py.typed"]
+
+
+def sha256_b64(data: bytes) -> str:
+    digest = hashlib.sha256(data).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def record_line(name: str, data: bytes) -> str:
+    return f"{name},sha256={sha256_b64(data)},{len(data)}"
+
+
+def build_wheel(
+    *,
+    cdylib: pathlib.Path,
+    python_src: pathlib.Path,
+    version: str,
+    platform_tag: str,
+    out: pathlib.Path,
+) -> pathlib.Path:
+    tag = f"cp311-abi3-{platform_tag}"
+    dist_info = f"{DIST}-{version}.dist-info"
+    wheel_path = out / f"{DIST}-{version}-{tag}.whl"
+
+    files: dict[str, bytes] = {}
+    for name in SOURCE_FILES:
+        files[f"{PKG}/{name}"] = (python_src / PKG / name).read_bytes()
+    files[f"{PKG}/{SO_NAME}"] = cdylib.read_bytes()
+
+    files[f"{dist_info}/METADATA"] = (
+        "Metadata-Version: 2.4\n"
+        f"Name: {DIST_NAME}\n"
+        f"Version: {version}\n"
+        "Summary: Polars IO source backed by Mixedbread store search. "
+        "Imported as `polars_mixedbread`.\n"
+        "Author: indexable\n"
+        "Requires-Python: >=3.11\n"
+        "Requires-Dist: polars\n"
+    ).encode()
+    files[f"{dist_info}/WHEEL"] = (
+        "Wheel-Version: 1.0\n"
+        "Generator: mkwheel\n"
+        "Root-Is-Purelib: false\n"
+        f"Tag: {tag}\n"
+    ).encode()
+
+    records = [record_line(name, data) for name, data in files.items()]
+    records.append(f"{dist_info}/RECORD,,")
+    files[f"{dist_info}/RECORD"] = "\n".join(records).encode() + b"\n"
+
+    out.mkdir(parents=True, exist_ok=True)
+    # Deterministic order *and* a fixed timestamp so the wheel is byte-for-byte
+    # reproducible: `writestr` with a bare name would stamp each entry with the
+    # current local time. 1980-01-01 is the zip epoch (the earliest a DOS-time
+    # field can encode).
+    with zipfile.ZipFile(wheel_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name in sorted(files):
+            info = zipfile.ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o644 << 16
+            zf.writestr(info, files[name])
+
+    return wheel_path
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--cdylib", type=pathlib.Path, required=True)
+    p.add_argument("--python-src", type=pathlib.Path, required=True)
+    p.add_argument("--version", default="0.1.0")
+    p.add_argument("--platform-tag", default="manylinux_2_34_x86_64")
+    p.add_argument("--out", type=pathlib.Path, required=True)
+    args = p.parse_args()
+
+    print(
+        build_wheel(
+            cdylib=args.cdylib,
+            python_src=args.python_src,
+            version=args.version,
+            platform_tag=args.platform_tag,
+            out=args.out,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `packages/polars-mixedbread`: a Polars IO source backed by Mixedbread store search. `scan_mixedbread(query, store=...)` returns a lazy `LazyFrame` with file metadata flattened into typed columns, so you can do in Polars everything Mixedbread doesn't, above all `group_by`.

```python
import polars as pl
from polars_mixedbread import scan_mixedbread

lf = scan_mixedbread("how does retry backoff work", store="index", top_k=500)
(lf.filter(pl.col("source") == "code")   # pushed down to Mixedbread
   .group_by("repo")                      # runs in Polars
   .agg(pl.len(), pl.col("score").mean())
   .collect())
```

## Predicate pushdown (one unified API)

No `filters=` arg: you filter with ordinary Polars expressions and the source pushes what it can down to Mixedbread. The IO-source callback parses Polars' pushed predicate (`predicate.meta.serialize` JSON AST) and translates the pushable part, string `==`/`!=` on a metadata column combined with `&`/`|`/`~`, into a Mixedbread metadata filter sent server-side. Everything else (`score` thresholds, `is_in`, substring) runs client-side in Polars.

Correctness: Polars does not re-apply an IO source's predicate, so the source always re-applies the full predicate client-side. Pushdown is therefore a best-effort optimization that only changes how much Mixedbread returns, never the answer. The invariant: the emitted filter must be a superset of the predicate (the client re-apply can only remove rows). Negation is the trap, so the translator threads polarity and pushes negation to the leaves via De Morgan (`eq`<->`not_eq`), never emitting a filter that excludes a row the predicate keeps. This is gated by an offline test, `checks.<system>.polars-mixedbread-pushdown`.

`top_k` is retrieval depth (the candidate pool entering Polars), not a final row count: server-pushed filters apply before it, client-side filters after it (so the result can be smaller). Use Polars `.head(n)`/`.limit(n)` for an output cap.

## Build

Thin PyO3 binding reusing the workspace `mixedbread` client (HTTP, retry, auth, filter DSL); returns columnar data. Flattening, pushdown, projection, and the row limit live in the Python wrapper where the runtime Polars is, so there's no Rust/Python Polars version coupling and no new crates.io deps. Adds `Deserialize` + `deny_unknown_fields` to the filter DSL so a filter JSON parses into the typed `Filter`. Wheel is byte-reproducible.

## Validated end-to-end on darwin against the live `index` store

- build, lint, schema (metadata flattened to `source`/`repo`/`path`/`title` columns)
- `filter(source=="code")` returns only `code` rows (server-side pushdown confirmed); `group_by("repo")`; mixed predicate (`==` pushed, `score>` client-side); De Morgan negation cases
- pushdown superset invariant unit-tested (CI); `mixedbread` filter `Deserialize` round-trip tested (CI)

cc @aamir-s18 (Mixedbread) since you starred the repo, in case a polars source is interesting on your end.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `polars-mixedbread` Polars IO source over Mixedbread search
> - Introduces a new `scan_mixedbread()` Python function that returns a Polars `LazyFrame` of Mixedbread search hits, with metadata keys materialized as typed columns.
> - Implements predicate pushdown in [_pushdown.py](https://github.com/indexable-inc/index/pull/634/files#diff-18889d8dcb151b9df4f0bd2f0dafde6ef7a59a11a8fc20fc637f0e41e06f0a08): translates Polars string equality/inequality predicates and boolean combinations into Mixedbread filter JSON, falling back to client-side filtering when pushdown is unsafe.
> - Adds a PyO3 Rust extension in [src/lib.rs](https://github.com/indexable-inc/index/pull/634/files#diff-93c6ca85c922556a16937e30ffdd5fc29b405179c26241d46917e6c1f38c73c7) that executes the async Mixedbread search on a current-thread Tokio runtime and returns columnar results as Python dicts.
> - Adds `Deserialize` support to `Filter`, `Condition`, `Group`, and `Operator` in [packages/mixedbread/src/filter.rs](https://github.com/indexable-inc/index/pull/634/files#diff-2cbe7bbb13d10d62a4cfcbf81f6841265438a1c5eaacc7768017852b17fb8a83), with `deny_unknown_fields` to prevent silent misparse.
> - Packaging is handled via Nix with a deterministic wheel builder in [mkwheel.py](https://github.com/indexable-inc/index/pull/634/files#diff-db18559f9609338c1bb74f95df3bcd4339e711f0dd34c029354c2b5d167f81a6).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e49430.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->