### PR TITLE
chore(sdk): license the public SDK as proprietary (supersede repo MIT)

### DIFF
--- a/sdk/LICENSE
+++ b/sdk/LICENSE
@@ -1,0 +1,17 @@
+Indexable SDK License
+
+Copyright (c) 2026 Indexable Inc. All rights reserved.
+
+This license governs all files in this directory ("sdk/") and its subdirectories, together with any compiled or binary components they fetch, download, link, or bundle (collectively, the "SDK"), including the precompiled ix-sdk libraries distributed by Indexable. For these files this license SUPERSEDES the MIT License at the root of this repository; the root MIT License does not apply to the SDK.
+
+1. License grant. Subject to your compliance with this license and the Indexable Terms of Service, Indexable Inc. grants you a limited, non-exclusive, non-transferable, non-sublicensable, revocable license to install and use the SDK solely to develop and operate your own applications that access Indexable's hosted "ix" service.
+
+2. Restrictions. You may not, and may not permit any third party to: (a) reverse engineer, decompile, disassemble, or otherwise attempt to derive the source code, underlying ideas, or algorithms of any compiled or binary component of the SDK, except to the limited extent applicable law expressly prohibits this restriction; (b) modify, adapt, translate, or create derivative works of the SDK; (c) copy, redistribute, sublicense, sell, rent, lease, or lend the SDK, except as strictly necessary to deploy your own applications that use the ix service; (d) use the SDK, or any information derived from it, to develop, train, or operate any product or service that competes with the ix service; or (e) remove, obscure, or alter any proprietary or attribution notices in the SDK.
+
+3. Ownership. The SDK is licensed, not sold. Indexable Inc. and its licensors retain all right, title, and interest in and to the SDK, including all intellectual property rights therein.
+
+4. Termination. This license terminates automatically upon any breach. On termination you must cease all use of and delete the SDK.
+
+5. No warranty; limitation of liability. THE SDK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. TO THE MAXIMUM EXTENT PERMITTED BY LAW, INDEXABLE INC. DISCLAIMS ALL WARRANTIES AND SHALL NOT BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY ARISING FROM OR IN CONNECTION WITH THE SDK OR ITS USE.
+
+For licensing inquiries, contact Indexable Inc.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,14 @@
+# ix SDK
+
+Public source for the ix SDKs (Rust, Python, TypeScript). Each links or bundles
+the precompiled, proprietary `ix-sdk` libraries distributed by Indexable.
+
+## License
+
+Everything under `sdk/` is proprietary and source-available, governed by
+[`sdk/LICENSE`](./LICENSE) (the Indexable SDK License), NOT the repository-root
+MIT license. The SDK license supersedes the root MIT for this directory and its
+subdirectories, including the compiled components the SDK fetches or bundles. In
+short: you may use the SDK to build applications that access the hosted ix
+service, but you may not reverse-engineer, modify, redistribute, or use it to
+build a competing service. See `sdk/LICENSE` for the full terms.

--- a/sdk/python/LICENSE
+++ b/sdk/python/LICENSE
@@ -1,0 +1,17 @@
+Indexable SDK License
+
+Copyright (c) 2026 Indexable Inc. All rights reserved.
+
+This license governs all files in this directory ("sdk/") and its subdirectories, together with any compiled or binary components they fetch, download, link, or bundle (collectively, the "SDK"), including the precompiled ix-sdk libraries distributed by Indexable. For these files this license SUPERSEDES the MIT License at the root of this repository; the root MIT License does not apply to the SDK.
+
+1. License grant. Subject to your compliance with this license and the Indexable Terms of Service, Indexable Inc. grants you a limited, non-exclusive, non-transferable, non-sublicensable, revocable license to install and use the SDK solely to develop and operate your own applications that access Indexable's hosted "ix" service.
+
+2. Restrictions. You may not, and may not permit any third party to: (a) reverse engineer, decompile, disassemble, or otherwise attempt to derive the source code, underlying ideas, or algorithms of any compiled or binary component of the SDK, except to the limited extent applicable law expressly prohibits this restriction; (b) modify, adapt, translate, or create derivative works of the SDK; (c) copy, redistribute, sublicense, sell, rent, lease, or lend the SDK, except as strictly necessary to deploy your own applications that use the ix service; (d) use the SDK, or any information derived from it, to develop, train, or operate any product or service that competes with the ix service; or (e) remove, obscure, or alter any proprietary or attribution notices in the SDK.
+
+3. Ownership. The SDK is licensed, not sold. Indexable Inc. and its licensors retain all right, title, and interest in and to the SDK, including all intellectual property rights therein.
+
+4. Termination. This license terminates automatically upon any breach. On termination you must cease all use of and delete the SDK.
+
+5. No warranty; limitation of liability. THE SDK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. TO THE MAXIMUM EXTENT PERMITTED BY LAW, INDEXABLE INC. DISCLAIMS ALL WARRANTIES AND SHALL NOT BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY ARISING FROM OR IN CONNECTION WITH THE SDK OR ITS USE.
+
+For licensing inquiries, contact Indexable Inc.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,29 @@
+# Public Python SDK for ix.
+#
+# Proprietary, source-available: governed by the Indexable SDK License shipped
+# alongside this file (sdk/python/LICENSE, a copy of sdk/LICENSE), which
+# supersedes the repo-root MIT for everything under sdk/. The project metadata
+# below points at that LICENSE and carries the Proprietary classifier so PyPI
+# and packaging tooling surface the real terms, never a permissive identifier.
+[project]
+name = "ix-sdk"
+version = "0.1.0"
+description = "Public Python SDK for ix; wraps the precompiled, proprietary ix-sdk native extension"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+classifiers = [
+  "License :: Other/Proprietary License",
+  "Programming Language :: Python :: 3",
+  "Operating System :: POSIX :: Linux",
+  "Operating System :: MacOS",
+]
+
+[tool.setuptools.packages.find]
+include = ["ix_sdk*"]
+
+[tool.setuptools.package-data]
+ix_sdk = ["py.typed", "*.pyi"]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"

--- a/sdk/rust/crates/ix-sdk/Cargo.toml
+++ b/sdk/rust/crates/ix-sdk/Cargo.toml
@@ -2,7 +2,11 @@
 name = "ix-sdk"
 version = "0.1.0"
 edition = "2024"
-license = "LicenseRef-Proprietary"
+# Proprietary, source-available: governed by sdk/LICENSE (the Indexable SDK
+# License), which supersedes the repo-root MIT for everything under sdk/. Use a
+# license-file rather than an SPDX `license` so `cargo metadata` and crawlers
+# surface the real proprietary terms, not a permissive identifier.
+license-file = "../../../LICENSE"
 description = "Public Rust SDK for ix; links the prebuilt ix-sdk-wire rlib fetched from R2"
 publish = false
 

--- a/sdk/rust/vendor/ix-sdk-wire/Cargo.toml
+++ b/sdk/rust/vendor/ix-sdk-wire/Cargo.toml
@@ -24,7 +24,13 @@
 name = "ix-sdk-wire"
 version = "0.1.0"
 edition = "2024"
-license = "LicenseRef-Proprietary"
+# Proprietary, source-available: governed by sdk/LICENSE (the Indexable SDK
+# License), which supersedes the repo-root MIT for everything under sdk/. The
+# `license`/`license-file` field is NOT folded into the cargo-unit identity hash
+# (only name+version, edition, crate-types, features, profile, lints, deps,
+# toolchain are; see packages/nix-cargo-unit/src/model.rs:write_unit_identity),
+# so this change does not perturb the stub's generated unit key.
+license-file = "../../../LICENSE"
 description = "Self-contained wire types crossing the ix SDK C-ABI boundary (no private ix deps)"
 publish = false
 

--- a/sdk/typescript/LICENSE
+++ b/sdk/typescript/LICENSE
@@ -1,0 +1,17 @@
+Indexable SDK License
+
+Copyright (c) 2026 Indexable Inc. All rights reserved.
+
+This license governs all files in this directory ("sdk/") and its subdirectories, together with any compiled or binary components they fetch, download, link, or bundle (collectively, the "SDK"), including the precompiled ix-sdk libraries distributed by Indexable. For these files this license SUPERSEDES the MIT License at the root of this repository; the root MIT License does not apply to the SDK.
+
+1. License grant. Subject to your compliance with this license and the Indexable Terms of Service, Indexable Inc. grants you a limited, non-exclusive, non-transferable, non-sublicensable, revocable license to install and use the SDK solely to develop and operate your own applications that access Indexable's hosted "ix" service.
+
+2. Restrictions. You may not, and may not permit any third party to: (a) reverse engineer, decompile, disassemble, or otherwise attempt to derive the source code, underlying ideas, or algorithms of any compiled or binary component of the SDK, except to the limited extent applicable law expressly prohibits this restriction; (b) modify, adapt, translate, or create derivative works of the SDK; (c) copy, redistribute, sublicense, sell, rent, lease, or lend the SDK, except as strictly necessary to deploy your own applications that use the ix service; (d) use the SDK, or any information derived from it, to develop, train, or operate any product or service that competes with the ix service; or (e) remove, obscure, or alter any proprietary or attribution notices in the SDK.
+
+3. Ownership. The SDK is licensed, not sold. Indexable Inc. and its licensors retain all right, title, and interest in and to the SDK, including all intellectual property rights therein.
+
+4. Termination. This license terminates automatically upon any breach. On termination you must cease all use of and delete the SDK.
+
+5. No warranty; limitation of liability. THE SDK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. TO THE MAXIMUM EXTENT PERMITTED BY LAW, INDEXABLE INC. DISCLAIMS ALL WARRANTIES AND SHALL NOT BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY ARISING FROM OR IN CONNECTION WITH THE SDK OR ITS USE.
+
+For licensing inquiries, contact Indexable Inc.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -38,3 +38,9 @@ console.log(result.stdout)
 The TypeScript layer is intentionally thin. Core behavior lives in the Rust SDK;
 this package adds TypeScript-native surface area such as `await using`,
 async iterators, overloads, and typed options.
+
+## License
+
+Proprietary and source-available, governed by the bundled `LICENSE` (the
+Indexable SDK License), NOT the repository-root MIT license. See
+[`../LICENSE`](../LICENSE).

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@indexable/sdk",
   "version": "0.3.0",
+  "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
@@ -12,7 +13,8 @@
   "files": [
     "src",
     "native",
-    "dist"
+    "dist",
+    "LICENSE"
   ],
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
The repo-root `LICENSE` is MIT, which until now licensed both the public SDK source under `sdk/` and the proprietary compiled `ix-sdk` libraries it fetches from R2 under MIT. That permitted reverse-engineering, modification, redistribution, and competing use of the SDK and the precompiled artifacts. This makes the SDK proprietary and source-available instead.

What changed:
- New `sdk/LICENSE` (the Indexable SDK License): proprietary, source-available. No reverse-engineering, no modification, no redistribution, no use to build a competing service; use is limited to building apps that access the hosted ix service. A supersedes-clause overrides the repo-root MIT for everything under `sdk/` and for the compiled components the SDK fetches or bundles. The root MIT is untouched and still governs the rest of the repo.
- Wired the license into every SDK package's metadata so tooling reports proprietary, not MIT:
  - `sdk/rust/crates/ix-sdk/Cargo.toml`: `license-file = "../../../LICENSE"`, `publish = false`.
  - `sdk/rust/vendor/ix-sdk-wire/Cargo.toml`: same `license-file`. The `license`/`license-file` field is NOT part of the cargo-unit identity hash (only name+version, edition, crate-types, features, profile, lints, deps, toolchain are; `packages/nix-cargo-unit/src/model.rs:write_unit_identity`), so the R2 rlib injection is unaffected, proven by the `sdk-rust-prebuilt` check.
  - `sdk/python/pyproject.toml` (new): `license = { file = "LICENSE" }` + classifier `License :: Other/Proprietary License`; ships `sdk/python/LICENSE` (a copy of `sdk/LICENSE`) in the wheel.
  - `sdk/typescript/package.json`: `"license": "SEE LICENSE IN LICENSE"` and `LICENSE` added to `files`; ships `sdk/typescript/LICENSE` (a copy) in the npm tarball.
- `sdk/README.md` (new) and `sdk/typescript/README.md` state the SDK is governed by `sdk/LICENSE` (proprietary), separate from the repo MIT.

Validation:
- `nix build .#checks.x86_64-linux.lint` green on vin-compute-1 (nixfmt, statix, deadnix, ast-grep, ast-grep-test all pass).
- `nix build .#checks.x86_64-linux.sdk-rust-prebuilt` green: the public ix-sdk still links and runs the R2-hosted prebuilt ix-sdk-wire rlib with the metadata change in place.

This license text is an engineering DRAFT and must be reviewed/approved by legal counsel before it is relied upon.

Part of ENG-2151

Made with AI (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### License the public SDK as proprietary, superseding the repository-root MIT license
> - Adds an Indexable SDK License file at [sdk/LICENSE](https://github.com/indexable-inc/index/pull/727/files#diff-40479a0b0c8cffcf25205ae477fc91bb576c60d9825777617a32e1502a77115f) that explicitly supersedes the repo-root MIT license for all content under `sdk/` and its subdirectories.
> - Updates the Rust (`ix-sdk`, `ix-sdk-wire`), Python, and TypeScript package manifests to reference the proprietary license file instead of an SPDX identifier.
> - Adds `sdk/README.md` and updates `sdk/typescript/README.md` to document the licensing change for SDK consumers.
> - Behavioral Change: the SDK was previously covered by the repo-root MIT license; it is now proprietary and source-available under the Indexable SDK License.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6b6a55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->