### PR TITLE
test(cargo-unit): pin subset-cargoTargets redundancy, document lazy root selection

### DIFF
--- a/lib/rust/cargo-unit.nix
+++ b/lib/rust/cargo-unit.nix
@@ -327,6 +327,19 @@ let
     Rendering fails when a unit path cannot be tied back to `src` or `vendorDir`.
     Pass `cargoTargets = [ [ "--workspace" ] [ "--workspace" "--tests" ] ]`
     to expose roots from several Cargo executions through one generated graph.
+    Roots are consumed lazily: `binaries.<name>`, `libraries.<name>`, and
+    `targetSets.<set>.*` each reference one rustc unit derivation, so selecting
+    a subset of roots (say the native cdylibs out of a graph that also plans a
+    wasm target) never builds the other entries' units. A second buildWorkspace
+    call that only narrows `cargoTargets` yields byte-identical root
+    derivations (pinned by a tests/default.nix assertion) and adds a unit-graph
+    plus render IFD; create a separate workspace only when unit identity
+    changes (profile, policy, rustToolchain, env, extraRustcArgs). Top-level
+    `binaries`/`libraries` dedupe by Cargo target name and the first
+    `cargoTargets` entry wins, so when one crate roots under several entries,
+    select through `targetSets.<set>` instead. The exception to per-root
+    laziness is `tests.<target>.cases`, whose shared manifest IFD builds every
+    test binary in the graph.
     Include `--benches` or `--bench <name>` to expose `[[bench]]` roots under
     `benchmarks` and `benchmarkPlan`. Tango benches can compare previous and
     next artifacts with `next.compareTangoBenchmarks { baseline = previous; }`,

--- a/lib/rust/cargo-unit.nix
+++ b/lib/rust/cargo-unit.nix
@@ -337,9 +337,11 @@ let
     changes (profile, policy, rustToolchain, env, extraRustcArgs). Top-level
     `binaries`/`libraries` dedupe by Cargo target name and the first
     `cargoTargets` entry wins, so when one crate roots under several entries,
-    select through `targetSets.<set>` instead. The exception to per-root
-    laziness is `tests.<target>.cases`, whose shared manifest IFD builds every
-    test binary in the graph.
+    select through `targetSets.<set>` instead. Per-case discovery is the
+    exception to per-root laziness: `tests.<target>.cases` uses a shared
+    manifest IFD that builds every test binary in the graph, and
+    `doctests.<target>.cases` uses a shared doctest manifest covering every
+    doctest target.
     Include `--benches` or `--bench <name>` to expose `[[bench]]` roots under
     `benchmarks` and `benchmarkPlan`. Tango benches can compare previous and
     next artifacts with `next.compareTangoBenchmarks { baseline = previous; }`,

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -626,6 +626,20 @@ let
     ];
   };
 
+  # Same workspace narrowed to the build graph only. Root derivations are
+  # per-unit, so this must yield byte-identical roots to lazily selecting from
+  # the multi-target workspace above; the helpers assertion pins that equality,
+  # which also proves a selected root's closure contains nothing from the
+  # dropped target sets. Consumers should select roots lazily instead of
+  # spinning up subset workspaces like this one (#716).
+  cargoUnitSubsetWorkspace = ix.cargoUnit.buildWorkspace {
+    src = cargoUnitFixture;
+    workspaceRoot = ./fixtures/cargo-unit-hello;
+    packageTestInputs.cargo-unit-hello = [ pkgs.hello ];
+    packageTestEnv.cargo-unit-hello.CARGO_UNIT_FIXTURE_ENV = "ok";
+    cargoTargets = [ [ "--workspace" ] ];
+  };
+
   cargoUnitCoverageRustToolchain = ix.languages.rust.toolchain pkgs {
     channel = "nightly";
     version = rustPinnedNightlyDate;
@@ -3325,6 +3339,12 @@ let
           cargoUnitWorkspace.targetSets.build.binaries.cargo-unit-hello.drvPath
           == cargoUnitWorkspace.binaries.cargo-unit-hello.drvPath;
         message = "cargo-unit should expose named target-set outputs without losing aggregate outputs";
+      }
+      {
+        assertion =
+          cargoUnitSubsetWorkspace.binaries.cargo-unit-hello.drvPath
+          == cargoUnitWorkspace.targetSets.build.binaries.cargo-unit-hello.drvPath;
+        message = "narrowing cargoTargets must yield identical root derivations; select roots lazily from the multi-target workspace instead of a subset buildWorkspace";
       }
       {
         assertion = cargoUnitPolicyDisabledWorkspace.policyChecks == { };


### PR DESCRIPTION
## Summary

#716 asked to confirm that `buildWorkspace { cargoTargets = [ts, wasm, py] }` exposes independent per-(crate,target) `libraries.*` derivations, so consumers can lazily pick a native-only subset without a second `buildWorkspace`. Confirmed, pinned, and documented.

**Confirmed by code:** `libraries.<name>` maps each root to one rustc unit derivation (`templates/units.nix.askama`, `render_root_entries_for` in `packages/nix-cargo-unit/src/render.rs`); unit identity hashes include the platform (`model.rs`), and the merge dedups per-entry graphs by closure identity hash, so each `cargoTargets` entry is an independent cargo invocation.

**Pinned by test:** a new helpers-group assertion proves a `buildWorkspace` that only narrows `cargoTargets` yields the byte-identical root drvPath as lazily selecting that root from the multi-target workspace. Equal drvPath means equal closure, so the selected root carries nothing from the dropped target sets, and subset workspaces buy nothing while adding a unit-graph plus render IFD pair.

**Documented at the owner:** the `buildWorkspace` docstring now states the lazy-selection contract, when a separate workspace is still warranted (profile, policy, rustToolchain, env, extraRustcArgs change unit identity, e.g. ix's `public-rlib` workspace), the top-level `binaries`/`libraries` first-entry-wins name dedup caveat (select through `targetSets.<set>` on collisions), and the `tests.<target>.cases` manifest-IFD exception.

Verified the assertion semantics empirically against this branch: both workspaces evaluated out-of-tree with identical args (`contentAddressed = false` locally; the daemon here lacks `ca-derivations`) produce equal drvPaths. CI runs the in-tree assertion with CA on.

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin subset-cargoTargets redundancy and document lazy root selection in cargo-unit
> - Adds a `cargoUnitSubsetWorkspace` test binding in [tests/default.nix](https://github.com/indexable-inc/index/pull/733/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) that builds a workspace restricted to `["--workspace"]` cargoTargets, representing a narrowed build graph.
> - Adds an assertion that the narrowed workspace's root derivation for `cargo-unit-hello` matches the equivalent derivation from the full multi-target workspace's `targetSets.build.binaries`, enforcing derivation identity across cargoTarget subsets.
> - Expands documentation in [lib/rust/cargo-unit.nix](https://github.com/indexable-inc/index/pull/733/files#diff-82054df1a7d1648a5be88265641a7ae5d3b9e4ec4cdea72c518359ea4ae3f804) to describe lazy root selection, deduplication behavior, and the recommendation to select roots via `targetSets` when a crate appears under multiple `cargoTargets` entries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba54372.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->