### PR TITLE
feat(packages): bump yc to 0.0.8

### DIFF
--- a/packages/yc/manifest.json
+++ b/packages/yc/manifest.json
@@ -1,21 +1,21 @@
 {
-  "version": "0.0.5",
+  "version": "0.0.8",
   "platforms": {
     "aarch64-darwin": {
       "slug": "darwin-arm64",
-      "hash": "sha256-Ffb7PX9fC8hbXu3EaQk6ZF0tBJER3DgXDdk4ReAHuX8="
+      "hash": "sha256-1vuQ1i881evjhlPtBjofbUzT5Gm5SYmHtv2Yd9l78Pg="
     },
     "x86_64-darwin": {
       "slug": "darwin-x64",
-      "hash": "sha256-nHU2RykREofUKr9CNEnV5BjpeyWE4gO0NyA6Cz1YmUQ="
+      "hash": "sha256-jpeeJwSp0zcVjY5LzKvxjOCfZpkKFrQKkTCyl64ZvZg="
     },
     "x86_64-linux": {
       "slug": "linux-x64",
-      "hash": "sha256-KZxcsvIG65493MwMTnEMXsgPPA3mHuWCBinps/iod/4="
+      "hash": "sha256-+aRxT8HfYnXrD3dgdf5yaftZR+UGK1gGxnFGm1RiP7E="
     },
     "aarch64-linux": {
       "slug": "linux-arm64",
-      "hash": "sha256-wYLAglUdCw7q5iOE2VtE+jnaSB8oOrTEOsmjB69jo18="
+      "hash": "sha256-sI3Pr2lK4c6JOiVUBcghdrN+bPEZTs1kDgUmwGVIz34="
     }
   }
 }


### PR DESCRIPTION
Bumps the `yc` package from `0.0.5` to `0.0.8`, the latest published YC CLI release. The S3 bucket has `0.0.6`/`0.0.7`/`0.0.8` (all HTTP 200); `0.0.9` returns 403, so `0.0.8` is current. All four platform hashes refreshed and verified locally on aarch64-darwin (`nix build .#yc` → `yc --version` prints `0.0.8`).

_Authored with Claude (Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `yc` package version to 0.0.8
> Updates [manifest.json](https://github.com/indexable-inc/index/pull/819/files#diff-f6ce55ed32bf6a47b2476cf05523239697c8bd578bf8eedeab698d07f854d660) to version 0.0.8 with new sha256 hashes for four fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b7e9a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->