### PR TITLE
feat(mcp): bundle `fleet` polars SSH fan-out source

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -90,7 +90,7 @@ install step: `fff` (fast fuzzy file search / content grep, with async
 `search_async`/`grep_async` + `afind`/`agrep`), `tui` (PTY driver), `search`
 (semantic/grep over the `index` corpus), `exa_py` (Exa web search; bring your own
 `EXA_API_KEY`), `google_auth` (Gmail/Calendar via `google_auth.gmail()` /
-`google_auth.calendar()`), numpy, polars, duckdb, httpx, matplotlib, playwright,
+`google_auth.calendar()`), `fleet` (polars-returning SSH fan-out: `await fleet.scan(hosts, cmd)` reads files/command-output from many hosts in parallel into one DataFrame), numpy, polars, duckdb, httpx, matplotlib, playwright,
 the Google API client, and on macOS `screen` and `vmkit`.
 
 ## Remote access

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -246,6 +246,27 @@ let
         cp -r ${viewPythonSource}/view/. "$site/"
       ''
   );
+  # Polars-returning SSH fan-out source: `import fleet`, then `await fleet.scan`
+  # runs a command on many hosts in parallel (asyncssh + a bounded semaphore on
+  # the shared loop) and combines per-host stdout into one DataFrame via
+  # `pl.concat(how="diagonal_relaxed")`. Pure Python over the bundled asyncssh +
+  # polars; cross-platform, so every session can `import fleet`.
+  fleetPythonSource = builtins.path {
+    name = "ix-mcp-fleet-python-source";
+    path = ./src/fleet;
+  };
+  fleetModule = pkgs.python3.pkgs.toPythonModule (
+    pkgs.runCommand "ix-mcp-fleet-python-module"
+      {
+        strictDeps = true;
+        meta.description = "Polars-returning SSH fan-out source bundled into the ix-mcp interpreter";
+      }
+      ''
+        site="$out/${pkgs.python3.sitePackages}/fleet"
+        mkdir -p "$site"
+        cp -r ${fleetPythonSource}/fleet/. "$site/"
+      ''
+  );
   screenPythonSource = builtins.path {
     name = "ix-mcp-screen-python-source";
     path = ./src/screen;
@@ -385,6 +406,7 @@ let
       ixGoogleModule
       ixNotebookMcpModule
       viewModule
+      fleetModule
     ]
     ++ darwinExtraPackages ps
   );
@@ -1019,6 +1041,125 @@ let
         mkdir -p "$out"
       '';
 
+  # The fleet module: a mocked asyncssh connection drives the fan-out so the test
+  # never depends on a reachable host or a running sshd. It asserts the contract
+  # that matters: import works, the semaphore caps in-flight connections,
+  # tag_host adds the column, diagonal_relaxed merges mismatched schemas, and
+  # on_error="collect" survives a failing host (recording it in attrs). Pure
+  # Python over the bundled asyncssh + polars, so the sandbox runs it.
+  fleetTestPy = pkgs.writeText "ix-mcp-fleet-test.py" ''
+    import asyncio
+    import sys
+
+    import polars as pl
+
+    import fleet
+
+    # --- Mock asyncssh so no network/sshd is needed. ---------------------------
+    inflight = {"now": 0, "max": 0}
+
+    class _Result:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    class _Conn:
+        def __init__(self, host):
+            self.host = host
+
+        async def __aenter__(self):
+            inflight["now"] += 1
+            inflight["max"] = max(inflight["max"], inflight["now"])
+            await asyncio.sleep(0.02)  # hold the slot so overlap is observable
+            return self
+
+        async def __aexit__(self, *exc):
+            inflight["now"] -= 1
+            return False
+
+        async def run(self, command, encoding=None, check=True):
+            # One host is configured to fail, to exercise on_error="collect".
+            if self.host == "bad":
+                raise RuntimeError("boom")
+            # Two hosts return DIFFERENT schemas to exercise diagonal_relaxed:
+            # one emits {a}, the other {b}.
+            if self.host == "h1":
+                return _Result(b'{"a": 1}\n')
+            return _Result(b'{"b": 2}\n')
+
+    def _connect(**opts):
+        return _Conn(opts["host"])
+
+    fleet.asyncssh.connect = _connect
+
+    async def main():
+        hosts = ["h1", "h2", "bad"]
+        df = await fleet.scan(hosts, "noop", concurrency=2, on_error="collect")
+
+        # tag_host added the host column, first.
+        assert df.columns[0] == "host", df.columns
+        # diagonal_relaxed unioned the {a} and {b} schemas.
+        assert set(df.columns) == {"host", "a", "b"}, df.columns
+        # Two good hosts -> two rows; the bad host did not abort the batch.
+        assert df.height == 2, df.height
+        # The failing host is recorded, not raised.
+        fails = df.attrs["fleet_failures"]
+        assert list(fails) == ["bad:22"], fails
+        assert "boom" in fails["bad:22"], fails
+
+        # Semaphore actually capped concurrency at 2 even with 3 hosts.
+        assert inflight["max"] <= 2, inflight
+
+        # on_error="raise" aggregates failures into FleetError.
+        try:
+            await fleet.scan(["bad"], "noop", on_error="raise")
+        except fleet.FleetError as exc:
+            assert "bad:22" in exc.failures, exc.failures
+        else:
+            raise AssertionError("expected FleetError")
+
+        # read_text yields one row per line with host+line columns.
+        class _Text(_Conn):
+            async def run(self, command, encoding=None, check=True):
+                return _Result(b"line one\nline two\n")
+        fleet.asyncssh.connect = lambda **o: _Text(o["host"])
+        txt = await fleet.read_text(["h1"], "/var/log/x")
+        assert set(txt.columns) == {"host", "line"}, txt.columns
+        assert txt.height == 2, txt.height
+
+        # An all-empty fan-out returns an empty frame, never crashes.
+        class _Empty(_Conn):
+            async def run(self, command, encoding=None, check=True):
+                return _Result(b"")
+        fleet.asyncssh.connect = lambda **o: _Empty(o["host"])
+        empty = await fleet.scan(["x"], "noop")
+        assert isinstance(empty, pl.DataFrame) and empty.height == 0
+
+        print("fleet-ok", fleet.__version__)
+
+    asyncio.run(main())
+  '';
+  fleetSmoke =
+    pkgs.runCommand "ix-mcp-fleet-smoke"
+      {
+        nativeBuildInputs = [ mcpPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        ${lib.getExe mcpPython} ${fleetTestPy} >stdout 2>stderr || {
+          echo "ix-mcp fleet smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -q '^fleet-ok' stdout || {
+          echo "ix-mcp fleet smoke did not confirm the fleet module:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
+
   # macOS-only modules (`screen`, `vmkit`) are only bundled on Darwin; their
   # import tests only exist there.
   screenBundled = importTest "screen" "import screen; print('screen-ok', callable(screen.capture), callable(screen.click), callable(screen.accessibility_trusted))";
@@ -1043,6 +1184,7 @@ package.overrideAttrs (old: {
         richSmoke
         bindDefaultSmoke
         viewSmoke
+        fleetSmoke
         ;
       site = dashboardSite;
     }

--- a/packages/mcp/src/fleet/fleet/__init__.py
+++ b/packages/mcp/src/fleet/fleet/__init__.py
@@ -1,0 +1,436 @@
+"""Polars-returning SSH fan-out source for the ix-mcp kernel.
+
+Bundled like ``view``/``fff``/``search`` so every session can ``import fleet``
+with no setup. The point: a ``python_exec`` cell often wants the same file or the
+same command's output from *many* fleet hosts at once (every node's journald
+tail, every host's disk usage, a config that should be identical everywhere),
+and then to slice the combined result with polars. Hand-rolling that means a
+loop of ``ssh`` subprocesses, manual stdout parsing, and a fragile merge. This
+module does the fan-out on the shared async loop (``asyncssh`` + a bounded
+``asyncio.Semaphore``), parses each host's bytes into a ``polars.DataFrame``,
+tags every row with its ``host``, and stitches the per-host frames into one with
+``pl.concat(how="diagonal_relaxed")`` so mismatched schemas still combine.
+
+Everything that touches the network is ``async def`` because the kernel is one
+shared event loop: a blocking ``ssh`` subprocess or ``time.sleep`` would freeze
+every other job. Cells ``await`` the read functions.
+
+Usage::
+
+    import fleet
+
+    # Every host's free-disk JSON (host-side `df` emitting NDJSON), one frame.
+    df = await fleet.scan(
+        ["hc1.ts.net:9999", "hc2.ts.net:9999"],
+        "df -h --output=source,size,used,avail,target | tail -n +2 "
+        "| awk '{print \"{\\\"src\\\":\\\"\"$1\"\\\",\\\"avail\\\":\\\"\"$4\"\\\"}\"}'",
+    )
+    df.filter(pl.col("avail").str.contains("G")).sort("host")
+
+    # Unstructured log lines, one row per line, tagged by host.
+    logs = await fleet.read_text(hosts, "/var/log/syslog")
+
+    # Survive a down host instead of failing the whole batch.
+    df = await fleet.scan(hosts, "uptime", parser=fleet.text_parser,
+                          on_error="collect")
+    df.attrs  # {"fleet_failures": {host: "error string", ...}}
+
+The SSH defaults match how the fleet is already reached: key auth via
+``~/.ssh/id_ed25519``, ``known_hosts`` resolved non-interactively (an unknown
+host is accepted and recorded rather than blocking on a prompt), and a per-entry
+port so ``*.ts.net`` hosts on ``:9999`` and plain hosts on ``:22`` mix freely in
+one call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import os
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import asyncssh
+import polars as pl
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "scan",
+    "read_ndjson",
+    "read_csv",
+    "read_parquet",
+    "read_text",
+    "ndjson_parser",
+    "csv_parser",
+    "parquet_parser",
+    "text_parser",
+    "FleetError",
+    "HostSpec",
+]
+
+# A parser turns one host's raw stdout bytes into a DataFrame. Kept as a plain
+# callable so a caller can pass `pl.read_ndjson`, a lambda, or one of the
+# wrappers below interchangeably.
+Parser = Callable[[bytes], pl.DataFrame]
+
+# How a caller may name a host: a bare hostname (default port), "host:port", or
+# a dict of asyncssh connect kwargs (must carry at least "host").
+HostSpec = "str | Mapping[str, Any]"
+
+# Default identity. The fleet is reached with this key already; resolve it once
+# here rather than relying on an ssh-agent that a non-interactive kernel may not
+# have. A missing file is simply not passed, so agent/other auth still works.
+_DEFAULT_KEY = Path(os.path.expanduser("~/.ssh/id_ed25519"))
+
+
+class FleetError(Exception):
+    """A fan-out failed.
+
+    Raised by :func:`scan` when ``on_error="raise"`` and one or more hosts
+    failed. ``failures`` maps each failed host label to its error string so the
+    caller sees every failure at once, not just the first.
+    """
+
+    def __init__(self, failures: dict[str, str]) -> None:
+        self.failures = failures
+        joined = "; ".join(f"{h}: {e}" for h, e in failures.items())
+        super().__init__(f"fleet scan failed on {len(failures)} host(s): {joined}")
+
+
+def ndjson_parser(data: bytes) -> pl.DataFrame:
+    """Parse newline-delimited JSON stdout. The default :func:`scan` parser."""
+    # Empty stdout (a command that printed nothing) is a legitimate result, not
+    # an error: return an empty frame so the host still contributes a `host`
+    # column under `diagonal_relaxed` rather than blowing up read_ndjson.
+    if not data.strip():
+        return pl.DataFrame()
+    return pl.read_ndjson(io.BytesIO(data))
+
+
+def csv_parser(data: bytes) -> pl.DataFrame:
+    """Parse CSV stdout into a DataFrame."""
+    if not data.strip():
+        return pl.DataFrame()
+    return pl.read_csv(io.BytesIO(data))
+
+
+def parquet_parser(data: bytes) -> pl.DataFrame:
+    """Parse Parquet bytes (e.g. from ``cat file.parquet``) into a DataFrame."""
+    if not data:
+        return pl.DataFrame()
+    return pl.read_parquet(io.BytesIO(data))
+
+
+def text_parser(data: bytes) -> pl.DataFrame:
+    """Parse raw stdout into one ``line`` column, one row per line.
+
+    For unstructured output (logs, shell history, ``uptime``) where there is no
+    record format to read. The ``host`` column is added by :func:`scan` when
+    ``tag_host`` is set.
+    """
+    text = data.decode("utf-8", errors="replace")
+    # Splitlines (not split on "\n") so a trailing newline does not yield a
+    # spurious empty final row, and CRLF logs split cleanly too.
+    lines = text.splitlines()
+    return pl.DataFrame({"line": lines}, schema={"line": pl.String})
+
+
+def _normalize_host(
+    spec: "str | Mapping[str, Any]",
+    *,
+    username: str | None,
+    connect_kwargs: dict[str, Any],
+) -> tuple[str, dict[str, Any]]:
+    """Resolve one host entry into (label, asyncssh.connect kwargs).
+
+    Accepts "host", "host:port", or a dict of connect kwargs. The label is what
+    shows up in the `host` column and in failure keys: a stable "host:port" so
+    two ports on one hostname stay distinct.
+    """
+    opts: dict[str, Any] = dict(connect_kwargs)
+
+    if isinstance(spec, Mapping):
+        opts.update(spec)
+        host = opts.get("host")
+        if not host:
+            raise ValueError(f"host dict missing 'host' key: {spec!r}")
+        port = opts.get("port", 22)
+    else:
+        host = spec
+        # "[v6::addr]:port" is out of scope here; the fleet is named hosts. A
+        # single trailing ":port" is the only split, so rsplit once.
+        if ":" in spec:
+            host, _, port_s = spec.rpartition(":")
+            port = int(port_s)
+        else:
+            port = 22
+        opts["host"] = host
+        opts["port"] = port
+
+    if username is not None:
+        opts.setdefault("username", username)
+
+    # Non-interactive known_hosts: never prompt (a prompt would hang the kernel
+    # forever). known_hosts=None tells asyncssh to accept and not verify the
+    # host key. Callers who want strict checking pass known_hosts= explicitly.
+    opts.setdefault("known_hosts", None)
+
+    # Default identity, only if present and the caller did not specify auth.
+    if (
+        "client_keys" not in opts
+        and "password" not in opts
+        and _DEFAULT_KEY.exists()
+    ):
+        opts["client_keys"] = [str(_DEFAULT_KEY)]
+
+    label = f"{opts['host']}:{opts['port']}"
+    return label, opts
+
+
+async def _run_one(
+    label: str,
+    opts: dict[str, Any],
+    command: str,
+    sem: asyncio.Semaphore,
+) -> bytes:
+    """Open one connection, run one command, return stdout bytes.
+
+    The semaphore is acquired around the whole connect+run so concurrency caps
+    the number of *live connections*, not just queued coroutines.
+    """
+    async with sem:
+        async with asyncssh.connect(**opts) as conn:
+            # encoding=None keeps stdout as bytes so a binary payload (parquet
+            # over `cat`) survives; text parsers decode themselves.
+            result = await conn.run(command, encoding=None, check=True)
+            out = result.stdout
+            return out if isinstance(out, bytes) else bytes(out or b"")
+
+
+async def scan(
+    hosts: Sequence["str | Mapping[str, Any]"],
+    command: str,
+    *,
+    parser: Parser | None = None,
+    concurrency: int = 16,
+    tag_host: bool = True,
+    username: str | None = None,
+    on_error: str = "collect",
+    **connect_kwargs: Any,
+) -> pl.DataFrame:
+    """Run ``command`` on every host in parallel and combine into one frame.
+
+    One ``asyncssh`` connection per host, bounded by
+    ``asyncio.Semaphore(concurrency)`` so at most ``concurrency`` connections are
+    live at once. Each host's stdout bytes go through ``parser`` (default
+    :func:`ndjson_parser`); per-host frames are combined with
+    ``pl.concat(how="diagonal_relaxed")`` so heterogeneous schemas still merge.
+
+    Args:
+        hosts: host entries as ``"host"``, ``"host:port"``, or a connect-kwargs
+            ``dict`` (must include ``"host"``). Ports are per entry, so a
+            ``*.ts.net:9999`` host and a plain ``:22`` host mix in one call.
+        command: the remote command. Prefer host-side filtering (``rg``/``jq``/
+            ``tail``) so less crosses the wire.
+        parser: ``bytes -> pl.DataFrame``. Defaults to NDJSON. Use
+            :func:`csv_parser`, :func:`parquet_parser`, :func:`text_parser`, or
+            your own.
+        concurrency: max simultaneous SSH connections.
+        tag_host: add a ``host`` literal column (the ``"host:port"`` label) to
+            each host's rows. The first column in the result.
+        username: SSH username applied to every host that does not set its own.
+        on_error: ``"collect"`` gathers per-host failures into
+            ``result.attrs["fleet_failures"]`` (a ``{label: error}`` dict) and
+            returns the successful rows; ``"raise"`` aggregates all failures and
+            raises :class:`FleetError`.
+        **connect_kwargs: extra kwargs passed to every ``asyncssh.connect``
+            (e.g. ``known_hosts=...``, ``client_keys=...``) unless a host dict
+            overrides them.
+
+    Returns:
+        A combined ``polars.DataFrame``. An all-empty fan-out returns an empty
+        frame rather than raising. When ``on_error="collect"``, per-host
+        failures are under ``result.attrs["fleet_failures"]``.
+
+    Example::
+
+        df = await fleet.scan(
+            ["hc1.ts.net:9999", "hc2.ts.net:9999"],
+            "cat /proc/loadavg | awk '{print \"{\\\"load1\\\":\"$1\"}\"}'",
+        )
+        df.sort("load1", descending=True)
+    """
+    if on_error not in ("collect", "raise"):
+        raise ValueError(f"on_error must be 'collect' or 'raise', got {on_error!r}")
+    if parser is None:
+        parser = ndjson_parser
+
+    sem = asyncio.Semaphore(max(1, concurrency))
+    normalized = [
+        _normalize_host(h, username=username, connect_kwargs=connect_kwargs)
+        for h in hosts
+    ]
+
+    # Launch every host concurrently; the semaphore inside _run_one is what
+    # actually caps in-flight connections. return_exceptions so one bad host
+    # never cancels the gather.
+    tasks = [_run_one(label, opts, command, sem) for label, opts in normalized]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    frames: list[pl.DataFrame] = []
+    failures: dict[str, str] = {}
+    for (label, _opts), res in zip(normalized, results):
+        if isinstance(res, BaseException):
+            failures[label] = f"{type(res).__name__}: {res}"
+            continue
+        frame = parser(res)
+        if tag_host and frame.width > 0:
+            # Prepend a host literal so every row carries its origin and the
+            # column lands first. An empty per-host frame stays empty (no rows
+            # to tag); diagonal_relaxed still unions it harmlessly.
+            frame = frame.with_columns(pl.lit(label).alias("host")).select(
+                ["host", *[c for c in frame.columns if c != "host"]]
+            )
+        frames.append(frame)
+
+    if on_error == "raise" and failures:
+        raise FleetError(failures)
+
+    if not frames or all(f.width == 0 for f in frames):
+        combined = pl.DataFrame()
+    else:
+        # diagonal_relaxed: union of columns across hosts, with dtype coercion
+        # when the same column came back as different types. Drop the truly
+        # empty (0-width) frames first so they do not force an all-null schema.
+        non_empty = [f for f in frames if f.width > 0]
+        combined = pl.concat(non_empty, how="diagonal_relaxed")
+
+    # Surface failures on the frame itself so a cell can inspect them without a
+    # separate return value. attrs is a plain dict polars passes through.
+    combined.attrs = {"fleet_failures": failures}  # type: ignore[attr-defined]
+    return combined
+
+
+async def read_ndjson(
+    hosts: Sequence["str | Mapping[str, Any]"],
+    remote_path: str,
+    *,
+    filter_cmd: str | None = None,
+    **kw: Any,
+) -> pl.DataFrame:
+    """Read an NDJSON file from every host into one frame.
+
+    Runs ``cat <remote_path>`` by default. ``filter_cmd`` replaces that with a
+    host-side pipeline so filtering happens at the source and less crosses the
+    wire, e.g. ``filter_cmd="rg level=error /var/log/app.ndjson"`` or
+    ``filter_cmd="tail -n 100 /var/log/app.ndjson | jq -c 'select(.ok)'"``.
+    Extra kwargs pass through to :func:`scan`.
+    """
+    command = filter_cmd if filter_cmd is not None else f"cat {_q(remote_path)}"
+    return await scan(hosts, command, parser=ndjson_parser, **kw)
+
+
+async def read_csv(
+    hosts: Sequence["str | Mapping[str, Any]"],
+    remote_path: str,
+    *,
+    filter_cmd: str | None = None,
+    **kw: Any,
+) -> pl.DataFrame:
+    """Read a CSV file from every host into one frame.
+
+    ``cat <remote_path>`` by default; ``filter_cmd`` substitutes a host-side
+    pipeline (keep the header if you filter, e.g. with ``head -1; rg ...``).
+    """
+    command = filter_cmd if filter_cmd is not None else f"cat {_q(remote_path)}"
+    return await scan(hosts, command, parser=csv_parser, **kw)
+
+
+async def read_parquet(
+    hosts: Sequence["str | Mapping[str, Any]"],
+    remote_path: str,
+    *,
+    use_sftp: bool = False,
+    **kw: Any,
+) -> pl.DataFrame:
+    """Read a Parquet file from every host into one frame.
+
+    Parquet is binary, so by default this streams the bytes over ``cat`` (stdout
+    is captured as bytes). ``use_sftp=True`` fetches via SFTP instead, which
+    avoids any shell-quoting of the path and is friendlier to large files. Both
+    paths feed the bytes to ``pl.read_parquet``.
+    """
+    if not use_sftp:
+        return await scan(
+            hosts, f"cat {_q(remote_path)}", parser=parquet_parser, **kw
+        )
+    # SFTP path: open one connection per host (bounded), read the whole file,
+    # then reuse `scan`'s combine by faking a parser over the prefetched bytes
+    # would be awkward, so do the gather here directly.
+    concurrency = kw.pop("concurrency", 16)
+    tag_host = kw.pop("tag_host", True)
+    username = kw.pop("username", None)
+    on_error = kw.pop("on_error", "collect")
+    sem = asyncio.Semaphore(max(1, concurrency))
+    normalized = [
+        _normalize_host(h, username=username, connect_kwargs=kw) for h in hosts
+    ]
+
+    async def fetch(label: str, opts: dict[str, Any]) -> bytes:
+        async with sem:
+            async with asyncssh.connect(**opts) as conn:
+                async with conn.start_sftp_client() as sftp:
+                    async with sftp.open(remote_path, "rb") as fh:
+                        return await fh.read()
+
+    results = await asyncio.gather(
+        *(fetch(label, opts) for label, opts in normalized),
+        return_exceptions=True,
+    )
+    frames: list[pl.DataFrame] = []
+    failures: dict[str, str] = {}
+    for (label, _opts), res in zip(normalized, results):
+        if isinstance(res, BaseException):
+            failures[label] = f"{type(res).__name__}: {res}"
+            continue
+        frame = parquet_parser(res)
+        if tag_host and frame.width > 0:
+            frame = frame.with_columns(pl.lit(label).alias("host")).select(
+                ["host", *[c for c in frame.columns if c != "host"]]
+            )
+        frames.append(frame)
+    if on_error == "raise" and failures:
+        raise FleetError(failures)
+    non_empty = [f for f in frames if f.width > 0]
+    combined = (
+        pl.concat(non_empty, how="diagonal_relaxed") if non_empty else pl.DataFrame()
+    )
+    combined.attrs = {"fleet_failures": failures}  # type: ignore[attr-defined]
+    return combined
+
+
+async def read_text(
+    hosts: Sequence["str | Mapping[str, Any]"],
+    remote_path: str,
+    *,
+    filter_cmd: str | None = None,
+    **kw: Any,
+) -> pl.DataFrame:
+    """Read an unstructured file from every host as one row per line.
+
+    Returns a frame with columns ``host`` and ``line`` (one row per line), for
+    logs, shell history, and other text with no record format. ``filter_cmd``
+    runs a host-side pipeline instead of ``cat`` so you can ``tail``/``rg`` at
+    the source (e.g. ``filter_cmd="rg -i oom /var/log/kern.log"``).
+    """
+    command = filter_cmd if filter_cmd is not None else f"cat {_q(remote_path)}"
+    return await scan(hosts, command, parser=text_parser, **kw)
+
+
+def _q(path: str) -> str:
+    """Shell-quote a remote path so spaces/specials are safe in the command."""
+    import shlex
+
+    return shlex.quote(path)


### PR DESCRIPTION
Adds a new bundled python module `fleet` for the index MCP: a polars-returning SSH fan-out source so `python_exec` cells read files / command-output from many fleet hosts in parallel and combine into one DataFrame.

## What
- `await fleet.scan(hosts, command, *, parser=None, concurrency=16, tag_host=True, username=None, on_error="collect", **connect_kwargs)`: one asyncssh connection per host bounded by `asyncio.Semaphore`, runs `command`, parses each host's stdout bytes (default NDJSON), combines via `pl.concat(how="diagonal_relaxed")` so mismatched schemas merge. `tag_host` prepends a `host` column; `on_error="collect"` records per-host failures in `result.attrs["fleet_failures"]` while `"raise"` aggregates into `FleetError`.
- Convenience wrappers with source-side filtering: `read_ndjson` / `read_csv` / `read_parquet` (SFTP or cat) / `read_text` (one row per line, `host`,`line` columns), each supporting a host-side `filter_cmd` so less crosses the wire.
- SSH defaults matching how the fleet is already reached: `~/.ssh/id_ed25519` key auth, non-interactive `known_hosts` (accept-and-record, never prompt/hang), per-entry port so `*.ts.net:9999` and `:22` hosts mix in one call. Host entries accept `"host"`, `"host:port"`, or a connect-kwargs dict.
- Fully async / non-blocking (the kernel is one shared event loop).

## How bundled
Same pattern as `view`: `packages/mcp/src/fleet/fleet/{__init__.py,py.typed}` wrapped by `toPythonModule` and added to the pinned interpreter's `withPackages`, so cells `import fleet` with zero install. `asyncssh` was already a dep.

## Validation
- `nix build .#mcp` green.
- `nix build .#mcp.tests.fleetSmoke` green: a mocked-asyncssh test (no sshd/network) asserts import works, the semaphore caps in-flight connections at the limit, `tag_host` adds the column, `diagonal_relaxed` merges mismatched schemas, `on_error="collect"` survives a failing host (recorded in attrs), `on_error="raise"` aggregates into `FleetError`, `read_text` yields one row per line, and an all-empty fan-out returns an empty frame.

Authored with Claude Opus 4.8.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bundle `fleet` polars SSH fan-out source into the MCP Python environment
> - Adds a new `fleet` Python module ([`__init__.py`](https://github.com/indexable-inc/index/pull/789/files#diff-8272134b0de53efa7e2c76d3726966d21a65955bcd55f0d128c34ccfe323f1f8)) providing `fleet.scan(hosts, cmd)`, which runs a shell command across multiple SSH hosts concurrently (bounded by an `asyncio.Semaphore`) and aggregates per-host stdout into a single polars DataFrame via `pl.concat(how='diagonal_relaxed')`.
> - Includes convenience wrappers `read_ndjson`, `read_csv`, `read_parquet`, and `read_text`, plus built-in parsers for each format and a `FleetError` exception for aggregated failures when `on_error='raise'`.
> - Packages the module into the Nix-built interpreter via [`default.nix`](https://github.com/indexable-inc/index/pull/789/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) and adds a smoke test (`fleetSmoke`) that monkeypatches asyncssh to validate concurrency, host tagging, schema union, and error handling — the build fails if the smoke test does not print `fleet-ok`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8eaf5e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->