### PR TITLE
feat(nix-web-monitor): show copy/download size and progress per activity

### DIFF
--- a/packages/nix-web-monitor/server/site/src/components/ActivityTreeRow.svelte
+++ b/packages/nix-web-monitor/server/site/src/components/ActivityTreeRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { SvelteSet } from 'svelte/reactivity';
   import Self from '$components/ActivityTreeRow.svelte';
-  import { formatDuration, middleTruncate } from '$lib/format';
+  import { formatBytes, formatDuration, formatRate, middleTruncate } from '$lib/format';
   import type { ActivityRowMeta } from '$lib/activity-tree';
 
   type Props = {
@@ -29,6 +29,34 @@
 
   function elapsed(row: ActivityRowMeta): number {
     return Math.max(0, (row.stoppedAtMs ?? now) - row.startedAtMs);
+  }
+
+  function percent(progress: NonNullable<ActivityRowMeta['progress']>): number {
+    return Math.min(100, Math.round((progress.done / progress.expected) * 100));
+  }
+
+  /// Average transfer rate (total bytes moved / elapsed) for a running byte row.
+  /// `null` for item-count rows, finished rows, or a span too short to divide,
+  /// where an instantaneous figure would just be noise.
+  function byteRate(row: ActivityRowMeta): number | null {
+    if (row.progress === null || row.progress.unit !== 'bytes' || row.stoppedAtMs !== null) {
+      return null;
+    }
+    const seconds = (now - row.startedAtMs) / 1000;
+    return seconds >= 0.5 ? row.progress.done / seconds : null;
+  }
+
+  /// Trailing readout next to the bar: `12.4 MB / 80 MB` plus a live rate for an
+  /// in-flight download, or `3 / 10` for an item-count activity.
+  function progressLabel(row: ActivityRowMeta): string {
+    const progress = row.progress;
+    if (progress === null) return '';
+    if (progress.unit !== 'bytes') {
+      return `${String(progress.done)} / ${String(progress.expected)}`;
+    }
+    const moved = `${formatBytes(progress.done)} / ${formatBytes(progress.expected)}`;
+    const rate = byteRate(row);
+    return rate === null ? moved : `${moved} · ${formatRate(rate)}`;
   }
 </script>
 
@@ -71,6 +99,14 @@
     {/if}
     {#if isCollapsed && children.length > 0}
       <span class="subtree-count">+{String(children.length)}</span>
+    {/if}
+    {#if meta.progress !== null}
+      <span class="activity-progress" title={progressLabel(meta)}>
+        <span class="pbar" aria-hidden="true"
+          ><span class="pbar-fill" style="--p: {String(percent(meta.progress))}%"></span></span
+        >
+        <span class="pbar-text">{progressLabel(meta)}</span>
+      </span>
     {/if}
     <span class="activity-dur">{formatDuration(elapsed(meta))}</span>
   </div>

--- a/packages/nix-web-monitor/server/site/src/lib/activity-tree.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/activity-tree.ts
@@ -19,8 +19,24 @@
 /// the builds and downloads an operator actually cares about. The fold keeps one
 /// row per distinct label per parent and pushes the real work back into view.
 
-import { activityKind, splitDerivation, type DerivationParts } from '$lib/format';
+import {
+  activityKind,
+  progressUnit,
+  splitDerivation,
+  type DerivationParts,
+  type ProgressUnit
+} from '$lib/format';
 import type { ActivityNode, ActivityStatus, BuildNode, BuildStatus } from '$lib/types';
+
+/// Byte/item progress for a copy or download row, summed across a folded group.
+/// `unit` says whether `done`/`expected` are bytes (a store copy or substituter
+/// download) or item counts. Only present when the activity reports measurable
+/// progress; a build or a copy before its first progress event has none.
+export type RowProgress = Readonly<{
+  done: number;
+  expected: number;
+  unit: ProgressUnit;
+}>;
 
 export type ActivityRowMeta = Readonly<{
   id: number;
@@ -39,6 +55,9 @@ export type ActivityRowMeta = Readonly<{
   startedAtMs: number;
   /// Latest stop across the folded group, or `null` while any member still runs.
   stoppedAtMs: number | null;
+  /// Copy/download progress, summed across the folded group, or `null` when the
+  /// row reports nothing measurable. Lets the row show how much data is moving.
+  progress: RowProgress | null;
 }>;
 
 export type ActivityTree = Readonly<{
@@ -160,6 +179,22 @@ export function buildActivityTree(activities: ActivityNode[], builds: BuildNode[
 
   const roots = descend(rawRoots);
 
+  /// Sum the `done`/`expected` counters across a folded group, classifying the
+  /// unit from the activity type (bytes for copies and downloads, items
+  /// otherwise). `null` when nothing in the group has measurable expected work,
+  /// so a build or a copy before its first progress event shows no bar.
+  function groupProgress(group: number[], typeName: string): RowProgress | null {
+    let done = 0;
+    let expected = 0;
+    for (const member of group) {
+      const progress = byId.get(member)?.progress;
+      if (progress === null || progress === undefined) continue;
+      done += progress.done;
+      expected += progress.expected;
+    }
+    return expected > 0 ? { done, expected, unit: progressUnit(typeName) } : null;
+  }
+
   const rowMeta = new Map<number, ActivityRowMeta>();
   for (const [rep, group] of members) {
     const desc = descriptor.get(rep);
@@ -175,7 +210,8 @@ export function buildActivityTree(activities: ActivityNode[], builds: BuildNode[
         text: desc.text,
         count: 1,
         startedAtMs: activity.startedAtMs,
-        stoppedAtMs: activity.stoppedAtMs
+        stoppedAtMs: activity.stoppedAtMs,
+        progress: groupProgress(group, activity.activityType.name)
       });
       continue;
     }
@@ -198,7 +234,8 @@ export function buildActivityTree(activities: ActivityNode[], builds: BuildNode[
       text: desc.text,
       count: group.length,
       startedAtMs,
-      stoppedAtMs
+      stoppedAtMs,
+      progress: groupProgress(group, activity.activityType.name)
     });
   }
 

--- a/packages/nix-web-monitor/server/site/src/lib/format.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/format.ts
@@ -76,8 +76,16 @@ export function formatDuration(ms: number): string {
 /// `2.4 MB/s` reading stays legible; whole numbers above to avoid noise.
 export function formatRate(bytesPerSecond: number): string {
   if (!Number.isFinite(bytesPerSecond) || bytesPerSecond <= 0) return '0 B/s';
-  const units = ['B/s', 'kB/s', 'MB/s', 'GB/s'];
-  let value = bytesPerSecond;
+  return `${formatBytes(bytesPerSecond)}/s`;
+}
+
+/// Human byte count in decimal units (`kB`/`MB` are 1000-based, matching how
+/// Nix substituters and binary caches report path sizes). One decimal below 100
+/// so `2.4 MB` stays legible; whole numbers above to keep the column quiet.
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  const units = ['B', 'kB', 'MB', 'GB', 'TB'];
+  let value = bytes;
   let unit = 0;
   while (value >= 1000 && unit < units.length - 1) {
     value /= 1000;
@@ -85,4 +93,17 @@ export function formatRate(bytesPerSecond: number): string {
   }
   const text = unit === 0 || value >= 100 ? String(Math.round(value)) : value.toFixed(1);
   return `${text} ${units[unit]}`;
+}
+
+/// Whether an activity's `progress` counters measure bytes or item counts. Nix
+/// reports `copy_path` and `file_transfer` progress in bytes (data moving across
+/// a store copy or substituter download); everything else (`copy_paths`,
+/// `builds`, ...) counts items. The activities panel uses this to label a row as
+/// `12.4 MB / 80 MB` versus `3 / 10`.
+export type ProgressUnit = 'bytes' | 'count';
+
+export function progressUnit(activityTypeName: string): ProgressUnit {
+  return activityTypeName === 'file_transfer' || activityTypeName === 'copy_path'
+    ? 'bytes'
+    : 'count';
 }

--- a/packages/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix-web-monitor/server/site/src/style.css
@@ -710,6 +710,40 @@ main.dragging-v .splitter-v::after {
   text-align: right;
 }
 
+/* Inline copy/download progress: a compact bar plus a byte (and live rate)
+ * readout, so a slow "copying …" / "downloading …" row shows how much data is
+ * moving and how fast instead of only a ticking duration. */
+.activity-progress {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.activity-progress .pbar {
+  position: relative;
+  width: 4rem;
+  height: 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: var(--panel-soft);
+  overflow: hidden;
+}
+
+.activity-progress .pbar-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--p, 0%);
+  background: linear-gradient(90deg, var(--accent), color-mix(in srgb, var(--accent) 70%, var(--green)));
+  transition: width 200ms ease-out;
+}
+
+.activity-progress .pbar-text {
+  white-space: nowrap;
+}
+
 /* ---------- builds ---------- */
 
 .build-table {


### PR DESCRIPTION
Copy and substituter-download rows in the activities panel showed only a ticking duration, so a slow `copying ...` / `downloading ...` gave no idea how big the path was or how far along it had gotten.

Now each activity shows its progress inline: a compact bar plus a readout.

- **bytes** for `copy_path` / `file_transfer`: `6.7 MB / 80 MB`, with a live average rate for in-flight transfers
- **item count** for `copy_paths` and other counted activities: `89 / 104`

The parser already attached per-activity `progress` (done/expected) and shipped it over the wire; this just renders it. Folded `×N` rows sum their members, so a repeated copy shows total bytes.

## Validation
Ran the built wrapper over `nix copy --to file://... nixpkgs#git` and diffed `/api/state` against the Playwright-rendered DOM: 92 activity rows carried progress, and the panel rendered `189 kB / 189 kB`, `6.7 MB / 6.7 MB`, and the `89 / 104` count row, matching the server state. See the testing recipe in the repo.

🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show copy/download size and live rate progress per activity row in nix-web-monitor
> - Each activity row in [ActivityTreeRow.svelte](https://github.com/indexable-inc/index/pull/814/files#diff-8520f61a42b109a6d89cd155e9688d53cf2653ad4bbf827925148837ffa3ce8c) now renders an inline progress bar and label showing bytes or item counts (e.g. `1.2 MB / 5.0 MB`) when progress data is available.
> - For running byte-based activities, a live transfer rate (e.g. `· 3.4 MB/s`) is appended to the label, computed as average bytes/sec over the activity's elapsed span.
> - [activity-tree.ts](https://github.com/indexable-inc/index/pull/814/files#diff-622a3308dfbb85cf31d899bd79a0ac4812783350b5fbda92d39eef215ccf7af1) aggregates `done`/`expected` across folded group members into a new `progress` field on `ActivityRowMeta`, classifying the unit as `bytes` (for `file_transfer`/`copy_path`) or `count`.
> - [format.ts](https://github.com/indexable-inc/index/pull/814/files#diff-d9f5256217da8c7536b8dc20f19d3ad1f66d8f8bad822ed6e2790cacddf18553) gains a `formatBytes` helper and refactors `formatRate` to delegate to it, adding support for units up to TB/s.
> - Progress bar fill width and transition are styled in [style.css](https://github.com/indexable-inc/index/pull/814/files#diff-dbfe775c90fa5d4b2078a2ecb07fcfd4f76dfca1caa859f1cd8f871764625d20).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e107cbb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->