### PR TITLE
snix: cargo-unit-built default CLI + keep plan mode tools

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,7 +306,8 @@
         "home-manager": "home-manager",
         "launchk-src": "launchk-src",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay",
+        "snix-src": "snix-src"
       }
     },
     "rust-overlay": {
@@ -327,6 +328,23 @@
         "owner": "oxalica",
         "repo": "rust-overlay",
         "type": "github"
+      }
+    },
+    "snix-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780855864,
+        "narHash": "sha256-I4jQAPpAxU6GMj/4mr20qfWZJ5enMVzyEpX/fXI6lU0=",
+        "ref": "canon",
+        "rev": "2272a9fc758e49a7f13a1685de1ebded84a0182e",
+        "revCount": 22436,
+        "type": "git",
+        "url": "https://git.snix.dev/snix/snix"
+      },
+      "original": {
+        "ref": "canon",
+        "type": "git",
+        "url": "https://git.snix.dev/snix/snix"
       }
     },
     "uv2nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,16 @@
       flake = false;
     };
 
+    # snix (Rust reimplementation of Nix; TVL-style depot, no flake.nix) consumed
+    # as a source tree so `packages/snix` builds its CLI through cargo-unit
+    # instead of the upstream crate2nix `Cargo.nix`. The Cargo workspace lives in
+    # the repo's `snix/` subdirectory. Pinned in flake.lock; `nix flake update
+    # snix-src` to bump.
+    snix-src = {
+      url = "git+https://git.snix.dev/snix/snix?ref=canon";
+      flake = false;
+    };
+
     # Nous Research's Hermes agent ships its own NixOS module
     # (`nixosModules.default`) and uv2nix-built Python closure. Pinned to
     # a release tag so routine bumps are review events; `nix flake update
@@ -109,6 +119,7 @@
       drgn-src,
       fff-src,
       launchk-src,
+      snix-src,
       clippy-fork,
       ghostty,
       ...
@@ -173,6 +184,7 @@
           drgn-src
           fff-src
           launchk-src
+          snix-src
           clippy-fork
           ghostty
           ;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -10,6 +10,7 @@
   drgn-src,
   fff-src,
   launchk-src,
+  snix-src,
   clippy-fork,
   ghostty,
   # Flake source revision, stamped into builds that want to report it (see
@@ -386,6 +387,7 @@ let
     drgnSrc = drgn-src;
     fffSrc = fff-src;
     launchkSrc = launchk-src;
+    snixSrc = snix-src;
   };
 
   /**

--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -144,12 +144,12 @@ let
   # Lean code-execution agent: the only surface this build needs is the index MCP
   # (its `mcp__index__*` tools, e.g. python_exec, which MCP namespacing leaves
   # untouched by `--disallowedTools`). Drop the built-in meta-tools so the model
-  # works turn-by-turn through code execution instead of branching into plan
-  # mode, structured task lists, agent teams, worktrees, or multiple-choice
-  # prompts. Removed regardless of permission mode, same as the autonomy list.
+  # works turn-by-turn through code execution instead of branching into
+  # structured task lists, agent teams, worktrees, or multiple-choice prompts.
+  # Plan mode (EnterPlanMode/ExitPlanMode) is intentionally NOT dropped, so the
+  # agent can propose a plan for a non-trivial change before executing it.
+  # Removed regardless of permission mode, same as the autonomy list.
   disallowedMetaTools = [
-    "EnterPlanMode"
-    "ExitPlanMode"
     "AskUserQuestion"
     "TaskCreate"
     "TaskList"
@@ -205,7 +205,6 @@ let
     "Bash"
     "BashOutput"
     "Edit"
-    "ExitPlanMode"
     "Glob"
     "Grep"
     "KillShell"
@@ -415,7 +414,9 @@ stdenv.mkDerivation {
       --inherit-argv0 \
       --add-flags --debug \
       --add-flags "--thinking-display summarized" \
-      --add-flags "--disallowedTools ${lib.concatStringsSep "," (disallowedAutonomyTools ++ disallowedMetaTools)}" \
+      --add-flags "--disallowedTools ${
+        lib.concatStringsSep "," (disallowedAutonomyTools ++ disallowedMetaTools)
+      }" \
       --append-flags "--settings ${settingsDefaultsFile}" \
       ${lib.escapeShellArgs systemPromptWrapperArgs} \
       --set DISABLE_AUTOUPDATER 1 \

--- a/packages/snix/default.nix
+++ b/packages/snix/default.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  ix,
+  protobuf,
+  pkg-config,
+  cmake,
+  perl,
+  makeWrapper,
+  runCommand,
+}:
+# snix is the Rust reimplementation of Nix (TVL depot `git.snix.dev/snix/snix`).
+# Upstream packages it with crate2nix (`snix/Cargo.nix` + `crate-hashes.json`):
+# ~1100 one-derivation-per-crate builds plus feature powersets, with no shared
+# incrementality. Here we build the same `default` CLI through index's
+# cargo-unit instead, so snix compiles as one Nix derivation per Cargo rustc
+# unit with source-scoped, content-addressed inputs — the same engine that
+# builds the rest of this repo's Rust tree.
+#
+# The Cargo workspace lives in the `snix/` subdirectory of the pinned source
+# (`snix-src` flake input, surfaced as `ix.snixSrc`).
+let
+  snixDir = ix.snixSrc + "/snix";
+
+  workspace = ix.cargoUnit.buildWorkspace {
+    pname = "snix";
+    src = snixDir;
+    # Fetched source: the filtered build input and the package-scope checkout
+    # root are the same store path (same shape as the real-workspace checks in
+    # tests/default.nix).
+    workspaceRoot = snixDir;
+    cargoLock = snixDir + "/Cargo.lock";
+    cargoArgs = [ "--workspace" ];
+
+    # snix is third-party: build it, do not lint or audit it. Same relaxed
+    # posture as `cargoUnitRealWorkspacePolicy` in tests/default.nix.
+    policy = {
+      denyUnusedCrateDependencies = false;
+      cargoAudit.enable = false;
+      cargoMachete.enable = false;
+      clippy.enable = false;
+    };
+
+    # Build-script tooling, applied to every unit:
+    #   * protobuf  — prost-build / tonic-build shell out to `protoc`.
+    #   * pkg-config — probed by several `*-sys` crates.
+    #   * cmake, perl — aws-lc-sys (rustls' default backend) builds its vendored
+    #     C with cmake and generates assembly with perl.
+    # `cc` is already supplied by cargo-unit.
+    nativeBuildInputs = [
+      protobuf
+      pkg-config
+      cmake
+      perl
+    ];
+    env = {
+      PROTOC = "${protobuf}/bin/protoc";
+      PROTOC_INCLUDE = "${protobuf}/include";
+      # snix's proto build scripts resolve `.proto` files as
+      # `$PROTO_ROOT/snix/<crate>/protos/...` (build.rs defaults PROTO_ROOT to
+      # `../..`, which only resolves in a full checkout). cargo-unit gives each
+      # build script a per-crate *scoped* CARGO_MANIFEST_DIR, so point PROTO_ROOT
+      # at the whole snix checkout (the repo root that contains `snix/`).
+      PROTO_ROOT = "${ix.snixSrc}";
+    };
+
+    # Git dependencies pinned in snix's Cargo.lock, keyed by the exact lock
+    # source string. Refresh with `nix flake update snix-src` then rebuild and
+    # copy the corrected hashes from the fetchgit mismatch errors.
+    outputHashes = {
+      "git+https://github.com/arianvp/hyper.git?branch=push-ktssyytnyrru#e071325cc75549b37bbcd5be591e93c4c974b4a2" =
+        "sha256-XnUOQYfPa+LKOx7aKz5wv4tL9hXirJ7UkrMBiM7bHb4=";
+      "git+https://github.com/edef1c/tonic.git?branch=push-rosuyzxnysvw#f03397b816b834f78c8b9e1a271c23ac4265d750" =
+        "sha256-bf88XZMzeplglunUDOU5XWFgKpbzoVV1r4Sj3qvhOHQ=";
+      "git+https://github.com/tvlfyi/wu-manber.git#0d5b22bea136659f7de60b102a7030e0daaa503d" =
+        "sha256-7YIttaQLfFC/32utojh2DyOHVsZiw8ul/z0lvOhAE/4=";
+    };
+  };
+
+  # The `default` CLI: the base `snix` dispatcher (crate `snix-cli`, bin `snix`)
+  # finds each `snix-<subcommand>` binary on `SNIX_LIBEXEC_PATH`, exactly as
+  # snix's own cli/make-cli.nix + cli/default-cli.nix assemble it. virtiofs is a
+  # Linux-only, non-default feature, so the plain `--workspace` graph omits it
+  # and the binary set is identical across platforms.
+  subcommands = [
+    "snix-build"
+    "snix-castore"
+    "snix-castore-http"
+    "snix-derivation-show"
+    "snix-eval"
+    "snix-nar-bridge"
+    "snix-nix-daemon"
+    "snix-store"
+  ];
+in
+runCommand "snix"
+  {
+    nativeBuildInputs = [ makeWrapper ];
+    passthru = { inherit workspace; };
+    meta = {
+      description = "Rust reimplementation of Nix (snix `default` CLI), built via cargo-unit";
+      homepage = "https://snix.dev";
+      license = lib.licenses.gpl3Only;
+      mainProgram = "snix";
+      platforms = lib.platforms.unix;
+    };
+  }
+  ''
+    mkdir -p "$out/bin" "$out/libexec"
+    ${lib.concatMapStringsSep "\n" (
+      name: ''ln -s ${workspace.binaries.${name}}/bin/${name} "$out/libexec/${name}"''
+    ) subcommands}
+    makeWrapper ${workspace.binaries.snix}/bin/snix "$out/bin/snix" \
+      --suffix SNIX_LIBEXEC_PATH : "$out/libexec"
+  ''

--- a/packages/snix/package.nix
+++ b/packages/snix/package.nix
@@ -1,0 +1,9 @@
+{
+  # snix's `default` CLI built through cargo-unit. Surface it as `pkgs.snix` in
+  # the repo package set and as the `snix` flake output. GPL-3.0; builds on
+  # Linux and macOS (meta.platforms = unix). NOT inRustWorkspace: snix is an
+  # external fetched Cargo workspace, not a member of this repo's workspace.
+  id = "snix";
+  flake = true;
+  packageSet = true;
+}


### PR DESCRIPTION
## What

Two changes:

1. **`packages/snix`** — package snix (Rust reimplementation of Nix, `git.snix.dev/snix/snix`)'s `default` CLI built through **cargo-unit** (`ix.cargoUnit.buildWorkspace`) instead of upstream's crate2nix `Cargo.nix`. snix now compiles as one Nix derivation per Cargo rustc unit, with source-scoped content-addressed inputs — the same engine as the rest of this repo's Rust tree. New `snix-src` flake input (workspace lives in the `snix/` subdir), surfaced as `ix.snixSrc`.

2. **`claude-code`** — stop baking `EnterPlanMode`/`ExitPlanMode` into `--disallowedTools` (and drop `ExitPlanMode` from the `restrictToTools` deny list), so the agent can propose a plan before a non-trivial change.

## Notes

- Third-party workspace, so a relaxed policy (no clippy/audit/machete), `protobuf`/`pkg-config`/`cmake`/`perl` for build scripts + aws-lc-sys, and `outputHashes` for snix's 3 git deps (hyper/tonic/wu-manber).
- **Gotcha solved:** snix's proto `build.rs` resolve `.proto` files via `$PROTO_ROOT/snix/<crate>/protos/...`, which cargo-unit's *scoped per-crate source* lacks — so `PROTO_ROOT` points at the full checkout (`ix.snixSrc`).
- The base `snix` dispatcher + 8 subcommands are assembled into a `makeWrapper` with `SNIX_LIBEXEC_PATH`, mirroring snix's own `make-cli.nix`.

## Verify

```
nix build .#snix
./result/bin/snix eval -E '1 + 2 * 20'   # => 41 :: int
./result/bin/snix store --help           # routes to snix-store
```

🤖 Generated with Claude Code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add snix CLI package via cargo-unit and re-enable plan mode tools in claude-code
> - Adds [packages/snix/default.nix](https://github.com/indexable-inc/index/pull/858/files#diff-ea02182c14f097e131f457151ec1c3741fdf4580cb49b1659bf0a6572672ca48) which builds the `snix` CLI and its subcommands from the `snix-src` flake input using `cargo-unit`, assembling a wrapper that exposes subcommands via `SNIX_LIBEXEC_PATH`.
> - Wires `snix-src` through [flake.nix](https://github.com/indexable-inc/index/pull/858/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) and [lib/default.nix](https://github.com/indexable-inc/index/pull/858/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188) so it is available as `ix.snixSrc` alongside other sources.
> - Removes `EnterPlanMode` and `ExitPlanMode` from the disallowed tools list in [packages/claude-code/default.nix](https://github.com/indexable-inc/index/pull/858/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b), re-enabling plan mode at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bef7fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->