### PR TITLE
mcp: render rich outputs on the dashboard + trailing-expression prompts

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -688,6 +688,91 @@ let
         mkdir -p "$out"
       '';
 
+  # Exercises the rich-output capture path: a DataFrame result is persisted to the
+  # store with its text/html bundle (so the dashboard renders a table, not a repr),
+  # a display() call made while a job runs is captured the same way, and a bytes
+  # image payload normalizes to a base64 string. Stands up an InteractiveShell
+  # in-process so the formatter runs without booting a kernel; sandbox-safe.
+  richTestPy = pkgs.writeText "ix-mcp-rich-test.py" ''
+    import asyncio
+    import json
+    import os
+    import sqlite3
+    import tempfile
+
+    from IPython.core.interactiveshell import InteractiveShell
+
+    # A kernel always has a shell; this in-process test stands one up so the rich
+    # formatter path runs without booting a kernel.
+    InteractiveShell.instance()
+
+    store_path = tempfile.mktemp(suffix=".db")
+    os.environ["IX_MCP_STORE"] = store_path
+
+    import polars as pl
+
+    from ix_notebook_mcp import runtime
+
+    # A bytes image payload must normalize to a base64 string: raw bytes would not
+    # survive JSON storage or an <img> data URI.
+    bundle = runtime._normalize_bundle({"image/png": b"\x89PNG\r\n", "text/plain": "x"})
+    assert isinstance(bundle["data"]["image/png"], str), bundle
+
+    ns = {"pl": pl}
+    runtime.install(ns)
+    run = ns["__ix_run"]
+
+
+    async def main():
+        # A DataFrame result is stored with its text/html bundle.
+        df_job = await run("pl.DataFrame({'a': [1, 2], 'b': ['x', 'y']})", budget=3.0, name="df")
+        await df_job.task
+        conn = sqlite3.connect(store_path)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT status, outputs FROM executions WHERE id = ?", (df_job.id,)).fetchone()
+        assert row["status"] == "done", row["status"]
+        result_mimes = {mime for out in json.loads(row["outputs"]) for mime in out["data"]}
+        assert "text/html" in result_mimes, ("result mimes", result_mimes)
+
+        # A display() call made while a job runs is captured too.
+        disp_job = await run(
+            "from IPython.display import display\ndisplay(pl.DataFrame({'z': [9]}))",
+            budget=3.0,
+            name="disp",
+        )
+        await disp_job.task
+        disp_outputs = conn.execute(
+            "SELECT outputs FROM executions WHERE id = ?", (disp_job.id,)
+        ).fetchone()[0]
+        disp_mimes = {mime for out in json.loads(disp_outputs) for mime in out["data"]}
+        assert "text/html" in disp_mimes, ("display mimes", disp_mimes)
+
+
+    asyncio.run(main())
+    print("rich-ok")
+  '';
+  richSmoke =
+    pkgs.runCommand "ix-mcp-rich-smoke"
+      {
+        nativeBuildInputs = [ mcpPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        ${lib.getExe mcpPython} ${richTestPy} >stdout 2>stderr || {
+          echo "ix-mcp rich smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -qx 'rich-ok' stdout || {
+          echo "ix-mcp rich smoke did not confirm rich-output capture:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
+
   # macOS-only modules (`screen`, `vmkit`) are only bundled on Darwin; their
   # import tests only exist there.
   screenBundled = importTest "screen" "import screen; print('screen-ok', callable(screen.capture), callable(screen.click), callable(screen.accessibility_trusted))";
@@ -709,6 +794,7 @@ package.overrideAttrs (old: {
         serverTools
         evalSmoke
         runtimeSmoke
+        richSmoke
         bindDefaultSmoke
         ;
     }

--- a/packages/mcp/ix_notebook_mcp/dashboard.py
+++ b/packages/mcp/ix_notebook_mcp/dashboard.py
@@ -3,8 +3,9 @@
 Auto-started by the CLI. It renders every execution (running first) with its live
 output, polling the SQLite store the kernel writes to, so a human can watch all
 the running "things" and their output like a notebook view. Deliberately simple:
-one HTML page that fetches ``/api/jobs`` once a second. Rich output (images,
-HTML tables) is a follow-up; v1 shows code, status, duration, output, and result.
+one HTML page that fetches ``/api/jobs`` once a second. Each execution renders
+its rich outputs like a notebook: a polars DataFrame as its HTML table, a
+matplotlib figure as an image, falling back to text for everything else.
 """
 
 from __future__ import annotations
@@ -29,6 +30,11 @@ _PAGE = """<!doctype html>
  pre{white-space:pre-wrap;word-break:break-word;margin:6px 0 0;color:#a9b1d6;max-height:320px;overflow:auto}
  .code{color:#565f89;max-height:80px}.res{color:#9ece6a}
  .empty{color:#565f89}
+ .rich{background:#fff;color:#111;padding:8px;border-radius:4px;margin:6px 0 0;overflow:auto;max-height:460px}
+ .rich table{border-collapse:collapse;font:12px/1.4 ui-monospace,Menlo,monospace}
+ .rich th,.rich td{border:1px solid #d0d7de;padding:2px 7px;text-align:right}
+ .rich th{background:#f6f8fa}
+ .img{display:block;max-width:100%;margin:6px 0 0;border-radius:4px;background:#fff}
 </style></head><body>
 <h1>ix-mcp executions</h1><div id="jobs"></div>
 <script>
@@ -42,13 +48,27 @@ async function tick(){
   el.innerHTML=js.map(j=>{
    const dur=((j.ended_at||Date.now()/1000)-j.started_at).toFixed(1);
    const esc=s=>(s||'').replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
+   // Rich outputs render like a notebook cell. The dashboard is read-only over the
+   // tailnet (the trust boundary); the HTML is the agent's own code output, so it
+   // is injected as-is rather than re-sanitized.
+   const rich=o=>{const d=(o&&o.data)||{};
+     if(d['image/png'])return `<img class="img" src="data:image/png;base64,${d['image/png']}">`;
+     if(d['image/jpeg'])return `<img class="img" src="data:image/jpeg;base64,${d['image/jpeg']}">`;
+     if(d['image/svg+xml'])return `<div class="rich">${d['image/svg+xml']}</div>`;
+     if(d['text/html'])return `<div class="rich">${d['text/html']}</div>`;
+     if(d['text/markdown'])return `<pre>${esc(d['text/markdown'])}</pre>`;
+     if(d['text/plain'])return `<pre class="res">${esc(d['text/plain'])}</pre>`;
+     return '';};
+   const richOut=(j.outputs&&j.outputs.length)
+     ? j.outputs.map(rich).join('')
+     : (j.result?`<pre class="res">${esc(j.result)}</pre>`:'');
    return `<div class="job ${j.status}">
      <div class="hdr"><span class="st">${j.status}</span>
      <span class="id">${j.id}</span><span class="name">${esc(j.name)}</span>
      <span class="dur">${dur}s</span></div>
      <pre class="code">${esc(j.code)}</pre>
      ${j.output?`<pre>${esc(j.output)}</pre>`:''}
-     ${j.result?`<pre class="res">${esc(j.result)}</pre>`:''}
+     ${richOut}
      ${j.error&&!j.output.includes(j.error)?`<pre class="error">${esc(j.error)}</pre>`:''}
    </div>`;
   }).join('');

--- a/packages/mcp/ix_notebook_mcp/ipython/01-ix-polars.py
+++ b/packages/mcp/ix_notebook_mcp/ipython/01-ix-polars.py
@@ -1,12 +1,11 @@
 """Widen polars' text repr for the MCP agent's view of DataFrames.
 
-itables (00-ix-itables.py) drives the human's interactive table straight from the
-data, so this only changes the ``text/plain`` repr: what the agent (which reads
-text, not HTML) and any non-JS viewer get. Polars defaults truncate to ~8 rows,
-~8 columns, and 30-char strings, which hides most of a frame from the agent;
-widen to a fuller but still bounded view. The MCP layer caps a single text output
-at 50k chars (outputs._MAX_TEXT_CHARS), so a wide repr cannot flood the agent's
-context.
+The dashboard renders a DataFrame result from its ``text/html`` repr, so this
+only changes the ``text/plain`` repr: what the agent (which reads text, not HTML)
+and any non-JS viewer get. Polars defaults truncate to ~8 rows, ~8 columns, and
+30-char strings, which hides most of a frame from the agent; widen to a fuller
+but still bounded view. The MCP layer caps a single text output at 50k chars
+(outputs._MAX_TEXT_CHARS), so a wide repr cannot flood the agent's context.
 """
 
 import polars as pl

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -19,15 +19,20 @@ numpy, a subprocess) stays non-blocking by going through ``asyncio.to_thread``
 
 Every job also writes itself to the SQLite store at ``IX_MCP_STORE`` (start, a
 throttled output tail while running, final status) so the dashboard can show all
-running things and their live output without ever touching the kernel.
+running things and their live output without ever touching the kernel. The
+result's rich display (HTML tables, images) and any ``display()`` calls made
+while a job runs are captured into the store too, so the dashboard renders them
+like a notebook instead of plain text.
 """
 
 from __future__ import annotations
 
 import ast
 import asyncio
+import base64
 import contextvars
 import inspect
+import json
 import os
 import sys
 import time
@@ -41,10 +46,31 @@ _ix_current: contextvars.ContextVar = contextvars.ContextVar("ix_current_job", d
 # memory, store writes, and poll payloads all stay bounded.
 _MAX_OUTPUT_CHARS = 256_000
 
+# The custom mime the kernel hands the server to carry a job summary (mirrors
+# outputs.JOB_MIME; duplicated so the kernel-side runtime stays import-light).
+JOB_MIME = "application/x-ix-job+json"
+
+# Rich display capture: which mimes we keep for the dashboard, and per-mime size
+# caps. Truncating a base64 image yields a corrupt data URI, so an oversize image
+# is dropped whole rather than clipped; text mimes clip with a marker.
+_RICH_MIMES = (
+    "text/html",
+    "image/png",
+    "image/jpeg",
+    "image/svg+xml",
+    "text/markdown",
+    "application/json",
+    "text/plain",
+)
+_IMAGE_MIMES = frozenset({"image/png", "image/jpeg"})
+_MAX_TEXT_BUNDLE = 400_000
+_MAX_IMAGE_BUNDLE = 4_000_000
+
 # Opened lazily in install(); None when no store path is configured (the
 # one-shot eval/exec paths, or a bare kernel started outside the server).
 _store_conn = None
 _store = None
+_shell = None  # the InteractiveShell, set in install(); used to format rich results
 
 
 class _Tee:
@@ -90,6 +116,8 @@ class Job:
         self.error: str | None = None
         self._buf: list[str] = []
         self._buflen = 0
+        # Rich outputs (mime bundles) display()-ed while this job runs.
+        self._displays: list[dict] = []
         self.task: asyncio.Task | None = None
 
     def _append(self, s: str) -> None:
@@ -200,6 +228,7 @@ def _persist_final(job: Job) -> None:
             output=job.output,
             result=result_repr,
             error=job.error,
+            outputs=_job_outputs(job),
         )
     except Exception:
         # Best-effort logging: persisting the final status must not raise during cleanup.
@@ -213,6 +242,54 @@ def _safe_repr(value) -> str:
         return f"<unreprable {type(value).__name__}>"
 
 
+def _normalize_bundle(data: dict, metadata: dict | None = None) -> dict:
+    """Coerce a display formatter mime bundle to JSON-safe values (bytes -> base64),
+    keeping only whitelisted mimes within size caps, for the store and dashboard."""
+    out: dict[str, str] = {}
+    for mime in _RICH_MIMES:
+        if mime not in data:
+            continue
+        value = data[mime]
+        if isinstance(value, (bytes, bytearray)):
+            value = base64.b64encode(bytes(value)).decode("ascii")
+        elif not isinstance(value, str):
+            try:
+                value = json.dumps(value)
+            except Exception:
+                value = str(value)
+        if mime in _IMAGE_MIMES:
+            if len(value) > _MAX_IMAGE_BUNDLE:
+                continue  # clipping a base64 image corrupts the data URI; drop it
+        elif len(value) > _MAX_TEXT_BUNDLE:
+            value = value[:_MAX_TEXT_BUNDLE] + "\n... [truncated]"
+        out[mime] = value
+    return {"data": out, "metadata": metadata or {}}
+
+
+def _result_bundle(value) -> dict | None:
+    """Render a job's result through IPython's display machinery (a polars
+    DataFrame yields text/html, a matplotlib Figure image/png) for the dashboard."""
+    if _shell is None:
+        return None
+    try:
+        data, metadata = _shell.display_formatter.format(value)
+    except Exception:
+        return None
+    bundle = _normalize_bundle(data, metadata)
+    return bundle if bundle["data"] else None
+
+
+def _job_outputs(job: "Job") -> list[dict]:
+    """A job's rich outputs for the store: every display() bundle captured while it
+    ran, plus the trailing-expression result rendered the same way."""
+    outs = list(job._displays)
+    if job.result is not None and not job.running():
+        bundle = _result_bundle(job.result)
+        if bundle is not None:
+            outs.append(bundle)
+    return outs
+
+
 async def _flusher() -> None:
     """Throttled background loop: persist every running job's output tail to the
     store so the dashboard shows live output. One loop for all jobs (cheap)."""
@@ -223,7 +300,7 @@ async def _flusher() -> None:
         for job in list(jobs.values()):
             if job.running():
                 try:
-                    _store.update_output(_store_conn, job.id, job.output)
+                    _store.update_output(_store_conn, job.id, job.output, job._displays or None)
                 except Exception:
                     # Best-effort live output: a store write must not kill the loop.
                     pass
@@ -254,7 +331,7 @@ def _emit(job: Job) -> None:
         "result": None if job.result is None else _safe_repr(job.result),
         "error": job.error,
     }
-    publish_display_data({"application/x-ix-job+json": summary, "text/plain": f"[{job.id}] {job.status}"})
+    publish_display_data({JOB_MIME: summary, "text/plain": f"[{job.id}] {job.status}"})
     if job.result is not None and not job.running():
         try:
             display(job.result)
@@ -269,19 +346,69 @@ async def __ix_exec(code: str, budget: float = 15.0, name: str | None = None) ->
     _emit(job)
 
 
+def _install_display_capture(shell) -> None:
+    """Route display() / rich auto-display made *inside a job* to that job's output
+    list (still forwarding to IOPub for the agent's reply), so the dashboard can
+    show images and HTML tables, not just text."""
+    pub = shell.display_pub
+    if getattr(pub, "_ix_wrapped", False):
+        return
+    original = pub.publish
+
+    def publish(data, metadata=None, **kwargs):
+        job = _ix_current.get()
+        if job is not None and isinstance(data, dict) and JOB_MIME not in data:
+            bundle = _normalize_bundle(data, metadata)
+            if bundle["data"]:
+                job._displays.append(bundle)
+        return original(data, metadata, **kwargs)
+
+    pub.publish = publish
+    pub._ix_wrapped = True
+
+
+def _figure_png(fig) -> bytes:
+    import io
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", bbox_inches="tight")
+    return buf.getvalue()
+
+
+def _register_rich_formatters(shell) -> None:
+    """Make matplotlib figures render as image/png. A bare ipykernel only wires the
+    inline png formatter after %matplotlib inline; register it lazily by type name
+    so importing matplotlib stays the user's choice."""
+    try:
+        png = shell.display_formatter.formatters["image/png"]
+        png.for_type_by_name("matplotlib.figure", "Figure", _figure_png)
+    except Exception:
+        # No display formatter (non-IPython host) or a matplotlib too old to wire.
+        pass
+
+
 _user_ns: dict | None = None
 
 
 def install(user_ns: dict | None = None) -> None:
     """Wire the runtime into the kernel: tee stdout/err, open the store, start the
     flusher, and expose the registry + entrypoints in the user namespace."""
-    global _store, _store_conn, _user_ns
+    global _store, _store_conn, _user_ns, _shell
     _user_ns = user_ns
 
     if not isinstance(sys.stdout, _Tee):
         sys.stdout = _Tee(sys.stdout)
     if not isinstance(sys.stderr, _Tee):
         sys.stderr = _Tee(sys.stderr)
+
+    import IPython
+
+    _shell = IPython.get_ipython()
+    if _shell is not None:
+        # Capture rich display output and teach the kernel to render figures, so
+        # the dashboard shows tables/images like a notebook (not just text).
+        _install_display_capture(_shell)
+        _register_rich_formatters(_shell)
 
     store_path = os.environ.get("IX_MCP_STORE")
     if store_path:

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -52,8 +52,17 @@ def start(conn: sqlite3.Connection, *, id: str, name: str, code: str, started_at
     )
 
 
-def update_output(conn: sqlite3.Connection, id: str, output: str) -> None:
-    conn.execute("UPDATE executions SET output = ? WHERE id = ?", (output, id))
+def update_output(conn: sqlite3.Connection, id: str, output: str, outputs: list | None = None) -> None:
+    """Persist a running job's live output. When ``outputs`` is given (rich display
+    bundles captured so far), update that column too so the dashboard can show a
+    long job's in-progress tables/images, not only its text."""
+    if outputs is None:
+        conn.execute("UPDATE executions SET output = ? WHERE id = ?", (output, id))
+    else:
+        conn.execute(
+            "UPDATE executions SET output = ?, outputs = ? WHERE id = ?",
+            (output, json.dumps(outputs), id),
+        )
 
 
 def finish(

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -36,8 +36,14 @@ mcp = FastMCP(
         "op, a subprocess) wrap it in `await asyncio.to_thread(...)` so it stays "
         "off the event loop. Bundled modules import with no install step: `fff` "
         "(async file search/grep), `tui`, `search`, `exa_py`, `google_auth`, "
-        "numpy, polars, duckdb, httpx, matplotlib, playwright. A dashboard shows "
-        "every running job and its live output; its URL is the `DASHBOARD_URL` variable in the namespace (share it with the human)."
+        "numpy, polars, duckdb, httpx, matplotlib, playwright. Use polars (`pl`) "
+        "for dataframes; pandas is not bundled. End a cell with a bare expression "
+        "to display its result richly: a polars DataFrame renders as an HTML table "
+        "and a matplotlib figure as an image, both in this reply and on the "
+        "dashboard. Reach for that instead of print() for data and plots (keep "
+        "print() for plain log lines). A dashboard shows every running job and its "
+        "live output; its URL is the `DASHBOARD_URL` variable in the namespace "
+        "(share it with the human)."
     ),
 )
 
@@ -49,7 +55,9 @@ Content = list[outputs.Content]
         "Run Python on the shared persistent kernel. Waits up to `budget` seconds; "
         "if the code is still running it keeps going in the background as jobs['<id>'] "
         "and this returns a job handle. Inspect/await/cancel background jobs with more "
-        "python_exec against the `jobs` dict. The namespace persists across calls."
+        "python_exec against the `jobs` dict. The namespace persists across calls. End "
+        "with a bare expression to display the result richly (DataFrame as a table, "
+        "figure as an image) instead of print()."
     )
 )
 async def python_exec(


### PR DESCRIPTION
## What

The dashboard could only show **text**. A job's result and any `display()` call were published to IOPub (the agent's tool reply) but never written to the SQLite store the dashboard reads, so a polars DataFrame showed up as a repr string and there was no special HTML/image rendering.

This captures rich output into the store and renders it on the dashboard like a notebook:

- **runtime.py** — capture every `display()` mime bundle made while a job runs (by wrapping `display_pub.publish`, routed to the current job via the existing `ContextVar`) plus the trailing-expression result (through IPython's display formatter). Bytes (image payloads) are normalized to base64; per-mime size caps keep store rows bounded. Persisted to the store's `outputs` column (final, and progressively via the flusher). matplotlib `Figure`s render as `image/png` via a lazily-registered formatter (no eager matplotlib import).
- **store.py** — `update_output` can now also write the `outputs` JSON (the column already existed).
- **dashboard.py** — render `outputs` Jupyter-style: HTML tables, `<img>` for png/jpeg, inline svg, on a white output area; fall back to text.

## Prompt fixes

The agent was `print()`-ing DataFrames and reaching for `pandas` (not bundled). The instructions now tell it to **end a cell with a bare expression** for rich display (DataFrame → table, figure → image, in both the reply and the dashboard) instead of `print()`, and to use **polars**.

## Validation

Native build (darwin) of `mcp.passthru.tests.{richSmoke,runtimeSmoke,serverTools,engineBundled}` ✅ and `nix run .#lint` ✅. New `richSmoke` test proves a DataFrame result and a `display()` call both land in the store's `outputs` with a `text/html` bundle, and that a bytes image payload normalizes to base64.

🤖 Generated with Claude Code (Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render rich outputs (HTML tables, images, markdown) on the MCP notebook dashboard
> - Captures `display()` calls and trailing-expression results during IPython job execution in [runtime.py](https://github.com/indexable-inc/index/pull/771/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95), normalizing bundles (base64 images, size caps) for JSON persistence.
> - Persists rich outputs to the store via updated `store.update_output` and `_persist_final`, including live incremental updates from the flusher loop.
> - Registers a matplotlib PNG formatter so figures render as images in the display pipeline.
> - Updates the dashboard HTML template in [dashboard.py](https://github.com/indexable-inc/index/pull/771/files#diff-42d31638eb95030752ef7a84f47bf14ecd13cbfe141948c40115b8cae061ce5e) to render persisted outputs per job: `<img>` data URIs for images, divs for HTML/SVG, and `<pre>` blocks for markdown/plain text.
> - Adds a smoke test in [default.nix](https://github.com/indexable-inc/index/pull/771/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) that validates rich output capture (DataFrame HTML, `display()`, image base64) at build time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f81d56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->