### PR TITLE
refactor(nix-web-monitor): stream live feed over WebSocket, drop WebTransport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -601,6 +601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -619,8 +620,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -686,15 +689,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-vec"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,15 +735,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -1197,12 +1182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,15 +1392,6 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -1678,19 +1648,8 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.0",
- "const-oid",
- "crypto-common 0.2.2",
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1848,7 +1807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2266,7 +2225,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "snafu 0.9.1",
  "tempfile",
  "tokio",
@@ -2528,12 +2487,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
-name = "httlib-huffman"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9fcbcc408c5526c3ab80d534e5c86e7967c1fb7aa0a8c76abd1edc27deb877"
-
-[[package]]
 name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,15 +2542,6 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "hyper"
@@ -2875,7 +2819,7 @@ dependencies = [
  "nix 0.30.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "snafu 0.9.1",
  "tempfile",
 ]
@@ -3019,7 +2963,7 @@ dependencies = [
  "rustls-native-certs",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "url",
  "webpki-roots",
  "x509-parser",
@@ -3581,7 +3525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3887,7 +3831,6 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
- "wtransport",
 ]
 
 [[package]]
@@ -3928,7 +3871,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4329,16 +4272,10 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "tar",
  "tempfile",
 ]
-
-[[package]]
-name = "octets"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8311fa8ab7a57759b4ff1f851a3048d9ef0effaa0130726426b742d26d8a88e7"
 
 [[package]]
 name = "ogg"
@@ -4490,16 +4427,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64",
- "serde_core",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4545,7 +4472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -5026,19 +4953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rcgen"
-version = "0.14.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "time",
- "x509-parser",
- "yasna",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5330,7 +5244,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5527,7 +5441,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "snafu 0.9.1",
  "source-meta",
  "tempfile",
@@ -5705,6 +5619,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5712,18 +5637,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -5817,7 +5731,7 @@ dependencies = [
  "object_store",
  "parquet",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "snafu 0.9.1",
  "source-meta",
  "tokio",
@@ -5924,7 +5838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6008,7 +5922,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "snafu 0.9.1",
 ]
 
@@ -6374,7 +6288,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6568,6 +6482,18 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -7127,6 +7053,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7536,7 +7478,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8091,42 +8033,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "wtransport"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4aacf790813ee1956751491800537f4e04af7557b7b370501ccbfbc85963e4"
-dependencies = [
- "bytes",
- "pem",
- "quinn",
- "rcgen",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "sha2 0.11.0",
- "socket2",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "tracing",
- "url",
- "wtransport-proto",
- "x509-parser",
-]
-
-[[package]]
-name = "wtransport-proto"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5867c629e4252f7439d82315923daaf27f4fa442410d51b78ab93ef4c432a11"
-dependencies = [
- "httlib-huffman",
- "octets",
- "thiserror 2.0.18",
- "url",
-]
-
-[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8138,7 +8044,6 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry",
- "ring",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
@@ -8175,16 +8080,6 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "yasna"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
-dependencies = [
- "bit-vec",
- "time",
-]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,5 +261,4 @@ url = { version = "2.5.8", default-features = false }
 uuid = "1"
 vt100 = "0.16"
 webpki-roots = "1"
-wtransport = "0.7"
 x509-parser = "0.18"

--- a/packages/nix-web-monitor/server/Cargo.toml
+++ b/packages/nix-web-monitor/server/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-axum.workspace = true
+axum = { workspace = true, features = ["ws"] }
 bytes.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 nix-web-monitor-parser.workspace = true
@@ -19,7 +19,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["io-std", "io-util", "macros", "process", "rt-multi-thread", "signal", "sync"] }
 tower-http = { workspace = true, features = ["fs"] }
-wtransport.workspace = true
 
 [dev-dependencies]
 tower = { workspace = true, features = ["util"] }

--- a/packages/nix-web-monitor/server/site/src/lib/monitor-store.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/monitor-store.ts
@@ -1,4 +1,4 @@
-/// The live monitor feed runs over WebTransport (see `monitor-transport.ts`).
+/// The live monitor feed runs over a WebSocket (see `monitor-transport.ts`).
 /// This module keeps the `openMonitorEvents` entry point stable for the app
 /// shell, which is agnostic to the transport underneath.
 export { openMonitorEvents } from '$lib/monitor-transport';

--- a/packages/nix-web-monitor/server/site/src/lib/monitor-transport.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/monitor-transport.ts
@@ -1,16 +1,16 @@
-/// WebTransport client for the live delta stream.
+/// WebSocket client for the live delta stream.
 ///
-/// The server pushes a `reset` seed then incremental `Delta`s as msgpack frames
-/// (a `u32` big-endian length prefix per frame) on one unidirectional stream. We
-/// reframe, decode, validate, and fold them into a working model, projecting a
-/// fresh `MonitorSnapshot` to the caller. There is deliberately no SSE or
-/// WebSocket fallback: a browser without WebTransport reports an error.
+/// The server pushes a `reset` seed then incremental `Delta`s as msgpack
+/// payloads, one delta per binary WebSocket frame. WebSocket preserves message
+/// boundaries, so there is no length prefix to reassemble: we decode each frame,
+/// validate it, and fold it into a working model, projecting a fresh
+/// `MonitorSnapshot` to the caller. The page is served over plain HTTP on the
+/// same origin, so the socket opens `ws://` with no TLS or certificate dance.
 
 import { decode } from '@msgpack/msgpack';
 import * as v from 'valibot';
 import {
   deltaSchema,
-  EMPTY_SNAPSHOT,
   type ActivityNode,
   type BuildNode,
   type ConnectionStatus,
@@ -22,11 +22,6 @@ import {
 
 type SnapshotHandler = (snapshot: MonitorSnapshot) => void;
 type StatusHandler = (status: ConnectionStatus) => void;
-
-const transportInfoSchema = v.object({
-  port: v.number(),
-  certHash: v.array(v.number())
-});
 
 /// Mirror the server's retention caps so a long run cannot grow these without
 /// bound. The UI only renders the tail anyway; older entries fall off the head.
@@ -169,28 +164,25 @@ const GRACE_MS = 1_200;
 const BACKOFF_MIN_MS = 250;
 const BACKOFF_MAX_MS = 5_000;
 
-/// Open the WebTransport session and drive the snapshot/status callbacks until
-/// the returned disposer is called or the monitored run finishes. A dropped
-/// session reconnects with backoff; there is still no cross-protocol fallback.
+/// Open the WebSocket session and drive the snapshot/status callbacks until the
+/// returned disposer is called or the monitored run finishes. A dropped session
+/// reconnects with backoff.
 export function openMonitorEvents(onSnapshot: SnapshotHandler, onStatus: StatusHandler): () => void {
   onStatus('connecting');
-
-  if (typeof WebTransport === 'undefined') {
-    onSnapshot(EMPTY_SNAPSHOT);
-    onStatus('error');
-    return () => {};
-  }
 
   // Cancellation flips with the disposer from outside the async flow. Read
   // through `isAborted()` so the type-aware lint re-evaluates it at each
   // await-point instead of narrowing it to a constant after the first guard.
   const aborted = new AbortController();
   const isAborted = (): boolean => aborted.signal.aborted;
-  let transport: WebTransport | null = null;
+  let socket: WebSocket | null = null;
   // `live` once a session has ever come up: it picks the degraded label
   // (`reconnecting` vs the initial `error`) and is the signal that a drop is
   // transient rather than a cold start against a server that is not up yet.
   let everLive = false;
+  // Reconnect counter, reset to zero each time a socket opens so the backoff
+  // grows only across consecutive failures.
+  let attempt = 0;
   let degradeTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Hold the visible status on its pre-drop value until the link has been down
@@ -212,30 +204,16 @@ export function openMonitorEvents(onSnapshot: SnapshotHandler, onStatus: StatusH
   void loop();
 
   async function loop(): Promise<void> {
-    let attempt = 0;
     while (!isAborted()) {
       let finished = false;
       try {
-        const info = await fetchTransportInfo();
-        if (isAborted()) return;
-        transport = new WebTransport(`https://${location.hostname}:${String(info.port)}/`, {
-          serverCertificateHashes: [{ algorithm: 'sha-256', value: new Uint8Array(info.certHash) }]
-        });
-        await transport.ready;
-        if (isAborted()) return;
-        attempt = 0;
-        everLive = true;
-        clearDegrade();
-        onStatus('live');
-        finished = await consume(transport);
+        finished = await runSession();
       } catch {
         // Fall through to the reconnect/degrade handling below.
       }
       if (isAborted()) return;
-      transport?.close();
-      transport = null;
       // A clean end carrying the `finished` delta means the run is over; stop.
-      // Any other end (thrown, or stream closed mid-run) is treated as a drop.
+      // Any other close (errored or dropped mid-run) is treated as a drop.
       if (finished) {
         onStatus('closed');
         return;
@@ -246,42 +224,60 @@ export function openMonitorEvents(onSnapshot: SnapshotHandler, onStatus: StatusH
     }
   }
 
-  /// Drain one session's delta stream into snapshots. Returns `true` when the
-  /// stream ended on a `finished` delta (run complete) and `false` when it ended
-  /// otherwise, which the caller treats as a drop to reconnect through.
-  async function consume(wt: WebTransport): Promise<boolean> {
-    // The DOM lib types incoming streams loosely; narrow to the byte stream we
-    // know the server opens.
-    const streams = wt.incomingUnidirectionalStreams.getReader();
-    const result = await streams.read();
-    if (result.done) return false;
-    const stream = result.value as ReadableStream<Uint8Array>;
+  /// Run one WebSocket session, folding each binary frame into a snapshot.
+  /// Resolves `true` when the socket closed after a `finished` delta (run
+  /// complete) and `false` on any other close, which the caller reconnects
+  /// through. Resolves rather than rejects on error: a failed connect is just a
+  /// drop, and `onclose` always follows `onerror`, so the outcome settles once.
+  function runSession(): Promise<boolean> {
+    return new Promise((resolve) => {
+      const scheme = location.protocol === 'https:' ? 'wss' : 'ws';
+      const ws = new WebSocket(`${scheme}://${location.host}/ws`);
+      socket = ws;
+      ws.binaryType = 'arraybuffer';
 
-    const working = createWorking();
-    let frameDue = false;
-    // Coalesce bursts of deltas into one snapshot per frame. The terminal
-    // snapshot is delivered either by the `finished` branch's explicit flush or
-    // by the last scheduled frame, so no trailing flush is needed after the loop.
-    const flush = (): void => {
-      frameDue = false;
-      if (!isAborted()) onSnapshot(projectSnapshot(working));
-    };
-    const schedule = (): void => {
-      if (frameDue) return;
-      frameDue = true;
-      requestAnimationFrame(flush);
-    };
+      const working = createWorking();
+      let frameDue = false;
+      let sawFinished = false;
+      // Coalesce bursts of deltas into one snapshot per animation frame. The
+      // terminal snapshot is delivered either by the `finished` branch's
+      // explicit flush or by the last scheduled frame, so no trailing flush is
+      // needed once the socket closes.
+      const flush = (): void => {
+        frameDue = false;
+        if (!isAborted()) onSnapshot(projectSnapshot(working));
+      };
+      const schedule = (): void => {
+        if (frameDue) return;
+        frameDue = true;
+        requestAnimationFrame(flush);
+      };
 
-    for await (const delta of frames(stream)) {
-      if (isAborted()) break;
-      applyDelta(working, delta);
-      if (delta.type === 'finished') {
-        flush();
-        return true;
-      }
-      schedule();
-    }
-    return false;
+      ws.onopen = (): void => {
+        attempt = 0;
+        everLive = true;
+        clearDegrade();
+        if (!isAborted()) onStatus('live');
+      };
+      ws.onmessage = (event: MessageEvent): void => {
+        const delta = decodeDelta(new Uint8Array(event.data as ArrayBuffer));
+        if (delta === null) return;
+        applyDelta(working, delta);
+        if (delta.type === 'finished') {
+          sawFinished = true;
+          flush();
+          ws.close();
+          return;
+        }
+        schedule();
+      };
+      // A transport error always pairs with a `close` event; let `onclose`
+      // settle the result so it resolves exactly once.
+      ws.onerror = (): void => {};
+      ws.onclose = (): void => {
+        resolve(sawFinished);
+      };
+    });
   }
 
   /// Backoff sleep that resolves early when the disposer aborts, so teardown
@@ -300,44 +296,9 @@ export function openMonitorEvents(onSnapshot: SnapshotHandler, onStatus: StatusH
     });
   }
 
-  /// Reassemble length-prefixed msgpack frames from the raw byte stream and
-  /// yield each decoded, validated delta.
-  async function* frames(stream: ReadableStream<Uint8Array>): AsyncGenerator<Delta> {
-    const reader = stream.getReader();
-    let buffer: Uint8Array = new Uint8Array(0);
-    for (;;) {
-      const { value, done } = await reader.read();
-      if (done) return;
-      buffer = concat(buffer, value);
-
-      for (;;) {
-        if (buffer.length < 4) break;
-        const length = new DataView(buffer.buffer, buffer.byteOffset, 4).getUint32(0, false);
-        if (buffer.length < 4 + length) break;
-        const delta = decodeDelta(buffer.subarray(4, 4 + length));
-        buffer = buffer.slice(4 + length);
-        if (delta !== null) yield delta;
-      }
-    }
-  }
-
   return () => {
     aborted.abort();
     clearDegrade();
-    transport?.close();
+    socket?.close();
   };
-}
-
-async function fetchTransportInfo(): Promise<v.InferOutput<typeof transportInfoSchema>> {
-  const response = await fetch('/api/transport');
-  if (!response.ok) throw new Error(`transport handshake failed: ${String(response.status)}`);
-  return v.parse(transportInfoSchema, await response.json());
-}
-
-function concat(left: Uint8Array, right: Uint8Array): Uint8Array {
-  if (left.length === 0) return right;
-  const merged = new Uint8Array(left.length + right.length);
-  merged.set(left);
-  merged.set(right, left.length);
-  return merged;
 }

--- a/packages/nix-web-monitor/server/site/src/lib/types.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/types.ts
@@ -83,8 +83,8 @@ export const snapshotSchema = v.object({
 });
 
 /// One incremental change to the monitor state, mirroring Rust's `Delta` enum.
-/// The live WebTransport stream carries these (msgpack-framed) after an initial
-/// `reset` seed; the discriminant rides in `type`. Field names are camelCase to
+/// The live WebSocket stream carries these (one msgpack frame each) after an
+/// initial `reset` seed; the discriminant rides in `type`. Field names are camelCase to
 /// match the serde wire shape.
 export const deltaSchema = v.variant('type', [
   v.object({ type: v.literal('reset'), snapshot: snapshotSchema }),

--- a/packages/nix-web-monitor/server/src/main.rs
+++ b/packages/nix-web-monitor/server/src/main.rs
@@ -3,23 +3,21 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use axum::Json;
 use axum::Router;
 use axum::extract::State;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::response::Response;
 use axum::routing::get;
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::Bytes;
 use clap::{Parser, ValueEnum};
 use nix_web_monitor_parser::{Delta, MonitorSnapshot, MonitorState, NixEvent, ParsedLine, strip_ansi};
-use serde::Serialize;
 use tokio::io::{self, AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::process::Command;
 use tokio::sync::{RwLock, broadcast, mpsc};
 use tower_http::services::{ServeDir, ServeFile};
-use wtransport::endpoint::IncomingSession;
-use wtransport::{Endpoint, Identity, ServerConfig};
 
 mod dependencies;
 use dependencies::resolve_dependencies;
@@ -27,10 +25,6 @@ use dependencies::resolve_dependencies;
 /// Bound on the delta broadcast ring. A client that falls this far behind gets
 /// resynced with a fresh `Reset` rather than the dropped frames.
 const DELTA_CHANNEL_CAPACITY: usize = 1024;
-
-/// WebTransport keep-alive. Localhost rarely idles, but a short interval keeps
-/// the QUIC connection from being reaped during a quiet stretch of a long build.
-const KEEP_ALIVE: Duration = Duration::from_secs(3);
 
 #[derive(Parser)]
 #[command(
@@ -40,18 +34,14 @@ const KEEP_ALIVE: Duration = Duration::from_secs(3);
 #[allow(clippy::struct_field_names)] // `nix_args` is the wire-level name passed to `nix`; renaming would hurt the CLI help text.
 struct Args {
     /// Interface used by the web monitor. Defaults to all interfaces so the UI
-    /// is reachable over LAN/Tailscale without a flag; the WebTransport identity
-    /// already covers off-host names via cert-hash pinning.
+    /// is reachable over LAN/Tailscale without a flag. The live feed is a plain
+    /// WebSocket, so off-host access needs no certificate.
     #[arg(long, default_value = "0.0.0.0")]
     host: String,
 
-    /// TCP port for the static UI and JSON endpoints.
+    /// TCP port for the UI, the JSON snapshot, and the WebSocket delta feed.
     #[arg(long, default_value_t = 7532)]
     port: u16,
-
-    /// UDP port for the WebTransport (HTTP/3) live delta stream.
-    #[arg(long, default_value_t = 7533)]
-    udp_port: u16,
 
     /// Static UI directory. The Nix package wrapper fills this in.
     #[arg(long, env = "NIX_WEB_MONITOR_SITE_DIR")]
@@ -86,27 +76,12 @@ enum TerminalOutput {
     Quiet,
 }
 
-/// Shared state for the HTTP handlers. The live delta feed rides WebTransport,
-/// so the broadcast sender lives with those tasks, not here; HTTP only serves
-/// the one-shot snapshot and the transport handshake.
+/// Shared state for the HTTP handlers: the monitor for one-shot JSON snapshots
+/// and the broadcast sender each WebSocket subscribes to for the live feed.
 #[derive(Clone)]
 struct AppState {
     monitor: Arc<RwLock<MonitorState>>,
-    /// What the browser needs to dial the WebTransport endpoint.
-    transport: TransportInfo,
-}
-
-/// Connection details the page fetches over plain HTTP before opening the
-/// WebTransport session. The cert hash lets the browser pin our ephemeral
-/// self-signed certificate via `serverCertificateHashes` instead of the public
-/// PKI, which is what makes a localhost HTTP/3 server reachable without a CA.
-#[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct TransportInfo {
-    /// UDP port of the WebTransport endpoint.
-    port: u16,
-    /// SHA-256 of the server's self-signed certificate (32 bytes).
-    cert_hash: Vec<u8>,
+    deltas: broadcast::Sender<Bytes>,
 }
 
 #[tokio::main]
@@ -114,36 +89,20 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     validate_site_dir(&args.site_dir)?;
 
-    // ECDSA P-256, 14-day validity: exactly what `serverCertificateHashes`
-    // requires, so the browser can pin this cert without a CA.
-    let identity = Identity::self_signed(["localhost", "127.0.0.1", "::1"])
-        .context("generating self-signed WebTransport identity")?;
-    let cert_hash = identity.certificate_chain().as_slice()[0]
-        .hash()
-        .as_ref()
-        .to_vec();
-
     let monitor = Arc::new(RwLock::new(MonitorState::default()));
     let (deltas, _) = broadcast::channel::<Bytes>(DELTA_CHANNEL_CAPACITY);
 
     let http_addr: SocketAddr = format!("{}:{}", args.host, args.port)
         .parse()
         .with_context(|| format!("invalid HTTP address {}:{}", args.host, args.port))?;
-    let udp_addr: SocketAddr = format!("{}:{}", args.host, args.udp_port)
-        .parse()
-        .with_context(|| format!("invalid WebTransport address {}:{}", args.host, args.udp_port))?;
 
     let state = AppState {
         monitor: Arc::clone(&monitor),
-        transport: TransportInfo {
-            port: args.udp_port,
-            cert_hash,
-        },
+        deltas: deltas.clone(),
     };
     let http_server = serve(http_addr, args.site_dir, state).await?;
-    let wt_server = spawn_webtransport(udp_addr, identity, Arc::clone(&monitor), deltas.clone())?;
 
-    eprintln!("nix-web-monitor: http://{http_addr} (WebTransport on udp/{})", args.udp_port);
+    eprintln!("nix-web-monitor: http://{http_addr}");
 
     let build = tokio::spawn(run_nix_command(
         args.nix_args,
@@ -165,7 +124,6 @@ async fn main() -> Result<()> {
             .context("waiting for Ctrl-C")?;
     }
     http_server.abort();
-    wt_server.abort();
     // Propagate Nix's exit status either way; otherwise the wrapper masks
     // build failures from shells and CI.
     std::process::exit(exit_code.unwrap_or(1));
@@ -188,83 +146,42 @@ async fn serve(
     }))
 }
 
-/// Build the HTTP router: the JSON endpoints plus the static UI fallback. The
-/// live stream rides WebTransport, not HTTP, so the only API routes here are the
-/// one-shot snapshot and the transport handshake. Split from [`serve`] so it can
-/// be exercised without binding a socket.
+/// Build the HTTP router: the JSON snapshot, the WebSocket live feed, and the
+/// static UI fallback, all on one port. Split from [`serve`] so it can be
+/// exercised without binding a socket.
 fn router(site_dir: &Path, state: AppState) -> Router {
     let index = site_dir.join("index.html");
     let static_files = ServeDir::new(site_dir).fallback(ServeFile::new(index));
     Router::new()
         .route("/api/state", get(state_snapshot))
-        .route("/api/transport", get(transport_info))
+        .route("/ws", get(ws_handler))
         .fallback_service(static_files)
         .with_state(state)
 }
 
 /// One-shot snapshot of the current monitor state as JSON, for scripts and
 /// agents that want to `curl | jaq` the build tree instead of opening a
-/// WebTransport session. Same payload the live stream seeds each client with.
+/// WebSocket. Same payload the live stream seeds each client with.
 async fn state_snapshot(State(state): State<AppState>) -> Json<MonitorSnapshot> {
     Json(state.monitor.read().await.snapshot())
 }
 
-/// WebTransport handshake details the page needs before dialing the HTTP/3
-/// endpoint: the UDP port and the certificate hash to pin.
-async fn transport_info(State(state): State<AppState>) -> Json<TransportInfo> {
-    Json(state.transport)
+/// Upgrade the request to a WebSocket and stream deltas to it. The page is
+/// served over plain HTTP on this same origin, so the browser opens `ws://`
+/// with no TLS and no certificate handshake: that simplicity is the whole
+/// reason for WebSocket over WebTransport here.
+async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> Response {
+    ws.on_upgrade(move |socket| serve_socket(socket, state.monitor, state.deltas))
 }
 
-/// Bind the WebTransport endpoint and serve one delta stream per session.
-fn spawn_webtransport(
-    addr: SocketAddr,
-    identity: Identity,
+/// Push deltas to one client on its WebSocket: a `Reset` seed first, then the
+/// live feed, until the client disconnects or the broadcast closes.
+#[allow(clippy::significant_drop_tightening)] // read lock must outlive subscribe(); see below.
+async fn serve_socket(
+    mut socket: WebSocket,
     monitor: Arc<RwLock<MonitorState>>,
     deltas: broadcast::Sender<Bytes>,
-) -> Result<tokio::task::JoinHandle<()>> {
-    let config = ServerConfig::builder()
-        .with_bind_address(addr)
-        .with_identity(identity)
-        .keep_alive_interval(Some(KEEP_ALIVE))
-        .build();
-    let endpoint =
-        Endpoint::server(config).with_context(|| format!("binding WebTransport endpoint on {addr}"))?;
-
-    Ok(tokio::spawn(async move {
-        loop {
-            let incoming = endpoint.accept().await;
-            let monitor = Arc::clone(&monitor);
-            let deltas = deltas.clone();
-            tokio::spawn(async move {
-                if let Err(error) = serve_session(incoming, &monitor, &deltas).await {
-                    eprintln!("nix-web-monitor: WebTransport session ended: {error:#}");
-                }
-            });
-        }
-    }))
-}
-
-/// Accept one WebTransport session and push deltas on a unidirectional stream:
-/// a `Reset` seed first, then the live feed.
-#[allow(clippy::significant_drop_tightening)] // read lock must outlive subscribe(); see below.
-async fn serve_session(
-    incoming: IncomingSession,
-    monitor: &Arc<RwLock<MonitorState>>,
-    deltas: &broadcast::Sender<Bytes>,
-) -> Result<()> {
-    let connection = incoming
-        .await
-        .context("awaiting WebTransport session request")?
-        .accept()
-        .await
-        .context("accepting WebTransport session")?;
-    let mut stream = connection
-        .open_uni()
-        .await
-        .context("opening unidirectional stream")?
-        .await
-        .context("establishing unidirectional stream")?;
-
+) {
     // Seed and subscribe under the read lock. Broadcasters drain and send while
     // holding the write lock, so nothing can be broadcast between this snapshot
     // and the subscription: the seed reflects everything applied so far, and the
@@ -274,43 +191,63 @@ async fn serve_session(
     let (seed, mut receiver) = {
         let state = monitor.read().await;
         let receiver = deltas.subscribe();
-        let seed = frame(&Delta::Reset {
+        let seed = match encode(&Delta::Reset {
             snapshot: state.snapshot(),
-        })?;
+        }) {
+            Ok(seed) => seed,
+            Err(error) => {
+                eprintln!("nix-web-monitor: encoding WebSocket seed failed: {error:#}");
+                return;
+            }
+        };
         (seed, receiver)
     };
-    stream.write_all(&seed).await.context("writing seed frame")?;
+    if socket.send(Message::Binary(seed)).await.is_err() {
+        return;
+    }
 
     loop {
-        match receiver.recv().await {
-            Ok(payload) => stream.write_all(&payload).await.context("writing delta frame")?,
-            // A slow client outran the ring; resync from a fresh snapshot
-            // rather than leaving it stuck on stale state.
-            Err(broadcast::error::RecvError::Lagged(_)) => {
-                let resync = frame(&Delta::Reset {
-                    snapshot: monitor.read().await.snapshot(),
-                })?;
-                stream
-                    .write_all(&resync)
-                    .await
-                    .context("writing resync frame")?;
-            }
-            Err(broadcast::error::RecvError::Closed) => break,
+        tokio::select! {
+            // Detect a client close promptly even while the build is quiet, so
+            // the task drops instead of lingering until the next delta send.
+            incoming = socket.recv() => match incoming {
+                None | Some(Err(_)) | Some(Ok(Message::Close(_))) => break,
+                Some(Ok(_)) => {} // ignore any other client-sent frame
+            },
+            received = receiver.recv() => match received {
+                Ok(payload) => {
+                    if socket.send(Message::Binary(payload)).await.is_err() {
+                        break;
+                    }
+                }
+                // A slow client outran the ring; resync from a fresh snapshot
+                // rather than leaving it stuck on stale state.
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    let resync = match encode(&Delta::Reset {
+                        snapshot: monitor.read().await.snapshot(),
+                    }) {
+                        Ok(resync) => resync,
+                        Err(error) => {
+                            eprintln!("nix-web-monitor: encoding WebSocket resync failed: {error:#}");
+                            break;
+                        }
+                    };
+                    if socket.send(Message::Binary(resync)).await.is_err() {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            },
         }
     }
-    Ok(())
 }
 
-/// Encode one delta as a length-prefixed msgpack frame: a `u32` big-endian byte
-/// count followed by the payload, so the client can split the stream back into
-/// discrete deltas.
-fn frame(delta: &Delta) -> Result<Bytes> {
+/// Encode one delta as a msgpack payload. WebSocket preserves message
+/// boundaries, so each delta rides exactly one binary frame with no length
+/// prefix for the client to reassemble.
+fn encode(delta: &Delta) -> Result<Bytes> {
     let payload = rmp_serde::to_vec_named(delta).context("serializing delta to msgpack")?;
-    let len = u32::try_from(payload.len()).context("delta frame exceeds u32 length")?;
-    let mut buf = BytesMut::with_capacity(4 + payload.len());
-    buf.put_u32(len);
-    buf.put_slice(&payload);
-    Ok(buf.freeze())
+    Ok(Bytes::from(payload))
 }
 
 async fn run_nix_command(
@@ -452,8 +389,8 @@ where
     Ok(())
 }
 
-/// Drain the deltas accumulated by the latest mutation and broadcast each as a
-/// framed message. Drains and sends under the write lock so concurrent callers
+/// Drain the deltas accumulated by the latest mutation and broadcast each as an
+/// encoded message. Drains and sends under the write lock so concurrent callers
 /// cannot interleave frames out of the order the state machine produced them.
 // Hold the write lock across the sends on purpose: draining and broadcasting
 // under one lock is what keeps two concurrent callers from interleaving frames
@@ -467,7 +404,7 @@ pub(crate) async fn broadcast_deltas(
     let mut state = monitor.write().await;
     for delta in state.drain_deltas() {
         // Subscribers may all have dropped; that's fine.
-        let _ = deltas.send(frame(&delta)?);
+        let _ = deltas.send(encode(&delta)?);
     }
     Ok(())
 }
@@ -555,12 +492,10 @@ mod tests {
     use tower::ServiceExt;
 
     fn test_state() -> AppState {
+        let (deltas, _) = broadcast::channel::<Bytes>(DELTA_CHANNEL_CAPACITY);
         AppState {
             monitor: Arc::new(RwLock::new(MonitorState::default())),
-            transport: TransportInfo {
-                port: 7533,
-                cert_hash: vec![0u8; 32],
-            },
+            deltas,
         }
     }
 
@@ -592,49 +527,40 @@ mod tests {
         );
     }
 
-    /// The handshake route must expose the UDP port and the 32-byte cert hash
-    /// the browser pins; without both the page cannot open a session.
+    /// `/ws` must be a wired route that performs the WebSocket upgrade: a plain
+    /// GET without the upgrade headers is rejected, proving the handler expects
+    /// a real WebSocket handshake rather than serving the static fallback.
     #[tokio::test]
-    async fn transport_endpoint_exposes_port_and_cert_hash() {
+    async fn ws_route_requires_websocket_upgrade() {
         let response = router(Path::new("/nonexistent-site"), test_state())
             .oneshot(
                 Request::builder()
-                    .uri("/api/transport")
+                    .uri("/ws")
                     .body(Body::empty())
                     .expect("request builds"),
             )
             .await
             .expect("router responds");
 
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let bytes = axum::body::to_bytes(response.into_body(), 1 << 20)
-            .await
-            .expect("body collects");
-        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("body is JSON");
-        assert_eq!(json.get("port").and_then(serde_json::Value::as_u64), Some(7533));
         assert_eq!(
-            json.get("certHash").and_then(serde_json::Value::as_array).map(Vec::len),
-            Some(32),
-            "cert hash is the 32-byte SHA-256 the browser pins"
+            response.status(),
+            StatusCode::UPGRADE_REQUIRED,
+            "a non-upgrade GET to /ws is rejected by the WebSocket extractor"
         );
     }
 
-    /// A framed delta must carry its msgpack length prefix and decode back to an
-    /// equal value: this is the exact wire contract the browser reframes and
-    /// decodes, so a serialization change that breaks it must fail here.
+    /// An encoded delta must decode back to an equal value: this is the exact
+    /// wire contract the browser decodes per WebSocket frame, so a
+    /// serialization change that breaks it must fail here.
     #[test]
-    fn delta_frames_round_trip_through_msgpack() {
+    fn delta_encode_round_trips_through_msgpack() {
         let delta = Delta::ExpectedSet {
             name: "build".to_owned(),
             value: 12,
         };
-        let framed = frame(&delta).expect("delta frames");
+        let encoded = encode(&delta).expect("delta encodes");
 
-        let len = u32::from_be_bytes(framed[..4].try_into().expect("length prefix")) as usize;
-        assert_eq!(len, framed.len() - 4, "prefix counts the payload bytes");
-
-        let decoded: Delta = rmp_serde::from_slice(&framed[4..]).expect("payload decodes");
+        let decoded: Delta = rmp_serde::from_slice(&encoded).expect("payload decodes");
         assert_eq!(decoded, delta);
     }
 }


### PR DESCRIPTION
## What

Switch nix-web-monitor's live delta feed from WebTransport (HTTP/3 over QUIC) to a plain WebSocket on the existing HTTP port.

## Why

The whole WebTransport setup, a self-signed ECDSA cert pinned via `serverCertificateHashes`, a second UDP port, and the `wtransport`/`quinn` deps, existed for one reason: WebTransport mandates TLS even on localhost. The UI is served over plain `http://` on the same origin, so a `ws://` socket needs none of that:

- no cert generation, no `serverCertificateHashes` handshake, no `/api/transport` endpoint, no second UDP port
- works in every browser (the WebTransport + cert-hash path was effectively Chromium-only; the client even hard-errored when `WebTransport` was undefined)
- no 14-day cert-validity ceiling / per-process cert regen

The feed is a single reliable, ordered `broadcast` on one unidirectional stream, which maps 1:1 to a WebSocket. None of QUIC's multiplexing/datagrams were used, so nothing is lost. ANSI is still stripped at the parser, so the durable log stays clean and color lives in the UI.

Tradeoff: `ws://` is plaintext on the `0.0.0.0` bind. Over Tailscale that's already encrypted at the network layer; for build-log streaming on your own tailnet the WebTransport complexity wasn't worth it.

## Changes

- **server**: `axum` `ws` route (`/ws`) replaces the `wtransport` endpoint; each delta rides one binary frame (no `u32` length prefix). Removed the cert/identity/`/api/transport`/UDP-port code. `select!` on the socket so a client close is detected promptly even during a quiet build.
- **client** (`monitor-transport.ts`): `WebSocket` with `binaryType='arraybuffer'`; decode one delta per `onmessage`; same reconnect/backoff/degrade logic. Dropped the length-prefix reassembly, the transport-info fetch, and the cert pinning.
- **deps**: dropped `wtransport` (workspace + lock); `axum` gains `ws` → `tokio-tungstenite`. Net -220 lines.

## Validation

- `nix build .#nix-web-monitor` (Rust server + Svelte site build, i.e. tsc/eslint/svelte-check)
- runtime: `/ws` returns `101 Switching Protocols`; a real WebSocket client receives the `Delta::Reset` msgpack seed; `/api/state` and the UI still serve

AI-generated with Claude Opus 4.8.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace WebTransport with WebSocket for live delta feed in nix-web-monitor
> - Removes the UDP-based WebTransport endpoint and `wtransport` dependency; the live delta stream now runs over a `/ws` WebSocket route on the same HTTP port.
> - Each delta is sent as a single binary msgpack frame (no length prefix), using WebSocket message boundaries instead of the previous length-prefixed framing.
> - The server seeds each WebSocket client with a full `Reset` delta on connect, and resends a fresh `Reset` if a slow client lags behind the broadcast ring.
> - The client in [monitor-transport.ts](https://github.com/indexable-inc/index/pull/804/files#diff-3600e88edc89da306e3911677f724371bfc3126f68f93276d8bc303912c1c52a) no longer fetches `/api/transport`, pins a cert, or emits an `EMPTY_SNAPSHOT` fallback; it connects to `ws://`/`wss://` on the same origin and coalesces deltas per animation frame.
> - Behavioral Change: `--udp-port` CLI argument and `/api/transport` HTTP endpoint are removed; only `--port` remains for both HTTP and WebSocket traffic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 982a6f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->