### PR TITLE
fix(ci): enable ca-derivations for the flake-check gate

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -17,8 +17,12 @@ env:
   # client-side eval knobs (matching check.yml). `accept-flake-config` consumes
   # the flake's nixConfig (the indexable-inc Cachix substituter) without a
   # prompt, which the inner nix-eval-jobs run needs to fetch the IFD closure.
+  # `ca-derivations`: the rust units default to contentAddressed = true, so the
+  # `.#checks` eval this job forces resolves content-addressed drvs. Without it
+  # nix-eval-jobs aborts ("experimental Nix feature 'ca-derivations' is
+  # disabled"). Mirrors check.yml.
   NIX_CONFIG: |-
-    experimental-features = nix-command flakes
+    experimental-features = nix-command flakes ca-derivations
     accept-flake-config = true
 
 jobs:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,8 +36,15 @@ env:
   # build single-threaded. The closure is wide, so parallelism comes from
   # building many derivations at once, not threads inside one build.
   # https://nix.dev/manual/nix/2.28/advanced-topics/cores-vs-jobs
+  # `ca-derivations`: the rust workspace units default to
+  # `contentAddressed = true` (lib/rust/cargo-unit.nix), so evaluating the
+  # check / package sets resolves floating content-addressed derivations.
+  # Without the feature the evaluator aborts with "experimental Nix feature
+  # 'ca-derivations' is disabled". The flake's nixConfig also declares it (via
+  # accept-flake-config), but pinning it in the job env covers any sub-eval that
+  # does not inherit the flake config.
   NIX_CONFIG: |-
-    experimental-features = nix-command flakes
+    experimental-features = nix-command flakes ca-derivations
     accept-flake-config = true
     extra-system-features = gccarch-znver5
     max-jobs = auto

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,7 +994,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tempfile",
  "tokio",
 ]
 

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,14 @@
     extra-trusted-public-keys = [
       "indexable-inc.cachix.org-1:HQ5mjdOyhgNjLVhjv0qgVMJ5YiO1zEEVMAtF9mTcpiI="
     ];
+    # The rust workspace units default to `contentAddressed = true`
+    # (lib/rust/cargo-unit.nix), so evaluating `.#checks` / `.#packages`
+    # resolves floating content-addressed derivations. Without this feature the
+    # evaluator aborts with "experimental Nix feature 'ca-derivations' is
+    # disabled". Declared here so any eval against this flake (CI's
+    # `accept-flake-config` runs, a local `nix flake check`, `nix build
+    # .#checks.<sys>.<name>`) picks it up from one source of truth.
+    extra-experimental-features = [ "ca-derivations" ];
   };
 
   inputs = {

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -145,6 +145,15 @@ let
       const eval_jobs = "github:nix-community/nix-eval-jobs/65ebf5b7cd453a27af09cf02b1fc57b3568cc4b7"
 
       def main [] {
+        # ca-derivations: the rust workspace units default to
+        # `contentAddressed = true` (lib/rust/cargo-unit.nix), so evaluating
+        # `.#checks.x86_64-linux` resolves floating content-addressed drvs. The
+        # evaluator (nix-eval-jobs, which nix-fast-build wraps) needs the
+        # `ca-derivations` experimental feature, or it aborts with
+        # "experimental Nix feature 'ca-derivations' is disabled". The flake's
+        # nixConfig.extra-experimental-features carries it via
+        # accept-flake-config; `--option extra-experimental-features` here pins
+        # it for the build pool too so the gate is self-contained.
         ^nix run $fast_build -- ...[
           "--flake" ".#checks.x86_64-linux"
           "--eval-max-memory-size" "6144"
@@ -153,6 +162,7 @@ let
           "--no-nom"
           "--no-link"
           "--option" "accept-flake-config" "true"
+          "--option" "extra-experimental-features" "ca-derivations"
         ]
 
         let tmp = (mktemp --directory --tmpdir "ix-check.XXXXXX")
@@ -164,6 +174,9 @@ let
             "--gc-roots-dir" ($tmp | path join "flake-schema-eval-gc")
             "--option" "accept-flake-config" "true"
             "--option" "eval-cache" "false"
+            # See the ca-derivations note above: the package set also resolves
+            # content-addressed rust units, so this eval needs the feature too.
+            "--option" "extra-experimental-features" "ca-derivations"
           ]
         } | tee { save --raw --force $report }
 

--- a/packages/claude-stories/Cargo.toml
+++ b/packages/claude-stories/Cargo.toml
@@ -23,6 +23,3 @@ serde_json.workspace = true
 # `serve` is an HTTP listener; `render` fans out concurrent fetches. A
 # multi-thread runtime keeps both simple.
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "time", "macros"] }
-
-[dev-dependencies]
-tempfile.workspace = true

--- a/tools/blast-radius.nu
+++ b/tools/blast-radius.nu
@@ -13,6 +13,11 @@ def eval-checks [repo: string, rev: string] {
         "--workers" "8"
         "--option" "accept-flake-config" "true"
         "--option" "eval-cache" "false"
+        # The rust units default to contentAddressed = true, so the checks eval
+        # as content-addressed drvs. Pin the feature on directly rather than via
+        # the flake nixConfig: this evals a base `?rev=<sha>` that predates the
+        # nixConfig declaration, so accept-flake-config alone would miss it.
+        "--option" "extra-experimental-features" "ca-derivations"
       ]
     }
     | lines


### PR DESCRIPTION
Fix red main: enable the \`ca-derivations\` experimental feature for the flake-check gate.

- PR #615 defaulted rust units to \`contentAddressed = true\`, so \`.#checks\`/\`.#packages\` now eval as content-addressed drvs; the gate never enabled the feature, so nix-eval-jobs aborts with "experimental Nix feature ca-derivations is disabled" (main red since #615).
- Enabled in three paths: flake \`nixConfig.extra-experimental-features\` (carried by accept-flake-config), the \`check\` wrapper (\`--option\` on nix-fast-build + nix-eval-jobs), and \`check.yml\` \`NIX_CONFIG\`.
- Validated locally: reproduced the exact error under \`--experimental-features "nix-command flakes"\` and confirmed \`--extra-experimental-features ca-derivations\` clears it; the \`check\` wrapper rebuilds clean.

Filed by Claude (Opus 4.8) for @andrewgazelka

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable `ca-derivations` experimental feature in CI flake-check gate
> Adds `ca-derivations` to the Nix experimental features across all CI workflows and evaluation scripts so the flake-check gate succeeds.
>
> - Adds `extra-experimental-features = ca-derivations` to [flake.nix](https://github.com/indexable-inc/index/pull/653/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) `nixConfig` for evaluations that accept flake config
> - Sets `ca-derivations` in `NIX_CONFIG.experimental-features` in [blast-radius.yml](https://github.com/indexable-inc/index/pull/653/files#diff-f18ec732b17d456a8d2f9c00a4941f9433314b97b8a3df9cea22bdaf15337468) and [check.yml](https://github.com/indexable-inc/index/pull/653/files#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428)
> - Passes `--option extra-experimental-features ca-derivations` to `nix-fast-build` and `nix-eval-jobs` invocations in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/653/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) and [tools/blast-radius.nu](https://github.com/indexable-inc/index/pull/653/files#diff-042e18b7ef34127bf537e9dd2454a21d878e3919ed70aa8f6ec733e8501b776e)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b24794.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->