### PR TITLE
claude-code: prefer git worktrees + paragraph-list system prompt

### DIFF
--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -58,13 +58,16 @@
   # `--add-flags` (prepended) so an explicit
   # `--system-prompt`/`--system-prompt-file` on the CLI still wins. Defaults to the
   # house prompt below (the shokunin craft ethos plus the pre-v1
-  # backward-compatibility engineering rule); set to `null` to bake no flag and keep
-  # Claude Code's stock prompt.
-  systemPrompt ? ''
-    Work as a shokunin (職人): a craftsman devoted to mastering the craft. Be thoughtful. Ship a beautiful, nearly perfect product, and make the code behind it just as beautiful. It just works.
-
-    This codebase is pre-v1: do not preserve backward compatibility. Design the correct API, then rename and migrate every call site in the same change rather than adding aliases, shims, or deprecated paths. Keep a compatibility layer only when explicitly asked or when a real external consumer is out of reach.
-  '',
+  # backward-compatibility engineering rule, plus a preference for working in git
+  # worktrees); set to `null` to bake no flag and keep Claude Code's stock prompt.
+  # Authored as one paragraph per list element and joined with blank lines, so a
+  # rule reads as a self-contained line of source instead of buried in a wall of
+  # indented-string prose.
+  systemPrompt ? lib.concatStringsSep "\n\n" [
+    "Work as a shokunin (職人): a craftsman devoted to mastering the craft. Be thoughtful. Ship a beautiful, nearly perfect product, and make the code behind it just as beautiful. It just works."
+    "This codebase is pre-v1: do not preserve backward compatibility. Design the correct API, then rename and migrate every call site in the same change rather than adding aliases, shims, or deprecated paths. Keep a compatibility layer only when explicitly asked or when a real external consumer is out of reach."
+    "Prefer working in a git worktree. Create or use a dedicated worktree for your changes instead of editing the primary checkout directly, so the main working tree stays clean and independent lines of work stay isolated."
+  ],
   # Only the flake package set injects the Nushell writer; the overlay eval
   # context does not. The updater is a maintainer-facing flake output, so the
   # overlay build of `pkgs.claude-code` simply omits `passthru.updateScript`.


### PR DESCRIPTION
Add a third paragraph to the baked default `systemPrompt` in `packages/claude-code` steering the agent to **prefer working in a git worktree** rather than editing the primary checkout directly, so the main working tree stays clean and independent lines of work stay isolated.

While here, refactor the prompt default from one indented multi-line string into a **list of paragraphs** joined with blank lines via `lib.concatStringsSep "\n\n" [ ... ]`, so each rule reads as a self-contained line of source instead of being buried in a wall of indented prose.

Verified: `nix-instantiate --parse` passes and `nixfmt` is clean.

🤖 Authored with Claude Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add git worktree preference to claude-code default system prompt
> Updates the default `systemPrompt` in [default.nix](https://github.com/indexable-inc/index/pull/862/files#diff-09ffe85c84eaed27e6303e856f19ca2a0a7584d09e5912d4173d987c5271716b) to include a new paragraph instructing Claude to prefer working in a git worktree. The prompt is now structured as a list of strings joined with double newlines, making each paragraph easier to maintain independently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d19c59a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->