### PR TITLE
claude-code default system prompt + fff API rename

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -54,12 +54,16 @@
   # spaces, it survives makeBinaryWrapper's word splitting where an inline
   # `--system-prompt "<text with spaces>"` would shatter into separate argv.
   # This DROPS the default prompt wholesale (tool guidance, safety rules, coding
-  # conventions), so the agent only knows what this text says: use it for a
-  # non-coding agent that supplies its own complete prompt, not to add a rule on
-  # top of the default. Baked with `--add-flags` (prepended) so an explicit
-  # `--system-prompt`/`--system-prompt-file` on the CLI still wins. `null`
-  # (default) bakes no flag.
-  systemPrompt ? null,
+  # conventions), so the agent only knows what this text says. Baked with
+  # `--add-flags` (prepended) so an explicit
+  # `--system-prompt`/`--system-prompt-file` on the CLI still wins. Defaults to the
+  # house prompt below (location plus the pre-v1 backward-compatibility engineering
+  # rule); set to `null` to bake no flag and keep Claude Code's stock prompt.
+  systemPrompt ? ''
+    You live at SOMA, SF.
+
+    Treat this codebase as pre-v1: by default do not preserve backward compatibility. Design the correct API, then rename and migrate every call site in the same change rather than adding aliases, shims, or deprecated compatibility paths. Keep a compatibility layer only when explicitly asked or when a real external consumer is out of reach.
+  '',
   # Only the flake package set injects the Nushell writer; the overlay eval
   # context does not. The updater is a maintainer-facing flake output, so the
   # overlay build of `pkgs.claude-code` simply omits `passthru.updateScript`.

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -605,12 +605,12 @@ let
         for _ in range(20):
             finder.wait_for_scan(2000)
             result = finder.search("hello")
-            match = next((h for h in result.items if "hello_world" in h.path), None)
+            match = next((h for h in result.hits if "hello_world" in h.path), None)
             if match is not None:
                 hit_path = match.path
                 break
             time.sleep(0.25)
-        assert hit_path is not None, f"fuzzy search did not find hello_world.txt: {result.items!r}"
+        assert hit_path is not None, f"fuzzy search did not find hello_world.txt: {result.hits!r}"
 
         grep_result = finder.grep("find me on this line", limit=10)
         files = {m.path for m in grep_result.matches}
@@ -620,8 +620,8 @@ let
         assert defs.matches, "regex grep returned no matches"
 
         glob_result = finder.glob("**/*.rs")
-        assert any("main.rs" in h.path for h in glob_result.items), (
-            f"glob missed main.rs: {glob_result.items!r}"
+        assert any("main.rs" in h.path for h in glob_result.hits), (
+            f"glob missed main.rs: {glob_result.hits!r}"
         )
     finally:
         finder.close()

--- a/packages/mcp/src/fff/fff/__init__.py
+++ b/packages/mcp/src/fff/fff/__init__.py
@@ -9,11 +9,11 @@ index; this module loads the `fff-c` cdylib (`packages/fff` emits it next to the
     import fff
 
     # one-shot helpers keep a cached, file-watching index per directory:
-    for hit in fff.find("picker", path=".").items:
+    for hit in fff.find("picker", root=".").hits:
         print(hit.path, hit.frecency)
 
-    for m in fff.grep("fn main", path=".").matches:
-        print(f"{m.path}:{m.line_number}: {m.line_content}")
+    for m in fff.grep("fn main", root=".").matches:
+        print(f"{m.path}:{m.line_number}: {m.line}")
 
     # or hold an instance for repeated queries against one tree:
     with fff.FileFinder(".", content_indexing=True) as ff:
@@ -336,15 +336,15 @@ class FileHit:
 
 @dataclass(frozen=True)
 class SearchResult:
-    items: list[FileHit]
+    hits: list[FileHit]
     total_matched: int
     total_files: int
 
     def __iter__(self):
-        return iter(self.items)
+        return iter(self.hits)
 
     def __len__(self) -> int:
-        return len(self.items)
+        return len(self.hits)
 
     @property
     def df(self):
@@ -352,7 +352,7 @@ class SearchResult:
         renders as the dashboard's styled table). Requires polars."""
         pl = _polars()
         if pl is None:
-            raise FffError("polars is not available; iterate .items instead")
+            raise FffError("polars is not available; iterate .hits instead")
         return pl.DataFrame(
             [
                 {
@@ -363,7 +363,7 @@ class SearchResult:
                     "git": h.git_status,
                     "binary": h.is_binary,
                 }
-                for h in self.items
+                for h in self.hits
             ],
             schema={
                 "path": pl.Utf8,
@@ -382,11 +382,11 @@ class SearchResult:
         return self.df._repr_html_() if pl is not None else None
 
     def __repr__(self) -> str:
-        head = "\n".join(f"  {h.path}" for h in self.items[:30])
-        more = f"\n  ... ({len(self.items) - 30} more)" if len(self.items) > 30 else ""
+        head = "\n".join(f"  {h.path}" for h in self.hits[:30])
+        more = f"\n  ... ({len(self.hits) - 30} more)" if len(self.hits) > 30 else ""
         return (
-            f"SearchResult: {len(self.items)} of {self.total_files} files "
-            f"(matched {self.total_matched})" + (f"\n{head}{more}" if self.items else "")
+            f"SearchResult: {len(self.hits)} of {self.total_files} files "
+            f"(matched {self.total_matched})" + (f"\n{head}{more}" if self.hits else "")
         )
 
 
@@ -405,7 +405,7 @@ class GrepMatch:
     line_number: int
     col: int
     byte_offset: int
-    line_content: str
+    line: str
     is_definition: bool
     is_binary: bool
     git_status: str | None = None
@@ -440,7 +440,7 @@ class GrepResult:
                     "path": m.path,
                     "line": m.line_number,
                     "col": m.col,
-                    "content": m.line_content,
+                    "content": m.line,
                     "def": m.is_definition,
                     "git": m.git_status,
                 }
@@ -464,7 +464,7 @@ class GrepResult:
 
     def __repr__(self) -> str:
         head = "\n".join(
-            f"  {m.path}:{m.line_number}: {m.line_content.strip()}" for m in self.matches[:30]
+            f"  {m.path}:{m.line_number}: {m.line.strip()}" for m in self.matches[:30]
         )
         more = f"\n  ... ({len(self.matches) - 30} more)" if len(self.matches) > 30 else ""
         return (
@@ -487,7 +487,7 @@ class FileFinder:
 
     def __init__(
         self,
-        path=".",
+        root=".",
         *,
         ai_mode: bool = True,
         watch: bool = False,
@@ -498,7 +498,7 @@ class FileFinder:
     ) -> None:
         opts = _CreateOptions()
         opts.version = _OPTIONS_VERSION
-        opts.base_path = _encode(os.path.abspath(os.fspath(path)))
+        opts.base_path = _encode(os.path.abspath(os.fspath(root)))
         opts.frecency_db_path = _encode(frecency_db)
         opts.history_db_path = _encode(history_db)
         opts.enable_mmap_cache = mmap_cache
@@ -654,7 +654,7 @@ class FileFinder:
                 )
             )
         return SearchResult(
-            items=items,
+            hits=items,
             total_matched=_lib.fff_search_result_get_total_matched(h),
             total_files=_lib.fff_search_result_get_total_files(h),
         )
@@ -814,7 +814,7 @@ class FileFinder:
                     line_number=_lib.fff_grep_match_get_line_number(m),
                     col=_lib.fff_grep_match_get_col(m),
                     byte_offset=_lib.fff_grep_match_get_byte_offset(m),
-                    line_content=_str(_lib.fff_grep_match_get_line_content(m)) or "",
+                    line=_str(_lib.fff_grep_match_get_line_content(m)) or "",
                     is_definition=bool(_lib.fff_grep_match_get_is_definition(m)),
                     is_binary=bool(_lib.fff_grep_match_get_is_binary(m)),
                     git_status=_str(_lib.fff_grep_match_get_git_status(m)),
@@ -843,13 +843,13 @@ _cache: OrderedDict[str, FileFinder] = OrderedDict()
 _cache_lock = threading.Lock()
 
 
-def finder(path=".", **kwargs) -> FileFinder:
+def finder(root=".", **kwargs) -> FileFinder:
     """Construct a `FileFinder` (does not scan; call `wait_for_scan` yourself)."""
-    return FileFinder(path, **kwargs)
+    return FileFinder(root, **kwargs)
 
 
-def _cached(path) -> FileFinder:
-    key = os.path.abspath(os.fspath(path))
+def _cached(root) -> FileFinder:
+    key = os.path.abspath(os.fspath(root))
     with _cache_lock:
         existing = _cache.get(key)
         if existing is not None and not existing._closed:
@@ -872,24 +872,24 @@ def _cached(path) -> FileFinder:
         return ff
 
 
-def find(query: str, path=".", *, limit: int = 100) -> SearchResult:
-    """Fuzzy file search over `path`, reusing a cached watched index."""
-    return _cached(path).search(query, limit=limit)
+def find(query: str, root=".", *, limit: int = 100) -> SearchResult:
+    """Fuzzy file search over `root`, reusing a cached watched index."""
+    return _cached(root).search(query, limit=limit)
 
 
-def grep(query: str, path=".", *, mode: str = "plain", limit: int = 50) -> GrepResult:
-    """Content grep over `path`, reusing a cached watched (content-indexed) index."""
-    return _cached(path).grep(query, mode=mode, limit=limit)
+def grep(query: str, root=".", *, mode: str = "plain", limit: int = 50) -> GrepResult:
+    """Content grep over `root`, reusing a cached watched (content-indexed) index."""
+    return _cached(root).grep(query, mode=mode, limit=limit)
 
 
-async def afind(query: str, path=".", *, limit: int = 100) -> SearchResult:
+async def afind(query: str, root=".", *, limit: int = 100) -> SearchResult:
     """Async fuzzy file search: runs off the event loop (non-blocking)."""
-    return await asyncio.to_thread(find, query, path, limit=limit)
+    return await asyncio.to_thread(find, query, root, limit=limit)
 
 
-async def agrep(query: str, path=".", *, mode: str = "plain", limit: int = 50) -> GrepResult:
+async def agrep(query: str, root=".", *, mode: str = "plain", limit: int = 50) -> GrepResult:
     """Async content grep: runs off the event loop (non-blocking)."""
-    return await asyncio.to_thread(grep, query, path, mode=mode, limit=limit)
+    return await asyncio.to_thread(grep, query, root, mode=mode, limit=limit)
 
 
 import html as _html_mod
@@ -928,7 +928,7 @@ class CodeMap:
             lines.append(f" {path}")
             for m in hits:
                 mark = "\u25cf" if m.is_definition else "\u25cb"
-                lines.append(f"   {mark} {m.line_number:>5}  {m.line_content.strip()}")
+                lines.append(f"   {mark} {m.line_number:>5}  {m.line.strip()}")
         return "\n".join(lines)
 
     def _repr_html_(self) -> str:
@@ -945,7 +945,7 @@ class CodeMap:
             for m in hits:
                 mark = "\u25cf" if m.is_definition else "\u25cb"
                 mark_col = "#e6e6e6" if m.is_definition else "#55555b"
-                line_html = _html_mod.escape(m.line_content.rstrip())
+                line_html = _html_mod.escape(m.line.rstrip())
                 rows.append(
                     '<div style="display:flex;gap:10px;padding:1px 0">'
                     f'<span style="color:{mark_col};width:1em">{mark}</span>'
@@ -975,14 +975,14 @@ class CodeMap:
         )
 
 
-def map(query: str, path=".", *, mode: str = "plain", limit: int = 200) -> CodeMap:
+def map(query: str, root=".", *, mode: str = "plain", limit: int = 200) -> CodeMap:
     """Content grep grouped into a :class:`CodeMap`: hits per file with
     definitions ranked first. A glanceable answer to "where is X defined and
     used?" built straight on :func:`grep`."""
-    return CodeMap(query, grep(query, path, mode=mode, limit=limit).matches)
+    return CodeMap(query, grep(query, root, mode=mode, limit=limit).matches)
 
 
-async def amap(query: str, path=".", *, mode: str = "plain", limit: int = 200) -> CodeMap:
+async def amap(query: str, root=".", *, mode: str = "plain", limit: int = 200) -> CodeMap:
     """Async :func:`map`: the same code map, off the event loop."""
-    res = await agrep(query, path, mode=mode, limit=limit)
+    res = await agrep(query, root, mode=mode, limit=limit)
     return CodeMap(query, res.matches)

--- a/packages/mcp/src/view/view/__init__.py
+++ b/packages/mcp/src/view/view/__init__.py
@@ -427,7 +427,7 @@ def grep(
 
     result = fff.grep(query, str(path), mode=mode, limit=limit)
     rows = [
-        {"path": m.path, "line": m.line_number, "text": m.line_content.strip()}
+        {"path": m.path, "line": m.line_number, "text": m.line.strip()}
         for m in result.matches
     ]
     return pl.DataFrame(
@@ -444,7 +444,7 @@ def find(
     result = fff.find(query, str(path), limit=limit)
     rows = [
         {"path": h.path, "name": h.name, "size": getattr(h, "size", None)}
-        for h in result.items
+        for h in result.hits
     ]
     return pl.DataFrame(
         rows, schema={"path": pl.Utf8, "name": pl.Utf8, "size": pl.Int64}


### PR DESCRIPTION
## What

Two small index changes:

1. **fff: rename to proper names** (`b81ddc87`). Pre-v1 cleanup, no back-compat shims:
   - module helpers + `FileFinder`/`finder`: search-root param `path` -> `root`
   - `GrepMatch.line_content` -> `line`
   - `SearchResult.items` -> `hits`
   Updated the only call sites (`view` wrapper, `default.nix` fff test harness). The C accessor symbol `fff_grep_match_get_line_content` is unchanged.

2. **claude-code: default system prompt** (`cadee679`). Sets the `systemPrompt` arg default (was `null`) to the house prompt: SoMA location line + the pre-v1 rule that we do not preserve backward compatibility by default. Still a full replace via `--system-prompt-file`; set to `null` to keep Claude Code's stock prompt.

## Validation

- ✅ `nix build .#mcp` and `.#mcp.tests.fffBundled` (the `.hits`/`.line`/`.map` harness) pass
- ✅ `nix build .#claude-code`; the built wrapper bakes `--system-prompt-file` pointing at a file with both lines
- ✅ nix lint (nixfmt/statix/deadnix/ast-grep) clean

🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `fff` API fields and add default system prompt to claude-code wrapper
> - Renames `SearchResult.items` to `hits`, `GrepMatch.line_content` to `line`, and the `path` parameter to `root` across all public `fff` functions (`find`, `grep`, `afind`, `agrep`, `map`, `amap`) in [__init__.py](https://github.com/indexable-inc/index/pull/832/files#diff-04cf9369e128a37711b583a278d82557a69696b7ad87abacabfd89301ab6403d)
> - Updates [view/__init__.py](https://github.com/indexable-inc/index/pull/832/files#diff-3fb883791c4d496cf7370e61715a007772f0dca222406e20e8c8944f7ef1a2ab) and embedded tests in [mcp/default.nix](https://github.com/indexable-inc/index/pull/832/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) to use the renamed fields
> - Adds a default system prompt to the claude-code wrapper in [default.nix](https://github.com/indexable-inc/index/pull/832/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b) that includes location and a pre-v1 backward-compatibility rule; set `systemPrompt = null` to revert to Claude Code's stock prompt
> - Risk: breaking API changes — all callers using `.items`, `.line_content`, or `path=` keyword arguments must be updated
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cadee67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->