### PR TITLE
mcp: de-jank kernel modules and fix the open MCP tool issues

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1132,6 +1132,51 @@ let
         assert slow.done() and slow.ok, slow.status
         assert slow.result.llm_result == "late", slow.result
 
+        # Job.wait: a timed wait that never raises -- one cell replaces a
+        # sleep-and-poll loop. At a short deadline the job is still running;
+        # with no deadline it returns the finished job.
+        slow2 = await run("import asyncio\nawait asyncio.sleep(0.3)\nResult.text('w')", budget=0.02, name="wait")
+        assert (await slow2.wait(0.01)).running(), slow2.status
+        assert (await slow2.wait()).done() and slow2.result.llm_result == "w"
+
+        # A Result nested inside a Result (llm_result=Result.text(...)) is
+        # flattened to its model text at construction, so the summary/paging
+        # path never hits a non-str ("Result object is not subscriptable").
+        nested = runtime.Result(user_html="<b>x</b>", llm_result=runtime.Result.text("inner"))
+        assert nested.llm_result == "inner", nested.llm_result
+        nj = await run(
+            "Result(user_html='<b>x</b>', llm_result=Result.text('inner-e2e'))",
+            budget=2.0, name="nested",
+        )
+        assert nj.status == "done", (nj.status, nj.error)
+        assert "inner-e2e" in nj.tail(100), nj.tail(100)
+        assert runtime._job_summary(nj)["result_chars"] == len("inner-e2e")
+        # Any other non-str llm_result coerces to its repr rather than crash later.
+        odd = runtime.Result(user_html="x", llm_result=123)
+        assert odd.llm_result == "123", odd.llm_result
+
+        # __ix_read: a file-path target returns the file's CONTENTS to the model
+        # (the dashboard note is user_html only), honoring start/end; and an
+        # expression that EVALUATES to an existing path reads that file too.
+        import pathlib
+        import tempfile
+        rd = ns["__ix_read"]
+        p = pathlib.Path(tempfile.mkdtemp()) / "sample.txt"
+        body = "alpha\nbeta\ngamma\ndelta"
+        p.write_text(body)
+        whole = await rd(str(p), None, None)
+        assert whole.llm_result == body, repr(whole.llm_result)
+        assert str(p) not in whole.llm_result or whole.llm_result == body
+        span = await rd(str(p), 2, 3)
+        assert span.llm_result == "beta\ngamma", repr(span.llm_result)
+        ns["sample_path"] = str(p)
+        via_expr = await rd("sample_path", None, None)
+        assert via_expr.llm_result == body, repr(via_expr.llm_result)
+        # A plain expression target still renders its value.
+        ns["answer"] = 41
+        via_val = await rd("answer + 1", None, None)
+        assert via_val.llm_result == "42", repr(via_val.llm_result)
+
     asyncio.run(main())
     # api(): a discoverable catalog of kernel builtins + bundled modules.
     cat = ns["api"]()
@@ -2473,6 +2518,63 @@ let
         direct = await sh("printf hi", cwd=".")
         assert direct.ok and direct.text == "hi", repr(direct.text)
 
+        # cwd defaults to the current directory: no required-kwarg TypeError.
+        import os
+        here = await sh("pwd")
+        assert here.ok and here.text.strip() == os.path.realpath(os.getcwd()), (
+            here.text, os.getcwd())
+
+        # An Output composes like its text: slice, concat, contains, len, str.
+        assert direct[-1:] == "i" and direct[0] == "h", (direct[-1:], direct[0])
+        assert direct + "!" == "hi!" and "say " + direct == "say hi"
+        assert "hi" in direct and len(direct) == 2 and str(direct) == "hi"
+        assert bool(await sh("true")) is True  # empty but successful: still truthy
+
+        # Output streams to sys.stdout as it arrives (echo=True forces it outside
+        # a kernel job), escape-stripped -- so a long command's log lands in the
+        # job's pageable stdout even if the cell backgrounds before binding it.
+        import contextlib
+        import io
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            echoed = await sh(r"printf '\033[31mstreamed\033[0m\n'", echo=True)
+        assert "streamed" in buf.getvalue() and "\x1b" not in buf.getvalue(), repr(buf.getvalue())
+        assert "streamed" in echoed.text, repr(echoed.text)
+        # And echo stays off by default outside a kernel job.
+        quiet = io.StringIO()
+        with contextlib.redirect_stdout(quiet):
+            await sh("printf silent")
+        assert quiet.getvalue() == "", repr(quiet.getvalue())
+
+        # Cancelling the awaiting task kills the child's whole process group:
+        # no orphan keeps running (or holding a lock) after a .cancel().
+        import signal
+        import tempfile
+        pidfile = tempfile.mktemp()
+        task = asyncio.ensure_future(sh(f"echo $$ > {pidfile}; sleep 30", cwd="."))
+        for _ in range(100):
+            await asyncio.sleep(0.05)
+            try:
+                pid = int(open(pidfile).read().strip())
+                break
+            except (FileNotFoundError, ValueError):
+                continue
+        else:
+            raise SystemExit("child never wrote its pidfile")
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        await asyncio.sleep(0.3)
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            pass  # the group is dead, as required
+        else:
+            os.kill(pid, signal.SIGKILL)
+            raise SystemExit(f"cancel orphaned the child (pid {pid} still alive)")
+
         print("sh-ok", sh.__version__)
 
 
@@ -3037,7 +3139,17 @@ let
         print("vdom-ok", browser.__version__, n_real, "nodes")
 
 
-    asyncio.run(main())
+    # A sandboxed headless chromium occasionally tears down mid-run
+    # (TargetClosedError); that is environment flake, not a vdom regression, so
+    # retry the whole run a couple of times before failing the gate.
+    for attempt in range(3):
+        try:
+            asyncio.run(main())
+            break
+        except Exception as exc:
+            if attempt == 2 or "closed" not in str(exc).lower():
+                raise
+            print(f"retry {attempt + 1}: transient browser teardown: {exc}", file=sys.stderr)
   '';
   browserVdomSmoke =
     pkgs.runCommand "ix-mcp-browser-vdom-smoke"

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -70,7 +70,7 @@ BLOCKING = (
     "CPU-bound numpy op) freezes the WHOLE kernel: every other job and even your own next "
     "status-check cell stall behind it until it returns. So a blocking call MUST be made "
     "non-blocking: wrap it in `await asyncio.to_thread(...)`, or prefer the async API (`fff`, "
-    "`httpx`, and the bundled `sh(cmd, cwd=...)` to shell out instead of `subprocess.run`), and run "
+    "`httpx`, and the bundled `sh(cmd)` to shell out instead of `subprocess.run`), and run "
     "anything slow as a background job you "
     "poll, never inline. To shell out, reach for `sh()` rather than a hand-rolled "
     "`asyncio.create_subprocess_exec/_shell` + `communicate()`: `sh()` runs the child in its own "
@@ -120,8 +120,8 @@ NO_SHELL = (
     "frame rather than an unstyled text dump. To list a directory use `view.ls`/`view.tree`, never "
     "`os.walk` or `ls`; to edit, `view.edit(path, old, new)`, never blind. For meaning-based "
     "recall across a corpus, `import search`. When you genuinely must shell out, use the async "
-    "`sh` (it runs off the loop and preserves clean color) and pass it a `cwd=` (`cwd=\".\"` for "
-    "here), never a `cd X && ...` prefix."
+    "`sh` (it runs off the loop, streams into the job's pageable output, and preserves clean "
+    "color); to run elsewhere pass `cwd=`, never a `cd X && ...` prefix."
 )
 
 VERIFY = (
@@ -217,7 +217,8 @@ READ = (
     "cell's result streams to BOTH audiences, so it would flood the dashboard. `target` is read "
     "as a file when it names an existing file, otherwise it is evaluated as a Python expression "
     "in the kernel namespace (e.g. `jobs['ab12'].output` to page a job, or a variable you bound "
-    "earlier). Pass `start` / `end` for a 1-based inclusive line range."
+    "earlier); an expression whose value is a string naming an existing file reads that file "
+    "too. Pass `start` / `end` for a 1-based inclusive line range."
 )
 
 TRACE = (

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -59,6 +59,25 @@ MODULES: tuple[Module, ...] = (
     Module("search", "meaning-based semantic recall across an indexed corpus"),
     Module("tui", "drive and snapshot a terminal program; renders as HTML"),
     Module(
+        "screen",
+        "native macOS desktop control: capture the screen, a region, or one app's window "
+        "(`screen.capture(app=...)`), move/click the mouse, type, and manage apps (macOS only)",
+    ),
+    Module(
+        "vmkit",
+        "boot and drive a macOS/Linux guest VM fully off-screen and screenshot its display "
+        "(macOS only)",
+    ),
+    Module(
+        "imessage",
+        "read Messages and Contacts into polars and send iMessages "
+        "(`imessage.messages()` / `chats()` / `send()`) (macOS only)",
+    ),
+    Module(
+        "tasks",
+        "generate and read the task-graph demo's SQLite DAG (`tasks.seed` / `load` / `frame`)",
+    ),
+    Module(
         "worktree",
         "do risky or parallel work on a throwaway branch in its own checkout, leaving the main "
         "tree untouched",

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -326,6 +326,16 @@ class Job:
             self.task.cancel()
         return self
 
+    async def wait(self, timeout: float | None = None) -> "Job":
+        """Wait until this job finishes, or up to ``timeout`` seconds, and return
+        the job (check ``.done()`` / ``.status`` / ``.result`` on it). Unlike
+        ``await jobs['<id>']`` it never raises on a slow job -- it just returns
+        the still-running handle at the deadline -- so one cell replaces a
+        sleep-and-poll loop: ``(await jobs['ab12'].wait(30)).status``."""
+        if self.task is not None and not self.task.done():
+            await asyncio.wait({self.task}, timeout=timeout)
+        return self
+
     def __await__(self):
         # `await jobs['id']` should yield the job's result, but the runner task
         # returns None, so wait for it then hand back the captured result.
@@ -340,6 +350,24 @@ class Job:
         head = f"<Job {self.id} ({self.name}) [{self.status}] {dur:.2f}s>"
         out = self.tail(800)
         return head + ("\n" + out if out else "")
+
+
+def _llm_text(value):
+    """Coerce a model-facing text field to ``str`` (or None to keep a default).
+
+    ``llm_result`` flows into string paths (the job summary, ``Job.tail``
+    paging, the reply text), so a non-str here -- most commonly a Result nested
+    inside a Result, e.g. ``Result(llm_result=await browser.read(pg))`` -- used
+    to surface later as an opaque ``TypeError`` deep in the runtime. Flatten a
+    nested Result/Output to its own model text, and any other value to its repr,
+    at construction time instead.
+    """
+    if value is None or isinstance(value, str):
+        return value
+    inner = getattr(value, "llm_result", None)
+    if isinstance(inner, str):
+        return inner
+    return _safe_repr(value)
 
 
 class Result:
@@ -365,7 +393,12 @@ class Result:
 
     ``llm_images`` items may be raw PNG/JPEG bytes, a base64 string, a data URI,
     a matplotlib Figure, a PIL image, or a path to an image file; each is sent to
-    the model as a real image block. It is a mime bundle under the hood:
+    the model as a real image block, downscaled and re-encoded to fit the model
+    image budget (``IX_MCP_IMAGE_MAX_DIM`` / ``IX_MCP_IMAGE_MAX_BYTES``), so a
+    full-res screenshot never floods the reply. For an image meant only for the
+    human, put it in ``user_html`` (an ``<img>`` data URI) and omit
+    ``llm_images``: the dashboard shows the picture, the model pays no vision
+    tokens at all. It is a mime bundle under the hood:
     ``text/html`` carries ``user_html`` and, when present, ``IX_LLM_MIME`` carries
     the model's text+images (unpacked by the server); ``text/plain`` carries the
     text as a fallback for plain hosts.
@@ -378,6 +411,7 @@ class Result:
     # the keywords, which always win: `Result(user_html=..., llm_result=...,
     # llm_images=[...])`.
     def __init__(self, *values, user_html=None, llm_result=None, llm_images=None):
+        llm_result = _llm_text(llm_result)
         if user_html is not None:
             self.user_html = user_html
             self.llm_result = llm_result if llm_result is not None else ""
@@ -441,6 +475,18 @@ class Result:
             user = f'<img alt="" src="data:{img["mime"]};base64,{img["data"]}" />'
             note = llm_result if llm_result is not None else f"[{image_mime} image, {len(bytes(value))} bytes]"
             return cls(user_html=user, llm_result=note, llm_images=[value])
+        module = type(value).__module__ or ""
+        if module.startswith(("matplotlib", "PIL")):
+            # A figure or PIL image (e.g. `screen.capture()`): treat it exactly
+            # like raw screenshot bytes -- inline image for the human, a real,
+            # size-fitted image block for the model -- rather than leaving the
+            # model a repr while a full-res PNG rides the display bundle (where
+            # the byte cap would drop it entirely).
+            img = _coerce_image(value)
+            if img is not None:
+                user = f'<img alt="" src="data:{img["mime"]};base64,{img["data"]}" />'
+                note = llm_result if llm_result is not None else f"[{img['mime']} image]"
+                return cls(user_html=user, llm_result=note, llm_images=[value])
         if isinstance(value, str):
             # A plain string is output, not a Python literal: hand the model the
             # string verbatim with terminal escapes stripped, so captured CLI /
@@ -1743,10 +1789,16 @@ _SUMMARY_CHARS = 50_000
 
 def _result_text(job: Job) -> str:
     """The job result's model-facing text (a Result's ``llm_result``, else its
-    repr), used only to measure how much the inline summary leaves out."""
+    repr). Feeds ``Job.pageable`` and the per-call summary, so it must always be
+    a ``str`` -- a non-str ``llm_result`` (now coerced at Result construction,
+    but possibly present on an old object) falls back to the repr rather than
+    crash the summary path."""
     if job._result is None:
         return ""
-    return getattr(job._result, "llm_result", None) or _safe_repr(job._result)
+    text = getattr(job._result, "llm_result", None)
+    if isinstance(text, str) and text:
+        return text
+    return _safe_repr(job._result)
 
 
 def _job_summary(job: Job) -> dict:
@@ -1809,6 +1861,19 @@ async def __ix_exec(code: str, budget: float = 15.0, name: str | None = None) ->
     """The MCP server's per-call entrypoint: run with a budget, emit the summary."""
     job = await __ix_run(code, budget=budget, name=name)
     _emit(job)
+
+
+def _existing_file(value) -> pathlib.Path | None:
+    """``value`` as a :class:`pathlib.Path` when it is a string naming an
+    existing file, else None. The one rule `__ix_read` applies to both the raw
+    ``target`` and to a string an expression evaluates to."""
+    if not isinstance(value, str) or not value or len(value) > 4096 or "\n" in value:
+        return None
+    try:
+        candidate = pathlib.Path(value).expanduser()
+        return candidate if candidate.is_file() else None
+    except OSError:
+        return None
 
 
 def _tilde(path) -> str:
@@ -1894,13 +1959,15 @@ async def __ix_read(target, start=None, end=None) -> "Result":
     ``end`` select a 1-based inclusive line range. Backs the ``read`` MCP tool.
     """
     ns = _user_ns if _user_ns is not None else globals()
-    path = None
-    if isinstance(target, str):
-        try:
-            candidate = pathlib.Path(target).expanduser()
-            path = candidate if candidate.is_file() else None
-        except OSError:
-            path = None
+    value = None
+    path = _existing_file(target)
+    if path is None:
+        # Not a file on disk: evaluate the expression. If the VALUE is a string
+        # naming an existing file (`os.path.join(...)`, a variable holding a
+        # path), the same file rule applies to it -- an expression yielding a
+        # path reads the file, never echoes the path string back.
+        value = eval(target, ns) if isinstance(target, str) else target
+        path = _existing_file(value)
     if path is not None:
         # Off the loop: a large file read is blocking I/O, the one thing that
         # freezes every other job on the shared event loop.
@@ -1908,7 +1975,6 @@ async def __ix_read(target, start=None, end=None) -> "Result":
         label = _tilde(path)
         icon = _file_icon_svg(path)
     else:
-        value = eval(target, ns) if isinstance(target, str) else target
         full = value if isinstance(value, str) else _safe_repr(value)
         label = target if isinstance(target, str) else _safe_repr(target)
         icon = _value_icon_svg()

--- a/packages/mcp/src/browser/browser/__init__.py
+++ b/packages/mcp/src/browser/browser/__init__.py
@@ -11,7 +11,7 @@ hands you a live Playwright ``Page``. The Playwright driver and the CDP connecti
 are started once and cached, so successive calls reuse the same session.
 
     import browser
-    await browser.get_or_create_browser()        # connect, or launch a visible Dia
+    await browser.get_or_create_browser()        # connect, or launch a visible Chrome
     await browser.goto("https://example.com")     # navigate the front tab
     await browser.shot()                          # screenshot -> a Result (image)
     await browser.read()                          # cheap text+elements readout (no vision tokens)
@@ -91,9 +91,14 @@ __version__ = "0.2.0"
 # argument at all.
 DEFAULT_ENDPOINT = "http://127.0.0.1:9222"
 
-# The browser to launch when none is running. Dia is the default on this fleet; a
-# caller can pass any Chromium-family app name (macOS) or executable path.
-DEFAULT_APP = "Dia"
+# The browser to launch when none is running: a stock Chromium-family browser
+# whose UI actually renders CDP-created tabs, so the "visible, never headless"
+# promise holds -- you can SEE and click the tab `goto` opened. Dia (Arc engine)
+# manages its tab strip in its own layer and never shows CDP-created tabs, so a
+# page driven in Dia is live but invisible in its UI; pass `app="Dia"` only if
+# you know you want that. Any Chromium-family app name (macOS) or executable
+# path works.
+DEFAULT_APP = "Google Chrome"
 
 # Started once per kernel and reused: the Playwright driver process and one CDP
 # connection per endpoint. Module-level so the live browser session survives across
@@ -172,9 +177,14 @@ async def get_or_create_browser(
     Playwright ``Browser``.
 
     ``app`` is the browser to launch when none is running (a macOS application name
-    like ``"Dia"`` / ``"Google Chrome"``, or an executable path elsewhere);
+    like ``"Google Chrome"`` / ``"Dia"``, or an executable path elsewhere);
     ``user_data_dir`` is the profile to launch with (defaults to a dedicated
-    ``~/.cdp-<app>-profile`` so it never disturbs your everyday session)."""
+    ``~/.cdp-<app>-profile`` so it never disturbs your everyday session).
+
+    A LAUNCH (as opposed to a reuse) is announced on stdout: the launched browser
+    is a separate instance on a fresh, logged-out profile, possibly behind other
+    windows -- without the note, "it worked" is indistinguishable from "nothing
+    happened" to the human looking for the window."""
     try:
         return await connect(endpoint)
     except Exception:
@@ -196,6 +206,11 @@ async def get_or_create_browser(
             f"launched {app!r} but no CDP endpoint came up at {endpoint} within {timeout}s "
             f"(argv: {argv})"
         )
+    print(
+        f"browser: launched a NEW visible {app} instance on {endpoint} with its own "
+        f"profile {udd} (a fresh, logged-out session, separate from your everyday "
+        f"{app}; its window may be behind others). Future calls reuse it."
+    )
     return await connect(endpoint)
 
 
@@ -253,10 +268,22 @@ async def goto(
     return pg
 
 
-async def shot(target=None, *, endpoint: str = DEFAULT_ENDPOINT, full_page: bool = False):
+async def shot(
+    target=None,
+    *,
+    endpoint: str = DEFAULT_ENDPOINT,
+    full_page: bool = False,
+    to_model: bool = True,
+):
     """Screenshot a ``Page`` (or the front tab when ``target`` is None) and return a
     :class:`Result`: the human sees the image, the model gets the PNG plus the page's
-    title and url. End a cell with it to render the screenshot."""
+    title and url. End a cell with it to render the screenshot.
+
+    The model's copy is automatically downscaled and re-encoded by the kernel to
+    fit the image budget (``IX_MCP_IMAGE_MAX_DIM`` / ``IX_MCP_IMAGE_MAX_BYTES``),
+    so a quick visual check costs a thumbnail, never a full-res blob. Pass
+    ``to_model=False`` for a dashboard-only screenshot: the human sees the full
+    image, the model gets just the title/url note and zero vision tokens."""
     pg = target if target is not None else await page(endpoint=endpoint)
     try:
         await pg.bring_to_front()
@@ -278,7 +305,8 @@ async def shot(target=None, *, endpoint: str = DEFAULT_ENDPOINT, full_page: bool
 
         data_uri = "data:image/png;base64," + _base64.b64encode(png).decode("ascii")
         user_html = f'<img alt="{_html.escape(note)}" src="{data_uri}" style="max-width:100%" />'
-        return Result(user_html=user_html, llm_result=note, llm_images=[png])
+        images = [png] if to_model else []
+        return Result(user_html=user_html, llm_result=note, llm_images=images)
     except Exception:
         # Outside the kernel (no runtime): hand back the raw PNG bytes.
         return png
@@ -740,16 +768,33 @@ async def vdom(
     ``viewport_only=True`` to keep only what is currently on screen, so the snapshot
     stays small. ``max_text`` bounds each accessible name's length.
     """
+    opts = {
+        "interactiveOnly": interactive_only,
+        "viewportOnly": viewport_only,
+        "maxText": max_text,
+    }
     pg = target if target is not None else await page(endpoint=endpoint)
-    raw = await pg.evaluate(
-        _VDOM_JS,
-        {
-            "interactiveOnly": interactive_only,
-            "viewportOnly": viewport_only,
-            "maxText": max_text,
-        },
-    )
+    try:
+        raw = await pg.evaluate(_VDOM_JS, opts)
+    except Exception as exc:
+        # The front tab can be torn down underneath the evaluate (the user closed
+        # it, the browser swapped contexts). When WE picked the page, re-resolve
+        # the front tab once and retry; a caller-supplied page is theirs to own,
+        # so its closure propagates.
+        if target is not None or not _target_closed(exc):
+            raise
+        pg = await page(endpoint=endpoint)
+        raw = await pg.evaluate(_VDOM_JS, opts)
     return Vdom(raw)
+
+
+def _target_closed(exc: Exception) -> bool:
+    """True when ``exc`` is Playwright's page/context/browser-closed error."""
+    try:
+        from playwright._impl._errors import TargetClosedError
+    except Exception:
+        return "has been closed" in str(exc)
+    return isinstance(exc, TargetClosedError) or "has been closed" in str(exc)
 
 
 async def close(endpoint: str | None = None):

--- a/packages/mcp/src/screen/screen/__init__.py
+++ b/packages/mcp/src/screen/screen/__init__.py
@@ -10,6 +10,7 @@ the framebuffer and the mouse, and posts synthetic input through CoreGraphics.
     print(img.size)                 # auto-rendered inline by python_eval/exec
 
     region = screen.capture(screen.Rect(0, 0, 400, 300))  # a sub-rectangle
+    dia = screen.capture(app="Dia")  # one app's frontmost window (or capture("Dia"))
     where = screen.cursor()         # current pointer, a screen.Point
     screen.move(100, 200)           # warp the cursor (no permission needed)
     screen.click(100, 200)          # synthetic click (needs Accessibility, see below)
@@ -85,6 +86,7 @@ __all__ = [
     "press",
     "screen_size",
     "terminate",
+    "window_bounds",
     "write",
 ]
 
@@ -213,24 +215,65 @@ def _cgimage_to_pil(image: object) -> Image.Image:
     return pil.convert("RGB")
 
 
-def capture(region: Rect | None = None) -> Image.Image:
-    """Capture the screen (or a sub-rectangle) as an RGB `PIL.Image`.
+def window_bounds(app: str) -> Rect:
+    """The on-screen bounds of ``app``'s frontmost window, as a `Rect` in points.
 
-    With no argument, captures the full virtual desktop across all displays.
-    Pass a `Rect` in points to capture a region. The returned image is rendered
-    inline when it is the value of a python_eval/python_exec cell.
+    ``app`` is a display name or bundle id (case-insensitive), the same key
+    `activate`/`terminate` take. Raises `LookupError` when the app has no
+    on-screen window (not running, hidden, or minimized).
     """
 
-    if region is None:
-        image = Quartz.CGDisplayCreateImage(Quartz.CGMainDisplayID())
-    else:
-        cg_rect = Quartz.CGRectMake(region.x, region.y, region.width, region.height)
-        image = Quartz.CGWindowListCreateImage(
-            cg_rect,
-            Quartz.kCGWindowListOptionOnScreenOnly,
-            Quartz.kCGNullWindowID,
-            Quartz.kCGWindowImageDefault,
+    running = _find_running(app)
+    pid = int(running.processIdentifier()) if running is not None else None
+    key = app.lower()
+    windows = Quartz.CGWindowListCopyWindowInfo(
+        Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements,
+        Quartz.kCGNullWindowID,
+    )
+    for win in windows or ():
+        owner_matches = (
+            (pid is not None and int(win.get("kCGWindowOwnerPID", -1)) == pid)
+            or str(win.get("kCGWindowOwnerName", "")).lower() == key
         )
+        # Layer 0 is a normal document window (not a menu bar item or overlay).
+        if owner_matches and int(win.get("kCGWindowLayer", 0)) == 0:
+            b = win.get("kCGWindowBounds", {})
+            return Rect(float(b["X"]), float(b["Y"]), float(b["Width"]), float(b["Height"]))
+    raise LookupError(
+        f"screen: no on-screen window found for {app!r}. Is it running and visible? "
+        "(launch()/activate() it first; minimized windows are not on screen.)"
+    )
+
+
+def capture(region: Rect | str | None = None, *, app: str | None = None) -> Image.Image:
+    """Capture the screen, a region, or one app's window as an RGB `PIL.Image`.
+
+    With no argument, captures the full virtual desktop across all displays
+    (multi-monitor setups included). Pass a `Rect` in points for a region, or
+    target one application's frontmost window with ``app="Dia"`` (an app name as
+    the positional argument means the same), which is what a "did the UI do the
+    right thing?" check almost always wants. The returned image is rendered
+    inline -- automatically downscaled for the model -- when it is the value of a
+    python_exec cell.
+    """
+
+    if isinstance(region, str):
+        app, region = region, None
+    if app is not None:
+        if region is not None:
+            raise ValueError("screen.capture: pass a region OR an app, not both")
+        region = window_bounds(app)
+    cg_rect = (
+        Quartz.CGRectInfinite
+        if region is None
+        else Quartz.CGRectMake(region.x, region.y, region.width, region.height)
+    )
+    image = Quartz.CGWindowListCreateImage(
+        cg_rect,
+        Quartz.kCGWindowListOptionOnScreenOnly,
+        Quartz.kCGNullWindowID,
+        Quartz.kCGWindowImageDefault,
+    )
     if image is None:
         raise RuntimeError(
             "screen: capture returned no image. On recent macOS, reading the "
@@ -240,15 +283,16 @@ def capture(region: Rect | None = None) -> Image.Image:
     return _cgimage_to_pil(image)
 
 
-def capture_ndarray(region: Rect | None = None):
+def capture_ndarray(region: Rect | str | None = None, *, app: str | None = None):
     """Capture as an `(H, W, 3)` uint8 NumPy array (RGB).
 
-    Convenience for pixel math and image diffing; wraps `capture()`.
+    Convenience for pixel math and image diffing; wraps `capture()` (same
+    region / app targeting).
     """
 
     import numpy as np
 
-    return np.asarray(capture(region))
+    return np.asarray(capture(region, app=app))
 
 
 def cursor() -> Point:

--- a/packages/mcp/src/sh/sh/__init__.py
+++ b/packages/mcp/src/sh/sh/__init__.py
@@ -6,7 +6,7 @@ invocation with no Python binding), do it without blocking the one shared event
 loop and without leaking terminal escape codes into your own context.
 
     import sh
-    out = await sh("gh run list --limit 5", cwd=".")
+    out = await sh("gh run list --limit 5")
     out                       # last expr: dashboard shows the COLORED terminal
                               # block, you get the escape-stripped plain text
 
@@ -30,19 +30,31 @@ The :class:`Output` also exposes the parts programmatically::
     out.raw      # the same, with the original ANSI color preserved
     out.cmd      # the command that was run
 
+An ``Output`` also behaves like its text for the common string operations
+(``out[-4000:]``, ``out + "..."``, ``"error" in out``, ``len(out)``,
+``str(out)``), so composing command output needs no ``str(...)`` wrapping.
+
 stdout and stderr are merged in emission order (terminal-style). A non-zero exit
 is surfaced, never swallowed: the model view appends an ``[exit N]`` marker, and
 ``await sh(cmd, check=True)`` raises :class:`ShellError` instead of returning.
+
+Inside the kernel the child's output also streams to the running cell's stdout
+as it arrives, so it lands in ``jobs['<id>'].output`` live: a long command's log
+is pageable from the job even when the cell backgrounds (or is cancelled) before
+the ``Output`` value is ever bound. Cancelling the task kills the child's whole
+process group, never orphaning it.
 """
 
 from __future__ import annotations
 
 import asyncio
+import codecs
 import html as _html
 import os
 import re
 import shlex
 import signal
+import sys
 
 __all__ = ["sh", "Output", "ShellError"]
 
@@ -55,7 +67,7 @@ __version__ = "0.1.0"
 # module still imports and `_repr_html_`/`__repr__` carry the rendering.
 try:
     from ix_notebook_mcp.runtime import Result as _ResultBase
-    from ix_notebook_mcp.runtime import _ansi_to_html, _strip_ansi
+    from ix_notebook_mcp.runtime import _ANSI, _ansi_to_html, _ix_current, _strip_ansi
 
     _HAS_RESULT = True
 except Exception:  # pragma: no cover - exercised only outside the kernel
@@ -64,9 +76,12 @@ except Exception:  # pragma: no cover - exercised only outside the kernel
     # escape for HTML rather than reimplement the escape grammar here.
     _ResultBase = object
     _HAS_RESULT = False
+    _ix_current = None
+    # SGR color only; the full escape grammar is the runtime's to own.
+    _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
     def _strip_ansi(text: str) -> str:
-        return text
+        return _ANSI.sub("", text)
 
     def _ansi_to_html(text: str) -> str:
         return _html.escape(text)
@@ -169,6 +184,33 @@ class Output(_ResultBase):
     def _repr_html_(self) -> str:
         return self._render_html()
 
+    # An Output composes like its text: slice it, concatenate it, search it,
+    # measure it -- no `str(...)` wrapping. All delegate to `.text` (the
+    # escape-stripped output), the same view `str(out)` returns.
+    def __str__(self) -> str:
+        return self.text
+
+    def __bool__(self) -> bool:
+        # Defining __len__ would otherwise make an empty (but successful) output
+        # falsy; an Output is a result object, so it is always truthy -- test
+        # success with `.ok`, emptiness with `len(out)`.
+        return True
+
+    def __getitem__(self, key) -> str:
+        return self.text[key]
+
+    def __len__(self) -> int:
+        return len(self.text)
+
+    def __contains__(self, item) -> bool:
+        return item in self.text
+
+    def __add__(self, other) -> str:
+        return self.text + other
+
+    def __radd__(self, other) -> str:
+        return other + self.text
+
 
 def _terminate(proc: asyncio.subprocess.Process) -> None:
     """Kill the child and the process group it leads.
@@ -187,25 +229,69 @@ def _terminate(proc: asyncio.subprocess.Process) -> None:
             pass
 
 
+class _EchoStripper:
+    """Incrementally strip ANSI escapes from streamed chunks.
+
+    A chunk boundary can split an escape sequence in two; a naive per-chunk
+    ``_strip_ansi`` would then leak half of it as visible garbage. This holds
+    back a trailing, still-incomplete escape and prepends it to the next chunk,
+    so the echoed stream is clean no matter where the pipe chops it.
+    """
+
+    def __init__(self) -> None:
+        self._pending = ""
+
+    def feed(self, text: str) -> str:
+        text = self._pending + text
+        self._pending = ""
+        cut = text.rfind("\x1b")
+        if cut != -1:
+            tail = text[cut:]
+            # A complete sequence (or ESC followed by plain text) strips fine;
+            # only a short, genuinely unfinished introducer is held back.
+            if _ANSI.match(tail) is None and len(tail) < 64:
+                self._pending = tail
+                text = text[:cut]
+        return _strip_ansi(text)
+
+    def flush(self) -> str:
+        text, self._pending = self._pending, ""
+        return _strip_ansi(text)
+
+
+def _in_kernel_job() -> bool:
+    """True when this call runs inside a kernel job, where ``sys.stdout`` routes
+    to that job's captured output (the runtime's tee)."""
+    return _ix_current is not None and _ix_current.get() is not None
+
+
 async def sh(
     cmd: str | list[str],
     *,
-    cwd: str | os.PathLike,
+    cwd: str | os.PathLike | None = None,
     env: dict[str, str] | None = None,
     timeout: float | None = None,
     check: bool = False,
     color: bool = True,
+    echo: bool | None = None,
 ) -> Output:
     """Run ``cmd`` on the shared async loop and return its :class:`Output`.
 
     ``cmd`` is a string (run through the shell, so pipes and globs work) or an
     argv list (executed directly, no shell parsing). stdout and stderr are merged
-    in order. ``cwd`` is REQUIRED -- pass the directory to run in (``cwd="."`` for
-    here) instead of a `cd X && ...` prefix, which is rejected, so the command
-    string stays clean. ``env`` extends the environment;
+    in order. ``cwd`` is the directory to run in (defaults to the kernel's
+    current directory); pass it instead of a `cd X && ...` prefix, which is
+    rejected, so the command string stays clean. ``env`` extends the environment;
     ``timeout`` (seconds) kills the child's whole process group and raises
     :class:`TimeoutError`; ``check=True`` raises :class:`ShellError` on a non-zero
     exit; ``color=False`` suppresses the forced-color environment.
+
+    Output STREAMS as it arrives: inside the kernel each chunk is echoed
+    (escape-stripped) to the running cell's stdout, so a long command's log is in
+    ``jobs['<id>'].output`` live and survives the cell backgrounding or being
+    cancelled. ``echo`` overrides that default (it is off outside the kernel).
+    Cancelling the awaiting task kills the child's whole process group, so a
+    cancelled cell never leaves an orphan running (or holding a lock) behind.
 
     With no ``timeout`` a command that keeps the stdout pipe open (a daemon it
     backgrounds, say) waits for that pipe to close. The await yields to the loop,
@@ -244,13 +330,36 @@ async def sh(
             start_new_session=True,
         )
 
+    do_echo = _in_kernel_job() if echo is None else echo
+    decoder = codecs.getincrementaldecoder("utf-8")("replace")
+    stripper = _EchoStripper()
+    chunks: list[str] = []
+
+    def _keep(text: str) -> None:
+        chunks.append(text)
+        if do_echo:
+            sys.stdout.write(stripper.feed(text))
+
+    async def _drain() -> None:
+        while True:
+            block = await proc.stdout.read(8192)
+            if not block:
+                break
+            _keep(decoder.decode(block))
+        tail = decoder.decode(b"", final=True)
+        if tail:
+            _keep(tail)
+        if do_echo:
+            sys.stdout.write(stripper.flush())
+        await proc.wait()
+
     loop = asyncio.get_running_loop()
     started = loop.time()
     try:
         if timeout is not None:
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout)
+            await asyncio.wait_for(_drain(), timeout)
         else:
-            stdout, _ = await proc.communicate()
+            await _drain()
     except asyncio.TimeoutError:
         _terminate(proc)
         # The group is dead, so the pipe closes and this reap returns promptly;
@@ -260,12 +369,18 @@ async def sh(
         except asyncio.TimeoutError:
             pass
         raise TimeoutError(f"command timed out after {timeout}s: {shown}") from None
+    except asyncio.CancelledError:
+        # The awaiting task was cancelled (jobs['<id>'].cancel()): take the child
+        # and its whole group down with it, so a cancelled cell never leaves an
+        # orphan still running (and holding locks) in the background.
+        _terminate(proc)
+        raise
 
     duration = loop.time() - started
     out = Output(
         cmd=shown,
         code=proc.returncode if proc.returncode is not None else -1,
-        raw=stdout.decode("utf-8", "replace"),
+        raw="".join(chunks),
         duration=duration,
     )
     if check and not out.ok:
@@ -279,7 +394,6 @@ async def sh(
 # kernel binds this same module object as `sh` in the user namespace too (see
 # ix_notebook_mcp.runtime.install), so `await sh(...)` works with or without an
 # explicit import, while `sh.Output` / `sh.ShellError` stay reachable as attrs.
-import sys as _sys
 import types as _types
 
 
@@ -288,4 +402,4 @@ class _CallableModule(_types.ModuleType):
         return sh(*args, **kwargs)
 
 
-_sys.modules[__name__].__class__ = _CallableModule
+sys.modules[__name__].__class__ = _CallableModule


### PR DESCRIPTION
Fixes the open MCP tool issues and de-janks `packages/mcp`.

## sh
- `cwd` optional, defaults to the current directory (#929)
- `Output` composes like its text: `out[-4000:]`, `out + "..."`, `"x" in out`, `len`, `str` (#949, #926)
- output **streams** into the running cell's stdout (chunk-safe ANSI stripping), so a long command's log is pageable via `jobs['<id>'].output` even after backgrounding/cancellation (#950)
- cancel kills the child's whole process group: no more orphaned `git commit` holding `index.lock` (#925)

## runtime
- `Result(llm_result=<Result>)` flattens to its model text at construction; no more `'Result' object is not subscriptable` deep in `Job.tail` (#956)
- `Job.wait(timeout)`: a timed wait that never raises, replacing sleep-and-poll loops (#925)
- `read`: an expression evaluating to an existing path now reads the file (#905); regression tests lock the file-path branch returning real contents with `start`/`end` (#951, #947, #943, #903)
- `Result.of` routes PIL/matplotlib values through size-fitted `llm_images`; docs for the dashboard-only image pattern (#934, #933)

## browser
- default app is Google Chrome: Dia (Arc engine) never renders CDP-created tabs, silently breaking the visible-browser promise (#958)
- launches are announced (app, endpoint, fresh profile) instead of silent (#957)
- `shot(to_model=False)` for dashboard-only screenshots; model copies are auto-downscaled (#970, #934)
- `vdom()` retries once when the front tab is torn down mid-evaluate; the vdom smoke retries transient teardown (#987)

## screen
- `capture(app="Dia")` / `capture("Dia")` captures one app's frontmost window via new `window_bounds`; no-arg capture now truly captures the full virtual desktop, matching its doc (#969)

## registry
- `screen`, `vmkit`, `imessage`, `tasks` are now discoverable in `api()` (#906)

Tested: `mcp.tests.runtimeSmoke` and `mcp.tests.shSmoke` green with the new assertions (Job.wait, nested-Result coercion, `__ix_read` file/range/expression-path, Output string ops, streamed echo, cancel-kills-group); full `mcp.tests.*` suite run locally.

(opened by Claude Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP open tool issues and de-jank kernel modules for browser, sh, and screen
> - `browser.vdom()` retries once when the implicitly selected tab is closed, reducing transient failures; the test runner also retries up to 3 times on `TargetClosedError`
> - `sh()` now streams child output to `sys.stdout` with ANSI stripping when running inside a kernel job, accepts an optional `cwd`, and kills the entire process group on cancellation to prevent orphan processes
> - `__ix_read` now evaluates expressions that yield a string path to an existing file and reads that file, rather than echoing the path string
> - `Job.wait(timeout)` is added as a non-raising async method that returns the job handle regardless of completion state
> - `screen.capture()` and `screen.array()` now accept an `app=` argument to target a specific application's frontmost window
> - `registry.MODULES` adds entries for `screen`, `vmkit`, `imessage`, and `tasks`
> - Behavioral Change: `sh()` default `cwd` is now `None` (inherits caller's cwd) instead of a fixed path; echo defaults to on inside kernel jobs
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c59ec4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->