### PR TITLE
mcp: auto-wrap displayable results, ls gitignore column, clearer job polling

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -888,6 +888,28 @@ let
         assert "printed to stdout" in p.error, p.error
         assert "hello-from-stdout" in p.error, p.error
 
+        # A bare final value that already renders richly is auto-wrapped in
+        # Result.of, so `df` on the last line just works without an explicit Result.
+        d = await run("import polars as pl\npl.DataFrame({'x': [1, 2]})", budget=2.0, name="auto-df")
+        assert d.status == "done", (d.status, d.error)
+        assert isinstance(d.result, runtime.Result), type(d.result)
+        # A plain scalar is not displayable, so the contract still rejects it.
+        sc = await run("1 + 1", budget=2.0, name="scalar")
+        assert sc.status == "error", sc.status
+
+        # .result raises while the job runs (a misleading None would read as
+        # "finished with no value"); .done()/.ok track the lifecycle.
+        slow = await run("import asyncio\nawait asyncio.sleep(0.4)\nResult.text('late')", budget=0.02, name="slow")
+        assert slow.running() and not slow.done(), slow.status
+        try:
+            _ = slow.result
+            raise AssertionError("expected .result to raise while running")
+        except runtime.JobStillRunning:
+            pass
+        await slow.task
+        assert slow.done() and slow.ok, slow.status
+        assert slow.result.llm_result == "late", slow.result
+
     asyncio.run(main())
     # api(): a discoverable catalog of kernel builtins + bundled modules.
     cat = ns["api"]()
@@ -971,6 +993,14 @@ let
         assert not any("big.py" in n for n in _gi), _gi
         assert not any("debug.log" in n for n in _gi), _gi
         assert any("src" in n for n in _gi), _gi
+
+        # view.ls stays flat but flags git-ignored entries in an `ignored` column
+        # (it never drops them, unlike tree): the *.log file is ignored, src is not.
+        _lsg = _view.ls(_g)
+        assert "ignored" in _lsg.columns, _lsg.columns
+        _byname = {r["name"]: r["ignored"] for r in _lsg.iter_rows(named=True)}
+        assert _byname.get("debug.log") is True, _byname
+        assert _byname.get("src") is False, _byname
 
     print("runtime-ok")
   '';
@@ -1562,6 +1592,10 @@ let
 
     lsdf = view.ls(base)
     assert isinstance(lsdf, pl.DataFrame) and "kind" in lsdf.columns, lsdf.columns
+    # ls flags git-ignored entries in an `ignored` Boolean column rather than
+    # dropping them; outside a git work tree (this store path) nothing is ignored.
+    assert lsdf.schema["ignored"] == pl.Boolean, lsdf.schema
+    assert not lsdf["ignored"].any(), lsdf
     # A DataFrame stays a DataFrame through polars ops (composable).
     assert isinstance(lsdf.filter(pl.col("kind") == "dir"), pl.DataFrame)
 
@@ -1989,6 +2023,101 @@ let
         mkdir -p "$out"
       '';
 
+  # The worktree module: drive real `git worktree` against a throwaway repo
+  # (git is on PATH in this sandbox). Proves add() creates a new branch in its
+  # own tree (and checks out an existing branch instead of recreating it),
+  # list() is a DataFrame marking the current tree, the Worktree is os.PathLike
+  # and `wt / "x"` joins onto it, commit() stages new files, and remove() drops
+  # the tree. Pure git + the bundled sh, so the sandbox runs it.
+  worktreeTestPy = pkgs.writeText "ix-mcp-worktree-test.py" ''
+    import asyncio
+    import os
+    import pathlib
+    import subprocess
+    import tempfile
+
+    import polars as pl
+
+    import worktree
+
+
+    def _git(*args, cwd):
+        subprocess.run(["git", "-C", cwd, *args], check=True, capture_output=True)
+
+
+    async def main():
+        repo = tempfile.mkdtemp()
+        _git("init", "-q", cwd=repo)
+        _git("config", "user.email", "t@t", cwd=repo)
+        _git("config", "user.name", "t", cwd=repo)
+        _git("commit", "--allow-empty", "-q", "-m", "init", cwd=repo)
+
+        # add() creates a NEW branch in its own tree off HEAD.
+        wt = await worktree.add("feature-x", repo=repo)
+        assert wt.branch == "feature-x", wt
+        assert wt.path.is_dir(), wt.path
+
+        # os.PathLike + `wt / "x"` join onto the tree.
+        assert os.fspath(wt) == str(wt.path), wt
+        (wt / "hello.txt").write_text("hi")
+
+        # list() is a DataFrame; exactly one tree is `current` (the main one), and
+        # the new worktree is not it.
+        lst = worktree.list(repo)
+        assert isinstance(lst, pl.DataFrame) and "current" in lst.columns, lst.columns
+        assert "feature-x" in set(lst["branch"].to_list()), lst
+        assert lst.filter(pl.col("current")).height == 1, lst
+        assert not lst.filter(pl.col("branch") == "feature-x")["current"][0], lst
+
+        # commit() stages the new (untracked) file, so it lands in the commit.
+        c = await wt.commit("add hello")
+        assert c.ok, c.text
+        tracked = subprocess.run(
+            ["git", "-C", str(wt.path), "ls-files"], capture_output=True, text=True
+        ).stdout
+        assert "hello.txt" in tracked, tracked
+
+        # An existing branch is checked out (not recreated) by add().
+        _git("branch", "existing", cwd=repo)
+        wt2 = await worktree.add("existing", repo=repo)
+        assert wt2.branch == "existing", wt2
+
+        # remove() drops the tree (force discards uncommitted changes in it);
+        # main + feature-x remain.
+        rm = await wt2.remove(force=True)
+        assert rm.ok, rm.text
+        assert worktree.list(repo).height == 2, worktree.list(repo)
+
+        print("worktree-ok")
+
+
+    asyncio.run(main())
+  '';
+  worktreeSmoke =
+    pkgs.runCommand "ix-mcp-worktree-smoke"
+      {
+        nativeBuildInputs = [
+          mcpPython
+          pkgs.git
+        ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        ${lib.getExe mcpPython} ${worktreeTestPy} >stdout 2>stderr || {
+          echo "ix-mcp worktree smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -qx 'worktree-ok' stdout || {
+          echo "ix-mcp worktree smoke did not confirm the worktree module:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
+
   screenBundled = importTest "screen" "import screen; print('screen-ok', all(callable(getattr(screen, n)) for n in ('capture', 'click', 'write', 'press', 'key_down', 'key_up', 'apps', 'frontmost', 'launch', 'activate', 'terminate', 'accessibility_trusted')))";
   vmkitBundled = importTest "vmkit" "import vmkit; print('vmkit-ok', callable(vmkit.boot_linux), callable(vmkit.drive), callable(vmkit.screenshot))";
 in
@@ -2018,6 +2147,7 @@ package.overrideAttrs (old: {
         nixSmoke
         fleetSmoke
         shSmoke
+        worktreeSmoke
         ;
       site = dashboardSite;
     }

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -29,15 +29,17 @@ JOBS = (
     "Each call runs as an async task and waits up to `budget` seconds; if the work is still going "
     "it keeps running in the background and the call returns a job handle. Background jobs live "
     "in the `jobs` dict, so manage them with more python_exec: `jobs['ab12']` to inspect, `await "
-    "jobs['ab12']` to wait, `jobs['ab12'].cancel()` to stop, `[j for j in jobs.values() if "
+    "jobs['ab12']` to wait (it yields the run's value), `jobs['ab12'].cancel()` to stop, "
+    "`jobs['ab12'].done()` to test if it has finished, `[j for j in jobs.values() if "
     "j.running()]` to list."
 )
 
 PAGING = (
     "Every run is kept in `jobs`, so a truncated reply is never lost: page the run with "
     "jobs['<id>'].tail(n) / .head(n) / .slice(a, b) / .grep('pat') / .lines(a, b), or read "
-    "jobs['<id>'].output (stdout) and jobs['<id>'].result (the value); history() lists recent "
-    "runs."
+    "jobs['<id>'].output (stdout) and, once it has finished, jobs['<id>'].result (the value — "
+    "it raises while the job is still running rather than return a misleading None, so `await "
+    "jobs['<id>']` to wait for it); history() lists recent runs."
 )
 
 BLOCKING = (
@@ -56,7 +58,10 @@ RESULT_CONTRACT = (
     "surface anything worth seeing as a Result. A cell must either END with a `Result(...)` or "
     "`yield Result(...)` one or more times — each yielded Result streams to both the human and "
     "you the moment it is produced, so prefer yielding as you go to report progress and partial "
-    "results. The kernel rejects a cell that neither ends with nor yields a Result."
+    "results. The kernel rejects a cell that neither ends with nor yields a Result — except that "
+    "a bare final value which already renders richly (a polars DataFrame, a matplotlib figure, a "
+    "view/fff render, an htpy element) is auto-wrapped in `Result.of` for you, so `df` on the "
+    "last line just works; a plain scalar, dict, list, or None still needs an explicit Result."
 )
 
 # --- kernel guide only ---
@@ -119,7 +124,8 @@ VIEW = (
     "(`view.tree` prunes noise — anything the repo's `.gitignore` ignores, plus a denylist of heavy "
     "dirs like node_modules / target / dist — so a project's structure is not buried under vendored "
     "or generated files; an ignored dir collapses to one row, an ignored file drops, and `all=True` "
-    "shows everything) "
+    "shows everything; `view.ls` stays flat instead and adds an `ignored` column flagging the "
+    "git-ignored entries rather than dropping them) "
     "(never `ls` — not via bash, `sh`, or `asyncio.create_subprocess_exec`, and never paste a raw "
     "`ls -la` dump at the human), `view.grep` / `view.find` search as DataFrames, "
     "`view.cat/read/head/json/diff` return a syntax-highlighted view, and `view.edit(path, old, "

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -145,6 +145,16 @@ class _Tee:
         return getattr(self._original, name)
 
 
+class JobStillRunning(RuntimeError):
+    """Raised by ``Job.result`` when the job has not finished yet.
+
+    Reaching for a running job's result is the one job-polling footgun: a plain
+    ``None`` reads as "finished with no value". This raises instead, so the
+    confusion surfaces as a clear instruction to ``await`` it (or poll
+    ``.done()``) rather than a silent wrong answer.
+    """
+
+
 class Job:
     """A single ``python_exec`` execution: an awaitable handle over the asyncio
     task running the code, with its captured output, result, and status."""
@@ -156,7 +166,10 @@ class Job:
         self.status = "running"
         self.started = time.time()
         self.ended: float | None = None
-        self.result = None
+        # The cell's final value (a Result), exposed through the `result`
+        # property; stored privately so an access while running can raise rather
+        # than hand back a misleading None.
+        self._result = None
         self.error: str | None = None
         self._buf: list[str] = []
         self._buflen = 0
@@ -250,6 +263,34 @@ class Job:
     def running(self) -> bool:
         return self.status == "running"
 
+    def done(self) -> bool:
+        """True once the job has finished (done, error, or cancelled). Pair it
+        with `.result`, which only yields a value once the job is done."""
+        return self.status != "running"
+
+    @property
+    def ok(self) -> bool:
+        """True if the job finished successfully (no error, not cancelled)."""
+        return self.status == "done"
+
+    @property
+    def result(self):
+        """This run's final value -- the `Result` the cell produced (or the one
+        auto-wrapped from a bare displayable final expression like a DataFrame).
+
+        Accessing it while the job is still running raises `JobStillRunning`,
+        instead of returning a misleading `None`: background the work, then
+        `await jobs['id']` to get the result, or poll `.done()` / `.running()`
+        first. Once finished this is exactly what `await jobs['id']` yields."""
+        if self.running():
+            dur = time.time() - self.started
+            raise JobStillRunning(
+                f"job {self.id} is still running ({dur:.1f}s); "
+                f"`await jobs['{self.id}']` to get its result, "
+                f"or check `.done()` / `.running()` first"
+            )
+        return self._result
+
     def cancel(self) -> "Job":
         if self.task is not None and not self.task.done():
             self.task.cancel()
@@ -260,7 +301,7 @@ class Job:
         # returns None, so wait for it then hand back the captured result.
         async def _await_result():
             await self.task
-            return self.result
+            return self._result
 
         return _await_result().__await__()
 
@@ -695,6 +736,33 @@ def _display_result(result: "Result") -> None:
         pass
 
 
+def _is_displayable(value) -> bool:
+    """True if a bare final expression value is rich enough to auto-wrap in
+    ``Result.of`` (so ``df`` on the last line just works), False if returning it
+    is the print-like anti-pattern the Result contract nudges away from.
+
+    Displayable = it already knows how to render itself: an IPython rich repr
+    (a polars DataFrame, a ``view.Code``, ...), an htpy-style ``__html__``, or a
+    figure/image that renders through a registered formatter. Plain scalars,
+    ``str``/``bytes``, and the container types (dict/list/tuple/set) are NOT --
+    those still fail the contract, to keep pushing key/value data toward a
+    DataFrame and confirmations toward ``Result.ok``.
+    """
+    if value is None or isinstance(
+        value, (str, bytes, bool, int, float, complex, dict, list, tuple, set, frozenset)
+    ):
+        return False
+    for attr in (
+        "_repr_html_", "_repr_png_", "_repr_jpeg_", "_repr_svg_",
+        "_repr_markdown_", "_repr_latex_", "_repr_mimebundle_", "__html__",
+    ):
+        if callable(getattr(value, attr, None)):
+            return True
+    # Figures/axes/images render via a registered formatter, not a method.
+    module = type(value).__module__ or ""
+    return module.startswith("matplotlib") or module.startswith("PIL")
+
+
 async def _runner(job: Job, ns: dict) -> None:
     token = _ix_current.set(job)
     if _store is not None and _store_conn is not None:
@@ -734,23 +802,31 @@ async def _runner(job: Job, ns: dict) -> None:
                     job.status = "done"
             # The results were displayed as they streamed; there is no single
             # trailing value to return.
-            job.result = None
+            job._result = None
         else:
             maybe = eval(code_obj, ns)
             if inspect.iscoroutine(maybe):
                 await maybe
-            job.result = ns.pop("__ix_result", None)
-            if isinstance(job.result, Result):
+            value = ns.pop("__ix_result", None)
+            if not isinstance(value, Result) and _is_displayable(value):
+                # A bare final value that already knows how to render itself (a
+                # DataFrame, a figure, a view.Code, an htpy element) is wrapped
+                # in Result.of, so `df` on the last line just works. Plain
+                # scalars / dicts / None fall through to the contract error below.
+                value = Result.of(value)
+            job._result = value
+            if isinstance(value, Result):
                 job.status = "done"
             else:
                 # Enforce the Result contract: a non-yielding cell must END with a
-                # Result so a run always declares what the human sees and what the
-                # model gets. A bare value (or a side-effecting cell that returns
-                # None) is a failed run with an instructive message, not a silent pass.
+                # Result (or a value that renders as one) so a run always declares
+                # what the human sees and what the model gets. A bare scalar (or a
+                # side-effecting cell returning None) is a failed run with an
+                # instructive message, not a silent pass.
                 job.status = "error"
                 job.error = _RESULT_REQUIRED + _stdout_hint(job)
                 job._append(job.error)
-                job.result = None
+                job._result = None
     except asyncio.CancelledError:
         job.status = "cancelled"
         raise
@@ -790,7 +866,7 @@ def _persist_final(job: Job) -> None:
     if _store is None or _store_conn is None:
         return
     try:
-        result_repr = None if job.result is None else _safe_repr(job.result)
+        result_repr = None if job._result is None else _safe_repr(job._result)
         _store.finish(
             _store_conn,
             id=job.id,
@@ -1000,8 +1076,8 @@ def _job_outputs(job: "Job") -> list[dict]:
     """A job's rich outputs for the store: every display() bundle captured while it
     ran, plus the trailing-expression result rendered the same way."""
     outs = list(job._displays)
-    if job.result is not None and not job.running():
-        bundle = _result_bundle(job.result)
+    if not job.running() and job._result is not None:
+        bundle = _result_bundle(job._result)
         if bundle is not None:
             outs.append(bundle)
     return outs
@@ -1290,9 +1366,9 @@ _SUMMARY_CHARS = 50_000
 def _result_text(job: Job) -> str:
     """The job result's model-facing text (a Result's ``llm_result``, else its
     repr), used only to measure how much the inline summary leaves out."""
-    if job.result is None:
+    if job._result is None:
         return ""
-    return getattr(job.result, "llm_result", None) or _safe_repr(job.result)
+    return getattr(job._result, "llm_result", None) or _safe_repr(job._result)
 
 
 def _job_summary(job: Job) -> dict:
@@ -1307,7 +1383,7 @@ def _job_summary(job: Job) -> dict:
         "running": job.running(),
         "output": job.tail(_SUMMARY_CHARS),
         "output_chars": len(job.output),
-        "result": None if job.result is None else _safe_repr(job.result),
+        "result": None if job._result is None else _safe_repr(job._result),
         "result_chars": len(_result_text(job)),
         "error": job.error,
     }
@@ -1341,11 +1417,11 @@ def _emit(job: Job) -> None:
 
     summary = _job_summary(job)
     publish_display_data({JOB_MIME: summary, "text/plain": f"[{job.id}] {job.status}"})
-    # On success job.result is always a Result (the runner enforces it); display
+    # On success job._result is always a Result (the runner enforces it); display
     # it so the server can unpack the model view and the dashboard the human one.
-    if job.status == "done" and job.result is not None:
+    if job.status == "done" and job._result is not None:
         try:
-            display(job.result)
+            display(job._result)
         except Exception:
             # Rich display is best-effort; failures must not block the summary.
             pass

--- a/packages/mcp/src/nix/nix/__init__.py
+++ b/packages/mcp/src/nix/nix/__init__.py
@@ -29,9 +29,10 @@ Two ways in:
   gets the finished :class:`NixLog` back -- ``log.activities`` / ``log.events``
   are polars frames, ``log.tree()`` is the rendered DAG.
 
-Run it as a background job (``await nix.build(".#foo")`` past the budget) and the
-model can sample ``jobs['..'].result`` -- the same :class:`NixLog`, mutated in
-place -- between turns: the durable, growable interface for a long build.
+Run it as a background job (``await nix.build(".#foo")`` runs past the budget and
+backgrounds); next turn ``await jobs['..']`` yields the finished :class:`NixLog`
+(``log.activities`` / ``log.events`` / ``log.tree()``), while the dashboard
+Resource shows the DAG growing live as it builds.
 """
 
 from __future__ import annotations

--- a/packages/mcp/src/view/view/__init__.py
+++ b/packages/mcp/src/view/view/__init__.py
@@ -474,15 +474,23 @@ def _lang_for(path: pathlib.Path) -> str | None:
 
 
 def ls(path: str | os.PathLike = ".", *, all: bool = False) -> "pl.DataFrame":
-    """A directory listing as a DataFrame (name, kind, size, modified).
+    """A directory listing as a DataFrame (name, kind, size, modified, ignored).
 
     Dirs sort first, then by name. Hidden entries are skipped unless ``all``.
+    ``ignored`` flags the entries the repo's ``.gitignore`` ignores (when ``path``
+    is in a git work tree, else always False) -- unlike :func:`tree`, ``ls`` stays
+    flat and never drops them, so ``view.ls("node_modules")`` still lists its
+    contents; filter with ``.filter(~pl.col("ignored"))`` when you want them gone.
     """
     base = pathlib.Path(path)
+    entries = [
+        p for p in base.iterdir() if all or not p.name.startswith(".")
+    ]
+    ignored = (
+        set() if all else _git_ignored(base, [p.name for p in entries])
+    )
     rows = []
-    for p in base.iterdir():
-        if not all and p.name.startswith("."):
-            continue
+    for p in entries:
         try:
             st = p.stat()
             size = st.st_size if p.is_file() else None
@@ -491,7 +499,13 @@ def ls(path: str | os.PathLike = ".", *, all: bool = False) -> "pl.DataFrame":
             size, mtime = None, None
         kind = "dir" if p.is_dir() else ("link" if p.is_symlink() else "file")
         rows.append(
-            {"name": p.name, "kind": kind, "size": size, "modified": mtime}
+            {
+                "name": p.name,
+                "kind": kind,
+                "size": size,
+                "modified": mtime,
+                "ignored": p.name in ignored,
+            }
         )
     df = pl.DataFrame(
         rows,
@@ -500,6 +514,7 @@ def ls(path: str | os.PathLike = ".", *, all: bool = False) -> "pl.DataFrame":
             "kind": pl.Utf8,
             "size": pl.Int64,
             "modified": pl.Datetime,
+            "ignored": pl.Boolean,
         },
     )
     if df.height:


### PR DESCRIPTION
## What

Three independent ix-mcp DX follow-ups (the ones deferred last round), each its own concern.

### 1. Auto-wrap a bare displayable final value in `Result.of`
A cell ending in a value that already knows how to render itself — a polars DataFrame, a matplotlib figure, a `view`/`fff` render, an htpy element (anything carrying an IPython rich repr or `__html__`) — is wrapped in `Result.of` for you, so `df` on the last line just works.

Plain scalars / `dict` / `list` / `None` **still** fail the Result contract, on purpose: returning one of those is the print-like anti-pattern the contract nudges away from (toward a DataFrame or `Result.ok`). `_is_displayable` is the predicate; the contract message and guide are updated.

### 2. `view.ls` is gitignore-aware
`ls` now adds an `ignored` Boolean column flagging the entries the repo's `.gitignore` ignores — it **does not drop them** (unlike `tree`). `ls` stays flat, so `view.ls("node_modules")` still lists its contents; `.filter(~pl.col("ignored"))` hides them when you want.

### 3. Clearer job polling
`Job.result` is now a property that raises `JobStillRunning` while the job is in flight, instead of returning a misleading `None` (which reads as "finished with no value"). The value is stored privately (`_result`) and every internal reader uses that, so the live store / per-call summary still work on a running job. Adds `Job.done()` and `Job.ok`. The `nix` module's live-sampling docstring (which claimed `.result` worked mid-build — it never did, it was `None`) is corrected to the accurate `await jobs['..']` path.

## Docs + tests
- `guide.py` fragments (RESULT_CONTRACT, PAGING, JOBS, VIEW) updated to match.
- Bundled sandbox tests extended: `runtimeSmoke` covers auto-wrap, the `.result`-raises-while-running path, and `done()`/`ok`; `viewSmoke` + the git block cover the `ignored` column.
- Added a **`worktreeSmoke`** test for the `worktree` module shipped in #860 (it had none): add (new + existing branch), `list()`, `os.PathLike` / `wt / "x"`, `commit()` staging, `remove()`.

## Validation
- `nix build .#mcp` ✅
- `nix build .#mcp.tests.{runtimeSmoke,viewSmoke,worktreeSmoke}` ✅
- `nix run .#lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-wrap displayable final values in `Result.of` and add `ignored` column to `view.ls`
> - `_runner` in [runtime.py](https://github.com/indexable-inc/index/pull/861/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) now auto-wraps bare displayable final values (e.g. DataFrames, figures) in `Result.of`; plain scalars/dicts/lists/None still require an explicit `Result`.
> - Introduces `JobStillRunning` exception: accessing `Job.result` before completion now raises instead of returning `None`; `Job.done()` and `Job.ok` are added for lifecycle checks.
> - [view.ls](https://github.com/indexable-inc/index/pull/861/files#diff-3fb883791c4d496cf7370e61715a007772f0dca222406e20e8c8944f7ef1a2ab) adds a boolean `ignored` column indicating `.gitignore` status instead of dropping ignored entries.
> - Smoke tests and guide strings updated to cover the new contract, `view.ls` behavior, and a new worktree module test.
> - Behavioral Change: cells that return a bare scalar/None as the final value now fail with a contract error rather than silently producing no result.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4cfbf4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->