### PR TITLE
feat(mcp): theme the dashboard to the browser's light/dark setting

### DIFF
--- a/packages/mcp/ix_notebook_mcp/dashboard.py
+++ b/packages/mcp/ix_notebook_mcp/dashboard.py
@@ -27,9 +27,11 @@ from .config import Config
 
 _STUB = (
     "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
-    "<title>ix-mcp</title></head>"
-    "<body style=\"font:14px ui-monospace,monospace;background:#0b0b0c;"
-    "color:#e6e6e6;padding:2rem\">"
+    "<title>ix-mcp</title>"
+    "<style>:root{color-scheme:dark light}"
+    "body{font:14px ui-monospace,monospace;background:#0b0b0c;color:#e6e6e6;padding:2rem}"
+    "@media(prefers-color-scheme:light){body{background:#fbfbfc;color:#1b1b1f}}</style>"
+    "</head><body>"
     "<p>The dashboard UI was not built. Build through nix "
     "(<code>nix build .#mcp</code>), which sets <code>IX_MCP_DASHBOARD_HTML</code> "
     "to the Vite output. The data API is live at "
@@ -48,35 +50,32 @@ def _load_page() -> str:
     return _STUB
 
 
-# Read once at startup: the page is an immutable nix-store artifact for the life
-# of the server, and the live data arrives over the API rather than the HTML.
-_PAGE = _load_page()
-
-
 @functools.lru_cache(maxsize=512)
 def _code_html(code: str) -> str:
-    """A python snippet as self-contained highlighted HTML (inline monokai
-    styles, no wrapping ``<pre>`` so the card controls layout). Every identifier
-    token carries a ``data-ix-name`` so the dashboard can attach the value inlay
-    and hover card to it; the join with values is by name, done in the browser
-    against the job's ``bindings`` (kept out of here so this stays cache-keyed on
-    the code text alone). Cached so each unique snippet is highlighted once, not
-    on every one-second poll; falls back to empty (the card then shows the raw
-    text) when pygments is unavailable."""
+    """A python snippet as highlighted HTML: one ``<span class="...">`` per token
+    using pygments' standard short class names, with no inline colors and no
+    wrapping ``<pre>`` (the card controls layout). The class palette is themed in
+    CSS (``_highlight_css``), so the same cached HTML reads correctly in both the
+    dark and light dashboard. Every identifier token also carries a
+    ``data-ix-name`` so the dashboard can attach the value hover card; the join
+    with values is by name, done in the browser against the job's ``bindings``
+    (kept out of here so this stays cache-keyed on the code text alone). Cached so
+    each unique snippet is highlighted once, not on every one-second poll; falls
+    back to empty (the card then shows the raw text) when pygments is
+    unavailable."""
     if not code:
         return ""
     try:
         from pygments.lexers import PythonLexer
-        from pygments.styles import get_style_by_name
         from pygments.token import Token
 
-        style = get_style_by_name("monokai")
         parts: list[str] = []
         for token_type, value in PythonLexer().get_tokens(code):
             if not value:
                 continue
             text = html.escape(value)
-            css = _token_css(style, token_type)
+            cls = _token_class(token_type)
+            cls_attr = f' class="{cls}"' if cls else ""
             # Anchor only real identifiers (not builtins, operators, or the `@` of
             # a decorator) so the inlay/hover attaches to user namespace names. This
             # also tags attribute parts (`head` in `df.head`); the join is by name,
@@ -84,10 +83,9 @@ def _code_html(code: str) -> str:
             # edge of name-keyed (vs position-keyed) matching.
             if token_type in Token.Name and token_type not in Token.Name.Builtin and value.isidentifier():
                 attr = html.escape(value, quote=True)
-                style_attr = f' style="{css}"' if css else ""
-                parts.append(f'<span data-ix-name="{attr}"{style_attr}>{text}</span>')
-            elif css:
-                parts.append(f'<span style="{css}">{text}</span>')
+                parts.append(f'<span{cls_attr} data-ix-name="{attr}">{text}</span>')
+            elif cls:
+                parts.append(f'<span{cls_attr}>{text}</span>')
             else:
                 parts.append(text)
         return "".join(parts).strip("\n")
@@ -96,20 +94,66 @@ def _code_html(code: str) -> str:
         return ""
 
 
-def _token_css(style, token_type) -> str:
-    """Inline CSS for one pygments token under ``style`` (the noclasses path,
-    rebuilt here so we can also emit identifier anchors)."""
-    spec = style.style_for_token(token_type)
-    parts: list[str] = []
-    if spec.get("color"):
-        parts.append(f"color:#{spec['color']}")
-    if spec.get("bold"):
-        parts.append("font-weight:bold")
-    if spec.get("italic"):
-        parts.append("font-style:italic")
-    if spec.get("underline"):
-        parts.append("text-decoration:underline")
-    return ";".join(parts)
+def _token_class(token_type) -> str:
+    """The pygments standard short CSS class for a token (``k``, ``s``, ``nf``,
+    ...), climbing to the nearest classified ancestor. Empty for plain text,
+    which is then emitted without a span. Matches the class names in the
+    stylesheet ``_highlight_css`` builds."""
+    from pygments.token import STANDARD_TYPES
+
+    ttype = token_type
+    while ttype not in STANDARD_TYPES:
+        ttype = ttype.parent
+    return STANDARD_TYPES[ttype]
+
+
+def _highlight_css() -> str:
+    """Two scoped token palettes for the highlighted source: monokai for the dark
+    dashboard (the default) and a light palette under ``prefers-color-scheme:
+    light``. Both are scoped to ``.ix-code`` so they only touch injected source
+    spans, and the chrome rules (background, line numbers, highlight line) are
+    dropped so tokens inherit the dashboard's own ``--inset`` box. Empty when
+    pygments is unavailable."""
+    try:
+        from pygments.formatters import HtmlFormatter
+    except Exception:
+        return ""
+
+    def token_rules(style_name: str) -> str:
+        defs = HtmlFormatter(style=style_name).get_style_defs(".ix-code")
+        rules: list[str] = []
+        for line in defs.splitlines():
+            stripped = line.strip()
+            # Keep only per-token color rules (".ix-code .<cls> { ... }"), not the
+            # background, line-number, or highlight-line chrome the formatter adds.
+            if not stripped.startswith(".ix-code ."):
+                continue
+            if stripped.startswith(".ix-code .hll"):
+                continue
+            rules.append(stripped)
+        return "\n".join(rules)
+
+    dark = token_rules("monokai")
+    light = token_rules("xcode")
+    return f"{dark}\n@media (prefers-color-scheme: light) {{\n{light}\n}}\n"
+
+
+def _with_highlight_css(page: str) -> str:
+    """Inline the highlight palette into the served page's head so the
+    single-file dashboard stays self-contained (no sidecar request)."""
+    css = _highlight_css()
+    if not css:
+        return page
+    tag = f'<style id="ix-highlight">\n{css}</style>'
+    if "</head>" in page:
+        return page.replace("</head>", f"{tag}</head>", 1)
+    return tag + page
+
+
+# Read once at startup: the page is an immutable nix-store artifact for the life
+# of the server, and the live data arrives over the API rather than the HTML. The
+# highlight palette is inlined now so every served copy carries both themes.
+_PAGE = _with_highlight_css(_load_page())
 
 
 async def start(config: Config) -> web.AppRunner:

--- a/packages/mcp/site/src/App.svelte
+++ b/packages/mcp/site/src/App.svelte
@@ -258,7 +258,7 @@
     gap: 12px;
     align-items: center;
     padding: 11px 18px;
-    background: rgba(11, 11, 12, 0.86);
+    background: var(--header-bg);
     backdrop-filter: blur(8px);
     border-bottom: 1px solid var(--line);
   }

--- a/packages/mcp/site/src/components/StatusChip.svelte
+++ b/packages/mcp/site/src/components/StatusChip.svelte
@@ -21,12 +21,12 @@
   }
   .running {
     background: var(--active);
-    color: #0b0b0c;
+    color: var(--on-active);
     border-color: var(--active);
   }
   .error {
     color: var(--err);
-    border-color: #43282b;
+    border-color: var(--err-line);
   }
   .cancelled {
     color: var(--muted);

--- a/packages/mcp/site/src/style.css
+++ b/packages/mcp/site/src/style.css
@@ -1,4 +1,8 @@
 :root {
+  /* Dark is the default palette; the light overrides live in the
+     prefers-color-scheme media query at the foot of this file. color-scheme
+     keeps native UI (scrollbars, form controls) in step with the theme. */
+  color-scheme: dark;
   --bg: #0b0b0c;
   --panel: #141416;
   --panel-2: #1a1a1d;
@@ -12,7 +16,43 @@
   --active: #f2f2f2;
   --err: #cf5a5a;
   --accent: #6ea8fe;
+  /* Derived roles, named so components never hardcode a literal: text that sits
+     on an --active fill, the error chip's border, the header's translucent
+     backdrop, and the text selection. */
+  --on-active: #0b0b0c;
+  --err-line: #43282b;
+  --header-bg: rgba(11, 11, 12, 0.86);
+  --sel-bg: #33333a;
+  --sel-fg: #ffffff;
   --mono: 'Berkeley Mono', ui-monospace, 'SF Mono', SFMono-Regular, Menlo, 'Cascadia Code', monospace;
+}
+
+/* Follow the browser's light preference. Only the palette flips; every rule
+   below is authored against the variables, so the layout is untouched. The
+   highlighted-source token colors flip too, served as a second scoped palette
+   by dashboard.py (see _highlight_css). */
+@media (prefers-color-scheme: light) {
+  :root {
+    color-scheme: light;
+    --bg: #fbfbfc;
+    --panel: #ffffff;
+    --panel-2: #f1f1f4;
+    --inset: #f6f6f8;
+    --line: #e4e4e8;
+    --line-2: #d4d4da;
+    --text: #1b1b1f;
+    --dim: #55555c;
+    --muted: #80808a;
+    --faint: #a8a8b0;
+    --active: #18181b;
+    --err: #c0392b;
+    --accent: #2563eb;
+    --on-active: #fbfbfc;
+    --err-line: #f0c9c4;
+    --header-bg: rgba(251, 251, 252, 0.86);
+    --sel-bg: #cfe0ff;
+    --sel-fg: #0b0b0c;
+  }
 }
 
 * {
@@ -64,8 +104,8 @@ body {
 }
 
 ::selection {
-  background: #33333a;
-  color: #fff;
+  background: var(--sel-bg);
+  color: var(--sel-fg);
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
## What
Make the MCP dashboard (`packages/mcp`) follow the browser's `prefers-color-scheme`. It stays dark by default and switches to a light palette when the browser asks for light.

## Why
The dashboard was dark-only with the palette hardcoded, so a user on a light system got a forced dark UI.

## How
- `site/src/style.css`: one `@media (prefers-color-scheme: light)` block overrides the `:root` variables, plus `color-scheme` and named role vars (`--on-active`, `--err-line`, `--header-bg`, `--sel-bg/-fg`) so components stop hardcoding literals. `App.svelte`, `StatusChip.svelte`, and `::selection` move onto those vars.
- `ix_notebook_mcp/dashboard.py`: code highlighting moves off baked monokai colors (whose near-white default token is unreadable on a light background). It now emits pygments class names (keeping the `data-ix-name` hover anchors) and serves two scoped token palettes (monokai default, xcode under light), inlined into the page head so the single-file dashboard stays self-contained. The no-UI stub is themed too.

## Validation
`nix build .#mcp` green; built single-file page carries the light palette; subprocess smoke confirmed class-based tokens and the dark/light token split.

Generated with `claude`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Theme the MCP dashboard to the browser's light/dark color scheme preference
> - Adds a CSS variable-driven theming system to [style.css](https://github.com/indexable-inc/index/pull/848/files#diff-4774a2c52f3e46291224b8fed637455657aa84d7745354813ce3e0e9f8443709), defaulting to dark mode with a full palette override for `prefers-color-scheme: light`.
> - Switches highlighted code in [dashboard.py](https://github.com/indexable-inc/index/pull/848/files#diff-42d31638eb95030752ef7a84f47bf14ecd13cbfe141948c40115b8cae061ce5e) from inline token styles (monokai) to CSS class-based spans, with a scoped `<style id="ix-highlight">` inlined at startup covering both monokai (dark) and xcode (light) palettes.
> - Updates `App.svelte` and `StatusChip.svelte` to use theme variables (`--header-bg`, `--on-active`, `--err-line`) instead of hardcoded colors.
> - Behavioral Change: code highlighting now relies on an external stylesheet rather than inline styles; any tooling that depends on inline token colors will no longer find them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb25f6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->