### PR TITLE
corpus-lake: Reconciler trait, the Iceberg document log, and snapshot-cursor consume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2894,9 +2894,9 @@ checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -3331,6 +3331,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dirs",
+ "iceberg",
  "lake-iceberg",
  "mixedbread",
  "nix 0.30.1",
@@ -3604,12 +3605,13 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -3886,9 +3888,9 @@ dependencies = [
 
 [[package]]
 name = "loro"
-version = "1.13.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd1b63cd2f0cf66acbbb3191c41feaff03c94c3f6c6bb1e61d2ab3062c301c7"
+checksum = "2a596639ccae76a9a6607930f59a105ab5c8b430cc54f2f9d7c4b8422956cb2c"
 dependencies = [
  "enum-as-inner 0.6.1",
  "generic-btree",
@@ -3902,9 +3904,9 @@ dependencies = [
 
 [[package]]
 name = "loro-common"
-version = "1.13.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51042936156a1d537df8a38938ec8ed24b45de14530af933c1d02de39c9e056"
+checksum = "909f26cb6944835928d71688ca8821db0f99ef6f6144a7efff94cc61995bd437"
 dependencies = [
  "arbitrary",
  "enum-as-inner 0.6.1",
@@ -3932,9 +3934,9 @@ dependencies = [
 
 [[package]]
 name = "loro-internal"
-version = "1.13.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252a84196402ac55a7dd064af87a747a430fc176ec744d5bb99f4ed92e639fa8"
+checksum = "94f2baab1be59b0da06cf7779d90e419c2e936485c94e52181ef21e04e9286bd"
 dependencies = [
  "append-only-bytes",
  "arref",
@@ -3979,9 +3981,9 @@ dependencies = [
 
 [[package]]
 name = "loro-kv-store"
-version = "1.13.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950cc8bcc64dcff536e949fbc56ccc3d0759646fa441c7f76b3cd7c3eafa2096"
+checksum = "dacf29d41af781a8c6de87c72ca2d35c119993949e581a63b06080d5c1b4cb81"
 dependencies = [
  "bytes",
  "ensure-cov",
@@ -8221,9 +8223,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8234,9 +8236,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.73"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8244,9 +8246,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8254,9 +8256,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8267,9 +8269,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -8323,9 +8325,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.100"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3331,6 +3331,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dirs",
+ "lake-iceberg",
  "mixedbread",
  "nix 0.30.1",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -168,6 +168,31 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "apache-avro"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36fa98bc79671c7981272d91a8753a928ff6a1cd8e4f20a44c45bd5d313840bf"
+dependencies = [
+ "bigdecimal",
+ "bon",
+ "digest",
+ "log",
+ "miniz_oxide",
+ "num-bigint",
+ "quad-rand",
+ "rand 0.9.4",
+ "regex-lite",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+ "uuid",
+ "zstd",
+]
 
 [[package]]
 name = "append-only-bytes"
@@ -194,6 +219,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,19 +242,33 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
  "arrow-csv",
- "arrow-data",
- "arrow-ipc",
+ "arrow-data 58.3.0",
+ "arrow-ipc 58.3.0",
  "arrow-json",
- "arrow-ord",
+ "arrow-ord 58.3.0",
  "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "arrow-string 58.3.0",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7bbd679c5418b8639b92be01f361d60013c4906574b578b77b63c78356594c"
+dependencies = [
+ "arrow-array 57.3.1",
+ "arrow-buffer 57.3.1",
+ "arrow-data 57.3.1",
+ "arrow-schema 57.3.1",
+ "chrono",
+ "num-traits",
 ]
 
 [[package]]
@@ -232,11 +277,29 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
  "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8a4ab47b3f3eac60f7fd31b81e9028fda018607bcc63451aca4f2b755269862"
+dependencies = [
+ "ahash",
+ "arrow-buffer 57.3.1",
+ "arrow-data 57.3.1",
+ "arrow-schema 57.3.1",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
  "num-traits",
 ]
 
@@ -247,14 +310,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
  "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
  "chrono",
  "half",
  "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
  "num-traits",
 ]
 
@@ -272,16 +347,37 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "722b5c41dd1d14d0a879a1bce92c6fe33f546101bb2acce57a209825edd075b3"
+dependencies = [
+ "arrow-array 57.3.1",
+ "arrow-buffer 57.3.1",
+ "arrow-data 57.3.1",
+ "arrow-ord 57.3.1",
+ "arrow-schema 57.3.1",
+ "arrow-select 57.3.1",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
  "atoi",
  "base64",
  "chrono",
@@ -297,9 +393,9 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de"
 dependencies = [
- "arrow-array",
- "arrow-cast",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-schema 58.3.0",
  "chrono",
  "csv",
  "csv-core",
@@ -308,15 +404,42 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1683705c63dcf0d18972759eda48489028cbbff67af7d6bef2c6b7b74ab778a"
+dependencies = [
+ "arrow-buffer 57.3.1",
+ "arrow-schema 57.3.1",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-data"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 58.3.0",
+ "arrow-schema 58.3.0",
  "half",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf72d04c07229fbf4dbebe7145cac37d7cf7ec582fe705c6b92cb314af096ab"
+dependencies = [
+ "arrow-array 57.3.1",
+ "arrow-buffer 57.3.1",
+ "arrow-data 57.3.1",
+ "arrow-schema 57.3.1",
+ "arrow-select 57.3.1",
+ "flatbuffers",
 ]
 
 [[package]]
@@ -325,11 +448,11 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
  "flatbuffers",
 ]
 
@@ -339,15 +462,15 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
  "chrono",
  "half",
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "lexical-core",
  "memchr",
@@ -360,15 +483,28 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082342947d4e5a2bcccf029a0a0397e21cb3bb8421edd9571d34fb5dd2670256"
+dependencies = [
+ "arrow-array 57.3.1",
+ "arrow-buffer 57.3.1",
+ "arrow-data 57.3.1",
+ "arrow-schema 57.3.1",
+ "arrow-select 57.3.1",
+]
+
+[[package]]
+name = "arrow-ord"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
 ]
 
 [[package]]
@@ -377,12 +513,18 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
  "half",
 ]
+
+[[package]]
+name = "arrow-schema"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4cf0d4a6609679e03002167a61074a21d7b1ad9ea65e462b2c0a97f8a3b2bc6"
 
 [[package]]
 name = "arrow-schema"
@@ -392,16 +534,47 @@ checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 
 [[package]]
 name = "arrow-select"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b320d86a9806923663bb0fd9baa65ecaba81cb0cd77ff8c1768b9716b4ef891"
+dependencies = [
+ "ahash",
+ "arrow-array 57.3.1",
+ "arrow-buffer 57.3.1",
+ "arrow-data 57.3.1",
+ "arrow-schema 57.3.1",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-select"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b493e99162e5764077e7823e50ba284858d365922631c7aaefe9487b1abd02c2"
+dependencies = [
+ "arrow-array 57.3.1",
+ "arrow-buffer 57.3.1",
+ "arrow-data 57.3.1",
+ "arrow-schema 57.3.1",
+ "arrow-select 57.3.1",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -410,16 +583,22 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
  "memchr",
  "num-traits",
  "regex",
  "regex-syntax",
 ]
+
+[[package]]
+name = "as-any"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
 
 [[package]]
 name = "asn1-rs"
@@ -554,6 +733,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +840,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +870,26 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bindgen"
@@ -747,6 +968,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bnum"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f781dba93de3a5ef6dc5b17c9958b208f6f3f021623b360fb605ea51ce443f10"
+dependencies = [
+ "serde",
+ "serde-big-array",
+]
+
+[[package]]
 name = "bon"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +1021,15 @@ checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -902,8 +1142,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1177,6 +1419,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1438,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-random"
@@ -1307,6 +1564,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -1613,6 +1879,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,7 +1953,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1701,6 +2000,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dissimilar"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1814,7 +2128,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "expect-test"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
+dependencies = [
+ "dissimilar",
+ "once_cell",
 ]
 
 [[package]]
@@ -1844,6 +2189,18 @@ name = "fastdivide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
+
+[[package]]
+name = "fastnum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4089ab2dfd45d8ddc92febb5ca80644389d5ebb954f40231274a3f18341762e2"
+dependencies = [
+ "bnum",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "fastrand"
@@ -2212,6 +2569,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "goblin"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2310,7 +2679,7 @@ dependencies = [
  "google-calendar",
  "google-gmail",
  "rmcp",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "tokio",
@@ -2329,7 +2698,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2365,6 +2734,12 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2488,6 +2863,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "htmlescape"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,9 +2894,9 @@ checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2634,6 +3033,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "iceberg"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d9c3fc1f55c84ff64645c0d2ee35159f5574d33f729fc0860783bc247c8b8c5"
+dependencies = [
+ "anyhow",
+ "apache-avro",
+ "array-init",
+ "arrow-arith 57.3.1",
+ "arrow-array 57.3.1",
+ "arrow-buffer 57.3.1",
+ "arrow-cast 57.3.1",
+ "arrow-ord 57.3.1",
+ "arrow-schema 57.3.1",
+ "arrow-select 57.3.1",
+ "arrow-string 57.3.1",
+ "as-any",
+ "async-trait",
+ "backon",
+ "base64",
+ "bimap",
+ "bytes",
+ "chrono",
+ "derive_builder",
+ "expect-test",
+ "fastnum",
+ "flate2",
+ "fnv",
+ "futures",
+ "itertools 0.13.0",
+ "moka",
+ "murmur3",
+ "once_cell",
+ "ordered-float 4.6.0",
+ "parquet 57.3.1",
+ "rand 0.9.4",
+ "reqwest",
+ "roaring",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "strum",
+ "tokio",
+ "typed-builder",
+ "typetag",
+ "url",
+ "uuid",
+ "zstd",
+]
+
+[[package]]
+name = "iceberg-catalog-rest"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a49dfef578060c3a2a3f619522dcb25382a7ce85336dcb500495d4b8d72ae714"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "http",
+ "iceberg",
+ "itertools 0.13.0",
+ "reqwest",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "typed-builder",
+ "uuid",
+]
+
+[[package]]
+name = "iceberg-storage-opendal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30acae4698949eea6cfbd3e64ddf1c3ec39e6b7191acb0b0da2dcd1a25dfa842"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "iceberg",
+ "opendal",
+ "reqsign",
+ "reqwest",
+ "serde",
+ "typetag",
+ "url",
 ]
 
 [[package]]
@@ -2861,6 +3354,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -3003,6 +3507,47 @@ name = "ix-vt-sys"
 version = "0.1.0"
 
 [[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,13 +3603,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -3073,6 +3617,25 @@ name = "kitty"
 version = "0.1.0"
 dependencies = [
  "base64",
+]
+
+[[package]]
+name = "lake-iceberg"
+version = "0.1.0"
+dependencies = [
+ "arrow-array 57.3.1",
+ "arrow-schema 57.3.1",
+ "futures",
+ "iceberg",
+ "iceberg-catalog-rest",
+ "iceberg-storage-opendal",
+ "parquet 57.3.1",
+ "serde_json",
+ "snafu 0.9.1",
+ "source-meta",
+ "tempfile",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -3322,9 +3885,9 @@ dependencies = [
 
 [[package]]
 name = "loro"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a596639ccae76a9a6607930f59a105ab5c8b430cc54f2f9d7c4b8422956cb2c"
+checksum = "7bd1b63cd2f0cf66acbbb3191c41feaff03c94c3f6c6bb1e61d2ab3062c301c7"
 dependencies = [
  "enum-as-inner 0.6.1",
  "generic-btree",
@@ -3338,9 +3901,9 @@ dependencies = [
 
 [[package]]
 name = "loro-common"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909f26cb6944835928d71688ca8821db0f99ef6f6144a7efff94cc61995bd437"
+checksum = "b51042936156a1d537df8a38938ec8ed24b45de14530af933c1d02de39c9e056"
 dependencies = [
  "arbitrary",
  "enum-as-inner 0.6.1",
@@ -3368,9 +3931,9 @@ dependencies = [
 
 [[package]]
 name = "loro-internal"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f2baab1be59b0da06cf7779d90e419c2e936485c94e52181ef21e04e9286bd"
+checksum = "252a84196402ac55a7dd064af87a747a430fc176ec744d5bb99f4ed92e639fa8"
 dependencies = [
  "append-only-bytes",
  "arref",
@@ -3415,9 +3978,9 @@ dependencies = [
 
 [[package]]
 name = "loro-kv-store"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dacf29d41af781a8c6de87c72ca2d35c119993949e581a63b06080d5c1b4cb81"
+checksum = "950cc8bcc64dcff536e949fbc56ccc3d0759646fa441c7f76b3cd7c3eafa2096"
 dependencies = [
  "bytes",
  "ensure-cov",
@@ -3478,6 +4041,15 @@ name = "lz4_flex"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 dependencies = [
  "twox-hash",
 ]
@@ -3655,6 +4227,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3663,6 +4255,12 @@ dependencies = [
  "num-traits",
  "pxfm",
 ]
+
+[[package]]
+name = "murmur3"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "murmurhash32"
@@ -3879,7 +4477,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3904,6 +4502,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -4234,7 +4833,7 @@ dependencies = [
  "md-5",
  "parking_lot",
  "percent-encoding",
- "quick-xml",
+ "quick-xml 0.39.4",
  "rand 0.10.1",
  "reqwest",
  "ring",
@@ -4322,6 +4921,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
+name = "opendal"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d075ab8a203a6ab4bc1bce0a4b9fe486a72bf8b939037f4b78d95386384bc80a"
+dependencies = [
+ "anyhow",
+ "backon",
+ "base64",
+ "bytes",
+ "crc32c",
+ "futures",
+ "getrandom 0.2.17",
+ "http",
+ "http-body",
+ "jiff",
+ "log",
+ "md-5",
+ "percent-encoding",
+ "quick-xml 0.38.4",
+ "reqsign",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4344,11 +4972,30 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4365,6 +5012,12 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4391,17 +5044,53 @@ dependencies = [
 
 [[package]]
 name = "parquet"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e832c6aa20310fc6de7ea5a3f4e20d34fd83e3b43229d32b81ffe5c14d74692"
+dependencies = [
+ "ahash",
+ "arrow-array 57.3.1",
+ "arrow-buffer 57.3.1",
+ "arrow-cast 57.3.1",
+ "arrow-data 57.3.1",
+ "arrow-ipc 57.3.1",
+ "arrow-schema 57.3.1",
+ "arrow-select 57.3.1",
+ "base64",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "futures",
+ "half",
+ "hashbrown 0.16.1",
+ "lz4_flex 0.12.2",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "tokio",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "parquet"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
  "base64",
  "brotli",
  "bytes",
@@ -4721,6 +5410,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quad-rand"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
+
+[[package]]
 name = "quartz_nbt"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4730,7 +5425,7 @@ dependencies = [
  "byteorder",
  "cesu8",
  "flate2",
- "indexmap",
+ "indexmap 2.14.0",
  "quartz_nbt_macros",
 ]
 
@@ -4750,6 +5445,26 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "quick-xml"
@@ -5035,6 +5750,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5046,6 +5767,35 @@ version = "0.1.0"
 dependencies = [
  "ignore",
  "tempfile",
+]
+
+[[package]]
+name = "reqsign"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43451dbf3590a7590684c25fb8d12ecdcc90ed3ac123433e500447c7d77ed701"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64",
+ "chrono",
+ "form_urlencoded",
+ "getrandom 0.2.17",
+ "hex",
+ "hmac",
+ "home",
+ "http",
+ "log",
+ "percent-encoding",
+ "quick-xml 0.37.5",
+ "rand 0.8.6",
+ "reqwest",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "tokio",
 ]
 
 [[package]]
@@ -5122,7 +5872,7 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "rmcp-macros",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -5164,6 +5914,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "rodio"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5186,6 +5946,16 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -5252,7 +6022,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5330,6 +6100,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5512,6 +6294,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_columnar"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5573,7 +6374,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -5587,7 +6388,7 @@ version = "0.9.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -5603,6 +6404,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5624,6 +6436,38 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5737,7 +6581,7 @@ version = "0.1.0"
 dependencies = [
  "arrow",
  "object_store",
- "parquet",
+ "parquet 58.3.0",
  "serde_json",
  "sha2",
  "snafu 0.9.1",
@@ -5846,7 +6690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5941,7 +6785,7 @@ dependencies = [
  "arrow",
  "futures",
  "object_store",
- "parquet",
+ "parquet 58.3.0",
  "serde_json",
  "snafu 0.9.1",
  "source-meta",
@@ -6001,6 +6845,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6056,6 +6921,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tango-bench"
@@ -6296,7 +7167,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6545,7 +7416,7 @@ version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -7083,6 +7954,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
+name = "typed-builder"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7329,9 +8220,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7342,9 +8233,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7352,9 +8243,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7362,9 +8253,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7375,9 +8266,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]
@@ -7399,7 +8290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -7425,15 +8316,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7486,7 +8377,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7974,7 +8865,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -8005,7 +8896,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -8024,7 +8915,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
   "packages/indexbench",
   "packages/ix-dev-diagnose",
   "packages/kitty",
+  "packages/lake/iceberg",
   "packages/minecraft/nbt",
   "packages/minecraft/sound",
   "packages/minecraft/sync-managed",
@@ -147,6 +148,7 @@ google-calendar = { path = "packages/google/calendar" }
 google-gmail = { path = "packages/google/gmail" }
 indexbench = { path = "packages/indexbench" }
 kitty = { path = "packages/kitty" }
+lake-iceberg = { path = "packages/lake/iceberg" }
 color-eyre = "0.6"
 dashboard-core = { path = "packages/dashboard-core" }
 devicons = "0.6"
@@ -157,6 +159,12 @@ futures = "0.3"
 git2 = { version = "0.20", default-features = false }
 glob = "0.3"
 hegeltest = { version = "0.14", default-features = false }
+# The Iceberg corpus lake (issue #752). iceberg 0.9 pins arrow/parquet ^57.1
+# while the workspace parquet pair is on 58; the 57 tree stays isolated inside
+# lake-iceberg (see its Cargo.toml).
+iceberg = "0.9"
+iceberg-catalog-rest = "0.9"
+iceberg-storage-opendal = { version = "0.9", features = ["opendal-s3"] }
 ignore = "0.4"
 indicatif = "0.18"
 insta = { version = "1.42", features = ["json"] }

--- a/examples/minecraft-blocks/schema.nix
+++ b/examples/minecraft-blocks/schema.nix
@@ -181,6 +181,11 @@ let
   # what turns an at-least-once transport plus this view into effectively-once:
   # the broker may re-deliver and the shipper may re-send the whole file on
   # restart, yet every duplicate folds back into the single canonical row.
+  #
+  # In corpus terms this lane satisfies source-meta's `Reconciler` contract at
+  # the engine level: idempotent convergence is declared in the table engine
+  # (replayed duplicates collapse in storage) rather than implemented in a
+  # consumer.
   createTableSql = ''
     CREATE TABLE IF NOT EXISTS ${database}.${table} (
       ${columnDefs},

--- a/packages/indexer/Cargo.toml
+++ b/packages/indexer/Cargo.toml
@@ -23,6 +23,7 @@ source-slack.workspace = true
 source-linear.workspace = true
 source-github.workspace = true
 source-parquet.workspace = true
+lake-iceberg.workspace = true
 search-core.workspace = true
 sink-mixedbread.workspace = true
 sink-parquet.workspace = true

--- a/packages/indexer/Cargo.toml
+++ b/packages/indexer/Cargo.toml
@@ -36,5 +36,8 @@ dirs.workspace = true
 nix = { workspace = true, features = ["hostname"] }
 
 [dev-dependencies]
+# The lake-consume tests drive run_cursor_consume against iceberg's in-memory
+# catalog (the same harness lake-iceberg's own suite uses).
+iceberg.workspace = true
 rusqlite = { workspace = true, features = ["bundled"] }
 tempfile.workspace = true

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -1,6 +1,8 @@
 //! `indexer`: sync every configured corpus source into Mixedbread (semantic
-//! search) and a durable Parquet corpus log, the log-as-source-of-truth with the
-//! Mixedbread index as a materialized view (issue #736).
+//! search) and a durable corpus log — the full-file-overwrite Parquet log
+//! and/or its successor, the Iceberg corpus lake (issue #752) — the
+//! log-as-source-of-truth with the Mixedbread index as a materialized view
+//! (issue #736).
 //!
 //! Each source is an adapter implementing [`source_meta::SourceAdapter`]. The
 //! routing differs by corpus shape:
@@ -23,6 +25,7 @@ use std::time::Duration;
 
 use anyhow::Context as _;
 use clap::Parser;
+use lake_iceberg::IcebergReconciler;
 use search_core::MixedbreadStore;
 use sink_mixedbread::MixedbreadReconciler;
 use sink_parquet::ParquetReconciler;
@@ -72,6 +75,25 @@ struct Cli {
     /// scanning local sources.
     #[arg(long, env = "INDEXER_FROM_PARQUET_PREFIX")]
     from_parquet_prefix: Option<String>,
+
+    /// Iceberg REST catalog URI; enables the corpus-lake sink (issue #752).
+    /// For R2 Data Catalog: `https://catalog.cloudflarestorage.com/<account>/<bucket>`.
+    #[arg(long, env = "INDEXER_CATALOG_URI")]
+    catalog_uri: Option<String>,
+
+    /// Iceberg warehouse name (R2: `<account>_<bucket>`); required with --catalog-uri.
+    #[arg(long, env = "INDEXER_WAREHOUSE")]
+    warehouse: Option<String>,
+
+    /// Bearer token for the catalog REST API.
+    #[arg(long, env = "INDEXER_CATALOG_TOKEN", hide_env_values = true)]
+    catalog_token: Option<String>,
+
+    /// Rebuild the Mixedbread index from the Iceberg corpus lake; pair with
+    /// --mixedbread-store and the --catalog-* flags. The lake's analog of
+    /// --from-parquet-prefix.
+    #[arg(long, env = "INDEXER_FROM_ICEBERG")]
+    from_iceberg: bool,
 
     /// Index local agent/shell history (claude, codex, atuin) at their default
     /// paths, in addition to any explicit `--*` overrides below.
@@ -165,6 +187,26 @@ async fn main() -> anyhow::Result<()> {
         .zip(cli.mixedbread_store.as_deref())
         .map(|(store, name)| Mixedbread { store, name, index_timeout: INDEX_TIMEOUT });
 
+    // Consume mode (Iceberg corpus lake): fold the lake's revision log into its
+    // current document set and reconcile that back into Mixedbread — the lake's
+    // replay/rebuild path. Like the parquet consume below, emit and consume run
+    // as separate invocations of this binary.
+    if cli.from_iceberg {
+        anyhow::ensure!(
+            cli.from_parquet_prefix.is_none(),
+            "--from-iceberg and --from-parquet-prefix are mutually exclusive (one log at a time)"
+        );
+        let mixedbread =
+            mixedbread.context("--from-iceberg requires --mixedbread-store (the reconcile target)")?;
+        let config = lake_config(&cli)?;
+        let catalog = config.connect().await.context("connecting the Iceberg catalog")?;
+        let ident =
+            lake_iceberg::ensure_table(catalog.as_ref()).await.context("ensuring the lake table")?;
+        let documents =
+            lake_iceberg::read_all(catalog.as_ref(), &ident).await.context("reading the lake")?;
+        return finish(run_consume(documents, mixedbread).await);
+    }
+
     // Consume mode (parquet corpus log): read the per-source `data.parquet` files
     // `sink-parquet` wrote at this prefix under `--bucket` and reconcile them back
     // into Mixedbread. Uses the SAME bucket/endpoint/region the parquet sink uses,
@@ -208,8 +250,23 @@ async fn main() -> anyhow::Result<()> {
         }
         None => None,
     };
-    if store.is_none() && parquet.is_none() {
-        anyhow::bail!("nothing to do: pass --mixedbread-store and/or --bucket");
+    // The Iceberg corpus lake (issue #752): the parquet log's successor, run
+    // alongside it during the migration. Connecting and ensuring the table here
+    // surfaces a bad catalog config at startup, like the parquet connect above.
+    let lake = match cli.catalog_uri.as_ref() {
+        Some(_) => {
+            let config = lake_config(&cli)?;
+            let catalog = config.connect().await.context("connecting the Iceberg catalog")?;
+            let ident = lake_iceberg::ensure_table(catalog.as_ref())
+                .await
+                .context("ensuring the lake table")?;
+            let host = resolve_host(&cli).context("resolving host for the lake")?;
+            Some(IcebergReconciler::new(catalog, ident, host))
+        }
+        None => None,
+    };
+    if store.is_none() && parquet.is_none() && lake.is_none() {
+        anyhow::bail!("nothing to do: pass --mixedbread-store, --bucket, and/or --catalog-uri");
     }
     if !any_source_selected(&cli) {
         anyhow::bail!(
@@ -217,7 +274,22 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
-    finish(run_sources(&cli, mixedbread, parquet.as_ref()).await)
+    finish(run_sources(&cli, mixedbread, parquet.as_ref(), lake.as_ref()).await)
+}
+
+/// Build the lake's catalog config from the CLI: the catalog flags plus the
+/// shared S3 endpoint/region (the lake's data plane is the same account the
+/// parquet archive uses during the migration).
+fn lake_config(cli: &Cli) -> anyhow::Result<lake_iceberg::Config> {
+    let uri = cli.catalog_uri.clone().context("--catalog-uri is required for the Iceberg lake")?;
+    let warehouse = cli.warehouse.clone().context("--warehouse is required with --catalog-uri")?;
+    Ok(lake_iceberg::Config {
+        uri,
+        warehouse,
+        token: cli.catalog_token.clone(),
+        s3_endpoint: cli.endpoint.clone(),
+        s3_region: cli.region.clone(),
+    })
 }
 
 /// Turn the per-run counts into the process result: success only when no source
@@ -263,6 +335,7 @@ async fn run_sources(
     cli: &Cli,
     mixedbread: Option<Mixedbread<'_>>,
     parquet: Option<&ParquetReconciler>,
+    lake: Option<&IcebergReconciler>,
 ) -> Counts {
     let home = dirs::home_dir();
     let default = |suffix: &str| home.as_ref().map(|h| h.join(suffix));
@@ -275,7 +348,7 @@ async fn run_sources(
         let result = async {
             let adapter = source_claude::ClaudeHistoryExport::open(&dir)
                 .with_context(|| format!("parsing Claude transcripts at {}", dir.display()))?;
-            run_source("claude", &adapter, mixedbread, parquet).await
+            run_source("claude", &adapter, mixedbread, parquet, lake).await
         }
         .await;
         record("claude", result, &mut counts);
@@ -284,15 +357,20 @@ async fn run_sources(
         let result = async {
             let adapter = source_codex::CodexHistory::open(&file)
                 .with_context(|| format!("parsing Codex history at {}", file.display()))?;
-            run_source("codex", &adapter, mixedbread, parquet).await
+            run_source("codex", &adapter, mixedbread, parquet, lake).await
         }
         .await;
         record("codex", result, &mut counts);
     }
     if let Some(db) = atuin {
-        match open_atuin("shell", &db, mixedbread.is_some() || parquet.is_some(), &mut counts) {
+        match open_atuin(
+            "shell",
+            &db,
+            mixedbread.is_some() || parquet.is_some() || lake.is_some(),
+            &mut counts,
+        ) {
             Ok(Atuin::Ready(adapter)) => {
-                let result = run_source("shell", &adapter, mixedbread, parquet).await;
+                let result = run_source("shell", &adapter, mixedbread, parquet, lake).await;
                 record("shell", result, &mut counts);
             }
             // An uninitialized db is already logged and tallied as a soft skip.
@@ -304,7 +382,7 @@ async fn run_sources(
         let result = async {
             let adapter = source_slack::SlackExport::open(dir)
                 .with_context(|| format!("reading Slack export at {}", dir.display()))?;
-            run_source("slack", &adapter, mixedbread, parquet).await
+            run_source("slack", &adapter, mixedbread, parquet, lake).await
         }
         .await;
         record("slack", result, &mut counts);
@@ -313,7 +391,7 @@ async fn run_sources(
         let result = async {
             let adapter = source_linear::LinearExport::open(dir)
                 .with_context(|| format!("reading Linear export at {}", dir.display()))?;
-            run_source("linear", &adapter, mixedbread, parquet).await
+            run_source("linear", &adapter, mixedbread, parquet, lake).await
         }
         .await;
         record("linear", result, &mut counts);
@@ -322,7 +400,7 @@ async fn run_sources(
         let result = async {
             let adapter = source_github::GithubExport::open(dir)
                 .with_context(|| format!("reading GitHub export at {}", dir.display()))?;
-            run_source("github", &adapter, mixedbread, parquet).await
+            run_source("github", &adapter, mixedbread, parquet, lake).await
         }
         .await;
         record("github", result, &mut counts);
@@ -332,7 +410,7 @@ async fn run_sources(
         let result = async {
             let adapter = source_git::GitLog::open(repo)
                 .with_context(|| format!("reading git history at {}", repo.display()))?;
-            run_source("git", &adapter, mixedbread, parquet).await
+            run_source("git", &adapter, mixedbread, parquet, lake).await
         }
         .await;
         record(&label, result, &mut counts);
@@ -343,7 +421,7 @@ async fn run_sources(
         record(&label, result, &mut counts);
     }
     if !cli.users.is_empty() {
-        run_users(cli, mixedbread, parquet, &mut counts).await;
+        run_users(cli, mixedbread, parquet, lake, &mut counts).await;
     }
     counts
 }
@@ -354,6 +432,7 @@ async fn run_users(
     cli: &Cli,
     mixedbread: Option<Mixedbread<'_>>,
     parquet: Option<&ParquetReconciler>,
+    lake: Option<&IcebergReconciler>,
     counts: &mut Counts,
 ) {
     let host = match resolve_host(cli) {
@@ -369,7 +448,7 @@ async fn run_users(
     };
     for spec in &cli.users {
         match parse_user(spec) {
-            Ok(user) => index_user(&user, &host, mixedbread, parquet, counts).await,
+            Ok(user) => index_user(&user, &host, mixedbread, parquet, lake, counts).await,
             Err(error) => {
                 eprintln!("[users] bad --user spec: {error:#}");
                 counts.failures += 1;
@@ -441,6 +520,7 @@ async fn index_user(
     host: &str,
     mixedbread: Option<Mixedbread<'_>>,
     parquet: Option<&ParquetReconciler>,
+    lake: Option<&IcebergReconciler>,
     counts: &mut Counts,
 ) {
     let name = user.name.as_str();
@@ -448,17 +528,21 @@ async fn index_user(
     // User-scope the parquet log so several accounts on one host do not clobber
     // each other's `source=<source>/data.parquet` (the sink overwrites that file
     // in full per run, and every account produces the same `source=claude` etc.).
+    // The lake scopes the same way: its slice (and so its tombstones) must be
+    // per-account, or one user's reconcile would delete another's documents.
     // The Mixedbread sink needs no such scoping: its `external_id`s already carry
     // the per-message uuid, so records never collide across users there.
     let user_parquet =
         parquet.map(|reconciler| reconciler.with_prefix(user_prefix(&reconciler.prefix, name)));
     let parquet = user_parquet.as_ref();
+    let user_lake = lake.map(|reconciler| reconciler.with_user(name));
+    let lake = user_lake.as_ref();
     if let Some(claude_dir) = safe_path_under(home, &[".claude", "projects"], true) {
         let label = format!("claude:{name}");
         let result = async {
             let adapter = source_claude::ClaudeHistoryExport::open_with(&claude_dir, host, name)
                 .with_context(|| format!("parsing Claude transcripts for {name} at {}", claude_dir.display()))?;
-            run_source(&label, &adapter, mixedbread, parquet).await
+            run_source(&label, &adapter, mixedbread, parquet, lake).await
         }
         .await;
         record(&label, result, counts);
@@ -469,7 +553,7 @@ async fn index_user(
         let result = async {
             let adapter = source_codex::CodexHistory::open_with(&codex_file, host, name)
                 .with_context(|| format!("parsing Codex history for {name} at {}", codex_file.display()))?;
-            run_source(&label, &adapter, mixedbread, parquet).await
+            run_source(&label, &adapter, mixedbread, parquet, lake).await
         }
         .await;
         record(&label, result, counts);
@@ -481,9 +565,14 @@ async fn index_user(
     // such account cannot fail the whole fleet run (ENG-2141).
     if let Some(atuin_db) = safe_path_under(home, &[".local", "share", "atuin", "history.db"], false) {
         let label = format!("shell:{name}");
-        match open_atuin(&label, &atuin_db, mixedbread.is_some() || parquet.is_some(), counts) {
+        match open_atuin(
+            &label,
+            &atuin_db,
+            mixedbread.is_some() || parquet.is_some() || lake.is_some(),
+            counts,
+        ) {
             Ok(Atuin::Ready(adapter)) => {
-                let result = run_source(&label, &adapter, mixedbread, parquet).await;
+                let result = run_source(&label, &adapter, mixedbread, parquet, lake).await;
                 record(&label, result, counts);
             }
             Ok(Atuin::Skipped) => {}
@@ -499,7 +588,7 @@ async fn index_user(
         let result = async {
             let adapter = source_debug::DebugLogs::open_with(&debug_dir, host, name)
                 .with_context(|| format!("reading Claude debug logs for {name} at {}", debug_dir.display()))?;
-            run_source(&label, &adapter, mixedbread, parquet).await
+            run_source(&label, &adapter, mixedbread, parquet, lake).await
         }
         .await;
         record(&label, result, counts);
@@ -678,25 +767,26 @@ fn open_atuin(
 
 /// Fan one source out to every enabled sink.
 ///
-/// The parquet archive runs FIRST and the two sinks are INDEPENDENT: a slow or
-/// failing Mixedbread upload must not gate or skip the durable archive. The
-/// archive write is a fast local-S3 full-file put, while the Mixedbread leg is
-/// network-bound and rate-limited (429 + backoff), so ordering it first lands
-/// the queryable parquet in seconds instead of after a multi-hour upload. Each
-/// sink's error is captured separately and only combined at the end, so one
-/// sink's failure still lets the other run.
+/// The durable logs run FIRST (parquet, then the Iceberg lake) and every sink
+/// is INDEPENDENT: a slow or failing Mixedbread upload must not gate or skip a
+/// durable write. The log writes are fast object-store puts, while the
+/// Mixedbread leg is network-bound and rate-limited (429 + backoff), so
+/// ordering it last lands the queryable logs in seconds instead of after a
+/// multi-hour upload. Each sink's error is captured separately and only
+/// combined at the end, so one sink's failure still lets the others run.
 async fn run_source<A: SourceAdapter + Sync>(
     label: &str,
     adapter: &A,
     mixedbread: Option<Mixedbread<'_>>,
     parquet: Option<&ParquetReconciler>,
+    lake: Option<&IcebergReconciler>,
 ) -> anyhow::Result<()> {
     // A selected source with no sink is a misconfiguration, not a no-op: a missing
-    // `--mixedbread-store`/`--bucket` would otherwise drop the source silently
-    // while still counting as a success.
+    // `--mixedbread-store`/`--bucket`/`--catalog-uri` would otherwise drop the
+    // source silently while still counting as a success.
     anyhow::ensure!(
-        mixedbread.is_some() || parquet.is_some(),
-        "[{label}] no sink configured: pass --mixedbread-store and/or --bucket"
+        mixedbread.is_some() || parquet.is_some() || lake.is_some(),
+        "[{label}] no sink configured: pass --mixedbread-store, --bucket, and/or --catalog-uri"
     );
 
     // One pass over the adapter feeds every view (each sink used to re-run, and
@@ -717,6 +807,19 @@ async fn run_source<A: SourceAdapter + Sync>(
             Ok(report) => eprintln!("[{label}] parquet: wrote {} rows", report.rows),
             Err(error) => {
                 errors.push(anyhow::Error::new(error).context(format!("[{label}] parquet sync")));
+            }
+        }
+    }
+
+    if let Some(reconciler) = lake {
+        match reconciler.reconcile(&source, &documents).await {
+            Ok(report) if report.skipped => eprintln!("[{label}] lake: skipped (unchanged)"),
+            Ok(report) => eprintln!(
+                "[{label}] lake: appended {} upserts, {} tombstones",
+                report.upserts, report.deletes
+            ),
+            Err(error) => {
+                errors.push(anyhow::Error::new(error).context(format!("[{label}] lake sync")));
             }
         }
     }

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -26,7 +26,7 @@ use std::time::Duration;
 use anyhow::Context as _;
 use clap::Parser;
 use lake_iceberg::IcebergReconciler;
-use search_core::MixedbreadStore;
+use search_core::{MixedbreadStore, Store};
 use sink_mixedbread::MixedbreadReconciler;
 use sink_parquet::ParquetReconciler;
 
@@ -212,16 +212,19 @@ async fn main() -> anyhow::Result<()> {
     );
 
     // Consume mode (Iceberg corpus lake, full): fold the lake's revision log
-    // into its current document set and reconcile that back into Mixedbread —
-    // the lake's replay/rebuild path. Like the parquet consume below, emit and
-    // consume run as separate invocations of this binary.
+    // into its current per-source document sets and REPLACE each source's
+    // Mixedbread records with them — the lake's replay/rebuild path. Replace,
+    // not reconcile: the fold's absences are explicit tombstones, so the
+    // rebuild also deletes view records the lake has let go of, including a
+    // source whose records are all tombstoned. Like the parquet consume below,
+    // emit and consume run as separate invocations of this binary.
     if cli.from_iceberg {
         let mixedbread =
-            mixedbread.context("--from-iceberg requires --mixedbread-store (the reconcile target)")?;
+            mixedbread.context("--from-iceberg requires --mixedbread-store (the replace target)")?;
         let Lake { catalog, ident } = connect_lake(&cli).await?;
-        let documents =
-            lake_iceberg::read_all(catalog.as_ref(), &ident).await.context("reading the lake")?;
-        return finish(run_consume(documents, mixedbread).await);
+        let state =
+            lake_iceberg::read_state(catalog.as_ref(), &ident).await.context("reading the lake")?;
+        return finish(run_replace(state, mixedbread).await);
     }
 
     // Consume mode (Iceberg corpus lake, incremental): apply the changes since
@@ -347,11 +350,11 @@ async fn connect_lake(cli: &Cli) -> anyhow::Result<Lake> {
 
 /// Apply the lake's changes since `cursor` to Mixedbread, returning the
 /// snapshot the store is now caught up to (the next cursor).
-async fn run_lake_delta(
+async fn run_lake_delta<S: Store + Sync>(
     catalog: &dyn lake_iceberg::Catalog,
     ident: &lake_iceberg::TableIdent,
     cursor: i64,
-    mixedbread: Mixedbread<'_>,
+    mixedbread: MixedbreadReconciler<'_, S>,
 ) -> anyhow::Result<Option<i64>> {
     let delta = lake_iceberg::added_since(catalog, ident, cursor)
         .await
@@ -370,13 +373,13 @@ async fn run_lake_delta(
 
 /// Steady-state lake consume: cursor from `path`, delta applied to Mixedbread,
 /// new cursor written back. Bootstraps (absent file) and recovers (expired
-/// cursor) via a full rebuild. The apply is idempotent, so a crash before the
-/// cursor write replays safely on the next run.
-async fn run_cursor_consume(
+/// cursor) via a full replace rebuild. The apply is idempotent, so a crash
+/// before the cursor write replays safely on the next run.
+async fn run_cursor_consume<S: Store + Sync>(
     catalog: &dyn lake_iceberg::Catalog,
     ident: &lake_iceberg::TableIdent,
     path: &Path,
-    mixedbread: Mixedbread<'_>,
+    mixedbread: MixedbreadReconciler<'_, S>,
 ) -> Counts {
     let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
     let cursor = match read_cursor(path) {
@@ -414,25 +417,27 @@ async fn run_cursor_consume(
         }
     }
 
-    // Bootstrap / recovery: full rebuild, then store the snapshot read BEFORE
-    // the fold, so appends landing mid-rebuild are replayed next pass rather
-    // than skipped.
+    // Bootstrap / recovery: full rebuild with replace semantics — the cursor
+    // is gone, so tombstones appended while it was lost can never arrive as a
+    // delta, and only a full-state diff (deleting view records the lake no
+    // longer holds) can apply them before the new cursor buries them. The
+    // snapshot is read BEFORE the fold, so appends landing mid-rebuild are
+    // replayed next pass rather than skipped.
     let rebuild = async {
         let to_snapshot = lake_iceberg::current_snapshot_id(catalog, ident)
             .await
             .context("reading the lake snapshot")?;
-        let documents =
-            lake_iceberg::read_all(catalog, ident).await.context("reading the lake")?;
-        anyhow::Ok((to_snapshot, documents))
+        let state = lake_iceberg::read_state(catalog, ident).await.context("reading the lake")?;
+        anyhow::Ok((to_snapshot, state))
     }
     .await;
     match rebuild {
-        Ok((to_snapshot, documents)) => {
-            let consume = run_consume(documents, mixedbread).await;
-            counts.indexed += consume.indexed;
-            counts.skipped += consume.skipped;
-            counts.failures += consume.failures;
-            if consume.failures == 0
+        Ok((to_snapshot, state)) => {
+            let replace = run_replace(state, mixedbread).await;
+            counts.indexed += replace.indexed;
+            counts.skipped += replace.skipped;
+            counts.failures += replace.failures;
+            if replace.failures == 0
                 && let Some(snapshot) = to_snapshot
             {
                 record("lake-cursor", write_cursor(path, snapshot), &mut counts);
@@ -653,12 +658,44 @@ async fn consume_parquet(config: &source_parquet::Config, mixedbread: Mixedbread
     run_consume(documents, mixedbread).await
 }
 
+/// Replace each lake source's Mixedbread records with the lake's live fold:
+/// upload the new or changed, delete the records the lake no longer holds.
+///
+/// Only sources present in the lake are touched, so a store shared with
+/// directly indexed sources (code repos) keeps those intact — and a source
+/// whose lake records are all tombstoned still gets its view records deleted.
+/// The lake consume paths use this instead of [`run_consume`] because the
+/// lake's absences are explicit tombstone folds, while the parquet log has no
+/// tombstones and its absences stay protective.
+async fn run_replace<S: Store + Sync>(
+    state: lake_iceberg::LakeState,
+    mixedbread: MixedbreadReconciler<'_, S>,
+) -> Counts {
+    let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
+    for (source, documents) in state.sources {
+        let label = format!("replace:{source}");
+        let result = mixedbread
+            .replace(&Source::new(source), &documents)
+            .await
+            .map(|report| {
+                eprintln!(
+                    "[{label}] mixedbread: uploaded {}, skipped {}, deleted {} of {}",
+                    report.uploaded, report.skipped, report.deleted, report.total
+                );
+            })
+            .with_context(|| format!("[{label}] Mixedbread replace"));
+        record(&label, result, &mut counts);
+    }
+    counts
+}
+
 /// Reconcile already-read documents into Mixedbread, grouped by their `source`.
 ///
 /// Grouping keeps each Mixedbread reconcile scoped to one source, exactly as the
 /// direct per-source ingestion did, so a consumed record dedups against its own
 /// source and never touches another's. The parquet consume path reads its
-/// documents first, then shares this reconcile.
+/// documents first, then shares this reconcile (the lake paths replace instead;
+/// see [`run_replace`]).
 async fn run_consume(documents: Vec<Document>, mixedbread: Mixedbread<'_>) -> Counts {
     let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
     let mut by_source: BTreeMap<String, Vec<Document>> = BTreeMap::new();
@@ -1036,11 +1073,20 @@ async fn run_source<A: SourceAdapter + Sync>(
 mod tests {
     #![expect(clippy::expect_used, reason = "tests assert observable filesystem outcomes")]
 
+    use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use iceberg::CatalogBuilder as _;
+    use lake_iceberg::IcebergReconciler;
+    use search_core::{MemoryStore, Store as _};
+    use sink_mixedbread::MixedbreadReconciler;
+    use source_meta::{Reconciler as _, Source};
 
     use super::{
         Atuin, Counts, archive_prefix, finish, open_atuin, parse_user, read_cursor,
-        safe_path_under, user_prefix, write_cursor,
+        run_cursor_consume, safe_path_under, user_prefix, write_cursor,
     };
 
     /// Create a valid sqlite db with no `history` table at `path`, mirroring
@@ -1206,5 +1252,84 @@ mod tests {
             user_prefix(&base, "bob"),
             "two users must not share a parquet prefix"
         );
+    }
+
+    /// A `source=test` document for the lake-consume tests.
+    fn lake_doc(id: &str) -> source_meta::Document {
+        let body = format!("body of {id}");
+        let content_hash = source_meta::hash_body(body.as_bytes());
+        source_meta::Document {
+            external_id: id.to_owned(),
+            file_name: id.to_owned(),
+            mime: "text/plain",
+            body: body.into_bytes(),
+            meta_json: serde_json::json!({
+                "source": "test",
+                "external_id": id,
+                "content_hash": content_hash,
+            }),
+            content_hash,
+        }
+    }
+
+    /// The store's current external ids, for asserting view state.
+    async fn stored_ids(store: &MemoryStore) -> Vec<String> {
+        let mut ids: Vec<String> =
+            store.list_external_ids("s", None).await.expect("list").into_iter().collect();
+        ids.sort();
+        ids
+    }
+
+    #[tokio::test]
+    async fn cursor_rebuild_gcs_tombstones_missed_while_the_cursor_was_gone() {
+        // The recovery contract: when the cursor is absent or expired, the
+        // rebuild must not just re-upload the lake's current documents — it
+        // must also DELETE view records whose lake rows were tombstoned while
+        // no consumer was watching, because writing the new cursor buries
+        // those tombstones forever.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let warehouse = format!("file://{}", dir.path().display());
+        let catalog = iceberg::memory::MemoryCatalogBuilder::default()
+            .load(
+                "lake",
+                HashMap::from([(iceberg::memory::MEMORY_CATALOG_WAREHOUSE.to_owned(), warehouse)]),
+            )
+            .await
+            .expect("memory catalog");
+        let catalog: Arc<dyn lake_iceberg::Catalog> = Arc::new(catalog);
+        let ident = lake_iceberg::ensure_table(catalog.as_ref()).await.expect("ensure table");
+        let sink = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-1");
+        let source = Source::new("test");
+        let store = MemoryStore::new();
+        let mixedbread =
+            MixedbreadReconciler { store: &store, name: "s", index_timeout: Duration::from_secs(1) };
+        let cursor = dir.path().join("cursor.json");
+
+        // Bootstrap (absent cursor file): a full rebuild lands both documents.
+        sink.reconcile(&source, &[lake_doc("a"), lake_doc("b")]).await.expect("seed");
+        let counts = run_cursor_consume(catalog.as_ref(), &ident, &cursor, mixedbread).await;
+        assert_eq!(counts.failures, 0);
+        assert_eq!(stored_ids(&store).await, ["a", "b"]);
+        read_cursor(&cursor).expect("cursor readable").expect("cursor written");
+
+        // While no consumer watches, `a` is tombstoned — then the cursor
+        // expires (an unknown snapshot id is exactly what expiry surfaces as).
+        sink.reconcile(&source, &[lake_doc("b")]).await.expect("tombstone a");
+        write_cursor(&cursor, 0).expect("plant an expired cursor");
+        let counts = run_cursor_consume(catalog.as_ref(), &ident, &cursor, mixedbread).await;
+        assert_eq!(counts.failures, 0);
+        assert_eq!(
+            stored_ids(&store).await,
+            ["b"],
+            "the rebuild must GC the record tombstoned while the cursor was gone"
+        );
+        let rebuilt = read_cursor(&cursor).expect("cursor readable").expect("cursor rewritten");
+        assert_ne!(rebuilt, 0, "the rebuild must store the snapshot it read");
+
+        // Steady state after the rebuild: the next change arrives as a delta.
+        sink.reconcile(&source, &[lake_doc("c")]).await.expect("replace b with c");
+        let counts = run_cursor_consume(catalog.as_ref(), &ident, &cursor, mixedbread).await;
+        assert_eq!(counts.failures, 0);
+        assert_eq!(stored_ids(&store).await, ["c"], "the delta applies b's tombstone and c");
     }
 }

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -24,13 +24,14 @@ use std::time::Duration;
 use anyhow::Context as _;
 use clap::Parser;
 use search_core::MixedbreadStore;
-use sink_mixedbread::sync_documents;
+use sink_mixedbread::MixedbreadReconciler;
+use sink_parquet::ParquetReconciler;
 
 /// Manifest limits for code repos, matching `search-core`'s defaults.
 const MAX_FILE_BYTES: u64 = 1024 * 1024;
 /// Cap on new files uploaded per code sync (a runaway guard).
 const MAX_FILES: usize = 10_000;
-use source_meta::{Document, Source, SourceAdapter, keys};
+use source_meta::{Document, Reconciler as _, Source, SourceAdapter, keys};
 
 /// How long to wait for Mixedbread to finish embedding new documents.
 const INDEX_TIMEOUT: Duration = Duration::from_mins(2);
@@ -123,13 +124,9 @@ struct Cli {
     host: Option<String>,
 }
 
-/// The Mixedbread sink for a run: the connected store and the store name to
-/// sync into. Passed together wherever a source may fan out to Mixedbread.
-#[derive(Clone, Copy)]
-struct Mixedbread<'a> {
-    store: &'a MixedbreadStore,
-    name: &'a str,
-}
+/// The Mixedbread view for a run: the connected store, the store name, and the
+/// embedding wait, passed together wherever a source may fan out to Mixedbread.
+type Mixedbread<'a> = MixedbreadReconciler<'a, MixedbreadStore>;
 
 /// Per-run tally of how many sources were indexed, soft-skipped, or failed.
 ///
@@ -163,8 +160,10 @@ async fn main() -> anyhow::Result<()> {
         }
         None => None,
     };
-    let mixedbread =
-        store.as_ref().zip(cli.mixedbread_store.as_deref()).map(|(store, name)| Mixedbread { store, name });
+    let mixedbread = store
+        .as_ref()
+        .zip(cli.mixedbread_store.as_deref())
+        .map(|(store, name)| Mixedbread { store, name, index_timeout: INDEX_TIMEOUT });
 
     // Consume mode (parquet corpus log): read the per-source `data.parquet` files
     // `sink-parquet` wrote at this prefix under `--bucket` and reconcile them back
@@ -193,14 +192,19 @@ async fn main() -> anyhow::Result<()> {
         // and the per-host manifest skip-gate makes them ping-pong every tick.
         // `host`/`user`/`source` are all hive partitions, matching the old
         // history-ship layout (`host=<host>/user=<user>/...`).
+        //
+        // Connecting here (once per run, not once per source) also surfaces a
+        // misconfigured endpoint or missing credentials at startup instead of
+        // as a per-source failure.
         Some(bucket) => {
             let host = resolve_host(&cli).context("resolving host for the parquet archive prefix")?;
-            Some(sink_parquet::Config {
+            let config = sink_parquet::Config {
                 bucket: bucket.clone(),
                 endpoint: cli.endpoint.clone(),
                 region: cli.region.clone(),
                 prefix: archive_prefix(&cli.prefix, &host),
-            })
+            };
+            Some(config.connect().context("building the S3 client for the parquet archive")?)
         }
         None => None,
     };
@@ -258,7 +262,7 @@ const fn any_source_selected(cli: &Cli) -> bool {
 async fn run_sources(
     cli: &Cli,
     mixedbread: Option<Mixedbread<'_>>,
-    parquet: Option<&sink_parquet::Config>,
+    parquet: Option<&ParquetReconciler>,
 ) -> Counts {
     let home = dirs::home_dir();
     let default = |suffix: &str| home.as_ref().map(|h| h.join(suffix));
@@ -286,7 +290,7 @@ async fn run_sources(
         record("codex", result, &mut counts);
     }
     if let Some(db) = atuin {
-        match open_atuin("shell", &db, mixedbread, parquet, &mut counts) {
+        match open_atuin("shell", &db, mixedbread.is_some() || parquet.is_some(), &mut counts) {
             Ok(Atuin::Ready(adapter)) => {
                 let result = run_source("shell", &adapter, mixedbread, parquet).await;
                 record("shell", result, &mut counts);
@@ -349,7 +353,7 @@ async fn run_sources(
 async fn run_users(
     cli: &Cli,
     mixedbread: Option<Mixedbread<'_>>,
-    parquet: Option<&sink_parquet::Config>,
+    parquet: Option<&ParquetReconciler>,
     counts: &mut Counts,
 ) {
     let host = match resolve_host(cli) {
@@ -371,24 +375,6 @@ async fn run_users(
                 counts.failures += 1;
             }
         }
-    }
-}
-
-/// An in-memory source: documents already tagged with one `source`, used by
-/// [`run_consume`] to reuse the per-source Mixedbread reconcile (which scopes its
-/// skip-if-unchanged listing by `source`).
-struct VecSource {
-    source: Source,
-    documents: Vec<Document>,
-}
-
-impl SourceAdapter for VecSource {
-    type Error = std::convert::Infallible;
-    fn source(&self) -> Source {
-        self.source.clone()
-    }
-    fn documents(&self) -> impl Iterator<Item = Result<Document, Self::Error>> + Send {
-        self.documents.clone().into_iter().map(Ok)
     }
 }
 
@@ -424,11 +410,10 @@ async fn run_consume(documents: Vec<Document>, mixedbread: Mixedbread<'_>) -> Co
         by_source.entry(source).or_default().push(document);
     }
 
-    let Mixedbread { store, name } = mixedbread;
     for (source, documents) in by_source {
         let label = format!("consume:{source}");
-        let adapter = VecSource { source: Source::new(source), documents };
-        let result = sync_documents(&adapter, store, name, INDEX_TIMEOUT, |_, _| {})
+        let result = mixedbread
+            .reconcile(&Source::new(source), &documents)
             .await
             .map(|report| {
                 eprintln!(
@@ -455,7 +440,7 @@ async fn index_user(
     user: &User,
     host: &str,
     mixedbread: Option<Mixedbread<'_>>,
-    parquet: Option<&sink_parquet::Config>,
+    parquet: Option<&ParquetReconciler>,
     counts: &mut Counts,
 ) {
     let name = user.name.as_str();
@@ -465,7 +450,8 @@ async fn index_user(
     // in full per run, and every account produces the same `source=claude` etc.).
     // The Mixedbread sink needs no such scoping: its `external_id`s already carry
     // the per-message uuid, so records never collide across users there.
-    let user_parquet = parquet.map(|config| user_scoped_parquet(config, name));
+    let user_parquet =
+        parquet.map(|reconciler| reconciler.with_prefix(user_prefix(&reconciler.prefix, name)));
     let parquet = user_parquet.as_ref();
     if let Some(claude_dir) = safe_path_under(home, &[".claude", "projects"], true) {
         let label = format!("claude:{name}");
@@ -495,7 +481,7 @@ async fn index_user(
     // such account cannot fail the whole fleet run (ENG-2141).
     if let Some(atuin_db) = safe_path_under(home, &[".local", "share", "atuin", "history.db"], false) {
         let label = format!("shell:{name}");
-        match open_atuin(&label, &atuin_db, mixedbread, parquet, counts) {
+        match open_atuin(&label, &atuin_db, mixedbread.is_some() || parquet.is_some(), counts) {
             Ok(Atuin::Ready(adapter)) => {
                 let result = run_source(&label, &adapter, mixedbread, parquet).await;
                 record(&label, result, counts);
@@ -545,7 +531,7 @@ fn archive_prefix(base: &str, host: &str) -> String {
     format!("{base}/host={host}")
 }
 
-/// User-scope a parquet config for the multi-user `--user` path:
+/// User-scope a parquet prefix for the multi-user `--user` path:
 /// `<host-prefix>/user=<name>`. `sink-parquet` writes one full-file-overwrite
 /// `source=<source>/data.parquet` per (prefix, source), and several accounts on
 /// one host produce the same `source=claude` (etc.), so without a `user` segment
@@ -553,13 +539,8 @@ fn archive_prefix(base: &str, host: &str) -> String {
 /// [`parse_user`] to a safe charset (no `/`/`=`), so it cannot escape the
 /// partition. `user` is the inner hive partition under `host`, matching the old
 /// history-ship `host=<host>/user=<user>/...` layout.
-fn user_scoped_parquet(config: &sink_parquet::Config, name: &str) -> sink_parquet::Config {
-    sink_parquet::Config {
-        bucket: config.bucket.clone(),
-        endpoint: config.endpoint.clone(),
-        region: config.region.clone(),
-        prefix: format!("{}/user={name}", config.prefix),
-    }
+fn user_prefix(base: &str, name: &str) -> String {
+    format!("{base}/user={name}")
 }
 
 /// Resolve a user-controlled subpath under a trusted `home`, refusing to follow
@@ -617,7 +598,7 @@ async fn index_code(
     repo_dir: &std::path::Path,
     mixedbread: Option<Mixedbread<'_>>,
 ) -> anyhow::Result<()> {
-    let Some(Mixedbread { store, name }) = mixedbread else {
+    let Some(Mixedbread { store, name, .. }) = mixedbread else {
         anyhow::bail!("--code-repo requires --mixedbread-store (code is semantic-search only)");
     };
     let manifest = search_core::Manifest::build(repo_dir, None, MAX_FILE_BYTES)
@@ -671,8 +652,7 @@ enum Atuin {
 fn open_atuin(
     label: &str,
     db: &Path,
-    mixedbread: Option<Mixedbread<'_>>,
-    parquet: Option<&sink_parquet::Config>,
+    has_sink: bool,
     counts: &mut Counts,
 ) -> anyhow::Result<Atuin> {
     match source_atuin::AtuinHistory::open(db) {
@@ -684,7 +664,7 @@ fn open_atuin(
             // db cannot let a sink-less run exit 0 when the identical config fails
             // once the `history` table exists.
             anyhow::ensure!(
-                mixedbread.is_some() || parquet.is_some(),
+                has_sink,
                 "[{label}] no sink configured: pass --mixedbread-store and/or --bucket"
             );
             eprintln!("[{label}] skipped: {error} ({db})", db = db.display());
@@ -709,7 +689,7 @@ async fn run_source<A: SourceAdapter + Sync>(
     label: &str,
     adapter: &A,
     mixedbread: Option<Mixedbread<'_>>,
-    parquet: Option<&sink_parquet::Config>,
+    parquet: Option<&ParquetReconciler>,
 ) -> anyhow::Result<()> {
     // A selected source with no sink is a misconfiguration, not a no-op: a missing
     // `--mixedbread-store`/`--bucket` would otherwise drop the source silently
@@ -719,10 +699,20 @@ async fn run_source<A: SourceAdapter + Sync>(
         "[{label}] no sink configured: pass --mixedbread-store and/or --bucket"
     );
 
+    // One pass over the adapter feeds every view (each sink used to re-run, and
+    // re-parse, the source's iterator independently). An adapter error fails the
+    // source before either view is touched, exactly as it failed both sinks
+    // mid-iteration before.
+    let source = adapter.source();
+    let documents = adapter
+        .documents()
+        .collect::<Result<Vec<Document>, _>>()
+        .with_context(|| format!("[{label}] reading documents"))?;
+
     let mut errors: Vec<anyhow::Error> = Vec::new();
 
-    if let Some(config) = parquet {
-        match sink_parquet::sync(adapter, config).await {
+    if let Some(reconciler) = parquet {
+        match reconciler.reconcile(&source, &documents).await {
             Ok(report) if report.skipped => eprintln!("[{label}] parquet: skipped (unchanged)"),
             Ok(report) => eprintln!("[{label}] parquet: wrote {} rows", report.rows),
             Err(error) => {
@@ -731,8 +721,8 @@ async fn run_source<A: SourceAdapter + Sync>(
         }
     }
 
-    if let Some(Mixedbread { store, name }) = mixedbread {
-        match sync_documents(adapter, store, name, INDEX_TIMEOUT, |_, _| {}).await {
+    if let Some(reconciler) = mixedbread {
+        match reconciler.reconcile(&source, &documents).await {
             Ok(report) => eprintln!(
                 "[{label}] mixedbread: uploaded {}, skipped {} of {}",
                 report.uploaded, report.skipped, report.total
@@ -764,7 +754,7 @@ mod tests {
 
     use super::{
         Atuin, Counts, archive_prefix, finish, open_atuin, parse_user, safe_path_under,
-        user_scoped_parquet,
+        user_prefix,
     };
 
     /// Create a valid sqlite db with no `history` table at `path`, mirroring
@@ -773,30 +763,18 @@ mod tests {
         rusqlite::Connection::open(path).expect("create empty sqlite db");
     }
 
-    /// A throwaway parquet sink config so `open_atuin`'s sink validation passes;
-    /// the bucket is never written to in these tests (they assert open/skip
-    /// behavior). `open_atuin`'s validation only checks that a sink is present.
-    fn parquet_sink() -> sink_parquet::Config {
-        sink_parquet::Config {
-            bucket: "test-bucket".to_string(),
-            endpoint: None,
-            region: "auto".to_string(),
-            prefix: "corpus".to_string(),
-        }
-    }
-
     #[test]
     fn uninitialized_atuin_db_is_soft_skipped_and_run_succeeds() {
         // ENG-2141: one account whose atuin db exists but has no `history` table
         // (atuin never ran there) must be a logged soft skip, not a failure, so
-        // the whole indexing unit still succeeds.
+        // the whole indexing unit still succeeds. `has_sink` is true: a sink is
+        // configured, it just never gets written in this test.
         let temp = tempfile::tempdir().expect("tempdir");
         let db = temp.path().join("history.db");
         make_uninitialized_db(&db);
 
         let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
-        let sink = parquet_sink();
-        let outcome = open_atuin("shell:tester", &db, None, Some(&sink), &mut counts)
+        let outcome = open_atuin("shell:tester", &db, true, &mut counts)
             .expect("uninitialized db is not an error");
 
         assert!(matches!(outcome, Atuin::Skipped), "uninitialized db must be skipped");
@@ -814,9 +792,8 @@ mod tests {
         let db = temp.path().join("does-not-exist.db");
 
         let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
-        let sink = parquet_sink();
         assert!(
-            open_atuin("shell:tester", &db, None, Some(&sink), &mut counts).is_err(),
+            open_atuin("shell:tester", &db, true, &mut counts).is_err(),
             "a missing db file must remain a real error, not a soft skip"
         );
         assert_eq!(counts.skipped, 0, "a real error must not be tallied as a skip");
@@ -834,7 +811,7 @@ mod tests {
 
         let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
         assert!(
-            open_atuin("shell:tester", &db, None, None, &mut counts).is_err(),
+            open_atuin("shell:tester", &db, false, &mut counts).is_err(),
             "an uninitialized db with no sink must error, not silently skip"
         );
         assert_eq!(counts.skipped, 0, "a misconfiguration must not be tallied as a skip");
@@ -909,23 +886,16 @@ mod tests {
     }
 
     #[test]
-    fn user_scoped_parquet_adds_user_partition() {
+    fn user_prefix_adds_user_partition() {
         // Several accounts on one host produce the same `source=claude`, so the
         // per-user parquet log must add a `user=` segment under the host prefix or
         // they clobber each other in the full-file-overwrite sink.
-        let base = sink_parquet::Config {
-            bucket: "corpus-bucket".to_string(),
-            endpoint: Some("http://127.0.0.1:9010".to_string()),
-            region: "auto".to_string(),
-            prefix: archive_prefix("corpus", "hil-compute-1"),
-        };
-        let alice = user_scoped_parquet(&base, "alice");
-        let bob = user_scoped_parquet(&base, "bob");
-        assert_eq!(alice.prefix, "corpus/host=hil-compute-1/user=alice");
-        assert_ne!(alice.prefix, bob.prefix, "two users must not share a parquet prefix");
-        // Bucket/endpoint/region carry through unchanged; only the prefix scopes.
-        assert_eq!(alice.bucket, base.bucket);
-        assert_eq!(alice.endpoint, base.endpoint);
-        assert_eq!(alice.region, base.region);
+        let base = archive_prefix("corpus", "hil-compute-1");
+        assert_eq!(user_prefix(&base, "alice"), "corpus/host=hil-compute-1/user=alice");
+        assert_ne!(
+            user_prefix(&base, "alice"),
+            user_prefix(&base, "bob"),
+            "two users must not share a parquet prefix"
+        );
     }
 }

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -104,7 +104,7 @@ struct Cli {
     /// Steady-state lake consume: read the cursor from this file, apply the
     /// delta to Mixedbread, write the new cursor back. An absent file or an
     /// expired cursor falls back to a full rebuild. The fleet passes a
-    /// StateDirectory path (cursor.json).
+    /// `StateDirectory` path (cursor.json).
     #[arg(long, env = "INDEXER_CURSOR_FILE")]
     cursor_file: Option<PathBuf>,
 
@@ -218,7 +218,7 @@ async fn main() -> anyhow::Result<()> {
     if cli.from_iceberg {
         let mixedbread =
             mixedbread.context("--from-iceberg requires --mixedbread-store (the reconcile target)")?;
-        let (catalog, ident) = connect_lake(&cli).await?;
+        let Lake { catalog, ident } = connect_lake(&cli).await?;
         let documents =
             lake_iceberg::read_all(catalog.as_ref(), &ident).await.context("reading the lake")?;
         return finish(run_consume(documents, mixedbread).await);
@@ -229,7 +229,7 @@ async fn main() -> anyhow::Result<()> {
     if let Some(cursor) = cli.from_snapshot {
         let mixedbread =
             mixedbread.context("--from-snapshot requires --mixedbread-store (the apply target)")?;
-        let (catalog, ident) = connect_lake(&cli).await?;
+        let Lake { catalog, ident } = connect_lake(&cli).await?;
         let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
         let result =
             run_lake_delta(catalog.as_ref(), &ident, cursor, mixedbread).await.map(|_| ());
@@ -243,7 +243,7 @@ async fn main() -> anyhow::Result<()> {
     if let Some(path) = cli.cursor_file.clone() {
         let mixedbread =
             mixedbread.context("--cursor-file requires --mixedbread-store (the apply target)")?;
-        let (catalog, ident) = connect_lake(&cli).await?;
+        let Lake { catalog, ident } = connect_lake(&cli).await?;
         return finish(run_cursor_consume(catalog.as_ref(), &ident, &path, mixedbread).await);
     }
 
@@ -295,7 +295,7 @@ async fn main() -> anyhow::Result<()> {
     // surfaces a bad catalog config at startup, like the parquet connect above.
     let lake = match cli.catalog_uri.as_ref() {
         Some(_) => {
-            let (catalog, ident) = connect_lake(&cli).await?;
+            let Lake { catalog, ident } = connect_lake(&cli).await?;
             let host = resolve_host(&cli).context("resolving host for the lake")?;
             Some(IcebergReconciler::new(catalog, ident, host))
         }
@@ -328,17 +328,21 @@ fn lake_config(cli: &Cli) -> anyhow::Result<lake_iceberg::Config> {
     })
 }
 
+/// A connected lake: the catalog handle and the corpus table within it.
+struct Lake {
+    catalog: std::sync::Arc<dyn lake_iceberg::Catalog>,
+    ident: lake_iceberg::TableIdent,
+}
+
 /// Connect the lake's catalog and ensure its table, shared by the lake sink
 /// and every lake consume mode. Failing here surfaces a bad catalog config at
 /// startup.
-async fn connect_lake(
-    cli: &Cli,
-) -> anyhow::Result<(std::sync::Arc<dyn lake_iceberg::Catalog>, lake_iceberg::TableIdent)> {
+async fn connect_lake(cli: &Cli) -> anyhow::Result<Lake> {
     let config = lake_config(cli)?;
     let catalog = config.connect().await.context("connecting the Iceberg catalog")?;
     let ident =
         lake_iceberg::ensure_table(catalog.as_ref()).await.context("ensuring the lake table")?;
-    Ok((catalog, ident))
+    Ok(Lake { catalog, ident })
 }
 
 /// Apply the lake's changes since `cursor` to Mixedbread, returning the
@@ -388,11 +392,9 @@ async fn run_cursor_consume(
     if let Some(cursor) = cursor {
         match run_lake_delta(catalog, ident, cursor, mixedbread).await {
             Ok(to_snapshot) => {
-                let result = match to_snapshot {
-                    Some(snapshot) => write_cursor(path, snapshot),
-                    // An empty table has no snapshot to store; keep the old cursor.
-                    None => Ok(()),
-                };
+                // An empty table has no snapshot to store; keep the old cursor.
+                let result = to_snapshot
+                    .map_or_else(|| Ok(()), |snapshot| write_cursor(path, snapshot));
                 record("lake-cursor", result, &mut counts);
                 return counts;
             }

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -95,6 +95,19 @@ struct Cli {
     #[arg(long, env = "INDEXER_FROM_ICEBERG")]
     from_iceberg: bool,
 
+    /// Apply the lake's changes since this snapshot to Mixedbread (incremental
+    /// catch-up from an explicit cursor); pair with --mixedbread-store and the
+    /// --catalog-* flags. Prints the snapshot to use as the next cursor.
+    #[arg(long, env = "INDEXER_FROM_SNAPSHOT")]
+    from_snapshot: Option<i64>,
+
+    /// Steady-state lake consume: read the cursor from this file, apply the
+    /// delta to Mixedbread, write the new cursor back. An absent file or an
+    /// expired cursor falls back to a full rebuild. The fleet passes a
+    /// StateDirectory path (cursor.json).
+    #[arg(long, env = "INDEXER_CURSOR_FILE")]
+    cursor_file: Option<PathBuf>,
+
     /// Index local agent/shell history (claude, codex, atuin) at their default
     /// paths, in addition to any explicit `--*` overrides below.
     #[arg(long)]
@@ -187,24 +200,51 @@ async fn main() -> anyhow::Result<()> {
         .zip(cli.mixedbread_store.as_deref())
         .map(|(store, name)| Mixedbread { store, name, index_timeout: INDEX_TIMEOUT });
 
-    // Consume mode (Iceberg corpus lake): fold the lake's revision log into its
-    // current document set and reconcile that back into Mixedbread — the lake's
-    // replay/rebuild path. Like the parquet consume below, emit and consume run
-    // as separate invocations of this binary.
+    // The consume modes replay a log into Mixedbread instead of scanning local
+    // sources; exactly one log (and one read discipline) per invocation.
+    let consume_modes = usize::from(cli.from_parquet_prefix.is_some())
+        + usize::from(cli.from_iceberg)
+        + usize::from(cli.from_snapshot.is_some())
+        + usize::from(cli.cursor_file.is_some());
+    anyhow::ensure!(
+        consume_modes <= 1,
+        "--from-parquet-prefix, --from-iceberg, --from-snapshot, and --cursor-file are mutually exclusive consume modes"
+    );
+
+    // Consume mode (Iceberg corpus lake, full): fold the lake's revision log
+    // into its current document set and reconcile that back into Mixedbread —
+    // the lake's replay/rebuild path. Like the parquet consume below, emit and
+    // consume run as separate invocations of this binary.
     if cli.from_iceberg {
-        anyhow::ensure!(
-            cli.from_parquet_prefix.is_none(),
-            "--from-iceberg and --from-parquet-prefix are mutually exclusive (one log at a time)"
-        );
         let mixedbread =
             mixedbread.context("--from-iceberg requires --mixedbread-store (the reconcile target)")?;
-        let config = lake_config(&cli)?;
-        let catalog = config.connect().await.context("connecting the Iceberg catalog")?;
-        let ident =
-            lake_iceberg::ensure_table(catalog.as_ref()).await.context("ensuring the lake table")?;
+        let (catalog, ident) = connect_lake(&cli).await?;
         let documents =
             lake_iceberg::read_all(catalog.as_ref(), &ident).await.context("reading the lake")?;
         return finish(run_consume(documents, mixedbread).await);
+    }
+
+    // Consume mode (Iceberg corpus lake, incremental): apply the changes since
+    // an explicit cursor. Stateless — the caller owns the cursor.
+    if let Some(cursor) = cli.from_snapshot {
+        let mixedbread =
+            mixedbread.context("--from-snapshot requires --mixedbread-store (the apply target)")?;
+        let (catalog, ident) = connect_lake(&cli).await?;
+        let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
+        let result =
+            run_lake_delta(catalog.as_ref(), &ident, cursor, mixedbread).await.map(|_| ());
+        record("lake-delta", result, &mut counts);
+        return finish(counts);
+    }
+
+    // Consume mode (Iceberg corpus lake, steady state): the cursor lives in a
+    // file; absent or expired falls back to a full rebuild. This is the
+    // deployed view-catch-up invocation.
+    if let Some(path) = cli.cursor_file.clone() {
+        let mixedbread =
+            mixedbread.context("--cursor-file requires --mixedbread-store (the apply target)")?;
+        let (catalog, ident) = connect_lake(&cli).await?;
+        return finish(run_cursor_consume(catalog.as_ref(), &ident, &path, mixedbread).await);
     }
 
     // Consume mode (parquet corpus log): read the per-source `data.parquet` files
@@ -255,11 +295,7 @@ async fn main() -> anyhow::Result<()> {
     // surfaces a bad catalog config at startup, like the parquet connect above.
     let lake = match cli.catalog_uri.as_ref() {
         Some(_) => {
-            let config = lake_config(&cli)?;
-            let catalog = config.connect().await.context("connecting the Iceberg catalog")?;
-            let ident = lake_iceberg::ensure_table(catalog.as_ref())
-                .await
-                .context("ensuring the lake table")?;
+            let (catalog, ident) = connect_lake(&cli).await?;
             let host = resolve_host(&cli).context("resolving host for the lake")?;
             Some(IcebergReconciler::new(catalog, ident, host))
         }
@@ -290,6 +326,151 @@ fn lake_config(cli: &Cli) -> anyhow::Result<lake_iceberg::Config> {
         s3_endpoint: cli.endpoint.clone(),
         s3_region: cli.region.clone(),
     })
+}
+
+/// Connect the lake's catalog and ensure its table, shared by the lake sink
+/// and every lake consume mode. Failing here surfaces a bad catalog config at
+/// startup.
+async fn connect_lake(
+    cli: &Cli,
+) -> anyhow::Result<(std::sync::Arc<dyn lake_iceberg::Catalog>, lake_iceberg::TableIdent)> {
+    let config = lake_config(cli)?;
+    let catalog = config.connect().await.context("connecting the Iceberg catalog")?;
+    let ident =
+        lake_iceberg::ensure_table(catalog.as_ref()).await.context("ensuring the lake table")?;
+    Ok((catalog, ident))
+}
+
+/// Apply the lake's changes since `cursor` to Mixedbread, returning the
+/// snapshot the store is now caught up to (the next cursor).
+async fn run_lake_delta(
+    catalog: &dyn lake_iceberg::Catalog,
+    ident: &lake_iceberg::TableIdent,
+    cursor: i64,
+    mixedbread: Mixedbread<'_>,
+) -> anyhow::Result<Option<i64>> {
+    let delta = lake_iceberg::added_since(catalog, ident, cursor)
+        .await
+        .context("reading the lake delta")?;
+    let to_snapshot = delta.to_snapshot;
+    let report = mixedbread
+        .apply(delta.upserts, &delta.deletes)
+        .await
+        .context("applying the lake delta to Mixedbread")?;
+    eprintln!(
+        "[lake-delta] applied {} upserts, {} deletes (cursor {cursor} -> {to_snapshot:?})",
+        report.uploaded, report.deleted
+    );
+    Ok(to_snapshot)
+}
+
+/// Steady-state lake consume: cursor from `path`, delta applied to Mixedbread,
+/// new cursor written back. Bootstraps (absent file) and recovers (expired
+/// cursor) via a full rebuild. The apply is idempotent, so a crash before the
+/// cursor write replays safely on the next run.
+async fn run_cursor_consume(
+    catalog: &dyn lake_iceberg::Catalog,
+    ident: &lake_iceberg::TableIdent,
+    path: &Path,
+    mixedbread: Mixedbread<'_>,
+) -> Counts {
+    let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
+    let cursor = match read_cursor(path) {
+        Ok(cursor) => cursor,
+        Err(error) => {
+            // A malformed cursor file is a real error, not a silent rebuild: it
+            // means state corruption worth a human look.
+            record("lake-cursor", Err(error), &mut counts);
+            return counts;
+        }
+    };
+
+    if let Some(cursor) = cursor {
+        match run_lake_delta(catalog, ident, cursor, mixedbread).await {
+            Ok(to_snapshot) => {
+                let result = match to_snapshot {
+                    Some(snapshot) => write_cursor(path, snapshot),
+                    // An empty table has no snapshot to store; keep the old cursor.
+                    None => Ok(()),
+                };
+                record("lake-cursor", result, &mut counts);
+                return counts;
+            }
+            // The one recoverable failure: snapshot expiration outran the
+            // cursor. Fall through to the full rebuild below.
+            Err(error)
+                if error
+                    .downcast_ref::<lake_iceberg::Error>()
+                    .is_some_and(|e| matches!(e, lake_iceberg::Error::CursorNotFound { .. })) =>
+            {
+                eprintln!("[lake-cursor] cursor {cursor} expired; falling back to a full rebuild");
+            }
+            Err(error) => {
+                record("lake-cursor", Err(error), &mut counts);
+                return counts;
+            }
+        }
+    }
+
+    // Bootstrap / recovery: full rebuild, then store the snapshot read BEFORE
+    // the fold, so appends landing mid-rebuild are replayed next pass rather
+    // than skipped.
+    let rebuild = async {
+        let to_snapshot = lake_iceberg::current_snapshot_id(catalog, ident)
+            .await
+            .context("reading the lake snapshot")?;
+        let documents =
+            lake_iceberg::read_all(catalog, ident).await.context("reading the lake")?;
+        anyhow::Ok((to_snapshot, documents))
+    }
+    .await;
+    match rebuild {
+        Ok((to_snapshot, documents)) => {
+            let consume = run_consume(documents, mixedbread).await;
+            counts.indexed += consume.indexed;
+            counts.skipped += consume.skipped;
+            counts.failures += consume.failures;
+            if consume.failures == 0
+                && let Some(snapshot) = to_snapshot
+            {
+                record("lake-cursor", write_cursor(path, snapshot), &mut counts);
+            }
+        }
+        Err(error) => record("lake-cursor", Err(error), &mut counts),
+    }
+    counts
+}
+
+/// Read the cursor file: `Ok(None)` when absent (bootstrap), the snapshot id
+/// when well-formed, and an error when present but malformed.
+fn read_cursor(path: &Path) -> anyhow::Result<Option<i64>> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(anyhow::Error::new(error)
+                .context(format!("reading the cursor file {}", path.display())));
+        }
+    };
+    let value: serde_json::Value = serde_json::from_str(&text)
+        .with_context(|| format!("parsing the cursor file {}", path.display()))?;
+    let snapshot = value
+        .get("snapshot")
+        .and_then(serde_json::Value::as_i64)
+        .with_context(|| format!("cursor file {} has no integer `snapshot`", path.display()))?;
+    Ok(Some(snapshot))
+}
+
+/// Write the cursor file atomically (temp file + rename, same directory), so a
+/// crash mid-write can never leave a truncated cursor.
+fn write_cursor(path: &Path, snapshot: i64) -> anyhow::Result<()> {
+    let tmp = path.with_extension("json.tmp");
+    let body = serde_json::json!({ "snapshot": snapshot }).to_string();
+    std::fs::write(&tmp, body)
+        .with_context(|| format!("writing the cursor temp file {}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("renaming the cursor file into place at {}", path.display()))?;
+    Ok(())
 }
 
 /// Turn the per-run counts into the process result: success only when no source
@@ -856,8 +1037,8 @@ mod tests {
     use std::path::PathBuf;
 
     use super::{
-        Atuin, Counts, archive_prefix, finish, open_atuin, parse_user, safe_path_under,
-        user_prefix,
+        Atuin, Counts, archive_prefix, finish, open_atuin, parse_user, read_cursor,
+        safe_path_under, user_prefix, write_cursor,
     };
 
     /// Create a valid sqlite db with no `history` table at `path`, mirroring
@@ -986,6 +1167,29 @@ mod tests {
         // the same bucket never clobber each other.
         assert_eq!(archive_prefix("corpus", "hil-compute-1"), "corpus/host=hil-compute-1");
         assert_ne!(archive_prefix("corpus", "a"), archive_prefix("corpus", "b"));
+    }
+
+    #[test]
+    fn cursor_file_bootstraps_then_round_trips() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("cursor.json");
+        // Absent file is the bootstrap signal, not an error.
+        assert_eq!(read_cursor(&path).expect("absent file"), None);
+        write_cursor(&path, 42).expect("write");
+        assert_eq!(read_cursor(&path).expect("read back"), Some(42));
+        write_cursor(&path, 43).expect("overwrite");
+        assert_eq!(read_cursor(&path).expect("read back"), Some(43));
+        assert!(!path.with_extension("json.tmp").exists(), "the temp file must not linger");
+    }
+
+    #[test]
+    fn malformed_cursor_file_is_an_error_not_a_silent_rebuild() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("cursor.json");
+        std::fs::write(&path, "not json").expect("write garbage");
+        assert!(read_cursor(&path).is_err(), "garbage must surface, not bootstrap");
+        std::fs::write(&path, "{}").expect("write empty object");
+        assert!(read_cursor(&path).is_err(), "a missing `snapshot` key must surface");
     }
 
     #[test]

--- a/packages/lake/iceberg/Cargo.toml
+++ b/packages/lake/iceberg/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "lake-iceberg"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "The Iceberg corpus lake: append+tombstone document log with snapshot-cursor reads"
+
+[lints]
+workspace = true
+
+[dependencies]
+# iceberg 0.9 pins arrow/parquet ^57.1; the rest of the workspace is on 58 for
+# the plain-parquet pair. The 57 tree is pinned here directly (not in the
+# workspace table) so it stays an implementation detail of this crate; both
+# trees coexist (`multiple_crate_versions` is allowed workspace-wide).
+arrow-array = "57"
+arrow-schema = "57"
+futures.workspace = true
+iceberg.workspace = true
+iceberg-catalog-rest.workspace = true
+iceberg-storage-opendal.workspace = true
+parquet-57 = { package = "parquet", version = "57", features = ["arrow"] }
+serde_json.workspace = true
+snafu.workspace = true
+source-meta.workspace = true
+uuid = { workspace = true, features = ["v4"] }
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/packages/lake/iceberg/fixture/README.md
+++ b/packages/lake/iceberg/fixture/README.md
@@ -32,3 +32,8 @@ The stale-base leg prints which behavior the backend exhibits (`MERGES` or
 (issue #752, phase 0.4). What it cannot cover locally: R2's managed
 compaction interacting with the snapshot cursor, and snapshot expiration —
 those need the R2 staging run.
+
+`ensure_table` creates the table but never migrates it. A staging
+`corpus.documents` created before the `version` column (field 13) was added
+will fail every append with an arrow column-count error; drop the table and
+let the next run recreate it.

--- a/packages/lake/iceberg/fixture/README.md
+++ b/packages/lake/iceberg/fixture/README.md
@@ -1,0 +1,34 @@
+# lake-iceberg REST fixture
+
+The lake's unit suite runs against iceberg's in-memory catalog; this fixture
+runs the same code against a **real REST catalog** locally — the production
+`RestCatalogBuilder` + OpenDal S3 wiring, server-side metadata writes, and the
+stale-base commit behavior a real server exhibits (merge, or HTTP 409 mapped
+to the retryable `CatalogCommitConflicts`).
+
+```sh
+./rest-fixture.sh   # needs docker + cargo on PATH
+```
+
+Stands up `apache/iceberg-rest-fixture` + MinIO with host networking (one
+`localhost` namespace, so the fixture's own metadata writes and our client
+reach the same S3 endpoint — no split-horizon hostnames), creates the
+warehouse bucket, and runs the ignored `rest_round_trip_via_env` test.
+
+## The same test against R2 Data Catalog staging
+
+```sh
+LAKE_TEST_CATALOG_URI=https://catalog.cloudflarestorage.com/<account>/<bucket> \
+LAKE_TEST_WAREHOUSE=<account>_<bucket> \
+LAKE_TEST_CATALOG_TOKEN=<cloudflare api token> \
+LAKE_TEST_S3_ENDPOINT=https://<account>.r2.cloudflarestorage.com \
+LAKE_TEST_S3_REGION=auto \
+AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... \
+cargo test -p lake-iceberg -- --ignored rest_round_trip --nocapture
+```
+
+The stale-base leg prints which behavior the backend exhibits (`MERGES` or
+`CASes (409, retryable)`) — for R2 that print is a spike deliverable
+(issue #752, phase 0.4). What it cannot cover locally: R2's managed
+compaction interacting with the snapshot cursor, and snapshot expiration —
+those need the R2 staging run.

--- a/packages/lake/iceberg/fixture/docker-compose.yml
+++ b/packages/lake/iceberg/fixture/docker-compose.yml
@@ -1,0 +1,31 @@
+# Local REST-catalog fixture for the lake's REST path and real commit
+# conflicts (#752: the spike's REST half, and lake-iceberg's ignored
+# rest_round_trip_via_env). Driven by rest-fixture.sh.
+#
+# Host networking on purpose: the fixture's Java side writes table metadata to
+# MinIO itself, so both the fixture and the host-side rust client must resolve
+# the same S3 endpoint — one hostname space (localhost) avoids the classic
+# split-horizon problem where the catalog vends a compose-internal hostname
+# the host cannot reach.
+services:
+  minio:
+    image: minio/minio
+    network_mode: host
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --address :9000
+
+  rest:
+    image: apache/iceberg-rest-fixture:1.10.1
+    network_mode: host
+    depends_on:
+      - minio
+    environment:
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      AWS_REGION: us-east-1
+      CATALOG_WAREHOUSE: s3://warehouse/
+      CATALOG_IO__IMPL: org.apache.iceberg.aws.s3.S3FileIO
+      CATALOG_S3_ENDPOINT: http://localhost:9000
+      CATALOG_S3_PATH__STYLE__ACCESS: "true"

--- a/packages/lake/iceberg/fixture/rest-fixture.sh
+++ b/packages/lake/iceberg/fixture/rest-fixture.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Stand up a local Iceberg REST catalog (apache/iceberg-rest-fixture + MinIO)
+# and run lake-iceberg's ignored REST round-trip against it: the full
+# reconcile/converge/tombstone/cursor cycle plus the stale-base commit leg,
+# through the production RestCatalogBuilder + OpenDal S3 wiring. Tears the
+# containers down on exit.
+#
+# Needs docker and cargo on PATH (on a bare NixOS host:
+#   nix shell nixpkgs#cargo nixpkgs#rustc nixpkgs#gcc nixpkgs#pkg-config \
+#     -c ./rest-fixture.sh
+# ). The same LAKE_TEST_* variables point the test at R2 Data Catalog staging
+# instead — see README.md.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+compose() { docker compose -f docker-compose.yml "$@"; }
+compose up -d
+trap 'compose down -v' EXIT
+
+echo "waiting for the REST catalog on :8181 ..."
+for _ in $(seq 60); do
+  curl -sf http://localhost:8181/v1/config >/dev/null 2>&1 && break
+  sleep 1
+done
+curl -sf http://localhost:8181/v1/config >/dev/null || {
+  echo "the REST fixture never became healthy" >&2
+  exit 1
+}
+
+echo "creating the warehouse bucket ..."
+AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \
+  nix run nixpkgs#awscli2 -- s3 mb s3://warehouse \
+  --endpoint-url http://localhost:9000 --region us-east-1 2>/dev/null || true
+
+echo "=== lake-iceberg: REST round-trip + stale-base commit leg ==="
+LAKE_TEST_CATALOG_URI=http://localhost:8181 \
+  LAKE_TEST_WAREHOUSE=s3://warehouse/ \
+  LAKE_TEST_S3_ENDPOINT=http://localhost:9000 \
+  LAKE_TEST_S3_REGION=us-east-1 \
+  AWS_ACCESS_KEY_ID=minioadmin \
+  AWS_SECRET_ACCESS_KEY=minioadmin \
+  cargo test -p lake-iceberg -- --ignored rest_round_trip --nocapture
+
+echo "REST-FIXTURE CHECKS PASS"

--- a/packages/lake/iceberg/package.nix
+++ b/packages/lake/iceberg/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "lake-iceberg";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/lake/iceberg/src/codec.rs
+++ b/packages/lake/iceberg/src/codec.rs
@@ -40,16 +40,16 @@ pub const OP_DELETE: &str = "delete";
 /// The columns a [`Document`] (or tombstone) is reconstructed from; the rest of
 /// the schema is a projection out of `meta_json`. Mirrors `source-parquet`'s
 /// four-column rule, plus the log's `op` and `observed_at`.
-pub(crate) const CODEC_COLUMNS: [&str; 6] =
+pub const CODEC_COLUMNS: [&str; 6] =
     ["external_id", "content_hash", "body", "meta_json", "op", "observed_at"];
 
 /// The columns the sink needs to diff a slice's live state against desired
 /// state: identity, change-detection hash, and the fold keys.
-pub(crate) const STATE_COLUMNS: [&str; 4] = ["external_id", "content_hash", "op", "observed_at"];
+pub const STATE_COLUMNS: [&str; 4] = ["external_id", "content_hash", "op", "observed_at"];
 
 /// The lake's Iceberg schema. Field ids are stable and append-only: the first
 /// nine are `sink-parquet`'s columns in its order, then the log's additions.
-pub(crate) fn table_schema() -> Result<Schema> {
+pub fn table_schema() -> Result<Schema> {
     let optional =
         |id: i32, name: &str| NestedField::optional(id, name, Type::Primitive(PrimitiveType::String));
     let required =
@@ -79,7 +79,7 @@ pub(crate) fn table_schema() -> Result<Schema> {
 /// fleet path) the observations belong to. Tombstones are scoped to a slice so
 /// host A never deletes what host B still observes.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct Slice<'a> {
+pub struct Slice<'a> {
     /// The writing host (`networking.hostName` on the fleet).
     pub host: &'a str,
     /// The account, for per-user sources; `None` for host-level bulk exports.
@@ -89,7 +89,7 @@ pub(crate) struct Slice<'a> {
 /// Encode one reconcile pass — upserts plus tombstones — as a single record
 /// batch against the table's arrow schema (which carries the parquet field-id
 /// metadata the writer requires).
-pub(crate) fn encode_batch(
+pub fn encode_batch(
     arrow_schema: &Arc<ArrowSchema>,
     source: &Source,
     slice: Slice<'_>,
@@ -141,7 +141,7 @@ pub(crate) fn encode_batch(
 
 /// A row's operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Op {
+pub enum Op {
     /// The document was observed in the writer's desired state.
     Upsert,
     /// The document left the writer's desired state.
@@ -151,7 +151,7 @@ pub(crate) enum Op {
 /// One decoded log row: identity, fold keys, and (for payload reads) the
 /// content needed to reconstruct a [`Document`].
 #[derive(Debug)]
-pub(crate) struct LakeRow {
+pub struct LakeRow {
     /// Stable per-record id (the store `external_id`).
     pub external_id: String,
     /// sha256 of the body; `None` only on tombstones.
@@ -170,7 +170,7 @@ pub(crate) struct LakeRow {
 /// Decode one record batch into rows, appending to `out`. `with_payload` says
 /// whether `body`/`meta_json` are expected in the batch (a state-projected
 /// scan omits them).
-pub(crate) fn rows_from_batch(
+pub fn rows_from_batch(
     batch: &RecordBatch,
     with_payload: bool,
     out: &mut Vec<LakeRow>,
@@ -231,7 +231,7 @@ pub(crate) fn rows_from_batch(
 ///
 /// Calling this on a tombstone or state-projected row is a typed error
 /// ([`rows_from_batch`] already validated payload presence for upserts).
-pub(crate) fn document_from_row(row: LakeRow) -> Result<Document> {
+pub fn document_from_row(row: LakeRow) -> Result<Document> {
     let tombstone = |what: &'static str| TombstoneDocumentSnafu { what };
     let body = row.body.context(tombstone("body"))?.into_bytes();
     let meta_str = row.meta_json.context(tombstone("meta_json"))?;
@@ -250,7 +250,7 @@ pub(crate) fn document_from_row(row: LakeRow) -> Result<Document> {
 /// (ties: the later-read row). Per-slice writers are serialized by the fleet's
 /// oneshot units, so within a slice `observed_at` only moves forward; across
 /// slices the rule is "any writer's most recent observation wins".
-pub(crate) fn fold_latest(rows: Vec<LakeRow>) -> HashMap<String, LakeRow> {
+pub fn fold_latest(rows: Vec<LakeRow>) -> HashMap<String, LakeRow> {
     let mut latest: HashMap<String, LakeRow> = HashMap::new();
     for row in rows {
         match latest.get(&row.external_id) {

--- a/packages/lake/iceberg/src/codec.rs
+++ b/packages/lake/iceberg/src/codec.rs
@@ -1,0 +1,282 @@
+//! The lake table's schema and the row ↔ [`Document`] codec.
+//!
+//! One row is one *observation*: a source's document as seen by one writer
+//! (`host`, optional `user`) at `observed_at`, tagged `op = upsert`, or a
+//! tombstone (`op = delete`) recording that the document left that writer's
+//! desired state. The table is an append-only revision log; current state is a
+//! latest-wins fold per `external_id` (see [`crate::read_all`]).
+//!
+//! The first nine columns are exactly `sink-parquet`'s flat corpus schema, so
+//! every existing polars/duckdb query ports by adding `op != 'delete'` to its
+//! filter. `user`, `op`, and `observed_at` are the log's additions. As in the
+//! parquet log, `source`/`title`/`url`/`host`/`timestamp`/`user` are
+//! projections for queryability: a [`Document`] is reconstructed from
+//! `external_id`, `content_hash`, `body`, and `meta_json` alone.
+//!
+//! Nullability rule: `content_hash`, `body`, and `meta_json` are null exactly
+//! when `op = delete` (a tombstone carries identity, not content). A null in
+//! any of them on an upsert row is a malformed log and decodes to a typed
+//! error, never a default.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow_array::{Array as _, ArrayRef, Int64Array, RecordBatch, StringArray};
+use arrow_schema::Schema as ArrowSchema;
+use iceberg::spec::{NestedField, PrimitiveType, Schema, Type};
+use snafu::{OptionExt as _, ResultExt as _};
+use source_meta::{Document, Source, keys};
+
+use crate::error::{
+    BadOpSnafu, BatchSnafu, ColumnTypeSnafu, MetaJsonSnafu, MissingColumnSnafu, NullValueSnafu,
+    Result, SchemaSnafu, TombstoneDocumentSnafu,
+};
+
+/// `op` value for a document observation.
+pub const OP_UPSERT: &str = "upsert";
+/// `op` value for a tombstone (the document left the writer's desired state).
+pub const OP_DELETE: &str = "delete";
+
+/// The columns a [`Document`] (or tombstone) is reconstructed from; the rest of
+/// the schema is a projection out of `meta_json`. Mirrors `source-parquet`'s
+/// four-column rule, plus the log's `op` and `observed_at`.
+pub(crate) const CODEC_COLUMNS: [&str; 6] =
+    ["external_id", "content_hash", "body", "meta_json", "op", "observed_at"];
+
+/// The columns the sink needs to diff a slice's live state against desired
+/// state: identity, change-detection hash, and the fold keys.
+pub(crate) const STATE_COLUMNS: [&str; 4] = ["external_id", "content_hash", "op", "observed_at"];
+
+/// The lake's Iceberg schema. Field ids are stable and append-only: the first
+/// nine are `sink-parquet`'s columns in its order, then the log's additions.
+pub(crate) fn table_schema() -> Result<Schema> {
+    let optional =
+        |id: i32, name: &str| NestedField::optional(id, name, Type::Primitive(PrimitiveType::String));
+    let required =
+        |id: i32, name: &str| NestedField::required(id, name, Type::Primitive(PrimitiveType::String));
+    Schema::builder()
+        .with_schema_id(0)
+        .with_fields(vec![
+            required(1, "external_id").into(),
+            required(2, "source").into(),
+            // Null only on op=delete rows (a tombstone carries no content).
+            optional(3, "content_hash").into(),
+            optional(4, "title").into(),
+            optional(5, "url").into(),
+            required(6, "host").into(),
+            NestedField::optional(7, "timestamp", Type::Primitive(PrimitiveType::Long)).into(),
+            optional(8, "body").into(),
+            optional(9, "meta_json").into(),
+            optional(10, "user").into(),
+            required(11, "op").into(),
+            NestedField::required(12, "observed_at", Type::Primitive(PrimitiveType::Long)).into(),
+        ])
+        .build()
+        .context(SchemaSnafu)
+}
+
+/// One writer's slice of the corpus: which host (and account, for the per-user
+/// fleet path) the observations belong to. Tombstones are scoped to a slice so
+/// host A never deletes what host B still observes.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Slice<'a> {
+    /// The writing host (`networking.hostName` on the fleet).
+    pub host: &'a str,
+    /// The account, for per-user sources; `None` for host-level bulk exports.
+    pub user: Option<&'a str>,
+}
+
+/// Encode one reconcile pass — upserts plus tombstones — as a single record
+/// batch against the table's arrow schema (which carries the parquet field-id
+/// metadata the writer requires).
+pub(crate) fn encode_batch(
+    arrow_schema: &Arc<ArrowSchema>,
+    source: &Source,
+    slice: Slice<'_>,
+    observed_at: i64,
+    upserts: &[&Document],
+    deletes: &[&str],
+) -> Result<RecordBatch> {
+    let n = upserts.len() + deletes.len();
+    let up = upserts.len();
+    let meta_str = |doc: &Document, key: &str| {
+        doc.meta_json.get(key).and_then(serde_json::Value::as_str).map(str::to_owned)
+    };
+    // Upsert rows first, tombstones after; per-column closures keep each
+    // column a single pass over both halves.
+    let string_col = |f: &dyn Fn(usize) -> Option<String>| -> ArrayRef {
+        Arc::new((0..n).map(f).collect::<StringArray>())
+    };
+    let columns: Vec<ArrayRef> = vec![
+        string_col(&|i| {
+            Some(if i < up { upserts[i].external_id.clone() } else { deletes[i - up].to_owned() })
+        }),
+        string_col(&|_| Some(source.as_str().to_owned())),
+        string_col(&|i| (i < up).then(|| upserts[i].content_hash.clone())),
+        string_col(&|i| (i < up).then(|| meta_str(upserts[i], keys::TITLE)).flatten()),
+        string_col(&|i| (i < up).then(|| meta_str(upserts[i], "url")).flatten()),
+        string_col(&|_| Some(slice.host.to_owned())),
+        Arc::new(
+            (0..n)
+                .map(|i| {
+                    (i < up)
+                        .then(|| {
+                            upserts[i]
+                                .meta_json
+                                .get(keys::TIMESTAMP)
+                                .and_then(serde_json::Value::as_i64)
+                        })
+                        .flatten()
+                })
+                .collect::<Int64Array>(),
+        ),
+        string_col(&|i| (i < up).then(|| String::from_utf8_lossy(&upserts[i].body).into_owned())),
+        string_col(&|i| (i < up).then(|| upserts[i].meta_json.to_string())),
+        string_col(&|_| slice.user.map(str::to_owned)),
+        string_col(&|i| Some((if i < up { OP_UPSERT } else { OP_DELETE }).to_owned())),
+        Arc::new((0..n).map(|_| Some(observed_at)).collect::<Int64Array>()),
+    ];
+    RecordBatch::try_new(Arc::clone(arrow_schema), columns).context(BatchSnafu)
+}
+
+/// A row's operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Op {
+    /// The document was observed in the writer's desired state.
+    Upsert,
+    /// The document left the writer's desired state.
+    Delete,
+}
+
+/// One decoded log row: identity, fold keys, and (for payload reads) the
+/// content needed to reconstruct a [`Document`].
+#[derive(Debug)]
+pub(crate) struct LakeRow {
+    /// Stable per-record id (the store `external_id`).
+    pub external_id: String,
+    /// sha256 of the body; `None` only on tombstones.
+    pub content_hash: Option<String>,
+    /// The embedded text; `None` on tombstones, or when the read was projected
+    /// to [`STATE_COLUMNS`].
+    pub body: Option<String>,
+    /// The full metadata object as JSON; `None` like `body`.
+    pub meta_json: Option<String>,
+    /// The row's operation.
+    pub op: Op,
+    /// When the writer observed this state (epoch milliseconds).
+    pub observed_at: i64,
+}
+
+/// Decode one record batch into rows, appending to `out`. `with_payload` says
+/// whether `body`/`meta_json` are expected in the batch (a state-projected
+/// scan omits them).
+pub(crate) fn rows_from_batch(
+    batch: &RecordBatch,
+    with_payload: bool,
+    out: &mut Vec<LakeRow>,
+) -> Result<()> {
+    let external_id = string_column(batch, "external_id")?;
+    let content_hash = string_column(batch, "content_hash")?;
+    let op_col = string_column(batch, "op")?;
+    let observed_at = long_column(batch, "observed_at")?;
+    let payload = if with_payload {
+        Some((string_column(batch, "body")?, string_column(batch, "meta_json")?))
+    } else {
+        None
+    };
+
+    out.reserve(batch.num_rows());
+    for row in 0..batch.num_rows() {
+        let op = match non_null_str(op_col, row, "op")? {
+            OP_UPSERT => Op::Upsert,
+            OP_DELETE => Op::Delete,
+            other => return BadOpSnafu { value: other.to_owned(), row }.fail(),
+        };
+        let opt = |array: &StringArray| array.is_valid(row).then(|| array.value(row).to_owned());
+        let (body, meta_json) = match &payload {
+            Some((body, meta_json)) => (opt(body), opt(meta_json)),
+            None => (None, None),
+        };
+        // An upsert row missing its content is a malformed log, surfaced as a
+        // typed error rather than reconstructed from defaults.
+        if op == Op::Upsert {
+            if content_hash.is_null(row) {
+                return NullValueSnafu { column: "content_hash", row }.fail();
+            }
+            if with_payload && body.is_none() {
+                return NullValueSnafu { column: "body", row }.fail();
+            }
+            if with_payload && meta_json.is_none() {
+                return NullValueSnafu { column: "meta_json", row }.fail();
+            }
+        }
+        out.push(LakeRow {
+            external_id: non_null_str(external_id, row, "external_id")?.to_owned(),
+            content_hash: opt(content_hash),
+            body,
+            meta_json,
+            op,
+            observed_at: observed_at
+                .is_valid(row)
+                .then(|| observed_at.value(row))
+                .context(NullValueSnafu { column: "observed_at", row })?,
+        });
+    }
+    Ok(())
+}
+
+/// Reconstruct a [`Document`] from an upsert row, mirroring `source-parquet`'s
+/// conventions exactly: `file_name` is the `external_id`, the mime is plain
+/// text, and `meta_json` is parsed whole (source extras intact).
+///
+/// Calling this on a tombstone or state-projected row is a typed error
+/// ([`rows_from_batch`] already validated payload presence for upserts).
+pub(crate) fn document_from_row(row: LakeRow) -> Result<Document> {
+    let tombstone = |what: &'static str| TombstoneDocumentSnafu { what };
+    let body = row.body.context(tombstone("body"))?.into_bytes();
+    let meta_str = row.meta_json.context(tombstone("meta_json"))?;
+    let meta = serde_json::from_str(&meta_str).context(MetaJsonSnafu)?;
+    Ok(Document {
+        file_name: row.external_id.clone(),
+        external_id: row.external_id,
+        mime: "text/plain",
+        body,
+        meta_json: meta,
+        content_hash: row.content_hash.context(tombstone("content_hash"))?,
+    })
+}
+
+/// Keep, per `external_id`, only the row with the greatest `observed_at`
+/// (ties: the later-read row). Per-slice writers are serialized by the fleet's
+/// oneshot units, so within a slice `observed_at` only moves forward; across
+/// slices the rule is "any writer's most recent observation wins".
+pub(crate) fn fold_latest(rows: Vec<LakeRow>) -> HashMap<String, LakeRow> {
+    let mut latest: HashMap<String, LakeRow> = HashMap::new();
+    for row in rows {
+        match latest.get(&row.external_id) {
+            Some(existing) if existing.observed_at > row.observed_at => {}
+            _ => {
+                latest.insert(row.external_id.clone(), row);
+            }
+        }
+    }
+    latest
+}
+
+/// Borrow one column as a `StringArray`, erroring (never defaulting) when the
+/// column is absent or mis-typed.
+fn string_column<'a>(batch: &'a RecordBatch, column: &'static str) -> Result<&'a StringArray> {
+    let array = batch.column_by_name(column).context(MissingColumnSnafu { column })?;
+    array.as_any().downcast_ref::<StringArray>().context(ColumnTypeSnafu { column })
+}
+
+/// Borrow one column as an `Int64Array`, erroring like [`string_column`].
+fn long_column<'a>(batch: &'a RecordBatch, column: &'static str) -> Result<&'a Int64Array> {
+    let array = batch.column_by_name(column).context(MissingColumnSnafu { column })?;
+    array.as_any().downcast_ref::<Int64Array>().context(ColumnTypeSnafu { column })
+}
+
+/// Read one row of a required string column, erroring on a null cell.
+fn non_null_str<'a>(array: &'a StringArray, row: usize, column: &'static str) -> Result<&'a str> {
+    array.is_valid(row).then(|| array.value(row)).context(NullValueSnafu { column, row })
+}

--- a/packages/lake/iceberg/src/codec.rs
+++ b/packages/lake/iceberg/src/codec.rs
@@ -1,15 +1,22 @@
 //! The lake table's schema and the row ↔ [`Document`] codec.
 //!
 //! One row is one *observation*: a source's document as seen by one writer
-//! (`host`, optional `user`) at `observed_at`, tagged `op = upsert`, or a
-//! tombstone (`op = delete`) recording that the document left that writer's
-//! desired state. The table is an append-only revision log; current state is a
-//! latest-wins fold per `external_id` (see [`crate::read_all`]).
+//! slice (`host`, optional `user`), tagged `op = upsert`, or a tombstone
+//! (`op = delete`) recording that the document left that slice's desired
+//! state. The table is an append-only revision log; current state is a
+//! per-slice fold ordered by `version` (see [`fold_slices`]): an id is live
+//! while any slice's latest op for it is an upsert.
+//!
+//! `version` is the slice's revision counter, assigned by the writer as its
+//! slice's previous maximum plus one. It is committed data, so it survives
+//! compaction and clock steps; `observed_at` (wall-clock epoch ms) is kept for
+//! queryability and as the freshness arbiter between live replicas of one id
+//! in different slices, never to order one slice's operations.
 //!
 //! The first nine columns are exactly `sink-parquet`'s flat corpus schema, so
 //! every existing polars/duckdb query ports by adding `op != 'delete'` to its
-//! filter. `user`, `op`, and `observed_at` are the log's additions. As in the
-//! parquet log, `source`/`title`/`url`/`host`/`timestamp`/`user` are
+//! filter. `user`, `op`, `observed_at`, and `version` are the log's additions.
+//! As in the parquet log, `source`/`title`/`url`/`host`/`timestamp`/`user` are
 //! projections for queryability: a [`Document`] is reconstructed from
 //! `external_id`, `content_hash`, `body`, and `meta_json` alone.
 //!
@@ -19,6 +26,7 @@
 //! error, never a default.
 
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
 use arrow_array::{Array as _, ArrayRef, Int64Array, RecordBatch, StringArray};
@@ -37,15 +45,28 @@ pub const OP_UPSERT: &str = "upsert";
 /// `op` value for a tombstone (the document left the writer's desired state).
 pub const OP_DELETE: &str = "delete";
 
-/// The columns a [`Document`] (or tombstone) is reconstructed from; the rest of
-/// the schema is a projection out of `meta_json`. Mirrors `source-parquet`'s
-/// four-column rule, plus the log's `op` and `observed_at`.
-pub const CODEC_COLUMNS: [&str; 6] =
-    ["external_id", "content_hash", "body", "meta_json", "op", "observed_at"];
+/// The non-payload columns every read needs: identity, grouping (`source`),
+/// the slice and version fold keys, the change-detection hash, and the
+/// cross-slice freshness arbiter. Enough to diff a slice's live state against
+/// desired state or to judge global liveness, without hauling bodies.
+pub const STATE_COLUMNS: [&str; 8] =
+    ["external_id", "source", "content_hash", "host", "user", "op", "observed_at", "version"];
 
-/// The columns the sink needs to diff a slice's live state against desired
-/// state: identity, change-detection hash, and the fold keys.
-pub const STATE_COLUMNS: [&str; 4] = ["external_id", "content_hash", "op", "observed_at"];
+/// [`STATE_COLUMNS`] plus the payload a [`Document`] is reconstructed from
+/// (`body`, `meta_json`); the rest of the schema is a projection out of
+/// `meta_json`, mirroring `source-parquet`'s four-column rule.
+pub const CODEC_COLUMNS: [&str; 10] = [
+    "external_id",
+    "source",
+    "content_hash",
+    "host",
+    "user",
+    "op",
+    "observed_at",
+    "version",
+    "body",
+    "meta_json",
+];
 
 /// The lake's Iceberg schema. Field ids are stable and append-only: the first
 /// nine are `sink-parquet`'s columns in its order, then the log's additions.
@@ -70,6 +91,7 @@ pub fn table_schema() -> Result<Schema> {
             optional(10, "user").into(),
             required(11, "op").into(),
             NestedField::required(12, "observed_at", Type::Primitive(PrimitiveType::Long)).into(),
+            NestedField::required(13, "version", Type::Primitive(PrimitiveType::Long)).into(),
         ])
         .build()
         .context(SchemaSnafu)
@@ -88,12 +110,14 @@ pub struct Slice<'a> {
 
 /// Encode one reconcile pass — upserts plus tombstones — as a single record
 /// batch against the table's arrow schema (which carries the parquet field-id
-/// metadata the writer requires).
+/// metadata the writer requires). `version` is the slice's revision counter
+/// for this pass (its previous maximum plus one).
 pub fn encode_batch(
     arrow_schema: &Arc<ArrowSchema>,
     source: &Source,
     slice: Slice<'_>,
     observed_at: i64,
+    version: i64,
     upserts: &[&Document],
     deletes: &[&str],
 ) -> Result<RecordBatch> {
@@ -135,6 +159,7 @@ pub fn encode_batch(
         string_col(&|_| slice.user.map(str::to_owned)),
         string_col(&|i| Some((if i < up { OP_UPSERT } else { OP_DELETE }).to_owned())),
         Arc::new((0..n).map(|_| Some(observed_at)).collect::<Int64Array>()),
+        Arc::new((0..n).map(|_| Some(version)).collect::<Int64Array>()),
     ];
     RecordBatch::try_new(Arc::clone(arrow_schema), columns).context(BatchSnafu)
 }
@@ -154,6 +179,12 @@ pub enum Op {
 pub struct LakeRow {
     /// Stable per-record id (the store `external_id`).
     pub external_id: String,
+    /// The source the row belongs to (grouping key for the per-source view).
+    pub source: String,
+    /// The writing host (slice fold key).
+    pub host: String,
+    /// The account, for per-user slices (slice fold key).
+    pub user: Option<String>,
     /// sha256 of the body; `None` only on tombstones.
     pub content_hash: Option<String>,
     /// The embedded text; `None` on tombstones, or when the read was projected
@@ -163,8 +194,11 @@ pub struct LakeRow {
     pub meta_json: Option<String>,
     /// The row's operation.
     pub op: Op,
-    /// When the writer observed this state (epoch milliseconds).
+    /// When the writer observed this state (epoch milliseconds). Informational
+    /// and a cross-slice freshness arbiter; never orders a slice's operations.
     pub observed_at: i64,
+    /// The slice's committed revision counter; orders the slice's operations.
+    pub version: i64,
 }
 
 /// Decode one record batch into rows, appending to `out`. `with_payload` says
@@ -176,9 +210,13 @@ pub fn rows_from_batch(
     out: &mut Vec<LakeRow>,
 ) -> Result<()> {
     let external_id = string_column(batch, "external_id")?;
+    let source = string_column(batch, "source")?;
+    let host = string_column(batch, "host")?;
+    let user = string_column(batch, "user")?;
     let content_hash = string_column(batch, "content_hash")?;
     let op_col = string_column(batch, "op")?;
     let observed_at = long_column(batch, "observed_at")?;
+    let version = long_column(batch, "version")?;
     let payload = if with_payload {
         Some((string_column(batch, "body")?, string_column(batch, "meta_json")?))
     } else {
@@ -210,16 +248,23 @@ pub fn rows_from_batch(
                 return NullValueSnafu { column: "meta_json", row }.fail();
             }
         }
+        let long = |array: &Int64Array, column: &'static str| {
+            array
+                .is_valid(row)
+                .then(|| array.value(row))
+                .context(NullValueSnafu { column, row })
+        };
         out.push(LakeRow {
             external_id: non_null_str(external_id, row, "external_id")?.to_owned(),
+            source: non_null_str(source, row, "source")?.to_owned(),
+            host: non_null_str(host, row, "host")?.to_owned(),
+            user: opt(user),
             content_hash: opt(content_hash),
             body,
             meta_json,
             op,
-            observed_at: observed_at
-                .is_valid(row)
-                .then(|| observed_at.value(row))
-                .context(NullValueSnafu { column: "observed_at", row })?,
+            observed_at: long(observed_at, "observed_at")?,
+            version: long(version, "version")?,
         });
     }
     Ok(())
@@ -246,21 +291,47 @@ pub fn document_from_row(row: LakeRow) -> Result<Document> {
     })
 }
 
-/// Keep, per `external_id`, only the row with the greatest `observed_at`
-/// (ties: the later-read row). Per-slice writers are serialized by the fleet's
-/// oneshot units, so within a slice `observed_at` only moves forward; across
-/// slices the rule is "any writer's most recent observation wins".
-pub fn fold_latest(rows: Vec<LakeRow>) -> HashMap<String, LakeRow> {
-    let mut latest: HashMap<String, LakeRow> = HashMap::new();
+/// Fold rows into current state: per `external_id`, each slice's latest row.
+///
+/// Within a slice, "latest" is the greatest `version` — the writer's committed
+/// revision counter — so ordering is immune to wall-clock steps and to
+/// compaction rewriting files. (A version tie means two writers raced one
+/// slice, which the fleet's serialized oneshot units rule out; it breaks by
+/// `observed_at`, then the later-read row, to stay deterministic.) Slices are
+/// kept apart because tombstones are slice-scoped: one host's delete must not
+/// erase a record another slice still observes — liveness belongs to
+/// [`live_winner`].
+pub fn fold_slices(rows: Vec<LakeRow>) -> HashMap<String, Vec<LakeRow>> {
+    let mut latest: HashMap<String, HashMap<(String, Option<String>), LakeRow>> = HashMap::new();
     for row in rows {
-        match latest.get(&row.external_id) {
-            Some(existing) if existing.observed_at > row.observed_at => {}
-            _ => {
-                latest.insert(row.external_id.clone(), row);
+        let slices = latest.entry(row.external_id.clone()).or_default();
+        match slices.entry((row.host.clone(), row.user.clone())) {
+            Entry::Occupied(mut entry) => {
+                let held = entry.get();
+                if (row.version, row.observed_at) >= (held.version, held.observed_at) {
+                    entry.insert(row);
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(row);
             }
         }
     }
-    latest
+    latest.into_iter().map(|(id, slices)| (id, slices.into_values().collect())).collect()
+}
+
+/// The row representing one id's live state, given its slice-latest rows from
+/// [`fold_slices`]: the id is live while *any* slice's latest op is an upsert,
+/// and the greatest `observed_at` (ties: slice identity) among those upserts
+/// picks which replica's content the view shows. Versions order operations
+/// within a slice and are not comparable across slices, so wall clock here
+/// only arbitrates between concurrently live copies of the same record — it
+/// never decides whether an id lives or dies. `None` means every slice that
+/// ever held the id has tombstoned it.
+pub fn live_winner(rows: Vec<LakeRow>) -> Option<LakeRow> {
+    rows.into_iter()
+        .filter(|row| row.op == Op::Upsert)
+        .max_by(|a, b| (a.observed_at, &a.host, &a.user).cmp(&(b.observed_at, &b.host, &b.user)))
 }
 
 /// Borrow one column as a `StringArray`, erroring (never defaulting) when the

--- a/packages/lake/iceberg/src/error.rs
+++ b/packages/lake/iceberg/src/error.rs
@@ -1,0 +1,159 @@
+//! Typed failures for the lake. Every decode failure names the column and row
+//! rather than defaulting, mirroring `source-parquet`'s malformed-log posture.
+
+use snafu::Snafu;
+
+/// Failures from the Iceberg corpus lake.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// The lake table schema could not be built.
+    #[snafu(display("failed to build the lake table schema"))]
+    Schema {
+        /// Underlying iceberg error.
+        source: iceberg::Error,
+    },
+    /// The REST catalog could not be connected.
+    #[snafu(display("failed to connect the Iceberg catalog at {uri}"))]
+    Connect {
+        /// Catalog URI dialed.
+        uri: String,
+        /// Underlying iceberg error.
+        source: iceberg::Error,
+    },
+    /// The corpus namespace or table could not be created or loaded.
+    #[snafu(display("failed to ensure the lake table {table}"))]
+    EnsureTable {
+        /// Table identifier.
+        table: String,
+        /// Underlying iceberg error.
+        source: iceberg::Error,
+    },
+    /// The lake table could not be loaded from the catalog.
+    #[snafu(display("failed to load the lake table {table}"))]
+    LoadTable {
+        /// Table identifier.
+        table: String,
+        /// Underlying iceberg error.
+        source: iceberg::Error,
+    },
+    /// A table scan failed.
+    #[snafu(display("failed to scan the lake table ({stage})"))]
+    Scan {
+        /// Which scan stage failed.
+        stage: &'static str,
+        /// Underlying iceberg error.
+        source: iceberg::Error,
+    },
+    /// The append record batch could not be assembled.
+    #[snafu(display("failed to build the append record batch"))]
+    Batch {
+        /// Underlying arrow error.
+        source: arrow_schema::ArrowError,
+    },
+    /// Writing the append's data files failed.
+    #[snafu(display("failed to write lake data files ({stage})"))]
+    Write {
+        /// Which writer stage failed.
+        stage: &'static str,
+        /// Underlying iceberg error.
+        source: iceberg::Error,
+    },
+    /// Committing the append failed (conflicts are retried first).
+    #[snafu(display("failed to commit the lake append after {attempts} attempt(s)"))]
+    Commit {
+        /// How many commit attempts were made.
+        attempts: u32,
+        /// Underlying iceberg error.
+        source: iceberg::Error,
+    },
+    /// A data file could not be read during an incremental walk.
+    #[snafu(display("failed to read lake data file {path}"))]
+    ReadFile {
+        /// Object path of the data file.
+        path: String,
+        /// Underlying iceberg error.
+        source: iceberg::Error,
+    },
+    /// A data file could not be opened as parquet.
+    #[snafu(display("failed to parse lake data file {path} as parquet"))]
+    ParseFile {
+        /// Object path of the data file.
+        path: String,
+        /// Underlying parquet error.
+        source: parquet_57::errors::ParquetError,
+    },
+    /// A data file's record batches could not be decoded.
+    #[snafu(display("failed to decode lake data file {path}"))]
+    DecodeFile {
+        /// Object path of the data file.
+        path: String,
+        /// Underlying arrow error.
+        source: arrow_schema::ArrowError,
+    },
+    /// The cursor snapshot is no longer in table metadata (expired or never
+    /// existed); the caller must fall back to a full rescan.
+    #[snafu(display("cursor snapshot {snapshot} not found (expired?); a full rescan is required"))]
+    CursorNotFound {
+        /// The cursor's snapshot id.
+        snapshot: i64,
+    },
+    /// A required column was absent from a scanned batch.
+    #[snafu(display("the lake scan is missing column {column}"))]
+    MissingColumn {
+        /// Name of the absent column.
+        column: &'static str,
+    },
+    /// A column was present but not the expected arrow type.
+    #[snafu(display("lake column {column} has an unexpected type"))]
+    ColumnType {
+        /// Name of the mis-typed column.
+        column: &'static str,
+    },
+    /// A required cell was null. The writer never produces this shape, so a
+    /// null here is a malformed log.
+    #[snafu(display("lake column {column} is null at row {row}"))]
+    NullValue {
+        /// Name of the column with the null cell.
+        column: &'static str,
+        /// Row index of the null cell.
+        row: usize,
+    },
+    /// A row's `op` was neither `upsert` nor `delete`.
+    #[snafu(display("unknown lake op {value:?} at row {row}"))]
+    BadOp {
+        /// The unexpected op value.
+        value: String,
+        /// Row index of the bad op.
+        row: usize,
+    },
+    /// A row's `meta_json` did not parse as JSON.
+    #[snafu(display("failed to parse meta_json from the lake"))]
+    MetaJson {
+        /// Underlying serde error.
+        source: serde_json::Error,
+    },
+    /// A tombstone (or state-projected) row cannot become a
+    /// [`Document`](source_meta::Document).
+    #[snafu(display("cannot build a Document from a tombstone row (missing {what})"))]
+    TombstoneDocument {
+        /// Which content field was absent.
+        what: &'static str,
+    },
+    /// The system clock is before the unix epoch.
+    #[snafu(display("system clock is before the unix epoch"))]
+    ClockBeforeEpoch {
+        /// Underlying time error.
+        source: std::time::SystemTimeError,
+    },
+    /// The system clock does not fit the `observed_at` column.
+    #[snafu(display("system clock out of range for observed_at"))]
+    Clock {
+        /// Underlying conversion error.
+        source: std::num::TryFromIntError,
+    },
+}
+
+/// Result alias defaulting to this crate's [`Error`].
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/packages/lake/iceberg/src/error.rs
+++ b/packages/lake/iceberg/src/error.rs
@@ -11,40 +11,45 @@ pub enum Error {
     /// The lake table schema could not be built.
     #[snafu(display("failed to build the lake table schema"))]
     Schema {
-        /// Underlying iceberg error.
-        source: iceberg::Error,
+        /// Underlying iceberg error (boxed: it is large, and errors are cold).
+        #[snafu(source(from(iceberg::Error, Box::new)))]
+        source: Box<iceberg::Error>,
     },
     /// The REST catalog could not be connected.
     #[snafu(display("failed to connect the Iceberg catalog at {uri}"))]
     Connect {
         /// Catalog URI dialed.
         uri: String,
-        /// Underlying iceberg error.
-        source: iceberg::Error,
+        /// Underlying iceberg error (boxed: it is large, and errors are cold).
+        #[snafu(source(from(iceberg::Error, Box::new)))]
+        source: Box<iceberg::Error>,
     },
     /// The corpus namespace or table could not be created or loaded.
     #[snafu(display("failed to ensure the lake table {table}"))]
     EnsureTable {
         /// Table identifier.
         table: String,
-        /// Underlying iceberg error.
-        source: iceberg::Error,
+        /// Underlying iceberg error (boxed: it is large, and errors are cold).
+        #[snafu(source(from(iceberg::Error, Box::new)))]
+        source: Box<iceberg::Error>,
     },
     /// The lake table could not be loaded from the catalog.
     #[snafu(display("failed to load the lake table {table}"))]
     LoadTable {
         /// Table identifier.
         table: String,
-        /// Underlying iceberg error.
-        source: iceberg::Error,
+        /// Underlying iceberg error (boxed: it is large, and errors are cold).
+        #[snafu(source(from(iceberg::Error, Box::new)))]
+        source: Box<iceberg::Error>,
     },
     /// A table scan failed.
     #[snafu(display("failed to scan the lake table ({stage})"))]
     Scan {
         /// Which scan stage failed.
         stage: &'static str,
-        /// Underlying iceberg error.
-        source: iceberg::Error,
+        /// Underlying iceberg error (boxed: it is large, and errors are cold).
+        #[snafu(source(from(iceberg::Error, Box::new)))]
+        source: Box<iceberg::Error>,
     },
     /// The append record batch could not be assembled.
     #[snafu(display("failed to build the append record batch"))]
@@ -57,24 +62,27 @@ pub enum Error {
     Write {
         /// Which writer stage failed.
         stage: &'static str,
-        /// Underlying iceberg error.
-        source: iceberg::Error,
+        /// Underlying iceberg error (boxed: it is large, and errors are cold).
+        #[snafu(source(from(iceberg::Error, Box::new)))]
+        source: Box<iceberg::Error>,
     },
     /// Committing the append failed (conflicts are retried first).
     #[snafu(display("failed to commit the lake append after {attempts} attempt(s)"))]
     Commit {
         /// How many commit attempts were made.
         attempts: u32,
-        /// Underlying iceberg error.
-        source: iceberg::Error,
+        /// Underlying iceberg error (boxed: it is large, and errors are cold).
+        #[snafu(source(from(iceberg::Error, Box::new)))]
+        source: Box<iceberg::Error>,
     },
     /// A data file could not be read during an incremental walk.
     #[snafu(display("failed to read lake data file {path}"))]
     ReadFile {
         /// Object path of the data file.
         path: String,
-        /// Underlying iceberg error.
-        source: iceberg::Error,
+        /// Underlying iceberg error (boxed: it is large, and errors are cold).
+        #[snafu(source(from(iceberg::Error, Box::new)))]
+        source: Box<iceberg::Error>,
     },
     /// A data file could not be opened as parquet.
     #[snafu(display("failed to parse lake data file {path} as parquet"))]

--- a/packages/lake/iceberg/src/lib.rs
+++ b/packages/lake/iceberg/src/lib.rs
@@ -546,8 +546,15 @@ mod tests {
 
     use super::{IcebergReconciler, added_since, current_snapshot_id, ensure_table, read_all};
 
-    /// A memory-catalog lake; the tempdir must outlive the catalog.
-    async fn lake() -> (Arc<dyn Catalog>, TableIdent, tempfile::TempDir) {
+    /// A memory-catalog lake for one test.
+    struct TestLake {
+        catalog: Arc<dyn Catalog>,
+        ident: TableIdent,
+        /// Held for its `Drop`: the warehouse directory lives inside.
+        _dir: tempfile::TempDir,
+    }
+
+    async fn lake() -> TestLake {
         let dir = tempfile::tempdir().expect("tempdir");
         let warehouse = format!("file://{}", dir.path().display());
         let catalog = MemoryCatalogBuilder::default()
@@ -556,7 +563,7 @@ mod tests {
             .expect("memory catalog");
         let catalog: Arc<dyn Catalog> = Arc::new(catalog);
         let ident = ensure_table(catalog.as_ref()).await.expect("ensure table");
-        (catalog, ident, dir)
+        TestLake { catalog, ident, _dir: dir }
     }
 
     fn doc_in(source: &str, id: &str, body: &str) -> Document {
@@ -583,7 +590,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_appends_then_skips_then_reads_back() {
-        let (catalog, ident, _dir) = lake().await;
+        let TestLake { catalog, ident, _dir } = lake().await;
         let sink = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-1");
         let source = Source::new("test");
         let docs = vec![doc("a", "alpha"), doc("b", "beta")];
@@ -618,7 +625,7 @@ mod tests {
 
     #[tokio::test]
     async fn change_and_vanish_append_upsert_and_tombstone() {
-        let (catalog, ident, _dir) = lake().await;
+        let TestLake { catalog, ident, _dir } = lake().await;
         let sink = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-1");
         let source = Source::new("test");
         sink.reconcile(&source, &[doc("a", "alpha"), doc("b", "beta")]).await.expect("seed");
@@ -636,7 +643,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty_desired_state_never_mass_tombstones() {
-        let (catalog, ident, _dir) = lake().await;
+        let TestLake { catalog, ident, _dir } = lake().await;
         let sink = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-1");
         let source = Source::new("test");
         sink.reconcile(&source, &[doc("a", "alpha")]).await.expect("seed");
@@ -651,7 +658,7 @@ mod tests {
 
     #[tokio::test]
     async fn slices_tombstone_independently() {
-        let (catalog, ident, _dir) = lake().await;
+        let TestLake { catalog, ident, _dir } = lake().await;
         let source = Source::new("test");
         let host1 = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-1");
         let host2 = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-2");
@@ -705,7 +712,7 @@ mod tests {
 
     #[tokio::test]
     async fn stale_base_append_merges_without_losing_either_commit() {
-        let (catalog, ident, _dir) = lake().await;
+        let TestLake { catalog, ident, _dir } = lake().await;
         let sink = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-1");
         let source = Source::new("test");
         sink.reconcile(&source, &[doc("a", "alpha")]).await.expect("seed");
@@ -730,7 +737,7 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_writers_all_land() {
-        let (catalog, ident, _dir) = lake().await;
+        let TestLake { catalog, ident, _dir } = lake().await;
         let source = Source::new("test");
         let mut handles = Vec::new();
         for i in 0..4 {
@@ -753,7 +760,7 @@ mod tests {
     /// The same code against a live REST catalog, env-configured. One test,
     /// three backends: the memory catalog covers the suite above,
     /// `fixture/rest-fixture.sh` stands up the apache/iceberg-rest-fixture +
-    /// MinIO pair locally, and R2 Data Catalog staging uses the same
+    /// `MinIO` pair locally, and R2 Data Catalog staging uses the same
     /// variables with Cloudflare values (see fixture/README.md).
     #[tokio::test]
     #[ignore = "needs a live REST catalog: run fixture/rest-fixture.sh, or set LAKE_TEST_* for R2"]
@@ -839,7 +846,7 @@ mod tests {
 
     #[tokio::test]
     async fn snapshot_cursor_sees_only_later_appends() {
-        let (catalog, ident, _dir) = lake().await;
+        let TestLake { catalog, ident, _dir } = lake().await;
         let sink = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-1");
         let source = Source::new("test");
         sink.reconcile(&source, &[doc("a", "alpha")]).await.expect("first");

--- a/packages/lake/iceberg/src/lib.rs
+++ b/packages/lake/iceberg/src/lib.rs
@@ -212,10 +212,10 @@ impl IcebergReconciler {
 
     /// The predicate selecting this slice's rows for one source.
     fn slice_filter(&self, source: &Source) -> Predicate {
-        let user = match &self.user {
-            Some(user) => Reference::new("user").equal_to(Datum::string(user)),
-            None => Reference::new("user").is_null(),
-        };
+        let user = self.user.as_ref().map_or_else(
+            || Reference::new("user").is_null(),
+            |user| Reference::new("user").equal_to(Datum::string(user)),
+        );
         Reference::new("source")
             .equal_to(Datum::string(source.as_str()))
             .and(Reference::new("host").equal_to(Datum::string(&self.host)))
@@ -289,9 +289,11 @@ impl Reconciler for IcebergReconciler {
     }
 }
 
-/// Fold the whole log into the current document set (every slice, tombstones
-/// applied, latest observation per `external_id`), sorted by id. The full
-/// rebuild primitive: replaying this into a view reproduces current state.
+/// Fold the whole log into the current document set, sorted by id.
+///
+/// Every slice, tombstones applied, latest observation per `external_id` —
+/// the full rebuild primitive: replaying this into a view reproduces current
+/// state.
 ///
 /// # Errors
 /// Returns an error if the table cannot be loaded or scanned, or a row is
@@ -519,9 +521,12 @@ fn now_ms() -> Result<i64> {
     let elapsed =
         SystemTime::now().duration_since(UNIX_EPOCH).context(ClockBeforeEpochSnafu)?;
     let now = i64::try_from(elapsed.as_millis()).context(ClockSnafu)?;
-    let mut last = LAST.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    let stamped = now.max(*last + 1);
-    *last = stamped;
+    let stamped = {
+        let mut last = LAST.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let stamped = now.max(*last + 1);
+        *last = stamped;
+        stamped
+    };
     Ok(stamped)
 }
 

--- a/packages/lake/iceberg/src/lib.rs
+++ b/packages/lake/iceberg/src/lib.rs
@@ -40,6 +40,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 pub use codec::{OP_DELETE, OP_UPSERT};
 pub use error::{Error, Result};
+// Re-exported so consumers can hold a connected lake without depending on the
+// iceberg crate (and its arrow tree) directly.
+pub use iceberg::{Catalog, TableIdent};
 
 use futures::TryStreamExt as _;
 use iceberg::expr::{Predicate, Reference};
@@ -56,9 +59,7 @@ use iceberg::writer::file_writer::location_generator::{
 };
 use iceberg::writer::file_writer::rolling_writer::RollingFileWriterBuilder;
 use iceberg::writer::{IcebergWriter as _, IcebergWriterBuilder as _};
-use iceberg::{
-    Catalog, CatalogBuilder as _, ErrorKind, NamespaceIdent, TableCreation, TableIdent,
-};
+use iceberg::{CatalogBuilder as _, ErrorKind, NamespaceIdent, TableCreation};
 use iceberg_catalog_rest::{
     REST_CATALOG_PROP_URI, REST_CATALOG_PROP_WAREHOUSE, RestCatalogBuilder,
 };

--- a/packages/lake/iceberg/src/lib.rs
+++ b/packages/lake/iceberg/src/lib.rs
@@ -541,6 +541,7 @@ mod tests {
     use iceberg::memory::{MEMORY_CATALOG_WAREHOUSE, MemoryCatalogBuilder};
     use iceberg::{Catalog, CatalogBuilder as _, TableIdent};
     use serde_json::json;
+    use snafu::IntoError as _;
     use source_meta::{Document, Reconciler as _, Source};
 
     use super::{IcebergReconciler, added_since, current_snapshot_id, ensure_table, read_all};
@@ -558,7 +559,7 @@ mod tests {
         (catalog, ident, dir)
     }
 
-    fn doc(id: &str, body: &str) -> Document {
+    fn doc_in(source: &str, id: &str, body: &str) -> Document {
         let content_hash = source_meta::hash_body(body.as_bytes());
         Document {
             external_id: id.to_owned(),
@@ -566,7 +567,7 @@ mod tests {
             mime: "text/plain",
             body: body.as_bytes().to_vec(),
             meta_json: json!({
-                "source": "test",
+                "source": source,
                 "external_id": id,
                 "content_hash": content_hash,
                 "title": format!("title {id}"),
@@ -574,6 +575,10 @@ mod tests {
             }),
             content_hash,
         }
+    }
+
+    fn doc(id: &str, body: &str) -> Document {
+        doc_in("test", id, body)
     }
 
     #[tokio::test]
@@ -665,6 +670,171 @@ mod tests {
         alice.reconcile(&source, &[doc("alice-1", "hers")]).await.expect("alice seed");
         let report = host1.reconcile(&source, &[doc("one-b", "new")]).await.expect("host1 again");
         assert!(report.skipped, "host-level slice must not see alice's rows");
+    }
+
+    /// Commit a small batch onto an explicit (possibly stale) table handle,
+    /// bypassing the reconciler's reload-per-attempt loop — the construction
+    /// both conflict tests share.
+    async fn commit_on(
+        catalog: &dyn Catalog,
+        table: &iceberg::table::Table,
+        source: &Source,
+        document: &Document,
+    ) -> super::Result<()> {
+        use iceberg::transaction::{ApplyTransactionAction as _, Transaction};
+        let schema = Arc::new(
+            iceberg::arrow::schema_to_arrow_schema(table.metadata().current_schema())
+                .expect("arrow schema"),
+        );
+        let batch = crate::codec::encode_batch(
+            &schema,
+            source,
+            crate::codec::Slice { host: "host-1", user: None },
+            1,
+            &[document],
+            &[],
+        )
+        .expect("batch");
+        let files = super::write_batch(table, batch).await.expect("write files");
+        let tx = Transaction::new(table);
+        let tx = tx.fast_append().add_data_files(files).apply(tx).expect("apply");
+        tx.commit(catalog).await.map(|_| ()).map_err(|error| {
+            super::error::CommitSnafu { attempts: 1_u32 }.into_error(error)
+        })
+    }
+
+    #[tokio::test]
+    async fn stale_base_append_merges_without_losing_either_commit() {
+        let (catalog, ident, _dir) = lake().await;
+        let sink = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-1");
+        let source = Source::new("test");
+        sink.reconcile(&source, &[doc("a", "alpha")]).await.expect("seed");
+
+        // Hold a stale handle while another commit advances the table.
+        let stale = catalog.load_table(&ident).await.expect("stale handle");
+        sink.reconcile(&source, &[doc("a", "alpha"), doc("b", "beta")]).await.expect("advance");
+
+        // Appends carry no snapshot-ref requirement, so a commit from the
+        // stale base MERGES rather than conflicts: that is the lost-update
+        // safety the fleet's concurrent writers rely on. (A REST server that
+        // CASes the metadata pointer surfaces the same race as HTTP 409 →
+        // CatalogCommitConflicts, which commit_files retries; that leg is
+        // exercised in rest_round_trip_via_env against a real server.)
+        commit_on(catalog.as_ref(), &stale, &source, &doc("c", "gamma"))
+            .await
+            .expect("a stale-base append must merge");
+        let all = read_all(catalog.as_ref(), &ident).await.expect("read_all");
+        let ids: Vec<&str> = all.iter().map(|d| d.external_id.as_str()).collect();
+        assert_eq!(ids, ["a", "b", "c"], "no commit may be lost to the race");
+    }
+
+    #[tokio::test]
+    async fn concurrent_writers_all_land() {
+        let (catalog, ident, _dir) = lake().await;
+        let source = Source::new("test");
+        let mut handles = Vec::new();
+        for i in 0..4 {
+            let catalog = Arc::clone(&catalog);
+            let ident = ident.clone();
+            let source = source.clone();
+            handles.push(tokio::spawn(async move {
+                let sink = IcebergReconciler::new(catalog, ident, format!("host-{i}"));
+                sink.reconcile(&source, &[doc(&format!("doc-{i}"), "body")]).await
+            }));
+        }
+        for handle in handles {
+            let report = handle.await.expect("join").expect("reconcile");
+            assert!(!report.skipped);
+        }
+        let all = read_all(catalog.as_ref(), &ident).await.expect("read_all");
+        assert_eq!(all.len(), 4, "every concurrent writer's document must land");
+    }
+
+    /// The same code against a live REST catalog, env-configured. One test,
+    /// three backends: the memory catalog covers the suite above,
+    /// `fixture/rest-fixture.sh` stands up the apache/iceberg-rest-fixture +
+    /// MinIO pair locally, and R2 Data Catalog staging uses the same
+    /// variables with Cloudflare values (see fixture/README.md).
+    #[tokio::test]
+    #[ignore = "needs a live REST catalog: run fixture/rest-fixture.sh, or set LAKE_TEST_* for R2"]
+    async fn rest_round_trip_via_env() {
+        let uri = std::env::var("LAKE_TEST_CATALOG_URI")
+            .expect("LAKE_TEST_CATALOG_URI must be set; see fixture/README.md");
+        let config = super::Config {
+            uri,
+            warehouse: std::env::var("LAKE_TEST_WAREHOUSE").unwrap_or_default(),
+            token: std::env::var("LAKE_TEST_CATALOG_TOKEN").ok(),
+            s3_endpoint: std::env::var("LAKE_TEST_S3_ENDPOINT").ok(),
+            s3_region: std::env::var("LAKE_TEST_S3_REGION").unwrap_or_else(|_| "auto".to_owned()),
+        };
+        let catalog = config.connect().await.expect("connect");
+        let ident = ensure_table(catalog.as_ref()).await.expect("ensure table");
+
+        // Unique ids and source tag per run: repeated runs share the catalog.
+        let tag = format!("resttest-{}", uuid::Uuid::new_v4());
+        let source = Source::new(tag.clone());
+        let id = |suffix: &str| format!("{tag}:{suffix}");
+        let sink = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "rest-host");
+
+        // Reconcile, converge, change + tombstone — the memory-catalog suite's
+        // arc, through the production REST + S3 wiring.
+        let seed = vec![doc_in(&tag, &id("r1"), "one"), doc_in(&tag, &id("r2"), "two")];
+        let first = sink.reconcile(&source, &seed).await.expect("seed");
+        assert_eq!((first.upserts, first.deletes, first.skipped), (2, 0, false));
+        assert!(sink.reconcile(&source, &seed).await.expect("converged").skipped);
+
+        let cursor = current_snapshot_id(catalog.as_ref(), &ident)
+            .await
+            .expect("snapshot")
+            .expect("committed");
+        let changed = vec![doc_in(&tag, &id("r1"), "one EDITED")];
+        let delta_report = sink.reconcile(&source, &changed).await.expect("delta");
+        assert_eq!((delta_report.upserts, delta_report.deletes), (1, 1));
+
+        let mine: Vec<Document> = read_all(catalog.as_ref(), &ident)
+            .await
+            .expect("read_all")
+            .into_iter()
+            .filter(|d| d.meta_json["source"] == tag.as_str())
+            .collect();
+        assert_eq!(mine.len(), 1);
+        assert_eq!(mine[0].body, b"one EDITED");
+
+        let delta = added_since(catalog.as_ref(), &ident, cursor).await.expect("added_since");
+        assert!(delta.deletes.contains(&id("r2")), "the tombstone must arrive via the cursor");
+
+        // The stale-base leg, against a real server. Two acceptable behaviors
+        // exist, and which one a backend exhibits is exactly what this records:
+        // an Iceberg-aware server rebases the append (merge, like the memory
+        // catalog), while a metadata-pointer-CAS server answers HTTP 409,
+        // which must map to the kind commit_files retries on. Anything else
+        // is a contract break.
+        let stale = catalog.load_table(&ident).await.expect("stale handle");
+        sink.reconcile(&source, &[doc_in(&tag, &id("r3"), "three")]).await.expect("advance");
+        match commit_on(catalog.as_ref(), &stale, &source, &doc_in(&tag, &id("c1"), "x")).await {
+            Ok(()) => {
+                eprintln!("[rest_round_trip] stale-base append: backend MERGES (no retry needed)");
+                let mine: Vec<Document> = read_all(catalog.as_ref(), &ident)
+                    .await
+                    .expect("read_all after merge")
+                    .into_iter()
+                    .filter(|d| d.meta_json["source"] == tag.as_str())
+                    .collect();
+                assert!(
+                    mine.iter().any(|d| d.external_id == id("c1")),
+                    "the merged append must not be lost"
+                );
+            }
+            Err(super::Error::Commit { source: inner, .. }) => {
+                eprintln!("[rest_round_trip] stale-base append: backend CASes (409, retryable)");
+                assert_eq!(
+                    inner.kind(),
+                    iceberg::ErrorKind::CatalogCommitConflicts,
+                    "a commit rejection must carry the kind the retry loop matches"
+                );
+            }
+            Err(other) => panic!("unexpected stale-base failure shape: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/packages/lake/iceberg/src/lib.rs
+++ b/packages/lake/iceberg/src/lib.rs
@@ -1,0 +1,701 @@
+//! The Iceberg corpus lake: the durable, replayable log under the multi-source
+//! search corpus (issue #752), succeeding the full-file-overwrite parquet log.
+//!
+//! One table (`corpus.documents`) holds an **append-only revision log** of
+//! [`Document`] observations: each reconcile pass appends only the documents
+//! that are new or changed (`op = upsert`) plus tombstones for the ones that
+//! left the writer's desired state (`op = delete`). Current state is a
+//! latest-wins fold per `external_id`; replay and incremental catch-up share
+//! one discipline, the **snapshot cursor** ([`added_since`]).
+//!
+//! Both halves live in this one crate — unlike the `sink-parquet` /
+//! `source-parquet` pair, where the object layout is the whole contract, the
+//! write and read halves here share the table's schema, codec, catalog
+//! connection, and fold, so splitting them would only duplicate that core.
+//!
+//! - **Write half**: [`IcebergReconciler`] implements
+//!   [`source_meta::Reconciler`]. Each pass diffs the writer's *slice* (its
+//!   `host`, optional `user`) against the desired set and appends the delta.
+//!   An empty desired set is treated as "source absent", never as "delete
+//!   everything" (matching `sink-parquet`), so a transiently empty read cannot
+//!   tombstone a corpus.
+//! - **Read half**: [`read_all`] folds the whole log into current documents
+//!   (full rebuilds); [`added_since`] walks only the snapshots a cursor has
+//!   not seen (steady-state view catch-up). Compaction (`Replace` snapshots,
+//!   e.g. R2 Data Catalog's managed compaction) rewrites files without adding
+//!   rows, so the cursor walk follows `Append` snapshots only.
+//!
+//! Production is a REST catalog (Cloudflare R2 Data Catalog) over S3-compatible
+//! storage ([`Config::connect`]); tests run the same code against iceberg's
+//! in-memory catalog.
+
+#![forbid(unsafe_code)]
+
+mod codec;
+mod error;
+
+use std::collections::{BTreeSet, HashMap};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub use codec::{OP_DELETE, OP_UPSERT};
+pub use error::{Error, Result};
+
+use futures::TryStreamExt as _;
+use iceberg::expr::{Predicate, Reference};
+use iceberg::io::FileIO;
+use iceberg::spec::{
+    DataContentType, DataFile, Datum, ManifestContentType, ManifestStatus, Operation,
+};
+use iceberg::table::Table;
+use iceberg::transaction::{ApplyTransactionAction as _, Transaction};
+use iceberg::writer::base_writer::data_file_writer::DataFileWriterBuilder;
+use iceberg::writer::file_writer::ParquetWriterBuilder;
+use iceberg::writer::file_writer::location_generator::{
+    DefaultFileNameGenerator, DefaultLocationGenerator,
+};
+use iceberg::writer::file_writer::rolling_writer::RollingFileWriterBuilder;
+use iceberg::writer::{IcebergWriter as _, IcebergWriterBuilder as _};
+use iceberg::{
+    Catalog, CatalogBuilder as _, ErrorKind, NamespaceIdent, TableCreation, TableIdent,
+};
+use iceberg_catalog_rest::{
+    REST_CATALOG_PROP_URI, REST_CATALOG_PROP_WAREHOUSE, RestCatalogBuilder,
+};
+use iceberg_storage_opendal::OpenDalStorageFactory;
+use parquet_57::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet_57::file::properties::WriterProperties;
+use snafu::{OptionExt as _, ResultExt as _};
+use source_meta::{Document, Reconciler, Source};
+
+use crate::codec::{LakeRow, Op, Slice};
+use crate::error::{
+    ClockBeforeEpochSnafu, ClockSnafu, CommitSnafu, ConnectSnafu, CursorNotFoundSnafu,
+    DecodeFileSnafu, EnsureTableSnafu, LoadTableSnafu, ParseFileSnafu, ReadFileSnafu, SchemaSnafu,
+    ScanSnafu, WriteSnafu,
+};
+
+/// The lake's Iceberg namespace.
+pub const NAMESPACE: &str = "corpus";
+/// The lake's table name within [`NAMESPACE`].
+pub const TABLE: &str = "documents";
+
+/// How many times a conflicted append commit is retried (each attempt reloads
+/// the table and re-applies the already-written data files).
+const COMMIT_ATTEMPTS: u32 = 5;
+
+/// Connection settings for the production REST catalog (R2 Data Catalog).
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Catalog URI (R2: `https://catalog.cloudflarestorage.com/<account>/<bucket>`).
+    pub uri: String,
+    /// Warehouse name the catalog serves (R2: `<account>_<bucket>`).
+    pub warehouse: String,
+    /// Bearer token for the catalog REST API.
+    pub token: Option<String>,
+    /// S3 endpoint for the data plane (R2: the account endpoint). `None` lets
+    /// the catalog's own storage config (if vended) or AWS defaults apply.
+    pub s3_endpoint: Option<String>,
+    /// S3 region label (`auto` for R2).
+    pub s3_region: String,
+}
+
+impl Config {
+    /// Connect the REST catalog with an S3 data plane. S3 credentials come
+    /// from the environment (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`),
+    /// the same convention as the parquet sink.
+    ///
+    /// # Errors
+    /// Returns an error if the catalog handshake fails.
+    pub async fn connect(&self) -> Result<Arc<dyn Catalog>> {
+        let mut props = HashMap::from([
+            (REST_CATALOG_PROP_URI.to_owned(), self.uri.clone()),
+            (REST_CATALOG_PROP_WAREHOUSE.to_owned(), self.warehouse.clone()),
+            (iceberg::io::S3_REGION.to_owned(), self.s3_region.clone()),
+        ]);
+        if let Some(token) = &self.token {
+            props.insert("token".to_owned(), token.clone());
+        }
+        if let Some(endpoint) = &self.s3_endpoint {
+            props.insert(iceberg::io::S3_ENDPOINT.to_owned(), endpoint.clone());
+        }
+        for (env, key) in [
+            ("AWS_ACCESS_KEY_ID", iceberg::io::S3_ACCESS_KEY_ID),
+            ("AWS_SECRET_ACCESS_KEY", iceberg::io::S3_SECRET_ACCESS_KEY),
+        ] {
+            if let Ok(value) = std::env::var(env) {
+                props.insert(key.to_owned(), value);
+            }
+        }
+        let catalog = RestCatalogBuilder::default()
+            .with_storage_factory(Arc::new(OpenDalStorageFactory::S3 {
+                configured_scheme: "s3".to_owned(),
+                customized_credential_load: None,
+            }))
+            .load("lake", props)
+            .await
+            .context(ConnectSnafu { uri: self.uri.clone() })?;
+        Ok(Arc::new(catalog))
+    }
+}
+
+/// Create the `corpus.documents` table if absent and return its identifier.
+/// Race-safe: a concurrent host winning the create is fine (`AlreadyExists`
+/// from either step is success).
+///
+/// # Errors
+/// Returns an error if the namespace or table cannot be created or checked.
+pub async fn ensure_table(catalog: &dyn Catalog) -> Result<TableIdent> {
+    let ns = NamespaceIdent::new(NAMESPACE.to_owned());
+    let ident = TableIdent::new(ns.clone(), TABLE.to_owned());
+    match catalog.create_namespace(&ns, HashMap::new()).await {
+        Ok(_) => {}
+        Err(error) if error.kind() == ErrorKind::NamespaceAlreadyExists => {}
+        Err(error) => return Err(error).context(EnsureTableSnafu { table: ident.to_string() }),
+    }
+    let creation =
+        TableCreation::builder().name(TABLE.to_owned()).schema(codec::table_schema()?).build();
+    match catalog.create_table(&ns, creation).await {
+        Ok(_) => Ok(ident),
+        Err(error) if error.kind() == ErrorKind::TableAlreadyExists => Ok(ident),
+        Err(error) => Err(error).context(EnsureTableSnafu { table: ident.to_string() }),
+    }
+}
+
+/// Outcome of one lake reconcile pass for a source.
+#[derive(Debug, Clone, Copy)]
+pub struct Report {
+    /// Documents appended as new or changed observations.
+    pub upserts: usize,
+    /// Tombstones appended for documents that left the slice's desired state.
+    pub deletes: usize,
+    /// Whether the pass appended nothing (desired state already converged, or
+    /// the desired set was empty).
+    pub skipped: bool,
+}
+
+/// Reconciles a source's documents into the lake as an appended delta.
+///
+/// Holds the writer's *slice* identity: tombstones are computed against this
+/// `host`/`user`'s own previous observations only, so host A never deletes
+/// what host B still observes (the per-user fleet path derives per-account
+/// reconcilers via [`IcebergReconciler::with_user`], mirroring the parquet
+/// sink's per-user prefixes).
+pub struct IcebergReconciler {
+    /// The connected catalog.
+    catalog: Arc<dyn Catalog>,
+    /// The lake table.
+    ident: TableIdent,
+    /// The writing host.
+    host: String,
+    /// The account, for per-user sources.
+    user: Option<String>,
+}
+
+impl IcebergReconciler {
+    /// A reconciler writing host-level observations (no `user` scope).
+    #[must_use]
+    pub fn new(catalog: Arc<dyn Catalog>, ident: TableIdent, host: impl Into<String>) -> Self {
+        Self { catalog, ident, host: host.into(), user: None }
+    }
+
+    /// The same connection, scoped to one account's slice.
+    #[must_use]
+    pub fn with_user(&self, user: impl Into<String>) -> Self {
+        Self {
+            catalog: Arc::clone(&self.catalog),
+            ident: self.ident.clone(),
+            host: self.host.clone(),
+            user: Some(user.into()),
+        }
+    }
+
+    /// The predicate selecting this slice's rows for one source.
+    fn slice_filter(&self, source: &Source) -> Predicate {
+        let user = match &self.user {
+            Some(user) => Reference::new("user").equal_to(Datum::string(user)),
+            None => Reference::new("user").is_null(),
+        };
+        Reference::new("source")
+            .equal_to(Datum::string(source.as_str()))
+            .and(Reference::new("host").equal_to(Datum::string(&self.host)))
+            .and(user)
+    }
+}
+
+impl Reconciler for IcebergReconciler {
+    type Report = Report;
+    type Error = Error;
+
+    /// Diff `documents` against this slice's live state and append the delta:
+    /// upserts for new or changed documents, tombstones for vanished ones.
+    /// Converged state appends nothing (no empty snapshots). An empty
+    /// `documents` is a skip, never a mass tombstone.
+    async fn reconcile(&self, source: &Source, documents: &[Document]) -> Result<Report> {
+        if documents.is_empty() {
+            return Ok(Report { upserts: 0, deletes: 0, skipped: true });
+        }
+        let table = load_table(self.catalog.as_ref(), &self.ident).await?;
+
+        // The slice's live state: latest observation per id, minus tombstones.
+        let rows =
+            scan_rows(&table, Some(self.slice_filter(source)), &codec::STATE_COLUMNS, false)
+                .await?;
+        let mut live: HashMap<String, Option<String>> = HashMap::new();
+        for (id, row) in codec::fold_latest(rows) {
+            if row.op == Op::Upsert {
+                live.insert(id, row.content_hash);
+            }
+        }
+
+        // The delta. A live record with no stored hash cannot happen from this
+        // writer, but is treated as changed (re-observe) rather than trusted.
+        let upserts: Vec<&Document> = documents
+            .iter()
+            .filter(|document| {
+                !matches!(
+                    live.get(&document.external_id),
+                    Some(Some(hash)) if *hash == document.content_hash
+                )
+            })
+            .collect();
+        let desired: BTreeSet<&str> =
+            documents.iter().map(|document| document.external_id.as_str()).collect();
+        let deletes: BTreeSet<&str> = live
+            .keys()
+            .map(String::as_str)
+            .filter(|id| !desired.contains(id))
+            .collect();
+        if upserts.is_empty() && deletes.is_empty() {
+            return Ok(Report { upserts: 0, deletes: 0, skipped: true });
+        }
+        let deletes: Vec<&str> = deletes.into_iter().collect();
+
+        let arrow_schema = Arc::new(
+            iceberg::arrow::schema_to_arrow_schema(table.metadata().current_schema())
+                .context(SchemaSnafu)?,
+        );
+        let batch = codec::encode_batch(
+            &arrow_schema,
+            source,
+            Slice { host: &self.host, user: self.user.as_deref() },
+            now_ms()?,
+            &upserts,
+            &deletes,
+        )?;
+        let files = write_batch(&table, batch).await?;
+        commit_files(self.catalog.as_ref(), &self.ident, files).await?;
+        Ok(Report { upserts: upserts.len(), deletes: deletes.len(), skipped: false })
+    }
+}
+
+/// Fold the whole log into the current document set (every slice, tombstones
+/// applied, latest observation per `external_id`), sorted by id. The full
+/// rebuild primitive: replaying this into a view reproduces current state.
+///
+/// # Errors
+/// Returns an error if the table cannot be loaded or scanned, or a row is
+/// malformed.
+pub async fn read_all(catalog: &dyn Catalog, ident: &TableIdent) -> Result<Vec<Document>> {
+    let table = load_table(catalog, ident).await?;
+    let rows = scan_rows(&table, None, &codec::CODEC_COLUMNS, true).await?;
+    let mut documents = codec::fold_latest(rows)
+        .into_values()
+        .filter(|row| row.op == Op::Upsert)
+        .map(codec::document_from_row)
+        .collect::<Result<Vec<Document>>>()?;
+    documents.sort_by(|a, b| a.external_id.cmp(&b.external_id));
+    Ok(documents)
+}
+
+/// The table's current snapshot id, the cursor a caught-up consumer stores.
+/// `None` for a table with no commits yet.
+///
+/// # Errors
+/// Returns an error if the table cannot be loaded.
+pub async fn current_snapshot_id(catalog: &dyn Catalog, ident: &TableIdent) -> Result<Option<i64>> {
+    let table = load_table(catalog, ident).await?;
+    Ok(table.metadata().current_snapshot().map(|snapshot| snapshot.snapshot_id()))
+}
+
+/// The changes a cursor has not seen, folded (a later op on the same id wins).
+#[derive(Debug)]
+pub struct Delta {
+    /// Documents observed new or changed since the cursor.
+    pub upserts: Vec<Document>,
+    /// Ids tombstoned since the cursor.
+    pub deletes: Vec<String>,
+    /// The snapshot this delta is current to; store it as the next cursor.
+    pub to_snapshot: Option<i64>,
+}
+
+/// Walk the snapshots appended after `cursor` and fold their rows into a
+/// [`Delta`] — the steady-state incremental read.
+///
+/// Only `Append` snapshots are followed: `Replace` snapshots are compaction
+/// (R2 Data Catalog's managed compaction emits these) and rewrite existing
+/// rows into new files, so following them would re-deliver the whole table
+/// after every compaction. Within each followed snapshot, only manifests it
+/// added are read — manifest files are immutable and carried forward, so an
+/// unfiltered walk would also re-deliver every old file.
+///
+/// # Errors
+/// Returns [`Error::CursorNotFound`] when `cursor` is no longer in table
+/// metadata (snapshot expiration) — the caller falls back to [`read_all`] —
+/// and other errors when the walk or a data file read fails.
+pub async fn added_since(
+    catalog: &dyn Catalog,
+    ident: &TableIdent,
+    cursor: i64,
+) -> Result<Delta> {
+    let table = load_table(catalog, ident).await?;
+    let meta = table.metadata();
+    let cursor_seq = meta
+        .snapshots()
+        .find(|snapshot| snapshot.snapshot_id() == cursor)
+        .map(|snapshot| snapshot.sequence_number())
+        .context(CursorNotFoundSnafu { snapshot: cursor })?;
+
+    let mut rows = Vec::new();
+    let appends = meta.snapshots().filter(|snapshot| {
+        snapshot.sequence_number() > cursor_seq
+            && snapshot.summary().operation == Operation::Append
+    });
+    for snapshot in appends {
+        let list = snapshot
+            .load_manifest_list(table.file_io(), meta)
+            .await
+            .context(ScanSnafu { stage: "manifest list" })?;
+        for manifest_file in list.entries() {
+            if manifest_file.content != ManifestContentType::Data
+                || manifest_file.added_snapshot_id != snapshot.snapshot_id()
+            {
+                continue;
+            }
+            let manifest = manifest_file
+                .load_manifest(table.file_io())
+                .await
+                .context(ScanSnafu { stage: "manifest" })?;
+            for entry in manifest.entries() {
+                if entry.status() == ManifestStatus::Added
+                    && entry.data_file().content_type() == DataContentType::Data
+                {
+                    read_data_file(table.file_io(), entry.data_file().file_path(), &mut rows)
+                        .await?;
+                }
+            }
+        }
+    }
+
+    let mut upserts = Vec::new();
+    let mut deletes = Vec::new();
+    for (id, row) in codec::fold_latest(rows) {
+        match row.op {
+            Op::Upsert => upserts.push(codec::document_from_row(row)?),
+            Op::Delete => deletes.push(id),
+        }
+    }
+    upserts.sort_by(|a, b| a.external_id.cmp(&b.external_id));
+    deletes.sort();
+    Ok(Delta { upserts, deletes, to_snapshot: meta.current_snapshot().map(|s| s.snapshot_id()) })
+}
+
+/// Load the lake table, with a typed error naming it.
+async fn load_table(catalog: &dyn Catalog, ident: &TableIdent) -> Result<Table> {
+    catalog.load_table(ident).await.context(LoadTableSnafu { table: ident.to_string() })
+}
+
+/// Scan rows with an optional filter and a column projection, decoding into
+/// [`LakeRow`]s (`with_payload` per [`codec::rows_from_batch`]).
+async fn scan_rows(
+    table: &Table,
+    filter: Option<Predicate>,
+    columns: &[&str],
+    with_payload: bool,
+) -> Result<Vec<LakeRow>> {
+    // A table with no commits yet has nothing to scan (and no snapshot for the
+    // scan planner to anchor on).
+    if table.metadata().current_snapshot().is_none() {
+        return Ok(Vec::new());
+    }
+    let mut builder = table.scan().select(columns.iter().copied());
+    if let Some(predicate) = filter {
+        builder = builder.with_filter(predicate);
+    }
+    let stream = builder
+        .build()
+        .context(ScanSnafu { stage: "build" })?
+        .to_arrow()
+        .await
+        .context(ScanSnafu { stage: "open" })?;
+    let batches: Vec<arrow_array::RecordBatch> =
+        stream.try_collect().await.context(ScanSnafu { stage: "read" })?;
+    let mut rows = Vec::new();
+    for batch in &batches {
+        codec::rows_from_batch(batch, with_payload, &mut rows)?;
+    }
+    Ok(rows)
+}
+
+/// Read one data file's rows directly through the table's `FileIO` (the
+/// incremental walk reads files the scan planner has no task list for).
+async fn read_data_file(file_io: &FileIO, path: &str, out: &mut Vec<LakeRow>) -> Result<()> {
+    let input = file_io.new_input(path).context(ReadFileSnafu { path })?;
+    let bytes = input.read().await.context(ReadFileSnafu { path })?;
+    let reader = ParquetRecordBatchReaderBuilder::try_new(bytes)
+        .context(ParseFileSnafu { path })?
+        .build()
+        .context(ParseFileSnafu { path })?;
+    for batch in reader {
+        let batch = batch.context(DecodeFileSnafu { path })?;
+        codec::rows_from_batch(&batch, true, out)?;
+    }
+    Ok(())
+}
+
+/// Write one record batch as data files, named uniquely per pass (a reused
+/// name is rejected by the table as already-referenced).
+async fn write_batch(
+    table: &Table,
+    batch: arrow_array::RecordBatch,
+) -> Result<Vec<DataFile>> {
+    let location_gen = DefaultLocationGenerator::new(table.metadata().clone())
+        .context(WriteSnafu { stage: "location" })?;
+    let name_gen = DefaultFileNameGenerator::new(
+        "corpus".to_owned(),
+        Some(uuid::Uuid::new_v4().to_string()),
+        iceberg::spec::DataFileFormat::Parquet,
+    );
+    let parquet_writer = ParquetWriterBuilder::new(
+        WriterProperties::default(),
+        table.metadata().current_schema().clone(),
+    );
+    let rolling = RollingFileWriterBuilder::new_with_default_file_size(
+        parquet_writer,
+        table.file_io().clone(),
+        location_gen,
+        name_gen,
+    );
+    let mut writer = DataFileWriterBuilder::new(rolling)
+        .build(None)
+        .await
+        .context(WriteSnafu { stage: "build" })?;
+    writer.write(batch).await.context(WriteSnafu { stage: "write" })?;
+    writer.close().await.context(WriteSnafu { stage: "close" })
+}
+
+/// Commit already-written data files, retrying commit conflicts (concurrent
+/// fleet hosts appending) by reloading the table and re-applying the same
+/// files — data files are snapshot-independent, so they are reusable across
+/// attempts.
+async fn commit_files(
+    catalog: &dyn Catalog,
+    ident: &TableIdent,
+    files: Vec<DataFile>,
+) -> Result<()> {
+    let mut attempt = 1;
+    loop {
+        let table = load_table(catalog, ident).await?;
+        let tx = Transaction::new(&table);
+        let action = tx.fast_append().add_data_files(files.clone());
+        let tx = action.apply(tx).context(CommitSnafu { attempts: attempt })?;
+        match tx.commit(catalog).await {
+            Ok(_) => return Ok(()),
+            Err(error)
+                if error.kind() == ErrorKind::CatalogCommitConflicts
+                    && attempt < COMMIT_ATTEMPTS =>
+            {
+                attempt += 1;
+            }
+            Err(error) => return Err(error).context(CommitSnafu { attempts: attempt }),
+        }
+    }
+}
+
+/// Current time as epoch milliseconds, strictly monotonic within this process
+/// so two passes in the same millisecond still order correctly in the fold.
+fn now_ms() -> Result<i64> {
+    static LAST: Mutex<i64> = Mutex::new(0);
+    let elapsed =
+        SystemTime::now().duration_since(UNIX_EPOCH).context(ClockBeforeEpochSnafu)?;
+    let now = i64::try_from(elapsed.as_millis()).context(ClockSnafu)?;
+    let mut last = LAST.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let stamped = now.max(*last + 1);
+    *last = stamped;
+    Ok(stamped)
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::expect_used, reason = "tests assert observable lake outcomes")]
+
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use iceberg::memory::{MEMORY_CATALOG_WAREHOUSE, MemoryCatalogBuilder};
+    use iceberg::{Catalog, CatalogBuilder as _, TableIdent};
+    use serde_json::json;
+    use source_meta::{Document, Reconciler as _, Source};
+
+    use super::{IcebergReconciler, added_since, current_snapshot_id, ensure_table, read_all};
+
+    /// A memory-catalog lake; the tempdir must outlive the catalog.
+    async fn lake() -> (Arc<dyn Catalog>, TableIdent, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let warehouse = format!("file://{}", dir.path().display());
+        let catalog = MemoryCatalogBuilder::default()
+            .load("lake", HashMap::from([(MEMORY_CATALOG_WAREHOUSE.to_owned(), warehouse)]))
+            .await
+            .expect("memory catalog");
+        let catalog: Arc<dyn Catalog> = Arc::new(catalog);
+        let ident = ensure_table(catalog.as_ref()).await.expect("ensure table");
+        (catalog, ident, dir)
+    }
+
+    fn doc(id: &str, body: &str) -> Document {
+        let content_hash = source_meta::hash_body(body.as_bytes());
+        Document {
+            external_id: id.to_owned(),
+            file_name: id.to_owned(),
+            mime: "text/plain",
+            body: body.as_bytes().to_vec(),
+            meta_json: json!({
+                "source": "test",
+                "external_id": id,
+                "content_hash": content_hash,
+                "title": format!("title {id}"),
+                "timestamp": 100,
+            }),
+            content_hash,
+        }
+    }
+
+    #[tokio::test]
+    async fn reconcile_appends_then_skips_then_reads_back() {
+        let (catalog, ident, _dir) = lake().await;
+        let sink = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-1");
+        let source = Source::new("test");
+        let docs = vec![doc("a", "alpha"), doc("b", "beta")];
+
+        let first = sink.reconcile(&source, &docs).await.expect("first");
+        assert_eq!((first.upserts, first.deletes, first.skipped), (2, 0, false));
+
+        // Converged state appends nothing — no empty snapshots.
+        let snapshot = current_snapshot_id(catalog.as_ref(), &ident)
+            .await
+            .expect("snapshot")
+            .expect("one commit");
+        let second = sink.reconcile(&source, &docs).await.expect("second");
+        assert!(second.skipped);
+        assert_eq!(
+            current_snapshot_id(catalog.as_ref(), &ident).await.expect("snapshot"),
+            Some(snapshot),
+            "a skipped pass must not commit"
+        );
+
+        // Full read-back round-trips the documents (source-parquet parity:
+        // file_name = external_id, plain-text mime, meta_json intact).
+        let all = read_all(catalog.as_ref(), &ident).await.expect("read_all");
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].external_id, "a");
+        assert_eq!(all[0].body, b"alpha");
+        assert_eq!(all[0].file_name, "a");
+        assert_eq!(all[0].mime, "text/plain");
+        assert_eq!(all[0].meta_json["title"], "title a");
+        assert_eq!(all[1].external_id, "b");
+    }
+
+    #[tokio::test]
+    async fn change_and_vanish_append_upsert_and_tombstone() {
+        let (catalog, ident, _dir) = lake().await;
+        let sink = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-1");
+        let source = Source::new("test");
+        sink.reconcile(&source, &[doc("a", "alpha"), doc("b", "beta")]).await.expect("seed");
+
+        // `a` changes, `b` vanishes from the desired state.
+        let report =
+            sink.reconcile(&source, &[doc("a", "alpha EDITED")]).await.expect("delta");
+        assert_eq!((report.upserts, report.deletes), (1, 1));
+
+        let all = read_all(catalog.as_ref(), &ident).await.expect("read_all");
+        assert_eq!(all.len(), 1, "the tombstoned document must fold away");
+        assert_eq!(all[0].external_id, "a");
+        assert_eq!(all[0].body, b"alpha EDITED");
+    }
+
+    #[tokio::test]
+    async fn empty_desired_state_never_mass_tombstones() {
+        let (catalog, ident, _dir) = lake().await;
+        let sink = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-1");
+        let source = Source::new("test");
+        sink.reconcile(&source, &[doc("a", "alpha")]).await.expect("seed");
+
+        // A transiently empty read (unreadable export, fresh account) must be
+        // a skip, not a corpus wipe.
+        let report = sink.reconcile(&source, &[]).await.expect("empty");
+        assert!(report.skipped);
+        let all = read_all(catalog.as_ref(), &ident).await.expect("read_all");
+        assert_eq!(all.len(), 1, "the document must survive an empty pass");
+    }
+
+    #[tokio::test]
+    async fn slices_tombstone_independently() {
+        let (catalog, ident, _dir) = lake().await;
+        let source = Source::new("test");
+        let host1 = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-1");
+        let host2 = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-2");
+        host1.reconcile(&source, &[doc("one", "from host 1")]).await.expect("host1 seed");
+        host2.reconcile(&source, &[doc("two", "from host 2")]).await.expect("host2 seed");
+
+        // host-1's document vanishes; host-2's slice must be untouched.
+        let report = host1.reconcile(&source, &[doc("one-b", "new")]).await.expect("host1 delta");
+        assert_eq!(report.deletes, 1);
+        let all = read_all(catalog.as_ref(), &ident).await.expect("read_all");
+        let ids: Vec<&str> = all.iter().map(|d| d.external_id.as_str()).collect();
+        assert_eq!(ids, ["one-b", "two"], "host-2's document must survive host-1's tombstone");
+
+        // The per-user derivation scopes the same way.
+        let alice = host1.with_user("alice");
+        alice.reconcile(&source, &[doc("alice-1", "hers")]).await.expect("alice seed");
+        let report = host1.reconcile(&source, &[doc("one-b", "new")]).await.expect("host1 again");
+        assert!(report.skipped, "host-level slice must not see alice's rows");
+    }
+
+    #[tokio::test]
+    async fn snapshot_cursor_sees_only_later_appends() {
+        let (catalog, ident, _dir) = lake().await;
+        let sink = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-1");
+        let source = Source::new("test");
+        sink.reconcile(&source, &[doc("a", "alpha")]).await.expect("first");
+        let cursor = current_snapshot_id(catalog.as_ref(), &ident)
+            .await
+            .expect("snapshot")
+            .expect("one commit");
+
+        sink.reconcile(&source, &[doc("a", "alpha"), doc("b", "beta")]).await.expect("second");
+        sink.reconcile(&source, &[doc("b", "beta")]).await.expect("third tombstones a");
+
+        let delta = added_since(catalog.as_ref(), &ident, cursor).await.expect("delta");
+        let upsert_ids: Vec<&str> =
+            delta.upserts.iter().map(|d| d.external_id.as_str()).collect();
+        assert_eq!(upsert_ids, ["b"], "only the post-cursor document arrives");
+        assert_eq!(delta.deletes, ["a"], "the later tombstone wins over a's earlier upsert");
+        assert_eq!(
+            delta.to_snapshot,
+            current_snapshot_id(catalog.as_ref(), &ident).await.expect("snapshot"),
+            "the delta reports the cursor to store next"
+        );
+
+        // A caught-up cursor yields an empty delta.
+        let caught_up = delta.to_snapshot.expect("snapshot");
+        let empty = added_since(catalog.as_ref(), &ident, caught_up).await.expect("empty delta");
+        assert!(empty.upserts.is_empty() && empty.deletes.is_empty());
+
+        // An expired/unknown cursor is the typed full-rescan signal.
+        let missing = added_since(catalog.as_ref(), &ident, 0).await;
+        assert!(
+            matches!(missing, Err(super::Error::CursorNotFound { snapshot: 0, .. })),
+            "an unknown cursor must demand a full rescan, got {missing:?}"
+        );
+    }
+}

--- a/packages/lake/iceberg/src/lib.rs
+++ b/packages/lake/iceberg/src/lib.rs
@@ -5,8 +5,12 @@
 //! [`Document`] observations: each reconcile pass appends only the documents
 //! that are new or changed (`op = upsert`) plus tombstones for the ones that
 //! left the writer's desired state (`op = delete`). Current state is a
-//! latest-wins fold per `external_id`; replay and incremental catch-up share
-//! one discipline, the **snapshot cursor** ([`added_since`]).
+//! per-slice fold ordered by each slice's committed `version` counter: an
+//! `external_id` is live while any slice's latest op for it is an upsert, so
+//! one host's tombstone cannot erase a record another slice still observes,
+//! and a wall-clock step on a writer cannot reorder its operations. Replay
+//! and incremental catch-up share one discipline, the **snapshot cursor**
+//! ([`added_since`]).
 //!
 //! Both halves live in this one crate — unlike the `sink-parquet` /
 //! `source-parquet` pair, where the object layout is the whole contract, the
@@ -19,11 +23,13 @@
 //!   An empty desired set is treated as "source absent", never as "delete
 //!   everything" (matching `sink-parquet`), so a transiently empty read cannot
 //!   tombstone a corpus.
-//! - **Read half**: [`read_all`] folds the whole log into current documents
-//!   (full rebuilds); [`added_since`] walks only the snapshots a cursor has
-//!   not seen (steady-state view catch-up). Compaction (`Replace` snapshots,
-//!   e.g. R2 Data Catalog's managed compaction) rewrites files without adding
-//!   rows, so the cursor walk follows `Append` snapshots only.
+//! - **Read half**: [`read_state`] folds the whole log into the current
+//!   per-source document sets (full rebuilds, including sources whose records
+//!   are all tombstoned, so a rebuild can also garbage-collect); [`added_since`]
+//!   walks only the snapshots a cursor has not seen (steady-state view
+//!   catch-up). Compaction (`Replace` snapshots, e.g. R2 Data Catalog's
+//!   managed compaction) rewrites files without adding rows, so the cursor
+//!   walk follows `Append` snapshots only.
 //!
 //! Production is a REST catalog (Cloudflare R2 Data Catalog) over S3-compatible
 //! storage ([`Config::connect`]); tests run the same code against iceberg's
@@ -34,7 +40,7 @@
 mod codec;
 mod error;
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -239,12 +245,17 @@ impl Reconciler for IcebergReconciler {
         let table = load_table(self.catalog.as_ref(), &self.ident).await?;
 
         // The slice's live state: latest observation per id, minus tombstones.
+        // The filter pins one slice, so each id folds to exactly one row.
         let rows =
             scan_rows(&table, Some(self.slice_filter(source)), &codec::STATE_COLUMNS, false)
                 .await?;
+        // The slice's next committed revision: its previous maximum plus one.
+        // `version`, not wall clock, is what orders this slice's operations in
+        // the fold, so a clock step between runs cannot reorder them.
+        let version = rows.iter().map(|row| row.version).max().unwrap_or(0) + 1;
         let mut live: HashMap<String, Option<String>> = HashMap::new();
-        for (id, row) in codec::fold_latest(rows) {
-            if row.op == Op::Upsert {
+        for (id, slice_rows) in codec::fold_slices(rows) {
+            if let Some(row) = codec::live_winner(slice_rows) {
                 live.insert(id, row.content_hash);
             }
         }
@@ -281,6 +292,7 @@ impl Reconciler for IcebergReconciler {
             source,
             Slice { host: &self.host, user: self.user.as_deref() },
             now_ms()?,
+            version,
             &upserts,
             &deletes,
         )?;
@@ -290,25 +302,44 @@ impl Reconciler for IcebergReconciler {
     }
 }
 
-/// Fold the whole log into the current document set, sorted by id.
+/// The lake's folded current state, for the rebuild/replace consume paths.
+#[derive(Debug, Default)]
+pub struct LakeState {
+    /// Every source that has ever written a row, mapped to its live documents
+    /// (sorted by `external_id`). A source whose records are all tombstoned is
+    /// present with an empty set, so a rebuild can still garbage-collect its
+    /// view records.
+    pub sources: BTreeMap<String, Vec<Document>>,
+}
+
+/// Fold the whole log into [`LakeState`] — the full rebuild primitive:
+/// replaying it into a view (uploads for what is here, deletes for what is
+/// not, per source) reproduces current state.
 ///
-/// Every slice, tombstones applied, latest observation per `external_id` —
-/// the full rebuild primitive: replaying this into a view reproduces current
-/// state.
+/// Liveness is per slice: an id stays while any slice's latest op for it is
+/// an upsert, so one host's tombstone never erases a record another slice
+/// still observes.
 ///
 /// # Errors
 /// Returns an error if the table cannot be loaded or scanned, or a row is
 /// malformed.
-pub async fn read_all(catalog: &dyn Catalog, ident: &TableIdent) -> Result<Vec<Document>> {
+pub async fn read_state(catalog: &dyn Catalog, ident: &TableIdent) -> Result<LakeState> {
     let table = load_table(catalog, ident).await?;
     let rows = scan_rows(&table, None, &codec::CODEC_COLUMNS, true).await?;
-    let mut documents = codec::fold_latest(rows)
-        .into_values()
-        .filter(|row| row.op == Op::Upsert)
-        .map(codec::document_from_row)
-        .collect::<Result<Vec<Document>>>()?;
-    documents.sort_by(|a, b| a.external_id.cmp(&b.external_id));
-    Ok(documents)
+    let mut sources: BTreeMap<String, Vec<Document>> = BTreeMap::new();
+    for row in &rows {
+        sources.entry(row.source.clone()).or_default();
+    }
+    for slice_rows in codec::fold_slices(rows).into_values() {
+        if let Some(row) = codec::live_winner(slice_rows) {
+            let documents = sources.entry(row.source.clone()).or_default();
+            documents.push(codec::document_from_row(row)?);
+        }
+    }
+    for documents in sources.values_mut() {
+        documents.sort_by(|a, b| a.external_id.cmp(&b.external_id));
+    }
+    Ok(LakeState { sources })
 }
 
 /// The table's current snapshot id, the cursor a caught-up consumer stores.
@@ -321,12 +352,17 @@ pub async fn current_snapshot_id(catalog: &dyn Catalog, ident: &TableIdent) -> R
     Ok(table.metadata().current_snapshot().map(|snapshot| snapshot.snapshot_id()))
 }
 
-/// The changes a cursor has not seen, folded (a later op on the same id wins).
+/// The changes a cursor has not seen, folded per slice (a slice's later op on
+/// an id supersedes its earlier one; liveness spans slices).
 #[derive(Debug)]
 pub struct Delta {
-    /// Documents observed new or changed since the cursor.
+    /// Documents observed new or changed since the cursor, plus the surviving
+    /// replica's document for any id one slice tombstoned while another still
+    /// holds it (so the view converges to [`read_state`]).
     pub upserts: Vec<Document>,
-    /// Ids tombstoned since the cursor.
+    /// Ids tombstoned since the cursor by their last holder: verified against
+    /// the whole table's state, not just the delta, so a slice-scoped
+    /// tombstone never deletes a record live in another slice.
     pub deletes: Vec<String>,
     /// The snapshot this delta is current to; store it as the next cursor.
     pub to_snapshot: Option<i64>,
@@ -342,9 +378,16 @@ pub struct Delta {
 /// added are read — manifest files are immutable and carried forward, so an
 /// unfiltered walk would also re-deliver every old file.
 ///
+/// An id whose post-cursor rows end in tombstones only proves those slices
+/// let go of it; a slice untouched since the cursor may still hold it live.
+/// Such candidates are checked against the whole table's state (a cheap
+/// no-payload scan, only on deltas that contain tombstones) before they reach
+/// `deletes`, and a surviving replica is re-emitted as an upsert so the view
+/// converges to [`read_state`].
+///
 /// # Errors
 /// Returns [`Error::CursorNotFound`] when `cursor` is no longer in table
-/// metadata (snapshot expiration) — the caller falls back to [`read_all`] —
+/// metadata (snapshot expiration) — the caller falls back to [`read_state`] —
 /// and other errors when the walk or a data file read fails.
 pub async fn added_since(
     catalog: &dyn Catalog,
@@ -391,16 +434,55 @@ pub async fn added_since(
     }
 
     let mut upserts = Vec::new();
-    let mut deletes = Vec::new();
-    for (id, row) in codec::fold_latest(rows) {
-        match row.op {
-            Op::Upsert => upserts.push(codec::document_from_row(row)?),
-            Op::Delete => deletes.push(id),
+    let mut candidates = Vec::new();
+    for (id, slice_rows) in codec::fold_slices(rows) {
+        match codec::live_winner(slice_rows) {
+            Some(row) => upserts.push(codec::document_from_row(row)?),
+            None => candidates.push(id),
         }
     }
+
+    let mut deletes = Vec::new();
+    if !candidates.is_empty() {
+        let state = scan_rows(&table, None, &codec::STATE_COLUMNS, false).await?;
+        let global = codec::fold_slices(state);
+        let mut survivors = Vec::new();
+        for id in candidates {
+            let live = global
+                .get(&id)
+                .is_some_and(|rows| rows.iter().any(|row| row.op == Op::Upsert));
+            if live {
+                survivors.push(id);
+            } else {
+                deletes.push(id);
+            }
+        }
+        upserts.extend(read_documents_by_id(&table, &survivors).await?);
+    }
+
     upserts.sort_by(|a, b| a.external_id.cmp(&b.external_id));
     deletes.sort();
     Ok(Delta { upserts, deletes, to_snapshot: meta.current_snapshot().map(|s| s.snapshot_id()) })
+}
+
+/// Read the current live document of each id — the survivor fetch: ids whose
+/// post-cursor rows are all tombstones but which another slice still holds
+/// live. Scoped to those ids by predicate, so it reads payloads for a handful
+/// of records, not the table.
+async fn read_documents_by_id(table: &Table, ids: &[String]) -> Result<Vec<Document>> {
+    let Some(filter) = ids
+        .iter()
+        .map(|id| Reference::new("external_id").equal_to(Datum::string(id)))
+        .reduce(Predicate::or)
+    else {
+        return Ok(Vec::new());
+    };
+    let rows = scan_rows(table, Some(filter), &codec::CODEC_COLUMNS, true).await?;
+    codec::fold_slices(rows)
+        .into_values()
+        .filter_map(codec::live_winner)
+        .map(codec::document_from_row)
+        .collect()
 }
 
 /// Load the lake table, with a typed error naming it.
@@ -544,7 +626,9 @@ mod tests {
     use snafu::IntoError as _;
     use source_meta::{Document, Reconciler as _, Source};
 
-    use super::{IcebergReconciler, added_since, current_snapshot_id, ensure_table, read_all};
+    use super::{
+        IcebergReconciler, LakeState, added_since, current_snapshot_id, ensure_table, read_state,
+    };
 
     /// A memory-catalog lake for one test.
     struct TestLake {
@@ -588,6 +672,12 @@ mod tests {
         doc_in("test", id, body)
     }
 
+    /// Flatten a [`LakeState`] into its live documents (source-major, id-sorted
+    /// within a source) — the shape most assertions want.
+    fn live_docs(state: LakeState) -> Vec<Document> {
+        state.sources.into_values().flatten().collect()
+    }
+
     #[tokio::test]
     async fn reconcile_appends_then_skips_then_reads_back() {
         let TestLake { catalog, ident, _dir } = lake().await;
@@ -613,7 +703,7 @@ mod tests {
 
         // Full read-back round-trips the documents (source-parquet parity:
         // file_name = external_id, plain-text mime, meta_json intact).
-        let all = read_all(catalog.as_ref(), &ident).await.expect("read_all");
+        let all = live_docs(read_state(catalog.as_ref(), &ident).await.expect("read_state"));
         assert_eq!(all.len(), 2);
         assert_eq!(all[0].external_id, "a");
         assert_eq!(all[0].body, b"alpha");
@@ -635,7 +725,7 @@ mod tests {
             sink.reconcile(&source, &[doc("a", "alpha EDITED")]).await.expect("delta");
         assert_eq!((report.upserts, report.deletes), (1, 1));
 
-        let all = read_all(catalog.as_ref(), &ident).await.expect("read_all");
+        let all = live_docs(read_state(catalog.as_ref(), &ident).await.expect("read_state"));
         assert_eq!(all.len(), 1, "the tombstoned document must fold away");
         assert_eq!(all[0].external_id, "a");
         assert_eq!(all[0].body, b"alpha EDITED");
@@ -652,7 +742,7 @@ mod tests {
         // a skip, not a corpus wipe.
         let report = sink.reconcile(&source, &[]).await.expect("empty");
         assert!(report.skipped);
-        let all = read_all(catalog.as_ref(), &ident).await.expect("read_all");
+        let all = live_docs(read_state(catalog.as_ref(), &ident).await.expect("read_state"));
         assert_eq!(all.len(), 1, "the document must survive an empty pass");
     }
 
@@ -668,7 +758,7 @@ mod tests {
         // host-1's document vanishes; host-2's slice must be untouched.
         let report = host1.reconcile(&source, &[doc("one-b", "new")]).await.expect("host1 delta");
         assert_eq!(report.deletes, 1);
-        let all = read_all(catalog.as_ref(), &ident).await.expect("read_all");
+        let all = live_docs(read_state(catalog.as_ref(), &ident).await.expect("read_state"));
         let ids: Vec<&str> = all.iter().map(|d| d.external_id.as_str()).collect();
         assert_eq!(ids, ["one-b", "two"], "host-2's document must survive host-1's tombstone");
 
@@ -679,14 +769,18 @@ mod tests {
         assert!(report.skipped, "host-level slice must not see alice's rows");
     }
 
-    /// Commit a small batch onto an explicit (possibly stale) table handle,
-    /// bypassing the reconciler's reload-per-attempt loop — the construction
-    /// both conflict tests share.
+    /// Commit one crafted batch onto an explicit (possibly stale) table
+    /// handle, bypassing the reconciler's reload-per-attempt loop and its
+    /// clock/version assignment — the construction the conflict tests and the
+    /// ordering tests share.
     async fn commit_on(
         catalog: &dyn Catalog,
         table: &iceberg::table::Table,
         source: &Source,
-        document: &Document,
+        observed_at: i64,
+        version: i64,
+        upserts: &[&Document],
+        deletes: &[&str],
     ) -> super::Result<()> {
         use iceberg::transaction::{ApplyTransactionAction as _, Transaction};
         let schema = Arc::new(
@@ -697,9 +791,10 @@ mod tests {
             &schema,
             source,
             crate::codec::Slice { host: "host-1", user: None },
-            1,
-            &[document],
-            &[],
+            observed_at,
+            version,
+            upserts,
+            deletes,
         )
         .expect("batch");
         let files = super::write_batch(table, batch).await.expect("write files");
@@ -727,10 +822,11 @@ mod tests {
         // CASes the metadata pointer surfaces the same race as HTTP 409 →
         // CatalogCommitConflicts, which commit_files retries; that leg is
         // exercised in rest_round_trip_via_env against a real server.)
-        commit_on(catalog.as_ref(), &stale, &source, &doc("c", "gamma"))
+        let gamma = doc("c", "gamma");
+        commit_on(catalog.as_ref(), &stale, &source, 1, 1, &[&gamma], &[])
             .await
             .expect("a stale-base append must merge");
-        let all = read_all(catalog.as_ref(), &ident).await.expect("read_all");
+        let all = live_docs(read_state(catalog.as_ref(), &ident).await.expect("read_state"));
         let ids: Vec<&str> = all.iter().map(|d| d.external_id.as_str()).collect();
         assert_eq!(ids, ["a", "b", "c"], "no commit may be lost to the race");
     }
@@ -753,7 +849,7 @@ mod tests {
             let report = handle.await.expect("join").expect("reconcile");
             assert!(!report.skipped);
         }
-        let all = read_all(catalog.as_ref(), &ident).await.expect("read_all");
+        let all = live_docs(read_state(catalog.as_ref(), &ident).await.expect("read_state"));
         assert_eq!(all.len(), 4, "every concurrent writer's document must land");
     }
 
@@ -798,12 +894,12 @@ mod tests {
         let delta_report = sink.reconcile(&source, &changed).await.expect("delta");
         assert_eq!((delta_report.upserts, delta_report.deletes), (1, 1));
 
-        let mine: Vec<Document> = read_all(catalog.as_ref(), &ident)
-            .await
-            .expect("read_all")
-            .into_iter()
-            .filter(|d| d.meta_json["source"] == tag.as_str())
-            .collect();
+        let mine: Vec<Document> = live_docs(
+            read_state(catalog.as_ref(), &ident).await.expect("read_state"),
+        )
+        .into_iter()
+        .filter(|d| d.meta_json["source"] == tag.as_str())
+        .collect();
         assert_eq!(mine.len(), 1);
         assert_eq!(mine[0].body, b"one EDITED");
 
@@ -818,15 +914,16 @@ mod tests {
         // is a contract break.
         let stale = catalog.load_table(&ident).await.expect("stale handle");
         sink.reconcile(&source, &[doc_in(&tag, &id("r3"), "three")]).await.expect("advance");
-        match commit_on(catalog.as_ref(), &stale, &source, &doc_in(&tag, &id("c1"), "x")).await {
+        let c1 = doc_in(&tag, &id("c1"), "x");
+        match commit_on(catalog.as_ref(), &stale, &source, 1, 1, &[&c1], &[]).await {
             Ok(()) => {
                 eprintln!("[rest_round_trip] stale-base append: backend MERGES (no retry needed)");
-                let mine: Vec<Document> = read_all(catalog.as_ref(), &ident)
-                    .await
-                    .expect("read_all after merge")
-                    .into_iter()
-                    .filter(|d| d.meta_json["source"] == tag.as_str())
-                    .collect();
+                let mine: Vec<Document> = live_docs(
+                    read_state(catalog.as_ref(), &ident).await.expect("read_state after merge"),
+                )
+                .into_iter()
+                .filter(|d| d.meta_json["source"] == tag.as_str())
+                .collect();
                 assert!(
                     mine.iter().any(|d| d.external_id == id("c1")),
                     "the merged append must not be lost"
@@ -879,6 +976,106 @@ mod tests {
         assert!(
             matches!(missing, Err(super::Error::CursorNotFound { snapshot: 0, .. })),
             "an unknown cursor must demand a full rescan, got {missing:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn version_orders_a_slice_not_wall_clock() {
+        let TestLake { catalog, ident, _dir } = lake().await;
+        let source = Source::new("test");
+        let alpha = doc("a", "alpha");
+
+        // A writer whose clock stepped backward between runs (NTP, reboot):
+        // the tombstone at version 2 carries a SMALLER observed_at than the
+        // upsert it supersedes. Committed version order must decide.
+        let table = catalog.load_table(&ident).await.expect("table");
+        commit_on(catalog.as_ref(), &table, &source, 1_000, 1, &[&alpha], &[])
+            .await
+            .expect("upsert");
+        let cursor = current_snapshot_id(catalog.as_ref(), &ident)
+            .await
+            .expect("snapshot")
+            .expect("one commit");
+        let table = catalog.load_table(&ident).await.expect("reload");
+        commit_on(catalog.as_ref(), &table, &source, 10, 2, &[], &["a"])
+            .await
+            .expect("tombstone");
+
+        let docs = live_docs(read_state(catalog.as_ref(), &ident).await.expect("read_state"));
+        assert!(docs.is_empty(), "the version-2 tombstone must win over the older wall clock");
+        let delta = added_since(catalog.as_ref(), &ident, cursor).await.expect("delta");
+        assert_eq!(delta.deletes, ["a"], "the cursor read must apply the same order");
+
+        // And back: a later re-observation with an even older clock revives it.
+        let table = catalog.load_table(&ident).await.expect("reload");
+        let revived = doc("a", "alpha revived");
+        commit_on(catalog.as_ref(), &table, &source, 5, 3, &[&revived], &[])
+            .await
+            .expect("revive");
+        let docs = live_docs(read_state(catalog.as_ref(), &ident).await.expect("read_state"));
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].body, b"alpha revived");
+    }
+
+    #[tokio::test]
+    async fn cross_slice_tombstone_keeps_the_other_slices_record() {
+        let TestLake { catalog, ident, _dir } = lake().await;
+        let source = Source::new("test");
+        let host1 = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-1");
+        let host2 = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-2");
+        // The same record observed by two slices (synced shell history, the
+        // same repo indexed on two hosts).
+        host1.reconcile(&source, &[doc("x", "shared")]).await.expect("host1 seed");
+        host2.reconcile(&source, &[doc("x", "shared")]).await.expect("host2 seed");
+        let cursor = current_snapshot_id(catalog.as_ref(), &ident)
+            .await
+            .expect("snapshot")
+            .expect("committed");
+
+        // host-1 lets go of x; host-2 still observes it.
+        host1.reconcile(&source, &[doc("y", "new")]).await.expect("host1 delta");
+        let all = live_docs(read_state(catalog.as_ref(), &ident).await.expect("read_state"));
+        let ids: Vec<&str> = all.iter().map(|d| d.external_id.as_str()).collect();
+        assert_eq!(ids, ["x", "y"], "host-2's replica must keep x alive");
+
+        let delta = added_since(catalog.as_ref(), &ident, cursor).await.expect("delta");
+        assert_eq!(
+            delta.deletes,
+            Vec::<String>::new(),
+            "a slice-scoped tombstone must not delete a record live in another slice"
+        );
+        let upsert_ids: Vec<&str> = delta.upserts.iter().map(|d| d.external_id.as_str()).collect();
+        assert_eq!(upsert_ids, ["x", "y"], "the surviving replica is re-emitted to converge");
+
+        // Once the last holder lets go, the delete goes through.
+        let cursor = delta.to_snapshot.expect("snapshot");
+        host2.reconcile(&source, &[doc("z", "other")]).await.expect("host2 delta");
+        let delta = added_since(catalog.as_ref(), &ident, cursor).await.expect("second delta");
+        assert_eq!(delta.deletes, ["x"], "the last holder's tombstone must delete");
+        let all = live_docs(read_state(catalog.as_ref(), &ident).await.expect("read_state"));
+        let ids: Vec<&str> = all.iter().map(|d| d.external_id.as_str()).collect();
+        assert_eq!(ids, ["y", "z"]);
+    }
+
+    #[tokio::test]
+    async fn read_state_keeps_fully_tombstoned_sources_for_gc() {
+        let TestLake { catalog, ident, _dir } = lake().await;
+        let source = Source::new("test");
+        let sink = IcebergReconciler::new(Arc::clone(&catalog), ident.clone(), "host-1");
+        sink.reconcile(&source, &[doc("a", "alpha")]).await.expect("seed");
+        // Tombstone the source's only record (crafted directly: the reconciler
+        // never appends a bare tombstone, but manual surgery can leave a
+        // source fully dead, and the rebuild must still GC its view records).
+        let table = catalog.load_table(&ident).await.expect("table");
+        commit_on(catalog.as_ref(), &table, &source, 2, 2, &[], &["a"])
+            .await
+            .expect("tombstone");
+
+        let state = read_state(catalog.as_ref(), &ident).await.expect("read_state");
+        assert_eq!(
+            state.sources.get("test").map(Vec::len),
+            Some(0),
+            "a fully tombstoned source must stay listed so a rebuild can GC it"
         );
     }
 }

--- a/packages/sink/mixedbread/src/lib.rs
+++ b/packages/sink/mixedbread/src/lib.rs
@@ -51,6 +51,19 @@ pub struct ApplyReport {
     pub deleted: usize,
 }
 
+/// Outcome of a replace pass over one record source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReplaceReport {
+    /// Records uploaded this run (new or changed).
+    pub uploaded: usize,
+    /// Records skipped because their `content_hash` was unchanged.
+    pub skipped: usize,
+    /// Records deleted (present remotely, absent from the desired set).
+    pub deleted: usize,
+    /// Total records in the desired set.
+    pub total: usize,
+}
+
 /// Outcome of a garbage-collection pass over one record source.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GcReport {
@@ -68,8 +81,11 @@ fn source_filter(source: &Source) -> Filter {
 /// Reconciles one source's documents into a Mixedbread store.
 ///
 /// Uploads records that are new or whose `content_hash` changed, skips the
-/// unchanged, and blocks until the new content is embedded. Absent records are
-/// kept — deletion is [`gc_documents`], a separate explicit pass.
+/// unchanged, and blocks until the new content is embedded. In a
+/// [`Reconciler::reconcile`] pass absent records are kept (deletion is
+/// [`gc_documents`], a separate explicit pass); a [`Self::replace`] pass
+/// deletes them, for callers replaying a log whose absences are authoritative
+/// tombstone folds.
 pub struct MixedbreadReconciler<'a, S> {
     /// The store reconciled into (production: `search-core`'s `MixedbreadStore`,
     /// tests: its `MemoryStore`).
@@ -90,7 +106,109 @@ impl<S> Clone for MixedbreadReconciler<'_, S> {
 }
 impl<S> Copy for MixedbreadReconciler<'_, S> {}
 
+/// What [`MixedbreadReconciler::sync_source`] saw and did: the remote records
+/// listed before uploading, and the upload tallies.
+struct SyncOutcome {
+    /// Each external id the store held for the source before this pass, with
+    /// its stored content hash (`None` predates hash tracking).
+    remote: HashMap<String, Option<String>>,
+    /// Records uploaded (new or changed).
+    uploaded: usize,
+    /// Records skipped because their `content_hash` was unchanged.
+    skipped: usize,
+}
+
 impl<S: Store + Sync> MixedbreadReconciler<'_, S> {
+    /// One source's upload half, shared by [`Reconciler::reconcile`] (which
+    /// keeps remote absences) and [`Self::replace`] (which deletes them): list
+    /// the source's remote records, upload the new or changed documents, and
+    /// block until new content is embedded.
+    async fn sync_source(&self, source: &Source, documents: &[Document]) -> Result<SyncOutcome> {
+        self.store.ensure_store(self.name).await.context(StoreSnafu)?;
+        let filter = source_filter(source);
+        let remote: HashMap<String, Option<String>> = self
+            .store
+            .list_records(self.name, Some(&filter))
+            .await
+            .context(StoreSnafu)?
+            .into_iter()
+            .map(|record| (record.external_id, record.content_hash))
+            .collect();
+
+        // Uploading is the expensive part and runs concurrently. Only documents
+        // that actually need uploading are cloned and held, so reconciling an
+        // unchanged corpus holds almost nothing.
+        let to_upload: Vec<Document> = documents
+            .iter()
+            .filter(|document| {
+                // A record with no stored content_hash predates hash tracking;
+                // re-embed it.
+                !matches!(
+                    remote.get(&document.external_id),
+                    Some(Some(stored)) if *stored == document.content_hash
+                )
+            })
+            .cloned()
+            .collect();
+
+        let skipped = documents.len() - to_upload.len();
+
+        let results: Vec<Result<()>> = stream::iter(to_upload)
+            .map(|document| async move {
+                self.store.upload(self.name, document).await.context(StoreSnafu)?;
+                Ok(())
+            })
+            .buffer_unordered(UPLOAD_CONCURRENCY)
+            .collect()
+            .await;
+
+        let mut uploaded = 0;
+        for result in results {
+            result?;
+            uploaded += 1;
+        }
+
+        if uploaded > 0 {
+            wait_until_indexed(self.store, self.name, self.index_timeout, |_| {})
+                .await
+                .context(StoreSnafu)?;
+        }
+
+        Ok(SyncOutcome { remote, uploaded, skipped })
+    }
+
+    /// Make the store's records for one source exactly `documents`: upload the
+    /// new or changed, skip the unchanged, and delete remote records absent
+    /// from the desired set.
+    ///
+    /// This is the log-replay sibling of [`Reconciler::reconcile`]. A reconcile
+    /// pass scans a live source whose read can be transiently empty or partial,
+    /// so absence there is kept; a replace pass replays a durable log fold,
+    /// where absence is an explicit tombstone, so absence here is authoritative
+    /// — including an empty `documents` for a fully tombstoned source.
+    ///
+    /// # Errors
+    /// Returns an error if the store cannot be reached, an upload fails, or a
+    /// delete fails.
+    pub async fn replace(&self, source: &Source, documents: &[Document]) -> Result<ReplaceReport> {
+        let outcome = self.sync_source(source, documents).await?;
+        let desired: HashSet<&str> =
+            documents.iter().map(|document| document.external_id.as_str()).collect();
+        let mut deleted = 0;
+        for external_id in outcome.remote.keys() {
+            if !desired.contains(external_id.as_str()) {
+                self.store.delete(self.name, external_id).await.context(StoreSnafu)?;
+                deleted += 1;
+            }
+        }
+        Ok(ReplaceReport {
+            uploaded: outcome.uploaded,
+            skipped: outcome.skipped,
+            deleted,
+            total: documents.len(),
+        })
+    }
+
     /// Apply a log-derived delta: upload the changed documents, then delete
     /// the tombstoned ids that still exist in the store.
     ///
@@ -154,58 +272,12 @@ impl<S: Store + Sync> Reconciler for MixedbreadReconciler<'_, S> {
     /// Upload the new or changed (keyed on `external_id` + `content_hash`),
     /// skip the unchanged, and block until new content is embedded.
     async fn reconcile(&self, source: &Source, documents: &[Document]) -> Result<SyncReport> {
-        self.store.ensure_store(self.name).await.context(StoreSnafu)?;
-        let filter = source_filter(source);
-        let remote: HashMap<String, Option<String>> = self
-            .store
-            .list_records(self.name, Some(&filter))
-            .await
-            .context(StoreSnafu)?
-            .into_iter()
-            .map(|record| (record.external_id, record.content_hash))
-            .collect();
-
-        // Uploading is the expensive part and runs concurrently. Only documents
-        // that actually need uploading are cloned and held, so reconciling an
-        // unchanged corpus holds almost nothing.
-        let to_upload: Vec<Document> = documents
-            .iter()
-            .filter(|document| {
-                // A record with no stored content_hash predates hash tracking;
-                // re-embed it.
-                !matches!(
-                    remote.get(&document.external_id),
-                    Some(Some(stored)) if *stored == document.content_hash
-                )
-            })
-            .cloned()
-            .collect();
-
-        let total = documents.len();
-        let skipped = total - to_upload.len();
-
-        let results: Vec<Result<()>> = stream::iter(to_upload)
-            .map(|document| async move {
-                self.store.upload(self.name, document).await.context(StoreSnafu)?;
-                Ok(())
-            })
-            .buffer_unordered(UPLOAD_CONCURRENCY)
-            .collect()
-            .await;
-
-        let mut uploaded = 0;
-        for result in results {
-            result?;
-            uploaded += 1;
-        }
-
-        if uploaded > 0 {
-            wait_until_indexed(self.store, self.name, self.index_timeout, |_| {})
-                .await
-                .context(StoreSnafu)?;
-        }
-
-        Ok(SyncReport { uploaded, skipped, total })
+        let outcome = self.sync_source(source, documents).await?;
+        Ok(SyncReport {
+            uploaded: outcome.uploaded,
+            skipped: outcome.skipped,
+            total: documents.len(),
+        })
     }
 }
 
@@ -350,6 +422,42 @@ mod tests {
         assert_eq!(replay.uploaded, 1);
         assert_eq!(replay.deleted, 0);
         assert_eq!(store.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn replace_deletes_absences_and_scopes_to_the_source() {
+        let store = MemoryStore::new();
+        let sink = reconciler(&store, "s");
+        let linear = Source::new("linear");
+        sink.reconcile(&linear, &[linear_doc("A", "a"), linear_doc("B", "b")])
+            .await
+            .expect("seed linear");
+        // A second source sharing the store must be invisible to the replace.
+        let mut other = linear_doc("O", "o");
+        other.meta_json["source"] = serde_json::json!("other");
+        sink.reconcile(&Source::new("other"), std::slice::from_ref(&other))
+            .await
+            .expect("seed other");
+
+        // The log fold now holds A (changed) and C; B was tombstoned.
+        let desired = vec![linear_doc("A", "a EDITED"), linear_doc("C", "c")];
+        let report = sink.replace(&linear, &desired).await.expect("replace");
+        assert_eq!(report.uploaded, 2, "the changed and the new document upload");
+        assert_eq!(report.skipped, 0);
+        assert_eq!(report.deleted, 1, "the absent document is deleted");
+        assert_eq!(report.total, 2);
+        assert_eq!(store.len(), 3, "linear A+C survive, other O untouched");
+
+        // Replaying the same fold converges: nothing uploads, nothing deletes.
+        let again = sink.replace(&linear, &desired).await.expect("replay");
+        assert_eq!((again.uploaded, again.skipped, again.deleted), (0, 2, 0));
+
+        // A fully tombstoned source folds to an empty desired set, and that
+        // emptiness is authoritative for a replace (unlike reconcile, whose
+        // live-scan absences are protective).
+        let report = sink.replace(&linear, &[]).await.expect("empty replace");
+        assert_eq!(report.deleted, 2, "an empty fold deletes the source's records");
+        assert_eq!(store.len(), 1, "only the other source's record remains");
     }
 
     #[tokio::test]

--- a/packages/sink/mixedbread/src/lib.rs
+++ b/packages/sink/mixedbread/src/lib.rs
@@ -42,6 +42,15 @@ pub struct SyncReport {
     pub total: usize,
 }
 
+/// Outcome of applying a log-derived delta.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ApplyReport {
+    /// Documents uploaded (the delta's upserts).
+    pub uploaded: usize,
+    /// Records deleted (the delta's tombstones that still existed remotely).
+    pub deleted: usize,
+}
+
 /// Outcome of a garbage-collection pass over one record source.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GcReport {
@@ -80,6 +89,63 @@ impl<S> Clone for MixedbreadReconciler<'_, S> {
     }
 }
 impl<S> Copy for MixedbreadReconciler<'_, S> {}
+
+impl<S: Store + Sync> MixedbreadReconciler<'_, S> {
+    /// Apply a log-derived delta: upload the changed documents, then delete
+    /// the tombstoned ids that still exist in the store.
+    ///
+    /// Unlike [`Reconciler::reconcile`], this trusts the log's change
+    /// detection: no remote listing for skip decisions, every upsert uploads.
+    /// Idempotent by construction, so a crash between an apply and its cursor
+    /// write replays safely: re-uploading a document overwrites in place, and
+    /// deletes are filtered against the store's current ids first (the
+    /// production store hard-errors deleting a missing id, which would
+    /// otherwise wedge a replayed cursor in a permanent retry loop).
+    ///
+    /// # Errors
+    /// Returns an error if the store cannot be reached, an upload fails, or a
+    /// delete of a still-existing record fails.
+    pub async fn apply(
+        &self,
+        upserts: Vec<Document>,
+        deletes: &[String],
+    ) -> Result<ApplyReport> {
+        self.store.ensure_store(self.name).await.context(StoreSnafu)?;
+
+        let results: Vec<Result<()>> = stream::iter(upserts)
+            .map(|document| async move {
+                self.store.upload(self.name, document).await.context(StoreSnafu)?;
+                Ok(())
+            })
+            .buffer_unordered(UPLOAD_CONCURRENCY)
+            .collect()
+            .await;
+        let mut uploaded = 0;
+        for result in results {
+            result?;
+            uploaded += 1;
+        }
+        if uploaded > 0 {
+            wait_until_indexed(self.store, self.name, self.index_timeout, |_| {})
+                .await
+                .context(StoreSnafu)?;
+        }
+
+        let mut removed = 0;
+        if !deletes.is_empty() {
+            let existing: HashSet<String> =
+                self.store.list_external_ids(self.name, None).await.context(StoreSnafu)?;
+            for external_id in deletes {
+                if existing.contains(external_id) {
+                    self.store.delete(self.name, external_id).await.context(StoreSnafu)?;
+                    removed += 1;
+                }
+            }
+        }
+
+        Ok(ApplyReport { uploaded, deleted: removed })
+    }
+}
 
 impl<S: Store + Sync> Reconciler for MixedbreadReconciler<'_, S> {
     type Report = SyncReport;
@@ -258,6 +324,32 @@ mod tests {
         let third = sink.reconcile(&source, &changed).await.expect("third");
         assert_eq!(third.uploaded, 1);
         assert_eq!(store.upload_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn apply_delta_uploads_and_deletes_idempotently() {
+        let store = MemoryStore::new();
+        let sink = reconciler(&store, "s");
+        let source = Source::new("linear");
+        sink.reconcile(&source, &[linear_doc("A", "a"), linear_doc("B", "b")])
+            .await
+            .expect("seed");
+
+        // A delta: A changed, B tombstoned, C never existed (a replayed delete).
+        let delta_upserts = vec![linear_doc("A", "a EDITED")];
+        let deletes =
+            vec!["linear:issue:B".to_owned(), "linear:issue:C".to_owned()];
+        let report = sink.apply(delta_upserts.clone(), &deletes).await.expect("apply");
+        assert_eq!(report.uploaded, 1);
+        assert_eq!(report.deleted, 1, "the never-existed id must be skipped, not an error");
+        assert_eq!(store.len(), 1, "only A remains");
+
+        // Replaying the same delta (a crash before the cursor write) is safe:
+        // the re-upload overwrites in place and the delete finds nothing.
+        let replay = sink.apply(delta_upserts, &deletes).await.expect("replay");
+        assert_eq!(replay.uploaded, 1);
+        assert_eq!(replay.deleted, 0);
+        assert_eq!(store.len(), 1);
     }
 
     #[tokio::test]

--- a/packages/sink/mixedbread/src/lib.rs
+++ b/packages/sink/mixedbread/src/lib.rs
@@ -17,13 +17,12 @@
 mod error;
 
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use futures::stream::{self, StreamExt as _};
 use mixedbread::Filter;
 use search_core::{Store, wait_until_indexed};
-use source_meta::{SourceAdapter, keys};
+use source_meta::{Document, Reconciler, Source, SourceAdapter, keys};
 use snafu::ResultExt as _;
 
 pub use crate::error::Error;
@@ -53,88 +52,95 @@ pub struct GcReport {
 }
 
 /// The filter selecting one source's records in the shared store.
-fn source_filter(adapter: &impl SourceAdapter) -> Filter {
-    Filter::eq(keys::SOURCE, adapter.source().as_str())
+fn source_filter(source: &Source) -> Filter {
+    Filter::eq(keys::SOURCE, source.as_str())
 }
 
-/// Reconcile a record source into `store`: upload records that are new or whose
-/// `content_hash` changed, skip the unchanged, and block until the new content
-/// is embedded.
+/// Reconciles one source's documents into a Mixedbread store.
 ///
-/// `on_progress(uploaded_so_far, total_to_upload)` is called once with the total
-/// before uploading and again after each successful upload.
-///
-/// # Errors
-/// Returns an error if the store cannot be reached, a document cannot be
-/// produced by the adapter, or an upload fails.
-pub async fn sync_documents<A>(
-    adapter: &A,
-    store: &(impl Store + Sync),
-    store_name: &str,
-    index_timeout: Duration,
-    on_progress: impl Fn(usize, usize) + Send + Sync,
-) -> Result<SyncReport>
-where
-    A: SourceAdapter + Sync,
-{
-    store.ensure_store(store_name).await.context(StoreSnafu)?;
-    let filter = source_filter(adapter);
-    let remote: HashMap<String, Option<String>> = store
-        .list_records(store_name, Some(&filter))
-        .await
-        .context(StoreSnafu)?
-        .into_iter()
-        .map(|record| (record.external_id, record.content_hash))
-        .collect();
+/// Uploads records that are new or whose `content_hash` changed, skips the
+/// unchanged, and blocks until the new content is embedded. Absent records are
+/// kept — deletion is [`gc_documents`], a separate explicit pass.
+pub struct MixedbreadReconciler<'a, S> {
+    /// The store reconciled into (production: `search-core`'s `MixedbreadStore`,
+    /// tests: its `MemoryStore`).
+    pub store: &'a S,
+    /// The store name to sync into.
+    pub name: &'a str,
+    /// How long to wait for newly uploaded content to be embedded.
+    pub index_timeout: Duration,
+}
 
-    // Parsing is sequential and cheap; uploading is the expensive part and runs
-    // concurrently. Collect only documents that actually need uploading so a
-    // re-ingest of an unchanged export holds almost nothing.
-    let mut to_upload = Vec::new();
-    let mut total = 0;
-    for item in adapter.documents() {
-        let document = item.map_err(|error| AdapterSnafu { message: error.to_string() }.build())?;
-        total += 1;
-        // A record with no stored content_hash predates hash tracking; re-embed.
-        let unchanged = matches!(
-            remote.get(&document.external_id),
-            Some(Some(stored)) if *stored == document.content_hash
-        );
-        if !unchanged {
-            to_upload.push(document);
-        }
+// Manual impls: a derive would needlessly bound `S: Copy`/`S: Clone`, but the
+// fields (a shared reference, a str reference, a Duration) are copyable for
+// any `S`.
+impl<S> Clone for MixedbreadReconciler<'_, S> {
+    fn clone(&self) -> Self {
+        *self
     }
+}
+impl<S> Copy for MixedbreadReconciler<'_, S> {}
 
-    let upload_target = to_upload.len();
-    let skipped = total - upload_target;
-    on_progress(0, upload_target);
-    let done = AtomicUsize::new(0);
+impl<S: Store + Sync> Reconciler for MixedbreadReconciler<'_, S> {
+    type Report = SyncReport;
+    type Error = Error;
 
-    let results: Vec<Result<()>> = stream::iter(to_upload)
-        .map(|document| {
-            let done = &done;
-            let on_progress = &on_progress;
-            async move {
-                store.upload(store_name, document).await.context(StoreSnafu)?;
-                on_progress(done.fetch_add(1, Ordering::Relaxed) + 1, upload_target);
+    /// Upload the new or changed (keyed on `external_id` + `content_hash`),
+    /// skip the unchanged, and block until new content is embedded.
+    async fn reconcile(&self, source: &Source, documents: &[Document]) -> Result<SyncReport> {
+        self.store.ensure_store(self.name).await.context(StoreSnafu)?;
+        let filter = source_filter(source);
+        let remote: HashMap<String, Option<String>> = self
+            .store
+            .list_records(self.name, Some(&filter))
+            .await
+            .context(StoreSnafu)?
+            .into_iter()
+            .map(|record| (record.external_id, record.content_hash))
+            .collect();
+
+        // Uploading is the expensive part and runs concurrently. Only documents
+        // that actually need uploading are cloned and held, so reconciling an
+        // unchanged corpus holds almost nothing.
+        let to_upload: Vec<Document> = documents
+            .iter()
+            .filter(|document| {
+                // A record with no stored content_hash predates hash tracking;
+                // re-embed it.
+                !matches!(
+                    remote.get(&document.external_id),
+                    Some(Some(stored)) if *stored == document.content_hash
+                )
+            })
+            .cloned()
+            .collect();
+
+        let total = documents.len();
+        let skipped = total - to_upload.len();
+
+        let results: Vec<Result<()>> = stream::iter(to_upload)
+            .map(|document| async move {
+                self.store.upload(self.name, document).await.context(StoreSnafu)?;
                 Ok(())
-            }
-        })
-        .buffer_unordered(UPLOAD_CONCURRENCY)
-        .collect()
-        .await;
+            })
+            .buffer_unordered(UPLOAD_CONCURRENCY)
+            .collect()
+            .await;
 
-    let mut uploaded = 0;
-    for result in results {
-        result?;
-        uploaded += 1;
+        let mut uploaded = 0;
+        for result in results {
+            result?;
+            uploaded += 1;
+        }
+
+        if uploaded > 0 {
+            wait_until_indexed(self.store, self.name, self.index_timeout, |_| {})
+                .await
+                .context(StoreSnafu)?;
+        }
+
+        Ok(SyncReport { uploaded, skipped, total })
     }
-
-    if uploaded > 0 {
-        wait_until_indexed(store, store_name, index_timeout, |_| {}).await.context(StoreSnafu)?;
-    }
-
-    Ok(SyncReport { uploaded, skipped, total })
 }
 
 /// Delete records present in the store for this source but absent from the
@@ -155,7 +161,7 @@ pub async fn gc_documents<A>(
 where
     A: SourceAdapter + Sync,
 {
-    let filter = source_filter(adapter);
+    let filter = source_filter(&adapter.source());
     let remote: HashSet<String> = store
         .list_records(store_name, Some(&filter))
         .await
@@ -184,9 +190,14 @@ mod tests {
     use std::time::Duration;
 
     use search_core::MemoryStore;
-    use source_meta::{Document, SourceAdapter};
+    use source_meta::{Document, Reconciler as _, Source, SourceAdapter};
 
-    use super::{gc_documents, sync_documents};
+    use super::{MixedbreadReconciler, gc_documents};
+
+    /// The reconciler under test, with the embedding wait kept short.
+    fn reconciler<'a>(store: &'a MemoryStore, name: &'a str) -> MixedbreadReconciler<'a, MemoryStore> {
+        MixedbreadReconciler { store, name, index_timeout: Duration::from_secs(1) }
+    }
 
     // A fake record source for exercising the reconcile and GC without a real
     // parser crate. It yields Linear-shaped documents from owned data.
@@ -228,31 +239,23 @@ mod tests {
     #[tokio::test]
     async fn document_sync_uploads_then_skips_unchanged_and_reuploads_changed() {
         let store = MemoryStore::new();
-        let source = FakeSource {
-            docs: vec![linear_doc("A", "alpha body"), linear_doc("B", "beta body")],
-        };
+        let sink = reconciler(&store, "s");
+        let source = Source::new("linear");
+        let docs = vec![linear_doc("A", "alpha body"), linear_doc("B", "beta body")];
 
-        let first = sync_documents(&source, &store, "s", Duration::from_secs(1), |_, _| {})
-            .await
-            .expect("first");
+        let first = sink.reconcile(&source, &docs).await.expect("first");
         assert_eq!(first.uploaded, 2);
         assert_eq!(store.upload_count(), 2);
 
         // Re-running the same export uploads nothing (content_hash unchanged).
-        let second = sync_documents(&source, &store, "s", Duration::from_secs(1), |_, _| {})
-            .await
-            .expect("second");
+        let second = sink.reconcile(&source, &docs).await.expect("second");
         assert_eq!(second.uploaded, 0);
         assert_eq!(second.skipped, 2);
         assert_eq!(store.upload_count(), 2, "no redundant re-upload");
 
         // A changed body for A re-embeds only A.
-        let changed = FakeSource {
-            docs: vec![linear_doc("A", "alpha body EDITED"), linear_doc("B", "beta body")],
-        };
-        let third = sync_documents(&changed, &store, "s", Duration::from_secs(1), |_, _| {})
-            .await
-            .expect("third");
+        let changed = vec![linear_doc("A", "alpha body EDITED"), linear_doc("B", "beta body")];
+        let third = sink.reconcile(&source, &changed).await.expect("third");
         assert_eq!(third.uploaded, 1);
         assert_eq!(store.upload_count(), 3);
     }
@@ -260,10 +263,9 @@ mod tests {
     #[tokio::test]
     async fn gc_deletes_records_absent_from_the_export() {
         let store = MemoryStore::new();
-        let full = FakeSource {
-            docs: vec![linear_doc("A", "a"), linear_doc("B", "b"), linear_doc("C", "c")],
-        };
-        sync_documents(&full, &store, "s", Duration::from_secs(1), |_, _| {})
+        let docs = vec![linear_doc("A", "a"), linear_doc("B", "b"), linear_doc("C", "c")];
+        reconciler(&store, "s")
+            .reconcile(&Source::new("linear"), &docs)
             .await
             .expect("seed");
         assert_eq!(store.len(), 3);

--- a/packages/sink/parquet/src/lib.rs
+++ b/packages/sink/parquet/src/lib.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 
 use arrow::array::{ArrayRef, Int64Array, RecordBatch, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
-use source_meta::{Document, SourceAdapter, keys};
+use source_meta::{Document, Reconciler, Source, keys};
 use object_store::aws::{AmazonS3, AmazonS3Builder};
 use object_store::path::Path as ObjectPath;
 use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
@@ -56,12 +56,6 @@ pub enum Error {
         bucket: String,
         /// Underlying object-store error.
         source: object_store::Error,
-    },
-    /// The source adapter failed while producing documents.
-    #[snafu(display("source adapter failed while producing documents"))]
-    Adapter {
-        /// Underlying adapter error.
-        source: Box<dyn std::error::Error + Send + Sync>,
     },
     /// An object could not be read.
     #[snafu(display("failed to read object {path}"))]
@@ -119,50 +113,69 @@ pub struct Report {
     pub skipped: bool,
 }
 
-/// Sync one source's documents to the bucket as a single parquet file, skipping
-/// the rewrite when the source's corpus hash is unchanged.
-///
-/// # Errors
-/// Returns an error if the client cannot be built, the adapter fails, or any
-/// object cannot be read, written, or encoded.
-pub async fn sync<A: SourceAdapter + Sync>(adapter: &A, config: &Config) -> Result<Report> {
-    let store = build_store(config)?;
-    sync_to(adapter, &store, &config.prefix).await
+/// Reconciles a source's documents into the bucket as one parquet file per
+/// source. The production store is [`AmazonS3`] (see [`Config::connect`]);
+/// tests drive an in-memory store.
+#[derive(Debug, Clone)]
+pub struct ParquetReconciler<S = AmazonS3> {
+    /// The object store written to.
+    pub store: S,
+    /// Key prefix every object lands under (e.g. `corpus/host=<host>`).
+    pub prefix: String,
 }
 
-/// The store-agnostic core of [`sync`], so tests can drive an in-memory store.
-///
-/// `A: Sync` so the returned future is `Send` (the adapter is borrowed across no
-/// await, but the bound keeps the future usable from a multi-threaded runtime).
-async fn sync_to<A: SourceAdapter + Sync>(
-    adapter: &A,
-    store: &dyn ObjectStore,
-    prefix: &str,
-) -> Result<Report> {
-    let source = adapter.source();
-    let mut documents = Vec::new();
-    for document in adapter.documents() {
-        documents.push(document.map_err(|err| AdapterSnafu.into_error(Box::new(err)))?);
+impl Config {
+    /// Build the S3-backed reconciler for this config. Credentials come from
+    /// the environment (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`).
+    ///
+    /// # Errors
+    /// Returns an error if the S3 client cannot be built from the config and
+    /// environment.
+    pub fn connect(&self) -> Result<ParquetReconciler> {
+        Ok(ParquetReconciler { store: build_store(self)?, prefix: self.prefix.clone() })
     }
-    if documents.is_empty() {
-        return Ok(Report { rows: 0, skipped: true });
-    }
+}
 
-    let data_path = ObjectPath::from(format!("{prefix}/source={source}/data.parquet"));
-    let manifest_path = ObjectPath::from(format!("{prefix}/source={source}/_manifest.json"));
-    let hash = corpus_hash(&documents);
-    if load_manifest(store, &manifest_path).await? == Some(hash.clone()) {
-        return Ok(Report { rows: 0, skipped: true });
+impl<S: Clone> ParquetReconciler<S> {
+    /// The same store, writing under a different prefix (the indexer derives
+    /// per-user prefixes from one connected reconciler this way).
+    #[must_use]
+    pub fn with_prefix(&self, prefix: impl Into<String>) -> Self {
+        Self { store: self.store.clone(), prefix: prefix.into() }
     }
+}
 
-    let batch = record_batch(&documents)?;
-    let bytes = encode_parquet(&batch)?;
-    store
-        .put(&data_path, PutPayload::from(bytes))
-        .await
-        .context(PutSnafu { path: data_path.to_string() })?;
-    save_manifest(store, &manifest_path, &hash).await?;
-    Ok(Report { rows: documents.len(), skipped: false })
+impl<S: ObjectStore> Reconciler for ParquetReconciler<S> {
+    type Report = Report;
+    type Error = Error;
+
+    /// Write `documents` as `<prefix>/source=<source>/data.parquet` in one
+    /// full-file overwrite, skipping the rewrite when the corpus hash in the
+    /// sibling manifest is unchanged. The file always reflects the source's
+    /// current desired state, so a document absent from `documents` simply
+    /// vanishes with the rewrite.
+    async fn reconcile(&self, source: &Source, documents: &[Document]) -> Result<Report> {
+        if documents.is_empty() {
+            return Ok(Report { rows: 0, skipped: true });
+        }
+
+        let prefix = &self.prefix;
+        let data_path = ObjectPath::from(format!("{prefix}/source={source}/data.parquet"));
+        let manifest_path = ObjectPath::from(format!("{prefix}/source={source}/_manifest.json"));
+        let hash = corpus_hash(documents);
+        if load_manifest(&self.store, &manifest_path).await? == Some(hash.clone()) {
+            return Ok(Report { rows: 0, skipped: true });
+        }
+
+        let batch = record_batch(documents)?;
+        let bytes = encode_parquet(&batch)?;
+        self.store
+            .put(&data_path, PutPayload::from(bytes))
+            .await
+            .context(PutSnafu { path: data_path.to_string() })?;
+        save_manifest(&self.store, &manifest_path, &hash).await?;
+        Ok(Report { rows: documents.len(), skipped: false })
+    }
 }
 
 /// Build the S3 client. Credentials come from the environment
@@ -281,26 +294,12 @@ async fn save_manifest(store: &dyn ObjectStore, path: &ObjectPath, hash: &str) -
 
 #[cfg(test)]
 mod tests {
-    use super::{Report, sync_to};
-    use source_meta::{Document, Source, SourceAdapter};
+    use super::{ParquetReconciler, Report};
+    use source_meta::{Document, Reconciler as _, Source};
     use object_store::ObjectStoreExt;
     use object_store::memory::InMemory;
     use object_store::path::Path as ObjectPath;
     use serde_json::json;
-
-    struct TestSource {
-        docs: Vec<Document>,
-    }
-
-    impl SourceAdapter for TestSource {
-        type Error = std::convert::Infallible;
-        fn source(&self) -> Source {
-            Source::new("test")
-        }
-        fn documents(&self) -> impl Iterator<Item = Result<Document, Self::Error>> + Send {
-            self.docs.clone().into_iter().map(Ok)
-        }
-    }
 
     fn doc(id: &str, body: &str) -> Document {
         let content_hash = source_meta::hash_body(body.as_bytes());
@@ -322,31 +321,49 @@ mod tests {
 
     #[tokio::test]
     async fn writes_parquet_and_manifest_then_skips_unchanged() {
-        let store = InMemory::new();
-        let adapter = TestSource { docs: vec![doc("a", "alpha"), doc("b", "beta")] };
+        let reconciler =
+            ParquetReconciler { store: InMemory::new(), prefix: "corpus".to_owned() };
+        let source = Source::new("test");
+        let docs = vec![doc("a", "alpha"), doc("b", "beta")];
 
-        let first: Report = sync_to(&adapter, &store, "corpus").await.expect("first sync");
+        let first: Report = reconciler.reconcile(&source, &docs).await.expect("first sync");
         assert_eq!(first.rows, 2);
         assert!(!first.skipped);
 
         // The parquet file and manifest both landed under the source partition.
         let data = ObjectPath::from("corpus/source=test/data.parquet");
         let manifest = ObjectPath::from("corpus/source=test/_manifest.json");
-        assert!(store.get(&data).await.is_ok());
-        assert!(store.get(&manifest).await.is_ok());
+        assert!(reconciler.store.get(&data).await.is_ok());
+        assert!(reconciler.store.get(&manifest).await.is_ok());
 
         // A second identical run is a no-op (corpus hash unchanged).
-        let second = sync_to(&adapter, &store, "corpus").await.expect("second sync");
+        let second = reconciler.reconcile(&source, &docs).await.expect("second sync");
         assert!(second.skipped);
         assert_eq!(second.rows, 0);
     }
 
     #[tokio::test]
     async fn empty_source_writes_nothing() {
-        let store = InMemory::new();
-        let adapter = TestSource { docs: vec![] };
-        let report = sync_to(&adapter, &store, "corpus").await.expect("sync");
+        let reconciler =
+            ParquetReconciler { store: InMemory::new(), prefix: "corpus".to_owned() };
+        let report =
+            reconciler.reconcile(&Source::new("test"), &[]).await.expect("sync");
         assert!(report.skipped);
         assert_eq!(report.rows, 0);
+    }
+
+    #[tokio::test]
+    async fn with_prefix_scopes_writes_under_the_new_prefix() {
+        // `with_prefix` derives the per-user reconciler in the fleet path; the
+        // derived writer must land objects under the new prefix, not the base.
+        let store = std::sync::Arc::new(InMemory::new());
+        let base = ParquetReconciler { store: std::sync::Arc::clone(&store), prefix: "corpus/host=h".to_owned() };
+        let scoped = base.with_prefix("corpus/host=h/user=alice");
+
+        scoped.reconcile(&Source::new("test"), &[doc("a", "alpha")]).await.expect("sync");
+        let scoped_path = ObjectPath::from("corpus/host=h/user=alice/source=test/data.parquet");
+        let base_path = ObjectPath::from("corpus/host=h/source=test/data.parquet");
+        assert!(store.get(&scoped_path).await.is_ok());
+        assert!(store.get(&base_path).await.is_err(), "base prefix must stay untouched");
     }
 }

--- a/packages/source/meta/src/lib.rs
+++ b/packages/source/meta/src/lib.rs
@@ -23,6 +23,7 @@
 pub mod keys;
 
 use std::fmt;
+use std::future::Future;
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
@@ -198,6 +199,40 @@ pub trait SourceAdapter {
 
     /// The current desired-state documents for this corpus.
     fn documents(&self) -> impl Iterator<Item = Result<Document, Self::Error>> + Send;
+}
+
+/// Converges one external view to a source's current desired-state document set.
+///
+/// The consumer counterpart of [`SourceAdapter`]: adapters produce desired
+/// state, reconcilers make a view (a search index, an object-store log, an
+/// analytics table) match it.
+///
+/// The contract every implementation upholds:
+///
+/// 1. **Desired state, not deltas.** `documents` is `source`'s complete current
+///    set. Implementations converge toward it; what absence means (keep vs
+///    delete) is each implementation's documented choice.
+/// 2. **Idempotent.** Reconciling the same set twice is a no-op, keyed on
+///    `external_id` + `content_hash` (see [`hash_body`]).
+/// 3. **Source-scoped.** A reconcile reads and writes only `source`'s records,
+///    never another source's.
+///
+/// A view can also satisfy this contract at the engine level instead of
+/// implementing the trait: replayed duplicates collapsing in storage (e.g. a
+/// `ClickHouse` `ReplacingMergeTree` whose sorting key is the record's natural
+/// identity) is the same idempotence, declared rather than coded.
+pub trait Reconciler {
+    /// Per-pass outcome; each view reports its own shape.
+    type Report;
+    /// Reconcile failure type.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Converge the view to `documents`, the current desired state of `source`.
+    fn reconcile(
+        &self,
+        source: &Source,
+        documents: &[Document],
+    ) -> impl Future<Output = Result<Self::Report, Self::Error>> + Send;
 }
 
 /// The `content_hash` of a body: `sha256:<hex>` over the exact bytes embedded.


### PR DESCRIPTION
Phases 2 + 3 of the migration plan on #752: the consumer trait, the Iceberg corpus lake, and the snapshot-cursor consume modes — everything buildable before Cloudflare credentials exist. **Lands inert**: fleet behavior is unchanged until the ix deploy passes the new flags.

## Commits (one concern each)

1. **source-meta: `Reconciler` trait**; sink-parquet/sink-mixedbread become reconcilers. Zero behavior change; adapters are now iterated once per source instead of once per sink, and the S3 client is built once per run (bad config fails at startup instead of per-source).
2. **lake-iceberg: the append+tombstone revision log on Iceberg.** Slice-scoped tombstones (`host`, optional `user` — host A can never delete what host B observes), latest-wins fold, empty-desired-set safety (skip, never mass-tombstone), commit-conflict retry, `read_all` + the `added_since` snapshot-cursor walk (Append-only snapshots; `Replace` = compaction is skipped; expired cursor is a typed full-rescan signal). First nine columns are byte-for-byte `sink-parquet`'s schema, so existing duckdb/polars queries port with `op != 'delete'`.
3. **indexer: the lake as a third view.** `--catalog-uri`/`--warehouse`/`--catalog-token`; writes ordered parquet → lake → Mixedbread; per-account slices via `with_user` on the fleet's `--user` path; `--from-iceberg` full rebuild.
4. **indexer: snapshot-cursor consume.** `--from-snapshot <id>` (stateless) and `--cursor-file` (steady state: atomic `cursor.json`, absent-file bootstrap, expired-cursor full-rebuild fallback, malformed file surfaces). `MixedbreadReconciler::apply` is crash-replay-safe: re-uploads overwrite in place, tombstones filter against `list_external_ids` first because the production store hard-errors deleting a missing id — that would otherwise wedge a replayed cursor.
5. **REST fixture + merge-semantics proof + registry marker.** `packages/lake/iceberg/fixture/rest-fixture.sh` runs the env-gated round-trip against apache/iceberg-rest-fixture + MinIO; `package.nix` registers the crate with the package registry (without it the cargo-unit source fileset excludes the crate and the unit-graph IFD fails).

## Design notes & deviations from the issue-comment plan

- **One crate (`lake-iceberg`), not `sink-iceberg` + `source-iceberg`**: both halves share the table schema, codec, catalog connection, and fold — unlike the parquet pair, the layout is not the whole contract. (Acked by Wyatt.)
- **Unpartitioned v1** instead of `identity(source)`: at the measured ~990MB corpus, single-source data files give equivalent pruning via column stats, and a partition spec is a metadata-only evolution later if scan patterns want it.
- **Stale-base appends MERGE** — appends carry no snapshot-ref requirement, so concurrent writers lose nothing (pinned by test). The `CatalogCommitConflicts` retry exists for metadata-CAS REST servers (R2's likely behavior); `rest_round_trip_via_env` records which behavior a backend exhibits.

## Tests

32 hermetic (memory catalog + in-memory object store) + 1 env-gated REST round-trip: one test, three backends — memory always, the local fixture via `rest-fixture.sh` (needs docker), and R2 Data Catalog staging later via the same `LAKE_TEST_*` variables.

## Deliberately not in this PR

Dual-write removal, leader-gated reconciliation, and parquet-path deletion — those are ix-side deploys (PR-E) and the post-rollback-window deletion PR, per the sequencing on #752.

Refs #752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Iceberg-backed corpus lake with reconciler trait, document log, and snapshot-cursor delta consumption
> - Introduces a new `lake-iceberg` crate implementing an append-only Iceberg document log with `IcebergReconciler`, full-state reads via `read_state`, and incremental delta walking via `added_since` using snapshot cursors.
> - Adds a `Reconciler` trait to `source-meta` and refactors `sink-parquet` and `sink-mixedbread` to implement it, replacing ad-hoc `sync`/`sync_to` entrypoints with a uniform `reconcile(&[Document])` API.
> - Extends the indexer CLI with `--catalog-uri`, `--from-iceberg`, `--from-snapshot`, and `--cursor-file` flags; source runs now fan out to parquet, Iceberg lake, and Mixedbread in order, with durable sinks written before Mixedbread.
> - Adds steady-state cursor-file consumption (`run_cursor_consume`) with bootstrap, expiration recovery, and atomic cursor writes; also adds `run_replace` for full Mixedbread rebuilds aligned to lake tombstones.
> - Risk: the `lake-iceberg` crate pins `arrow`/`parquet` at version 57, isolated from the rest of the workspace, which may cause linker or ABI friction if other crates later adopt a different Arrow version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc0b365.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->