### PR TITLE
feat(blast-radius): annotate rebuilt-checks with base-branch wall-clock

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -122,7 +122,13 @@ jobs:
               (.categories | type == "array") and
               (.categories | all((.name | name_ok) and (.count | type == "number"))) and
               (.causes | type == "array") and
-              (.causes | all((.name | name_ok) and (.checks | type == "array") and (.checks | all(name_ok))))
+              (.causes | all((.name | name_ok) and (.checks | type == "array") and (.checks | all(name_ok)))) and
+              # `timings` is optional (omitted when empty by the Rust crate via
+              # skip_serializing_if). When present it must be a string -> number
+              # map; the same `name_ok` charset gates the keys so a malicious
+              # report cannot inject mention/HTML through a check label.
+              ((.timings // {}) | type == "object") and
+              ((.timings // {}) | to_entries | all((.key | name_ok) and (.value | type == "number")))
             )
           ' report.json > /dev/null \
             || { echo "::error::malformed blast-radius report.json"; exit 1; }
@@ -136,9 +142,22 @@ jobs:
           set -euo pipefail
           jq -r '
             def safename: select(test("^[A-Za-z0-9_./ +():-]+$"));
+            # Mirror packages/blast-radius/src/report.rs::format_seconds: bucket
+            # by magnitude, round to integer. Empty string for a missing entry
+            # so a bare label renders when an attr was a substituter hit or new
+            # on this PR.
+            def round_int: (. + 0.5) | floor;
+            def fmt_time:
+              if . == null then ""
+              elif . < 1 then " (<1s)"
+              elif . < 60 then " (\(round_int)s)"
+              elif . < 3600 then " (\(. / 60 | round_int)m)"
+              else " (\(. / 3600 | round_int)h)"
+              end;
             # Unique checks across all causes, so the flowchart shares one node
             # per check (keeps the graph under the Mermaid node budget).
             ([ .causes[].checks[] ] | unique) as $checks
+            | (.timings // {}) as $t
             | "<!-- blast-radius -->",
             "### Blast radius",
             "",
@@ -162,18 +181,18 @@ jobs:
              then "", "```mermaid", "flowchart LR",
                   (.causes | to_entries[]
                    | if (.value.checks | length) == 1
-                     then "  c\(.key)[\"\(.value.checks[0] | safename)\"]"
+                     then "  c\(.key)[\"\(.value.checks[0] | safename)\($t[.value.checks[0]] | fmt_time)\"]"
                      else "  c\(.key)[\"\(.value.name | safename)\"]"
                      end),
                   (.causes | to_entries[] as $c
                    | select(($c.value.checks | length) > 1)
                    | $c.value.checks[] as $k
-                   | "  c\($c.key) --> k\($checks | index($k))[\"\($k | safename)\"]"),
+                   | "  c\($c.key) --> k\($checks | index($k))[\"\($k | safename)\($t[$k] | fmt_time)\"]"),
                   "```"
              else empty end),
             (if (.changed | length) > 0
              then "", "<details><summary>changed checks</summary>", "",
-                  (.changed[] | safename | "- \(.)"),
+                  (.changed[] | safename as $n | "- \($n)\($t[$n] | fmt_time)"),
                   "", "</details>"
              else empty end)
           ' report.json > comment.md

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -82,3 +82,18 @@ jobs:
       # check fails to build or the flake stops evaluating.
       - name: Build all flake checks
         run: nix run .#check
+
+      # The `check` app writes nix-fast-build per-attr durations to
+      # check-results.json in the workspace (see lib/per-system.nix). Upload it
+      # so the blast-radius workflow can fetch the most recent successful base
+      # run and annotate the rebuilt-checks list with wall-clock seconds. The
+      # artifact is data-only, and the upload runs even on a failing build so a
+      # partial-timings snapshot still beats no timings at all.
+      - name: Upload check-results.json
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: check-timings-${{ github.run_id }}
+          path: check-results.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -154,6 +154,11 @@ let
         # nixConfig.extra-experimental-features carries it via
         # accept-flake-config; `--option extra-experimental-features` here pins
         # it for the build pool too so the gate is self-contained.
+        # --result-format json --result-file emits one record per attr per phase
+        # ({attr, type: EVAL|BUILD, duration, success, error, outputs}) into the
+        # cwd. blast-radius consumes this on a later PR via `--timings` to
+        # annotate the rebuilt-checks list with wall-clock seconds. The path is
+        # relative to the runner cwd; check.yml uploads it as an artifact.
         ^nix run $fast_build -- ...[
           "--flake" ".#checks.x86_64-linux"
           "--eval-max-memory-size" "6144"
@@ -161,6 +166,8 @@ let
           "--skip-cached"
           "--no-nom"
           "--no-link"
+          "--result-format" "json"
+          "--result-file" "check-results.json"
           "--option" "accept-flake-config" "true"
           "--option" "extra-experimental-features" "ca-derivations"
         ]

--- a/packages/blast-radius/src/main.rs
+++ b/packages/blast-radius/src/main.rs
@@ -10,8 +10,10 @@ mod causes;
 mod git;
 mod nix;
 mod report;
+mod timings;
 
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 use clap::Parser;
 use color_eyre::eyre::Result;
@@ -38,6 +40,11 @@ struct Cli {
     /// Emit the machine-readable report.json instead of Markdown.
     #[arg(long)]
     json: bool,
+    /// nix-fast-build `check-results.json` from a prior successful Check run
+    /// (typically the base branch). Used to annotate the rebuilt-checks list
+    /// with per-attr wall-clock seconds. Missing attrs are omitted, not zeroed.
+    #[arg(long, value_name = "PATH")]
+    timings: Option<PathBuf>,
 }
 
 fn short(rev: &str) -> String {
@@ -109,6 +116,11 @@ fn main() -> Result<()> {
         root_causes(&base_graph, &head_graph, &changed_basenames, CAPS)
     };
 
+    let timings = match cli.timings.as_deref() {
+        Some(path) => timings::load(path)?,
+        None => BTreeMap::new(),
+    };
+
     let report = Report {
         base: short(&revs.base),
         head: short(&revs.head),
@@ -118,6 +130,7 @@ fn main() -> Result<()> {
         changed,
         added,
         removed,
+        timings,
     };
 
     if cli.json {

--- a/packages/blast-radius/src/report.rs
+++ b/packages/blast-radius/src/report.rs
@@ -45,6 +45,30 @@ pub struct Report {
     pub removed: Vec<String>,
     pub categories: Vec<Category>,
     pub causes: Vec<CauseJson>,
+    /// Per-attribute wall-clock seconds from the prior successful Check run on
+    /// the base branch (see [`crate::timings`]). Empty when no prior run was
+    /// available; missing attrs are checks that were a substituter hit (never
+    /// rebuilt) or are new on this PR.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub timings: BTreeMap<String, f64>,
+}
+
+/// Format `seconds` as a short, scannable suffix: `<1s` under a second,
+/// `12s` under a minute, `5m` under an hour, `2h` beyond. Rounding goes
+/// through `f64::round` (round half-away-from-zero) so the output matches
+/// the jq renderer in `.github/workflows/blast-radius.yml`, whose
+/// `(x + 0.5) | floor` is round half-up and agrees for non-negative values.
+/// `{:.0}` alone would use Rust's round-half-to-even and silently diverge.
+pub fn format_seconds(seconds: f64) -> String {
+    if seconds < 1.0 {
+        "<1s".to_owned()
+    } else if seconds < 60.0 {
+        format!("{:.0}s", seconds.round())
+    } else if seconds < 3600.0 {
+        format!("{:.0}m", (seconds / 60.0).round())
+    } else {
+        format!("{:.0}h", (seconds / 3600.0).round())
+    }
 }
 
 /// Count `changed + added` checks by category, most-rebuilt family first.
@@ -73,6 +97,17 @@ impl Report {
     /// Render the sticky-comment Markdown, mirroring the trusted workflow
     /// renderer: one shared flowchart node per check, capped to the drawn causes.
     pub fn to_markdown(&self) -> String {
+        // Suffix any check label with ` (12s)` when the base-branch timings
+        // include it. A missing attr is a substituter hit or a new check on
+        // this PR (no base timing) and renders bare. Shared by the cause
+        // flowchart and the changed-checks list so both stay consistent.
+        let label_for = |attr: &str| {
+            self.timings.get(attr).map_or_else(
+                || attr.to_owned(),
+                |seconds| format!("{attr} ({})", format_seconds(*seconds)),
+            )
+        };
+
         let mut out = String::new();
         out.push_str("<!-- blast-radius -->\n### Blast radius\n\n");
         let rebuilt = self.changed.len() + self.added.len();
@@ -120,9 +155,9 @@ impl Report {
             // multi-check causes still fan out cause -> check.
             for (index, cause) in self.causes.iter().enumerate() {
                 let label = if cause.checks.len() == 1 {
-                    &cause.checks[0]
+                    label_for(&cause.checks[0])
                 } else {
-                    &cause.name
+                    cause.name.clone()
                 };
                 let _ = writeln!(out, "  c{index}[\"{label}\"]");
             }
@@ -132,7 +167,8 @@ impl Report {
                 }
                 for check in &cause.checks {
                     let node = checks.iter().position(|name| name == check).unwrap_or(0);
-                    let _ = writeln!(out, "  c{index} --> k{node}[\"{check}\"]");
+                    let label = label_for(check);
+                    let _ = writeln!(out, "  c{index} --> k{node}[\"{label}\"]");
                 }
             }
             out.push_str("```\n");
@@ -141,7 +177,7 @@ impl Report {
         if !self.changed.is_empty() {
             out.push_str("\n<details><summary>changed checks</summary>\n\n");
             for name in &self.changed {
-                let _ = writeln!(out, "- {name}");
+                let _ = writeln!(out, "- {}", label_for(name));
             }
             out.push_str("\n</details>\n");
         }
@@ -154,12 +190,8 @@ impl Report {
 mod tests {
     use super::*;
 
-    // Locks in the single-check collapse and keeps it in sync with the
-    // workflow's jq renderer (validated against the same shape by
-    // tools/blast-radius-test.sh against tools/blast-radius-fixtures/).
-    #[test]
-    fn single_check_cause_collapses_to_one_node() {
-        let report = Report {
+    fn sample_report(timings: BTreeMap<String, f64>) -> Report {
+        Report {
             base: "aaaaaaa".into(),
             head: "bbbbbbb".into(),
             total: 120,
@@ -191,8 +223,16 @@ mod tests {
                     checks: vec!["lint".into()],
                 },
             ],
-        };
-        let md = report.to_markdown();
+            timings,
+        }
+    }
+
+    // Locks in the single-check collapse and keeps it in sync with the
+    // workflow's jq renderer (validated against the same shape by
+    // tools/blast-radius-test.sh against tools/blast-radius-fixtures/).
+    #[test]
+    fn single_check_cause_collapses_to_one_node() {
+        let md = sample_report(BTreeMap::new()).to_markdown();
         // Multi-check cause keeps its drv label and draws arrows.
         assert!(md.contains("c0[\"ix-rust-workspace\"]"));
         assert!(md.contains("c0 --> k"));
@@ -204,5 +244,40 @@ mod tests {
         assert!(!md.contains("c2 -->"));
         assert!(!md.contains("image-base-layer"));
         assert!(!md.contains("ix-images-lint"));
+    }
+
+    // When a base-branch Check artifact is fed in, every known attr is
+    // suffixed with `(<duration>)` in the cause flowchart and the
+    // changed-checks list; unknown attrs render bare.
+    #[test]
+    fn timings_annotate_checks_when_present() {
+        let timings: BTreeMap<String, f64> = [
+            ("mcp-serverTools".to_owned(), 42.0),
+            ("rust-test-search_core".to_owned(), 130.0),
+            ("image-base".to_owned(), 0.6),
+            // `lint` deliberately omitted: cache hit or new check, no suffix.
+        ]
+        .into();
+        let md = sample_report(timings).to_markdown();
+        // Multi-check cause: per-check arrows carry the suffix. Check nodes
+        // are k<index> into the sorted+deduped unique check list, so
+        // mcp-serverTools is k2 and rust-test-search_core is k3.
+        assert!(md.contains("k2[\"mcp-serverTools (42s)\"]"));
+        assert!(md.contains("k3[\"rust-test-search_core (2m)\"]"));
+        // Single-check cause: collapsed node carries the suffix.
+        assert!(md.contains("c1[\"image-base (<1s)\"]"));
+        // Known timing missing: bare label, no parens.
+        assert!(md.contains("c2[\"lint\"]"));
+        // Changed-checks list mirrors the same annotation.
+        assert!(md.contains("- mcp-serverTools (42s)\n"));
+        assert!(md.contains("- lint\n"));
+    }
+
+    #[test]
+    fn format_seconds_buckets() {
+        assert_eq!(format_seconds(0.4), "<1s");
+        assert_eq!(format_seconds(12.4), "12s");
+        assert_eq!(format_seconds(89.9), "1m");
+        assert_eq!(format_seconds(7200.0), "2h");
     }
 }

--- a/packages/blast-radius/src/timings.rs
+++ b/packages/blast-radius/src/timings.rs
@@ -1,0 +1,74 @@
+//! Parse nix-fast-build's `--result-format json --result-file` output (the
+//! `check` app writes it to `check-results.json` in cwd; check.yml uploads it
+//! as an artifact).
+//!
+//! Each entry is one phase for one attr: `{attr, type: "EVAL" | "BUILD",
+//! duration, success, error, outputs}`. We only care about the BUILD pass:
+//! that is the wall-clock the rebuilt-checks list annotates.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use color_eyre::eyre::{Context as _, Result};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct ResultFile {
+    results: Vec<Entry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Entry {
+    attr: String,
+    #[serde(rename = "type")]
+    kind: String,
+    duration: f64,
+}
+
+/// Map of attribute -> BUILD wall-clock seconds. EVAL entries are dropped; a
+/// missing attr (substituter cache hit, never rebuilt this run) is absent
+/// from the map rather than reported as zero.
+pub fn load<P: AsRef<Path>>(path: P) -> Result<BTreeMap<String, f64>> {
+    let path = path.as_ref();
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("read nix-fast-build result file {}", path.display()))?;
+    parse(&raw)
+        .with_context(|| format!("parse nix-fast-build result file {}", path.display()))
+}
+
+fn parse(raw: &str) -> Result<BTreeMap<String, f64>> {
+    let file: ResultFile = serde_json::from_str(raw)?;
+    let mut out = BTreeMap::new();
+    for entry in file.results {
+        if entry.kind == "BUILD" {
+            // Later entries win on the rare retry; nix-fast-build emits a fresh
+            // BUILD record per attempt.
+            out.insert(entry.attr, entry.duration);
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drops_eval_entries_and_keeps_build_durations() {
+        let raw = r#"{
+            "results": [
+                {"attr": "lint", "type": "EVAL", "duration": 0.0, "success": true, "error": null},
+                {"attr": "lint", "type": "BUILD", "duration": 12.5, "success": true, "error": null, "outputs": {"out": "/nix/store/abc"}},
+                {"attr": "rust-test-search", "type": "BUILD", "duration": 87.3, "success": true, "error": null, "outputs": {"out": "/nix/store/def"}}
+            ]
+        }"#;
+        let map = parse(raw).unwrap();
+        assert_eq!(map.len(), 2);
+        // f64 equality is forbidden by clippy::float_cmp; the BUILD durations
+        // are deliberate small constants so an absolute-tolerance check is
+        // sufficient and avoids the lint suppression.
+        assert!((map["lint"] - 12.5).abs() < 1e-9);
+        assert!((map["rust-test-search"] - 87.3).abs() < 1e-9);
+    }
+}

--- a/tools/blast-radius-fixtures/good.expected.md
+++ b/tools/blast-radius-fixtures/good.expected.md
@@ -16,17 +16,17 @@ pie showData title Rebuilt checks by category
 ```mermaid
 flowchart LR
   c0["ix-rust-workspace"]
-  c1["image-base"]
+  c1["image-base (<1s)"]
   c2["lint"]
-  c0 --> k2["mcp-serverTools"]
-  c0 --> k3["rust-test-search_core"]
+  c0 --> k2["mcp-serverTools (42s)"]
+  c0 --> k3["rust-test-search_core (2m)"]
 ```
 
 <details><summary>changed checks</summary>
 
-- mcp-serverTools
-- rust-test-search_core
-- image-base
+- mcp-serverTools (42s)
+- rust-test-search_core (2m)
+- image-base (<1s)
 - lint
 
 </details>

--- a/tools/blast-radius-fixtures/good.json
+++ b/tools/blast-radius-fixtures/good.json
@@ -4,4 +4,5 @@
  "categories":[{"name":"rust","count":2},{"name":"mcp","count":2},{"name":"image","count":1},{"name":"lint","count":1}],
  "causes":[{"name":"ix-rust-workspace","checks":["mcp-serverTools","rust-test-search_core"]},
            {"name":"image-base-layer","checks":["image-base"]},
-           {"name":"ix-images-lint","checks":["lint"]}]}
+           {"name":"ix-images-lint","checks":["lint"]}],
+ "timings":{"mcp-serverTools":42.0,"rust-test-search_core":130.0,"image-base":0.6}}


### PR DESCRIPTION
A blast-radius comment that says "5 of 120 checks would rebuild" doesn't say which of those 5 take 10s and which take 10m. This adds per-check wall-clock so the reader can tell at a glance whether a small-looking PR is about to rebuild something expensive.

The change is in three pieces:

1. `lib/per-system.nix`: the `.#check` Nushell app passes nix-fast-build `--result-format json --result-file check-results.json`. nix-fast-build already emits one record per attr per phase with a `duration` field, so no per-build wrappers are needed.

2. `.github/workflows/check.yml`: uploads `check-results.json` as `check-timings-${run_id}` for 30 days (long enough that a blast-radius PR run can find the most recent successful base-branch run).

3. `packages/blast-radius/`: adds `--timings <path>`. A new `timings` module parses nix-fast-build's JSON, dropping `EVAL` entries and keeping per-attr `BUILD` seconds. The Report serializes them as an optional `timings: {attr: seconds}` map and the renderer suffixes each check label with `(12s)` / `(5m)` / `(2h)` / `(<1s)`; a missing attr (substituter hit, or a new check on this PR) renders bare.

Both renderers move together: the local `to_markdown` in `packages/blast-radius/src/report.rs` and the trusted jq in `.github/workflows/blast-radius.yml`. Rounding uses round-half-away-from-zero in Rust so its output matches jq's `(x + 0.5) | floor`; `{:.0}` alone would round half-to-even and silently diverge on `.5` boundaries. The schema validator accepts the new optional field and gates its keys through the same charset as check names, so a hostile report cannot inject HTML through a label.

The fixture exercises a check with no timing (`lint`) so the empty case is locked.

**Scope:** this PR captures the data, exposes the CLI surface, and renders the field when present. It does NOT yet wire `blast-radius.yml` to fetch the base-branch timings artifact via `gh api` and pass `--timings` to the CLI; that is a small follow-up.

Validated: `nix build .#blast-radius` on darwin; `rust-blast-radius-blast-radius-all`, `rust-blast-radius-clippy`, and `blast-radius-test` on x86_64-linux (vin-compute-1); workflow-extracted jq test in `tools/blast-radius-test.sh`.

Made with AI (Claude Opus 4.7).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Annotate blast-radius rebuilt-checks with base-branch wall-clock timings
> - Adds a `--timings` flag to the `blast-radius` binary that accepts a `nix-fast-build` `check-results.json` path; parsed BUILD durations are stored in a `BTreeMap<String, f64>` and attached to the `Report` struct.
> - Timing data is surfaced in both Markdown output (flowchart node labels and changed-checks list) and serialized `report.json` as a `timings` object, omitted when empty.
> - A new [`timings.rs`](https://github.com/indexable-inc/index/pull/682/files#diff-d01a843a7f3d06afa53965b354dadf9a47a5c27068a4de3ba5511fd0a69ae8d0) module handles parsing, dropping EVAL entries and keeping only BUILD records.
> - [`check.yml`](https://github.com/indexable-inc/index/pull/682/files#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428) uploads `check-results.json` as a `check-timings-${{ github.run_id }}` artifact on every run; [`lib/per-system.nix`](https://github.com/indexable-inc/index/pull/682/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) passes `--result-format json --result-file check-results.json` to `nix-fast-build` to produce the file.
> - The blast-radius workflow validates the optional `timings` field as a string-to-number map and renders durations into flowchart labels using `s`/`m`/`h` buckets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c1f6d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->