### PR TITLE
fix(git-log-pretty): bypass the pager when drawing avatars

### DIFF
--- a/packages/git-log-pretty/src/main.rs
+++ b/packages/git-log-pretty/src/main.rs
@@ -144,13 +144,21 @@ fn run_log(allow_pager: bool, want_avatars: bool, avatar_rows: u32) -> Result<()
     )
 }
 
-/// Render the header and commit blocks, paging like `git log`.
+/// Render the header and commit blocks, paging like `git log` unless avatars
+/// are drawn.
 ///
 /// When avatars are enabled (a graphics terminal, a real TTY, and not opted
 /// out), each unique author image is transmitted to the terminal once, up
-/// front, as a kitty Unicode-placeholder virtual placement. The paged text then
-/// only carries placeholder cells, which are ordinary characters, so the log
-/// pages and scrolls with the avatars in place instead of bypassing the pager.
+/// front, as a kitty Unicode-placeholder virtual placement, and the commit
+/// gutter is rendered with placeholder cells that resolve to it.
+///
+/// Those cells must reach the terminal verbatim, so a graphics log bypasses the
+/// pager and writes straight to stdout, leaning on the terminal's own
+/// scrollback. A screen-repainting pager (`less`) redraws each line with its own
+/// cursor and SGR state, which severs a placeholder cell from the foreground
+/// color that carries its image id (and its alternate screen keeps a separate,
+/// empty image store), so the avatars collapse into replacement glyphs. Without
+/// avatars there are no such cells, so the plain log pages like `git log`.
 fn emit_log(
     repo: &git2::Repository,
     header: &str,
@@ -169,9 +177,9 @@ fn emit_log(
         .then(|| fetch_avatars(repo, commits).ok())
         .flatten();
 
-    // Transmit the pixels before the pager starts drawing, so the placeholder
-    // cells it later prints have an image to resolve against. If that write to
-    // the terminal fails, drop the avatars and page the plain log rather than
+    // Transmit the pixels before any output is drawn, so the placeholder cells
+    // printed later have an image to resolve against. If that write to the
+    // terminal fails, drop the avatars and render the plain log rather than
     // erroring out, matching the fetch-failure fallback above.
     if let Some(images) = &fetched
         && transmit_avatars(images, avatar_rows).is_err()
@@ -179,7 +187,14 @@ fn emit_log(
         fetched = None;
     }
 
-    pager::paged(allow_pager, |out| {
+    // Graphics bypass the pager: placeholder cells only survive when written to
+    // the terminal verbatim, so once we are actually drawing an avatar we skip
+    // the pager (see this function's docs). A plain log still pages.
+    let drawing_avatars = fetched
+        .as_ref()
+        .is_some_and(|fetched| fetched.iter().any(Option::is_some));
+
+    pager::paged(allow_pager && !drawing_avatars, |out| {
         writeln!(out, "{}\n", paint(fg(Color::Ansi(AnsiColor::Cyan)), header))?;
         for (index, commit) in commits.iter().enumerate() {
             match fetched.as_ref().and_then(|fetched| fetched.get(index)) {
@@ -201,7 +216,7 @@ fn emit_log(
 
 /// Transmit each unique avatar's pixels to the terminal as a kitty virtual
 /// placement, sized to the avatar box. Writes straight to stdout (the TTY) and
-/// flushes, so the images are stored before the pager prints any placeholders.
+/// flushes, so the images are stored before any placeholder cell is printed.
 fn transmit_avatars(fetched: &[Option<avatar::Avatar>], rows: u32) -> Result<()> {
     let cols = display::avatar_cols(rows);
     let mut out = std::io::stdout().lock();


### PR DESCRIPTION
## What

`git-log-pretty` draws broken white boxes where author avatars should be when
the log is paged through `less` (the default `$PAGER`). Reported with a
multi-line starship prompt; a short "blank page" log looked fine.

## Root cause

PR #538 routed the avatar gutter *through* the pager. Avatars are kitty
**Unicode-placeholder** cells: the image is transmitted once as a virtual
placement, then each gutter cell carries the image id in its foreground color
plus row/column diacritics. Those cells only resolve when they reach the
terminal **verbatim**.

`less` repaints the screen with its own cursor and SGR state, which severs a
placeholder cell from the foreground color that carries its image id (and its
alternate screen keeps a separate, empty image store). The cells fall back to
the `U+10EEEE` replacement glyph: the boxes in the report. It only shows when
`less` actually paints; with `cat`, or when `less -F` quits because the output
fits one screen, the bytes pass through untouched, hence "blank page works,
longer log breaks".

## Fix

Restore the rule the codebase already learned (graphics bypass the pager): once
an avatar is actually drawn, write straight to the terminal and lean on its own
scrollback. A plain log (no graphics terminal, no TTY, or `--no-avatar`) still
pages like `git log`.

## Verification

- Built and run in a real ghostty PTY (`TERM_PROGRAM=ghostty`):
  - `PAGER=less` **old** binary spawns `less` and mangles the gutter (32 of 120
    placeholder cells survive, mouse-tracking enabled).
  - `PAGER=less` **fixed** binary emits all 120 intact placeholder cells with no
    `less` involvement, identical to `PAGER=cat` and `--no-pager`.
- `cargo test -p git-log-pretty -p kitty`: 24 + 7 + 8 unit/integration + 1 doctest pass.
- `cargo fmt --check` clean; stock clippy (all/pedantic/nursery) clean on the
  changed code.

Made with Claude Opus 4.8.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bypass the pager in `emit_log` when avatar images are present
> Terminal pagers intercept stdout in a way that breaks kitty image protocol rendering. When at least one avatar is available, `emit_log` now writes directly to stdout instead of invoking the pager; when no avatars will be drawn, paging behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b609f9a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->