### PR TITLE
chore(sdk): bump pinned ix-sdk-wire rlib SRIs to the license-baked artifact

### DIFF
--- a/sdk/rust/default.nix
+++ b/sdk/rust/default.nix
@@ -65,11 +65,11 @@ let
   # compiled artifacts produced in the ix repo, not rebuilt here.
   wireRlib = pkgs.fetchurl {
     url = "${r2Base}/libix_sdk_wire-${wireHash}.rlib";
-    hash = "sha256-WxJF0gSJIJhSvF60nPu9F5xdgD7j6TxtKxvyy1DYals=";
+    hash = "sha256-2tb6UoAkABVaEU0uSrrUSUMNk1uh3tA9DD1pwjDzHyE=";
   };
   wireRmeta = pkgs.fetchurl {
     url = "${r2Base}/libix_sdk_wire-${wireHash}.rmeta";
-    hash = "sha256-9P5fn/5lVyhaQvVAMspfCK1AUF02VsdF/rCvngN1O2o=";
+    hash = "sha256-27T6SgFketntMqD/gAplv563tjYZ6K9/nY7SZV70D0Q=";
   };
 
   # Wrap the fetched rlib+rmeta as a cargo-unit library unit. The Cargo lib


### PR DESCRIPTION
ix #4276 baked the proprietary license into the rlib (new bytes, same unit hash 134ac8c636bf38ee); this re-pins the fetchurl SRIs.

Part of ENG-2151.

Made with AI (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump pinned `ix-sdk-wire` rlib and rmeta SRI hashes to license-baked artifacts
> Updates the fixed-output SHA256 hashes in [default.nix](https://github.com/indexable-inc/index/pull/729/files#diff-46fa88d41982cdb7255a084462fcb03966b09864f14b1626c3dab5187c433886) for the fetched `libix_sdk_wire` `.rlib` and `.rmeta` artifacts to match the new license-baked versions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98ea751.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->