### PR TITLE
ci(check): replay failed build logs so clippy/test diagnostics are visible

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -223,9 +223,13 @@ let
               # the diagnostic (clippy lint / test output). nix does not cache
               # failures, so this just re-attempts that single check.
               try {
-                ^nix build $inst "-L" "--no-link"
+                ^nix build ...[
+                  $inst
+                  "-L"
+                  "--no-link"
                   "--option" "accept-flake-config" "true"
                   "--option" "extra-experimental-features" "ca-derivations"
+                ]
               } catch { }
             }
             print --stderr "::endgroup::"

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -159,18 +159,67 @@ let
         # cwd. blast-radius consumes this on a later PR via `--timings` to
         # annotate the rebuilt-checks list with wall-clock seconds. The path is
         # relative to the runner cwd; check.yml uploads it as an artifact.
-        ^nix run $fast_build -- ...[
-          "--flake" ".#ciChecks.x86_64-linux"
-          "--eval-max-memory-size" "6144"
-          "--eval-workers" "16"
-          "--skip-cached"
-          "--no-nom"
-          "--no-link"
-          "--result-format" "json"
-          "--result-file" "check-results.json"
-          "--option" "accept-flake-config" "true"
-          "--option" "extra-experimental-features" "ca-derivations"
-        ]
+        # nix-fast-build prints "Cannot build <drv>" for a failed check but not the
+        # build's own output, so a clippy lint or a test panic surfaces only as a
+        # bare "build exited with 1" with no diagnostic to act on. Catch the
+        # failure, then replay each failed build's log via `nix log` so the actual
+        # clippy/test output lands in the CI log. The failed attrs are read from
+        # the --result-file this just wrote (one {attr,type,success,...} record
+        # per attr per phase); it is written even on failure.
+        # `try` returns false on success and the `catch` returns true, so the
+        # failure is carried in an immutable binding (nushell forbids mutating an
+        # outer `mut` from inside the catch closure).
+        let build_failed = (
+          try {
+            ^nix run $fast_build -- ...[
+              "--flake" ".#ciChecks.x86_64-linux"
+              "--eval-max-memory-size" "6144"
+              "--eval-workers" "16"
+              "--skip-cached"
+              "--no-nom"
+              "--no-link"
+              "--result-format" "json"
+              "--result-file" "check-results.json"
+              "--option" "accept-flake-config" "true"
+              "--option" "extra-experimental-features" "ca-derivations"
+            ]
+            false
+          } catch {
+            true
+          }
+        )
+
+        if ("check-results.json" | path exists) {
+          let failed = (
+            open check-results.json
+            | get results
+            | where type == "BUILD" and success == false
+          )
+          for f in $failed {
+            # GitHub Actions log group so a long clippy dump stays collapsible;
+            # harmless plain text in a local `nix run .#check`.
+            print --stderr $"::group::build log: ($f.attr)"
+            let drv = (
+              ^nix eval --raw
+                --option accept-flake-config true
+                --option extra-experimental-features ca-derivations
+                $".#ciChecks.x86_64-linux.($f.attr).drvPath"
+              | complete
+            )
+            if $drv.exit_code == 0 and (($drv.stdout | str trim) | is-not-empty) {
+              # `nix log` replays the build output nix-fast-build swallowed,
+              # including the clippy diagnostic that explains the failure.
+              ^nix log ($drv.stdout | str trim) | print --stderr
+            } else {
+              print --stderr $"  could not resolve a drvPath for ($f.attr); error was: ($f.error)"
+            }
+            print --stderr "::endgroup::"
+          }
+        }
+
+        if $build_failed {
+          exit 1
+        }
 
         let tmp = (mktemp --directory --tmpdir "ix-check.XXXXXX")
         let report = ($tmp | path join "flake-schema-eval.jsonl")

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -199,19 +199,34 @@ let
             # GitHub Actions log group so a long clippy dump stays collapsible;
             # harmless plain text in a local `nix run .#check`.
             print --stderr $"::group::build log: ($f.attr)"
+            let inst = $".#ciChecks.x86_64-linux.($f.attr)"
+            # Fast path: replay the retained build log via `nix log` (works for
+            # input-addressed checks like the browser smoke test).
             let drv = (
               ^nix eval --raw
                 --option accept-flake-config true
                 --option extra-experimental-features ca-derivations
-                $".#ciChecks.x86_64-linux.($f.attr).drvPath"
+                $"($inst).drvPath"
               | complete
             )
-            if $drv.exit_code == 0 and (($drv.stdout | str trim) | is-not-empty) {
-              # `nix log` replays the build output nix-fast-build swallowed,
-              # including the clippy diagnostic that explains the failure.
-              ^nix log ($drv.stdout | str trim) | print --stderr
+            let logged = if $drv.exit_code == 0 and (($drv.stdout | str trim) | is-not-empty) {
+              ^nix log ($drv.stdout | str trim) | complete
             } else {
-              print --stderr $"  could not resolve a drvPath for ($f.attr); error was: ($f.error)"
+              { exit_code: 1, stdout: "" }
+            }
+            if $logged.exit_code == 0 and (($logged.stdout | str trim) | is-not-empty) {
+              print --stderr $logged.stdout
+            } else {
+              # A content-addressed build (the rust units default to CA) keeps
+              # its log under the *resolved* drv, which `nix log` cannot fetch by
+              # the original -- so re-run the one failed check with -L to stream
+              # the diagnostic (clippy lint / test output). nix does not cache
+              # failures, so this just re-attempts that single check.
+              try {
+                ^nix build $inst "-L" "--no-link"
+                  "--option" "accept-flake-config" "true"
+                  "--option" "extra-experimental-features" "ca-derivations"
+              } catch { }
             }
             print --stderr "::endgroup::"
           }


### PR DESCRIPTION
## Why

When a flake check fails, `nix-fast-build` prints `Cannot build <drv>` / `build exited with 1` but **not the build's own output**, so a clippy lint or a test panic shows up in CI with no diagnostic to act on. (Landing #932 took several blind CI rounds because the failing clippy lint was only visible by reproducing the fork clippy locally.)

## What

The `check` app (`lib/per-system.nix`, run by `flake-check`) now:
1. catches the `nix-fast-build` failure instead of aborting,
2. reads the failed `BUILD` attrs from the `--result-file` it already writes (`check-results.json`),
3. resolves each attr's `drvPath` and replays `nix log` for it under a collapsible GitHub Actions group,
4. re-exits nonzero, so the gate semantics are unchanged.

Net effect: the actual clippy/test output lands in the `flake-check` log next to the "failed attributes" line.

## Test

- Logic verified locally with `nu` against a real failed-run `check-results.json` (parses the 3 failed builds, replays each log under `::group::`, exits 1).
- `nix build .#check` passes (the `writeNushellApplication` parse check validates the nushell, incl. the `try {…; false} catch { true }` immutable-failure pattern nushell requires).
- Full execution is CI-only (targets `x86_64-linux`); behavior on a green run is unchanged (no failed BUILD records → no extra output).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replay failed build logs in CI checks so clippy/test diagnostics are visible
> - Wraps the `nix-fast-build` invocation in [per-system.nix](https://github.com/indexable-inc/index/pull/935/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) with a try/catch that records build failure, then post-processes `check-results.json` to find failed BUILD phases.
> - For each failed attribute, prints a GitHub Actions log group header, then fetches the build log via `nix log`; if that fails (e.g. CA derivations), re-runs the check with `nix build -L --no-link` to stream diagnostics to stderr.
> - Exits non-zero if the original build failed; successful builds are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fb0fcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->