### PR TITLE
pi-base: announce the pack once on session start

### DIFF
--- a/packages/pi-harnesses/base/default.nix
+++ b/packages/pi-harnesses/base/default.nix
@@ -12,6 +12,7 @@ mkPiHarness {
   description = "Pi with the base UX pack: live tok/s, git status widget, /diff, /lg.";
 
   extensions = [
+    ./extension/banner.ts
     ./extension/tps-tracker.ts
     ./extension/git-status-widget.ts
     ./extension/turn-diff.ts

--- a/packages/pi-harnesses/base/extension/banner.ts
+++ b/packages/pi-harnesses/base/extension/banner.ts
@@ -1,0 +1,15 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+// One-time toast on session start so it is self-evident the pack is active and
+// what it added. Everything else in pi-base is intentionally quiet at rest
+// (widget only in git repos, tok/s only while streaming, commands on demand).
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", async (event: any, ctx: any) => {
+    if (!ctx.hasUI) return;
+    if (event?.reason !== "startup" && event?.reason !== "new") return;
+    ctx.ui.notify(
+      "pi-base UX active: live tok/s (footer, while streaming) · git widget (above editor, in repos) · /diff · /lg",
+      "info",
+    );
+  });
+}


### PR DESCRIPTION
Tiny follow-up to #979 (the banner commit landed just after merge).

One-time `ctx.ui.notify` toast on `session_start` (startup/new only) listing what pi-base adds, so the pack is discoverable: everything else is intentionally quiet at rest (git widget only in repos, tok/s only while streaming, /diff and /lg on demand).

Verified: `nix build .#pi-base` green; TUI pty test on main's build confirms the git widget renders ('master · 2 unstaged files') and no extension load errors.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Announce active pi-base UX features once on session start
> Adds a new [banner.ts](https://github.com/indexable-inc/index/pull/981/files#diff-d88dd32cd9e95e27a7b617a1dae52b6b6fba5b968680b486d5038f44a833b115) extension to the base harness that listens for `session_start` events. When a UI session starts with reason `startup` or `new`, it shows a one-time info notification listing active UX features (live tok/s footer, git widget, `/diff`, `/lg`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcaf241.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->