### PR TITLE
claude-code: add extraSettings passthrough into the flagSettings layer

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -36,6 +36,16 @@
   # avoided. Takes PRECEDENCE over `dangerouslySkipPermissions`, since bypass
   # would void the deny rules. `null` (default) leaves the normal posture.
   restrictToTools ? null,
+  # Extra settings.json keys to ship through the read-only flagSettings layer
+  # (the `--settings` file below), deep-merged UNDER the computed defaults so the
+  # security-relevant keys this package controls (the restrictToTools / bypass
+  # `permissions`) always win on a conflict. Lets a consumer keep its whole
+  # static Claude config (hooks, statusLine, enabledPlugins, marketplaces, ...)
+  # in Nix and out of a hand-maintained ~/.claude/settings.json: flagSettings
+  # merges per-key ABOVE user settings and is a separate read-only layer, so it
+  # never occupies (or symlinks) the writable settings.json the CLI churns at
+  # runtime. `{ }` (default) ships only the computed defaults.
+  extraSettings ? { },
   # Only the flake package set injects the Nushell writer; the overlay eval
   # context does not. The updater is a maintainer-facing flake output, so the
   # overlay build of `pkgs.claude-code` simply omits `passthru.updateScript`.
@@ -149,23 +159,28 @@ let
   # The lockdown is active whenever the caller pins an allow-list.
   restrictTools = restrictToTools != null;
 
-  settingsDefaults = {
-    cleanupPeriodDays = 365;
-  }
-  // lib.optionalAttrs restrictTools {
-    permissions = {
-      allow = restrictToTools;
-      # A built-in named in the allow-list is re-allowed by dropping it here.
-      deny = lib.subtractLists restrictToTools deniedBuiltinTools;
-    };
-  }
-  # restrictToTools takes precedence: bypass would skip the permission layer and
-  # void its deny rules, so the two never co-set `permissions` (a shallow //
-  # merge would otherwise clobber allow/deny with defaultMode).
-  // lib.optionalAttrs (dangerouslySkipPermissions && !restrictTools) {
-    permissions.defaultMode = "bypassPermissions";
-    skipDangerousModePermissionPrompt = true;
-  };
+  # Caller's extraSettings first, then the computed defaults recursively merged
+  # ON TOP, so the security-relevant `permissions`/bypass keys below always win a
+  # conflict while the caller's other keys (hooks, statusLine, ...) pass through.
+  settingsDefaults = lib.recursiveUpdate extraSettings (
+    {
+      cleanupPeriodDays = 365;
+    }
+    // lib.optionalAttrs restrictTools {
+      permissions = {
+        allow = restrictToTools;
+        # A built-in named in the allow-list is re-allowed by dropping it here.
+        deny = lib.subtractLists restrictToTools deniedBuiltinTools;
+      };
+    }
+    # restrictToTools takes precedence: bypass would skip the permission layer and
+    # void its deny rules, so the two never co-set `permissions` (a shallow //
+    # merge would otherwise clobber allow/deny with defaultMode).
+    // lib.optionalAttrs (dangerouslySkipPermissions && !restrictTools) {
+      permissions.defaultMode = "bypassPermissions";
+      skipDangerousModePermissionPrompt = true;
+    }
+  );
   settingsDefaultsFile =
     (formats.json { }).generate "claude-code-default-settings.json"
       settingsDefaults;


### PR DESCRIPTION
## What

Adds an `extraSettings ? {}` arg to the `claude-code` package, deep-merged into the existing `settingsDefaults` that ships through the read-only `--settings` (flagSettings) file.

## Why

Lets a consumer keep its **whole static Claude config** (hooks, statusLine, enabledPlugins, marketplaces, autoMemory, ...) in Nix and out of a hand-maintained `~/.claude/settings.json`. The flagSettings layer:
- merges per-key **above** user settings, and
- is a **separate read-only layer** that never occupies (or symlinks) the writable `~/.claude/settings.json` the CLI churns at runtime.

That sidesteps the known Claude Code symlink bugs ([#3575](https://github.com/anthropics/claude-code/issues/3575) perms/perf, [#58443](https://github.com/anthropics/claude-code/issues/58443) env block, [#55485](https://github.com/anthropics/claude-code/issues/55485) read-only EACCES) while staying fully declarative — no `install`/copy activation hack.

Deep-merged **under** the computed defaults via `lib.recursiveUpdate`, so the security-relevant `permissions`/bypass keys this package controls always win a conflict.

## Validation

- `nix build .#claude-code` → byte-identical output to before (`extraSettings` defaults to `{}`, fully backward-compatible).
- Override with `extraSettings = { theme = "dark"; statusLine = {...}; }` → both land in the rendered `--settings` file, with `permissions.defaultMode=bypassPermissions` + `skipDangerousModePermissionPrompt` preserved on top.

🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `extraSettings` passthrough parameter to claude-code package settings layer
> Adds an `extraSettings` parameter to [default.nix](https://github.com/indexable-inc/index/pull/799/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b) that lets callers inject arbitrary `settings.json` keys into the generated config. The extra settings are deep-merged as the base layer via `lib.recursiveUpdate`, so computed defaults and permission/bypass keys always win on conflict, keeping security-relevant settings under package control.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0338865.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->