### PR TITLE
ENG-2263: Integrate Pi with ix-mcp cells and resources

### DIFF
--- a/packages/pi-harness/README.md
+++ b/packages/pi-harness/README.md
@@ -25,7 +25,7 @@ PI_HARNESS_MODEL=codex pi-harness "..."  # gpt-5.5 via OpenAI
 | No accidental tools | `--no-extensions --no-skills` (the bridge still loads via explicit `-e`) |
 | Only tool surface | `extension/ix-mcp-bridge.ts` runs `ix-mcp serve` over stdio and re-exposes its tools (`python_exec`, `search_*`, `calendar_*`) via `pi.registerTool` |
 | Minimal context | `--system-prompt` defaults to a one-line controlled prompt; override with `PI_HARNESS_SYSTEM_PROMPT` |
-| Machine-readable stream | `--mode json` (default); `PI_HARNESS_MODE=text` for interactive dev |
+| Machine-readable stream | `--mode json` (default) via `room_event_mapper.py`; `PI_HARNESS_MODE=text` for direct interactive dev |
 | Model selection | `models.nix` table → `--provider`/`--model` |
 | API keys | Read by Pi from the env the caller provides (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`); never looked up here |
 | MCP subprocess env | `ix-mcp` receives a scrubbed allowlist; model-provider keys are blocked so `python_exec` cannot read them |
@@ -63,8 +63,34 @@ value):
 | `turn_end` | `turn_completed` |
 | error events | `error` |
 
-This first cut emits Pi's native JSON; the mapper and the `cell_update` /
-`resource_update` detail land with ENG-2263.
+ENG-2263 adds `room_event_mapper.py`. In JSON mode, the hardened launcher
+allocates a per-run `IX_MCP_STORE` when the caller did not provide one, starts
+the mapper, and the mapper starts Pi. The mapper combines Pi's JSON lifecycle
+events with ix-mcp's SQLite rows, which are the same `Job`, `Cell`, and
+`Resource` objects consumed by the existing MCP Svelte dashboard.
+
+The harness does not render cells, tool calls, or TUIs itself. It emits a
+machine-readable feed for the Room server to ingest; the Room Svelte/Tauri UI
+will render inline jobs/cells and sidebar resources later.
+
+Pi lifecycle/tool events keep the original Pi event under `raw` and map to
+stable Room-facing names such as `turn_started`, `text_delta`,
+`reasoning_delta`, `tool_call_started`, `tool_call_output`, `usage`,
+`turn_completed`, and `error`.
+
+ix-mcp store updates emit the dashboard-shaped payloads directly:
+
+```json
+{ "type": "cell_update", "cell_kind": "execution", "job": { "...": "MCP Job" } }
+{ "type": "cell_update", "cell_kind": "presentation", "cell": { "...": "MCP Cell" } }
+{ "type": "resource_update", "resource": { "...": "MCP Resource" } }
+```
+
+Those payloads preserve the MCP dashboard interpretations for source/code,
+stdout tail, status, final result, rich mime outputs, bindings, curated cells,
+and live HTML resources. `code_html` is intentionally empty in the harness feed;
+the MCP UI already falls back to raw `code`, and final Room rendering owns
+syntax highlighting.
 
 ## Validation
 
@@ -87,6 +113,12 @@ If an MCP feature needs an extra non-provider environment variable, add it via
 `PI_HARNESS_MCP_ENV_ALLOWLIST=NAME`; model-provider keys remain blocked even
 when listed there.
 
+The Room event mapper has a pure stdlib test:
+
+```
+python3 packages/pi-harness/room_event_mapper_test.py
+```
+
 The process hardening is part of the shipped `pi-harness` binary. On Linux,
 the launcher hardens itself first, then sets `LD_PRELOAD` for Pi so the
 post-`exec` Pi process reapplies the same non-dumpable boundary. The MCP child
@@ -97,4 +129,5 @@ provider keys.
 
 - Package `pi` as a pinned nix dependency (dependency-intake) and wire it +
   `ix-mcp` into `default.nix` `runtimeInputs` instead of relying on PATH.
-- Add the Pi→Room event mapper (ENG-2263).
+- Run the ENG-2263 live smoke matrix in CI once model-provider test credentials
+  are available.

--- a/packages/pi-harness/default.nix
+++ b/packages/pi-harness/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   buildNpmPackage,
+  python3,
   # Pi is not yet packaged in this repo. Until the dependency-intake follow-up
   # lands a pinned `pi` derivation, the wrapper calls `pi` from PATH (the dev
   # image / system already provides it). Pass a derivation here to pin it.
@@ -63,9 +64,12 @@ let
     '';
   };
 
-  runtimeInputs = lib.optional (pi != null) pi ++ lib.optional (ix-mcp != null) ix-mcp;
+  mapper = ./room_event_mapper.py;
+
+  runtimeInputs = [ python3 ] ++ lib.optional (pi != null) pi ++ lib.optional (ix-mcp != null) ix-mcp;
   runtimePath = lib.makeBinPath runtimeInputs;
   piCommand = if pi == null then "pi" else lib.getExe pi;
+  pythonCommand = lib.getExe python3;
   isLinux = stdenv.hostPlatform.isLinux;
   hardenerLibraryName = "libpi-harness-harden.so";
   hardenerPath = lib.optionalString isLinux "$out/lib/${hardenerLibraryName}";
@@ -75,6 +79,7 @@ stdenv.mkDerivation {
   version = "0.1.0";
   dontUnpack = true;
   strictDeps = true;
+  doCheck = true;
 
   buildPhase = ''
         runHook preBuild
@@ -193,6 +198,32 @@ stdenv.mkDerivation {
           return set_joined_env("LD_PRELOAD", hardener, " ");
         }
 
+        static char *make_default_store_path(void) {
+          const char *tmpdir = env_or_default("TMPDIR", "/tmp");
+          size_t template_len = strlen(tmpdir) + strlen("/pi-harness.XXXXXX") + 1;
+          char *template = malloc(template_len);
+          if (template == NULL) {
+            return NULL;
+          }
+          snprintf(template, template_len, "%s/pi-harness.XXXXXX", tmpdir);
+
+          char *dir = mkdtemp(template);
+          if (dir == NULL) {
+            free(template);
+            return NULL;
+          }
+
+          size_t store_len = strlen(dir) + strlen("/ix-mcp.sqlite") + 1;
+          char *store = malloc(store_len);
+          if (store == NULL) {
+            free(template);
+            return NULL;
+          }
+          snprintf(store, store_len, "%s/ix-mcp.sqlite", dir);
+          free(template);
+          return store;
+        }
+
         int main(int argc, char **argv) {
         #ifdef __linux__
           pi_harness_harden_current_process();
@@ -217,37 +248,74 @@ stdenv.mkDerivation {
           );
           const char *pi = ${builtins.toJSON piCommand};
           const char *extension = ${builtins.toJSON "${extension}/ix-mcp-bridge.ts"};
+          const char *python = ${builtins.toJSON pythonCommand};
+          const char *mapper = ${builtins.toJSON mapper};
 
           size_t rest = (argc > 1) ? (size_t)(argc - 1) : 0;
-          char **args = calloc(17 + rest, sizeof(char *));
-          if (args == NULL) {
+          char **pi_args = calloc(17 + rest, sizeof(char *));
+          if (pi_args == NULL) {
             fprintf(stderr, "pi-harness: failed to allocate argv\n");
             return 125;
           }
 
           size_t i = 0;
-          args[i++] = (char *)pi;
-          args[i++] = "--no-builtin-tools";
-          args[i++] = "--no-extensions";
-          args[i++] = "--no-skills";
-          args[i++] = "--no-session";
-          args[i++] = "--mode";
-          args[i++] = (char *)mode;
-          args[i++] = "--print";
-          args[i++] = "--provider";
-          args[i++] = (char *)cfg->provider;
-          args[i++] = "--model";
-          args[i++] = (char *)cfg->model;
-          args[i++] = "--system-prompt";
-          args[i++] = (char *)system_prompt;
-          args[i++] = "--extension";
-          args[i++] = (char *)extension;
+          pi_args[i++] = (char *)pi;
+          pi_args[i++] = "--no-builtin-tools";
+          pi_args[i++] = "--no-extensions";
+          pi_args[i++] = "--no-skills";
+          pi_args[i++] = "--no-session";
+          pi_args[i++] = "--mode";
+          pi_args[i++] = (char *)mode;
+          pi_args[i++] = "--print";
+          pi_args[i++] = "--provider";
+          pi_args[i++] = (char *)cfg->provider;
+          pi_args[i++] = "--model";
+          pi_args[i++] = (char *)cfg->model;
+          pi_args[i++] = "--system-prompt";
+          pi_args[i++] = (char *)system_prompt;
+          pi_args[i++] = "--extension";
+          pi_args[i++] = (char *)extension;
           for (int j = 1; j < argc; j++) {
-            args[i++] = argv[j];
+            pi_args[i++] = argv[j];
           }
-          args[i] = NULL;
+          pi_args[i] = NULL;
+          size_t pi_argc = i;
 
-          execvp(pi, args);
+          if (strcmp(mode, "json") == 0) {
+            const char *store = getenv("IX_MCP_STORE");
+            char *owned_store = NULL;
+            if (store == NULL || store[0] == '\0') {
+              owned_store = make_default_store_path();
+              if (owned_store == NULL || setenv("IX_MCP_STORE", owned_store, 1) != 0) {
+                fprintf(stderr, "pi-harness: failed to prepare IX_MCP_STORE: %s\n", strerror(errno));
+                return 125;
+              }
+              store = owned_store;
+            }
+
+            char **mapper_args = calloc(6 + pi_argc, sizeof(char *));
+            if (mapper_args == NULL) {
+              fprintf(stderr, "pi-harness: failed to allocate mapper argv\n");
+              return 125;
+            }
+
+            size_t k = 0;
+            mapper_args[k++] = (char *)python;
+            mapper_args[k++] = (char *)mapper;
+            mapper_args[k++] = "--store";
+            mapper_args[k++] = (char *)store;
+            mapper_args[k++] = "--";
+            for (size_t j = 0; j < pi_argc; j++) {
+              mapper_args[k++] = pi_args[j];
+            }
+            mapper_args[k] = NULL;
+
+            execv(python, mapper_args);
+            fprintf(stderr, "pi-harness: failed to exec %s: %s\n", python, strerror(errno));
+            return 127;
+          }
+
+          execvp(pi, pi_args);
           fprintf(stderr, "pi-harness: failed to exec %s: %s\n", pi, strerror(errno));
           return 127;
         }
@@ -261,6 +329,12 @@ stdenv.mkDerivation {
         $CC launcher.c -o pi-harness
 
         runHook postBuild
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    PYTHONPATH=${./.} ${pythonCommand} ${./room_event_mapper_test.py}
+    runHook postCheck
   '';
 
   installPhase = ''

--- a/packages/pi-harness/room_event_mapper.py
+++ b/packages/pi-harness/room_event_mapper.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Map Pi JSON plus ix-mcp dashboard rows into Room-facing engine events.
+
+Pi owns the model turn and emits generic JSON lifecycle/tool events. ix-mcp owns
+the notebook state and persists the same Job/Cell/Resource rows its Svelte
+dashboard already renders. Room needs one ordered JSON stream that keeps both
+surfaces explicit, so this mapper passes Pi lifecycle through under stable Room
+event names while polling the MCP store for dashboard-shaped updates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import queue
+import sqlite3
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+
+Json = dict[str, Any]
+
+PI_TO_ROOM_EVENTS = {
+    "turn_start": "turn_started",
+    "turn_started": "turn_started",
+    "message_update": "text_delta",
+    "assistant_message_delta": "text_delta",
+    "assistantMessageEvent": "text_delta",
+    "reasoning_delta": "reasoning_delta",
+    "thinking_delta": "reasoning_delta",
+    "tool_execution_start": "tool_call_started",
+    "tool_call_started": "tool_call_started",
+    "tool_execution_update": "tool_call_output",
+    "tool_execution_end": "tool_call_output",
+    "tool_call_output": "tool_call_output",
+    "usage": "usage",
+    "turn_end": "turn_completed",
+    "turn_completed": "turn_completed",
+    "error": "error",
+}
+
+
+def _json_dumps(event: Json) -> str:
+    return json.dumps(event, ensure_ascii=False, separators=(",", ":"))
+
+
+class Emitter:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+
+    def emit(self, event: Json) -> None:
+        with self._lock:
+            print(_json_dumps(event), flush=True)
+
+
+def _event_type(event: Json) -> str | None:
+    value = event.get("type") or event.get("event") or event.get("name")
+    if isinstance(value, str):
+        return value
+    nested = event.get("assistantMessageEvent")
+    if isinstance(nested, dict):
+        nested_type = nested.get("type")
+        if isinstance(nested_type, str):
+            return nested_type
+    return None
+
+
+def _text_delta(event: Json) -> str | None:
+    for key in ("delta", "text", "content"):
+        value = event.get(key)
+        if isinstance(value, str):
+            return value
+
+    nested = event.get("assistantMessageEvent")
+    if isinstance(nested, dict):
+        for key in ("delta", "text", "content"):
+            value = nested.get(key)
+            if isinstance(value, str):
+                return value
+    return None
+
+
+def map_pi_event(event: Json) -> Json:
+    pi_type = _event_type(event)
+    room_type = PI_TO_ROOM_EVENTS.get(pi_type or "", "pi_event")
+    mapped: Json = {"type": room_type, "source": "pi", "raw": event}
+
+    if pi_type is not None:
+        mapped["pi_type"] = pi_type
+
+    if room_type in {"text_delta", "reasoning_delta"}:
+        delta = _text_delta(event)
+        if delta is not None:
+            mapped["delta"] = delta
+
+    for key in ("toolCallId", "tool_call_id", "id", "name", "usage", "error"):
+        if key in event:
+            mapped[key] = event[key]
+
+    return mapped
+
+
+def _connect(path: Path) -> sqlite3.Connection | None:
+    if not path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=0.2)
+        conn.row_factory = sqlite3.Row
+        return conn
+    except sqlite3.Error:
+        return None
+
+
+def _load_json(value: Any, fallback: Any) -> Any:
+    if not isinstance(value, str) or value == "":
+        return fallback
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return fallback
+
+
+def _rows(conn: sqlite3.Connection, query: str) -> list[sqlite3.Row]:
+    try:
+        return list(conn.execute(query).fetchall())
+    except sqlite3.Error:
+        return []
+
+
+def _job_from_row(row: sqlite3.Row) -> Json:
+    status = row["status"]
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "code": row["code"],
+        "code_html": "",
+        "status": status,
+        "started_at": row["started_at"],
+        "ended_at": row["ended_at"],
+        "output": row["output"],
+        "result": row["result"],
+        "error": row["error"],
+        "outputs": _load_json(row["outputs"], []),
+        "bindings": _load_json(row["bindings"], {}),
+    }
+
+
+def _execution_event(row: sqlite3.Row) -> Json:
+    job = _job_from_row(row)
+    return {
+        "type": "cell_update",
+        "source": "ix-mcp",
+        "cell_kind": "execution",
+        "id": job["id"],
+        "job": job,
+    }
+
+
+def _cell_from_row(row: sqlite3.Row) -> Json:
+    return {
+        "id": row["id"],
+        "title": row["title"],
+        "position": row["position"],
+        "outputs": _load_json(row["outputs"], []),
+        "updated_at": row["updated_at"],
+    }
+
+
+def _presentation_cell_event(row: sqlite3.Row) -> Json:
+    cell = _cell_from_row(row)
+    return {
+        "type": "cell_update",
+        "source": "ix-mcp",
+        "cell_kind": "presentation",
+        "id": cell["id"],
+        "cell": cell,
+    }
+
+
+def _resource_from_row(row: sqlite3.Row) -> Json:
+    return {
+        "id": row["id"],
+        "title": row["title"],
+        "kind": row["kind"],
+        "html": row["html"],
+        "status": row["status"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def _resource_event(row: sqlite3.Row) -> Json:
+    resource = _resource_from_row(row)
+    return {
+        "type": "resource_update",
+        "source": "ix-mcp",
+        "id": resource["id"],
+        "resource": resource,
+    }
+
+
+class StorePoller:
+    def __init__(self, store: Path, interval: float, emitter: Emitter) -> None:
+        self._store = store
+        self._interval = interval
+        self._emitter = emitter
+        self._seen: dict[str, str] = {}
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, name="ix-mcp-store-poller", daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=max(1.0, self._interval * 4))
+        self.poll_once()
+
+    def _run(self) -> None:
+        while not self._stop.wait(self._interval):
+            self.poll_once()
+
+    def poll_once(self) -> None:
+        conn = _connect(self._store)
+        if conn is None:
+            return
+        try:
+            events: list[Json] = []
+            for row in _rows(
+                conn,
+                "SELECT id, name, code, status, started_at, ended_at, output, result, error, outputs, bindings "
+                "FROM executions ORDER BY started_at ASC",
+            ):
+                events.append(_execution_event(row))
+            for row in _rows(
+                conn,
+                "SELECT id, title, position, outputs, updated_at FROM cells ORDER BY position ASC",
+            ):
+                events.append(_presentation_cell_event(row))
+            for row in _rows(
+                conn,
+                "SELECT id, title, kind, html, status, created_at, updated_at FROM resources ORDER BY created_at ASC",
+            ):
+                events.append(_resource_event(row))
+        finally:
+            conn.close()
+
+        for event in events:
+            key = f"{event['type']}:{event.get('cell_kind', '')}:{event['id']}"
+            encoded = _json_dumps(event)
+            if self._seen.get(key) == encoded:
+                continue
+            self._seen[key] = encoded
+            self._emitter.emit(event)
+
+
+def _reader(lines: queue.Queue[str | None]) -> None:
+    for line in sys.stdin:
+        lines.put(line)
+    lines.put(None)
+
+
+def _read_stream(stream, lines: queue.Queue[str | None]) -> None:
+    for line in stream:
+        lines.put(line)
+    lines.put(None)
+
+
+def _strip_command_separator(command: list[str]) -> list[str]:
+    if command and command[0] == "--":
+        return command[1:]
+    return command
+
+
+def run(store: Path, interval: float, command: list[str] | None = None) -> int:
+    emitter = Emitter()
+    poller = StorePoller(store, interval, emitter)
+    poller.start()
+
+    lines: queue.Queue[str | None] = queue.Queue()
+    process: subprocess.Popen[str] | None = None
+    if command:
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, text=True)
+        assert process.stdout is not None
+        threading.Thread(target=_read_stream, args=(process.stdout, lines), name="pi-stdout-reader", daemon=True).start()
+    else:
+        threading.Thread(target=_reader, args=(lines,), name="stdin-reader", daemon=True).start()
+
+    try:
+        while True:
+            poller.poll_once()
+            try:
+                line = lines.get(timeout=interval)
+            except queue.Empty:
+                continue
+            if line is None:
+                break
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                event = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                emitter.emit({"type": "error", "source": "pi-harness", "message": str(exc), "line": stripped})
+                continue
+            if isinstance(event, dict):
+                emitter.emit(map_pi_event(event))
+            else:
+                emitter.emit({"type": "pi_event", "source": "pi", "raw": event})
+    finally:
+        poller.stop()
+    if process is None:
+        return 0
+    return process.wait()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--store", default=os.environ.get("IX_MCP_STORE"), help="ix-mcp SQLite store path")
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=float(os.environ.get("PI_HARNESS_MCP_POLL_INTERVAL", "0.2")),
+        help="seconds between ix-mcp store polls",
+    )
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="optional Pi command to spawn and map")
+    args = parser.parse_args()
+    if not args.store:
+        print("room-event-mapper: --store or IX_MCP_STORE is required", file=sys.stderr)
+        return 2
+    command = _strip_command_separator(args.command)
+    return run(Path(args.store), max(args.poll_interval, 0.05), command or None)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/pi-harness/room_event_mapper_test.py
+++ b/packages/pi-harness/room_event_mapper_test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+import room_event_mapper as mapper
+
+
+SCHEMA = """
+CREATE TABLE executions (
+    id TEXT PRIMARY KEY,
+    name TEXT,
+    code TEXT NOT NULL,
+    status TEXT NOT NULL,
+    started_at REAL NOT NULL,
+    ended_at REAL,
+    output TEXT NOT NULL DEFAULT '',
+    result TEXT,
+    error TEXT,
+    outputs TEXT NOT NULL DEFAULT '[]',
+    bindings TEXT NOT NULL DEFAULT '{}'
+);
+CREATE TABLE cells (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL DEFAULT '',
+    position INTEGER NOT NULL,
+    outputs TEXT NOT NULL DEFAULT '[]',
+    updated_at REAL NOT NULL
+);
+CREATE TABLE resources (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'html',
+    html TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'live',
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+"""
+
+
+class CaptureEmitter:
+    def __init__(self) -> None:
+        self.events = []
+
+    def emit(self, event):
+        self.events.append(event)
+
+
+class MapperTest(unittest.TestCase):
+    def test_maps_pi_lifecycle_events(self) -> None:
+        self.assertEqual(mapper.map_pi_event({"type": "turn_start"})["type"], "turn_started")
+        text = mapper.map_pi_event({"type": "message_update", "delta": "hi"})
+        self.assertEqual(text["type"], "text_delta")
+        self.assertEqual(text["delta"], "hi")
+        self.assertEqual(mapper.map_pi_event({"type": "tool_execution_start", "id": "t1"})["type"], "tool_call_started")
+        self.assertEqual(mapper.map_pi_event({"type": "turn_end"})["type"], "turn_completed")
+
+    def test_strips_command_separator(self) -> None:
+        self.assertEqual(mapper._strip_command_separator(["--", "pi", "--mode", "json"]), ["pi", "--mode", "json"])
+        self.assertEqual(mapper._strip_command_separator(["pi"]), ["pi"])
+
+    def test_polls_cells_and_resources_from_store(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = Path(tmp) / "mcp.sqlite"
+            conn = sqlite3.connect(store)
+            conn.executescript(SCHEMA)
+            conn.execute(
+                "INSERT INTO executions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "job-1",
+                    "demo",
+                    "Result.text('ok')",
+                    "done",
+                    1.0,
+                    2.0,
+                    "stdout",
+                    "ok",
+                    None,
+                    json.dumps([{"type": "text", "text": "ok"}]),
+                    json.dumps({"value": {"repr": "1"}}),
+                ),
+            )
+            conn.execute(
+                "INSERT INTO cells VALUES (?, ?, ?, ?, ?)",
+                ("cell-1", "Answer", 0, json.dumps([{"type": "html", "html": "<b>ok</b>"}]), 3.0),
+            )
+            conn.execute(
+                "INSERT INTO resources VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("res-1", "Terminal", "html", "<pre>hi</pre>", "live", 4.0, 5.0),
+            )
+            conn.commit()
+            conn.close()
+
+            emitter = CaptureEmitter()
+            poller = mapper.StorePoller(store, 0.1, emitter)  # type: ignore[arg-type]
+            poller.poll_once()
+            self.assertEqual([event["type"] for event in emitter.events], ["cell_update", "cell_update", "resource_update"])
+            execution = emitter.events[0]
+            self.assertEqual(execution["cell_kind"], "execution")
+            self.assertEqual(execution["job"]["code"], "Result.text('ok')")
+            self.assertEqual(execution["job"]["code_html"], "")
+            self.assertEqual(execution["job"]["outputs"][0]["text"], "ok")
+            self.assertEqual(emitter.events[1]["cell_kind"], "presentation")
+            self.assertEqual(emitter.events[1]["cell"]["title"], "Answer")
+            self.assertEqual(emitter.events[2]["resource"]["html"], "<pre>hi</pre>")
+
+            poller.poll_once()
+            self.assertEqual(len(emitter.events), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Integrate Pi with ix-mcp cells and resources via room_event_mapper in pi-harness
> - In JSON mode, [pi-harness](https://github.com/indexable-inc/index/pull/841/files#diff-f442c7cf04ca1885536551a7a706b8819baad3abf3e9fdd17d68546016c76096) now execs [room_event_mapper.py](https://github.com/indexable-inc/index/pull/841/files#diff-22973fd261f4acfc9d1ca991e65ef4ac2d720a010c44f228a6facc86861915da) instead of Pi directly, which spawns Pi as a subprocess and merges its JSON lifecycle events with live ix-mcp SQLite store updates into a unified event stream.
> - The launcher auto-creates a temporary `IX_MCP_STORE` SQLite path when one is not provided, using `mkdtemp`.
> - [room_event_mapper.py](https://github.com/indexable-inc/index/pull/841/files#diff-22973fd261f4acfc9d1ca991e65ef4ac2d720a010c44f228a6facc86861915da) normalizes Pi event variants to stable Room event names (`turn_started`, `text_delta`, `tool_call_started`, etc.) and polls the ix-mcp store to emit `cell_update` and `resource_update` events with deduplicated payloads.
> - Unit tests in [room_event_mapper_test.py](https://github.com/indexable-inc/index/pull/841/files#diff-cf21d800904ed4b25b016d21eb14e315d4e696a3d7b64b7a286d1967d5f55151) run during the Nix `checkPhase`, failing the build if any test fails.
> - Behavioral Change: in non-JSON mode, Pi is still exec'd directly with no change in behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67c12a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->