### PR TITLE
pi-harness: scrub MCP subprocess environment

### DIFF
--- a/packages/pi-harness/README.md
+++ b/packages/pi-harness/README.md
@@ -28,6 +28,7 @@ PI_HARNESS_MODEL=codex pi-harness "..."  # gpt-5.5 via OpenAI
 | Machine-readable stream | `--mode json` (default); `PI_HARNESS_MODE=text` for interactive dev |
 | Model selection | `models.nix` table → `--provider`/`--model` |
 | API keys | Read by Pi from the env the caller provides (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`); never looked up here |
+| MCP subprocess env | `ix-mcp` receives a scrubbed allowlist; model-provider keys are blocked so `python_exec` cannot read them |
 
 ## Design decisions (the ticket's open questions)
 
@@ -79,6 +80,11 @@ The bridge is packaged with `buildNpmPackage`, so the store extension ships its
 `node_modules` and Pi resolves `@modelcontextprotocol/sdk` at runtime. Refresh
 the pinned dep hash after changing `package-lock.json` with
 `nix run nixpkgs#prefetch-npm-deps -- extension/package-lock.json`.
+
+The MCP bridge's env scrubber is covered by `npm test` inside the Nix build.
+If an MCP feature needs an extra non-provider environment variable, add it via
+`PI_HARNESS_MCP_ENV_ALLOWLIST=NAME`; model-provider keys remain blocked even
+when listed there.
 
 ## Follow-ups (intentionally deferred)
 

--- a/packages/pi-harness/default.nix
+++ b/packages/pi-harness/default.nix
@@ -28,6 +28,8 @@ let
     root = ./extension;
     fileset = lib.fileset.unions [
       (./extension + "/ix-mcp-bridge.ts")
+      (./extension + "/env.js")
+      (./extension + "/env.test.mjs")
       (./extension + "/package.json")
       (./extension + "/package-lock.json")
     ];
@@ -44,10 +46,16 @@ let
     npmDepsHash = "sha256-Nis7wQLp7wASaEu4n/Cp3pthB3z+9FsTJs5pK3oq77M=";
     # No build script: install the source plus production node_modules verbatim.
     dontNpmBuild = true;
+    doCheck = true;
+    checkPhase = ''
+      runHook preCheck
+      npm test
+      runHook postCheck
+    '';
     installPhase = ''
       runHook preInstall
       mkdir -p $out
-      cp ix-mcp-bridge.ts package.json $out/
+      cp ix-mcp-bridge.ts env.js package.json $out/
       cp -r node_modules $out/node_modules
       runHook postInstall
     '';

--- a/packages/pi-harness/extension/env.js
+++ b/packages/pi-harness/extension/env.js
@@ -1,0 +1,73 @@
+const SAFE_MCP_ENV_VARS = [
+  "HOME",
+  "LOGNAME",
+  "PATH",
+  "SHELL",
+  "TERM",
+  "TMP",
+  "TMPDIR",
+  "TEMP",
+  "USER",
+  "XDG_RUNTIME_DIR",
+  "SSL_CERT_FILE",
+  "NIX_SSL_CERT_FILE",
+  "REQUESTS_CA_BUNDLE",
+  "CURL_CA_BUNDLE",
+  "GIT_CONFIG_NOSYSTEM",
+  "GIT_SSL_CAINFO",
+  "IX_GCAL_BIN",
+  "IX_MCP_DASHBOARD_HTML",
+  "IX_MCP_HOST",
+  "IX_MCP_KERNEL_TRACE",
+  "IX_MCP_PUBLIC_HOST",
+  "IX_MCP_STORE",
+  "IX_VMKIT_BIN",
+];
+
+const MODEL_PROVIDER_ENV_VARS = [
+  "ANTHROPIC_API_KEY",
+  "AZURE_OPENAI_API_KEY",
+  "CLAUDE_API_KEY",
+  "CODEX_API_KEY",
+  "COHERE_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "GROQ_API_KEY",
+  "MISTRAL_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "PERPLEXITY_API_KEY",
+  "TOGETHER_API_KEY",
+  "XAI_API_KEY",
+];
+
+const EXTRA_ALLOWLIST_ENV = "PI_HARNESS_MCP_ENV_ALLOWLIST";
+const ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function parseExtraAllowlist(value) {
+  if (typeof value !== "string" || value.trim() === "") return [];
+  return value
+    .split(",")
+    .map((name) => name.trim())
+    .filter((name) => ENV_NAME.test(name));
+}
+
+export function buildMcpEnv(source = process.env) {
+  const blocked = new Set(MODEL_PROVIDER_ENV_VARS);
+  const names = new Set([
+    ...SAFE_MCP_ENV_VARS,
+    ...parseExtraAllowlist(source[EXTRA_ALLOWLIST_ENV]),
+  ]);
+  const env = {};
+
+  for (const name of names) {
+    if (blocked.has(name)) continue;
+    const value = source[name];
+    if (typeof value === "string") env[name] = value;
+  }
+
+  return env;
+}
+
+export { EXTRA_ALLOWLIST_ENV, MODEL_PROVIDER_ENV_VARS, SAFE_MCP_ENV_VARS };

--- a/packages/pi-harness/extension/env.test.mjs
+++ b/packages/pi-harness/extension/env.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EXTRA_ALLOWLIST_ENV, buildMcpEnv } from "./env.js";
+
+test("buildMcpEnv keeps only safe defaults", () => {
+  const env = buildMcpEnv({
+    PATH: "/bin",
+    HOME: "/home/test",
+    IX_MCP_HOST: "127.0.0.1",
+    EXA_API_KEY: "not-default-safe",
+    RANDOM_SECRET: "hidden",
+  });
+
+  assert.deepEqual(env, {
+    HOME: "/home/test",
+    PATH: "/bin",
+    IX_MCP_HOST: "127.0.0.1",
+  });
+});
+
+test("buildMcpEnv strips model-provider keys even when explicitly allowlisted", () => {
+  const env = buildMcpEnv({
+    [EXTRA_ALLOWLIST_ENV]: "OPENAI_API_KEY,ANTHROPIC_API_KEY,EXA_API_KEY",
+    OPENAI_API_KEY: "openai-secret",
+    ANTHROPIC_API_KEY: "anthropic-secret",
+    EXA_API_KEY: "tool-secret",
+  });
+
+  assert.deepEqual(env, {
+    EXA_API_KEY: "tool-secret",
+  });
+});
+
+test("buildMcpEnv ignores malformed allowlist names", () => {
+  const env = buildMcpEnv({
+    [EXTRA_ALLOWLIST_ENV]: "OK_NAME,NOT-AN-ENV, ALSO_OK ",
+    OK_NAME: "ok",
+    ALSO_OK: "also-ok",
+    "NOT-AN-ENV": "bad",
+  });
+
+  assert.deepEqual(env, {
+    OK_NAME: "ok",
+    ALSO_OK: "also-ok",
+  });
+});

--- a/packages/pi-harness/extension/ix-mcp-bridge.ts
+++ b/packages/pi-harness/extension/ix-mcp-bridge.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { buildMcpEnv } from "./env.js";
 
 // Bridge the ix-mcp Python-execution MCP server into Pi as native tools.
 //
@@ -20,7 +21,9 @@ export default async function (pi: ExtensionAPI): Promise<void> {
   const command = process.env.IX_MCP_BIN ?? "ix-mcp";
 
   const client = new Client({ name: "ix-mcp-bridge", version: "0.1.0" });
-  await client.connect(new StdioClientTransport({ command, args: ["serve"] }));
+  await client.connect(
+    new StdioClientTransport({ command, args: ["serve"], env: buildMcpEnv() }),
+  );
 
   const { tools } = await client.listTools();
   for (const tool of tools) {

--- a/packages/pi-harness/extension/package.json
+++ b/packages/pi-harness/extension/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "type": "module",
   "description": "Bridge the ix-mcp Python-execution MCP server into Pi as native tools",
+  "scripts": {
+    "test": "node --test env.test.mjs"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0"
   }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Scrub model-provider API keys from the `ix-mcp` subprocess environment in pi-harness
- Adds [env.js](https://github.com/indexable-inc/index/pull/839/files#diff-dc3af93be1faaaa1f238f23f27b762a5216d41ecc0bd0a95a5e19ed65e84f0c7) with `buildMcpEnv`, which constructs a restricted environment from an explicit allowlist (`SAFE_MCP_ENV_VARS`) while always stripping known model-provider API keys, even if they appear in the extra allowlist.
- Extra variables can be added at runtime via the `PI_HARNESS_MCP_ENV_ALLOWLIST` env var (comma-separated); malformed names are silently ignored.
- Updates [ix-mcp-bridge.ts](https://github.com/indexable-inc/index/pull/839/files#diff-830ca07b7413388a525cec72571fefa983b863e0556af1573cdc134959cefc5d) to pass the scrubbed env to `StdioClientTransport` when spawning `ix-mcp serve`.
- Adds [env.test.mjs](https://github.com/indexable-inc/index/pull/839/files#diff-3bfb849b28700b3f7a25ddd57e24fb32a56811285f2d65071ef4147a1e92b4be) with three test cases covering default filtering, provider-key blocking, and allowlist validation; the Nix build now runs these via `npm test` in `checkPhase`.
- Behavioral Change: `ix-mcp` subprocesses launched by the bridge no longer inherit the full parent environment — only allowlisted variables are passed through.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a2abe2.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->