### PR TITLE
feat(mcp): default Jupyter bind to the node's Tailscale IPv4

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -27,15 +27,20 @@ reachable Jupyter Server is arbitrary code execution for whoever can dial it.
 
 Two env vars control how a remote VM hands back a reachable URL:
 
-- `IX_MCP_HOST` (default `127.0.0.1`): the address Jupyter binds. Set it to
-  `0.0.0.0` to listen on every interface so the lab is reachable off-box.
+- `IX_MCP_HOST`: the address Jupyter binds. The default is this node's
+  Tailscale IPv4 (`100.x.y.z`) when Tailscale is up, so a phone or laptop on
+  the same tailnet can open the lab URL without ssh. Falls back to `127.0.0.1`
+  when Tailscale is not up. Set it to `0.0.0.0` to listen on every interface
+  (do this only behind a host firewall), or to a specific address to override
+  the auto-detected Tailscale IP.
 - `IX_MCP_PUBLIC_HOST`: the host put into the lab URL. Set it to force a specific
   name (e.g. `myvm.tail368802.ts.net`).
 
+The default Tailscale-IP bind keeps the trust boundary at the tailnet: only
+tailnet peers can dial `100.x.y.z`, so the local Wi-Fi cannot reach the server.
 If you bind a wildcard (`0.0.0.0`/`::`) without setting `IX_MCP_PUBLIC_HOST`, the
 URL host is auto-resolved to a reachable name: the Tailscale MagicDNS name first,
-then the FQDN, then `127.0.0.1` as a fallback. The default loopback bind keeps
-the URL on `127.0.0.1` and the server unexposed.
+then the FQDN, then `127.0.0.1` as a fallback.
 
 ## How it works
 

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -468,6 +468,66 @@ let
         mkdir -p "$out"
       '';
 
+  # Locks the bind-address default: with a working `tailscale status --json`
+  # in PATH, `_tailscale_ip()` returns the first IPv4 from `Self.TailscaleIPs`
+  # so the Jupyter Server is reachable from any tailnet peer; with no tailscale
+  # binary, it returns None so the CLI falls through to loopback. The mock
+  # binary lives in TMP/path so we control PATH exactly without touching the
+  # real tailscale state. The mock is shell, not a subprocess of an actual
+  # tailscale, so this test runs in the Nix sandbox.
+  bindDefaultTest = pkgs.writeText "ix-mcp-bind-default-test.py" ''
+    from unittest.mock import patch
+    from ix_notebook_mcp import cli
+
+    status = {
+        "Self": {
+            "TailscaleIPs": ["100.64.0.7", "fd7a::1"],
+            "DNSName": "node.tail-x.ts.net.",
+        }
+    }
+
+    # Happy path: tailscale is up. The helper picks the first IPv4 and strips
+    # the trailing dot from the DNS name.
+    with patch.object(cli, "_tailscale_status", return_value=status):
+        assert cli._tailscale_ip() == "100.64.0.7", f"got {cli._tailscale_ip()!r}"
+        assert cli._tailscale_dns_name() == "node.tail-x.ts.net", f"got {cli._tailscale_dns_name()!r}"
+
+    # No tailscale: the helpers return None so the CLI falls back to loopback.
+    # Stubbing the inner _tailscale_status is more robust than juggling PATH or
+    # the absolute fallback paths the real helper probes (which exist on hydra
+    # outside the sandbox, so a PATH-only test would still find them).
+    with patch.object(cli, "_tailscale_status", return_value=None):
+        assert cli._tailscale_ip() is None, "expected None when tailscale is unavailable"
+        assert cli._tailscale_dns_name() is None, "expected None when tailscale is unavailable"
+
+    # IPv6-only or empty IP list: still None (the bind expects IPv4).
+    with patch.object(cli, "_tailscale_status", return_value={"Self": {"TailscaleIPs": ["fd7a::1"]}}):
+        assert cli._tailscale_ip() is None, "IPv6-only TailscaleIPs should yield None"
+
+    print("bind-default-ok")
+  '';
+  bindDefaultSmoke =
+    pkgs.runCommand "ix-mcp-bind-default-smoke"
+      {
+        nativeBuildInputs = [ mcpPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        ${mcpPython}/bin/python3 ${bindDefaultTest} >stdout 2>stderr || {
+          echo "ix-mcp bind-default smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -qx 'bind-default-ok' stdout || {
+          echo "ix-mcp bind-default smoke did not confirm helper behaviour:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
+
   # Boots a real kernel with the shipped IPython startup in place and proves a
   # polars DataFrame comes back as an interactive itables table (the human's
   # JupyterLab upgrade) while keeping its text/plain repr (the agent path). Reads
@@ -548,6 +608,7 @@ package.overrideAttrs (old: {
         serverTools
         evalSmoke
         tablesSmoke
+        bindDefaultSmoke
         ;
     }
     // lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -128,12 +128,12 @@ def _free_port() -> int:
         return sock.getsockname()[1]
 
 
-def _tailscale_dns_name() -> str | None:
-    """This node's MagicDNS name (e.g. ``host.tail<id>.ts.net``), or None.
+def _tailscale_status() -> dict | None:
+    """Parsed ``tailscale status --json`` for this node, or None.
 
-    Best-effort: locating the binary and parsing `tailscale status --json` can
-    fail many ways (no tailscale, not logged in, malformed output); every such
-    case yields None rather than raising, so the caller can fall through.
+    Best-effort: locating the binary and parsing the output can fail many ways
+    (no tailscale, not logged in, malformed output); every such case yields
+    None rather than raising, so the callers can fall through.
     """
     tailscale = (
         shutil.which("tailscale")
@@ -150,11 +150,35 @@ def _tailscale_dns_name() -> str | None:
             timeout=2,
             check=True,
         ).stdout
-        name = json.loads(out).get("Self", {}).get("DNSName", "")
+        return json.loads(out)
     except Exception:
         return None
-    name = name.rstrip(".")
+
+
+def _tailscale_dns_name() -> str | None:
+    """This node's MagicDNS name (e.g. ``host.tail<id>.ts.net``), or None."""
+    status = _tailscale_status()
+    if not status:
+        return None
+    name = status.get("Self", {}).get("DNSName", "").rstrip(".")
     return name or None
+
+
+def _tailscale_ip() -> str | None:
+    """This node's first Tailscale IPv4 address (e.g. ``100.x.y.z``), or None.
+
+    Used as the default Jupyter bind so the lab URL is reachable from any
+    tailnet peer (phone, laptop) without re-exposing the server to the local
+    Wi-Fi: only tailnet members can dial 100.x.y.z. Falls through to loopback
+    when Tailscale is not up.
+    """
+    status = _tailscale_status()
+    if not status:
+        return None
+    for ip in status.get("Self", {}).get("TailscaleIPs", []) or []:
+        if isinstance(ip, str) and "." in ip and ":" not in ip:
+            return ip
+    return None
 
 
 def _advertised_host(bind_host: str) -> str:
@@ -188,9 +212,14 @@ def _serve(args: argparse.Namespace) -> int:
     workdir.mkdir(parents=True, exist_ok=True)
 
     # Resolve both host knobs once here (Config is pure data): the bind address
-    # Jupyter listens on, and the host advertised in the lab URL. Default bind is
-    # loopback so the server is never exposed unless asked.
-    bind_host = os.environ.get("IX_MCP_HOST", "127.0.0.1")
+    # Jupyter listens on, and the host advertised in the lab URL. The default
+    # bind is this node's Tailscale IPv4 when Tailscale is up, falling back to
+    # loopback otherwise. The Tailscale IP is reachable only from tailnet peers,
+    # so the trust boundary stays "tailnet only" (the local Wi-Fi cannot dial it)
+    # while a phone or laptop on the tailnet can open the lab URL without ssh.
+    # IX_MCP_HOST still wins for an explicit override (e.g. 0.0.0.0 on a fleet
+    # node that is firewalled).
+    bind_host = os.environ.get("IX_MCP_HOST") or _tailscale_ip() or "127.0.0.1"
     advertised_host = _advertised_host(bind_host)
 
     http = getattr(args, "http", None)

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -24,10 +24,14 @@ class Config:
     # The Jupyter Server bind address. The server runs with auth disabled (no
     # token, no password): the lab URL opens straight into the live notebook so a
     # human can co-edit without copying a token out of band. Access is instead
-    # gated by reachability: the default bind is loopback, and the fleet only
-    # exposes it over Tailscale, where the tailnet is the trust boundary. Note a
-    # reachable Jupyter Server is arbitrary code execution for whoever can dial
-    # it, so never bind it to a public interface.
+    # gated by reachability: the CLI default is this node's Tailscale IPv4 when
+    # Tailscale is up (so the tailnet is the trust boundary and a phone or
+    # laptop on the tailnet can open the lab URL without ssh), and loopback
+    # otherwise. The dataclass default stays loopback so an in-process Config()
+    # in a test cannot accidentally bind to a tailnet address; the CLI overrides
+    # this when it builds the real Config. Note a reachable Jupyter Server is
+    # arbitrary code execution for whoever can dial it, so never bind it to a
+    # non-tailnet public interface without an explicit IX_MCP_HOST override.
     host: str = "127.0.0.1"
     jupyter_port: int = 0
 


### PR DESCRIPTION
`ix-mcp serve` defaulted to `127.0.0.1`, so the JupyterLab co-edit URL was only usable from the host. To open it from a phone or laptop on the same tailnet you had to ssh in or set `IX_MCP_HOST=0.0.0.0`, which widens the trust boundary off the tailnet.

The bind default is now this node's first Tailscale IPv4 (`100.x.y.z`) when the `tailscale` CLI returns a usable status, falling back to loopback otherwise. Only tailnet peers can dial `100.x.y.z`, so the trust boundary stays "tailnet only" while the URL becomes reachable from any other tailnet device without re-exposing the server to local Wi-Fi.

Resolution order: `IX_MCP_HOST` (explicit override, still wins) → `_tailscale_ip()` → `127.0.0.1`. The `Config.host` dataclass default stays loopback so a unit test that instantiates `Config()` directly can never accidentally bind to a tailnet address; the CLI is the only place that substitutes the Tailscale IP.

`bindDefaultSmoke` mocks `_tailscale_status` at the inner boundary (rather than juggling PATH) because hydra's Darwin sandbox sees `/usr/local/bin/tailscale`, so a PATH-only test would still resolve it. The test pins three paths: happy IPv4, no-tailscale → None, IPv6-only entries → None.

Validated: `nix build .#mcp.tests.bindDefaultSmoke .#mcp.tests.evalSmoke .#mcp.tests.tablesSmoke .#mcp.tests.serverTools` all pass on aarch64-darwin.

Made with AI (Claude Opus 4.7).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `ix-mcp serve` to bind Jupyter to the node's Tailscale IPv4
> - Adds `_tailscale_ip()` in [cli.py](https://github.com/indexable-inc/index/pull/686/files#diff-7ce741e8223d63fdea11625cb78abad266299445db0213d2355bc93306df9ac5) to retrieve the node's Tailscale IPv4 from `tailscale status --json`; returns `None` if Tailscale is unavailable or only IPv6 addresses are present.
> - Changes the default bind host in `_serve`: uses `IX_MCP_HOST` if set, then `_tailscale_ip()`, then falls back to `127.0.0.1`.
> - Refactors `_tailscale_dns_name` to share the new `_tailscale_status` helper instead of calling `tailscale` directly.
> - Adds a Nix smoke test in [default.nix](https://github.com/indexable-inc/index/pull/686/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) that validates the tailscale helper functions during the build.
> - Behavioral Change: on nodes with Tailscale up, the lab will now bind to `100.x.y.z` instead of `127.0.0.1`, making it reachable from tailnet peers without SSH forwarding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c29724.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->