### PR TITLE
chore(symphony): drop the symphony flake-input room-server pin (interim)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -232,8 +232,7 @@
         "hermes-agent": "hermes-agent",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay",
-        "symphony": "symphony"
+        "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
@@ -253,27 +252,6 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "symphony": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1780772522,
-        "narHash": "sha256-hGwQqPLYF/ksn1PU68iPVKd8YY4+uiSpMaISba2NoM8=",
-        "owner": "indexable-inc",
-        "repo": "symphony",
-        "rev": "e645d0d8db5c78341ce9ce931a83cd0a379e7a0b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "indexable-inc",
-        "ref": "main",
-        "repo": "symphony",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -57,15 +57,13 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # Provides only `room-server` for images/dev/symphony-codex (through
-    # `pkgs.symphony-room-server` in lib/overlay.nix). The Elixir runtime
-    # itself lives in packages/symphony now; room-server's source moved to
-    # the ix monorepo, so this pin stays on the last symphony rev that still
-    # builds it and retires once the image's room-server seam moves too.
-    symphony = {
-      url = "github:indexable-inc/symphony/main";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    # TODO: re-add the `symphony` flake input that provided
+    # `pkgs.symphony-room-server` for images/dev/symphony-codex. room-server's
+    # real home is the ix monorepo (`crates/room`,
+    # `ix#packages.x86_64-linux.room-server`), but ix already inputs index
+    # (`ix/flake.nix`), so index cannot source it from ix without a circular
+    # flake dependency. Pin removed for now; re-add once that cycle is resolved
+    # or the symphony-codex image moves into ix.
 
     # Ghostty's terminal VT engine, consumed as a source tree (not a flake) so
     # `packages/vt/libghostty-vt` owns the build. Pinned to the commit the
@@ -87,7 +85,6 @@
       rust-overlay,
       home-manager,
       hermes-agent,
-      symphony,
       clippy-fork,
       ghostty,
       ...
@@ -148,7 +145,6 @@
           rust-overlay
           home-manager
           hermes-agent
-          symphony
           clippy-fork
           ghostty
           ;

--- a/images/dev/symphony-codex/default.nix
+++ b/images/dev/symphony-codex/default.nix
@@ -54,7 +54,9 @@
     pkgs.pkg-config
     pkgs.python3
     pkgs.ripgrep
-    pkgs.symphony-room-server
+    # TODO: re-add pkgs.symphony-room-server (room-server lives in ix monorepo;
+    # ix<->index flake cycle blocks sourcing it). Ports/portClaims below kept
+    # so re-adding is just this line.
     pkgs.unzip
     pkgs.which
     pkgs.zstd

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -6,7 +6,6 @@
   rust-overlay,
   home-manager,
   hermes-agent,
-  symphony,
   clippy-fork,
   ghostty,
   # Flake source revision, stamped into builds that want to report it (see
@@ -51,7 +50,6 @@ let
     inherit
       lib
       packageRegistry
-      symphony
       buildIxRustTool
       clippy-fork
       writePythonApplication

--- a/lib/overlay.nix
+++ b/lib/overlay.nix
@@ -1,7 +1,6 @@
 {
   lib,
   packageRegistry,
-  symphony,
   buildIxRustTool,
   clippy-fork,
   writePythonApplication,
@@ -43,7 +42,10 @@ lib.genAttrs' (packageRegistry.overlayEntriesFor packageSystem) (
   entry: lib.nameValuePair entry.overlay.attrName (buildOverlayPackage entry)
 )
 // {
-  symphony-room-server = symphony.packages."${packageSystem}".room-server;
+  # TODO: re-add symphony-room-server. The room-server binary lives in the ix
+  # monorepo (`ix#packages.x86_64-linux.room-server`); the ix<->index flake
+  # cycle blocks sourcing it from there, so the old `symphony` input pin was
+  # removed. images/dev/symphony-codex consumes this when re-added.
 
   # Default Temurin JRE for repo-owned package sets. The major lives in
   # `lib/languages/jvm-defaults.nix`, shared with `ix.languages.{java,scala}`

--- a/packages/symphony/README.md
+++ b/packages/symphony/README.md
@@ -30,7 +30,7 @@ The launcher requires an authenticated `codex` on PATH and refuses to start with
 ## Neighbors
 
 - The room stack symphony drives over HTTP (`room-server` and the room UI) lives in the ix monorepo (`crates/room`, `packages/room`).
-- `location: ixvm` placements provision VMs from the [`symphony-codex`](../../images/dev/symphony-codex/) image, which carries `room-server` on PATH.
+- `location: ixvm` placements provision VMs from the [`symphony-codex`](../../images/dev/symphony-codex/) image. TODO: that image temporarily does **not** carry `room-server` on PATH (the `symphony` flake input pin was removed; room-server lives in the ix monorepo and the ix<->index flake cycle blocks sourcing it from ix).
 - Deployment goes through the [`symphony` NixOS module](../../modules/services/symphony/) (`services.symphony.*`), with secrets supplied via `environmentFile` or `secretsCommand`.
 
 ## Developing

--- a/packages/symphony/default.nix
+++ b/packages/symphony/default.nix
@@ -7,9 +7,10 @@
 # did from the standalone flake's `packages.default`.
 #
 # The room stack symphony drives over HTTP (room-server and the room UI)
-# lives in the ix monorepo. The `room-server` binary baked into
-# `images/dev/symphony-codex` still resolves from the pinned `symphony`
-# flake input (see flake.nix); only the runtime moved here.
+# lives in the ix monorepo. TODO: re-add the `room-server` binary to
+# `images/dev/symphony-codex`; the pinned `symphony` flake input that provided
+# it was removed (the ix<->index flake cycle blocks sourcing it from ix). Only
+# the runtime moved here.
 {
   lib,
   pkgs,

--- a/packages/symphony/package.nix
+++ b/packages/symphony/package.nix
@@ -1,9 +1,11 @@
 # Registry metadata. The launcher is a flake output (`nix run .#symphony`,
 # `index.packages.<sys>.symphony`, the attr ix's symphony host modules
 # consume) and deliberately not an overlay: nothing inside an image
-# evaluation needs `pkgs.symphony`, and the room-server the symphony-codex
-# image embeds is a separate package (`pkgs.symphony-room-server`, still
-# provided by the pinned `symphony` flake input).
+# evaluation needs `pkgs.symphony`. The room-server the symphony-codex image
+# embeds is a separate package (`pkgs.symphony-room-server`).
+# TODO: re-add it; the `symphony` flake input that provided it was removed
+# (room-server lives in the ix monorepo; the ix<->index flake cycle blocks
+# sourcing it from ix). See flake.nix and lib/overlay.nix.
 {
   id = "symphony";
   packageSet = true;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2960,10 +2960,9 @@ let
     ];
 
     symphony-codex = [
-      {
-        assertion = builtins.elem pkgs.symphony-room-server symphonyCodex.packages;
-        message = "symphony-codex image should include the room-server binary it starts";
-      }
+      # TODO: re-add the room-server-presence assertion once
+      # pkgs.symphony-room-server is restored (the `symphony` flake input pin was
+      # removed; referencing the missing attr would fail eval).
       {
         assertion = builtins.elem pkgs.codex symphonyCodex.packages;
         message = "symphony-codex image should include codex for diagnostic shell sessions";


### PR DESCRIPTION
## What

room-server is **not defined in index** â it was only pulled in as a *prebuilt binary* via a flake input on the dead standalone `indexable-inc/symphony` repo, re-exposed as `pkgs.symphony-room-server` (`lib/overlay.nix`) and embedded in the `images/dev/symphony-codex` dev image.

This drops that stale pin and the overlay alias **for now**, with `TODO: re-add` markers.

## Why

room-server's real home is the **ix monorepo** (`crates/room`, `ix#packages.x86_64-linux.room-server`). But **ix already inputs index** (`ix/flake.nix`), so index cannot source room-server from ix without a circular flake dependency. The old symphony pin was the only acyclic way to get the binary â a transitional seam the code comments already flagged for retirement. This removes it until the cycle is resolved or the symphony-codex image moves into ix.

## Changes

- `flake.nix`, `lib/default.nix`, `lib/overlay.nix`: remove the `symphony` flake input + its threading and the `symphony-room-server` overlay alias (â TODO comments).
- `images/dev/symphony-codex/default.nix`: drop `pkgs.symphony-room-server` from systemPackages (TODO). **Kept** the 8080/4433 ports + portClaims so re-add is one line.
- `tests/default.nix`: remove only the room-server-presence assertion (it would throw "attribute missing" once the alias is gone); the other 7 symphony-codex assertions stay.
- `packages/symphony/{package,default}.nix` + `README.md`: correct now-stale comments.
- `flake.lock`: pruned the `symphony` node.

## â ï¸ Behavior change

The `symphony-codex` image temporarily no longer carries `room-server` on PATH, so Symphony's `:ixvm` placement loses its in-image room-server until re-added. Intentional, per request.

## Validation

- â `nix eval .#packages.{aarch64-darwin,x86_64-linux}` â overlay evaluates clean, no missing-attr.
- â symphony-codex eval-test group: 7/7 pass, 0 fail.
- â `flake.lock` no longer contains a `symphony` node.
- â lint (ast-grep/nixfmt/statix/deadnix) green.
- Full image build + `nix flake check` need a Linux builder (man-db/rust IFD) â left to CI.

ð¤ Generated with Claude (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove symphony flake input and `symphony-room-server` from the symphony-codex image
> - Drops the `symphony` flake input from [flake.nix](https://github.com/indexable-inc/index/pull/831/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) and removes all references to it across the overlay, lib, and image definitions to resolve an `ix`↔`index` flake dependency cycle.
> - Removes `pkgs.symphony-room-server` from the [symphony-codex image](https://github.com/indexable-inc/index/pull/831/files#diff-fa98741b6cea42742963877e10afa3971317522ac8a23331307fedfee04b1101) package list; the binary is no longer on PATH.
> - Drops the test assertion in [tests/default.nix](https://github.com/indexable-inc/index/pull/831/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) that checked for `symphony-room-server` in the image.
> - TODO comments are left throughout marking where the input and package should be restored once the cycle is resolved.
> - Behavioral Change: the `symphony-codex` image no longer includes the `room-server` binary; downstream tooling that depends on it will break until the pin is restored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fba6574.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->