### PR TITLE
mcp: surface the live dashboard URL in the server instructions

### DIFF
--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -194,7 +194,7 @@ def _serve(args: argparse.Namespace) -> int:
 
 
 async def _run(cfg: Config) -> None:
-    from . import dashboard, transport
+    from . import dashboard, tools, transport
     from .kernel import Kernel, set_kernel
 
     kernel = Kernel(cfg)
@@ -204,6 +204,9 @@ async def _run(cfg: Config) -> None:
     runner = await dashboard.start(cfg)
     url = cfg.dashboard_url()
     (runtime_dir() / "dashboard-url").write_text(url)
+    # Bake the live URL into the MCP instructions before serving, so the client
+    # gets it in the `initialize` response -- no tool call to discover it.
+    tools.set_dashboard_url(url)
     print(f"[ix-mcp] dashboard (all running things + output): {url}", file=sys.stderr, flush=True)
 
     try:

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -25,9 +25,7 @@ from pydantic import Field
 from . import outputs
 from .kernel import current_kernel
 
-mcp = FastMCP(
-    "ix-mcp",
-    instructions=(
+_INSTRUCTIONS = (
         "Run Python on one shared, persistent kernel with `python_exec`. The "
         "namespace persists across calls, so variables, functions, classes, and "
         "imports you define stay defined and are reusable by every later call \u2014 "
@@ -132,10 +130,24 @@ mcp = FastMCP(
         "important results with `cells.add(value, title=...)`, and prune stale "
         "ones as the state moves on \u2014 `cells.set(key, value)` to replace in "
         "place, `cells.remove(key)` to drop one, `cells.clear()` to start over \u2014 "
-        "so the page always reflects where things stand now. The dashboard URL is "
-        "the `DASHBOARD_URL` variable in the namespace (share it with the human)."
-    ),
-)
+        "so the page always reflects where things stand now."
+    )
+
+mcp = FastMCP("ix-mcp", instructions=_INSTRUCTIONS)
+
+
+def set_dashboard_url(url: str) -> None:
+    """Bake the live dashboard URL into the server instructions so a client reads
+    it straight out of the ``initialize`` response -- the agent has the URL from
+    the first message, with no tool call to look it up. The CLI calls this once
+    the dashboard has bound its port, before the transport serves ``initialize``.
+    """
+    mcp._mcp_server.instructions = (
+        f"{_INSTRUCTIONS}\n\nThis session's live dashboard (every running job, "
+        f"its output, and your curated cells) is at {url} -- share it with the "
+        f"human now. It is also the `DASHBOARD_URL` variable in the kernel "
+        f"namespace."
+    )
 
 # Report the build's source revision as the MCP `serverInfo.version` so a client
 # can see exactly which commit of the server it is talking to. The nix wrapper


### PR DESCRIPTION
The agent had to run a tool to read `DASHBOARD_URL`. This bakes the live URL into the MCP `instructions` once the dashboard binds its port (before the transport serves `initialize`), so a client reads it straight out of the `initialize` response — instant, no tool call.

🤖 Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface the live dashboard URL in MCP server instructions
> - Adds `tools.set_dashboard_url(url)` in [cli.py](https://github.com/indexable-inc/index/pull/853/files#diff-7ce741e8223d63fdea11625cb78abad266299445db0213d2355bc93306df9ac5) to inject the session's dashboard URL into the MCP server instructions before transport starts, so clients receive it in the `initialize` response.
> - Extracts the static instructions string into a `_INSTRUCTIONS` constant in [tools.py](https://github.com/indexable-inc/index/pull/853/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6); the new `set_dashboard_url` function appends the live URL to `mcp._mcp_server.instructions` at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e33c533.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->