### PR TITLE
fix(tests): drop the ix CLI package assertion obsoleted by #731

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3415,10 +3415,6 @@ let
         message = "repo Rust package builds should be exposed as flake-checkable tests";
       }
       {
-        assertion = repoPackages ? ix;
-        message = "repo package set should expose the ix CLI package by default";
-      }
-      {
         assertion = repoPackages.minecraft-nbt.passthru.tests ? unusedCrateDependencies;
         message = "repo Rust per-crate policy checks should be exposed as flake-checkable tests";
       }


### PR DESCRIPTION
#731 removed `packages/ix` but left the eval assertion `repoPackages ? ix`, which now fails and reddens `.#checks.x86_64-linux.eval` on main (cascading into every open PR's flake-check). The package was removed on purpose, so the assertion is obsolete. One-line deletion.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove obsolete `ix` CLI package assertion from test suite
> Drops the assertion in [tests/default.nix](https://github.com/indexable-inc/index/pull/732/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) that checked `repoPackages ? ix`, as it was made obsolete by PR #731.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99dfee2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->