### PR TITLE
feat(agent-context): allow Bash as a fallback, mandate index feedback issues

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash"
+    ]
+  },
   "extraKnownMarketplaces": {
     "mixedbread-skills": {
       "source": {

--- a/agent-context/sections/00a-execution.md
+++ b/agent-context/sections/00a-execution.md
@@ -1,0 +1,13 @@
+---
+name: execution
+disclosure: always
+---
+
+## Execution
+
+Run everything through the index Python MCP kernel (`python_exec`): it is the
+default path for shell-outs, file reads, and any code you run, and the namespace
+persists so helpers you define stay reusable. Reach for the Bash tool only when
+the Python MCP is *completely* wedged — the event loop is frozen and neither
+`kernel_trace` nor a fresh `python_exec` can recover it. Bash is the fallback
+for an unresponsive kernel, not a parallel way to run ordinary commands.

--- a/agent-context/sections/00b-index-feedback.md
+++ b/agent-context/sections/00b-index-feedback.md
@@ -1,0 +1,16 @@
+---
+name: index-feedback
+disclosure: always
+---
+
+## Filing index feedback
+
+Always open a GitHub issue in `indexable-inc/index` whenever using index is
+subpar — every time, not only on a crash. File one when you misunderstood a tool
+or its surface and a clearer design would have helped, when output flooded or
+filled your context, when the kernel wedged, when the user says you did the
+wrong thing, or when the task worked but a better implementation plainly exists.
+One concrete observation per issue: what you expected, what happened, and the
+smallest change that would have removed the friction. Label it (`bug`,
+`enhancement`) at filing time. These reports are how index improves — treat the
+friction itself as the bug.


### PR DESCRIPTION
Enable the Bash tool in the project's committed Claude Code settings, paired with two always-on agent-context sections:

- **`execution`** — run everything through the index Python MCP kernel; reach for Bash only when the kernel is *completely* wedged (event loop frozen, `kernel_trace` and a fresh `python_exec` both fail). Bash is the dead-kernel fallback, not a parallel command runner.
- **`index-feedback`** — always file a GitHub issue in `indexable-inc/index` whenever using index is subpar: a misunderstood/unclear surface, flooded context, a wedged kernel, a "you did the wrong thing" correction, or a task that worked but has a plainly-better implementation.

Both are `disclosure: always`, so they render into the always-on core (CLAUDE.md/AGENTS.md). The rendered always-doc is 1157 chars, well under the 9000 build cap; section frontmatter matches the existing committed sections.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow Bash as a fallback execution method and mandate index feedback issue filing
> - Adds `Bash` to the permissions allow list in [settings.json](.claude/settings.json), enabling the Bash tool in environments that honor this config.
> - Adds [00a-execution.md](agent-context/sections/00a-execution.md) documenting that all execution should go through the index Python MCP kernel (`python_exec`), with Bash permitted only when the kernel is unresponsive.
> - Adds [00b-index-feedback.md](agent-context/sections/00b-index-feedback.md) specifying how to file GitHub issues for index feedback, including expectations and required labeling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f7f4ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->