### PR TITLE
fix(agent-context): materialize skill farm so / autocomplete discovers skills

### DIFF
--- a/.claude/hooks/agent-instructions.sh
+++ b/.claude/hooks/agent-instructions.sh
@@ -6,9 +6,8 @@
 # into the `claude-md` / `codex-md` flake packages, and the `disclosure:
 # progressive` fragments become on-demand skills in the `skills` flake package
 # alongside the handwritten skills/. This hook builds those packages, prints the
-# always-on core as `additionalContext`, and materializes `.claude/skills`
-# (Claude Code) / `.agents/skills` (Codex) as a real tree copied from the
-# generated skill link farm.
+# always-on core as `additionalContext`, and copies the skills package into
+# `.claude/skills` (Claude Code) / `.agents/skills` (Codex).
 #
 # Output is the SessionStart hook JSON envelope. Codex requires a JSON object
 # with hookSpecificOutput.additionalContext (its parser rejects plain stdout);
@@ -40,11 +39,14 @@ fi
 
 doc=$(nix build --no-link --print-out-paths "$root#$package")
 
-# Materialize the link farm onto disk; Claude Code's `/`-autocomplete
-# discovery filters symlinks (anthropics/claude-code#36659), so the tree
-# must be real files even though the skill *loader* follows symlinks fine.
+# Copy the skills package onto disk. The package is symlink-free by build-time
+# assertion (see lib/agent-context/skills.nix), but the destination directory
+# itself must also be real rather than a symlink to the store: Claude Code's
+# `/`-autocomplete discovery filters symlinks (anthropics/claude-code#36659)
+# even though the skill *loader* follows them fine. chmod because cp preserves
+# the store's read-only mode and the next session's rm -rf must succeed.
 # Best-effort: a skills-build failure must not abort the session, so guard
-# the build and skip the materialization if it produces no path.
+# the build and skip the copy if it produces no path.
 skills_store=$(nix build --no-link --print-out-paths "$root#skills" 2>/dev/null || true)
 if [ -n "$skills_store" ]; then
   case "$package" in
@@ -53,10 +55,7 @@ if [ -n "$skills_store" ]; then
   esac
   rm -rf "$dest"
   mkdir -p "$dest"
-  for skill in "$skills_store"/*; do
-    [ -e "$skill" ] || continue
-    cp -RH "$skill" "$dest"/
-  done
+  cp -R "$skills_store"/. "$dest"/
   chmod -R u+w "$dest"
 fi
 

--- a/.claude/hooks/agent-instructions.sh
+++ b/.claude/hooks/agent-instructions.sh
@@ -53,7 +53,10 @@ if [ -n "$skills_store" ]; then
   esac
   rm -rf "$dest"
   mkdir -p "$dest"
-  cp -RL "$skills_store"/. "$dest"/
+  for skill in "$skills_store"/*; do
+    [ -e "$skill" ] || continue
+    cp -RH "$skill" "$dest"/
+  done
   chmod -R u+w "$dest"
 fi
 

--- a/.claude/hooks/agent-instructions.sh
+++ b/.claude/hooks/agent-instructions.sh
@@ -6,8 +6,9 @@
 # into the `claude-md` / `codex-md` flake packages, and the `disclosure:
 # progressive` fragments become on-demand skills in the `skills` flake package
 # alongside the handwritten skills/. This hook builds those packages, prints the
-# always-on core as `additionalContext`, and repoints `.claude/skills` (Claude
-# Code) / `.agents/skills` (Codex) at the generated skill link farm.
+# always-on core as `additionalContext`, and materializes `.claude/skills`
+# (Claude Code) / `.agents/skills` (Codex) as a real tree copied from the
+# generated skill link farm.
 #
 # Output is the SessionStart hook JSON envelope. Codex requires a JSON object
 # with hookSpecificOutput.additionalContext (its parser rejects plain stdout);
@@ -39,21 +40,21 @@ fi
 
 doc=$(nix build --no-link --print-out-paths "$root#$package")
 
-# Repoint skills at the generated link farm. Claude Code reads `.claude/skills`,
-# Codex reads `.agents/skills`. Best-effort: a skills-build failure must not
-# abort the session, so guard the build and skip the repoint if it produces no
-# path.
+# Materialize the link farm onto disk; Claude Code's `/`-autocomplete
+# discovery filters symlinks (anthropics/claude-code#36659), so the tree
+# must be real files even though the skill *loader* follows symlinks fine.
+# Best-effort: a skills-build failure must not abort the session, so guard
+# the build and skip the materialization if it produces no path.
 skills_store=$(nix build --no-link --print-out-paths "$root#skills" 2>/dev/null || true)
 if [ -n "$skills_store" ]; then
   case "$package" in
-  codex-md)
-    mkdir -p "$root/.agents"
-    ln -sfn "$skills_store" "$root/.agents/skills"
-    ;;
-  *)
-    ln -sfn "$skills_store" "$root/.claude/skills"
-    ;;
+  codex-md) dest="$root/.agents/skills" ;;
+  *)        dest="$root/.claude/skills" ;;
   esac
+  rm -rf "$dest"
+  mkdir -p "$dest"
+  cp -RL "$skills_store"/. "$dest"/
+  chmod -R u+w "$dest"
 fi
 
 # Codex: emit the document as one value, no reloadSkills field its parser might
@@ -64,7 +65,7 @@ if [ "$package" = codex-md ]; then
   exit 0
 fi
 
-# Claude Code: emit the core plus reloadSkills so the freshly repointed
+# Claude Code: emit the core plus reloadSkills so the freshly materialized
 # .claude/skills is picked up this session.
 jaq -n --rawfile additionalContext "$doc" \
   '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $additionalContext, reloadSkills: true}}'

--- a/agent-context/README.md
+++ b/agent-context/README.md
@@ -4,11 +4,11 @@ This directory owns the agent instructions and skills delivered to a coding
 agent at session start. There are no committed `AGENTS.md` / `CLAUDE.md` files:
 the content is rendered live by the `agent-instructions.sh` SessionStart hook
 (`.claude/hooks/`), which builds the flake packages below and prints the
-always-on core as `additionalContext` while materializing `.claude/skills` as a
-real tree copied from the generated skill link farm (the copy is required
-because Claude Code's `/`-autocomplete discovery filters symlinks). Editing a
-fragment changes what the next session sees, with nothing to regenerate or
-commit.
+always-on core as `additionalContext` while copying the generated skills
+package into `.claude/skills` (the package is built symlink-free and copied
+rather than symlinked because Claude Code's `/`-autocomplete discovery filters
+symlinks). Editing a fragment changes what the next session sees, with nothing
+to regenerate or commit.
 
 ## Disclosure tiers
 

--- a/agent-context/README.md
+++ b/agent-context/README.md
@@ -4,9 +4,11 @@ This directory owns the agent instructions and skills delivered to a coding
 agent at session start. There are no committed `AGENTS.md` / `CLAUDE.md` files:
 the content is rendered live by the `agent-instructions.sh` SessionStart hook
 (`.claude/hooks/`), which builds the flake packages below and prints the
-always-on core as `additionalContext` while repointing `.claude/skills` at the
-generated skill link farm. Editing a fragment changes what the next session
-sees, with nothing to regenerate or commit.
+always-on core as `additionalContext` while materializing `.claude/skills` as a
+real tree copied from the generated skill link farm (the copy is required
+because Claude Code's `/`-autocomplete discovery filters symlinks). Editing a
+fragment changes what the next session sees, with nothing to regenerate or
+commit.
 
 ## Disclosure tiers
 

--- a/lib/agent-context/default.nix
+++ b/lib/agent-context/default.nix
@@ -158,7 +158,7 @@ in
     Returns an attrset from skill name to a derivation whose output is a
     directory containing `SKILL.md`. Pass it as `extraSkills` to
     `skills.mkSkillsDir` to merge generated section-skills with the handwritten
-    ones under a single `.claude/skills` link farm.
+    ones under a single `.claude/skills` directory.
 
     Arguments:
     - `pkgs`: the package set used to write the skill files.

--- a/lib/agent-context/skills.nix
+++ b/lib/agent-context/skills.nix
@@ -36,17 +36,33 @@ let
     }:
     let
       unknownNames = lib.subtractLists allSkills names;
+      farm = pkgs.linkFarm "claude-skills-farm" (
+        (map (name: {
+          inherit name;
+          path = sources.${name};
+        }) names)
+        ++ (lib.mapAttrsToList (name: path: { inherit name path; }) extraSkills)
+      );
     in
     assert lib.assertMsg (
       unknownNames == [ ]
     ) "skills.mkSkillsDir contains unknown skills: ${lib.concatStringsSep ", " unknownNames}";
-    pkgs.linkFarm "claude-skills" (
-      (map (name: {
-        inherit name;
-        path = sources.${name};
-      }) names)
-      ++ (lib.mapAttrsToList (name: path: { inherit name path; }) extraSkills)
-    );
+    # Claude Code's `/`-autocomplete discovery filters directory entries with
+    # `Dirent.isFile()` and silently drops symlinks (anthropics/claude-code
+    # issues #36659, #55791), so the published tree must be real directories of
+    # real files. Dereference the link farm here in the sandbox, where every
+    # symlink target is a store path, instead of asking each consumer to do it
+    # on the host, and pin the no-symlink invariant so a future skill that
+    # ships a symlink fails this build rather than vanishing from the menu.
+    pkgs.runCommand "claude-skills" { } ''
+      cp -RL ${farm} "$out"
+      links=$(find "$out" -type l)
+      if [ -n "$links" ]; then
+        echo "claude-skills: symlinks survived materialization:" >&2
+        echo "$links" >&2
+        exit 1
+      fi
+    '';
 in
 {
   /**
@@ -79,14 +95,17 @@ in
     Build a single directory of selected skills for `.claude/skills`.
 
     Arguments:
-    - `pkgs`: the package set used to build the link farm.
+    - `pkgs`: the package set used to build the skills directory.
     - `names`: skill names to include. Defaults to every discovered skill.
     - `extraSkills`: attrset from name to path for consumer-local skills
       that live outside this repository.
 
-    Returns a `linkFarm` whose output directory holds one entry per skill
-    (`<name>` -> skill directory), suitable for symlinking into a
-    repository's `.claude/skills`. Unknown names in `names` are rejected.
+    Returns a directory holding one entry per skill (`<name>/` containing
+    `SKILL.md`), built as real directories of real files with no symlinks:
+    Claude Code's `/`-autocomplete discovery drops symlinked entries
+    (anthropics/claude-code#36659), so deliver this by copying it into a
+    repository's `.claude/skills` rather than symlinking the store path.
+    Unknown names in `names` are rejected.
   */
   inherit mkSkillsDir;
 }

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -226,8 +226,9 @@ let
   agentContextClaudeMd = pkgs.writeText "CLAUDE.md" ix.agentContext.alwaysDoc;
   agentContextCodexMd = pkgs.writeText "AGENTS.md" ix.agentContext.alwaysDoc;
 
-  # One link farm holding every handwritten skill plus one generated skill per
-  # `disclosure: progressive` section, ready to symlink into `.claude/skills`.
+  # One symlink-free directory holding every handwritten skill plus one
+  # generated skill per `disclosure: progressive` section, ready to copy into
+  # `.claude/skills`.
   agentContextProgressiveSkills = ix.agentContext.mkProgressiveSkills { inherit pkgs; };
   agentContextSkillCollisions = lib.intersectLists ix.skills.allSkills (
     lib.attrNames agentContextProgressiveSkills
@@ -583,7 +584,8 @@ let
           # Instruction files are not committed; they are rendered live by the
           # SessionStart hook. This gate forces the rendered always-on documents
           # (which evaluates the always-on char cap assertion) and the combined
-          # skills link farm (which evaluates the name-collision assertion) to build.
+          # skills directory (which evaluates the name-collision assertion and
+          # the no-symlink materialization check) to build.
           agent-context = pkgs.runCommand "agent-context-check" { } ''
             test -s ${agentContextClaudeMd}
             test -s ${agentContextCodexMd}


### PR DESCRIPTION
## Summary

`packages.skills` is delivered to `.claude/skills` / `.agents/skills` via `ln -sfn` of the Nix `linkFarm` store path. The skill loader follows symlinks (so the Skill tool works), but Claude Code's `/`-autocomplete discovery filters with `Dirent.isFile()` (anthropics/claude-code#36659, #55791) and silently drops every symlinked entry, so generated progressive-section skills (`/rust-style`, `/workflow`, `/nix-style`, ...) never appear in the `/` menu.

Fix it at the owner: `mkSkillsDir` (lib/agent-context/skills.nix) now materializes the link farm inside the Nix sandbox (`cp -RL` of the farm, where every symlink target is a store path) and asserts the output contains zero symlinks, so the published `skills` package is real directories of real files by construction. The SessionStart hook's delivery step becomes a plain `rm -rf` + `cp -R` + `chmod -R u+w` of that store path into `.claude/skills` (Claude Code) / `.agents/skills` (Codex). Nix stays the single source of truth; build-time collision and always-cap asserts are unchanged.

Closes #478

## Why this shape

- Materializing in the sandbox removes the security concern the AI review raised against host-side `cp -RL`/`cp -RH`: a symlink committed inside a skill can no longer pull arbitrary host files into `.claude/skills`. Inside the sandbox it either resolves to deterministic store content or fails the build naming the offending path.
- The no-symlink invariant is checked where it is produced (`find "$out" -type l` in the derivation), so a future skill that ships a symlink fails `nix build` / the `agent-context` flake check instead of silently vanishing from the `/` menu.
- Every consumer of `mkSkillsDir` gets the symlink-free tree; none of them re-implements dereferencing at delivery time.
- `chmod -R u+w` in the hook is kept because `cp` propagates the store's read-only mode and the next session's `rm -rf` must succeed.
- `set -euo pipefail`, the best-effort `nix build ... || true`, and the `reloadSkills: true` envelope field for Claude Code are all preserved unchanged.

## Verified locally

- `nix build .#skills`: 0 symlinks anywhere in the output, 58 skills with 58 real `SKILL.md` files.
- Hook exits 0 for both targets; Claude Code envelope parses with `reloadSkills: true` and ~7.3 KB of `additionalContext`; Codex envelope has no `reloadSkills` key.
- `.claude/skills` and `.agents/skills` are real directories with 0 symlinks; hook is idempotent on a second run.
- Negative path: a skill whose `SKILL.md` symlinks to a host-absolute path fails the build with `cp: cannot stat ...` inside the sandbox; a benign relative symlink inside a skill materializes into a real file.
- `nix run .#lint` passes; `checks.x86_64-linux.agent-context` builds.

Acceptance per the issue is "validate in a real session, not by inspecting the store path": confirm by typing `/` in a fresh session and seeing the generated progressive-section skills in the dropdown.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Materialize skill farm as real files so `/` autocomplete discovers skills in Claude Code
> - [`skills.nix`](https://github.com/indexable-inc/index/pull/667/files#diff-e475e33dbf57053afc32ce31772799f180018031a9d5b0d96f6d0735fad146aa): `mkSkillsDir` now uses `pkgs.runCommand` to recursively copy (`-RL`) an intermediate link farm into a symlink-free output directory. The build fails if any symlinks remain after copying.
> - [`agent-instructions.sh`](https://github.com/indexable-inc/index/pull/667/files#diff-6858799d11b7350b7cfa67d7e2eb3803531b1452e81a3f91360b10859d7f1280): On `SessionStart`, the hook now copies the built skills package into `.claude/skills` (or `.agents/skills` for `codex-md`) instead of creating a symlink to the Nix store, ensuring Claude Code's `/`-autocomplete can discover the files.
> - Behavioral Change: Skills are now materialized as writable real files on disk; previously they were symlinks pointing into the Nix store.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 563d27d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->