### PR TITLE
feat(mcp): draggable resizable dashboard panes

### DIFF
--- a/packages/mcp/site/src/App.svelte
+++ b/packages/mcp/site/src/App.svelte
@@ -9,6 +9,85 @@
   const ordered = $derived([...feed.jobs].sort((a, b) => a.started_at - b.started_at));
   const running = $derived(feed.jobs.filter((j) => j.status === 'running').length);
 
+  // The three panes are grid tracks sized in `fr`, so they always fill the row.
+  // A drag on a gutter moves weight between the two panes it sits between; the
+  // sizes persist so a refresh keeps the layout the user chose.
+  const GUTTER = 6; // px width of a drag handle
+  const MIN_PX = 220; // a pane never shrinks below this
+  const STORE_KEY = 'ix-mcp-pane-cols';
+  const DEFAULT_COLS = [1.4, 1, 0.85];
+
+  function loadCols(): number[] {
+    try {
+      const raw = localStorage.getItem(STORE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        const valid =
+          Array.isArray(parsed) &&
+          parsed.length === 3 &&
+          parsed.every((n) => typeof n === 'number' && n > 0 && Number.isFinite(n));
+        if (valid) return parsed;
+      }
+    } catch {
+      // Unreadable or blocked storage: fall back to the defaults below.
+    }
+    return [...DEFAULT_COLS];
+  }
+
+  let cols = $state(loadCols());
+  let panesEl: HTMLDivElement;
+
+  const gridTemplate = $derived(
+    `${cols[0]}fr ${GUTTER}px ${cols[1]}fr ${GUTTER}px ${cols[2]}fr`,
+  );
+
+  function startDrag(index: number, event: PointerEvent): void {
+    // index 0 is the gutter between panes 0 and 1; index 1 between 1 and 2.
+    if (!panesEl) return;
+    event.preventDefault();
+    const handle = event.currentTarget as HTMLElement;
+    handle.setPointerCapture(event.pointerId);
+
+    const available = panesEl.clientWidth - 2 * GUTTER;
+    const total = cols[0] + cols[1] + cols[2];
+    const pxPerFr = available / total;
+    const minFr = MIN_PX / pxPerFr;
+    const startX = event.clientX;
+    const startA = cols[index];
+    const startB = cols[index + 1];
+
+    function onMove(e: PointerEvent): void {
+      let deltaFr = (e.clientX - startX) / pxPerFr;
+      // Clamp so neither neighbour drops below the minimum width.
+      deltaFr = Math.max(minFr - startA, Math.min(startB - minFr, deltaFr));
+      const next = [...cols];
+      next[index] = startA + deltaFr;
+      next[index + 1] = startB - deltaFr;
+      cols = next;
+    }
+    function onUp(e: PointerEvent): void {
+      handle.releasePointerCapture(e.pointerId);
+      handle.removeEventListener('pointermove', onMove);
+      handle.removeEventListener('pointerup', onUp);
+      try {
+        localStorage.setItem(STORE_KEY, JSON.stringify(cols));
+      } catch {
+        // Storage may be blocked; the live layout still holds for this session.
+      }
+    }
+    handle.addEventListener('pointermove', onMove);
+    handle.addEventListener('pointerup', onUp);
+  }
+
+  function resetCols(): void {
+    cols = [...DEFAULT_COLS];
+    try {
+      localStorage.removeItem(STORE_KEY);
+    } catch {
+      // Nothing to clear if storage is unavailable.
+    }
+  }
+
   // Each column owns its own scroll, so the page never scrolls as a whole and a
   // refresh to one column never moves another. Stick-to-bottom on executions only
   // re-pins when the user was already near the bottom; scrolling up frees it.
@@ -49,7 +128,7 @@
   </span>
 </header>
 
-<div class="panes">
+<div class="panes" bind:this={panesEl} style="grid-template-columns: {gridTemplate}">
   <!-- The agent's curated highlight reel: the most important results, presented. -->
   <section class="pane cells-pane">
     <div class="sec">cells <span class="count">{feed.cells.length}</span></div>
@@ -64,6 +143,17 @@
     </div>
   </section>
 
+  <!-- Drag to resize the panes either side; double-click to reset. -->
+  <div
+    class="gutter"
+    role="separator"
+    aria-orientation="vertical"
+    aria-label="Resize cells and executions"
+    tabindex="-1"
+    onpointerdown={(e) => startDrag(0, e)}
+    ondblclick={resetCols}
+  ></div>
+
   <!-- Every run, oldest first, streaming live as it goes. -->
   <section class="pane exec-pane">
     <div class="sec">executions <span class="count">{feed.jobs.length}</span></div>
@@ -77,6 +167,16 @@
       {/if}
     </div>
   </section>
+
+  <div
+    class="gutter"
+    role="separator"
+    aria-orientation="vertical"
+    aria-label="Resize executions and resources"
+    tabindex="-1"
+    onpointerdown={(e) => startDrag(1, e)}
+    ondblclick={resetCols}
+  ></div>
 
   <!-- Live, self-updating views: a terminal screen, a VM framebuffer, a widget. -->
   <section class="pane res-pane">
@@ -139,13 +239,13 @@
     vertical-align: middle;
   }
 
-  /* Three columns filling the viewport; each scrolls on its own. */
+  /* Three columns filling the viewport; each scrolls on its own. The track
+     sizes come from `gridTemplate` (inline), with drag gutters between them. */
   .panes {
     flex: 1 1 auto;
     min-height: 0;
-    display: flex;
-    gap: 1px;
-    background: var(--line);
+    display: grid;
+    background: var(--bg);
   }
   .pane {
     display: flex;
@@ -154,14 +254,23 @@
     min-height: 0;
     background: var(--bg);
   }
-  .cells-pane {
-    flex: 1.4 1 0;
+
+  /* A thin separator that drags horizontally. The ::after widens the pointer
+     target past the 6px track without changing the layout. */
+  .gutter {
+    background: var(--line);
+    cursor: col-resize;
+    position: relative;
+    touch-action: none;
   }
-  .exec-pane {
-    flex: 1 1 0;
+  .gutter::after {
+    content: '';
+    position: absolute;
+    inset: 0 -4px;
   }
-  .res-pane {
-    flex: 0 0 clamp(320px, 26%, 460px);
+  .gutter:hover,
+  .gutter:active {
+    background: var(--active);
   }
   .pane-body {
     flex: 1 1 auto;
@@ -197,14 +306,19 @@
   }
 
   /* Stack the columns on a narrow screen; the page scrolls and each pane sizes
-     to its content rather than competing for one screen's height. */
+     to its content rather than competing for one screen's height. The grid and
+     its drag gutters give way to a simple vertical flow. */
   @media (max-width: 1000px) {
     .panes {
+      display: flex;
       flex-direction: column;
       overflow: auto;
     }
     .pane {
       flex: none;
+    }
+    .gutter {
+      display: none;
     }
     .pane-body {
       overflow: visible;


### PR DESCRIPTION
## What

The MCP dashboard's three panes (cells / executions / resources) are now resizable: drag the gutter between any two panes to move width between them, and double-click a gutter to reset.

## Why

The panes were fixed proportions (`1.4fr` / `1fr` / a clamped `320–460px`). Depending on what you're watching you want a wider executions column, or more room for a resource (a live terminal/VM framebuffer), or to shrink cells. There was no way to adjust it.

## How

`.panes` becomes a CSS grid whose track sizes are reactive `fr` values, with two 6px drag gutters between the panes. A gutter drag (pointer-capture, so it tracks outside the handle) converts pixel movement to `fr` and shifts weight between its two neighbours only, clamped so no pane drops below 220px. The grid `fr` model means the panes always fill the row. The chosen sizes persist in `localStorage` and restore on load; double-click clears them back to the defaults. The narrow-screen (`<1000px`) layout still stacks vertically with the gutters hidden.

## Validated

- `nix build .#mcp.tests.site` passes (vite + svelte compile clean).
- Playwright against the built `index.html`: dragging gutter 0 left 150px moved the cells track −150px and the executions track +150px with the resources track unchanged; the layout persisted identically across a reload via `localStorage`.

🤖 Generated with Claude Code (Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add draggable, resizable panes to the MCP dashboard
> - Replaces the flex-based `.panes` layout in [App.svelte](https://github.com/indexable-inc/index/pull/802/files#diff-240d9cd1cc9a37ac80415eb1f218541e5d440fddfbe53ac6ced472263f7fd939) with a CSS grid that has two draggable gutter elements between the three panes.
> - Dragging a gutter resizes the two adjacent panes in real time while enforcing a minimum pixel width per pane; releasing saves widths to `localStorage`.
> - Column widths are restored from `localStorage` on load, with validation and fallback to defaults on invalid data.
> - Double-clicking a gutter resets all pane widths to defaults and clears the stored value.
> - On screens ≤1000px, gutters are hidden and panes stack vertically in a flex column layout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a1a10e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->