### PR TITLE
docs(mcp): front-door README for a Show HN

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,13 +1,41 @@
 # ix-mcp
 
-<img width="985" height="1083" alt="Dia 2026-06-03 15 57 22" src="https://github.com/user-attachments/assets/e0815b1a-7126-4ba0-9315-a7db53615266" />
-<img width="2100" height="1540" alt="IMG_7380" src="https://github.com/user-attachments/assets/f7d34718-d44a-441a-9927-d367a725de04" />
+<!--
+  DEMO (front door): the thing that sells this is motion — an agent writing and
+  running cells while a human watches them appear in JupyterLab. Record a ~20s
+  loop and drop in two theme variants, then replace the <p align="center"> hero
+  image below with the <picture> block:
+
+  <p align="center">
+    <picture>
+      <source media="(prefers-color-scheme: dark)"  srcset="docs/demo-dark.avif"  type="image/avif">
+      <source media="(prefers-color-scheme: light)" srcset="docs/demo-light.avif" type="image/avif">
+      <source media="(prefers-color-scheme: dark)"  srcset="docs/demo-dark.webp">
+      <source media="(prefers-color-scheme: light)" srcset="docs/demo-light.webp">
+      <img alt="An agent and a human co-editing one live Jupyter notebook" src="docs/demo-dark.webp" width="900">
+    </picture>
+  </p>
+
+  Commit the files at packages/mcp/docs/demo-{dark,light}.{webp,avif}. GitHub
+  strips author-written <video> tags, so an animated WebP/AVIF inside <picture>
+  is the only thing that autoplays, loops, and swaps on dark/light. Encode the
+  loop with ffmpeg -loop 0; see skills/github-readme-media for the recipe and
+  size limits.
+-->
+
+<p align="center">
+  <img width="720" alt="An agent renders a live htop screen into the shared notebook with the bundled tui driver" src="https://github.com/user-attachments/assets/e0815b1a-7126-4ba0-9315-a7db53615266" />
+  <br>
+  <sub><i>An agent renders a live htop screen into the notebook with the bundled <code>tui</code> driver. A human watching the same notebook in JupyterLab sees the cells and outputs appear as they happen.</i></sub>
+</p>
 
 A notebook-first MCP server. An AI agent and a human drive **one live Jupyter
 notebook** together: every tool call edits a real `.ipynb` through Jupyter's
 real-time-collaboration layer, so a person who opens the same notebook in
 JupyterLab sees the agent's cells and outputs appear as they happen, and the work
 is left behind as a notebook with outputs that anyone can reopen.
+
+## Quickstart
 
 ```
 nix run .#mcp -- serve            # MCP over stdio (what an MCP client launches)
@@ -20,27 +48,9 @@ When `serve` starts it prints a JupyterLab URL to stderr; open it, or run
 `ix-mcp lab`, to co-edit the notebook the agent is working in. Jupyter auth is
 disabled (no token, no password), so the URL opens straight in. Access is gated
 by reachability instead: the default bind is loopback, and the fleet only
-exposes the server over Tailscale. Never bind it to a public interface, since a
-reachable Jupyter Server is arbitrary code execution for whoever can dial it.
-
-## Remote access
-
-Two env vars control how a remote VM hands back a reachable URL:
-
-- `IX_MCP_HOST`: the address Jupyter binds. The default is this node's
-  Tailscale IPv4 (`100.x.y.z`) when Tailscale is up, so a phone or laptop on
-  the same tailnet can open the lab URL without ssh. Falls back to `127.0.0.1`
-  when Tailscale is not up. Set it to `0.0.0.0` to listen on every interface
-  (do this only behind a host firewall), or to a specific address to override
-  the auto-detected Tailscale IP.
-- `IX_MCP_PUBLIC_HOST`: the host put into the lab URL. Set it to force a specific
-  name (e.g. `myvm.tail368802.ts.net`).
-
-The default Tailscale-IP bind keeps the trust boundary at the tailnet: only
-tailnet peers can dial `100.x.y.z`, so the local Wi-Fi cannot reach the server.
-If you bind a wildcard (`0.0.0.0`/`::`) without setting `IX_MCP_PUBLIC_HOST`, the
-URL host is auto-resolved to a reachable name: the Tailscale MagicDNS name first,
-then the FQDN, then `127.0.0.1` as a fallback.
+exposes the server over Tailscale (see [Remote access](#remote-access)). Never
+bind it to a public interface, since a reachable Jupyter Server is arbitrary
+code execution for whoever can dial it.
 
 ## How it works
 
@@ -72,6 +82,12 @@ the `index` corpus), numpy, polars, duckdb, httpx, matplotlib, playwright, the
 Google API client, and on macOS `screen` and `macvm`. A per-notebook kernel is
 shared with the human, so state set by an agent cell is visible in the browser.
 
+<p align="center">
+  <img width="760" alt="An agent drives lldb through the bundled tui module to a breakpoint in a C program, inside a notebook cell" src="https://github.com/user-attachments/assets/f7d34718-d44a-441a-9927-d367a725de04" />
+  <br>
+  <sub><i>The bundled <code>tui</code> driver lets a cell spawn and steer a real program: here an agent drives <code>lldb</code> to a breakpoint, rendered back into the notebook.</i></sub>
+</p>
+
 DataFrames render as interactive tables out of the box: every kernel loads
 [itables](https://mwouts.github.io/itables/) at startup with
 `init_notebook_mode(all_interactive=True)`, so displaying a pandas or polars
@@ -86,6 +102,25 @@ The agent reads that `text/plain` repr, so the kernel also widens polars'
 defaults (up to 40 rows and columns, 80-char strings) so a frame is not
 truncated to ~8 columns in the agent's view. The MCP layer still caps a single
 text output at 50k chars, so the wider repr cannot flood the agent's context.
+
+## Remote access
+
+Two env vars control how a remote VM hands back a reachable URL:
+
+- `IX_MCP_HOST`: the address Jupyter binds. The default is this node's
+  Tailscale IPv4 (`100.x.y.z`) when Tailscale is up, so a phone or laptop on
+  the same tailnet can open the lab URL without ssh. Falls back to `127.0.0.1`
+  when Tailscale is not up. Set it to `0.0.0.0` to listen on every interface
+  (do this only behind a host firewall), or to a specific address to override
+  the auto-detected Tailscale IP.
+- `IX_MCP_PUBLIC_HOST`: the host put into the lab URL. Set it to force a specific
+  name (e.g. `myvm.tail368802.ts.net`).
+
+The default Tailscale-IP bind keeps the trust boundary at the tailnet: only
+tailnet peers can dial `100.x.y.z`, so the local Wi-Fi cannot reach the server.
+If you bind a wildcard (`0.0.0.0`/`::`) without setting `IX_MCP_PUBLIC_HOST`, the
+URL host is auto-resolved to a reachable name: the Tailscale MagicDNS name first,
+then the FQDN, then `127.0.0.1` as a fallback.
 
 ## Bad fit if
 


### PR DESCRIPTION
Reshapes packages/mcp/README.md so it works as a Show HN landing, not just internal docs.

- Top of file: a ready-to-fill dark/light autoplay `<picture>` placeholder (in an HTML comment with the recipe). GitHub strips author-written `<video>`, so an animated webp/avif inside `<picture>` is the only thing that autoplays, loops, and swaps on theme.
- Real captions on the two screenshots (htop render, lldb breakpoint) instead of the raw `Dia .../IMG_7380` upload alt text.
- Moved the Remote access env-var section below the pitch so the sell is above the fold.

Draft until the demo loop is recorded: drop `packages/mcp/docs/demo-{dark,light}.{webp,avif}` and swap the hero `<img>` for the `<picture>` block shown in the comment.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add front-door README for the MCP package
> Rewrites [packages/mcp/README.md](https://github.com/indexable-inc/index/pull/699/files#diff-ba5dea79fe8446f1a9461322ff9b3158efbf2e11e1bf709973a2c146fba55539) to serve as a public-facing landing page for a Show HN audience.
>
> - Adds placeholder markup for a looping hero demo (dark/light variants via `<picture>`) and a captioned screenshot of the TUI driver rendering htop in a shared notebook
> - Introduces a `## Quickstart` section header to organize the existing command examples
> - Relocates the `## Remote access` section to later in the document and adds an anchor link from the Tailscale network exposure sentence
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00391f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->