### PR TITLE
claude-code: rename lockdown arg to generic restrictToTools

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -22,26 +22,20 @@
   # own IS_SANDBOX=1 wrapper and managed-settings layer. Turn it off with
   # `claude-code.override { dangerouslySkipPermissions = false; }`.
   dangerouslySkipPermissions ? true,
-  # Opt-in alternative posture: confine the agent to the index MCP server (the
-  # Jupyter/python surface) and nothing else. `default` permission mode keeps the
-  # permission layer live, so the bare-name deny rules below strip every built-in
-  # tool (Bash, Read, Edit, Write, ...) from the model's context, while the allow
-  # rule lets the index MCP run without a prompt. Whatever the agent needs (shell,
-  # file IO, HTTP) it does through python in the kernel. `bypassPermissions`
-  # cannot express this (it skips the permission layer entirely, so deny rules are
-  # silently ignored) and `dontAsk` is intentionally avoided. Takes PRECEDENCE
-  # over `dangerouslySkipPermissions` when both are set, since bypass would void
-  # the deny rules. Enable with `claude-code.override { restrictToIndexMcp = true; }`.
-  restrictToIndexMcp ? false,
-  # Permission rules naming the index MCP server's tools, used when
-  # restrictToIndexMcp is set. A bare `mcp__index` matches every tool the server
-  # named `index` provides; the wildcard form is belt-and-suspenders. Override
-  # when the server is registered under a different name (e.g. home-manager's
-  # plugin delivery exposes it as `mcp__plugin_<plugin>_index`).
-  indexMcpAllow ? [
-    "mcp__index"
-    "mcp__index__*"
-  ],
+  # Opt-in alternative posture: confine the agent to a fixed allow-list and
+  # nothing else. Set to a list of permission rules (typically one MCP server,
+  # e.g. `[ "mcp__index" "mcp__index__*" ]`) and the wrapper switches to plain
+  # `default` permission mode, `allow`s exactly those rules, and bare-`deny`s
+  # every other built-in tool (Bash, Read, Edit, Write, ...), stripping them from
+  # the model's context. The agent can then only use the allowed tools; anything
+  # else (shell, file IO, HTTP) it must do through whatever those tools expose
+  # (e.g. a python/Jupyter MCP kernel). A built-in name listed here is removed
+  # from the deny list, so you can also re-allow a specific built-in.
+  # `bypassPermissions` cannot express this (it skips the permission layer
+  # entirely, so deny rules are silently ignored) and `dontAsk` is intentionally
+  # avoided. Takes PRECEDENCE over `dangerouslySkipPermissions`, since bypass
+  # would void the deny rules. `null` (default) leaves the normal posture.
+  restrictToTools ? null,
   # Only the flake package set injects the Nushell writer; the overlay eval
   # context does not. The updater is a maintainer-facing flake output, so the
   # overlay build of `pkgs.claude-code` simply omits `passthru.updateScript`.
@@ -99,15 +93,15 @@ let
   # prepend ours and silently shadow a user's `--settings`.
   #   cleanupPeriodDays: keep transcripts + the wrapper's --debug logs ~1yr for
   #     the optimize analysis and troubleshooting (CLI default 30).
-  #   permissions.{allow,deny} (only when `restrictToIndexMcp`, opt-in): confine
-  #     the agent to the index MCP server and strip every built-in tool from
-  #     context. Arrays concat across layers and a deny at any scope wins, so a
-  #     downstream user/project/local settings file cannot un-deny these; the
-  #     only un-lock is dropping the nix `restrictToIndexMcp = true` override.
-  #     Caveat: a managed `bypassPermissions` skips the whole permission layer, so
-  #     these deny rules would be inert under one.
+  #   permissions.{allow,deny} (only when `restrictToTools` is set, opt-in):
+  #     confine the agent to that allow-list and strip every other built-in tool
+  #     from context. Arrays concat across layers and a deny at any scope wins, so
+  #     a downstream user/project/local settings file cannot un-deny these; the
+  #     only un-lock is dropping the nix `restrictToTools` override. Caveat: a
+  #     managed `bypassPermissions` skips the whole permission layer, so these
+  #     deny rules would be inert under one.
   #   permissions.defaultMode + skipDangerousModePermissionPrompt (the default,
-  #     unless `restrictToIndexMcp` takes precedence): start in bypass mode and
+  #     unless `restrictToTools` takes precedence): start in bypass mode and
   #     pre-accept the one-time dangerous-mode warning. Both keys are
   #     required: managed/flag bypass alone does not suppress that warning.
   #     skipDangerousModePermissionPrompt is honored in every scope except
@@ -144,19 +138,23 @@ let
     "Write"
   ];
 
+  # The lockdown is active whenever the caller pins an allow-list.
+  restrictTools = restrictToTools != null;
+
   settingsDefaults = {
     cleanupPeriodDays = 365;
   }
-  // lib.optionalAttrs restrictToIndexMcp {
+  // lib.optionalAttrs restrictTools {
     permissions = {
-      allow = indexMcpAllow;
-      deny = deniedBuiltinTools;
+      allow = restrictToTools;
+      # A built-in named in the allow-list is re-allowed by dropping it here.
+      deny = lib.subtractLists restrictToTools deniedBuiltinTools;
     };
   }
-  # restrictToIndexMcp takes precedence: bypass would skip the permission layer
-  # and void its deny rules, so the two never co-set `permissions` (a shallow //
+  # restrictToTools takes precedence: bypass would skip the permission layer and
+  # void its deny rules, so the two never co-set `permissions` (a shallow //
   # merge would otherwise clobber allow/deny with defaultMode).
-  // lib.optionalAttrs (dangerouslySkipPermissions && !restrictToIndexMcp) {
+  // lib.optionalAttrs (dangerouslySkipPermissions && !restrictTools) {
     permissions.defaultMode = "bypassPermissions";
     skipDangerousModePermissionPrompt = true;
   };

--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -101,7 +101,9 @@ let
   #     the agent to the index MCP server and strip every built-in tool from
   #     context. Arrays concat across layers and a deny at any scope wins, so a
   #     downstream user/project/local settings file cannot un-deny these; the
-  #     only un-lock is the nix `restrictToIndexMcp = false` override.
+  #     only un-lock is the nix `restrictToIndexMcp = false` override. Caveat: a
+  #     managed `bypassPermissions` (e.g. the dev image) skips the whole
+  #     permission layer, so these deny rules are inert there.
   #   permissions.defaultMode + skipDangerousModePermissionPrompt (only when
   #     `dangerouslySkipPermissions`, the opt-in escape hatch): start in bypass
   #     mode and pre-accept the one-time dangerous-mode warning. Both keys are
@@ -128,6 +130,7 @@ let
     "KillShell"
     "ListMcpResources"
     "NotebookEdit"
+    "PowerShell"
     "Read"
     "ReadMcpResource"
     "Skill"

--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -12,34 +12,36 @@
   gnupg,
   writeText,
   binName ? "claude",
-  # Confine the agent to the index MCP server (the in-VM Jupyter/python surface)
-  # and nothing else, as the default posture. `default` permission mode keeps the
+  # Default posture: start every session in bypass-permissions mode. We run a
+  # trusted config inside disposable sandboxes (ix guest VMs, the dev image,
+  # throwaway checkouts) where a per-tool approval dialog buys nothing and only
+  # stalls an agent that has nowhere unsafe to go. The upstream uid-0 guard still
+  # refuses bypass for an unsandboxed root user (no IS_SANDBOX=1 is baked here,
+  # since a bare host genuinely is not a sandbox), so it is a no-op exactly where
+  # it would be unsafe; sandboxed-root consumers (e.g. the dev image) keep their
+  # own IS_SANDBOX=1 wrapper and managed-settings layer. Turn it off with
+  # `claude-code.override { dangerouslySkipPermissions = false; }`.
+  dangerouslySkipPermissions ? true,
+  # Opt-in alternative posture: confine the agent to the index MCP server (the
+  # Jupyter/python surface) and nothing else. `default` permission mode keeps the
   # permission layer live, so the bare-name deny rules below strip every built-in
   # tool (Bash, Read, Edit, Write, ...) from the model's context, while the allow
   # rule lets the index MCP run without a prompt. Whatever the agent needs (shell,
-  # file IO, HTTP) it does through python in the kernel. We deliberately avoid
-  # `bypassPermissions` (it skips the permission layer entirely, so deny rules are
-  # silently ignored) and `dontAsk`. A consumer that wants the raw built-in tools
-  # back turns this off with `claude-code.override { restrictToIndexMcp = false; }`.
-  restrictToIndexMcp ? true,
-  # Permission rules naming the index MCP server's tools. A bare `mcp__index`
-  # matches every tool the server named `index` provides; the wildcard form is
-  # belt-and-suspenders. Override when the server is registered under a different
-  # name (e.g. home-manager's plugin delivery exposes it as
-  # `mcp__plugin_<plugin>_index`).
+  # file IO, HTTP) it does through python in the kernel. `bypassPermissions`
+  # cannot express this (it skips the permission layer entirely, so deny rules are
+  # silently ignored) and `dontAsk` is intentionally avoided. Takes PRECEDENCE
+  # over `dangerouslySkipPermissions` when both are set, since bypass would void
+  # the deny rules. Enable with `claude-code.override { restrictToIndexMcp = true; }`.
+  restrictToIndexMcp ? false,
+  # Permission rules naming the index MCP server's tools, used when
+  # restrictToIndexMcp is set. A bare `mcp__index` matches every tool the server
+  # named `index` provides; the wildcard form is belt-and-suspenders. Override
+  # when the server is registered under a different name (e.g. home-manager's
+  # plugin delivery exposes it as `mcp__plugin_<plugin>_index`).
   indexMcpAllow ? [
     "mcp__index"
     "mcp__index__*"
   ],
-  # Escape hatch for disposable sandboxes (ix guest VMs, dev containers) that
-  # genuinely want every tool with no prompt. Mutually exclusive with
-  # restrictToIndexMcp, since bypass would void the lockdown's deny rules. The
-  # upstream uid-0 guard still refuses bypass for an unsandboxed root user (no
-  # IS_SANDBOX=1 is baked here, since a bare host genuinely is not a sandbox), so
-  # it is a no-op exactly where it would be unsafe. Sandboxed-root consumers
-  # (e.g. the dev image) keep their own IS_SANDBOX=1 wrapper and managed-settings
-  # layer.
-  dangerouslySkipPermissions ? false,
   # Only the flake package set injects the Nushell writer; the overlay eval
   # context does not. The updater is a maintainer-facing flake output, so the
   # overlay build of `pkgs.claude-code` simply omits `passthru.updateScript`.
@@ -97,16 +99,16 @@ let
   # prepend ours and silently shadow a user's `--settings`.
   #   cleanupPeriodDays: keep transcripts + the wrapper's --debug logs ~1yr for
   #     the optimize analysis and troubleshooting (CLI default 30).
-  #   permissions.{allow,deny} (when `restrictToIndexMcp`, the default): confine
+  #   permissions.{allow,deny} (only when `restrictToIndexMcp`, opt-in): confine
   #     the agent to the index MCP server and strip every built-in tool from
   #     context. Arrays concat across layers and a deny at any scope wins, so a
   #     downstream user/project/local settings file cannot un-deny these; the
-  #     only un-lock is the nix `restrictToIndexMcp = false` override. Caveat: a
-  #     managed `bypassPermissions` (e.g. the dev image) skips the whole
-  #     permission layer, so these deny rules are inert there.
-  #   permissions.defaultMode + skipDangerousModePermissionPrompt (only when
-  #     `dangerouslySkipPermissions`, the opt-in escape hatch): start in bypass
-  #     mode and pre-accept the one-time dangerous-mode warning. Both keys are
+  #     only un-lock is dropping the nix `restrictToIndexMcp = true` override.
+  #     Caveat: a managed `bypassPermissions` skips the whole permission layer, so
+  #     these deny rules would be inert under one.
+  #   permissions.defaultMode + skipDangerousModePermissionPrompt (the default,
+  #     unless `restrictToIndexMcp` takes precedence): start in bypass mode and
+  #     pre-accept the one-time dangerous-mode warning. Both keys are
   #     required: managed/flag bypass alone does not suppress that warning.
   #     skipDangerousModePermissionPrompt is honored in every scope except
   #     *project* (a guard against untrusted repos), so it takes effect from this
@@ -151,7 +153,10 @@ let
       deny = deniedBuiltinTools;
     };
   }
-  // lib.optionalAttrs dangerouslySkipPermissions {
+  # restrictToIndexMcp takes precedence: bypass would skip the permission layer
+  # and void its deny rules, so the two never co-set `permissions` (a shallow //
+  # merge would otherwise clobber allow/deny with defaultMode).
+  // lib.optionalAttrs (dangerouslySkipPermissions && !restrictToIndexMcp) {
     permissions.defaultMode = "bypassPermissions";
     skipDangerousModePermissionPrompt = true;
   };
@@ -245,8 +250,6 @@ let
         '';
       };
 in
-assert lib.assertMsg (!(restrictToIndexMcp && dangerouslySkipPermissions))
-  "claude-code: restrictToIndexMcp and dangerouslySkipPermissions are mutually exclusive (bypassPermissions skips the permission layer, voiding the lockdown's deny rules).";
 stdenv.mkDerivation {
   pname = "claude-code";
   inherit version;

--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -12,18 +12,34 @@
   gnupg,
   writeText,
   binName ? "claude",
-  # Start every session in bypass-permissions mode by default. We run a trusted
-  # config inside disposable sandboxes (ix guest VMs, the dev image, throwaway
-  # checkouts) where a per-tool approval dialog buys nothing and only stalls an
-  # agent that has nowhere unsafe to go. Folded into `settingsDefaults` below so
-  # it rides the same `--settings` layer as the other defaults; a consumer turns
-  # it off with `claude-code.override { dangerouslySkipPermissions = false; }`.
-  # This only flips the default mode: the upstream uid-0 guard still refuses
-  # bypass for an unsandboxed root user (no IS_SANDBOX=1 is baked here, since a
-  # bare host genuinely is not a sandbox), so it is a no-op exactly where it
-  # would be unsafe. Sandboxed-root consumers (e.g. the dev image) keep their own
-  # IS_SANDBOX=1 wrapper and managed-settings layer.
-  dangerouslySkipPermissions ? true,
+  # Confine the agent to the index MCP server (the in-VM Jupyter/python surface)
+  # and nothing else, as the default posture. `default` permission mode keeps the
+  # permission layer live, so the bare-name deny rules below strip every built-in
+  # tool (Bash, Read, Edit, Write, ...) from the model's context, while the allow
+  # rule lets the index MCP run without a prompt. Whatever the agent needs (shell,
+  # file IO, HTTP) it does through python in the kernel. We deliberately avoid
+  # `bypassPermissions` (it skips the permission layer entirely, so deny rules are
+  # silently ignored) and `dontAsk`. A consumer that wants the raw built-in tools
+  # back turns this off with `claude-code.override { restrictToIndexMcp = false; }`.
+  restrictToIndexMcp ? true,
+  # Permission rules naming the index MCP server's tools. A bare `mcp__index`
+  # matches every tool the server named `index` provides; the wildcard form is
+  # belt-and-suspenders. Override when the server is registered under a different
+  # name (e.g. home-manager's plugin delivery exposes it as
+  # `mcp__plugin_<plugin>_index`).
+  indexMcpAllow ? [
+    "mcp__index"
+    "mcp__index__*"
+  ],
+  # Escape hatch for disposable sandboxes (ix guest VMs, dev containers) that
+  # genuinely want every tool with no prompt. Mutually exclusive with
+  # restrictToIndexMcp, since bypass would void the lockdown's deny rules. The
+  # upstream uid-0 guard still refuses bypass for an unsandboxed root user (no
+  # IS_SANDBOX=1 is baked here, since a bare host genuinely is not a sandbox), so
+  # it is a no-op exactly where it would be unsafe. Sandboxed-root consumers
+  # (e.g. the dev image) keep their own IS_SANDBOX=1 wrapper and managed-settings
+  # layer.
+  dangerouslySkipPermissions ? false,
   # Only the flake package set injects the Nushell writer; the overlay eval
   # context does not. The updater is a maintainer-facing flake output, so the
   # overlay build of `pkgs.claude-code` simply omits `passthru.updateScript`.
@@ -81,16 +97,56 @@ let
   # prepend ours and silently shadow a user's `--settings`.
   #   cleanupPeriodDays: keep transcripts + the wrapper's --debug logs ~1yr for
   #     the optimize analysis and troubleshooting (CLI default 30).
+  #   permissions.{allow,deny} (when `restrictToIndexMcp`, the default): confine
+  #     the agent to the index MCP server and strip every built-in tool from
+  #     context. Arrays concat across layers and a deny at any scope wins, so a
+  #     downstream user/project/local settings file cannot un-deny these; the
+  #     only un-lock is the nix `restrictToIndexMcp = false` override.
   #   permissions.defaultMode + skipDangerousModePermissionPrompt (only when
-  #     `dangerouslySkipPermissions`): start in bypass mode and pre-accept the
-  #     one-time dangerous-mode warning. Both keys are required: managed/flag
-  #     bypass alone does not suppress that warning. skipDangerousModePermission-
-  #     Prompt is honored in every scope except *project* (a guard against
-  #     untrusted repos), so it takes effect from this flagSettings layer. Same
-  #     two keys the dev image (images/dev/development-base) enforces via managed
-  #     settings; see its comment for the full rationale.
+  #     `dangerouslySkipPermissions`, the opt-in escape hatch): start in bypass
+  #     mode and pre-accept the one-time dangerous-mode warning. Both keys are
+  #     required: managed/flag bypass alone does not suppress that warning.
+  #     skipDangerousModePermissionPrompt is honored in every scope except
+  #     *project* (a guard against untrusted repos), so it takes effect from this
+  #     flagSettings layer. Same two keys the dev image
+  #     (images/dev/development-base) enforces via managed settings; see its
+  #     comment for the full rationale.
+  #
+  # Bare tool names as deny rules remove the built-in tool from the model's
+  # context entirely (per the permissions docs), not merely gate it behind a
+  # prompt, so the agent never sees a shell/file/web/subagent tool. Read-only Bash
+  # (`cat`, `ls`, ...) is otherwise always allowed in every mode, so denying bare
+  # `Bash` is what actually closes the shell.
+  deniedBuiltinTools = [
+    "Agent"
+    "Bash"
+    "BashOutput"
+    "Edit"
+    "ExitPlanMode"
+    "Glob"
+    "Grep"
+    "KillShell"
+    "ListMcpResources"
+    "NotebookEdit"
+    "Read"
+    "ReadMcpResource"
+    "Skill"
+    "SlashCommand"
+    "Task"
+    "TodoWrite"
+    "WebFetch"
+    "WebSearch"
+    "Write"
+  ];
+
   settingsDefaults = {
     cleanupPeriodDays = 365;
+  }
+  // lib.optionalAttrs restrictToIndexMcp {
+    permissions = {
+      allow = indexMcpAllow;
+      deny = deniedBuiltinTools;
+    };
   }
   // lib.optionalAttrs dangerouslySkipPermissions {
     permissions.defaultMode = "bypassPermissions";
@@ -186,6 +242,8 @@ let
         '';
       };
 in
+assert lib.assertMsg (!(restrictToIndexMcp && dangerouslySkipPermissions))
+  "claude-code: restrictToIndexMcp and dangerouslySkipPermissions are mutually exclusive (bypassPermissions skips the permission layer, voiding the lockdown's deny rules).";
 stdenv.mkDerivation {
   pname = "claude-code";
   inherit version;

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -172,12 +172,7 @@ let
     runtimeInputs = [
       pkgs.gh
       pkgs.jq
-      # ci-triage drives `claude -p --allowedTools Bash`; the package's default
-      # index-MCP-only lockdown bare-denies Bash (deny wins over --allowedTools,
-      # and --setting-sources "" does not drop the wrapper's --settings layer),
-      # which would strip its only tool. This agent has no index MCP and works
-      # through the shell, so opt it out of the lockdown.
-      (pkgs.claude-code.override { restrictToIndexMcp = false; })
+      pkgs.claude-code
       pkgs.coreutils
     ];
     text = builtins.readFile ./scripts/ci-triage.sh;

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -172,7 +172,12 @@ let
     runtimeInputs = [
       pkgs.gh
       pkgs.jq
-      pkgs.claude-code
+      # ci-triage drives `claude -p --allowedTools Bash`; the package's default
+      # index-MCP-only lockdown bare-denies Bash (deny wins over --allowedTools,
+      # and --setting-sources "" does not drop the wrapper's --settings layer),
+      # which would strip its only tool. This agent has no index MCP and works
+      # through the shell, so opt it out of the lockdown.
+      (pkgs.claude-code.override { restrictToIndexMcp = false; })
       pkgs.coreutils
     ];
     text = builtins.readFile ./scripts/ci-triage.sh;


### PR DESCRIPTION
Follow-up to #756. The lockdown is not index-specific, so replace `restrictToIndexMcp` (bool) + `indexMcpAllow` (list) with a single nullable `restrictToTools`:

- `null` (default) → normal posture (bypass).
- a list of permission rules → plain `default` mode, `allow` exactly those, bare-`deny` every other built-in tool. A built-in named in the list is subtracted from the deny list, so the knob works for any tool, not just an MCP server.

Validated: default still renders `bypassPermissions`; `restrictToTools = ["mcp__index__*" "Read"]` renders default mode + allow=[those] with Read re-allowed and Bash still denied. Lint green.

AI-generated with Claude Opus 4.8.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `lockdown` arg to `restrictToTools` in claude-code Nix derivation
> - Replaces the previous `lockdown` argument with `restrictToTools`, which accepts an explicit allow-list of tool rules instead of a boolean flag.
> - When set, applies `permissions.allow` and `permissions.deny` in the generated settings, denying all built-in tools not in the allow-list.
> - `restrictToTools` takes precedence over `dangerouslySkipPermissions`; bypass mode is only applied when `restrictToTools` is null.
> - Behavioral Change: callers using the old `lockdown` argument must migrate to `restrictToTools` with an explicit tool list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7366262.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->