### PR TITLE
feat(mcp): bundle the Exa web-search SDK (exa_py)

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -80,9 +80,11 @@ disk instead of fighting the browser with out-of-band file writes.
 The kernel runs on the same pinned interpreter as the server (see
 [`default.nix`](./default.nix)), so notebook cells can `import` the bundled
 modules with no install step: `tui` (PTY driver), `search` (semantic/grep over
-the `index` corpus), numpy, polars, duckdb, httpx, matplotlib, playwright, the
-Google API client, and on macOS `screen` and `vmkit`. A per-notebook kernel is
-shared with the human, so state set by an agent cell is visible in the browser.
+the `index` corpus), `fff` (fast fuzzy file search / content grep over a repo),
+`exa_py` (the Exa web-search SDK; bring your own `EXA_API_KEY`), numpy, polars,
+duckdb, httpx, matplotlib, playwright, the Google API client, and on macOS
+`screen` and `vmkit`. A per-notebook kernel is shared with the human, so state
+set by an agent cell is visible in the browser.
 
 <p align="center">
   <img width="760" alt="An agent drives lldb through the bundled tui module to a breakpoint in a C program, inside a notebook cell" src="https://github.com/user-attachments/assets/f7d34718-d44a-441a-9927-d367a725de04" />

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -341,10 +341,10 @@ let
     ];
 
   # The interpreter the wrapper pins. Sessions build their venv from this with
-  # `--system-site-packages`, so `tui`, `search`, numpy, polars (incl. Postgres
-  # via psycopg + SQLAlchemy), duckdb, httpx, and playwright are importable by
-  # default while an in-session `pip install` still writes to the per-session
-  # venv.
+  # `--system-site-packages`, so `tui`, `search`, `fff`, `exa_py`, numpy, polars
+  # (incl. Postgres via psycopg + SQLAlchemy), duckdb, httpx, and playwright are
+  # importable by default while an in-session `pip install` still writes to the
+  # per-session venv.
   mcpPython = pkgs.python3.withPackages (
     ps:
     [
@@ -375,6 +375,12 @@ let
       # async via asyncssh/playwright/tui but had no way to call a REST API). Sync
       # `httpx.get(...)` and `async with httpx.AsyncClient()` both work.
       ps.httpx
+      # exa-py: the official Exa (exa.ai) SDK, so a session can run neural web
+      # search, get page contents, and `answer(...)` over the live web with no
+      # install step (`from exa_py import Exa`). It is a thin client over the Exa
+      # REST API. No key is bundled: the caller brings `EXA_API_KEY` (sourced
+      # from rbw/op per the secrets split), e.g. `Exa(os.environ["EXA_API_KEY"])`.
+      ps.exa-py
       # Gmail / Google Workspace, the "third surface" for an integration alongside
       # the MCP binding and the index CLI (rfcs/0003): a session can drive the
       # Gmail and Calendar APIs directly with no install step. This is the official
@@ -575,6 +581,11 @@ let
     + "build('gmail', 'v1', credentials=Credentials(token='x'), static_discovery=True); "
     + "print('gmail-libs-ok')"
   );
+  exaBundled = importTest "exa" (
+    "from exa_py import Exa; e = Exa('dummy-key'); "
+    + "assert callable(e.search) and callable(e.answer); "
+    + "print('exa-ok')"
+  );
   jupyterBundled = importTest "jupyter" (
     "import ipykernel, jupyter_server, jupyterlab, nbformat, jupyter_collaboration, "
     + "jupyter_server_ydoc, jupyter_ydoc, pycrdt, mcp; "
@@ -757,6 +768,7 @@ package.overrideAttrs (old: {
         fffBundled
         dataLibsBundled
         gmailLibsBundled
+        exaBundled
         jupyterBundled
         serverTools
         evalSmoke

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -28,7 +28,8 @@ mcp = FastMCP(
         "write the notebook as a readable narrative: markdown for context, code "
         "cells for steps. Call `notebook_use` first to pick or create a notebook. "
         "The kernel is shared with the human, and bundled modules (`tui`, `search`, "
-        "numpy, polars, duckdb, httpx, playwright, ...) import with no install step. "
+        "`fff`, `exa_py`, numpy, polars, duckdb, httpx, playwright, ...) import with "
+        "no install step. "
         "`cell_add(run=True)` is the usual way to add and execute a step in one call."
     ),
 )


### PR DESCRIPTION
## What

Bundles the official Exa web-search SDK (`exa-py`, already in nixpkgs) into the notebook MCP interpreter, so any session can run neural web search / page contents / `answer(...)` over the live web with no install step:

```python
import os
from exa_py import Exa
exa = Exa(os.environ["EXA_API_KEY"])
exa.search("best rust async runtime 2026", num_results=5)
exa.answer("what changed in the latest tokio release?")
```

No key is baked in: the caller brings `EXA_API_KEY` (sourced from rbw/op per the secrets split), matching how the bundled Google API client is handled.

## Changes

- `packages/mcp/default.nix`: add `ps.exa-py` to the pinned interpreter + an `exaBundled` import smoke test.
- Documented `fff` and `exa_py` in the three bundled-modules lists (README, the interpreter comment, and the MCP server-instructions string the agent reads) — `fff` had landed in #760 without those doc touch-ups.

## Validation (aarch64-darwin)

- `nix build .#mcp.tests.exaBundled` passes (`from exa_py import Exa`, `.search`/`.answer` callable).
- nix lint clean.

AI-attribution: drafted with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bundle the `exa_py` web-search SDK into the MCP Python interpreter
> - Adds `ps.exa-py` to the pinned Python interpreter in [default.nix](https://github.com/indexable-inc/index/pull/761/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db), making `from exa_py import Exa` importable by default without installation.
> - Updates tool instructions in [tools.py](https://github.com/indexable-inc/index/pull/761/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) and [README.md](https://github.com/indexable-inc/index/pull/761/files#diff-ba5dea79fe8446f1a9461322ff9b3158efbf2e11e1bf709973a2c146fba55539) to document `exa_py` as a bundled module alongside `fff`.
> - Adds a build-time import sanity check (`exaBundled`) that instantiates `Exa` with a dummy key and asserts `search` and `answer` are callable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2201b98.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->