### PR TITLE
docs(cargo-unit): explain why rustflagsFromCargoConfig parses the config

### DIFF
--- a/lib/rust/build.nix
+++ b/lib/rust/build.nix
@@ -124,12 +124,19 @@ let
 
   # Apply the rustflags a normal `cargo build` reads from `.cargo/config.toml`,
   # which cargoUnit otherwise ignores (it assembles rustc args itself instead of
-  # going through cargo). Returns the rustc args for a target triple following
-  # cargo precedence: `target.<triple>.rustflags` wins outright over
-  # `build.rustflags` (cargo does not merge the two). Flags may be a TOML array
-  # or a single whitespace-separated string. `cfg(...)` target sections and the
-  # `[env]` table are NOT honored. A `configPath` that does not exist yields no
-  # flags, so callers may pass the path unconditionally.
+  # going through cargo). Parsing the config here is the only route: cargo's
+  # `cargo build --unit-graph` does NOT carry rustflags (each unit records only
+  # dependencies/features/mode/pkg_id/platform/profile/target), because cargo
+  # resolves config rustflags at compile time and applies them when it invokes
+  # rustc, which cargoUnit bypasses by invoking rustc per unit from the graph. So
+  # there is nothing in the graph to pick up automatically; we read the config.
+  # Returns the rustc args for a target triple following cargo precedence:
+  # `target.<triple>.rustflags` wins outright over `build.rustflags` (cargo does
+  # not merge the two). Flags may be a TOML array or a single whitespace-
+  # separated string. `cfg(...)` target sections and the `[env]` table are NOT
+  # honored (cargo evaluates those against the full target cfg set, which this
+  # static parse does not reproduce). A `configPath` that does not exist yields
+  # no flags, so callers may pass the path unconditionally.
   rustflagsFromCargoConfig =
     configPath: platform:
     let


### PR DESCRIPTION
## What

Comment-only follow-up to #874: document *why* `rust.rustflagsFromCargoConfig` parses `.cargo/config.toml` itself instead of reading the rustflags off the cargo unit graph.

## Why

A natural question on #874 was "can't cargoUnit just pick the rustflags up from the unit graph?" I tested it: `cargo build --unit-graph` records only

```
dependencies, features, mode, pkg_id, platform, profile, target
```

per unit and **no rustflags at all**. Cargo resolves config rustflags at compile time and applies them when it invokes rustc; it never puts them in the graph. cargoUnit invokes rustc per unit straight from the graph (bypassing cargo's compile step), so there is nothing to pick up automatically: the config must be parsed. The comment now states this, plus the reason `cfg(...)` target sections are intentionally skipped (cargo evaluates those against the full target cfg set, which a static nix parse does not reproduce).

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document why `rustflagsFromCargoConfig` parses `.cargo/config.toml` directly
> Expands the comment block above `rustflagsFromCargoConfig` in [build.nix](https://github.com/indexable-inc/index/pull/876/files#diff-8ab3484d4c25eaf4ab0beac36848ba87229282d10d3524b969f90a880b330dab) to explain the design rationale: `cargo --unit-graph` omits rustflags, and `cargoUnit` bypasses the normal rustc invocation where cargo would apply them, so the config must be parsed directly. The comment also documents precedence rules, accepted flag formats, unhandled cases (`cfg(...)` target sections and `[env]` table), and that a nonexistent `configPath` safely yields no flags. No executable code was changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c5299b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->