### PR TITLE
fix(mcp): doc() helper (#894), api() builtin summaries (#911), NixLog.ok (#919)

### DIFF
--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -76,6 +76,7 @@ BUILTINS: tuple[Builtin, ...] = (
     Builtin("cells", "curate the dashboard's highlight reel (`cells.add` / `set` / `remove` / `clear`)"),
     Builtin("jobs", "the background-run registry (inspect / await / cancel / page each run)"),
     Builtin("history", "list recent runs"),
+    Builtin("doc", "the signature + docstring of any object, returned as a Result (help() only prints and returns None)"),
     Builtin("resources", "the live, self-updating views (a terminal, a widget)"),
     Builtin("register_resource", "publish a live Resource to the dashboard"),
     Builtin("sh", "shell out on the loop; the Output IS a Result (ANSI as HTML for the human, `.text`/`.code`/`.ok` for you)"),

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -1469,6 +1469,7 @@ def _escape_html(text: str) -> str:
 _API_MODULES = registry.module_names()
 # Always-present namespace builtins (no import needed); see install().
 _API_BUILTINS = registry.builtin_names()
+_BUILTIN_TAGLINES = {b.name: b.tagline for b in registry.BUILTINS}
 
 
 def _api_rows() -> list[dict]:
@@ -1476,7 +1477,7 @@ def _api_rows() -> list[dict]:
     module's public surface, with signature and a one-line summary."""
     rows: list[dict] = []
 
-    def add(where: str, name: str, obj) -> None:
+    def add(where: str, name: str, obj, summary: str | None = None) -> None:
         if inspect.iscoroutinefunction(obj):
             kind = "async"
         elif inspect.isclass(obj):
@@ -1491,14 +1492,21 @@ def _api_rows() -> list[dict]:
                 sig = f"{name}{inspect.signature(obj)}"
             except (ValueError, TypeError):
                 sig = f"{name}(...)"
-        doc = inspect.getdoc(obj) or ""
-        summary = doc.strip().split("\n", 1)[0]
+        if summary is None:
+            # inspect.getdoc on a plain value returns its TYPE's doc (e.g. a str
+            # value yields `str(object='') -> str`), which says nothing about the
+            # value -- so only fall back to getdoc for things that document
+            # themselves (callables/classes/modules), never a bare value.
+            doc = (inspect.getdoc(obj) or "") if callable(obj) or inspect.ismodule(obj) else ""
+            summary = doc.strip().split("\n", 1)[0]
         rows.append({"where": where, "name": name, "kind": kind, "sig": sig, "summary": summary})
 
     target = _user_ns if _user_ns is not None else globals()
     for name in _API_BUILTINS:
         if name in target:
-            add("kernel", name, target[name])
+            # Builtins carry an authored one-line tagline in the registry; it is
+            # the curated summary, so prefer it over introspection.
+            add("kernel", name, target[name], summary=_BUILTIN_TAGLINES.get(name))
 
     for mod_name in _API_MODULES:
         try:
@@ -1534,6 +1542,23 @@ def _api_rows() -> list[dict]:
             pass
         rows.append({"where": "library", "name": lib_name, "kind": "library", "sig": sig, "summary": summary})
     return rows
+
+
+def doc(obj) -> "Result":
+    """The signature and docstring of any object, RETURNED (not printed) as a
+    Result -- so the documented "everything through Result" path also works for
+    reading docs. ``help()`` only writes to stdout (not your channel) and returns
+    ``None``, so ``Result(help(x))`` shows nothing; use ``doc(fff.grep)`` instead.
+    Pair it with `api()`: `api('grep')` to find a name, `doc(fff.grep)` to read it."""
+    name = getattr(obj, "__name__", None) or type(obj).__name__
+    sig = ""
+    if callable(obj):
+        try:
+            sig = f"{name}{inspect.signature(obj)}"
+        except (ValueError, TypeError):
+            sig = name if inspect.isclass(obj) else f"{name}(...)"
+    body = inspect.getdoc(obj) or "(no docstring)"
+    return Result.text(f"{sig}\n\n{body}" if sig else body)
 
 
 def api(filter: str | None = None):
@@ -1977,6 +2002,7 @@ def install(user_ns: dict | None = None) -> None:
     target = user_ns if user_ns is not None else globals()
     target["jobs"] = jobs
     target["history"] = history
+    target["doc"] = doc
     target["Job"] = Job
     target["Result"] = Result
     target["cells"] = cells

--- a/packages/mcp/src/nix/nix/__init__.py
+++ b/packages/mcp/src/nix/nix/__init__.py
@@ -142,6 +142,14 @@ class NixLog:
         self.returncode: int | None = None
         self.started = time.time()
 
+    @property
+    def ok(self) -> bool:
+        """True once the build has finished successfully (done, exit 0, no error),
+        mirroring ``sh()``'s ``Output.ok`` so "await a build, branch on success"
+        reads the same across both. False while still running, so it never reads
+        like a missing attribute the way ``getattr(log, "ok", None)`` -> None did."""
+        return self.done and self.returncode == 0 and self.error is None
+
     def feed(self, line: str) -> None:
         """Consume one line of nix output (``@nix {...}`` JSON or plain text)."""
         line = line.rstrip("\n")


### PR DESCRIPTION
## Summary
More bounded MCP DX fixes (verified live in-kernel).

- **#894** — add a `doc(obj)` builtin that **returns** the signature + docstring as a `Result`, so the documented "everything through `Result`" path works for reading docs (`help()` only prints to stdout and returns `None`, so `Result(help(x))` showed nothing). Listed in `api()`.
- **#911** — `api()` now summarizes each builtin from its authored registry tagline instead of `inspect.getdoc`, which leaked `str.__doc__` (`str(object='') -> str`) for a plain value. `DASHBOARD_URL` now reads "this session's live dashboard URL"; getdoc no longer falls back to a bare value's type doc.
- **#919** — add `NixLog.ok` (`done and returncode == 0 and error is None`), mirroring `sh()`'s `Output.ok`, so `getattr(log, "ok", None)` no longer reads `None` (which looked like "not finished").

## Verified
- `doc(fff.grep)` → Result with signature + docstring.
- `api()` row for `DASHBOARD_URL` → real tagline summary.
- `NixLog.ok`: False while running, True on done+rc0+no-error, False on nonzero/err; `'ok' in dir(log)`.
- `ruff check` passes on all changed files.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `doc()` helper, `api()` builtin summaries, and add `NixLog.ok` property
> - Adds a `doc(obj)` function to the kernel namespace that returns a `Result` with the object's signature and docstring, replacing `help()`-style stdout output.
> - Registers `doc` in the builtin registry so it appears in `api()` discovery.
> - Fixes `api()` to use curated taglines from the builtin registry instead of introspected type docstrings; plain values no longer incorrectly show their type's docstring as a summary.
> - Adds a read-only `NixLog.ok` property to [`nix/__init__.py`](https://github.com/indexable-inc/index/pull/920/files#diff-b4bb27410b6cb969e2cdc750a71d049b0c52a3faecc2ca9709a4278184a20890) that returns `True` when a build completes successfully (`done=True`, `returncode==0`, `error=None`), mirroring `sh()`'s `Output.ok` semantics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65ae692.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->