### PR TITLE
mcp: add Result(user_html, llm_result) to split human and model views

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -37,10 +37,30 @@ jobs['ab12'].cancel()                       # stop it
 [j for j in jobs.values() if j.running()]   # list running jobs
 ```
 
+Anything you define on the kernel persists, so define a function or class once
+and call it again on a later turn; you are building up a session, not running
+one-shot snippets.
+
 Many jobs run at once and none blocks the others. The concurrency is cooperative:
 a job yields the loop at each `await`. For a blocking call (a heavy numpy/polars
 op, `fff`, a subprocess) wrap it in `await asyncio.to_thread(...)` so its
 GIL-releasing work runs off the loop and stays non-blocking.
+
+## Two audiences: `Result(user_html, llm_result)`
+
+When a cell's final value should read differently for the human watching and for
+you, return a `Result`:
+
+```python
+Result(user_html="<table>…</table>", llm_result="42 rows, mean 3.1")
+```
+
+The dashboard renders `user_html` (a rich HTML view for the human) while your
+`python_exec` tool result receives only `llm_result` (concise text). It is a mime
+bundle under the hood (`text/html` for the dashboard, `text/plain` for you), so a
+large rendered view never costs you tokens. For an ordinary value the two
+audiences share one rendering: a bare trailing expression still shows its rich
+repr on the dashboard and its text to you.
 
 ## How it works
 
@@ -91,6 +111,6 @@ The default Tailscale-IP bind keeps the trust boundary at the tailnet.
 - You need crash isolation between executions: they share one kernel, so a hard
   crash (a segfaulting C extension) takes the kernel down. State is recoverable
   by re-running; the durable log survives.
-- You want rich (image/HTML) output in the dashboard: v1 renders code, status,
-  output, and result text. Images/HTML still come back to the agent through
-  `python_exec`; the dashboard rendering them is a follow-up.
+- You want a human and the model to read the *same* large output cheaply: the
+  model reads everything it is sent, so a giant HTML blob meant for the dashboard
+  costs tokens unless you split it behind a `Result(user_html=…, llm_result=…)`.

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -747,6 +747,19 @@ let
         disp_mimes = {mime for out in json.loads(disp_outputs) for mime in out["data"]}
         assert "text/html" in disp_mimes, ("display mimes", disp_mimes)
 
+        # A Result splits the human view (HTML on the dashboard) from the model
+        # view (text in the tool result): the stored bundle carries user_html as
+        # text/html, and to_mcp hands the model only the text/plain llm_result.
+        from ix_notebook_mcp import outputs
+        res_job = await run("Result(user_html='<b>hi</b>', llm_result='just-text')", budget=3.0, name="res")
+        await res_job.task
+        res_outputs = conn.execute("SELECT outputs FROM executions WHERE id = ?", (res_job.id,)).fetchone()[0]
+        res_bundle = [out["data"] for out in json.loads(res_outputs)][-1]
+        assert res_bundle.get("text/html") == "<b>hi</b>", res_bundle
+        mcp = outputs.to_mcp([{"output_type": "execute_result", "data": res_bundle, "metadata": {}}])
+        texts = [c.text for c in mcp if getattr(c, "text", None) is not None]
+        assert texts == ["just-text"], texts
+
 
     asyncio.run(main())
     print("rich-ok")

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -31,6 +31,7 @@ import ast
 import asyncio
 import base64
 import contextvars
+import dataclasses
 import inspect
 import json
 import os
@@ -160,6 +161,35 @@ class Job:
         head = f"<Job {self.id} ({self.name}) [{self.status}] {dur:.2f}s>"
         out = self.tail(800)
         return head + ("\n" + out if out else "")
+
+
+@dataclasses.dataclass
+class Result:
+    """Split a cell's final value into a human view and a model view.
+
+    Return ``Result(user_html=..., llm_result=...)`` as a cell's trailing
+    expression. The dashboard renders ``user_html`` (a rich HTML view for the
+    human watching) while the model's ``python_exec`` tool result receives only
+    ``llm_result`` (concise text). The two never cross: the human is not shown
+    the model's text, and the model does not pay tokens for the HTML render.
+
+    It is a mime bundle under the hood: ``text/html`` carries ``user_html`` (the
+    dashboard prefers HTML) and ``text/plain`` carries ``llm_result`` (what the
+    tool result renders, since to_mcp prefers text/plain). Nothing else in the
+    pipeline changes.
+    """
+
+    user_html: str
+    llm_result: str
+
+    def _repr_mimebundle_(self, **_kwargs) -> dict[str, str]:
+        # IPython's display protocol: html for the dashboard, plain for the model.
+        return {"text/html": self.user_html, "text/plain": self.llm_result}
+
+    def __repr__(self) -> str:
+        # Plain-text fallback (the stored result repr, non-rich hosts): the model
+        # view, never the HTML.
+        return self.llm_result
 
 
 jobs: dict[str, Job] = {}
@@ -425,6 +455,7 @@ def install(user_ns: dict | None = None) -> None:
     target = user_ns if user_ns is not None else globals()
     target["jobs"] = jobs
     target["Job"] = Job
+    target["Result"] = Result
     target["__ix_run"] = __ix_run
     target["__ix_exec"] = __ix_exec
     target["DASHBOARD_URL"] = os.environ.get("IX_MCP_DASHBOARD_URL", "")

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -25,7 +25,9 @@ mcp = FastMCP(
     "ix-mcp",
     instructions=(
         "Run Python on one shared, persistent kernel with `python_exec`. The "
-        "namespace persists across calls, so variables you define stay defined. "
+        "namespace persists across calls, so variables, functions, classes, and "
+        "imports you define stay defined and are reusable by every later call \u2014 "
+        "define a helper once and call it again next turn. "
         "Each call runs as an async task and waits up to `budget` seconds; if the "
         "work is still going it keeps running in the background and the call "
         "returns a job handle. Background jobs live in the `jobs` dict, so manage "
@@ -41,7 +43,11 @@ mcp = FastMCP(
         "to display its result richly: a polars DataFrame renders as an HTML table "
         "and a matplotlib figure as an image, both in this reply and on the "
         "dashboard. Reach for that instead of print() for data and plots (keep "
-        "print() for plain log lines). A dashboard shows every running job and its "
+        "print() for plain log lines). To split what the human sees from what you "
+        "get back, end a cell with `Result(user_html=..., llm_result=...)`: the "
+        "dashboard renders `user_html` for the human while your tool result receives "
+        "only `llm_result` (text), so a big rendered view never costs you tokens. "
+        "A dashboard shows every running job and its "
         "live output; its URL is the `DASHBOARD_URL` variable in the namespace "
         "(share it with the human)."
     ),
@@ -55,9 +61,12 @@ Content = list[outputs.Content]
         "Run Python on the shared persistent kernel. Waits up to `budget` seconds; "
         "if the code is still running it keeps going in the background as jobs['<id>'] "
         "and this returns a job handle. Inspect/await/cancel background jobs with more "
-        "python_exec against the `jobs` dict. The namespace persists across calls. End "
+        "python_exec against the `jobs` dict. The namespace persists across calls, so "
+        "functions and classes you define are reusable next turn. End "
         "with a bare expression to display the result richly (DataFrame as a table, "
-        "figure as an image) instead of print()."
+        "figure as an image) instead of print(); return `Result(user_html=..., "
+        "llm_result=...)` to show the human a rich HTML view while your tool result "
+        "gets only the text."
     )
 )
 async def python_exec(


### PR DESCRIPTION
## What

Adds a `Result(user_html, llm_result)` type to the in-kernel runtime so a cell can return two views of its final value:

```python
Result(user_html="<table>…</table>", llm_result="42 rows, mean 3.1")
```

The dashboard renders `user_html` (a rich HTML view for the human watching) while the model's `python_exec` tool result receives only `llm_result` (concise text). A large rendered view never costs the model tokens, and the human never reads the model's terse summary.

## How

`Result` is a dataclass with `_repr_mimebundle_` returning `{text/html: user_html, text/plain: llm_result}`. That rides the existing split with no render changes:

- the dashboard's `rich()` already prefers `text/html`, so the human sees `user_html`;
- `outputs.to_mcp` already prefers `text/plain`, so the model gets `llm_result`;
- `__repr__` returns `llm_result`, so the stored result repr and non-rich hosts also show the model view, never the HTML.

It is exposed in the namespace by `runtime.install` alongside `jobs`/`Job`.

Also clarifies the tool wording (instructions + `python_exec` description + README): functions and classes you define on the shared kernel persist and are reusable on later calls, and documents `Result`. Corrects a stale README "bad fit" bullet that predated dashboard rich rendering.

## Validated

`nix build .#mcp.tests.richSmoke` green: the new in-process assertion runs a `Result(...)` cell, checks the stored bundle carries `user_html` as `text/html`, and checks `to_mcp` hands the model only the `text/plain` `llm_result`.

🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Result(user_html, llm_result)` to split human-facing HTML from model-facing text in notebook cells
> - Introduces a `Result` dataclass in [`runtime.py`](https://github.com/indexable-inc/index/pull/772/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) with `user_html` and `llm_result` fields; its `_repr_mimebundle_` emits `text/html` for the dashboard and `text/plain` for MCP tool consumers.
> - Exports `Result` into the kernel namespace via `install()` so user code can construct and return it directly.
> - Updates MCP server instructions and the `python_exec` tool description in [`tools.py`](https://github.com/indexable-inc/index/pull/772/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) to document the split-output pattern and its token-cost benefit.
> - Adds a test in [`default.nix`](https://github.com/indexable-inc/index/pull/772/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) that verifies the stored mime bundle contains `text/html` and that `outputs.to_mcp` surfaces only the plain-text `llm_result`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6a6831.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->