### PR TITLE
polars-mixedbread: min_results output floor via auto-overfetch

### DIFF
--- a/packages/polars-mixedbread/README.md
+++ b/packages/polars-mixedbread/README.md
@@ -60,6 +60,20 @@ For a final row cap use Polars' own `.head(n)` / `.limit(n)` (applied last).
 `top_k` only controls how deep the search goes; raise it when a client-side
 filter is discarding too much of the window.
 
+For an output *floor* instead, pass `min_results=N`: when a client-side filter
+trims the window below N rows, the source re-searches with a growing `top_k`
+(doubling) until at least N rows survive or the store is exhausted. `max_top_k`
+is a hard ceiling on search depth (a `min_results` above it is capped there;
+raise `max_top_k` to go deeper). Combine with `.head(N)` for exactly N rows out
+of an arbitrarily selective filter:
+
+```python
+# at least 20 high-score code rows, however deep the search has to go:
+scan_mixedbread("auth", store="index", min_results=20).filter(
+    (pl.col("source") == "code") & (pl.col("score") > 0.8)
+).head(20)
+```
+
 ## Columns
 
 `text` (str), `score` (f64), `filename` (str), `start_line` (u32), `num_lines`

--- a/packages/polars-mixedbread/default.nix
+++ b/packages/polars-mixedbread/default.nix
@@ -108,11 +108,25 @@ let
         python3 ${./tests/test_pushdown.py} ${./python/polars_mixedbread/_pushdown.py}
         mkdir -p "$out"
       '';
+
+  # Same idea for the `min_results` over-fetch loop: pure logic (driven by an
+  # injected fetch), so its termination cases are checked offline.
+  overfetchTest =
+    pkgs.runCommand "polars-mixedbread-overfetch-test"
+      {
+        strictDeps = true;
+        nativeBuildInputs = [ (pkgs.python3.withPackages (ps: [ ps.polars ])) ];
+      }
+      ''
+        python3 ${./tests/test_overfetch.py} ${./python/polars_mixedbread/_overfetch.py}
+        mkdir -p "$out"
+      '';
 in
 wheel.overrideAttrs (old: {
   passthru = (old.passthru or { }) // {
     tests = (old.passthru.tests or { }) // {
       pushdown = pushdownTest;
+      overfetch = overfetchTest;
     };
   };
 })

--- a/packages/polars-mixedbread/python/polars_mixedbread/__init__.py
+++ b/packages/polars-mixedbread/python/polars_mixedbread/__init__.py
@@ -50,8 +50,11 @@ final row count:
   can leave fewer than ``top_k`` rows.
 
 For a final row cap use Polars' own ``.head(n)`` / ``.limit(n)`` (applied last);
-``top_k`` only controls how deep the search goes. Raise ``top_k`` when a
-client-side filter is throwing away too much of the window.
+``top_k`` only controls how deep the search goes. For an output *floor* instead,
+pass ``min_results=N``: when a client-side filter trims the window below N, the
+source re-searches with a growing ``top_k`` until at least N rows survive (or the
+store is exhausted). Combine ``min_results=N`` with ``.head(N)`` for exactly N
+rows out of an arbitrarily selective filter.
 
 Columns: ``text`` (str), ``score`` (f64), ``filename`` (str), ``start_line``
 (u32), ``num_lines`` (u32), ``metadata`` (str, the raw JSON), plus one typed
@@ -78,6 +81,7 @@ from typing import Iterator
 import polars as pl
 from polars.io.plugins import register_io_source
 
+from ._overfetch import DEFAULT_MAX_TOP_K, grow_until, initial_k
 from ._polars_mixedbread import __version__, search_mixedbread
 from ._pushdown import pushdown
 
@@ -108,6 +112,8 @@ def scan_mixedbread(
     *,
     store: str | list[str] = "index",
     top_k: int = 10,
+    min_results: int | None = None,
+    max_top_k: int = DEFAULT_MAX_TOP_K,
     base_url: str | None = None,
     rerank: bool = True,
     agentic: bool = False,
@@ -122,6 +128,14 @@ def scan_mixedbread(
     ``"index"``). ``metadata_columns`` maps metadata keys to dtypes to surface as
     typed columns (default: the ``index`` keys).
     ``rerank``/``agentic``/``score_threshold`` tune retrieval.
+
+    ``min_results`` turns ``top_k`` into a floor on the *output*: when a
+    client-side filter trims the window below N rows, the source re-searches with
+    a growing ``top_k`` until at least N rows survive the filter or the store is
+    exhausted. ``max_top_k`` is a hard ceiling on search depth (a ``min_results``
+    above it is capped there; raise ``max_top_k`` to go deeper). Leave
+    ``min_results`` ``None`` (default) for a single fetch. Combine with
+    ``.head(N)`` for exactly N rows.
 
     Filter with ordinary Polars expressions; string equality on a metadata
     column is pushed to Mixedbread and everything else runs in Polars. See the
@@ -140,28 +154,36 @@ def scan_mixedbread(
         batch_size: int | None,  # noqa: ARG001 - single-shot source ignores the hint
     ) -> Iterator[pl.DataFrame]:
         pushed = None if predicate is None else pushdown(predicate, pushable)
-        columns = search_mixedbread(
-            stores,
-            query,
-            top_k=top_k,
-            base_url=base_url,
-            rerank=rerank,
-            agentic=agentic,
-            score_threshold=score_threshold,
-            filters=None if pushed is None else json.dumps(pushed),
-        )
-        df = pl.DataFrame(columns, schema=_INTRINSIC)
-        # Flatten the declared metadata keys out of the JSON column into typed
-        # columns. A missing key reads back null; a non-string dtype is cast
-        # leniently so a bad value is null rather than an error.
-        if meta_cols:
-            df = df.with_columns(
-                _metadata_column(name, dtype) for name, dtype in meta_cols.items()
+
+        def fetch(k: int) -> tuple[pl.DataFrame, int]:
+            columns = search_mixedbread(
+                stores,
+                query,
+                top_k=k,
+                base_url=base_url,
+                rerank=rerank,
+                agentic=agentic,
+                score_threshold=score_threshold,
+                filters=None if pushed is None else json.dumps(pushed),
             )
-        # The source owns predicate application: Polars does not re-apply it, so
-        # this is what makes a partial (or empty) pushdown correct.
-        if predicate is not None:
-            df = df.filter(predicate)
+            n_raw = len(columns["score"])
+            df = pl.DataFrame(columns, schema=_INTRINSIC)
+            # Flatten the declared metadata keys out of the JSON column into typed
+            # columns. A missing key reads back null; a non-string dtype is cast
+            # leniently so a bad value is null rather than an error.
+            if meta_cols:
+                df = df.with_columns(
+                    _metadata_column(name, dtype) for name, dtype in meta_cols.items()
+                )
+            # The source owns predicate application: Polars does not re-apply it,
+            # so this is what makes a partial (or empty) pushdown correct, and it
+            # is the filter `min_results` grows the window against.
+            if predicate is not None:
+                df = df.filter(predicate)
+            return df, n_raw
+
+        start_k = initial_k(top_k, min_results, max_top_k)
+        df = grow_until(min_results, start_k, max_top_k, fetch)
         if with_columns is not None:
             df = df.select(with_columns)
         if n_rows is not None:

--- a/packages/polars-mixedbread/python/polars_mixedbread/_overfetch.py
+++ b/packages/polars-mixedbread/python/polars_mixedbread/_overfetch.py
@@ -1,0 +1,69 @@
+"""Grow the search size until enough rows survive the client-side filter.
+
+``top_k`` is retrieval depth, not an output count: a client-side filter (a score
+threshold, an ``is_in``, anything that does not push to Mixedbread) trims the
+fetched window, so a small ``top_k`` can leave very few rows. ``min_results``
+asks for an output floor instead: re-search with a growing ``top_k`` until at
+least N rows survive the filter, the store is exhausted, or a ceiling is hit.
+
+Kept separate from ``__init__`` (which imports the compiled extension) and pure
+(it drives an injected ``fetch`` callable), so the loop's termination logic can
+be tested with no built cdylib and no network (see ``tests/test_overfetch.py``).
+
+Mixedbread search has no cursor, so "fetch more" means re-running the search with
+a larger ``top_k``; a larger ``top_k`` returns a superset of the smaller one's
+ranked hits, so growth is monotonic. The search re-runs each round, so the cost
+is geometric in the final size, not linear in the number of rounds.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    import polars as pl
+
+# Doubling each round, this caps the over-fetch so a filter that matches almost
+# nothing cannot grow the search without bound; the loop also stops earlier when
+# the store is exhausted (a round returns fewer raw hits than it asked for).
+DEFAULT_MAX_TOP_K = 4096
+
+
+def initial_k(top_k: int, min_results: int | None, max_k: int) -> int:
+    """The ``top_k`` for the first search round.
+
+    With no floor, that is just ``top_k``. With a floor, start as deep as the
+    floor needs (no point fetching ``top_k`` then immediately growing), but never
+    past ``max_k``: ``max_k`` is a hard ceiling on how deep the source will ever
+    search, so a ``min_results`` larger than it is capped (raise ``max_k`` to go
+    deeper) rather than silently bypassing the cap on the first round.
+    """
+    if min_results is None:
+        return top_k
+    return min(max(top_k, min_results), max_k)
+
+
+def grow_until(
+    min_results: int | None,
+    start_k: int,
+    max_k: int,
+    fetch: Callable[[int], tuple[pl.DataFrame, int]],
+) -> pl.DataFrame:
+    """Return the filtered frame, growing ``top_k`` toward ``min_results`` rows.
+
+    ``fetch(k)`` runs one search at depth ``k`` and returns ``(df, n_raw)``: the
+    fully-filtered frame and the number of raw hits the search returned before
+    filtering. With ``min_results`` ``None`` this is a single fetch. Otherwise it
+    doubles ``k`` until ``df`` has at least ``min_results`` rows, the search is
+    exhausted (``n_raw < k``: no deeper hits exist), or ``k`` reaches ``max_k``.
+    It can return fewer than ``min_results`` rows in the latter two cases, the
+    same way ``head(n)`` returns what exists when the source is shorter than ``n``.
+    """
+    k = start_k
+    df, n_raw = fetch(k)
+    if min_results is None:
+        return df
+    while df.height < min_results and n_raw >= k and k < max_k:
+        k = min(k * 2, max_k)
+        df, n_raw = fetch(k)
+    return df

--- a/packages/polars-mixedbread/tests/test_overfetch.py
+++ b/packages/polars-mixedbread/tests/test_overfetch.py
@@ -1,0 +1,123 @@
+"""Offline, deterministic checks for the ``min_results`` over-fetch loop.
+
+Runnable as a plain script (``python tests/test_overfetch.py``) with only Polars
+and no built extension. It loads the pure ``_overfetch`` module by path (never
+importing the ``polars_mixedbread`` package, which would pull in the compiled
+cdylib): pass the module path in ``POLARS_MIXEDBREAD_OVERFETCH`` or argv[1], or
+rely on the in-repo default.
+
+The loop must terminate in every case: when enough rows survive, when the store
+is exhausted (a round returns fewer raw hits than it asked for), and when the
+``max_k`` ceiling is reached. A bug here is either an infinite loop or a silent
+under-fetch.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import sys
+
+import polars as pl
+
+_DEFAULT = pathlib.Path(__file__).resolve().parent.parent / "python" / "polars_mixedbread" / "_overfetch.py"
+_explicit = (sys.argv[1] if len(sys.argv) > 1 else None) or os.environ.get("POLARS_MIXEDBREAD_OVERFETCH")
+_MODULE_PATH = pathlib.Path(_explicit) if _explicit else _DEFAULT
+
+_spec = importlib.util.spec_from_file_location("polars_mixedbread_overfetch", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None, f"cannot load {_MODULE_PATH}"
+_overfetch = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_overfetch)
+
+grow_until = _overfetch.grow_until
+initial_k = _overfetch.initial_k
+
+
+def make_fetch(*, total_hits: int, pass_every: int, calls: list[int]):
+    """A fake ``fetch(k)``: a store of ``total_hits`` ranked hits where 1 in
+    ``pass_every`` survives the client-side filter. Records each ``k`` it sees."""
+
+    def fetch(k: int) -> tuple[pl.DataFrame, int]:
+        calls.append(k)
+        n_raw = min(k, total_hits)
+        survivors = n_raw // pass_every
+        return pl.DataFrame({"x": list(range(survivors))}), n_raw
+
+    return fetch
+
+
+def test_none_is_a_single_fetch() -> None:
+    calls: list[int] = []
+    df = grow_until(None, start_k=10, max_k=4096, fetch=make_fetch(total_hits=1000, pass_every=1, calls=calls))
+    assert calls == [10]
+    assert df.height == 10
+
+
+def test_first_fetch_already_enough() -> None:
+    calls: list[int] = []
+    # 100% pass rate: start_k=25 yields 25 survivors >= 25.
+    df = grow_until(25, start_k=25, max_k=4096, fetch=make_fetch(total_hits=1000, pass_every=1, calls=calls))
+    assert calls == [25]
+    assert df.height >= 25
+
+
+def test_grows_until_enough_survive() -> None:
+    calls: list[int] = []
+    # 10% pass rate: need k>=250 for 25 survivors; doubling from 25 -> 400.
+    df = grow_until(25, start_k=25, max_k=4096, fetch=make_fetch(total_hits=10_000, pass_every=10, calls=calls))
+    assert calls == [25, 50, 100, 200, 400]
+    assert df.height >= 25
+    assert calls == sorted(calls)  # monotonic growth
+
+
+def test_stops_when_store_exhausted() -> None:
+    calls: list[int] = []
+    # Only 30 hits exist; 10% survive (3), far below min_results=25. The round at
+    # k=50 returns n_raw=30 < 50, so the store is exhausted: stop, do not loop.
+    df = grow_until(25, start_k=25, max_k=4096, fetch=make_fetch(total_hits=30, pass_every=10, calls=calls))
+    assert calls == [25, 50]
+    assert df.height < 25  # returns what exists, like head(n) past the end
+
+
+def test_initial_k() -> None:
+    assert initial_k(top_k=10, min_results=None, max_k=4096) == 10  # no floor: just top_k
+    assert initial_k(top_k=10, min_results=5, max_k=4096) == 10  # floor below top_k: top_k
+    assert initial_k(top_k=10, min_results=50, max_k=4096) == 50  # floor above top_k: start deep
+    assert initial_k(top_k=10, min_results=9000, max_k=4096) == 4096  # floor above ceiling: capped
+
+
+def test_min_results_above_ceiling_is_one_fetch_at_the_cap() -> None:
+    # start_k is clamped to max_k by initial_k, so the loop guard `k < max_k` is
+    # false immediately: exactly one fetch at the ceiling, never beyond it.
+    calls: list[int] = []
+    k0 = initial_k(top_k=10, min_results=9000, max_k=100)
+    grow_until(9000, start_k=k0, max_k=100, fetch=make_fetch(total_hits=10**9, pass_every=1, calls=calls))
+    assert calls == [100]
+
+
+def test_non_positive_min_results_is_one_fetch() -> None:
+    calls: list[int] = []
+    df = grow_until(0, start_k=10, max_k=4096, fetch=make_fetch(total_hits=1000, pass_every=10**9, calls=calls))
+    assert calls == [10]  # df.height (0) < 0 is false -> no growth
+    assert df.height == 0
+
+
+def test_stops_at_max_k_ceiling() -> None:
+    calls: list[int] = []
+    # Filter matches nothing; without a ceiling this would grow forever.
+    df = grow_until(10, start_k=10, max_k=100, fetch=make_fetch(total_hits=10**9, pass_every=10**9, calls=calls))
+    assert calls == [10, 20, 40, 80, 100]
+    assert calls[-1] == 100  # clamped to max_k, then stops
+    assert df.height == 0
+
+
+def main() -> None:
+    tests = [v for name, v in sorted(globals().items()) if name.startswith("test_") and callable(v)]
+    for test in tests:
+        test()
+    print(f"ok: {len(tests)} overfetch tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/polars-mixedbread/wheel/mkwheel.py
+++ b/packages/polars-mixedbread/wheel/mkwheel.py
@@ -22,7 +22,7 @@ DIST = "polars_mixedbread"
 DIST_NAME = "polars-mixedbread"
 SO_NAME = "_polars_mixedbread.abi3.so"
 # Files copied verbatim from the Python source tree into the wheel.
-SOURCE_FILES = ["__init__.py", "_pushdown.py", "_polars_mixedbread.pyi", "py.typed"]
+SOURCE_FILES = ["__init__.py", "_pushdown.py", "_overfetch.py", "_polars_mixedbread.pyi", "py.typed"]
 
 
 def sha256_b64(data: bytes) -> str:


### PR DESCRIPTION
Follow-up to #634. Adds `min_results=N` to `scan_mixedbread`: an output *floor* on top of `top_k` (which is retrieval depth, not a row count).

A client-side filter (a `score` threshold, `is_in`, anything that doesn't push to Mixedbread) trims the fetched window, so a small `top_k` can leave very few rows. `min_results=N` re-searches with a growing `top_k` (doubling, up to `max_top_k`) until at least N rows survive the filter, the store is exhausted, or the ceiling is hit. Combine with `.head(N)` for exactly N rows out of an arbitrarily selective filter.

```python
# at least 20 high-score code rows, however deep the search has to go:
scan_mixedbread("auth", store="index", min_results=20).filter(
    (pl.col("source") == "code") & (pl.col("score") > 0.8)
).head(20)
```

Default (`min_results=None`) is unchanged: one fetch.

The loop is a pure module (`_overfetch.grow_until`, driven by an injected `fetch`), so its termination is gated offline by `checks.<system>.polars-mixedbread-overfetch`: enough-on-first-try, grows-until-enough, stops-on-exhaustion (a round returns fewer raw hits than requested), stops-at-ceiling, and None-is-a-single-fetch.

Validated end-to-end on darwin against the live `index` store: `top_k=10` + `score>0.6` → 9 survivors; same with `min_results=30` → 46 (all satisfy the filter); `min_results=20` + `.head(20)` → exactly 20. Build + lint + both offline test checks green.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `min_results` parameter to `scan_mixedbread` with auto-overfetch
> - Adds `min_results` and `max_top_k` parameters to `scan_mixedbread` in [__init__.py](https://github.com/indexable-inc/index/pull/636/files#diff-34a6182be9a43298ba54f75ea2560aa88e880feff7a3c6771f69dc8924a4b55a); when `min_results` is set, the function iteratively doubles `top_k` until at least that many rows survive client-side filtering or the store is exhausted.
> - Implements the overfetch loop in a new pure-Python module [_overfetch.py](https://github.com/indexable-inc/index/pull/636/files#diff-77e7e4a4a473578d030e1941ff6cc5203b956d1d6d62c46880ed4b7dbab185f6), exposing `initial_k` and `grow_until` helpers with a default ceiling of `DEFAULT_MAX_TOP_K = 4096`.
> - When `min_results` is `None`, behavior is unchanged: a single fetch is performed.
> - Adds tests in [test_overfetch.py](https://github.com/indexable-inc/index/pull/636/files#diff-51c48044d4fdc561e8a77b9d230744e07b28dba6f12e1aa873e6849b6cbd1733) and packages `_overfetch.py` into the wheel via [mkwheel.py](https://github.com/indexable-inc/index/pull/636/files#diff-db18559f9609338c1bb74f95df3bcd4339e711f0dd34c029354c2b5d167f81a6).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5606a75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->