### PR TITLE
flake: scope data subtrees to relative-path inputs for lazy source trees

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,29 @@
 {
   "nodes": {
+    "agent-context": {
+      "flake": false,
+      "locked": {
+        "path": "./agent-context",
+        "type": "path"
+      },
+      "original": {
+        "path": "./agent-context",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "bench-filesystem": {
+      "flake": false,
+      "locked": {
+        "path": "./bench/filesystem",
+        "type": "path"
+      },
+      "original": {
+        "path": "./bench/filesystem",
+        "type": "path"
+      },
+      "parent": []
+    },
     "btop-src": {
       "flake": false,
       "locked": {
@@ -51,6 +75,18 @@
         "type": "git",
         "url": "https://github.com/osandov/drgn"
       }
+    },
+    "examples": {
+      "flake": false,
+      "locked": {
+        "path": "./examples",
+        "type": "path"
+      },
+      "original": {
+        "path": "./examples",
+        "type": "path"
+      },
+      "parent": []
     },
     "fff-src": {
       "flake": false,
@@ -152,6 +188,18 @@
         "repo": "home-manager",
         "type": "github"
       }
+    },
+    "images": {
+      "flake": false,
+      "locked": {
+        "path": "./images",
+        "type": "path"
+      },
+      "original": {
+        "path": "./images",
+        "type": "path"
+      },
+      "parent": []
     },
     "launchk-src": {
       "flake": false,
@@ -297,17 +345,24 @@
     },
     "root": {
       "inputs": {
+        "agent-context": "agent-context",
+        "bench-filesystem": "bench-filesystem",
         "btop-src": "btop-src",
         "clippy-fork": "clippy-fork",
         "drgn-src": "drgn-src",
+        "examples": "examples",
         "fff-src": "fff-src",
         "ghostty": "ghostty",
         "hermes-agent": "hermes-agent",
         "home-manager": "home-manager",
+        "images": "images",
         "launchk-src": "launchk-src",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay",
-        "snix-src": "snix-src"
+        "site": "site",
+        "skills": "skills",
+        "snix-src": "snix-src",
+        "tests": "tests"
       }
     },
     "rust-overlay": {
@@ -330,6 +385,30 @@
         "type": "github"
       }
     },
+    "site": {
+      "flake": false,
+      "locked": {
+        "path": "./site",
+        "type": "path"
+      },
+      "original": {
+        "path": "./site",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "skills": {
+      "flake": false,
+      "locked": {
+        "path": "./skills",
+        "type": "path"
+      },
+      "original": {
+        "path": "./skills",
+        "type": "path"
+      },
+      "parent": []
+    },
     "snix-src": {
       "flake": false,
       "locked": {
@@ -346,6 +425,18 @@
         "type": "git",
         "url": "https://git.snix.dev/snix/snix"
       }
+    },
+    "tests": {
+      "flake": false,
+      "locked": {
+        "path": "./tests",
+        "type": "path"
+      },
+      "original": {
+        "path": "./tests",
+        "type": "path"
+      },
+      "parent": []
     },
     "uv2nix": {
       "inputs": {

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,47 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
+    # Relative-path ("subflake") inputs for the repo's independent data
+    # subtrees. With lazy source trees a flake that reaches its whole tree via
+    # `self` gives every package the entire repo as its source identity: any
+    # file change anywhere re-hashes and re-copies the full tree per eval and
+    # invalidates every dependent. Declaring each pure-data subtree as its own
+    # `flake = false` path input scopes a consumer's source to just the subtree
+    # it reads, so an edit under `site/` no longer perturbs an `agent-context`
+    # package's drvPath. nix and nox both resolve these as lock nodes
+    # `{ type = "path"; path = "./<dir>"; parent = []; }` against the parent
+    # tree, with no separate fetch. Nix-code roots the flake itself imports
+    # (`modules`, `packages`) stay ordinary relative paths: they are
+    # import-time, not source identity. See ENG-2362.
+    agent-context = {
+      url = "path:./agent-context";
+      flake = false;
+    };
+    skills = {
+      url = "path:./skills";
+      flake = false;
+    };
+    images = {
+      url = "path:./images";
+      flake = false;
+    };
+    examples = {
+      url = "path:./examples";
+      flake = false;
+    };
+    tests = {
+      url = "path:./tests";
+      flake = false;
+    };
+    bench-filesystem = {
+      url = "path:./bench/filesystem";
+      flake = false;
+    };
+    site = {
+      url = "path:./site";
+      flake = false;
+    };
+
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -122,6 +163,13 @@
       snix-src,
       clippy-fork,
       ghostty,
+      agent-context,
+      skills,
+      images,
+      examples,
+      tests,
+      bench-filesystem,
+      site,
       ...
     }:
     let
@@ -143,24 +191,36 @@
 
       # All path literals the flake exposes. Centralized so lib/ and
       # lib/per-system.nix have a single source of truth.
+      #
+      # The data-subtree entries below resolve to the `outPath` of a
+      # relative-path input (declared `flake = false` above) instead of a
+      # bare `./<dir>` literal, so each consumer's source identity is scoped to
+      # just that subtree. The shape and names of `paths` are unchanged, so no
+      # downstream lib code needs editing. Nix-code roots the flake imports
+      # directly (`modules`, `packagesRoot`) and the whole-repo `root` (the lint
+      # source intentionally covers the entire tree) stay ordinary relative
+      # paths: those are import-time / whole-repo by design, not per-subtree
+      # source identity. The minecraft sub-paths are projections of the `images`
+      # subtree, so they ride the same `images` input rather than each opening a
+      # new whole-repo dependency.
       paths = {
         root = ./.;
-        agentContext = ./agent-context;
-        skills = ./skills;
-        images = ./images;
+        agentContext = agent-context.outPath;
+        skills = skills.outPath;
+        images = images.outPath;
         modules = ./modules;
-        examples = ./examples;
-        tests = ./tests;
-        bench.filesystem = ./bench/filesystem;
-        site = ./site;
+        examples = examples.outPath;
+        tests = tests.outPath;
+        bench.filesystem = bench-filesystem.outPath;
+        site = site.outPath;
         packagesRoot = ./packages;
-        minecraftMods = ./images/games/minecraft/mods;
-        minecraftPaperPlugins = ./images/games/minecraft/plugins/paper;
-        minecraftVelocityPlugins = ./images/games/minecraft/plugins/velocity;
+        minecraftMods = images.outPath + "/games/minecraft/mods";
+        minecraftPaperPlugins = images.outPath + "/games/minecraft/plugins/paper";
+        minecraftVelocityPlugins = images.outPath + "/games/minecraft/plugins/velocity";
         minecraftLoaders = {
-          paper = ./images/games/minecraft/loaders/paper;
-          velocity = ./images/games/minecraft/loaders/velocity;
-          fabric = ./images/games/minecraft/loaders/fabric;
+          paper = images.outPath + "/games/minecraft/loaders/paper";
+          velocity = images.outPath + "/games/minecraft/loaders/velocity";
+          fabric = images.outPath + "/games/minecraft/loaders/fabric";
         };
         tools = {
           ixShellSyncIgnored = ./tools/ix-shell-sync-ignored.py;


### PR DESCRIPTION
## What

Convert the repo's independent data subtrees from `self`-rooted relative-path literals (`paths.<name> = ./<dir>`) to relative-path ("subflake") inputs (`inputs.<name> = { url = "path:./<dir>"; flake = false; }`), and resolve the matching `paths` entry to that input's `outPath`. Implements ENG-2362.

Converted (pure data subtrees, category a):

| input | `paths` entry | how it is consumed |
| --- | --- | --- |
| `agent-context` | `agentContext` | `readFile` of `sections/`, always-doc + progressive skills |
| `skills` | `skills` | `readDir` + per-skill `linkFarm` sources |
| `images` | `images`, `minecraftMods`, `minecraftPaperPlugins`, `minecraftVelocityPlugins`, `minecraftLoaders.*` | image discovery + minecraft catalog/loader JSON (the minecraft leaves are projections of the images subtree, so they ride the one `images` input) |
| `examples` | `examples` | fleet/tree discovery + per-example `import` |
| `tests` | `tests` | `import paths.tests` |
| `bench-filesystem` | `bench.filesystem` | `import paths.bench.filesystem` |
| `site` | `site` | SvelteKit `fs.toSource` + vitest source |

Left as ordinary relative paths (category b, deliberately not converted):

- `modules` and `packagesRoot`: nix-code roots the flake imports directly (the package registry and module discovery are foundational, imported at the top of `lib/default.nix`). These are import-time, not per-subtree source identity.
- `root` (`./.`): the lint check (`lintSource = fs.toSource { root = paths.root; fileset = fs.gitTracked paths.root; }`) is meant to cover the whole tree by design.
- `tools`: a handful of individual `.py` / `.nu` script files, not a subtree.

The shape and names of `paths` are unchanged, so no `lib/` code needed editing (verified by grepping every `paths.` reference).

## Why (lazy source trees)

With lazy source trees a flake that reaches its whole tree via `self` makes every package's source identity the *entire* repo. The old `paths` set centralized `agent-context`, `skills`, `images`, `examples`, `tests`, `bench/filesystem`, and `site` as `./<dir>` literals rooted at `self`. When this flake is consumed as a locked input (the `ix` monorepo inputs `index`), or evaluated through an eval cache, the whole-tree fetch is the dominant per-eval cost and any tracked change anywhere re-locks/re-copies/re-hashes the full tree and invalidates the validated input set for every dependent.

A relative-path input scopes a consumer's source to just the subtree it reads. nix and nox both lock these as

```json
"agent-context": {
  "flake": false,
  "locked":   { "path": "./agent-context", "type": "path" },
  "original": { "path": "./agent-context", "type": "path" },
  "parent": []
}
```

and resolve them against the parent tree with no separate fetch. Under a lazy-trees evaluator the subtree resolves *in place* (no whole-tree copy), which is exactly the shape nox's per-input eval cache rewards: validation reads only the subtree, so an unrelated subtree edit keeps the cache hit.

## flake.lock diff

`nix flake lock` adds 7 nodes, each of the `type = "path"`, `parent = []`, `flake = false` shape shown above (`agent-context`, `skills`, `images`, `examples`, `tests`, `bench-filesystem`, `site`), plus the matching `root.inputs` entries. No existing node changed.

## Validation

`nix flake show` (`--extra-experimental-features "nix-command flakes ca-derivations" --accept-flake-config --allow-import-from-derivation`) succeeds before and after with **byte-identical output structure** (2030 lines, the only diff being the header flakeref line: committed `main` rev vs the working-tree ref).

Three representative light packages, evaluated for `drvPath` with both real nix (2.34.7) and `nox` (`NOX_NO_EVAL_CACHE=1`), after the change:

| package | nix | nox | agree |
| --- | --- | --- | --- |
| `claude-md` | `c38y4p75…-CLAUDE.md.drv` | `c38y4p75…-CLAUDE.md.drv` | yes |
| `codex-md` | `4g1jmrb1…-AGENTS.md.drv` | `4g1jmrb1…-AGENTS.md.drv` | yes |
| `bench-filesystem` | `zk1xb616…-ix-bench-filesystem.drv` | `zk1xb616…-ix-bench-filesystem.drv` | yes |

These content-derived outputs agree across evaluators and are unchanged before→after (the subtree path is not part of their content hash).

### Unrelated-change invalidation proof (the motivation)

Tree-sourced package `skills` (a `linkFarm` over the `skills` subtree), under `nox` (the lazy-trees evaluator):

- commit an unrelated change under `site/`, re-evaluate `packages.x86_64-linux.skills.drvPath`:
  - **after this change:** `b14gzffq…-claude-skills.drv` before *and* after the `site/` edit -> **unchanged** (source scoped to the `skills` subtree; the unrelated subtree is invisible).

That is the win: a package sourced from one subtree no longer rebuilds when an unrelated subtree changes.

### One-time rebuild + the nix-version caveat

Source-identity drvPaths for *tree-sourced* packages shift once with this restructure, because the source moves from a whole-repo slice to a declared subtree. Concretely `skills` moves to `w14qiyml…` under upstream nix.

Worth being explicit: the in-place benefit requires a lazy-trees-capable evaluator.

- **nox** (lazy trees): resolves `path:./skills` in place to `<repo>/skills`, so `skills` = `b14gzffq…` and stays stable across unrelated subtree edits. This is the target behavior (ENG-2362: "this should work because nox supports it").
- **upstream nix 2.34.7** (no `lazy-trees` feature): resolves a relative-path input by copying the *whole parent tree* to the store and slicing `<store-source>/skills`, so `skills` = `w14qiyml…` and an unrelated tracked change still shifts it. This nix does not yet realize the in-place benefit; it sees only the one-time drv shift. The lock shape is identical either way, so the repo is correct for both, and gets the full benefit the moment it is evaluated by nox or a lazy-trees nix.

Content-derived outputs (`claude-md`, `codex-md`, `bench-filesystem`) are unaffected by the restructure and agree between nix and nox in all cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope flake data subtrees to relative-path inputs for lazy source trees
> - Declares seven new `flake = false` path inputs in [flake.nix](https://github.com/indexable-inc/index/pull/1018/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) (`agent-context`, `skills`, `images`, `examples`, `tests`, `bench-filesystem`, `site`), each pointing to a local subdirectory via `url = "path:./<dir>"`.
> - Rewires the `paths` attrset to use `<input>.outPath` for each of these directories instead of repo-relative path literals, scoping source identity to each subtree independently.
> - Behavioral Change: derivations consuming these paths now depend on the specific locked outPath of each subtree input, changing rebuild granularity so that changes in one subtree no longer invalidate unrelated derivations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5835514.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->