### PR TITLE
fix(tui): readable Snapshot repr, mode-aware arrows, consistent is_alive, default TERM

### DIFF
--- a/packages/tui-py/README.md
+++ b/packages/tui-py/README.md
@@ -260,7 +260,7 @@ from tui import Tui
 async def main() -> None:
     t = Tui("bash", "-c", "echo hi; exit 7")
     code = await t.wait(timeout=3)     # blocks until exit; raises WaitTimeout on deadline
-    print(code, t.is_alive())          # 7 False
+    print(code, t.is_alive)            # 7 False
     print(t.exit_code)                 # 7 (None while running or if killed by a signal)
 
 asyncio.run(main())

--- a/packages/tui-py/python/tui/__init__.py
+++ b/packages/tui-py/python/tui/__init__.py
@@ -358,6 +358,28 @@ class Snapshot:
     def __str__(self) -> str:
         return self.text
 
+    def __repr__(self) -> str:
+        """Plain-text display for terminals, logs, and a notebook's `text/plain`.
+
+        The dataclass default repr would expand every `StyledCell`, which for a
+        full screen is tens of kilobytes of noise: an agent reading the cell
+        output wants the screen, not the grid. Render the viewport inside a
+        width-exact frame so columns, trailing space, and the real size are
+        unambiguous, and summarize the styling instead of expanding it. The
+        colored view is still available via `_repr_html_` / `to_html`.
+        """
+        rows, cols = self.size.rows, self.size.cols
+        top = "┌" + "─" * cols + "┐"
+        bottom = "└" + "─" * cols + "┘"
+        body = "\n".join(f"│{line[:cols]:<{cols}}│" for line in self.viewport)
+        notes = [f"{rows}x{cols}"]
+        if self.scrollback:
+            notes.append(f"+{len(self.scrollback)} scrollback")
+        if self.styled:
+            notes.append("styled")
+        header = f"Snapshot {', '.join(notes)}"
+        return f"{header}\n{top}\n{body}\n{bottom}" if body else f"{header}\n{top}\n{bottom}"
+
     def to_html(self, theme: Theme | None = None) -> str:
         """Render the viewport to a colored monospace HTML block.
 
@@ -553,6 +575,7 @@ class Tui:
     def scrollback_limit(self) -> int:
         return self._raw.scrollback_limit
 
+    @property
     def is_alive(self) -> bool:
         """Whether the child process is still running."""
         return self._raw.is_alive()

--- a/packages/tui/src/actor/engine.rs
+++ b/packages/tui/src/actor/engine.rs
@@ -65,13 +65,25 @@ pub fn spawn(
     cols: u16,
     scrollback: usize,
     cursor_shape: Arc<SyncRwLock<CursorShape>>,
+    app_cursor_keys: Arc<SyncRwLock<bool>>,
 ) -> Result<Sender<EngineRequest>> {
     let (tx, rx) = std::sync::mpsc::channel::<EngineRequest>();
     let (init_tx, init_rx) = std::sync::mpsc::sync_channel::<Result<()>>(1);
 
     std::thread::Builder::new()
         .name("ix-vt-engine".to_owned())
-        .spawn(move || engine_loop(id, rows, cols, scrollback, &cursor_shape, &rx, &init_tx))
+        .spawn(move || {
+            engine_loop(
+                id,
+                rows,
+                cols,
+                scrollback,
+                &cursor_shape,
+                &app_cursor_keys,
+                &rx,
+                &init_tx,
+            );
+        })
         .map_err(|e| vt_engine_error_io(id, &e))?;
 
     // Propagate the terminal-creation result before handing back the channel, so
@@ -102,6 +114,7 @@ fn engine_loop(
     cols: u16,
     scrollback: usize,
     cursor_shape: &Arc<SyncRwLock<CursorShape>>,
+    app_cursor_keys: &Arc<SyncRwLock<bool>>,
     rx: &Receiver<EngineRequest>,
     init_tx: &SyncSender<Result<()>>,
 ) {
@@ -116,7 +129,18 @@ fn engine_loop(
 
     while let Ok(request) = rx.recv() {
         match request {
-            EngineRequest::Process(bytes) => terminal.vt_write(&bytes),
+            EngineRequest::Process(bytes) => {
+                terminal.vt_write(&bytes);
+                // Refresh the cached cursor-key mode so the actor picks the
+                // right arrow-key form on the next write. The mode is set by
+                // the program's own output (terminfo `smkx`/`rmkx`), so reading
+                // it here, right after feeding that output, keeps it current. A
+                // failed query leaves the last known value: the mode did not
+                // change, we just could not re-read it.
+                if let Ok(app) = terminal.application_cursor_keys() {
+                    *app_cursor_keys.write() = app;
+                }
+            }
             EngineRequest::Resize { rows, cols, reply } => {
                 let result = terminal.resize(rows, cols).map_err(|e| vt_engine_error(id, e));
                 let _ = reply.send(result);

--- a/packages/tui/src/actor/mod.rs
+++ b/packages/tui/src/actor/mod.rs
@@ -1,5 +1,8 @@
 pub mod engine;
 
+use std::sync::Arc;
+
+use parking_lot::RwLock as SyncRwLock;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, oneshot, watch};
 use uuid::Uuid;
@@ -60,6 +63,7 @@ pub async fn pty_actor(
     mut commands: mpsc::Receiver<PtyCommand>,
     engine_tx: std::sync::mpsc::Sender<EngineRequest>,
     exit_tx: watch::Sender<ExitState>,
+    app_cursor_keys: Arc<SyncRwLock<bool>>,
 ) {
     let mut read_buffer = [0u8; 8192];
     let mut pty_active = true;
@@ -73,6 +77,11 @@ pub async fn pty_actor(
                 match cmd {
                     PtyCommand::Write { data, response } => {
                         if pty_active {
+                            // A real terminal emits the cursor keys in
+                            // application form once the program enables DECCKM;
+                            // rewrite them here so callers send one spelling and
+                            // full-screen programs still receive their arrows.
+                            let data = apply_cursor_key_mode(&data, *app_cursor_keys.read());
                             let result = pty.write_all(&data)
                                 .await
                                 .map_err(|e| crate::Error::WriteToTui {
@@ -213,4 +222,72 @@ async fn resize_engine(
         .send(EngineRequest::Resize { rows, cols, reply })
         .map_err(|_| Error::TuiNotFound { id })?;
     response.await.map_err(|_| Error::TuiNotFound { id })?
+}
+
+/// Rewrite normal-mode cursor-key sequences into their application-mode form
+/// when the program has enabled DECCKM.
+///
+/// A real terminal emits the cursor keys as `ESC O A`..`ESC O D` (and Home/End
+/// as `ESC O H`/`ESC O F`) once the program enables DECCKM via terminfo `smkx`,
+/// which ncurses, vim, and less all do on entry. Sending the normal `ESC [ A`
+/// form instead leaves those programs blind to the arrows. These exact 3-byte
+/// sequences only arise as terminal *input* from a cursor key, so the
+/// substitution is unambiguous. A modified arrow carries parameters
+/// (`ESC [ 1 ; 5 A` for Ctrl+Up), so the byte after `[` is a digit rather than
+/// the final letter and the sequence is left untouched.
+fn apply_cursor_key_mode(data: &[u8], application_mode: bool) -> Vec<u8> {
+    if !application_mode {
+        return data.to_vec();
+    }
+
+    let mut out = Vec::with_capacity(data.len());
+    let mut rest = data;
+    while let Some((&first, tail)) = rest.split_first() {
+        if first == 0x1b
+            && let [b'[', final_byte, remainder @ ..] = tail
+            && matches!(*final_byte, b'A' | b'B' | b'C' | b'D' | b'H' | b'F')
+        {
+            out.extend_from_slice(&[0x1b, b'O', *final_byte]);
+            rest = remainder;
+        } else {
+            out.push(first);
+            rest = tail;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::apply_cursor_key_mode;
+
+    #[test]
+    fn normal_mode_passes_cursor_keys_through() {
+        assert_eq!(apply_cursor_key_mode(b"\x1b[B", false), b"\x1b[B".to_vec());
+    }
+
+    #[test]
+    fn application_mode_rewrites_cursor_and_home_end_keys() {
+        assert_eq!(apply_cursor_key_mode(b"\x1b[A", true), b"\x1bOA".to_vec());
+        assert_eq!(apply_cursor_key_mode(b"\x1b[B", true), b"\x1bOB".to_vec());
+        assert_eq!(apply_cursor_key_mode(b"\x1b[C", true), b"\x1bOC".to_vec());
+        assert_eq!(apply_cursor_key_mode(b"\x1b[D", true), b"\x1bOD".to_vec());
+        assert_eq!(apply_cursor_key_mode(b"\x1b[H", true), b"\x1bOH".to_vec());
+        assert_eq!(apply_cursor_key_mode(b"\x1b[F", true), b"\x1bOF".to_vec());
+    }
+
+    #[test]
+    fn application_mode_leaves_text_and_modified_keys_untouched() {
+        assert_eq!(apply_cursor_key_mode(b"hello", true), b"hello".to_vec());
+        // Modified arrow (Ctrl+Up = ESC [ 1 ; 5 A) keeps its CSI form.
+        assert_eq!(
+            apply_cursor_key_mode(b"\x1b[1;5A", true),
+            b"\x1b[1;5A".to_vec()
+        );
+        // A cursor key surrounded by text is still rewritten in place.
+        assert_eq!(
+            apply_cursor_key_mode(b"a\x1b[Bb", true),
+            b"a\x1bOBb".to_vec()
+        );
+    }
 }

--- a/packages/tui/src/manager/spawn.rs
+++ b/packages/tui/src/manager/spawn.rs
@@ -77,6 +77,13 @@ pub(super) fn spawn_tui(
 
         let mut cmd = pty_process::Command::new(&command);
         cmd.args(&args);
+        // A PTY-backed emulator is only as useful as the TERM the child thinks
+        // it is driving. With no TERM the child inherits the host's, so curses
+        // and terminfo capabilities (e.g. `curs_set`) silently fail or differ
+        // by machine. ix-vt implements an xterm-256color superset, so advertise
+        // that plus truecolor for a consistent, capable default.
+        cmd.env("TERM", "xterm-256color");
+        cmd.env("COLORTERM", "truecolor");
 
         let child = cmd
             .spawn(&pty_slave)
@@ -91,13 +98,24 @@ pub(super) fn spawn_tui(
     // cursor shape on every render. The cache is read by the frame builder, so
     // it is shared like `size` rather than channelled.
     let cursor_shape = Arc::new(parking_lot::RwLock::new(CursorShape::default()));
-    let engine_tx = engine::spawn(id, rows, cols, scrollback_lines, Arc::clone(&cursor_shape))?;
+    // Whether the child has enabled DECCKM (application cursor keys). The engine
+    // refreshes it as it processes output; the actor reads it to pick the arrow
+    // form on write. Shared like `cursor_shape` rather than channelled.
+    let app_cursor_keys = Arc::new(parking_lot::RwLock::new(false));
+    let engine_tx = engine::spawn(
+        id,
+        rows,
+        cols,
+        scrollback_lines,
+        Arc::clone(&cursor_shape),
+        Arc::clone(&app_cursor_keys),
+    )?;
 
     // The actor owns the child: it reaps it (so short-lived commands leave no
     // zombie), publishes the exit code through `exit_tx`, and can signal it on
     // a kill request. It forwards bytes and reads to the engine thread.
     runtime.spawn(async move {
-        pty_actor(id, pty, child, command_rx, engine_tx, exit_tx).await;
+        pty_actor(id, pty, child, command_rx, engine_tx, exit_tx, app_cursor_keys).await;
     });
 
     let instance = TuiInstance {

--- a/packages/vt/ix-vt/src/lib.rs
+++ b/packages/vt/ix-vt/src/lib.rs
@@ -290,6 +290,12 @@ pub struct Terminal {
 // another thread owns it on a pinned thread behind a channel API rather than
 // moving the handle. Do not add an `unsafe impl Send`/`Sync`.
 
+/// DECCKM (DEC private mode 1, "cursor keys") in libghostty's packed mode
+/// encoding. The C header defines it as `ghostty_mode_new(1, ansi=false)`, i.e.
+/// `(value & 0x7FFF) | ((ansi as u16) << 15)`, which for value 1 / DEC-private
+/// is simply `1`. See `ghostty/vt/modes.h` (`GHOSTTY_MODE_DECCKM`).
+const DECCKM: sys::GhosttyMode = 1;
+
 impl Terminal {
     /// Create a terminal sized `rows` by `cols` with `scrollback` lines of
     /// history.
@@ -412,6 +418,26 @@ impl Terminal {
         let bar: sys::GhosttyTerminalScrollbar =
             unsafe { self.get(sys::GhosttyTerminalData::GHOSTTY_TERMINAL_DATA_SCROLLBAR) }?;
         Ok(bar.total.saturating_sub(bar.len))
+    }
+
+    /// Whether the program has enabled DECCKM (DEC private mode 1, "cursor
+    /// keys"). When set, the program (via terminfo `smkx`, as ncurses, vim, and
+    /// less do on entry) expects the cursor keys in application form
+    /// (`ESC O A`..`ESC O D`) instead of normal form (`ESC [ A`..`ESC [ D`), so
+    /// an input driver must emit the matching form or the program never sees the
+    /// arrow keys at all.
+    ///
+    /// # Errors
+    /// Returns [`Error::InvalidValue`] if ghostty rejects the mode query.
+    pub fn application_cursor_keys(&self) -> Result<bool> {
+        self.mode_enabled(DECCKM)
+    }
+
+    /// Read a DEC/ANSI mode's current state via `ghostty_terminal_mode_get`.
+    fn mode_enabled(&self, mode: sys::GhosttyMode) -> Result<bool> {
+        let mut out = false;
+        check(unsafe { sys::ghostty_terminal_mode_get(self.raw, mode, &raw mut out) })?;
+        Ok(out)
     }
 }
 

--- a/packages/vt/ix-vt/tests/round_trip.rs
+++ b/packages/vt/ix-vt/tests/round_trip.rs
@@ -74,3 +74,30 @@ fn resize_changes_viewport_dimensions() {
     assert_eq!((after.rows, after.cols), (12, 40), "viewport tracks resize");
     assert_eq!(after.viewport.len(), 12, "row count matches new height");
 }
+
+#[test]
+fn decckm_tracks_application_cursor_keys() {
+    let mut term = Terminal::new(24, 80, 0).expect("create terminal");
+    assert!(
+        !term
+            .application_cursor_keys()
+            .expect("query DECCKM at start"),
+        "cursor keys default to normal mode"
+    );
+
+    // ESC[?1h sets DECCKM (what ncurses/vim emit via `smkx` on entry).
+    term.vt_write(b"\x1b[?1h");
+    assert!(
+        term.application_cursor_keys().expect("query DECCKM after set"),
+        "ESC[?1h enables application cursor keys"
+    );
+
+    // ESC[?1l resets it (the `rmkx` on exit).
+    term.vt_write(b"\x1b[?1l");
+    assert!(
+        !term
+            .application_cursor_keys()
+            .expect("query DECCKM after reset"),
+        "ESC[?1l restores normal cursor keys"
+    );
+}


### PR DESCRIPTION
Four fixes to the `tui` PTY driver, all surfaced while driving a real curses TUI from a notebook.

**A. Readable `Snapshot` repr for agents (tui-py).** The frozen dataclass default repr expanded every `StyledCell`, so a full-screen `snapshot()` returned tens of KB of grid as `text/plain` (exactly what an agent/LLM reading the notebook cell gets). Now renders the viewport in a width-exact frame with a `size / scrollback / styled` header; the colored view stays on `_repr_html_` / `to_html`.

**B. Mode-aware cursor keys (DECCKM).** `Key.UP/DOWN/LEFT/RIGHT` were hardcoded to normal mode (`ESC [ A..D`), but ncurses/vim/less enable DECCKM via terminfo `smkx` and expect the application form (`ESC O A..D`), so arrows silently did nothing on the full-screen apps this driver exists to test. Fixed at the owner: `ix-vt` exposes `application_cursor_keys()` via `ghostty_terminal_mode_get`, the engine caches it per output chunk (the `cursor_shape` idiom), and the actor rewrites the cursor sequences on write, so every binding (py/node/rust) is fixed once. Home/End included; modified arrows (`ESC [ 1;5 A`) left untouched.

**C. `is_alive` consistency.** It was a method while `exit_code` is a property; made it a property to match the documented cached-accessor surface.

**D. Default TERM on spawn.** Spawn set no TERM, so curses apps inherited the host's and `curs_set()` could return ERR; default `TERM=xterm-256color` + `COLORTERM=truecolor`.

Tests: `ix-vt` round-trip asserts `ESC[?1h`/`ESC[?1l` flip `application_cursor_keys()`; actor unit tests cover the rewrite (on/off, Home/End, embedded, modified-arrow passthrough). Validated end-to-end live in a notebook (arrows now move a curses menu; snapshot output is readable).

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix TUI cursor key mode, Snapshot repr, and default TERM environment variable
> - Adds DECCKM tracking: the engine reads `application_cursor_keys` state after processing terminal output and stores it in a shared flag, so arrow/home/end keys written to the PTY are rewritten from CSI to SS3 form when application cursor mode is active.
> - Sets `TERM=xterm-256color` and `COLORTERM=truecolor` on spawned child processes in [`manager/spawn.rs`](https://github.com/indexable-inc/index/pull/663/files#diff-1f2ed13c3c0205b65fd020a0507058f66f1cbadab5e75273f81fda7afbd921af).
> - Adds `Snapshot.__repr__` in [`tui/__init__.py`](https://github.com/indexable-inc/index/pull/663/files#diff-a5eea6189d72f8bbbdcad9f6f1d921e1e109f73b0113c9cef8bdba0623d8d436) that renders a boxed, human-readable view of the terminal viewport instead of the default dataclass repr.
> - Converts `Tui.is_alive` from a method to a `@property`.
> - Risk: `Tui.is_alive()` called with parentheses will no longer work; callers must use `t.is_alive`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcc6eba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->