### PR TITLE
feat(chrome-vm): nix run demo, headless Chromium in a Linux VM on macOS

### DIFF
--- a/packages/chrome-vm-image/default.nix
+++ b/packages/chrome-vm-image/default.nix
@@ -1,0 +1,24 @@
+# Build a raw EFI-bootable aarch64 NixOS disk image for the `chrome-vm` demo.
+# The guest (./nixos.nix) screenshots a baked page with Chromium and base64s the
+# PNG over the serial console; the host runner (`packages/chrome-vm`,
+# `nix run .#chrome-vm`) boots this under vmkit/libkrun and decodes the shot.
+#
+# The image is assembled with systemd-repart (the image/repart module imported by
+# ./nixos.nix), which runs in the build sandbox with no qemu/kvm VM. So unlike
+# `make-disk-image`, this builds on a plain aarch64-linux builder with no
+# /dev/kvm, e.g. hydra's OrbStack remote builder. `path` is `pkgs.path` from the
+# package autoArgs.
+{
+  path,
+}:
+let
+  nixos = import "${path}/nixos/lib/eval-config.nix" {
+    system = "aarch64-linux";
+    modules = [ ./nixos.nix ];
+  };
+in
+# Expose the raw disk directly as the package output (the repart module produces
+# it at `${system.build.image}/${image.filePath}`).
+nixos.pkgs.runCommand "chrome-vm.raw" { } ''
+  cp "${nixos.config.system.build.image}/${nixos.config.image.filePath}" "$out"
+''

--- a/packages/chrome-vm-image/nixos.nix
+++ b/packages/chrome-vm-image/nixos.nix
@@ -59,7 +59,14 @@ in
   # We place the bootloader + UKI manually via repart, so disable grub.
   boot = {
     loader.grub.enable = false;
-    kernelParams = [ "console=hvc0" ];
+    # `loglevel=0` keeps kernel printk OFF the console (hvc0): the screenshot
+    # comes back as one long base64 line on this same console, and a stray printk
+    # mid-line (its `[ 1.234] ...` text survives a whitespace strip) would corrupt
+    # the decode. Userspace writes (the markers + base64) are unaffected.
+    kernelParams = [
+      "console=hvc0"
+      "loglevel=0"
+    ];
     initrd.availableKernelModules = [
       "virtio_pci"
       "virtio_blk"
@@ -146,6 +153,9 @@ in
         # (its prefix alphanumerics survive any non-base64 strip). /dev/console
         # is hvc0 (console=hvc0), captured raw by vmkit's --console-file.
         exec >/dev/console 2>&1
+        # Belt-and-suspenders with loglevel=0: drop the console printk level to 1
+        # (emergency only) so no late kernel message can land inside the base64.
+        echo 1 >/proc/sys/kernel/printk || true
         export HOME=/tmp
         mkdir -p /tmp/cr
         echo "===VMKIT-CHROME-DEMO==="

--- a/packages/chrome-vm-image/nixos.nix
+++ b/packages/chrome-vm-image/nixos.nix
@@ -1,0 +1,182 @@
+# aarch64 NixOS guest for the `chrome-vm` demo: boots headless, runs Chromium
+# against a baked proof page, base64s the screenshot over the serial console
+# (hvc0, which vmkit captures), then powers off. The host side
+# (packages/chrome-vm) decodes the base64 between the markers into a PNG.
+#
+# The disk is assembled with **systemd-repart** (via the image/repart module),
+# NOT `make-disk-image`: repart runs in the build sandbox with no qemu/kvm VM, so
+# the image builds on a plain aarch64-linux builder (e.g. hydra's OrbStack remote
+# builder, which has no /dev/kvm). libkrun-efi boots OVMF -> systemd-boot (at the
+# EFI removable path) -> the UKI in /EFI/Linux. Modelled on nixpkgs'
+# nixos/tests/appliance-repart-image.nix.
+{
+  lib,
+  pkgs,
+  config,
+  modulesPath,
+  ...
+}:
+let
+  # A page that proves a real browser + real JS ran in the guest: it prints the
+  # Chromium user-agent, a fresh timestamp, and draws a canvas gradient (all via
+  # JS at render time), so a blank/placeholder capture is obvious.
+  demoPage = pkgs.writeText "chrome-vm-demo.html" ''
+    <!doctype html><html><head><meta charset="utf-8"><style>
+      body{margin:0;font-family:system-ui,-apple-system,sans-serif;
+        background:linear-gradient(135deg,#1a1a2e,#16213e);color:#eee;height:100vh;
+        display:flex;align-items:center;justify-content:center}
+      .card{background:#0f3460;padding:48px 56px;border-radius:18px;
+        box-shadow:0 24px 70px rgba(0,0,0,.55);max-width:780px}
+      h1{margin:0 0 14px;font-size:34px}
+      p{font-size:18px;line-height:1.5;margin:8px 0}
+      .k{color:#e94560;font-weight:700}
+      code{background:#000;padding:2px 7px;border-radius:5px;font-size:15px}
+    </style></head><body><div class="card">
+      <h1>👋 Hello from inside a Linux VM</h1>
+      <p>Rendered by <span class="k">headless Chromium</span> in a
+         <span class="k">libkrun</span> Linux guest, booted by
+         <code>vmkit</code> on a macOS host.</p>
+      <p>UA: <code id="ua"></code></p>
+      <p>Rendered at: <code id="t"></code></p>
+      <canvas id="c" width="700" height="84"></canvas>
+      <script>
+        document.getElementById('ua').textContent = navigator.userAgent;
+        document.getElementById('t').textContent = new Date().toISOString();
+        var x = document.getElementById('c').getContext('2d');
+        var g = x.createLinearGradient(0, 0, 700, 0);
+        g.addColorStop(0, '#e94560'); g.addColorStop(1, '#53a8b6');
+        x.fillStyle = g; x.fillRect(0, 0, 700, 84);
+        x.fillStyle = '#fff'; x.font = '26px system-ui, sans-serif';
+        x.fillText('this strip was drawn by JS in the guest', 22, 52);
+      </script>
+    </div></body></html>
+  '';
+in
+{
+  imports = [ "${modulesPath}/image/repart.nix" ];
+
+  # Boot path: OVMF (libkrun-efi) -> systemd-boot (EFI removable path) -> UKI.
+  # We place the bootloader + UKI manually via repart, so disable grub.
+  boot = {
+    loader.grub.enable = false;
+    kernelParams = [ "console=hvc0" ];
+    initrd.availableKernelModules = [
+      "virtio_pci"
+      "virtio_blk"
+      "virtio_console"
+      "sd_mod"
+    ];
+  };
+
+  # Root is the repart "root"-typed partition, found by its GPT partition label.
+  fileSystems."/" = {
+    device = "/dev/disk/by-partlabel/root";
+    fsType = "ext4";
+  };
+
+  system.image = {
+    id = "chrome-vm";
+    version = "1";
+  };
+
+  image.repart = {
+    name = "chrome-vm";
+    # OVMF does not work with repart's default 4096-byte sector size.
+    sectorSize = 512;
+    partitions = {
+      "esp" = {
+        contents =
+          let
+            # aarch64-only image (see package.nix), so the EFI arch is fixed.
+            # Avoids depending on `config.nixpkgs.hostPlatform` (unset under
+            # eval-config with a bare `system`).
+            efiArch = "aa64";
+          in
+          {
+            "/EFI/BOOT/BOOT${lib.toUpper efiArch}.EFI".source =
+              "${pkgs.systemd}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi";
+            "/EFI/Linux/${config.system.boot.loader.ukiFile}".source =
+              "${config.system.build.uki}/${config.system.boot.loader.ukiFile}";
+            # Auto-boot the single UKI with no menu/delay.
+            "/loader/loader.conf".source = pkgs.writeText "loader.conf" "timeout 0\n";
+          };
+        repartConfig = {
+          Type = "esp";
+          Format = "vfat";
+          # Roomy for the UKI (kernel + initrd) on aarch64.
+          SizeMinBytes = "256M";
+        };
+      };
+      "root" = {
+        storePaths = [ config.system.build.toplevel ];
+        repartConfig = {
+          Type = "root";
+          Format = "ext4";
+          Label = "root";
+          Minimize = "guess";
+        };
+      };
+    };
+  };
+
+  systemd.services = {
+    # The demo: one oneshot that runs at the end of boot, captures, powers off.
+    chrome-shot = {
+      description = "Headless Chromium screenshot demo (vmkit chrome-vm)";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        # Mirror stdout/stderr to the serial console so the host's --console-file
+        # capture sees the markers + base64.
+        StandardOutput = "journal+console";
+        StandardError = "journal+console";
+        TimeoutStartSec = 90;
+      };
+      path = [
+        pkgs.chromium
+        pkgs.coreutils
+        pkgs.systemd
+      ];
+      script = ''
+        set -u
+        # Write straight to the serial console, bypassing systemd's
+        # StandardOutput connector: journal+console prefixes every line with
+        # "[ts] chrome-shot[pid]: " and wraps it, which would corrupt the base64
+        # (its prefix alphanumerics survive any non-base64 strip). /dev/console
+        # is hvc0 (console=hvc0), captured raw by vmkit's --console-file.
+        exec >/dev/console 2>&1
+        export HOME=/tmp
+        mkdir -p /tmp/cr
+        echo "===VMKIT-CHROME-DEMO==="
+        uname -srm
+        chromium --version || true
+        # `--virtual-time-budget` lets the page's JS (UA/timestamp/canvas) run
+        # before the shot; software raster (no GPU) is fine for a screenshot.
+        chromium --headless=new --no-sandbox --disable-gpu --hide-scrollbars \
+          --user-data-dir=/tmp/cr --window-size=1280,800 \
+          --virtual-time-budget=2500 \
+          --screenshot=/tmp/shot.png \
+          "file://${demoPage}" || echo "CHROMIUM-EXIT=$?"
+        if [ -s /tmp/shot.png ]; then
+          echo "===VMKIT-SHOT-BEGIN==="
+          base64 -w0 /tmp/shot.png
+          echo
+          echo "===VMKIT-SHOT-END==="
+        else
+          echo "===VMKIT-NO-SHOT==="
+        fi
+        # End the VM; vmkit returns when the guest powers off.
+        systemctl poweroff --no-block || poweroff -f || true
+      '';
+    };
+
+    # Don't block boot waiting for a network that the demo never uses.
+    NetworkManager-wait-online.enable = lib.mkDefault false;
+  };
+
+  # Trim the image: no docs, no GUI, no DHCP wait (the demo is offline).
+  documentation.enable = lib.mkDefault false;
+  networking.useDHCP = lib.mkDefault false;
+  system.stateVersion = "24.11";
+}

--- a/packages/chrome-vm-image/package.nix
+++ b/packages/chrome-vm-image/package.nix
@@ -1,0 +1,9 @@
+{
+  id = "chrome-vm-image";
+  # aarch64-linux only: the raw EFI disk the `chrome-vm` demo boots under
+  # vmkit/libkrun on Apple Silicon. Gate the flake output + package-set attr to
+  # that system so `nix flake check` never forces it elsewhere. On hydra it builds
+  # via the OrbStack aarch64-linux remote builder.
+  flake.systems = [ "aarch64-linux" ];
+  packageSet.systems = [ "aarch64-linux" ];
+}

--- a/packages/chrome-vm/README.md
+++ b/packages/chrome-vm/README.md
@@ -1,0 +1,45 @@
+# chrome-vm
+
+Run headless Chromium inside a real Linux VM on a macOS host and get the
+screenshot back, in one command:
+
+```sh
+nix run github:indexable-inc/index#chrome-vm
+# or, from a checkout: nix run .#chrome-vm [out.png]
+```
+
+It boots an aarch64 Linux guest under [`vmkit`](../vmkit)/libkrun (Hypervisor.framework),
+runs `chromium --headless` against a baked proof page, and opens the PNG the guest
+captured. The page prints the live Chromium user-agent, a fresh timestamp, and a
+canvas gradient drawn by JS, so the screenshot is proof that a real browser ran
+real JS in the guest, not a placeholder.
+
+Self-contained: the guest needs no network, no GPU, and no host directory
+sharing. The screenshot travels back as base64 over the guest's serial console,
+which `vmkit --console-file` captures and the runner decodes.
+
+## How it works
+
+- **Guest** ([`../chrome-vm-image`](../chrome-vm-image)): an aarch64 NixOS image
+  whose only job is a boot-time oneshot that screenshots the page with headless
+  Chromium (software raster, no GPU), writes the PNG as `base64` straight to
+  `/dev/console` between `===VMKIT-SHOT-BEGIN===`/`===VMKIT-SHOT-END===` markers,
+  then powers off. Writing to `/dev/console` bypasses systemd's per-line console
+  prefixing, which would otherwise corrupt the base64.
+- **Disk**: assembled with `systemd-repart` (not `make-disk-image`), so it builds
+  in the Nix sandbox with no qemu/kvm VM. libkrun-efi boots OVMF -> systemd-boot
+  (at the EFI removable path) -> a UKI. `sectorSize = 512` is required (OVMF does
+  not handle repart's 4096 default).
+- **Runner** (this package): a macOS nushell app that builds the guest image,
+  boots it with `vmkit boot-linux`, decodes the screenshot, and `open`s it.
+
+## Requirements and limits
+
+- Host is `aarch64-darwin` (Apple Silicon); `vmkit`'s Linux-guest path is
+  libkrun-efi there.
+- Building the guest image needs an **aarch64-linux builder**. hydra has none
+  natively, so it offloads to the local OrbStack remote builder (see
+  `~/.config/nix` `hosts/hydra`). The first run also fetches Chromium's closure
+  (~1.5 GiB), so it is slow once, then cached.
+- Override the image source flake for local testing:
+  `IX_CHROME_VM_FLAKE=/path/to/checkout nix run .#chrome-vm`.

--- a/packages/chrome-vm/default.nix
+++ b/packages/chrome-vm/default.nix
@@ -53,26 +53,37 @@ writeNushellApplication {
       let log = $"($work)/console.log"
       print "chrome-vm: booting the Linux guest under vmkit (libkrun-efi)..."
       # The guest screenshots on boot, prints the PNG as base64 over the console,
-      # then powers off (vmkit returns); the timeout is a backstop.
+      # then powers off. vmkit's watchdog exit()s 0 on both a clean poweroff and a
+      # timeout, so a nonzero exit here is a real pre-boot libkrun error; swallow
+      # it so the diagnostics + cleanup below still run (the PNG check catches it).
       try {
         ^vmkit boot-linux --disk $disk --console-file $log --memory-mib 2048 --cpus 4 --timeout-secs 150
       }
 
-      # Decode the screenshot the guest base64'd between the console markers. Done
-      # in bash with positional args so paths/escapes need no nu<->sh quoting; the
-      # guest emits one `base64 -w0` line, so base64 ignores the trailing newline.
-      ^bash -c 'awk "/===VMKIT-SHOT-BEGIN===/{f=1;next} /===VMKIT-SHOT-END===/{f=0} f" "$1" | tr -d "[:space:]" | base64 -d > "$2"' bash $log $outpath
+      # Decode the screenshot the guest base64'd between the console markers (one
+      # `base64 -w0` line). bash positional args avoid nu<->sh quoting. Swallow a
+      # decode error so the diagnostics below run instead of a bare nu abort.
+      try {
+        ^bash -c 'awk "/===VMKIT-SHOT-BEGIN===/{f=1;next} /===VMKIT-SHOT-END===/{f=0} f" "$1" | tr -d "[:space:]" | base64 -d > "$2"' bash $log $outpath
+      }
 
-      let ok = (($outpath | path exists) and ((ls $outpath | get size | first) > 0b))
+      # Success only on a real PNG (guards against a truncated/partial decode).
+      let ok = if ($outpath | path exists) {
+        (open --raw $outpath | first 8) == 0x[89 50 4E 47 0D 0A 1A 0A]
+      } else {
+        false
+      }
       if $ok {
         print ""
         print "chrome-vm: Chromium rendered + screenshotted inside the Linux guest:"
         ^grep -m1 -A4 VMKIT-CHROME-DEMO $log | lines | each {|l| print $"  | ($l)" }
         print $"  -> ($outpath)"
+        ^rm -rf $work
         try { ^open $outpath }
       } else {
-        print -e "chrome-vm: no screenshot captured. last console lines:"
+        print -e "chrome-vm: no valid screenshot captured. last console lines:"
         ^tail -n 40 $log
+        ^rm -rf $work
         exit 1
       }
     }

--- a/packages/chrome-vm/default.nix
+++ b/packages/chrome-vm/default.nix
@@ -1,0 +1,80 @@
+# `nix run .#chrome-vm`: boot a Linux guest under vmkit/libkrun on the macOS host,
+# run headless Chromium inside it against a baked proof page, and open the
+# screenshot the guest captured. Self-contained: the guest needs no network, no
+# GPU, and no host sharing; the screenshot comes back base64 over the serial
+# console (see ../chrome-vm-image/nixos.nix).
+#
+# The aarch64-linux guest image is built at run time (`nix build` of
+# `chrome-vm-image`), which offloads to a linux builder; on hydra that is the
+# local OrbStack remote builder. Override the source flake for local testing with
+# `IX_CHROME_VM_FLAKE=/path/to/checkout nix run .#chrome-vm`.
+{
+  writeNushellApplication,
+  ix,
+  bash,
+  gawk,
+  coreutils,
+  gnugrep,
+}:
+let
+  # The aarch64-darwin vmkit binary (self-signs + re-execs at runtime). Repo
+  # crates aren't overlaid into `pkgs`, so reach it through the workspace units
+  # the same way packages/mcp does.
+  vmkit = ix.rustWorkspace.units.binaries."vmkit";
+in
+writeNushellApplication {
+  name = "chrome-vm";
+  runtimeInputs = [
+    vmkit
+    bash
+    gawk
+    coreutils
+    gnugrep
+  ];
+  text = ''
+    def main [out?: string] {
+      let flake = ($env.IX_CHROME_VM_FLAKE? | default "github:indexable-inc/index")
+      let outpath = ($out | default $"($env.PWD)/chrome-vm-shot.png")
+      let work = (^mktemp -d | str trim)
+
+      print $"chrome-vm: building the aarch64 Linux guest image from ($flake)"
+      print "  (first run fetches Chromium's closure; the build offloads to a linux builder)"
+      let raw = (
+        ^nix build $"($flake)#packages.aarch64-linux.chrome-vm-image"
+          --no-link --print-out-paths --accept-flake-config
+        | str trim
+      )
+
+      # libkrun needs a writable disk; the Nix store image is read-only.
+      let disk = $"($work)/disk.raw"
+      ^cp $raw $disk
+      ^chmod u+w $disk
+
+      let log = $"($work)/console.log"
+      print "chrome-vm: booting the Linux guest under vmkit (libkrun-efi)..."
+      # The guest screenshots on boot, prints the PNG as base64 over the console,
+      # then powers off (vmkit returns); the timeout is a backstop.
+      try {
+        ^vmkit boot-linux --disk $disk --console-file $log --memory-mib 2048 --cpus 4 --timeout-secs 150
+      }
+
+      # Decode the screenshot the guest base64'd between the console markers. Done
+      # in bash with positional args so paths/escapes need no nu<->sh quoting; the
+      # guest emits one `base64 -w0` line, so base64 ignores the trailing newline.
+      ^bash -c 'awk "/===VMKIT-SHOT-BEGIN===/{f=1;next} /===VMKIT-SHOT-END===/{f=0} f" "$1" | tr -d "[:space:]" | base64 -d > "$2"' bash $log $outpath
+
+      let ok = (($outpath | path exists) and ((ls $outpath | get size | first) > 0b))
+      if $ok {
+        print ""
+        print "chrome-vm: Chromium rendered + screenshotted inside the Linux guest:"
+        ^grep -m1 -A4 VMKIT-CHROME-DEMO $log | lines | each {|l| print $"  | ($l)" }
+        print $"  -> ($outpath)"
+        try { ^open $outpath }
+      } else {
+        print -e "chrome-vm: no screenshot captured. last console lines:"
+        ^tail -n 40 $log
+        exit 1
+      }
+    }
+  '';
+}

--- a/packages/chrome-vm/package.nix
+++ b/packages/chrome-vm/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "chrome-vm";
+  # macOS host runner (aarch64-darwin): boots the aarch64-linux `chrome-vm-image`
+  # guest under vmkit/libkrun and opens the screenshot Chromium took inside it.
+  flake.systems = [ "aarch64-darwin" ];
+  packageSet.systems = [ "aarch64-darwin" ];
+}


### PR DESCRIPTION
`nix run .#chrome-vm` boots an aarch64 Linux guest under vmkit/libkrun-efi on the macOS host, runs headless Chromium against a baked proof page, and opens the screenshot the guest captured.

The proof page prints the live Chromium UA, a fresh JS timestamp, and a canvas gradient, so the screenshot proves a real browser ran real JS in the guest. The shot travels back as base64 over the serial console (no network, no GPU, no host sharing).

Notable: the disk is built with `systemd-repart` (not `make-disk-image`), so it assembles in the Nix sandbox with **no kvm/qemu VM** and builds on a plain aarch64-linux builder (hydra offloads to the OrbStack remote builder). libkrun-efi boots OVMF -> systemd-boot -> a UKI; `sectorSize = 512` is required for OVMF.

Validated e2e on aarch64-darwin: real 1280x800 PNG of Chromium 148 rendering inside the guest (Linux 6.18 aarch64). Lint clean.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add headless Chromium screenshot demo runnable via `nix run .#chrome-vm` on macOS
> - Adds [chrome-vm](https://github.com/indexable-inc/index/pull/723/files#diff-86f62eabe792282046209f90a1cde2d4ccac7ffc1d18f4e1777d3adc858c431c), a Nushell CLI (aarch64-darwin only) that builds a NixOS guest image, boots it under vmkit/libkrun-efi, and extracts a base64-encoded PNG screenshot from the serial console output.
> - Adds [chrome-vm-image](https://github.com/indexable-inc/index/pull/723/files#diff-efb6f843f7189e08695444d025d2cdce1b190aa1fa875f6e823e560e8415a700), a NixOS configuration (aarch64-linux only) that boots headless Chromium against a baked-in HTML page, emits the screenshot between `===VMKIT-SHOT-BEGIN===`/`===VMKIT-SHOT-END===` markers on the virtio console, then powers off.
> - The guest disk is assembled via `systemd-repart` with a 512-byte sector size, an ESP containing systemd-boot and a UKI, and an ext4 root partition.
> - The runner copies the read-only image to a writable temp file, boots it with 2 GiB RAM and 4 CPUs (150s timeout), decodes the screenshot, and opens the resulting PNG at `./chrome-vm-shot.png`.
> - Risk: vmkit non-zero exit codes are swallowed; success is determined solely by PNG magic-byte validation of the decoded output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bedeba5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->