### PR TITLE
nix-cargo-unit: don't substitute per-test leaf derivations

### DIFF
--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -177,6 +177,16 @@ let
   packageTestAttrs = packageName: {
     nativeBuildInputs = packageTestInputs.${packageName} or [];
     env = packageTestEnv.${packageName} or {};
+    # A per-test leaf just runs an already-compiled test binary and produces an
+    # empty marker `$out` that nothing consumes. Substituting it is a net loss:
+    # each leaf costs a narinfo round-trip against every configured substituter
+    # (thousands of leaves x N caches per CI run) only to fetch an empty
+    # directory, when re-running the test on the local store is cheaper. Skip
+    # substitution so no cache is ever queried for these paths, and build them
+    # locally. They stay tiny and input-addressed, so once the run root is gone
+    # they GC trivially and never need to be kept as a useful cached artifact.
+    allowSubstitutes = false;
+    preferLocalBuild = true;
   };
   packageTestEnvArgs =
     packageName:


### PR DESCRIPTION
## What

Set `allowSubstitutes = false` + `preferLocalBuild = true` on the per-test leaf derivations in `packages/nix-cargo-unit/templates/units.nix.askama` (`packageTestAttrs`, inherited by both `mkTestCases` per-`#[test]` and `mkTestEntry.all`).

## Why

Each per-`#[test]` leaf (`cargo-unit-test-<crate>--<test>`) just runs an already-compiled test binary and produces an empty marker `$out` that nothing consumes. Substituting it is a net loss: every leaf costs a narinfo round-trip against **each** configured substituter (thousands of leaves × N caches per CI run) only to fetch an empty directory, when re-running the test on the local store is cheaper.

A CI run was observed querying both `cache.ix.dev` and `cache.nixos.org` for ~5k such leaves — **all misses**, since the build plan listed them as "will be built" with no fetch list (i.e. they're never cached anyway). This eliminates those wasted queries.

- `allowSubstitutes = false` → no cache is ever queried for these paths.
- `preferLocalBuild = true` → build locally; the conventional "trivial, not worth distributing/uploading" signal.
- Outputs stay tiny + input-addressed, so once the run root is gone they GC trivially.

Extends the existing reasoning in `render.rs:801` (tests kept input-addressed to dodge shared-store CA failures, NixOS/nix#15649).

**Doctests** are intentionally left substitutable: they recompile via `rustdoc`, so caching their result can be worth a fetch.

## Validation

`nix build .#packages.x86_64-linux.nix-cargo-unit` → exit 0; askama template compiles; **51/51** generator tests pass (incl. `tests_stay_input_addressed_even_with_content_addressing`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable substitute fetching for per-test leaf derivations in `nix-cargo-unit`
> Sets `allowSubstitutes = false` and `preferLocalBuild = true` on per-test leaf derivations in [units.nix.askama](https://github.com/indexable-inc/index/pull/658/files#diff-0962f6bad01321924b1688b79dee1e5626eeb872b7be247007c19f81bae72ff5). This ensures test leaves are always built locally rather than queried from binary caches, which is the intended behavior for these short-lived derivations. A block comment in the template documents the rationale.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f91e0b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->