### PR TITLE
feat(pi-harnesses): add pi-base UX pack and prosecutor supervision visibility

### DIFF
--- a/packages/pi-harnesses/README.md
+++ b/packages/pi-harnesses/README.md
@@ -14,6 +14,7 @@ pi-harnesses/
     models.nix            # canonical alias -> { provider, model } table
     ext-lib/              # reusable extension helpers (trust, child-agent, probes, scoring, turn-cap)
   engine/                 # id: pi-harness   - the locked-down Room engine (tools ABSENT, JSON event stream)
+  base/                   # id: pi-base       - base UX pack: live tok/s, git widget, /diff, /lg
   prosecutor/             # id: pi-prosecutor - executor under a skeptical, earned-trust supervisor
   beam/                   # id: pi-beam       - executor with beam search over isolated worktree branches
 ```

--- a/packages/pi-harnesses/base/README.md
+++ b/packages/pi-harnesses/base/README.md
@@ -1,0 +1,27 @@
+# pi-base
+
+Pi with a small base UX pack - quality-of-life extensions that are a plus for
+any setup, with no behavior changes to the agent itself.
+
+Adapted from [davis7dotsh/my-pi-setup](https://github.com/davis7dotsh/my-pi-setup)
+(MIT, (c) 2026 Benjamin Davis).
+
+## What you get
+
+| Piece | Surface | What it does |
+| --- | --- | --- |
+| `tps-tracker` | footer status | live tokens/sec while streaming (estimated until official usage arrives), final per-run summary toast |
+| `git-status-widget` | widget above editor | ` <branch> · N unstaged files`, refreshed every 2s and on input/tool activity |
+| `turn-diff` | `/diff`, `/diff list`, `/diff clear` | tracks exactly which files the last agent run touched (git baseline diff + edit/write tool targets), toast at run end, picker to open one in `$PI_DIFF_EDITOR`/`$EDITOR` |
+| `lg` | `/lg` | concise summary of unstaged changes with per-file +/- counts; queues as follow-up if the agent is busy |
+
+## Run
+
+```
+ANTHROPIC_API_KEY=... nix run .#pi-base -- "your task"
+PI_HARNESS_MODEL=codex OPENAI_API_KEY=... nix run .#pi-base
+```
+
+The extension files also land in `share/pi-base/`, so they can be symlinked
+into `~/.pi/agent/extensions/` (e.g. via home-manager) to get the same UX in a
+plain `pi` session.

--- a/packages/pi-harnesses/base/default.nix
+++ b/packages/pi-harnesses/base/default.nix
@@ -1,0 +1,32 @@
+{
+  callPackage,
+  git,
+  pi ? null,
+}:
+let
+  mkPiHarness = callPackage ../shared/mk-pi-harness.nix { inherit pi; };
+  models = import ../shared/models.nix;
+in
+mkPiHarness {
+  name = "pi-base";
+  description = "Pi with the base UX pack: live tok/s, git status widget, /diff, /lg.";
+
+  extensions = [
+    ./extension/tps-tracker.ts
+    ./extension/git-status-widget.ts
+    ./extension/turn-diff.ts
+    ./extension/lg.ts
+  ];
+  libFiles = [ ../shared/ext-lib/git-files.js ];
+
+  inherit models;
+  defaultModel = "claude";
+
+  lockdown = false;
+  session = true;
+
+  runtimeInputs = [ git ];
+
+  checkFiles = [ ./test/git-files.test.mjs ];
+  checkLib = [ ../shared/ext-lib/git-files.js ];
+}

--- a/packages/pi-harnesses/base/extension/git-status-widget.ts
+++ b/packages/pi-harnesses/base/extension/git-status-widget.ts
@@ -1,0 +1,73 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { countUnstagedFiles } from "./lib/git-files.js";
+
+// Persistent widget above the editor showing the current branch and unstaged
+// file count, refreshed on a timer plus input/tool activity.
+//
+// Adapted from davis7dotsh/my-pi-setup (MIT, (c) 2026 Benjamin Davis).
+const execFileAsync = promisify(execFile);
+const WIDGET_ID = "git-status-widget";
+const UPDATE_INTERVAL_MS = 2_000;
+
+async function runGit(args: string[], cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, {
+    cwd,
+    timeout: 2_000,
+    maxBuffer: 1024 * 1024,
+  });
+  return stdout.trimEnd();
+}
+
+async function getBranch(cwd: string): Promise<string> {
+  const branch = await runGit(["branch", "--show-current"], cwd);
+  if (branch.length > 0) return branch;
+  const head = await runGit(["rev-parse", "--short", "HEAD"], cwd);
+  return head.length > 0 ? `detached@${head}` : "unknown";
+}
+
+async function updateWidget(ctx: any): Promise<void> {
+  if (!ctx.hasUI) return;
+  try {
+    await runGit(["rev-parse", "--is-inside-work-tree"], ctx.cwd);
+    const [branch, status] = await Promise.all([
+      getBranch(ctx.cwd),
+      runGit(["status", "--porcelain", "--untracked-files=normal"], ctx.cwd),
+    ]);
+    const unstagedCount = countUnstagedFiles(status);
+    const fileLabel = unstagedCount === 1 ? "file" : "files";
+    ctx.ui.setWidget(WIDGET_ID, [` ${branch} · ${unstagedCount} unstaged ${fileLabel}`]);
+  } catch {
+    ctx.ui.setWidget(WIDGET_ID, undefined);
+  }
+}
+
+export default function (pi: ExtensionAPI) {
+  let interval: ReturnType<typeof setInterval> | undefined;
+
+  pi.on("session_start", async (_event: any, ctx: any) => {
+    if (interval) clearInterval(interval);
+    await updateWidget(ctx);
+    interval = setInterval(() => {
+      void updateWidget(ctx);
+    }, UPDATE_INTERVAL_MS);
+  });
+
+  pi.on("input", async (_event: any, ctx: any) => {
+    await updateWidget(ctx);
+    return { action: "continue" as const };
+  });
+
+  pi.on("tool_execution_end", async (_event: any, ctx: any) => {
+    await updateWidget(ctx);
+  });
+
+  pi.on("session_shutdown", async (_event: any, ctx: any) => {
+    if (interval) {
+      clearInterval(interval);
+      interval = undefined;
+    }
+    if (ctx.hasUI) ctx.ui.setWidget(WIDGET_ID, undefined);
+  });
+}

--- a/packages/pi-harnesses/base/extension/lg.ts
+++ b/packages/pi-harnesses/base/extension/lg.ts
@@ -1,0 +1,27 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+// /lg - ask the agent for a concise summary of unstaged changes with per-file
+// +/- counts. If the agent is mid-turn, queue it as a follow-up.
+//
+// Adapted from davis7dotsh/my-pi-setup (MIT, (c) 2026 Benjamin Davis).
+const LG_PROMPT = `Run git status, inspect what has changed, then respond with only:
+
+1. A short 1-2 sentence summary of the unstaged changes.
+2. A list of changed unstaged files with their +/- line counts.
+3. A total +/- line count at the bottom.
+
+Keep it concise. Use git commands to calculate the line counts; do not include staged changes unless they also have unstaged modifications.`;
+
+export default function (pi: ExtensionAPI) {
+  pi.registerCommand("lg", {
+    description: "Summarize unstaged git changes with per-file +/- counts",
+    handler: async (_args: string, ctx: any) => {
+      if (!ctx.isIdle()) {
+        pi.sendUserMessage(LG_PROMPT, { deliverAs: "followUp" });
+        ctx.ui.notify("Queued /lg after the current turn finishes.", "info");
+        return;
+      }
+      pi.sendUserMessage(LG_PROMPT);
+    },
+  });
+}

--- a/packages/pi-harnesses/base/extension/tps-tracker.ts
+++ b/packages/pi-harnesses/base/extension/tps-tracker.ts
@@ -1,0 +1,95 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+// Live tokens-per-second in the footer while the model streams, plus a final
+// per-run summary toast. Until the provider reports official usage, output is
+// estimated at ~4 chars/token from streamed deltas.
+//
+// Adapted from davis7dotsh/my-pi-setup (MIT, (c) 2026 Benjamin Davis).
+export default function (pi: ExtensionAPI) {
+  let messageStart: number | null = null;
+  let streamStart: number | null = null;
+  let estimatedStreamedTokens = 0;
+  let totalOutputTokens = 0;
+  let totalStreamMs = 0;
+
+  pi.on("agent_start", async (_event: any, ctx: any) => {
+    totalOutputTokens = 0;
+    totalStreamMs = 0;
+    messageStart = null;
+    streamStart = null;
+    estimatedStreamedTokens = 0;
+    if (!ctx.hasUI) return;
+    ctx.ui.setStatus("tps", ctx.ui.theme.fg("dim", "generating..."));
+  });
+
+  pi.on("message_start", async (event: any) => {
+    if (event.message.role !== "assistant") return;
+    messageStart = Date.now();
+    streamStart = null;
+    estimatedStreamedTokens = 0;
+  });
+
+  pi.on("message_update", async (event: any, ctx: any) => {
+    if (event.message.role !== "assistant") return;
+
+    const streamEvent = event.assistantMessageEvent;
+    const isOutputDelta =
+      streamEvent.type === "text_delta" ||
+      streamEvent.type === "thinking_delta" ||
+      streamEvent.type === "toolcall_delta";
+    if (!isOutputDelta) return;
+
+    const now = Date.now();
+    streamStart ??= now;
+    estimatedStreamedTokens += Math.max(0, (streamEvent.delta?.length ?? 0) / 4);
+
+    if (!ctx.hasUI) return;
+    const elapsed = (now - streamStart) / 1000;
+    const officialTokens = event.message.usage?.output ?? 0;
+    const currentTokens = officialTokens > 0 ? officialTokens : estimatedStreamedTokens;
+
+    if (elapsed > 0 && currentTokens > 0) {
+      const tps = Math.round(currentTokens / elapsed);
+      const tokenLabel =
+        officialTokens > 0 ? `${officialTokens} tok` : `~${Math.round(estimatedStreamedTokens)} tok`;
+      const theme = ctx.ui.theme;
+      ctx.ui.setStatus(
+        "tps",
+        `${theme.fg("accent", `${tps} tok/s`)} ${theme.fg("dim", `(${tokenLabel} / ${elapsed.toFixed(1)}s)`)}`,
+      );
+    }
+  });
+
+  pi.on("message_end", async (event: any) => {
+    if (event.message.role !== "assistant") return;
+
+    const messageTokens = event.message.usage?.output ?? 0;
+    const timingStart = streamStart ?? messageStart;
+    if (!timingStart || messageTokens <= 0) {
+      messageStart = null;
+      streamStart = null;
+      estimatedStreamedTokens = 0;
+      return;
+    }
+
+    totalOutputTokens += messageTokens;
+    totalStreamMs += Math.max(0, Date.now() - timingStart);
+
+    messageStart = null;
+    streamStart = null;
+    estimatedStreamedTokens = 0;
+  });
+
+  pi.on("agent_end", async (_event: any, ctx: any) => {
+    if (!ctx.hasUI) return;
+    const elapsed = totalStreamMs / 1000;
+    const tps = totalOutputTokens > 0 && elapsed > 0 ? Math.round(totalOutputTokens / elapsed) : 0;
+
+    const theme = ctx.ui.theme;
+    const tpsLabel = tps > 0 ? theme.fg("accent", `${tps} tok/s`) : theme.fg("dim", "N/A");
+    const detail = theme.fg("dim", `${totalOutputTokens} tokens in ${elapsed.toFixed(1)}s streaming`);
+
+    ctx.ui.notify(`${tpsLabel}  ${detail}`, "info");
+    ctx.ui.setStatus("tps", theme.fg("dim", `done - ${tpsLabel}`));
+  });
+}

--- a/packages/pi-harnesses/base/extension/turn-diff.ts
+++ b/packages/pi-harnesses/base/extension/turn-diff.ts
@@ -1,0 +1,131 @@
+import path from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { parseStatusPaths } from "./lib/git-files.js";
+
+// Track exactly which files the last agent run touched (git delta vs a
+// baseline snapshot at agent_start, plus edit/write tool targets), toast a
+// summary at agent_end, and offer /diff to inspect or open them.
+//
+// /diff        pick a changed file, open it in $PI_DIFF_EDITOR or $EDITOR
+// /diff list   list the changed files
+// /diff clear  reset tracking
+//
+// Adapted from davis7dotsh/my-pi-setup (MIT, (c) 2026 Benjamin Davis);
+// editor made configurable instead of hardcoding Zed.
+const commandName = "diff";
+
+function getStringPath(input: unknown): string | undefined {
+  if (!input || typeof input !== "object" || !("path" in input)) return undefined;
+  return typeof (input as any).path === "string" ? (input as any).path : undefined;
+}
+
+function toAbsolute(cwd: string, filePath: string): string {
+  return path.isAbsolute(filePath) ? path.normalize(filePath) : path.resolve(cwd, filePath);
+}
+
+function toRelative(cwd: string, filePath: string): string {
+  const relative = path.relative(cwd, filePath);
+  return relative && !relative.startsWith("..") && !path.isAbsolute(relative) ? relative : filePath;
+}
+
+async function getGitChangedFiles(pi: ExtensionAPI, cwd: string): Promise<Set<string>> {
+  const result = await pi.exec("git", ["status", "--porcelain", "--untracked-files=all"], {
+    cwd,
+    timeout: 5000,
+  });
+  if (result.code !== 0) return new Set<string>();
+  const paths = parseStatusPaths(result.stdout) as Set<string>;
+  return new Set([...paths].map((p) => toAbsolute(cwd, p)));
+}
+
+function difference(current: Set<string>, baseline: Set<string>): Set<string> {
+  return new Set([...current].filter((file) => !baseline.has(file)));
+}
+
+export default function (pi: ExtensionAPI) {
+  let gitBaseline = new Set<string>();
+  let changedFiles = new Set<string>();
+  let toolTouchedFiles = new Set<string>();
+
+  pi.on("agent_start", async (_event: any, ctx: any) => {
+    toolTouchedFiles = new Set();
+    changedFiles = new Set();
+    gitBaseline = await getGitChangedFiles(pi, ctx.cwd);
+  });
+
+  pi.on("tool_result", (event: any, ctx: any) => {
+    if (event.toolName !== "edit" && event.toolName !== "write") return;
+    const filePath = getStringPath(event.input);
+    if (!filePath) return;
+    toolTouchedFiles.add(toAbsolute(ctx.cwd, filePath));
+  });
+
+  pi.on("agent_end", async (_event: any, ctx: any) => {
+    const gitChanged = await getGitChangedFiles(pi, ctx.cwd);
+    changedFiles = new Set([...difference(gitChanged, gitBaseline), ...toolTouchedFiles]);
+    if (changedFiles.size > 0 && ctx.hasUI) {
+      ctx.ui.notify(`${changedFiles.size} changed file(s). Run /${commandName} to view.`, "info");
+    }
+  });
+
+  pi.registerCommand(commandName, {
+    description: "Show files changed by the last agent run and open one in your editor",
+    handler: async (args: string, ctx: any) => {
+      await ctx.waitForIdle();
+
+      const arg = (args ?? "").trim();
+      if (arg === "clear") {
+        changedFiles = new Set();
+        toolTouchedFiles = new Set();
+        gitBaseline = await getGitChangedFiles(pi, ctx.cwd);
+        ctx.ui.notify("Cleared changed file list", "info");
+        return;
+      }
+
+      const files = [...changedFiles].sort((a, b) =>
+        toRelative(ctx.cwd, a).localeCompare(toRelative(ctx.cwd, b)),
+      );
+      if (files.length === 0) {
+        ctx.ui.notify("No changed files tracked from the last agent run", "info");
+        return;
+      }
+
+      if (arg === "list") {
+        ctx.ui.notify(
+          `Changed files:\n${files.map((file) => `- ${toRelative(ctx.cwd, file)}`).join("\n")}`,
+          "info",
+        );
+        return;
+      }
+
+      if (arg) {
+        ctx.ui.notify(
+          `Unknown /${commandName} argument: ${arg}. Try /${commandName}, /${commandName} list, or /${commandName} clear.`,
+          "warning",
+        );
+        return;
+      }
+
+      const labels = files.map((file) => toRelative(ctx.cwd, file));
+      const selected = await ctx.ui.select("Open changed file", labels);
+      if (!selected) return;
+
+      const selectedIndex = labels.indexOf(selected);
+      const file = files[selectedIndex];
+      if (!file) return;
+
+      const editor = process.env.PI_DIFF_EDITOR || process.env.EDITOR;
+      if (!editor) {
+        ctx.ui.notify(`Set PI_DIFF_EDITOR or EDITOR to open files. Path: ${file}`, "warning");
+        return;
+      }
+
+      const result = await pi.exec(editor, [file], { cwd: ctx.cwd, timeout: 10000 });
+      if (result.code === 0) {
+        ctx.ui.notify(`Opened ${selected}`, "info");
+      } else {
+        ctx.ui.notify(result.stderr.trim() || `Failed to open ${selected} with ${editor}`, "error");
+      }
+    },
+  });
+}

--- a/packages/pi-harnesses/base/package.nix
+++ b/packages/pi-harnesses/base/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "pi-base";
+  packageSet = true;
+  flake = true;
+}

--- a/packages/pi-harnesses/base/test/git-files.test.mjs
+++ b/packages/pi-harnesses/base/test/git-files.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+// Run flat (the Nix checkPhase copies git-files.js next to this file).
+import { countUnstagedFiles, parseStatusPaths } from "./git-files.js";
+
+test("empty status means zero unstaged", () => {
+  assert.equal(countUnstagedFiles(""), 0);
+});
+
+test("counts untracked and worktree-modified, not index-only", () => {
+  const status = ["?? new.txt", " M dirty.txt", "M  staged-only.txt", "MM both.txt"].join("\n");
+  // ??, " M", "MM" count; "M " (staged only) does not.
+  assert.equal(countUnstagedFiles(status), 3);
+});
+
+test("parseStatusPaths extracts plain paths", () => {
+  const paths = parseStatusPaths(["?? a.txt", " M dir/b.txt"].join("\n"));
+  assert.deepEqual([...paths].sort(), ["a.txt", "dir/b.txt"]);
+});
+
+test("parseStatusPaths takes rename destination and unquotes", () => {
+  const paths = parseStatusPaths(['R  old.txt -> new.txt', '?? "with space.txt"'].join("\n"));
+  assert.ok(paths.has("new.txt"));
+  assert.ok(paths.has("with space.txt"));
+  assert.ok(!paths.has("old.txt"));
+});

--- a/packages/pi-harnesses/prosecutor/extension/prosecutor.ts
+++ b/packages/pi-harnesses/prosecutor/extension/prosecutor.ts
@@ -65,8 +65,26 @@ export default function (pi: ExtensionAPI): void {
     return undefined;
   });
 
-  pi.on("tool_execution_end", (event: any) => {
+  // Keep the supervision state visible: a footer status with the current
+  // trust interval, streak, and actions remaining until the next check-in.
+  const updateStatus = (ctx: any) => {
+    if (!ctx?.hasUI) return;
+    const theme = ctx.ui.theme;
+    const left = Math.max(0, trust.interval - sinceCheckin);
+    ctx.ui.setStatus(
+      "prosecutor",
+      `${theme.fg("accent", `trust ${trust.interval}/16`)} ${theme.fg(
+        "dim",
+        `streak ${trust.streak} · check-in in ${left}`,
+      )}`,
+    );
+  };
+
+  pi.on("session_start", (_event: any, ctx: any) => updateStatus(ctx));
+
+  pi.on("tool_execution_end", (event: any, ctx: any) => {
     if (event?.toolName !== "claim") sinceCheckin += 1;
+    updateStatus(ctx);
   });
 
   pi.registerTool({
@@ -84,6 +102,10 @@ export default function (pi: ExtensionAPI): void {
         "claim is literally true right now. Trust nothing you cannot observe.\n" +
         'End with exactly one line: "VERDICT: UPHELD" or "VERDICT: BROKEN <one-line evidence>".';
       const prompt = `Claim: ${params.statement}\nSuggested check: ${params.verify}`;
+
+      // The isolated verification can take up to two minutes; without a
+      // working message the TUI just looks frozen.
+      if (ctx?.hasUI) ctx.ui.setWorkingMessage("prosecutor verifying claim...");
 
       let verdict: { upheld: boolean; evidence: string };
       try {
@@ -103,10 +125,21 @@ export default function (pi: ExtensionAPI): void {
         verdict = parseVerdict(`${res.stdout}\n${res.stderr}`);
       } catch (err) {
         verdict = { upheld: false, evidence: `prosecutor failed to run: ${String(err)}` };
+      } finally {
+        if (ctx?.hasUI) ctx.ui.setWorkingMessage(undefined);
       }
 
       const t = trust.record(verdict.upheld);
       sinceCheckin = 0;
+
+      if (ctx?.hasUI) {
+        if (verdict.upheld) {
+          ctx.ui.notify(`Claim UPHELD - trust interval now ${t.interval}`, "info");
+        } else {
+          ctx.ui.notify(`Claim BROKEN: ${verdict.evidence}`, "error");
+        }
+        updateStatus(ctx);
+      }
 
       // Persist the verdict out of the model's context for replay/audit.
       pi.appendEntry("prosecutor", {

--- a/packages/pi-harnesses/shared/ext-lib/git-files.js
+++ b/packages/pi-harnesses/shared/ext-lib/git-files.js
@@ -1,0 +1,33 @@
+// Pure helpers over `git status --porcelain` output, shared by the base UX
+// extensions. Kept pure so they can be unit-tested without git.
+//
+// Adapted from davis7dotsh/my-pi-setup (MIT, (c) 2026 Benjamin Davis).
+
+// Count entries that have unstaged or untracked changes. Porcelain v1 lines
+// are two status columns then a space: untracked is "??", and any non-space
+// second column means the working tree differs from the index.
+export function countUnstagedFiles(statusOutput) {
+  if (statusOutput.length === 0) return 0;
+  let count = 0;
+  for (const line of statusOutput.split("\n")) {
+    if (line.length < 2) continue;
+    if (line.startsWith("??") || line[1] !== " ") count += 1;
+  }
+  return count;
+}
+
+// Extract the set of paths from porcelain output. Rename/copy entries look
+// like `old -> new`; the destination is what we want. Quoted paths are
+// unquoted naively (good enough for display/select purposes).
+export function parseStatusPaths(statusOutput) {
+  const files = new Set();
+  for (const line of statusOutput.split("\n")) {
+    if (line.length < 4) continue;
+    const rawPath = line.slice(3).trim();
+    if (!rawPath) continue;
+    const targetPath = rawPath.includes(" -> ") ? rawPath.split(" -> ").at(-1) : rawPath;
+    if (!targetPath) continue;
+    files.add(targetPath.replace(/^"|"$/g, ""));
+  }
+  return files;
+}


### PR DESCRIPTION
## What

Add `packages/pi-harnesses/base` (id: `pi-base`) - a base UX pack of small, universally useful quality-of-life extensions, adapted from [davis7dotsh/my-pi-setup](https://github.com/davis7dotsh/my-pi-setup) (MIT, attributed in file headers). Also wire the prosecutor harness's supervision state into the TUI.

## pi-base pack

| Piece | Surface | What it does |
|---|---|---|
| `tps-tracker` | footer status | live tok/s while streaming (len/4 estimate until official usage arrives), per-run summary toast |
| `git-status-widget` | widget above editor | `<branch> · N unstaged files`, refreshed every 2s + on input/tool activity |
| `turn-diff` | `/diff`, `/diff list`, `/diff clear` | tracks exactly which files the last run touched (git baseline snapshot at agent_start vs agent_end, plus edit/write tool targets); picker opens a file in `$PI_DIFF_EDITOR`/`$EDITOR` (upstream hardcoded Zed; made configurable) |
| `lg` | `/lg` | concise unstaged-changes summary with per-file +/- counts; queues as follow-up if the agent is busy |

Porcelain parsing extracted to `shared/ext-lib/git-files.js` (pure, unit-tested, shared by widget + /diff). Extensions are plain `.ts` with type-only imports - no node_modules.

## Prosecutor visibility

The supervision mechanics existed but were invisible:
- footer status: `trust 4/16 · streak 3 · check-in in 2`
- working message while the isolated prosecutor verifies a claim (previously the TUI looked frozen for up to 120s - the worst UX moment of the harness)
- toasts on `UPHELD` (interval widened) / `BROKEN` (evidence)

All UI calls are `ctx.hasUI`-guarded, so headless/RPC use is unaffected.

## Validation

- `nix build .#pi-base .#pi-prosecutor .#pi-beam .#pi-harness` all green
- `git-files.test.mjs` 4/4 in the `checkPhase`
- `pi-base` wrapper inspected: loads all four extensions via `-e`, `lib/git-files.js` lands next to them in `share/pi-base/`
- `nix fmt` applied

## Manual verification (needs key + network)

```bash
ANTHROPIC_API_KEY=... nix run .#pi-base -- "touch two files then explain what changed"
# expect: live tok/s in footer, git widget above editor, end-of-run changed-files toast, /diff picker, /lg summary

ANTHROPIC_API_KEY=... nix run .#pi-prosecutor
# expect: trust status in footer, "prosecutor verifying claim..." during check-ins, verdict toasts
```

## Notes

- Skipped from the reference setup on purpose: `/yeet` (auto-push is too opinionated for a base pack), the ephemeral overlay system and pi-mcp (not "simple"). The beam adoption overlay is the natural follow-up.
- `share/pi-base/*.ts` is symlink-ready for `~/.pi/agent/extensions/` (home-manager wiring is a follow-up in the nix repo).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pi-base harness with git status widget, TPS tracker, turn diff, and prosecutor supervision visibility
> - Introduces a new `pi-base` harness ([base/default.nix](https://github.com/indexable-inc/index/pull/979/files#diff-2c904981ea306f5463d093db4ccfca004a818769ee73d638ef78c01603e365c0)) bundling four extensions: `git-status-widget`, `tps-tracker`, `turn-diff`, and `lg`.
> - `git-status-widget` shows a live header widget with current branch and unstaged file count, updated on a 2s timer and on user/tool activity.
> - `tps-tracker` displays live tokens/sec during assistant streaming and posts a summary toast at the end of each run, estimating tokens from deltas when usage data is absent.
> - `turn-diff` snapshots git state at agent start, tracks files touched by tools, and provides a `/diff` command to list or interactively open changed files in the configured editor.
> - `lg` adds a `/lg` command that requests a concise summary of unstaged git changes; queues the message if the agent is busy.
> - The prosecutor harness extension gains a live footer status showing trust interval, streak, and remaining actions, plus notifications on claim UPHELD/BROKEN outcomes.
> - Adds shared git porcelain parsing helpers in [git-files.js](https://github.com/indexable-inc/index/pull/979/files#diff-fed6e2e84c9748b14482f8c5462362c1c5294bc56cb02fed54e7b6b5489c64e7) with unit tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b55694a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->