### PR TITLE
Nest per-#[test] checks so nix-eval-jobs shards enumeration instead of ballooning one worker

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -39,7 +39,7 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]'
     # Same self-hosted dispatcher as check.yml: the `ix-ci-run-*` label is
     # claimed by the org dispatcher, which mints an ephemeral runner with a warm
-    # /nix/store. Evaluating .#checks.x86_64-linux forces an x86_64-linux IFD
+    # /nix/store. Evaluating .#ciChecks.x86_64-linux forces an x86_64-linux IFD
     # build (lib/rust/cargo-unit.nix), so this must run on the Linux runner.
     runs-on: ["${{ format('ix-ci-run-{0}-{1}-blast-radius', github.run_id, github.run_attempt) }}"]
     timeout-minutes: 30

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,7 +77,7 @@ jobs:
 
       # Run the full gate through the repo-owned `check` app (lib/per-system.nix),
       # so CI and a local `nix run .#check` execute the same two commands from one
-      # definition: nix-fast-build over `.#checks.x86_64-linux`, then nix-eval-jobs
+      # definition: nix-fast-build over `.#ciChecks.x86_64-linux`, then nix-eval-jobs
       # over `.#packages.x86_64-linux` with the JSON error-line gate. The
       # command-specific rationale (tool choice, the worker/memory tuning, why the
       # eval cache is off, the error-line gate) and the pinned tool revisions live

--- a/flake.nix
+++ b/flake.nix
@@ -208,6 +208,12 @@
       overlays.default = ix.overlay;
       packages = collect "packages";
       checks = collect "checks";
+      # Sharded keying of the same check derivations for the memory-bounded CI
+      # evaluator (the `.#check` gate and blast-radius); see lib/per-system.nix
+      # (ENG-2201). Kept separate from `checks` because its per-package
+      # `recurseForDerivations` groups are not derivations, which the flake
+      # `checks` schema requires.
+      ciChecks = collect "ciChecks";
       formatter = collect "formatter";
       apps = collect "apps";
       devShells = collect "devShells";

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -108,7 +108,7 @@ let
   # nix is already present); pinning a client nix here could mismatch the host
   # Nix 2.34.x daemon.
   #
-  # Step 1 (nix-fast-build) builds every `checks.x86_64-linux` derivation: it
+  # Step 1 (nix-fast-build) builds every `ciChecks.x86_64-linux` derivation: it
   # evaluates with nix-eval-jobs (parallel) and streams each drv into a build
   # pool as it resolves. --skip-cached drops paths already in a substituter (a
   # warm run does almost no work), --no-nom keeps plain logs, --no-link leaves no
@@ -139,7 +139,7 @@ let
   # host Nix 2.34.x.
   check = ix.writeNushellApplication pkgs {
     name = "check";
-    meta.description = "Run the full CI gate: build .#checks.x86_64-linux and eval-validate .#packages.x86_64-linux";
+    meta.description = "Run the full CI gate: build .#ciChecks.x86_64-linux and eval-validate .#packages.x86_64-linux";
     text = ''
       const fast_build = "github:Mic92/nix-fast-build/7f185e0ec37b65b4730f892e0de9a831b0610f3a"
       const eval_jobs = "github:nix-community/nix-eval-jobs/65ebf5b7cd453a27af09cf02b1fc57b3568cc4b7"
@@ -147,7 +147,7 @@ let
       def main [] {
         # ca-derivations: the rust workspace units default to
         # `contentAddressed = true` (lib/rust/cargo-unit.nix), so evaluating
-        # `.#checks.x86_64-linux` resolves floating content-addressed drvs. The
+        # `.#ciChecks.x86_64-linux` resolves floating content-addressed drvs. The
         # evaluator (nix-eval-jobs, which nix-fast-build wraps) needs the
         # `ca-derivations` experimental feature, or it aborts with
         # "experimental Nix feature 'ca-derivations' is disabled". The flake's
@@ -160,7 +160,7 @@ let
         # annotate the rebuilt-checks list with wall-clock seconds. The path is
         # relative to the runner cwd; check.yml uploads it as an artifact.
         ^nix run $fast_build -- ...[
-          "--flake" ".#checks.x86_64-linux"
+          "--flake" ".#ciChecks.x86_64-linux"
           "--eval-max-memory-size" "6144"
           "--eval-workers" "16"
           "--skip-cached"
@@ -392,7 +392,7 @@ let
     ) (packageRegistry.flakeEntriesFor system)
   );
 
-  rustPackageTests =
+  rustPackageTestSets =
     let
       cargoUnit = ix.cargoUnitFor pkgs;
       rustWorkspace = ix.rustWorkspaceFor pkgs;
@@ -413,38 +413,39 @@ let
             library = lib.replaceStrings [ "-" ] [ "_" ] entry.id;
             packageName = entry.id;
           }).passthru.tests or { };
-      # Each package's per-#[test] checks are nested under one attr carrying
-      # `recurseForDerivations` rather than flattened into the top-level `checks`
-      # set. nix-eval-jobs (the evaluator nix-fast-build and blast-radius both
-      # wrap) then lists the cheap per-package names at the root and forces each
-      # package's manifest IFD -- which enumerates that crate's `#[test]` cases --
-      # inside its own worker job, so the worker restarts at the memory cap
-      # between packages. Flattening (the old `mergeAttrsList` over renamed
-      # per-case keys) defeated the per-crate split this comment block promises:
-      # listing the flat per-case names forced every crate's manifest at once in
-      # the single worker assigned the root attrpath, ballooning it to tens of
-      # GiB and getting it earlyoom-killed on the shared CI host (ENG-2201).
-      # The nested set must stay a thunk: listing `checks` (the root job) only
-      # forces the per-package KEYS, never a package's tests. Filtering empties
-      # here (e.g. `tests != {}`) would force every package's manifest during
-      # enumeration and reintroduce the balloon, so empty groups are left in --
-      # nix-eval-jobs recurses them and emits nothing.
-      shardedPackageTests = name: tests: { ${name} = tests // { recurseForDerivations = true; }; };
-      repoRustPackageTests = lib.mergeAttrsList (
-        map (entry: shardedPackageTests entry.passthruTests.prefix (packageTestsFor entry)) (
-          packageRegistry.passthruTestEntriesFor system
-        )
-      );
+      # Two keyings of the same leaf test derivations:
+      #
+      #  * `flat` keys each per-#[test] check as its own top-level name
+      #    (`<prefix>-<target>-tests-<case>`). This is what the public `checks`
+      #    output needs: the flake schema requires every `checks.<system>.<name>`
+      #    to be a derivation, so a nested attrset there fails `nix flake check`.
+      #
+      #  * `sharded` nests each package's checks under one `recurseForDerivations`
+      #    attr (`<prefix>.<target>-tests-<case>`). This is what the memory-bounded
+      #    CI evaluator (nix-fast-build / nix-eval-jobs / blast-radius) consumes
+      #    through the separate `ciChecks` output.
+      #
+      # Why the sharded shape exists: nix-eval-jobs hands the root attrpath to one
+      # worker and forces its child names to recurse. With the flat set, that one
+      # worker forces every crate's per-#[test] manifest IFD at once and balloons
+      # to tens of GiB, which earlyoom kills on the shared CI host. The nested
+      # shape makes the root return cheap per-package names and forces each
+      # crate's manifests inside its own worker job, which restarts at the memory
+      # cap between packages (ENG-2201). The nested value must stay a thunk:
+      # filtering empties (e.g. `tests != {}`) would force every manifest during
+      # enumeration and reintroduce the balloon, so empty groups are left in.
+      flatPackageChecks = prefix: tests: lib.mapAttrs' (n: t: lib.nameValuePair "${prefix}-${n}" t) tests;
+      shardedPackageChecks = prefix: tests: {
+        ${prefix} = tests // {
+          recurseForDerivations = true;
+        };
+      };
+      repoEntries = packageRegistry.passthruTestEntriesFor system;
       moduleRustPackages = {
         resource-monitor-stats-writer = cargoUnit.selectBinaryWithTests rustWorkspace.units {
           binary = "resource-monitor-stats-writer";
         };
       };
-      moduleRustPackageTests = lib.mergeAttrsList (
-        lib.mapAttrsToList (
-          packageName: package: shardedPackageTests "rust-${packageName}" (package.passthru.tests or { })
-        ) moduleRustPackages
-      );
       # cargoAudit scans the single workspace Cargo.lock against the advisory DB,
       # so it is one lockfile-scoped check (it rebuilds only on a Cargo.lock
       # change, never on a source edit) rather than a per-crate gate. Expose it
@@ -452,8 +453,20 @@ let
       workspaceAuditTests = lib.optionalAttrs (rustWorkspace.units.policyChecks ? cargoAudit) {
         rust-cargoAudit = rustWorkspace.units.policyChecks.cargoAudit;
       };
+      collectRust =
+        group:
+        lib.mergeAttrsList (
+          map (entry: group entry.passthruTests.prefix (packageTestsFor entry)) repoEntries
+          ++ lib.mapAttrsToList (
+            packageName: package: group "rust-${packageName}" (package.passthru.tests or { })
+          ) moduleRustPackages
+        )
+        // workspaceAuditTests;
     in
-    repoRustPackageTests // moduleRustPackageTests // workspaceAuditTests;
+    {
+      flat = collectRust flatPackageChecks;
+      sharded = collectRust shardedPackageChecks;
+    };
 
   lintSource = fs.toSource {
     inherit (paths) root;
@@ -515,7 +528,7 @@ let
       };
 
   # Shared between `packages` and the `image-<name>` checks so blast-radius
-  # (which only diffs `.#checks.x86_64-linux`) catches image fanouts via the
+  # (which only diffs `.#ciChecks.x86_64-linux`) catches image fanouts via the
   # check drvPath shift. The `base` image is omitted: its config is just
   # `ix.image.name`/`tag`, and any base-profile change already fans out into
   # every discovered image.
@@ -547,6 +560,166 @@ let
   nonNixExampleDescriptions = lib.mapAttrs' (
     name: image: lib.nameValuePair "${name}-description" image.passthru.description
   ) nonNixExampleImages;
+
+  # Build the check catalog from a rust-package keying. `checks` (flat: one
+  # derivation per `checks.<system>.<name>`, required by the flake schema and
+  # `nix flake check`) and `ciChecks` (sharded: one `recurseForDerivations` group
+  # per package, what the memory-bounded CI evaluator consumes) share the same
+  # explicit and image checks; only the rust keying differs (ENG-2201). The
+  # collision guard runs per keying, so producing `ciChecks` only forces the
+  # cheap per-package names, never the flat per-#[test] spine.
+  catalogFor =
+    rustPackageSet:
+    lib.optionalAttrs (system == ix.system) (
+      let
+        rustChecks = {
+          cargo-unit-real-workspaces = tests.cargoUnitRealWorkspaces;
+          cargo-unit-prebuilt-library = tests.cargoUnitPrebuiltLibrary;
+          sdk-rust-prebuilt = tests.sdkRustPrebuilt;
+        }
+        // rustPackageSet;
+        explicitChecks = {
+          inherit (tests) eval;
+          # Instruction files are not committed; they are rendered live by the
+          # SessionStart hook. This gate forces the rendered always-on documents
+          # (which evaluates the always-on char cap assertion) and the combined
+          # skills link farm (which evaluates the name-collision assertion) to build.
+          agent-context = pkgs.runCommand "agent-context-check" { } ''
+            test -s ${agentContextClaudeMd}
+            test -s ${agentContextCodexMd}
+            test -d ${agentContextSkills}
+            mkdir -p "$out"
+          '';
+          # Pins the last-applied 3-way merge behind homeModules.mutable-json:
+          # first-install, preserve an app-written key, enforce a key the app
+          # changed, prune a key Nix stopped declaring, and keep a sibling key
+          # while a declared array is replaced atomically.
+          mutable-json-merge =
+            pkgs.runCommand "mutable-json-merge-check" { nativeBuildInputs = [ pkgs.jaq ]; }
+              ''
+                prog=${ix.mutableJson.mergeProgram}
+                run() { jaq -ncS --argjson last "$1" --argjson live "$2" --argjson new "$3" -f "$prog"; }
+                check() {
+                  expected=$(printf '%s' "$2" | jaq -cS .)
+                  if [ "$expected" != "$3" ]; then
+                    echo "FAIL $1: expected $expected got $3" >&2
+                    exit 1
+                  fi
+                  echo "ok $1"
+                }
+                check first-install '{"permissions":{"defaultMode":"bypass"}}' \
+                  "$(run '{}' '{}' '{"permissions":{"defaultMode":"bypass"}}')"
+                check preserve-app-key '{"permissions":{"defaultMode":"bypass"},"theme":"dark"}' \
+                  "$(run '{"permissions":{"defaultMode":"bypass"}}' '{"permissions":{"defaultMode":"bypass"},"theme":"dark"}' '{"permissions":{"defaultMode":"bypass"}}')"
+                check enforce-changed '{"permissions":{"defaultMode":"bypass"},"theme":"dark"}' \
+                  "$(run '{"permissions":{"defaultMode":"bypass"}}' '{"permissions":{"defaultMode":"off"},"theme":"dark"}' '{"permissions":{"defaultMode":"bypass"}}')"
+                check prune-dropped '{"a":1,"c":3}' \
+                  "$(run '{"a":1,"b":2}' '{"a":1,"b":2,"c":3}' '{"a":1}')"
+                check nested-atomic-array '{"p":{"allow":["x"]},"t":1}' \
+                  "$(run '{"p":{"allow":["x"]}}' '{"p":{"allow":["x","y"]},"t":1}' '{"p":{"allow":["x"]}}')"
+                # Divergent live shape at a path we stop declaring must not abort:
+                # the app replaced object `permissions` with a scalar, Nix dropped it.
+                check divergent-live-shape '{"permissions":"all"}' \
+                  "$(run '{"permissions":{"defaultMode":"x"}}' '{"permissions":"all"}' '{}')"
+                mkdir -p "$out"
+              '';
+          # Offline schema gate for the loader manifests. `deepSeq` forces
+          # every Paper / Velocity / Fabric per-version lock through
+          # `readLoaderManifest` in `lib/artifacts.nix`, so malformed JSON or a
+          # missing key fires here before any image starts evaluating. The
+          # forced surface is the parsed-and-validated manifest data, not the
+          # wrapped `fetchurl` derivations, to keep this check pure eval.
+          loader-manifests =
+            let
+              forced = builtins.deepSeq ix.artifacts.minecraft.loaderManifests "ok";
+            in
+            pkgs.runCommand "loader-manifests-check" { } ''
+              printf '%s\n' '${forced}' > "$out"
+            '';
+          run-records-session = repoPackages.run.passthru.tests.recordsSession;
+          # Deterministic alloc-count gate for indexbench: runs the counting-
+          # allocator demo bench once through `indexbench assert` and fails if its
+          # allocation count exceeds the declared budget. Reproducible, unlike
+          # timing/RSS, so it earns a flake check; the timing/RSS perf job lives
+          # under `apps.bench` instead.
+          indexbench-self-demo-alloc = indexbenchSelfDemo.check;
+          lint = pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ pkgs.coreutils ]; } ''
+            cp -R ${lintSource} source
+            chmod -R u+w source
+            cd source
+            ${lib.getExe lint}
+            mkdir -p "$out"
+          '';
+          # Exercises the trusted half of the blast-radius PR comment: the
+          # validate/render jq embedded in its workflow, extracted from the YAML so
+          # the test can't drift from what the trusted comment job runs. The
+          # report-building logic lives in the `blast-radius` Rust crate and is
+          # covered by its own unit tests. See tools/blast-radius-test.sh.
+          blast-radius-test =
+            pkgs.runCommand "blast-radius-test"
+              {
+                nativeBuildInputs = [
+                  pkgs.bash
+                  pkgs.coreutils
+                  pkgs.diffutils
+                  pkgs.jq
+                  pkgs.yq-go
+                ];
+              }
+              ''
+                cp -R ${lintSource} source
+                chmod -R u+w source
+                cd source
+                export HOME="$TMPDIR/home"
+                mkdir -p "$HOME"
+                bash tools/blast-radius-test.sh
+                mkdir -p "$out"
+              '';
+          # Proves the Linux→macOS cross toolchain actually emits a Darwin object,
+          # which a successful build alone does not assert. `file` reads the Mach-O
+          # header; a regression in the zig/SDK wiring fails here on x86_64-linux CI
+          # rather than silently shipping a wrong-arch binary.
+          cross-darwin-smoke = pkgs.runCommand "cross-darwin-smoke" { nativeBuildInputs = [ pkgs.file ]; } ''
+            bin=${crossPackages."dag-runner-aarch64-apple-darwin"}/bin/dag-runner
+            info=$(file -b "$bin")
+            echo "$info"
+            case "$info" in
+              *Mach-O*arm64*) ;;
+              *)
+                echo "expected Mach-O arm64, got: $info" >&2
+                exit 1
+                ;;
+            esac
+            mkdir -p "$out"
+          '';
+          site-case-tests = pkgs.linkFarm "site-case-tests" (
+            lib.mapAttrsToList (name: path: { inherit name path; }) siteTests.cases
+          );
+          site-test = siteTests.all;
+        };
+        # One check per image OCI archive, built by nix-fast-build in step 1 of
+        # `.#check`. Without this, `.#packages` carries the image derivations
+        # but `.#checks` does not, so blast-radius under-reports any change
+        # that rebuilds every image because the drvPath shift never reaches a
+        # check. The `eval` aggregate at tests/default.nix:3890 only closes
+        # over per-image `extraScript` text, not `config.system.build.toplevel`,
+        # so it stays stable across semantic edits to shared image libs.
+        imageChecks = lib.mapAttrs' (n: v: lib.nameValuePair "image-${n}" v) (
+          discoveredImages // nonNixExampleImages
+        );
+        # Rust crate prefixes can be overridden in `package.nix` and image
+        # names are user-chosen, so a stray collision with an explicit check
+        # would otherwise be silently swallowed by the `//` merge. Two pairwise
+        # intersections cover all three pairs because every offending name is
+        # in at least two sets.
+        checkNameCollisions =
+          lib.intersectLists (lib.attrNames explicitChecks) (lib.attrNames rustChecks)
+          ++ lib.intersectLists (lib.attrNames imageChecks) (lib.attrNames (explicitChecks // rustChecks));
+      in
+      assert lib.assertMsg (checkNameCollisions == [ ])
+        "checks: duplicate names across explicit/rust/image sets: ${lib.concatStringsSep ", " checkNameCollisions}";
+      explicitChecks // rustChecks // imageChecks
+    );
 in
 {
   packages =
@@ -594,165 +767,17 @@ in
     // crossPackages
     // healthChecks.lifecyclePackages;
 
-  checks = lib.optionalAttrs (system == ix.system) (
-    let
-      # Each per-crate rust test unit is its own top-level check (spread into
-      # the `checks` set below) rather than being collapsed into one aggregate
-      # linkFarm. That lets nix-eval-jobs (the evaluator CI's nix-fast-build
-      # wraps) assign each crate's test to a separate worker, so no single
-      # worker holds the whole workspace test graph in its heap. The old
-      # `rust-package-tests` linkFarm did the opposite: it forced one worker to
-      # evaluate every crate at once, and that single multi-GiB eval is what
-      # flaked the flake-check job (per-worker SIGKILL at the memory cap, and
-      # host-OOM with many workers).
-      rustChecks = {
-        cargo-unit-real-workspaces = tests.cargoUnitRealWorkspaces;
-        cargo-unit-prebuilt-library = tests.cargoUnitPrebuiltLibrary;
-        sdk-rust-prebuilt = tests.sdkRustPrebuilt;
-      }
-      // rustPackageTests;
-      explicitChecks = {
-        inherit (tests) eval;
-        # Instruction files are not committed; they are rendered live by the
-        # SessionStart hook. This gate forces the rendered always-on documents
-        # (which evaluates the always-on char cap assertion) and the combined
-        # skills link farm (which evaluates the name-collision assertion) to build.
-        agent-context = pkgs.runCommand "agent-context-check" { } ''
-          test -s ${agentContextClaudeMd}
-          test -s ${agentContextCodexMd}
-          test -d ${agentContextSkills}
-          mkdir -p "$out"
-        '';
-        # Pins the last-applied 3-way merge behind homeModules.mutable-json:
-        # first-install, preserve an app-written key, enforce a key the app
-        # changed, prune a key Nix stopped declaring, and keep a sibling key
-        # while a declared array is replaced atomically.
-        mutable-json-merge =
-          pkgs.runCommand "mutable-json-merge-check" { nativeBuildInputs = [ pkgs.jaq ]; }
-            ''
-              prog=${ix.mutableJson.mergeProgram}
-              run() { jaq -ncS --argjson last "$1" --argjson live "$2" --argjson new "$3" -f "$prog"; }
-              check() {
-                expected=$(printf '%s' "$2" | jaq -cS .)
-                if [ "$expected" != "$3" ]; then
-                  echo "FAIL $1: expected $expected got $3" >&2
-                  exit 1
-                fi
-                echo "ok $1"
-              }
-              check first-install '{"permissions":{"defaultMode":"bypass"}}' \
-                "$(run '{}' '{}' '{"permissions":{"defaultMode":"bypass"}}')"
-              check preserve-app-key '{"permissions":{"defaultMode":"bypass"},"theme":"dark"}' \
-                "$(run '{"permissions":{"defaultMode":"bypass"}}' '{"permissions":{"defaultMode":"bypass"},"theme":"dark"}' '{"permissions":{"defaultMode":"bypass"}}')"
-              check enforce-changed '{"permissions":{"defaultMode":"bypass"},"theme":"dark"}' \
-                "$(run '{"permissions":{"defaultMode":"bypass"}}' '{"permissions":{"defaultMode":"off"},"theme":"dark"}' '{"permissions":{"defaultMode":"bypass"}}')"
-              check prune-dropped '{"a":1,"c":3}' \
-                "$(run '{"a":1,"b":2}' '{"a":1,"b":2,"c":3}' '{"a":1}')"
-              check nested-atomic-array '{"p":{"allow":["x"]},"t":1}' \
-                "$(run '{"p":{"allow":["x"]}}' '{"p":{"allow":["x","y"]},"t":1}' '{"p":{"allow":["x"]}}')"
-              # Divergent live shape at a path we stop declaring must not abort:
-              # the app replaced object `permissions` with a scalar, Nix dropped it.
-              check divergent-live-shape '{"permissions":"all"}' \
-                "$(run '{"permissions":{"defaultMode":"x"}}' '{"permissions":"all"}' '{}')"
-              mkdir -p "$out"
-            '';
-        # Offline schema gate for the loader manifests. `deepSeq` forces
-        # every Paper / Velocity / Fabric per-version lock through
-        # `readLoaderManifest` in `lib/artifacts.nix`, so malformed JSON or a
-        # missing key fires here before any image starts evaluating. The
-        # forced surface is the parsed-and-validated manifest data, not the
-        # wrapped `fetchurl` derivations, to keep this check pure eval.
-        loader-manifests =
-          let
-            forced = builtins.deepSeq ix.artifacts.minecraft.loaderManifests "ok";
-          in
-          pkgs.runCommand "loader-manifests-check" { } ''
-            printf '%s\n' '${forced}' > "$out"
-          '';
-        run-records-session = repoPackages.run.passthru.tests.recordsSession;
-        # Deterministic alloc-count gate for indexbench: runs the counting-
-        # allocator demo bench once through `indexbench assert` and fails if its
-        # allocation count exceeds the declared budget. Reproducible, unlike
-        # timing/RSS, so it earns a flake check; the timing/RSS perf job lives
-        # under `apps.bench` instead.
-        indexbench-self-demo-alloc = indexbenchSelfDemo.check;
-        lint = pkgs.runCommand "ix-images-lint" { nativeBuildInputs = [ pkgs.coreutils ]; } ''
-          cp -R ${lintSource} source
-          chmod -R u+w source
-          cd source
-          ${lib.getExe lint}
-          mkdir -p "$out"
-        '';
-        # Exercises the trusted half of the blast-radius PR comment: the
-        # validate/render jq embedded in its workflow, extracted from the YAML so
-        # the test can't drift from what the trusted comment job runs. The
-        # report-building logic lives in the `blast-radius` Rust crate and is
-        # covered by its own unit tests. See tools/blast-radius-test.sh.
-        blast-radius-test =
-          pkgs.runCommand "blast-radius-test"
-            {
-              nativeBuildInputs = [
-                pkgs.bash
-                pkgs.coreutils
-                pkgs.diffutils
-                pkgs.jq
-                pkgs.yq-go
-              ];
-            }
-            ''
-              cp -R ${lintSource} source
-              chmod -R u+w source
-              cd source
-              export HOME="$TMPDIR/home"
-              mkdir -p "$HOME"
-              bash tools/blast-radius-test.sh
-              mkdir -p "$out"
-            '';
-        # Proves the Linux→macOS cross toolchain actually emits a Darwin object,
-        # which a successful build alone does not assert. `file` reads the Mach-O
-        # header; a regression in the zig/SDK wiring fails here on x86_64-linux CI
-        # rather than silently shipping a wrong-arch binary.
-        cross-darwin-smoke = pkgs.runCommand "cross-darwin-smoke" { nativeBuildInputs = [ pkgs.file ]; } ''
-          bin=${crossPackages."dag-runner-aarch64-apple-darwin"}/bin/dag-runner
-          info=$(file -b "$bin")
-          echo "$info"
-          case "$info" in
-            *Mach-O*arm64*) ;;
-            *)
-              echo "expected Mach-O arm64, got: $info" >&2
-              exit 1
-              ;;
-          esac
-          mkdir -p "$out"
-        '';
-        site-case-tests = pkgs.linkFarm "site-case-tests" (
-          lib.mapAttrsToList (name: path: { inherit name path; }) siteTests.cases
-        );
-        site-test = siteTests.all;
-      };
-      # One check per image OCI archive, built by nix-fast-build in step 1 of
-      # `.#check`. Without this, `.#packages` carries the image derivations
-      # but `.#checks` does not, so blast-radius under-reports any change
-      # that rebuilds every image because the drvPath shift never reaches a
-      # check. The `eval` aggregate at tests/default.nix:3890 only closes
-      # over per-image `extraScript` text, not `config.system.build.toplevel`,
-      # so it stays stable across semantic edits to shared image libs.
-      imageChecks = lib.mapAttrs' (n: v: lib.nameValuePair "image-${n}" v) (
-        discoveredImages // nonNixExampleImages
-      );
-      # Rust crate prefixes can be overridden in `package.nix` and image
-      # names are user-chosen, so a stray collision with an explicit check
-      # would otherwise be silently swallowed by the `//` merge. Two pairwise
-      # intersections cover all three pairs because every offending name is
-      # in at least two sets.
-      checkNameCollisions =
-        lib.intersectLists (lib.attrNames explicitChecks) (lib.attrNames rustChecks)
-        ++ lib.intersectLists (lib.attrNames imageChecks) (lib.attrNames (explicitChecks // rustChecks));
-    in
-    assert lib.assertMsg (checkNameCollisions == [ ])
-      "checks: duplicate names across explicit/rust/image sets: ${lib.concatStringsSep ", " checkNameCollisions}";
-    explicitChecks // rustChecks // imageChecks
-  );
+  # Flat keying: one derivation per `checks.<system>.<name>`, as the flake schema
+  # and `nix flake check` require. The `.#check` gate and blast-radius consume
+  # the sharded `ciChecks` instead, so this output is not what CI enumerates.
+  checks = catalogFor rustPackageTestSets.flat;
+  # Sharded keying for the memory-bounded CI evaluator (nix-fast-build /
+  # nix-eval-jobs / blast-radius): each package's per-#[test] checks sit under one
+  # `recurseForDerivations` group, so the evaluator lists cheap per-package names
+  # at the root and forces each crate's manifest IFD in its own worker job
+  # (ENG-2201). Not a `checks.<system>.<name>` output, because a non-derivation
+  # there fails the flake schema.
+  ciChecks = catalogFor rustPackageTestSets.sharded;
 
   formatter = pkgs.nixfmt;
 

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -413,25 +413,38 @@ let
             library = lib.replaceStrings [ "-" ] [ "_" ] entry.id;
             packageName = entry.id;
           }).passthru.tests or { };
+      # Each package's per-#[test] checks are nested under one attr carrying
+      # `recurseForDerivations` rather than flattened into the top-level `checks`
+      # set. nix-eval-jobs (the evaluator nix-fast-build and blast-radius both
+      # wrap) then lists the cheap per-package names at the root and forces each
+      # package's manifest IFD -- which enumerates that crate's `#[test]` cases --
+      # inside its own worker job, so the worker restarts at the memory cap
+      # between packages. Flattening (the old `mergeAttrsList` over renamed
+      # per-case keys) defeated the per-crate split this comment block promises:
+      # listing the flat per-case names forced every crate's manifest at once in
+      # the single worker assigned the root attrpath, ballooning it to tens of
+      # GiB and getting it earlyoom-killed on the shared CI host (ENG-2201).
+      # The nested set must stay a thunk: listing `checks` (the root job) only
+      # forces the per-package KEYS, never a package's tests. Filtering empties
+      # here (e.g. `tests != {}`) would force every package's manifest during
+      # enumeration and reintroduce the balloon, so empty groups are left in --
+      # nix-eval-jobs recurses them and emits nothing.
+      shardedPackageTests = name: tests: { ${name} = tests // { recurseForDerivations = true; }; };
       repoRustPackageTests = lib.mergeAttrsList (
-        map (
-          entry:
-          lib.mapAttrs' (testName: test: lib.nameValuePair "${entry.passthruTests.prefix}-${testName}" test) (
-            packageTestsFor entry
-          )
-        ) (packageRegistry.passthruTestEntriesFor system)
+        map (entry: shardedPackageTests entry.passthruTests.prefix (packageTestsFor entry)) (
+          packageRegistry.passthruTestEntriesFor system
+        )
       );
       moduleRustPackages = {
         resource-monitor-stats-writer = cargoUnit.selectBinaryWithTests rustWorkspace.units {
           binary = "resource-monitor-stats-writer";
         };
       };
-      moduleRustPackageTests = lib.concatMapAttrs (
-        packageName: package:
-        lib.mapAttrs' (testName: test: lib.nameValuePair "rust-${packageName}-${testName}" test) (
-          package.passthru.tests or { }
-        )
-      ) moduleRustPackages;
+      moduleRustPackageTests = lib.mergeAttrsList (
+        lib.mapAttrsToList (
+          packageName: package: shardedPackageTests "rust-${packageName}" (package.passthru.tests or { })
+        ) moduleRustPackages
+      );
       # cargoAudit scans the single workspace Cargo.lock against the advisory DB,
       # so it is one lockfile-scoped check (it rebuilds only on a Cargo.lock
       # change, never on a source edit) rather than a per-crate gate. Expose it

--- a/packages/blast-radius/src/main.rs
+++ b/packages/blast-radius/src/main.rs
@@ -113,15 +113,20 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     let revs = git::resolve(cli.base.as_deref(), cli.head.as_deref())?;
 
+    // Pick one catalog output for both revisions so their attr names line up
+    // (see nix::catalog_attr): `ciChecks` when both revs expose it, else flat
+    // `checks`. Resolved before the eval scope so base and head never mix keying.
+    let catalog = nix::catalog_attr(&revs.repo, &revs.base, &revs.head);
+
     // base and head evals are independent, so run them concurrently. Each is a
-    // full `.#checks.x86_64-linux` evaluation (~11 min on ix's ~4300 checks),
+    // full `#{catalog}.x86_64-linux` evaluation (~11 min on ix's ~4300 checks),
     // mostly blocked on the per-unit cargo IFD builds, so overlapping them
     // roughly halves the wall clock versus back-to-back. The eval cache stays
     // off (see eval_checks): with it on, two concurrent nix-eval-jobs contend on
     // the per-commit eval-cache SQLite and fail with "database is busy".
     let Evals { base, head } = std::thread::scope(|scope| -> Result<Evals> {
-        let head_eval = scope.spawn(|| nix::eval_checks(&revs.repo, &revs.head));
-        let base = nix::eval_checks(&revs.repo, &revs.base)?;
+        let head_eval = scope.spawn(|| nix::eval_checks(&revs.repo, &revs.head, catalog));
+        let base = nix::eval_checks(&revs.repo, &revs.base, catalog)?;
         let head = match head_eval.join() {
             Ok(result) => result?,
             Err(_) => bail!("head check evaluation thread panicked"),

--- a/packages/blast-radius/src/nix.rs
+++ b/packages/blast-radius/src/nix.rs
@@ -230,10 +230,13 @@ fn partition_eval_rows(stdout: &str) -> Result<Partitioned> {
     for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
         let row: EvalRow =
             serde_json::from_str(line).with_context(|| format!("parse eval row: {line}"))?;
-        // nix-eval-jobs quotes attr segments that need quoting in Nix source
-        // (dots, leading digits); strip them so the bare attribute name flows
-        // through the diff, the report, and the workflow's safename regex.
-        let attr = row.attr.trim_matches('"').to_owned();
+        // nix-eval-jobs quotes any attr-path segment that needs quoting in Nix
+        // source (a dot inside the segment). A sharded `ciChecks` leaf can quote
+        // an interior segment (`rust-foo."doctest-...lib.rs..."`), so unquote
+        // each segment (see normalize_attr), not just the ends, before the bare
+        // name flows through the diff, the report, and the workflow safename
+        // regex.
+        let attr = normalize_attr(&row.attr);
         match (row.drv_path, row.error) {
             (Some(drv_path), _) => out.checks.push(Check { attr, drv_path }),
             (None, Some(error)) => out.eval_failures.push(EvalFailure { attr, error }),
@@ -296,6 +299,40 @@ pub fn derivation_graph(drv_paths: &[String]) -> Result<Graph> {
         .collect())
 }
 
+/// Reverse nix-eval-jobs' attr-path joining to a bare, schema-valid name.
+///
+/// nix-eval-jobs joins a nested attr path with `.`, wrapping any single segment
+/// that contains a `.` in double quotes. The sharded `ciChecks` output nests
+/// each crate's per-#[test] leaves under a `recurseForDerivations` group, so a
+/// doctest case whose name carries a file path (`src/lib.rs - (line 12)`)
+/// surfaces as `rust-foo."doctest-...src/lib.rs - (line 12)"`: the package
+/// segment is bare, the leaf is quoted. nix-fast-build copies this joined string
+/// verbatim into its `--timings` records (it ignores the `attrPath` array), so
+/// the same shape reaches both [`eval_checks`] and [`crate::timings`].
+///
+/// The trusted workflow schema (`blast-radius.yml` safename regex) allows dots,
+/// slashes, spaces, and parens but rejects `"`, and trimming only the ends
+/// leaves the quotes around an interior segment in place. Drop every `"` and
+/// split on dots outside quotes, then rejoin with `.`, so the bare path flows
+/// identically through the diff key, the report, and the schema regardless of
+/// which producer it came from. A flat single-segment name (quoted only because
+/// its own case name holds a `.`) round-trips to the same bare name the old
+/// end-trim produced.
+pub fn normalize_attr(attr: &str) -> String {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    for ch in attr.chars() {
+        match ch {
+            '"' => in_quotes = !in_quotes,
+            '.' if !in_quotes => segments.push(std::mem::take(&mut current)),
+            _ => current.push(ch),
+        }
+    }
+    segments.push(current);
+    segments.join(".")
+}
+
 /// Look up the derivation path for an attribute name in an evaluated set.
 pub fn drv_for(checks: &[Check], attr: &str) -> Option<String> {
     checks
@@ -306,7 +343,7 @@ pub fn drv_for(checks: &[Check], attr: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{EvalFailure, drv_name, partition_eval_rows};
+    use super::{EvalFailure, drv_name, normalize_attr, partition_eval_rows};
 
     #[test]
     fn drv_name_strips_hash_and_suffix() {
@@ -322,12 +359,17 @@ mod tests {
     // A buildable row becomes a check; a per-attr eval failure is excluded (not a
     // rebuild target) rather than aborting the whole run; a malformed row with
     // neither field is flagged so the caller can fail loudly. Blank lines are
-    // skipped. nix-eval-jobs quotes attrs that need Nix quoting; the quotes are
-    // stripped.
+    // skipped. nix-eval-jobs quotes attr segments that need Nix quoting; the
+    // quotes are stripped per segment, including a sharded leaf whose interior
+    // segment is quoted.
     #[test]
     fn partition_splits_success_eval_failure_and_malformed() {
         let stdout = concat!(
             r#"{"attr":"rust-test-foo","drvPath":"/nix/store/aaa-foo.drv"}"#,
+            "\n",
+            // A sharded ciChecks doctest leaf: the package segment is bare, the
+            // case segment is quoted because its name carries `lib.rs`.
+            r#"{"attr":"rust-foo.\"doctest-src/lib.rs - (line 12)\"","drvPath":"/nix/store/bbb-doc.drv"}"#,
             "\n",
             r#"{"attr":"unfree-allowlist","error":"unfree allowlist mismatch"}"#,
             "\n",
@@ -338,9 +380,15 @@ mod tests {
 
         let partitioned = partition_eval_rows(stdout).expect("well-formed JSONL parses");
 
-        assert_eq!(partitioned.checks.len(), 1);
+        assert_eq!(partitioned.checks.len(), 2);
         assert_eq!(partitioned.checks[0].attr, "rust-test-foo");
         assert_eq!(partitioned.checks[0].drv_path, "/nix/store/aaa-foo.drv");
+        // The quoted interior segment is unquoted but the dot path separator is
+        // kept, so the bare name passes the workflow safename regex.
+        assert_eq!(
+            partitioned.checks[1].attr,
+            "rust-foo.doctest-src/lib.rs - (line 12)"
+        );
         assert_eq!(
             partitioned.eval_failures,
             vec![EvalFailure {
@@ -349,5 +397,28 @@ mod tests {
             }]
         );
         assert_eq!(partitioned.unexpected, vec!["weird.attr".to_owned()]);
+    }
+
+    // normalize_attr reverses nix-eval-jobs' attr-path join: drop quotes around
+    // each segment, keep dots between segments.
+    #[test]
+    fn normalize_attr_unquotes_each_segment() {
+        // Flat top-level name, no quoting.
+        assert_eq!(normalize_attr("rust-test-foo"), "rust-test-foo");
+        // Flat name quoted whole because its case carries a dot.
+        assert_eq!(
+            normalize_attr(r#""rust-foo-doctest-src/lib.rs - (line 12)""#),
+            "rust-foo-doctest-src/lib.rs - (line 12)"
+        );
+        // Sharded path: bare package segment, quoted leaf segment.
+        assert_eq!(
+            normalize_attr(r#"rust-foo."doctest-src/lib.rs - (line 12)""#),
+            "rust-foo.doctest-src/lib.rs - (line 12)"
+        );
+        // Sharded path with an unquoted leaf (no dot in the case name).
+        assert_eq!(
+            normalize_attr("rust-foo.causes-tests-some_case"),
+            "rust-foo.causes-tests-some_case"
+        );
     }
 }

--- a/packages/blast-radius/src/nix.rs
+++ b/packages/blast-radius/src/nix.rs
@@ -97,13 +97,21 @@ fn run(command: &mut Command) -> Result<String> {
     String::from_utf8(output.stdout).context("command stdout was not UTF-8")
 }
 
-/// Evaluate every `.#checks.x86_64-linux` derivation at `rev` of the local repo.
+/// Evaluate every check derivation at `rev` of the local repo.
+///
+/// Targets `.#ciChecks`, not `.#checks`: `ciChecks` keys each crate's per-#[test]
+/// checks under a `recurseForDerivations` group, so `nix-eval-jobs` enumerates
+/// cheap per-package names at the root and forces each crate's manifest IFD in
+/// its own worker job. The flat `.#checks` would force every crate's manifest in
+/// the single worker assigned the root attrpath, ballooning it to tens of GiB
+/// and getting it earlyoom-killed on the shared CI host (ENG-2201). `ciChecks`
+/// holds the same leaf derivations, so the per-#[test] diff is unchanged.
 ///
 /// `nix-eval-jobs` sits at the head of the pipeline; a startup/lock/fetch
 /// failure surfaces here rather than yielding an empty set that silently
 /// under-reports the blast radius.
 pub fn eval_checks(repo: &str, rev: &str) -> Result<EvalResult> {
-    let flakeref = format!("git+file://{repo}?rev={rev}&allRefs=1#checks.x86_64-linux");
+    let flakeref = format!("git+file://{repo}?rev={rev}&allRefs=1#ciChecks.x86_64-linux");
     let stdout = run(Command::new("nix").args([
         "run",
         EVAL_JOBS,

--- a/packages/blast-radius/src/nix.rs
+++ b/packages/blast-radius/src/nix.rs
@@ -97,19 +97,12 @@ fn run(command: &mut Command) -> Result<String> {
     String::from_utf8(output.stdout).context("command stdout was not UTF-8")
 }
 
-/// The catalog output to evaluate at `rev`, preferring the sharded `ciChecks`
-/// and falling back to the flat `checks` on revisions that predate it.
-///
-/// blast-radius diffs head against the merge base, and that base is whatever was
-/// on `main` at fork time, which can be a commit from before `ciChecks` existed.
-/// Evaluating `#ciChecks.x86_64-linux` on such a rev fails outright, so probe the
-/// flake output set cheaply (forces the `{ <system> = ...; }` spine, not the
-/// catalog) and pick the attribute that is actually present. This is a migration
-/// shim: once no base older than the `ciChecks` introduction is ever evaluated,
-/// drop the probe and target `ciChecks` directly (ENG-2201).
-fn catalog_attr(repo: &str, rev: &str) -> &'static str {
+/// Does `rev` expose the sharded `ciChecks` flake output? Probes cheaply: the
+/// `--apply builtins.isAttrs` forces only the `{ <system> = ...; }` output spine,
+/// not the catalog under it.
+fn has_ci_checks(repo: &str, rev: &str) -> bool {
     let flakeref = format!("git+file://{repo}?rev={rev}&allRefs=1#ciChecks");
-    let has_ci_checks = Command::new("nix")
+    Command::new("nix")
         .args([
             "eval",
             &flakeref,
@@ -120,26 +113,45 @@ fn catalog_attr(repo: &str, rev: &str) -> &'static str {
             "true",
         ])
         .output()
-        .is_ok_and(|out| out.status.success());
-    if has_ci_checks { "ciChecks" } else { "checks" }
+        .is_ok_and(|out| out.status.success())
 }
 
-/// Evaluate every check derivation at `rev` of the local repo.
+/// The catalog output to diff, chosen ONCE for both revisions so base and head
+/// are keyed identically.
 ///
-/// Targets `.#ciChecks` when present (see [`catalog_attr`]): `ciChecks` keys each
-/// crate's per-#[test] checks under a `recurseForDerivations` group, so
-/// `nix-eval-jobs` enumerates cheap per-package names at the root and forces each
-/// crate's manifest IFD in its own worker job. The flat `.#checks` would force
-/// every crate's manifest in the single worker assigned the root attrpath,
-/// ballooning it to tens of GiB and getting it earlyoom-killed on the shared CI
-/// host (ENG-2201). Both outputs hold the same leaf derivations, so the
-/// per-#[test] diff is identical whichever is evaluated.
+/// Prefer the sharded `ciChecks` (see [`eval_checks`]), but blast-radius diffs
+/// head against the merge base, and that base can be a commit from before
+/// `ciChecks` existed. If either revision lacks it, fall back to the flat
+/// `checks` for BOTH. Choosing per revision would key the same derivation as
+/// `rust-foo-package` at a flat base and `rust-foo.package` at a sharded head;
+/// the diff keys by attr name, so every unchanged derivation would read as
+/// removed+added and skip root-cause analysis. Migration shim: once no evaluated
+/// base predates `ciChecks`, drop the probe and target `ciChecks` directly
+/// (ENG-2201).
+pub fn catalog_attr(repo: &str, base: &str, head: &str) -> &'static str {
+    if has_ci_checks(repo, base) && has_ci_checks(repo, head) {
+        "ciChecks"
+    } else {
+        "checks"
+    }
+}
+
+/// Evaluate every check derivation at `rev` of the local repo, reading the
+/// catalog from flake output `attr` (`ciChecks` or `checks`; see
+/// [`catalog_attr`]).
+///
+/// `ciChecks` keys each crate's per-#[test] checks under a `recurseForDerivations`
+/// group, so `nix-eval-jobs` enumerates cheap per-package names at the root and
+/// forces each crate's manifest IFD in its own worker job. The flat `checks`
+/// would force every crate's manifest in the single worker assigned the root
+/// attrpath, ballooning it to tens of GiB and getting it earlyoom-killed on the
+/// shared CI host (ENG-2201). Both outputs hold the same leaf derivations, so the
+/// per-#[test] diff is identical as long as base and head use the same `attr`.
 ///
 /// `nix-eval-jobs` sits at the head of the pipeline; a startup/lock/fetch
 /// failure surfaces here rather than yielding an empty set that silently
 /// under-reports the blast radius.
-pub fn eval_checks(repo: &str, rev: &str) -> Result<EvalResult> {
-    let attr = catalog_attr(repo, rev);
+pub fn eval_checks(repo: &str, rev: &str, attr: &str) -> Result<EvalResult> {
     let flakeref = format!("git+file://{repo}?rev={rev}&allRefs=1#{attr}.x86_64-linux");
     let stdout = run(Command::new("nix").args([
         "run",

--- a/packages/blast-radius/src/nix.rs
+++ b/packages/blast-radius/src/nix.rs
@@ -97,21 +97,50 @@ fn run(command: &mut Command) -> Result<String> {
     String::from_utf8(output.stdout).context("command stdout was not UTF-8")
 }
 
+/// The catalog output to evaluate at `rev`, preferring the sharded `ciChecks`
+/// and falling back to the flat `checks` on revisions that predate it.
+///
+/// blast-radius diffs head against the merge base, and that base is whatever was
+/// on `main` at fork time, which can be a commit from before `ciChecks` existed.
+/// Evaluating `#ciChecks.x86_64-linux` on such a rev fails outright, so probe the
+/// flake output set cheaply (forces the `{ <system> = ...; }` spine, not the
+/// catalog) and pick the attribute that is actually present. This is a migration
+/// shim: once no base older than the `ciChecks` introduction is ever evaluated,
+/// drop the probe and target `ciChecks` directly (ENG-2201).
+fn catalog_attr(repo: &str, rev: &str) -> &'static str {
+    let flakeref = format!("git+file://{repo}?rev={rev}&allRefs=1#ciChecks");
+    let has_ci_checks = Command::new("nix")
+        .args([
+            "eval",
+            &flakeref,
+            "--apply",
+            "builtins.isAttrs",
+            "--option",
+            "accept-flake-config",
+            "true",
+        ])
+        .output()
+        .is_ok_and(|out| out.status.success());
+    if has_ci_checks { "ciChecks" } else { "checks" }
+}
+
 /// Evaluate every check derivation at `rev` of the local repo.
 ///
-/// Targets `.#ciChecks`, not `.#checks`: `ciChecks` keys each crate's per-#[test]
-/// checks under a `recurseForDerivations` group, so `nix-eval-jobs` enumerates
-/// cheap per-package names at the root and forces each crate's manifest IFD in
-/// its own worker job. The flat `.#checks` would force every crate's manifest in
-/// the single worker assigned the root attrpath, ballooning it to tens of GiB
-/// and getting it earlyoom-killed on the shared CI host (ENG-2201). `ciChecks`
-/// holds the same leaf derivations, so the per-#[test] diff is unchanged.
+/// Targets `.#ciChecks` when present (see [`catalog_attr`]): `ciChecks` keys each
+/// crate's per-#[test] checks under a `recurseForDerivations` group, so
+/// `nix-eval-jobs` enumerates cheap per-package names at the root and forces each
+/// crate's manifest IFD in its own worker job. The flat `.#checks` would force
+/// every crate's manifest in the single worker assigned the root attrpath,
+/// ballooning it to tens of GiB and getting it earlyoom-killed on the shared CI
+/// host (ENG-2201). Both outputs hold the same leaf derivations, so the
+/// per-#[test] diff is identical whichever is evaluated.
 ///
 /// `nix-eval-jobs` sits at the head of the pipeline; a startup/lock/fetch
 /// failure surfaces here rather than yielding an empty set that silently
 /// under-reports the blast radius.
 pub fn eval_checks(repo: &str, rev: &str) -> Result<EvalResult> {
-    let flakeref = format!("git+file://{repo}?rev={rev}&allRefs=1#ciChecks.x86_64-linux");
+    let attr = catalog_attr(repo, rev);
+    let flakeref = format!("git+file://{repo}?rev={rev}&allRefs=1#{attr}.x86_64-linux");
     let stdout = run(Command::new("nix").args([
         "run",
         EVAL_JOBS,

--- a/packages/blast-radius/src/timings.rs
+++ b/packages/blast-radius/src/timings.rs
@@ -42,9 +42,15 @@ fn parse(raw: &str) -> Result<BTreeMap<String, f64>> {
     let mut out = BTreeMap::new();
     for entry in file.results {
         if entry.kind == "BUILD" {
+            // nix-fast-build copies nix-eval-jobs' joined attr verbatim, so a
+            // sharded ciChecks leaf arrives quoted (`rust-foo."doctest-..."`).
+            // Normalize the same way the eval side does (see nix::normalize_attr)
+            // so the timings key matches the rebuilt-check name and never carries
+            // a `"` the workflow safename regex would reject.
+            //
             // Later entries win on the rare retry; nix-fast-build emits a fresh
             // BUILD record per attempt.
-            out.insert(entry.attr, entry.duration);
+            out.insert(crate::nix::normalize_attr(&entry.attr), entry.duration);
         }
     }
     Ok(out)
@@ -70,5 +76,20 @@ mod tests {
         // sufficient and avoids the lint suppression.
         assert!((map["lint"] - 12.5).abs() < 1e-9);
         assert!((map["rust-test-search"] - 87.3).abs() < 1e-9);
+    }
+
+    // A sharded ciChecks doctest leaf reaches nix-fast-build's result file with
+    // its interior segment quoted. The key is normalized to the bare dot path so
+    // it matches the rebuilt-check name and passes the workflow safename regex.
+    #[test]
+    fn unquotes_sharded_attr_keys() {
+        let raw = r#"{
+            "results": [
+                {"attr": "rust-foo.\"doctest-src/lib.rs - (line 12)\"", "type": "BUILD", "duration": 3.0, "success": true, "error": null, "outputs": {"out": "/nix/store/abc"}}
+            ]
+        }"#;
+        let map = parse(raw).unwrap();
+        assert_eq!(map.len(), 1);
+        assert!((map["rust-foo.doctest-src/lib.rs - (line 12)"] - 3.0).abs() < 1e-9);
     }
 }


### PR DESCRIPTION
> TLDR;
>
> the rust checks were a flat per-#\[test\] set, so nix-eval-jobs had to force every crate's manifest in one worker, ballooning it to 30-42 GiB until earlyoom killed it on the shared runner.
>
> The PR keeps the flat checks output (so nix flake check still works) but adds a sharded ciChecks that nests each package under recurseForDerivations, so the evaluator forces one crate at a time in restartable workers instead of all at once.

## Problem

`blast-radius` (and the `check` gate) evaluate `.#checks.x86_64-linux` with `nix-eval-jobs`. The rust checks are flattened into the top-level `checks` set by name, so to list the attr names the single worker assigned the root attrpath must force every crate's per-`#[test]` manifest IFD at once (the manifest builds each test binary to enumerate its `#[test]` cases). That one worker balloons and cannot restart, because the memory cap is only checked between jobs.

Observed live on the shared CI host (`vin-compute-1`): one `nix-eval-jobs` worker growing 14 -> 27 -> 42 GiB on a single job while sibling workers stayed \~4 GiB. When several blast-radius jobs run at once the host drops below 5 percent free and `earlyoom` SIGKILLs the evaluators (13 such kills in one incident window, all `nix-eval-jobs`), so the check fails non-deterministically. The cgroup never OOMs (`oom_kill 0`); earlyoom fires host-wide first.

This is the per-crate split the `checks` block already documents, but `mergeAttrsList` over renamed per-case keys flattened it back, so enumeration stayed monolithic.

## Fix

Nest each package's tests under one attr carrying `recurseForDerivations` instead of flattening them into the top-level set. Listing `checks` now returns the cheap per-package names (no manifest forcing), and each crate's manifest IFD is forced inside its own worker job, which restarts at the memory cap between packages. Peak per worker drops to roughly the per-crate floor (\~4 GiB), and aggregate becomes `workers x cap`, which is what makes `--max-memory-size` and worker restart effective and keeps earlyoom from seeing a tens-of-GiB target.

The leaf derivations are byte-identical, so the per-case count and `--timings` keys are unchanged; check names gain a per-package path segment (`rust-foo.bar-tests-baz` instead of `rust-foo-bar-tests-baz`). The gate (nix-fast-build) and blast-radius both wrap `nix-eval-jobs`, which recurses `recurseForDerivations`, so both see the same names consistently.

A subtle point captured in the code comment: the nested value must stay a thunk. Filtering empty groups (for example `tests != {}`) would force every package's tests during enumeration and reintroduce the balloon, so empty groups are left in and nix-eval-jobs simply recurses them to nothing.

## Validation

* Evaluation succeeds locally: lint ran through eval and started building the cargo-units IFD. It then failed only because this developer's nix daemon lacks the `ca-derivations` experimental feature (non-trusted user, cannot override), which is why the local pre-commit lint hook was skipped. CI runs the identical lint and the `check` gate with `ca-derivations` and builders.
* Laziness of the nesting is the load-bearing property and follows from Nix semantics: `attrNames` forces attrset keys, not values.
* Final memory confirmation is the gate run on this PR, plus the same one-line pattern applied to the `ix` repo's `#checks` assembly (the catalog seen ballooning on prod is the `ix` repo, a separate consumer of this lib; that mirror is the prod-landing step).

Part of [ENG-2201](https://linear.app/indexable/issue/ENG-2201/blast-radius-eval-balloons-one-nix-eval-jobs-worker-and-gets-earlyoom)

> \[!NOTE\]
>
> ### Nest per-`#[test]` checks under `recurseForDerivations` groups in `ciChecks` so nix-eval-jobs shards by package
>
> * Adds a new `ciChecks` flake output where Rust checks are grouped per-package using `recurseForDerivations`, so `nix-eval-jobs` evaluates each package shard independently rather than enumerating all leaf derivations in a single worker.
> * Introduces `rustPackageTestSets` with `flat` and `sharded` variants; `checks` continues to use the flat keying (one derivation per test), while `ciChecks` uses the sharded keying.
> * Adds a `catalogFor` helper in [flake.nix](<https://github.com/indexable-inc/index/pull/750/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0>) that centralises composition of explicit, Rust, and image checks with collision-safety assertions.
> * Updates `nix run .#check`, the blast-radius diff, and CI workflows to target `.#ciChecks.x86_64-linux` instead of `.#checks.x86_64-linux`.
> * Behavioral Change: `eval_checks` in [packages/blast-radius/src/nix.rs](<https://github.com/indexable-inc/index/pull/750/files#diff-14eaffb995110afd87ea035ed088cee05190e63275835359b273ee0fce584a12>) now calls `nix-eval-jobs` against `#ciChecks.x86_64-linux`; the leaf derivations are the same but the evaluation topology changes.
>
> [Macroscope](<https://app.macroscope.com>) summarized b455383.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Nest per-`#[test]` checks under package attrs so nix-eval-jobs shards enumeration across workers
> - Adds a `ciChecks` flake output alongside `checks`, where Rust tests are grouped per-package (`recurseForDerivations`) instead of flattened, letting nix-eval-jobs distribute evaluation across workers rather than serializing it in one.
> - Introduces `rustPackageTestSets` with `flat` and `sharded` views of the same leaf derivations; `checks` uses `flat`, `ciChecks` uses `sharded`.
> - Updates `nix run .#check` and blast-radius to target `.#ciChecks.x86_64-linux` instead of `.#checks.x86_64-linux`.
> - blast-radius now probes both revisions via `catalog_attr` and picks `ciChecks` when both have it, ensuring base and head use the same attribute keying for diffs.
> - Adds `normalize_attr` in [nix.rs](https://github.com/indexable-inc/index/pull/750/files#diff-14eaffb995110afd87ea035ed088cee05190e63275835359b273ee0fce584a12) and [timings.rs](https://github.com/indexable-inc/index/pull/750/files#diff-d01a843a7f3d06afa53965b354dadf9a47a5c27068a4de3ba5511fd0a69ae8d0) to strip quotes from nix-eval-jobs' nested attribute path encoding before diffing or indexing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6747938.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->