### PR TITLE
feat(git-log-pretty): gray out and strike through deleted files

### DIFF
--- a/packages/git-log-pretty/src/git.rs
+++ b/packages/git-log-pretty/src/git.rs
@@ -6,11 +6,44 @@ use std::collections::HashSet;
 use color_eyre::eyre::{Result, WrapErr, eyre};
 use git2::{Commit, DiffOptions, Oid, Repository};
 
-/// A commit selected for display, paired with the paths it changed. The ahead
+/// How a file changed in a commit, distilled from git's per-delta status. The
+/// display layer struck-through and dims deletions so a removed file reads at a
+/// glance; the other kinds render normally today but are kept distinct so
+/// additions and renames can grow their own styling without another migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChangeKind {
+    Added,
+    Modified,
+    Deleted,
+    Renamed,
+}
+
+impl ChangeKind {
+    /// Map git's per-delta [`git2::Delta`] onto the coarser set the display
+    /// cares about. Unmodified and unreadable deltas never reach us (a diff only
+    /// yields touched files), so they collapse into `Modified`.
+    fn from_delta(status: git2::Delta) -> Self {
+        match status {
+            git2::Delta::Added | git2::Delta::Copied | git2::Delta::Untracked => Self::Added,
+            git2::Delta::Deleted => Self::Deleted,
+            git2::Delta::Renamed => Self::Renamed,
+            _ => Self::Modified,
+        }
+    }
+}
+
+/// A file a commit (or diff) touched, paired with how it changed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangedFile {
+    pub path: String,
+    pub kind: ChangeKind,
+}
+
+/// A commit selected for display, paired with the files it changed. The ahead
 /// list is sorted newest-first by commit time.
 pub struct AheadCommit<'repo> {
     pub commit: Commit<'repo>,
-    pub changed_files: Vec<String>,
+    pub changed_files: Vec<ChangedFile>,
 }
 
 /// Open the repository containing the current directory.
@@ -99,7 +132,7 @@ fn reachable(repo: &Repository, start: Oid) -> Result<HashSet<Oid>> {
 
 /// Paths touched by `commit` relative to its first parent. A root commit (no
 /// parent) reports every file in its tree.
-pub fn changed_files(repo: &Repository, commit: &Commit) -> Result<Vec<String>> {
+pub fn changed_files(repo: &Repository, commit: &Commit) -> Result<Vec<ChangedFile>> {
     let new_tree = commit.tree().wrap_err("failed to read commit tree")?;
 
     let old_tree = match commit.parent(0) {
@@ -112,7 +145,7 @@ pub fn changed_files(repo: &Repository, commit: &Commit) -> Result<Vec<String>> 
         .diff_tree_to_tree(old_tree.as_ref(), Some(&new_tree), Some(&mut options))
         .wrap_err("failed to diff commit against its parent")?;
 
-    Ok(collect_diff_paths(&diff))
+    Ok(collect_diff_changes(&diff))
 }
 
 /// Commits reachable from HEAD but not from `base`, newest-first, each paired
@@ -143,7 +176,7 @@ pub fn commits_ahead<'repo>(repo: &'repo Repository, base: &str) -> Result<Vec<A
 /// advertises with the triple dot: diffing the merge base against `head` so
 /// commits that landed on `base` after the fork point do not pollute the tree.
 /// `head` accepts `"HEAD"` for the current head.
-pub fn diff_stat_files(repo: &Repository, base: &str, head: &str) -> Result<Vec<String>> {
+pub fn diff_stat_files(repo: &Repository, base: &str, head: &str) -> Result<Vec<ChangedFile>> {
     let base_oid = target_oid(&resolve_ref(repo, base)?, base)?;
     let head_oid = target_oid(&resolve_ref(repo, head)?, head)?;
 
@@ -165,16 +198,20 @@ pub fn diff_stat_files(repo: &Repository, base: &str, head: &str) -> Result<Vec<
         .diff_tree_to_tree(Some(&base_tree), Some(&head_tree), Some(&mut options))
         .wrap_err("failed to diff merge base against head")?;
 
-    Ok(collect_diff_paths(&diff))
+    Ok(collect_diff_changes(&diff))
 }
 
-/// Pull one display path per delta, preferring the new path and falling back to
-/// the old one for deletions.
-fn collect_diff_paths(diff: &git2::Diff) -> Vec<String> {
+/// Pull one [`ChangedFile`] per delta, preferring the new path and falling back
+/// to the old one for deletions, and tagging each with how it changed.
+fn collect_diff_changes(diff: &git2::Diff) -> Vec<ChangedFile> {
     diff.deltas()
         .filter_map(|delta| {
             let path = delta.new_file().path().or_else(|| delta.old_file().path());
-            path.and_then(|p| p.to_str()).map(str::to_string)
+            let path = path.and_then(|p| p.to_str())?.to_string();
+            Some(ChangedFile {
+                path,
+                kind: ChangeKind::from_delta(delta.status()),
+            })
         })
         .collect()
 }

--- a/packages/git-log-pretty/src/tree.rs
+++ b/packages/git-log-pretty/src/tree.rs
@@ -10,28 +10,31 @@ use std::collections::BTreeMap;
 use anstyle::Color;
 use devicons::icon_for_file;
 
+use crate::git::{ChangeKind, ChangedFile};
 use crate::palette::{self, GRAY, Theme};
 
 /// Closed-folder glyph (Nerd Font `nf-md-folder`), shown for directory nodes.
 const FOLDER_GLYPH: &str = "\u{e5ff}";
 
-/// A node in the path trie. Leaves are files; interior nodes are directories.
+/// A node in the path trie. Leaves are files (`change` carries how the file was
+/// touched); interior nodes are directories.
 #[derive(Default)]
 struct Node {
     is_file: bool,
+    change: Option<ChangeKind>,
     children: BTreeMap<String, Self>,
 }
 
 /// Render `files` as a tree, one line per node, joined by newlines. Returns an
 /// empty string when there are no files so callers can skip printing.
-pub fn render(files: &[String], theme: Theme) -> String {
+pub fn render(files: &[ChangedFile], theme: Theme) -> String {
     if files.is_empty() {
         return String::new();
     }
 
     let mut root = Node::default();
-    for path in files {
-        insert(&mut root, path);
+    for file in files {
+        insert(&mut root, file);
     }
     collapse(&mut root);
 
@@ -40,16 +43,19 @@ pub fn render(files: &[String], theme: Theme) -> String {
     lines.join("\n")
 }
 
-/// Insert one slash-separated path into the trie, marking the final segment as a
-/// file.
-fn insert(root: &mut Node, path: &str) {
-    let parts: Vec<&str> = path.split('/').collect();
+/// Insert one changed file into the trie, marking the final path segment as a
+/// file and recording how it changed so the leaf can be styled.
+fn insert(root: &mut Node, file: &ChangedFile) {
+    let parts: Vec<&str> = file.path.split('/').collect();
     let mut node = root;
 
     for (index, part) in parts.iter().enumerate() {
         let is_last = index == parts.len() - 1;
         node = node.children.entry((*part).to_string()).or_default();
-        node.is_file = node.is_file || is_last;
+        if is_last {
+            node.is_file = true;
+            node.change = Some(file.kind);
+        }
     }
 }
 
@@ -111,8 +117,11 @@ fn render_children(node: &Node, theme: Theme, prefix: &str, lines: &mut Vec<Stri
 /// (gray directory segments, high-contrast basename) followed by its colored
 /// icon. The basename follows the detected theme so it stays readable on light
 /// terminals (black) as well as dark ones (white).
+///
+/// A deleted file is grayed out and struck through end to end — directory
+/// segments, basename, and icon alike — so a removal reads at a glance and never
+/// competes for attention with the files that still exist.
 fn node_label(name: &str, child: &Node, theme: Theme) -> String {
-    let basename_fg = Color::Rgb(palette::chip_foreground(theme));
     let gray = palette::fg(Color::Rgb(GRAY));
 
     if !child.is_file {
@@ -123,16 +132,28 @@ fn node_label(name: &str, child: &Node, theme: Theme) -> String {
         );
     }
 
+    let deleted = child.change == Some(ChangeKind::Deleted);
+    let dir_style = if deleted { gray.strikethrough() } else { gray };
+    let basename_style = if deleted {
+        gray.strikethrough()
+    } else {
+        palette::fg(Color::Rgb(palette::chip_foreground(theme)))
+    };
+
     let icon = icon_for_file(name, &Some(palette::devicons(theme)));
-    let icon_style = palette::fg(Color::Rgb(palette::parse_hex(icon.color)));
+    let icon_style = if deleted {
+        gray.strikethrough()
+    } else {
+        palette::fg(Color::Rgb(palette::parse_hex(icon.color)))
+    };
 
     let name_part = name.rfind('/').map_or_else(
-        || palette::paint(palette::fg(basename_fg), name),
+        || palette::paint(basename_style, name),
         |slash| {
             format!(
                 "{}{}",
-                palette::paint(gray, &name[..=slash]),
-                palette::paint(palette::fg(basename_fg), &name[slash + 1..]),
+                palette::paint(dir_style, &name[..=slash]),
+                palette::paint(basename_style, &name[slash + 1..]),
             )
         },
     );
@@ -153,6 +174,22 @@ mod tests {
         String::from_utf8(bytes).unwrap()
     }
 
+    /// A file touched without being removed, the common case.
+    fn modified(path: &str) -> ChangedFile {
+        ChangedFile {
+            path: path.to_string(),
+            kind: ChangeKind::Modified,
+        }
+    }
+
+    /// A removed file, which the renderer grays out and strikes through.
+    fn deleted(path: &str) -> ChangedFile {
+        ChangedFile {
+            path: path.to_string(),
+            kind: ChangeKind::Deleted,
+        }
+    }
+
     #[test]
     fn empty_input_renders_nothing() {
         assert_eq!(render(&[], Theme::Dark), "");
@@ -160,7 +197,7 @@ mod tests {
 
     #[test]
     fn single_chain_collapses_into_one_node() {
-        let rendered = plain(&render(&["a/b/c.rs".to_string()], Theme::Dark));
+        let rendered = plain(&render(&[modified("a/b/c.rs")], Theme::Dark));
         assert!(rendered.contains("a/b/c.rs"), "got: {rendered}");
         assert_eq!(rendered.lines().count(), 1, "got: {rendered}");
     }
@@ -168,10 +205,31 @@ mod tests {
     #[test]
     fn siblings_use_branch_and_last_connectors() {
         let rendered = plain(&render(
-            &["src/a.rs".to_string(), "src/b.rs".to_string()],
+            &[modified("src/a.rs"), modified("src/b.rs")],
             Theme::Dark,
         ));
         assert!(rendered.contains("├ "), "got: {rendered}");
         assert!(rendered.contains("└ "), "got: {rendered}");
+    }
+
+    /// The strikethrough SGR prefix (`\x1b[9m`) the deleted style emits, used to
+    /// assert styling without depending on the surrounding color parameters.
+    fn strike_prefix() -> String {
+        palette::fg(Color::Rgb(GRAY)).strikethrough().render().to_string()
+    }
+
+    #[test]
+    fn deleted_file_is_struck_through_but_keeps_its_name() {
+        let styled = render(&[deleted("src/gone.rs")], Theme::Dark);
+        // The path still reads plainly once SGR is stripped...
+        assert!(plain(&styled).contains("gone.rs"), "got: {}", plain(&styled));
+        // ...but the styled output carries the strikethrough effect.
+        assert!(styled.contains(&strike_prefix()), "deleted file not struck through");
+    }
+
+    #[test]
+    fn surviving_file_is_not_struck_through() {
+        let styled = render(&[modified("src/stays.rs")], Theme::Dark);
+        assert!(!styled.contains(&strike_prefix()), "modified file should not be struck through");
     }
 }

--- a/packages/git-log-pretty/tests/integration.rs
+++ b/packages/git-log-pretty/tests/integration.rs
@@ -96,6 +96,14 @@ fn plain(bytes: &[u8]) -> String {
     String::from_utf8(strip_ansi_escapes::strip(bytes)).unwrap()
 }
 
+/// Whether `bytes` carry the strikethrough SGR effect (parameter `9`), regardless
+/// of the color parameters folded into the same escape. Used to assert deleted
+/// files are struck through without depending on the exact byte layout.
+fn has_strikethrough(bytes: &[u8]) -> bool {
+    let text = String::from_utf8_lossy(bytes);
+    ["[9m", "[9;", ";9m", ";9;"].iter().any(|needle| text.contains(needle))
+}
+
 #[test]
 fn log_lists_commits_ahead_of_main() {
     let dir = repo_ahead_of_main();
@@ -200,4 +208,39 @@ fn diff_subcommand_renders_changed_file_tree() {
     let stdout = plain(&output.stdout);
     assert!(stdout.contains("files changed in main...HEAD"), "got: {stdout}");
     assert!(stdout.contains("src/lib.rs"), "got: {stdout}");
+}
+
+#[test]
+fn diff_strikes_through_deleted_files() {
+    // A feature branch removes a file that exists on main. The diff view must
+    // still list it, grayed out and struck through, so the deletion is obvious.
+    let MainRepo {
+        repo,
+        dir,
+        main_oid,
+    } = init_on_main();
+    let sig = signature();
+
+    let main_commit = repo.find_commit(main_oid).unwrap();
+    repo.branch("feature", &main_commit, false).expect("create feature");
+    repo.set_head("refs/heads/feature").expect("checkout feature");
+
+    // Drop README.md (committed on main) on the feature branch.
+    std::fs::remove_file(dir.path().join("README.md")).unwrap();
+    let mut index = repo.index().unwrap();
+    index.remove_path(std::path::Path::new("README.md")).unwrap();
+    index.write().unwrap();
+    let tree = repo.find_tree(index.write_tree().unwrap()).unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "chore: drop readme", &tree, &[&main_commit])
+        .unwrap();
+
+    let output = run(dir.path(), &["diff", "main", "HEAD"]);
+    assert!(output.status.success(), "stderr: {}", plain(&output.stderr));
+
+    assert!(plain(&output.stdout).contains("README.md"), "got: {}", plain(&output.stdout));
+    assert!(
+        has_strikethrough(&output.stdout),
+        "deleted file not struck through: {:?}",
+        String::from_utf8_lossy(&output.stdout),
+    );
 }


### PR DESCRIPTION
## What

Deleted files in the changed-file tree are now **grayed out and struck through** end to end — directory segment, basename, and icon — so a removal reads at a glance instead of looking identical to an add.

## Why

The tree only carried a `Vec<String>` of paths, discarding git's per-delta status. A commit that removed a file looked the same as one that added it.

## How

- `git.rs` now yields `ChangedFile { path, kind }` instead of bare paths, mapping `git2::Delta` onto a `ChangeKind` (`Added` / `Modified` / `Deleted` / `Renamed`). The non-deleted kinds are kept distinct so additions/renames can grow their own styling later.
- `tree.rs` records each leaf's `ChangeKind` and paints deletions gray + strikethrough (`SGR 9`).

## Tests

`tree.rs` unit tests updated to the new type, plus `deleted_file_is_struck_through_but_keeps_its_name`, `surviving_file_is_not_struck_through`, and an end-to-end `diff_strikes_through_deleted_files`. 31/31 pass; the repo's `nix run .#lint` pre-commit hook passed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gray out and strike through deleted files in git-log-pretty tree output
> - Introduces a `ChangeKind` enum (`Added`, `Modified`, `Deleted`, `Renamed`) in [git.rs](https://github.com/indexable-inc/index/pull/882/files#diff-1c773343e00a72dd79022529dee02bb58edc0cd528677f17d640df4ee4ca463a) and replaces bare file path strings with `ChangedFile` structs throughout the diff pipeline.
> - Updates the trie renderer in [tree.rs](https://github.com/indexable-inc/index/pull/882/files#diff-f7f8f7a19865921612ded61f5da053707a0c1724fd92c35a32765229a48bf75c) to carry `ChangeKind` on leaf nodes and apply a strikethrough gray SGR style to deleted files across path segments, basename, and icon.
> - Adds an integration test in [integration.rs](https://github.com/indexable-inc/index/pull/882/files#diff-d53b1ff8510d9f30fa2e7e0c8018e0dfde455b8df6b4958e08ea812d03172a53) that verifies strikethrough SGR is present in output for a deleted file.
> - Behavioral Change: `render` now accepts `&[ChangedFile]` instead of `&[String]`; any callers outside this crate must be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b457cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->