### PR TITLE
cargo-unit: deduplicate selectors and name failing test-listing targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ case derivations, and coverage runs.
 
 ## Cargo Unit Benchmarks
 
-[`ix.cargoUnit.buildWorkspace`](lib/cargo-unit.nix) exposes Cargo `[[bench]]`
+[`ix.cargoUnit.buildWorkspace`](lib/rust/cargo-unit.nix) exposes Cargo `[[bench]]`
 roots under `benchmarks` when a target set includes `--benches` or a specific
 `--bench <name>`. Tango benches work as Nix artifacts, including the usual
 Linux/macOS `cargo:rustc-link-arg-benches=-rdynamic` build-script line.

--- a/lib/rust/cargo-unit.nix
+++ b/lib/rust/cargo-unit.nix
@@ -245,10 +245,17 @@ let
             } > "$out"
           '';
 
+      # The workspace's toolchain id, handed to the renderer and baked into
+      # every from-source unit hash. A prebuilt unit must have been compiled
+      # with this exact toolchain, or its hash (hence its key) would not
+      # match. `mkPrebuiltLibraryUnit` asserts against its own `rustToolchain`
+      # arg; the injection guards below cross-check against this id, the one
+      # the graph really used.
+      workspaceToolchainId = rust.toolchainId args.rustToolchain;
+
       # Second IFD stage: render `units.nix` from the unit graph above.
       unitsNix =
         let
-          toolchainId = rust.toolchainId args.rustToolchain;
           contentAddressed = rawArgs.contentAddressed or true;
 
           extraFlags =
@@ -265,7 +272,7 @@ let
             nix-cargo-unit render \
               --workspace-root ${escapeShellArg args.src} \
               --vendor-root ${escapeShellArg args.vendorDir} \
-              --toolchain-id ${escapeShellArg toolchainId} \
+              --toolchain-id ${escapeShellArg workspaceToolchainId} \
               ${lib.escapeShellArgs extraFlags} \
               --cargo-lock "$cargoLockForRender" \
               < ${unitGraphJson} \
@@ -360,14 +367,6 @@ let
       };
       generatedUnitKeys = attrNames generatedView.units;
       generatedLibraryKeys = attrNames generatedView.libraries;
-
-      # The workspace's ACTUAL toolchain id (cargo-unit.nix toolchainId at render
-      # time), which is what every from-source unit hash was computed with. A
-      # prebuilt unit must have been compiled with this exact toolchain, or its
-      # hash (hence its key) would not match. `mkPrebuiltLibraryUnit` asserts
-      # against its own `rustToolchain` arg; this is the workspace-side
-      # cross-check against the toolchain the graph really used.
-      workspaceToolchainId = rust.toolchainId args.rustToolchain;
 
       # C1: a prebuilt injection must OVERRIDE a unit/library the graph already
       # references. A key that is absent silently builds from source, defeating
@@ -481,22 +480,24 @@ let
       inherit (args) policy;
     };
 
+  # One lookup for every selector that picks a root out of a workspace: fail
+  # with the calling selector's name and the full set of available keys, so a
+  # typo'd target name reads as a menu instead of a bare missing-attribute
+  # error.
+  rootOrThrow =
+    caller: kind: roots: name:
+    roots.${name}
+      or (throw "${caller}: no ${kind} `${name}` in workspace; available: ${lib.concatStringsSep ", " (attrNames roots)}");
+
   /**
     Select one binary target from a generated workspace graph.
   */
   buildBinary =
-    {
-      binary,
-      cargoArgs ? [ ],
-      ...
-    }@args:
+    { binary, ... }@args:
     let
       workspace = buildWorkspace (removeAttrs args [ "binary" ]);
     in
-    workspace.binaries.${binary}
-      or (throw "buildBinary: no binary `${binary}` in workspace; available: ${
-        lib.concatStringsSep ", " (attrNames (workspace.binaries or { }))
-      }");
+    rootOrThrow "buildBinary" "binary" (workspace.binaries or { }) binary;
 
   /**
     Pick a binary out of a pre-built `buildWorkspace` plus its test
@@ -521,11 +522,7 @@ let
       passthru ? { },
     }:
     selectRootWithTests workspace {
-      rootDrv =
-        workspace.binaries.${binary}
-          or (throw "selectBinaryWithTests: no binary `${binary}` in workspace; available: ${
-            lib.concatStringsSep ", " (attrNames (workspace.binaries or { }))
-          }");
+      rootDrv = rootOrThrow "selectBinaryWithTests" "binary" (workspace.binaries or { }) binary;
       inherit
         packageName
         includeTestCases
@@ -554,11 +551,7 @@ let
       passthru ? { },
     }:
     selectRootWithTests workspace {
-      rootDrv =
-        workspace.libraries.${library}
-          or (throw "selectLibraryWithTests: no library `${library}` in workspace; available: ${
-            lib.concatStringsSep ", " (attrNames (workspace.libraries or { }))
-          }");
+      rootDrv = rootOrThrow "selectLibraryWithTests" "library" (workspace.libraries or { }) library;
       inherit
         packageName
         includeTestCases
@@ -651,21 +644,11 @@ let
     roots from several Cargo executions, such as build and test graphs.
   */
   buildBinaries =
-    {
-      binaries,
-      cargoArgs ? [ ],
-      ...
-    }@args:
+    { binaries, ... }@args:
     let
       workspace = buildWorkspace (removeAttrs args [ "binaries" ]);
     in
-    lib.genAttrs binaries (
-      binary:
-      workspace.binaries.${binary}
-        or (throw "buildBinaries: no binary `${binary}` in workspace; available: ${
-          lib.concatStringsSep ", " (attrNames (workspace.binaries or { }))
-        }")
-    );
+    lib.genAttrs binaries (rootOrThrow "buildBinaries" "binary" (workspace.binaries or { }));
 
   /**
     Build a library unit derivation from already-compiled artifacts instead of

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -3578,6 +3578,7 @@ mod tests {
         assert!(rendered.contains("source-roots.tsv"));
         assert!(rendered.contains("testManifestDrv ="));
         assert!(rendered.contains("cargo-unit-test-manifest"));
+        assert!(rendered.contains("failed to list tests for"));
     }
 
     #[test]

--- a/packages/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix-cargo-unit/templates/units.nix.askama
@@ -654,8 +654,11 @@ let
       ''
       + pkgs.lib.concatMapStrings (target: ''
         (
-          ${target.binary} --list --format terse > "$out"/${pkgs.lib.escapeShellArg target.name}.list
-          ${target.binary} --list --format terse --ignored > "$out"/${pkgs.lib.escapeShellArg target.name}.ignored.list
+          if ! ${target.binary} --list --format terse > "$out"/${pkgs.lib.escapeShellArg target.name}.list ||
+             ! ${target.binary} --list --format terse --ignored > "$out"/${pkgs.lib.escapeShellArg target.name}.ignored.list; then
+            echo >&2 "error: cargo-unit: failed to list tests for ${target.name} (${target.binary})"
+            exit 1
+          fi
         ) &
         running=$((running + 1))
         if [ "$running" -ge "$max_jobs" ]; then
@@ -668,7 +671,7 @@ let
         done
 
         if [ "$failures" -ne 0 ]; then
-          echo >&2 "error: cargo-unit failed to list $failures test target(s)"
+          echo >&2 "error: cargo-unit failed to list $failures test target(s); each is named above"
           exit 1
         fi
       ''


### PR DESCRIPTION
## Why

Polish pass over the cargo-unit test pipeline after reviewing how per-case tests are discovered and run.

- `lib/rust/cargo-unit.nix` had four hand-rolled copies of the same lookup-or-throw ("no binary `x` in workspace; available: ...") across `buildBinary`, `buildBinaries`, `selectBinaryWithTests`, and `selectLibraryWithTests`. One `rootOrThrow` helper now owns that message.
- The workspace toolchain id was computed twice (`toolchainId` inside `unitsNix`, `workspaceToolchainId` for the injection guards). One binding, two readers.
- The `cargoArgs ? [ ]` pattern defaults in `buildBinary`/`buildBinaries` were dead (an `@args` pattern default never reaches `args`) and misleading (the real default in `normalizeArgs` is `--workspace`).
- The shared `cargo-unit-test-manifest` derivation lists every test binary in parallel and only counted anonymous failures: `failed to list 2 test target(s)` with no names, leaving a hunt through interleaved logs. Each listing job now reports its target name and binary path when it fails.
- CONTRIBUTING.md linked `lib/cargo-unit.nix`; the file lives at `lib/rust/cargo-unit.nix`.

No behavior changes outside error reporting; root derivations are untouched (only the manifest script in the rendered units.nix changes).

## Testing

- `cargo test` in `packages/nix-cargo-unit`: 51 passed (includes the new rendered-template assertion).
- `nix run .#lint`: all five checks pass.
- Built the `cargo-unit-hello` fixture workspace on aarch64-darwin through the modified template: binaries, per-case test derivations (forcing the new test-manifest script), doctest cases, and `selectBinaryWithTests` passthru tests all build.
- Verified the consolidated selector error: `selectBinaryWithTests ws { binary = "nope"; }` fails with ``no binary `nope` in workspace; available: cargo-unit-goodbye, cargo-unit-hello``.

(sent by Claude Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix test-listing failures to surface target names and deduplicate selectors in cargo-unit
> - Updates the test-listing script in [units.nix.askama](https://github.com/indexable-inc/index/pull/1000/files#diff-0962f6bad01321924b1688b79dee1e5626eeb872b7be247007c19f81bae72ff5) to exit non-zero if either `--list --format terse` command fails, and prints a per-target error to stderr identifying the target name and binary path.
> - Adds a `rootOrThrow` helper in [cargo-unit.nix](https://github.com/indexable-inc/index/pull/1000/files#diff-82054df1a7d1648a5be88265641a7ae5d3b9e4ec4cdea72c518359ea4ae3f804) to standardize missing-root error messages across `buildBinary`, `buildBinaries`, `selectBinaryWithTests`, and `selectLibraryWithTests`.
> - Deduplicates the `workspaceToolchainId` binding by computing it once and removing the later redundant definition.
> - Behavioral Change: test listing failures that were previously silent now cause the subshell to exit 1 and print a named error per failing target.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2ffd01.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->