### PR TITLE
mcp(sh): require an explicit cwd, reject `cd ... &&` prefixes

### DIFF
--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -105,7 +105,8 @@ NO_SHELL = (
     "syntax-highlighted views) — so the human gets a styled table and you get a clean frame "
     "rather than an unstyled text dump. To list a directory use `view.ls`/`view.tree`, never "
     "`os.walk` or `ls`; to edit, `view.edit(path, old, new)`, never blind. For meaning-based "
-    "recall across a corpus, `import search`."
+    "recall across a corpus, `import search`. When you genuinely must shell out, `sh` requires a "
+    "`cwd=` (`cwd=\".\"` for here) — pass the directory there, never a `cd X && ...` prefix."
 )
 
 VERIFY = (

--- a/packages/mcp/src/sh/sh/__init__.py
+++ b/packages/mcp/src/sh/sh/__init__.py
@@ -6,7 +6,7 @@ invocation with no Python binding), do it without blocking the one shared event
 loop and without leaking terminal escape codes into your own context.
 
     import sh
-    out = await sh("gh run list --limit 5")
+    out = await sh("gh run list --limit 5", cwd=".")
     out                       # last expr: dashboard shows the COLORED terminal
                               # block, you get the escape-stripped plain text
 
@@ -211,7 +211,7 @@ def _terminate(proc: asyncio.subprocess.Process) -> None:
 async def sh(
     cmd: str | list[str],
     *,
-    cwd: str | os.PathLike | None = None,
+    cwd: str | os.PathLike,
     env: dict[str, str] | None = None,
     timeout: float | None = None,
     check: bool = False,
@@ -221,7 +221,9 @@ async def sh(
 
     ``cmd`` is a string (run through the shell, so pipes and globs work) or an
     argv list (executed directly, no shell parsing). stdout and stderr are merged
-    in order. ``cwd`` and ``env`` extend the current directory and environment;
+    in order. ``cwd`` is REQUIRED -- pass the directory to run in (``cwd="."`` for
+    here) instead of a `cd X && ...` prefix, which is rejected, so the command
+    string stays clean. ``env`` extends the environment;
     ``timeout`` (seconds) kills the child's whole process group and raises
     :class:`TimeoutError`; ``check=True`` raises :class:`ShellError` on a non-zero
     exit; ``color=False`` suppresses the forced-color environment.
@@ -230,6 +232,11 @@ async def sh(
     backgrounds, say) waits for that pipe to close. The await yields to the loop,
     so it never blocks other jobs; pass ``timeout`` to bound such a command.
     """
+    if isinstance(cmd, str) and re.match(r"\s*cd\b", cmd):
+        raise ValueError(
+            "sh() takes no `cd ...` prefix: pass the working directory as cwd= and keep "
+            "the command itself clean, e.g. await sh('ix trace <id>', cwd='/path/to/repo')."
+        )
     full_env = dict(os.environ)
     if color:
         full_env.update(_COLOR_ENV)

--- a/packages/mcp/src/worktree/worktree/__init__.py
+++ b/packages/mcp/src/worktree/worktree/__init__.py
@@ -122,8 +122,8 @@ class Worktree:
         import sh as _sh
 
         if all:
-            await _sh(["git", "-C", str(self.path), "add", "-A"], check=True)
-        return await _sh(["git", "-C", str(self.path), "commit", "-m", message])
+            await _sh(["git", "-C", str(self.path), "add", "-A"], check=True, cwd=str(self.path))
+        return await _sh(["git", "-C", str(self.path), "commit", "-m", message], cwd=str(self.path))
 
     async def build(self, attr: str, *flags: str, add: bool = True, **kwargs):
         """``nix build`` this worktree's flake (bundled ``nix``, ``cwd`` threaded).
@@ -137,7 +137,7 @@ class Worktree:
         if add:
             import sh as _sh
 
-            await _sh(["git", "-C", str(self.path), "add", "-A"], check=True)
+            await _sh(["git", "-C", str(self.path), "add", "-A"], check=True, cwd=str(self.path))
         return await _nix.build(attr, *flags, cwd=str(self.path), **kwargs)
 
     async def remove(self, *, force: bool = False):
@@ -262,7 +262,7 @@ async def add(
         argv += ["-b", branch, str(dest)]
         if base is not None:
             argv.append(base)
-    await _sh(argv, check=True)
+    await _sh(argv, check=True, cwd=str(top))
     head = _run(dest, "rev-parse", "HEAD").stdout.strip()
     return Worktree(path=dest.resolve(), branch=branch, head=head, repo=top)
 
@@ -285,7 +285,7 @@ async def remove(
     if force:
         argv.append("--force")
     argv.append(str(target))
-    return await _sh(argv)
+    return await _sh(argv, cwd=str(top))
 
 
 async def prune(repo: str | os.PathLike = "."):
@@ -296,4 +296,4 @@ async def prune(repo: str | os.PathLike = "."):
     import sh as _sh
 
     top = _toplevel(repo)
-    return await _sh(["git", "-C", str(top), "worktree", "prune", "-v"])
+    return await _sh(["git", "-C", str(top), "worktree", "prune", "-v"], cwd=str(top))


### PR DESCRIPTION
`await sh("cd /path && cmd")` mixed the working directory into the command string. Now `sh`'s `cwd` is a required keyword-only argument (pass `cwd='.'` for here) and a leading `cd ` is rejected with a message pointing at `cwd=`, so the command itself stays clean (`await sh('ix trace <id>', cwd=repo)`). Migrated the in-repo `worktree` callers to pass `cwd=`, updated the `sh` docstring/examples, and added an NO_SHELL guidance line.

Author: Andrew Gazelka (with Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require explicit `cwd` in `sh()` and reject `cd ... &&` command prefixes
> - Makes `cwd` a required parameter in [`sh()`](https://github.com/indexable-inc/index/pull/867/files#diff-f9700c17685e82e375a4176ad39ea4dfb7728f90008c6fe9c7678e7de72dd59d) and raises `ValueError` if the command string starts with `cd`, forcing callers to pass the working directory explicitly.
> - Updates all `sh()` call sites in [`worktree/__init__.py`](https://github.com/indexable-inc/index/pull/867/files#diff-ed475dec83bc9cd3332dbf5d7d753dea1ebccefb2e14b3310352ba9bb80162d1) to pass `cwd` derived from the relevant repo or worktree path.
> - Updates MCP guidance in [`guide.py`](https://github.com/indexable-inc/index/pull/867/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) to document the new `cwd` requirement.
> - Behavioral Change: any existing caller that omits `cwd` or prefixes commands with `cd X &&` will now get a runtime error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a72f369.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->