### PR TITLE
feat(mcp/imessage): surface reply threading, edits, unsends, and tapbacks

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2041,6 +2041,10 @@ let
     assert imessage._tapback(2000) == "loved"
     assert imessage._tapback(2005) == "questioned"
     assert imessage._tapback(3003) == "removed-laughed"
+    # base outside 2xxx/3xxx is not a tapback even when the low digit collides
+    # with a reaction offset (1000 is an inline association, not a "loved").
+    assert imessage._tapback(1000) is None
+    assert imessage._tapback(2) is None
     assert imessage._tapback(0) is None
     assert imessage._tapback(None) is None
 
@@ -2136,7 +2140,10 @@ let
     # an edited message and an unsent (retracted) message.
     con.execute("INSERT INTO message " + cols2 + " VALUES (13, 'm13', ?, 'fixed typo', NULL, 1, 1, 'iMessage', 1, NULL, NULL, 0, ?, 0)", (ns(t3), ns(t3)))
     con.execute("INSERT INTO message " + cols2 + " VALUES (14, 'm14', ?, 'oops', NULL, 1, 1, 'iMessage', 1, NULL, NULL, 0, 0, ?)", (ns(t3), ns(t3)))
-    con.execute("INSERT INTO chat_message_join VALUES (1, 10), (1, 11), (1, 12), (1, 13), (1, 14)")
+    # associated_message_type 1000 is a non-tapback association: it must not be
+    # mislabeled "loved" just because its low digit is the loved offset.
+    con.execute("INSERT INTO message " + cols2 + " VALUES (15, 'm15', ?, 'inline assoc', NULL, 1, 1, 'iMessage', 1, NULL, 'p:0/m1', 1000, 0, 0)", (ns(t3),))
+    con.execute("INSERT INTO chat_message_join VALUES (1, 10), (1, 11), (1, 12), (1, 13), (1, 14), (1, 15)")
     con.commit()
     con.close()
 
@@ -2151,10 +2158,35 @@ let
     assert removed["tapback"] == "removed-liked" and removed["tapback_target_guid"] == "m1", removed
     assert thr.filter(pl.col("rowid") == 13)["edited"][0] is True
     assert thr.filter(pl.col("rowid") == 14)["unsent"][0] is True
+    assert thr.filter(pl.col("rowid") == 15)["tapback"][0] is None, thr.filter(pl.col("rowid") == 15)
     # a plain message carries none of this metadata.
     plain = thr.filter(pl.col("rowid") == 1).row(0, named=True)
     assert plain["reply_to_guid"] is None and plain["tapback"] is None, plain
     assert plain["edited"] is False and plain["unsent"] is False, plain
+
+    # legacy chat.db compatibility: a pre-macOS-13 schema has no
+    # thread_originator_guid / date_edited / date_retracted columns. messages()
+    # must select those only when present and degrade to empty fields, not raise.
+    legacy = os.path.join(work, "legacy.db")
+    con = sqlite3.connect(legacy)
+    con.executescript(
+        """
+        CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+        CREATE TABLE chat (ROWID INTEGER PRIMARY KEY, display_name TEXT, chat_identifier TEXT, service_name TEXT);
+        CREATE TABLE message (ROWID INTEGER PRIMARY KEY, guid TEXT, date INTEGER, text TEXT, attributedBody BLOB, is_from_me INTEGER, is_read INTEGER, service TEXT, handle_id INTEGER);
+        CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
+        CREATE TABLE message_attachment_join (message_id INTEGER, attachment_id INTEGER);
+        """
+    )
+    con.execute("INSERT INTO handle VALUES (1, '+12025550123')")
+    con.execute("INSERT INTO message (ROWID, guid, date, text, is_from_me, is_read, service, handle_id) VALUES (1, 'g1', ?, 'legacy', 1, 1, 'iMessage', 1)", (ns(t1),))
+    con.execute("INSERT INTO chat_message_join VALUES (1, 1)")
+    con.commit()
+    con.close()
+    leg = imessage.messages(db=legacy, limit=5)
+    assert leg.height == 1 and leg["text"][0] == "legacy", leg
+    assert leg["reply_to_guid"][0] is None and leg["tapback"][0] is None, leg
+    assert leg["edited"][0] is False and leg["unsent"][0] is False, leg
 
     # contacts: phones/emails aggregate into list columns under one display name.
     ab = os.path.join(work, "ab.abcddb")

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2032,6 +2032,18 @@ let
     assert imessage._norm("+1 (202) 555-0123") == imessage._norm("2025550123")
     assert imessage._norm("Me@Example.COM ") == "me@example.com"
 
+    # reply/tapback reference parsing: strip the "p:<part>/" or "bp:" prefix to the
+    # bare GUID, and decode associated_message_type into a tapback label.
+    assert imessage._bare_guid("p:0/ABC") == "ABC"
+    assert imessage._bare_guid("bp:XYZ") == "XYZ"
+    assert imessage._bare_guid("ABC") == "ABC"
+    assert imessage._bare_guid(None) is None
+    assert imessage._tapback(2000) == "loved"
+    assert imessage._tapback(2005) == "questioned"
+    assert imessage._tapback(3003) == "removed-laughed"
+    assert imessage._tapback(0) is None
+    assert imessage._tapback(None) is None
+
     work = tempfile.mkdtemp()
     chat = os.path.join(work, "chat.db")
     con = sqlite3.connect(chat)
@@ -2039,7 +2051,7 @@ let
         """
         CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
         CREATE TABLE chat (ROWID INTEGER PRIMARY KEY, display_name TEXT, chat_identifier TEXT, service_name TEXT);
-        CREATE TABLE message (ROWID INTEGER PRIMARY KEY, date INTEGER, text TEXT, attributedBody BLOB, is_from_me INTEGER, is_read INTEGER, service TEXT, handle_id INTEGER);
+        CREATE TABLE message (ROWID INTEGER PRIMARY KEY, guid TEXT, date INTEGER, text TEXT, attributedBody BLOB, is_from_me INTEGER, is_read INTEGER, service TEXT, handle_id INTEGER, thread_originator_guid TEXT, associated_message_guid TEXT, associated_message_type INTEGER DEFAULT 0, date_edited INTEGER DEFAULT 0, date_retracted INTEGER DEFAULT 0);
         CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
         CREATE TABLE message_attachment_join (message_id INTEGER, attachment_id INTEGER);
         """
@@ -2053,8 +2065,8 @@ let
     t2 = datetime(2024, 1, 2, 3, 5, 5, tzinfo=timezone.utc)
     con.execute("INSERT INTO handle VALUES (1, '+12025550123')")
     con.execute("INSERT INTO chat VALUES (1, NULL, '+12025550123', 'iMessage')")
-    con.execute("INSERT INTO message VALUES (1, ?, 'plain text', NULL, 1, 1, 'iMessage', 1)", (ns(t1),))
-    con.execute("INSERT INTO message VALUES (2, ?, NULL, ?, 0, 0, 'iMessage', 1)", (ns(t2), blob))
+    con.execute("INSERT INTO message (ROWID, guid, date, text, attributedBody, is_from_me, is_read, service, handle_id) VALUES (1, 'm1', ?, 'plain text', NULL, 1, 1, 'iMessage', 1)", (ns(t1),))
+    con.execute("INSERT INTO message (ROWID, guid, date, text, attributedBody, is_from_me, is_read, service, handle_id) VALUES (2, 'm2', ?, NULL, ?, 0, 0, 'iMessage', 1)", (ns(t2), blob))
     con.execute("INSERT INTO chat_message_join VALUES (1, 1), (1, 2)")
     con.execute("INSERT INTO message_attachment_join VALUES (2, 99)")
     con.commit()
@@ -2070,6 +2082,12 @@ let
     assert df["text"].to_list() == ["héllo 👋 world", "plain text"], df["text"].to_list()
     assert df["is_from_me"].to_list() == [False, True], df
     assert df["name"].to_list() == [None, None], df
+    # the relational columns default cleanly when a message is none of these.
+    assert df["reply_to_guid"].to_list() == [None, None], df
+    assert df["reply_to_rowid"].to_list() == [None, None], df
+    assert df["tapback"].to_list() == [None, None], df
+    assert df["edited"].to_list() == [False, False], df
+    assert df["unsent"].to_list() == [False, False], df
 
     row2 = df.filter(pl.col("rowid") == 2)
     assert row2["date"][0] == t2, (row2["date"][0], t2)
@@ -2096,13 +2114,47 @@ let
     writer = sqlite3.connect(chat)
     writer.execute("PRAGMA journal_mode=WAL")
     writer.execute(
-        "INSERT INTO message VALUES (3, ?, 'in the wal', NULL, 1, 1, 'iMessage', 1)",
+        "INSERT INTO message (ROWID, guid, date, text, attributedBody, is_from_me, is_read, service, handle_id) VALUES (3, 'm3', ?, 'in the wal', NULL, 1, 1, 'iMessage', 1)",
         (ns(datetime(2024, 1, 2, 3, 6, 5, tzinfo=timezone.utc)),),
     )
     writer.execute("INSERT INTO chat_message_join VALUES (1, 3)")
     writer.commit()
     assert "in the wal" in imessage.messages(db=chat)["text"].to_list(), "WAL rows must be visible"
     writer.close()
+
+    # reply threading, tapbacks, edits, and unsends: insert one of each and assert
+    # messages() resolves a threaded reply to its originator and decodes the rest.
+    con = sqlite3.connect(chat)
+    cols2 = "(ROWID, guid, date, text, attributedBody, is_from_me, is_read, service, handle_id, thread_originator_guid, associated_message_guid, associated_message_type, date_edited, date_retracted)"
+    t3 = datetime(2024, 1, 2, 4, 0, 0, tzinfo=timezone.utc)
+    # a threaded reply to message 1 ("plain text"); the originator ref carries a
+    # "p:0/" part prefix that must be stripped back to the bare guid "m1".
+    con.execute("INSERT INTO message " + cols2 + " VALUES (10, 'm10', ?, 'a reply', NULL, 0, 1, 'iMessage', 1, 'p:0/m1', NULL, 0, 0, 0)", (ns(t3),))
+    # a Loved tapback on message 2, and a removed-liked on message 1.
+    con.execute("INSERT INTO message " + cols2 + " VALUES (11, 'm11', ?, 'Loved a message', NULL, 1, 1, 'iMessage', 1, NULL, 'p:0/m2', 2000, 0, 0)", (ns(t3),))
+    con.execute("INSERT INTO message " + cols2 + " VALUES (12, 'm12', ?, 'Removed a like', NULL, 1, 1, 'iMessage', 1, NULL, 'p:0/m1', 3001, 0, 0)", (ns(t3),))
+    # an edited message and an unsent (retracted) message.
+    con.execute("INSERT INTO message " + cols2 + " VALUES (13, 'm13', ?, 'fixed typo', NULL, 1, 1, 'iMessage', 1, NULL, NULL, 0, ?, 0)", (ns(t3), ns(t3)))
+    con.execute("INSERT INTO message " + cols2 + " VALUES (14, 'm14', ?, 'oops', NULL, 1, 1, 'iMessage', 1, NULL, NULL, 0, 0, ?)", (ns(t3), ns(t3)))
+    con.execute("INSERT INTO chat_message_join VALUES (1, 10), (1, 11), (1, 12), (1, 13), (1, 14)")
+    con.commit()
+    con.close()
+
+    thr = imessage.messages(db=chat, limit=50)
+    reply = thr.filter(pl.col("rowid") == 10).row(0, named=True)
+    assert reply["reply_to_guid"] == "m1", reply
+    assert reply["reply_to_rowid"] == 1, reply
+    assert reply["reply_to_text"] == "plain text", reply
+    love = thr.filter(pl.col("rowid") == 11).row(0, named=True)
+    assert love["tapback"] == "loved" and love["tapback_target_guid"] == "m2", love
+    removed = thr.filter(pl.col("rowid") == 12).row(0, named=True)
+    assert removed["tapback"] == "removed-liked" and removed["tapback_target_guid"] == "m1", removed
+    assert thr.filter(pl.col("rowid") == 13)["edited"][0] is True
+    assert thr.filter(pl.col("rowid") == 14)["unsent"][0] is True
+    # a plain message carries none of this metadata.
+    plain = thr.filter(pl.col("rowid") == 1).row(0, named=True)
+    assert plain["reply_to_guid"] is None and plain["tapback"] is None, plain
+    assert plain["edited"] is False and plain["unsent"] is False, plain
 
     # contacts: phones/emails aggregate into list columns under one display name.
     ab = os.path.join(work, "ab.abcddb")

--- a/packages/mcp/src/imessage/imessage/__init__.py
+++ b/packages/mcp/src/imessage/imessage/__init__.py
@@ -317,12 +317,37 @@ def _tapback(assoc_type: int | None) -> str | None:
     if not assoc_type:
         return None
     base, offset = divmod(assoc_type, 1000)
+    if base not in (2, 3):  # only 2xxx (add) and 3xxx (remove) are tapbacks
+        return None
     name = _TAPBACKS.get(offset)
     if name is None:
         return None
-    if base == 3:
-        return f"removed-{name}"
-    return name
+    return f"removed-{name}" if base == 3 else name
+
+
+# These message columns arrived in later macOS releases (thread_originator_guid in
+# macOS 11, date_edited / date_retracted in macOS 13), so an older chat.db lacks
+# them. Each is selected only when present, with NULL otherwise, so reading a
+# legacy database degrades to empty reply/tapback/edit fields instead of raising
+# "no such column".
+_OPTIONAL_COLUMNS = (
+    ("thread_originator_guid", "reply_to_raw"),
+    ("associated_message_guid", "assoc_guid"),
+    ("associated_message_type", "assoc_type"),
+    ("date_edited", "date_edited"),
+    ("date_retracted", "date_retracted"),
+)
+
+
+def _optional_columns(con: sqlite3.Connection) -> str:
+    """The SELECT fragment for version-gated message columns, NULL where absent."""
+
+    present = {row[1] for row in con.execute("PRAGMA table_info(message)")}
+    indent = ",\n" + " " * 19
+    return indent.join(
+        f"m.{name} AS {alias}" if name in present else f"NULL AS {alias}"
+        for name, alias in _OPTIONAL_COLUMNS
+    )
 
 
 def messages(
@@ -384,15 +409,13 @@ def messages(
             clauses.append("m.date <= ?")
             params.append(_apple_ns(until))
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        optional_cols = _optional_columns(con)
         sql = f"""
             SELECT m.ROWID AS rowid, m.guid AS guid, m.date AS date, m.text AS text,
                    m.attributedBody AS attributed_body,
                    m.is_from_me AS is_from_me, m.is_read AS is_read,
                    m.service AS service, h.id AS handle,
-                   m.thread_originator_guid AS reply_to_raw,
-                   m.associated_message_guid AS assoc_guid,
-                   m.associated_message_type AS assoc_type,
-                   m.date_edited AS date_edited, m.date_retracted AS date_retracted,
+                   {optional_cols},
                    c.ROWID AS chat_id, c.display_name AS chat_name,
                    c.chat_identifier AS chat_identifier,
                    (SELECT COUNT(*) FROM message_attachment_join maj

--- a/packages/mcp/src/imessage/imessage/__init__.py
+++ b/packages/mcp/src/imessage/imessage/__init__.py
@@ -284,6 +284,47 @@ def _apple_ns(when: datetime | str) -> int:
     return int(when.timestamp() * 1_000_000_000) - _APPLE_EPOCH_NS
 
 
+# A reply or tapback references another message by GUID, sometimes prefixed with
+# the message *part* it points at: "p:<part>/<guid>" for one part of a balloon,
+# "bp:<guid>" for the whole balloon. Only the bare GUID joins back to `message.guid`.
+_ASSOC_PREFIX = re.compile(r"^(?:p:\d+/|bp:)")
+
+
+def _bare_guid(value: str | None) -> str | None:
+    """The bare message GUID from a reply/tapback reference, any part prefix stripped."""
+
+    if not value:
+        return None
+    return _ASSOC_PREFIX.sub("", value)
+
+
+# `associated_message_type` encodes a tapback: 2000-2007 add one, 3000-3007 retract
+# the matching one. The low digit is the reaction; the thousands digit is add (2)
+# vs. remove (3), so one table keyed on the offset covers both.
+_TAPBACKS = {
+    0: "loved", 1: "liked", 2: "disliked", 3: "laughed",
+    4: "emphasized", 5: "questioned", 6: "emoji", 7: "sticker",
+}
+
+
+def _tapback(assoc_type: int | None) -> str | None:
+    """A tapback label for `associated_message_type`, or None for a real message.
+
+    ``0`` is an ordinary message; ``2000``-``2007`` are tapbacks and
+    ``3000``-``3007`` retract the matching one (``"removed-loved"``).
+    """
+
+    if not assoc_type:
+        return None
+    base, offset = divmod(assoc_type, 1000)
+    name = _TAPBACKS.get(offset)
+    if name is None:
+        return None
+    if base == 3:
+        return f"removed-{name}"
+    return name
+
+
 def messages(
     *,
     contact: str | None = None,
@@ -297,9 +338,14 @@ def messages(
 ) -> pl.DataFrame:
     """Messages from ``chat.db`` as a polars DataFrame, newest first.
 
-    Columns: ``rowid``, ``date`` (UTC datetime), ``name`` (resolved contact name
-    or None), ``handle`` (phone/email of the other party), ``is_from_me`` (bool),
-    ``text`` (decoded from ``attributedBody`` when needed), ``service``
+    Columns: ``rowid``, ``guid``, ``date`` (UTC datetime), ``name`` (resolved
+    contact name or None), ``handle`` (phone/email of the other party),
+    ``is_from_me`` (bool), ``text`` (decoded from ``attributedBody`` when needed),
+    ``reply_to_guid`` / ``reply_to_rowid`` / ``reply_to_text`` (the message this
+    one is a threaded reply to, resolved; all None when it is not a reply),
+    ``tapback`` (``"loved"`` / ``"removed-liked"`` / ... for a reaction, else
+    None) and ``tapback_target_guid`` (the message it reacts to), ``edited`` and
+    ``unsent`` (bool, from ``date_edited`` / ``date_retracted``), ``service``
     (``iMessage`` / ``SMS``), ``chat_id``, ``chat_name``, ``chat_identifier``,
     ``is_read`` (bool), ``n_attachments``.
 
@@ -339,10 +385,14 @@ def messages(
             params.append(_apple_ns(until))
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
         sql = f"""
-            SELECT m.ROWID AS rowid, m.date AS date, m.text AS text,
+            SELECT m.ROWID AS rowid, m.guid AS guid, m.date AS date, m.text AS text,
                    m.attributedBody AS attributed_body,
                    m.is_from_me AS is_from_me, m.is_read AS is_read,
                    m.service AS service, h.id AS handle,
+                   m.thread_originator_guid AS reply_to_raw,
+                   m.associated_message_guid AS assoc_guid,
+                   m.associated_message_type AS assoc_type,
+                   m.date_edited AS date_edited, m.date_retracted AS date_retracted,
                    c.ROWID AS chat_id, c.display_name AS chat_name,
                    c.chat_identifier AS chat_identifier,
                    (SELECT COUNT(*) FROM message_attachment_join maj
@@ -356,21 +406,33 @@ def messages(
             LIMIT ?
         """
         rows = con.execute(sql, [*params, int(limit)]).fetchall()
+        reply_to = _resolve_reply_targets(con, rows)
     finally:
         con.close()
 
     records = []
     name_index = _name_index(None) if resolve_names else {}
     for r in rows:
-        (rowid, date, t, ab, is_from_me, is_read, service, handle,
+        (rowid, guid, date, t, ab, is_from_me, is_read, service, handle,
+         reply_to_raw, assoc_guid, assoc_type, date_edited, date_retracted,
          chat_id, chat_name, chat_identifier, n_att) = r
+        reply_to_guid = _bare_guid(reply_to_raw)
+        target_rowid, target_text = reply_to.get(reply_to_guid, (None, None))
         records.append({
             "rowid": rowid,
+            "guid": guid,
             "date": date,
             "name": name_index.get(_norm(handle)),
             "handle": handle,
             "is_from_me": bool(is_from_me),
             "text": t if t is not None else _decode_attributed_body(ab),
+            "reply_to_guid": reply_to_guid,
+            "reply_to_rowid": target_rowid,
+            "reply_to_text": target_text,
+            "tapback": _tapback(assoc_type),
+            "tapback_target_guid": _bare_guid(assoc_guid),
+            "edited": bool(date_edited),
+            "unsent": bool(date_retracted),
             "service": service,
             "chat_id": chat_id,
             "chat_name": chat_name,
@@ -383,11 +445,38 @@ def messages(
     return pl.DataFrame(records, schema=_MESSAGE_SCHEMA).with_columns(_to_datetime("date").alias("date"))
 
 
+def _resolve_reply_targets(
+    con: sqlite3.Connection, rows: list[tuple]
+) -> dict[str, tuple[int, str | None]]:
+    """Map each replied-to GUID in ``rows`` to its ``(rowid, text)``.
+
+    A threaded reply only stores the originator's GUID; one extra query resolves
+    those GUIDs to the original message's row id and decoded text so a reply is
+    readable on its own. ``reply_to_raw`` is the 10th selected column.
+    """
+
+    wanted = {_bare_guid(r[9]) for r in rows}
+    wanted.discard(None)
+    if not wanted:
+        return {}
+    placeholders = ",".join("?" * len(wanted))
+    resolved: dict[str, tuple[int, str | None]] = {}
+    for guid, rowid, text, ab in con.execute(
+        f"SELECT guid, ROWID, text, attributedBody FROM message WHERE guid IN ({placeholders})",
+        list(wanted),
+    ):
+        resolved[guid] = (rowid, text if text is not None else _decode_attributed_body(ab))
+    return resolved
+
+
 _MESSAGE_SCHEMA = {
-    "rowid": pl.Int64, "date": pl.Int64, "name": pl.Utf8, "handle": pl.Utf8,
-    "is_from_me": pl.Boolean, "text": pl.Utf8, "service": pl.Utf8,
-    "chat_id": pl.Int64, "chat_name": pl.Utf8, "chat_identifier": pl.Utf8,
-    "is_read": pl.Boolean, "n_attachments": pl.Int64,
+    "rowid": pl.Int64, "guid": pl.Utf8, "date": pl.Int64, "name": pl.Utf8,
+    "handle": pl.Utf8, "is_from_me": pl.Boolean, "text": pl.Utf8,
+    "reply_to_guid": pl.Utf8, "reply_to_rowid": pl.Int64, "reply_to_text": pl.Utf8,
+    "tapback": pl.Utf8, "tapback_target_guid": pl.Utf8,
+    "edited": pl.Boolean, "unsent": pl.Boolean,
+    "service": pl.Utf8, "chat_id": pl.Int64, "chat_name": pl.Utf8,
+    "chat_identifier": pl.Utf8, "is_read": pl.Boolean, "n_attachments": pl.Int64,
 }
 
 


### PR DESCRIPTION
## What

`imessage.messages()` returned one flat row per message and dropped the
relationships that make a conversation readable. This adds columns resolved
directly from `chat.db`:

- `guid`, `reply_to_guid`, `reply_to_rowid`, `reply_to_text`: a threaded reply
  (`thread_originator_guid`, with its `p:<part>/` prefix stripped) now resolves
  to the originator's row id and decoded text.
- `tapback` (`loved` / `removed-liked` / ...) and `tapback_target_guid` from
  `associated_message_type` / `associated_message_guid`.
- `edited` and `unsent` from `date_edited` / `date_retracted`.

## Why

A reply, reaction, edit, or unsend was previously invisible or showed as an
opaque "Loved ..." row. These are the relationships you actually read a thread
by.

## Test

The hermetic smoke test (`mcp.passthru.tests.imessageSmoke`) gains a threaded
reply, a tapback and a removed tapback, an edit, and an unsend, plus unit checks
for `_bare_guid` prefix stripping and `_tapback` decoding. Built green on
aarch64-darwin.

Closes #953

The write half (reply / edit / unsend over the wire) is blocked on an entitled
sender and tracked separately in #954.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface reply threading, edits, unsends, and tapbacks in iMessage `messages()`
> - Extends `messages()` in [`imessage/__init__.py`](https://github.com/indexable-inc/index/pull/955/files#diff-3a3674149c65edcf48f5351586e5225e834cbb3aaa1e8818556d34dcb868deed) to return new columns: `guid`, `reply_to_guid`, `reply_to_rowid`, `reply_to_text`, `tapback`, `tapback_target_guid`, `edited`, and `unsent`.
> - Adds `_bare_guid` to strip association prefixes (`p:<part>/`, `bp:`) from GUIDs, and `_tapback` to decode `associated_message_type` into normalized labels like `'loved'` or `'removed-liked'`.
> - Adds `_optional_columns` to detect missing schema columns via `PRAGMA table_info(message)` and substitute `NULL` aliases, so older `chat.db` files without thread/tapback/edit columns continue to work.
> - Adds `_resolve_reply_targets` to look up reply originator GUIDs and return their row IDs and decoded text for display alongside replies.
> - Behavioral Change: `messages()` now returns a wider schema; callers that expect a fixed set of columns will receive additional fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f32a92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->