### PR TITLE
feat(examples): forkable nixos-switch example for the native switch loop

### DIFF
--- a/examples/nixos-switch/README.md
+++ b/examples/nixos-switch/README.md
@@ -1,0 +1,49 @@
+# NixOS switch
+
+The smallest fork-and-go example of the native `ix switch` loop: boot a NixOS VM
+from the `ix/base` image, add a package, and watch ix rebuild and activate the
+new system on the running VM in place.
+
+This is the native path to switch a NixOS VM via ix infrastructure. Your source
+tree is uploaded to ix, the `nix build` and `switch-to-configuration switch` run
+server-side on ix (not as remote-shell commands driven from your laptop), and
+only the result streams back. Re-running converges the VM to the current
+configuration, the same contract as `nixos-rebuild switch`.
+
+## Run
+
+```sh
+ix up
+```
+
+The first run creates `devbox` from `ix/base:latest` and activates this
+configuration on it.
+
+## The loop
+
+1. Edit [`configuration.nix`](configuration.nix): add a package to
+   `environment.systemPackages` (try `pkgs.ripgrep`).
+2. Run `ix up` again. ix uploads the change, builds the new closure on ix, and
+   switches the running VM to it.
+3. `ix shell devbox` and confirm the new package is on `PATH`.
+
+The VM keeps running across switches: only its system generation changes,
+nothing is recreated.
+
+## Shape
+
+- [`default.nix`](default.nix) declares a one-node fleet (`devbox`) on the
+  `ix/base` NixOS base image.
+- [`configuration.nix`](configuration.nix) is the NixOS module you edit.
+
+## Fork it
+
+Copy this directory into your own repo and change `ix.image.tag` in
+`default.nix` to your own registry namespace. The switch path needs no admin
+rights: it builds and activates your own system onto your own VM.
+
+## Scope
+
+This builds on the target VM itself, the `ix up` / `ix switch` default. Building
+on a separate per-user builder VM (`--build-vm`) is a follow-up; the same-VM
+path shown here is the native switch primitive.

--- a/examples/nixos-switch/configuration.nix
+++ b/examples/nixos-switch/configuration.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }:
+{
+  # This is the line to edit. Add or remove packages, then run `ix up` again
+  # (or `ix switch`) and ix rebuilds the closure and activates it on the running
+  # VM in place, the same contract as `nixos-rebuild switch`.
+  #
+  # This is an ordinary NixOS module: `services.*`, `users.*`, `systemd.*`, and
+  # any module shipped by the ix base image all work here too.
+  environment.systemPackages = [
+    pkgs.htop
+  ];
+}

--- a/examples/nixos-switch/default.nix
+++ b/examples/nixos-switch/default.nix
@@ -1,0 +1,12 @@
+{ index }:
+
+# A one-node NixOS fleet that exists to demonstrate the native `ix switch` loop:
+# `ix up` builds this configuration on ix and activates it on the running VM in
+# place. Edit `configuration.nix`, run it again, and the VM converges.
+index.lib.mkFleet {
+  defaults = [ { ix.image.tag = "nixos-switch"; } ];
+
+  nodes.devbox = {
+    modules = [ ./configuration.nix ];
+  };
+}

--- a/skills/ix/references/vms.md
+++ b/skills/ix/references/vms.md
@@ -19,4 +19,10 @@ East-west networking groups for VM-to-VM connectivity.
 
 ## NixOS
 
-`ix switch` applies a new NixOS system configuration to a running VM. Target can be a Nix installable, a `.drv` path, or a `/nix/store` system path.
+`ix switch` applies a new NixOS system configuration to a running VM, the same contract as `nixos-rebuild switch`: the VM keeps running and only its system generation changes. The target is a Nix installable, a `.drv` path, or a `/nix/store` system path.
+
+This is native, not remote-shell puppeteering. For the default same-VM path, your source tree is uploaded to ix and the `nix build` plus `switch-to-configuration switch` run server-side on ix infrastructure; only the build/activate output streams back.
+
+`ix up` is the declarative front-end over create + switch: it creates the VM from a NixOS base image (`ix/base:latest`) if it does not exist yet, then switches it to the freshly built system. Re-running `ix up` converges the VM to the current configuration.
+
+The [`nixos-switch`](../../../examples/nixos-switch/) example is the smallest fork-and-go version of this loop: one NixOS node, one package list to edit, `ix up` to converge.


### PR DESCRIPTION
## What

A minimal, fork-and-go `examples/nixos-switch/` that teaches the native `ix switch` / `ix up` loop: boot a NixOS VM from `ix/base`, edit one package list, and ix rebuilds the closure and activates it on the running VM in place, the same contract as `nixos-rebuild switch`.

This is the native path to switch a NixOS VM via ix infrastructure: the source tree is uploaded to ix and the `nix build` plus `switch-to-configuration switch` run server-side on ix, not as remote-shell commands puppeted from the laptop. Only the build/activate output streams back.

## Why

ENG-1731 (modern-dx switch) wants an index example users can fork to set up NixOS VMs and do switches natively. The existing `examples/*` all teach the fleet/image-build model; none is the minimal edit-a-package-and-switch loop. This fills that gap with the smallest possible teaching example and documents the loop in the VMs reference.

## Shape

- `examples/nixos-switch/default.nix` - one-node fleet (`devbox`) on `ix/base`, modeled on the existing minimal examples (`mkFleet`, in-place switch is the default since `recreateOnUp` is `false`).
- `examples/nixos-switch/configuration.nix` - the single NixOS module to edit (`environment.systemPackages`).
- `examples/nixos-switch/README.md` - the fork -> edit -> `ix up` loop, plus how to point it at your own registry namespace (no admin rights needed).
- `skills/ix/references/vms.md` - expanded NixOS section documenting the native switch loop and linking the example.

## Scope

Same-VM path (the `ix up` / `ix switch` default). The per-user builder VM (`--build-vm`, ENG-2125) is a deferred follow-up.

Closes ENG-2126
Part of ENG-1731

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add forkable NixOS switch example for the native `ix switch` loop
> - Adds a minimal example at [examples/nixos-switch/](https://github.com/indexable-inc/index/pull/751/files#diff-f04c8b5ec488776de8ac353921f90db746491010af97e36e02040f60bc01c7ad) with a one-node fleet declaration and a `configuration.nix` that installs `htop`, designed to be forked as a starting point.
> - Expands [skills/ix/references/vms.md](https://github.com/indexable-inc/index/pull/751/files#diff-3a7aa674b59a7a248de5eb635addc737e2d329eb420a03a3b0b435210666a36c) to clarify `ix switch` semantics (matches `nixos-rebuild switch`; VM keeps running, only the system generation changes) and the same-VM build path (source uploaded to ix, built and activated server-side).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81dec73.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->