### PR TITLE
docs(mcp): give NO_SHELL the concrete reason to prefer fff over rg

### DIFF
--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -98,15 +98,21 @@ DISCOVER = (
 )
 
 NO_SHELL = (
-    "Never shell out for what the bundled helpers already do — no `ls`/`cat`/`grep`/`find`/`rg`/"
+    "Never shell out for what the bundled helpers already do: no `ls`/`cat`/`grep`/`find`/`rg`/"
     "`fd` via bash, `sh`, or `asyncio.create_subprocess_exec`, and no one-off search or listing "
-    "helper. `fff` finds files and greps content, `view` lists directories and shows files, and "
-    "both return polars frames you compose `.filter`/`.sort`/`.group_by`/`.head` on (or "
-    "syntax-highlighted views) — so the human gets a styled table and you get a clean frame "
-    "rather than an unstyled text dump. To list a directory use `view.ls`/`view.tree`, never "
+    "helper. Doing it by hand is concretely worse, not just off-style: a bare `subprocess.run` "
+    "runs synchronously on the kernel's one event loop and freezes every other job until it "
+    "returns, and its piped output arrives corrupted (ANSI color codes get interleaved into the "
+    "matched text, silently mangling and truncating the very tokens you searched for). `fff` finds "
+    "files and greps content, `view` lists directories and shows files; both run off the loop, "
+    "reuse a cached content index so they are faster than re-walking the tree each call, and "
+    "return polars frames you compose `.filter`/`.sort`/`.group_by`/`.head` on (or "
+    "syntax-highlighted views), so the human gets a styled table and you get a clean, uncorrupted "
+    "frame rather than an unstyled text dump. To list a directory use `view.ls`/`view.tree`, never "
     "`os.walk` or `ls`; to edit, `view.edit(path, old, new)`, never blind. For meaning-based "
-    "recall across a corpus, `import search`. When you genuinely must shell out, `sh` requires a "
-    "`cwd=` (`cwd=\".\"` for here) — pass the directory there, never a `cd X && ...` prefix."
+    "recall across a corpus, `import search`. When you genuinely must shell out, use the async "
+    "`sh` (it runs off the loop and preserves clean color) and pass it a `cwd=` (`cwd=\".\"` for "
+    "here), never a `cd X && ...` prefix."
 )
 
 VERIFY = (


### PR DESCRIPTION
-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `NO_SHELL` guidance to explain why `fff`/`view` are preferred over `rg`
> Rewrites the `NO_SHELL` constant in [guide.py](https://github.com/indexable-inc/index/pull/871/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) to give concrete reasons for avoiding `subprocess.run`: it is synchronous and corrupts piped ANSI-colored output. The updated text explains that `fff`/`view` run off the event loop, reuse a cached index, and return clean Polars frames. Also clarifies that `async sh` with `cwd=` should be used instead of a `cd` prefix, and notes it preserves color.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7684bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->