### PR TITLE
feat(claude-code): pare sessions to index MCP, drop built-in meta-tools

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -141,6 +141,28 @@ let
     "CronList"
   ];
 
+  # Lean code-execution agent: the only surface this build needs is the index MCP
+  # (its `mcp__index__*` tools, e.g. python_exec, which MCP namespacing leaves
+  # untouched by `--disallowedTools`). Drop the built-in meta-tools so the model
+  # works turn-by-turn through code execution instead of branching into plan
+  # mode, structured task lists, agent teams, worktrees, or multiple-choice
+  # prompts. Removed regardless of permission mode, same as the autonomy list.
+  disallowedMetaTools = [
+    "EnterPlanMode"
+    "ExitPlanMode"
+    "AskUserQuestion"
+    "TaskCreate"
+    "TaskList"
+    "TaskGet"
+    "TaskUpdate"
+    "TeamCreate"
+    "TeamDelete"
+    "SendMessage"
+    "EnterWorktree"
+    "ExitWorktree"
+    "WaitForMcpServers"
+  ];
+
   # Settings-key defaults that have no env knob, shipped as a JSON the wrapper
   # injects via `--settings`. The package wraps the binary, so it can carry env
   # vars and CLI flags but not a settings.json *key* directly. `--settings` adds
@@ -393,7 +415,7 @@ stdenv.mkDerivation {
       --inherit-argv0 \
       --add-flags --debug \
       --add-flags "--thinking-display summarized" \
-      --add-flags "--disallowedTools ${lib.concatStringsSep "," disallowedAutonomyTools}" \
+      --add-flags "--disallowedTools ${lib.concatStringsSep "," (disallowedAutonomyTools ++ disallowedMetaTools)}" \
       --append-flags "--settings ${settingsDefaultsFile}" \
       ${lib.escapeShellArgs systemPromptWrapperArgs} \
       --set DISABLE_AUTOUPDATER 1 \


### PR DESCRIPTION
-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disallow meta/agent-control tools in the `claude-code` wrapper
> Adds a `disallowedMetaTools` list in [default.nix](https://github.com/indexable-inc/index/pull/846/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b) covering plan mode, task, team, messaging, worktree, and MCP wait operations. The wrapper now passes both `disallowedAutonomyTools` and `disallowedMetaTools` to `--disallowedTools`, preventing the runtime from invoking any of these tools.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75a5460.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->