### PR TITLE
feat(packages): add version-pinned, auto-updating Dia browser

### DIFF
--- a/lib/overlay.nix
+++ b/lib/overlay.nix
@@ -12,9 +12,18 @@
   # packages/claude-code uses `ix.deepMerge.rhs`).
   ix,
 }:
-final: _prev:
+final: prev:
 let
-  packageSystem = final.stdenv.hostPlatform.system;
+  # Read the target system from `prev`, not `final`: this overlay's attribute
+  # *names* are computed by filtering the registry's `overlay` entries by
+  # system (see `overlayEntriesFor`), so forcing the system through `final`
+  # would require applying this overlay to know whether it defines `stdenv` --
+  # a cycle. `prev` is the pre-overlay pkgs (same hostPlatform), so it breaks
+  # the recursion. Without this, any registry entry with a non-null
+  # `overlay.systems` triggers an infinite recursion (a `systems = null` entry
+  # short-circuits before the system is ever forced, which is why it went
+  # unnoticed).
+  packageSystem = prev.stdenv.hostPlatform.system;
   overlayContext = entry: {
     inherit
       entry

--- a/packages/dia/default.nix
+++ b/packages/dia/default.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  undmg,
+  nix,
+  # Only the flake package set injects the Nushell writer; the overlay eval
+  # context does not. The updater is a maintainer-facing flake output, so the
+  # overlay build of `pkgs.dia` simply omits `passthru.updateScript`.
+  writeNushellApplication ? null,
+}:
+
+let
+  # Version and content hash are generated, never hand-edited. Bump with
+  # `nix run .#dia.updateScript -- [version]`, which resolves the upstream
+  # `Dia-latest.dmg` pointer (or a pinned version) and rewrites manifest.json.
+  # We pin by raw bytes so the download is reproducible: unlike Homebrew, which
+  # only lets you freeze an already-installed cask (`brew pin`) and has no
+  # supported way to fetch an arbitrary older version, the hash pin makes any
+  # exact version installable and verifiable.
+  #
+  # `version` is "<short>-<build>" (e.g. "1.34.1-81705"), matching the upstream
+  # download filename `Dia-<version>.dmg`.
+  manifest = lib.importJSON ./manifest.json;
+  inherit (manifest) version hash;
+
+  # Refreshes manifest.json to a Dia release. With no argument it tracks the
+  # `Dia-latest.dmg` pointer, reading the resolved version out of the
+  # Content-Disposition filename the CDN returns (there is no appcast/manifest);
+  # pass a version to pin an exact one. `nix store prefetch-file` downloads the
+  # .dmg once and emits the SRI hash the fetcher pins.
+  updateScript =
+    if writeNushellApplication == null then
+      null
+    else
+      writeNushellApplication {
+        name = "dia-update";
+        runtimeInputs = [ nix ];
+        meta.description = "Refresh packages/dia/manifest.json to a Dia release";
+        text = ''
+          const base = "https://releases.diabrowser.com/release"
+
+          # Run from the repo root: `nix run .#dia.updateScript -- [version]`.
+          def main [version?: string] {
+            let v = ($version | default (
+              http head $"($base)/Dia-latest.dmg"
+              | where name == "content-disposition"
+              | get value.0
+              | parse --regex 'filename="?Dia-(?<v>[^"]+)\.dmg'
+              | get v.0
+            ))
+            let url = $"($base)/Dia-($v).dmg"
+            let hash = (^nix store prefetch-file --json --hash-type sha256 $url | from json | get hash)
+            let out = "packages/dia/manifest.json"
+            { version: $v, hash: $hash } | to json --indent 2 | save --force $out
+            print $"updated ($out) to ($v)"
+          }
+        '';
+      };
+in
+stdenv.mkDerivation {
+  pname = "dia";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://releases.diabrowser.com/release/Dia-${version}.dmg";
+    inherit hash;
+  };
+
+  nativeBuildInputs = [ undmg ];
+  # undmg's unpackCmd hook extracts the .app straight into the build dir.
+  sourceRoot = ".";
+
+  dontConfigure = true;
+  dontBuild = true;
+  # The bundle is signed and notarized; any byte rewrite (strip, patch, the
+  # default fixup) would void the code signature, so install it verbatim.
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/Applications" "$out/bin"
+    cp -R Dia.app "$out/Applications/Dia.app"
+    # `nix run .#dia` and a PATH `dia` launch the bundle executable directly.
+    ln -s "$out/Applications/Dia.app/Contents/MacOS/Dia" "$out/bin/dia"
+    runHook postInstall
+  '';
+
+  passthru = lib.optionalAttrs (updateScript != null) {
+    inherit updateScript;
+  };
+
+  meta = {
+    description = "Dia, The Browser Company's AI browser";
+    homepage = "https://www.diabrowser.com";
+    # License omitted rather than `licenses.unfree`: the per-system flake
+    # package set evaluates nixpkgs without `allowUnfree`, so tagging this
+    # proprietary bundle unfree would block `nix run .#dia`. Distribution terms
+    # are The Browser Company's Dia license.
+    mainProgram = "dia";
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/packages/dia/manifest.json
+++ b/packages/dia/manifest.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.34.1-81705",
+  "hash": "sha256-FHDJWxvYtu6rxyHJoj0h9vbIrD1NkN/XLUa1DPNw38U="
+}

--- a/packages/dia/package.nix
+++ b/packages/dia/package.nix
@@ -1,0 +1,16 @@
+{
+  id = "dia";
+  # macOS-only: Dia ships a single Apple-Silicon .app inside a .dmg and
+  # requires macOS 14+ on M1+, so every target is gated to aarch64-darwin.
+  # The linux flake/overlay/update paths then never see (or try to build) it.
+  packageSet = {
+    systems = [ "aarch64-darwin" ];
+  };
+  flake = {
+    systems = [ "aarch64-darwin" ];
+  };
+  overlay = {
+    systems = [ "aarch64-darwin" ];
+  };
+  updateScript = true;
+}


### PR DESCRIPTION
-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add version-pinned Dia browser package for aarch64-darwin
> - Adds a new `dia` package in [packages/dia/default.nix](https://github.com/indexable-inc/index/pull/977/files#diff-8e3d8be48a9106ee0cc3b4331ec6e1acc4cb00397218ff9cda045b0e1c46ea06) that fetches a versioned `.dmg` from `releases.diabrowser.com`, installs `Dia.app` into `$out/Applications`, and exposes a `$out/bin/dia` symlink.
> - Version and SHA256 hash are pinned in [packages/dia/manifest.json](https://github.com/indexable-inc/index/pull/977/files#diff-0505b22a1d934867ccaf980cc5a82fd3c56f6ccbe6d2e2af331d99b32187e863); configure/build/fixup phases are skipped to preserve code signing.
> - A Nushell-based `passthru.updateScript` (when available) resolves the latest version, prefetches the `.dmg`, and rewrites the manifest.
> - Fixes a cycle in [lib/overlay.nix](https://github.com/indexable-inc/index/pull/977/files#diff-65204771292c901d3da5be0a98b4162f557dc034fc1f1b58400a6d136b0525cd) by reading the target system from `prev.stdenv.hostPlatform.system` instead of `final.stdenv.hostPlatform.system`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89865b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->