### PR TITLE
fix(nix): properly fix gradle-fat-jar lint instead of suppressing it

### DIFF
--- a/lib/build/gradle-fat-jar.nix
+++ b/lib/build/gradle-fat-jar.nix
@@ -69,75 +69,76 @@ let
     in
     if match == null then null else builtins.head match;
 
-  parseArtifacts =
-    component: remainingLines:
-    let
-      go =
-        activeArtifact: todo:
-        # Recursion base case (no lines left -> no artifacts), not conditional
-        # list construction; lib.optionals would obscure the recursion.
-        # ast-grep-ignore: no-deprecated-iflist-empty
-        if todo == [ ] then
-          [ ]
-        else
-          let
-            line = builtins.head todo;
-            rest = builtins.tail todo;
-            artifactName = attrFromLine "name" line;
-            # Verbatim hex parsed from Gradle's verification-metadata.xml
-            # (value="<hex>"); it round-trips into the component record below,
-            # it is not a fetcher `hash` slot.
-            # ast-grep-ignore: prefer-sri-hash
-            sha256 = attrFromLine "value" line;
-          in
-          # Terminal guard in the line walk (the closing tag ends the
-          # component): a recursion-termination case, not list splicing.
-          # ast-grep-ignore: no-deprecated-iflist-empty
-          if lib.hasInfix "</component>" line then
-            [ ]
-          else if artifactName != null then
-            go artifactName rest
-          else if activeArtifact != null && sha256 != null then
-            [
-              (
-                component
-                // {
-                  inherit sha256;
-                  file = activeArtifact;
-                }
-              )
-            ]
-            ++ go null rest
-          else
-            go activeArtifact rest;
-    in
-    go null remainingLines;
+  # Gradle records each artifact digest as a hex `value="<hex>"`. Convert it to
+  # the self-describing SRI form the fetcher `hash` slot expects, rather than
+  # carrying a legacy `sha256` attr.
+  hexToSri =
+    hex:
+    builtins.convertHash {
+      hash = hex;
+      hashAlgo = "sha256";
+      toHashFormat = "sri";
+    };
 
-  parseComponents =
-    current: remainingLines:
-    # Recursion base case (no lines left -> no components).
-    # ast-grep-ignore: no-deprecated-iflist-empty
-    if remainingLines == [ ] then
-      [ ]
+  # Walk the verification XML line by line, carrying the open component and
+  # artifact in the fold accumulator. Gradle emits one tag per line:
+  #   <component group="…" name="…" version="…">   opens a component
+  #   <artifact name="…">                          opens an artifact in it
+  #   <sha256 value="<hex>"/>                       the artifact's sha256 digest
+  #   </artifact> / </component>                    close and reset state
+  # Only the first `<sha256>` of an artifact is taken; any other digest or
+  # signature line (sha512, sha1, md5, pgp, also-trust) is ignored, so a 128-hex
+  # or 40-hex fingerprint never reaches `hexToSri`. Close tags clear the open
+  # artifact/component so a stray digest line is never reattributed.
+  collect =
+    state: line:
+    if lib.hasInfix "<component " line then
+      state
+      // {
+        component = {
+          group = attrFromLine "group" line;
+          name = attrFromLine "name" line;
+          version = attrFromLine "version" line;
+        };
+        artifact = null;
+      }
+    else if lib.hasInfix "</component>" line then
+      state
+      // {
+        component = null;
+        artifact = null;
+      }
+    else if lib.hasInfix ''<artifact name="'' line then
+      state // { artifact = attrFromLine "name" line; }
+    else if lib.hasInfix "</artifact>" line then
+      state // { artifact = null; }
+    else if
+      lib.hasInfix ''<sha256 value="'' line && state.component != null && state.artifact != null
+    then
+      state
+      // {
+        # First digest wins: clear the artifact so a later digest line under the
+        # same artifact cannot emit a second record for the same file.
+        artifact = null;
+        results = state.results ++ [
+          (
+            state.component
+            // {
+              file = state.artifact;
+              hash = hexToSri (attrFromLine "value" line);
+            }
+          )
+        ];
+      }
     else
-      let
-        line = builtins.head remainingLines;
-        rest = builtins.tail remainingLines;
-        group = attrFromLine "group" line;
-        name = attrFromLine "name" line;
-        artifactVersion = attrFromLine "version" line;
-      in
-      if lib.hasInfix "<component " line then
-        parseComponents {
-          inherit group name;
-          version = artifactVersion;
-        } rest
-      else if current != null && lib.hasInfix ''<artifact name="'' line then
-        parseArtifacts current remainingLines ++ parseComponents null remainingLines
-      else
-        parseComponents current rest;
+      state;
 
-  artifacts = parseComponents null lines;
+  artifacts =
+    (lib.foldl' collect {
+      component = null;
+      artifact = null;
+      results = [ ];
+    } lines).results;
 
   artifactUrl =
     {
@@ -157,7 +158,7 @@ let
     // {
       src = pkgs.fetchurl {
         url = artifactUrl artifact;
-        hash = "sha256:${artifact.sha256}";
+        inherit (artifact) hash;
       };
     }
   ) artifacts;


### PR DESCRIPTION
Follow-up to #763, which cleared the lint #693 surfaced by adding `# ast-grep-ignore` suppressions to `lib/build/gradle-fat-jar.nix`. This replaces those suppressions with real fixes so the lint passes on its own terms.

**prefer-sri-hash**: the Gradle hex digest was stored on a legacy `sha256` attr and spliced into `hash = "sha256:${...}"`. It is consumed as a fetch hash, not round-tripped, so the rule applies. Convert it once with `builtins.convertHash` to a real SRI hash and feed the fetcher `hash` slot directly.

**no-deprecated-iflist-empty** (3x): the violations were the `if … == [] then [] else …` base cases of a hand-rolled mutual recursion that walked the XML. Replaced the whole thing with a single `lib.foldl'` that carries the open component and artifact in its accumulator. No empty-list base case, and the parse is simpler to read.

Validation:
- `ast-grep scan` of both rules on the file: clean.
- `nix build .#minestom-hello-server-jar`: BUILD SUCCESSFUL. Gradle resolved every dependency offline from the maven repo built out of the FOD-fetched artifacts, so every converted SRI hash matched the real jars/poms/modules.

AI-authored by Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix gradle-fat-jar lint by using SRI-formatted hashes instead of raw hex sha256
> Replaces the recursive `parseComponents`/`parseArtifacts` walkers in [gradle-fat-jar.nix](https://github.com/indexable-inc/index/pull/764/files#diff-6c744f2ae2c079232b9c005652eadd9b590693680462d13d9ec2f107c28aa4b4) with a single `lib.foldl'`-based state machine that parses the verification XML and emits artifact records with SRI-formatted hashes.
>
> - Adds a `hexToSri` utility using `builtins.convertHash` to convert hex sha256 digests to SRI format.
> - The new `collect` reducer opens on `<component>`, tracks `<artifact>`, and records only the first `<sha256>` digest per artifact, ignoring other digest types and signature lines.
> - `pkgs.fetchurl` now receives the hash via the `hash` attribute (SRI format) rather than a manually concatenated `sha256:<hex>` string, resolving the lint violation properly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 178d416.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->