### PR TITLE
fix(indexer): tolerate an uninitialized per-user atuin history db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2787,6 +2787,7 @@ dependencies = [
  "dirs",
  "mixedbread",
  "nix 0.30.1",
+ "rusqlite",
  "search-core",
  "serde_json",
  "sink-mixedbread",

--- a/packages/indexer/Cargo.toml
+++ b/packages/indexer/Cargo.toml
@@ -36,4 +36,5 @@ dirs.workspace = true
 nix = { workspace = true, features = ["hostname"] }
 
 [dev-dependencies]
+rusqlite = { workspace = true, features = ["bundled"] }
 tempfile.workspace = true

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -291,7 +291,7 @@ async fn run_sources(
         record("codex", result, &mut counts);
     }
     if let Some(db) = atuin {
-        match open_atuin("shell", &db, &mut counts) {
+        match open_atuin("shell", &db, otlp, &mut counts) {
             Ok(Atuin::Ready(adapter)) => {
                 let result = run_source("shell", &adapter, None, None, otlp).await;
                 record("shell", result, &mut counts);
@@ -482,7 +482,7 @@ async fn index_user(
     // such account cannot fail the whole fleet run (ENG-2141).
     if let Some(atuin_db) = safe_path_under(home, &[".local", "share", "atuin", "history.db"], false) {
         let label = format!("shell:{name}");
-        match open_atuin(&label, &atuin_db, counts) {
+        match open_atuin(&label, &atuin_db, otlp, counts) {
             Ok(Atuin::Ready(adapter)) => {
                 let result = run_source(&label, &adapter, None, None, otlp).await;
                 record(&label, result, counts);
@@ -638,10 +638,25 @@ enum Atuin {
 /// [`Counts::skipped`] and never gates the unit's exit code. Any other open
 /// failure (a corrupt db, a permissions error) is still returned for the caller
 /// to record as a genuine failure, preserving real-error reporting.
-fn open_atuin(label: &str, db: &Path, counts: &mut Counts) -> anyhow::Result<Atuin> {
+fn open_atuin(
+    label: &str,
+    db: &Path,
+    otlp: Option<&sink_otlp::Config>,
+    counts: &mut Counts,
+) -> anyhow::Result<Atuin> {
     match source_atuin::AtuinHistory::open(db) {
         Ok(history) => Ok(Atuin::Ready(history)),
         Err(error) if error.is_uninitialized() => {
+            // A history source routes only to the OTLP bus, so a run that selects
+            // one with no --otlp-endpoint is a misconfiguration. run_source
+            // rejects it for a readable db; enforce the same here BEFORE
+            // downgrading to a soft skip, so an uninitialized db cannot let a
+            // sink-less run exit 0 when the identical config fails once the
+            // `history` table exists.
+            anyhow::ensure!(
+                otlp.is_some(),
+                "[{label}] no sink configured: pass --otlp-endpoint for history sources"
+            );
             eprintln!("[{label}] skipped: {error} ({db})", db = db.display());
             counts.skipped += 1;
             Ok(Atuin::Skipped)
@@ -736,6 +751,14 @@ mod tests {
         rusqlite::Connection::open(path).expect("create empty sqlite db");
     }
 
+    /// A throwaway OTLP sink config so `open_atuin`'s sink validation passes; the
+    /// endpoint is never dialed in these tests (they assert open/skip behavior).
+    fn otlp_sink() -> sink_otlp::Config {
+        sink_otlp::Config {
+            endpoint: "http://127.0.0.1:4317".to_string(),
+        }
+    }
+
     #[test]
     fn uninitialized_atuin_db_is_soft_skipped_and_run_succeeds() {
         // ENG-2141: one account whose atuin db exists but has no `history` table
@@ -746,7 +769,9 @@ mod tests {
         make_uninitialized_db(&db);
 
         let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
-        let outcome = open_atuin("shell:tester", &db, &mut counts).expect("uninitialized db is not an error");
+        let sink = otlp_sink();
+        let outcome = open_atuin("shell:tester", &db, Some(&sink), &mut counts)
+            .expect("uninitialized db is not an error");
 
         assert!(matches!(outcome, Atuin::Skipped), "uninitialized db must be skipped");
         assert_eq!(counts.skipped, 1, "the skip must be tallied");
@@ -763,11 +788,30 @@ mod tests {
         let db = temp.path().join("does-not-exist.db");
 
         let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
+        let sink = otlp_sink();
         assert!(
-            open_atuin("shell:tester", &db, &mut counts).is_err(),
+            open_atuin("shell:tester", &db, Some(&sink), &mut counts).is_err(),
             "a missing db file must remain a real error, not a soft skip"
         );
         assert_eq!(counts.skipped, 0, "a real error must not be tallied as a skip");
+    }
+
+    #[test]
+    fn uninitialized_atuin_db_without_sink_is_an_error() {
+        // The soft skip must not bypass sink validation: an uninitialized db with
+        // no OTLP sink is the same misconfiguration run_source rejects once the db
+        // has a `history` table, so it must fail consistently rather than exit 0
+        // (the per-user fleet path shares open_atuin, so it is covered too).
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db = temp.path().join("history.db");
+        make_uninitialized_db(&db);
+
+        let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
+        assert!(
+            open_atuin("shell:tester", &db, None, &mut counts).is_err(),
+            "an uninitialized db with no sink must error, not silently skip"
+        );
+        assert_eq!(counts.skipped, 0, "a misconfiguration must not be tallied as a skip");
     }
 
     #[test]

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -234,7 +234,7 @@ fn finish(counts: Counts) -> anyhow::Result<()> {
         anyhow::bail!(
             "{} of {} source(s) failed; {} succeeded, {} skipped",
             counts.failures,
-            counts.indexed + counts.failures,
+            counts.indexed + counts.failures + counts.skipped,
             counts.indexed,
             counts.skipped
         );

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -137,10 +137,17 @@ struct Mixedbread<'a> {
     name: &'a str,
 }
 
-/// Per-run tally of how many sources were indexed versus failed.
+/// Per-run tally of how many sources were indexed, soft-skipped, or failed.
+///
+/// `skipped` counts sources that were deliberately and visibly passed over for a
+/// benign reason (e.g. an atuin db file that exists but has no `history` table
+/// because that account never ran atuin). A soft skip is logged but never gates
+/// the run's exit code — only `failures` does — so one uninitialized per-user
+/// history db cannot degrade the whole indexing unit.
 #[derive(Clone, Copy)]
 struct Counts {
     indexed: usize,
+    skipped: usize,
     failures: usize,
 }
 
@@ -215,13 +222,21 @@ async fn main() -> anyhow::Result<()> {
 
 /// Turn the per-run counts into the process result: success only when no source
 /// failed, so a partial failure is a non-zero exit the timer/operator can see.
+///
+/// Soft skips (e.g. an uninitialized atuin db, counted in `skipped`) never gate
+/// the exit code — only genuine `failures` do — so one account whose history db
+/// has no `history` table cannot degrade the whole indexing unit.
 fn finish(counts: Counts) -> anyhow::Result<()> {
+    if counts.skipped > 0 {
+        eprintln!("[indexer] {} source(s) soft-skipped (uninitialized/empty)", counts.skipped);
+    }
     if counts.failures > 0 {
         anyhow::bail!(
-            "{} of {} source(s) failed; {} succeeded",
+            "{} of {} source(s) failed; {} succeeded, {} skipped",
             counts.failures,
             counts.indexed + counts.failures,
-            counts.indexed
+            counts.indexed,
+            counts.skipped
         );
     }
     Ok(())
@@ -256,7 +271,7 @@ async fn run_sources(
     let codex = cli.codex_file.clone().or_else(|| cli.local.then(|| default(".codex/history.jsonl")).flatten());
     let atuin = cli.atuin_db.clone().or_else(|| cli.local.then(|| default(".local/share/atuin/history.db")).flatten());
 
-    let mut counts = Counts { indexed: 0, failures: 0 };
+    let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
     if let Some(dir) = claude {
         let result = async {
             let adapter = source_claude::ClaudeHistoryExport::open(&dir)
@@ -276,13 +291,15 @@ async fn run_sources(
         record("codex", result, &mut counts);
     }
     if let Some(db) = atuin {
-        let result = async {
-            let adapter = source_atuin::AtuinHistory::open(&db)
-                .with_context(|| format!("reading atuin history at {}", db.display()))?;
-            run_source("shell", &adapter, None, None, otlp).await
+        match open_atuin("shell", &db, &mut counts) {
+            Ok(Atuin::Ready(adapter)) => {
+                let result = run_source("shell", &adapter, None, None, otlp).await;
+                record("shell", result, &mut counts);
+            }
+            // An uninitialized db is already logged and tallied as a soft skip.
+            Ok(Atuin::Skipped) => {}
+            Err(error) => record("shell", Err(error), &mut counts),
         }
-        .await;
-        record("shell", result, &mut counts);
     }
     if let Some(dir) = &cli.slack_export {
         let result = async {
@@ -381,7 +398,7 @@ impl SourceAdapter for VecSource {
 /// ingestion did, so a consumed record dedups against its own source and never
 /// touches another's.
 async fn run_consume(config: &source_otlp::Config, mixedbread: Mixedbread<'_>) -> Counts {
-    let mut counts = Counts { indexed: 0, failures: 0 };
+    let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
     let documents = match source_otlp::read_documents(config).await {
         Ok(documents) => documents,
         Err(error) => {
@@ -460,16 +477,19 @@ async fn index_user(
     }
 
     // atuin records its own `host`/`user` in each row, so it self-tags per user
-    // regardless of who runs the process.
+    // regardless of who runs the process. An account whose db file exists but
+    // was never initialized by atuin (no `history` table) is a soft skip, so one
+    // such account cannot fail the whole fleet run (ENG-2141).
     if let Some(atuin_db) = safe_path_under(home, &[".local", "share", "atuin", "history.db"], false) {
         let label = format!("shell:{name}");
-        let result = async {
-            let adapter = source_atuin::AtuinHistory::open(&atuin_db)
-                .with_context(|| format!("reading atuin history for {name} at {}", atuin_db.display()))?;
-            run_source(&label, &adapter, None, None, otlp).await
+        match open_atuin(&label, &atuin_db, counts) {
+            Ok(Atuin::Ready(adapter)) => {
+                let result = run_source(&label, &adapter, None, None, otlp).await;
+                record(&label, result, counts);
+            }
+            Ok(Atuin::Skipped) => {}
+            Err(error) => record(&label, Err(error), counts),
         }
-        .await;
-        record(&label, result, counts);
     }
 
     // Claude debug logs (`~/.claude/debug/<session>.txt`), present only for
@@ -600,6 +620,37 @@ fn record(label: &str, result: anyhow::Result<()>, counts: &mut Counts) {
     }
 }
 
+/// The outcome of opening one atuin db: a parsed source to index, or a logged,
+/// non-fatal skip already tallied into [`Counts::skipped`].
+enum Atuin {
+    /// The db opened and its `history` table was read.
+    Ready(source_atuin::AtuinHistory),
+    /// The db was uninitialized (no `history` table) and is being skipped.
+    Skipped,
+}
+
+/// Open one atuin history db, folding the "uninitialized db" case into a logged
+/// soft skip rather than a hard error.
+///
+/// The fleet run reads every account's history; an account that has an atuin db
+/// file but never ran atuin has a db with no `history` table. That is a benign,
+/// expected state — not a read failure — so it is recorded in
+/// [`Counts::skipped`] and never gates the unit's exit code. Any other open
+/// failure (a corrupt db, a permissions error) is still returned for the caller
+/// to record as a genuine failure, preserving real-error reporting.
+fn open_atuin(label: &str, db: &Path, counts: &mut Counts) -> anyhow::Result<Atuin> {
+    match source_atuin::AtuinHistory::open(db) {
+        Ok(history) => Ok(Atuin::Ready(history)),
+        Err(error) if error.is_uninitialized() => {
+            eprintln!("[{label}] skipped: {error} ({db})", db = db.display());
+            counts.skipped += 1;
+            Ok(Atuin::Skipped)
+        }
+        Err(error) => Err(anyhow::Error::new(error)
+            .context(format!("reading atuin history at {}", db.display()))),
+    }
+}
+
 /// Fan one source out to every enabled sink.
 ///
 /// The parquet archive runs FIRST and the two sinks are INDEPENDENT: a slow or
@@ -677,7 +728,47 @@ mod tests {
 
     use std::path::PathBuf;
 
-    use super::{archive_prefix, parse_user, safe_path_under};
+    use super::{Atuin, Counts, archive_prefix, finish, open_atuin, parse_user, safe_path_under};
+
+    /// Create a valid sqlite db with no `history` table at `path`, mirroring
+    /// atuin's pre-first-run state (the file exists before migrations add tables).
+    fn make_uninitialized_db(path: &std::path::Path) {
+        rusqlite::Connection::open(path).expect("create empty sqlite db");
+    }
+
+    #[test]
+    fn uninitialized_atuin_db_is_soft_skipped_and_run_succeeds() {
+        // ENG-2141: one account whose atuin db exists but has no `history` table
+        // (atuin never ran there) must be a logged soft skip, not a failure, so
+        // the whole indexing unit still succeeds.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db = temp.path().join("history.db");
+        make_uninitialized_db(&db);
+
+        let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
+        let outcome = open_atuin("shell:tester", &db, &mut counts).expect("uninitialized db is not an error");
+
+        assert!(matches!(outcome, Atuin::Skipped), "uninitialized db must be skipped");
+        assert_eq!(counts.skipped, 1, "the skip must be tallied");
+        assert_eq!(counts.failures, 0, "an uninitialized db must not count as a failure");
+        // The run as a whole still succeeds: no failures means a zero exit.
+        assert!(finish(counts).is_ok(), "a soft-skipped source must not fail the run");
+    }
+
+    #[test]
+    fn missing_atuin_db_is_a_real_error() {
+        // A genuinely missing file (nothing to open) is a hard error so real
+        // failures are still surfaced; only the uninitialized-db case is a skip.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db = temp.path().join("does-not-exist.db");
+
+        let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
+        assert!(
+            open_atuin("shell:tester", &db, &mut counts).is_err(),
+            "a missing db file must remain a real error, not a soft skip"
+        );
+        assert_eq!(counts.skipped, 0, "a real error must not be tallied as a skip");
+    }
 
     #[test]
     fn safe_path_accepts_real_nested_dir() {

--- a/packages/source/atuin/src/error.rs
+++ b/packages/source/atuin/src/error.rs
@@ -18,6 +18,16 @@ pub enum Error {
         source: rusqlite::Error,
     },
 
+    /// The db file exists but has no `history` table: atuin has not run (or not
+    /// finished its first-run migration) for this account, so there is nothing
+    /// to index. Distinct from [`Error::Query`] so a caller can treat it as a
+    /// soft, non-fatal skip rather than a genuine read failure.
+    #[snafu(display("atuin history db {} is uninitialized (no history table)", path.display()))]
+    UninitializedDb {
+        /// Database path.
+        path: PathBuf,
+    },
+
     /// The history table could not be queried.
     #[snafu(display("failed to query atuin history"))]
     Query {
@@ -33,6 +43,17 @@ pub enum Error {
         /// Underlying limit error.
         source: source_meta::MetadataError,
     },
+}
+
+impl Error {
+    /// Whether this error is the benign "db exists but atuin never initialized
+    /// it" case ([`Error::UninitializedDb`]). The fleet indexer reads many
+    /// accounts' history; an account that has an atuin db file but no `history`
+    /// table yet (atuin has not run there) is a soft skip, not a run failure.
+    #[must_use]
+    pub const fn is_uninitialized(&self) -> bool {
+        matches!(self, Self::UninitializedDb { .. })
+    }
 }
 
 /// Result alias defaulting to this crate's [`Error`].

--- a/packages/source/atuin/src/lib.rs
+++ b/packages/source/atuin/src/lib.rs
@@ -27,7 +27,7 @@ use snafu::ResultExt as _;
 
 pub use crate::error::Error;
 pub use crate::record::Entry;
-use crate::error::{OpenDbSnafu, QuerySnafu, Result};
+use crate::error::{OpenDbSnafu, QuerySnafu, Result, UninitializedDbSnafu};
 
 /// The `source` tag every atuin command document carries. atuin records
 /// commands from every shell (nushell, zsh, bash), so one `shell` corpus covers
@@ -66,6 +66,12 @@ impl AtuinHistory {
     ///
     /// # Errors
     /// Returns an error if the database cannot be opened or queried.
+    ///
+    /// An existing db file that atuin has not yet initialized (no `history`
+    /// table — atuin creates the file before its first-run migration, or a row
+    /// has never been written) yields [`Error::UninitializedDb`] rather than a
+    /// generic query failure, so a fleet caller can skip it as a soft,
+    /// non-fatal source instead of failing the whole run.
     pub fn open(path: &Path) -> Result<Self> {
         // URI form so `immutable=1` applies; the path is the trusted db path the
         // caller resolved (no untrusted query-string injection).
@@ -75,6 +81,12 @@ impl AtuinHistory {
             OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
         )
         .context(OpenDbSnafu { path: path.to_path_buf() })?;
+        // Distinguish an uninitialized db (file present, no `history` table) from
+        // a genuine query failure. `sqlite_master` always exists, so this probe
+        // never itself trips the "no such table" path we are guarding against.
+        if !history_table_exists(&conn)? {
+            return UninitializedDbSnafu { path: path.to_path_buf() }.fail();
+        }
         let entries = read_entries(&conn)?;
         Ok(Self { entries })
     }
@@ -111,6 +123,21 @@ impl SourceAdapter for AtuinHistory {
         // independent of `&self` (mirrors the claude/codex/slack adapters).
         self.entries.clone().into_iter().map(Entry::into_document)
     }
+}
+
+/// Whether the atuin `history` table exists. atuin creates the db file before
+/// its first migration runs, so a freshly-seen account can have a db with only
+/// the sqlite header and no tables. Querying `sqlite_master` (always present)
+/// for the table lets the caller treat that as a soft skip.
+fn history_table_exists(conn: &Connection) -> Result<bool> {
+    let count: i64 = conn
+        .query_row(
+            "select count(*) from sqlite_master where type = 'table' and name = 'history'",
+            [],
+            |row| row.get(0),
+        )
+        .context(QuerySnafu)?;
+    Ok(count > 0)
 }
 
 /// Read every non-deleted, non-empty command from the atuin `history` table.

--- a/packages/source/atuin/tests/parse.rs
+++ b/packages/source/atuin/tests/parse.rs
@@ -49,6 +49,38 @@ fn skips_deleted_and_empty_commands() {
 }
 
 #[test]
+fn uninitialized_db_is_a_typed_skip() {
+    // atuin creates the db file before its first-run migration adds the
+    // `history` table, so a freshly-seen account can have a db with no tables.
+    // Opening it must yield the typed `UninitializedDb` skip (so the fleet
+    // indexer treats it as a soft, non-fatal skip), not a generic query error.
+    let path = std::env::temp_dir().join("source-atuin-test-uninit.db");
+    let _ = std::fs::remove_file(&path);
+    // Create an empty db (a connection with no schema), matching atuin's
+    // pre-migration state.
+    Connection::open(&path).expect("create empty db");
+
+    let error = AtuinHistory::open(&path).expect_err("uninitialized db must error");
+    assert!(error.is_uninitialized(), "expected UninitializedDb, got {error:?}");
+    assert!(
+        error.to_string().contains("uninitialized"),
+        "skip message should explain the db is uninitialized: {error}"
+    );
+}
+
+#[test]
+fn corrupt_db_is_not_a_skip() {
+    // A genuine failure (a file that is not a valid sqlite db) must remain a
+    // hard error so real-error reporting is preserved; only the uninitialized
+    // case is downgraded to a skip.
+    let path = std::env::temp_dir().join("source-atuin-test-corrupt.db");
+    std::fs::write(&path, b"this is not a sqlite database").expect("write garbage");
+
+    let error = AtuinHistory::open(&path).expect_err("corrupt db must error");
+    assert!(!error.is_uninitialized(), "a corrupt db must not be treated as a soft skip: {error:?}");
+}
+
+#[test]
 fn documents_carry_shell_source_and_tags() {
     let history = open_fixture("tags");
     assert_eq!(history.source(), Source::new("shell"));


### PR DESCRIPTION
## Problem (ENG-2141)

The fleet indexer (`indexer`, run as root over every account via `--user NAME:HOME`) reads each account's atuin shell history. atuin creates its sqlite db **file** before its first-run migration adds the `history` **table**, so an account that has the db file but never ran atuin (or never recorded a command) has a db with no `history` table.

Reading it failed with `reading atuin history for <user> at /home/<user>/.local/share/atuin/history.db: no such table: history`. Because one failed source makes the run bail non-zero (`finish`), a single such account produced `1 of 1 source(s) failed`, a non-zero exit, and a **degraded node** (seen on hil-stor-2, vin-stor-1).

## Fix

Treat an uninitialized db as a typed, logged **soft skip** instead of a hard failure (snafu/no-fallback discipline preserved — it is a typed decision that is logged and counted, never silently swallowed).

- **`source-atuin`**: new distinct `Error::UninitializedDb` variant + `Error::is_uninitialized()`. `AtuinHistory::open` proactively probes `sqlite_master` for the `history` table and returns the typed skip rather than a generic query error. `sqlite_master` always exists, so the probe never trips the "no such table" path it guards against.
- **`indexer`**: new `open_atuin` helper folds the uninitialized case into a warning + a `Counts::skipped` tally at **both** the local `--atuin-db` and fleet `--user` sites. `finish` gates the exit code on genuine `failures` only, so one bad source no longer fails the unit. Any other open failure (corrupt db, permissions) is still recorded as a real failure, so real-error reporting is preserved.

## Validation

All via the repo's nix toolchain (clippy = deny all/pedantic/nursery/cargo, warnings = deny):

- `nix build .#indexer` — builds.
- `.#checks.x86_64-linux.rust-source-atuin-parse-…-all` — 4 tests pass, including new `uninitialized_db_is_a_typed_skip` and `corrupt_db_is_not_a_skip`.
- `.#checks.x86_64-linux.rust-indexer-indexer-all` — 9 tests pass, including new `uninitialized_atuin_db_is_soft_skipped_and_run_succeeds` (asserts the run still succeeds) and `missing_atuin_db_is_a_real_error`.
- `rust-source-atuin-clippy`, `rust-source-atuin-package`, `rust-source-atuin-unusedCrateDependencies` — pass.
- `rust-indexer-clippy`, `rust-indexer-package`, `rust-indexer-unusedCrateDependencies` — pass.

Test log confirms the intended behavior:
```
[shell:tester] skipped: atuin history db …/history.db is uninitialized (no history table) (…/history.db)
[indexer] 1 source(s) soft-skipped (uninitialized/empty)
test tests::uninitialized_atuin_db_is_soft_skipped_and_run_succeeds ... ok
```

Fixes ENG-2141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix indexer to soft-skip uninitialized per-user atuin history databases
> - Adds a `UninitializedDb` error variant to [`packages/source/atuin/src/error.rs`](https://github.com/indexable-inc/index/pull/719/files#diff-3218b93494d39890747747cac5a2b0fff6a72426e8cc63f908a57a1345e1e8b6) and a probe in `AtuinHistory::open` that checks `sqlite_master` for the `history` table before querying, returning the typed error instead of a generic failure.
> - Introduces an `open_atuin` helper in the indexer that maps `UninitializedDb` to a soft-skip (logged, tallied separately) rather than a failure, provided an OTLP sink is configured; missing sinks or other errors still fail the run.
> - Adds a `skipped` counter to the `Counts` struct so soft-skipped sources are reported in run output without gating the exit status.
> - Behavioral Change: atuin accounts whose DB exists but has no `history` table no longer cause the indexer run to fail; they are logged and counted as skipped. If no OTLP sink is configured, the behavior is unchanged (still an error).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66466ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->