### PR TITLE
fix(flake): drop stale rust-overlay follows on symphony input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,6 @@
     symphony = {
       url = "github:indexable-inc/symphony/main";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.rust-overlay.follows = "rust-overlay";
     };
 
     # Ghostty's terminal VT engine, consumed as a source tree (not a flake) so


### PR DESCRIPTION
The `symphony` input pins rev `e645d0d8` (kept only for `room-server`), and at that rev symphony's flake declares a single input: `nixpkgs`. The `inputs.rust-overlay.follows = "rust-overlay"` override therefore points at an input that doesn't exist, so Nix prints `warning: input 'symphony' has an override for a non-existent input 'rust-overlay'` on every evaluation (visible on any `nix run index#...`).

Removing the override silences the warning. `flake.lock` is unchanged because no `rust-overlay` edge ever existed under `symphony`; the node still resolves to the same rev.

🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove stale `rust-overlay` follows from `symphony` input in `flake.nix`
> The `inputs.symphony.inputs.rust-overlay.follows` line in [flake.nix](https://github.com/indexable-inc/index/pull/816/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) is removed because it was stale. The `symphony` input will now resolve `rust-overlay` according to its own pins rather than mirroring the root flake's version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1dfdb86.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->