### PR TITLE
mcp: widen polars text repr for the agent's DataFrame view

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -77,6 +77,11 @@ DataTables library loads from a CDN (itables `connected=True`), the mode that
 works from a startup script; a frame larger than 256KB is downsampled to a slice
 with a banner so a single cell cannot embed megabytes into the notebook.
 
+The agent reads that `text/plain` repr, so the kernel also widens polars'
+defaults (up to 40 rows and columns, 80-char strings) so a frame is not
+truncated to ~8 columns in the agent's view. The MCP layer still caps a single
+text output at 50k chars, so the wider repr cannot flood the agent's context.
+
 ## Bad fit if
 
 - You need a fully offline, server-less notebook: `serve` always runs a Jupyter

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -477,7 +477,7 @@ let
     from jupyter_client.manager import start_new_kernel
 
     km, kc = start_new_kernel(kernel_name="python3")
-    found = {"html": False, "plain": False}
+    found = {"html": False, "plain": ""}
 
     def hook(msg):
         if msg["msg_type"] in ("execute_result", "display_data"):
@@ -485,12 +485,14 @@ let
             html = data.get("text/html", "")
             if html and ("dt_for_itables" in html or "itables" in html):
                 found["html"] = True
-            if data.get("text/plain"):
-                found["plain"] = True
+            found["plain"] += data.get("text/plain", "")
 
     try:
+        # A 12-column frame: more than polars' ~8-column default, so the text/plain
+        # repr only shows the last column (c11) if 01-ix-polars.py widened the
+        # config. Exercises both startup scripts at once.
         kc.execute_interactive(
-            "import polars as pl; pl.DataFrame({'a': [1, 2], 'b': [3, 4]})",
+            "import polars as pl; pl.DataFrame({f'c{i}': [i] for i in range(12)})",
             timeout=120, output_hook=hook, store_history=True,
         )
     finally:
@@ -499,6 +501,7 @@ let
 
     assert found["html"], "DataFrame did not render as an interactive itables table (startup did not run?)"
     assert found["plain"], "DataFrame lost its text/plain repr (the agent path would break)"
+    assert "c11" in found["plain"], "polars repr was not widened (01-ix-polars.py did not run?)"
     print("tables-ok")
   '';
   tablesSmoke =

--- a/packages/mcp/ix_notebook_mcp/ipython/01-ix-polars.py
+++ b/packages/mcp/ix_notebook_mcp/ipython/01-ix-polars.py
@@ -1,0 +1,17 @@
+"""Widen polars' text repr for the MCP agent's view of DataFrames.
+
+itables (00-ix-itables.py) drives the human's interactive table straight from the
+data, so this only changes the ``text/plain`` repr: what the agent (which reads
+text, not HTML) and any non-JS viewer get. Polars defaults truncate to ~8 rows,
+~8 columns, and 30-char strings, which hides most of a frame from the agent;
+widen to a fuller but still bounded view. The MCP layer caps a single text output
+at 50k chars (outputs._MAX_TEXT_CHARS), so a wide repr cannot flood the agent's
+context.
+"""
+
+import polars as pl
+
+pl.Config.set_tbl_rows(40)
+pl.Config.set_tbl_cols(40)
+pl.Config.set_fmt_str_lengths(80)
+pl.Config.set_tbl_width_chars(160)


### PR DESCRIPTION
Follow-up to #669. itables gives the human an interactive table, but the agent reads the `text/plain` repr, which polars truncates to ~8 rows / ~8 columns / 30-char strings, hiding most of a frame. Adds a second kernel startup (`01-ix-polars.py`) that widens polars to 40 rows/cols and 80-char strings. The MCP layer still caps a single text output at 50k chars, so this cannot flood the agent's context.

Extends `tablesSmoke` to display a 12-column frame and assert the last column (`c11`) shows up in `text/plain`, proving the widened config ran.

Validated: `nix build .#mcp.tests.tablesSmoke` passes; `nix run .#lint` clean.

Made with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Widen polars text repr for agent DataFrame view to 40 rows/columns
> - Adds [01-ix-polars.py](https://github.com/indexable-inc/index/pull/670/files#diff-3e91f1402b88310bc4e9938f81a0cefa8ae054eaec377787011e839c2870642f), an IPython startup script that sets polars display config to 40 rows, 40 columns, 80-char string truncation, and 160-char table width so the agent sees a fuller DataFrame repr.
> - Updates the `tablesSmoke` test in [default.nix](https://github.com/indexable-inc/index/pull/670/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) to build a 12-column DataFrame and assert that `c11` appears in the accumulated `text/plain` output, confirming the wider repr is active.
> - Documents the behavior in the README: the kernel widens polars defaults and MCP caps a single text output at 50k characters.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d62c886.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->