### PR TITLE
claude-code: add opt-in index-MCP-only lockdown

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -101,7 +101,9 @@ let
   #     the agent to the index MCP server and strip every built-in tool from
   #     context. Arrays concat across layers and a deny at any scope wins, so a
   #     downstream user/project/local settings file cannot un-deny these; the
-  #     only un-lock is the nix `restrictToIndexMcp = false` override.
+  #     only un-lock is the nix `restrictToIndexMcp = false` override. Caveat: a
+  #     managed `bypassPermissions` (e.g. the dev image) skips the whole
+  #     permission layer, so these deny rules are inert there.
   #   permissions.defaultMode + skipDangerousModePermissionPrompt (only when
   #     `dangerouslySkipPermissions`, the opt-in escape hatch): start in bypass
   #     mode and pre-accept the one-time dangerous-mode warning. Both keys are
@@ -128,6 +130,7 @@ let
     "KillShell"
     "ListMcpResources"
     "NotebookEdit"
+    "PowerShell"
     "Read"
     "ReadMcpResource"
     "Skill"

--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -12,34 +12,36 @@
   gnupg,
   writeText,
   binName ? "claude",
-  # Confine the agent to the index MCP server (the in-VM Jupyter/python surface)
-  # and nothing else, as the default posture. `default` permission mode keeps the
+  # Default posture: start every session in bypass-permissions mode. We run a
+  # trusted config inside disposable sandboxes (ix guest VMs, the dev image,
+  # throwaway checkouts) where a per-tool approval dialog buys nothing and only
+  # stalls an agent that has nowhere unsafe to go. The upstream uid-0 guard still
+  # refuses bypass for an unsandboxed root user (no IS_SANDBOX=1 is baked here,
+  # since a bare host genuinely is not a sandbox), so it is a no-op exactly where
+  # it would be unsafe; sandboxed-root consumers (e.g. the dev image) keep their
+  # own IS_SANDBOX=1 wrapper and managed-settings layer. Turn it off with
+  # `claude-code.override { dangerouslySkipPermissions = false; }`.
+  dangerouslySkipPermissions ? true,
+  # Opt-in alternative posture: confine the agent to the index MCP server (the
+  # Jupyter/python surface) and nothing else. `default` permission mode keeps the
   # permission layer live, so the bare-name deny rules below strip every built-in
   # tool (Bash, Read, Edit, Write, ...) from the model's context, while the allow
   # rule lets the index MCP run without a prompt. Whatever the agent needs (shell,
-  # file IO, HTTP) it does through python in the kernel. We deliberately avoid
-  # `bypassPermissions` (it skips the permission layer entirely, so deny rules are
-  # silently ignored) and `dontAsk`. A consumer that wants the raw built-in tools
-  # back turns this off with `claude-code.override { restrictToIndexMcp = false; }`.
-  restrictToIndexMcp ? true,
-  # Permission rules naming the index MCP server's tools. A bare `mcp__index`
-  # matches every tool the server named `index` provides; the wildcard form is
-  # belt-and-suspenders. Override when the server is registered under a different
-  # name (e.g. home-manager's plugin delivery exposes it as
-  # `mcp__plugin_<plugin>_index`).
+  # file IO, HTTP) it does through python in the kernel. `bypassPermissions`
+  # cannot express this (it skips the permission layer entirely, so deny rules are
+  # silently ignored) and `dontAsk` is intentionally avoided. Takes PRECEDENCE
+  # over `dangerouslySkipPermissions` when both are set, since bypass would void
+  # the deny rules. Enable with `claude-code.override { restrictToIndexMcp = true; }`.
+  restrictToIndexMcp ? false,
+  # Permission rules naming the index MCP server's tools, used when
+  # restrictToIndexMcp is set. A bare `mcp__index` matches every tool the server
+  # named `index` provides; the wildcard form is belt-and-suspenders. Override
+  # when the server is registered under a different name (e.g. home-manager's
+  # plugin delivery exposes it as `mcp__plugin_<plugin>_index`).
   indexMcpAllow ? [
     "mcp__index"
     "mcp__index__*"
   ],
-  # Escape hatch for disposable sandboxes (ix guest VMs, dev containers) that
-  # genuinely want every tool with no prompt. Mutually exclusive with
-  # restrictToIndexMcp, since bypass would void the lockdown's deny rules. The
-  # upstream uid-0 guard still refuses bypass for an unsandboxed root user (no
-  # IS_SANDBOX=1 is baked here, since a bare host genuinely is not a sandbox), so
-  # it is a no-op exactly where it would be unsafe. Sandboxed-root consumers
-  # (e.g. the dev image) keep their own IS_SANDBOX=1 wrapper and managed-settings
-  # layer.
-  dangerouslySkipPermissions ? false,
   # Only the flake package set injects the Nushell writer; the overlay eval
   # context does not. The updater is a maintainer-facing flake output, so the
   # overlay build of `pkgs.claude-code` simply omits `passthru.updateScript`.
@@ -97,16 +99,16 @@ let
   # prepend ours and silently shadow a user's `--settings`.
   #   cleanupPeriodDays: keep transcripts + the wrapper's --debug logs ~1yr for
   #     the optimize analysis and troubleshooting (CLI default 30).
-  #   permissions.{allow,deny} (when `restrictToIndexMcp`, the default): confine
+  #   permissions.{allow,deny} (only when `restrictToIndexMcp`, opt-in): confine
   #     the agent to the index MCP server and strip every built-in tool from
   #     context. Arrays concat across layers and a deny at any scope wins, so a
   #     downstream user/project/local settings file cannot un-deny these; the
-  #     only un-lock is the nix `restrictToIndexMcp = false` override. Caveat: a
-  #     managed `bypassPermissions` (e.g. the dev image) skips the whole
-  #     permission layer, so these deny rules are inert there.
-  #   permissions.defaultMode + skipDangerousModePermissionPrompt (only when
-  #     `dangerouslySkipPermissions`, the opt-in escape hatch): start in bypass
-  #     mode and pre-accept the one-time dangerous-mode warning. Both keys are
+  #     only un-lock is dropping the nix `restrictToIndexMcp = true` override.
+  #     Caveat: a managed `bypassPermissions` skips the whole permission layer, so
+  #     these deny rules would be inert under one.
+  #   permissions.defaultMode + skipDangerousModePermissionPrompt (the default,
+  #     unless `restrictToIndexMcp` takes precedence): start in bypass mode and
+  #     pre-accept the one-time dangerous-mode warning. Both keys are
   #     required: managed/flag bypass alone does not suppress that warning.
   #     skipDangerousModePermissionPrompt is honored in every scope except
   #     *project* (a guard against untrusted repos), so it takes effect from this
@@ -151,7 +153,10 @@ let
       deny = deniedBuiltinTools;
     };
   }
-  // lib.optionalAttrs dangerouslySkipPermissions {
+  # restrictToIndexMcp takes precedence: bypass would skip the permission layer
+  # and void its deny rules, so the two never co-set `permissions` (a shallow //
+  # merge would otherwise clobber allow/deny with defaultMode).
+  // lib.optionalAttrs (dangerouslySkipPermissions && !restrictToIndexMcp) {
     permissions.defaultMode = "bypassPermissions";
     skipDangerousModePermissionPrompt = true;
   };
@@ -245,8 +250,6 @@ let
         '';
       };
 in
-assert lib.assertMsg (!(restrictToIndexMcp && dangerouslySkipPermissions))
-  "claude-code: restrictToIndexMcp and dangerouslySkipPermissions are mutually exclusive (bypassPermissions skips the permission layer, voiding the lockdown's deny rules).";
 stdenv.mkDerivation {
   pname = "claude-code";
   inherit version;

--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -12,18 +12,34 @@
   gnupg,
   writeText,
   binName ? "claude",
-  # Start every session in bypass-permissions mode by default. We run a trusted
-  # config inside disposable sandboxes (ix guest VMs, the dev image, throwaway
-  # checkouts) where a per-tool approval dialog buys nothing and only stalls an
-  # agent that has nowhere unsafe to go. Folded into `settingsDefaults` below so
-  # it rides the same `--settings` layer as the other defaults; a consumer turns
-  # it off with `claude-code.override { dangerouslySkipPermissions = false; }`.
-  # This only flips the default mode: the upstream uid-0 guard still refuses
-  # bypass for an unsandboxed root user (no IS_SANDBOX=1 is baked here, since a
-  # bare host genuinely is not a sandbox), so it is a no-op exactly where it
-  # would be unsafe. Sandboxed-root consumers (e.g. the dev image) keep their own
-  # IS_SANDBOX=1 wrapper and managed-settings layer.
-  dangerouslySkipPermissions ? true,
+  # Confine the agent to the index MCP server (the in-VM Jupyter/python surface)
+  # and nothing else, as the default posture. `default` permission mode keeps the
+  # permission layer live, so the bare-name deny rules below strip every built-in
+  # tool (Bash, Read, Edit, Write, ...) from the model's context, while the allow
+  # rule lets the index MCP run without a prompt. Whatever the agent needs (shell,
+  # file IO, HTTP) it does through python in the kernel. We deliberately avoid
+  # `bypassPermissions` (it skips the permission layer entirely, so deny rules are
+  # silently ignored) and `dontAsk`. A consumer that wants the raw built-in tools
+  # back turns this off with `claude-code.override { restrictToIndexMcp = false; }`.
+  restrictToIndexMcp ? true,
+  # Permission rules naming the index MCP server's tools. A bare `mcp__index`
+  # matches every tool the server named `index` provides; the wildcard form is
+  # belt-and-suspenders. Override when the server is registered under a different
+  # name (e.g. home-manager's plugin delivery exposes it as
+  # `mcp__plugin_<plugin>_index`).
+  indexMcpAllow ? [
+    "mcp__index"
+    "mcp__index__*"
+  ],
+  # Escape hatch for disposable sandboxes (ix guest VMs, dev containers) that
+  # genuinely want every tool with no prompt. Mutually exclusive with
+  # restrictToIndexMcp, since bypass would void the lockdown's deny rules. The
+  # upstream uid-0 guard still refuses bypass for an unsandboxed root user (no
+  # IS_SANDBOX=1 is baked here, since a bare host genuinely is not a sandbox), so
+  # it is a no-op exactly where it would be unsafe. Sandboxed-root consumers
+  # (e.g. the dev image) keep their own IS_SANDBOX=1 wrapper and managed-settings
+  # layer.
+  dangerouslySkipPermissions ? false,
   # Only the flake package set injects the Nushell writer; the overlay eval
   # context does not. The updater is a maintainer-facing flake output, so the
   # overlay build of `pkgs.claude-code` simply omits `passthru.updateScript`.
@@ -81,16 +97,56 @@ let
   # prepend ours and silently shadow a user's `--settings`.
   #   cleanupPeriodDays: keep transcripts + the wrapper's --debug logs ~1yr for
   #     the optimize analysis and troubleshooting (CLI default 30).
+  #   permissions.{allow,deny} (when `restrictToIndexMcp`, the default): confine
+  #     the agent to the index MCP server and strip every built-in tool from
+  #     context. Arrays concat across layers and a deny at any scope wins, so a
+  #     downstream user/project/local settings file cannot un-deny these; the
+  #     only un-lock is the nix `restrictToIndexMcp = false` override.
   #   permissions.defaultMode + skipDangerousModePermissionPrompt (only when
-  #     `dangerouslySkipPermissions`): start in bypass mode and pre-accept the
-  #     one-time dangerous-mode warning. Both keys are required: managed/flag
-  #     bypass alone does not suppress that warning. skipDangerousModePermission-
-  #     Prompt is honored in every scope except *project* (a guard against
-  #     untrusted repos), so it takes effect from this flagSettings layer. Same
-  #     two keys the dev image (images/dev/development-base) enforces via managed
-  #     settings; see its comment for the full rationale.
+  #     `dangerouslySkipPermissions`, the opt-in escape hatch): start in bypass
+  #     mode and pre-accept the one-time dangerous-mode warning. Both keys are
+  #     required: managed/flag bypass alone does not suppress that warning.
+  #     skipDangerousModePermissionPrompt is honored in every scope except
+  #     *project* (a guard against untrusted repos), so it takes effect from this
+  #     flagSettings layer. Same two keys the dev image
+  #     (images/dev/development-base) enforces via managed settings; see its
+  #     comment for the full rationale.
+  #
+  # Bare tool names as deny rules remove the built-in tool from the model's
+  # context entirely (per the permissions docs), not merely gate it behind a
+  # prompt, so the agent never sees a shell/file/web/subagent tool. Read-only Bash
+  # (`cat`, `ls`, ...) is otherwise always allowed in every mode, so denying bare
+  # `Bash` is what actually closes the shell.
+  deniedBuiltinTools = [
+    "Agent"
+    "Bash"
+    "BashOutput"
+    "Edit"
+    "ExitPlanMode"
+    "Glob"
+    "Grep"
+    "KillShell"
+    "ListMcpResources"
+    "NotebookEdit"
+    "Read"
+    "ReadMcpResource"
+    "Skill"
+    "SlashCommand"
+    "Task"
+    "TodoWrite"
+    "WebFetch"
+    "WebSearch"
+    "Write"
+  ];
+
   settingsDefaults = {
     cleanupPeriodDays = 365;
+  }
+  // lib.optionalAttrs restrictToIndexMcp {
+    permissions = {
+      allow = indexMcpAllow;
+      deny = deniedBuiltinTools;
+    };
   }
   // lib.optionalAttrs dangerouslySkipPermissions {
     permissions.defaultMode = "bypassPermissions";
@@ -186,6 +242,8 @@ let
         '';
       };
 in
+assert lib.assertMsg (!(restrictToIndexMcp && dangerouslySkipPermissions))
+  "claude-code: restrictToIndexMcp and dangerouslySkipPermissions are mutually exclusive (bypassPermissions skips the permission layer, voiding the lockdown's deny rules).";
 stdenv.mkDerivation {
   pname = "claude-code";
   inherit version;

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -172,12 +172,7 @@ let
     runtimeInputs = [
       pkgs.gh
       pkgs.jq
-      # ci-triage drives `claude -p --allowedTools Bash`; the package's default
-      # index-MCP-only lockdown bare-denies Bash (deny wins over --allowedTools,
-      # and --setting-sources "" does not drop the wrapper's --settings layer),
-      # which would strip its only tool. This agent has no index MCP and works
-      # through the shell, so opt it out of the lockdown.
-      (pkgs.claude-code.override { restrictToIndexMcp = false; })
+      pkgs.claude-code
       pkgs.coreutils
     ];
     text = builtins.readFile ./scripts/ci-triage.sh;

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -172,7 +172,12 @@ let
     runtimeInputs = [
       pkgs.gh
       pkgs.jq
-      pkgs.claude-code
+      # ci-triage drives `claude -p --allowedTools Bash`; the package's default
+      # index-MCP-only lockdown bare-denies Bash (deny wins over --allowedTools,
+      # and --setting-sources "" does not drop the wrapper's --settings layer),
+      # which would strip its only tool. This agent has no index MCP and works
+      # through the shell, so opt it out of the lockdown.
+      (pkgs.claude-code.override { restrictToIndexMcp = false; })
       pkgs.coreutils
     ];
     text = builtins.readFile ./scripts/ci-triage.sh;


### PR DESCRIPTION
## What

Add an **opt-in** `restrictToIndexMcp` posture to the vendored Claude Code wrapper. The package default is unchanged (`dangerouslySkipPermissions ? true` → `bypassPermissions`). A consumer locks its own claude to the index MCP server with:

```nix
pkgs.claude-code.override { restrictToIndexMcp = true; }
```

## Why this shape

The goal "only the index MCP usable, every other tool off, no prompts" cannot be expressed with `bypassPermissions`: per the [permission-modes docs](https://code.claude.com/docs/en/permission-modes) it *skips the permission layer entirely*, so `deny` rules are silently ignored. `dontAsk` was ruled out by preference. Plain `default` mode keeps the permission layer live, so:

- bare-name `deny` (`"Bash"`, `"Read"`, ...) removes each built-in from context, including read-only Bash (`cat`/`ls`), which is otherwise always allowed.
- `allow: indexMcpAllow` lets the index MCP run with no prompt.
- a new upstream tool we forgot to deny would prompt rather than auto-run, so it still fails safe headless.

## Interface

- `restrictToIndexMcp ? false` — opt-in lockdown posture.
- `indexMcpAllow ? [ "mcp__index" "mcp__index__*" ]` — server name(s); override when registered differently (e.g. home-manager plugin delivery names it `mcp__plugin_<plugin>_index`).
- `dangerouslySkipPermissions ? true` — unchanged default (full bypass). When both are set, `restrictToIndexMcp` takes precedence (bypass would void its deny rules), so the two never co-set `permissions`.

## Validation

- Default settings JSON: `bypassPermissions` + `skipDangerousModePermissionPrompt` (byte-identical to before).
- `restrictToIndexMcp = true` override: no `defaultMode` (default mode), `allow` = index MCP, `deny` = 20 built-ins incl. `PowerShell`. Wrapper still injects `--settings`.
- Lint green (nixfmt/statix/deadnix/ast-grep). Adversarial code-review pass.

Used by the author's home-manager config to lock their interactive claude to the index/python MCP.

AI-generated with Claude Opus 4.8.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add opt-in `restrictToIndexMcp` lockdown mode to claude-code wrapper
> - Adds two new arguments to [default.nix](https://github.com/indexable-inc/index/pull/756/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b): `restrictToIndexMcp` (default `false`) and `indexMcpAllow` (default `["mcp__index" "mcp__index__*"]`).
> - When `restrictToIndexMcp = true`, the wrapper sets `permissions.allow` to the MCP allowlist and `permissions.deny` to a list of all built-in tools (Bash, Edit, Read, Write, WebFetch, etc.), removing them from the model's context.
> - When both `restrictToIndexMcp` and `dangerouslySkipPermissions` are true, `bypassPermissions` is not set so deny rules are preserved; bypass behavior only applies when `restrictToIndexMcp` is false.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a31bb0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->