### PR TITLE
Add btop fork package

### DIFF
--- a/ast-grep/nix/rules/no-fetchfromgithub-fixed-hash.yml
+++ b/ast-grep/nix/rules/no-fetchfromgithub-fixed-hash.yml
@@ -1,0 +1,16 @@
+id: no-fetchfromgithub-fixed-hash
+language: nix
+severity: error
+message: "Do not pin GitHub source with `fetchFromGitHub { ... hash = ...; }`. Add it as a flake input with `flake = false` and consume that source instead."
+note: |
+  WHY: A GitHub source used by repo packages is a repository-level dependency,
+  not package-local string data. Putting the pin in flake.lock gives us one
+  update path, visible dependency metadata, and avoids duplicating a rev plus
+  fixed-output hash in Nix expressions.
+  REPO: Add a flake input like `name-src = { url = "github:owner/repo/rev";
+  flake = false; };`, thread it through `ix`, and use that source as `src`.
+rule:
+  any:
+    - pattern: fetchFromGitHub { owner = $OWNER; repo = $REPO; rev = $REV; hash = $HASH; }
+    - pattern: fetchFromGitHub { owner = $OWNER; repo = $REPO; tag = $TAG; hash = $HASH; $$$REST }
+    - pattern: fetchFromGitHub { inherit owner repo rev hash; }

--- a/ast-grep/nix/tests/no-fetchfromgithub-fixed-hash-test.yml
+++ b/ast-grep/nix/tests/no-fetchfromgithub-fixed-hash-test.yml
@@ -1,0 +1,16 @@
+id: no-fetchfromgithub-fixed-hash
+valid:
+  - 'src = ix.toolSrc;'
+  - 'src = fetchFromGitHub { owner = "owner"; repo = "repo"; rev = version; };'
+  - 'src = fetchurl { url = "https://example.com/archive.tar.gz"; hash = "sha256-AAAA"; };'
+invalid:
+  - '{ src = fetchFromGitHub { owner = "owner"; repo = "repo"; rev = "abc"; hash = "sha256-AAAA"; }; }'
+  - |
+    {
+      src = fetchFromGitHub {
+        owner = "owner";
+        repo = "repo";
+        rev = "abc";
+        hash = sourceHash;
+      };
+    }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "btop-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780863565,
+        "narHash": "sha256-o8HUTwhZYiivv/uvd/CUgB/zJpQJ/4aHFx/OWfuLJXs=",
+        "owner": "indexable-inc",
+        "repo": "btop",
+        "rev": "a49aa61bec9b0e0564704c904a3e1689612c8aef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "indexable-inc",
+        "repo": "btop",
+        "rev": "a49aa61bec9b0e0564704c904a3e1689612c8aef",
+        "type": "github"
+      }
+    },
     "clippy-fork": {
       "flake": false,
       "locked": {
@@ -13,6 +30,42 @@
       "original": {
         "owner": "indexable-inc",
         "repo": "clippy",
+        "type": "github"
+      }
+    },
+    "drgn-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777486813,
+        "narHash": "sha256-RyMWHiNfpJ6gAefXVB5cQKbtXQzBEJ+0syPsry2me1I=",
+        "ref": "refs/tags/v0.2.0",
+        "rev": "818b5a7e8a4db82a1e0326667e7afaec5bf5fd19",
+        "revCount": 3016,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/osandov/drgn"
+      },
+      "original": {
+        "ref": "refs/tags/v0.2.0",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/osandov/drgn"
+      }
+    },
+    "fff-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780561592,
+        "narHash": "sha256-6ZmEeN/Ued9FZo/qfUb8/0L02F+8ECV0smAiQvIqyzU=",
+        "owner": "dmtrKovalenko",
+        "repo": "fff",
+        "rev": "1e055f9d7b94f33a7f393ac95e779bed72650d56",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dmtrKovalenko",
+        "ref": "v0.9.1",
+        "repo": "fff",
         "type": "github"
       }
     },
@@ -97,6 +150,23 @@
       "original": {
         "owner": "nix-community",
         "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "launchk-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1749324662,
+        "narHash": "sha256-yZZGCPul1Q8KBgFIG9qkevnOxqnRbK8sqIu5OUPPTFQ=",
+        "owner": "mach-kernel",
+        "repo": "launchk",
+        "rev": "6f5f09e0dfa3fea662e859de5d7d49ac09a9dbe6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mach-kernel",
+        "repo": "launchk",
+        "rev": "6f5f09e0dfa3fea662e859de5d7d49ac09a9dbe6",
         "type": "github"
       }
     },
@@ -227,10 +297,14 @@
     },
     "root": {
       "inputs": {
+        "btop-src": "btop-src",
         "clippy-fork": "clippy-fork",
+        "drgn-src": "drgn-src",
+        "fff-src": "fff-src",
         "ghostty": "ghostty",
         "hermes-agent": "hermes-agent",
         "home-manager": "home-manager",
+        "launchk-src": "launchk-src",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,26 @@
       flake = false;
     };
 
+    btop-src = {
+      url = "github:indexable-inc/btop/a49aa61bec9b0e0564704c904a3e1689612c8aef";
+      flake = false;
+    };
+
+    drgn-src = {
+      url = "git+https://github.com/osandov/drgn?ref=refs/tags/v0.2.0&submodules=1";
+      flake = false;
+    };
+
+    fff-src = {
+      url = "github:dmtrKovalenko/fff/v0.9.1";
+      flake = false;
+    };
+
+    launchk-src = {
+      url = "github:mach-kernel/launchk/6f5f09e0dfa3fea662e859de5d7d49ac09a9dbe6";
+      flake = false;
+    };
+
     # Nous Research's Hermes agent ships its own NixOS module
     # (`nixosModules.default`) and uv2nix-built Python closure. Pinned to
     # a release tag so routine bumps are review events; `nix flake update
@@ -85,6 +105,10 @@
       rust-overlay,
       home-manager,
       hermes-agent,
+      btop-src,
+      drgn-src,
+      fff-src,
+      launchk-src,
       clippy-fork,
       ghostty,
       ...
@@ -145,6 +169,10 @@
           rust-overlay
           home-manager
           hermes-agent
+          btop-src
+          drgn-src
+          fff-src
+          launchk-src
           clippy-fork
           ghostty
           ;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -6,6 +6,10 @@
   rust-overlay,
   home-manager,
   hermes-agent,
+  btop-src,
+  drgn-src,
+  fff-src,
+  launchk-src,
   clippy-fork,
   ghostty,
   # Flake source revision, stamped into builds that want to report it (see
@@ -378,6 +382,10 @@ let
       writeProcessComposeApplication
       writePythonApplication
       ;
+    btopSrc = btop-src;
+    drgnSrc = drgn-src;
+    fffSrc = fff-src;
+    launchkSrc = launchk-src;
   };
 
   /**

--- a/packages/btop/default.nix
+++ b/packages/btop/default.nix
@@ -1,0 +1,12 @@
+{
+  btop,
+  ix,
+}:
+
+btop.overrideAttrs (old: {
+  src = ix.btopSrc;
+
+  meta = old.meta // {
+    homepage = "https://github.com/indexable-inc/btop";
+  };
+})

--- a/packages/btop/package.nix
+++ b/packages/btop/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "btop";
+  packageSet = true;
+  flake = true;
+}

--- a/packages/drgn/default.nix
+++ b/packages/drgn/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitHub,
+  ix,
   python3,
   pkg-config,
   elfutils,
@@ -16,13 +16,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   version = "0.2.0";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "osandov";
-    repo = "drgn";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-RyMWHiNfpJ6gAefXVB5cQKbtXQzBEJ+0syPsry2me1I=";
-    fetchSubmodules = true;
-  };
+  src = ix.drgnSrc;
 
   build-system = [ python3.pkgs.setuptools ];
 

--- a/packages/fff/default.nix
+++ b/packages/fff/default.nix
@@ -1,13 +1,13 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitHub,
+  ix,
   cmake,
   pkg-config,
   stdenv,
 }:
 # External-Rust-tool house style: a standalone third-party binary built from a
-# pinned `fetchFromGitHub` rev with `rustPlatform.buildRustPackage`. See
+# pinned flake source input with `rustPlatform.buildRustPackage`. See
 # `agent-context/sections/13-dependency-intake.md` and `packages/launchk`.
 #
 # fff is a fast file-search toolkit for humans and AI agents. Two artifacts ship
@@ -16,12 +16,7 @@
 #   * `lib/libfff_c.{so,dylib}` – the stable C ABI (crate `fff-c`), which the
 #     `mcp` package loads via ctypes to expose `import fff` in notebook sessions.
 let
-  src = fetchFromGitHub {
-    owner = "dmtrKovalenko";
-    repo = "fff";
-    rev = "v0.9.1";
-    hash = "sha256-6ZmEeN/Ued9FZo/qfUb8/0L02F+8ECV0smAiQvIqyzU=";
-  };
+  src = ix.fffSrc;
 in
 rustPlatform.buildRustPackage {
   pname = "fff";

--- a/packages/launchk/default.nix
+++ b/packages/launchk/default.nix
@@ -1,18 +1,13 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitHub,
+  ix,
 }:
 # Reference package for the external-Rust-tool house style: a standalone
-# third-party binary built from a pinned `fetchFromGitHub` rev with
+# third-party binary built from a pinned flake source input with
 # `rustPlatform.buildRustPackage`. See `agent-context/sections/13-dependency-intake.md`.
 let
-  src = fetchFromGitHub {
-    owner = "mach-kernel";
-    repo = "launchk";
-    rev = "6f5f09e0dfa3fea662e859de5d7d49ac09a9dbe6";
-    hash = "sha256-yZZGCPul1Q8KBgFIG9qkevnOxqnRbK8sqIu5OUPPTFQ=";
-  };
+  src = ix.launchkSrc;
 in
 rustPlatform.buildRustPackage {
   pname = "launchk";


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add btop fork package and migrate source inputs to flake-pinned sources
- Adds a new [btop package](https://github.com/indexable-inc/index/pull/851/files#diff-7a821e0262c177bdedf27b544a338883e942a4ee16953f475c056b1174d56900) that overrides the upstream `btop` derivation to build from the `indexable-inc` fork via a pinned flake input.
- Migrates `drgn`, `fff`, and `launchk` packages from inline `fetchFromGitHub` calls to flake-level pinned source inputs, centralizing source management in [flake.nix](https://github.com/indexable-inc/index/pull/851/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0).
- Exposes the new source inputs (`btopSrc`, `drgnSrc`, `fffSrc`, `launchkSrc`) through the `ix` attribute set in [lib/default.nix](https://github.com/indexable-inc/index/pull/851/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188).
- Adds an ast-grep lint rule in [no-fetchfromgithub-fixed-hash.yml](https://github.com/indexable-inc/index/pull/851/files#diff-768ad81d623dc5933a4672227ba96fa67d55efab6307756c646153dc2cd7d099) that errors on `fetchFromGitHub` calls with a fixed hash, enforcing the flake-input pattern going forward.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ef3b3a.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->