### PR TITLE
fix(mcp): stack a tuple/list of rich values instead of rasterizing it

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1177,6 +1177,16 @@ let
     runtime.install(ns)
     run = ns["__ix_run"]
 
+    # A tuple/list carrying a rich value (a DataFrame) renders each element with
+    # its own view, stacked, instead of stringifying the frame into a one-column
+    # table -- Result((repr_text, df)) shows the text AND the real table.
+    stacked = runtime.Result.of(("GrepResult: 0 matches", pl.DataFrame({"a": [1, 2]})))
+    assert stacked.user_html.count("<table") == 1, stacked.user_html[:200]
+    assert "GrepResult: 0 matches" in stacked.llm_result and "shape:" in stacked.llm_result, stacked.llm_result
+    # A plain list of scalars is still ONE table (not stacked), unchanged.
+    scalars = runtime.Result.of([1, 2, 3])
+    assert scalars.user_html.count("<table") == 1, scalars.user_html[:200]
+
 
     async def main():
         # A DataFrame result is stored with its text/html bundle.
@@ -1249,7 +1259,9 @@ let
         ).fetchone()
         assert multi_row["status"] == "done", multi_row["status"]
         multi_text = [out["data"].get("text/plain", "") for out in json.loads(multi_row["outputs"])][-1]
-        assert "True" in multi_text and "[1, 2, 3]" in multi_text, ("multi-value dropped a value", multi_text)
+        # Both values are shown: the bool by its repr, the list as its one-column
+        # frame (CSV rows 1/2/3), not collapsed to just the first value.
+        assert "True" in multi_text and "1\n2\n3" in multi_text, ("multi-value dropped a value", multi_text)
 
 
     asyncio.run(main())

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1221,6 +1221,11 @@ let
     # A plain list of scalars is still ONE table (not stacked), unchanged.
     scalars = runtime.Result.of([1, 2, 3])
     assert scalars.user_html.count("<table") == 1, scalars.user_html[:200]
+    # Stacking preserves a nested Result's model images (Result.of copies a
+    # Result faithfully instead of rebuilding it from its display bundle).
+    inner = runtime.Result(user_html="<b>x</b>", llm_result="x", llm_images=[b"\x89PNG\r\n"])
+    nested = runtime.Result.of([inner, pl.DataFrame({"a": [1]})])
+    assert len(nested.llm_images) == 1, ("nested Result dropped its images", nested.llm_images)
 
 
     async def main():

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -157,7 +157,10 @@ RESULT_VARIANTS = (
     "Use the shortcuts: `Result.text('done')` (same text to both), `Result.ok('what happened')` "
     "(a quiet confirmation for a side-effecting cell), `Result.of(df)` (render any value richly "
     "for the human, its repr to you), or `Result(user_html=..., llm_result=..., llm_images=[fig, "
-    "png_bytes])`."
+    "png_bytes])`. To show several values at once, pass them as separate args "
+    "(`Result(repr(hits), hits.df)`) or in one list/tuple: each renders with its "
+    "OWN view, stacked, so a DataFrame stays a real table and is never flattened "
+    "into a cell of some outer frame."
 )
 
 READABLE = (

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -398,6 +398,13 @@ class Result:
         the frame as compact, untruncated CSV (the human still gets the styled
         HTML table), so a wide or long-stringed frame is never clipped to the
         agent the way the boxed text repr clips it. Override with ``llm_result``."""
+        if _is_multi_rich(value):
+            # A tuple/list that carries a rich element (a DataFrame, a figure, a
+            # nested Result) is several things to SHOW, not one table: render each
+            # element with its own view, stacked, rather than stringifying the rich
+            # one into a `value` cell. `Result((repr_text, df))` thus shows the text
+            # and the real table, not a 2-row frame of two reprs.
+            return _result_from_values(list(value), llm_result=llm_result)
         value = _as_frame_if_tabular(value)
         if llm_result is not None:
             text_view = llm_result
@@ -486,6 +493,22 @@ def _as_frame_if_tabular(value):
             except Exception:
                 return value
     return value
+
+
+def _is_rich_element(value) -> bool:
+    """True if ``value`` carries its own rich view (a DataFrame, a figure/image,
+    an htpy element, or a Result), so flattening it into a one-column frame would
+    throw that view away. Plain scalars and containers are not rich."""
+    return isinstance(value, Result) or _is_polars_df(value) or _is_displayable(value)
+
+
+def _is_multi_rich(value) -> bool:
+    """True for a non-empty list/tuple that carries at least one rich element, so
+    ``Result.of`` should stack each element's view instead of coercing the whole
+    sequence to a single table. A list/tuple of plain scalars (or of mappings)
+    stays tabular -- only a sequence mixing in a DataFrame/figure/Result needs the
+    stacked treatment."""
+    return isinstance(value, (list, tuple)) and bool(value) and any(_is_rich_element(v) for v in value)
 
 
 def _result_from_values(values, *, llm_result=None):

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -398,6 +398,16 @@ class Result:
         the frame as compact, untruncated CSV (the human still gets the styled
         HTML table), so a wide or long-stringed frame is never clipped to the
         agent the way the boxed text repr clips it. Override with ``llm_result``."""
+        if isinstance(value, Result):
+            # An existing Result is already split into its two views: copy it
+            # faithfully (keeping llm_images) instead of rebuilding it from its
+            # display bundle, which would drop the model image blocks. This also
+            # preserves images when a nested Result is stacked below.
+            return cls(
+                user_html=value.user_html,
+                llm_result=value.llm_result if llm_result is None else llm_result,
+                llm_images=value.llm_images,
+            )
         if _is_multi_rich(value):
             # A tuple/list that carries a rich element (a DataFrame, a figure, a
             # nested Result) is several things to SHOW, not one table: render each


### PR DESCRIPTION
## What
`Result.of((repr_text, df))` coerced the whole tuple through `_as_frame_if_tabular`, which built a one-column frame and stringified the inner DataFrame into a cell. The human saw a 2-row frame of two reprs ("a text dataframe inside a dataframe") instead of the text plus the real table. Reported from:

```python
hits = fff.grep(...)
Result((repr(hits), hits.df))   # -> rasterized the inner df
```

## Change
A list/tuple that carries a rich element (a DataFrame, a figure, a nested `Result`) now routes to `_result_from_values`, so each element renders with its **own** view, stacked. A list/tuple of plain scalars (or of mappings) stays tabular, unchanged. `Result(repr(hits), hits.df)` (separate args) already worked; this makes the single-tuple form work too.

Also fixes a `richSmoke` assertion that is **already failing on `main`** (`nix build .#mcp.tests.richSmoke`): a list value renders as its one-column frame now, so the test asserts both values are present rather than the list's old `[1, 2, 3]` repr.

## Test
`packages/mcp/default.nix` rich smoke: a `(text, df)` tuple renders one real table plus the text (not a stringified frame); a plain scalar list stays one table.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Result.of` to stack list/tuple of rich values instead of rasterizing to a table
> - `Result.of` in [runtime.py](https://github.com/indexable-inc/index/pull/879/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) now detects when the input is a list/tuple containing at least one rich element (Result, DataFrame, or displayable/figure) and stacks each element's own view via `_result_from_values` instead of coercing the whole sequence into a single table.
> - `Result.of` also gains an early-return path for an existing `Result` input that preserves `llm_images` and `user_html`, fixing a prior regression where those fields were lost.
> - Two new helpers, `_is_rich_element` and `_is_multi_rich`, encapsulate the detection logic.
> - Guide text in [guide.py](https://github.com/indexable-inc/index/pull/879/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) is updated to document that multiple values can be passed as a list/tuple to stack views, and that DataFrames remain real tables rather than cells in an outer frame.
> - Behavioral Change: sequences with at least one rich element now render as stacked views; previously they were flattened into a single table.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b2cdd8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->