### PR TITLE
feat(nix-web-monitor): stamp --version with revision and commit date

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,14 @@
       # `<commit>-dirty`; neither (eval from a non-git source) -> "dev".
       rev = self.rev or self.dirtyRev or "dev";
 
+      # Commit date of that revision as `YYYYMMDDHHMMSS`, threaded alongside
+      # `rev` so a build can stamp a human-meaningful date. Under reproducible
+      # builds there is no wall-clock compile time; this is the source date Nix
+      # already records (`lastModifiedDate`): the commit date on a clean tree,
+      # the working-tree mtime on a dirty one. Empty when evaluated from a
+      # non-git source.
+      revDate = self.lastModifiedDate or "";
+
       # All path literals the flake exposes. Centralized so lib/ and
       # lib/per-system.nix have a single source of truth.
       paths = {
@@ -135,6 +143,7 @@
       ix = import ./lib {
         inherit
           rev
+          revDate
           nixpkgs
           paths
           rust-overlay

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -12,6 +12,10 @@
   # Flake source revision, stamped into builds that want to report it (see
   # `sharedHelpers.rev`). Defaulted so a direct `import ./lib` still evaluates.
   rev ? "dev",
+  # Commit date of `rev` as `YYYYMMDDHHMMSS` (Nix's `lastModifiedDate`), for
+  # builds that want to show a human date alongside the revision. Empty when
+  # unknown. Defaulted so a direct `import ./lib` still evaluates.
+  revDate ? "",
 }:
 let
   inherit (nixpkgs) lib;
@@ -337,6 +341,29 @@ let
   appleSdkToolchain = import ./darwin/apple-sdk-toolchain.nix;
 
   /**
+    Human build stamp for a tool's `--version` line: the short flake revision
+    plus its commit date, e.g. `abc123def456, 2026-06-07`. Reproducible builds
+    have no wall-clock compile time, so the commit date (`revDate`) is the
+    meaningful "when". Falls back to the short `rev` alone when `revDate` is
+    unknown, and to `"dev"` on a non-git eval.
+
+    Set this on a wrapper through an env var (`makeWrapper --set ...`) rather
+    than compiling it in, so a new commit only rehashes the wrapper, never the
+    underlying build. Shared here so every tool stamps its version the same way
+    from one source of truth.
+  */
+  buildStamp =
+    let
+      revShort = if rev == "dev" then "dev" else builtins.substring 0 12 rev;
+      date =
+        if builtins.stringLength revDate >= 8 then
+          "${builtins.substring 0 4 revDate}-${builtins.substring 4 2 revDate}-${builtins.substring 6 2 revDate}"
+        else
+          "";
+    in
+    if date == "" then revShort else "${revShort}, ${date}";
+
+  /**
     Helper surface shared by both the per-module `specialArgs.ix`
     (`ixSpecialArgs`) and the public `index.lib` (`ixReturn`). Listed once
     here so a new shared helper reaches both surfaces from a single edit;
@@ -345,6 +372,8 @@ let
   sharedHelpers = {
     inherit
       rev
+      revDate
+      buildStamp
       agentContext
       artifacts
       buildGradleFatJar

--- a/packages/nix-web-monitor/server/default.nix
+++ b/packages/nix-web-monitor/server/default.nix
@@ -52,7 +52,8 @@ let
         # extra copy into every closure and silently shadows custom
         # builds.
         makeWrapper ${lib.getExe unwrapped} "$out/bin/nix-web-monitor" \
-          --set NIX_WEB_MONITOR_SITE_DIR "$out/share/nix-web-monitor"
+          --set NIX_WEB_MONITOR_SITE_DIR "$out/share/nix-web-monitor" \
+          --set NIX_WEB_MONITOR_BUILD ${lib.escapeShellArg ix.buildStamp}
       '';
 in
 wrapper

--- a/packages/nix-web-monitor/server/src/main.rs
+++ b/packages/nix-web-monitor/server/src/main.rs
@@ -14,7 +14,7 @@ use axum::http::header;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use bytes::Bytes;
-use clap::{Parser, ValueEnum};
+use clap::{CommandFactory, FromArgMatches, Parser, ValueEnum};
 use nix_web_monitor_parser::{Delta, MonitorSnapshot, MonitorState, NixEvent, ParsedLine, strip_ansi};
 use tokio::io::{self, AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::process::Command;
@@ -36,8 +36,7 @@ const SEND_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Parser)]
 #[command(
-    about = "Run a Nix command with quiet terminal output and a live browser monitor.",
-    version
+    about = "Run a Nix command with quiet terminal output and a live browser monitor."
 )]
 #[allow(clippy::struct_field_names)] // `nix_args` is the wire-level name passed to `nix`; renaming would hurt the CLI help text.
 struct Args {
@@ -94,9 +93,32 @@ struct AppState {
     index_html: Bytes,
 }
 
+/// `--version` text: the crate version plus the build stamp the Nix wrapper
+/// sets (`NIX_WEB_MONITOR_BUILD`, the flake revision and its commit date).
+/// Read at runtime, not baked in with `env!`, so a new commit re-stamps the
+/// tiny wrapper without rebuilding the Rust unit. Plain crate version outside
+/// the packaged wrapper (e.g. a dev `cargo run`), where the env var is unset.
+///
+/// Interned in a `OnceLock` so the returned `&'static str` satisfies clap's
+/// `Command::version` bound, which the owned `String` does not.
+fn version() -> &'static str {
+    static VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    VERSION.get_or_init(|| {
+        let base = env!("CARGO_PKG_VERSION");
+        match std::env::var("NIX_WEB_MONITOR_BUILD") {
+            Ok(stamp) if !stamp.is_empty() => format!("{base} ({stamp})"),
+            _ => base.to_owned(),
+        }
+    })
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = Args::parse();
+    // Inject the runtime version onto the derived command, then parse. `--help`
+    // / `--version` exit inside `get_matches`; a parse error exits via
+    // `Error::exit`, matching `Args::parse()`'s behavior.
+    let matches = Args::command().version(version()).get_matches();
+    let args = Args::from_arg_matches(&matches).unwrap_or_else(|error| error.exit());
     validate_site_dir(&args.site_dir)?;
 
     let index_html = Bytes::from(


### PR DESCRIPTION
`nwm --version` showed only `nix-web-monitor 0.1.0`. Now it shows the flake revision and its commit date:

```
nix-web-monitor 0.1.0 (05c74f94973a, 2026-06-07)
```

Reproducible builds have no wall-clock compile time, so the commit date (`lastModifiedDate`) is the meaningful "when".

## What changed
- New shared `ix.buildStamp` in `lib/default.nix`: `{short-rev}, {YYYY-MM-DD}`, derived from `rev` + a new `revDate` thread (`self.lastModifiedDate`). One source of truth so any tool can stamp its `--version` the same way.
- `flake.nix` threads `revDate` into `ix`; `lib` exposes `revDate` and `buildStamp` via `sharedHelpers`.
- `nix-web-monitor` wrapper sets `NIX_WEB_MONITOR_BUILD=${ix.buildStamp}`; `main.rs` reads it at runtime and injects it onto the clap command. Runtime env, not `env!`, so a new commit only rehashes the tiny wrapper, never the cargo build.

Outside the packaged wrapper (`cargo run`), `--version` falls back to the plain crate version.

🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stamp `nix-web-monitor --version` with flake revision and commit date
> - The `--version` output now shows `<crate-version> (<rev>-<date>)` when `NIX_WEB_MONITOR_BUILD` is set at runtime, or just the crate version otherwise.
> - The Nix wrapper in [packages/nix-web-monitor/server/default.nix](https://github.com/indexable-inc/index/pull/813/files#diff-e39e5c2c152ebf9dcaaaacf58bb66b747fe17fb0e84e0ff0a6a1916d22f789f1) sets `NIX_WEB_MONITOR_BUILD` using a new `buildStamp` helper derived from `self.lastModifiedDate` and `self.rev`.
> - Manual clap command construction in [main.rs](https://github.com/indexable-inc/index/pull/813/files#diff-977e9b4c7d6ca1d62be6c912a6a6fa9b7f790dfb4618a8291d59752d0f25e191) replaces `Args::parse()` to inject the version string at runtime via a `OnceLock`-backed `version()` function.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ceb62a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->