### PR TITLE
mynoise: clap usage errors, 0-indexed bands, robust scrape

### DIFF
--- a/packages/mynoise/src/main.rs
+++ b/packages/mynoise/src/main.rs
@@ -15,14 +15,19 @@ mod resolve;
 
 use std::path::PathBuf;
 
-use anyhow::{Context as _, Result, bail};
-use clap::Parser;
+use anyhow::{Context as _, Result};
+use clap::{ArgGroup, Parser};
 
 use crate::audio::Band;
 
 /// Play a myNoise.net generator by mixing its band loops locally.
 #[derive(Parser)]
 #[command(version, about)]
+// Bare `mynoise` prints help instead of erroring; otherwise clap requires
+// exactly one of a generator name or `--list`, so it owns the "no target"
+// usage error (clean exit 2, no anyhow backtrace).
+#[command(arg_required_else_help = true)]
+#[command(group(ArgGroup::new("target").required(true).args(["name", "list"])))]
 struct Cli {
     /// Generator to play: a bare data code (`RAIN`, `OSMOSIS`) or a generator
     /// page slug (`rainNoiseGenerator`). Omit together with `--list`.
@@ -73,9 +78,11 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    let Some(name) = cli.name.as_deref() else {
-        bail!("provide a generator name (or use --list); see --help");
-    };
+    // The required `target` group guarantees a name here when `--list` is unset.
+    let name = cli
+        .name
+        .as_deref()
+        .expect("clap requires a name unless --list");
 
     let cache_dir = cli
         .cache_dir
@@ -88,16 +95,27 @@ fn main() -> Result<()> {
         Ok::<_, anyhow::Error>((code, files))
     })?;
 
-    let master = f32::from(cli.volume) / 100.0;
+    // Resolve the per-band gains (explicit value, else the default) in band order.
+    let gains: Vec<f32> = files
+        .iter()
+        .enumerate()
+        .map(|(i, _)| f32::from(cli.gains.get(i).copied().unwrap_or(cli.default_gain)) / 100.0)
+        .collect();
+
+    // The bands are decorrelated noise, so their power (not their amplitude) adds;
+    // dividing the master by sqrt(active band count) keeps a full mix from
+    // overshooting full scale and clipping in rodio's mixer, while holding
+    // roughly constant perceived loudness as the band count changes.
+    let active = gains.iter().filter(|g| **g > 0.0).count().max(1);
+    #[allow(clippy::cast_precision_loss)]
+    let master = f32::from(cli.volume) / 100.0 / (active as f32).sqrt();
+
     let bands: Vec<Band> = files
         .into_iter()
-        .enumerate()
-        .map(|(i, path)| {
-            let gain = cli.gains.get(i).copied().unwrap_or(cli.default_gain);
-            Band {
-                path,
-                amplitude: f32::from(gain) / 100.0 * master,
-            }
+        .zip(gains)
+        .map(|(path, gain)| Band {
+            path,
+            amplitude: gain * master,
         })
         .collect();
 

--- a/packages/mynoise/src/resolve.rs
+++ b/packages/mynoise/src/resolve.rs
@@ -14,24 +14,51 @@ use anyhow::{Context as _, Result, bail};
 
 const BASE: &str = "https://mynoise.net";
 
-/// Upper bound on band probing. Real generators top out around 10 bands; this
-/// guards against an unbounded loop if the server ever stops returning 404 for
-/// missing files.
+/// Upper bound on band probing. Bands are 0-indexed and real generators top out
+/// around 10 (`0a.ogg`..`9a.ogg`); this guards against an unbounded loop if the
+/// server ever stops returning 404 for missing files.
 const MAX_BANDS: u32 = 16;
 
-/// Pull the first `Data/<CODE>/` path out of a generator page's HTML.
+/// True if `s` starts with a band reference: `<digits>a` or `<digits>b`. Pages
+/// reference bands bare (`Data/RAIN/0a"`, the `.ogg` is appended in JS), while
+/// images keep their extension (`fb.jpg`), so we require digits then `a`/`b`
+/// then a non-alphanumeric boundary (end, quote, or `.ogg`) and reject e.g.
+/// `0album` or `fb.jpg`.
+fn is_band_file(s: &str) -> bool {
+    let digits = s.chars().take_while(char::is_ascii_digit).count();
+    if digits == 0 {
+        return false;
+    }
+    let Some(rest) = s[digits..].strip_prefix(['a', 'b']) else {
+        return false;
+    };
+    rest.chars().next().is_none_or(|c| !c.is_ascii_alphanumeric())
+}
+
+/// Pull a generator's audio `CODE` out of its page HTML.
 ///
-/// The generator pages embed their audio folder as `Data/CODE/...` URLs; the
-/// code is upper-case alphanumerics plus underscores. Pure so it can be unit
-/// tested offline.
+/// Generator pages embed their audio as `Data/<CODE>/<n>a.ogg` URLs, where the
+/// code is upper-case alphanumerics plus underscores. We accept the first
+/// `Data/<CODE>/` whose code is immediately followed by a band file: the first
+/// bare `Data/` reference on a page is usually a share image
+/// (`Data/RAIN/fb.jpg`) that only shares the audio folder by luck, so anchoring
+/// on the band file is robust to pages whose first reference is a different
+/// folder. Pure so it can be unit tested offline.
 fn parse_data_code(html: &str) -> Option<String> {
     let marker = "Data/";
-    let start = html.find(marker)? + marker.len();
-    let code: String = html[start..]
-        .chars()
-        .take_while(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || *c == '_')
-        .collect();
-    if code.is_empty() { None } else { Some(code) }
+    html.match_indices(marker).find_map(|(i, _)| {
+        let rest = &html[i + marker.len()..];
+        // Code chars are ASCII, so byte length equals the char count taken.
+        let code: String = rest
+            .chars()
+            .take_while(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || *c == '_')
+            .collect();
+        if code.is_empty() {
+            return None;
+        }
+        let tail = rest[code.len()..].strip_prefix('/')?;
+        is_band_file(tail).then_some(code)
+    })
 }
 
 /// True if `url` returns a 2xx for a HEAD request.
@@ -42,14 +69,15 @@ async fn head_ok(client: &reqwest::Client, url: &str) -> bool {
 /// Resolve `name` to a generator data code.
 ///
 /// Tries, in order: the name as a bare upper-cased code (verified by probing its
-/// `1a.ogg`), then the name as a generator-page slug whose HTML is scraped for
+/// `0a.ogg`), then the name as a generator-page slug whose HTML is scraped for
 /// the embedded `Data/<CODE>/`.
 pub async fn resolve_code(client: &reqwest::Client, name: &str) -> Result<String> {
     let upper = name.to_ascii_uppercase();
     let looks_like_code = name
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '_');
-    if looks_like_code && head_ok(client, &format!("{BASE}/Data/{upper}/1a.ogg")).await {
+    // Band 0 is the lowest band and always present for a valid code.
+    if looks_like_code && head_ok(client, &format!("{BASE}/Data/{upper}/0a.ogg")).await {
         return Ok(upper);
     }
 
@@ -80,7 +108,9 @@ pub async fn download_bands(
         .with_context(|| format!("create cache dir {}", dir.display()))?;
 
     let mut bands = Vec::new();
-    for n in 1..=MAX_BANDS {
+    // Bands are 0-indexed: a generator serves `0a.ogg`..`Na.ogg`. Starting at 1
+    // would drop the lowest band and shift every per-band gain by one.
+    for n in 0..MAX_BANDS {
         let file = dir.join(format!("{n}a.ogg"));
         if file.exists() {
             bands.push(file);
@@ -102,8 +132,14 @@ pub async fn download_bands(
             .bytes()
             .await
             .with_context(|| format!("read band body {url}"))?;
-        std::fs::write(&file, &bytes)
-            .with_context(|| format!("write cache file {}", file.display()))?;
+        // Write to a temp file then rename so a Ctrl-C mid-download (the normal
+        // way to quit this tool) can't leave a truncated `.ogg` that the next
+        // run reuses as if complete. Rename is atomic on the same filesystem.
+        let tmp = file.with_extension("ogg.part");
+        std::fs::write(&tmp, &bytes)
+            .with_context(|| format!("write cache file {}", tmp.display()))?;
+        std::fs::rename(&tmp, &file)
+            .with_context(|| format!("finalize cache file {}", file.display()))?;
         bands.push(file);
     }
 
@@ -132,12 +168,11 @@ pub async fn list_slugs(client: &reqwest::Client) -> Result<Vec<String>> {
         .match_indices(marker)
         .filter_map(|(i, _)| {
             let rest = &html[i + marker.len()..];
+            // `take_while` stops at the `.` before `.php`, so the slug is clean.
             let slug: String = rest
                 .chars()
                 .take_while(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
                 .collect();
-            // Drop the trailing `.php` if the slug captured it via a stray char.
-            let slug = slug.strip_suffix(".php").unwrap_or(&slug).to_string();
             (!slug.is_empty()).then_some(slug)
         })
         .collect();
@@ -151,8 +186,8 @@ mod tests {
     use super::parse_data_code;
 
     #[test]
-    fn extracts_code_from_data_url() {
-        let html = r#"<audio src="Data/RAIN/1a.ogg"></audio>"#;
+    fn extracts_code_from_band_url() {
+        let html = r#"<audio src="Data/RAIN/0a.ogg"></audio>"#;
         assert_eq!(parse_data_code(html).as_deref(), Some("RAIN"));
     }
 
@@ -163,7 +198,45 @@ mod tests {
     }
 
     #[test]
+    fn skips_leading_share_image() {
+        // Real pages reference the share image (`Data/<CODE>/fb.jpg`) before any
+        // band file; the bare-prefix parse used to return from that match.
+        let html = r#"<meta content="Data/RAIN/fb.jpg"><audio src="Data/RAIN/0a.ogg">"#;
+        assert_eq!(parse_data_code(html).as_deref(), Some("RAIN"));
+    }
+
+    #[test]
+    fn prefers_band_folder_over_unrelated_folder() {
+        let html = r#"img "Data/SHARE/og.png" audio "Data/THUNDER/0a.ogg""#;
+        assert_eq!(parse_data_code(html).as_deref(), Some("THUNDER"));
+    }
+
+    #[test]
+    fn accepts_b_take_files() {
+        assert_eq!(parse_data_code("Data/CALM/2b.ogg").as_deref(), Some("CALM"));
+    }
+
+    #[test]
+    fn accepts_bare_band_token_without_extension() {
+        // The real page shape: image first, then bare band tokens (no `.ogg`).
+        let html = r#"["Data/RAIN/fb.jpg","Data/RAIN/0a","Data/RAIN/1a"]"#;
+        assert_eq!(parse_data_code(html).as_deref(), Some("RAIN"));
+    }
+
+    #[test]
+    fn rejects_non_band_word_after_code() {
+        // `album` art shares the folder but is not a band.
+        assert_eq!(parse_data_code(r#""Data/RAIN/album.jpg""#), None);
+    }
+
+    #[test]
     fn none_when_absent() {
         assert_eq!(parse_data_code("<html>no audio here</html>"), None);
+    }
+
+    #[test]
+    fn none_when_no_band_file_follows() {
+        // A `Data/<CODE>/` that is only ever an image must not resolve.
+        assert_eq!(parse_data_code(r#"<img src="Data/RAIN/fb.jpg">"#), None);
     }
 }


### PR DESCRIPTION
Follow-up to #671 addressing the review.

**Fixes the reported UX bug:** bare `mynoise` printed an anyhow backtrace. clap now owns it: bare invocation prints help, and a required `<NAME|--list>` group gives a clean usage error (exit 2).

**Plus confirmed correctness/robustness fixes from the #671 review:**
- **Bands are 0-indexed** (`0a.ogg`..`9a.ogg`). The `1..` loop dropped band 0 and shifted every per-band gain by one. Verified live: `0a.ogg` is HTTP 200. RAIN now plays 10 bands, not 9.
- **`parse_data_code` anchors on a band reference** instead of the first `Data/` (which is the share image `fb.jpg`), and accepts the bare `0a` token the page actually uses (the `.ogg` is appended in JS).
- **Atomic cache writes** (temp + rename) so Ctrl-C mid-download can't leave a truncated `.ogg` the next run reuses.
- **Clip-safe default:** scale master by sqrt(active band count) so a full default mix doesn't clip.
- Dropped dead `.php` strip; added parser unit tests.

Memory was the one open review concern (rodio `buffered().repeat_infinite()`): measured bounded at ~45MB for 10 bands, flat over 3+ loops (footprint), so kept the gapless code.

Validated on darwin: build, mynoise clippy clean, machete, unused-deps, 9 unit tests; live bare-code (`OSMOSIS`), slug scrape (`rainNoiseGenerator`→RAIN), `--list`, and the two clap error paths.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 0-indexed band handling, atomic cache writes, and robust code scraping in mynoise
> - Band indexing now starts at 0 (previously 1), aligning with page semantics so the lowest band is downloaded and included; probe validation uses `0a.ogg` instead of `1a.ogg`.
> - `parse_data_code` in [resolve.rs](https://github.com/indexable-inc/index/pull/672/files#diff-b01e2b4e0df9bbbf16acb34b17815971b334ca710b5f456b5b8303445daf9edb) now ignores image references and unrelated folders when scraping generator codes, and accepts both a/b-take files and bare band tokens.
> - Cache writes in `download_bands` are now atomic: files are written to a `.ogg.part` temp file and renamed on success, preventing truncated cache files after interrupted runs.
> - Master gain is divided by `sqrt(active band count)` to reduce clipping and stabilize perceived loudness as bands are added or muted.
> - Clap now enforces that exactly one of a generator name or `--list` is provided, exiting with code 2 on misuse and printing help on bare invocation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 666cef9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->