### PR TITLE
feat(cargo-unit): per-package build env (packageBuildEnv)

### DIFF
--- a/lib/rust/cargo-unit.nix
+++ b/lib/rust/cargo-unit.nix
@@ -50,7 +50,11 @@ let
     call that only narrows `cargoTargets` yields byte-identical root
     derivations (pinned by a tests/default.nix assertion) and adds a unit-graph
     plus render IFD; create a separate workspace only when unit identity
-    changes (profile, policy, rustToolchain, env, extraRustcArgs). Top-level
+    changes (profile, policy, rustToolchain, env, extraRustcArgs). `env` folds
+    into every unit, so a value that changes often (a baked git commit) busts the
+    whole dependency closure; scope it with `packageBuildEnv.<package> = { ... }`
+    instead, which only reaches that package's own compile and build-script-run
+    units. Top-level
     `binaries`/`libraries` dedupe by Cargo target name and the first
     `cargoTargets` entry wins, so when one crate roots under several entries,
     select through `targetSets.<set>` instead. Per-case discovery is the
@@ -338,6 +342,7 @@ let
             testArgsByPackage = rawArgs.testArgsByPackage or { };
             packageTestInputs = rawArgs.packageTestInputs or { };
             packageTestEnv = rawArgs.packageTestEnv or { };
+            packageBuildEnv = rawArgs.packageBuildEnv or { };
             inherit extraRustcArgsForPlatform;
             # Manifest-derived flags come first so per-call `policy.clippy`
             # entries land later in argv and can override them. Cargo's

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -769,6 +769,12 @@ struct UnitDerivation<'a> {
     native_build_inputs: &'a str,
     driver: Driver,
     install_phase: String,
+    // `Some` only for a unit that compiles the package's own code, so
+    // `packageBuildEnv.<package>` can be merged onto its env in the template.
+    // `None` for the clippy and panic-object check units: build env is for
+    // producing the artifact, not for lints, and tagging them would needlessly
+    // invalidate them when the env changes.
+    package_name: Option<String>,
 }
 
 // Shared scaffold for the build, clippy, and panic-object derivations. They
@@ -787,10 +793,14 @@ fn render_unit_derivation(
         native_build_inputs,
         driver,
         install_phase,
+        package_name,
     } = spec;
     let mut attrs = Attrs::new();
 
     attrs.string("pname", &pname);
+    if let Some(package_name) = &package_name {
+        attrs.string("packageName", package_name);
+    }
     attrs.string("version", graph.units[index].package_version());
     attrs.expr("src", &prepared.source_ref(index));
     attrs.expr("nativeBuildInputs", native_build_inputs);
@@ -849,6 +859,7 @@ fn render_rustc_unit(
             native_build_inputs,
             driver: Driver::Rustc,
             install_phase: render_install_phase(unit, options, &prepared.hashes[index]),
+            package_name: Some(unit.package_name().into_owned()),
         },
     )
 }
@@ -874,6 +885,7 @@ fn render_clippy_unit(
             native_build_inputs: "[ rustToolchain ] ++ extraNativeBuildInputs ++ extraClippyNativeBuildInputs",
             driver: Driver::Clippy,
             install_phase: "mkdir -p $out\n".to_string(),
+            package_name: None,
         },
     )
 }
@@ -899,6 +911,7 @@ fn render_panic_object_unit(
             install_phase:
                 "mkdir -p $out\nfind build -maxdepth 1 -name '*.o' -exec cp {} \"$out/\" ';'\n"
                     .to_string(),
+            package_name: None,
         },
     )
 }
@@ -1432,6 +1445,10 @@ fn render_build_script_run(
         "pname",
         &format!("{}-build-script-output", run_unit.package_name()),
     );
+    // Tag so `packageBuildEnv.<package>` reaches the build script's process env:
+    // this is the unit that runs build.rs, and a `cargo:rustc-env` it emits in
+    // turn flows to this package's compile units.
+    attrs.string("packageName", &run_unit.package_name());
     attrs.string("version", run_unit.package_version());
     attrs.expr("src", &prepared.source_ref(run_index));
     attrs.expr(
@@ -3552,6 +3569,11 @@ mod tests {
         assert!(rendered.contains("testArgsByPackage ? {}"));
         assert!(rendered.contains("packageTestInputs ? {}"));
         assert!(rendered.contains("packageTestEnv ? {}"));
+        // Per-package build env: the param exists, mkUnit merges it keyed by the
+        // unit's `packageName` tag, and strips that tag before `mkDerivation`.
+        assert!(rendered.contains("packageBuildEnv ? {}"));
+        assert!(rendered.contains("packageBuildEnv.${attrs.packageName or \"\"} or {}"));
+        assert!(rendered.contains("builtins.removeAttrs attrs [ \"packageName\" ]"));
         assert!(rendered.contains("mkTestEntry ="));
         assert!(rendered.contains("RUST_TEST_THREADS"));
         assert!(rendered.contains("mkTestCases ="));

--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -17,6 +17,13 @@
   testArgsByPackage ? {},
   packageTestInputs ? {},
   packageTestEnv ? {},
+  # Per-package build env, keyed by Cargo package name. Merged onto the env of
+  # that package's own compile and build-script-run units only (the renderer
+  # tags those units with `packageName`); other packages and vendored
+  # dependency units are untouched. Use this instead of workspace-wide `extraEnv`
+  # for values that change often (e.g. a git commit baked into one crate) so the
+  # churn invalidates that one package's units, not the whole dependency closure.
+  packageBuildEnv ? {},
   extraPolicyChecks ? {},
   extraRustcArgs ? [],
   extraRustcArgsForPlatform ? _platform: [],
@@ -138,10 +145,15 @@ let
     in
     if audit.scope == "closure" then audit.relative else "";
 
-  mkUnit = attrs: pkgs.stdenv.mkDerivation (attrs // {
+  # `packageName` is a render-time tag the renderer attaches to a unit's own
+  # compile and build-script-run units so per-package build env can find them. It
+  # is not a derivation attribute, so strip it before `mkDerivation`; for a
+  # package with no `packageBuildEnv` entry the resulting derivation is
+  # byte-identical to one rendered without the tag.
+  mkUnit = attrs: pkgs.stdenv.mkDerivation ((builtins.removeAttrs attrs [ "packageName" ]) // {
     dontUnpack = true;
     dontConfigure = true;
-    env = (attrs.env or {}) // extraEnv;
+    env = (attrs.env or {}) // extraEnv // (packageBuildEnv.${attrs.packageName or ""} or {});
   });
 
   # Shape-identical to `mkUnit`. Kept distinct so per-unit clippy derivation

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -638,6 +638,11 @@ let
     ];
     packageTestInputs.cargo-unit-hello = [ pkgs.hello ];
     packageTestEnv.cargo-unit-hello.CARGO_UNIT_FIXTURE_ENV = "ok";
+    # Drive the packageBuildEnv -> build.rs -> rustc-env path: the build script
+    # reads CARGO_UNIT_BUILD_ENV and re-exposes it; the fixture test compares the
+    # baked value against this expected value (passed at test runtime).
+    packageBuildEnv.cargo-unit-hello.CARGO_UNIT_BUILD_ENV = "build-ok";
+    packageTestEnv.cargo-unit-hello.CARGO_UNIT_BUILD_ENV_EXPECTED = "build-ok";
     cargoTargets = [
       [ "--workspace" ]
       [
@@ -662,6 +667,10 @@ let
     workspaceRoot = ./fixtures/cargo-unit-hello;
     packageTestInputs.cargo-unit-hello = [ pkgs.hello ];
     packageTestEnv.cargo-unit-hello.CARGO_UNIT_FIXTURE_ENV = "ok";
+    # Mirror cargoUnitWorkspace exactly except cargoTargets so the byte-identical
+    # root assertion (a packageBuildEnv-tagged unit must narrow identically) holds.
+    packageBuildEnv.cargo-unit-hello.CARGO_UNIT_BUILD_ENV = "build-ok";
+    packageTestEnv.cargo-unit-hello.CARGO_UNIT_BUILD_ENV_EXPECTED = "build-ok";
     cargoTargets = [ [ "--workspace" ] ];
   };
 

--- a/tests/fixtures/cargo-unit-hello/build.rs
+++ b/tests/fixtures/cargo-unit-hello/build.rs
@@ -1,4 +1,11 @@
 fn main() {
     println!("cargo:rustc-link-arg-benches=-rdynamic");
     println!("cargo:rerun-if-changed=build.rs");
+
+    // Round-trips `packageBuildEnv` so a test can prove the build script saw it:
+    // read the build-time env var and re-expose it to the crate as a compile-time
+    // env var. Defaults to "absent" so the crate compiles when nothing is set.
+    println!("cargo:rerun-if-env-changed=CARGO_UNIT_BUILD_ENV");
+    let build_env = std::env::var("CARGO_UNIT_BUILD_ENV").unwrap_or_else(|_| "absent".to_owned());
+    println!("cargo:rustc-env=CARGO_UNIT_HELLO_BUILD_ENV={build_env}");
 }

--- a/tests/fixtures/cargo-unit-hello/src/lib.rs
+++ b/tests/fixtures/cargo-unit-hello/src/lib.rs
@@ -23,6 +23,18 @@ mod tests {
     }
 
     #[test]
+    fn package_build_env_reaches_build_script() {
+        // build.rs re-exposed CARGO_UNIT_BUILD_ENV (from packageBuildEnv) as this
+        // compile-time var. Only enforce when the workspace opts in by setting the
+        // expected value at test runtime (via packageTestEnv); otherwise the build
+        // script saw nothing and this is a no-op.
+        const FROM_BUILD: &str = env!("CARGO_UNIT_HELLO_BUILD_ENV");
+        if let Ok(expected) = std::env::var("CARGO_UNIT_BUILD_ENV_EXPECTED") {
+            assert_eq!(FROM_BUILD, expected);
+        }
+    }
+
+    #[test]
     fn package_test_env_and_path_are_available() {
         assert_eq!(
             std::env::var("CARGO_UNIT_FIXTURE_ENV").as_deref(),


### PR DESCRIPTION
Allows us to pass extra information to specific packages without invalidating the cache for unrelated packages.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `packageBuildEnv` parameter for per-package build environment variables in cargo-unit
> - Adds a `packageBuildEnv` parameter (keyed by Cargo package name) to the generated [units.nix template](https://github.com/indexable-inc/index/pull/828/files#diff-0962f6bad01321924b1688b79dee1e5626eeb872b7be247007c19f81bae72ff5) and [cargo-unit.nix](https://github.com/indexable-inc/index/pull/828/files#diff-82054df1a7d1648a5be88265641a7ae5d3b9e4ec4cdea72c518359ea4ae3f804), allowing callers to inject env vars into specific packages' build derivations.
> - Tags rustc compile unit and build-script run derivations with a `packageName` attribute in [render.rs](https://github.com/indexable-inc/index/pull/828/files#diff-da81bb79268fbaf52a96664faa4d392b9b83a48a4b3b54bb1c3a2a5f2f50f26a); `packageName` is stripped before `mkDerivation` to avoid leaking it into the output.
> - The per-package env is merged into the derivation's `env` set alongside existing `extraEnv`; units without a matching `packageName` entry are unaffected.
> - Test fixture [build.rs](https://github.com/indexable-inc/index/pull/828/files#diff-22b9f339da78c01eabe74056676557ef3267dc60279551731b86bcf3f65ee45d) propagates `CARGO_UNIT_BUILD_ENV` from the build environment to a compile-time constant, validated by a new test in [lib.rs](https://github.com/indexable-inc/index/pull/828/files#diff-948edea2a9d5f285d085d3b70e4ad7573f2013c4127c19c79ed1b5a5596abd75).
> - Behavioral Change: when `packageBuildEnv` is empty (the default), derivation byte identity is preserved; non-empty entries change the env hash for matched packages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 079485f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->