### PR TITLE
fix(cargo): repair the rest of #998 dependency-bump fallout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3643,8 +3643,8 @@ dependencies = [
 name = "lake-iceberg"
 version = "0.1.0"
 dependencies = [
- "arrow-array 59.0.0",
- "arrow-schema 59.0.0",
+ "arrow-array 57.3.1",
+ "arrow-schema 57.3.1",
  "futures",
  "iceberg",
  "iceberg-catalog-rest",
@@ -4892,6 +4892,7 @@ name = "oci-image-builder"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "hex",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -6227,6 +6228,7 @@ dependencies = [
  "dirs",
  "futures",
  "git2",
+ "hex",
  "mixedbread",
  "rayon",
  "regex",
@@ -6591,6 +6593,7 @@ name = "sink-parquet"
 version = "0.1.0"
 dependencies = [
  "arrow",
+ "hex",
  "object_store",
  "parquet 59.0.0",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,9 +158,10 @@ fontdue = "0.9"
 futures = "0.3"
 git2 = { version = "0.21", default-features = false }
 glob = "0.3"
+hex = "0.4"
 hegeltest = { version = "0.14", default-features = false }
 # The Iceberg corpus lake (issue #752). iceberg 0.9 pins arrow/parquet ^57.1
-# while the workspace parquet pair is on 58; the 57 tree stays isolated inside
+# while the workspace parquet pair is on 59; the 57 tree stays isolated inside
 # lake-iceberg (see its Cargo.toml).
 iceberg = "0.9"
 iceberg-catalog-rest = "0.9"

--- a/packages/claude-stories/src/story.rs
+++ b/packages/claude-stories/src/story.rs
@@ -61,20 +61,25 @@ pub fn derive(path: &Path) -> Result<Story> {
     let commit = head
         .peel_to_commit()
         .wrap_err("HEAD does not point at a commit")?;
-    let subject = commit.summary().unwrap_or("(no commit message)").to_owned();
+    let subject = commit
+        .summary()
+        .ok()
+        .flatten()
+        .unwrap_or("(no commit message)")
+        .to_owned();
 
     // Prefer the configured user.name; fall back to the latest commit's author.
     let name = repo
         .config()
         .ok()
         .and_then(|c| c.get_string("user.name").ok())
-        .or_else(|| commit.author().name().map(str::to_owned))
+        .or_else(|| commit.author().name().ok().map(str::to_owned))
         .unwrap_or_else(|| "anonymous".to_owned());
 
     let origin = repo
         .find_remote("origin")
         .ok()
-        .and_then(|r| r.url().map(str::to_owned));
+        .and_then(|r| r.url().ok().map(str::to_owned));
     let repo_name = origin
         .as_deref()
         .and_then(repo_basename)

--- a/packages/git-log-pretty/src/avatar.rs
+++ b/packages/git-log-pretty/src/avatar.rs
@@ -57,7 +57,7 @@ impl Resolver {
         let origin = repo
             .find_remote("origin")
             .ok()
-            .and_then(|remote| remote.url().and_then(github_avatar::parse_remote));
+            .and_then(|remote| remote.url().ok().and_then(github_avatar::parse_remote));
 
         let cache_dir = avatar_cache_dir();
         let login_cache = cache_dir
@@ -270,7 +270,8 @@ fn load_identities(repo: &Repository) -> HashMap<String, String> {
     // it so it matches only `githublogin.map` and not other keys.
     if let Ok(entries) = config.entries(Some("^githublogin\\.map$")) {
         let _ = entries.for_each(|entry| {
-            if let Some((email, login)) = entry.value().and_then(|value| value.split_once('=')) {
+            if let Some((email, login)) = entry.value().ok().and_then(|value| value.split_once('='))
+            {
                 let (email, login) = (email.trim(), login.trim());
                 if !email.is_empty() && !login.is_empty() {
                     map.insert(email.to_string(), login.to_string());

--- a/packages/git-log-pretty/src/display.rs
+++ b/packages/git-log-pretty/src/display.rs
@@ -81,7 +81,12 @@ fn commit_block(
 ) -> color_eyre::eyre::Result<CommitBlock> {
     let commit = &ahead.commit;
     let short = commit.id().to_string().chars().take(7).collect::<String>();
-    let summary = commit.summary().unwrap_or("<no message>").trim();
+    let summary = commit
+        .summary()
+        .ok()
+        .flatten()
+        .unwrap_or("<no message>")
+        .trim();
     let when = time::relative(commit.time().seconds())?;
 
     let yellow = palette::fg(Color::Ansi(AnsiColor::Yellow));

--- a/packages/git-log-pretty/src/git.rs
+++ b/packages/git-log-pretty/src/git.rs
@@ -58,7 +58,7 @@ pub fn discover() -> Result<Repository> {
 pub fn head_branch_name(repo: &Repository) -> Option<String> {
     let head = repo.head().ok()?;
     head.is_branch()
-        .then(|| head.shorthand().map(str::to_string))?
+        .then(|| head.shorthand().ok().map(str::to_string))?
 }
 
 /// Pair a commit with the files it changed, the shape the display layer expects.

--- a/packages/lake/iceberg/Cargo.toml
+++ b/packages/lake/iceberg/Cargo.toml
@@ -9,12 +9,12 @@ description = "The Iceberg corpus lake: append+tombstone document log with snaps
 workspace = true
 
 [dependencies]
-# iceberg 0.9 pins arrow/parquet ^57.1; the rest of the workspace is on 58 for
+# iceberg 0.9 pins arrow/parquet ^57.1; the rest of the workspace is on 59 for
 # the plain-parquet pair. The 57 tree is pinned here directly (not in the
 # workspace table) so it stays an implementation detail of this crate; both
 # trees coexist (`multiple_crate_versions` is allowed workspace-wide).
-arrow-array = "59"
-arrow-schema = "59"
+arrow-array = "57"
+arrow-schema = "57"
 futures.workspace = true
 iceberg.workspace = true
 iceberg-catalog-rest.workspace = true

--- a/packages/oci-image-builder/Cargo.toml
+++ b/packages/oci-image-builder/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 chrono = { workspace = true, default-features = false, features = ["clock", "std"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+hex.workspace = true
 sha2.workspace = true
 tar.workspace = true
 tempfile.workspace = true

--- a/packages/oci-image-builder/src/main.rs
+++ b/packages/oci-image-builder/src/main.rs
@@ -1622,7 +1622,7 @@ impl<W: Write> HashingWriter<W> {
     }
 
     fn finalize(self) -> HashedBytes {
-        let checksum = format!("{:x}", self.hasher.finalize());
+        let checksum = hex::encode(self.hasher.finalize());
         HashedBytes {
             size: self.size,
             checksum,
@@ -1644,7 +1644,7 @@ impl<W: Write> Write for HashingWriter<W> {
 }
 
 fn sha256_bytes(data: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(data))
+    hex::encode(Sha256::digest(data))
 }
 
 #[cfg(test)]

--- a/packages/search-core/Cargo.toml
+++ b/packages/search-core/Cargo.toml
@@ -24,6 +24,7 @@ rusqlite = { workspace = true, features = ["bundled"] }
 source-meta.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+hex.workspace = true
 sha2.workspace = true
 snafu.workspace = true
 tokio = { workspace = true, features = ["fs", "time"] }

--- a/packages/search-core/src/db.rs
+++ b/packages/search-core/src/db.rs
@@ -107,11 +107,16 @@ impl Db {
             .query_map([root.as_ref()], |row| {
                 let rel_path: String = row.get(0)?;
                 let hash: String = row.get(1)?;
-                // Read the INTEGER columns straight into `u64`: rusqlite errors
-                // (rather than silently clamping) if a stored value is negative,
-                // so DB corruption surfaces instead of being zeroed.
-                let mtime_ms: u64 = row.get(2)?;
-                let size: u64 = row.get(3)?;
+                // SQLite stores these as signed INTEGER; rusqlite 0.40 dropped
+                // its `u64` column readers, so read `i64` and convert. A negative
+                // value is impossible for an mtime/size, so reject it (surfacing
+                // DB corruption) instead of wrapping it into a huge `u64`.
+                let mtime_raw: i64 = row.get(2)?;
+                let size_raw: i64 = row.get(3)?;
+                let mtime_ms = u64::try_from(mtime_raw)
+                    .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(2, mtime_raw))?;
+                let size = u64::try_from(size_raw)
+                    .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(3, size_raw))?;
                 Ok(FileEntry {
                     rel_path,
                     hash: ContentHash::from_raw(hash),
@@ -148,15 +153,21 @@ impl Db {
                 )
                 .context(DbSnafu)?;
             for entry in &manifest.entries {
-                // Bind the `u64` fields directly: rusqlite's `ToSql` errors if a
-                // value exceeds `i64::MAX` rather than silently saturating, so an
-                // impossible mtime/size fails the write instead of corrupting it.
+                // SQLite columns are signed INTEGER and rusqlite 0.40 dropped its
+                // `u64` binders, so convert. An mtime/size past `i64::MAX` cannot
+                // occur in practice; fail the write rather than wrap it negative.
+                let mtime_ms = i64::try_from(entry.mtime_ms)
+                    .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
+                    .context(DbSnafu)?;
+                let size = i64::try_from(entry.size)
+                    .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
+                    .context(DbSnafu)?;
                 stmt.execute(params![
                     root.as_ref(),
                     entry.rel_path,
                     entry.hash.as_str(),
-                    entry.mtime_ms,
-                    entry.size,
+                    mtime_ms,
+                    size,
                 ])
                 .context(DbSnafu)?;
             }

--- a/packages/search-core/src/manifest.rs
+++ b/packages/search-core/src/manifest.rs
@@ -145,7 +145,7 @@ impl Manifest {
             digest.update(value.as_bytes());
             digest.update(b"\n");
         }
-        format!("{:x}", digest.finalize())
+        hex::encode(digest.finalize())
     }
 
     /// The first relative path that maps to `hash`, if any. Identical content

--- a/packages/search-core/src/repo.rs
+++ b/packages/search-core/src/repo.rs
@@ -29,7 +29,7 @@ pub fn repo_slug(root: &Path) -> RepoSlug {
 fn origin_slug(root: &Path) -> Option<String> {
     let repo = git2::Repository::discover(root).ok()?;
     let remote = repo.find_remote("origin").ok()?;
-    slug_from_url(remote.url()?)
+    slug_from_url(remote.url().ok()?)
 }
 
 /// Extract `owner/repo` from a git remote URL, dropping a trailing `.git`.

--- a/packages/sink/parquet/Cargo.toml
+++ b/packages/sink/parquet/Cargo.toml
@@ -14,6 +14,7 @@ arrow.workspace = true
 parquet = { workspace = true, features = ["arrow"] }
 object_store = { workspace = true, features = ["aws"] }
 serde_json.workspace = true
+hex.workspace = true
 sha2.workspace = true
 snafu.workspace = true
 

--- a/packages/sink/parquet/src/lib.rs
+++ b/packages/sink/parquet/src/lib.rs
@@ -327,7 +327,7 @@ fn corpus_hash(documents: &[Document]) -> String {
         digest.update(content_hash.as_bytes());
         digest.update([0]);
     }
-    format!("{:x}", digest.finalize())
+    hex::encode(digest.finalize())
 }
 
 /// Load the per-source manifest's corpus hash, or `None` when it does not exist

--- a/packages/tap/pty/src/lib.rs
+++ b/packages/tap/pty/src/lib.rs
@@ -42,12 +42,6 @@ pub enum Error {
         /// Underlying OS error.
         source: std::io::Error,
     },
-    /// Acquiring the PTY slave failed.
-    #[snafu(display("failed to get PTY slave: {source}"))]
-    Pts {
-        /// Underlying OS error.
-        source: std::io::Error,
-    },
     /// Sizing the PTY failed.
     #[snafu(display("failed to size PTY: {source}"))]
     Resize {
@@ -148,16 +142,16 @@ impl PtySession {
         } = config;
         let (program, args) = command.split_first().context(EmptyCommandSnafu)?;
 
-        let pty = pty_process::Pty::new()
+        // `pty_process::open` allocates the PTY master and its slave together.
+        let (pty, pts) = pty_process::open()
             .map_err(std::io::Error::other)
             .context(OpenPtySnafu)?;
-        let pts = pty.pts().map_err(std::io::Error::other).context(PtsSnafu)?;
         pty.resize(pty_process::Size::new(rows, cols))
             .map_err(std::io::Error::other)
             .context(ResizeSnafu)?;
         let child = pty_process::Command::new(program)
             .args(args)
-            .spawn(&pts)
+            .spawn(pts)
             .map_err(std::io::Error::other)
             .context(SpawnSnafu {
                 program: program.clone(),

--- a/packages/tui/src/manager/spawn.rs
+++ b/packages/tui/src/manager/spawn.rs
@@ -62,27 +62,22 @@ pub(super) fn spawn_tui(
     let display = format!("{command} {}", args.join(" "));
 
     let (pty, child) = runtime.block_on(async {
-        let pty = pty_process::Pty::new().map_err(|e| process_spawn_error(&display, e))?;
-
-        let pty_slave = pty
-            .pts()
-            .map_err(|e| process_spawn_error("get PTY slave", e))?;
+        // `pty_process::open` allocates the PTY master and its slave together.
+        let (pty, pty_slave) = pty_process::open().map_err(|e| process_spawn_error(&display, e))?;
 
         pty.resize(pty_process::Size::new(rows, cols))
             .map_err(|e| process_spawn_error("resize PTY", e))?;
 
-        let mut cmd = pty_process::Command::new(&command);
-        cmd.args(&args);
         // A PTY-backed emulator is only as useful as the TERM the child thinks
         // it is driving. With no TERM the child inherits the host's, so curses
         // and terminfo capabilities (e.g. `curs_set`) silently fail or differ
         // by machine. ix-vt implements an xterm-256color superset, so advertise
         // that plus truecolor for a consistent, capable default.
-        cmd.env("TERM", "xterm-256color");
-        cmd.env("COLORTERM", "truecolor");
-
-        let child = cmd
-            .spawn(&pty_slave)
+        let child = pty_process::Command::new(&command)
+            .args(&args)
+            .env("TERM", "xterm-256color")
+            .env("COLORTERM", "truecolor")
+            .spawn(pty_slave)
             .map_err(|e| process_spawn_error(&display, e))?;
 
         Ok::<_, Error>((pty, child))


### PR DESCRIPTION
Repairs the rest of #998's dependency-bump fallout that left `origin/main` unbuildable. #1001 handled rodio; this fixes everything else `flake-check` flagged.

| dependency | bump | change | crates |
|---|---|---|---|
| git2 | 0.20 -> 0.21 | `url`/`shorthand`/`name`/`summary`/`ConfigEntry::value` now return `Result`, not `Option` | search-core, git-log-pretty, claude-stories |
| rusqlite | 0.32 -> 0.40 | dropped `u64` `FromSql`/`ToSql` (SQLite is signed `i64`) | search-core |
| sha2 | 0.10 -> 0.11 | digest `Output` no longer impls `LowerHex`, so `format!("{:x}", ..)` fails | search-core, sink-parquet, oci-image-builder |
| pty-process | 0.4 -> 0.5 | `Pty::new()`+`pts()` -> `open() -> (Pty, Pts)`; `Command` is a consuming builder; `spawn` takes `Pts` by value | tap-pty, tui |
| arrow/parquet | 58 -> 59 | the bot also bumped lake-iceberg's **deliberately pinned** arrow 57 to 59, breaking interop with `iceberg` 0.9 (pins arrow ^57.1) | lake-iceberg (reverted to 57) |

Notes:
- git2 conversions thread `.ok()` (and `.ok().flatten()` for the `Result<Option<_>>` shapes) so the prior "None on failure" behavior is preserved.
- rusqlite reads `i64` then `u64::try_from`, writes via `i64::try_from`, still erroring on an impossible (negative / `> i64::MAX`) value rather than silently wrapping.
- hex encoding uses `hex::encode`; `hex` is added to the workspace dep table (already in the lock transitively).
- tap-pty's now-unreachable `Pts` error variant is removed.

Verified: `cargo test` passes for every touched crate locally. (My local rustup toolchain is a different build than CI's nix-pinned nightly, so I am relying on `flake-check` for the full lint suite rather than force-merging.)

🤖 Generated with Claude Opus 4.8

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix git2 and rusqlite API breakage from dependency bump in issue #998
> - Updates `git2` call sites across `claude-stories`, `git-log-pretty`, and `search-core` to handle `Result`-returning accessors (`summary()`, `author().name()`, `remote.url()`, `shorthand()`) by chaining `.ok()` and falling back to defaults instead of panicking.
> - Fixes `rusqlite` u64 column reads in [`search-core/src/db.rs`](https://github.com/indexable-inc/index/pull/1005/files#diff-6420bd6145cfcd5022c8049f0aefa5539a99b631acf52ab35430d41474debbfc) by reading as `i64` and converting via `try_from`, since rusqlite 0.40 dropped direct u64 readers.
> - Replaces `format!("{:x}", ...)` hex encoding with `hex::encode()` across `oci-image-builder`, `search-core`, `sink/parquet`, and adds `hex` as a workspace dependency.
> - Updates `pty_process` usage in `tap/pty` and `tui` to use the new `pty_process::open()` API returning `(pty, pts)` instead of separate `Pty::new()` + `pts()` calls.
> - Pins `lake/iceberg` arrow dependencies to version 57 to match iceberg 0.9's `^57.1` constraint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc31c7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->