### PR TITLE
blast-radius: overlap the base and head evals

### DIFF
--- a/packages/blast-radius/src/main.rs
+++ b/packages/blast-radius/src/main.rs
@@ -105,8 +105,23 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     let revs = git::resolve(cli.base.as_deref(), cli.head.as_deref())?;
 
-    let base = nix::eval_checks(&revs.repo, &revs.base)?;
-    let head = nix::eval_checks(&revs.repo, &revs.head)?;
+    // The base and head evals are independent (read-only against the git and
+    // nix stores), and each is a separate 8-worker nix-eval-jobs run, so
+    // overlapping them stays inside the 16-worker envelope the check gate
+    // already runs on this host (lib/per-system.nix) and halves the dominant
+    // cost of a report: the two full-catalog evals were ~95s each, back to
+    // back, on a warm store.
+    let (base, head) = std::thread::scope(|scope| {
+        let base = scope.spawn(|| nix::eval_checks(&revs.repo, &revs.base));
+        let head = nix::eval_checks(&revs.repo, &revs.head);
+        let base = base
+            .join()
+            .unwrap_or_else(|panic| std::panic::resume_unwind(panic));
+        (base, head)
+    });
+    // Base error first: it matches the old sequential precedence when both fail.
+    let base = base?;
+    let head = head?;
     guard_eval_failures(&base, &head)?;
     let base = base.checks;
     let head = head.checks;


### PR DESCRIPTION
Every blast-radius report pays two sequential full evaluations of `.#checks.x86_64-linux` (~95s each on a warm store with `--workers 8`): a docs-only PR that rebuilds nothing still spent 189s in the eval step (run 26993318380). The two evals are independent, read-only against the git and nix stores, so this runs the base eval on a scoped thread while head evaluates on the main one.

Combined they spawn 16 eval workers, the same envelope the check gate already runs on this host (`lib/per-system.nix` measured 342s at 1 worker, 75s at 16 for one full eval), so this should roughly halve the dominant cost of every report without changing memory posture.

Error precedence is preserved: when both revs fail to evaluate, the base error still surfaces first. Panics on the eval thread are re-raised via `resume_unwind`.

Context: blast-radius runs on June 2-3 averaged 11-14 minutes (nushell-era tool plus IFD-cold storms, two runs queued 2h+ for a runner, several killed at the 30-minute timeout with the base eval alone taking 19 minutes). The Rust rewrite (#676) brought the baseline to ~2.5 minutes; this takes the steady-state eval portion from ~190s toward ~100s. Reusing the base eval across runs and failing fast on a cold IFD closure are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run base and head evaluations concurrently in blast-radius
> Spawns a thread for the base `nix::eval_checks` call while the head evaluation runs on the main thread, then joins the thread afterward. If both evaluations fail, the base error is surfaced first to preserve previous precedence. Panics from the base thread are rethrown on the main thread after joining.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb17d5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->