### PR TITLE
mcp: add a `read` tool and sharpen the agent instructions

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 # ix-mcp
 
-A single-tool Python execution MCP server. One tool, `python_exec`, runs code on
+A Python execution MCP server. Its one general tool, `python_exec`, runs code on
 **one shared, persistent IPython kernel**. The namespace persists across calls,
 many executions run **concurrently** on the kernel's event loop, and work that
 outlives a short foreground budget keeps running in the background. An
@@ -20,7 +20,7 @@ read-only (it renders the execution log); access is gated by reachability: the
 default bind is loopback, and the fleet only exposes it over Tailscale (see
 [Remote access](#remote-access)).
 
-## The one tool
+## The main tool
 
 `python_exec(code, budget=15, name=None)` runs `code` on the shared kernel and
 waits up to `budget` seconds. If the code finishes in time you get its output and
@@ -76,11 +76,11 @@ read-only dashboard, and the MCP transport, all on one event loop.
 - `store.py` is the append-only execution log (one SQLite file in WAL mode).
 - `dashboard.py` serves a one-page live view of that log.
 - `outputs.py` renders kernel messages for the agent (text, images).
-- `tools.py` is the MCP surface: `python_exec`, plus `search_semantic`/
-  `search_grep` over the shared `index` corpus and `calendar_events`/
-  `calendar_event_create`/`calendar_event_cancel` (thin bindings over the bundled
-  [`gcal`](../google/calendar/README.md) binary). All of these are also reachable
-  from `python_exec` by importing the bundled modules.
+- `tools.py` is the MCP surface: the general `python_exec`, plus `read` (pull a
+  file or kernel value into the model's context while the dashboard stays quiet)
+  and `kernel_trace` (an out-of-band stack dump for a wedged kernel). Everything
+  else an agent needs is reachable from `python_exec` by importing the bundled
+  modules.
 
 ## Pinned interpreter and bundled modules
 

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -35,6 +35,7 @@ import dataclasses
 import inspect
 import json
 import os
+import pathlib
 import sys
 import time
 import traceback
@@ -1281,6 +1282,50 @@ async def __ix_exec(code: str, budget: float = 15.0, name: str | None = None) ->
     _emit(job)
 
 
+async def __ix_read(target, start=None, end=None) -> "Result":
+    """Read a file (or evaluate a kernel value) FOR THE MODEL, quietly.
+
+    Returns a Result whose ``llm_result`` is the full text the model receives and
+    whose ``user_html`` is a one-line note the human sees, so a large read informs
+    the model without flooding the dashboard. ``target`` is read as a file when it
+    names an existing file, otherwise evaluated as a Python expression in the user
+    namespace (e.g. ``jobs['ab12'].output``, a variable you bound). ``start`` and
+    ``end`` select a 1-based inclusive line range. Backs the ``read`` MCP tool.
+    """
+    ns = _user_ns if _user_ns is not None else globals()
+    path = None
+    if isinstance(target, str):
+        try:
+            candidate = pathlib.Path(target).expanduser()
+            path = candidate if candidate.is_file() else None
+        except OSError:
+            path = None
+    if path is not None:
+        # Off the loop: a large file read is blocking I/O, the one thing that
+        # freezes every other job on the shared event loop.
+        full = await asyncio.to_thread(path.read_text, errors="replace")
+        label = str(path)
+    else:
+        value = eval(target, ns) if isinstance(target, str) else target
+        full = value if isinstance(value, str) else _safe_repr(value)
+        label = target if isinstance(target, str) else _safe_repr(target)
+    lines = full.splitlines()
+    total = len(lines)
+    if start is not None or end is not None:
+        lo = max((start or 1) - 1, 0)
+        hi = total if end is None else min(end, total)
+        selected = lines[lo:hi]
+        body = "\n".join(selected)
+        span = f"lines {lo + 1}-{lo + len(selected)} of {total}"
+    else:
+        body = full
+        span = f"{total} lines"
+    note = f"read {label} \u00b7 {span}, {len(body)} chars"
+    user = f'<div class="ix-ok">\U0001F4D6 {_escape_html(note)}</div>'
+    return Result(user_html=user, llm_result=body)
+
+
+
 def _install_display_capture(shell) -> None:
     """Route display() / rich auto-display made *inside a job* to that job's output
     list (still forwarding to IOPub for the agent's reply), so the dashboard can
@@ -1431,6 +1476,7 @@ def install(user_ns: dict | None = None) -> None:
     target["register_resource"] = register_resource
     target["__ix_run"] = __ix_run
     target["__ix_exec"] = __ix_exec
+    target["__ix_read"] = __ix_read
     target["DASHBOARD_URL"] = os.environ.get("IX_MCP_DASHBOARD_URL", "")
     # `sh` is a bundled, callable module (see packages/mcp/src/sh). Bind it here
     # so `await sh(cmd)` works with no import, the way Result/cells/jobs do; an

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -1,16 +1,23 @@
 """The MCP tool surface.
 
-Two tools only. ``python_exec`` runs code on the single shared kernel with a
-foreground budget and, if the work outlives the budget, leaves it running in the
-background as an entry in the in-kernel ``jobs`` dict. Job control needs no extra
-tools because ``jobs`` is just namespace state: inspect/await/cancel it with more
-``python_exec`` (``jobs['ab12'].cancel()``). Everything else an agent might want
-(search the index, read the calendar, shell out) is reachable the same way, by
-importing the bundled module inside a cell, so it does not earn a dedicated tool.
+``python_exec`` is the one general tool: it runs code on the single shared kernel
+with a foreground budget and, if the work outlives the budget, leaves it running
+in the background as an entry in the in-kernel ``jobs`` dict. Job control needs no
+extra tools because ``jobs`` is just namespace state: inspect/await/cancel it with
+more ``python_exec`` (``jobs['ab12'].cancel()``). Everything else an agent might
+want (search the index, read the calendar, shell out) is reachable the same way,
+by importing the bundled module inside a cell, so it does not earn a dedicated
+tool.
 
-``kernel_trace`` is the one exception: it dumps the kernel's stack out of band
-(a faulthandler signal, not the execute channel) so it works even when a cell has
-wedged the event loop, which is exactly when ``python_exec`` cannot help.
+Two tools earn their place beside it because they do something ``python_exec``
+cannot. ``read`` pulls a file or a kernel value into the MODEL's context without
+spamming the human: the full text comes back to the agent while the dashboard
+shows only a one-line note. A plain cell cannot make that split for free — its
+result streams to both audiences — so reading a large file or paging a job's
+output through ``python_exec`` either floods the dashboard or costs the human a
+wall of text they did not ask for. ``kernel_trace`` dumps the kernel's stack out
+of band (a faulthandler signal, not the execute channel) so it works even when a
+cell has wedged the event loop, which is exactly when ``python_exec`` cannot help.
 """
 
 from __future__ import annotations
@@ -84,7 +91,7 @@ _INSTRUCTIONS = (
         "`Result.of(df)`) and the human gets the styled HTML table for free "
         "while you get the frame as compact, untruncated CSV \u2014 so you never "
         "hand-build a table and a wide/long-stringed frame is never clipped to "
-        "you. Use `pl`; pandas is not bundled. "
+        "you. Use `pl`; pandas is not bundled. Even key/value data \u2014 environment variables, a config dict, counts \u2014 is tabular: return a two-column DataFrame, never a `\\n`-joined string or a printed dict. "
         "To find files or code, use `fff` with polars \u2014 never shell out to "
         "`rg`/`grep`/`fd`/`find`/`ls`/`mgrep`, and never write a one-off search "
         "helper. `fff.find(query)` (typo-tolerant, frecency-ranked file find) "
@@ -97,6 +104,11 @@ _INSTRUCTIONS = (
         "listing. `fff.map(pattern)` groups hits into a foldable code map with "
         "definitions ranked first, for \u201cwhere is X defined and used?\u201d. "
         "For meaning-based recall across a corpus, `import search`. "
+        "When you want to pull a file or a big kernel value into YOUR context, "
+        "reach for the `read` tool rather than `cat`/`view.cat` or printing it "
+        "through a cell: `read` hands the full text back to you while the "
+        "dashboard shows only a one-line note, so a large read never floods the "
+        "human's view. "
         "Return results through `Result`, never `print`: a cell's stdout is NOT "
         "sent to you and is hidden in the dashboard by default (it is kept only "
         "for paging via jobs['<id>'].output), so surface anything worth seeing as "
@@ -121,13 +133,17 @@ _INSTRUCTIONS = (
         "expression. "
         "Three dashboard panes show the session live: every running/finished run "
         "under executions, every live view (a terminal, a widget) under resources, "
-        "and your curated highlight reel under cells. Answer THROUGH cells by "
+        "and your curated highlight reel under cells; its address is the "
+        "`DASHBOARD_URL` value in the namespace (read the variable \u2014 there "
+        "is no `dashboard()` function to call). Answer THROUGH cells by "
         "default: the cells pane is what the human reads as the answer, so put "
         "any result worth seeing there with `cells.add(value, title=...)` (a "
         "DataFrame, a figure, a `view`/`fff` render, an htpy element) rather than "
         "leaving it only in your tool text. Treat cells as the FINAL "
         "PRESENTATION of the CURRENT state, not an append-only log: add the most "
-        "important results with `cells.add(value, title=...)`, and prune stale "
+        "important results with `cells.add(value, id=..., title=...)` (a stable "
+        "`id=` makes a re-run replace that cell in place instead of stacking a "
+        "duplicate), and prune stale "
         "ones as the state moves on \u2014 `cells.set(key, value)` to replace in "
         "place, `cells.remove(key)` to drop one, `cells.clear()` to start over \u2014 "
         "so the page always reflects where things stand now."
@@ -183,7 +199,8 @@ Content = list[outputs.Content]
         "`Result.of(value)` (render a DataFrame/figure/value richly for the human, its "
         "repr to you), or `Result(user_html=..., llm_result=..., llm_images=[fig])` to "
         "split the human's rich HTML view from your text+images. Curate the dashboard's "
-        "presentation pane with `cells.add(value, title=...)` — it is the final view of "
+        "presentation pane with `cells.add(value, id=..., title=...)` — a stable id= "
+        "replaces a cell in place instead of duplicating it, and it is the final view of "
         "the current state, so prune stale cells (`cells.set`/`.remove`/`.clear`) rather "
         "than letting it grow into a log. "
         "Write readable, idiomatic Python: the dashboard shows your source verbatim, so "
@@ -234,6 +251,42 @@ async def python_exec(
             )
         )
     return parts
+
+
+@mcp.tool(
+    description=(
+        "Read a file (or a kernel value) into YOUR context WITHOUT spamming the "
+        "human's dashboard: the full text comes back to you, while the dashboard "
+        "shows only a one-line note (path, line span, size). Use this instead of "
+        "`cat`/`view.cat` or printing a big value through python_exec whenever the "
+        "content is for you to read, not for the human to look at \u2014 a normal "
+        "cell's result streams to BOTH audiences, so it would flood the dashboard. "
+        "`target` is read as a file when it names an existing file, otherwise it is "
+        "evaluated as a Python expression in the kernel namespace (e.g. "
+        "`jobs['ab12'].output` to page a job, or a variable you bound earlier). "
+        "Pass `start`/`end` for a 1-based inclusive line range."
+    )
+)
+async def read(
+    target: Annotated[
+        str,
+        Field(
+            description=(
+                "A file path, or a Python expression evaluated in the kernel "
+                "(e.g. jobs['ab12'].output, or a variable you bound earlier)"
+            )
+        ),
+    ],
+    start: Annotated[int | None, Field(description="1-based first line to include")] = None,
+    end: Annotated[int | None, Field(description="Last line to include (inclusive)")] = None,
+) -> Content:
+    code = f"await __ix_read({target!r}, {start!r}, {end!r})"
+    cell_outputs, summary = await current_kernel().python_exec(code, budget=30.0)
+    if summary is not None and summary.get("status") == "error" and summary.get("error"):
+        return [outputs.text(summary["error"])]
+    rendered = outputs.to_mcp(cell_outputs)
+    content = [item for item in rendered if getattr(item, "text", None) != "(no output)"]
+    return content or rendered
 
 
 @mcp.tool(


### PR DESCRIPTION
## What

Adds a third MCP tool, `read`, and sharpens the agent instructions so an agent does the right thing on the first try.

### `read` tool
Pulls a file (or a kernel value) into the **model's** context without spamming the **human's** dashboard: the full text comes back to the agent while the dashboard shows only a one-line note (path · line span · size). A plain `python_exec` cell can't make that split for free — its result streams to *both* audiences — so reading a large file or paging a job's output through a cell either floods the dashboard or costs the human a wall of text.

- `target` is read as a file when it names one, otherwise evaluated as a kernel expression (e.g. `jobs['ab12'].output`, a bound variable).
- `start`/`end` select a 1-based inclusive line range.
- Backed by a new `__ix_read` runtime helper; file I/O runs off the event loop via `asyncio.to_thread`.

### Instruction fixes (drove the design — these were real first-try misses)
- **Tabular by default:** key/value data — env vars, a config dict, counts — is tabular, so return a two-column DataFrame, never a `\n`-joined string or a printed dict.
- **Dashboard URL:** it's the `DASHBOARD_URL` *value* in the namespace (read the variable — there is no `dashboard()` function to call).
- **Stable cell ids:** give a cell a stable `id=` so a re-run replaces it in place instead of stacking duplicates.

Also refreshes the README tool list (it referenced `search_semantic`/`calendar_*` tools that no longer exist).

## Test
- `runtime.py` / `tools.py` compile clean.
- Unit-tested `__ix_read` logic in isolation: full file read, 1-based inclusive line range, and expression eval (`jobs['ab12'].output`) all produce the right full-text-to-model + quiet-note-to-human split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `read` MCP tool to fetch file or kernel value content into model context
> - Adds a new `read` MCP tool in [tools.py](https://github.com/indexable-inc/index/pull/856/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) that accepts a file path or kernel expression, with optional 1-based line range, and returns the text directly to the caller.
> - Implements `__ix_read` coroutine in [runtime.py](https://github.com/indexable-inc/index/pull/856/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) to handle both file reads (off the event loop via `asyncio.to_thread`) and kernel namespace expression evaluation, emitting only a short summary note to the dashboard.
> - Sharpens `_INSTRUCTIONS` to prefer polars over pandas, document `DASHBOARD_URL`, and recommend `cells.add(value, id=..., title=...)` with a stable id for in-place cell replacement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b4e704.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->