### PR TITLE
blast-radius: inline Mermaid graphs (category pie + cause fan-out)

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -105,6 +105,7 @@ jobs:
           # otherwise exits on the last value, letting `{}` followed by a valid
           # report pass while the render then emits a null first section.
           jq -e -s '
+            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +():-]+$");
             length == 1 and
             (.[0] |
               (.base    | type == "string" and test("^[0-9a-f]{7,40}$")) and
@@ -113,7 +114,11 @@ jobs:
               (.changed | type == "array") and
               (.added   | type == "array") and
               (.removed | type == "array") and
-              ((.changed + .added + .removed) | all(type == "string" and test("^[A-Za-z0-9_./ +():-]+$")))
+              ((.changed + .added + .removed) | all(name_ok)) and
+              (.categories | type == "array") and
+              (.categories | all((.name | name_ok) and (.count | type == "number"))) and
+              (.causes | type == "array") and
+              (.causes | all((.name | name_ok) and (.checks | type == "array") and (.checks | all(name_ok))))
             )
           ' report.json > /dev/null \
             || { echo "::error::malformed blast-radius report.json"; exit 1; }
@@ -127,12 +132,29 @@ jobs:
           set -euo pipefail
           jq -r '
             def safename: select(test("^[A-Za-z0-9_./ +():-]+$"));
-            "<!-- blast-radius -->",
+            # Unique checks across all causes, so the flowchart shares one node
+            # per check (keeps the graph under the Mermaid node budget).
+            ([ .causes[].checks[] ] | unique) as $checks
+            | "<!-- blast-radius -->",
             "### Blast radius",
             "",
             "`\((.changed | length) + (.added | length))` of `\(.total)` checks would rebuild between base `\(.base)` and head `\(.head)`.",
             (if ((.added | length) > 0) or ((.removed | length) > 0)
              then "", "\(.added | length) added, \(.removed | length) removed"
+             else empty end),
+            # v1: proportions of what rebuilt, by check family.
+            (if (.categories | length) > 0
+             then "", "```mermaid", "pie showData title Rebuilt checks by category",
+                  (.categories[] | "  \"\(.name | safename)\" : \(.count)"),
+                  "```"
+             else empty end),
+            # v2: which changed inputs fan out to which checks (top causes).
+            (if (.causes | length) > 0
+             then "", "```mermaid", "flowchart LR",
+                  (.causes | to_entries[] | "  c\(.key)[\"\(.value.name | safename)\"]"),
+                  (.causes | to_entries[] as $c | $c.value.checks[] as $k
+                   | "  c\($c.key) --> k\($checks | index($k))[\"\($k | safename)\"]"),
+                  "```"
              else empty end),
             (if (.changed | length) > 0
              then "", "<details><summary>changed checks</summary>", "",

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -642,6 +642,31 @@ in
           ${lib.getExe lint}
           mkdir -p "$out"
         '';
+        # Exercises the blast-radius PR comment: the validate/render jq embedded
+        # in its workflow (extracted from the YAML so the test can't drift from
+        # what the trusted comment job runs) plus the report-building logic in
+        # tools/blast-radius.nu. See tools/blast-radius-test.sh for the cases.
+        blast-radius-test =
+          pkgs.runCommand "blast-radius-test"
+            {
+              nativeBuildInputs = [
+                pkgs.bash
+                pkgs.coreutils
+                pkgs.diffutils
+                pkgs.jq
+                pkgs.yq-go
+                pkgs.nushell
+              ];
+            }
+            ''
+              cp -R ${lintSource} source
+              chmod -R u+w source
+              cd source
+              export HOME="$TMPDIR/home"
+              mkdir -p "$HOME"
+              bash tools/blast-radius-test.sh
+              mkdir -p "$out"
+            '';
         # Proves the Linux→macOS cross toolchain actually emits a Darwin object,
         # which a successful build alone does not assert. `file` reads the Mach-O
         # header; a regression in the zig/SDK wiring fails here on x86_64-linux CI

--- a/tools/blast-radius-fixtures/bad-check.json
+++ b/tools/blast-radius-fixtures/bad-check.json
@@ -1,0 +1,2 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":1,"changed":[],"added":[],"removed":[],
+ "categories":[],"causes":[{"name":"x","checks":["ok","`rm -rf`"]}]}

--- a/tools/blast-radius-fixtures/bad-name.json
+++ b/tools/blast-radius-fixtures/bad-name.json
@@ -1,0 +1,2 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":1,"changed":[],"added":[],"removed":[],
+ "categories":[{"name":"rust\n@room ping","count":1}],"causes":[]}

--- a/tools/blast-radius-fixtures/good.expected.md
+++ b/tools/blast-radius-fixtures/good.expected.md
@@ -1,0 +1,30 @@
+<!-- blast-radius -->
+### Blast radius
+
+`4` of `120` checks would rebuild between base `aaaaaaa` and head `bbbbbbb`.
+
+1 added, 0 removed
+
+```mermaid
+pie showData title Rebuilt checks by category
+  "rust" : 2
+  "mcp" : 2
+  "image" : 1
+```
+
+```mermaid
+flowchart LR
+  c0["ix-rust-workspace"]
+  c1["image-base-layer"]
+  c0 --> k1["mcp-serverTools"]
+  c0 --> k2["rust-test-search_core"]
+  c1 --> k0["image-base"]
+```
+
+<details><summary>changed checks</summary>
+
+- mcp-serverTools
+- rust-test-search_core
+- image-base
+
+</details>

--- a/tools/blast-radius-fixtures/good.json
+++ b/tools/blast-radius-fixtures/good.json
@@ -1,0 +1,6 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":120,
+ "changed":["mcp-serverTools","rust-test-search_core","image-base"],
+ "added":["mcp-evalSmoke"],"removed":[],
+ "categories":[{"name":"rust","count":2},{"name":"mcp","count":2},{"name":"image","count":1}],
+ "causes":[{"name":"ix-rust-workspace","checks":["mcp-serverTools","rust-test-search_core"]},
+           {"name":"image-base-layer","checks":["image-base"]}]}

--- a/tools/blast-radius-fixtures/logic-test.nu
+++ b/tools/blast-radius-fixtures/logic-test.nu
@@ -1,0 +1,18 @@
+# Unit test for the report-building logic in tools/blast-radius.nu.
+# `nix-store` is stubbed by the caller (blast-radius-test.sh) so `causes-for`
+# runs its real reference-diff code path without a live store.
+use std assert
+source ../blast-radius.nu
+
+assert equal (category "image-foo") "image"
+assert equal (category "rust-test-bar") "rust"
+assert equal (category "lint") "lint"
+assert equal (drv-name "/nix/store/abcdefghijklmnopqrstuvwxyz012345-ix-rust-workspace.drv") "ix-rust-workspace"
+
+let b = [{attr: "rust-a", drvPath: "/nix/store/base-rust-a.drv"} {attr: "rust-b", drvPath: "/nix/store/base-rust-b.drv"}]
+let h = [{attr: "rust-a", drvPath: "/nix/store/head-rust-a.drv"} {attr: "rust-b", drvPath: "/nix/store/head-rust-b.drv"}]
+# Both checks' direct refs gain a fresh ix-rust-workspace hash (glibc is
+# unchanged), so it is the single root cause fanning out to both.
+assert equal (causes-for $b $h ["rust-a" "rust-b"]) [{name: "ix-rust-workspace", checks: ["rust-a" "rust-b"]}]
+
+print "logic-test: ok"

--- a/tools/blast-radius-fixtures/missing.json
+++ b/tools/blast-radius-fixtures/missing.json
@@ -1,0 +1,1 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":1,"changed":[],"added":[],"removed":[]}

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Tests the blast-radius PR comment end to end:
+#   * the security-critical validate + render jq embedded in
+#     .github/workflows/blast-radius.yml (extracted from the workflow so the test
+#     can never drift from what the trusted comment job actually runs), and
+#   * the report-building logic in tools/blast-radius.nu (categories + the
+#     cause/fan-out reference diff), with a stubbed `nix-store`.
+# Needs jq, yq (yq-go), and nu on PATH.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fixtures="$here/blast-radius-fixtures"
+workflow="$here/../.github/workflows/blast-radius.yml"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+fail=0
+note() { printf '  %s\n' "$*"; }
+
+# Extract the exact run-scripts the trusted comment job executes.
+yq '.jobs.comment.steps[] | select(.name == "Validate report schema").run' "$workflow" > "$tmp/validate.sh"
+yq '.jobs.comment.steps[] | select(.name == "Render comment").run' "$workflow" > "$tmp/render.sh"
+
+validate() { ( cd "$tmp" && cp "$1" report.json && bash validate.sh ); }
+
+# Schema validation: the good report passes; hostile names and old (missing
+# categories/causes) reports are rejected fail-closed.
+if validate "$fixtures/good.json" >/dev/null 2>&1; then note "validate good: ok"; else note "validate good: FAIL"; fail=1; fi
+for bad in bad-name bad-check missing; do
+  if validate "$fixtures/$bad.json" >/dev/null 2>&1; then
+    note "validate $bad: FAIL (accepted hostile/old report)"; fail=1
+  else
+    note "validate $bad: rejected ok"
+  fi
+done
+
+# Render: the good report produces the golden comment (pie + flowchart + list).
+( cd "$tmp" && cp "$fixtures/good.json" report.json && bash render.sh )
+if diff -u "$fixtures/good.expected.md" "$tmp/comment.md"; then note "render good: ok"; else note "render good: FAIL (output drift)"; fail=1; fi
+
+# Report-building logic with a stubbed nix-store (head vs base refs differ only
+# in the ix-rust-workspace hash, so it is the changed root cause).
+cat > "$tmp/nix-store" <<'STUB'
+#!/usr/bin/env bash
+drv="${!#}"
+case "$drv" in
+  *head-rust-*) echo /nix/store/h1111111111111111111111111111111-ix-rust-workspace.drv
+                echo /nix/store/g2222222222222222222222222222222-glibc.drv ;;
+  *base-rust-*) echo /nix/store/b0000000000000000000000000000000-ix-rust-workspace.drv
+                echo /nix/store/g2222222222222222222222222222222-glibc.drv ;;
+esac
+STUB
+chmod +x "$tmp/nix-store"
+# Run via `-c "source ..."`, not `nu logic-test.nu`: executing a file auto-runs
+# any `main` in scope, and the test sources blast-radius.nu (which defines one),
+# so a plain file run would fire the real report build. `-c` does not auto-run.
+if PATH="$tmp:$PATH" nu --no-config-file -c "source '$fixtures/logic-test.nu'"; then note "logic-test: ok"; else note "logic-test: FAIL"; fail=1; fi
+
+if [ "$fail" -ne 0 ]; then echo "blast-radius-test: FAILED"; exit 1; fi
+echo "blast-radius-test: all passed"

--- a/tools/blast-radius.nu
+++ b/tools/blast-radius.nu
@@ -1,5 +1,11 @@
 const eval_jobs = "github:nix-community/nix-eval-jobs/65ebf5b7cd453a27af09cf02b1fc57b3568cc4b7"
 
+# Caps that keep the rendered Mermaid graph under GitHub's ~50KB / ~25-node
+# budget: only the highest fan-out root causes, and only a few affected checks
+# per cause, are drawn (the comment still lists every changed check in full).
+const max_causes = 6
+const max_checks_per_cause = 5
+
 def eval-checks [repo: string, rev: string] {
   let flakeref = $"git+file://($repo)?rev=($rev)&allRefs=1#checks.x86_64-linux"
   # nix-eval-jobs sits at the head of the pipeline, and Nushell only
@@ -36,6 +42,52 @@ def drv-for [tbl, name] {
   $tbl | each {|r| if ($r.attr == $name) { $r.drvPath } } | compact | first
 }
 
+# A check's category for the v1 breakdown: the segment before the first dash
+# (`image-foo` -> `image`, `rust-test-bar` -> `rust`, `lint` -> `lint`). Coarse
+# but it groups the families that actually share fan-out.
+def category [name: string] {
+  let head = ($name | split row "-" | first)
+  if ($head | is-empty) { $name } else { $head }
+}
+
+# Strip a store path to its derivation name: drop the `/nix/store/<hash>-`
+# prefix and the `.drv` suffix, leaving e.g. `ix-rust-workspace` or
+# `search_core-0.1.0` -- a stable, readable label for a graph node.
+def drv-name [p: string] {
+  $p | path basename | str replace -r '^[a-z0-9]{32}-' '' | str replace -r '\.drv$' ''
+}
+
+# v2 root causes: for each changed check, the *direct* input derivations whose
+# store path differs between base and head. Direct references suffice because a
+# changed transitive dependency propagates a fresh hash up to the immediate
+# input, so the check's direct refs always move when anything below them does --
+# and querying references (not the full closure) keeps this cheap. Causes are
+# ranked by fan-out (how many checks they rebuild) and capped for the graph.
+def causes-for [b, h, changed: list<string>] {
+  mut acc = {}
+  for name in $changed {
+    let hd = (drv-for $h $name)
+    let bd = (drv-for $b $name)
+    if ($hd | is-empty) or ($bd | is-empty) { continue }
+    let changed_names = (
+      do --ignore-errors {
+        let hr = (^nix-store -q --references $hd | lines | where ($it | str ends-with ".drv"))
+        let br = (^nix-store -q --references $bd | lines | where ($it | str ends-with ".drv"))
+        $hr | where ($it not-in $br) | each {|p| drv-name $p } | uniq
+      }
+    )
+    for cn in ($changed_names | default []) {
+      $acc = ($acc | upsert $cn (($acc | get -o $cn | default []) | append $name))
+    }
+  }
+  $acc
+  | transpose name checks
+  | each {|r| { name: $r.name, checks: ($r.checks | uniq | sort), fanout: ($r.checks | uniq | length) } }
+  | sort-by fanout --reverse
+  | first $max_causes
+  | each {|r| { name: $r.name, checks: ($r.checks | first $max_checks_per_cause) } }
+}
+
 def main [base?: string, head?: string, --json] {
   let repo = (^git rev-parse --show-toplevel | str trim)
   let head_rev = (^git rev-parse --verify $"($head | default 'HEAD')^{commit}" | str trim)
@@ -55,6 +107,17 @@ def main [base?: string, head?: string, --json] {
   let na = ($added | length)
   let nr = ($removed | length)
 
+  # v1: changed + added grouped by category, largest first.
+  let categories = (
+    ($changed ++ $added)
+    | each {|n| category $n }
+    | uniq --count
+    | rename name count
+    | sort-by count --reverse
+  )
+  # v2: root-cause fan-out edges (only meaningful for the changed set).
+  let causes = (if ($nc > 0) { causes-for $b $h $changed } else { [] })
+
   if $json {
     print ({
       base: ($base_rev | str substring 0..7)
@@ -63,6 +126,8 @@ def main [base?: string, head?: string, --json] {
       changed: $changed
       added: $added
       removed: $removed
+      categories: $categories
+      causes: $causes
     } | to json)
   } else {
     print "<!-- blast-radius -->"
@@ -70,6 +135,30 @@ def main [base?: string, head?: string, --json] {
     print ""
     print $"`($nc + $na)` of `($total)` checks would rebuild between base `($base_rev | str substring 0..7)` and head `($head_rev | str substring 0..7)`."
     if ($na > 0) or ($nr > 0) { print ""; print $"($na) added, ($nr) removed" }
+    if ($categories | length) > 0 {
+      print ""
+      print "```mermaid"
+      print "pie showData title Rebuilt checks by category"
+      for c in $categories { print $"  \"($c.name)\" : ($c.count)" }
+      print "```"
+    }
+    if ($causes | length) > 0 {
+      print ""
+      print "```mermaid"
+      print "flowchart LR"
+      mut i = 0
+      for c in $causes {
+        let cid = $"c($i)"
+        print $"  ($cid)\([\"($c.name)\"]\)"
+        mut j = 0
+        for k in $c.checks {
+          print $"  ($cid) --> ($cid)k($j)\([\"($k)\"]\)"
+          $j = $j + 1
+        }
+        $i = $i + 1
+      }
+      print "```"
+    }
     if ($nc > 0) {
       print ""
       print "<details><summary>changed checks</summary>"


### PR DESCRIPTION
Adds two inline graphs to the blast-radius PR comment so the cache-impact is visual, not just a count + list.

- **v1 pie** — proportions of rebuilt checks by family.
- **v2 flowchart** — the top changed inputs and the checks they fan out to (the "one crate bump rebuilds N checks" picture).

Both are GitHub-native Mermaid, rendered inline. I went this way rather than dot/svg because inline images don't work for a private repo: `raw.githubusercontent.com` 404s, the `user-attachments` CDN needs a browser-session cookie (not a CI token), and artifact URLs are download links, not inline images. Mermaid needs no hosting.

Security model preserved: the untrusted `evaluate` job only emits new data-only fields (`categories`, `causes`); the trusted `comment` job validates them fail-closed (charset-checked, rejects injected names / old reports) and builds the Mermaid itself, so PR code still can't inject into the posted comment.

`causes` come from each changed check's direct-reference drv diff between base and head (cheap; a changed transitive dep propagates a fresh hash to the immediate input), ranked by fan-out and capped to stay under the Mermaid node budget.

### What it looks like

```mermaid
pie showData title Rebuilt checks by category
  "rust" : 2
  "mcp" : 2
  "image" : 1
```

```mermaid
flowchart LR
  c0["ix-rust-workspace"]
  c1["image-base-layer"]
  c0 --> k1["mcp-serverTools"]
  c0 --> k2["rust-test-search_core"]
  c1 --> k0["image-base"]
```

### Testing

`tools/blast-radius-test.sh` (+ fixtures), wired as the `blast-radius-test` flake check, extracts the validate/render jq straight from the workflow YAML (so the test can't drift from what CI runs) and asserts: the good report renders the golden comment; hostile/old reports are rejected; and `blast-radius.nu`'s category + cause logic is correct with a stubbed `nix-store`. All green locally.

@wyattgill9 you own this workflow (#547) — flagging you; happy to adjust.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add inline Mermaid category pie chart and cause fan-out flowchart to blast-radius PR comments
> - Extends [blast-radius.nu](https://github.com/indexable-inc/index/pull/661/files#diff-042e18b7ef34127bf537e9dd2454a21d878e3919ed70aa8f6ec733e8501b776e) to compute check categories (by name prefix) and top root causes (by derivation fan-out), and includes both in JSON output and CLI output as Mermaid diagrams.
> - Updates the [blast-radius.yml](https://github.com/indexable-inc/index/pull/661/files#diff-f18ec732b17d456a8d2f9c00a4941f9433314b97b8a3df9cea22bdaf15337468) render step to embed a Mermaid pie chart (rebuilt checks by category) and a Mermaid flowchart (causes → affected checks) in the posted PR comment.
> - Tightens schema validation in the workflow to require `categories` and `causes` arrays and reject names with disallowed characters.
> - Adds an end-to-end test harness ([blast-radius-test.sh](https://github.com/indexable-inc/index/pull/661/files#diff-008b7e349202f69865582328028ef88fb2c6c22cdfd1f42fbbf5533600c2e27b)) with golden-file diffing and bad-fixture rejection tests, wired up as a Nix derivation in [per-system.nix](https://github.com/indexable-inc/index/pull/661/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683).
> - Graph rendering is capped at a fixed number of cause nodes and checks per cause to stay within Mermaid limits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d6bf6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->