### PR TITLE
mcp/nix: harden parser + streaming (review fixes)

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1392,6 +1392,28 @@ let
     assert empty.events.height == 0 and empty.activities.height == 0
     assert empty.events.schema["seq"] == pl.Int64
 
+    # A warning (level 1) or an info line containing "error:" is NOT the failure.
+    warn = nix.parse(
+        '@nix {"action":"msg","level":1,"msg":"warning: deprecated"}\n'
+        '@nix {"action":"msg","level":3,"msg":"note: see error: above"}'
+    )
+    assert warn.error is None, warn.error
+
+    # Malformed parent cycle must not infinite-recurse the activities/render path.
+    cyc = nix.parse(
+        '@nix {"action":"start","id":1,"parent":2,"text":"a","type":0}\n'
+        '@nix {"action":"start","id":2,"parent":1,"text":"b","type":0}'
+    )
+    assert cyc.activities.height == 2, cyc.activities
+    assert "a" in cyc.tree()
+
+    # Non-int progress fields must not crash the Int64 activities schema.
+    bad = nix.parse(
+        '@nix {"action":"start","id":1,"parent":0,"text":"x","type":101}\n'
+        '@nix {"action":"result","id":1,"type":105,"fields":["nan","oops",0,0]}'
+    )
+    assert bad.activities.row(0, named=True)["done"] == 0, bad.activities
+
     print("nix-ok", nix.__version__)
   '';
   nixSmoke =

--- a/packages/mcp/src/nix/nix/__init__.py
+++ b/packages/mcp/src/nix/nix/__init__.py
@@ -115,6 +115,13 @@ def _strip(s: object) -> str:
     return _ANSI.sub("", s if isinstance(s, str) else "" if s is None else str(s))
 
 
+def _as_int(v: object) -> int:
+    try:
+        return int(v)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+
+
 class NixLog:
     """A growing record of one ``nix`` invocation's ``internal-json`` stream.
 
@@ -179,15 +186,19 @@ class NixLog:
             rtype = o.get("type")
             fields = o.get("fields") or []
             if rtype == 105 and len(fields) >= 2:  # progress: [done, expected, ...]
-                act["done"], act["expected"] = fields[0], fields[1]
+                # Coerce defensively: the Int64 schema would crash `.activities`
+                # on a non-numeric field (nix always sends ints, but never trust).
+                act["done"], act["expected"] = _as_int(fields[0]), _as_int(fields[1])
             elif rtype == 104 and fields:  # setPhase: [phase]
                 act["phase"] = _strip(fields[0])
             elif rtype in (101, 107) and fields:  # build / post-build log line
                 act["last_log"] = _strip(fields[0])
         elif action == "msg":
             msg = _strip(o.get("msg") or o.get("raw_msg"))
-            if msg and (o.get("level", 99) <= 1 or "error:" in msg.lower()):
-                # First error wins; nix prints the root cause first.
+            # Nix Verbosity: lvlError=0, lvlWarn=1, ... Capture only true errors
+            # (level 0); a warning or an info line that merely contains "error:"
+            # is not the build's failure. First error wins (root cause prints first).
+            if msg and o.get("level") == 0:
                 self.error = self.error or msg
 
     # -- frames ---------------------------------------------------------------
@@ -244,11 +255,17 @@ class NixLog:
     def _depths(self) -> dict[int, int]:
         depth: dict[int, int] = {}
 
-        def d(i: int) -> int:
+        def d(i: int, seen: frozenset[int] = frozenset()) -> int:
             if i in depth:
                 return depth[i]
             act = self._acts.get(i)
-            depth[i] = 0 if act is None or act["parent"] == 0 else d(act["parent"]) + 1
+            parent = act["parent"] if act is not None else 0
+            # Guard a malformed parent cycle (self-parent or a→b→a) so a forward
+            # reference can't infinite-recurse the live render path.
+            if act is None or parent == 0 or parent in seen or parent == i:
+                depth[i] = 0
+            else:
+                depth[i] = d(parent, seen | {i}) + 1
             return depth[i]
 
         return {i: d(i) for i in self._order}
@@ -343,6 +360,9 @@ async def run(
     appended. With ``live`` (the default) the in-flight log shows up as a
     self-closing dashboard Resource. Run it as a background job for a long build
     and sample the returned NixLog between turns.
+
+    ``cwd`` defaults to the kernel process's working directory; pass ``cwd=`` to
+    resolve a flake ref (``.#foo``) against a specific worktree.
     """
     log = NixLog(label=label or (args[1] if len(args) > 1 else args[0] if args else "nix"))
     if live:
@@ -357,12 +377,28 @@ async def run(
         stderr=asyncio.subprocess.STDOUT,
     )
     assert proc.stdout is not None
-    async for raw in proc.stdout:
-        log.feed(raw.decode(errors="replace"))
-    log.returncode = await proc.wait()
-    log.done = True
-    if log.returncode and not log.error:
-        log.error = f"nix exited with code {log.returncode}"
+    # Read raw chunks and split on newlines ourselves: a single `buildLogLine`
+    # (a compiler/test/minified line) can exceed asyncio's default 64 KiB
+    # StreamReader limit, which would make `async for`/`readline` raise and
+    # abort mid-stream. `finally` guarantees the process is reaped and the live
+    # Resource self-closes (`alive` keys off `log.done`) on every exit path.
+    buf = b""
+    try:
+        while True:
+            chunk = await proc.stdout.read(65536)
+            if not chunk:
+                break
+            buf += chunk
+            *complete, buf = buf.split(b"\n")
+            for line in complete:
+                log.feed(line.decode(errors="replace"))
+        if buf:
+            log.feed(buf.decode(errors="replace"))
+    finally:
+        log.returncode = await proc.wait()
+        log.done = True
+        if log.returncode and not log.error:
+            log.error = f"nix exited with code {log.returncode}"
     return log
 
 


### PR DESCRIPTION
## What

Follow-up hardening for the `nix` module (#794), from an adversarial review of the merged diff.

- **C1 (blocker) — long log line crashed `run()`.** A single `buildLogLine` over asyncio's default 64 KiB `StreamReader` limit made the `async for` raise mid-stream, so `log.done`/`proc.wait()` never ran: parsed log discarded, subprocess orphaned, and the live Resource (keyed on `done`) leaked forever. Now reads raw chunks and splits on newlines (no per-line limit), in a `try/finally` that reaps the process and closes the Resource on every exit path. Verified end-to-end with a build emitting a 200 KB line: captured cleanly, `returncode=0`.
- **C2 — parent-cycle `RecursionError`.** `_depths()` now carries a visited set, so a malformed `a→b→a` parent reference can't infinite-recurse the live render path.
- **C3 — non-int progress crashed the frame.** Progress fields coerced via `_as_int`, so a non-numeric value can't blow up the `Int64` `activities` schema.
- **M1** — `msg`→`error` only on level 0 (true errors), not warnings or info lines that merely contain `"error:"`.
- **M2** — docstring note: pass `cwd=` to resolve a flake ref against a worktree.

## Validation
- `nix build .#mcp.tests.nixSmoke` — extended with warn/cycle/non-int cases. ✅
- Real build with a 200 KB single log line: no crash, full log captured, process reaped. ✅

🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden Nix log parser and streaming to fix crashes and false failures
> - Non-integer progress fields in activity results are coerced to int (defaulting to 0) instead of crashing the `Int64` schema in `NixLog.feed`
> - Only level-0 messages set `log.error`; warnings and info lines containing `'error:'` no longer mark the build as failed
> - `NixLog._depths` now tracks a `seen` set to break cyclic or self-parent relationships, assigning depth 0 instead of infinite-recursing
> - The `run` coroutine reads stdout in fixed-size chunks instead of `async for` lines, avoiding failures on lines exceeding asyncio's default line limit; a `finally` block ensures `returncode`, `done`, and `error` are always set
> - Three smoke-test assertions are added to [default.nix](https://github.com/indexable-inc/index/pull/795/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) covering these three fix scenarios
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 104a950.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->