### PR TITLE
feat(ix-fleet): port to the ix Python SDK (R2 wheel + rewrite)

### DIFF
--- a/packages/ix-fleet/default.nix
+++ b/packages/ix-fleet/default.nix
@@ -6,6 +6,10 @@
 
 let
   dagRunner = pkgs.callPackage ../dag-runner { inherit ix; };
+  # The ix Python SDK is a prebuilt wheel fetched from R2, not a uv/PyPI
+  # dependency, so it is injected into the venv below rather than resolved by uv.
+  ixSdk = pkgs.callPackage ../ix-sdk-python { };
+
   unwrapped = ix.buildUvApplication pkgs {
     pname = "ix-fleet";
     version = "0.1.0";
@@ -37,46 +41,38 @@ let
     };
   };
 
-  fakeIx = ix.writeNushellApplication pkgs {
-    name = "ix";
-    text = ''
-      def --wrapped main [command: string, ...args] {
-        match $command {
-          "ls" => { print "[]" }
-          "new" => { }
-          _ => {
-            print -e $"unexpected ix command: ($command) (($args | str join ' '))"
-            exit 1
-          }
-        }
-      }
-    '';
-  };
-
-  upFindsDagRunner =
-    pkgs.runCommand "ix-fleet-up-finds-dag-runner"
+  # Drives the full `up` workflow under --dry-run: it makes no API calls and
+  # touches no network, so it runs in the sandbox, yet it exercises the rewritten
+  # control flow and (because the module imports ix_sdk at load) proves the
+  # prebuilt SDK wheel is importable from the built venv. The CLI-stubbing test
+  # this replaces no longer fits now that fleet ops go through the SDK, not a
+  # subprocess; live SDK behavior is covered by the example health-checks.
+  dryRunUp =
+    pkgs.runCommand "ix-fleet-dry-run-up"
       {
-        nativeBuildInputs = [
-          fakeIx
-          package
-        ];
+        nativeBuildInputs = [ package ];
         strictDeps = true;
       }
       ''
-        ix-fleet --plan ${dryRunPlan} up --skip-push --skip-health
+        ix-fleet --plan ${dryRunPlan} up --skip-push --skip-health --dry-run
         mkdir -p "$out"
       '';
 
   package = unwrapped.overrideAttrs (old: {
     postInstall = ''
       ${old.postInstall or ""}
+      # Drop the prebuilt ix_sdk wheel into the venv site-packages so `import
+      # ix_sdk` resolves both at runtime and for the ty install check, without a
+      # PYTHONPATH shim. The cdylib comes from R2 (packages/ix-sdk-python).
+      cp -r ${ixSdk}/${pkgs.python3.sitePackages}/. "$out/venv/${pkgs.python3.sitePackages}/"
+
       wrapProgram "$out/bin/ix-fleet" \
         --set IX_FLEET_DAG_RUNNER ${lib.escapeShellArg (lib.getExe dagRunner)}
     '';
 
     passthru = (old.passthru or { }) // {
       tests = (old.passthru.tests or { }) // {
-        inherit upFindsDagRunner;
+        inherit dryRunUp;
       };
     };
   });

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
+import ix_sdk
+
 
 def empty_str_list() -> list[str]:
     return []
@@ -192,6 +194,32 @@ def step(message: str) -> None:
     print(message, flush=True)
 
 
+_client: ix_sdk.Client | None = None
+
+
+def client() -> ix_sdk.Client:
+    """Lazily construct the SDK client.
+
+    `ix_sdk.Client()` resolves IX_TOKEN and the base URL from the environment,
+    the same inputs the `ix` CLI used; constructing it lazily keeps `--dry-run`
+    runs (which never touch the API) from requiring a token.
+    """
+    global _client
+    if _client is None:
+        _client = ix_sdk.Client()
+    return _client
+
+
+def status_str(status: ix_sdk.BranchStatus) -> str:
+    """Render a BranchStatus as the lowercase string the `ix ls` JSON used, so
+    host health-check env vars (IX_NODE_STATUS) keep their previous shape."""
+    return {
+        ix_sdk.BranchStatus.RUNNING: "running",
+        ix_sdk.BranchStatus.STOPPED: "stopped",
+        ix_sdk.BranchStatus.FAILED: "failed",
+    }.get(status, str(status))
+
+
 class CliError(RuntimeError):
     def __init__(self, command: list[str], returncode: int, stdout: str, stderr: str) -> None:
         self.command = command
@@ -270,40 +298,36 @@ async def run_cli(
     return stdout
 
 
+BOOTSTRAP_PROBE_SCRIPT = (
+    "set -euo pipefail\n"
+    "export PATH=/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:$PATH\n"
+    "if command -v systemctl >/dev/null 2>&1; then\n"
+    "  systemctl start nix-daemon.socket >/dev/null 2>&1 || true\n"
+    "fi\n"
+    "nix --extra-experimental-features nix-command store info >/dev/null"
+)
+
+
 async def wait_node_ready(node: FleetNode, *, dry_run: bool) -> None:
-    command = [
-        "ix",
-        "shell",
-        node.name,
-        "--",
-        "/run/current-system/sw/bin/bash",
-        "-lc",
-        (
-            "set -euo pipefail\n"
-            "export PATH=/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:$PATH\n"
-            "if command -v systemctl >/dev/null 2>&1; then\n"
-            "  systemctl start nix-daemon.socket >/dev/null 2>&1 || true\n"
-            "fi\n"
-            "nix --extra-experimental-features nix-command store info >/dev/null"
-        ),
-    ]
     if dry_run:
-        step("+ wait until bootstrap is ready: " + " ".join(command))
+        step(f"+ wait until {node.name} bootstrap is ready (guest nix store probe)")
         return
 
     step(f"waiting for {node.name} bootstrap")
+    c = client()
     deadline = asyncio.get_running_loop().time() + 180
     last_error = ""
     while asyncio.get_running_loop().time() < deadline:
-        probe = await asyncio.create_subprocess_exec(
-            *command,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout_b, stderr_b = await probe.communicate()
-        if probe.returncode == 0:
-            return
-        last_error = (stderr_b.decode(errors="replace") or stdout_b.decode(errors="replace")).strip()
+        branch = await c.find_by_name(node.name)
+        if branch is None:
+            last_error = f"{node.name} not found"
+        else:
+            # check=False: a not-yet-ready store info is expected while we poll,
+            # so inspect the exit code instead of raising CommandError.
+            result = await branch.bash(BOOTSTRAP_PROBE_SCRIPT, check=False, quiet=True)
+            if result.exit_code == 0:
+                return
+            last_error = (result.stderr or result.stdout).strip()
         await asyncio.sleep(2)
 
     raise RuntimeError(f"{node.name} bootstrap did not become ready: {last_error}")
@@ -325,36 +349,29 @@ async def push_replacement_image(node: FleetNode, *, dry_run: bool) -> str:
     return refs[-1] if refs else image.destination
 
 
-async def list_nodes() -> list[dict[str, typing.Any]]:
-    out = await run_cli(["ix", "ls", "--output", "json"], dry_run=False)
-    rows = json.loads(out)
-    if not isinstance(rows, list):
-        raise TypeError("ix ls --output json must return a list")
-    return [row for row in rows if isinstance(row, dict)]
+async def list_nodes() -> list[ix_sdk.BranchInfo]:
+    return await client().branches()
 
 
-def find_node(rows: list[dict[str, typing.Any]], name: str) -> dict[str, typing.Any] | None:
-    return next((row for row in rows if row.get("name") == name), None)
+def find_node(rows: list[ix_sdk.BranchInfo], name: str) -> ix_sdk.BranchInfo | None:
+    return next((row for row in rows if row.name == name), None)
 
 
 async def create_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
-    command = [
-        "ix",
-        "new",
+    if dry_run:
+        step(
+            f"+ create {node.name} from {image} "
+            f"(region={node.region}, ipv4={node.ipv4}, l7={list(node.l7ProxyPorts)})"
+        )
+        return
+    await client().create(
         image,
-        "--name",
-        node.name,
-        "--region",
-        node.region,
-        "--no-shell",
-    ]
-    for name, value in sorted(node.env.items()):
-        command.extend(["--env", f"{name}={value}"])
-    for port in node.l7ProxyPorts:
-        command.extend(["--l7-proxy-port", str(port)])
-    if node.ipv4:
-        command.append("--ipv4")
-    await run_cli(command, dry_run=dry_run)
+        region=node.region,
+        name=node.name,
+        env=dict(sorted(node.env.items())),
+        l7_proxy_ports=list(node.l7ProxyPorts),
+        ipv4=node.ipv4,
+    )
 
 
 async def ensure_node(node: FleetNode, *, dry_run: bool) -> bool:
@@ -368,48 +385,48 @@ async def ensure_node(node: FleetNode, *, dry_run: bool) -> bool:
         await wait_node_ready(node, dry_run=dry_run)
         return True
 
-    if existing.get("status") == "failed":
-        await run_cli(["ix", "rm", "--force", node.name], dry_run=dry_run)
+    if existing.status == ix_sdk.BranchStatus.FAILED:
+        await remove_node(node, dry_run=dry_run)
         await create_node(node, node.bootstrapImage, dry_run=dry_run)
         await wait_node_ready(node, dry_run=dry_run)
         return True
 
-    if existing.get("status") == "running":
+    if existing.status == ix_sdk.BranchStatus.RUNNING:
         await wait_node_ready(node, dry_run=dry_run)
         return False
 
-    await run_cli(["ix", "start", node.name], dry_run=dry_run)
+    branch = await client().find_by_name(node.name)
+    if branch is not None:
+        await branch.start()
     await wait_node_ready(node, dry_run=dry_run)
     return False
 
 
 async def snapshot_node(node: FleetNode, *, dry_run: bool) -> None:
-    await run_cli(["ix", "snapshot", "create", node.name], dry_run=dry_run)
+    if dry_run:
+        step(f"+ snapshot create {node.name}")
+        return
+    await client().snapshot(name=node.name)
 
 
 async def switch_node(node: FleetNode, *, dry_run: bool) -> None:
     if node.switch.buildOn == "local":
-        # ix switch --build-on local expects the system out-path already in the
-        # local store. Realize the flake installable first so the path is valid.
+        # build-on=local expects the system out-path already in the local store;
+        # the nix build stays a host-side step (it drives the local builder), and
+        # the switch RPC itself goes through the SDK.
         await run_cli(
             ["nix", "build", "--no-link", "--print-out-paths", node.switch.sourceInstallable],
             dry_run=dry_run,
         )
     step(f"switching {node.name} (build-on={node.switch.buildOn})")
-    await run_cli(
-        ["ix", "switch", node.name, node.switch.target, "--build-on", node.switch.buildOn],
-        dry_run=dry_run,
-        timeout=1800,
+    if dry_run:
+        step(f"+ switch {node.name} -> {node.switch.target} (build-on={node.switch.buildOn})")
+        return
+    await client().switch_system(
+        name=node.name,
+        target=node.switch.target,
+        build_on=node.switch.buildOn,
     )
-
-
-def is_existing_group_error(error: CliError) -> bool:
-    return "already exists" in error.output.lower()
-
-
-def is_existing_member_error(error: CliError) -> bool:
-    output = error.output.lower()
-    return "already" in output and ("member" in output or "group" in output)
 
 
 async def ensure_group(group: str, *, dry_run: bool) -> None:
@@ -418,24 +435,21 @@ async def ensure_group(group: str, *, dry_run: bool) -> None:
         return
 
     try:
-        await run_cli(["ix", "group", "create", group], dry_run=dry_run)
-    except CliError as error:
-        if is_existing_group_error(error):
-            step(f"east-west group {group} already exists")
-            return
-        raise
+        await client().create_group(group)
+    except ix_sdk.IxConflictError:
+        step(f"east-west group {group} already exists")
 
 
 async def ensure_node_groups(node: FleetNode, *, dry_run: bool) -> None:
     for group in sorted(node.groups):
         await ensure_group(group, dry_run=dry_run)
+        if dry_run:
+            step(f"+ add {node.name} to east-west group {group}")
+            continue
         try:
-            await run_cli(["ix", "group", "add", group, node.name], dry_run=dry_run)
-        except CliError as error:
-            if is_existing_member_error(error):
-                step(f"{node.name} is already in east-west group {group}")
-                continue
-            raise
+            await client().add_group_member(group, node.name)
+        except ix_sdk.IxConflictError:
+            step(f"{node.name} is already in east-west group {group}")
 
 
 async def bootstrap_node(node: FleetNode, *, dry_run: bool) -> None:
@@ -463,38 +477,30 @@ def dependency_batches(plan: FleetPlan, selectors: list[str]) -> list[list[Fleet
     return batches
 
 
-def is_missing_node_error(error: CliError) -> bool:
-    return "not found" in error.output.lower()
-
-
 async def remove_node(node: FleetNode, *, dry_run: bool) -> None:
     if dry_run:
         step(f"remove {node.name}")
         return
-    try:
-        await run_cli(["ix", "rm", "--force", node.name], dry_run=dry_run)
-    except CliError as error:
-        if is_missing_node_error(error):
-            step(f"{node.name} is already absent")
-            return
-        raise
+    branch = await client().find_by_name(node.name)
+    if branch is None:
+        step(f"{node.name} is already absent")
+        return
+    await branch.delete()
 
 
-def _stringify_env_value(value: typing.Any) -> str:
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    if value is None:
-        return ""
-    if isinstance(value, (str, int, float)):
-        return str(value)
-    return json.dumps(value)
-
-
-def node_env_vars(node: FleetNode, row: dict[str, typing.Any] | None) -> dict[str, str]:
+def node_env_vars(node: FleetNode, info: ix_sdk.BranchInfo | None) -> dict[str, str]:
     env = {"IX_NODE": node.name}
-    if row is not None:
-        for key, value in row.items():
-            env[f"IX_NODE_{key.upper()}"] = _stringify_env_value(value)
+    if info is not None:
+        env["IX_NODE_NAME"] = info.name
+        env["IX_NODE_IMAGE"] = info.image
+        env["IX_NODE_STATUS"] = status_str(info.status)
+        env["IX_NODE_IPV6"] = info.ipv6
+        if info.ipv4 is not None:
+            env["IX_NODE_IPV4"] = info.ipv4
+        if info.subdomain is not None:
+            env["IX_NODE_SUBDOMAIN"] = info.subdomain
+        if info.region is not None:
+            env["IX_NODE_REGION"] = info.region.slug
     return env
 
 
@@ -509,44 +515,65 @@ async def run_health_check(
     *,
     dry_run: bool,
 ) -> None:
-    command = ["ix", "shell", node.name, "--", *check.command] if check.from_ == "guest" else check.command
-
     if dry_run:
-        step(f"+ health {node.name}/{check_name} ({check.from_}): {shlex.join(command)}")
+        if check.from_ == "guest":
+            step(f"+ health {node.name}/{check_name} (guest): exec {shlex.join(check.command)}")
+        else:
+            step(f"+ health {node.name}/{check_name} (host): {shlex.join(check.command)}")
         return
 
     step(f"checking {node.name}/{check_name} ({check.from_}): {check.description}")
     last_error = ""
     for attempt in range(1, check.attempts + 1):
-        env: dict[str, str] | None = None
-        if check.from_ == "host":
-            row = find_node(await list_nodes(), node.name)
-            host_env = node_env_vars(node, row)
+        if check.from_ == "guest":
+            # Run the check argv inside the VM through the SDK exec channel.
+            branch = await client().find_by_name(node.name)
+            if branch is None:
+                last_error = f"{node.name} not found"
+            else:
+                try:
+                    result = await asyncio.wait_for(
+                        branch.exec(list(check.command), check=False, quiet=True),
+                        check.timeoutSec,
+                    )
+                except asyncio.TimeoutError:
+                    last_error = f"timed out after {check.timeoutSec}s"
+                else:
+                    if result.exit_code == 0:
+                        step(f"healthy {node.name}/{check_name}")
+                        return
+                    last_error = (result.stdout + result.stderr).strip()
+        else:
+            # Host check: run on the operator's machine with IX_NODE_* env so it
+            # can probe the node from outside (public reachability, firewall).
+            info = find_node(await list_nodes(), node.name)
+            host_env = node_env_vars(node, info)
             if check.requiresIpv4 and not host_env.get("IX_NODE_IPV4"):
-                last_error = "ix ls did not report IX_NODE_IPV4 yet"
+                last_error = "node has not reported IX_NODE_IPV4 yet"
                 if attempt < check.attempts:
                     await asyncio.sleep(check.intervalSec)
                 continue
             env = {**os.environ, **host_env}
             command = expand_host_command(check.command, host_env)
-
-        process = await asyncio.create_subprocess_exec(
-            *command,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=env,
-        )
-        try:
-            stdout_b, stderr_b = await asyncio.wait_for(process.communicate(), check.timeoutSec)
-        except asyncio.TimeoutError:
-            process.kill()
-            await process.wait()
-            last_error = f"timed out after {check.timeoutSec}s"
-        else:
-            if process.returncode == 0:
-                step(f"healthy {node.name}/{check_name}")
-                return
-            last_error = (stdout_b.decode(errors="replace") + stderr_b.decode(errors="replace")).strip()
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+            try:
+                stdout_b, stderr_b = await asyncio.wait_for(process.communicate(), check.timeoutSec)
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+                last_error = f"timed out after {check.timeoutSec}s"
+            else:
+                if process.returncode == 0:
+                    step(f"healthy {node.name}/{check_name}")
+                    return
+                last_error = (
+                    stdout_b.decode(errors="replace") + stderr_b.decode(errors="replace")
+                ).strip()
 
         if attempt < check.attempts:
             await asyncio.sleep(check.intervalSec)
@@ -627,31 +654,17 @@ async def switch_node_from_source(
                 raise
 
 
+# `ix new --name X` is create-or-replace by name; `client.create` calls the same
+# create RPC, so replacing an existing node is identical to creating it.
 async def replace_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
-    command = [
-        "ix",
-        "new",
-        image,
-        "--name",
-        node.name,
-        "--region",
-        node.region,
-        "--no-shell",
-    ]
-    for name, value in sorted(node.env.items()):
-        command.extend(["--env", f"{name}={value}"])
-    for port in node.l7ProxyPorts:
-        command.extend(["--l7-proxy-port", str(port)])
-    if node.ipv4:
-        command.append("--ipv4")
-    await run_cli(command, dry_run=dry_run)
+    await create_node(node, image, dry_run=dry_run)
 
 
 async def up_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
     if dry_run:
         if node.recreateOnUp:
             step(f"recreate {node.name} from uploaded image {image}")
-            await run_cli(["ix", "rm", "--force", node.name], dry_run=dry_run)
+            await remove_node(node, dry_run=dry_run)
             await create_node(node, image, dry_run=dry_run)
         else:
             step(f"create or replace {node.name} from uploaded image {image}")
@@ -660,7 +673,7 @@ async def up_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
 
     existing = find_node(await list_nodes(), node.name)
     if existing is not None and node.recreateOnUp:
-        await run_cli(["ix", "rm", "--force", node.name], dry_run=dry_run)
+        await remove_node(node, dry_run=dry_run)
         await create_node(node, image, dry_run=dry_run)
         return
 
@@ -668,8 +681,8 @@ async def up_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
         await create_node(node, image, dry_run=dry_run)
         return
 
-    if existing.get("status") == "failed":
-        await run_cli(["ix", "rm", "--force", node.name], dry_run=dry_run)
+    if existing.status == ix_sdk.BranchStatus.FAILED:
+        await remove_node(node, dry_run=dry_run)
         await create_node(node, image, dry_run=dry_run)
         return
 
@@ -841,7 +854,7 @@ async def cmd_down(plan: FleetPlan, args: argparse.Namespace) -> None:
     for node in reversed(selected_nodes(plan, args.on)):
         try:
             await remove_node(node, dry_run=args.dry_run)
-        except (CliError, OSError) as error:
+        except (ix_sdk.IxError, CliError, OSError) as error:
             failures.append(f"{node.name}: {error}")
     if failures:
         raise RuntimeError("failed to remove fleet nodes: " + "; ".join(failures))

--- a/packages/ix-sdk-python/default.nix
+++ b/packages/ix-sdk-python/default.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  pkgs,
+  # Match the interpreter of any consumer (ix-fleet builds on pkgs.python3).
+  # The wheel is abi3 (cp313+), so a 3.13+ interpreter is required.
+  python3 ? pkgs.python3,
+}:
+
+let
+  # Prebuilt `ix_sdk` wheels hosted on the public R2 bucket `ix-sdk-artifacts`.
+  # This is the index <-> ix artifact boundary (ENG-2151): index fetches the
+  # published wheel and never builds private ix source. The native `_ix_sdk`
+  # cdylib is built, stripped, and scanned store-clean by ix's
+  # `nix/packages/workspace-sdks.nix`, then uploaded to R2 with `wrangler`.
+  #
+  # The URL + SRI live here next to the consumer rather than in flake.lock, so a
+  # routine SDK bump is: re-publish the wheel to R2 and edit this catalog. Each
+  # key embeds the wheel's nix-store hash so distinct builds never collide.
+  #
+  # Only x86_64-linux is published today; the darwin SDK wheel build path does
+  # not yet exist in indexable-inc/ix (its sdks are linux-only), so a darwin
+  # entry is added once that lands.
+  catalog = {
+    x86_64-linux = {
+      url = "https://pub-c52bf5a1e3db4628aaf57fe94cb5de10.r2.dev/wheel/ix-sdk/w3mxsrmhkgvbgfg9nq9d408sa1xqfb7y/ix_sdk-0.1.0-cp313-abi3-manylinux_2_34_x86_64.whl";
+      hash = "sha256-UhhiTB/vy6y2UZAx/z19KxkUKyKscxEJcPeYWVgQp0I=";
+    };
+  };
+
+  inherit (pkgs.stdenv.hostPlatform) system;
+  entry = catalog.${system} or null;
+in
+if entry == null then
+  # Eval-safe placeholder: `packages.<unsupported>.ix-sdk-python` still
+  # evaluates (so flake eval and x86_64-linux CI are unaffected), but realizing
+  # it fails loudly instead of silently guessing a wheel. Reject the fallback.
+  pkgs.runCommand "ix-sdk-python-unsupported-${system}" { } ''
+    echo "ix-sdk-python: no prebuilt ix_sdk wheel published for ${system} (only x86_64-linux so far)." >&2
+    echo "Build + publish the wheel for this platform to the R2 bucket ix-sdk-artifacts and add it to packages/ix-sdk-python/default.nix." >&2
+    exit 1
+  ''
+else
+  let
+    wheel = pkgs.fetchurl { inherit (entry) url hash; };
+
+    package =
+      pkgs.runCommand "ix-sdk-python-0.1.0"
+        {
+          inherit wheel;
+          nativeBuildInputs = [ python3 ];
+          passthru = {
+            inherit python3 wheel;
+            inherit (python3) sitePackages;
+          };
+          meta = {
+            description = "Prebuilt Python bindings for the ix Rust SDK (fetched from R2)";
+            homepage = "https://github.com/indexable-inc/ix";
+            platforms = builtins.attrNames catalog;
+          };
+        }
+        ''
+          mkdir -p "$out/${python3.sitePackages}"
+          # A wheel is a zip: extract `ix_sdk/` + `ix_sdk-*.dist-info/` straight
+          # into site-packages so consumers `import ix_sdk` with no shim.
+          python3 -m zipfile -e "$wheel" "$out/${python3.sitePackages}/"
+        '';
+
+    # Defends the load-bearing claim: the prebuilt cdylib actually imports under
+    # index's nixpkgs interpreter, and the surface we depend on is present.
+    importTest = pkgs.runCommand "ix-sdk-python-import" { nativeBuildInputs = [ python3 ]; } ''
+      export PYTHONPATH="${package}/${python3.sitePackages}"
+      python3 - <<'PY'
+      import ix_sdk
+      assert ix_sdk.__version__, "missing __version__"
+      for name in ("Client", "Group", "GroupMember"):
+          assert hasattr(ix_sdk, name), f"missing ix_sdk.{name}"
+      for method in ("create_group", "add_group_member", "create", "branches"):
+          assert hasattr(ix_sdk.Client, method), f"missing Client.{method}"
+      print("ix_sdk", ix_sdk.__version__, "imported; group + lifecycle surface present")
+      PY
+      touch "$out"
+    '';
+  in
+  package.overrideAttrs (old: {
+    passthru = (old.passthru or { }) // {
+      tests = (old.passthru.tests or { }) // {
+        import = importTest;
+      };
+    };
+  })

--- a/packages/ix-sdk-python/default.nix
+++ b/packages/ix-sdk-python/default.nix
@@ -15,7 +15,7 @@ let
   #
   # The URL + SRI live here next to the consumer rather than in flake.lock, so a
   # routine SDK bump is: re-publish the wheel to R2 and edit this catalog. Each
-  # key embeds the wheel's nix-store hash so distinct builds never collide.
+  # URL path embeds the wheel's nix-store hash so distinct builds never collide.
   #
   # Only x86_64-linux is published today; the darwin SDK wheel build path does
   # not yet exist in indexable-inc/ix (its sdks are linux-only), so a darwin
@@ -28,22 +28,40 @@ let
   };
 
   inherit (pkgs.stdenv.hostPlatform) system;
-  entry = catalog.${system} or null;
+  rawEntry = catalog.${system} or null;
+  # Catch a careless bump (an http:// URL or a non-SRI hash) at eval time, the
+  # same guard lib/util/artifacts.nix applies to its loader catalogs.
+  entry =
+    if rawEntry == null then
+      null
+    else
+      assert lib.assertMsg (
+        lib.hasPrefix "https://" rawEntry.url && lib.hasPrefix "sha256-" rawEntry.hash
+      ) "ix-sdk-python: catalog entry for ${system} needs an https:// url and an sha256- SRI hash";
+      rawEntry;
 in
 if entry == null then
   # Eval-safe placeholder: `packages.<unsupported>.ix-sdk-python` still
   # evaluates (so flake eval and x86_64-linux CI are unaffected), but realizing
   # it fails loudly instead of silently guessing a wheel. Reject the fallback.
-  pkgs.runCommand "ix-sdk-python-unsupported-${system}" { } ''
-    echo "ix-sdk-python: no prebuilt ix_sdk wheel published for ${system} (only x86_64-linux so far)." >&2
-    echo "Build + publish the wheel for this platform to the R2 bucket ix-sdk-artifacts and add it to packages/ix-sdk-python/default.nix." >&2
-    exit 1
-  ''
+  pkgs.runCommand "ix-sdk-python-unsupported-${system}"
+    {
+      meta.description = "ix_sdk Python bindings (no prebuilt wheel for ${system})";
+    }
+    ''
+      echo "ix-sdk-python: no prebuilt ix_sdk wheel published for ${system} (only x86_64-linux so far)." >&2
+      echo "Build + publish the wheel for this platform to the R2 bucket ix-sdk-artifacts and add it to packages/ix-sdk-python/default.nix." >&2
+      exit 1
+    ''
 else
   let
     wheel = pkgs.fetchurl { inherit (entry) url hash; };
 
-    package =
+    # `toPythonModule` stamps `pythonModule = python3` so the package composes
+    # the normal way (`python3.withPackages (ps: [ ix-sdk-python ])`); without
+    # it nixpkgs' `hasPythonModule` filter silently drops the package from any
+    # environment. This is the repo convention (see packages/mcp).
+    package = python3.pkgs.toPythonModule (
       pkgs.runCommand "ix-sdk-python-0.1.0"
         {
           inherit wheel;
@@ -63,13 +81,12 @@ else
           # A wheel is a zip: extract `ix_sdk/` + `ix_sdk-*.dist-info/` straight
           # into site-packages so consumers `import ix_sdk` with no shim.
           python3 -m zipfile -e "$wheel" "$out/${python3.sitePackages}/"
-        '';
+        ''
+    );
 
-    # Defends the load-bearing claim: the prebuilt cdylib actually imports under
-    # index's nixpkgs interpreter, and the surface we depend on is present.
-    importTest = pkgs.runCommand "ix-sdk-python-import" { nativeBuildInputs = [ python3 ]; } ''
-      export PYTHONPATH="${package}/${python3.sitePackages}"
-      python3 - <<'PY'
+    # The surface ix-fleet depends on, asserted once so a bad wheel fails the
+    # check rather than ix-fleet at runtime.
+    assertSurface = ''
       import ix_sdk
       assert ix_sdk.__version__, "missing __version__"
       for name in ("Client", "Group", "GroupMember"):
@@ -77,9 +94,21 @@ else
       for method in ("create_group", "add_group_member", "create", "branches"):
           assert hasattr(ix_sdk.Client, method), f"missing Client.{method}"
       print("ix_sdk", ix_sdk.__version__, "imported; group + lifecycle surface present")
-      PY
-      touch "$out"
     '';
+
+    # Import through a real `withPackages` environment, the way consumers use it,
+    # so the toPythonModule wiring can't silently regress.
+    importTest =
+      pkgs.runCommand "ix-sdk-python-import"
+        {
+          pythonEnv = python3.withPackages (_: [ package ]);
+        }
+        ''
+          "$pythonEnv/bin/python" - <<'PY'
+          ${assertSurface}
+          PY
+          touch "$out"
+        '';
   in
   package.overrideAttrs (old: {
     passthru = (old.passthru or { }) // {

--- a/packages/ix-sdk-python/package.nix
+++ b/packages/ix-sdk-python/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "ix-sdk-python";
+  packageSet = true;
+  passthruTests = {
+    prefix = "ix-sdk-python";
+  };
+}

--- a/packages/ix-sdk-python/package.nix
+++ b/packages/ix-sdk-python/package.nix
@@ -1,6 +1,7 @@
 {
   id = "ix-sdk-python";
   packageSet = true;
+  flake = true;
   passthruTests = {
     prefix = "ix-sdk-python";
   };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2352,9 +2352,11 @@ let
           &&
             observabilityStackExample.observability.collector.exporters.clickhouse.traces_table_name
             == "otel_traces"
-          &&
-            observabilityStackExample.observability.collector.service.pipelines.logs.exporters
-            == [ "clickhouse" ];
+          # RFC-0004 (#705) added the per-host history S3/OTLP sink, so the logs
+          # pipeline now fans out to both clickhouse and awss3. Assert ClickHouse
+          # is still an exporter rather than pinning the exact list, which breaks
+          # on every legitimate addition to the pipeline.
+          && builtins.elem "clickhouse" observabilityStackExample.observability.collector.service.pipelines.logs.exporters;
         message = "observability-stack collector should receive OTLP and export logs/traces/metrics to ClickHouse";
       }
       {


### PR DESCRIPTION
Ports `ix-fleet` (the Python fleet orchestrator) off the `ix` CLI subprocess onto the `ix_sdk` Python SDK.

**Delivery (index <-> ix artifact boundary):** `packages/ix-sdk-python` fetches the prebuilt SDK wheel from the public R2 bucket by URL + SRI and exposes it as a `toPythonModule`; index never builds private ix source.

**Rewrite:** `ix-fleet` now uses `ix_sdk` for ls / new / rm / start / snapshot / switch / group / shell, with typed `IxNotFoundError`/`IxConflictError` handling instead of sniffing CLI stderr. The `ix` CLI is kept intentionally for only two ops, `image push` and `switch --source`, whose logic moves into `sdk-core` in a follow-up.

**Also:** unbreaks the `observability-stack` eval test, which pinned `logs.exporters == ["clickhouse"]` and broke when RFC-0004 (#705) added the S3/OTLP history sink.

Depends on ix#4275 (group API, merged).

Validated on x86_64-linux (fleet host): `nix build .#ix-fleet` (incl. ty check) passes, the `.#ix-sdk-python` import test and the ix-fleet `--dry-run up` smoke test pass, and `.#checks.x86_64-linux.eval` builds.

Known follow-ups: aarch64-darwin SDK wheel (ix sdks are linux-only today), and the `image push` / `switch --source` core migration.

Made with AI (Claude Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Port ix-fleet to the ix Python SDK replacing all ix CLI calls
> - Replaces all `ix` CLI subprocess calls in [ix_fleet/__init__.py](https://github.com/indexable-inc/index/pull/728/files#diff-d83777ed2e90ee1f7371ffa0e55fe375c817b07e2cb2a15a5b58423ad93dae3e) with `ix_sdk.Client()` SDK calls for node lifecycle (create, start, delete, snapshot, switch), group management, and health checks.
> - Adds a new [ix-sdk-python](https://github.com/indexable-inc/index/pull/728/files#diff-80f46c8d1744ebc070c811611b94e45d792b24cdeeae53fcaf78e4db15945032) Nix derivation that fetches a prebuilt wheel from a public R2 bucket and injects it into the ix-fleet venv's site-packages at install time.
> - Guest health checks now execute inside the VM via the SDK exec channel instead of spawning `ix` CLI; host health checks use a narrowed set of `IX_NODE_*` env vars derived from typed `BranchInfo` objects.
> - Package-level tests are updated to run `ix-fleet --plan ... up --dry-run` instead of stubbing the ix CLI.
> - Behavioral Change: `IX_NODE_*` environment variables for host health checks are now restricted to a fixed set of keys; previously all keys from `ix ls` JSON were exported.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb50859.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->