### PR TITLE
browser: add vdom() — a clean, filtered, machine-readable page map

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2503,8 +2503,10 @@ let
     # reuse one instance instead of spawning a new window each time.
     assert browser.DEFAULT_ENDPOINT == "http://127.0.0.1:9222", browser.DEFAULT_ENDPOINT
     assert browser.DEFAULT_APP == "Dia", browser.DEFAULT_APP
-    for fn in ("get_or_create_browser", "connect", "context", "page", "goto", "shot", "close"):
+    for fn in ("get_or_create_browser", "connect", "context", "page", "goto", "shot", "read", "vdom", "close"):
         assert callable(getattr(browser, fn)), fn
+    # `vdom()` returns a Vdom: a clean, filtered, machine-readable map of the page.
+    assert isinstance(browser.Vdom, type), browser.Vdom
 
     udd = browser._default_user_data_dir("Dia")
     assert udd.endswith(".cdp-dia-profile"), udd
@@ -2561,6 +2563,143 @@ let
         mkdir -p "$out"
       '';
 
+  # The clean-vdom contract, exercised against a real (headless) browser. Unlike
+  # the launch smoke above, `vdom()` only reads the DOM, so it can run headless on
+  # a `data:` fixture with no display and no network: it asserts the filtering
+  # (hidden / aria-hidden pruned), the wrapper-chain collapse, that every kept node
+  # has geometry and a CSS selector that actually resolves, and that the
+  # interactive_only / viewport_only lean modes behave.
+  browserVdomTestPy = pkgs.writeText "ix-mcp-browser-vdom-test.py" ''
+    import asyncio
+    import sys
+
+    import browser
+    from playwright.async_api import async_playwright
+
+    # A fixture page exercising the cleaning rules: landmarks, a collapsible wrapper
+    # chain, hidden + aria-hidden subtrees, a named image, and a form. Served as a
+    # data: URL so the test needs no network and no on-screen window.
+    FIXTURE = (
+        "data:text/html," + (
+            "<html><head><title>Fixture</title></head><body>"
+            "<header><a id='home' href='/'><img alt='Logo'></a>"
+            "<nav><a href='/a'>Alpha</a><a href='/b'>Beta</a></nav></header>"
+            "<main><h1>Heading</h1><p>Visible paragraph text.</p>"
+            "<div><div><div><button id='go' onclick='void 0'>Click me</button></div></div></div>"
+            "<form><input type='search' placeholder='Find'><button type='submit'>Go</button></form>"
+            "<div style='display:none'><a href='/hidden'>Hidden</a></div>"
+            "<span aria-hidden='true'><a href='/aria'>AriaHidden</a></span>"
+            "</main></body></html>"
+        )
+    )
+
+
+    def names(flat):
+        return {n.get("name") for n in flat if not n.get("group")}
+
+
+    def by_tag(flat, tag):
+        return [n for n in flat if n.get("tag") == tag and not n.get("group")]
+
+
+    async def main():
+        pw = await async_playwright().start()
+        b = await pw.chromium.launch(
+            headless=True, args=["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"]
+        )
+        ctx = await b.new_context(viewport={"width": 1000, "height": 800})
+        pg = await ctx.new_page()
+        await pg.goto(FIXTURE)
+
+        v = await browser.vdom(pg)
+
+        # It is the documented type, with the page's identity captured.
+        assert isinstance(v, browser.Vdom), type(v)
+        assert v.title == "Fixture", v.title
+        assert v.viewport.get("w") == 1000, v.viewport
+
+        ns = names(v.flat)
+        # Hidden (display:none) and aria-hidden subtrees are pruned entirely.
+        assert "Hidden" not in ns, ns
+        assert "AriaHidden" not in ns, ns
+        # Landmarks, heading, controls and the named image survive.
+        assert any(n.get("role") == "banner" for n in v.flat), "banner landmark missing"
+        assert any(n.get("role") == "navigation" for n in v.flat), "nav landmark missing"
+        assert any(n.get("role") == "main" for n in v.flat), "main landmark missing"
+        assert any(n.get("role") == "heading" and n.get("name") == "Heading" for n in v.flat), ns
+        assert "Logo" in ns, ("named image missing", ns)
+        assert any(n.get("name") == "Alpha" and n.get("interactive") for n in v.flat), ns
+
+        # The triple-nested wrapper <div><div><div> around the button is collapsed:
+        # the button is reached without a chain of empty group nodes above it.
+        btn = next(n for n in v.flat if n.get("tag") == "button" and n.get("name") == "Click me")
+        assert btn["depth"] <= 2, ("wrapper chain not collapsed", btn["depth"])
+
+        # Every kept node carries a usable on-screen box and a working CSS selector.
+        for n in v.flat:
+            if n.get("group"):
+                continue
+            assert n.get("w", 0) > 0 and n.get("h", 0) > 0, ("no geometry", n)
+            sel = n.get("selector")
+            assert sel, ("no selector", n)
+            assert await pg.query_selector(sel) is not None, ("selector did not resolve", sel)
+
+        # Refs are dense and 1-based; node(ref) round-trips; df/json agree on counts.
+        refs = [n["ref"] for n in v.flat if not n.get("group")]
+        assert refs == list(range(1, len(refs) + 1)), refs
+        assert v.node(refs[-1]) is not None
+        n_real = len(refs)
+        assert v.df.height == len(v.flat), (v.df.height, len(v.flat))
+        assert v.df.filter(v.df["interactive"]).height >= 4  # 4 links + 2 buttons + 1 field
+
+        # The compact glance is bounded and self-describes; the full map lives in .df.
+        txt = repr(v)
+        assert "Fixture" in txt and "nodes" in txt, txt[:200]
+
+        # interactive_only drops body text but keeps the controls.
+        vi = await browser.vdom(pg, interactive_only=True)
+        nsi = names(vi.flat)
+        assert "Visible paragraph text." not in nsi, nsi
+        assert any(n.get("name") == "Alpha" for n in vi.flat), nsi
+
+        # viewport_only keeps only on-screen nodes (all fixture nodes are on screen,
+        # so it must still find the controls -- and never error).
+        vvp = await browser.vdom(pg, viewport_only=True)
+        assert any(n.get("interactive") for n in vvp.flat), "viewport_only lost controls"
+
+        await b.close()
+        await pw.stop()
+        print("vdom-ok", browser.__version__, n_real, "nodes")
+
+
+    asyncio.run(main())
+  '';
+  browserVdomSmoke =
+    pkgs.runCommand "ix-mcp-browser-vdom-smoke"
+      {
+        nativeBuildInputs = [ mcpPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        # `vdom()` launches a (headless) browser, so point Playwright at the bundled
+        # browser bundle -- the bare mcpPython has no wrapper to set this (only the
+        # `ix-mcp` entrypoint does).
+        export PLAYWRIGHT_BROWSERS_PATH=${lib.escapeShellArg playwrightBrowsers}
+        ${lib.getExe mcpPython} ${browserVdomTestPy} >stdout 2>stderr || {
+          echo "ix-mcp browser vdom smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -q '^vdom-ok' stdout || {
+          echo "ix-mcp browser vdom smoke did not confirm the clean vdom:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
+
   screenBundled = importTest "screen" "import screen; print('screen-ok', all(callable(getattr(screen, n)) for n in ('capture', 'click', 'write', 'press', 'key_down', 'key_up', 'apps', 'frontmost', 'launch', 'activate', 'terminate', 'accessibility_trusted')))";
   vmkitBundled = importTest "vmkit" "import vmkit; print('vmkit-ok', callable(vmkit.boot_linux), callable(vmkit.drive), callable(vmkit.screenshot))";
 in
@@ -2593,6 +2732,7 @@ package.overrideAttrs (old: {
         shSmoke
         worktreeSmoke
         browserSmoke
+        browserVdomSmoke
         ;
       site = dashboardSite;
     }

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -66,8 +66,10 @@ MODULES: tuple[Module, ...] = (
     Module(
         "browser",
         "drive a running browser over CDP with Playwright (connects to the standard debug port "
-        "9222 by default); `browser.read()` is a cheap text/elements readout, `browser.shot()` "
-        "renders a screenshot inline",
+        "9222 by default); `browser.vdom()` returns a clean, filtered virtual DOM -- a "
+        "machine-readable map of where every control, landmark and heading is (role, name, box, "
+        "CSS selector) -- so you can act without a screenshot; `browser.read()` is a lighter "
+        "text-first readout and `browser.shot()` renders a screenshot inline",
     ),
 )
 

--- a/packages/mcp/src/browser/browser/__init__.py
+++ b/packages/mcp/src/browser/browser/__init__.py
@@ -41,6 +41,23 @@ runs as its own instance without disturbing your everyday browser session.
 to the human and hands the model the same image. Every other call returns the raw
 Playwright object (``Browser`` / ``BrowserContext`` / ``Page``), so the full async
 Playwright API is yours.
+
+To *understand* a page rather than look at it, reach for ``vdom()``: a clean,
+filtered virtual DOM -- a compact, machine-readable map of where everything is.
+One in-page pass keeps only the nodes that matter (interactive controls,
+landmarks, headings, named images), drops hidden / ``aria-hidden`` / script /
+style noise, and collapses wrapper ``<div>`` chains, so even a busy page reads as
+a small tree. Every node carries its role, accessible name, on-screen box
+(x, y, w, h) and a Playwright-ready CSS ``selector``, so the model can decide what
+to click without a screenshot. ``read()`` is the lighter text-first sibling (page
+prose plus the same elements, flat); ``vdom()`` is the structured map you act on.
+
+    v = await browser.vdom()                      # clean tree of the front tab
+    v                                             # render: a compact, indented map
+    v.df                                          # the full map as a polars frame
+    sel = v.node(12)["selector"]                  # act on a node by its [12] ref
+    await (await browser.page()).click(sel)
+    await browser.vdom(interactive_only=True)     # leanest map for a complex page
 """
 
 from __future__ import annotations
@@ -61,10 +78,13 @@ __all__ = [
     "page",
     "goto",
     "shot",
+    "read",
+    "vdom",
+    "Vdom",
     "close",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 # The standard Chrome DevTools Protocol port. Connect here unless told otherwise,
 # so the common case ("a browser is already running with the debug port") needs no
@@ -266,53 +286,41 @@ async def shot(target=None, *, endpoint: str = DEFAULT_ENDPOINT, full_page: bool
 
 async def read(target=None, *, endpoint: str = DEFAULT_ENDPOINT, max_chars: int = 8000):
     """A cheap, text-first readout of a page (or the front tab when ``target`` is
-    None): its title/url, visible text, and the interactive elements (links,
-    buttons, inputs) with their role and accessible name -- an accessibility-style
+    None): its title/url, the visible text, and the interactive elements (links,
+    buttons, fields) with their role and accessible name -- an accessibility-style
     snapshot for an iterative navigate -> inspect -> click loop WITHOUT the vision
-    tokens of a full-res :func:`shot`. Returns a :class:`Result`. Reach for `shot()`
-    only when you actually need to SEE layout/visuals; `read()` is enough to find
-    and click things. ``max_chars`` caps the visible-text section."""
+    tokens of a full-res :func:`shot`. Returns a :class:`Result`.
+
+    This is the text-first sibling of :func:`vdom`, built on the very same clean-DOM
+    walker: the element list here is exactly ``vdom().interactive``, plus the page's
+    visible prose. Reach for :func:`vdom` when you want the structured map to act on
+    (geometry + a CSS ``selector`` per node); reach for :func:`shot` only when you
+    must SEE layout/visuals. ``max_chars`` caps the visible-text section."""
     pg = target if target is not None else await page(endpoint=endpoint)
-    snapshot = await pg.evaluate(
-        """() => {
-          const vis = el => { const r = el.getBoundingClientRect(); const s = getComputedStyle(el);
-            return r.width > 0 && r.height > 0 && s.visibility !== 'hidden' && s.display !== 'none'; };
-          const norm = s => (s || '').replace(/\\s+/g, ' ').trim();
-          const out = [];
-          const sel = 'a[href], button, input, select, textarea, [role=button], [role=link], [role=checkbox], [role=tab], [contenteditable=true]';
-          for (const el of document.querySelectorAll(sel)) {
-            if (!vis(el)) continue;
-            const tag = el.tagName.toLowerCase();
-            out.push({
-              role: el.getAttribute('role') || tag,
-              name: norm(el.getAttribute('aria-label') || el.innerText || el.value || el.getAttribute('placeholder') || el.getAttribute('name') || el.getAttribute('title')).slice(0, 100),
-              href: el.getAttribute('href') || '',
-              type: el.getAttribute('type') || '',
-            });
-            if (out.length >= 200) break;
-          }
-          return { text: norm(document.body ? document.body.innerText : ''), els: out };
-        }"""
+    snap = await vdom(pg, interactive_only=True)
+    text = await pg.evaluate(
+        "() => (document.body ? document.body.innerText : '').replace(/\\s+/g, ' ').trim()"
     )
-    title = await pg.title()
-    text = snapshot.get("text", "")
     clipped = text[:max_chars]
     if len(text) > max_chars:
         clipped += f"\n... [+{len(text) - max_chars} more chars]"
+    els = [n for n in snap.flat if n.get("interactive")][:200]
     lines = []
-    for e in snapshot.get("els", []):
+    for e in els:
         name = e.get("name") or ""
-        extra = e.get("href") or (f"[{e['type']}]" if e.get("type") else "")
-        lines.append(f"- {e.get('role', '?')} {name!r}" + (f" -> {extra}" if extra else ""))
+        a = e.get("attrs", {})
+        extra = a.get("href") or (f"[{a['type']}]" if a.get("type") else "")
+        role = e.get("role") or e.get("tag", "?")
+        lines.append(f"- {role} {name!r}" + (f" -> {extra}" if extra else ""))
     elements = "\n".join(lines) or "(none)"
     body = (
-        f"{title} \u2014 {pg.url}\n\n## visible text\n{clipped}\n\n"
-        f"## interactive ({len(snapshot.get('els', []))})\n{elements}"
+        f"{snap.title} \u2014 {snap.url}\n\n## visible text\n{clipped}\n\n"
+        f"## interactive ({len(els)})\n{elements}"
     )
     try:
         from ix_notebook_mcp.runtime import Result
 
-        head = _html.escape(f"{title} \u2014 {pg.url}")
+        head = _html.escape(f"{snap.title} \u2014 {snap.url}")
         user_html = (
             f'<div style="font:13px ui-monospace,monospace"><b>{head}</b>'
             f'<pre style="white-space:pre-wrap;max-height:24em;overflow:auto">{_html.escape(body)}</pre></div>'
@@ -320,6 +328,428 @@ async def read(target=None, *, endpoint: str = DEFAULT_ENDPOINT, max_chars: int 
         return Result(user_html=user_html, llm_result=body)
     except Exception:
         return body
+
+
+# ---------------------------------------------------------------------------
+# Clean virtual DOM: a filtered, machine-readable map of the page.
+# ---------------------------------------------------------------------------
+#
+# A screenshot tells the model what a page LOOKS like; `vdom()` tells it what the
+# page IS and WHERE everything is -- as compact, machine-readable structure rather
+# than pixels. One pass in the page walks the live DOM and returns only the nodes
+# that matter (interactive controls, landmarks, headings, named images), pruning
+# scripts/styles/comments/hidden/`aria-hidden` nodes and collapsing the wrapper
+# `<div>` chains that make raw HTML unreadable. Each kept node carries its role, a
+# concise accessible name, the attributes worth acting on (href/type/value/...),
+# its on-screen box (x, y, w, h) and a CSS `selector` you can hand straight to
+# Playwright. So the agent can decide what to click WITHOUT a screenshot.
+
+# Injected into the page by `vdom()`; returns the clean tree as plain JSON.
+_VDOM_JS = r"""
+(opts) => {
+  const maxText = (opts && opts.maxText) || 120;
+  const viewportOnly = !!(opts && opts.viewportOnly);
+  const interactiveOnly = !!(opts && opts.interactiveOnly);
+
+  const IMPLICIT_ROLE = {
+    a: 'link', button: 'button', input: 'textbox', select: 'combobox',
+    textarea: 'textbox', img: 'image', nav: 'navigation', main: 'main',
+    header: 'banner', footer: 'contentinfo', aside: 'complementary',
+    form: 'form', section: 'region', article: 'article', dialog: 'dialog',
+    h1: 'heading', h2: 'heading', h3: 'heading', h4: 'heading', h5: 'heading',
+    h6: 'heading', ul: 'list', ol: 'list', li: 'listitem', table: 'table',
+    summary: 'button', option: 'option', label: 'label',
+  };
+  const INTERACTIVE_TAGS = new Set(
+    ['a','button','input','select','textarea','summary','details','label','option','video','audio','iframe']);
+  const LANDMARK_TAGS = new Set(
+    ['main','nav','header','footer','aside','form','section','article','dialog']);
+  const HEADING_TAGS = new Set(['h1','h2','h3','h4','h5','h6']);
+  const SKIP_TAGS = new Set(
+    ['script','style','noscript','template','head','meta','link','br','path','svg','defs','g']);
+
+  const clamp = (s) => {
+    s = (s || '').replace(/\s+/g, ' ').trim();
+    return s.length > maxText ? s.slice(0, maxText - 1) + '…' : s;
+  };
+
+  const cssEscape = (s) =>
+    (window.CSS && CSS.escape) ? CSS.escape(s) : String(s).replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+
+  // A short, reasonably-unique CSS selector for `el`.
+  const selectorFor = (el) => {
+    if (el.id && document.querySelectorAll('#' + cssEscape(el.id)).length === 1)
+      return '#' + cssEscape(el.id);
+    const parts = [];
+    let cur = el;
+    while (cur && cur.nodeType === 1 && cur.tagName.toLowerCase() !== 'html') {
+      let part = cur.tagName.toLowerCase();
+      if (cur.id) { parts.unshift('#' + cssEscape(cur.id)); break; }
+      const parent = cur.parentElement;
+      if (parent) {
+        const sibs = Array.from(parent.children).filter(c => c.tagName === cur.tagName);
+        if (sibs.length > 1) part += ':nth-of-type(' + (sibs.indexOf(cur) + 1) + ')';
+      }
+      parts.unshift(part);
+      cur = cur.parentElement;
+    }
+    return parts.join(' > ');
+  };
+
+  const directText = (el) => {
+    let t = '';
+    for (const n of el.childNodes)
+      if (n.nodeType === 3) t += n.nodeValue;
+    return t.replace(/\s+/g, ' ').trim();
+  };
+
+  const accName = (el) => {
+    const tag = el.tagName.toLowerCase();
+    const aria = el.getAttribute('aria-label');
+    if (aria) return clamp(aria);
+    const labelledby = el.getAttribute('aria-labelledby');
+    if (labelledby) {
+      const parts = labelledby.split(/\s+/)
+        .map(id => { const r = document.getElementById(id); return r ? r.innerText : ''; })
+        .filter(Boolean);
+      if (parts.length) return clamp(parts.join(' '));
+    }
+    if (tag === 'img') return clamp(el.getAttribute('alt') || '');
+    if (tag === 'input') {
+      const type = (el.getAttribute('type') || 'text').toLowerCase();
+      if (type === 'submit' || type === 'button') return clamp(el.value);
+      return clamp(el.getAttribute('placeholder') || el.getAttribute('aria-label') || el.value || '');
+    }
+    if (tag === 'select' || tag === 'textarea')
+      return clamp(el.getAttribute('placeholder') || el.getAttribute('aria-label') || '');
+    const own = directText(el);
+    if (own) return clamp(own);
+    return clamp(el.innerText || el.getAttribute('title') || '');
+  };
+
+  const visible = (el, rect) => {
+    if (rect.width <= 1 || rect.height <= 1) return false;
+    const st = getComputedStyle(el);
+    if (st.visibility === 'hidden' || st.display === 'none' || +st.opacity === 0) return false;
+    if (viewportOnly) {
+      const vw = innerWidth, vh = innerHeight;
+      if (rect.bottom < 0 || rect.right < 0 || rect.top > vh || rect.left > vw) return false;
+    }
+    return true;
+  };
+
+  const KEEP_ATTRS = ['href','type','placeholder','value','name','aria-label','title','alt','for','role','checked','selected','disabled','aria-expanded','aria-checked'];
+
+  // Collapse a run of consecutive short text-only leaves (syntax-highlight token
+  // soup, operator spans, breadcrumb bits) into ONE text node, so a highlighted
+  // code block or a chip row reads as a single line instead of dozens. Long text
+  // (paragraphs) and anything interactive/structural is left untouched.
+  const isLeafText = (n) =>
+    n && !n.interactive && !n.group && (!n.children || n.children.length === 0) &&
+    n.name && n.tag !== 'img' && n.tag !== 'iframe' && n.role !== 'heading' &&
+    n.name.length <= 30;
+  const mergeRuns = (arr) => {
+    const out = [];
+    let run = [];
+    const flush = () => {
+      if (run.length === 0) return;
+      if (run.length === 1) { out.push(run[0]); run = []; return; }
+      const x = Math.min(...run.map(r => r.x));
+      const y = Math.min(...run.map(r => r.y));
+      const w = Math.max(...run.map(r => r.x + r.w)) - x;
+      const h = Math.max(...run.map(r => r.y + r.h)) - y;
+      out.push({ tag: 'text', role: 'text', name: clamp(run.map(r => r.name).join(' ')),
+                 interactive: false, x, y, w, h, selector: '', attrs: {}, group: false, children: [] });
+      run = [];
+    };
+    for (const n of arr) { if (isLeafText(n)) run.push(n); else { flush(); out.push(n); } }
+    flush();
+    return out;
+  };
+
+  const build = (el, inLabel) => {
+    const tag = el.tagName ? el.tagName.toLowerCase() : '';
+    if (!tag || SKIP_TAGS.has(tag)) return [];
+    if (el.getAttribute && el.getAttribute('aria-hidden') === 'true') return [];
+
+    const rect = el.getBoundingClientRect();
+    const isVisible = visible(el, rect);
+
+    const role0 = (el.getAttribute && el.getAttribute('role')) || IMPLICIT_ROLE[tag] || '';
+    const interactive0 =
+      INTERACTIVE_TAGS.has(tag) ||
+      (el.getAttribute && (el.getAttribute('onclick') !== null ||
+        el.getAttribute('contenteditable') === 'true' ||
+        (el.getAttribute('tabindex') !== null && +el.getAttribute('tabindex') >= 0) ||
+        ['button','link','checkbox','radio','tab','menuitem','switch','option','textbox','combobox','searchbox','slider']
+          .includes(el.getAttribute('role'))));
+    const heading0 = HEADING_TAGS.has(tag);
+    const childInLabel = inLabel || interactive0 || heading0;
+
+    // Recurse first so we can collapse pure wrappers.
+    let kids = [];
+    for (const c of el.children) kids.push(...build(c, childInLabel));
+    kids = mergeRuns(kids);
+
+    const role = role0, interactive = interactive0, heading = heading0;
+    const landmark = LANDMARK_TAGS.has(tag);
+    const name = accName(el);
+    const interesting =
+      isVisible && (interactive || landmark || heading || tag === 'iframe' ||
+        (tag === 'img' && (name || !interactiveOnly)) ||
+        (!interactiveOnly && name && directText(el) && !inLabel));
+
+    if (!interesting) {
+      if (kids.length === 0) return [];
+      if (kids.length === 1) return kids;        // collapse transparent wrapper
+      // a branching container: keep a lightweight group so structure survives
+      return [{ tag, role: role || 'group', name: '', interactive: false,
+                x: Math.round(rect.x), y: Math.round(rect.y),
+                w: Math.round(rect.width), h: Math.round(rect.height),
+                selector: '', attrs: {}, group: true, children: kids }];
+    }
+
+    const attrs = {};
+    if (el.getAttributeNames) for (const a of el.getAttributeNames())
+      if (KEEP_ATTRS.includes(a)) {
+        const v = el.getAttribute(a);
+        if (v !== null && v !== '') attrs[a] = clamp(v);
+      }
+
+    return [{
+      tag, role, name, interactive,
+      x: Math.round(rect.x), y: Math.round(rect.y),
+      w: Math.round(rect.width), h: Math.round(rect.height),
+      selector: selectorFor(el), attrs, group: false, children: kids,
+    }];
+  };
+
+  const roots = mergeRuns(build(document.body, false));
+  return {
+    url: location.href,
+    title: document.title,
+    viewport: { w: innerWidth, h: innerHeight, scrollX: Math.round(scrollX), scrollY: Math.round(scrollY) },
+    nodes: roots,
+  };
+}
+"""
+
+
+def _walk_assign(nodes, _counter=None, _depth=0, _out=None):
+    """Number the kept (non-group) nodes in document order and flatten the tree.
+
+    Refs are 1-based and stable within one snapshot, so `[12]` in the rendered
+    tree, the `ref` column of `.df`, and `vdom.node(12)` all denote the same node.
+    """
+    if _counter is None:
+        _counter, _out = [0], []
+    for n in nodes:
+        if n.get("group"):
+            n["ref"] = None
+        else:
+            _counter[0] += 1
+            n["ref"] = _counter[0]
+        n["depth"] = _depth
+        _out.append(n)
+        _walk_assign(n.get("children", ()), _counter, _depth + 1, _out)
+    return _out
+
+
+_PRUNE = ("children", "group", "depth")
+
+
+def _node_public(n: dict) -> dict:
+    """A node as the model/JSON sees it: drop tree-walk bookkeeping, keep the map."""
+    return {k: v for k, v in n.items() if k not in _PRUNE}
+
+
+class Vdom:
+    """A clean, filtered snapshot of a page's DOM: the recommended way to understand
+    a page's structure and find what to act on.
+
+    Render it (end a cell with it) for a compact, indented tree -- the model reads
+    that text, the human sees the same tree as styled HTML. The full machine-readable
+    map is always one attribute away and never truncated:
+
+        v = await browser.vdom()
+        v                       # compact tree (capped; the glance)
+        v.df                    # every node as a polars frame: ref, role, name, x, y, w, h, selector
+        v.json                  # the nested tree as plain JSON (dicts/lists)
+        v.interactive           # just the actionable nodes (a frame)
+        v.node(12)              # the dict for ref 12 (its selector, box, attrs)
+        await browser.goto(...); (await browser.vdom(interactive_only=True))  # leanest map
+
+    For big, complex pages prefer ``interactive_only=True`` (drop body text, keep the
+    controls) and/or ``viewport_only=True`` (only what is on screen) so the snapshot
+    stays small instead of dumping thousands of nodes.
+    """
+
+    # How many tree lines the text/HTML glance shows before pointing at `.df` for
+    # the rest. The full map is always in `.df` / `.json`; this only caps the glance.
+    RENDER_LIMIT = 200
+
+    def __init__(self, raw: dict):
+        self.url: str = raw.get("url", "")
+        self.title: str = raw.get("title", "")
+        self.viewport: dict = raw.get("viewport", {})
+        self.nodes: list = raw.get("nodes", [])
+        self.flat: list = _walk_assign(self.nodes)
+
+    # -- machine-readable views ------------------------------------------------
+    @property
+    def json(self) -> list:
+        """The clean DOM as a nested list of plain dicts (JSON-serializable)."""
+
+        def strip(nodes):
+            out = []
+            for n in nodes:
+                d = _node_public(n)
+                d["children"] = strip(n.get("children", ()))
+                out.append(d)
+            return out
+
+        return strip(self.nodes)
+
+    @property
+    def df(self):
+        """Every kept node as a polars frame -- the full, untruncated page map:
+        one row per node with its ref, role, name, geometry and CSS selector."""
+        import polars as pl
+
+        rows = []
+        for n in self.flat:
+            a = n.get("attrs", {})
+            rows.append(
+                {
+                    "ref": n.get("ref"),
+                    "depth": n["depth"],
+                    "role": n.get("role") or n.get("tag", ""),
+                    "tag": n.get("tag", ""),
+                    "name": n.get("name", ""),
+                    "interactive": bool(n.get("interactive")),
+                    "href": a.get("href", ""),
+                    "type": a.get("type", ""),
+                    "x": n.get("x"),
+                    "y": n.get("y"),
+                    "w": n.get("w"),
+                    "h": n.get("h"),
+                    "selector": n.get("selector", ""),
+                }
+            )
+        schema = ["ref", "depth", "role", "tag", "name", "interactive",
+                  "href", "type", "x", "y", "w", "h", "selector"]
+        return pl.DataFrame(rows, schema=schema) if rows else pl.DataFrame(schema=schema)
+
+    @property
+    def interactive(self):
+        """Just the actionable nodes (links, buttons, fields, ...) as a polars frame."""
+        return self.df.filter(__import__("polars").col("interactive"))
+
+    def node(self, ref: int) -> dict | None:
+        """The public dict for a node by its ``ref`` (selector, box, attrs)."""
+        for n in self.flat:
+            if n.get("ref") == ref:
+                return _node_public(n)
+        return None
+
+    # -- glance (capped) -------------------------------------------------------
+    def _lines(self) -> list[str]:
+        lines: list[str] = []
+
+        def emit(nodes, depth):
+            for n in nodes:
+                pad = "  " * depth
+                if n.get("group"):
+                    lines.append(f"{pad}<{n.get('tag', 'div')}>")
+                else:
+                    a = n.get("attrs", {})
+                    role = n.get("role") or n.get("tag", "")
+                    mark = "*" if n.get("interactive") else " "
+                    nm = f' "{n["name"]}"' if n.get("name") else ""
+                    extra = ""
+                    if a.get("href"):
+                        extra += f" href={a['href']}"
+                    if a.get("type"):
+                        extra += f" type={a['type']}"
+                    box = f"  @{n.get('x')},{n.get('y')} {n.get('w')}x{n.get('h')}"
+                    lines.append(f"{pad}[{n['ref']}] {mark}{role}{nm}{extra}{box}")
+                emit(n.get("children", ()), depth + 1)
+
+        emit(self.nodes, 0)
+        return lines
+
+    def text(self, limit: int | None = None) -> str:
+        """The indented tree as plain text, capped at ``limit`` lines (the glance)."""
+        limit = self.RENDER_LIMIT if limit is None else limit
+        n_real = sum(1 for n in self.flat if not n.get("group"))
+        head = (
+            f"{self.title or '(untitled)'} \u2014 {self.url}\n"
+            f"{n_real} nodes "
+            f"({sum(1 for n in self.flat if n.get('interactive'))} interactive) "
+            f"\u00b7 viewport {self.viewport.get('w')}x{self.viewport.get('h')}"
+        )
+        lines = self._lines()
+        body = lines if limit <= 0 or len(lines) <= limit else lines[:limit] + [
+            f"\u2026 +{len(lines) - limit} more lines \u2014 see .df for the full map, "
+            f"or re-run with interactive_only=True / viewport_only=True"
+        ]
+        return head + "\n" + "\n".join(body)
+
+    def __repr__(self) -> str:
+        return self.text()
+
+    def _repr_html_(self) -> str:
+        rows = []
+        for ln in self.text().split("\n")[1:]:  # skip the header line; shown separately
+            rows.append(_html.escape(ln))
+        title = _html.escape(self.title or "(untitled)")
+        n_real = sum(1 for n in self.flat if not n.get("group"))
+        n_int = sum(1 for n in self.flat if n.get("interactive"))
+        head = (
+            f'<div style="font:600 13px system-ui;margin-bottom:4px">{title}'
+            f'<span style="font-weight:400;opacity:.6"> \u2014 {_html.escape(self.url)}</span></div>'
+            f'<div style="font:400 11px system-ui;opacity:.6;margin-bottom:6px">'
+            f"{n_real} nodes \u00b7 {n_int} interactive \u00b7 "
+            f'viewport {self.viewport.get("w")}\u00d7{self.viewport.get("h")}</div>'
+        )
+        pre = (
+            '<pre style="font:12px ui-monospace,monospace;line-height:1.45;margin:0;'
+            'white-space:pre;overflow-x:auto">' + "\n".join(rows) + "</pre>"
+        )
+        return head + pre
+
+
+async def vdom(
+    target=None,
+    *,
+    endpoint: str = DEFAULT_ENDPOINT,
+    interactive_only: bool = False,
+    viewport_only: bool = False,
+    max_text: int = 120,
+):
+    """A clean, filtered :class:`Vdom` of a page -- the recommended way to read a
+    page's structure and decide what to act on, without a screenshot.
+
+    One in-page pass keeps only meaningful nodes (interactive controls, landmarks,
+    headings, named images), drops hidden / ``aria-hidden`` / script / style nodes,
+    and collapses wrapper ``<div>`` chains. Each node carries its role, accessible
+    name, key attributes, on-screen box and a Playwright-ready CSS ``selector``.
+
+    ``target`` is a Playwright ``Page`` (defaults to the front tab). For big pages
+    pass ``interactive_only=True`` to keep just the controls, and/or
+    ``viewport_only=True`` to keep only what is currently on screen, so the snapshot
+    stays small. ``max_text`` bounds each accessible name's length.
+    """
+    pg = target if target is not None else await page(endpoint=endpoint)
+    raw = await pg.evaluate(
+        _VDOM_JS,
+        {
+            "interactiveOnly": interactive_only,
+            "viewportOnly": viewport_only,
+            "maxText": max_text,
+        },
+    )
+    return Vdom(raw)
 
 
 async def close(endpoint: str | None = None):


### PR DESCRIPTION
## What

Adds **`browser.vdom()`** — a clean, filtered, machine-readable map of a page's DOM — and consolidates the freshly-merged `browser.read()` (#915) onto the same single DOM walker.

A screenshot shows what a page *looks like*; `vdom()` tells the agent what the page *is and where everything is*, as compact structure instead of pixels. One in-page pass:

- keeps only meaningful nodes (interactive controls, landmarks, headings, named images);
- drops hidden / `aria-hidden` / script / style noise;
- collapses wrapper `<div>` chains and merges short text-leaf runs (syntax-highlight token soup → one line);
- gives every node a **role, accessible name, key attrs, on-screen box `(x,y,w,h)`, and a Playwright-ready CSS `selector`**.

The returned `Vdom` renders as a compact, capped indented tree (model reads the text, human sees the same tree as styled HTML), while the full untruncated map is always one attribute away: `.df` (polars), `.json`, `.interactive`, `.node(ref)`.

### Not spammy on complex pages
`interactive_only=True` (drop body text) and `viewport_only=True` (only on-screen) keep snapshots small. Measured: Wikipedia 827 → viewport ~132; python.org 305 → viewport 94 → 70 after the text-merge rule. The tree glance caps at 200 lines pointing to `.df`.

### One concept, one implementation
Main's #915 `read()` had its own bespoke `querySelectorAll` DOM walk. This PR removes it and rebuilds `read()` on the vdom core, so `read().elements == vdom().interactive` — `read()` is the lighter text-first sibling (page prose + flat elements), `vdom()` is the structured map you act on.

## Tested

- **Live:** example.com, Wikipedia, GitHub, BBC News, Hacker News, python.org.
- **CI (Nix):** new `browserVdomSmoke` launches a real **headless Chromium** (bundled browsers, no network, a `data:` fixture) and asserts the filtering, wrapper-collapse, geometry, resolvable selectors and the lean modes — confirmed passing in the Nix sandbox (needed a `PLAYWRIGHT_BROWSERS_PATH` export on bare `mcpPython`). `browserSmoke` extended to assert the new surface.
- Registry tagline (feeds `api()` + server instructions) now recommends `vdom()`.

## Files
- `packages/mcp/src/browser/browser/__init__.py` — `vdom()`, `Vdom`, in-page walker; `read()` consolidated onto it.
- `packages/mcp/default.nix` — `browserVdomSmoke` check + env fix.
- `packages/mcp/ix_notebook_mcp/registry.py` — recommend `vdom()`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `vdom()` to the browser module as a clean, filtered, machine-readable page map
> - Introduces `vdom()` in [browser/__init__.py](https://github.com/indexable-inc/index/pull/922/files#diff-4d8f6838184ae77ce7ecd94b0eac290aaf4703a0b9a3a3165f3989c9cbe9dcea), which evaluates an in-page JS DOM walker (`_VDOM_JS`) and returns a `Vdom` snapshot with structured node data: role, name, geometry, CSS selector, and accessible attributes.
> - The `Vdom` class exposes the snapshot as a nested JSON tree, a polars DataFrame, and ref-indexed node lookup; supports `interactive_only` and `viewport_only` filter modes.
> - `read()` is refactored to derive its interactive element list from the `vdom()` snapshot instead of a separate in-page JS query, aligning roles/names/attributes with the DOM walker's cleaning rules.
> - A new headless smoke test (`browserVdomSmoke`) is added to the Nix build's `checkPhase`, validating the vdom contract (hidden pruning, landmarks, geometry, selector validity, DataFrame agreement) against a fixture page.
> - Behavioral Change: `read()` element details (roles, names, attributes) may differ from the previous heuristic due to the new DOM walker logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2908ea8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->