### PR TITLE
claude-code: run the auto-bump hourly

### DIFF
--- a/.github/workflows/update-claude-code.yml
+++ b/.github/workflows/update-claude-code.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
   schedule:
     # Claude Code ships several builds a week: Anthropic promotes them from the
-    # `next` tag to `latest` a few days apart, so check daily rather than the
-    # weekly cadence the flake.lock / loader jobs use. The updater tracks the
-    # `latest` pointer, and the PR step reuses one branch, so a daily run just
-    # advances the open PR instead of stacking new ones.
-    - cron: "37 9 * * *"
+    # `next` tag to `latest` a few days apart. Check hourly so the open PR
+    # advances within the hour a new `latest` lands. The updater tracks the
+    # `latest` pointer and reuses one branch, and a no-op run is a Cachix hit,
+    # so the hourly cadence stays cheap and never stacks new PRs.
+    - cron: "37 * * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
Move the Claude Code updater from daily to hourly so a new signed `latest` lands in the open PR within the hour. Updater still tracks `latest`, reuses one branch, and a no-op run is a Cachix hit, so hourly stays cheap and never stacks PRs.

Made with Claude Opus 4.8.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run the claude-code auto-bump workflow hourly instead of daily
> Changes the cron schedule in [update-claude-code.yml](.github/workflows/update-claude-code.yml) from `37 9 * * *` (once daily) to `37 * * * *` (every hour at minute 37).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9200f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->