### PR TITLE
feat(mcp): add nix.eval for structured flake evaluation without shell quoting

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2098,6 +2098,17 @@ let
     assert all(r["attr"] for r in rows), rows
     assert isinstance(nix._current_system(), str) and "-" in nix._current_system()
 
+    # eval(): the arg builder quotes nothing through a shell and substitutes the
+    # {system} template, so `--apply` rides as its own argv element.
+    assert nix._eval_args(".#mcp") == ["eval", ".#mcp", "--json", "--no-warn-dirty"]
+    assert nix._eval_args(".#mcp", apply="builtins.attrNames") == [
+        "eval", ".#mcp", "--json", "--no-warn-dirty", "--apply", "builtins.attrNames",
+    ]
+    assert nix._eval_args(".#x", raw=True)[2] == "--raw", nix._eval_args(".#x", raw=True)
+    sysd = nix._current_system()
+    assert nix._eval_args(".#checks.{system}.lint")[1] == f".#checks.{sysd}.lint"
+    assert nix._eval_args(".#checks.{system}", system="x86_64-linux")[1] == ".#checks.x86_64-linux"
+
     print("nix-ok", nix.__version__)
   '';
   nixSmoke =

--- a/packages/mcp/src/nix/nix/__init__.py
+++ b/packages/mcp/src/nix/nix/__init__.py
@@ -46,7 +46,7 @@ from collections.abc import Iterable
 
 import polars as pl
 
-__all__ = ["NixLog", "parse", "run", "build", "attrs", "ACTIVITY_TYPES", "RESULT_TYPES"]
+__all__ = ["NixLog", "parse", "run", "build", "attrs", "eval", "ACTIVITY_TYPES", "RESULT_TYPES"]
 
 __version__ = "0.1.0"
 
@@ -493,6 +493,67 @@ async def attrs(flake: str = ".", *, system: str | None = None, cwd: str | None 
     if proc.returncode != 0:
         raise RuntimeError(f"nix flake show failed: {err.decode('utf-8', 'replace').strip()}")
     return pl.DataFrame(
-        _flake_show_rows(json.loads(out), system),
+        _flake_show_rows(_json.loads(out), system),
         schema={"kind": pl.Utf8, "attr": pl.Utf8, "type": pl.Utf8, "description": pl.Utf8},
     )
+
+
+def _eval_args(
+    installable: str, *, apply: str | None = None, system: str | None = None, raw: bool = False
+) -> list[str]:
+    """Build the ``nix eval`` argv (pure, so the quoting is testable).
+
+    ``{system}`` in ``installable`` is substituted with ``system`` (or the host's
+    system), so ``.#checks.{system}.lint`` resolves without hardcoding the double.
+    ``apply`` rides as its own argv element, never spliced into a shell string.
+    """
+    target = installable.replace("{system}", system or _current_system())
+    args = ["eval", target, "--raw" if raw else "--json", "--no-warn-dirty"]
+    if apply is not None:
+        args += ["--apply", apply]
+    return args
+
+
+async def eval(
+    installable: str = ".",
+    *,
+    apply: str | None = None,
+    system: str | None = None,
+    cwd: str | None = None,
+    raw: bool = False,
+):
+    """Evaluate a Nix installable and return the result as a native Python value.
+
+    The friction this removes: ``nix eval .#checks.aarch64-linux --apply
+    'builtins.attrNames'`` makes you hand-quote a Nix function inside a shell
+    string inside a Python string, and hardcode the system double. Here ``apply``
+    is a plain Python string passed as its own argv element (``create_subprocess_exec``,
+    no shell, so no quoting), and the JSON result decodes to native Python ready
+    for polars::
+
+        names = await nix.eval(".#checks.{system}", apply="builtins.attrNames")
+        pl.Series("check", names)                    # by lines / as a frame
+
+        desc = await nix.eval(".#mcp", apply="p: p.meta.description")
+
+    ``installable`` is a flake ref or attr path; ``{system}`` in it is replaced
+    with ``system`` (default: the host's system double). ``apply`` is a Nix
+    function applied before serialization. ``raw=True`` returns the string
+    verbatim (``nix eval --raw``, e.g. a derivation's ``outPath``) instead of
+    decoding JSON. ``cwd`` resolves a relative flake ref against a worktree. Runs
+    on the shared event loop, so it never blocks other jobs; raise on a non-zero
+    exit with nix's own stderr.
+    """
+    args = _eval_args(installable, apply=apply, system=system, raw=raw)
+    proc = await asyncio.create_subprocess_exec(
+        "nix",
+        *args,
+        cwd=cwd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    out, err = await proc.communicate()
+    if proc.returncode != 0:
+        raise RuntimeError(f"nix eval failed: {err.decode('utf-8', 'replace').strip()}")
+    text = out.decode("utf-8", "replace")
+    return text if raw else _json.loads(text)


### PR DESCRIPTION
Add `nix.eval` so a session can read structured data out of a flake without hand-quoting Nix inside a shell string inside a Python string.

The friction it removes:

    ev = await sh("nix eval .#checks.aarch64-linux --apply 'builtins.attrNames'")

forces three layers of quoting and a hardcoded system double, then hands back text. The replacement:

    names = await nix.eval(".#checks.{system}", apply="builtins.attrNames")
    pl.Series("check", names)            # by lines / as a frame

`apply` rides as its own argv element via `create_subprocess_exec` (no shell, no quoting); `{system}` is substituted with the host's system double (override with `system=`); the JSON result decodes to native Python ready for polars. `raw=True` returns the string verbatim (`nix eval --raw`).

Also fixes a latent `NameError` in `nix.attrs`: it called `json.loads` while the module only imports `json as _json`, so the first real `attrs()` call would have crashed.

Tests: `_eval_args` is a pure argv builder, covered in `nixSmoke` (default, `--apply`, `--raw`, and `{system}` substitution both defaulted and explicit).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `nix.eval` async function for structured Nix flake evaluation without shell quoting
> - Adds `nix.eval` to [nix/__init__.py](https://github.com/indexable-inc/index/pull/883/files#diff-b4bb27410b6cb969e2cdc750a71d049b0c52a3faecc2ca9709a4278184a20890), an async function that builds argv via the new `_eval_args` helper and spawns `nix eval`, returning parsed JSON or raw text.
> - `_eval_args` substitutes `{system}` in the installable string, appends `--json`/`--raw` and `--no-warn-dirty`, and adds `--apply <expr>` as distinct argv elements to avoid shell quoting issues.
> - Raises `RuntimeError` on non-zero exit with stderr content; exports `eval` via `__all__`.
> - Tests in [default.nix](https://github.com/indexable-inc/index/pull/883/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) assert `_eval_args` output for base args, `--apply`, `--raw`, and `{system}` substitution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4a6d20.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->