### PR TITLE
fix(mcp): rescue a kernel wedged by a synchronous call, add kernel_trace

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -662,7 +662,7 @@ let
   serverTools = importTest "server" (
     "import asyncio; from ix_notebook_mcp.tools import mcp; "
     + "names = sorted(t.name for t in asyncio.run(mcp.list_tools())); "
-    + "expected = {'python_exec','search_semantic','search_grep','calendar_events','calendar_event_create','calendar_event_cancel'}; "
+    + "expected = {'python_exec','kernel_trace','search_semantic','search_grep','calendar_events','calendar_event_create','calendar_event_cancel'}; "
     + "missing = expected - set(names); "
     + "assert not missing, ('missing tools: %r' % (missing,)); "
     + "print('server-ok', len(names))"
@@ -792,6 +792,14 @@ let
         h = ns["history"]()
         assert isinstance(h, runtime.Result) and a.id in h.llm_result and b.id in h.llm_result
 
+        # A KeyboardInterrupt (what the server's wedge watchdog raises to free a
+        # blocked kernel) becomes a failed job with an actionable message, not a
+        # raw traceback that escapes the runner.
+        k = await run("raise KeyboardInterrupt", budget=1.0, name="kbi")
+        assert k.status == "error", k.status
+        assert "asyncio.to_thread" in k.error, k.error
+        assert "Traceback" not in k.error, k.error
+
     asyncio.run(main())
     print("runtime-ok")
   '';
@@ -811,6 +819,95 @@ let
         }
         grep -qx 'runtime-ok' stdout || {
           echo "ix-mcp runtime smoke did not confirm concurrent jobs:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
+
+  # Boots a real kernel and proves the two signal-driven recoveries for a cell
+  # that blocks the kernel's event loop with a synchronous call:
+  #   1. kernel_trace (SIGUSR1 -> faulthandler) returns the kernel's stack WHILE
+  #      the loop is wedged, since it never touches the execute channel.
+  #   2. the wedge watchdog (SIGUSR2 -> KeyboardInterrupt) breaks the block past
+  #      budget+grace, returns a 'wedged' summary in about budget+grace (not the
+  #      sleep's full duration), and leaves the kernel usable for the next cell.
+  # Guards the fix for the opaque "Timeout waiting for output" a forgotten
+  # blocking call used to cause. SIGINT is NOT enough here: every cell is async
+  # (await __ix_exec), and ipykernel interrupts async cells by cancelling the
+  # asyncio task, which a synchronous call never yields to.
+  wedgeTestPy = pkgs.writeText "ix-mcp-wedge-test.py" ''
+    import asyncio
+    import os
+    import tempfile
+    from pathlib import Path
+
+    from ix_notebook_mcp import cli
+    from ix_notebook_mcp.config import Config
+    from ix_notebook_mcp.kernel import Kernel
+
+    # Install the shipped IPython startup so the in-kernel runtime (__ix_exec,
+    # Result, jobs, the SIGUSR1/SIGUSR2 handlers) loads in the booted kernel,
+    # exactly as the CLI wires it.
+    os.environ["IPYTHONDIR"] = str(cli._prepare_ipython_startup(0))
+    config = Config(workdir=Path(tempfile.mkdtemp()), wedge_grace=1.0)
+
+
+    async def main():
+        kernel = Kernel(config)
+        await kernel.start()
+        try:
+            loop = asyncio.get_running_loop()
+
+            # (1) A trace must come back even while a cell blocks the loop. Start a
+            # blocking cell (budget high enough that the watchdog does not fire),
+            # let it enter the sleep, then dump the kernel stack out of band.
+            blocking = asyncio.ensure_future(
+                kernel.python_exec("import time\ntime.sleep(6)\nResult.ok('slept')", budget=30.0, name="blk")
+            )
+            await asyncio.sleep(1.0)
+            trace = await kernel.dump_trace()
+            assert "Thread" in trace and 'File "' in trace, ("not a faulthandler dump", trace)
+            _, blk = await blocking
+            assert blk is not None and blk["status"] == "done", blk
+
+            # (2) A cell that blocks past budget+grace is interrupted via SIGUSR2
+            # and the kernel is usable for the next cell.
+            started = loop.time()
+            _, summary = await kernel.python_exec(
+                "import time\ntime.sleep(30)\nResult.ok('done')", budget=0.5, name="block"
+            )
+            elapsed = loop.time() - started
+            assert summary is not None and summary["status"] == "wedged", summary
+            assert elapsed < 15, ("watchdog did not fire promptly", elapsed)
+            assert "asyncio.to_thread" in summary["error"], summary
+
+            _, after = await kernel.python_exec("Result.text('alive')", budget=10.0, name="after")
+            assert after is not None and after["status"] == "done", after
+            assert after["result"] is not None, after
+        finally:
+            await kernel.shutdown()
+
+
+    asyncio.run(main())
+    print("wedge-ok")
+  '';
+  wedgeSmoke =
+    pkgs.runCommand "ix-mcp-wedge-smoke"
+      {
+        nativeBuildInputs = [ mcpPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        ${lib.getExe mcpPython} ${wedgeTestPy} >stdout 2>stderr || {
+          echo "ix-mcp wedge smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -qx 'wedge-ok' stdout || {
+          echo "ix-mcp wedge smoke did not confirm the watchdog:" >&2
           cat stdout stderr >&2
           exit 1
         }
@@ -1567,6 +1664,7 @@ package.overrideAttrs (old: {
         serverTools
         evalSmoke
         runtimeSmoke
+        wedgeSmoke
         richSmoke
         bindingsSmoke
         bindDefaultSmoke

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -43,6 +43,11 @@ class Config:
     stdin_fd: int | None = None
     stdout_fd: int | None = None
 
+    # Seconds past a cell's own ``budget`` that the server waits for the kernel to
+    # report idle before treating it as wedged by a synchronous call, interrupting
+    # the kernel, and returning an actionable summary. See ``kernel.python_exec``.
+    wedge_grace: float = 15.0
+
     def dashboard_url(self) -> str:
         return f"http://{self.advertised_host}:{self.dashboard_port}/"
 

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -15,11 +15,46 @@ inspects ``jobs`` gets serviced promptly.
 from __future__ import annotations
 
 import asyncio
+import os
+import signal
+from pathlib import Path
 
-from .config import Config
+from .config import Config, runtime_dir
 from .outputs import job_summary, output_from_message
 
 _READY_TIMEOUT = 60.0
+
+# Env var carrying the path the kernel's faulthandler writes all-thread stacks to
+# on SIGUSR1. The server sets it before launching the kernel and reads it back in
+# ``dump_trace``; the kernel-side runtime registers the handler (``runtime``).
+TRACE_ENV = "IX_MCP_KERNEL_TRACE"
+
+
+def _wedged_summary(budget: float, grace: float, deadline: float) -> dict:
+    """A per-call summary, shaped like ``runtime._job_summary``, returned when a
+    cell blocks the kernel past ``deadline``. The server renders it like any
+    other summary, so the caller gets a clear, actionable message rather than an
+    opaque transport timeout."""
+    message = (
+        f"Cell blocked the kernel's event loop for over {deadline:.0f}s "
+        f"(budget {budget:.0f}s + {grace:.0f}s grace) with a synchronous "
+        "call, so the budget could not background it. The kernel was interrupted "
+        "and is usable again. Wrap blocking calls (subprocess.run, time.sleep, "
+        "requests, heavy CPU) in `await asyncio.to_thread(...)` or use an async "
+        "API, and run anything slow as a background job. The interrupted run is "
+        "recoverable in this kernel via history() / jobs['<id>']."
+    )
+    return {
+        "id": None,
+        "name": None,
+        "status": "wedged",
+        "running": False,
+        "output": message,
+        "output_chars": len(message),
+        "result": None,
+        "result_chars": 0,
+        "error": message,
+    }
 
 
 class Kernel:
@@ -28,15 +63,59 @@ class Kernel:
         self._km = None
         self._kc = None
         self._lock = asyncio.Lock()
+        self._trace_path: Path | None = None
+        self._pid: int | None = None
 
     async def start(self) -> None:
         from jupyter_client.manager import AsyncKernelManager
 
+        # Point the kernel's faulthandler at a private file before launch; the
+        # kernel inherits this env and registers the SIGUSR1 dump handler.
+        self._trace_path = runtime_dir() / "kernel-trace.txt"
+        os.environ[TRACE_ENV] = str(self._trace_path)
+
         self._km = AsyncKernelManager(kernel_name="python3")
         await self._km.start_kernel(cwd=str(self._config.workdir))
+        self._pid = self._kernel_pid()
         self._kc = self._km.client()
         self._kc.start_channels()
         await self._kc.wait_for_ready(timeout=_READY_TIMEOUT)
+
+    def _kernel_pid(self) -> int | None:
+        """The kernel process's pid, so a trace signal targets that process alone
+        (not the kernel's process group, whose default SIGUSR1 would terminate
+        user-launched subprocesses)."""
+        provisioner = getattr(self._km, "provisioner", None)
+        pid = getattr(provisioner, "pid", None)
+        if pid is None:
+            pid = getattr(getattr(self._km, "kernel", None), "pid", None)
+        return pid
+
+    async def dump_trace(self, timeout: float = 5.0) -> str:
+        """All-thread Python stack of the kernel, captured via faulthandler on
+        SIGUSR1. Works even when a synchronous call has wedged the event loop:
+        the C-level handler runs in signal context, so it dumps while the main
+        thread is still parked in the blocking call. Returns the newest dump."""
+        if self._km is None or self._trace_path is None or self._pid is None:
+            return "kernel is not running"
+        path = self._trace_path
+        before = path.stat().st_size if path.exists() else 0
+        try:
+            os.kill(self._pid, signal.SIGUSR1)
+        except ProcessLookupError:
+            return "kernel process is not alive"
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while loop.time() < deadline:
+            await asyncio.sleep(0.05)
+            if path.exists() and path.stat().st_size > before:
+                # A short settle so the whole multi-thread dump has flushed.
+                await asyncio.sleep(0.05)
+                return path.read_text()[before:].strip() or "(empty trace)"
+        return (
+            f"No trace was produced within {timeout:.0f}s. The kernel may not have "
+            "the faulthandler registered (older build) or cannot service signals."
+        )
 
     async def _execute(self, code: str, timeout: float) -> tuple[list[dict], dict | None]:
         async with self._lock:
@@ -62,12 +141,36 @@ class Kernel:
         """Run user ``code`` with a foreground budget; return (outputs, summary).
 
         ``code`` is passed as a repr-encoded string literal so any quoting is
-        safe. The server timeout exceeds the budget so the wrapper cell (which
-        returns right after the budget elapses) always completes in time.
+        safe. A healthy cell completes within ``budget`` (the runtime backgrounds
+        the job and returns the summary right after the budget elapses). If the
+        kernel does not report idle within ``budget + wedge_grace`` the cell is
+        blocking the kernel's single event loop with a synchronous call: interrupt
+        the kernel so it is usable again and return an actionable summary instead
+        of letting an opaque ``Timeout waiting for output`` escape to the caller.
         """
         name_arg = "None" if name is None else repr(name)
         wrapper = f"await __ix_exec({code!r}, budget={float(budget)!r}, name={name_arg})"
-        return await self._execute(wrapper, timeout=float(budget) + 30.0)
+        grace = self._config.wedge_grace
+        deadline = float(budget) + grace
+        try:
+            return await self._execute(wrapper, timeout=deadline)
+        except TimeoutError:
+            await self._interrupt()
+            return [], _wedged_summary(budget, grace, deadline)
+
+    async def _interrupt(self) -> None:
+        """Break a synchronous call wedging the kernel's event loop. ipykernel's
+        own ``interrupt_kernel`` cancels the asyncio task, which a synchronous call
+        never yields to, so it cannot break a wedged async cell. Send SIGUSR2 to
+        the kernel's runtime handler instead: it raises ``KeyboardInterrupt`` inline
+        at the blocked frame, which ``_runner`` records as a failed job so the
+        kernel returns to idle and the next call runs."""
+        if self._pid is None:
+            return
+        try:
+            os.kill(self._pid, signal.SIGUSR2)
+        except ProcessLookupError:
+            pass
 
     async def restart(self) -> None:
         if self._km is not None:

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -88,6 +88,7 @@ _RESULT_REQUIRED = (
 _store_conn = None
 _store = None
 _shell = None  # the InteractiveShell, set in install(); used to format rich results
+_trace_file = None  # faulthandler dump target, kept open for the kernel's lifetime
 
 
 class _Tee:
@@ -606,7 +607,21 @@ async def _runner(job: Job, ns: dict) -> None:
     except asyncio.CancelledError:
         job.status = "cancelled"
         raise
-    except (Exception, SystemExit, KeyboardInterrupt):
+    except KeyboardInterrupt:
+        # The only source of an interrupt here is the server's wedge watchdog
+        # (SIGUSR2, fired after config.wedge_grace): a synchronous call blocked the
+        # event loop past the budget, so the kernel was interrupted to free it.
+        # Record a crisp, actionable message instead of a bare traceback.
+        job.status = "error"
+        job.error = (
+            "Interrupted: this cell exceeded its budget while blocking the "
+            "kernel's event loop with a synchronous call (subprocess.run, "
+            "time.sleep, requests, a long CPU op), which freezes every job. Wrap "
+            "it in `await asyncio.to_thread(...)` or use an async API, and run "
+            "anything slow as a background job."
+        )
+        job._append(job.error)
+    except (Exception, SystemExit):
         # Isolate user code from the kernel: a job's SyntaxError, exception, or
         # even sys.exit()/exit() becomes a failed job (traceback captured) instead
         # of escaping the task and tearing down the shared kernel session.
@@ -1109,11 +1124,54 @@ def _register_rich_formatters(shell) -> None:
 _user_ns: dict | None = None
 
 
+def _install_signal_handlers() -> None:
+    """Wire the two operator signals the MCP server uses to inspect or rescue a
+    kernel whose event loop is blocked by a synchronous call.
+
+    SIGUSR1: faulthandler dumps every thread's Python stack to the file named by
+    ``IX_MCP_KERNEL_TRACE`` (kept by ``kernel.TRACE_ENV``). The handler is C-level
+    so it runs even while the main thread is parked in a blocking call; the
+    ``kernel_trace`` tool reads the file back.
+
+    SIGUSR2: raise ``KeyboardInterrupt`` in the main thread when a job is running.
+    Every cell runs as an async cell (``await __ix_exec(...)``), and ipykernel
+    interrupts async cells by cancelling the asyncio task, which a synchronous
+    call never yields to, so SIGINT cannot break a wedged cell. A custom handler
+    that raises does: the signal interrupts the blocking syscall and the handler
+    runs inline at the blocked frame, where ``_runner`` catches it."""
+    global _trace_file
+    import faulthandler
+    import signal
+
+    trace_path = os.environ.get("IX_MCP_KERNEL_TRACE")
+    if trace_path:
+        _trace_file = open(trace_path, "w")  # truncates any stale dump from a prior kernel
+        faulthandler.enable()
+        faulthandler.register(signal.SIGUSR1, file=_trace_file, all_threads=True, chain=False)
+
+    def _break(signum, frame):
+        # Only raise while a job is on the stack; a stray signal to an idle kernel
+        # must not blow up the event loop. The handler runs in the interrupted
+        # frame's context, so it sees the running job's ContextVar.
+        if _ix_current.get() is not None:
+            raise KeyboardInterrupt("ix: cell exceeded its budget while blocking the event loop")
+
+    try:
+        signal.signal(signal.SIGUSR2, _break)
+    except ValueError:
+        # signal.signal only works on the main thread; the in-process unit tests
+        # call install() off the main thread. Only the real kernel needs rescue.
+        pass
+
+
 def install(user_ns: dict | None = None) -> None:
     """Wire the runtime into the kernel: tee stdout/err, open the store, start the
-    flusher, and expose the registry + entrypoints in the user namespace."""
+    flusher, install the rescue/trace signal handlers, and expose the registry +
+    entrypoints in the user namespace."""
     global _store, _store_conn, _user_ns, _shell
     _user_ns = user_ns
+
+    _install_signal_handlers()
 
     if not isinstance(sys.stdout, _Tee):
         sys.stdout = _Tee(sys.stdout)

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -174,6 +174,21 @@ async def python_exec(
 
 
 @mcp.tool(
+    description=(
+        "Dump the kernel's current Python stack for every thread. Works even when "
+        "a cell has wedged the kernel by blocking its event loop with a synchronous "
+        "call (subprocess.run, time.sleep, requests, a long CPU op): the dump is "
+        "captured via a faulthandler signal, not the execute channel, so it returns "
+        "while the loop is still frozen. Use it to see WHERE a wedged or slow cell "
+        "is stuck, then fix the blocking call (wrap it in `await asyncio.to_thread"
+        "(...)` and background it)."
+    )
+)
+async def kernel_trace() -> str:
+    return await current_kernel().dump_trace()
+
+
+@mcp.tool(
     description="Read-only semantic search over the shared `index` corpus (code plus "
     "Claude/Codex/shell history across the fleet). Scope with source, user, repo, "
     "host, project. Returns matching chunks as JSON."


### PR DESCRIPTION
## Problem

A synchronous call in a `python_exec` cell (`subprocess.run`, `time.sleep`, `requests`, a heavy CPU op) freezes the kernel's single asyncio event loop. The per-cell `budget` timer lives on that same loop, so it can never fire to background the job. The server's `execute_interactive` then timed out and let a bare `TimeoutError("Timeout waiting for output")` escape as an opaque tool error with **no job handle**, and the kernel stayed wedged for every subsequent call.

This is what made `python_exec` look "frozen": once a cell blocked the loop, there was no recovery and no useful error.

## Why the obvious fix doesn't work

`interrupt_kernel()` / SIGINT does **not** break a wedged cell here. Every cell runs as an async cell (`await __ix_exec(...)`), and ipykernel interrupts async cells by **cancelling the asyncio task** — which is cooperative and only delivered at an `await`. A synchronous block never yields, so the cancel sits in a queue until the call finishes on its own. Verified empirically: a `time.sleep(20)` async cell ignores `interrupt_kernel()` and runs the full duration; the same cell broke at ~2s under a custom signal handler.

## Fix

The kernel runtime installs two operator signals (`runtime._install_signal_handlers`, called from `install()`):

- **SIGUSR2 — rescue.** A handler that raises `KeyboardInterrupt` in the main thread *only when a job is running*. The signal interrupts the blocking syscall and the handler runs inline at the frozen frame, where `_runner` catches it and records a failed job, so the kernel returns to idle. On `budget + wedge_grace` overshoot the server (`kernel._interrupt`) sends SIGUSR2 to the kernel's own pid (not the process group, so user subprocesses are untouched) and returns an actionable `"wedged"` summary instead of the opaque timeout.
- **SIGUSR1 — trace.** `faulthandler` dumps every thread's Python stack to a file. The new **`kernel_trace`** MCP tool reads it back. Because it goes through a signal, not the execute channel, it returns the kernel's stack **even while the loop is wedged** — so you can see *where* a stuck or slow cell is parked. This is the one diagnostic that genuinely can't be done from `python_exec` (a `python_exec` cell would just queue behind the blocking one).

`wedge_grace` is a `Config` field (default 15s).

## Tests

- `wedgeSmoke` (boots a real kernel): `kernel_trace` returns a faulthandler dump while a cell blocks the loop; a cell that blocks past `budget + grace` is interrupted in well under the sleep's duration and the **next cell runs**.
- `runtimeSmoke`: the `KeyboardInterrupt` path produces the actionable message, not a raw traceback.
- `serverTools`: locks in `kernel_trace`.

Validated locally: `nix build .#mcp.tests.{runtimeSmoke,wedgeSmoke,serverTools}` green.

---
🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix wedged MCP kernel by interrupting synchronous calls and add `kernel_trace` tool
> - Adds a watchdog in `Kernel.python_exec` ([kernel.py](https://github.com/indexable-inc/index/pull/807/files#diff-ced4fbbdf05b4f126e987804d73fdc2d811511b346e4985a9996ae7903683d1c)) that fires after `budget + wedge_grace` (default 15s) seconds: sends SIGUSR2 to the kernel process to raise `KeyboardInterrupt` and returns a structured error advising use of `asyncio.to_thread`.
> - Adds a `kernel_trace` MCP tool ([tools.py](https://github.com/indexable-inc/index/pull/807/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6)) that sends SIGUSR1 to the kernel and returns a faulthandler stack dump of all threads, even while the event loop is wedged.
> - On kernel start, exports a trace file path via `IX_MCP_KERNEL_TRACE` so the kernel process self-registers a SIGUSR1 faulthandler in [runtime.py](https://github.com/indexable-inc/index/pull/807/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95).
> - `KeyboardInterrupt` in `_runner` now produces a concise actionable error message instead of a raw traceback.
> - Adds a new `ix-mcp-wedge-smoke` end-to-end test that verifies wedge detection, out-of-band stack dumping, and kernel recovery.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 94238ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->