### PR TITLE
feat(mcp): Gmail + Calendar from Python via google_auth

### DIFF
--- a/packages/google/calendar/cli/src/main.rs
+++ b/packages/google/calendar/cli/src/main.rs
@@ -13,8 +13,14 @@ use chrono::{
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use google_calendar::{
     Attendee, AttendeeDraft, Authenticator, Client, ClientSecrets, EVENTS_SCOPE, Event, EventDraft,
-    EventQuery, EventTime, PRIMARY_CALENDAR, SendUpdates, TokenStore, begin_consent,
+    EventQuery, EventTime, GMAIL_MODIFY_SCOPE, GMAIL_SEND_SCOPE, PRIMARY_CALENDAR, SendUpdates,
+    TokenStore, begin_consent,
 };
+
+/// Scopes the one-time consent requests: Calendar events plus Gmail
+/// read/modify and send, so the single stored grant authorizes both the
+/// calendar tools and the bundled Python `google_auth` helper.
+const CONSENT_SCOPES: [&str; 3] = [EVENTS_SCOPE, GMAIL_MODIFY_SCOPE, GMAIL_SEND_SCOPE];
 
 /// Command-line arguments.
 #[derive(Parser)]
@@ -31,8 +37,14 @@ enum Command {
     /// Needs the team OAuth client in `GOOGLE_OAUTH_CLIENT_ID` and
     /// `GOOGLE_OAUTH_CLIENT_SECRET`. Prints a consent URL; with a local browser
     /// the redirect lands automatically, over SSH pass `--paste` and feed the
-    /// redirect URL back on stdin.
+    /// redirect URL back on stdin. The grant covers Calendar and Gmail.
     Auth(AuthArgs),
+    /// Print a current OAuth access token minted from the stored grant.
+    ///
+    /// With `--json`, emits `{access_token, expires_in, scopes}`; this is the
+    /// contract the bundled Python `google_auth` helper consumes to drive the
+    /// Gmail and Calendar APIs. Without it, prints the bare token.
+    PrintAccessToken(PrintAccessTokenArgs),
     /// List events in a window (default: now through 7 days from now).
     List(ListArgs),
     /// Show one event.
@@ -41,6 +53,14 @@ enum Command {
     Create(CreateArgs),
     /// Cancel (delete) an event.
     Cancel(CancelArgs),
+}
+
+#[derive(Args)]
+struct PrintAccessTokenArgs {
+    /// Emit `{access_token, expires_in, scopes}` as JSON instead of the bare
+    /// token (what the Python `google_auth` helper reads).
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Args)]
@@ -184,6 +204,7 @@ impl From<Notify> for SendUpdates {
 async fn main() -> anyhow::Result<()> {
     match Cli::parse().command {
         Command::Auth(args) => run_auth(args).await,
+        Command::PrintAccessToken(args) => run_print_access_token(args).await,
         Command::List(args) => run_list(args).await,
         Command::Show(args) => run_show(args).await,
         Command::Create(args) => run_create(args).await,
@@ -200,7 +221,7 @@ fn client() -> anyhow::Result<Client> {
 async fn run_auth(args: AuthArgs) -> anyhow::Result<()> {
     let secrets = ClientSecrets::from_env()?;
     let store = TokenStore::new()?;
-    let pending = begin_consent(secrets.clone(), &[EVENTS_SCOPE]).await?;
+    let pending = begin_consent(secrets.clone(), &CONSENT_SCOPES).await?;
 
     println!("Open this URL in your browser:\n\n  {}\n", pending.auth_url);
     let code = if args.paste {
@@ -231,6 +252,24 @@ async fn run_auth(args: AuthArgs) -> anyhow::Result<()> {
     };
     client.list_events(PRIMARY_CALENDAR, &probe).await?;
     println!("Verified: the Calendar API answers with this grant.");
+    Ok(())
+}
+
+async fn run_print_access_token(args: PrintAccessTokenArgs) -> anyhow::Result<()> {
+    let auth = Authenticator::new(ClientSecrets::from_env()?, TokenStore::new()?)?;
+    let minted = auth.mint_access_token().await?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "access_token": minted.token,
+                "expires_in": minted.expires_in,
+                "scopes": minted.scopes,
+            })
+        );
+    } else {
+        println!("{}", minted.token);
+    }
     Ok(())
 }
 

--- a/packages/google/calendar/src/auth.rs
+++ b/packages/google/calendar/src/auth.rs
@@ -45,6 +45,14 @@ pub const CLIENT_SECRET_ENV: &str = "GOOGLE_OAUTH_CLIENT_SECRET";
 /// access to calendar settings or the user's calendar list.
 pub const EVENTS_SCOPE: &str = "https://www.googleapis.com/auth/calendar.events";
 
+/// Gmail read/modify scope: read messages, labels, and threads, and change
+/// labels/read-state (archive, trash). Does not cover sending; pair it with
+/// [`GMAIL_SEND_SCOPE`] for that.
+pub const GMAIL_MODIFY_SCOPE: &str = "https://www.googleapis.com/auth/gmail.modify";
+
+/// Gmail send scope: send mail as the authenticated user.
+pub const GMAIL_SEND_SCOPE: &str = "https://www.googleapis.com/auth/gmail.send";
+
 /// Google's OAuth consent endpoint.
 const AUTH_ENDPOINT: &str = "https://accounts.google.com/o/oauth2/v2/auth";
 
@@ -213,6 +221,9 @@ struct TokenResponse {
     refresh_token: Option<String>,
     #[serde(default)]
     scope: Option<String>,
+    /// Access-token lifetime in seconds, when the endpoint reports one.
+    #[serde(default)]
+    expires_in: Option<u64>,
 }
 
 /// The token endpoint's error body (RFC 6749 §5.2).
@@ -310,6 +321,32 @@ impl TokenClient {
     }
 }
 
+/// A freshly minted access token plus the metadata a caller needs to cache it.
+///
+/// Returned by [`Authenticator::mint_access_token`]: the bearer token, its
+/// reported lifetime, and the scopes the underlying grant covers (read from the
+/// stored grant, since the refresh response often omits `scope`). The token is
+/// the short-lived credential, so `Debug` redacts it.
+#[derive(Clone)]
+pub struct AccessToken {
+    /// The bearer access token.
+    pub token: String,
+    /// Lifetime in seconds, when the token endpoint reported one.
+    pub expires_in: Option<u64>,
+    /// Scopes the grant covers (e.g. calendar.events, gmail.modify).
+    pub scopes: Vec<String>,
+}
+
+impl std::fmt::Debug for AccessToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AccessToken")
+            .field("token", &"<redacted>")
+            .field("expires_in", &self.expires_in)
+            .field("scopes", &self.scopes)
+            .finish()
+    }
+}
+
 /// Mints access tokens from the stored refresh token.
 ///
 /// One access token is fetched lazily per `Authenticator` and reused for its
@@ -351,11 +388,27 @@ impl Authenticator {
     /// [`crate::Error::TokenRevoked`] when the grant no longer works, and
     /// transport errors otherwise.
     pub async fn access_token(&self) -> Result<&str> {
-        let token = self.access.get_or_try_init(|| self.refresh()).await?;
+        let token = self
+            .access
+            .get_or_try_init(|| async { self.refresh().await.map(|minted| minted.token) })
+            .await?;
         Ok(token)
     }
 
-    async fn refresh(&self) -> Result<String> {
+    /// Mint a fresh access token (always a network refresh, never the cache),
+    /// returning the token plus its lifetime and the grant's scopes. This is
+    /// the path the `print-access-token` CLI uses to hand a current token to the
+    /// bundled Python `google_auth` helper for Gmail/Calendar calls.
+    ///
+    /// # Errors
+    /// Same as [`Self::access_token`]: [`crate::Error::NoToken`] when nothing is
+    /// stored, [`crate::Error::TokenRevoked`] when the grant no longer works,
+    /// and transport errors otherwise.
+    pub async fn mint_access_token(&self) -> Result<AccessToken> {
+        self.refresh().await
+    }
+
+    async fn refresh(&self) -> Result<AccessToken> {
         let stored = self.store.load()?;
         let outcome = self
             .token
@@ -369,15 +422,20 @@ impl Authenticator {
             TokenOutcome::Granted(token) => token,
             TokenOutcome::Denied(denied) => return Err(denied.refresh_error()),
         };
+        let scopes = stored.scopes;
         if let Some(rotated) = token.refresh_token {
             // Google occasionally rotates the refresh token on refresh; the
             // old one stops working, so persist the replacement immediately.
             self.store.save(&StoredToken {
                 refresh_token: rotated,
-                scopes: stored.scopes,
+                scopes: scopes.clone(),
             })?;
         }
-        Ok(token.access_token)
+        Ok(AccessToken {
+            token: token.access_token,
+            expires_in: token.expires_in,
+            scopes,
+        })
     }
 }
 

--- a/packages/google/calendar/src/auth.rs
+++ b/packages/google/calendar/src/auth.rs
@@ -219,6 +219,10 @@ struct TokenResponse {
     access_token: String,
     #[serde(default)]
     refresh_token: Option<String>,
+    /// The granted scopes as the endpoint reports them. Read on the initial
+    /// code exchange to record what was granted; ignored on refresh, where the
+    /// authoritative scopes come from the stored grant (a refresh response often
+    /// omits `scope`).
     #[serde(default)]
     scope: Option<String>,
     /// Access-token lifetime in seconds, when the endpoint reports one.

--- a/packages/google/calendar/src/lib.rs
+++ b/packages/google/calendar/src/lib.rs
@@ -5,17 +5,22 @@
 //! HTTP client, the wire types, OAuth, and error mapping. The user-facing
 //! surfaces stay thin per RFC 0003: the `gcal` CLI
 //! (`packages/google/calendar/cli`) shapes arguments, and the ix-mcp calendar
-//! tools (`packages/mcp`) run that CLI with `--json`. When the Gmail
-//! integration (#644) lands, the `auth` module is the part to graduate into a
-//! shared `packages/google/auth` crate.
+//! tools (`packages/mcp`) run that CLI with `--json`.
+//!
+//! The `auth` module owns the shared Google grant: its consent now covers Gmail
+//! (`gmail.modify`, `gmail.send`) alongside `calendar.events`, and
+//! `gcal print-access-token` hands a current token to the bundled Python
+//! `google_auth` helper so notebook cells can drive Gmail and Calendar through
+//! the official client. When more Google surfaces land, this `auth` module is
+//! the part to graduate into a shared `packages/google/auth` crate (#644).
 
 pub mod auth;
 mod error;
 mod model;
 
 pub use auth::{
-    AuthCode, Authenticator, ClientSecrets, EVENTS_SCOPE, PendingConsent, StoredToken, TokenStore,
-    begin_consent,
+    AccessToken, AuthCode, Authenticator, ClientSecrets, EVENTS_SCOPE, GMAIL_MODIFY_SCOPE,
+    GMAIL_SEND_SCOPE, PendingConsent, StoredToken, TokenStore, begin_consent,
 };
 pub use error::{Error, Result};
 pub use model::{

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -81,7 +81,9 @@ The kernel runs on the same pinned interpreter as the server (see
 [`default.nix`](./default.nix)), so notebook cells can `import` the bundled
 modules with no install step: `tui` (PTY driver), `search` (semantic/grep over
 the `index` corpus), `fff` (fast fuzzy file search / content grep over a repo),
-`exa_py` (the Exa web-search SDK; bring your own `EXA_API_KEY`), numpy, polars,
+`exa_py` (the Exa web-search SDK; bring your own `EXA_API_KEY`), `google_auth`
+(Gmail and Calendar through the official Google client: `google_auth.gmail()` /
+`google_auth.calendar()`, backed by the shared `gcal` grant), numpy, polars,
 duckdb, httpx, matplotlib, playwright, the Google API client, and on macOS
 `screen` and `vmkit`. A per-notebook kernel is shared with the human, so state
 set by an agent cell is visible in the browser.

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -275,6 +275,29 @@ let
       ''
   );
 
+  # `google_auth`: mint Google credentials for the bundled Gmail/Calendar Python
+  # clients. Pure Python (no cdylib): it shells to the bundled `gcal` binary
+  # (`IX_GCAL_BIN`, set on the wrapper below) for a short-lived access token from
+  # the shared Google grant, and wraps it as a `google.oauth2.credentials`
+  # object the official client accepts. The refresh token / client secret stay
+  # inside `gcal`; only access tokens cross into Python.
+  googleAuthPythonSource = builtins.path {
+    name = "ix-mcp-google-auth-python-source";
+    path = ./src/google_auth;
+  };
+  googleAuthModule = pkgs.python3.pkgs.toPythonModule (
+    pkgs.runCommand "ix-mcp-google-auth-python-module"
+      {
+        strictDeps = true;
+        meta.description = "Google OAuth credentials helper bundled into the ix-mcp interpreter";
+      }
+      ''
+        site="$out/${pkgs.python3.sitePackages}/google_auth"
+        mkdir -p "$site"
+        cp -r ${googleAuthPythonSource}/google_auth/. "$site/"
+      ''
+  );
+
   # Native macOS screen capture and cursor control, bundled like `tui` and
   # `search` so every session can `import screen`. This one is pure Python (no
   # PyO3 cdylib): it wraps the Apple-maintained pyobjc `Quartz` binding for
@@ -438,6 +461,7 @@ let
       tuiModule
       searchModule
       fffModule
+      googleAuthModule
       ixNotebookMcpModule
     ]
     ++ darwinExtraPackages ps
@@ -586,6 +610,26 @@ let
     + "assert callable(e.search) and callable(e.answer); "
     + "print('exa-ok')"
   );
+  # The `google_auth` helper imports (pulling in google-auth) and exposes its
+  # builders. A real token mint needs IX_GCAL_BIN + a prior `gcal auth`, so the
+  # sandbox-safe assertion is the unset path: it must raise a clear, typed error
+  # naming the missing piece rather than hanging or crashing vaguely.
+  googleAuthBundled = importTest "google-auth" ''
+    import os
+
+    import google_auth
+
+    assert callable(google_auth.credentials)
+    assert callable(google_auth.gmail) and callable(google_auth.calendar)
+    os.environ.pop("IX_GCAL_BIN", None)
+    try:
+        google_auth.credentials()
+    except google_auth.GoogleAuthError as exc:
+        assert "IX_GCAL_BIN" in str(exc), exc
+    else:
+        raise SystemExit("expected GoogleAuthError when IX_GCAL_BIN is unset")
+    print("google-auth-ok")
+  '';
   jupyterBundled = importTest "jupyter" (
     "import ipykernel, jupyter_server, jupyterlab, nbformat, jupyter_collaboration, "
     + "jupyter_server_ydoc, jupyter_ydoc, pycrdt, mcp; "
@@ -769,6 +813,7 @@ package.overrideAttrs (old: {
         dataLibsBundled
         gmailLibsBundled
         exaBundled
+        googleAuthBundled
         jupyterBundled
         serverTools
         evalSmoke

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -28,7 +28,8 @@ mcp = FastMCP(
         "write the notebook as a readable narrative: markdown for context, code "
         "cells for steps. Call `notebook_use` first to pick or create a notebook. "
         "The kernel is shared with the human, and bundled modules (`tui`, `search`, "
-        "`fff`, `exa_py`, numpy, polars, duckdb, httpx, playwright, ...) import with "
+        "`fff`, `exa_py`, `google_auth` (Gmail/Calendar via `google_auth.gmail()` / "
+        "`.calendar()`), numpy, polars, duckdb, httpx, playwright, ...) import with "
         "no install step. "
         "`cell_add(run=True)` is the usual way to add and execute a step in one call."
     ),

--- a/packages/mcp/src/google_auth/google_auth/__init__.py
+++ b/packages/mcp/src/google_auth/google_auth/__init__.py
@@ -1,0 +1,127 @@
+"""Google OAuth credentials for the bundled Gmail/Calendar Python clients.
+
+The ix-mcp interpreter bundles the official Google API client
+(`google-api-python-client`), but a session has no credential to hand it. This
+module mints one from the shared Google grant the `gcal` binary holds: it shells
+to `gcal print-access-token --json` (via `IX_GCAL_BIN`, set on the mcp wrapper)
+for a current access token and returns a `google.oauth2.credentials.Credentials`
+that transparently re-mints when the token expires. The refresh token and client
+secret stay inside the binary; only short-lived access tokens cross into Python.
+
+    import google_auth
+
+    gmail = google_auth.gmail()          # googleapiclient Resource for Gmail
+    cal = google_auth.calendar()         # ... and Calendar
+    print(gmail.users().getProfile(userId="me").execute()["emailAddress"])
+
+    # or build any Google API yourself from the credentials:
+    from googleapiclient.discovery import build
+    drive = build("drive", "v3", credentials=google_auth.credentials())
+
+The grant covers Gmail (read/modify/send) and Calendar events. It needs a
+one-time `gcal auth` on the host running the MCP server; until then (or if the
+stored grant predates the Gmail scopes) calls raise `GoogleAuthError` with that
+instruction.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import subprocess
+
+from google.oauth2.credentials import Credentials
+
+__all__ = ["GoogleAuthError", "calendar", "credentials", "gmail", "service"]
+
+# Refresh a little early so a call near the boundary does not race expiry.
+_EXPIRY_SKEW = datetime.timedelta(seconds=30)
+
+# Default access-token lifetime when the binary does not report `expires_in`
+# (Google access tokens last ~1h); keeps `expiry` concrete so google-auth knows
+# to call the refresh handler again rather than treating the token as eternal.
+_DEFAULT_LIFETIME = 3600
+
+# Minting is a single token-endpoint refresh; cap it so a network stall surfaces
+# rather than hanging the kernel.
+_MINT_TIMEOUT = 30.0
+
+
+class GoogleAuthError(RuntimeError):
+    """Raised when an access token cannot be minted from the stored grant."""
+
+
+def _mint() -> dict:
+    binary = os.environ.get("IX_GCAL_BIN")
+    if not binary:
+        raise GoogleAuthError("IX_GCAL_BIN is not set; the gcal binary is bundled into ix-mcp")
+    proc = subprocess.run(
+        [binary, "print-access-token", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=_MINT_TIMEOUT,
+    )
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout).strip()
+        raise GoogleAuthError(
+            detail or f"gcal print-access-token exited with status {proc.returncode}"
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise GoogleAuthError(f"gcal returned non-JSON output: {proc.stdout!r}") from exc
+
+
+def _expiry(expires_in: object) -> datetime.datetime:
+    seconds = expires_in if isinstance(expires_in, int) and expires_in > 0 else _DEFAULT_LIFETIME
+    # google-auth compares `expiry` against a naive UTC clock, so keep it naive.
+    now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+    return now + datetime.timedelta(seconds=seconds) - _EXPIRY_SKEW
+
+
+def _refresh_handler(request: object, scopes: object) -> tuple[str, datetime.datetime]:
+    """google-auth refresh hook: mint a fresh token from the bundled binary.
+
+    This is google-auth's documented extension point for tokens fetched from an
+    external broker on demand (`Credentials(refresh_handler=...)`). The library
+    calls it with the transport and requested scopes (both ignored: the binary
+    always mints the full shared grant) and expects `(token, expiry)`. Routing
+    through it keeps the refresh token and client secret inside the binary.
+    """
+    data = _mint()
+    return data["access_token"], _expiry(data.get("expires_in"))
+
+
+def credentials() -> Credentials:
+    """Mint Google credentials from the shared grant (Gmail + Calendar).
+
+    Returns a stock `google.oauth2.credentials.Credentials` wired to re-mint via
+    the bundled binary (`refresh_handler`) when the access token expires. Raises
+    `GoogleAuthError` if the grant is missing (run `gcal auth` on the MCP host)
+    or the binary is unavailable.
+    """
+    data = _mint()
+    return Credentials(
+        token=data["access_token"],
+        expiry=_expiry(data.get("expires_in")),
+        scopes=data.get("scopes"),
+        refresh_handler=_refresh_handler,
+    )
+
+
+def service(api: str, version: str):
+    """Build a googleapiclient Resource for `api`/`version` with the grant."""
+    from googleapiclient.discovery import build
+
+    return build(api, version, credentials=credentials(), cache_discovery=False)
+
+
+def gmail(version: str = "v1"):
+    """A Gmail API client: `gmail().users().messages()`, `.send()`, ..."""
+    return service("gmail", version)
+
+
+def calendar(version: str = "v3"):
+    """A Google Calendar API client: `calendar().events()`, ..."""
+    return service("calendar", version)

--- a/packages/mcp/src/google_auth/google_auth/__init__.py
+++ b/packages/mcp/src/google_auth/google_auth/__init__.py
@@ -70,7 +70,11 @@ def _mint() -> dict:
     try:
         return json.loads(proc.stdout)
     except json.JSONDecodeError as exc:
-        raise GoogleAuthError(f"gcal returned non-JSON output: {proc.stdout!r}") from exc
+        # Deliberately omit the body: with `--json` it should be JSON, and on a
+        # bug it could contain the access token, which must not land in an error.
+        raise GoogleAuthError(
+            f"gcal print-access-token returned non-JSON output ({len(proc.stdout)} bytes)"
+        ) from exc
 
 
 def _expiry(expires_in: object) -> datetime.datetime:


### PR DESCRIPTION
## What

Gmail and Calendar from a notebook cell, through the official Google client, with no install step:

```python
import google_auth
gmail = google_auth.gmail()                 # googleapiclient Resource
cal = google_auth.calendar()
print(gmail.users().getProfile(userId="me").execute()["emailAddress"])
gmail.users().messages().send(userId="me", body={...}).execute()
```

This reuses the existing Google OAuth the `gcal` crate already owns (one installed-app grant, refresh token in `~/.config/gcal/token.json`) rather than adding a second auth system. "MCP OAuth" (the OAuth 2.1 client↔server framework) is deliberately *not* used: the MCP spec says STDIO-style servers should take credentials from the environment, and ours is Tailscale-gated — what we need is the server↔Google grant, which already exists.

## Changes

- **`packages/google/calendar`** (the `gcal` crate, which owns the shared grant):
  - Broaden the one-time consent to `calendar.events` + `gmail.modify` + `gmail.send`, so one grant authorizes both.
  - Add `gcal print-access-token --json` (mirrors `gcloud auth print-access-token`) that mints a current access token from the stored refresh token, via a new `Authenticator::mint_access_token` / `AccessToken`.
- **`packages/mcp/src/google_auth`** — a pure-Python helper bundled into the interpreter. It wires a stock `google.oauth2.credentials.Credentials` to the binary through google-auth's first-class **`refresh_handler`** hook (the documented path for "tokens fetched from an external broker on demand"), so the refresh token and client secret never leave the binary; only short-lived access tokens cross into Python. `credentials()`, plus `gmail()` / `calendar()` / `service()` builders.
- `packages/mcp/default.nix` bundles the module + an import/error-path smoke test; bundled-modules docs (README, server instructions, interpreter comment) now list `google_auth`.

## One-time setup

The new Gmail scopes require re-running `gcal auth` once on the host running the MCP server (the stored grant predates them). Until then, `google_auth` calls raise a clear `GoogleAuthError`.

## Security note

The grant now includes Gmail send/modify, i.e. an agent holding it can read, change, and send mail as you (chosen deliberately). The token file stays mode 0600; refresh token + client secret remain inside the `gcal` binary.

## Validation (aarch64-darwin)

- `nix build .#gcal` compiles; `gcal print-access-token --json` mints/errors cleanly (`no stored Google token …; run gcal auth first`).
- `nix build .#mcp.tests.googleAuthBundled` passes (module imports, and a missing `IX_GCAL_BIN` raises a typed `GoogleAuthError`).
- nix lint clean. Linux build path covered by CI.

AI-attribution: drafted with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `google_auth` Python module to MCP for Gmail and Calendar API access
> - Adds a new `google_auth` Python package to the MCP environment ([`__init__.py`](https://github.com/indexable-inc/index/pull/762/files#diff-a31e9489e608de89bdd19aa1fb80b8fc8d42366733c8d9c7dd260771bec32bd9)) that provides `gmail()`, `calendar()`, `credentials()`, and `service()` helpers backed by the existing `gcal` CLI grant.
> - Mints fresh access tokens by shelling out to the `gcal print-access-token --json` binary (configured via `IX_GCAL_BIN`) and wraps them in `google.oauth2.credentials.Credentials` with automatic refresh support.
> - Extends the `gcal` CLI ([`cli/src/main.rs`](https://github.com/indexable-inc/index/pull/762/files#diff-f51f3b078900a0dab6cc08b39dbaf921524a17fd677e1fe8ea29117e2226449b)) with a `print-access-token` subcommand and updates the OAuth consent flow to request Calendar and Gmail scopes in a single grant.
> - The `auth.rs` `refresh` method now returns a structured `AccessToken` (token + `expires_in` + scopes) instead of a bare string.
> - Behavioral Change: re-running `gcal auth` will now request Gmail modify/send scopes in addition to Calendar; existing stored tokens won't include Gmail scopes until re-consent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a1afb4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->