### PR TITLE
feat(claude-code): disable self-driving autonomy tools fleet-wide

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -106,6 +106,14 @@ let
     # settings key would, since flagSettings outranks user settings.json).
     # Re-enable 1M per machine: `export CLAUDE_CODE_DISABLE_1M_CONTEXT=`.
     CLAUDE_CODE_DISABLE_1M_CONTEXT = 1;
+    # Self-driving autonomy off fleet-wide. Background tasks are a
+    # `run_in_background` *parameter* (no tool to disallow), so this env knob is
+    # the only lever; the cron family is also dropped via `--disallowedTools`
+    # below, with this as defense in depth. `--set-default`, so a machine opts
+    # back in with `export CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=` /
+    # `export CLAUDE_CODE_DISABLE_CRON=`.
+    CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = 1;
+    CLAUDE_CODE_DISABLE_CRON = 1;
   };
   envDefaultFlags = lib.concatLists (
     lib.mapAttrsToList (name: value: [
@@ -114,6 +122,22 @@ let
       (toString value)
     ]) wrapperEnvDefaults
   );
+
+  # Autonomy tools removed from every session: self-watching (Monitor),
+  # self-scheduling (ScheduleWakeup and the cron family), and the
+  # user-interrupting PushNotification. `--disallowedTools` drops them from the
+  # model's tool set regardless of permission mode; `permissions.deny` would not,
+  # since the default `bypassPermissions` posture skips the permission layer.
+  # Monitor and PushNotification are server-gated with no env knob, so this flag
+  # is their only off-switch.
+  disallowedAutonomyTools = [
+    "Monitor"
+    "ScheduleWakeup"
+    "PushNotification"
+    "CronCreate"
+    "CronDelete"
+    "CronList"
+  ];
 
   # Settings-key defaults that have no env knob, shipped as a JSON the wrapper
   # injects via `--settings`. The package wraps the binary, so it can carry env
@@ -367,6 +391,7 @@ stdenv.mkDerivation {
       --inherit-argv0 \
       --add-flags --debug \
       --add-flags "--thinking-display summarized" \
+      --add-flags "--disallowedTools ${lib.concatStringsSep "," disallowedAutonomyTools}" \
       --append-flags "--settings ${settingsDefaultsFile}" \
       ${lib.escapeShellArgs systemPromptWrapperArgs} \
       --set DISABLE_AUTOUPDATER 1 \


### PR DESCRIPTION
-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable autonomy tools and background tasks in `claude-code` fleet-wide
> - Adds `Monitor`, `ScheduleWakeup`, `PushNotification`, `CronCreate`, `CronDelete`, and `CronList` to a `--disallowedTools` flag passed to the wrapped binary in [default.nix](https://github.com/indexable-inc/index/pull/836/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b), removing them from the model's available toolset for all sessions.
> - Sets `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` and `CLAUDE_CODE_DISABLE_CRON=1` as default environment variables; users can opt out by overriding these to empty values.
> - Behavioral Change: all existing and new sessions lose access to scheduling and monitoring tools by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09f2f6a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->