### PR TITLE
fix(mcp): pageable values (#916), composable fff (#917), image bytes (#357), browser docs (#358/#359)

### DIFF
--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -202,23 +202,33 @@ class Job:
     def output(self) -> str:
         return "".join(self._buf)
 
+    @property
+    def pageable(self) -> str:
+        """The text the paging helpers (`tail`/`head`/`slice`/`lines`/`grep`)
+        operate on: this job's captured stdout, or -- when the cell printed
+        nothing and its bulk is the returned value (a `Result`, or `sh()` output,
+        whose text lives in the result, not stdout) -- the result's model-facing
+        text. So the paging the over-cap notice advertises reaches a big returned
+        value just as it reaches a big `print()`, never an empty buffer."""
+        return self.output or _result_text(self)
+
     def tail(self, n: int = 2000) -> str:
-        """Last ``n`` chars of this job's captured output."""
-        return self.output[-n:]
+        """Last ``n`` chars of this job's output (stdout, else its result text)."""
+        return self.pageable[-n:]
 
     def head(self, n: int = 2000) -> str:
-        """First ``n`` chars of this job's captured output."""
-        return self.output[:n]
+        """First ``n`` chars of this job's output (stdout, else its result text)."""
+        return self.pageable[:n]
 
     def slice(self, start: int = 0, end: int | None = None) -> str:
-        """A character window ``output[start:end]``, for paging a large output a
+        """A character window ``pageable[start:end]``, for paging a large output a
         chunk at a time after `grep`/`lines` locates the region."""
-        return self.output[start:end]
+        return self.pageable[start:end]
 
     def lines(self, start: int = 0, end: int | None = None) -> str:
         """Output lines ``[start:end]`` (0-based, ``end`` exclusive), numbered to
         match `grep`'s line numbers so you can jump straight to a region."""
-        numbered = self.output.splitlines()
+        numbered = self.pageable.splitlines()
         return "\n".join(f"{i}: {numbered[i]}" for i in range(*slice(start, end).indices(len(numbered))))
 
     def grep(
@@ -239,7 +249,7 @@ class Job:
         import re as _re
 
         rx = _re.compile(pattern, _re.IGNORECASE if ignore_case else 0)
-        src = self.output.splitlines()
+        src = self.pageable.splitlines()
         keep: list[int] = []
         seen: set[int] = set()
         matches = 0

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -419,6 +419,15 @@ class Result:
                 llm_result=value.llm_result if llm_result is None else llm_result,
                 llm_images=value.llm_images,
             )
+        image_mime = _image_bytes_mime(value)
+        if image_mime is not None:
+            # Raw PNG/JPEG bytes (e.g. `await page.screenshot()`): show the human
+            # the inline image and hand the model a real image block, not the
+            # ~50k-char byte repr that would blow the result cap.
+            img = _coerce_image(value)
+            user = f'<img alt="" src="data:{img["mime"]};base64,{img["data"]}" />'
+            note = llm_result if llm_result is not None else f"[{image_mime} image, {len(bytes(value))} bytes]"
+            return cls(user_html=user, llm_result=note, llm_images=[value])
         if isinstance(value, str):
             # A plain string is output, not a Python literal: hand the model the
             # string verbatim with terminal escapes stripped, so captured CLI /
@@ -918,6 +927,9 @@ def _is_displayable(value) -> bool:
     those still fail the contract, to keep pushing key/value data toward a
     DataFrame and confirmations toward ``Result.ok``.
     """
+    if _image_bytes_mime(value) is not None:
+        # Raw image bytes (a screenshot) know how to render: as an inline image.
+        return True
     if value is None or isinstance(
         value, (str, bytes, bool, int, float, complex, dict, list, tuple, set, frozenset)
     ):
@@ -1199,6 +1211,19 @@ def _encode_image_b64(b64: str, mime: str) -> dict:
     except (ValueError, base64.binascii.Error):
         return {"mime": mime, "data": b64}
     return _encode_image_bytes(raw, mime)
+
+
+def _image_bytes_mime(value) -> str | None:
+    """The image mime of raw ``bytes``/``bytearray`` by magic number (PNG or
+    JPEG), else None. Lets a bare ``await page.screenshot()`` -- which returns raw
+    image bytes -- auto-render as an image instead of dumping a ~50k-char repr."""
+    if isinstance(value, (bytes, bytearray)):
+        head = bytes(value[:8])
+        if head.startswith(b"\x89PNG\r\n\x1a\n"):
+            return "image/png"
+        if head[:3] == b"\xff\xd8\xff":
+            return "image/jpeg"
+    return None
 
 
 def _coerce_image(value) -> dict | None:

--- a/packages/mcp/src/browser/browser/__init__.py
+++ b/packages/mcp/src/browser/browser/__init__.py
@@ -15,7 +15,19 @@ are started once and cached, so successive calls reuse the same session.
     await browser.goto("https://example.com")     # navigate the front tab
     await browser.shot()                          # screenshot -> a Result (image)
     page = await browser.page()                   # the live Page: full Playwright API
-    await page.click("text=Sign in")
+
+    # Drive a page (every Playwright call is awaited; reuse the one `page`):
+    await page.fill("input[name=q]", "ix mcp")    # type into a field
+    await page.click("text=Sign in")              # click by text / CSS / role
+    await page.wait_for_selector(".results")      # wait for an element...
+    await page.wait_for_load_state("networkidle")  # ...or for the page to settle
+    text = await page.inner_text(".results")      # read text (or .text_content / .content)
+    await page.screenshot()                       # bare bytes auto-render as an image
+
+`await page.screenshot()` returns raw PNG bytes; ending a cell with it (or with
+`browser.shot()`) renders the image inline for the human and the model -- so the
+"do something, then look" loop is one obvious flow. Never `print()` a screenshot:
+its byte repr is a ~50k-char wall that blows the result cap.
 
 ``get_or_create_browser()`` is the entry point: it connects to whatever is already
 on the port, and otherwise launches a real, on-screen browser listening there. It

--- a/packages/mcp/src/fff/fff/__init__.py
+++ b/packages/mcp/src/fff/fff/__init__.py
@@ -9,8 +9,11 @@ index; this module loads the `fff-c` cdylib (`packages/fff` emits it next to the
     import fff
 
     # one-shot helpers keep a cached, file-watching index per directory:
-    for hit in fff.find(query="picker", path=".").hits:
+    res = fff.find(query="picker", path=".")
+    for hit in res.hits:
         print(hit.path, hit.frecency)
+    res[0]                              # results are subscriptable (and sliceable)
+    Path(res[0]).read_text()           # a hit is os.PathLike -> its absolute path
 
     for m in fff.grep(query="fn main", path=".", mode="regex").matches:
         print(f"{m.path}:{m.line_number}: {m.line}")
@@ -71,7 +74,7 @@ __all__ = [
     "CodeMap",
 ]
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 # Mirrors `FFF_CREATE_OPTIONS_VERSION` in fff-c. The options struct only ever
 # appends fields, so v1 stays valid forever; the library reads exactly the
@@ -329,7 +332,13 @@ def _polars():
 
 @dataclass(frozen=True)
 class FileHit:
-    """One file from `search`/`glob`, ranked by fuzzy score and frecency."""
+    """One file from `search`/`glob`, ranked by fuzzy score and frecency.
+
+    ``path`` is relative to the index ``root`` (compact for display); ``abspath``
+    joins the two. The hit is ``os.PathLike`` -- ``os.fspath(hit)`` returns the
+    *absolute* path, so ``open(hit)`` / ``Path(hit).read_text()`` work from any
+    cwd, not just the index root.
+    """
 
     path: str
     name: str
@@ -338,6 +347,16 @@ class FileHit:
     frecency: int
     is_binary: bool
     git_status: str | None = None
+    root: str | None = None
+
+    @property
+    def abspath(self) -> str:
+        """The absolute filesystem path (``root`` joined with the relative
+        ``path``), or ``path`` unchanged when no root is known."""
+        return os.path.join(self.root, self.path) if self.root else self.path
+
+    def __fspath__(self) -> str:
+        return self.abspath
 
 
 @dataclass(frozen=True)
@@ -351,6 +370,16 @@ class SearchResult:
 
     def __len__(self) -> int:
         return len(self.hits)
+
+    def __getitem__(self, index):
+        """Index a single ``FileHit`` (``result[0]``) or slice into a new
+        ``SearchResult`` (``result[:10]``), so the result composes like a list."""
+        if isinstance(index, slice):
+            sliced = self.hits[index]
+            return SearchResult(
+                hits=sliced, total_matched=self.total_matched, total_files=self.total_files
+            )
+        return self.hits[index]
 
     @property
     def df(self):
@@ -424,6 +453,16 @@ class GrepMatch:
     match_ranges: list[MatchRange] = field(default_factory=list)
     context_before: list[str] = field(default_factory=list)
     context_after: list[str] = field(default_factory=list)
+    root: str | None = None
+
+    @property
+    def abspath(self) -> str:
+        """The absolute path of the matched file (``root`` joined with the
+        relative ``path``), or ``path`` unchanged when no root is known."""
+        return os.path.join(self.root, self.path) if self.root else self.path
+
+    def __fspath__(self) -> str:
+        return self.abspath
 
 
 @dataclass(frozen=True)
@@ -438,6 +477,19 @@ class GrepResult:
 
     def __len__(self) -> int:
         return len(self.matches)
+
+    def __getitem__(self, index):
+        """Index a single ``GrepMatch`` (``result[0]``) or slice into a new
+        ``GrepResult`` (``result[:10]``), so the result composes like a list."""
+        if isinstance(index, slice):
+            sliced = self.matches[index]
+            return GrepResult(
+                matches=sliced,
+                total_matched=self.total_matched,
+                total_files_searched=self.total_files_searched,
+                next_file_offset=self.next_file_offset,
+            )
+        return self.matches[index]
 
     @property
     def df(self):
@@ -514,9 +566,10 @@ class FileFinder:
         frecency_db=None,
         history_db=None,
     ) -> None:
+        self._root = os.path.abspath(os.fspath(root))
         opts = _CreateOptions()
         opts.version = _OPTIONS_VERSION
-        opts.base_path = _encode(os.path.abspath(os.fspath(root)))
+        opts.base_path = _encode(self._root)
         opts.frecency_db_path = _encode(frecency_db)
         opts.history_db_path = _encode(history_db)
         opts.enable_mmap_cache = mmap_cache
@@ -669,6 +722,7 @@ class FileFinder:
                     frecency=_lib.fff_file_item_get_total_frecency_score(it),
                     is_binary=bool(_lib.fff_file_item_get_is_binary(it)),
                     git_status=_str(_lib.fff_file_item_get_git_status(it)),
+                    root=self._root,
                 )
             )
         return SearchResult(
@@ -843,6 +897,7 @@ class FileFinder:
                     match_ranges=ranges,
                     context_before=before,
                     context_after=after,
+                    root=self._root,
                 )
             )
         return GrepResult(
@@ -978,7 +1033,7 @@ def find(*, query: str, path, limit: int = 100) -> SearchResult:
     with tempfile.TemporaryDirectory(prefix="ix-fff-file-") as tmp:
         with _isolated_file_finder(os.path.join(root, only), tmp, content_indexing=False) as ff:
             result = ff.search(query=query, limit=limit)
-    hits = [replace(h, path=only, name=only) for h in result.hits][:limit]
+    hits = [replace(h, path=only, name=only, root=root) for h in result.hits][:limit]
     return SearchResult(hits=hits, total_matched=len(hits), total_files=len(hits))
 
 
@@ -1022,7 +1077,7 @@ def grep(*, query: str | list[str], path, mode: str, limit: int = 50) -> GrepRes
     with tempfile.TemporaryDirectory(prefix="ix-fff-file-") as tmp:
         with _isolated_file_finder(os.path.join(root, only), tmp, content_indexing=True) as ff:
             result = _run(ff)
-    matches = [replace(m, path=only, name=only) for m in result.matches]
+    matches = [replace(m, path=only, name=only, root=root) for m in result.matches]
     return GrepResult(
         matches=matches,
         total_matched=result.total_matched,


### PR DESCRIPTION
## Summary
Fixes the concrete, reproducible MCP bugs and closes the already-resolved ones.

- **#916** — `jobs['<id>'].tail/head/slice/grep/lines` now page a returned value / `sh()` output (new `Job.pageable` falls back to the result's model text when stdout is empty), so the over-cap notice's advice works.
- **#917** — `fff` results compose: `SearchResult`/`GrepResult` are subscriptable & sliceable, and `FileHit`/`GrepMatch` are `os.PathLike` returning the absolute path (relative `.path` kept for display).
- **#357** — raw PNG/JPEG bytes (e.g. `await page.screenshot()`) auto-render as an image block instead of a ~50k-char byte repr.
- **#358 / #359** — browser module docstring (the doc surface the instructions draw from) gains an interaction recipe (fill/click/wait/extract) and the now-working bare-screenshot idiom.

## Verified live in-kernel
- `Job.pageable` pages a 200k-char returned Result via all five helpers; stdout jobs unchanged.
- fff against real `libfff_c`: subscript, slice, `os.fspath` → absolute, single-file abspath, `.df` intact.
- `Result.of(png_bytes)` → TextContent + ImageContent; generic bytes still rejected; runner auto-wraps a bare screenshot.
- `ruff check` passes on every changed file.

## Closed separately (already fixed / obsolete)
- **#913** str Result verbatim (59ec261d) · **#912** async `sh()` bundled · **#704** obsolete (static script-free dashboard tables, no JupyterLab/itables).

## Deferred (design)
- **#903** is a symptom of the IOPub parent cross-talk under concurrency tracked in **#907**; ipykernel 7's contextvar parent attribution already mitigates the display path, and `read` is correct when idle. Folded into the #907 work rather than patched blind.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pageable helpers, image bytes rendering, and add `fff` composable search results
> - Paging helpers (`head`, `tail`, `slice`, `lines`, `grep`) in [runtime.py](https://github.com/indexable-inc/index/pull/918/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) now operate on a new `pageable` property that uses stdout if present, falling back to the job's result text, so large returned values are navigable even without stdout output.
> - `Result.of` now detects raw PNG/JPEG bytes via a new `_image_bytes_mime` helper and renders them as inline images for users with a proper image block for the model, instead of a raw byte-string dump.
> - `fff` `FileHit` and `GrepMatch` gain `abspath` and `__fspath__` for `os.PathLike` compatibility; `SearchResult` and `GrepResult` gain `__getitem__` for indexing and slicing.
> - Browser docs in [browser/__init__.py](https://github.com/indexable-inc/index/pull/918/files#diff-4d8f6838184ae77ce7ecd94b0eac290aaf4703a0b9a3a3165f3989c9cbe9dcea) are expanded to clarify that `page.screenshot()` returns raw PNG bytes that auto-render and should not be printed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93823a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->