### PR TITLE
otlp-mixedbread: index OTLP logs into Mixedbread for semantic search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4296,6 +4296,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "otlp-mixedbread"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "mixedbread",
+ "search-core",
+ "serde",
+ "serde_json",
+ "source-meta",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "ownedbytes"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5668,18 +5685,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "skill-lint"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "clap",
- "ignore",
- "serde",
- "serde_json",
- "serde_norway",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5741,6 +5746,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "skill-lint"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ignore",
+ "serde",
+ "serde_json",
+ "serde_norway",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
   "packages/nix-web-monitor/parser",
   "packages/nix-web-monitor/server",
   "packages/oci-image-builder",
+  "packages/otlp-mixedbread",
   "packages/polars-mixedbread",
   "packages/progress-style",
   "packages/reel",

--- a/modules/services/observability/default.nix
+++ b/modules/services/observability/default.nix
@@ -38,6 +38,19 @@ let
   filelogEnabled = agentEnabled && cfg.agent.filelog.paths != [ ];
   journaldEnabled = agentEnabled && cfg.agent.journal.enable;
   hostMetricsEnabled = agentEnabled && cfg.agent.hostMetrics.enable;
+  # Mixedbread is an additive logs exporter: the bridge ingests the logs pipeline
+  # over OTLP/HTTP and indexes each record for semantic search. It rides whatever
+  # base exporter the collector already has (the `exporterNames` assertion still
+  # requires clickhouse or forward), so logs land in both ClickHouse and Mixedbread.
+  mixedbreadEnabled = collectorEnabled && cfg.collector.mixedbread.enable;
+  mixedbreadBridge = ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+    binary = "otlp-mixedbread";
+    meta.mainProgram = "otlp-mixedbread";
+  };
+  # The bridge serves OTLP/HTTP on loopback only; the co-located collector exports
+  # to it, and it is never reachable off-host.
+  mixedbreadListen = "127.0.0.1:${toString cfg.collector.mixedbread.port}";
+  mixedbreadEndpoint = "http://${mixedbreadListen}/v1/logs";
   listenAddress = cfg.collector.listenAddress;
   listenGrpcEndpoint = "${listenAddress}:${toString cfg.collector.grpcPort}";
   listenHttpEndpoint = "${listenAddress}:${toString cfg.collector.httpPort}";
@@ -268,6 +281,63 @@ in
           description = "Use cleartext OTLP/gRPC for east-west collector forwarding.";
         };
       };
+
+      mixedbread = {
+        enable = mkEnableOption "indexing the collected logs into a Mixedbread store for semantic search (runs the otlp-mixedbread bridge and adds it as a logs-pipeline exporter). Additive: also keep a base exporter (the stack/clickhouse or forward)";
+
+        package = mkOption {
+          type = types.package;
+          default = mixedbreadBridge;
+          defaultText = lib.literalExpression "index.packages.\${system}.otlp-mixedbread";
+          description = "The `otlp-mixedbread` bridge package to run.";
+        };
+
+        store = mkOption {
+          type = types.str;
+          default = "index";
+          description = "Mixedbread store to index log records into.";
+        };
+
+        baseUrl = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "Mixedbread API base URL override. Null uses the SDK default.";
+        };
+
+        sourceTag = mkOption {
+          type = types.str;
+          default = "log";
+          description = "The `source` tag stamped on every indexed log document (its corpus name).";
+        };
+
+        port = mkOption {
+          type = types.port;
+          default = 4319;
+          description = "Loopback port the bridge serves its OTLP/HTTP logs receiver on. The collector exports to it; it is never opened off-host.";
+        };
+
+        minSeverityNumber = mkOption {
+          type = types.ints.between 0 24;
+          default = 0;
+          description = "Drop records below this OTLP severity number (1..=24, higher is more severe; 13 = WARN). 0 keeps everything. A floor in addition to any collector-side filtering.";
+        };
+
+        environmentFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          example = "/run/secrets/otlp-mixedbread.env";
+          description = "EnvironmentFile for the bridge, supplying `MXBAI_API_KEY`. Keep the key out of the Nix store: reference a runtime secrets file (on the fleet, wired by the secret store) rather than inlining it.";
+        };
+
+        environment = mkOption {
+          type = types.attrsOf types.str;
+          default = { };
+          example = {
+            RUST_LOG = "info";
+          };
+          description = "Extra non-secret environment for the bridge. Rendered into the unit in the world-readable store, so never inline secrets here.";
+        };
+      };
     };
 
     agent = {
@@ -492,6 +562,15 @@ in
                 endpoint = forwardEndpoint;
                 tls.insecure = cfg.collector.forward.insecure;
               };
+            }
+            // lib.optionalAttrs mixedbreadEnabled {
+              # JSON encoding (not protobuf) and no compression: the bridge speaks
+              # OTLP/JSON and shares the host, so this keeps it dependency-light.
+              "otlphttp/mixedbread" = {
+                logs_endpoint = mixedbreadEndpoint;
+                encoding = "json";
+                compression = "none";
+              };
             };
 
           extensions.health_check.endpoint = "127.0.0.1:${toString cfg.collector.healthPort}";
@@ -528,7 +607,9 @@ in
                   "resource"
                   "batch"
                 ];
-                exporters = exporterNames;
+                # Logs fan out to the base exporter(s) AND, when enabled, the
+                # Mixedbread bridge for semantic search.
+                exporters = exporterNames ++ lib.optional mixedbreadEnabled "otlphttp/mixedbread";
               };
             };
           };
@@ -564,6 +645,57 @@ in
           "--show-error"
           "http://127.0.0.1:${toString cfg.collector.healthPort}/"
         ];
+      };
+    })
+
+    (mkIf mixedbreadEnabled {
+      assertions = [
+        {
+          assertion = cfg.collector.mixedbread.environmentFile != null;
+          message = "services.ix-observability.collector.mixedbread needs environmentFile supplying MXBAI_API_KEY (keep the key out of the Nix store).";
+        }
+      ];
+
+      systemd.services.otlp-mixedbread = {
+        description = "Index collected logs into Mixedbread (OTLP/HTTP bridge)";
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+        # Start before the collector so its first log batch has somewhere to land;
+        # the collector's retry queue covers any residual startup gap.
+        before = [ "opentelemetry-collector.service" ];
+        wantedBy = [ "multi-user.target" ];
+        environment = cfg.collector.mixedbread.environment;
+        serviceConfig = ix.systemdHardening // {
+          ExecStart = lib.escapeShellArgs (
+            [
+              (lib.getExe cfg.collector.mixedbread.package)
+              "--store"
+              cfg.collector.mixedbread.store
+              "--listen"
+              mixedbreadListen
+              "--source-tag"
+              cfg.collector.mixedbread.sourceTag
+              "--min-severity-number"
+              (toString cfg.collector.mixedbread.minSeverityNumber)
+            ]
+            ++ lib.optionals (cfg.collector.mixedbread.baseUrl != null) [
+              "--base-url"
+              cfg.collector.mixedbread.baseUrl
+            ]
+          );
+          # Supplies MXBAI_API_KEY (asserted non-null above); kept out of the store.
+          EnvironmentFile = cfg.collector.mixedbread.environmentFile;
+          Restart = "on-failure";
+          RestartSec = "5s";
+          DynamicUser = true;
+        };
+      };
+
+      ix.networking.portClaims.otlp-mixedbread = {
+        protocol = "tcp";
+        port = cfg.collector.mixedbread.port;
+        address = "127.0.0.1";
+        description = "otlp-mixedbread bridge OTLP/HTTP logs receiver (loopback)";
       };
     })
 

--- a/packages/otlp-mixedbread/Cargo.toml
+++ b/packages/otlp-mixedbread/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "otlp-mixedbread"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "OTLP/HTTP logs receiver that maps each LogRecord into a Mixedbread document for semantic search"
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "otlp-mixedbread"
+path = "src/main.rs"
+
+[dependencies]
+source-meta.workspace = true
+search-core.workspace = true
+mixedbread.workspace = true
+axum.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "signal"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync"] }

--- a/packages/otlp-mixedbread/default.nix
+++ b/packages/otlp-mixedbread/default.nix
@@ -1,0 +1,6 @@
+{ ix, ... }:
+
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "otlp-mixedbread";
+  meta.mainProgram = "otlp-mixedbread";
+}

--- a/packages/otlp-mixedbread/package.nix
+++ b/packages/otlp-mixedbread/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "otlp-mixedbread";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/otlp-mixedbread/src/ingest.rs
+++ b/packages/otlp-mixedbread/src/ingest.rs
@@ -8,10 +8,21 @@
 //! A drain task pulls from the channel and uploads with bounded concurrency.
 //!
 //! Dedup is applied at upload time, not enqueue time: an id is recorded as seen
-//! only after a successful upload, so a record that is dropped under backpressure
-//! (and retried by the collector) always re-flows. Because the store is keyed by
-//! `external_id`, a duplicate upload is an idempotent overwrite, so the cache
-//! only ever saves redundant embedding work, it can never cause data loss.
+//! only after a successful upload, so a record dropped under backpressure (queue
+//! full, the handler 503s and the collector retries) always re-flows, and the
+//! dedup cache itself never causes loss. Because the store is keyed by
+//! `external_id`, a re-delivery is an idempotent overwrite, so the cache only
+//! saves redundant embedding work.
+//!
+//! Durability is best-effort, by design. The HTTP handler acks (200) on enqueue,
+//! before upload, so a record whose upload still fails after `max_attempts`
+//! (logged at `error!`) is dropped, and the collector, already told success, does
+//! not retry it. A *sustained* outage instead fills the queue so the handler
+//! 503s and the collector holds the data; the loss window is the narrow case of
+//! per-record failures that exhaust retries while the queue is not saturated.
+//! This is acceptable because Mixedbread is a semantic-search index, not the
+//! system of record: the same logs are durably retained by the collector's other
+//! exporter (e.g. ClickHouse).
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex, PoisonError};

--- a/packages/otlp-mixedbread/src/ingest.rs
+++ b/packages/otlp-mixedbread/src/ingest.rs
@@ -1,0 +1,202 @@
+//! The async upload path: a bounded queue, a worker pool that reconciles each
+//! document into Mixedbread, and a dedup cache so a re-delivered record is not
+//! re-embedded.
+//!
+//! The HTTP handler stays fast: it projects records and hands them to [`Ingest`]
+//! over a bounded channel, returning backpressure (a full queue) to the caller
+//! rather than blocking on Mixedbread, which is network-bound and rate-limited.
+//! A drain task pulls from the channel and uploads with bounded concurrency.
+//!
+//! Dedup is applied at upload time, not enqueue time: an id is recorded as seen
+//! only after a successful upload, so a record that is dropped under backpressure
+//! (and retried by the collector) always re-flows. Because the store is keyed by
+//! `external_id`, a duplicate upload is an idempotent overwrite, so the cache
+//! only ever saves redundant embedding work, it can never cause data loss.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex, PoisonError};
+use std::time::Duration;
+
+use search_core::{MixedbreadStore, Store as _};
+use source_meta::Document;
+use tokio::sync::{Semaphore, mpsc};
+
+/// Base delay for the upload retry backoff.
+const RETRY_BASE: Duration = Duration::from_millis(500);
+/// Cap on a single retry delay.
+const RETRY_CAP: Duration = Duration::from_secs(30);
+
+/// Outcome of offering a document to the queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Sent {
+    /// Queued for upload.
+    Accepted,
+    /// The queue is full; the caller should apply backpressure (retry later).
+    Full,
+    /// The drain task is gone; the service is shutting down.
+    Closed,
+}
+
+/// Handle the HTTP layer uses to offer documents to the upload pipeline.
+pub struct Ingest {
+    tx: mpsc::Sender<Document>,
+}
+
+impl Ingest {
+    /// Offer one document to the queue without blocking.
+    #[must_use]
+    pub fn offer(&self, document: Document) -> Sent {
+        match self.tx.try_send(document) {
+            Ok(()) => Sent::Accepted,
+            Err(mpsc::error::TrySendError::Full(_)) => Sent::Full,
+            Err(mpsc::error::TrySendError::Closed(_)) => Sent::Closed,
+        }
+    }
+}
+
+/// Tuning for the upload pipeline.
+#[derive(Debug, Clone, Copy)]
+pub struct Config {
+    /// Bounded queue depth between the handler and the workers.
+    pub queue_capacity: usize,
+    /// Maximum concurrent uploads in flight.
+    pub concurrency: usize,
+    /// How many recent `external_id`s to remember for dedup.
+    pub dedup_capacity: usize,
+    /// Upload attempts per document before giving up (and logging).
+    pub max_attempts: u32,
+}
+
+/// Spawn the drain + worker pipeline and return the [`Ingest`] handle.
+///
+/// The drain task lives for the process lifetime; it ends only when the channel
+/// closes (the handle is dropped at shutdown).
+#[must_use]
+pub fn spawn(store: Arc<MixedbreadStore>, store_name: Arc<str>, config: Config) -> Arc<Ingest> {
+    let (tx, mut rx) = mpsc::channel::<Document>(config.queue_capacity);
+    let limiter = Arc::new(Semaphore::new(config.concurrency.max(1)));
+    let dedup = Arc::new(Mutex::new(Dedup::new(config.dedup_capacity)));
+    let attempts = config.max_attempts.max(1);
+
+    tokio::spawn(async move {
+        while let Some(document) = rx.recv().await {
+            if locked(&dedup).contains(&document.external_id, &document.content_hash) {
+                continue;
+            }
+            // Bound concurrent uploads; the permit is released when the task ends.
+            let permit = limiter
+                .clone()
+                .acquire_owned()
+                .await
+                .expect("upload semaphore is never closed while the drain task runs");
+            let store = store.clone();
+            let store_name = store_name.clone();
+            let dedup = dedup.clone();
+            tokio::spawn(async move {
+                let _permit = permit;
+                let id = document.external_id.clone();
+                let hash = document.content_hash.clone();
+                if upload_with_retry(&store, &store_name, document, attempts).await {
+                    locked(&dedup).insert(id, hash);
+                }
+            });
+        }
+    });
+
+    Arc::new(Ingest { tx })
+}
+
+/// Upload one document, retrying transient failures with exponential backoff.
+/// Returns whether it ultimately succeeded; a permanent failure is logged.
+async fn upload_with_retry(
+    store: &MixedbreadStore,
+    store_name: &str,
+    document: Document,
+    max_attempts: u32,
+) -> bool {
+    let external_id = document.external_id.clone();
+    for attempt in 1..=max_attempts {
+        // `upload` consumes the document, so each attempt gets its own clone.
+        match store.upload(store_name, document.clone()).await {
+            Ok(()) => return true,
+            Err(error) => {
+                if attempt == max_attempts {
+                    tracing::error!(%external_id, %error, attempt, "giving up on log upload");
+                    return false;
+                }
+                tracing::warn!(%external_id, %error, attempt, "log upload failed, retrying");
+                tokio::time::sleep(backoff(attempt)).await;
+            }
+        }
+    }
+    false
+}
+
+/// Exponential backoff for retry `attempt` (1-based), capped at [`RETRY_CAP`].
+fn backoff(attempt: u32) -> Duration {
+    RETRY_BASE.saturating_mul(1u32 << (attempt - 1).min(16)).min(RETRY_CAP)
+}
+
+/// Lock the dedup mutex, recovering the inner value if a prior holder panicked
+/// (the critical section is panic-free, so this is just defensive).
+fn locked(dedup: &Mutex<Dedup>) -> std::sync::MutexGuard<'_, Dedup> {
+    dedup.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// A bounded FIFO set of recently-uploaded `external_id` -> `content_hash`.
+///
+/// `contains` is a true skip only when both the id and its content match, so an
+/// updated record (same id, new body) still re-uploads.
+struct Dedup {
+    cap: usize,
+    seen: HashMap<String, String>,
+    order: VecDeque<String>,
+}
+
+impl Dedup {
+    fn new(cap: usize) -> Self {
+        Self { cap: cap.max(1), seen: HashMap::new(), order: VecDeque::new() }
+    }
+
+    fn contains(&self, external_id: &str, content_hash: &str) -> bool {
+        self.seen.get(external_id).is_some_and(|hash| hash == content_hash)
+    }
+
+    fn insert(&mut self, external_id: String, content_hash: String) {
+        if self.seen.insert(external_id.clone(), content_hash).is_none() {
+            self.order.push_back(external_id);
+            while self.order.len() > self.cap {
+                if let Some(evicted) = self.order.pop_front() {
+                    self.seen.remove(&evicted);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Dedup;
+
+    #[test]
+    fn dedup_skips_only_identical_id_and_hash() {
+        let mut dedup = Dedup::new(8);
+        assert!(!dedup.contains("a", "h1"));
+        dedup.insert("a".to_owned(), "h1".to_owned());
+        assert!(dedup.contains("a", "h1"));
+        // Same id, changed content re-uploads.
+        assert!(!dedup.contains("a", "h2"));
+    }
+
+    #[test]
+    fn dedup_evicts_oldest_past_capacity() {
+        let mut dedup = Dedup::new(2);
+        dedup.insert("a".to_owned(), "h".to_owned());
+        dedup.insert("b".to_owned(), "h".to_owned());
+        dedup.insert("c".to_owned(), "h".to_owned());
+        // "a" was evicted, "b"/"c" remain.
+        assert!(!dedup.contains("a", "h"));
+        assert!(dedup.contains("b", "h"));
+        assert!(dedup.contains("c", "h"));
+    }
+}

--- a/packages/otlp-mixedbread/src/lib.rs
+++ b/packages/otlp-mixedbread/src/lib.rs
@@ -48,6 +48,7 @@ mod tests {
             "attributes": [
               { "key": "_SYSTEMD_UNIT", "value": { "stringValue": "nginx.service" } },
               { "key": "SYSLOG_IDENTIFIER", "value": { "stringValue": "nginx" } },
+              { "key": "PRIORITY", "value": { "stringValue": "3" } },
               { "key": "_PID", "value": { "intValue": "4242" } }
             ]
           }]
@@ -72,10 +73,29 @@ mod tests {
         assert_eq!(meta[keys::UNIT], "nginx.service");
         assert_eq!(meta[keys::SERVICE_NAME], "nginx");
         assert_eq!(meta[keys::SEVERITY], "ERROR");
+        assert_eq!(meta[keys::PRIORITY], 3);
         assert_eq!(meta[keys::HOST], "node-1");
         assert_eq!(meta[keys::PID], 4242);
         assert_eq!(meta[keys::TIMESTAMP], 1_700_000_000);
         assert!(doc.external_id.starts_with("log:sha256:"));
+    }
+
+    #[test]
+    fn same_second_distinct_nanos_do_not_collide() {
+        // Regression: two identical messages from one unit in the same second
+        // must get distinct ids, or the second silently overwrites the first.
+        let make = |nanos: &str| {
+            format!(
+                r#"{{"resourceLogs":[{{"scopeLogs":[{{"logRecords":[
+                  {{"timeUnixNano":"{nanos}","body":{{"stringValue":"connection refused"}},
+                   "attributes":[{{"key":"_SYSTEMD_UNIT","value":{{"stringValue":"api.service"}}}}]}}
+                ]}}]}}]}}"#
+            )
+        };
+        let a = first_document(&make("1700000000000000001"), "log");
+        let b = first_document(&make("1700000000000000002"), "log");
+        assert_eq!(a.meta_json[keys::TIMESTAMP], b.meta_json[keys::TIMESTAMP], "same whole second");
+        assert_ne!(a.external_id, b.external_id, "distinct nanoseconds must not collide");
     }
 
     #[test]

--- a/packages/otlp-mixedbread/src/lib.rs
+++ b/packages/otlp-mixedbread/src/lib.rs
@@ -1,0 +1,114 @@
+//! `otlp-mixedbread`: an OTLP/HTTP logs receiver that maps each log record into a
+//! Mixedbread document for semantic search.
+//!
+//! It is the bridge that lets Mixedbread sit at the OpenTelemetry collector's
+//! exporter layer: the collector's `otlphttp` exporter (JSON encoding) points at
+//! this service, which projects every [`otlp::LogRecord`] into a
+//! [`source_meta::Document`] and reconciles it into a Mixedbread store via
+//! `search-core`. Where the logs come from (a journald receiver, a `filelog`
+//! receiver, an app's OTLP SDK) is the collector's concern, so this stays one
+//! generic ingress for any OTLP log source.
+//!
+//! See [`server::router`] for the HTTP surface and [`ingest`] for the async
+//! upload pipeline.
+
+#![forbid(unsafe_code)]
+
+pub mod ingest;
+pub mod otlp;
+pub mod project;
+pub mod server;
+
+pub use ingest::{Config, Ingest, Sent, spawn};
+pub use server::{AppState, router};
+
+#[cfg(test)]
+mod tests {
+    use source_meta::keys;
+
+    use crate::otlp::ExportLogsServiceRequest;
+    use crate::project::project;
+
+    // A journald-shaped OTLP/JSON export: the journald receiver puts `MESSAGE`
+    // in the body and the journal fields in record attributes, with `host.name`
+    // and `service.name` in the resource. `intValue` is a string (proto3 JSON);
+    // `severityNumber` is the integer form.
+    const SAMPLE: &str = r#"{
+      "resourceLogs": [{
+        "resource": { "attributes": [
+          { "key": "host.name", "value": { "stringValue": "node-1" } },
+          { "key": "service.name", "value": { "stringValue": "nginx" } }
+        ] },
+        "scopeLogs": [{
+          "logRecords": [{
+            "timeUnixNano": "1700000000000000000",
+            "severityNumber": 17,
+            "severityText": "ERROR",
+            "body": { "stringValue": "upstream timed out" },
+            "attributes": [
+              { "key": "_SYSTEMD_UNIT", "value": { "stringValue": "nginx.service" } },
+              { "key": "SYSLOG_IDENTIFIER", "value": { "stringValue": "nginx" } },
+              { "key": "_PID", "value": { "intValue": "4242" } }
+            ]
+          }]
+        }]
+      }]
+    }"#;
+
+    fn first_document(json: &str, source: &str) -> source_meta::Document {
+        let request: ExportLogsServiceRequest = serde_json::from_str(json).expect("parse OTLP json");
+        let resource_logs = request.resource_logs.first().expect("one resourceLogs");
+        let record = resource_logs.scope_logs[0].log_records.first().expect("one record");
+        project(resource_logs.resource.as_ref(), record, source).expect("a document")
+    }
+
+    #[test]
+    fn projects_journald_record_with_structured_tags() {
+        let doc = first_document(SAMPLE, "log");
+        // Unit is embedded so a query can match on it, not just the message.
+        assert_eq!(doc.body, b"nginx.service: upstream timed out");
+        let meta = doc.meta_json.as_object().expect("object");
+        assert_eq!(meta[keys::SOURCE], "log");
+        assert_eq!(meta[keys::UNIT], "nginx.service");
+        assert_eq!(meta[keys::SERVICE_NAME], "nginx");
+        assert_eq!(meta[keys::SEVERITY], "ERROR");
+        assert_eq!(meta[keys::HOST], "node-1");
+        assert_eq!(meta[keys::PID], 4242);
+        assert_eq!(meta[keys::TIMESTAMP], 1_700_000_000);
+        assert!(doc.external_id.starts_with("log:sha256:"));
+    }
+
+    #[test]
+    fn re_delivery_is_idempotent() {
+        // Two projections of the same record must produce the same store id, so a
+        // collector retry overwrites rather than duplicates.
+        let a = first_document(SAMPLE, "log");
+        let b = first_document(SAMPLE, "log");
+        assert_eq!(a.external_id, b.external_id);
+        assert_eq!(a.content_hash, b.content_hash);
+    }
+
+    #[test]
+    fn empty_body_record_is_skipped() {
+        let json = r#"{"resourceLogs":[{"scopeLogs":[{"logRecords":[
+          {"body":{"stringValue":"   "}},
+          {"severityText":"INFO"}
+        ]}]}]}"#;
+        let request: ExportLogsServiceRequest = serde_json::from_str(json).expect("parse");
+        let records = &request.resource_logs[0].scope_logs[0].log_records;
+        assert!(project(None, &records[0], "log").is_none(), "blank body skipped");
+        assert!(project(None, &records[1], "log").is_none(), "missing body skipped");
+    }
+
+    #[test]
+    fn severity_number_accepts_enum_name() {
+        // proto3 JSON may encode the enum as its name instead of the integer.
+        let json = r#"{"resourceLogs":[{"scopeLogs":[{"logRecords":[
+          {"severityNumber":"SEVERITY_NUMBER_WARN","body":{"stringValue":"disk low"}}
+        ]}]}]}"#;
+        let request: ExportLogsServiceRequest = serde_json::from_str(json).expect("parse");
+        let record = &request.resource_logs[0].scope_logs[0].log_records[0];
+        let doc = project(None, record, "log").expect("a document");
+        assert_eq!(doc.meta_json[keys::SEVERITY], "WARN");
+    }
+}

--- a/packages/otlp-mixedbread/src/main.rs
+++ b/packages/otlp-mixedbread/src/main.rs
@@ -1,0 +1,126 @@
+//! `otlp-mixedbread`: receive OTLP logs over HTTP and index them into Mixedbread.
+//!
+//! Point the OpenTelemetry collector's `otlphttp` exporter (JSON encoding) at
+//! this service's `/v1/logs`; every log record becomes a semantically searchable
+//! document. Mixedbread auth comes from `MXBAI_API_KEY` (else the `mgrep login`
+//! token), the same as the `indexer`.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use clap::Parser;
+use search_core::{MixedbreadStore, Store as _};
+use tracing_subscriber::EnvFilter;
+
+use otlp_mixedbread::{AppState, Config, router, spawn};
+
+/// Receive OTLP logs over HTTP and index them into a Mixedbread store.
+#[derive(Debug, Parser)]
+#[command(name = "otlp-mixedbread", about, version)]
+struct Cli {
+    /// Mixedbread store to index log records into.
+    #[arg(long, env = "MXBAI_STORE")]
+    store: String,
+
+    /// Mixedbread API base URL override. Absent uses the SDK default.
+    #[arg(long = "base-url", env = "MXBAI_BASE_URL")]
+    base_url: Option<String>,
+
+    /// Address to serve the OTLP/HTTP receiver on. Defaults to loopback so the
+    /// co-located collector reaches it without exposing it on the network.
+    #[arg(long, env = "OTLP_MIXEDBREAD_LISTEN", default_value = "127.0.0.1:4319")]
+    listen: SocketAddr,
+
+    /// The `source` tag stamped on every document (the corpus name).
+    #[arg(long = "source-tag", default_value = "log")]
+    source_tag: String,
+
+    /// Drop records whose OTLP severity number is below this (1..=24, higher is
+    /// more severe; 13 = WARN). 0 keeps everything. A floor in addition to any
+    /// filtering the collector pipeline already applies.
+    #[arg(long = "min-severity-number", default_value_t = 0)]
+    min_severity: i32,
+
+    /// Maximum concurrent uploads to Mixedbread.
+    #[arg(long, default_value_t = 8)]
+    concurrency: usize,
+
+    /// Bounded queue depth between the HTTP handler and the upload workers. When
+    /// full, the handler returns 503 so the collector retries.
+    #[arg(long = "queue-capacity", default_value_t = 10_000)]
+    queue_capacity: usize,
+
+    /// How many recent record ids to remember to skip re-embedding on retries.
+    #[arg(long = "dedup-capacity", default_value_t = 100_000)]
+    dedup_capacity: usize,
+
+    /// Upload attempts per record before giving up (and logging the failure).
+    #[arg(long = "max-upload-attempts", default_value_t = 5)]
+    max_attempts: u32,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        .init();
+
+    let base_url = cli.base_url.unwrap_or_else(|| mixedbread::DEFAULT_BASE_URL.to_owned());
+    let store = MixedbreadStore::from_login(base_url).await.context("connecting to Mixedbread")?;
+    store.ensure_store(&cli.store).await.context("ensuring the Mixedbread store exists")?;
+
+    let ingest = spawn(
+        Arc::new(store),
+        Arc::from(cli.store.as_str()),
+        Config {
+            queue_capacity: cli.queue_capacity,
+            concurrency: cli.concurrency,
+            dedup_capacity: cli.dedup_capacity,
+            max_attempts: cli.max_attempts,
+        },
+    );
+
+    let app = router(AppState {
+        ingest,
+        source: Arc::from(cli.source_tag.as_str()),
+        min_severity: cli.min_severity,
+    });
+
+    let listener = tokio::net::TcpListener::bind(cli.listen)
+        .await
+        .with_context(|| format!("binding {}", cli.listen))?;
+    tracing::info!(listen = %cli.listen, store = %cli.store, "otlp-mixedbread ready");
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .context("serving OTLP/HTTP")?;
+    Ok(())
+}
+
+/// Resolve when the process receives Ctrl-C or `SIGTERM` (the systemd stop
+/// signal), so in-flight uploads can drain on shutdown.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut term) => {
+                term.recv().await;
+            }
+            Err(error) => tracing::warn!(%error, "failed to install SIGTERM handler"),
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {}
+        () = terminate => {}
+    }
+    tracing::info!("shutdown signal received");
+}

--- a/packages/otlp-mixedbread/src/otlp.rs
+++ b/packages/otlp-mixedbread/src/otlp.rs
@@ -1,0 +1,205 @@
+//! The subset of the OTLP/JSON logs schema we consume, plus helpers to flatten
+//! it into the shape the projection needs.
+//!
+//! We accept OTLP over HTTP with `encoding: json` (the collector's `otlphttp`
+//! exporter), so this is the protobuf-JSON mapping of `ExportLogsServiceRequest`
+//! ([opentelemetry-proto]), not protobuf. Only the fields we project are typed;
+//! everything else is ignored by serde. A field that proto3-JSON may encode as
+//! either a number or a string (an int64, an enum) is kept as a [`serde_json::Value`]
+//! and normalized in code rather than fighting serde over the dual encoding.
+//!
+//! [opentelemetry-proto]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/logs/v1/logs_service.proto
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+/// Top-level OTLP logs export request body.
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportLogsServiceRequest {
+    #[serde(default)]
+    pub resource_logs: Vec<ResourceLogs>,
+}
+
+/// Logs from one resource (a process/host), with its resource attributes.
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceLogs {
+    pub resource: Option<Resource>,
+    #[serde(default)]
+    pub scope_logs: Vec<ScopeLogs>,
+}
+
+/// A resource descriptor; we only read its attributes.
+#[derive(Debug, Deserialize, Default)]
+pub struct Resource {
+    #[serde(default)]
+    pub attributes: Vec<KeyValue>,
+}
+
+/// Logs from one instrumentation scope.
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ScopeLogs {
+    #[serde(default)]
+    pub log_records: Vec<LogRecord>,
+}
+
+/// One log line and its structured fields.
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct LogRecord {
+    /// Event time, nanoseconds since the Unix epoch, as a string (proto3 JSON).
+    #[serde(default)]
+    pub time_unix_nano: Option<String>,
+    /// When the collector observed the record; the fallback time.
+    #[serde(default)]
+    pub observed_time_unix_nano: Option<String>,
+    /// OTLP severity number 1..=24 (higher is more severe); a number or enum name.
+    #[serde(default)]
+    pub severity_number: Option<serde_json::Value>,
+    /// Human severity text (`ERROR`, `WARN`, ...), when set by the source.
+    #[serde(default)]
+    pub severity_text: Option<String>,
+    /// The log body; usually a `stringValue`.
+    pub body: Option<AnyValue>,
+    /// Record-level attributes (journald fields land here).
+    #[serde(default)]
+    pub attributes: Vec<KeyValue>,
+}
+
+/// One attribute: a key and its (optional) value.
+#[derive(Debug, Deserialize)]
+pub struct KeyValue {
+    pub key: String,
+    pub value: Option<AnyValue>,
+}
+
+/// OTLP `AnyValue`: exactly one of these fields is set. We render it to a string
+/// for metadata and bodies; nested array/kvlist values keep their JSON form.
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AnyValue {
+    pub string_value: Option<String>,
+    pub bool_value: Option<bool>,
+    pub int_value: Option<serde_json::Value>,
+    pub double_value: Option<f64>,
+    pub bytes_value: Option<String>,
+    pub array_value: Option<serde_json::Value>,
+    pub kvlist_value: Option<serde_json::Value>,
+}
+
+impl AnyValue {
+    /// The value as a display string, or `None` when no field is set.
+    #[must_use]
+    pub fn render(&self) -> Option<String> {
+        if let Some(text) = &self.string_value {
+            return Some(text.clone());
+        }
+        if let Some(flag) = self.bool_value {
+            return Some(flag.to_string());
+        }
+        if let Some(int) = &self.int_value {
+            return Some(scalar_string(int));
+        }
+        if let Some(float) = self.double_value {
+            return Some(float.to_string());
+        }
+        if let Some(array) = &self.array_value {
+            return Some(array.to_string());
+        }
+        if let Some(kvlist) = &self.kvlist_value {
+            return Some(kvlist.to_string());
+        }
+        self.bytes_value.clone()
+    }
+}
+
+/// A `serde_json` scalar as a bare string: the inner text for a JSON string, the
+/// numeric literal for a number, else its JSON form. Used because proto3 JSON
+/// encodes int64 as a string but some encoders still emit a number.
+fn scalar_string(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(text) => text.clone(),
+        serde_json::Value::Number(number) => number.to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// A flat, case-sensitive view of one record's attributes (resource attributes
+/// merged with record attributes, record winning), plus first-match lookup over
+/// candidate keys so a caller can try several spellings of the same field.
+pub struct Attrs {
+    map: HashMap<String, String>,
+}
+
+impl Attrs {
+    /// Merge resource then record attributes into one lookup. Record attributes
+    /// override resource ones on a key clash.
+    #[must_use]
+    pub fn merge(resource: Option<&Resource>, record: &LogRecord) -> Self {
+        let mut map = HashMap::new();
+        if let Some(resource) = resource {
+            insert_all(&mut map, &resource.attributes);
+        }
+        insert_all(&mut map, &record.attributes);
+        Self { map }
+    }
+
+    /// The first candidate key that is present, or `None`.
+    #[must_use]
+    pub fn first(&self, keys: &[&str]) -> Option<String> {
+        keys.iter().find_map(|key| self.map.get(*key).cloned())
+    }
+}
+
+/// Insert every renderable attribute into `map`.
+fn insert_all(map: &mut HashMap<String, String>, attributes: &[KeyValue]) {
+    for attribute in attributes {
+        if let Some(rendered) = attribute.value.as_ref().and_then(AnyValue::render) {
+            map.insert(attribute.key.clone(), rendered);
+        }
+    }
+}
+
+/// The numeric value of an OTLP `severityNumber`, whether encoded as an integer
+/// or the proto enum name (`SEVERITY_NUMBER_ERROR` -> 17). `None` when absent or
+/// unrecognized.
+#[must_use]
+pub fn severity_number(value: Option<&serde_json::Value>) -> Option<i32> {
+    let value = value?;
+    if let Some(int) = value.as_i64() {
+        return i32::try_from(int).ok();
+    }
+    let name = value.as_str()?;
+    // SeverityNumber enum: 4 tiers of 4, TRACE..FATAL. The suffix names map to a
+    // base; the numbered variants (`..._ERROR2`) add an offset.
+    let (base, tier) = match name.trim_start_matches("SEVERITY_NUMBER_") {
+        n if n.starts_with("TRACE") => (1, n.strip_prefix("TRACE")),
+        n if n.starts_with("DEBUG") => (5, n.strip_prefix("DEBUG")),
+        n if n.starts_with("INFO") => (9, n.strip_prefix("INFO")),
+        n if n.starts_with("WARN") => (13, n.strip_prefix("WARN")),
+        n if n.starts_with("ERROR") => (17, n.strip_prefix("ERROR")),
+        n if n.starts_with("FATAL") => (21, n.strip_prefix("FATAL")),
+        _ => return None,
+    };
+    // "" or "2".."4" -> offset 0..3.
+    let offset = tier.and_then(|t| t.parse::<i32>().ok()).map_or(0, |n| n - 1);
+    Some(base + offset.clamp(0, 3))
+}
+
+/// The standard short label for an OTLP severity number, for titles when the
+/// source did not set `severityText`.
+#[must_use]
+pub fn severity_label(number: i32) -> &'static str {
+    match number {
+        1..=4 => "TRACE",
+        5..=8 => "DEBUG",
+        9..=12 => "INFO",
+        13..=16 => "WARN",
+        17..=20 => "ERROR",
+        n if n >= 21 => "FATAL",
+        _ => "UNSPECIFIED",
+    }
+}

--- a/packages/otlp-mixedbread/src/project.rs
+++ b/packages/otlp-mixedbread/src/project.rs
@@ -25,6 +25,12 @@ struct Fields {
     pid: Option<i64>,
     boot_id: Option<String>,
     severity: Option<String>,
+    priority: Option<u8>,
+    /// Raw `time_unix_nano` string (full nanosecond precision); the identity axis
+    /// for `external_id`. `timestamp` below is the same value floored to seconds
+    /// for the recency metadata, but the id must keep nanoseconds so two records
+    /// in the same second do not collide.
+    time_nanos: Option<String>,
     timestamp: Option<i64>,
 }
 
@@ -54,6 +60,8 @@ pub fn project(resource: Option<&Resource>, record: &LogRecord, source: &str) ->
     let severity = record.severity_text.clone().or_else(|| {
         severity_number(record.severity_number.as_ref()).map(|n| severity_label(n).to_owned())
     });
+    let time_nanos = record.time_unix_nano.clone().or_else(|| record.observed_time_unix_nano.clone());
+    let timestamp = time_nanos.as_deref().and_then(|nanos| nanos.parse::<i64>().ok()).map(|nanos| nanos / NANOS_PER_SEC);
     let fields = Fields {
         body,
         host: attrs.first(&["host.name", "_HOSTNAME", "host"]),
@@ -63,12 +71,9 @@ pub fn project(resource: Option<&Resource>, record: &LogRecord, source: &str) ->
         pid: attrs.first(&["_PID", "process.pid"]).and_then(|value| value.parse().ok()),
         boot_id: attrs.first(&["_BOOT_ID"]),
         severity,
-        timestamp: record
-            .time_unix_nano
-            .as_deref()
-            .or(record.observed_time_unix_nano.as_deref())
-            .and_then(|nanos| nanos.parse::<i64>().ok())
-            .map(|nanos| nanos / NANOS_PER_SEC),
+        priority: attrs.first(&["PRIORITY", "_PRIORITY"]).and_then(|value| value.parse().ok()),
+        time_nanos,
+        timestamp,
     };
 
     document(&fields, source)
@@ -91,6 +96,7 @@ fn document(fields: &Fields, source: &str) -> Option<Document> {
     insert_some(&mut meta, keys::SYSLOG_IDENTIFIER, fields.identifier.clone().map(Value::from));
     insert_some(&mut meta, keys::SERVICE_NAME, fields.service_name.clone().map(Value::from));
     insert_some(&mut meta, keys::SEVERITY, fields.severity.clone().map(Value::from));
+    insert_some(&mut meta, keys::PRIORITY, fields.priority.map(Value::from));
     insert_some(&mut meta, keys::PID, fields.pid.map(Value::from));
     insert_some(&mut meta, keys::BOOT_ID, fields.boot_id.clone().map(Value::from));
     insert_some(&mut meta, keys::TIMESTAMP, fields.timestamp.map(Value::from));
@@ -114,12 +120,21 @@ fn document(fields: &Fields, source: &str) -> Option<Document> {
 }
 
 /// A stable, unique id for the record: `log:<sha256 of identity>`. The identity
-/// is time + host + unit + body, so two deliveries of one record collide (good:
-/// idempotent overwrite) while distinct records do not.
+/// is `time_nanos + host + label + severity + pid + body`, so two deliveries of
+/// one record collide (good: idempotent overwrite) while distinct records do not.
+///
+/// The full nanosecond timestamp (not the seconds-floored `timestamp`) is the
+/// key axis: journald commonly emits many distinct records with identical text
+/// from one unit within the same second (a tight error loop), and a seconds-only
+/// id would overwrite all but the last. `severity`/`pid` add further separation
+/// for the rare same-nanosecond case.
 fn external_id(fields: &Fields, label: &str) -> String {
-    let timestamp = fields.timestamp.unwrap_or(0);
+    let nanos = fields.time_nanos.as_deref().unwrap_or("0");
     let host = fields.host.as_deref().unwrap_or("");
-    let identity = format!("{timestamp}\u{1f}{host}\u{1f}{label}\u{1f}{}", fields.body);
+    let severity = fields.severity.as_deref().unwrap_or("");
+    let pid = fields.pid.map_or_else(String::new, |pid| pid.to_string());
+    let identity =
+        format!("{nanos}\u{1f}{host}\u{1f}{label}\u{1f}{severity}\u{1f}{pid}\u{1f}{}", fields.body);
     format!("log:{}", source_meta::hash_body(identity.as_bytes()))
 }
 

--- a/packages/otlp-mixedbread/src/project.rs
+++ b/packages/otlp-mixedbread/src/project.rs
@@ -1,0 +1,145 @@
+//! Projection of one OTLP [`LogRecord`] into a Mixedbread [`Document`].
+//!
+//! The embedded body is `"<label>: <message>"` so a semantic query matches on the
+//! unit/service as well as the text. The `external_id` is a content hash over the
+//! record's identity (time + host + unit + body), so re-delivery of the same
+//! record (a collector retry) is idempotent: it maps to the same store id and
+//! overwrites rather than duplicating. A log record is immutable, so its
+//! `content_hash` is stable too.
+
+use source_meta::{Document, keys};
+use serde_json::{Map, Value, json};
+
+use crate::otlp::{Attrs, LogRecord, Resource, severity_label, severity_number};
+
+/// Nanoseconds per second; OTLP timestamps are nanoseconds since the epoch.
+const NANOS_PER_SEC: i64 = 1_000_000_000;
+
+/// A record reduced to the fields we store, with the merged attribute view.
+struct Fields {
+    body: String,
+    host: Option<String>,
+    unit: Option<String>,
+    identifier: Option<String>,
+    service_name: Option<String>,
+    pid: Option<i64>,
+    boot_id: Option<String>,
+    severity: Option<String>,
+    timestamp: Option<i64>,
+}
+
+impl Fields {
+    /// The display label for the log's origin: unit, else program identifier,
+    /// else service name, else a generic tag.
+    fn label(&self) -> &str {
+        self.unit
+            .as_deref()
+            .or(self.identifier.as_deref())
+            .or(self.service_name.as_deref())
+            .unwrap_or("log")
+    }
+}
+
+/// Project one record (with its resource) into a [`Document`], or `None` when it
+/// has no body to embed or its metadata would exceed the store limits. The
+/// `source` tag scopes the corpus (e.g. `"log"`).
+#[must_use]
+pub fn project(resource: Option<&Resource>, record: &LogRecord, source: &str) -> Option<Document> {
+    let attrs = Attrs::merge(resource, record);
+    let body = record.body.as_ref().and_then(|value| value.render())?;
+    if body.trim().is_empty() {
+        return None;
+    }
+
+    let severity = record.severity_text.clone().or_else(|| {
+        severity_number(record.severity_number.as_ref()).map(|n| severity_label(n).to_owned())
+    });
+    let fields = Fields {
+        body,
+        host: attrs.first(&["host.name", "_HOSTNAME", "host"]),
+        unit: attrs.first(&["_SYSTEMD_UNIT", "systemd.unit", "_SYSTEMD_USER_UNIT"]),
+        identifier: attrs.first(&["SYSLOG_IDENTIFIER", "syslog.identifier", "_COMM"]),
+        service_name: attrs.first(&["service.name"]),
+        pid: attrs.first(&["_PID", "process.pid"]).and_then(|value| value.parse().ok()),
+        boot_id: attrs.first(&["_BOOT_ID"]),
+        severity,
+        timestamp: record
+            .time_unix_nano
+            .as_deref()
+            .or(record.observed_time_unix_nano.as_deref())
+            .and_then(|nanos| nanos.parse::<i64>().ok())
+            .map(|nanos| nanos / NANOS_PER_SEC),
+    };
+
+    document(&fields, source)
+}
+
+/// Build the [`Document`] from reduced fields, or `None` if metadata is too big.
+fn document(fields: &Fields, source: &str) -> Option<Document> {
+    let label = fields.label();
+    let embedded = format!("{label}: {}", fields.body);
+    let content_hash = source_meta::hash_body(embedded.as_bytes());
+    let external_id = external_id(fields, label);
+
+    let mut meta = Map::new();
+    meta.insert(keys::SOURCE.to_owned(), json!(source));
+    meta.insert("external_id".to_owned(), json!(external_id));
+    meta.insert(keys::CONTENT_HASH.to_owned(), json!(content_hash));
+    meta.insert(keys::TITLE.to_owned(), json!(title(fields, label)));
+    insert_some(&mut meta, keys::HOST, fields.host.clone().map(Value::from));
+    insert_some(&mut meta, keys::UNIT, fields.unit.clone().map(Value::from));
+    insert_some(&mut meta, keys::SYSLOG_IDENTIFIER, fields.identifier.clone().map(Value::from));
+    insert_some(&mut meta, keys::SERVICE_NAME, fields.service_name.clone().map(Value::from));
+    insert_some(&mut meta, keys::SEVERITY, fields.severity.clone().map(Value::from));
+    insert_some(&mut meta, keys::PID, fields.pid.map(Value::from));
+    insert_some(&mut meta, keys::BOOT_ID, fields.boot_id.clone().map(Value::from));
+    insert_some(&mut meta, keys::TIMESTAMP, fields.timestamp.map(Value::from));
+    let meta_json = Value::Object(meta);
+
+    if let Err(error) = source_meta::check_metadata(&external_id, &meta_json) {
+        // A pathological record (huge attribute) is dropped, not fatal; the rest
+        // of the batch still flows.
+        tracing::warn!(%external_id, %error, "dropping log record: metadata over limit");
+        return None;
+    }
+
+    Some(Document {
+        external_id,
+        file_name: format!("{}.txt", &content_hash["sha256:".len()..]),
+        mime: "text/plain",
+        body: embedded.into_bytes(),
+        meta_json,
+        content_hash,
+    })
+}
+
+/// A stable, unique id for the record: `log:<sha256 of identity>`. The identity
+/// is time + host + unit + body, so two deliveries of one record collide (good:
+/// idempotent overwrite) while distinct records do not.
+fn external_id(fields: &Fields, label: &str) -> String {
+    let timestamp = fields.timestamp.unwrap_or(0);
+    let host = fields.host.as_deref().unwrap_or("");
+    let identity = format!("{timestamp}\u{1f}{host}\u{1f}{label}\u{1f}{}", fields.body);
+    format!("log:{}", source_meta::hash_body(identity.as_bytes()))
+}
+
+/// A short human title: `log[<severity>] <label>: <first line>` capped.
+fn title(fields: &Fields, label: &str) -> String {
+    let severity = fields.severity.as_deref().unwrap_or("");
+    let snippet: String = fields
+        .body
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or_default()
+        .chars()
+        .take(80)
+        .collect();
+    format!("log[{severity}] {label}: {snippet}")
+}
+
+/// Insert `key` only when a value is present, keeping absent tags off the record.
+fn insert_some(meta: &mut Map<String, Value>, key: &str, value: Option<Value>) {
+    if let Some(value) = value {
+        meta.insert(key.to_owned(), value);
+    }
+}

--- a/packages/otlp-mixedbread/src/server.rs
+++ b/packages/otlp-mixedbread/src/server.rs
@@ -1,0 +1,121 @@
+//! The OTLP/HTTP front door: a `POST /v1/logs` receiver and a `/health` probe.
+//!
+//! We accept the OTLP logs export in JSON encoding (the collector's `otlphttp`
+//! exporter with `encoding: json`). Compressed bodies are rejected with `415`;
+//! configure the exporter with `compression: none` (the collector and this
+//! service share a host or a local network, so compression buys little). On a
+//! full upload queue the handler returns `503` so the collector retries with
+//! backoff rather than this service buffering without bound.
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+
+use crate::ingest::{Ingest, Sent};
+use crate::otlp::{ExportLogsServiceRequest, severity_number};
+use crate::project::project;
+
+/// Shared handler state.
+#[derive(Clone)]
+pub struct AppState {
+    /// The upload pipeline handle.
+    pub ingest: Arc<Ingest>,
+    /// The `source` tag stamped on every document (the corpus name).
+    pub source: Arc<str>,
+    /// Drop records whose OTLP severity number is below this (0 keeps all). A
+    /// defense-in-depth floor; the collector pipeline is the primary filter.
+    pub min_severity: i32,
+}
+
+/// Build the router for the OTLP logs receiver.
+#[must_use]
+pub fn router(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/logs", post(ingest_logs))
+        .route("/health", get(health))
+        .with_state(state)
+}
+
+/// Liveness probe.
+async fn health() -> StatusCode {
+    StatusCode::OK
+}
+
+/// Receive one OTLP logs export, project each record, and enqueue it.
+async fn ingest_logs(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    if is_compressed(&headers) {
+        return (
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "compressed bodies are not supported; set the exporter `compression: none`",
+        )
+            .into_response();
+    }
+
+    let request: ExportLogsServiceRequest = match serde_json::from_slice(&body) {
+        Ok(request) => request,
+        Err(error) => {
+            return (StatusCode::BAD_REQUEST, format!("invalid OTLP/JSON logs body: {error}"))
+                .into_response();
+        }
+    };
+
+    let mut accepted = 0_u64;
+    let mut dropped = 0_u64;
+    // A full queue aborts the batch (we have not consumed it), so the collector
+    // retries the whole export; dedup keeps the retry from re-embedding.
+    for resource_logs in &request.resource_logs {
+        for scope_logs in &resource_logs.scope_logs {
+            for record in &scope_logs.log_records {
+                if below_floor(record.severity_number.as_ref(), state.min_severity) {
+                    dropped += 1;
+                    continue;
+                }
+                let Some(document) = project(resource_logs.resource.as_ref(), record, &state.source)
+                else {
+                    dropped += 1;
+                    continue;
+                };
+                match state.ingest.offer(document) {
+                    Sent::Accepted => accepted += 1,
+                    Sent::Full => return backpressure(accepted),
+                    Sent::Closed => {
+                        return (StatusCode::SERVICE_UNAVAILABLE, "shutting down").into_response();
+                    }
+                }
+            }
+        }
+    }
+
+    tracing::debug!(accepted, dropped, "accepted OTLP logs batch");
+    // An empty `ExportLogsServiceResponse` signals full success to the collector.
+    (StatusCode::OK, [(header::CONTENT_TYPE, "application/json")], "{}").into_response()
+}
+
+/// Tell the collector to retry: queue is full. `Retry-After` is advisory.
+fn backpressure(accepted_before_full: u64) -> axum::response::Response {
+    tracing::warn!(accepted_before_full, "upload queue full, asking collector to retry");
+    (StatusCode::SERVICE_UNAVAILABLE, [(header::RETRY_AFTER, "1")], "upload queue full")
+        .into_response()
+}
+
+/// Whether the request carries a non-identity `Content-Encoding`.
+fn is_compressed(headers: &HeaderMap) -> bool {
+    headers.get(header::CONTENT_ENCODING).is_some_and(|value| {
+        !value.as_bytes().eq_ignore_ascii_case(b"identity") && !value.is_empty()
+    })
+}
+
+/// Whether a record falls below the severity floor. A record with no severity is
+/// kept (we do not drop unlabeled logs); a floor of 0 keeps everything.
+fn below_floor(severity: Option<&serde_json::Value>, floor: i32) -> bool {
+    floor > 0 && severity_number(severity).is_some_and(|number| number < floor)
+}

--- a/packages/source/meta/src/keys.rs
+++ b/packages/source/meta/src/keys.rs
@@ -77,6 +77,23 @@ pub const OUTPUT_TOKENS: &str = "output_tokens";
 /// Process exit status of a recorded shell command.
 pub const EXIT_STATUS: &str = "exit_status";
 
+// Logs (systemd journal via the OTel collector, plus any OTLP log source).
+// `host` and `timestamp` above are reused.
+/// systemd unit that emitted the entry (`_SYSTEMD_UNIT` or the user unit).
+pub const UNIT: &str = "unit";
+/// syslog priority 0..=7 (0 = emerg, 7 = debug), an integer for range filters.
+pub const PRIORITY: &str = "priority";
+/// OTLP severity text (`ERROR`, `WARN`, ...), the cross-source severity axis.
+pub const SEVERITY: &str = "severity";
+/// OTLP `service.name` resource attribute, when present.
+pub const SERVICE_NAME: &str = "service_name";
+/// Free-form program identifier (`SYSLOG_IDENTIFIER`, falling back to `_COMM`).
+pub const SYSLOG_IDENTIFIER: &str = "syslog_identifier";
+/// Boot id the entry was recorded under (`_BOOT_ID`).
+pub const BOOT_ID: &str = "boot_id";
+/// PID of the process that logged the entry (`_PID`).
+pub const PID: &str = "pid";
+
 // Linear.
 /// Linear issue identifier, e.g. `ENG-1885`.
 pub const IDENTIFIER: &str = "identifier";


### PR DESCRIPTION
Sends systemd/app logs to Mixedbread for semantic search by riding the OpenTelemetry pipeline instead of re-reading the journal.

New `otlp-mixedbread` service (axum OTLP/HTTP logs receiver): maps each OTLP `LogRecord` to a `source-meta` `Document` and reconciles it into a Mixedbread store via `search-core`. Bounded queue + concurrent uploads + retry; deterministic per-record `external_id` so a collector retry is an idempotent overwrite, plus a dedup cache to skip re-embedding.

Wired into the observability module as an additive logs-pipeline exporter: `services.ix-observability.collector.mixedbread.enable`. The collector's `otlphttp` exporter (JSON, no compression) points at the loopback bridge, so journald/filelog/app logs already collected also land in Mixedbread. Collection stays the collector's job; Mixedbread sits at the exporter layer (the agent-to-gateway shape).

Context: chosen over a bespoke `journalctl` source so there's one collection path, and over a custom Go collector exporter so the Mixedbread mapping stays in our Rust. Cross-VM placement (local vs remote collector) is tracked separately in #638.

Validation:
- `nix build .#otlp-mixedbread` (compiles + links on darwin under deny-warnings)
- `cargo test -p otlp-mixedbread` 6/6 (projection, severity-enum decode, idempotent re-delivery, dedup)
- `cargo clippy -p otlp-mixedbread` clean (all/pedantic/nursery)
- `nix run .#lint` 5/5
- Not yet validated: the NixOS module's x86_64-linux eval/build (collector YAML render + unit). Relying on CI for that layer.

Follow-up: enabling it on the fleet (set `collector.mixedbread.enable` + wire `MXBAI_API_KEY` via the secret store) is an ix-repo change.

---
Made with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `otlp-mixedbread` service to index OTLP logs into Mixedbread for semantic search
> - Adds a new `otlp-mixedbread` binary ([main.rs](https://github.com/indexable-inc/index/pull/639/files#diff-1a458c3ad14a4e26dc7ac885a2a204cf63a7398a75e0d75d201a20090f08ed66)) that runs an OTLP/HTTP server, receives logs at `/v1/logs`, and uploads them as documents to a Mixedbread vector store.
> - OTLP log records are projected into structured documents ([project.rs](https://github.com/indexable-inc/index/pull/639/files#diff-1c147b03e6f26e9c3c99f81f6e72cc0fd773b1a6f31d6723f216214ab8041670)) with stable `external_id` hashing so re-deliveries produce idempotent overwrites.
> - An async upload pipeline ([ingest.rs](https://github.com/indexable-inc/index/pull/639/files#diff-8f01a213c5777a3571717f7dd5c4e7a736f1f8a64a1e8c0ac4b17a912d6b5d77)) provides bounded queueing, per-`external_id` deduplication, bounded concurrency, and exponential backoff retry.
> - The NixOS observability module ([default.nix](https://github.com/indexable-inc/index/pull/639/files#diff-7029ccc17804e27e33f1692b141cd10d0044f44ce657aa3cd8520cc7e35807cb)) gains a `collector.mixedbread` option block; when enabled, it starts a `otlp-mixedbread` systemd service and adds an `otlphttp/mixedbread` exporter to the OpenTelemetry Collector log pipeline.
> - New metadata keys (`UNIT`, `PRIORITY`, `SEVERITY`, `SERVICE_NAME`, `BOOT_ID`, `PID`) are added to [source_meta/keys.rs](https://github.com/indexable-inc/index/pull/639/files#diff-2c2b3a88424c9ff11c748ed438367ed943da8868bfa26e61205879eeeca11734) for log document tagging.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b571db8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->