### PR TITLE
fix(lib): thread ix helpers into the package overlay

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -51,6 +51,10 @@ let
       clippy-fork
       writePythonApplication
       ;
+    # Pure cross-cutting helpers (deepMerge, writers, ...) so overlay packages
+    # that take an `ix` argument resolve it the same way flake-output packages
+    # do. Defined below in this recursive `let`; threaded lazily.
+    ix = sharedHelpers;
   };
   overlays = [ overlay ];
 

--- a/lib/overlay.nix
+++ b/lib/overlay.nix
@@ -5,6 +5,13 @@
   buildIxRustTool,
   clippy-fork,
   writePythonApplication,
+  # Curated cross-cutting helper surface (`lib`'s `sharedHelpers`), threaded in
+  # as the `ix` arg so overlay-built packages can reach pure helpers like
+  # `ix.deepMerge` exactly as flake-output packages do (lib/packages.nix binds
+  # `ix` for the `packageSetFor` path). Without this, an overlay package that
+  # takes an `ix` argument fails callPackage with a missing-arg error (e.g.
+  # packages/claude-code uses `ix.deepMerge.rhs`).
+  ix,
 }:
 final: _prev:
 let
@@ -15,6 +22,7 @@ let
       final
       buildIxRustTool
       clippy-fork
+      ix
       ;
     pkgs = final;
     inherit (entry) path;


### PR DESCRIPTION
## Problem

`pkgs.claude-code` (the overlay attr) fails to evaluate:

```
error: lib.customisation.callPackageWith: Function called without required argument "ix"
  at packages/claude-code/default.nix:3
```

`packages/claude-code` now uses `ix.deepMerge.rhs`, so it takes an `ix` argument. The flake-output path works because `lib/packages.nix` threads `ix` (`ixForPackages`) into its `callPackageWith` autoArgs. The **overlay** path (`lib/overlay.nix`) never received `ix` at all, so any overlay package taking an `ix` arg breaks. This took down every consumer of `overlays.default` (downstream home-manager configs, dev images) on `main` (3cb7687c).

## Fix

Thread the curated `sharedHelpers` surface (which includes `deepMerge`) into the overlay as `ix`, mirroring how `packageSetFor` binds it for flake-output packages.

## Validation

- ✅ `pkgs.claude-code.drvPath` via `overlays.default` on `aarch64-darwin` (was the missing-arg throw, now resolves)
- ✅ `pkgs.claude-code.override { restrictToTools = null; extraSettings = {...}; }` still resolves through the overlay
- ✅ flake output `packages.aarch64-darwin.claude-code` unchanged

🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Thread `ix` helpers into the package overlay via `makePackageSet`
> - Adds `ix = sharedHelpers` to the exported attribute set in [lib/default.nix](https://github.com/indexable-inc/index/pull/808/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188), exposing cross-cutting helpers to downstream consumers.
> - Updates [lib/overlay.nix](https://github.com/indexable-inc/index/pull/808/files#diff-65204771292c901d3da5be0a98b4162f557dc034fc1f1b58400a6d136b0525cd) to accept `ix` as a required argument and passes it through to `makePackageSet`.
> - Risk: `overlay.nix` now requires an `ix` argument at call sites; omitting it will cause an argument-missing error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea422f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->