### PR TITLE
feat(mcp): decode sh stdout as JSON with Output.json/jsonl

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1868,6 +1868,19 @@ let
         direct = await sh("printf hi", cwd=".")
         assert direct.ok and direct.text == "hi", repr(direct.text)
 
+        # Structured stdout decodes straight to Python (the polars on-ramp).
+        doc = await sh.sh("printf '%s' '{\"a\": 1, \"b\": [2, 3]}'", cwd=".")
+        assert doc.json() == {"a": 1, "b": [2, 3]}, doc.json()
+        rows = await sh.sh("printf '%s\\n%s\\n' '{\"n\": 1}' '{\"n\": 2}'", cwd=".")
+        assert rows.jsonl() == [{"n": 1}, {"n": 2}], rows.jsonl()
+        # A failed command raises ShellError from json(), never a decode error.
+        try:
+            (await sh.sh("echo nope; exit 4", cwd=".")).json()
+        except sh.ShellError as exc:
+            assert exc.output.code == 4, exc.output.code
+        else:
+            raise SystemExit("expected ShellError from json() on a non-zero exit")
+
         print("sh-ok", sh.__version__)
 
 

--- a/packages/mcp/src/sh/sh/__init__.py
+++ b/packages/mcp/src/sh/sh/__init__.py
@@ -29,6 +29,21 @@ The :class:`Output` also exposes the parts programmatically::
     out.text     # combined stdout+stderr, escape codes stripped
     out.raw      # the same, with the original ANSI color preserved
     out.cmd      # the command that was run
+    out.lines()  # out.text split into lines
+    out.json()   # parse out.text as one JSON document
+    out.jsonl()  # parse out.text as JSON Lines (one value per line)
+
+For a command that emits structured output, decode it straight into a polars
+DataFrame without a hand-written ``json.loads``::
+
+    import polars as pl
+    prs = (await sh("gh pr list --json number,title,state", cwd=".")).json()
+    pl.DataFrame(prs)
+    # JSON Lines (cargo, nix --log-format internal-json) -> .jsonl()
+    msgs = (await sh("cargo metadata --format-version 1", cwd=".")).json()
+
+``json``/``jsonl`` raise :class:`ShellError` when the command failed, so a broken
+``gh ... --json`` surfaces its real error instead of a confusing decode failure.
 
 stdout and stderr are merged in emission order (terminal-style). A non-zero exit
 is surfaced, never swallowed: the model view appends an ``[exit N]`` marker, and
@@ -39,6 +54,7 @@ from __future__ import annotations
 
 import asyncio
 import html as _html
+import json as _json
 import os
 import re
 import shlex
@@ -139,6 +155,31 @@ class Output(_ResultBase):
     def lines(self) -> list[str]:
         """The escape-stripped output split into lines (trailing newline dropped)."""
         return self.text.splitlines()
+
+    def json(self):
+        """Parse the command's stdout as a single JSON document.
+
+        For a tool with a JSON mode (``gh ... --json``, ``cargo metadata``,
+        ``nix eval --json``): ``(await sh(...)).json()`` hands back the decoded
+        Python value, ready for ``pl.DataFrame(...)``. Raises :class:`ShellError`
+        if the command exited non-zero (so the real failure surfaces, not a
+        :class:`json.JSONDecodeError` over an error message), and
+        :class:`json.JSONDecodeError` if the output is not valid JSON.
+        """
+        if not self.ok:
+            raise ShellError(self)
+        return _json.loads(self.text)
+
+    def jsonl(self) -> list:
+        """Parse stdout as JSON Lines: one JSON value per non-empty line.
+
+        For tools that stream line-delimited JSON (``cargo --message-format
+        json``, ``nix ... --log-format internal-json``). Same non-zero guard as
+        :meth:`json`; blank lines are skipped.
+        """
+        if not self.ok:
+            raise ShellError(self)
+        return [_json.loads(line) for line in self.text.splitlines() if line.strip()]
 
     def _render_text(self) -> str:
         body = self.text


### PR DESCRIPTION
-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Output.json()` and `Output.jsonl()` methods to decode shell stdout as JSON
> - Adds `Output.json()` to parse a command's stdout as a single JSON document, raising `ShellError` on non-zero exit instead of surfacing `JSONDecodeError` from error text.
> - Adds `Output.jsonl()` to parse stdout as newline-delimited JSON, returning a list of decoded values and skipping blank lines.
> - Both methods are tested in [packages/mcp/default.nix](https://github.com/indexable-inc/index/pull/889/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) covering success paths and error propagation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ccc1ef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->