### PR TITLE
docs(dependency-intake): document the repo-wide updater

### DIFF
--- a/agent-context/sections/13-dependency-intake.md
+++ b/agent-context/sections/13-dependency-intake.md
@@ -35,10 +35,20 @@ is wrong, change the manifest or generator that owns it.
 A prebuilt-binary package pins its version and per-platform hashes in a generated
 `manifest.json` read with `lib.importJSON` and refreshed by a
 `passthru.updateScript`; bump by running the updater, never by hand-editing the
-hashes. When upstream signs its release manifest, the updater verifies that
-signature against a pinned key and fails closed before writing hashes. See
-[`packages/claude-code`](packages/claude-code) for the worked shape:
-`nix run .#claude-code.updateScript -- <version>`.
+hashes. Set `updateScript = true` in the package's `package.nix` so it joins the
+repo-wide updater: `nix run .#update` runs every flagged package's updater (plus
+the Minecraft catalogs) in parallel via dag-runner, and the `update.yml` workflow
+runs it hourly and opens one PR. Do not add a per-package update workflow. See
+[`packages/claude-code`](packages/claude-code) and [`packages/yc`](packages/yc)
+for the worked shape: `nix run .#claude-code.updateScript -- <version>`.
+
+When upstream signs its release manifest, the updater verifies that signature
+against a pinned key and fails closed before writing hashes (claude-code). When
+upstream publishes no signature (yc), there is no provenance check: the updater
+pins whatever bytes the release host serves, the CI build only proves the hash
+fetches and builds on one platform, and the real gate is human review of the hash
+changes in the auto-bump PR. Say which case applies in a comment next to the
+updater.
 
 Keep binary and generated artifacts near the owner that can explain and refresh
 them. Use small manifests for curated sets, generated catalogs for URLs and


### PR DESCRIPTION
Documents the repo-wide updater in the `dependency-intake` agent-context section, so the next person adding a prebuilt-binary package knows to wire it in.

- A prebuilt-binary package sets `updateScript = true` in its `package.nix` to join `nix run .#update` (one parallel dag-runner updater + one hourly `update.yml`); no per-package workflow.
- Spells out the two trust models: signed upstream (claude-code verifies a GPG signature, fails closed) vs unsigned (yc has no provenance check, so the gate is human review of the hash diff in the auto-bump PR).

Follow-up to the unified-updater change (#822).

_Authored with Claude (Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document the repo-wide updater for prebuilt-binary packages in dependency-intake guide
> Expands [13-dependency-intake.md](https://github.com/indexable-inc/index/pull/823/files#diff-830e6f04026126c1cfd2867c2e239116786297a2733e5e8c975fe1be90ed158b) with guidance on how packages participate in the repo-wide updater.
>
> - Setting `updateScript = true` in `package.nix` opts a package into `nix run .#update`, which runs all flagged updaters; `update.yml` runs this hourly and opens a single PR
> - Instructs contributors not to add per-package update workflows
> - Adds `yc` as a second worked example alongside `claude-code`, contrasting signed-manifest provenance (verified against a pinned key) with unsigned-manifest packages (no provenance check, relies on CI and human review)
> - Documents that a comment should be left next to the updater indicating which provenance case applies
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42bfee5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->