### PR TITLE
feat(mcp): page truncated runs from the jobs registry

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -708,6 +708,18 @@ let
         assert a.status == "done" and b.status == "done", (a.status, b.status)
         assert "A 0" in a.output and "B 0" in b.output, (a.output, b.output)
         assert a.result.llm_result == "A done" and b.result.llm_result == "B done", (a.result, b.result)
+        # paging ops over a finished job keep a large output recoverable
+        assert "A 0" in a.head(10000) and a.slice(0, 1) == a.output[0]
+        assert a.lines(0, 1).startswith("0: ")
+        g = a.grep("A 1")
+        assert "A 1" in g and g.split(":", 1)[0].strip().isdigit(), g
+        assert "no lines match" in a.grep("nonesuch-xyz-pattern")
+        # full sizes the server uses to detect a truncated reply
+        s = runtime._job_summary(a)
+        assert s["output_chars"] == len(a.output) and s["result_chars"] == len("A done"), s
+        # history() indexes the runs and returns a Result naming both jobs
+        h = ns["history"]()
+        assert isinstance(h, runtime.Result) and a.id in h.llm_result and b.id in h.llm_result
 
     asyncio.run(main())
     print("runtime-ok")

--- a/packages/mcp/ix_notebook_mcp/ipython/01-ix-polars.py
+++ b/packages/mcp/ix_notebook_mcp/ipython/01-ix-polars.py
@@ -5,7 +5,7 @@ only changes the ``text/plain`` repr: what the agent (which reads text, not HTML
 and any non-JS viewer get. Polars defaults truncate to ~8 rows, ~8 columns, and
 30-char strings, which hides most of a frame from the agent; widen to a fuller
 but still bounded view. The MCP layer caps a single text output at 50k chars
-(outputs._MAX_TEXT_CHARS), so a wide repr cannot flood the agent's context.
+(outputs.MAX_TEXT_CHARS), so a wide repr cannot flood the agent's context.
 """
 
 import polars as pl

--- a/packages/mcp/ix_notebook_mcp/outputs.py
+++ b/packages/mcp/ix_notebook_mcp/outputs.py
@@ -15,7 +15,10 @@ from typing import Any
 import nbformat
 from mcp import types as mcp_types
 
-_MAX_TEXT_CHARS = 50_000
+# Max chars of a single text block shown to the model per reply. The full output
+# is never lost: it stays in the kernel as ``jobs['<id>']`` (see tools.python_exec),
+# which pages it with tail/head/slice/grep/lines.
+MAX_TEXT_CHARS = 50_000
 _MAX_IMAGES = 8
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -87,8 +90,8 @@ def to_mcp(outputs: list[dict]) -> list[Content]:
 
 def text(value: Any) -> mcp_types.TextContent:
     rendered = _ANSI.sub("", value if isinstance(value, str) else "".join(value))
-    if len(rendered) > _MAX_TEXT_CHARS:
-        rendered = f"{rendered[:_MAX_TEXT_CHARS]}\n... [truncated {len(rendered) - _MAX_TEXT_CHARS} chars]"
+    if len(rendered) > MAX_TEXT_CHARS:
+        rendered = f"{rendered[:MAX_TEXT_CHARS]}\n... [truncated {len(rendered) - MAX_TEXT_CHARS} chars; full run kept as jobs['<id>'] — see the pager note below]"
     return mcp_types.TextContent(type="text", text=rendered)
 
 

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -153,7 +153,69 @@ class Job:
         return "".join(self._buf)
 
     def tail(self, n: int = 2000) -> str:
+        """Last ``n`` chars of this job's captured output."""
         return self.output[-n:]
+
+    def head(self, n: int = 2000) -> str:
+        """First ``n`` chars of this job's captured output."""
+        return self.output[:n]
+
+    def slice(self, start: int = 0, end: int | None = None) -> str:
+        """A character window ``output[start:end]``, for paging a large output a
+        chunk at a time after `grep`/`lines` locates the region."""
+        return self.output[start:end]
+
+    def lines(self, start: int = 0, end: int | None = None) -> str:
+        """Output lines ``[start:end]`` (0-based, ``end`` exclusive), numbered to
+        match `grep`'s line numbers so you can jump straight to a region."""
+        numbered = self.output.splitlines()
+        return "\n".join(f"{i}: {numbered[i]}" for i in range(*slice(start, end).indices(len(numbered))))
+
+    def grep(
+        self,
+        pattern: str,
+        ctx: int = 0,
+        *,
+        ignore_case: bool = True,
+        max_matches: int = 200,
+        max_chars: int = 20_000,
+    ) -> str:
+        """Lines of the captured output matching ``pattern`` (a regex), each with
+        ``ctx`` lines of surrounding context and its line number. Capped at
+        ``max_matches`` matches and ``max_chars`` total so the return is small
+        enough to read in one reply; once you spot the region, widen with
+        ``lines``/``slice``. Use this to find the needle in a truncated run
+        instead of re-running the work."""
+        import re as _re
+
+        rx = _re.compile(pattern, _re.IGNORECASE if ignore_case else 0)
+        src = self.output.splitlines()
+        keep: list[int] = []
+        seen: set[int] = set()
+        matches = 0
+        for index, line in enumerate(src):
+            if rx.search(line):
+                matches += 1
+                if matches > max_matches:
+                    break
+                for j in range(max(0, index - ctx), min(len(src), index + ctx + 1)):
+                    if j not in seen:
+                        seen.add(j)
+                        keep.append(j)
+        keep.sort()
+        rendered: list[str] = []
+        prev: int | None = None
+        for j in keep:
+            if prev is not None and j > prev + 1:
+                rendered.append("--")
+            rendered.append(f"{j}: {src[j]}")
+            prev = j
+        body = "\n".join(rendered)
+        if len(body) > max_chars:
+            body = body[:max_chars] + f"\n... [grep output clipped to {max_chars} chars; use slice()]"
+        if matches > max_matches:
+            body += f"\n... [stopped at {max_matches} matches; narrow the pattern]"
+        return body or f"(no lines match {pattern!r} in {len(src)} lines)"
 
     def running(self) -> bool:
         return self.status == "running"
@@ -870,20 +932,66 @@ async def __ix_run(code: str, budget: float = 15.0, name: str | None = None) -> 
     return job
 
 
+# How many chars of a job's output/result the per-call summary carries inline.
+# The full output stays in the kernel as ``jobs[id]`` (paged via tail/head/slice/
+# grep/lines); the summary also reports the full sizes so the server can tell the
+# caller when a reply was truncated and point at the job to page.
+_SUMMARY_CHARS = 50_000
+
+
+def _result_text(job: Job) -> str:
+    """The job result's model-facing text (a Result's ``llm_result``, else its
+    repr), used only to measure how much the inline summary leaves out."""
+    if job.result is None:
+        return ""
+    return getattr(job.result, "llm_result", None) or _safe_repr(job.result)
+
+
+def _job_summary(job: Job) -> dict:
+    """The structured per-call summary the MCP server parses. ``output_chars`` and
+    ``result_chars`` are the *full* sizes (the inline ``output`` is only a tail),
+    so the server can detect a truncated reply and tell the caller to page
+    ``jobs['<id>']``."""
+    return {
+        "id": job.id,
+        "name": job.name,
+        "status": job.status,
+        "running": job.running(),
+        "output": job.tail(_SUMMARY_CHARS),
+        "output_chars": len(job.output),
+        "result": None if job.result is None else _safe_repr(job.result),
+        "result_chars": len(_result_text(job)),
+        "error": job.error,
+    }
+
+
+def history(n: int = 20) -> "Result":
+    """A compact, newest-last listing of the most recent runs in this kernel, so
+    you can see what is available to drill into without remembering ids. Each row
+    is a ``jobs['<id>']`` you can page: ``.tail()/.head()/.slice()/.lines()/
+    .grep()`` for its output, ``.output`` for the full stdout, ``.result`` for the
+    value. The full runs persist in the kernel; this is just the index over them."""
+    items = list(jobs.values())[-n:]
+    header = f"{'id':<10}{'name':<18}{'status':<10}{'dur':>8}{'out':>9}{'result':>9}"
+    rows = [header]
+    for job in items:
+        dur = (job.ended or time.time()) - job.started
+        name = "" if job.name == job.id else job.name
+        rows.append(
+            f"{job.id:<10}{name[:17]:<18}{job.status:<10}{dur:>7.1f}s"
+            f"{len(job.output):>9}{len(_result_text(job)):>9}"
+        )
+    body = "\n".join(rows) if items else "(no runs yet)"
+    html = f'<pre class="ix-result">{_escape_html(body)}</pre>'
+    return Result.text(body, html=html)
+
+
 def _emit(job: Job) -> None:
     """Publish a structured summary the MCP server parses, plus the result's rich
     repr (image/HTML/table) as normal display output the server already renders."""
     from IPython.display import display, publish_display_data
 
-    summary = {
-        "id": job.id,
-        "name": job.name,
-        "status": job.status,
-        "running": job.running(),
-        "output": job.tail(50_000),
-        "result": None if job.result is None else _safe_repr(job.result),
-        "error": job.error,
-    }
+    summary = _job_summary(job)
     publish_display_data({JOB_MIME: summary, "text/plain": f"[{job.id}] {job.status}"})
     # On success job.result is always a Result (the runner enforces it); display
     # it so the server can unpack the model view and the dashboard the human one.
@@ -979,6 +1087,7 @@ def install(user_ns: dict | None = None) -> None:
 
     target = user_ns if user_ns is not None else globals()
     target["jobs"] = jobs
+    target["history"] = history
     target["Job"] = Job
     target["Result"] = Result
     target["cells"] = cells

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -77,7 +77,11 @@ Content = list[outputs.Content]
         "Run Python on the shared persistent kernel. Waits up to `budget` seconds; "
         "if the code is still running it keeps going in the background as jobs['<id>'] "
         "and this returns a job handle. Inspect/await/cancel background jobs with more "
-        "python_exec against the `jobs` dict. The namespace persists across calls, so "
+        "python_exec against the `jobs` dict. Every run is kept there, so a reply that "
+        "gets truncated is never lost: page the full run with jobs['<id>'].grep('pat') / "
+        ".tail(n) / .head(n) / .slice(a, b) / .lines(a, b), or read jobs['<id>'].output "
+        "(stdout) and jobs['<id>'].result (the value); history() lists recent runs. "
+        "The namespace persists across calls, so "
         "functions and classes you define are reusable next turn. The kernel is one "
         "shared event loop: a blocking call (`subprocess.run`, `time.sleep`, a heavy "
         "CPU op) freezes EVERY job and your own next cell, so it MUST be wrapped in "
@@ -112,6 +116,25 @@ async def python_exec(
     # Rich result blocks (images / HTML / the result repr) come from the kernel
     # display; drop the "(no output)" placeholder to_mcp emits when there were none.
     parts.extend(item for item in rendered if getattr(item, "text", None) != "(no output)")
+    # When the reply was clipped to fit, the full run still lives in the kernel as
+    # jobs['<id>']. Point the caller at it (with the ops to page it) so a large
+    # result is recoverable without re-running the work \u2014 the failure mode this
+    # whole jobs registry exists to avoid.
+    job_id = summary.get("id")
+    output_chars = summary.get("output_chars") or 0
+    result_chars = summary.get("result_chars") or 0
+    clipped = output_chars > len(captured or "") or result_chars > outputs.MAX_TEXT_CHARS
+    if clipped and job_id:
+        parts.append(
+            outputs.text(
+                f"[Reply truncated to fit. The full run stays in this kernel as "
+                f"jobs['{job_id}'] (stdout {output_chars} chars, result {result_chars} chars). "
+                f"Page it in a new python_exec cell instead of re-running: "
+                f"Result.text(jobs['{job_id}'].grep('pattern')) | .tail(8000) | .head(8000) | "
+                f".slice(50000, 70000) | .lines(0, 200). jobs['{job_id}'].output is the full "
+                f"stdout, jobs['{job_id}'].result the value; history() lists recent runs.]"
+            )
+        )
     return parts
 
 


### PR DESCRIPTION
## What

A large `python_exec` reply was clipped at 50k chars with only `[truncated N chars]` and no way to get the rest, so a big result meant re-running the work. Every run is already kept in the `jobs` dict, so this makes it the recovery path.

## Change

- **`Job` pagers** over the captured output: `head`, `slice`, `lines` (line-numbered), and a regex `grep` (line-numbered, context, self-capping at 200 matches / 20k chars), alongside the existing `tail`.
- **`history(n=20)`** lists the most recent runs (id, status, dur, output/result sizes) so you can see what's available to drill into without remembering ids. Returns a `Result` (table for the human, text for the model).
- The per-call summary now reports the **full** `output_chars` / `result_chars` (the inline `output` is only a tail), and `python_exec` appends an **actionable pointer** naming `jobs['<id>']` and the pager ops whenever a reply was truncated.
- `outputs._MAX_TEXT_CHARS` → public `outputs.MAX_TEXT_CHARS` (tools.py is now a second owner of "chars shown per block").

So instead of `[truncated 120000 chars]` and a lost tail, you get a pointer to `jobs['ab12'].grep('error')` / `.slice(50000, 70000)` / `.output` / `.result`, and `history()` to list runs.

## Validation

- `nix build .#mcp.tests.runtimeSmoke` (extended with the pager / `history()` / summary-size assertions)
- In-process: pagers, context grep, no-match message, `_job_summary` sizes, `history()` returning a `Result` naming the jobs

🤖 Written with Claude Opus 4.8 (claude-opus-4-8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add paging and search helpers to jobs registry for truncated run output
> - Adds `head`, `slice`, `lines`, and `grep` methods to the `Job` class in [`runtime.py`](https://github.com/indexable-inc/index/pull/787/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) so callers can retrieve segments of captured output without re-running jobs.
> - Adds a `history(n=20)` function (exposed in the kernel namespace) that lists recent jobs with id, name, status, duration, output length, and result length.
> - When `python_exec` output is truncated, it now appends a text advisory pointing to `jobs['<id>']` with example paging calls to recover the full run.
> - Truncation messages in [`outputs.py`](https://github.com/indexable-inc/index/pull/787/files#diff-c0531af2f36a91cd56ac9ae4f0be9a0cbb88094a80355387d1b13e95e1568eb9) now include the remaining char count and a reference to the relevant job id.
> - Behavioral Change: `_MAX_TEXT_CHARS` is renamed to `MAX_TEXT_CHARS`; any code importing the private name will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01d5c65.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->