### PR TITLE
docs(mcp): stop duplicating the bundled-modules list in the README

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -84,14 +84,13 @@ read-only dashboard, and the MCP transport, all on one event loop.
 
 ## Pinned interpreter and bundled modules
 
-The kernel runs on the same pinned interpreter as the server (see
-[`default.nix`](./default.nix)), so code can `import` the bundled modules with no
-install step: `fff` (fast fuzzy file search / content grep, with async
-`search_async`/`grep_async` + `afind`/`agrep`), `tui` (PTY driver), `search`
-(semantic/grep over the `index` corpus), `exa_py` (Exa web search; bring your own
-`EXA_API_KEY`), `google_auth` (Gmail/Calendar via `google_auth.gmail()` /
-`google_auth.calendar()`), `fleet` (polars-returning SSH fan-out: `await fleet.scan(hosts, cmd)` reads files/command-output from many hosts in parallel into one DataFrame), numpy, polars, duckdb, httpx, matplotlib, playwright,
-the Google API client, and on macOS `screen` and `vmkit`.
+The kernel runs on the same pinned interpreter as the server, so code can
+`import` a set of bundled modules (the data libraries plus the in-house `fff` /
+`view` / `tui` / `search` / `fleet` helpers) with no install step. The canonical
+list lives in one place, the MCP server `instructions=` string in
+[`tools.py`](./ix_notebook_mcp/tools.py); the interpreter that
+backs it is assembled in [`default.nix`](./default.nix). Both are kept here
+rather than re-enumerated in this README so the list cannot drift.
 
 ## Remote access
 


### PR DESCRIPTION
Follow-up to #789/#790. The MCP server `instructions=` string in `packages/mcp/ix_notebook_mcp/tools.py` is the single source of truth for the bundled-modules list. The README's "Pinned interpreter and bundled modules" section re-enumerated that list (and carried the `fleet` entry added in #789), which is redundant and will drift.

This removes the duplicated module enumeration (and the `fleet` README entry), pointing readers at the instructions string and `default.nix` instead. Kept the genuinely human-only context: that the kernel runs on the same pinned interpreter as the server, and the links to the canonical sources.

`nix build .#mcp` green (docs-only).

Authored with Claude Opus 4.8.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove duplicated bundled-modules list from MCP README
> The README previously listed bundled modules explicitly, risking drift from the actual definitions. The list is removed and replaced with a pointer to the canonical source in `ix_notebook_mcp/tools.py` (server instructions string) and `default.nix` (interpreter assembly).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 721e7d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->