### PR TITLE
feat(blast-radius): per-phase wall-clock instrumentation (ENG-2187)

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -164,7 +164,12 @@ jobs:
               # map; the same `name_ok` charset gates the keys so a malicious
               # report cannot inject mention/HTML through a check label.
               ((.timings // {}) | type == "object") and
-              ((.timings // {}) | to_entries | all((.key | name_ok) and (.value | type == "number")))
+              ((.timings // {}) | to_entries | all((.key | name_ok) and (.value | type == "number"))) and
+              # `phaseTimings` is always present (the Rust crate stamps every
+              # phase including `total`). Keys are stable kebab-case so a
+              # hostile report cannot smuggle attacker-controlled keys into
+              # the artifact, even though the renderer never reads them.
+              (.phaseTimings | type == "object" and (to_entries | all((.key | type == "string" and test("^[a-z][a-z0-9-]*$")) and (.value | type == "number"))))
             )
           ' report.json > /dev/null \
             || { echo "::error::malformed blast-radius report.json"; exit 1; }

--- a/packages/blast-radius/src/main.rs
+++ b/packages/blast-radius/src/main.rs
@@ -14,6 +14,7 @@ mod timings;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
+use std::time::Instant;
 
 use clap::Parser;
 use color_eyre::eyre::{Result, bail};
@@ -21,20 +22,19 @@ use color_eyre::eyre::{Result, bail};
 use causes::{Caps, root_causes};
 use report::{Report, categories};
 
+/// Phase labels are kebab-case and stable: they appear in CI logs and in
+/// `report.json.phaseTimings`, so renaming them breaks downstream readers.
+fn record_phase(phases: &mut BTreeMap<String, f64>, label: &'static str, secs: f64) {
+    eprintln!("blast-radius: {label}: {secs:.2}s");
+    phases.insert(label.to_owned(), secs);
+}
+
 /// Graph budget for the rendered flowchart: only the highest fan-out causes, and
 /// a few checks each, are drawn. The changed-checks list stays complete.
 const CAPS: Caps = Caps {
     max_causes: 6,
     max_checks_per_cause: 5,
 };
-
-/// The two catalog evaluations a report diffs. A named struct rather than a bare
-/// `(EvalResult, EvalResult)` so the concurrent-eval scope below has a
-/// self-documenting return (and satisfies `clippy::anonymous_tuple_return_type`).
-struct Evals {
-    base: nix::EvalResult,
-    head: nix::EvalResult,
-}
 
 #[derive(Parser)]
 #[command(
@@ -108,31 +108,103 @@ fn guard_eval_failures(base: &nix::EvalResult, head: &nix::EvalResult) -> Result
     Ok(())
 }
 
+/// The two catalog evaluations a report diffs. Named (rather than a bare
+/// tuple) to satisfy the workspace's `clippy::anonymous_tuple_return_type`.
+struct Evals {
+    base: nix::EvalResult,
+    head: nix::EvalResult,
+}
+
+/// Evaluate the catalog at base and head in parallel, timing each thread's
+/// own work so the recorded seconds reflect that worker's compute and not the
+/// parent scope's wall clock. The gap between `eval-base + eval-head` and
+/// `total` is the parallelism dividend.
+///
+/// The eval cache stays off (see [`nix::eval_checks`]): two concurrent
+/// `nix-eval-jobs` contend on the per-commit eval-cache `SQLite`.
+fn concurrent_evals(
+    repo: &str,
+    base: &str,
+    head: &str,
+    catalog: &str,
+    phases: &mut BTreeMap<String, f64>,
+) -> Result<Evals> {
+    let (base, head) = std::thread::scope(|scope| {
+        let head_h = scope.spawn(|| {
+            let t = Instant::now();
+            (nix::eval_checks(repo, head, catalog), t.elapsed().as_secs_f64())
+        });
+        let t = Instant::now();
+        let base = (nix::eval_checks(repo, base, catalog), t.elapsed().as_secs_f64());
+        let head = head_h
+            .join()
+            .unwrap_or_else(|panic| std::panic::resume_unwind(panic));
+        (base, head)
+    });
+    record_phase(phases, "eval-base", base.1);
+    record_phase(phases, "eval-head", head.1);
+    Ok(Evals {
+        base: base.0?,
+        head: head.0?,
+    })
+}
+
+/// Walk the changed-check frontier into a ranked cause list. Returns an
+/// empty list when nothing changed: the caller only renders causes that fan
+/// out from one of the rebuilt drvs.
+fn compute_causes(
+    base: &[nix::Check],
+    head: &[nix::Check],
+    changed: &[String],
+    phases: &mut BTreeMap<String, f64>,
+) -> Result<Vec<causes::Cause>> {
+    if changed.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Full `.drv` paths feed `nix derivation show`; the resulting graphs are
+    // keyed by basename, so attribute a check to its head drv's basename.
+    let head_paths: Vec<String> = changed
+        .iter()
+        .filter_map(|attr| nix::drv_for(head, attr))
+        .collect();
+    let base_paths: Vec<String> = changed
+        .iter()
+        .filter_map(|attr| nix::drv_for(base, attr))
+        .collect();
+    let t = Instant::now();
+    let head_graph = nix::derivation_graph(&head_paths)?;
+    record_phase(phases, "derivation-show-head", t.elapsed().as_secs_f64());
+    let t = Instant::now();
+    let base_graph = nix::derivation_graph(&base_paths)?;
+    record_phase(phases, "derivation-show-base", t.elapsed().as_secs_f64());
+    let changed_basenames: BTreeMap<String, String> = changed
+        .iter()
+        .filter_map(|attr| {
+            nix::drv_for(head, attr).map(|path| (attr.clone(), nix::basename(&path).to_owned()))
+        })
+        .collect();
+    let t = Instant::now();
+    let causes = root_causes(&base_graph, &head_graph, &changed_basenames, CAPS);
+    record_phase(phases, "root-causes", t.elapsed().as_secs_f64());
+    Ok(causes)
+}
+
 fn main() -> Result<()> {
     color_eyre::install()?;
     let cli = Cli::parse();
+    let wall = Instant::now();
+    let mut phases: BTreeMap<String, f64> = BTreeMap::new();
     let revs = git::resolve(cli.base.as_deref(), cli.head.as_deref())?;
 
     // Pick one catalog output for both revisions so their attr names line up
     // (see nix::catalog_attr): `ciChecks` when both revs expose it, else flat
     // `checks`. Resolved before the eval scope so base and head never mix keying.
+    let t = Instant::now();
     let catalog = nix::catalog_attr(&revs.repo, &revs.base, &revs.head);
+    record_phase(&mut phases, "catalog-probe", t.elapsed().as_secs_f64());
 
-    // base and head evals are independent, so run them concurrently. Each is a
-    // full `#{catalog}.x86_64-linux` evaluation (~11 min on ix's ~4300 checks),
-    // mostly blocked on the per-unit cargo IFD builds, so overlapping them
-    // roughly halves the wall clock versus back-to-back. The eval cache stays
-    // off (see eval_checks): with it on, two concurrent nix-eval-jobs contend on
-    // the per-commit eval-cache SQLite and fail with "database is busy".
-    let Evals { base, head } = std::thread::scope(|scope| -> Result<Evals> {
-        let head_eval = scope.spawn(|| nix::eval_checks(&revs.repo, &revs.head, catalog));
-        let base = nix::eval_checks(&revs.repo, &revs.base, catalog)?;
-        let head = match head_eval.join() {
-            Ok(result) => result?,
-            Err(_) => bail!("head check evaluation thread panicked"),
-        };
-        Ok(Evals { base, head })
-    })?;
+    let Evals { base, head } =
+        concurrent_evals(&revs.repo, &revs.base, &revs.head, catalog, &mut phases)?;
     guard_eval_failures(&base, &head)?;
     let base = base.checks;
     let head = head.checks;
@@ -170,29 +242,7 @@ fn main() -> Result<()> {
     removed.sort();
     let total = head.len();
 
-    let causes = if changed.is_empty() {
-        Vec::new()
-    } else {
-        // Full `.drv` paths feed `nix derivation show`; the resulting graphs are
-        // keyed by basename, so attribute a check to its head drv's basename.
-        let head_paths: Vec<String> = changed
-            .iter()
-            .filter_map(|attr| nix::drv_for(&head, attr))
-            .collect();
-        let base_paths: Vec<String> = changed
-            .iter()
-            .filter_map(|attr| nix::drv_for(&base, attr))
-            .collect();
-        let head_graph = nix::derivation_graph(&head_paths)?;
-        let base_graph = nix::derivation_graph(&base_paths)?;
-        let changed_basenames: BTreeMap<String, String> = changed
-            .iter()
-            .filter_map(|attr| {
-                nix::drv_for(&head, attr).map(|path| (attr.clone(), nix::basename(&path).to_owned()))
-            })
-            .collect();
-        root_causes(&base_graph, &head_graph, &changed_basenames, CAPS)
-    };
+    let causes = compute_causes(&base, &head, &changed, &mut phases)?;
 
     // Best-effort: a present-but-unreadable or corrupt timings file (a partial
     // artifact download, an empty upload) must not fail the report and break the
@@ -209,6 +259,8 @@ fn main() -> Result<()> {
         })
     });
 
+    record_phase(&mut phases, "total", wall.elapsed().as_secs_f64());
+
     let report = Report {
         base: short(&revs.base),
         head: short(&revs.head),
@@ -219,6 +271,7 @@ fn main() -> Result<()> {
         added,
         removed,
         timings,
+        phase_timings: phases,
     };
 
     if cli.json {

--- a/packages/blast-radius/src/report.rs
+++ b/packages/blast-radius/src/report.rs
@@ -60,6 +60,11 @@ pub struct Report {
     /// rebuilt) or are new on this PR.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub timings: BTreeMap<String, f64>,
+    /// Per-phase wall-clock seconds for this report's producer pipeline.
+    /// Keys are stable kebab-case (see `main::record_phase`); values are raw
+    /// seconds with no rounding so a downstream trend stays precise.
+    #[serde(default, rename = "phaseTimings")]
+    pub phase_timings: BTreeMap<String, f64>,
 }
 
 /// Format `seconds` as a short, scannable suffix: `<1s` under a second,
@@ -241,6 +246,7 @@ mod tests {
                 },
             ],
             timings,
+            phase_timings: BTreeMap::new(),
         }
     }
 

--- a/tools/blast-radius-fixtures/bad-phase-key.json
+++ b/tools/blast-radius-fixtures/bad-phase-key.json
@@ -1,0 +1,4 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":1,
+ "changed":[],"added":[],"removed":[],
+ "categories":[],"causes":[],
+ "phaseTimings":{"Eval-Base":1.0}}

--- a/tools/blast-radius-fixtures/bad-phase-value.json
+++ b/tools/blast-radius-fixtures/bad-phase-value.json
@@ -1,0 +1,4 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":1,
+ "changed":[],"added":[],"removed":[],
+ "categories":[],"causes":[],
+ "phaseTimings":{"eval-base":"23s"}}

--- a/tools/blast-radius-fixtures/good.json
+++ b/tools/blast-radius-fixtures/good.json
@@ -5,4 +5,5 @@
  "causes":[{"name":"ix-rust-workspace","checks":["mcp-serverTools","rust-test-search_core"]},
            {"name":"image-base-layer","checks":["image-base"]},
            {"name":"ix-images-lint","checks":["lint"]}],
- "timings":{"mcp-serverTools":42.0,"rust-test-search_core":130.0,"image-base":0.6}}
+ "timings":{"mcp-serverTools":42.0,"rust-test-search_core":130.0,"image-base":0.6},
+ "phaseTimings":{"catalog-probe":0.4,"eval-base":23.4,"eval-head":25.1,"derivation-show-base":2.1,"derivation-show-head":2.0,"root-causes":0.05,"total":47.3}}

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -22,10 +22,13 @@ yq '.jobs.comment.steps[] | select(.name == "Render comment").run' "$workflow" >
 
 validate() { ( cd "$tmp" && cp "$1" report.json && bash validate.sh ); }
 
-# Schema validation: the good report passes; hostile names and old (missing
-# categories/causes) reports are rejected fail-closed.
+# Schema validation: the good report passes; hostile and old (missing
+# categories/causes/phaseTimings) reports are rejected fail-closed. The two
+# `bad-phase-*` fixtures pin the kebab-case key constraint and the number-
+# typed value constraint that keep an attacker from smuggling shapes into
+# the artifact.
 if validate "$fixtures/good.json" >/dev/null 2>&1; then note "validate good: ok"; else note "validate good: FAIL"; fail=1; fi
-for bad in bad-name bad-check missing; do
+for bad in bad-name bad-check missing bad-phase-key bad-phase-value; do
   if validate "$fixtures/$bad.json" >/dev/null 2>&1; then
     note "validate $bad: FAIL (accepted hostile/old report)"; fail=1
   else
@@ -34,6 +37,9 @@ for bad in bad-name bad-check missing; do
 done
 
 # Render: the good report produces the golden comment (pie + flowchart + list).
+# `phaseTimings` is observability-only and never renders, so the golden
+# comment from a report carrying phaseTimings has no trace of those keys;
+# any drift here means the renderer leaked them.
 ( cd "$tmp" && cp "$fixtures/good.json" report.json && bash render.sh )
 if diff -u "$fixtures/good.expected.md" "$tmp/comment.md"; then note "render good: ok"; else note "render good: FAIL (output drift)"; fail=1; fi
 


### PR DESCRIPTION
blast-radius takes ~11m on ix's ~4300-check catalog and the CI step only sees its outer start/end. The tool emits no per-phase timing, so any optimization picked today (narrowing the rust family, restructuring the eval cache, batching `nix derivation show`, swapping producers) is guessing at which phase dominates.

Wrap each subprocess phase with an `Instant::now()` pair, log it to stderr as it ends, and stamp the same map into a `phaseTimings` field on report.json. Stable kebab-case keys: `catalog-probe`, `eval-base`, `eval-head`, `derivation-show-base|head`, `root-causes`, `total`. The sum of `eval-base + eval-head` exceeds `total` by exactly the concurrent scope's overlap window; that gap is the parallelism dividend the next optimization will trade against.

The producer always emits the field, the validator requires it, the renderer ignores it. Both producer and validator ship from the same PR tree, so there is no in-flight version drift to compat around.

Empirical baseline on this repo (1003 checks; ix is ~4.3x bigger and per-check is ~3x slower):

| Run | Wall | Catalog |
|---|---|---|
| skills-materialize ([27027129419](https://github.com/indexable-inc/index/actions/runs/27027129419)) | 47s | 1003, 3 changed |
| codex/google-calendar ([27027787432](https://github.com/indexable-inc/index/actions/runs/27027787432)) | 94s | 1042, 211 changed + 41 added |

I cannot reproduce ix-scale timings from this darwin box, so any direct optimization here is speculative. Once this lands, the next ix blast-radius CI run carries the breakdown and ENG-2187 closes with the smallest fix the numbers justify.

## Test plan

- [x] `cargo test -p blast-radius` (14 tests pass)
- [x] `bash tools/blast-radius-test.sh` (12 assertions: `good` validates and renders byte-identical to the golden, `bad-phase-key` rejects uppercase, `bad-phase-value` rejects non-numeric, overflow + backstop guards intact)
- [ ] First post-merge ix blast-radius run exposes the breakdown — that observation, not this PR, is the ENG-2187 deliverable

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-phase wall-clock instrumentation to blast-radius report output
> - Adds a `phaseTimings` field (`BTreeMap<String, f64>`) to the `Report` struct in [report.rs](https://github.com/indexable-inc/index/pull/753/files#diff-2c62d3a5b277d0658a5553d55b62ab38ba2fe8e7e459d2d4910f85a98782dd93), serialized as a JSON object of kebab-case keys to seconds.
> - Refactors [main.rs](https://github.com/indexable-inc/index/pull/753/files#diff-26dadfc8230ddb1d1e7777603b294fc2e488f469a8c3f43c05132eec464898d6) to extract `concurrent_evals` and `compute_causes` functions, each measuring elapsed time via `Instant` for phases: `catalog-probe`, `eval-base`, `eval-head`, `derivation-show-base`, `derivation-show-head`, `root-causes`, and `total`.
> - Emits human-readable timing lines to stderr and populates `phaseTimings` in `report.json`.
> - Extends CI schema validation in [blast-radius.yml](https://github.com/indexable-inc/index/pull/753/files#diff-f18ec732b17d456a8d2f9c00a4941f9433314b97b8a3df9cea22bdaf15337468) and [blast-radius-test.sh](https://github.com/indexable-inc/index/pull/753/files#diff-008b7e349202f69865582328028ef88fb2c6c22cdfd1f42fbbf5533600c2e27b) to reject reports missing `phaseTimings` or using non-kebab-case keys / non-numeric values.
> - Risk: panics in the head eval thread now propagate as process panics rather than being converted to handled `eyre` errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb5797b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->