### PR TITLE
claude-code: 2.1.168 -> 2.1.169

### DIFF
--- a/packages/claude-code/manifest.json
+++ b/packages/claude-code/manifest.json
@@ -1,21 +1,21 @@
 {
-  "version": "2.1.168",
+  "version": "2.1.169",
   "platforms": {
     "aarch64-darwin": {
       "slug": "darwin-arm64",
-      "hash": "sha256-N38OztuoJGvavfMSzot8yK4RYJl7JvXtyjUqSo1h3Hg="
+      "hash": "sha256-hti4IK1+7VDlChMHBtPcXvcGlvkRlN4bOJeoQhgq/jo="
     },
     "x86_64-darwin": {
       "slug": "darwin-x64",
-      "hash": "sha256-aI89n6CVWHjCkaWP6+nk2qBhMm2iF62nQNl8XhdjSiY="
+      "hash": "sha256-bY1RDHFbiZMHt9KaEGLUPmLJk3DFUzDaw+wYUaL798g="
     },
     "x86_64-linux": {
       "slug": "linux-x64",
-      "hash": "sha256-4vfLUEQr3uIb8mhu83JaavGHogTkbEr1wS0PbXYyZIU="
+      "hash": "sha256-zwZr82DL97UavrjLIwAS/A8v7UJTss4wXeSMzW1Jo5w="
     },
     "aarch64-linux": {
       "slug": "linux-arm64",
-      "hash": "sha256-QNUOfEV0Kqo3B/o2KNf3ZcVe1QMQi28QBRPjjTJHeqA="
+      "hash": "sha256-NBByOVhEsrbShG2NYdVRdSsSpEQzySDQzH/m57VpKps="
     }
   }
 }


### PR DESCRIPTION
Bump pinned Claude Code release to 2.1.169 via the signed updateScript. Manifest signature verified; package builds and \`claude --version\` reports 2.1.169 on aarch64-darwin.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump claude-code version from 2.1.168 to 2.1.169
> Updates [manifest.json](https://github.com/indexable-inc/index/pull/976/files#diff-07231a29e842291cdba811cc694c7fe37386a88958609a48480b263aa9dca446) with the new version and refreshed sha256 hashes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a06e47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->