### PR TITLE
tui-py: fix from_ghostty #-hex parse + drop dead branch

### DIFF
--- a/packages/tui-py/python/tui/__init__.py
+++ b/packages/tui-py/python/tui/__init__.py
@@ -162,15 +162,27 @@ class Theme:
         ignored. Unspecified palette slots keep the bundled `DARK_THEME` color.
         """
         text = source
-        expanded = os.path.expanduser(source)
-        if "\n" not in source and os.path.exists(expanded):
-            with open(expanded, encoding="utf-8") as fh:
-                text = fh.read()
+        if "\n" not in source:
+            expanded = os.path.expanduser(source)
+            if os.path.exists(expanded):
+                with open(expanded, encoding="utf-8") as fh:
+                    text = fh.read()
+            elif "/" in source or source.startswith("~"):
+                # Looks like a path but is not there: a typo'd path would
+                # otherwise parse as (key-less) theme text and silently return
+                # the defaults, so fail loudly instead.
+                msg = f"ghostty theme file not found: {source}"
+                raise FileNotFoundError(msg)
 
         fg, bg = DARK_THEME.fg, DARK_THEME.bg
         ansi = list(DARK_THEME.ansi)
         for raw in text.splitlines():
-            line = raw.split("#", 1)[0].strip()
+            line = raw.strip()
+            # Whole-line comments start with `#`. A `#` inside a value is a hex
+            # color (ghostty writes `background = #1e1e1e`), so do not treat it
+            # as a comment delimiter; `_hex_to_rgb` strips a leading `#`.
+            if not line or line.startswith("#"):
+                continue
             key, sep, val = line.partition("=")
             if not sep:
                 continue
@@ -282,10 +294,6 @@ def _styled_grid_to_html(grid: tuple[tuple[StyledCell, ...], ...], theme: Theme)
         run_css: str | None = None
         run: list[str] = []
         for cell in row:
-            # A wide character's trailing continuation cell carries "": skip it
-            # so a double-width glyph occupies its two monospace columns once.
-            if cell.char == "":
-                continue
             css = _cell_css(cell, theme)
             if css != run_css:
                 if run:


### PR DESCRIPTION
Follow-up to #659, fixing two issues the code review caught.

- `Theme.from_ghostty` crashed (`ValueError`) on `#`-prefixed hex colors (`background = #1e1e1e`, `palette = 0=#51576d`) because comment-stripping ate the value. That is the common ghostty form (every Catppuccin theme). Now only whole-line `#` comments are dropped; a `#` inside a value is left for `_hex_to_rgb`. Bare-hex themes still parse.
- A path-shaped `source` that does not exist now raises `FileNotFoundError` instead of silently parsing as theme text and returning the defaults.
- Removed the dead `cell.char == ""` branch in the styled renderer: the Rust layer always emits a one-scalar string (blanks are `" "`), so it never fired and its comment described a non-existent contract.

Validated: parses a Catppuccin-style `#`-prefixed theme correctly (bg/fg/palette), the real bare-hex `custom-dark` still works, a mistyped path raises, inline text still parses. Lint clean.

Made with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Theme.from_ghostty` hex color parsing and path error handling
> - Fixes comment stripping in `from_ghostty` so that whole-line `#` comments are skipped but inline values starting with `#` (e.g. `#1e1e1e`) are preserved and passed correctly to `_hex_to_rgb`.
> - Adds `FileNotFoundError` when the source looks like a path (contains `/` or starts with `~`) but the file does not exist, rather than silently treating it as inline content.
> - Removes a dead branch in `_styled_grid_to_html` that skipped cells with empty `char` values; these are now processed through the normal run-accumulation logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4aa7f46.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->