### PR TITLE
fix(claude-code): replace recursiveUpdate with ix.deepMerge.rhs

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  ix,
   stdenv,
   fetchurl,
   makeBinaryWrapper,
@@ -162,7 +163,7 @@ let
   # Caller's extraSettings first, then the computed defaults recursively merged
   # ON TOP, so the security-relevant `permissions`/bypass keys below always win a
   # conflict while the caller's other keys (hooks, statusLine, ...) pass through.
-  settingsDefaults = lib.recursiveUpdate extraSettings (
+  settingsDefaults = ix.deepMerge.rhs extraSettings (
     {
       cleanupPeriodDays = 365;
     }


### PR DESCRIPTION
The `no-recursive-update` ast-grep rule flags `lib.recursiveUpdate` in `packages/claude-code/default.nix`. Swap it for `ix.deepMerge.rhs`, the sanctioned helper the rule points to.

Semantics are identical: the prior call merged the computed defaults on top of the caller's `extraSettings` so the security-relevant `permissions`/bypass keys win a collision. `ix.deepMerge.rhs lhs rhs` keeps rhs (defaults) winning, so behavior is unchanged.

Validated: `nix run .#lint` green (ast-grep passes), `nix eval .#packages.aarch64-darwin.claude-code.drvPath` resolves (confirms the new `ix` callPackage arg threads through).

🤖 Generated with Claude Code (Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `lib.recursiveUpdate` with `ix.deepMerge.rhs` in claude-code settings merge
> Switches the `settingsDefaults` merge in [default.nix](https://github.com/indexable-inc/index/pull/805/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b) from `lib.recursiveUpdate` to `ix.deepMerge.rhs`, with `extraSettings` as lhs and defaults as rhs. Adds `ix` as a required argument to the module's top-level parameter set. Risk: consumers of this module must now supply an `ix` argument or the import will fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61d9506.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->