### PR TITLE
fix(symphony): stray port messages no longer crash a run

### DIFF
--- a/packages/symphony/elixir/lib/symphony_elixir/command.ex
+++ b/packages/symphony/elixir/lib/symphony_elixir/command.ex
@@ -45,6 +45,25 @@ defmodule SymphonyElixir.Command do
     if Port.info(port) != nil, do: Port.close(port)
   rescue
     _ -> :ok
+  after
+    flush_port(port)
+  end
+
+  # A SIGTERM'd child often writes a final line (for example an
+  # "interrupted, shutting down" notice) between the kill and
+  # Port.close/1, and Port.close does not flush messages the port
+  # already delivered. Without a drain those sit in the caller's
+  # mailbox and surface later as raw `{port, {:data, ...}}` messages;
+  # a GenServer caller with no matching handle_info clause dies with a
+  # FunctionClauseError. Drain everything the port sent before
+  # returning. Once Port.close/1 has returned the port sends nothing
+  # further, so a single non-blocking sweep is complete.
+  defp flush_port(port) do
+    receive do
+      {^port, _message} -> flush_port(port)
+    after
+      0 -> :ok
+    end
   end
 
   # Port.close/1 on a :spawn_executable port closes the stdio pipes but

--- a/packages/symphony/elixir/lib/symphony_elixir/runtime.ex
+++ b/packages/symphony/elixir/lib/symphony_elixir/runtime.ex
@@ -290,6 +290,17 @@ defmodule SymphonyElixir.Runtime do
     end
   end
 
+  @impl true
+  def handle_info(message, state) do
+    # Defense in depth: a stray message (for example a late port line
+    # leaked by a timed-out Command.run child) must not crash the run.
+    # A FunctionClauseError here kills the GenServer; the supervisor's
+    # transient restart then replays the run from its persisted graph
+    # and can double-submit in-flight turns. Log and drop instead.
+    Logger.warning("Runtime #{state.graph.run_id} ignoring unexpected message: #{inspect(message)}")
+    {:noreply, state}
+  end
+
   # Re-expand the AST after a successful node so a resolved gate or
   # fan-out emits its children. Only runs on `{:ok, _}`: a failure does not
   # produce an output a gate can read. The new children land `:pending`

--- a/packages/symphony/elixir/test/command_test.exs
+++ b/packages/symphony/elixir/test/command_test.exs
@@ -15,6 +15,23 @@ defmodule SymphonyElixir.CommandTest do
     assert {:error, {:timeout, 50, _output}} = Command.run("/bin/sh", ["-c", "sleep 5"], 50)
   end
 
+  test "leaves no stray port messages in the caller's mailbox after a timeout" do
+    # The child traps TERM and prints a goodbye line, the shape of the
+    # `ix` CLI's "Interrupted. Shutting down..." on the timeout kill.
+    # Without the post-close drain that line lands in the caller's
+    # mailbox as a raw `{port, {:data, ...}}` message and crashes a
+    # GenServer caller that has no clause for it.
+    assert {:error, {:timeout, 50, _output}} =
+             Command.run(
+               "/bin/sh",
+               ["-c", "trap 'echo interrupted; exit 0' TERM; sleep 30 & wait"],
+               50
+             )
+
+    refute_receive {_port, {:data, _}}, 200
+    refute_receive {_port, {:exit_status, _}}, 0
+  end
+
   test "kills the spawned process on timeout so it does not orphan" do
     pid_file = Path.join(System.tmp_dir!(), "command_test_#{System.unique_integer([:positive])}.pid")
     on_exit(fn -> File.rm(pid_file) end)

--- a/packages/symphony/elixir/test/symphony_elixir/runtime_test.exs
+++ b/packages/symphony/elixir/test/symphony_elixir/runtime_test.exs
@@ -230,6 +230,26 @@ defmodule SymphonyElixir.RuntimeTest do
     assert final.nodes["b"].state == :succeeded
   end
 
+  test "a stray message does not crash the run", %{dir: dir} do
+    g = graph("run-stray-message", [node("a", state: :pending)])
+    FakeEngine.program("a", {:sleep_then, {:ok, %{v: 1}}})
+
+    {:ok, pid} = Runtime.start_link(g, opts(dir))
+
+    # The shape a timed-out Command.run child used to leak: a raw port
+    # line dequeued by the GenServer long after collect/4 gave up.
+    # Without the catch-all clause this was a FunctionClauseError that
+    # killed the run mid-flight (and the transient restart then
+    # double-submitted the in-flight turn).
+    send(pid, {self(), {:data, "Interrupted. Shutting down...\n"}})
+
+    wait_for_exit(pid)
+
+    {:ok, final} = Store.load("run-stray-message", dir: dir)
+    assert final.status == :succeeded
+    assert final.nodes["a"].state == :succeeded
+  end
+
   test "threads the resolved placement cwd into an agent turn", %{dir: dir} do
     # A `{:host, _}` location makes the runtime acquire a placement, so the
     # agent run_opts must carry the checkout cwd the engine turn needs.


### PR DESCRIPTION
## Problem

Observed on the docsync run `docsync-1781035474726-48`: an `ix vm create` placement attempt timed out at 120s, `Command.run`'s timeout path SIGTERM'd the ix CLI, and the CLI printed `Interrupted. Shutting down...` between the kill and `Port.close/1`. `Port.close` does not flush messages the port already delivered, so that line sat in the Runtime GenServer's mailbox as a raw `{port, {:data, ...}}` message.

`Runtime.handle_info/2` had no clause for port data, so when the GenServer dequeued it (after placement had already fallen back to a remote worker and the turn task was in flight):

1. `FunctionClauseError`, the run process died (`runtime.ex:259`).
2. The supervisor's transient restart replayed the run from its persisted graph and spawned a second turn task.
3. Both the orphaned pre-crash task and the new one submitted the same prompt to the worker 16ms apart (two `user_prompt` rows in the thread).

## Fix

Two layers:

- `Command.close_port/1` now drains every message the port sent before returning (once `Port.close/1` has returned the port sends nothing further, so a single non-blocking sweep is complete). A timed-out child can never leak into the caller's mailbox.
- `Runtime` gets a catch-all `handle_info` clause that logs and drops unexpected messages, so no stray message of any origin can kill a run again.

## Tests

- `command_test.exs`: a child that traps TERM and prints a goodbye line leaves no stray port messages in the caller's mailbox after a timeout.
- `runtime_test.exs`: a stray `{from, {:data, ...}}` message sent to a mid-flight run does not crash it; the run completes successfully.

Both red without the lib changes, green with them. `mix compile --warnings-as-errors`, `mix format --check-formatted`, and `credo` clean under Elixir 1.19/OTP 28.

Note: `mix test` has one pre-existing failure on main, unrelated to this change: `ir_run_controller_test.exs` drift test's `model_for/1` helper has no clause for the `:pi` engine added in c73a31ec.

Companion room-server fix (the claude adapter passing an invalid `--thinking high` flag and hanging on a dead claude) is indexable-inc/ix#4555.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stray port messages crashing a Symphony run
> - Adds `flush_port/1` in [`command.ex`](https://github.com/indexable-inc/index/pull/1008/files#diff-af8214855063eb0c444feb897406ef8de133373b256ade39d2a75605f61084f1) to drain any remaining `{port, ...}` messages from the caller's mailbox after `Port.close/1`, including when exceptions occur.
> - Adds a catch-all `handle_info/2` clause in [`runtime.ex`](https://github.com/indexable-inc/index/pull/1008/files#diff-66b52590997a473e90f9cf449bfab03b019f2db143377bc3ea621be532fa1041) so unexpected messages sent to the Runtime GenServer are logged and ignored instead of raising a `FunctionClauseError` crash.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90b5a56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->