### PR TITLE
mcp: render DataFrames as interactive tables (itables)

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -67,6 +67,16 @@ the `index` corpus), numpy, polars, duckdb, httpx, matplotlib, playwright, the
 Google API client, and on macOS `screen` and `macvm`. A per-notebook kernel is
 shared with the human, so state set by an agent cell is visible in the browser.
 
+DataFrames render as interactive tables out of the box: every kernel loads
+[itables](https://mwouts.github.io/itables/) at startup with
+`init_notebook_mode(all_interactive=True)`, so displaying a pandas or polars
+frame gives the human a sortable, searchable, paginated DataTable in JupyterLab
+instead of a static table. The `text/plain` repr is kept alongside it, so the
+agent (which reads text, not HTML) and any non-JS viewer are unchanged. The
+DataTables library loads from a CDN (itables `connected=True`), the mode that
+works from a startup script; a frame larger than 256KB is downsampled to a slice
+with a banner so a single cell cannot embed megabytes into the notebook.
+
 ## Bad fit if
 
 - You need a fully offline, server-less notebook: `serve` always runs a Jupyter

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -287,6 +287,12 @@ let
       # the polars/duckdb paths return frames natively. A session that needs
       # explicit Arrow tables (`pl.to_arrow()`) can `pip install pyarrow`.
       ps.duckdb
+      # itables: every kernel's IPython startup (ix_notebook_mcp/ipython/) calls
+      # init_notebook_mode(all_interactive=True), so a pandas/polars DataFrame
+      # renders as an interactive DataTable (sort, search, paginate, scroll) in
+      # the human's JupyterLab view with no per-session call. It keeps the
+      # text/plain repr too, so the agent path and non-JS viewers are unchanged.
+      ps.itables
       # httpx: an HTTP client for the shared async loop (the session already speaks
       # async via asyncssh/playwright/tui but had no way to call a REST API). Sync
       # `httpx.get(...)` and `async with httpx.AsyncClient()` both work.
@@ -462,6 +468,66 @@ let
         mkdir -p "$out"
       '';
 
+  # Boots a real kernel with the shipped IPython startup in place and proves a
+  # polars DataFrame comes back as an interactive itables table (the human's
+  # JupyterLab upgrade) while keeping its text/plain repr (the agent path). Reads
+  # the startup script from the built module, so it also guards that the asset
+  # actually ships. Loopback only, like evalSmoke, so the sandbox allows it.
+  tablesTestPy = pkgs.writeText "ix-mcp-tables-test.py" ''
+    from jupyter_client.manager import start_new_kernel
+
+    km, kc = start_new_kernel(kernel_name="python3")
+    found = {"html": False, "plain": False}
+
+    def hook(msg):
+        if msg["msg_type"] in ("execute_result", "display_data"):
+            data = msg["content"].get("data", {})
+            html = data.get("text/html", "")
+            if html and ("dt_for_itables" in html or "itables" in html):
+                found["html"] = True
+            if data.get("text/plain"):
+                found["plain"] = True
+
+    try:
+        kc.execute_interactive(
+            "import polars as pl; pl.DataFrame({'a': [1, 2], 'b': [3, 4]})",
+            timeout=120, output_hook=hook, store_history=True,
+        )
+    finally:
+        kc.stop_channels()
+        km.shutdown_kernel(now=True)
+
+    assert found["html"], "DataFrame did not render as an interactive itables table (startup did not run?)"
+    assert found["plain"], "DataFrame lost its text/plain repr (the agent path would break)"
+    print("tables-ok")
+  '';
+  tablesSmoke =
+    pkgs.runCommand "ix-mcp-tables-smoke"
+      {
+        nativeBuildInputs = [ mcpPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        export IPYTHONDIR=$TMPDIR/ipython
+        mkdir -p "$IPYTHONDIR/profile_default/startup"
+        cp ${ixNotebookMcpModule}/${pkgs.python3.sitePackages}/ix_notebook_mcp/ipython/*.py \
+          "$IPYTHONDIR/profile_default/startup/"
+
+        ${lib.getExe mcpPython} ${tablesTestPy} >stdout 2>stderr || {
+          echo "ix-mcp tables smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -qx 'tables-ok' stdout || {
+          echo "ix-mcp tables smoke did not confirm interactive tables:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
+
   # macOS-only modules (`screen`, `macvm`) are only bundled on Darwin; their
   # import tests only exist there.
   screenBundled = importTest "screen" "import screen; print('screen-ok', callable(screen.capture), callable(screen.click), callable(screen.accessibility_trusted))";
@@ -478,6 +544,7 @@ package.overrideAttrs (old: {
         jupyterBundled
         serverTools
         evalSmoke
+        tablesSmoke
         ;
     }
     // lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -97,6 +97,28 @@ def _prepare_lab_config(jupyter_port: int) -> tuple[Path, bool]:
     return base, has_css
 
 
+def _prepare_ipython_startup(jupyter_port: int) -> Path:
+    """Materialize a private ``IPYTHONDIR`` whose startup folder holds the shipped
+    ``ipython/`` scripts, and return it.
+
+    IPython runs every ``*.py`` under ``{IPYTHONDIR}/profile_default/startup/``
+    before a kernel's first cell. Kernels inherit this process's environment, so
+    pointing ``IPYTHONDIR`` here (in :func:`_serve`, before the server launches)
+    is what makes 00-ix-itables.py run in each kernel and turn DataFrames into
+    interactive tables. Per-port and under the 0700 runtime dir so concurrent
+    servers do not share an IPython history db, and isolated from the user's
+    ``~/.ipython`` for the same reason the lab config is isolated from
+    ``~/.jupyter``: reproducible behavior that the user's profile cannot break.
+    """
+    assets = Path(__file__).resolve().parent / "ipython"
+    base = runtime_dir() / f"ipython-{jupyter_port}"
+    startup = base / "profile_default" / "startup"
+    startup.mkdir(parents=True, exist_ok=True)
+    for script in sorted(assets.glob("*.py")):
+        shutil.copyfile(script, startup / script.name)
+    return base
+
+
 def _free_port() -> int:
     # Just reserves a free port number; the kernel gives port 0 an unused port.
     # The interface here is irrelevant: a number free on loopback is free for the
@@ -220,6 +242,11 @@ def _serve(args: argparse.Namespace) -> int:
     # unconditionally so the config surface does not change based on whether the
     # generated CSS happens to be present.
     os.environ["JUPYTER_CONFIG_DIR"] = str(lab_config_dir)
+
+    # Point IPython at a private profile whose startup scripts run in every
+    # kernel (kernels inherit this env). 00-ix-itables.py turns DataFrames into
+    # interactive tables; see _prepare_ipython_startup.
+    os.environ["IPYTHONDIR"] = str(_prepare_ipython_startup(cfg.jupyter_port))
 
     from jupyter_server.serverapp import ServerApp
 

--- a/packages/mcp/ix_notebook_mcp/ipython/00-ix-itables.py
+++ b/packages/mcp/ix_notebook_mcp/ipython/00-ix-itables.py
@@ -1,0 +1,29 @@
+"""Auto-loaded IPython startup for every ix-mcp notebook kernel.
+
+The CLI copies this into ``$IPYTHONDIR/profile_default/startup/`` (see
+``cli._prepare_ipython_startup``), so IPython runs it before the first cell of
+every kernel. It turns on itables, which patches the IPython display formatter so
+any pandas or polars ``DataFrame``/``Series`` renders as an interactive
+DataTable (sort, search, paginate, horizontal scroll) with no per-session call.
+
+``connected=True`` loads the DataTables library with an ESM ``import`` from the
+jsDelivr CDN, which makes each table output self-contained. That is the mode that
+works from a startup file: itables' offline mode embeds the library through the
+*output* of ``init_notebook_mode``, so it must be called inside a real cell, not
+here where the call's output has no cell to attach to.
+
+itables keeps the ``text/plain`` repr alongside the HTML, so the MCP agent path
+(which omits HTML) and any non-JS viewer still get a readable table; only the
+human's JupyterLab view upgrades to the interactive widget.
+"""
+
+from itables import init_notebook_mode
+import itables.options as it
+
+# Render moderately large frames in full before itables downsamples to a slice
+# with a banner. The default (64KB) clips common analysis frames; 256KB keeps
+# them whole while still capping a runaway cell from embedding megabytes of JSON
+# into the notebook (and the agent's context).
+it.maxBytes = "256KB"
+
+init_notebook_mode(all_interactive=True, connected=True)


### PR DESCRIPTION
Polars (and pandas) DataFrames now render as interactive tables in the notebook automatically. Every kernel loads itables at startup with `init_notebook_mode(all_interactive=True)`, so a displayed frame becomes a sortable, searchable, paginated DataTable in JupyterLab instead of a static one, with no per-session call.

How: a shipped `ipython/00-ix-itables.py` is copied into a private `IPYTHONDIR/profile_default/startup/` and the env var is set in `_serve` before launch (same isolation pattern as `JUPYTER_CONFIG_DIR`); kernels inherit it and IPython runs the script before the first cell. `connected=True` loads DataTables via a CDN ESM import (the mode that works from a startup script; offline mode would need init in a real cell). itables keeps the `text/plain` repr, so the MCP agent path and any non-JS viewer are unchanged. Frames over 256KB are downsampled to a slice with a banner so a single cell cannot embed megabytes into the notebook.

Adds a `tablesSmoke` passthru test that boots a real kernel with the shipped startup and asserts a polars frame returns interactive html plus text/plain.

Validated: `nix build .#mcp`; `tablesSmoke`/`serverTools`/`evalSmoke`/`jupyter` tests pass; `nix run .#lint` clean; a live `serve` materializes the IPYTHONDIR startup file.

Made with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render pandas/polars DataFrames as interactive itables tables in notebook kernels
> - Adds [00-ix-itables.py](https://github.com/indexable-inc/index/pull/669/files#diff-313722773f1ff3695de6bc73164b21d6463e7c258782ac59d99ca53bcdbcf10a), an IPython startup script that calls `init_notebook_mode(all_interactive=True)` and sets `maxBytes` to 256KB, so DataFrames render as interactive DataTables in JupyterLab while preserving `text/plain` output.
> - Adds `_prepare_ipython_startup()` in [cli.py](https://github.com/indexable-inc/index/pull/669/files#diff-7ce741e8223d63fdea11625cb78abad266299445db0213d2355bc93306df9ac5) to copy packaged startup scripts into a per-port `IPYTHONDIR` profile, which is then set as an env variable before the Jupyter Server launches.
> - Adds `itables` to the Nix Python environment and a `tablesSmoke` check that verifies both `text/html` (itables markers) and `text/plain` are present in kernel output.
> - Behavioral Change: DataTables assets load from a CDN, and DataFrame outputs larger than 256KB are downsampled with a banner.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de6ed70.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->