### PR TITLE
corpus-lake: leader fold of the parquet archive into the lake (#752)

### DIFF
--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -257,8 +257,6 @@ async fn main() -> anyhow::Result<()> {
     // log) and consume (replay the log into Mixedbread) run as separate
     // invocations of this binary; consume reconciles the log rather than scanning.
     if let Some(prefix) = cli.from_parquet_prefix.clone() {
-        let mixedbread = mixedbread
-            .context("--from-parquet-prefix requires --mixedbread-store (the reconcile target)")?;
         let bucket = cli.bucket.clone().context("--from-parquet-prefix requires --bucket")?;
         let config = source_parquet::Config {
             bucket,
@@ -266,6 +264,17 @@ async fn main() -> anyhow::Result<()> {
             region: cli.region.clone(),
             prefix,
         };
+        // With --catalog-uri this folds the parquet archive INTO the lake (the
+        // leader's parquet->lake step under leader-funnel, issue #752);
+        // otherwise it replays the archive into Mixedbread. The lake fold keeps
+        // each (host, user, source) slice separate, so it cannot share
+        // consume_parquet's host-flattened read.
+        if cli.catalog_uri.is_some() {
+            let Lake { catalog, ident } = connect_lake(&cli).await?;
+            return finish(fold_parquet_into_lake(&config, catalog, &ident).await);
+        }
+        let mixedbread = mixedbread
+            .context("--from-parquet-prefix requires --mixedbread-store or --catalog-uri")?;
         return finish(consume_parquet(&config, mixedbread).await);
     }
 
@@ -656,6 +665,62 @@ async fn consume_parquet(config: &source_parquet::Config, mixedbread: Mixedbread
         }
     };
     run_consume(documents, mixedbread).await
+}
+
+/// Fold the parquet corpus archive into the Iceberg lake, one slice per
+/// `(host, user, source)`: the leader's parquet->lake step under leader-funnel.
+///
+/// Each slice reconciles scoped to its origin host and user, so a shared
+/// `external_id` on two hosts stays two rows instead of one host silently
+/// clobbering the other (issue #752). A slice failure is logged and tallied but
+/// never aborts the rest, matching [`run_source`].
+async fn fold_parquet_into_lake(
+    config: &source_parquet::Config,
+    catalog: std::sync::Arc<dyn lake_iceberg::Catalog>,
+    ident: &lake_iceberg::TableIdent,
+) -> Counts {
+    let slices = match source_parquet::read_slices(config).await {
+        Ok(slices) => slices,
+        Err(error) => {
+            eprintln!("[fold] failed to read the parquet corpus log: {error:#}");
+            return Counts { indexed: 0, skipped: 0, failures: 1 };
+        }
+    };
+    let mut counts = Counts { indexed: 0, skipped: 0, failures: 0 };
+    for slice in slices {
+        let source_parquet::Slice { host, user, source, documents } = slice;
+        let Some(host) = host else {
+            eprintln!("[fold:{source}] skipping a slice whose key has no host= segment");
+            counts.failures += 1;
+            continue;
+        };
+        let mut reconciler =
+            IcebergReconciler::new(std::sync::Arc::clone(&catalog), ident.clone(), host);
+        if let Some(user) = user {
+            reconciler = reconciler.with_user(user);
+        }
+        let source = Source::new(source);
+        match reconciler.reconcile(&source, &documents).await {
+            Ok(report) if report.skipped => {
+                eprintln!("[fold:{}] skipped (unchanged)", source.as_str());
+                counts.skipped += 1;
+            }
+            Ok(report) => {
+                eprintln!(
+                    "[fold:{}] appended {} upserts, {} tombstones",
+                    source.as_str(),
+                    report.upserts,
+                    report.deletes
+                );
+                counts.indexed += 1;
+            }
+            Err(error) => {
+                eprintln!("[fold:{}] failed: {error:#}", source.as_str());
+                counts.failures += 1;
+            }
+        }
+    }
+    counts
 }
 
 /// Replace each lake source's Mixedbread records with the lake's live fold:

--- a/packages/source/parquet/src/lib.rs
+++ b/packages/source/parquet/src/lib.rs
@@ -186,6 +186,97 @@ pub async fn read_from_store(store: &dyn ObjectStore, prefix: &str) -> Result<Ve
     Ok(documents)
 }
 
+/// A corpus slice: one `data.parquet` and the `host=/user=/source=` identity
+/// parsed from its key.
+///
+/// The lake fold needs each slice's origin host and user, which
+/// [`read_documents`] flattens away.
+pub struct Slice {
+    /// The `host=` segment, when present in the key.
+    pub host: Option<String>,
+    /// The `user=` segment, when present (host-level sources have none).
+    pub user: Option<String>,
+    /// The `source=` segment (the corpus tag).
+    pub source: String,
+    /// The documents this slice's data file carries.
+    pub documents: Vec<Document>,
+}
+
+/// The hive-partition identity (`host=/user=/source=`) parsed from a key.
+#[derive(Debug, PartialEq, Eq)]
+struct SliceId {
+    /// The `host=` segment, when present.
+    host: Option<String>,
+    /// The `user=` segment, when present.
+    user: Option<String>,
+    /// The `source=` segment.
+    source: String,
+}
+
+/// Parse the hive identity from a data-file key.
+///
+/// Returns `None` when there is no `source=` segment: the identity is
+/// incomplete, so the object is not a corpus slice.
+fn parse_slice_key(key: &str) -> Option<SliceId> {
+    let mut host = None;
+    let mut user = None;
+    let mut source = None;
+    for segment in key.split('/') {
+        if let Some(value) = segment.strip_prefix("host=") {
+            host = Some(value.to_owned());
+        } else if let Some(value) = segment.strip_prefix("user=") {
+            user = Some(value.to_owned());
+        } else if let Some(value) = segment.strip_prefix("source=") {
+            source = Some(value.to_owned());
+        }
+    }
+    source.map(|source| SliceId { host, user, source })
+}
+
+/// Read every `data.parquet` under the prefix as a [`Slice`], keyed by its
+/// `host=/user=/source=` identity.
+///
+/// Unlike [`read_documents`], which flattens the whole prefix into one
+/// host/user-less document set, this keeps each slice separate, so the lake fold
+/// can reconcile it scoped to its origin host and user instead of silently
+/// merging records across hosts.
+///
+/// # Errors
+/// Returns an error if the client cannot be built, the prefix cannot be listed,
+/// or any object cannot be read or decoded.
+pub async fn read_slices(config: &Config) -> Result<Vec<Slice>> {
+    let store = build_store(config)?;
+    read_slices_from_store(&store, &config.prefix).await
+}
+
+/// The store-agnostic core of [`read_slices`], so tests can drive an in-memory
+/// store. A `data.parquet` whose key carries no `source=` segment is skipped,
+/// like the `_manifest.json` sidecar.
+///
+/// # Errors
+/// Returns an error if the store cannot be listed, an object cannot be read, or
+/// a data file cannot be parsed as the corpus parquet schema.
+pub async fn read_slices_from_store(store: &dyn ObjectStore, prefix: &str) -> Result<Vec<Slice>> {
+    let mut slices = Vec::new();
+    let mut listing = store.list(Some(&ObjectPath::from(prefix)));
+    while let Some(entry) = listing.next().await {
+        let meta = entry.context(ListSnafu { prefix })?;
+        let key = meta.location.to_string();
+        if !key.ends_with(DATA_SUFFIX) {
+            continue;
+        }
+        let Some(SliceId { host, user, source }) = parse_slice_key(&key) else {
+            continue;
+        };
+        let result = store.get(&meta.location).await.context(GetSnafu { key: key.clone() })?;
+        let bytes = result.bytes().await.context(GetSnafu { key: key.clone() })?;
+        let mut documents = Vec::new();
+        parse_parquet(bytes, &key, &mut documents)?;
+        slices.push(Slice { host, user, source, documents });
+    }
+    Ok(slices)
+}
+
 /// Build the S3 client. Credentials come from the environment
 /// (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`).
 fn build_store(config: &Config) -> Result<AmazonS3> {
@@ -290,7 +381,7 @@ mod tests {
     use parquet::arrow::ArrowWriter;
     use serde_json::json;
 
-    use super::{Error, read_from_store};
+    use super::{Error, SliceId, parse_slice_key, read_from_store, read_slices_from_store};
 
     /// The exact flat schema `sink-parquet` writes (kept in lockstep with its
     /// `schema()`), so this test round-trips the real on-disk shape.
@@ -385,6 +476,75 @@ mod tests {
         let store = InMemory::new();
         let docs = read_from_store(&store, "corpus").await.expect("read");
         assert!(docs.is_empty());
+    }
+
+    #[test]
+    fn parse_slice_key_extracts_hive_identity() {
+        assert_eq!(
+            parse_slice_key("corpus/host=h1/user=root/source=shell/data.parquet"),
+            Some(SliceId {
+                host: Some("h1".to_owned()),
+                user: Some("root".to_owned()),
+                source: "shell".to_owned()
+            })
+        );
+        // A host-level source has no `user=` segment.
+        assert_eq!(
+            parse_slice_key("corpus/host=h2/source=git/data.parquet"),
+            Some(SliceId { host: Some("h2".to_owned()), user: None, source: "git".to_owned() })
+        );
+        // No `source=` segment: not a corpus slice.
+        assert_eq!(parse_slice_key("corpus/host=h2/data.parquet"), None);
+    }
+
+    #[tokio::test]
+    async fn slices_preserve_per_host_identity() {
+        // The lake fold relies on this: two hosts' slices must stay separate,
+        // each tagged with its own host/user, never flattened together (which
+        // would let a shared external_id silently clobber across hosts).
+        let store = InMemory::new();
+        store
+            .put(
+                &ObjectPath::from("corpus/host=hil-compute-1/user=root/source=shell/data.parquet"),
+                encode_two_rows().into(),
+            )
+            .await
+            .expect("put slice a");
+        store
+            .put(
+                &ObjectPath::from("corpus/host=hil-compute-2/source=git/data.parquet"),
+                encode_two_rows().into(),
+            )
+            .await
+            .expect("put slice b");
+        // A manifest sibling must be skipped, like the flat read.
+        store
+            .put(
+                &ObjectPath::from(
+                    "corpus/host=hil-compute-1/user=root/source=shell/_manifest.json",
+                ),
+                serde_json::to_vec(&json!({ "content_hash": "sha256:aaa" }))
+                    .expect("serialize manifest")
+                    .into(),
+            )
+            .await
+            .expect("put manifest");
+
+        let mut slices = read_slices_from_store(&store, "corpus").await.expect("read slices");
+        slices.sort_by(|a, b| a.source.cmp(&b.source));
+        assert_eq!(slices.len(), 2, "one slice per data.parquet, manifest skipped");
+
+        let git = &slices[0];
+        assert_eq!(git.source, "git");
+        assert_eq!(git.host.as_deref(), Some("hil-compute-2"));
+        assert_eq!(git.user, None, "a host-level source carries no user");
+        assert_eq!(git.documents.len(), 2);
+
+        let shell = &slices[1];
+        assert_eq!(shell.source, "shell");
+        assert_eq!(shell.host.as_deref(), Some("hil-compute-1"));
+        assert_eq!(shell.user.as_deref(), Some("root"));
+        assert_eq!(shell.documents.len(), 2);
     }
 
     /// A schema whose required columns are written nullable, so a row can carry a


### PR DESCRIPTION
Stacked on #785 (base `corpus-lake`; retargets to `main` once #785 merges). The piece that makes the lake deployable under **leader-funnel**: only the leader folds the existing per-host parquet archive into the Iceberg lake.

### Why it isn't a trivial consume mode
`--from-parquet-prefix` reads via `read_documents`, which returns a flat `Vec<Document>` with host/user dropped (`DocumentMeta` has none). But `IcebergReconciler` tags every row by `{host,user}` slice. A naive flatten collides `external_id`s across hosts → silent row drops. The archive is hive-partitioned (`corpus/host=…/user=…/source=…/data.parquet`), so host/user are recoverable from the key.

### What's here (one commit)
- **source-parquet**: `read_slices` / `read_slices_from_store` — a path-parsing slice reader yielding `{host, user, source}` + docs per `data.parquet` (identity via a named `SliceId`). Unit-tested for per-host separation.
- **indexer**: `fold_parquet_into_lake` — per-slice reconcile into the lake scoped to each slice's origin host/user, gated by `--catalog-uri` on the existing `--from-parquet-prefix` path (with it → fold into the lake; without → the prior Mixedbread replay). A slice failure is logged + tallied, never aborts the rest.

### Verification
Per-crate nix checks green on the rebased tip: `indexer` (14 tests) + `source-parquet` (5, incl. the 2 new slice tests) + `lake-iceberg`/`source-meta`/`sink-parquet` `*-all` + clippy (`-D nursery`) + doctests.

The ix side (Lakekeeper catalog + the `ix-corpus-lake-fold` unit) is indexable-inc/ix#4506. Refs #752.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fold parquet archive into Iceberg lake and add lake-backed consume paths to the indexer
> - Introduces a new `lake-iceberg` crate ([packages/lake/iceberg](https://github.com/indexable-inc/index/pull/923/files#diff-30b4ec86bc3eee4c63b5a4a6d3ab0578338934caa52739f22c0066a93c221fcd)) with Iceberg table schema, Arrow codec (encode/decode), and structured error types for reading and writing corpus documents to an Iceberg REST catalog.
> - Adds `ParquetReconciler` and `IcebergReconciler` types to the parquet and Iceberg sink crates, replacing the old `SourceAdapter`-based `sync` free functions with a uniform `Reconciler` trait defined in `source-meta`.
> - Adds `MixedbreadReconciler` to the mixedbread sink, providing `reconcile`, `replace`, and `apply` methods; removes the prior `sync_documents` free function.
> - Extends the indexer CLI with `--catalog-uri`, `--warehouse`, `--from-iceberg`, `--from-snapshot`, and `--cursor-file` flags enabling: full Mixedbread rebuild from lake, stateless delta apply from a snapshot, and cursor-file-managed steady-state consumption with atomic cursor writes and automatic full-rebuild fallback.
> - When `--catalog-uri` is set alongside `--from-parquet-prefix`, the parquet archive is folded into the Iceberg lake slice-by-slice instead of syncing directly to Mixedbread.
> - Adds a local fixture ([packages/lake/iceberg/fixture](https://github.com/indexable-inc/index/pull/923/files#diff-0037fba85426754bdde9737fbdd22973749d892abc32149180048fc37aa47c44)) with Docker Compose (MinIO + Iceberg REST) and a test script for running the REST round-trip integration test.
> - Behavioral Change: the single-source document collection now feeds parquet, lake, and Mixedbread sinks independently in that order; a failure in one sink no longer blocks the others but all failures are reported together.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bb47e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->