### PR TITLE
Add an x module to read recent X posts into polars

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -335,6 +335,27 @@ let
         cp -r ${browserPythonSource}/browser/. "$site/"
       ''
   );
+  # Read recent X (Twitter) posts into polars by driving the logged-in browser:
+  # `import x`, then `await x.posts("@handle")` / `x.posts("home")` navigates the
+  # browser `browser` connects to, scrolls until it has enough tweets, and parses
+  # them into a polars frame. Pure Python over the bundled browser/playwright/polars
+  # (X has no usable unauthenticated read API); cross-platform.
+  xPythonSource = builtins.path {
+    name = "ix-mcp-x-python-source";
+    path = ./src/x;
+  };
+  xModule = pkgs.python3.pkgs.toPythonModule (
+    pkgs.runCommand "ix-mcp-x-python-module"
+      {
+        strictDeps = true;
+        meta.description = "Read recent X posts to polars via the logged-in browser, bundled into the ix-mcp interpreter";
+      }
+      ''
+        site="$out/${pkgs.python3.sitePackages}/x"
+        mkdir -p "$site"
+        cp -r ${xPythonSource}/x/. "$site/"
+      ''
+  );
   # Git worktrees as the unit of isolated work: `import worktree`, then
   # `wt = await worktree.add("my-fix")` checks out a new branch in its own tree,
   # `await wt.build(".#mcp")` stages + nix-builds it, `worktree.list()` is a
@@ -584,6 +605,7 @@ let
       shModule
       worktreeModule
       browserModule
+      xModule
       tasksModule
     ]
     ++ darwinExtraPackages ps
@@ -3046,6 +3068,7 @@ let
   screenBundled = importTest "screen" "import screen; print('screen-ok', all(callable(getattr(screen, n)) for n in ('capture', 'click', 'write', 'press', 'key_down', 'key_up', 'apps', 'frontmost', 'launch', 'activate', 'terminate', 'accessibility_trusted')))";
   vmkitBundled = importTest "vmkit" "import vmkit; print('vmkit-ok', callable(vmkit.boot_linux), callable(vmkit.drive), callable(vmkit.screenshot))";
   imessageBundled = importTest "imessage" "import imessage; print('imessage-ok', all(callable(getattr(imessage, n)) for n in ('messages', 'chats', 'contacts', 'send')))";
+  xBundled = importTest "x" "import x; print('x-ok', callable(x.posts), x.__version__)";
 in
 package.overrideAttrs (old: {
   passthru = (old.passthru or { }) // {
@@ -3077,6 +3100,7 @@ package.overrideAttrs (old: {
         worktreeSmoke
         browserSmoke
         browserVdomSmoke
+        xBundled
         ;
       site = dashboardSite;
     }

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -82,7 +82,7 @@ MODULES: tuple[Module, ...] = (
         "x",
         "read recent X (Twitter) posts into polars by driving your logged-in browser: "
         "`x.posts(\"@handle\")` / `x.posts(\"home\")` / `x.posts(\"#tag\")` / a thread URL, "
-        "scrolled until it has `limit` tweets (one row each, with author, time, text and counts)",
+        "scrolled until it has `limit` tweets (one row each, with author, time, text and counts). Reads the signed-in account's personal feed, so incognito sessions only (a shared room never sees your timeline)",
     ),
 )
 

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -78,6 +78,12 @@ MODULES: tuple[Module, ...] = (
         "`await google_auth.login()` signs in through your browser and `status()` / `logout()` "
         "manage the grant. Incognito sessions only (a personal mailbox never reaches a shared room)",
     ),
+    Module(
+        "x",
+        "read recent X (Twitter) posts into polars by driving your logged-in browser: "
+        "`x.posts(\"@handle\")` / `x.posts(\"home\")` / `x.posts(\"#tag\")` / a thread URL, "
+        "scrolled until it has `limit` tweets (one row each, with author, time, text and counts)",
+    ),
 )
 
 # Always-present namespace builtins (installed by runtime.install; no import).

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -81,7 +81,7 @@ MODULES: tuple[Module, ...] = (
     Module(
         "x",
         "read recent X (Twitter) posts into polars by driving your logged-in browser: "
-        "`x.posts(\"@handle\")` / `x.posts(\"home\")` / `x.posts(\"#tag\")` / a thread URL, "
+        "`await x.posts(\"@handle\")` / `await x.posts(\"home\")` / `await x.posts(\"#tag\")` / a thread URL, "
         "scrolled until it has `limit` tweets (one row each, with author, time, text and counts). Reads the signed-in account's personal feed, so incognito sessions only (a shared room never sees your timeline)",
     ),
 )

--- a/packages/mcp/src/x/x/__init__.py
+++ b/packages/mcp/src/x/x/__init__.py
@@ -152,18 +152,37 @@ _EXTRACT_JS = r"""
 """
 
 
+# X/Twitter is the only site this reader is allowed to drive: it is advertised
+# and permission-gated as an X reader and reuses the signed-in browser, so a full
+# URL must point at X, never an arbitrary site. Accept x.com / twitter.com and any
+# subdomain (mobile., www., pro., ...).
+def _is_x_host(host: str) -> bool:
+    host = host.lower().rsplit(":", 1)[0]
+    return host in ("x.com", "twitter.com") or host.endswith((".x.com", ".twitter.com"))
+
+
 def _resolve(source: str | None) -> str:
     """Turn a friendly ``source`` into the x.com URL to open.
 
-    ``None`` is the home timeline. A full ``http(s)`` URL is used as-is. A bare
-    keyword (``"home"``, ``"notifications"``, ...) maps to its timeline. ``"@name"``
-    is a profile; ``"#tag"`` or any other text is a search.
+    ``None`` is the home timeline. A full ``http(s)`` URL is used as-is, but only
+    if it points at X/Twitter (this reader is gated to X and drives the signed-in
+    browser, so it refuses to navigate anywhere else). A bare keyword (``"home"``,
+    ``"notifications"``, ...) maps to its timeline. ``"@name"`` is a profile;
+    ``"#tag"`` or any other text is a search.
     """
 
     if not source:
         return _NAMED["home"]
     s = source.strip()
     if s.startswith(("http://", "https://")):
+        from urllib.parse import urlparse
+        host = urlparse(s).hostname or ""
+        if not _is_x_host(host):
+            raise ValueError(
+                f"x.posts only reads X/Twitter URLs, not {host!r}. Pass an "
+                "x.com/twitter.com link, a \"@handle\", a \"#tag\" or search "
+                "text, or a timeline keyword like \"home\"."
+            )
         return s
     low = s.lower()
     if low in _NAMED:

--- a/packages/mcp/src/x/x/__init__.py
+++ b/packages/mcp/src/x/x/__init__.py
@@ -33,6 +33,7 @@ signed out. Cross-platform.
 from __future__ import annotations
 
 import asyncio
+import os
 
 import polars as pl
 
@@ -46,12 +47,35 @@ __version__ = "0.1.0"
 DEFAULT_ENDPOINT = browser.DEFAULT_ENDPOINT
 DEFAULT_APP = browser.DEFAULT_APP
 
+# A shared (multiplayer) room marks the MCP it replicates across participants with
+# this env var. Reading X timelines/notifications/bookmarks exposes the signed-in
+# account's personal data, so -- like `google_auth` -- it is confined to incognito
+# sessions (the default for a plain ix-mcp); only a truthy value refuses access.
+SHARED_ENV = "IX_MCP_SHARED"
+
+
+def _require_incognito() -> None:
+    """Refuse to read personal X data in a shared (multiplayer) room.
+
+    `x.posts()` reads whatever the signed-in browser can see (home timeline,
+    notifications, bookmarks, a private account's posts), so a shared room would
+    leak one person's feed into state everyone can see. A shared room sets
+    ``IX_MCP_SHARED``; only then is access refused.
+    """
+    if os.environ.get(SHARED_ENV):
+        raise RuntimeError(
+            "x.posts is not available in a shared (multiplayer) room "
+            "(IX_MCP_SHARED is set), because it would expose the signed-in "
+            "X account's personal feed to everyone in the room. Use it from an "
+            "incognito chat instead; its transcript stays private to you."
+        )
+
 # Named timeline shortcuts: a bare keyword maps to its x.com path. Anything else
 # is treated as a handle (leading "@"), a search ("#tag" or free text), or a URL.
 _NAMED = {
     "home": "https://x.com/home",
     "notifications": "https://x.com/notifications",
-    "bookmarks": "https://i.x.com/bookmarks",
+    "bookmarks": "https://x.com/i/bookmarks",
     "explore": "https://x.com/explore",
     "following": "https://x.com/home",
 }
@@ -180,8 +204,13 @@ async def posts(
     Drives the browser :mod:`browser` connects to (``endpoint``), launching ``app``
     if nothing is listening. Reading a signed-in timeline needs that browser signed
     in to X. Returns an empty (correctly typed) frame when no posts are found.
+
+    Reads the signed-in account's personal feed, so it is confined to incognito
+    sessions: in a shared (multiplayer) room (``IX_MCP_SHARED`` set) it raises
+    rather than leak one person's timeline into shared state.
     """
 
+    _require_incognito()
     url = _resolve(source)
     await browser.get_or_create_browser(endpoint=endpoint, app=app)
     page = await browser.goto(url, endpoint=endpoint, wait_until="domcontentloaded", timeout=timeout * 1000)

--- a/packages/mcp/src/x/x/__init__.py
+++ b/packages/mcp/src/x/x/__init__.py
@@ -234,17 +234,13 @@ async def posts(
     await browser.get_or_create_browser(endpoint=endpoint, app=app, timeout=timeout)
     # Open a dedicated tab (``new=True``) rather than reusing the shared front
     # tab: the runtime runs jobs concurrently, so two reads sharing one tab would
-    # clobber each other's navigation and scroll. Close it in ``finally`` so
-    # repeated reads do not pile up tabs.
-    page = await browser.goto(
-        url,
-        endpoint=endpoint,
-        new=True,
-        wait_until="domcontentloaded",
-        timeout=timeout * 1000,
-    )
+    # clobber each other's navigation and scroll. Acquire the tab *before*
+    # navigating so the ``finally`` below closes it even when ``goto`` itself
+    # fails (a navigation timeout would otherwise leak the tab).
+    page = await browser.page(endpoint=endpoint, new=True)
 
     try:
+        await page.goto(url, wait_until="domcontentloaded", timeout=timeout * 1000)
         try:
             await page.wait_for_selector("article", timeout=timeout * 1000)
         except Exception:

--- a/packages/mcp/src/x/x/__init__.py
+++ b/packages/mcp/src/x/x/__init__.py
@@ -10,12 +10,12 @@ posts, and parses the rendered tweets into a ``polars`` DataFrame.
 
     import x
 
-    x.posts()                      # your home timeline, most recent first
-    x.posts("@andrewgazelka")      # a user's recent posts
-    x.posts("notifications")       # your notifications
-    x.posts("#rustlang")           # a search
-    x.posts("rust async runtime")  # any text is a search
-    x.posts("https://x.com/Plambey/status/2064307527114793062")  # a thread
+    await x.posts()                # your home timeline, most recent first
+    await x.posts("@andrewgazelka")  # a user's recent posts
+    await x.posts("notifications")   # your notifications
+    await x.posts("#rustlang")       # a search
+    await x.posts("rust async runtime")  # any text is a search
+    await x.posts("https://x.com/Plambey/status/2064307527114793062")  # a thread
 
 Each call returns one row per post with: ``id``, ``handle``, ``author``,
 ``time`` (UTC datetime), ``text``, ``replies`` / ``reposts`` / ``likes`` /

--- a/packages/mcp/src/x/x/__init__.py
+++ b/packages/mcp/src/x/x/__init__.py
@@ -1,0 +1,226 @@
+"""Read recent X (Twitter) posts into polars, by driving your logged-in browser.
+
+Bundled into the ix-mcp interpreter like ``browser`` and ``view``, so a session
+can ``import x`` with no install step. X has no usable unauthenticated read API
+(the public syndication endpoints now return empty timelines), so this module
+reads what you can actually see: it drives the browser you are already signed in
+to over the Chrome DevTools Protocol -- the same one :mod:`browser` connects to --
+navigates to a timeline, profile, search, or thread, scrolls until it has enough
+posts, and parses the rendered tweets into a ``polars`` DataFrame.
+
+    import x
+
+    x.posts()                      # your home timeline, most recent first
+    x.posts("@andrewgazelka")      # a user's recent posts
+    x.posts("notifications")       # your notifications
+    x.posts("#rustlang")           # a search
+    x.posts("rust async runtime")  # any text is a search
+    x.posts("https://x.com/Plambey/status/2064307527114793062")  # a thread
+
+Each call returns one row per post with: ``id``, ``handle``, ``author``,
+``time`` (UTC datetime), ``text``, ``replies`` / ``reposts`` / ``likes`` /
+``views`` / ``bookmarks`` (counts, when shown), ``url`` (the permalink), and
+``is_reply``. Pass ``limit`` for how many posts to collect (the page is scrolled
+to load more) and ``scroll=False`` to read only what is on screen.
+
+This reuses :mod:`browser`, so the first call connects to a browser already
+listening on the CDP port (``http://127.0.0.1:9222`` by default) or launches a
+visible one (Dia by default). Reading a timeline that requires sign-in needs that
+browser to be signed in to X; a thread or public profile usually reads even
+signed out. Cross-platform.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import polars as pl
+
+import browser
+
+__all__ = ["posts", "DEFAULT_ENDPOINT", "DEFAULT_APP"]
+
+__version__ = "0.1.0"
+
+# Match the browser module's defaults so `x` and `browser` drive the same session.
+DEFAULT_ENDPOINT = browser.DEFAULT_ENDPOINT
+DEFAULT_APP = browser.DEFAULT_APP
+
+# Named timeline shortcuts: a bare keyword maps to its x.com path. Anything else
+# is treated as a handle (leading "@"), a search ("#tag" or free text), or a URL.
+_NAMED = {
+    "home": "https://x.com/home",
+    "notifications": "https://x.com/notifications",
+    "bookmarks": "https://i.x.com/bookmarks",
+    "explore": "https://x.com/explore",
+    "following": "https://x.com/home",
+}
+
+# The post schema, fixed so an empty result still has the right columns/dtypes.
+_SCHEMA: dict[str, pl.DataType] = {
+    "id": pl.Utf8,
+    "handle": pl.Utf8,
+    "author": pl.Utf8,
+    "time": pl.Datetime("us", "UTC"),
+    "text": pl.Utf8,
+    "replies": pl.Int64,
+    "reposts": pl.Int64,
+    "likes": pl.Int64,
+    "views": pl.Int64,
+    "bookmarks": pl.Int64,
+    "url": pl.Utf8,
+    "is_reply": pl.Boolean,
+}
+
+# In-page extraction: one pass over the rendered <article> tweets. Engagement
+# numbers are read from the action bar's aria-label (e.g. "75 replies, 3 reposts,
+# ...") because the visible chips are abbreviated ("1.2K") while the label carries
+# the exact count. Returns plain JSON so the result crosses the CDP bridge cleanly.
+_EXTRACT_JS = r"""
+() => {
+  const norm = s => (s || '').replace(/ /g, ' ').trim();
+  const arts = Array.from(
+    document.querySelectorAll('article[data-testid="tweet"], article[role="article"]')
+  );
+  return arts.map(a => {
+    const textEl = a.querySelector('[data-testid="tweetText"]');
+    const text = textEl ? norm(textEl.innerText) : '';
+
+    let url = null, id = null, time = null;
+    const timeEl = a.querySelector('time');
+    const timeA = timeEl ? timeEl.closest('a') : null;
+    if (timeA) {
+      url = timeA.href;
+      time = timeEl.getAttribute('datetime');
+      const m = url.match(/status\/(\d+)/);
+      if (m) id = m[1];
+    }
+
+    let author = null, handle = null;
+    const nameEl = a.querySelector('[data-testid="User-Name"]');
+    if (nameEl) {
+      const parts = norm(nameEl.innerText).split('\n').map(s => s.trim()).filter(Boolean);
+      author = parts[0] || null;
+      const h = parts.find(p => p.startsWith('@'));
+      handle = h ? h.slice(1) : null;
+    }
+    if (!handle && url) {
+      const m = url.match(/(?:x|twitter)\.com\/([^/]+)\/status/);
+      if (m) handle = m[1];
+    }
+
+    let replies = null, reposts = null, likes = null, views = null, bookmarks = null;
+    const group = a.querySelector('[role="group"][aria-label]');
+    if (group) {
+      const al = group.getAttribute('aria-label').toLowerCase();
+      const grab = re => { const m = al.match(re); return m ? parseInt(m[1].replace(/,/g, '')) : null; };
+      replies = grab(/([\d,]+)\s+repl/);
+      reposts = grab(/([\d,]+)\s+repost/);
+      likes = grab(/([\d,]+)\s+like/);
+      views = grab(/([\d,]+)\s+view/);
+      bookmarks = grab(/([\d,]+)\s+bookmark/);
+    }
+
+    const isReply = /^Replying to/m.test(a.innerText);
+    return { id, handle, author, time, text, replies, reposts, likes, views, bookmarks, url, is_reply: isReply };
+  });
+}
+"""
+
+
+def _resolve(source: str | None) -> str:
+    """Turn a friendly ``source`` into the x.com URL to open.
+
+    ``None`` is the home timeline. A full ``http(s)`` URL is used as-is. A bare
+    keyword (``"home"``, ``"notifications"``, ...) maps to its timeline. ``"@name"``
+    is a profile; ``"#tag"`` or any other text is a search.
+    """
+
+    if not source:
+        return _NAMED["home"]
+    s = source.strip()
+    if s.startswith(("http://", "https://")):
+        return s
+    low = s.lower()
+    if low in _NAMED:
+        return _NAMED[low]
+    if s.startswith("@"):
+        return f"https://x.com/{s[1:]}"
+    if s.startswith("#"):
+        from urllib.parse import quote
+        return f"https://x.com/search?q={quote(s)}&src=typed_query&f=live"
+    # A plain word that looks like a single handle (no spaces) is still ambiguous
+    # with a one-word search; treat free text as a search, which is the safe, most
+    # useful default. Use "@name" to force a profile.
+    from urllib.parse import quote
+    return f"https://x.com/search?q={quote(s)}&src=typed_query&f=live"
+
+
+async def posts(
+    source: str | None = None,
+    *,
+    limit: int = 30,
+    scroll: bool = True,
+    endpoint: str = DEFAULT_ENDPOINT,
+    app: str = DEFAULT_APP,
+    timeout: float = 30.0,
+) -> pl.DataFrame:
+    """Recent X posts from ``source`` as a polars DataFrame, in page order.
+
+    ``source`` is a timeline keyword (``"home"`` -- the default -- or
+    ``"notifications"`` / ``"bookmarks"`` / ``"explore"``), a profile (``"@handle"``),
+    a search (``"#tag"`` or any free text), or a full ``x.com`` URL (including a
+    ``/status/`` thread). The browser is scrolled until ``limit`` posts are loaded
+    (pass ``scroll=False`` to read only what is initially on screen).
+
+    Columns: ``id``, ``handle``, ``author``, ``time`` (UTC datetime), ``text``,
+    ``replies`` / ``reposts`` / ``likes`` / ``views`` / ``bookmarks`` (Int64,
+    null when X does not show that count), ``url`` (permalink), ``is_reply``.
+
+    Drives the browser :mod:`browser` connects to (``endpoint``), launching ``app``
+    if nothing is listening. Reading a signed-in timeline needs that browser signed
+    in to X. Returns an empty (correctly typed) frame when no posts are found.
+    """
+
+    url = _resolve(source)
+    await browser.get_or_create_browser(endpoint=endpoint, app=app)
+    page = await browser.goto(url, endpoint=endpoint, wait_until="domcontentloaded", timeout=timeout * 1000)
+
+    try:
+        await page.wait_for_selector("article", timeout=timeout * 1000)
+    except Exception:
+        # No tweets rendered (an empty timeline, a login wall, a deleted post):
+        # return an empty, correctly-typed frame rather than raise.
+        return pl.DataFrame(schema=_SCHEMA)
+
+    collected: dict[str, dict] = {}
+    order: list[str] = []
+    stable = 0
+    max_passes = 60 if scroll else 1
+    for _ in range(max_passes):
+        for row in await page.evaluate(_EXTRACT_JS):
+            # Key on the permalink id; fall back to a synthetic key for the rare
+            # promoted/edge card without one so it is not silently dropped.
+            key = row.get("id") or f"{row.get('handle')}:{row.get('text')[:40]}"
+            if key not in collected:
+                order.append(key)
+            collected[key] = row
+        if len(collected) >= limit or not scroll:
+            break
+        before = len(collected)
+        await page.evaluate("window.scrollBy(0, window.innerHeight * 1.5)")
+        await asyncio.sleep(0.8)
+        # Stop once a few scrolls in a row add nothing (the end of the timeline,
+        # or X has stopped loading more).
+        stable = stable + 1 if len(collected) == before else 0
+        if stable >= 3:
+            break
+
+    rows = [collected[k] for k in order][:limit]
+    if not rows:
+        return pl.DataFrame(schema=_SCHEMA)
+
+    df = pl.DataFrame(rows, schema_overrides={k: v for k, v in _SCHEMA.items() if k != "time"})
+    return df.with_columns(
+        pl.col("time").str.to_datetime(time_zone="UTC", strict=False)
+    ).select(list(_SCHEMA))

--- a/packages/mcp/src/x/x/__init__.py
+++ b/packages/mcp/src/x/x/__init__.py
@@ -231,46 +231,64 @@ async def posts(
 
     _require_incognito()
     url = _resolve(source)
-    await browser.get_or_create_browser(endpoint=endpoint, app=app)
-    page = await browser.goto(url, endpoint=endpoint, wait_until="domcontentloaded", timeout=timeout * 1000)
+    await browser.get_or_create_browser(endpoint=endpoint, app=app, timeout=timeout)
+    # Open a dedicated tab (``new=True``) rather than reusing the shared front
+    # tab: the runtime runs jobs concurrently, so two reads sharing one tab would
+    # clobber each other's navigation and scroll. Close it in ``finally`` so
+    # repeated reads do not pile up tabs.
+    page = await browser.goto(
+        url,
+        endpoint=endpoint,
+        new=True,
+        wait_until="domcontentloaded",
+        timeout=timeout * 1000,
+    )
 
     try:
-        await page.wait_for_selector("article", timeout=timeout * 1000)
-    except Exception:
-        # No tweets rendered (an empty timeline, a login wall, a deleted post):
-        # return an empty, correctly-typed frame rather than raise.
-        return pl.DataFrame(schema=_SCHEMA)
+        try:
+            await page.wait_for_selector("article", timeout=timeout * 1000)
+        except Exception:
+            # No tweets rendered (an empty timeline, a login wall, a deleted
+            # post): return an empty, correctly-typed frame rather than raise.
+            return pl.DataFrame(schema=_SCHEMA)
 
-    collected: dict[str, dict] = {}
-    order: list[str] = []
-    stable = 0
-    max_passes = 60 if scroll else 1
-    for _ in range(max_passes):
-        before = len(collected)
-        for row in await page.evaluate(_EXTRACT_JS):
-            # Key on the permalink id; fall back to a synthetic key for the rare
-            # promoted/edge card without one so it is not silently dropped.
-            key = row.get("id") or f"{row.get('handle')}:{row.get('text')[:40]}"
-            if key not in collected:
-                order.append(key)
-            collected[key] = row
-        if len(collected) >= limit or not scroll:
-            break
-        # Stop once a few scrolls in a row load nothing new (the end of the
-        # timeline, or X has stopped loading more). `before` is the count from
-        # before this pass's extraction, so the comparison reflects what the
-        # previous scroll actually loaded, not the rows already in hand.
-        stable = stable + 1 if len(collected) == before else 0
-        if stable >= 3:
-            break
-        await page.evaluate("window.scrollBy(0, window.innerHeight * 1.5)")
-        await asyncio.sleep(0.8)
+        collected: dict[str, dict] = {}
+        order: list[str] = []
+        stable = 0
+        max_passes = 60 if scroll else 1
+        for _ in range(max_passes):
+            before = len(collected)
+            for row in await page.evaluate(_EXTRACT_JS):
+                # Key on the permalink id; fall back to a synthetic key for the
+                # rare promoted/edge card without one so it is not silently dropped.
+                key = row.get("id") or f"{row.get('handle')}:{row.get('text')[:40]}"
+                if key not in collected:
+                    order.append(key)
+                collected[key] = row
+            if len(collected) >= limit or not scroll:
+                break
+            # Stop once a few scrolls in a row load nothing new (the end of the
+            # timeline, or X has stopped loading more). `before` is the count from
+            # before this pass's extraction, so the comparison reflects what the
+            # previous scroll actually loaded, not the rows already in hand.
+            stable = stable + 1 if len(collected) == before else 0
+            if stable >= 3:
+                break
+            await page.evaluate("window.scrollBy(0, window.innerHeight * 1.5)")
+            await asyncio.sleep(0.8)
 
-    rows = [collected[k] for k in order][:limit]
-    if not rows:
-        return pl.DataFrame(schema=_SCHEMA)
+        rows = [collected[k] for k in order][:limit]
+        if not rows:
+            return pl.DataFrame(schema=_SCHEMA)
 
-    df = pl.DataFrame(rows, schema_overrides={k: v for k, v in _SCHEMA.items() if k != "time"})
-    return df.with_columns(
-        pl.col("time").str.to_datetime(time_zone="UTC", strict=False)
-    ).select(list(_SCHEMA))
+        df = pl.DataFrame(
+            rows, schema_overrides={k: v for k, v in _SCHEMA.items() if k != "time"}
+        )
+        return df.with_columns(
+            pl.col("time").str.to_datetime(time_zone="UTC", strict=False)
+        ).select(list(_SCHEMA))
+    finally:
+        try:
+            await page.close()
+        except Exception:
+            pass

--- a/packages/mcp/src/x/x/__init__.py
+++ b/packages/mcp/src/x/x/__init__.py
@@ -198,6 +198,7 @@ async def posts(
     stable = 0
     max_passes = 60 if scroll else 1
     for _ in range(max_passes):
+        before = len(collected)
         for row in await page.evaluate(_EXTRACT_JS):
             # Key on the permalink id; fall back to a synthetic key for the rare
             # promoted/edge card without one so it is not silently dropped.
@@ -207,14 +208,15 @@ async def posts(
             collected[key] = row
         if len(collected) >= limit or not scroll:
             break
-        before = len(collected)
-        await page.evaluate("window.scrollBy(0, window.innerHeight * 1.5)")
-        await asyncio.sleep(0.8)
-        # Stop once a few scrolls in a row add nothing (the end of the timeline,
-        # or X has stopped loading more).
+        # Stop once a few scrolls in a row load nothing new (the end of the
+        # timeline, or X has stopped loading more). `before` is the count from
+        # before this pass's extraction, so the comparison reflects what the
+        # previous scroll actually loaded, not the rows already in hand.
         stable = stable + 1 if len(collected) == before else 0
         if stable >= 3:
             break
+        await page.evaluate("window.scrollBy(0, window.innerHeight * 1.5)")
+        await asyncio.sleep(0.8)
 
     rows = [collected[k] for k in order][:limit]
     if not rows:


### PR DESCRIPTION
## What

Adds an `x` module to the ix-mcp interpreter for reading recent X (Twitter) posts into polars.

```python
import x
x.posts()                      # home timeline, newest first
x.posts("@andrewgazelka")      # a user's recent posts
x.posts("#rustlang")           # a search
x.posts("https://x.com/Plambey/status/2064307527114793062")  # a thread
```

Returns one row per post: `id`, `handle`, `author`, `time` (UTC datetime), `text`, `replies`/`reposts`/`likes`/`views`/`bookmarks`, `url`, `is_reply`.

## How

X has no usable unauthenticated read API (the public syndication endpoints now return empty timelines), so `x.posts()` reuses the `browser` module: it drives the logged-in browser over CDP, navigates to the timeline/profile/search/thread, scrolls until it has `limit` tweets, and parses the rendered `article` elements (engagement counts come from the action-bar `aria-label`, which carries exact figures the visible chips abbreviate). Pure Python over the bundled browser/playwright/polars; cross-platform.

## Wiring

- `packages/mcp/default.nix`: `xModule` (bundled like `browserModule`) + `xBundled` import test
- `packages/mcp/ix_notebook_mcp/registry.py`: registered so it appears in `api()` and the server instructions

## Tests

- `mcp.tests.xBundled` (new) — builds the interpreter env with `xModule` and asserts `import x; callable(x.posts)`
- `mcp.tests.runtimeSmoke` — still green with the new registry entry
- Verified live against the running Dia browser: read a thread, a profile, and the home timeline into polars frames.

(opened by Claude Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `x` module to read recent X posts into a Polars DataFrame
> - Adds a new [`x` package](https://github.com/indexable-inc/index/pull/968/files#diff-1c7780ef3e0ef8a2100d2aa95acd9e1d53141c7375f44acb663e47f285c63a4c) with an async `x.posts(source, ...)` function that opens a dedicated browser tab, navigates to an X/Twitter page, scrolls to collect posts, and returns them as a Polars DataFrame with a fixed schema.
> - `source` accepts timeline keywords (`home`, `bookmarks`, etc.), `@handles`, `#tags`, search text, or direct X/Twitter URLs; non-X URLs are rejected.
> - Raises `RuntimeError` in shared (multiplayer) rooms where browser isolation is not guaranteed.
> - Registers the module in the MCP [registry](https://github.com/indexable-inc/index/pull/968/files#diff-92f567578e1217b8207dbbd21af1cdee4978728a8ca9e774cd65ed17170d2ae5) and packages it into the Python environment via [default.nix](https://github.com/indexable-inc/index/pull/968/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0032ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->