### PR TITLE
mynoise: CLI to play myNoise.net generators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3611,6 +3611,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
+name = "mynoise"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "dirs",
+ "reqwest",
+ "rodio",
+ "tokio",
+]
+
+[[package]]
 name = "napi"
 version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
   "packages/minecraft/sound",
   "packages/minecraft/sync-managed",
   "packages/mixedbread",
+  "packages/mynoise",
   "packages/nix-web-monitor/parser",
   "packages/nix-web-monitor/server",
   "packages/oci-image-builder",

--- a/packages/mynoise/Cargo.toml
+++ b/packages/mynoise/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "mynoise"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Play myNoise.net generators by streaming and mixing their band loops locally"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+dirs.workspace = true
+# Async GET over HTTPS to fetch band loops and scrape the generator index.
+# Inherits the workspace `default-features = false` + rustls, so no system
+# OpenSSL. A small current-thread runtime drives the download phase only.
+reqwest.workspace = true
+# OGG/Vorbis decode + mixing. The workspace already wires ALSA's pkg-config and
+# `-lasound` link path for every unit (see lib/rust/workspace.nix), so this
+# crate needs no extra Nix plumbing on Linux.
+rodio.workspace = true
+tokio = { workspace = true, features = ["rt", "net", "time"] }

--- a/packages/mynoise/default.nix
+++ b/packages/mynoise/default.nix
@@ -1,0 +1,10 @@
+{ ix, lib, ... }:
+
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "mynoise";
+  meta = {
+    description = "Play myNoise.net generators by streaming and mixing their band loops locally";
+    license = lib.licenses.mit;
+    mainProgram = "mynoise";
+  };
+}

--- a/packages/mynoise/package.nix
+++ b/packages/mynoise/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "mynoise";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/mynoise/src/audio.rs
+++ b/packages/mynoise/src/audio.rs
@@ -1,0 +1,57 @@
+//! Mix a generator's band loops and play them until interrupted.
+//!
+//! Each band is one OGG loop. The website mixes them in the browser with a
+//! per-band volume; we do the same by giving each band its own rodio `Sink` on
+//! a shared output stream (the stream sums all sinks) and looping it forever.
+
+use std::fs::File;
+use std::io::BufReader;
+use std::path::PathBuf;
+use std::thread;
+
+use anyhow::{Context as _, Result, bail};
+use rodio::source::Source as _;
+use rodio::{Decoder, OutputStream, Sink};
+
+/// A band file paired with the linear amplitude (0.0..) to play it at.
+pub struct Band {
+    pub path: PathBuf,
+    pub amplitude: f32,
+}
+
+/// Decode each band, loop it forever, mix them, and block until the process is
+/// interrupted (Ctrl-C). Bands at zero amplitude are skipped entirely.
+pub fn play(bands: &[Band]) -> Result<()> {
+    let (_stream, handle) = OutputStream::try_default().context("open audio output device")?;
+
+    // Hold every sink for the life of playback; dropping a sink stops its band.
+    let mut sinks = Vec::new();
+    for band in bands {
+        if band.amplitude <= 0.0 {
+            continue;
+        }
+        let file = File::open(&band.path)
+            .with_context(|| format!("open band {}", band.path.display()))?;
+        // `Decoder` is not `Clone`, so `repeat_infinite` needs a `Buffered`
+        // wrapper, which caches decoded samples and replays them each loop.
+        let source = Decoder::new(BufReader::new(file))
+            .with_context(|| format!("decode band {}", band.path.display()))?
+            .buffered()
+            .repeat_infinite()
+            .amplify(band.amplitude);
+        let sink = Sink::try_new(&handle).context("create audio sink")?;
+        sink.append(source);
+        sinks.push(sink);
+    }
+
+    if sinks.is_empty() {
+        bail!("every band is muted; nothing to play");
+    }
+
+    // The loops never end on their own; park forever (cheaper than a timed
+    // sleep loop) until the user sends Ctrl-C, which terminates the process and
+    // tears down the output stream. `park` may wake spuriously, so loop.
+    loop {
+        thread::park();
+    }
+}

--- a/packages/mynoise/src/main.rs
+++ b/packages/mynoise/src/main.rs
@@ -1,0 +1,110 @@
+//! `mynoise`: play [myNoise.net](https://mynoise.net) generators from the CLI.
+//!
+//! myNoise has no server-side audio generation. Each generator is a handful of
+//! stereo OGG loops served as static files at
+//! `https://mynoise.net/Data/<CODE>/<n>a.ogg`, one per frequency band; the
+//! website's sliders are pure per-band volume mixed in the browser. This tool
+//! resolves a name to its `<CODE>`, downloads the bands (cached locally), then
+//! loops and mixes them with the same per-band gains.
+//!
+//! The audio is © Stéphane Pigeon (mynoise.net), patron-funded. Streaming it
+//! for personal listening is fine; redistribution is not.
+
+mod audio;
+mod resolve;
+
+use std::path::PathBuf;
+
+use anyhow::{Context as _, Result, bail};
+use clap::Parser;
+
+use crate::audio::Band;
+
+/// Play a myNoise.net generator by mixing its band loops locally.
+#[derive(Parser)]
+#[command(version, about)]
+struct Cli {
+    /// Generator to play: a bare data code (`RAIN`, `OSMOSIS`) or a generator
+    /// page slug (`rainNoiseGenerator`). Omit together with `--list`.
+    name: Option<String>,
+
+    /// Per-band gains in band order, each 0..=100. Bands without an explicit
+    /// value use `--default-gain`; extra values past the band count are ignored.
+    gains: Vec<u8>,
+
+    /// List the generator slugs scraped from the myNoise index and exit.
+    #[arg(long)]
+    list: bool,
+
+    /// Master volume applied on top of every per-band gain, 0..=100. Lower it if
+    /// a full mix clips.
+    #[arg(long, default_value_t = 50)]
+    volume: u8,
+
+    /// Gain (0..=100) for any band without an explicit value in `gains`.
+    #[arg(long, default_value_t = 70)]
+    default_gain: u8,
+
+    /// Cache directory for downloaded band files. Defaults to the OS cache dir.
+    #[arg(long)]
+    cache_dir: Option<PathBuf>,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    let client = reqwest::Client::builder()
+        // A real UA avoids the index/page scrape being served a bot stub.
+        .user_agent("mynoise-cli (https://github.com/indexable-inc/index)")
+        .build()
+        .context("build HTTP client")?;
+
+    // One current-thread runtime drives the network phase; playback is blocking.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("build async runtime")?;
+
+    if cli.list {
+        let slugs = rt.block_on(resolve::list_slugs(&client))?;
+        for slug in slugs {
+            println!("{slug}");
+        }
+        return Ok(());
+    }
+
+    let Some(name) = cli.name.as_deref() else {
+        bail!("provide a generator name (or use --list); see --help");
+    };
+
+    let cache_dir = cli
+        .cache_dir
+        .or_else(|| dirs::cache_dir().map(|d| d.join("mynoise")))
+        .context("could not determine a cache directory; pass --cache-dir")?;
+
+    let (code, files) = rt.block_on(async {
+        let code = resolve::resolve_code(&client, name).await?;
+        let files = resolve::download_bands(&client, &code, &cache_dir).await?;
+        Ok::<_, anyhow::Error>((code, files))
+    })?;
+
+    let master = f32::from(cli.volume) / 100.0;
+    let bands: Vec<Band> = files
+        .into_iter()
+        .enumerate()
+        .map(|(i, path)| {
+            let gain = cli.gains.get(i).copied().unwrap_or(cli.default_gain);
+            Band {
+                path,
+                amplitude: f32::from(gain) / 100.0 * master,
+            }
+        })
+        .collect();
+
+    eprintln!(
+        "Playing {code} ({} bands) at volume {}. Ctrl-C to stop.",
+        bands.len(),
+        cli.volume
+    );
+    audio::play(&bands)
+}

--- a/packages/mynoise/src/resolve.rs
+++ b/packages/mynoise/src/resolve.rs
@@ -1,0 +1,169 @@
+//! Resolve a user-supplied generator name to its myNoise data `CODE`, then
+//! download that generator's band loops.
+//!
+//! myNoise serves every generator's audio as static files under
+//! `https://mynoise.net/Data/<CODE>/<n>a.ogg`, one OGG per frequency band (the
+//! `a` files; `b` files are alternate takes the site randomizes for variety, we
+//! always take `a`). There is no server-side generation, so "resolve" is just
+//! finding the `CODE` and "download" is fetching `1a.ogg`, `2a.ogg`, ... until
+//! one 404s.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, Result, bail};
+
+const BASE: &str = "https://mynoise.net";
+
+/// Upper bound on band probing. Real generators top out around 10 bands; this
+/// guards against an unbounded loop if the server ever stops returning 404 for
+/// missing files.
+const MAX_BANDS: u32 = 16;
+
+/// Pull the first `Data/<CODE>/` path out of a generator page's HTML.
+///
+/// The generator pages embed their audio folder as `Data/CODE/...` URLs; the
+/// code is upper-case alphanumerics plus underscores. Pure so it can be unit
+/// tested offline.
+fn parse_data_code(html: &str) -> Option<String> {
+    let marker = "Data/";
+    let start = html.find(marker)? + marker.len();
+    let code: String = html[start..]
+        .chars()
+        .take_while(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || *c == '_')
+        .collect();
+    if code.is_empty() { None } else { Some(code) }
+}
+
+/// True if `url` returns a 2xx for a HEAD request.
+async fn head_ok(client: &reqwest::Client, url: &str) -> bool {
+    matches!(client.head(url).send().await, Ok(r) if r.status().is_success())
+}
+
+/// Resolve `name` to a generator data code.
+///
+/// Tries, in order: the name as a bare upper-cased code (verified by probing its
+/// `1a.ogg`), then the name as a generator-page slug whose HTML is scraped for
+/// the embedded `Data/<CODE>/`.
+pub async fn resolve_code(client: &reqwest::Client, name: &str) -> Result<String> {
+    let upper = name.to_ascii_uppercase();
+    let looks_like_code = name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_');
+    if looks_like_code && head_ok(client, &format!("{BASE}/Data/{upper}/1a.ogg")).await {
+        return Ok(upper);
+    }
+
+    let page = format!("{BASE}/NoiseMachines/{name}.php");
+    let html = client
+        .get(&page)
+        .send()
+        .await
+        .with_context(|| format!("fetch generator page {page}"))?
+        .error_for_status()
+        .with_context(|| format!("generator page not found for {name:?}"))?
+        .text()
+        .await
+        .context("read generator page body")?;
+    parse_data_code(&html)
+        .with_context(|| format!("could not find a Data/<CODE>/ reference on {page}"))
+}
+
+/// Download every band loop for `code` into `cache_dir`, returning the cached
+/// file paths in band order. Files already present are reused.
+pub async fn download_bands(
+    client: &reqwest::Client,
+    code: &str,
+    cache_dir: &Path,
+) -> Result<Vec<PathBuf>> {
+    let dir = cache_dir.join(code);
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("create cache dir {}", dir.display()))?;
+
+    let mut bands = Vec::new();
+    for n in 1..=MAX_BANDS {
+        let file = dir.join(format!("{n}a.ogg"));
+        if file.exists() {
+            bands.push(file);
+            continue;
+        }
+        let url = format!("{BASE}/Data/{code}/{n}a.ogg");
+        let resp = client
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("fetch band {url}"))?;
+        // First missing band marks the end of the generator's band list.
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            break;
+        }
+        let bytes = resp
+            .error_for_status()
+            .with_context(|| format!("fetch band {url}"))?
+            .bytes()
+            .await
+            .with_context(|| format!("read band body {url}"))?;
+        std::fs::write(&file, &bytes)
+            .with_context(|| format!("write cache file {}", file.display()))?;
+        bands.push(file);
+    }
+
+    if bands.is_empty() {
+        bail!("no band files found for code {code:?}");
+    }
+    Ok(bands)
+}
+
+/// List generator page slugs from the noise-machine index, sorted and de-duped.
+pub async fn list_slugs(client: &reqwest::Client) -> Result<Vec<String>> {
+    let url = format!("{BASE}/noiseMachines.php");
+    let html = client
+        .get(&url)
+        .send()
+        .await
+        .context("fetch noise-machine index")?
+        .error_for_status()
+        .context("noise-machine index returned an error")?
+        .text()
+        .await
+        .context("read noise-machine index body")?;
+
+    let marker = "NoiseMachines/";
+    let mut slugs: Vec<String> = html
+        .match_indices(marker)
+        .filter_map(|(i, _)| {
+            let rest = &html[i + marker.len()..];
+            let slug: String = rest
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+                .collect();
+            // Drop the trailing `.php` if the slug captured it via a stray char.
+            let slug = slug.strip_suffix(".php").unwrap_or(&slug).to_string();
+            (!slug.is_empty()).then_some(slug)
+        })
+        .collect();
+    slugs.sort_unstable();
+    slugs.dedup();
+    Ok(slugs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_data_code;
+
+    #[test]
+    fn extracts_code_from_data_url() {
+        let html = r#"<audio src="Data/RAIN/1a.ogg"></audio>"#;
+        assert_eq!(parse_data_code(html).as_deref(), Some("RAIN"));
+    }
+
+    #[test]
+    fn allows_digits_and_underscores() {
+        let html = r"loadBand('Data/B_17/3a.ogg');";
+        assert_eq!(parse_data_code(html).as_deref(), Some("B_17"));
+    }
+
+    #[test]
+    fn none_when_absent() {
+        assert_eq!(parse_data_code("<html>no audio here</html>"), None);
+    }
+}


### PR DESCRIPTION
Rust CLI that plays [myNoise.net](https://mynoise.net) generators.

myNoise has no server-side generation: each generator is ~9 stereo OGG band loops served as static files at `Data/<CODE>/<n>a.ogg`, mixed in-browser by the sliders. `mynoise` does the same locally: resolve a name (bare code like `RAIN` or a page slug like `rainNoiseGenerator`) to its CODE, download + cache the bands, then loop and mix them with per-band gains via rodio. Pure Rust, no ffmpeg.

- `mynoise RAIN`, `mynoise OSMOSIS 80 80 20 ...` (per-band gains), `mynoise --list`
- Validated on darwin: build, clippy, machete, unused-deps, unit tests, live list/resolve/play.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `mynoise` CLI to play myNoise.net generators
> - Adds a new `mynoise` binary crate that downloads and plays audio generators from [mynoise.net](https://mynoise.net) via the command line.
> - Resolves a generator name or code to a data code via HEAD probing or HTML scraping, then downloads and caches up to 16 OGG band files under `~/.cache/mynoise`.
> - Mixes the bands with per-band amplitude (derived from positional gain args and `--volume`) using `rodio`, looping indefinitely until the process is interrupted.
> - Supports `--list` to print available generator slugs scraped from the site index.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fede835.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->