### PR TITLE
feat(search): default to mxbai-rerank-v3-listwise reranker

### DIFF
--- a/packages/mixedbread/src/lib.rs
+++ b/packages/mixedbread/src/lib.rs
@@ -122,14 +122,66 @@ pub enum Error {
 /// Result alias defaulting to this crate's [`Error`].
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// Default second-stage reranking model: Mixedbread's listwise reranker.
+///
+/// It reads the candidate set as a whole and lifts ranking quality across every
+/// benchmark relative to the prior pointwise default.
+/// See <https://www.mixedbread.com/blog/mxbai-rerank-v3-listwise>.
+pub const DEFAULT_RERANK_MODEL: &str = "mixedbread-ai/mxbai-rerank-v3-listwise";
+
+/// Second-stage reranker selection.
+///
+/// Serialized as the API's `rerank` field, which is `boolean | object`:
+/// [`Rerank::Toggle`] serializes to a bare bool (so the legacy "just turn it
+/// on/off" wire body is byte-for-byte unchanged), while [`Rerank::Model`]
+/// serializes to `{ "model": "..." }` to pin a specific reranking model.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(untagged)]
+pub enum Rerank {
+    /// Toggle the server's default reranker: `false` disables reranking,
+    /// `true` applies the API-chosen default model.
+    Toggle(bool),
+    /// Apply a named reranking model, e.g. [`DEFAULT_RERANK_MODEL`].
+    Model {
+        /// Reranking model name forwarded to the API.
+        model: String,
+    },
+}
+
+impl Rerank {
+    /// Reranking disabled (wire `false`).
+    #[must_use]
+    pub const fn off() -> Self {
+        Self::Toggle(false)
+    }
+
+    /// The API's default reranker (wire `true`).
+    #[must_use]
+    pub const fn server_default() -> Self {
+        Self::Toggle(true)
+    }
+
+    /// Pin a specific reranking model.
+    #[must_use]
+    pub fn model(name: impl Into<String>) -> Self {
+        Self::Model { model: name.into() }
+    }
+
+    /// The listwise reranker ([`DEFAULT_RERANK_MODEL`]).
+    #[must_use]
+    pub fn listwise() -> Self {
+        Self::model(DEFAULT_RERANK_MODEL)
+    }
+}
+
 /// Search tuning forwarded to the API.
 ///
 /// `score_threshold` and `return_metadata` are skipped when unset, so a caller
 /// that only sets `rerank`/`agentic` produces the same wire body as before.
-#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct SearchOptions {
-    /// Apply the second-stage reranker.
-    pub rerank: bool,
+    /// Apply the second-stage reranker (toggle or a pinned model).
+    pub rerank: Rerank,
     /// Let the API plan and run multiple searches.
     pub agentic: bool,
     /// Drop hits scoring below this threshold (`0.0..=1.0`). Used to keep a
@@ -754,7 +806,28 @@ mod tests {
     use axum::http::{StatusCode, header};
     use axum::response::IntoResponse;
 
-    use super::{BACKOFF_BASE, BACKOFF_CAP, Chunk, Client, Error, MAX_RETRIES, RawChunk, backoff};
+    use super::{
+        BACKOFF_BASE, BACKOFF_CAP, Chunk, Client, DEFAULT_RERANK_MODEL, Error, MAX_RETRIES,
+        RawChunk, Rerank, backoff,
+    };
+
+    #[test]
+    fn rerank_serializes_as_bool_or_object() {
+        // The toggle keeps the legacy bare-bool wire body byte-for-byte.
+        assert_eq!(
+            serde_json::to_value(Rerank::off()).expect("serialize"),
+            serde_json::json!(false)
+        );
+        assert_eq!(
+            serde_json::to_value(Rerank::server_default()).expect("serialize"),
+            serde_json::json!(true)
+        );
+        // A pinned model serializes to the `{ "model": ... }` object form.
+        assert_eq!(
+            serde_json::to_value(Rerank::listwise()).expect("serialize"),
+            serde_json::json!({ "model": DEFAULT_RERANK_MODEL })
+        );
+    }
 
     /// A spawned test server: its base URL and a shared counter of requests it received.
     struct MockServer {

--- a/packages/polars-mixedbread/python/polars_mixedbread/__init__.py
+++ b/packages/polars-mixedbread/python/polars_mixedbread/__init__.py
@@ -116,6 +116,7 @@ def scan_mixedbread(
     max_top_k: int = DEFAULT_MAX_TOP_K,
     base_url: str | None = None,
     rerank: bool = True,
+    reranker: str | None = None,
     agentic: bool = False,
     score_threshold: float | None = None,
     metadata_columns: dict[str, pl.DataType] | None = None,
@@ -127,7 +128,9 @@ def scan_mixedbread(
     docstring). ``store`` is one store name or a list of them (default
     ``"index"``). ``metadata_columns`` maps metadata keys to dtypes to surface as
     typed columns (default: the ``index`` keys).
-    ``rerank``/``agentic``/``score_threshold`` tune retrieval.
+    ``rerank``/``agentic``/``score_threshold`` tune retrieval. ``reranker`` names
+    the reranking model (default: the listwise reranker); ignored when ``rerank``
+    is ``False``.
 
     ``min_results`` turns ``top_k`` into a floor on the *output*: when a
     client-side filter trims the window below N rows, the source re-searches with
@@ -162,6 +165,7 @@ def scan_mixedbread(
                 top_k=k,
                 base_url=base_url,
                 rerank=rerank,
+                reranker=reranker,
                 agentic=agentic,
                 score_threshold=score_threshold,
                 filters=None if pushed is None else json.dumps(pushed),

--- a/packages/polars-mixedbread/python/polars_mixedbread/_polars_mixedbread.pyi
+++ b/packages/polars-mixedbread/python/polars_mixedbread/_polars_mixedbread.pyi
@@ -10,6 +10,7 @@ def search_mixedbread(
     top_k: int = ...,
     base_url: str | None = ...,
     rerank: bool = ...,
+    reranker: str | None = ...,
     agentic: bool = ...,
     score_threshold: float | None = ...,
     filters: str | None = ...,

--- a/packages/polars-mixedbread/python/polars_mixedbread/_polars_mixedbread.pyi
+++ b/packages/polars-mixedbread/python/polars_mixedbread/_polars_mixedbread.pyi
@@ -10,10 +10,10 @@ def search_mixedbread(
     top_k: int = ...,
     base_url: str | None = ...,
     rerank: bool = ...,
-    reranker: str | None = ...,
     agentic: bool = ...,
     score_threshold: float | None = ...,
     filters: str | None = ...,
+    reranker: str | None = ...,
 ) -> dict[str, list[Any]]:
     """Run a Mixedbread store search, returning a dict of the six source columns.
 

--- a/packages/polars-mixedbread/src/lib.rs
+++ b/packages/polars-mixedbread/src/lib.rs
@@ -14,7 +14,7 @@
 //! no `pyo3-polars` Arrow-FFI lockstep to keep in sync (unlike `polars-sftp`,
 //! which decodes files in Rust and so must pin both).
 
-use mixedbread::{Client, SearchOptions, filter::Filter};
+use mixedbread::{Client, Rerank, SearchOptions, filter::Filter};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
@@ -42,6 +42,9 @@ use pyo3::types::{PyDict, PyList};
     agentic = false,
     score_threshold = None,
     filters = None,
+    // Trailing optional so existing positional callers keep their slots; a name
+    // pins a reranking model, unset uses the listwise default.
+    reranker = None,
 ))]
 #[allow(
     clippy::too_many_arguments,
@@ -58,6 +61,7 @@ fn search_mixedbread(
     agentic: bool,
     score_threshold: Option<f32>,
     filters: Option<String>,
+    reranker: Option<String>,
 ) -> PyResult<Py<PyDict>> {
     if stores.is_empty() {
         return Err(PyValueError::new_err(
@@ -73,6 +77,13 @@ fn search_mixedbread(
         .map_err(|error| {
             PyValueError::new_err(format!("polars-mixedbread: invalid filters JSON: {error}"))
         })?;
+    // `rerank=False` disables reranking; otherwise a named model wins, defaulting
+    // to the listwise reranker for the best ordering.
+    let rerank = match (rerank, reranker) {
+        (false, _) => Rerank::off(),
+        (true, Some(model)) => Rerank::model(model),
+        (true, None) => Rerank::listwise(),
+    };
     let options = SearchOptions {
         rerank,
         agentic,

--- a/packages/search-core/src/adapter.rs
+++ b/packages/search-core/src/adapter.rs
@@ -49,7 +49,7 @@ impl MixedbreadStore {
     }
 }
 
-const fn to_client_options(options: SearchOptions) -> mixedbread::SearchOptions {
+fn to_client_options(options: SearchOptions) -> mixedbread::SearchOptions {
     mixedbread::SearchOptions {
         rerank: options.rerank,
         agentic: options.agentic,

--- a/packages/search-core/src/backend.rs
+++ b/packages/search-core/src/backend.rs
@@ -22,10 +22,11 @@ use snafu::{OptionExt as _, ResultExt as _};
 use crate::error::{InvalidMetadataSnafu, InvalidPatternSnafu, Result};
 
 /// Knobs forwarded to the backend's search call.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct SearchOptions {
-    /// Apply the second-stage reranker for better ordering.
-    pub rerank: bool,
+    /// Second-stage reranker selection: a toggle or a pinned model
+    /// (defaults to [`mixedbread::DEFAULT_RERANK_MODEL`] at the CLI/binding edge).
+    pub rerank: mixedbread::Rerank,
     /// Let the backend plan and run several searches itself.
     pub agentic: bool,
 }

--- a/packages/search-core/src/lib.rs
+++ b/packages/search-core/src/lib.rs
@@ -51,5 +51,5 @@ pub use sync::{SyncReport, sync, wait_until_indexed};
 
 // Re-export the shared metadata and filter types so binaries depend only on
 // search-core.
-pub use mixedbread::{Condition, Filter, Group, Operator};
+pub use mixedbread::{Condition, DEFAULT_RERANK_MODEL, Filter, Group, Operator, Rerank};
 pub use source_meta::{Document, RepoSlug, Source, SourceAdapter};

--- a/packages/search-core/src/pipeline.rs
+++ b/packages/search-core/src/pipeline.rs
@@ -17,7 +17,7 @@ use crate::search::{AnswerView, CodeScope, DisplayHit, ask, grep, semantic};
 use crate::sync::{sync, wait_until_indexed};
 
 /// What to query and how, independent of the backend and progress reporting.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Query<'a> {
     /// Absolute checkout root to index and scope results to.
     pub root: &'a Path,
@@ -147,7 +147,7 @@ pub async fn index_and_semantic(
         &manifest,
         query.text,
         query.top_k,
-        query.options,
+        query.options.clone(),
         query.include_web,
         query.filters,
         query.code_scope,
@@ -205,7 +205,7 @@ pub async fn index_and_answer(
         &manifest,
         query.text,
         query.top_k,
-        query.options,
+        query.options.clone(),
         query.include_web,
         query.filters,
         query.code_scope,

--- a/packages/search-core/src/search.rs
+++ b/packages/search-core/src/search.rs
@@ -238,7 +238,7 @@ mod tests {
 
     fn opts() -> SearchOptions {
         SearchOptions {
-            rerank: true,
+            rerank: mixedbread::Rerank::server_default(),
             agentic: false,
         }
     }

--- a/packages/search-eval/src/search_eval/backend.py
+++ b/packages/search-eval/src/search_eval/backend.py
@@ -33,6 +33,7 @@ class SearchBackend:
     store: str | None = None
     max_count: int = 10
     rerank: bool = True
+    reranker: str | None = None
     timeout_seconds: float = 180.0
 
     def _base_args(self, no_sync: bool) -> list[str]:
@@ -41,6 +42,8 @@ class SearchBackend:
             args += ["--source", source]
         if not self.rerank:
             args.append("--no-rerank")
+        elif self.reranker:
+            args += ["--reranker", self.reranker]
         if no_sync:
             args.append("--no-sync")
         if self.store:

--- a/packages/search-eval/src/search_eval/cli.py
+++ b/packages/search-eval/src/search_eval/cli.py
@@ -57,6 +57,11 @@ def _build_parser() -> argparse.ArgumentParser:
     retr = sub.add_parser("retrieval", help="Tier A: grade search rankings vs gold")
     _add_common(retr)
     retr.add_argument("--no-rerank", action="store_true", help="disable the second-stage reranker")
+    retr.add_argument(
+        "--reranker",
+        default=None,
+        help="reranking model to compare (default: the search CLI's listwise default)",
+    )
     retr.add_argument("--no-judge", action="store_true", help="skip the LLM relevance judge")
     retr.add_argument("--judge-top-n", type=int, default=3, help="hits to LLM-grade per query")
     retr.add_argument("--dataset", type=Path, default=None, help="override retrieval.jsonl")
@@ -85,6 +90,7 @@ def _search_backend(args: argparse.Namespace) -> SearchBackend:
         store=args.store,
         max_count=args.max_count,
         rerank=not getattr(args, "no_rerank", False),
+        reranker=getattr(args, "reranker", None),
     )
 
 

--- a/packages/search-py/README.md
+++ b/packages/search-py/README.md
@@ -35,6 +35,7 @@ Keyword arguments mirror the `search` CLI:
 - `store`: store name (default `index`).
 - `base_url`: Mixedbread API base URL (default the client's built-in).
 - `rerank` (default `True`): apply the second-stage reranker.
+- `reranker` (default the listwise model): reranking model name; ignored when `rerank=False`.
 - `web` (default `False`): mix in web results.
 - scope: `source`, `not_source`, `repo`, `user`, `host`, `project` (see below).
 

--- a/packages/search-py/python/search/_search.pyi
+++ b/packages/search-py/python/search/_search.pyi
@@ -29,6 +29,7 @@ def semantic(
     store: str | None = ...,
     base_url: str | None = ...,
     rerank: bool = ...,
+    reranker: str | None = ...,
     web: bool = ...,
     source: list[str] | None = ...,
     not_source: list[str] | None = ...,

--- a/packages/search-py/python/search/_search.pyi
+++ b/packages/search-py/python/search/_search.pyi
@@ -29,7 +29,6 @@ def semantic(
     store: str | None = ...,
     base_url: str | None = ...,
     rerank: bool = ...,
-    reranker: str | None = ...,
     web: bool = ...,
     source: list[str] | None = ...,
     not_source: list[str] | None = ...,
@@ -38,6 +37,7 @@ def semantic(
     host: list[str] | None = ...,
     project: list[str] | None = ...,
     agentic: bool = ...,
+    reranker: str | None = ...,
 ) -> Awaitable[list[Hit]]: ...
 def grep(
     pattern: str,

--- a/packages/search-py/src/lib.rs
+++ b/packages/search-py/src/lib.rs
@@ -46,7 +46,6 @@ use search_core::{
     store = None,
     base_url = None,
     rerank = true,
-    reranker = None,
     web = false,
     source = None,
     not_source = None,
@@ -55,6 +54,9 @@ use search_core::{
     host = None,
     project = None,
     agentic = true,
+    // Trailing optional so existing positional callers (…, rerank, web, …) keep
+    // their slots; inserting it mid-signature would rebind their arguments.
+    reranker = None,
 ))]
 #[allow(
     clippy::too_many_arguments,
@@ -67,7 +69,6 @@ fn semantic(
     store: Option<String>,
     base_url: Option<String>,
     rerank: bool,
-    reranker: Option<String>,
     web: bool,
     source: Option<Vec<String>>,
     not_source: Option<Vec<String>>,
@@ -76,6 +77,7 @@ fn semantic(
     host: Option<Vec<String>>,
     project: Option<Vec<String>>,
     agentic: bool,
+    reranker: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     let store_name = store.unwrap_or_else(|| DEFAULT_STORE.to_owned());
     let base = base_url.unwrap_or_else(|| mixedbread::DEFAULT_BASE_URL.to_owned());

--- a/packages/search-py/src/lib.rs
+++ b/packages/search-py/src/lib.rs
@@ -19,7 +19,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use search_core::{
     CodeScope, DEFAULT_STORE, DisplayHit, Filter, FilterSpec, GrepOptions, GrepTargets, Manifest,
-    MixedbreadStore, SearchOptions, Source, build_filter,
+    MixedbreadStore, Rerank, SearchOptions, Source, build_filter,
 };
 
 /// Run a natural-language semantic search over the shared corpus store.
@@ -34,6 +34,11 @@ use search_core::{
 /// multiple searches gives better results out of the box. Pass `agentic=False`
 /// for a single-shot query when speed beats recall. (The `search` CLI keeps it
 /// off by default for scripted, low-latency use.)
+///
+/// `rerank` toggles the second-stage reranker (on by default). `reranker` names
+/// the model: when unset the listwise reranker is used, which reads the
+/// candidate set as a whole and lifts ranking quality over the pointwise
+/// default.
 #[pyfunction]
 #[pyo3(signature = (
     query,
@@ -41,6 +46,7 @@ use search_core::{
     store = None,
     base_url = None,
     rerank = true,
+    reranker = None,
     web = false,
     source = None,
     not_source = None,
@@ -61,6 +67,7 @@ fn semantic(
     store: Option<String>,
     base_url: Option<String>,
     rerank: bool,
+    reranker: Option<String>,
     web: bool,
     source: Option<Vec<String>>,
     not_source: Option<Vec<String>>,
@@ -73,6 +80,14 @@ fn semantic(
     let store_name = store.unwrap_or_else(|| DEFAULT_STORE.to_owned());
     let base = base_url.unwrap_or_else(|| mixedbread::DEFAULT_BASE_URL.to_owned());
     let filter = scope_filter(source, not_source, repo, user, host, project)?;
+    // `rerank=False` disables reranking; otherwise a named model wins, falling
+    // back to the listwise reranker so the interactive MCP surface gets the best
+    // ordering by default.
+    let rerank = match (rerank, reranker) {
+        (false, _) => Rerank::off(),
+        (true, Some(model)) => Rerank::model(model),
+        (true, None) => Rerank::listwise(),
+    };
     let options = SearchOptions { rerank, agentic };
     // Keep every value the borrowed `search_core::semantic` call reads owned in
     // one frame, so the future handed to `future_into_py` stays `'static`.

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -48,7 +48,8 @@ search --source code --repo indexable-inc/index "manifest reconcile"
 ```
 
 Flags mirror `mgrep search` where they overlap: `-c/--content`, `-m/--max-count`,
-`-a/--answer`, `--no-rerank`, `-w/--web`, `--agentic`. The store name comes from
+`-a/--answer`, `--no-rerank`, `--reranker <model>` (defaults to the listwise
+reranker), `-w/--web`, `--agentic`. The store name comes from
 `--store` or `MXBAI_STORE` (default `index`); the API base URL from `--base-url`
 or `MXBAI_BASE_URL`.
 

--- a/packages/search/src/main.rs
+++ b/packages/search/src/main.rs
@@ -14,8 +14,8 @@ use clap::error::ErrorKind;
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use indicatif::ProgressBar;
 use search_core::{
-    CodeScope, DEFAULT_STORE, DisplayHit, Filter, FilterSpec, GrepOptions, GrepTargets, Manifest,
-    MixedbreadStore, SearchOptions, Source, build_filter,
+    CodeScope, DEFAULT_RERANK_MODEL, DEFAULT_STORE, DisplayHit, Filter, FilterSpec, GrepOptions,
+    GrepTargets, Manifest, MixedbreadStore, Rerank, SearchOptions, Source, build_filter,
 };
 
 /// Command-line arguments.
@@ -162,6 +162,11 @@ struct SemanticArgs {
     #[arg(long = "no-rerank")]
     no_rerank: bool,
 
+    /// Reranking model to apply. Defaults to Mixedbread's listwise reranker.
+    /// Ignored when `--no-rerank` is set.
+    #[arg(long = "reranker", default_value_t = DEFAULT_RERANK_MODEL.to_owned())]
+    reranker: String,
+
     /// Include web results from the hosted web store.
     #[arg(short = 'w', long)]
     web: bool,
@@ -281,7 +286,11 @@ async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
     // the manifest is empty (it only ever held this checkout's hashes).
     let manifest = Manifest::default();
     let options = SearchOptions {
-        rerank: !cli.no_rerank,
+        rerank: if cli.no_rerank {
+            Rerank::off()
+        } else {
+            Rerank::model(cli.reranker)
+        },
         agentic: cli.agentic,
     };
     let top_k = cli.max_count.max(1);


### PR DESCRIPTION
Wire Mixedbread's new listwise reranker (`mxbai-rerank-v3-listwise`) through the whole search stack and make it the default.

- `mixedbread::Rerank` replaces the bare `rerank: bool`. It serializes as the API's `boolean | object` field: a toggle keeps the legacy bare-bool wire body, a model selection sends `{ "model": ... }`. Wire shape locked by a new serde test.
- CLI (`search`/`mgrep`), the MCP/`search-py` binding, and `polars-mixedbread` now default to the listwise model. `--no-rerank` still disables; `--reranker <model>` / `reranker=` pins another model.
- `search-eval` gains `--reranker` so the listwise default can be measured against a baseline.

The listwise model reads the candidate set as a whole instead of scoring each chunk independently, which lifts ranking quality over the prior pointwise default (Mixedbread reports gains on every benchmark they tested).

Validated: `nix build .#search .#polars-mixedbread .#file-search .#indexer` green on aarch64-darwin (compile gate covers mixedbread + search-core + the polars binding). Linux rust checks (including the Linux-only `search-py` wheel) run in CI.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default reranking to `mxbai-rerank-v3-listwise` across search CLI and Python bindings
> - Introduces a `Rerank` enum in [packages/mixedbread/src/lib.rs](https://github.com/indexable-inc/index/pull/654/files#diff-1ccc2330cdefa0e3534bffd0e0b7af64c448d14a8f6715cc4f69c594032e607e) with variants for off, server default, and named model; serializes to boolean or `{model: ...}` to match the API contract.
> - Adds `DEFAULT_RERANK_MODEL` constant (`mixedbread-ai/mxbai-rerank-v3-listwise`) used as the default when reranking is enabled without an explicit model.
> - Updates the search CLI (`--reranker` flag, defaults to `DEFAULT_RERANK_MODEL`) and Python `semantic()`/`scan_mixedbread()` bindings to accept an optional reranker model name.
> - Behavioral Change: enabling reranking without specifying a model previously used the server default; it now pins `mxbai-rerank-v3-listwise` explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76c9520.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->