### PR TITLE
mcp: accept `ix-mcp serve --workdir DIR`

### DIFF
--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -32,10 +32,13 @@ _WILDCARD_HOSTS = {"0.0.0.0", "::"}
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="ix-mcp", description="Notebook-first MCP server")
-    parser.add_argument("--workdir", help="Directory notebooks live in (default: cwd)")
     sub = parser.add_subparsers(dest="command")
 
     serve = sub.add_parser("serve", help="Run the MCP server")
+    # --workdir lives on `serve` (not the top-level parser) so the natural
+    # `ix-mcp serve --workdir DIR` works; a top-level option would have to precede
+    # the subcommand, which is a surprising ordering.
+    serve.add_argument("--workdir", help="Directory notebooks live in (default: cwd)")
     serve.add_argument(
         "--http",
         nargs="?",
@@ -123,7 +126,10 @@ def _advertised_host(bind_host: str) -> str:
 
 
 def _serve(args: argparse.Namespace) -> int:
-    workdir = (Path(args.workdir).resolve() if args.workdir else Path.cwd())
+    # `getattr`: a bare `ix-mcp` (no subcommand) defaults to serve but never ran
+    # the serve subparser, so `args` has no `workdir` attribute then.
+    wd = getattr(args, "workdir", None)
+    workdir = Path(wd).resolve() if wd else Path.cwd()
     workdir.mkdir(parents=True, exist_ok=True)
 
     # Resolve both host knobs once here (Config is pure data): the bind address


### PR DESCRIPTION
`--workdir` was a top-level flag, so the natural `ix-mcp serve --workdir DIR` (and the README's own example) failed with `unrecognized arguments`; it only worked as `ix-mcp --workdir DIR serve`. Move it onto the `serve` subparser. `_serve` reads it via `getattr` so a bare `ix-mcp` (defaults to serve) still works.

Verified: `ix-mcp serve --workdir /tmp/x` parses; `ix-mcp eval '2+5'` → 7; `nix build .#mcp` green.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move `--workdir` option to the `serve` subcommand in the `ix-mcp` CLI
> - `--workdir` is now only accepted after the `serve` subcommand (e.g., `ix-mcp serve --workdir DIR`); passing it as a top-level flag is rejected by the parser.
> - `_serve` now uses `getattr(args, 'workdir', None)` to safely fall back to cwd when invoked without the `serve` subparser (i.e., default behavior).
> - Behavioral Change: existing scripts using `ix-mcp --workdir DIR` will now fail with a parse error and must be updated to `ix-mcp serve --workdir DIR`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db9fe71.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->