### PR TITLE
fix(nix): clear the 6 lint violations #693 surfaced in lib/build

### DIFF
--- a/lib/build/bun-lock.nix
+++ b/lib/build/bun-lock.nix
@@ -78,7 +78,7 @@ lib.fix (self: {
     Returns `{ packages = [ ... ]; }`, where every package includes `name`,
     `version`, `url`, `integrity`, and `cachePath`.
   */
-  importLock = args: fromJSON (readFile (self.generateLockJson args));
+  importLock = args: lib.importJSON (self.generateLockJson args);
 
   /**
     Build a Bun install cache from `bun.lock` without a caller-provided hash.

--- a/lib/build/gradle-fat-jar.nix
+++ b/lib/build/gradle-fat-jar.nix
@@ -74,6 +74,9 @@ let
     let
       go =
         activeArtifact: todo:
+        # Recursion base case (no lines left -> no artifacts), not conditional
+        # list construction; lib.optionals would obscure the recursion.
+        # ast-grep-ignore: no-deprecated-iflist-empty
         if todo == [ ] then
           [ ]
         else
@@ -81,8 +84,15 @@ let
             line = builtins.head todo;
             rest = builtins.tail todo;
             artifactName = attrFromLine "name" line;
+            # Verbatim hex parsed from Gradle's verification-metadata.xml
+            # (value="<hex>"); it round-trips into the component record below,
+            # it is not a fetcher `hash` slot.
+            # ast-grep-ignore: prefer-sri-hash
             sha256 = attrFromLine "value" line;
           in
+          # Terminal guard in the line walk (the closing tag ends the
+          # component): a recursion-termination case, not list splicing.
+          # ast-grep-ignore: no-deprecated-iflist-empty
           if lib.hasInfix "</component>" line then
             [ ]
           else if artifactName != null then
@@ -105,6 +115,8 @@ let
 
   parseComponents =
     current: remainingLines:
+    # Recursion base case (no lines left -> no components).
+    # ast-grep-ignore: no-deprecated-iflist-empty
     if remainingLines == [ ] then
       [ ]
     else

--- a/lib/build/npm-vitest.nix
+++ b/lib/build/npm-vitest.nix
@@ -151,35 +151,33 @@ let
     in
     "${readable}-${digest}";
 
-  cases = lib.listToAttrs (
-    map (
-      entry:
-      lib.nameValuePair (caseId entry) (
-        pkgs.stdenvNoCC.mkDerivation (
-          baseAttrs
-          // {
-            pname = "${pname}-vitest-${caseId entry}";
-            inherit version;
-            passthru = {
-              testName = entry.name;
-              testFile = relativeTestFile entry;
-              testProject = entry.projectName or null;
-              vitestArgs = caseArgs entry;
-            };
-            buildPhase = ''
-              runHook preBuild
-              ${preTest}
-              ${vitestCli} run ${lib.escapeShellArgs (caseArgs entry)}
-              runHook postBuild
-            '';
-            installPhase = ''
-              mkdir -p "$out"
-              echo passed > "$out/result"
-            '';
-          }
-        )
+  cases = lib.genAttrs' manifestEntries (
+    entry:
+    lib.nameValuePair (caseId entry) (
+      pkgs.stdenvNoCC.mkDerivation (
+        baseAttrs
+        // {
+          pname = "${pname}-vitest-${caseId entry}";
+          inherit version;
+          passthru = {
+            testName = entry.name;
+            testFile = relativeTestFile entry;
+            testProject = entry.projectName or null;
+            vitestArgs = caseArgs entry;
+          };
+          buildPhase = ''
+            runHook preBuild
+            ${preTest}
+            ${vitestCli} run ${lib.escapeShellArgs (caseArgs entry)}
+            runHook postBuild
+          '';
+          installPhase = ''
+            mkdir -p "$out"
+            echo passed > "$out/result"
+          '';
+        }
       )
-    ) manifestEntries
+    )
   );
 in
 {


### PR DESCRIPTION
## What

Fixes the 6 ast-grep violations that broke `main`'s lint (the "Check" workflow / `ix-images-lint`).

#693 ("build pipeline cleanup and nix lint idioms, stage 1 of N", merged as f734bd81) added stricter rules (`prefer-sri-hash`, `prefer-lib-import-format`, `no-deprecated-iflist-empty`, `prefer-genattrs-listtoattrs`) but left 6 pre-existing violations in `lib/build/`. Those slipped through because the local ast-grep scan runs in a tree *with* `.git` and so honors `.gitignore`, while CI's `ix-images-lint` runs the full repo ast-grep over a `.git`-less source copy that scans everything — so `main` went red the moment #693 landed.

## The 6, and the fix

- `lib/build/bun-lock.nix` — `fromJSON (readFile …)` → **`lib.importJSON`** (matches `npm-vitest.nix`'s existing idiom).
- `lib/build/npm-vitest.nix` — `lib.listToAttrs (map f xs)` → **`lib.genAttrs' xs f`** (provably equivalent; verified arg order).
- `lib/build/gradle-fat-jar.nix` — 4 suppressions with reasons, the rules' own acknowledged exceptions:
  - the verification-metadata `sha256` is a verbatim Gradle hex digest that round-trips into the component record, not a fetcher `hash` slot (mirrors the existing `lib/rust/build.nix` suppression);
  - 3 `if xs == [] then [] else …` are recursion base cases, not conditional list construction (same rationale as the rule's existing `lib/image/fleet.nix` exemption); `lib.optionals` would obscure the recursion.

## Validation

Reproduced CI exactly (`git archive HEAD | ast-grep scan --error .`, i.e. a `.git`-less tree): **6 → 0** errors. All three files parse and `nixfmt --check` clean.

Note for #693 follow-ups: `lib/build/*` being skipped by local `.git`-aware scans is a latent blind spot worth closing in a later stage.

AI-attribution: drafted with Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 6 lint violations in Nix build lib files
> - Replaces `fromJSON (readFile ...)` with `lib.importJSON` in [bun-lock.nix](https://github.com/indexable-inc/index/pull/763/files#diff-d8562d624a6e59b39bbfc7e955ef589f3883852fbc464aeaddcb93696a888c55) to use the standard library helper.
> - Refactors attribute set construction in [npm-vitest.nix](https://github.com/indexable-inc/index/pull/763/files#diff-1045922791dbbb8c2c85630c1c4897bff58fdbea3c3fc2f6383ec655283dea3e) from `lib.listToAttrs (map ...)` to `lib.genAttrs'`.
> - Adds explanatory comments and `ast-grep-ignore` annotations in [gradle-fat-jar.nix](https://github.com/indexable-inc/index/pull/763/files#diff-6c744f2ae2c079232b9c005652eadd9b590693680462d13d9ec2f107c28aa4b4) to suppress linter warnings; no logic changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c624f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->