### PR TITLE
Add Claude and ix-mcp to Symphony image

### DIFF
--- a/images/dev/symphony-codex/default.nix
+++ b/images/dev/symphony-codex/default.nix
@@ -1,4 +1,21 @@
-{ ix, pkgs, ... }:
+{
+  ix,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  # Claude Code refuses bypass-permissions mode for the root user unless it is
+  # told it is sandboxed. Symphony agents run as root inside this disposable VM,
+  # so use the same narrow wrapper as development-base instead of a global env
+  # variable.
+  claude-code =
+    pkgs.runCommand "claude-code-${pkgs.claude-code.version}"
+      { nativeBuildInputs = [ pkgs.makeWrapper ]; }
+      ''
+        makeWrapper ${pkgs.claude-code}/bin/claude "$out/bin/claude" --set IS_SANDBOX 1
+      '';
+in
 {
   ix.image = {
     name = "ix/symphony-codex";
@@ -29,10 +46,17 @@
     ];
   };
 
+  # Claude Code ships under Anthropic's commercial terms (unfree in nixpkgs).
+  # Keep the exception scoped to that package; mcp and codex are repo/open
+  # packages.
+  nixpkgs.config.allowUnfreePredicate =
+    pkg: builtins.elem (pkg.pname or (lib.getName pkg)) [ "claude-code" ];
+
   environment.systemPackages = [
     pkgs.ast-grep
     pkgs.bashInteractive
     pkgs.cacert
+    claude-code
     pkgs.cmake
     pkgs.codex
     pkgs.coreutils
@@ -49,6 +73,7 @@
     pkgs.gnutar
     pkgs.gzip
     pkgs.jaq
+    pkgs.mcp
     pkgs.nodejs_24
     pkgs.openssh
     pkgs.pkg-config


### PR DESCRIPTION
## Summary
- add a sandbox-signaling Claude Code wrapper to the symphony-codex image
- include the vendored index ix-mcp package so pi/ix MCP tooling is available inside Symphony iXVM runs
- keep the unfree exception scoped to claude-code

## Validation
- git diff --check
- nix-instantiate --parse images/dev/symphony-codex/default.nix

## Deployment
After merge, rebuild/push the symphony image used by prod Symphony as ix/symphony-codex:latest in us-west-1.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Claude CLI and `ix-mcp` to the Symphony image
> - Adds a `claude` binary to the Symphony image by wrapping `claude-code` with `makeWrapper`, setting `IS_SANDBOX=1` at execution time.
> - Adds `pkgs.mcp` to the image's system packages.
> - Permits the unfree `claude-code` package via a scoped `allowUnfreePredicate` in [default.nix](https://github.com/indexable-inc/index/pull/965/files#diff-fa98741b6cea42742963877e10afa3971317522ac8a23331307fedfee04b1101).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23fade9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->