### PR TITLE
fix(blast-radius): cap comment body and wire base-branch timings

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -43,9 +43,15 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      # Read-only: lets `gh run download` fetch the base-branch check-timings
+      # artifact from the most recent successful main Check run (best-effort
+      # build-time annotations). No write scope is introduced.
+      actions: read
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       HEAD_SHA: ${{ github.sha }}
+      REPOSITORY: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       # The default pull_request checkout is the merge ref, so its working tree
       # already carries this PR's `.#blast-radius` app, and fetch-depth 0 brings
@@ -58,14 +64,40 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Best-effort: download the most recent successful main Check run's
+      # check-timings artifact (the nix-fast-build --result-file the `check` gate
+      # uploads; see lib/per-system.nix). blast-radius --timings annotates each
+      # rebuilt check with its base-branch BUILD wall-clock. Every failure path
+      # (no run, no artifact, gh error) leaves no check-results.json, so the next
+      # step renders without timings rather than failing the job. This step never
+      # exits nonzero.
+      - name: Fetch base-branch check timings
+        run: |
+          set -uo pipefail
+          run_id="$(gh run list --repo "${REPOSITORY}" --workflow Check --branch main \
+                      --status success --limit 1 --json databaseId \
+                      --jq '.[0].databaseId // empty' 2>/dev/null || true)"
+          if [ -z "${run_id}" ]; then
+            echo "no successful main Check run found; rendering without timings"
+            exit 0
+          fi
+          gh run download "${run_id}" --repo "${REPOSITORY}" \
+            --name "check-timings-${run_id}" --dir . 2>/dev/null \
+            || echo "check-timings-${run_id} unavailable; rendering without timings"
+
       # --json emits a constrained data object (counts + name lists), not the
       # final Markdown, so the trusted comment job owns the published body.
       # pipefail makes an eval failure (nonzero `nix run`) fail the step instead
-      # of being masked by tee's exit code.
+      # of being masked by tee's exit code. Pass --timings only when the base
+      # artifact was fetched above (the flag's input is optional in the tool).
       - name: Report blast radius
         run: |
           set -euo pipefail
-          nix run .#blast-radius -- --json "${BASE_SHA}" "${HEAD_SHA}" | tee report.json
+          if [ -f check-results.json ]; then
+            nix run .#blast-radius -- --json --timings check-results.json "${BASE_SHA}" "${HEAD_SHA}" | tee report.json
+          else
+            nix run .#blast-radius -- --json "${BASE_SHA}" "${HEAD_SHA}" | tee report.json
+          fi
 
       - name: Upload report
         if: ${{ success() }}
@@ -190,12 +222,35 @@ jobs:
                    | "  c\($c.key) --> k\($checks | index($k))[\"\($k | safename)\($t[$k] | fmt_time)\"]"),
                   "```"
              else empty end),
-            (if (.changed | length) > 0
-             then "", "<details><summary>changed checks</summary>", "",
-                  (.changed[] | safename as $n | "- \($n)\($t[$n] | fmt_time)"),
-                  "", "</details>"
-             else empty end)
+            # Cap the changed-checks list so the comment cannot exceed the GitHub
+            # 65536-char body limit (HTTP 422 "Body is too long"). A PR touching
+            # a shared input rebuilds thousands of checks; the header and bounded
+            # mermaid diagrams carry the signal, the summary shows the true total,
+            # and the full list lives in the run artifact and logs. Mirrors
+            # packages/blast-radius/src/report.rs (CHANGED_LIST_CAP). (Keep this
+            # jq apostrophe-free: it is single-quoted in the shell.)
+            (200 as $cap
+             | if (.changed | length) > 0
+               then "", "<details><summary>changed checks (\(.changed | length))</summary>", "",
+                    (.changed[0:$cap][] | safename as $n | "- \($n)\($t[$n] | fmt_time)"),
+                    (if (.changed | length) > $cap
+                     then "- ...and \((.changed | length) - $cap) more (see the Blast radius check logs)"
+                     else empty end),
+                    "", "</details>"
+               else empty end)
           ' report.json > comment.md
+          # Final hard guard against GitHub's 65536-char comment-body limit. The
+          # changed-checks cap covers the common case, but the mermaid sections
+          # are bounded only by the PR-controlled report, so a pathological shape
+          # could still overflow. Truncate on a byte boundary (the marker the
+          # post job keys on is at the TOP, so a tail truncation leaves it
+          # intact) and append a notice.
+          max_bytes=65000
+          if [ "$(wc -c < comment.md)" -gt "${max_bytes}" ]; then
+            head -c "${max_bytes}" comment.md > comment.md.trunc
+            mv comment.md.trunc comment.md
+            printf '\n\n_Comment truncated to fit the GitHub comment size limit._\n' >> comment.md
+          fi
 
       # One sticky comment per PR, keyed by the `<!-- blast-radius -->` marker.
       # Paginate the comment list so the marker is found on busy PRs (no

--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -26,10 +26,12 @@ env:
     accept-flake-config = true
 
 jobs:
-  # Untrusted half: runs this PR's own `.#blast-radius` flake code. It holds no
-  # write token and no secrets, so PR-authored code cannot reach a privileged
-  # credential or poison a later token-backed step in the same job. The report
-  # leaves this job only as an artifact (plain data) for the comment job.
+  # Untrusted half: runs this PR's own `.#blast-radius` flake code. It holds only
+  # a read-only token (contents + actions: read), and that token is scoped to the
+  # timings-fetch step alone -- never the env of the PR-code "Report blast radius"
+  # step -- so PR-authored code cannot reach a credential or poison a later
+  # token-backed step. The report leaves this job only as an artifact (plain
+  # data) for the comment job.
   evaluate:
     # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml).
     if: >-
@@ -50,14 +52,12 @@ jobs:
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       HEAD_SHA: ${{ github.sha }}
-      REPOSITORY: ${{ github.repository }}
-      GH_TOKEN: ${{ github.token }}
     steps:
       # The default pull_request checkout is the merge ref, so its working tree
       # already carries this PR's `.#blast-radius` app, and fetch-depth 0 brings
       # both parents (base.sha, head.sha) into the clone so the tool's
-      # `git merge-base` and the `?rev=<sha>` flake refs resolve. No write token
-      # is introduced anywhere in this job.
+      # `git merge-base` and the `?rev=<sha>` flake refs resolve. The only token
+      # in this job is the read-only one on the timings-fetch step below.
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -70,8 +70,12 @@ jobs:
       # rebuilt check with its base-branch BUILD wall-clock. Every failure path
       # (no run, no artifact, gh error) leaves no check-results.json, so the next
       # step renders without timings rather than failing the job. This step never
-      # exits nonzero.
+      # exits nonzero. The read-only token lives here, not at job level, so the
+      # PR-code "Report blast radius" step below never sees a credential.
       - name: Fetch base-branch check timings
+        env:
+          REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
           run_id="$(gh run list --repo "${REPOSITORY}" --workflow Check --branch main \

--- a/packages/blast-radius/src/main.rs
+++ b/packages/blast-radius/src/main.rs
@@ -169,7 +169,18 @@ fn main() -> Result<()> {
     };
 
     let timings = match cli.timings.as_deref() {
-        Some(path) => timings::load(path)?,
+        // Best-effort: a present-but-unreadable or corrupt timings file (a
+        // partial artifact download, an empty upload) must not fail the report
+        // and break the PR comment. The workflow already decides *whether* to
+        // pass --timings; if it does and the file is bad, warn and continue with
+        // no annotations rather than aborting.
+        Some(path) => timings::load(path).unwrap_or_else(|err| {
+            eprintln!(
+                "blast-radius: ignoring unreadable timings file {}: {err:?}",
+                path.display()
+            );
+            BTreeMap::new()
+        }),
         None => BTreeMap::new(),
     };
 

--- a/packages/blast-radius/src/main.rs
+++ b/packages/blast-radius/src/main.rs
@@ -168,21 +168,20 @@ fn main() -> Result<()> {
         root_causes(&base_graph, &head_graph, &changed_basenames, CAPS)
     };
 
-    let timings = match cli.timings.as_deref() {
-        // Best-effort: a present-but-unreadable or corrupt timings file (a
-        // partial artifact download, an empty upload) must not fail the report
-        // and break the PR comment. The workflow already decides *whether* to
-        // pass --timings; if it does and the file is bad, warn and continue with
-        // no annotations rather than aborting.
-        Some(path) => timings::load(path).unwrap_or_else(|err| {
+    // Best-effort: a present-but-unreadable or corrupt timings file (a partial
+    // artifact download, an empty upload) must not fail the report and break the
+    // PR comment. The workflow already decides *whether* to pass --timings; if it
+    // does and the file is bad, warn and continue with no annotations rather than
+    // aborting.
+    let timings = cli.timings.as_deref().map_or_else(BTreeMap::new, |path| {
+        timings::load(path).unwrap_or_else(|err| {
             eprintln!(
                 "blast-radius: ignoring unreadable timings file {}: {err:?}",
                 path.display()
             );
             BTreeMap::new()
-        }),
-        None => BTreeMap::new(),
-    };
+        })
+    });
 
     let report = Report {
         base: short(&revs.base),

--- a/packages/blast-radius/src/report.rs
+++ b/packages/blast-radius/src/report.rs
@@ -13,6 +13,15 @@ use serde::Serialize;
 
 use crate::causes::{Cause, category};
 
+/// Maximum number of changed-check bullets to render in the `<details>` list.
+/// A PR touching a shared input rebuilds thousands of checks (on ix, 3817 of
+/// 4315 once), and the uncapped list produced a ~300 KB body that GitHub
+/// rejected with HTTP 422 ("Body is too long", 65536-char limit), so no comment
+/// posted at all. The trusted jq renderer in `.github/workflows/blast-radius.yml`
+/// caps identically; the `<summary>` carries the true total and the full list
+/// lives in the run artifact and logs.
+pub const CHANGED_LIST_CAP: usize = 200;
+
 #[derive(Debug, Serialize)]
 pub struct Category {
     pub name: String,
@@ -175,9 +184,17 @@ impl Report {
         }
 
         if !self.changed.is_empty() {
-            out.push_str("\n<details><summary>changed checks</summary>\n\n");
-            for name in &self.changed {
+            let total = self.changed.len();
+            let _ = writeln!(out, "\n<details><summary>changed checks ({total})</summary>\n");
+            for name in self.changed.iter().take(CHANGED_LIST_CAP) {
                 let _ = writeln!(out, "- {}", label_for(name));
+            }
+            if total > CHANGED_LIST_CAP {
+                let _ = writeln!(
+                    out,
+                    "- ...and {} more (see the Blast radius check logs)",
+                    total - CHANGED_LIST_CAP
+                );
             }
             out.push_str("\n</details>\n");
         }
@@ -271,6 +288,25 @@ mod tests {
         // Changed-checks list mirrors the same annotation.
         assert!(md.contains("- mcp-serverTools (42s)\n"));
         assert!(md.contains("- lint\n"));
+    }
+
+    // A PR that rebuilds thousands of checks must not blow GitHub's 65536-char
+    // comment body limit: the list caps at CHANGED_LIST_CAP with an overflow
+    // note, while the summary still carries the true total. Mirrors the trusted
+    // jq renderer's cap (tools/blast-radius-test.sh asserts the same bound).
+    #[test]
+    fn caps_long_changed_list() {
+        let mut report = sample_report(BTreeMap::new());
+        report.changed = (0..4000).map(|i| format!("rust-test-crate-{i}")).collect();
+        let md = report.to_markdown();
+        assert!(md.contains("<summary>changed checks (4000)</summary>"));
+        let bullets = md
+            .lines()
+            .filter(|line| line.starts_with("- rust-test-crate-"))
+            .count();
+        assert_eq!(bullets, CHANGED_LIST_CAP);
+        assert!(md.contains(&format!("- ...and {} more", 4000 - CHANGED_LIST_CAP)));
+        assert!(md.len() < 65_536);
     }
 
     #[test]

--- a/tools/blast-radius-fixtures/good.expected.md
+++ b/tools/blast-radius-fixtures/good.expected.md
@@ -22,7 +22,7 @@ flowchart LR
   c0 --> k3["rust-test-search_core (2m)"]
 ```
 
-<details><summary>changed checks</summary>
+<details><summary>changed checks (4)</summary>
 
 - mcp-serverTools (42s)
 - rust-test-search_core (2m)

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -37,5 +37,56 @@ done
 ( cd "$tmp" && cp "$fixtures/good.json" report.json && bash render.sh )
 if diff -u "$fixtures/good.expected.md" "$tmp/comment.md"; then note "render good: ok"; else note "render good: FAIL (output drift)"; fail=1; fi
 
+# Overflow guard: a PR touching a shared input rebuilds thousands of checks, and
+# an uncapped changed-checks list overflows GitHub's 65536-char comment limit
+# (HTTP 422), so no comment posts. Synthesize a large report and assert the body
+# stays bounded with an "...and N more" note. Behavior assertion, not a re-spell
+# of the cap constant.
+big="$tmp/big.json"
+jq '.changed = [range(0; 4000) | "rust-test-crate-\(.)-unit-tests"]' "$fixtures/good.json" > "$big"
+( cd "$tmp" && cp "$big" report.json && bash render.sh )
+big_bytes="$(wc -c < "$tmp/comment.md")"
+if [ "$big_bytes" -lt 65536 ]; then
+  note "render overflow: body bounded (${big_bytes} B < 65536)"
+else
+  note "render overflow: FAIL (${big_bytes} B >= 65536)"; fail=1
+fi
+if grep -qE '^- \.\.\.and 3800 more ' "$tmp/comment.md"; then
+  note "render overflow: cap note ok"
+else
+  note "render overflow: FAIL (missing/incorrect cap note)"; fail=1
+fi
+if grep -q '<summary>changed checks (4000)</summary>' "$tmp/comment.md"; then
+  note "render overflow: total count ok"
+else
+  note "render overflow: FAIL (summary missing true total)"; fail=1
+fi
+
+# Backstop guard: the changed-checks cap does NOT bound the mermaid sections,
+# which the render sizes from the (PR-controlled) report's causes. A schema-valid
+# but pathological report with huge causes must still render under the limit via
+# the byte-budget backstop, and the leading marker (the post job keys the sticky
+# comment on it) must survive the tail truncation.
+huge="$tmp/huge.json"
+jq '
+  .changed = [] |
+  .causes = [range(0; 400) | {
+    name: "ix-rust-workspace-\(.)",
+    checks: [range(0; 5) | "rust-test-crate-\(.)-pads-the-body-out-to-exceed-the-limit-\(.)"]
+  }]
+' "$fixtures/good.json" > "$huge"
+( cd "$tmp" && cp "$huge" report.json && bash render.sh )
+huge_bytes="$(wc -c < "$tmp/comment.md")"
+if [ "$huge_bytes" -lt 65536 ]; then
+  note "render backstop: body bounded (${huge_bytes} B < 65536)"
+else
+  note "render backstop: FAIL (${huge_bytes} B >= 65536; backstop did not fire)"; fail=1
+fi
+if head -c 64 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
+  note "render backstop: marker survived truncation ok"
+else
+  note "render backstop: FAIL (marker lost; sticky-comment keying breaks)"; fail=1
+fi
+
 if [ "$fail" -ne 0 ]; then echo "blast-radius-test: FAILED"; exit 1; fi
 echo "blast-radius-test: all passed"


### PR DESCRIPTION
Two fixes to the blast-radius PR comment.

**1. Cap the comment body (overflow fix).** A PR touching a shared input rebuilds thousands of checks, and the uncapped changed-checks list overflows GitHub's 65536-char issue-comment limit (HTTP 422 "Body is too long"), so no comment posts. This is already biting the sibling ix repo, where a PR rebuilt 3817 of 4315 checks and produced a ~305 KB body. The fix caps the list at `CHANGED_LIST_CAP` (200) with a `...and N more` line, shows the true total in the `<details>` summary, and adds a byte-budget backstop for the (PR-controlled) mermaid sections. It also fixes the drift between `report.rs::to_markdown` (local `nix run`) and the trusted jq renderer, which the reviewer flagged.

**2. Wire `--timings` (include build times).** `lib/per-system.nix` already produces `check-results.json` and notes "blast-radius consumes this on a later PR via `--timings`". This is that PR: the evaluate job downloads the most recent successful main `Check` run's `check-timings` artifact and passes it to the tool, so each rebuilt check is annotated with its base-branch BUILD wall-clock (`(12s)`, `(2m)`). Best-effort: a missing run/artifact renders without timings and never fails the job. The evaluate job gains read-only `actions: read` for the artifact download.

`blast-radius-test` gains overflow + backstop assertions; `report.rs` gains a cap unit test. Verified the jq test suite locally and the crate compiles.

Made with Claude (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap blast-radius comment body and wire base-branch check timings in the workflow
> - The blast-radius workflow now best-effort fetches the latest check-timings artifact from `main` and passes it to the tool via `--timings`; if the artifact is missing or unreadable, the tool proceeds without timings instead of failing.
> - Changed-checks list in the Markdown report is capped at 200 entries (`CHANGED_LIST_CAP` in [report.rs](https://github.com/indexable-inc/index/pull/743/files#diff-2c62d3a5b277d0658a5553d55b62ab38ba2fe8e7e459d2d4910f85a98782dd93)); the `<summary>` shows the true total and an overflow note is appended when truncated.
> - A byte-size backstop in the workflow truncates [comment.md](https://github.com/indexable-inc/index/pull/743/files#diff-f18ec732b17d456a8d2f9c00a4941f9433314b97b8a3df9cea22bdaf15337468) to 65000 bytes if it exceeds GitHub's 65536-char limit, preserving the leading marker.
> - Behavioral Change: `--timings` load errors are now warnings rather than fatal exits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5426442.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->