### PR TITLE
fix(mcp): bound model-facing images by bytes, not just dimension

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1078,6 +1078,28 @@ let
     _w, _h = _Image.open(_io.BytesIO(_b64.b64decode(_coerced["data"]))).size
     assert max(_w, _h) <= runtime._IMAGE_MAX_DIM, (_w, _h, runtime._IMAGE_MAX_DIM)
 
+    # The dimension cap alone does not bound bytes: a busy 1280px screenshot stays
+    # megabytes as PNG. So _fit_image_bytes also enforces _IMAGE_MAX_BYTES, falling
+    # back to JPEG (and further downscales) -- a high-entropy image comes back well
+    # under the byte cap instead of flooding the model's reply with base64.
+    import os as _osr
+
+    _noisy = _Image.frombytes("RGB", (3000, 1500), _osr.urandom(3000 * 1500 * 3))
+    _nbuf = _io.BytesIO()
+    _noisy.save(_nbuf, format="PNG")
+    assert len(_nbuf.getvalue()) > runtime._IMAGE_MAX_BYTES, len(_nbuf.getvalue())
+    _fit = runtime._coerce_image(_nbuf.getvalue())
+    _raw = _b64.b64decode(_fit["data"])
+    assert len(_raw) <= runtime._IMAGE_MAX_BYTES, ("over byte cap", len(_raw))
+    _fw, _fh = _Image.open(_io.BytesIO(_raw)).size
+    assert max(_fw, _fh) <= runtime._IMAGE_MAX_DIM, (_fw, _fh)
+    # A small lossless image fits both caps and is kept byte-for-byte (a crisp PNG
+    # for UI/diagrams is never needlessly re-encoded).
+    _sbuf = _io.BytesIO()
+    _Image.new("RGB", (200, 100), (10, 20, 30)).save(_sbuf, format="PNG")
+    _small = _sbuf.getvalue()
+    assert _b64.b64decode(runtime._coerce_image(_small)["data"]) == _small
+
     # outputs.text() renders an over-cap block as a head+tail preview (not a
     # one-sided clip) with paging guidance, and honours IX_MCP_MAX_RESULT_CHARS.
     import importlib as _il
@@ -1092,6 +1114,21 @@ let
     assert "output too large" in _blk and len(_blk) < 2000, len(_blk)
     _os.environ.pop("IX_MCP_MAX_RESULT_CHARS", None)
     _il.reload(_outputs)
+
+    # outputs._image is the final byte net for every image reaching the model: a
+    # small image becomes a real image block, but an oversize blob (e.g. a raw
+    # display(fig) bundle that never went through the kernel's fitter) is dropped
+    # with a short note rather than dumped as megabytes of base64.
+    _ok = _outputs._image("image/png", _b64.b64encode(_small).decode("ascii"))
+    assert _ok.type == "image", _ok
+    _over = _b64.b64encode(b"x" * (_outputs.MAX_IMAGE_BYTES + 5000)).decode("ascii")
+    _dropped = _outputs._image("image/png", _over)
+    assert _dropped.type == "text" and "dropped" in _dropped.text, _dropped
+    assert len(_dropped.text) < 400, len(_dropped.text)
+    # End to end: an oversize image in a display bundle yields no giant text block.
+    _rendered = _outputs.to_mcp([{"output_type": "display_data", "data": {"image/png": _over}}])
+    assert all(_c.type == "text" for _c in _rendered), [_c.type for _c in _rendered]
+    assert max(len(_c.text) for _c in _rendered) < 400, [len(_c.text) for _c in _rendered]
 
     # view.tree lists but does not descend into heavy dirs (node_modules, ...)
     # unless all=True, so a project's structure is not buried under vendored files.

--- a/packages/mcp/ix_notebook_mcp/outputs.py
+++ b/packages/mcp/ix_notebook_mcp/outputs.py
@@ -27,6 +27,18 @@ try:
 except ValueError:
     MAX_TEXT_CHARS = 50_000
 _MAX_IMAGES = 8
+
+# Hard byte cap (decoded) on a single image block to the model. The kernel
+# already fits Result images to this budget (IX_MCP_IMAGE_MAX_BYTES, see
+# runtime._fit_image_bytes), so this is the final net catching any image that
+# reaches the model UNfitted -- a raw ``display(fig)`` bundle that never went
+# through a Result -- which is dropped with a short note here instead of dumped as
+# megabytes of base64 (which floods the reply or is rejected by the host). Set
+# ``IX_MCP_IMAGE_MAX_BYTES=0`` to disable.
+try:
+    MAX_IMAGE_BYTES = max(0, int(os.environ.get("IX_MCP_IMAGE_MAX_BYTES", "1000000")))
+except ValueError:
+    MAX_IMAGE_BYTES = 1_000_000
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
 _OUTPUT_TYPES = frozenset({"stream", "execute_result", "display_data", "error"})
@@ -116,6 +128,22 @@ def text(value: Any) -> mcp_types.TextContent:
     return mcp_types.TextContent(type="text", text=rendered)
 
 
-def _image(mime: str, data: Any) -> mcp_types.ImageContent:
-    encoded = data if isinstance(data, str) else base64.b64encode(bytes(data)).decode("ascii")
-    return mcp_types.ImageContent(type="image", data=encoded.strip(), mimeType=mime)
+def _image(mime: str, data: Any) -> Content:
+    """One image as an MCP image block -- unless its decoded size exceeds
+    ``MAX_IMAGE_BYTES``, in which case it is dropped with a short text note rather
+    than flooding the reply with base64. ``data`` is base64 text or raw bytes."""
+    if isinstance(data, str):
+        try:
+            raw = base64.b64decode(data, validate=True)
+        except (ValueError, base64.binascii.Error):
+            raw = None  # not decodable; pass the string through untouched below
+    else:
+        raw = bytes(data)
+    if raw is not None and MAX_IMAGE_BYTES and len(raw) > MAX_IMAGE_BYTES:
+        return text(
+            f"[{mime} image dropped: {len(raw)} bytes exceeds the "
+            f"{MAX_IMAGE_BYTES}-byte cap. Return it via Result(llm_images=[...]) -- "
+            f"the kernel shrinks those to fit -- or raise IX_MCP_IMAGE_MAX_BYTES.]"
+        )
+    encoded = data.strip() if isinstance(data, str) else base64.b64encode(raw).decode("ascii")
+    return mcp_types.ImageContent(type="image", data=encoded, mimeType=mime)

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -63,6 +63,19 @@ try:
 except ValueError:
     _IMAGE_MAX_DIM = 1280
 
+# Max encoded size (bytes) of a single image returned to the model. The dimension
+# cap alone does not bound bytes: a busy 1280px screenshot re-encoded as PNG can
+# still be several megabytes, which floods the reply (and the model's context) and
+# can exceed the host's per-image limit, so the host falls back to dumping the
+# base64 as text. After the dimension cap an oversize image is therefore
+# re-encoded as JPEG at descending quality -- and, if still over, downscaled
+# further -- until it fits. Set ``IX_MCP_IMAGE_MAX_BYTES=0`` to disable the byte
+# cap (the dimension cap still applies).
+try:
+    _IMAGE_MAX_BYTES = int(os.environ.get("IX_MCP_IMAGE_MAX_BYTES", "1000000"))
+except ValueError:
+    _IMAGE_MAX_BYTES = 1_000_000
+
 # The custom mime the kernel hands the server to carry a job summary (mirrors
 # outputs.JOB_MIME; duplicated so the kernel-side runtime stays import-light).
 JOB_MIME = "application/x-ix-job+json"
@@ -1167,37 +1180,91 @@ def _df_llm_text(df) -> str:
         return _safe_repr(df)
 
 
+def _png_bytes(img) -> bytes:
+    """Encode a Pillow image as an optimized PNG (lossless)."""
+    import io
+
+    if img.mode not in ("RGB", "RGBA", "L"):
+        img = img.convert("RGBA")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()
+
+
+def _jpeg_bytes(img, quality: int) -> bytes:
+    """Encode a Pillow image as JPEG at ``quality``, flattening any alpha onto a
+    white background (JPEG has no alpha) so transparency does not turn black."""
+    import io
+
+    from PIL import Image
+
+    if img.mode != "RGB":
+        rgba = img.convert("RGBA")
+        flat = Image.new("RGB", rgba.size, (255, 255, 255))
+        flat.paste(rgba, mask=rgba.split()[-1])
+        img = flat
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=quality, optimize=True)
+    return buf.getvalue()
+
+
 def _fit_image_bytes(raw: bytes, mime: str) -> tuple[bytes, str]:
-    """Downscale raster image bytes so the longest edge is at most
-    ``_IMAGE_MAX_DIM`` (aspect preserved), re-encoding as PNG. Returns the bytes
-    unchanged when the cap is disabled, Pillow is unavailable, or the image is
-    already small enough. Never raises: on any failure the original bytes/mime are
-    returned, so downscaling can only ever shrink the reply, never break it."""
-    if _IMAGE_MAX_DIM <= 0:
+    """Bound a raster image for the model. First downscale so its longest edge is
+    at most ``_IMAGE_MAX_DIM`` (aspect preserved); then ensure the encoding is at
+    most ``_IMAGE_MAX_BYTES`` -- preferring a lossless PNG, falling back to JPEG
+    at descending quality and, if still over, repeated downscales -- so a detailed
+    screenshot can never flood the reply with megabytes of base64. Returns the
+    bytes unchanged when both caps are disabled, Pillow is unavailable, or the
+    image already fits untouched (a crisp PNG is kept for small UI/diagrams).
+    Never raises: on any failure the original bytes/mime are returned, so fitting
+    can only ever shrink the reply, never break it."""
+    if _IMAGE_MAX_DIM <= 0 and _IMAGE_MAX_BYTES <= 0:
         return raw, mime
     try:
         import io
 
         from PIL import Image
 
-        with Image.open(io.BytesIO(raw)) as img:
-            width, height = img.size
-            longest = max(width, height)
-            if longest <= _IMAGE_MAX_DIM:
-                return raw, mime
+        img = Image.open(io.BytesIO(raw))
+        img.load()
+        width, height = img.size
+        longest = max(width, height)
+        resized = False
+        if _IMAGE_MAX_DIM > 0 and longest > _IMAGE_MAX_DIM:
             scale = _IMAGE_MAX_DIM / longest
-            resized = img.resize((max(1, round(width * scale)), max(1, round(height * scale))))
-            if resized.mode not in ("RGB", "RGBA", "L"):
-                resized = resized.convert("RGBA")
-            buf = io.BytesIO()
-            resized.save(buf, format="PNG", optimize=True)
-            return buf.getvalue(), "image/png"
+            img = img.resize((max(1, round(width * scale)), max(1, round(height * scale))))
+            resized = True
+        # Untouched and already under the byte cap: keep the original bytes -- a
+        # crisp lossless PNG is worth more than a needless re-encode.
+        within_bytes = _IMAGE_MAX_BYTES <= 0 or len(raw) <= _IMAGE_MAX_BYTES
+        if not resized and within_bytes:
+            return raw, mime
+        # Prefer a lossless PNG if it fits the byte cap.
+        png = _png_bytes(img)
+        if _IMAGE_MAX_BYTES <= 0 or len(png) <= _IMAGE_MAX_BYTES:
+            return png, "image/png"
+        # PNG is too big (a photographic / busy screenshot): switch to JPEG and
+        # walk quality, then dimensions, down until it fits the byte cap.
+        for quality in (85, 70, 55, 40, 25):
+            jpg = _jpeg_bytes(img, quality)
+            if len(jpg) <= _IMAGE_MAX_BYTES:
+                return jpg, "image/jpeg"
+        for _ in range(8):
+            w, h = img.size
+            if w <= 16 or h <= 16:
+                break
+            img = img.resize((max(1, w * 3 // 4), max(1, h * 3 // 4)))
+            jpg = _jpeg_bytes(img, 40)
+            if len(jpg) <= _IMAGE_MAX_BYTES:
+                return jpg, "image/jpeg"
+        return jpg, "image/jpeg"  # best effort: the smallest we could produce
     except Exception:
         return raw, mime
 
 
 def _encode_image_bytes(raw: bytes, mime: str) -> dict:
-    """One image as a downscaled ``{"mime", "data"}`` base64 dict."""
+    """One image as a size-bounded ``{"mime", "data"}`` base64 dict (see
+    :func:`_fit_image_bytes`)."""
     raw, mime = _fit_image_bytes(raw, mime)
     return {"mime": mime, "data": base64.b64encode(raw).decode("ascii")}
 
@@ -1231,7 +1298,8 @@ def _coerce_image(value) -> dict | None:
     (base64), or None if it is not an image we can encode. Accepts raw PNG/JPEG
     bytes, a base64 / data-URI string, a path to an image file, a matplotlib
     Figure, or any object with ``_repr_png_`` / ``_repr_jpeg_`` (a PIL image, a
-    plot). Every path runs through the downscaler (see ``_IMAGE_MAX_DIM``)."""
+    plot). Every path runs through :func:`_fit_image_bytes` (dimension and byte
+    caps)."""
     if value is None:
         return None
     # Raw bytes: sniff PNG vs JPEG by magic, default to PNG.


### PR DESCRIPTION
## Problem

Returning an image from a `python_exec` cell could flood the model's context with a wall of base64 (`iVBORw0KGgo…`) and trip the host's output-truncation. The image pipeline downscaled by **dimension** (longest edge ≤ `_IMAGE_MAX_DIM`, 1280px) but never bounded the resulting **bytes**. A busy/photographic screenshot re-encoded as PNG at 1280px is still several megabytes — large enough that the host falls back to dumping the base64 as text instead of rendering an image block. A raw `display(fig)` bundle reached the model entirely unfitted.

## Fix

One concept — *every image reaching the model is size-bounded* — with one fitter and one safety net:

- **`runtime._fit_image_bytes`** (the single raster fitter, used by `Result.llm_images` and the dashboard store) now enforces `_IMAGE_MAX_BYTES` (env `IX_MCP_IMAGE_MAX_BYTES`, default 1 MB) *after* the dimension cap: it keeps a crisp lossless PNG when it already fits, otherwise falls back to JPEG at descending quality and, if still over, repeated downscales — so a detailed screenshot can never flood the reply.
- **`outputs._image`** is the final byte net at the one chokepoint where bytes become an MCP image block: an oversize image (e.g. a raw `display(fig)` bundle that never went through the kernel's fitter) is dropped with a short text note rather than dumped as megabytes of base64.

A 3000×1500 noise PNG (13.5 MB) now comes back as a 1280px JPEG ~360 KB; small UI/diagram PNGs pass through byte-for-byte.

## Tests

Added to `runtimeTestPy`/`default.nix`: the byte cap shrinks a high-entropy image under `_IMAGE_MAX_BYTES` while keeping it ≤ `_IMAGE_MAX_DIM`; a small lossless PNG is kept untouched; `outputs._image` returns a real image block for a small image but a short note for an oversize blob; and `to_mcp` over an oversize display bundle yields no giant text block.

Closes the image-flood gap from #357.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound MCP model-facing images by decoded byte size in addition to dimensions
> - Adds `_IMAGE_MAX_BYTES` (default 1 MB, configurable via `IX_MCP_IMAGE_MAX_BYTES`) to both [runtime.py](https://github.com/indexable-inc/index/pull/942/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) and [outputs.py](https://github.com/indexable-inc/index/pull/942/files#diff-c0531af2f36a91cd56ac9ae4f0be9a0cbb88094a80355387d1b13e95e1568eb9) as a hard per-image decoded byte cap.
> - `_fit_image_bytes` in `runtime.py` now enforces both caps: first resizes to `_IMAGE_MAX_DIM` if needed, then tries optimized PNG, then iterates through descending JPEG quality levels (85→25), then repeated 3/4 downscales at quality 40 (up to 8 iterations).
> - `outputs._image` now returns a short `TextContent` note instead of an `ImageContent` block when the decoded image exceeds `MAX_IMAGE_BYTES`, advising users to use `Result` or raise the cap.
> - Behavioral Change: images that previously passed dimension checks may now be dropped or re-encoded to JPEG if their byte size exceeds 1 MB; oversized images in `display_data` output are replaced with text rather than forwarded to the model.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0957eb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->