### PR TITLE
feat(mcp): expose the agent presentation as an embeddable feed

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -92,6 +92,27 @@ list lives in one place, the MCP server `instructions=` string in
 backs it is assembled in [`default.nix`](./default.nix). Both are kept here
 rather than re-enumerated in this README so the list cannot drift.
 
+## Embedding (the room server)
+
+The same rich feed the dashboard renders is the contract an embedder consumes.
+`ix_notebook_mcp/feed.py` is the single source of truth for the agent's
+presentation as structured data; the dashboard is one view of it, the room
+server is another. Read it two ways:
+
+- In-process: `feed.snapshot(conn)` returns `{jobs, cells, resources, rev}`, and
+  `feed.job(conn, id)` returns one execution by id. `rev` is a cheap change
+  marker so a poller re-renders only when something moved.
+- Over HTTP (what an out-of-process embedder like the Rust room server uses):
+  `GET /api/snapshot` is the whole feed; `GET /api/jobs/{id}` is one run.
+
+`jobs` carry rich `outputs` as nbformat-style mime bundles: `text/html` is the
+human view, `application/x-ix-llm+json` is what the model received. A
+`python_exec` tool result already names its run as `jobs['<id>']`, so an embedder
+parses that id and fetches `/api/jobs/{id}` to render that turn's tables, plots,
+and HTML inline beside the agent's text. `cells` is the agent's curated highlight
+reel (`cells.add(...)`), and `resources` are live, self-updating views. The JSON
+shape mirrors `site/src/lib/types.ts`.
+
 ## Remote access
 
 - `IX_MCP_HOST`: the address the dashboard binds. Default is this node's

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1104,6 +1104,74 @@ let
 
     print("runtime-ok")
   '';
+  # Locks the embed contract (ix_notebook_mcp/feed.py): the dashboard and the
+  # room server both read the agent's presentation through `feed`, so prove a
+  # snapshot returns running-pinned jobs with decoded rich outputs, the curated
+  # cells and live resources, a change marker that advances as a running job
+  # streams output, and that `feed.job` fetches one run by the id a python_exec
+  # tool result names (and None for a miss).
+  feedTestPy = pkgs.writeText "ix-mcp-feed-test.py" ''
+    import tempfile
+    import time
+
+    from ix_notebook_mcp import feed, store
+
+    conn = store.connect(tempfile.mktemp(suffix=".db"))
+    now = time.time()
+    store.start(conn, id="aa11", name="run1", code="Result.of(df)", started_at=now, budget=15.0)
+    store.finish(
+        conn, id="aa11", status="done", ended_at=now + 1, output="hi", result="42 rows",
+        error=None, outputs=[{"data": {"text/html": "<table>x</table>"}}],
+        bindings={"df": {"kind": "DataFrame"}},
+    )
+    store.start(conn, id="bb22", name="run2", code="time.sleep(99)", started_at=now + 2, budget=5.0)
+    store.replace_cells(conn, [{"id": "cell0", "title": "latency", "position": 0,
+                                "outputs": [{"data": {"text/html": "<b>p50</b>"}}]}])
+    store.upsert_resource(conn, id="res0", title="term", kind="html", html="<pre>$</pre>",
+                          status="live", created_at=now, updated_at=now)
+
+    snap = feed.snapshot(conn)
+    assert len(snap["jobs"]) == 2, snap["jobs"]
+    assert snap["jobs"][0]["id"] == "bb22", "running job must pin first"
+    done = snap["jobs"][1]
+    assert done["outputs"][0]["data"]["text/html"] == "<table>x</table>", done
+    assert done["bindings"] == {"df": {"kind": "DataFrame"}}, done
+    assert snap["cells"][0]["outputs"][0]["data"]["text/html"] == "<b>p50</b>", snap["cells"]
+    assert snap["resources"][0]["html"] == "<pre>$</pre>", snap["resources"]
+    assert isinstance(snap["rev"], str), snap["rev"]
+
+    one = feed.job(conn, "aa11")
+    assert one is not None and one["result"] == "42 rows", one
+    assert one["outputs"][0]["data"]["text/html"] == "<table>x</table>", one
+    assert feed.job(conn, "nope") is None
+
+    store.update_output(conn, "bb22", "tick tick tick")
+    assert feed.snapshot(conn)["rev"] != snap["rev"], "rev must advance on streamed output"
+
+    print("feed-ok")
+  '';
+  feedSmoke =
+    pkgs.runCommand "ix-mcp-feed-smoke"
+      {
+        nativeBuildInputs = [ mcpPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        ${lib.getExe mcpPython} ${feedTestPy} >stdout 2>stderr || {
+          echo "ix-mcp feed smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -qx 'feed-ok' stdout || {
+          echo "ix-mcp feed smoke did not confirm the embed contract:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
+
   runtimeSmoke =
     pkgs.runCommand "ix-mcp-runtime-smoke"
       {
@@ -2376,6 +2444,7 @@ package.overrideAttrs (old: {
         serverTools
         evalSmoke
         runtimeSmoke
+        feedSmoke
         wedgeSmoke
         richSmoke
         yieldSmoke

--- a/packages/mcp/ix_notebook_mcp/dashboard.py
+++ b/packages/mcp/ix_notebook_mcp/dashboard.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 from aiohttp import web
 
-from . import store
+from . import feed, store
 from .config import Config
 
 _STUB = (
@@ -179,12 +179,16 @@ async def start(config: Config) -> web.AppRunner:
     async def index(_request: web.Request) -> web.Response:
         return web.Response(text=_PAGE, content_type="text/html")
 
-    async def jobs(_request: web.Request) -> web.Response:
-        rows = store.recent(conn, limit=200)
+    def _highlight(rows: list[dict]) -> list[dict]:
+        # Highlight each job's source once per unique snippet (cached); the
+        # dashboard card renders the spans. This is a dashboard-only view detail,
+        # so it is layered here, not in `feed` (an embedder highlights its own way).
         for row in rows:
-            # Highlight once per unique snippet (cached); the card renders it.
             row["code_html"] = _code_html(row.get("code") or "")
-        return web.json_response(rows)
+        return rows
+
+    async def jobs(_request: web.Request) -> web.Response:
+        return web.json_response(_highlight(store.recent(conn, limit=feed.JOBS_LIMIT)))
 
     async def resources(_request: web.Request) -> web.Response:
         return web.json_response(store.live_resources(conn))
@@ -192,10 +196,26 @@ async def start(config: Config) -> web.AppRunner:
     async def cells(_request: web.Request) -> web.Response:
         return web.json_response(store.cells(conn))
 
+    async def snapshot(_request: web.Request) -> web.Response:
+        # The whole presentation in one read, the embed contract an external
+        # consumer (the room server) polls; `rev` lets it skip unchanged renders.
+        return web.json_response(feed.snapshot(conn))
+
+    async def job(request: web.Request) -> web.Response:
+        # One execution by id: the rich outputs for the `jobs['<id>']` a
+        # python_exec tool result already names, so an embedder renders that run's
+        # tables/plots/HTML beside the tool call.
+        one = feed.job(conn, request.match_info["id"])
+        if one is None:
+            return web.json_response({"error": "no such job"}, status=404)
+        return web.json_response(one)
+
     app.router.add_get("/", index)
     app.router.add_get("/api/jobs", jobs)
+    app.router.add_get("/api/jobs/{id}", job)
     app.router.add_get("/api/resources", resources)
     app.router.add_get("/api/cells", cells)
+    app.router.add_get("/api/snapshot", snapshot)
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, config.host, config.dashboard_port)

--- a/packages/mcp/ix_notebook_mcp/feed.py
+++ b/packages/mcp/ix_notebook_mcp/feed.py
@@ -1,0 +1,72 @@
+"""The agent's presentation as structured data: the single source of truth that
+both the read-only dashboard and any embedder (the room server) consume.
+
+The dashboard (``dashboard.py``) is one view of this feed, served over HTTP. The
+room server is another: it spawns ``ix-mcp`` as the agent's only tool, then
+renders the same feed inline in the chat so a turn's tables, plots, and HTML show
+up beside the agent's text. Both read the feed the same way -- in-process by
+importing this module, or over HTTP via the ``/api/...`` routes ``dashboard.py``
+wraps around it -- so the shape is defined once, here.
+
+Three kinds, mirroring the store tables (``store.py``) and ``site/src/lib/types.ts``:
+
+- ``jobs``: every ``python_exec`` run (running or finished), newest first with
+  running pinned. Each carries its rich ``outputs`` as nbformat-style mime
+  bundles: ``text/html`` is the human view, ``application/x-ix-llm+json`` is what
+  the model received. An embedder joins one job by its id (the id a
+  ``python_exec`` tool result already names) to render that run's outputs inline.
+- ``cells``: the agent's curated highlight reel (``cells.add(...)`` in the
+  kernel), in display order. The presentation pane a chat surfaces as artifacts.
+- ``resources``: live, self-updating views (a running terminal, a custom widget),
+  re-rendered to HTML for as long as their source stays alive.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from . import store
+
+# How many recent executions a snapshot carries. Matches the dashboard's prior
+# inline limit; running jobs are pinned first by `store.recent`, so an active run
+# is never dropped past it.
+JOBS_LIMIT = 200
+
+
+def snapshot(conn: sqlite3.Connection, *, jobs_limit: int = JOBS_LIMIT) -> dict:
+    """The whole presentation in one read: ``{"jobs", "cells", "resources"}``.
+
+    The embed contract. A consumer polls this (or, in-process, calls it) to get
+    the agent's full current presentation; ``rev`` lets it skip rendering when
+    nothing changed (a cheap-to-compute change marker, not a content hash)."""
+    jobs = store.recent(conn, limit=jobs_limit)
+    cells = store.cells(conn)
+    resources = store.live_resources(conn)
+    return {
+        "jobs": jobs,
+        "cells": cells,
+        "resources": resources,
+        "rev": _rev(jobs, cells, resources),
+    }
+
+
+def job(conn: sqlite3.Connection, job_id: str) -> dict | None:
+    """One execution by id, or ``None`` -- the rich outputs for the
+    ``jobs['<id>']`` a ``python_exec`` tool result names, so an embedder renders
+    that run's tables/plots/HTML beside the tool call that produced them."""
+    return store.get(conn, job_id)
+
+
+def _rev(jobs: list[dict], cells: list[dict], resources: list[dict]) -> str:
+    """A change marker for the snapshot: a consumer that polls re-renders only
+    when this differs. Built from each row's id and last-write time (``ended_at``
+    / ``updated_at``) plus a running job's live ``output`` length, so an in-flight
+    job streaming output advances the marker without hashing whole payloads."""
+    parts: list[str] = []
+    for j in jobs:
+        parts.append(f"j{j['id']}:{j.get('status')}:{j.get('ended_at') or len(j.get('output') or '')}")
+    for c in cells:
+        parts.append(f"c{c['id']}:{c.get('updated_at')}")
+    for r in resources:
+        parts.append(f"r{r['id']}:{r.get('updated_at')}:{r.get('status')}")
+    return str(hash(tuple(parts)))

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -131,23 +131,43 @@ def finish(
     )
 
 
+# The execution columns every reader projects, in one place so `recent` and
+# `get` return the identical shape (the embed contract in feed.py depends on it).
+_EXEC_COLUMNS = (
+    "id, name, code, status, started_at, ended_at, budget, output, result, error, outputs, bindings"
+)
+
+
+def _exec_row(row: sqlite3.Row) -> dict:
+    """One execution row as a plain dict with its JSON columns decoded."""
+    d = dict(row)
+    d["outputs"] = json.loads(d.get("outputs") or "[]")
+    d["bindings"] = json.loads(d.get("bindings") or "{}")
+    return d
+
+
 def recent(conn: sqlite3.Connection, limit: int = 100) -> list[dict]:
     """The most recent executions, newest first, as plain dicts for the dashboard."""
     conn.row_factory = sqlite3.Row
     # Running jobs sort first so a long-running job is never dropped by the limit
     # (a finished-jobs backlog could otherwise push it past LIMIT); then newest.
     rows = conn.execute(
-        "SELECT id, name, code, status, started_at, ended_at, budget, output, result, error, outputs, bindings "
+        f"SELECT {_EXEC_COLUMNS} "
         "FROM executions ORDER BY (status = 'running') DESC, started_at DESC LIMIT ?",
         (limit,),
     ).fetchall()
-    out = []
-    for r in rows:
-        d = dict(r)
-        d["outputs"] = json.loads(d.get("outputs") or "[]")
-        d["bindings"] = json.loads(d.get("bindings") or "{}")
-        out.append(d)
-    return out
+    return [_exec_row(r) for r in rows]
+
+
+def get(conn: sqlite3.Connection, id: str) -> dict | None:
+    """One execution by id (or None), same shape as a `recent` row. An embedder
+    joins this to the ``jobs['<id>']`` a ``python_exec`` tool result already names,
+    to render that run's rich outputs inline with the tool call."""
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        f"SELECT {_EXEC_COLUMNS} FROM executions WHERE id = ?", (id,)
+    ).fetchone()
+    return _exec_row(row) if row is not None else None
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

Expose the ix-mcp agent presentation (rich `python_exec` outputs, curated cells, live resources) as an embeddable feed, so the room server can run ix-mcp as an agent's only tool and render those results inline in the chat.

- `feed.py`: single source of truth for the presentation as structured data. `feed.snapshot(conn)` -> `{jobs, cells, resources, rev}`; `feed.job(conn, id)` -> one run by the id a `python_exec` tool result already names. `rev` is a cheap change marker.
- `store.get(conn, id)`: one execution by id; `recent`/`get` share one column list + row decoder.
- `dashboard.py`: reads through `feed`; adds `GET /api/snapshot` and `GET /api/jobs/{id}` for an out-of-process embedder. Code highlighting stays a dashboard-only view detail.
- `feedSmoke` nix test locks the contract.

## Why

The rich `user_html`/cells outputs only fed the read-only dashboard. The room server needs the same feed to display turn results beside the agent's text. This names the seam (one step toward driving codex in room-server through ix-mcp as its only tool).

## Validation

`nix build .#mcp.tests.feedSmoke` is green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose agent presentation as an embeddable feed via `feed.snapshot` and `feed.job`
> - Adds [feed.py](https://github.com/indexable-inc/index/pull/904/files#diff-b03d5c23bfa6e90d2be49cf52abcd83fee950e45d7608b3e98430d17c81c326e) with `snapshot()` (returns jobs, cells, resources, and a `rev` change marker) and `job(id)` (returns a single execution with decoded outputs/bindings).
> - The `rev` marker advances as running job output grows and when jobs/cells/resources change, allowing efficient polling without hashing full payloads.
> - Exposes two new HTTP endpoints in [dashboard.py](https://github.com/indexable-inc/index/pull/904/files#diff-42d31638eb95030752ef7a84f47bf14ecd13cbfe141948c40115b8cae061ce5e): `GET /api/snapshot` and `GET /api/jobs/{id}` (returns 404 with `{"error": "no such job"}` if missing).
> - Adds `store.get()` in [store.py](https://github.com/indexable-inc/index/pull/904/files#diff-a4763dded9f44ec2a563e568a62d900b996c6a956b6de36462468f1d2b03b976) to fetch a single execution by id, sharing column projection and JSON decoding with `store.recent()`.
> - A new smoke test in [default.nix](https://github.com/indexable-inc/index/pull/904/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) validates the feed contract including rev progression and job fetching.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 740c62a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->