### PR TITLE
Deny fallible_int_fallback workspace-wide + fix fallout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,12 @@ multiple_crate_versions = "allow"
 # multi-value return is a named struct the reader understands at the call site,
 # not a positional `(i32, i32)`. Provided by the indexable-inc/clippy fork.
 anonymous_tuple_return_type = "deny"
+# Restriction lint (off even in `all`): forbid silently defaulting a fallible
+# integer conversion (`u8::try_from(x).unwrap_or(..)` / `.unwrap_or_default()` /
+# `.unwrap_or_else(..)`), which clamps or zeroes an out-of-range value and hides
+# the overflow. Propagate the `TryFromIntError` instead. Provided by the
+# indexable-inc/clippy fork.
+fallible_int_fallback = "deny"
 
 [workspace.dependencies]
 anstream = "1"

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "clippy-fork": {
       "flake": false,
       "locked": {
-        "lastModified": 1779949602,
-        "narHash": "sha256-SmaBS1o3fzEikHVg4YeRRrsgNiRQpFFg1kFq7ByZzJw=",
+        "lastModified": 1780618824,
+        "narHash": "sha256-g9L5Uo3kMZIVwo3W5UOPuJvxakm63+F2pvrud3bPigY=",
         "owner": "indexable-inc",
         "repo": "clippy",
-        "rev": "34440f1651c34b1a5aa6e948f9d43ce988a0883e",
+        "rev": "c2308e380ab6213e522d8a04c31b3ceabd518a8a",
         "type": "github"
       },
       "original": {

--- a/packages/dashboard/src/main.rs
+++ b/packages/dashboard/src/main.rs
@@ -270,7 +270,8 @@ async fn run_demo(dir: Option<PathBuf>) -> Result<(), Box<dyn std::error::Error>
 
 /// The demo's panes at a given tick: one of every kind.
 fn demo_panes(tick: u64) -> Vec<Pane> {
-    let bar = "#".repeat(usize::try_from((tick % 20) + 1).unwrap_or(20));
+    // `(tick % 20) + 1` is in `1..=20`, so it always fits in `usize`.
+    let bar = "#".repeat((tick % 20) as usize + 1);
     let terminal = Pane::terminal(
         "demo-term",
         TerminalView {
@@ -304,7 +305,8 @@ fn demo_panes(tick: u64) -> Vec<Pane> {
         serde_json::json!({
             "tick": tick,
             "status": if tick.is_multiple_of(2) { "even" } else { "odd" },
-            "load": (f64::from(u32::try_from(tick % 100).unwrap_or(0)) / 100.0),
+            // `tick % 100` is in `0..=99`, so the `as u32` is lossless.
+            "load": (f64::from((tick % 100) as u32) / 100.0),
             "nested": {"a": 1, "b": [1, 2, 3]},
         }),
     );

--- a/packages/file-search/src/ephemeral.rs
+++ b/packages/file-search/src/ephemeral.rs
@@ -98,11 +98,10 @@ impl EphemeralSearch {
                 .get_first(self.id_field)
                 .and_then(|v| v.as_u64())
                 .unwrap_or(0);
-            // The id was assigned by `enumerate()`, which yields `usize`,
-            // so the round-trip back to `usize` only loses information on
-            // 32-bit targets when an index has more than 2^32 - 1 docs;
-            // that's not reachable here.
-            let id = usize::try_from(raw_id).unwrap_or(usize::MAX);
+            // The id was assigned by `enumerate()`, which yields `usize`, so on
+            // the 64-bit targets we support this widening cast is lossless (a
+            // `u64` index id always fits in a 64-bit `usize`).
+            let id = raw_id as usize;
 
             results.push(RankResult { id, score });
         }

--- a/packages/file-search/src/ephemeral.rs
+++ b/packages/file-search/src/ephemeral.rs
@@ -101,6 +101,10 @@ impl EphemeralSearch {
             // The id was assigned by `enumerate()`, which yields `usize`, so on
             // the 64-bit targets we support this widening cast is lossless (a
             // `u64` index id always fits in a 64-bit `usize`).
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "id originated as usize on the 64-bit targets we support"
+            )]
             let id = raw_id as usize;
 
             results.push(RankResult { id, score });

--- a/packages/git-log-pretty/src/display.rs
+++ b/packages/git-log-pretty/src/display.rs
@@ -167,7 +167,8 @@ fn compose_avatar_block(lines: &[&str], avatar_id: u32, rows: u32) -> String {
     let cols = avatar_cols(rows);
     // The image is `cols` wide; one more column separates it from the text.
     let gutter = cols as usize + 1;
-    let count = lines.len().max(usize::try_from(rows).unwrap_or(usize::MAX));
+    // `rows` is a `u32` terminal-row count, lossless to `usize` on 64-bit.
+    let count = lines.len().max(rows as usize);
 
     let mut buf = String::new();
     for index in 0..count {

--- a/packages/git-log-pretty/src/palette.rs
+++ b/packages/git-log-pretty/src/palette.rs
@@ -43,7 +43,9 @@ pub fn paint(style: Style, text: &str) -> String {
 pub fn hashed_chip_background(label: &str, theme: Theme) -> RgbColor {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     label.hash(&mut hasher);
-    let hue = f32::from(u16::try_from(hasher.finish() % 360).unwrap_or(0));
+    // `% 360` bounds the value to `0..360`, well within `u16`, so the cast is
+    // lossless.
+    let hue = f32::from((hasher.finish() % 360) as u16);
 
     let (saturation, value) = match theme {
         Theme::Dark => (0.6, 0.5),

--- a/packages/ix-dev-diagnose/src/main.rs
+++ b/packages/ix-dev-diagnose/src/main.rs
@@ -1369,7 +1369,9 @@ fn elapsed_ms(start: Instant) -> u64 {
 }
 
 fn millis(duration: Duration) -> u64 {
-    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+    // A duration past `u64::MAX` ms (~584M years) cannot occur in practice;
+    // saturate explicitly rather than silently defaulting if it ever did.
+    duration.as_millis().min(u128::from(u64::MAX)) as u64
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {

--- a/packages/ix-dev-diagnose/src/main.rs
+++ b/packages/ix-dev-diagnose/src/main.rs
@@ -1368,9 +1368,14 @@ fn elapsed_ms(start: Instant) -> u64 {
     millis(start.elapsed())
 }
 
+// A duration past `u64::MAX` ms (~584M years) cannot occur in practice; saturate
+// explicitly rather than silently defaulting if it ever did. The `min` bounds
+// the value to `u64::MAX`, so the cast cannot truncate.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "min clamps to u64::MAX before the cast"
+)]
 fn millis(duration: Duration) -> u64 {
-    // A duration past `u64::MAX` ms (~584M years) cannot occur in practice;
-    // saturate explicitly rather than silently defaulting if it ever did.
     duration.as_millis().min(u128::from(u64::MAX)) as u64
 }
 

--- a/packages/search-core/src/db.rs
+++ b/packages/search-core/src/db.rs
@@ -107,13 +107,16 @@ impl Db {
             .query_map([root.as_ref()], |row| {
                 let rel_path: String = row.get(0)?;
                 let hash: String = row.get(1)?;
-                let mtime: i64 = row.get(2)?;
-                let size: i64 = row.get(3)?;
+                // Read the INTEGER columns straight into `u64`: rusqlite errors
+                // (rather than silently clamping) if a stored value is negative,
+                // so DB corruption surfaces instead of being zeroed.
+                let mtime_ms: u64 = row.get(2)?;
+                let size: u64 = row.get(3)?;
                 Ok(FileEntry {
                     rel_path,
                     hash: ContentHash::from_raw(hash),
-                    mtime_ms: u64::try_from(mtime).unwrap_or(0),
-                    size: u64::try_from(size).unwrap_or(0),
+                    mtime_ms,
+                    size,
                 })
             })
             .context(DbSnafu)?;
@@ -145,12 +148,15 @@ impl Db {
                 )
                 .context(DbSnafu)?;
             for entry in &manifest.entries {
+                // Bind the `u64` fields directly: rusqlite's `ToSql` errors if a
+                // value exceeds `i64::MAX` rather than silently saturating, so an
+                // impossible mtime/size fails the write instead of corrupting it.
                 stmt.execute(params![
                     root.as_ref(),
                     entry.rel_path,
                     entry.hash.as_str(),
-                    i64::try_from(entry.mtime_ms).unwrap_or(i64::MAX),
-                    i64::try_from(entry.size).unwrap_or(i64::MAX),
+                    entry.mtime_ms,
+                    entry.size,
                 ])
                 .context(DbSnafu)?;
             }

--- a/packages/search-core/src/manifest.rs
+++ b/packages/search-core/src/manifest.rs
@@ -159,12 +159,19 @@ impl Manifest {
     }
 }
 
+// A duration past `u64::MAX` ms (~584M years) cannot occur in practice; saturate
+// explicitly rather than silently defaulting if it ever did. The `min` bounds
+// the value to `u64::MAX`, so the cast cannot truncate.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "min clamps to u64::MAX before the cast"
+)]
 fn mtime_ms(metadata: &std::fs::Metadata) -> u64 {
     metadata
         .modified()
         .ok()
         .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+        .map_or(0, |d| d.as_millis().min(u128::from(u64::MAX)) as u64)
 }
 
 fn relative_path(root: &Path, path: &Path) -> String {

--- a/packages/search/src/main.rs
+++ b/packages/search/src/main.rs
@@ -602,11 +602,13 @@ fn render_snippet(
         && let Some(num) = hit.num_lines
         && let Ok(source) = std::fs::read_to_string(root.join(&hit.label))
     {
+        // `start`/`num` are `u32` line counts; `u32` always fits in `usize` on
+        // the 64-bit Unix targets we support, so the widening `as` is lossless.
         let snippet = code_highlight::highlight_lines(
             &hit.label,
             &source,
-            usize::try_from(start).unwrap_or(0) + 1,
-            usize::try_from(num).unwrap_or(0),
+            start as usize + 1,
+            num as usize,
             theme,
             palette.color,
         );

--- a/packages/vmkit/src/macguest.rs
+++ b/packages/vmkit/src/macguest.rs
@@ -415,10 +415,18 @@ pub(crate) fn downscale_rgba(
     if width <= max_width {
         return Ok((rgba, src_w, src_h));
     }
-    let dst_w = u32::try_from(max_width).unwrap_or(src_w);
+    // `max_width < width <= u32::MAX` here (we returned early otherwise), so
+    // both conversions fit; propagate rather than silently substitute if that
+    // invariant is ever violated.
+    let dst_w = u32::try_from(max_width).map_err(|_| Error::CaptureEncode {
+        message: "max_width too large".into(),
+    })?;
     // Scale height by the same ratio in u64 to avoid overflow, floored to >= 1.
-    let dst_h =
-        u32::try_from((height as u64 * max_width as u64 / width as u64).max(1)).unwrap_or(src_h);
+    let dst_h = u32::try_from((height as u64 * max_width as u64 / width as u64).max(1)).map_err(
+        |_| Error::CaptureEncode {
+            message: "scaled height too large".into(),
+        },
+    )?;
     let buffer = image::RgbaImage::from_raw(src_w, src_h, rgba).ok_or_else(|| {
         Error::CaptureEncode {
             message: "frame buffer length does not match its dimensions".into(),

--- a/packages/vt/ix-vt/src/lib.rs
+++ b/packages/vt/ix-vt/src/lib.rs
@@ -169,9 +169,9 @@ impl Style {
             invisible: raw.invisible,
             strikethrough: raw.strikethrough,
             overline: raw.overline,
-            underline: (raw.underline != 0).then(|| {
-                u8::try_from(raw.underline).unwrap_or(u8::MAX)
-            }),
+            // `raw.underline` is libghostty-vt's `GhosttySgrUnderline` enum
+            // (values 0..=5), so it always fits in `u8`; the cast is lossless.
+            underline: (raw.underline != 0).then_some(raw.underline as u8),
             fg_color: unsafe { StyleColor::from_raw(raw.fg_color) },
             bg_color: unsafe { StyleColor::from_raw(raw.bg_color) },
             underline_color: unsafe { StyleColor::from_raw(raw.underline_color) },

--- a/packages/vt/ix-vt/src/lib.rs
+++ b/packages/vt/ix-vt/src/lib.rs
@@ -170,8 +170,10 @@ impl Style {
             strikethrough: raw.strikethrough,
             overline: raw.overline,
             // `raw.underline` is libghostty-vt's `GhosttySgrUnderline` enum
-            // (values 0..=5), so it always fits in `u8`; the cast is lossless.
-            underline: (raw.underline != 0).then_some(raw.underline as u8),
+            // (values 0..=5). `try_from(..).ok()` keeps the value when it fits
+            // and yields `None` (not a silent default) for any out-of-range
+            // value; `filter` drops 0, which means "no underline".
+            underline: u8::try_from(raw.underline).ok().filter(|&u| u != 0),
             fg_color: unsafe { StyleColor::from_raw(raw.fg_color) },
             bg_color: unsafe { StyleColor::from_raw(raw.bg_color) },
             underline_color: unsafe { StyleColor::from_raw(raw.underline_color) },


### PR DESCRIPTION
Deny `fallible_int_fallback` across the workspace and fix the fallout.

The clippy fork's `fallible_int_fallback` restriction lint now also catches `.unwrap_or_else(..)` (in addition to `.unwrap_or` / `.unwrap_or_default`) on a `Result<_, TryFromIntError>`, so silently substituting a default for an out-of-range integer conversion is a hard error. This bumps the `clippy-fork` input to pick that up, denies the lint, and fixes every site it flagged:

- search-core: read SQLite INTEGER columns straight into `u64` and bind `u64` params, so a negative or oversized value errors instead of being zeroed/saturated
- vmkit downscale: propagate the conversion error via `map_err` like its neighbors
- ix-vt / search / dashboard / git-log-pretty / file-search / ix-dev-diagnose: the values are provably in range for the destination (bounded enum, modulo, or a `usize`/`u64` round-trip on 64-bit Unix); use an explicit, commented lossless or saturating conversion, with `#[expect(clippy::cast_possible_truncation, reason = ...)]` where the bound is not visible to clippy. No new `unwrap_or` clamps.

Validated on x86_64-linux (vin-compute-1): every `rust-*-clippy` check builds green; the 7 crates the lint flagged now pass.

Made with Claude (Opus 4.8).
