### PR TITLE
docs(ix): replace removed `ix switch` command with `ix up`

### DIFF
--- a/examples/nixos-switch/README.md
+++ b/examples/nixos-switch/README.md
@@ -1,6 +1,6 @@
 # NixOS switch
 
-The smallest fork-and-go example of the native `ix switch` loop: boot a NixOS VM
+The smallest fork-and-go example of the native `ix up` loop: boot a NixOS VM
 from the `ix/base` image, add a package, and watch ix rebuild and activate the
 new system on the running VM in place.
 
@@ -44,6 +44,6 @@ rights: it builds and activates your own system onto your own VM.
 
 ## Scope
 
-This builds on the target VM itself, the `ix up` / `ix switch` default. Building
+This builds on the target VM itself, the `ix up` default. Building
 on a separate per-user builder VM (`--build-vm`) is a follow-up; the same-VM
 path shown here is the native switch primitive.

--- a/examples/nixos-switch/configuration.nix
+++ b/examples/nixos-switch/configuration.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   # This is the line to edit. Add or remove packages, then run `ix up` again
-  # (or `ix switch`) and ix rebuilds the closure and activates it on the running
+  # and ix rebuilds the closure and activates it on the running
   # VM in place, the same contract as `nixos-rebuild switch`.
   #
   # This is an ordinary NixOS module: `services.*`, `users.*`, `systemd.*`, and

--- a/examples/nixos-switch/default.nix
+++ b/examples/nixos-switch/default.nix
@@ -1,6 +1,6 @@
 { index }:
 
-# A one-node NixOS fleet that exists to demonstrate the native `ix switch` loop:
+# A one-node NixOS fleet that exists to demonstrate the native `ix up` loop:
 # `ix up` builds this configuration on ix and activates it on the running VM in
 # place. Edit `configuration.nix`, run it again, and the VM converges.
 index.lib.mkFleet {

--- a/images/dev/development-base/default.nix
+++ b/images/dev/development-base/default.nix
@@ -2,7 +2,7 @@
 # The auto-enabled base profile (modules/profiles/base) supplies version
 # control, editors, the nushell workspace wrapper, gdb/lldb, strace, tcpdump,
 # jaq, btop, bpftrace, lsof, ncdu, pv, file, and the gnutar/gzip/zstd trio
-# needed to stay `ix switch`-able.
+# needed to stay `ix up`-switchable.
 {
   ix,
   lib,

--- a/lib/image/fleet.nix
+++ b/lib/image/fleet.nix
@@ -258,7 +258,7 @@ let
       replacementDestination = deploy.destination or "${imageName}:${imageTag}";
       switchBuildOn = deploy.switch.buildOn or "remote";
       ipv4HealthChecks = lib.filterAttrs (_: check: check.requiresIpv4) config.ix.healthChecks;
-      # ix switch expects a system out-path for local copy and a .drv for remote
+      # ix up expects a system out-path for local copy and a .drv for remote
       # build. Picking the wrong shape uploads the build-time closure and tries
       # to run `<drv>/bin/switch-to-configuration`, which deadlocks.
       switchTarget = deploy.switch.target or unsafeDiscardStringContext (

--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -485,7 +485,7 @@ in
           file
           gdb
           # gnutar, gzip, and zstd ride along so any VM switched once stays
-          # switchable: `ix switch --source` streams a tarball through
+          # switchable: the `ix up` source upload streams a tarball through
           # `tar -x -I zstd` inside the guest, and these binaries are not
           # on NixOS' default system PATH.
           gnutar

--- a/skills/ix/references/vms.md
+++ b/skills/ix/references/vms.md
@@ -19,10 +19,8 @@ East-west networking groups for VM-to-VM connectivity.
 
 ## NixOS
 
-`ix switch` applies a new NixOS system configuration to a running VM, the same contract as `nixos-rebuild switch`: the VM keeps running and only its system generation changes. The target is a Nix installable, a `.drv` path, or a `/nix/store` system path.
+`ix up` applies a new NixOS system configuration to a VM, the same contract as `nixos-rebuild switch`: the VM keeps running and only its system generation changes. It creates the VM from a NixOS base image (`ix/base:latest`) if it does not exist yet, then activates the freshly built system in place; re-running `ix up` converges the VM to the current configuration. The target is a Nix installable, a `.drv` path, or a `/nix/store` system path.
 
 This is native, not remote-shell puppeteering. For the default same-VM path, your source tree is uploaded to ix and the `nix build` plus `switch-to-configuration switch` run server-side on ix infrastructure; only the build/activate output streams back.
-
-`ix up` is the declarative front-end over create + switch: it creates the VM from a NixOS base image (`ix/base:latest`) if it does not exist yet, then switches it to the freshly built system. Re-running `ix up` converges the VM to the current configuration.
 
 The [`nixos-switch`](../../../examples/nixos-switch/) example is the smallest fork-and-go version of this loop: one NixOS node, one package list to edit, `ix up` to converge.


### PR DESCRIPTION
## What

Update the index SDK docs and examples to invoke `ix up` instead of the removed `ix switch` CLI command.

## Why

indexable-inc/ix#4442 folds the `ix switch` command into `ix up` and removes it (pre-v1, no compat alias). After it lands, `ix switch <vm> <target>` is no longer a valid command, so the docs/examples here that show it are stale. The example directory is even named `nixos-switch` and its prose led with "the native `ix switch` loop".

## Changes

- `skills/ix/references/vms.md`: the NixOS section documented `ix switch` verbatim as a command (and then separately described `ix up`, contradicting itself). Rewritten so `ix up` is the command, folding in the converge contract and target-shape note.
- `examples/nixos-switch/{README.md,configuration.nix,default.nix}`: prose/comments now say `ix up`.
- `modules/profiles/base/default.nix`: `ix switch --source` was doubly stale (command gone, and `ix up` has no `--source` flag, it auto-uploads); reworded to "the `ix up` source upload".
- `images/dev/development-base/default.nix`, `lib/image/fleet.nix`: operation-level comments that used the literal `ix switch` token, reworded to `ix up`.

Left as-is on purpose:
- `rfcs/0001-router-vm.html`: a point-in-time RFC; not rewriting history.
- The `nixos-switch` example directory name and `ix.image.tag = "nixos-switch"`: the switch *operation* still exists; renaming is pure churn.

No code behavior changes; docs and comments only.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace references to removed `ix switch` command with `ix up` in docs and comments
> Updates documentation and inline comments across the `nixos-switch` example, `lib/image/fleet.nix`, `modules/profiles/base`, and `skills/ix/references/vms.md` to reflect that `ix switch` has been removed and `ix up` is now the canonical command for rebuilding and activating NixOS configurations. No code logic is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea3005e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->