### PR TITLE
Audit ix CLI -> ix_sdk migration; document why ix-fleet stays on the CLI

### DIFF
--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -1,4 +1,30 @@
 #!/usr/bin/env python3
+#
+# This orchestrator drives the `ix` CLI as a PATH binary rather than the
+# `ix_sdk` Python SDK. That is deliberate, not legacy: the operations it needs
+# have no SDK equivalent today.
+#
+#   - `ix image push`            no SDK method (the SDK builds *from* an OCI
+#                                reference via build_snapshot_from_oci; it does
+#                                not push a local image tarball to a registry).
+#   - `ix group create` / `add`  no SDK method for east-west groups.
+#   - `ix switch --source ...`   the SDK's switch_system takes only
+#     `--source-workdir`         name/target/build_on; it has no --source,
+#     `--build-vm`               --source-workdir, --build-vm, or
+#     `--override-input`         --override-input, which the remote-source
+#                                switch path (the primary one) requires.
+#   - `ix ls --output json`      the SDK's Client.branches() returns BranchInfo
+#                                objects with a fixed, different field set, so
+#                                the IX_NODE_<KEY> env exposed to host health
+#                                checks (derived from every key of the CLI JSON
+#                                rows) would silently change names and values.
+#
+# Idempotency here also keys off CLI stderr text ("already exists", "not
+# found"), and the package treats `ix` as a swappable binary (the nix test
+# shims a fake `ix`). Mixing in SDK calls for only `start`/`rm`/`snapshot`
+# would split that seam and break the exact-argv unit tests for no behavior
+# gain. Revisit if/when the SDK grows image-push, groups, and a source-based
+# switch.
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
Audit of every `ix` CLI usage in index for migration to the `ix_sdk` Python SDK. Net result: **0 of the real call sites can move to the SDK today** without new SDK methods or a behavior change, so this PR converts none and instead records the rationale inline in `ix-fleet` (the only place with non-doc CLI calls).

### What I found

| Location | CLI use | Verdict |
|---|---|---|
| `packages/ix-fleet/src/ix_fleet/__init__.py` | `ix new/ls/rm/start/snapshot/switch/group/image/shell` | Left as CLI (see below) |
| `tools/ix-shell-sync-ignored.py` | `tar | ix shell <vm> -- ...` streams a tarball over stdin | Left as CLI: SDK `exec`/`bash` take no stdin stream; no equivalent |
| `tools/update-ix-cli.py` | only `nix store prefetch-file` + `git` | Not an `ix` CLI usage |
| `packages/search-eval/src/search_eval/agent.py` | `IxVmBackend` mentions `ix new` in a docstring | Unimplemented stub (raises); nothing to convert |
| `packages/run/run.py` | `ix run` is its own branding label | Does not shell out to `ix` |
| `packages/ix-dev-diagnose`, examples, READMEs, `.nix` | `ix shell ...` etc. | Docs / human-facing CLI examples, not code |

### Why `ix-fleet` stays on the CLI

It is node-orchestration, and the operations it needs have no SDK equivalent (SDK surface read from `sdk/python/ix_sdk/__init__.py`):

- `ix image push <src> <dest>` -> no SDK method (the SDK builds *from* an OCI ref via `build_snapshot_from_oci`; it does not push a local tarball to a registry).
- `ix group create` / `ix group add` -> no SDK method for east-west groups.
- `ix switch <name> <target> --build-on --source --source-workdir --build-vm --override-input` -> `Client.switch_system` takes only name/target/build_on. The primary remote-source switch path needs the other flags.
- `ix ls --output json` -> `Client.branches()` returns `BranchInfo` with a fixed, different field set. `ix-fleet` derives `IX_NODE_<KEY>` env (exposed to host health-check command templates) from every key of the CLI JSON rows, so switching would silently rename/revalue that user-facing env contract. `BranchInfo.status` is also a `BranchStatus` enum, not the string the code matches on.

On top of that, idempotency keys off CLI stderr text ("already exists", "not found"), and the package treats `ix` as a swappable binary (its nix test shims a fake `ix`). Converting only the three calls that *do* have SDK equivalents (`start`, `rm`, `snapshot`) would split that seam, break the exact-argv unit tests, and add a compiled-extension dependency for no behavior gain.

### Follow-ups (missing SDK methods that would unblock a future migration)

- image push to a registry
- east-west group create / add
- source-based `switch_system` (`source`, `source_workdir`, `build_vm`, `override_input`)
- a `branches()` shape (or helper) that preserves the `ix ls --output json` keys ix-fleet relies on
- exec with a streamed stdin (to replace the `tar | ix shell` pipe in `ix-shell-sync-ignored.py`)

### Validation
- `nix build .#ix-fleet` passes (runs the `upFindsDagRunner` integration test).
- `ix-fleet` unit suite passes (24/24) under `python313 + pydantic`.
- Change is comment-only; exact-argv tests and the fake-`ix` nix test are unaffected.

Made with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document why `ix-fleet` orchestrator uses the `ix` CLI instead of the Python SDK
> Adds a header comment to [`ix_fleet/__init__.py`](https://github.com/indexable-inc/index/pull/711/files#diff-d83777ed2e90ee1f7371ffa0e55fe375c817b07e2cb2a15a5b58423ad93dae3e) explaining the deliberate choice to invoke the `ix` CLI rather than `ix_sdk`. The comment enumerates missing SDK capabilities (image push, groups, source-based switch), describes the idempotency strategy based on CLI stderr output, and notes the testing approach.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cfc372c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->