### PR TITLE
feat(browser): text-first read() (#915) + steer subprocess to sh() (#914)

### DIFF
--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -72,7 +72,11 @@ BLOCKING = (
     "non-blocking: wrap it in `await asyncio.to_thread(...)`, or prefer the async API (`fff`, "
     "`httpx`, and the bundled `sh(cmd, cwd=...)` to shell out instead of `subprocess.run`), and run "
     "anything slow as a background job you "
-    "poll, never inline."
+    "poll, never inline. To shell out, reach for `sh()` rather than a hand-rolled "
+    "`asyncio.create_subprocess_exec/_shell` + `communicate()`: `sh()` runs the child in its own "
+    "session and enforces a timeout with a process-group kill, so it cannot sit in `running` "
+    "forever when the command has finished but a child left the merged stdout pipe open (a "
+    "`communicate()` that never returns) — the exact hang a raw async subprocess gives you."
 )
 
 RESULT_CONTRACT = (

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -66,7 +66,8 @@ MODULES: tuple[Module, ...] = (
     Module(
         "browser",
         "drive a running browser over CDP with Playwright (connects to the standard debug port "
-        "9222 by default); `browser.shot()` renders the screenshot inline",
+        "9222 by default); `browser.read()` is a cheap text/elements readout, `browser.shot()` "
+        "renders a screenshot inline",
     ),
 )
 

--- a/packages/mcp/src/browser/browser/__init__.py
+++ b/packages/mcp/src/browser/browser/__init__.py
@@ -14,6 +14,7 @@ are started once and cached, so successive calls reuse the same session.
     await browser.get_or_create_browser()        # connect, or launch a visible Dia
     await browser.goto("https://example.com")     # navigate the front tab
     await browser.shot()                          # screenshot -> a Result (image)
+    await browser.read()                          # cheap text+elements readout (no vision tokens)
     page = await browser.page()                   # the live Page: full Playwright API
 
     # Drive a page (every Playwright call is awaited; reuse the one `page`):
@@ -261,6 +262,64 @@ async def shot(target=None, *, endpoint: str = DEFAULT_ENDPOINT, full_page: bool
     except Exception:
         # Outside the kernel (no runtime): hand back the raw PNG bytes.
         return png
+
+
+async def read(target=None, *, endpoint: str = DEFAULT_ENDPOINT, max_chars: int = 8000):
+    """A cheap, text-first readout of a page (or the front tab when ``target`` is
+    None): its title/url, visible text, and the interactive elements (links,
+    buttons, inputs) with their role and accessible name -- an accessibility-style
+    snapshot for an iterative navigate -> inspect -> click loop WITHOUT the vision
+    tokens of a full-res :func:`shot`. Returns a :class:`Result`. Reach for `shot()`
+    only when you actually need to SEE layout/visuals; `read()` is enough to find
+    and click things. ``max_chars`` caps the visible-text section."""
+    pg = target if target is not None else await page(endpoint=endpoint)
+    snapshot = await pg.evaluate(
+        """() => {
+          const vis = el => { const r = el.getBoundingClientRect(); const s = getComputedStyle(el);
+            return r.width > 0 && r.height > 0 && s.visibility !== 'hidden' && s.display !== 'none'; };
+          const norm = s => (s || '').replace(/\\s+/g, ' ').trim();
+          const out = [];
+          const sel = 'a[href], button, input, select, textarea, [role=button], [role=link], [role=checkbox], [role=tab], [contenteditable=true]';
+          for (const el of document.querySelectorAll(sel)) {
+            if (!vis(el)) continue;
+            const tag = el.tagName.toLowerCase();
+            out.push({
+              role: el.getAttribute('role') || tag,
+              name: norm(el.getAttribute('aria-label') || el.innerText || el.value || el.getAttribute('placeholder') || el.getAttribute('name') || el.getAttribute('title')).slice(0, 100),
+              href: el.getAttribute('href') || '',
+              type: el.getAttribute('type') || '',
+            });
+            if (out.length >= 200) break;
+          }
+          return { text: norm(document.body ? document.body.innerText : ''), els: out };
+        }"""
+    )
+    title = await pg.title()
+    text = snapshot.get("text", "")
+    clipped = text[:max_chars]
+    if len(text) > max_chars:
+        clipped += f"\n... [+{len(text) - max_chars} more chars]"
+    lines = []
+    for e in snapshot.get("els", []):
+        name = e.get("name") or ""
+        extra = e.get("href") or (f"[{e['type']}]" if e.get("type") else "")
+        lines.append(f"- {e.get('role', '?')} {name!r}" + (f" -> {extra}" if extra else ""))
+    elements = "\n".join(lines) or "(none)"
+    body = (
+        f"{title} \u2014 {pg.url}\n\n## visible text\n{clipped}\n\n"
+        f"## interactive ({len(snapshot.get('els', []))})\n{elements}"
+    )
+    try:
+        from ix_notebook_mcp.runtime import Result
+
+        head = _html.escape(f"{title} \u2014 {pg.url}")
+        user_html = (
+            f'<div style="font:13px ui-monospace,monospace"><b>{head}</b>'
+            f'<pre style="white-space:pre-wrap;max-height:24em;overflow:auto">{_html.escape(body)}</pre></div>'
+        )
+        return Result(user_html=user_html, llm_result=body)
+    except Exception:
+        return body
 
 
 async def close(endpoint: str | None = None):


### PR DESCRIPTION
## Summary
- **#915** — add `browser.read()`: a cheap, text-first accessibility readout (title/url + visible text + interactive elements with role and accessible name) returned as a `Result`. An iterative navigate->inspect->click loop no longer needs full-res `shot()` screenshots (which don't downscale at 1280px), saving ~50x the context. `shot()` stays for visual layout.
- **#914** — strengthen the BLOCKING guidance to steer subprocess work to `sh()` (own session + timeout + process-group kill) over a hand-rolled `asyncio.create_subprocess_*` + `communicate()`, which can pin a job in `running` forever when a child leaves the merged stdout pipe open.

## Verified
- `browser.read()` against a real page returns title, visible text, and `[role name -> href/type]` for link/button/input. `ruff` passes on all changed files.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `browser.read()` for text and interactive-elements page snapshot without vision tokens
> - Adds `browser.read()` in [`browser/__init__.py`](https://github.com/indexable-inc/index/pull/921/files#diff-4d8f6838184ae77ce7ecd94b0eac290aaf4703a0b9a3a3165f3989c9cbe9dcea), returning page title, URL, visible text (clipped to `max_chars`, default 8000), and up to 200 interactive elements (links, buttons, inputs) with role, name, and href/type.
> - Returns a `Result` object with `user_html` and `llm_result` when running inside the MCP runtime, or a plain string otherwise.
> - Updates the MCP guide to recommend `sh()` over raw `asyncio` subprocess calls, noting that `sh()` runs the child in its own session and kills the process group on timeout to avoid hangs.
> - Updates the `browser` module description in the registry to mention `browser.read()` as a cheap alternative to `browser.shot()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83e533d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->