### PR TITLE
feat(nix-web-monitor): show measured size on store-copy rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3832,6 +3832,7 @@ dependencies = [
  "build-version",
  "bytes",
  "clap",
+ "ignore",
  "nix-web-monitor-parser",
  "rmp-serde",
  "serde_json",

--- a/packages/nix-web-monitor/parser/package.nix
+++ b/packages/nix-web-monitor/parser/package.nix
@@ -1,4 +1,5 @@
 {
   id = "nix-web-monitor-parser";
   inRustWorkspace = true;
+  passthruTests = true;
 }

--- a/packages/nix-web-monitor/parser/src/lib.rs
+++ b/packages/nix-web-monitor/parser/src/lib.rs
@@ -331,9 +331,9 @@ impl MonitorState {
     /// Attach a measured byte size to a "copying <path> to the store" activity
     /// and re-broadcast the row. The server measures the source itself because
     /// Nix reports that copy with no byte progress (see [`copy_to_store_source`]);
-    /// this is the only place `size_bytes` is set. A no-op if the activity has
-    /// already stopped and been dropped, so a slow measurement that lands late
-    /// is harmless.
+    /// this is the only place `size_bytes` is set. Activities are never removed,
+    /// so a slow measurement that lands after the copy stopped still annotates
+    /// the (stopped) row; the only no-op is an id that was never seen.
     pub fn set_activity_size(&mut self, id: u64, size_bytes: i64) {
         let Some(activity) = self.activities.get_mut(&id) else {
             return;
@@ -682,6 +682,10 @@ impl MonitorState {
     }
 
     fn push_log(&mut self, activity_id: Option<u64>, level: Option<i64>, text: &str) {
+        #[expect(
+            clippy::fallible_int_fallback,
+            reason = "log_counter is a u64 index that always fits usize on the repo's 64-bit targets"
+        )]
         let index = usize::try_from(self.log_counter).unwrap_or(usize::MAX);
         self.log_counter = self.log_counter.saturating_add(1);
         if let Some(id) = activity_id
@@ -797,7 +801,7 @@ pub fn copy_to_store_source(text: &str) -> Option<&str> {
     let body = &rest[quote.len_utf8()..];
     let end = body.find(quote)?;
     let path = &body[..end];
-    if body[end + quote.len_utf8()..].trim_start() != "to the store" {
+    if path.is_empty() || body[end + quote.len_utf8()..].trim_start() != "to the store" {
         return None;
     }
     Some(path.strip_suffix('/').unwrap_or(path))
@@ -1163,6 +1167,10 @@ fn text_field(fields: &[FieldValue], index: usize) -> Option<String> {
     })
 }
 
+#[expect(
+    clippy::fallible_int_fallback,
+    reason = "a usize always fits in u64 on every supported target, so the fallback is unreachable"
+)]
 fn next_tick(value: usize) -> u64 {
     u64::try_from(value).unwrap_or(u64::MAX)
 }
@@ -1730,6 +1738,8 @@ mod tests {
         assert_eq!(copy_to_store_source("building '/nix/store/x.drv'"), None);
         assert_eq!(copy_to_store_source("copying '/tmp/x' to somewhere else"), None);
         assert_eq!(copy_to_store_source("copying /tmp/x to the store"), None);
+        // An empty path would make the server walk its own CWD; reject it.
+        assert_eq!(copy_to_store_source("copying '' to the store"), None);
     }
 
     #[test]

--- a/packages/nix-web-monitor/parser/src/lib.rs
+++ b/packages/nix-web-monitor/parser/src/lib.rs
@@ -328,6 +328,20 @@ impl MonitorState {
         }
     }
 
+    /// Attach a measured byte size to a "copying <path> to the store" activity
+    /// and re-broadcast the row. The server measures the source itself because
+    /// Nix reports that copy with no byte progress (see [`copy_to_store_source`]);
+    /// this is the only place `size_bytes` is set. A no-op if the activity has
+    /// already stopped and been dropped, so a slow measurement that lands late
+    /// is harmless.
+    pub fn set_activity_size(&mut self, id: u64, size_bytes: i64) {
+        let Some(activity) = self.activities.get_mut(&id) else {
+            return;
+        };
+        activity.size_bytes = Some(size_bytes);
+        self.emit_activity(id);
+    }
+
     /// Record the transitive input `.drv` closure of one derivation, learned
     /// from `nix-store --query --requisites`. The caller filters source paths
     /// and the derivation itself out before calling. Stored unfiltered by build
@@ -448,6 +462,7 @@ impl MonitorState {
                 started_at_ms: now_ms,
                 stopped_at_ms: None,
                 build: build.clone(),
+                size_bytes: None,
             },
         );
 
@@ -764,6 +779,30 @@ fn planned_derivation(text: &str) -> Option<&str> {
     (path.starts_with("/nix/store/") && path.ends_with(DRV_SUFFIX)).then_some(path)
 }
 
+/// Extract the source path from a Nix "copying <path> to the store" activity.
+///
+/// Nix emits this for the local source-tree copy as an unstructured `unknown`
+/// activity carrying no byte progress, so the server measures the path itself to
+/// show how large the copy is (see [`MonitorState::set_activity_size`]). Handles
+/// both quote styles Nix uses (`'…'` for a `git+file` flake, `"…"` for a `path:`
+/// flake) and trims a trailing slash so the returned path stats cleanly. Returns
+/// `None` for any other activity text.
+#[must_use]
+pub fn copy_to_store_source(text: &str) -> Option<&str> {
+    let rest = text.strip_prefix("copying ")?;
+    let quote = rest.chars().next()?;
+    if quote != '\'' && quote != '"' {
+        return None;
+    }
+    let body = &rest[quote.len_utf8()..];
+    let end = body.find(quote)?;
+    let path = &body[..end];
+    if body[end + quote.len_utf8()..].trim_start() != "to the store" {
+        return None;
+    }
+    Some(path.strip_suffix('/').unwrap_or(path))
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MonitorSnapshot {
@@ -811,6 +850,13 @@ pub struct ActivityNode {
     pub started_at_ms: u64,
     pub stopped_at_ms: Option<u64>,
     pub build: Option<String>,
+    /// Total bytes the server measured for a "copying <path> to the store"
+    /// activity. Nix reports that local source copy as an unstructured `unknown`
+    /// activity with no byte progress (see [`copy_to_store_source`]), so without
+    /// this the operator cannot tell whether the copy moves a megabyte or a
+    /// hundred gigabytes. `None` on every other activity and until the
+    /// measurement lands.
+    pub size_bytes: Option<i64>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -1662,6 +1708,55 @@ mod tests {
         assert!(
             state.drain_deltas().is_empty(),
             "a second drain with no intervening mutation is empty"
+        );
+    }
+
+    #[test]
+    fn copy_to_store_source_handles_both_quote_styles() {
+        // `git+file` flakes single-quote and append a trailing slash; `path:`
+        // flakes double-quote with no slash. Both must yield the bare path.
+        assert_eq!(
+            copy_to_store_source("copying '/home/me/proj/' to the store"),
+            Some("/home/me/proj")
+        );
+        assert_eq!(
+            copy_to_store_source(r#"copying "/tmp/proj" to the store"#),
+            Some("/tmp/proj")
+        );
+    }
+
+    #[test]
+    fn copy_to_store_source_rejects_other_text() {
+        assert_eq!(copy_to_store_source("building '/nix/store/x.drv'"), None);
+        assert_eq!(copy_to_store_source("copying '/tmp/x' to somewhere else"), None);
+        assert_eq!(copy_to_store_source("copying /tmp/x to the store"), None);
+    }
+
+    #[test]
+    fn set_activity_size_attaches_bytes_and_reupserts() {
+        let mut state = MonitorState::default();
+        state.apply_line(
+            r#"@nix {"action":"start","id":3,"level":4,"text":"copying \"/tmp/proj\" to the store","type":0}"#,
+        );
+        state.drain_deltas();
+
+        state.set_activity_size(3, 4_096);
+
+        assert_eq!(state.activities[&3].size_bytes, Some(4_096));
+        let upserted = state.drain_deltas().into_iter().find_map(|delta| match delta {
+            Delta::ActivityUpsert { activity } if activity.id == 3 => activity.size_bytes,
+            _ => None,
+        });
+        assert_eq!(upserted, Some(4_096), "the measured size rides an ActivityUpsert");
+    }
+
+    #[test]
+    fn set_activity_size_is_a_noop_for_a_missing_activity() {
+        let mut state = MonitorState::default();
+        state.set_activity_size(99, 1);
+        assert!(
+            state.drain_deltas().is_empty(),
+            "measuring a dropped activity broadcasts nothing"
         );
     }
 }

--- a/packages/nix-web-monitor/server/Cargo.toml
+++ b/packages/nix-web-monitor/server/Cargo.toml
@@ -14,6 +14,7 @@ axum = { workspace = true, features = ["ws"] }
 build-version.workspace = true
 bytes.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
+ignore.workspace = true
 nix-web-monitor-parser.workspace = true
 rmp-serde.workspace = true
 serde_json.workspace = true

--- a/packages/nix-web-monitor/server/site/src/components/ActivityTreeRow.svelte
+++ b/packages/nix-web-monitor/server/site/src/components/ActivityTreeRow.svelte
@@ -107,6 +107,12 @@
         >
         <span class="pbar-text">{progressLabel(meta)}</span>
       </span>
+    {:else if meta.sizeBytes !== null}
+      <!-- Nix reports the local source copy with no byte progress, so show the
+           measured total instead of a bar. -->
+      <span class="activity-size" title="{formatBytes(meta.sizeBytes)} copied to the store"
+        >{formatBytes(meta.sizeBytes)}</span
+      >
     {/if}
     <span class="activity-dur">{formatDuration(elapsed(meta))}</span>
   </div>

--- a/packages/nix-web-monitor/server/site/src/lib/activity-tree.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/activity-tree.ts
@@ -58,6 +58,10 @@ export type ActivityRowMeta = Readonly<{
   /// Copy/download progress, summed across the folded group, or `null` when the
   /// row reports nothing measurable. Lets the row show how much data is moving.
   progress: RowProgress | null;
+  /// Total bytes being copied to the store, summed across the folded group, or
+  /// `null` when nothing in the group was measured. Set for Nix's local source
+  /// copy, which it reports without `progress`, so the row can still show a size.
+  sizeBytes: number | null;
 }>;
 
 export type ActivityTree = Readonly<{
@@ -195,6 +199,21 @@ export function buildActivityTree(activities: ActivityNode[], builds: BuildNode[
     return expected > 0 ? { done, expected, unit: progressUnit(typeName) } : null;
   }
 
+  /// Sum the measured copy size across a folded group. `null` when no member was
+  /// measured, so a row that is not a "copying … to the store" activity (or one
+  /// whose measurement has not landed yet) shows no size badge.
+  function groupSize(group: number[]): number | null {
+    let total = 0;
+    let measured = false;
+    for (const member of group) {
+      const size = byId.get(member)?.sizeBytes;
+      if (size === null || size === undefined) continue;
+      total += size;
+      measured = true;
+    }
+    return measured ? total : null;
+  }
+
   const rowMeta = new Map<number, ActivityRowMeta>();
   for (const [rep, group] of members) {
     const desc = descriptor.get(rep);
@@ -211,7 +230,8 @@ export function buildActivityTree(activities: ActivityNode[], builds: BuildNode[
         count: 1,
         startedAtMs: activity.startedAtMs,
         stoppedAtMs: activity.stoppedAtMs,
-        progress: groupProgress(group, activity.activityType.name)
+        progress: groupProgress(group, activity.activityType.name),
+        sizeBytes: groupSize(group)
       });
       continue;
     }
@@ -235,7 +255,8 @@ export function buildActivityTree(activities: ActivityNode[], builds: BuildNode[
       count: group.length,
       startedAtMs,
       stoppedAtMs,
-      progress: groupProgress(group, activity.activityType.name)
+      progress: groupProgress(group, activity.activityType.name),
+      sizeBytes: groupSize(group)
     });
   }
 

--- a/packages/nix-web-monitor/server/site/src/lib/types.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/types.ts
@@ -40,7 +40,10 @@ export const activityNodeSchema = v.object({
   startedTick: v.number(),
   startedAtMs: v.number(),
   stoppedAtMs: v.nullable(v.number()),
-  build: v.nullable(v.string())
+  build: v.nullable(v.string()),
+  /// Total bytes the server measured for a "copying … to the store" activity,
+  /// which Nix reports without byte progress. `null` on every other activity.
+  sizeBytes: v.nullable(v.number())
 });
 
 export const buildNodeSchema = v.object({

--- a/packages/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix-web-monitor/server/site/src/style.css
@@ -744,6 +744,14 @@ main.dragging-v .splitter-v::after {
   white-space: nowrap;
 }
 
+/* Measured size of a source copy Nix reports without byte progress. */
+.activity-size {
+  flex: 0 0 auto;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
 /* ---------- builds ---------- */
 
 .build-table {

--- a/packages/nix-web-monitor/server/src/main.rs
+++ b/packages/nix-web-monitor/server/src/main.rs
@@ -504,9 +504,14 @@ async fn measure_copy_size(
 fn copied_size(source: &Path) -> Result<i64> {
     let mut total: u64 = 0;
     // `hidden(false)` keeps tracked dotfiles (`.github`, `.gitignore`); the
-    // gitignore filters stay on by default; `.git` itself is never copied.
+    // gitignore filters stay on by default; `.git` itself is never copied;
+    // `parents(false)` confines the rules to the source tree's own ignore files,
+    // ignoring any `.gitignore` in a directory above the flake root. This is an
+    // approximate hint: it follows gitignore semantics rather than git's tracked
+    // set, so it can differ from Nix's copy for untracked-but-unignored files.
     let walker = WalkBuilder::new(source)
         .hidden(false)
+        .parents(false)
         .filter_entry(|entry| entry.file_name() != ".git")
         .build();
     for entry in walker {
@@ -517,7 +522,9 @@ fn copied_size(source: &Path) -> Result<i64> {
             total = total.saturating_add(metadata.len());
         }
     }
-    Ok(i64::try_from(total).unwrap_or(i64::MAX))
+    // The wire size is i64 (matching the progress counters); a source tree above
+    // 8 EiB cannot occur, so surface the impossible overflow rather than clamp.
+    i64::try_from(total).context("source tree size exceeds i64 range")
 }
 
 /// Drain the deltas accumulated by the latest mutation and broadcast each as an

--- a/packages/nix-web-monitor/server/src/main.rs
+++ b/packages/nix-web-monitor/server/src/main.rs
@@ -15,7 +15,10 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use bytes::Bytes;
 use clap::{CommandFactory, FromArgMatches, Parser, ValueEnum};
-use nix_web_monitor_parser::{Delta, MonitorSnapshot, MonitorState, NixEvent, ParsedLine, strip_ansi};
+use ignore::WalkBuilder;
+use nix_web_monitor_parser::{
+    Delta, MonitorSnapshot, MonitorState, NixEvent, ParsedLine, copy_to_store_source, strip_ansi,
+};
 use tokio::io::{self, AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::process::Command;
 use tokio::sync::{RwLock, broadcast, mpsc};
@@ -448,9 +451,73 @@ where
         if let Some(rendered) = render_for(terminal_output, &parsed) {
             eprintln!("{rendered}");
         }
+        // A "copying <path> to the store" activity is Nix's local source copy,
+        // which it reports as an unstructured activity with no byte progress.
+        // Measure the source off the parse path so the row can show its size.
+        if let ParsedLine::Event(NixEvent::Start(start)) = &parsed
+            && let Some(source) = copy_to_store_source(&start.text)
+        {
+            tokio::spawn(measure_copy_size(
+                start.id,
+                PathBuf::from(source),
+                Arc::clone(&monitor),
+                deltas.clone(),
+            ));
+        }
         broadcast_deltas(&monitor, &deltas).await?;
     }
     Ok(())
+}
+
+/// Measure the source path of a "copying … to the store" activity and attach the
+/// size to its row, so a copy Nix reports without byte progress still shows how
+/// large it is. The filesystem walk runs on a blocking thread and the row is
+/// re-broadcast once it lands. A measurement failure leaves the row unannotated
+/// rather than failing the build.
+async fn measure_copy_size(
+    activity_id: u64,
+    source: PathBuf,
+    monitor: Arc<RwLock<MonitorState>>,
+    deltas: broadcast::Sender<Bytes>,
+) -> Result<()> {
+    let size = match tokio::task::spawn_blocking(move || copied_size(&source)).await {
+        Ok(Ok(size)) => size,
+        Ok(Err(error)) => {
+            eprintln!("nix-web-monitor: measuring copy source failed: {error:#}");
+            return Ok(());
+        }
+        Err(error) => {
+            eprintln!("nix-web-monitor: copy-size measurement task panicked: {error}");
+            return Ok(());
+        }
+    };
+    monitor.write().await.set_activity_size(activity_id, size);
+    broadcast_deltas(&monitor, &deltas).await
+}
+
+/// Sum the apparent byte size of the files Nix would copy from `source` into the
+/// store: every regular file the gitignore rules do not exclude, which mirrors
+/// how a flake's source tree is assembled. `.git` is skipped because Nix never
+/// copies it. The figure is an approximate hint (apparent file sizes, not the
+/// NAR encoding), so a file that vanishes or is unreadable mid-walk contributes
+/// nothing rather than aborting the measurement.
+fn copied_size(source: &Path) -> Result<i64> {
+    let mut total: u64 = 0;
+    // `hidden(false)` keeps tracked dotfiles (`.github`, `.gitignore`); the
+    // gitignore filters stay on by default; `.git` itself is never copied.
+    let walker = WalkBuilder::new(source)
+        .hidden(false)
+        .filter_entry(|entry| entry.file_name() != ".git")
+        .build();
+    for entry in walker {
+        let entry = entry.context("walking copy source")?;
+        if entry.file_type().is_some_and(|file_type| file_type.is_file())
+            && let Ok(metadata) = entry.metadata()
+        {
+            total = total.saturating_add(metadata.len());
+        }
+    }
+    Ok(i64::try_from(total).unwrap_or(i64::MAX))
 }
 
 /// Drain the deltas accumulated by the latest mutation and broadcast each as an


### PR DESCRIPTION
## What

The activities panel showed no size for the copy operators wait on most: Nix's local source-tree copy (`copying '<path>' to the store`). Nix reports that as an unstructured `unknown` activity with **no byte progress**, so the GB/rate readout (which only fires on `copy_path`/`file_transfer` downloads) never appeared for it.

Now the server detects that activity, measures the source itself, and renders the total as a size badge on the row where a progress bar would otherwise sit.

## How

- **Parser** (`parser/src/lib.rs`): `ActivityNode` gains a measured `size_bytes`; a pure `copy_to_store_source(text)` extracts the path from both quote styles Nix uses (`'…'` for `git+file`, `"…"` for `path:`); `set_activity_size(id, bytes)` attaches it and re-broadcasts the row.
- **Server** (`server/src/main.rs`): on a `copying … to the store` start, spawns a blocking `ignore`-crate walk that respects `.gitignore` (so `target/`, `result`, etc. are excluded, matching what Nix copies), keeps tracked dotfiles, and skips `.git/`; attaches the total off the parse path.
- **UI**: `sizeBytes` flows through the wire schema and the folded-group row meta (summed); the row shows the size unless live byte progress is present, which takes precedence.

It's an approximate hint (apparent file sizes, not the NAR encoding); Nix exposes no live progress for this copy, so it's a total, not a moving bar.

## Validation

- `nix build .#nix-web-monitor` (Rust + Svelte/TS) green.
- Live end-to-end against a git flake with a tracked 5 MB file and a **gitignored 80 MB file**: `/api/state` reported `sizeBytes: 5000053` — the gitignored file and `.git/` were correctly excluded.
- x86_64-linux `rust-nix-web-monitor{,-parser}` clippy + tests + unused-deps.

🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show measured file size on store-copy activity rows in nix-web-monitor
> - When a Nix `copying '<path>' to the store` activity starts, the server spawns a background task that walks the source tree using gitignore semantics ([`copied_size`](https://github.com/indexable-inc/index/pull/817/files#diff-977e9b4c7d6ca1d62be6c912a6a6fa9b7f790dfb4618a8291d59752d0f25e191)) and attaches the result to the activity via `MonitorState.set_activity_size`.
> - The parser's `ActivityNode` gains an optional `sizeBytes` field; the server broadcasts the updated activity once the walk completes.
> - The UI ([`ActivityTreeRow.svelte`](https://github.com/indexable-inc/index/pull/817/files#diff-8520f61a42b109a6d89cd155e9688d53cf2653ad4bbf827925148837ffa3ce8c)) renders a muted size badge for copy rows that have a measured size but no byte-progress bar. Grouped rows sum `sizeBytes` across members.
> - Risk: filesystem walk errors are logged but silently ignored, so the badge may not appear if the source path is inaccessible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b1f631.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->