### PR TITLE
feat(mcp): dark Islands theme + Python highlighting + Berkeley Mono by default

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -90,11 +90,97 @@ let
       ''
   );
 
+  # JupyterLab custom CSS, generated from the shared JetBrains Islands palette
+  # (`ix.islandsTheme`, the same JSON the search `-c` highlighter and the Neovim
+  # colorscheme read) so there is one source of truth for color. It maps the
+  # palette slots onto JupyterLab's `--jp-*` UI variables and its
+  # `--jp-mirror-editor-*-color` CodeMirror syntax variables, and switches the
+  # code font to Berkeley Mono. Both theme variants are emitted and gated on the
+  # body's `data-jp-theme-light` attribute, so syntax color tracks whichever
+  # theme is active; dark is the shipped default (see jupyter/overrides.json).
+  # The variant selector (body + attribute + class) outranks the theme's own
+  # `:root` declarations on specificity, so these win without `!important`.
+  islandsVars = t: ''
+    --jp-layout-color0: ${t.bg};
+    --jp-layout-color1: ${t.bg};
+    --jp-layout-color2: ${t.line_hl};
+    --jp-layout-color3: ${t.ui_subtle_bg};
+    --jp-layout-color4: ${t.ui_input_bg};
+    --jp-border-color0: ${t.ui_subtle_bg};
+    --jp-border-color1: ${t.indent_guide};
+    --jp-border-color2: ${t.line_hl};
+    --jp-border-color3: ${t.bg};
+    --jp-ui-font-color0: ${t.fg};
+    --jp-ui-font-color1: ${t.fg};
+    --jp-ui-font-color2: ${t.ui_dim};
+    --jp-ui-font-color3: ${t.whitespace};
+    --jp-content-font-color0: ${t.fg};
+    --jp-content-font-color1: ${t.fg};
+    --jp-content-font-color2: ${t.ui_dim};
+    --jp-content-font-color3: ${t.comment};
+    --jp-brand-color0: ${t.ui_border};
+    --jp-brand-color1: ${t.ui_border};
+    --jp-brand-color2: ${t.info};
+    --jp-brand-color3: ${t.info};
+    --jp-accent-color1: ${t.func};
+    --jp-cell-editor-background: ${t.bg};
+    --jp-cell-editor-border-color: ${t.indent_guide};
+    --jp-editor-selected-background: ${t.selection};
+    --jp-editor-selected-focused-background: ${t.selection};
+    --jp-editor-cursor-color: ${t.cursor};
+    --jp-error-color1: ${t.error};
+    --jp-warn-color1: ${t.warning};
+    --jp-success-color1: ${t.git_add};
+    --jp-info-color1: ${t.info};
+    --jp-mirror-editor-keyword-color: ${t.keyword};
+    --jp-mirror-editor-atom-color: ${t.constant};
+    --jp-mirror-editor-number-color: ${t.number};
+    --jp-mirror-editor-def-color: ${t.func};
+    --jp-mirror-editor-variable-color: ${t.variable};
+    --jp-mirror-editor-variable-2-color: ${t.variable};
+    --jp-mirror-editor-variable-3-color: ${t.type};
+    --jp-mirror-editor-punctuation-color: ${t.punctuation};
+    --jp-mirror-editor-property-color: ${t.property};
+    --jp-mirror-editor-operator-color: ${t.operator};
+    --jp-mirror-editor-comment-color: ${t.comment};
+    --jp-mirror-editor-string-color: ${t.string};
+    --jp-mirror-editor-string-2-color: ${t.string};
+    --jp-mirror-editor-meta-color: ${t.decorator};
+    --jp-mirror-editor-qualifier-color: ${t.property};
+    --jp-mirror-editor-builtin-color: ${t.func};
+    --jp-mirror-editor-bracket-color: ${t.punctuation};
+    --jp-mirror-editor-tag-color: ${t.tag};
+    --jp-mirror-editor-attribute-color: ${t.attribute};
+    --jp-mirror-editor-header-color: ${t.heading};
+    --jp-mirror-editor-quote-color: ${t.string};
+    --jp-mirror-editor-link-color: ${t.link};
+    --jp-mirror-editor-error-color: ${t.error};
+    --jp-mirror-editor-hr-color: ${t.line_nr};
+  '';
+  islandsCss = pkgs.writeText "ix-mcp-islands.css" ''
+    /* GENERATED from packages/code-highlight/src/islands-theme.json by
+       packages/mcp/default.nix. Do not edit by hand; edit the palette JSON.
+       JetBrains Islands -> JupyterLab UI + Python syntax, plus Berkeley Mono. */
+    .jp-ThemedContainer {
+      --jp-code-font-family: 'Berkeley Mono', 'JetBrains Mono', ui-monospace,
+        SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+      --jp-code-font-size: 13px;
+      --jp-code-line-height: 1.55;
+    }
+    body[data-jp-theme-light="false"].jp-ThemedContainer {
+      ${islandsVars ix.islandsTheme.dark}}
+    body[data-jp-theme-light="true"].jp-ThemedContainer {
+      ${islandsVars ix.islandsTheme.light}}
+  '';
+
   # The notebook-first MCP server itself, a pure-Python package installed into
   # the pinned interpreter so the `ix-mcp` entrypoint, the Jupyter Server
   # extension, and the kernels all share one environment (that co-location is
   # what makes real-time co-editing work). No build step: it is plain Python that
   # imports the Jupyter stack and bundled modules already in this interpreter.
+  # The generated Islands CSS is dropped next to the package's static jupyter/
+  # assets (overrides.json), where the CLI materializes them into a writable lab
+  # config dir at serve time.
   ixNotebookMcpSource = builtins.path {
     name = "ix-notebook-mcp-source";
     path = ./ix_notebook_mcp;
@@ -109,6 +195,10 @@ let
         site="$out/${pkgs.python3.sitePackages}/ix_notebook_mcp"
         mkdir -p "$site"
         cp -r ${ixNotebookMcpSource}/. "$site/"
+        # Source comes from the store read-only; make the tree writable so the
+        # generated CSS can be dropped alongside the static jupyter/ assets.
+        chmod -R u+w "$site"
+        install -Dm444 ${islandsCss} "$site/jupyter/islands.css"
       ''
   );
 

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -210,12 +210,16 @@ def _serve(args: argparse.Namespace) -> int:
     # co-edit browser opens dark, Islands-colored, and in Berkeley Mono with no
     # per-user setup. Isolated under the runtime dir, not the user's ~/.jupyter.
     lab_config_dir, has_custom_css = _prepare_lab_config(cfg.jupyter_port)
-    # The custom-CSS handler serves from `{config_dir}/custom`, and config_dir is
-    # derived from JUPYTER_CONFIG_DIR. Setting it via the env var reliably moves
-    # static_custom_path; the equivalent `--ServerApp.config_dir` flag does not
-    # (static_custom_path resolves before that config applies, so the link 404s).
-    if has_custom_css:
-        os.environ["JUPYTER_CONFIG_DIR"] = str(lab_config_dir)
+    # Run with this as the Jupyter config dir. This is deliberate isolation: the
+    # co-edit server defines everything it needs through the flags below, so it
+    # should not inherit (or be broken by) the user's ~/.jupyter server config,
+    # and it keeps behavior reproducible across machines. It is also the only way
+    # to relocate where custom CSS is served from ({config_dir}/custom): the
+    # `static_custom_path` is derived from config_dir and is not itself settable,
+    # and `--ServerApp.config_dir` is applied too late to move it. Set
+    # unconditionally so the config surface does not change based on whether the
+    # generated CSS happens to be present.
+    os.environ["JUPYTER_CONFIG_DIR"] = str(lab_config_dir)
 
     from jupyter_server.serverapp import ServerApp
 
@@ -228,10 +232,13 @@ def _serve(args: argparse.Namespace) -> int:
             f"--IdentityProvider.token={cfg.token}",
             "--ServerApp.log_level=WARN",
             # app_settings_dir holds overrides.json (default dark theme + editor
-            # settings); custom CSS is served from {config_dir}/custom, with
-            # config_dir set via JUPYTER_CONFIG_DIR above.
+            # settings); custom CSS is served from {config_dir}/custom.
             f"--LabApp.app_settings_dir={lab_config_dir / 'lab-settings'}",
-            *(["--LabApp.custom_css=True"] if has_custom_css else []),
+            *(
+                ["--LabApp.custom_css=True"]
+                if has_custom_css
+                else []
+            ),
             # In-process extensions: ours (MCP + YDoc bridge) and jupyter_server_ydoc
             # (the server side of real-time collaboration). The browser
             # collaboration UI loads from the installed jupyter-collaboration lab

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -64,6 +64,39 @@ def main(argv: list[str] | None = None) -> int:
     return 2
 
 
+def _prepare_lab_config(jupyter_port: int) -> tuple[Path, bool]:
+    """Materialize a writable JupyterLab config dir from the shipped assets so a
+    fresh browser opens dark, Islands-colored, and in Berkeley Mono with no
+    per-user setup.
+
+    Returns ``(config_dir, has_custom_css)``. JupyterLab reads its custom CSS from
+    ``{config_dir}/custom/custom.css`` and its default-settings overrides from
+    the app settings dir; we point both at this per-server dir under the runtime
+    dir, isolated from the user's ``~/.jupyter``. The assets are *copied* (not
+    symlinked): Tornado's static handler refuses to follow a symlink that escapes
+    its root into the Nix store, so a symlinked ``custom.css`` would 403.
+    """
+    assets = Path(__file__).resolve().parent / "jupyter"
+    base = runtime_dir() / f"lab-{jupyter_port}"
+    custom = base / "custom"
+    settings = base / "lab-settings"
+    custom.mkdir(parents=True, exist_ok=True)
+    settings.mkdir(parents=True, exist_ok=True)
+
+    overrides = assets / "overrides.json"
+    if overrides.exists():
+        shutil.copyfile(overrides, settings / "overrides.json")
+
+    # islands.css is generated at build time (packages/mcp/default.nix); when
+    # running straight from a source checkout it is absent, so custom CSS is
+    # simply skipped rather than serving a 404 link.
+    css = assets / "islands.css"
+    has_css = css.exists()
+    if has_css:
+        shutil.copyfile(css, custom / "custom.css")
+    return base, has_css
+
+
 def _free_port() -> int:
     # Just reserves a free port number; the kernel gives port 0 an unused port.
     # The interface here is irrelevant: a number free on loopback is free for the
@@ -173,6 +206,17 @@ def _serve(args: argparse.Namespace) -> int:
     )
     set_config(cfg)
 
+    # A writable lab config dir (custom CSS + default-settings overrides) so the
+    # co-edit browser opens dark, Islands-colored, and in Berkeley Mono with no
+    # per-user setup. Isolated under the runtime dir, not the user's ~/.jupyter.
+    lab_config_dir, has_custom_css = _prepare_lab_config(cfg.jupyter_port)
+    # The custom-CSS handler serves from `{config_dir}/custom`, and config_dir is
+    # derived from JUPYTER_CONFIG_DIR. Setting it via the env var reliably moves
+    # static_custom_path; the equivalent `--ServerApp.config_dir` flag does not
+    # (static_custom_path resolves before that config applies, so the link 404s).
+    if has_custom_css:
+        os.environ["JUPYTER_CONFIG_DIR"] = str(lab_config_dir)
+
     from jupyter_server.serverapp import ServerApp
 
     ServerApp.launch_instance(
@@ -183,6 +227,11 @@ def _serve(args: argparse.Namespace) -> int:
             "--ServerApp.open_browser=False",
             f"--IdentityProvider.token={cfg.token}",
             "--ServerApp.log_level=WARN",
+            # app_settings_dir holds overrides.json (default dark theme + editor
+            # settings); custom CSS is served from {config_dir}/custom, with
+            # config_dir set via JUPYTER_CONFIG_DIR above.
+            f"--LabApp.app_settings_dir={lab_config_dir / 'lab-settings'}",
+            *(["--LabApp.custom_css=True"] if has_custom_css else []),
             # In-process extensions: ours (MCP + YDoc bridge) and jupyter_server_ydoc
             # (the server side of real-time collaboration). The browser
             # collaboration UI loads from the installed jupyter-collaboration lab

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import secrets
+import stat
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -90,9 +91,27 @@ def config() -> Config:
 
 
 def runtime_dir() -> Path:
-    """A writable directory for the lab-url handoff file, so ``ix-mcp lab`` (a
-    separate process) can find a running server's URL."""
+    """A private writable directory for the lab-url handoff file and the
+    materialized JupyterLab config (custom CSS + settings) served to the
+    authenticated browser.
+
+    Hardened against an untrusted base: when neither ``XDG_RUNTIME_DIR`` nor
+    ``TMPDIR`` is set (e.g. a headless service) the base is the world-writable
+    sticky ``/tmp``, where another local user could pre-create ``ix-mcp`` and drop
+    files we would then serve into the session (CWE-377). So create it ``0700`` and
+    fail closed if a pre-existing one is a symlink, not ours, or group/other
+    accessible, rather than silently reusing it.
+    """
     base = os.environ.get("XDG_RUNTIME_DIR") or os.environ.get("TMPDIR") or "/tmp"
     path = Path(base) / "ix-mcp"
-    path.mkdir(parents=True, exist_ok=True)
+    # mode is masked by umask on create and ignored when the dir already exists,
+    # so perms are re-asserted (and ownership checked) below regardless.
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    info = path.lstat()
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        raise RuntimeError(f"runtime dir {path} is not a real directory")
+    if info.st_uid != os.getuid():
+        raise RuntimeError(f"runtime dir {path} is not owned by the current user")
+    if info.st_mode & 0o077:
+        path.chmod(0o700)
     return path

--- a/packages/mcp/ix_notebook_mcp/jupyter/overrides.json
+++ b/packages/mcp/ix_notebook_mcp/jupyter/overrides.json
@@ -1,0 +1,12 @@
+{
+  "@jupyterlab/apputils-extension:themes": {
+    "theme": "JupyterLab Dark"
+  },
+  "@jupyterlab/codemirror-extension:plugin": {
+    "defaultConfig": {
+      "highlightActiveLine": true,
+      "highlightWhitespace": false,
+      "highlightTrailingWhitespace": true
+    }
+  }
+}


### PR DESCRIPTION
Make the co-edit JupyterLab open thoughtfully styled with zero per-user setup: dark by default, JetBrains Islands palette for Python syntax, Berkeley Mono code font.

- `islands.css` generated from `code-highlight/src/islands-theme.json` (`ix.islandsTheme`), the same source the nvim colorscheme and search highlighter use. Maps the palette onto `--jp-*` and `--jp-mirror-editor-*-color`; both theme variants emitted, gated on `data-jp-theme-light` so highlighting follows the active theme.
- `overrides.json` sets dark as the default; serve time materializes a writable lab config dir (custom CSS via `JUPYTER_CONFIG_DIR`, defaults via `--LabApp.app_settings_dir`), isolated from `~/.jupyter`.

Validated in a real browser (Playwright): `JupyterLab Dark`, `'Berkeley Mono'`, bg `#191A1C`, keyword `#CF8E6D`, strings/numbers per palette.

Made with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dark Islands theme, Berkeley Mono font, and isolated JupyterLab config to ix-notebook-mcp
> - Generates a `jupyter/islands.css` asset at build time in [default.nix](https://github.com/indexable-inc/index/pull/665/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) that applies the Islands dark/light theme palette as JupyterLab CSS variables and sets Berkeley Mono as the default code font.
> - Adds [overrides.json](https://github.com/indexable-inc/index/pull/665/files#diff-d0a778f0dd813df6c11f8eb18c767a3dba231b64c442d224cbd4a4fd0795bf8e) to default JupyterLab to the Dark theme and configure CodeMirror editor settings (active line highlight, trailing whitespace highlight).
> - Each server instance now builds an isolated `JUPYTER_CONFIG_DIR` under the runtime dir via `_prepare_lab_config` in [cli.py](https://github.com/indexable-inc/index/pull/665/files#diff-7ce741e8223d63fdea11625cb78abad266299445db0213d2355bc93306df9ac5), copying packaged assets to avoid reliance on `~/.jupyter`.
> - Hardens `runtime_dir` in [config.py](https://github.com/indexable-inc/index/pull/665/files#diff-33f6f17aed79724ba72211bc8bf9dc1da1bbdb38de56be7ace76cc09837929ca) to enforce mode 0700, verify ownership, and raise `RuntimeError` on unsafe paths (symlinks, wrong owner, non-directory).
> - Behavioral Change: server startup now creates and sets `JUPYTER_CONFIG_DIR` per instance, overriding any user-level Jupyter config that was previously inherited.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0b8d97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->