### PR TITLE
refactor(mcp): trim tool surface to python_exec + kernel_trace

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -702,9 +702,8 @@ let
   serverTools = importTest "server" (
     "import asyncio; from ix_notebook_mcp.tools import mcp; "
     + "names = sorted(t.name for t in asyncio.run(mcp.list_tools())); "
-    + "expected = {'python_exec','kernel_trace','search_semantic','search_grep','calendar_events','calendar_event_create','calendar_event_cancel'}; "
-    + "missing = expected - set(names); "
-    + "assert not missing, ('missing tools: %r' % (missing,)); "
+    + "expected = {'python_exec','kernel_trace'}; "
+    + "assert set(names) == expected, ('tool surface drifted: %r' % (names,)); "
     + "print('server-ok', len(names))"
   );
 

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -1,19 +1,23 @@
 """The MCP tool surface.
 
-One execution tool, ``python_exec``: it runs code on the single shared kernel
-with a foreground budget and, if the work outlives the budget, leaves it running
-in the background as an entry in the in-kernel ``jobs`` dict. Job control needs
-no extra tools because ``jobs`` is just namespace state: inspect/await/cancel it
-with more ``python_exec`` (``jobs['ab12'].cancel()``). ``search_*`` and
-``calendar_*`` stay as thin convenience tools over the bundled integrations.
+Two tools only. ``python_exec`` runs code on the single shared kernel with a
+foreground budget and, if the work outlives the budget, leaves it running in the
+background as an entry in the in-kernel ``jobs`` dict. Job control needs no extra
+tools because ``jobs`` is just namespace state: inspect/await/cancel it with more
+``python_exec`` (``jobs['ab12'].cancel()``). Everything else an agent might want
+(search the index, read the calendar, shell out) is reachable the same way, by
+importing the bundled module inside a cell, so it does not earn a dedicated tool.
+
+``kernel_trace`` is the one exception: it dumps the kernel's stack out of band
+(a faulthandler signal, not the execute channel) so it works even when a cell has
+wedged the event loop, which is exactly when ``python_exec`` cannot help.
 """
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
-from typing import Annotated, Any
+from typing import Annotated
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
@@ -193,138 +197,3 @@ async def python_exec(
 )
 async def kernel_trace() -> str:
     return await current_kernel().dump_trace()
-
-
-@mcp.tool(
-    description="Read-only semantic search over the shared `index` corpus (code plus "
-    "Claude/Codex/shell history across the fleet). Scope with source, user, repo, "
-    "host, project. Returns matching chunks as JSON."
-)
-async def search_semantic(
-    query: str,
-    top_k: int = 10,
-    source: list[str] | None = None,
-    user: list[str] | None = None,
-    repo: str | None = None,
-    host: list[str] | None = None,
-    project: list[str] | None = None,
-) -> str:
-    import search as _search
-
-    hits = await _search.semantic(query, top_k=top_k, **_scope(source, user, repo, host, project))
-    return json.dumps(hits)
-
-
-@mcp.tool(description="Read-only regex grep over the same shared `index` corpus the semantic search covers.")
-async def search_grep(
-    pattern: str,
-    top_k: int = 10,
-    case_sensitive: bool = False,
-    source: list[str] | None = None,
-    user: list[str] | None = None,
-    repo: str | None = None,
-    host: list[str] | None = None,
-    project: list[str] | None = None,
-) -> str:
-    import search as _search
-
-    hits = await _search.grep(
-        pattern, top_k=top_k, case_sensitive=case_sensitive, **_scope(source, user, repo, host, project)
-    )
-    return json.dumps(hits)
-
-
-def _scope(
-    source: list[str] | None,
-    user: list[str] | None,
-    repo: str | None,
-    host: list[str] | None,
-    project: list[str] | None,
-) -> dict[str, Any]:
-    return {
-        key: value
-        for key, value in (("source", source), ("user", user), ("repo", repo), ("host", host), ("project", project))
-        if value
-    }
-
-
-@mcp.tool(
-    description="List Google Calendar events in a window (default: now through 7 days "
-    "from now). Times are RFC 3339, `YYYY-MM-DD HH:MM` (host-local), or `YYYY-MM-DD`. "
-    "Returns the events as a JSON array. Needs a one-time `gcal auth` on this host."
-)
-async def calendar_events(
-    time_min: Annotated[str | None, Field(description="Window start; default now")] = None,
-    time_max: Annotated[str | None, Field(description="Window end; default a week after the start")] = None,
-    query: Annotated[str | None, Field(description="Free-text filter over summary, description, attendees")] = None,
-    max_events: Annotated[int, Field(description="Maximum number of events")] = 20,
-    calendar: Annotated[str, Field(description="Calendar id: an email, or `primary`")] = "primary",
-) -> str:
-    args = ["list", "--json", "--calendar", calendar, "--max", str(max_events)]
-    if time_min:
-        args += ["--from", time_min]
-    if time_max:
-        args += ["--to", time_max]
-    if query:
-        args += ["--query", query]
-    return await _gcal(*args)
-
-
-@mcp.tool(
-    description="Create a Google Calendar event and return it as JSON. Timed events "
-    "take RFC 3339 or host-local `YYYY-MM-DD HH:MM` for start/end; with all_day=True "
-    "they are dates and end is the last day, inclusive. By default Google emails every "
-    "attendee (notify='all'); pass notify='none' to stay silent."
-)
-async def calendar_event_create(
-    summary: Annotated[str, Field(description="Event title")],
-    start: Annotated[str, Field(description="Start time, or a date with all_day")],
-    end: Annotated[str | None, Field(description="End time; required unless all_day")] = None,
-    all_day: Annotated[bool, Field(description="All-day event (start/end are dates)")] = False,
-    description: Annotated[str | None, Field(description="Free-text body")] = None,
-    location: Annotated[str | None, Field(description="Free-text location")] = None,
-    attendees: Annotated[list[str] | None, Field(description="Attendee emails to invite")] = None,
-    notify: Annotated[str, Field(description="Who Google emails: all | external-only | none")] = "all",
-    calendar: Annotated[str, Field(description="Calendar id: an email, or `primary`")] = "primary",
-) -> str:
-    args = [
-        "create", "--json", "--calendar", calendar,
-        "--summary", summary, "--start", start, "--notify", notify,
-    ]
-    if end:
-        args += ["--end", end]
-    if all_day:
-        args.append("--all-day")
-    if description:
-        args += ["--description", description]
-    if location:
-        args += ["--location", location]
-    for attendee in attendees or []:
-        args += ["--attendee", attendee]
-    return await _gcal(*args)
-
-
-@mcp.tool(
-    description="Cancel (delete) a Google Calendar event by id. By default Google "
-    "emails every attendee about the cancellation; pass notify='none' to stay silent."
-)
-async def calendar_event_cancel(
-    event_id: Annotated[str, Field(description="The event id, as returned by calendar_events")],
-    notify: Annotated[str, Field(description="Who Google emails: all | external-only | none")] = "all",
-    calendar: Annotated[str, Field(description="Calendar id: an email, or `primary`")] = "primary",
-) -> str:
-    return await _gcal("cancel", event_id, "--json", "--calendar", calendar, "--notify", notify)
-
-
-async def _gcal(*args: str) -> str:
-    binary = os.environ.get("IX_GCAL_BIN")
-    if not binary:
-        raise RuntimeError("IX_GCAL_BIN is not set; the gcal binary is bundled into ix-mcp")
-    proc = await asyncio.create_subprocess_exec(
-        binary, *args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
-    )
-    stdout, stderr = await proc.communicate()
-    if proc.returncode != 0:
-        detail = stderr.decode(errors="replace").strip()
-        raise RuntimeError(detail or f"gcal exited with status {proc.returncode}")
-    return stdout.decode(errors="replace")


### PR DESCRIPTION
The `search_*` and `calendar_*` MCP tools were thin wrappers over bundled modules (`search`, the google libs) that are all reachable from `python_exec` by importing the module in a cell. They duplicated the one-tool, notebook-first design without adding capability.

Remove them, leaving exactly two tools:
- **`python_exec`** — run anything on the shared kernel.
- **`kernel_trace`** — the one diagnostic that *can't* go through `python_exec`, because it must work when a cell has wedged the kernel (out-of-band faulthandler signal, not the execute channel).

`serverTools` now asserts the surface is exactly these two. The bundled modules (`search`, google libs, `gcal`) stay importable from cells.

🤖 Generated with Claude Code (Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove search and calendar tools from MCP, leaving only `python_exec` and `kernel_trace`
> - Deletes `search_semantic`, `search_grep`, `calendar_events`, `calendar_event_create`, and `calendar_event_cancel` from [tools.py](https://github.com/indexable-inc/index/pull/809/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6), along with their internal helpers `_scope` and `_gcal`.
> - The module docstring now explains that these capabilities should be accessed via `python_exec` instead of dedicated tools.
> - The server tool-surface test in [default.nix](https://github.com/indexable-inc/index/pull/809/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) is updated to assert exact equality against `{'python_exec', 'kernel_trace'}`, so any re-addition of tools will cause a test failure.
> - Risk: callers relying on the removed MCP tools will receive errors; they must migrate to invoking equivalent logic through `python_exec`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86330ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->