### PR TITLE
mcp dashboard: drop inlay value chips, keep hover card

### DIFF
--- a/packages/mcp/site/src/components/CodeView.svelte
+++ b/packages/mcp/site/src/components/CodeView.svelte
@@ -3,12 +3,13 @@
 
   // Highlighted source with live-value affordances. The server marks every
   // identifier token with `data-ix-name` (dashboard.py); here we join those
-  // anchors with the run's `bindings` by name: a dimmed inlay chip after each
-  // name's first use, and one shared hover card with the value's type, detail,
-  // and (for things with source) its definition site. The code HTML is injected
-  // with {@html}, which Svelte does not scope or manage, so the chips and the
-  // `.ix-bound` underline are styled globally (style.css) and the hover is driven
-  // by event delegation on the host rather than per-node listeners.
+  // anchors with the run's `bindings` by name and underline the bound ones, then
+  // surface the value on demand through one shared hover card with the value's
+  // type, detail, and (for things with source) its definition site. The code HTML
+  // is injected with {@html}, which Svelte does not scope or manage, so the
+  // `.ix-bound` underline is styled globally (style.css) and the hover is driven
+  // by event delegation on the host rather than per-node listeners. Inlay chips
+  // are intentionally not rendered; `strip` still clears any stale ones.
   let { html, bindings = {} }: { html: string; bindings?: Record<string, Binding> } = $props();
 
   let host: HTMLElement;
@@ -22,7 +23,6 @@
 
   function decorate(): void {
     if (!host) return;
-    const seen = new Set<string>();
     for (const el of host.querySelectorAll<HTMLElement>('[data-ix-name]')) {
       const name = el.dataset.ixName;
       const b = name ? bindings[name] : undefined;
@@ -30,16 +30,7 @@
       el.classList.add('ix-bound');
       // Make the token keyboard-reachable so the card is not mouse-only.
       el.tabIndex = 0;
-      // The inlay sits after the first mention only; later uses stay clean but
-      // still light up on hover.
-      if (!seen.has(name)) {
-        seen.add(name);
-        const chip = document.createElement('span');
-        chip.className = 'ix-inlay';
-        chip.dataset.ixChip = '';
-        chip.textContent = b.summary;
-        el.after(chip);
-      }
+      // No inlay chip: the value shows only on hover/focus via the card below.
     }
   }
 


### PR DESCRIPTION
Removes the dimmed inlay value chip the dashboard rendered after each bound name's first use in a cell's source. The source stays clean; the live value still appears on hover/focus through the shared card (type, detail, definition site). `strip()` keeps clearing any stale chips, so nothing leaks across re-renders.

Disabling the inlay for now per request; hover-to-reveal is unchanged.

Validated: `nix build .#mcp` (site compiles).

🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove inlay value chips from MCP dashboard `CodeView` bound identifier decoration
> The `decorate` function in [CodeView.svelte](https://github.com/indexable-inc/index/pull/797/files#diff-6c4adaa035fd6894dec61c54b23def38f42ec610785e724808de69453f4b0a6d) no longer inserts `<span class="ix-inlay">` chip elements after the first occurrence of bound identifiers. Bound tokens still receive the `ix-bound` underline class and `tabIndex=0` for keyboard accessibility; values are now shown only via the shared hover/focus card.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61a0029.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->