### PR TITLE
mcp: advertise a reachable lab URL host on remote VMs

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -16,6 +16,20 @@ nix run .#mcp -- eval '1 + 2'     # one-shot expression on a throwaway kernel
 When `serve` starts it prints a JupyterLab URL (with an auth token) to stderr;
 open it, or run `ix-mcp lab`, to co-edit the notebook the agent is working in.
 
+## Remote access
+
+Two env vars control how a remote VM hands back a reachable URL:
+
+- `IX_MCP_HOST` (default `127.0.0.1`): the address Jupyter binds. Set it to
+  `0.0.0.0` to listen on every interface so the lab is reachable off-box.
+- `IX_MCP_PUBLIC_HOST`: the host put into the lab URL. Set it to force a specific
+  name (e.g. `myvm.tail368802.ts.net`).
+
+If you bind a wildcard (`0.0.0.0`/`::`) without setting `IX_MCP_PUBLIC_HOST`, the
+URL host is auto-resolved to a reachable name: the Tailscale MagicDNS name first,
+then the FQDN, then `127.0.0.1` as a fallback. The default loopback bind keeps
+the URL on `127.0.0.1` and the server unexposed.
+
 ## How it works
 
 `ix-mcp serve` launches a Jupyter Server in the same process as the MCP server,

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -11,9 +11,12 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
+import shutil
 import socket
+import subprocess
 import sys
 import webbrowser
 from pathlib import Path
@@ -21,6 +24,10 @@ from pathlib import Path
 from .config import Config, runtime_dir, set_config
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+# A bound socket on these binds to every interface, so the address itself is not
+# a host anyone can dial; the lab URL must advertise a concrete reachable name.
+_WILDCARD_HOSTS = {"0.0.0.0", "::"}
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -55,14 +62,75 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _free_port() -> int:
+    # Just reserves a free port number; the kernel gives port 0 an unused port.
+    # The interface here is irrelevant: a number free on loopback is free for the
+    # eventual bind too, so this stays 127.0.0.1 regardless of the final bind.
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
         return sock.getsockname()[1]
 
 
+def _tailscale_dns_name() -> str | None:
+    """This node's MagicDNS name (e.g. ``host.tail<id>.ts.net``), or None.
+
+    Best-effort: locating the binary and parsing `tailscale status --json` can
+    fail many ways (no tailscale, not logged in, malformed output); every such
+    case yields None rather than raising, so the caller can fall through.
+    """
+    tailscale = (
+        shutil.which("tailscale")
+        # macOS ships the CLI as a GUI-app shim outside PATH; Linux pkgs land here.
+        or next((p for p in ("/usr/local/bin/tailscale", "/usr/bin/tailscale") if os.path.exists(p)), None)
+    )
+    if not tailscale:
+        return None
+    try:
+        out = subprocess.run(
+            [tailscale, "status", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=True,
+        ).stdout
+        name = json.loads(out).get("Self", {}).get("DNSName", "")
+    except Exception:
+        return None
+    name = name.rstrip(".")
+    return name or None
+
+
+def _advertised_host(bind_host: str) -> str:
+    """The host to put in the lab URL given the Jupyter bind address.
+
+    An explicit ``IX_MCP_PUBLIC_HOST`` always wins. Otherwise a concrete bind
+    host is already dialable and used as-is; only a wildcard bind needs a
+    reachable name resolved for it.
+    """
+    public = os.environ.get("IX_MCP_PUBLIC_HOST")
+    if public:
+        return public
+    if bind_host not in _WILDCARD_HOSTS:
+        return bind_host
+    # Wildcard bind: substitute a reachable name, best to worst. 127.0.0.1 last so
+    # the URL is at least well-formed even if nothing better resolves.
+    dns = _tailscale_dns_name()
+    if dns:
+        return dns
+    fqdn = socket.getfqdn()
+    if "." in fqdn and fqdn != "localhost":
+        return fqdn
+    return "127.0.0.1"
+
+
 def _serve(args: argparse.Namespace) -> int:
     workdir = (Path(args.workdir).resolve() if args.workdir else Path.cwd())
     workdir.mkdir(parents=True, exist_ok=True)
+
+    # Resolve both host knobs once here (Config is pure data): the bind address
+    # Jupyter listens on, and the host advertised in the lab URL. Default bind is
+    # loopback so the server is never exposed unless asked.
+    bind_host = os.environ.get("IX_MCP_HOST", "127.0.0.1")
+    advertised_host = _advertised_host(bind_host)
 
     http = getattr(args, "http", None)
     stdin_fd = stdout_fd = None
@@ -88,6 +156,8 @@ def _serve(args: argparse.Namespace) -> int:
     # so reading serverapp.port there would still see the unbound value).
     cfg = Config(
         workdir=workdir,
+        host=bind_host,
+        advertised_host=advertised_host,
         jupyter_port=_free_port(),
         transport=transport,
         mcp_http_host=mcp_http_host,

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -27,6 +27,12 @@ class Config:
     jupyter_port: int = 0
     token: str = field(default_factory=lambda: secrets.token_urlsafe(24))
 
+    # The host string put into the lab URL a human opens. Distinct from `host`
+    # (the bind address): when Jupyter binds a wildcard like 0.0.0.0, that is
+    # not a usable URL host, so the CLI resolves a reachable name (tailnet, fqdn)
+    # and stores it here. Defaults to the loopback bind so behaviour is unchanged.
+    advertised_host: str = "127.0.0.1"
+
     # "stdio" (the default; what an MCP client launches) or "http".
     transport: str = "stdio"
 
@@ -43,7 +49,7 @@ class Config:
 
     def lab_url(self) -> str:
         """The URL a human opens to co-edit, including the auth token."""
-        return f"http://{self.host}:{self.jupyter_port}/lab?token={self.token}"
+        return f"http://{self.advertised_host}:{self.jupyter_port}/lab?token={self.token}"
 
     def resolve(self, rel_path: str) -> Path:
         """Resolve a workspace-relative path to an absolute one, refusing escapes.


### PR DESCRIPTION
Make the JupyterLab URL `ix-mcp` hands back work on a remote VM, not just localhost. `lab_url` returned `127.0.0.1`, unreachable off-box.

- `IX_MCP_HOST` (default `127.0.0.1`): Jupyter bind address; unchanged safe default, never exposed unless set to `0.0.0.0`.
- `IX_MCP_PUBLIC_HOST`: forces the advertised URL host. Else, on a wildcard bind, auto-resolve a reachable name (Tailscale MagicDNS, then FQDN, then loopback).
- Fixes both `notebook_use`'s returned `lab_url` and the `ix-mcp lab` handoff.

Validated: `nix build .#mcp` and `nix run .#mcp -- eval` pass. lab_url cases: default -> `http://127.0.0.1:PORT/...`; `IX_MCP_HOST=0.0.0.0` -> `http://hydra.tail368802.ts.net:PORT/...`; `IX_MCP_PUBLIC_HOST=foo.example` -> `http://foo.example:PORT/...`.

Made with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Advertise a reachable host in the JupyterLab URL when binding to wildcard addresses on remote VMs
> - Adds `IX_MCP_HOST` (bind address, default `127.0.0.1`) and `IX_MCP_PUBLIC_HOST` (advertised URL host) env vars to [cli.py](https://github.com/indexable-inc/index/pull/655/files#diff-7ce741e8223d63fdea11625cb78abad266299445db0213d2355bc93306df9ac5).
> - When binding to a wildcard (`0.0.0.0` or `::`), the advertised host is resolved in order: `IX_MCP_PUBLIC_HOST`, Tailscale MagicDNS name, system FQDN, or `127.0.0.1`.
> - `Config.lab_url()` in [config.py](https://github.com/indexable-inc/index/pull/655/files#diff-33f6f17aed79724ba72211bc8bf9dc1da1bbdb38de56be7ace76cc09837929ca) now uses the new `advertised_host` field instead of the bind `host`.
> - Tailscale resolution runs `tailscale status --json` with a short timeout and returns `None` on any failure.
> - Behavioral Change: the printed lab URL may now differ from the Jupyter bind address when binding to a wildcard interface.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f39ebb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->