### PR TITLE
mcp: instruct the kernel to write readable multi-line Python

### DIFF
--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -73,6 +73,13 @@ mcp = FastMCP(
         "happened')` (a quiet confirmation for a side-effecting cell), "
         "`Result.of(df)` (render any value richly for the human, its repr to you), "
         "or `Result(user_html=..., llm_result=..., llm_images=[fig, png_bytes])`. "
+        "Write the cell as readable, idiomatic Python, not a cramped one-liner: "
+        "the dashboard shows your source verbatim, so a human reads it. Use real "
+        "statements over several lines, bind intermediate results to clearly named "
+        "variables, and break a long comprehension or chained call across lines "
+        "instead of nesting it inside a `str(...)` or a `Result(...)` call. Let the "
+        "final `Result(...)` name what it returns rather than wrap one dense "
+        "expression. "
         "Three dashboard panes show the session live: every running/finished run "
         "under executions, every live view (a terminal, a widget) under resources, "
         "and your curated highlight reel under cells \u2014 fill it with the most "
@@ -113,7 +120,10 @@ Content = list[outputs.Content]
         "`Result.of(value)` (render a DataFrame/figure/value richly for the human, its "
         "repr to you), or `Result(user_html=..., llm_result=..., llm_images=[fig])` to "
         "split the human's rich HTML view from your text+images. Curate the dashboard's "
-        "presentation pane with `cells.add(value, title=...)`."
+        "presentation pane with `cells.add(value, title=...)`. "
+        "Write readable, idiomatic Python: the dashboard shows your source verbatim, so "
+        "prefer multi-line statements with named intermediates over a one-liner that "
+        "nests a comprehension or chain inside a `str(...)`/`Result(...)` call."
     )
 )
 async def python_exec(


### PR DESCRIPTION
The `python_exec` instructions describe the kernel/jobs/`Result` contract but never ask for readable code, so cells came out as cramped one-liners. Example seen in the wild: a dict comprehension nested inside `str(...)` inside `Result.text(...)`. The dashboard renders the cell source verbatim for the human, so that reads badly.

Adds a short readability directive to both the server `instructions` (read once) and the `python_exec` tool `description` (in front of the model every call): prefer multi-line statements with named intermediates over nesting a comprehension or chain inside a `str()`/`Result()` call.

Validated: `nix build .#mcp`.

🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Instruct the MCP kernel to write readable multi-line Python
> Adds guidance to the FastMCP server instructions and the `python_exec` tool description in [tools.py](https://github.com/indexable-inc/index/pull/798/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6). The guidance tells the model to prefer multi-line statements with named intermediate variables over dense one-line expressions nested inside `str(...)` or `Result(...)`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1792b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->