### PR TITLE
feat(indexer): source-parquet — replay the Parquet corpus log into Mixedbread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2802,6 +2802,7 @@ dependencies = [
  "source-linear",
  "source-meta",
  "source-otlp",
+ "source-parquet",
  "source-slack",
  "tempfile",
  "tokio",
@@ -3431,28 +3432,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "vmkit"
-version = "0.1.0"
-dependencies = [
- "base64",
- "block2",
- "clap",
- "dashboard-core",
- "dispatch2",
- "image",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
- "objc2-io-surface",
- "objc2-quartz-core",
- "objc2-virtualization",
- "serde",
- "serde_json",
- "snafu 0.8.9",
- "tokio",
 ]
 
 [[package]]
@@ -5838,6 +5817,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "source-parquet"
+version = "0.1.0"
+dependencies = [
+ "arrow",
+ "futures",
+ "object_store",
+ "parquet",
+ "serde_json",
+ "snafu 0.9.1",
+ "source-meta",
+ "tokio",
+]
+
+[[package]]
 name = "source-slack"
 version = "0.1.0"
 dependencies = [
@@ -7092,6 +7085,28 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vmkit"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "block2",
+ "clap",
+ "dashboard-core",
+ "dispatch2",
+ "image",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-io-surface",
+ "objc2-quartz-core",
+ "objc2-virtualization",
+ "serde",
+ "serde_json",
+ "snafu 0.8.9",
+ "tokio",
+]
 
 [[package]]
 name = "vt100"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
   "packages/search-core",
   "packages/source/meta",
   "packages/source/otlp",
+  "packages/source/parquet",
   "packages/search-py",
   "packages/skill-lint",
   "packages/source/slack",
@@ -192,6 +193,7 @@ sha2 = "0.10"
 similar = "2"
 source-slack = { path = "packages/source/slack" }
 source-otlp = { path = "packages/source/otlp" }
+source-parquet = { path = "packages/source/parquet" }
 sink-mixedbread = { path = "packages/sink/mixedbread" }
 sink-otlp = { path = "packages/sink/otlp" }
 sink-parquet = { path = "packages/sink/parquet" }

--- a/packages/indexer/Cargo.toml
+++ b/packages/indexer/Cargo.toml
@@ -23,6 +23,7 @@ source-slack.workspace = true
 source-linear.workspace = true
 source-github.workspace = true
 source-otlp.workspace = true
+source-parquet.workspace = true
 search-core.workspace = true
 sink-mixedbread.workspace = true
 sink-parquet.workspace = true

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -13,8 +13,10 @@
 //!   [`sink_parquet`].
 //! - Code repos go direct to Mixedbread only.
 //!
-//! Consume mode (`--from-otlp-prefix`) reads the collector's S3 archive and
-//! reconciles it into Mixedbread, the consumer half of the bus.
+//! Consume mode reconciles a durable corpus log back into Mixedbread rather than
+//! scanning local sources: `--from-otlp-prefix` reads the collector's S3 archive
+//! (the consumer half of the bus), and `--from-parquet-prefix` reads the parquet
+//! corpus log `sink-parquet` wrote (the consumer half of that log).
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -77,6 +79,14 @@ struct Cli {
     /// sources; pair with `--mixedbread-store` and `--bucket`.
     #[arg(long, env = "INDEXER_FROM_OTLP_PREFIX")]
     from_otlp_prefix: Option<String>,
+
+    /// Rebuild the Mixedbread index from the Parquet corpus log at this prefix;
+    /// pair with --mixedbread-store and --bucket. Reads the per-source
+    /// `data.parquet` files `sink-parquet` wrote (the other half of the parquet
+    /// corpus log) and reconciles every record back into Mixedbread, rather than
+    /// scanning local sources.
+    #[arg(long, env = "INDEXER_FROM_PARQUET_PREFIX")]
+    from_parquet_prefix: Option<String>,
 
     /// Index local agent/shell history (claude, codex, atuin) at their default
     /// paths, in addition to any explicit `--*` overrides below.
@@ -185,7 +195,25 @@ async fn main() -> anyhow::Result<()> {
             region: cli.region.clone(),
             prefix,
         };
-        return finish(run_consume(&config, mixedbread).await);
+        return finish(consume_otlp(&config, mixedbread).await);
+    }
+
+    // Consume mode (parquet corpus log): read the per-source `data.parquet` files
+    // `sink-parquet` wrote at this prefix under `--bucket` and reconcile them back
+    // into Mixedbread. Uses the SAME bucket/endpoint/region the parquet sink uses,
+    // so it reads exactly what was written. Like the OTLP consume path, this
+    // reconciles the log rather than scanning local sources.
+    if let Some(prefix) = cli.from_parquet_prefix.clone() {
+        let mixedbread = mixedbread
+            .context("--from-parquet-prefix requires --mixedbread-store (the reconcile target)")?;
+        let bucket = cli.bucket.clone().context("--from-parquet-prefix requires --bucket")?;
+        let config = source_parquet::Config {
+            bucket,
+            endpoint: cli.endpoint.clone(),
+            region: cli.region.clone(),
+            prefix,
+        };
+        return finish(consume_parquet(&config, mixedbread).await);
     }
 
     let parquet = match cli.bucket.as_ref() {
@@ -392,22 +420,40 @@ impl SourceAdapter for VecSource {
     }
 }
 
-/// Consume mode: read the collector's OTLP archive, group the records by their
-/// `source`, and reconcile each group into Mixedbread. Grouping keeps each
-/// Mixedbread reconcile scoped to one source, exactly as the direct per-source
-/// ingestion did, so a consumed record dedups against its own source and never
-/// touches another's.
-async fn run_consume(config: &source_otlp::Config, mixedbread: Mixedbread<'_>) -> Counts {
-    let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
+/// Consume the OTLP archive: read the collector's OTLP/JSON objects into
+/// documents, then reconcile them into Mixedbread via [`run_consume`].
+async fn consume_otlp(config: &source_otlp::Config, mixedbread: Mixedbread<'_>) -> Counts {
     let documents = match source_otlp::read_documents(config).await {
         Ok(documents) => documents,
         Err(error) => {
             eprintln!("[consume] failed to read the OTLP archive: {error:#}");
-            counts.failures += 1;
-            return counts;
+            return Counts { indexed: 0, skipped: 0, failures: 1 };
         }
     };
+    run_consume(documents, mixedbread).await
+}
 
+/// Consume the parquet corpus log: read the per-source `data.parquet` files into
+/// documents, then reconcile them into Mixedbread via [`run_consume`].
+async fn consume_parquet(config: &source_parquet::Config, mixedbread: Mixedbread<'_>) -> Counts {
+    let documents = match source_parquet::read_documents(config).await {
+        Ok(documents) => documents,
+        Err(error) => {
+            eprintln!("[consume] failed to read the parquet corpus log: {error:#}");
+            return Counts { indexed: 0, skipped: 0, failures: 1 };
+        }
+    };
+    run_consume(documents, mixedbread).await
+}
+
+/// Reconcile already-read documents into Mixedbread, grouped by their `source`.
+///
+/// Grouping keeps each Mixedbread reconcile scoped to one source, exactly as the
+/// direct per-source ingestion did, so a consumed record dedups against its own
+/// source and never touches another's. Both the OTLP and parquet consume paths
+/// read their documents first, then share this reconcile.
+async fn run_consume(documents: Vec<Document>, mixedbread: Mixedbread<'_>) -> Counts {
+    let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
     let mut by_source: BTreeMap<String, Vec<Document>> = BTreeMap::new();
     for document in documents {
         let source = document

--- a/packages/source/parquet/Cargo.toml
+++ b/packages/source/parquet/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "source-parquet"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Read the S3/R2 parquet corpus log written by sink-parquet back into search Documents"
+
+[lints]
+workspace = true
+
+[dependencies]
+source-meta.workspace = true
+object_store = { workspace = true, features = ["aws"] }
+futures.workspace = true
+serde_json.workspace = true
+snafu.workspace = true
+parquet = { workspace = true, features = ["arrow"] }
+arrow.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/packages/source/parquet/package.nix
+++ b/packages/source/parquet/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "source-parquet";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/source/parquet/src/lib.rs
+++ b/packages/source/parquet/src/lib.rs
@@ -151,6 +151,10 @@ pub async fn read_documents(config: &Config) -> Result<Vec<Document>> {
 /// Lists `<prefix>` and, for each object whose key ends in `/data.parquet`,
 /// fetches the bytes and parses them. The `_manifest.json` sidecar and any other
 /// object under the prefix are skipped.
+///
+/// # Errors
+/// Returns an error if the store cannot be listed, an object cannot be read, or a
+/// data file cannot be parsed as the corpus parquet schema.
 pub async fn read_from_store(store: &dyn ObjectStore, prefix: &str) -> Result<Vec<Document>> {
     let mut documents = Vec::new();
     let mut listing = store.list(Some(&ObjectPath::from(prefix)));

--- a/packages/source/parquet/src/lib.rs
+++ b/packages/source/parquet/src/lib.rs
@@ -1,0 +1,355 @@
+//! Read the S3/R2 parquet corpus log written by `sink-parquet` back into search
+//! [`Document`]s.
+//!
+//! This is the consumer half of the parquet corpus log. The `sink-parquet`
+//! sink writes one flat parquet file per source at
+//! `<prefix>/source=<source>/data.parquet`, with a sibling
+//! `<prefix>/source=<source>/_manifest.json`; this crate lists that prefix,
+//! reads each `data.parquet`, and reconstructs the [`Document`]s so the indexer
+//! can rebuild the Mixedbread search index from the log. It mirrors
+//! `source-otlp` (the OTLP-bus consumer): same `Config`, same
+//! `read_documents` / `read_from_store` shape, same `build_store`.
+//!
+//! # What is read
+//! The sink's `meta_json` column already holds the FULL metadata object as a
+//! JSON string, so a [`Document`] is reconstructed from just four columns:
+//! `external_id`, `content_hash`, `body`, and `meta_json`. The other columns
+//! (`source`, `title`, `url`, `host`, `timestamp`) are projections out of
+//! `meta_json` for queryability, so they are ignored on read. Only objects whose
+//! key ends in `/data.parquet` are parsed; the `_manifest.json` sidecar and any
+//! other object under the prefix are skipped.
+//!
+//! Known limitation: this lists the whole prefix and materializes every row each
+//! run, matching `source-otlp`. An incremental cursor is a future refinement,
+//! not a correctness issue.
+
+#![forbid(unsafe_code)]
+
+use arrow::array::{Array as _, StringArray};
+use arrow::record_batch::RecordBatch;
+use futures::stream::StreamExt as _;
+use object_store::aws::{AmazonS3, AmazonS3Builder};
+use object_store::path::Path as ObjectPath;
+use object_store::{ObjectStore, ObjectStoreExt as _};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use snafu::{OptionExt as _, ResultExt as _, Snafu};
+use source_meta::Document;
+
+/// The object name `sink-parquet` writes for each source's data file. Only
+/// objects with this suffix are parsed; the `_manifest.json` sidecar and any
+/// other key under the prefix are skipped.
+const DATA_SUFFIX: &str = "/data.parquet";
+
+/// The four columns a [`Document`] is reconstructed from. The rest of
+/// `sink-parquet`'s schema is a projection out of `meta_json`, so it is ignored
+/// on read.
+const COL_EXTERNAL_ID: &str = "external_id";
+const COL_CONTENT_HASH: &str = "content_hash";
+const COL_BODY: &str = "body";
+const COL_META_JSON: &str = "meta_json";
+
+/// Connection and layout for reading the parquet corpus log.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Bucket the parquet sink writes to.
+    pub bucket: String,
+    /// S3 endpoint URL. `None` uses AWS S3; for a self-hosted store pass its endpoint.
+    pub endpoint: Option<String>,
+    /// Region (`auto` for non-AWS stores).
+    pub region: String,
+    /// Key prefix under the bucket to read parquet objects from.
+    pub prefix: String,
+}
+
+/// Failures from the parquet reader.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum Error {
+    /// The S3 client could not be built from the config and environment.
+    #[snafu(display("failed to build the S3 client for bucket {bucket}"))]
+    BuildStore {
+        /// Bucket the client targeted.
+        bucket: String,
+        /// Underlying object-store error.
+        source: object_store::Error,
+    },
+    /// Listing the prefix failed.
+    #[snafu(display("failed to list parquet objects under {prefix}"))]
+    List {
+        /// Prefix being listed.
+        prefix: String,
+        /// Underlying object-store error.
+        source: object_store::Error,
+    },
+    /// An object could not be read.
+    #[snafu(display("failed to read parquet object {key}"))]
+    Get {
+        /// Object key.
+        key: String,
+        /// Underlying object-store error.
+        source: object_store::Error,
+    },
+    /// A parquet object could not be opened (bad footer/metadata).
+    #[snafu(display("failed to open parquet object {key}"))]
+    Parquet {
+        /// Object key.
+        key: String,
+        /// Underlying parquet error.
+        source: parquet::errors::ParquetError,
+    },
+    /// A parquet object's record batches could not be decoded.
+    #[snafu(display("failed to decode parquet object {key}"))]
+    Decode {
+        /// Object key.
+        key: String,
+        /// Underlying arrow error.
+        source: arrow::error::ArrowError,
+    },
+    /// A required column was absent from a parquet object's schema.
+    #[snafu(display("parquet object {key} is missing the required column {column}"))]
+    MissingColumn {
+        /// Object key.
+        key: String,
+        /// Name of the absent column.
+        column: &'static str,
+    },
+    /// A required column was present but not the expected `Utf8` type.
+    #[snafu(display("parquet object {key} column {column} is not a string column"))]
+    ColumnType {
+        /// Object key.
+        key: String,
+        /// Name of the mis-typed column.
+        column: &'static str,
+    },
+    /// A row's `meta_json` string did not parse as JSON.
+    #[snafu(display("failed to parse meta_json in parquet object {key}"))]
+    MetaJson {
+        /// Object key.
+        key: String,
+        /// Underlying serde error.
+        source: serde_json::Error,
+    },
+}
+
+/// Result alias defaulting to this crate's [`Error`].
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Read every parquet object under the configured prefix and reconstruct the
+/// corpus documents they carry.
+///
+/// # Errors
+/// Returns an error if the client cannot be built, the prefix cannot be listed,
+/// or any object cannot be read, decoded, or reconstructed.
+pub async fn read_documents(config: &Config) -> Result<Vec<Document>> {
+    let store = build_store(config)?;
+    read_from_store(&store, &config.prefix).await
+}
+
+/// The store-agnostic core of [`read_documents`], so tests can drive an
+/// in-memory store.
+///
+/// Lists `<prefix>` and, for each object whose key ends in `/data.parquet`,
+/// fetches the bytes and parses them. The `_manifest.json` sidecar and any other
+/// object under the prefix are skipped.
+pub async fn read_from_store(store: &dyn ObjectStore, prefix: &str) -> Result<Vec<Document>> {
+    let mut documents = Vec::new();
+    let mut listing = store.list(Some(&ObjectPath::from(prefix)));
+    while let Some(entry) = listing.next().await {
+        let meta = entry.context(ListSnafu { prefix })?;
+        let key = meta.location.to_string();
+        // Only the per-source data files are corpus parquet; the `_manifest.json`
+        // sidecar (and anything else) under the prefix is not, so skip it.
+        if !key.ends_with(DATA_SUFFIX) {
+            continue;
+        }
+        let result = store.get(&meta.location).await.context(GetSnafu { key: key.clone() })?;
+        let bytes = result.bytes().await.context(GetSnafu { key: key.clone() })?;
+        parse_parquet(bytes, &key, &mut documents)?;
+    }
+    Ok(documents)
+}
+
+/// Build the S3 client. Credentials come from the environment
+/// (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`).
+fn build_store(config: &Config) -> Result<AmazonS3> {
+    let mut builder =
+        AmazonS3Builder::from_env().with_bucket_name(&config.bucket).with_region(&config.region);
+    if let Some(endpoint) = &config.endpoint {
+        builder = builder.with_endpoint(endpoint);
+    }
+    builder.build().context(BuildStoreSnafu { bucket: config.bucket.clone() })
+}
+
+/// Parse one parquet object's record batches into documents, appending to `out`.
+///
+/// `object_store`'s `Bytes` is a valid [`ChunkReader`](parquet::file::reader::ChunkReader),
+/// so the reader builds directly off the in-memory bytes with no temp file. Taking
+/// any `ChunkReader` keeps this off a direct `bytes` dependency.
+fn parse_parquet<R>(data: R, key: &str, out: &mut Vec<Document>) -> Result<()>
+where
+    R: parquet::file::reader::ChunkReader + 'static,
+{
+    let reader = ParquetRecordBatchReaderBuilder::try_new(data)
+        .context(ParquetSnafu { key })?
+        .build()
+        .context(ParquetSnafu { key })?;
+    for batch in reader {
+        let batch = batch.context(DecodeSnafu { key })?;
+        documents_from_batch(&batch, key, out)?;
+    }
+    Ok(())
+}
+
+/// Reconstruct one record batch's rows into documents.
+///
+/// Only the four identity/content columns are read; the rest of the sink schema
+/// is a projection out of `meta_json`, so it is ignored. A missing or mis-typed
+/// required column is a typed error, never a silent default.
+fn documents_from_batch(batch: &RecordBatch, key: &str, out: &mut Vec<Document>) -> Result<()> {
+    let external_id = string_column(batch, COL_EXTERNAL_ID, key)?;
+    let content_hash = string_column(batch, COL_CONTENT_HASH, key)?;
+    let body = string_column(batch, COL_BODY, key)?;
+    let meta_json = string_column(batch, COL_META_JSON, key)?;
+
+    out.reserve(batch.num_rows());
+    for row in 0..batch.num_rows() {
+        // All four columns are non-nullable in the sink schema, so `value(row)`
+        // is always a real value (a null would be a malformed log, but the sink
+        // never writes one). `meta_json` is the full metadata object as a string.
+        let meta_str = meta_json.value(row);
+        let meta = serde_json::from_str(meta_str).context(MetaJsonSnafu { key })?;
+        out.push(Document {
+            external_id: external_id.value(row).to_owned(),
+            file_name: external_id.value(row).to_owned(),
+            mime: "text/plain",
+            body: body.value(row).to_owned().into_bytes(),
+            meta_json: meta,
+            content_hash: content_hash.value(row).to_owned(),
+        });
+    }
+    Ok(())
+}
+
+/// Borrow one column as a `StringArray`, erroring (never defaulting) when the
+/// column is absent or not a `Utf8` array.
+fn string_column<'a>(
+    batch: &'a RecordBatch,
+    column: &'static str,
+    key: &str,
+) -> Result<&'a StringArray> {
+    let array =
+        batch.column_by_name(column).context(MissingColumnSnafu { key, column })?;
+    array.as_any().downcast_ref::<StringArray>().context(ColumnTypeSnafu { key, column })
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::expect_used, reason = "tests assert observable parse outcomes")]
+
+    use std::sync::Arc;
+
+    use arrow::array::{Int64Array, RecordBatch, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use object_store::ObjectStoreExt as _;
+    use object_store::memory::InMemory;
+    use object_store::path::Path as ObjectPath;
+    use parquet::arrow::ArrowWriter;
+    use serde_json::json;
+
+    use super::read_from_store;
+
+    /// The exact flat schema `sink-parquet` writes (kept in lockstep with its
+    /// `schema()`), so this test round-trips the real on-disk shape.
+    fn sink_schema() -> Schema {
+        let text = |name: &str, nullable: bool| Field::new(name, DataType::Utf8, nullable);
+        Schema::new(vec![
+            text("external_id", false),
+            text("source", false),
+            text("content_hash", false),
+            text("title", true),
+            text("url", true),
+            text("host", true),
+            Field::new("timestamp", DataType::Int64, true),
+            text("body", false),
+            text("meta_json", false),
+        ])
+    }
+
+    /// Build a 2-row parquet object in the exact sink layout, via arrow arrays +
+    /// `ArrowWriter`, exactly as `sink-parquet::encode_parquet` does.
+    fn encode_two_rows() -> Vec<u8> {
+        let meta_a = json!({
+            "source": "test", "external_id": "a", "content_hash": "sha256:aaa",
+            "title": "title a", "timestamp": 100,
+        });
+        let meta_b = json!({
+            "source": "test", "external_id": "b", "content_hash": "sha256:bbb",
+            "title": "title b", "timestamp": 200,
+        });
+        let columns: Vec<arrow::array::ArrayRef> = vec![
+            Arc::new(StringArray::from(vec!["a", "b"])),
+            Arc::new(StringArray::from(vec!["test", "test"])),
+            Arc::new(StringArray::from(vec!["sha256:aaa", "sha256:bbb"])),
+            Arc::new(StringArray::from(vec![Some("title a"), Some("title b")])),
+            Arc::new(StringArray::from(vec![None::<&str>, None::<&str>])),
+            Arc::new(StringArray::from(vec![None::<&str>, None::<&str>])),
+            Arc::new(Int64Array::from(vec![Some(100), Some(200)])),
+            Arc::new(StringArray::from(vec!["alpha", "beta"])),
+            Arc::new(StringArray::from(vec![meta_a.to_string(), meta_b.to_string()])),
+        ];
+        let batch =
+            RecordBatch::try_new(Arc::new(sink_schema()), columns).expect("build record batch");
+        let mut buffer = Vec::new();
+        let mut writer =
+            ArrowWriter::try_new(&mut buffer, batch.schema(), None).expect("arrow writer");
+        writer.write(&batch).expect("write batch");
+        writer.close().expect("close writer");
+        buffer
+    }
+
+    #[tokio::test]
+    async fn reads_data_parquet_and_skips_manifest() {
+        let store = InMemory::new();
+        store
+            .put(&ObjectPath::from("corpus/source=test/data.parquet"), encode_two_rows().into())
+            .await
+            .expect("put data");
+        // A sibling manifest must be skipped, not parsed as parquet.
+        store
+            .put(
+                &ObjectPath::from("corpus/source=test/_manifest.json"),
+                serde_json::to_vec(&json!({ "content_hash": "sha256:aaa" }))
+                    .expect("serialize manifest")
+                    .into(),
+            )
+            .await
+            .expect("put manifest");
+
+        let mut docs = read_from_store(&store, "corpus").await.expect("read");
+        docs.sort_by(|a, b| a.external_id.cmp(&b.external_id));
+        assert_eq!(docs.len(), 2, "exactly the two parquet rows, manifest skipped");
+
+        let a = &docs[0];
+        assert_eq!(a.external_id, "a");
+        assert_eq!(a.content_hash, "sha256:aaa");
+        assert_eq!(a.body, b"alpha");
+        assert_eq!(a.mime, "text/plain");
+        // meta_json is reconstructed whole from the column, source extras intact.
+        assert_eq!(a.meta_json["source"], "test");
+        assert_eq!(a.meta_json["title"], "title a");
+        assert_eq!(a.meta_json["timestamp"], 100);
+
+        let b = &docs[1];
+        assert_eq!(b.external_id, "b");
+        assert_eq!(b.content_hash, "sha256:bbb");
+        assert_eq!(b.body, b"beta");
+        assert_eq!(b.meta_json["title"], "title b");
+    }
+
+    #[tokio::test]
+    async fn empty_prefix_yields_no_documents() {
+        let store = InMemory::new();
+        let docs = read_from_store(&store, "corpus").await.expect("read");
+        assert!(docs.is_empty());
+    }
+}


### PR DESCRIPTION
First step of #736: make the existing Parquet corpus log (`sink-parquet`) replayable into the Mixedbread search index, so the index becomes a materialized view you can rebuild from the log.

- New crate `source-parquet`: the read half of the Parquet corpus log, mirroring `source-otlp`. Lists `<prefix>/source=*/data.parquet`, reconstructs `Document`s from the `external_id`/`content_hash`/`body`/`meta_json` columns (the rest are `meta_json` projections). Missing/mis-typed columns are typed errors, never silent defaults. In-memory round-trip test included.
- Indexer: `--from-parquet-prefix` consume mode; `run_consume` refactored to take `Vec<Document>` so the otlp and parquet consume paths share one reconcile (otlp path unchanged).

Additive and safe (no deletions). Removing the OTLP corpus path and demoting OTel to telemetry-only is the next PR on #736.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `source-parquet` crate to replay the Parquet corpus log into Mixedbread
> - Introduces a new `source-parquet` crate ([lib.rs](https://github.com/indexable-inc/index/pull/738/files#diff-ddcd5814aadef30562feae49e63c1ca92e8388df2e8dca7a57f3f916c2fe35b0)) that reads `data.parquet` files from an S3 prefix, reconstructs `Document` instances from required columns (`external_id`, `content_hash`, `body`, `meta_json`), and exposes a `read_documents` API.
> - Extends the indexer CLI ([main.rs](https://github.com/indexable-inc/index/pull/738/files#diff-5664bac77cedfa678d477bb44bf07a8888bdbb1eb15055f1c164d6c9c131ce7d)) with `--from-parquet-prefix` (`INDEXER_FROM_PARQUET_PREFIX`); when set, the process reads the parquet corpus log and reconciles it into Mixedbread, then exits.
> - Refactors `run_consume` to accept a `Vec<Document>` so both the OTLP and new parquet paths share the same reconciliation logic via `consume_otlp` and `consume_parquet` helpers.
> - Behavioral Change: the OTLP consume path now goes through `consume_otlp` instead of calling `run_consume` directly; error log text changes slightly but reconciliation semantics are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d41c63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->