### PR TITLE
tui-py: accept size=(rows, cols) on Tui(...)

### DIFF
--- a/packages/tui-py/python/tui/__init__.py
+++ b/packages/tui-py/python/tui/__init__.py
@@ -517,7 +517,9 @@ class Tui:
             snap = await tui.wait_for("3", timeout=2.0)
 
     The terminal opens at `rows` x `cols` (default 80x24) with `scrollback_lines`
-    of history (default 10,000). A single process-wide tokio runtime drives every
+    of history (default 10,000). Pass the shape as `size=(rows, cols)` (the same
+    spelling the `.size` accessor returns) or as granular `rows=`/`cols=`, but not
+    both. A single process-wide tokio runtime drives every
     spawned PTY; each I/O method returns a native asyncio coroutine bridged
     through pyo3-async-runtimes, with no thread-pool hop. Construction and the
     shape accessors (`id`, `command`, `args`, `size`, `is_alive`, `exit_code`)
@@ -539,10 +541,20 @@ class Tui:
         self,
         command: str,
         *args: str,
+        size: tuple[int, int] | Size | None = None,
         rows: int | None = None,
         cols: int | None = None,
         scrollback_lines: int | None = None,
     ) -> None:
+        # `size=(rows, cols)` mirrors the `.size` accessor (a `Size` is also a
+        # (rows, cols) iterable), so the shape can be read and set with the same
+        # spelling; `rows=`/`cols=` stay as the granular form. Accept one or the
+        # other, not both, so a conflicting pair is an error rather than a silent
+        # winner.
+        if size is not None:
+            if rows is not None or cols is not None:
+                raise TypeError("pass either size=(rows, cols) or rows=/cols=, not both")
+            rows, cols = size
         _ensure_autopublish()
         self._raw = _RawTuiInstance(command, list(args), rows, cols, scrollback_lines)
 


### PR DESCRIPTION
`Tui.size` returns a `(rows, cols)` `Size`, but the constructor only took granular `rows=`/`cols=`, so the natural `Tui(cmd, size=(r, c))` raised `TypeError` first try.

Accept `size=` as a keyword-only shorthand that unpacks to `rows`/`cols` (a `Size` is itself a `(rows, cols)` iterable, so read and set share one spelling). Passing both `size=` and `rows=`/`cols=` raises `TypeError` rather than silently picking one.

Validated against the built module: `size=(8,30)` -> rows 8/cols 30, `rows=/cols=` unchanged, conflict raises.

Made with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept `size=(rows, cols)` parameter in `Tui.__init__` constructor
> Adds a `size` keyword-only parameter to [`Tui.__init__`](https://github.com/indexable-inc/index/pull/666/files#diff-a5eea6189d72f8bbbdcad9f6f1d921e1e109f73b0113c9cef8bdba0623d8d436) that accepts a `(rows, cols)` tuple or `Size` iterable. When provided, `rows` and `cols` are derived by unpacking `size`. Raises `TypeError` if `size` is combined with `rows` or `cols`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4540b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->