### PR TITLE
Add our own codex wrapper package

### DIFF
--- a/packages/codex/default.nix
+++ b/packages/codex/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  codex,
+  makeBinaryWrapper,
+  symlinkJoin,
+  binName ? "codex",
+  # Config-key defaults, applied as highest-precedence runtime `-c key=value`
+  # overrides (codex's `--config` layer wins over every file layer, so a baked
+  # value here cannot be silently dropped by a churned ~/.codex/config.toml).
+  # Declared as data so the flags below derive from one source; a consumer adds
+  # or replaces keys with `codex.override { settings = { ... }; }`.
+  #
+  # We run a trusted config (our own AGENTS.md / hooks / MCP servers), so the
+  # one default we bake fleet-wide is turning off the startup update check: the
+  # store binary is read-only and the wrapper owns the version pin, so the check
+  # only ever costs a network round-trip it can never act on. Anything
+  # security-shaped (sandbox mode, approval policy) is left to the user's config
+  # and codex's own requirements layer, since a bare host is genuinely not a
+  # sandbox.
+  settings ? {
+    check_for_update_on_startup = false;
+  },
+}:
+let
+  # Render an attrset of config defaults into the repeated `--config key=value`
+  # flags codex accepts. Each value is encoded as TOML (booleans bare, strings
+  # quoted, tables inline) so structured defaults round-trip through the runtime
+  # override layer exactly as a config.toml entry would. Inline tables are
+  # emitted WITHOUT spaces so the whole flag survives makeBinaryWrapper's
+  # space-splitting of `--add-flags`.
+  toToml =
+    value:
+    if builtins.isBool value then
+      (if value then "true" else "false")
+    else if builtins.isString value then
+      builtins.toJSON value
+    else if builtins.isInt value || builtins.isFloat value then
+      toString value
+    else if builtins.isAttrs value then
+      "{${lib.concatStringsSep "," (lib.mapAttrsToList (k: v: "${k}=${toToml v}") value)}}"
+    else
+      throw "codex: unsupported config value type for ${builtins.toJSON value}";
+  configFlags = lib.mapAttrsToList (key: value: "--config ${key}=${toToml value}") settings;
+in
+symlinkJoin {
+  name = "codex-${codex.version}";
+  paths = [ codex ];
+  nativeBuildInputs = [ makeBinaryWrapper ];
+  # symlinkJoin links the whole codex output (libexec, completions, ...); we only
+  # re-wrap the entrypoint so our baked `-c` defaults ride every invocation while
+  # everything else stays pristine. `--add-flags` (prepended) keeps a user's
+  # explicit `-c` on the CLI winning, since codex is last-wins within the runtime
+  # layer.
+  postBuild = ''
+    rm -f $out/bin/${binName}
+    makeBinaryWrapper ${lib.getExe codex} $out/bin/${binName} \
+      --inherit-argv0 \
+      --add-flags ${lib.escapeShellArg (lib.concatStringsSep " " configFlags)}
+  '';
+  meta = codex.meta // {
+    description = "${codex.meta.description or "OpenAI Codex CLI"} (index wrapper with baked defaults)";
+    mainProgram = binName;
+  };
+}

--- a/packages/codex/package.nix
+++ b/packages/codex/package.nix
@@ -1,0 +1,14 @@
+{
+  id = "codex";
+  # `packageSet` here means the index package set (`index.packages.<sys>.codex`,
+  # built via packageSetFor), NOT a nixpkgs overlay: it does not inject into
+  # `pkgs`, so `pkgs.codex` stays the plain nixpkgs CLI (see the `flake`-only
+  # note below).
+  packageSet = true;
+  # Flake-output only, deliberately NOT an overlay: `pkgs.codex` must stay the
+  # plain nixpkgs CLI because symphony's room-server wrapper pins `pkgs.codex`
+  # as the binary it spawns over JSON-RPC. Our wrapper is an additive output
+  # (`nix run .#codex`, `index.packages.<sys>.codex`) that bakes our defaults on
+  # top of that same base, without changing what the overlay hands other code.
+  flake = true;
+}


### PR DESCRIPTION
Wraps the nixpkgs codex CLI with our baked operational defaults, parallel to `packages/claude-code`. Flake-output only (not an overlay), so `pkgs.codex` stays the plain CLI that symphony's room-server pins.

Defaults are data: an attrset rendered to highest-precedence `-c key=value` runtime flags (codex's `--config` layer wins over every file layer). Ships with the startup update check off; consumers add model/sandbox/MCP servers via `codex.override { settings = { ... }; }`.

`nix run .#codex` and `index.packages.<sys>.codex` now resolve to the wrapped binary. Consumed downstream by my personal nix config to inject a declarative MCP set (single-sourced with Claude).

Made with Claude Code (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a `codex` wrapper package that disables update checks on startup
> - Introduces [packages/codex/default.nix](https://github.com/indexable-inc/index/pull/755/files#diff-e55d9cc88afab2dfc2df8aaee679a57dad3e8e9395013e040581705d85b918da), a `symlinkJoin`-based derivation that wraps the upstream `codex` binary using `makeBinaryWrapper`, prepending `--config check_for_update_on_startup=false` (and any additional `settings`) before user-supplied arguments.
> - Adds a local `toToml` helper that serializes Nix values (booleans, strings, integers/floats, nested attribute sets) into TOML-compatible strings for use as `--config key=value` flags; throws on unsupported types.
> - Registers the package via [packages/codex/package.nix](https://github.com/indexable-inc/index/pull/755/files#diff-dc22f03bf54af28ffea01cb6b71d1968c8d9f004cd477b94bf5b09a7c35f8689) with id `codex` in the index package set with flake output enabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3554c38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->