### PR TITLE
Fix pi harness runtime binary and text deltas

### DIFF
--- a/packages/pi-harness/default.nix
+++ b/packages/pi-harness/default.nix
@@ -246,7 +246,7 @@ stdenv.mkDerivation {
             "PI_HARNESS_SYSTEM_PROMPT",
             ${builtins.toJSON defaultSystemPrompt}
           );
-          const char *pi = ${builtins.toJSON piCommand};
+          const char *pi = env_or_default("PI_HARNESS_PI_BIN", ${builtins.toJSON piCommand});
           const char *extension = ${builtins.toJSON "${extension}/ix-mcp-bridge.ts"};
           const char *python = ${builtins.toJSON pythonCommand};
           const char *mapper = ${builtins.toJSON mapper};

--- a/packages/pi-harness/room_event_mapper.py
+++ b/packages/pi-harness/room_event_mapper.py
@@ -69,6 +69,20 @@ def _event_type(event: Json) -> str | None:
     return None
 
 
+def _room_event_type(event: Json, pi_type: str | None) -> str:
+    if pi_type == "message_update":
+        nested = event.get("assistantMessageEvent")
+        nested_type = nested.get("type") if isinstance(nested, dict) else None
+        if nested_type == "text_delta":
+            return "text_delta"
+        if nested_type in {"reasoning_delta", "thinking_delta"}:
+            return "reasoning_delta"
+        if nested_type is None and _text_delta(event) is not None:
+            return "text_delta"
+        return "pi_event"
+    return PI_TO_ROOM_EVENTS.get(pi_type or "", "pi_event")
+
+
 def _text_delta(event: Json) -> str | None:
     for key in ("delta", "text", "content"):
         value = event.get(key)
@@ -86,7 +100,7 @@ def _text_delta(event: Json) -> str | None:
 
 def map_pi_event(event: Json) -> Json:
     pi_type = _event_type(event)
-    room_type = PI_TO_ROOM_EVENTS.get(pi_type or "", "pi_event")
+    room_type = _room_event_type(event, pi_type)
     mapped: Json = {"type": room_type, "source": "pi", "raw": event}
 
     if pi_type is not None:

--- a/packages/pi-harness/room_event_mapper_test.py
+++ b/packages/pi-harness/room_event_mapper_test.py
@@ -59,6 +59,19 @@ class MapperTest(unittest.TestCase):
         text = mapper.map_pi_event({"type": "message_update", "delta": "hi"})
         self.assertEqual(text["type"], "text_delta")
         self.assertEqual(text["delta"], "hi")
+        text_start = mapper.map_pi_event(
+            {"type": "message_update", "assistantMessageEvent": {"type": "text_start"}}
+        )
+        self.assertEqual(text_start["type"], "pi_event")
+        text_delta = mapper.map_pi_event(
+            {"type": "message_update", "assistantMessageEvent": {"type": "text_delta", "delta": "hi"}}
+        )
+        self.assertEqual(text_delta["type"], "text_delta")
+        self.assertEqual(text_delta["delta"], "hi")
+        text_end = mapper.map_pi_event(
+            {"type": "message_update", "assistantMessageEvent": {"type": "text_end", "delta": "hi"}}
+        )
+        self.assertEqual(text_end["type"], "pi_event")
         self.assertEqual(mapper.map_pi_event({"type": "tool_execution_start", "id": "t1"})["type"], "tool_call_started")
         self.assertEqual(mapper.map_pi_event({"type": "turn_end"})["type"], "turn_completed")
 


### PR DESCRIPTION
## Summary
- let pi-harness use PI_HARNESS_PI_BIN so Room/deploy can point at the raw Pi CLI instead of the ix convenience wrapper
- keep Pi text_start/text_end message_update events out of Room text deltas so final text is not duplicated
- cover the mapper behavior in tests

## Validation
- python3 packages/pi-harness/room_event_mapper_test.py
- nix build /home/rathi/Documents/Git/indexable/index#pi-harness --no-link --print-out-paths --accept-flake-config
- raw Pi/Codex provider smoke with supplied OPENAI_API_KEY returned exactly pi-codex-ok
- rebuilt pi-harness JSON smoke with raw Pi + fake MCP emitted turn_started/text_delta/turn_completed and aggregated text exactly pi-codex-ok
- ix room-server smoke using ROOM_PI_BIN=<rebuilt pi-harness>, PI_HARNESS_PI_BIN=<raw pi>, IX_MCP_BIN=<fake MCP>, engine pi/model codex persisted assistant_text exactly pi-codex-room-ok


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pi harness binary path override and message_update event type mapping
> - The pi binary path in [default.nix](https://github.com/indexable-inc/index/pull/964/files#diff-f442c7cf04ca1885536551a7a706b8819baad3abf3e9fdd17d68546016c76096) is now read from the `PI_HARNESS_PI_BIN` environment variable, falling back to the previous hardcoded default.
> - `message_update` events in [room_event_mapper.py](https://github.com/indexable-inc/index/pull/964/files#diff-22973fd261f4acfc9d1ca991e65ef4ac2d720a010c44f228a6facc86861915da) are now classified by inspecting the nested `assistantMessageEvent` object: `text_delta` maps to `text_delta`, `reasoning_delta`/`thinking_delta` maps to `reasoning_delta`, and other nested types map to `pi_event`.
> - The `map_pi_event` function uses the new `_room_event_type` helper instead of a direct lookup in `PI_TO_ROOM_EVENTS` for `message_update` events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4503f4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->