### PR TITLE
fff: keyword-only args, required path, no smart mode (maximum explicit)

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -618,14 +618,14 @@ let
     with open(os.path.join(root, "src", "main.rs"), "w") as fh:
         fh.write('fn main() {\n    println!("find me on this line");\n}\n')
 
-    finder = fff.FileFinder(root, watch=False, content_indexing=True, ai_mode=True)
+    finder = fff.FileFinder(root=root, watch=False, content_indexing=True, ai_mode=True)
     try:
         # The initial scan runs in the background; poll until the planted file
         # is visible (a few short waits, robust to sandbox scheduling).
         hit_path = None
         for _ in range(20):
             finder.wait_for_scan(2000)
-            result = finder.search("hello")
+            result = finder.search(query="hello")
             match = next((h for h in result.hits if "hello_world" in h.path), None)
             if match is not None:
                 hit_path = match.path
@@ -633,14 +633,14 @@ let
             time.sleep(0.25)
         assert hit_path is not None, f"fuzzy search did not find hello_world.txt: {result.hits!r}"
 
-        grep_result = finder.grep("find me on this line", mode="plain", limit=10)
+        grep_result = finder.grep(query="find me on this line", mode="plain", limit=10)
         files = {m.path for m in grep_result.matches}
         assert any("hello_world" in f for f in files), f"grep missed the txt file: {files!r}"
         assert any("main.rs" in f for f in files), f"grep missed main.rs: {files!r}"
-        defs = finder.grep("fn main", mode="regex", classify_definitions=True)
+        defs = finder.grep(query="fn main", mode="regex", classify_definitions=True)
         assert defs.matches, "regex grep returned no matches"
 
-        glob_result = finder.glob("**/*.rs")
+        glob_result = finder.glob(pattern="**/*.rs")
         assert any("main.rs" in h.path for h in glob_result.hits), (
             f"glob missed main.rs: {glob_result.hits!r}"
         )
@@ -648,12 +648,12 @@ let
         finder.close()
 
     # CodeMap groups grep matches (defs first) and renders foldable per-file.
-    cm = fff.CodeMap("find me on this line", grep_result.matches)
+    cm = fff.CodeMap(query="find me on this line", matches=grep_result.matches)
     assert cm.by_file and cm.matches and "find me on this line" in repr(cm), repr(cm)
     cm_html = cm._repr_html_()
     assert "<details" in cm_html and "find me" in cm_html, cm_html[:200]
     # map() is the grep -> CodeMap convenience (type only; avoids a scan race).
-    assert isinstance(fff.map("fn main", root, mode="plain"), fff.CodeMap)
+    assert isinstance(fff.map(query="fn main", path=root, mode="plain"), fff.CodeMap)
 
     # The public search surface takes `path=` (consistent with `view`), not `root=`.
     import inspect as _inspect
@@ -661,18 +661,18 @@ let
     for _fn in (fff.find, fff.grep, fff.afind, fff.agrep, fff.map, fff.amap):
         _params = _inspect.signature(_fn).parameters
         assert "path" in _params and "root" not in _params, (_fn.__name__, list(_params))
-    assert isinstance(fff.grep("find me on this line", path=root, mode="plain"), fff.GrepResult)
+    assert isinstance(fff.grep(query="find me on this line", path=root, mode="plain"), fff.GrepResult)
 
     # A single file as `path` is grepped on its own, in an isolated one-file
     # index: fff-c cannot content-index a lone file as a root, and its indexer
     # skips dotfiles and ignored paths, so the helper copies the target into a
     # throwaway visible-named tree and remaps matches back to its real name.
     main_rs = os.path.join(root, "src", "main.rs")
-    one = fff.grep("find me on this line", path=main_rs, mode="plain")
+    one = fff.grep(query="find me on this line", path=main_rs, mode="plain")
     assert {m.path for m in one.matches} == {"main.rs"}, f"file grep not scoped: {one.matches!r}"
-    assert fff.grep("no such content anywhere", path=main_rs, mode="plain").matches == [], "empty file grep should be empty"
-    assert any(h.path == "main.rs" for h in fff.find("main", path=main_rs).hits), "file find missed it"
-    assert fff.map("find me on this line", path=main_rs, mode="plain").by_file, "file map should group the hit"
+    assert fff.grep(query="no such content anywhere", path=main_rs, mode="plain").matches == [], "empty file grep should be empty"
+    assert any(h.path == "main.rs" for h in fff.find(query="main", path=main_rs).hits), "file find missed it"
+    assert fff.map(query="find me on this line", path=main_rs, mode="plain").by_file, "file map should group the hit"
 
     # Regression guard for indexable-inc/index#890: a dotfile, and a file
     # directly under $HOME, are both greppable even though fff's indexer skips
@@ -680,67 +680,75 @@ let
     dotfile = os.path.join(root, ".env")
     with open(dotfile, "w") as fh:
         fh.write("SECRET=find me on this line\n")
-    assert fff.grep("find me on this line", path=dotfile, mode="plain").matches, "dotfile grep found nothing"
+    assert fff.grep(query="find me on this line", path=dotfile, mode="plain").matches, "dotfile grep found nothing"
 
     home_file = os.path.join(os.environ["HOME"], ".zshrc")
     with open(home_file, "w") as fh:
         fh.write("export FIND_ME=1\n")
-    home_hit = fff.grep("FIND_ME", path=home_file, mode="plain")
+    home_hit = fff.grep(query="FIND_ME", path=home_file, mode="plain")
     assert {m.path for m in home_hit.matches} == {".zshrc"}, f"home dotfile grep: {home_hit.matches!r}"
-    assert any(h.path == ".zshrc" for h in fff.find("zshrc", path=home_file).hits), "home dotfile find missed it"
+    assert any(h.path == ".zshrc" for h in fff.find(query="zshrc", path=home_file).hits), "home dotfile find missed it"
 
     # A bare home / fs-root *directory* is refused with actionable guidance —
     # never silently, and never with a message that nudges toward shelling out.
     try:
-        fff.grep("anything", path=os.environ["HOME"], mode="plain")
+        fff.grep(query="anything", path=os.environ["HOME"], mode="plain")
         raise AssertionError("expected a refusal for the bare home directory")
     except fff.FffError as exc:
         assert "subdirectory" in str(exc), f"unhelpful home-dir error: {exc}"
 
-    # `mode` is REQUIRED (no default): omitting it is a TypeError, so every call
-    # states whether it wants a literal or a regex rather than guessing.
-    try:
-        fff.grep("greetings", path=root)
-        raise AssertionError("grep must require an explicit mode")
-    except TypeError:
-        pass
+    # Every public arg is keyword-only and `path`/`mode` are required (no hidden
+    # default): a positional call, or a missing path/mode, is a TypeError, so each
+    # call states exactly what it searches, where, and how.
+    for bad in (
+        lambda: fff.grep("greetings", path=root, mode="plain"),  # positional query
+        lambda: fff.grep(query="greetings", mode="plain"),       # missing path
+        lambda: fff.grep(query="greetings", path=root),          # missing mode
+    ):
+        try:
+            bad()
+            raise AssertionError("expected a TypeError for an under-specified grep")
+        except TypeError:
+            pass
 
     # mode="regex" runs the query as a regex and mode="plain" as a fast literal,
-    # so an alternation matches under regex but not under plain. mode="smart" is
-    # the explicit auto-detect: regex for a metacharacter query that compiles,
-    # literal otherwise (an unbalanced paren falls back to literal, never errors).
-    assert fff.grep("greetings|fn main", path=root, mode="regex").matches, "regex missed the alternation"
-    assert fff.grep("greetings|fn main", path=root, mode="plain").matches == [], (
+    # so an alternation matches under regex but not under plain. There is no
+    # "smart" auto-detect mode -- the caller is always explicit.
+    assert fff.grep(query="greetings|fn main", path=root, mode="regex").matches, "regex missed the alternation"
+    assert fff.grep(query="greetings|fn main", path=root, mode="plain").matches == [], (
         "plain must treat the alternation literally"
     )
-    assert fff.grep("greetings|fn main", path=root, mode="smart").matches, "smart should pick regex here"
-    assert fff.grep("fn main(", path=root, mode="smart").matches, "smart should fall back to a literal"
+    try:
+        fff.grep(query="x", path=root, mode="smart")
+        raise AssertionError("smart mode was removed")
+    except ValueError:
+        pass
 
     # The flat results opt into the kernel table protocol (_ix_to_frame_), so a
     # bare return renders as a polars table for both the human and the model;
     # CodeMap exposes the nested per-file frame instead.
     import polars as _pl
 
-    assert isinstance(fff.grep("find me on this line", path=root, mode="plain")._ix_to_frame_(), _pl.DataFrame)
-    assert isinstance(fff.find("main", path=root)._ix_to_frame_(), _pl.DataFrame)
-    cmdf = fff.map("find me on this line", path=root, mode="plain").df
+    assert isinstance(fff.grep(query="find me on this line", path=root, mode="plain")._ix_to_frame_(), _pl.DataFrame)
+    assert isinstance(fff.find(query="main", path=root)._ix_to_frame_(), _pl.DataFrame)
+    cmdf = fff.map(query="find me on this line", path=root, mode="plain").df
     assert cmdf.schema["matches"] == _pl.List(
         _pl.Struct({"line": _pl.Int64, "col": _pl.Int64, "def": _pl.Boolean, "content": _pl.Utf8})
     ), cmdf.schema
 
     # One grep, one OR many patterns: a list is matched as a literal OR in a
     # single pass (no Python loop of greps). A list requires mode="plain".
-    multi = fff.grep(["greetings", "fn main"], path=root, mode="plain")
+    multi = fff.grep(query=["greetings", "fn main"], path=root, mode="plain")
     multi_files = {m.path for m in multi.matches}
     assert any("hello_world" in f for f in multi_files) and any("main.rs" in f for f in multi_files), (
         multi_files
     )
     try:
-        fff.grep(["a", "b"], path=root, mode="regex")
+        fff.grep(query=["a", "b"], path=root, mode="regex")
         raise AssertionError("a list query must reject a non-plain mode")
     except ValueError:
         pass
-    assert isinstance(fff.map(["greetings", "fn main"], path=root, mode="plain"), fff.CodeMap)
+    assert isinstance(fff.map(query=["greetings", "fn main"], path=root, mode="plain"), fff.CodeMap)
 
     print("fff-ok", fff.__version__)
   '';
@@ -1816,13 +1824,13 @@ let
     # table for both the human and the model.
     import fff
 
-    gr = fff.grep("viewTestPy", base, mode="plain")
+    gr = fff.grep(query="viewTestPy", path=base, mode="plain")
     g = gr.df
     assert isinstance(g, pl.DataFrame) and {"path", "line", "content"} <= set(g.columns), g.columns
     assert g.height > 0, "expected a grep hit for the marker"
     assert gr._ix_to_frame_() is not None, "GrepResult must expose the table protocol"
 
-    f = fff.find("default.nix", base).df
+    f = fff.find(query="default.nix", path=base).df
     assert isinstance(f, pl.DataFrame) and "path" in f.columns
 
     tr = view.tree(base, depth=1)

--- a/packages/mcp/src/fff/fff/__init__.py
+++ b/packages/mcp/src/fff/fff/__init__.py
@@ -9,22 +9,22 @@ index; this module loads the `fff-c` cdylib (`packages/fff` emits it next to the
     import fff
 
     # one-shot helpers keep a cached, file-watching index per directory:
-    for hit in fff.find("picker", path=".").hits:
+    for hit in fff.find(query="picker", path=".").hits:
         print(hit.path, hit.frecency)
 
-    for m in fff.grep("fn main", path=".", mode="regex").matches:
+    for m in fff.grep(query="fn main", path=".", mode="regex").matches:
         print(f"{m.path}:{m.line_number}: {m.line}")
 
     # one query, or many at once (matched as a literal OR in a single pass):
-    fff.grep(["TODO", "FIXME", "XXX"], path=".", mode="plain")
+    fff.grep(query=["TODO", "FIXME", "XXX"], path=".", mode="plain")
 
     # or hold an instance for repeated queries against one tree:
-    with fff.FileFinder(".", content_indexing=True) as ff:
+    with fff.FileFinder(root=".", content_indexing=True) as ff:
         ff.wait_for_scan()              # block until the initial scan finishes
-        ff.search("readme")            # fuzzy file search, frecency-ranked
-        ff.glob("**/*.rs")             # literal glob, no fuzzy parsing
-        ff.grep("TODO", mode="regex")  # content search (smart | plain | regex | fuzzy)
-        ff.multi_grep(["foo", "bar"])  # OR across many literals (Aho-Corasick)
+        ff.search(query="readme")      # fuzzy file search, frecency-ranked
+        ff.glob(pattern="**/*.rs")     # literal glob, no fuzzy parsing
+        ff.grep(query="TODO", mode="regex")  # content search (plain | regex | fuzzy)
+        ff.multi_grep(patterns=["foo", "bar"])  # OR across many literals (Aho-Corasick)
 
 Results are plain dataclasses (`FileHit`, `GrepMatch`, `SearchResult`,
 `GrepResult`). Only the accessor-backed surfaces of fff-c are bound: file search
@@ -42,9 +42,9 @@ from __future__ import annotations
 
 import asyncio
 import ctypes
+import html
 import json
 import os
-import re
 import shutil
 import sys
 import tempfile
@@ -80,34 +80,6 @@ _OPTIONS_VERSION = 1
 
 # fff_live_grep mode byte: 0 plain (SIMD literal), 1 regex, 2 fuzzy.
 _GREP_MODES = {"plain": 0, "text": 0, "regex": 1, "fuzzy": 2}
-
-# Regex metacharacters that tell a regex query apart from a literal one. With
-# mode="smart" a query containing any of these is run as a regex when it
-# compiles, otherwise as a fast SIMD literal -- a convenience for callers who
-# want auto-detection, opted into explicitly (grep has no default mode).
-_RE_META = frozenset("\\^$.|?*+()[]{}")
-
-
-def _resolve_mode(query: str, mode: str) -> str:
-    """Resolve the public ``mode`` to a concrete fff grep mode.
-
-    ``"smart"`` inspects ``query``: regex when it holds regex metacharacters and
-    compiles to a valid pattern, else plain literal. Every other mode passes
-    through after validation.
-    """
-    if mode == "smart":
-        if any(c in _RE_META for c in query):
-            try:
-                re.compile(query)
-                return "regex"
-            except re.error:
-                return "plain"
-        return "plain"
-    if mode not in _GREP_MODES:
-        raise ValueError(
-            f"unknown grep mode {mode!r}; use 'smart', 'plain', 'regex', or 'fuzzy'"
-        )
-    return mode
 
 
 class FffError(RuntimeError):
@@ -533,8 +505,8 @@ class FileFinder:
 
     def __init__(
         self,
-        root=".",
         *,
+        root,
         ai_mode: bool = True,
         watch: bool = False,
         content_indexing: bool = False,
@@ -624,8 +596,8 @@ class FileFinder:
 
     def search(
         self,
-        query: str,
         *,
+        query: str,
         limit: int = 100,
         page: int = 0,
         current_file=None,
@@ -655,8 +627,8 @@ class FileFinder:
 
     def glob(
         self,
-        pattern: str,
         *,
+        pattern: str,
         limit: int = 100,
         page: int = 0,
         current_file=None,
@@ -709,8 +681,8 @@ class FileFinder:
 
     def grep(
         self,
-        query: str,
         *,
+        query: str,
         mode: str,
         limit: int = 50,
         max_matches_per_file: int = 0,
@@ -724,13 +696,13 @@ class FileFinder:
     ) -> GrepResult:
         """Content search across indexed files.
 
-        ``mode`` is required (no default), so each call states its intent:
-        ``"plain"`` (fast SIMD literal), ``"regex"``, ``"fuzzy"``, or ``"smart"``
-        (regex when the query holds regex metacharacters and compiles, else a
-        literal).
+        ``mode`` is required (no default): ``"plain"`` (fast SIMD literal),
+        ``"regex"``, or ``"fuzzy"``.
         """
         self._check_open()
-        mode_byte = _GREP_MODES[_resolve_mode(query, mode)]
+        if mode not in _GREP_MODES:
+            raise ValueError(f"unknown grep mode {mode!r}; use 'plain', 'regex', or 'fuzzy'")
+        mode_byte = _GREP_MODES[mode]
         _validate_grep_args(
             limit,
             max_matches_per_file,
@@ -763,8 +735,8 @@ class FileFinder:
 
     def multi_grep(
         self,
-        patterns: list[str],
         *,
+        patterns: list[str],
         constraints: str | None = None,
         limit: int = 50,
         max_matches_per_file: int = 0,
@@ -893,9 +865,9 @@ _cache: OrderedDict[str, FileFinder] = OrderedDict()
 _cache_lock = threading.Lock()
 
 
-def finder(root=".", **kwargs) -> FileFinder:
+def finder(*, root, **kwargs) -> FileFinder:
     """Construct a `FileFinder` (does not scan; call `wait_for_scan` yourself)."""
-    return FileFinder(root, **kwargs)
+    return FileFinder(root=root, **kwargs)
 
 
 def _cached(root) -> FileFinder:
@@ -905,7 +877,7 @@ def _cached(root) -> FileFinder:
         if existing is not None and not existing._closed:
             _cache.move_to_end(key)
             return existing
-        ff = FileFinder(key, watch=True, content_indexing=True)
+        ff = FileFinder(root=key, watch=True, content_indexing=True)
         ff.wait_for_scan(10_000)
         _cache[key] = ff  # a fresh insert is already the most-recent (LRU) end
         while len(_cache) > _CACHE_MAX:
@@ -985,12 +957,12 @@ def _isolated_file_finder(abspath: str, tmp: str, *, content_indexing: bool) -> 
     """
     copy_name = os.path.basename(abspath).lstrip(".") or "file"
     shutil.copy2(abspath, os.path.join(tmp, copy_name))
-    ff = FileFinder(tmp, watch=False, content_indexing=content_indexing)
+    ff = FileFinder(root=tmp, watch=False, content_indexing=content_indexing)
     ff.wait_for_scan(10_000)
     return ff
 
 
-def find(query: str, path=".", *, limit: int = 100) -> SearchResult:
+def find(*, query: str, path, limit: int = 100) -> SearchResult:
     """Fuzzy file search over `path`, reusing a cached watched index.
 
     `path` may be a directory (searched whole) or a single file (searched on its
@@ -1002,24 +974,22 @@ def find(query: str, path=".", *, limit: int = 100) -> SearchResult:
     if only is None:
         if _is_unindexable_root(root):
             raise _refuse_unindexable_dir(root)
-        return _cached(root).search(query, limit=limit)
+        return _cached(root).search(query=query, limit=limit)
     with tempfile.TemporaryDirectory(prefix="ix-fff-file-") as tmp:
         with _isolated_file_finder(os.path.join(root, only), tmp, content_indexing=False) as ff:
-            result = ff.search(query, limit=limit)
+            result = ff.search(query=query, limit=limit)
     hits = [replace(h, path=only, name=only) for h in result.hits][:limit]
     return SearchResult(hits=hits, total_matched=len(hits), total_files=len(hits))
 
 
-def grep(query: str | list[str], path=".", *, mode: str, limit: int = 50) -> GrepResult:
+def grep(*, query: str | list[str], path, mode: str, limit: int = 50) -> GrepResult:
     """Content grep over `path`, reusing a cached watched (content-indexed) index.
 
     `query` is one pattern, or a list of patterns matched as literals in a single
     OR pass (Aho-Corasick) -- the one call for "where does any of these appear?",
     so you never loop grep over a list. `mode` is required (no default), so each
     call states its intent:
-      - one string: ``"plain"`` (fast SIMD literal), ``"regex"``, ``"fuzzy"``, or
-        ``"smart"`` (regex when the query holds regex metacharacters and compiles,
-        else a literal);
+      - one string: ``"plain"`` (fast SIMD literal), ``"regex"``, or ``"fuzzy"``;
       - a list: matched literally, so pass ``"plain"`` (for a regex, pass one
         string like ``"a|b"`` with ``"regex"``).
 
@@ -1038,7 +1008,11 @@ def grep(query: str | list[str], path=".", *, mode: str, limit: int = 50) -> Gre
         )
 
     def _run(ff: "FileFinder") -> GrepResult:
-        return ff.multi_grep(query, limit=limit) if multi else ff.grep(query, mode=mode, limit=limit)
+        return (
+            ff.multi_grep(patterns=query, limit=limit)
+            if multi
+            else ff.grep(query=query, mode=mode, limit=limit)
+        )
 
     root, only = _split_path(path)
     if only is None:
@@ -1057,17 +1031,14 @@ def grep(query: str | list[str], path=".", *, mode: str, limit: int = 50) -> Gre
     )
 
 
-async def afind(query: str, path=".", *, limit: int = 100) -> SearchResult:
+async def afind(*, query: str, path, limit: int = 100) -> SearchResult:
     """Async fuzzy file search: runs off the event loop (non-blocking)."""
-    return await asyncio.to_thread(find, query, path, limit=limit)
+    return await asyncio.to_thread(find, query=query, path=path, limit=limit)
 
 
-async def agrep(query: str | list[str], path=".", *, mode: str, limit: int = 50) -> GrepResult:
+async def agrep(*, query: str | list[str], path, mode: str, limit: int = 50) -> GrepResult:
     """Async content grep: runs off the event loop (non-blocking)."""
-    return await asyncio.to_thread(grep, query, path, mode=mode, limit=limit)
-
-
-import html as _html_mod
+    return await asyncio.to_thread(grep, query=query, path=path, mode=mode, limit=limit)
 
 
 class CodeMap:
@@ -1079,7 +1050,7 @@ class CodeMap:
     stays scannable on the dashboard.
     """
 
-    def __init__(self, query: "str | list[str]", matches: list["GrepMatch"]) -> None:
+    def __init__(self, *, query: "str | list[str]", matches: list["GrepMatch"]) -> None:
         self.query = query
         # A list query (multi-pattern OR) displays as ``a | b`` in the headers.
         self._query_str = query if isinstance(query, str) else " | ".join(query)
@@ -1157,7 +1128,7 @@ class CodeMap:
         if not self.matches:
             return (
                 '<div style="color:#6a6a70;font-style:italic">'
-                f"no matches for {_html_mod.escape(self._query_str)}</div>"
+                f"no matches for {html.escape(self._query_str)}</div>"
             )
         mono = "ui-monospace,SFMono-Regular,Menlo,monospace"
         blocks = []
@@ -1167,7 +1138,7 @@ class CodeMap:
             for m in hits:
                 mark = "\u25cf" if m.is_definition else "\u25cb"
                 mark_col = "#e6e6e6" if m.is_definition else "#55555b"
-                line_html = _html_mod.escape(m.line.rstrip())
+                line_html = html.escape(m.line.rstrip())
                 rows.append(
                     '<div style="display:flex;gap:10px;padding:1px 0">'
                     f'<span style="color:{mark_col};width:1em">{mark}</span>'
@@ -1177,7 +1148,7 @@ class CodeMap:
                 )
             summary = (
                 '<summary style="cursor:pointer;color:#e6e6e6;padding:4px 0">'
-                f"{_html_mod.escape(path)} "
+                f"{html.escape(path)} "
                 f'<span style="color:#6a6a70">\u00b7 {ndef} def / {len(hits)} hits</span>'
                 "</summary>"
             )
@@ -1187,7 +1158,7 @@ class CodeMap:
             )
         head = (
             '<div style="color:#6a6a70;padding:6px 10px">'
-            f"{_html_mod.escape(self._query_str)} \u00b7 {len(self.defs)} def \u00b7 "
+            f"{html.escape(self._query_str)} \u00b7 {len(self.defs)} def \u00b7 "
             f"{len(self.matches)} hits \u00b7 {len(self.by_file)} files</div>"
         )
         return (
@@ -1197,14 +1168,14 @@ class CodeMap:
         )
 
 
-def map(query: str | list[str], path=".", *, mode: str, limit: int = 200) -> CodeMap:
+def map(*, query: str | list[str], path, mode: str, limit: int = 200) -> CodeMap:
     """Content grep grouped into a :class:`CodeMap`: hits per file with
     definitions ranked first. A glanceable answer to "where is X defined and
     used?" built straight on :func:`grep`."""
-    return CodeMap(query, grep(query, path, mode=mode, limit=limit).matches)
+    return CodeMap(query=query, matches=grep(query=query, path=path, mode=mode, limit=limit).matches)
 
 
-async def amap(query: str | list[str], path=".", *, mode: str, limit: int = 200) -> CodeMap:
+async def amap(*, query: str | list[str], path, mode: str, limit: int = 200) -> CodeMap:
     """Async :func:`map`: the same code map, off the event loop."""
-    res = await agrep(query, path, mode=mode, limit=limit)
-    return CodeMap(query, res.matches)
+    res = await agrep(query=query, path=path, mode=mode, limit=limit)
+    return CodeMap(query=query, matches=res.matches)


### PR DESCRIPTION
Makes the fff search API maximally explicit, with no hidden fallbacks — following the same "one unified, explicit way" direction as #896/#897/#899.

## What changed
- **Keyword-only everywhere.** The search term (`query`/`pattern`/`patterns`), `path`/`root`, `mode`, and `limit` must all be named:
  ```python
  fff.grep(query="prompt|shokunin", path=".", mode="regex")
  fff.grep(query=["TODO", "FIXME"], path="src", mode="plain")
  ```
  No more `grep("foo", "src")` ambiguity ("is that a path or a second query?").
- **`path`/`root` required** (no `"."` default), so a search never silently runs against whatever the kernel's cwd happens to be.
- **Removed the `smart` mode.** Its regex-vs-literal auto-detect (regex when the query compiles, else a silent fall back to plain) was exactly a hidden fallback and a redundant fourth way to grep. Modes are now the three honest ones: `plain` | `regex` | `fuzzy`. The caller is always explicit.

Applies to `fff.find`/`grep`/`map` + async variants, `fff.finder`, `FileFinder.__init__`/`search`/`glob`/`grep`/`multi_grep`, and `CodeMap`. Every call site migrated to keyword form. Also moved the stray mid-file `import html` to the top — the file is now ruff-clean.

## Tests
`nix build .#mcp.tests.{fffBundled,viewSmoke}` → green. New/updated coverage asserts the positional-call / missing-`path` / missing-`mode` TypeErrors and that `mode="smart"` is now rejected.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require keyword-only args and remove `smart` grep mode from `fff` API
> - All public functions and methods in `fff` now use keyword-only arguments; positional calls to `find`, `grep`, `map`, `FileFinder`, etc. raise `TypeError`.
> - `path` is now required on `find`, `grep`, `afind`, `agrep`, `map`, and `amap` — no default path is inferred.
> - `mode='smart'` is removed from `FileFinder.grep`; passing it (or any unknown mode) now raises `ValueError`. Callers must explicitly pass `mode='literal'` or `mode='regex'`.
> - Tests in [default.nix](https://github.com/indexable-inc/index/pull/901/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) are updated to assert `ValueError` for `mode='smart'` and `TypeError` for positional or missing required args.
> - Risk: any existing caller using positional arguments or `mode='smart'` will break at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 858ef9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->