### PR TITLE
flake.lock: hourly updates + reusable workflow_call

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -2,8 +2,13 @@ name: Update flake.lock
 
 on:
   workflow_dispatch:
+  # Reusable: ix (and any other indexable-inc repo) calls this same job via
+  # `uses: indexable-inc/index/.github/workflows/update-flake-lock.yml@main`
+  # so the flake-bump mechanics live in one place. The caller supplies the
+  # schedule and the contents/PR permissions.
+  workflow_call:
   schedule:
-    - cron: "17 10 * * 1"
+    - cron: "17 * * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
Run the flake.lock updater hourly (was weekly) and add a `workflow_call` trigger so ix can reuse the same job instead of copying the mechanics.

The updater reuses one branch/PR, so hourly just advances the open PR rather than stacking new ones.

Made with Claude Opus 4.8.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update flake.lock workflow to run hourly and support `workflow_call`
> - Changes the cron schedule in [update-flake-lock.yml](.github/workflows/update-flake-lock.yml) from weekly (Mondays at 10:17 UTC) to hourly (at minute 17).
> - Adds a `workflow_call` trigger so this workflow can be reused by other repositories in the `indexable-inc` org via `uses`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 737fb51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->