### PR TITLE
Revert "fix(lib): drop removed checkAssertWarn in dimension-type (unbreaks downstream lib eval)"

### DIFF
--- a/lib/minecraft/dimension-type.nix
+++ b/lib/minecraft/dimension-type.nix
@@ -64,10 +64,7 @@ let
         }
       ];
     in
-    # Assert every check (each carries its own message), then return `rendered`.
-    # Matches the `assert lib.assertMsg ...` idiom the rest of lib/ uses; the
-    # old `lib.checkAssertWarn` helper was removed in the lib/builtins refactor.
-    lib.foldl' (val: c: assert lib.assertMsg c.assertion c.message; val) rendered checks;
+    lib.checkAssertWarn checks [ ] rendered;
 
   # Project a dimensionTypes submodule value to the JSON written to disk: strip
   # the `base` field, merge the named vanilla snapshot underneath, default

--- a/lib/minecraft/dimension-type.nix
+++ b/lib/minecraft/dimension-type.nix
@@ -64,7 +64,7 @@ let
         }
       ];
     in
-    lib.checkAssertWarn checks [ ] rendered;
+    lib.asserts.checkAssertWarn checks [ ] rendered;
 
   # Project a dimensionTypes submodule value to the JSON written to disk: strip
   # the `base` field, merge the named vanilla snapshot underneath, default


### PR DESCRIPTION
Reverts indexable-inc/index#909

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert assertion check method in `dimension-type.nix` to use manual fold
> Reverts a previous fix in [dimension-type.nix](https://github.com/indexable-inc/index/pull/928/files#diff-adc800c68bb1928783c3fa5a4698498f79541f4f02ba0405a8b6e9406e81e95b) that replaced a manual `lib.foldl'` assertion loop with `lib.asserts.checkAssertWarn`. The revert restores the fold-based approach to unbreak downstream library evaluation that depended on the prior behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3658276.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->