### PR TITLE
fix(claude-code): also disable RemoteTrigger in the autonomy lockout

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -124,15 +124,17 @@ let
   );
 
   # Autonomy tools removed from every session: self-watching (Monitor),
-  # self-scheduling (ScheduleWakeup and the cron family), and the
-  # user-interrupting PushNotification. `--disallowedTools` drops them from the
-  # model's tool set regardless of permission mode; `permissions.deny` would not,
-  # since the default `bypassPermissions` posture skips the permission layer.
-  # Monitor and PushNotification are server-gated with no env knob, so this flag
-  # is their only off-switch.
+  # self-scheduling (ScheduleWakeup, the cron family, and RemoteTrigger, which
+  # creates/runs claude.ai routines server-side), and the user-interrupting
+  # PushNotification. `--disallowedTools` drops them from the model's tool set
+  # regardless of permission mode; `permissions.deny` would not, since the
+  # default `bypassPermissions` posture skips the permission layer. Monitor,
+  # PushNotification, and RemoteTrigger are server-gated with no env knob, so
+  # this flag is their only off-switch.
   disallowedAutonomyTools = [
     "Monitor"
     "ScheduleWakeup"
+    "RemoteTrigger"
     "PushNotification"
     "CronCreate"
     "CronDelete"


### PR DESCRIPTION
-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RemoteTrigger` to the autonomy lockout's `disallowedAutonomyTools` list
> Adds `"RemoteTrigger"` to `disallowedAutonomyTools` in [default.nix](https://github.com/indexable-inc/index/pull/845/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b), alongside `ScheduleWakeup` and the cron family, treating it as a self-scheduling tool that should be blocked during autonomy lockout. Comments are updated to clarify which tools are self-scheduling vs. server-gated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c96414.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->