### PR TITLE
lint: deny clippy::anonymous_tuple_return_type across the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,10 @@ pedantic = { level = "deny", priority = -1 }
 nursery = { level = "deny", priority = -1 }
 cargo = { level = "deny", priority = -1 }
 multiple_crate_versions = "allow"
+# Restriction lint (off even in `all`): forbid anonymous tuple return types so a
+# multi-value return is a named struct the reader understands at the call site,
+# not a positional `(i32, i32)`. Provided by the indexable-inc/clippy fork.
+anonymous_tuple_return_type = "deny"
 
 [workspace.dependencies]
 anstream = "1"

--- a/modules/services/resource-monitor/stats-writer/src/main.rs
+++ b/modules/services/resource-monitor/stats-writer/src/main.rs
@@ -249,7 +249,7 @@ fn iso_timestamp(time: SystemTime) -> Result<String, Box<dyn Error>> {
     let unix = time.duration_since(UNIX_EPOCH)?.as_secs() as i64;
     let days = unix.div_euclid(86_400);
     let seconds = unix.rem_euclid(86_400);
-    let (year, month, day) = civil_from_days(days);
+    let CivilDate { year, month, day } = civil_from_days(days);
     let hour = seconds / 3600;
     let minute = (seconds % 3600) / 60;
     let second = seconds % 60;
@@ -259,7 +259,14 @@ fn iso_timestamp(time: SystemTime) -> Result<String, Box<dyn Error>> {
     ))
 }
 
-const fn civil_from_days(days_since_epoch: i64) -> (i64, u32, u32) {
+/// A proleptic-Gregorian calendar date decomposed into year, month, and day.
+struct CivilDate {
+    year: i64,
+    month: u32,
+    day: u32,
+}
+
+const fn civil_from_days(days_since_epoch: i64) -> CivilDate {
     let z = days_since_epoch + 719_468;
     let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
     let day_of_era = z - era * 146_097;
@@ -272,5 +279,9 @@ const fn civil_from_days(days_since_epoch: i64) -> (i64, u32, u32) {
     let month = month_prime + if month_prime < 10 { 3 } else { -9 };
     let year = year + (month <= 2) as i64;
 
-    (year, month as u32, day as u32)
+    CivilDate {
+        year,
+        month: month as u32,
+        day: day as u32,
+    }
 }

--- a/packages/code-highlight/src/lib.rs
+++ b/packages/code-highlight/src/lib.rs
@@ -94,8 +94,8 @@ const HIGHLIGHT_NAMES: &[&str] = &[
     clippy::too_many_lines,
     reason = "flat one-arm-per-language dispatch table; splitting it would hide the grammar-to-query mapping"
 )]
-fn grammar_query(language: Language) -> Option<(tree_sitter::Language, String)> {
-    let pair = match language {
+fn grammar_query(language: Language) -> Option<GrammarQuery> {
+    let (ts_language, highlights) = match language {
         Language::Rust => (
             tree_sitter_rust::LANGUAGE.into(),
             tree_sitter_rust::HIGHLIGHTS_QUERY.to_owned(),
@@ -222,7 +222,15 @@ fn grammar_query(language: Language) -> Option<(tree_sitter::Language, String)> 
         // grammar here.
         _ => return None,
     };
-    Some(pair)
+    Some(GrammarQuery { ts_language, highlights })
+}
+
+/// A tree-sitter grammar paired with its highlights query source.
+struct GrammarQuery {
+    /// The tree-sitter language (grammar) to parse with.
+    ts_language: tree_sitter::Language,
+    /// The combined highlights query source for that grammar.
+    highlights: String,
 }
 
 /// Builds a [`HighlightConfiguration`] for a language, or `None` when the
@@ -232,7 +240,7 @@ fn grammar_query(language: Language) -> Option<(tree_sitter::Language, String)> 
 /// language per file and resolves no injections, so the queries would do nothing
 /// and only add per-grammar constant-name fragility.
 fn build_config(language: Language) -> Option<HighlightConfiguration> {
-    let (ts_language, highlights) = grammar_query(language)?;
+    let GrammarQuery { ts_language, highlights } = grammar_query(language)?;
     let mut config = HighlightConfiguration::new(ts_language, language.name(), &highlights, "", "")
         .inspect_err(|error| {
             // A query that fails to compile is a grammar-version skew bug, not a
@@ -323,8 +331,8 @@ fn parse_hex(hex: &str) -> Option<RgbColor> {
 /// colorscheme so the terminal and the editor color the same constructs alike;
 /// the colors themselves live only in `islands-theme.json`. Returns `None` for
 /// captures the theme leaves at the terminal default.
-fn slot_for_name(name: &str) -> Option<(&'static str, bool)> {
-    Some(match name {
+fn slot_for_name(name: &str) -> Option<SlotStyle> {
+    let (slot, italic) = match name {
         "keyword" | "constant.builtin" | "type.builtin" | "function.macro" | "label" => {
             ("keyword", false)
         }
@@ -346,7 +354,17 @@ fn slot_for_name(name: &str) -> Option<(&'static str, bool)> {
         "comment.documentation" => ("doc_comment", true),
         "constant" => ("constant", true),
         _ => return None,
-    })
+    };
+    Some(SlotStyle { slot, italic })
+}
+
+/// A palette slot name and whether captures mapped to it render italic.
+#[derive(Debug, Clone, Copy)]
+struct SlotStyle {
+    /// The islands palette slot key (a field in `islands-theme.json`).
+    slot: &'static str,
+    /// Whether the capture renders italic.
+    italic: bool,
 }
 
 /// Resolves the [`Style`] for a capture name in a theme variant, falling back
@@ -355,7 +373,7 @@ fn slot_for_name(name: &str) -> Option<(&'static str, bool)> {
 fn style_for(name: &str, theme: Theme) -> Style {
     let mut current = name;
     loop {
-        if let Some((slot, italic)) = slot_for_name(current) {
+        if let Some(SlotStyle { slot, italic }) = slot_for_name(current) {
             let style = slot_color(theme, slot)
                 .map_or_else(Style::new, |rgb| Style::new().fg_color(Some(Color::Rgb(rgb))));
             return if italic { style.italic() } else { style };
@@ -744,7 +762,7 @@ mod tests {
         // both palettes, or a capture would silently render uncolored. Guards
         // against a typo in the Rust map or a missing key in the JSON.
         for &name in HIGHLIGHT_NAMES {
-            if let Some((slot, _)) = slot_for_name(name) {
+            if let Some(SlotStyle { slot, .. }) = slot_for_name(name) {
                 assert!(
                     slot_color(Theme::Dark, slot).is_some(),
                     "dark palette missing slot {slot:?} for capture {name:?}"

--- a/packages/code-tokenizer/src/tests/basic.rs
+++ b/packages/code-tokenizer/src/tests/basic.rs
@@ -1,4 +1,9 @@
-use super::helpers::{tokenize, tokenize_full};
+use super::helpers::{TokenSpan, tokenize, tokenize_full};
+
+/// Build a [`TokenSpan`] from its parts for terse assertions.
+fn span(text: &str, position: usize, offset_from: usize, offset_to: usize) -> TokenSpan {
+    TokenSpan { text: text.to_string(), position, offset_from, offset_to }
+}
 
 #[test]
 fn camel_case() {
@@ -119,10 +124,7 @@ fn digit_prefix_splits_on_letter() {
 fn snake_case_token_shape() {
     assert_eq!(
         tokenize_full("hello_world"),
-        vec![
-            ("hello".to_string(), 0, 0, 5),
-            ("world".to_string(), 1, 6, 11),
-        ]
+        vec![span("hello", 0, 0, 5), span("world", 1, 6, 11)]
     );
 }
 
@@ -130,10 +132,7 @@ fn snake_case_token_shape() {
 fn camel_case_token_shape() {
     assert_eq!(
         tokenize_full("helloWorld"),
-        vec![
-            ("hello".to_string(), 0, 0, 5),
-            ("world".to_string(), 1, 5, 10),
-        ]
+        vec![span("hello", 0, 0, 5), span("world", 1, 5, 10)]
     );
 }
 
@@ -142,10 +141,10 @@ fn kebab_case_token_shape_four_tokens() {
     assert_eq!(
         tokenize_full("get-user-by-id"),
         vec![
-            ("get".to_string(), 0, 0, 3),
-            ("user".to_string(), 1, 4, 8),
-            ("by".to_string(), 2, 9, 11),
-            ("id".to_string(), 3, 12, 14),
+            span("get", 0, 0, 3),
+            span("user", 1, 4, 8),
+            span("by", 2, 9, 11),
+            span("id", 3, 12, 14),
         ]
     );
 }
@@ -157,14 +156,11 @@ fn multi_byte_chars_keep_byte_offsets() {
     // first token and the single-byte separator.
     assert_eq!(
         tokenize_full("héllo_wörld"),
-        vec![
-            ("héllo".to_string(), 0, 0, 6),
-            ("wörld".to_string(), 1, 7, 13),
-        ]
+        vec![span("héllo", 0, 0, 6), span("wörld", 1, 7, 13)]
     );
 }
 
 #[test]
 fn single_token_eof_branch_shape() {
-    assert_eq!(tokenize_full("hello"), vec![("hello".to_string(), 0, 0, 5)]);
+    assert_eq!(tokenize_full("hello"), vec![span("hello", 0, 0, 5)]);
 }

--- a/packages/code-tokenizer/src/tests/helpers.rs
+++ b/packages/code-tokenizer/src/tests/helpers.rs
@@ -11,21 +11,33 @@ pub fn tokenize(text: &str) -> Vec<String> {
     tokens
 }
 
-/// `(text, position, offset_from, offset_to)` for every emitted token, so
-/// tests can pin the byte spans that index queries and result highlighting
-/// rely on, not just the lowered token text.
-pub fn tokenize_full(text: &str) -> Vec<(String, usize, usize, usize)> {
+/// One emitted token's text and byte span, so tests can pin the offsets that
+/// index queries and result highlighting rely on, not just the lowered text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenSpan {
+    /// The lowered token text.
+    pub text: String,
+    /// The token's ordinal position in the stream.
+    pub position: usize,
+    /// Byte offset where the token starts in the source.
+    pub offset_from: usize,
+    /// Byte offset just past the token's end in the source.
+    pub offset_to: usize,
+}
+
+/// Collect a [`TokenSpan`] for every emitted token.
+pub fn tokenize_full(text: &str) -> Vec<TokenSpan> {
     let mut tokenizer = CodeTokenizer;
     let mut stream = tokenizer.token_stream(text);
     let mut tokens = Vec::new();
     while stream.advance() {
         let token = stream.token();
-        tokens.push((
-            token.text.clone(),
-            token.position,
-            token.offset_from,
-            token.offset_to,
-        ));
+        tokens.push(TokenSpan {
+            text: token.text.clone(),
+            position: token.position,
+            offset_from: token.offset_from,
+            offset_to: token.offset_to,
+        });
     }
     tokens
 }

--- a/packages/dag-runner/src/main.rs
+++ b/packages/dag-runner/src/main.rs
@@ -384,7 +384,8 @@ async fn run(
 
             report_started(&name_owned, started, mode, pb.as_ref());
             let node_started = Instant::now();
-            let (outcome, stdout, stderr) = run_command(&node, pb.as_ref(), cancel_for_task).await;
+            let CommandOutput { outcome, stdout, stderr } =
+                run_command(&node, pb.as_ref(), cancel_for_task).await;
             let duration = node_started.elapsed();
             report_finished(&name_owned, &outcome, duration, started, mode, pb.as_ref());
 
@@ -426,19 +427,26 @@ fn make_spinner(multi: &MultiProgress, name: &str) -> ProgressBar {
     pb
 }
 
+/// The result of running one node's command: its outcome and captured output.
+struct CommandOutput {
+    outcome: Outcome,
+    stdout: String,
+    stderr: String,
+}
+
 async fn run_command(
     node: &NodeSpec,
     pb: Option<&ProgressBar>,
     mut cancel_rx: tokio::sync::watch::Receiver<bool>,
-) -> (Outcome, String, String) {
+) -> CommandOutput {
     // If cancellation already fired (a later-spawning node sees the bit
     // before it ever reaches its select!), skip the work entirely.
     if *cancel_rx.borrow() {
-        return (
-            Outcome::Failed(130),
-            String::new(),
-            "dag-runner: cancelled\n".into(),
-        );
+        return CommandOutput {
+            outcome: Outcome::Failed(130),
+            stdout: String::new(),
+            stderr: "dag-runner: cancelled\n".into(),
+        };
     }
 
     let mut cmd = Command::new(&node.command[0]);
@@ -453,11 +461,11 @@ async fn run_command(
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            return (
-                Outcome::Failed(127),
-                String::new(),
-                format!("failed to spawn: {e}\n"),
-            );
+            return CommandOutput {
+                outcome: Outcome::Failed(127),
+                stdout: String::new(),
+                stderr: format!("failed to spawn: {e}\n"),
+            };
         }
     };
 
@@ -512,7 +520,7 @@ async fn run_command(
     let stdout = stdout_task.await.unwrap_or_default();
     let mut stderr = stderr_task.await.unwrap_or_default();
     stderr.push_str(&extra_stderr);
-    (outcome, stdout, stderr)
+    CommandOutput { outcome, stdout, stderr }
 }
 
 enum Completion {

--- a/packages/dag-runner/tests/integration.rs
+++ b/packages/dag-runner/tests/integration.rs
@@ -2,7 +2,14 @@ use std::process::Command;
 
 use serde_json::Value;
 
-fn run_binary(spec: &str) -> (std::process::Output, tempfile::TempDir) {
+/// The process output of one `dag-runner` invocation. Holds the temp dir so it
+/// outlives the run; the dir is deleted when this is dropped.
+struct RunResult {
+    output: std::process::Output,
+    _dir: tempfile::TempDir,
+}
+
+fn run_binary(spec: &str) -> RunResult {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("spec.json");
     std::fs::write(&path, spec).unwrap();
@@ -13,7 +20,7 @@ fn run_binary(spec: &str) -> (std::process::Output, tempfile::TempDir) {
         .arg(&path)
         .output()
         .expect("spawn dag-runner");
-    (output, dir)
+    RunResult { output, _dir: dir }
 }
 
 fn parse_events(stdout: &[u8]) -> Vec<Value> {
@@ -31,7 +38,7 @@ fn all_succeed_produces_zero_exit_and_finished_events() {
         "a":{"command":["true"]},
         "b":{"command":["true"],"depends_on":["a"]}
     }}"#;
-    let (output, _dir) = run_binary(spec);
+    let RunResult { output, _dir } = run_binary(spec);
     assert!(
         output.status.success(),
         "stderr: {}",
@@ -65,7 +72,7 @@ fn failed_dep_skips_downstream_with_exit_one() {
         "a":{"command":["false"]},
         "b":{"command":["true"],"depends_on":["a"]}
     }}"#;
-    let (output, _dir) = run_binary(spec);
+    let RunResult { output, _dir } = run_binary(spec);
     // `false` exits 1; skipped also contributes 1 → worst is 1.
     assert_eq!(output.status.code(), Some(1));
     let events = parse_events(&output.stdout);
@@ -85,7 +92,7 @@ fn skipped_node_reports_zero_json_duration_after_slow_failed_dep() {
         "a":{"command":["sh","-c","sleep 0.2; false"]},
         "b":{"command":["true"],"depends_on":["a"]}
     }}"#;
-    let (output, _dir) = run_binary(spec);
+    let RunResult { output, _dir } = run_binary(spec);
     assert_eq!(output.status.code(), Some(1));
     let events = parse_events(&output.stdout);
     let b = events
@@ -102,7 +109,7 @@ fn worst_failure_drives_exit_code() {
         "a":{"command":["sh","-c","exit 3"]},
         "b":{"command":["sh","-c","exit 9"]}
     }}"#;
-    let (output, _dir) = run_binary(spec);
+    let RunResult { output, _dir } = run_binary(spec);
     assert_eq!(output.status.code(), Some(9));
 }
 
@@ -111,7 +118,7 @@ fn env_overlay_is_visible_to_child() {
     let spec = r#"{"nodes":{
         "a":{"command":["sh","-c","test \"$DAG_RUNNER_TEST\" = wired"],"env":{"DAG_RUNNER_TEST":"wired"}}
     }}"#;
-    let (output, _dir) = run_binary(spec);
+    let RunResult { output, _dir } = run_binary(spec);
     assert!(
         output.status.success(),
         "stderr: {}",
@@ -170,7 +177,7 @@ fn env_value_with_equals_is_preserved() {
     let spec = r#"{"nodes":{
         "a":{"command":["sh","-c","test \"$DAG_RUNNER_TEST\" = 'a=b=c'"],"env":{"DAG_RUNNER_TEST":"a=b=c"}}
     }}"#;
-    let (output, _dir) = run_binary(spec);
+    let RunResult { output, _dir } = run_binary(spec);
     assert!(
         output.status.success(),
         "stderr: {}",
@@ -209,7 +216,7 @@ fn node_completes_before_timeout_succeeds() {
     let spec = r#"{"nodes":{
         "a":{"command":["true"],"timeout_secs":30}
     }}"#;
-    let (output, _dir) = run_binary(spec);
+    let RunResult { output, _dir } = run_binary(spec);
     assert!(
         output.status.success(),
         "stderr: {}",
@@ -223,7 +230,7 @@ fn cycle_is_rejected_before_running() {
         "a":{"command":["true"],"depends_on":["b"]},
         "b":{"command":["true"],"depends_on":["a"]}
     }}"#;
-    let (output, _dir) = run_binary(spec);
+    let RunResult { output, _dir } = run_binary(spec);
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -271,7 +278,7 @@ fn missing_dependency_is_rejected_before_running() {
     let spec = r#"{"nodes":{
         "a":{"command":["true"],"depends_on":["ghost"]}
     }}"#;
-    let (output, _dir) = run_binary(spec);
+    let RunResult { output, _dir } = run_binary(spec);
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -285,7 +292,7 @@ fn empty_command_is_rejected_before_running() {
     let spec = r#"{"nodes":{
         "a":{"command":[]}
     }}"#;
-    let (output, _dir) = run_binary(spec);
+    let RunResult { output, _dir } = run_binary(spec);
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(

--- a/packages/dashboard-core/src/dashboard/hub.rs
+++ b/packages/dashboard-core/src/dashboard/hub.rs
@@ -73,22 +73,32 @@ enum Scalar {
     Absent,
 }
 
+/// One scalar meta field a view contributes: the meta key and the value to
+/// reconcile under it.
+struct ScalarField {
+    /// The meta key this scalar is written under. Fixed per view kind.
+    name: &'static str,
+    /// The value to reconcile, including [`Scalar::Absent`] to clear the key.
+    value: Scalar,
+}
+
 /// The scalar meta fields a view contributes, besides the common `kind`,
 /// `created_at`, `title`, and `subtitle` that every pane carries.
 ///
 /// The keys a view returns are fixed for its kind, so a slot created for one
 /// kind always sees the same set on every later tick.
-fn view_scalars(view: &View) -> Vec<(&'static str, Scalar)> {
+fn view_scalars(view: &View) -> Vec<ScalarField> {
+    let field = |name, value| ScalarField { name, value };
     match view {
         View::Terminal(t) => vec![
-            ("rows", Scalar::Int(i64::from(t.rows))),
-            ("cols", Scalar::Int(i64::from(t.cols))),
-            ("alive", Scalar::Bool(t.alive)),
-            ("cursor_row", Scalar::Int(i64::from(t.cursor_row))),
-            ("cursor_col", Scalar::Int(i64::from(t.cursor_col))),
-            ("cursor_visible", Scalar::Bool(t.cursor_visible)),
-            ("cursor_shape", Scalar::Str(t.cursor_shape.clone())),
-            (
+            field("rows", Scalar::Int(i64::from(t.rows))),
+            field("cols", Scalar::Int(i64::from(t.cols))),
+            field("alive", Scalar::Bool(t.alive)),
+            field("cursor_row", Scalar::Int(i64::from(t.cursor_row))),
+            field("cursor_col", Scalar::Int(i64::from(t.cursor_col))),
+            field("cursor_visible", Scalar::Bool(t.cursor_visible)),
+            field("cursor_shape", Scalar::Str(t.cursor_shape.clone())),
+            field(
                 "exit_code",
                 t.exit_code
                     .map_or(Scalar::Absent, |code| Scalar::Int(i64::from(code))),
@@ -96,40 +106,50 @@ fn view_scalars(view: &View) -> Vec<(&'static str, Scalar)> {
         ],
         View::Html(_) => Vec::new(),
         View::Exec(e) => vec![
-            ("lang", Scalar::Str(e.lang.clone())),
-            ("running", Scalar::Bool(e.running)),
-            ("ok", e.ok.map_or(Scalar::Absent, Scalar::Bool)),
-            (
+            field("lang", Scalar::Str(e.lang.clone())),
+            field("running", Scalar::Bool(e.running)),
+            field("ok", e.ok.map_or(Scalar::Absent, Scalar::Bool)),
+            field(
                 "duration_ms",
                 e.duration_ms.map_or(Scalar::Absent, |ms| {
                     Scalar::Int(i64::try_from(ms).unwrap_or(i64::MAX))
                 }),
             ),
         ],
-        View::Data(d) => vec![("renderer", Scalar::Str(d.renderer.clone()))],
+        View::Data(d) => vec![field("renderer", Scalar::Str(d.renderer.clone()))],
     }
+}
+
+/// One large mutable text field a view contributes: the container key and the
+/// text to reconcile into it.
+struct TextField {
+    /// The text container key this field is stored under. Fixed per view kind.
+    name: &'static str,
+    /// The full text to reconcile into the container.
+    value: String,
 }
 
 /// The large mutable text fields a view contributes, each stored in its own Loro
 /// text container so it diffs and replays independently. The terminal's command
 /// and args are not here: they ride in the pane's title and subtitle, which
 /// every pane already has.
-fn view_texts(view: &View) -> Vec<(&'static str, String)> {
+fn view_texts(view: &View) -> Vec<TextField> {
+    let field = |name, value| TextField { name, value };
     match view {
-        View::Terminal(t) => vec![("body", t.screen.clone())],
-        View::Html(h) => vec![("body", h.html.clone())],
+        View::Terminal(t) => vec![field("body", t.screen.clone())],
+        View::Html(h) => vec![field("body", h.html.clone())],
         View::Exec(e) => vec![
-            ("source", e.source.clone()),
-            ("stdout", e.stdout.clone()),
-            ("stderr", e.stderr.clone()),
-            ("result", e.result.clone()),
+            field("source", e.source.clone()),
+            field("stdout", e.stdout.clone()),
+            field("stderr", e.stderr.clone()),
+            field("result", e.result.clone()),
             // Inline-trace output→line map, canonicalized to JSON text (like the
             // data view's body) so it diffs and replays; the frontend parses it.
-            ("trace", serde_json::to_string(&e.trace).unwrap_or_default()),
+            field("trace", serde_json::to_string(&e.trace).unwrap_or_default()),
         ],
         // A data view's JSON is canonicalized to text so it diffs and replays
         // like any other body; the frontend parses it back.
-        View::Data(d) => vec![("body", serde_json::to_string(&d.data).unwrap_or_default())],
+        View::Data(d) => vec![field("body", serde_json::to_string(&d.data).unwrap_or_default())],
     }
 }
 
@@ -285,14 +305,14 @@ impl DocState {
         // shows each resource's age with no producer opt-in.
         meta.insert("created_at", now_ms()).map_err(loro_err)?;
         let mut texts = Vec::new();
-        for (text_key, _) in view_texts(&pane.view) {
+        for field in view_texts(&pane.view) {
             let text = meta
-                .insert_container(text_key, LoroText::new())
+                .insert_container(field.name, LoroText::new())
                 .map_err(loro_err)?;
             // A fresh container is empty, so a cached empty value matches it and
             // the first update writes only a non-empty initial body.
             texts.push(TextSlot {
-                key: text_key,
+                key: field.name,
                 text,
                 value: String::new(),
             });
@@ -329,21 +349,21 @@ impl DocState {
                 .map_err(loro_err)?;
             slot.subtitle.clone_from(&pane.subtitle);
         }
-        for (field, scalar) in view_scalars(&pane.view) {
-            if slot.scalars.get(field) != Some(&scalar) {
-                write_scalar(&slot.meta, field, &scalar)?;
-                slot.scalars.insert(field, scalar);
+        for field in view_scalars(&pane.view) {
+            if slot.scalars.get(field.name) != Some(&field.value) {
+                write_scalar(&slot.meta, field.name, &field.value)?;
+                slot.scalars.insert(field.name, field.value);
             }
         }
-        for (field, next) in view_texts(&pane.view) {
+        for field in view_texts(&pane.view) {
             // Match by key rather than position: the key set is fixed per kind,
             // so the lookup always hits, and matching keeps the two projections
             // from silently drifting if one is reordered.
-            if let Some(text_slot) = slot.texts.iter_mut().find(|slot| slot.key == field)
-                && text_slot.value != next
+            if let Some(text_slot) = slot.texts.iter_mut().find(|slot| slot.key == field.name)
+                && text_slot.value != field.value
             {
-                set_text(&text_slot.text, &next)?;
-                text_slot.value = next;
+                set_text(&text_slot.text, &field.value)?;
+                text_slot.value = field.value;
             }
         }
         Ok(())
@@ -423,6 +443,16 @@ fn loro_err(source: impl std::fmt::Display) -> Error {
     }
 }
 
+/// A new subscriber's starting point: the current full snapshot taken under the
+/// hub lock, plus the live update stream whose first item lines up with it.
+pub(crate) struct Subscription {
+    /// The full document snapshot at subscribe time, for the client to import
+    /// before applying any update.
+    pub(crate) snapshot: Vec<u8>,
+    /// The base64 CRDT update stream, consistent with `snapshot`.
+    pub(crate) updates: broadcast::Receiver<Arc<str>>,
+}
+
 /// Owns the shared document and fans CRDT updates out to SSE subscribers.
 ///
 /// One hub backs any number of frame sources. The in-process dashboard drives it
@@ -468,10 +498,13 @@ impl Hub {
     /// Subscribe to the base64 CRDT update stream and read the current full
     /// snapshot, both under one lock so the snapshot version lines up with the
     /// first update the subscriber will receive.
-    pub(crate) fn subscribe(&self) -> (Vec<u8>, broadcast::Receiver<Arc<str>>) {
+    pub(crate) fn subscribe(&self) -> Subscription {
         let state = self.state.lock();
-        let rx = self.updates.subscribe();
-        (state.snapshot().unwrap_or_default(), rx)
+        let updates = self.updates.subscribe();
+        Subscription {
+            snapshot: state.snapshot().unwrap_or_default(),
+            updates,
+        }
     }
 
     /// A base64 full snapshot, for a client the broadcast stream outran.

--- a/packages/dashboard-core/src/dashboard/hub.rs
+++ b/packages/dashboard-core/src/dashboard/hub.rs
@@ -445,7 +445,7 @@ fn loro_err(source: impl std::fmt::Display) -> Error {
 
 /// A new subscriber's starting point: the current full snapshot taken under the
 /// hub lock, plus the live update stream whose first item lines up with it.
-pub(crate) struct Subscription {
+pub struct Subscription {
     /// The full document snapshot at subscribe time, for the client to import
     /// before applying any update.
     pub(crate) snapshot: Vec<u8>,

--- a/packages/dashboard-core/src/dashboard/mod.rs
+++ b/packages/dashboard-core/src/dashboard/mod.rs
@@ -26,8 +26,8 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 
 pub use hub::Hub;
-pub use recordings::{RecordingInfo, RecordingStore};
-pub use server::{Dashboard, serve_hub};
+pub use recordings::{Recorder, RecordingInfo, RecordingStore};
+pub use server::{Dashboard, ServedDashboard, serve_hub};
 
 /// Base64 for the SSE wire. One spelling shared by the snapshot and update
 /// encoders in [`server`].

--- a/packages/dashboard-core/src/dashboard/recordings.rs
+++ b/packages/dashboard-core/src/dashboard/recordings.rs
@@ -56,6 +56,16 @@ pub struct RecordingStore {
     dir: PathBuf,
 }
 
+/// The result of starting a periodic recorder: the new recording's id and the
+/// background task that keeps it current. The caller holds the task to tie its
+/// lifetime to the dashboard.
+pub struct Recorder {
+    /// The id of the recording being written (its filename stem).
+    pub id: String,
+    /// The spawned task that refreshes the snapshot on each interval.
+    pub task: JoinHandle<()>,
+}
+
 impl RecordingStore {
     /// Open (creating if needed) a store rooted at `dir`.
     ///
@@ -149,7 +159,7 @@ impl RecordingStore {
         hub: Arc<Hub>,
         interval: Duration,
         runtime: &tokio::runtime::Handle,
-    ) -> (String, JoinHandle<()>) {
+    ) -> Recorder {
         self.prune(KEEP_RECORDINGS.saturating_sub(1));
         let id = format!("{PREFIX}{}", now_ms());
         // Persist once up front so a session shorter than `interval` still
@@ -170,7 +180,7 @@ impl RecordingStore {
                 }
             }
         });
-        (id, task)
+        Recorder { id, task }
     }
 
     /// Resolve a safe on-disk path for a recording id, or `None` when the id is

--- a/packages/dashboard-core/src/dashboard/server.rs
+++ b/packages/dashboard-core/src/dashboard/server.rs
@@ -47,6 +47,17 @@ struct AppState {
     recordings: Option<Arc<RecordingStore>>,
 }
 
+/// What [`serve_hub`] hands back: the running dashboard plus the shutdown
+/// receiver the caller threads into its own frame-source tasks so one signal
+/// stops the whole dashboard.
+pub struct ServedDashboard {
+    /// The running dashboard handle.
+    pub dashboard: Dashboard,
+    /// Fires `true` when the dashboard is stopping; the caller's frame-source
+    /// tasks watch it to wind down with the server.
+    pub shutdown: watch::Receiver<bool>,
+}
+
 /// A running dashboard server. Dropping it, or calling [`Dashboard::stop`],
 /// shuts the HTTP server and every attached frame-source task down.
 pub struct Dashboard {
@@ -129,7 +140,7 @@ pub async fn serve_hub(
     addr: SocketAddr,
     recordings: Option<Arc<RecordingStore>>,
     runtime: &tokio::runtime::Handle,
-) -> Result<(Dashboard, watch::Receiver<bool>)> {
+) -> Result<ServedDashboard> {
     let listener = TcpListener::bind(addr)
         .await
         .map_err(|source| Error::Dashboard {
@@ -164,7 +175,10 @@ pub async fn serve_hub(
         shutdown: Some(shutdown),
         tasks: vec![http],
     };
-    Ok((dashboard, stop_rx))
+    Ok(ServedDashboard {
+        dashboard,
+        shutdown: stop_rx,
+    })
 }
 
 async fn index() -> Html<&'static str> {
@@ -194,8 +208,9 @@ async fn get_recording(
 async fn events(State(state): State<AppState>) -> impl IntoResponse {
     let hub = state.hub;
     // Loro imports are idempotent, so an overlapping snapshot/update is harmless.
-    let (snapshot, rx) = hub.subscribe();
+    let subscription = hub.subscribe();
 
+    let snapshot = subscription.snapshot;
     let first = futures::stream::once(async move {
         Ok::<_, Infallible>(
             Event::default()
@@ -204,7 +219,7 @@ async fn events(State(state): State<AppState>) -> impl IntoResponse {
         )
     });
 
-    let tail = BroadcastStream::new(rx).map(move |item| {
+    let tail = BroadcastStream::new(subscription.updates).map(move |item| {
         let event = match item {
             Ok(encoded) => Event::default().event("update").data(encoded.as_ref()),
             Err(BroadcastStreamRecvError::Lagged(_)) => {

--- a/packages/dashboard-core/src/lib.rs
+++ b/packages/dashboard-core/src/lib.rs
@@ -30,7 +30,9 @@ mod error;
 mod pane;
 mod publish;
 
-pub use dashboard::{Dashboard, Hub, RecordingInfo, RecordingStore, serve_hub};
+pub use dashboard::{
+    Dashboard, Hub, Recorder, RecordingInfo, RecordingStore, ServedDashboard, serve_hub,
+};
 pub use error::{Error, Result};
 pub use pane::{
     DataView, ExecTraceLine, ExecView, HtmlView, Pane, ProducerSnapshot, TerminalView, View,

--- a/packages/dashboard-core/tests/pipeline.rs
+++ b/packages/dashboard-core/tests/pipeline.rs
@@ -130,10 +130,10 @@ fn http_serves_page_and_lists_recordings() {
 
     let hub = Hub::new();
     let addr = "127.0.0.1:0".parse().unwrap();
-    let (dashboard, _stop) = runtime
+    let served = runtime
         .block_on(serve_hub(hub, addr, Some(store), runtime.handle()))
         .expect("serve");
-    let addr = dashboard.addr();
+    let addr = served.dashboard.addr();
 
     assert!(http_get(addr, "/").contains("ix"), "index page must render");
     let recordings = http_get(addr, "/recordings");

--- a/packages/dashboard/src/main.rs
+++ b/packages/dashboard/src/main.rs
@@ -105,8 +105,10 @@ async fn run_server(cli: &Cli) -> Result<(), Box<dyn std::error::Error>> {
 
     // The process runtime outlives the dashboard, so the server and discovery
     // loop spawned on it run for the lifetime of the binary.
-    let (mut dashboard, _stop_rx) =
-        serve_hub(hub.clone(), addr, recordings.clone(), &handle).await?;
+    let served = serve_hub(hub.clone(), addr, recordings.clone(), &handle).await?;
+    let mut dashboard = served.dashboard;
+    // Held until shutdown so the server keeps running for the binary's lifetime.
+    let _stop_rx = served.shutdown;
     println!(
         "dashboard: serving {}  (watching {})",
         dashboard.url(),
@@ -120,11 +122,15 @@ async fn run_server(cli: &Cli) -> Result<(), Box<dyn std::error::Error>> {
         .as_ref()
         .filter(|_| cli.record_ms > 0)
         .map(|store| {
-            let (id, recorder) =
+            let recorder =
                 store.spawn_recorder(hub.clone(), Duration::from_millis(cli.record_ms), &handle);
-            println!("dashboard: recording to {} ({id})", store.dir().display());
-            dashboard.push_task(recorder);
-            (store.clone(), id)
+            println!(
+                "dashboard: recording to {} ({})",
+                store.dir().display(),
+                recorder.id
+            );
+            dashboard.push_task(recorder.task);
+            (store.clone(), recorder.id)
         });
 
     let connected = Arc::new(Mutex::new(HashSet::new()));

--- a/packages/file-search/src/ephemeral.rs
+++ b/packages/file-search/src/ephemeral.rs
@@ -36,7 +36,7 @@ impl EphemeralSearch {
     /// Returns an error if the index, writer, or reader cannot be created,
     /// or if a document cannot be added or committed.
     pub fn from_texts(texts: impl IntoIterator<Item = String>) -> Result<Self> {
-        let (schema, id_field, content_field) = build_schema();
+        let EphemeralSchema { schema, id_field, content_field } = build_schema();
 
         let index = Index::builder()
             .schema(schema)
@@ -111,7 +111,14 @@ impl EphemeralSearch {
     }
 }
 
-fn build_schema() -> (Schema, Field, Field) {
+/// The ephemeral index schema together with handles to its two fields.
+struct EphemeralSchema {
+    schema: Schema,
+    id_field: Field,
+    content_field: Field,
+}
+
+fn build_schema() -> EphemeralSchema {
     let text_indexing = TextFieldIndexing::default()
         .set_tokenizer(code_tokenizer::CODE_STEMMED_TOKENIZER)
         .set_index_option(IndexRecordOption::WithFreqsAndPositions);
@@ -123,5 +130,9 @@ fn build_schema() -> (Schema, Field, Field) {
     let mut builder = Schema::builder();
     let id_field = builder.add_u64_field("id", STORED);
     let content_field = builder.add_text_field("content", text_options);
-    (builder.build(), id_field, content_field)
+    EphemeralSchema {
+        schema: builder.build(),
+        id_field,
+        content_field,
+    }
 }

--- a/packages/file-search/src/indexing.rs
+++ b/packages/file-search/src/indexing.rs
@@ -24,9 +24,18 @@ pub fn directory_term(path: &Path) -> String {
     s
 }
 
-pub fn chunk_content(content: &str) -> Vec<(usize, String)> {
+/// One chunk of a file's content: its starting byte offset and the chunk text.
+pub struct ContentChunk {
+    pub offset: usize,
+    pub text: String,
+}
+
+pub fn chunk_content(content: &str) -> Vec<ContentChunk> {
     if content.len() <= CHUNK_SIZE {
-        return vec![(0, content.to_string())];
+        return vec![ContentChunk {
+            offset: 0,
+            text: content.to_string(),
+        }];
     }
 
     // Materialize char boundaries once so each chunk's end + next-start lookup
@@ -53,7 +62,10 @@ pub fn chunk_content(content: &str) -> Vec<(usize, String)> {
     while offset < content.len() {
         let end = aligned(offset + CHUNK_SIZE);
         let chunk = content.get(offset..end).unwrap_or("");
-        chunks.push((offset, chunk.to_string()));
+        chunks.push(ContentChunk {
+            offset,
+            text: chunk.to_string(),
+        });
 
         if end >= content.len() {
             break;
@@ -183,12 +195,12 @@ fn index_file(writer: &IndexWriter, schema: &IndexSchema, file_path: &Path) -> R
     // `schema.path` would silently no-op because that field is stemmed.
     writer.delete_term(Term::from_field_text(schema.path_exact, &path_str));
 
-    for (offset, chunk) in chunk_content(&content) {
+    for ContentChunk { offset, text } in chunk_content(&content) {
         writer
             .add_document(doc!(
                 schema.path => path_str.clone(),
                 schema.path_exact => path_str.clone(),
-                schema.content => chunk,
+                schema.content => text,
                 schema.filename => filename,
                 schema.chunk_offset => offset as u64,
                 schema.directory => directory_value.clone(),

--- a/packages/git-log-pretty/src/avatar.rs
+++ b/packages/git-log-pretty/src/avatar.rs
@@ -34,7 +34,7 @@ pub struct Avatar {
 pub struct Resolver {
     client: Client,
     /// `owner/repo` parsed from the `origin` remote, if it is a GitHub remote.
-    origin: Option<(String, String)>,
+    origin: Option<github_avatar::RepoSlug>,
     /// Explicit `email -> login` overrides from `git config githubLogin.map`.
     identities: HashMap<String, String>,
     size_px: u32,
@@ -119,7 +119,7 @@ impl Resolver {
     }
 
     async fn resolve_via_commit(&self, sha: &str) -> Option<String> {
-        let (owner, repo) = self.origin.as_ref()?;
+        let github_avatar::RepoSlug { owner, repo } = self.origin.as_ref()?;
         self.client
             .resolve_commit(owner, repo, sha)
             .await

--- a/packages/git-log-pretty/src/display.rs
+++ b/packages/git-log-pretty/src/display.rs
@@ -65,9 +65,17 @@ fn format_summary(summary: &str, theme: Theme) -> String {
     )
 }
 
+/// A commit's two rendered pieces: the header line and the changed-file tree.
+struct CommitBlock {
+    /// The `shorthash summary • when` header line.
+    header: String,
+    /// The indented changed-file tree, possibly empty.
+    tree: String,
+}
+
 /// Build a commit's two rendered pieces: the `shorthash summary • when` header
 /// line and the (possibly empty) indented changed-file tree.
-fn commit_block(ahead: &git::AheadCommit<'_>, theme: Theme) -> color_eyre::eyre::Result<(String, String)> {
+fn commit_block(ahead: &git::AheadCommit<'_>, theme: Theme) -> color_eyre::eyre::Result<CommitBlock> {
     let commit = &ahead.commit;
     let short = commit.id().to_string().chars().take(7).collect::<String>();
     let summary = commit.summary().unwrap_or("<no message>").trim();
@@ -84,7 +92,7 @@ fn commit_block(ahead: &git::AheadCommit<'_>, theme: Theme) -> color_eyre::eyre:
         when = palette::paint(dim, &when),
     );
     let icons = tree::render(&ahead.changed_files, theme);
-    Ok((header, icons))
+    Ok(CommitBlock { header, tree: icons })
 }
 
 /// Write the plain header / tree / blank-line form (no avatar).
@@ -104,7 +112,7 @@ pub fn print_commit(
     ahead: &git::AheadCommit<'_>,
     theme: Theme,
 ) -> color_eyre::eyre::Result<()> {
-    let (header, icons) = commit_block(ahead, theme)?;
+    let CommitBlock { header, tree: icons } = commit_block(ahead, theme)?;
     write_plain(out, &header, &icons)
 }
 
@@ -133,7 +141,7 @@ pub fn print_commit_with_avatar(
     avatar: Option<&Avatar>,
     rows: u32,
 ) -> color_eyre::eyre::Result<()> {
-    let (header, icons) = commit_block(ahead, theme)?;
+    let CommitBlock { header, tree: icons } = commit_block(ahead, theme)?;
 
     let Some(avatar) = avatar.filter(|_| rows > 0) else {
         return write_plain(out, &header, &icons);

--- a/packages/git-log-pretty/tests/integration.rs
+++ b/packages/git-log-pretty/tests/integration.rs
@@ -6,11 +6,17 @@ use std::process::Command;
 use git2::{Repository, Signature};
 use tempfile::TempDir;
 
-/// Initialize a repo whose first commit sits on `main`, returning the open repo,
-/// the temp dir (kept alive for the test), the test signature, and the `main`
-/// commit oid. `git init`'s default branch name varies, so HEAD is forced to
-/// `refs/heads/main` before the first commit lands.
-fn init_on_main() -> (Repository, TempDir, git2::Oid) {
+/// A repo whose first commit sits on `main`: the open repo, its temp dir (kept
+/// alive for the test), and the initial `main` commit oid.
+struct MainRepo {
+    repo: Repository,
+    dir: TempDir,
+    main_oid: git2::Oid,
+}
+
+/// Initialize a [`MainRepo`]. `git init`'s default branch name varies, so HEAD is
+/// forced to `refs/heads/main` before the first commit lands.
+fn init_on_main() -> MainRepo {
     let dir = tempfile::tempdir().expect("tempdir");
     let repo = Repository::init(dir.path()).expect("init repo");
     repo.set_head("refs/heads/main").expect("point HEAD at main");
@@ -19,13 +25,21 @@ fn init_on_main() -> (Repository, TempDir, git2::Oid) {
     std::fs::write(dir.path().join("README.md"), "hello\n").unwrap();
     let main_oid = commit(&repo, &sig, &["README.md"], "chore: initial commit", &[]);
 
-    (repo, dir, main_oid)
+    MainRepo {
+        repo,
+        dir,
+        main_oid,
+    }
 }
 
 /// Build a repo with one commit on `main` and a feature commit checked out on a
 /// branch that is one commit ahead.
 fn repo_ahead_of_main() -> TempDir {
-    let (repo, dir, main_oid) = init_on_main();
+    let MainRepo {
+        repo,
+        dir,
+        main_oid,
+    } = init_on_main();
     let sig = signature();
 
     let main_commit = repo.find_commit(main_oid).unwrap();
@@ -111,7 +125,7 @@ fn no_pager_flag_is_accepted_and_renders_log() {
 fn log_shows_recent_history_on_main() {
     // On `main` there is nothing to be ahead of, so the default view lists
     // main's own recent commits rather than reporting "caught up".
-    let (_repo, dir, _main_oid) = init_on_main();
+    let MainRepo { dir, .. } = init_on_main();
 
     let output = run(dir.path(), &[]);
     assert!(output.status.success(), "stderr: {}", plain(&output.stderr));
@@ -125,7 +139,11 @@ fn log_shows_recent_history_on_main() {
 fn log_reports_caught_up_off_main_when_level_with_main() {
     // A non-main branch sitting exactly at main has no ahead commits, so the
     // caught-up message still applies there.
-    let (repo, dir, main_oid) = init_on_main();
+    let MainRepo {
+        repo,
+        dir,
+        main_oid,
+    } = init_on_main();
     let main_commit = repo.find_commit(main_oid).unwrap();
     repo.branch("feature", &main_commit, false).expect("create feature");
     repo.set_head("refs/heads/feature").expect("checkout feature");
@@ -139,7 +157,11 @@ fn log_reports_caught_up_off_main_when_level_with_main() {
 fn diff_uses_merge_base_after_main_advances() {
     // main advances past the branch point. The branch only touched src/lib.rs,
     // so the `main...HEAD` diff must not include main-only files.
-    let (repo, dir, main_oid) = init_on_main();
+    let MainRepo {
+        repo,
+        dir,
+        main_oid,
+    } = init_on_main();
     let sig = signature();
 
     let main_commit = repo.find_commit(main_oid).unwrap();

--- a/packages/github-avatar/src/lib.rs
+++ b/packages/github-avatar/src/lib.rs
@@ -98,12 +98,21 @@ pub fn is_valid_login(login: &str) -> bool {
         && login.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
 }
 
-/// Parse `owner` and `repo` from a GitHub remote URL (https or ssh forms).
+/// An `owner/repo` pair identifying a GitHub repository.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoSlug {
+    /// The repository owner (user or org).
+    pub owner: String,
+    /// The repository name.
+    pub repo: String,
+}
+
+/// Parse the [`RepoSlug`] from a GitHub remote URL (https or ssh forms).
 ///
 /// Returns `None` for non-GitHub remotes, so callers can skip the commit-author
 /// lookup entirely off GitHub.
 #[must_use]
-pub fn parse_remote(url: &str) -> Option<(String, String)> {
+pub fn parse_remote(url: &str) -> Option<RepoSlug> {
     let url = url.trim();
     let url = url.strip_suffix(".git").unwrap_or(url);
     let rest = url
@@ -112,7 +121,8 @@ pub fn parse_remote(url: &str) -> Option<(String, String)> {
         .or_else(|| url.strip_prefix("ssh://git@github.com/"))
         .or_else(|| url.strip_prefix("git@github.com:"))?;
     let (owner, repo) = rest.split_once('/')?;
-    (!owner.is_empty() && !repo.is_empty()).then(|| (owner.to_string(), repo.to_string()))
+    (!owner.is_empty() && !repo.is_empty())
+        .then(|| RepoSlug { owner: owner.to_string(), repo: repo.to_string() })
 }
 
 /// Authenticated response for `GET /repos/{owner}/{repo}/commits/{sha}`; only
@@ -229,7 +239,7 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
-    use super::{User, is_valid_login, parse_noreply, parse_remote};
+    use super::{RepoSlug, User, is_valid_login, parse_noreply, parse_remote};
 
     #[test]
     fn noreply_with_and_without_id() {
@@ -264,7 +274,7 @@ mod tests {
 
     #[test]
     fn remote_https_and_ssh() {
-        let want = Some(("indexable-inc".to_string(), "index".to_string()));
+        let want = Some(RepoSlug { owner: "indexable-inc".to_string(), repo: "index".to_string() });
         assert_eq!(parse_remote("https://github.com/indexable-inc/index.git"), want);
         assert_eq!(parse_remote("https://github.com/indexable-inc/index"), want);
         assert_eq!(parse_remote("git@github.com:indexable-inc/index.git"), want);

--- a/packages/indexbench/src/macro_harness.rs
+++ b/packages/indexbench/src/macro_harness.rs
@@ -156,7 +156,7 @@ fn run_once(program: &str, args: &[String]) -> crate::Result<RunSample> {
     }
     let stderr_buf = stderr_reader.join().unwrap_or_default();
 
-    let (raw_status, max_rss) = wait4(child.id() as i32, program)?;
+    let Reaped { raw_status, max_rss } = wait4(child.id() as i32, program)?;
     let wall_clock_ns = start.elapsed().as_nanos() as f64;
     let max_rss_bytes = maxrss_to_bytes(max_rss);
 
@@ -176,8 +176,16 @@ fn run_once(program: &str, args: &[String]) -> crate::Result<RunSample> {
     })
 }
 
-/// Reap `pid` with `wait4`, returning `(raw_wait_status, ru_maxrss_kib)`.
-fn wait4(pid: i32, program: &str) -> crate::Result<(i32, i64)> {
+/// What `wait4` reaped from a child: its raw wait status and peak RSS.
+struct Reaped {
+    /// Raw `wait` status, to be classified by [`check_exit_status`].
+    raw_status: i32,
+    /// `ru_maxrss` as reported by the platform (kibibytes on Linux, bytes on macOS).
+    max_rss: i64,
+}
+
+/// Reap `pid` with `wait4`.
+fn wait4(pid: i32, program: &str) -> crate::Result<Reaped> {
     // SAFETY: `rusage` is plain C data with no invalid bit patterns, so a zeroed
     // value is a valid initial state for `wait4` to fill.
     let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
@@ -195,7 +203,10 @@ fn wait4(pid: i32, program: &str) -> crate::Result<(i32, i64)> {
         .fail();
     }
 
-    Ok((status, usage.ru_maxrss))
+    Ok(Reaped {
+        raw_status: status,
+        max_rss: usage.ru_maxrss,
+    })
 }
 
 /// Convert `wait4`'s `ru_maxrss` to bytes.

--- a/packages/indexbench/src/main.rs
+++ b/packages/indexbench/src/main.rs
@@ -138,7 +138,7 @@ struct AssertArgs {
     /// Fails when the measured metric exceeds the budget, or when the command
     /// never reports the named metric.
     #[arg(long = "max", value_name = "METRIC=VALUE", value_parser = parse_budget)]
-    max: Vec<(String, f64)>,
+    max: Vec<Budget>,
     /// How many times to run the command. Defaults to 1 so a deterministic
     /// metric (an allocation count) stays deterministic; raise it only to budget
     /// a distribution's median.
@@ -268,14 +268,26 @@ fn ensure_cmd_names(args: &RunArgs) -> Result<()> {
     Ok(())
 }
 
+/// An upper-bound budget for one metric, parsed from a `METRIC=VALUE` argument.
+#[derive(Debug, Clone)]
+struct Budget {
+    /// The metric name to gate.
+    metric: String,
+    /// The inclusive upper bound the metric must not exceed.
+    limit: f64,
+}
+
 /// Parse a `METRIC=VALUE` budget for `assert --max`.
-fn parse_budget(raw: &str) -> std::result::Result<(String, f64), String> {
+fn parse_budget(raw: &str) -> std::result::Result<Budget, String> {
     let (name, value) = raw.split_once('=').ok_or_else(|| format!("`{raw}` is not METRIC=VALUE"))?;
     if name.is_empty() {
         return Err(format!("`{raw}` has an empty metric name"));
     }
     let parsed: f64 = value.parse().map_err(|err| format!("budget `{value}`: {err}"))?;
-    Ok((name.to_owned(), parsed))
+    Ok(Budget {
+        metric: name.to_owned(),
+        limit: parsed,
+    })
 }
 
 /// Run a command and gate each measured metric against its declared upper-bound
@@ -298,7 +310,7 @@ fn assert_budgets(args: &AssertArgs) -> Result<ExitCode> {
     let metrics = indexbench::macro_harness::run_command(&program, &cmd_args, args.runs)?;
 
     let mut all_within = true;
-    for (name, budget) in &args.max {
+    for Budget { metric: name, limit: budget } in &args.max {
         if let Some(metric) = metrics.iter().find(|metric| &metric.name == name) {
             let within = metric.value <= *budget;
             all_within &= within;

--- a/packages/ix-dev-diagnose/src/main.rs
+++ b/packages/ix-dev-diagnose/src/main.rs
@@ -368,7 +368,10 @@ fn run(args: &Args) -> Result<Report> {
     let port = url.port_or_known_default().unwrap_or(443);
     let path_and_query = path_and_query(&url);
     let trust_roots = build_root_verifiers()?;
-    let (addresses, dns_error) = resolve_addresses(&host, port, args.family);
+    let AddressResolution {
+        addresses,
+        error: dns_error,
+    } = resolve_addresses(&host, port, args.family);
     let address_reports = addresses.iter().copied().map(AddressReport::from).collect();
 
     let target = TargetReport {
@@ -451,11 +454,13 @@ fn build_root_verifiers() -> Result<RootVerifiers> {
     })
 }
 
-fn resolve_addresses(
-    host: &str,
-    port: u16,
-    family: AddressFamily,
-) -> (Vec<SocketAddr>, Option<String>) {
+/// Outcome of resolving a host to socket addresses, with any DNS error captured.
+struct AddressResolution {
+    addresses: Vec<SocketAddr>,
+    error: Option<String>,
+}
+
+fn resolve_addresses(host: &str, port: u16, family: AddressFamily) -> AddressResolution {
     match (host, port).to_socket_addrs() {
         Ok(addrs) => {
             let addresses = addrs
@@ -463,9 +468,15 @@ fn resolve_addresses(
                 .collect::<BTreeSet<_>>()
                 .into_iter()
                 .collect::<Vec<_>>();
-            (addresses, None)
+            AddressResolution {
+                addresses,
+                error: None,
+            }
         }
-        Err(error) => (Vec::new(), Some(error.to_string())),
+        Err(error) => AddressResolution {
+            addresses: Vec::new(),
+            error: Some(error.to_string()),
+        },
     }
 }
 
@@ -710,7 +721,11 @@ fn parse_http_response(
     read_limit_reached: bool,
     elapsed_ms: u64,
 ) -> HttpReport {
-    let Some((header_start, header_end)) = final_header_block(response) else {
+    let Some(HeaderBlock {
+        start: header_start,
+        end: header_end,
+    }) = final_header_block(response)
+    else {
         return HttpReport::Failed {
             elapsed_ms,
             error: "response did not contain complete HTTP headers".to_owned(),
@@ -722,7 +737,11 @@ fn parse_http_response(
     let body_start = header_end + 4;
     let body = response.get(body_start..).unwrap_or_default();
     let body_sample = &body[..body.len().min(max_body_bytes)];
-    let (status_code, reason, headers) = parse_headers(header_bytes);
+    let ParsedHeaders {
+        status_code,
+        reason,
+        headers,
+    } = parse_headers(header_bytes);
 
     HttpReport::Completed {
         elapsed_ms,
@@ -740,10 +759,27 @@ fn parse_http_response(
     }
 }
 
-fn parse_headers(header_bytes: &[u8]) -> (Option<u16>, Option<String>, Vec<HttpHeader>) {
+/// Status code and reason phrase parsed from an HTTP status line.
+#[derive(Default)]
+struct StatusLine {
+    status_code: Option<u16>,
+    reason: Option<String>,
+}
+
+/// HTTP response head: the status line fields plus the parsed header list.
+struct ParsedHeaders {
+    status_code: Option<u16>,
+    reason: Option<String>,
+    headers: Vec<HttpHeader>,
+}
+
+fn parse_headers(header_bytes: &[u8]) -> ParsedHeaders {
     let header_text = String::from_utf8_lossy(header_bytes);
     let mut lines = header_text.split("\r\n");
-    let (status_code, reason) = lines.next().map_or((None, None), parse_status_line);
+    let StatusLine {
+        status_code,
+        reason,
+    } = lines.next().map(parse_status_line).unwrap_or_default();
     let headers = lines
         .filter_map(|line| {
             let (name, value) = line.split_once(':')?;
@@ -754,29 +790,46 @@ fn parse_headers(header_bytes: &[u8]) -> (Option<u16>, Option<String>, Vec<HttpH
         })
         .collect();
 
-    (status_code, reason, headers)
+    ParsedHeaders {
+        status_code,
+        reason,
+        headers,
+    }
 }
 
-fn parse_status_line(line: &str) -> (Option<u16>, Option<String>) {
+fn parse_status_line(line: &str) -> StatusLine {
     let mut parts = line.splitn(3, ' ');
     let _version = parts.next();
     let status_code = parts.next().and_then(|code| code.parse().ok());
     let reason = parts.next().map(str::to_owned);
-    (status_code, reason)
+    StatusLine {
+        status_code,
+        reason,
+    }
 }
 
-fn final_header_block(response: &[u8]) -> Option<(usize, usize)> {
+/// Byte offsets bounding the final HTTP header block within a response buffer.
+#[derive(Clone, Copy)]
+struct HeaderBlock {
+    start: usize,
+    end: usize,
+}
+
+fn final_header_block(response: &[u8]) -> Option<HeaderBlock> {
     let mut header_start = 0;
     loop {
         let header_end = header_start + find_header_end(&response[header_start..])?;
         let header_bytes = &response[header_start..header_end];
-        let (status_code, _reason, _headers) = parse_headers(header_bytes);
+        let ParsedHeaders { status_code, .. } = parse_headers(header_bytes);
         if matches!(status_code, Some(100..=199)) {
             header_start = header_end + 4;
             continue;
         }
 
-        return Some((header_start, header_end));
+        return Some(HeaderBlock {
+            start: header_start,
+            end: header_end,
+        });
     }
 }
 
@@ -792,11 +845,19 @@ fn eof_completes_response(response: &[u8]) -> bool {
 }
 
 fn response_framing(response: &[u8]) -> ResponseFraming {
-    let Some((header_start, header_end)) = final_header_block(response) else {
+    let Some(HeaderBlock {
+        start: header_start,
+        end: header_end,
+    }) = final_header_block(response)
+    else {
         return ResponseFraming::Incomplete;
     };
     let header_bytes = &response[header_start..header_end];
-    let (status_code, _reason, headers) = parse_headers(header_bytes);
+    let ParsedHeaders {
+        status_code,
+        headers,
+        ..
+    } = parse_headers(header_bytes);
     if matches!(status_code, Some(204 | 205 | 304)) {
         return ResponseFraming::Complete;
     }

--- a/packages/kitty/src/lib.rs
+++ b/packages/kitty/src/lib.rs
@@ -289,18 +289,27 @@ mod tests {
     };
     use base64::Engine;
 
-    fn single_command(sequence: &str) -> (&str, &str) {
+    /// The control and payload halves of one APC graphics command.
+    struct Command<'a> {
+        /// The `key=value;...` control fields before the `;`.
+        control: &'a str,
+        /// The base64 image payload after the `;`.
+        payload: &'a str,
+    }
+
+    fn single_command(sequence: &str) -> Command<'_> {
         let body = sequence
             .strip_prefix(APC_START)
             .and_then(|rest| rest.strip_suffix(ST))
             .expect("framed as one APC command");
-        body.split_once(';').expect("control;payload")
+        let (control, payload) = body.split_once(';').expect("control;payload");
+        Command { control, payload }
     }
 
     #[test]
     fn png_single_chunk_has_control_and_payload() {
         let sequence = transmit(&Image::Png(b"hello"), None, &Placement::default());
-        let (control, payload) = single_command(&sequence);
+        let Command { control, payload } = single_command(&sequence);
         assert!(control.contains("a=T"));
         assert!(control.contains("f=100"));
         assert!(control.contains("q=2"));
@@ -324,7 +333,7 @@ mod tests {
                 move_cursor: false,
             },
         );
-        let (control, _) = single_command(&sequence);
+        let Command { control, .. } = single_command(&sequence);
         for key in ["f=32", "s=2", "v=2", "i=7", "c=4", "r=2", "C=1"] {
             assert!(control.contains(key), "missing {key} in {control}");
         }
@@ -351,7 +360,7 @@ mod tests {
     #[test]
     fn virtual_transmit_marks_unicode_placement() {
         let sequence = transmit_virtual(&Image::Png(b"hello"), 42, 4, 2);
-        let (control, payload) = single_command(&sequence);
+        let Command { control, payload } = single_command(&sequence);
         // U=1 makes the placement virtual; q=2 silences acknowledgements.
         for key in ["a=T", "U=1", "f=100", "i=42", "c=4", "r=2", "q=2", "m=0"] {
             assert!(control.contains(key), "missing {key} in {control}");

--- a/packages/minecraft/sound/src/assets.rs
+++ b/packages/minecraft/sound/src/assets.rs
@@ -385,8 +385,14 @@ mod tests {
     /// otherwise share an address and collide under `{:p}`.
     static TEST_DIR_SEQ: AtomicU64 = AtomicU64::new(0);
 
+    /// A `Bundled` backend over a temp dir, paired with that dir's path for cleanup.
+    struct BundledFixture {
+        assets: MinecraftAssets,
+        root: PathBuf,
+    }
+
     /// Build a `Bundled` backend over a fresh temp dir holding `.ogg` files.
-    fn bundled_with(names: &[&str]) -> (MinecraftAssets, PathBuf) {
+    fn bundled_with(names: &[&str]) -> BundledFixture {
         let seq = TEST_DIR_SEQ.fetch_add(1, Ordering::Relaxed);
         let unique = format!("mcsound-test-{}-{seq}", std::process::id());
         let root = env::temp_dir().join(unique);
@@ -398,12 +404,15 @@ mod tests {
             }
             fs::write(&path, b"ogg").expect("write file");
         }
-        (MinecraftAssets::Bundled { root: root.clone() }, root)
+        BundledFixture {
+            assets: MinecraftAssets::Bundled { root: root.clone() },
+            root,
+        }
     }
 
     #[test]
     fn unknown_name_is_an_error() {
-        let (assets, root) = bundled_with(&["mob/zombie/death", "block/stone/break"]);
+        let BundledFixture { assets, root } = bundled_with(&["mob/zombie/death", "block/stone/break"]);
         let err = assets
             .resolve_sound("this/does/not/exist")
             .expect_err("unknown sound must error");
@@ -420,7 +429,7 @@ mod tests {
 
     #[test]
     fn known_name_resolves() {
-        let (assets, root) = bundled_with(&["mob/zombie/death"]);
+        let BundledFixture { assets, root } = bundled_with(&["mob/zombie/death"]);
         let path = assets
             .resolve_sound("mob/zombie/death")
             .expect("known sound resolves");
@@ -430,7 +439,7 @@ mod tests {
 
     #[test]
     fn close_typo_is_suggested() {
-        let (assets, root) = bundled_with(&["mob/zombie/death"]);
+        let BundledFixture { assets, root } = bundled_with(&["mob/zombie/death"]);
         let err = assets
             .resolve_sound("mob/zombie/deaht")
             .expect_err("typo must error");

--- a/packages/minecraft/sync-managed/src/main.rs
+++ b/packages/minecraft/sync-managed/src/main.rs
@@ -118,10 +118,23 @@ fn collect_managed_files(root: &Path, dir: &Path, files: &mut Vec<String>) -> Re
     Ok(())
 }
 
-fn manifest_entry(line: &str) -> (&str, Option<&str>) {
+/// A parsed manifest line: the relative path and an optional absolute source target.
+#[derive(Debug, PartialEq, Eq)]
+struct ManifestEntry<'a> {
+    rel: &'a str,
+    target: Option<&'a str>,
+}
+
+fn manifest_entry(line: &str) -> ManifestEntry<'_> {
     match line.rsplit_once(' ') {
-        Some((rel, target)) if Path::new(target).is_absolute() => (rel, Some(target)),
-        _ => (line, None),
+        Some((rel, target)) if Path::new(target).is_absolute() => ManifestEntry {
+            rel,
+            target: Some(target),
+        },
+        _ => ManifestEntry {
+            rel: line,
+            target: None,
+        },
     }
 }
 
@@ -153,7 +166,7 @@ fn sync_tree(
     }
 
     for (i, line) in read_manifest_lines(manifest)?.into_iter().enumerate() {
-        let (rel, _) = manifest_entry(&line);
+        let ManifestEntry { rel, .. } = manifest_entry(&line);
         if rel.is_empty() || preserve_removed.contains(rel) {
             continue;
         }
@@ -215,7 +228,7 @@ fn sync_tree(
 
 fn managed_target_for(manifest: &Path, rel: &str) -> Result<Option<String>> {
     for line in read_manifest_lines(manifest)? {
-        let (entry_rel, target) = manifest_entry(&line);
+        let ManifestEntry { rel: entry_rel, target } = manifest_entry(&line);
         if entry_rel == rel
             && let Some(target) = target
         {
@@ -341,7 +354,7 @@ fn plan_dropin_reloads(config: &Config, plan: &mut BTreeSet<ReloadEntry>) -> Res
     }
 
     for line in read_manifest_lines(&dropin_manifest)? {
-        let (rel, _) = manifest_entry(&line);
+        let ManifestEntry { rel, .. } = manifest_entry(&line);
         if !is_jar_path(rel) || rel == "PlugManX.jar" {
             continue;
         }
@@ -392,7 +405,7 @@ fn plan_server_file_reloads(config: &Config, plan: &mut BTreeSet<ReloadEntry>) -
     }
 
     for line in read_manifest_lines(&server_manifest)? {
-        let (rel, _) = manifest_entry(&line);
+        let ManifestEntry { rel, .. } = manifest_entry(&line);
         let Some(plugin) = plugin_name_from_config_path(rel) else {
             continue;
         };
@@ -785,15 +798,24 @@ mod tests {
     fn manifest_entry_keeps_legacy_paths_with_spaces() {
         assert_eq!(
             manifest_entry("plugins/Foo Bar.yml /nix/store/source"),
-            ("plugins/Foo Bar.yml", Some("/nix/store/source"))
+            ManifestEntry {
+                rel: "plugins/Foo Bar.yml",
+                target: Some("/nix/store/source"),
+            }
         );
         assert_eq!(
             manifest_entry("plugins/Foo;Bar.yml"),
-            ("plugins/Foo;Bar.yml", None)
+            ManifestEntry {
+                rel: "plugins/Foo;Bar.yml",
+                target: None,
+            }
         );
         assert_eq!(
             manifest_entry("plugins/Foo Bar.yml"),
-            ("plugins/Foo Bar.yml", None)
+            ManifestEntry {
+                rel: "plugins/Foo Bar.yml",
+                target: None,
+            }
         );
     }
 

--- a/packages/mixedbread/src/lib.rs
+++ b/packages/mixedbread/src/lib.rs
@@ -756,6 +756,12 @@ mod tests {
 
     use super::{BACKOFF_BASE, BACKOFF_CAP, Chunk, Client, Error, MAX_RETRIES, RawChunk, backoff};
 
+    /// A spawned test server: its base URL and a shared counter of requests it received.
+    struct MockServer {
+        base_url: String,
+        calls: Arc<AtomicUsize>,
+    }
+
     #[test]
     fn raw_chunk_projects_generated_metadata() {
         let json = serde_json::json!({
@@ -804,7 +810,7 @@ mod tests {
     /// Mock server that answers `429` (with `Retry-After: 0` so retries are
     /// instant) for the first `fail_times` requests, then `200`. Returns the
     /// base URL and a shared counter of total requests received.
-    async fn spawn_mock(fail_times: usize) -> (String, Arc<AtomicUsize>) {
+    async fn spawn_mock(fail_times: usize) -> MockServer {
         let calls = Arc::new(AtomicUsize::new(0));
         let app = Router::new().fallback({
             let calls = Arc::clone(&calls);
@@ -828,13 +834,13 @@ mod tests {
         tokio::spawn(async move {
             axum::serve(listener, app).await.expect("serve");
         });
-        (format!("http://{addr}"), calls)
+        MockServer { base_url: format!("http://{addr}"), calls }
     }
 
     #[tokio::test]
     async fn retries_429_then_succeeds() {
-        let (base, calls) = spawn_mock(2).await;
-        let client = Client::new(base, "test-key").expect("client");
+        let MockServer { base_url, calls } = spawn_mock(2).await;
+        let client = Client::new(base_url, "test-key").expect("client");
         client.ensure_store("store").await.expect("succeeds after retries");
         // 2 rejected + 1 accepted.
         assert_eq!(calls.load(Ordering::SeqCst), 3);
@@ -843,7 +849,7 @@ mod tests {
     /// TCP server that drops the connection without a response for the first
     /// `fail_times` requests (a transport error, no HTTP status), then answers
     /// `200`. Returns the base URL and a counter of accepted connections.
-    async fn spawn_flaky_tcp(fail_times: usize) -> (String, Arc<AtomicUsize>) {
+    async fn spawn_flaky_tcp(fail_times: usize) -> MockServer {
         use tokio::io::AsyncWriteExt as _;
 
         let calls = Arc::new(AtomicUsize::new(0));
@@ -870,15 +876,15 @@ mod tests {
                 }
             }
         });
-        (format!("http://{addr}"), calls)
+        MockServer { base_url: format!("http://{addr}"), calls }
     }
 
     #[tokio::test]
     async fn retries_transport_errors_then_succeeds() {
         // Pays real backoff (~1s): transport errors carry no `Retry-After`, so
         // don't raise `fail_times` expecting it to stay instant.
-        let (base, calls) = spawn_flaky_tcp(2).await;
-        let client = Client::new(base, "test-key").expect("client");
+        let MockServer { base_url, calls } = spawn_flaky_tcp(2).await;
+        let client = Client::new(base_url, "test-key").expect("client");
         client
             .ensure_store("store")
             .await
@@ -889,8 +895,8 @@ mod tests {
 
     #[tokio::test]
     async fn gives_up_after_max_retries() {
-        let (base, calls) = spawn_mock(usize::MAX).await;
-        let client = Client::new(base, "test-key").expect("client");
+        let MockServer { base_url, calls } = spawn_mock(usize::MAX).await;
+        let client = Client::new(base_url, "test-key").expect("client");
         let err = client.ensure_store("store").await.expect_err("never succeeds");
         assert!(matches!(err, Error::Api { status: 429, .. }), "got {err:?}");
         // The initial attempt plus MAX_RETRIES retries.

--- a/packages/nix-web-monitor/parser/src/lib.rs
+++ b/packages/nix-web-monitor/parser/src/lib.rs
@@ -917,7 +917,10 @@ fn parse_result(raw: &Value) -> Result<ResultAction, ParseError> {
     let fields = fields(raw);
     let result = match result_type {
         result_code::FILE_LINKED => {
-            let (linked, total) = two_numbers(&fields)?;
+            let NumberPair {
+                first: linked,
+                second: total,
+            } = two_numbers(&fields)?;
             ActivityResult::FileLinked { linked, total }
         }
         result_code::BUILD_LOG_LINE => ActivityResult::BuildLogLine {
@@ -930,7 +933,10 @@ fn parse_result(raw: &Value) -> Result<ResultAction, ParseError> {
             progress: parse_progress(&fields)?,
         },
         result_code::SET_EXPECTED => {
-            let (activity_type_code, expected) = two_numbers(&fields)?;
+            let NumberPair {
+                first: activity_type_code,
+                second: expected,
+            } = two_numbers(&fields)?;
             let activity_type_code =
                 u64::try_from(activity_type_code).map_err(|_| ParseError::NegativeActivityType)?;
             ActivityResult::SetExpected {
@@ -982,9 +988,18 @@ fn one_text(fields: &[FieldValue]) -> Result<String, ParseError> {
     }
 }
 
-fn two_numbers(fields: &[FieldValue]) -> Result<(i64, i64), ParseError> {
+/// The two numeric fields extracted from an activity record, in field order.
+struct NumberPair {
+    first: i64,
+    second: i64,
+}
+
+fn two_numbers(fields: &[FieldValue]) -> Result<NumberPair, ParseError> {
     match fields {
-        [FieldValue::Number(first), FieldValue::Number(second)] => Ok((*first, *second)),
+        [FieldValue::Number(first), FieldValue::Number(second)] => Ok(NumberPair {
+            first: *first,
+            second: *second,
+        }),
         _ => Err(ParseError::TwoNumericFields),
     }
 }

--- a/packages/oci-image-builder/src/main.rs
+++ b/packages/oci-image-builder/src/main.rs
@@ -63,6 +63,13 @@ struct Layer {
     tar_path: PathBuf,
 }
 
+/// The result of streaming bytes through a hasher: the total byte count written
+/// and the lowercase-hex sha256 digest of those bytes.
+struct HashedBytes {
+    size: u64,
+    checksum: String,
+}
+
 #[derive(Debug, PartialEq)]
 struct LayerEfficiency {
     entries: usize,
@@ -287,7 +294,7 @@ fn make_store_layer(
     fs::write(&paths_file, paths.join("\n"))?;
 
     let layer_tmp = layers_dir.join(format!("{number}.layer.tar"));
-    let (checksum, size) = write_tar_layer(&layer_tmp, &paths_file, conf, mtime)?;
+    let HashedBytes { size, checksum } = write_tar_layer(&layer_tmp, &paths_file, conf, mtime)?;
     let tar_path = blobs_dir.join(&checksum);
     fs::rename(&layer_tmp, &tar_path)?;
 
@@ -685,7 +692,7 @@ fn write_tar_layer(
     paths_file: &Path,
     conf: &Config,
     mtime: &str,
-) -> Result<(String, u64), Box<dyn Error>> {
+) -> Result<HashedBytes, Box<dyn Error>> {
     let mtime_secs: u64 = mtime.parse()?;
     let uid: u64 = conf.uid.parse()?;
     let gid: u64 = conf.gid.parse()?;
@@ -718,8 +725,7 @@ fn write_tar_layer(
     }
 
     let writer = builder.into_inner()?;
-    let (size, hash) = writer.finalize();
-    Ok((hash, size))
+    Ok(writer.finalize())
 }
 
 fn collect_paths_recursive(root: &Path, out: &mut Vec<PathBuf>) -> Result<(), Box<dyn Error>> {
@@ -802,9 +808,12 @@ impl<W: Write> HashingWriter<W> {
         }
     }
 
-    fn finalize(self) -> (u64, String) {
-        let hash = format!("{:x}", self.hasher.finalize());
-        (self.size, hash)
+    fn finalize(self) -> HashedBytes {
+        let checksum = format!("{:x}", self.hasher.finalize());
+        HashedBytes {
+            size: self.size,
+            checksum,
+        }
     }
 }
 

--- a/packages/reel/src/record.rs
+++ b/packages/reel/src/record.rs
@@ -56,10 +56,14 @@ pub fn record(cols: u16, rows: u16, fps: u32) -> Result<Vec<Frame>> {
 /// Capture one frame: the styled grid plus the cursor.
 fn capture(term: &TuiInstance, frames: &mut Vec<Frame>) -> Result<()> {
     let cells = term.read_styled_cells().wrap_err("read styled cells")?;
-    let (row, col, visible) = term.read_cursor().wrap_err("read cursor")?;
+    let cursor = term.read_cursor().wrap_err("read cursor")?;
     frames.push(Frame::Terminal {
         cells,
-        cursor: Cursor { row, col, visible },
+        cursor: Cursor {
+            row: cursor.row,
+            col: cursor.col,
+            visible: cursor.visible,
+        },
     });
     Ok(())
 }

--- a/packages/screencast-ingest/src/main.rs
+++ b/packages/screencast-ingest/src/main.rs
@@ -154,26 +154,45 @@ fn content_type(file: &str) -> &'static str {
     }
 }
 
+/// An HTTP error response: a status code and a client-safe message. Returned as
+/// the `Err` of handlers and helpers so the `(StatusCode, String)` axum response
+/// tuple is built from a named, self-documenting shape rather than a bare pair.
+struct HttpError {
+    status: StatusCode,
+    message: String,
+}
+
+impl IntoResponse for HttpError {
+    fn into_response(self) -> Response {
+        (self.status, self.message).into_response()
+    }
+}
+
+/// A validated on-disk location for an ingest file: the session directory and
+/// the full path to the file within it.
+struct ResolvedPath {
+    dir: PathBuf,
+    path: PathBuf,
+}
+
 /// Resolve `{user}/{session}/{file}` to an on-disk path, rejecting any segment
 /// that is not a safe plain name. Returns the validated directory and full path.
-fn resolve(
-    root: &FsPath,
-    user: &str,
-    session: &str,
-    file: &str,
-) -> Result<(PathBuf, PathBuf), (StatusCode, String)> {
+fn resolve(root: &FsPath, user: &str, session: &str, file: &str) -> Result<ResolvedPath, HttpError> {
     if !(safe_component(user) && safe_component(session) && safe_component(file)) {
-        return Err((StatusCode::BAD_REQUEST, "invalid path component".to_owned()));
+        return Err(HttpError {
+            status: StatusCode::BAD_REQUEST,
+            message: "invalid path component".to_owned(),
+        });
     }
     let dir = root.join(user).join(session);
     let path = dir.join(file);
-    Ok((dir, path))
+    Ok(ResolvedPath { dir, path })
 }
 
 /// Enforce the bearer token on a mutating request when one is configured. The
 /// token compare is constant-time so a timing side channel cannot recover it
 /// byte by byte (the length is allowed to leak, which is conventional).
-fn check_auth(state: &AppState, headers: &HeaderMap) -> Result<(), (StatusCode, String)> {
+fn check_auth(state: &AppState, headers: &HeaderMap) -> Result<(), HttpError> {
     let Some(expected) = &state.0.token else {
         return Ok(());
     };
@@ -184,7 +203,10 @@ fn check_auth(state: &AppState, headers: &HeaderMap) -> Result<(), (StatusCode, 
     if presented.is_some_and(|p| ct_eq(p.as_bytes(), expected.as_bytes())) {
         Ok(())
     } else {
-        Err((StatusCode::UNAUTHORIZED, "missing or invalid bearer token".to_owned()))
+        Err(HttpError {
+            status: StatusCode::UNAUTHORIZED,
+            message: "missing or invalid bearer token".to_owned(),
+        })
     }
 }
 
@@ -209,16 +231,20 @@ async fn upload(
     Path((user, session, file)): Path<(String, String, String)>,
     headers: HeaderMap,
     body: Body,
-) -> Result<StatusCode, (StatusCode, String)> {
+) -> Result<StatusCode, HttpError> {
     check_auth(&state, &headers)?;
-    let (dir, path) = resolve(&state.0.root, &user, &session, &file)?;
+    let ResolvedPath { dir, path } = resolve(&state.0.root, &user, &session, &file)?;
     if !matches!(file.rsplit('.').next(), Some("m3u8" | "m4s" | "mp4" | "ts")) {
-        return Err((StatusCode::BAD_REQUEST, "unsupported file type".to_owned()));
+        return Err(HttpError {
+            status: StatusCode::BAD_REQUEST,
+            message: "unsupported file type".to_owned(),
+        });
     }
 
-    let bytes = to_bytes(body, MAX_UPLOAD)
-        .await
-        .map_err(|_| (StatusCode::PAYLOAD_TOO_LARGE, "upload too large".to_owned()))?;
+    let bytes = to_bytes(body, MAX_UPLOAD).await.map_err(|_| HttpError {
+        status: StatusCode::PAYLOAD_TOO_LARGE,
+        message: "upload too large".to_owned(),
+    })?;
     tokio::fs::create_dir_all(&dir)
         .await
         .map_err(|e| internal(&format!("create dir: {e}")))?;
@@ -237,8 +263,8 @@ async fn serve(
     State(state): State<AppState>,
     Path((user, session, file)): Path<(String, String, String)>,
 ) -> Response {
-    let (_, path) = match resolve(&state.0.root, &user, &session, &file) {
-        Ok(p) => p,
+    let path = match resolve(&state.0.root, &user, &session, &file) {
+        Ok(resolved) => resolved.path,
         Err(e) => return e.into_response(),
     };
     tokio::fs::read(&path).await.map_or_else(
@@ -256,9 +282,9 @@ async fn remove(
     State(state): State<AppState>,
     Path((user, session, file)): Path<(String, String, String)>,
     headers: HeaderMap,
-) -> Result<StatusCode, (StatusCode, String)> {
+) -> Result<StatusCode, HttpError> {
     check_auth(&state, &headers)?;
-    let (_, path) = resolve(&state.0.root, &user, &session, &file)?;
+    let path = resolve(&state.0.root, &user, &session, &file)?.path;
     match tokio::fs::remove_file(&path).await {
         Ok(()) => Ok(StatusCode::NO_CONTENT),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(StatusCode::NO_CONTENT),
@@ -268,9 +294,12 @@ async fn remove(
 
 /// Log the detailed cause and return a generic 500, so an OS error string
 /// (which can include absolute server paths) never reaches the client.
-fn internal(detail: &str) -> (StatusCode, String) {
+fn internal(detail: &str) -> HttpError {
     warn!("{detail}");
-    (StatusCode::INTERNAL_SERVER_ERROR, "internal error".to_owned())
+    HttpError {
+        status: StatusCode::INTERNAL_SERVER_ERROR,
+        message: "internal error".to_owned(),
+    }
 }
 
 /// One stream's summary, derived entirely from its directory on disk.

--- a/packages/skill-lint/src/fix.rs
+++ b/packages/skill-lint/src/fix.rs
@@ -17,7 +17,9 @@ pub struct FixOutcome {
 pub fn fix_skill(path: &Path, contents: &str) -> FixOutcome {
     // Refuse to touch a file with missing or unparseable frontmatter; surface
     // it through the linter instead so we never corrupt a broken document.
-    let Some((yaml, yaml_is_mapping)) = parse_frontmatter(contents) else {
+    let Some(Frontmatter { mapping: yaml, is_mapping: yaml_is_mapping }) =
+        parse_frontmatter(contents)
+    else {
         return FixOutcome {
             contents: None,
             changes: Vec::new(),
@@ -52,15 +54,24 @@ pub fn fix_skill(path: &Path, contents: &str) -> FixOutcome {
     }
 }
 
-/// Parse the frontmatter block; returns the mapping (for key lookups) and
-/// whether it was a mapping. `None` means no usable frontmatter. Reuses the
+/// Parsed frontmatter: the mapping (for key lookups) and whether the document's
+/// frontmatter was actually a YAML mapping.
+struct Frontmatter {
+    mapping: serde_norway::Mapping,
+    is_mapping: bool,
+}
+
+/// Parse the frontmatter block. `None` means no usable frontmatter. Reuses the
 /// linter's splitter so fix and lint agree on what frontmatter is.
-fn parse_frontmatter(contents: &str) -> Option<(serde_norway::Mapping, bool)> {
+fn parse_frontmatter(contents: &str) -> Option<Frontmatter> {
     let frontmatter = crate::lint::split_frontmatter(contents)?;
     let value: serde_norway::Value = serde_norway::from_str(frontmatter.yaml).ok()?;
     match value {
-        serde_norway::Value::Mapping(mapping) => Some((mapping, true)),
-        _ => Some((serde_norway::Mapping::new(), false)),
+        serde_norway::Value::Mapping(mapping) => Some(Frontmatter { mapping, is_mapping: true }),
+        _ => Some(Frontmatter {
+            mapping: serde_norway::Mapping::new(),
+            is_mapping: false,
+        }),
     }
 }
 

--- a/packages/source/atuin/src/lib.rs
+++ b/packages/source/atuin/src/lib.rs
@@ -125,7 +125,7 @@ fn read_entries(conn: &Connection) -> Result<Vec<Entry>> {
         .query_map([], |row| {
             let timestamp_ns: Option<i64> = row.get(1)?;
             let hostname: Option<String> = row.get(6)?;
-            let (host, user) = split_host_user(hostname.as_deref());
+            let HostUser { host, user } = split_host_user(hostname.as_deref());
             Ok(Entry {
                 id: row.get(0)?,
                 command: row.get(3)?,
@@ -150,15 +150,24 @@ fn read_entries(conn: &Connection) -> Result<Vec<Entry>> {
     Ok(entries)
 }
 
+/// Host and optional user parsed from an atuin `hostname` column.
+#[derive(Debug, Clone)]
+struct HostUser {
+    /// The host portion (the whole value when no `:` is present).
+    host: String,
+    /// The user portion after the first `:`, if any and non-empty.
+    user: Option<String>,
+}
+
 /// atuin records `hostname` as `"<host>:<user>"`. Split on the first colon; fall
 /// back to the whole value as the host with no user.
-fn split_host_user(hostname: Option<&str>) -> (String, Option<String>) {
+fn split_host_user(hostname: Option<&str>) -> HostUser {
     let Some(value) = hostname else {
-        return ("unknown".to_owned(), None);
+        return HostUser { host: "unknown".to_owned(), user: None };
     };
     value.split_once(':').map_or_else(
-        || (value.to_owned(), None),
-        |(host, user)| (host.to_owned(), non_empty(Some(user.to_owned()))),
+        || HostUser { host: value.to_owned(), user: None },
+        |(host, user)| HostUser { host: host.to_owned(), user: non_empty(Some(user.to_owned())) },
     )
 }
 

--- a/packages/source/claude/tests/parse.rs
+++ b/packages/source/claude/tests/parse.rs
@@ -49,6 +49,14 @@ fn parses_messages_and_tags_them() {
     assert!(body.contains("[tool_use Read]"));
 }
 
+/// A document's stable identity for the reingest comparison: its external id
+/// paired with the content hash that drives the reconcile.
+#[derive(Debug, PartialEq, Eq)]
+struct DocId {
+    external_id: String,
+    content_hash: String,
+}
+
 #[test]
 fn reingest_is_stable() {
     // Same input twice yields identical ids and hashes, so a re-ingest of an
@@ -56,12 +64,15 @@ fn reingest_is_stable() {
     let first = ClaudeHistoryExport::open_with(&fixtures(), "h", "u").expect("open");
     let second = ClaudeHistoryExport::open_with(&fixtures(), "h", "u").expect("open");
 
-    let ids = |export: &ClaudeHistoryExport| -> Vec<(String, String)> {
+    let ids = |export: &ClaudeHistoryExport| -> Vec<DocId> {
         export
             .documents()
             .map(|doc| {
                 let doc = doc.expect("document");
-                (doc.external_id, doc.content_hash)
+                DocId {
+                    external_id: doc.external_id,
+                    content_hash: doc.content_hash,
+                }
             })
             .collect()
     };

--- a/packages/source/slack/src/channel.rs
+++ b/packages/source/slack/src/channel.rs
@@ -76,7 +76,7 @@ pub fn discover_channel_dirs(root: &Path) -> Result<Vec<ChannelDir>, Error> {
         if NON_CHANNEL_DIRS.contains(&raw.as_str()) {
             continue;
         }
-        let (id_from_prefix, display_name) = split_id_prefix(&raw);
+        let SplitName { id: id_from_prefix, name: display_name } = split_id_prefix(&raw);
         dirs.push(ChannelDir {
             id_from_prefix,
             display_name,
@@ -88,15 +88,24 @@ pub fn discover_channel_dirs(root: &Path) -> Result<Vec<ChannelDir>, Error> {
     Ok(dirs)
 }
 
+/// A directory name split into an optional `C0...` id prefix and a display name.
+#[derive(Debug, Clone)]
+struct SplitName {
+    /// The channel id parsed from the prefix, if present.
+    id: Option<String>,
+    /// The directory name with any leading `C0...` token removed.
+    name: String,
+}
+
 /// Split a `C0...` id prefix from a directory name.
 ///
 /// Recognizes `C0XYZ--name`, `C0XYZ-name`, and a bare `C0XYZ`. A name with no
-/// id prefix returns `(None, name)`. The id token is a `C` followed by
-/// uppercase alphanumerics.
+/// id prefix returns `id: None` and the whole name. The id token is a `C`
+/// followed by uppercase alphanumerics.
 #[must_use]
-fn split_id_prefix(raw: &str) -> (Option<String>, String) {
+fn split_id_prefix(raw: &str) -> SplitName {
     if !raw.starts_with('C') {
-        return (None, raw.to_owned());
+        return SplitName { id: None, name: raw.to_owned() };
     }
     let id_len = raw
         .char_indices()
@@ -106,15 +115,15 @@ fn split_id_prefix(raw: &str) -> (Option<String>, String) {
         .unwrap_or(0);
     // A real id is more than just "C"; require at least a few chars.
     if id_len < 4 {
-        return (None, raw.to_owned());
+        return SplitName { id: None, name: raw.to_owned() };
     }
     let (id, rest) = raw.split_at(id_len);
     let name = rest.trim_start_matches('-');
     if name.is_empty() {
         // Directory was just the id; use the id as the display name.
-        (Some(id.to_owned()), id.to_owned())
+        SplitName { id: Some(id.to_owned()), name: id.to_owned() }
     } else {
-        (Some(id.to_owned()), name.to_owned())
+        SplitName { id: Some(id.to_owned()), name: name.to_owned() }
     }
 }
 
@@ -199,32 +208,32 @@ pub fn read_channel_messages(dir: &Path) -> Result<Vec<Message>, Error> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_external_name, split_id_prefix};
+    use super::{SplitName, is_external_name, split_id_prefix};
 
     #[test]
     fn splits_double_dash_id_prefix() {
-        let (id, name) = split_id_prefix("C0AGC8VFVQV--alerts");
+        let SplitName { id, name } = split_id_prefix("C0AGC8VFVQV--alerts");
         assert_eq!(id.as_deref(), Some("C0AGC8VFVQV"));
         assert_eq!(name, "alerts");
     }
 
     #[test]
     fn splits_single_dash_id_prefix() {
-        let (id, name) = split_id_prefix("C0AQELZ5H3N-ext-nu");
+        let SplitName { id, name } = split_id_prefix("C0AQELZ5H3N-ext-nu");
         assert_eq!(id.as_deref(), Some("C0AQELZ5H3N"));
         assert_eq!(name, "ext-nu");
     }
 
     #[test]
     fn leaves_plain_name_alone() {
-        let (id, name) = split_id_prefix("p-billing");
+        let SplitName { id, name } = split_id_prefix("p-billing");
         assert_eq!(id, None);
         assert_eq!(name, "p-billing");
     }
 
     #[test]
     fn bare_id_directory_uses_id_as_name() {
-        let (id, name) = split_id_prefix("C0AHW2W3V7W");
+        let SplitName { id, name } = split_id_prefix("C0AHW2W3V7W");
         assert_eq!(id.as_deref(), Some("C0AHW2W3V7W"));
         assert_eq!(name, "C0AHW2W3V7W");
     }

--- a/packages/tap/pty/src/lib.rs
+++ b/packages/tap/pty/src/lib.rs
@@ -83,6 +83,24 @@ pub struct SessionConfig {
     pub scrollback_lines: usize,
 }
 
+/// Terminal dimensions in rows and columns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WinSize {
+    /// Number of rows.
+    pub rows: u16,
+    /// Number of columns.
+    pub cols: u16,
+}
+
+/// A 0-indexed cursor position on the screen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CursorPosition {
+    /// 0-indexed row.
+    pub row: u16,
+    /// 0-indexed column.
+    pub col: u16,
+}
+
 /// A live attachment: a resync `snapshot` plus the raw output stream.
 ///
 /// The snapshot reproduces the screen at the moment of attach; `output` carries
@@ -239,16 +257,18 @@ impl PtySession {
         }
     }
 
-    /// Cursor position as `(row, col)`, both 0-indexed.
+    /// Cursor position, both row and column 0-indexed.
     #[must_use]
-    pub fn cursor(&self) -> (u16, u16) {
-        self.emulator.lock().screen().cursor_position()
+    pub fn cursor(&self) -> CursorPosition {
+        let (row, col) = self.emulator.lock().screen().cursor_position();
+        CursorPosition { row, col }
     }
 
-    /// Current emulator size as `(rows, cols)`.
+    /// Current emulator size.
     #[must_use]
-    pub fn size(&self) -> (u16, u16) {
-        self.emulator.lock().screen().size()
+    pub fn size(&self) -> WinSize {
+        let (rows, cols) = self.emulator.lock().screen().size();
+        WinSize { rows, cols }
     }
 
     /// Whether the child has switched to the alternate screen (full-screen TUI).

--- a/packages/tap/src/attach.rs
+++ b/packages/tap/src/attach.rs
@@ -13,12 +13,13 @@ use std::path::Path;
 
 use anyhow::{Context as _, Result, bail};
 use tap_protocol::{Request, Response};
+use tap_pty::WinSize;
 use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _, BufReader, Lines, Stdout};
 use tokio::net::UnixStream;
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::signal::unix::{SignalKind, signal};
 
-use crate::client::{self, resolve_socket};
+use crate::client::{self, ResolvedSocket, resolve_socket};
 use crate::config;
 use crate::editor;
 use crate::input::{InputProcessor, InputResult, KeybindAction};
@@ -54,8 +55,11 @@ enum Event {
 // ever runs on the main thread via the runtime's block_on, never spawned.
 #[allow(clippy::future_not_send, reason = "owns the tty; runs only on the main thread")]
 pub async fn run(session: Option<String>) -> Result<()> {
-    let (label, socket) = resolve_socket(session)?;
-    let (mut my_rows, mut my_cols) = term::current_winsize();
+    let ResolvedSocket { label, socket } = resolve_socket(session)?;
+    let WinSize {
+        rows: mut my_rows,
+        cols: mut my_cols,
+    } = term::current_winsize();
     // Held for the whole session; restores the terminal on every exit path.
     let raw = RawGuard::enter();
     let mut stdout = tokio::io::stdout();
@@ -114,7 +118,7 @@ pub async fn run(session: Option<String>) -> Result<()> {
                 },
             },
             _ = winch.recv() => {
-                let (rows, cols) = term::current_winsize();
+                let WinSize { rows, cols } = term::current_winsize();
                 my_rows = rows;
                 my_cols = cols;
                 send_request(&mut writer, &Request::Resize { rows, cols }).await?;

--- a/packages/tap/src/client.rs
+++ b/packages/tap/src/client.rs
@@ -100,21 +100,32 @@ async fn spawn_daemon(id: &str, argv: &[String]) -> Result<PathBuf> {
     bail!("session daemon did not come up in time")
 }
 
-/// Resolve a session selector to its `(id, socket)`, defaulting to the most
+/// A resolved session: its id (`label`) and the path to its Unix socket.
+pub struct ResolvedSocket {
+    /// Human-readable session id.
+    pub label: String,
+    /// Path to the session's Unix socket.
+    pub socket: PathBuf,
+}
+
+/// Resolve a session selector to its id and socket, defaulting to the most
 /// recently started live session.
 ///
 /// # Errors
 ///
 /// Returns an error if the named session is missing or there are no sessions.
-pub fn resolve_socket(session: Option<String>) -> Result<(String, PathBuf)> {
+pub fn resolve_socket(session: Option<String>) -> Result<ResolvedSocket> {
     let Some(id) = session else {
         let latest =
             index::latest_live().ok_or_else(|| anyhow!("no active sessions; start one with `tap`"))?;
-        return Ok((latest.id, latest.socket));
+        return Ok(ResolvedSocket {
+            label: latest.id,
+            socket: latest.socket,
+        });
     };
     let socket = tap_protocol::socket_path(&id);
     if socket.exists() {
-        Ok((id, socket))
+        Ok(ResolvedSocket { label: id, socket })
     } else {
         bail!("session '{id}' not found; run `tap list`")
     }
@@ -145,7 +156,7 @@ pub fn list() {
 ///
 /// Returns an error if the session cannot be reached.
 pub async fn scrollback(session: Option<String>, lines: Option<usize>) -> Result<()> {
-    let (_id, socket) = resolve_socket(session)?;
+    let ResolvedSocket { socket, .. } = resolve_socket(session)?;
     match request_once(&socket, &Request::GetScrollback { lines }).await? {
         Response::Scrollback { content } => {
             print!("{content}");
@@ -162,7 +173,7 @@ pub async fn scrollback(session: Option<String>, lines: Option<usize>) -> Result
 ///
 /// Returns an error if the session cannot be reached.
 pub async fn cursor(session: Option<String>) -> Result<()> {
-    let (_id, socket) = resolve_socket(session)?;
+    let ResolvedSocket { socket, .. } = resolve_socket(session)?;
     match request_once(&socket, &Request::GetCursor).await? {
         Response::Cursor { row, col } => {
             println!("row {row}, col {col}");
@@ -179,7 +190,7 @@ pub async fn cursor(session: Option<String>) -> Result<()> {
 ///
 /// Returns an error if the session cannot be reached.
 pub async fn size(session: Option<String>) -> Result<()> {
-    let (_id, socket) = resolve_socket(session)?;
+    let ResolvedSocket { socket, .. } = resolve_socket(session)?;
     match request_once(&socket, &Request::GetSize).await? {
         Response::Size { rows, cols } => {
             println!("{rows}x{cols}");
@@ -196,7 +207,7 @@ pub async fn size(session: Option<String>) -> Result<()> {
 ///
 /// Returns an error if the session cannot be reached or rejects the write.
 pub async fn inject(session: Option<String>, text: String) -> Result<()> {
-    let (_id, socket) = resolve_socket(session)?;
+    let ResolvedSocket { socket, .. } = resolve_socket(session)?;
     match request_once(&socket, &Request::Inject { data: text }).await? {
         Response::Ok => {
             println!("injected");
@@ -213,7 +224,7 @@ pub async fn inject(session: Option<String>, text: String) -> Result<()> {
 ///
 /// Returns an error if the session cannot be reached or rejects the request.
 pub async fn kill(session: Option<String>) -> Result<()> {
-    let (id, socket) = resolve_socket(session)?;
+    let ResolvedSocket { label: id, socket } = resolve_socket(session)?;
     match request_once(&socket, &Request::Kill).await? {
         Response::Ok => {
             println!("killed session {id}");
@@ -230,7 +241,7 @@ pub async fn kill(session: Option<String>) -> Result<()> {
 ///
 /// Returns an error if the session cannot be reached.
 pub async fn subscribe(session: Option<String>) -> Result<()> {
-    let (_id, socket) = resolve_socket(session)?;
+    let ResolvedSocket { socket, .. } = resolve_socket(session)?;
     let stream = UnixStream::connect(&socket)
         .await
         .with_context(|| format!("connecting to {}", socket.display()))?;

--- a/packages/tap/src/daemon.rs
+++ b/packages/tap/src/daemon.rs
@@ -22,7 +22,7 @@ use parking_lot::Mutex;
 
 use crate::index;
 use tap_protocol::{Request, Response, Session};
-use tap_pty::{Attachment, PtySession, SessionConfig};
+use tap_pty::{Attachment, CursorPosition, PtySession, SessionConfig, WinSize};
 use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader, Lines};
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::{UnixListener, UnixStream};
@@ -54,8 +54,28 @@ struct ClientReg {
 
 struct Inner {
     next_id: u64,
-    session_size: (u16, u16),
+    session_size: WinSize,
     clients: HashMap<u64, ClientReg>,
+}
+
+/// The result of attaching an interactive client: its registry id, the
+/// negotiated session size, and the live output attachment.
+struct AttachResult {
+    /// The new client's registry id.
+    id: u64,
+    /// The negotiated session size after this client joined.
+    size: WinSize,
+    /// The live output stream plus resync snapshot.
+    attachment: Attachment,
+}
+
+/// The result of registering a read-only observer: its registry id and the live
+/// output attachment.
+struct ObserverResult {
+    /// The new observer's registry id.
+    id: u64,
+    /// The live output stream plus resync snapshot.
+    attachment: Attachment,
 }
 
 /// Shared daemon state: the PTY session plus the client registry.
@@ -65,7 +85,7 @@ struct DaemonState {
 }
 
 impl DaemonState {
-    fn new(session: PtySession, size: (u16, u16)) -> Self {
+    fn new(session: PtySession, size: WinSize) -> Self {
         Self {
             session,
             inner: Mutex::new(Inner {
@@ -76,7 +96,7 @@ impl DaemonState {
         }
     }
 
-    fn session_size(&self) -> (u16, u16) {
+    fn session_size(&self) -> WinSize {
         self.inner.lock().session_size
     }
 
@@ -86,7 +106,7 @@ impl DaemonState {
         rows: u16,
         cols: u16,
         control: mpsc::UnboundedSender<ResizeNotice>,
-    ) -> (u64, (u16, u16), Attachment) {
+    ) -> AttachResult {
         let mut inner = self.inner.lock();
         let id = inner.next_id;
         inner.next_id += 1;
@@ -105,11 +125,15 @@ impl DaemonState {
         let size = inner.session_size;
         let attachment = self.session.subscribe();
         drop(inner);
-        (id, size, attachment)
+        AttachResult {
+            id,
+            size,
+            attachment,
+        }
     }
 
     /// Register a read-only observer that does not affect size negotiation.
-    fn add_observer(&self, control: mpsc::UnboundedSender<ResizeNotice>) -> (u64, Attachment) {
+    fn add_observer(&self, control: mpsc::UnboundedSender<ResizeNotice>) -> ObserverResult {
         let mut inner = self.inner.lock();
         let id = inner.next_id;
         inner.next_id += 1;
@@ -124,7 +148,7 @@ impl DaemonState {
         );
         let attachment = self.session.subscribe();
         drop(inner);
-        (id, attachment)
+        ObserverResult { id, attachment }
     }
 
     /// Record a client's new terminal size, renegotiate, and repaint it.
@@ -137,7 +161,10 @@ impl DaemonState {
         self.recompute(&mut inner, None);
         // Always hand the requester a fresh snapshot so it repaints on its own
         // resize (and after the editor keybind, which fakes a resize to refresh).
-        let (s_rows, s_cols) = inner.session_size;
+        let WinSize {
+            rows: s_rows,
+            cols: s_cols,
+        } = inner.session_size;
         let snapshot = self.session.snapshot();
         if let Some(client) = inner.clients.get(&id) {
             let _ = client.control.send(ResizeNotice {
@@ -171,7 +198,7 @@ impl DaemonState {
         }
         let rows = sizes.iter().map(|s| s.0).min().unwrap_or(DEFAULT_ROWS).max(1);
         let cols = sizes.iter().map(|s| s.1).min().unwrap_or(DEFAULT_COLS).max(1);
-        let new = (rows, cols);
+        let new = WinSize { rows, cols };
         if new == inner.session_size {
             return;
         }
@@ -234,7 +261,13 @@ pub async fn run(id: String, socket: PathBuf, command: Vec<String>) -> Result<()
     let listener =
         UnixListener::bind(&socket).with_context(|| format!("binding socket {}", socket.display()))?;
 
-    let state = Arc::new(DaemonState::new(session, (DEFAULT_ROWS, DEFAULT_COLS)));
+    let state = Arc::new(DaemonState::new(
+        session,
+        WinSize {
+            rows: DEFAULT_ROWS,
+            cols: DEFAULT_COLS,
+        },
+    ));
     let mut exit = state.session.exit_watch();
 
     loop {
@@ -284,11 +317,11 @@ async fn handle_conn(stream: UnixStream, state: Arc<DaemonState>) -> Result<()> 
                 send_line(&mut write_half, &Response::Scrollback { content }).await?;
             }
             Request::GetCursor => {
-                let (row, col) = state.session.cursor();
+                let CursorPosition { row, col } = state.session.cursor();
                 send_line(&mut write_half, &Response::Cursor { row, col }).await?;
             }
             Request::GetSize => {
-                let (rows, cols) = state.session_size();
+                let WinSize { rows, cols } = state.session_size();
                 send_line(&mut write_half, &Response::Size { rows, cols }).await?;
             }
             Request::Inject { data } => {
@@ -317,7 +350,14 @@ async fn handle_attach(
     cols: u16,
 ) -> Result<()> {
     let (control_tx, mut control_rx) = mpsc::unbounded_channel();
-    let (id, (s_rows, s_cols), attachment) = state.attach(rows, cols, control_tx);
+    let AttachResult {
+        id,
+        size: WinSize {
+            rows: s_rows,
+            cols: s_cols,
+        },
+        attachment,
+    } = state.attach(rows, cols, control_tx);
     send_line(
         &mut write_half,
         &Response::Attached {
@@ -358,7 +398,7 @@ async fn handle_attach(
                     Err(RecvError::Lagged(_)) => {
                         // Fell behind: resync from a fresh snapshot instead of
                         // replaying a torn byte stream.
-                        let (r, c) = lag_state.session_size();
+                        let WinSize { rows: r, cols: c } = lag_state.session_size();
                         let snapshot = lag_state.session.snapshot();
                         let resized = Response::Resized { rows: r, cols: c, snapshot };
                         if send_line(&mut write_half, &resized).await.is_err() {
@@ -403,7 +443,7 @@ async fn handle_attach(
 /// Drive a read-only observer: an initial paint, then the live output stream.
 async fn handle_subscribe(state: Arc<DaemonState>, mut write_half: OwnedWriteHalf) -> Result<()> {
     let (control_tx, _control_rx) = mpsc::unbounded_channel();
-    let (id, attachment) = state.add_observer(control_tx);
+    let ObserverResult { id, attachment } = state.add_observer(control_tx);
     send_line(&mut write_half, &Response::Subscribed).await?;
     send_line(
         &mut write_half,

--- a/packages/tap/src/editor.rs
+++ b/packages/tap/src/editor.rs
@@ -56,14 +56,26 @@ pub struct Position {
     pub col: Option<usize>,
 }
 
-/// Build `(args_before_file, file_argument)` for opening `file_path` at `pos`.
+/// The argument vector for invoking an editor at a position: the flags that
+/// precede the file, plus the file argument itself (which may carry the position).
+pub struct EditorArgs {
+    /// Arguments placed before the file argument (e.g. `+42`, `-g`).
+    pub pos_args: Vec<String>,
+    /// The file argument, possibly suffixed with `:line:col`.
+    pub file_arg: String,
+}
+
+/// Build the argument vector for opening `file_path` at `pos`.
 #[must_use]
-pub fn build_args(editor_cmd: &str, file_path: &Path, pos: Option<Position>) -> (Vec<String>, String) {
+pub fn build_args(editor_cmd: &str, file_path: &Path, pos: Option<Position>) -> EditorArgs {
     let file = file_path.display().to_string();
     let Some(pos) = pos else {
-        return (vec![], file);
+        return EditorArgs {
+            pos_args: vec![],
+            file_arg: file,
+        };
     };
-    match EditorKind::detect(editor_cmd) {
+    let (pos_args, file_arg) = match EditorKind::detect(editor_cmd) {
         EditorKind::Vim => (vec![format!("+{}", pos.line)], file),
         EditorKind::VsCode => {
             let col = pos.col.unwrap_or(1);
@@ -83,7 +95,8 @@ pub fn build_args(editor_cmd: &str, file_path: &Path, pos: Option<Position>) -> 
         }
         EditorKind::Helix => (vec![], format!("{file}:{}", pos.line)),
         EditorKind::Unknown => (vec![], file),
-    }
+    };
+    EditorArgs { pos_args, file_arg }
 }
 
 /// Open `content` in `editor_cmd`, restoring raw mode afterward.
@@ -108,7 +121,7 @@ pub fn open(content: &str, editor_cmd: &str, raw: &RawGuard, pos: Option<Positio
     let (program, leading) = parts
         .split_first()
         .context("empty editor command; set $EDITOR or configure tap")?;
-    let (pos_args, file_arg) = build_args(program, temp.path(), pos);
+    let EditorArgs { pos_args, file_arg } = build_args(program, temp.path(), pos);
 
     // Hand the tty to the editor in cooked mode, then take it back.
     raw.suspend();
@@ -140,16 +153,17 @@ mod tests {
 
     #[test]
     fn builds_position_args_per_editor() {
-        let (args, file) = build_args("vim", Path::new("/t.txt"), Some(Position { line: 42, col: None }));
-        assert_eq!(args, vec!["+42"]);
-        assert_eq!(file, "/t.txt");
+        let EditorArgs { pos_args, file_arg } =
+            build_args("vim", Path::new("/t.txt"), Some(Position { line: 42, col: None }));
+        assert_eq!(pos_args, vec!["+42"]);
+        assert_eq!(file_arg, "/t.txt");
 
-        let (args, file) = build_args(
+        let EditorArgs { pos_args, file_arg } = build_args(
             "cursor",
             Path::new("/t.txt"),
             Some(Position { line: 42, col: Some(10) }),
         );
-        assert_eq!(args, vec!["-g"]);
-        assert_eq!(file, "/t.txt:42:10");
+        assert_eq!(pos_args, vec!["-g"]);
+        assert_eq!(file_arg, "/t.txt:42:10");
     }
 }

--- a/packages/tap/src/term.rs
+++ b/packages/tap/src/term.rs
@@ -9,23 +9,27 @@
 use std::os::fd::BorrowedFd;
 
 use nix::sys::termios::{SetArg, Termios};
+use tap_pty::WinSize;
 
 const STDIN_FD: std::os::fd::RawFd = nix::libc::STDIN_FILENO;
 
-/// Current controlling-terminal size as `(rows, cols)`.
+/// Current controlling-terminal size.
 ///
 /// Falls back to 80×24 when stdin is not a terminal or the ioctl fails, so a
 /// session started without a tty still has a sane geometry.
 #[must_use]
-pub fn current_winsize() -> (u16, u16) {
+pub fn current_winsize() -> WinSize {
     // SAFETY: `ws` is fully written by a successful TIOCGWINSZ; on failure we
     // discard it and use the fallback.
     let mut ws: nix::libc::winsize = unsafe { std::mem::zeroed() };
     let ret = unsafe { nix::libc::ioctl(STDIN_FD, nix::libc::TIOCGWINSZ, &raw mut ws) };
     if ret != 0 || ws.ws_row == 0 || ws.ws_col == 0 {
-        return (24, 80);
+        return WinSize { rows: 24, cols: 80 };
     }
-    (ws.ws_row, ws.ws_col)
+    WinSize {
+        rows: ws.ws_row,
+        cols: ws.ws_col,
+    }
 }
 
 /// Raw-mode guard for stdin. Restores the original termios on drop.

--- a/packages/tui/src/actor/engine.rs
+++ b/packages/tui/src/actor/engine.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 use crate::Error;
 use crate::error::Result;
-use crate::types::{CursorShape, StyledCell};
+use crate::types::{CursorPos, CursorShape, StyledCell};
 
 /// A request to the VT engine thread.
 ///
@@ -288,12 +288,16 @@ pub fn snapshot_to_styled_cells(
     })
 }
 
-/// The cursor's `(row, col, visible)` in viewport cell coordinates.
+/// The cursor's position and visibility in viewport cell coordinates.
 ///
 /// The snapshot stores the cursor position as `(col, row)`, so it is swapped
 /// here. A cursor scrolled out of the viewport reports `(0, 0)`.
-pub fn snapshot_to_cursor(snapshot: &ix_vt::Snapshot) -> (u16, u16, bool) {
+pub fn snapshot_to_cursor(snapshot: &ix_vt::Snapshot) -> CursorPos {
     let cursor = snapshot.cursor;
     let (row, col) = cursor.viewport.map_or((0, 0), |(x, y)| (y, x));
-    (row, col, cursor.visible)
+    CursorPos {
+        row,
+        col,
+        visible: cursor.visible,
+    }
 }

--- a/packages/tui/src/actor/mod.rs
+++ b/packages/tui/src/actor/mod.rs
@@ -40,7 +40,7 @@ pub enum PtyCommand {
         response: oneshot::Sender<Result<ndarray::Array2<crate::types::StyledCell>>>,
     },
     ReadCursor {
-        response: oneshot::Sender<Result<(u16, u16, bool)>>,
+        response: oneshot::Sender<Result<crate::types::CursorPos>>,
     },
 }
 

--- a/packages/tui/src/dashboard/mod.rs
+++ b/packages/tui/src/dashboard/mod.rs
@@ -58,11 +58,13 @@ pub async fn serve(
     let hub = Hub::new();
     // The in-process dashboard streams a live manager; persisted recordings are
     // the standalone aggregator's job, so it serves the replay routes empty.
-    let (mut dashboard, mut stop_rx) = serve_hub(hub.clone(), addr, None, &runtime)
+    let served = serve_hub(hub.clone(), addr, None, &runtime)
         .await
         .map_err(|source| Error::Dashboard {
             message: source.to_string(),
         })?;
+    let mut dashboard = served.dashboard;
+    let mut stop_rx = served.shutdown;
 
     let manager = manager.clone();
     let poller = runtime.spawn(async move {

--- a/packages/tui/src/frame/mod.rs
+++ b/packages/tui/src/frame/mod.rs
@@ -28,8 +28,11 @@ pub async fn collect_panes(manager: &crate::TuiManager) -> Vec<Pane> {
         };
         // Cursor and exit are best-effort: a failed cursor read defaults to the
         // top-left, never dropping the whole pane.
-        let (cursor_row, cursor_col, cursor_visible) =
-            instance.read_cursor_async().await.unwrap_or((0, 0, true));
+        let cursor = instance.read_cursor_async().await.unwrap_or(crate::CursorPos {
+            row: 0,
+            col: 0,
+            visible: true,
+        });
         let rows: Vec<Vec<crate::StyledCell>> =
             cells.rows().into_iter().map(|row| row.to_vec()).collect();
 
@@ -42,9 +45,9 @@ pub async fn collect_panes(manager: &crate::TuiManager) -> Vec<Pane> {
                 cols: instance.cols(),
                 alive: instance.is_alive(),
                 screen: sgr::encode(&rows),
-                cursor_row,
-                cursor_col,
-                cursor_visible,
+                cursor_row: cursor.row,
+                cursor_col: cursor.col,
+                cursor_visible: cursor.visible,
                 cursor_shape: instance.cursor_shape().as_str().to_owned(),
                 exit_code: match instance.exit_state() {
                     crate::ExitState::Exited(code) => code,

--- a/packages/tui/src/frame/sgr.rs
+++ b/packages/tui/src/frame/sgr.rs
@@ -72,15 +72,26 @@ fn trim_default_tail(row: &[StyledCell]) -> &[StyledCell] {
 }
 
 /// The style-only view of a cell, used to decide when a new escape is needed.
-const fn cell_style(cell: &StyledCell) -> (Color, Color, bool, bool, bool, bool) {
-    (
-        cell.fg,
-        cell.bg,
-        cell.bold,
-        cell.italic,
-        cell.underline,
-        cell.inverse,
-    )
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct CellStyle {
+    fg: Color,
+    bg: Color,
+    bold: bool,
+    italic: bool,
+    underline: bool,
+    inverse: bool,
+}
+
+/// The style-only view of a cell, used to decide when a new escape is needed.
+const fn cell_style(cell: &StyledCell) -> CellStyle {
+    CellStyle {
+        fg: cell.fg,
+        bg: cell.bg,
+        bold: cell.bold,
+        italic: cell.italic,
+        underline: cell.underline,
+        inverse: cell.inverse,
+    }
 }
 
 /// Push a full SGR escape that sets exactly `cell`'s style. Always emits a reset

--- a/packages/tui/src/lib.rs
+++ b/packages/tui/src/lib.rs
@@ -58,7 +58,7 @@ pub use manager::{TuiInstance, TuiManager};
 #[cfg(feature = "publish")]
 pub use publish::{Publisher, publish};
 pub use slice::{ColRange, RowRange, slice_2d};
-pub use types::{Color, CursorShape, ExitState, FullOutput, SpawnConfig, StyledCell};
+pub use types::{Color, CursorPos, CursorShape, ExitState, FullOutput, SpawnConfig, StyledCell};
 
 #[cfg(test)]
 mod tests;

--- a/packages/tui/src/manager/mod.rs
+++ b/packages/tui/src/manager/mod.rs
@@ -12,7 +12,7 @@ use tokio::sync::{mpsc, watch};
 use uuid::Uuid;
 
 use crate::actor::PtyCommand;
-use crate::types::{CursorShape, ExitState, FullOutput, SpawnConfig, StyledCell};
+use crate::types::{CursorPos, CursorShape, ExitState, FullOutput, SpawnConfig, StyledCell};
 use crate::{Error, Result};
 
 /// A handle to one spawned PTY-backed process.
@@ -65,14 +65,14 @@ impl TuiInstance {
         *self.cursor_shape.read()
     }
 
-    /// The cursor's `(row, col, visible)` in viewport cell coordinates.
-    pub fn read_cursor(&self) -> Result<(u16, u16, bool)> {
+    /// The cursor's position and visibility in viewport cell coordinates.
+    pub fn read_cursor(&self) -> Result<CursorPos> {
         self.runtime
             .block_on(reader::read_cursor(self.id, &self.command_tx))
     }
 
     /// [`TuiInstance::read_cursor`] as a future.
-    pub async fn read_cursor_async(&self) -> Result<(u16, u16, bool)> {
+    pub async fn read_cursor_async(&self) -> Result<CursorPos> {
         reader::read_cursor(self.id, &self.command_tx).await
     }
 

--- a/packages/tui/src/manager/reader.rs
+++ b/packages/tui/src/manager/reader.rs
@@ -12,7 +12,7 @@ use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
 use crate::actor::PtyCommand;
-use crate::types::{FullOutput, StyledCell};
+use crate::types::{CursorPos, FullOutput, StyledCell};
 use crate::{Error, Result};
 
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
@@ -105,7 +105,7 @@ pub(super) async fn read_styled_cells(
 pub(super) async fn read_cursor(
     id: Uuid,
     command_tx: &mpsc::Sender<PtyCommand>,
-) -> Result<(u16, u16, bool)> {
+) -> Result<CursorPos> {
     request(id, command_tx, |response| PtyCommand::ReadCursor {
         response,
     })

--- a/packages/tui/src/slice/core.rs
+++ b/packages/tui/src/slice/core.rs
@@ -1,5 +1,15 @@
 use crate::{Error, Result};
 
+/// A resolved 1-indexed inclusive range, with optional endpoints filled in from
+/// the available extent.
+#[derive(Debug, Clone, Copy)]
+struct Bounds {
+    /// First selected index (1-indexed, inclusive).
+    from: usize,
+    /// Last selected index (1-indexed, inclusive).
+    to: usize,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct RowRange {
     pub from: Option<usize>,
@@ -18,10 +28,11 @@ impl RowRange {
         Self { from, to }
     }
 
-    pub(super) fn resolve(&self, total_lines: usize) -> (usize, usize) {
-        let from = self.from.unwrap_or(1);
-        let to = self.to.unwrap_or(total_lines);
-        (from, to)
+    pub(super) fn resolve(&self, total_lines: usize) -> Bounds {
+        Bounds {
+            from: self.from.unwrap_or(1),
+            to: self.to.unwrap_or(total_lines),
+        }
     }
 }
 
@@ -31,10 +42,11 @@ impl ColRange {
         Self { from, to }
     }
 
-    pub(super) fn resolve(&self, line_len: usize) -> (usize, usize) {
-        let from = self.from.unwrap_or(1);
-        let to = self.to.unwrap_or(line_len);
-        (from, to)
+    pub(super) fn resolve(&self, line_len: usize) -> Bounds {
+        Bounds {
+            from: self.from.unwrap_or(1),
+            to: self.to.unwrap_or(line_len),
+        }
     }
 }
 
@@ -44,12 +56,12 @@ pub fn slice_2d(lines: &[String], row_range: RowRange, col_range: ColRange) -> R
     }
 
     let total_lines = lines.len();
-    let (row_from, row_to) = row_range.resolve(total_lines);
+    let rows = row_range.resolve(total_lines);
 
-    validate_row_range(row_from, row_to, total_lines)?;
+    validate_row_range(rows.from, rows.to, total_lines)?;
 
     #[allow(clippy::indexing_slicing, reason = "row range validated above")]
-    let selected_lines = &lines[row_from - 1..row_to];
+    let selected_lines = &lines[rows.from - 1..rows.to];
 
     let result: Result<Vec<String>> = selected_lines
         .iter()
@@ -59,12 +71,12 @@ pub fn slice_2d(lines: &[String], row_range: RowRange, col_range: ColRange) -> R
                 return Ok(String::new());
             }
 
-            let (col_from, col_to) = col_range.resolve(char_count);
-            validate_col_range(col_from, col_to, char_count)?;
+            let cols = col_range.resolve(char_count);
+            validate_col_range(cols.from, cols.to, char_count)?;
 
             let chars: Vec<char> = line.chars().collect();
             #[allow(clippy::indexing_slicing, reason = "col range validated above")]
-            let sliced: String = chars[col_from - 1..col_to].iter().collect();
+            let sliced: String = chars[cols.from - 1..cols.to].iter().collect();
             Ok(sliced)
         })
         .collect();

--- a/packages/tui/src/types.rs
+++ b/packages/tui/src/types.rs
@@ -129,6 +129,17 @@ impl Default for SpawnConfig {
     }
 }
 
+/// The cursor's position and visibility in viewport cell coordinates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CursorPos {
+    /// Zero-based row within the viewport.
+    pub row: u16,
+    /// Zero-based column within the viewport.
+    pub col: u16,
+    /// Whether the cursor is currently shown.
+    pub visible: bool,
+}
+
 /// A point-in-time read of a terminal: scrollback history plus the viewport.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FullOutput {

--- a/packages/tui/tests/aggregate.rs
+++ b/packages/tui/tests/aggregate.rs
@@ -17,11 +17,20 @@ use tokio::io::{AsyncBufReadExt as _, BufReader};
 use tokio::net::UnixStream;
 use tui::{ProducerSnapshot, SpawnConfig, TerminalView, TuiManager, View, publish};
 
-/// The first terminal pane in a snapshot, as `(id, view)`. The producer wraps
-/// every terminal as a `Pane` whose body is a `View::Terminal`.
-fn first_terminal(snapshot: &ProducerSnapshot) -> Option<(String, TerminalView)> {
+/// The first terminal pane in a snapshot: its pane id and terminal view.
+struct FirstTerminal {
+    id: String,
+    view: TerminalView,
+}
+
+/// The first terminal pane in a snapshot. The producer wraps every terminal as
+/// a `Pane` whose body is a `View::Terminal`.
+fn first_terminal(snapshot: &ProducerSnapshot) -> Option<FirstTerminal> {
     snapshot.panes.first().and_then(|pane| match &pane.view {
-        View::Terminal(view) => Some((pane.id.clone(), view.clone())),
+        View::Terminal(view) => Some(FirstTerminal {
+            id: pane.id.clone(),
+            view: view.clone(),
+        }),
         _ => None,
     })
 }
@@ -67,10 +76,10 @@ fn producer_streams_live_terminal_over_socket() {
                     "producer id should carry this pid: {}",
                     snapshot.producer
                 );
-                if let Some((id, view)) = first_terminal(&snapshot) {
-                    assert_eq!(view.command, "cat");
-                    if view.screen.contains("AGG-MARKER") {
-                        return id;
+                if let Some(terminal) = first_terminal(&snapshot) {
+                    assert_eq!(terminal.view.command, "cat");
+                    if terminal.view.screen.contains("AGG-MARKER") {
+                        return terminal.id;
                     }
                 }
             }
@@ -127,11 +136,11 @@ fn producer_carries_sgr_and_cursor_shape() {
                 }
                 let snapshot: ProducerSnapshot =
                     serde_json::from_str(&line).expect("parse snapshot");
-                if let Some((_, view)) = first_terminal(&snapshot)
-                    && view.cursor_shape == "bar"
-                    && view.screen.contains("hi")
+                if let Some(terminal) = first_terminal(&snapshot)
+                    && terminal.view.cursor_shape == "bar"
+                    && terminal.view.screen.contains("hi")
                 {
-                    return view;
+                    return terminal.view;
                 }
             }
         })

--- a/packages/vt/ix-vt/src/lib.rs
+++ b/packages/vt/ix-vt/src/lib.rs
@@ -607,7 +607,10 @@ fn read_row(cells: &RowCells, cols: u16) -> Result<Vec<Cell>> {
         })?;
         let style = unsafe { Style::from_raw(&style_raw) };
 
-        let (ch, combining) = read_graphemes(cells)?;
+        let Grapheme {
+            base: ch,
+            combining,
+        } = read_graphemes(cells)?;
 
         // Resolved colors return GHOSTTY_INVALID_VALUE when the cell has no
         // explicit color; that is the documented "use your default" signal, not
@@ -626,14 +629,23 @@ fn read_row(cells: &RowCells, cols: u16) -> Result<Vec<Cell>> {
     Ok(row)
 }
 
+/// A cell's grapheme: its base codepoint plus any trailing combining marks.
+struct Grapheme {
+    base: Option<char>,
+    combining: Vec<char>,
+}
+
 /// Read the base codepoint plus any combining marks of the selected cell.
-fn read_graphemes(cells: &RowCells) -> Result<(Option<char>, Vec<char>)> {
+fn read_graphemes(cells: &RowCells) -> Result<Grapheme> {
     use sys::GhosttyRenderStateRowCellsData as CellData;
 
     let len: u32 =
         unsafe { cells.get(CellData::GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_GRAPHEMES_LEN) }?;
     if len == 0 {
-        return Ok((None, Vec::new()));
+        return Ok(Grapheme {
+            base: None,
+            combining: Vec::new(),
+        });
     }
 
     let mut buf = vec![0u32; len as usize];
@@ -648,7 +660,7 @@ fn read_graphemes(cells: &RowCells) -> Result<(Option<char>, Vec<char>)> {
     let mut codepoints = buf.into_iter().map(char::from_u32);
     let base = codepoints.next().flatten();
     let combining = codepoints.flatten().collect();
-    Ok((base, combining))
+    Ok(Grapheme { base, combining })
 }
 
 /// Read a resolved cell color, mapping the "no explicit color" signal to `None`.


### PR DESCRIPTION
Enable the `indexable-inc/clippy` fork's `anonymous_tuple_return_type` restriction lint (off even in `clippy::all`) at `deny`, and convert every anonymous-tuple return in the workspace to a named struct: self-documenting fields, minimal derives, no `#[allow]`, no type aliases.

Scope: ~50 functions across ~28 crates. New structs carry a one-line doc and per-field intent; all call sites (including cross-crate consumers in `reel`, `tui` dashboard, and `dashboard`) updated to field access / struct destructuring.

Validated on x86_64-linux (vin-compute-1) via `nix run .#check`: the full clippy + test suite is green. Three units the initial pass missed were caught and fixed here (a closure `-> Vec<(String, String)>`, a `(Repository, TempDir, Oid)` test helper, and a `pub(crate)` struct that tripped `redundant_pub_crate`).

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deny `clippy::anonymous_tuple_return_type` across the workspace by replacing tuple returns with named structs
> Enforces the `clippy::anonymous_tuple_return_type = "deny"` lint in [Cargo.toml](https://github.com/indexable-inc/index/pull/675/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) to require named structs in place of anonymous tuple return types across all packages. Each function previously returning a tuple now returns a dedicated struct with named fields, improving call-site readability and making return semantics explicit. Affected packages include `tap`, `tui`, `dashboard-core`, `file-search`, `code-highlight`, `screencast-ingest`, `git-log-pretty`, `dag-runner`, and many others across the workspace.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da7b6a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->