### PR TITLE
feat(nix-web-monitor): live nix-daemon syscall view + fix copy-source spam

### DIFF
--- a/packages/nix-web-monitor/parser/src/daemon.rs
+++ b/packages/nix-web-monitor/parser/src/daemon.rs
@@ -1,0 +1,331 @@
+//! Live `nix-daemon` syscall view.
+//!
+//! The internal-json stream the monitor parses elsewhere is the daemon's work
+//! *as the client sees it*: it goes silent during a single long `addToStore`
+//! (writing a path, or hard-linking every file when `auto-optimise-store` is on),
+//! which is exactly when a build looks hung. To see *into* that, the server taps
+//! the daemon's filesystem syscalls with a platform tracer (`fs_usage` on macOS,
+//! `strace` on Linux) and folds them into the small, wire-friendly
+//! [`DaemonInfo`] the UI renders. This module owns the pure, testable pieces:
+//! the per-tracer line parsers and the rolling aggregator. Spawning the tracer
+//! (privileged, platform-specific, best-effort) lives in the server.
+
+use serde::{Deserialize, Serialize};
+
+/// A class of filesystem syscall.
+///
+/// Grouped so the UI shows what kind of work the daemon is doing rather than a
+/// raw syscall histogram: `Link`/`Rename` dominate store optimisation,
+/// `Write`/`Fsync` dominate writing a new path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OpClass {
+    Link,
+    Rename,
+    Open,
+    Write,
+    Fsync,
+    Stat,
+    Unlink,
+    Other,
+}
+
+impl OpClass {
+    /// Classify a syscall by name. Handles the `*at` and `p*`/`*64` variants the
+    /// two tracers emit (`openat`, `pwrite`, `lstat64`, `fdatasync`, ...).
+    #[must_use]
+    pub fn classify(syscall: &str) -> Self {
+        // Strip a trailing `64`/`_nocancel` so `stat64` / `open_nocancel` match.
+        let name = syscall
+            .trim_end_matches("_nocancel")
+            .trim_end_matches("64");
+        match name {
+            "link" | "linkat" | "clonefile" | "clonefileat" => Self::Link,
+            "rename" | "renameat" | "renameatx_np" => Self::Rename,
+            "unlink" | "unlinkat" | "rmdir" => Self::Unlink,
+            "fsync" | "fdatasync" => Self::Fsync,
+            "write" | "pwrite" | "writev" | "pwritev" => Self::Write,
+            "open" | "openat" => Self::Open,
+            "stat" | "lstat" | "fstat" | "fstatat" | "access" | "getattrlist" | "readlink"
+            | "readlinkat" => Self::Stat,
+            _ => Self::Other,
+        }
+    }
+}
+
+/// Per-class syscall counts. Cumulative since the tracer started.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DaemonOps {
+    pub link: u64,
+    pub rename: u64,
+    pub open: u64,
+    pub write: u64,
+    pub fsync: u64,
+    pub stat: u64,
+    pub unlink: u64,
+    pub other: u64,
+}
+
+impl DaemonOps {
+    /// Count one syscall against its class.
+    pub fn bump(&mut self, op: OpClass) {
+        let slot = match op {
+            OpClass::Link => &mut self.link,
+            OpClass::Rename => &mut self.rename,
+            OpClass::Open => &mut self.open,
+            OpClass::Write => &mut self.write,
+            OpClass::Fsync => &mut self.fsync,
+            OpClass::Stat => &mut self.stat,
+            OpClass::Unlink => &mut self.unlink,
+            OpClass::Other => &mut self.other,
+        };
+        *slot = slot.saturating_add(1);
+    }
+
+    /// Total across all classes.
+    #[must_use]
+    pub const fn total(&self) -> u64 {
+        self.link
+            .saturating_add(self.rename)
+            .saturating_add(self.open)
+            .saturating_add(self.write)
+            .saturating_add(self.fsync)
+            .saturating_add(self.stat)
+            .saturating_add(self.unlink)
+            .saturating_add(self.other)
+    }
+}
+
+/// One observed daemon syscall: its class and, when the tracer reported one, the
+/// path it touched (preferring `/nix/store` paths, which are the interesting
+/// ones).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SyscallEvent {
+    pub op: OpClass,
+    pub path: Option<String>,
+}
+
+/// Wire-friendly snapshot of the daemon syscall view.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DaemonInfo {
+    /// Whether a tracer is attached and producing events.
+    pub tracing: bool,
+    /// Human-readable state when not tracing.
+    ///
+    /// "no nix-daemon (single-user store)", "syscall tracing needs root", an
+    /// error, ...; so the panel always explains itself instead of sitting blank.
+    pub status: String,
+    /// `nix-daemon` worker pids currently being traced.
+    pub workers: Vec<u32>,
+    /// Cumulative syscalls by class since tracing started.
+    pub ops: DaemonOps,
+    /// Recent syscall rate, in events over the last one-second window.
+    ///
+    /// Integer (not `f64`) so the whole snapshot stays `Eq`, which the
+    /// delta-dedup in the state machine relies on; the one-second window means
+    /// the per-window count *is* the per-second rate, with no division.
+    pub ops_per_sec: u64,
+    /// The most recent path the daemon touched, for a "currently working on"
+    /// readout. `None` until a path-bearing syscall is seen.
+    pub current_path: Option<String>,
+}
+
+/// Rolling aggregator that folds [`SyscallEvent`]s into a [`DaemonInfo`].
+///
+/// Kept separate from the wire type so the server can mutate it freely and
+/// publish a clone on a timer. `ops` is cumulative; `ops_per_sec` is computed by
+/// the server from the cumulative total between samples.
+#[derive(Clone, Debug, Default)]
+pub struct DaemonTrace {
+    pub ops: DaemonOps,
+    pub workers: Vec<u32>,
+    pub current_path: Option<String>,
+}
+
+impl DaemonTrace {
+    /// Fold one parsed syscall event into the running totals.
+    pub fn record(&mut self, event: SyscallEvent) {
+        self.ops.bump(event.op);
+        if let Some(path) = event.path {
+            self.current_path = Some(path);
+        }
+    }
+
+    /// Project the current totals into a wire [`DaemonInfo`]. `ops_per_sec` is
+    /// supplied by the caller, which alone knows the wall-clock between samples.
+    #[must_use]
+    pub fn info(&self, tracing: bool, status: String, ops_per_sec: u64) -> DaemonInfo {
+        DaemonInfo {
+            tracing,
+            status,
+            workers: self.workers.clone(),
+            ops: self.ops,
+            ops_per_sec,
+            current_path: self.current_path.clone(),
+        }
+    }
+}
+
+/// Pick the most interesting path from a tracer line's tokens.
+///
+/// Prefers the last `/nix/store/...` token (the store path being written or
+/// linked), else the last absolute-path token; keeps relative and `/dev` noise
+/// out of the readout.
+fn best_path<'a>(tokens: impl Iterator<Item = &'a str>) -> Option<String> {
+    let mut store: Option<&str> = None;
+    let mut any_abs: Option<&str> = None;
+    for token in tokens {
+        let cleaned = token.trim_matches(|c| c == '"' || c == ',' || c == '\'');
+        if cleaned.starts_with("/nix/store/") {
+            store = Some(cleaned);
+        } else if cleaned.starts_with('/') && cleaned.len() > 1 {
+            any_abs = Some(cleaned);
+        }
+    }
+    store.or(any_abs).map(ToOwned::to_owned)
+}
+
+/// Parse one `fs_usage -w -f filesys` line (macOS).
+///
+/// The format is whitespace-columned: `HH:MM:SS.uuuuuu  <syscall>  <args/paths>
+/// <duration> <process>`. We take the first non-timestamp token as the syscall
+/// name and scan the remaining tokens for the best path. Lines that are headers
+/// or lack a recognizable syscall yield `None`.
+#[must_use]
+pub fn parse_fs_usage_line(line: &str) -> Option<SyscallEvent> {
+    let mut tokens = line.split_whitespace();
+    let first = tokens.next()?;
+    // The leading token is a `HH:MM:SS.uuuuuu` timestamp; anything else is a
+    // header/banner line we skip.
+    if !(first.len() >= 8 && first.as_bytes()[2] == b':' && first.as_bytes()[5] == b':') {
+        return None;
+    }
+    let syscall = tokens.next()?;
+    if syscall.is_empty() || !syscall.as_bytes()[0].is_ascii_alphabetic() {
+        return None;
+    }
+    let op = OpClass::classify(syscall);
+    // Re-scan the whole line for a path; fs_usage puts paths after the syscall.
+    let path = best_path(line.split_whitespace().skip(2));
+    Some(SyscallEvent { op, path })
+}
+
+/// Parse one `strace -f` line (Linux).
+///
+/// The relevant form is `[pid 123] syscall(arg, "path", ...) = ret`. We take the
+/// token before the first `(` as the syscall name and the first quoted argument
+/// (or any `/nix/store` token) as the path. Resumed (`<... resumed>`), unfinished
+/// (`<unfinished ...>`), and signal lines yield `None`.
+#[must_use]
+pub fn parse_strace_line(line: &str) -> Option<SyscallEvent> {
+    let line = line.trim_start();
+    // Drop an optional `[pid 1234] ` prefix.
+    let rest = if let Some(after) = line.strip_prefix("[pid ") {
+        after.split_once("] ").map(|(_, r)| r)?
+    } else {
+        line
+    };
+    // The syscall name is the identifier before the first `(`.
+    let paren = rest.find('(')?;
+    let name = rest[..paren].trim();
+    if name.is_empty() || !name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
+        return None;
+    }
+    let op = OpClass::classify(name);
+    // First double-quoted argument is the path for the file syscalls we trace.
+    let path = rest[paren + 1..]
+        .split('"')
+        .nth(1)
+        .filter(|p| p.starts_with('/'))
+        .map(ToOwned::to_owned);
+    Some(SyscallEvent { op, path })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_handles_variants() {
+        assert_eq!(OpClass::classify("openat"), OpClass::Open);
+        assert_eq!(OpClass::classify("open_nocancel"), OpClass::Open);
+        assert_eq!(OpClass::classify("lstat64"), OpClass::Stat);
+        assert_eq!(OpClass::classify("link"), OpClass::Link);
+        assert_eq!(OpClass::classify("clonefile"), OpClass::Link);
+        assert_eq!(OpClass::classify("rename"), OpClass::Rename);
+        assert_eq!(OpClass::classify("fdatasync"), OpClass::Fsync);
+        assert_eq!(OpClass::classify("pwrite"), OpClass::Write);
+        assert_eq!(OpClass::classify("getpid"), OpClass::Other);
+    }
+
+    #[test]
+    fn ops_bump_and_total() {
+        let mut ops = DaemonOps::default();
+        ops.bump(OpClass::Link);
+        ops.bump(OpClass::Link);
+        ops.bump(OpClass::Fsync);
+        assert_eq!(ops.link, 2);
+        assert_eq!(ops.fsync, 1);
+        assert_eq!(ops.total(), 3);
+    }
+
+    #[test]
+    fn parses_fs_usage_link_line() {
+        let line = "22:35:01.123456  link              \
+            /nix/store/.tmp-link-abc -> /nix/store/aaaa-foo   0.000030   nix-daemon.31415";
+        let event = parse_fs_usage_line(line).expect("a syscall line parses");
+        assert_eq!(event.op, OpClass::Link);
+        assert_eq!(
+            event.path.as_deref(),
+            Some("/nix/store/aaaa-foo"),
+            "prefers the last /nix/store path"
+        );
+    }
+
+    #[test]
+    fn fs_usage_rejects_banner_lines() {
+        assert!(parse_fs_usage_line("").is_none());
+        assert!(parse_fs_usage_line("  Command must be run as root").is_none());
+        assert!(parse_fs_usage_line("PROCESS   TYPE   PATHNAME").is_none());
+    }
+
+    #[test]
+    fn parses_strace_lines() {
+        let with_pid = r#"[pid 31415] openat(AT_FDCWD, "/nix/store/aaaa-foo", O_RDONLY) = 3"#;
+        let event = parse_strace_line(with_pid).expect("strace line parses");
+        assert_eq!(event.op, OpClass::Open);
+        assert_eq!(event.path.as_deref(), Some("/nix/store/aaaa-foo"));
+
+        let fsync = "fsync(7) = 0";
+        let event = parse_strace_line(fsync).expect("fsync parses");
+        assert_eq!(event.op, OpClass::Fsync);
+        assert_eq!(event.path, None);
+
+        assert!(parse_strace_line("+++ exited with 0 +++").is_none());
+        assert!(parse_strace_line(r#"[pid 1] <... read resumed>) = 0"#).is_none());
+    }
+
+    #[test]
+    fn trace_records_and_projects() {
+        let mut trace = DaemonTrace::default();
+        trace.workers = vec![10, 11];
+        trace.record(SyscallEvent {
+            op: OpClass::Write,
+            path: Some("/nix/store/x".to_owned()),
+        });
+        trace.record(SyscallEvent {
+            op: OpClass::Fsync,
+            path: None,
+        });
+        let info = trace.info(true, "tracing".to_owned(), 42);
+        assert!(info.tracing);
+        assert_eq!(info.ops.write, 1);
+        assert_eq!(info.ops.fsync, 1);
+        assert_eq!(info.ops.total(), 2);
+        assert_eq!(info.current_path.as_deref(), Some("/nix/store/x"));
+        assert_eq!(info.workers, vec![10, 11]);
+        assert_eq!(info.ops_per_sec, 42);
+    }
+}

--- a/packages/nix-web-monitor/parser/src/daemon.rs
+++ b/packages/nix-web-monitor/parser/src/daemon.rs
@@ -69,7 +69,7 @@ pub struct DaemonOps {
 
 impl DaemonOps {
     /// Count one syscall against its class.
-    pub fn bump(&mut self, op: OpClass) {
+    pub const fn bump(&mut self, op: OpClass) {
         let slot = match op {
             OpClass::Link => &mut self.link,
             OpClass::Rename => &mut self.rename,
@@ -177,7 +177,7 @@ fn best_path<'a>(tokens: impl Iterator<Item = &'a str>) -> Option<String> {
     let mut store: Option<&str> = None;
     let mut any_abs: Option<&str> = None;
     for token in tokens {
-        let cleaned = token.trim_matches(|c| c == '"' || c == ',' || c == '\'');
+        let cleaned = token.trim_matches(['"', ',', '\'']);
         if cleaned.starts_with("/nix/store/") {
             store = Some(cleaned);
         } else if cleaned.starts_with('/') && cleaned.len() > 1 {
@@ -199,11 +199,12 @@ pub fn parse_fs_usage_line(line: &str) -> Option<SyscallEvent> {
     let first = tokens.next()?;
     // The leading token is a `HH:MM:SS.uuuuuu` timestamp; anything else is a
     // header/banner line we skip.
-    if !(first.len() >= 8 && first.as_bytes()[2] == b':' && first.as_bytes()[5] == b':') {
+    let stamp = first.as_bytes();
+    if stamp.len() < 8 || stamp[2] != b':' || stamp[5] != b':' {
         return None;
     }
     let syscall = tokens.next()?;
-    if syscall.is_empty() || !syscall.as_bytes()[0].is_ascii_alphabetic() {
+    if !syscall.starts_with(|c: char| c.is_ascii_alphabetic()) {
         return None;
     }
     let op = OpClass::classify(syscall);
@@ -222,10 +223,9 @@ pub fn parse_fs_usage_line(line: &str) -> Option<SyscallEvent> {
 pub fn parse_strace_line(line: &str) -> Option<SyscallEvent> {
     let line = line.trim_start();
     // Drop an optional `[pid 1234] ` prefix.
-    let rest = if let Some(after) = line.strip_prefix("[pid ") {
-        after.split_once("] ").map(|(_, r)| r)?
-    } else {
-        line
+    let rest = match line.strip_prefix("[pid ") {
+        Some(after) => after.split_once("] ").map(|(_, rest)| rest)?,
+        None => line,
     };
     // The syscall name is the identifier before the first `(`.
     let paren = rest.find('(')?;

--- a/packages/nix-web-monitor/parser/src/daemon.rs
+++ b/packages/nix-web-monitor/parser/src/daemon.rs
@@ -304,13 +304,15 @@ mod tests {
         assert_eq!(event.path, None);
 
         assert!(parse_strace_line("+++ exited with 0 +++").is_none());
-        assert!(parse_strace_line(r#"[pid 1] <... read resumed>) = 0"#).is_none());
+        assert!(parse_strace_line(r"[pid 1] <... read resumed>) = 0").is_none());
     }
 
     #[test]
     fn trace_records_and_projects() {
-        let mut trace = DaemonTrace::default();
-        trace.workers = vec![10, 11];
+        let mut trace = DaemonTrace {
+            workers: vec![10, 11],
+            ..DaemonTrace::default()
+        };
         trace.record(SyscallEvent {
             op: OpClass::Write,
             path: Some("/nix/store/x".to_owned()),

--- a/packages/nix-web-monitor/parser/src/lib.rs
+++ b/packages/nix-web-monitor/parser/src/lib.rs
@@ -7,6 +7,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use snafu::Snafu;
 
+pub mod daemon;
+pub use daemon::{DaemonInfo, DaemonOps, OpClass};
+
 const NIX_JSON_PREFIX: &str = "@nix ";
 
 /// Suffix Nix uses for derivation files. Build-plan lines and closure queries
@@ -252,6 +255,8 @@ pub enum Delta {
     ProgressSet { progress: ActivityProgress },
     /// Run-wide store-optimisation totals moved (a file was hard-linked).
     OptimiseSet { optimise: OptimiseStats },
+    /// The live nix-daemon syscall view changed (new counts, path, or status).
+    DaemonSet { daemon: DaemonInfo },
     /// The expected count for one activity type was (re)declared.
     ExpectedSet { name: String, value: i64 },
     /// One operator/error message was appended to the errors list.
@@ -272,6 +277,8 @@ pub struct MonitorState {
     pub progress: Option<ActivityProgress>,
     /// Run-wide store-optimisation totals, summed from `FileLinked` events.
     pub optimise: OptimiseStats,
+    /// Live nix-daemon syscall view, fed out-of-band by the server's tracer.
+    pub daemon: DaemonInfo,
     pub expected: BTreeMap<String, i64>,
     pub exit_code: Option<i32>,
     pub finished: bool,
@@ -339,6 +346,7 @@ impl MonitorState {
             errors: self.errors.clone(),
             progress: self.progress,
             optimise: self.optimise,
+            daemon: self.daemon.clone(),
             expected: self.expected.clone(),
             dependencies: dependency_edges(&self.closure_deps, &observed),
             exit_code: self.exit_code,
@@ -387,6 +395,20 @@ impl MonitorState {
         };
         activity.size_bytes = Some(size_bytes);
         self.emit_activity(id);
+    }
+
+    /// Replace the live nix-daemon syscall view and broadcast the change.
+    ///
+    /// Called by the server's tracer on its sampling timer. Skips the broadcast
+    /// when nothing changed so an idle daemon (or a tracer that cannot attach)
+    /// does not put a frame on the wire every tick; the snapshot still carries
+    /// the latest value for a freshly-connected client.
+    pub fn set_daemon(&mut self, daemon: DaemonInfo) {
+        if self.daemon == daemon {
+            return;
+        }
+        self.daemon = daemon.clone();
+        self.emit(Delta::DaemonSet { daemon });
     }
 
     /// Record the transitive input `.drv` closure of one derivation, learned
@@ -892,14 +914,22 @@ fn planned_derivation(text: &str) -> Option<&str> {
     (path.starts_with("/nix/store/") && path.ends_with(DRV_SUFFIX)).then_some(path)
 }
 
-/// Extract the source path from a Nix "copying <path> to the store" activity.
+/// Extract the local source path from a Nix "copying <path> to the store"
+/// activity, or `None` when the path is not one the server can measure.
 ///
 /// Nix emits this for the local source-tree copy as an unstructured `unknown`
 /// activity carrying no byte progress, so the server measures the path itself to
 /// show how large the copy is (see [`MonitorState::set_activity_size`]). Handles
 /// both quote styles Nix uses (`'…'` for a `git+file` flake, `"…"` for a `path:`
-/// flake) and trims a trailing slash so the returned path stats cleanly. Returns
-/// `None` for any other activity text.
+/// flake) and trims a trailing slash so the returned path stats cleanly.
+///
+/// Only an absolute filesystem path (one starting with `/`) is returned. Nix
+/// also copies individual files out of fetched flake inputs and prints those
+/// with its virtual source-accessor notation, e.g. `copying
+/// '«github:NixOS/nixpkgs#…»/pkgs/…/foo.patch' to the store`. That `«…»` path
+/// has no on-disk location, so measuring it spams one `No such file or
+/// directory` per patch; rejecting non-absolute paths keeps the measurement to
+/// the real local source tree the operator cares about.
 #[must_use]
 pub fn copy_to_store_source(text: &str) -> Option<&str> {
     let rest = text.strip_prefix("copying ")?;
@@ -910,7 +940,7 @@ pub fn copy_to_store_source(text: &str) -> Option<&str> {
     let body = &rest[quote.len_utf8()..];
     let end = body.find(quote)?;
     let path = &body[..end];
-    if path.is_empty() || body[end + quote.len_utf8()..].trim_start() != "to the store" {
+    if !path.starts_with('/') || body[end + quote.len_utf8()..].trim_start() != "to the store" {
         return None;
     }
     Some(path.strip_suffix('/').unwrap_or(path))
@@ -928,6 +958,8 @@ pub struct MonitorSnapshot {
     pub progress: Option<ActivityProgress>,
     /// Run-wide store-optimisation totals, summed from `FileLinked` events.
     pub optimise: OptimiseStats,
+    /// Live nix-daemon syscall view, fed out-of-band by the server's tracer.
+    pub daemon: DaemonInfo,
     pub expected: BTreeMap<String, i64>,
     /// Minimal dependency DAG over derivations Nix actually built: each edge's
     /// `from` directly requires `to`. Derived from `direct_deps` at snapshot
@@ -1987,6 +2019,14 @@ mod tests {
         assert_eq!(copy_to_store_source("copying /tmp/x to the store"), None);
         // An empty path would make the server walk its own CWD; reject it.
         assert_eq!(copy_to_store_source("copying '' to the store"), None);
+        // Nix's virtual flake-input accessor path has no on-disk location, so
+        // it must be rejected rather than walked (one ENOENT per patch file).
+        assert_eq!(
+            copy_to_store_source(
+                "copying '«github:NixOS/nixpkgs#abc»/pkgs/foo/bar.patch' to the store"
+            ),
+            None
+        );
     }
 
     #[test]

--- a/packages/nix-web-monitor/parser/src/lib.rs
+++ b/packages/nix-web-monitor/parser/src/lib.rs
@@ -407,8 +407,10 @@ impl MonitorState {
         if self.daemon == daemon {
             return;
         }
-        self.daemon = daemon.clone();
-        self.emit(Delta::DaemonSet { daemon });
+        self.daemon = daemon;
+        self.emit(Delta::DaemonSet {
+            daemon: self.daemon.clone(),
+        });
     }
 
     /// Record the transitive input `.drv` closure of one derivation, learned

--- a/packages/nix-web-monitor/server/site/src/App.svelte
+++ b/packages/nix-web-monitor/server/site/src/App.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, onMount } from 'svelte';
   import ActivityGraph from '$components/ActivityGraph.svelte';
   import BuildTable from '$components/BuildTable.svelte';
+  import DaemonPanel from '$components/DaemonPanel.svelte';
   import ErrorPanel from '$components/ErrorPanel.svelte';
   import LogPanel from '$components/LogPanel.svelte';
   import SummaryBar from '$components/SummaryBar.svelte';
@@ -216,6 +217,7 @@
         onkeydown={sidebarKeydown}
       />
       <aside class="side-pane">
+        <DaemonPanel daemon={snapshot.daemon} />
         <ActivityGraph activities={snapshot.activities} builds={snapshot.builds} />
       </aside>
     </section>

--- a/packages/nix-web-monitor/server/site/src/components/DaemonPanel.svelte
+++ b/packages/nix-web-monitor/server/site/src/components/DaemonPanel.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import PanelHeader from '$lib/PanelHeader.svelte';
+  import { middleTruncate } from '$lib/format';
+  import type { DaemonInfo, DaemonOps } from '$lib/types';
+
+  type Props = {
+    daemon: DaemonInfo;
+  };
+
+  const { daemon }: Props = $props();
+
+  /// Op classes in a fixed display order with a short label. Keyed by the
+  /// `DaemonOps` field so the row count joins by identity.
+  const OP_ORDER: ReadonlyArray<readonly [keyof DaemonOps, string]> = [
+    ['link', 'link'],
+    ['rename', 'rename'],
+    ['write', 'write'],
+    ['fsync', 'fsync'],
+    ['open', 'open'],
+    ['stat', 'stat'],
+    ['unlink', 'unlink'],
+    ['other', 'other']
+  ];
+
+  const rows = $derived(
+    OP_ORDER.map(([key, label]) => ({ label, count: daemon.ops[key] })).filter(
+      (row) => row.count > 0
+    )
+  );
+  const max = $derived(rows.reduce((peak, row) => Math.max(peak, row.count), 1));
+
+  function pct(count: number): number {
+    return Math.max(2, Math.round((count / max) * 100));
+  }
+</script>
+
+<section class="panel daemon-panel">
+  <PanelHeader title="daemon">
+    {#if daemon.tracing}
+      <span class="panel-meta"
+        >{daemon.workers.length} worker{daemon.workers.length === 1 ? '' : 's'} &middot; {daemon.opsPerSec}/s</span
+      >
+    {/if}
+  </PanelHeader>
+
+  <div class="daemon-body">
+    {#if !daemon.tracing}
+      <!-- No tracer attached (no daemon, or it needs root). The status string
+           explains why, so the panel never sits blank. -->
+      <div class="daemon-status">{daemon.status || 'waiting for the daemon…'}</div>
+    {:else if rows.length === 0}
+      <div class="daemon-status">attached &middot; idle (no syscalls yet)</div>
+    {:else}
+      <div class="daemon-ops">
+        {#each rows as row (row.label)}
+          <div class="daemon-op" title="{String(row.count)} {row.label}">
+            <span class="daemon-op-label">{row.label}</span>
+            <span class="daemon-op-bar" aria-hidden="true"
+              ><span class="daemon-op-fill" style="--p: {String(pct(row.count))}%"></span></span
+            >
+            <span class="daemon-op-count">{row.count}</span>
+          </div>
+        {/each}
+      </div>
+      {#if daemon.currentPath !== null}
+        <div class="daemon-path" title={daemon.currentPath}>
+          {middleTruncate(daemon.currentPath, 56)}
+        </div>
+      {/if}
+    {/if}
+  </div>
+</section>

--- a/packages/nix-web-monitor/server/site/src/lib/monitor-transport.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/monitor-transport.ts
@@ -38,6 +38,7 @@ type Working = {
   errors: string[];
   progress: MonitorSnapshot['progress'];
   optimise: MonitorSnapshot['optimise'];
+  daemon: MonitorSnapshot['daemon'];
   expected: Record<string, number>;
   dependencies: DerivationEdge[];
   exitCode: number | null;
@@ -53,6 +54,14 @@ function createWorking(): Working {
     errors: [],
     progress: null,
     optimise: { filesLinked: 0, bytesFreed: 0 },
+    daemon: {
+      tracing: false,
+      status: '',
+      workers: [],
+      ops: { link: 0, rename: 0, open: 0, write: 0, fsync: 0, stat: 0, unlink: 0, other: 0 },
+      opsPerSec: 0,
+      currentPath: null
+    },
     expected: {},
     dependencies: [],
     exitCode: null,
@@ -86,6 +95,9 @@ export function applyDelta(working: Working, delta: Delta): Working {
     case 'optimiseSet':
       working.optimise = delta.optimise;
       return working;
+    case 'daemonSet':
+      working.daemon = delta.daemon;
+      return working;
     case 'expectedSet':
       working.expected = { ...working.expected, [delta.name]: delta.value };
       return working;
@@ -112,6 +124,7 @@ function fromSnapshot(snapshot: MonitorSnapshot): Working {
     errors: [...snapshot.errors],
     progress: snapshot.progress,
     optimise: snapshot.optimise,
+    daemon: snapshot.daemon,
     expected: { ...snapshot.expected },
     dependencies: snapshot.dependencies,
     exitCode: snapshot.exitCode,
@@ -148,6 +161,7 @@ export function projectSnapshot(working: Working): MonitorSnapshot {
     errors: [...working.errors],
     progress: working.progress,
     optimise: working.optimise,
+    daemon: working.daemon,
     expected: { ...working.expected },
     dependencies: working.dependencies,
     exitCode: working.exitCode,

--- a/packages/nix-web-monitor/server/site/src/lib/types.ts
+++ b/packages/nix-web-monitor/server/site/src/lib/types.ts
@@ -38,6 +38,33 @@ export const optimiseStatsSchema = v.object({
   bytesFreed: v.number()
 });
 
+/// Filesystem syscalls the nix-daemon made, grouped by class. Mirrors the Rust
+/// `DaemonOps`; the daemon panel renders these as the breakdown of what kind of
+/// work the daemon is doing (link/rename dominate store optimisation,
+/// write/fsync dominate writing a new path).
+export const daemonOpsSchema = v.object({
+  link: v.number(),
+  rename: v.number(),
+  open: v.number(),
+  write: v.number(),
+  fsync: v.number(),
+  stat: v.number(),
+  unlink: v.number(),
+  other: v.number()
+});
+
+/// Live nix-daemon syscall view. `tracing` is false when no tracer is attached
+/// (no daemon, or it needs root), in which case `status` explains why and the
+/// counters are zero. Mirrors the Rust `DaemonInfo`.
+export const daemonInfoSchema = v.object({
+  tracing: v.boolean(),
+  status: v.string(),
+  workers: v.array(v.number()),
+  ops: daemonOpsSchema,
+  opsPerSec: v.number(),
+  currentPath: v.nullable(v.string())
+});
+
 export const activityNodeSchema = v.object({
   id: v.number(),
   parent: v.nullable(v.number()),
@@ -94,6 +121,7 @@ export const snapshotSchema = v.object({
   errors: v.array(v.string()),
   progress: v.nullable(activityProgressSchema),
   optimise: optimiseStatsSchema,
+  daemon: daemonInfoSchema,
   expected: v.record(v.string(), v.number()),
   dependencies: v.array(derivationEdgeSchema),
   exitCode: v.nullable(v.number()),
@@ -111,6 +139,7 @@ export const deltaSchema = v.variant('type', [
   v.object({ type: v.literal('logsAppend'), entries: v.array(logEntrySchema) }),
   v.object({ type: v.literal('progressSet'), progress: activityProgressSchema }),
   v.object({ type: v.literal('optimiseSet'), optimise: optimiseStatsSchema }),
+  v.object({ type: v.literal('daemonSet'), daemon: daemonInfoSchema }),
   v.object({ type: v.literal('expectedSet'), name: v.string(), value: v.number() }),
   v.object({ type: v.literal('errorAppend'), message: v.string() }),
   v.object({ type: v.literal('dependenciesSet'), edges: v.array(derivationEdgeSchema) }),
@@ -122,6 +151,8 @@ export type BuildStatus = v.InferOutput<typeof buildStatusSchema>;
 export type ActivityType = v.InferOutput<typeof activityTypeSchema>;
 export type ActivityProgress = v.InferOutput<typeof activityProgressSchema>;
 export type OptimiseStats = v.InferOutput<typeof optimiseStatsSchema>;
+export type DaemonOps = v.InferOutput<typeof daemonOpsSchema>;
+export type DaemonInfo = v.InferOutput<typeof daemonInfoSchema>;
 export type ActivityNode = v.InferOutput<typeof activityNodeSchema>;
 export type BuildNode = v.InferOutput<typeof buildNodeSchema>;
 export type LogEntry = v.InferOutput<typeof logEntrySchema>;
@@ -151,6 +182,14 @@ export const EMPTY_SNAPSHOT: MonitorSnapshot = Object.freeze({
   errors: [],
   progress: null,
   optimise: { filesLinked: 0, bytesFreed: 0 },
+  daemon: {
+    tracing: false,
+    status: '',
+    workers: [],
+    ops: { link: 0, rename: 0, open: 0, write: 0, fsync: 0, stat: 0, unlink: 0, other: 0 },
+    opsPerSec: 0,
+    currentPath: null
+  },
   expected: {},
   dependencies: [],
   exitCode: null,

--- a/packages/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix-web-monitor/server/site/src/style.css
@@ -498,6 +498,82 @@ main.dragging-v .splitter-v::after {
   font-variant-numeric: tabular-nums;
 }
 
+.side-pane > .daemon-panel {
+  flex: 0 0 auto;
+  max-height: 45%;
+  border-bottom: 1px solid var(--line);
+}
+
+.side-pane > .graph-panel {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* ---------- daemon panel ---------- */
+
+.daemon-body {
+  min-height: 0;
+  overflow: auto;
+  padding: 0.4rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+/* Not-tracing reason / idle note. */
+.daemon-status {
+  color: var(--muted);
+  white-space: normal;
+  line-height: 1.4;
+}
+
+.daemon-ops {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+/* label | proportional bar | count, columns aligned across rows. */
+.daemon-op {
+  display: grid;
+  grid-template-columns: 3.5rem 1fr 3.5rem;
+  align-items: center;
+  gap: 0.4rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.daemon-op-label {
+  color: var(--muted);
+}
+
+.daemon-op-bar {
+  height: 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: var(--panel-soft);
+  overflow: hidden;
+}
+
+.daemon-op-fill {
+  display: block;
+  height: 100%;
+  width: var(--p, 0%);
+  background: linear-gradient(90deg, var(--accent), color-mix(in srgb, var(--accent) 70%, var(--green)));
+}
+
+.daemon-op-count {
+  text-align: right;
+  color: var(--ink);
+}
+
+/* The store path the daemon last touched -- the "currently working on" line. */
+.daemon-path {
+  color: var(--faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* ---------- activity graph ---------- */
 
 .graph,

--- a/packages/nix-web-monitor/server/src/daemon.rs
+++ b/packages/nix-web-monitor/server/src/daemon.rs
@@ -1,0 +1,242 @@
+//! Live `nix-daemon` syscall tracer (best-effort, privileged).
+//!
+//! Attaches a platform tracer to the running `nix-daemon` and folds its
+//! filesystem syscalls into [`DaemonInfo`], which the UI renders as the daemon
+//! panel. This is the one view the internal-json stream cannot give: it stays
+//! quiet inside a single long `addToStore`, so without this a slow "copying to
+//! the store" looks like a hang. Tracing is privileged and platform-specific,
+//! so every failure path degrades to a status string the panel shows rather
+//! than aborting the run.
+//!
+//! * macOS: `fs_usage -w -f filesys nix-daemon` (filters by process name, so it
+//!   follows every daemon worker, including ones forked after we attach).
+//! * Linux: `strace -f -p <pid>` on the daemon master (`-f` follows the per-
+//!   connection workers it forks).
+
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use nix_web_monitor_parser::MonitorState;
+use nix_web_monitor_parser::daemon::{DaemonTrace, parse_fs_usage_line, parse_strace_line};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::{RwLock, broadcast};
+use tokio::time::{MissedTickBehavior, interval};
+
+use crate::broadcast_deltas;
+
+/// How often the daemon view is recomputed and (if changed) broadcast. Exactly
+/// one second so the per-window syscall delta *is* the per-second rate, with no
+/// division (and no lossy int/float casts) to compute it.
+const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Pause before re-discovering the daemon after the tracer exits or no daemon is
+/// found, so a single-user store (no daemon) or a denied tracer does not spin.
+const RETRY_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Run the daemon syscall probe until the task is aborted.
+///
+/// Never returns an error: tracing is a best-effort overlay, so any failure
+/// becomes a status the panel shows and the loop retries.
+pub async fn run_daemon_probe(monitor: Arc<RwLock<MonitorState>>, deltas: broadcast::Sender<Bytes>) {
+    loop {
+        let pids = daemon_pids().await;
+        if pids.is_empty() {
+            publish_status(
+                &monitor,
+                &deltas,
+                "no nix-daemon running -- single-user store, nothing to trace",
+            )
+            .await;
+            tokio::time::sleep(RETRY_INTERVAL).await;
+            continue;
+        }
+
+        match spawn_tracer(&pids).await {
+            Ok(child) => trace_loop(child, pids, &monitor, &deltas).await,
+            Err(reason) => publish_status(&monitor, &deltas, &reason).await,
+        }
+        // The tracer exited (daemon idle/restarted or attach denied). Surface
+        // the idle state and back off before trying to re-attach.
+        tokio::time::sleep(RETRY_INTERVAL).await;
+    }
+}
+
+/// `nix-daemon` pids, newest last. Empty on a single-user store or if `pgrep` is
+/// missing. `pgrep` ships on macOS and Linux, so this needs no extra dependency.
+async fn daemon_pids() -> Vec<u32> {
+    let Ok(output) = Command::new("pgrep").arg("-f").arg("nix-daemon").output().await else {
+        return Vec::new();
+    };
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.trim().parse::<u32>().ok())
+        .collect()
+}
+
+/// Whether the current process is root, so we know whether to wrap the tracer in
+/// `sudo -n`. Shells out to `id -u` to avoid a libc dependency for one number.
+async fn is_root() -> bool {
+    let Ok(output) = Command::new("id").arg("-u").output().await else {
+        return false;
+    };
+    String::from_utf8_lossy(&output.stdout).trim() == "0"
+}
+
+/// Build the tracer command for this platform.
+///
+/// Wrapped in `sudo -n` when not already root: the daemon is root-owned, so
+/// tracing it needs privilege, and `-n` never prompts -- a user without cached
+/// sudo just gets the "needs root" status instead of a hung password prompt.
+async fn tracer_command(pids: &[u32]) -> Command {
+    let root = is_root().await;
+    let (program, args): (&str, Vec<String>) = if cfg!(target_os = "macos") {
+        // Filter fs_usage by process name so it captures every daemon worker.
+        (
+            "fs_usage",
+            vec![
+                "-w".into(),
+                "-f".into(),
+                "filesys".into(),
+                "nix-daemon".into(),
+            ],
+        )
+    } else {
+        // strace -f follows the workers the master forks per connection.
+        let mut args = vec!["-f".into(), "-qq".into(), "-e".into(), "trace=%file,write,fsync,fdatasync".into()];
+        for pid in pids {
+            args.push("-p".into());
+            args.push(pid.to_string());
+        }
+        ("strace", args)
+    };
+
+    let mut command = if root {
+        let mut c = Command::new(program);
+        c.args(args);
+        c
+    } else {
+        let mut c = Command::new("sudo");
+        c.arg("-n").arg(program).args(args);
+        c
+    };
+    command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    command
+}
+
+/// Spawn the tracer, or return a human status explaining why it could not start
+/// (binary missing, or `sudo -n` refused for lack of privilege).
+async fn spawn_tracer(pids: &[u32]) -> Result<Child, String> {
+    let mut command = tracer_command(pids).await;
+    command.spawn().map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            format!(
+                "syscall tracer not found ({}); daemon view unavailable",
+                if cfg!(target_os = "macos") { "fs_usage" } else { "strace" }
+            )
+        } else {
+            format!("could not start daemon tracer: {error}")
+        }
+    })
+}
+
+/// Read the tracer's output, folding syscalls into a [`DaemonTrace`] and
+/// publishing a [`DaemonInfo`] every [`SAMPLE_INTERVAL`]. Returns when the
+/// tracer exits.
+async fn trace_loop(
+    mut child: Child,
+    pids: Vec<u32>,
+    monitor: &Arc<RwLock<MonitorState>>,
+    deltas: &broadcast::Sender<Bytes>,
+) {
+    let Some(stdout) = child.stdout.take() else {
+        return;
+    };
+    // The first stderr line is the most useful failure explanation (e.g.
+    // fs_usage's "requires root"); capture it so a denied attach shows a reason.
+    let stderr = child.stderr.take();
+    let mut lines = BufReader::new(stdout).lines();
+
+    let mut trace = DaemonTrace { workers: pids, ..DaemonTrace::default() };
+    // Counts at the previous tick; the difference over the ~1s window is the
+    // per-second rate the panel shows.
+    let mut last_total: u64 = 0;
+    let mut saw_any = false;
+
+    let mut ticker = interval(SAMPLE_INTERVAL);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            line = lines.next_line() => match line {
+                Ok(Some(line)) => {
+                    saw_any = true;
+                    if let Some(event) = parse_tracer_line(&line) {
+                        trace.record(event);
+                    }
+                }
+                // Stream ended or errored: the tracer is gone.
+                Ok(None) | Err(_) => break,
+            },
+            _ = ticker.tick() => {
+                let total = trace.ops.total();
+                let ops_per_sec = total.saturating_sub(last_total);
+                last_total = total;
+                let worker_count = trace.workers.len();
+                let status = format!("tracing nix-daemon ({worker_count} workers)");
+                let info = trace.info(true, status, ops_per_sec);
+                monitor.write().await.set_daemon(info);
+                let _ = broadcast_deltas(monitor, deltas).await;
+            }
+        }
+    }
+
+    // The tracer produced nothing and exited: almost always a denied attach.
+    if !saw_any {
+        let reason = denied_reason(stderr, is_root().await).await;
+        publish_status(monitor, deltas, &reason).await;
+    }
+}
+
+/// Parse one tracer line with the parser for this platform.
+fn parse_tracer_line(line: &str) -> Option<nix_web_monitor_parser::daemon::SyscallEvent> {
+    if cfg!(target_os = "macos") {
+        parse_fs_usage_line(line)
+    } else {
+        parse_strace_line(line)
+    }
+}
+
+/// Best explanation for a tracer that started but produced nothing: prefer its
+/// own stderr, else a privilege hint.
+async fn denied_reason(stderr: Option<tokio::process::ChildStderr>, root: bool) -> String {
+    if let Some(stderr) = stderr
+        && let Ok(Some(first)) = BufReader::new(stderr).lines().next_line().await
+        && !first.trim().is_empty()
+    {
+        return format!("daemon tracer: {}", first.trim());
+    }
+    if root {
+        "daemon tracer attached but reported no syscalls".to_owned()
+    } else {
+        "nix-daemon syscall tracing needs root -- run `sudo -v`, then restart, \
+         or run nwm under sudo"
+            .to_owned()
+    }
+}
+
+/// Publish a not-tracing [`DaemonInfo`] carrying only a status line.
+async fn publish_status(
+    monitor: &Arc<RwLock<MonitorState>>,
+    deltas: &broadcast::Sender<Bytes>,
+    status: &str,
+) {
+    let info = DaemonTrace::default().info(false, status.to_owned(), 0);
+    monitor.write().await.set_daemon(info);
+    let _ = broadcast_deltas(monitor, deltas).await;
+}

--- a/packages/nix-web-monitor/server/src/main.rs
+++ b/packages/nix-web-monitor/server/src/main.rs
@@ -25,7 +25,9 @@ use tokio::sync::{RwLock, broadcast, mpsc};
 use tokio::time::timeout;
 use tower_http::services::ServeDir;
 
+mod daemon;
 mod dependencies;
+use daemon::run_daemon_probe;
 use dependencies::resolve_dependencies;
 
 /// Bound on the delta broadcast ring. A client that falls this far behind gets
@@ -130,6 +132,11 @@ async fn main() -> Result<()> {
 
     eprintln!("nix-web-monitor: http://{http_addr}");
 
+    // Trace the nix-daemon's syscalls for the daemon panel. Independent of the
+    // build task: it keeps reporting (or explaining why it cannot) for the whole
+    // life of the UI. Best-effort, so its handle is just aborted at shutdown.
+    let daemon_probe = tokio::spawn(run_daemon_probe(Arc::clone(&monitor), deltas.clone()));
+
     let build = tokio::spawn(run_nix_command(
         args.nix_args,
         args.terminal_output,
@@ -149,6 +156,7 @@ async fn main() -> Result<()> {
             .await
             .context("waiting for Ctrl-C")?;
     }
+    daemon_probe.abort();
     http_server.abort();
     // Propagate Nix's exit status either way; otherwise the wrapper masks
     // build failures from shells and CI.
@@ -480,6 +488,13 @@ async fn measure_copy_size(
     monitor: Arc<RwLock<MonitorState>>,
     deltas: broadcast::Sender<Bytes>,
 ) -> Result<()> {
+    // A copy whose source is not on the local filesystem is nothing to measure.
+    // `copy_to_store_source` already rejects Nix's virtual `«…»` accessor paths,
+    // but an absolute path can still be a transient that has gone away by the
+    // time this runs; skip it silently rather than logging a walk error.
+    if !tokio::fs::try_exists(&source).await.unwrap_or(false) {
+        return Ok(());
+    }
     let size = match tokio::task::spawn_blocking(move || copied_size(&source)).await {
         Ok(Ok(size)) => size,
         Ok(Err(error)) => {
@@ -515,7 +530,10 @@ fn copied_size(source: &Path) -> Result<i64> {
         .filter_entry(|entry| entry.file_name() != ".git")
         .build();
     for entry in walker {
-        let entry = entry.context("walking copy source")?;
+        // Skip an entry that vanished or is unreadable mid-walk rather than
+        // aborting the whole measurement; the figure is an approximate hint, so
+        // a few missing files just make it a slight undercount.
+        let Ok(entry) = entry else { continue };
         if entry.file_type().is_some_and(|file_type| file_type.is_file())
             && let Ok(metadata) = entry.metadata()
         {


### PR DESCRIPTION
## What

1. **Daemon panel** — answers "where does nwm show the daemon?" (previously: nowhere). The internal-json stream goes quiet inside a single long `addToStore` (writing a path, or hard-linking every file with `auto-optimise-store`), which is exactly when a build looks hung. A best-effort tracer attaches to the running `nix-daemon` — `fs_usage` on macOS, `strace -f` on Linux — and folds its filesystem syscalls into a small `DaemonInfo` (per-class counts: link/rename/write/fsync/…, ops·sec, current store path), rendered as a **daemon** panel in the sidebar. Privileged: when it can't attach (no daemon / needs root) the panel shows a status string explaining why, and nothing breaks.

2. **Fix the `measuring copy source failed: … No such file or directory` spam** you hit on `nix build .#minecraft`. Nix copies individual files out of fetched flake inputs and prints them with its virtual accessor notation (`copying '«github:NixOS/nixpkgs#…»/pkgs/…/foo.patch' to the store`). That `«…»` path has no on-disk location, so the size measurer logged one ENOENT per patch. `copy_to_store_source` now returns only absolute local paths; the server also skips a missing source and no longer aborts the walk on a vanished entry.

## Design

- Pure, testable pieces — the `fs_usage`/`strace` line parsers (→ syscall class + path) and the rolling aggregator — live in the **parser crate** (`daemon.rs`) and are unit-tested. Spawning the privileged tracer lives in the **server** (`daemon.rs`), runs for the life of the UI, and degrades to a status string on any failure. New wire: `DaemonInfo` snapshot field + `DaemonSet` delta (dedup'd so an idle daemon puts nothing on the wire).
- Not a per-syscall *attribution* to builds (the protocol can't do that) and not eBPF; it's the portable tracer view, which is what reveals a silent store step.

## Test

- `cargo test` — parser 43 (6 new daemon parser/aggregator tests + a copy-source reject for `«…»`), server 5.
- `svelte-check` 0 errors, `eslint` clean, `vite build` clean.
- Local stock clippy can't run through the workspace's fork-lint deps; relying on CI's `rust-nix-web-monitor*.clippy`.

Note: `flake-check` is red on `main` from 3 pre-existing, unrelated attrs (`rust-git-log-pretty.clippy`, `rust-mcp.browserVdomSmoke`, `sdk-rust-prebuilt`).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add live nix-daemon syscall view to nix-web-monitor and fix copy-source path spam
> - Adds a background `run_daemon_probe` task in [server/src/daemon.rs](https://github.com/indexable-inc/index/pull/932/files#diff-112db9c84625afc382100ab8e385d35dbeb69aa5dc79dc43988a57320f4dd581) that continuously attaches `strace` (Linux) or `fs_usage` (macOS) to nix-daemon processes, aggregating syscall counts by class (link, rename, open, write, fsync, etc.) and publishing `DaemonSet` deltas once per second.
> - Adds parser support in [parser/src/daemon.rs](https://github.com/indexable-inc/index/pull/932/files#diff-3e405387b26db820790568d0295ec6ef164a55ac65e50d1f0eca765f5fd2986a) for both `strace` and `fs_usage` output, normalizing syscall names and extracting the most relevant `/nix/store` path from each traced line.
> - Adds a [DaemonPanel.svelte](https://github.com/indexable-inc/index/pull/932/files#diff-cf9887c19ef0a9404df4db0acc10a7207649e3cc70fd109e6d07d10071a56bdf) UI component that shows tracing status, a proportional bar breakdown of op classes, ops/sec, and the most recently accessed path.
> - Fixes `copy_to_store_source` to reject non-absolute (virtual/flake-accessor) paths, preventing ENOENT spam from `measure_copy_size`; also adds a pre-flight `try_exists` check and skips unreadable directory entries.
> - Risk: tracing requires `sudo -n` when not root; if permission is denied, the panel shows an explanatory status rather than silently failing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae04518.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->