### PR TITLE
feat(ix-fleet): push images via the SDK (image_push)

### DIFF
--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -335,18 +335,22 @@ async def wait_node_ready(node: FleetNode, *, dry_run: bool) -> None:
 
 async def push_replacement_image(node: FleetNode, *, dry_run: bool) -> str:
     image = node.replacementImage
-    source = image.source
-    if not dry_run:
-        out = await run_cli(["nix-store", "--realise", image.sourceDrv], dry_run=False)
-        realised = [line.strip() for line in out.splitlines() if line.strip()]
-        if realised:
-            source = realised[-1]
-        if not Path(source).exists():
-            raise RuntimeError(f"OCI image derivation did not realise to an existing path: {source}")
+    if dry_run:
+        step(f"+ realise {image.sourceDrv} and image push -> {image.destination}")
+        return image.destination
 
-    out = await run_cli(["ix", "image", "push", source, image.destination], dry_run=dry_run)
-    refs = [line.strip() for line in out.splitlines() if line.strip()]
-    return refs[-1] if refs else image.destination
+    # Realising the OCI image is host-side nix work; the push itself goes through
+    # the SDK (sdk-core owns the chunk/dedup/upload pipeline).
+    source = image.source
+    out = await run_cli(["nix-store", "--realise", image.sourceDrv], dry_run=False)
+    realised = [line.strip() for line in out.splitlines() if line.strip()]
+    if realised:
+        source = realised[-1]
+    if not Path(source).exists():
+        raise RuntimeError(f"OCI image derivation did not realise to an existing path: {source}")
+
+    step(f"pushing {image.destination} from {source}")
+    return await client().image_push(source, image.destination, region=node.region)
 
 
 async def list_nodes() -> list[ix_sdk.BranchInfo]:

--- a/packages/ix-sdk-python/default.nix
+++ b/packages/ix-sdk-python/default.nix
@@ -22,8 +22,8 @@ let
   # entry is added once that lands.
   catalog = {
     x86_64-linux = {
-      url = "https://pub-c52bf5a1e3db4628aaf57fe94cb5de10.r2.dev/wheel/ix-sdk/w3mxsrmhkgvbgfg9nq9d408sa1xqfb7y/ix_sdk-0.1.0-cp313-abi3-manylinux_2_34_x86_64.whl";
-      hash = "sha256-UhhiTB/vy6y2UZAx/z19KxkUKyKscxEJcPeYWVgQp0I=";
+      url = "https://pub-c52bf5a1e3db4628aaf57fe94cb5de10.r2.dev/wheel/ix-sdk/i8isn1mld0vilr6prxd283kkq2pk8q02/ix_sdk-0.1.0-cp313-abi3-manylinux_2_34_x86_64.whl";
+      hash = "sha256-SiLtLWRzUT+++6+M0WlPqMB/0Dca7iJRU075uajw7Rg=";
     };
   };
 


### PR DESCRIPTION
ix-fleet now pushes replacement images through the SDK (`client.image_push`) instead of shelling out to `ix image push`. The OCI push pipeline moved into sdk-core in ix#4280; the nix-store realise stays host-side.

Also bumps the `ix-sdk-python` R2 wheel catalog to the build from ix main that carries `image_push`.

Validated on x86_64-linux: `.#ix-sdk-python` import test, `.#ix-fleet` (ty check), and the ix-fleet dry-run smoke test all build; the wheel exposes `Client.image_push`.

With this, ix-fleet uses the ix SDK for every fleet operation except `switch --source` (host-side nix build orchestration, a separate follow-up).

Made with AI (Claude Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Push images via SDK in `ix_fleet.push_replacement_image` instead of CLI
> - Replaces the `ix image push` CLI invocation in [`push_replacement_image`](https://github.com/indexable-inc/index/pull/739/files#diff-d83777ed2e90ee1f7371ffa0e55fe375c817b07e2cb2a15a5b58423ad93dae3e) with a direct `client().image_push(source, destination, region=node.region)` SDK call.
> - When `dry_run=True`, the function now skips both nix-store realisation and the push entirely, logging and returning the destination immediately.
> - Updates the `ix_sdk` wheel URL and hash in [`default.nix`](https://github.com/indexable-inc/index/pull/739/files#diff-80f46c8d1744ebc070c811611b94e45d792b24cdeeae53fcaf78e4db15945032) to provide the SDK version that supports `image_push`.
> - Behavioral Change: the return value is now the SDK call result string rather than the last line of CLI output; `dry_run=True` no longer runs nix-store realisation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 411132e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->