### PR TITLE
feat(nix-web-monitor): wrap log lines instead of truncating with ellipsis

### DIFF
--- a/packages/nix-web-monitor/server/site/src/components/LogPanel.svelte
+++ b/packages/nix-web-monitor/server/site/src/components/LogPanel.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { tick } from 'svelte';
-  import { SvelteSet } from 'svelte/reactivity';
   import PanelHeader from '$lib/PanelHeader.svelte';
   import { splitDerivation } from '$lib/format';
   import { LOG_LEVEL_FILTERS, type LogEntry, type LogLevelFilter } from '$lib/types';
@@ -42,9 +41,6 @@
   /// scroll handler flips this off the moment the user scrolls up, and back
   /// on if they scroll back to the end.
   let follow = $state(true);
-  /// Set of log indices the user has chosen to expand from the default
-  /// single-line truncation.
-  const expanded = new SvelteSet<number>();
 
   const filtered = $derived(filterLogs(logs, level, search, selectedActivityId));
   const visible = $derived(filtered.slice(-RECENT_LOG_LIMIT));
@@ -94,15 +90,6 @@
       default:
         return level === null ? '' : 'log-debug';
     }
-  }
-
-  function isMultiline(text: string): boolean {
-    return text.length > 120 || text.includes('\n');
-  }
-
-  function toggleExpanded(index: number): void {
-    if (expanded.has(index)) expanded.delete(index);
-    else expanded.add(index);
   }
 
   function onScroll(): void {
@@ -197,30 +184,7 @@
   </PanelHeader>
   <div class="log-stream" bind:this={stream} onscroll={onScroll}>
     {#each visible as log (log.index)}
-      {@const long = isMultiline(log.text)}
-      {@const open = expanded.has(log.index)}
-      <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-      <div
-        class="line {lineClass(log.level)}"
-        class:expandable={long}
-        class:expanded={open}
-        role={long ? 'button' : undefined}
-        tabindex={long ? 0 : undefined}
-        onclick={long
-          ? () => {
-              toggleExpanded(log.index);
-            }
-          : undefined}
-        onkeydown={long
-          ? (event) => {
-              if (event.key === 'Enter' || event.key === ' ') {
-                event.preventDefault();
-                toggleExpanded(log.index);
-              }
-            }
-          : undefined}
-        title={long && !open ? log.text : undefined}
-      >
+      <div class="line {lineClass(log.level)}">
         <span class="idx">{String(log.index).padStart(5, '0')}</span>
         <span class="text">{log.text}</span>
       </div>

--- a/packages/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix-web-monitor/server/site/src/style.css
@@ -993,49 +993,14 @@ main.dragging-v .splitter-v::after {
   background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
-.line.expandable {
-  cursor: pointer;
-}
-
-.line.expandable .text::after {
-  content: '⤵';
-  color: var(--faint);
-  margin-left: 0.35rem;
-  opacity: 0;
-  transition: opacity 100ms ease-out;
-}
-
-.line.expandable:hover .text::after,
-.line.expandable:focus-visible .text::after {
-  opacity: 0.8;
-}
-
-.line.expandable.expanded .text::after {
-  content: '⤴';
-  opacity: 0.8;
-}
-
-.line.expandable:focus-visible {
-  outline: 1px solid var(--accent);
-  outline-offset: -1px;
-}
-
 .idx {
   color: var(--faint);
   user-select: none;
 }
 
 .text {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.line.expanded .text {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
-  overflow: visible;
-  text-overflow: clip;
 }
 
 .log-error { color: var(--red); }


### PR DESCRIPTION
The log panel truncated each line to one row with a `…` ellipsis and made long lines click-to-expand. Long build lines (e.g. a full `rustc` invocation) were unreadable without clicking. Now log lines wrap by default.

- `.text` uses `white-space: pre-wrap; overflow-wrap: anywhere;` so lines wrap on the line-number grid.
- Removed the now-vestigial expand machinery: the `expandable`/`expanded` classes, the `SvelteSet` of expanded indices, `toggleExpanded`, `isMultiline`, the click/keydown handlers, the `::after` caret rules, and the truncation CSS.

Validated with `nix build .#nix-web-monitor` (runs svelte-check + eslint + vite build).

🤖 Generated with Claude Code (Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wrap log lines instead of truncating with ellipsis in `LogPanel`
> Replaces the expand/collapse interaction on long log lines with unconditional wrapping. Log text now uses `pre-wrap` and `break-anywhere` at all times, so messages display in full without user interaction.
>
> - Removes the `expanded` set, `isMultiline` helper, and `toggleExpanded` function from [LogPanel.svelte](https://github.com/indexable-inc/index/pull/820/files#diff-5e09dc6af292e83bb05987bc8d966b59f065c0dbba20c02909c1e2452ce2b48b)
> - Removes expandable/expanded CSS rules and chevron pseudo-elements from [style.css](https://github.com/indexable-inc/index/pull/820/files#diff-dbfe775c90fa5d4b2078a2ecb07fcfd4f76dfca1caa859f1cd8f871764625d20)
> - Behavioral Change: log lines are no longer interactive; click/keyboard handlers and focus outlines for expansion are gone
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4885b5e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->