### PR TITLE
refactor(symphony): make skills model-agnostic, envelope lives on the node

### DIFF
--- a/packages/symphony/docs/setup.md
+++ b/packages/symphony/docs/setup.md
@@ -102,8 +102,8 @@ report <- agent {
 ```
 
 A Claude model means `claude-*` or the `opus` / `sonnet` / `haiku` aliases.
-Claude turns are billed against `ANTHROPIC_API_KEY`. The codex-only `sandbox`
-/ `approval_policy` skill fields do not apply to Claude turns.
+Claude turns are billed against `ANTHROPIC_API_KEY`. Engine, model, effort, and
+permissions are node fields on the `.sym` agent node, not skill frontmatter.
 
 ## Production deployment (NixOS)
 

--- a/packages/symphony/elixir/lib/symphony_elixir/claude/code.ex
+++ b/packages/symphony/elixir/lib/symphony_elixir/claude/code.ex
@@ -1,9 +1,9 @@
 defmodule SymphonyElixir.Claude.Code do
   @moduledoc """
   Runs one workflow node as a headless Claude Code session in the run's
-  workspace, used when a skill's `codex_model` names a Claude model
-  (`claude-*`, or the `opus` / `sonnet` / `haiku` aliases); every other
-  model goes to Codex.
+  workspace, used when a node's model is a Claude model (`claude-*`, or
+  the `opus` / `sonnet` / `haiku` aliases); every other model goes to
+  Codex.
 
   This is the in-process Claude runner the YAML/DAG `NodeExecutor` used.
   The `.sym`/IR engine path runs Claude turns through the room-server's
@@ -26,7 +26,7 @@ defmodule SymphonyElixir.Claude.Code do
     there is no per-tool gate the way codex has `approval_policy`.
   - `--output-format json` emits one result object on stdout whose
     `result`, `session_id`, and `is_error` fields we surface.
-  - `--model` is the skill's `codex_model` value, passed through verbatim.
+  - `--model` is the node's model value, passed through verbatim.
 
   The agent uses Claude Code's own tools (Bash, Edit, Read, ...) plus
   whatever CLIs are on PATH inside the workspace (`git`, `gh`). The

--- a/packages/symphony/elixir/lib/symphony_elixir/config.ex
+++ b/packages/symphony/elixir/lib/symphony_elixir/config.ex
@@ -82,7 +82,7 @@ defmodule SymphonyElixir.Config do
                               "none" leaves the run to fail against the
                               missing placement with no fallback.
 
-  Claude models (any skill whose codex_model names a Claude model, e.g.
+  Claude models (any node whose model is a Claude model, e.g.
   claude-opus-4-8, runs through Claude Code instead of codex):
 
       ANTHROPIC_API_KEY       Anthropic API key billed for Claude Code turns.

--- a/packages/symphony/elixir/lib/symphony_elixir/skill.ex
+++ b/packages/symphony/elixir/lib/symphony_elixir/skill.ex
@@ -1,16 +1,14 @@
 defmodule SymphonyElixir.Skill do
   @moduledoc """
-  A skill is a markdown file under `skills/` whose YAML frontmatter declares
-  the codex runtime envelope (model, reasoning effort, sandbox, approval
-  policy, tools) and whose body is the system prompt for that node type.
+  A skill is a markdown file under `skills/` whose body is the system
+  prompt for a workflow node. Its YAML frontmatter is the model-agnostic
+  Agent Skills shape: an optional one-line `description` and an optional
+  `tools` allowlist. The skill carries no model or engine.
 
   Example `skills/implement.md`:
 
       ---
-      codex_model: gpt-5-codex
-      reasoning_effort: medium
-      sandbox: workspace-write
-      approval_policy: never
+      description: Land the Linear ticket in $INPUT and open a PR.
       tools: [linear_graphql]
       ---
 
@@ -19,6 +17,14 @@ defmodule SymphonyElixir.Skill do
       exit.
 
   The body is the lever for improving the agent without code changes.
+
+  ## Execution envelope vs. frontmatter
+
+  The execution envelope (which engine, model, reasoning effort, and
+  permission level run the node) lives on the workflow `.sym` agent node,
+  not here: see `SymphonyElixir.Engine.Envelope`. A node selects its
+  engine and model with the node's `engine:` / `model:` fields, so the
+  skill file is model-agnostic and never restates them.
 
   ## Partials
 
@@ -63,22 +69,23 @@ defmodule SymphonyElixir.Skill do
   re-scanned and hard-errored on. The fixpoint + seen-set makes the
   catalog body genuinely token-free regardless of partial prose content.
 
-  ## Reasoning effort
+  ## Frontmatter fields
 
-  Optional. Accepts `none`, `minimal`, `low`, `medium`, `high`, or
-  `xhigh`, mirroring the codex app-server `ReasoningEffort` enum. When
-  set, the runtime passes it as the `effort` parameter on `turn/start`
-  so the codex session uses that reasoning budget. When absent, codex
-  falls back to its built-in default for the model.
+  All optional. Mirrors the model-agnostic Agent Skills shape:
+
+  - `description` - one line on what the skill does, shown on the skills
+    dashboard. The `name` is the filename, so it is not repeated here.
+  - `tools` - dynamic-tool allowlist the host executes on the engine's
+    behalf (for example `linear_graphql`). Empty for engines that
+    self-execute their tools.
+
+  Reasoning effort, model, engine, and permissions are NOT skill fields:
+  they are the workflow node's execution envelope (see the moduledoc).
   """
 
   @enforce_keys [
     :name,
     :path,
-    :codex_model,
-    :reasoning_effort,
-    :sandbox,
-    :approval_policy,
     :tools,
     :body,
     :body_hash
@@ -86,29 +93,20 @@ defmodule SymphonyElixir.Skill do
   defstruct [
     :name,
     :path,
-    :codex_model,
-    :reasoning_effort,
-    :sandbox,
-    :approval_policy,
+    :description,
     :tools,
     :body,
     :body_hash
   ]
 
-  @type reasoning_effort :: nil | String.t()
   @type t :: %__MODULE__{
           name: String.t(),
           path: Path.t(),
-          codex_model: String.t(),
-          reasoning_effort: reasoning_effort(),
-          sandbox: String.t(),
-          approval_policy: String.t(),
+          description: String.t() | nil,
           tools: [String.t()],
           body: String.t(),
           body_hash: binary()
         }
-
-  @reasoning_efforts ~w(none minimal low medium high xhigh)
 
   @spec load(Path.t()) :: {:ok, t()} | {:error, term()}
   def load(path) when is_binary(path) do
@@ -124,11 +122,7 @@ defmodule SymphonyElixir.Skill do
   @spec from_parts(map(), String.t(), Path.t()) :: {:ok, t()} | {:error, term()}
   defp from_parts(frontmatter, body, path)
        when is_map(frontmatter) and is_binary(body) and is_binary(path) do
-    with {:ok, codex_model} <- fetch_string(frontmatter, "codex_model"),
-         {:ok, reasoning_effort} <- fetch_reasoning_effort(frontmatter),
-         {:ok, sandbox} <- fetch_string(frontmatter, "sandbox"),
-         {:ok, approval_policy} <- fetch_string(frontmatter, "approval_policy"),
-         {:ok, tools} <- fetch_string_list(frontmatter, "tools") do
+    with {:ok, tools} <- fetch_string_list(frontmatter, "tools") do
       name =
         path
         |> Path.basename(".md")
@@ -137,10 +131,7 @@ defmodule SymphonyElixir.Skill do
        %__MODULE__{
          name: name,
          path: path,
-         codex_model: codex_model,
-         reasoning_effort: reasoning_effort,
-         sandbox: sandbox,
-         approval_policy: approval_policy,
+         description: optional_string(frontmatter, "description"),
          tools: tools,
          body: body,
          body_hash: <<>>
@@ -163,16 +154,17 @@ defmodule SymphonyElixir.Skill do
     end
   end
 
-  defp fetch_string(map, key) do
+  # Optional frontmatter string: a present non-blank value, else nil.
+  defp optional_string(map, key) do
     case Map.get(map, key) do
       value when is_binary(value) ->
         case String.trim(value) do
-          "" -> {:error, {:missing_field, key}}
-          trimmed -> {:ok, trimmed}
+          "" -> nil
+          trimmed -> trimmed
         end
 
       _ ->
-        {:error, {:missing_field, key}}
+        nil
     end
   end
 
@@ -187,25 +179,6 @@ defmodule SymphonyElixir.Skill do
 
       _ ->
         {:error, {:invalid_field, key}}
-    end
-  end
-
-  defp fetch_reasoning_effort(map) do
-    case Map.get(map, "reasoning_effort") do
-      nil ->
-        {:ok, nil}
-
-      value when is_binary(value) ->
-        normalized = value |> String.trim() |> String.downcase()
-
-        cond do
-          normalized == "" -> {:ok, nil}
-          normalized in @reasoning_efforts -> {:ok, normalized}
-          true -> {:error, {:invalid_reasoning_effort, value}}
-        end
-
-      other ->
-        {:error, {:invalid_reasoning_effort, other}}
     end
   end
 

--- a/packages/symphony/elixir/lib/symphony_elixir_web/live/skills_live.ex
+++ b/packages/symphony/elixir/lib/symphony_elixir_web/live/skills_live.ex
@@ -2,11 +2,15 @@ defmodule SymphonyElixirWeb.SkillsLive do
   @moduledoc """
   Skill catalog view.
 
-  - `:index` lists every skill the catalog has loaded with its codex
-    envelope (model, sandbox, approval policy, tools).
+  - `:index` lists every skill the catalog has loaded with its
+    description and tools.
   - `:show` renders the full system-prompt body for one skill so the
     operator can read what the agent is being told without leaving the
     dashboard.
+
+  A skill is a model-agnostic prompt body: the execution envelope
+  (engine, model, effort, permissions) lives on the workflow `.sym`
+  agent node, not the skill, and is shown on the runs view.
 
   Reads through `Catalog`; hot-reloads when `skills/*.md` changes on
   disk because Catalog re-emits the skill list on its 1s tick.
@@ -55,8 +59,7 @@ defmodule SymphonyElixirWeb.SkillsLive do
         <%= for skill <- @skills do %>
           <div class="dag-row">
             <div class="name"><a href={"/skills/" <> skill.name}>{skill.name}</a></div>
-            <div class="muted mono" title={model_summary(skill)}>{model_summary(skill)}</div>
-            <div class="muted" title={skill.sandbox}>{skill.sandbox}</div>
+            <div class="muted" title={description_summary(skill.description)}>{description_summary(skill.description)}</div>
             <div class="muted right-align" title={tool_summary(skill.tools)}>{tool_summary(skill.tools)}</div>
           </div>
         <% end %>
@@ -82,14 +85,8 @@ defmodule SymphonyElixirWeb.SkillsLive do
             <div class="muted mono">{Path.relative_to_cwd(@skill.path)}</div>
           </div>
           <dl class="kv" style="margin-top:12px">
-            <dt>codex model</dt>
-            <dd class="mono">{@skill.codex_model}</dd>
-            <dt>reasoning effort</dt>
-            <dd class="mono">{effort_label(@skill.reasoning_effort)}</dd>
-            <dt>sandbox</dt>
-            <dd class="mono">{@skill.sandbox}</dd>
-            <dt>approval policy</dt>
-            <dd class="mono">{@skill.approval_policy}</dd>
+            <dt>description</dt>
+            <dd>{description_summary(@skill.description)}</dd>
             <dt>tools</dt>
             <dd class="mono">{tool_summary(@skill.tools)}</dd>
           </dl>
@@ -110,11 +107,6 @@ defmodule SymphonyElixirWeb.SkillsLive do
   defp tool_summary([]), do: "(no tools)"
   defp tool_summary(tools), do: Enum.join(tools, ", ")
 
-  defp model_summary(skill) do
-    "#{skill.codex_model} (#{effort_label(skill.reasoning_effort)})"
-  end
-
-  defp effort_label(nil), do: "default"
-  defp effort_label(""), do: "default"
-  defp effort_label(effort) when is_binary(effort), do: effort
+  defp description_summary(nil), do: "(no description)"
+  defp description_summary(description) when is_binary(description), do: description
 end

--- a/packages/symphony/elixir/test/symphony_elixir/skill_test.exs
+++ b/packages/symphony/elixir/test/symphony_elixir/skill_test.exs
@@ -6,10 +6,7 @@ defmodule SymphonyElixir.SkillTest do
   # Minimal valid YAML frontmatter shared by all fixture skills.
   @frontmatter """
   ---
-  codex_model: gpt-5-codex
-  reasoning_effort: medium
-  sandbox: workspace-write
-  approval_policy: never
+  description: Fixture skill for parser tests.
   tools: []
   ---
   """
@@ -33,6 +30,52 @@ defmodule SymphonyElixir.SkillTest do
 
   defp write_partial!(partials_dir, name, body) do
     File.write!(Path.join(partials_dir, "#{name}.md"), body)
+  end
+
+  describe "model-agnostic frontmatter" do
+    # The execution envelope (engine, model, effort, permissions) lives on the
+    # workflow `.sym` agent node, not in skill frontmatter. The skill is the
+    # Agent Skills shape: an optional description plus a tools allowlist, never
+    # a model. The loader must not carry the removed codex envelope fields.
+    test "a skill with only a body and empty tools loads; description defaults to nil" do
+      {dir, _partials_dir} = setup_skill_dir()
+
+      path = Path.join(dir, "node_skill.md")
+
+      File.write!(path, """
+      ---
+      tools: []
+      ---
+      Body for a model-agnostic skill.
+      """)
+
+      assert {:ok, skill} = Skill.load(path)
+      assert skill.description == nil
+      assert skill.tools == []
+      assert String.contains?(skill.body, "model-agnostic skill")
+      refute Map.has_key?(skill, :codex_model)
+      refute Map.has_key?(skill, :sandbox)
+      refute Map.has_key?(skill, :approval_policy)
+      refute Map.has_key?(skill, :reasoning_effort)
+    end
+
+    test "description and tools are read from frontmatter" do
+      {dir, _partials_dir} = setup_skill_dir()
+
+      path = Path.join(dir, "described_skill.md")
+
+      File.write!(path, """
+      ---
+      description: Does a specific thing.
+      tools: [linear_graphql]
+      ---
+      Body.
+      """)
+
+      assert {:ok, skill} = Skill.load(path)
+      assert skill.description == "Does a specific thing."
+      assert skill.tools == ["linear_graphql"]
+    end
   end
 
   describe "expand_partials: self-referential partial" do

--- a/packages/symphony/workflows/example/skills/inspect.md
+++ b/packages/symphony/workflows/example/skills/inspect.md
@@ -1,8 +1,5 @@
 ---
-codex_model: gpt-5.3-codex
-reasoning_effort: medium
-sandbox: workspace-write
-approval_policy: never
+description: Sample skill that inspects the checked-out workspace and reports, without mutating anything.
 tools: []
 ---
 


### PR DESCRIPTION
Symphony skills carried a codex execution envelope in their frontmatter (`codex_model`, `reasoning_effort`, `sandbox`, `approval_policy`), but the `.sym` agent node has owned the real execution envelope (engine, model, effort, permissions) since the `Engine.Envelope` overhaul. Those frontmatter fields were display-only, read solely by the skills dashboard, yet the parser hard-required `codex_model`/`sandbox`/`approval_policy`. That forced every skill, including claude-engine skills, to restate a model the node already selects.

This aligns the skill format to the model-agnostic Agent Skills shape: an optional `description` and an optional `tools` allowlist, nothing else. `Skill.load` no longer requires or stores `codex_model`/`reasoning_effort`/`sandbox`/`approval_policy`. The skills dashboard now shows description plus tools; engine/model/effort/permissions stay visible on the runs view, where the node envelope lives. The example-pack skill and the stale doc and comment references are updated to match.

Backward compatible: skills that still set the old keys parse fine, since unknown frontmatter keys are ignored. Forward dependency: a workflow pack whose skills omit the keys needs this change deployed first, because the old parser rejected a missing `codex_model`.

skill_test covers a skill with no envelope fields (description nil, removed fields absent from the struct) and description/tools parsing from frontmatter.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make Symphony skills model-agnostic by moving execution envelope to the agent node
> - The `Skill` struct in [skill.ex](https://github.com/indexable-inc/index/pull/945/files#diff-e25f083c8ebbeea0ab8d613f7d4302c43b0777168733cdbd4071ef43f83bf67a) drops `codex_model`, `reasoning_effort`, `sandbox`, and `approval_policy` fields; skills now carry only an optional `description` and a `tools` allowlist.
> - Engine, model, reasoning effort, and permissions are now configured on the `.sym` agent node rather than in skill frontmatter.
> - The skills dashboard in [skills_live.ex](https://github.com/indexable-inc/index/pull/945/files#diff-25be3f8f45da4b00d467fddd507b11d60cde23d1a79b4b2c946192a7e62b1085) replaces model/sandbox columns with a `description` column.
> - Documentation and the example skill in [inspect.md](https://github.com/indexable-inc/index/pull/945/files#diff-f368c711867f1afc45f7fd6bc84d506ca68cc5f07a713a29f44aade35d204b12) are updated to match the new frontmatter contract.
> - Behavioral Change: any existing skill files with `codex_model`, `reasoning_effort`, `sandbox`, or `approval_policy` frontmatter will have those fields silently ignored; callers reading those fields from the struct will no longer find them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0932049.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->