### PR TITLE
fix(mcp/fff): accept a single file path in find/grep/map

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -663,6 +663,15 @@ let
         assert "path" in _params and "root" not in _params, (_fn.__name__, list(_params))
     assert isinstance(fff.grep("find me on this line", path=root), fff.GrepResult)
 
+    # A single file as `path` is grepped on its own (fff-c cannot content-index a
+    # lone file as a root, so the helpers root at its parent and scope to it).
+    main_rs = os.path.join(root, "src", "main.rs")
+    one = fff.grep("find me on this line", path=main_rs)
+    assert {m.path for m in one.matches} == {"main.rs"}, f"file grep not scoped: {one.matches!r}"
+    assert fff.grep("no such content anywhere", path=main_rs).matches == [], "empty file grep should be empty"
+    assert any(h.path == "main.rs" for h in fff.find("main", path=main_rs).hits), "file find missed it"
+    assert fff.map("find me on this line", path=main_rs).by_file, "file map should group the hit"
+
     print("fff-ok", fff.__version__)
   '';
   fffBundled =

--- a/packages/mcp/src/fff/fff/__init__.py
+++ b/packages/mcp/src/fff/fff/__init__.py
@@ -872,14 +872,74 @@ def _cached(root) -> FileFinder:
         return ff
 
 
+def _split_path(path) -> tuple[str, str | None]:
+    """Resolve a search `path` into an indexable directory root and an optional
+    single-file scope.
+
+    fff-c indexes a directory tree; a lone file as the root scans no content (it
+    reports one file but builds no content index, so every grep returns zero).
+    When `path` is a file, root the index at its parent directory and return the
+    file's name (its path relative to that root), so the caller can scope results
+    to just that file. A directory passes through unscoped.
+    """
+    fspath = os.fspath(path)
+    if os.path.isfile(fspath):
+        absolute = os.path.abspath(fspath)
+        return os.path.dirname(absolute), os.path.basename(absolute)
+    return fspath, None
+
+
+def _grep_one_file(ff: FileFinder, query: str, relpath: str, *, mode: str, limit: int) -> GrepResult:
+    """Grep a single file via a finder rooted at its directory.
+
+    fff returns whole files per page (matches are file-grouped, and `limit` is a
+    soft cap that stops only after a file completes), so the target's matches
+    arrive together in the page whose window reaches it. Page by `file_offset`
+    until that file appears; there is no pre-filter `limit` hole because we never
+    truncate before finding it. Returns empty when the file has no match.
+    """
+    file_offset = 0
+    while True:
+        page = ff.grep(query, mode=mode, limit=limit, file_offset=file_offset, max_matches_per_file=limit)
+        hits = [m for m in page.matches if m.path == relpath][:limit]
+        if hits:
+            return GrepResult(
+                matches=hits,
+                total_matched=len(hits),
+                total_files_searched=1,
+                next_file_offset=0,
+            )
+        if page.next_file_offset in (0, file_offset):
+            return GrepResult(matches=[], total_matched=0, total_files_searched=0, next_file_offset=0)
+        file_offset = page.next_file_offset
+
+
 def find(query: str, path=".", *, limit: int = 100) -> SearchResult:
-    """Fuzzy file search over `path`, reusing a cached watched index."""
-    return _cached(path).search(query, limit=limit)
+    """Fuzzy file search over `path`, reusing a cached watched index.
+
+    `path` may be a directory (searched whole) or a single file (matched on its
+    own, by rooting the index at its parent directory).
+    """
+    root, only = _split_path(path)
+    result = _cached(root).search(query, limit=limit)
+    if only is None:
+        return result
+    hits = [h for h in result.hits if h.path == only][:limit]
+    return SearchResult(hits=hits, total_matched=len(hits), total_files=len(hits))
 
 
 def grep(query: str, path=".", *, mode: str = "plain", limit: int = 50) -> GrepResult:
-    """Content grep over `path`, reusing a cached watched (content-indexed) index."""
-    return _cached(path).grep(query, mode=mode, limit=limit)
+    """Content grep over `path`, reusing a cached watched (content-indexed) index.
+
+    `path` may be a directory (grepped whole) or a single file: a lone file
+    cannot be content-indexed as a root, so it is grepped by rooting the index at
+    its parent directory and scoping the result to that file.
+    """
+    root, only = _split_path(path)
+    ff = _cached(root)
+    if only is None:
+        return ff.grep(query, mode=mode, limit=limit)
+    return _grep_one_file(ff, query, only, mode=mode, limit=limit)
 
 
 async def afind(query: str, path=".", *, limit: int = 100) -> SearchResult:


### PR DESCRIPTION
-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `fff.find`, `fff.grep`, and `fff.map` to accept a single file path
> - Introduces `_split_path` in [__init__.py](https://github.com/indexable-inc/index/pull/872/files#diff-04cf9369e128a37711b583a278d82557a69696b7ad87abacabfd89301ab6403d) to resolve a path into a root directory and optional single-file scope, distinguishing file paths from directory paths.
> - `find()` now filters search hits to only the target file when given a single file path, rather than treating the file path as a root directory.
> - `grep()` now indexes the parent directory and pages through results via a new `_grep_one_file` helper to return matches scoped to the target file only.
> - Tests in [default.nix](https://github.com/indexable-inc/index/pull/872/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) assert correct single-file behavior for all three helpers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68ec1f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->