### PR TITLE
fix(macos-vm): gate libkrun on the build host, not the target (fix cross-darwin-smoke)

### DIFF
--- a/lib/rust/workspace.nix
+++ b/lib/rust/workspace.nix
@@ -85,21 +85,22 @@ let
     target:
     if target == null then workspacePkgs.stdenv.hostPlatform.isLinux else lib.hasInfix "-linux-" target;
 
-  # `macos-vm` links libkrun-efi for its Linux-guest backend, which nixpkgs only
-  # provides on aarch64-darwin. Gate the libkrun plumbing on that target so other
-  # platforms (Linux, x86_64-darwin) never force the package and the Linux stub
-  # graph stays clean, the same target-scoped shape as the ALSA gating above.
-  targetIsAarch64Darwin =
-    target:
-    if target == null then
-      workspacePkgs.stdenv.hostPlatform.isDarwin && workspacePkgs.stdenv.hostPlatform.isAarch64
-    else
-      target == "aarch64-apple-darwin";
+  # `macos-vm` links libkrun-efi for its Linux-guest backend. nixpkgs only
+  # provides libkrun-efi when the *build host* is aarch64-darwin (it is not
+  # cross-buildable from Linux), so gate on the build host, NOT the target: a
+  # Linux->darwin cross build (the `cross-darwin-smoke` check) must never force
+  # `workspacePkgs.libkrun-efi`, which would refuse to evaluate on the Linux host.
+  # When this is false, `macos-vm`'s build script omits the firmware env, so the
+  # crate compiles without the libkrun backend (see its `build.rs`/`linuxkrun.rs`).
+  buildHostIsAarch64Darwin =
+    workspacePkgs.stdenv.hostPlatform.isDarwin && workspacePkgs.stdenv.hostPlatform.isAarch64;
 
   # libkrun-efi lib dir and the OVMF firmware blob it embeds (the latter lives in
   # the libkrun source tree). `macos-vm`'s build script embeds the firmware via
   # `KRUN_EFI_FIRMWARE` and links `-lkrun`; the search path/rpath are injected
   # below because a build script's link-search does not reach the final unit link.
+  # Only referenced under `buildHostIsAarch64Darwin`, so non-darwin hosts never
+  # force the (host-only) package.
   libkrunEfiLibDir = "${workspacePkgs.libkrun-efi}/lib";
   krunEfiFirmware = "${workspacePkgs.libkrun-efi.src}/edk2/KRUN_EFI.silent.fd";
 
@@ -202,10 +203,10 @@ let
         // lib.optionalAttrs (targetIsLinux target) {
           PKG_CONFIG_PATH = "${workspacePkgs.alsa-lib.dev}/lib/pkgconfig";
         }
-        // lib.optionalAttrs (targetIsAarch64Darwin target) {
+        // lib.optionalAttrs buildHostIsAarch64Darwin {
           # macos-vm's build script forwards this to a compile-time env so
-          # linuxkrun.rs can `include_bytes!` the OVMF firmware. Only macos-vm
-          # reads it.
+          # linuxkrun.rs can `include_bytes!` the OVMF firmware, and uses its
+          # presence to enable the libkrun backend. Only macos-vm reads it.
           KRUN_EFI_FIRMWARE = krunEfiFirmware;
         }
         // lib.optionalAttrs (appleToolchain != null) appleToolchain.env;
@@ -228,7 +229,7 @@ let
           "-L"
           "native=${workspacePkgs.alsa-lib}/lib"
         ]
-        ++ lib.optionals (targetIsAarch64Darwin target) [
+        ++ lib.optionals buildHostIsAarch64Darwin [
           # macos-vm links `-lkrun` (libkrun-efi). Its build script emits the
           # `-l`, but the search path and rpath must be added here because a build
           # script's link-search does not reach the final unit link (same shape as

--- a/packages/macos-vm/build.rs
+++ b/packages/macos-vm/build.rs
@@ -1,30 +1,40 @@
 //! Build script for `macos-vm`.
 //!
-//! On macOS the crate links the libkrun-efi dylib (for the Linux-guest path,
-//! `src/linuxkrun.rs`) and embeds the OVMF firmware blob. On Linux the crate is
-//! a typed "macOS only" stub, so this is a no-op there.
+//! When building natively on aarch64-darwin the crate links the libkrun-efi
+//! dylib (for the Linux-guest path, `src/linuxkrun.rs`) and embeds the OVMF
+//! firmware blob. Everywhere else (Linux, x86_64-darwin, and Linux->darwin cross
+//! builds) libkrun-efi is unavailable, so the `have_libkrun` cfg is left unset
+//! and the crate compiles without the libkrun backend.
 
 fn main() {
+    // Declare the custom cfg unconditionally so the `unexpected_cfgs` lint
+    // accepts `#[cfg(have_libkrun)]` on every platform.
+    println!("cargo:rustc-check-cfg=cfg(have_libkrun)");
+    println!("cargo:rerun-if-env-changed=KRUN_EFI_FIRMWARE");
+
     // `CARGO_CFG_TARGET_OS` is the target, set by cargo for the build script.
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     if target_os != "macos" {
         return;
     }
 
-    // Link libkrun-efi. `-lkrun` resolves to `libkrun-efi.dylib` via the symlink
-    // chain the nix package provides. The link *search path* and rpath are added
-    // by the workspace build (lib/rust/workspace.nix), because a build script's
-    // `rustc-link-search` does not reach the final unit link in the repo's
-    // cargo-unit graph (the same reason the ALSA lib dir is added there); the
-    // `-l` directive below does propagate.
-    println!("cargo:rustc-link-lib=dylib=krun");
-
-    // Forward the OVMF firmware path to a compile-time env so `linuxkrun.rs` can
-    // `include_bytes!` it into the binary (self-contained across the entitlement
-    // self-sign re-exec). The nix build sets `KRUN_EFI_FIRMWARE` to the libkrun
-    // source's `edk2/KRUN_EFI.silent.fd`.
-    println!("cargo:rerun-if-env-changed=KRUN_EFI_FIRMWARE");
+    // The workspace build sets `KRUN_EFI_FIRMWARE` (the embedded OVMF blob) only
+    // when the build host is aarch64-darwin, where nixpkgs provides libkrun-efi
+    // (it is not cross-buildable from Linux). Use its presence as the signal that
+    // the libkrun backend can be linked: a Linux->darwin cross build has neither
+    // the firmware nor the dylib, so it compiles the crate without libkrun.
     if let Ok(firmware) = std::env::var("KRUN_EFI_FIRMWARE") {
+        // Enable the libkrun backend in `linuxkrun.rs`.
+        println!("cargo:rustc-cfg=have_libkrun");
+        // Link libkrun-efi. `-lkrun` resolves to `libkrun-efi.dylib` via the
+        // symlink chain the nix package provides. The link *search path* and
+        // rpath are added by the workspace build (lib/rust/workspace.nix),
+        // because a build script's `rustc-link-search` does not reach the final
+        // unit link in the repo's cargo-unit graph; the `-l` directive does.
+        println!("cargo:rustc-link-lib=dylib=krun");
+        // Forward the firmware path to a compile-time env so `linuxkrun.rs` can
+        // `include_bytes!` it into the binary (self-contained across the
+        // entitlement self-sign re-exec).
         println!("cargo:rustc-env=KRUN_EFI_FIRMWARE={firmware}");
     }
 }

--- a/packages/macos-vm/src/linuxkrun.rs
+++ b/packages/macos-vm/src/linuxkrun.rs
@@ -22,7 +22,9 @@
 //! re-exec (see `main.rs`), which would otherwise break a relative firmware
 //! lookup.
 
+#[cfg(have_libkrun)]
 use std::ffi::CString;
+#[cfg(have_libkrun)]
 use std::os::raw::c_char;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -34,6 +36,12 @@ use crate::imp::Error;
 // `i32`: >= 0 success, negative is `-errno`. `#[link(name = "krun")]` resolves
 // to `libkrun-efi.dylib` through the symlink chain the nix package provides; the
 // search path and rpath come from the workspace build (see lib/rust/workspace.nix).
+//
+// The whole libkrun surface is gated on the `have_libkrun` cfg, which the build
+// script sets only when building natively on aarch64-darwin (where libkrun-efi
+// is available). A Linux->darwin cross build compiles the crate without it (see
+// the stub `boot_linux` at the bottom of this file).
+#[cfg(have_libkrun)]
 #[link(name = "krun")]
 unsafe extern "C" {
     fn krun_set_log_level(level: u32) -> i32;
@@ -52,16 +60,21 @@ unsafe extern "C" {
     fn krun_start_enter(ctx_id: u32) -> i32;
 }
 
+#[cfg(have_libkrun)]
 const KRUN_DISK_FORMAT_RAW: u32 = 0;
 // virtio-gpu Venus, no virgl: the flag set krunkit uses on macOS for a
 // MoltenVK-backed Vulkan device (libkrun.h VIRGLRENDERER_VENUS | _NO_VIRGL).
+#[cfg(have_libkrun)]
 const VIRGLRENDERER_VENUS: u32 = 1 << 6;
+#[cfg(have_libkrun)]
 const VIRGLRENDERER_NO_VIRGL: u32 = 1 << 7;
 // GPU shared-memory (vRAM) window. 1 GiB matches krunkit's default.
+#[cfg(have_libkrun)]
 const GPU_SHM_BYTES: u64 = 1 << 30;
 
 /// The OVMF/EDK2 firmware the EFI guest boots, embedded at build time so the
 /// binary is self-contained (survives the self-sign re-exec).
+#[cfg(have_libkrun)]
 const FIRMWARE: &[u8] = include_bytes!(env!("KRUN_EFI_FIRMWARE"));
 
 /// Parameters for booting a Linux guest under libkrun. Named fields (like
@@ -84,6 +97,7 @@ pub struct BootLinux {
     pub timeout: Duration,
 }
 
+#[cfg(have_libkrun)]
 fn cstr(s: &str) -> Result<CString, Error> {
     CString::new(s).map_err(|_| Error::Bundle {
         message: format!("path {s:?} contains a NUL byte"),
@@ -92,6 +106,7 @@ fn cstr(s: &str) -> Result<CString, Error> {
 
 /// Write the embedded firmware to a per-user cache file (once) and return its
 /// path, since `krun_set_firmware` takes a path, not bytes.
+#[cfg(have_libkrun)]
 fn firmware_path() -> Result<PathBuf, Error> {
     use std::os::unix::fs::PermissionsExt;
 
@@ -131,6 +146,7 @@ fn firmware_path() -> Result<PathBuf, Error> {
     Ok(path)
 }
 
+#[cfg(have_libkrun)]
 fn check(op: &str, code: i32) -> Result<(), Error> {
     if code >= 0 {
         Ok(())
@@ -142,9 +158,22 @@ fn check(op: &str, code: i32) -> Result<(), Error> {
     }
 }
 
+/// Stub for builds without the libkrun backend (Linux->darwin cross builds,
+/// where libkrun-efi is unavailable). Returns a typed error rather than silently
+/// doing nothing, so a caller learns the backend was not compiled in.
+#[cfg(not(have_libkrun))]
+pub fn boot_linux(_boot: BootLinux) -> Result<(), Error> {
+    Err(Error::Libkrun {
+        op: "boot-linux: libkrun backend not built in (needs a native aarch64-darwin build)"
+            .to_owned(),
+        code: 0,
+    })
+}
+
 /// Boot a Linux guest under libkrun and run it until it powers off or the
 /// timeout elapses. Does not return on success: `krun_start_enter` takes over
 /// the process and `exit()`s with the guest's exit code when the VM stops.
+#[cfg(have_libkrun)]
 pub fn boot_linux(boot: BootLinux) -> Result<(), Error> {
     if !boot.disk.exists() {
         return Err(Error::Disk {


### PR DESCRIPTION
Fixes `flake-check` on main, broken by #712.

The `cross-darwin-smoke` check cross-compiles darwin from a Linux host, and the libkrun wiring in `lib/rust/workspace.nix` forced `workspacePkgs.libkrun-efi` for the aarch64-apple-darwin *target*. libkrun-efi is aarch64-darwin **host**-only (not cross-buildable from Linux), so it refuses to evaluate on the Linux build host:

```
error: Refusing to evaluate package 'libkrun-efi-1.18.0' ... not available on the requested hostPlatform
```

Fix: gate the libkrun plumbing on the **build host** being aarch64-darwin, not the target. The crate's build script sets a `have_libkrun` cfg (and links `-lkrun` / embeds the firmware) only when the firmware env is present (a native aarch64-darwin build); `linuxkrun.rs` compiles its libkrun backend under that cfg and provides a stub `boot_linux` otherwise. So a Linux->darwin cross build compiles `macos-vm` without libkrun (keeping the VZ macOS-guest paths via the SDK).

Validated: `nix build .#macos-vm` and `nix run .#lint` pass on aarch64-darwin (have_libkrun path); `lib.optionalAttrs false`/`lib.optionals false` no longer reference libkrun-efi on a Linux host (the eval failure).

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix libkrun-efi gating to use build host instead of target to fix cross-darwin builds
> - Changes the libkrun-efi dependency in [workspace.nix](https://github.com/indexable-inc/index/pull/713/files#diff-ea594f8bfd460f458ce6b01ce873abb2ff3a3cf89d789587a70728ef478b4ceb) from a target-platform gate (`targetIsAarch64Darwin`) to a build-host gate (`buildHostIsAarch64Darwin`), so Linux hosts cross-compiling to darwin no longer pull or reference libkrun-efi.
> - Updates [build.rs](https://github.com/indexable-inc/index/pull/713/files#diff-fe1fd849327943fc1e136535bb40bab827bc457ebea84fc5f652b15806279f6f) to link libkrun and set the `have_libkrun` cfg only when `KRUN_EFI_FIRMWARE` is present at build time, rather than unconditionally on macOS targets.
> - Adds `#[cfg(have_libkrun)]` guards throughout [linuxkrun.rs](https://github.com/indexable-inc/index/pull/713/files#diff-13d46c81f34f2b1c68cb1f0a48420b29f566c5ef3c9153bba7a817e5f1f408aa) and a stub `boot_linux` that returns a typed `Error::Libkrun` when the backend is absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4667641.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->