### PR TITLE
lib: consolidate hand-rolled checked-bash writers into ix.writeBashApplication

### DIFF
--- a/ast-grep/nix/rules/no-write-shell-application.yml
+++ b/ast-grep/nix/rules/no-write-shell-application.yml
@@ -6,6 +6,9 @@ note: |
   WHY: Repo user-facing commands should be Nushell, not Bash, so structured data,
   argument forwarding, and command orchestration stay readable and checked by Nu.
   Use ix.writeNushellApplication pkgs { ... } with runtimeInputs. Keep wrappers
-  as real Nu and preserve ambient PATH through the shared helper.
+  as real Nu and preserve ambient PATH through the shared helper. If the script
+  truly must be bash (an exec-style toolchain wrapper, POSIX process control),
+  use ix.writeBashApplication, the shared checked escape hatch in
+  lib/util/writers.nix; never hand-roll writeTextFile for it.
 rule:
   pattern: writeShellApplication

--- a/ast-grep/nix/rules/no-write-shell-script-bin.yml
+++ b/ast-grep/nix/rules/no-write-shell-script-bin.yml
@@ -6,7 +6,9 @@ note: |
   WHY: writeShellScriptBin produces a script without shellcheck validation, without
   declared runtime dependencies, and without the repo's Nushell syntax check.
   ix.writeNushellApplication keeps runtime dependencies explicit and checks Nu
-  scripts during the build.
+  scripts during the build. Scripts that truly must be bash go through
+  ix.writeBashApplication (lib/util/writers.nix), which checks them with
+  `bash -n` and shellcheck.
   NIXPKGS: Yes — nixpkgs#208242 tracks this. nixpkgs-hammering does not flag it yet
   but the community consensus is clear. This repo uses Nushell for user-facing commands.
   REPO: Banned in AGENTS.md.

--- a/lib/darwin/apple-sdk-toolchain.nix
+++ b/lib/darwin/apple-sdk-toolchain.nix
@@ -6,9 +6,10 @@
 # nix-cargo-unit renderer picks up `CARGO_TARGET_<T>_LINKER` per unit and
 # threads `--target` into rustc itself (see packages/nix-cargo-unit/src/render.rs).
 #
-# Ported from the sibling `ix` repo (nix/lib/apple-sdk-toolchain.nix). The wrapper
-# scripts use `writeTextFile` rather than `writeShellApplication` because the
-# latter is lint-banned here; a `bash -n` checkPhase keeps the syntax checked.
+# Ported from the sibling `ix` repo (nix/lib/apple-sdk-toolchain.nix). The
+# wrapper scripts go through the shared `writeBashApplication`
+# (lib/util/writers.nix), which checks them with `bash -n` and shellcheck at
+# build time.
 {
   appleSdk,
   lib,
@@ -143,21 +144,9 @@ let
   ar = lib.getExe' pkgs.llvmPackages.bintools "ar";
   ranlib = lib.getExe' pkgs.llvmPackages.bintools "ranlib";
 
-  # writeTextFile + `bash -n` checkPhase: a checked replacement for the
-  # lint-banned writeShellApplication for these internal build wrappers.
-  mkScript =
-    name: text:
-    pkgs.writeTextFile {
-      inherit name;
-      executable = true;
-      destination = "/bin/${name}";
-      text = ''
-        #!${pkgs.runtimeShell}
-        set -euo pipefail
-        ${text}
-      '';
-      checkPhase = ''${lib.getExe' pkgs.bash "bash"} -n "$out/bin/${name}"'';
-    };
+  # These wrappers must be bash (argv rewriting with arrays, `exec "$@"`), so
+  # they use the repo's one checked-bash escape hatch instead of Nushell.
+  inherit (import ../util/writers.nix { inherit lib; }) writeBashApplication;
 
   ccName = "apple-sdk-cc-${target}";
   cxxName = "apple-sdk-cxx-${target}";
@@ -165,39 +154,57 @@ let
   arName = "apple-sdk-ar-${target}";
   ranlibName = "apple-sdk-ranlib-${target}";
 
-  appleCcPackage = mkScript ccName ''
-    ${zigCachePreamble}
-    ${argLoop}
-    if [ "$has_target" -eq 0 ]; then
-      apple_args=("--target=${zigTarget}" "''${apple_args[@]}")
-    fi
-    exec ${zig} cc -mmacosx-version-min=11.0 ${frameworkFlags} "''${apple_args[@]}" -fno-sanitize=undefined
-  '';
-  appleCxxPackage = mkScript cxxName ''
-    ${zigCachePreamble}
-    ${argLoop}
-    if [ "$has_target" -eq 0 ]; then
-      apple_args=("--target=${zigTarget}" "''${apple_args[@]}")
-    fi
-    exec ${zig} c++ -mmacosx-version-min=11.0 ${frameworkFlags} "''${apple_args[@]}" -fno-sanitize=undefined
-  '';
-  appleLinkerPackage = mkScript linkerName ''
-    ${argLoop}
-    if [ "$has_target" -eq 0 ]; then
-      apple_args=("--target=${target}" "''${apple_args[@]}")
-    fi
-    exec ${clang} -B${pkgs.lld}/bin -fuse-ld=lld -mmacosx-version-min=11.0 -isysroot ${appleSdk} -Wno-unused-command-line-argument "''${apple_args[@]}" -fno-sanitize=undefined
-  '';
-  appleArPackage = mkScript arName ''exec ${ar} "$@"'';
-  appleRanlibPackage = mkScript ranlibName ''exec ${ranlib} "$@"'';
-  appleXcrun = mkScript "xcrun" ''
-    if [ "$#" -eq 3 ] && [ "$1" = "--sdk" ] && [ "$2" = "macosx" ] && [ "$3" = "--show-sdk-path" ]; then
-      printf '%s\n' ${appleSdk}
-      exit 0
-    fi
-    echo "unsupported xcrun invocation: $*" >&2
-    exit 1
-  '';
+  appleCcPackage = writeBashApplication pkgs {
+    name = ccName;
+    text = ''
+      ${zigCachePreamble}
+      ${argLoop}
+      if [ "$has_target" -eq 0 ]; then
+        apple_args=("--target=${zigTarget}" "''${apple_args[@]}")
+      fi
+      exec ${zig} cc -mmacosx-version-min=11.0 ${frameworkFlags} "''${apple_args[@]}" -fno-sanitize=undefined
+    '';
+  };
+  appleCxxPackage = writeBashApplication pkgs {
+    name = cxxName;
+    text = ''
+      ${zigCachePreamble}
+      ${argLoop}
+      if [ "$has_target" -eq 0 ]; then
+        apple_args=("--target=${zigTarget}" "''${apple_args[@]}")
+      fi
+      exec ${zig} c++ -mmacosx-version-min=11.0 ${frameworkFlags} "''${apple_args[@]}" -fno-sanitize=undefined
+    '';
+  };
+  appleLinkerPackage = writeBashApplication pkgs {
+    name = linkerName;
+    text = ''
+      ${argLoop}
+      if [ "$has_target" -eq 0 ]; then
+        apple_args=("--target=${target}" "''${apple_args[@]}")
+      fi
+      exec ${clang} -B${pkgs.lld}/bin -fuse-ld=lld -mmacosx-version-min=11.0 -isysroot ${appleSdk} -Wno-unused-command-line-argument "''${apple_args[@]}" -fno-sanitize=undefined
+    '';
+  };
+  appleArPackage = writeBashApplication pkgs {
+    name = arName;
+    text = ''exec ${ar} "$@"'';
+  };
+  appleRanlibPackage = writeBashApplication pkgs {
+    name = ranlibName;
+    text = ''exec ${ranlib} "$@"'';
+  };
+  appleXcrun = writeBashApplication pkgs {
+    name = "xcrun";
+    text = ''
+      if [ "$#" -eq 3 ] && [ "$1" = "--sdk" ] && [ "$2" = "macosx" ] && [ "$3" = "--show-sdk-path" ]; then
+        printf '%s\n' ${appleSdk}
+        exit 0
+      fi
+      echo "unsupported xcrun invocation: $*" >&2
+      exit 1
+    '';
+  };
 
   appleCc = lib.getExe' appleCcPackage ccName;
   appleCxx = lib.getExe' appleCxxPackage cxxName;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -41,6 +41,7 @@ let
   inherit (import ./util/writers.nix { inherit lib; })
     writePythonApplication
     writeNushellApplication
+    writeBashApplication
     writeProcessComposeApplication
     ;
 
@@ -388,6 +389,7 @@ let
       secrets
       skills
       systemdHardening
+      writeBashApplication
       writeNushellApplication
       writeProcessComposeApplication
       writePythonApplication

--- a/lib/util/writers.nix
+++ b/lib/util/writers.nix
@@ -130,6 +130,53 @@ let
     };
 
   /**
+    Package a Bash script as a standalone executable.
+
+    Nushell (`writeNushellApplication`) is the default for repo commands; this
+    is the one sanctioned escape hatch for scripts that must be bash, such as
+    exec-style toolchain wrappers and POSIX process-control idioms (setsid,
+    flock, `exec "$@"`). The generated script runs under `set -euo pipefail`
+    with `runtimeInputs` prepended to PATH, and the build runs `bash -n` plus
+    shellcheck so a syntax error or a shellcheck-class bug fails the
+    derivation instead of surfacing at runtime.
+
+    Arguments:
+    - `name`: derivation name and `/bin/<name>` executable.
+    - `runtimeInputs`: packages prepended to PATH for the script body.
+    - `text`: the bash script body. No shebang or `set` line; the wrapper
+      supplies both.
+    - `meta`: standard derivation meta, with `mainProgram` defaulted.
+  */
+  writeBashApplication =
+    pkgs:
+    {
+      name,
+      runtimeInputs ? [ ],
+      text,
+      meta ? { },
+    }:
+    pkgs.writeTextFile {
+      inherit name;
+      executable = true;
+      destination = "/bin/${name}";
+      text = ''
+        #!${pkgs.runtimeShell}
+        set -euo pipefail
+      ''
+      + lib.optionalString (runtimeInputs != [ ]) ''
+        export PATH=${lib.makeBinPath runtimeInputs}''${PATH:+:$PATH}
+      ''
+      + text;
+      checkPhase = ''
+        ${lib.getExe' pkgs.bash "bash"} -n "$target"
+        ${lib.getExe pkgs.shellcheck} --shell=bash --severity=warning "$target"
+      '';
+      meta = meta // {
+        mainProgram = meta.mainProgram or name;
+      };
+    };
+
+  /**
     Package a process-compose specification as a `nix run` application.
 
     Generates a checked YAML config from Nix values and wraps
@@ -220,6 +267,7 @@ in
   inherit
     writePythonApplication
     writeNushellApplication
+    writeBashApplication
     writeProcessComposeApplication
     ;
 }

--- a/packages/bossbar-overlay/ci-bars-home-module.nix
+++ b/packages/bossbar-overlay/ci-bars-home-module.nix
@@ -42,36 +42,13 @@ let
 
   defaultBossbar = (indexPackages pkgs.stdenv.hostPlatform.system).bossbar;
 
-  # Checked replacement for the lint-banned writeShellApplication: writeTextFile
-  # gives a real bash script, runtimeInputs are prepended to PATH like
-  # writeShellApplication does, and `bash -n` + shellcheck run in the build so a
-  # syntax or shellcheck-class bug fails the derivation instead of surfacing at
-  # runtime. The body assumes `set -euo pipefail` + runtimeInputs on PATH. Same
-  # escape hatch as lib/darwin/apple-sdk-toolchain.nix's `mkScript`; kept inline so this
-  # module is self-contained and copy-pasteable for other people.
-  mkBashApp =
-    {
-      name,
-      text,
-      runtimeInputs ? [ ],
-    }:
-    pkgs.writeTextFile {
-      inherit name;
-      executable = true;
-      destination = "/bin/${name}";
-      text = ''
-        #!${pkgs.runtimeShell}
-        set -euo pipefail
-        export PATH=${lib.makeBinPath runtimeInputs}''${PATH:+:$PATH}
-        ${text}
-      '';
-      checkPhase = ''
-        ${lib.getExe' pkgs.bash "bash"} -n "$out/bin/${name}"
-        ${lib.getExe pkgs.shellcheck} --shell=bash --severity=warning "$out/bin/${name}"
-      '';
-    };
+  # The repo's checked-bash writer (lib/util/writers.nix): the watcher leans on
+  # bash process control (the perl flock guard), so it uses the shared escape
+  # hatch instead of Nushell. The script body gets `set -euo pipefail` and
+  # runtimeInputs on PATH, and `bash -n` + shellcheck run in the build.
+  inherit (import ../../lib/util/writers.nix { inherit lib; }) writeBashApplication;
 
-  ciBars = mkBashApp {
+  ciBars = writeBashApplication pkgs {
     name = "ci-bars";
     runtimeInputs = [
       pkgs.gh

--- a/packages/bossbar-overlay/ci-bars.sh
+++ b/packages/bossbar-overlay/ci-bars.sh
@@ -1,5 +1,5 @@
 # Body of the `ci-bars` bash app (see ci-bars-home-module.nix).
-# No shebang / `set` line: the mkBashApp wrapper supplies bash + `set -euo
+# No shebang / `set` line: the writeBashApplication wrapper supplies bash + `set -euo
 # pipefail` and bakes gh/jq/sqlite/coreutils/perl + the bossbar CLI onto PATH via
 # runtimeInputs. Everything tunable comes from the environment so the script is a
 # plain, testable file with no build-time string baking:

--- a/packages/pi-harnesses/shared/mk-pi-harness.nix
+++ b/packages/pi-harnesses/shared/mk-pi-harness.nix
@@ -61,8 +61,8 @@ let
       "--no-extensions"
       "--no-skills"
     ]
-    ++ lib.optionals (!session) [ "--no-session" ]
-    ++ lib.optionals headless [ "--print" ]
+    ++ lib.optional (!session) "--no-session"
+    ++ lib.optional headless "--print"
     ++ lib.optionals (headless && mode != null) [
       "--mode"
       mode

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -580,6 +580,14 @@ let
     processes.hello.command = "true";
   };
 
+  bashApplicationProbe = ix.writeBashApplication pkgs {
+    name = "bash-application-probe";
+    runtimeInputs = [ pkgs.hello ];
+    text = ''
+      hello
+    '';
+  };
+
   zigAppFixture = fs.toSource {
     root = ./fixtures/zig-app;
     fileset = fs.unions [
@@ -4518,6 +4526,8 @@ let
     ${lib.getExe pythonAppClosureProbe} > python-app-closure-probe.out
     grep -q 'python app source is in the runtime closure' python-app-closure-probe.out
     test -e ${processComposeApplication.passthru.tests.dryRun}
+    ${lib.getExe bashApplicationProbe} > bash-application-probe.out
+    grep -q 'Hello, world!' bash-application-probe.out
 
     ${lib.getExe zigApplication} > zig-app-fixture.out
     grep -q 'hello from zig app fixture' zig-app-fixture.out

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -64,40 +64,18 @@ let
   # say-detached body via the @SAY_CMD@ placeholder.
   sayCommand = if isDarwin then "/usr/bin/say" else cfg.sound.linuxSayCommand;
 
-  # Checked replacement for the lint-banned writeShellApplication: writeTextFile
-  # gives us a real bash script, runtimeInputs are prepended to PATH like
-  # writeShellApplication does, and `bash -n` + shellcheck run in the build so a
-  # syntax error or a shellcheck-class bug fails the derivation instead of
-  # surfacing at runtime. The script body assumes `set -euo pipefail` and the
-  # runtimeInputs on PATH, exactly as writeShellApplication would supply. Same
-  # escape hatch as lib/darwin/apple-sdk-toolchain.nix's `mkScript`.
-  mkBashApp =
-    {
-      name,
-      text,
-      runtimeInputs ? [ ],
-    }:
-    pkgs.writeTextFile {
-      inherit name;
-      executable = true;
-      destination = "/bin/${name}";
-      text = ''
-        #!${pkgs.runtimeShell}
-        set -euo pipefail
-        export PATH=${lib.makeBinPath runtimeInputs}''${PATH:+:$PATH}
-        ${text}
-      '';
-      checkPhase = ''
-        ${lib.getExe' pkgs.bash "bash"} -n "$out/bin/${name}"
-        ${lib.getExe pkgs.shellcheck} --shell=bash --severity=warning "$out/bin/${name}"
-      '';
-    };
+  # The repo's checked-bash writer (lib/util/writers.nix): these watchers lean
+  # on POSIX process control (the perl setsid/flock detach idioms) that is
+  # native bash territory, so they use the shared escape hatch instead of
+  # Nushell. The script body gets `set -euo pipefail` and runtimeInputs on
+  # PATH, and `bash -n` + shellcheck run in the build.
+  inherit (import ../../lib/util/writers.nix { inherit lib; }) writeBashApplication;
 
   # Shared announcement helper: plays an optional Minecraft sound then speaks
   # text, detached into its own session (POSIX setsid via perl) so a switch
   # reloading the calling agent never clips an in-flight speech. The @SAY_CMD@
   # placeholder is baked to the per-OS speech command at build time.
-  sayDetached = mkBashApp {
+  sayDetached = writeBashApplication pkgs {
     name = "say-detached";
     runtimeInputs = [ indexPkgs.minecraft-sound ];
     text = builtins.replaceStrings [ "@SAY_CMD@" ] [ sayCommand ] (
@@ -108,7 +86,7 @@ let
   # The ix.dev downtime watcher itself. bossbar raises/clears the per-service
   # outage bar; say-detached carries the growl + spoken summary; claude-code
   # writes the one-sentence root cause; coreutils provides `timeout`/`date`.
-  ixDowntime = mkBashApp {
+  ixDowntime = writeBashApplication pkgs {
     name = "ix-downtime";
     runtimeInputs = [
       pkgs.curl
@@ -131,7 +109,7 @@ let
   # so it needs no say-detached. The Linear API key is read at runtime from the
   # login Keychain (service `pr-watch-linear`); see the script header.
   # CI_TRIAGE_DRY_RUN makes it non-destructive for testing.
-  ciTriage = mkBashApp {
+  ciTriage = writeBashApplication pkgs {
     name = "ci-triage";
     runtimeInputs = [
       pkgs.gh
@@ -148,7 +126,7 @@ let
   # ci-triage is the detached stage-2 deep dive; coreutils provides
   # `timeout`/`date`; perl supplies the intrinsic flock guard and the setsid
   # detach. The @PLACEHOLDERS@ are baked from the options.
-  prWatch = mkBashApp {
+  prWatch = writeBashApplication pkgs {
     name = "pr-watch";
     runtimeInputs = [
       pkgs.gh

--- a/users/andrewgazelka/scripts/ci-triage.sh
+++ b/users/andrewgazelka/scripts/ci-triage.sh
@@ -1,5 +1,5 @@
 # Body of the `ci-triage` bash app (see users/andrewgazelka/home.nix).
-# No shebang / `set` line: the mkBashApp wrapper supplies bash + `set -euo
+# No shebang / `set` line: the writeBashApplication wrapper supplies bash + `set -euo
 # pipefail` and bakes gh/jq/claude/coreutils onto PATH.
 #
 # Stage-2 of the pr-watch CI response: a per-run DEEP DIVE into one GitHub

--- a/users/andrewgazelka/scripts/ix-downtime.sh
+++ b/users/andrewgazelka/scripts/ix-downtime.sh
@@ -1,5 +1,5 @@
 # Body of the `ix-downtime` bash app (see users/andrewgazelka/home.nix).
-# No shebang / `set` line: the mkBashApp wrapper supplies bash + `set -euo
+# No shebang / `set` line: the writeBashApplication wrapper supplies bash + `set -euo
 # pipefail` and bakes curl/jaq/sqlite/minecraft-sound/claude/coreutils + the
 # bossbar CLI + say-detached onto PATH via runtimeInputs.
 #

--- a/users/andrewgazelka/scripts/pr-watch.sh
+++ b/users/andrewgazelka/scripts/pr-watch.sh
@@ -1,5 +1,5 @@
 # Body of the `pr-watch` bash app (see users/andrewgazelka/home.nix).
-# No shebang / `set` line: the mkBashApp wrapper supplies bash + `set -euo
+# No shebang / `set` line: the writeBashApplication wrapper supplies bash + `set -euo
 # pipefail` and bakes gh/jq/ci-triage/claude/coreutils onto PATH via
 # runtimeInputs. The module bakes these placeholders at build time:
 #   @REPOS@            the watched repos as a quoted bash-array body

--- a/users/andrewgazelka/scripts/say-detached.sh
+++ b/users/andrewgazelka/scripts/say-detached.sh
@@ -1,5 +1,5 @@
 # Body of the `say-detached` bash app (see users/andrewgazelka/home.nix).
-# No shebang / `set` line: the mkBashApp wrapper supplies bash + `set -euo
+# No shebang / `set` line: the writeBashApplication wrapper supplies bash + `set -euo
 # pipefail` and bakes minecraft-sound + the speaker onto PATH via runtimeInputs.
 #
 # Play an optional Minecraft sound, then speak text aloud, in a NEW session


### PR DESCRIPTION
## Jank fixed

Three files each hand-rolled the same "checked replacement for the lint-banned `writeShellApplication`" (a `writeTextFile` with `bash -n` + shellcheck in `checkPhase`), each comment pointing at the others as the same escape hatch:

- `mkBashApp` in `users/andrewgazelka/home.nix`
- a byte-identical `mkBashApp` in `packages/bossbar-overlay/ci-bars-home-module.nix`
- a weaker `mkScript` (no shellcheck, no `runtimeInputs`) in `lib/darwin/apple-sdk-toolchain.nix`

One concept, one implementation: `writeBashApplication` now lives beside the Python / Nushell / process-compose writers in `lib/util/writers.nix`, is exported through `ix` like its siblings, and every former copy calls it.

### What improves

- The apple-sdk cross wrappers gain the shellcheck gate they were missing (pre-flighted clean).
- Empty `runtimeInputs` no longer renders an `export PATH` line; the old inline copies would have prepended a bare colon, putting the cwd on PATH.
- The `no-write-shell-application` / `no-write-shell-script-bin` ast-grep notes now name the shared escape hatch, so the next must-be-bash script does not grow a fourth copy.
- `tests/default.nix` runs a probe through the writer, proving the generated wrapper executes and `runtimeInputs` land on PATH.

Also collapses two `lib.optionals cond [ x ]` singletons in `packages/pi-harnesses/shared/mk-pi-harness.nix` that landed red on main: `nix run .#lint` currently fails on `main` because of them.

### Verification

- `nix run .#lint`: green (it fails on current `main`).
- Native build of the writer with and without `runtimeInputs`, asserting output, PATH wiring, and the no-bare-colon guarantee.
- Pure eval: all six apple-sdk wrappers and both home modules (`homeModules.andrewgazelka` with `ciBars` enabled) instantiate.

(opened by Claude Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate hand-rolled Bash script writers into shared `ix.writeBashApplication`
> - Introduces `writeBashApplication` in [writers.nix](https://github.com/indexable-inc/index/pull/982/files#diff-0623e72dad4f8369a1e1c6c92bceea5b8671425268aa161961e3d52950e07d3a) as a shared utility that wraps `pkgs.writeTextFile`, adding `set -euo pipefail`, optional `runtimeInputs` PATH prefixing, and a build-time `bash -n` + shellcheck validation.
> - Exports `writeBashApplication` via [lib/default.nix](https://github.com/indexable-inc/index/pull/982/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188) so it's available as `ix.writeBashApplication` to all consumers.
> - Replaces local `mkScript`/`mkBashApp` helpers in [apple-sdk-toolchain.nix](https://github.com/indexable-inc/index/pull/982/files#diff-280b8ec772b384638a8cf0c0343253ce69ad4920a97b562518ef17b33ba436d8), [ci-bars-home-module.nix](https://github.com/indexable-inc/index/pull/982/files#diff-9ad2a911dd8e5dc204b66ecc4d03c5dc01ea4fc043ed837d960b42176fb316d1), and [andrewgazelka/home.nix](https://github.com/indexable-inc/index/pull/982/files#diff-b9c7bb705f699ec210f648820aef5c561583845b682d07d6e1dc19de7685cb0f) with the new shared writer.
> - Updates ast-grep lint rules to direct contributors toward `ix.writeBashApplication` for Bash scripts.
> - Adds a test derivation in [tests/default.nix](https://github.com/indexable-inc/index/pull/982/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) that builds and validates a Bash application probe.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ccb3d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->