### PR TITLE
feat(claude-stories): tailnet-p2p stories for Claude Code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,6 +984,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "claude-stories"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "clap",
+ "color-eyre",
+ "git2",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "clone-cli"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5683,18 +5683,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "skill-lint"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "clap",
- "ignore",
- "serde",
- "serde_json",
- "serde_norway",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5756,6 +5744,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "skill-lint"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ignore",
+ "serde",
+ "serde_json",
+ "serde_norway",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "modules/services/resource-monitor/stats-writer",
   "packages/agents-md",
+  "packages/claude-stories",
   "packages/ast-merge/ast",
   "packages/ast-merge/cli",
   "packages/ast-merge/diff",

--- a/packages/claude-stories/Cargo.toml
+++ b/packages/claude-stories/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "claude-stories"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Instagram-style 'stories' for Claude Code: a status-line row of teammates' avatars and what they're working on, served peer-to-peer over a Tailscale tailnet"
+
+[lints]
+workspace = true
+
+[dependencies]
+axum = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+color-eyre.workspace = true
+# Story content is derived from the local repo (name, branch, last commit
+# subject, author identity). `default-features = false` + `vendored-libgit2`
+# drops the https/ssh transports and builds the bundled libgit2 with `cc`, so the
+# build needs no system libgit2 or cmake. Matches git-log-pretty.
+git2 = { workspace = true, default-features = false, features = ["vendored-libgit2"] }
+reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+# `serve` is an HTTP listener; `render` fans out concurrent fetches. A
+# multi-thread runtime keeps both simple.
+tokio = { workspace = true, features = ["rt-multi-thread", "net", "time", "macros"] }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/packages/claude-stories/README.md
+++ b/packages/claude-stories/README.md
@@ -1,0 +1,84 @@
+# claude-stories
+
+Instagram-style "stories" for [Claude Code](https://code.claude.com): a status-line
+row of your teammates' avatars and what each is working on right now. Inspired by
+Ben Awad's [vscode-stories](https://github.com/benawad/vscode-stories).
+
+Each avatar is two half-circle glyphs around the author's initials, colored along
+the Instagram story gradient, and is a clickable link to their repo. Claude Code
+strips Kitty graphics sequences from status-line output
+([anthropics/claude-code#39024](https://github.com/anthropics/claude-code/issues/39024)),
+so real profile photos are not possible there; text-art rings are the faithful
+substitute.
+
+```
+📸 STORIES  ◖+◗  ◖AG◗  ◖WG◗  ◖HA◗
+```
+
+## How it works
+
+Three commands, no central server:
+
+- `claude-stories publish` reads the current git repo (name, branch, latest commit
+  subject, author identity) and writes a story to a small state file.
+- `claude-stories serve` exposes that file at `GET /story` over HTTP.
+- `claude-stories render` discovers peers, fetches everyone's `/story`
+  concurrently, drops anything older than 24h, and prints the avatar row.
+
+Discovery defaults to the **Tailscale tailnet**: `tailscale status --json` is
+already an authenticated, NAT-traversed directory of every online device, so it
+doubles as the peer list. No DHT, no bootstrap nodes, no OAuth. Set
+`CLAUDE_STORIES_PEERS=host[:port],...` to use an explicit list instead (testing,
+or running off a tailnet).
+
+## Wiring it into Claude Code
+
+Build it: `nix build .#claude-stories` (or add the package to your home config).
+
+Status line, in `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": { "type": "command", "command": "claude-stories render" }
+}
+```
+
+Publish your own story whenever you start a session, via a `SessionStart` hook in
+the same file:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [ { "type": "command", "command": "claude-stories publish" } ] }
+    ]
+  }
+}
+```
+
+Run the server once per host (for example through `homeModules.portable-services`,
+or any launchd/systemd user unit):
+
+```
+claude-stories serve
+```
+
+## Commands
+
+| Command | Purpose |
+| --- | --- |
+| `claude-stories publish [--path DIR]` | Derive the current repo's story, write the state file. |
+| `claude-stories serve [--port 4810] [--bind 0.0.0.0]` | Serve the published story at `/story`. |
+| `claude-stories render [--port 4810]` | Status-line row of peers' fresh stories. |
+| `claude-stories show [--path DIR]` | Print the current repo's story as JSON. |
+
+## Known limitations
+
+- **No real avatars in the status line.** Image escapes are stripped by Claude
+  Code today; this renders initials in gradient rings instead.
+- **Off-tailnet needs explicit peers.** Without Tailscale, discovery has nothing
+  to enumerate, so set `CLAUDE_STORIES_PEERS`. A hosted rendezvous transport is a
+  natural future addition for the public case.
+- **Your story is the last repo you published from**, not a live view of whatever
+  directory each Claude session is in. Re-run `publish` (the hook does this) to
+  update it.

--- a/packages/claude-stories/README.md
+++ b/packages/claude-stories/README.md
@@ -79,6 +79,10 @@ claude-stories serve
 - **Off-tailnet needs explicit peers.** Without Tailscale, discovery has nothing
   to enumerate, so set `CLAUDE_STORIES_PEERS`. A hosted rendezvous transport is a
   natural future addition for the public case.
+- **`serve` binds `0.0.0.0` and is unauthenticated.** It serves low-sensitivity
+  data (your latest commit subject) and relies entirely on your tailnet ACLs, so
+  the same port is reachable from any other network the host is on. Firewall it
+  to the Tailscale interface, or pass `--bind` your tailnet IP, on shared networks.
 - **Your story is the last repo you published from**, not a live view of whatever
   directory each Claude session is in. Re-run `publish` (the hook does this) to
   update it.

--- a/packages/claude-stories/default.nix
+++ b/packages/claude-stories/default.nix
@@ -1,0 +1,10 @@
+{ ix, lib, ... }:
+
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "claude-stories";
+  meta = {
+    description = "Instagram-style status-line 'stories' for Claude Code, served peer-to-peer over a Tailscale tailnet";
+    license = lib.licenses.mit;
+    mainProgram = "claude-stories";
+  };
+}

--- a/packages/claude-stories/package.nix
+++ b/packages/claude-stories/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "claude-stories";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/claude-stories/src/avatar.rs
+++ b/packages/claude-stories/src/avatar.rs
@@ -1,0 +1,137 @@
+//! Text-art "avatars" for the status line. Claude Code strips Kitty graphics
+//! APC sequences from status-line output (`anthropics/claude-code#39024`), so real
+//! profile images are impossible there. Instead each avatar is two half-circle
+//! glyphs (◖ ◗) flanking the author's initials, colored along the Instagram
+//! story gradient (purple -> pink -> orange) so the row reads as ringed avatars.
+
+use crate::story::Story;
+
+type Rgb = (u8, u8, u8);
+
+/// Instagram story-ring gradient stops.
+const GRADIENT: [Rgb; 5] = [
+    (0x83, 0x3A, 0xB4),
+    (0xC1, 0x35, 0x84),
+    (0xE1, 0x30, 0x6C),
+    (0xFC, 0xAF, 0x45),
+    (0xF7, 0x77, 0x37),
+];
+
+const RESET: &str = "\x1b[0m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+
+// The result is a rounded color component clamped to 0..=255, so the byte cast
+// cannot lose information. Same idiom as git-log-pretty's palette.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn lerp(a: u8, b: u8, t: f32) -> u8 {
+    (f32::from(a) + (f32::from(b) - f32::from(a)) * t)
+        .round()
+        .clamp(0.0, 255.0) as u8
+}
+
+/// Sample the gradient at `t` in `[0, 1]`.
+// `t` is clamped to 0..=1 and GRADIENT is tiny, so the index and float casts are
+// bounded and stay within the array.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss
+)]
+fn grad(t: f32) -> Rgb {
+    let t = t.clamp(0.0, 1.0);
+    let span = t * (GRADIENT.len() - 1) as f32;
+    let i = span.floor() as usize;
+    if i >= GRADIENT.len() - 1 {
+        return GRADIENT[GRADIENT.len() - 1];
+    }
+    let f = span - i as f32;
+    let (a, b) = (GRADIENT[i], GRADIENT[i + 1]);
+    (lerp(a.0, b.0, f), lerp(a.1, b.1, f), lerp(a.2, b.2, f))
+}
+
+fn fg((r, g, b): Rgb) -> String {
+    format!("\x1b[38;2;{r};{g};{b}m")
+}
+
+/// Up to two uppercase initials from a display name.
+fn initials(name: &str) -> String {
+    let words: Vec<&str> = name
+        .split(|c: char| c.is_whitespace() || c == '-' || c == '_')
+        .filter(|s| !s.is_empty())
+        .collect();
+    let pick = |s: &str| s.chars().next().map(|c| c.to_ascii_uppercase());
+    let two: String = match words.as_slice() {
+        [a, b, ..] => [pick(a), pick(b)].into_iter().flatten().collect(),
+        [a] => a.chars().filter(|c| c.is_alphanumeric()).take(2).collect::<String>().to_uppercase(),
+        [] => String::new(),
+    };
+    if two.is_empty() { "??".to_owned() } else { two }
+}
+
+/// Wrap `text` in an OSC 8 hyperlink when a target is present.
+fn link(text: &str, url: Option<&str>) -> String {
+    match url {
+        Some(u) => format!("\x1b]8;;{u}\x1b\\{text}\x1b]8;;\x1b\\"),
+        None => text.to_owned(),
+    }
+}
+
+/// A single ringed avatar: ◖INITIALS◗ in gradient colors.
+fn avatar(story: &Story) -> String {
+    let left = fg(grad(0.15));
+    let mid = fg(grad(0.5));
+    let right = fg(grad(0.85));
+    let ini = initials(&story.name);
+    let token = format!("{left}◖{mid}{BOLD}{ini}{RESET}{right}◗{RESET}");
+    link(&token, story.url.as_deref())
+}
+
+/// The leading "your story" bubble: a dim ◖+◗.
+fn add_bubble() -> String {
+    format!("{DIM}◖{RESET}{BOLD}+{RESET}{DIM}◗{RESET}")
+}
+
+/// Render the full status-line row from the peer stories (already filtered to
+/// the fresh ones). Newest first.
+pub fn row(mut stories: Vec<Story>) -> String {
+    stories.sort_by(|a, b| b.ts.cmp(&a.ts));
+    let label = format!("{}{BOLD}📸 STORIES{RESET}", fg(grad(0.5)));
+    let mut parts = vec![label, add_bubble()];
+    parts.extend(stories.iter().map(avatar));
+    parts.join("  ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initials_handles_common_shapes() {
+        assert_eq!(initials("Andrew Gazelka"), "AG");
+        assert_eq!(initials("wyatt-gill"), "WG");
+        assert_eq!(initials("amber"), "AM");
+        assert_eq!(initials(""), "??");
+    }
+
+    #[test]
+    fn gradient_endpoints_are_stable() {
+        assert_eq!(grad(0.0), GRADIENT[0]);
+        assert_eq!(grad(1.0), GRADIENT[GRADIENT.len() - 1]);
+    }
+
+    #[test]
+    fn row_contains_label_and_initials() {
+        let s = Story {
+            name: "Andrew Gazelka".into(),
+            repo: "index".into(),
+            branch: "main".into(),
+            subject: "x".into(),
+            ts: 0,
+            url: None,
+        };
+        let out = row(vec![s]);
+        assert!(out.contains("STORIES"));
+        assert!(out.contains("AG"));
+    }
+}

--- a/packages/claude-stories/src/avatar.rs
+++ b/packages/claude-stories/src/avatar.rs
@@ -25,7 +25,8 @@ const DIM: &str = "\x1b[2m";
 // cannot lose information. Same idiom as git-log-pretty's palette.
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn lerp(a: u8, b: u8, t: f32) -> u8 {
-    (f32::from(a) + (f32::from(b) - f32::from(a)) * t)
+    (f32::from(b) - f32::from(a))
+        .mul_add(t, f32::from(a))
         .round()
         .clamp(0.0, 255.0) as u8
 }
@@ -36,7 +37,8 @@ fn lerp(a: u8, b: u8, t: f32) -> u8 {
 #[allow(
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
-    clippy::cast_precision_loss
+    clippy::cast_precision_loss,
+    clippy::many_single_char_names
 )]
 fn grad(t: f32) -> Rgb {
     let t = t.clamp(0.0, 1.0);
@@ -69,12 +71,20 @@ fn initials(name: &str) -> String {
     if two.is_empty() { "??".to_owned() } else { two }
 }
 
-/// Wrap `text` in an OSC 8 hyperlink when a target is present.
+/// A peer-supplied URL is safe to emit as a hyperlink only if it is plain
+/// http(s) and carries no control characters. Stories come from untrusted peer
+/// JSON, so an unguarded `url` would let any tailnet host inject terminal escape
+/// sequences into the victim's status line via the OSC 8 payload.
+fn is_safe_url(u: &str) -> bool {
+    (u.starts_with("https://") || u.starts_with("http://")) && !u.chars().any(char::is_control)
+}
+
+/// Wrap `text` in an OSC 8 hyperlink when a safe target is present.
 fn link(text: &str, url: Option<&str>) -> String {
-    match url {
-        Some(u) => format!("\x1b]8;;{u}\x1b\\{text}\x1b]8;;\x1b\\"),
-        None => text.to_owned(),
-    }
+    url.filter(|u| is_safe_url(u)).map_or_else(
+        || text.to_owned(),
+        |u| format!("\x1b]8;;{u}\x1b\\{text}\x1b]8;;\x1b\\"),
+    )
 }
 
 /// A single ringed avatar: ◖INITIALS◗ in gradient colors.
@@ -95,7 +105,7 @@ fn add_bubble() -> String {
 /// Render the full status-line row from the peer stories (already filtered to
 /// the fresh ones). Newest first.
 pub fn row(mut stories: Vec<Story>) -> String {
-    stories.sort_by(|a, b| b.ts.cmp(&a.ts));
+    stories.sort_by_key(|s| std::cmp::Reverse(s.ts));
     let label = format!("{}{BOLD}📸 STORIES{RESET}", fg(grad(0.5)));
     let mut parts = vec![label, add_bubble()];
     parts.extend(stories.iter().map(avatar));
@@ -118,6 +128,16 @@ mod tests {
     fn gradient_endpoints_are_stable() {
         assert_eq!(grad(0.0), GRADIENT[0]);
         assert_eq!(grad(1.0), GRADIENT[GRADIENT.len() - 1]);
+    }
+
+    #[test]
+    fn unsafe_peer_urls_are_not_linked() {
+        // A control char (here ESC) or a non-http scheme must never reach the
+        // OSC 8 payload, or a peer could inject escapes into the status line.
+        assert!(!link("X", Some("https://x\x1b]8;;evil")).contains("evil"));
+        assert!(!link("X", Some("javascript:alert(1)")).contains("alert"));
+        assert_eq!(link("X", None), "X");
+        assert!(link("X", Some("https://github.com/a")).contains("github.com/a"));
     }
 
     #[test]

--- a/packages/claude-stories/src/discovery.rs
+++ b/packages/claude-stories/src/discovery.rs
@@ -17,10 +17,12 @@ pub enum Discovery {
 }
 
 impl Discovery {
-    /// Choose a transport from the environment. Returns a typed error rather
-    /// than silently defaulting to an empty peer set, so a misconfigured host
-    /// shows "tailscale not found" instead of an empty row.
-    pub fn from_env() -> Result<Self> {
+    /// Choose a transport from the environment: an explicit
+    /// `CLAUDE_STORIES_PEERS` list if set, otherwise the tailnet. Any failure to
+    /// actually reach peers surfaces later, as a typed error from
+    /// [`Self::endpoints`].
+    #[must_use]
+    pub fn from_env() -> Self {
         if let Some(list) = std::env::var_os("CLAUDE_STORIES_PEERS") {
             let peers: Vec<String> = list
                 .to_string_lossy()
@@ -29,9 +31,9 @@ impl Discovery {
                 .filter(|s| !s.is_empty())
                 .map(str::to_owned)
                 .collect();
-            return Ok(Self::Peers(peers));
+            return Self::Peers(peers);
         }
-        Ok(Self::Tailnet)
+        Self::Tailnet
     }
 
     /// Build the `/story` endpoint URLs to fetch, one per peer.
@@ -88,7 +90,11 @@ fn tailnet_endpoints(port: u16) -> Result<Vec<String>> {
             continue;
         }
         // Prefer the IPv4 (100.x) address; it is the most broadly reachable.
-        if let Some(ip) = peer.ips.iter().find(|ip| ip.contains('.')) {
+        if let Some(ip) = peer
+            .ips
+            .iter()
+            .find(|ip| ip.parse::<std::net::Ipv4Addr>().is_ok())
+        {
             endpoints.push(format!("http://{ip}:{port}/story"));
         }
     }

--- a/packages/claude-stories/src/discovery.rs
+++ b/packages/claude-stories/src/discovery.rs
@@ -1,0 +1,109 @@
+//! Peer discovery. The default transport is the Tailscale tailnet: `tailscale
+//! status --json` is already an authenticated, NAT-traversed list of every
+//! online device, so it doubles as the peer directory. No central server, no
+//! DHT, no bootstrap nodes. `CLAUDE_STORIES_PEERS` overrides it with an explicit
+//! list for testing or off-tailnet use.
+
+use color_eyre::Result;
+use color_eyre::eyre::{Context, eyre};
+use serde::Deserialize;
+
+/// Where to find peers.
+pub enum Discovery {
+    /// Static `host:port` (or full URL) list from `CLAUDE_STORIES_PEERS`.
+    Peers(Vec<String>),
+    /// Every online peer on the tailnet.
+    Tailnet,
+}
+
+impl Discovery {
+    /// Choose a transport from the environment. Returns a typed error rather
+    /// than silently defaulting to an empty peer set, so a misconfigured host
+    /// shows "tailscale not found" instead of an empty row.
+    pub fn from_env() -> Result<Self> {
+        if let Some(list) = std::env::var_os("CLAUDE_STORIES_PEERS") {
+            let peers: Vec<String> = list
+                .to_string_lossy()
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_owned)
+                .collect();
+            return Ok(Self::Peers(peers));
+        }
+        Ok(Self::Tailnet)
+    }
+
+    /// Build the `/story` endpoint URLs to fetch, one per peer.
+    pub fn endpoints(&self, port: u16) -> Result<Vec<String>> {
+        match self {
+            Self::Peers(peers) => Ok(peers.iter().map(|p| story_url(p, port)).collect()),
+            Self::Tailnet => tailnet_endpoints(port),
+        }
+    }
+}
+
+/// Normalize a peer entry into a full `/story` URL.
+fn story_url(peer: &str, port: u16) -> String {
+    let base = if peer.starts_with("http://") || peer.starts_with("https://") {
+        peer.trim_end_matches('/').to_owned()
+    } else if peer.contains(':') {
+        format!("http://{peer}")
+    } else {
+        format!("http://{peer}:{port}")
+    };
+    if base.ends_with("/story") { base } else { format!("{base}/story") }
+}
+
+// Subset of `tailscale status --json` we need.
+#[derive(Deserialize)]
+struct TsStatus {
+    #[serde(rename = "Peer", default)]
+    peer: std::collections::HashMap<String, TsPeer>,
+}
+
+#[derive(Deserialize)]
+struct TsPeer {
+    #[serde(rename = "TailscaleIPs", default)]
+    ips: Vec<String>,
+    #[serde(rename = "Online", default)]
+    online: bool,
+}
+
+fn tailnet_endpoints(port: u16) -> Result<Vec<String>> {
+    let out = std::process::Command::new("tailscale")
+        .args(["status", "--json"])
+        .output()
+        .wrap_err("running `tailscale status --json` (is the Tailscale CLI installed?)")?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(eyre!("tailscale status failed: {}", stderr.trim()));
+    }
+    let status: TsStatus =
+        serde_json::from_slice(&out.stdout).wrap_err("parsing tailscale status JSON")?;
+
+    let mut endpoints = Vec::new();
+    for peer in status.peer.values() {
+        if !peer.online {
+            continue;
+        }
+        // Prefer the IPv4 (100.x) address; it is the most broadly reachable.
+        if let Some(ip) = peer.ips.iter().find(|ip| ip.contains('.')) {
+            endpoints.push(format!("http://{ip}:{port}/story"));
+        }
+    }
+    Ok(endpoints)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn story_url_normalizes() {
+        assert_eq!(story_url("host", 4810), "http://host:4810/story");
+        assert_eq!(story_url("100.1.2.3:9000", 4810), "http://100.1.2.3:9000/story");
+        assert_eq!(story_url("http://x:1/story", 4810), "http://x:1/story");
+        assert_eq!(story_url("https://x/", 4810), "https://x/story");
+    }
+}

--- a/packages/claude-stories/src/main.rs
+++ b/packages/claude-stories/src/main.rs
@@ -1,7 +1,7 @@
 //! Instagram-style "stories" for Claude Code.
 //!
 //! - `publish` derives your current story from the local repo and writes it to a
-//!   state file (wire it to a SessionStart hook).
+//!   state file (wire it to a `SessionStart` hook).
 //! - `serve` exposes that file over HTTP so tailnet peers can read it.
 //! - `render` is the status-line command: it discovers peers, fetches their
 //!   stories concurrently, and prints the avatar row.
@@ -71,10 +71,10 @@ async fn main() -> Result<()> {
 }
 
 fn cwd_or(path: Option<PathBuf>) -> Result<PathBuf> {
-    match path {
-        Some(p) => Ok(p),
-        None => std::env::current_dir().wrap_err("reading current directory"),
-    }
+    path.map_or_else(
+        || std::env::current_dir().wrap_err("reading current directory"),
+        Ok,
+    )
 }
 
 fn publish(path: Option<PathBuf>) -> Result<()> {
@@ -115,7 +115,7 @@ async fn serve(bind: &str, port: u16) -> Result<()> {
 }
 
 async fn render(port: u16) -> Result<()> {
-    let endpoints = Discovery::from_env()?.endpoints(port)?;
+    let endpoints = Discovery::from_env().endpoints(port)?;
 
     let client = reqwest::Client::builder()
         .timeout(Duration::from_millis(1500))
@@ -133,10 +133,10 @@ async fn render(port: u16) -> Result<()> {
     while let Some(joined) = set.join_next().await {
         // A peer that is offline, slow, or has no story is simply absent from
         // the row; that is the expected steady state, not an error.
-        if let Ok(Some(s)) = joined {
-            if s.is_fresh(now) {
-                stories.push(s);
-            }
+        if let Ok(Some(s)) = joined
+            && s.is_fresh(now)
+        {
+            stories.push(s);
         }
     }
 

--- a/packages/claude-stories/src/main.rs
+++ b/packages/claude-stories/src/main.rs
@@ -1,0 +1,153 @@
+//! Instagram-style "stories" for Claude Code.
+//!
+//! - `publish` derives your current story from the local repo and writes it to a
+//!   state file (wire it to a SessionStart hook).
+//! - `serve` exposes that file over HTTP so tailnet peers can read it.
+//! - `render` is the status-line command: it discovers peers, fetches their
+//!   stories concurrently, and prints the avatar row.
+
+mod avatar;
+mod discovery;
+mod story;
+
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use clap::{Parser, Subcommand};
+use color_eyre::Result;
+use color_eyre::eyre::Context;
+
+use crate::discovery::Discovery;
+use crate::story::Story;
+
+/// Default port for the per-host story server.
+const DEFAULT_PORT: u16 = 4810;
+
+#[derive(Parser)]
+#[command(name = "claude-stories", version, about)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Derive the current repo's story and write it to the state file.
+    Publish {
+        /// Repository to read; defaults to the current directory.
+        #[arg(long)]
+        path: Option<PathBuf>,
+    },
+    /// Serve the published story over HTTP at `/story`.
+    Serve {
+        #[arg(long, default_value_t = DEFAULT_PORT)]
+        port: u16,
+        /// Address to bind. Defaults to all interfaces so tailnet peers reach it.
+        #[arg(long, default_value = "0.0.0.0")]
+        bind: String,
+    },
+    /// Render the status-line row of peers' stories.
+    Render {
+        #[arg(long, default_value_t = DEFAULT_PORT)]
+        port: u16,
+    },
+    /// Print the current repo's story as JSON (for debugging).
+    Show {
+        #[arg(long)]
+        path: Option<PathBuf>,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Publish { path } => publish(path),
+        Command::Serve { port, bind } => serve(&bind, port).await,
+        Command::Render { port } => render(port).await,
+        Command::Show { path } => show(path),
+    }
+}
+
+fn cwd_or(path: Option<PathBuf>) -> Result<PathBuf> {
+    match path {
+        Some(p) => Ok(p),
+        None => std::env::current_dir().wrap_err("reading current directory"),
+    }
+}
+
+fn publish(path: Option<PathBuf>) -> Result<()> {
+    let story = story::derive(&cwd_or(path)?)?;
+    story::write_state(&story)?;
+    println!("published: {} in {}@{}", story.name, story.repo, story.branch);
+    Ok(())
+}
+
+fn show(path: Option<PathBuf>) -> Result<()> {
+    let story = story::derive(&cwd_or(path)?)?;
+    println!("{}", serde_json::to_string_pretty(&story)?);
+    Ok(())
+}
+
+async fn serve(bind: &str, port: u16) -> Result<()> {
+    use axum::Router;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use axum::routing::get;
+
+    async fn story_handler() -> impl IntoResponse {
+        match story::read_state() {
+            Ok(Some(s)) => axum::Json(s).into_response(),
+            Ok(None) => (StatusCode::NOT_FOUND, "no story published").into_response(),
+            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        }
+    }
+
+    let app = Router::new().route("/story", get(story_handler));
+    let addr = format!("{bind}:{port}");
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .wrap_err_with(|| format!("binding {addr}"))?;
+    println!("claude-stories serving on http://{addr}/story");
+    axum::serve(listener, app).await.wrap_err("serving")?;
+    Ok(())
+}
+
+async fn render(port: u16) -> Result<()> {
+    let endpoints = Discovery::from_env()?.endpoints(port)?;
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(1500))
+        .build()
+        .wrap_err("building HTTP client")?;
+
+    let mut set = tokio::task::JoinSet::new();
+    for url in endpoints {
+        let client = client.clone();
+        set.spawn(async move { fetch_story(&client, &url).await });
+    }
+
+    let now = i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs())?;
+    let mut stories: Vec<Story> = Vec::new();
+    while let Some(joined) = set.join_next().await {
+        // A peer that is offline, slow, or has no story is simply absent from
+        // the row; that is the expected steady state, not an error.
+        if let Ok(Some(s)) = joined {
+            if s.is_fresh(now) {
+                stories.push(s);
+            }
+        }
+    }
+
+    println!("{}", avatar::row(stories));
+    Ok(())
+}
+
+async fn fetch_story(client: &reqwest::Client, url: &str) -> Option<Story> {
+    let resp = client.get(url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    resp.json::<Story>().await.ok()
+}

--- a/packages/claude-stories/src/story.rs
+++ b/packages/claude-stories/src/story.rs
@@ -30,9 +30,15 @@ pub struct Story {
 }
 
 impl Story {
+    /// Whether the story is within the visibility window. `ts` comes from
+    /// untrusted peer JSON, so the subtraction is checked (a `ts` of `i64::MIN`
+    /// would otherwise overflow) and future-dated stories are rejected.
     #[must_use]
     pub const fn is_fresh(&self, now: i64) -> bool {
-        now - self.ts < TTL_SECS
+        match now.checked_sub(self.ts) {
+            Some(age) => age >= 0 && age < TTL_SECS,
+            None => false,
+        }
     }
 }
 
@@ -137,5 +143,31 @@ pub fn read_state() -> Result<Option<Story>> {
         Ok(bytes) => Ok(Some(serde_json::from_slice(&bytes)?)),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(e).wrap_err_with(|| format!("reading {}", path.display())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(ts: i64) -> Story {
+        Story {
+            name: "x".into(),
+            repo: "r".into(),
+            branch: "b".into(),
+            subject: "s".into(),
+            ts,
+            url: None,
+        }
+    }
+
+    #[test]
+    fn freshness_bounds() {
+        let now = 1_000_000_i64;
+        assert!(at(now).is_fresh(now));
+        assert!(at(now - TTL_SECS + 1).is_fresh(now));
+        assert!(!at(now - TTL_SECS).is_fresh(now)); // exactly at TTL: expired
+        assert!(!at(now + 100).is_fresh(now)); // future-dated peer rejected
+        assert!(!at(i64::MIN).is_fresh(now)); // must not overflow/panic
     }
 }

--- a/packages/claude-stories/src/story.rs
+++ b/packages/claude-stories/src/story.rs
@@ -1,0 +1,141 @@
+//! A "story": who you are and what you're currently working on, plus the local
+//! state file the `publish`/`serve` commands share.
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use color_eyre::Result;
+use color_eyre::eyre::{Context, eyre};
+use serde::{Deserialize, Serialize};
+
+/// How long a story stays visible, mirroring Instagram's 24h window. A peer
+/// whose story is older than this is treated as having no current story.
+pub const TTL_SECS: i64 = 24 * 60 * 60;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Story {
+    /// Display name of the author, e.g. "Andrew Gazelka".
+    pub name: String,
+    /// Repository the author is working in, e.g. "index".
+    pub repo: String,
+    /// Current branch.
+    pub branch: String,
+    /// Subject line of the latest commit: the "what I'm working on" caption.
+    pub subject: String,
+    /// Unix seconds when the story was published.
+    pub ts: i64,
+    /// Optional link opened when the avatar is clicked (OSC 8 hyperlink).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+impl Story {
+    #[must_use]
+    pub const fn is_fresh(&self, now: i64) -> bool {
+        now - self.ts < TTL_SECS
+    }
+}
+
+fn now_secs() -> Result<i64> {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .wrap_err("system clock is before the Unix epoch")?
+        .as_secs();
+    i64::try_from(secs).wrap_err("timestamp does not fit in i64")
+}
+
+/// Derive the current story from a git repository at `path`.
+pub fn derive(path: &Path) -> Result<Story> {
+    let repo = git2::Repository::discover(path)
+        .wrap_err_with(|| format!("no git repository at or above {}", path.display()))?;
+
+    let head = repo.head().wrap_err("repository has no HEAD")?;
+    let branch = head.shorthand().unwrap_or("HEAD").to_owned();
+
+    let commit = head
+        .peel_to_commit()
+        .wrap_err("HEAD does not point at a commit")?;
+    let subject = commit.summary().unwrap_or("(no commit message)").to_owned();
+
+    // Prefer the configured user.name; fall back to the latest commit's author.
+    let name = repo
+        .config()
+        .ok()
+        .and_then(|c| c.get_string("user.name").ok())
+        .or_else(|| commit.author().name().map(str::to_owned))
+        .unwrap_or_else(|| "anonymous".to_owned());
+
+    let origin = repo
+        .find_remote("origin")
+        .ok()
+        .and_then(|r| r.url().map(str::to_owned));
+    let repo_name = origin
+        .as_deref()
+        .and_then(repo_basename)
+        .unwrap_or_else(|| dir_name(&repo));
+    let url = origin.as_deref().and_then(github_https);
+
+    Ok(Story {
+        name,
+        repo: repo_name,
+        branch,
+        subject,
+        ts: now_secs()?,
+        url,
+    })
+}
+
+/// `git@github.com:owner/name.git` or `https://github.com/owner/name` -> "name".
+fn repo_basename(remote_url: &str) -> Option<String> {
+    let tail = remote_url.rsplit(['/', ':']).next()?;
+    Some(tail.strip_suffix(".git").unwrap_or(tail).to_owned())
+}
+
+/// Map a GitHub remote URL (ssh or https) to its https web URL, for the OSC 8
+/// link target. Returns `None` for non-GitHub or unparseable remotes rather
+/// than guessing a URL that might 404.
+fn github_https(remote_url: &str) -> Option<String> {
+    let rest = remote_url
+        .strip_prefix("git@github.com:")
+        .or_else(|| remote_url.strip_prefix("https://github.com/"))
+        .or_else(|| remote_url.strip_prefix("ssh://git@github.com/"))?;
+    let slug = rest.strip_suffix(".git").unwrap_or(rest);
+    Some(format!("https://github.com/{slug}"))
+}
+
+fn dir_name(repo: &git2::Repository) -> String {
+    repo.workdir()
+        .and_then(Path::file_name)
+        .and_then(|s| s.to_str())
+        .unwrap_or("repo")
+        .to_owned()
+}
+
+/// Path to the shared state file. `publish` writes it; `serve` reads it.
+pub fn state_path() -> Result<PathBuf> {
+    let base = std::env::var_os("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/state")))
+        .ok_or_else(|| eyre!("neither XDG_STATE_HOME nor HOME is set"))?;
+    Ok(base.join("claude-stories").join("story.json"))
+}
+
+pub fn write_state(story: &Story) -> Result<()> {
+    let path = state_path()?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)
+            .wrap_err_with(|| format!("creating state dir {}", dir.display()))?;
+    }
+    let json = serde_json::to_vec_pretty(story)?;
+    std::fs::write(&path, json).wrap_err_with(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+pub fn read_state() -> Result<Option<Story>> {
+    let path = state_path()?;
+    match std::fs::read(&path) {
+        Ok(bytes) => Ok(Some(serde_json::from_slice(&bytes)?)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).wrap_err_with(|| format!("reading {}", path.display())),
+    }
+}


### PR DESCRIPTION
Instagram-style "stories" for Claude Code: a status-line row of teammates' gradient-ring avatars and what each is working on. Inspired by Ben Awad's vscode-stories.

Peer-to-peer, no central server. `publish` derives a story from the local git repo, `serve` exposes it over HTTP, `render` (the status-line command) discovers peers, fetches concurrently, drops anything >24h, and draws the row.

Discovery defaults to the Tailscale tailnet (`tailscale status --json` is already an authenticated, NAT-traversed peer directory, so it doubles as discovery, no DHT/OAuth). `CLAUDE_STORIES_PEERS` overrides for off-tailnet/testing.

Real images can't render in the status line (anthropics/claude-code#39024 strips Kitty graphics), so avatars are text-art rings. New `packages/claude-stories` crate, reuses workspace deps only (no dependency intake). README covers the settings.json wiring.

Made with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `claude-stories` tool for sharing git repo status across a Tailscale tailnet
> - Adds a new `claude-stories` binary crate with four subcommands: `publish` (writes current repo/branch/commit info to disk), `serve` (exposes it over HTTP on port 4810), `render` (queries peers and outputs a terminal status line with gradient-colored avatars), and `show` (prints the local story as JSON).
> - Peer discovery defaults to Tailscale (`tailscale status --json`) but can be overridden via `CLAUDE_STORIES_PEERS` (comma-separated hosts).
> - The `render` command fetches stories concurrently with a 1500ms timeout and filters to stories within a 24-hour TTL before rendering.
> - Story state is persisted to `$XDG_STATE_HOME/claude-stories/story.json` and served as a plain JSON HTTP endpoint.
> - Includes a Nix package definition in [default.nix](https://github.com/indexable-inc/index/pull/641/files#diff-602bd867e3411f539f74161ed54aaa0f3019fd11834f303c504b08bb695fbb85) and [package.nix](https://github.com/indexable-inc/index/pull/641/files#diff-aa872b48d3852f110e321c54b29dcf157be23c1aa6edf13718b7a6994ccf66d0).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a15d82.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->