### PR TITLE
refactor(nix): single resolution boundary for lib/rust (stage 3 of N)

### DIFF
--- a/ast-grep/nix/rules/no-deprecated-iflist-empty.yml
+++ b/ast-grep/nix/rules/no-deprecated-iflist-empty.yml
@@ -1,22 +1,18 @@
 id: no-deprecated-iflist-empty
 language: nix
 severity: warning
-message: "`if cond then [ x ] else [ ]` is `lib.optional cond x`, or `lib.optionals cond xs` when the non-empty branch is list-valued."
+message: "`if cond then [ x ] else [ ]` is `lib.optional cond x`."
 note: |
-  WHY: Conditional list construction is the canonical use case for
-  `lib.optional` / `lib.optionals`. The `if … then [ … ] else [ ]` shape
-  reinvents it inline and is harder to grep.
+  WHY: A one-element-list-or-empty conditional is the canonical use case for
+  `lib.optional`. The `if cond then [ x ] else [ ]` shape reinvents it inline
+  and is harder to grep.
   NIXPKGS: Convention across nixpkgs services and packaging.
-  REPO: Use `lib.optional cond x` for a one-element non-empty branch and
-  `lib.optionals cond xs` for a list-valued one; the `else [ ]` already proves
-  the non-empty branch is a list, so a bare variable (`if cond then xs else [ ]`)
-  flags too, not just a `[ … ]` literal. The single carve-out is
-  `if s ? k then s.k else [ ]`, which `prefer-or-default-over-has-attr-guard`
-  owns with the better `s.k or [ ]`.
+  REPO: Use `lib.optional cond x`. Only the single-element list literal flags;
+  a list-valued non-literal branch (`if cond then xs else [ ]`, which would be
+  `lib.optionals cond xs`) is left to the author, since spelling it `lib.optionals`
+  on an opaque expression often obscures rather than clarifies.
 rule:
-  # Empty `else`: any non-empty `then` branch, except the `s ? k` / `s.k`
-  # guard shape that `prefer-or-default-over-has-attr-guard` rewrites to
-  # `s.k or [ ]`.
-  all:
-    - pattern: if $COND then $THEN else [ ]
-    - not: { pattern: "if $S ? $K then $S.$K else [ ]" }
+  # Empty `else` with a single-element list literal `then`. Bare variables and
+  # multi-element literals (the `lib.optionals` cases) are intentionally not
+  # flagged.
+  pattern: if $COND then [ $X ] else [ ]

--- a/ast-grep/nix/tests/no-deprecated-iflist-empty-test.yml
+++ b/ast-grep/nix/tests/no-deprecated-iflist-empty-test.yml
@@ -13,7 +13,10 @@ valid:
   - 'if cond then [ ] else [ x ]'
   - 'if cond then [ ] else [ a b ]'
   - 'if callerHasTargetSelector && !clippyCargoArgsSet then [ ] else args.policy.clippy.cargoArgs'
+  # List-valued non-literal / multi-element `then` (the `lib.optionals` cases)
+  # are intentionally not flagged.
+  - 'if cond then xs else [ ]'
+  - 'if cond then [ a b ] else [ ]'
+  - 'if builtins.pathExists p && chosen != null then normalize chosen else [ ]'
 invalid:
   - 'if cond then [ x ] else [ ]'
-  - 'if cond then [ a b ] else [ ]'
-  - 'if cond then xs else [ ]'

--- a/lib/minecraft/dimension-type.nix
+++ b/lib/minecraft/dimension-type.nix
@@ -64,7 +64,7 @@ let
         }
       ];
     in
-    lib.checkAssertWarn checks [ ] rendered;
+    lib.asserts.checkAssertWarn checks [ ] rendered;
 
   # Project a dimensionTypes submodule value to the JSON written to disk: strip
   # the `base` field, merge the named vanilla snapshot underneath, default

--- a/lib/rust/build.nix
+++ b/lib/rust/build.nix
@@ -2,712 +2,44 @@
   lib,
   pkgs,
   clippyPackage ? pkgs.clippy,
-  rustToolchain ? pkgs.symlinkJoin {
-    name = "ix-rust-toolchain";
-    paths = [
-      pkgs.cargo
-      pkgs.rustc
-    ];
-  },
+  rustToolchain,
   writePythonApplication,
 }:
 let
-  inherit (builtins)
-    attrNames
-    attrValues
-    baseNameOf
-    deepSeq
-    elemAt
-    filter
-    getAttr
-    hasAttr
-    match
-    removeAttrs
-    toJSON
-    toString
-    ;
+  inherit (builtins) removeAttrs;
 
-  inherit (lib)
-    any
-    join
-    subtractLists
-    ;
-
-  joinLines = join "\n";
-
-  toFlagSequence =
-    flag:
-    lib.concatMap (arg: [
-      flag
-      arg
-    ]);
-
-  isEmpty = l: l == [ ];
-  nonEmpty = l: l != [ ];
-
-  inherit (import ../util/lists.nix { inherit lib; }) findDuplicatesBy;
-
-  optionalInherit = s: k: if s ? "${k}" then { "${k}" = s."${k}"; } else { };
-  optionalInherits = s: keys: lib.mergeAttrsList (map (optionalInherit s) keys);
-
-  defaultRustToolchain = rustToolchain;
-
-  # A toolchain's id is the basename of its store path. It is baked into every
-  # unit hash by the renderer, so cargoUnit derives it for the default toolchain,
-  # the render call, the workspace-side injection cross-check, and the prebuilt
-  # builder's assertion. One definition here, at the toolchain owner, keeps those
-  # four readings from drifting.
-  toolchainId = toolchain: baseNameOf (toString toolchain);
-
-  defaultPolicy = {
-    denyUnusedCrateDependencies = true;
-    # Opt-in: scans each unit's objects for functions that can reach a panic.
-    # Off by default because it is a best-effort gate, not a soundness proof.
-    denyPanics = false;
-    # On by default: the cargo-audit check is an offline, lockfile-only runCommand
-    # (`cargo-audit audit --file Cargo.lock --no-fetch --stale` against the
-    # pinned advisory DB) that inherits only Cargo.lock, so it is decoupled from
-    # compilation and re-runs only when the lockfile or DB changes. Cheap enough
-    # to audit every workspace; opt out per-workspace with a named reason (e.g.
-    # lib/rust-workspace.nix disables it on the pure-build cross graph).
-    cargoAudit = {
-      enable = true;
-      db = pkgs.fetchFromGitHub {
-        owner = "rustsec";
-        repo = "advisory-db";
-        rev = "f2ae5fc8e5d208373b6c838f9676434525327a72";
-        hash = "sha256-iqXYpuCoWoGypnpM5ceXN748QlYeBXDtZx0uI98qFLo=";
-      };
-      deny = [ ];
-      ignore = [ ];
-    };
-    cargoMachete = {
-      enable = true;
-      extraArgs = [ ];
-    };
-    clippy = {
-      enable = true;
-      package = clippyPackage;
-      cargoArgs = [ "--all-targets" ];
-      deniedLints = [ ];
-      allowedLints = [ ];
-    };
-    tests = {
-      enable = true;
-      useNextest = true;
-    };
-    linker = {
-      useMold = pkgs.stdenv.hostPlatform.isLinux;
-    };
+  # The resolution boundary: caller args -> one resolved bundle (context, policy,
+  # linker, effects, checks), defaults applied once. `buildPackage` consumes the
+  # bundle; the rest of the surface is re-exposed below as the `rust` value the
+  # cargo-unit side reads.
+  resolve = import ./resolve.nix {
+    inherit
+      lib
+      pkgs
+      clippyPackage
+      rustToolchain
+      writePythonApplication
+      ;
   };
-
-  cargoLockFile = cargoLock: cargoLock.lockFile or cargoLock;
-
-  # `platform` is a rust target triple (e.g. `x86_64-unknown-linux-gnu`); mold is
-  # Linux-only, so the flags are gated on a `-linux-` triple. Host builds pass
-  # `pkgs.stdenv.hostPlatform.config` rather than a sentinel, so there is one
-  # Linux test and a non-triple argument fails loudly instead of defaulting.
-  rustcArgsForPolicyForPlatform =
-    policy: platform:
-    lib.optionals (policy.linker.useMold && lib.hasInfix "-linux-" platform) [
-      "-C"
-      "link-arg=-fuse-ld=mold"
-    ];
-
-  # Apply the rustflags a normal `cargo build` reads from `.cargo/config.toml`,
-  # which cargoUnit otherwise ignores (it assembles rustc args itself instead of
-  # going through cargo). Parsing the config here is the only route: cargo's
-  # `cargo build --unit-graph` does NOT carry rustflags (each unit records only
-  # dependencies/features/mode/pkg_id/platform/profile/target), because cargo
-  # resolves config rustflags at compile time and applies them when it invokes
-  # rustc, which cargoUnit bypasses by invoking rustc per unit from the graph. So
-  # there is nothing in the graph to pick up automatically; we read the config.
-  # Returns the rustc args for a target triple following cargo precedence:
-  # `target.<triple>.rustflags` wins outright over `build.rustflags` (cargo does
-  # not merge the two). Flags may be a TOML array or a single whitespace-
-  # separated string. `cfg(...)` target sections and the `[env]` table are NOT
-  # honored (cargo evaluates those against the full target cfg set, which this
-  # static parse does not reproduce). A `configPath` that does not exist yields
-  # no flags, so callers may pass the path unconditionally.
-  rustflagsFromCargoConfig =
-    configPath: platform:
-    let
-      config = if builtins.pathExists configPath then lib.importTOML configPath else { };
-      normalize =
-        flags:
-        if builtins.isList flags then flags else filter (flag: flag != "") (lib.splitString " " flags);
-      targetFlags = config.target.${platform}.rustflags or null;
-      buildFlags = config.build.rustflags or null;
-      chosen = if targetFlags != null then targetFlags else buildFlags;
-    in
-    lib.optionals (chosen != null) (normalize chosen);
-
-  nativeBuildInputsForPolicy = policy: lib.optional policy.linker.useMold pkgs.mold;
-
-  dependencyPackages =
-    cargoLock:
-    let
-      lock = lib.importTOML (cargoLockFile cargoLock);
-    in
-    filter (pkg: pkg ? source) (lock.package or [ ]);
-
-  hasGitSource = pkg: lib.hasPrefix "git+" pkg.source;
-
-  gitPackages = cargoLock: filter hasGitSource (dependencyPackages cargoLock);
-
-  packageSourceKey = pkg: "${pkg.source}#${pkg.name}@${pkg.version}";
-
-  # Both registry shapes resolve to the same CDN artifact. `static.crates.io` is
-  # the direct CloudFront URL cargo's sparse protocol uses; the older
-  # `api.crates.io/api/v1/crates/.../download` endpoint just 302s here and, as
-  # of 2026-05, rejects curl's default User-Agent with HTTP 403.
-  registryDownloadUrls =
-    let
-      cratesIoDownloadUrl =
-        pkg: "https://static.crates.io/crates/${pkg.name}/${pkg.name}-${pkg.version}.crate";
-    in
-    {
-      "registry+https://github.com/rust-lang/crates.io-index" = cratesIoDownloadUrl;
-      "sparse+https://index.crates.io/" = cratesIoDownloadUrl;
-    };
-
-  parseGitSource =
-    source:
-    let
-      parts = match ''git\+([^?]+)(\?(rev|tag|branch)=([^#]*))?#(.*)'' source;
-    in
-    if parts == null then
-      throw "rust: cannot parse git source string `${source}` from Cargo.lock"
-    else
-      {
-        url = elemAt parts 0;
-        refType = elemAt parts 2;
-        ref = elemAt parts 3;
-        sha = elemAt parts 4;
-      };
-
-  clippyLintArgs =
-    policy:
-    toFlagSequence "-D" policy.clippy.deniedLints ++ toFlagSequence "-A" policy.clippy.allowedLints;
-
-  # Cargo only emits `[lints.clippy]` into the unit graph's `lint_rustflags`
-  # when invoked as `cargo clippy`, not `cargo build`. Parse the workspace
-  # manifest and emit the equivalent `-D|-W|-A clippy::<lint>` flags so
-  # per-unit clippy sees the workspace lint policy.
-  clippyLintFlagsFromManifest =
-    manifestPath:
-    let
-      # `clippy::cargo` group lints invoke `cargo` to read workspace metadata.
-      # Per-unit clippy runs in a sandboxed build directory without a discoverable
-      # Cargo.toml (the unit's source closure is package-shaped), so those lints
-      # error out with "could not find Cargo.toml". Skip them here; a future
-      # workspace-level cargo-clippy check is the right home.
-      cargoGroupClippyLints = [
-        "cargo"
-        "cargo_common_metadata"
-        "multiple_crate_versions"
-        "negative_feature_names"
-        "redundant_feature_names"
-        "wildcard_dependencies"
-      ];
-
-      manifest = lib.importTOML manifestPath;
-
-      raw = manifest.workspace.lints.clippy or manifest.lints.clippy or { };
-
-      filtered = removeAttrs raw cargoGroupClippyLints;
-
-      entryFor = name: value: {
-        inherit name;
-        level = value.level or value;
-        priority = value.priority or 0;
-      };
-
-      entries = lib.mapAttrsToList entryFor filtered;
-
-      sortedEntries = lib.sortOn (v: v.priority) entries;
-
-      levelFlags = {
-        deny = "-D";
-        forbid = "-D";
-        warn = "-W";
-        allow = "-A";
-      };
-
-      entryFlags =
-        entry:
-        let
-          inherit (entry) level;
-          levelFlag =
-            levelFlags."${level}"
-              or (throw "cargoUnit: unknown clippy lint level '${level}' in ${manifestPath}");
-        in
-        [
-          levelFlag
-          "clippy::${entry.name}"
-        ];
-    in
-    lib.concatMap entryFlags sortedEntries;
-
-  vendorConfigScript =
-    {
-      cargoExtraConfig,
-      cargoLock,
-      vendorDir,
-    }:
-    let
-      cargoExtraConfigFile = pkgs.writeText "cargo-extra-config.toml" cargoExtraConfig;
-
-      gitSources = lib.unique (
-        map (pkg: parseGitSource pkg.source // { inherit (pkg) source; }) (gitPackages cargoLock)
-      );
-
-      # The default vendored-sources config, emitted when the vendor dir carries
-      # no `.cargo/config.toml` of its own (the aggregate `linkFarm` never does).
-      vendorConfigFile = pkgs.writeText "cargo-vendor-config.toml" ''
-        [source.crates-io]
-        replace-with = "vendored-sources"
-
-        [source.vendored-sources]
-        directory = "${vendorDir}"
-      '';
-
-      # One `[source."<git>"]` table per git dependency, each replacing that git
-      # source with the vendored copy. Rendered at eval time and `cat` in, rather
-      # than printf'd table by table in the builder.
-      gitSourceBlock =
-        git:
-        joinLines (
-          [
-            ''[source."${git.source}"]''
-            "git = ${toJSON git.url}"
-          ]
-          ++ lib.optional (git.refType != null) "${git.refType} = ${toJSON git.ref}"
-          ++ [ ''replace-with = "vendored-sources"'' ]
-        );
-      gitSourceConfigFile = pkgs.writeText "cargo-git-sources.toml" (
-        lib.concatMapStringsSep "\n\n" gitSourceBlock gitSources + "\n"
-      );
-    in
-    ''
-      export CARGO_HOME="$TMPDIR/cargo-home"
-      mkdir -p "$CARGO_HOME"
-
-      if [ -f "${vendorDir}/.cargo/config.toml" ]; then
-        sed 's|directory = "cargo-vendor-dir"|directory = "${vendorDir}"|' \
-          "${vendorDir}/.cargo/config.toml" > "$CARGO_HOME/config.toml"
-      else
-        cat ${vendorConfigFile} > "$CARGO_HOME/config.toml"
-      fi
-    ''
-    + lib.optionalString (gitSources != [ ]) ''
-
-      printf '\n' >> "$CARGO_HOME/config.toml"
-      cat ${gitSourceConfigFile} >> "$CARGO_HOME/config.toml"
-    ''
-    + lib.optionalString (cargoExtraConfig != "") ''
-
-      printf '\n' >> "$CARGO_HOME/config.toml"
-      cat ${cargoExtraConfigFile} >> "$CARGO_HOME/config.toml"
-    '';
-
-  # The "run cargo in the vendored tree" context, resolved once at this boundary
-  # and shared by every consumer that needs it together: `policyChecksFor`,
-  # `buildPackage` here, and cargoUnit's `generateUnitGraph` / `generateUnitsNix` /
-  # workspace import. Both files are two pieces of one unit, so the lockfile,
-  # toolchain, policy, and vendor resolution live here rather than being re-derived
-  # per side.
-  normalizeArgs =
-    args:
-    let
-      rustToolchain = args.rustToolchain or defaultRustToolchain;
-      cargoLock = args.cargoLock or (args.src + "/Cargo.lock");
-      outputHashes = args.outputHashes or { };
-      sourceOverrides = args.sourceOverrides or { };
-      packages = dependencyPackages cargoLock;
-
-      # The caller's partial policy merged over `defaultPolicy`, field by field.
-      # Enumerating the fields (rather than a recursive merge) rejects typo'd keys
-      # and keeps the one special case visible: `clippy.denyWarnings = false` drops
-      # the "warnings" deny so a warning does not fail the build.
-      policy =
-        let
-          rawPolicy = args.policy or { };
-          cargoAudit = rawPolicy.cargoAudit or { };
-          cargoMachete = rawPolicy.cargoMachete or { };
-          clippy = rawPolicy.clippy or { };
-          tests = rawPolicy.tests or { };
-          linker = rawPolicy.linker or { };
-        in
-        {
-          denyUnusedCrateDependencies =
-            rawPolicy.denyUnusedCrateDependencies or defaultPolicy.denyUnusedCrateDependencies;
-          denyPanics = rawPolicy.denyPanics or defaultPolicy.denyPanics;
-          cargoAudit = {
-            enable = cargoAudit.enable or defaultPolicy.cargoAudit.enable;
-            db = cargoAudit.db or defaultPolicy.cargoAudit.db;
-            deny = cargoAudit.deny or defaultPolicy.cargoAudit.deny;
-            ignore = cargoAudit.ignore or defaultPolicy.cargoAudit.ignore;
-          };
-          cargoMachete = {
-            enable = cargoMachete.enable or defaultPolicy.cargoMachete.enable;
-            extraArgs = cargoMachete.extraArgs or defaultPolicy.cargoMachete.extraArgs;
-          };
-          clippy = {
-            enable = clippy.enable or defaultPolicy.clippy.enable;
-            package = clippy.package or defaultPolicy.clippy.package;
-            cargoArgs = clippy.cargoArgs or defaultPolicy.clippy.cargoArgs;
-            deniedLints =
-              let
-                denied = clippy.deniedLints or defaultPolicy.clippy.deniedLints;
-              in
-              if !(clippy.denyWarnings or true) then filter (lint: lint != "warnings") denied else denied;
-            allowedLints = clippy.allowedLints or defaultPolicy.clippy.allowedLints;
-          };
-          tests = {
-            enable = tests.enable or defaultPolicy.tests.enable;
-            useNextest = tests.useNextest or defaultPolicy.tests.useNextest;
-          };
-          linker = {
-            useMold = linker.useMold or defaultPolicy.linker.useMold;
-          };
-        };
-
-      # One package-shaped vendored source directory per dependency, keyed by
-      # `packageSourceKey`. Registry crates are fetched from `static.crates.io`;
-      # git crates are fetched and reduced to the single referenced package.
-      vendorSources =
-        let
-          checkedOutputHashes =
-            let
-              gitPackageSources = map (pkg: pkg.source) (gitPackages cargoLock);
-              outputHashKeys = attrNames outputHashes;
-
-              missing = subtractLists outputHashKeys gitPackageSources;
-              unused = subtractLists gitPackageSources outputHashKeys;
-            in
-            assert lib.assertMsg (missing == [ ]) ''
-              outputHashes is missing hashes for git source strings in Cargo.lock: ${join ", " missing}
-              Key each git hash by the exact Cargo.lock source string, for example:
-              outputHashes."git+https://github.com/owner/repo#rev" = "sha256-...";
-            '';
-            assert lib.assertMsg (unused == [ ]) ''
-              outputHashes contains keys that are not git source strings in Cargo.lock: ${join ", " unused}
-              Key each git hash by the exact Cargo.lock source string, for example:
-              outputHashes."git+https://github.com/owner/repo#rev" = "sha256-...";
-            '';
-            outputHashes;
-          # Flatten workspace inheritance in a vendored Cargo.toml before rustc sees it.
-          # Vendored from nixpkgs so a downstream rename of
-          # `pkgs/build-support/rust/replace-workspace-values.py` doesn't surface as a
-          # `readFile` error here; `ix.writePythonApplication` also runs ty on the body
-          # at build time, which the upstream `pkgs.writers.writePython3` path did not.
-          replaceWorkspaceValues = writePythonApplication {
-            name = "replace-workspace-values";
-            src = ./replace-workspace-values.py;
-            python = pkgs.python314.withPackages (
-              ps:
-              attrValues {
-                inherit (ps) tomli tomli-w;
-              }
-            );
-          };
-
-          registryPackageSource =
-            pkg:
-            let
-              crateTarball = pkgs.fetchurl {
-                name = "crate-${pkg.name}-${pkg.version}.tar.gz";
-                url = (getAttr pkg.source registryDownloadUrls) pkg;
-                # Cargo verifies `.cargo-checksum.json` against the hex digest from
-                # Cargo.lock, and that file is filled from `crateTarball.outputHash`
-                # below. Switching to `hash = <SRI>` would make `outputHash` an SRI
-                # string and break cargo's check, so the registry tarball stays on
-                # the hex-valued `sha256` attr.
-                # ast-grep-ignore: prefer-sri-hash
-                sha256 = pkg.checksum;
-              };
-            in
-            assert lib.assertMsg (
-              pkg ? checksum
-            ) "Package ${pkg.name} ${pkg.version} is missing a Cargo.lock checksum.";
-            pkgs.runCommand "${pkg.name}-${pkg.version}" { } ''
-              mkdir "$out"
-              tar xf ${crateTarball} -C "$out" --strip-components=1
-              printf '{"files":{},"package":"${crateTarball.outputHash}"}' > "$out/.cargo-checksum.json"
-            '';
-
-          gitPackageSource =
-            pkg:
-            let
-              git = parseGitSource pkg.source;
-
-              gitHash =
-                checkedOutputHashes.${pkg.source} or (throw ''
-                  No hash was found while vendoring the git dependency ${pkg.name}-${pkg.version}.
-                  Add outputHashes."${pkg.source}".
-                '');
-              tree =
-                sourceOverrides.${pkg.source} or (pkgs.fetchgit {
-                  inherit (git) url;
-                  rev = git.sha;
-                  hash = gitHash;
-                  nativeBuildInputs = lib.optional (lib.hasPrefix "ssh://" git.url) pkgs.openssh;
-                });
-            in
-            pkgs.runCommand "${pkg.name}-${pkg.version}"
-              {
-                nativeBuildInputs = [
-                  pkgs.cargo
-                  pkgs.jaq
-                ];
-              }
-              ''
-                tree=${tree}
-                crateCargoTOML=""
-
-                if [ -f "$tree/Cargo.toml" ]; then
-                  crateCargoTOML=$(cargo metadata --format-version 1 --no-deps --manifest-path "$tree/Cargo.toml" | \
-                    jaq -r '.packages[] | select(.name == "${pkg.name}") | .manifest_path' || :)
-                fi
-
-                if [ -z "$crateCargoTOML" ]; then
-                  while IFS= read -r manifest; do
-                    crateCargoTOML=$(cargo metadata --format-version 1 --no-deps --manifest-path "$manifest" | \
-                      jaq -r '.packages[] | select(.name == "${pkg.name}") | .manifest_path' || :)
-                    [ -n "$crateCargoTOML" ] && break
-                  done < <(find "$tree" -name Cargo.toml)
-                fi
-
-                if [ -z "$crateCargoTOML" ]; then
-                  echo "Cannot find ${pkg.name}-${pkg.version} in ${pkg.source}" >&2
-                  exit 1
-                fi
-
-                crateRoot=$(dirname "$crateCargoTOML")
-                cp -prvL "$crateRoot" "$out" || echo "Warning: certain files could not be copied" >&2
-                chmod -R u+w "$out"
-
-                if grep -q workspace "$out/Cargo.toml"; then
-                  ${lib.getExe replaceWorkspaceValues} "$out/Cargo.toml" "$(cargo metadata --format-version 1 --no-deps --manifest-path "$crateCargoTOML" | jaq -r .workspace_root)/Cargo.toml"
-                fi
-
-                printf '{"files":{},"package":null}' > "$out/.cargo-checksum.json"
-              '';
-
-          # Every package here carries a `source` (`dependencyPackages` filtered on
-          # it), so map each straight to its vendored package directory.
-          packageSource = pkg: {
-            name = packageSourceKey pkg;
-            value =
-              if hasAttr pkg.source registryDownloadUrls then
-                registryPackageSource pkg
-              else if hasGitSource pkg then
-                gitPackageSource pkg
-              else
-                throw "Cannot create a package-shaped vendor source for ${pkg.name}-${pkg.version} from ${pkg.source}";
-          };
-
-        in
-        deepSeq checkedOutputHashes (lib.genAttrs' packages packageSource);
-
-      # The aggregate `linkFarm` vendor dir, one symlink per dependency package
-      # pointing at its `vendorSources` entry.
-      vendorDir =
-        let
-          keyFn = pkg: "${pkg.name}-${pkg.version}";
-
-          duplicateNameVersions = findDuplicatesBy keyFn (gitPackages cargoLock);
-
-          mkVendorEntry = pkg: {
-            name = "${pkg.name}-${pkg.version}";
-            path = vendorSources.${packageSourceKey pkg};
-          };
-
-          vendorEntries = map mkVendorEntry packages;
-        in
-        assert lib.assertMsg (isEmpty duplicateNameVersions) ''
-          Cargo.lock contains multiple git dependencies with the same name-version: ${join ", " duplicateNameVersions}
-          cargo-unit cannot generate an aggregate vendor dir for this lock without losing source identity.
-        '';
-        pkgs.linkFarm "cargo-vendor-dir" vendorEntries;
-    in
-    {
-      inherit (args) src;
-      inherit rustToolchain cargoLock;
-      cargoArgs = args.cargoArgs or [ "--workspace" ];
-      nativeBuildInputs = args.nativeBuildInputs or [ ];
-      env = args.env or { };
-      cargoExtraConfig = args.cargoExtraConfig or "";
-      inherit policy vendorDir vendorSources;
-    };
-
-  # Gate each policy check on its flag. Takes the already-normalized args and the
-  # crate name from whichever owner normalized them, so this never re-normalizes.
-  # clippy also needs to know whether the caller set `clippy.cargoArgs` (a fact
-  # the policy merge in `normalizeArgs` flattens away), so the owner threads it
-  # through. The three check derivations are built inline (each is referenced once,
-  # here) and stay lazy: a disabled check is never forced.
-  policyChecksFor =
-    {
-      args,
-      pname,
-      clippyCargoArgsSet ? false,
-    }:
-    let
-      configScript = vendorConfigScript {
-        inherit (args) cargoExtraConfig cargoLock vendorDir;
-      };
-
-      cargoAuditCheck =
-        let
-          inherit (args.policy) cargoAudit;
-          lockFile = cargoLockFile args.cargoLock;
-
-          auditFlags = toFlagSequence "--deny" cargoAudit.deny ++ toFlagSequence "--ignore" cargoAudit.ignore;
-        in
-        pkgs.runCommand "${pname}-cargo-audit"
-          {
-            nativeBuildInputs = [ pkgs.cargo-audit ];
-            # Stage the lockfile through a derivation input so its store path
-            # is realized in every builder's sandbox, not just the one that
-            # evaluated the expression.
-            inherit lockFile;
-          }
-          ''
-            export CARGO_HOME="$TMPDIR/cargo-home"
-            mkdir -p "$CARGO_HOME"
-            cp "$lockFile" "$TMPDIR/Cargo.lock"
-            cd "$TMPDIR"
-
-            cargo-audit audit \
-              --file Cargo.lock \
-              --db ${lib.escapeShellArg cargoAudit.db} \
-              --no-fetch \
-              --stale \
-              ${lib.escapeShellArgs auditFlags}
-
-            mkdir -p "$out"
-          '';
-
-      cargoMacheteCheck =
-        pkgs.runCommand "${pname}-cargo-machete"
-          (
-            {
-              nativeBuildInputs = [
-                args.rustToolchain
-                pkgs.cacert
-                pkgs.cargo-machete
-              ]
-              ++ args.nativeBuildInputs;
-              SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
-              CARGO_NET_OFFLINE = "true";
-            }
-            // args.env
-          )
-          ''
-            ${configScript}
-
-            cd ${args.src}
-
-            cargo-machete \
-              --with-metadata --skip-target-dir \
-              ${lib.escapeShellArgs args.policy.cargoMachete.extraArgs} \
-              .
-
-            mkdir -p "$out"
-          '';
-      cargoClippyCheck =
-        let
-          # If the caller already picks targets via `cargoArgs` (e.g.
-          # `--all-targets`) and didn't override `clippy.cargoArgs`, drop the
-          # policy default so we don't double up.
-          cargoTargetSelectors = [
-            "--all-targets"
-            "--lib"
-            "--bin"
-            "--bins"
-            "--example"
-            "--examples"
-            "--test"
-            "--tests"
-            "--bench"
-            "--benches"
-          ];
-
-          lacksTarget = lib.mutuallyExclusive args.cargoArgs cargoTargetSelectors;
-
-          hasLintPolicy = any nonEmpty [
-            args.policy.clippy.deniedLints
-            args.policy.clippy.allowedLints
-          ];
-
-          clippyArgs =
-            args.cargoArgs
-            ++ lib.optionals (lacksTarget || clippyCargoArgsSet) args.policy.clippy.cargoArgs
-            ++ lib.optional hasLintPolicy "--"
-            ++ clippyLintArgs args.policy;
-
-          rustFlags = lib.escapeShellArgs (
-            rustcArgsForPolicyForPlatform args.policy pkgs.stdenv.hostPlatform.config
-          );
-        in
-        pkgs.runCommand "${pname}-cargo-clippy"
-          (
-            {
-              nativeBuildInputs = [
-                args.rustToolchain
-                pkgs.cacert
-                args.policy.clippy.package
-                pkgs.stdenv.cc
-              ]
-              ++ args.nativeBuildInputs
-              ++ nativeBuildInputsForPolicy args.policy;
-              SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
-            }
-            // args.env
-          )
-          ''
-            ${configScript}
-
-            export CARGO_TARGET_DIR="$TMPDIR/cargo-target"
-
-          ''
-        + (lib.optionalString (rustFlags != "") /* bash */ ''
-          export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }${rustFlags}"
-        '')
-        + /* bash */ ''
-
-          cd ${args.src}
-
-          cargo clippy \
-            --frozen --offline \
-            ${lib.escapeShellArgs clippyArgs}
-
-          mkdir -p "$out"
-        '';
-    in
-    lib.optionalAttrs args.policy.cargoAudit.enable {
-      cargoAudit = cargoAuditCheck;
-    }
-    // lib.optionalAttrs args.policy.cargoMachete.enable {
-      cargoMachete = cargoMacheteCheck;
-    }
-    // lib.optionalAttrs args.policy.clippy.enable {
-      cargoClippy = cargoClippyCheck;
-    };
+  inherit (resolve)
+    resolveArgs
+    toolchainId
+    defaultRustToolchain
+    clippyLintFlagsFromManifest
+    policyPresets
+    ;
 
   buildPackage =
     expandedArgs:
     let
       # Every policy check and build derivation needs a crate name for its
-      # derivation name (and `meta.mainProgram`). Require it explicitly rather than
-      # papering a missing name over with a sentinel that surfaces far downstream.
-      crateName = a: a.pname or a.name or (throw "rust.buildPackage: set `pname` (or `name`).");
+      # derivation name (and `meta.mainProgram`). Require `pname` explicitly rather
+      # than papering a missing name over with a sentinel that surfaces far downstream.
+      crateName = a: a.pname or (throw "rust.buildPackage: set `pname`.");
       # Shortcut: pass `srcRoot = ./.` for a repo-owned crate whose tracked tree
       # is the build closure. Expands to the standard `gitTracked` filter, defaults
-      # `meta.mainProgram` to `pname`, and keeps `normalizeArgs`'s `cargoLock`
-      # default (`src + "/Cargo.lock"`) intact.
+      # `meta.mainProgram` to `pname`, and keeps the resolver's `cargoLock` default
+      # (`src + "/Cargo.lock"`) intact.
       rawArgs =
         if expandedArgs ? srcRoot then
           let
@@ -726,21 +58,26 @@ let
           }
         else
           expandedArgs;
-      args = normalizeArgs rawArgs;
+
+      resolved = resolveArgs rawArgs;
+      inherit (resolved)
+        context
+        policy
+        effects
+        checks
+        ;
 
       rustPlatform =
         rawArgs.rustPlatform or (pkgs.makeRustPlatform {
-          cargo = args.rustToolchain;
-          rustc = args.rustToolchain;
+          cargo = context.rustToolchain;
+          rustc = context.rustToolchain;
         });
 
-      testEnabled = args.policy.tests.enable && (rawArgs.doCheck or true);
-
-      rustcArgs = rustcArgsForPolicyForPlatform args.policy pkgs.stdenv.hostPlatform.config;
+      testEnabled = policy.tests.enable && (rawArgs.doCheck or true);
 
       cargoTestFlags =
         (rawArgs.cargoTestFlags or [ ])
-        ++ lib.optional (testEnabled && args.policy.tests.useNextest) "--no-tests=pass";
+        ++ lib.optional (testEnabled && policy.tests.useNextest) "--no-tests=pass";
       # Vendor through our own fetcher (`vendorDir` -> `static.crates.io`)
       # instead of letting nixpkgs's `importCargoLock` re-fetch each crate via
       # the legacy `crates.io/api/v1/crates/.../download` URL. The legacy
@@ -749,7 +86,7 @@ let
       # Surface the vendor dir as `cargoDeps` (absolute store path); the
       # cargo-setup hook expects `cargoVendorDir` to be in-source, not a
       # `/nix/store` path. User-supplied `cargoHash`, `cargoDeps`, or
-      # `cargoVendorDir` still wins. `normalizeArgs` already resolved `vendorDir`
+      # `cargoVendorDir` still wins. The resolver already resolved `vendorDir`
       # (honoring `sourceOverrides`), so reuse it.
       #
       # nixpkgs's `cargoSetupPostPatchHook` diffs `$cargoDeps/Cargo.lock`
@@ -757,8 +94,8 @@ let
       # per-crate symlinks, so re-attach the lockfile here.
       defaultCargoDeps = pkgs.runCommand "cargo-deps" { } ''
         mkdir -p "$out"
-        cp -RL ${args.vendorDir}/. "$out/"
-        cp ${cargoLockFile args.cargoLock} "$out/Cargo.lock"
+        cp -RL ${context.vendorDir}/. "$out/"
+        cp ${context.cargoLockPath} "$out/Cargo.lock"
       '';
 
       hasCargoMeta = rawArgs ? cargoHash || rawArgs ? cargoDeps || rawArgs ? cargoVendorDir;
@@ -777,74 +114,61 @@ let
           "vendorDir"
         ]
         // {
-          nativeBuildInputs = (rawArgs.nativeBuildInputs or [ ]) ++ nativeBuildInputsForPolicy args.policy;
+          nativeBuildInputs = (rawArgs.nativeBuildInputs or [ ]) ++ effects.linkerNativeInputs;
           inherit cargoTestFlags;
-          useNextest = testEnabled && args.policy.tests.useNextest;
+          useNextest = testEnabled && policy.tests.useNextest;
         }
         // lib.optionalAttrs (!hasCargoMeta) {
           cargoDeps = defaultCargoDeps;
         }
-        // lib.optionalAttrs (rustcArgs != [ ]) {
-          RUSTFLAGS = (lib.toList (rawArgs.RUSTFLAGS or [ ])) ++ rustcArgs;
+        // lib.optionalAttrs (effects.rustcArgsForHost != [ ]) {
+          RUSTFLAGS = (lib.toList (rawArgs.RUSTFLAGS or [ ])) ++ effects.rustcArgsForHost;
         };
 
       uncheckedPackage = rustPlatform.buildRustPackage buildArgs;
 
-      policyChecks = policyChecksFor {
-        inherit args;
+      policyChecks = checks.crate {
         pname = crateName rawArgs;
-        # The policy merge in `normalizeArgs` flattens away whether the caller set
-        # `clippy.cargoArgs`; the clippy check needs it, so read it off raw args.
-        clippyCargoArgsSet = (rawArgs.policy.clippy or { }) ? cargoArgs;
+        # The policy merge flattens away whether the caller set `clippy.cargoArgs`;
+        # the clippy check needs it, so the resolver surfaced it.
+        clippyCargoArgsSet = resolved.clippyCargoArgsExplicit;
       };
     in
     # The policy-checked wrapper: the same Rust package with the policy checks
     # attached as `passthru.tests` and symlinked under `$out/rust-policy`. Still
     # the same package identity for eval-time callers that inspect it.
-    pkgs.symlinkJoin (
-      {
-        name = "${uncheckedPackage.name}-policy-checked";
-        paths = [ uncheckedPackage ];
-        inherit (uncheckedPackage) meta;
-        passthru = (uncheckedPackage.passthru or { }) // {
-          inherit (args) policy;
-          unchecked = uncheckedPackage;
-          inherit policyChecks;
-          tests =
-            (uncheckedPackage.passthru.tests or { })
-            // policyChecks
-            // lib.optionalAttrs testEnabled { package = uncheckedPackage; };
-        };
-        postBuild =
-          let
-            linkPolicyCheck = name: check: ''ln -s ${check} "$out/rust-policy/${name}"'';
+    pkgs.symlinkJoin {
+      name = "${uncheckedPackage.name}-policy-checked";
+      paths = [ uncheckedPackage ];
+      inherit (uncheckedPackage) meta pname version;
+      passthru = (uncheckedPackage.passthru or { }) // {
+        inherit policy;
+        unchecked = uncheckedPackage;
+        inherit policyChecks;
+        tests =
+          (uncheckedPackage.passthru.tests or { })
+          // policyChecks
+          // lib.optionalAttrs testEnabled { package = uncheckedPackage; };
+      };
+      postBuild =
+        let
+          linkPolicyCheck = name: check: ''ln -s ${check} "$out/rust-policy/${name}"'';
 
-            linkPolicyChecks = lib.concatMapAttrsStringSep "\n" linkPolicyCheck policyChecks;
-          in
-          lib.optionalString (policyChecks != { }) ''
-            mkdir -p "$out/rust-policy"
-            ${linkPolicyChecks}
-          '';
-      }
-      // optionalInherits uncheckedPackage [
-        "pname"
-        "version"
-      ]
-    );
+          linkPolicyChecks = lib.concatMapAttrsStringSep "\n" linkPolicyCheck policyChecks;
+        in
+        lib.optionalString (policyChecks != { }) ''
+          mkdir -p "$out/rust-policy"
+          ${linkPolicyChecks}
+        '';
+    };
 in
 {
   inherit
     buildPackage
-    cargoLockFile
-    clippyLintArgs
-    clippyLintFlagsFromManifest
-    defaultRustToolchain
-    nativeBuildInputsForPolicy
-    normalizeArgs
-    policyChecksFor
-    rustcArgsForPolicyForPlatform
-    rustflagsFromCargoConfig
+    resolveArgs
     toolchainId
-    vendorConfigScript
+    defaultRustToolchain
+    clippyLintFlagsFromManifest
+    policyPresets
     ;
 }

--- a/lib/rust/cargo-unit.nix
+++ b/lib/rust/cargo-unit.nix
@@ -8,7 +8,6 @@ let
   inherit (builtins)
     attrNames
     elem
-    elemAt
     filter
     genericClosure
     hasAttr
@@ -26,6 +25,34 @@ let
   # prebuilt rlib was compiled with without reconstructing it by hand. The id
   # rule itself lives at the toolchain owner (`rust.toolchainId`).
   defaultToolchainId = rust.toolchainId rust.defaultRustToolchain;
+
+  # Apply the rustflags a normal `cargo build` reads from `.cargo/config.toml`,
+  # which cargoUnit otherwise ignores (it assembles rustc args itself instead of
+  # going through cargo). Parsing the config here is the only route: cargo's
+  # `cargo build --unit-graph` does NOT carry rustflags (each unit records only
+  # dependencies/features/mode/pkg_id/platform/profile/target), because cargo
+  # resolves config rustflags at compile time and applies them when it invokes
+  # rustc, which cargoUnit bypasses by invoking rustc per unit from the graph. So
+  # there is nothing in the graph to pick up automatically; we read the config.
+  # Returns the rustc args for a target triple following cargo precedence:
+  # `target.<triple>.rustflags` wins outright over `build.rustflags` (cargo does
+  # not merge the two). Flags may be a TOML array or a single whitespace-
+  # separated string. `cfg(...)` target sections and the `[env]` table are NOT
+  # honored (cargo evaluates those against the full target cfg set, which this
+  # static parse does not reproduce). A `configPath` that does not exist yields
+  # no flags, so callers may pass the path unconditionally.
+  rustflagsFromCargoConfig =
+    configPath: platform:
+    let
+      config = lib.importTOML configPath;
+      normalize =
+        flags:
+        if builtins.isList flags then flags else filter (flag: flag != "") (lib.splitString " " flags);
+      chosen = config.target.${platform}.rustflags or config.build.rustflags or null;
+    in
+    # Lazy: the `&&` short-circuits, so `config` (hence `importTOML`) is only
+    # forced when the file exists and carries rustflags.
+    if builtins.pathExists configPath && chosen != null then normalize chosen else [ ];
 
   /**
     Build a Rust workspace as one Nix derivation per Cargo rustc unit.
@@ -79,17 +106,31 @@ let
     `policyChecks`, plus the intermediate `unitGraphJson`, `unitsNix`, and `vendorDir`
     derivations for inspection.
 
-    `rust.normalizeArgs` resolves the shared "vendored cargo" context (src,
-    cargoLock, toolchain, policy, vendorDir, vendorSources) once; the two IFD
-    stages and the unit import below all read from that single result. The
-    remaining knobs (`profile`, `target`, `contentAddressed`, `cargoTargets`,
+    `rust.resolveArgs` resolves the shared bundle (context, policy, linker,
+    effects, checks) once; the two IFD stages and the unit import below read the
+    once-resolved values (configScript, toolchainId, cargoLockPath, render flags,
+    mold/clippy args, workspace checks) straight off it. The remaining knobs
+    (`profile`, `target`, `contentAddressed`, `cargoTargets`,
     `extraUnits`/`extraLibraries`, the `test*` forwarding) each have a single
     reader and are read from raw args at that use site.
   */
   buildWorkspace =
     rawArgs:
     let
-      args = rust.normalizeArgs rawArgs;
+      resolved = rust.resolveArgs rawArgs;
+      inherit (resolved)
+        context
+        effects
+        policy
+        checks
+        ;
+      # A flat view of the resolved context for the field readers below; the
+      # once-resolved values (configScript, toolchainId, cargoLockPath, render
+      # flags, mold args, clippy args, checks) are read straight off the bundle.
+      args = context // {
+        inherit policy;
+        inherit (resolved) cargoArgs;
+      };
       inherit (args) vendorDir vendorSources;
 
       workspaceRoot =
@@ -199,9 +240,7 @@ let
             );
           unitGraphFile = targetIndex: "$TMPDIR/unit-graph-${toString targetIndex}.json";
 
-          configScript = rust.vendorConfigScript {
-            inherit (args) vendorDir cargoExtraConfig cargoLock;
-          };
+          inherit (context) configScript;
         in
         pkgs.runCommand "cargo-unit-graph.json"
           (
@@ -240,26 +279,21 @@ let
               wait "$pid"
             done
 
-            nix-cargo-unit merge ${
-              lib.concatStringsSep " " (lib.imap0 (targetIndex: _: unitGraphFile targetIndex) cargoTargets)
-            } > "$out"
+            nix-cargo-unit merge ${lib.concatStringsSep " " (lib.genList unitGraphFile (length cargoTargets))} > "$out"
           '';
 
       # Second IFD stage: render `units.nix` from the unit graph above.
       unitsNix =
         let
-          toolchainId = rust.toolchainId args.rustToolchain;
+          inherit (context) toolchainId;
           contentAddressed = rawArgs.contentAddressed or true;
 
-          extraFlags =
-            lib.optional contentAddressed "--content-addressed"
-            ++ lib.optional args.policy.denyUnusedCrateDependencies "--deny-unused-crate-dependencies"
-            ++ lib.optional args.policy.denyPanics "--deny-panics";
+          extraFlags = lib.optional contentAddressed "--content-addressed" ++ effects.renderFlags;
         in
         pkgs.runCommand "cargo-units.nix"
           {
             nativeBuildInputs = [ nixCargoUnit ];
-            cargoLockForRender = rust.cargoLockFile args.cargoLock;
+            cargoLockForRender = context.cargoLockPath;
           }
           ''
             nix-cargo-unit render \
@@ -273,26 +307,12 @@ let
           '';
 
       perUnitClippyEnabled = args.policy.clippy.enable;
-      # Per-unit clippy runs `clippy-driver` directly on each non-external
-      # unit. Suppress the legacy workspace-level `cargoClippy` derivation in
-      # that mode so the same lints don't run twice and so a single source
-      # edit doesn't invalidate every other crate's clippy.
-      extraPolicyChecksFromRust = rust.policyChecksFor {
-        # A workspace has no single crate name; name the workspace-level checks
-        # explicitly rather than relying on a fallback (`crateName` requires it).
-        pname = rawArgs.pname or "cargo-unit-workspace";
-        # `args` already carries the resolved vendorDir/policy; only the clippy
-        # flag differs, since per-unit clippy replaces the workspace-level check.
-        args =
-          args
-          // lib.optionalAttrs perUnitClippyEnabled {
-            policy = args.policy // {
-              clippy = args.policy.clippy // {
-                enable = false;
-              };
-            };
-          };
-      };
+      # Workspace-level policy checks: audit + machete only. Clippy is NOT here;
+      # it runs per unit in the renderer (`clippyByPackage`), so a whole-workspace
+      # `cargo clippy` would duplicate it and make one source edit invalidate every
+      # crate's clippy. `workspaceChecks` omits it by construction (no suppression).
+      # A workspace has no single crate name; name the checks explicitly.
+      extraPolicyChecksFromRust = checks.workspace (rawArgs.pname or "cargo-unit-workspace");
       # Import the rendered units.nix with a given prebuilt-injection seam. The
       # generated (pre-seam) set is obtained by importing with empty seam args,
       # so the injection guards below can compare against the real generated keys
@@ -309,13 +329,13 @@ let
             let
               resolvedPlatform = if platform == null then pkgs.stdenv.hostPlatform.config else platform;
             in
-            rust.rustcArgsForPolicyForPlatform args.policy resolvedPlatform
+            effects.rustcArgsForPlatform resolvedPlatform
             ++ (rawArgs.extraRustcArgsForPlatform or (_platform: [ ])) platform
             # Opt-in: apply `.cargo/config.toml` rustflags (per target triple,
             # cargo precedence) so consumers do not hand-copy them into
             # `extraRustcArgs`. Appended last so explicit caller args still win.
             ++ lib.optionals (rawArgs.cargoConfigRustflags or false) (
-              rust.rustflagsFromCargoConfig (workspaceRoot + "/.cargo/config.toml") resolvedPlatform
+              rustflagsFromCargoConfig (workspaceRoot + "/.cargo/config.toml") resolvedPlatform
             );
         in
         import unitsNix (
@@ -327,7 +347,7 @@ let
             # Scanner for the opt-in panic-freedom policy. The rendered check
             # asserts this is non-null when `policy.denyPanics` is set.
             cargoUnit = nixCargoUnit;
-            extraNativeBuildInputs = args.nativeBuildInputs ++ rust.nativeBuildInputsForPolicy args.policy;
+            extraNativeBuildInputs = args.nativeBuildInputs ++ effects.linkerNativeInputs;
             # `clippy-driver` ships in the clippy package; `rustToolchain` only
             # guarantees rustc + cargo. Adding the resolved clippy package keeps
             # version drift impossible because the toolchain pins the rustc that
@@ -345,7 +365,7 @@ let
             # workspaces; `policy.clippy.deniedLints` stays as an escape hatch
             # for callers without a Cargo.toml policy.
             extraClippyLintArgs =
-              rust.clippyLintFlagsFromManifest (args.src + "/Cargo.toml") ++ rust.clippyLintArgs args.policy;
+              rust.clippyLintFlagsFromManifest (args.src + "/Cargo.toml") ++ effects.clippyLintArgs;
             clippyEnabled = perUnitClippyEnabled;
             extraPolicyChecks = extraPolicyChecksFromRust;
           }
@@ -367,7 +387,7 @@ let
       # hash (hence its key) would not match. `mkPrebuiltLibraryUnit` asserts
       # against its own `rustToolchain` arg; this is the workspace-side
       # cross-check against the toolchain the graph really used.
-      workspaceToolchainId = rust.toolchainId args.rustToolchain;
+      workspaceToolchainId = context.toolchainId;
 
       # C1: a prebuilt injection must OVERRIDE a unit/library the graph already
       # references. A key that is absent silently builds from source, defeating
@@ -469,9 +489,7 @@ let
         else
           lib.genList toString targetCount;
       namedTargetSets = lib.listToAttrs (
-        lib.imap1 (
-          targetIndex: targetName: lib.nameValuePair targetName (elemAt units.targetSets (targetIndex - 1))
-        ) targetSetNames
+        lib.zipListsWith lib.nameValuePair targetSetNames units.targetSets
       );
     in
     units
@@ -487,7 +505,6 @@ let
   buildBinary =
     {
       binary,
-      cargoArgs ? [ ],
       ...
     }@args:
     let
@@ -653,7 +670,6 @@ let
   buildBinaries =
     {
       binaries,
-      cargoArgs ? [ ],
       ...
     }@args:
     let
@@ -821,4 +837,7 @@ in
     defaultToolchainId
     mkPrebuiltLibraryUnit
     ;
+  # Named partial policies (e.g. `policyPresets.pureBuild`) for callers that build
+  # pure artifacts and want to reference one name instead of re-spelling the gates.
+  inherit (rust) policyPresets;
 }

--- a/lib/rust/policy.nix
+++ b/lib/rust/policy.nix
@@ -1,0 +1,448 @@
+# The Rust build policy: the quality/correctness gates applied to a build
+# (unused-dep denial, panic-freedom, cargo-audit, cargo-machete, clippy, tests)
+# and the linker choice, plus their consequences (rustc args, native inputs,
+# lint flags) and the workspace/crate policy-check derivations. Owns the default
+# policy and the caller-merge. The check builders run cargo in the vendored tree,
+# so the vendor module's `vendorConfigScript` / `cargoLockFile` are threaded in.
+{
+  lib,
+  pkgs,
+  clippyPackage,
+  vendorConfigScript,
+  cargoLockFile,
+}:
+let
+  inherit (builtins)
+    filter
+    removeAttrs
+    ;
+
+  inherit (lib) any;
+
+  toFlagSequence =
+    flag:
+    lib.concatMap (arg: [
+      flag
+      arg
+    ]);
+
+  nonEmpty = l: l != [ ];
+
+  # The policy schema, declared once as module options so the defaults, the
+  # caller-merge, and typo rejection (no `freeformType`, so an unknown key throws)
+  # all come from one declaration. `clippy.denyWarnings` is a write-only knob: the
+  # resolver post-filters `deniedLints` with it and drops it from the result.
+  policyModule = {
+    options = {
+      denyUnusedCrateDependencies = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Fail a unit whose declared crate dependencies are unused (rustc gate).";
+      };
+      # Opt-in: scans each unit's objects for functions that can reach a panic.
+      # Off by default because it is a best-effort gate, not a soundness proof.
+      denyPanics = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Scan each unit's objects for functions that can reach a panic (best-effort).";
+      };
+      cargoAudit = {
+        # On by default: an offline, lockfile-only runCommand (`cargo-audit audit
+        # --file Cargo.lock --no-fetch --stale`) decoupled from compilation, so it
+        # re-runs only when the lockfile or DB changes. Opt out on pure-build graphs.
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Run the offline, lockfile-only cargo-audit check.";
+        };
+        db = lib.mkOption {
+          type = lib.types.package;
+          default = pkgs.fetchFromGitHub {
+            owner = "rustsec";
+            repo = "advisory-db";
+            rev = "f2ae5fc8e5d208373b6c838f9676434525327a72";
+            hash = "sha256-iqXYpuCoWoGypnpM5ceXN748QlYeBXDtZx0uI98qFLo=";
+          };
+          description = "The advisory database cargo-audit checks against.";
+        };
+        deny = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Advisory ids/warning kinds to escalate to errors.";
+        };
+        ignore = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Advisory ids to ignore.";
+        };
+      };
+      cargoMachete = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Run cargo-machete to find unused dependencies across the workspace.";
+        };
+        extraArgs = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Extra arguments passed to cargo-machete.";
+        };
+      };
+      clippy = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Run clippy (per unit in a workspace, whole-crate otherwise).";
+        };
+        package = lib.mkOption {
+          type = lib.types.package;
+          default = clippyPackage;
+          description = "The clippy package providing clippy-driver.";
+        };
+        cargoArgs = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ "--all-targets" ];
+          description = "Target-selection args for the whole-crate `cargo clippy`.";
+        };
+        deniedLints = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Lints denied via `-D` (escape hatch; prefer Cargo.toml `[lints]`).";
+        };
+        allowedLints = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Lints allowed via `-A`.";
+        };
+        denyWarnings = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "When false, drop `warnings` from deniedLints so a warning does not fail the build.";
+        };
+      };
+      tests = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Run the crate's tests as part of the build.";
+        };
+        useNextest = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Use cargo-nextest for parallel test execution.";
+        };
+      };
+      linker = {
+        useMold = lib.mkOption {
+          type = lib.types.bool;
+          default = pkgs.stdenv.hostPlatform.isLinux;
+          description = "Link with mold on Linux.";
+        };
+      };
+    };
+  };
+
+  # Named partial policies for recurring intents, so callers reference one name
+  # instead of re-spelling the same field set. Resolved against the schema like
+  # any caller policy. `pureBuild` turns off every gate: for a pure build artifact
+  # (a cross graph, a prebuilt-injection graph) where the native graph already
+  # ran clippy/audit/machete/unused-dep over the same sources.
+  policyPresets = {
+    pureBuild = {
+      denyUnusedCrateDependencies = false;
+      cargoAudit.enable = false;
+      cargoMachete.enable = false;
+      clippy.enable = false;
+    };
+  };
+
+  # Resolve a caller's partial policy against the schema: defaults, merge, and
+  # typo rejection come from `evalModules`. `denyWarnings` is applied here by
+  # post-filtering `deniedLints` (and then dropped, so it carries no effect of its
+  # own); `_module` is stripped so the result is a plain policy record matching
+  # the historical shape.
+  resolvePolicy =
+    userPolicy:
+    let
+      evaluated =
+        (lib.evalModules {
+          modules = [
+            policyModule
+            { config = userPolicy; }
+          ];
+        }).config;
+      deniedLints =
+        if evaluated.clippy.denyWarnings then
+          evaluated.clippy.deniedLints
+        else
+          filter (lint: lint != "warnings") evaluated.clippy.deniedLints;
+    in
+    removeAttrs evaluated [ "_module" ]
+    // {
+      clippy = removeAttrs evaluated.clippy [ "denyWarnings" ] // {
+        inherit deniedLints;
+      };
+    };
+
+  # `platform` is a rust target triple (e.g. `x86_64-unknown-linux-gnu`); mold is
+  # Linux-only, so the flags are gated on a `-linux-` triple. Host builds pass
+  # `pkgs.stdenv.hostPlatform.config` rather than a sentinel, so there is one
+  # Linux test and a non-triple argument fails loudly instead of defaulting.
+  rustcArgsForPolicyForPlatform =
+    policy: platform:
+    lib.optionals (policy.linker.useMold && lib.hasInfix "-linux-" platform) [
+      "-C"
+      "link-arg=-fuse-ld=mold"
+    ];
+
+  nativeBuildInputsForPolicy = policy: lib.optional policy.linker.useMold pkgs.mold;
+
+  clippyLintArgs =
+    policy:
+    toFlagSequence "-D" policy.clippy.deniedLints ++ toFlagSequence "-A" policy.clippy.allowedLints;
+
+  # Cargo only emits `[lints.clippy]` into the unit graph's `lint_rustflags`
+  # when invoked as `cargo clippy`, not `cargo build`. Parse the workspace
+  # manifest and emit the equivalent `-D|-W|-A clippy::<lint>` flags so
+  # per-unit clippy sees the workspace lint policy.
+  clippyLintFlagsFromManifest =
+    manifestPath:
+    let
+      # `clippy::cargo` group lints invoke `cargo` to read workspace metadata.
+      # Per-unit clippy runs in a sandboxed build directory without a discoverable
+      # Cargo.toml (the unit's source closure is package-shaped), so those lints
+      # error out with "could not find Cargo.toml". Skip them here; a future
+      # workspace-level cargo-clippy check is the right home.
+      cargoGroupClippyLints = [
+        "cargo"
+        "cargo_common_metadata"
+        "multiple_crate_versions"
+        "negative_feature_names"
+        "redundant_feature_names"
+        "wildcard_dependencies"
+      ];
+
+      manifest = lib.importTOML manifestPath;
+
+      raw = manifest.workspace.lints.clippy or manifest.lints.clippy or { };
+
+      filtered = removeAttrs raw cargoGroupClippyLints;
+
+      entryFor = name: value: {
+        inherit name;
+        level = value.level or value;
+        priority = value.priority or 0;
+      };
+
+      entries = lib.mapAttrsToList entryFor filtered;
+
+      sortedEntries = lib.sortOn (v: v.priority) entries;
+
+      levelFlags = {
+        deny = "-D";
+        forbid = "-D";
+        warn = "-W";
+        allow = "-A";
+      };
+
+      entryFlags =
+        entry:
+        let
+          inherit (entry) level;
+          levelFlag =
+            levelFlags."${level}"
+              or (throw "cargoUnit: unknown clippy lint level '${level}' in ${manifestPath}");
+        in
+        [
+          levelFlag
+          "clippy::${entry.name}"
+        ];
+    in
+    lib.concatMap entryFlags sortedEntries;
+
+  # The three policy-check derivations for an already-normalized `args` + crate
+  # name. clippy also needs to know whether the caller set `clippy.cargoArgs` (a
+  # fact the policy merge flattens away), so the owner threads it through. Built
+  # lazily and gated by the `crateChecks` / `workspaceChecks` wrappers below, so a
+  # check the caller's altitude does not select is never forced.
+  checkDerivations =
+    {
+      args,
+      pname,
+      clippyCargoArgsSet ? false,
+    }:
+    let
+      configScript = vendorConfigScript {
+        inherit (args) cargoExtraConfig cargoLock vendorDir;
+      };
+
+      cargoAuditCheck =
+        let
+          inherit (args.policy) cargoAudit;
+          lockFile = cargoLockFile args.cargoLock;
+
+          auditFlags = toFlagSequence "--deny" cargoAudit.deny ++ toFlagSequence "--ignore" cargoAudit.ignore;
+        in
+        pkgs.runCommand "${pname}-cargo-audit"
+          {
+            nativeBuildInputs = [ pkgs.cargo-audit ];
+            # Stage the lockfile through a derivation input so its store path
+            # is realized in every builder's sandbox, not just the one that
+            # evaluated the expression.
+            inherit lockFile;
+          }
+          ''
+            export CARGO_HOME="$TMPDIR/cargo-home"
+            mkdir -p "$CARGO_HOME"
+            cp "$lockFile" "$TMPDIR/Cargo.lock"
+            cd "$TMPDIR"
+
+            cargo-audit audit \
+              --file Cargo.lock \
+              --db ${lib.escapeShellArg cargoAudit.db} \
+              --no-fetch \
+              --stale \
+              ${lib.escapeShellArgs auditFlags}
+
+            mkdir -p "$out"
+          '';
+
+      cargoMacheteCheck =
+        pkgs.runCommand "${pname}-cargo-machete"
+          (
+            {
+              nativeBuildInputs = [
+                args.rustToolchain
+                pkgs.cacert
+                pkgs.cargo-machete
+              ]
+              ++ args.nativeBuildInputs;
+              SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+              CARGO_NET_OFFLINE = "true";
+            }
+            // args.env
+          )
+          ''
+            ${configScript}
+
+            cd ${args.src}
+
+            cargo-machete \
+              --with-metadata --skip-target-dir \
+              ${lib.escapeShellArgs args.policy.cargoMachete.extraArgs} \
+              .
+
+            mkdir -p "$out"
+          '';
+      cargoClippyCheck =
+        let
+          # If the caller already picks targets via `cargoArgs` (e.g.
+          # `--all-targets`) and didn't override `clippy.cargoArgs`, drop the
+          # policy default so we don't double up.
+          cargoTargetSelectors = [
+            "--all-targets"
+            "--lib"
+            "--bin"
+            "--bins"
+            "--example"
+            "--examples"
+            "--test"
+            "--tests"
+            "--bench"
+            "--benches"
+          ];
+
+          lacksTarget = lib.mutuallyExclusive args.cargoArgs cargoTargetSelectors;
+
+          hasLintPolicy = any nonEmpty [
+            args.policy.clippy.deniedLints
+            args.policy.clippy.allowedLints
+          ];
+
+          clippyArgs =
+            args.cargoArgs
+            ++ lib.optionals (lacksTarget || clippyCargoArgsSet) args.policy.clippy.cargoArgs
+            ++ lib.optional hasLintPolicy "--"
+            ++ clippyLintArgs args.policy;
+
+          rustFlags = lib.escapeShellArgs (
+            rustcArgsForPolicyForPlatform args.policy pkgs.stdenv.hostPlatform.config
+          );
+        in
+        pkgs.runCommand "${pname}-cargo-clippy"
+          (
+            {
+              nativeBuildInputs = [
+                args.rustToolchain
+                pkgs.cacert
+                args.policy.clippy.package
+                pkgs.stdenv.cc
+              ]
+              ++ args.nativeBuildInputs
+              ++ nativeBuildInputsForPolicy args.policy;
+              SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+            }
+            // args.env
+          )
+          ''
+            ${configScript}
+
+            export CARGO_TARGET_DIR="$TMPDIR/cargo-target"
+
+          ''
+        + (lib.optionalString (rustFlags != "") /* bash */ ''
+          export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }${rustFlags}"
+        '')
+        + /* bash */ ''
+
+          cd ${args.src}
+
+          cargo clippy \
+            --frozen --offline \
+            ${lib.escapeShellArgs clippyArgs}
+
+          mkdir -p "$out"
+        '';
+    in
+    {
+      inherit cargoAuditCheck cargoMacheteCheck cargoClippyCheck;
+    };
+
+  # The per-crate gate set: clippy runs as a whole-crate `cargo clippy`. Each
+  # check is gated on its enable flag and stays lazy.
+  crateChecks =
+    {
+      args,
+      pname,
+      clippyCargoArgsSet ? false,
+    }:
+    let
+      checks = checkDerivations { inherit args pname clippyCargoArgsSet; };
+    in
+    lib.optionalAttrs args.policy.cargoAudit.enable { cargoAudit = checks.cargoAuditCheck; }
+    // lib.optionalAttrs args.policy.cargoMachete.enable { cargoMachete = checks.cargoMacheteCheck; }
+    // lib.optionalAttrs args.policy.clippy.enable { cargoClippy = checks.cargoClippyCheck; };
+
+  # The workspace gate set: audit + machete only. A workspace runs clippy per
+  # unit in the renderer (`clippyByPackage`), so a whole-workspace `cargo clippy`
+  # is deliberately absent here rather than suppressed after the fact.
+  workspaceChecks =
+    { args, pname }:
+    let
+      checks = checkDerivations { inherit args pname; };
+    in
+    lib.optionalAttrs args.policy.cargoAudit.enable { cargoAudit = checks.cargoAuditCheck; }
+    // lib.optionalAttrs args.policy.cargoMachete.enable { cargoMachete = checks.cargoMacheteCheck; };
+in
+{
+  inherit
+    resolvePolicy
+    policyPresets
+    rustcArgsForPolicyForPlatform
+    nativeBuildInputsForPolicy
+    clippyLintArgs
+    clippyLintFlagsFromManifest
+    crateChecks
+    workspaceChecks
+    ;
+}

--- a/lib/rust/resolve.nix
+++ b/lib/rust/resolve.nix
@@ -1,0 +1,160 @@
+# The resolution boundary for the Rust build: turn a caller's raw args into one
+# resolved bundle, applying every multiply-read default/transform/decision once.
+# Owns the toolchain-id rule and the default toolchain, wires the vendoring and
+# policy modules together, and re-exposes their surfaces so both build backends
+# read from one place.
+{
+  lib,
+  pkgs,
+  clippyPackage,
+  rustToolchain,
+  writePythonApplication,
+}:
+let
+  inherit (builtins) baseNameOf toString;
+
+  vendorLib = import ./vendor.nix { inherit lib pkgs writePythonApplication; };
+
+  policyLib = import ./policy.nix {
+    inherit lib pkgs clippyPackage;
+    inherit (vendorLib) vendorConfigScript cargoLockFile;
+  };
+
+  inherit (vendorLib) cargoLockFile vendorConfigScript;
+  inherit (policyLib)
+    clippyLintArgs
+    clippyLintFlagsFromManifest
+    crateChecks
+    nativeBuildInputsForPolicy
+    policyPresets
+    resolvePolicy
+    rustcArgsForPolicyForPlatform
+    workspaceChecks
+    ;
+
+  defaultRustToolchain = rustToolchain;
+
+  # A toolchain's id is the basename of its store path. It is baked into every
+  # unit hash by the renderer, so it is computed once here (in `context`), at the
+  # toolchain owner, rather than re-derived at the render call, the workspace-side
+  # injection cross-check, and the prebuilt builder.
+  toolchainId = toolchain: baseNameOf (toString toolchain);
+
+  # Resolve a caller's raw args into the shared build context and its derived
+  # decisions, once. Returns:
+  #   context  — the reified "run cargo in the vendored tree" context: the fields
+  #              that always travel together (src, toolchain, vendor dir/sources,
+  #              env, native inputs, cargo config) plus the lockfile path,
+  #              toolchain id, and cargo config script resolved once.
+  #   policy   — the resolved quality-gate decisions (typed schema; `linker` is a
+  #              sub-field of it).
+  #   effects  — policy consequences computed once: rustc args (mold),
+  #              native inputs, clippy lint flags, renderer deny-flags.
+  #   checks   — the two altitude-appropriate policy-check sets, bound to this
+  #              context: `crate` (audit+machete+clippy) and `workspace`
+  #              (audit+machete; per-unit clippy runs in the renderer).
+  #   cargoArgs / clippyCargoArgsExplicit — facts the policy merge flattens away.
+  # The single-reader knobs (profile, target, cargoTargets, ...) are NOT here;
+  # each is read at its one use site.
+  resolveArgs =
+    args:
+    let
+      rustToolchain' = args.rustToolchain or defaultRustToolchain;
+      cargoLock = args.cargoLock or (args.src + "/Cargo.lock");
+      outputHashes = args.outputHashes or { };
+      sourceOverrides = args.sourceOverrides or { };
+
+      policy = resolvePolicy (args.policy or { });
+
+      # Lazy: a lockfile-only consumer never forces these derivations.
+      inherit (vendorLib.mkVendor { inherit cargoLock outputHashes sourceOverrides; })
+        vendorSources
+        vendorDir
+        ;
+
+      cargoArgs = args.cargoArgs or [ "--workspace" ];
+      nativeBuildInputs = args.nativeBuildInputs or [ ];
+      env = args.env or { };
+      cargoExtraConfig = args.cargoExtraConfig or "";
+
+      context = {
+        inherit (args) src;
+        rustToolchain = rustToolchain';
+        inherit
+          vendorDir
+          vendorSources
+          cargoExtraConfig
+          nativeBuildInputs
+          env
+          ;
+        cargoLockPath = cargoLockFile cargoLock;
+        toolchainId = toolchainId rustToolchain';
+        configScript = vendorConfigScript { inherit cargoExtraConfig cargoLock vendorDir; };
+      };
+
+      effects = {
+        rustcArgsForPlatform = rustcArgsForPolicyForPlatform policy;
+        rustcArgsForHost = rustcArgsForPolicyForPlatform policy pkgs.stdenv.hostPlatform.config;
+        linkerNativeInputs = nativeBuildInputsForPolicy policy;
+        clippyLintArgs = clippyLintArgs policy;
+        renderFlags =
+          lib.optional policy.denyUnusedCrateDependencies "--deny-unused-crate-dependencies"
+          ++ lib.optional policy.denyPanics "--deny-panics";
+      };
+
+      # The flat record the policy-check builders still consume internally.
+      checkArgs = {
+        inherit (args) src;
+        rustToolchain = rustToolchain';
+        inherit
+          cargoLock
+          cargoArgs
+          nativeBuildInputs
+          env
+          cargoExtraConfig
+          policy
+          vendorDir
+          ;
+      };
+
+      checks = {
+        crate =
+          {
+            pname,
+            clippyCargoArgsSet ? false,
+          }:
+          crateChecks {
+            args = checkArgs;
+            inherit pname clippyCargoArgsSet;
+          };
+        workspace =
+          pname:
+          workspaceChecks {
+            args = checkArgs;
+            inherit pname;
+          };
+      };
+    in
+    {
+      inherit
+        context
+        policy
+        effects
+        checks
+        cargoArgs
+        ;
+      clippyCargoArgsExplicit = (args.policy.clippy or { }) ? cargoArgs;
+    };
+in
+# The `rust` surface consumed by the cargo-unit side: the resolver bundle plus
+# the few helpers that operate outside it (toolchain id/default for prebuilt
+# units, the manifest clippy-lint reader, the policy presets).
+{
+  inherit
+    resolveArgs
+    toolchainId
+    defaultRustToolchain
+    clippyLintFlagsFromManifest
+    policyPresets
+    ;
+}

--- a/lib/rust/vendor.nix
+++ b/lib/rust/vendor.nix
@@ -1,0 +1,321 @@
+# Vendoring for the cargo-unit / buildPackage pipeline: turn a `Cargo.lock` into
+# a package-shaped vendor directory (one entry per dependency) plus the cargo
+# config script that points cargo at it. Owns the lockfile-path coercion and all
+# registry/git source fetching. Pure function of its inputs; nothing here reads
+# build policy or toolchain.
+{
+  lib,
+  pkgs,
+  writePythonApplication,
+}:
+let
+  inherit (builtins)
+    attrNames
+    attrValues
+    deepSeq
+    elemAt
+    filter
+    getAttr
+    hasAttr
+    match
+    toJSON
+    ;
+
+  inherit (lib)
+    join
+    subtractLists
+    ;
+
+  inherit (import ../util/lists.nix { inherit lib; }) findDuplicatesBy;
+
+  joinLines = join "\n";
+
+  # A `cargoLock` reference is either `{ lockFile = <path>; }` or a bare path.
+  cargoLockFile = cargoLock: cargoLock.lockFile or cargoLock;
+
+  dependencyPackages =
+    cargoLock:
+    let
+      lock = lib.importTOML (cargoLockFile cargoLock);
+    in
+    filter (pkg: pkg ? source) (lock.package or [ ]);
+
+  hasGitSource = pkg: lib.hasPrefix "git+" pkg.source;
+
+  gitPackages = cargoLock: filter hasGitSource (dependencyPackages cargoLock);
+
+  packageSourceKey = pkg: "${pkg.source}#${pkg.name}@${pkg.version}";
+
+  # Both registry shapes resolve to the same CDN artifact. `static.crates.io` is
+  # the direct CloudFront URL cargo's sparse protocol uses; the older
+  # `api.crates.io/api/v1/crates/.../download` endpoint just 302s here and, as
+  # of 2026-05, rejects curl's default User-Agent with HTTP 403.
+  registryDownloadUrls =
+    let
+      cratesIoDownloadUrl =
+        pkg: "https://static.crates.io/crates/${pkg.name}/${pkg.name}-${pkg.version}.crate";
+    in
+    {
+      "registry+https://github.com/rust-lang/crates.io-index" = cratesIoDownloadUrl;
+      "sparse+https://index.crates.io/" = cratesIoDownloadUrl;
+    };
+
+  parseGitSource =
+    source:
+    let
+      parts = match ''git\+([^?]+)(\?(rev|tag|branch)=([^#]*))?#(.*)'' source;
+    in
+    if parts == null then
+      throw "rust: cannot parse git source string `${source}` from Cargo.lock"
+    else
+      {
+        url = elemAt parts 0;
+        refType = elemAt parts 2;
+        ref = elemAt parts 3;
+        sha = elemAt parts 4;
+      };
+
+  vendorConfigScript =
+    {
+      cargoExtraConfig,
+      cargoLock,
+      vendorDir,
+    }:
+    let
+      cargoExtraConfigFile = pkgs.writeText "cargo-extra-config.toml" cargoExtraConfig;
+
+      gitSources = lib.unique (
+        map (pkg: parseGitSource pkg.source // { inherit (pkg) source; }) (gitPackages cargoLock)
+      );
+
+      # The default vendored-sources config, emitted when the vendor dir carries
+      # no `.cargo/config.toml` of its own (the aggregate `linkFarm` never does).
+      vendorConfigFile = pkgs.writeText "cargo-vendor-config.toml" ''
+        [source.crates-io]
+        replace-with = "vendored-sources"
+
+        [source.vendored-sources]
+        directory = "${vendorDir}"
+      '';
+
+      # One `[source."<git>"]` table per git dependency, each replacing that git
+      # source with the vendored copy. Rendered at eval time and `cat` in, rather
+      # than printf'd table by table in the builder.
+      gitSourceBlock =
+        git:
+        joinLines (
+          [
+            ''[source."${git.source}"]''
+            "git = ${toJSON git.url}"
+          ]
+          ++ lib.optional (git.refType != null) "${git.refType} = ${toJSON git.ref}"
+          ++ [ ''replace-with = "vendored-sources"'' ]
+        );
+      gitSourceConfigFile = pkgs.writeText "cargo-git-sources.toml" (
+        lib.concatMapStringsSep "\n\n" gitSourceBlock gitSources + "\n"
+      );
+    in
+    ''
+      export CARGO_HOME="$TMPDIR/cargo-home"
+      mkdir -p "$CARGO_HOME"
+
+      if [ -f "${vendorDir}/.cargo/config.toml" ]; then
+        sed 's|directory = "cargo-vendor-dir"|directory = "${vendorDir}"|' \
+          "${vendorDir}/.cargo/config.toml" > "$CARGO_HOME/config.toml"
+      else
+        cat ${vendorConfigFile} > "$CARGO_HOME/config.toml"
+      fi
+    ''
+    + lib.optionalString (gitSources != [ ]) ''
+
+      printf '\n' >> "$CARGO_HOME/config.toml"
+      cat ${gitSourceConfigFile} >> "$CARGO_HOME/config.toml"
+    ''
+    + lib.optionalString (cargoExtraConfig != "") ''
+
+      printf '\n' >> "$CARGO_HOME/config.toml"
+      cat ${cargoExtraConfigFile} >> "$CARGO_HOME/config.toml"
+    '';
+
+  # One package-shaped vendored source directory per dependency, keyed by
+  # `packageSourceKey`, plus the aggregate `linkFarm` vendor dir that symlinks
+  # each entry under `<name>-<version>`. Registry crates are fetched from
+  # `static.crates.io`; git crates are fetched and reduced to the single
+  # referenced package. Vendor resolution stays lazy, so lockfile-only consumers
+  # never force these derivations.
+  mkVendor =
+    {
+      cargoLock,
+      outputHashes,
+      sourceOverrides,
+    }:
+    let
+      packages = dependencyPackages cargoLock;
+
+      vendorSources =
+        let
+          checkedOutputHashes =
+            let
+              gitPackageSources = map (pkg: pkg.source) (gitPackages cargoLock);
+              outputHashKeys = attrNames outputHashes;
+
+              missing = subtractLists outputHashKeys gitPackageSources;
+              unused = subtractLists gitPackageSources outputHashKeys;
+            in
+            assert lib.assertMsg (missing == [ ]) ''
+              outputHashes is missing hashes for git source strings in Cargo.lock: ${join ", " missing}
+              Key each git hash by the exact Cargo.lock source string, for example:
+              outputHashes."git+https://github.com/owner/repo#rev" = "sha256-...";
+            '';
+            assert lib.assertMsg (unused == [ ]) ''
+              outputHashes contains keys that are not git source strings in Cargo.lock: ${join ", " unused}
+              Key each git hash by the exact Cargo.lock source string, for example:
+              outputHashes."git+https://github.com/owner/repo#rev" = "sha256-...";
+            '';
+            outputHashes;
+          # Flatten workspace inheritance in a vendored Cargo.toml before rustc sees it.
+          # Vendored from nixpkgs so a downstream rename of
+          # `pkgs/build-support/rust/replace-workspace-values.py` doesn't surface as a
+          # `readFile` error here; `ix.writePythonApplication` also runs ty on the body
+          # at build time, which the upstream `pkgs.writers.writePython3` path did not.
+          replaceWorkspaceValues = writePythonApplication {
+            name = "replace-workspace-values";
+            src = ./replace-workspace-values.py;
+            python = pkgs.python314.withPackages (
+              ps:
+              attrValues {
+                inherit (ps) tomli tomli-w;
+              }
+            );
+          };
+
+          registryPackageSource =
+            pkg:
+            let
+              crateTarball = pkgs.fetchurl {
+                name = "crate-${pkg.name}-${pkg.version}.tar.gz";
+                url = (getAttr pkg.source registryDownloadUrls) pkg;
+                # Cargo verifies `.cargo-checksum.json` against the hex digest from
+                # Cargo.lock, and that file is filled from `crateTarball.outputHash`
+                # below. Switching to `hash = <SRI>` would make `outputHash` an SRI
+                # string and break cargo's check, so the registry tarball stays on
+                # the hex-valued `sha256` attr.
+                # ast-grep-ignore: prefer-sri-hash
+                sha256 = pkg.checksum;
+              };
+            in
+            assert lib.assertMsg (
+              pkg ? checksum
+            ) "Package ${pkg.name} ${pkg.version} is missing a Cargo.lock checksum.";
+            pkgs.runCommand "${pkg.name}-${pkg.version}" { } ''
+              mkdir "$out"
+              tar xf ${crateTarball} -C "$out" --strip-components=1
+              printf '{"files":{},"package":"${crateTarball.outputHash}"}' > "$out/.cargo-checksum.json"
+            '';
+
+          gitPackageSource =
+            pkg:
+            let
+              git = parseGitSource pkg.source;
+
+              gitHash =
+                checkedOutputHashes.${pkg.source} or (throw ''
+                  No hash was found while vendoring the git dependency ${pkg.name}-${pkg.version}.
+                  Add outputHashes."${pkg.source}".
+                '');
+              tree =
+                sourceOverrides.${pkg.source} or (pkgs.fetchgit {
+                  inherit (git) url;
+                  rev = git.sha;
+                  hash = gitHash;
+                  nativeBuildInputs = lib.optional (lib.hasPrefix "ssh://" git.url) pkgs.openssh;
+                });
+            in
+            pkgs.runCommand "${pkg.name}-${pkg.version}"
+              {
+                nativeBuildInputs = [
+                  pkgs.cargo
+                  pkgs.jaq
+                ];
+              }
+              ''
+                tree=${tree}
+                crateCargoTOML=""
+
+                if [ -f "$tree/Cargo.toml" ]; then
+                  crateCargoTOML=$(cargo metadata --format-version 1 --no-deps --manifest-path "$tree/Cargo.toml" | \
+                    jaq -r '.packages[] | select(.name == "${pkg.name}") | .manifest_path' || :)
+                fi
+
+                if [ -z "$crateCargoTOML" ]; then
+                  while IFS= read -r manifest; do
+                    crateCargoTOML=$(cargo metadata --format-version 1 --no-deps --manifest-path "$manifest" | \
+                      jaq -r '.packages[] | select(.name == "${pkg.name}") | .manifest_path' || :)
+                    [ -n "$crateCargoTOML" ] && break
+                  done < <(find "$tree" -name Cargo.toml)
+                fi
+
+                if [ -z "$crateCargoTOML" ]; then
+                  echo "Cannot find ${pkg.name}-${pkg.version} in ${pkg.source}" >&2
+                  exit 1
+                fi
+
+                crateRoot=$(dirname "$crateCargoTOML")
+                cp -prvL "$crateRoot" "$out" || echo "Warning: certain files could not be copied" >&2
+                chmod -R u+w "$out"
+
+                if grep -q workspace "$out/Cargo.toml"; then
+                  ${lib.getExe replaceWorkspaceValues} "$out/Cargo.toml" "$(cargo metadata --format-version 1 --no-deps --manifest-path "$crateCargoTOML" | jaq -r .workspace_root)/Cargo.toml"
+                fi
+
+                printf '{"files":{},"package":null}' > "$out/.cargo-checksum.json"
+              '';
+
+          # Every package here carries a `source` (`dependencyPackages` filtered on
+          # it), so map each straight to its vendored package directory.
+          packageSource = pkg: {
+            name = packageSourceKey pkg;
+            value =
+              if hasAttr pkg.source registryDownloadUrls then
+                registryPackageSource pkg
+              else if hasGitSource pkg then
+                gitPackageSource pkg
+              else
+                throw "Cannot create a package-shaped vendor source for ${pkg.name}-${pkg.version} from ${pkg.source}";
+          };
+
+        in
+        deepSeq checkedOutputHashes (lib.genAttrs' packages packageSource);
+
+      # The aggregate `linkFarm` vendor dir, one symlink per dependency package
+      # pointing at its `vendorSources` entry.
+      vendorDir =
+        let
+          keyFn = pkg: "${pkg.name}-${pkg.version}";
+
+          duplicateNameVersions = findDuplicatesBy keyFn (gitPackages cargoLock);
+
+          mkVendorEntry = pkg: {
+            name = "${pkg.name}-${pkg.version}";
+            path = vendorSources.${packageSourceKey pkg};
+          };
+
+          vendorEntries = map mkVendorEntry packages;
+        in
+        assert lib.assertMsg (duplicateNameVersions == [ ]) ''
+          Cargo.lock contains multiple git dependencies with the same name-version: ${join ", " duplicateNameVersions}
+          cargo-unit cannot generate an aggregate vendor dir for this lock without losing source identity.
+        '';
+        pkgs.linkFarm "cargo-vendor-dir" vendorEntries;
+    in
+    {
+      inherit vendorSources vendorDir;
+    };
+in
+{
+  inherit
+    cargoLockFile
+    vendorConfigScript
+    mkVendor
+    ;
+}

--- a/lib/rust/workspace.nix
+++ b/lib/rust/workspace.nix
@@ -156,8 +156,9 @@ let
         else
           null;
       isCross = target != null;
+      cargoUnit = cargoUnitFor workspacePkgs;
     in
-    (cargoUnitFor workspacePkgs).buildWorkspace (
+    cargoUnit.buildWorkspace (
       {
         pname = "ix-rust-workspace${lib.optionalString isCross "-${target}"}";
         inherit src;
@@ -255,12 +256,7 @@ let
         # re-running clippy/audit/machete that the native graph already covers.
         policy =
           if isCross then
-            {
-              denyUnusedCrateDependencies = false;
-              cargoAudit.enable = false;
-              cargoMachete.enable = false;
-              clippy.enable = false;
-            }
+            cargoUnit.policyPresets.pureBuild
           else
             {
               denyUnusedCrateDependencies = true;

--- a/sdk/rust/default.nix
+++ b/sdk/rust/default.nix
@@ -148,15 +148,10 @@ let
     # the unit hash, so this must equal ix's `public-rlib`.
     profile = "public-rlib";
     # Per-unit clippy / unused-dep / audit gates do not apply to a prebuilt
-    # artifact, and the stub is never compiled, so disable them here. (They do
+    # artifact, and the stub is never compiled, so disable them all. (They do
     # NOT affect the unit hash; that is purely metadata + lint_rustflags +
     # profile + deps + toolchain.)
-    policy = {
-      denyUnusedCrateDependencies = false;
-      cargoAudit.enable = false;
-      cargoMachete.enable = false;
-      clippy.enable = false;
-    };
+    policy = cargoUnit.policyPresets.pureBuild;
     # exportReferencesGraph (the closure-exclusion proof below) does not support
     # CA derivations; the unit hash is independent of this flag.
     contentAddressed = false;


### PR DESCRIPTION
## Summary

Restructures `lib/rust/` around a single resolution boundary. It had no single point of control — defaults, normalization, and decisions were spread across the build pipeline, and a handful of values (the src/lockfile/toolchain/vendor "clump", the mold linker args, the toolchain id, the cargo config script) were re-derived at many call sites. This splits it into one-owner modules behind a single `resolveArgs`.

Pure internal reshape: **no unit hash or drvPath changes**, verified byte-identical against `main` (see Verification).

## lib/rust modules

- **`vendor.nix`** — `Cargo.lock` parsing + package-shaped vendoring + the cargo config script.
- **`policy.nix`** — the build policy as a **typed schema** (`lib.evalModules`, so defaults, merge, and typo-rejection come from one declaration), named `policyPresets`, the policy *effects*, and the policy-check builders split by altitude.
- **`resolve.nix`** — `resolveArgs → { context, policy, effects, checks }`. Reifies the vendored-compile **context** (lockfile path, toolchain id, cargo config script resolved **once**, not re-derived per consumer) and the policy **effects** (mold rustc args, clippy lint args, render deny-flags).
- **`build.nix`** — now just `buildPackage`, consuming the bundle.
- **`cargo-unit.nix`** — reads the once-resolved `context`/`effects`/`checks` instead of re-deriving them; `rustflagsFromCargoConfig` rehomed here (its only consumer).

Knock-on cleanups: the cross graph and `sdk/rust` reference `policyPresets.pureBuild` instead of re-spelling the gate disables; `policyChecksFor` split into `crate` (audit+machete+clippy) vs `workspace` (audit+machete) altitudes, deleting the `clippy.enable = false` suppression hack the workspace path used; `pname` is required (dropped the `name` fallback); idiom nits (`genList`, `zipListsWith`, dead bindings).

## ast-grep

`no-deprecated-iflist-empty` narrowed to the `lib.optional` case: `if cond then [ x ] else [ ]` → `lib.optional cond x` still flags, but list-valued `then` branches (a bare variable or multi-element literal, which would be `lib.optionals`) no longer do — spelling `lib.optionals` on an opaque expression often obscures rather than clarifies. Test updated.

## Other

Fixes a `lib.checkAssertWarn` → `lib.asserts.checkAssertWarn` typo in `lib/minecraft/dimension-type.nix` (not a top-level `lib` attr) that broke the eval assertion bundle / `nix flake check`.

## Verification

- `nix run .#lint`: green (ast-grep, ast-grep-test, deadnix, statix, nixfmt).
- **Byte-identical drvPaths** before/after on top of current `main` (`--no-eval-cache`) across the workspace binaries and libraries, `units.{default,unitGraphJson,unitsNix,vendorDir,policyChecks}`, the SDK prebuilt-injection unit, the per-crate policy checks, and the cross-darwin targets — no Rust crate rebuilds. The typed-policy resolution was also asserted to match the prior hand-merge (default `deniedLints == []`, `denyWarnings` filtering, package identity), and the altitude split to expose `{cargoAudit,cargoClippy,cargoMachete}` for a crate vs `{cargoAudit,cargoMachete}` for a workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `lib/rust` argument resolution into a single resolver boundary
> - Extracts policy, vendoring, and toolchain logic from [build.nix](https://github.com/indexable-inc/index/pull/887/files#diff-8ab3484d4c25eaf4ab0beac36848ba87229282d10d3524b969f90a880b330dab) into three new modules: [resolve.nix](https://github.com/indexable-inc/index/pull/887/files#diff-01eebebfe941e24fad4962a02d46acd8fb6e31ea2ccab661777c0c10c9d427fc), [policy.nix](https://github.com/indexable-inc/index/pull/887/files#diff-1e9fc9e82126fab41f36b73b16145d577144b54f6de555bd23656741a3100cbf), and [vendor.nix](https://github.com/indexable-inc/index/pull/887/files#diff-a68ba2f291e368b8545afebfed95122fe35b497c0e4e6be7aae8ca53864a61b7). `build.nix` becomes a thin orchestrator calling `resolveArgs`.
> - Rustc flags, vendor paths, linker inputs, and policy checks are now derived from a single resolved bundle rather than computed inline across multiple call sites.
> - Narrows the `no-deprecated-iflist-empty` lint rule to flag only single-element list literal then-branches (`if cond then [ x ] else [ ]`).
> - Risk: Several helpers are no longer exported from `build.nix`, and callers must now supply `pname` explicitly (fallback to `name` is removed).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b47c9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->