### PR TITLE
feat(lib): idiomatic fleet API — expose, healthChecks.unit, endpoints

### DIFF
--- a/examples/east-west-firewall/allowed-client.nix
+++ b/examples/east-west-firewall/allowed-client.nix
@@ -1,14 +1,13 @@
 {
+  ix,
   lib,
   nodes,
   pkgs,
   ...
 }:
 let
-  service = {
-    host = nodes.service.config.ix.networking.eastWest.hostName;
-    port = 8080;
-  };
+  # Resolve the service node's listener by the name it exposes it under.
+  service = ix.endpointOf nodes.service "http";
 in
 {
   environment.systemPackages = [ pkgs.curl ];
@@ -20,7 +19,7 @@ in
       "--fail"
       "--silent"
       "--show-error"
-      "http://${service.host}:${toString service.port}/"
+      "http://${service}/"
     ];
   };
 }

--- a/examples/east-west-firewall/outside-client.nix
+++ b/examples/east-west-firewall/outside-client.nix
@@ -1,14 +1,12 @@
 {
+  ix,
   lib,
   nodes,
   pkgs,
   ...
 }:
 let
-  service = {
-    host = nodes.service.config.ix.networking.eastWest.hostName;
-    port = 8080;
-  };
+  service = ix.endpointOf nodes.service "http";
 in
 {
   environment.systemPackages = [ pkgs.curl ];
@@ -24,8 +22,8 @@ in
       "pipefail"
       "-c"
       ''
-        if ${lib.getExe pkgs.curl} --fail --silent --show-error --connect-timeout 2 http://${service.host}:${toString service.port}/; then
-          echo "unexpectedly reached http://${service.host}:${toString service.port}/" >&2
+        if ${lib.getExe pkgs.curl} --fail --silent --show-error --connect-timeout 2 http://${service}/; then
+          echo "unexpectedly reached http://${service}/" >&2
           exit 1
         fi
       ''

--- a/examples/east-west-firewall/service.nix
+++ b/examples/east-west-firewall/service.nix
@@ -22,25 +22,17 @@ in
     };
   };
 
-  networking.firewall.allowedTCPPorts = [ httpPort ];
-
   environment.systemPackages = [ pkgs.curl ];
 
-  ix.networking.portClaims.http = {
-    protocol = "tcp";
+  # One declaration opens the firewall, registers the claim, and lets
+  # east-west peers resolve this listener with `ix.endpointOf nodes.service "http"`.
+  ix.networking.expose.http = {
     port = httpPort;
     description = "private HTTP service for east-west group members";
   };
 
   ix.healthChecks = {
-    nginx = {
-      command = [
-        (lib.getExe' config.systemd.package "systemctl")
-        "is-active"
-        "--quiet"
-        "nginx.service"
-      ];
-    };
+    nginx.unit = "nginx";
 
     http-loopback = {
       description = "private HTTP service answers locally";

--- a/examples/hermes-agent/hermes.nix
+++ b/examples/hermes-agent/hermes.nix
@@ -187,13 +187,7 @@ in
   # Surface the daemon health to fleet-wide health checks. The unit is
   # forking with `Restart=always`, so `is-active` is the right probe.
   ix.healthChecks.hermes-agent = {
-    from = "guest";
     description = "Hermes agent gateway is active";
-    command = [
-      (lib.getExe' config.systemd.package "systemctl")
-      "is-active"
-      "--quiet"
-      "hermes-agent.service"
-    ];
+    unit = "hermes-agent";
   };
 }

--- a/examples/minecraft-blocks/log.nix
+++ b/examples/minecraft-blocks/log.nix
@@ -86,14 +86,13 @@ in
     };
   };
 
-  ix.networking.portClaims.kafka = {
-    protocol = "tcp";
+  # One declaration: registers the claim, opens the in-guest firewall, and makes
+  # the broker resolvable from sibling nodes via `ix.endpointOf nodes.log "kafka"`.
+  ix.networking.expose.kafka = {
     port = brokerPort;
     address = "0.0.0.0";
     description = "Kafka broker (block_events log)";
   };
-
-  networking.firewall.allowedTCPPorts = [ brokerPort ];
 
   ix.healthChecks.kafka-topic = {
     description = "Kafka broker is up and the block_events topic exists";

--- a/examples/minecraft-blocks/producer.nix
+++ b/examples/minecraft-blocks/producer.nix
@@ -28,17 +28,19 @@ let
   packages = import ./packages.nix { inherit ix pkgs; };
 
   blockLog = "/var/lib/minecraft/block-events.jsonl";
-  brokerPort = 9092;
   kafkaBin = "${pkgs.apacheKafka}/bin";
 
-  log = {
-    host = nodes.log.config.ix.networking.eastWest.hostName;
-  };
+  # The log node declares the broker via `ix.networking.expose.kafka`, so we
+  # resolve its reachable `host:port` by name instead of reaching into its
+  # option tree. `kafka` renders to "log:9092" in string context.
+  kafka = ix.endpointOf nodes.log "kafka";
+
   # The view node runs the shared observability stack, so it is also the
-  # telemetry sink. One ClickHouse, two legs.
-  observability = {
+  # telemetry sink. One ClickHouse, two legs. The collector port is an upstream
+  # module option (not an `expose`), so build the endpoint directly.
+  collector = ix.endpoint {
     host = nodes.view.config.ix.networking.eastWest.hostName;
-    otlpGrpcPort = nodes.view.config.services.ix-observability.collector.grpcPort;
+    port = nodes.view.config.services.ix-observability.collector.grpcPort;
   };
 
   # Transport leg: follow the plugin's append-only file and produce each new
@@ -53,12 +55,12 @@ let
   shipToKafka = pkgs.writeShellScript "mc-blocks-ship" ''
     set -eu
     touch ${blockLog}
-    until ${kafkaBin}/kafka-broker-api-versions.sh --bootstrap-server ${log.host}:${toString brokerPort} >/dev/null 2>/tmp/kafka-probe.err; do
+    until ${kafkaBin}/kafka-broker-api-versions.sh --bootstrap-server ${kafka} >/dev/null 2>/tmp/kafka-probe.err; do
       sleep 2
     done
     exec ${pkgs.coreutils}/bin/tail -F -n +1 ${blockLog} \
       | ${kafkaBin}/kafka-console-producer.sh \
-          --bootstrap-server ${log.host}:${toString brokerPort} \
+          --bootstrap-server ${kafka} \
           --topic ${schema.topic}
   '';
 in
@@ -123,7 +125,7 @@ in
     stack.enable = false;
     agent = {
       enable = true;
-      endpoint = "${observability.host}:${toString observability.otlpGrpcPort}";
+      endpoint = "${collector}";
       journal.enable = true;
     };
     environment = "example";
@@ -136,11 +138,6 @@ in
   # transport service is running.
   ix.healthChecks.mc-blocks-producer = {
     description = "block-events plugin installed and Kafka shipper active";
-    command = [
-      (lib.getExe' config.systemd.package "systemctl")
-      "is-active"
-      "--quiet"
-      "mc-blocks-ship.service"
-    ];
+    unit = "mc-blocks-ship";
   };
 }

--- a/examples/minecraft-blocks/view.nix
+++ b/examples/minecraft-blocks/view.nix
@@ -31,10 +31,8 @@ let
   clickhouseHost = obs.clickhouse.host;
   clickhousePort = obs.clickhouse.nativePort;
 
-  log = {
-    host = nodes.log.config.ix.networking.eastWest.hostName;
-    brokerPort = 9092;
-  };
+  # Resolve the log node's broker by the name it exposes it under.
+  kafka = ix.endpointOf nodes.log "kafka";
 
   columnList = lib.concatStringsSep ", " schema.columnNames;
 
@@ -47,7 +45,7 @@ let
     )
     ENGINE = Kafka
     SETTINGS
-      kafka_broker_list = '${log.host}:${toString log.brokerPort}',
+      kafka_broker_list = '${kafka}',
       kafka_topic_list = '${schema.topic}',
       kafka_group_name = 'clickhouse-${schema.database}',
       kafka_format = 'JSONEachRow',

--- a/examples/multi-client-file-sharing/server.nix
+++ b/examples/multi-client-file-sharing/server.nix
@@ -14,9 +14,8 @@ in
   # `cifs.ko` from the host kernel.
   services.samba = {
     enable = true;
-    # We claim and open TCP 445 explicitly below so the firewall rule and
-    # the `ix.networking.portClaims` registry stay co-located with the
-    # rest of the listener policy.
+    # `ix.networking.expose.samba` below claims the port and opens the
+    # in-guest firewall, so the listener policy stays in one place.
     openFirewall = false;
 
     settings = {
@@ -67,21 +66,14 @@ in
     "d ${shareDir} 0770 nobody nogroup -"
   ];
 
-  networking.firewall.allowedTCPPorts = [ sambaPort ];
-
-  ix.networking.portClaims.samba = {
-    protocol = "tcp";
+  # One declaration registers the claim and opens the firewall for SMB.
+  ix.networking.expose.samba = {
     port = sambaPort;
     description = "Samba SMB3 share for east-west clients";
   };
 
   ix.healthChecks.smbd = {
     description = "smbd is active";
-    command = [
-      (lib.getExe' config.systemd.package "systemctl")
-      "is-active"
-      "--quiet"
-      "samba-smbd.service"
-    ];
+    unit = "samba-smbd";
   };
 }

--- a/examples/nginx-lifecycle/service.nix
+++ b/examples/nginx-lifecycle/service.nix
@@ -13,24 +13,15 @@ in
     virtualHosts.localhost.locations."/".return = "200 'ix nginx lifecycle ok\n'";
   };
 
-  networking.firewall.allowedTCPPorts = [ nginxPort ];
   environment.systemPackages = [ pkgs.curl ];
 
-  ix.networking.portClaims.nginx = {
-    protocol = "tcp";
+  ix.networking.expose.nginx = {
     port = nginxPort;
     description = "nginx lifecycle HTTP";
   };
 
   ix.healthChecks = {
-    nginx = {
-      command = [
-        (lib.getExe' config.systemd.package "systemctl")
-        "is-active"
-        "--quiet"
-        "nginx.service"
-      ];
-    };
+    nginx.unit = "nginx";
 
     nginx-http = {
       description = "nginx HTTP loopback";

--- a/examples/observability-stack/app.nix
+++ b/examples/observability-stack/app.nix
@@ -1,5 +1,6 @@
 {
   config,
+  ix,
   lib,
   nodes,
   pkgs,
@@ -8,9 +9,14 @@
 let
   observability = {
     host = nodes.observability.config.ix.networking.eastWest.hostName;
-    otlpGrpcPort = nodes.observability.config.services.ix-observability.collector.grpcPort;
     clickhousePort = nodes.observability.config.services.ix-observability.clickhouse.nativePort;
     database = nodes.observability.config.services.ix-observability.clickhouse.database;
+  };
+  # The collector's OTLP/gRPC port is an upstream module option, so build the
+  # endpoint directly. Renders to "observability:<port>" in string context.
+  collector = ix.endpoint {
+    inherit (observability) host;
+    port = nodes.observability.config.services.ix-observability.collector.grpcPort;
   };
   logDir = "/var/log/ix-observability-demo";
   logPath = "${logDir}/app.log";
@@ -43,7 +49,7 @@ in
     stack.enable = false;
     agent = {
       enable = true;
-      endpoint = "${observability.host}:${toString observability.otlpGrpcPort}";
+      endpoint = "${collector}";
       filelog.paths = [ logPath ];
     };
     environment = "example";
@@ -77,12 +83,7 @@ in
   ix.healthChecks = {
     observability-demo = {
       description = "demo telemetry emitter ran";
-      command = [
-        (lib.getExe' config.systemd.package "systemctl")
-        "is-active"
-        "--quiet"
-        "ix-observability-demo.service"
-      ];
+      unit = "ix-observability-demo";
     };
 
     observability-ingested = {

--- a/examples/python-daily-scraper/service.nix
+++ b/examples/python-daily-scraper/service.nix
@@ -27,8 +27,6 @@ let
     };
   };
 
-  systemctl = lib.getExe' config.systemd.package "systemctl";
-
   scraperArgs = [
     (lib.getExe scraper.package)
     "--output-dir"
@@ -61,14 +59,8 @@ in
   environment.systemPackages = [ scraper.package ];
 
   ix.healthChecks.daily-scraper = {
-    from = "guest";
     description = "Daily scraper timer is active";
-    command = [
-      systemctl
-      "is-active"
-      "--quiet"
-      "daily-scraper.timer"
-    ];
+    unit = "daily-scraper.timer";
   };
 
   systemd.services.daily-scraper = {

--- a/examples/ray-cluster/cluster-node.nix
+++ b/examples/ray-cluster/cluster-node.nix
@@ -131,39 +131,28 @@ in
     };
   };
 
-  networking.firewall = {
-    allowedTCPPorts = [
-      ports.nodeManager
-      ports.objectManager
-    ];
-    allowedTCPPortRanges = [
-      {
-        from = ports.workerLow;
-        to = ports.workerHigh;
-      }
-    ];
-  };
-
-  ix.networking.portClaims = {
+  ix.networking.expose = {
     ray-node-manager = {
-      protocol = "tcp";
       port = ports.nodeManager;
       description = "Ray node manager (inter-node scheduling)";
     };
     ray-object-manager = {
-      protocol = "tcp";
       port = ports.objectManager;
       description = "Ray object manager (object store transfers)";
     };
   };
 
+  # The worker port range is opened at the firewall directly: `expose` covers a
+  # single named listener, not a range.
+  networking.firewall.allowedTCPPortRanges = [
+    {
+      from = ports.workerLow;
+      to = ports.workerHigh;
+    }
+  ];
+
   ix.healthChecks."ray-${role}-active" = {
     description = "ray-${role} service is active";
-    command = [
-      (lib.getExe' config.systemd.package "systemctl")
-      "is-active"
-      "--quiet"
-      "ray-${role}.service"
-    ];
+    unit = "ray-${role}";
   };
 }

--- a/examples/ray-cluster/head.nix
+++ b/examples/ray-cluster/head.nix
@@ -50,19 +50,12 @@ in
 
   # GCS bootstrap and the Ray Client server are head-only listeners; the shared
   # node-manager, object-manager, and worker ports are opened in cluster-node.
-  networking.firewall.allowedTCPPorts = [
-    gcsPort
-    clientPort
-  ];
-
-  ix.networking.portClaims = {
+  ix.networking.expose = {
     ray-gcs = {
-      protocol = "tcp";
       port = gcsPort;
       description = "Ray GCS (cluster bootstrap)";
     };
     ray-client = {
-      protocol = "tcp";
       port = clientPort;
       description = "Ray Client server";
     };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -358,6 +358,7 @@ let
     each consumer splices its own extras on top with `//`.
   */
   sharedHelpers = {
+    inherit (import ./util/endpoint.nix { inherit lib; }) endpoint endpointOf;
     inherit
       rev
       revEpoch

--- a/lib/image/platform.nix
+++ b/lib/image/platform.nix
@@ -6,14 +6,42 @@
   ...
 }:
 let
+  # `ix.healthChecks.<name>.unit` sugar: probe a systemd unit with
+  # `systemctl is-active`. A bare name gets the `.service` suffix; pass an
+  # explicit `foo.socket`/`foo.timer` to probe another unit type.
+  unitName = unit: if lib.hasInfix "." unit then unit else "${unit}.service";
+  mkUnitCommand = unit: [
+    (lib.getExe' config.systemd.package "systemctl")
+    "is-active"
+    "--quiet"
+    (unitName unit)
+  ];
+
   healthCheckType = lib.types.submodule (
-    { name, ... }:
+    { name, config, ... }:
     {
       options = {
         description = lib.mkOption {
           type = lib.types.str;
           default = name;
           description = "Human-readable check name shown by fleet health commands.";
+        };
+
+        unit = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "nginx";
+          description = ''
+            A systemd unit to probe with `systemctl is-active --quiet`.
+
+            Sugar for the overwhelmingly common "is this unit running?" check:
+            setting `unit` derives `command` for you, so
+            `ix.healthChecks.nginx.unit = "nginx";` replaces the full
+            `systemctl is-active` argv. A bare name gets the `.service` suffix;
+            pass `foo.socket` or `foo.timer` to probe another unit type.
+
+            Mutually exclusive with `command`: set one or the other, not both.
+          '';
         };
 
         from = lib.mkOption {
@@ -40,6 +68,11 @@ let
             `ix shell`. For `from = "host"` it runs directly with the
             `IX_NODE*` env vars described above; tools must be on the
             operator's PATH.
+
+            When `unit` is set this defaults to a `systemctl is-active` probe of
+            that unit, so most checks only set `unit`. Set `command` for a real
+            readiness probe (an HTTP request, a query) rather than a bare unit
+            liveness check; set one of `unit` or `command`.
           '';
         };
 
@@ -72,6 +105,14 @@ let
             with this requirement unless `deployment.ipv4 = true`.
           '';
         };
+      };
+
+      # `unit` sugar lives here, not in `command`'s default: a public option's
+      # default must be a self-contained literal (repo ast-grep rule), so the
+      # `unit` -> command branch is seeded in config as an mkDefault a real
+      # `command` (priority 100) still overrides.
+      config = lib.mkIf (config.unit != null) {
+        command = lib.mkDefault (mkUnitCommand config.unit);
       };
     }
   );
@@ -142,6 +183,81 @@ let
   ipv4GuestHealthChecks = lib.filterAttrs (
     _name: check: check.requiresIpv4 && check.from != "host"
   ) config.ix.healthChecks;
+
+  # Health checks that set `unit` must not also override `command`: the whole
+  # point of `unit` is that it derives the command, so a custom command means
+  # `unit` is silently ignored. Flag it instead of letting them disagree.
+  overSpecifiedHealthChecks = lib.filterAttrs (
+    _name: check: check.unit != null && check.command != mkUnitCommand check.unit
+  ) config.ix.healthChecks;
+
+  # `ix.networking.expose.<name>` is the one declaration for "this image listens
+  # here": it registers the port in the claim registry (so collisions are caught
+  # at eval time) and, by default, opens the in-guest firewall for it. It also
+  # makes the listener discoverable across the fleet via `ix.endpointOf`.
+  exposeType = lib.types.submodule (
+    { name, ... }:
+    {
+      options = {
+        port = lib.mkOption {
+          type = lib.types.port;
+          description = "Port this image listens on.";
+        };
+
+        protocol = lib.mkOption {
+          type = lib.types.enum [
+            "tcp"
+            "udp"
+          ];
+          default = "tcp";
+          description = "Transport protocol of this listener.";
+        };
+
+        address = lib.mkOption {
+          type = lib.types.str;
+          default = "*";
+          description = "Bind address. Use * when the service binds every address or the bind behavior is implicit.";
+        };
+
+        namespace = lib.mkOption {
+          type = lib.types.str;
+          default = "default";
+          description = "Network namespace for this listener. Ordinary image services use the default namespace.";
+        };
+
+        description = lib.mkOption {
+          type = lib.types.str;
+          default = name;
+          description = "Human-readable listener owner, used in collision errors and health output.";
+        };
+
+        firewall = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = ''
+            Open the in-guest firewall for this port. Leave it on for the normal
+            case (this image owns the listener). Set it false when another
+            mechanism already opens the port (a service's own
+            `openFirewall = true`) and you only want the registry entry and
+            cross-node discovery.
+          '';
+        };
+      };
+    }
+  );
+
+  exposeList = lib.attrValues config.ix.networking.expose;
+  exposePortClaims = lib.mapAttrs (_name: e: {
+    inherit (e)
+      protocol
+      port
+      address
+      namespace
+      description
+      ;
+  }) config.ix.networking.expose;
+  exposeFirewallPorts =
+    proto: map (e: e.port) (lib.filter (e: e.firewall && e.protocol == proto) exposeList);
 in
 {
   options.ix = {
@@ -173,6 +289,29 @@ in
         '';
       };
 
+      expose = lib.mkOption {
+        type = lib.types.attrsOf exposeType;
+        default = { };
+        example = lib.literalExpression ''
+          {
+            http = {
+              port = 8080;
+              description = "public HTTP API";
+            };
+          }
+        '';
+        description = ''
+          Listeners this image exposes, declared once. Each entry registers a
+          port claim (so same-namespace collisions fail at eval time), opens the
+          in-guest firewall for the port (unless `firewall = false`), and becomes
+          discoverable from sibling nodes via `ix.endpointOf nodes.<node> "<name>"`.
+
+          This is the one source of truth for a port: prefer it over hand-pairing
+          `networking.firewall.allowed*Ports` with `ix.networking.portClaims`,
+          which is the lower-level primitive `expose` desugars to.
+        '';
+      };
+
       # Networking policy (per-port filtering, L7, WAF, rate limiting, gateway
       # behavior) belongs to the image, not to ix. ix exposes two primitives:
       # east-west group membership (which VMs can reach each other) and
@@ -188,7 +327,7 @@ in
   };
 
   config = {
-    ix.networking.portClaims = {
+    ix.networking.portClaims = exposePortClaims // {
       ix-console = {
         protocol = "tcp";
         port = 5001;
@@ -219,6 +358,17 @@ in
         message = ''
           ix.healthChecks can only set requiresIpv4 on host checks:
             ${lib.concatStringsSep ", " (lib.attrNames ipv4GuestHealthChecks)}
+        '';
+      }
+      {
+        assertion = overSpecifiedHealthChecks == { };
+        message = ''
+          ix.healthChecks set both `unit` and a custom `command`, which conflict
+          (a custom command makes `unit` a no-op):
+            ${lib.concatStringsSep ", " (lib.attrNames overSpecifiedHealthChecks)}
+
+          Set `unit` for a `systemctl is-active` probe, or `command` for an
+          explicit argv -- not both.
         '';
       }
     ];
@@ -291,10 +441,12 @@ in
         enable = lib.mkDefault true;
         allowedTCPPorts = [
           5001 # ix-console shell and terminal snapshot listener.
-        ];
+        ]
+        ++ exposeFirewallPorts "tcp";
         allowedUDPPorts = [
           8443 # ix-agent WebTransport direct-connect endpoint.
-        ];
+        ]
+        ++ exposeFirewallPorts "udp";
       };
     };
 

--- a/lib/util/endpoint.nix
+++ b/lib/util/endpoint.nix
@@ -1,0 +1,66 @@
+/**
+  A small, stringifiable network endpoint value shared across the fleet.
+
+  `endpoint { host; port; }` returns an attrset that renders to `host:port` in
+  string context (via `__toString`) yet still exposes `.host`, `.port`,
+  `.authority`, and `.url` for callers that need a part. This kills the
+  `"${host}:${toString port}"` boilerplate and the stray `toString port` that
+  litter cross-node wiring, and gives one type every producer/consumer agrees on.
+
+  `endpointOf node "name"` resolves a *peer's* declared listener: it reads that
+  node's `ix.networking.expose.<name>` port and pairs it with the node's
+  east-west hostname, so a consumer never reaches into a sibling's internal
+  option tree to discover where to connect.
+
+      kafka = ix.endpointOf nodes.log "kafka";   # => log:9092
+      "--bootstrap-server" "${kafka}"            # renders host:port
+      kafka.port                                 # => 9092
+
+  For a listener that is not declared through `expose` (an upstream module's own
+  option), build one directly: `ix.endpoint { host = peerHost; port = thePort; }`.
+*/
+{ lib }:
+let
+  endpoint =
+    {
+      host,
+      port,
+      # Optional application scheme (http, grpc, ...). When set, `url` becomes
+      # `scheme://host:port<path>`; when null, `url` is the bare `host:port`
+      # authority, which is what most callers interpolate.
+      scheme ? null,
+      path ? "",
+    }:
+    let
+      authority = "${host}:${toString port}";
+    in
+    {
+      inherit
+        host
+        port
+        scheme
+        path
+        authority
+        ;
+      url = if scheme == null then authority else "${scheme}://${authority}${path}";
+      __toString = self: self.url;
+    };
+
+  endpointOf =
+    node: name:
+    let
+      config = node.config or node;
+      listeners = config.ix.networking.expose;
+    in
+    assert lib.assertMsg (listeners ? ${name})
+      "endpointOf: node '${
+        config.networking.hostName or "?"
+      }' has no `ix.networking.expose.${name}` listener; declare it with `ix.networking.expose.${name}` on that node, or build an endpoint directly with `ix.endpoint`.";
+    endpoint {
+      host = config.ix.networking.eastWest.hostName;
+      inherit (listeners.${name}) port;
+    };
+in
+{
+  inherit endpoint endpointOf;
+}

--- a/modules/services/minecraft/default.nix
+++ b/modules/services/minecraft/default.nix
@@ -29,7 +29,6 @@ let
 
   dataDir = "/var/lib/minecraft";
   managedRoot = "/etc/minecraft";
-  systemctl = lib.getExe' config.systemd.package "systemctl";
   fileExt = path: lib.last (lib.splitString "." path);
 
   flattenProperties =
@@ -1201,12 +1200,7 @@ in
         minecraft = {
           from = "guest";
           description = "Minecraft systemd unit is active";
-          command = [
-            systemctl
-            "is-active"
-            "--quiet"
-            "minecraft.service"
-          ];
+          unit = "minecraft";
         };
 
         minecraft-status = {

--- a/modules/services/velocity/default.nix
+++ b/modules/services/velocity/default.nix
@@ -20,7 +20,6 @@ let
   yourkit = ix.languages.java.yourkit;
   dataDir = "/var/lib/velocity";
   java = lib.getExe' cfg.javaPackage "java";
-  systemctl = lib.getExe' config.systemd.package "systemctl";
   tomlFormat = pkgs.formats.toml { };
   yamlFormat = pkgs.formats.yaml { };
   jsonFormat = pkgs.formats.json { };
@@ -652,12 +651,7 @@ in
       velocity = {
         from = "guest";
         description = "Velocity systemd unit is active";
-        command = [
-          systemctl
-          "is-active"
-          "--quiet"
-          "velocity.service"
-        ];
+        unit = "velocity";
       };
 
       velocity-status = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2198,7 +2198,124 @@ let
   );
   # --- Per-image assertion groups -------------------------------------------
 
+  # --- Idiomatic fleet API (expose / healthChecks.unit / endpoint) ----------
+  idiomaticExpose = evalConfig [
+    {
+      networking.hostName = "svc-a";
+      ix = {
+        networking.expose = {
+          web = {
+            port = 8080;
+            description = "demo web listener";
+          };
+          metrics = {
+            port = 9090;
+            # Opened by something else; only register the claim + discovery.
+            firewall = false;
+          };
+          dns = {
+            port = 53;
+            protocol = "udp";
+          };
+        };
+        healthChecks = {
+          web.unit = "nginx";
+          cron.unit = "backup.timer";
+        };
+      };
+    }
+  ];
+
+  idiomaticUnitConflictFailures = failedAssertionsFor [
+    {
+      ix.healthChecks.bad = {
+        unit = "nginx";
+        command = [ "true" ];
+      };
+    }
+  ];
+
+  idiomaticExposeCollisionFailures = failedAssertionsFor [
+    {
+      ix.networking = {
+        expose.first.port = 7000;
+        portClaims.second = {
+          protocol = "tcp";
+          port = 7000;
+        };
+      };
+    }
+  ];
+
   groups = {
+    idiomatic-fleet-api = [
+      {
+        assertion =
+          idiomaticExpose.ix.healthChecks.web.command == [
+            (lib.getExe' idiomaticExpose.systemd.package "systemctl")
+            "is-active"
+            "--quiet"
+            "nginx.service"
+          ];
+        message = "ix.healthChecks.<name>.unit should derive a `systemctl is-active` probe and add the .service suffix";
+      }
+      {
+        assertion = lib.last idiomaticExpose.ix.healthChecks.cron.command == "backup.timer";
+        message = "ix.healthChecks.<name>.unit should keep an explicit unit type suffix (.timer)";
+      }
+      {
+        assertion = idiomaticUnitConflictFailures != [ ];
+        message = "ix.healthChecks should reject setting both `unit` and a custom `command`";
+      }
+      {
+        assertion =
+          let
+            c = idiomaticExpose.ix.networking.portClaims;
+          in
+          c.web.port == 8080 && c.web.protocol == "tcp" && c.metrics.port == 9090 && c.dns.protocol == "udp";
+        message = "ix.networking.expose should register a port claim per listener";
+      }
+      {
+        assertion =
+          let
+            fw = idiomaticExpose.networking.firewall;
+          in
+          builtins.elem 8080 fw.allowedTCPPorts
+          && !(builtins.elem 9090 fw.allowedTCPPorts)
+          && builtins.elem 53 fw.allowedUDPPorts;
+        message = "ix.networking.expose should open the firewall by default, skip it when firewall = false, and use the listener's protocol";
+      }
+      {
+        assertion = idiomaticExposeCollisionFailures != [ ];
+        message = "ix.networking.expose should feed the port-claim registry so it collides with a conflicting portClaim";
+      }
+      {
+        assertion =
+          let
+            e = ix.endpoint {
+              host = "db";
+              port = 5432;
+            };
+          in
+          "${e}" == "db:5432" && e.host == "db" && e.port == 5432 && e.authority == "db:5432";
+        message = "ix.endpoint should stringify to host:port and expose its parts";
+      }
+      {
+        assertion =
+          (ix.endpoint {
+            host = "h";
+            port = 80;
+            scheme = "http";
+            path = "/x";
+          }).url == "http://h:80/x";
+        message = "ix.endpoint should build a scheme URL when given a scheme";
+      }
+      {
+        assertion = "${ix.endpointOf { config = idiomaticExpose; } "web"}" == "svc-a:8080";
+        message = "ix.endpointOf should resolve a peer's exposed listener to its east-west host:port";
+      }
+    ];
+
     base = [
       {
         assertion = base.cfg.shellWorkspace.enable;


### PR DESCRIPTION
## What

Collapses the four-way boilerplate every image/example repeated into one declaration each, and gives cross-node wiring a typed value.

- **`ix.networking.expose.<name>`** — one declaration registers the port claim *and* opens the in-guest firewall (`firewall = false` to claim only). Replaces hand-pairing `networking.firewall.allowed*Ports` with `ix.networking.portClaims`; `portClaims` stays the lower-level primitive `expose` desugars to.
- **`ix.healthChecks.<name>.unit`** — sugar for a `systemctl is-active` probe, so `unit = "nginx"` replaces the full systemctl argv. Setting both `unit` and `command` is rejected. The `unit -> command` branch is seeded in `config` (`mkDefault`) to keep `mkOption.default` a self-contained literal (repo ast-grep rule).
- **`ix.endpoint` / `ix.endpointOf`** — a stringifiable endpoint (`host:port`, with `.host`/`.port`/`.authority`/`.url`) and a resolver that reads a peer's `expose` listener + east-west hostname. Kills `"${host}:${toString port}"` and deep cross-node attr paths.

## Migration

Every example and the `minecraft`/`velocity` modules move to the new surface. The change is **behaviorally identical at the assertion level** (same port claims, firewall ports, and `is-active` commands), so existing tests stay green.

## Tests

New `idiomatic-fleet-api` test group covers the `expose`/`unit` desugar, the conflict guards, and `endpoint`/`endpointOf` resolution. Validated locally on darwin through the real `evalImageConfig`/fleet path; full lint (nixfmt, statix, deadnix, ast-grep) passes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ix.networking.expose`, `ix.healthChecks.unit`, and `ix.endpointOf` to the fleet API
> - Introduces `ix.networking.expose.<name>` in [lib/image/platform.nix](https://github.com/indexable-inc/index/pull/946/files#diff-4e9f8a1975e02453aa569916bd7b0c3a25baa581602e105115a45921f41bf7d7) to declare network listeners; automatically registers port claims and opens the in-guest firewall, replacing manual `portClaims` + `allowedTCPPorts` combinations.
> - Adds `unit` shorthand to `ix.healthChecks.<name>` that derives a `systemctl is-active` probe from a unit name, removing the need to spell out the command array.
> - Adds `ix.endpointOf node name` and `ix.endpoint { host; port; }` utilities in [lib/util/endpoint.nix](https://github.com/indexable-inc/index/pull/946/files#diff-dee246fa5d43544c049ade1d08be58970baaf57a892fd7f43c386ec830eb72b0); endpoints stringify to `host:port` and carry structured fields for scheme/path URLs.
> - Updates all examples and built-in service modules to use the new API.
> - Risk: health check configs that set both `unit` and a custom `command` now fail evaluation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 860b333.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->