### PR TITLE
mcp: surface DASHBOARD_URL + flip dashboard order

### DIFF
--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -184,6 +184,9 @@ def _serve(args: argparse.Namespace) -> int:
     # writes there) and the private IPYTHONDIR (so the runtime startup runs)
     # before the kernel starts.
     os.environ["IX_MCP_STORE"] = str(store_path)
+    # Surface the dashboard URL to the kernel so `DASHBOARD_URL` is one lookup
+    # away (the agent should not have to spelunk the runtime dir to find it).
+    os.environ["IX_MCP_DASHBOARD_URL"] = cfg.dashboard_url()
     os.environ["IPYTHONDIR"] = str(_prepare_ipython_startup(dashboard_port))
 
     asyncio.run(_run(cfg))

--- a/packages/mcp/ix_notebook_mcp/dashboard.py
+++ b/packages/mcp/ix_notebook_mcp/dashboard.py
@@ -37,6 +37,8 @@ async function tick(){
   const r=await fetch('api/jobs');const js=await r.json();
   const el=document.getElementById('jobs');
   if(!js.length){el.innerHTML='<div class="empty">no executions yet</div>';return;}
+  js.sort((a,b)=>a.started_at-b.started_at);          // oldest at top, newest at bottom
+  const nearBottom=(window.innerHeight+window.scrollY)>=(document.body.scrollHeight-120);
   el.innerHTML=js.map(j=>{
    const dur=((j.ended_at||Date.now()/1000)-j.started_at).toFixed(1);
    const esc=s=>(s||'').replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
@@ -50,6 +52,7 @@ async function tick(){
      ${j.error&&!j.output.includes(j.error)?`<pre class="error">${esc(j.error)}</pre>`:''}
    </div>`;
   }).join('');
+  if(nearBottom) window.scrollTo(0, document.body.scrollHeight);
  }catch(e){}
 }
 tick();setInterval(tick,1000);

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -300,6 +300,7 @@ def install(user_ns: dict | None = None) -> None:
     target["Job"] = Job
     target["__ix_run"] = __ix_run
     target["__ix_exec"] = __ix_exec
+    target["DASHBOARD_URL"] = os.environ.get("IX_MCP_DASHBOARD_URL", "")
 
     try:
         asyncio.get_event_loop().create_task(_flusher())

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -37,7 +37,7 @@ mcp = FastMCP(
         "off the event loop. Bundled modules import with no install step: `fff` "
         "(async file search/grep), `tui`, `search`, `exa_py`, `google_auth`, "
         "numpy, polars, duckdb, httpx, matplotlib, playwright. A dashboard shows "
-        "every running job and its live output; its URL is printed at startup."
+        "every running job and its live output; its URL is the `DASHBOARD_URL` variable in the namespace (share it with the human)."
     ),
 )
 


### PR DESCRIPTION
## What

Two small fixes to the new `python_exec` MCP, from watching a fresh agent struggle:

1. **Agent couldn't find the dashboard URL** (it took ~11 ops to dig it out of the runtime dir). Now the URL is exported to the kernel (`IX_MCP_DASHBOARD_URL`), exposed as the **`DASHBOARD_URL`** variable in the namespace, and named in the tool instructions, so the agent gets it in one lookup.
2. **Dashboard order flipped** to oldest-at-top / newest-at-bottom (chronological), with log-tail autoscroll that only sticks to the bottom when the viewer is already there.

## Validation

`nix build .#mcp` + engine/runtime/server tests green. DASHBOARD_URL exposure verified in-process.

AI-assisted (Claude, Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface `DASHBOARD_URL` in kernel namespace and reorder dashboard jobs oldest-first
> - Passes `IX_MCP_DASHBOARD_URL` (from `cfg.dashboard_url()`) to the spawned kernel process environment in [cli.py](https://github.com/indexable-inc/index/pull/770/files#diff-7ce741e8223d63fdea11625cb78abad266299445db0213d2355bc93306df9ac5), and exposes it as `DASHBOARD_URL` in the kernel namespace via [runtime.py](https://github.com/indexable-inc/index/pull/770/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95).
> - Updates MCP tool instructions in [tools.py](https://github.com/indexable-inc/index/pull/770/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) to direct users to read `DASHBOARD_URL` from the kernel namespace rather than relying on startup output.
> - Dashboard in [dashboard.py](https://github.com/indexable-inc/index/pull/770/files#diff-42d31638eb95030752ef7a84f47bf14ecd13cbfe141948c40115b8cae061ce5e) now sorts jobs oldest-first and auto-scrolls to the bottom when the viewer is already near the bottom of the page.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fdd14e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->