### PR TITLE
feat(packages): add yc CLI package

### DIFF
--- a/packages/yc/default.nix
+++ b/packages/yc/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+}:
+let
+  # Slug map and pinned hashes live in manifest.json as the single owner; this
+  # file only reads them back. Bump by editing the version and refreshing the
+  # four hashes (the upstream binaries are republished per release at the S3
+  # bucket below). Mirrors the packages/claude-code layout.
+  manifest = lib.importJSON ./manifest.json;
+  inherit (manifest) version;
+
+  inherit (stdenv.hostPlatform) system;
+  target =
+    manifest.platforms.${system}
+      or (throw "yc: no prebuilt binary for ${system}; supported: ${lib.concatStringsSep ", " (builtins.attrNames manifest.platforms)}");
+
+  src = fetchurl {
+    url = "https://bookface-public.s3.us-west-2.amazonaws.com/cli/${version}/yc-${target.slug}";
+    inherit (target) hash;
+  };
+in
+stdenv.mkDerivation {
+  pname = "yc";
+  inherit version src;
+  dontUnpack = true;
+
+  # The Linux binaries are dynamically linked against a generic libc; patch their
+  # interpreter to the Nix store. Darwin binaries need no patching.
+  nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 $src $out/bin/yc
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "YC CLI: search Bookface and chat with the YC Agent from the terminal";
+    homepage = "https://bookface.ycombinator.com";
+    # License omitted rather than `licenses.unfree` so the per-system flake
+    # package set (which evaluates nixpkgs without `allowUnfree`) can still
+    # `nix run .#yc`. Same posture as packages/claude-code. Distribution terms
+    # are Y Combinator's; this flake only repackages the published binaries.
+    mainProgram = "yc";
+    platforms = builtins.attrNames manifest.platforms;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/packages/yc/manifest.json
+++ b/packages/yc/manifest.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.0.5",
+  "platforms": {
+    "aarch64-darwin": {
+      "slug": "darwin-arm64",
+      "hash": "sha256-Ffb7PX9fC8hbXu3EaQk6ZF0tBJER3DgXDdk4ReAHuX8="
+    },
+    "x86_64-darwin": {
+      "slug": "darwin-x64",
+      "hash": "sha256-nHU2RykREofUKr9CNEnV5BjpeyWE4gO0NyA6Cz1YmUQ="
+    },
+    "x86_64-linux": {
+      "slug": "linux-x64",
+      "hash": "sha256-KZxcsvIG65493MwMTnEMXsgPPA3mHuWCBinps/iod/4="
+    },
+    "aarch64-linux": {
+      "slug": "linux-arm64",
+      "hash": "sha256-wYLAglUdCw7q5iOE2VtE+jnaSB8oOrTEOsmjB69jo18="
+    }
+  }
+}

--- a/packages/yc/package.nix
+++ b/packages/yc/package.nix
@@ -1,0 +1,6 @@
+{
+  id = "yc";
+  packageSet = true;
+  flake = true;
+  overlay = true;
+}


### PR DESCRIPTION
Repackages the official prebuilt [YC CLI](https://bookface.ycombinator.com) binaries (Bookface search + YC Agent chat) into the monorepo overlay, mirroring `packages/claude-code`.

- `manifest.json` owns the version + per-platform slug/hash map (single source of truth); `default.nix` reads it back.
- `autoPatchelfHook` on Linux; Darwin needs no patching.
- License omitted (not `licenses.unfree`) so the per-system flake package set can still `nix run .#yc`, same posture as `packages/claude-code`.
- Exposed via `packageSet` + `flake` + `overlay`, so both `pkgs.yc` and `nix run .#yc` work.

Note: the upstream S3 binary for `darwin-arm64` had been silently republished under the same `0.0.5` tag since the standalone yc flake was pinned, so its hash here differs from that flake. The other three platforms match.

Validated locally on aarch64-darwin: `nix build .#yc` succeeds, `yc --version` prints `0.0.5`, `nix run .#lint` passes.

_Authored with Claude (Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `yc` CLI package as a prebuilt Nix derivation
> - Adds [packages/yc/default.nix](https://github.com/indexable-inc/index/pull/818/files#diff-0df35cd256ac3e08097668bd35bc840354461acfc70a04ccf3a15f891af4b421) that fetches a platform-specific prebuilt binary from S3 and installs it as `$out/bin/yc`.
> - Version and per-platform slugs/hashes are sourced from [packages/yc/manifest.json](https://github.com/indexable-inc/index/pull/818/files#diff-f6ce55ed32bf6a47b2476cf05523239697c8bd578bf8eedeab698d07f854d660), which covers `aarch64-darwin`, `x86_64-darwin`, `x86_64-linux`, and `aarch64-linux` at version 0.0.5.
> - On Linux, `autoPatchelfHook` patches the ELF interpreter to use Nix store paths.
> - [packages/yc/package.nix](https://github.com/indexable-inc/index/pull/818/files#diff-c8a54c6bece486094ab2eea2acb705d86316008302030d18b30228712299f155) registers the package for exposure via the package set, flake outputs, and overlay.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78cc37b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->