### PR TITLE
feat(rust): auto-inject prebuilt cargo units' transitive depUnits

### DIFF
--- a/lib/rust/cargo-unit.nix
+++ b/lib/rust/cargo-unit.nix
@@ -10,7 +10,9 @@ let
     elem
     elemAt
     filter
+    genericClosure
     hasAttr
+    head
     length
     removeAttrs
     replaceStrings
@@ -102,8 +104,43 @@ let
         else
           targets;
 
-      extraUnits = rawArgs.extraUnits or { };
+      explicitExtraUnits = rawArgs.extraUnits or { };
       extraLibraries = rawArgs.extraLibraries or { };
+
+      # Every injected unit plus everything reachable from one through
+      # `passthru.depUnits` (recorded by `mkPrebuiltLibraryUnit`), deduplicated
+      # by derivation. Walking by drvPath rather than unitKey keeps two distinct
+      # derivations that claim the same unit key visible to the conflict guard
+      # below instead of silently dropping one of them.
+      injectedUnitClosure = map (item: item.unit) (genericClosure {
+        startSet = lib.mapAttrsToList (_: unit: {
+          key = unit.drvPath;
+          inherit unit;
+        }) explicitExtraUnits;
+        operator =
+          item:
+          map (dep: {
+            key = dep.drvPath;
+            unit = dep;
+          }) (item.unit.passthru.depUnits or [ ]);
+      });
+
+      # The closure grouped by recorded unit key. Injected units without a
+      # `passthru.unitKey` (arbitrary caller-owned derivations) record no key
+      # and never participate in auto-injection.
+      injectedUnitsByKey = lib.groupBy (unit: unit.passthru.unitKey) (
+        filter (unit: unit ? passthru.unitKey) injectedUnitClosure
+      );
+
+      # Transitive deps of the injected prebuilts, auto-injected under their own
+      # recorded unit keys so a caller injects only the root unit (ENG-2166).
+      # An explicit `extraUnits` entry wins the merge below, so a caller can
+      # deliberately pin one dep key to a different artifact.
+      autoInjectedDepUnits = lib.mapAttrs (_: head) (
+        lib.filterAttrs (key: _: !(hasAttr key explicitExtraUnits)) injectedUnitsByKey
+      );
+
+      extraUnits = autoInjectedDepUnits // explicitExtraUnits;
 
       # First IFD stage: emit Cargo's `--unit-graph` JSON for the vendored
       # workspace, one cargo invocation per `cargoTargets` entry merged into one
@@ -343,14 +380,51 @@ let
           the toolchain that produced it. Thread the workspace's rustToolchain into
           mkPrebuiltLibraryUnit.'';
 
+      # C3: when an explicitly injected unit records its own unit key, the
+      # caller's chosen attr key must agree with it. The artifact names inside
+      # the unit embed that key's hash, and auto-injection keys the unit's deps
+      # by `passthru.unitKey`, so a disagreement would inject one derivation
+      # under two keys.
+      injectionUnitKeyMismatchProblems =
+        let
+          mismatched = lib.filterAttrs (key: unit: (unit.passthru.unitKey or key) != key) explicitExtraUnits;
+          render = key: unit: "${key} (the unit's own passthru.unitKey is ${unit.passthru.unitKey})";
+        in
+        lib.optional (mismatched != { }) ''
+          extraUnits key(s) that disagree with the injected unit's recorded unitKey:
+            ${lib.concatStringsSep "\n  " (lib.mapAttrsToList render mismatched)}
+          A prebuilt unit must be injected under its `passthru.unitKey`; the rlib and
+          extern-path inside it are named for that key's hash.'';
+
+      # C4: two recorded prebuilts claiming one unit key with different
+      # derivations is ambiguous, and whichever the graph linked would be a
+      # silent choice. An explicit `extraUnits` entry for the key resolves the
+      # ambiguity (it wins the merge), so only unpinned keys are problems.
+      depUnitConflictProblems =
+        let
+          conflicts = lib.filterAttrs (
+            key: unitDrvs: length unitDrvs > 1 && !(hasAttr key explicitExtraUnits)
+          ) injectedUnitsByKey;
+          render =
+            key: unitDrvs: "${key}:\n    ${lib.concatMapStringsSep "\n    " (unit: unit.drvPath) unitDrvs}";
+        in
+        lib.optional (conflicts != { }) ''
+          conflicting prebuilt derivations recorded for the same dependency unit key:
+            ${lib.concatStringsSep "\n  " (lib.mapAttrsToList render conflicts)}
+          Two injected prebuilt units recorded different derivations for one transitive
+          dep (`passthru.depUnits`). Pin the key in extraUnits explicitly to choose one.'';
+
       # All prebuilt-injection guard problems, gathered so a single assert can
       # report every offending key at once (and so the assert keeps its
       # `lib.assertMsg` shape, per the no-bare-assert lint).
       injectionProblems =
-        injectionKeyProblems "extraUnits" extraUnits generatedUnitKeys
+        injectionKeyProblems "extraUnits" explicitExtraUnits generatedUnitKeys
+        ++ injectionKeyProblems "extraUnits (auto-injected depUnits)" autoInjectedDepUnits generatedUnitKeys
         ++ injectionKeyProblems "extraLibraries" extraLibraries generatedLibraryKeys
         ++ injectionToolchainProblems "extraUnits" extraUnits
-        ++ injectionToolchainProblems "extraLibraries" extraLibraries;
+        ++ injectionToolchainProblems "extraLibraries" extraLibraries
+        ++ injectionUnitKeyMismatchProblems
+        ++ depUnitConflictProblems;
 
       units =
         assert lib.assertMsg (injectionProblems == [ ]) (
@@ -628,13 +702,20 @@ let
       only for the toolchain-id assertion. A caller whose `buildWorkspace` uses a
       non-default toolchain MUST thread that same `rustToolchain` here, or the
       workspace-side cross-check in `buildWorkspace` will reject the injection.
-    - `depUnits`: optional list of this prebuilt's own transitive dependency unit
-      derivations, recorded to `$out/nix-support/dependency-units` for provenance.
-      Defaults to `[ ]` (a leaf library, the validated path). NOTE: this is
-      currently informational only and is NOT auto-injected into the consuming
-      graph; a prebuilt with transitive deps still requires those dep units to be
-      present in the consumer's graph (keyed by the same hash) and injected via
-      `extraUnits`. Tracked in ENG-2166.
+    - `depUnits`: this prebuilt's own dependency unit derivations, each built
+      with `mkPrebuiltLibraryUnit` (each entry must carry `passthru.unitKey`).
+      Direct deps that each record their own `depUnits`, or a flattened
+      transitive list, inject identically. Defaults to `[ ]` (a leaf library).
+      `buildWorkspace` walks `passthru.depUnits` transitively and auto-injects
+      every recorded unit into the consuming graph under its own
+      `passthru.unitKey`, so the caller injects only the root unit. Each
+      auto-injected key must name a unit the consumer's graph already
+      references (the C1 guard), which holds exactly when the consumer's
+      manifest pins the dependency closure the prebuilt was compiled against:
+      the unit hash folds in dependency hashes recursively, so a root key match
+      implies every dep key matches. An explicit `extraUnits` entry for a dep
+      key overrides the recorded derivation. The deps are also recorded to
+      `$out/nix-support/dependency-units` for provenance.
   */
   mkPrebuiltLibraryUnit =
     {
@@ -670,10 +751,21 @@ let
     assert lib.assertMsg (lib.hasSuffix ".rmeta" (toString rmeta)) ''
       cargoUnit.mkPrebuiltLibraryUnit: `rmeta` for `${name}` must be a .rmeta path; got ${toString rmeta}.
     '';
+    # Auto-injection keys each dep by its `passthru.unitKey`, so an entry
+    # without one could never be wired into a consuming graph. Reject it at
+    # construction, naming the offender, instead of at injection time.
+    assert lib.assertMsg (filter (dep: !(dep ? passthru.unitKey)) depUnits == [ ]) ''
+      cargoUnit.mkPrebuiltLibraryUnit: depUnits for `${name}` must be prebuilt unit
+      derivations carrying `passthru.unitKey` (build them with mkPrebuiltLibraryUnit); got:
+        ${lib.concatMapStringsSep "\n  " (dep: dep.name or "<non-derivation>") (
+          filter (dep: !(dep ? passthru.unitKey)) depUnits
+        )}
+    '';
     pkgs.runCommand "cargo-unit-prebuilt-${name}-${version}-${hash}"
       {
         # Surfaced for callers/tests that want to confirm the injected key
-        # without reconstructing the format string.
+        # without reconstructing the format string. `depUnits` is what
+        # `buildWorkspace` walks to auto-inject this unit's transitive deps.
         passthru = {
           unitKey = "${name}-${version}-${hash}";
           libraryName = libName;
@@ -682,6 +774,7 @@ let
             version
             hash
             toolchainId
+            depUnits
             ;
         };
       }

--- a/lib/rust/cargo-unit.nix
+++ b/lib/rust/cargo-unit.nix
@@ -109,9 +109,14 @@ let
 
       # Every injected unit plus everything reachable from one through
       # `passthru.depUnits` (recorded by `mkPrebuiltLibraryUnit`), deduplicated
-      # by derivation. Walking by drvPath rather than unitKey keeps two distinct
-      # derivations that claim the same unit key visible to the conflict guard
-      # below instead of silently dropping one of them.
+      # by derivation. A recorded dep whose unit key the caller explicitly
+      # pinned in `extraUnits` is pruned BEFORE descending: the pinned
+      # derivation (already a closure root) is the selected unit for that key,
+      # and the discarded dep's own subtree must not auto-inject units or
+      # raise conflicts on behalf of an artifact the graph never links.
+      # Walking by drvPath rather than unitKey keeps two distinct derivations
+      # that claim the same unpinned key visible to the conflict guard below
+      # instead of silently dropping one of them.
       injectedUnitClosure = map (item: item.unit) (genericClosure {
         startSet = lib.mapAttrsToList (_: unit: {
           key = unit.drvPath;
@@ -119,10 +124,16 @@ let
         }) explicitExtraUnits;
         operator =
           item:
-          map (dep: {
-            key = dep.drvPath;
-            unit = dep;
-          }) (item.unit.passthru.depUnits or [ ]);
+          map
+            (dep: {
+              key = dep.drvPath;
+              unit = dep;
+            })
+            (
+              filter (dep: !(hasAttr (dep.passthru.unitKey or "") explicitExtraUnits)) (
+                item.unit.passthru.depUnits or [ ]
+              )
+            );
       });
 
       # The closure grouped by recorded unit key. Injected units without a

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -713,6 +713,11 @@ let
   # consumer prints 99. Using a distinguishable variant is what makes the proof
   # real: a same-source rlib is byte-identical, so a runtime check could not tell
   # prebuilt from source; 99-vs-42 can only come from the injected prebuilt.
+  # The fixture also has a chained pair (prebuilt-mid depends on prebuilt-lib,
+  # prebuilt-chain-consumer depends only on prebuilt-mid) proving that a
+  # prebuilt unit's recorded `depUnits` are auto-injected into the consuming
+  # graph: the chain consumer links and prints 100 (variant 99 + 1) with only
+  # the mid prebuilt passed to extraUnits.
   cargoUnitPrebuiltFixture = fs.toSource {
     root = ./fixtures/cargo-unit-prebuilt;
     fileset = fs.unions [
@@ -758,24 +763,29 @@ let
     }
   );
 
-  # The single `prebuilt_lib-0.1.0-<hash>` unit from the variant graph, found by
-  # key prefix (mirrors `cargoUnitScopeUnit`). Its attr name IS the unit key.
-  cargoUnitPrebuiltLibMatches = lib.filterAttrs (
-    name: _: lib.hasPrefix "prebuilt_lib-0.1.0-" name
-  ) cargoUnitPrebuiltVariant.units;
-  cargoUnitPrebuiltLibKey =
+  # Find the single unit whose key starts with `<target-name>-<version>-` in a
+  # workspace's unit set (mirrors `cargoUnitScopeUnit`; the attr name IS the
+  # unit key) and split out the trailing hash. The crate names here have no
+  # dashes and the version is a fixed literal, so stripping the prefix leaves
+  # the hash. Exactly one match is asserted so a manifest or profile drift
+  # fails here, not downstream.
+  cargoUnitPrebuiltUnitByPrefix =
+    workspace: prefix:
     let
-      names = builtins.attrNames cargoUnitPrebuiltLibMatches;
+      names = builtins.filter (lib.hasPrefix prefix) (builtins.attrNames workspace.units);
+      key = builtins.head names;
     in
     assert lib.assertMsg (
       builtins.length names == 1
-    ) "expected exactly one prebuilt_lib unit, found ${lib.concatStringsSep ", " names}";
-    builtins.head names;
-  # The hash component of "<name>-<version>-<hash>". The library crate name has
-  # no dashes, and the version is the fixed literal above, so stripping the known
-  # prefix leaves the hash.
-  cargoUnitPrebuiltLibHash = lib.removePrefix "prebuilt_lib-0.1.0-" cargoUnitPrebuiltLibKey;
-  cargoUnitPrebuiltVariantLibUnit = cargoUnitPrebuiltLibMatches.${cargoUnitPrebuiltLibKey};
+    ) "expected exactly one ${prefix}* unit, found ${lib.concatStringsSep ", " names}";
+    {
+      inherit key;
+      hash = lib.removePrefix prefix key;
+      unit = workspace.units.${key};
+    };
+
+  cargoUnitPrebuiltVariantLib = cargoUnitPrebuiltUnitByPrefix cargoUnitPrebuiltVariant "prebuilt_lib-0.1.0-";
+  cargoUnitPrebuiltVariantMid = cargoUnitPrebuiltUnitByPrefix cargoUnitPrebuiltVariant "prebuilt_mid-0.1.0-";
 
   # (b) Wrap the variant's rlib+rmeta as a prebuilt unit. The rlib/rmeta paths
   # are reconstructed from the known underscored name + hash, exactly as the
@@ -788,10 +798,24 @@ let
     # The package is `prebuilt-lib`; its lib target is `prebuilt_lib`.
     name = "prebuilt_lib";
     version = "0.1.0";
-    hash = cargoUnitPrebuiltLibHash;
-    rlib = "${cargoUnitPrebuiltVariantLibUnit}/lib/libprebuilt_lib-${cargoUnitPrebuiltLibHash}.rlib";
-    rmeta = "${cargoUnitPrebuiltVariantLibUnit}/lib/libprebuilt_lib-${cargoUnitPrebuiltLibHash}.rmeta";
+    inherit (cargoUnitPrebuiltVariantLib) hash;
+    rlib = "${cargoUnitPrebuiltVariantLib.unit}/lib/libprebuilt_lib-${cargoUnitPrebuiltVariantLib.hash}.rlib";
+    rmeta = "${cargoUnitPrebuiltVariantLib.unit}/lib/libprebuilt_lib-${cargoUnitPrebuiltVariantLib.hash}.rmeta";
     toolchainId = ix.cargoUnit.defaultToolchainId;
+  };
+
+  # The variant mid prebuilt, recording its leaf dep so buildWorkspace can
+  # auto-inject it. The mid rlib embeds the VARIANT leaf's SVH, so linking it
+  # in a consumer graph only works when the leaf prebuilt rides along; that is
+  # the path the chain arm proves end to end (ENG-2166).
+  cargoUnitPrebuiltMidUnit = ix.cargoUnit.mkPrebuiltLibraryUnit {
+    name = "prebuilt_mid";
+    version = "0.1.0";
+    inherit (cargoUnitPrebuiltVariantMid) hash;
+    rlib = "${cargoUnitPrebuiltVariantMid.unit}/lib/libprebuilt_mid-${cargoUnitPrebuiltVariantMid.hash}.rlib";
+    rmeta = "${cargoUnitPrebuiltVariantMid.unit}/lib/libprebuilt_mid-${cargoUnitPrebuiltVariantMid.hash}.rmeta";
+    toolchainId = ix.cargoUnit.defaultToolchainId;
+    depUnits = [ cargoUnitPrebuiltLibUnit ];
   };
 
   # Negative arm: a wrong toolchain id must fail at eval (not at link time).
@@ -801,10 +825,26 @@ let
       (ix.cargoUnit.mkPrebuiltLibraryUnit {
         name = "prebuilt_lib";
         version = "0.1.0";
-        hash = cargoUnitPrebuiltLibHash;
-        rlib = "${cargoUnitPrebuiltVariantLibUnit}/lib/libprebuilt_lib-${cargoUnitPrebuiltLibHash}.rlib";
-        rmeta = "${cargoUnitPrebuiltVariantLibUnit}/lib/libprebuilt_lib-${cargoUnitPrebuiltLibHash}.rmeta";
+        inherit (cargoUnitPrebuiltVariantLib) hash;
+        rlib = "${cargoUnitPrebuiltVariantLib.unit}/lib/libprebuilt_lib-${cargoUnitPrebuiltVariantLib.hash}.rlib";
+        rmeta = "${cargoUnitPrebuiltVariantLib.unit}/lib/libprebuilt_lib-${cargoUnitPrebuiltVariantLib.hash}.rmeta";
         toolchainId = "definitely-not-the-toolchain";
+      }).drvPath
+      true
+  );
+
+  # Negative arm: depUnits entries that carry no `passthru.unitKey` could never
+  # be auto-injected; mkPrebuiltLibraryUnit must reject them at construction.
+  cargoUnitPrebuiltBadDepEval = builtins.tryEval (
+    builtins.seq
+      (ix.cargoUnit.mkPrebuiltLibraryUnit {
+        name = "prebuilt_mid";
+        version = "0.1.0";
+        inherit (cargoUnitPrebuiltVariantMid) hash;
+        rlib = "${cargoUnitPrebuiltVariantMid.unit}/lib/libprebuilt_mid-${cargoUnitPrebuiltVariantMid.hash}.rlib";
+        rmeta = "${cargoUnitPrebuiltVariantMid.unit}/lib/libprebuilt_mid-${cargoUnitPrebuiltVariantMid.hash}.rmeta";
+        toolchainId = ix.cargoUnit.defaultToolchainId;
+        depUnits = [ (pkgs.runCommand "not-a-prebuilt-unit" { } ''mkdir "$out"'') ];
       }).drvPath
       true
   );
@@ -820,7 +860,7 @@ let
       pname = "cargo-unit-prebuilt-injected";
       src = cargoUnitPrebuiltFixture;
       extraUnits = {
-        ${cargoUnitPrebuiltLibKey} = cargoUnitPrebuiltLibUnit;
+        ${cargoUnitPrebuiltVariantLib.key} = cargoUnitPrebuiltLibUnit;
       };
       extraLibraries = {
         prebuilt_lib = cargoUnitPrebuiltLibUnit;
@@ -829,6 +869,22 @@ let
   );
 
   cargoUnitPrebuiltConsumer = cargoUnitPrebuiltInjected.binaries.prebuilt-consumer;
+
+  # (d) ENG-2166: inject ONLY the mid prebuilt; its recorded leaf dep must be
+  # auto-injected for the chain consumer to link at all. The mid rlib references
+  # the VARIANT leaf's SVH, which no from-source leaf build can satisfy, so a
+  # successful link plus the 100 output proves the dep auto-injection worked.
+  cargoUnitPrebuiltChainInjected = ix.cargoUnit.buildWorkspace (
+    cargoUnitPrebuiltCommon
+    // {
+      pname = "cargo-unit-prebuilt-chain";
+      src = cargoUnitPrebuiltFixture;
+      extraUnits = {
+        ${cargoUnitPrebuiltVariantMid.key} = cargoUnitPrebuiltMidUnit;
+      };
+    }
+  );
+  cargoUnitPrebuiltChainConsumer = cargoUnitPrebuiltChainInjected.binaries.prebuilt-chain-consumer;
 
   # The consumer workspace's OWN from-source lib unit key (no injection). Used to
   # prove the variant (different source) hashes to the same key, which is the
@@ -840,10 +896,83 @@ let
       src = cargoUnitPrebuiltFixture;
     }
   );
-  cargoUnitPrebuiltPlainLibKey = builtins.head (
-    builtins.filter (lib.hasPrefix "prebuilt_lib-0.1.0-") (
-      builtins.attrNames cargoUnitPrebuiltPlain.units
-    )
+  cargoUnitPrebuiltPlainLib = cargoUnitPrebuiltUnitByPrefix cargoUnitPrebuiltPlain "prebuilt_lib-0.1.0-";
+  cargoUnitPrebuiltPlainMid = cargoUnitPrebuiltUnitByPrefix cargoUnitPrebuiltPlain "prebuilt_mid-0.1.0-";
+
+  # A SECOND prebuilt for the same leaf unit key, wrapped from the PLAIN
+  # workspace's artifacts (answer = 42): same unit key, different derivation.
+  # Used by the explicit-override arm and the dep-conflict negative arm below.
+  cargoUnitPrebuiltLibUnitFromPlain = ix.cargoUnit.mkPrebuiltLibraryUnit {
+    name = "prebuilt_lib";
+    version = "0.1.0";
+    inherit (cargoUnitPrebuiltPlainLib) hash;
+    rlib = "${cargoUnitPrebuiltPlainLib.unit}/lib/libprebuilt_lib-${cargoUnitPrebuiltPlainLib.hash}.rlib";
+    rmeta = "${cargoUnitPrebuiltPlainLib.unit}/lib/libprebuilt_lib-${cargoUnitPrebuiltPlainLib.hash}.rmeta";
+    toolchainId = ix.cargoUnit.defaultToolchainId;
+  };
+
+  # Explicit override of an auto-injected dep: the caller pins the leaf key to
+  # a different derivation than the one the mid prebuilt recorded. Eval-only:
+  # the assertion below checks the graph routes the key to the explicit pin.
+  # Actually LINKING this combination would fail (the mid rlib references the
+  # variant leaf's SVH, not the plain one's), which is exactly why replacing a
+  # recorded dep must be an explicit caller choice and never a silent merge.
+  cargoUnitPrebuiltChainOverride = ix.cargoUnit.buildWorkspace (
+    cargoUnitPrebuiltCommon
+    // {
+      pname = "cargo-unit-prebuilt-chain-override";
+      src = cargoUnitPrebuiltFixture;
+      extraUnits = {
+        ${cargoUnitPrebuiltVariantMid.key} = cargoUnitPrebuiltMidUnit;
+        ${cargoUnitPrebuiltVariantLib.key} = cargoUnitPrebuiltLibUnitFromPlain;
+      };
+    }
+  );
+
+  # C4 negative arm: one root recording two different derivations for the same
+  # dep unit key, with no explicit pin to break the tie, must fail at eval.
+  cargoUnitPrebuiltDepConflictEval = builtins.tryEval (
+    builtins.seq (builtins.attrNames
+      (ix.cargoUnit.buildWorkspace (
+        cargoUnitPrebuiltCommon
+        // {
+          pname = "cargo-unit-prebuilt-dep-conflict";
+          src = cargoUnitPrebuiltFixture;
+          extraUnits = {
+            ${cargoUnitPrebuiltVariantMid.key} = ix.cargoUnit.mkPrebuiltLibraryUnit {
+              name = "prebuilt_mid";
+              version = "0.1.0";
+              inherit (cargoUnitPrebuiltVariantMid) hash;
+              rlib = "${cargoUnitPrebuiltVariantMid.unit}/lib/libprebuilt_mid-${cargoUnitPrebuiltVariantMid.hash}.rlib";
+              rmeta = "${cargoUnitPrebuiltVariantMid.unit}/lib/libprebuilt_mid-${cargoUnitPrebuiltVariantMid.hash}.rmeta";
+              toolchainId = ix.cargoUnit.defaultToolchainId;
+              depUnits = [
+                cargoUnitPrebuiltLibUnit
+                cargoUnitPrebuiltLibUnitFromPlain
+              ];
+            };
+          };
+        }
+      )).units
+    ) true
+  );
+
+  # C3 negative arm: injecting a prebuilt under a key that disagrees with its
+  # own recorded unitKey must fail at eval. The mid's generated key exists in
+  # the graph and the toolchain matches, so only the key-mismatch guard fires.
+  cargoUnitPrebuiltKeyMismatchEval = builtins.tryEval (
+    builtins.seq (builtins.attrNames
+      (ix.cargoUnit.buildWorkspace (
+        cargoUnitPrebuiltCommon
+        // {
+          pname = "cargo-unit-prebuilt-key-mismatch";
+          src = cargoUnitPrebuiltFixture;
+          extraUnits = {
+            ${cargoUnitPrebuiltVariantMid.key} = cargoUnitPrebuiltLibUnit;
+          };
+        }
+      )).units
+    ) true
   );
 
   # M1 / C1 negative arm: a mis-keyed injection (a key absent from the generated
@@ -4257,26 +4386,35 @@ let
   # Proves mkPrebuiltLibraryUnit + extraUnits/extraLibraries: a leaf library is
   # built from source, its rlib+rmeta and source-independent hash are captured,
   # and those artifacts are re-injected as a prebuilt unit that a downstream
-  # consumer links with no library source in its own graph.
+  # consumer links with no library source in its own graph. The chain arm
+  # proves the same for a prebuilt WITH a dep: only the mid prebuilt is passed
+  # to extraUnits, and its recorded depUnits are auto-injected (ENG-2166).
   cargoUnitPrebuiltAssertions = [
     {
       # Source-independence: the variant lib (answer = 99) hashes to the SAME
       # unit key as the consumer's own from-source lib (answer = 42). This is the
       # property that lets a metadata-faithful prebuilt stand in for source.
-      assertion = cargoUnitPrebuiltLibKey == cargoUnitPrebuiltPlainLibKey;
+      assertion = cargoUnitPrebuiltVariantLib.key == cargoUnitPrebuiltPlainLib.key;
       message = "a metadata-identical variant should produce the same unit key as the from-source lib";
+    }
+    {
+      # Recursive source-independence: the mid unit's hash folds in the leaf
+      # dep's hash, so it must also key identically across the variant and
+      # from-source graphs. This is what makes auto-injected dep keys resolve.
+      assertion = cargoUnitPrebuiltVariantMid.key == cargoUnitPrebuiltPlainMid.key;
+      message = "a metadata-identical variant should produce the same unit key for a lib with a dep";
     }
     {
       # The injected prebuilt unit is a genuinely different derivation from the
       # variant's from-source compile unit.
-      assertion = cargoUnitPrebuiltLibUnit.drvPath != cargoUnitPrebuiltVariantLibUnit.drvPath;
+      assertion = cargoUnitPrebuiltLibUnit.drvPath != cargoUnitPrebuiltVariantLib.unit.drvPath;
       message = "mkPrebuiltLibraryUnit should produce a distinct prebuilt derivation, not the from-source unit";
     }
     {
       # `extraUnits` merges over the generated `units` set under the unit key, so
       # the downstream consumer's `units.<key>` reference resolves to it.
       assertion =
-        cargoUnitPrebuiltInjected.units.${cargoUnitPrebuiltLibKey}.drvPath
+        cargoUnitPrebuiltInjected.units.${cargoUnitPrebuiltVariantLib.key}.drvPath
         == cargoUnitPrebuiltLibUnit.drvPath;
       message = "extraUnits should override the generated units entry with the injected prebuilt unit";
     }
@@ -4287,8 +4425,29 @@ let
       message = "extraLibraries should override the libraries entry with the injected prebuilt unit";
     }
     {
-      assertion = cargoUnitPrebuiltLibUnit.passthru.unitKey == cargoUnitPrebuiltLibKey;
+      assertion = cargoUnitPrebuiltLibUnit.passthru.unitKey == cargoUnitPrebuiltVariantLib.key;
       message = "mkPrebuiltLibraryUnit should expose the unit key it was injected under";
+    }
+    {
+      assertion =
+        cargoUnitPrebuiltChainInjected.units.${cargoUnitPrebuiltVariantMid.key}.drvPath
+        == cargoUnitPrebuiltMidUnit.drvPath;
+      message = "extraUnits should override the generated mid unit with the injected prebuilt";
+    }
+    {
+      # ENG-2166: the leaf key was never passed to extraUnits; it must arrive
+      # through the mid prebuilt's recorded depUnits.
+      assertion =
+        cargoUnitPrebuiltChainInjected.units.${cargoUnitPrebuiltVariantLib.key}.drvPath
+        == cargoUnitPrebuiltLibUnit.drvPath;
+      message = "buildWorkspace should auto-inject a prebuilt unit's recorded depUnits";
+    }
+    {
+      # An explicit extraUnits entry for a dep key beats the recorded dep.
+      assertion =
+        cargoUnitPrebuiltChainOverride.units.${cargoUnitPrebuiltVariantLib.key}.drvPath
+        == cargoUnitPrebuiltLibUnitFromPlain.drvPath;
+      message = "an explicit extraUnits entry should override an auto-injected dep unit";
     }
     {
       # A toolchain id mismatch must be caught at eval, not at link time.
@@ -4301,15 +4460,32 @@ let
       assertion = !cargoUnitPrebuiltMiskeyEval.success;
       message = "buildWorkspace should reject an extraUnits key absent from the generated graph";
     }
+    {
+      assertion = !cargoUnitPrebuiltBadDepEval.success;
+      message = "mkPrebuiltLibraryUnit should reject depUnits entries without passthru.unitKey";
+    }
+    {
+      # C4: two recorded prebuilts for one dep key with no explicit pin.
+      assertion = !cargoUnitPrebuiltDepConflictEval.success;
+      message = "buildWorkspace should reject conflicting recorded derivations for one dep unit key";
+    }
+    {
+      # C3: the injection key must agree with the unit's own recorded unitKey.
+      assertion = !cargoUnitPrebuiltKeyMismatchEval.success;
+      message = "buildWorkspace should reject an extraUnits key that disagrees with the unit's recorded unitKey";
+    }
   ];
 
   cargoUnitPrebuiltScript = ''
     # The injected unit's $out matches the unit contract: extern-path holds the
     # absolute path to the rlib (render.rs:1386-1398).
-    test -f ${cargoUnitPrebuiltLibUnit}/lib/libprebuilt_lib-${cargoUnitPrebuiltLibHash}.rlib
-    test -f ${cargoUnitPrebuiltLibUnit}/lib/libprebuilt_lib-${cargoUnitPrebuiltLibHash}.rmeta
+    test -f ${cargoUnitPrebuiltLibUnit}/lib/libprebuilt_lib-${cargoUnitPrebuiltVariantLib.hash}.rlib
+    test -f ${cargoUnitPrebuiltLibUnit}/lib/libprebuilt_lib-${cargoUnitPrebuiltVariantLib.hash}.rmeta
     test -f ${cargoUnitPrebuiltLibUnit}/nix-support/extern-path
     grep -q '\.rlib$' ${cargoUnitPrebuiltLibUnit}/nix-support/extern-path
+
+    # Provenance: the mid prebuilt records its leaf dep's store path.
+    grep -qx '${cargoUnitPrebuiltLibUnit}' ${cargoUnitPrebuiltMidUnit}/nix-support/dependency-units
 
     # M1 (definitive source-less proof): the consumer's OWN source returns 42,
     # but it links the injected prebuilt rlib built from the variant (99). The
@@ -4321,6 +4497,19 @@ let
     grep -q 'prebuilt-lib:99 (answer=99)' cargo-unit-prebuilt.out
     if grep -q 'answer=42' cargo-unit-prebuilt.out; then
       echo "error: consumer used its own from-source lib (42), not the injected prebuilt (99)" >&2
+      exit 1
+    fi
+
+    # ENG-2166 chained proof: the chain consumer's own sources answer 43
+    # (42 + 1); the injected variant mid answers 100 (99 + 1) and its rlib
+    # references the variant leaf's SVH, which only the auto-injected leaf
+    # prebuilt satisfies. Linking at all, and printing 100, therefore proves
+    # the recorded depUnits were injected without being passed to extraUnits.
+    ${cargoUnitPrebuiltChainConsumer}/bin/prebuilt-chain-consumer > cargo-unit-prebuilt-chain.out
+    cat cargo-unit-prebuilt-chain.out
+    grep -q 'prebuilt-mid:100 (answer=100)' cargo-unit-prebuilt-chain.out
+    if grep -q 'answer=43' cargo-unit-prebuilt-chain.out; then
+      echo "error: chain consumer used from-source libs (43), not the injected prebuilts (100)" >&2
       exit 1
     fi
   '';

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -911,9 +911,39 @@ let
     toolchainId = ix.cargoUnit.defaultToolchainId;
   };
 
+  # A well-formed prebuilt whose unit key exists in NO graph. Recorded as a
+  # dep of the overridden leaf below: if the closure traversal ever walks the
+  # discarded leaf's subtree, this key gets auto-injected and the C1 guard
+  # fails eval, so the override arm passing proves the prune.
+  cargoUnitPrebuiltPhantomDep = ix.cargoUnit.mkPrebuiltLibraryUnit {
+    name = "phantom_dep";
+    version = "0.0.1";
+    hash = "0000000000000000";
+    # Never built or linked; any .rlib/.rmeta-suffixed store path satisfies the
+    # shape asserts.
+    rlib = "${cargoUnitPrebuiltVariantLib.unit}/lib/libprebuilt_lib-${cargoUnitPrebuiltVariantLib.hash}.rlib";
+    rmeta = "${cargoUnitPrebuiltVariantLib.unit}/lib/libprebuilt_lib-${cargoUnitPrebuiltVariantLib.hash}.rmeta";
+    toolchainId = ix.cargoUnit.defaultToolchainId;
+  };
+
+  # The variant leaf again, but recording the phantom dep. This is the
+  # derivation the override arm DISCARDS; its subtree must be pruned, not
+  # walked.
+  cargoUnitPrebuiltLibUnitWithPhantomDep = ix.cargoUnit.mkPrebuiltLibraryUnit {
+    name = "prebuilt_lib";
+    version = "0.1.0";
+    inherit (cargoUnitPrebuiltVariantLib) hash;
+    rlib = "${cargoUnitPrebuiltVariantLib.unit}/lib/libprebuilt_lib-${cargoUnitPrebuiltVariantLib.hash}.rlib";
+    rmeta = "${cargoUnitPrebuiltVariantLib.unit}/lib/libprebuilt_lib-${cargoUnitPrebuiltVariantLib.hash}.rmeta";
+    toolchainId = ix.cargoUnit.defaultToolchainId;
+    depUnits = [ cargoUnitPrebuiltPhantomDep ];
+  };
+
   # Explicit override of an auto-injected dep: the caller pins the leaf key to
   # a different derivation than the one the mid prebuilt recorded. Eval-only:
-  # the assertion below checks the graph routes the key to the explicit pin.
+  # the assertion below checks the graph routes the key to the explicit pin,
+  # and the recorded (discarded) leaf carries a phantom dep that would fail C1
+  # if the traversal walked the discarded subtree instead of pruning it.
   # Actually LINKING this combination would fail (the mid rlib references the
   # variant leaf's SVH, not the plain one's), which is exactly why replacing a
   # recorded dep must be an explicit caller choice and never a silent merge.
@@ -923,7 +953,15 @@ let
       pname = "cargo-unit-prebuilt-chain-override";
       src = cargoUnitPrebuiltFixture;
       extraUnits = {
-        ${cargoUnitPrebuiltVariantMid.key} = cargoUnitPrebuiltMidUnit;
+        ${cargoUnitPrebuiltVariantMid.key} = ix.cargoUnit.mkPrebuiltLibraryUnit {
+          name = "prebuilt_mid";
+          version = "0.1.0";
+          inherit (cargoUnitPrebuiltVariantMid) hash;
+          rlib = "${cargoUnitPrebuiltVariantMid.unit}/lib/libprebuilt_mid-${cargoUnitPrebuiltVariantMid.hash}.rlib";
+          rmeta = "${cargoUnitPrebuiltVariantMid.unit}/lib/libprebuilt_mid-${cargoUnitPrebuiltVariantMid.hash}.rmeta";
+          toolchainId = ix.cargoUnit.defaultToolchainId;
+          depUnits = [ cargoUnitPrebuiltLibUnitWithPhantomDep ];
+        };
         ${cargoUnitPrebuiltVariantLib.key} = cargoUnitPrebuiltLibUnitFromPlain;
       };
     }
@@ -4443,11 +4481,13 @@ let
       message = "buildWorkspace should auto-inject a prebuilt unit's recorded depUnits";
     }
     {
-      # An explicit extraUnits entry for a dep key beats the recorded dep.
+      # An explicit extraUnits entry for a dep key beats the recorded dep, and
+      # the discarded dep's subtree is pruned: forcing this workspace at all
+      # would fail C1 on the phantom dep's key if the traversal walked it.
       assertion =
         cargoUnitPrebuiltChainOverride.units.${cargoUnitPrebuiltVariantLib.key}.drvPath
         == cargoUnitPrebuiltLibUnitFromPlain.drvPath;
-      message = "an explicit extraUnits entry should override an auto-injected dep unit";
+      message = "an explicit extraUnits entry should override an auto-injected dep unit and prune its subtree";
     }
     {
       # A toolchain id mismatch must be caught at eval, not at link time.

--- a/tests/fixtures/cargo-unit-prebuilt/Cargo.lock
+++ b/tests/fixtures/cargo-unit-prebuilt/Cargo.lock
@@ -3,6 +3,13 @@
 version = 4
 
 [[package]]
+name = "prebuilt-chain-consumer"
+version = "0.1.0"
+dependencies = [
+ "prebuilt-mid",
+]
+
+[[package]]
 name = "prebuilt-consumer"
 version = "0.1.0"
 dependencies = [
@@ -12,3 +19,10 @@ dependencies = [
 [[package]]
 name = "prebuilt-lib"
 version = "0.1.0"
+
+[[package]]
+name = "prebuilt-mid"
+version = "0.1.0"
+dependencies = [
+ "prebuilt-lib",
+]

--- a/tests/fixtures/cargo-unit-prebuilt/Cargo.toml
+++ b/tests/fixtures/cargo-unit-prebuilt/Cargo.toml
@@ -2,5 +2,7 @@
 members = [
   "crates/prebuilt-lib",
   "crates/prebuilt-consumer",
+  "crates/prebuilt-mid",
+  "crates/prebuilt-chain-consumer",
 ]
 resolver = "3"

--- a/tests/fixtures/cargo-unit-prebuilt/crates/prebuilt-chain-consumer/Cargo.toml
+++ b/tests/fixtures/cargo-unit-prebuilt/crates/prebuilt-chain-consumer/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "prebuilt-chain-consumer"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "prebuilt-chain-consumer"
+path = "src/main.rs"
+
+# Depends only on prebuilt-mid: prebuilt-lib enters this binary's link line
+# purely as mid's transitive dep, which is the path depUnits auto-injection
+# exercises.
+[dependencies]
+prebuilt-mid = { path = "../prebuilt-mid" }

--- a/tests/fixtures/cargo-unit-prebuilt/crates/prebuilt-chain-consumer/src/main.rs
+++ b/tests/fixtures/cargo-unit-prebuilt/crates/prebuilt-chain-consumer/src/main.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Links `prebuilt-mid` directly and `prebuilt-lib` only transitively. When
+    // the mid unit is injected as a prebuilt rlib, rustc can resolve the leaf
+    // crate that rlib references only if the leaf prebuilt was auto-injected
+    // from the mid unit's recorded depUnits.
+    println!("{} (answer={})", prebuilt_mid::greeting(), prebuilt_mid::answer());
+}

--- a/tests/fixtures/cargo-unit-prebuilt/crates/prebuilt-mid/Cargo.toml
+++ b/tests/fixtures/cargo-unit-prebuilt/crates/prebuilt-mid/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "prebuilt-mid"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+# A library WITH a dependency, so the self-test can prove a prebuilt unit's
+# recorded `depUnits` are auto-injected into the consuming graph: injecting the
+# prebuilt-mid rlib only links when the prebuilt-lib rlib it was compiled
+# against rides along.
+
+[dependencies]
+prebuilt-lib = { path = "../prebuilt-lib" }

--- a/tests/fixtures/cargo-unit-prebuilt/crates/prebuilt-mid/src/lib.rs
+++ b/tests/fixtures/cargo-unit-prebuilt/crates/prebuilt-mid/src/lib.rs
@@ -1,0 +1,11 @@
+/// Marker the chain consumer prints so the self-test can prove it linked the
+/// prebuilt mid rlib and the leaf rlib that rlib was compiled against.
+pub fn greeting() -> String {
+    format!("prebuilt-mid:{}", answer())
+}
+
+/// One more than the leaf's answer: 43 from source, 100 when the variant mid
+/// rlib (leaf answer = 99) and its recorded leaf dep are both injected.
+pub fn answer() -> u32 {
+    prebuilt_lib::answer() + 1
+}


### PR DESCRIPTION
## What

`mkPrebuiltLibraryUnit` took a `depUnits` arg but only recorded it to `$out/nix-support/dependency-units`; a prebuilt library WITH transitive deps required the caller to hand-inject every dep unit via `extraUnits`, and nothing documented that. This implements option (a) from ENG-2166: `buildWorkspace` now walks `passthru.depUnits` transitively (`builtins.genericClosure` keyed by drvPath) and auto-injects every recorded prebuilt under its own `passthru.unitKey`, so the caller injects one root unit.

Semantics, all failing at eval with the existing gathered-problems assert:

- An explicit `extraUnits` entry wins over a recorded dep for the same key (the named-reason override for pinning one dep to a different artifact).
- C3 (new): an explicit key that disagrees with the unit's own `passthru.unitKey` is rejected; the artifact names inside the unit embed that key's hash, and auto-injection keys deps by it.
- C4 (new): two recorded prebuilts claiming one unpinned dep key with different derivations is rejected instead of silently picking one.
- C1/C2 run unchanged over the expanded set, so an auto-injected dep key absent from the consumer graph (manifest divergence) or a toolchain mismatch fails with the existing loud errors.
- `depUnits` entries must carry `passthru.unitKey` (asserted at construction; the arg had zero callers, so nothing breaks).

Why this is sound: the renderer routes both direct `--extern` and transitive `-L dependency=` flags through the merged `units.<key>` binding (`render.rs:1015-1047`), so a key-level override reroutes every consumer; and the unit hash folds dep hashes recursively (`render.rs:684-693`), so a root key match implies every dep key matches.

## Proof

The fixture gains a chain: `prebuilt-mid` depends on `prebuilt-lib`, and `prebuilt-chain-consumer` depends only on mid. Only the variant mid prebuilt is passed to `extraUnits` (recording the variant leaf in `depUnits`). The mid rlib references the variant leaf's SVH (`-Cmetadata`/source both differ from the stub), so the consumer can only link when the leaf prebuilt is auto-injected, and printing 100 (variant 99 + 1) proves both prebuilt rlibs were live. From the passing check's rustc invocation:

```
-L dependency=/nix/store/...-cargo-unit-prebuilt-prebuilt_lib-0.1.0-6d725f3f450b2862/lib   <- auto-injected, never passed to extraUnits
--extern prebuilt_mid=/nix/store/...-cargo-unit-prebuilt-prebuilt_mid-...rlib
```

Eval arms added: recursive key equality for the mid unit across variant/plain graphs, auto-injection drvPath identity, explicit-override drvPath identity, plus negative arms for depUnits-without-unitKey, C4 conflicts, and C3 key mismatch.

The public SDK path is untouched by construction: `passthru` does not enter the drv hash and a leaf unit's closure collapses to its explicit entry, so `prebuiltWireUnit` and the proof derivation are byte-identical.

## Verification

- `nix run .#lint`: clean
- `nix build .#checks.x86_64-linux.cargo-unit-prebuilt-library`: passes; runtime output `prebuilt-lib:99 (answer=99)` and `prebuilt-mid:100 (answer=100)`

Fixes ENG-2166. Refs #724 (the injection seam this extends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-inject transitive `depUnits` for prebuilt Cargo units in `buildWorkspace`
> - `mkPrebuiltLibraryUnit` now accepts a `depUnits` parameter and exposes it via `passthru.depUnits`; fails at construction time if any entry lacks `passthru.unitKey`.
> - `buildWorkspace` traverses `passthru.depUnits` transitively from explicitly injected units and auto-injects them under their recorded `unitKey`, so callers only need to pass the top-level prebuilt in `extraUnits`.
> - Explicit `extraUnits` entries override auto-injected deps for the same key, and subtrees rooted at explicitly pinned keys are pruned during traversal.
> - Two new evaluation guards are added: one rejects an `extraUnits` entry whose attribute key disagrees with the unit's own `passthru.unitKey`, and one rejects ambiguous recorded dep derivations claiming the same key without an explicit pin.
> - Tests in [tests/default.nix](https://github.com/indexable-inc/index/pull/769/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) are extended with a two-crate chain fixture (`prebuilt-mid` → `prebuilt-lib`) and negative eval tests for bad `depUnits`, key mismatches, and dep conflicts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c5ec33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->