### PR TITLE
feat(symphony): add :pi to the engine envelope and attempt vocabulary

### DIFF
--- a/packages/symphony/elixir/lib/symphony_elixir/engine/envelope.ex
+++ b/packages/symphony/elixir/lib/symphony_elixir/engine/envelope.ex
@@ -12,11 +12,14 @@ defmodule SymphonyElixir.Engine.Envelope do
 
   ## Fields
 
-  - `engine` - `:codex` or `:claude`. Explicit; never inferred from the
-    model name.
+  - `engine` - `:codex`, `:claude`, or `:pi`. Explicit; never inferred
+    from the model name.
   - `model` - the model identifier passed through to the engine verbatim
     (for example `gpt-5.3-codex` or `claude-opus-4-8`, or the `opus` /
-    `sonnet` / `haiku` aliases Claude accepts).
+    `sonnet` / `haiku` aliases Claude accepts). For `:pi` it is a
+    pi-harness model alias (`claude`, `codex`, ...): the room-server
+    forwards it as `PI_HARNESS_MODEL` and the harness's own model table
+    resolves the provider and concrete model.
   - `effort` - reasoning budget. One of `:none`, `:minimal`, `:low`,
     `:medium`, `:high`, `:xhigh`, or `nil` to let the engine pick its
     default.
@@ -40,7 +43,7 @@ defmodule SymphonyElixir.Engine.Envelope do
   @enforce_keys [:engine, :model]
   defstruct [:engine, :model, :effort, :permissions, :location]
 
-  @engines [:codex, :claude]
+  @engines [:codex, :claude, :pi]
   @efforts [:none, :minimal, :low, :medium, :high, :xhigh]
   @permissions [:read_only, :workspace_write, :danger_full_access]
   # The placement targets a `location` can name. `:host` and `:room` carry
@@ -236,4 +239,11 @@ defmodule SymphonyElixir.Engine.Envelope do
   defp check_engine_model_agree(:claude, model) do
     if claude_model?(model), do: :ok, else: {:error, {:engine_model_mismatch, :claude, model}}
   end
+
+  # Pi is a meta-harness fronting multiple providers: its model value is a
+  # pi-harness alias ("claude", "codex", ...) resolved by the harness's own
+  # model table, so a Claude-looking model under :pi is correct, not a
+  # mismatch. Existence of the alias is validated by the harness at turn
+  # start, where the table lives.
+  defp check_engine_model_agree(:pi, _model), do: :ok
 end

--- a/packages/symphony/elixir/lib/symphony_elixir/ir/attempt.ex
+++ b/packages/symphony/elixir/lib/symphony_elixir/ir/attempt.ex
@@ -28,12 +28,12 @@ defmodule SymphonyElixir.IR.Attempt do
   ]
 
   @typedoc """
-  What executed the attempt. `:codex`/`:claude` are engine turns; `:exec`
-  is a pack shell script; `:subrun` is a child run. A non-agent node has
-  no engine, so its attempt records the executor kind instead of a sham
-  `:codex`.
+  What executed the attempt. `:codex`/`:claude`/`:pi` are engine turns;
+  `:exec` is a pack shell script; `:subrun` is a child run. A non-agent
+  node has no engine, so its attempt records the executor kind instead of
+  a sham `:codex`.
   """
-  @type engine :: :codex | :claude | :exec | :subrun
+  @type engine :: :codex | :claude | :pi | :exec | :subrun
   @type state :: :running | :succeeded | :failed | :timeout | :cancelled | :stranded
 
   @typedoc """
@@ -69,7 +69,7 @@ defmodule SymphonyElixir.IR.Attempt do
         }
 
   @states [:running, :succeeded, :failed, :timeout, :cancelled, :stranded]
-  @engines [:codex, :claude, :exec, :subrun]
+  @engines [:codex, :claude, :pi, :exec, :subrun]
 
   @doc "The attempt states a persisted attempt may hold. Source of truth for safe decode."
   @spec states() :: [state()]

--- a/packages/symphony/elixir/lib/symphony_elixir/runtime.ex
+++ b/packages/symphony/elixir/lib/symphony_elixir/runtime.ex
@@ -789,7 +789,9 @@ defmodule SymphonyElixir.Runtime do
   # An attempt records what executed it. Agent attempts carry the engine;
   # exec/subrun carry the executor kind so the run record is honest about a
   # node that never touched an engine.
-  defp attempt_engine(%Node{kind: :agent, envelope: %{engine: engine}}) when engine in [:codex, :claude], do: engine
+  defp attempt_engine(%Node{kind: :agent, envelope: %{engine: engine}}) when engine in [:codex, :claude, :pi],
+    do: engine
+
   defp attempt_engine(%Node{kind: :exec}), do: :exec
   defp attempt_engine(%Node{kind: :subrun}), do: :subrun
   defp attempt_engine(_node), do: :codex

--- a/packages/symphony/elixir/lib/symphony_elixir/runtime/recovery.ex
+++ b/packages/symphony/elixir/lib/symphony_elixir/runtime/recovery.ex
@@ -204,7 +204,9 @@ defmodule SymphonyElixir.Runtime.Recovery do
     Enum.map(attempts, fn a -> if a.n == current.n, do: finished, else: a end)
   end
 
-  defp attempt_engine(%Node{envelope: %{engine: engine}}) when engine in [:codex, :claude], do: engine
+  defp attempt_engine(%Node{envelope: %{engine: engine}}) when engine in [:codex, :claude, :pi],
+    do: engine
+
   defp attempt_engine(_node), do: :codex
 
   defp attempt_state_for({:ok, _}), do: :succeeded

--- a/packages/symphony/elixir/test/symphony_elixir/engine/client_test.exs
+++ b/packages/symphony/elixir/test/symphony_elixir/engine/client_test.exs
@@ -52,6 +52,15 @@ defmodule SymphonyElixir.Engine.ClientTest do
       refute Map.has_key?(body, "nodeId")
     end
 
+    test "lowers a pi envelope to the room-server wire shape" do
+      # The room-server's EngineKind deserializes lowercase ("pi"); the model
+      # rides through verbatim as the pi-harness alias (PI_HARNESS_MODEL).
+      {:ok, env} = Envelope.validate(%Envelope{engine: :pi, model: "claude", location: :local})
+      assert {:ok, body} = Client.request_body(env, %{prompt: "hi", cwd: "/w"})
+      assert body["engine"] == "pi"
+      assert body["model"] == "claude"
+    end
+
     test "rejects a turn missing the prompt or cwd" do
       {:ok, env} = Envelope.validate(%Envelope{engine: :claude, model: "haiku", location: :local})
       assert {:error, :missing_prompt} = Client.request_body(env, %{cwd: "/w"})

--- a/packages/symphony/elixir/test/symphony_elixir/engine/envelope_test.exs
+++ b/packages/symphony/elixir/test/symphony_elixir/engine/envelope_test.exs
@@ -46,6 +46,23 @@ defmodule SymphonyElixir.Engine.EnvelopeTest do
                Envelope.from_map(%{"engine" => "claude", "model" => "gpt-5.3-codex"})
     end
 
+    test "builds a valid pi envelope and defaults permissions and location" do
+      assert {:ok, env} = Envelope.from_map(%{"engine" => "pi", "model" => "claude"})
+
+      assert env.engine == :pi
+      assert env.model == "claude"
+      assert env.permissions == :workspace_write
+      assert env.location == :local
+    end
+
+    test "pi accepts any model alias (the harness's model table resolves it)" do
+      # Pi fronts multiple providers, so a claude-looking alias under :pi is
+      # correct, not an engine/model mismatch.
+      assert {:ok, %{engine: :pi}} = Envelope.from_map(%{"engine" => "pi", "model" => "claude"})
+      assert {:ok, %{engine: :pi}} = Envelope.from_map(%{"engine" => "pi", "model" => "codex"})
+      assert {:ok, %{engine: :pi}} = Envelope.from_map(%{"engine" => "pi", "model" => "opus"})
+    end
+
     test "rejects unknown keys instead of silently ignoring them" do
       assert {:error, {:unknown_envelope_keys, ["sandbox"]}} =
                Envelope.from_map(%{"engine" => "claude", "model" => "opus", "sandbox" => "workspace-write"})


### PR DESCRIPTION
Completes the Elixir half of the room engine unification (ix-side: indexable-inc/ix#4539). The room-server has run a pi engine adapter for a while (`EngineKind::Pi`, lowering `TurnRequest.model` to `PI_HARNESS_MODEL` for the MCP-locked pi-harness engine posture), but the runtime could not declare it.

## Changes
- **`Engine.Envelope`**: `:pi` joins `@engines`. Pi is a meta-harness fronting multiple providers; its `model` is a pi-harness alias (`claude`, `codex`, ...) resolved by the harness's own model table, so the claude/codex engine-model mismatch guard deliberately does not apply (a claude-looking alias under `:pi` is correct). The DSL schema derives engines from `Envelope.engines()`, so the form offers `pi` automatically.
- **`IR.Attempt`**: `:pi` joins the engine type + decode vocabulary.
- **`runtime.ex` / `recovery.ex`**: the `attempt_engine` guards include `:pi`. Previously any non-codex/claude engine **silently recorded the attempt as `:codex`** - a `:pi` run would have been misattributed in the run record.

`Engine.Client` lowers the engine atom generically (`Atom.to_string`), so the wire shape needs no change.

## Not in scope (deliberate)
The runtime's `Engine.Client` stays on the synchronous `POST /api/agent/turns` -> `AgentTurnResponse` surface; nothing in the ix-side pipeline change altered that contract (the new `EngineEvent` variants and the `engine:events` CRDT log are additive, and the runtime does not parse the event stream today). A streaming/CRDT consumer in the runtime is a feature with no current consumer, so it is not stubbed in here.

## Tests
- Envelope: valid pi envelope with defaults; pi accepts any alias (claude/codex/opus).
- Client: pi envelope lowers to `"engine": "pi"` with the model riding verbatim.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `:pi` as a supported engine in Symphony envelope and attempt vocabulary
> - Adds `:pi` to the `@engines` list in [`Envelope`](https://github.com/indexable-inc/index/pull/988/files#diff-1878fcebc0b6e96def8189c5c17cf13ebee8bd857846a0d31d02512162830921) and [`Attempt`](https://github.com/indexable-inc/index/pull/988/files#diff-66f68a35914a4f021be05c046afe276efe1ff062784057614b6828a6279d8e31), enabling `:pi` to pass validation throughout encoding, decoding, and type checks.
> - Skips model/provider consistency checks for `:pi` in `check_engine_model_agree/2`, so any model alias is accepted without pattern matching against a specific provider.
> - Updates `attempt_engine/2` in both [`Runtime`](https://github.com/indexable-inc/index/pull/988/files#diff-66b52590997a473e90f9cf449bfab03b019f2db143377bc3ea621be532fa1041) and [`Runtime.Recovery`](https://github.com/indexable-inc/index/pull/988/files#diff-161d7238c6748a0117dfcb8cabf6dfbebe5dee869643bb9158dd8029e13c6f0e) to return `:pi` directly instead of defaulting to `:codex` for agent nodes using the `:pi` engine.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ebb2b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->