### PR TITLE
Fix Pi MCP room feed edge cases

### DIFF
--- a/packages/pi-harness/room_event_mapper.py
+++ b/packages/pi-harness/room_event_mapper.py
@@ -124,11 +124,11 @@ def _load_json(value: Any, fallback: Any) -> Any:
         return fallback
 
 
-def _rows(conn: sqlite3.Connection, query: str) -> list[sqlite3.Row]:
+def _rows(conn: sqlite3.Connection, query: str) -> list[sqlite3.Row] | None:
     try:
         return list(conn.execute(query).fetchall())
     except sqlite3.Error:
-        return []
+        return None
 
 
 def _job_from_row(row: sqlite3.Row) -> Json:
@@ -231,29 +231,38 @@ class StorePoller:
             return
         try:
             events: list[Json] = []
-            presentation_cell_ids: set[str] = set()
-            for row in _rows(
+            presentation_cell_ids: set[str] | None = None
+            execution_rows = _rows(
                 conn,
                 "SELECT id, name, code, status, started_at, ended_at, output, result, error, outputs, bindings "
                 "FROM executions ORDER BY started_at ASC",
-            ):
-                events.append(_execution_event(row))
-            for row in _rows(
+            )
+            if execution_rows is not None:
+                for row in execution_rows:
+                    events.append(_execution_event(row))
+
+            cell_rows = _rows(
                 conn,
                 "SELECT id, title, position, outputs, updated_at FROM cells ORDER BY position ASC",
-            ):
-                event = _presentation_cell_event(row)
-                presentation_cell_ids.add(event["id"])
-                events.append(event)
-            for row in _rows(
+            )
+            if cell_rows is not None:
+                presentation_cell_ids = set()
+                for row in cell_rows:
+                    event = _presentation_cell_event(row)
+                    presentation_cell_ids.add(event["id"])
+                    events.append(event)
+
+            resource_rows = _rows(
                 conn,
                 "SELECT id, title, kind, html, status, created_at, updated_at FROM resources ORDER BY created_at ASC",
-            ):
-                events.append(_resource_event(row))
+            )
+            if resource_rows is not None:
+                for row in resource_rows:
+                    events.append(_resource_event(row))
         finally:
             conn.close()
 
-        if self._presentation_cell_ids is not None:
+        if presentation_cell_ids is not None and self._presentation_cell_ids is not None:
             for removed_id in sorted(self._presentation_cell_ids - presentation_cell_ids):
                 events.append(
                     {
@@ -265,7 +274,8 @@ class StorePoller:
                         "cell": {"id": removed_id, "removed": True},
                     }
                 )
-        self._presentation_cell_ids = presentation_cell_ids
+        if presentation_cell_ids is not None:
+            self._presentation_cell_ids = presentation_cell_ids
 
         for event in events:
             key = f"{event['type']}:{event.get('cell_kind', '')}:{event['id']}"

--- a/packages/pi-harness/room_event_mapper.py
+++ b/packages/pi-harness/room_event_mapper.py
@@ -209,6 +209,7 @@ class StorePoller:
         self._interval = interval
         self._emitter = emitter
         self._seen: dict[str, str] = {}
+        self._presentation_cell_ids: set[str] | None = None
         self._stop = threading.Event()
         self._thread = threading.Thread(target=self._run, name="ix-mcp-store-poller", daemon=True)
 
@@ -230,6 +231,7 @@ class StorePoller:
             return
         try:
             events: list[Json] = []
+            presentation_cell_ids: set[str] = set()
             for row in _rows(
                 conn,
                 "SELECT id, name, code, status, started_at, ended_at, output, result, error, outputs, bindings "
@@ -240,7 +242,9 @@ class StorePoller:
                 conn,
                 "SELECT id, title, position, outputs, updated_at FROM cells ORDER BY position ASC",
             ):
-                events.append(_presentation_cell_event(row))
+                event = _presentation_cell_event(row)
+                presentation_cell_ids.add(event["id"])
+                events.append(event)
             for row in _rows(
                 conn,
                 "SELECT id, title, kind, html, status, created_at, updated_at FROM resources ORDER BY created_at ASC",
@@ -248,6 +252,20 @@ class StorePoller:
                 events.append(_resource_event(row))
         finally:
             conn.close()
+
+        if self._presentation_cell_ids is not None:
+            for removed_id in sorted(self._presentation_cell_ids - presentation_cell_ids):
+                events.append(
+                    {
+                        "type": "cell_update",
+                        "source": "ix-mcp",
+                        "cell_kind": "presentation",
+                        "id": removed_id,
+                        "removed": True,
+                        "cell": {"id": removed_id, "removed": True},
+                    }
+                )
+        self._presentation_cell_ids = presentation_cell_ids
 
         for event in events:
             key = f"{event['type']}:{event.get('cell_kind', '')}:{event['id']}"
@@ -265,9 +283,12 @@ def _reader(lines: queue.Queue[str | None]) -> None:
 
 
 def _read_stream(stream, lines: queue.Queue[str | None]) -> None:
-    for line in stream:
-        lines.put(line)
-    lines.put(None)
+    try:
+        with stream:
+            for line in stream:
+                lines.put(line)
+    finally:
+        lines.put(None)
 
 
 def _strip_command_separator(command: list[str]) -> list[str]:
@@ -277,6 +298,7 @@ def _strip_command_separator(command: list[str]) -> list[str]:
 
 
 def run(store: Path, interval: float, command: list[str] | None = None) -> int:
+    os.environ["IX_MCP_STORE"] = str(store)
     emitter = Emitter()
     poller = StorePoller(store, interval, emitter)
     poller.start()

--- a/packages/pi-harness/room_event_mapper_test.py
+++ b/packages/pi-harness/room_event_mapper_test.py
@@ -144,6 +144,32 @@ class MapperTest(unittest.TestCase):
             self.assertTrue(removed["removed"])
             self.assertTrue(removed["cell"]["removed"])
 
+    def test_cell_query_failure_does_not_emit_removals(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = Path(tmp) / "mcp.sqlite"
+            conn = sqlite3.connect(store)
+            conn.executescript(SCHEMA)
+            conn.execute(
+                "INSERT INTO cells VALUES (?, ?, ?, ?, ?)",
+                ("cell-kept", "Kept", 0, json.dumps([]), 1.0),
+            )
+            conn.commit()
+            conn.close()
+
+            emitter = CaptureEmitter()
+            poller = mapper.StorePoller(store, 0.1, emitter)  # type: ignore[arg-type]
+            poller.poll_once()
+            self.assertEqual(emitter.events[-1]["cell"]["id"], "cell-kept")
+
+            conn = sqlite3.connect(store)
+            conn.execute("DROP TABLE cells")
+            conn.commit()
+            conn.close()
+
+            before = len(emitter.events)
+            poller.poll_once()
+            self.assertEqual(len(emitter.events), before)
+
     def test_spawned_command_gets_store_env(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             store = Path(tmp) / "mcp.sqlite"

--- a/packages/pi-harness/room_event_mapper_test.py
+++ b/packages/pi-harness/room_event_mapper_test.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -111,6 +113,66 @@ class MapperTest(unittest.TestCase):
 
             poller.poll_once()
             self.assertEqual(len(emitter.events), 3)
+
+    def test_polls_removed_presentation_cell(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = Path(tmp) / "mcp.sqlite"
+            conn = sqlite3.connect(store)
+            conn.executescript(SCHEMA)
+            conn.execute(
+                "INSERT INTO cells VALUES (?, ?, ?, ?, ?)",
+                ("cell-removed", "Stale", 0, json.dumps([]), 1.0),
+            )
+            conn.commit()
+            conn.close()
+
+            emitter = CaptureEmitter()
+            poller = mapper.StorePoller(store, 0.1, emitter)  # type: ignore[arg-type]
+            poller.poll_once()
+            self.assertEqual(emitter.events[-1]["cell"]["id"], "cell-removed")
+
+            conn = sqlite3.connect(store)
+            conn.execute("DELETE FROM cells WHERE id = ?", ("cell-removed",))
+            conn.commit()
+            conn.close()
+
+            poller.poll_once()
+            removed = emitter.events[-1]
+            self.assertEqual(removed["type"], "cell_update")
+            self.assertEqual(removed["cell_kind"], "presentation")
+            self.assertEqual(removed["id"], "cell-removed")
+            self.assertTrue(removed["removed"])
+            self.assertTrue(removed["cell"]["removed"])
+
+    def test_spawned_command_gets_store_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = Path(tmp) / "mcp.sqlite"
+            env_seen = Path(tmp) / "env-seen.txt"
+            old = os.environ.pop("IX_MCP_STORE", None)
+            old_env_seen = os.environ.get("ENV_SEEN")
+            os.environ["ENV_SEEN"] = str(env_seen)
+            try:
+                rc = mapper.run(
+                    store,
+                    0.05,
+                    [
+                        sys.executable,
+                        "-c",
+                        "import os, pathlib; pathlib.Path(os.environ['ENV_SEEN']).write_text(os.environ.get('IX_MCP_STORE', ''))",
+                    ],
+                )
+            finally:
+                if old is not None:
+                    os.environ["IX_MCP_STORE"] = old
+                else:
+                    os.environ.pop("IX_MCP_STORE", None)
+                if old_env_seen is not None:
+                    os.environ["ENV_SEEN"] = old_env_seen
+                else:
+                    os.environ.pop("ENV_SEEN", None)
+            self.assertEqual(rc, 0)
+            self.assertEqual(env_seen.read_text(), str(store))
+            self.assertEqual(os.environ.get("IX_MCP_STORE"), old)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix Pi MCP room feed edge cases for removed cells and stream termination
- `StorePoller.poll_once` in [room_event_mapper.py](https://github.com/indexable-inc/index/pull/842/files#diff-22973fd261f4acfc9d1ca991e65ef4ac2d720a010c44f228a6facc86861915da) now emits `cell_update` events with `removed=True` for presentation cells that disappear between polls, and skips emitting removals when the cells query fails (distinguished from an empty result by returning `None` on error).
- `_read_stream` now uses a `finally` block to guarantee the termination sentinel is enqueued even if reading raises an exception.
- `run` sets `IX_MCP_STORE` in the environment before starting the poller and any spawned child process.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95ac9b2.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->