### PR TITLE
fix(lib): drop removed checkAssertWarn in dimension-type (unbreaks downstream lib eval)

### DIFF
--- a/lib/minecraft/dimension-type.nix
+++ b/lib/minecraft/dimension-type.nix
@@ -64,7 +64,10 @@ let
         }
       ];
     in
-    lib.checkAssertWarn checks [ ] rendered;
+    # Assert every check (each carries its own message), then return `rendered`.
+    # Matches the `assert lib.assertMsg ...` idiom the rest of lib/ uses; the
+    # old `lib.checkAssertWarn` helper was removed in the lib/builtins refactor.
+    lib.foldl' (val: c: assert lib.assertMsg c.assertion c.message; val) rendered checks;
 
   # Project a dimensionTypes submodule value to the JSON written to disk: strip
   # the `base` field, merge the named vanilla snapshot underneath, default


### PR DESCRIPTION
## Problem

The lib/builtins idioms refactor (#877) removed the `checkAssertWarn` helper and converted assertion sites tree-wide to `assert lib.assertMsg (cond) msg;`, but **missed one straggler**: `lib/minecraft/dimension-type.nix:67` still calls the now-deleted helper:

```nix
in
lib.checkAssertWarn checks [ ] rendered;
```

Any evaluation that forces this file fails:

```
error: attribute 'checkAssertWarn' missing
    67|     lib.checkAssertWarn checks [ ] rendered;
```

This is currently breaking downstream consumers that evaluate `lib`. Concretely, **indexable-inc/ix's required `build` check is red on `main`** (and on every open ix PR) for exactly this reason — ix pins this `index` rev, and evaluating `.#required-ci-checks` forces this file.

`checkAssertWarn` has no remaining definition anywhere in the repo (`rg` confirms the call site is the only occurrence), so this is a dangling reference, not a load-order issue.

## Fix

Convert the straggler to the same idiom the rest of `lib/` now uses — fold over the checks, asserting each via `lib.assertMsg` (keeping each check's own message), and return `rendered`:

```nix
lib.foldl' (val: c: assert lib.assertMsg c.assertion c.message; val) rendered checks;
```

Behavior is identical to the old helper for the all-assertions / no-warnings call here (the second arg was always `[ ]`).

## Verification

- `nix-instantiate --parse lib/minecraft/dimension-type.nix` → clean.
- Semantics preserved: every failing check throws with its original message; on success returns the rendered dimension-type JSON unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `render-with-checks` in dimension-type by replacing removed `lib.checkAssertWarn`
> Replaces the use of the removed `lib.checkAssertWarn` helper in [dimension-type.nix](https://github.com/indexable-inc/index/pull/909/files#diff-adc800c68bb1928783c3fa5a4698498f79541f4f02ba0405a8b6e9406e81e95b) with a left fold that asserts each check via `lib.assertMsg` before returning the rendered value. This restores correct behavior for downstream library evaluation that was broken by the missing helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b31f622.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->