### PR TITLE
feat(mcp): expose an embeddable results API over the execution store

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -923,6 +923,120 @@ let
         mkdir -p "$out"
       '';
 
+  # The read-only data API is also the embedding contract: a host (the room
+  # server runs `ix-mcp` as its agent's only tool) reads the agent's rich
+  # results back over HTTP and renders them in its own UI. Exercise that path
+  # in-process: seed the store, start the dashboard server, and assert the JSON
+  # routes (incl. the by-id lookup an embedder keys off the job id in a tool
+  # reply) return the run's nbformat output bundles, cells, and live resources.
+  apiTest = pkgs.writeText "ix-mcp-api-test.py" ''
+    import asyncio, tempfile
+    from pathlib import Path
+
+    import aiohttp
+
+    from ix_notebook_mcp import cli, dashboard, store
+    from ix_notebook_mcp.config import Config, set_config
+
+    # An embedder pins the data-API port so it knows where to reach this instance.
+    import os
+
+    os.environ["IX_MCP_DASHBOARD_PORT"] = "54321"
+    assert cli._dashboard_port() == 54321, cli._dashboard_port()
+    os.environ.pop("IX_MCP_DASHBOARD_PORT")
+    assert isinstance(cli._dashboard_port(), int)
+
+    tmp = Path(tempfile.mkdtemp())
+    store_path = tmp / "store.db"
+    conn = store.connect(store_path)
+    rich = [
+        {
+            "output_type": "execute_result",
+            "data": {
+                "text/plain": "shape: (1, 1)",
+                "text/html": "<table><tr><td>1</td></tr></table>",
+            },
+        }
+    ]
+    store.start(conn, id="job1", name="demo", code="df.head()", started_at=1000.0, budget=15.0)
+    store.finish(
+        conn,
+        id="job1",
+        status="done",
+        ended_at=1001.0,
+        output="stdout tail",
+        result="ok",
+        error=None,
+        outputs=rich,
+        bindings={"df": {"summary": "DataFrame"}},
+    )
+    store.replace_cells(conn, [{"id": "c1", "title": "Result", "position": 0, "outputs": rich}])
+    store.upsert_resource(
+        conn, id="r1", title="Live", kind="html", html="<b>hi</b>", status="live",
+        created_at=1000.0, updated_at=1000.0,
+    )
+
+    cfg = Config(
+        workdir=tmp, host="127.0.0.1", advertised_host="127.0.0.1",
+        dashboard_port=cli._free_port(), store_path=store_path,
+    )
+    set_config(cfg)
+
+    async def main():
+        runner = await dashboard.start(cfg)
+        base = f"http://127.0.0.1:{cfg.dashboard_port}"
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(base + "/api/jobs") as resp:
+                    jobs = await resp.json()
+                assert len(jobs) == 1 and jobs[0]["id"] == "job1", jobs
+                assert jobs[0]["outputs"] == rich, jobs[0]["outputs"]
+                assert jobs[0].get("code_html"), "expected highlighted code"
+
+                async with session.get(base + "/api/jobs/job1") as resp:
+                    assert resp.status == 200, resp.status
+                    one = await resp.json()
+                assert one["id"] == "job1" and one["outputs"] == rich
+                assert one["bindings"] == {"df": {"summary": "DataFrame"}}, one["bindings"]
+
+                async with session.get(base + "/api/jobs/nope") as resp:
+                    assert resp.status == 404, resp.status
+
+                async with session.get(base + "/api/cells") as resp:
+                    cells = await resp.json()
+                assert cells[0]["id"] == "c1" and cells[0]["outputs"] == rich
+
+                async with session.get(base + "/api/resources") as resp:
+                    resources = await resp.json()
+                assert resources[0]["id"] == "r1" and resources[0]["html"] == "<b>hi</b>"
+        finally:
+            await runner.cleanup()
+
+    asyncio.run(main())
+    print("api-ok")
+  '';
+  apiSmoke =
+    pkgs.runCommand "ix-mcp-api-smoke"
+      {
+        nativeBuildInputs = [ mcpPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        ${mcpPython}/bin/python3 ${apiTest} >stdout 2>stderr || {
+          echo "ix-mcp api smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -qx 'api-ok' stdout || {
+          echo "ix-mcp api smoke did not confirm the embedding data API:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
+
   # Exercises the in-kernel runtime (ix_notebook_mcp/runtime.py) in-process: two
   # jobs run concurrently on one event loop, neither blocks the other, each keeps
   # its own captured stdout, and the trailing expression is captured as the
@@ -2381,6 +2495,7 @@ package.overrideAttrs (old: {
         yieldSmoke
         bindingsSmoke
         bindDefaultSmoke
+        apiSmoke
         viewSmoke
         nixSmoke
         fleetSmoke

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -85,6 +85,17 @@ def _free_port() -> int:
         return sock.getsockname()[1]
 
 
+def _dashboard_port() -> int:
+    """The port the read-only data API / dashboard binds. An embedder (the room
+    server runs ``ix-mcp`` as its agent's tool and reads results back over HTTP)
+    pins it with ``IX_MCP_DASHBOARD_PORT`` so it knows where to reach this
+    instance; left unset, a free port is chosen so a bare run never collides."""
+    pinned = os.environ.get("IX_MCP_DASHBOARD_PORT")
+    if pinned:
+        return int(pinned)
+    return _free_port()
+
+
 def _tailscale_status() -> dict | None:
     tailscale = shutil.which("tailscale") or next(
         (p for p in ("/usr/local/bin/tailscale", "/usr/bin/tailscale") if os.path.exists(p)), None
@@ -159,7 +170,7 @@ def _serve(args: argparse.Namespace) -> int:
         host, _, port = http.partition(":")
         mcp_http_host, mcp_http_port = host or "127.0.0.1", int(port) if port else 8000
 
-    dashboard_port = _free_port()
+    dashboard_port = _dashboard_port()
     store_path = runtime_dir() / f"store-{dashboard_port}.db"
     # Fresh execution log per server: if this port was used by a prior server,
     # drop its database (and WAL sidecars) so the dashboard never shows stale runs.

--- a/packages/mcp/ix_notebook_mcp/dashboard.py
+++ b/packages/mcp/ix_notebook_mcp/dashboard.py
@@ -11,6 +11,23 @@ so a human can watch every running "thing" and its output like a notebook.
 The page diffs the DOM reactively (Svelte) instead of rebuilding it, so scroll
 position and open panels survive each refresh. When the env var is unset (a bare
 run outside nix), a small stub explains how to build the UI.
+
+The JSON routes are also the stable *embedding contract*: a host that runs
+``ix-mcp`` to drive an agent (the room server points its Codex at this MCP as the
+agent's only tool) reads the agent's rich results back over HTTP and renders them
+in its own UI. The host pins the address with ``IX_MCP_HOST`` + ``IX_MCP_DASHBOARD_PORT``
+so it knows where to reach this instance, then polls:
+
+  - ``GET /api/jobs``       recent runs, newest first (running first), each with
+                            ``code``, ``status``, ``output`` (stdout tail) and
+                            ``outputs`` (nbformat display bundles: ``text/plain``,
+                            ``text/html``, ``image/png`` for the human view).
+  - ``GET /api/jobs/<id>``  one run by id (404 if unknown). The model-facing
+                            ``python_exec`` reply carries the job id, so the host
+                            fetches exactly the run behind a tool call and renders
+                            its tables/images/HTML inline.
+  - ``GET /api/resources``  live, self-updating HTML widgets (a Tui screen, a VM).
+  - ``GET /api/cells``      the agent's curated presentation pane, in order.
 """
 
 from __future__ import annotations
@@ -179,12 +196,20 @@ async def start(config: Config) -> web.AppRunner:
     async def index(_request: web.Request) -> web.Response:
         return web.Response(text=_PAGE, content_type="text/html")
 
+    def with_code_html(row: dict) -> dict:
+        # Highlight once per unique snippet (cached); the card renders it.
+        row["code_html"] = _code_html(row.get("code") or "")
+        return row
+
     async def jobs(_request: web.Request) -> web.Response:
-        rows = store.recent(conn, limit=200)
-        for row in rows:
-            # Highlight once per unique snippet (cached); the card renders it.
-            row["code_html"] = _code_html(row.get("code") or "")
+        rows = [with_code_html(row) for row in store.recent(conn, limit=200)]
         return web.json_response(rows)
+
+    async def job(request: web.Request) -> web.Response:
+        row = store.get(conn, request.match_info["id"])
+        if row is None:
+            return web.json_response({"error": "no such job"}, status=404)
+        return web.json_response(with_code_html(row))
 
     async def resources(_request: web.Request) -> web.Response:
         return web.json_response(store.live_resources(conn))
@@ -194,6 +219,7 @@ async def start(config: Config) -> web.AppRunner:
 
     app.router.add_get("/", index)
     app.router.add_get("/api/jobs", jobs)
+    app.router.add_get("/api/jobs/{id}", job)
     app.router.add_get("/api/resources", resources)
     app.router.add_get("/api/cells", cells)
     runner = web.AppRunner(app)

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -150,6 +150,26 @@ def recent(conn: sqlite3.Connection, limit: int = 100) -> list[dict]:
     return out
 
 
+def get(conn: sqlite3.Connection, id: str) -> dict | None:
+    """One execution by id, or None, as a plain dict (same shape as a
+    :func:`recent` row). The by-id lookup an embedder uses to fetch the rich
+    outputs of a specific run: the model-facing ``python_exec`` reply carries the
+    job id, so a host (e.g. the room server) reads ``GET /api/jobs/<id>`` to
+    render that run's tables/images/HTML in its own UI."""
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT id, name, code, status, started_at, ended_at, budget, output, result, error, outputs, bindings "
+        "FROM executions WHERE id = ?",
+        (id,),
+    ).fetchone()
+    if row is None:
+        return None
+    d = dict(row)
+    d["outputs"] = json.loads(d.get("outputs") or "[]")
+    d["bindings"] = json.loads(d.get("bindings") or "{}")
+    return d
+
+
 # --------------------------------------------------------------------------- #
 # Cells: the agent's curated presentation pane.
 #


### PR DESCRIPTION
## What

Make the `ix-mcp` execution store readable from outside the process, so a host that embeds `ix-mcp` (the room server runs Codex with `ix-mcp` as the agent's only tool) can fetch the agent's rich results and render them in its own chat UI.

- **`IX_MCP_DASHBOARD_PORT`** pins the data-API port (`cli._dashboard_port`). Today the port is a random free port announced only to the co-located dashboard, so an embedder can't address a specific instance. With the pin, the host sets the port when it launches `ix-mcp` and knows exactly where to poll.
- **`GET /api/jobs/<id>`** (backed by `store.get`) returns a single run by id, 404 otherwise. The model-facing `python_exec` reply already carries the job id, so the host fetches exactly the run behind a tool call and renders its tables/images/HTML inline rather than scanning the recent list.
- The dashboard module docstring now documents `/api/{jobs, jobs/<id>, resources, cells}` as the stable **embedding contract**.

## Why

First step toward merging the room server with `ix-mcp`: the agent does its work and *display* through `python_exec`/`Result`, and the room server is the surface that renders those results. That needs an addressable, by-run results API. This is decision-independent groundwork (true under any room-server topology) and changes no existing behavior: the dashboard still binds a free port when the env var is unset.

## Test

New `apiSmoke` (`packages/mcp/default.nix`, registered in `passthru.tests`): seeds the store, starts the server, and asserts the JSON routes (including the 404 and by-id paths) return the run's nbformat bundles, cells, and live resources. Built green via `nix build .#mcp.tests.apiSmoke`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose a JSON results API over the MCP execution store
> - Adds `GET /api/jobs/{id}` to the dashboard server, returning a single execution as JSON with `code_html` syntax highlighting, or a 404 when the id is unknown.
> - Adds `store.get` in [store.py](https://github.com/indexable-inc/index/pull/902/files#diff-a4763dded9f44ec2a563e568a62d900b996c6a956b6de36462468f1d2b03b976) to fetch a single execution row by id with outputs and bindings parsed from JSON.
> - Introduces `_dashboard_port()` in [cli.py](https://github.com/indexable-inc/index/pull/902/files#diff-7ce741e8223d63fdea11625cb78abad266299445db0213d2355bc93306df9ac5) so the dashboard port can be pinned via `IX_MCP_DASHBOARD_PORT`, falling back to a free port when unset.
> - Adds an `apiSmoke` Nix check in [default.nix](https://github.com/indexable-inc/index/pull/902/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) that seeds the store, starts the server, and asserts `/api/jobs`, `/api/jobs/{id}`, `/api/cells`, and `/api/resources` return expected JSON structures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4895d29.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->