### PR TITLE
ci: add hourly Cargo dependency updater

### DIFF
--- a/.github/workflows/update-cargo.yml
+++ b/.github/workflows/update-cargo.yml
@@ -1,0 +1,94 @@
+name: Update Cargo dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Hourly refresh of the Rust workspace, mirroring the flake.lock
+    # (update-flake-lock.yml) and content (update.yml) updaters. A plain
+    # `cargo update` only moves dependencies *within* the SemVer ranges pinned
+    # in Cargo.toml, so this also advances the SemVer-*incompatible* (major)
+    # ranges via `cargo update --breaking`. The resulting PR is gated by
+    # `flake-check`, which is what actually proves the new versions still build.
+    # A no-op run opens no PR and the updater reuses one branch, so this stays
+    # cheap and never stacks PRs. The minute is offset from the other updaters
+    # so the three never start in the same tick.
+    - cron: "47 * * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-cargo
+  cancel-in-progress: false
+
+jobs:
+  update-cargo:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      # The GitHub-hosted Ubuntu runner ships rustup, and the repo's
+      # rust-toolchain.toml pins the nightly cargo it downloads on first use
+      # (same toolchain story as fuzz-nbt.yml). nightly is what makes
+      # `cargo update --breaking` available: it is an unstable option.
+      - name: Update Cargo dependencies
+        env:
+          # Deterministic, un-colored status lines so the parse below is stable
+          # regardless of whether the runner looks like a TTY.
+          CARGO_TERM_COLOR: never
+        run: |
+          set -euo pipefail
+
+          # Major (SemVer-incompatible) bumps rewrite Cargo.toml, so cargo gates
+          # them behind `--breaking`. Run whole-workspace it is atomic: a single
+          # crate that cannot resolve (a renamed feature, a yanked release)
+          # aborts every other major bump with it. So discover the candidates
+          # with a dry run, then apply each on its own and let the unresolvable
+          # ones fall away instead of blocking the rest. cargo prints the
+          # `Upgrading <crate> ...` plan to stderr, hence the 2>&1.
+          mapfile -t breaking < <(
+            cargo update --breaking -Zunstable-options --dry-run 2>&1 \
+              | awk '$1 == "Upgrading" { print $2 }' | sort -u
+          )
+          for crate in "${breaking[@]}"; do
+            echo "::group::cargo update --breaking $crate"
+            cargo update --breaking -Zunstable-options "$crate" \
+              || echo "skipped $crate: no SemVer-incompatible version resolves"
+            echo "::endgroup::"
+          done
+
+          # The ordinary SemVer-compatible refresh for everything else, which
+          # also normalizes the lockfile after the breaking edits above.
+          cargo update
+
+      # Opens (or updates) a single PR, and only when something changed:
+      # create-pull-request no-ops on an empty diff. It reuses the
+      # `update-cargo` branch so each run advances the same PR.
+      #
+      # `token`: a PR opened with the default GITHUB_TOKEN does not trigger the
+      # `pull_request` workflows (`flake-check`), so branch protection would
+      # block the merge. Set an `AUTOBUMP_TOKEN` repo secret (a PAT or GitHub
+      # App token) to make the PR run CI; without it this falls back to
+      # GITHUB_TOKEN and a maintainer must re-trigger `flake-check`.
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.AUTOBUMP_TOKEN || github.token }}
+          base: main
+          branch: update-cargo
+          delete-branch: true
+          commit-message: "cargo: update dependencies"
+          title: "cargo: update dependencies"
+          body: |
+            Automated refresh of the Rust workspace dependencies.
+
+            `cargo update` advanced every dependency within its existing SemVer range, and `cargo update --breaking` was applied per-crate to also bump the **major** (SemVer-incompatible) ranges in `Cargo.toml`. A crate whose major bump can't resolve (for example a renamed feature) is skipped so it never blocks the others.
+
+            `flake-check` is what proves the new versions actually build, so review its result before merging.
+
+            Auto-bump, made with Claude Opus 4.8.

--- a/agent-context/sections/13-dependency-intake.md
+++ b/agent-context/sections/13-dependency-intake.md
@@ -42,6 +42,13 @@ runs it hourly and opens one PR. Do not add a per-package update workflow. See
 [`packages/claude-code`](packages/claude-code) and [`packages/yc`](packages/yc)
 for the worked shape: `nix run .#claude-code.updateScript -- <version>`.
 
+Ecosystem lockfiles get their own hourly updater rather than joining
+`nix run .#update`: the Rust workspace `Cargo.lock` is refreshed by
+`update-cargo.yml` (a plain `cargo update` plus a per-crate
+`cargo update --breaking` for the major bumps) and `flake.lock` by
+`update-flake-lock.yml`. Each opens its own PR gated by `flake-check`; do not
+fold them into the content updater.
+
 When upstream signs its release manifest, the updater verifies that signature
 against a pinned key and fails closed before writing hashes (claude-code). When
 upstream publishes no signature (yc), there is no provenance check: the updater


### PR DESCRIPTION
## What

Adds `update-cargo.yml`, an **hourly** workflow that refreshes the Rust workspace dependencies and opens a single PR — the Cargo analogue of `update.yml` (content) and `update-flake-lock.yml` (flake inputs). `Cargo.lock` is its own ecosystem lockfile, so like `flake.lock` it gets its own updater rather than joining the content updater.

## Major version updates

A plain `cargo update` only moves *within* the SemVer ranges pinned in `Cargo.toml`. To also pick up **major** (SemVer-incompatible) bumps, the job runs `cargo update --breaking` (nightly `-Zunstable-options`, available via the pinned `rust-toolchain.toml`). Because `--breaking` is atomic across the whole workspace — one unresolvable crate aborts every other major bump — it discovers the candidates with a dry run and then applies each crate on its own, letting the unresolvable ones (e.g. a renamed feature) fall away instead of blocking the rest.

`flake-check` on the PR is the real build gate (set the `AUTOBUMP_TOKEN` secret so the bot PR triggers it).

## Testing

- Ran the full update script end-to-end against the workspace: it landed the resolvable majors (`similar 2→3`, `dirs 5→6`, `git2 0.20→0.21`, `rusqlite 0.32→0.40`, `sha2 0.10→0.11`, …) and cleanly skipped `reqwest` / `hegeltest` whose major bumps don't resolve, then normalized the lockfile.
- `actionlint` (incl. embedded shellcheck) passes on the new workflow.

🤖 Made with Claude Opus 4.8.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hourly GitHub Actions workflow to update Cargo dependencies
> - Adds [update-cargo.yml](.github/workflows/update-cargo.yml), a scheduled (hourly) and manually dispatchable workflow that applies both SemVer-compatible (`cargo update`) and per-crate breaking updates (`cargo update --breaking -Zunstable-options`) to the Rust workspace.
> - Breaking updates are discovered via dry-run, then applied individually per crate to avoid broad unintended bumps.
> - The workflow opens or updates a single PR on branch `update-cargo` using `peter-evans/create-pull-request`, triggering CI via `AUTOBUMP_TOKEN`.
> - Documents the workflow in [13-dependency-intake.md](https://github.com/indexable-inc/index/pull/974/files#diff-830e6f04026126c1cfd2867c2e239116786297a2733e5e8c975fe1be90ed158b) alongside the existing `update-flake-lock.yml` updater.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5873cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->