### PR TITLE
fix(otlp-bus): no silent drop on sink-less source; recompute content_hash from body

### DIFF
--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -616,6 +616,14 @@ async fn run_source<A: SourceAdapter + Sync>(
     parquet: Option<&sink_parquet::Config>,
     otlp: Option<&sink_otlp::Config>,
 ) -> anyhow::Result<()> {
+    // A selected source with no sink is a misconfiguration, not a no-op. History
+    // sources route only to the OTLP bus, so a missing `--otlp-endpoint` would
+    // otherwise drop them silently while still counting as a success.
+    anyhow::ensure!(
+        mixedbread.is_some() || parquet.is_some() || otlp.is_some(),
+        "[{label}] no sink configured: pass --otlp-endpoint for history sources (or --mixedbread-store/--bucket for exports)"
+    );
+
     let mut errors: Vec<anyhow::Error> = Vec::new();
 
     if let Some(config) = parquet {
@@ -669,7 +677,7 @@ mod tests {
 
     use std::path::PathBuf;
 
-    use super::{parse_user, safe_path_under};
+    use super::{archive_prefix, parse_user, safe_path_under};
 
     #[test]
     fn safe_path_accepts_real_nested_dir() {
@@ -729,5 +737,13 @@ mod tests {
         let user = parse_user("alice-1.2_3:/home/alice").expect("valid spec");
         assert_eq!(user.name, "alice-1.2_3");
         assert_eq!(user.home, PathBuf::from("/home/alice"));
+    }
+
+    #[test]
+    fn archive_prefix_is_host_scoped() {
+        // Bulk exports still host-scope their parquet keys, so two hosts writing
+        // the same bucket never clobber each other.
+        assert_eq!(archive_prefix("corpus", "hil-compute-1"), "corpus/host=hil-compute-1");
+        assert_ne!(archive_prefix("corpus", "a"), archive_prefix("corpus", "b"));
     }
 }

--- a/packages/source/otlp/src/lib.rs
+++ b/packages/source/otlp/src/lib.rs
@@ -10,9 +10,17 @@
 //! into Mixedbread. It pairs with `sink-otlp`: the attribute names it reads back
 //! are the ones that sink writes.
 //!
-//! A log record is only turned into a document when it carries the
-//! `external_id` and `content_hash` attributes a corpus record always has; any
-//! other log on the bus (a stray app log) is skipped rather than mis-ingested.
+//! A log record is only turned into a document when it carries the `external_id`
+//! attribute a corpus record always has; any other log on the bus (a stray app
+//! log) is skipped rather than mis-ingested. The document's `content_hash` is
+//! recomputed from the reconstructed body, not read from an attribute, so it
+//! always describes the bytes that get embedded.
+//!
+//! Known limitation: this lists the whole prefix and materializes every record
+//! each run, and the emitter is append-only, so the archive and the in-memory
+//! set grow with runs. Before this carries real volume it needs an incremental
+//! cursor (only read partitions newer than the last consumed) plus a retention
+//! policy on the bucket. Tracked as follow-up; fine for the initial wiring.
 
 #![forbid(unsafe_code)]
 
@@ -146,13 +154,19 @@ fn document_from_record(record: LogRecord) -> Option<Document> {
     for attribute in record.attributes {
         meta.insert(attribute.key, attribute.value.into_json());
     }
+    // `external_id` is the corpus identity; a record without it is a stray log.
     let external_id = meta.get(EXTERNAL_ID)?.as_str()?.to_owned();
-    let content_hash = meta.get(keys::CONTENT_HASH)?.as_str()?.to_owned();
+    let body = record.body.string_value().into_bytes();
+    // Recompute the hash from the reconstructed body so it always describes the
+    // bytes that get embedded (source_meta invariant #1), rather than trusting a
+    // possibly-stale `content_hash` attribute. Keep meta_json consistent with it.
+    let content_hash = source_meta::hash_body(&body);
+    meta.insert(keys::CONTENT_HASH.to_owned(), serde_json::Value::String(content_hash.clone()));
     Some(Document {
         file_name: external_id.clone(),
         external_id,
         mime: "text/plain",
-        body: record.body.string_value().into_bytes(),
+        body,
         meta_json: serde_json::Value::Object(meta),
         content_hash,
     })
@@ -286,7 +300,9 @@ mod tests {
         assert_eq!(docs.len(), 1);
         let doc = &docs[0];
         assert_eq!(doc.external_id, "atuin:1");
-        assert_eq!(doc.content_hash, "abc123");
+        // content_hash is recomputed from the reconstructed body, not the stale
+        // "abc123" attribute, so it describes the bytes that get embedded.
+        assert_eq!(doc.content_hash, source_meta::hash_body(b"ls -la"));
         assert_eq!(doc.body, b"ls -la");
         assert_eq!(doc.mime, "text/plain");
         // String attribute round-trips as a string; int64 attribute as a number.


### PR DESCRIPTION
Follow-up to #705 fixing two correctness findings from an adversarial review of the RFC 0004 bus.

- **C1 (silent data loss):** per-host history routes to `(None, None, otlp)`; if `--otlp-endpoint` was absent every sink was `None`, so `run_source` no-opped and reported success, silently dropping history. `run_source` now errors when no sink is configured, so the misconfiguration fails visibly (non-zero exit) instead of dropping data.
- **C2 (content_hash invariant):** `source-otlp` copied `content_hash` from the OTLP attribute while building the body independently, so a lossy body hop would embed under a stale hash and dedup forever. It now recomputes `content_hash` from the reconstructed body (the source_meta invariant), and keeps `meta_json` consistent.

Also: restores `archive_prefix` test coverage (lost with `user_parquet`), and documents the unbounded archive-read as a tracked follow-up (incremental cursor + bucket retention before real volume).

Declined: the reviewer's "unused ObjectStoreExt import" (it's used by production `.get`; clippy's deny-unused proves it).

Validated on a clean x86_64-linux checkout (vin): indexer clippy + `archive_prefix` test, source-otlp clippy + both unit tests, all green.

Written with AI assistance (Claude, Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix silent no-op and recompute `content_hash` from body in OTLP source
> - `run_source` in [main.rs](https://github.com/indexable-inc/index/pull/706/files#diff-5664bac77cedfa678d477bb44bf07a8888bdbb1eb15055f1c164d6c9c131ce7d) now returns an error when no sinks (mixedbread, parquet, or otlp) are configured, preventing silent no-op execution.
> - `document_from_record` in [lib.rs](https://github.com/indexable-inc/index/pull/706/files#diff-5ecae4205b52de962af947304da19e1479f5e29597d97b00f47460050bee4c2a) no longer requires a `content_hash` attribute; it now recomputes `content_hash` from the log body using `source_meta::hash_body`, storing the result in both `Document.content_hash` and `meta_json`.
> - Behavioral Change: records that previously required a `content_hash` attribute are now accepted with only `external_id`, and the hash value will differ from any previously stored attribute value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a226ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->