### PR TITLE
feat(nix-web-monitor): surface store optimisation and flag slow store ops

### DIFF
--- a/packages/nix-web-monitor/parser/src/lib.rs
+++ b/packages/nix-web-monitor/parser/src/lib.rs
@@ -89,6 +89,9 @@ pub enum ParseError {
     #[snafu(display("expected two numeric fields"))]
     TwoNumericFields,
 
+    #[snafu(display("expected a byte count and an optional block count"))]
+    FileLinkedFields,
+
     #[snafu(display("expected four numeric progress fields"))]
     ProgressFields,
 
@@ -164,9 +167,17 @@ pub enum FieldValue {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 pub enum ActivityResult {
+    /// One duplicate store file Nix replaced with a hard link.
+    ///
+    /// Nix emits this per linked file during `actOptimiseStore`, with the
+    /// file's apparent size and (off Windows) its block count -- the space that
+    /// hard-linking reclaims. The state machine folds these into
+    /// [`OptimiseStats`] so the run-wide hard-linking cost is visible;
+    /// auto-optimise-store does this work inline on every store add, which is a
+    /// common reason a "copying ... to the store" step is slow.
     FileLinked {
-        linked: i64,
-        total: i64,
+        bytes: i64,
+        blocks: Option<i64>,
     },
     BuildLogLine {
         line: String,
@@ -201,6 +212,22 @@ pub struct ActivityProgress {
     pub failed: i64,
 }
 
+/// Run-wide store-optimisation totals.
+///
+/// Accumulated from the per-file [`ActivityResult::FileLinked`] events Nix
+/// emits while hard-linking duplicate store files. Nix reports no aggregate, so
+/// the state machine sums one here: `files_linked` counts the events and
+/// `bytes_freed` sums their apparent sizes (the space hard-linking reclaims).
+/// Carried in the snapshot like [`ActivityProgress`] so the UI can show how
+/// much store optimisation a run did -- the otherwise-invisible cost behind a
+/// slow "copying to the store".
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OptimiseStats {
+    pub files_linked: u64,
+    pub bytes_freed: i64,
+}
+
 /// One incremental change to the monitor state, mirroring the snapshot shape.
 ///
 /// The state machine accumulates these as it applies each Nix log line, so the
@@ -223,6 +250,8 @@ pub enum Delta {
     LogsAppend { entries: Vec<LogEntry> },
     /// The aggregate progress line moved.
     ProgressSet { progress: ActivityProgress },
+    /// Run-wide store-optimisation totals moved (a file was hard-linked).
+    OptimiseSet { optimise: OptimiseStats },
     /// The expected count for one activity type was (re)declared.
     ExpectedSet { name: String, value: i64 },
     /// One operator/error message was appended to the errors list.
@@ -241,6 +270,8 @@ pub struct MonitorState {
     pub logs: Vec<LogEntry>,
     pub errors: Vec<String>,
     pub progress: Option<ActivityProgress>,
+    /// Run-wide store-optimisation totals, summed from `FileLinked` events.
+    pub optimise: OptimiseStats,
     pub expected: BTreeMap<String, i64>,
     pub exit_code: Option<i32>,
     pub finished: bool,
@@ -307,6 +338,7 @@ impl MonitorState {
             logs: self.logs[log_tail_start..].to_vec(),
             errors: self.errors.clone(),
             progress: self.progress,
+            optimise: self.optimise,
             expected: self.expected.clone(),
             dependencies: dependency_edges(&self.closure_deps, &observed),
             exit_code: self.exit_code,
@@ -680,7 +712,18 @@ impl MonitorState {
                 let cleaned = strip_ansi(status);
                 self.push_log(Some(action.id), None, &cleaned);
             }
-            ActivityResult::FileLinked { .. } | ActivityResult::Other { .. } => {}
+            ActivityResult::FileLinked { bytes, .. } => {
+                // Each event is one duplicate store file replaced by a hard link;
+                // sum the count and the reclaimed bytes so the run-wide
+                // optimisation cost is visible. `bytes` is an apparent file size
+                // and never negative, but clamp defensively before summing.
+                self.optimise.files_linked = self.optimise.files_linked.saturating_add(1);
+                self.optimise.bytes_freed = self.optimise.bytes_freed.saturating_add((*bytes).max(0));
+                self.emit(Delta::OptimiseSet {
+                    optimise: self.optimise,
+                });
+            }
+            ActivityResult::Other { .. } => {}
         }
     }
 
@@ -883,6 +926,8 @@ pub struct MonitorSnapshot {
     pub logs: Vec<LogEntry>,
     pub errors: Vec<String>,
     pub progress: Option<ActivityProgress>,
+    /// Run-wide store-optimisation totals, summed from `FileLinked` events.
+    pub optimise: OptimiseStats,
     pub expected: BTreeMap<String, i64>,
     /// Minimal dependency DAG over derivations Nix actually built: each edge's
     /// `from` directly requires `to`. Derived from `direct_deps` at snapshot
@@ -1054,11 +1099,8 @@ fn parse_result(raw: &Value) -> Result<ResultAction, ParseError> {
     let fields = fields(raw);
     let result = match result_type {
         result_code::FILE_LINKED => {
-            let NumberPair {
-                first: linked,
-                second: total,
-            } = two_numbers(&fields)?;
-            ActivityResult::FileLinked { linked, total }
+            let LinkedFile { bytes, blocks } = file_linked_fields(&fields)?;
+            ActivityResult::FileLinked { bytes, blocks }
         }
         result_code::BUILD_LOG_LINE => ActivityResult::BuildLogLine {
             line: one_text(&fields)?,
@@ -1138,6 +1180,32 @@ fn two_numbers(fields: &[FieldValue]) -> Result<NumberPair, ParseError> {
             second: *second,
         }),
         _ => Err(ParseError::TwoNumericFields),
+    }
+}
+
+/// The fields of a `resFileLinked` result.
+struct LinkedFile {
+    /// The linked file's apparent size in bytes (the space hard-linking reclaims).
+    bytes: i64,
+    /// The file's block count, present only on platforms that report one.
+    blocks: Option<i64>,
+}
+
+/// Parse a `resFileLinked` result's numeric fields.
+///
+/// Nix omits the block field on Windows (`st_blocks` has no analogue), so it is
+/// optional rather than required.
+fn file_linked_fields(fields: &[FieldValue]) -> Result<LinkedFile, ParseError> {
+    match fields {
+        [FieldValue::Number(bytes)] => Ok(LinkedFile {
+            bytes: *bytes,
+            blocks: None,
+        }),
+        [FieldValue::Number(bytes), FieldValue::Number(blocks)] => Ok(LinkedFile {
+            bytes: *bytes,
+            blocks: Some(*blocks),
+        }),
+        _ => Err(ParseError::FileLinkedFields),
     }
 }
 
@@ -1836,6 +1904,65 @@ mod tests {
         assert!(
             state.drain_deltas().is_empty(),
             "a second drain with no intervening mutation is empty"
+        );
+    }
+
+    #[test]
+    fn file_linked_accumulates_optimise_stats() {
+        let mut state = MonitorState::default();
+        // Nix emits one resFileLinked (type 100) per hard-linked file, fields
+        // [apparent_size_bytes, st_blocks].
+        state.apply_line(r#"@nix {"action":"result","fields":[4096,8],"id":1,"type":100}"#);
+        state.apply_line(r#"@nix {"action":"result","fields":[1024,2],"id":1,"type":100}"#);
+
+        let optimise = state.snapshot().optimise;
+        assert_eq!(optimise.files_linked, 2);
+        assert_eq!(optimise.bytes_freed, 5120);
+    }
+
+    #[test]
+    fn file_linked_parses_with_or_without_block_count() {
+        // Off Windows Nix sends [bytes, blocks]; on Windows just [bytes].
+        let two = parse_line(r#"@nix {"action":"result","fields":[4096,8],"id":1,"type":100}"#);
+        assert!(matches!(
+            two,
+            ParsedLine::Event(NixEvent::Result(ResultAction {
+                result: ActivityResult::FileLinked {
+                    bytes: 4096,
+                    blocks: Some(8)
+                },
+                ..
+            }))
+        ));
+        let one = parse_line(r#"@nix {"action":"result","fields":[4096],"id":1,"type":100}"#);
+        assert!(matches!(
+            one,
+            ParsedLine::Event(NixEvent::Result(ResultAction {
+                result: ActivityResult::FileLinked {
+                    bytes: 4096,
+                    blocks: None
+                },
+                ..
+            }))
+        ));
+    }
+
+    #[test]
+    fn file_linked_emits_optimise_delta() {
+        let mut state = MonitorState::default();
+        state.apply_line(r#"@nix {"action":"result","fields":[2048,4],"id":1,"type":100}"#);
+        let deltas = state.drain_deltas();
+        assert!(
+            deltas.iter().any(|delta| matches!(
+                delta,
+                Delta::OptimiseSet {
+                    optimise: OptimiseStats {
+                        files_linked: 1,
+                        bytes_freed: 2048,
+                    }
+                }
+            )),
+            "a hard-linked file should broadcast the updated optimise totals"
         );
     }
 

--- a/packages/nix-web-monitor/server/site/src/components/ActivityTreeRow.svelte
+++ b/packages/nix-web-monitor/server/site/src/components/ActivityTreeRow.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import type { SvelteSet } from 'svelte/reactivity';
   import Self from '$components/ActivityTreeRow.svelte';
-  import { formatBytes, formatDuration, formatRate, middleTruncate } from '$lib/format';
+  import {
+    formatBytes,
+    formatDuration,
+    formatRate,
+    isSlowStoreOp,
+    middleTruncate
+  } from '$lib/format';
   import type { ActivityRowMeta } from '$lib/activity-tree';
 
   type Props = {
@@ -23,6 +29,12 @@
     $props();
 
   const meta = $derived(rowMeta.get(id));
+  /// A store op (copy/substitute/optimise/query) still running past the slow
+  /// threshold. `now` ticks once a second, so this re-evaluates live and the row
+  /// escalates the moment a store step stalls.
+  const slow = $derived.by(() =>
+    meta === undefined ? false : isSlowStoreOp(meta.kind, meta.stoppedAtMs === null, elapsed(meta))
+  );
   const children = $derived(childrenById.get(id) ?? []);
   const isCollapsed = $derived(collapsed.has(id));
   const childGuideLines = $derived(isRoot ? [] : [...guideLines, !isLast]);
@@ -61,7 +73,7 @@
 </script>
 
 {#if meta !== undefined}
-  <div class="activity-row" class:stopped={meta.state === 'stopped'}>
+  <div class="activity-row" class:stopped={meta.state === 'stopped'} class:slow>
     {#if !isRoot}
       <span class="guides" aria-hidden="true"
         >{#each guideLines as line, level (level)}<span class="guide">{line ? '│' : ' '}</span
@@ -112,6 +124,13 @@
            measured total instead of a bar. -->
       <span class="activity-size" title="{formatBytes(meta.sizeBytes)} copied to the store"
         >{formatBytes(meta.sizeBytes)}</span
+      >
+    {/if}
+    {#if slow}
+      <span
+        class="slow-tag"
+        title="this store step has been running a while; a copy or store add stalls here (e.g. auto-optimise-store hard-linking every file inline)"
+        >slow</span
       >
     {/if}
     <span class="activity-dur">{formatDuration(elapsed(meta))}</span>

--- a/packages/nix-web-monitor/server/site/src/components/SummaryBar.svelte
+++ b/packages/nix-web-monitor/server/site/src/components/SummaryBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { formatDuration, formatRate } from '$lib/format';
+  import { formatBytes, formatDuration, formatRate } from '$lib/format';
   import { useNow } from '$lib/now.svelte';
   import {
     ACTIVITY_NAME_BUILD,
@@ -168,6 +168,18 @@
       <div class="kpi kpi-info">
         <span class="kpi-num">{querying}</span>
         <span class="kpi-label">querying</span>
+      </div>
+    {/if}
+    {#if snapshot.optimise.filesLinked > 0}
+      <div
+        class="kpi kpi-info"
+        title="store optimisation: {String(snapshot.optimise.filesLinked)} duplicate files hard-linked, {formatBytes(
+          snapshot.optimise.bytesFreed
+        )} reclaimed"
+      >
+        <span class="kpi-num">{snapshot.optimise.filesLinked}</span>
+        <span class="kpi-label">linked</span>
+        <span class="kpi-num kpi-faint">{formatBytes(snapshot.optimise.bytesFreed)}</span>
       </div>
     {/if}
     {#if counts.succeeded > 0}

--- a/packages/nix-web-monitor/server/site/src/lib/format.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/format.ts
@@ -115,3 +115,38 @@ export function progressUnit(activityTypeName: string): ProgressUnit {
     ? 'bytes'
     : 'count';
 }
+
+/// A store I/O activity that has been running longer than this reads as slow in
+/// the activity view. Nix reports the local source copy and an inline store add
+/// with no byte progress, and the daemon goes quiet while it hard-links files
+/// (`auto-optimise-store`) or writes the path, so a stalled store step is
+/// otherwise just another row ticking its duration up. The threshold is
+/// deliberately generous: a healthy copy or substitution finishes well under
+/// it, so only the genuinely slow ones light up.
+export const SLOW_STORE_OP_MS = 20_000;
+
+/// Activity kinds that represent store I/O worth flagging when they run long:
+/// the typed copy/substitute/download/optimise/query activities, plus the verb
+/// `activityKind` synthesizes for Nix's untyped "copying … to the store" line.
+/// Build and coordinator rows are excluded on purpose -- a long build is normal
+/// and has its own surface, so flagging it would just add noise.
+const SLOW_STORE_OP_KINDS: ReadonlySet<string> = new Set([
+  'copy_path',
+  'copy_paths',
+  'copying',
+  'substitute',
+  'substituting',
+  'file_transfer',
+  'downloading',
+  'optimise_store',
+  'optimising',
+  'query_path_info',
+  'querying'
+]);
+
+/// Whether a still-running store activity has exceeded the slow threshold. Used
+/// by the activity row to escalate a silently-stalled store step (the exact
+/// blind spot behind a slow "copying to the store").
+export function isSlowStoreOp(kind: string, running: boolean, elapsedMs: number): boolean {
+  return running && elapsedMs >= SLOW_STORE_OP_MS && SLOW_STORE_OP_KINDS.has(kind);
+}

--- a/packages/nix-web-monitor/server/site/src/lib/monitor-transport.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/monitor-transport.ts
@@ -37,6 +37,7 @@ type Working = {
   logs: LogEntry[];
   errors: string[];
   progress: MonitorSnapshot['progress'];
+  optimise: MonitorSnapshot['optimise'];
   expected: Record<string, number>;
   dependencies: DerivationEdge[];
   exitCode: number | null;
@@ -51,6 +52,7 @@ function createWorking(): Working {
     logs: [],
     errors: [],
     progress: null,
+    optimise: { filesLinked: 0, bytesFreed: 0 },
     expected: {},
     dependencies: [],
     exitCode: null,
@@ -81,6 +83,9 @@ export function applyDelta(working: Working, delta: Delta): Working {
     case 'progressSet':
       working.progress = delta.progress;
       return working;
+    case 'optimiseSet':
+      working.optimise = delta.optimise;
+      return working;
     case 'expectedSet':
       working.expected = { ...working.expected, [delta.name]: delta.value };
       return working;
@@ -106,6 +111,7 @@ function fromSnapshot(snapshot: MonitorSnapshot): Working {
     logs: [...snapshot.logs],
     errors: [...snapshot.errors],
     progress: snapshot.progress,
+    optimise: snapshot.optimise,
     expected: { ...snapshot.expected },
     dependencies: snapshot.dependencies,
     exitCode: snapshot.exitCode,
@@ -141,6 +147,7 @@ export function projectSnapshot(working: Working): MonitorSnapshot {
     logs: [...working.logs],
     errors: [...working.errors],
     progress: working.progress,
+    optimise: working.optimise,
     expected: { ...working.expected },
     dependencies: working.dependencies,
     exitCode: working.exitCode,

--- a/packages/nix-web-monitor/server/site/src/lib/types.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/types.ts
@@ -29,6 +29,15 @@ export const activityProgressSchema = v.object({
   failed: v.number()
 });
 
+/// Run-wide store-optimisation totals: how many duplicate store files Nix
+/// replaced with hard links and the apparent bytes that reclaimed. Summed by
+/// the parser from per-file `FileLinked` events; surfaced so the operator can
+/// see the store-optimisation work behind an otherwise-silent slow store add.
+export const optimiseStatsSchema = v.object({
+  filesLinked: v.number(),
+  bytesFreed: v.number()
+});
+
 export const activityNodeSchema = v.object({
   id: v.number(),
   parent: v.nullable(v.number()),
@@ -84,6 +93,7 @@ export const snapshotSchema = v.object({
   logs: v.array(logEntrySchema),
   errors: v.array(v.string()),
   progress: v.nullable(activityProgressSchema),
+  optimise: optimiseStatsSchema,
   expected: v.record(v.string(), v.number()),
   dependencies: v.array(derivationEdgeSchema),
   exitCode: v.nullable(v.number()),
@@ -100,6 +110,7 @@ export const deltaSchema = v.variant('type', [
   v.object({ type: v.literal('activityUpsert'), activity: activityNodeSchema }),
   v.object({ type: v.literal('logsAppend'), entries: v.array(logEntrySchema) }),
   v.object({ type: v.literal('progressSet'), progress: activityProgressSchema }),
+  v.object({ type: v.literal('optimiseSet'), optimise: optimiseStatsSchema }),
   v.object({ type: v.literal('expectedSet'), name: v.string(), value: v.number() }),
   v.object({ type: v.literal('errorAppend'), message: v.string() }),
   v.object({ type: v.literal('dependenciesSet'), edges: v.array(derivationEdgeSchema) }),
@@ -110,6 +121,7 @@ export type ActivityStatus = v.InferOutput<typeof activityStatusSchema>;
 export type BuildStatus = v.InferOutput<typeof buildStatusSchema>;
 export type ActivityType = v.InferOutput<typeof activityTypeSchema>;
 export type ActivityProgress = v.InferOutput<typeof activityProgressSchema>;
+export type OptimiseStats = v.InferOutput<typeof optimiseStatsSchema>;
 export type ActivityNode = v.InferOutput<typeof activityNodeSchema>;
 export type BuildNode = v.InferOutput<typeof buildNodeSchema>;
 export type LogEntry = v.InferOutput<typeof logEntrySchema>;
@@ -138,6 +150,7 @@ export const EMPTY_SNAPSHOT: MonitorSnapshot = Object.freeze({
   logs: [],
   errors: [],
   progress: null,
+  optimise: { filesLinked: 0, bytesFreed: 0 },
   expected: {},
   dependencies: [],
   exitCode: null,

--- a/packages/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix-web-monitor/server/site/src/style.css
@@ -752,6 +752,32 @@ main.dragging-v .splitter-v::after {
   white-space: nowrap;
 }
 
+/* A store I/O activity (copy / substitute / optimise / query) still running
+ * past the slow threshold. The daemon goes silent while it writes a path or
+ * hard-links files (auto-optimise-store), so an in-flight store step would
+ * otherwise read as just another long-ticking row; the amber rail plus the
+ * `slow` tag pull it to the foreground. Scoped to in-flight rows so a finished
+ * row keeps the muted/stopped treatment. */
+.activity-row.slow:not(.stopped) {
+  box-shadow: inset 2px 0 0 var(--amber);
+}
+
+.activity-row.slow:not(.stopped) .activity-text,
+.activity-row.slow:not(.stopped) .activity-kind {
+  color: var(--amber);
+}
+
+.slow-tag {
+  flex: 0 0 auto;
+  color: var(--amber);
+  border: 1px solid color-mix(in srgb, var(--amber) 45%, transparent);
+  border-radius: 3px;
+  padding: 0 0.25rem;
+  font-size: 0.85em;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
 /* ---------- builds ---------- */
 
 .build-table {


### PR DESCRIPTION
## What

The web monitor went quiet during the slowest part of many runs: the daemon copying a source tree into the store and hard-linking duplicate files (`auto-optimise-store`). A multi-minute "copying to the store" looked like a hang with nothing to explain it. This surfaces that store-side work.

## Changes

- **parser**: stop discarding `resFileLinked`. Its two numbers are a linked file's apparent **size** and **block count** (not the `linked`/`total` the field names claimed -- verified against Nix `optimise-store.cc`). Sum them into run-wide `OptimiseStats { files_linked, bytes_freed }`, carried in the snapshot and broadcast via a new `OptimiseSet` delta.
- **summary bar**: show `<n> linked - <bytes>` once store optimisation starts.
- **activity view**: flag a store op (copy / substitute / optimise / query) still running past a threshold with an amber rail and a `slow` tag, so a stalled store step stands out instead of only ticking its duration up.

## Why these

These came out of debugging a recurring "`nix run .#lint` hangs for minutes on *copying ... to the store*" report: the cost was the daemon re-adding a dirty flake source with `auto-optimise-store = true` hard-linking every file inline -- invisible in the monitor. The slow-op flag surfaces the symptom; the optimise totals surface the hard-linking work whenever Nix reports it.

## Test

- `cargo test -p nix-web-monitor-parser` (37 pass, incl. 3 new: accumulation, with/without block count, delta broadcast).
- `cargo test -p nix-web-monitor` (5 pass).
- `npm run check` (svelte-check, 0 errors) + `npm run lint` (eslint, clean) + `vite build`.

Minimal diff: no `cargo fmt` churn (the repo gates Rust style via clippy, not rustfmt); `server/src/main.rs` untouched.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface store optimisation stats and flag slow store ops in nix-web-monitor
> - Adds an `OptimiseStats` aggregate (files linked, bytes freed) to parser state and snapshots, populated by parsing `resFileLinked` results with updated field semantics (bytes + optional block count).
> - Extends the delta stream with an `optimiseSet` message type; the client transport applies these deltas to keep the working model in sync.
> - Displays run-wide optimisation totals in `SummaryBar` once any files have been hard-linked.
> - Flags in-flight store I/O operations exceeding 20 seconds with an amber highlight and a 'slow' tag in `ActivityTreeRow`, using the new `isSlowStoreOp` predicate in [format.ts](https://github.com/indexable-inc/index/pull/931/files#diff-d9f5256217da8c7536b8dc20f19d3ad1f66d8f8bad822ed6e2790cacddf18553).
> - Behavioral Change: `resFileLinked` fields are now interpreted as `bytes` and optional `blocks` rather than `linked` and `total`; existing consumers of `ActivityResult::FileLinked` must update their field access.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2aaf359.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->