### PR TITLE
flake.lock: let reusable callers scope which inputs update

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -2,11 +2,23 @@ name: Update flake.lock
 
 on:
   workflow_dispatch:
+    inputs:
+      flake-inputs:
+        description: "Space-separated flake inputs to update; empty updates all."
+        type: string
+        default: ""
   # Reusable: ix (and any other indexable-inc repo) calls this same job via
   # `uses: indexable-inc/index/.github/workflows/update-flake-lock.yml@main`
   # so the flake-bump mechanics live in one place. The caller supplies the
-  # schedule and the contents/PR permissions.
+  # schedule and the contents/PR permissions. A caller whose flake has private
+  # inputs the GitHub-hosted runner cannot fetch passes `flake-inputs` to
+  # update only the public ones (e.g. ix scopes to `index`).
   workflow_call:
+    inputs:
+      flake-inputs:
+        description: "Space-separated flake inputs to update; empty updates all."
+        type: string
+        default: ""
   schedule:
     - cron: "17 * * * *"
 
@@ -34,3 +46,6 @@ jobs:
           branch: update-flake-lock
           commit-msg: "flake.lock: update"
           pr-title: "Update Nix flake inputs"
+          # Empty for schedule/dispatch on index (all inputs public); a caller
+          # scopes this to avoid fetching private inputs it can't auth for.
+          inputs: ${{ inputs.flake-inputs }}


### PR DESCRIPTION
Add an optional `flake-inputs` parameter to the reusable `update-flake-lock` workflow. Empty (index's own schedule/dispatch) keeps updating all inputs; a caller passes a space-separated list to update only those.

Needed because ix's flake has private `git+ssh://` inputs (colmena, linux-ix, ghostty) the GitHub-hosted runner can't fetch, so `nix flake update` over everything fails with a publickey error. ix will pass `flake-inputs: index` to bump just the public index input (which carries claude tooling) without touching the private ones.

Made with Claude Opus 4.8.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `flake-inputs` parameter to `update-flake-lock` workflow for selective input updates
> Adds an optional `flake-inputs` string input to the [update-flake-lock.yml](.github/workflows/update-flake-lock.yml) workflow, exposed via both `workflow_dispatch` and `workflow_call` triggers. The value is forwarded to the `DeterminateSystems/update-flake-lock` action's `inputs` field, allowing callers to restrict which flake inputs are updated rather than updating all of them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9f8d23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->