### PR TITLE
chore(symphony): bump pinned input to a896b6ab

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -266,11 +266,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780248344,
-        "narHash": "sha256-dkpHwTbpQcxG9mOctMuSN4jRX2S/06aPGLMlJdqnebU=",
+        "lastModified": 1780588535,
+        "narHash": "sha256-EOfJBxgmjZVqtPSI3dG1I7UJ0JOZ/fj3KQ4XHTT+k+4=",
         "owner": "indexable-inc",
         "repo": "symphony",
-        "rev": "8b210247d64388e06f9e2e84a81a426999a9dd8c",
+        "rev": "a896b6ab23b9a6331f77cebc9cd5597d7fb73702",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Keep the `symphony` flake input current (`8b21024` → `a896b6ab`).

This rev carries symphony's room-transcript Slack-link change, the codex-tab removal (#253), and the quality-gate dialyzer fix (#254). The `room-server` package this repo builds the room-codex image from is **unchanged** in that range (no Rust changes), so the image content is unaffected - this just keeps the pinned input from drifting.

Only `flake.lock` changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump pinned `symphony` input to a896b6ab in flake.lock
> Updates [flake.lock](https://github.com/indexable-inc/index/pull/689/files#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9c) to pin the `symphony` input to commit `a896b6ab`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e553d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->