### PR TITLE
mcp(view): style the Code line-number gutter

### DIFF
--- a/packages/mcp/src/view/view/__init__.py
+++ b/packages/mcp/src/view/view/__init__.py
@@ -143,8 +143,16 @@ def _code_css() -> str:
     light_css = "".join(
         f"{sel_} {{ {light.get(sel_, reset)} }}" for sel_ in {**dark, **light}
     )
+    # The `linenos="inline"` line-number spans are chrome, not tokens, so they
+    # are not in the palette above. Style them explicitly (theme-aware via the
+    # `--ixv-*` vars): a muted color and a gap so they read as a gutter, not as
+    # digits fused to the first token, and unselectable so a copy skips them.
+    gutter = (
+        f"{sel} .linenos {{ color: {_c('muted')}; "
+        f"padding-right: 1.25em; user-select: none; -webkit-user-select: none }}"
+    )
     return (
-        f"<style>{dark_css}@media (prefers-color-scheme: light) "
+        f"<style>{gutter}{dark_css}@media (prefers-color-scheme: light) "
         f"{{{light_css}}}</style>"
     )
 


### PR DESCRIPTION
Follow-up to #852. The “weird numbers” are line numbers — the theming PR switched the Code view from inline styles to pygments classes, which dropped pygments' line-number chrome, so the `linenos` spans rendered in full code color with no separation (the digits fused onto the first token: `8-- — Core model` read as `8--`).

Fix: style `.ixv-hl .linenos` explicitly — a muted, theme-aware color (`--ixv-muted`), a right-pad gutter, and `user-select:none` so copying the snippet skips the numbers.

🤖 Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Style the line-number gutter in `_code_css` for MCP code view
> Adds a CSS rule targeting `.linenos` spans in the generated stylesheet to display line numbers as a styled gutter. Line numbers receive a muted color, `1.25em` right padding, and `user-select: none` so they are excluded when copying code. The rule applies in both dark and light themes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59740df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->