### PR TITLE
fix(macos-vm): oci-boot.sh uses gzip -dc, not BSD zcat

### DIFF
--- a/packages/macos-vm/examples/oci-boot.sh
+++ b/packages/macos-vm/examples/oci-boot.sh
@@ -121,8 +121,10 @@ cp "$WORK/root/bin/busybox" "$IR/bin/busybox"
 for lib in ld-linux-aarch64.so.1 libc.so.6 libm.so.6 libresolv.so.2; do
   [[ -e "$WORK/root/lib/$lib" ]] && cp "$WORK/root/lib/$lib" "$IR/lib/"
 done
-# Extract the two kernel modules from the Alpine initramfs.
-( cd "$WORK" && mkdir -p aird && cd aird && zcat ../initramfs-virt | cpio -idm 2>/dev/null )
+# Extract the two kernel modules from the Alpine initramfs. Use `gzip -dc`, not
+# `zcat`: macOS ships BSD `zcat`, which appends `.Z` and decodes compress(1), so
+# `zcat initramfs-virt` looks for `initramfs-virt.Z` and fails on a gzip file.
+( cd "$WORK" && mkdir -p aird && cd aird && gzip -dc ../initramfs-virt | cpio -idm 2>/dev/null )
 # The kernel-version directory name is unknown, so glob it (one match expected).
 kmods=( "$WORK"/aird/lib/modules/*/kernel )
 KMOD="${kmods[0]}"


### PR DESCRIPTION
macOS ships BSD `zcat`, which appends `.Z` and decodes compress(1), so `zcat initramfs-virt` looks for `initramfs-virt.Z` and dies on the gzip Alpine initramfs. The example aborts before booting. `gzip -dc` is portable across BSD and GNU and reads the gzip stream directly.

Verified end to end on aarch64-darwin (M5 Max): the guest boots, switch_roots into the busybox OCI rootfs, and prints `uname` + `ls /` over the serial console.

```
INITRAMFS: mounted OCI squashfs; switch_root
OCI-GUEST-PROOF: reached userspace from OCI rootfs on /dev/vda
uname: Linux (none) 6.12.81-0-virt ... aarch64 GNU/Linux
root contents: bin dev etc home init lib lib64 root tmp usr var
```

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `oci-boot.sh` to use `gzip -dc` instead of BSD `zcat` for initramfs extraction
> On macOS, BSD `zcat` expects `.Z` compressed files and fails on gzip files without that suffix. Replaces `zcat ../initramfs-virt | cpio -idm` with `gzip -dc ../initramfs-virt | cpio -idm` in [oci-boot.sh](https://github.com/indexable-inc/index/pull/707/files#diff-36dac10d1f4770e5fb622aafaa85592e0836664c80ed10d062f05ff717b10bd4) and adds a comment explaining the reason.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6869cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->