### PR TITLE
mcp(read): normalize the read note path to ~

### DIFF
--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -1533,6 +1533,18 @@ async def __ix_exec(code: str, budget: float = 15.0, name: str | None = None) ->
     _emit(job)
 
 
+def _tilde(path) -> str:
+    """An absolute path with the home directory collapsed to ``~`` for a compact,
+    privacy-friendly note (``/Users/me/.ix/trace/x`` -> ``~/.ix/trace/x``)."""
+    text = str(path)
+    home = str(pathlib.Path.home())
+    if text == home:
+        return "~"
+    if text.startswith(home + os.sep):
+        return "~" + text[len(home):]
+    return text
+
+
 async def __ix_read(target, start=None, end=None) -> "Result":
     """Read a file (or evaluate a kernel value) FOR THE MODEL, quietly.
 
@@ -1555,7 +1567,7 @@ async def __ix_read(target, start=None, end=None) -> "Result":
         # Off the loop: a large file read is blocking I/O, the one thing that
         # freezes every other job on the shared event loop.
         full = await asyncio.to_thread(path.read_text, errors="replace")
-        label = str(path)
+        label = _tilde(path)
     else:
         value = eval(target, ns) if isinstance(target, str) else target
         full = value if isinstance(value, str) else _safe_repr(value)


### PR DESCRIPTION
The `read` tool's dashboard note showed a full absolute path (`📖 read /Users/andrewgazelka/.ix/trace/…`). Add a `_tilde()` helper that collapses the home prefix to `~`, so the note reads `📖 read ~/.ix/trace/…` (icon kept, span/char counts unchanged). Paths outside $HOME are left absolute.

Author: Andrew Gazelka (with Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize file path display to `~` in `__ix_read` note labels
> Adds a `_tilde` helper in [runtime.py](https://github.com/indexable-inc/index/pull/866/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) that collapses the home directory prefix to `~` in path strings. The `__ix_read` tool now uses this helper when building the user-facing note label for file reads (e.g. `/Users/me/.ix/trace/x` → `~/.ix/trace/x`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7239b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->