### PR TITLE
mcp: cut context bloat (tree/images), better stdout + result-cap DX

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -859,6 +859,14 @@ let
         assert w.status == "error", w.status
         assert "asyncio.to_thread" in w.error and "Traceback" not in w.error, w.error
 
+        # A cell that prints but returns no Result fails the Result contract, and
+        # the error now shows what it printed (stdout never reaches the model), so
+        # a printing agent gets an actionable nudge instead of a silent dead end.
+        p = await run("print('hello-from-stdout')", budget=1.0, name="printed")
+        assert p.status == "error", p.status
+        assert "printed to stdout" in p.error, p.error
+        assert "hello-from-stdout" in p.error, p.error
+
     asyncio.run(main())
     # api(): a discoverable catalog of kernel builtins + bundled modules.
     cat = ns["api"]()
@@ -866,6 +874,61 @@ let
     assert {"Result", "cells", "jobs", "sh", "api"} <= names, names
     filt = ns["api"]("cells")
     assert 1 <= filt.height <= cat.height, (filt.height, cat.height)
+
+    # fff and view are pre-bound in the namespace (no import needed), the way
+    # Result/cells/jobs/sh are, so fff.grep(...) / view.tree(...) just work.
+    assert callable(getattr(ns.get("fff"), "grep", None)), ns.get("fff")
+    assert callable(getattr(ns.get("view"), "tree", None)), ns.get("view")
+
+    # Result.llm_images downscale a large raster to <= _IMAGE_MAX_DIM on its
+    # longest edge before base64-encoding it for the model (Pillow is present via
+    # matplotlib), so a full-page screenshot does not cost vision tokens at full
+    # resolution.
+    import base64 as _b64
+    import io as _io
+
+    from PIL import Image as _Image
+
+    _buf = _io.BytesIO()
+    _Image.new("RGB", (3000, 1500), (10, 20, 30)).save(_buf, format="PNG")
+    _coerced = runtime._coerce_image(_buf.getvalue())
+    assert _coerced is not None, _coerced
+    _w, _h = _Image.open(_io.BytesIO(_b64.b64decode(_coerced["data"]))).size
+    assert max(_w, _h) <= runtime._IMAGE_MAX_DIM, (_w, _h, runtime._IMAGE_MAX_DIM)
+
+    # outputs.text() renders an over-cap block as a head+tail preview (not a
+    # one-sided clip) with paging guidance, and honours IX_MCP_MAX_RESULT_CHARS.
+    import importlib as _il
+    import os as _os
+
+    from ix_notebook_mcp import outputs as _outputs
+
+    _os.environ["IX_MCP_MAX_RESULT_CHARS"] = "1000"
+    _il.reload(_outputs)
+    _blk = _outputs.text("HEAD" + ("z" * 5000) + "TAIL").text
+    assert _blk.startswith("HEAD") and _blk.endswith("TAIL"), _blk[:40]
+    assert "output too large" in _blk and len(_blk) < 2000, len(_blk)
+    _os.environ.pop("IX_MCP_MAX_RESULT_CHARS", None)
+    _il.reload(_outputs)
+
+    # view.tree lists but does not descend into heavy dirs (node_modules, ...)
+    # unless all=True, so a project's structure is not buried under vendored files.
+    import pathlib as _pl
+    import tempfile as _tf
+
+    import view as _view
+
+    _root = _tf.mkdtemp()
+    _pl.Path(_root, "src").mkdir()
+    _pkg = _pl.Path(_root, "node_modules", "pkg")
+    _pkg.mkdir(parents=True)
+    (_pkg / "index.js").write_text("x")
+    _collapsed = _view.tree(_root, depth=3)
+    _walked = _view.tree(_root, depth=3, all=True)
+    assert _walked.height > _collapsed.height, (_collapsed.height, _walked.height)
+    _names = _collapsed["name"].to_list()
+    assert any("node_modules" in n for n in _names), _names
+    assert not any("index.js" in n for n in _names), _names
 
     print("runtime-ok")
   '';

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -930,12 +930,39 @@ let
     assert any("node_modules" in n for n in _names), _names
     assert not any("index.js" in n for n in _names), _names
 
+    # .gitignore-aware pruning (git is on PATH in this sandbox): a dir the repo
+    # ignores but that is NOT in the static denylist still collapses, and an
+    # ignored file drops entirely.
+    import shutil as _shutil
+    import subprocess as _sub
+
+    if _shutil.which("git"):
+        _g = _tf.mkdtemp()
+        _pl.Path(_g, "src").mkdir()
+        _gen = _pl.Path(_g, "generated")
+        _gen.mkdir()
+        (_gen / "big.py").write_text("x")
+        (_pl.Path(_g) / "debug.log").write_text("x")
+        (_pl.Path(_g) / ".gitignore").write_text("generated/" + chr(10) + "*.log" + chr(10))
+        _sub.run(["git", "init", "-q"], cwd=_g, check=True)
+        _gi = _view.tree(_g, depth=3)["name"].to_list()
+        assert any("generated" in n for n in _gi), _gi
+        assert not any("big.py" in n for n in _gi), _gi
+        assert not any("debug.log" in n for n in _gi), _gi
+        assert any("src" in n for n in _gi), _gi
+
     print("runtime-ok")
   '';
   runtimeSmoke =
     pkgs.runCommand "ix-mcp-runtime-smoke"
       {
-        nativeBuildInputs = [ mcpPython ];
+        # git is on PATH so the view.tree .gitignore-pruning assertion can init a
+        # throwaway repo; without it that path falls back to the denylist (still
+        # covered by the no-git case in the same test).
+        nativeBuildInputs = [
+          mcpPython
+          pkgs.git
+        ];
         strictDeps = true;
       }
       ''

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -67,13 +67,26 @@ INTRO = (
 
 DISCOVER = (
     "Call `api()` (always in the namespace, no import) to list every helper you have — the kernel "
-    "builtins (`Result`, `cells`, `jobs`, `sh`, ...) and each bundled module's functions with "
+    "builtins (`Result`, `cells`, `jobs`, `sh`, plus `fff` and `view`, all bound with no import) "
+    "and each bundled module's functions with "
     "signatures and summaries — or `api('grep')` to filter; reach for it instead of guessing "
     "names or grepping source."
 )
 
+VERIFY = (
+    "Verify a change by its actual effect, not by a proxy: when you change "
+    "something whose result a static check cannot see — an interactive UI, a "
+    "rendered page, a runtime behaviour — exercise it and observe the outcome "
+    "(screenshot it with the bundled `playwright`, run the path, diff the live "
+    "state) BEFORE reporting it done. A green type-check or linter is necessary "
+    "but not sufficient: 'it compiles' is not 'it works', and 'the tab switches "
+    "in the source' is not 'the tab switches on screen'."
+)
+
 MODULES = (
-    "Bundled modules import with no install step: `fff` (async file search/grep), `view`, `tui`, "
+    "Bundled modules need no install step. `fff` (async file search/grep) and `view` are already "
+    "bound in the namespace, so use them with no import (an explicit `import fff` returns the same "
+    "object); the rest you `import` once and reuse: `tui`, "
     "`exa_py`, `google_auth`, `fleet` (async polars SSH fan-out across hosts: `await "
     "fleet.read_ndjson(hosts, path)` or `await fleet.scan(hosts, cmd)`; pass "
     "`username=`/`connect_timeout=` through to asyncssh, and note that `on_error='collect'` waits "
@@ -99,6 +112,9 @@ HTML = (
 VIEW = (
     "Prefer these over shelling out, and never reach for a subprocess to do them: `view.ls(path)` "
     "/ `view.tree(path)` list a directory as a polars DataFrame you can `.filter` / `.sort` "
+    "(`view.tree` lists but does not descend into node_modules / target / build / dist and other "
+    "heavy dirs, so a project's structure is not buried under vendored files — pass `all=True` to "
+    "walk them) "
     "(never `ls` — not via bash, `sh`, or `asyncio.create_subprocess_exec`, and never paste a raw "
     "`ls -la` dump at the human), `view.grep` / `view.find` search as DataFrames, "
     "`view.cat/read/head/json/diff` return a syntax-highlighted view, and `view.edit(path, old, "

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -112,9 +112,10 @@ HTML = (
 VIEW = (
     "Prefer these over shelling out, and never reach for a subprocess to do them: `view.ls(path)` "
     "/ `view.tree(path)` list a directory as a polars DataFrame you can `.filter` / `.sort` "
-    "(`view.tree` lists but does not descend into node_modules / target / build / dist and other "
-    "heavy dirs, so a project's structure is not buried under vendored files — pass `all=True` to "
-    "walk them) "
+    "(`view.tree` prunes noise — anything the repo's `.gitignore` ignores, plus a denylist of heavy "
+    "dirs like node_modules / target / dist — so a project's structure is not buried under vendored "
+    "or generated files; an ignored dir collapses to one row, an ignored file drops, and `all=True` "
+    "shows everything) "
     "(never `ls` — not via bash, `sh`, or `asyncio.create_subprocess_exec`, and never paste a raw "
     "`ls -la` dump at the human), `view.grep` / `view.find` search as DataFrames, "
     "`view.cat/read/head/json/diff` return a syntax-highlighted view, and `view.edit(path, old, "

--- a/packages/mcp/ix_notebook_mcp/outputs.py
+++ b/packages/mcp/ix_notebook_mcp/outputs.py
@@ -9,16 +9,23 @@ text). The kernel-side runtime also emits a structured summary under the
 from __future__ import annotations
 
 import base64
+import os
 import re
 from typing import Any
 
 import nbformat
 from mcp import types as mcp_types
 
-# Max chars of a single text block shown to the model per reply. The full output
-# is never lost: it stays in the kernel as ``jobs['<id>']`` (see tools.python_exec),
-# which pages it with tail/head/slice/grep/lines.
-MAX_TEXT_CHARS = 50_000
+# Max chars of a single text block shown to the model per reply, overridable with
+# ``IX_MCP_MAX_RESULT_CHARS`` (set it low to force aggressive paging, high to read
+# more in one shot). The full output is never lost: it stays in the kernel as
+# ``jobs['<id>']`` (see tools.python_exec), which pages it with
+# tail/head/slice/grep/lines. An over-cap block is shown as a head+tail preview
+# (see :func:`text`) so its shape is visible while the bulk is paged, not dumped.
+try:
+    MAX_TEXT_CHARS = max(500, int(os.environ.get("IX_MCP_MAX_RESULT_CHARS", "50000")))
+except ValueError:
+    MAX_TEXT_CHARS = 50_000
 _MAX_IMAGES = 8
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -90,8 +97,22 @@ def to_mcp(outputs: list[dict]) -> list[Content]:
 
 def text(value: Any) -> mcp_types.TextContent:
     rendered = _ANSI.sub("", value if isinstance(value, str) else "".join(value))
-    if len(rendered) > MAX_TEXT_CHARS:
-        rendered = f"{rendered[:MAX_TEXT_CHARS]}\n... [truncated {len(rendered) - MAX_TEXT_CHARS} chars; full run kept as jobs['<id>'] — see the pager note below]"
+    if len(rendered) <= MAX_TEXT_CHARS:
+        return mcp_types.TextContent(type="text", text=rendered)
+    # Too large to return whole. Show a head AND a tail so the shape of the output
+    # is visible (the end of a traceback, the last rows of a frame) rather than a
+    # one-sided clip, and point at paging/filtering instead of dumping a wall. The
+    # full run stays in the kernel as jobs['<id>'] (see the pager note in tools).
+    head_n = MAX_TEXT_CHARS * 2 // 3
+    tail_n = MAX_TEXT_CHARS - head_n
+    omitted = len(rendered) - head_n - tail_n
+    rendered = (
+        f"{rendered[:head_n]}\n"
+        f"... [output too large: {len(rendered)} chars, {omitted} omitted. Read the "
+        f"full run with jobs['<id>'].grep('pattern') / .head(n) / .tail(n) / "
+        f".slice(a, b), or narrow your query so it returns less.] ...\n"
+        f"{rendered[-tail_n:]}"
+    )
     return mcp_types.TextContent(type="text", text=rendered)
 
 

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -49,6 +49,16 @@ _ix_current: contextvars.ContextVar = contextvars.ContextVar("ix_current_job", d
 # memory, store writes, and poll payloads all stay bounded.
 _MAX_OUTPUT_CHARS = 256_000
 
+# Longest edge (px) of an image returned to the model. A full-page screenshot or
+# hi-DPI figure otherwise spends vision tokens scaling with its resolution for no
+# added legibility, so an oversize raster image is downscaled (aspect preserved,
+# re-encoded as PNG) before it is base64-encoded into the reply. Set
+# ``IX_MCP_IMAGE_MAX_DIM=0`` to disable downscaling and send images at full size.
+try:
+    _IMAGE_MAX_DIM = int(os.environ.get("IX_MCP_IMAGE_MAX_DIM", "1280"))
+except ValueError:
+    _IMAGE_MAX_DIM = 1280
+
 # The custom mime the kernel hands the server to carry a job summary (mirrors
 # outputs.JOB_MIME; duplicated so the kernel-side runtime stays import-light).
 JOB_MIME = "application/x-ix-job+json"
@@ -653,6 +663,24 @@ def _compile_generator(code: str, filename: str) -> "types.CodeType":
     return compile(shell, filename, "exec")
 
 
+def _stdout_hint(job: "Job") -> str:
+    """A suffix for the Result-contract error when the cell also printed: stdout
+    never reaches the model, so the bare "you must return a Result" message leaves
+    a printing agent unsure what happened to its output. Show a preview of what
+    was printed and the one-line fix, turning a silent dead-end into a nudge."""
+    printed = job.output.strip()
+    if not printed:
+        return ""
+    limit = 1500
+    if len(printed) > limit:
+        printed = f"{printed[:limit]}\n... [+{len(printed) - limit} more chars in jobs['{job.id}'].output]"
+    return (
+        "\n\nThis cell printed to stdout, which the model never receives. To send "
+        f"this text, return it (e.g. `Result.text(...)`) or page jobs['{job.id}'].output. "
+        f"What the cell printed:\n{printed}"
+    )
+
+
 def _display_result(result: "Result") -> None:
     """Show one yielded Result to both audiences. The IPython display goes onto
     the running job's captured outputs (the dashboard) and out on iopub (the
@@ -700,7 +728,7 @@ async def _runner(job: Job, ns: dict) -> None:
                 # Loop ran to completion (no non-Result break).
                 if emitted == 0:
                     job.status = "error"
-                    job.error = _YIELD_REQUIRED
+                    job.error = _YIELD_REQUIRED + _stdout_hint(job)
                     job._append(job.error)
                 else:
                     job.status = "done"
@@ -720,7 +748,7 @@ async def _runner(job: Job, ns: dict) -> None:
                 # model gets. A bare value (or a side-effecting cell that returns
                 # None) is a failed run with an instructive message, not a silent pass.
                 job.status = "error"
-                job.error = _RESULT_REQUIRED
+                job.error = _RESULT_REQUIRED + _stdout_hint(job)
                 job._append(job.error)
                 job.result = None
     except asyncio.CancelledError:
@@ -833,24 +861,71 @@ def _df_llm_text(df) -> str:
         return _safe_repr(df)
 
 
+def _fit_image_bytes(raw: bytes, mime: str) -> tuple[bytes, str]:
+    """Downscale raster image bytes so the longest edge is at most
+    ``_IMAGE_MAX_DIM`` (aspect preserved), re-encoding as PNG. Returns the bytes
+    unchanged when the cap is disabled, Pillow is unavailable, or the image is
+    already small enough. Never raises: on any failure the original bytes/mime are
+    returned, so downscaling can only ever shrink the reply, never break it."""
+    if _IMAGE_MAX_DIM <= 0:
+        return raw, mime
+    try:
+        import io
+
+        from PIL import Image
+
+        with Image.open(io.BytesIO(raw)) as img:
+            width, height = img.size
+            longest = max(width, height)
+            if longest <= _IMAGE_MAX_DIM:
+                return raw, mime
+            scale = _IMAGE_MAX_DIM / longest
+            resized = img.resize((max(1, round(width * scale)), max(1, round(height * scale))))
+            if resized.mode not in ("RGB", "RGBA", "L"):
+                resized = resized.convert("RGBA")
+            buf = io.BytesIO()
+            resized.save(buf, format="PNG", optimize=True)
+            return buf.getvalue(), "image/png"
+    except Exception:
+        return raw, mime
+
+
+def _encode_image_bytes(raw: bytes, mime: str) -> dict:
+    """One image as a downscaled ``{"mime", "data"}`` base64 dict."""
+    raw, mime = _fit_image_bytes(raw, mime)
+    return {"mime": mime, "data": base64.b64encode(raw).decode("ascii")}
+
+
+def _encode_image_b64(b64: str, mime: str) -> dict:
+    """Like :func:`_encode_image_bytes` for already-base64 input: decode so it can
+    be downscaled, falling back to the original string if it is not valid base64
+    (then it is passed through untouched)."""
+    try:
+        raw = base64.b64decode(b64, validate=True)
+    except (ValueError, base64.binascii.Error):
+        return {"mime": mime, "data": b64}
+    return _encode_image_bytes(raw, mime)
+
+
 def _coerce_image(value) -> dict | None:
-    """Coerce one ``Result.llm_images`` item to ``{"mime", "data"}`` (base64),
-    or None if it is not an image we can encode. Accepts raw PNG/JPEG bytes, a
-    base64 / data-URI string, a path to an image file, a matplotlib Figure, or
-    any object with ``_repr_png_`` / ``_repr_jpeg_`` (a PIL image, a plot)."""
+    """Coerce one ``Result.llm_images`` item to a downscaled ``{"mime", "data"}``
+    (base64), or None if it is not an image we can encode. Accepts raw PNG/JPEG
+    bytes, a base64 / data-URI string, a path to an image file, a matplotlib
+    Figure, or any object with ``_repr_png_`` / ``_repr_jpeg_`` (a PIL image, a
+    plot). Every path runs through the downscaler (see ``_IMAGE_MAX_DIM``)."""
     if value is None:
         return None
     # Raw bytes: sniff PNG vs JPEG by magic, default to PNG.
     if isinstance(value, (bytes, bytearray)):
         raw = bytes(value)
         mime = "image/jpeg" if raw[:3] == b"\xff\xd8\xff" else "image/png"
-        return {"mime": mime, "data": base64.b64encode(raw).decode("ascii")}
+        return _encode_image_bytes(raw, mime)
     if isinstance(value, str):
         s = value.strip()
         if s.startswith("data:image/"):
             head, _, payload = s.partition(",")
             mime = head[5:].split(";", 1)[0] or "image/png"
-            return {"mime": mime, "data": payload}
+            return _encode_image_b64(payload, mime)
         # A filesystem path to an image.
         if len(s) < 4096 and os.path.isfile(s):
             try:
@@ -858,13 +933,13 @@ def _coerce_image(value) -> dict | None:
             except OSError:
                 return None
             mime = "image/jpeg" if s.lower().endswith((".jpg", ".jpeg")) else "image/png"
-            return {"mime": mime, "data": base64.b64encode(raw).decode("ascii")}
+            return _encode_image_bytes(raw, mime)
         # Otherwise assume it is already base64-encoded PNG.
-        return {"mime": "image/png", "data": s}
+        return _encode_image_b64(s, "image/png")
     # matplotlib Figure: render to PNG.
     if type(value).__module__.startswith("matplotlib") and hasattr(value, "savefig"):
         try:
-            return {"mime": "image/png", "data": base64.b64encode(_figure_png(value)).decode("ascii")}
+            return _encode_image_bytes(_figure_png(value), "image/png")
         except Exception:
             return None
     # Anything with a rich image repr (a PIL image, a plotly/altair object).
@@ -878,9 +953,9 @@ def _coerce_image(value) -> dict | None:
             if out is None:
                 continue
             if isinstance(out, (bytes, bytearray)):
-                return {"mime": mime, "data": base64.b64encode(bytes(out)).decode("ascii")}
+                return _encode_image_bytes(bytes(out), mime)
             if isinstance(out, str):
-                return {"mime": mime, "data": out}
+                return _encode_image_b64(out, mime)
     return None
 
 
@@ -1487,6 +1562,17 @@ def install(user_ns: dict | None = None) -> None:
     except Exception:
         # Outside the bundled interpreter the module may be absent; skip it.
         pass
+    # Pre-bind the two most-reached-for bundled modules so `fff.grep(...)` and
+    # `view.ls(...)` work with no import, the way Result/cells/jobs/sh do (an
+    # explicit `import fff` returns the same object, so both styles agree). Both
+    # are already imported at startup (01-ix-polars installs view's renderer, which
+    # imports fff), so binding them here costs nothing; heavier modules (nix,
+    # fleet, search) stay import-on-demand to keep the namespace lean.
+    for _mod_name in ("fff", "view"):
+        try:
+            target[_mod_name] = __import__(_mod_name)
+        except Exception:
+            pass
     target["api"] = api
 
     try:

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -49,6 +49,7 @@ _KERNEL_GUIDE = guide.compose(
     guide.MODULES,
     guide.HTML,
     guide.VIEW,
+    guide.VERIFY,
     guide.POLARS,
     guide.SEARCH,
     guide.RESULT_CONTRACT,

--- a/packages/mcp/src/view/view/__init__.py
+++ b/packages/mcp/src/view/view/__init__.py
@@ -31,6 +31,26 @@ from datetime import datetime
 
 import polars as pl
 
+# Heavy, rarely-relevant directories `tree` collapses (lists but does not descend
+# into) unless ``all=True``: dependency installs, build output, vendored code, and
+# caches. Dotted dirs (.git, .venv, .svelte-kit, ...) are already skipped by the
+# hidden-entry rule, so this names only the non-dotted offenders that otherwise
+# bury a project's real structure under thousands of files.
+_NOISE_DIRS = frozenset(
+    {
+        "node_modules",
+        "target",
+        "build",
+        "dist",
+        "out",
+        "result",
+        "vendor",
+        "venv",
+        "coverage",
+        "__pycache__",
+    }
+)
+
 __all__ = [
     "ls",
     "tree",
@@ -469,7 +489,11 @@ def tree(
     """A recursive listing to ``depth`` as a DataFrame (depth, name, path, kind).
 
     ``name`` is indented by depth for a tree shape; ``path`` is relative to the
-    root so results stay sortable/filterable.
+    root so results stay sortable/filterable. Heavy dependency/build/cache dirs
+    (``node_modules``, ``target``, ``dist``, ...) are listed but not descended
+    into, so a tree of a real project shows its structure instead of thousands of
+    vendored files; pass ``all=True`` to include hidden entries and walk those
+    dirs too. A collapsed dir's ``name`` is suffixed ``/…``.
     """
     root = pathlib.Path(path)
     rows = []
@@ -486,16 +510,17 @@ def tree(
         for p in entries:
             if not all and p.name.startswith("."):
                 continue
-            kind = "dir" if p.is_dir() else "file"
+            is_dir = p.is_dir()
+            collapsed = is_dir and not all and p.name in _NOISE_DIRS
             rows.append(
                 {
                     "depth": level,
-                    "name": ("  " * level) + p.name,
+                    "name": ("  " * level) + p.name + ("/\u2026" if collapsed else ""),
                     "path": str(p.relative_to(root)),
-                    "kind": kind,
+                    "kind": "dir" if is_dir else "file",
                 }
             )
-            if p.is_dir():
+            if is_dir and not collapsed:
                 walk(p, level + 1)
 
     walk(root, 0)

--- a/packages/mcp/src/view/view/__init__.py
+++ b/packages/mcp/src/view/view/__init__.py
@@ -27,6 +27,7 @@ import html as _html
 import json as _json
 import os
 import pathlib
+import subprocess
 from datetime import datetime
 
 import polars as pl
@@ -50,6 +51,29 @@ _NOISE_DIRS = frozenset(
         "__pycache__",
     }
 )
+
+
+def _git_ignored(root: pathlib.Path, rels: list[str]) -> set[str]:
+    """The subset of ``rels`` (paths relative to ``root``) that git ignores, via
+    ``git check-ignore``. Empty when ``root`` is not a git work tree or git is
+    unavailable, so callers fall back to the static :data:`_NOISE_DIRS` denylist.
+    Never raises: ignore-pruning is best-effort and must not break a listing."""
+    if not rels:
+        return set()
+    try:
+        proc = subprocess.run(
+            ["git", "check-ignore", "--stdin", "-z"],
+            input="\0".join(rels) + "\0",
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    # exit 0 = some ignored, 1 = none, 128 = not a repo: all non-fatal here.
+    return {p for p in proc.stdout.split("\0") if p}
+
 
 __all__ = [
     "ls",
@@ -489,11 +513,12 @@ def tree(
     """A recursive listing to ``depth`` as a DataFrame (depth, name, path, kind).
 
     ``name`` is indented by depth for a tree shape; ``path`` is relative to the
-    root so results stay sortable/filterable. Heavy dependency/build/cache dirs
-    (``node_modules``, ``target``, ``dist``, ...) are listed but not descended
-    into, so a tree of a real project shows its structure instead of thousands of
-    vendored files; pass ``all=True`` to include hidden entries and walk those
-    dirs too. A collapsed dir's ``name`` is suffixed ``/…``.
+    root so results stay sortable/filterable. Noise is pruned: anything the repo's
+    ``.gitignore`` ignores (when ``path`` is in a git work tree), plus a static
+    denylist of heavy dirs (``node_modules``, ``target``, ``dist``, ...) so it
+    still works outside git. An ignored directory is listed as one collapsed row
+    (suffixed ``/…``) but not descended into; an ignored file is dropped. Pass
+    ``all=True`` to include hidden + ignored entries and walk everything.
     """
     root = pathlib.Path(path)
     rows = []
@@ -507,16 +532,29 @@ def tree(
             )
         except OSError:
             return
+        ignored = (
+            set()
+            if all
+            else _git_ignored(root, [str(p.relative_to(root)) for p in entries])
+        )
         for p in entries:
             if not all and p.name.startswith("."):
                 continue
             is_dir = p.is_dir()
-            collapsed = is_dir and not all and p.name in _NOISE_DIRS
+            rel = str(p.relative_to(root))
+            # Prune noise: anything .gitignore ignores, plus the static denylist
+            # of heavy dirs (so it still works outside a git repo). An ignored DIR
+            # is shown as one collapsed row (structure stays visible) but not
+            # walked; an ignored FILE (build artifact, .env, ...) is dropped.
+            noisy = not all and (rel in ignored or (is_dir and p.name in _NOISE_DIRS))
+            if noisy and not is_dir:
+                continue
+            collapsed = noisy and is_dir
             rows.append(
                 {
                     "depth": level,
                     "name": ("  " * level) + p.name + ("/\u2026" if collapsed else ""),
-                    "path": str(p.relative_to(root)),
+                    "path": rel,
                     "kind": "dir" if is_dir else "file",
                 }
             )


### PR DESCRIPTION
## Why

Six developer-experience fixes to `packages/mcp`, each from a concrete failure mode hit while actually using the kernel (a self-review of where the surface tripped me up and filled context):

| # | Fix | Failure it addresses |
|---|-----|----------------------|
| 1 | **`view.tree` collapses heavy dirs** | A depth-2 tree of a JS project dumped **1356 rows** (almost all `node_modules`). Biggest single context killer. |
| 2 | **`Result.llm_images` downscaling** | Full-page Playwright screenshots returned at full resolution, spending vision tokens for no added legibility. |
| 3 | **stdout preview on a failed Result contract** | A cell that `print(...)`s but returns no `Result` failed with a bare "must return a Result" — no hint that stdout was dropped or what it contained. |
| 4 | **`fff` + `view` pre-bound** | First-cell `NameError: fff is not defined` — bundled modules needed `import` but `Result`/`cells`/`jobs`/`sh` did not. |
| 5 | **Configurable result cap + head/tail preview** | The per-reply cap was a fixed 50k one-sided clip; no operator knob, and a clip hid the end of the output. |
| 6 | **`VERIFY` guidance + module/tree notes** | Shipped a broken interactive toggle that passed `svelte-check`; "it compiles" was treated as "it works". |

## What changed

1. **`view.tree`** lists but does not descend into `node_modules`/`target`/`build`/`dist`/`out`/`result`/`vendor`/`venv`/`coverage`/`__pycache__` (collapsed dir shown as `name/…`). `all=True` walks them. *(1356 → ~85 rows on the repro.)*
2. **Image downscaling** in `Result._coerce_image`: any raster image is shrunk so its longest edge ≤ `IX_MCP_IMAGE_MAX_DIM` (default **1280px**) and re-encoded as PNG before base64. Set `IX_MCP_IMAGE_MAX_DIM=0` to disable. Pillow is already present (transitively via matplotlib); failure falls back to the original bytes.
3. **stdout hint**: when a cell prints but returns no `Result`, the contract error now appends a preview of what was printed and the one-line fix (`Result.text(...)` / page `jobs['<id>'].output`).
4. **`fff` and `view` pre-bound** in the namespace (no import), like `Result`/`cells`/`jobs`/`sh`. Both are already imported at startup, so this costs nothing; heavier modules (`nix`/`fleet`/`search`) stay import-on-demand.
5. **`IX_MCP_MAX_RESULT_CHARS`** makes the per-reply text cap configurable; an over-cap block is rendered as a **head + tail** preview with paging guidance instead of a one-sided clip.
6. **`guide.py`**: new `VERIFY` rule (exercise interactive/runtime changes — screenshot, run the path — before reporting done; a green type-check is necessary, not sufficient), plus notes that `fff`/`view` are pre-bound and that `tree` collapses heavy dirs.

## Config knobs (new)

- `IX_MCP_IMAGE_MAX_DIM` (default `1280`, `0` disables)
- `IX_MCP_MAX_RESULT_CHARS` (default `50000`)

## Tests

Extended the in-build `runtimeSmoke` harness to cover all five runtime/output/view behaviors (stdout hint, fff/view pre-bind, real-Pillow image downscale, outputs head/tail cap, view-tree collapse). All green:

- `nix build .#mcp` ✅
- `.#mcp.tests.runtimeSmoke` ✅ (new assertions)
- `.#mcp.tests.{viewSmoke,richSmoke,yieldSmoke}` ✅ (no regressions)

## Considered and dropped

"`fff` search coverage gap" — turned out not to be a bug: `fff.grep` **does** find `.svelte` content; the earlier miss was searching the wrong repo. No change made (fixing a non-bug would be noise).

🤖 Authored with Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cut context bloat in MCP runtime by downscaling images, truncating oversized text, and pruning tree output
> - Images passed to `Result.llm_images` are downscaled to a configurable longest-edge cap (default 1280px, via `IX_MCP_IMAGE_MAX_DIM`) before base64 encoding in [runtime.py](https://github.com/indexable-inc/index/pull/859/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95).
> - Oversized text responses in [outputs.py](https://github.com/indexable-inc/index/pull/859/files#diff-c0531af2f36a91cd56ac9ae4f0be9a0cbb88094a80355387d1b13e95e1568eb9) now return a head+tail preview with paging instructions instead of a truncated head block; cap is configurable via `IX_MCP_MAX_RESULT_CHARS` (default 50,000, floor 500).
> - `view.tree` in [view/__init__.py](https://github.com/indexable-inc/index/pull/859/files#diff-3fb883791c4d496cf7370e61715a007772f0dca222406e20e8c8944f7ef1a2ab) now collapses `.gitignore`-ignored paths and a denylist of heavy directories (e.g. `node_modules`, `venv`) by default; pass `all=True` to show everything.
> - Cells that print to stdout but return no `Result` now include a hint showing what was printed and how to surface it to the model.
> - `fff` and `view` are pre-bound in the kernel namespace without requiring an explicit import.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af5a264.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->