### PR TITLE
vmkit: keep stdout a clean ack channel for Linux guests

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -847,6 +847,20 @@ let
     dd._proc = types.SimpleNamespace(
         poll=lambda: None, returncode=None, stdin=_Sink(), stdout=rfile
     )
+    # Guest serial console can share stdout (Linux guest): non-ack lines are
+    # skipped, the real ok/err ack is returned.
+    wfile.write("[  OK  ] Reached target Initrd Root Device.\n")
+    wfile.write("Starting File System Check...\n")
+    wfile.write("\n")
+    wfile.write("ok size 1280 800\n")
+    assert dd._send_locked("size") == "ok size 1280 800"
+    wfile.write("[  OK  ] Started Service.\n")
+    wfile.write("err size guest framebuffer not available yet\n")
+    try:
+        dd._send_locked("size")
+        raise AssertionError("err ack should raise")
+    except vmkit.VmkitError as exc:
+        assert "framebuffer not available" in str(exc), exc
     try:
         dd._send_locked("shot /tmp/x", ack_timeout=0.2)
         raise AssertionError("bounded read should have timed out")

--- a/packages/mcp/src/vmkit/vmkit/__init__.py
+++ b/packages/mcp/src/vmkit/vmkit/__init__.py
@@ -799,13 +799,11 @@ class Driver:
         if proc.poll() is not None:
             raise VmkitError(f"driver process exited with code {proc.returncode}")
         # Drain acks left pending by an earlier timed-out read so this command
-        # reads its OWN ack, never a stale one.
+        # reads its OWN ack, never a stale one. The pending ack is already in
+        # flight, so this waits (unbounded) for it.
         while self._pending_acks > 0:
-            stale = proc.stdout.readline()
-            if stale == "":
-                raise VmkitError("driver closed its output while draining a pending ack")
-            if stale.rstrip("\n"):
-                self._pending_acks -= 1
+            self._read_ack(proc, None)
+            self._pending_acks -= 1
         line = command.rstrip("\n")
         try:
             proc.stdin.write(line + "\n")
@@ -813,33 +811,45 @@ class Driver:
         except (BrokenPipeError, OSError) as exc:
             raise VmkitError(f"driver process closed its input: {exc}") from exc
         deadline = None if ack_timeout is None else time.monotonic() + ack_timeout
-        # stderr is discarded, so the next stdout line is this command's ack;
-        # skip a stray blank line all the same.
+        ack = self._read_ack(proc, deadline)
+        if ack is None:
+            # The ack is still coming; mark it so the next command drains it
+            # instead of mistaking it for its own (no desync).
+            self._pending_acks += 1
+            raise VmkitError(
+                f"timed out after {ack_timeout}s waiting for ack to {command!r}"
+            )
+        if ack.startswith("err"):
+            raise VmkitError(f"command {command!r} failed: {ack}")
+        return ack
+
+    def _read_ack(self, proc: "subprocess.Popen[str]", deadline: float | None) -> str | None:
+        """Return the next ack line, skipping guest-console noise; ``None`` on
+        deadline.
+
+        The binary writes every ack as ``ok``/``err`` (optionally followed by a
+        detail), one per command. A Linux guest's serial console can share this
+        stdout, so any line that is not an ack (boot logs, blank lines) is
+        skipped rather than mistaken for one. Raises :class:`VmkitError` if the
+        process closes its output.
+        """
         while True:
             if deadline is not None:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
-                    # The ack is still coming; mark it so the next command drains
-                    # it instead of mistaking it for its own (no desync).
-                    self._pending_acks += 1
-                    raise VmkitError(
-                        f"timed out after {ack_timeout}s waiting for ack to {command!r}"
-                    )
+                    return None
                 if not select.select([proc.stdout], [], [], remaining)[0]:
                     continue
-            ack = proc.stdout.readline()
-            if ack == "":
-                rc = proc.poll()
+            raw = proc.stdout.readline()
+            if raw == "":
                 raise VmkitError(
-                    f"driver process gave no ack for {command!r} "
-                    f"(process exited with code {rc})"
+                    f"driver process closed its output (exited with code {proc.poll()})"
                 )
-            ack = ack.rstrip("\n")
-            if ack != "":
-                break
-        if ack.startswith("err"):
-            raise VmkitError(f"command {command!r} failed: {ack}")
-        return ack
+            ack = raw.strip()
+            if ack in ("ok", "err") or ack.startswith(("ok ", "err ")):
+                return ack
+            # Otherwise: guest console output on the shared stdout, or a blank
+            # line. Skip it and keep reading for the real ack.
 
     def key(self, name: str, count: int = 1) -> str:
         """Press a named key (``return``, ``tab``, arrows, ``f1``..``f12``, a

--- a/packages/vmkit/src/linuxguest.rs
+++ b/packages/vmkit/src/linuxguest.rs
@@ -122,7 +122,7 @@ pub fn drive_linux(drive: DriveLinux) -> Result<(), Error> {
 
 /// Build the Linux GUI guest configuration: generic platform booted by EFI off
 /// the raw disk, one virtio-gpu scanout, USB keyboard + pointing device, a
-/// serial console to stdout (the guest must use `console=hvc0`), and entropy +
+/// serial console to stderr (the guest must use `console=hvc0`), and entropy +
 /// balloon. Shared by the screenshot ([`boot_linux_gui`]) and interactive
 /// ([`drive_linux`]) paths.
 fn build_linux_gui_config(
@@ -191,16 +191,22 @@ fn build_linux_gui_config(
     let keyboard = unsafe { VZUSBKeyboardConfiguration::new() };
     let pointing = unsafe { VZUSBScreenCoordinatePointingDeviceConfiguration::new() };
 
-    // Guest serial console -> our stdout for boot debugging. VZ rejects a null
-    // read handle, so give it the (unwritten) read end of a fresh pipe.
+    // Guest serial console -> our stderr for boot debugging. stdout is the
+    // command/ack channel (see `crate::drive::run_commands`); routing the guest
+    // console there too would interleave kernel/systemd boot lines with acks and
+    // break the interactive `drive-linux` protocol. stderr keeps stdout a clean
+    // ack-only channel (the Python `Driver` reads acks from stdout and discards
+    // stderr) while console logs stay visible when the binary is run directly.
+    // VZ rejects a null read handle, so give it the (unwritten) read end of a
+    // fresh pipe.
     let pipe = NSPipe::pipe();
     let read_handle = pipe.fileHandleForReading();
-    let stdout_handle = NSFileHandle::fileHandleWithStandardOutput();
+    let stderr_handle = NSFileHandle::fileHandleWithStandardError();
     let serial_attachment = unsafe {
         VZFileHandleSerialPortAttachment::initWithFileHandleForReading_fileHandleForWriting(
             VZFileHandleSerialPortAttachment::alloc(),
             Some(&read_handle),
-            Some(&stdout_handle),
+            Some(&stderr_handle),
         )
     };
     let serial = unsafe { VZVirtioConsoleDeviceSerialPortConfiguration::new() };


### PR DESCRIPTION
Found while live-testing #775 (booting a real Linux guest): driving a Linux guest interactively was unreliable because the guest serial console shares stdout with the command/ack channel, so boot logs interleaved with acks and the driver never got a real frame.

- **Rust**: route the guest serial console to **stderr**; stdout becomes ack-only (the Python `Driver` already discards stderr, so boot noise is dropped during normal driving, still visible running the binary directly).
- **Python (defensive)**: `_read_ack` skips any non-ack line (the binary always writes `ok`/`err`) so a stray stdout line can never be mistaken for an ack, on any platform.
- **Test**: smoke test now feeds interleaved console noise + an `err` ack through a fake pipe and asserts the real ack is recovered.

Validated: `nix build .#mcp` (compiles the Rust change) and `nix run .#lint` pass; ack-skip logic covered by a deterministic fake-pipe test.

_Authored with Claude (Opus 4.8)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route Linux guest serial console output to stderr to keep stdout as a clean ack channel
> - In [linuxguest.rs](https://github.com/indexable-inc/index/pull/776/files#diff-053e77104ce1c6b2d60cc0725a17bf00c98ae34a35d6b84d30418c71cf43b9e9), switches the guest serial console's write handle from stdout to stderr, reserving stdout exclusively for the command/ack protocol.
> - Introduces a `_read_ack` helper in [vmkit/__init__.py](https://github.com/indexable-inc/index/pull/776/files#diff-2bffc71291fb6e25d6830e14f40c1f120b520cf6ab8592256ee130680ff055e6) that reads stdout lines, skipping blank lines and non-ack guest console output, until it finds an `ok`/`err` line or hits a deadline.
> - `send()` now raises `VmkitError` immediately on `err` acks, and on timeout increments `_pending_acks` so the next call can drain it.
> - Behavioral Change: guest console lines on stdout are now silently skipped by the ack reader rather than being misinterpreted as acknowledgements.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ddc6327.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->