### PR TITLE
feat(mcp): collapse run source by default in the dashboard

### DIFF
--- a/packages/mcp/site/src/components/JobCard.svelte
+++ b/packages/mcp/site/src/components/JobCard.svelte
@@ -15,19 +15,35 @@
   const hasRich = $derived(job.outputs.length > 0);
   // Don't repeat the error if it's already in the captured stdout tail.
   const showError = $derived(!!job.error && !(job.output ?? '').includes(job.error));
+  // A run reads as its output by default: the source is one click away, not in
+  // the way. Only runs that actually carry source get a reveal toggle.
+  const hasCode = $derived(!!(job.code_html || job.code));
+  let showCode = $state(false);
 </script>
 
 <article class="job {job.status}">
-  <header class="hdr">
+  <!-- The header doubles as the source toggle: a caret on the left reveals the
+       code, the rest stays a quiet label. Inert when there is no source. -->
+  <button
+    class="hdr"
+    type="button"
+    aria-expanded={showCode}
+    disabled={!hasCode}
+    title={hasCode ? (showCode ? 'Hide source' : 'Show source') : undefined}
+    onclick={() => (showCode = !showCode)}
+  >
+    {#if hasCode}<span class="caret" aria-hidden="true">{showCode ? '▾' : '▸'}</span>{/if}
     <StatusChip status={job.status} />
     {#if title}<span class="name">{title}</span>{/if}
     <span class="dur">{elapsed}</span>
-  </header>
+  </button>
 
-  {#if job.code_html}
-    <CodeView html={job.code_html} bindings={job.bindings} />
-  {:else if job.code}
-    <pre class="code">{job.code}</pre>
+  {#if showCode}
+    {#if job.code_html}
+      <CodeView html={job.code_html} bindings={job.bindings} />
+    {:else if job.code}
+      <pre class="code">{job.code}</pre>
+    {/if}
   {/if}
 
   {#if job.output}
@@ -61,10 +77,39 @@
   .job.error {
     border-left-color: var(--err);
   }
+  /* The header is the source toggle, so it is a full-width button reset to read
+     as the plain status line it replaces. */
   .hdr {
+    appearance: none;
+    width: 100%;
     display: flex;
     gap: 9px;
     align-items: baseline;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+  .hdr:disabled {
+    cursor: default;
+  }
+  .hdr:focus-visible {
+    outline: 1px solid var(--active);
+    outline-offset: 2px;
+  }
+  .caret {
+    flex: none;
+    color: var(--faint);
+    font-size: 9px;
+    line-height: 1;
+    align-self: center;
+  }
+  .hdr:hover .caret {
+    color: var(--active);
   }
   .name {
     flex: 1 1 auto;


### PR DESCRIPTION
-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collapse run source code by default in the MCP dashboard job card
> The source code section in [JobCard.svelte](https://github.com/indexable-inc/index/pull/835/files#diff-fda0bddd25f2dbc1ad654afeaebf1aad93841277ef3e930742e260c49f11c03e) is now hidden by default and toggled via a clickable header button. The header shows a caret when source exists and sets `aria-expanded` to reflect state; it is disabled when no source is available. The code view component only mounts when expanded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3494ca9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->