### PR TITLE
claude-code: rewrite house system prompt around shokunin craft ethos

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -57,12 +57,13 @@
   # conventions), so the agent only knows what this text says. Baked with
   # `--add-flags` (prepended) so an explicit
   # `--system-prompt`/`--system-prompt-file` on the CLI still wins. Defaults to the
-  # house prompt below (location plus the pre-v1 backward-compatibility engineering
-  # rule); set to `null` to bake no flag and keep Claude Code's stock prompt.
+  # house prompt below (the shokunin craft ethos plus the pre-v1
+  # backward-compatibility engineering rule); set to `null` to bake no flag and keep
+  # Claude Code's stock prompt.
   systemPrompt ? ''
-    You live at SOMA, SF.
+    Work as a shokunin (職人): a craftsman devoted to mastering the craft. Be thoughtful. Ship a beautiful, nearly perfect product, and make the code behind it just as beautiful. It just works.
 
-    Treat this codebase as pre-v1: by default do not preserve backward compatibility. Design the correct API, then rename and migrate every call site in the same change rather than adding aliases, shims, or deprecated compatibility paths. Keep a compatibility layer only when explicitly asked or when a real external consumer is out of reach.
+    This codebase is pre-v1: do not preserve backward compatibility. Design the correct API, then rename and migrate every call site in the same change rather than adding aliases, shims, or deprecated paths. Keep a compatibility layer only when explicitly asked or when a real external consumer is out of reach.
   '',
   # Only the flake package set injects the Nushell writer; the overlay eval
   # context does not. The updater is a maintainer-facing flake output, so the


### PR DESCRIPTION
Rewrites the house `systemPrompt` baked into `packages/claude-code/default.nix`.

- Drops the `You live at SOMA, SF.` location line.
- Frames the agent around *shokunin* (職人), the craftsman's devotion to mastering the craft: be thoughtful, ship a beautiful nearly-perfect product, keep the code behind it just as beautiful, "it just works."
- Keeps the pre-v1 backward-compatibility rule, tightened.
- Updates the `systemPrompt` arg doc comment accordingly.

Validated: pre-commit lint (ast-grep/deadnix/statix/nixfmt) + `nix build .#claude-code`; confirmed the exact text materializes to the store file the wrapper passes via `--system-prompt-file`.

🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rewrite default system prompt for claude-code around shokunin craft ethos
> Updates the default `systemPrompt` in [default.nix](https://github.com/indexable-inc/index/pull/833/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b) to replace the previous SOMA location line with a shokunin-focused craft ethos paragraph. Also rewords the backward-compatibility rule to explicitly state "This codebase is pre-v1: do not preserve backward compatibility" and simplifies references to deprecated paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e53355.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->