### PR TITLE
fix(mcp): bound python_exec budget and keep the shell channel clean on cancel

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1079,7 +1079,7 @@ let
     # Result, jobs, the SIGUSR1/SIGUSR2 handlers) loads in the booted kernel,
     # exactly as the CLI wires it.
     os.environ["IPYTHONDIR"] = str(cli._prepare_ipython_startup(0))
-    config = Config(workdir=Path(tempfile.mkdtemp()), wedge_grace=1.0)
+    config = Config(workdir=Path(tempfile.mkdtemp()), wedge_grace=1.0, max_budget=2.0)
 
 
     async def main():
@@ -1114,6 +1114,41 @@ let
             _, after = await kernel.python_exec("Result.text('alive')", budget=10.0, name="after")
             assert after is not None and after["status"] == "done", after
             assert after["result"] is not None, after
+
+            # (3) Cancelling an in-flight python_exec (the client cancels the call)
+            # must not desync the shared shell channel. Start a cell that
+            # backgrounds at its small budget, cancel the foreground wait while the
+            # reply is in flight, then prove a later call still runs.
+            inflight = asyncio.ensure_future(
+                kernel.python_exec("await asyncio.sleep(5)\nResult.ok('slept')", budget=0.4, name="cancelme")
+            )
+            await asyncio.sleep(0.1)
+            inflight.cancel()
+            try:
+                await inflight
+            except asyncio.CancelledError:
+                pass
+            _, revived = await kernel.python_exec("Result.text('post-cancel')", budget=10.0, name="post-cancel")
+            assert revived is not None and revived["status"] == "done", revived
+            assert revived["result"] is not None, revived
+
+            # (4) The python_exec TOOL clamps an oversized budget to max_budget so a
+            # giant foreground wait cannot sit on the one shell channel: the call
+            # returns within the cap (not the requested 600s) and says it clamped.
+            from ix_notebook_mcp import tools
+            from ix_notebook_mcp.config import set_config
+            from ix_notebook_mcp.kernel import set_kernel
+
+            set_config(config)
+            set_kernel(kernel)
+            started = loop.time()
+            clamped = await tools.python_exec(
+                "await asyncio.sleep(30)\nResult.ok('done')", budget=600.0, name="bigbudget"
+            )
+            elapsed = loop.time() - started
+            assert elapsed < 10, ("budget was not clamped", elapsed)
+            note = " ".join(getattr(c, "text", "") or "" for c in clamped)
+            assert "clamped" in note, note
         finally:
             await kernel.shutdown()
 

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -48,6 +48,14 @@ class Config:
     # the kernel, and returning an actionable summary. See ``kernel.python_exec``.
     wedge_grace: float = 15.0
 
+    # Hard ceiling on a single ``python_exec`` foreground ``budget``. The budget is
+    # how long the ONE shared shell channel is held before the run backgrounds, so
+    # an oversized budget (a 15-minute ``await jobs['x']``) wedges every other call
+    # behind it for that whole time. Clamp it: a longer wait backgrounds and is
+    # resumed by polling ``jobs['x']`` in a later cell. Raise it with a reason if a
+    # workload genuinely needs a longer foreground hold.
+    max_budget: float = 120.0
+
     def dashboard_url(self) -> str:
         return f"http://{self.advertised_host}:{self.dashboard_port}/"
 

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -49,7 +49,11 @@ JOBS = (
     "in the `jobs` dict, so manage them with more python_exec: `jobs['ab12']` to inspect, `await "
     "jobs['ab12']` to wait (it yields the run's value), `jobs['ab12'].cancel()` to stop, "
     "`jobs['ab12'].done()` to test if it has finished, `[j for j in jobs.values() if "
-    "j.running()]` to list."
+    "j.running()]` to list. `budget` is how long the run holds the one shared shell channel "
+    "before it backgrounds, so keep it small and poll: do NOT pass a huge budget to sit on a "
+    "long `await jobs['ab12']` in the foreground — it blocks every other call for that whole "
+    "time and is capped server-side anyway. Let the work background, then re-await or poll "
+    "`.done()` in a later cell."
 )
 
 PAGING = (

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -162,9 +162,16 @@ class Kernel:
             except asyncio.CancelledError:
                 try:
                     await task
+                except TimeoutError:
+                    # The cell is synchronously wedging the loop, so the reply
+                    # never arrives within the deadline. The drain alone would
+                    # leave the kernel stuck behind the cancelled-but-still-running
+                    # cell, so fire the same SIGUSR2 watchdog the outer timeout
+                    # path uses to break the blocked frame and free the channel.
+                    await self._interrupt()
                 except BaseException:
-                    # The drained request may itself time out or error; we only
-                    # need the socket read to finish before releasing the lock.
+                    # Any other drain error: we only need the socket read to
+                    # finish before releasing the lock.
                     pass
                 raise
             return outputs, summary

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -144,9 +144,29 @@ class Kernel:
                     summary = found
                 outputs.append(output)
 
-            await self._kc.execute_interactive(
-                code, timeout=timeout, allow_stdin=False, output_hook=on_iopub, store_history=True
+            # Run the request as a task and shield it from client-side
+            # cancellation. A CancelledError thrown straight into
+            # execute_interactive (the client cancels the python_exec call)
+            # abandons a half-read multipart reply on the shared shell socket,
+            # desyncing it so EVERY later python_exec hangs -- the "I cancelled and
+            # now nothing runs" wedge. The cell self-backgrounds at its budget, so
+            # the reply always arrives within ``timeout``; on cancel we still drain
+            # it (lock held) before re-raising, leaving the channel clean.
+            task = asyncio.ensure_future(
+                self._kc.execute_interactive(
+                    code, timeout=timeout, allow_stdin=False, output_hook=on_iopub, store_history=True
+                )
             )
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                try:
+                    await task
+                except BaseException:
+                    # The drained request may itself time out or error; we only
+                    # need the socket read to finish before releasing the lock.
+                    pass
+                raise
             return outputs, summary
 
     async def python_exec(self, code: str, budget: float, name: str | None = None) -> tuple[list[dict], dict | None]:

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -37,6 +37,7 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
 from . import guide, outputs
+from .config import config
 from .kernel import current_kernel
 
 _KERNEL_GUIDE = guide.compose(
@@ -126,7 +127,13 @@ async def python_exec(
     budget: Annotated[float, Field(description="Seconds to wait before backgrounding the run")] = 15.0,
     name: Annotated[str | None, Field(description="Optional label for the job in the dashboard")] = None,
 ) -> Content:
-    cell_outputs, summary = await current_kernel().python_exec(code, budget, name)
+    # A foreground budget is how long the run holds the one shared shell channel
+    # before it backgrounds, so cap it: a giant budget (a 15-minute `await
+    # jobs[...]`) would block every other call behind it. The clamp is surfaced
+    # below so the caller knows to poll the job rather than silently lose the wait.
+    cap = config().max_budget
+    effective_budget = min(budget, cap)
+    cell_outputs, summary = await current_kernel().python_exec(code, effective_budget, name)
     rendered = outputs.to_mcp(cell_outputs)
     if summary is None:
         return rendered
@@ -149,6 +156,19 @@ async def python_exec(
     # result is recoverable without re-running the work \u2014 the failure mode this
     # whole jobs registry exists to avoid.
     job_id = summary.get("id")
+    # The requested budget exceeded the cap, so the run was given the smaller
+    # foreground window and (if it outlived it) backgrounded. Tell the caller so a
+    # long wait is resumed by polling the job, not mistaken for a finished run.
+    if budget > cap and job_id:
+        parts.append(
+            outputs.text(
+                f"[budget {budget:g}s exceeds the {cap:g}s cap and was clamped to "
+                f"{cap:g}s: a foreground call holds the kernel's one shell channel, so "
+                f"a longer wait backgrounds instead of blocking every other call. If "
+                f"jobs['{job_id}'] is still running, resume it with await jobs['{job_id}'] "
+                f"(or poll jobs['{job_id}'].done()) in a later cell.]"
+            )
+        )
     output_chars = summary.get("output_chars") or 0
     result_chars = summary.get("result_chars") or 0
     clipped = result_chars > outputs.MAX_TEXT_CHARS


### PR DESCRIPTION
## What
A `python_exec` budget is how long a run holds the kernel's one shared shell channel before it backgrounds, but nothing bounded it, and a client cancel could desync that channel. Two failure modes, one root area:

1. **Oversized budget blocks everything.** `await jobs['x']` with `budget=900` held the channel for 15 minutes, so every other `python_exec` (including status checks) blocked behind it.
2. **Cancel wedges the kernel.** Cancelling an in-flight `python_exec` threw `CancelledError` straight into `execute_interactive`, abandoning a half-read multipart reply on the shell socket. The socket desynced and every later call hung. This is the "I did mcp cancel and now nothing runs" wedge.

## Changes
- `Config.max_budget` (default 120s) caps the foreground hold. The `python_exec` tool clamps to it and surfaces a note so a clamped long wait is resumed by polling `jobs['x']`, not silently lost.
- `Kernel._execute` runs the request as a shielded task and, on cancel, drains the reply with the lock held before re-raising, so the shared channel is never left mid-message.
- Guide: keep `budget` small and poll, rather than sitting on a huge foreground wait.

## Test
Extends the wedge smoke (`packages/mcp/default.nix`):
- cancelling an in-flight `python_exec` leaves the channel usable for the next call;
- the tool clamps a 600s budget to the 2s cap (returns within the cap, says it clamped).

Verified green by running the wedge test against this branch.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `python_exec` shell channel desync on cancel and clamp foreground budget to `max_budget`
> - Wraps the `execute_interactive` call in an `asyncio` task and shields it from client cancellation in [`kernel.py`](https://github.com/indexable-inc/index/pull/878/files#diff-ced4fbbdf05b4f126e987804d73fdc2d811511b346e4985a9996ae7903683d1c); on cancel, the reply is drained under lock and `_interrupt()` is called if the drain times out before re-raising.
> - Adds `max_budget: float = 120.0` to [`Config`](https://github.com/indexable-inc/index/pull/878/files#diff-33f6f17aed79724ba72211bc8bf9dc1da1bbdb38de56be7ace76cc09837929ca) as a hard ceiling on a single `python_exec` foreground budget.
> - Clamps the requested budget to `Config.max_budget` in the [`python_exec` MCP tool](https://github.com/indexable-inc/index/pull/878/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) and appends a note to the response when clamping occurs.
> - Extends JOBS guidance in [`guide.py`](https://github.com/indexable-inc/index/pull/878/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) to advise keeping budgets small and polling for long-running jobs.
> - Behavioral Change: cancelling an in-flight `python_exec` no longer desync the shared shell channel; budgets above `max_budget` are silently clamped server-side.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 687d4e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->