### PR TITLE
mcp: render nested dicts recursively + guide toward nested frames

### DIFF
--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -133,7 +133,10 @@ POLARS = (
     "you never hand-build a table and a wide/long-stringed frame is never clipped to you. Use "
     "`pl`; pandas is not bundled. Even key/value data — environment variables, a config dict, "
     "counts — is tabular: return a two-column DataFrame, never a `\\n`-joined string or a printed "
-    "dict."
+    "dict. Nested data renders recursively: a dict of dicts (or a frame with struct/list columns) "
+    "shows each value as a nushell-style nested sub-table, so prefer one frame with struct/list "
+    "columns over a `{label: blob}` dict that collapses each value to a clipped repr — or add each "
+    "item as its own `cells.add`."
 )
 
 RESULT_SPLIT = (

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -452,6 +452,18 @@ def _as_frame_if_tabular(value):
     except Exception:
         return value
     if isinstance(value, Mapping) and value:
+        vals = list(value.values())
+        # A dict whose values are themselves mappings is NESTED data: render the
+        # value column as a polars Struct so `view.df_html` shows each value as a
+        # recursive nushell-style sub-table rather than a clipped repr. Scalar or
+        # heterogeneous values fall back to the flat key/value repr below.
+        if all(isinstance(v, Mapping) for v in vals):
+            try:
+                return pl.DataFrame(
+                    {"key": [str(k) for k in value], "value": pl.Series([dict(v) for v in vals])}
+                )
+            except Exception:
+                pass
         return pl.DataFrame(
             {"key": [str(k) for k in value], "value": [_safe_repr(v) for v in value.values()]}
         )


### PR DESCRIPTION
A `Result({...})` whose values are themselves mappings was flattened to a two-column key/value frame with each value `_safe_repr`'d (clipped). Now a dict of dicts builds a polars Struct value column, so `view.df_html` renders each value as a recursive nushell-style nested sub-table. Scalar/heterogeneous dicts keep the flat repr (guarded fallback). POLARS guidance updated to incentivize struct/list columns over `{label: blob}` dicts.

Author: Andrew Gazelka (with Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render nested dicts as Struct columns in MCP notebook tabular output
> - Updates `_as_frame_if_tabular` in [runtime.py](https://github.com/indexable-inc/index/pull/864/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) to detect dicts whose values are all mappings and build a polars DataFrame with a `key` column and a `value` Struct column, instead of falling back to string reprs.
> - Falls back silently to the existing two-column repr if DataFrame construction fails.
> - Updates guidance text in [guide.py](https://github.com/indexable-inc/index/pull/864/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) to document recursive nushell-style nested sub-table rendering and recommend using struct/list columns or `cells.add` for nested data.
> - Behavioral Change: dicts of dicts now produce a Struct-typed `value` column rather than a string repr column.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 501ce89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->