### PR TITLE
feat(blast-radius): tolerate per-attr eval failures instead of bailing

### DIFF
--- a/packages/blast-radius/src/main.rs
+++ b/packages/blast-radius/src/main.rs
@@ -60,25 +60,41 @@ fn short(rev: &str) -> String {
 /// is violated and are not in its required gate); those have no derivation, so
 /// they are excluded from the diff and only reported.
 fn guard_eval_failures(base: &nix::EvalResult, head: &nix::EvalResult) -> Result<()> {
-    let base_failures: BTreeSet<&str> = base.failures.iter().map(String::as_str).collect();
-    let new_failures: Vec<&str> = head
+    // Tolerate by attribute NAME, not by error text: some eval errors embed
+    // rev-varying store paths (e.g. an `*-no-nix-dependencies` check names the
+    // offending `.drv`), so comparing payloads would read the same pre-existing
+    // failure as new and false-bail on every run. An attr unevaluable at both
+    // base and head has no derivation at either, so it is out of rebuild scope
+    // regardless of WHY it fails.
+    let base_attrs: BTreeSet<&str> = base.failures.iter().map(|f| f.attr.as_str()).collect();
+    let new_failures: Vec<&nix::EvalFailure> = head
         .failures
         .iter()
-        .map(String::as_str)
-        .filter(|attr| !base_failures.contains(attr))
+        .filter(|f| !base_attrs.contains(f.attr.as_str()))
         .collect();
     if !new_failures.is_empty() {
+        // Surface the full error text: per-attr eval failures exit nix-eval-jobs
+        // 0, so this bail is the only place the cause reaches the CI log.
+        let detail = new_failures
+            .iter()
+            .map(|f| format!("  {}: {}", f.attr, f.error))
+            .collect::<Vec<_>>()
+            .join("\n");
         bail!(
-            "{} check(s) newly fail to evaluate at head (this change broke them): {}",
-            new_failures.len(),
-            new_failures.join(", ")
+            "{} check(s) newly fail to evaluate at head (this change broke them):\n{detail}",
+            new_failures.len()
         );
     }
     if !base.failures.is_empty() {
+        let names = base
+            .failures
+            .iter()
+            .map(|f| f.attr.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
         eprintln!(
-            "blast-radius: {} check(s) fail to evaluate at base and head; excluded from the diff: {}",
-            base.failures.len(),
-            base.failures.join(", ")
+            "blast-radius: {} check(s) fail to evaluate at base and head; excluded from the diff: {names}",
+            base.failures.len()
         );
     }
     Ok(())

--- a/packages/blast-radius/src/main.rs
+++ b/packages/blast-radius/src/main.rs
@@ -51,21 +51,15 @@ fn short(rev: &str) -> String {
     rev.chars().take(7).collect()
 }
 
-fn main() -> Result<()> {
-    color_eyre::install()?;
-    let cli = Cli::parse();
-    let revs = git::resolve(cli.base.as_deref(), cli.head.as_deref())?;
-
-    let base = nix::eval_checks(&revs.repo, &revs.base)?;
-    let head = nix::eval_checks(&revs.repo, &revs.head)?;
-
-    // An attr that fails to evaluate has no derivation, so it cannot be a rebuild
-    // target. Tolerate failures already present at base (a `.#checks` catalog is
-    // not guaranteed eval-clean: ix carries eval-assertion checks that throw when
-    // their invariant is violated and are not in its required gate). But FAIL
-    // CLOSED on any failure new at head -- a check this change broke, or a broken
-    // check it added -- so blast-radius never renders a successful-looking report
-    // that hides an eval regression it introduced.
+/// Fail closed if any check fails to evaluate at head that did not already fail
+/// at base. A failure new at head is a regression this change introduced (a
+/// check it broke, or a broken check it added), so the run aborts rather than
+/// render a successful-looking report that hides it. Failures present at base
+/// too are a pre-existing catalog issue (a `.#checks` set is not guaranteed
+/// eval-clean: ix carries eval-assertion checks that throw when their invariant
+/// is violated and are not in its required gate); those have no derivation, so
+/// they are excluded from the diff and only reported.
+fn guard_eval_failures(base: &nix::EvalResult, head: &nix::EvalResult) -> Result<()> {
     let base_failures: BTreeSet<&str> = base.failures.iter().map(String::as_str).collect();
     let new_failures: Vec<&str> = head
         .failures
@@ -87,7 +81,17 @@ fn main() -> Result<()> {
             base.failures.join(", ")
         );
     }
+    Ok(())
+}
 
+fn main() -> Result<()> {
+    color_eyre::install()?;
+    let cli = Cli::parse();
+    let revs = git::resolve(cli.base.as_deref(), cli.head.as_deref())?;
+
+    let base = nix::eval_checks(&revs.repo, &revs.base)?;
+    let head = nix::eval_checks(&revs.repo, &revs.head)?;
+    guard_eval_failures(&base, &head)?;
     let base = base.checks;
     let head = head.checks;
 

--- a/packages/blast-radius/src/main.rs
+++ b/packages/blast-radius/src/main.rs
@@ -12,11 +12,11 @@ mod nix;
 mod report;
 mod timings;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use clap::Parser;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, bail};
 
 use causes::{Caps, root_causes};
 use report::{Report, categories};
@@ -58,6 +58,38 @@ fn main() -> Result<()> {
 
     let base = nix::eval_checks(&revs.repo, &revs.base)?;
     let head = nix::eval_checks(&revs.repo, &revs.head)?;
+
+    // An attr that fails to evaluate has no derivation, so it cannot be a rebuild
+    // target. Tolerate failures already present at base (a `.#checks` catalog is
+    // not guaranteed eval-clean: ix carries eval-assertion checks that throw when
+    // their invariant is violated and are not in its required gate). But FAIL
+    // CLOSED on any failure new at head -- a check this change broke, or a broken
+    // check it added -- so blast-radius never renders a successful-looking report
+    // that hides an eval regression it introduced.
+    let base_failures: BTreeSet<&str> = base.failures.iter().map(String::as_str).collect();
+    let new_failures: Vec<&str> = head
+        .failures
+        .iter()
+        .map(String::as_str)
+        .filter(|attr| !base_failures.contains(attr))
+        .collect();
+    if !new_failures.is_empty() {
+        bail!(
+            "{} check(s) newly fail to evaluate at head (this change broke them): {}",
+            new_failures.len(),
+            new_failures.join(", ")
+        );
+    }
+    if !base.failures.is_empty() {
+        eprintln!(
+            "blast-radius: {} check(s) fail to evaluate at base and head; excluded from the diff: {}",
+            base.failures.len(),
+            base.failures.join(", ")
+        );
+    }
+
+    let base = base.checks;
+    let head = head.checks;
 
     let base_map: BTreeMap<&str, &str> = base
         .iter()

--- a/packages/blast-radius/src/nix.rs
+++ b/packages/blast-radius/src/nix.rs
@@ -25,6 +25,15 @@ pub struct Check {
     pub drv_path: String,
 }
 
+/// The result of evaluating `.#checks.x86_64-linux` at one rev: the buildable
+/// checks, plus the attrs that failed to evaluate there (no derivation, so not a
+/// rebuild target). The caller diffs `failures` across base and head to tell a
+/// pre-existing catalog failure (tolerated) from one this change introduced.
+pub struct EvalResult {
+    pub checks: Vec<Check>,
+    pub failures: Vec<String>,
+}
+
 /// One line of `nix-eval-jobs` output.
 #[derive(Deserialize)]
 struct EvalRow {
@@ -83,7 +92,7 @@ fn run(command: &mut Command) -> Result<String> {
 /// `nix-eval-jobs` sits at the head of the pipeline; a startup/lock/fetch
 /// failure surfaces here rather than yielding an empty set that silently
 /// under-reports the blast radius.
-pub fn eval_checks(repo: &str, rev: &str) -> Result<Vec<Check>> {
+pub fn eval_checks(repo: &str, rev: &str) -> Result<EvalResult> {
     let flakeref = format!("git+file://{repo}?rev={rev}&allRefs=1#checks.x86_64-linux");
     let stdout = run(Command::new("nix").args([
         "run",
@@ -125,24 +134,14 @@ pub fn eval_checks(repo: &str, rev: &str) -> Result<Vec<Check>> {
         );
     }
 
-    // A per-attr eval failure has no derivation at this rev, so it cannot be a
-    // rebuild target: exclude it from the diff rather than failing the whole
-    // report. A repo's `.#checks` catalog is not guaranteed to be eval-clean --
-    // ix carries eval-assertion checks (unfree-allowlist, *-invariants, ...)
-    // that throw when their invariant is violated and are not in its required
-    // gate, so a strict bail would make the report unusable there. The skip is
-    // summarized to stderr (never silent), which is the under-reporting the old
-    // hard bail guarded against.
-    if !eval_failures.is_empty() {
-        eval_failures.sort();
-        eprintln!(
-            "blast-radius: excluded {} check(s) that failed to evaluate at {rev} (no derivation, not a rebuild target): {}",
-            eval_failures.len(),
-            eval_failures.join(", ")
-        );
-    }
-
-    Ok(checks)
+    // Eval failures are returned, not skipped here: the caller distinguishes a
+    // failure present at base (a pre-existing catalog issue, tolerated) from one
+    // new at head (a regression this change introduced, which must fail closed).
+    eval_failures.sort();
+    Ok(EvalResult {
+        checks,
+        failures: eval_failures,
+    })
 }
 
 /// The outcome of classifying one `nix-eval-jobs` run: the buildable checks, the

--- a/packages/blast-radius/src/nix.rs
+++ b/packages/blast-radius/src/nix.rs
@@ -25,13 +25,23 @@ pub struct Check {
     pub drv_path: String,
 }
 
+/// An attr that failed to evaluate, with the nix-eval-jobs error. Carried (not
+/// just the name) so a fail-closed bail on a head regression can print WHY it
+/// failed: per-attr eval failures exit nix-eval-jobs 0, so the error text is
+/// otherwise never surfaced in CI logs.
+#[derive(Debug, PartialEq, Eq)]
+pub struct EvalFailure {
+    pub attr: String,
+    pub error: String,
+}
+
 /// The result of evaluating `.#checks.x86_64-linux` at one rev: the buildable
 /// checks, plus the attrs that failed to evaluate there (no derivation, so not a
 /// rebuild target). The caller diffs `failures` across base and head to tell a
 /// pre-existing catalog failure (tolerated) from one this change introduced.
 pub struct EvalResult {
     pub checks: Vec<Check>,
-    pub failures: Vec<String>,
+    pub failures: Vec<EvalFailure>,
 }
 
 /// One line of `nix-eval-jobs` output.
@@ -137,7 +147,7 @@ pub fn eval_checks(repo: &str, rev: &str) -> Result<EvalResult> {
     // Eval failures are returned, not skipped here: the caller distinguishes a
     // failure present at base (a pre-existing catalog issue, tolerated) from one
     // new at head (a regression this change introduced, which must fail closed).
-    eval_failures.sort();
+    eval_failures.sort_by(|left, right| left.attr.cmp(&right.attr));
     Ok(EvalResult {
         checks,
         failures: eval_failures,
@@ -149,7 +159,7 @@ pub fn eval_checks(repo: &str, rev: &str) -> Result<EvalResult> {
 /// unexpected shape (neither drvPath nor error).
 struct Partitioned {
     checks: Vec<Check>,
-    eval_failures: Vec<String>,
+    eval_failures: Vec<EvalFailure>,
     unexpected: Vec<String>,
 }
 
@@ -171,7 +181,7 @@ fn partition_eval_rows(stdout: &str) -> Result<Partitioned> {
         let attr = row.attr.trim_matches('"').to_owned();
         match (row.drv_path, row.error) {
             (Some(drv_path), _) => out.checks.push(Check { attr, drv_path }),
-            (None, Some(_)) => out.eval_failures.push(attr),
+            (None, Some(error)) => out.eval_failures.push(EvalFailure { attr, error }),
             (None, None) => out.unexpected.push(attr),
         }
     }
@@ -241,7 +251,7 @@ pub fn drv_for(checks: &[Check], attr: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{drv_name, partition_eval_rows};
+    use super::{EvalFailure, drv_name, partition_eval_rows};
 
     #[test]
     fn drv_name_strips_hash_and_suffix() {
@@ -276,7 +286,13 @@ mod tests {
         assert_eq!(partitioned.checks.len(), 1);
         assert_eq!(partitioned.checks[0].attr, "rust-test-foo");
         assert_eq!(partitioned.checks[0].drv_path, "/nix/store/aaa-foo.drv");
-        assert_eq!(partitioned.eval_failures, vec!["unfree-allowlist".to_owned()]);
+        assert_eq!(
+            partitioned.eval_failures,
+            vec![EvalFailure {
+                attr: "unfree-allowlist".to_owned(),
+                error: "unfree allowlist mismatch".to_owned(),
+            }]
+        );
         assert_eq!(partitioned.unexpected, vec!["weird.attr".to_owned()]);
     }
 }

--- a/packages/blast-radius/src/nix.rs
+++ b/packages/blast-radius/src/nix.rs
@@ -108,8 +108,61 @@ pub fn eval_checks(repo: &str, rev: &str) -> Result<Vec<Check>> {
     ]))
     .with_context(|| format!("evaluate checks at {rev}"))?;
 
-    let mut checks = Vec::new();
-    let mut errors = Vec::new();
+    let Partitioned {
+        checks,
+        mut eval_failures,
+        unexpected,
+    } = partition_eval_rows(&stdout)?;
+
+    // Neither a drvPath nor an error is a contract violation of nix-eval-jobs
+    // (every row carries one or the other); fail loudly rather than guess at a
+    // shape that could silently under-report the blast radius.
+    if !unexpected.is_empty() {
+        bail!(
+            "checks at {rev} produced {} row(s) with neither drvPath nor error: {}",
+            unexpected.len(),
+            unexpected.join(", ")
+        );
+    }
+
+    // A per-attr eval failure has no derivation at this rev, so it cannot be a
+    // rebuild target: exclude it from the diff rather than failing the whole
+    // report. A repo's `.#checks` catalog is not guaranteed to be eval-clean --
+    // ix carries eval-assertion checks (unfree-allowlist, *-invariants, ...)
+    // that throw when their invariant is violated and are not in its required
+    // gate, so a strict bail would make the report unusable there. The skip is
+    // summarized to stderr (never silent), which is the under-reporting the old
+    // hard bail guarded against.
+    if !eval_failures.is_empty() {
+        eval_failures.sort();
+        eprintln!(
+            "blast-radius: excluded {} check(s) that failed to evaluate at {rev} (no derivation, not a rebuild target): {}",
+            eval_failures.len(),
+            eval_failures.join(", ")
+        );
+    }
+
+    Ok(checks)
+}
+
+/// The outcome of classifying one `nix-eval-jobs` run: the buildable checks, the
+/// attrs that failed to evaluate (no derivation at this rev), and any rows of an
+/// unexpected shape (neither drvPath nor error).
+struct Partitioned {
+    checks: Vec<Check>,
+    eval_failures: Vec<String>,
+    unexpected: Vec<String>,
+}
+
+/// Parse one nix-eval-jobs JSONL stream and sort each row into [`Partitioned`].
+/// Pure (no subprocess) so the success / eval-failure / malformed split is unit
+/// tested without invoking nix.
+fn partition_eval_rows(stdout: &str) -> Result<Partitioned> {
+    let mut out = Partitioned {
+        checks: Vec::new(),
+        eval_failures: Vec::new(),
+        unexpected: Vec::new(),
+    };
     for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
         let row: EvalRow =
             serde_json::from_str(line).with_context(|| format!("parse eval row: {line}"))?;
@@ -118,18 +171,12 @@ pub fn eval_checks(repo: &str, rev: &str) -> Result<Vec<Check>> {
         // through the diff, the report, and the workflow's safename regex.
         let attr = row.attr.trim_matches('"').to_owned();
         match (row.drv_path, row.error) {
-            (Some(drv_path), _) => checks.push(Check { attr, drv_path }),
-            // A row with neither a drvPath nor an error is an unexpected shape;
-            // dropping it would silently under-report the blast radius (the very
-            // thing this evaluator is meant to avoid), so treat it as an error.
-            (None, Some(error)) => errors.push(format!("{attr}: {error}")),
-            (None, None) => errors.push(format!("{attr}: eval row had neither drvPath nor error")),
+            (Some(drv_path), _) => out.checks.push(Check { attr, drv_path }),
+            (None, Some(_)) => out.eval_failures.push(attr),
+            (None, None) => out.unexpected.push(attr),
         }
     }
-    if !errors.is_empty() {
-        bail!("checks failed to evaluate at {rev}:\n{}", errors.join("\n"));
-    }
-    Ok(checks)
+    Ok(out)
 }
 
 /// `nix derivation show` output: a `{ version, derivations }` envelope (schema 4+)
@@ -195,7 +242,7 @@ pub fn drv_for(checks: &[Check], attr: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::drv_name;
+    use super::{drv_name, partition_eval_rows};
 
     #[test]
     fn drv_name_strips_hash_and_suffix() {
@@ -206,5 +253,31 @@ mod tests {
         // No hash prefix: left as-is (minus the suffix).
         assert_eq!(drv_name("plain-name.drv"), "plain-name");
         assert_eq!(drv_name("/nix/store/short.drv"), "short");
+    }
+
+    // A buildable row becomes a check; a per-attr eval failure is excluded (not a
+    // rebuild target) rather than aborting the whole run; a malformed row with
+    // neither field is flagged so the caller can fail loudly. Blank lines are
+    // skipped. nix-eval-jobs quotes attrs that need Nix quoting; the quotes are
+    // stripped.
+    #[test]
+    fn partition_splits_success_eval_failure_and_malformed() {
+        let stdout = concat!(
+            r#"{"attr":"rust-test-foo","drvPath":"/nix/store/aaa-foo.drv"}"#,
+            "\n",
+            r#"{"attr":"unfree-allowlist","error":"unfree allowlist mismatch"}"#,
+            "\n",
+            "\n",
+            r#"{"attr":"\"weird.attr\""}"#,
+            "\n",
+        );
+
+        let partitioned = partition_eval_rows(stdout).expect("well-formed JSONL parses");
+
+        assert_eq!(partitioned.checks.len(), 1);
+        assert_eq!(partitioned.checks[0].attr, "rust-test-foo");
+        assert_eq!(partitioned.checks[0].drv_path, "/nix/store/aaa-foo.drv");
+        assert_eq!(partitioned.eval_failures, vec!["unfree-allowlist".to_owned()]);
+        assert_eq!(partitioned.unexpected, vec!["weird.attr".to_owned()]);
     }
 }


### PR DESCRIPTION
`eval_checks` bailed if any attribute in `.#checks.x86_64-linux` failed to evaluate. That assumes an eval-clean catalog, which holds for index but not for every consumer: ix imports this binary (via the index flake input) to report its own blast radius, and ix's catalog carries eval-assertion checks (`unfree-allowlist`, `ix-systemd-startup-timeouts`, `*-invariants`, ...) that throw when their invariant is currently violated and are not in its required gate. The strict bail made the report fail on every ix PR.

Now an attribute that fails to evaluate is excluded from the diff (no derivation at that rev means it cannot be a rebuild target) and the run prints a stderr summary of what it skipped. A malformed row (neither `drvPath` nor `error`, a nix-eval-jobs contract violation) still fails loudly. Row classification is factored into a pure `partition_eval_rows` and unit-tested.

Validated: `nix build .#blast-radius` (compiles). clippy + the new unit test run in CI.

Made with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tolerate per-attribute eval failures in blast-radius instead of bailing on all failures
> - Adds `guard_eval_failures` in [main.rs](https://github.com/indexable-inc/index/pull/692/files#diff-26dadfc8230ddb1d1e7777603b294fc2e488f469a8c3f43c05132eec464898d6) that compares eval failures between base and head: bails with a detailed error only if head introduces new failures not present at base, and emits a warning for pre-existing base failures before continuing.
> - Adds `EvalResult` and `EvalFailure` structs in [nix.rs](https://github.com/indexable-inc/index/pull/692/files#diff-14eaffb995110afd87ea035ed088cee05190e63275835359b273ee0fce584a12); `eval_checks` now returns both buildable checks and per-attribute failures instead of aborting on any eval error.
> - Adds `partition_eval_rows` as a pure helper that classifies `nix-eval-jobs` JSONL output into buildable checks, per-attribute failures, and malformed rows (which still cause a bail).
> - Behavioral Change: the binary previously aborted on any per-attribute eval failure; it now only aborts when head introduces failures that did not exist at base.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae7cd8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->