### PR TITLE
fix(ix-fleet): restore switch timeout + real replace (review fixes)

### DIFF
--- a/packages/ix-fleet/default.nix
+++ b/packages/ix-fleet/default.nix
@@ -41,12 +41,12 @@ let
     };
   };
 
-  # Drives the full `up` workflow under --dry-run: it makes no API calls and
-  # touches no network, so it runs in the sandbox, yet it exercises the rewritten
-  # control flow and (because the module imports ix_sdk at load) proves the
-  # prebuilt SDK wheel is importable from the built venv. The CLI-stubbing test
-  # this replaces no longer fits now that fleet ops go through the SDK, not a
-  # subprocess; live SDK behavior is covered by the example health-checks.
+  # Walks the `up` command's --dry-run control flow (no API calls, no network,
+  # so it runs in the sandbox) and, because the module imports ix_sdk at load,
+  # proves the prebuilt SDK wheel is importable from the built venv. Note this
+  # only covers the dry-run branches: the live SDK calls and the dag-runner
+  # fan-out are not exercised here (the SDK can't be stubbed by a fake CLI like
+  # the old test did); that path is covered by the example health-checks.
   dryRunUp =
     pkgs.runCommand "ix-fleet-dry-run-up"
       {

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -374,6 +374,19 @@ async def create_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
     )
 
 
+async def recreate_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
+    """Delete the node if present, then create it on `image`.
+
+    `client.create` (like `ix new --name`) inserts against a UNIQUE (owner,
+    name) constraint and errors if the name is taken, so replacing a node's
+    image is delete-then-create, not an in-place update. In-place updates are
+    `switch`; this is the image-swap path used by `replace`/`up`/failed-node
+    recovery.
+    """
+    await remove_node(node, dry_run=dry_run)
+    await create_node(node, image, dry_run=dry_run)
+
+
 async def ensure_node(node: FleetNode, *, dry_run: bool) -> bool:
     if dry_run:
         step(f"ensure {node.name} exists from {node.bootstrapImage}")
@@ -386,8 +399,7 @@ async def ensure_node(node: FleetNode, *, dry_run: bool) -> bool:
         return True
 
     if existing.status == ix_sdk.BranchStatus.FAILED:
-        await remove_node(node, dry_run=dry_run)
-        await create_node(node, node.bootstrapImage, dry_run=dry_run)
+        await recreate_node(node, node.bootstrapImage, dry_run=dry_run)
         await wait_node_ready(node, dry_run=dry_run)
         return True
 
@@ -422,11 +434,22 @@ async def switch_node(node: FleetNode, *, dry_run: bool) -> None:
     if dry_run:
         step(f"+ switch {node.name} -> {node.switch.target} (build-on={node.switch.buildOn})")
         return
-    await client().switch_system(
-        name=node.name,
-        target=node.switch.target,
-        build_on=node.switch.buildOn,
-    )
+    # The SDK switch RPC has no deadline of its own; bound it like the old CLI
+    # path (which passed timeout=1800) so a hung remote/local switch can't block
+    # the fleet workflow forever.
+    try:
+        await asyncio.wait_for(
+            client().switch_system(
+                name=node.name,
+                target=node.switch.target,
+                build_on=node.switch.buildOn,
+            ),
+            SWITCH_TIMEOUT_SECS,
+        )
+    except asyncio.TimeoutError as error:
+        raise RuntimeError(
+            f"switch of {node.name} timed out after {SWITCH_TIMEOUT_SECS}s"
+        ) from error
 
 
 async def ensure_group(group: str, *, dry_run: bool) -> None:
@@ -612,6 +635,9 @@ def default_source_workdir(cwd: Path, source_root: Path) -> Path:
         return Path(".")
 
 
+# Bound a target-based `switch` (matches the old CLI `timeout=1800`). The
+# source-build switch below uses its own, longer deadline.
+SWITCH_TIMEOUT_SECS = 1800
 MAX_SWITCH_RETRIES = 3
 RETRY_DELAY_SECS = 10
 
@@ -654,39 +680,28 @@ async def switch_node_from_source(
                 raise
 
 
-# `ix new --name X` is create-or-replace by name; `client.create` calls the same
-# create RPC, so replacing an existing node is identical to creating it.
+# Replacing a node's image is delete-then-create (see recreate_node): a new
+# image cannot be applied to an existing VM in place.
 async def replace_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
-    await create_node(node, image, dry_run=dry_run)
+    await recreate_node(node, image, dry_run=dry_run)
 
 
 async def up_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
     if dry_run:
-        if node.recreateOnUp:
-            step(f"recreate {node.name} from uploaded image {image}")
-            await remove_node(node, dry_run=dry_run)
-            await create_node(node, image, dry_run=dry_run)
-        else:
-            step(f"create or replace {node.name} from uploaded image {image}")
-            await replace_node(node, image, dry_run=dry_run)
+        verb = "recreate" if node.recreateOnUp else "create or replace"
+        step(f"{verb} {node.name} from uploaded image {image}")
+        await recreate_node(node, image, dry_run=dry_run)
         return
 
     existing = find_node(await list_nodes(), node.name)
-    if existing is not None and node.recreateOnUp:
-        await remove_node(node, dry_run=dry_run)
-        await create_node(node, image, dry_run=dry_run)
-        return
-
     if existing is None:
         await create_node(node, image, dry_run=dry_run)
         return
 
-    if existing.status == ix_sdk.BranchStatus.FAILED:
-        await remove_node(node, dry_run=dry_run)
-        await create_node(node, image, dry_run=dry_run)
-        return
-
-    await replace_node(node, image, dry_run=dry_run)
+    # Any existing node (recreateOnUp, failed, or a plain image change) needs a
+    # fresh VM on the uploaded image, since `up` swaps the image rather than
+    # updating in place.
+    await recreate_node(node, image, dry_run=dry_run)
 
 
 async def cmd_diff(plan: FleetPlan, args: argparse.Namespace) -> None:
@@ -854,7 +869,7 @@ async def cmd_down(plan: FleetPlan, args: argparse.Namespace) -> None:
     for node in reversed(selected_nodes(plan, args.on)):
         try:
             await remove_node(node, dry_run=args.dry_run)
-        except (ix_sdk.IxError, CliError, OSError) as error:
+        except (ix_sdk.IxError, OSError) as error:
             failures.append(f"{node.name}: {error}")
     if failures:
         raise RuntimeError("failed to remove fleet nodes: " + "; ".join(failures))


### PR DESCRIPTION
Review fixes on the ix-fleet SDK port (#728):

- **C2 (regression):** `switch_node` lost the old CLI `timeout=1800`; a hung SDK `switch_system` blocked the workflow indefinitely. Now wrapped in `asyncio.wait_for(SWITCH_TIMEOUT_SECS)`.
- **C1:** `replace_node` only created, but `client.create` errors on an existing name (UNIQUE owner,name), so it never replaced a running node. Introduced `recreate_node` (delete-then-create) and routed replace/up/failed through it (DRY); corrected the false comment.
- Dropped the dead `CliError` arm in `cmd_down` (pure SDK now).
- Softened the dry-run test comment to state it covers only the dry-run branches.

Validated on x86_64-linux: `nix build .#ix-fleet` (ty check) + `.#ix-fleet.passthru.tests.dryRunUp` pass.

Made with AI (Claude Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `replace_node` and `up_node` to use delete-then-create and restore `switch_node` timeout in ix-fleet
> - Introduces `recreate_node` helper in [__init__.py](https://github.com/indexable-inc/index/pull/730/files#diff-d83777ed2e90ee1f7371ffa0e55fe375c817b07e2cb2a15a5b58423ad93dae3e) that deletes an existing node then creates it fresh, fixing name-conflict failures in `replace_node` and `up_node`.
> - `replace_node` now calls `recreate_node` instead of `create_node`, ensuring the old node is removed before the new one is created.
> - `up_node` is simplified to always call `recreate_node` for existing nodes, removing conditional branches based on `recreateOnUp` or FAILED status.
> - Restores a 1800s timeout on the `switch_system` RPC in `switch_node` via `asyncio.wait_for`, raising `RuntimeError` on expiry.
> - `cmd_down` no longer catches `CliError` during `remove_node`; such errors now propagate instead of being aggregated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c949985.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->