### PR TITLE
feat(mcp): stream results via yield, drop print as a channel

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1069,6 +1069,100 @@ let
     asyncio.run(main())
     print("rich-ok")
   '';
+  # Proves the yielding-cell contract end to end: a cell that `yield Result(...)`
+  # streams every yielded Result to the store (the dashboard) and to the model
+  # (to_mcp), keeps its top-level names in the namespace like a normal cell, and a
+  # non-Result yield fails the run. A plain (non-yielding) cell is unchanged. In
+  # process (a shell, the store), no kernel boot or network, so the sandbox runs it.
+  yieldTestPy = pkgs.writeText "ix-mcp-yield-test.py" ''
+    import asyncio
+    import json
+    import os
+    import sqlite3
+    import tempfile
+
+    from IPython.core.interactiveshell import InteractiveShell
+
+    InteractiveShell.instance()
+
+    store_path = tempfile.mktemp(suffix=".db")
+    os.environ["IX_MCP_STORE"] = store_path
+
+    from ix_notebook_mcp import outputs, runtime
+
+    ns = {}
+    runtime.install(ns)
+    run = ns["__ix_run"]
+
+
+    async def main():
+        conn = sqlite3.connect(store_path)
+        conn.row_factory = sqlite3.Row
+
+        # A yielding cell streams multiple Results; its top-level names persist.
+        code = (
+            "acc = 0\n"
+            "for i in range(3):\n"
+            "    acc += i\n"
+            "    yield Result.ok(f'step {i}')\n"
+            "yield Result.of(acc)"
+        )
+        job = await run(code, budget=3.0, name="yield")
+        await job.task
+        assert job.status == "done", (job.status, job.error)
+        assert ns["acc"] == 3, ns.get("acc")
+        outs = json.loads(
+            conn.execute("SELECT outputs FROM executions WHERE id = ?", (job.id,)).fetchone()[0]
+        )
+        htmls = [o["data"].get("text/html") for o in outs if "text/html" in o["data"]]
+        assert len(htmls) == 4, ("expected 4 yielded results", len(htmls), outs)
+
+        # Each yielded Result reaches the model: to_mcp over the stored bundles
+        # hands back the llm text for every one.
+        mcp = outputs.to_mcp(
+            [{"output_type": "display_data", "data": o["data"], "metadata": {}} for o in outs]
+        )
+        texts = [c.text for c in mcp if getattr(c, "text", None) is not None]
+        assert "step 0" in texts and "3" in texts, texts
+
+        # A non-Result yield fails the run with the contract message.
+        bad = await run("yield 123", budget=3.0, name="bad")
+        await bad.task
+        assert bad.status == "error", bad.status
+        assert "was not a Result" in (bad.error or ""), bad.error
+
+        # A normal (non-yielding) cell is unchanged: it must still end with a Result.
+        plain = await run("Result.ok('plain')", budget=3.0, name="plain")
+        await plain.task
+        assert plain.status == "done", (plain.status, plain.error)
+
+
+    asyncio.run(main())
+    print("yield-ok")
+  '';
+
+  yieldSmoke =
+    pkgs.runCommand "ix-mcp-yield-smoke"
+      {
+        nativeBuildInputs = [ mcpPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        ${lib.getExe mcpPython} ${yieldTestPy} >stdout 2>stderr || {
+          echo "ix-mcp yield smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -qx 'yield-ok' stdout || {
+          echo "ix-mcp yield smoke did not confirm yielded results:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
+
   richSmoke =
     pkgs.runCommand "ix-mcp-rich-smoke"
       {
@@ -1806,6 +1900,7 @@ package.overrideAttrs (old: {
         runtimeSmoke
         wedgeSmoke
         richSmoke
+        yieldSmoke
         bindingsSmoke
         bindDefaultSmoke
         viewSmoke

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -38,6 +38,7 @@ import os
 import sys
 import time
 import traceback
+import types
 import uuid
 
 _ix_current: contextvars.ContextVar = contextvars.ContextVar("ix_current_job", default=None)
@@ -74,13 +75,27 @@ _MAX_TEXT_BUNDLE = 400_000
 _MAX_IMAGE_BUNDLE = 4_000_000
 
 _RESULT_REQUIRED = (
-    "python_exec: every cell must END with a Result(...). This cell's last "
-    "expression was not a Result, so nothing was returned. Wrap your final value:\n"
+    "python_exec: a cell must declare its result. Either END with a Result(...), "
+    "or `yield Result(...)` one or more times to stream results as you go. This "
+    "cell's last expression was not a Result and it did not yield, so nothing was "
+    "returned. Wrap your final value (or yield each result):\n"
     "  Result.text('done')                       # same text to human and model\n"
     "  Result.ok('what happened')                # a quiet confirmation for a side effect\n"
     "  Result.of(value)                          # render any value richly for the human\n"
     "  Result(user_html='<b>hi</b>', llm_result='hi', llm_images=[fig])\n"
-    "Curate the human's view of the most important results with cells.add(value)."
+    "  yield Result.ok('step 1'); ...; yield Result.of(df)   # stream as you go\n"
+    "Print is not a channel: stdout is not returned to the model and is hidden in "
+    "the dashboard by default, so surface anything worth seeing as a Result."
+)
+
+_YIELD_REQUIRED = (
+    "python_exec: this cell uses `yield` but yielded no Result(...). Yield at "
+    "least one Result(...) so the run declares what the human and model receive."
+)
+
+_YIELD_NOT_RESULT = (
+    "python_exec: a yielded value was not a Result(...). Every top-level `yield` "
+    "in a cell must yield a Result (Result.text/ok/of or Result(user_html=...))."
 )
 
 # Opened lazily in install(); None when no store path is configured (the
@@ -565,18 +580,90 @@ class Cells:
 cells = Cells()
 
 
-def _compile(code: str, filename: str):
-    """Compile statements with top-level ``await`` allowed, capturing the value
-    of a trailing expression into ``__ix_result`` (REPL-style), so a job has a
-    result like a notebook cell does."""
+# AST node types that open their own scope: a `yield` (or a name binding) inside
+# one of these belongs to that inner scope, not the cell's top level.
+_NESTED_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+
+
+def _has_toplevel_yield(nodes) -> bool:
+    """True if a ``yield``/``yield from`` appears at the cell's own top level
+    (not inside a nested def, lambda, or class). Such a cell is run as a
+    generator: each ``yield Result(...)`` streams a result to both the human and
+    the model, instead of the cell ending with a single trailing Result."""
+    for node in nodes:
+        if isinstance(node, (ast.Yield, ast.YieldFrom)):
+            return True
+        if isinstance(node, _NESTED_SCOPES):
+            continue  # its own scope: a yield in there is that scope's, not ours
+        if _has_toplevel_yield(ast.iter_child_nodes(node)):
+            return True
+    return False
+
+
+def _compile(code: str, filename: str) -> tuple[str, "types.CodeType"]:
+    """Compile a cell, returning ``(mode, code_obj)``.
+
+    ``mode == "gen"`` for a cell that yields at top level (run as an async
+    generator; see :func:`_compile_generator`). Otherwise ``mode == "expr"``: the
+    classic path that allows top-level ``await`` and captures a trailing
+    expression into ``__ix_result`` (REPL-style) so the cell has a result like a
+    notebook cell does."""
     tree = ast.parse(code, filename, "exec")
+    if _has_toplevel_yield(tree.body):
+        return ("gen", _compile_generator(code, filename))
     if tree.body and isinstance(tree.body[-1], ast.Expr):
         last = tree.body[-1]
         assign = ast.Assign(targets=[ast.Name(id="__ix_result", ctx=ast.Store())], value=last.value)
         ast.copy_location(assign, last)
         tree.body[-1] = assign
         ast.fix_missing_locations(tree)
-    return compile(tree, filename, "exec", flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
+    return ("expr", compile(tree, filename, "exec", flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT))
+
+
+def _compile_generator(code: str, filename: str) -> "types.CodeType":
+    """Compile a yielding cell as ``async def __ix_cell__()`` whose top-level
+    names stay in the shared namespace.
+
+    Wrapping the body in an async function makes top-level ``yield`` and ``await``
+    legal; declaring every name the body binds ``global`` keeps assignments
+    persistent across calls, exactly like a normal module-level cell. The set of
+    bound names is read from Python's own scope analysis (the compiled function's
+    locals and cellvars), so it is precisely the names that would otherwise be
+    function-locals, without re-deriving Python's scoping rules by hand. The user
+    statements keep their original line numbers (only an enclosing def is added),
+    so tracebacks still point at the cell's real lines."""
+    user = ast.parse(code, filename, "exec")
+    shell = ast.parse("async def __ix_cell__():\n    pass\n", filename, "exec")
+    func = shell.body[0]
+    func.body = user.body  # the cell's own statements, original line numbers intact
+    ast.fix_missing_locations(shell)
+    probe = compile(shell, filename, "exec")
+    cell_code = next(
+        c for c in probe.co_consts if isinstance(c, types.CodeType) and c.co_name == "__ix_cell__"
+    )
+    # co_varnames + co_cellvars are the names this function binds; making them
+    # global is what turns "function locals" back into "notebook globals". Names
+    # like ".0" (comprehension internals) live in their own code objects, never
+    # here, but filter the dotted ones defensively.
+    names = [n for n in (cell_code.co_varnames + cell_code.co_cellvars) if not n.startswith(".")]
+    if names:
+        func.body.insert(0, ast.parse("global " + ", ".join(names)).body[0])
+        ast.fix_missing_locations(shell)
+    return compile(shell, filename, "exec")
+
+
+def _display_result(result: "Result") -> None:
+    """Show one yielded Result to both audiences. The IPython display goes onto
+    the running job's captured outputs (the dashboard) and out on iopub (the
+    model's tool result), the same path the trailing Result takes \u2014 so a
+    yielding cell needs no separate plumbing."""
+    from IPython.display import display
+
+    try:
+        display(result)
+    except Exception:
+        # Rich display is best-effort; a formatter failure must not abort the run.
+        pass
 
 
 async def _runner(job: Job, ns: dict) -> None:
@@ -590,23 +677,51 @@ async def _runner(job: Job, ns: dict) -> None:
     try:
         # Compile inside the runner so a SyntaxError is recorded as a job error
         # (status + traceback in the store/dashboard) instead of escaping __ix_run.
-        code_obj = _compile(job.code, f"<job {job.id}>")
+        mode, code_obj = _compile(job.code, f"<job {job.id}>")
         ns.pop("__ix_result", None)
-        maybe = eval(code_obj, ns)
-        if inspect.iscoroutine(maybe):
-            await maybe
-        job.result = ns.pop("__ix_result", None)
-        if isinstance(job.result, Result):
-            job.status = "done"
-        else:
-            # Enforce the Result contract: every cell must END with a Result so a
-            # run always declares what the human sees and what the model gets.
-            # A bare value (or a side-effecting cell that returns None) is a
-            # failed run with an instructive message rather than a silent pass.
-            job.status = "error"
-            job.error = _RESULT_REQUIRED
-            job._append(job.error)
+        if mode == "gen":
+            # A yielding cell streams results: drain the async generator and
+            # display each yielded Result so it reaches the human (the job's
+            # captured outputs) and the model (iopub) as it is produced. The
+            # yields ARE the results, so there is no trailing-Result requirement.
+            exec(code_obj, ns)
+            agen = ns.pop("__ix_cell__")()
+            emitted = 0
+            async for item in agen:
+                if not isinstance(item, Result):
+                    job.status = "error"
+                    job.error = _YIELD_NOT_RESULT
+                    job._append(job.error)
+                    break
+                _display_result(item)
+                emitted += 1
+            else:
+                # Loop ran to completion (no non-Result break).
+                if emitted == 0:
+                    job.status = "error"
+                    job.error = _YIELD_REQUIRED
+                    job._append(job.error)
+                else:
+                    job.status = "done"
+            # The results were displayed as they streamed; there is no single
+            # trailing value to return.
             job.result = None
+        else:
+            maybe = eval(code_obj, ns)
+            if inspect.iscoroutine(maybe):
+                await maybe
+            job.result = ns.pop("__ix_result", None)
+            if isinstance(job.result, Result):
+                job.status = "done"
+            else:
+                # Enforce the Result contract: a non-yielding cell must END with a
+                # Result so a run always declares what the human sees and what the
+                # model gets. A bare value (or a side-effecting cell that returns
+                # None) is a failed run with an instructive message, not a silent pass.
+                job.status = "error"
+                job.error = _RESULT_REQUIRED
+                job._append(job.error)
+                job.result = None
     except asyncio.CancelledError:
         job.status = "cancelled"
         raise

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -99,9 +99,14 @@ mcp = FastMCP(
         "listing. `fff.map(pattern)` groups hits into a foldable code map with "
         "definitions ranked first, for \u201cwhere is X defined and used?\u201d. "
         "For meaning-based recall across a corpus, `import search`. "
-        "EVERY cell MUST END with a `Result(...)`; the kernel rejects a cell whose "
-        "last expression is not one (a bare value or a side-effect that returns "
-        "nothing fails with a reminder). A Result splits the human view from your "
+        "Return results through `Result`, never `print`: a cell's stdout is NOT "
+        "sent to you and is hidden in the dashboard by default (it is kept only "
+        "for paging via jobs['<id>'].output), so surface anything worth seeing as "
+        "a Result. A cell must either END with a `Result(...)` or `yield "
+        "Result(...)` one or more times \u2014 each yielded Result streams to both "
+        "the human and you the moment it is produced, so prefer yielding as you go "
+        "to report progress and partial results. The kernel rejects a cell that "
+        "neither ends with nor yields a Result. A Result splits the human view from your "
         "view: the dashboard renders `user_html` for the human while your tool "
         "result gets `llm_result` text plus any `llm_images`, so a big rendered "
         "view never costs you tokens and you can hand yourself back images. Use the "
@@ -156,8 +161,12 @@ Content = list[outputs.Content]
         "shared event loop: a blocking call (`subprocess.run`, `time.sleep`, a heavy "
         "CPU op) freezes EVERY job and your own next cell, so it MUST be wrapped in "
         "`await asyncio.to_thread(...)` (or use an async API) and backgrounded if slow. "
-        "EVERY cell MUST END "
-        "with a `Result(...)` or the run is rejected: `Result.text('done')` (same text "
+        "Results go back through `Result`, never `print`: stdout is NOT returned to you "
+        "and is hidden in the dashboard by default (kept only for paging via "
+        "jobs['<id>'].output). A cell must END with a `Result(...)` OR `yield Result(...)` "
+        "one or more times (each yielded Result streams to both the human and you as it "
+        "is produced \u2014 prefer yielding to report progress); a cell that does neither is "
+        "rejected. `Result.text('done')` (same text "
         "to human and model), `Result.ok('what happened')` (a side-effect confirmation), "
         "`Result.of(value)` (render a DataFrame/figure/value richly for the human, its "
         "repr to you), or `Result(user_html=..., llm_result=..., llm_images=[fig])` to "
@@ -183,13 +192,15 @@ async def python_exec(
         json.dumps({"job": summary.get("id"), "status": summary.get("status"), "running": summary.get("running")})
     )
     parts: Content = [header]
-    # The job's captured stdout/stderr and (on failure) its traceback live in the
-    # summary, not in the kernel display stream, so surface them to the caller.
-    captured = summary.get("output")
-    if captured:
-        parts.append(outputs.text(captured))
-    # Rich result blocks (images / HTML / the result repr) come from the kernel
-    # display; drop the "(no output)" placeholder to_mcp emits when there were none.
+    # Print is not a channel back to the model: a job's stdout is captured for the
+    # dashboard (collapsed) and for paging via jobs['<id>'].output, but it is not
+    # returned here \u2014 results come from Result/yield. A failing run is the
+    # exception: its traceback IS the result, so surface that.
+    if summary.get("status") == "error" and summary.get("error"):
+        parts.append(outputs.text(summary["error"]))
+    # Rich result blocks (images / HTML / the result repr, including every yielded
+    # Result) come from the kernel display; drop the "(no output)" placeholder
+    # to_mcp emits when there were none.
     parts.extend(item for item in rendered if getattr(item, "text", None) != "(no output)")
     # When the reply was clipped to fit, the full run still lives in the kernel as
     # jobs['<id>']. Point the caller at it (with the ops to page it) so a large
@@ -198,7 +209,7 @@ async def python_exec(
     job_id = summary.get("id")
     output_chars = summary.get("output_chars") or 0
     result_chars = summary.get("result_chars") or 0
-    clipped = output_chars > len(captured or "") or result_chars > outputs.MAX_TEXT_CHARS
+    clipped = result_chars > outputs.MAX_TEXT_CHARS
     if clipped and job_id:
         parts.append(
             outputs.text(

--- a/packages/mcp/site/src/components/JobCard.svelte
+++ b/packages/mcp/site/src/components/JobCard.svelte
@@ -15,10 +15,11 @@
   const hasRich = $derived(job.outputs.length > 0);
   // Don't repeat the error if it's already in the captured stdout tail.
   const showError = $derived(!!job.error && !(job.output ?? '').includes(job.error));
-  // A run reads as its output by default: the source is one click away, not in
-  // the way. Only runs that actually carry source get a reveal toggle.
-  const hasCode = $derived(!!(job.code_html || job.code));
-  let showCode = $state(false);
+  // A run reads as its results by default: the source and the captured stdout are
+  // one click away, not in the way (stdout is not the channel — a run reports
+  // through Results). Only runs that carry source or stdout get a reveal toggle.
+  const hasDetails = $derived(!!(job.code_html || job.code || job.output));
+  let showDetails = $state(false);
 </script>
 
 <article class="job {job.status}">
@@ -27,27 +28,26 @@
   <button
     class="hdr"
     type="button"
-    aria-expanded={showCode}
-    disabled={!hasCode}
-    title={hasCode ? (showCode ? 'Hide source' : 'Show source') : undefined}
-    onclick={() => (showCode = !showCode)}
+    aria-expanded={showDetails}
+    disabled={!hasDetails}
+    title={hasDetails ? (showDetails ? 'Hide source & output' : 'Show source & output') : undefined}
+    onclick={() => (showDetails = !showDetails)}
   >
-    {#if hasCode}<span class="caret" aria-hidden="true">{showCode ? '▾' : '▸'}</span>{/if}
+    {#if hasDetails}<span class="caret" aria-hidden="true">{showDetails ? '▾' : '▸'}</span>{/if}
     <StatusChip status={job.status} />
     {#if title}<span class="name">{title}</span>{/if}
     <span class="dur">{elapsed}</span>
   </button>
 
-  {#if showCode}
+  {#if showDetails}
     {#if job.code_html}
       <CodeView html={job.code_html} bindings={job.bindings} />
     {:else if job.code}
       <pre class="code">{job.code}</pre>
     {/if}
-  {/if}
-
-  {#if job.output}
-    <pre class="out">{job.output}</pre>
+    {#if job.output}
+      <pre class="out">{job.output}</pre>
+    {/if}
   {/if}
 
   {#if hasRich}


### PR DESCRIPTION
-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stream Results via `yield` in MCP notebook cells, dropping stdout as a channel
> - Cells can now either end with a `Result` or `yield` one or more `Result` values; top-level yields are detected via AST analysis in [`runtime.py`](https://github.com/indexable-inc/index/pull/849/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) and compiled as async generators.
> - Each yielded `Result` is streamed to the job outputs and model as it is produced; the job is marked done only if at least one `Result` was yielded.
> - [`tools.py`](https://github.com/indexable-inc/index/pull/849/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) no longer returns captured stdout on successful runs; only rich result blocks and (on failure) the traceback are returned.
> - In [`JobCard.svelte`](https://github.com/indexable-inc/index/pull/849/files#diff-fda0bddd25f2dbc1ad654afeaebf1aad93841277ef3e930742e260c49f11c03e), stdout is hidden by default and only shown when the details section is expanded; rich outputs remain visible.
> - Behavioral Change: cells that previously relied on stdout being returned to the model or visible by default will now need to use `Result` or `yield Result(...)` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0328e39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->