### PR TITLE
Add Pi harness to Symphony image

### DIFF
--- a/images/dev/symphony-codex/default.nix
+++ b/images/dev/symphony-codex/default.nix
@@ -76,6 +76,7 @@ in
     pkgs.mcp
     pkgs.nodejs_24
     pkgs.openssh
+    pkgs.pi-harness
     pkgs.pkg-config
     pkgs.python3
     pkgs.ripgrep


### PR DESCRIPTION
Summary\n- add the existing tuned pkgs.pi-harness to the Symphony codex image\n- no raw Pi package or npm dependency intake in this PR\n\nValidation\n- nix-instantiate --parse images/dev/symphony-codex/default.nix\n- git diff --check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `pi-harness` to the Symphony Codex dev image
> Adds `pkgs.pi-harness` to the package list in [default.nix](https://github.com/indexable-inc/index/pull/966/files#diff-fa98741b6cea42742963877e10afa3971317522ac8a23331307fedfee04b1101), making its binaries available at runtime in the symphony-codex development environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e61544.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->