### PR TITLE
refactor(agent-context): make every section progressive

### DIFF
--- a/agent-context/sections/00-intro.md
+++ b/agent-context/sections/00-intro.md
@@ -1,6 +1,6 @@
 ---
 name: intro
-disclosure: always
+disclosure: progressive
 description: "What this repo is: pre-built OCI images for ix VMs plus composable NixOS modules."
 ---
 

--- a/agent-context/sections/01b-craft-standard.md
+++ b/agent-context/sections/01b-craft-standard.md
@@ -1,6 +1,6 @@
 ---
 name: craft-standard
-disclosure: always
+disclosure: progressive
 description: "The craft bar and defaults for every change: clear ownership, typed boundaries, checked defaults, root-cause fixes, no silent fallbacks."
 ---
 

--- a/agent-context/sections/04-writing-style.md
+++ b/agent-context/sections/04-writing-style.md
@@ -1,6 +1,6 @@
 ---
 name: writing-style
-disclosure: always
+disclosure: progressive
 description: "How to write prose (docs, comments, issues, PRs) and replies to the user."
 ---
 


### PR DESCRIPTION
Flip the three remaining `disclosure: always` sections (intro, craft-standard, writing-style) to `disclosure: progressive`. Every agent-context section now loads as an on-demand skill; the always-on `alwaysDoc` is empty.

- ix is unaffected: it imports `craft-standard`/`writing-style` by name from `agentContext.sections` (not via index `alwaysDoc`), so its always-on context stays as-is.
- Validated: `nix build .#agent-context` builds all targets (renderer evaluates with an empty always-tier, generates the three new skills, no assertion failures).

_Authored with Claude Code (Opus 4.8)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change agent-context sections to use progressive disclosure
> Updates the `disclosure` front-matter field from `always` to `progressive` in three agent-context sections: [00-intro.md](https://github.com/indexable-inc/index/pull/827/files#diff-a22cd8807398570434ff700721bb22dc30a1021f79490814b5a1d867d1364c6a), [01b-craft-standard.md](https://github.com/indexable-inc/index/pull/827/files#diff-03b6fd9ace92dfc5113589d80ebf6ba6cf21b8a4a521a4d730cdb952de7fcb79), and [04-writing-style.md](https://github.com/indexable-inc/index/pull/827/files#diff-3603ff288aad49bc96507d9817d1bbf2d748f238cc70b325b90ba6f581ff1502). This makes every section consistent in using progressive disclosure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 666aeff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->