### PR TITLE
feat(blast-radius): collapse single-check causes into one node

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -152,11 +152,22 @@ jobs:
                   (.categories[] | "  \"\(.name | safename)\" : \(.count)"),
                   "```"
              else empty end),
-            # v2: which changed inputs fan out to which checks (top causes).
+            # v2: which changed inputs fan out to which checks (top causes). A
+            # single-check cause is the same node twice (the cause drv is that
+            # check own per-unit derivation), so render it as one node labeled
+            # with the check name and skip the arrow; multi-check causes still
+            # fan out cause -> check. Mirror the local renderer in
+            # packages/blast-radius/src/report.rs.
             (if (.causes | length) > 0
              then "", "```mermaid", "flowchart LR",
-                  (.causes | to_entries[] | "  c\(.key)[\"\(.value.name | safename)\"]"),
-                  (.causes | to_entries[] as $c | $c.value.checks[] as $k
+                  (.causes | to_entries[]
+                   | if (.value.checks | length) == 1
+                     then "  c\(.key)[\"\(.value.checks[0] | safename)\"]"
+                     else "  c\(.key)[\"\(.value.name | safename)\"]"
+                     end),
+                  (.causes | to_entries[] as $c
+                   | select(($c.value.checks | length) > 1)
+                   | $c.value.checks[] as $k
                    | "  c\($c.key) --> k\($checks | index($k))[\"\($k | safename)\"]"),
                   "```"
              else empty end),

--- a/packages/blast-radius/src/report.rs
+++ b/packages/blast-radius/src/report.rs
@@ -113,10 +113,23 @@ impl Report {
             checks.dedup();
 
             out.push_str("\n```mermaid\nflowchart LR\n");
+            // A single-check cause is the same node twice (the cause drv is the
+            // check's own per-unit derivation, e.g. lint/lint or
+            // oci-image-builder-clippy-0.1.0/rust-oci-image-builder-clippy). Draw
+            // those as one node labeled with the check name and skip the arrow;
+            // multi-check causes still fan out cause -> check.
             for (index, cause) in self.causes.iter().enumerate() {
-                let _ = writeln!(out, "  c{index}[\"{}\"]", cause.name);
+                let label = if cause.checks.len() == 1 {
+                    &cause.checks[0]
+                } else {
+                    &cause.name
+                };
+                let _ = writeln!(out, "  c{index}[\"{label}\"]");
             }
             for (index, cause) in self.causes.iter().enumerate() {
+                if cause.checks.len() == 1 {
+                    continue;
+                }
                 for check in &cause.checks {
                     let node = checks.iter().position(|name| name == check).unwrap_or(0);
                     let _ = writeln!(out, "  c{index} --> k{node}[\"{check}\"]");
@@ -134,5 +147,62 @@ impl Report {
         }
 
         out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Locks in the single-check collapse and keeps it in sync with the
+    // workflow's jq renderer (validated against the same shape by
+    // tools/blast-radius-test.sh against tools/blast-radius-fixtures/).
+    #[test]
+    fn single_check_cause_collapses_to_one_node() {
+        let report = Report {
+            base: "aaaaaaa".into(),
+            head: "bbbbbbb".into(),
+            total: 120,
+            changed: vec![
+                "mcp-serverTools".into(),
+                "rust-test-search_core".into(),
+                "image-base".into(),
+                "lint".into(),
+            ],
+            added: vec!["mcp-evalSmoke".into()],
+            removed: vec![],
+            categories: vec![
+                Category { name: "rust".into(), count: 2 },
+                Category { name: "mcp".into(), count: 2 },
+                Category { name: "image".into(), count: 1 },
+                Category { name: "lint".into(), count: 1 },
+            ],
+            causes: vec![
+                CauseJson {
+                    name: "ix-rust-workspace".into(),
+                    checks: vec!["mcp-serverTools".into(), "rust-test-search_core".into()],
+                },
+                CauseJson {
+                    name: "image-base-layer".into(),
+                    checks: vec!["image-base".into()],
+                },
+                CauseJson {
+                    name: "ix-images-lint".into(),
+                    checks: vec!["lint".into()],
+                },
+            ],
+        };
+        let md = report.to_markdown();
+        // Multi-check cause keeps its drv label and draws arrows.
+        assert!(md.contains("c0[\"ix-rust-workspace\"]"));
+        assert!(md.contains("c0 --> k"));
+        // Single-check causes drop the drv label and use the check name, with
+        // no outgoing arrow.
+        assert!(md.contains("c1[\"image-base\"]"));
+        assert!(md.contains("c2[\"lint\"]"));
+        assert!(!md.contains("c1 -->"));
+        assert!(!md.contains("c2 -->"));
+        assert!(!md.contains("image-base-layer"));
+        assert!(!md.contains("ix-images-lint"));
     }
 }

--- a/tools/blast-radius-fixtures/good.expected.md
+++ b/tools/blast-radius-fixtures/good.expected.md
@@ -1,7 +1,7 @@
 <!-- blast-radius -->
 ### Blast radius
 
-`4` of `120` checks would rebuild between base `aaaaaaa` and head `bbbbbbb`.
+`5` of `120` checks would rebuild between base `aaaaaaa` and head `bbbbbbb`.
 
 1 added, 0 removed
 
@@ -10,15 +10,16 @@ pie showData title Rebuilt checks by category
   "rust" : 2
   "mcp" : 2
   "image" : 1
+  "lint" : 1
 ```
 
 ```mermaid
 flowchart LR
   c0["ix-rust-workspace"]
-  c1["image-base-layer"]
-  c0 --> k1["mcp-serverTools"]
-  c0 --> k2["rust-test-search_core"]
-  c1 --> k0["image-base"]
+  c1["image-base"]
+  c2["lint"]
+  c0 --> k2["mcp-serverTools"]
+  c0 --> k3["rust-test-search_core"]
 ```
 
 <details><summary>changed checks</summary>
@@ -26,5 +27,6 @@ flowchart LR
 - mcp-serverTools
 - rust-test-search_core
 - image-base
+- lint
 
 </details>

--- a/tools/blast-radius-fixtures/good.json
+++ b/tools/blast-radius-fixtures/good.json
@@ -1,6 +1,7 @@
 {"base":"aaaaaaa","head":"bbbbbbb","total":120,
- "changed":["mcp-serverTools","rust-test-search_core","image-base"],
+ "changed":["mcp-serverTools","rust-test-search_core","image-base","lint"],
  "added":["mcp-evalSmoke"],"removed":[],
- "categories":[{"name":"rust","count":2},{"name":"mcp","count":2},{"name":"image","count":1}],
+ "categories":[{"name":"rust","count":2},{"name":"mcp","count":2},{"name":"image","count":1},{"name":"lint","count":1}],
  "causes":[{"name":"ix-rust-workspace","checks":["mcp-serverTools","rust-test-search_core"]},
-           {"name":"image-base-layer","checks":["image-base"]}]}
+           {"name":"image-base-layer","checks":["image-base"]},
+           {"name":"ix-images-lint","checks":["lint"]}]}


### PR DESCRIPTION
Fixes the apparent "self-loop" in the cause flowchart on PRs like #680 where the cause and the check are two names for the same thing.

The frontier walk in `packages/blast-radius/src/causes.rs:71-99` lands on the check's own per-unit derivation when nothing changed below it. The current renderer then draws an arrow between a cause node and a check node whose labels are effectively identical:

```
blast-radius-test --> blast-radius-test
ix-images-lint    --> lint
oci-image-builder-clippy-0.1.0 --> rust-oci-image-builder-clippy
```

The arrow carries no information (the drv name and the flake check attribute name are the same root cause under two naming surfaces), and the duplication reads as a graph bug.

After this change, any cause with exactly one check renders as a single node labeled with the check name and no outgoing arrow. Multi-check causes still fan out `cause -> check` across the shared check nodes. JSON keeps both fields, so nothing downstream needs to change.

Mirrored in both renderers (`packages/blast-radius/src/report.rs` and the trusted jq in `.github/workflows/blast-radius.yml`), with a Rust unit test on `to_markdown` and the workflow fixture extended to cover a mismatched cause/check name pair so the two paths cannot drift.

Made with AI (Claude Opus 4.7).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collapse single-check causes into one node in blast-radius Mermaid flowchart
> - When a cause maps to exactly one check, `Report::to_markdown` now uses the check name as the node label and omits the edge; multi-check causes retain the drv label and fan out with edges as before.
> - The same logic is applied to the jq-based renderer in [blast-radius.yml](.github/workflows/blast-radius.yml) for parity.
> - A new unit test in [report.rs](packages/blast-radius/src/report.rs) and updated fixtures in [good.expected.md](tools/blast-radius-fixtures/good.expected.md) and [good.json](tools/blast-radius-fixtures/good.json) cover both cases.
> - Behavioral Change: PR comments and reports will now show fewer nodes and edges for causes that affect only one check.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ff0a28.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->