### PR TITLE
fix(mcp): correct wedge-interrupt edge cases from review

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -832,13 +832,25 @@ let
         h = ns["history"]()
         assert isinstance(h, runtime.Result) and a.id in h.llm_result and b.id in h.llm_result
 
-        # A KeyboardInterrupt (what the server's wedge watchdog raises to free a
-        # blocked kernel) becomes a failed job with an actionable message, not a
-        # raw traceback that escapes the runner.
+        # A KeyboardInterrupt the user's own code raises keeps its real traceback
+        # (it is NOT misattributed to the wedge watchdog, whose flag is unset here).
         k = await run("raise KeyboardInterrupt", budget=1.0, name="kbi")
         assert k.status == "error", k.status
-        assert "asyncio.to_thread" in k.error, k.error
-        assert "Traceback" not in k.error, k.error
+        assert "Traceback" in k.error and "KeyboardInterrupt" in k.error, k.error
+        assert "asyncio.to_thread" not in k.error, k.error
+
+        # When the watchdog flag IS set (as the SIGUSR2 handler does before raising),
+        # the same interrupt yields the actionable wedge message instead. The cell
+        # sets the flag on its own running job via the runtime ContextVar.
+        w = await run(
+            "import ix_notebook_mcp.runtime as _rt\n"
+            "_rt._ix_current.get().interrupted_by_watchdog = True\n"
+            "raise KeyboardInterrupt",
+            budget=1.0,
+            name="kbi-watchdog",
+        )
+        assert w.status == "error", w.status
+        assert "asyncio.to_thread" in w.error and "Traceback" not in w.error, w.error
 
     asyncio.run(main())
     print("runtime-ok")

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -30,16 +30,24 @@ _READY_TIMEOUT = 60.0
 TRACE_ENV = "IX_MCP_KERNEL_TRACE"
 
 
-def _wedged_summary(budget: float, grace: float, deadline: float) -> dict:
+def _wedged_summary(budget: float, grace: float, deadline: float, interrupted: bool) -> dict:
     """A per-call summary, shaped like ``runtime._job_summary``, returned when a
     cell blocks the kernel past ``deadline``. The server renders it like any
     other summary, so the caller gets a clear, actionable message rather than an
-    opaque transport timeout."""
+    opaque transport timeout. ``interrupted`` reports whether the rescue signal
+    was actually sent, so the message does not claim a recovery that did not
+    happen when the kernel pid is unknown."""
+    recovery = (
+        "The kernel was interrupted and is usable again."
+        if interrupted
+        else "The kernel could NOT be interrupted (its pid is unknown); it is still "
+        "blocked and likely needs a restart."
+    )
     message = (
         f"Cell blocked the kernel's event loop for over {deadline:.0f}s "
         f"(budget {budget:.0f}s + {grace:.0f}s grace) with a synchronous "
-        "call, so the budget could not background it. The kernel was interrupted "
-        "and is usable again. Wrap blocking calls (subprocess.run, time.sleep, "
+        f"call, so the budget could not background it. {recovery} "
+        "Wrap blocking calls (subprocess.run, time.sleep, "
         "requests, heavy CPU) in `await asyncio.to_thread(...)` or use an async "
         "API, and run anything slow as a background job. The interrupted run is "
         "recoverable in this kernel via history() / jobs['<id>']."
@@ -63,6 +71,7 @@ class Kernel:
         self._km = None
         self._kc = None
         self._lock = asyncio.Lock()
+        self._trace_lock = asyncio.Lock()
         self._trace_path: Path | None = None
         self._pid: int | None = None
 
@@ -99,19 +108,22 @@ class Kernel:
         if self._km is None or self._trace_path is None or self._pid is None:
             return "kernel is not running"
         path = self._trace_path
-        before = path.stat().st_size if path.exists() else 0
-        try:
-            os.kill(self._pid, signal.SIGUSR1)
-        except ProcessLookupError:
-            return "kernel process is not alive"
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + timeout
-        while loop.time() < deadline:
-            await asyncio.sleep(0.05)
-            if path.exists() and path.stat().st_size > before:
-                # A short settle so the whole multi-thread dump has flushed.
+        # Serialize dumps: two concurrent traces share the same `before` offset and
+        # would each read both appended dumps. The lock keeps each dump clean.
+        async with self._trace_lock:
+            before = path.stat().st_size if path.exists() else 0
+            try:
+                os.kill(self._pid, signal.SIGUSR1)
+            except ProcessLookupError:
+                return "kernel process is not alive"
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + timeout
+            while loop.time() < deadline:
                 await asyncio.sleep(0.05)
-                return path.read_text()[before:].strip() or "(empty trace)"
+                if path.exists() and path.stat().st_size > before:
+                    # A short settle so the whole multi-thread dump has flushed.
+                    await asyncio.sleep(0.05)
+                    return path.read_text()[before:].strip() or "(empty trace)"
         return (
             f"No trace was produced within {timeout:.0f}s. The kernel may not have "
             "the faulthandler registered (older build) or cannot service signals."
@@ -155,26 +167,33 @@ class Kernel:
         try:
             return await self._execute(wrapper, timeout=deadline)
         except TimeoutError:
-            await self._interrupt()
-            return [], _wedged_summary(budget, grace, deadline)
+            interrupted = await self._interrupt()
+            return [], _wedged_summary(budget, grace, deadline, interrupted)
 
-    async def _interrupt(self) -> None:
+    async def _interrupt(self) -> bool:
         """Break a synchronous call wedging the kernel's event loop. ipykernel's
         own ``interrupt_kernel`` cancels the asyncio task, which a synchronous call
         never yields to, so it cannot break a wedged async cell. Send SIGUSR2 to
         the kernel's runtime handler instead: it raises ``KeyboardInterrupt`` inline
         at the blocked frame, which ``_runner`` records as a failed job so the
-        kernel returns to idle and the next call runs."""
+        kernel returns to idle and the next call runs. Returns whether the signal
+        was actually delivered, so the caller's summary does not claim a recovery
+        that did not happen."""
         if self._pid is None:
-            return
+            return False
         try:
             os.kill(self._pid, signal.SIGUSR2)
         except ProcessLookupError:
-            pass
+            return False
+        return True
 
     async def restart(self) -> None:
         if self._km is not None:
             await self._km.restart_kernel(now=True)
+            # The restart launches a new process, so refresh the pid the trace and
+            # interrupt signals target; a stale pid would signal a dead or reused
+            # process. The new kernel re-runs install() and re-opens the trace file.
+            self._pid = self._kernel_pid()
             await self._kc.wait_for_ready(timeout=_READY_TIMEOUT)
 
     async def shutdown(self) -> None:

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -137,6 +137,9 @@ class Job:
         # Rich outputs (mime bundles) display()-ed while this job runs.
         self._displays: list[dict] = []
         self.task: asyncio.Task | None = None
+        # Set by the SIGUSR2 wedge watchdog so _runner can tell its interrupt from
+        # a KeyboardInterrupt the user's own code raised.
+        self.interrupted_by_watchdog = False
 
     def _append(self, s: str) -> None:
         """Append output, trimming to the most recent _MAX_OUTPUT_CHARS so a
@@ -608,18 +611,21 @@ async def _runner(job: Job, ns: dict) -> None:
         job.status = "cancelled"
         raise
     except KeyboardInterrupt:
-        # The only source of an interrupt here is the server's wedge watchdog
-        # (SIGUSR2, fired after config.wedge_grace): a synchronous call blocked the
-        # event loop past the budget, so the kernel was interrupted to free it.
-        # Record a crisp, actionable message instead of a bare traceback.
         job.status = "error"
-        job.error = (
-            "Interrupted: this cell exceeded its budget while blocking the "
-            "kernel's event loop with a synchronous call (subprocess.run, "
-            "time.sleep, requests, a long CPU op), which freezes every job. Wrap "
-            "it in `await asyncio.to_thread(...)` or use an async API, and run "
-            "anything slow as a background job."
-        )
+        if job.interrupted_by_watchdog:
+            # The server's wedge watchdog (SIGUSR2, fired after config.wedge_grace)
+            # raised this: a synchronous call blocked the event loop past the
+            # budget. Record a crisp, actionable message instead of a bare traceback.
+            job.error = (
+                "Interrupted: this cell exceeded its budget while blocking the "
+                "kernel's event loop with a synchronous call (subprocess.run, "
+                "time.sleep, requests, a long CPU op), which freezes every job. Wrap "
+                "it in `await asyncio.to_thread(...)` or use an async API, and run "
+                "anything slow as a background job."
+            )
+        else:
+            # The user's own code raised KeyboardInterrupt; keep its real traceback.
+            job.error = traceback.format_exc()
         job._append(job.error)
     except (Exception, SystemExit):
         # Isolate user code from the kernel: a job's SyntaxError, exception, or
@@ -1146,14 +1152,20 @@ def _install_signal_handlers() -> None:
     trace_path = os.environ.get("IX_MCP_KERNEL_TRACE")
     if trace_path:
         _trace_file = open(trace_path, "w")  # truncates any stale dump from a prior kernel
+        # enable() handles fatal signals (SIGSEGV/SIGABRT) -> stderr; register()
+        # adds the on-demand SIGUSR1 all-thread dump the kernel_trace tool reads.
         faulthandler.enable()
         faulthandler.register(signal.SIGUSR1, file=_trace_file, all_threads=True, chain=False)
 
     def _break(signum, frame):
         # Only raise while a job is on the stack; a stray signal to an idle kernel
         # must not blow up the event loop. The handler runs in the interrupted
-        # frame's context, so it sees the running job's ContextVar.
-        if _ix_current.get() is not None:
+        # frame's context, so it sees the running job's ContextVar. Flag the job so
+        # _runner can tell this watchdog interrupt from a KeyboardInterrupt the
+        # user's own code raised (which must keep its real traceback).
+        job = _ix_current.get()
+        if job is not None:
+            job.interrupted_by_watchdog = True
             raise KeyboardInterrupt("ix: cell exceeded its budget while blocking the event loop")
 
     try:


### PR DESCRIPTION
Follow-up to #807, addressing the adversarial review of the kernel-wedge rescue.

- **User-raised `KeyboardInterrupt` is no longer mislabeled as a wedge.** The SIGUSR2 watchdog handler flags the job (`interrupted_by_watchdog`) before raising; `_runner` shows the actionable wedge message only for the flagged case and keeps the real traceback otherwise. (Previously any `KeyboardInterrupt` from user code got the 'exceeded budget while blocking' message.)
- **`restart()` refreshes `self._pid`** so post-restart interrupt/trace signals target the new process, not a dead or pid-reused one.
- **`_interrupt()` reports whether it actually signaled**; the wedged summary no longer claims 'interrupted and usable' when the kernel pid is unknown (says it likely needs a restart instead).
- **`dump_trace` is serialized** with a lock so two concurrent `kernel_trace` calls can't interleave dumps.
- Note why `faulthandler.enable()` sits alongside `register()`.

`runtimeSmoke` now asserts both branches (user interrupt keeps traceback; flagged interrupt yields the wedge message). Validated: `nix build .#mcp.tests.{runtimeSmoke,wedgeSmoke,serverTools}` green.

🤖 Generated with Claude Code (Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix wedge-interrupt edge cases to distinguish watchdog vs user-raised `KeyboardInterrupt`
> - `_runner` in [runtime.py](https://github.com/indexable-inc/index/pull/810/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) now checks `job.interrupted_by_watchdog`: watchdog-triggered interrupts produce the concise wedge message, while user-raised `KeyboardInterrupt` preserves the full traceback.
> - The SIGUSR2 handler sets `job.interrupted_by_watchdog = True` before raising `KeyboardInterrupt`, so downstream code can distinguish the two cases.
> - `_wedged_summary` in [kernel.py](https://github.com/indexable-inc/index/pull/810/files#diff-ced4fbbdf05b4f126e987804d73fdc2d811511b346e4985a9996ae7903683d1c) accepts an `interrupted: bool` parameter and reports accurate recovery status depending on whether the interrupt signal was actually sent.
> - `_interrupt_kernel` now returns a boolean indicating whether SIGUSR2 was successfully delivered (returns `False` on missing pid or `ProcessLookupError`).
> - `dump_trace` serializes concurrent trace reads with a new `_trace_lock`, and `restart` refreshes the cached kernel pid after restart so subsequent signals target the correct process.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b285196.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->