### PR TITLE
feat(mcp): gate Gmail/Calendar to incognito sessions

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -800,6 +800,22 @@ let
 
     assert callable(google_auth.credentials)
     assert callable(google_auth.gmail) and callable(google_auth.calendar)
+
+    # Gmail/Calendar are gated to an incognito (private) session. Outside one
+    # (IX_MCP_PRIVATE unset) minting refuses before it ever looks for the grant,
+    # so a synced chat can never reach the personal credential.
+    os.environ.pop("IX_MCP_PRIVATE", None)
+    os.environ["IX_GCAL_BIN"] = "/nonexistent/gcal"
+    try:
+        google_auth.credentials()
+    except google_auth.GoogleAuthError as exc:
+        assert "incognito" in str(exc).lower(), exc
+    else:
+        raise SystemExit("expected GoogleAuthError when the session is not private")
+
+    # Inside a private session the gate passes; minting then fails on the missing
+    # binary instead, proving the gate is the only thing that blocked it before.
+    os.environ["IX_MCP_PRIVATE"] = "1"
     os.environ.pop("IX_GCAL_BIN", None)
     try:
         google_auth.credentials()

--- a/packages/mcp/src/google_auth/google_auth/__init__.py
+++ b/packages/mcp/src/google_auth/google_auth/__init__.py
@@ -22,6 +22,13 @@ The grant covers Gmail (read/modify/send) and Calendar events. It needs a
 one-time `gcal auth` on the host running the MCP server; until then (or if the
 stored grant predates the Gmail scopes) calls raise `GoogleAuthError` with that
 instruction.
+
+Gmail and Calendar reach the user's personal mailbox and schedule, so they are
+gated to an **incognito (private) session**: a chat whose transcript is never
+replicated to the shared room. The MCP server the room spawns for incognito
+threads sets ``IX_MCP_PRIVATE=1`` (and is the only one given the gcal grant), so
+minting a token outside that context raises `GoogleAuthError`. This keeps a
+personal credential, and any mail it reads, off the synced room state.
 """
 
 from __future__ import annotations
@@ -52,7 +59,30 @@ class GoogleAuthError(RuntimeError):
     """Raised when an access token cannot be minted from the stored grant."""
 
 
+# The env var the room sets on the MCP instance backing incognito threads. Gmail
+# and Calendar refuse to mint a token unless it is truthy, so a normal (synced)
+# chat can never reach the personal Google grant even if the binary is on PATH.
+PRIVATE_ENV = "IX_MCP_PRIVATE"
+
+
+def _require_private() -> None:
+    """Allow token minting only inside an incognito session.
+
+    Gmail/Calendar read personal data; binding them to ``IX_MCP_PRIVATE`` keeps
+    that access (and the credential behind it) inside chats that never sync to
+    the shared room. The room runs a dedicated, private MCP for incognito
+    threads and routes only those threads to it.
+    """
+    if not os.environ.get(PRIVATE_ENV):
+        raise GoogleAuthError(
+            "Gmail and Calendar are available only in an incognito chat (the "
+            "session is not private). Start an incognito chat to use them; their "
+            "credential is scoped to that context and never reaches the shared room."
+        )
+
+
 def _mint() -> dict:
+    _require_private()
     binary = os.environ.get("IX_GCAL_BIN")
     if not binary:
         raise GoogleAuthError("IX_GCAL_BIN is not set; the gcal binary is bundled into ix-mcp")


### PR DESCRIPTION
## What

Gmail and Calendar reach the user's personal mailbox/schedule, so they should only be usable in an **incognito (private) chat** whose transcript never syncs to the shared room. This gates token minting in `google_auth._mint` (the single chokepoint behind `credentials()`/`gmail()`/`calendar()`/`service()`) on `IX_MCP_PRIVATE`:

- Outside a private session → `GoogleAuthError("...available only in an incognito chat...")` before the grant is ever consulted.
- The room runs a dedicated private MCP for incognito threads (the only instance given the gcal grant + `GOOGLE_OAUTH_*`/token), and routes only those threads to it (ix-side change), so the credential is scoped to that context. `ix_google`'s lower-level `Client` is enforced by that credential absence in the normal MCP.

## Test

`googleAuthBundled` now asserts both legs: refused (message mentions "incognito") when not private; past the gate (fails on missing `IX_GCAL_BIN`) when private.

Pairs with the ix room-side change that spawns the private MCP for incognito threads.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate Gmail/Calendar token minting to incognito sessions via `IX_MCP_PRIVATE`
> - Adds a `_require_private()` helper in [`google_auth/__init__.py`](https://github.com/indexable-inc/index/pull/908/files#diff-a31e9489e608de89bdd19aa1fb80b8fc8d42366733c8d9c7dd260771bec32bd9) that raises `GoogleAuthError` (with incognito guidance) when `IX_MCP_PRIVATE` is unset or falsy.
> - Prepends this check in `_mint()` so token minting fails before any binary lookup or credential access outside a private session.
> - Motivation: prevents personal Gmail/Calendar credentials and data from reaching shared room state.
> - Adds tests in [`default.nix`](https://github.com/indexable-inc/index/pull/908/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) asserting the gate rejects calls without `IX_MCP_PRIVATE=1` and passes through to the next failure (missing binary) when it is set.
> - Behavioral Change: `google_auth.credentials()` now raises `GoogleAuthError` in non-incognito sessions where it previously would have proceeded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a1de61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->