### PR TITLE
fix: repair the three red flake-check tests on main

### DIFF
--- a/lib/rust/build.nix
+++ b/lib/rust/build.nix
@@ -141,7 +141,7 @@ let
       buildFlags = config.build.rustflags or null;
       chosen = if targetFlags != null then targetFlags else buildFlags;
     in
-    if chosen == null then [ ] else normalize chosen;
+    lib.optionals (chosen != null) (normalize chosen);
 
   nativeBuildInputsForPolicy = policy: lib.optional policy.linker.useMold pkgs.mold;
 

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1249,7 +1249,7 @@ let
         ).fetchone()
         assert multi_row["status"] == "done", multi_row["status"]
         multi_text = [out["data"].get("text/plain", "") for out in json.loads(multi_row["outputs"])][-1]
-        assert "True" in multi_text and "[1, 2, 3]" in multi_text, ("multi-value dropped a value", multi_text)
+        assert "True" in multi_text and "1\n2\n3" in multi_text, ("multi-value dropped a value", multi_text)
 
 
     asyncio.run(main())
@@ -1745,7 +1745,7 @@ let
 
     async def main():
         # A command that emits an SGR color escape around its output.
-        colored = await sh.sh(r"printf '\033[31mred\033[0m\n'")
+        colored = await sh.sh(r"printf '\033[31mred\033[0m\n'", cwd=".")
         assert colored.ok and colored.code == 0, colored.code
         # Model view: no escape bytes, the word survives.
         assert "\x1b" not in colored.text and "red" in colored.text, repr(colored.text)
@@ -1758,13 +1758,13 @@ let
         assert isinstance(colored, Result), type(colored)
 
         # argv form, and a non-zero exit is surfaced (not swallowed).
-        failed = await sh.sh(["false"])
+        failed = await sh.sh(["false"], cwd=".")
         assert not failed.ok and failed.code == 1, failed.code
         assert "[exit 1]" in failed.llm_result, failed.llm_result
 
         # check=True turns a non-zero exit into a typed error carrying the output.
         try:
-            await sh.sh("exit 3", check=True)
+            await sh.sh("exit 3", check=True, cwd=".")
         except sh.ShellError as exc:
             assert exc.output.code == 3, exc.output.code
         else:
@@ -1772,7 +1772,7 @@ let
 
         # An OSC-8 hyperlink (what gh/eza emit under FORCE_COLOR) is a non-CSI
         # escape: the stripper must remove its \x1b bytes too, not just SGR color.
-        osc = await sh.sh(r"printf '\033]8;;https://x\033\\link\033]8;;\033\\\n'")
+        osc = await sh.sh(r"printf '\033]8;;https://x\033\\link\033]8;;\033\\\n'", cwd=".")
         assert "\x1b" not in osc.text and "link" in osc.text, repr(osc.text)
         assert "\x1b" not in osc.llm_result, repr(osc.llm_result)
 
@@ -1782,7 +1782,7 @@ let
         loop = asyncio.get_running_loop()
         start = loop.time()
         try:
-            await sh.sh("sleep 30 & echo started; wait", timeout=0.5)
+            await sh.sh("sleep 30 & echo started; wait", timeout=0.5, cwd=".")
         except TimeoutError:
             pass
         else:
@@ -1793,7 +1793,7 @@ let
         # The module object itself is callable: the documented
         # `import sh; await sh(cmd)` works without reaching for `sh.sh`.
         assert callable(sh), "sh module is not callable"
-        direct = await sh("printf hi")
+        direct = await sh("printf hi", cwd=".")
         assert direct.ok and direct.text == "hi", repr(direct.text)
 
         print("sh-ok", sh.__version__)


### PR DESCRIPTION
## What
`main`'s `flake-check` is currently red on three stale checks, each independent and predating this PR (confirmed by building each from `origin/main`):

1. **lint** (`no-deprecated-iflist-empty`): `lib/rust/build.nix:144` used `if chosen == null then [ ] else normalize chosen`. Switched to `lib.optionals (chosen != null) (normalize chosen)`.
2. **mcp `shSmoke`**: `sh()` now requires `cwd=`, but the smoke still called `sh.sh(...)` without it and raised `TypeError: sh() missing 1 required keyword-only argument: 'cwd'`. Pass `cwd="."` at every call site.
3. **mcp `richSmoke`**: the multi-value assertion expected the old list repr `[1, 2, 3]`, but a list now renders as its one-column frame, so the run failed. Assert both values are present (the bool and the frame's rows) instead.

## Test
Built green locally from this branch: `.#lint`, `.#mcp.tests.shSmoke`, `.#mcp.tests.richSmoke`.

Unblocks the merge queue for follow-up mcp PRs.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix three failing flake-check tests in MCP package and Rust build
> - Adds `cwd="."` to multiple `sh.sh` invocations in [packages/mcp/default.nix](https://github.com/indexable-inc/index/pull/880/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) test snippets so commands run with a consistent working directory.
> - Updates the `multi_text` assertion to expect one-per-line output (`1\n2\n3`) instead of a JSON-like `[1, 2, 3]` string.
> - Replaces an explicit `if/else` in [lib/rust/build.nix](https://github.com/indexable-inc/index/pull/880/files#diff-8ab3484d4c25eaf4ab0beac36848ba87229282d10d3524b969f90a880b330dab) with `lib.optionals` for selecting Rust build flags, preserving existing behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cfcb3d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->