### PR TITLE
claude-code: rename lockdown arg to generic restrictToTools

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -22,26 +22,20 @@
   # own IS_SANDBOX=1 wrapper and managed-settings layer. Turn it off with
   # `claude-code.override { dangerouslySkipPermissions = false; }`.
   dangerouslySkipPermissions ? true,
-  # Opt-in alternative posture: confine the agent to the index MCP server (the
-  # Jupyter/python surface) and nothing else. `default` permission mode keeps the
-  # permission layer live, so the bare-name deny rules below strip every built-in
-  # tool (Bash, Read, Edit, Write, ...) from the model's context, while the allow
-  # rule lets the index MCP run without a prompt. Whatever the agent needs (shell,
-  # file IO, HTTP) it does through python in the kernel. `bypassPermissions`
-  # cannot express this (it skips the permission layer entirely, so deny rules are
-  # silently ignored) and `dontAsk` is intentionally avoided. Takes PRECEDENCE
-  # over `dangerouslySkipPermissions` when both are set, since bypass would void
-  # the deny rules. Enable with `claude-code.override { restrictToIndexMcp = true; }`.
-  restrictToIndexMcp ? false,
-  # Permission rules naming the index MCP server's tools, used when
-  # restrictToIndexMcp is set. A bare `mcp__index` matches every tool the server
-  # named `index` provides; the wildcard form is belt-and-suspenders. Override
-  # when the server is registered under a different name (e.g. home-manager's
-  # plugin delivery exposes it as `mcp__plugin_<plugin>_index`).
-  indexMcpAllow ? [
-    "mcp__index"
-    "mcp__index__*"
-  ],
+  # Opt-in alternative posture: confine the agent to a fixed allow-list and
+  # nothing else. Set to a list of permission rules (typically one MCP server,
+  # e.g. `[ "mcp__index" "mcp__index__*" ]`) and the wrapper switches to plain
+  # `default` permission mode, `allow`s exactly those rules, and bare-`deny`s
+  # every other built-in tool (Bash, Read, Edit, Write, ...), stripping them from
+  # the model's context. The agent can then only use the allowed tools; anything
+  # else (shell, file IO, HTTP) it must do through whatever those tools expose
+  # (e.g. a python/Jupyter MCP kernel). A built-in name listed here is removed
+  # from the deny list, so you can also re-allow a specific built-in.
+  # `bypassPermissions` cannot express this (it skips the permission layer
+  # entirely, so deny rules are silently ignored) and `dontAsk` is intentionally
+  # avoided. Takes PRECEDENCE over `dangerouslySkipPermissions`, since bypass
+  # would void the deny rules. `null` (default) leaves the normal posture.
+  restrictToTools ? null,
   # Only the flake package set injects the Nushell writer; the overlay eval
   # context does not. The updater is a maintainer-facing flake output, so the
   # overlay build of `pkgs.claude-code` simply omits `passthru.updateScript`.
@@ -99,15 +93,15 @@ let
   # prepend ours and silently shadow a user's `--settings`.
   #   cleanupPeriodDays: keep transcripts + the wrapper's --debug logs ~1yr for
   #     the optimize analysis and troubleshooting (CLI default 30).
-  #   permissions.{allow,deny} (only when `restrictToIndexMcp`, opt-in): confine
-  #     the agent to the index MCP server and strip every built-in tool from
-  #     context. Arrays concat across layers and a deny at any scope wins, so a
-  #     downstream user/project/local settings file cannot un-deny these; the
-  #     only un-lock is dropping the nix `restrictToIndexMcp = true` override.
-  #     Caveat: a managed `bypassPermissions` skips the whole permission layer, so
-  #     these deny rules would be inert under one.
+  #   permissions.{allow,deny} (only when `restrictToTools` is set, opt-in):
+  #     confine the agent to that allow-list and strip every other built-in tool
+  #     from context. Arrays concat across layers and a deny at any scope wins, so
+  #     a downstream user/project/local settings file cannot un-deny these; the
+  #     only un-lock is dropping the nix `restrictToTools` override. Caveat: a
+  #     managed `bypassPermissions` skips the whole permission layer, so these
+  #     deny rules would be inert under one.
   #   permissions.defaultMode + skipDangerousModePermissionPrompt (the default,
-  #     unless `restrictToIndexMcp` takes precedence): start in bypass mode and
+  #     unless `restrictToTools` takes precedence): start in bypass mode and
   #     pre-accept the one-time dangerous-mode warning. Both keys are
   #     required: managed/flag bypass alone does not suppress that warning.
   #     skipDangerousModePermissionPrompt is honored in every scope except
@@ -144,19 +138,23 @@ let
     "Write"
   ];
 
+  # The lockdown is active whenever the caller pins an allow-list.
+  restrictTools = restrictToTools != null;
+
   settingsDefaults = {
     cleanupPeriodDays = 365;
   }
-  // lib.optionalAttrs restrictToIndexMcp {
+  // lib.optionalAttrs restrictTools {
     permissions = {
-      allow = indexMcpAllow;
-      deny = deniedBuiltinTools;
+      allow = restrictToTools;
+      # A built-in named in the allow-list is re-allowed by dropping it here.
+      deny = lib.subtractLists restrictToTools deniedBuiltinTools;
     };
   }
-  # restrictToIndexMcp takes precedence: bypass would skip the permission layer
-  # and void its deny rules, so the two never co-set `permissions` (a shallow //
+  # restrictToTools takes precedence: bypass would skip the permission layer and
+  # void its deny rules, so the two never co-set `permissions` (a shallow //
   # merge would otherwise clobber allow/deny with defaultMode).
-  // lib.optionalAttrs (dangerouslySkipPermissions && !restrictToIndexMcp) {
+  // lib.optionalAttrs (dangerouslySkipPermissions && !restrictTools) {
     permissions.defaultMode = "bypassPermissions";
     skipDangerousModePermissionPrompt = true;
   };


### PR DESCRIPTION
Follow-up to #756. The lockdown is not index-specific, so replace `restrictToIndexMcp` (bool) + `indexMcpAllow` (list) with a single nullable `restrictToTools`:

- `null` (default) → normal posture (bypass, unchanged).
- a list of permission rules → plain `default` mode, `allow` exactly those, bare-`deny` every other built-in. A built-in named in the list is subtracted from the deny list, so the knob works for any tool, not just an MCP server.

Validated: default still renders `bypassPermissions`; `restrictToTools = ["mcp__index__*" "Read"]` renders default mode + allow=[those], Read re-allowed, Bash still denied. Lint green.

AI-generated with Claude Opus 4.8.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `restrictToIndexMcp`/`indexMcpAllow` params with generic `restrictToTools` in claude-code wrapper
> - Replaces the boolean `restrictToIndexMcp` and `indexMcpAllow` list params in [default.nix](https://github.com/indexable-inc/index/pull/759/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b) with a single nullable `restrictToTools` param that accepts an arbitrary allow-list of tool permission rules.
> - When `restrictToTools` is set, the deny list is computed by subtracting the allow-list from the built-in denied tools, so any built-in explicitly allowed is not also denied.
> - `dangerouslySkipPermissions` bypass mode is suppressed whenever `restrictToTools` is non-null, taking precedence over that flag.
> - Behavioral Change: callers using `restrictToIndexMcp` or `indexMcpAllow` must migrate to `restrictToTools`; passing the old parameters will no longer have any effect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e1e849.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->