### PR TITLE
rust checks: make clippy + unused-crate-deps per-crate (drop machete, audit once)

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -432,8 +432,15 @@ let
           package.passthru.tests or { }
         )
       ) moduleRustPackages;
+      # cargoAudit scans the single workspace Cargo.lock against the advisory DB,
+      # so it is one lockfile-scoped check (it rebuilds only on a Cargo.lock
+      # change, never on a source edit) rather than a per-crate gate. Expose it
+      # once instead of aliasing the same derivation onto every crate.
+      workspaceAuditTests = lib.optionalAttrs (rustWorkspace.units.policyChecks ? cargoAudit) {
+        rust-cargoAudit = rustWorkspace.units.policyChecks.cargoAudit;
+      };
     in
-    repoRustPackageTests // moduleRustPackageTests;
+    repoRustPackageTests // moduleRustPackageTests // workspaceAuditTests;
 
   lintSource = fs.toSource {
     inherit (paths) root;

--- a/lib/rust/cargo-unit.nix
+++ b/lib/rust/cargo-unit.nix
@@ -565,7 +565,19 @@ let
             lib.nameValuePair "${prefix}${targetName}-${lib.replaceStrings [ "::" ] [ "-" ] case}" drv
           ) (target.cases or { })
         ) (lib.getAttrs (builtins.filter (name: targets ? ${name}) targetNames) targets);
-      policyChecks = workspace.policyChecks or { };
+      # Per-crate policy gates. Each crate gets its own clippy and
+      # unused-crate-dependency check (referencing only its own units) instead of
+      # the workspace-wide aggregates, so editing one crate rebuilds only its own
+      # checks. cargoAudit is lockfile-scoped (one Cargo.lock) and is exposed once
+      # at the workspace level rather than aliased onto every crate.
+      policyChecks =
+        lib.optionalAttrs (
+          (workspace.policy.clippy.enable or false) && (workspace.clippyByPackage or { }) ? ${packageName}
+        ) { clippy = workspace.clippyByPackage.${packageName}; }
+        // lib.optionalAttrs (
+          (workspace.policy.denyUnusedCrateDependencies or false)
+          && (workspace.unusedCrateDependenciesByPackage or { }) ? ${packageName}
+        ) { unusedCrateDependencies = workspace.unusedCrateDependenciesByPackage.${packageName}; };
       testCases =
         flattenCaseTargets "" selectedTestTargets (workspace.tests or { })
         // flattenCaseTargets "doctest-" selectedDoctestTargets (workspace.doctests or { });

--- a/lib/rust/workspace.nix
+++ b/lib/rust/workspace.nix
@@ -220,7 +220,11 @@ let
             {
               denyUnusedCrateDependencies = true;
               cargoAudit.enable = true;
-              cargoMachete.enable = true;
+              # cargo-machete is redundant with the per-crate
+              # unused_crate_dependencies (rustc) gate, which is compile-based and
+              # more precise than machete's heuristic scan, and machete only ran
+              # as one whole-workspace pass. Rely on the per-crate check instead.
+              cargoMachete.enable = false;
               clippy.enable = true;
             };
       }

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -267,8 +267,10 @@ struct UnitsNixTemplate {
     source_audit_entries: String,
     unit_entries: String,
     clippy_unit_entries: String,
+    clippy_unit_names_by_package: String,
     panic_object_unit_entries: String,
     policy_check_entries: String,
+    unused_crate_dependencies_by_package: String,
     roots: String,
     checked_roots: String,
     package_entries: String,
@@ -292,8 +294,12 @@ pub fn render_units_nix(graph: &UnitGraph, options: &RenderOptions) -> Result<St
         source_audit_entries: render_source_audit_entries(&prepared),
         unit_entries: render_unit_entries(graph, options, &prepared)?,
         clippy_unit_entries: render_clippy_unit_entries(graph, options, &prepared)?,
+        clippy_unit_names_by_package: render_clippy_unit_names_by_package(graph, options, &prepared),
         panic_object_unit_entries: render_panic_object_unit_entries(graph, options, &prepared)?,
         policy_check_entries: render_policy_check_entries(graph, options, &prepared)?,
+        unused_crate_dependencies_by_package: render_unused_crate_dependencies_by_package(
+            graph, options, &prepared,
+        ),
         roots: render_roots(graph, &prepared),
         checked_roots: render_checked_roots(graph, &prepared),
         package_entries: render_root_entries(graph, &prepared, |_| true),
@@ -401,14 +407,11 @@ fn render_policy_check_entries(
     options: &RenderOptions,
     prepared: &PreparedGraph,
 ) -> Result<String> {
+    // Unused-crate-dependency checks are emitted per package
+    // (`unusedCrateDependenciesByPackage`), not as one workspace aggregate, so a
+    // single crate edit rebuilds only its own check. `_options` stays for the
+    // panic-freedom gate below.
     let mut entries = String::new();
-    if options.deny_unused_crate_dependencies {
-        writeln!(
-            entries,
-            "    unusedCrateDependencies = {};",
-            render_unused_crate_dependencies_check(graph, options, prepared)
-        )?;
-    }
     if options.deny_panics
         && let Some(check) = render_panic_freedom_check(graph, prepared)
     {
@@ -1640,25 +1643,37 @@ struct DependencyPolicyKey {
     extern_crate_name: String,
 }
 
-fn render_unused_crate_dependencies_check(
+// The shell helper every per-package unused-crate-dependency check shares: a
+// dependency is unused only when *every* unit of the package that declares it
+// reports it unused, so a dependency exercised by one target but not another is
+// not flagged.
+const UNUSED_CRATE_DEPENDENCIES_HELPER: &str = "      failures=0\n      check_unused() {\n        package=\"$1\"\n        dependency=\"$2\"\n        shift 2\n        unit_count=\"$#\"\n        unused_count=0\n\n        for unit in \"$@\"; do\n          report=\"$unit/nix-support/unused-crate-dependencies\"\n          if [ -f \"$report\" ] && grep -Fxq \"$dependency\" \"$report\"; then\n            unused_count=$((unused_count + 1))\n          fi\n        done\n\n        if [ \"$unused_count\" -eq \"$unit_count\" ]; then\n          printf 'unused dependency in %s: %s\\n' \"$package\" \"$dependency\" >&2\n          failures=1\n        fi\n      }\n\n";
+
+// Per-package unused-crate-dependency checks. Each package's check references
+// only that package's own units, so editing one crate rebuilds only its own
+// check rather than a single whole-workspace aggregate that fans out to every
+// crate. Returns a Nix attrset keyed by cargo package name.
+fn render_unused_crate_dependencies_by_package(
     graph: &UnitGraph,
     options: &RenderOptions,
     prepared: &PreparedGraph,
 ) -> String {
-    let mut dependency_units: BTreeMap<DependencyPolicyKey, BTreeSet<usize>> = BTreeMap::new();
+    // package name -> (dependency -> units of that package declaring it)
+    let mut by_package: BTreeMap<String, BTreeMap<DependencyPolicyKey, BTreeSet<usize>>> =
+        BTreeMap::new();
 
     for (index, unit) in graph.units.iter().enumerate() {
         if unit.is_run_custom_build() || !collects_unused_crate_dependencies(unit, options) {
             continue;
         }
-
         for dependency in &unit.dependencies {
             let dep_unit = &graph.units[dependency.index];
             if dep_unit.is_run_custom_build() || dep_unit.is_bin() {
                 continue;
             }
-
-            dependency_units
+            by_package
+                .entry(unit.package_name().to_string())
+                .or_default()
                 .entry(DependencyPolicyKey {
                     pkg_id: unit.pkg_id.clone(),
                     package_name: unit.package_name().to_string(),
@@ -1670,54 +1685,72 @@ fn render_unused_crate_dependencies_check(
         }
     }
 
-    let mut script = String::new();
-    script.push_str(
-        "pkgs.runCommand \"cargo-unit-unused-crate-dependencies\" { nativeBuildInputs = [ pkgs.gnugrep ]; } ''\n",
-    );
-    script.push_str("      failures=0\n");
-    script.push_str("      check_unused() {\n");
-    script.push_str("        package=\"$1\"\n");
-    script.push_str("        dependency=\"$2\"\n");
-    script.push_str("        shift 2\n");
-    script.push_str("        unit_count=\"$#\"\n");
-    script.push_str("        unused_count=0\n\n");
-    script.push_str("        for unit in \"$@\"; do\n");
-    script.push_str("          report=\"$unit/nix-support/unused-crate-dependencies\"\n");
-    script.push_str(
-        "          if [ -f \"$report\" ] && grep -Fxq \"$dependency\" \"$report\"; then\n",
-    );
-    script.push_str("            unused_count=$((unused_count + 1))\n");
-    script.push_str("          fi\n");
-    script.push_str("        done\n\n");
-    script.push_str("        if [ \"$unused_count\" -eq \"$unit_count\" ]; then\n");
-    script.push_str(
-        "          printf 'unused dependency in %s: %s\\n' \"$package\" \"$dependency\" >&2\n",
-    );
-    script.push_str("          failures=1\n");
-    script.push_str("        fi\n");
-    script.push_str("      }\n\n");
-
-    for (dependency, unit_indexes) in dependency_units {
-        let unit_refs = unit_indexes
-            .iter()
-            .map(|index| format!("\"${{units.{}}}\"", nix_attr(&prepared.names[*index])))
-            .collect::<Vec<_>>()
-            .join(" ");
-        let package = format!("{} {}", dependency.package_name, dependency.package_version);
-        let _ = writeln!(
-            script,
-            "      check_unused {} {} {unit_refs}",
-            shell::quote(&package),
-            shell::quote(&dependency.extern_crate_name),
-        );
+    if by_package.is_empty() {
+        return "{ }".to_string();
     }
 
-    script.push_str("\n      if [ \"$failures\" -ne 0 ]; then\n");
-    script.push_str("        exit 1\n");
-    script.push_str("      fi\n");
-    script.push_str("      mkdir -p \"$out\"\n");
-    script.push_str("    ''");
-    script
+    let mut out = String::from("{\n");
+    for (package_name, dependency_units) in by_package {
+        let mut script = String::new();
+        let _ = writeln!(
+            script,
+            "pkgs.runCommand {} {{ nativeBuildInputs = [ pkgs.gnugrep ]; }} ''",
+            nix_attr(&format!("{package_name}-unused-crate-dependencies"))
+        );
+        script.push_str(UNUSED_CRATE_DEPENDENCIES_HELPER);
+        for (dependency, unit_indexes) in dependency_units {
+            let unit_refs = unit_indexes
+                .iter()
+                .map(|index| format!("\"${{units.{}}}\"", nix_attr(&prepared.names[*index])))
+                .collect::<Vec<_>>()
+                .join(" ");
+            let package = format!("{} {}", dependency.package_name, dependency.package_version);
+            let _ = writeln!(
+                script,
+                "      check_unused {} {} {unit_refs}",
+                shell::quote(&package),
+                shell::quote(&dependency.extern_crate_name),
+            );
+        }
+        script.push_str("\n      if [ \"$failures\" -ne 0 ]; then\n        exit 1\n      fi\n      mkdir -p \"$out\"\n    ''");
+        let _ = writeln!(out, "      {} = {script};", nix_attr(&package_name));
+    }
+    out.push_str("    }");
+    out
+}
+
+// Maps each cargo package name to the attr names of its per-unit clippy
+// derivations, so the template can join just that package's clippy units into
+// one per-crate gate instead of one whole-workspace aggregate.
+fn render_clippy_unit_names_by_package(
+    graph: &UnitGraph,
+    _options: &RenderOptions,
+    prepared: &PreparedGraph,
+) -> String {
+    let mut by_package: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (index, unit) in graph.units.iter().enumerate() {
+        if !is_clippy_unit_candidate(unit) {
+            continue;
+        }
+        by_package
+            .entry(unit.package_name().to_string())
+            .or_default()
+            .push(prepared.names[index].clone());
+    }
+    if by_package.is_empty() {
+        return "{ }".to_string();
+    }
+    let mut out = String::from("{\n");
+    for (package_name, names) in by_package {
+        let _ = writeln!(
+            out,
+            "      {} = {};",
+            nix_attr(&package_name),
+            nix_string_list(&names)
+        );
+    }
+    out.push_str("    }");
+    out
 }
 
 fn cargo_package_exports(unit: &Unit) -> Result<String> {
@@ -3182,13 +3215,13 @@ mod tests {
         assert!(rendered.contains("--json=unused-externs-silent"));
         assert!(rendered.contains("withPolicyChecks"));
         // Per-unit clippy: the same local unit gets a sibling clippy-driver
-        // derivation in `clippyUnits`, threaded through `policyChecks.clippy`.
+        // derivation in `clippyUnits`, grouped per crate by `clippyByPackage`.
         assert!(rendered.contains("clippyUnits = rec"));
         assert!(rendered.contains("mkClippyUnit"));
         assert!(rendered.contains("env \"''${rustc_env[@]}\" clippy-driver"));
         assert!(rendered.contains("extraClippyLintArgs"));
-        assert!(rendered.contains("clippy = clippyPolicyAggregate;"));
-        assert!(rendered.contains("clippyPolicyAggregate ="));
+        assert!(rendered.contains("clippyByPackage ="));
+        assert!(rendered.contains("clippyUnitNamesByPackage ="));
     }
 
     #[test]
@@ -3456,10 +3489,10 @@ mod tests {
         .unwrap();
 
         // `clippyUnits = rec { };` rendered empty proves no per-unit clippy
-        // derivations were emitted. The `clippy = clippyUnits;` text and
-        // the template's `mkClippyUnit` helper are template-literal and
-        // always present; the driver invocation only appears inside a
-        // rendered clippy unit's build phase, so it's the load-bearing tell.
+        // derivations were emitted. The template's `mkClippyUnit` helper is
+        // template-literal and always present; the driver invocation only
+        // appears inside a rendered clippy unit's build phase, so it's the
+        // load-bearing tell.
         assert!(rendered.contains("clippyUnits = rec {\n  };"));
         assert!(!rendered.contains("env \"''${rustc_env[@]}\" clippy-driver"));
         assert!(!rendered.contains("mkClippyUnit {\n      pname ="));

--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -27,8 +27,8 @@
   extraClippyLintArgs ? [],
   # Cargo policy can disable per-unit clippy. The rendered template always
   # contains the clippyUnits definitions (they're cheap text), but this gate
-  # decides whether `policyChecks.clippy` is published and therefore whether
-  # downstream consumers pick the clippy derivations up.
+  # decides whether `clippyByPackage` is populated and therefore whether
+  # downstream consumers pick the per-crate clippy gates up.
   clippyEnabled ? true,
   # When true, `tests.<binary>.cases` also includes #[ignore]'d tests.
   # Off by default to match `cargo test`. Toggling this only affects
@@ -148,6 +148,28 @@ let
 
   clippyUnits = rec {
 {{ clippy_unit_entries }}  };
+
+  clippyUnitNamesByPackage = {{ clippy_unit_names_by_package }};
+
+  # Per-crate clippy gate: join only this package's own clippy units so editing
+  # one crate rebuilds only its clippy check, not a single whole-workspace
+  # aggregate that fans out to every crate. Empty when clippy is disabled (e.g.
+  # the cross-compile graph), matching the old aggregate's enable gate.
+  clippyByPackage =
+    if clippyEnabled then
+      pkgs.lib.mapAttrs
+        (packageName: names:
+          pkgs.symlinkJoin {
+            name = "${packageName}-clippy";
+            paths = map (unitName: clippyUnits.${unitName}) names;
+          })
+        clippyUnitNamesByPackage
+    else
+      { };
+
+  # Per-crate unused-crate-dependency gate, each referencing only its own
+  # package's units (see render_unused_crate_dependencies_by_package).
+  unusedCrateDependenciesByPackage = {{ unused_crate_dependencies_by_package }};
 
   panicObjectUnits = rec {
 {{ panic_object_unit_entries }}  };
@@ -739,17 +761,12 @@ let
   # lives at `clippyUnits` for callers that want individual units; the policy
   # surface wraps every clippy unit into one symlinkJoin so the gate is one
   # store path that depends on every per-unit clippy build.
-  clippyPolicyAggregate =
-    pkgs.symlinkJoin {
-      name = "cargo-unit-clippy";
-      paths = pkgs.lib.attrValues clippyUnits;
-    };
+  # Workspace-level policy checks (panic-freedom, cargoAudit). Clippy and
+  # unused-crate-dependencies are per-crate (clippyByPackage /
+  # unusedCrateDependenciesByPackage), not aggregated here.
   policyChecks =
     {
 {{ policy_check_entries }}    }
-    // pkgs.lib.optionalAttrs (clippyEnabled && clippyUnits != {}) {
-      clippy = clippyPolicyAggregate;
-    }
     // extraPolicyChecks;
   withPolicyChecks = package:
     if policyChecks == {} then package else pkgs.symlinkJoin {
@@ -765,10 +782,12 @@ in
 {
   inherit
     clippyUnits
+    clippyByPackage
     doctestTargetNamesByPackage
     policyChecks
     sourceAudit
     testTargetNamesByPackage
+    unusedCrateDependenciesByPackage
     units
     ;
   testPlan = mkTestPlan "cargo-unit-test-plan";

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2878,8 +2878,8 @@ let
         message = "exported JVM profile should evaluate with plain nixpkgs and no repo overlay";
       }
       {
-        assertion = cargoUnitWorkspace.policyChecks ? unusedCrateDependencies;
-        message = "cargo-unit workspaces should expose an unused dependency policy check by default";
+        assertion = cargoUnitWorkspace.unusedCrateDependenciesByPackage != { };
+        message = "cargo-unit workspaces should expose per-crate unused dependency policy checks by default";
       }
       {
         assertion = lib.hasInfix "--ordered-shutdown" processComposeApplication.passthru.tests.dryRun.buildCommand;
@@ -3041,20 +3041,21 @@ let
         message = "cargo-unit workspaces should expose a cargo-audit policy check by default";
       }
       {
-        assertion = cargoUnitWorkspace.policyChecks ? clippy;
-        message = "cargo-unit workspaces should expose a clippy policy check derivation";
+        # Clippy is a per-crate gate (clippyByPackage), not one workspace
+        # aggregate, so editing one crate rebuilds only its clippy check.
+        assertion = cargoUnitWorkspace.clippyByPackage != { };
+        message = "cargo-unit workspaces should expose per-crate clippy gates";
       }
       {
         assertion = !(cargoUnitWorkspace.policyChecks ? cargoClippy);
         message = "cargo-unit buildWorkspace should suppress the legacy workspace-level cargoClippy when per-unit clippy is on";
       }
       {
-        # `policyChecks.clippy` is one aggregate derivation so
-        # `withPolicyChecks` and `selectBinaryWithTests` can string-coerce it
-        # like every other policy check. The aggregate transitively depends on
-        # every per-unit clippy derivation.
-        assertion = lib.isDerivation cargoUnitWorkspace.policyChecks.clippy;
-        message = "cargo-unit policyChecks.clippy should be a single aggregate derivation";
+        # Each package's clippy gate is one derivation (a symlinkJoin over only
+        # that package's per-unit clippy derivations) that callers can
+        # string-coerce like any other check.
+        assertion = builtins.all lib.isDerivation (builtins.attrValues cargoUnitWorkspace.clippyByPackage);
+        message = "cargo-unit clippyByPackage entries should each be a single derivation";
       }
       {
         # The per-unit fan-out lives at `clippyUnits` for callers that want
@@ -3204,16 +3205,28 @@ let
         message = "cargo-unit source audit should record full dependency source identity";
       }
       {
-        assertion = repoPackages.minecraft-nbt.passthru.policyChecks ? cargoMachete;
-        message = "repo Rust packages should expose cargo-machete policy checks by default";
+        # cargo-machete is dropped in favor of the per-crate
+        # unused_crate_dependencies (rustc) gate (lib/rust/workspace.nix).
+        assertion = !(repoPackages.minecraft-nbt.passthru.policyChecks ? cargoMachete);
+        message = "repo Rust packages should not expose cargo-machete (dropped for the per-crate unused-deps gate)";
+      }
+      {
+        # cargoAudit is lockfile-scoped and exposed once at the workspace level
+        # (per-system rust-cargoAudit), not aliased onto every crate.
+        assertion = !(repoPackages.minecraft-nbt.passthru.policyChecks ? cargoAudit);
+        message = "repo Rust packages should not alias the workspace cargoAudit per crate";
       }
       {
         # Repo packages route through `cargoUnit.buildWorkspace` via
-        # `ix.rustWorkspace.units`, so they pick up the aggregate per-unit
-        # clippy policy check rather than the legacy workspace-level
-        # `cargoClippy` single derivation.
+        # `ix.rustWorkspace.units`, so they pick up their own per-crate clippy
+        # gate (clippyByPackage) rather than a workspace-wide aggregate or the
+        # legacy `cargoClippy` single derivation.
         assertion = repoPackages.minecraft-nbt.passthru.policyChecks ? clippy;
-        message = "repo Rust packages should expose per-unit clippy policy checks by default";
+        message = "repo Rust packages should expose a per-crate clippy policy check";
+      }
+      {
+        assertion = repoPackages.minecraft-nbt.passthru.policyChecks ? unusedCrateDependencies;
+        message = "repo Rust packages with dependencies should expose a per-crate unused-crate-dependencies check";
       }
       {
         assertion = !(repoPackages.minecraft-nbt.passthru.policyChecks ? cargoClippy);
@@ -3241,8 +3254,8 @@ let
         message = "repo package set should expose the ix CLI package by default";
       }
       {
-        assertion = repoPackages.minecraft-nbt.passthru.tests ? cargoMachete;
-        message = "repo Rust policy checks should be exposed as flake-checkable tests";
+        assertion = repoPackages.minecraft-nbt.passthru.tests ? unusedCrateDependencies;
+        message = "repo Rust per-crate policy checks should be exposed as flake-checkable tests";
       }
       {
         assertion = !(repoPackages.dag-runner.passthru ? unchecked);


### PR DESCRIPTION
## Why

The rust policy checks were single **workspace aggregates re-exposed under every crate name**: `clippy` = one `cargo-unit-clippy` symlinkJoin over all clippy units; `unusedCrateDependencies` = one runCommand over all units; `cargoMachete` = one whole-workspace-src run; `cargoAudit` = one lockfile run. So touching any crate rebuilt the shared aggregate, which blast-radius then counted once per crate — the workspace-wide fan-out you saw in the graph (e.g. editing `mynoise` showed up as rebuilding every crate's `unusedCrateDependencies`).

## What

Make them genuinely per-crate:
- `nix-cargo-unit` renders `clippyByPackage` (join only a package's own clippy units) and `unusedCrateDependenciesByPackage` (per-package check referencing only that package's units); the workspace aggregates are removed.
- `selectRootWithTests` attaches the crate's own clippy + unused-deps gate.
- Drop `cargo-machete` (redundant with the compile-based per-crate `unused_crate_dependencies` gate).
- `cargoAudit` is lockfile-scoped (one `Cargo.lock`, only rebuilds on a lock change), so expose it **once** as `rust-cargoAudit` instead of aliasing it onto every crate.

## Verified (x86_64-linux, vin-compute-1)

- Per-crate check drvs are now distinct: `minecraft-nbt-clippy.drv` ≠ `ast-merge-git-clippy.drv`; `<crate>-unused-crate-dependencies.drv` each.
- A live single-crate edit (`minecraft-nbt` only) rebuilds **16 checks, all `rust-minecraft-nbt-*`** + 3 whole-source meta checks (`lint`/`eval`/`blast-radius-test`). No other crate's clippy/unused/audit rebuilds.
- `nix-cargo-unit` 51 tests + clippy green; full `nix run .#check` green (build phase 0 failures, packages eval 0 errors); `tests/default.nix` assertions updated.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make clippy and unused-crate-deps checks per-crate and run cargo audit once at workspace scope
> - Replaces workspace-aggregated clippy and `unusedCrateDependencies` checks with per-crate derivations keyed by package name, so only edited crates are rebuilt/checked.
> - The generated `units.nix` now exposes `clippyByPackage` and `unusedCrateDependenciesByPackage` instead of a single aggregate; `cargo-unit.nix` wires each crate's `policyChecks` to its own entry in these maps.
> - `cargoAudit` is now run once at workspace scope via `workspaceAuditTests` in [per-system.nix](https://github.com/indexable-inc/index/pull/677/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) instead of being aliased per crate.
> - `cargoMachete` is disabled by default in workspace policy in [workspace.nix](https://github.com/indexable-inc/index/pull/677/files#diff-ea594f8bfd460f458ce6b01ce873abb2ff3a3cf89d789587a70728ef478b4ceb), replaced by the per-crate `unused_crate_dependencies` rustc lint.
> - Behavioral Change: `policyChecks` on individual crate units no longer contains an aggregate clippy entry or a workspace-level `unusedCrateDependencies` entry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97f37ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->