### PR TITLE
chore(tui): remove stray err.log, document write rewrite, cover edge cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ packages/dashboard-core/src/dashboard/dashboard.html
 # ix-mcp / jupyter-collaboration writes this YDoc store into the server cwd at runtime
 .jupyter_ystore.db
 *.ystore.db
+
+# Stray command logs (e.g. a `cmd 2>err.log` that got swept up by `git add -A`)
+*.log

--- a/packages/tui-py/python/tui/__init__.py
+++ b/packages/tui-py/python/tui/__init__.py
@@ -367,6 +367,10 @@ class Snapshot:
         width-exact frame so columns, trailing space, and the real size are
         unambiguous, and summarize the styling instead of expanding it. The
         colored view is still available via `_repr_html_` / `to_html`.
+
+        Width is counted in code points, not display columns, so a line with
+        wide (CJK/emoji) glyphs can push the right border out; this is a
+        cosmetic frame artifact in the plain-text view only.
         """
         rows, cols = self.size.rows, self.size.cols
         top = "┌" + "─" * cols + "┐"
@@ -588,7 +592,13 @@ class Tui:
     # -- writing ------------------------------------------------------------
 
     async def write(self, data: str) -> None:
-        """Send `data` to the PTY exactly."""
+        """Send `data` to the PTY.
+
+        Like a real terminal, while the program has DECCKM (application cursor
+        keys) enabled a bare cursor sequence (`ESC [ A`..`D`, `ESC [ H`/`F`) is
+        rewritten to its `ESC O ...` form so arrows reach full-screen programs;
+        every other byte passes through unchanged.
+        """
         await self._raw.write_async(data)
 
     async def send(self, *parts: str) -> None:

--- a/packages/tui/src/actor/mod.rs
+++ b/packages/tui/src/actor/mod.rs
@@ -290,4 +290,22 @@ mod tests {
             b"a\x1bOBb".to_vec()
         );
     }
+
+    #[test]
+    fn application_mode_preserves_sequence_truncated_at_end() {
+        // A buffer that ends mid-sequence has no final byte to match, so the
+        // partial bytes are emitted verbatim rather than dropped or panicking.
+        assert_eq!(apply_cursor_key_mode(b"\x1b", true), b"\x1b".to_vec());
+        assert_eq!(apply_cursor_key_mode(b"\x1b[", true), b"\x1b[".to_vec());
+        assert_eq!(apply_cursor_key_mode(b"x\x1b[", true), b"x\x1b[".to_vec());
+    }
+
+    #[test]
+    fn rewrite_is_per_call_not_across_writes() {
+        // Each write is rewritten independently: an arrow split across two
+        // calls is not reassembled, so neither half is altered. Callers that
+        // need a cursor key send it as one chunk.
+        assert_eq!(apply_cursor_key_mode(b"\x1b[", true), b"\x1b[".to_vec());
+        assert_eq!(apply_cursor_key_mode(b"B", true), b"B".to_vec());
+    }
 }

--- a/packages/tui/src/manager/mod.rs
+++ b/packages/tui/src/manager/mod.rs
@@ -95,7 +95,14 @@ impl TuiInstance {
         Ok(())
     }
 
-    /// Send `data` to the PTY exactly as given.
+    /// Send `data` to the PTY.
+    ///
+    /// One transformation is applied, matching what a real terminal does: while
+    /// the program has DECCKM (application cursor keys) enabled, a bare cursor
+    /// CSI (`ESC [ A`..`D`, `ESC [ H`/`ESC [ F`) is rewritten to its SS3 form
+    /// (`ESC O ...`), so arrows reach full-screen programs regardless of whether
+    /// the caller used [`write`](Self::write) or a key helper. All other bytes,
+    /// including modified arrows that carry parameters, pass through unchanged.
     pub fn write(&self, data: &str) -> Result<()> {
         self.runtime.block_on(reader::write(
             self.id,


### PR DESCRIPTION
Follow-ups from the #663 review (code-reviewer pass):

- Remove `err.log`, an empty file a bulk stage accidentally swept into #663; ignore `*.log` so a stray `2>err.log` redirect can't recur.
- Document that `write` (Rust `TuiInstance::write` and tui-py `Tui.write`) rewrites bare cursor CSIs to SS3 form under DECCKM, reconciling the old "send exactly" wording with the behavior added in #663.
- Add actor tests for a sequence truncated at the buffer end (no panic, bytes preserved) and for the per-call (not cross-write) nature of the rewrite.
- Note in the `Snapshot.__repr__` docstring that the plain-text frame counts code points, so wide (CJK/emoji) glyphs can ragged-edge it (cosmetic; the colored view is exact).

No behavior change beyond the doc/test/ignore additions; the #663 fixes were already validated live.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add edge case tests and documentation for DECCKM cursor key rewrite in TUI
> - Adds two new tests in [packages/tui/src/actor/mod.rs](https://github.com/indexable-inc/index/pull/664/files#diff-194bb9ad7bf0fbab5de0be1e3d966ed228a4a2a550136ce36f24bc44ff9809b5): one verifies `apply_cursor_key_mode` returns input unchanged when the buffer ends mid-escape-sequence, and one confirms rewriting is per-call and does not span separate writes.
> - Expands docstrings in [packages/tui-py/python/tui/__init__.py](https://github.com/indexable-inc/index/pull/664/files#diff-a5eea6189d72f8bbbdcad9f6f1d921e1e109f73b0113c9cef8bdba0623d8d436) and [packages/tui/src/manager/mod.rs](https://github.com/indexable-inc/index/pull/664/files#diff-1b6c336ac4df7d4702b056e7f4622d27190f6402ef65b30fa477f117ae0bb969) to document that DECCKM rewrites bare CSI arrow/home/end sequences to SS3 form, while modified arrows with parameters pass through unchanged.
> - Removes a stray [err.log](https://github.com/indexable-inc/index/pull/664/files#diff-80d9c096c6008bcb90b6b7052b93aff2ac6e1b040b25acc2cfbf3044f0774eb5) file and adds `*.log` to [.gitignore](https://github.com/indexable-inc/index/pull/664/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec66c9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->