### PR TITLE
fff: require an explicit grep mode (no default)

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -633,7 +633,7 @@ let
             time.sleep(0.25)
         assert hit_path is not None, f"fuzzy search did not find hello_world.txt: {result.hits!r}"
 
-        grep_result = finder.grep("find me on this line", limit=10)
+        grep_result = finder.grep("find me on this line", mode="plain", limit=10)
         files = {m.path for m in grep_result.matches}
         assert any("hello_world" in f for f in files), f"grep missed the txt file: {files!r}"
         assert any("main.rs" in f for f in files), f"grep missed main.rs: {files!r}"
@@ -653,7 +653,7 @@ let
     cm_html = cm._repr_html_()
     assert "<details" in cm_html and "find me" in cm_html, cm_html[:200]
     # map() is the grep -> CodeMap convenience (type only; avoids a scan race).
-    assert isinstance(fff.map("fn main", root), fff.CodeMap)
+    assert isinstance(fff.map("fn main", root, mode="plain"), fff.CodeMap)
 
     # The public search surface takes `path=` (consistent with `view`), not `root=`.
     import inspect as _inspect
@@ -661,18 +661,18 @@ let
     for _fn in (fff.find, fff.grep, fff.afind, fff.agrep, fff.map, fff.amap):
         _params = _inspect.signature(_fn).parameters
         assert "path" in _params and "root" not in _params, (_fn.__name__, list(_params))
-    assert isinstance(fff.grep("find me on this line", path=root), fff.GrepResult)
+    assert isinstance(fff.grep("find me on this line", path=root, mode="plain"), fff.GrepResult)
 
     # A single file as `path` is grepped on its own, in an isolated one-file
     # index: fff-c cannot content-index a lone file as a root, and its indexer
     # skips dotfiles and ignored paths, so the helper copies the target into a
     # throwaway visible-named tree and remaps matches back to its real name.
     main_rs = os.path.join(root, "src", "main.rs")
-    one = fff.grep("find me on this line", path=main_rs)
+    one = fff.grep("find me on this line", path=main_rs, mode="plain")
     assert {m.path for m in one.matches} == {"main.rs"}, f"file grep not scoped: {one.matches!r}"
-    assert fff.grep("no such content anywhere", path=main_rs).matches == [], "empty file grep should be empty"
+    assert fff.grep("no such content anywhere", path=main_rs, mode="plain").matches == [], "empty file grep should be empty"
     assert any(h.path == "main.rs" for h in fff.find("main", path=main_rs).hits), "file find missed it"
-    assert fff.map("find me on this line", path=main_rs).by_file, "file map should group the hit"
+    assert fff.map("find me on this line", path=main_rs, mode="plain").by_file, "file map should group the hit"
 
     # Regression guard for indexable-inc/index#890: a dotfile, and a file
     # directly under $HOME, are both greppable even though fff's indexer skips
@@ -680,41 +680,50 @@ let
     dotfile = os.path.join(root, ".env")
     with open(dotfile, "w") as fh:
         fh.write("SECRET=find me on this line\n")
-    assert fff.grep("find me on this line", path=dotfile).matches, "dotfile grep found nothing"
+    assert fff.grep("find me on this line", path=dotfile, mode="plain").matches, "dotfile grep found nothing"
 
     home_file = os.path.join(os.environ["HOME"], ".zshrc")
     with open(home_file, "w") as fh:
         fh.write("export FIND_ME=1\n")
-    home_hit = fff.grep("FIND_ME", path=home_file)
+    home_hit = fff.grep("FIND_ME", path=home_file, mode="plain")
     assert {m.path for m in home_hit.matches} == {".zshrc"}, f"home dotfile grep: {home_hit.matches!r}"
     assert any(h.path == ".zshrc" for h in fff.find("zshrc", path=home_file).hits), "home dotfile find missed it"
 
     # A bare home / fs-root *directory* is refused with actionable guidance —
     # never silently, and never with a message that nudges toward shelling out.
     try:
-        fff.grep("anything", path=os.environ["HOME"])
+        fff.grep("anything", path=os.environ["HOME"], mode="plain")
         raise AssertionError("expected a refusal for the bare home directory")
     except fff.FffError as exc:
         assert "subdirectory" in str(exc), f"unhelpful home-dir error: {exc}"
 
-    # mode="smart" (the default) runs a query as regex when it holds regex
-    # metacharacters and as a fast literal otherwise: an alternation matches with
-    # no mode= (the old plain default silently matched nothing), while an
-    # ordinary literal with an unbalanced paren falls back to literal, never errors.
-    assert fff.grep("greetings|fn main", path=root).matches, "smart default missed the alternation"
+    # `mode` is REQUIRED (no default): omitting it is a TypeError, so every call
+    # states whether it wants a literal or a regex rather than guessing.
+    try:
+        fff.grep("greetings", path=root)
+        raise AssertionError("grep must require an explicit mode")
+    except TypeError:
+        pass
+
+    # mode="regex" runs the query as a regex and mode="plain" as a fast literal,
+    # so an alternation matches under regex but not under plain. mode="smart" is
+    # the explicit auto-detect: regex for a metacharacter query that compiles,
+    # literal otherwise (an unbalanced paren falls back to literal, never errors).
+    assert fff.grep("greetings|fn main", path=root, mode="regex").matches, "regex missed the alternation"
     assert fff.grep("greetings|fn main", path=root, mode="plain").matches == [], (
-        "plain mode must treat the alternation literally"
+        "plain must treat the alternation literally"
     )
-    assert fff.grep("fn main(", path=root).matches, "smart must fall back to literal for an unbalanced paren"
+    assert fff.grep("greetings|fn main", path=root, mode="smart").matches, "smart should pick regex here"
+    assert fff.grep("fn main(", path=root, mode="smart").matches, "smart should fall back to a literal"
 
     # The flat results opt into the kernel table protocol (_ix_to_frame_), so a
     # bare return renders as a polars table for both the human and the model;
     # CodeMap exposes the nested per-file frame instead.
     import polars as _pl
 
-    assert isinstance(fff.grep("find me on this line", path=root)._ix_to_frame_(), _pl.DataFrame)
+    assert isinstance(fff.grep("find me on this line", path=root, mode="plain")._ix_to_frame_(), _pl.DataFrame)
     assert isinstance(fff.find("main", path=root)._ix_to_frame_(), _pl.DataFrame)
-    cmdf = fff.map("find me on this line", path=root).df
+    cmdf = fff.map("find me on this line", path=root, mode="plain").df
     assert cmdf.schema["matches"] == _pl.List(
         _pl.Struct({"line": _pl.Int64, "col": _pl.Int64, "def": _pl.Boolean, "content": _pl.Utf8})
     ), cmdf.schema
@@ -1793,7 +1802,7 @@ let
     # table for both the human and the model.
     import fff
 
-    gr = fff.grep("viewTestPy", base)
+    gr = fff.grep("viewTestPy", base, mode="plain")
     g = gr.df
     assert isinstance(g, pl.DataFrame) and {"path", "line", "content"} <= set(g.columns), g.columns
     assert g.height > 0, "expected a grep hit for the marker"

--- a/packages/mcp/src/fff/fff/__init__.py
+++ b/packages/mcp/src/fff/fff/__init__.py
@@ -12,7 +12,7 @@ index; this module loads the `fff-c` cdylib (`packages/fff` emits it next to the
     for hit in fff.find("picker", path=".").hits:
         print(hit.path, hit.frecency)
 
-    for m in fff.grep("fn main", path=".").matches:
+    for m in fff.grep("fn main", path=".", mode="regex").matches:
         print(f"{m.path}:{m.line_number}: {m.line}")
 
     # or hold an instance for repeated queries against one tree:
@@ -20,7 +20,7 @@ index; this module loads the `fff-c` cdylib (`packages/fff` emits it next to the
         ff.wait_for_scan()              # block until the initial scan finishes
         ff.search("readme")            # fuzzy file search, frecency-ranked
         ff.glob("**/*.rs")             # literal glob, no fuzzy parsing
-        ff.grep("TODO", mode="regex")  # content search (plain | regex | fuzzy)
+        ff.grep("TODO", mode="regex")  # content search (smart | plain | regex | fuzzy)
         ff.multi_grep(["foo", "bar"])  # OR across many literals (Aho-Corasick)
 
 Results are plain dataclasses (`FileHit`, `GrepMatch`, `SearchResult`,
@@ -79,10 +79,9 @@ _OPTIONS_VERSION = 1
 _GREP_MODES = {"plain": 0, "text": 0, "regex": 1, "fuzzy": 2}
 
 # Regex metacharacters that tell a regex query apart from a literal one. With
-# mode="smart" (the default) a query containing any of these is run as a regex
-# when it compiles, otherwise as a fast SIMD literal. This avoids both footguns
-# of a fixed default: a plain default silently treats `a|b` or `(?i)x` as text,
-# while a regex default breaks an ordinary literal like `fn main(`.
+# mode="smart" a query containing any of these is run as a regex when it
+# compiles, otherwise as a fast SIMD literal -- a convenience for callers who
+# want auto-detection, opted into explicitly (grep has no default mode).
 _RE_META = frozenset("\\^$.|?*+()[]{}")
 
 
@@ -709,7 +708,7 @@ class FileFinder:
         self,
         query: str,
         *,
-        mode: str = "smart",
+        mode: str,
         limit: int = 50,
         max_matches_per_file: int = 0,
         smart_case: bool = True,
@@ -722,9 +721,10 @@ class FileFinder:
     ) -> GrepResult:
         """Content search across indexed files.
 
-        ``mode``: ``"smart"`` (default) runs the query as a regex when it holds
-        regex metacharacters and as a fast literal otherwise; force it with
-        ``"plain"``, ``"regex"``, or ``"fuzzy"``.
+        ``mode`` is required (no default), so each call states its intent:
+        ``"plain"`` (fast SIMD literal), ``"regex"``, ``"fuzzy"``, or ``"smart"``
+        (regex when the query holds regex metacharacters and compiles, else a
+        literal).
         """
         self._check_open()
         mode_byte = _GREP_MODES[_resolve_mode(query, mode)]
@@ -1007,8 +1007,12 @@ def find(query: str, path=".", *, limit: int = 100) -> SearchResult:
     return SearchResult(hits=hits, total_matched=len(hits), total_files=len(hits))
 
 
-def grep(query: str, path=".", *, mode: str = "smart", limit: int = 50) -> GrepResult:
+def grep(query: str, path=".", *, mode: str, limit: int = 50) -> GrepResult:
     """Content grep over `path`, reusing a cached watched (content-indexed) index.
+
+    `mode` is required (no default), so each call states its intent: ``"plain"``
+    (fast SIMD literal), ``"regex"``, ``"fuzzy"``, or ``"smart"`` (regex when the
+    query holds regex metacharacters and compiles, else a literal).
 
     `path` may be a directory (grepped whole) or a single file. A single file is
     grepped in an isolated one-file index, so it works even for a dotfile (which
@@ -1038,7 +1042,7 @@ async def afind(query: str, path=".", *, limit: int = 100) -> SearchResult:
     return await asyncio.to_thread(find, query, path, limit=limit)
 
 
-async def agrep(query: str, path=".", *, mode: str = "smart", limit: int = 50) -> GrepResult:
+async def agrep(query: str, path=".", *, mode: str, limit: int = 50) -> GrepResult:
     """Async content grep: runs off the event loop (non-blocking)."""
     return await asyncio.to_thread(grep, query, path, mode=mode, limit=limit)
 
@@ -1171,14 +1175,14 @@ class CodeMap:
         )
 
 
-def map(query: str, path=".", *, mode: str = "smart", limit: int = 200) -> CodeMap:
+def map(query: str, path=".", *, mode: str, limit: int = 200) -> CodeMap:
     """Content grep grouped into a :class:`CodeMap`: hits per file with
     definitions ranked first. A glanceable answer to "where is X defined and
     used?" built straight on :func:`grep`."""
     return CodeMap(query, grep(query, path, mode=mode, limit=limit).matches)
 
 
-async def amap(query: str, path=".", *, mode: str = "smart", limit: int = 200) -> CodeMap:
+async def amap(query: str, path=".", *, mode: str, limit: int = 200) -> CodeMap:
     """Async :func:`map`: the same code map, off the event loop."""
     res = await agrep(query, path, mode=mode, limit=limit)
     return CodeMap(query, res.matches)


### PR DESCRIPTION
Follow-up to #896. Removes the default grep mode: `mode` is now a **required** keyword-only argument on `fff.grep`/`agrep`/`map`/`amap` and `FileFinder.grep`.

## Why
A default mode (even the `"smart"` one) makes a query's matching semantics implicit — the reader can't tell from the call site whether `a|b` is an alternation or a literal. Requiring `mode` forces every call to state its intent.

## What changed
- `mode` has no default; omitting it raises `TypeError: grep() missing 1 required keyword-only argument: 'mode'`.
- `"smart"` (regex when the query holds regex metacharacters and compiles, else literal) stays available as an explicit, opt-in choice alongside `plain`/`regex`/`fuzzy`.
- Migrated every internal call site to pass an explicit mode.
- Docstrings updated (no longer "default"); rewrote the fff test to cover explicit `plain`/`regex`/`smart` and to assert that omitting `mode` is a `TypeError`.

## Tests
`nix build .#mcp.tests.{fffBundled,viewSmoke}` → green.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require explicit `mode` argument in `fff.grep`, `fff.map`, and async variants
> - Removes the default `mode="smart"` from `FileFinder.grep`, `fff.grep`, `fff.agrep`, `fff.map`, and `fff.amap` — callers must now pass `mode` explicitly or receive a `TypeError`.
> - Updates all call sites in [default.nix](https://github.com/indexable-inc/index/pull/897/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) to pass `mode="plain"` (or the appropriate mode) and adds a test asserting that omitting `mode` raises `TypeError`.
> - Risk: any existing caller that relies on the implicit `smart` default will break at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ea592b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->