### PR TITLE
claude-code: 2.1.169 -> 2.1.170

### DIFF
--- a/packages/claude-code/manifest.json
+++ b/packages/claude-code/manifest.json
@@ -1,21 +1,21 @@
 {
-  "version": "2.1.169",
+  "version": "2.1.170",
   "platforms": {
     "aarch64-darwin": {
       "slug": "darwin-arm64",
-      "hash": "sha256-hti4IK1+7VDlChMHBtPcXvcGlvkRlN4bOJeoQhgq/jo="
+      "hash": "sha256-6QNkbYt6MYgqgOzSdWmifYrFezcIdF80lwljLIQRf98="
     },
     "x86_64-darwin": {
       "slug": "darwin-x64",
-      "hash": "sha256-bY1RDHFbiZMHt9KaEGLUPmLJk3DFUzDaw+wYUaL798g="
+      "hash": "sha256-kU8jpwu+1dmuVn4+BLhiBu2ZcbNxvJuso/eciIW/3bQ="
     },
     "x86_64-linux": {
       "slug": "linux-x64",
-      "hash": "sha256-zwZr82DL97UavrjLIwAS/A8v7UJTss4wXeSMzW1Jo5w="
+      "hash": "sha256-hJ4AcnegRCqydXDT49bUN4dQeUZZDo3RlH5aObcIH54="
     },
     "aarch64-linux": {
       "slug": "linux-arm64",
-      "hash": "sha256-NBByOVhEsrbShG2NYdVRdSsSpEQzySDQzH/m57VpKps="
+      "hash": "sha256-G7nQMkQKdVMvfdTK+8aH8iCq8Wxj66F+GS377C8EvSU="
     }
   }
 }


### PR DESCRIPTION
Bumps the vendored Claude Code pin from 2.1.169 to 2.1.170, the current `latest`/`next` release.

- Regenerated `packages/claude-code/manifest.json` via the package's own `updateScript` (`nix run .#claude-code.updateScript -- 2.1.170`).
- All four platform SRI hashes refreshed; the detached GPG signature verified against the pinned release signing key (fails closed otherwise).
- `nix build .#claude-code` succeeds and `claude --version` reports `2.1.170`.

(sent by Claude Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump claude-code version from 2.1.169 to 2.1.170
> Updates [manifest.json](https://github.com/indexable-inc/index/pull/980/files#diff-07231a29e842291cdba811cc694c7fe37386a88958609a48480b263aa9dca446) with the new version and refreshed SHA-256 hashes for all associated artifacts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f05f93a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->