### PR TITLE
mcp: report build revision as serverInfo.version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,7 @@
 
   outputs =
     {
+      self,
       nixpkgs,
       rust-overlay,
       home-manager,
@@ -94,6 +95,12 @@
     }:
     let
       inherit (nixpkgs) lib;
+
+      # The flake's own source revision, threaded into `ix` so packages can
+      # stamp the running build (e.g. the MCP server reports it as its
+      # `serverInfo.version`). Clean tree -> the commit hash; dirty tree ->
+      # `<commit>-dirty`; neither (eval from a non-git source) -> "dev".
+      rev = self.rev or self.dirtyRev or "dev";
 
       # All path literals the flake exposes. Centralized so lib/ and
       # lib/per-system.nix have a single source of truth.
@@ -127,6 +134,7 @@
 
       ix = import ./lib {
         inherit
+          rev
           nixpkgs
           paths
           rust-overlay

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -9,6 +9,9 @@
   symphony,
   clippy-fork,
   ghostty,
+  # Flake source revision, stamped into builds that want to report it (see
+  # `sharedHelpers.rev`). Defaulted so a direct `import ./lib` still evaluates.
+  rev ? "dev",
 }:
 let
   inherit (nixpkgs) lib;
@@ -337,6 +340,7 @@ let
   */
   sharedHelpers = {
     inherit
+      rev
       agentContext
       artifacts
       buildGradleFatJar

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -455,6 +455,7 @@ let
         mkdir -p $out/bin
         makeWrapper ${lib.getExe mcpPython} $out/bin/ix-mcp \
           --add-flags "-m ix_notebook_mcp" \
+          --set IX_MCP_VERSION ${lib.escapeShellArg ix.rev} \
           --set PLAYWRIGHT_BROWSERS_PATH ${lib.escapeShellArg playwrightBrowsers} \
           --set IX_GCAL_BIN ${lib.escapeShellArg "${gcalBin}/bin/gcal"} \
           --set IX_MCP_DASHBOARD_HTML ${lib.escapeShellArg dashboardHtml} \

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -80,6 +80,13 @@ mcp = FastMCP(
     ),
 )
 
+# Report the build's source revision as the MCP `serverInfo.version` so a client
+# can see exactly which commit of the server it is talking to. The nix wrapper
+# sets `IX_MCP_VERSION` to the flake rev (`<commit>` / `<commit>-dirty` / "dev");
+# FastMCP does not take a version, so stamp the low-level server directly. Absent
+# the env var (a bare `python -m ix_notebook_mcp`) it falls back to "dev".
+mcp._mcp_server.version = os.environ.get("IX_MCP_VERSION") or "dev"
+
 Content = list[outputs.Content]
 
 


### PR DESCRIPTION
## What

The MCP `serverInfo.version` was the **mcp SDK package version** (FastMCP's default fallback), so a client could never tell which commit of `ix-mcp` it was talking to. This stamps the **build's source revision** instead.

- `flake.nix`: thread the flake `rev` (`self.rev` clean → `<commit>`, dirty → `<commit>-dirty`, non-git → `dev`) into `import ./lib`.
- `lib/default.nix`: accept `rev`, expose as `ix.rev` via `sharedHelpers`.
- `packages/mcp/default.nix`: `--set IX_MCP_VERSION ${ix.rev}` on the `ix-mcp` wrapper.
- `tools.py`: stamp `mcp._mcp_server.version` from `IX_MCP_VERSION` (FastMCP takes no version arg), falling back to `dev`.

## Doesn't this rebuild the world every commit?

No. Nix keys a build on its realized inputs, not on what's merely available in the `ix` attrset. Only the one derivation that references `ix.rev` re-hashes: the tiny `ix-mcp` makeWrapper `runCommand`. Verified with an empty commit (which bumps `rev`):

```
$ nix build .#mcp --dry-run
this derivation will be built:
  /nix/store/...-ix-mcp.drv
```

The heavy `python3-…-env` interpreter and the bundled-module derivation are cache hits.

## Verify

```
$ grep IX_MCP_VERSION result/bin/ix-mcp
export IX_MCP_VERSION='e9b7b482dbc1cb12dbc571ef8b35523de94e9eff'   # == HEAD

$ IX_MCP_VERSION=testrev python -c "from ix_notebook_mcp.tools import mcp; \
    print(mcp._mcp_server.create_initialization_options().server_version)"
testrev
```

🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report build revision as MCP `serverInfo.version`
> - The flake computes a revision string (`self.rev`, `self.dirtyRev`, or `"dev"`) and threads it through to the `ix-mcp` wrapper as the `IX_MCP_VERSION` environment variable.
> - [tools.py](https://github.com/indexable-inc/index/pull/793/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) reads `IX_MCP_VERSION` at startup and sets it as `mcp._mcp_server.version`, falling back to `"dev"` if unset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9b7b48.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->