### PR TITLE
feat(mcp): bundle fff fast file-search as ctypes `import fff`

### DIFF
--- a/packages/fff/default.nix
+++ b/packages/fff/default.nix
@@ -10,8 +10,11 @@
 # pinned `fetchFromGitHub` rev with `rustPlatform.buildRustPackage`. See
 # `agent-context/sections/13-dependency-intake.md` and `packages/launchk`.
 #
-# fff is a fast file-search toolkit for humans and AI agents. The shipped binary
-# is `fff-mcp`: a CLI / MCP server over the in-memory file + content index.
+# fff is a fast file-search toolkit for humans and AI agents. Two artifacts ship
+# from one build:
+#   * `bin/fff-mcp`        – the CLI / MCP server over the in-memory file index.
+#   * `lib/libfff_c.{so,dylib}` – the stable C ABI (crate `fff-c`), which the
+#     `mcp` package loads via ctypes to expose `import fff` in notebook sessions.
 let
   src = fetchFromGitHub {
     owner = "dmtrKovalenko";
@@ -40,15 +43,43 @@ rustPlatform.buildRustPackage {
     pkg-config
   ];
 
-  # Build only the fff-mcp binary and skip the workspace's default `zlob`
-  # feature, which shells out to a system Zig install at build time (see
-  # crates/fff-core/build.rs). Without zlob the crate falls back to the pure-Rust
+  # Build the fff-mcp binary and the fff-c cdylib in one cargo invocation so
+  # both artifacts share the dependency compile. Scoping to these two packages
+  # (rather than the whole workspace) keeps out fff-nvim's mlua/Lua build.
+  # `--no-default-features` skips the workspace's default `zlob` feature, which
+  # shells out to a system Zig install at build time (see
+  # crates/fff-core/build.rs); without it the crate falls back to the pure-Rust
   # globset matcher.
-  buildAndTestSubdir = "crates/fff-mcp";
+  cargoBuildFlags = [
+    "--package"
+    "fff-mcp"
+    "--package"
+    "fff-c"
+  ];
+  cargoTestFlags = [
+    "--package"
+    "fff-mcp"
+    "--package"
+    "fff-c"
+  ];
   buildNoDefaultFeatures = true;
 
+  # buildRustPackage installs the binary to bin/, but the fff-c cdylib is not
+  # picked up automatically. Copy the unhashed final artifact into lib/ (skip
+  # the hashed copy under deps/) for both the Linux .so and the macOS .dylib.
+  postInstall = ''
+    mkdir -p "$out/lib"
+    find target -type f \( -name 'libfff_c.so' -o -name 'libfff_c.dylib' \) \
+      -not -path '*/deps/*' -exec install -Dm555 {} "$out/lib/" \;
+    if [ -z "$(ls -A "$out/lib" 2>/dev/null)" ]; then
+      echo "fff: no libfff_c cdylib found under target/" >&2
+      find target -name 'libfff_c.*' >&2 || true
+      exit 1
+    fi
+  '';
+
   meta = {
-    description = "Fast file-search toolkit for humans and AI agents (fff-mcp CLI / MCP server)";
+    description = "Fast file-search toolkit for humans and AI agents (fff-mcp CLI / MCP server + fff-c cdylib)";
     homepage = "https://github.com/dmtrKovalenko/fff";
     license = lib.licenses.mit;
     mainProgram = "fff-mcp";

--- a/packages/fff/package.nix
+++ b/packages/fff/package.nix
@@ -2,7 +2,10 @@
   id = "fff";
   # fff-mcp builds on Linux and macOS (see meta.platforms in default.nix), so
   # surface it on every system: as `pkgs.fff` in the repo package set and as the
-  # `fff` flake output.
+  # `fff` flake output. `overlay` also threads it into the nixpkgs overlay so
+  # other repo packages can take `pkgs.fff` as an input: `mcp` bundles the
+  # fff-c cdylib emitted here for its ctypes-backed `import fff`.
   packageSet = true;
   flake = true;
+  overlay = true;
 }

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -90,6 +90,48 @@ let
       ''
   );
 
+  # The `fff` fast file-search package, baked into the interpreter so every
+  # session can `import fff` and run fuzzy file search / SIMD grep over a repo
+  # with no setup. Unlike `tui`/`search`, fff has no PyO3 binding: it ships a
+  # stable C ABI (the `fff-c` cdylib, emitted next to `fff-mcp` by
+  # `packages/fff`), and the pure-Python module loads it via ctypes. The cdylib
+  # is dropped next to the package source so the module loads it by a fixed
+  # path. Cross-platform: `pkgs.fff` builds on Linux and macOS. Store references
+  # in the cdylib are fine: this module never leaves the Nix environment.
+  fffPythonSource = builtins.path {
+    name = "ix-mcp-fff-python-source";
+    path = ./src/fff;
+  };
+  fffModule = pkgs.python3.pkgs.toPythonModule (
+    pkgs.runCommand "ix-mcp-fff-python-module"
+      {
+        strictDeps = true;
+        meta.description = "fff fast file-search bound via ctypes, bundled into the ix-mcp interpreter";
+      }
+      ''
+        site="$out/${pkgs.python3.sitePackages}/fff"
+        mkdir -p "$site"
+        cp -r ${fffPythonSource}/fff/. "$site/"
+
+        cdylib=""
+        for candidate in \
+          ${pkgs.fff}/lib/libfff_c.so \
+          ${pkgs.fff}/lib/libfff_c.dylib
+        do
+          if [ -f "$candidate" ]; then
+            cdylib="$candidate"
+            break
+          fi
+        done
+        if [ -z "$cdylib" ]; then
+          echo "ix-fff module: no libfff_c cdylib under ${pkgs.fff}/lib" >&2
+          ls -la ${pkgs.fff}/lib >&2 || true
+          exit 1
+        fi
+        install -m555 "$cdylib" "$site/$(basename "$cdylib")"
+      ''
+  );
+
   # JupyterLab custom CSS, generated from the shared JetBrains Islands palette
   # (`ix.islandsTheme`, the same JSON the search `-c` highlighter and the Neovim
   # colorscheme read) so there is one source of truth for color. It maps the
@@ -389,6 +431,7 @@ let
       ps.mcp
       tuiModule
       searchModule
+      fffModule
       ixNotebookMcpModule
     ]
     ++ darwinExtraPackages ps
@@ -449,6 +492,78 @@ let
 
   tuiBundled = importTest "tui" "import tui; print('tui-ok', tui.__version__)";
   searchBundled = importTest "search" "import search; print('search-ok', search.__version__)";
+
+  # End-to-end through the bundled `fff` ctypes module: index a temp tree, wait
+  # for the scan, then prove fuzzy file search and content grep both return the
+  # planted hits. Loads the fff-c cdylib from site-packages, so it also guards
+  # that the library actually shipped next to the module. Pure local FS, no
+  # network or watcher, so the build sandbox runs it.
+  fffTestPy = pkgs.writeText "ix-mcp-fff-test.py" ''
+    import os
+    import tempfile
+    import time
+
+    import fff
+
+    root = tempfile.mkdtemp()
+    os.makedirs(os.path.join(root, "src"))
+    with open(os.path.join(root, "hello_world.txt"), "w") as fh:
+        fh.write("greetings\nfind me on this line\n")
+    with open(os.path.join(root, "src", "main.rs"), "w") as fh:
+        fh.write('fn main() {\n    println!("find me on this line");\n}\n')
+
+    finder = fff.FileFinder(root, watch=False, content_indexing=True, ai_mode=True)
+    try:
+        # The initial scan runs in the background; poll until the planted file
+        # is visible (a few short waits, robust to sandbox scheduling).
+        hit_path = None
+        for _ in range(20):
+            finder.wait_for_scan(2000)
+            result = finder.search("hello")
+            match = next((h for h in result.items if "hello_world" in h.path), None)
+            if match is not None:
+                hit_path = match.path
+                break
+            time.sleep(0.25)
+        assert hit_path is not None, f"fuzzy search did not find hello_world.txt: {result.items!r}"
+
+        grep_result = finder.grep("find me on this line", limit=10)
+        files = {m.path for m in grep_result.matches}
+        assert any("hello_world" in f for f in files), f"grep missed the txt file: {files!r}"
+        assert any("main.rs" in f for f in files), f"grep missed main.rs: {files!r}"
+        defs = finder.grep("fn main", mode="regex", classify_definitions=True)
+        assert defs.matches, "regex grep returned no matches"
+
+        glob_result = finder.glob("**/*.rs")
+        assert any("main.rs" in h.path for h in glob_result.items), (
+            f"glob missed main.rs: {glob_result.items!r}"
+        )
+    finally:
+        finder.close()
+
+    print("fff-ok", fff.__version__)
+  '';
+  fffBundled =
+    pkgs.runCommand "ix-mcp-fff"
+      {
+        nativeBuildInputs = [ mcpPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        ${lib.getExe mcpPython} ${fffTestPy} >stdout 2>stderr || {
+          echo "ix-mcp fff test failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -q '^fff-ok' stdout || {
+          echo "ix-mcp fff test did not print its ok marker:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
   dataLibsBundled = importTest "data-libs" (
     "import psycopg, sqlalchemy, duckdb, httpx; "
     + "from sqlalchemy import create_engine; create_engine('postgresql+psycopg://u@h/db'); "
@@ -639,6 +754,7 @@ package.overrideAttrs (old: {
       inherit
         tuiBundled
         searchBundled
+        fffBundled
         dataLibsBundled
         gmailLibsBundled
         jupyterBundled

--- a/packages/mcp/src/fff/fff/__init__.py
+++ b/packages/mcp/src/fff/fff/__init__.py
@@ -262,14 +262,21 @@ def _encode(value) -> bytes | None:
 
 def _u32(name: str, value: int) -> int:
     """Validate an unsigned-32 argument; ctypes would otherwise silently wrap."""
-    if not isinstance(value, int) or value < 0 or value > 0xFFFFFFFF:
+    # `bool` is an `int` subclass, so reject it explicitly: `limit=True` should
+    # be a type error, not a silent 1.
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0 or value > 0xFFFFFFFF:
         raise ValueError(f"{name} must be an int in [0, 2**32); got {value!r}")
     return value
 
 
 def _u64(name: str, value: int) -> int:
     """Validate an unsigned-64 argument; ctypes would otherwise silently wrap."""
-    if not isinstance(value, int) or value < 0 or value > 0xFFFFFFFFFFFFFFFF:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+        or value > 0xFFFFFFFFFFFFFFFF
+    ):
         raise ValueError(f"{name} must be an int in [0, 2**64); got {value!r}")
     return value
 
@@ -697,9 +704,8 @@ class FileFinder:
 #
 # One finder per directory, shared by `find` and `grep`. It is content-indexed
 # and watching, so repeated queries against the same tree skip the rescan cost
-# and `grep` always gets the SIMD content index. The cache is a bounded LRU: an
-# evicted finder is closed so its native instance and watcher thread are
-# released rather than leaking for the kernel's lifetime.
+# and `grep` always gets the SIMD content index. The cache is a bounded LRU, so
+# the live native instances and watcher threads stay bounded by `_CACHE_MAX`.
 
 _CACHE_MAX = 8
 _cache: OrderedDict[str, FileFinder] = OrderedDict()
@@ -720,11 +726,18 @@ def _cached(path) -> FileFinder:
             return existing
         ff = FileFinder(key, watch=True, content_indexing=True)
         ff.wait_for_scan(10_000)
-        _cache[key] = ff
-        _cache.move_to_end(key)
+        _cache[key] = ff  # a fresh insert is already the most-recent (LRU) end
         while len(_cache) > _CACHE_MAX:
-            _, evicted = _cache.popitem(last=False)
-            evicted.close()
+            # Drop the LRU entry but do NOT close() it here. A concurrent caller
+            # may still hold this finder and be mid-query on it (ctypes releases
+            # the GIL across the native call), so destroying the handle now would
+            # be a use-after-free. Removing the cache's reference is enough:
+            # FileFinder.__del__ reclaims the native instance once the last
+            # caller reference is gone, which is the only safe point to destroy
+            # it. Callers only ever hold a finder transiently (find/grep return
+            # results, not the finder), so this reclaims promptly under CPython
+            # refcounting and the watcher count still stays bounded.
+            _cache.popitem(last=False)
         return ff
 
 

--- a/packages/mcp/src/fff/fff/__init__.py
+++ b/packages/mcp/src/fff/fff/__init__.py
@@ -1,0 +1,669 @@
+"""fff fast file-search, bound to Python through its stable C ABI.
+
+Bundled into the pinned ix-mcp interpreter the same way `tui` and `search` are,
+so every session can `import fff` with no install step. fff (dmtrKovalenko/fff)
+is a typo-resistant fuzzy file finder and SIMD content grep with an in-memory
+index; this module loads the `fff-c` cdylib (`packages/fff` emits it next to the
+`fff-mcp` binary) via ctypes and exposes a small typed surface over it.
+
+    import fff
+
+    # one-shot helpers keep a cached, file-watching index per directory:
+    for hit in fff.find("picker", path=".").items:
+        print(hit.path, hit.frecency)
+
+    for m in fff.grep("fn main", path=".").matches:
+        print(f"{m.path}:{m.line_number}: {m.line_content}")
+
+    # or hold an instance for repeated queries against one tree:
+    with fff.FileFinder(".", content_indexing=True) as ff:
+        ff.wait_for_scan()              # block until the initial scan finishes
+        ff.search("readme")            # fuzzy file search, frecency-ranked
+        ff.glob("**/*.rs")             # literal glob, no fuzzy parsing
+        ff.grep("TODO", mode="regex")  # content search (plain | regex | fuzzy)
+        ff.multi_grep(["foo", "bar"])  # OR across many literals (Aho-Corasick)
+
+Results are plain dataclasses (`FileHit`, `GrepMatch`, `SearchResult`,
+`GrepResult`). Only the accessor-backed surfaces of fff-c are bound: file search
+(`search`/`glob`) and content grep (`grep`/`multi_grep`). Directory and mixed
+search are intentionally omitted because fff-c ships no stable field accessors
+for them, and reading those `#[repr(C)]` structs by offset would break silently
+on a layout change.
+
+This is a thin FFI layer with no domain logic of its own: every behavior comes
+from the one Rust core shared with fff-mcp and the Node/Neovim bindings. It runs
+on Linux and macOS (wherever `packages/fff` builds the cdylib).
+"""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import os
+import sys
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+
+__all__ = [
+    "FffError",
+    "FileFinder",
+    "FileHit",
+    "GrepMatch",
+    "GrepResult",
+    "MatchRange",
+    "SearchResult",
+    "find",
+    "finder",
+    "grep",
+]
+
+__version__ = "0.9.1"
+
+# Mirrors `FFF_CREATE_OPTIONS_VERSION` in fff-c. The options struct only ever
+# appends fields, so v1 stays valid forever; the library reads exactly the
+# fields this version knows about.
+_OPTIONS_VERSION = 1
+
+# fff_live_grep mode byte: 0 plain (SIMD literal), 1 regex, 2 fuzzy.
+_GREP_MODES = {"plain": 0, "text": 0, "regex": 1, "fuzzy": 2}
+
+
+class FffError(RuntimeError):
+    """Raised when a fff-c call returns an error result."""
+
+
+# ── library loading ────────────────────────────────────────────────────────
+
+
+def _load_library() -> ctypes.CDLL:
+    """Load the fff-c cdylib bundled next to this module.
+
+    `packages/mcp` copies `libfff_c.so` (Linux) or `libfff_c.dylib` (macOS)
+    into this package directory at build time, so the load is a fixed path with
+    no `LD_LIBRARY_PATH`/`ctypes.util.find_library` search.
+    """
+    here = Path(__file__).resolve().parent
+    names = ["libfff_c.dylib"] if sys.platform == "darwin" else ["libfff_c.so"]
+    for name in names:
+        candidate = here / name
+        if candidate.exists():
+            return ctypes.CDLL(str(candidate))
+    # Fall back to any libfff_c.* so a platform mismatch surfaces clearly.
+    for candidate in sorted(here.glob("libfff_c.*")):
+        return ctypes.CDLL(str(candidate))
+    raise ImportError(
+        f"fff: no libfff_c cdylib found in {here}. The mcp package must bundle "
+        "the fff-c shared library next to this module."
+    )
+
+
+_lib = _load_library()
+
+
+# ── C structs we read directly (no stable accessor exists for these) ─────────
+
+
+class _CreateOptions(ctypes.Structure):
+    # Layout asserted stable by fff-c's options_layout_tests (88 bytes, 8-align).
+    _fields_ = [
+        ("version", ctypes.c_uint32),
+        ("base_path", ctypes.c_char_p),
+        ("frecency_db_path", ctypes.c_char_p),
+        ("history_db_path", ctypes.c_char_p),
+        ("enable_mmap_cache", ctypes.c_bool),
+        ("enable_content_indexing", ctypes.c_bool),
+        ("watch", ctypes.c_bool),
+        ("ai_mode", ctypes.c_bool),
+        ("log_file_path", ctypes.c_char_p),
+        ("log_level", ctypes.c_char_p),
+        ("cache_budget_max_files", ctypes.c_uint64),
+        ("cache_budget_max_bytes", ctypes.c_uint64),
+        ("cache_budget_max_file_size", ctypes.c_uint64),
+        ("enable_fs_root_scanning", ctypes.c_bool),
+        ("enable_home_dir_scanning", ctypes.c_bool),
+    ]
+
+
+class _Result(ctypes.Structure):
+    # The envelope every fff_* call returns by pointer. `handle` carries the
+    # typed payload (a result struct, an opaque instance, or a C string);
+    # `int_value` carries simple scalar returns.
+    _fields_ = [
+        ("success", ctypes.c_bool),
+        ("error", ctypes.c_char_p),
+        ("handle", ctypes.c_void_p),
+        ("int_value", ctypes.c_int64),
+    ]
+
+
+class _MatchRange(ctypes.Structure):
+    # A highlight span within a matched grep line. fff-c exposes these only as a
+    # raw array; the surrounding `FffGrepMatch` is read through accessors.
+    _fields_ = [("start", ctypes.c_uint32), ("end", ctypes.c_uint32)]
+
+
+# ── prototype binding ────────────────────────────────────────────────────────
+#
+# ctypes defaults every return type to C `int`, which truncates 64-bit pointers.
+# Declare argtypes/restype for every symbol used so pointers round-trip intact.
+
+_VP = ctypes.c_void_p
+_CP = ctypes.c_char_p
+_U8 = ctypes.c_uint8
+_U32 = ctypes.c_uint32
+_U64 = ctypes.c_uint64
+_I64 = ctypes.c_int64
+_I32 = ctypes.c_int32
+_BOOL = ctypes.c_bool
+_RESULT_P = ctypes.POINTER(_Result)
+
+
+def _bind(name: str, restype, argtypes: list) -> None:
+    fn = getattr(_lib, name)
+    fn.restype = restype
+    fn.argtypes = argtypes
+
+
+_bind("fff_create_instance_with", _RESULT_P, [ctypes.POINTER(_CreateOptions)])
+_bind("fff_destroy", None, [_VP])
+_bind("fff_search", _RESULT_P, [_VP, _CP, _CP, _U32, _U32, _U32, _I32, _U32])
+_bind("fff_glob", _RESULT_P, [_VP, _CP, _CP, _U32, _U32, _U32])
+_bind(
+    "fff_live_grep",
+    _RESULT_P,
+    [_VP, _CP, _U8, _U64, _U32, _BOOL, _U32, _U32, _U64, _U32, _U32, _BOOL],
+)
+_bind(
+    "fff_multi_grep",
+    _RESULT_P,
+    [_VP, _CP, _CP, _U64, _U32, _BOOL, _U32, _U32, _U64, _U32, _U32, _BOOL],
+)
+_bind("fff_scan_files", _RESULT_P, [_VP])
+_bind("fff_is_scanning", _BOOL, [_VP])
+_bind("fff_wait_for_scan", _RESULT_P, [_VP, _U64])
+_bind("fff_get_base_path", _RESULT_P, [_VP])
+_bind("fff_health_check", _RESULT_P, [_VP, _CP])
+_bind("fff_refresh_git_status", _RESULT_P, [_VP])
+
+_bind("fff_free_result", None, [_RESULT_P])
+_bind("fff_free_search_result", None, [_VP])
+_bind("fff_free_grep_result", None, [_VP])
+_bind("fff_free_string", None, [_VP])
+
+# File-item + search-result accessors (stable named API; see fff-c accessors.rs).
+_bind("fff_search_result_get_count", _U32, [_VP])
+_bind("fff_search_result_get_total_matched", _U32, [_VP])
+_bind("fff_search_result_get_total_files", _U32, [_VP])
+_bind("fff_search_result_get_item", _VP, [_VP, _U32])
+_bind("fff_file_item_get_relative_path", _CP, [_VP])
+_bind("fff_file_item_get_file_name", _CP, [_VP])
+_bind("fff_file_item_get_git_status", _CP, [_VP])
+_bind("fff_file_item_get_size", _U64, [_VP])
+_bind("fff_file_item_get_modified", _U64, [_VP])
+_bind("fff_file_item_get_total_frecency_score", _I64, [_VP])
+_bind("fff_file_item_get_is_binary", _BOOL, [_VP])
+
+# Grep-match + grep-result accessors.
+_bind("fff_grep_result_get_count", _U32, [_VP])
+_bind("fff_grep_result_get_total_matched", _U32, [_VP])
+_bind("fff_grep_result_get_total_files_searched", _U32, [_VP])
+_bind("fff_grep_result_get_next_file_offset", _U32, [_VP])
+_bind("fff_grep_result_get_match", _VP, [_VP, _U32])
+_bind("fff_grep_match_get_relative_path", _CP, [_VP])
+_bind("fff_grep_match_get_file_name", _CP, [_VP])
+_bind("fff_grep_match_get_git_status", _CP, [_VP])
+_bind("fff_grep_match_get_line_content", _CP, [_VP])
+_bind("fff_grep_match_get_line_number", _U64, [_VP])
+_bind("fff_grep_match_get_col", _U32, [_VP])
+_bind("fff_grep_match_get_byte_offset", _U64, [_VP])
+_bind("fff_grep_match_get_is_definition", _BOOL, [_VP])
+_bind("fff_grep_match_get_is_binary", _BOOL, [_VP])
+_bind("fff_grep_match_get_match_ranges_count", _U32, [_VP])
+_bind("fff_grep_match_get_match_range", ctypes.POINTER(_MatchRange), [_VP, _U32])
+_bind("fff_grep_match_get_context_before_count", _U32, [_VP])
+_bind("fff_grep_match_get_context_before", _CP, [_VP, _U32])
+_bind("fff_grep_match_get_context_after_count", _U32, [_VP])
+_bind("fff_grep_match_get_context_after", _CP, [_VP, _U32])
+
+
+# ── result envelope helpers ──────────────────────────────────────────────────
+
+
+def _consume(result_ptr) -> tuple[int | None, int]:
+    """Read and free a `*FffResult`, returning `(handle, int_value)`.
+
+    Frees only the envelope (and its error string); the `handle` payload, when
+    present, is still owned by the caller and freed with its typed free fn.
+    """
+    if not result_ptr:
+        raise FffError("fff returned a null result")
+    res = result_ptr.contents
+    success = bool(res.success)
+    error = res.error  # copied to a Python bytes here, before the free below
+    handle = res.handle
+    int_value = res.int_value
+    _lib.fff_free_result(result_ptr)
+    if not success:
+        raise FffError(error.decode("utf-8", "replace") if error else "unknown fff error")
+    return handle, int_value
+
+
+def _str(value: bytes | None) -> str | None:
+    return value.decode("utf-8", "replace") if value else None
+
+
+def _encode(value) -> bytes | None:
+    if value is None:
+        return None
+    return os.fspath(value).encode("utf-8")
+
+
+# ── result types ─────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class FileHit:
+    """One file from `search`/`glob`, ranked by fuzzy score and frecency."""
+
+    path: str
+    name: str
+    size: int
+    modified: int
+    frecency: int
+    is_binary: bool
+    git_status: str | None = None
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    items: list[FileHit]
+    total_matched: int
+    total_files: int
+
+    def __iter__(self):
+        return iter(self.items)
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+
+@dataclass(frozen=True)
+class MatchRange:
+    """Byte span `[start, end)` within a matched line, for highlighting."""
+
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class GrepMatch:
+    path: str
+    name: str
+    line_number: int
+    col: int
+    byte_offset: int
+    line_content: str
+    is_definition: bool
+    is_binary: bool
+    git_status: str | None = None
+    match_ranges: list[MatchRange] = field(default_factory=list)
+    context_before: list[str] = field(default_factory=list)
+    context_after: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class GrepResult:
+    matches: list[GrepMatch]
+    total_matched: int
+    total_files_searched: int
+    next_file_offset: int
+
+    def __iter__(self):
+        return iter(self.matches)
+
+    def __len__(self) -> int:
+        return len(self.matches)
+
+
+# ── the finder ───────────────────────────────────────────────────────────────
+
+
+class FileFinder:
+    """An indexed view over one directory tree.
+
+    Construction kicks off a background scan; call `wait_for_scan()` before the
+    first query, or use the module-level `find`/`grep` helpers which do it for
+    you. Close it with `close()` or a `with` block to release the native index.
+    """
+
+    def __init__(
+        self,
+        path=".",
+        *,
+        ai_mode: bool = True,
+        watch: bool = False,
+        content_indexing: bool = False,
+        mmap_cache: bool = False,
+        frecency_db=None,
+        history_db=None,
+    ) -> None:
+        opts = _CreateOptions()
+        opts.version = _OPTIONS_VERSION
+        opts.base_path = _encode(os.path.abspath(os.fspath(path)))
+        opts.frecency_db_path = _encode(frecency_db)
+        opts.history_db_path = _encode(history_db)
+        opts.enable_mmap_cache = mmap_cache
+        opts.enable_content_indexing = content_indexing
+        opts.watch = watch
+        opts.ai_mode = ai_mode
+        handle, _ = _consume(_lib.fff_create_instance_with(ctypes.byref(opts)))
+        self._handle = ctypes.c_void_p(handle)
+        self._closed = False
+
+    # -- lifecycle --
+
+    def close(self) -> None:
+        if not self._closed and self._handle:
+            _lib.fff_destroy(self._handle)
+            self._closed = True
+
+    def __enter__(self) -> "FileFinder":
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def _check_open(self) -> None:
+        if self._closed:
+            raise FffError("FileFinder is closed")
+
+    # -- indexing --
+
+    def scan(self) -> None:
+        """Trigger a full rescan in the background (returns immediately)."""
+        self._check_open()
+        _consume(_lib.fff_scan_files(self._handle))
+
+    def is_scanning(self) -> bool:
+        self._check_open()
+        return bool(_lib.fff_is_scanning(self._handle))
+
+    def wait_for_scan(self, timeout_ms: int = 5000) -> bool:
+        """Block until the initial scan finishes; True if it completed in time."""
+        self._check_open()
+        _, completed = _consume(_lib.fff_wait_for_scan(self._handle, timeout_ms))
+        return bool(completed)
+
+    def refresh_git_status(self) -> int:
+        """Refresh the git-status cache; returns the number of files updated."""
+        self._check_open()
+        _, count = _consume(_lib.fff_refresh_git_status(self._handle))
+        return count
+
+    @property
+    def base_path(self) -> str:
+        self._check_open()
+        handle, _ = _consume(_lib.fff_get_base_path(self._handle))
+        try:
+            return _str(ctypes.cast(handle, _CP).value) or ""
+        finally:
+            _lib.fff_free_string(ctypes.c_void_p(handle))
+
+    def health_check(self, test_path=None) -> dict:
+        self._check_open()
+        handle, _ = _consume(_lib.fff_health_check(self._handle, _encode(test_path)))
+        try:
+            raw = ctypes.cast(handle, _CP).value
+            return json.loads(raw.decode("utf-8")) if raw else {}
+        finally:
+            _lib.fff_free_string(ctypes.c_void_p(handle))
+
+    # -- file search --
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 100,
+        page: int = 0,
+        current_file=None,
+        max_threads: int = 0,
+    ) -> SearchResult:
+        """Fuzzy file search, ranked by match score combined with frecency."""
+        self._check_open()
+        handle, _ = _consume(
+            _lib.fff_search(
+                self._handle,
+                query.encode("utf-8"),
+                _encode(current_file),
+                max_threads,
+                page,
+                limit,
+                0,
+                0,
+            )
+        )
+        try:
+            return self._read_search(handle)
+        finally:
+            _lib.fff_free_search_result(ctypes.c_void_p(handle))
+
+    def glob(
+        self,
+        pattern: str,
+        *,
+        limit: int = 100,
+        page: int = 0,
+        current_file=None,
+        max_threads: int = 0,
+    ) -> SearchResult:
+        """Literal glob filter (e.g. `*.rs`, `src/**`), ranked by frecency."""
+        self._check_open()
+        handle, _ = _consume(
+            _lib.fff_glob(
+                self._handle,
+                pattern.encode("utf-8"),
+                _encode(current_file),
+                max_threads,
+                page,
+                limit,
+            )
+        )
+        try:
+            return self._read_search(handle)
+        finally:
+            _lib.fff_free_search_result(ctypes.c_void_p(handle))
+
+    def _read_search(self, handle: int | None) -> SearchResult:
+        h = ctypes.c_void_p(handle)
+        count = _lib.fff_search_result_get_count(h)
+        items = []
+        for i in range(count):
+            it = _lib.fff_search_result_get_item(h, i)
+            items.append(
+                FileHit(
+                    path=_str(_lib.fff_file_item_get_relative_path(it)) or "",
+                    name=_str(_lib.fff_file_item_get_file_name(it)) or "",
+                    size=_lib.fff_file_item_get_size(it),
+                    modified=_lib.fff_file_item_get_modified(it),
+                    frecency=_lib.fff_file_item_get_total_frecency_score(it),
+                    is_binary=bool(_lib.fff_file_item_get_is_binary(it)),
+                    git_status=_str(_lib.fff_file_item_get_git_status(it)),
+                )
+            )
+        return SearchResult(
+            items=items,
+            total_matched=_lib.fff_search_result_get_total_matched(h),
+            total_files=_lib.fff_search_result_get_total_files(h),
+        )
+
+    # -- content grep --
+
+    def grep(
+        self,
+        query: str,
+        *,
+        mode: str = "plain",
+        limit: int = 50,
+        max_matches_per_file: int = 0,
+        smart_case: bool = True,
+        file_offset: int = 0,
+        max_file_size: int = 0,
+        time_budget_ms: int = 0,
+        before_context: int = 0,
+        after_context: int = 0,
+        classify_definitions: bool = False,
+    ) -> GrepResult:
+        """Content search across indexed files. mode: plain | regex | fuzzy."""
+        self._check_open()
+        mode_byte = _GREP_MODES.get(mode)
+        if mode_byte is None:
+            raise ValueError(f"unknown grep mode {mode!r}; use one of {sorted(_GREP_MODES)}")
+        handle, _ = _consume(
+            _lib.fff_live_grep(
+                self._handle,
+                query.encode("utf-8"),
+                mode_byte,
+                max_file_size,
+                max_matches_per_file,
+                smart_case,
+                file_offset,
+                limit,
+                time_budget_ms,
+                before_context,
+                after_context,
+                classify_definitions,
+            )
+        )
+        try:
+            return self._read_grep(handle)
+        finally:
+            _lib.fff_free_grep_result(ctypes.c_void_p(handle))
+
+    def multi_grep(
+        self,
+        patterns: list[str],
+        *,
+        constraints: str | None = None,
+        limit: int = 50,
+        max_matches_per_file: int = 0,
+        smart_case: bool = True,
+        file_offset: int = 0,
+        max_file_size: int = 0,
+        time_budget_ms: int = 0,
+        before_context: int = 0,
+        after_context: int = 0,
+        classify_definitions: bool = False,
+    ) -> GrepResult:
+        """Match any of several literal patterns (Aho-Corasick), one pass.
+
+        `constraints` is an optional file filter like `"*.rs"` or `"/src/"`.
+        """
+        self._check_open()
+        if not patterns or all(not p for p in patterns):
+            raise ValueError("multi_grep requires at least one non-empty pattern")
+        if any("\n" in p for p in patterns):
+            raise ValueError("multi_grep patterns must not contain newlines")
+        handle, _ = _consume(
+            _lib.fff_multi_grep(
+                self._handle,
+                "\n".join(patterns).encode("utf-8"),
+                _encode(constraints),
+                max_file_size,
+                max_matches_per_file,
+                smart_case,
+                file_offset,
+                limit,
+                time_budget_ms,
+                before_context,
+                after_context,
+                classify_definitions,
+            )
+        )
+        try:
+            return self._read_grep(handle)
+        finally:
+            _lib.fff_free_grep_result(ctypes.c_void_p(handle))
+
+    def _read_grep(self, handle: int | None) -> GrepResult:
+        h = ctypes.c_void_p(handle)
+        count = _lib.fff_grep_result_get_count(h)
+        matches = []
+        for i in range(count):
+            m = _lib.fff_grep_result_get_match(h, i)
+            ranges = [
+                MatchRange(start=r.contents.start, end=r.contents.end)
+                for j in range(_lib.fff_grep_match_get_match_ranges_count(m))
+                if (r := _lib.fff_grep_match_get_match_range(m, j))
+            ]
+            before = [
+                _str(_lib.fff_grep_match_get_context_before(m, j)) or ""
+                for j in range(_lib.fff_grep_match_get_context_before_count(m))
+            ]
+            after = [
+                _str(_lib.fff_grep_match_get_context_after(m, j)) or ""
+                for j in range(_lib.fff_grep_match_get_context_after_count(m))
+            ]
+            matches.append(
+                GrepMatch(
+                    path=_str(_lib.fff_grep_match_get_relative_path(m)) or "",
+                    name=_str(_lib.fff_grep_match_get_file_name(m)) or "",
+                    line_number=_lib.fff_grep_match_get_line_number(m),
+                    col=_lib.fff_grep_match_get_col(m),
+                    byte_offset=_lib.fff_grep_match_get_byte_offset(m),
+                    line_content=_str(_lib.fff_grep_match_get_line_content(m)) or "",
+                    is_definition=bool(_lib.fff_grep_match_get_is_definition(m)),
+                    is_binary=bool(_lib.fff_grep_match_get_is_binary(m)),
+                    git_status=_str(_lib.fff_grep_match_get_git_status(m)),
+                    match_ranges=ranges,
+                    context_before=before,
+                    context_after=after,
+                )
+            )
+        return GrepResult(
+            matches=matches,
+            total_matched=_lib.fff_grep_result_get_total_matched(h),
+            total_files_searched=_lib.fff_grep_result_get_total_files_searched(h),
+            next_file_offset=_lib.fff_grep_result_get_next_file_offset(h),
+        )
+
+
+# ── module-level convenience over a cached, watched index per directory ──────
+
+_cache: dict[str, FileFinder] = {}
+_cache_lock = threading.Lock()
+
+
+def finder(path=".", **kwargs) -> FileFinder:
+    """Construct a `FileFinder` (does not scan; call `wait_for_scan` yourself)."""
+    return FileFinder(path, **kwargs)
+
+
+def _cached(path, *, content_indexing: bool) -> FileFinder:
+    key = os.path.abspath(os.fspath(path))
+    with _cache_lock:
+        ff = _cache.get(key)
+        if ff is None or ff._closed:
+            # A long-lived, watching index: the file watcher keeps it fresh, so
+            # repeated calls against the same tree skip the rescan cost.
+            ff = FileFinder(key, watch=True, content_indexing=content_indexing)
+            ff.wait_for_scan(10_000)
+            _cache[key] = ff
+    return ff
+
+
+def find(query: str, path=".", *, limit: int = 100) -> SearchResult:
+    """Fuzzy file search over `path`, reusing a cached watched index."""
+    return _cached(path, content_indexing=False).search(query, limit=limit)
+
+
+def grep(query: str, path=".", *, mode: str = "plain", limit: int = 50) -> GrepResult:
+    """Content grep over `path`, reusing a cached watched (content-indexed) index."""
+    return _cached(path, content_indexing=True).grep(query, mode=mode, limit=limit)

--- a/packages/mcp/src/fff/fff/__init__.py
+++ b/packages/mcp/src/fff/fff/__init__.py
@@ -42,6 +42,7 @@ import json
 import os
 import sys
 import threading
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -259,6 +260,38 @@ def _encode(value) -> bytes | None:
     return os.fspath(value).encode("utf-8")
 
 
+def _u32(name: str, value: int) -> int:
+    """Validate an unsigned-32 argument; ctypes would otherwise silently wrap."""
+    if not isinstance(value, int) or value < 0 or value > 0xFFFFFFFF:
+        raise ValueError(f"{name} must be an int in [0, 2**32); got {value!r}")
+    return value
+
+
+def _u64(name: str, value: int) -> int:
+    """Validate an unsigned-64 argument; ctypes would otherwise silently wrap."""
+    if not isinstance(value, int) or value < 0 or value > 0xFFFFFFFFFFFFFFFF:
+        raise ValueError(f"{name} must be an int in [0, 2**64); got {value!r}")
+    return value
+
+
+def _validate_grep_args(
+    limit: int,
+    max_matches_per_file: int,
+    file_offset: int,
+    before_context: int,
+    after_context: int,
+    max_file_size: int,
+    time_budget_ms: int,
+) -> None:
+    _u32("limit", limit)
+    _u32("max_matches_per_file", max_matches_per_file)
+    _u32("file_offset", file_offset)
+    _u32("before_context", before_context)
+    _u32("after_context", after_context)
+    _u64("max_file_size", max_file_size)
+    _u64("time_budget_ms", time_budget_ms)
+
+
 # ── result types ─────────────────────────────────────────────────────────────
 
 
@@ -398,6 +431,7 @@ class FileFinder:
     def wait_for_scan(self, timeout_ms: int = 5000) -> bool:
         """Block until the initial scan finishes; True if it completed in time."""
         self._check_open()
+        _u64("timeout_ms", timeout_ms)
         _, completed = _consume(_lib.fff_wait_for_scan(self._handle, timeout_ms))
         return bool(completed)
 
@@ -438,6 +472,9 @@ class FileFinder:
     ) -> SearchResult:
         """Fuzzy file search, ranked by match score combined with frecency."""
         self._check_open()
+        _u32("limit", limit)
+        _u32("page", page)
+        _u32("max_threads", max_threads)
         handle, _ = _consume(
             _lib.fff_search(
                 self._handle,
@@ -466,6 +503,9 @@ class FileFinder:
     ) -> SearchResult:
         """Literal glob filter (e.g. `*.rs`, `src/**`), ranked by frecency."""
         self._check_open()
+        _u32("limit", limit)
+        _u32("page", page)
+        _u32("max_threads", max_threads)
         handle, _ = _consume(
             _lib.fff_glob(
                 self._handle,
@@ -526,6 +566,15 @@ class FileFinder:
         mode_byte = _GREP_MODES.get(mode)
         if mode_byte is None:
             raise ValueError(f"unknown grep mode {mode!r}; use one of {sorted(_GREP_MODES)}")
+        _validate_grep_args(
+            limit,
+            max_matches_per_file,
+            file_offset,
+            before_context,
+            after_context,
+            max_file_size,
+            time_budget_ms,
+        )
         handle, _ = _consume(
             _lib.fff_live_grep(
                 self._handle,
@@ -571,6 +620,15 @@ class FileFinder:
             raise ValueError("multi_grep requires at least one non-empty pattern")
         if any("\n" in p for p in patterns):
             raise ValueError("multi_grep patterns must not contain newlines")
+        _validate_grep_args(
+            limit,
+            max_matches_per_file,
+            file_offset,
+            before_context,
+            after_context,
+            max_file_size,
+            time_budget_ms,
+        )
         handle, _ = _consume(
             _lib.fff_multi_grep(
                 self._handle,
@@ -636,8 +694,15 @@ class FileFinder:
 
 
 # ── module-level convenience over a cached, watched index per directory ──────
+#
+# One finder per directory, shared by `find` and `grep`. It is content-indexed
+# and watching, so repeated queries against the same tree skip the rescan cost
+# and `grep` always gets the SIMD content index. The cache is a bounded LRU: an
+# evicted finder is closed so its native instance and watcher thread are
+# released rather than leaking for the kernel's lifetime.
 
-_cache: dict[str, FileFinder] = {}
+_CACHE_MAX = 8
+_cache: OrderedDict[str, FileFinder] = OrderedDict()
 _cache_lock = threading.Lock()
 
 
@@ -646,24 +711,28 @@ def finder(path=".", **kwargs) -> FileFinder:
     return FileFinder(path, **kwargs)
 
 
-def _cached(path, *, content_indexing: bool) -> FileFinder:
+def _cached(path) -> FileFinder:
     key = os.path.abspath(os.fspath(path))
     with _cache_lock:
-        ff = _cache.get(key)
-        if ff is None or ff._closed:
-            # A long-lived, watching index: the file watcher keeps it fresh, so
-            # repeated calls against the same tree skip the rescan cost.
-            ff = FileFinder(key, watch=True, content_indexing=content_indexing)
-            ff.wait_for_scan(10_000)
-            _cache[key] = ff
-    return ff
+        existing = _cache.get(key)
+        if existing is not None and not existing._closed:
+            _cache.move_to_end(key)
+            return existing
+        ff = FileFinder(key, watch=True, content_indexing=True)
+        ff.wait_for_scan(10_000)
+        _cache[key] = ff
+        _cache.move_to_end(key)
+        while len(_cache) > _CACHE_MAX:
+            _, evicted = _cache.popitem(last=False)
+            evicted.close()
+        return ff
 
 
 def find(query: str, path=".", *, limit: int = 100) -> SearchResult:
     """Fuzzy file search over `path`, reusing a cached watched index."""
-    return _cached(path, content_indexing=False).search(query, limit=limit)
+    return _cached(path).search(query, limit=limit)
 
 
 def grep(query: str, path=".", *, mode: str = "plain", limit: int = 50) -> GrepResult:
     """Content grep over `path`, reusing a cached watched (content-indexed) index."""
-    return _cached(path, content_indexing=True).grep(query, mode=mode, limit=limit)
+    return _cached(path).grep(query, mode=mode, limit=limit)

--- a/packages/mcp/src/fff/fff/__init__.py
+++ b/packages/mcp/src/fff/fff/__init__.py
@@ -412,7 +412,7 @@ class FileFinder:
         self._check_open()
         handle, _ = _consume(_lib.fff_get_base_path(self._handle))
         try:
-            return _str(ctypes.cast(handle, _CP).value) or ""
+            return _str(ctypes.cast(ctypes.c_void_p(handle), _CP).value) or ""
         finally:
             _lib.fff_free_string(ctypes.c_void_p(handle))
 
@@ -420,7 +420,7 @@ class FileFinder:
         self._check_open()
         handle, _ = _consume(_lib.fff_health_check(self._handle, _encode(test_path)))
         try:
-            raw = ctypes.cast(handle, _CP).value
+            raw = ctypes.cast(ctypes.c_void_p(handle), _CP).value
             return json.loads(raw.decode("utf-8")) if raw else {}
         finally:
             _lib.fff_free_string(ctypes.c_void_p(handle))


### PR DESCRIPTION
## What

Adds `import fff` to the notebook-first MCP interpreter: fuzzy file search and SIMD content grep from any session, with no install step, backed by [dmtrKovalenko/fff](https://github.com/dmtrKovalenko/fff).

fff has no PyO3 binding, only a stable C ABI (the `fff-c` cdylib). So:

- **`packages/fff`** now builds `fff-mcp` and the `fff-c` cdylib in one cargo invocation (scoped with `--package` so fff-nvim's Lua build stays out), and installs `lib/libfff_c.{so,dylib}` alongside `bin/fff-mcp`. Added `overlay = true` so other repo packages can take `pkgs.fff`.
- **`packages/mcp/src/fff`** is a pure-Python ctypes wrapper over that cdylib: typed dataclasses, `FileFinder` plus `find`/`grep` convenience helpers over a cached watched index. It binds only the accessor-backed surfaces (file `search`/`glob`, content `grep`/`multi_grep`); directory/mixed search are skipped because fff-c ships no stable field accessors for them and reading those structs by offset would break silently on a layout change.
- **`packages/mcp/default.nix`** bundles the module into the pinned interpreter (cdylib dropped next to the source, loaded by a fixed path) like `tui`/`search`.

## Usage

```python
import fff
fff.find("picker", path=".").items          # fuzzy file search, frecency-ranked
fff.grep("fn main", path=".").matches       # content grep

with fff.FileFinder(".", content_indexing=True) as ff:
    ff.wait_for_scan()
    ff.glob("**/*.rs")
    ff.grep("TODO", mode="regex")
```

## Validation (aarch64-darwin)

- `nix build .#fff` -> `bin/fff-mcp` + `lib/libfff_c.dylib`; in-build fff-mcp + fff-c tests pass.
- `nix build .#mcp.tests.fffBundled` passes: a new end-to-end smoke test indexes a temp tree and asserts search, grep, and glob return the planted hits through the ctypes layer.
- `ty check` clean on the wrapper; nix lint clean.

Linux (`.so`) path is handled in code but validated by CI here.

AI-attribution: drafted with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bundle fff fast file-search as a ctypes `import fff` module in ix-mcp
> - Adds a pure-Python `fff` package ([`__init__.py`](https://github.com/indexable-inc/index/pull/760/files#diff-04cf9369e128a37711b583a278d82557a69696b7ad87abacabfd89301ab6403d)) that loads the `libfff_c` cdylib via ctypes, exposing `FileFinder` with fuzzy file search, glob, and content grep (plain/regex/multi-pattern).
> - Module-level `find()` and `grep()` helpers cache `FileFinder` instances per path (LRU size 8), so callers don't need to manage lifecycle.
> - The Nix build ([`packages/fff/default.nix`](https://github.com/indexable-inc/index/pull/760/files#diff-7ff18369337bbb373952583482f8f92145a22466d9feacf2feb103fb8b953709)) now compiles both the `fff-mcp` binary and `fff-c` cdylib in one cargo invocation and copies `libfff_c.{so,dylib}` into `$out/lib`.
> - The mcp interpreter environment ([`packages/mcp/default.nix`](https://github.com/indexable-inc/index/pull/760/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db)) installs the cdylib alongside the Python source into `site-packages/fff`, with an end-to-end build-time test covering search, grep, and glob.
> - Risk: build fails hard if the cdylib is not produced or if the end-to-end `fffBundled` test fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 837f95f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->