### PR TITLE
style: nixfmt modules/home/raycast.nix

### DIFF
--- a/modules/home/raycast.nix
+++ b/modules/home/raycast.nix
@@ -35,17 +35,19 @@ let
   };
 
   # key -> JSON document Raycast stores as a plist <data> value
-  dataKeys =
-    { "raycast-startFocusSession-duration" = durationJson; }
-    // lib.optionalAttrs (cfg.categoryBlockableItems != null) {
-      "raycast-focus-category-blockable-items" = cfg.categoryBlockableItems;
-    }
-    // lib.optionalAttrs (cfg.blockableItems != null) {
-      "raycast-startFocusSession-blockable-items" = cfg.blockableItems;
-    };
+  dataKeys = {
+    "raycast-startFocusSession-duration" = durationJson;
+  }
+  // lib.optionalAttrs (cfg.categoryBlockableItems != null) {
+    "raycast-focus-category-blockable-items" = cfg.categoryBlockableItems;
+  }
+  // lib.optionalAttrs (cfg.blockableItems != null) {
+    "raycast-startFocusSession-blockable-items" = cfg.blockableItems;
+  };
 
   writeString =
-    key: val: "$DRY_RUN_CMD /usr/bin/defaults write ${domain} ${lib.escapeShellArg key} ${lib.escapeShellArg val}";
+    key: val:
+    "$DRY_RUN_CMD /usr/bin/defaults write ${domain} ${lib.escapeShellArg key} ${lib.escapeShellArg val}";
 
   # `defaults write -data` takes contiguous hex; od emits the JSON bytes as hex.
   writeData =


### PR DESCRIPTION
Format-only. The Raycast module from #684 landed slightly mis-formatted; the repo nixfmt collapses two `attrs-then-merge` spellings to the canonical form. No semantics change.

I'm hitting this in another PR because the pre-commit hook fails on the whole tree, so unblocking it here keeps the rest of my work small.

Made with AI (Claude Opus 4.7).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Format `modules/home/raycast.nix` with nixfmt
> Applies nixfmt formatting to [raycast.nix](https://github.com/indexable-inc/index/pull/685/files#diff-e733dbb02cd5bdcf1c9094b3ec75f7c7f4a62375c9be76ce3d12e2d6002e5d66) with no logical or structural changes. Reformats the `dataKeys` attrset merges onto separate lines and reflows the `writeString` function definition for readability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bdbc344.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->