### PR TITLE
docs(macos-vm): correct false 'libkrun has no off-screen capture' claim

### DIFF
--- a/packages/macos-vm/README.md
+++ b/packages/macos-vm/README.md
@@ -304,8 +304,12 @@ Podman Desktop, Lima, and colima reached (they use libkrun/krunkit on macOS).
 Details (the EFI-variant constraint, the embedded OVMF firmware, linking, and the
 `com.apple.security.hypervisor` entitlement) are in
 [`docs/linux-libkrun.md`](docs/linux-libkrun.md). The off-screen **GUI** capture
-paths (`boot-linux-gui`, `drive-linux`) still use VZ, since libkrun has no
-off-screen framebuffer-capture equivalent yet; migrating them is tracked below.
+paths (`boot-linux-gui`, `drive-linux`) still use VZ for now, but only as a
+not-yet-migrated implementation, not a libkrun limitation: libkrun-efi exports a
+full display + input API (`krun_add_display` + `krun_set_display_backend`, where
+the host owns the frame buffer, and `krun_add_input_device`; see libkrun's
+`examples/gui_vm`), so those paths can move to libkrun and gain GPU-accelerated
+rendering. Tracked below.
 
 ## Build notes
 
@@ -349,5 +353,7 @@ off-screen framebuffer-capture equivalent yet; migrating them is tracked below.
    --disk [--gpu]` boots a raw EFI disk under libkrun and streams its console;
    see [`docs/linux-libkrun.md`](docs/linux-libkrun.md).
 8. Move the off-screen GUI capture paths (`boot-linux-gui`, `drive-linux`) from
-   VZ to libkrun's virtio-gpu, so GPU-accelerated Linux GUIs can be captured
-   off-screen too. They stay on VZ until libkrun has an off-screen-capture path.
+   VZ to libkrun's virtio-gpu via `krun_set_display_backend` (host-owned frame
+   buffer) + `krun_add_input_device` (see libkrun's `examples/gui_vm`), so the
+   Linux GUI is GPU-accelerated (Venus) instead of software (VZ lavapipe). This is
+   a not-yet-done migration, not a libkrun limitation.

--- a/packages/macos-vm/docs/linux-libkrun.md
+++ b/packages/macos-vm/docs/linux-libkrun.md
@@ -27,6 +27,6 @@ libkrun needs `com.apple.security.hypervisor` on the running process (distinct f
 
 ## Known limitations
 
-- **GUI capture stays on Virtualization.framework.** The off-screen framebuffer capture and synthetic-input paths (`boot-linux-gui`, `drive-linux`) still use VZ's `VZVirtualMachineView` IOSurface, which libkrun has no direct equivalent for yet. Migrating them to libkrun's virtio-gpu is follow-up work; until then those two commands keep their VZ implementation.
+- **GUI capture still uses Virtualization.framework (not migrated yet).** The off-screen framebuffer capture and synthetic-input paths (`boot-linux-gui`, `drive-linux`) currently use VZ's `VZVirtualMachineView` IOSurface. This is a not-yet-done migration, not a libkrun limitation: libkrun-efi exports a display + input API for exactly this. `krun_add_display` + `krun_set_display_backend` register a host backend whose `configure_scanout`/`alloc_frame`/`present_frame` callbacks hand the host the guest's rendered scanout (the host allocates the frame buffer, so it owns the pixels, cleaner than reading VZ's IOSurface), and `krun_add_input_device` injects synthetic `krun_input_event`s. See libkrun's `examples/gui_vm`. Moving these paths to libkrun would also make the Linux GUI GPU-accelerated (Venus) instead of software (VZ's lavapipe).
 - **aarch64-darwin only.** libkrun-efi is packaged only for Apple Silicon.
 - **A guest is an EFI disk, not a kernel + initramfs.** The previous VZ `boot-linux` accepted a raw kernel + initramfs; libkrun-efi boots an EFI disk instead.


### PR DESCRIPTION
The README/docs/roadmap from #712 claimed libkrun has no off-screen framebuffer-capture equivalent, justifying keeping `boot-linux-gui`/`drive-linux` on VZ. That's wrong: `libkrun-efi` (the dylib we link) exports `krun_add_display` + `krun_set_display_backend` (host owns the frame buffer via `configure_scanout`/`alloc_frame`/`present_frame`) + `krun_add_input_device` (see libkrun `examples/gui_vm`). Docs-only correction; the GUI migration itself is separate follow-up.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Correct false claim that libkrun lacks off-screen capture capability in macOS VM docs
> Updates [README.md](https://github.com/indexable-inc/index/pull/714/files#diff-2671007570de681003a953dfc09e2b9af6e66cc927764881cefcc2630d0f0931) and [linux-libkrun.md](https://github.com/indexable-inc/index/pull/714/files#diff-e6f52e0783ced10218521032b8dc36bdb43b9bbf73107ec747b2bf4fb57ca1b0) to clarify that the current reliance on Virtualization.framework for GUI capture is a not-yet-completed migration, not a libkrun limitation. Adds documentation of the libkrun-efi display and input APIs (`krun_add_display`, `krun_set_display_backend`, `krun_add_input_device`) and references the `examples/gui_vm` example. Also notes the roadmap plan to migrate via libkrun's virtio-gpu with host-owned framebuffer, and contrasts GPU-accelerated Venus with VZ's software lavapipe path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fadaea8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->