### PR TITLE
feat(mcp): dashboard toggle to view the raw model output

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1212,6 +1212,19 @@ let
     runtime.install(ns)
     run = ns["__ix_run"]
 
+    # The model-facing view (IX_LLM_MIME: the exact llm_result text plus downscaled
+    # images) rides into the stored bundle so the dashboard's raw-LLM toggle can
+    # show precisely what the agent received, not just the human HTML.
+    llm_bundle = runtime._result_bundle(
+        runtime.Result(user_html="<b>chart</b>", llm_result="a chart of x", llm_images=[b"\x89PNG\r\n"])
+    )
+    assert runtime.IX_LLM_MIME in llm_bundle["data"], list(llm_bundle["data"])
+    decoded = json.loads(llm_bundle["data"][runtime.IX_LLM_MIME])
+    assert decoded["text"] == "a chart of x" and len(decoded["images"]) == 1, decoded
+    # A result with no model images carries no IX_LLM_MIME (text/plain is the text).
+    plain_bundle = runtime._result_bundle(runtime.Result(user_html="<b>hi</b>", llm_result="hi"))
+    assert runtime.IX_LLM_MIME not in plain_bundle["data"], list(plain_bundle["data"])
+
     # A tuple/list carrying a rich value (a DataFrame) renders each element with
     # its own view, stacked, instead of stringifying the frame into a one-column
     # table -- Result((repr_text, df)) shows the text AND the real table.

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1224,6 +1224,13 @@ let
     # A result with no model images carries no IX_LLM_MIME (text/plain is the text).
     plain_bundle = runtime._result_bundle(runtime.Result(user_html="<b>hi</b>", llm_result="hi"))
     assert runtime.IX_LLM_MIME not in plain_bundle["data"], list(plain_bundle["data"])
+    # A huge llm_result is clipped to the same cap as any other text mime, so it
+    # can never bypass the limit into the store / each dashboard poll.
+    big = runtime._result_bundle(
+        runtime.Result(user_html="<b>x</b>", llm_result="z" * 500_000, llm_images=[b"\x89PNG\r\n"])
+    )
+    big_text = json.loads(big["data"][runtime.IX_LLM_MIME])["text"]
+    assert big_text.endswith("[truncated]") and len(big_text) <= runtime._MAX_TEXT_BUNDLE + 32, len(big_text)
 
     # A tuple/list carrying a rich value (a DataFrame) renders each element with
     # its own view, stacked, instead of stringifying the frame into a one-column

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -1189,6 +1189,17 @@ def _normalize_bundle(data: dict, metadata: dict | None = None) -> dict:
         elif len(value) > _MAX_TEXT_BUNDLE:
             value = value[:_MAX_TEXT_BUNDLE] + "\n... [truncated]"
         out[mime] = value
+    # Carry the model-facing view (IX_LLM_MIME: the exact llm_result text plus the
+    # downscaled llm_images) so the dashboard's raw-LLM toggle can show precisely
+    # what the agent received, not just the human HTML. Stored JSON-encoded (the
+    # dashboard's data map is string-valued); each image is already size-bounded,
+    # so cap the whole only as a guard, dropping images (never the text) if huge.
+    llm = data.get(IX_LLM_MIME)
+    if isinstance(llm, dict):
+        encoded = json.dumps(llm)
+        if len(encoded) > _MAX_IMAGE_BUNDLE:
+            encoded = json.dumps({"text": llm.get("text", ""), "images": []})
+        out[IX_LLM_MIME] = encoded
     return {"data": out, "metadata": metadata or {}}
 
 

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -1196,9 +1196,16 @@ def _normalize_bundle(data: dict, metadata: dict | None = None) -> dict:
     # so cap the whole only as a guard, dropping images (never the text) if huge.
     llm = data.get(IX_LLM_MIME)
     if isinstance(llm, dict):
-        encoded = json.dumps(llm)
+        # Clip the text to the same cap as every other text mime so a huge
+        # llm_result can never bypass it into SQLite or each dashboard poll, and
+        # the raw view matches the model's own clipped text. Drop the images
+        # (never the text) if the whole still exceeds the image cap.
+        text = llm.get("text", "")
+        if len(text) > _MAX_TEXT_BUNDLE:
+            text = text[:_MAX_TEXT_BUNDLE] + "\n... [truncated]"
+        encoded = json.dumps({"text": text, "images": llm.get("images", [])})
         if len(encoded) > _MAX_IMAGE_BUNDLE:
-            encoded = json.dumps({"text": llm.get("text", ""), "images": []})
+            encoded = json.dumps({"text": text, "images": []})
         out[IX_LLM_MIME] = encoded
     return {"data": out, "metadata": metadata or {}}
 

--- a/packages/mcp/site/src/App.svelte
+++ b/packages/mcp/site/src/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { feed } from '$lib/feed.svelte';
   import { now } from '$lib/now.svelte';
+  import { view } from '$lib/view.svelte';
   import JobCard from '$components/JobCard.svelte';
   import CellCard from '$components/CellCard.svelte';
   import ResourceCard from '$components/ResourceCard.svelte';
@@ -171,6 +172,14 @@
 <header class="top">
   <span class="brand"><b>ix</b> &middot; mcp</span>
   <span class="spacer"></span>
+  <button
+    class="reset"
+    class:on={view.rawLLM}
+    type="button"
+    aria-pressed={view.rawLLM}
+    title={view.rawLLM ? "Showing the raw model view; click for the human view" : "Show what the LLM actually sees (raw text & images)"}
+    onclick={() => view.toggle()}
+  >raw llm</button>
   <button class="reset" type="button" title="Reset layout" onclick={resetLayout}>reset</button>
   <span class="stat" class:stale={!feed.connected}>
     {#if running}<span class="dot"></span><b>{running}</b> running &nbsp;{/if}
@@ -291,6 +300,14 @@
   .reset:hover {
     color: var(--text);
     border-color: var(--active);
+  }
+  .reset.on {
+    color: var(--bg);
+    background: var(--active);
+    border-color: var(--active);
+  }
+  .reset.on:hover {
+    color: var(--bg);
   }
   .stat {
     color: var(--muted);

--- a/packages/mcp/site/src/components/RichOutput.svelte
+++ b/packages/mcp/site/src/components/RichOutput.svelte
@@ -19,12 +19,21 @@
     const encoded = data[IX_LLM_MIME];
     if (encoded) {
       try {
-        return JSON.parse(encoded) as LlmView;
+        const parsed = JSON.parse(encoded) as LlmView;
+        if (typeof parsed.text === 'string' && Array.isArray(parsed.images)) return parsed;
       } catch {
-        // Fall through to the text-only view below.
+        // Fall through to the text/image fallback below.
       }
     }
-    return { text: plain ?? '', images: [] };
+    // No IX_LLM_MIME: the model still received this bundle's text/plain and any
+    // image mimes (a bare plot or screenshot), so reflect those, not just text.
+    return {
+      text: plain ?? (html && !png ? '[HTML output; see the dashboard]' : ''),
+      images: [
+        ...(png ? [{ mime: 'image/png', data: png }] : []),
+        ...(jpeg ? [{ mime: 'image/jpeg', data: jpeg }] : []),
+      ],
+    };
   });
 </script>
 

--- a/packages/mcp/site/src/components/RichOutput.svelte
+++ b/packages/mcp/site/src/components/RichOutput.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import type { RichOutput } from '$lib/types';
+  import { type RichOutput, type LlmView, IX_LLM_MIME } from '$lib/types';
+  import { view } from '$lib/view.svelte';
   let { output }: { output: RichOutput } = $props();
 
   const data = $derived(output.data ?? {});
@@ -10,9 +11,33 @@
   const html = $derived(data['text/html']);
   const markdown = $derived(data['text/markdown']);
   const plain = $derived(data['text/plain']);
+
+  // The raw model-facing view, when the header toggle is on: the exact text and
+  // images the agent received. IX_LLM_MIME carries both (text plus downscaled
+  // images) when a Result had images; otherwise text/plain is the model's text.
+  const llm = $derived.by((): LlmView => {
+    const encoded = data[IX_LLM_MIME];
+    if (encoded) {
+      try {
+        return JSON.parse(encoded) as LlmView;
+      } catch {
+        // Fall through to the text-only view below.
+      }
+    }
+    return { text: plain ?? '', images: [] };
+  });
 </script>
 
-{#if png}
+{#if view.rawLLM}
+  <!-- What the LLM actually saw: its concise text and any images it was sent. -->
+  {#if llm.text}<pre class="res">{llm.text}</pre>{/if}
+  {#each llm.images as img, i (i)}
+    <img class="img" src={`data:${img.mime};base64,${img.data}`} alt="" />
+  {/each}
+  {#if !llm.text && llm.images.length === 0}
+    <pre class="res dim">(no model output)</pre>
+  {/if}
+{:else if png}
   <img class="img" src={`data:image/png;base64,${png}`} alt="" />
 {:else if jpeg}
   <img class="img" src={`data:image/jpeg;base64,${jpeg}`} alt="" />
@@ -47,5 +72,9 @@
   }
   pre.res {
     color: var(--text);
+  }
+  pre.dim {
+    color: var(--faint);
+    font-style: italic;
   }
 </style>

--- a/packages/mcp/site/src/lib/types.ts
+++ b/packages/mcp/site/src/lib/types.ts
@@ -9,6 +9,18 @@ export interface RichOutput {
   data?: Record<string, string>;
 }
 
+// The custom mime a Result carries so the dashboard can reconstruct the exact
+// model-facing view (mirrors ix_notebook_mcp.runtime.IX_LLM_MIME). Stored
+// JSON-encoded in a RichOutput's `data` map; parse it to a `LlmView`.
+export const IX_LLM_MIME = 'application/x-ix-llm+json';
+
+// What the agent actually received for one output: the `llm_result` text and the
+// downscaled `llm_images`, each a base64 payload with its mime.
+export interface LlmView {
+  text: string;
+  images: { mime: string; data: string }[];
+}
+
 export type JobStatus = 'running' | 'done' | 'error' | 'cancelled';
 
 // The live value one of a cell's identifiers was bound to when the run finished

--- a/packages/mcp/site/src/lib/view.svelte.ts
+++ b/packages/mcp/site/src/lib/view.svelte.ts
@@ -1,0 +1,29 @@
+// Global UI preference: show the RAW model-facing view (the exact `llm_result`
+// text and `llm_images` the agent received) instead of the human-rendered HTML.
+// One switch in the header flips every output at once, so a curious human can
+// see what the LLM actually saw. Persisted so a refresh keeps the choice.
+const KEY = 'ix-mcp-raw-llm';
+
+function load(): boolean {
+  try {
+    return localStorage.getItem(KEY) === '1';
+  } catch {
+    // Storage may be blocked; default to the human view.
+    return false;
+  }
+}
+
+class View {
+  rawLLM = $state(load());
+
+  toggle(): void {
+    this.rawLLM = !this.rawLLM;
+    try {
+      localStorage.setItem(KEY, this.rawLLM ? '1' : '0');
+    } catch {
+      // Storage blocked: the choice still holds for this session.
+    }
+  }
+}
+
+export const view = new View();


### PR DESCRIPTION
Add a header toggle to the dashboard that flips every output to the RAW model-facing view: the exact `llm_result` text and `llm_images` the agent received, instead of the human-rendered HTML. For when a curious human wants to see what the LLM actually saw.

What it does:
- Server: `runtime._normalize_bundle` now carries `IX_LLM_MIME` (the model view: concise text plus the downscaled images) into the stored output bundle. Previously only `text/html` (the human view) and `text/plain` reached the dashboard, so the model's images were never recoverable. Capped as a guard (drop images, never text, if huge).
- UI: a new `view.svelte.ts` store holds one persisted `rawLLM` flag; a `raw llm` button in the header toggles it for the whole page. `RichOutput.svelte` renders the model text and images when it is on, the human view otherwise.

Tests (`richSmoke`): the model view (text + image) rides into the stored bundle, and a result with no model images carries no `IX_LLM_MIME`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dashboard toggle to view raw model output in MCP notebook UI
> - Adds a `rawLLM` toggle button to the dashboard header ([App.svelte](https://github.com/indexable-inc/index/pull/885/files#diff-240d9cd1cc9a37ac80415eb1f218541e5d440fddfbe53ac6ced472263f7fd939)) that switches all outputs to show the model-facing view; preference is persisted to localStorage via a new view store ([view.svelte.ts](https://github.com/indexable-inc/index/pull/885/files#diff-586d2a749c664e63f68ea038024fb694dc438881b7bf67c1538ecb51e18ebd82)).
> - Extends `_normalize_bundle` in [runtime.py](https://github.com/indexable-inc/index/pull/885/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) to emit an `IX_LLM_MIME` entry containing the exact model text (clipped to `_MAX_TEXT_BUNDLE`) and downscaled images (dropped if the payload exceeds `_MAX_IMAGE_BUNDLE`).
> - Updates [RichOutput.svelte](https://github.com/indexable-inc/index/pull/885/files#diff-495b38c06b4ec7e502f7a8c9554500e2e79425eae60ca1e4d5d59c2824c37be7) to render the `IX_LLM_MIME` payload when the toggle is on, falling back to `text/plain` and available image mimes when the mime is absent, with a placeholder when neither text nor images exist.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c2d348.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->