### PR TITLE
feat(packages): add fff (fast file-search MCP server)

### DIFF
--- a/packages/fff/default.nix
+++ b/packages/fff/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  stdenv,
+}:
+# External-Rust-tool house style: a standalone third-party binary built from a
+# pinned `fetchFromGitHub` rev with `rustPlatform.buildRustPackage`. See
+# `agent-context/sections/13-dependency-intake.md` and `packages/launchk`.
+#
+# fff is a fast file-search toolkit for humans and AI agents. The shipped binary
+# is `fff-mcp`: a CLI / MCP server over the in-memory file + content index.
+let
+  src = fetchFromGitHub {
+    owner = "dmtrKovalenko";
+    repo = "fff";
+    rev = "v0.9.1";
+    hash = "sha256-6ZmEeN/Ued9FZo/qfUb8/0L02F+8ECV0smAiQvIqyzU=";
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "fff";
+  version = "0.9.1";
+
+  inherit src;
+
+  # fff commits a pure-crates.io Cargo.lock, so read it straight from the
+  # source: a rev bump carries the dependency set with no coarse cargoHash to
+  # refresh by hand.
+  cargoLock.lockFile = src + "/Cargo.lock";
+
+  strictDeps = true;
+
+  # libgit2-sys (git2 with vendored-libgit2) and lmdb-master-sys (heed) build
+  # their C deps; pkg-config and cmake are the build-host tools they probe for.
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  # Build only the fff-mcp binary and skip the workspace's default `zlob`
+  # feature, which shells out to a system Zig install at build time (see
+  # crates/fff-core/build.rs). Without zlob the crate falls back to the pure-Rust
+  # globset matcher.
+  buildAndTestSubdir = "crates/fff-mcp";
+  buildNoDefaultFeatures = true;
+
+  meta = {
+    description = "Fast file-search toolkit for humans and AI agents (fff-mcp CLI / MCP server)";
+    homepage = "https://github.com/dmtrKovalenko/fff";
+    license = lib.licenses.mit;
+    mainProgram = "fff-mcp";
+    platforms = lib.platforms.unix;
+  };
+}

--- a/packages/fff/package.nix
+++ b/packages/fff/package.nix
@@ -1,0 +1,8 @@
+{
+  id = "fff";
+  # fff-mcp builds on Linux and macOS (see meta.platforms in default.nix), so
+  # surface it on every system: as `pkgs.fff` in the repo package set and as the
+  # `fff` flake output.
+  packageSet = true;
+  flake = true;
+}


### PR DESCRIPTION
Add a package for fff (dmtrKovalenko/fff), a fast file-search toolkit for AI agents. Ships the `fff-mcp` CLI / MCP server.

- pinned to v0.9.1, built with rustPlatform.buildRustPackage following the launchk house style
- zlob default feature off so no build-time Zig dep (pure-Rust globset fallback); `nix build .#fff` green, binary runs (`--version`, `--help`, `--healthcheck`)

Created with AI (Claude Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `fff` fast file-search MCP server as a Nix package
> Adds a Nix derivation in [packages/fff/default.nix](https://github.com/indexable-inc/index/pull/683/files#diff-7ff18369337bbb373952583482f8f92145a22466d9feacf2feb103fb8b953709) that builds `fff-mcp` (v0.9.1) from a pinned GitHub source using `rustPlatform.buildRustPackage`. Only the `crates/fff-mcp` sub-crate is built, with default features disabled to skip the `zlob` feature. The package is registered in [packages/fff/package.nix](https://github.com/indexable-inc/index/pull/683/files#diff-9640686e6d49ba70ecdc88f4278ca638927819f00adfa47328befd4b82e2478d) and surfaced as `pkgs.fff` and a flake output, restricted to Unix platforms.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c2a5d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->