### PR TITLE
mcp: unify content grep on fff, render rich results as polars tables

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -697,6 +697,28 @@ let
     except fff.FffError as exc:
         assert "subdirectory" in str(exc), f"unhelpful home-dir error: {exc}"
 
+    # mode="smart" (the default) runs a query as regex when it holds regex
+    # metacharacters and as a fast literal otherwise: an alternation matches with
+    # no mode= (the old plain default silently matched nothing), while an
+    # ordinary literal with an unbalanced paren falls back to literal, never errors.
+    assert fff.grep("greetings|fn main", path=root).matches, "smart default missed the alternation"
+    assert fff.grep("greetings|fn main", path=root, mode="plain").matches == [], (
+        "plain mode must treat the alternation literally"
+    )
+    assert fff.grep("fn main(", path=root).matches, "smart must fall back to literal for an unbalanced paren"
+
+    # The flat results opt into the kernel table protocol (_ix_to_frame_), so a
+    # bare return renders as a polars table for both the human and the model;
+    # CodeMap exposes the nested per-file frame instead.
+    import polars as _pl
+
+    assert isinstance(fff.grep("find me on this line", path=root)._ix_to_frame_(), _pl.DataFrame)
+    assert isinstance(fff.find("main", path=root)._ix_to_frame_(), _pl.DataFrame)
+    cmdf = fff.map("find me on this line", path=root).df
+    assert cmdf.schema["matches"] == _pl.List(
+        _pl.Struct({"line": _pl.Int64, "col": _pl.Int64, "def": _pl.Boolean, "content": _pl.Utf8})
+    ), cmdf.schema
+
     print("fff-ok", fff.__version__)
   '';
   fffBundled =
@@ -1272,6 +1294,30 @@ let
     nested = runtime.Result.of([inner, pl.DataFrame({"a": [1]})])
     assert len(nested.llm_images) == 1, ("nested Result dropped its images", nested.llm_images)
 
+    # The table protocol: a non-DataFrame value exposing _ix_to_frame_() renders
+    # as its polars frame -- a styled table for the human, compact CSV for the
+    # model -- instead of its one-line summary repr. This is what makes an fff
+    # GrepResult/SearchResult show the model the real rows, not just a count.
+    class _Framed:
+        def _ix_to_frame_(self):
+            return pl.DataFrame({"path": ["a.py"], "line": [3]})
+
+        def __repr__(self):
+            return "Framed: 1 match (summary)"
+
+    framed = runtime.Result.of(_Framed())
+    assert "<table" in framed.user_html, framed.user_html[:200]
+    assert framed.llm_result.startswith("shape: (1, 2)") and "a.py" in framed.llm_result, framed.llm_result
+    assert "summary" not in framed.llm_result, "must render the frame, not the summary repr"
+
+    # A hook that raises or returns a non-frame is ignored: fall back to the
+    # normal repr path rather than blowing up the result.
+    class _BadFrame:
+        def _ix_to_frame_(self):
+            raise RuntimeError("nope")
+
+    assert "BadFrame" in runtime.Result.of(_BadFrame()).llm_result
+
 
     async def main():
         # A DataFrame result is stored with its text/html bundle.
@@ -1741,11 +1787,19 @@ let
     # A DataFrame stays a DataFrame through polars ops (composable).
     assert isinstance(lsdf.filter(pl.col("kind") == "dir"), pl.DataFrame)
 
-    g = view.grep("viewTestPy", base)
-    assert isinstance(g, pl.DataFrame) and set(g.columns) == {"path", "line", "text"}, g.columns
-    assert g.height > 0, "expected a grep hit for the marker"
+    # Content/file search lives in fff now (one canonical grep/find): the rich
+    # GrepResult/SearchResult expose .df (the styled-table frame) and opt into
+    # the kernel table protocol via _ix_to_frame_, so a bare return renders as a
+    # table for both the human and the model.
+    import fff
 
-    f = view.find("default.nix", base)
+    gr = fff.grep("viewTestPy", base)
+    g = gr.df
+    assert isinstance(g, pl.DataFrame) and {"path", "line", "content"} <= set(g.columns), g.columns
+    assert g.height > 0, "expected a grep hit for the marker"
+    assert gr._ix_to_frame_() is not None, "GrepResult must expose the table protocol"
+
+    f = fff.find("default.nix", base).df
     assert isinstance(f, pl.DataFrame) and "path" in f.columns
 
     tr = view.tree(base, depth=1)

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -415,6 +415,20 @@ class Result:
             # one into a `value` cell. `Result((repr_text, df))` thus shows the text
             # and the real table, not a 2-row frame of two reprs.
             return _result_from_values(list(value), llm_result=llm_result)
+        frame = _frame_view(value)
+        if frame is not None:
+            # A rich result type (fff GrepResult/SearchResult) that exposes a
+            # polars frame: render that frame the same as a bare DataFrame -- a
+            # styled table for the human, compact CSV for the model -- so the
+            # model reads the real rows, not a one-line summary repr.
+            text_view = llm_result if llm_result is not None else _df_llm_text(frame)
+            try:
+                import view as _view
+
+                return cls(user_html=_view.df_html(frame), llm_result=text_view)
+            except Exception:
+                user = f'<pre class="ix-result">{_escape_html(text_view)}</pre>'
+                return cls(user_html=user, llm_result=text_view)
         value = _as_frame_if_tabular(value)
         if llm_result is not None:
             text_view = llm_result
@@ -1052,6 +1066,22 @@ def _is_polars_df(value) -> bool:
         and hasattr(value, "columns")
         and hasattr(value, "height")
     )
+
+
+def _frame_view(value):
+    """A non-DataFrame value that opts into the table protocol by exposing
+    ``_ix_to_frame_()`` returning a polars DataFrame (e.g. an fff ``GrepResult``
+    or ``SearchResult``). Returns that frame, else None. Lets a rich result type
+    render as the styled table for the human and compact CSV for the model,
+    instead of falling back to its one-line summary repr."""
+    hook = getattr(value, "_ix_to_frame_", None)
+    if hook is None:
+        return None
+    try:
+        frame = hook()
+    except Exception:
+        return None
+    return frame if _is_polars_df(frame) else None
 
 
 def _df_llm_text(df) -> str:

--- a/packages/mcp/src/fff/fff/__init__.py
+++ b/packages/mcp/src/fff/fff/__init__.py
@@ -41,6 +41,7 @@ import asyncio
 import ctypes
 import json
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -76,6 +77,35 @@ _OPTIONS_VERSION = 1
 
 # fff_live_grep mode byte: 0 plain (SIMD literal), 1 regex, 2 fuzzy.
 _GREP_MODES = {"plain": 0, "text": 0, "regex": 1, "fuzzy": 2}
+
+# Regex metacharacters that tell a regex query apart from a literal one. With
+# mode="smart" (the default) a query containing any of these is run as a regex
+# when it compiles, otherwise as a fast SIMD literal. This avoids both footguns
+# of a fixed default: a plain default silently treats `a|b` or `(?i)x` as text,
+# while a regex default breaks an ordinary literal like `fn main(`.
+_RE_META = frozenset("\\^$.|?*+()[]{}")
+
+
+def _resolve_mode(query: str, mode: str) -> str:
+    """Resolve the public ``mode`` to a concrete fff grep mode.
+
+    ``"smart"`` inspects ``query``: regex when it holds regex metacharacters and
+    compiles to a valid pattern, else plain literal. Every other mode passes
+    through after validation.
+    """
+    if mode == "smart":
+        if any(c in _RE_META for c in query):
+            try:
+                re.compile(query)
+                return "regex"
+            except re.error:
+                return "plain"
+        return "plain"
+    if mode not in _GREP_MODES:
+        raise ValueError(
+            f"unknown grep mode {mode!r}; use 'smart', 'plain', 'regex', or 'fuzzy'"
+        )
+    return mode
 
 
 class FffError(RuntimeError):
@@ -377,6 +407,12 @@ class SearchResult:
             },
         )
 
+    def _ix_to_frame_(self):
+        """Kernel table protocol: render as this polars frame for both the human
+        (styled HTML) and the model (compact CSV). None when polars is absent so
+        the kernel falls back to the text repr."""
+        return self.df if _polars() is not None else None
+
     def _repr_html_(self) -> str | None:
         """Render as the styled table for the dashboard (None when polars is
         absent, so the human falls back to the text repr)."""
@@ -457,6 +493,12 @@ class GrepResult:
                 "git": pl.Utf8,
             },
         )
+
+    def _ix_to_frame_(self):
+        """Kernel table protocol: render as this polars frame for both the human
+        (styled HTML) and the model (compact CSV). None when polars is absent so
+        the kernel falls back to the text repr."""
+        return self.df if _polars() is not None else None
 
     def _repr_html_(self) -> str | None:
         """Render as the styled table for the dashboard (None when polars is
@@ -667,7 +709,7 @@ class FileFinder:
         self,
         query: str,
         *,
-        mode: str = "plain",
+        mode: str = "smart",
         limit: int = 50,
         max_matches_per_file: int = 0,
         smart_case: bool = True,
@@ -678,11 +720,14 @@ class FileFinder:
         after_context: int = 0,
         classify_definitions: bool = False,
     ) -> GrepResult:
-        """Content search across indexed files. mode: plain | regex | fuzzy."""
+        """Content search across indexed files.
+
+        ``mode``: ``"smart"`` (default) runs the query as a regex when it holds
+        regex metacharacters and as a fast literal otherwise; force it with
+        ``"plain"``, ``"regex"``, or ``"fuzzy"``.
+        """
         self._check_open()
-        mode_byte = _GREP_MODES.get(mode)
-        if mode_byte is None:
-            raise ValueError(f"unknown grep mode {mode!r}; use one of {sorted(_GREP_MODES)}")
+        mode_byte = _GREP_MODES[_resolve_mode(query, mode)]
         _validate_grep_args(
             limit,
             max_matches_per_file,
@@ -962,7 +1007,7 @@ def find(query: str, path=".", *, limit: int = 100) -> SearchResult:
     return SearchResult(hits=hits, total_matched=len(hits), total_files=len(hits))
 
 
-def grep(query: str, path=".", *, mode: str = "plain", limit: int = 50) -> GrepResult:
+def grep(query: str, path=".", *, mode: str = "smart", limit: int = 50) -> GrepResult:
     """Content grep over `path`, reusing a cached watched (content-indexed) index.
 
     `path` may be a directory (grepped whole) or a single file. A single file is
@@ -993,7 +1038,7 @@ async def afind(query: str, path=".", *, limit: int = 100) -> SearchResult:
     return await asyncio.to_thread(find, query, path, limit=limit)
 
 
-async def agrep(query: str, path=".", *, mode: str = "plain", limit: int = 50) -> GrepResult:
+async def agrep(query: str, path=".", *, mode: str = "smart", limit: int = 50) -> GrepResult:
     """Async content grep: runs off the event loop (non-blocking)."""
     return await asyncio.to_thread(grep, query, path, mode=mode, limit=limit)
 
@@ -1022,6 +1067,51 @@ class CodeMap:
     @property
     def defs(self) -> list["GrepMatch"]:
         return [m for m in self.matches if m.is_definition]
+
+    @property
+    def df(self):
+        """The map as a nested ``polars.DataFrame``: one row per file, with the
+        per-file matches as a ``list[struct]`` of (line, col, def, content), and
+        ``defs``/``hits`` counts. Requires polars. (For a flat table use
+        ``fff.grep(...).df``; the nested frame is for grouping/aggregation.)"""
+        pl = _polars()
+        if pl is None:
+            raise FffError("polars is not available; iterate .by_file instead")
+        rows = [
+            {
+                "path": path,
+                "defs": sum(1 for h in hits if h.is_definition),
+                "hits": len(hits),
+                "matches": [
+                    {
+                        "line": h.line_number,
+                        "col": h.col,
+                        "def": h.is_definition,
+                        "content": h.line.strip(),
+                    }
+                    for h in hits
+                ],
+            }
+            for path, hits in self.by_file.items()
+        ]
+        return pl.DataFrame(
+            rows,
+            schema={
+                "path": pl.Utf8,
+                "defs": pl.Int64,
+                "hits": pl.Int64,
+                "matches": pl.List(
+                    pl.Struct(
+                        {
+                            "line": pl.Int64,
+                            "col": pl.Int64,
+                            "def": pl.Boolean,
+                            "content": pl.Utf8,
+                        }
+                    )
+                ),
+            },
+        )
 
     def __repr__(self) -> str:
         if not self.matches:
@@ -1081,14 +1171,14 @@ class CodeMap:
         )
 
 
-def map(query: str, path=".", *, mode: str = "plain", limit: int = 200) -> CodeMap:
+def map(query: str, path=".", *, mode: str = "smart", limit: int = 200) -> CodeMap:
     """Content grep grouped into a :class:`CodeMap`: hits per file with
     definitions ranked first. A glanceable answer to "where is X defined and
     used?" built straight on :func:`grep`."""
     return CodeMap(query, grep(query, path, mode=mode, limit=limit).matches)
 
 
-async def amap(query: str, path=".", *, mode: str = "plain", limit: int = 200) -> CodeMap:
+async def amap(query: str, path=".", *, mode: str = "smart", limit: int = 200) -> CodeMap:
     """Async :func:`map`: the same code map, off the event loop."""
     res = await agrep(query, path, mode=mode, limit=limit)
     return CodeMap(query, res.matches)

--- a/packages/mcp/src/view/view/__init__.py
+++ b/packages/mcp/src/view/view/__init__.py
@@ -7,11 +7,12 @@ listings an agent does constantly, and never shell out to ``ls``/``grep``/``cat`
 
 Two flavors of view:
 
-* The tabular helpers (:func:`ls`, :func:`tree`, :func:`grep`, :func:`find`)
-  return a plain ``polars.DataFrame``. They compose with the full polars API
-  (``.filter()``, ``.sort()``, ``.join()`` ...) and render as the dashboard's
-  styled HTML table, because the kernel installs a global
-  ``polars.DataFrame._repr_html_`` built from :func:`df_html`.
+* The tabular helpers (:func:`ls`, :func:`tree`) return a plain
+  ``polars.DataFrame``. They compose with the full polars API (``.filter()``,
+  ``.sort()``, ``.join()`` ...) and render as the dashboard's styled HTML table,
+  because the kernel installs a global ``polars.DataFrame._repr_html_`` built
+  from :func:`df_html`. For content/file search use ``fff.grep`` / ``fff.find``
+  (their results render as the same styled table and expose ``.df``).
 * The file helpers (:func:`cat`/:func:`read`, :func:`head`, :func:`tail`,
   :func:`json`, :func:`diff`) return a :class:`Code`: a syntax-highlighted HTML
   render for the human plus the raw text as the agent's value.
@@ -78,8 +79,6 @@ def _git_ignored(root: pathlib.Path, rels: list[str]) -> set[str]:
 __all__ = [
     "ls",
     "tree",
-    "grep",
-    "find",
     "cat",
     "read",
     "head",
@@ -585,41 +584,6 @@ def tree(
             "path": pl.Utf8,
             "kind": pl.Utf8,
         },
-    )
-
-
-def grep(
-    query: str, path: str | os.PathLike = ".", *, limit: int = 50, mode: str = "plain"
-) -> "pl.DataFrame":
-    """Content search via the bundled ``fff``, as a DataFrame (path, line, text).
-
-    ``mode`` is passed through to ``fff.grep`` (e.g. ``"plain"`` or ``"regex"``).
-    """
-    import fff
-
-    result = fff.grep(query, str(path), mode=mode, limit=limit)
-    rows = [
-        {"path": m.path, "line": m.line_number, "text": m.line.strip()}
-        for m in result.matches
-    ]
-    return pl.DataFrame(
-        rows, schema={"path": pl.Utf8, "line": pl.Int64, "text": pl.Utf8}
-    )
-
-
-def find(
-    query: str, path: str | os.PathLike = ".", *, limit: int = 100
-) -> "pl.DataFrame":
-    """Fuzzy file-name search via the bundled ``fff``, as a DataFrame."""
-    import fff
-
-    result = fff.find(query, str(path), limit=limit)
-    rows = [
-        {"path": h.path, "name": h.name, "size": getattr(h, "size", None)}
-        for h in result.hits
-    ]
-    return pl.DataFrame(
-        rows, schema={"path": pl.Utf8, "name": pl.Utf8, "size": pl.Int64}
     )
 
 


### PR DESCRIPTION
Unifies the overlapping content-grep surface and makes rich search results render as polars tables for the model too. Closes #892, #893, #895.

## Why
Three functions named `grep` (`fff.grep`, `view.grep`, `search.grep`) returned different shapes with **opposite defaults** (`fff.grep` plain, `search.grep` regex), and a `GrepResult` rendered as a styled HTML table for the human but only a one-line `GrepResult: N matches` summary for the model. A regex-looking query (`a|b`, `(?i)x`) passed to the default `plain` mode silently matched nothing.

## What changed
- **One content grep.** `fff.grep` is canonical. Removed the duplicate `view.grep`/`view.find`; callers use `fff.grep(q).df` / `fff.find(q).df`. Left `fff.grep` (working tree) and `search.grep` (semantic corpus) cleanly namespaced.
- **Smart default mode.** `mode` now defaults to `"smart"`: regex when the query holds regex metacharacters *and compiles*, else fast SIMD literal. Fixes both footguns — a plain default silently treating `a|b`/`(?i)x` as text, and a regex default breaking an ordinary literal like `fn main(`. Explicit `plain`/`regex`/`fuzzy` still available.
- **Table protocol (the central fix).** A result type exposing `_ix_to_frame_()` now renders as its polars frame for the **model** (compact CSV), not just the human HTML. `GrepResult`/`SearchResult` opt in, so the agent reads the real rows instead of a count. A broken/non-frame hook degrades gracefully to the normal repr path.
- **Nested polars.** `CodeMap.df` returns one row per file with `matches` as a `list[struct]` (line, col, def, content), plus `defs`/`hits` counts. (`CodeMap`'s glanceable text-tree repr is already ideal for the model, so it keeps that and isn't put through the CSV protocol.)

## Tests
All three affected nix test derivations build green (`nix build .#mcp.tests.{fffBundled,richSmoke,viewSmoke}`):
- `fffTestPy`: smart-mode default (alternation matches with no `mode=`; plain treats it literally; unbalanced paren falls back to literal), `_ix_to_frame_` on GrepResult/SearchResult, nested `CodeMap.df` schema.
- `richTestPy`: `Result.of` renders an `_ix_to_frame_` value as a table for the model (CSV) and HTML for the human, and ignores a raising hook.
- `viewTestPy`: migrated the grep/find coverage to `fff`.

#894 (help() returns None; add a `doc()` helper) is unrelated to grep and left for a separate small change.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify content grep on `fff` and render rich results as polars tables in MCP
> - Adds `_ix_to_frame_()` to `fff.GrepResult`, `fff.SearchResult`, and `fff.CodeMap` so they opt into the kernel table protocol, rendering as styled HTML tables and CSV-ish text in MCP results.
> - Introduces `_resolve_mode()` in [fff/__init__.py](https://github.com/indexable-inc/index/pull/896/files#diff-04cf9369e128a37711b583a278d82557a69696b7ad87abacabfd89301ab6403d) to implement a `'smart'` default grep mode: queries containing regex metacharacters are tried as regex and fall back to plain literal if compilation fails.
> - Removes `view.grep` and `view.find`; callers must use `fff.grep` and `fff.find` directly.
> - Adds `Result.of` handling in [runtime.py](https://github.com/indexable-inc/index/pull/896/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) to detect `_ix_to_frame_()` and render matching objects as DataFrames instead of their repr.
> - Behavioral Change: `fff.grep`, `fff.agrep`, `fff.map`, and `fff.amap` now default to `mode='smart'` instead of `mode='plain'`, which may silently interpret some queries as regex.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aeda5a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->