### PR TITLE
mcp: add live Resources + dashboard sidebar (Tui POC)

### DIFF
--- a/packages/mcp/ix_notebook_mcp/dashboard.py
+++ b/packages/mcp/ix_notebook_mcp/dashboard.py
@@ -41,8 +41,23 @@ _PAGE = """<!doctype html>
  .rich th,.rich td{border:1px solid #d0d7de;padding:2px 7px;text-align:right}
  .rich th{background:#f6f8fa}
  .img{display:block;max-width:100%;margin:6px 0 0;border-radius:4px;background:#fff}
+ .layout{display:flex;gap:16px;align-items:flex-start}
+ #main{flex:1 1 auto;min-width:0}
+ .sidebar{flex:0 0 540px;position:sticky;top:0;max-height:100vh;overflow:auto}
+ .res-card{border:1px solid #2a2e42;border-radius:6px;margin:0 0 10px;padding:8px}
+ .res-card.live{border-color:#7dcfff}
+ .res-card.error{border-color:#f7768e}
+ .res-hdr{display:flex;gap:8px;align-items:center;margin:0 0 6px}
+ .res-dot{width:8px;height:8px;border-radius:50%;background:#7dcfff;flex:none}
+ .res-card.error .res-dot{background:#f7768e}
+ .res-title{color:#bb9af7;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+ .res-kind{color:#565f89;font-size:11px;margin-left:auto;flex:none}
+ .res-body{overflow:auto;max-height:60vh}
 </style></head><body>
-<h1>ix-mcp executions</h1><div id="jobs"></div>
+<div class="layout">
+ <div id="main"><h1>ix-mcp executions</h1><div id="jobs"></div></div>
+ <aside class="sidebar"><h1>resources</h1><div id="resources"></div></aside>
+</div>
 <script>
 async function tick(){
  try{
@@ -81,7 +96,25 @@ async function tick(){
   if(nearBottom) window.scrollTo(0, document.body.scrollHeight);
  }catch(e){}
 }
+async function tickResources(){
+ try{
+  const r=await fetch('api/resources');const rs=await r.json();
+  const el=document.getElementById('resources');
+  if(!rs.length){el.innerHTML='<div class="empty">no live resources</div>';return;}
+  const esc=s=>(s||'').replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
+  // A resource's html is the agent's own live render (a terminal screen, a custom
+  // widget). The dashboard is read-only over the tailnet (the trust boundary), so
+  // it is injected as-is, exactly like job output above.
+  el.innerHTML=rs.map(x=>`<div class="res-card ${esc(x.status)}">
+    <div class="res-hdr"><span class="res-dot"></span>
+    <span class="res-title">${esc(x.title)}</span>
+    <span class="res-kind">${esc(x.kind)}</span></div>
+    <div class="res-body">${x.html||''}</div>
+  </div>`).join('');
+ }catch(e){}
+}
 tick();setInterval(tick,1000);
+tickResources();setInterval(tickResources,1000);
 </script></body></html>"""
 
 
@@ -95,8 +128,12 @@ async def start(config: Config) -> web.AppRunner:
     async def jobs(_request: web.Request) -> web.Response:
         return web.json_response(store.recent(conn, limit=200))
 
+    async def resources(_request: web.Request) -> web.Response:
+        return web.json_response(store.live_resources(conn))
+
     app.router.add_get("/", index)
     app.router.add_get("/api/jobs", jobs)
+    app.router.add_get("/api/resources", resources)
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, config.host, config.dashboard_port)

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -192,7 +192,95 @@ class Result:
         return self.llm_result
 
 
+class Resource:
+    """A live, self-updating HTML view that lives as long as its source does.
+
+    Where a :class:`Result` is a cell's *final* value rendered once, a Resource
+    is a living thing the kernel keeps re-rendering: a running terminal, a custom
+    widget, anything with a current HTML representation. Register one with
+    :func:`register_resource`; while it stays alive the runtime mirrors its
+    latest HTML to the store every flush tick and the dashboard sidebar shows
+    all live resources updating in place. The resource closes itself (leaves the
+    sidebar) when its ``alive`` predicate reports the source is gone.
+    """
+
+    def __init__(self, id, title, kind, render, alive=None):
+        self.id = id
+        self.title = title
+        self.kind = kind
+        self._render = render
+        self._alive = alive
+        self.status = "live"
+        self.created = time.time()
+        self.html = ""
+        self.error: str | None = None
+
+    def closed(self) -> bool:
+        return self.status == "closed"
+
+    def close(self) -> "Resource":
+        """Close the resource so the sidebar drops it on the next tick."""
+        self.status = "closed"
+        return self
+
+    def alive(self) -> bool:
+        if self.closed():
+            return False
+        if self._alive is None:
+            return True
+        try:
+            return bool(self._alive())
+        except Exception:
+            # A source whose liveness check raises is treated as gone.
+            return False
+
+    async def render_html(self) -> str:
+        """The current HTML for this resource (awaits the render if it is async)."""
+        out = self._render() if callable(self._render) else self._render
+        if inspect.iscoroutine(out):
+            out = await out
+        return out if isinstance(out, str) else str(out)
+
+    def __repr__(self) -> str:
+        return f"<Resource {self.id} ({self.title}) [{self.status}] {self.kind}>"
+
+
+def register_resource(
+    source=None, *, title=None, render=None, id=None, kind="html", alive=None
+) -> Resource:
+    """Register a live HTML resource for the dashboard sidebar.
+
+    Pass a ``render`` callable returning the current HTML (sync or async), or a
+    ``source`` object the runtime renders by calling its ``resource_html()`` /
+    ``to_html()`` (whichever it has). ``alive`` is an optional predicate; when it
+    returns False the resource closes itself and leaves the sidebar. Returns the
+    :class:`Resource` handle (call ``.close()`` to remove it explicitly).
+    """
+    if render is None:
+        if source is None:
+            raise ValueError("register_resource needs a render callable or a source object")
+        if hasattr(source, "resource_html"):
+            render = source.resource_html
+        elif hasattr(source, "to_html"):
+            render = source.to_html
+        elif callable(source):
+            render = source
+        else:
+            raise TypeError(
+                f"{type(source).__name__} has no resource_html()/to_html(); pass render="
+            )
+    if title is None:
+        title = getattr(source, "title", None) or (
+            type(source).__name__ if source is not None else "resource"
+        )
+    rid = id or uuid.uuid4().hex[:8]
+    res = Resource(rid, str(title), kind, render, alive)
+    resources[rid] = res
+    return res
+
+
 jobs: dict[str, Job] = {}
+resources: dict[str, Resource] = {}
 
 
 def _compile(code: str, filename: str):
@@ -320,9 +408,115 @@ def _job_outputs(job: "Job") -> list[dict]:
     return outs
 
 
+_tui_mod = None
+_tui_probed = False
+
+
+def _tui_module():
+    """The ``tui`` module if importable, cached. None when it is not available."""
+    global _tui_mod, _tui_probed
+    if not _tui_probed:
+        _tui_probed = True
+        try:
+            import tui as _m
+
+            _tui_mod = _m
+        except Exception:
+            # No tui in this kernel: the POC provider simply contributes nothing.
+            _tui_mod = None
+    return _tui_mod
+
+
+def _tui_renderer(term):
+    async def render() -> str:
+        snap = await term.snapshot()
+        return snap.to_html()
+
+    return render
+
+
+def _discover_tui_resources() -> None:
+    """POC resource provider: surface every live ``Tui`` as a resource.
+
+    Decoupled from tui-py: poll the public ``Tui.list_all()`` and register any
+    terminal not seen yet (keyed by its id). When a terminal exits it drops out
+    of ``list_all`` and its ``is_alive`` flips false, so the sweep closes the
+    resource. This is the proof of concept; any object can be a resource via
+    :func:`register_resource`.
+    """
+    tui = _tui_module()
+    if tui is None:
+        return
+    try:
+        live = tui.Tui.list_all()
+    except Exception:
+        return
+    for term in live:
+        rid = f"tui:{term.id}"
+        if rid in resources:
+            continue
+        register_resource(
+            term,
+            id=rid,
+            kind="tui",
+            title=f"tui \u00b7 {term.command}",
+            render=_tui_renderer(term),
+            alive=lambda t=term: t.is_alive,
+        )
+
+
+def _escape_html(text: str) -> str:
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+async def _sweep_resources() -> None:
+    """Render every live resource to the store; close the ones whose source died."""
+    if _store is None or _store_conn is None:
+        return
+    _discover_tui_resources()
+    now = time.time()
+    for res in list(resources.values()):
+        if not res.alive():
+            try:
+                _store.close_resource(_store_conn, id=res.id, updated_at=now)
+            except Exception:
+                # Best-effort: a store write must not kill the loop.
+                pass
+            resources.pop(res.id, None)
+            continue
+        status = "live"
+        try:
+            # Bound each render so one wedged source cannot stall the whole loop.
+            res.html = await asyncio.wait_for(res.render_html(), timeout=2.0)
+            res.error = None
+        except Exception as exc:
+            status = "error"
+            res.error = "".join(traceback.format_exception_only(type(exc), exc)).strip()
+            res.html = (
+                '<pre style="color:#f7768e;margin:0">resource render failed:\n'
+                + _escape_html(res.error)
+                + "</pre>"
+            )
+        try:
+            _store.upsert_resource(
+                _store_conn,
+                id=res.id,
+                title=res.title,
+                kind=res.kind,
+                html=res.html,
+                status=status,
+                created_at=res.created,
+                updated_at=now,
+            )
+        except Exception:
+            # Best-effort live render: a store write must not kill the loop.
+            pass
+
+
 async def _flusher() -> None:
-    """Throttled background loop: persist every running job's output tail to the
-    store so the dashboard shows live output. One loop for all jobs (cheap)."""
+    """Throttled background loop: persist every running job's output tail and
+    re-render every live resource to the store so the dashboard shows both live.
+    One loop for all jobs and resources (cheap)."""
     if _store is None or _store_conn is None:
         return
     while True:
@@ -334,6 +528,7 @@ async def _flusher() -> None:
                 except Exception:
                     # Best-effort live output: a store write must not kill the loop.
                     pass
+        await _sweep_resources()
 
 
 async def __ix_run(code: str, budget: float = 15.0, name: str | None = None) -> Job:
@@ -456,6 +651,9 @@ def install(user_ns: dict | None = None) -> None:
     target["jobs"] = jobs
     target["Job"] = Job
     target["Result"] = Result
+    target["resources"] = resources
+    target["Resource"] = Resource
+    target["register_resource"] = register_resource
     target["__ix_run"] = __ix_run
     target["__ix_exec"] = __ix_exec
     target["DASHBOARD_URL"] = os.environ.get("IX_MCP_DASHBOARD_URL", "")

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -30,6 +30,16 @@ CREATE TABLE IF NOT EXISTS executions (
     outputs     TEXT NOT NULL DEFAULT '[]'
 );
 CREATE INDEX IF NOT EXISTS executions_started ON executions (started_at);
+
+CREATE TABLE IF NOT EXISTS resources (
+    id          TEXT PRIMARY KEY,
+    title       TEXT NOT NULL,
+    kind        TEXT NOT NULL DEFAULT 'html',
+    html        TEXT NOT NULL DEFAULT '',
+    status      TEXT NOT NULL DEFAULT 'live',
+    created_at  REAL NOT NULL,
+    updated_at  REAL NOT NULL
+);
 """
 
 
@@ -99,3 +109,55 @@ def recent(conn: sqlite3.Connection, limit: int = 100) -> list[dict]:
         d["outputs"] = json.loads(d.get("outputs") or "[]")
         out.append(d)
     return out
+
+
+# --------------------------------------------------------------------------- #
+# Resources: live, self-updating views (a Tui's screen, a custom HTML widget).
+#
+# A resource is the long-lived counterpart to an execution: an execution is a
+# finished fact (one row, written once and amended to 'done'), while a resource
+# is a *living* thing the kernel keeps re-rendering to HTML for as long as it is
+# alive. The kernel upserts the latest HTML each flush tick and flips status to
+# 'closed' when the underlying object goes away; the dashboard sidebar reads the
+# still-live rows. Same single-writer / many-reader split as executions.
+# --------------------------------------------------------------------------- #
+
+
+def upsert_resource(
+    conn: sqlite3.Connection,
+    *,
+    id: str,
+    title: str,
+    kind: str,
+    html: str,
+    status: str,
+    created_at: float,
+    updated_at: float,
+) -> None:
+    """Insert a resource or refresh its rendered HTML/status in place."""
+    conn.execute(
+        "INSERT INTO resources (id, title, kind, html, status, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?) "
+        "ON CONFLICT(id) DO UPDATE SET "
+        "title = excluded.title, kind = excluded.kind, html = excluded.html, "
+        "status = excluded.status, updated_at = excluded.updated_at",
+        (id, title, kind, html, status, created_at, updated_at),
+    )
+
+
+def close_resource(conn: sqlite3.Connection, *, id: str, updated_at: float) -> None:
+    """Mark a resource closed so the sidebar drops it (the row stays for history)."""
+    conn.execute(
+        "UPDATE resources SET status = 'closed', updated_at = ? WHERE id = ?",
+        (updated_at, id),
+    )
+
+
+def live_resources(conn: sqlite3.Connection) -> list[dict]:
+    """Every resource not yet closed, oldest first, as plain dicts for the sidebar."""
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT id, title, kind, html, status, created_at, updated_at "
+        "FROM resources WHERE status != 'closed' ORDER BY created_at ASC"
+    ).fetchall()
+    return [dict(r) for r in rows]


### PR DESCRIPTION
## What

Introduces the concept of a **Resource** to the MCP kernel + dashboard.

A `Result(user_html=...)` is a cell's *final* value, rendered once. A **Resource** is its living counterpart: a long-lived object the kernel keeps re-rendering to HTML for as long as it stays alive (a running terminal, a custom widget, anything with a current HTML view). The existing 0.5s flush loop now also mirrors each live resource's current HTML to the store, and the dashboard grows a right-hand **sidebar** that shows them all updating live.

## Pieces

- **runtime.py** — `Resource` + `register_resource(source=None, *, title, render, id, kind, alive)`. Pass a `render` callable (sync or async) returning HTML, or a `source` object with `resource_html()`/`to_html()`. Optional `alive` predicate; when it returns False the resource closes itself and leaves the sidebar. `resources` registry exposed in the user namespace. The flusher renders every live resource (each render bounded by a 2s timeout so one wedged source can't stall the loop) and closes the ones whose source died.
- **store.py** — `resources` table + `upsert_resource` / `close_resource` / `live_resources` (same single-writer / many-reader split as `executions`).
- **dashboard.py** — `/api/resources` endpoint + a sidebar that polls it and injects each resource's html, exactly like job output (read-only over the tailnet, same trust boundary).

## POC: Tui

Fully decoupled, **no tui-py change**: the flusher auto-discovers every live `tui.Tui` via `Tui.list_all()` and surfaces it as a resource rendering `snapshot().to_html()`. When the terminal exits it drops out of `list_all` / `is_alive` flips false, so the sweep closes it.

```python
# any object can be a resource, too:
register_resource(render=lambda: "<b>hello widget</b>", title="my widget")
```

## Validation

Ran in a subprocess against the patched package (real flusher, real PTYs):
- ✅ a spawned btop auto-appears as a `tui` resource (~32KB styled HTML, status live)
- ✅ a manual `register_resource(render=...)` html resource appears
- ✅ a resource with `alive=lambda: False` is dropped
- ✅ `/api/resources` serves them and the page carries the sidebar markup
- ✅ closing the terminal closes its resource within one tick
- ✅ `ruff check` clean; lines within the package's existing width

Playwright screenshot of the live sidebar (custom widget + a live python REPL + live btop):

> _(sidebar renders 3 cards: `my widget`, `tui · python`, `tui · btop`, all updating in place)_

🤖 Generated with Claude Code (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add live Resources registry and dashboard sidebar to mcp runtime
> - Introduces a `Resource` class in [runtime.py](https://github.com/indexable-inc/index/pull/774/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) with rendering and liveness semantics, plus a `register_resource` helper and global `resources` registry exposed to user notebooks.
> - Adds `_sweep_resources` coroutine that periodically discovers live `tui.Tui` terminals, renders their HTML with a 2s timeout, and marks dead resources as closed — called from the existing `_flusher` background loop every 0.5s.
> - Extends [store.py](https://github.com/indexable-inc/index/pull/774/files#diff-a4763dded9f44ec2a563e568a62d900b996c6a956b6de36462468f1d2b03b976) with a `resources` table and `upsert_resource`, `close_resource`, and `live_resources` functions to persist resource state and rendered HTML.
> - Updates the dashboard in [dashboard.py](https://github.com/indexable-inc/index/pull/774/files#diff-42d31638eb95030752ef7a84f47bf14ecd13cbfe141948c40115b8cae061ce5e) to show a two-column layout with a live sidebar polling `GET /api/resources` every second and rendering returned HTML.
> - Risk: resource HTML is injected unsanitized into the dashboard sidebar via `innerHTML`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90f34ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->