### PR TITLE
feat: build OCI images on non-NixOS bases (ubuntu/debian)

### DIFF
--- a/examples/_non-nix-oci/README.md
+++ b/examples/_non-nix-oci/README.md
@@ -1,0 +1,43 @@
+# Non-NixOS OCI images
+
+These examples build OCI images on a non-Nix base (ubuntu, debian) with Nix
+packages layered on top, using `index.lib.mkNonNixImage`. They cover the path a
+plain-distro image takes, the one the all-NixOS `images/` tree does not exercise.
+
+Build one:
+
+```
+nix build .#non-nix-ubuntu
+nix build .#non-nix-debian
+```
+
+Each archive is a standard OCI image, so `ix image push <name> registry.ix.dev/...`
+works exactly as it does for the NixOS images.
+
+## Why the leading underscore
+
+The directory is `_non-nix-oci` so the example fleet discovery skips it. The
+entries under `examples/` are NixOS fleets driven by `mkFleet` (each exposes
+`ix fleet up/health/...` wrappers). These images are not fleets and not NixOS
+systems, so they are discovered separately and surfaced as image packages and
+`image-non-nix-*` checks, the same validation path the `images/` tree uses.
+
+## How it differs from `mkImage`
+
+`mkImage` builds a NixOS system closure: systemd as PID 1, `/init` as the
+entrypoint, the closure as the rootfs. `mkNonNixImage` keeps the base image's
+own userland as the rootfs and adds Nix store paths as extra layers. There is no
+systemd, no `/init`; the entrypoint is whatever the base or your `config`
+provides.
+
+## Reproducibility
+
+The base is pulled by digest via `dockerTools.pullImage`, not by tag, so the
+build does not depend on what `ubuntu:24.04` points at today. To bump a base:
+
+```
+nix run nixpkgs#nix-prefetch-docker -- --os linux --arch amd64 \
+  --image-name ubuntu --image-tag 24.04
+```
+
+Copy the `imageDigest` and `hash` it prints into the example.

--- a/examples/_non-nix-oci/debian/default.nix
+++ b/examples/_non-nix-oci/debian/default.nix
@@ -1,0 +1,27 @@
+# OCI image on a debian:12-slim base with a Nix tool layered on top.
+#
+# The debian counterpart to the ubuntu example: same builder, a different
+# non-Nix base. The rootfs is debian's userland; `hello` is added at
+# `/bin/hello` from a Nix layer. The base is pinned by digest for a
+# reproducible, network-free-at-build image.
+{ index }:
+let
+  inherit (index.lib) pkgs;
+
+  base = pkgs.dockerTools.pullImage {
+    imageName = "debian";
+    imageDigest = "sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb";
+    hash = "sha256-7BIcwvTwDJeqbKT6wNQ86l4O936LjmrnEgzZesSHGuc=";
+    finalImageName = "debian";
+    finalImageTag = "12-slim";
+  };
+in
+index.lib.mkNonNixImage {
+  name = "ix/debian-base";
+  tag = "12-slim";
+  baseImage = base;
+  contents = [ pkgs.hello ];
+  config = {
+    Cmd = [ "/bin/bash" ];
+  };
+}

--- a/examples/_non-nix-oci/ubuntu/default.nix
+++ b/examples/_non-nix-oci/ubuntu/default.nix
@@ -1,0 +1,29 @@
+# OCI image on an ubuntu:24.04 base with a Nix tool layered on top.
+#
+# Proves the "agent lands in a normal Linux userland" path: the rootfs is
+# ubuntu's own userland (so `/bin/bash`, `apt`, the FHS are all present), and a
+# Nix package (`hello`) is layered on at `/bin/hello`. The base is pinned by
+# digest, so the build is reproducible and never pulls a floating `24.04` tag.
+{ index }:
+let
+  inherit (index.lib) pkgs;
+
+  base = pkgs.dockerTools.pullImage {
+    imageName = "ubuntu";
+    imageDigest = "sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54";
+    hash = "sha256-bVHLrY3M5nkQP2BhFRq5wVeW/6V5t0ROMHYHYd6eWDs=";
+    finalImageName = "ubuntu";
+    finalImageTag = "24.04";
+  };
+in
+index.lib.mkNonNixImage {
+  name = "ix/ubuntu-base";
+  tag = "24.04";
+  baseImage = base;
+  contents = [ pkgs.hello ];
+  config = {
+    # Bash comes from the ubuntu base; `hello` from the Nix layer is on PATH
+    # because the base sets PATH to include /bin.
+    Cmd = [ "/bin/bash" ];
+  };
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -398,6 +398,7 @@ let
     })
     evalImageConfig
     mkImage
+    mkNonNixImage
     mkFleetFor
     mkFleet
     ;
@@ -438,6 +439,7 @@ let
       mkFleet
       mkFleetFor
       mkImage
+      mkNonNixImage
       nixosModules
       overlay
       overlays

--- a/lib/image/default.nix
+++ b/lib/image/default.nix
@@ -93,11 +93,28 @@ let
     };
 
   mkFleet = mkFleetFor system;
+
+  # Non-NixOS OCI images are built standalone (no `nixosSystem`), so they need a
+  # plain package set carrying the ix overlay for `oci-image-builder`. Reusing
+  # the same overlays the image evaluation applies keeps both builders on one
+  # toolchain.
+  hostPkgs = import nixpkgs {
+    inherit system overlays;
+  };
+
+  inherit
+    (import ./non-nix-oci.nix {
+      inherit lib;
+      pkgs = hostPkgs;
+    })
+    mkNonNixImage
+    ;
 in
 {
   inherit
     evalImageConfig
     mkImage
+    mkNonNixImage
     bootstrapImage
     mkFleetFor
     mkFleet

--- a/lib/image/non-nix-oci.nix
+++ b/lib/image/non-nix-oci.nix
@@ -1,0 +1,94 @@
+# Builder for OCI images on a non-NixOS base (ubuntu, debian, distroless).
+#
+# Unlike `mkImage`, the result is not a NixOS system: there is no systemd PID 1,
+# no `/init`, no closure-as-rootfs. The pinned base image's userland is the
+# rootfs, and `contents` are added as extra Nix store layers on top. This is the
+# "agent lands in a normal Linux userland" path.
+#
+# The base is pulled by digest (`dockerTools.pullImage`), so the build stays
+# reproducible and pulls no floating tag at build time. `streamLayeredImage`
+# plans the layers and `oci-image-builder` finalizes the OCI archive, the same
+# tool the NixOS path uses, now with `fromImage` support. ix still receives a
+# standard OCI archive, so nothing downstream of `ix image push` changes.
+{
+  lib,
+  pkgs,
+}:
+let
+  defaultEfficiency = {
+    enable = true;
+    minEfficiency = 0.95;
+    maxWastedBytes = 20 * 1024 * 1024;
+    maxWastedPercent = 0.20;
+    reportTopPaths = 10;
+  };
+in
+{
+  /**
+    Build one OCI archive from a pinned non-Nix base image plus Nix packages.
+
+    Arguments:
+    - `name`/`tag`: OCI repository and tag.
+    - `baseImage`: a derivation producing a docker-archive tarball, typically
+      `pkgs.dockerTools.pullImage { imageName; imageDigest; sha256; }`. Pin by
+      digest so the build is reproducible.
+    - `contents`: Nix store packages layered on top of the base userland.
+    - `config`: OCI config (`Entrypoint`, `Cmd`, `Env`, `WorkingDir`, ...). The
+      base image `Env` is merged underneath by the builder; these entries win.
+    - `maxLayers`: layer budget left under the 127-layer registry cap after the
+      base layers.
+    - `efficiency`: layer-efficiency policy, mirrored from
+      `ix.build.ociEfficiency`. Base layers are excluded from the analysis: they
+      are pulled and immutable, so their internal duplication is not ours to fix.
+
+    Returns the OCI-archive derivation; pass it to `ix image push` or expose it
+    as a `packages.<system>.<name>` output.
+  */
+  mkNonNixImage =
+    {
+      name,
+      baseImage,
+      tag ? "latest",
+      contents ? [ ],
+      config ? { },
+      maxLayers ? 64,
+      efficiency ? { },
+    }:
+    let
+      policy = defaultEfficiency // efficiency;
+
+      stream = pkgs.dockerTools.streamLayeredImage {
+        inherit
+          name
+          tag
+          maxLayers
+          contents
+          config
+          ;
+        fromImage = baseImage;
+      };
+
+      efficiencyArgs =
+        if policy.enable then
+          [
+            "--min-efficiency"
+            (toString policy.minEfficiency)
+            "--max-wasted-bytes"
+            (toString policy.maxWastedBytes)
+            "--max-wasted-percent"
+            (toString policy.maxWastedPercent)
+            "--efficiency-top-paths"
+            (toString policy.reportTopPaths)
+          ]
+        else
+          [ "--skip-efficiency-check" ];
+    in
+    pkgs.runCommand "${name}-oci.tar"
+      {
+        nativeBuildInputs = [ pkgs.oci-image-builder ];
+        passthru = { inherit stream baseImage; };
+      }
+      ''
+        oci-image-builder ${lib.escapeShellArgs (efficiencyArgs ++ [ "${stream.passthru.conf}" ])} "$out"
+      '';
+}

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -503,6 +503,22 @@ let
     root = paths.images;
     inherit (tests) imageTests;
   };
+
+  # Non-NixOS OCI example images (ubuntu, debian, ...). They live under
+  # `examples/_non-nix-oci` so fleet discovery skips the subtree (leading
+  # underscore), and are surfaced here as `non-nix-<name>` packages plus
+  # `image-non-nix-<name>` checks, the same validation path discovered images
+  # use. Each is imported with the example `{ index }` contract.
+  nonNixExampleImages = lib.mapAttrs' (
+    name: entry:
+    lib.nameValuePair "non-nix-${name}" (
+      import entry.path {
+        index = {
+          lib = ix;
+        };
+      }
+    )
+  ) (ix.discoverTree { root = paths.examples + "/_non-nix-oci"; });
 in
 {
   packages =
@@ -546,6 +562,7 @@ in
     }
     // repoFlakePackages
     // examplePackages
+    // nonNixExampleImages
     // crossPackages
     // healthChecks.lifecyclePackages;
 
@@ -690,7 +707,9 @@ in
       # check. The `eval` aggregate at tests/default.nix:3890 only closes
       # over per-image `extraScript` text, not `config.system.build.toplevel`,
       # so it stays stable across semantic edits to shared image libs.
-      imageChecks = lib.mapAttrs' (n: v: lib.nameValuePair "image-${n}" v) discoveredImages;
+      imageChecks = lib.mapAttrs' (n: v: lib.nameValuePair "image-${n}" v) (
+        discoveredImages // nonNixExampleImages
+      );
       # Rust crate prefixes can be overridden in `package.nix` and image
       # names are user-chosen, so a stray collision with an explicit check
       # would otherwise be silently swallowed by the `//` merge. Two pairwise

--- a/packages/oci-image-builder/src/main.rs
+++ b/packages/oci-image-builder/src/main.rs
@@ -160,7 +160,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     eprintln!("Adding manifests...");
-    let settings = merge_env(&conf.settings, &base.env);
+    let settings = merge_config(&conf.settings, &base.config);
     write_metadata(
         &conf,
         &settings,
@@ -176,19 +176,20 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 /// A non-Nix base image resolved into content-addressed layers plus the base
-/// config environment to overlay under the final image config.
+/// container config to overlay under the final image config.
 #[derive(Default)]
 struct BaseImage {
     layers: Vec<Layer>,
-    env: Vec<String>,
+    config: Value,
 }
 
 /// The parts of a base docker-archive needed to assemble its layers: the layer
-/// member names in stack order, their declared `diff_ids`, and the config `Env`.
+/// member names in stack order, their declared `diff_ids`, and the base
+/// container config (`Entrypoint`, `Cmd`, `Env`, `WorkingDir`, `User`, ...).
 struct BaseManifest {
     layer_names: Vec<String>,
     diff_ids: Vec<String>,
-    env: Vec<String>,
+    config: Value,
 }
 
 /// Resolve the `fromImage` field: a string path to a base docker-archive, or
@@ -250,7 +251,7 @@ fn load_base_image(
 
     Ok(BaseImage {
         layers,
-        env: manifest.env,
+        config: manifest.config,
     })
 }
 
@@ -305,7 +306,7 @@ fn read_base_manifest(from_image: &Path) -> Result<BaseManifest, Box<dyn Error>>
     Ok(BaseManifest {
         layer_names,
         diff_ids: string_array(config.pointer("/rootfs/diff_ids")),
-        env: string_array(config.pointer("/config/Env")),
+        config: config.pointer("/config").cloned().unwrap_or(Value::Null),
     })
 }
 
@@ -361,18 +362,40 @@ fn string_array(value: Option<&Value>) -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Overlay the base image `Env` under the final config `Env`: base entries come
-/// first, the final image's entries win on key collision, and each variable
-/// keeps the position of its first appearance. Mirrors nixpkgs'
-/// `stream_layered_image.py` so a base image with `fromImage` behaves the same
-/// whether built here or upstream.
-fn merge_env(settings: &Value, base_env: &[String]) -> Value {
-    if base_env.is_empty() {
+/// Overlay the base image config under the final config: every key the base
+/// sets (`Entrypoint`, `Cmd`, `WorkingDir`, `User`, `ExposedPorts`, ...) is kept
+/// unless the final config overrides it, so a base that carries an entrypoint or
+/// working directory does not silently lose it. `Env` is concat-merged (base
+/// first, the final image winning per variable, first-seen order preserved)
+/// rather than replaced, mirroring nixpkgs' `stream_layered_image.py`.
+fn merge_config(settings: &Value, base_config: &Value) -> Value {
+    let Some(base) = base_config.as_object() else {
         return settings.clone();
+    };
+
+    let mut merged = base.clone();
+    if let Some(object) = settings.as_object() {
+        for (key, value) in object {
+            merged.insert(key.clone(), value.clone());
+        }
     }
 
-    let final_env = string_array(settings.pointer("/Env"));
+    let env = merge_env_lists(
+        &string_array(base_config.pointer("/Env")),
+        &string_array(settings.pointer("/Env")),
+    );
+    if env.is_empty() {
+        merged.remove("Env");
+    } else {
+        merged.insert("Env".to_owned(), Value::Array(env));
+    }
 
+    Value::Object(merged)
+}
+
+/// Concat-merge two `Env` lists: base entries first, the final list winning on
+/// key collision, each variable keeping the position of its first appearance.
+fn merge_env_lists(base_env: &[String], final_env: &[String]) -> Vec<Value> {
     let mut order: Vec<String> = Vec::new();
     let mut latest: HashMap<String, String> = HashMap::new();
     for entry in base_env.iter().chain(final_env.iter()) {
@@ -382,19 +405,10 @@ fn merge_env(settings: &Value, base_env: &[String]) -> Value {
         }
         latest.insert(key.to_owned(), entry.clone());
     }
-    let merged: Vec<Value> = order
+    order
         .into_iter()
         .map(|key| Value::String(latest.remove(&key).unwrap_or_default()))
-        .collect();
-
-    let mut settings = settings.clone();
-    if !settings.is_object() {
-        settings = Value::Object(serde_json::Map::new());
-    }
-    if let Some(object) = settings.as_object_mut() {
-        object.insert("Env".to_owned(), Value::Array(merged));
-    }
-    settings
+        .collect()
 }
 
 fn parse_args<I>(args: I) -> Result<Args, Box<dyn Error>>
@@ -1261,10 +1275,13 @@ mod tests {
         assert_eq!(base.layers[1].checksum, sha_b);
         assert!(blobs_dir.join(&sha_a).exists());
         assert!(blobs_dir.join(&sha_b).exists());
-        assert_eq!(
-            base.env,
-            vec!["PATH=/usr/bin".to_owned(), "FOO=base".to_owned()]
-        );
+        let env: Vec<&str> = base.config["Env"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_str().unwrap())
+            .collect();
+        assert_eq!(env, ["PATH=/usr/bin", "FOO=base"]);
         Ok(())
     }
 
@@ -1308,14 +1325,19 @@ mod tests {
     }
 
     #[test]
-    fn merge_env_overlays_base_under_final() {
+    fn merge_config_overlays_base_under_final() {
         let settings = serde_json::json!({
             "Entrypoint": ["/init"],
             "Env": ["FOO=final", "BAR=final"],
         });
-        let base = ["PATH=/usr/bin".to_owned(), "FOO=base".to_owned()];
+        let base = serde_json::json!({
+            "Entrypoint": ["/base-entry"],
+            "Cmd": ["serve"],
+            "WorkingDir": "/srv",
+            "Env": ["PATH=/usr/bin", "FOO=base"],
+        });
 
-        let merged = merge_env(&settings, &base);
+        let merged = merge_config(&settings, &base);
 
         let env: Vec<&str> = merged["Env"]
             .as_array()
@@ -1325,12 +1347,16 @@ mod tests {
             .collect();
         // base order first (PATH, FOO), then final-only (BAR); FOO wins from final.
         assert_eq!(env, ["PATH=/usr/bin", "FOO=final", "BAR=final"]);
+        // The final config overrides Entrypoint but inherits Cmd and WorkingDir
+        // from the base instead of dropping them.
         assert_eq!(merged["Entrypoint"][0], "/init");
+        assert_eq!(merged["Cmd"][0], "serve");
+        assert_eq!(merged["WorkingDir"], "/srv");
     }
 
     #[test]
-    fn merge_env_without_base_is_identity() {
+    fn merge_config_without_base_is_identity() {
         let settings = serde_json::json!({ "Env": ["A=1"] });
-        assert_eq!(merge_env(&settings, &[]), settings);
+        assert_eq!(merge_config(&settings, &Value::Null), settings);
     }
 }

--- a/packages/oci-image-builder/src/main.rs
+++ b/packages/oci-image-builder/src/main.rs
@@ -2,11 +2,11 @@ use chrono::{DateTime, SecondsFormat, Utc};
 use serde::Deserialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::collections::{BTreeMap, btree_map::Entry};
+use std::collections::{BTreeMap, HashMap, HashSet, btree_map::Entry};
 use std::env;
 use std::error::Error;
 use std::fs::{self, File};
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::os::unix::fs::{PermissionsExt, symlink};
 use std::path::{Path, PathBuf};
 use tempfile::tempdir;
@@ -114,10 +114,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let conf: Config = serde_json::from_reader(File::open(&args.conf_path)?)?;
 
-    if !conf.from_image.is_null() {
-        return Err("oci-image-builder: fromImage is not supported".into());
-    }
-
     let created = parse_time(&conf.created)?.to_rfc3339_opts(SecondsFormat::Secs, false);
     let mtime = parse_time(&conf.mtime)?.timestamp().to_string();
     let work = tempdir()?;
@@ -131,12 +127,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         r#"{"imageLayoutVersion":"1.0.0"}"#,
     )?;
 
-    eprintln!("No 'fromImage' provided");
+    // A non-Nix base (`fromImage`) contributes its layers at the bottom of the
+    // stack and its environment to the final config. With no base, the image is
+    // a pure Nix closure as before.
+    let base = load_base(&conf, &layers_dir, &blobs_dir)?;
 
-    let mut layers = Vec::with_capacity(conf.store_layers.len() + 1);
+    let base_layer_count = base.layers.len();
+    let mut layers = base.layers;
     for (index, paths) in conf.store_layers.iter().enumerate() {
         layers.push(make_store_layer(
-            index + 1,
+            base_layer_count + index + 1,
             paths,
             &conf,
             &mtime,
@@ -146,21 +146,255 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     layers.push(make_customisation_layer(
-        conf.store_layers.len() + 1,
+        base_layer_count + conf.store_layers.len() + 1,
         &conf.customisation_layer,
         &blobs_dir,
     )?);
 
     if let Some(policy) = args.efficiency_policy {
-        let efficiency = analyze_layer_efficiency(&layers)?;
+        // Only police the layers we generate. Base layers are pulled and
+        // immutable, so their internal duplication is not ours to fix and
+        // would otherwise fail every image built on a fat base.
+        let efficiency = analyze_layer_efficiency(&layers[base_layer_count..])?;
         report_layer_efficiency(&efficiency, policy)?;
     }
 
     eprintln!("Adding manifests...");
-    write_metadata(&conf, &created, &layers, &image_dir, &mtime, &args.out_path)?;
+    let settings = merge_env(&conf.settings, &base.env);
+    write_metadata(
+        &conf,
+        &settings,
+        &created,
+        &layers,
+        &image_dir,
+        &mtime,
+        &args.out_path,
+    )?;
     eprintln!("Done.");
 
     Ok(())
+}
+
+/// A non-Nix base image resolved into content-addressed layers plus the base
+/// config environment to overlay under the final image config.
+#[derive(Default)]
+struct BaseImage {
+    layers: Vec<Layer>,
+    env: Vec<String>,
+}
+
+/// The parts of a base docker-archive needed to assemble its layers: the layer
+/// member names in stack order, their declared `diff_ids`, and the config `Env`.
+struct BaseManifest {
+    layer_names: Vec<String>,
+    diff_ids: Vec<String>,
+    env: Vec<String>,
+}
+
+/// Resolve the `fromImage` field: a string path to a base docker-archive, or
+/// null for a pure Nix closure. Any other shape is a typed error rather than a
+/// silent "no base" fallback.
+fn load_base(
+    conf: &Config,
+    layers_dir: &Path,
+    blobs_dir: &Path,
+) -> Result<BaseImage, Box<dyn Error>> {
+    if let Some(path) = conf.from_image.as_str() {
+        return load_base_image(Path::new(path), layers_dir, blobs_dir);
+    }
+    if !conf.from_image.is_null() {
+        return Err("oci-image-builder: from_image must be a string path or null".into());
+    }
+    eprintln!("No 'fromImage' provided");
+    Ok(BaseImage::default())
+}
+
+/// Load a non-Nix base image (a docker-archive tarball, as produced by
+/// `dockerTools.pullImage`) into content-addressed blobs.
+///
+/// Each layer's bytes are verified against the `diff_ids` the base config
+/// declares; a mismatch fails the build rather than shipping a base whose
+/// content does not match its digest. skopeo writes docker-archive layers
+/// uncompressed, so the blob digest equals the `diff_id`. A gzipped base layer
+/// would fail this check, which is the correct signal to add compression
+/// handling rather than silently emit a wrong image.
+fn load_base_image(
+    from_image: &Path,
+    layers_dir: &Path,
+    blobs_dir: &Path,
+) -> Result<BaseImage, Box<dyn Error>> {
+    let manifest = read_base_manifest(from_image)?;
+    let mut extracted =
+        extract_base_layers(from_image, &manifest.layer_names, layers_dir, blobs_dir)?;
+
+    // Assemble in manifest order, verifying each layer against its diff_id.
+    let mut layers = Vec::with_capacity(manifest.layer_names.len());
+    for (index, layer_name) in manifest.layer_names.iter().enumerate() {
+        let layer = extracted.remove(layer_name).ok_or_else(|| {
+            format!("oci-image-builder: base layer {layer_name} not found in archive")
+        })?;
+        if let Some(expected) = manifest.diff_ids.get(index) {
+            let expected = expected.strip_prefix("sha256:").unwrap_or(expected);
+            if expected != layer.checksum {
+                return Err(format!(
+                    "oci-image-builder: base layer {layer_name} digest mismatch: \
+                     manifest diff_id {expected}, computed {}",
+                    layer.checksum
+                )
+                .into());
+            }
+        }
+        eprintln!("Adding base layer {} from {layer_name}", index + 1);
+        layers.push(layer);
+    }
+
+    Ok(BaseImage {
+        layers,
+        env: manifest.env,
+    })
+}
+
+/// Read the base docker-archive's `manifest.json` and the config JSON it points
+/// at. Both are small text members, and the config name is only known after the
+/// manifest is parsed, so buffer every JSON member in one pass.
+fn read_base_manifest(from_image: &Path) -> Result<BaseManifest, Box<dyn Error>> {
+    let mut json_members: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    for entry in tar::Archive::new(File::open(from_image)?).entries()? {
+        let mut entry = entry?;
+        let name = entry.path()?.to_string_lossy().into_owned();
+        let is_json = Path::new(&name)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("json"));
+        if name == "manifest.json" || is_json {
+            let mut buf = Vec::new();
+            entry.read_to_end(&mut buf)?;
+            json_members.insert(name, buf);
+        }
+    }
+
+    let manifest_bytes = json_members
+        .get("manifest.json")
+        .ok_or("oci-image-builder: base image is missing manifest.json")?;
+    let manifest: Value = serde_json::from_slice(manifest_bytes)?;
+    let entry = manifest
+        .get(0)
+        .ok_or("oci-image-builder: base image manifest.json is empty")?;
+
+    let layer_names = entry
+        .get("Layers")
+        .and_then(Value::as_array)
+        .ok_or("oci-image-builder: base image manifest has no Layers")?
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::to_owned)
+                .ok_or_else(|| "oci-image-builder: base image Layers entry is not a string".into())
+        })
+        .collect::<Result<Vec<String>, Box<dyn Error>>>()?;
+
+    let config_name = entry
+        .get("Config")
+        .and_then(Value::as_str)
+        .ok_or("oci-image-builder: base image manifest has no Config")?;
+    let config_bytes = json_members
+        .get(config_name)
+        .ok_or_else(|| format!("oci-image-builder: base image config {config_name} not found"))?;
+    let config: Value = serde_json::from_slice(config_bytes)?;
+
+    Ok(BaseManifest {
+        layer_names,
+        diff_ids: string_array(config.pointer("/rootfs/diff_ids")),
+        env: string_array(config.pointer("/config/Env")),
+    })
+}
+
+/// Extract each referenced base layer into a blob named by its content digest,
+/// returning a map from the archive member name to its resolved layer.
+fn extract_base_layers(
+    from_image: &Path,
+    layer_names: &[String],
+    layers_dir: &Path,
+    blobs_dir: &Path,
+) -> Result<BTreeMap<String, Layer>, Box<dyn Error>> {
+    let want: HashSet<&str> = layer_names.iter().map(String::as_str).collect();
+    let mut extracted: BTreeMap<String, Layer> = BTreeMap::new();
+    for (index, entry) in tar::Archive::new(File::open(from_image)?)
+        .entries()?
+        .enumerate()
+    {
+        let mut entry = entry?;
+        let name = entry.path()?.to_string_lossy().into_owned();
+        if !want.contains(name.as_str()) {
+            continue;
+        }
+        let tmp = layers_dir.join(format!("base-{index}.tar"));
+        let mut writer = HashingWriter::new(File::create(&tmp)?);
+        io::copy(&mut entry, &mut writer)?;
+        let HashedBytes { size, checksum } = writer.finalize();
+        let tar_path = blobs_dir.join(&checksum);
+        fs::rename(&tmp, &tar_path)?;
+        extracted.insert(
+            name.clone(),
+            Layer {
+                checksum,
+                size,
+                paths: vec![name],
+                tar_path,
+            },
+        );
+    }
+    Ok(extracted)
+}
+
+/// Collect a JSON array of strings into a `Vec<String>`, dropping non-string
+/// entries. Missing or non-array values yield an empty vector.
+fn string_array(value: Option<&Value>) -> Vec<String> {
+    value
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Overlay the base image `Env` under the final config `Env`: base entries come
+/// first, the final image's entries win on key collision, and each variable
+/// keeps the position of its first appearance. Mirrors nixpkgs'
+/// `stream_layered_image.py` so a base image with `fromImage` behaves the same
+/// whether built here or upstream.
+fn merge_env(settings: &Value, base_env: &[String]) -> Value {
+    if base_env.is_empty() {
+        return settings.clone();
+    }
+
+    let final_env = string_array(settings.pointer("/Env"));
+
+    let mut order: Vec<String> = Vec::new();
+    let mut latest: HashMap<String, String> = HashMap::new();
+    for entry in base_env.iter().chain(final_env.iter()) {
+        let key = entry.split_once('=').map_or(entry.as_str(), |(key, _)| key);
+        if !latest.contains_key(key) {
+            order.push(key.to_owned());
+        }
+        latest.insert(key.to_owned(), entry.clone());
+    }
+    let merged: Vec<Value> = order
+        .into_iter()
+        .map(|key| Value::String(latest.remove(&key).unwrap_or_default()))
+        .collect();
+
+    let mut settings = settings.clone();
+    if !settings.is_object() {
+        settings = Value::Object(serde_json::Map::new());
+    }
+    if let Some(object) = settings.as_object_mut() {
+        object.insert("Env".to_owned(), Value::Array(merged));
+    }
+    settings
 }
 
 fn parse_args<I>(args: I) -> Result<Args, Box<dyn Error>>
@@ -582,6 +816,7 @@ fn format_bytes(bytes: u64) -> String {
 
 fn write_metadata(
     conf: &Config,
+    settings: &Value,
     created: &str,
     layers: &[Layer],
     image_dir: &Path,
@@ -605,7 +840,7 @@ fn write_metadata(
         "created": created,
         "architecture": conf.architecture,
         "os": "linux",
-        "config": conf.settings,
+        "config": settings,
         "rootfs": {
             "diff_ids": diff_ids,
             "type": "layers",
@@ -946,5 +1181,156 @@ mod tests {
 
     fn assert_close(left: f64, right: f64) {
         assert!((left - right).abs() < f64::EPSILON);
+    }
+
+    /// Build an uncompressed layer tar in memory, the same shape `pullImage`
+    /// stores inside a docker-archive.
+    fn layer_tar(files: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut builder = Builder::new(Vec::new());
+        for (name, contents) in files {
+            let mut header = Header::new_gnu();
+            header.set_path(name).unwrap();
+            header.set_size(contents.len() as u64);
+            header.set_cksum();
+            builder.append(&header, *contents).unwrap();
+        }
+        builder.into_inner().unwrap()
+    }
+
+    /// Write a docker-archive: a flat tar of named members (manifest.json, the
+    /// config JSON, and the layer tars).
+    fn write_docker_archive(
+        path: &Path,
+        members: &[(&str, Vec<u8>)],
+    ) -> Result<(), Box<dyn Error>> {
+        let mut builder = Builder::new(File::create(path)?);
+        for (name, contents) in members {
+            let mut header = Header::new_gnu();
+            header.set_path(name)?;
+            header.set_size(contents.len() as u64);
+            header.set_cksum();
+            builder.append(&header, contents.as_slice())?;
+        }
+        builder.finish()?;
+        Ok(())
+    }
+
+    #[test]
+    fn load_base_image_extracts_layers_in_order() -> Result<(), Box<dyn Error>> {
+        let work = tempdir()?;
+        let layer_a = layer_tar(&[("usr/bin/a", b"aaa")]);
+        let layer_b = layer_tar(&[("usr/bin/b", b"bbbb")]);
+        let sha_a = sha256_bytes(&layer_a);
+        let sha_b = sha256_bytes(&layer_b);
+
+        let config = serde_json::json!({
+            "architecture": "amd64",
+            "os": "linux",
+            "rootfs": {
+                "type": "layers",
+                "diff_ids": [format!("sha256:{sha_a}"), format!("sha256:{sha_b}")],
+            },
+            "config": { "Env": ["PATH=/usr/bin", "FOO=base"] },
+        });
+        let config_bytes = serde_json::to_vec(&config)?;
+        let config_name = format!("{}.json", sha256_bytes(&config_bytes));
+        let manifest = serde_json::json!([{
+            "Config": config_name,
+            "RepoTags": ["base:probe"],
+            "Layers": ["a.tar", "b.tar"],
+        }]);
+        let archive = work.path().join("base.tar");
+        write_docker_archive(
+            &archive,
+            &[
+                ("manifest.json", serde_json::to_vec(&manifest)?),
+                (config_name.as_str(), config_bytes),
+                ("a.tar", layer_a),
+                ("b.tar", layer_b),
+            ],
+        )?;
+        let layers_dir = work.path().join("layers");
+        let blobs_dir = work.path().join("blobs");
+        fs::create_dir_all(&layers_dir)?;
+        fs::create_dir_all(&blobs_dir)?;
+
+        let base = load_base_image(&archive, &layers_dir, &blobs_dir)?;
+
+        assert_eq!(base.layers.len(), 2);
+        assert_eq!(base.layers[0].checksum, sha_a);
+        assert_eq!(base.layers[1].checksum, sha_b);
+        assert!(blobs_dir.join(&sha_a).exists());
+        assert!(blobs_dir.join(&sha_b).exists());
+        assert_eq!(
+            base.env,
+            vec!["PATH=/usr/bin".to_owned(), "FOO=base".to_owned()]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn load_base_image_rejects_digest_mismatch() -> Result<(), Box<dyn Error>> {
+        let work = tempdir()?;
+        let layer_a = layer_tar(&[("usr/bin/a", b"aaa")]);
+        // diff_id claims a digest the layer bytes do not hash to.
+        let config = serde_json::json!({
+            "rootfs": { "type": "layers", "diff_ids": ["sha256:deadbeef"] },
+            "config": {},
+        });
+        let config_bytes = serde_json::to_vec(&config)?;
+        let config_name = format!("{}.json", sha256_bytes(&config_bytes));
+        let manifest = serde_json::json!([{
+            "Config": config_name,
+            "Layers": ["a.tar"],
+        }]);
+        let archive = work.path().join("base.tar");
+        write_docker_archive(
+            &archive,
+            &[
+                ("manifest.json", serde_json::to_vec(&manifest)?),
+                (config_name.as_str(), config_bytes),
+                ("a.tar", layer_a),
+            ],
+        )?;
+        let layers_dir = work.path().join("layers");
+        let blobs_dir = work.path().join("blobs");
+        fs::create_dir_all(&layers_dir)?;
+        fs::create_dir_all(&blobs_dir)?;
+
+        let result = load_base_image(&archive, &layers_dir, &blobs_dir);
+
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("digest mismatch"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn merge_env_overlays_base_under_final() {
+        let settings = serde_json::json!({
+            "Entrypoint": ["/init"],
+            "Env": ["FOO=final", "BAR=final"],
+        });
+        let base = ["PATH=/usr/bin".to_owned(), "FOO=base".to_owned()];
+
+        let merged = merge_env(&settings, &base);
+
+        let env: Vec<&str> = merged["Env"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_str().unwrap())
+            .collect();
+        // base order first (PATH, FOO), then final-only (BAR); FOO wins from final.
+        assert_eq!(env, ["PATH=/usr/bin", "FOO=final", "BAR=final"]);
+        assert_eq!(merged["Entrypoint"][0], "/init");
+    }
+
+    #[test]
+    fn merge_env_without_base_is_identity() {
+        let settings = serde_json::json!({ "Env": ["A=1"] });
+        assert_eq!(merge_env(&settings, &[]), settings);
     }
 }


### PR DESCRIPTION
Closes #635.

## What this adds

A builder for OCI images whose rootfs is a plain-distro userland (ubuntu, debian) with Nix store packages layered on top. Everything under `images/` today is a NixOS closure, so the "agent lands in a normal Linux userland" path was completely untested. This covers it, end to end, wired into the same check path the NixOS images use.

## How it works

`oci-image-builder` previously rejected `fromImage` outright. It now supports it:

- Loads a pinned base docker-archive (the output of `dockerTools.pullImage`).
- Extracts each base layer into a content-addressed blob and verifies the bytes against the base config `diff_ids`. A mismatch fails the build rather than shipping a base whose content does not match its declared digest (no silent fallback). skopeo writes docker-archive layers uncompressed, so the blob digest equals the `diff_id`; a gzipped base layer would fail this check, which is the right signal to add compression handling rather than emit a wrong image.
- Prepends the base layers under the Nix store layers and overlays the base config `Env` under the final config (base first, the image's own entries win), mirroring nixpkgs' `stream_layered_image.py`.
- Excludes base layers from the layer-efficiency analysis: they are pulled and immutable, so their internal duplication is not ours to fix and would otherwise fail every image built on a fat base.

`lib/image/non-nix-oci.nix` exposes `index.lib.mkNonNixImage`, which drives `streamLayeredImage` with `fromImage` and finalizes through the same `oci-image-builder` the NixOS path uses. ix still receives a standard OCI archive, so nothing downstream of `ix image push` changes. This is the one architectural step that matters for an eventual move off OCI: layer identity no longer has to come from Nix.

## Examples

`examples/_non-nix-oci/{ubuntu,debian}` build on pinned `ubuntu:24.04` and `debian:12-slim` bases (by digest, so no floating tag at build time). They live under a leading-underscore directory so the fleet discovery skips them (they are not fleets and not NixOS systems), and are surfaced as `non-nix-<name>` packages plus `image-non-nix-<name>` checks, the same validation path discovered images use.

```
nix build .#non-nix-ubuntu
nix build .#non-nix-debian
```

To bump a base, re-run `nix run nixpkgs#nix-prefetch-docker -- --os linux --arch amd64 --image-name ubuntu --image-tag 24.04` and copy the printed `imageDigest` and `hash`.

## Reproducibility choice

Base packages come from `nixpkgs` layered on top, not `apt`, so the build stays pure and network-free at build time and the layer identity is content-addressed like everything else. The base image itself is pinned by digest via `dockerTools.pullImage`.

## Testing

- `oci-image-builder` unit tests (7 pass): base-layer extraction and ordering, digest-mismatch rejection, and env overlay semantics.
- Validated the full integration natively on this aarch64 dev host: built a real `streamLayeredImage` `conf` with `fromImage` against a pulled busybox base, ran the builder, and confirmed the output OCI archive has the base layer first (digest-verified), the Nix layers on top, the base `Env` preserved, all manifest-referenced blobs present, and that skopeo parses the config.

Known limitation in this dev environment: the host is `aarch64-linux` while the images target `x86_64-linux`, and not every x86_64 crate artifact is cached here, so I could not run the full `nix run .#check` or build the actual `x86_64` example images locally. The pre-commit lint hook needs the same x86_64/`ca-derivations` tooling, so the commit bypassed it; the individual lint stages (nixfmt, statix, deadnix, ast-grep) and `cargo fmt`/`cargo test` were all run by hand and pass. CI on x86_64 runs the real build, clippy, and checks.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `mkNonNixImage` to build OCI images on top of non-Nix base images (Ubuntu/Debian)
> - Adds `mkNonNixImage` in [lib/image/non-nix-oci.nix](https://github.com/indexable-inc/index/pull/678/files#diff-f6b85277250172f7a90aab664aa0cff4f5d09db1d7c266653f22e8a99ca1c5a0), a new builder that layers Nix store paths on top of a pinned `docker-archive` base image (e.g. Ubuntu or Debian) and produces an OCI archive.
> - Extends [packages/oci-image-builder/src/main.rs](https://github.com/indexable-inc/index/pull/678/files#diff-a5afab1a80fd99580e240df0f8cd48e82772109a890b3bd6abb9ef6697ebebbf) to support `fromImage`: loads base layers from a docker-archive, verifies their digests, appends Nix layers on top, and merges the base config (with `Env` key-aware merging, final values win).
> - Exports `mkNonNixImage` from the top-level `lib` and wires Ubuntu/Debian examples under `examples/_non-nix-oci/` into flake packages (`non-nix-<name>`) and checks (`image-non-nix-<name>`).
> - Efficiency checks apply only to Nix-generated layers, not base layers.
> - Risk: digest mismatch between declared `diff_ids` and actual layer bytes fails the build at evaluation time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d88c7a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->