### PR TITLE
feat(mcp): keyboard input and app control in the screen module

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1878,7 +1878,7 @@ let
         mkdir -p "$out"
       '';
 
-  screenBundled = importTest "screen" "import screen; print('screen-ok', callable(screen.capture), callable(screen.click), callable(screen.accessibility_trusted))";
+  screenBundled = importTest "screen" "import screen; print('screen-ok', all(callable(getattr(screen, n)) for n in ('capture', 'click', 'write', 'press', 'key_down', 'key_up', 'apps', 'frontmost', 'launch', 'activate', 'terminate', 'accessibility_trusted')))";
   vmkitBundled = importTest "vmkit" "import vmkit; print('vmkit-ok', callable(vmkit.boot_linux), callable(vmkit.drive), callable(vmkit.screenshot))";
 in
 package.overrideAttrs (old: {

--- a/packages/mcp/src/screen/screen/__init__.py
+++ b/packages/mcp/src/screen/screen/__init__.py
@@ -15,6 +15,16 @@ the framebuffer and the mouse, and posts synthetic input through CoreGraphics.
     screen.click(100, 200)          # synthetic click (needs Accessibility, see below)
     screen.drag(100, 200, 300, 400) # press, move, release
 
+    screen.write("hello world")     # type text into the focused app
+    screen.press("a", "cmd")        # a key or chord (Cmd+A); also press("return")
+    screen.frontmost()              # app control: which app is active
+    screen.activate("Safari")       # launch / activate / list (apps()) / terminate
+
+Keyboard input (`write`, `press`, `key_down`/`key_up`) posts synthetic events
+and so needs Accessibility permission, like the mouse helpers. App control
+(`apps`, `frontmost`, `launch`, `activate`, `terminate`) goes through NSWorkspace
+and needs no special permission.
+
 Capture returns a `PIL.Image` in RGB. Because the worker renders any returned
 PIL image inline, returning the result of `capture()` from a cell shows the
 screenshot directly. NumPy users can call `capture_ndarray()` for an
@@ -53,19 +63,29 @@ from dataclasses import dataclass
 
 __all__ = [
     "AccessibilityNotTrusted",
+    "App",
     "Point",
     "Rect",
     "Size",
     "accessibility_trusted",
+    "activate",
+    "apps",
     "capture",
     "capture_ndarray",
     "click",
     "cursor",
     "drag",
+    "frontmost",
+    "key_down",
+    "key_up",
+    "launch",
     "mouse_down",
     "mouse_up",
     "move",
+    "press",
     "screen_size",
+    "terminate",
+    "write",
 ]
 
 if sys.platform != "darwin":
@@ -286,3 +306,220 @@ def drag(x1: float, y1: float, x2: float, y2: float) -> None:
     _post_mouse(Quartz.kCGEventLeftMouseDown, x1, y1, Quartz.kCGMouseButtonLeft)
     _post_mouse(Quartz.kCGEventLeftMouseDragged, x2, y2, Quartz.kCGMouseButtonLeft)
     _post_mouse(Quartz.kCGEventLeftMouseUp, x2, y2, Quartz.kCGMouseButtonLeft)
+
+
+# macOS ANSI virtual key codes for keys that have no character to `write()`:
+# named keys (Return, Tab, arrows, ...) and the letter/digit codes a chord like
+# Cmd+A needs. Layout-independent text typing does not use these \u2014 `write()`
+# injects Unicode directly \u2014 so this table only needs the keys you press by
+# name or combine with a modifier.
+_KEYS: dict[str, int] = {
+    # letters (US ANSI positions; the character a key produces depends on the
+    # active layout, but a chord like Cmd+A keys off the physical position)
+    "a": 0, "s": 1, "d": 2, "f": 3, "h": 4, "g": 5, "z": 6, "x": 7, "c": 8,
+    "v": 9, "b": 11, "q": 12, "w": 13, "e": 14, "r": 15, "y": 16, "t": 17,
+    "o": 31, "u": 32, "i": 34, "p": 35, "l": 37, "j": 38, "k": 40, "n": 45, "m": 46,
+    # digits
+    "1": 18, "2": 19, "3": 20, "4": 21, "5": 23, "6": 22, "7": 26, "8": 28, "9": 25, "0": 29,
+    # whitespace / editing
+    "return": 36, "enter": 36, "tab": 48, "space": 49, "delete": 51, "backspace": 51,
+    "escape": 53, "esc": 53, "forward_delete": 117,
+    # navigation
+    "home": 115, "end": 119, "pageup": 116, "pagedown": 121,
+    "left": 123, "right": 124, "down": 125, "up": 126,
+    # function row
+    "f1": 122, "f2": 120, "f3": 99, "f4": 118, "f5": 96, "f6": 97, "f7": 98,
+    "f8": 100, "f9": 101, "f10": 109, "f11": 103, "f12": 111,
+    # common punctuation
+    "minus": 27, "equal": 24, "leftbracket": 33, "rightbracket": 30, "backslash": 42,
+    "semicolon": 41, "quote": 39, "comma": 43, "period": 47, "slash": 44, "grave": 50,
+}
+
+_MODIFIERS: dict[str, int] = {
+    "command": Quartz.kCGEventFlagMaskCommand,
+    "cmd": Quartz.kCGEventFlagMaskCommand,
+    "shift": Quartz.kCGEventFlagMaskShift,
+    "option": Quartz.kCGEventFlagMaskAlternate,
+    "opt": Quartz.kCGEventFlagMaskAlternate,
+    "alt": Quartz.kCGEventFlagMaskAlternate,
+    "control": Quartz.kCGEventFlagMaskControl,
+    "ctrl": Quartz.kCGEventFlagMaskControl,
+}
+
+
+def _resolve_key(name: str) -> int:
+    code = _KEYS.get(name.lower())
+    if code is None:
+        raise ValueError(
+            f"screen: unknown key {name!r}. Use a named key ({', '.join(sorted(_KEYS))}) "
+            "for press()/key_down()/key_up(), or write() to type arbitrary text."
+        )
+    return code
+
+
+def _modifier_flags(modifiers: tuple[str, ...]) -> int:
+    flags = 0
+    for mod in modifiers:
+        flag = _MODIFIERS.get(mod.lower())
+        if flag is None:
+            raise ValueError(
+                f"screen: unknown modifier {mod!r}. Use one of: {', '.join(sorted(_MODIFIERS))}."
+            )
+        flags |= flag
+    return flags
+
+
+def _post_key(keycode: int, down: bool, flags: int) -> None:
+    event = Quartz.CGEventCreateKeyboardEvent(None, keycode, down)
+    if flags:
+        Quartz.CGEventSetFlags(event, flags)
+    Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
+
+
+def write(text: str) -> None:
+    """Type ``text`` into the focused app, character by character.
+
+    Injects each character as a Unicode keystroke, so it is independent of the
+    active keyboard layout and handles symbols and non-ASCII. Use this for text;
+    use `press` for named keys (Return, Tab) and shortcuts. Requires
+    Accessibility permission.
+    """
+
+    _require_accessibility()
+    for char in text:
+        for down in (True, False):
+            event = Quartz.CGEventCreateKeyboardEvent(None, 0, down)
+            Quartz.CGEventKeyboardSetUnicodeString(event, len(char), char)
+            Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
+
+
+def press(name: str, *modifiers: str) -> None:
+    """Press and release a named key, optionally as a chord with modifiers.
+
+        screen.press("return")
+        screen.press("a", "cmd")        # Cmd+A (select all)
+        screen.press("left", "shift")   # extend selection left
+
+    ``name`` is a key from the named set or a single letter/digit; modifiers are
+    any of command/cmd, shift, option/opt/alt, control/ctrl. Requires
+    Accessibility permission.
+    """
+
+    _require_accessibility()
+    keycode = _resolve_key(name)
+    flags = _modifier_flags(modifiers)
+    _post_key(keycode, True, flags)
+    _post_key(keycode, False, flags)
+
+
+def key_down(name: str, *modifiers: str) -> None:
+    """Press and hold a key (no release), for chords built up by hand. Pair with
+    `key_up`. Requires Accessibility permission."""
+
+    _require_accessibility()
+    _post_key(_resolve_key(name), True, _modifier_flags(modifiers))
+
+
+def key_up(name: str, *modifiers: str) -> None:
+    """Release a key held with `key_down`. Requires Accessibility permission."""
+
+    _require_accessibility()
+    _post_key(_resolve_key(name), False, _modifier_flags(modifiers))
+
+
+@dataclass(frozen=True, slots=True)
+class App:
+    """A running application: its display name, bundle id, pid, and whether it is
+    the active (frontmost) app."""
+
+    name: str
+    bundle_id: str | None
+    pid: int
+    active: bool
+
+
+def _workspace():
+    """The shared NSWorkspace. AppKit is imported lazily so the common
+    capture/input paths do not pay for it and a stripped environment fails only
+    when app control is actually used."""
+
+    from AppKit import NSWorkspace
+
+    return NSWorkspace.sharedWorkspace()
+
+
+def _as_app(running) -> App:
+    return App(
+        running.localizedName(),
+        running.bundleIdentifier(),
+        int(running.processIdentifier()),
+        bool(running.isActive()),
+    )
+
+
+def _find_running(app: str):
+    """The running application whose bundle id or display name matches ``app``
+    (case-insensitive), or None. App control acts on a running instance, so this
+    is how a name/bundle-id argument resolves to one."""
+
+    key = app.lower()
+    for running in _workspace().runningApplications():
+        if (running.bundleIdentifier() or "").lower() == key or (running.localizedName() or "").lower() == key:
+            return running
+    return None
+
+
+def apps() -> list[App]:
+    """Every running application as an `App`. App control (`activate`,
+    `terminate`) takes a name or bundle id; this is how you discover them."""
+
+    return [_as_app(running) for running in _workspace().runningApplications()]
+
+
+def frontmost() -> App | None:
+    """The active (frontmost) application, or None if there is none."""
+
+    running = _workspace().frontmostApplication()
+    return _as_app(running) if running is not None else None
+
+
+def launch(app: str) -> App | None:
+    """Launch an application by name or full path, or activate it if it is already
+    running. Returns the running `App` once it appears (None if it has not
+    registered yet \u2014 query `apps()`). Needs no Accessibility permission.
+    """
+
+    # NSWorkspace's synchronous replacement (openApplicationAtURL:...) is
+    # completion-handler only; launchApplication_ stays the simplest correct
+    # synchronous call and also foregrounds an already-running app.
+    if not _workspace().launchApplication_(app):
+        raise RuntimeError(
+            f"screen: could not launch app {app!r}. Pass the app's name (e.g. "
+            "'Safari') or its full .app path."
+        )
+    running = _find_running(app)
+    return _as_app(running) if running is not None else None
+
+
+def activate(app: str) -> None:
+    """Bring a running application to the front by name or bundle id. Raises
+    `LookupError` if it is not running (launch it first). Needs no Accessibility
+    permission."""
+
+    from AppKit import NSApplicationActivateIgnoringOtherApps
+
+    running = _find_running(app)
+    if running is None:
+        raise LookupError(f"screen: no running app matches {app!r}; launch() it first.")
+    running.activateWithOptions_(NSApplicationActivateIgnoringOtherApps)
+
+
+def terminate(app: str) -> None:
+    """Ask a running application to quit, by name or bundle id (a normal quit, so
+    it may prompt to save). Raises `LookupError` if it is not running. Needs no
+    Accessibility permission."""
+
+    running = _find_running(app)
+    if running is None:
+        raise LookupError(f"screen: no running app matches {app!r}.")
+    running.terminate()


### PR DESCRIPTION
-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add keyboard input and app control functions to the `screen` module
> - Adds `write`, `press`, `key_down`, and `key_up` functions to type text and send key events via Quartz keyboard events; all require macOS Accessibility permission.
> - Adds an `App` dataclass and functions `apps`, `frontmost`, `launch`, `activate`, and `terminate` for querying and controlling running macOS applications via `NSWorkspace`.
> - Includes a `_KEYS` mapping of named keys to ANSI virtual keycodes and a `_MODIFIERS` mapping for Quartz flag masks; both raise `ValueError` on unknown inputs.
> - Updates the Nix self-test in [default.nix](https://github.com/indexable-inc/index/pull/850/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) to verify all new public API symbols are callable.
> - Risk: keyboard functions silently depend on Accessibility permission being granted; callers receive a `RuntimeError` at call time if it is not.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f52a3b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->