### PR TITLE
fix: clear the clippy + lint failures blocking the merge queue

### DIFF
--- a/packages/git-log-pretty/src/git.rs
+++ b/packages/git-log-pretty/src/git.rs
@@ -22,7 +22,7 @@ impl ChangeKind {
     /// Map git's per-delta [`git2::Delta`] onto the coarser set the display
     /// cares about. Unmodified and unreadable deltas never reach us (a diff only
     /// yields touched files), so they collapse into `Modified`.
-    fn from_delta(status: git2::Delta) -> Self {
+    const fn from_delta(status: git2::Delta) -> Self {
         match status {
             git2::Delta::Added | git2::Delta::Copied | git2::Delta::Untracked => Self::Added,
             git2::Delta::Deleted => Self::Deleted,

--- a/packages/indexbench/src/macro_harness.rs
+++ b/packages/indexbench/src/macro_harness.rs
@@ -83,7 +83,7 @@ pub fn parse_custom_metric(line: &str) -> Result<Option<CustomMetric>, String> {
                 value = Some(
                     raw.parse::<f64>()
                         .map_err(|err| format!("value `{raw}`: {err}"))?,
-                )
+                );
             }
             "unit" => raw.clone_into(&mut unit),
             "lower_is_better" => {
@@ -234,7 +234,7 @@ fn wait4(pid: i32, program: &str) -> crate::Result<Reaped> {
     clippy::cast_precision_loss,
     reason = "byte counts at bench magnitudes are far below 2^52, so the f64 is exact"
 )]
-fn maxrss_to_bytes(ru_maxrss_bytes: i64) -> f64 {
+const fn maxrss_to_bytes(ru_maxrss_bytes: i64) -> f64 {
     ru_maxrss_bytes as f64
 }
 

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -221,80 +221,11 @@ async fn main() -> anyhow::Result<()> {
         "--from-parquet-prefix, --from-iceberg, --from-snapshot, and --cursor-file are mutually exclusive consume modes"
     );
 
-    // Consume mode (Iceberg corpus lake, full): fold the lake's revision log
-    // into its current per-source document sets and REPLACE each source's
-    // Mixedbread records with them — the lake's replay/rebuild path. Replace,
-    // not reconcile: the fold's absences are explicit tombstones, so the
-    // rebuild also deletes view records the lake has let go of, including a
-    // source whose records are all tombstoned. Like the parquet consume below,
-    // emit and consume run as separate invocations of this binary.
-    if cli.from_iceberg {
-        let mixedbread = mixedbread
-            .context("--from-iceberg requires --mixedbread-store (the replace target)")?;
-        let Lake { catalog, ident } = connect_lake(&cli).await?;
-        let state = lake_iceberg::read_state(catalog.as_ref(), &ident)
-            .await
-            .context("reading the lake")?;
-        return finish(run_replace(state, mixedbread).await);
-    }
-
-    // Consume mode (Iceberg corpus lake, incremental): apply the changes since
-    // an explicit cursor. Stateless — the caller owns the cursor.
-    if let Some(cursor) = cli.from_snapshot {
-        let mixedbread =
-            mixedbread.context("--from-snapshot requires --mixedbread-store (the apply target)")?;
-        let Lake { catalog, ident } = connect_lake(&cli).await?;
-        let mut counts = Counts {
-            indexed: 0,
-            skipped: 0,
-            failures: 0,
-        };
-        let result = run_lake_delta(catalog.as_ref(), &ident, cursor, mixedbread)
-            .await
-            .map(|_| ());
-        record("lake-delta", result, &mut counts);
-        return finish(counts);
-    }
-
-    // Consume mode (Iceberg corpus lake, steady state): the cursor lives in a
-    // file; absent or expired falls back to a full rebuild. This is the
-    // deployed view-catch-up invocation.
-    if let Some(path) = cli.cursor_file.clone() {
-        let mixedbread =
-            mixedbread.context("--cursor-file requires --mixedbread-store (the apply target)")?;
-        let Lake { catalog, ident } = connect_lake(&cli).await?;
-        return finish(run_cursor_consume(catalog.as_ref(), &ident, &path, mixedbread).await);
-    }
-
-    // Consume mode (parquet corpus log): read the per-source `data.parquet` files
-    // `sink-parquet` wrote at this prefix under `--bucket` and reconcile them back
-    // into Mixedbread. Uses the SAME bucket/endpoint/region the parquet sink uses,
-    // so it reads exactly what was written. Emit (scan local sources, write the
-    // log) and consume (replay the log into Mixedbread) run as separate
-    // invocations of this binary; consume reconciles the log rather than scanning.
-    if let Some(prefix) = cli.from_parquet_prefix.clone() {
-        let bucket = cli
-            .bucket
-            .clone()
-            .context("--from-parquet-prefix requires --bucket")?;
-        let config = source_parquet::Config {
-            bucket,
-            endpoint: cli.endpoint.clone(),
-            region: cli.region.clone(),
-            prefix,
-        };
-        // With --catalog-uri this folds the parquet archive INTO the lake (the
-        // leader's parquet->lake step under leader-funnel, issue #752);
-        // otherwise it replays the archive into Mixedbread. The lake fold keeps
-        // each (host, user, source) slice separate, so it cannot share
-        // consume_parquet's host-flattened read.
-        if cli.catalog_uri.is_some() {
-            let Lake { catalog, ident } = connect_lake(&cli).await?;
-            return finish(fold_parquet_into_lake(&config, catalog, &ident).await);
-        }
-        let mixedbread = mixedbread
-            .context("--from-parquet-prefix requires --mixedbread-store or --catalog-uri")?;
-        return finish(consume_parquet(&config, mixedbread).await);
+    // Consume modes replay a corpus log into Mixedbread/the lake instead of
+    // scanning local sources; dispatched in `run_consume_mode` to keep `main`
+    // a thin top-level. Exactly one is set here (guarded by the check above).
+    if consume_modes == 1 {
+        return run_consume_mode(&cli, mixedbread).await;
     }
 
     let parquet = match cli.bucket.as_ref() {
@@ -347,6 +278,91 @@ async fn main() -> anyhow::Result<()> {
     }
 
     finish(run_sources(&cli, mixedbread, parquet.as_ref(), lake.as_ref()).await)
+}
+
+/// Dispatch the consume modes: replay a corpus log (the Iceberg lake or the
+/// parquet archive) into Mixedbread/the lake instead of scanning local
+/// sources. Split out of [`main`] to keep the entry point readable.
+/// Precondition: exactly one consume flag is set (the caller guards on
+/// `consume_modes == 1`).
+async fn run_consume_mode(cli: &Cli, mixedbread: Option<Mixedbread<'_>>) -> anyhow::Result<()> {
+    // Consume mode (Iceberg corpus lake, full): fold the lake's revision log
+    // into its current per-source document sets and REPLACE each source's
+    // Mixedbread records with them — the lake's replay/rebuild path. Replace,
+    // not reconcile: the fold's absences are explicit tombstones, so the
+    // rebuild also deletes view records the lake has let go of, including a
+    // source whose records are all tombstoned. Like the parquet consume below,
+    // emit and consume run as separate invocations of this binary.
+    if cli.from_iceberg {
+        let mixedbread = mixedbread
+            .context("--from-iceberg requires --mixedbread-store (the replace target)")?;
+        let Lake { catalog, ident } = connect_lake(cli).await?;
+        let state = lake_iceberg::read_state(catalog.as_ref(), &ident)
+            .await
+            .context("reading the lake")?;
+        return finish(run_replace(state, mixedbread).await);
+    }
+
+    // Consume mode (Iceberg corpus lake, incremental): apply the changes since
+    // an explicit cursor. Stateless — the caller owns the cursor.
+    if let Some(cursor) = cli.from_snapshot {
+        let mixedbread =
+            mixedbread.context("--from-snapshot requires --mixedbread-store (the apply target)")?;
+        let Lake { catalog, ident } = connect_lake(cli).await?;
+        let mut counts = Counts {
+            indexed: 0,
+            skipped: 0,
+            failures: 0,
+        };
+        let result = run_lake_delta(catalog.as_ref(), &ident, cursor, mixedbread)
+            .await
+            .map(|_| ());
+        record("lake-delta", result, &mut counts);
+        return finish(counts);
+    }
+
+    // Consume mode (Iceberg corpus lake, steady state): the cursor lives in a
+    // file; absent or expired falls back to a full rebuild. This is the
+    // deployed view-catch-up invocation.
+    if let Some(path) = cli.cursor_file.clone() {
+        let mixedbread =
+            mixedbread.context("--cursor-file requires --mixedbread-store (the apply target)")?;
+        let Lake { catalog, ident } = connect_lake(cli).await?;
+        return finish(run_cursor_consume(catalog.as_ref(), &ident, &path, mixedbread).await);
+    }
+
+    // Consume mode (parquet corpus log): read the per-source `data.parquet` files
+    // `sink-parquet` wrote at this prefix under `--bucket` and reconcile them back
+    // into Mixedbread. Uses the SAME bucket/endpoint/region the parquet sink uses,
+    // so it reads exactly what was written. Emit (scan local sources, write the
+    // log) and consume (replay the log into Mixedbread) run as separate
+    // invocations of this binary; consume reconciles the log rather than scanning.
+    if let Some(prefix) = cli.from_parquet_prefix.clone() {
+        let bucket = cli
+            .bucket
+            .clone()
+            .context("--from-parquet-prefix requires --bucket")?;
+        let config = source_parquet::Config {
+            bucket,
+            endpoint: cli.endpoint.clone(),
+            region: cli.region.clone(),
+            prefix,
+        };
+        // With --catalog-uri this folds the parquet archive INTO the lake (the
+        // leader's parquet->lake step under leader-funnel, issue #752);
+        // otherwise it replays the archive into Mixedbread. The lake fold keeps
+        // each (host, user, source) slice separate, so it cannot share
+        // consume_parquet's host-flattened read.
+        if cli.catalog_uri.is_some() {
+            let Lake { catalog, ident } = connect_lake(cli).await?;
+            return finish(fold_parquet_into_lake(&config, catalog, &ident).await);
+        }
+        let mixedbread = mixedbread
+            .context("--from-parquet-prefix requires --mixedbread-store or --catalog-uri")?;
+        return finish(consume_parquet(&config, mixedbread).await);
+    }
+
+    unreachable!("run_consume_mode requires exactly one consume flag set")
 }
 
 /// Build the lake's catalog config from the CLI: the catalog flags plus the
@@ -632,33 +648,7 @@ async fn run_sources(
             Err(error) => record("shell", Err(error), &mut counts),
         }
     }
-    if let Some(dir) = &cli.slack_export {
-        let result = async {
-            let adapter = source_slack::SlackExport::open(dir)
-                .with_context(|| format!("reading Slack export at {}", dir.display()))?;
-            run_source("slack", &adapter, mixedbread, parquet, lake).await
-        }
-        .await;
-        record("slack", result, &mut counts);
-    }
-    if let Some(dir) = &cli.linear_export {
-        let result = async {
-            let adapter = source_linear::LinearExport::open(dir)
-                .with_context(|| format!("reading Linear export at {}", dir.display()))?;
-            run_source("linear", &adapter, mixedbread, parquet, lake).await
-        }
-        .await;
-        record("linear", result, &mut counts);
-    }
-    if let Some(dir) = &cli.github_export {
-        let result = async {
-            let adapter = source_github::GithubExport::open(dir)
-                .with_context(|| format!("reading GitHub export at {}", dir.display()))?;
-            run_source("github", &adapter, mixedbread, parquet, lake).await
-        }
-        .await;
-        record("github", result, &mut counts);
-    }
+    run_static_exports(cli, mixedbread, parquet, lake, &mut counts).await;
     for repo in &cli.git_repos {
         let label = format!("git:{}", repo.display());
         let result = async {
@@ -678,6 +668,45 @@ async fn run_sources(
         run_users(cli, mixedbread, parquet, lake, &mut counts).await;
     }
     counts
+}
+
+/// Run the directory-based export sources (Slack, Linear, GitHub), each
+/// independent (a failure never aborts the others), accumulating into the
+/// shared counters. Split out of [`run_sources`] to keep each function focused.
+async fn run_static_exports(
+    cli: &Cli,
+    mixedbread: Option<Mixedbread<'_>>,
+    parquet: Option<&ParquetReconciler>,
+    lake: Option<&IcebergReconciler>,
+    counts: &mut Counts,
+) {
+    if let Some(dir) = &cli.slack_export {
+        let result = async {
+            let adapter = source_slack::SlackExport::open(dir)
+                .with_context(|| format!("reading Slack export at {}", dir.display()))?;
+            run_source("slack", &adapter, mixedbread, parquet, lake).await
+        }
+        .await;
+        record("slack", result, counts);
+    }
+    if let Some(dir) = &cli.linear_export {
+        let result = async {
+            let adapter = source_linear::LinearExport::open(dir)
+                .with_context(|| format!("reading Linear export at {}", dir.display()))?;
+            run_source("linear", &adapter, mixedbread, parquet, lake).await
+        }
+        .await;
+        record("linear", result, counts);
+    }
+    if let Some(dir) = &cli.github_export {
+        let result = async {
+            let adapter = source_github::GithubExport::open(dir)
+                .with_context(|| format!("reading GitHub export at {}", dir.display()))?;
+            run_source("github", &adapter, mixedbread, parquet, lake).await
+        }
+        .await;
+        record("github", result, counts);
+    }
 }
 
 /// Run the `--user NAME:HOME` multi-user phase, accumulating into the shared

--- a/packages/pi-harnesses/shared/mk-pi-harness.nix
+++ b/packages/pi-harnesses/shared/mk-pi-harness.nix
@@ -61,8 +61,8 @@ let
       "--no-extensions"
       "--no-skills"
     ]
-    ++ lib.optionals (!session) [ "--no-session" ]
-    ++ lib.optionals headless [ "--print" ]
+    ++ lib.optional (!session) "--no-session"
+    ++ lib.optional headless "--print"
     ++ lib.optionals (headless && mode != null) [
       "--mode"
       mode

--- a/packages/reel/src/raster.rs
+++ b/packages/reel/src/raster.rs
@@ -119,7 +119,7 @@ pub fn render_frame(
     draw_chrome(&mut canvas, palette, font, layout);
     match frame {
         Frame::Terminal { cells, cursor } => {
-            draw_terminal(&mut canvas, palette, font, layout, cells, *cursor)
+            draw_terminal(&mut canvas, palette, font, layout, cells, *cursor);
         }
         Frame::Card(card) => draw_card(&mut canvas, palette, font, layout, card),
     }


### PR DESCRIPTION
-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix clippy and lint failures blocking the merge queue
> - Makes `ChangeKind::from_delta` and `maxrss_to_bytes` `const fn` to satisfy const context requirements in [git.rs](https://github.com/indexable-inc/index/pull/985/files#diff-1c773343e00a72dd79022529dee02bb58edc0cd528677f17d640df4ee4ca463a) and [macro_harness.rs](https://github.com/indexable-inc/index/pull/985/files#diff-551f78c2dfd3e120480a45fb96c6ebdf1810c2c2d4e6a80cbffb3d00946ea9d0)
> - Fixes missing semicolons in [macro_harness.rs](https://github.com/indexable-inc/index/pull/985/files#diff-551f78c2dfd3e120480a45fb96c6ebdf1810c2c2d4e6a80cbffb3d00946ea9d0) and [raster.rs](https://github.com/indexable-inc/index/pull/985/files#diff-eb8cda2bd6ef0940ce671cb16eaca99483fc77a3116720fc6a48c847480742ea) that caused lint warnings
> - Refactors [main.rs](https://github.com/indexable-inc/index/pull/985/files#diff-5664bac77cedfa678d477bb44bf07a8888bdbb1eb15055f1c164d6c9c131ce7d) to extract consume-mode dispatch into `run_consume_mode` and static exports into `run_static_exports`, resolving dead-code and complexity warnings
> - Replaces `lib.optionals` with `lib.optional` for single-element lists in [mk-pi-harness.nix](https://github.com/indexable-inc/index/pull/985/files#diff-19e403e172e5bc48bd8ffe7b99dd96bab25daae60447b04dd2408ac277f6eae5)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c991cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->