### PR TITLE
docs(examples): nixos-switch-multi, one build VM switches many VMs

### DIFF
--- a/examples/nixos-switch-multi/README.md
+++ b/examples/nixos-switch-multi/README.md
@@ -1,0 +1,61 @@
+# NixOS switch: many VMs, one build VM
+
+Switch several NixOS VMs in a single command, building every closure on one
+shared build-time VM. This is the colmena-style "build once, push many" loop as a
+first-class `ix up`: the source uploads once, each closure builds on the warm
+builder, and the activations fan out to their VMs through regional CAS.
+
+## Run
+
+```sh
+# 1. Bring up the build VM once.
+ix up .#builder
+
+# 2. Build all three app VMs on that builder and switch each in place.
+ix up .#web .#worker .#edge --build-vm builder
+```
+
+The second command creates `web`, `worker`, and `edge` from `ix/base` if they do
+not exist, builds their closures on `builder`, and activates each on its own VM.
+Re-run it to converge them, the same contract as `nixos-rebuild switch`.
+
+## Why one build VM
+
+`builder` keeps a warm `/nix/store`, so the first closure pays the full build and
+the rest only build their own delta. The built closures travel builder to target
+through regional CAS, which deduplicates the shared system paths, so the bytes on
+the wire for `worker` and `edge` are a fraction of a full closure. You get fleet
+rebuilds without N cold builds and without routing closures through your laptop.
+
+## The loop
+
+1. Edit a configuration in [`flake.nix`](flake.nix): change a VM's package list.
+2. Run the multi-VM `ix up` again. Only the changed closures rebuild on the
+   builder; unchanged VMs are a no-op.
+3. `ix shell web -- rg --version` (or `worker -- jq`, `edge -- hello`) confirms
+   the new closure is live.
+
+## Shape
+
+- [`flake.nix`](flake.nix) declares `builder` plus the target VMs `web`,
+  `worker`, and `edge`, each a NixOS system differing only by its sentinel
+  package.
+- [`configuration.nix`](configuration.nix) is the shared NixOS module every VM
+  switches onto. It imports `virtualisation/docker-image.nix` so the system
+  evaluates against the `ix/base` image without a bootloader.
+
+## Rules
+
+- Multiple targets require `--build-vm`: one build-time VM is what makes this one
+  operation instead of N. The build VM must already exist (step 1).
+- Each target names its own configuration (`.#web`), so `--name` is not used with
+  multiple targets.
+- The builder and every target must share a region (CAS chunks are
+  region-scoped). A cross-region target is a typed error, not a silent fallback.
+- A failed target is reported on its own; its siblings still switch.
+
+## Fork it
+
+Copy this directory, add or rename configurations in `flake.nix`, and point
+`--build-vm` at your own builder VM. No admin rights are needed: you build and
+activate your own systems onto your own VMs.

--- a/examples/nixos-switch-multi/configuration.nix
+++ b/examples/nixos-switch-multi/configuration.nix
@@ -1,0 +1,27 @@
+# Switch-target NixOS module shared by every VM in this example.
+#
+# It is never booted directly: each VM boots from the `ix/base` NixOS image,
+# then `ix up` activates this closure in place, the same contract as
+# `nixos-rebuild switch`. Importing `virtualisation/docker-image.nix` lets the
+# toplevel evaluate without a real bootloader or `fileSystems`, matching how the
+# ix base image is built.
+#
+# This is an ordinary NixOS module: `services.*`, `users.*`, and `systemd.*` all
+# work here. Per-VM differences in this example come from the package list in
+# `flake.nix`; share everything else from here.
+{
+  lib,
+  modulesPath,
+  ...
+}: {
+  imports = [
+    "${modulesPath}/virtualisation/docker-image.nix"
+  ];
+
+  # docker-image.nix injects post-boot image setup that is not valid for a
+  # switch-activated system root; priority 50 matches NixOS's force level while
+  # naming the conflict.
+  boot.postBootCommands = lib.mkOverride 50 "";
+  documentation.enable = false;
+  system.stateVersion = "25.11";
+}

--- a/examples/nixos-switch-multi/configuration.nix
+++ b/examples/nixos-switch-multi/configuration.nix
@@ -9,19 +9,12 @@
 # This is an ordinary NixOS module: `services.*`, `users.*`, and `systemd.*` all
 # work here. Per-VM differences in this example come from the package list in
 # `flake.nix`; share everything else from here.
+{ modulesPath, ... }:
 {
-  lib,
-  modulesPath,
-  ...
-}: {
   imports = [
     "${modulesPath}/virtualisation/docker-image.nix"
   ];
 
-  # docker-image.nix injects post-boot image setup that is not valid for a
-  # switch-activated system root; priority 50 matches NixOS's force level while
-  # naming the conflict.
-  boot.postBootCommands = lib.mkOverride 50 "";
   documentation.enable = false;
   system.stateVersion = "25.11";
 }

--- a/examples/nixos-switch-multi/flake.lock
+++ b/examples/nixos-switch-multi/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780511130,
+        "narHash": "sha256-2v9lT4ya59Lh1FqPeLnz1MoX9y/wz2huqfe9RtQZITk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "535f3e6942cb1cead3929c604320d3db54b542b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/nixos-switch-multi/flake.nix
+++ b/examples/nixos-switch-multi/flake.nix
@@ -3,33 +3,42 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
 
-  outputs = {nixpkgs, ...}: let
-    # ix VMs are x86_64-linux, and the build runs in the builder VM's guest, so
-    # the target system is fixed rather than discovered from the host.
-    system = "x86_64-linux";
+  outputs =
+    { nixpkgs, ... }:
+    let
+      # ix VMs are x86_64-linux, and the build runs in the builder VM's guest, so
+      # the target system is fixed rather than discovered from the host.
+      system = "x86_64-linux";
 
-    # Each configuration is a normal NixOS system that differs only by a sentinel
-    # package, so a switch onto it moves `/run/current-system` to a new store
-    # path you can observe with `command -v <tool>`.
-    mkSystem = packages:
-      nixpkgs.lib.nixosSystem {
-        inherit system;
-        modules = [
-          ./configuration.nix
-          ({pkgs, ...}: {environment.systemPackages = packages pkgs;})
-        ];
+      # Each configuration is a normal NixOS system that differs only by a sentinel
+      # package, so a switch onto it moves `/run/current-system` to a new store
+      # path you can observe with `command -v <tool>`.
+      mkSystem =
+        packages:
+        nixpkgs.lib.nixosSystem {
+          inherit system;
+          modules = [
+            ./configuration.nix
+            (
+              { pkgs, ... }:
+              {
+                environment.systemPackages = packages pkgs;
+              }
+            )
+          ];
+        };
+    in
+    {
+      nixosConfigurations = {
+        # The shared build VM. It only needs Nix (every NixOS system has the
+        # daemon), so it carries no sentinel; `ix up .#builder` brings it up once.
+        builder = mkSystem (_: [ ]);
+
+        # The target VMs. `ix up .#web .#worker .#edge --build-vm builder` builds
+        # all three closures on `builder` and activates each on its own VM.
+        web = mkSystem (pkgs: [ pkgs.ripgrep ]);
+        worker = mkSystem (pkgs: [ pkgs.jq ]);
+        edge = mkSystem (pkgs: [ pkgs.hello ]);
       };
-  in {
-    nixosConfigurations = {
-      # The shared build VM. It only needs Nix (every NixOS system has the
-      # daemon), so it carries no sentinel; `ix up .#builder` brings it up once.
-      builder = mkSystem (_: []);
-
-      # The target VMs. `ix up .#web .#worker .#edge --build-vm builder` builds
-      # all three closures on `builder` and activates each on its own VM.
-      web = mkSystem (pkgs: [pkgs.ripgrep]);
-      worker = mkSystem (pkgs: [pkgs.jq]);
-      edge = mkSystem (pkgs: [pkgs.hello]);
     };
-  };
 }

--- a/examples/nixos-switch-multi/flake.nix
+++ b/examples/nixos-switch-multi/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "ix up multi-VM switch: one build VM, several NixOS VMs switched in one command";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+
+  outputs = {nixpkgs, ...}: let
+    # ix VMs are x86_64-linux, and the build runs in the builder VM's guest, so
+    # the target system is fixed rather than discovered from the host.
+    system = "x86_64-linux";
+
+    # Each configuration is a normal NixOS system that differs only by a sentinel
+    # package, so a switch onto it moves `/run/current-system` to a new store
+    # path you can observe with `command -v <tool>`.
+    mkSystem = packages:
+      nixpkgs.lib.nixosSystem {
+        inherit system;
+        modules = [
+          ./configuration.nix
+          ({pkgs, ...}: {environment.systemPackages = packages pkgs;})
+        ];
+      };
+  in {
+    nixosConfigurations = {
+      # The shared build VM. It only needs Nix (every NixOS system has the
+      # daemon), so it carries no sentinel; `ix up .#builder` brings it up once.
+      builder = mkSystem (_: []);
+
+      # The target VMs. `ix up .#web .#worker .#edge --build-vm builder` builds
+      # all three closures on `builder` and activates each on its own VM.
+      web = mkSystem (pkgs: [pkgs.ripgrep]);
+      worker = mkSystem (pkgs: [pkgs.jq]);
+      edge = mkSystem (pkgs: [pkgs.hello]);
+    };
+  };
+}

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -251,6 +251,7 @@ async def run_cli(
     *,
     dry_run: bool,
     timeout: int | None = None,
+    cwd: Path | None = None,
 ) -> str:
     step("+ " + " ".join(command))
     if dry_run:
@@ -260,6 +261,7 @@ async def run_cli(
         *command,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        cwd=str(cwd) if cwd is not None else None,
     )
     assert process.stdout is not None
     assert process.stderr is not None
@@ -653,27 +655,35 @@ async def switch_node_from_source(
     *,
     dry_run: bool,
 ) -> None:
+    # `ix switch` was folded into `ix up` (indexable-inc/ix#4442): `ix up
+    # <installable> --name <vm>` is the converge path. `ix up` auto-uploads its
+    # working directory as the build source, so run it from `source_root` instead
+    # of passing the removed `--source`; `--workdir` selects the eval subdir
+    # relative to that root.
+    workdir = source_workdir
+    if workdir.is_absolute():
+        try:
+            workdir = workdir.relative_to(source_root)
+        except ValueError:
+            pass
     command = [
         "ix",
-        "switch",
-        node.name,
+        "up",
         node.switch.sourceInstallable,
-        "--build-on",
-        "remote",
-        "--source",
-        str(source_root),
-        "--source-workdir",
-        str(source_workdir),
+        "--name",
+        node.name,
+        "--workdir",
+        str(workdir),
     ]
     if node.switch.buildVm is not None:
         command.extend(["--build-vm", node.switch.buildVm])
     for name, path in sorted(node.switch.overrideInputs.items()):
-        command.extend(["--override-input", name, path])
+        command.extend(["--override-input", f"{name}={path}"])
 
     for attempt in range(1, MAX_SWITCH_RETRIES + 1):
         try:
             step(f"switching {node.name} from source (attempt {attempt}/{MAX_SWITCH_RETRIES})")
-            await run_cli(command, dry_run=dry_run, timeout=3600)
+            await run_cli(command, dry_run=dry_run, timeout=3600, cwd=source_root)
             return
         except (CliError, CliTimeoutError) as e:
             error_msg = e.output or str(e)

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -665,7 +665,12 @@ async def switch_node_from_source(
         try:
             workdir = workdir.relative_to(source_root)
         except ValueError:
-            pass
+            # `ix up --workdir` is resolved relative to the uploaded source root,
+            # so an absolute workdir outside that root has no valid mapping.
+            # Reject it instead of forwarding a path `ix up` cannot interpret.
+            raise ValueError(
+                f"source workdir {source_workdir} is outside source root {source_root}"
+            ) from None
     command = [
         "ix",
         "up",

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -600,8 +600,13 @@ class DownTests(unittest.TestCase):
 
 
 class SwitchSourceTests(unittest.TestCase):
-    def test_override_inputs_are_separate_nix_flag_arguments(self) -> None:
+    def test_source_switch_runs_ix_up_from_source_root(self) -> None:
+        # `ix switch` was folded into `ix up` (indexable-inc/ix#4442): the source
+        # switch now runs `ix up <installable> --name <vm>` from the source root
+        # (which `ix up` auto-uploads), with `--workdir` relative to that root and
+        # `--override-input NAME=VALUE` single-token flags.
         calls: list[list[str]] = []
+        cwds: list[Path | None] = []
         node_data = fleet_node("api")
         node_data["switch"]["buildVm"] = "builder"
         node_data["switch"]["overrideInputs"] = {
@@ -610,10 +615,17 @@ class SwitchSourceTests(unittest.TestCase):
         }
         node = ix_fleet.FleetNode.model_validate(node_data)
 
-        async def fake_run_cli(command: list[str], *, dry_run: bool, timeout: int | None = None) -> str:
+        async def fake_run_cli(
+            command: list[str],
+            *,
+            dry_run: bool,
+            timeout: int | None = None,
+            cwd: Path | None = None,
+        ) -> str:
             del timeout
             self.assertFalse(dry_run)
             calls.append(command)
+            cwds.append(cwd)
             return ""
 
         with patch.object(ix_fleet, "run_cli", fake_run_cli):
@@ -631,26 +643,22 @@ class SwitchSourceTests(unittest.TestCase):
             [
                 [
                     "ix",
-                    "switch",
-                    "api",
+                    "up",
                     ".#api",
-                    "--build-on",
-                    "remote",
-                    "--source",
-                    "/source",
-                    "--source-workdir",
-                    "/source/subdir",
+                    "--name",
+                    "api",
+                    "--workdir",
+                    "subdir",
                     "--build-vm",
                     "builder",
                     "--override-input",
-                    "ix",
-                    "github:indexable-inc/ix",
+                    "ix=github:indexable-inc/ix",
                     "--override-input",
-                    "ix-images",
-                    "path:/workspace/index",
+                    "ix-images=path:/workspace/index",
                 ],
             ],
         )
+        self.assertEqual(cwds, [Path("/source")])
 
 
 def argparse_namespace(**kwargs: typing.Any) -> typing.Any:

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -660,6 +660,27 @@ class SwitchSourceTests(unittest.TestCase):
         )
         self.assertEqual(cwds, [Path("/source")])
 
+    def test_source_switch_rejects_workdir_outside_source_root(self) -> None:
+        # `--workdir` is resolved relative to the uploaded source root, so an
+        # absolute workdir outside that root has no valid mapping and must fail
+        # loudly rather than forwarding a path `ix up` cannot interpret.
+        node = ix_fleet.FleetNode.model_validate(fleet_node("api"))
+
+        async def fail_run_cli(*args: typing.Any, **kwargs: typing.Any) -> str:
+            del args, kwargs
+            raise AssertionError("run_cli should not be reached")
+
+        with patch.object(ix_fleet, "run_cli", fail_run_cli):
+            with self.assertRaises(ValueError):
+                asyncio.run(
+                    ix_fleet.switch_node_from_source(
+                        node,
+                        Path("/source"),
+                        Path("/elsewhere/subdir"),
+                        dry_run=False,
+                    )
+                )
+
 
 def argparse_namespace(**kwargs: typing.Any) -> typing.Any:
     return type("Args", (), kwargs)()


### PR DESCRIPTION
## What

Two things for the multi-VM `ix up` work (ENG-2248):

### 1. Standalone example: `examples/nixos-switch-multi/`

```sh
ix up .#builder                                  # one-time: the build VM
ix up .#web .#worker .#edge --build-vm builder   # build all three on it, switch each
```

- `flake.nix` declares `builder` plus targets `web`/`worker`/`edge`, each a NixOS system differing only by a sentinel package so each switch is observable.
- `configuration.nix` is the shared module (imports `virtualisation/docker-image.nix` for `ix/base` compatibility, the pattern the ix `switch-fixture` uses).
- `flake.lock` pins nixpkgs; verified the toplevels evaluate. Raw-flake example (no `default.nix`), so `exampleFleetsFor` discovery skips it.

Depends on the ix CLI change (indexable-inc/ix#4443) that makes `ix up` variadic.

### 2. Fix: `ix-fleet` no longer calls the removed `ix switch` (Closes ENG-2270)

indexable-inc/ix#4442 folded `ix switch` into `ix up`, so the fleet's per-node source switch (`switch_node_from_source`) was shelling out to a removed command. Converted to `ix up <installable> --name <node>`:

- `ix up` auto-uploads its working directory, so it now runs with `cwd=source_root` (new `run_cli(cwd=...)` param) instead of the removed `--source`.
- `--source-workdir` -> `--workdir` (relative to source root); `--override-input` -> single-token `NAME=VALUE`; `--build-vm` unchanged.
- The target-based path (`switch_node`) already drives the SDK directly and is untouched. Source-switch test updated to the new command shape and passes.

Relates to ENG-2248.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `nixos-switch-multi` example and switch `ix-fleet` source switching to `ix up`
> - Adds the [`nixos-switch-multi`](https://github.com/indexable-inc/index/pull/837/files#diff-456f6f2351379872e2eb0d9738d9d1f315605da7db3bafcb36d937db1b1c8c24) example, which demonstrates switching multiple NixOS VMs (web, worker, edge) from a single shared build VM using `ix up`.
> - Reworks [`switch_node_from_source`](https://github.com/indexable-inc/index/pull/837/files#diff-d83777ed2e90ee1f7371ffa0e55fe375c817b07e2cb2a15a5b58423ad93dae3e) to invoke `ix up <installable> --name <vm> --workdir <rel>` instead of `ix switch`, running from `source_root` as the working directory; override inputs are now formatted as single-token `--override-input NAME=VALUE` flags.
> - Adds a `cwd` parameter to `run_cli` so commands can be executed from an arbitrary working directory.
> - An absolute `workdir` outside `source_root` now raises `ValueError` instead of proceeding silently.
> - Behavioral Change: source-based switch commands that previously used `--build-on`, `--source`, and `--source-workdir` flags now use a different CLI interface; any callers relying on the old flags will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3914e23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->