### PR TITLE
fix(tests): expect the S3 archive on the observability-stack logs pipeline

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2191,8 +2191,8 @@ let
             == "otel_traces"
           &&
             observabilityStackExample.observability.collector.service.pipelines.logs.exporters
-            == [ "clickhouse" ];
-        message = "observability-stack collector should receive OTLP and export logs/traces/metrics to ClickHouse";
+            == [ "clickhouse" "awss3" ];
+        message = "observability-stack collector should receive OTLP, export to ClickHouse, and mirror logs to the S3 archive";
       }
       {
         assertion =

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2190,8 +2190,10 @@ let
             observabilityStackExample.observability.collector.exporters.clickhouse.traces_table_name
             == "otel_traces"
           &&
-            observabilityStackExample.observability.collector.service.pipelines.logs.exporters
-            == [ "clickhouse" "awss3" ];
+            observabilityStackExample.observability.collector.service.pipelines.logs.exporters == [
+              "clickhouse"
+              "awss3"
+            ];
         message = "observability-stack collector should receive OTLP, export to ClickHouse, and mirror logs to the S3 archive";
       }
       {


### PR DESCRIPTION
## What

Updates the `observability-stack` eval assertion to expect `logs.exporters == ["clickhouse" "awss3"]`.

## Why

`main` is red: `.#checks.x86_64-linux.eval` fails with exactly one failure (999 ok, 1 fail) — `ix-test-observability-stack: observability-stack collector should receive OTLP and export logs/traces/metrics to ClickHouse`. This blocks every index PR (e.g. #719) and the downstream `inputs.index` bump.

Root cause: the example node enables the S3 archive leg —

```nix
# examples/observability-stack/default.nix
collector.archive = { enable = true; endpoint = "http://127.0.0.1:9010"; };  # "Exercise the RFC 0004 bus archive leg"
```

so the module correctly mirrors the logs pipeline to `awss3` alongside `clickhouse` (`modules/services/observability/default.nix:582`, `exporters = exporterNames ++ lib.optional archiveEnabled "awss3"`). The test assertion still expected `["clickhouse"]`, so it was stale relative to the intended archive behavior. Traces/metrics correctly stay on clickhouse-only, so only the logs assertion needed updating.

## Validation

- Confirmed `archiveEnabled = true` for the example's observability node and that `exporterNames == ["clickhouse"]` (forward disabled, stack enabled), so `logs.exporters == ["clickhouse" "awss3"]`.
- Local `nix build .#checks.x86_64-linux.eval` in progress as the authoritative gate; auto-merge enabled only once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `observabilityStackExample` test to expect `awss3` exporter in logs pipeline
> Updates the assertion in [tests/default.nix](https://github.com/indexable-inc/index/pull/725/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) to expect both `"clickhouse"` and `"awss3"` in `collector.service.pipelines.logs.exporters`, reflecting that logs are mirrored to the S3 archive in addition to ClickHouse.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fe2129.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

Closes ENG-2174
