### PR TITLE
feat(sink-otlp): OTLP emitter for the RFC 0004 ingestion bus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,6 +2789,7 @@ dependencies = [
  "nix 0.30.1",
  "search-core",
  "sink-mixedbread",
+ "sink-otlp",
  "sink-parquet",
  "source-atuin",
  "source-claude",
@@ -5598,6 +5599,19 @@ dependencies = [
  "futures",
  "mixedbread",
  "search-core",
+ "serde_json",
+ "snafu 0.9.1",
+ "source-meta",
+ "tokio",
+]
+
+[[package]]
+name = "sink-otlp"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "reqwest",
+ "serde",
  "serde_json",
  "snafu 0.9.1",
  "source-meta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
   "packages/source/slack",
   "packages/sink/mixedbread",
   "packages/sink/parquet",
+  "packages/sink/otlp",
   "packages/indexer",
   "packages/tap",
   "packages/tap/protocol",
@@ -184,6 +185,7 @@ sha2 = "0.10"
 similar = "2"
 source-slack = { path = "packages/source/slack" }
 sink-mixedbread = { path = "packages/sink/mixedbread" }
+sink-otlp = { path = "packages/sink/otlp" }
 sink-parquet = { path = "packages/sink/parquet" }
 snafu = "0.9"
 strip-ansi-escapes = "0.2"

--- a/packages/indexer/Cargo.toml
+++ b/packages/indexer/Cargo.toml
@@ -25,6 +25,7 @@ source-github.workspace = true
 search-core.workspace = true
 sink-mixedbread.workspace = true
 sink-parquet.workspace = true
+sink-otlp.workspace = true
 mixedbread.workspace = true
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -53,6 +53,12 @@ struct Cli {
     #[arg(long, env = "INDEXER_PREFIX", default_value = "corpus")]
     prefix: String,
 
+    /// OpenTelemetry Collector OTLP/HTTP endpoint (e.g. `http://127.0.0.1:4318`);
+    /// enables the OTLP sink, which emits every non-code source's records to the
+    /// collector as log records (RFC 0004 ingestion bus). Code is not emitted.
+    #[arg(long, env = "INDEXER_OTLP_ENDPOINT")]
+    otlp_endpoint: Option<String>,
+
     /// Index local agent/shell history (claude, codex, atuin) at their default
     /// paths, in addition to any explicit `--*` overrides below.
     #[arg(long)]
@@ -155,8 +161,9 @@ async fn main() -> anyhow::Result<()> {
         }
         None => None,
     };
-    if store.is_none() && parquet.is_none() {
-        anyhow::bail!("nothing to do: pass --mixedbread-store and/or --bucket");
+    let otlp = cli.otlp_endpoint.clone().map(|endpoint| sink_otlp::Config { endpoint });
+    if store.is_none() && parquet.is_none() && otlp.is_none() {
+        anyhow::bail!("nothing to do: pass --mixedbread-store, --bucket, and/or --otlp-endpoint");
     }
     if !any_source_selected(&cli) {
         anyhow::bail!(
@@ -166,7 +173,7 @@ async fn main() -> anyhow::Result<()> {
     let mixedbread =
         store.as_ref().zip(cli.mixedbread_store.as_deref()).map(|(store, name)| Mixedbread { store, name });
 
-    let counts = run_sources(&cli, mixedbread, parquet.as_ref()).await;
+    let counts = run_sources(&cli, mixedbread, parquet.as_ref(), otlp.as_ref()).await;
 
     if counts.failures > 0 {
         anyhow::bail!(
@@ -200,6 +207,7 @@ async fn run_sources(
     cli: &Cli,
     mixedbread: Option<Mixedbread<'_>>,
     parquet: Option<&sink_parquet::Config>,
+    otlp: Option<&sink_otlp::Config>,
 ) -> Counts {
     let home = dirs::home_dir();
     let default = |suffix: &str| home.as_ref().map(|h| h.join(suffix));
@@ -212,7 +220,7 @@ async fn run_sources(
         let result = async {
             let adapter = source_claude::ClaudeHistoryExport::open(&dir)
                 .with_context(|| format!("parsing Claude transcripts at {}", dir.display()))?;
-            run_source("claude", &adapter, mixedbread, parquet).await
+            run_source("claude", &adapter, mixedbread, parquet, otlp).await
         }
         .await;
         record("claude", result, &mut counts);
@@ -221,7 +229,7 @@ async fn run_sources(
         let result = async {
             let adapter = source_codex::CodexHistory::open(&file)
                 .with_context(|| format!("parsing Codex history at {}", file.display()))?;
-            run_source("codex", &adapter, mixedbread, parquet).await
+            run_source("codex", &adapter, mixedbread, parquet, otlp).await
         }
         .await;
         record("codex", result, &mut counts);
@@ -230,7 +238,7 @@ async fn run_sources(
         let result = async {
             let adapter = source_atuin::AtuinHistory::open(&db)
                 .with_context(|| format!("reading atuin history at {}", db.display()))?;
-            run_source("shell", &adapter, mixedbread, parquet).await
+            run_source("shell", &adapter, mixedbread, parquet, otlp).await
         }
         .await;
         record("shell", result, &mut counts);
@@ -239,7 +247,7 @@ async fn run_sources(
         let result = async {
             let adapter = source_slack::SlackExport::open(dir)
                 .with_context(|| format!("reading Slack export at {}", dir.display()))?;
-            run_source("slack", &adapter, mixedbread, parquet).await
+            run_source("slack", &adapter, mixedbread, parquet, otlp).await
         }
         .await;
         record("slack", result, &mut counts);
@@ -248,7 +256,7 @@ async fn run_sources(
         let result = async {
             let adapter = source_linear::LinearExport::open(dir)
                 .with_context(|| format!("reading Linear export at {}", dir.display()))?;
-            run_source("linear", &adapter, mixedbread, parquet).await
+            run_source("linear", &adapter, mixedbread, parquet, otlp).await
         }
         .await;
         record("linear", result, &mut counts);
@@ -257,7 +265,7 @@ async fn run_sources(
         let result = async {
             let adapter = source_github::GithubExport::open(dir)
                 .with_context(|| format!("reading GitHub export at {}", dir.display()))?;
-            run_source("github", &adapter, mixedbread, parquet).await
+            run_source("github", &adapter, mixedbread, parquet, otlp).await
         }
         .await;
         record("github", result, &mut counts);
@@ -267,7 +275,7 @@ async fn run_sources(
         let result = async {
             let adapter = source_git::GitLog::open(repo)
                 .with_context(|| format!("reading git history at {}", repo.display()))?;
-            run_source("git", &adapter, mixedbread, parquet).await
+            run_source("git", &adapter, mixedbread, parquet, otlp).await
         }
         .await;
         record(&label, result, &mut counts);
@@ -278,7 +286,7 @@ async fn run_sources(
         record(&label, result, &mut counts);
     }
     if !cli.users.is_empty() {
-        run_users(cli, mixedbread, parquet, &mut counts).await;
+        run_users(cli, mixedbread, parquet, otlp, &mut counts).await;
     }
     counts
 }
@@ -289,6 +297,7 @@ async fn run_users(
     cli: &Cli,
     mixedbread: Option<Mixedbread<'_>>,
     parquet: Option<&sink_parquet::Config>,
+    otlp: Option<&sink_otlp::Config>,
     counts: &mut Counts,
 ) {
     let host = match resolve_host(cli) {
@@ -304,7 +313,7 @@ async fn run_users(
     };
     for spec in &cli.users {
         match parse_user(spec) {
-            Ok(user) => index_user(&user, &host, mixedbread, parquet, counts).await,
+            Ok(user) => index_user(&user, &host, mixedbread, parquet, otlp, counts).await,
             Err(error) => {
                 eprintln!("[users] bad --user spec: {error:#}");
                 counts.failures += 1;
@@ -327,6 +336,7 @@ async fn index_user(
     host: &str,
     mixedbread: Option<Mixedbread<'_>>,
     parquet: Option<&sink_parquet::Config>,
+    otlp: Option<&sink_otlp::Config>,
     counts: &mut Counts,
 ) {
     let name = user.name.as_str();
@@ -337,7 +347,7 @@ async fn index_user(
         let result = async {
             let adapter = source_claude::ClaudeHistoryExport::open_with(&claude_dir, host, name)
                 .with_context(|| format!("parsing Claude transcripts for {name} at {}", claude_dir.display()))?;
-            run_source(&label, &adapter, mixedbread, parquet.as_ref()).await
+            run_source(&label, &adapter, mixedbread, parquet.as_ref(), otlp).await
         }
         .await;
         record(&label, result, counts);
@@ -349,7 +359,7 @@ async fn index_user(
         let result = async {
             let adapter = source_codex::CodexHistory::open_with(&codex_file, host, name)
                 .with_context(|| format!("parsing Codex history for {name} at {}", codex_file.display()))?;
-            run_source(&label, &adapter, mixedbread, parquet.as_ref()).await
+            run_source(&label, &adapter, mixedbread, parquet.as_ref(), otlp).await
         }
         .await;
         record(&label, result, counts);
@@ -363,7 +373,7 @@ async fn index_user(
         let result = async {
             let adapter = source_atuin::AtuinHistory::open(&atuin_db)
                 .with_context(|| format!("reading atuin history for {name} at {}", atuin_db.display()))?;
-            run_source(&label, &adapter, mixedbread, parquet.as_ref()).await
+            run_source(&label, &adapter, mixedbread, parquet.as_ref(), otlp).await
         }
         .await;
         record(&label, result, counts);
@@ -378,7 +388,7 @@ async fn index_user(
         let result = async {
             let adapter = source_debug::DebugLogs::open_with(&debug_dir, host, name)
                 .with_context(|| format!("reading Claude debug logs for {name} at {}", debug_dir.display()))?;
-            run_source(&label, &adapter, mixedbread, parquet.as_ref()).await
+            run_source(&label, &adapter, mixedbread, parquet.as_ref(), otlp).await
         }
         .await;
         record(&label, result, counts);
@@ -521,6 +531,7 @@ async fn run_source<A: SourceAdapter + Sync>(
     adapter: &A,
     mixedbread: Option<Mixedbread<'_>>,
     parquet: Option<&sink_parquet::Config>,
+    otlp: Option<&sink_otlp::Config>,
 ) -> anyhow::Result<()> {
     let mut errors: Vec<anyhow::Error> = Vec::new();
 
@@ -542,6 +553,16 @@ async fn run_source<A: SourceAdapter + Sync>(
             ),
             Err(error) => {
                 errors.push(anyhow::Error::new(error).context(format!("[{label}] Mixedbread sync")));
+            }
+        }
+    }
+
+    if let Some(config) = otlp {
+        match sink_otlp::sync(adapter, config).await {
+            Ok(report) if report.skipped => eprintln!("[{label}] otlp: skipped (empty)"),
+            Ok(report) => eprintln!("[{label}] otlp: emitted {} records", report.records),
+            Err(error) => {
+                errors.push(anyhow::Error::new(error).context(format!("[{label}] OTLP emit")));
             }
         }
     }

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -53,7 +53,7 @@ struct Cli {
     #[arg(long, env = "INDEXER_PREFIX", default_value = "corpus")]
     prefix: String,
 
-    /// OpenTelemetry Collector OTLP/HTTP endpoint (e.g. `http://127.0.0.1:4318`);
+    /// `OpenTelemetry` Collector OTLP/HTTP endpoint (e.g. `http://127.0.0.1:4318`);
     /// enables the OTLP sink, which emits every non-code source's records to the
     /// collector as log records (RFC 0004 ingestion bus). Code is not emitted.
     #[arg(long, env = "INDEXER_OTLP_ENDPOINT")]

--- a/packages/sink/otlp/Cargo.toml
+++ b/packages/sink/otlp/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "sink-otlp"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "OTLP/HTTP logs sink: emit each search Document to an OpenTelemetry Collector as a log record"
+
+[lints]
+workspace = true
+
+[dependencies]
+source-meta.workspace = true
+reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+snafu.workspace = true
+
+[dev-dependencies]
+axum.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net"] }

--- a/packages/sink/otlp/package.nix
+++ b/packages/sink/otlp/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "sink-otlp";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/sink/otlp/src/lib.rs
+++ b/packages/sink/otlp/src/lib.rs
@@ -337,7 +337,9 @@ mod tests {
         assert_eq!(report.records, 2);
         assert!(!report.skipped);
 
-        let bodies = receiver.captured.lock().expect("lock");
+        // Clone out so the mutex guard drops here, not across the asserts
+        // (clippy::significant_drop_tightening).
+        let bodies = receiver.captured.lock().expect("lock").clone();
         let records = bodies[0]["resourceLogs"][0]["scopeLogs"][0]["logRecords"]
             .as_array()
             .expect("logRecords array");

--- a/packages/sink/otlp/src/lib.rs
+++ b/packages/sink/otlp/src/lib.rs
@@ -1,11 +1,11 @@
 //! OTLP/HTTP logs sink for the multi-source search corpus.
 //!
-//! Each source's [`Document`]s are emitted to an OpenTelemetry Collector as OTLP
-//! log records (`POST {endpoint}/v1/logs`, JSON encoding). This is the emitter
-//! half of the ingestion bus (RFC 0004): the collector receives one record per
-//! document and fans it out to its own exporters (ClickHouse for Grafana, S3 for
-//! the durable archive), so a new corpus consumer is a new collector exporter
-//! rather than a new sink compiled into every producer.
+//! Each source's [`Document`]s are emitted to an `OpenTelemetry` Collector as
+//! OTLP log records (`POST {endpoint}/v1/logs`, JSON encoding). This is the
+//! emitter half of the ingestion bus (RFC 0004): the collector receives one
+//! record per document and fans it out to its own exporters (`ClickHouse` for
+//! Grafana, S3 for the durable archive), so a new corpus consumer is a new
+//! collector exporter rather than a new sink compiled into every producer.
 //!
 //! The document's flat metadata is projected onto the log record so no
 //! information is lost crossing the bus: the body becomes the record body, the
@@ -230,10 +230,9 @@ impl KeyValue {
         let any = match value {
             serde_json::Value::String(string) => AnyValue::String(string.clone()),
             serde_json::Value::Bool(boolean) => AnyValue::Bool(*boolean),
-            serde_json::Value::Number(number) => match number.as_i64() {
-                Some(int) => AnyValue::Int(int.to_string()),
-                None => AnyValue::String(number.to_string()),
-            },
+            serde_json::Value::Number(number) => number
+                .as_i64()
+                .map_or_else(|| AnyValue::String(number.to_string()), |int| AnyValue::Int(int.to_string())),
             other => AnyValue::String(other.to_string()),
         };
         Self { key: key.to_owned(), value: any }
@@ -268,6 +267,12 @@ mod tests {
 
     use super::{Config, sync};
 
+    /// A throwaway receiver: its `endpoint` plus the bodies it captured.
+    struct Receiver {
+        endpoint: String,
+        captured: Arc<Mutex<Vec<serde_json::Value>>>,
+    }
+
     struct TestSource {
         docs: Vec<Document>,
     }
@@ -301,7 +306,7 @@ mod tests {
     }
 
     /// Stand up a throwaway OTLP/HTTP receiver, capturing every posted body.
-    async fn spawn_receiver() -> (String, Arc<Mutex<Vec<serde_json::Value>>>) {
+    async fn spawn_receiver() -> Receiver {
         let captured: Arc<Mutex<Vec<serde_json::Value>>> = Arc::new(Mutex::new(Vec::new()));
         let app = Router::new()
             .route(
@@ -320,19 +325,19 @@ mod tests {
         tokio::spawn(async move {
             axum::serve(listener, app).await.expect("serve");
         });
-        (format!("http://{addr}"), captured)
+        Receiver { endpoint: format!("http://{addr}"), captured }
     }
 
     #[tokio::test]
     async fn emits_one_record_per_document() {
-        let (endpoint, captured) = spawn_receiver().await;
+        let receiver = spawn_receiver().await;
         let adapter = TestSource { docs: vec![doc("a", "ls"), doc("b", "cd /tmp")] };
 
-        let report = sync(&adapter, &Config { endpoint }).await.expect("sync");
+        let report = sync(&adapter, &Config { endpoint: receiver.endpoint }).await.expect("sync");
         assert_eq!(report.records, 2);
         assert!(!report.skipped);
 
-        let bodies = captured.lock().expect("lock");
+        let bodies = receiver.captured.lock().expect("lock");
         let records = bodies[0]["resourceLogs"][0]["scopeLogs"][0]["logRecords"]
             .as_array()
             .expect("logRecords array");
@@ -349,11 +354,11 @@ mod tests {
 
     #[tokio::test]
     async fn empty_source_emits_nothing() {
-        let (endpoint, captured) = spawn_receiver().await;
+        let receiver = spawn_receiver().await;
         let adapter = TestSource { docs: vec![] };
-        let report = sync(&adapter, &Config { endpoint }).await.expect("sync");
+        let report = sync(&adapter, &Config { endpoint: receiver.endpoint }).await.expect("sync");
         assert!(report.skipped);
         assert_eq!(report.records, 0);
-        assert!(captured.lock().expect("lock").is_empty());
+        assert!(receiver.captured.lock().expect("lock").is_empty());
     }
 }

--- a/packages/sink/otlp/src/lib.rs
+++ b/packages/sink/otlp/src/lib.rs
@@ -1,0 +1,359 @@
+//! OTLP/HTTP logs sink for the multi-source search corpus.
+//!
+//! Each source's [`Document`]s are emitted to an OpenTelemetry Collector as OTLP
+//! log records (`POST {endpoint}/v1/logs`, JSON encoding). This is the emitter
+//! half of the ingestion bus (RFC 0004): the collector receives one record per
+//! document and fans it out to its own exporters (ClickHouse for Grafana, S3 for
+//! the durable archive), so a new corpus consumer is a new collector exporter
+//! rather than a new sink compiled into every producer.
+//!
+//! The document's flat metadata is projected onto the log record so no
+//! information is lost crossing the bus: the body becomes the record body, the
+//! source becomes a resource attribute, and every metadata key (including
+//! `external_id` and `content_hash`, which a downstream consumer needs to
+//! reconstruct the document and skip-if-unchanged) becomes a record attribute.
+//!
+//! Emission is append-only: every run sends the current record set and the
+//! collector's downstream consumers dedup by `content_hash`. The sink does not
+//! itself skip unchanged corpora, because unlike a single rewritten S3 object
+//! there is no per-source manifest to compare against on the bus.
+
+#![forbid(unsafe_code)]
+
+use serde::Serialize;
+use source_meta::{Document, SourceAdapter, keys};
+use snafu::{IntoError as _, ResultExt as _, Snafu};
+
+/// Nanoseconds per second, for converting an epoch-second timestamp to the
+/// `timeUnixNano` OTLP field.
+const NANOS_PER_SEC: i64 = 1_000_000_000;
+
+/// Records per OTLP request. Large sources (a full shell history) are chunked so
+/// no single request grows unbounded; the collector batches internally anyway.
+const RECORDS_PER_REQUEST: usize = 500;
+
+/// Connection settings for the OTLP/HTTP logs sink.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Collector OTLP/HTTP base URL, e.g. `http://127.0.0.1:4318`. Records are
+    /// posted to `<endpoint>/v1/logs`.
+    pub endpoint: String,
+}
+
+/// Failures from the OTLP sink.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum Error {
+    /// The source adapter failed while producing documents.
+    #[snafu(display("source adapter failed while producing documents"))]
+    Adapter {
+        /// Underlying adapter error.
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    /// The HTTP request to the collector could not be sent.
+    #[snafu(display("failed to POST OTLP logs to {url}"))]
+    Request {
+        /// Target URL.
+        url: String,
+        /// Underlying reqwest error.
+        source: reqwest::Error,
+    },
+    /// The collector rejected the batch with a non-success status.
+    #[snafu(display("collector returned {status} for {url}: {body}"))]
+    Http {
+        /// Target URL.
+        url: String,
+        /// HTTP status code.
+        status: u16,
+        /// Response body, for the failure reason.
+        body: String,
+    },
+}
+
+/// Result alias defaulting to this crate's [`Error`].
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Outcome of one sink pass for a source.
+#[derive(Debug, Clone, Copy)]
+pub struct Report {
+    /// Log records emitted to the collector.
+    pub records: usize,
+    /// Whether the pass was skipped because the source produced no documents.
+    pub skipped: bool,
+}
+
+/// Emit one source's documents to the collector as OTLP log records.
+///
+/// # Errors
+/// Returns an error if the adapter fails, a request cannot be sent, or the
+/// collector rejects a batch.
+pub async fn sync<A: SourceAdapter + Sync>(adapter: &A, config: &Config) -> Result<Report> {
+    let source = adapter.source();
+    let mut documents = Vec::new();
+    for document in adapter.documents() {
+        documents.push(document.map_err(|err| AdapterSnafu.into_error(Box::new(err)))?);
+    }
+    if documents.is_empty() {
+        return Ok(Report { records: 0, skipped: true });
+    }
+
+    let url = format!("{}/v1/logs", config.endpoint.trim_end_matches('/'));
+    let client = reqwest::Client::new();
+    let total = documents.len();
+    for chunk in documents.chunks(RECORDS_PER_REQUEST) {
+        let request = export_request(source.as_str(), chunk);
+        post(&client, &url, &request).await?;
+    }
+    Ok(Report { records: total, skipped: false })
+}
+
+/// POST one OTLP `ExportLogsServiceRequest` and turn a non-success status into a
+/// typed [`Error::Http`] carrying the response body.
+async fn post(client: &reqwest::Client, url: &str, request: &ExportLogsServiceRequest) -> Result<()> {
+    let response = client.post(url).json(request).send().await.context(RequestSnafu { url })?;
+    let status = response.status();
+    if status.is_success() {
+        return Ok(());
+    }
+    let body = response.text().await.unwrap_or_else(|_| "<unreadable body>".to_owned());
+    Err(HttpSnafu { url, status: status.as_u16(), body }.build())
+}
+
+/// Build the OTLP request for one source's chunk of documents: a single
+/// `resourceLogs` whose resource names the producer and source, and one log
+/// record per document.
+fn export_request(source: &str, documents: &[Document]) -> ExportLogsServiceRequest {
+    let resource = Resource {
+        attributes: vec![
+            KeyValue::string("service.name", "indexer"),
+            KeyValue::string(keys::SOURCE, source),
+        ],
+    };
+    let log_records = documents.iter().map(log_record).collect();
+    ExportLogsServiceRequest {
+        resource_logs: vec![ResourceLogs {
+            resource,
+            scope_logs: vec![ScopeLogs { scope: Scope { name: "sink-otlp" }, log_records }],
+        }],
+    }
+}
+
+/// Project one document onto an OTLP log record: the body becomes the record
+/// body, and every flat metadata key becomes a record attribute so the document
+/// can be reconstructed downstream.
+fn log_record(document: &Document) -> LogRecord {
+    let nanos = document
+        .meta_json
+        .get(keys::TIMESTAMP)
+        .and_then(serde_json::Value::as_i64)
+        .map_or(0, |secs| secs.saturating_mul(NANOS_PER_SEC));
+    let attributes = match &document.meta_json {
+        serde_json::Value::Object(map) => {
+            map.iter().map(|(key, value)| KeyValue::from_json(key, value)).collect()
+        }
+        _ => Vec::new(),
+    };
+    LogRecord {
+        time_unix_nano: nanos.to_string(),
+        observed_time_unix_nano: nanos.to_string(),
+        body: AnyValue::String(String::from_utf8_lossy(&document.body).into_owned()),
+        attributes,
+    }
+}
+
+// --- OTLP/HTTP JSON model (the subset this sink emits) ---
+
+/// Top-level OTLP logs payload.
+#[derive(Debug, Serialize)]
+struct ExportLogsServiceRequest {
+    #[serde(rename = "resourceLogs")]
+    resource_logs: Vec<ResourceLogs>,
+}
+
+/// Records sharing one resource (here, one source).
+#[derive(Debug, Serialize)]
+struct ResourceLogs {
+    resource: Resource,
+    #[serde(rename = "scopeLogs")]
+    scope_logs: Vec<ScopeLogs>,
+}
+
+/// The resource attributes shared by every record in a batch.
+#[derive(Debug, Serialize)]
+struct Resource {
+    attributes: Vec<KeyValue>,
+}
+
+/// Records sharing one instrumentation scope.
+#[derive(Debug, Serialize)]
+struct ScopeLogs {
+    scope: Scope,
+    #[serde(rename = "logRecords")]
+    log_records: Vec<LogRecord>,
+}
+
+/// Names the emitter.
+#[derive(Debug, Serialize)]
+struct Scope {
+    name: &'static str,
+}
+
+/// One OTLP log record.
+#[derive(Debug, Serialize)]
+struct LogRecord {
+    #[serde(rename = "timeUnixNano")]
+    time_unix_nano: String,
+    #[serde(rename = "observedTimeUnixNano")]
+    observed_time_unix_nano: String,
+    body: AnyValue,
+    attributes: Vec<KeyValue>,
+}
+
+/// An OTLP attribute (key plus typed value).
+#[derive(Debug, Serialize)]
+struct KeyValue {
+    key: String,
+    value: AnyValue,
+}
+
+impl KeyValue {
+    /// A string-valued attribute.
+    fn string(key: &str, value: &str) -> Self {
+        Self { key: key.to_owned(), value: AnyValue::String(value.to_owned()) }
+    }
+
+    /// Map a JSON metadata value to the closest OTLP attribute value: strings and
+    /// booleans map directly, integers use OTLP's string-encoded int64, and any
+    /// other shape (float, array, object, null) is carried as its JSON text so no
+    /// metadata is dropped crossing the bus.
+    fn from_json(key: &str, value: &serde_json::Value) -> Self {
+        let any = match value {
+            serde_json::Value::String(string) => AnyValue::String(string.clone()),
+            serde_json::Value::Bool(boolean) => AnyValue::Bool(*boolean),
+            serde_json::Value::Number(number) => match number.as_i64() {
+                Some(int) => AnyValue::Int(int.to_string()),
+                None => AnyValue::String(number.to_string()),
+            },
+            other => AnyValue::String(other.to_string()),
+        };
+        Self { key: key.to_owned(), value: any }
+    }
+}
+
+/// The OTLP `AnyValue` shapes this sink emits. Externally tagged so each
+/// serializes to OTLP's `{"stringValue": ...}` / `{"intValue": ...}` form.
+#[derive(Debug, Serialize)]
+enum AnyValue {
+    #[serde(rename = "stringValue")]
+    String(String),
+    #[serde(rename = "intValue")]
+    Int(String),
+    #[serde(rename = "boolValue")]
+    Bool(bool),
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::expect_used, reason = "tests assert observable request outcomes")]
+
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use axum::Router;
+    use axum::extract::State;
+    use axum::routing::post;
+    use serde_json::json;
+    use source_meta::{Document, Source, SourceAdapter};
+
+    use super::{Config, sync};
+
+    struct TestSource {
+        docs: Vec<Document>,
+    }
+
+    impl SourceAdapter for TestSource {
+        type Error = std::convert::Infallible;
+        fn source(&self) -> Source {
+            Source::new("shell")
+        }
+        fn documents(&self) -> impl Iterator<Item = Result<Document, Self::Error>> + Send {
+            self.docs.clone().into_iter().map(Ok)
+        }
+    }
+
+    fn doc(id: &str, body: &str) -> Document {
+        let content_hash = source_meta::hash_body(body.as_bytes());
+        Document {
+            external_id: id.to_owned(),
+            file_name: format!("{id}.txt"),
+            mime: "text/plain",
+            body: body.as_bytes().to_vec(),
+            meta_json: json!({
+                "source": "shell",
+                "external_id": id,
+                "content_hash": content_hash,
+                "timestamp": 100,
+                "exit_status": 0,
+            }),
+            content_hash,
+        }
+    }
+
+    /// Stand up a throwaway OTLP/HTTP receiver, capturing every posted body.
+    async fn spawn_receiver() -> (String, Arc<Mutex<Vec<serde_json::Value>>>) {
+        let captured: Arc<Mutex<Vec<serde_json::Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route(
+                "/v1/logs",
+                post(|State(state): State<Arc<Mutex<Vec<serde_json::Value>>>>, body: String| async move {
+                    let value: serde_json::Value = serde_json::from_str(&body).expect("valid json body");
+                    state.lock().expect("lock").push(value);
+                    "{}"
+                }),
+            )
+            .with_state(Arc::clone(&captured));
+        let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve");
+        });
+        (format!("http://{addr}"), captured)
+    }
+
+    #[tokio::test]
+    async fn emits_one_record_per_document() {
+        let (endpoint, captured) = spawn_receiver().await;
+        let adapter = TestSource { docs: vec![doc("a", "ls"), doc("b", "cd /tmp")] };
+
+        let report = sync(&adapter, &Config { endpoint }).await.expect("sync");
+        assert_eq!(report.records, 2);
+        assert!(!report.skipped);
+
+        let bodies = captured.lock().expect("lock");
+        let records = bodies[0]["resourceLogs"][0]["scopeLogs"][0]["logRecords"]
+            .as_array()
+            .expect("logRecords array");
+        assert_eq!(records.len(), 2);
+        // The body and identity survive the projection onto the log record.
+        assert_eq!(records[0]["body"]["stringValue"], "ls");
+        let has_external_id = records[0]["attributes"]
+            .as_array()
+            .expect("attributes")
+            .iter()
+            .any(|kv| kv["key"] == "external_id" && kv["value"]["stringValue"] == "a");
+        assert!(has_external_id, "external_id must cross the bus as an attribute");
+    }
+
+    #[tokio::test]
+    async fn empty_source_emits_nothing() {
+        let (endpoint, captured) = spawn_receiver().await;
+        let adapter = TestSource { docs: vec![] };
+        let report = sync(&adapter, &Config { endpoint }).await.expect("sync");
+        assert!(report.skipped);
+        assert_eq!(report.records, 0);
+        assert!(captured.lock().expect("lock").is_empty());
+    }
+}


### PR DESCRIPTION
First implementation step of the RFC 0004 ingestion bus: a `sink-otlp` crate that emits every non-code corpus source's records to an OpenTelemetry Collector as OTLP/HTTP log records (`POST /v1/logs`, JSON). The collector then fans out to its own exporters (ClickHouse for Grafana, S3 for the archive); a downstream consumer reads S3 back into Mixedbread.

Additive and safe: enabled only by `--otlp-endpoint` (`INDEXER_OTLP_ENDPOINT`), running alongside the existing Mixedbread and parquet sinks. Code repos stay Mixedbread-only (files are documents, not events). Nothing is deleted yet; the scanning-path deletion follows once the collector + S3 consumer are live (RFC 0004 migration).

Dep-free (reqwest + serde_json, both already vendored). Unit-tested against a mock OTLP receiver.

Note: validated via CI / a clean checkout, not local `nix build`, because this branch lives in a linked git worktree and nix's flake source resolution snapshots the wrong tree there (excludes the brand-new crate dir).

Written with AI assistance (Claude, Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OTLP/HTTP sink to the indexer for RFC 0004 ingestion bus
> - Adds a new `sink-otlp` crate ([lib.rs](https://github.com/indexable-inc/index/pull/698/files#diff-e5875e905b69c6db2df305c6d2371d7e4e9041d7cc1e8896d447578ce78e63f4)) that POSTs documents as OTLP log records to a configurable `/v1/logs` endpoint, chunked in batches of 500.
> - Each document's body and metadata (including `external_id`, `content_hash`, timestamp) are mapped to OTLP `LogRecord` attributes; resource attributes include `service.name=indexer` and the source name.
> - Exposes a new `--otlp-endpoint` / `INDEXER_OTLP_ENDPOINT` CLI flag in the indexer; when set, every source emission also invokes the OTLP sink alongside the existing parquet and Mixedbread sinks.
> - Non-2xx responses are surfaced as typed errors including the response body; OTLP errors are collected and reported alongside other sink errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c014d75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->