### PR TITLE
mcp: surface vmkit guests as live dashboard resources

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -786,6 +786,103 @@ let
         mkdir -p "$out"
       '';
 
+  # The vmkit guest surfaces as a live dashboard resource: a booted Driver shows
+  # up in Driver.list_all(), renders its framebuffer to inline-PNG HTML, and the
+  # runtime's resource provider discovers it. Uses a fake proc + a seeded frame
+  # so no real VM (or Virtualization.framework entitlement) is needed; pure
+  # in-process, sandbox-safe.
+  vmkitResourceTestPy = pkgs.writeText "ix-mcp-vmkit-resource-test.py" ''
+    import asyncio
+    import os
+    import time
+    import types
+
+    import vmkit
+    from ix_notebook_mcp import runtime
+
+    d = vmkit.Driver(bundle="/tmp/guest.bundle")
+    assert d.is_alive is False
+    assert d.id and len(d.id) == 8
+    assert d.title == "vm · guest.bundle", repr(d.title)
+    # No frame yet, not booted: a placeholder, and no capture is attempted.
+    assert "booting" in d.resource_html() and "<img" not in d.resource_html()
+
+    # Pretend the guest is booted (poll() is None == running) and has a frame.
+    d._proc = types.SimpleNamespace(poll=lambda: None)
+    assert d.is_alive is True
+    d._frame_png = b"\x89PNG\r\n\x1a\nFRAME"
+    d._frame_at = time.time()
+    html = d.resource_html()
+    assert 'img src="data:image/png;base64,' in html, html[:120]
+
+    vmkit.Driver._live[d.id] = d
+    assert d in vmkit.Driver.list_all()
+
+    # The runtime provider discovers it, keyed vm:<id>, kind "vm", and renders.
+    runtime.resources.clear()
+    runtime._discover_vmkit_resources()
+    rid = "vm:" + d.id
+    assert rid in runtime.resources, list(runtime.resources)
+    res = runtime.resources[rid]
+    assert res.kind == "vm" and res.alive() is True
+    assert "<img" in asyncio.run(res.render_html())
+    # Idempotent: a second sweep does not duplicate the resource.
+    runtime._discover_vmkit_resources()
+    assert sum(1 for k in runtime.resources if k == rid) == 1
+    # The bounded grab read never holds the lockstep pipe forever, and a
+    # timed-out ack is drained before the next command (no desync). Fake pipe:
+    # stdin is a sink, stdout is a real os.pipe we feed.
+    dd = vmkit.Driver(bundle="/tmp/g")
+    rfd, wfd = os.pipe()
+    rfile = os.fdopen(rfd, "r")
+    wfile = os.fdopen(wfd, "w", buffering=1)
+
+    class _Sink:
+        def write(self, s):
+            pass
+
+        def flush(self):
+            pass
+
+    dd._proc = types.SimpleNamespace(
+        poll=lambda: None, returncode=None, stdin=_Sink(), stdout=rfile
+    )
+    try:
+        dd._send_locked("shot /tmp/x", ack_timeout=0.2)
+        raise AssertionError("bounded read should have timed out")
+    except vmkit.VmkitError as exc:
+        assert "timed out" in str(exc), exc
+    assert dd._pending_acks == 1
+    wfile.write("ok\n")    # the late ack for the timed-out shot
+    wfile.write("done\n")  # the next command's own ack
+    wfile.flush()
+    assert dd._send_locked("size") == "done"  # drained "ok", read its own ack
+    assert dd._pending_acks == 0
+
+    print("vmkit-resource-ok")
+  '';
+  vmkitResourceSmoke =
+    pkgs.runCommand "ix-mcp-vmkit-resource-smoke"
+      {
+        nativeBuildInputs = [ mcpPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        ${lib.getExe mcpPython} ${vmkitResourceTestPy} >stdout 2>stderr || {
+          echo "ix-mcp vmkit resource smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -qx 'vmkit-resource-ok' stdout || {
+          echo "ix-mcp vmkit resource smoke did not confirm the resource path:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
+
   # macOS-only modules (`screen`, `vmkit`) are only bundled on Darwin; their
   # import tests only exist there.
   screenBundled = importTest "screen" "import screen; print('screen-ok', callable(screen.capture), callable(screen.click), callable(screen.accessibility_trusted))";
@@ -812,7 +909,7 @@ package.overrideAttrs (old: {
         ;
     }
     // lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
-      inherit screenBundled vmkitBundled;
+      inherit screenBundled vmkitBundled vmkitResourceSmoke;
     };
   };
 })

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -410,6 +410,8 @@ def _job_outputs(job: "Job") -> list[dict]:
 
 _tui_mod = None
 _tui_probed = False
+_vmkit_mod = None
+_vmkit_probed = False
 
 
 def _tui_module():
@@ -465,6 +467,61 @@ def _discover_tui_resources() -> None:
         )
 
 
+def _vmkit_module():
+    """The ``vmkit`` module if importable, cached. None when unavailable.
+
+    vmkit is darwin-only in the interpreter, so on other platforms this provider
+    simply contributes nothing (same graceful-absence pattern as ``tui``).
+    """
+    global _vmkit_mod, _vmkit_probed
+    if not _vmkit_probed:
+        _vmkit_probed = True
+        try:
+            import vmkit as _m
+
+            _vmkit_mod = _m
+        except Exception:
+            _vmkit_mod = None
+    return _vmkit_mod
+
+
+def _vmkit_renderer(driver):
+    async def render() -> str:
+        # The capture is a blocking pipe round trip; keep it off the event loop.
+        return await asyncio.to_thread(driver.resource_html)
+
+    return render
+
+
+def _discover_vmkit_resources() -> None:
+    """Resource provider: surface every booted ``vmkit.Driver`` as a resource.
+
+    Decoupled from vmkit: poll the public ``Driver.list_all()`` and register any
+    guest not seen yet (keyed by its id). When a guest stops it drops out of
+    ``list_all`` and its ``is_alive`` flips false, so the sweep closes the
+    resource. The live HTML is the guest's framebuffer as an inline PNG.
+    """
+    vmkit = _vmkit_module()
+    if vmkit is None:
+        return
+    try:
+        live = vmkit.Driver.list_all()
+    except Exception:
+        return
+    for driver in live:
+        rid = f"vm:{driver.id}"
+        if rid in resources:
+            continue
+        register_resource(
+            driver,
+            id=rid,
+            kind="vm",
+            title=driver.title,
+            render=_vmkit_renderer(driver),
+            alive=lambda d=driver: d.is_alive,
+        )
+
+
 def _escape_html(text: str) -> str:
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
@@ -474,6 +531,7 @@ async def _sweep_resources() -> None:
     if _store is None or _store_conn is None:
         return
     _discover_tui_resources()
+    _discover_vmkit_resources()
     now = time.time()
     for res in list(resources.values()):
         if not res.alive():

--- a/packages/mcp/src/vmkit/vmkit/__init__.py
+++ b/packages/mcp/src/vmkit/vmkit/__init__.py
@@ -84,10 +84,16 @@ from __future__ import annotations
 
 import os
 import pathlib
+import select
 import shutil
 import subprocess
 import sys
 import tempfile
+import threading
+import time
+import uuid
+import weakref
+import base64
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -625,6 +631,17 @@ class Driver:
     independent instances drive different guests in parallel.
     """
 
+    # Every booted driver registers here so the dashboard can discover live
+    # guests with no coupling (the runtime polls ``Driver.list_all()``, mirroring
+    # the ``Tui`` resource provider). WeakValueDictionary so a driver that is
+    # dropped without ``close()`` simply falls out.
+    _live: "weakref.WeakValueDictionary[str, Driver]" = weakref.WeakValueDictionary()
+
+    @classmethod
+    def list_all(cls) -> "list[Driver]":
+        """Every currently-booted driver, for resource discovery."""
+        return [d for d in cls._live.values() if d.is_alive]
+
     def __init__(
         self,
         bundle: str | os.PathLike | None = None,
@@ -661,6 +678,20 @@ class Driver:
         self._proc: subprocess.Popen[str] | None = None
         # Cached captured-framebuffer size in pixels (see `size()`).
         self._size: tuple[int, int] | None = None
+        # Stable id + a guard so the dashboard's background framebuffer grab can
+        # never interleave with a user command on this driver's single lockstep
+        # pipe (the protocol is one-command-one-ack; concurrent writers would
+        # desync the ack stream). Every pipe round trip goes through the lock.
+        self.id = uuid.uuid4().hex[:8]
+        self._lock = threading.Lock()
+        # Most recent framebuffer PNG, so the live resource can serve a frame
+        # without a fresh capture when the pipe is busy with a user command.
+        self._frame_png: bytes | None = None
+        self._frame_at: float = 0.0
+        # Acks left unread by a timed-out bounded read (the dashboard grab); the
+        # next pipe round trip drains them first so a command never reads a stale
+        # ack (keeps the single lockstep pipe in sync).
+        self._pending_acks = 0
 
     def __enter__(self) -> "Driver":
         bin_path = _binary()
@@ -692,6 +723,7 @@ class Driver:
             text=True,
             bufsize=1,
         )
+        type(self)._live[self.id] = self
         return self
 
     def __exit__(self, *_exc: object) -> None:
@@ -699,6 +731,7 @@ class Driver:
 
     def close(self) -> None:
         """Quit the guest and tear down the process. Idempotent."""
+        type(self)._live.pop(self.id, None)
         proc = self._proc
         self._proc = None
         if proc is None:
@@ -728,26 +761,72 @@ class Driver:
                     except OSError:
                         pass
 
+    @property
+    def is_alive(self) -> bool:
+        """True while the driver process is running (for resource liveness)."""
+        proc = self._proc
+        return proc is not None and proc.poll() is None
+
+    @property
+    def title(self) -> str:
+        """A short label for the dashboard sidebar."""
+        target = self._bundle or self._disk or "guest"
+        return f"vm \u00b7 {os.path.basename(str(target))}"
+
     def send(self, command: str) -> str:
         """Write one ``command`` line, flush, and return its one-line ack.
 
+        Serialized by ``self._lock`` so the dashboard's background framebuffer
+        grab never interleaves with a user command on the single lockstep pipe.
         Raises :class:`VmkitError` on an ``err ...`` ack, or if the driver
         process has died or closed its output.
+        """
+        with self._lock:
+            return self._send_locked(command)
+
+    def _send_locked(self, command: str, ack_timeout: float | None = None) -> str:
+        """The raw one-command/one-ack round trip; caller must hold ``_lock``.
+
+        ``ack_timeout`` bounds the wait for the ack (the dashboard grab passes
+        one so a wedged guest can never hold the lock forever and stall the
+        agent's own driving); ``None`` waits indefinitely, as a slow guest boot
+        needs. A timed-out ack is not lost: it is recorded and drained before the
+        next command's ack so the lockstep pipe never desyncs.
         """
         proc = self._proc
         if proc is None or proc.stdin is None or proc.stdout is None:
             raise VmkitError("driver is not running (use it as a context manager)")
         if proc.poll() is not None:
             raise VmkitError(f"driver process exited with code {proc.returncode}")
+        # Drain acks left pending by an earlier timed-out read so this command
+        # reads its OWN ack, never a stale one.
+        while self._pending_acks > 0:
+            stale = proc.stdout.readline()
+            if stale == "":
+                raise VmkitError("driver closed its output while draining a pending ack")
+            if stale.rstrip("\n"):
+                self._pending_acks -= 1
         line = command.rstrip("\n")
         try:
             proc.stdin.write(line + "\n")
             proc.stdin.flush()
         except (BrokenPipeError, OSError) as exc:
             raise VmkitError(f"driver process closed its input: {exc}") from exc
+        deadline = None if ack_timeout is None else time.monotonic() + ack_timeout
         # stderr is discarded, so the next stdout line is this command's ack;
         # skip a stray blank line all the same.
         while True:
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    # The ack is still coming; mark it so the next command drains
+                    # it instead of mistaking it for its own (no desync).
+                    self._pending_acks += 1
+                    raise VmkitError(
+                        f"timed out after {ack_timeout}s waiting for ack to {command!r}"
+                    )
+                if not select.select([proc.stdout], [], [], remaining)[0]:
+                    continue
             ack = proc.stdout.readline()
             if ack == "":
                 rc = proc.poll()
@@ -889,6 +968,51 @@ class Driver:
             # Load and detach before the temp dir is removed.
             with Image.open(out) as img:
                 return img.convert("RGB")
+
+
+    def _shot_png_locked(self) -> bytes:
+        """Capture the framebuffer to PNG bytes; caller must hold ``_lock``."""
+        with tempfile.TemporaryDirectory(prefix="ix-vmkit-frame-") as tmp:
+            out = pathlib.Path(tmp) / "frame.png"
+            # Bounded: the dashboard grab must never hold the lock indefinitely.
+            self._send_locked(f"shot {out}", ack_timeout=4.0)
+            png = out.read_bytes()
+        self._frame_png = png
+        self._frame_at = time.time()
+        return png
+
+    def resource_html(self, max_age: float = 1.0) -> str:
+        """Live dashboard view: the guest's framebuffer as an inline PNG.
+
+        Serves the cached frame when it is fresh, or when the pipe is busy with a
+        user command (a non-blocking lock so the dashboard never stalls or
+        interferes with the agent's own driving). Falls back to a placeholder
+        until the first frame exists.
+        """
+        now = time.time()
+        fresh = self._frame_png is not None and (now - self._frame_at) < max_age
+        if not fresh and self.is_alive and self._lock.acquire(blocking=False):
+            try:
+                self._shot_png_locked()
+            except (VmkitError, OSError):
+                pass  # bad/slow frame: keep serving the last good one
+            finally:
+                self._lock.release()
+        if self._frame_png is None:
+            return (
+                '<div style="color:#7aa2f7;font:13px monospace;padding:8px">'
+                "booting guest\u2026</div>"
+            )
+        b64 = base64.b64encode(self._frame_png).decode("ascii")
+        age = max(0.0, time.time() - self._frame_at)
+        return (
+            '<div style="background:#000;border-radius:6px;overflow:hidden">'
+            f'<img src="data:image/png;base64,{b64}" '
+            'style="display:block;width:100%;height:auto" alt="vm framebuffer"/>'
+            '</div>'
+            f'<div style="color:#565f89;font:11px monospace;padding:2px 4px">'
+            f'{self.title} \u00b7 {age:.1f}s ago</div>'
+        )
 
 
 def drive(


### PR DESCRIPTION
## What

Surfaces VM / remote-desktop guests (`vmkit.Driver`) as **live resources** in the MCP dashboard sidebar, so a booted guest's framebuffer shows up live, the same way terminals do.

#774 added the Resource/dashboard sidebar but only auto-discovered `Tui` terminals (the explicit POC: *"any object can be a resource"*). `vmkit.Driver` was bundled into the interpreter but never shown live, so you could drive a VM yet not watch it. This wires it in, mirroring `_discover_tui_resources`.

## How

- **`vmkit.Driver`**: a process-global `_live` registry + `list_all()`, an `is_alive` flag, a `title`, and `resource_html()` that renders the guest framebuffer as an inline base64 PNG (cached last-frame).
- **`runtime.py`**: `_vmkit_module()` (cached lazy import; darwin-only, no-ops elsewhere), `_discover_vmkit_resources()`, and an async `_vmkit_renderer` that offloads the blocking capture via `asyncio.to_thread`. Wired into `_sweep_resources()`.

## Concurrency

The Driver speaks one lockstep stdin/stdout pipe (one command, one ack); a second concurrent writer would desync it. So:
- `send()` is split into a `_lock`-guarded public wrapper + `_send_locked()`; every pipe round trip is serialized.
- The dashboard grab uses a **non-blocking** lock acquire and a cached frame, so it never stalls or interferes with the agent's own driving.
- The grab's ack read is **time-bounded** (`ack_timeout`); a timed-out ack is recorded and **drained before the next command**, so a wedged guest can't hold the lock forever (which would otherwise block the agent's `send()`) and the pipe never desyncs. The agent's own commands stay unbounded (a slow guest boot needs that).

## Test

`.#mcp.tests.vmkitResourceSmoke` (darwin-only) covers the driver surface + the runtime provider end-to-end, plus the bounded-read/desync-safe drain via a fake pipe. No real VM needed.

✅ `nix build .#mcp` · ✅ `.#mcp.tests.vmkitResourceSmoke` · ✅ `nix run .#lint`

Reviewed adversarially by the `code-reviewer` agent; its two correctness/concurrency blockers (unbounded grab read holding the lock; `OSError` escaping the frame-read `except`) are fixed here.

_Authored with Claude (Opus 4.8)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface vmkit guests as live resources on the MCP dashboard
> - Adds `Driver.list_all()`, `Driver.is_alive`, `Driver.title`, and `Driver.resource_html()` to [`vmkit/__init__.py`](https://github.com/indexable-inc/index/pull/775/files#diff-2bffc71291fb6e25d6830e14f40c1f120b520cf6ab8592256ee130680ff055e6) so live VM instances can be enumerated and rendered as inline PNG snapshots.
> - Adds `_discover_vmkit_resources()` to [`runtime.py`](https://github.com/indexable-inc/index/pull/775/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95), which auto-registers each live `vmkit.Driver` as a dashboard resource with id `vm:<id>`, kind `vm`, and a liveness predicate; discovery runs on every periodic sweep.
> - Framebuffer capture runs via `asyncio.to_thread` to avoid blocking the event loop; ack waits are bounded with `ack_timeout` and late acks are drained to keep the pipe in lockstep.
> - Adds a build-time smoke test (`vmkitResourceSmoke`) on Darwin that exercises the full driver dashboard/resource path in-process.
> - Risk: vmkit guests registered as resources will persist until `is_alive` returns False; a crashed process whose `poll()` is delayed could leave stale resources visible briefly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 525b5ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->