### PR TITLE
mcp: collapse cell input by default on the dashboard

### DIFF
--- a/packages/mcp/ix_notebook_mcp/dashboard.py
+++ b/packages/mcp/ix_notebook_mcp/dashboard.py
@@ -28,7 +28,13 @@ _PAGE = """<!doctype html>
  .running .st{background:#9ece6a;color:#1a1b26}.done .st{background:#2a2e42}
  .error .st{background:#f7768e;color:#1a1b26}.cancelled .st{background:#565f89;color:#1a1b26}
  pre{white-space:pre-wrap;word-break:break-word;margin:6px 0 0;color:#a9b1d6;max-height:320px;overflow:auto}
- .code{color:#565f89;max-height:80px}.res{color:#9ece6a}
+ details.code{margin:6px 0 0}
+ details.code>summary{cursor:pointer;color:#565f89;font-size:11px;list-style:none;user-select:none;display:inline-block}
+ details.code>summary::-webkit-details-marker{display:none}
+ details.code>summary::before{content:"▸ code"}
+ details.code[open]>summary::before{content:"▾ code"}
+ details.code>pre{color:#565f89;max-height:320px}
+ .res{color:#9ece6a}
  .empty{color:#565f89}
  .rich{background:#fff;color:#111;padding:8px;border-radius:4px;margin:6px 0 0;overflow:auto;max-height:460px}
  .rich table{border-collapse:collapse;font:12px/1.4 ui-monospace,Menlo,monospace}
@@ -66,7 +72,7 @@ async function tick(){
      <div class="hdr"><span class="st">${j.status}</span>
      <span class="id">${j.id}</span><span class="name">${esc(j.name)}</span>
      <span class="dur">${dur}s</span></div>
-     <pre class="code">${esc(j.code)}</pre>
+     <details class="code"><summary></summary><pre>${esc(j.code)}</pre></details>
      ${j.output?`<pre>${esc(j.output)}</pre>`:''}
      ${richOut}
      ${j.error&&!j.output.includes(j.error)?`<pre class="error">${esc(j.error)}</pre>`:''}


### PR DESCRIPTION
Cell **input is now collapsed by default** on the dashboard. Each execution shows just its output (stdout + rich outputs); the source code is tucked behind a small `▸ code` disclosure you can click to expand.

Native `<details>`, no JS. Validated with playwright: input hidden by default, output visible, toggle reveals the full source.

🤖 Generated with Claude Code (Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collapse cell input by default on the MCP dashboard
> Wraps each job's code block in a `<details>`/`<summary>` element in [dashboard.py](https://github.com/indexable-inc/index/pull/773/files#diff-42d31638eb95030752ef7a84f47bf14ecd13cbfe141948c40115b8cae061ce5e), so cell input is collapsed by default and can be expanded by clicking a "code" label. Also increases the code area's max visible height from 80px to 320px with scroll.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9dc05fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->