### PR TITLE
mcp: disable Jupyter auth token

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -16,8 +16,12 @@ nix run .#mcp -- lab              # open the running server's JupyterLab URL
 nix run .#mcp -- eval '1 + 2'     # one-shot expression on a throwaway kernel
 ```
 
-When `serve` starts it prints a JupyterLab URL (with an auth token) to stderr;
-open it, or run `ix-mcp lab`, to co-edit the notebook the agent is working in.
+When `serve` starts it prints a JupyterLab URL to stderr; open it, or run
+`ix-mcp lab`, to co-edit the notebook the agent is working in. Jupyter auth is
+disabled (no token, no password), so the URL opens straight in. Access is gated
+by reachability instead: the default bind is loopback, and the fleet only
+exposes the server over Tailscale. Never bind it to a public interface, since a
+reachable Jupyter Server is arbitrary code execution for whoever can dial it.
 
 ## Remote access
 

--- a/packages/mcp/ix_notebook_mcp/__init__.py
+++ b/packages/mcp/ix_notebook_mcp/__init__.py
@@ -8,7 +8,7 @@ outputs that anyone can reopen.
 
 The pieces:
   - :mod:`ix_notebook_mcp.runtime` holds the process-global config (workspace
-    dir, auth token, the real stdout the MCP protocol owns).
+    dir, bind address, the real stdout the MCP protocol owns).
   - :mod:`ix_notebook_mcp.notebook` reaches the live ``YNotebook`` for a path and
     edits cells inside it (the co-edit boundary).
   - :mod:`ix_notebook_mcp.kernel` runs code on the notebook's own kernel and

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -229,7 +229,13 @@ def _serve(args: argparse.Namespace) -> int:
             f"--ServerApp.ip={cfg.host}",
             f"--ServerApp.port={cfg.jupyter_port}",
             "--ServerApp.open_browser=False",
-            f"--IdentityProvider.token={cfg.token}",
+            # Empty token + empty password disables Jupyter auth entirely
+            # (jupyter_server 2.x: auth_enabled becomes False, and
+            # allow_unauthenticated_access defaults True), so the lab URL opens
+            # straight in with no token to copy. Access is gated by reachability
+            # instead: loopback by default, Tailscale-only when exposed. See the
+            # Config bind-address comment for the security rationale.
+            "--IdentityProvider.token=",
             "--ServerApp.log_level=WARN",
             # app_settings_dir holds overrides.json (default dark theme + editor
             # settings); custom CSS is served from {config_dir}/custom.

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -11,9 +11,8 @@ The object is frozen so nothing mutates configuration after launch.
 from __future__ import annotations
 
 import os
-import secrets
 import stat
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 
@@ -22,11 +21,15 @@ class Config:
     # Directory notebooks live in and the Jupyter Server is rooted at.
     workdir: Path
 
-    # The Jupyter Server bind address + auth token (the token gates both the
-    # browser UI and the collaboration websocket, and appears in the lab URL).
+    # The Jupyter Server bind address. The server runs with auth disabled (no
+    # token, no password): the lab URL opens straight into the live notebook so a
+    # human can co-edit without copying a token out of band. Access is instead
+    # gated by reachability: the default bind is loopback, and the fleet only
+    # exposes it over Tailscale, where the tailnet is the trust boundary. Note a
+    # reachable Jupyter Server is arbitrary code execution for whoever can dial
+    # it, so never bind it to a public interface.
     host: str = "127.0.0.1"
     jupyter_port: int = 0
-    token: str = field(default_factory=lambda: secrets.token_urlsafe(24))
 
     # The host string put into the lab URL a human opens. Distinct from `host`
     # (the bind address): when Jupyter binds a wildcard like 0.0.0.0, that is
@@ -49,8 +52,8 @@ class Config:
     stdout_fd: int | None = None
 
     def lab_url(self) -> str:
-        """The URL a human opens to co-edit, including the auth token."""
-        return f"http://{self.advertised_host}:{self.jupyter_port}/lab?token={self.token}"
+        """The URL a human opens to co-edit (auth is disabled, so no token)."""
+        return f"http://{self.advertised_host}:{self.jupyter_port}/lab"
 
     def resolve(self, rel_path: str) -> Path:
         """Resolve a workspace-relative path to an absolute one, refusing escapes.


### PR DESCRIPTION
Drop the random auth token on the notebook MCP's Jupyter server. A human co-editing had to copy the token out of the lab URL (the friction we hit debugging CI). Now Jupyter launches with empty token + empty password, which disables auth entirely, and the lab URL opens straight in.

Access is gated by reachability instead: loopback bind by default, exposed only over Tailscale on the fleet. Comments on the bind address and the launch flag note that a reachable Jupyter server is RCE, so it must never bind a public interface.

Validated: built `.#mcp`, ran `serve`, server logs "All authentication is disabled", `/lab` and `/api/contents` both return 200 with no token.

Made with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable Jupyter auth token in `ix_notebook_mcp` server
> - Passes an empty `IdentityProvider.token` to Jupyter Server on startup, disabling token/password authentication so the Lab URL opens directly without a token.
> - Removes the `token` field from [`Config`](https://github.com/indexable-inc/index/pull/668/files#diff-33f6f17aed79724ba72211bc8bf9dc1da1bbdb38de56be7ace76cc09837929ca), and `Config.lab_url()` no longer appends a token query parameter.
> - Access is now controlled by bind address reachability (loopback by default, Tailscale for remote exposure).
> - Risk: any process that can reach the bind address gets unauthenticated access with arbitrary code execution capability; binding to a public interface is unsafe.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d0fa29.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->