### PR TITLE
mcp dashboard: live-value hover and inlay hints on cell source

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -866,6 +866,100 @@ let
         mkdir -p "$out"
       '';
 
+  # Exercises the live-value introspection that feeds the dashboard's hover/inlay:
+  # describe() classifies scalars, DataFrames, functions (with a source location),
+  # and modules; cell_bindings() resolves a cell's mentioned names against the
+  # namespace (excluding attribute parts); and a finished job persists those
+  # bindings to the store, which is where the dashboard reads them. In-process, no
+  # kernel or network, so the sandbox runs it.
+  bindingsTestPy = pkgs.writeText "ix-mcp-bindings-test.py" ''
+    import asyncio
+    import inspect
+    import json
+    import os
+    import sqlite3
+    import tempfile
+
+    import polars as pl
+
+    from ix_notebook_mcp import introspect
+
+    # Direct descriptors: each kind carries the inlay summary the dashboard shows.
+    assert introspect.describe(42)["summary"] == "42"
+    df_desc = introspect.describe(pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}))
+    assert df_desc["kind"] == "dataframe" and "3×2" in df_desc["summary"], df_desc
+
+    def sample(x):
+        "a doc line"
+        return x
+
+    fn_desc = introspect.describe(sample)
+    assert fn_desc["kind"] == "callable" and fn_desc["summary"].startswith("ƒ sample"), fn_desc
+    # A function has a definition site: this is the go-to-definition payload.
+    assert ":" in fn_desc.get("def", ""), fn_desc
+
+    mod_desc = introspect.describe(inspect)
+    assert mod_desc["kind"] == "module" and mod_desc["summary"] == "module inspect", mod_desc
+
+    # cell_bindings resolves names a cell mentions; an attribute (df.height) is not
+    # a name, so only `df` and `n` are described, not `height`.
+    ns = {"df": pl.DataFrame({"a": [1]}), "n": 7}
+    bound = introspect.cell_bindings("rows = df.height\ntotal = n + 1\n", ns)
+    assert set(bound) == {"df", "n"}, bound
+    assert bound["df"]["kind"] == "dataframe" and bound["n"]["summary"] == "7", bound
+
+    # End to end: a finished job snapshots its bindings into the store row.
+    store_path = tempfile.mktemp(suffix=".db")
+    os.environ["IX_MCP_STORE"] = store_path
+
+    from IPython.core.interactiveshell import InteractiveShell
+
+    InteractiveShell.instance()
+
+    from ix_notebook_mcp import runtime
+
+    user_ns = {"pl": pl}
+    runtime.install(user_ns)
+    run = user_ns["__ix_run"]
+
+
+    async def main():
+        job = await run("frame = pl.DataFrame({'a': [1, 2]})\nResult.ok('made it')", budget=3.0, name="bind")
+        await job.task
+        conn = sqlite3.connect(store_path)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT bindings FROM executions WHERE id = ?", (job.id,)).fetchone()
+        stored = json.loads(row["bindings"])
+        assert stored.get("frame", {}).get("kind") == "dataframe", stored
+        # `pl` is referenced and live, so it is described as a module.
+        assert stored.get("pl", {}).get("kind") == "module", stored
+
+
+    asyncio.run(main())
+    print("bindings-ok")
+  '';
+  bindingsSmoke =
+    pkgs.runCommand "ix-mcp-bindings-smoke"
+      {
+        nativeBuildInputs = [ mcpPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        ${lib.getExe mcpPython} ${bindingsTestPy} >stdout 2>stderr || {
+          echo "ix-mcp bindings smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -qx 'bindings-ok' stdout || {
+          echo "ix-mcp bindings smoke did not confirm value introspection:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
+
   # The vmkit guest surfaces as a live dashboard resource: a booted Driver shows
   # up in Driver.list_all(), renders its framebuffer to inline-PNG HTML, and the
   # runtime's resource provider discovers it. Uses a fake proc + a seeded frame
@@ -1182,6 +1276,7 @@ package.overrideAttrs (old: {
         evalSmoke
         runtimeSmoke
         richSmoke
+        bindingsSmoke
         bindDefaultSmoke
         viewSmoke
         fleetSmoke

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -941,6 +941,21 @@ let
     migrated = {row[1] for row in conn_a.execute("PRAGMA table_info(executions)")}
     assert "bindings" in migrated, migrated
 
+    # The duplicate-column race itself: a connection that observed the column
+    # missing (here forced via a shim) but runs ALTER after another connection
+    # already added it must swallow the error, not raise. This exercises the
+    # except branch the idempotency case above skips.
+    class _StaleSchema:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def execute(self, sql, *args):
+            if sql.startswith("PRAGMA table_info"):
+                return [(0, "id"), (1, "name")]  # pretend bindings is still absent
+            return self._conn.execute(sql, *args)
+
+    store_mod._migrate(_StaleSchema(conn_a))  # ALTER -> duplicate column -> caught
+
     # End to end: a finished job snapshots its bindings into the store row.
     store_path = tempfile.mktemp(suffix=".db")
     os.environ["IX_MCP_STORE"] = store_path

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -889,6 +889,11 @@ let
     df_desc = introspect.describe(pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}))
     assert df_desc["kind"] == "dataframe" and "3×2" in df_desc["summary"], df_desc
 
+    # A wide frame's schema detail is capped, not dumped whole, so the stored row
+    # and poll payload stay bounded.
+    wide = introspect.describe(pl.DataFrame({f"c{i}": [0] for i in range(30)}))
+    assert "+6 more" in wide["detail"], wide
+
     def sample(x):
         "a doc line"
         return x
@@ -917,6 +922,24 @@ let
     assert 'data-ix-name="df"' in highlighted, highlighted
     assert 'data-ix-name="rows"' in highlighted, highlighted
     assert 'data-ix-name="total"' in highlighted, highlighted
+
+    # Opening a pre-bindings store migrates it, and a second open (the kernel and
+    # dashboard each open the store) is a no-op rather than an error.
+    from ix_notebook_mcp import store as store_mod
+
+    legacy = tempfile.mktemp(suffix=".db")
+    seed = sqlite3.connect(legacy)
+    seed.execute(
+        "CREATE TABLE executions (id TEXT PRIMARY KEY, name TEXT, code TEXT NOT NULL, "
+        "status TEXT NOT NULL, started_at REAL NOT NULL, ended_at REAL, "
+        "output TEXT, result TEXT, error TEXT, outputs TEXT)"
+    )
+    seed.commit()
+    seed.close()
+    conn_a = store_mod.connect(legacy)
+    store_mod.connect(legacy)
+    migrated = {row[1] for row in conn_a.execute("PRAGMA table_info(executions)")}
+    assert "bindings" in migrated, migrated
 
     # End to end: a finished job snapshots its bindings into the store row.
     store_path = tempfile.mktemp(suffix=".db")

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -908,6 +908,16 @@ let
     assert set(bound) == {"df", "n"}, bound
     assert bound["df"]["kind"] == "dataframe" and bound["n"]["summary"] == "7", bound
 
+    # The highlighter marks each identifier token with data-ix-name, the anchor the
+    # browser joins with bindings; attribute parts (head) are not names so the
+    # frontend never lights them up, but the token is still present in the markup.
+    from ix_notebook_mcp import dashboard
+
+    highlighted = dashboard._code_html("rows = df.head()\ntotal = n + 1\n")
+    assert 'data-ix-name="df"' in highlighted, highlighted
+    assert 'data-ix-name="rows"' in highlighted, highlighted
+    assert 'data-ix-name="total"' in highlighted, highlighted
+
     # End to end: a finished job snapshots its bindings into the store row.
     store_path = tempfile.mktemp(suffix=".db")
     os.environ["IX_MCP_STORE"] = store_path

--- a/packages/mcp/ix_notebook_mcp/dashboard.py
+++ b/packages/mcp/ix_notebook_mcp/dashboard.py
@@ -16,6 +16,7 @@ run outside nix), a small stub explains how to build the UI.
 from __future__ import annotations
 
 import functools
+import html
 import os
 from pathlib import Path
 
@@ -55,21 +56,57 @@ _PAGE = _load_page()
 @functools.lru_cache(maxsize=512)
 def _code_html(code: str) -> str:
     """A python snippet as self-contained highlighted HTML (inline monokai
-    styles, no wrapping ``<pre>`` so the card controls layout). Cached so each
-    unique snippet is highlighted once, not on every one-second poll; falls back
-    to empty (the card then shows the raw text) when pygments is unavailable."""
+    styles, no wrapping ``<pre>`` so the card controls layout). Every identifier
+    token carries a ``data-ix-name`` so the dashboard can attach the value inlay
+    and hover card to it; the join with values is by name, done in the browser
+    against the job's ``bindings`` (kept out of here so this stays cache-keyed on
+    the code text alone). Cached so each unique snippet is highlighted once, not
+    on every one-second poll; falls back to empty (the card then shows the raw
+    text) when pygments is unavailable."""
     if not code:
         return ""
     try:
-        from pygments import highlight
-        from pygments.formatters import HtmlFormatter
         from pygments.lexers import PythonLexer
+        from pygments.styles import get_style_by_name
+        from pygments.token import Token
 
-        formatter = HtmlFormatter(style="monokai", noclasses=True, nowrap=True)
-        return highlight(code, PythonLexer(), formatter).strip()
+        style = get_style_by_name("monokai")
+        parts: list[str] = []
+        for token_type, value in PythonLexer().get_tokens(code):
+            if not value:
+                continue
+            text = html.escape(value)
+            css = _token_css(style, token_type)
+            # Anchor only real identifiers (not builtins, operators, or the `@` of
+            # a decorator) so the inlay/hover attaches to user namespace names.
+            if token_type in Token.Name and token_type not in Token.Name.Builtin and value.isidentifier():
+                attr = html.escape(value, quote=True)
+                style_attr = f' style="{css}"' if css else ""
+                parts.append(f'<span data-ix-name="{attr}"{style_attr}>{text}</span>')
+            elif css:
+                parts.append(f'<span style="{css}">{text}</span>')
+            else:
+                parts.append(text)
+        return "".join(parts).strip("\n")
     except Exception:
         # Highlighting is cosmetic: a missing/old pygments must not break the API.
         return ""
+
+
+def _token_css(style, token_type) -> str:
+    """Inline CSS for one pygments token under ``style`` (the noclasses path,
+    rebuilt here so we can also emit identifier anchors)."""
+    spec = style.style_for_token(token_type)
+    parts: list[str] = []
+    if spec.get("color"):
+        parts.append(f"color:#{spec['color']}")
+    if spec.get("bold"):
+        parts.append("font-weight:bold")
+    if spec.get("italic"):
+        parts.append("font-style:italic")
+    if spec.get("underline"):
+        parts.append("text-decoration:underline")
+    return ";".join(parts)
 
 
 async def start(config: Config) -> web.AppRunner:

--- a/packages/mcp/ix_notebook_mcp/dashboard.py
+++ b/packages/mcp/ix_notebook_mcp/dashboard.py
@@ -78,7 +78,10 @@ def _code_html(code: str) -> str:
             text = html.escape(value)
             css = _token_css(style, token_type)
             # Anchor only real identifiers (not builtins, operators, or the `@` of
-            # a decorator) so the inlay/hover attaches to user namespace names.
+            # a decorator) so the inlay/hover attaches to user namespace names. This
+            # also tags attribute parts (`head` in `df.head`); the join is by name,
+            # so they stay inert unless a same-named variable is live, an accepted
+            # edge of name-keyed (vs position-keyed) matching.
             if token_type in Token.Name and token_type not in Token.Name.Builtin and value.isidentifier():
                 attr = html.escape(value, quote=True)
                 style_attr = f' style="{css}"' if css else ""

--- a/packages/mcp/ix_notebook_mcp/introspect.py
+++ b/packages/mcp/ix_notebook_mcp/introspect.py
@@ -1,0 +1,284 @@
+"""Describe the live values a cell's identifiers are bound to.
+
+Runs *inside the kernel* (imported by :mod:`ix_notebook_mcp.runtime`), so it sees
+the real objects in the user namespace, not a static guess. After a job finishes,
+:func:`cell_bindings` walks the cell's source for the names it mentions, resolves
+each one that exists in the namespace, and returns a compact descriptor per name.
+The dashboard renders these as inlay hints (the ``summary``) and a hover card (the
+``detail`` plus, for things with source, a ``def`` of ``file:line``).
+
+This is a snapshot at execution time: an inlay shows the value as of the run that
+produced it, which is the honest thing to show next to that run's code. It is
+side-effect-free (only ``ns.get`` and metadata reads, never an eval of cell
+expressions) and bounded (capped name count and capped reprs), so describing a
+finished job is cheap and cannot perturb the namespace or flood the store.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import reprlib
+import types
+
+# A cell can mention many names; cap how many we resolve so a huge generated cell
+# cannot blow up the per-row payload. The cell's own code bounds the realistic
+# count well under this.
+_MAX_NAMES = 64
+
+# Bounded repr for previews: never walk a giant container or stringify megabytes.
+_repr = reprlib.Repr()
+_repr.maxstring = 120
+_repr.maxother = 120
+_repr.maxlist = 8
+_repr.maxtuple = 8
+_repr.maxset = 8
+_repr.maxdict = 8
+_repr.maxlevel = 2
+
+
+def cell_bindings(code: str, ns: dict, *, max_names: int = _MAX_NAMES) -> dict[str, dict]:
+    """Map each name the cell mentions that is live in ``ns`` to its descriptor.
+
+    Keyed by name (not source position): the dashboard anchors every occurrence
+    of a name and looks it up here, so one descriptor serves all uses. Returns an
+    empty dict for code that does not parse."""
+    try:
+        names = _mentioned_names(code)
+    except SyntaxError:
+        return {}
+    out: dict[str, dict] = {}
+    for name in sorted(names):
+        if name not in ns:
+            continue
+        try:
+            out[name] = describe(ns[name])
+        except Exception:
+            # A value whose own introspection raises (an exotic __getattr__, a
+            # property with side effects) simply contributes no hint.
+            continue
+        if len(out) >= max_names:
+            break
+    return out
+
+
+def _mentioned_names(code: str) -> set[str]:
+    """The top-level identifiers a cell binds or references: every ``Name``, the
+    bound head of each import, and each def/class name. Attribute parts (the
+    ``head`` in ``df.head``) are deliberately excluded, so an inlay attaches to
+    the variable, not its methods."""
+    tree = ast.parse(code)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.alias):
+            # `import a.b as c` binds `c`; `import a.b` binds `a`.
+            names.add(node.asname or node.name.split(".", 1)[0])
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+    return names
+
+
+def describe(value) -> dict:
+    """A compact descriptor for one live value.
+
+    Shape: ``{kind, type, summary, detail}`` plus an optional ``def`` of
+    ``"file:line"`` when the value has locatable source (a function, class, or
+    module). ``summary`` is the short inlay text; ``detail`` is the hover body."""
+    type_name = type(value).__name__
+
+    if value is None or isinstance(value, bool):
+        return {"kind": "scalar", "type": type_name, "summary": repr(value), "detail": repr(value)}
+
+    if isinstance(value, int):
+        text = repr(value)
+        summary = text if len(text) <= 24 else f"int ({len(text)} digits)"
+        return {"kind": "scalar", "type": type_name, "summary": summary, "detail": text}
+
+    if isinstance(value, float):
+        return {"kind": "scalar", "type": type_name, "summary": repr(value), "detail": repr(value)}
+
+    if isinstance(value, (str, bytes)):
+        return _describe_text(value, type_name)
+
+    if isinstance(value, types.ModuleType):
+        return _describe_module(value, type_name)
+
+    if callable(value) and isinstance(
+        value, (types.FunctionType, types.MethodType, types.BuiltinFunctionType, type)
+    ):
+        return _describe_callable(value, type_name)
+
+    if _looks_like_polars_df(value):
+        return _describe_polars_df(value, type_name)
+
+    if _looks_like_polars_lazy(value):
+        return _describe_polars_lazy(value, type_name)
+
+    if _looks_like_ndarray(value):
+        return _describe_ndarray(value, type_name)
+
+    if isinstance(value, dict):
+        keys = ", ".join(_repr.repr(k) for k in list(value)[:6])
+        more = ", …" if len(value) > 6 else ""
+        return {
+            "kind": "mapping",
+            "type": type_name,
+            "summary": f"{type_name}[{len(value)}]",
+            "detail": f"{len(value)} keys: {keys}{more}" if value else "empty",
+        }
+
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return {
+            "kind": "sequence",
+            "type": type_name,
+            "summary": f"{type_name}[{len(value)}]",
+            "detail": _repr.repr(value),
+        }
+
+    return {"kind": "object", "type": type_name, "summary": type_name, "detail": _repr.repr(value)}
+
+
+def _describe_text(value, type_name: str) -> dict:
+    n = len(value)
+    preview = _repr.repr(value)
+    return {"kind": "text", "type": type_name, "summary": f"{preview} · {n}", "detail": preview}
+
+
+def _describe_module(value, type_name: str) -> dict:
+    name = getattr(value, "__name__", "?")
+    out = {"kind": "module", "type": type_name, "summary": f"module {name}", "detail": _doc_head(value)}
+    location = _source_location(value)
+    if location is not None:
+        out["def"] = location
+    return out
+
+
+def _describe_callable(value, type_name: str) -> dict:
+    name = getattr(value, "__name__", type_name)
+    is_class = isinstance(value, type)
+    try:
+        signature = str(inspect.signature(value))
+    except (TypeError, ValueError):
+        signature = "(…)"
+    marker = "class" if is_class else "ƒ"
+    summary = f"{marker} {name}{signature}"
+    if len(summary) > 60:
+        summary = summary[:59] + "…"
+    detail_parts = [f"{name}{signature}"]
+    doc = _doc_head(value)
+    if doc:
+        detail_parts.append(doc)
+    out = {
+        "kind": "class" if is_class else "callable",
+        "type": type_name,
+        "summary": summary,
+        "detail": "\n".join(detail_parts),
+    }
+    location = _source_location(value)
+    if location is not None:
+        out["def"] = location
+    return out
+
+
+def _describe_polars_df(value, type_name: str) -> dict:
+    rows, cols = value.height, value.width
+    schema = "\n".join(f"  {name}: {dtype}" for name, dtype in zip(value.columns, value.dtypes))
+    return {
+        "kind": "dataframe",
+        "type": type_name,
+        "summary": f"DataFrame {_compact_int(rows)}×{cols}",
+        "detail": f"shape ({rows:,}, {cols})\n{schema}",
+    }
+
+
+def _describe_polars_lazy(value, type_name: str) -> dict:
+    detail = "LazyFrame (not yet collected)"
+    try:
+        schema = value.collect_schema()
+        lines = "\n".join(f"  {name}: {dtype}" for name, dtype in schema.items())
+        detail = f"LazyFrame · {len(schema)} cols\n{lines}"
+    except Exception:
+        # An optimizer that cannot resolve the schema cheaply: name only.
+        pass
+    return {"kind": "lazyframe", "type": type_name, "summary": "LazyFrame", "detail": detail}
+
+
+def _describe_ndarray(value, type_name: str) -> dict:
+    shape = "×".join(str(d) for d in value.shape) or "scalar"
+    dtype = str(value.dtype)
+    return {
+        "kind": "ndarray",
+        "type": type_name,
+        "summary": f"ndarray {dtype} ({shape})",
+        "detail": f"dtype {dtype}, shape {tuple(value.shape)}, {value.size:,} elems",
+    }
+
+
+def _doc_head(value) -> str:
+    """The first line of an object's docstring, if any."""
+    doc = inspect.getdoc(value)
+    if not doc:
+        return ""
+    first = doc.strip().splitlines()[0]
+    return first if len(first) <= 120 else first[:119] + "…"
+
+
+def _source_location(value) -> str | None:
+    """``"file:line"`` for a value with on-disk source, else None.
+
+    This is the go-to-definition payload: where the function, class, or module is
+    actually defined. Returns None for C extensions, dynamically built objects,
+    and anything ``inspect`` cannot locate (the honest signal that there is no
+    place to jump to)."""
+    try:
+        file = inspect.getsourcefile(value)
+    except TypeError:
+        return None
+    if not file:
+        return None
+    try:
+        _, line = inspect.getsourcelines(value)
+    except (OSError, TypeError):
+        line = 0
+    return f"{file}:{line}" if line else file
+
+
+def _compact_int(n: int) -> str:
+    """A human-scaled count for the inlay: ``1234`` -> ``1,234``, ``1200000`` ->
+    ``1.2M``. Keeps the chip narrow without losing the magnitude."""
+    if n < 10_000:
+        return f"{n:,}"
+    for limit, suffix in ((1_000_000_000, "B"), (1_000_000, "M"), (1_000, "K")):
+        if n >= limit:
+            scaled = n / limit
+            return f"{scaled:.1f}{suffix}".replace(".0", "")
+    return str(n)
+
+
+def _looks_like_polars_df(value) -> bool:
+    return (
+        type(value).__module__.split(".", 1)[0] == "polars"
+        and hasattr(value, "height")
+        and hasattr(value, "width")
+        and hasattr(value, "columns")
+        and hasattr(value, "dtypes")
+    )
+
+
+def _looks_like_polars_lazy(value) -> bool:
+    return (
+        type(value).__module__.split(".", 1)[0] == "polars"
+        and type(value).__name__ == "LazyFrame"
+        and hasattr(value, "collect")
+    )
+
+
+def _looks_like_ndarray(value) -> bool:
+    return (
+        type(value).__module__.split(".", 1)[0] == "numpy"
+        and hasattr(value, "shape")
+        and hasattr(value, "dtype")
+        and hasattr(value, "size")
+    )

--- a/packages/mcp/ix_notebook_mcp/introspect.py
+++ b/packages/mcp/ix_notebook_mcp/introspect.py
@@ -20,6 +20,7 @@ import ast
 import inspect
 import reprlib
 import types
+from itertools import islice
 
 # A cell can mention many names; cap how many we resolve so a huge generated cell
 # cannot blow up the per-row payload. The cell's own code bounds the realistic
@@ -120,7 +121,9 @@ def describe(value) -> dict:
         return _describe_ndarray(value, type_name)
 
     if isinstance(value, dict):
-        keys = ", ".join(_repr.repr(k) for k in list(value)[:6])
+        # islice, not list(value)[:6]: a huge dict must not be fully materialized
+        # here, since this runs synchronously on the kernel's shared event loop.
+        keys = ", ".join(_repr.repr(k) for k in islice(value, 6))
         more = ", …" if len(value) > 6 else ""
         return {
             "kind": "mapping",
@@ -184,7 +187,7 @@ def _describe_callable(value, type_name: str) -> dict:
 
 def _describe_polars_df(value, type_name: str) -> dict:
     rows, cols = value.height, value.width
-    schema = "\n".join(f"  {name}: {dtype}" for name, dtype in zip(value.columns, value.dtypes))
+    schema = _schema_lines(zip(value.columns, value.dtypes), cols)
     return {
         "kind": "dataframe",
         "type": type_name,
@@ -197,12 +200,27 @@ def _describe_polars_lazy(value, type_name: str) -> dict:
     detail = "LazyFrame (not yet collected)"
     try:
         schema = value.collect_schema()
-        lines = "\n".join(f"  {name}: {dtype}" for name, dtype in schema.items())
+        lines = _schema_lines(schema.items(), len(schema))
         detail = f"LazyFrame · {len(schema)} cols\n{lines}"
     except Exception:
         # An optimizer that cannot resolve the schema cheaply: name only.
         pass
     return {"kind": "lazyframe", "type": type_name, "summary": "LazyFrame", "detail": detail}
+
+
+# Cap on schema lines in a frame's hover detail. A wide frame (thousands of
+# feature columns) must not produce a multi-KB string that is stored per row and
+# polled to the browser; show the head and a count of the rest.
+_MAX_SCHEMA_COLS = 24
+
+
+def _schema_lines(pairs, total: int) -> str:
+    """Up to ``_MAX_SCHEMA_COLS`` ``name: dtype`` lines from ``pairs``, with a
+    ``… (+N more)`` tail when the frame is wider."""
+    lines = [f"  {name}: {dtype}" for name, dtype in islice(pairs, _MAX_SCHEMA_COLS)]
+    if total > _MAX_SCHEMA_COLS:
+        lines.append(f"  … (+{total - _MAX_SCHEMA_COLS} more)")
+    return "\n".join(lines)
 
 
 def _describe_ndarray(value, type_name: str) -> dict:

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -635,10 +635,25 @@ def _persist_final(job: Job) -> None:
             result=result_repr,
             error=job.error,
             outputs=_job_outputs(job),
+            bindings=_cell_bindings(job),
         )
     except Exception:
         # Best-effort logging: persisting the final status must not raise during cleanup.
         pass
+
+
+def _cell_bindings(job: Job) -> dict:
+    """The live value each of the cell's identifiers is bound to, snapshotted now
+    that the job has finished. Read off the shared user namespace (the same one
+    the code ran in), so the dashboard can show inlay hints and hover values that
+    reflect the actual objects. Best-effort: a failure here just means no hints."""
+    ns = _user_ns if _user_ns is not None else globals()
+    try:
+        from .introspect import cell_bindings
+
+        return cell_bindings(job.code, ns)
+    except Exception:
+        return {}
 
 
 def _safe_repr(value) -> str:

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -75,7 +75,14 @@ def _migrate(conn: sqlite3.Connection) -> None:
     older build is missing newer columns; add each idempotently."""
     have = {row[1] for row in conn.execute("PRAGMA table_info(executions)")}
     if "bindings" not in have:
-        conn.execute("ALTER TABLE executions ADD COLUMN bindings TEXT NOT NULL DEFAULT '{}'")
+        try:
+            conn.execute("ALTER TABLE executions ADD COLUMN bindings TEXT NOT NULL DEFAULT '{}'")
+        except sqlite3.OperationalError:
+            # The kernel and the dashboard open the store from two processes at
+            # startup, so both can see the column missing and race to add it; a
+            # duplicate-column error here means the other won, which is fine. This
+            # is a logical error, not SQLITE_BUSY, so busy_timeout does not cover it.
+            pass
 
 
 def start(conn: sqlite3.Connection, *, id: str, name: str, code: str, started_at: float) -> None:

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -32,7 +32,8 @@ CREATE TABLE IF NOT EXISTS executions (
     output      TEXT NOT NULL DEFAULT '',
     result      TEXT,
     error       TEXT,
-    outputs     TEXT NOT NULL DEFAULT '[]'
+    outputs     TEXT NOT NULL DEFAULT '[]',
+    bindings    TEXT NOT NULL DEFAULT '{}'
 );
 CREATE INDEX IF NOT EXISTS executions_started ON executions (started_at);
 
@@ -64,7 +65,17 @@ def connect(path: str | Path) -> sqlite3.Connection:
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA busy_timeout=5000")
     conn.executescript(_SCHEMA)
+    _migrate(conn)
     return conn
+
+
+def _migrate(conn: sqlite3.Connection) -> None:
+    """Add columns introduced after a store may have first been created. ``CREATE
+    TABLE IF NOT EXISTS`` never alters an existing table, so a store written by an
+    older build is missing newer columns; add each idempotently."""
+    have = {row[1] for row in conn.execute("PRAGMA table_info(executions)")}
+    if "bindings" not in have:
+        conn.execute("ALTER TABLE executions ADD COLUMN bindings TEXT NOT NULL DEFAULT '{}'")
 
 
 def start(conn: sqlite3.Connection, *, id: str, name: str, code: str, started_at: float) -> None:
@@ -98,11 +109,12 @@ def finish(
     result: str | None,
     error: str | None,
     outputs: list | None = None,
+    bindings: dict | None = None,
 ) -> None:
     conn.execute(
-        "UPDATE executions SET status = ?, ended_at = ?, output = ?, result = ?, error = ?, outputs = ? "
-        "WHERE id = ?",
-        (status, ended_at, output, result, error, json.dumps(outputs or []), id),
+        "UPDATE executions SET status = ?, ended_at = ?, output = ?, result = ?, error = ?, "
+        "outputs = ?, bindings = ? WHERE id = ?",
+        (status, ended_at, output, result, error, json.dumps(outputs or []), json.dumps(bindings or {}), id),
     )
 
 
@@ -112,7 +124,7 @@ def recent(conn: sqlite3.Connection, limit: int = 100) -> list[dict]:
     # Running jobs sort first so a long-running job is never dropped by the limit
     # (a finished-jobs backlog could otherwise push it past LIMIT); then newest.
     rows = conn.execute(
-        "SELECT id, name, code, status, started_at, ended_at, output, result, error, outputs "
+        "SELECT id, name, code, status, started_at, ended_at, output, result, error, outputs, bindings "
         "FROM executions ORDER BY (status = 'running') DESC, started_at DESC LIMIT ?",
         (limit,),
     ).fetchall()
@@ -120,6 +132,7 @@ def recent(conn: sqlite3.Connection, limit: int = 100) -> list[dict]:
     for r in rows:
         d = dict(r)
         d["outputs"] = json.loads(d.get("outputs") or "[]")
+        d["bindings"] = json.loads(d.get("bindings") or "{}")
         out.append(d)
     return out
 

--- a/packages/mcp/site/src/components/CodeView.svelte
+++ b/packages/mcp/site/src/components/CodeView.svelte
@@ -28,6 +28,8 @@
       const b = name ? bindings[name] : undefined;
       if (!name || !b) continue;
       el.classList.add('ix-bound');
+      // Make the token keyboard-reachable so the card is not mouse-only.
+      el.tabIndex = 0;
       // The inlay sits after the first mention only; later uses stay clean but
       // still light up on hover.
       if (!seen.has(name)) {
@@ -51,7 +53,9 @@
     return strip;
   });
 
-  function over(event: MouseEvent): void {
+  // Shared by mouse and keyboard: a FocusEvent and a MouseEvent both expose the
+  // target/relatedTarget this reads, so one handler serves hover and focus.
+  function enter(event: MouseEvent | FocusEvent): void {
     const target = (event.target as HTMLElement | null)?.closest<HTMLElement>('[data-ix-name]');
     const name = target?.dataset.ixName;
     const b = name ? bindings[name] : undefined;
@@ -60,14 +64,24 @@
     card = { name, b, x: rect.left, y: rect.bottom + 5 };
   }
 
-  function out(event: MouseEvent): void {
+  function leave(event: MouseEvent | FocusEvent): void {
     const to = event.relatedTarget as HTMLElement | null;
     if (to?.closest?.('[data-ix-name]')) return;
     card = null;
   }
 </script>
 
-<pre class="code ix-code" bind:this={host} onmouseover={over} onmouseout={out}>{@html html}</pre>
+<!-- svelte-ignore a11y_mouse_events_have_key_events -->
+<!-- The keyboard path uses focusin/focusout, which bubble from the {@html}-injected
+     tokens; onfocus/onblur do not bubble, so they cannot model this delegated case. -->
+<pre
+  class="code ix-code"
+  bind:this={host}
+  onmouseover={enter}
+  onmouseout={leave}
+  onfocusin={enter}
+  onfocusout={leave}
+>{@html html}</pre>
 
 {#if card}
   <div class="ix-card" style="left:{card.x}px; top:{card.y}px">

--- a/packages/mcp/site/src/components/CodeView.svelte
+++ b/packages/mcp/site/src/components/CodeView.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  import type { Binding } from '$lib/types';
+
+  // Highlighted source with live-value affordances. The server marks every
+  // identifier token with `data-ix-name` (dashboard.py); here we join those
+  // anchors with the run's `bindings` by name: a dimmed inlay chip after each
+  // name's first use, and one shared hover card with the value's type, detail,
+  // and (for things with source) its definition site. The code HTML is injected
+  // with {@html}, which Svelte does not scope or manage, so the chips and the
+  // `.ix-bound` underline are styled globally (style.css) and the hover is driven
+  // by event delegation on the host rather than per-node listeners.
+  let { html, bindings = {} }: { html: string; bindings?: Record<string, Binding> } = $props();
+
+  let host: HTMLElement;
+  let card = $state<{ name: string; b: Binding; x: number; y: number } | null>(null);
+
+  function strip(): void {
+    if (!host) return;
+    for (const chip of host.querySelectorAll('[data-ix-chip]')) chip.remove();
+    for (const el of host.querySelectorAll('.ix-bound')) el.classList.remove('ix-bound');
+  }
+
+  function decorate(): void {
+    if (!host) return;
+    const seen = new Set<string>();
+    for (const el of host.querySelectorAll<HTMLElement>('[data-ix-name]')) {
+      const name = el.dataset.ixName;
+      const b = name ? bindings[name] : undefined;
+      if (!name || !b) continue;
+      el.classList.add('ix-bound');
+      // The inlay sits after the first mention only; later uses stay clean but
+      // still light up on hover.
+      if (!seen.has(name)) {
+        seen.add(name);
+        const chip = document.createElement('span');
+        chip.className = 'ix-inlay';
+        chip.dataset.ixChip = '';
+        chip.textContent = b.summary;
+        el.after(chip);
+      }
+    }
+  }
+
+  // Re-decorate whenever the source or the values change. The injected content is
+  // already in `host` when this effect runs (effects fire after DOM updates).
+  $effect(() => {
+    void html;
+    void bindings;
+    strip();
+    decorate();
+    return strip;
+  });
+
+  function over(event: MouseEvent): void {
+    const target = (event.target as HTMLElement | null)?.closest<HTMLElement>('[data-ix-name]');
+    const name = target?.dataset.ixName;
+    const b = name ? bindings[name] : undefined;
+    if (!target || !name || !b) return;
+    const rect = target.getBoundingClientRect();
+    card = { name, b, x: rect.left, y: rect.bottom + 5 };
+  }
+
+  function out(event: MouseEvent): void {
+    const to = event.relatedTarget as HTMLElement | null;
+    if (to?.closest?.('[data-ix-name]')) return;
+    card = null;
+  }
+</script>
+
+<pre class="code ix-code" bind:this={host} onmouseover={over} onmouseout={out}>{@html html}</pre>
+
+{#if card}
+  <div class="ix-card" style="left:{card.x}px; top:{card.y}px">
+    <div class="ix-card-hd">
+      <span class="ix-card-name">{card.name}</span>
+      <span class="ix-card-type">{card.b.type}</span>
+    </div>
+    {#if card.b.detail}<pre class="ix-card-detail">{card.b.detail}</pre>{/if}
+    {#if card.b.def}<div class="ix-card-def" title={card.b.def}>{card.b.def}</div>{/if}
+  </div>
+{/if}
+
+<style>
+  /* The source block. Matches JobCard's former pre.code: a quiet inset box where
+     the colored tokens (inline-styled by the server) carry the meaning. */
+  .ix-code {
+    margin: 8px 0 0;
+    padding: 9px 11px;
+    max-height: 70vh;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-size: 12px;
+    color: var(--dim);
+    background: var(--inset);
+    border: 1px solid var(--line);
+  }
+
+  /* The hover card is Svelte-managed, so its styles can stay scoped. Flat and
+     square to match the rest of the dashboard; pinned to the viewport at the
+     token's position (it dismisses on mouse-out, so it need not track scroll). */
+  .ix-card {
+    position: fixed;
+    z-index: 40;
+    max-width: 460px;
+    padding: 7px 9px;
+    background: var(--panel-2);
+    border: 1px solid var(--line-2);
+    font-size: 11.5px;
+    pointer-events: none;
+  }
+  .ix-card-hd {
+    display: flex;
+    gap: 8px;
+    align-items: baseline;
+  }
+  .ix-card-name {
+    color: var(--text);
+    font-weight: 600;
+  }
+  .ix-card-type {
+    color: var(--muted);
+    font-size: 10.5px;
+  }
+  .ix-card-detail {
+    margin: 5px 0 0;
+    max-height: 240px;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--dim);
+    font-size: 11.5px;
+  }
+  .ix-card-def {
+    margin-top: 5px;
+    padding-top: 5px;
+    overflow: hidden;
+    color: var(--accent);
+    font-size: 10.5px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    border-top: 1px solid var(--line);
+  }
+</style>

--- a/packages/mcp/site/src/components/JobCard.svelte
+++ b/packages/mcp/site/src/components/JobCard.svelte
@@ -4,6 +4,7 @@
   import { duration, jobTitle } from '$lib/format';
   import StatusChip from './StatusChip.svelte';
   import RichOutput from './RichOutput.svelte';
+  import CodeView from './CodeView.svelte';
 
   let { job }: { job: Job } = $props();
 
@@ -24,7 +25,7 @@
   </header>
 
   {#if job.code_html}
-    <pre class="code">{@html job.code_html}</pre>
+    <CodeView html={job.code_html} bindings={job.bindings} />
   {:else if job.code}
     <pre class="code">{job.code}</pre>
   {/if}

--- a/packages/mcp/site/src/lib/types.ts
+++ b/packages/mcp/site/src/lib/types.ts
@@ -11,6 +11,18 @@ export interface RichOutput {
 
 export type JobStatus = 'running' | 'done' | 'error' | 'cancelled';
 
+// The live value one of a cell's identifiers was bound to when the run finished
+// (ix_notebook_mcp/introspect.py). `summary` is the inlay chip shown after the
+// name; `detail` and the optional `def` (a "file:line" definition site) fill the
+// hover card. Keyed by identifier name in `Job.bindings`.
+export interface Binding {
+  kind: string;
+  type: string;
+  summary: string;
+  detail: string;
+  def?: string;
+}
+
 export interface Job {
   id: string;
   name: string;
@@ -23,6 +35,7 @@ export interface Job {
   result: string | null;
   error: string | null;
   outputs: RichOutput[];
+  bindings: Record<string, Binding>;
 }
 
 export interface Resource {

--- a/packages/mcp/site/src/style.css
+++ b/packages/mcp/site/src/style.css
@@ -107,3 +107,29 @@ body {
 .rich tr:hover td {
   background: var(--panel-2);
 }
+
+/* Live-value affordances on highlighted source. CodeView injects the code with
+   {@html} and tags identifier tokens server-side, so (like .rich above) these
+   cannot be component-scoped. A bound name carries a dotted underline to mark it
+   hoverable; an inlay chip shows the value snapshot after the name's first use. */
+.ix-bound {
+  text-decoration: underline dotted var(--faint);
+  text-underline-offset: 3px;
+  cursor: help;
+}
+.ix-bound:hover {
+  text-decoration-color: var(--dim);
+}
+.ix-inlay {
+  margin-left: 4px;
+  color: var(--faint);
+  font-size: 10.5px;
+  font-style: italic;
+  user-select: none;
+}
+.ix-inlay::before {
+  content: '‹';
+}
+.ix-inlay::after {
+  content: '›';
+}


### PR DESCRIPTION
## What

Hover any variable in an executed cell's source on the MCP dashboard and see its live value; an inlay hint shows a compact value snapshot after each name's first use. For functions, classes, and modules the hover card also shows the definition site (`file:line`), so it doubles as go-to-definition.

This is the idiomatic answer to "can we have LSP-style hover/inlay over the Python the agent writes": the kernel holds the real objects, so instead of a static analyzer we snapshot each finished job's namespace and describe the actual values.

## How

- **`introspect.py`** (new, kernel-side, pure): `cell_bindings(code, ns)` AST-walks a cell for the identifiers it mentions, resolves each that is live in the namespace, and returns a per-name descriptor. `describe(v)` yields a short inlay `summary` (`DataFrame 1.2M×8`, `int 42`, `ƒ load(path)`, `module numpy`), a richer hover `detail` (dtypes / repr preview / signature+doc), and a `def` of `file:line` for things with source. Side-effect-free (only `ns.get`) and bounded (capped names + reprs).
- **runtime**: snapshot bindings when a job finishes; persist on the store row.
- **store**: one `bindings` JSON column (+ a guarded `ALTER TABLE` migration for older stores).
- **dashboard server**: the highlighter now tags each identifier token with `data-ix-name` (still cache-keyed on the code text alone).
- **frontend**: a composable `CodeView.svelte` joins the anchors with the run's `bindings` by name: a dimmed inlay chip after the first use plus one shared flat hover card. Keyboard-accessible (tokens are focusable; the card opens on focus). `JobCard` uses it.

Snapshot semantics: an inlay shows the value as of the run that produced it, which avoids contending the kernel's exec lock and is the honest thing to show next to that run's code.

## Validation

- `nix build .#mcp .#mcp.tests.site .#mcp.tests.bindingsSmoke` all green.
- New `bindingsSmoke` check: `describe` classification (scalar/DataFrame/function-with-def/module), `cell_bindings` name resolution (attributes excluded), the highlighter emitting `data-ix-name` anchors, and a finished job persisting its bindings to the store.
- Rendered the built site under Playwright against a fixture: inlay chips, dotted-underline bound names, hover card (type + dtype detail), the `file:line` definition line for a module, and the keyboard-focus path all confirmed.

🤖 Generated with Claude Opus 4.8


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add live-value hover cards and inlay hints to MCP dashboard code cells
> - Adds a new [`CodeView.svelte`](https://github.com/indexable-inc/index/pull/792/files#diff-6c4adaa035fd6894dec61c54b23def38f42ec610785e724808de69453f4b0a6d) component that renders syntax-highlighted code with dotted underlines on bound identifiers, inlay chips showing value summaries inline, and a hover/focus card displaying type, detail, and source location.
> - Adds [`introspect.py`](https://github.com/indexable-inc/index/pull/792/files#diff-006579eb39a5fc5841047297950ecbb104d7094d82bdaec8fe1b9a4eeeda9cad) with `cell_bindings` and `describe` to extract live value descriptors from a cell's namespace, supporting scalars, strings, modules, callables, polars DataFrames/LazyFrames, and numpy arrays.
> - Persists bindings as JSON in the `executions` table via a new `bindings` column; existing databases are migrated in-place via [`store.py`](https://github.com/indexable-inc/index/pull/792/files#diff-a4763dded9f44ec2a563e568a62d900b996c6a956b6de36462468f1d2b03b976)'s new `_migrate` function.
> - Updates [`dashboard.py`](https://github.com/indexable-inc/index/pull/792/files#diff-42d31638eb95030752ef7a84f47bf14ecd13cbfe141948c40115b8cae061ce5e) to emit per-identifier `data-ix-name` spans with inline styles so the frontend can join bindings to tokens.
> - Risk: Behavioral change — `_code_html` now returns an empty string on pygments errors instead of raising.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a210079.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->