### PR TITLE
claude-code: bump to 2.1.162

### DIFF
--- a/packages/claude-code/manifest.json
+++ b/packages/claude-code/manifest.json
@@ -1,21 +1,21 @@
 {
-  "version": "2.1.159",
+  "version": "2.1.162",
   "platforms": {
     "aarch64-darwin": {
       "slug": "darwin-arm64",
-      "hash": "sha256-Wt97TTSfdD1mnNWt8s5227XhRtirmbOmPFrvLvFVlfk="
+      "hash": "sha256-LUB90qYyQ6yQD2QzFYm5/NKaIVmnMokHCvaF9AhaF9I="
     },
     "x86_64-darwin": {
       "slug": "darwin-x64",
-      "hash": "sha256-q6vWx1T34CirXkvXTU1tOoAsr7V8nUHqkXjol2VcF70="
+      "hash": "sha256-U/J0m/JOWoCyOwF9CHf2HJiUo8BiIhQVFbN6lMYFHUE="
     },
     "x86_64-linux": {
       "slug": "linux-x64",
-      "hash": "sha256-4hJsrwDtPsCTcaKZR2WMfpsxGFJWsqxXKCY72V9+NUE="
+      "hash": "sha256-lHpJsN6GiPanSm51PCR3H/Pd0Xsqba6F82ME7FFOYdE="
     },
     "aarch64-linux": {
       "slug": "linux-arm64",
-      "hash": "sha256-vv0FTwLBfkthpqkrMChqFHyoxcG784uR3RTLpvux4H0="
+      "hash": "sha256-7KKmA9/rw0JqhGnL55f535UkVzi8HCDshC/I+Ar0AQ0="
     }
   }
 }


### PR DESCRIPTION
Bumps pinned claude-code from 2.1.159 to 2.1.162 (next channel). Manifest regenerated via updateScript; signature verified; `nix build .#claude-code` produces a binary reporting 2.1.162.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump claude-code to version 2.1.162
> Updates [manifest.json](https://github.com/indexable-inc/index/pull/637/files#diff-07231a29e842291cdba811cc694c7fe37386a88958609a48480b263aa9dca446) to version 2.1.162 (from 2.1.159) with updated package hashes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c873678.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->