### PR TITLE
Redesign MCP dashboard: sleek grayscale notebook view

### DIFF
--- a/packages/mcp/ix_notebook_mcp/dashboard.py
+++ b/packages/mcp/ix_notebook_mcp/dashboard.py
@@ -16,70 +16,130 @@ from . import store
 from .config import Config
 
 _PAGE = """<!doctype html>
-<html><head><meta charset="utf-8"><title>ix-mcp</title>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>ix · executions</title>
 <style>
- body{background:#1a1b26;color:#c0caf5;font:13px/1.5 ui-monospace,Menlo,monospace;margin:0;padding:16px}
- h1{font-size:14px;color:#7aa2f7;margin:0 0 12px}
- .job{border:1px solid #2a2e42;border-radius:6px;margin:0 0 10px;padding:10px}
- .job.running{border-color:#9ece6a}
- .hdr{display:flex;gap:10px;align-items:baseline;flex-wrap:wrap}
- .id{color:#7dcfff}.name{color:#bb9af7}.dur{color:#565f89;margin-left:auto}
- .st{padding:0 6px;border-radius:4px;font-size:11px}
- .running .st{background:#9ece6a;color:#1a1b26}.done .st{background:#2a2e42}
- .error .st{background:#f7768e;color:#1a1b26}.cancelled .st{background:#565f89;color:#1a1b26}
- pre{white-space:pre-wrap;word-break:break-word;margin:6px 0 0;color:#a9b1d6;max-height:320px;overflow:auto}
- details.code{margin:6px 0 0}
- details.code>summary{cursor:pointer;color:#565f89;font-size:11px;list-style:none;user-select:none;display:inline-block}
- details.code>summary::-webkit-details-marker{display:none}
- details.code>summary::before{content:"▸ code"}
- details.code[open]>summary::before{content:"▾ code"}
- details.code>pre{color:#565f89;max-height:320px}
- .res{color:#9ece6a}
- .empty{color:#565f89}
- .rich{background:#fff;color:#111;padding:8px;border-radius:4px;margin:6px 0 0;overflow:auto;max-height:460px}
- .rich table{border-collapse:collapse;font:12px/1.4 ui-monospace,Menlo,monospace}
- .rich th,.rich td{border:1px solid #d0d7de;padding:2px 7px;text-align:right}
- .rich th{background:#f6f8fa}
- .img{display:block;max-width:100%;margin:6px 0 0;border-radius:4px;background:#fff}
- .layout{display:flex;gap:16px;align-items:flex-start}
+ :root{
+  --bg:#0b0b0c; --panel:#141416; --panel-2:#1a1a1d; --inset:#101012;
+  --line:#242427; --line-2:#2e2e33;
+  --text:#e6e6e6; --dim:#9a9aa0; --muted:#6a6a70; --faint:#45454b;
+  --active:#f2f2f2; --err:#cf5a5a;
+  --mono:ui-monospace,"SF Mono",SFMono-Regular,Menlo,"Cascadia Code",monospace;
+ }
+ *{box-sizing:border-box}
+ html{scrollbar-color:var(--line-2) transparent}
+ body{background:var(--bg);color:var(--text);font:13px/1.55 var(--mono);margin:0;
+   -webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
+ ::selection{background:#33333a;color:#fff}
+
+ header.top{position:sticky;top:0;z-index:5;display:flex;align-items:center;gap:12px;
+   padding:11px 18px;background:rgba(11,11,12,.86);backdrop-filter:blur(8px);
+   border-bottom:1px solid var(--line)}
+ .brand{font-size:11px;letter-spacing:.22em;text-transform:uppercase;color:var(--dim);font-weight:600}
+ .brand b{color:var(--text);font-weight:600}
+ .spacer{flex:1}
+ .stat{font-size:11px;letter-spacing:.04em;color:var(--muted)}
+ .stat b{color:var(--text);font-weight:600}
+ .dot{display:inline-block;width:6px;height:6px;background:var(--active);margin-right:6px;vertical-align:middle}
+
+ .wrap{display:flex;gap:18px;align-items:flex-start;padding:18px;max-width:1600px;margin:0 auto}
  #main{flex:1 1 auto;min-width:0}
- .sidebar{flex:0 0 540px;position:sticky;top:0;max-height:100vh;overflow:auto}
- .res-card{border:1px solid #2a2e42;border-radius:6px;margin:0 0 10px;padding:8px}
- .res-card.live{border-color:#7dcfff}
- .res-card.error{border-color:#f7768e}
- .res-hdr{display:flex;gap:8px;align-items:center;margin:0 0 6px}
- .res-dot{width:8px;height:8px;border-radius:50%;background:#7dcfff;flex:none}
- .res-card.error .res-dot{background:#f7768e}
- .res-title{color:#bb9af7;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
- .res-kind{color:#565f89;font-size:11px;margin-left:auto;flex:none}
- .res-body{overflow:auto;max-height:60vh}
+ .sidebar{flex:0 0 520px;position:sticky;top:62px;max-height:calc(100vh - 78px);overflow:auto}
+ @media(max-width:1100px){.wrap{flex-direction:column}.sidebar{flex:none;width:100%;position:static;max-height:none}}
+
+ .sec{font-size:10px;letter-spacing:.2em;text-transform:uppercase;color:var(--muted);
+   margin:0 0 12px;padding-bottom:7px;border-bottom:1px solid var(--line);font-weight:600}
+
+ /* execution card */
+ .job{background:var(--panel);border:1px solid var(--line);border-left:2px solid var(--line-2);
+   margin:0 0 9px;padding:11px 14px}
+ .job.running{border-left-color:var(--active)}
+ .job.error{border-left-color:var(--err)}
+ .hdr{display:flex;gap:9px;align-items:center;flex-wrap:wrap}
+ .st{font-size:9px;letter-spacing:.12em;text-transform:uppercase;font-weight:600;
+   padding:2px 6px;border:1px solid var(--line-2);color:var(--dim)}
+ .running .st{background:var(--active);color:#0b0b0c;border-color:var(--active)}
+ .error .st{color:var(--err);border-color:#43282b}
+ .cancelled .st{color:var(--muted)}
+ .id{color:var(--muted);font-size:12px}
+ .name{color:var(--text);font-size:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+ .dur{margin-left:auto;color:var(--faint);font-size:11px;font-variant-numeric:tabular-nums;flex:none}
+
+ details.code{margin:8px 0 0}
+ details.code>summary{cursor:pointer;color:var(--faint);font-size:10px;letter-spacing:.14em;
+   text-transform:uppercase;list-style:none;user-select:none;display:inline-block}
+ details.code>summary::-webkit-details-marker{display:none}
+ details.code>summary::before{content:"+ source"}
+ details.code[open]>summary::before{content:"− source"}
+ details.code>pre{color:var(--dim);background:var(--inset);border:1px solid var(--line);
+   padding:9px 11px;max-height:340px}
+
+ pre{white-space:pre-wrap;word-break:break-word;margin:8px 0 0;color:var(--dim);
+   max-height:340px;overflow:auto;font-size:12px}
+ pre.res{color:var(--text)}
+ pre.error{color:var(--err)}
+ .empty{color:var(--faint);font-style:italic;font-size:12px;padding:2px 0}
+
+ /* rich notebook output: blends into the surface, no white card */
+ .rich{background:var(--inset);border:1px solid var(--line);padding:10px;margin:8px 0 0;
+   overflow:auto;max-height:480px;color:var(--text)}
+ .rich table{border-collapse:collapse;font:12px/1.45 var(--mono);color:var(--text)}
+ .rich th,.rich td{border-bottom:1px solid var(--line);padding:3px 12px;text-align:right;white-space:nowrap}
+ .rich th{color:var(--dim);font-weight:600;border-bottom:1px solid var(--line-2)}
+ .rich tr:hover td{background:var(--panel-2)}
+ .img{display:block;max-width:100%;margin:8px 0 0;border:1px solid var(--line);background:#fff}
+
+ /* resources */
+ .res-card{background:var(--panel);border:1px solid var(--line);border-left:2px solid var(--line-2);
+   margin:0 0 9px;padding:9px 11px}
+ .res-card.live{border-left-color:var(--active)}
+ .res-card.error{border-left-color:var(--err)}
+ .res-hdr{display:flex;gap:8px;align-items:center;margin:0 0 7px}
+ .res-dot{width:6px;height:6px;background:var(--active);flex:none}
+ .res-card.error .res-dot{background:var(--err)}
+ .res-title{color:var(--text);font-size:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+ .res-kind{margin-left:auto;color:var(--faint);font-size:10px;letter-spacing:.1em;
+   text-transform:uppercase;flex:none}
+ .res-body{overflow:auto;max-height:62vh}
+ ::-webkit-scrollbar{width:9px;height:9px}
+ ::-webkit-scrollbar-thumb{background:var(--line-2)}
+ ::-webkit-scrollbar-track{background:transparent}
 </style></head><body>
-<div class="layout">
- <div id="main"><h1>ix-mcp executions</h1><div id="jobs"></div></div>
- <aside class="sidebar"><h1>resources</h1><div id="resources"></div></aside>
+<header class="top">
+  <span class="brand"><b>ix</b> &middot; mcp</span>
+  <span class="spacer"></span>
+  <span class="stat" id="run-stat"></span>
+</header>
+<div class="wrap">
+ <div id="main"><div class="sec">executions</div><div id="jobs"></div></div>
+ <aside class="sidebar"><div class="sec">resources</div><div id="resources"></div></aside>
 </div>
 <script>
+const esc=s=>(s||'').replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
 async function tick(){
  try{
   const r=await fetch('api/jobs');const js=await r.json();
   const el=document.getElementById('jobs');
+  const running=js.filter(j=>j.status==='running').length;
+  document.getElementById('run-stat').innerHTML=
+    (running?`<span class="dot"></span><b>${running}</b> running &nbsp;`:'')+`<b>${js.length}</b> total`;
   if(!js.length){el.innerHTML='<div class="empty">no executions yet</div>';return;}
   js.sort((a,b)=>a.started_at-b.started_at);          // oldest at top, newest at bottom
   const nearBottom=(window.innerHeight+window.scrollY)>=(document.body.scrollHeight-120);
+  // Rich outputs render like a notebook cell. The dashboard is read-only over the
+  // tailnet (the trust boundary); the HTML is the agent's own code output, so it
+  // is injected as-is rather than re-sanitized.
+  const rich=o=>{const d=(o&&o.data)||{};
+    if(d['image/png'])return `<img class="img" src="data:image/png;base64,${d['image/png']}">`;
+    if(d['image/jpeg'])return `<img class="img" src="data:image/jpeg;base64,${d['image/jpeg']}">`;
+    if(d['image/svg+xml'])return `<div class="rich">${d['image/svg+xml']}</div>`;
+    if(d['text/html'])return `<div class="rich">${d['text/html']}</div>`;
+    if(d['text/markdown'])return `<pre>${esc(d['text/markdown'])}</pre>`;
+    if(d['text/plain'])return `<pre class="res">${esc(d['text/plain'])}</pre>`;
+    return '';};
   el.innerHTML=js.map(j=>{
    const dur=((j.ended_at||Date.now()/1000)-j.started_at).toFixed(1);
-   const esc=s=>(s||'').replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
-   // Rich outputs render like a notebook cell. The dashboard is read-only over the
-   // tailnet (the trust boundary); the HTML is the agent's own code output, so it
-   // is injected as-is rather than re-sanitized.
-   const rich=o=>{const d=(o&&o.data)||{};
-     if(d['image/png'])return `<img class="img" src="data:image/png;base64,${d['image/png']}">`;
-     if(d['image/jpeg'])return `<img class="img" src="data:image/jpeg;base64,${d['image/jpeg']}">`;
-     if(d['image/svg+xml'])return `<div class="rich">${d['image/svg+xml']}</div>`;
-     if(d['text/html'])return `<div class="rich">${d['text/html']}</div>`;
-     if(d['text/markdown'])return `<pre>${esc(d['text/markdown'])}</pre>`;
-     if(d['text/plain'])return `<pre class="res">${esc(d['text/plain'])}</pre>`;
-     return '';};
    const richOut=(j.outputs&&j.outputs.length)
      ? j.outputs.map(rich).join('')
      : (j.result?`<pre class="res">${esc(j.result)}</pre>`:'');
@@ -90,7 +150,7 @@ async function tick(){
      <details class="code"><summary></summary><pre>${esc(j.code)}</pre></details>
      ${j.output?`<pre>${esc(j.output)}</pre>`:''}
      ${richOut}
-     ${j.error&&!j.output.includes(j.error)?`<pre class="error">${esc(j.error)}</pre>`:''}
+     ${j.error&&!(j.output||'').includes(j.error)?`<pre class="error">${esc(j.error)}</pre>`:''}
    </div>`;
   }).join('');
   if(nearBottom) window.scrollTo(0, document.body.scrollHeight);
@@ -101,7 +161,6 @@ async function tickResources(){
   const r=await fetch('api/resources');const rs=await r.json();
   const el=document.getElementById('resources');
   if(!rs.length){el.innerHTML='<div class="empty">no live resources</div>';return;}
-  const esc=s=>(s||'').replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
   // A resource's html is the agent's own live render (a terminal screen, a custom
   // widget). The dashboard is read-only over the tailnet (the trust boundary), so
   // it is injected as-is, exactly like job output above.

--- a/packages/mcp/src/view/view/__init__.py
+++ b/packages/mcp/src/view/view/__init__.py
@@ -51,16 +51,18 @@ __all__ = [
 # (no gradients/animation): the "sexy" comes from typography, spacing, and a
 # small dtype-aware color set, not motion.
 _PAL = {
-    "panel": "#1f2335",
-    "alt": "#1c2030",
-    "border": "#2a2e42",
-    "head": "#7aa2f7",
-    "text": "#c0caf5",
-    "muted": "#565f89",
-    "num": "#ff9e64",
-    "str": "#9ece6a",
-    "bool": "#bb9af7",
-    "null": "#414868",
+    # Grayscale to match the dashboard: dtypes are distinguished by lightness,
+    # not hue (numbers brightest, then strings, then bools, then null).
+    "panel": "#141416",
+    "alt": "#17171a",
+    "border": "#242427",
+    "head": "#2e2e33",
+    "text": "#e6e6e6",
+    "muted": "#6a6a70",
+    "num": "#e6e6e6",
+    "str": "#bcbcc2",
+    "bool": "#9a9aa0",
+    "null": "#55555b",
 }
 _MONO = "ui-monospace,SFMono-Regular,Menlo,monospace"
 


### PR DESCRIPTION
Completely redesigns the `packages/mcp` dashboard from the old Tokyo Night palette to a flat, square, grayscale look.

The old design had a glaring white card behind every rich output (DataFrames, plots) sitting on a dark page, plus a colorful blue/green/purple palette that read as busy. This swaps in a layered neutral grayscale where status is conveyed by brightness rather than hue, with a single reserved muted red for errors.

What changed:
- `dashboard.py`: CSS-variable grayscale palette, no gradients/glow/rounded corners/animation. Running jobs get a filled light status chip and a white left rail; errors get the one red. Rich notebook output now renders on a dark inset instead of a white box, so tables and plots blend into the page. Sticky top bar with a live running/total counter.
- `view/__init__.py`: recolors the polars DataFrame palette to grayscale so tables match the dashboard (dtypes shown by lightness, not color).

Validated by serving the real aiohttp app over a populated SQLite store and screenshotting the rendered page with playwright (running/done/error/cancelled jobs, a DataFrame, a matplotlib plot, and live resources).

Generated with Claude Opus 4.8.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redesign MCP dashboard with a grayscale notebook view and sticky execution header
> - Replaces the dashboard UI in [dashboard.py](https://github.com/indexable-inc/index/pull/781/files#diff-42d31638eb95030752ef7a84f47bf14ecd13cbfe141948c40115b8cae061ce5e) with a new responsive dark grayscale theme, including a sticky header that shows running and total execution counts updated via `api/jobs`.
> - Switches the view palette in [__init__.py](https://github.com/indexable-inc/index/pull/781/files#diff-3fb883791c4d496cf7370e61715a007772f0dca222406e20e8c8944f7ef1a2ab) from a tokyo-night color scheme to a grayscale palette where lightness indicates data type (numbers brightest, null darkest).
> - Moves the shared `esc` HTML-escaping function to module scope, removing duplicated definitions inside per-job mapping functions.
> - Fixes a JS error when `j.output` is undefined by defaulting to an empty string before calling `String.includes`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7c1c3b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->