### PR TITLE
docs(mcp): always surface the dashboard URL in the first reply

### DIFF
--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -226,8 +226,9 @@ TRACE = (
 
 _DASHBOARD_URL_NOTE = (
     "This session's live dashboard (every running job, its output, and your curated cells) is at "
-    "{url} -- share it with the human now. It is also the `DASHBOARD_URL` variable in the kernel "
-    "namespace."
+    "{url} -- ALWAYS give the human this link in your very first reply of the session, before or "
+    "alongside your first answer, so they can watch the work unfold live; never make them ask for "
+    "it. It is also the `DASHBOARD_URL` variable in the kernel namespace."
 )
 
 


### PR DESCRIPTION
## What

The dashboard-URL note baked into the MCP server instructions (`guide._DASHBOARD_URL_NOTE`, folded in by `set_dashboard_url`) said only **"share it with the human now"** — soft enough to defer or skip entirely.

This makes the expectation unmistakable: **ALWAYS give the human the live dashboard link in the very first reply of the session**, before or alongside the first answer, and never make them ask for it.

## Why

The dashboard is where the human watches jobs, output, and curated cells unfold live. If the agent doesn't surface the URL up front, the human has no idea it exists. A single instruction sentence is the cheapest place to fix this.

## Change

`packages/mcp/ix_notebook_mcp/guide.py` — one note string, authored once and reused wherever the dashboard URL is mentioned:

```
... is at {url} -- ALWAYS give the human this link in your very first reply of
the session, before or alongside your first answer, so they can watch the work
unfold live; never make them ask for it. It is also the `DASHBOARD_URL` variable
in the kernel namespace.
```


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Always surface the dashboard URL in the first MCP reply
> Updates the `_DASHBOARD_URL_NOTE` constant in [guide.py](https://github.com/indexable-inc/index/pull/881/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) to require that the dashboard link be given in the first reply, before or alongside the first answer, without waiting for the user to ask.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6063cbc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->