### PR TITLE
fix(ci): derive Copy on tui EngineConfig (finish #673 clippy fix)

### DIFF
--- a/packages/tui/src/actor/engine.rs
+++ b/packages/tui/src/actor/engine.rs
@@ -111,6 +111,9 @@ fn vt_engine_error_io(id: Uuid, source: &std::io::Error) -> Error {
 /// Terminal-construction parameters threaded from [`spawn`] into the engine
 /// thread. Grouped so `engine_loop` stays under clippy's argument-count limit
 /// and so the values that only describe the terminal travel as one unit.
+/// `Copy` because every field is `Copy`: passing the struct by value otherwise
+/// trips `clippy::needless_pass_by_value`.
+#[derive(Clone, Copy)]
 struct EngineConfig {
     id: Uuid,
     rows: u16,


### PR DESCRIPTION
Follow-up to #673. That PR grouped `engine_loop`'s args into `EngineConfig`, but the `#[derive(Clone, Copy)]` was left uncommitted, so every `tui` clippy unit kept tripping `clippy::needless_pass_by_value` (struct passed by value, all fields `Copy`). main stayed red on the whole `rust-*-clippy` suite. This commits the derive.

Validated on x86_64-linux (vin-compute-1): built 10 previously-failing clippy checks covering all 6 `tui` feature-flag clippy variants, all clean (exit 0).

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive `Copy` on `EngineConfig` in tui actor engine
> Adds `Clone` and `Copy` derives to the `EngineConfig` struct in [engine.rs](https://github.com/indexable-inc/index/pull/674/files#diff-22ff2cefda8597416b57643b3205d4e14cada8b92ab27d3b2d06cb93b741b414), along with a doc comment explaining the intent. This completes a pending Clippy fix from #673.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8f91ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->