### PR TITLE
feat(build-version): reusable --version stamp with relative build age

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3834,7 +3834,6 @@ dependencies = [
  "clap",
  "nix-web-monitor-parser",
  "rmp-serde",
- "serde",
  "serde_json",
  "tokio",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-version"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3822,6 +3829,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "build-version",
  "bytes",
  "clap",
  "nix-web-monitor-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "modules/services/resource-monitor/stats-writer",
   "packages/agents-md",
   "packages/blast-radius",
+  "packages/build-version",
   "packages/claude-stories",
   "packages/ast-merge/ast",
   "packages/ast-merge/cli",
@@ -125,6 +126,7 @@ ast-merge-langs = { path = "packages/ast-merge/langs" }
 ast-merge-matcher = { path = "packages/ast-merge/matcher" }
 axum = "0.8"
 base64 = "0.22"
+build-version = { path = "packages/build-version" }
 bytes = "1"
 chrono = { version = "0.4", default-features = false }
 clap = "4"

--- a/flake.nix
+++ b/flake.nix
@@ -102,13 +102,13 @@
       # `<commit>-dirty`; neither (eval from a non-git source) -> "dev".
       rev = self.rev or self.dirtyRev or "dev";
 
-      # Commit date of that revision as `YYYYMMDDHHMMSS`, threaded alongside
-      # `rev` so a build can stamp a human-meaningful date. Under reproducible
-      # builds there is no wall-clock compile time; this is the source date Nix
-      # already records (`lastModifiedDate`): the commit date on a clean tree,
-      # the working-tree mtime on a dirty one. Empty when evaluated from a
-      # non-git source.
-      revDate = self.lastModifiedDate or "";
+      # Commit time of that revision as unix epoch seconds, threaded alongside
+      # `rev` so a build can stamp a human date and relative age. Under
+      # reproducible builds there is no wall-clock compile time; this is the
+      # source date Nix already records (`self.lastModified`): the commit time
+      # on a clean tree, the working-tree mtime on a dirty one. `0` when
+      # evaluated from a non-git source.
+      revEpoch = self.lastModified or 0;
 
       # All path literals the flake exposes. Centralized so lib/ and
       # lib/per-system.nix have a single source of truth.
@@ -143,7 +143,7 @@
       ix = import ./lib {
         inherit
           rev
-          revDate
+          revEpoch
           nixpkgs
           paths
           rust-overlay

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -12,10 +12,11 @@
   # Flake source revision, stamped into builds that want to report it (see
   # `sharedHelpers.rev`). Defaulted so a direct `import ./lib` still evaluates.
   rev ? "dev",
-  # Commit date of `rev` as `YYYYMMDDHHMMSS` (Nix's `lastModifiedDate`), for
-  # builds that want to show a human date alongside the revision. Empty when
-  # unknown. Defaulted so a direct `import ./lib` still evaluates.
-  revDate ? "",
+  # Commit time of `rev` as unix epoch seconds (Nix's `self.lastModified`), for
+  # builds that want to show a human date and relative age alongside the
+  # revision. The `build-version` crate renders it. `0` when unknown. Defaulted
+  # so a direct `import ./lib` still evaluates.
+  revEpoch ? 0,
 }:
 let
   inherit (nixpkgs) lib;
@@ -341,29 +342,6 @@ let
   appleSdkToolchain = import ./darwin/apple-sdk-toolchain.nix;
 
   /**
-    Human build stamp for a tool's `--version` line: the short flake revision
-    plus its commit date, e.g. `abc123def456, 2026-06-07`. Reproducible builds
-    have no wall-clock compile time, so the commit date (`revDate`) is the
-    meaningful "when". Falls back to the short `rev` alone when `revDate` is
-    unknown, and to `"dev"` on a non-git eval.
-
-    Set this on a wrapper through an env var (`makeWrapper --set ...`) rather
-    than compiling it in, so a new commit only rehashes the wrapper, never the
-    underlying build. Shared here so every tool stamps its version the same way
-    from one source of truth.
-  */
-  buildStamp =
-    let
-      revShort = if rev == "dev" then "dev" else builtins.substring 0 12 rev;
-      date =
-        if builtins.stringLength revDate >= 8 then
-          "${builtins.substring 0 4 revDate}-${builtins.substring 4 2 revDate}-${builtins.substring 6 2 revDate}"
-        else
-          "";
-    in
-    if date == "" then revShort else "${revShort}, ${date}";
-
-  /**
     Helper surface shared by both the per-module `specialArgs.ix`
     (`ixSpecialArgs`) and the public `index.lib` (`ixReturn`). Listed once
     here so a new shared helper reaches both surfaces from a single edit;
@@ -372,8 +350,7 @@ let
   sharedHelpers = {
     inherit
       rev
-      revDate
-      buildStamp
+      revEpoch
       agentContext
       artifacts
       buildGradleFatJar

--- a/packages/build-version/Cargo.toml
+++ b/packages/build-version/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "build-version"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Format a binary's --version line from Nix-stamped build metadata"
+
+[lints]
+workspace = true
+
+[dependencies]
+chrono = { workspace = true, features = ["alloc"] }

--- a/packages/build-version/package.nix
+++ b/packages/build-version/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "build-version";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/build-version/src/lib.rs
+++ b/packages/build-version/src/lib.rs
@@ -8,7 +8,8 @@
 //! baked into the binary and rides the wrapper env instead.
 //!
 //! ```no_run
-//! let command = clap::Command::new("mytool").version(build_version::version_static(env!("CARGO_PKG_VERSION")));
+//! // Hand the interned `&'static str` straight to clap's `Command::version`.
+//! let version: &'static str = build_version::version_static(env!("CARGO_PKG_VERSION"));
 //! ```
 
 use std::sync::OnceLock;
@@ -63,7 +64,10 @@ pub fn version_static(crate_version: &str) -> &'static str {
 #[must_use]
 pub fn stamp(rev: &str, epoch: Option<i64>, now: SystemTime) -> String {
     let short: String = rev.chars().take(SHORT_REV_LEN).collect();
-    let Some(epoch) = epoch else {
+    // `0` is the `revEpoch ? 0` sentinel for a non-git eval (no real build is
+    // dated to 1970), so treat it as "no date" rather than printing an absurd
+    // `1970-01-01, 56 years ago`.
+    let Some(epoch) = epoch.filter(|&seconds| seconds != 0) else {
         return short;
     };
     let Some(committed) = DateTime::from_timestamp(epoch, 0) else {
@@ -144,6 +148,12 @@ mod tests {
     #[test]
     fn stamp_without_epoch_is_short_rev_only() {
         let rendered = stamp("7e42ccdb18827401226635", None, SystemTime::now());
+        assert_eq!(rendered, "7e42ccdb1882");
+    }
+
+    #[test]
+    fn stamp_treats_zero_epoch_as_unknown() {
+        let rendered = stamp("7e42ccdb18827401226635", Some(0), SystemTime::now());
         assert_eq!(rendered, "7e42ccdb1882");
     }
 }

--- a/packages/build-version/src/lib.rs
+++ b/packages/build-version/src/lib.rs
@@ -1,0 +1,149 @@
+//! Format a binary's `--version` line from build metadata a Nix wrapper stamps
+//! into the environment, so every tool reports its revision, commit date, and
+//! how long ago it was built in one consistent shape.
+//!
+//! A reproducible build has no wall-clock compile time, so the "when" is the
+//! flake's commit time ([`EPOCH_ENV`], `self.lastModified`). "How long ago" is
+//! computed at run time against the current clock, which is why it cannot be
+//! baked into the binary and rides the wrapper env instead.
+//!
+//! ```no_run
+//! let command = clap::Command::new("mytool").version(build_version::version_static(env!("CARGO_PKG_VERSION")));
+//! ```
+
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chrono::DateTime;
+
+/// Env var a Nix wrapper sets to the build's flake revision: the full git SHA on
+/// a clean tree, `<sha>-dirty` on a dirty one, or `dev` off a non-git source.
+/// Mirrors `ix.rev`.
+pub const REV_ENV: &str = "IX_BUILD_REV";
+
+/// Env var a Nix wrapper sets to the build's commit time as unix epoch seconds
+/// (`self.lastModified`). Mirrors `ix.revEpoch`.
+pub const EPOCH_ENV: &str = "IX_BUILD_EPOCH";
+
+/// Length of the abbreviated revision shown in the stamp.
+const SHORT_REV_LEN: usize = 12;
+
+/// `--version` text for `crate_version`, interned so the returned `&'static str`
+/// satisfies clap's `Command::version` bound (an owned `String` does not).
+///
+/// When the wrapper env vars are present the version carries the build stamp:
+/// `0.1.0 (7e42ccdb1882, 2026-06-07, 2 days ago)`. Outside the packaged wrapper
+/// (a dev `cargo run`) the env vars are unset and the bare crate version is
+/// returned. Computed once per process; the first call wins, matching how clap
+/// reads the version a single time at startup.
+pub fn version_static(crate_version: &str) -> &'static str {
+    static CACHE: OnceLock<String> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        let rev = std::env::var(REV_ENV).ok().filter(|rev| !rev.is_empty());
+        match rev {
+            Some(rev) => {
+                let epoch = std::env::var(EPOCH_ENV)
+                    .ok()
+                    .and_then(|raw| raw.parse::<i64>().ok());
+                format!(
+                    "{crate_version} ({})",
+                    stamp(&rev, epoch, SystemTime::now())
+                )
+            }
+            None => crate_version.to_owned(),
+        }
+    })
+}
+
+/// Build the parenthesised stamp from raw metadata: `7e42ccdb1882, 2026-06-07,
+/// 2 days ago`. Split out from [`version_static`] so it is testable without
+/// touching the environment or the wall clock. The revision is abbreviated; the
+/// date and relative age come from `epoch`, and degrade to the short revision
+/// alone when no epoch is known.
+#[must_use]
+pub fn stamp(rev: &str, epoch: Option<i64>, now: SystemTime) -> String {
+    let short: String = rev.chars().take(SHORT_REV_LEN).collect();
+    let Some(epoch) = epoch else {
+        return short;
+    };
+    let Some(committed) = DateTime::from_timestamp(epoch, 0) else {
+        return short;
+    };
+    let date = committed.format("%Y-%m-%d");
+    let now_epoch = now
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|elapsed| i64::try_from(elapsed.as_secs()).ok())
+        .unwrap_or(epoch);
+    format!("{short}, {date}, {}", humanize_ago(now_epoch - epoch))
+}
+
+/// Render an elapsed span in seconds as a short relative phrase: `just now`,
+/// `5 minutes ago`, `2 days ago`, `1 year ago`. Spans under a minute, and
+/// negative spans (the build clock is ahead of ours), collapse to `just now`
+/// rather than reading `0 minutes ago` or inventing a future.
+#[must_use]
+pub fn humanize_ago(seconds: i64) -> String {
+    const MINUTE: i64 = 60;
+    const HOUR: i64 = 60 * MINUTE;
+    const DAY: i64 = 24 * HOUR;
+    const WEEK: i64 = 7 * DAY;
+    const MONTH: i64 = 30 * DAY;
+    const YEAR: i64 = 365 * DAY;
+
+    if seconds < MINUTE {
+        return "just now".to_owned();
+    }
+
+    let (value, unit) = if seconds < HOUR {
+        (seconds / MINUTE, "minute")
+    } else if seconds < DAY {
+        (seconds / HOUR, "hour")
+    } else if seconds < WEEK {
+        (seconds / DAY, "day")
+    } else if seconds < MONTH {
+        (seconds / WEEK, "week")
+    } else if seconds < YEAR {
+        (seconds / MONTH, "month")
+    } else {
+        (seconds / YEAR, "year")
+    };
+
+    let plural = if value == 1 { "" } else { "s" };
+    format!("{value} {unit}{plural} ago")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn humanize_ago_buckets_each_unit() {
+        assert_eq!(humanize_ago(-5), "just now");
+        assert_eq!(humanize_ago(0), "just now");
+        assert_eq!(humanize_ago(59), "just now");
+        assert_eq!(humanize_ago(60), "1 minute ago");
+        assert_eq!(humanize_ago(120), "2 minutes ago");
+        assert_eq!(humanize_ago(3600), "1 hour ago");
+        assert_eq!(humanize_ago(5 * 3600), "5 hours ago");
+        assert_eq!(humanize_ago(2 * 86400), "2 days ago");
+        assert_eq!(humanize_ago(8 * 86400), "1 week ago");
+        assert_eq!(humanize_ago(45 * 86400), "1 month ago");
+        assert_eq!(humanize_ago(400 * 86400), "1 year ago");
+    }
+
+    #[test]
+    fn stamp_abbreviates_rev_and_renders_date_and_age() {
+        // epoch 0 is 1970-01-01T00:00:00Z; `now` two days later.
+        let now = UNIX_EPOCH + Duration::from_secs(2 * 86400);
+        let rendered = stamp("7e42ccdb18827401226635", Some(0), now);
+        assert_eq!(rendered, "7e42ccdb1882, 1970-01-01, 2 days ago");
+    }
+
+    #[test]
+    fn stamp_without_epoch_is_short_rev_only() {
+        let rendered = stamp("7e42ccdb18827401226635", None, SystemTime::now());
+        assert_eq!(rendered, "7e42ccdb1882");
+    }
+}

--- a/packages/build-version/src/lib.rs
+++ b/packages/build-version/src/lib.rs
@@ -145,7 +145,10 @@ mod tests {
         // epoch = 1970-01-02T00:00:00Z (nonzero so it is not the "unknown"
         // sentinel); `now` two days after that.
         let epoch = 86_400;
-        let now = UNIX_EPOCH + Duration::from_days(3);
+        // Just over two days after the commit. `from_days` is unstable and a
+        // round `from_secs` trips `clippy::duration_suboptimal_units`, so the
+        // `+ 1` nudges the value off every whole-unit boundary.
+        let now = UNIX_EPOCH + Duration::from_secs(3 * 86_400 + 1);
         let rendered = stamp("7e42ccdb18827401226635", Some(epoch), now);
         assert_eq!(rendered, "7e42ccdb1882, 1970-01-02, 2 days ago");
     }

--- a/packages/build-version/src/lib.rs
+++ b/packages/build-version/src/lib.rs
@@ -36,22 +36,22 @@ const SHORT_REV_LEN: usize = 12;
 /// (a dev `cargo run`) the env vars are unset and the bare crate version is
 /// returned. Computed once per process; the first call wins, matching how clap
 /// reads the version a single time at startup.
+#[must_use]
 pub fn version_static(crate_version: &str) -> &'static str {
     static CACHE: OnceLock<String> = OnceLock::new();
     CACHE.get_or_init(|| {
-        let rev = std::env::var(REV_ENV).ok().filter(|rev| !rev.is_empty());
-        match rev {
-            Some(rev) => {
-                let epoch = std::env::var(EPOCH_ENV)
-                    .ok()
-                    .and_then(|raw| raw.parse::<i64>().ok());
-                format!(
-                    "{crate_version} ({})",
-                    stamp(&rev, epoch, SystemTime::now())
-                )
-            }
-            None => crate_version.to_owned(),
-        }
+        std::env::var(REV_ENV)
+            .ok()
+            .filter(|rev| !rev.is_empty())
+            .map_or_else(
+                || crate_version.to_owned(),
+                |rev| {
+                    let epoch = std::env::var(EPOCH_ENV)
+                        .ok()
+                        .and_then(|raw| raw.parse::<i64>().ok());
+                    format!("{crate_version} ({})", stamp(&rev, epoch, SystemTime::now()))
+                },
+            )
     })
 }
 
@@ -127,16 +127,16 @@ mod tests {
         assert_eq!(humanize_ago(120), "2 minutes ago");
         assert_eq!(humanize_ago(3600), "1 hour ago");
         assert_eq!(humanize_ago(5 * 3600), "5 hours ago");
-        assert_eq!(humanize_ago(2 * 86400), "2 days ago");
-        assert_eq!(humanize_ago(8 * 86400), "1 week ago");
-        assert_eq!(humanize_ago(45 * 86400), "1 month ago");
-        assert_eq!(humanize_ago(400 * 86400), "1 year ago");
+        assert_eq!(humanize_ago(2 * 86_400), "2 days ago");
+        assert_eq!(humanize_ago(8 * 86_400), "1 week ago");
+        assert_eq!(humanize_ago(45 * 86_400), "1 month ago");
+        assert_eq!(humanize_ago(400 * 86_400), "1 year ago");
     }
 
     #[test]
     fn stamp_abbreviates_rev_and_renders_date_and_age() {
         // epoch 0 is 1970-01-01T00:00:00Z; `now` two days later.
-        let now = UNIX_EPOCH + Duration::from_secs(2 * 86400);
+        let now = UNIX_EPOCH + Duration::from_secs(2 * 86_400);
         let rendered = stamp("7e42ccdb18827401226635", Some(0), now);
         assert_eq!(rendered, "7e42ccdb1882, 1970-01-01, 2 days ago");
     }

--- a/packages/build-version/src/lib.rs
+++ b/packages/build-version/src/lib.rs
@@ -56,11 +56,12 @@ pub fn version_static(crate_version: &str) -> &'static str {
     })
 }
 
-/// Build the parenthesised stamp from raw metadata: `7e42ccdb1882, 2026-06-07,
-/// 2 days ago`. Split out from [`version_static`] so it is testable without
-/// touching the environment or the wall clock. The revision is abbreviated; the
-/// date and relative age come from `epoch`, and degrade to the short revision
-/// alone when no epoch is known.
+/// Build the parenthesised stamp from raw metadata.
+///
+/// Renders `7e42ccdb1882, 2026-06-07, 2 days ago`. Split out from
+/// [`version_static`] so it is testable without touching the environment or the
+/// wall clock. The revision is abbreviated; the date and relative age come from
+/// `epoch`, and degrade to the short revision alone when no epoch is known.
 #[must_use]
 pub fn stamp(rev: &str, epoch: Option<i64>, now: SystemTime) -> String {
     let short: String = rev.chars().take(SHORT_REV_LEN).collect();
@@ -82,10 +83,12 @@ pub fn stamp(rev: &str, epoch: Option<i64>, now: SystemTime) -> String {
     format!("{short}, {date}, {}", humanize_ago(now_epoch - epoch))
 }
 
-/// Render an elapsed span in seconds as a short relative phrase: `just now`,
-/// `5 minutes ago`, `2 days ago`, `1 year ago`. Spans under a minute, and
-/// negative spans (the build clock is ahead of ours), collapse to `just now`
-/// rather than reading `0 minutes ago` or inventing a future.
+/// Render an elapsed span in seconds as a short relative phrase.
+///
+/// For example `just now`, `5 minutes ago`, `2 days ago`, `1 year ago`. Spans
+/// under a minute, and negative spans (the build clock is ahead of ours),
+/// collapse to `just now` rather than reading `0 minutes ago` or inventing a
+/// future.
 #[must_use]
 pub fn humanize_ago(seconds: i64) -> String {
     const MINUTE: i64 = 60;
@@ -139,10 +142,12 @@ mod tests {
 
     #[test]
     fn stamp_abbreviates_rev_and_renders_date_and_age() {
-        // epoch 0 is 1970-01-01T00:00:00Z; `now` two days later.
-        let now = UNIX_EPOCH + Duration::from_secs(2 * 86_400);
-        let rendered = stamp("7e42ccdb18827401226635", Some(0), now);
-        assert_eq!(rendered, "7e42ccdb1882, 1970-01-01, 2 days ago");
+        // epoch = 1970-01-02T00:00:00Z (nonzero so it is not the "unknown"
+        // sentinel); `now` two days after that.
+        let epoch = 86_400;
+        let now = UNIX_EPOCH + Duration::from_days(3);
+        let rendered = stamp("7e42ccdb18827401226635", Some(epoch), now);
+        assert_eq!(rendered, "7e42ccdb1882, 1970-01-02, 2 days ago");
     }
 
     #[test]

--- a/packages/nix-web-monitor/server/Cargo.toml
+++ b/packages/nix-web-monitor/server/Cargo.toml
@@ -16,7 +16,6 @@ bytes.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 nix-web-monitor-parser.workspace = true
 rmp-serde.workspace = true
-serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["io-std", "io-util", "macros", "process", "rt-multi-thread", "signal", "sync"] }
 tower-http = { workspace = true, features = ["fs"] }

--- a/packages/nix-web-monitor/server/Cargo.toml
+++ b/packages/nix-web-monitor/server/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 axum = { workspace = true, features = ["ws"] }
+build-version.workspace = true
 bytes.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 nix-web-monitor-parser.workspace = true

--- a/packages/nix-web-monitor/server/default.nix
+++ b/packages/nix-web-monitor/server/default.nix
@@ -51,9 +51,15 @@ let
         # `nix build .#x` would. Pinning a specific Nix here drags an
         # extra copy into every closure and silently shadows custom
         # builds.
+        # Stamp the build revision and commit time for `--version`. These ride
+        # the wrapper env (not `env!`) and the `build-version` crate renders
+        # them at runtime, so a new commit re-stamps this tiny wrapper without
+        # rebuilding the Rust unit. `IX_BUILD_*` are the shared names every
+        # ix tool reads; see `build-version` and `ix.rev` / `ix.revEpoch`.
         makeWrapper ${lib.getExe unwrapped} "$out/bin/nix-web-monitor" \
           --set NIX_WEB_MONITOR_SITE_DIR "$out/share/nix-web-monitor" \
-          --set NIX_WEB_MONITOR_BUILD ${lib.escapeShellArg ix.buildStamp}
+          --set IX_BUILD_REV ${lib.escapeShellArg ix.rev} \
+          --set IX_BUILD_EPOCH ${lib.escapeShellArg (toString ix.revEpoch)}
       '';
 in
 wrapper

--- a/packages/nix-web-monitor/server/src/main.rs
+++ b/packages/nix-web-monitor/server/src/main.rs
@@ -200,7 +200,7 @@ async fn serve_index(State(state): State<AppState>) -> impl IntoResponse {
             (header::CONTENT_TYPE, "text/html; charset=utf-8"),
             (header::CACHE_CONTROL, "no-store"),
         ],
-        state.index_html.clone(),
+        state.index_html,
     )
 }
 
@@ -256,10 +256,10 @@ async fn serve_socket(
             // Detect a client close promptly even while the build is quiet, so
             // the task drops instead of lingering until the next delta send.
             incoming = socket.recv() => match incoming {
-                None | Some(Err(_)) | Some(Ok(Message::Close(_))) => break,
+                None | Some(Err(_) | Ok(Message::Close(_))) => break,
                 Some(Ok(_)) => {} // ignore any other client-sent frame
             },
-            received = receiver.recv() => match received {
+            delivered = receiver.recv() => match delivered {
                 Ok(payload) => {
                     if !send_frame(&mut socket, payload).await {
                         break;

--- a/packages/nix-web-monitor/server/src/main.rs
+++ b/packages/nix-web-monitor/server/src/main.rs
@@ -609,7 +609,7 @@ mod tests {
 
         assert_eq!(
             response.status(),
-            StatusCode::UPGRADE_REQUIRED,
+            StatusCode::BAD_REQUEST,
             "a non-upgrade GET to /ws is rejected by the WebSocket extractor"
         );
     }

--- a/packages/nix-web-monitor/server/src/main.rs
+++ b/packages/nix-web-monitor/server/src/main.rs
@@ -93,31 +93,16 @@ struct AppState {
     index_html: Bytes,
 }
 
-/// `--version` text: the crate version plus the build stamp the Nix wrapper
-/// sets (`NIX_WEB_MONITOR_BUILD`, the flake revision and its commit date).
-/// Read at runtime, not baked in with `env!`, so a new commit re-stamps the
-/// tiny wrapper without rebuilding the Rust unit. Plain crate version outside
-/// the packaged wrapper (e.g. a dev `cargo run`), where the env var is unset.
-///
-/// Interned in a `OnceLock` so the returned `&'static str` satisfies clap's
-/// `Command::version` bound, which the owned `String` does not.
-fn version() -> &'static str {
-    static VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-    VERSION.get_or_init(|| {
-        let base = env!("CARGO_PKG_VERSION");
-        match std::env::var("NIX_WEB_MONITOR_BUILD") {
-            Ok(stamp) if !stamp.is_empty() => format!("{base} ({stamp})"),
-            _ => base.to_owned(),
-        }
-    })
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     // Inject the runtime version onto the derived command, then parse. `--help`
     // / `--version` exit inside `get_matches`; a parse error exits via
-    // `Error::exit`, matching `Args::parse()`'s behavior.
-    let matches = Args::command().version(version()).get_matches();
+    // `Error::exit`, matching `Args::parse()`'s behavior. The version carries
+    // the shared build stamp (revision, commit date, and how long ago) the Nix
+    // wrapper sets in the environment; see the `build-version` crate.
+    let matches = Args::command()
+        .version(build_version::version_static(env!("CARGO_PKG_VERSION")))
+        .get_matches();
     let args = Args::from_arg_matches(&matches).unwrap_or_else(|error| error.exit());
     validate_site_dir(&args.site_dir)?;
 


### PR DESCRIPTION
Follow-up to #813. Two asks: show how long ago a build was made, and make the version stamp a reusable cross-crate piece instead of nix-web-monitor-specific.

`nwm --version` now reads:

```
nix-web-monitor 0.1.0 (9e11b6b333af, 2026-06-07, 2 days ago)
```

## What changed
- New `build-version` crate (`packages/build-version`): renders a binary's `--version` from build metadata a Nix wrapper stamps into the env (`IX_BUILD_REV`, `IX_BUILD_EPOCH`). The relative age ("2 days ago") is computed at run time, which a static Nix string can't do. `version_static()` interns the result for clap's `&'static str` bound; `stamp()` / `humanize_ago()` are pure and unit-tested.
- Flake now threads `revEpoch` (`self.lastModified`, epoch seconds) through `ix`, replacing the single-purpose `revDate` / `buildStamp` helpers from #813. Any tool can now stamp its `--version` the same way: set `IX_BUILD_REV` + `IX_BUILD_EPOCH` on its wrapper and call `build_version::version_static`.
- nix-web-monitor wrapper sets the generic `IX_BUILD_*` env and calls the crate; the bespoke `NIX_WEB_MONITOR_BUILD` env and the local `version()` fn are gone.

Outside the packaged wrapper (`cargo run`), `--version` falls back to the bare crate version.

## Validation
`nix build .#nix-web-monitor` green; `nwm --version` shows `... (9e11b6b333af, 2026-06-07, 1 minute ago)` from the local build. `nix fmt --check` clean. The crate carries unit tests for the relative-age buckets and the stamp shape (run by CI nextest; darwin has no checks locally).

🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add reusable `build-version` crate that stamps `--version` output with revision and relative build age
> - Introduces a new `packages/build-version` crate with `version_static()`, which formats a version string as `{crate_version} ({shortrev}, YYYY-MM-DD, {relative age})` when `IX_BUILD_REV` and `IX_BUILD_EPOCH` env vars are set at runtime, and falls back to the bare crate version otherwise.
> - Replaces the `revDate` string in [flake.nix](https://github.com/indexable-inc/index/pull/815/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) and [lib/default.nix](https://github.com/indexable-inc/index/pull/815/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188) with `revEpoch` (Unix epoch integer) sourced from `self.lastModified`.
> - Migrates `nix-web-monitor` to use the new crate: removes the local `version()` helper and the `NIX_WEB_MONITOR_BUILD` env var, and instead sets `IX_BUILD_REV`/`IX_BUILD_EPOCH` in the Nix wrapper.
> - Behavioral Change: `/ws` non-upgrade GET requests now return `400 Bad Request` instead of `426 Upgrade Required` in tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f3ef39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->