### PR TITLE
Add pi-harness: Pi engine with built-ins absent + ix-mcp bridge (ENG-2262)

### DIFF
--- a/packages/pi-harness/README.md
+++ b/packages/pi-harness/README.md
@@ -1,0 +1,83 @@
+# pi-harness
+
+The Index-side Pi engine harness (ENG-2262). It runs [Pi](https://pi.dev) as a
+Room-facing engine with **the built-in tools absent**, exposing **only** the
+`ix-mcp` tool surface, selecting the model declaratively, and emitting a
+machine-readable JSON event stream. This is the Pi equivalent of the Claude
+"tools removed" posture in `packages/claude-code` (`restrictToTools`), and it is
+the first task in the ENG-2261 "Pi Room integration" stack.
+
+## What it is
+
+A declarative wrapper around `pi` plus one bridge extension. You import the
+package, you get a `pi-harness` command that launches Pi already locked down.
+
+```
+pi-harness "your prompt"                 # claude (opus-4-8), JSON event stream
+PI_HARNESS_MODEL=codex pi-harness "..."  # gpt-5.5 via OpenAI
+```
+
+## How the lockdown works
+
+| Concern | Mechanism |
+| --- | --- |
+| Built-ins absent (not denied) | `pi --no-builtin-tools` - bash/read/write/edit never enter the model's context |
+| No accidental tools | `--no-extensions --no-skills` (the bridge still loads via explicit `-e`) |
+| Only tool surface | `extension/ix-mcp-bridge.ts` runs `ix-mcp serve` over stdio and re-exposes its tools (`python_exec`, `search_*`, `calendar_*`) via `pi.registerTool` |
+| Minimal context | `--system-prompt` defaults to a one-line controlled prompt; override with `PI_HARNESS_SYSTEM_PROMPT` |
+| Machine-readable stream | `--mode json` (default); `PI_HARNESS_MODE=text` for interactive dev |
+| Model selection | `models.nix` table → `--provider`/`--model` |
+| API keys | Read by Pi from the env the caller provides (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`); never looked up here |
+
+## Design decisions (the ticket's open questions)
+
+- **Pi SDK vs CLI** → CLI subprocess in `--mode json`. Clean OS process boundary
+  Room can spawn or call; headless-testable; no Node embedding. The SDK
+  (`@earendil-works/pi-coding-agent`) stays a later option.
+- **Guaranteeing built-ins are absent** → `--no-builtin-tools` makes them absent,
+  not merely denied. The smoke test asserts no `bash`/`read`/`write`/`edit` tool
+  appears in the stream.
+- **Model/key ownership** → the harness owns model *selection* (`models.nix`);
+  the caller owns *keys* (env), matching the ENG-2261 secret-store plan.
+- **Session** → `--no-session` (ephemeral per turn) for this first cut. A
+  persistent per-conversation `--session <path>` is the durability follow-up
+  (ENG-2264).
+
+## Event stream → Room
+
+Pi's `--mode json` emits its own event names. The Room-facing names the parent
+ticket wants are produced by a thin mapping layer (this is the harness's core
+value):
+
+| Pi event | Room event |
+| --- | --- |
+| `turn_start` | `turn_started` |
+| `message_update` (`assistantMessageEvent.type=text_delta`) | `text_delta` |
+| reasoning/thinking delta | `reasoning_delta` |
+| `tool_execution_start` | `tool_call_started` |
+| `tool_execution_update` / `_end` | `tool_call_output` |
+| `tool_execution_*` for `python_exec` rich outputs / live resources | `cell_update` / `resource_update` |
+| message/turn usage | `usage` |
+| `turn_end` | `turn_completed` |
+| error events | `error` |
+
+This first cut emits Pi's native JSON; the mapper and the `cell_update` /
+`resource_update` detail land with ENG-2263.
+
+## Validation
+
+`smoke/run.sh` builds `ix-mcp`, resolves the bridge deps, runs one prompt, and
+asserts: built-ins absent, `python_exec` exposed, JSON turn events emitted. It
+needs network + an API key, so run it yourself:
+
+```
+ANTHROPIC_API_KEY=... ./packages/pi-harness/smoke/run.sh
+```
+
+## Follow-ups (intentionally deferred)
+
+- Package `pi` as a pinned nix dependency (dependency-intake) and wire it +
+  `ix-mcp` into `default.nix` `runtimeInputs` instead of relying on PATH.
+- Make the bridge's `node_modules` pure via `buildNpmPackage` (today the smoke
+  runs `npm install`).
+- Add the Pi→Room event mapper (ENG-2263).

--- a/packages/pi-harness/README.md
+++ b/packages/pi-harness/README.md
@@ -66,18 +66,22 @@ This first cut emits Pi's native JSON; the mapper and the `cell_update` /
 
 ## Validation
 
-`smoke/run.sh` builds `ix-mcp`, resolves the bridge deps, runs one prompt, and
-asserts: built-ins absent, `python_exec` exposed, JSON turn events emitted. It
-needs network + an API key, so run it yourself:
+`smoke/run.sh` builds `ix-mcp`, builds `.#pi-harness`, runs one prompt through
+the **shipped** `bin/pi-harness`, and asserts: built-ins absent, `python_exec`
+exposed, JSON turn events emitted. It needs network + an API key, so run it
+yourself:
 
 ```
 ANTHROPIC_API_KEY=... ./packages/pi-harness/smoke/run.sh
 ```
 
+The bridge is packaged with `buildNpmPackage`, so the store extension ships its
+`node_modules` and Pi resolves `@modelcontextprotocol/sdk` at runtime. Refresh
+the pinned dep hash after changing `package-lock.json` with
+`nix run nixpkgs#prefetch-npm-deps -- extension/package-lock.json`.
+
 ## Follow-ups (intentionally deferred)
 
 - Package `pi` as a pinned nix dependency (dependency-intake) and wire it +
   `ix-mcp` into `default.nix` `runtimeInputs` instead of relying on PATH.
-- Make the bridge's `node_modules` pure via `buildNpmPackage` (today the smoke
-  runs `npm install`).
 - Add the Pi→Room event mapper (ENG-2263).

--- a/packages/pi-harness/default.nix
+++ b/packages/pi-harness/default.nix
@@ -1,69 +1,80 @@
 {
   lib,
-  writeShellApplication,
+  writeNushellApplication,
   # Pi is not yet packaged in this repo. Until the dependency-intake follow-up
-  # lands a pinned `pi` derivation, pass null and the wrapper uses `pi` from PATH
-  # (the dev image / system already provides it). Pass a derivation to pin it.
+  # lands a pinned `pi` derivation, the wrapper calls `pi` from PATH (the dev
+  # image / system already provides it). Pass a derivation here to pin it.
   pi ? null,
-  # ix-mcp supplies the ONLY tool surface (python_exec + search_* + calendar_*).
-  # Built from index/packages/mcp. Pass null to fall back to PATH for local dev.
+  # ix-mcp supplies the ONLY tool surface (python_exec + search_* + calendar_*),
+  # built from index/packages/mcp. Pass null to fall back to PATH for local dev.
   ix-mcp ? null,
 }:
 let
   models = import ./models.nix;
   defaultModel = "claude";
 
-  # Generate the provider/model lookup as a bash case from the declarative table,
-  # so models.nix stays the single source of truth.
-  modelCase = lib.concatStringsSep "\n" (
+  # Render the declarative model table (models.nix) as a Nushell record literal,
+  # so models.nix stays the single source of truth for provider/model selection.
+  modelTable = lib.concatStringsSep ", " (
     lib.mapAttrsToList (
-      alias: m: "    ${alias}) provider=${m.provider}; model=${m.model} ;;"
+      alias: m: ''"${alias}": { provider: "${m.provider}", model: "${m.model}" }''
     ) models
   );
 
+  # The bridge source travels with the wrapper; Pi loads it with --extension.
+  # Drop node_modules/_probe so the store copy is reproducible (CI has neither;
+  # making the deps pure via buildNpmPackage is a follow-up).
+  extension = lib.cleanSourceWith {
+    src = ./extension;
+    filter =
+      path: _type:
+      let
+        name = baseNameOf path;
+      in
+      name != "node_modules" && name != "_probe";
+  };
+
   runtimeInputs = lib.optional (pi != null) pi ++ lib.optional (ix-mcp != null) ix-mcp;
 in
-writeShellApplication {
+writeNushellApplication {
   name = "pi-harness";
   inherit runtimeInputs;
-  # The bridge extension source travels with the wrapper; Pi loads it with -e.
-  # node_modules for @modelcontextprotocol/sdk are resolved at dev time today
-  # (see smoke/run.sh); making that pure via buildNpmPackage is a follow-up.
   text = ''
-    # Pi engine harness (ENG-2262): launch Pi as a Room-facing engine with the
+    # Pi engine harness (ENG-2262): run Pi as a Room-facing engine with the
     # built-in tools ABSENT (--no-builtin-tools), exposing only the ix-mcp tool
-    # surface through the bridge extension, and emitting a machine-readable JSON
-    # event stream. Model selection is declarative (models.nix); API keys come
-    # from the environment the caller hands us, never looked up here.
+    # surface via the bridge extension, and emitting a JSON event stream. Model
+    # selection is declarative (models.nix); API keys come from the caller's
+    # environment, never looked up here.
+    def main [...rest] {
+      let alias = ($env.PI_HARNESS_MODEL? | default "${defaultModel}")
+      let table = { ${modelTable} }
+      let cfg = ($table | get --ignore-errors $alias)
+      if ($cfg == null) {
+        print --stderr $"pi-harness: unknown model alias '($alias)'"
+        exit 2
+      }
 
-    model_alias="''${PI_HARNESS_MODEL:-${defaultModel}}"
-    provider=""
-    model=""
-    case "$model_alias" in
-${modelCase}
-      *) echo "pi-harness: unknown model alias '$model_alias'" >&2; exit 2 ;;
-    esac
+      # Minimal, controlled system prompt by default - no accidental repo-wide
+      # instructions. Override with PI_HARNESS_SYSTEM_PROMPT for a richer agent.
+      let system_prompt = (
+        $env.PI_HARNESS_SYSTEM_PROMPT?
+        | default "You are a coding agent. All actions - shell, file IO, HTTP - run through the python_exec tool on a shared Python kernel."
+      )
 
-    # Minimal, controlled system prompt by default - no accidental repo-wide
-    # instructions. Override with PI_HARNESS_SYSTEM_PROMPT for a richer agent.
-    system_prompt="''${PI_HARNESS_SYSTEM_PROMPT:-You are a coding agent. All actions - shell, file IO, HTTP - run through the python_exec tool on a shared Python kernel.}"
+      # --mode json: stable JSON event stream for Room (default). text/rpc are
+      # available via PI_HARNESS_MODE for interactive dev.
+      let mode = ($env.PI_HARNESS_MODE? | default "json")
 
-    # --mode json: stable JSON event stream for Room (default). text/rpc available
-    # via PI_HARNESS_MODE for interactive dev.
-    mode="''${PI_HARNESS_MODE:-json}"
-
-    exec pi \
-      --no-builtin-tools \
-      --no-extensions \
-      --no-skills \
-      --no-session \
-      --mode "$mode" \
-      --print \
-      --provider "$provider" \
-      --model "$model" \
-      --system-prompt "$system_prompt" \
-      -e ${./extension}/ix-mcp-bridge.ts \
-      "$@"
+      (
+        ^pi
+        --no-builtin-tools --no-extensions --no-skills --no-session
+        --mode $mode --print
+        --provider $cfg.provider --model $cfg.model
+        --system-prompt $system_prompt
+        --extension ${extension}/ix-mcp-bridge.ts
+        ...$rest
+      )
+    }
   '';
 
   meta = {

--- a/packages/pi-harness/default.nix
+++ b/packages/pi-harness/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   writeNushellApplication,
+  buildNpmPackage,
   # Pi is not yet packaged in this repo. Until the dependency-intake follow-up
   # lands a pinned `pi` derivation, the wrapper calls `pi` from PATH (the dev
   # image / system already provides it). Pass a derivation here to pin it.
@@ -21,16 +22,35 @@ let
     ) models
   );
 
-  # The bridge source travels with the wrapper; Pi loads it with --extension.
-  # Name exactly the files the build needs (the manifests are for the future
-  # buildNpmPackage follow-up), so node_modules/_probe never enter the closure.
-  extension = lib.fileset.toSource {
+  # Name exactly the files the build needs, so node_modules/_probe never enter
+  # the source closure.
+  extensionSrc = lib.fileset.toSource {
     root = ./extension;
     fileset = lib.fileset.unions [
       (./extension + "/ix-mcp-bridge.ts")
       (./extension + "/package.json")
       (./extension + "/package-lock.json")
     ];
+  };
+
+  # Build the bridge WITH its npm deps so the shipped extension actually loads:
+  # Pi resolves `@modelcontextprotocol/sdk` from node_modules next to the .ts,
+  # the same layout proven to work end-to-end. npmDepsHash pins the dep closure;
+  # refresh it with `nix run nixpkgs#prefetch-npm-deps -- extension/package-lock.json`.
+  extension = buildNpmPackage {
+    pname = "ix-mcp-bridge";
+    version = "0.1.0";
+    src = extensionSrc;
+    npmDepsHash = "sha256-Nis7wQLp7wASaEu4n/Cp3pthB3z+9FsTJs5pK3oq77M=";
+    # No build script: install the source plus production node_modules verbatim.
+    dontNpmBuild = true;
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp ix-mcp-bridge.ts package.json $out/
+      cp -r node_modules $out/node_modules
+      runHook postInstall
+    '';
   };
 
   runtimeInputs = lib.optional (pi != null) pi ++ lib.optional (ix-mcp != null) ix-mcp;

--- a/packages/pi-harness/default.nix
+++ b/packages/pi-harness/default.nix
@@ -22,16 +22,15 @@ let
   );
 
   # The bridge source travels with the wrapper; Pi loads it with --extension.
-  # Drop node_modules/_probe so the store copy is reproducible (CI has neither;
-  # making the deps pure via buildNpmPackage is a follow-up).
-  extension = lib.cleanSourceWith {
-    src = ./extension;
-    filter =
-      path: _type:
-      let
-        name = baseNameOf path;
-      in
-      name != "node_modules" && name != "_probe";
+  # Name exactly the files the build needs (the manifests are for the future
+  # buildNpmPackage follow-up), so node_modules/_probe never enter the closure.
+  extension = lib.fileset.toSource {
+    root = ./extension;
+    fileset = lib.fileset.unions [
+      (./extension + "/ix-mcp-bridge.ts")
+      (./extension + "/package.json")
+      (./extension + "/package-lock.json")
+    ];
   };
 
   runtimeInputs = lib.optional (pi != null) pi ++ lib.optional (ix-mcp != null) ix-mcp;

--- a/packages/pi-harness/default.nix
+++ b/packages/pi-harness/default.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  writeShellApplication,
+  # Pi is not yet packaged in this repo. Until the dependency-intake follow-up
+  # lands a pinned `pi` derivation, pass null and the wrapper uses `pi` from PATH
+  # (the dev image / system already provides it). Pass a derivation to pin it.
+  pi ? null,
+  # ix-mcp supplies the ONLY tool surface (python_exec + search_* + calendar_*).
+  # Built from index/packages/mcp. Pass null to fall back to PATH for local dev.
+  ix-mcp ? null,
+}:
+let
+  models = import ./models.nix;
+  defaultModel = "claude";
+
+  # Generate the provider/model lookup as a bash case from the declarative table,
+  # so models.nix stays the single source of truth.
+  modelCase = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (
+      alias: m: "    ${alias}) provider=${m.provider}; model=${m.model} ;;"
+    ) models
+  );
+
+  runtimeInputs = lib.optional (pi != null) pi ++ lib.optional (ix-mcp != null) ix-mcp;
+in
+writeShellApplication {
+  name = "pi-harness";
+  inherit runtimeInputs;
+  # The bridge extension source travels with the wrapper; Pi loads it with -e.
+  # node_modules for @modelcontextprotocol/sdk are resolved at dev time today
+  # (see smoke/run.sh); making that pure via buildNpmPackage is a follow-up.
+  text = ''
+    # Pi engine harness (ENG-2262): launch Pi as a Room-facing engine with the
+    # built-in tools ABSENT (--no-builtin-tools), exposing only the ix-mcp tool
+    # surface through the bridge extension, and emitting a machine-readable JSON
+    # event stream. Model selection is declarative (models.nix); API keys come
+    # from the environment the caller hands us, never looked up here.
+
+    model_alias="''${PI_HARNESS_MODEL:-${defaultModel}}"
+    provider=""
+    model=""
+    case "$model_alias" in
+${modelCase}
+      *) echo "pi-harness: unknown model alias '$model_alias'" >&2; exit 2 ;;
+    esac
+
+    # Minimal, controlled system prompt by default - no accidental repo-wide
+    # instructions. Override with PI_HARNESS_SYSTEM_PROMPT for a richer agent.
+    system_prompt="''${PI_HARNESS_SYSTEM_PROMPT:-You are a coding agent. All actions - shell, file IO, HTTP - run through the python_exec tool on a shared Python kernel.}"
+
+    # --mode json: stable JSON event stream for Room (default). text/rpc available
+    # via PI_HARNESS_MODE for interactive dev.
+    mode="''${PI_HARNESS_MODE:-json}"
+
+    exec pi \
+      --no-builtin-tools \
+      --no-extensions \
+      --no-skills \
+      --no-session \
+      --mode "$mode" \
+      --print \
+      --provider "$provider" \
+      --model "$model" \
+      --system-prompt "$system_prompt" \
+      -e ${./extension}/ix-mcp-bridge.ts \
+      "$@"
+  '';
+
+  meta = {
+    description = "Pi engine harness: Pi with built-in tools absent, exposing only the ix-mcp surface, emitting a JSON event stream for Room";
+    mainProgram = "pi-harness";
+  };
+}

--- a/packages/pi-harness/extension/.gitignore
+++ b/packages/pi-harness/extension/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+_probe/

--- a/packages/pi-harness/extension/ix-mcp-bridge.ts
+++ b/packages/pi-harness/extension/ix-mcp-bridge.ts
@@ -1,0 +1,52 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+// Bridge the ix-mcp Python-execution MCP server into Pi as native tools.
+//
+// Pi ships no built-in MCP client, so we run `ix-mcp serve` over stdio, list its
+// tools once at startup, and re-expose each through pi.registerTool. The harness
+// launches Pi with --no-builtin-tools, so these bridged tools are the ONLY tools
+// the model sees: shell, file IO and HTTP all happen inside the shared IPython
+// kernel via `python_exec`. This reproduces the Claude `restrictToTools` posture
+// (index/packages/claude-code/default.nix) on Pi, except Pi makes the built-ins
+// genuinely absent rather than merely denied.
+//
+// Each Pi run spawns its own `ix-mcp serve`, so it gets its own kernel. Shared
+// hc2 kernels are a later ticket (ENG-2264).
+export default async function (pi: ExtensionAPI): Promise<void> {
+  // The harness puts ix-mcp on PATH; IX_MCP_BIN lets the smoke test point at a
+  // freshly nix-built binary without a PATH dance.
+  const command = process.env.IX_MCP_BIN ?? "ix-mcp";
+
+  const client = new Client({ name: "ix-mcp-bridge", version: "0.1.0" });
+  await client.connect(new StdioClientTransport({ command, args: ["serve"] }));
+
+  const { tools } = await client.listTools();
+  for (const tool of tools) {
+    pi.registerTool({
+      name: tool.name,
+      description: tool.description ?? "",
+      // MCP inputSchema is JSON Schema; Pi accepts a JSON-Schema-shaped object
+      // for `parameters` (Typebox schemas are JSON Schema at runtime), so the
+      // MCP schema passes through unchanged.
+      parameters: tool.inputSchema as never,
+      async execute(_toolCallId, params) {
+        const result = await client.callTool({
+          name: tool.name,
+          arguments: params as Record<string, unknown>,
+        });
+        // MCP content blocks line up 1:1 with Pi tool-result content blocks.
+        return {
+          content: (result.content ?? []) as never,
+          details: { isError: result.isError ?? false },
+        };
+      },
+    });
+  }
+
+  // One ix-mcp (and one kernel) per Pi run: tear it down with the session.
+  pi.on("session_shutdown", async () => {
+    await client.close();
+  });
+}

--- a/packages/pi-harness/extension/package-lock.json
+++ b/packages/pi-harness/extension/package-lock.json
@@ -1,0 +1,1155 @@
+{
+  "name": "ix-mcp-bridge",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ix-mcp-bridge",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/packages/pi-harness/extension/package.json
+++ b/packages/pi-harness/extension/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ix-mcp-bridge",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Bridge the ix-mcp Python-execution MCP server into Pi as native tools",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  }
+}

--- a/packages/pi-harness/models.nix
+++ b/packages/pi-harness/models.nix
@@ -1,0 +1,25 @@
+# Declarative model table for the Pi harness.
+#
+# Each alias maps to the Pi provider name and model id passed straight through to
+# `pi --provider <provider> --model <model>`. API keys are NOT stored here: the
+# harness receives them from the caller's environment (Room / deploy injects them
+# from the ix secret-store per ENG-2261), and Pi reads the named env var itself.
+# This keeps the runtime pure - it owns model selection, not secret lookup.
+{
+  # Claude Opus 4.8 via the Anthropic API. On 4.8 adaptive thinking is the only
+  # thinking mode and temperature/top_p/budget_tokens are rejected, so the
+  # harness never passes sampling params.
+  claude = {
+    provider = "anthropic";
+    model = "claude-opus-4-8";
+    apiKeyEnv = "ANTHROPIC_API_KEY";
+  };
+
+  # GPT-5.5 (the model behind Codex) via the OpenAI API. `gpt-5.5` is the API
+  # model id - there is no separate `-codex` suffix on the API surface.
+  codex = {
+    provider = "openai";
+    model = "gpt-5.5";
+    apiKeyEnv = "OPENAI_API_KEY";
+  };
+}

--- a/packages/pi-harness/package.nix
+++ b/packages/pi-harness/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "pi-harness";
+  packageSet = true;
+  flake = true;
+}

--- a/packages/pi-harness/smoke/run.sh
+++ b/packages/pi-harness/smoke/run.sh
@@ -1,48 +1,44 @@
 #!/usr/bin/env bash
 # Local smoke + negative check for the Pi harness (ENG-2262 validation).
 #
+# Runs the SHIPPED artifact - builds `.#pi-harness` and runs its `bin/pi-harness`
+# - so it exercises the generated Nushell wrapper, the model-alias table, and the
+# Nix-packaged bridge (with its bundled node_modules), not a hand-rolled pi call.
+#
 # Proves three things from the ticket without Room:
-#   1. one prompt runs through the harness,
-#   2. the model has NO built-in bash/read/write/edit tools (they are absent,
-#      not denied), only the ix-mcp surface,
+#   1. one prompt runs through the packaged harness,
+#   2. the model has NO built-in bash/read/write/edit tools (absent, not denied),
+#      only the ix-mcp surface,
 #   3. the turn produces a stable JSON event stream.
 #
 # Needs network + an API key for the selected model (ANTHROPIC_API_KEY by
-# default). Run it yourself - it can exceed a couple of minutes on first build.
+# default; set PI_HARNESS_MODEL=codex + OPENAI_API_KEY for gpt-5.5). `pi` must be
+# on PATH. Run it yourself - first build can exceed a couple of minutes.
 #
 #   ANTHROPIC_API_KEY=... ./packages/pi-harness/smoke/run.sh
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-pkg="$(dirname "$here")"
-repo_root="$(cd "$pkg/../.." && pwd)"
+repo_root="$(cd "$here/../../.." && pwd)"
 
 # 1. Build ix-mcp and expose it to the bridge (it spawns `ix-mcp serve`).
 echo "[smoke] building ix-mcp..." >&2
-mcp_out="$(nix build "$repo_root#mcp" --no-link --print-out-paths)"
+mcp_out="$(nix build "$repo_root#mcp" --no-link --print-out-paths --accept-flake-config)"
 export IX_MCP_BIN="$mcp_out/bin/ix-mcp"
 [ -x "$IX_MCP_BIN" ] || { echo "[smoke] ix-mcp binary not found at $IX_MCP_BIN" >&2; exit 1; }
 
-# 2. Resolve the bridge extension's npm deps (dev-time; pure-nix is a follow-up).
-if [ ! -d "$pkg/extension/node_modules" ]; then
-  echo "[smoke] installing bridge npm deps..." >&2
-  (cd "$pkg/extension" && npm install --omit=dev --silent)
-fi
+# 2. Build the shipped harness (this packages the bridge + its node_modules).
+echo "[smoke] building pi-harness..." >&2
+harness="$(nix build "$repo_root#pi-harness" --no-link --print-out-paths --accept-flake-config)"
+[ -x "$harness/bin/pi-harness" ] || { echo "[smoke] pi-harness not built" >&2; exit 1; }
 
-# 3. Run one prompt through Pi with the harness posture and capture JSON events.
+# 3. Run one prompt through the packaged wrapper and capture its JSON events.
 events="$(mktemp)"
 trap 'rm -f "$events"' EXIT
-echo "[smoke] running one turn through pi..." >&2
-pi \
-  --no-builtin-tools --no-extensions --no-skills --no-session \
-  --mode json --print \
-  --provider "${PI_PROVIDER:-anthropic}" \
-  --model "${PI_MODEL:-claude-opus-4-8}" \
-  --system-prompt "Use python_exec for everything." \
-  -e "$pkg/extension/ix-mcp-bridge.ts" \
-  "What is 2+2? Compute it with python_exec." | tee "$events" >&2
+echo "[smoke] running one turn through bin/pi-harness..." >&2
+"$harness/bin/pi-harness" "What is 2+2? Compute it with python_exec." | tee "$events" >&2
 
-# 4. Assertions. agent_start carries the active tool list.
+# 4. Assertions. agent_start + the model's tool list ride the JSON stream.
 echo "[smoke] checking tool surface..." >&2
 fail=0
 for forbidden in '"bash"' '"read"' '"write"' '"edit"'; do
@@ -55,6 +51,6 @@ grep -q "python_exec" "$events" || { echo "[smoke] FAIL: python_exec not exposed
 grep -q '"type":"turn_' "$events" || { echo "[smoke] FAIL: no turn lifecycle events" >&2; fail=1; }
 
 if [ "$fail" -eq 0 ]; then
-  echo "[smoke] PASS: built-ins absent, ix-mcp exposed, JSON events emitted" >&2
+  echo "[smoke] PASS: built-ins absent, ix-mcp exposed, JSON events emitted via the shipped artifact" >&2
 fi
 exit "$fail"

--- a/packages/pi-harness/smoke/run.sh
+++ b/packages/pi-harness/smoke/run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Local smoke + negative check for the Pi harness (ENG-2262 validation).
+#
+# Proves three things from the ticket without Room:
+#   1. one prompt runs through the harness,
+#   2. the model has NO built-in bash/read/write/edit tools (they are absent,
+#      not denied), only the ix-mcp surface,
+#   3. the turn produces a stable JSON event stream.
+#
+# Needs network + an API key for the selected model (ANTHROPIC_API_KEY by
+# default). Run it yourself - it can exceed a couple of minutes on first build.
+#
+#   ANTHROPIC_API_KEY=... ./packages/pi-harness/smoke/run.sh
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+pkg="$(dirname "$here")"
+repo_root="$(cd "$pkg/../.." && pwd)"
+
+# 1. Build ix-mcp and expose it to the bridge (it spawns `ix-mcp serve`).
+echo "[smoke] building ix-mcp..." >&2
+mcp_out="$(nix build "$repo_root#mcp" --no-link --print-out-paths)"
+export IX_MCP_BIN="$mcp_out/bin/ix-mcp"
+[ -x "$IX_MCP_BIN" ] || { echo "[smoke] ix-mcp binary not found at $IX_MCP_BIN" >&2; exit 1; }
+
+# 2. Resolve the bridge extension's npm deps (dev-time; pure-nix is a follow-up).
+if [ ! -d "$pkg/extension/node_modules" ]; then
+  echo "[smoke] installing bridge npm deps..." >&2
+  (cd "$pkg/extension" && npm install --omit=dev --silent)
+fi
+
+# 3. Run one prompt through Pi with the harness posture and capture JSON events.
+events="$(mktemp)"
+trap 'rm -f "$events"' EXIT
+echo "[smoke] running one turn through pi..." >&2
+pi \
+  --no-builtin-tools --no-extensions --no-skills --no-session \
+  --mode json --print \
+  --provider "${PI_PROVIDER:-anthropic}" \
+  --model "${PI_MODEL:-claude-opus-4-8}" \
+  --system-prompt "Use python_exec for everything." \
+  -e "$pkg/extension/ix-mcp-bridge.ts" \
+  "What is 2+2? Compute it with python_exec." | tee "$events" >&2
+
+# 4. Assertions. agent_start carries the active tool list.
+echo "[smoke] checking tool surface..." >&2
+fail=0
+for forbidden in '"bash"' '"read"' '"write"' '"edit"'; do
+  if grep -q "$forbidden" "$events"; then
+    echo "[smoke] FAIL: built-in tool $forbidden present in stream" >&2
+    fail=1
+  fi
+done
+grep -q "python_exec" "$events" || { echo "[smoke] FAIL: python_exec not exposed" >&2; fail=1; }
+grep -q '"type":"turn_' "$events" || { echo "[smoke] FAIL: no turn lifecycle events" >&2; fail=1; }
+
+if [ "$fail" -eq 0 ]; then
+  echo "[smoke] PASS: built-ins absent, ix-mcp exposed, JSON events emitted" >&2
+fi
+exit "$fail"


### PR DESCRIPTION
Implements ENG-2262 (task 1 of the ENG-2261 "Pi Room integration" stack): the Index-side Pi engine harness.

## What it is
A declarative `index/packages/pi-harness` that runs Pi as a Room-facing engine with the **built-in tools absent**, exposing **only** the `ix-mcp` tool surface, selecting the model declaratively, and emitting Pi's JSON event stream. This is the Pi equivalent of the Claude "tools removed" posture in `packages/claude-code` (`restrictToTools`), and stronger: `--no-builtin-tools` makes bash/read/write *absent*, not merely denied.

## Contents
- `default.nix` - wrapper baking the lockdown (`--no-builtin-tools --no-extensions --no-skills`), minimal system prompt, `--mode json`, declarative model selection.
- `models.nix` - `claude` -> anthropic/`claude-opus-4-8`, `codex` -> openai/`gpt-5.5` (keys from caller env, never looked up here).
- `extension/ix-mcp-bridge.ts` - runs `ix-mcp serve` over stdio and re-exposes its tools (`python_exec`, `search_*`, `calendar_*`) via `pi.registerTool` (Pi has no native MCP).
- `smoke/run.sh` - builds ix-mcp, runs one prompt, asserts built-ins absent + `python_exec` present + JSON events.
- `README.md` - records the design decisions (CLI subprocess vs SDK, builtins-absent flag, key ownership, session, Pi->Room event mapping table).

## Validation
- `nix build .#pi-harness` succeeds; package is flake-discoverable.
- MCP transport proven: a client using the bridge's SDK lists and calls `python_exec` (correct result).
- pi loads the bridge cleanly and emits the JSON stream.
- **Live end-to-end with real gpt-5.5**: under the harness, the model's only tool was `python_exec`; it called it through the bridge, got `4`, and answered "2 + 2 = 4". (Used a stub MCP server because building real `ix-mcp` needs `ca-derivations` in nix.conf; the bridge<->real-MCP path was proven separately. The harness mechanism is identical.)

## Follow-ups (documented in README, intentionally deferred)
- Pin `pi` as a Nix dep (currently uses PATH) and wire `pi` + `ix-mcp` into `runtimeInputs`.
- Make the bridge `node_modules` pure via `buildNpmPackage` (smoke uses `npm install`).
- Pi -> Room event mapper (ENG-2263).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `pi-harness` CLI that runs Pi with built-ins removed and ix-mcp tools bridged via MCP
> - Adds a Nushell CLI wrapper ([default.nix](https://github.com/indexable-inc/index/pull/838/files#diff-f442c7cf04ca1885536551a7a706b8819baad3abf3e9fdd17d68546016c76096)) that invokes `pi` with `--no-builtin-tools`, `--no-extensions`, `--no-skills`, and `--no-session`, exposing only the ix-mcp tool surface. Model is selected by alias via `PI_HARNESS_MODEL` (defaulting to `claude`), mapped in [models.nix](https://github.com/indexable-inc/index/pull/838/files#diff-e266373a1801206d0bff0cc945a7368c60db51aa2cc559bfe0a4e1e1df8cf706).
> - Adds [ix-mcp-bridge.ts](https://github.com/indexable-inc/index/pull/838/files#diff-830ca07b7413388a525cec72571fefa983b863e0556af1573cdc134959cefc5d), a Pi extension that spawns `ix-mcp serve` over stdio using the MCP Client SDK, lists its tools, and registers each (e.g. `python_exec`) as a native Pi tool. Each call is proxied to the MCP server and results are returned to Pi.
> - The extension and its `node_modules` are packaged as a Nix `buildNpmPackage` derivation so Pi can load the bridge at runtime without external npm installs.
> - Adds a smoke test ([smoke/run.sh](https://github.com/indexable-inc/index/pull/838/files#diff-4059a11d0c60da759107a76b5f6c3bb98fd428768ae7e294779a036405eccb89)) that builds via Nix, runs a single prompt, and asserts that built-in tools are absent, `python_exec` is present, and turn lifecycle events appear in JSON output.
>
> #### 🖇️ Linked Issues
> Implements [ENG-2262](https://linear.app/indexable/issue/ENG-2262).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6daa972.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->