### PR TITLE
claude-code: default to 200K Opus 4.8 context, not the 1M auto-upgrade

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -56,7 +56,7 @@ let
   # Env defaults applied through the wrapper, declared as data (single source)
   # and derived into flags below rather than hand-written into the install phase.
   # `--set-default` (not `--set`) so an explicit env or settings.json `env` value
-  # still overrides per machine. Two groups:
+  # still overrides per machine. Three groups:
   #  - Output-truncation caps raised to the CLI's built-in maxima: we run a
   #    trusted config (our own CLAUDE.md / AGENTS.md / hooks / MCP servers), so
   #    prefer full output over pruning. BASH_MAX_OUTPUT_LENGTH default 30000
@@ -64,11 +64,19 @@ let
   #    160000); MAX_MCP_OUTPUT_TOKENS default ~25000 tokens (no clamp).
   #  - Feature toggles on by default fleet-wide: agent teams, still gated behind
   #    the EXPERIMENTAL_ env var in this build.
+  #  - Context window: default every session to standard 200K Opus 4.8, not the
+  #    1M window the `opus` alias is silently auto-upgraded to on
+  #    Max/Team/Enterprise/API (1M reads past 200K are uncached and slower per
+  #    turn). Per the inline note this is the env knob, not a `model` setting.
   wrapperEnvDefaults = {
     BASH_MAX_OUTPUT_LENGTH = 150000;
     TASK_MAX_OUTPUT_LENGTH = 160000;
     MAX_MCP_OUTPUT_TOKENS = 200000;
     CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = 1;
+    # Drops [1m] variants from /model without touching model selection (a `model`
+    # settings key would, since flagSettings outranks user settings.json).
+    # Re-enable 1M per machine: `export CLAUDE_CODE_DISABLE_1M_CONTEXT=`.
+    CLAUDE_CODE_DISABLE_1M_CONTEXT = 1;
   };
   envDefaultFlags = lib.concatLists (
     lib.mapAttrsToList (name: value: [


### PR DESCRIPTION
## What

Bake `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` into the `claude-code` wrapper env defaults so every fleet session defaults to the standard **200K** Opus 4.8 context window instead of the silent 1M auto-upgrade.

## Why

On Max/Team/Enterprise/API plans the `opus` alias is auto-upgraded to a 1M context window with no configuration. Reads past the 200K mark are uncached and slower per turn for no reasoning gain on most tasks. `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` is the only documented lever that turns the upgrade off (and drops the `[1m]` variants from the `/model` picker).

It ships via `--set-default`, so it's per-machine overridable: `export CLAUDE_CODE_DISABLE_1M_CONTEXT=`. Uses the env knob rather than a `model` settings key on purpose: the wrapper's flagSettings layer outranks user `settings.json`, so pinning `model` would clobber every user's own `/model` selection on each launch. This only caps context; model selection is untouched.

## Validation

- Wrapper bakes `setenv("CLAUDE_CODE_DISABLE_1M_CONTEXT", "1", 0)` (the `0` = don't-overwrite = overridable).
- Wrapped CLI boots (`2.1.168`); banner reads "Opus 4.8".
- Live `/model` picker driven in a PTY shows **no** 1M entry; default resolves to `claude-opus-4-8` (200K):

```
1. Default (recommended)  currently Opus 4.8
2. Sonnet  · Sonnet 4.6
3. Haiku   · Haiku 4.5
❯ 4. Opus 4.8 ✔  (claude-opus-4-8)
```

AI-authored with Claude Code (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default claude-code wrapper to 200K context by disabling 1M auto-upgrade
> Sets `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` in [default.nix](https://github.com/indexable-inc/index/pull/796/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b) `wrapperEnvDefaults` so the wrapper uses the standard 200K Opus context window instead of automatically upgrading to 1M. The variable can be overridden by the user environment. Behavioral Change: any existing setup relying on the 1M context auto-upgrade will now default to 200K unless the variable is explicitly unset or overridden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0fffb49.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->