### PR TITLE
fix(mcp): sh helper strips non-CSI escapes and bounds timeout kill

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1272,6 +1272,26 @@ let
         else:
             raise SystemExit("expected ShellError on a non-zero exit with check=True")
 
+        # An OSC-8 hyperlink (what gh/eza emit under FORCE_COLOR) is a non-CSI
+        # escape: the stripper must remove its \x1b bytes too, not just SGR color.
+        osc = await sh.sh(r"printf '\033]8;;https://x\033\\link\033]8;;\033\\\n'")
+        assert "\x1b" not in osc.text and "link" in osc.text, repr(osc.text)
+        assert "\x1b" not in osc.llm_result, repr(osc.llm_result)
+
+        # A timeout must terminate the command's whole group and return promptly,
+        # even when the command backgrounds a child that holds the stdout pipe
+        # (the case where a naive kill + reap hangs forever).
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        try:
+            await sh.sh("sleep 30 & echo started; wait", timeout=0.5)
+        except TimeoutError:
+            pass
+        else:
+            raise SystemExit("expected TimeoutError from a command that outlives its timeout")
+        elapsed = loop.time() - start
+        assert elapsed < 10, f"timeout did not return promptly: {elapsed:.1f}s"
+
         print("sh-ok", sh.__version__)
 
 

--- a/packages/mcp/src/sh/sh/__init__.py
+++ b/packages/mcp/src/sh/sh/__init__.py
@@ -42,6 +42,7 @@ import html as _html
 import os
 import re
 import shlex
+import signal
 
 __all__ = ["sh", "Output", "ShellError"]
 
@@ -60,7 +61,19 @@ except Exception:  # pragma: no cover - exercised only outside the kernel
     _ResultBase = object
     _HAS_RESULT = False
 
-_ANSI = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+# Strip the terminal escape families a CLI actually emits, not just CSI color.
+# With FORCE_COLOR forced on, tools like `gh`/`eza`/`ls` emit OSC-8 hyperlinks
+# and charset-reset (`ESC ( B`) around their output; matching CSI alone would
+# leak the `\x1b` bytes of those into the model's text. Order matters: the
+# string-terminated families (OSC/DCS) come before the single-final forms so an
+# introducer is never half-matched.
+_ANSI = re.compile(
+    r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"  # OSC string, BEL- or ST-terminated
+    r"|\x1b[P^_X][^\x1b]*\x1b\\"  # DCS/PM/APC/SOS string, ST-terminated
+    r"|\x1b\[[0-9;?]*[ -/]*[@-~]"  # CSI (color, cursor, mode)
+    r"|\x1b[()*+#%][@-~]"  # charset designation / selection (e.g. ESC ( B)
+    r"|\x1b[@-Z\\-_a-z=>]"  # remaining solo Fe/Fs escapes (RIS, keypad, ...)
+)
 
 # Environment that asks well-behaved CLIs to emit SGR color even though their
 # stdout is a pipe, not a TTY. PAGER=cat keeps a tool that auto-pages (git, gh)
@@ -170,13 +183,29 @@ def _ansi_to_html(raw: str) -> str:
     ``ansi2html`` converter is unavailable."""
     try:
         from ansi2html import Ansi2HTMLConverter
-
-        conv = Ansi2HTMLConverter(inline=True, scheme="osx", dark_bg=True)
-        return conv.convert(raw, full=False)
-    except Exception:
-        # No converter (or a malformed stream): show the escape-stripped text
-        # rather than raw control bytes.
+    except ImportError:
+        # The converter is not installed (module used outside the bundled
+        # interpreter): show the escape-stripped text rather than control bytes.
         return _html.escape(_strip_ansi(raw))
+    conv = Ansi2HTMLConverter(inline=True, scheme="osx", dark_bg=True)
+    return conv.convert(raw, full=False)
+
+
+def _terminate(proc: asyncio.subprocess.Process) -> None:
+    """Kill the child and the process group it leads.
+
+    ``sh`` starts each child in its own session (``start_new_session=True``), so a
+    command that backgrounds a grandchild (which would otherwise keep the merged
+    stdout pipe open and hang the reap forever) is killed as a group here.
+    """
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        # Process already gone, or no group to signal: kill the child directly.
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
 
 
 async def sh(
@@ -193,9 +222,13 @@ async def sh(
     ``cmd`` is a string (run through the shell, so pipes and globs work) or an
     argv list (executed directly, no shell parsing). stdout and stderr are merged
     in order. ``cwd`` and ``env`` extend the current directory and environment;
-    ``timeout`` (seconds) kills the child and raises :class:`TimeoutError`;
-    ``check=True`` raises :class:`ShellError` on a non-zero exit; ``color=False``
-    suppresses the forced-color environment.
+    ``timeout`` (seconds) kills the child's whole process group and raises
+    :class:`TimeoutError`; ``check=True`` raises :class:`ShellError` on a non-zero
+    exit; ``color=False`` suppresses the forced-color environment.
+
+    With no ``timeout`` a command that keeps the stdout pipe open (a daemon it
+    backgrounds, say) waits for that pipe to close. The await yields to the loop,
+    so it never blocks other jobs; pass ``timeout`` to bound such a command.
     """
     full_env = dict(os.environ)
     if color:
@@ -212,6 +245,7 @@ async def sh(
             stderr=asyncio.subprocess.STDOUT,
             cwd=cwd,
             env=full_env,
+            start_new_session=True,
         )
     else:
         shown = cmd
@@ -221,9 +255,10 @@ async def sh(
             stderr=asyncio.subprocess.STDOUT,
             cwd=cwd,
             env=full_env,
+            start_new_session=True,
         )
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     started = loop.time()
     try:
         if timeout is not None:
@@ -231,8 +266,13 @@ async def sh(
         else:
             stdout, _ = await proc.communicate()
     except asyncio.TimeoutError:
-        proc.kill()
-        await proc.communicate()
+        _terminate(proc)
+        # The group is dead, so the pipe closes and this reap returns promptly;
+        # bound it anyway so a wedged reap can never hang the job past its timeout.
+        try:
+            await asyncio.wait_for(proc.wait(), 2.0)
+        except asyncio.TimeoutError:
+            pass
         raise TimeoutError(f"command timed out after {timeout}s: {shown}") from None
 
     duration = loop.time() - started


### PR DESCRIPTION
Follow-up to #800, fixing two issues an adversarial review found in the `sh` helper.

## Fixes

**Escape leak (correctness).** The ANSI stripper matched only CSI, so non-CSI escapes survived into the model's `.text`/`.llm_result`. With `FORCE_COLOR` forced on, `gh`/`eza`/`ls` emit OSC-8 hyperlinks (`\x1b]8;;…`) and charset resets (`\x1b(B`), which carry raw `\x1b` bytes, contradicting the module's "escape codes stripped" promise. The regex now also strips OSC/DCS/PM/APC strings, charset designations, and the remaining solo Fe/Fs escapes.

**Timeout reliability (correctness).** `proc.kill()` killed only the shell, not a backgrounded grandchild holding the merged stdout pipe, and the post-kill reap was unbounded, so `timeout=` could fail to terminate. Each child now starts in its own session (`start_new_session=True`) and a timeout kills the whole process group with a bounded reap, so a command like `sleep 30 & ...` still returns promptly. (The reviewer's "freezes the whole kernel" framing was off: the call is an `await`, which yields to the loop and only hangs its own job; the real bug was the unreliable timeout, now fixed.)

## Nits also addressed

- `asyncio.get_running_loop()` instead of the deprecated `get_event_loop()`.
- `_terminate` guards against `ProcessLookupError`/`PermissionError`.
- `_ansi_to_html` fallback narrowed to `ImportError` so a real converter bug surfaces instead of silently degrading to plain text.

## Validated

`nix build .#mcp.tests.shSmoke` passes. The smoke now exercises both fixes: an OSC-8 input asserted `\x1b`-free in the model view, and a backgrounding command with `timeout=0.5` asserted to raise `TimeoutError` and return promptly. `nixfmt --check` clean.

🤖 Generated with Claude Code (Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `sh` helper to strip non-CSI escapes and kill process groups on timeout
> - Replaces the CSI-only `_ANSI` regex in [sh/__init__.py](https://github.com/indexable-inc/index/pull/801/files#diff-f9700c17685e82e375a4176ad39ea4dfb7728f90008c6fe9c7678e7de72dd59d) with a composite pattern covering OSC, DCS/PM/APC/SOS, charset, and other ESC sequences, preventing raw ESC bytes from leaking into processed output.
> - Adds a `_terminate` helper that sends `SIGKILL` to the entire process group via `killpg`, falling back to `proc.kill()`, so backgrounded children that hold stdout open are also killed on timeout.
> - Spawns subprocesses with `start_new_session=True` and, on `asyncio.TimeoutError`, calls `_terminate` then awaits `proc.wait()` bounded to 2 seconds before raising `TimeoutError`.
> - Fixes `_ansi_to_html` to only catch `ImportError` on the ansi2html import, letting conversion errors propagate instead of silently falling back.
> - Behavioral Change: timeout now kills the full process group rather than just the direct child, and conversion exceptions from ansi2html are no longer swallowed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d99b363.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->