### PR TITLE
btop: show process working directory (cwd)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,17 +3,17 @@
     "btop-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1780863565,
-        "narHash": "sha256-o8HUTwhZYiivv/uvd/CUgB/zJpQJ/4aHFx/OWfuLJXs=",
+        "lastModified": 1780871699,
+        "narHash": "sha256-dUM7UGO6lzT1At7m2xnnJD9mFbyFO7gjHonVE++YK58=",
         "owner": "indexable-inc",
         "repo": "btop",
-        "rev": "a49aa61bec9b0e0564704c904a3e1689612c8aef",
+        "rev": "711f4a128b1b7009ee9cf0fa179a586c82586613",
         "type": "github"
       },
       "original": {
         "owner": "indexable-inc",
         "repo": "btop",
-        "rev": "a49aa61bec9b0e0564704c904a3e1689612c8aef",
+        "rev": "711f4a128b1b7009ee9cf0fa179a586c82586613",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
     };
 
     btop-src = {
-      url = "github:indexable-inc/btop/a49aa61bec9b0e0564704c904a3e1689612c8aef";
+      url = "github:indexable-inc/btop/711f4a128b1b7009ee9cf0fa179a586c82586613";
       flake = false;
     };
 


### PR DESCRIPTION
Repoints the `btop-src` flake input at the indexable patch-stack tip
(`indexable/process-cwd` = 711f4a1).

That patch adds a **process working-directory** field to btop's detail box:
it reads the real kernel cwd (the dir set by `chdir(2)`) — `readlink
/proc/<pid>/cwd` on Linux, `proc_pidinfo(PROC_PIDVNODEPATHINFO)` on macOS —
not the stale `$PWD` env var. Shown under the command line with a dim `cwd`
label when the command fits in <=2 rows.

The fork keeps a linear patch stack on top of upstream:
`main -> indexable/disk-io-process-view -> indexable/process-cwd`.

## Verification
- `nix build .#btop` (aarch64-darwin): green
- `nix build .#packages.aarch64-linux.btop`: green (Linux collector compiles)
- macOS runtime: detail box shows correct cwd, cross-checked against `lsof -d cwd`

🤖 Generated with Claude Code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update btop source to show process working directory (cwd)
> Bumps the `btop-src` pin in [flake.nix](https://github.com/indexable-inc/index/pull/863/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) from commit `a49aa61` to `711f4a1` to pull in upstream changes that add process working directory (cwd) display.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4743a6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->