### PR TITLE
fix(pi-harness): pin the pi binary and emit one terminal turn_completed

### DIFF
--- a/packages/pi-harnesses/README.md
+++ b/packages/pi-harnesses/README.md
@@ -49,8 +49,10 @@ PI_HARNESS_MODEL=codex nix run .#pi-prosecutor -- "..."   # gpt-5.5 medium
 ```
 
 API keys come from the caller's environment (`ANTHROPIC_API_KEY` /
-`OPENAI_API_KEY`); the harness owns model *selection* only. `pi` must be on PATH
-until the dependency-intake follow-up pins a `pi` derivation (same as engine).
+`OPENAI_API_KEY`); the harness owns model *selection* only. Every harness execs
+nixpkgs' pinned `pi-coding-agent` binary, never a `pi` resolved from the
+caller's PATH (host-level wrappers there inject conflicting flags and
+extensions); swap it with `.override { pi = ...; }`.
 
 ## Adding a harness
 

--- a/packages/pi-harnesses/base/default.nix
+++ b/packages/pi-harnesses/base/default.nix
@@ -1,7 +1,10 @@
 {
   callPackage,
   git,
-  pi ? null,
+  pi-coding-agent,
+  # Pinned bare `pi` binary (see ../shared/mk-pi-harness.nix). Override here
+  # to swap the pi the wrapper execs.
+  pi ? pi-coding-agent,
 }:
 let
   mkPiHarness = callPackage ../shared/mk-pi-harness.nix { inherit pi; };

--- a/packages/pi-harnesses/beam/default.nix
+++ b/packages/pi-harnesses/beam/default.nix
@@ -1,7 +1,10 @@
 {
   callPackage,
   git,
-  pi ? null,
+  pi-coding-agent,
+  # Pinned bare `pi` binary (see ../shared/mk-pi-harness.nix). Override here
+  # to swap the pi the wrapper execs.
+  pi ? pi-coding-agent,
 }:
 let
   mkPiHarness = callPackage ../shared/mk-pi-harness.nix { inherit pi; };

--- a/packages/pi-harnesses/engine/README.md
+++ b/packages/pi-harnesses/engine/README.md
@@ -78,6 +78,14 @@ stable Room-facing names such as `turn_started`, `text_delta`,
 `reasoning_delta`, `tool_call_started`, `tool_call_output`, `usage`,
 `turn_completed`, and `error`.
 
+Pi auto-retries provider errors (up to three attempts; `agent_end` with
+`willRetry: true`, then `auto_retry_start`). The mapper suppresses the
+retried attempts' `turn_end` events and emits exactly one terminal
+`turn_completed` per turn, so a consumer that ends the turn on
+`turn_completed` (the Room server) survives retries. When the final attempt
+still failed (`message_end` with `stopReason: "error"`), the terminal
+`turn_completed` carries top-level `status: "error"` and `error: <message>`.
+
 ix-mcp store updates emit the dashboard-shaped payloads directly:
 
 ```json

--- a/packages/pi-harnesses/engine/README.md
+++ b/packages/pi-harnesses/engine/README.md
@@ -135,7 +135,5 @@ provider keys.
 
 ## Follow-ups (intentionally deferred)
 
-- Package `pi` as a pinned nix dependency (dependency-intake) and wire it +
-  `ix-mcp` into `default.nix` `runtimeInputs` instead of relying on PATH.
 - Run the ENG-2263 live smoke matrix in CI once model-provider test credentials
   are available.

--- a/packages/pi-harnesses/engine/default.nix
+++ b/packages/pi-harnesses/engine/default.nix
@@ -3,10 +3,14 @@
   stdenv,
   buildNpmPackage,
   python3,
-  # Pi is not yet packaged in this repo. Until the dependency-intake follow-up
-  # lands a pinned `pi` derivation, the wrapper calls `pi` from PATH (the dev
-  # image / system already provides it). Pass a derivation here to pin it.
-  pi ? null,
+  pi-coding-agent,
+  # The bare `pi` binary the launcher execs. Pinned to nixpkgs'
+  # `pi-coding-agent` so the shipped harness never resolves `pi` from the
+  # caller's PATH: host-level `pi` wrappers inject their own `--extension` /
+  # `--provider` flags, which loads a second ix-mcp-bridge copy, makes every
+  # tool name conflict, and kills the lockdown posture. Override with a
+  # different derivation here, or at runtime with `PI_HARNESS_PI_BIN`.
+  pi ? pi-coding-agent,
   # ix-mcp supplies the ONLY tool surface (python_exec + search_* + calendar_*),
   # built from index/packages/mcp. Pass null to fall back to PATH for local dev.
   ix-mcp ? null,
@@ -66,9 +70,13 @@ let
 
   mapper = ./room_event_mapper.py;
 
-  runtimeInputs = [ python3 ] ++ lib.optional (pi != null) pi ++ lib.optional (ix-mcp != null) ix-mcp;
+  runtimeInputs = [
+    python3
+    pi
+  ]
+  ++ lib.optional (ix-mcp != null) ix-mcp;
   runtimePath = lib.makeBinPath runtimeInputs;
-  piCommand = if pi == null then "pi" else lib.getExe pi;
+  piCommand = lib.getExe pi;
   pythonCommand = lib.getExe python3;
   isLinux = stdenv.hostPlatform.isLinux;
   hardenerLibraryName = "libpi-harness-harden.so";

--- a/packages/pi-harnesses/engine/room_event_mapper.py
+++ b/packages/pi-harnesses/engine/room_event_mapper.py
@@ -139,14 +139,17 @@ class TurnLifecycle:
     the next attempt. Room terminates the turn on the first turn_completed, so a
     per-attempt mapping ends a retried turn early. This holds each turn_end
     until agent_end (or the next event) reveals whether the attempt is final,
-    drops the suppressed attempts, and stamps the terminal turn_completed with
-    the provider error when the last attempt also failed.
+    suppresses the retried attempts, and stamps the terminal turn_completed
+    with the provider error when the last attempt also failed. A suppressed
+    attempt is kept as a fallback so a stream that dies between the retry
+    announcement and the next attempt's turn_end still terminates the turn.
     """
 
     def __init__(self, emitter: Emitter) -> None:
         self._emitter = emitter
         self._pending_turn_end: Json | None = None
         self._error: str | None = None
+        self._suppressed: tuple[Json, str] | None = None
 
     def handle(self, event: Json) -> None:
         pi_type = _event_type(event)
@@ -162,8 +165,15 @@ class TurnLifecycle:
             self._pending_turn_end = event
             return
         if pi_type == "auto_retry_start" or (pi_type == "agent_end" and _will_retry(event)):
-            # The attempt is being retried: suppress its turn_completed.
-            self._pending_turn_end = None
+            # The attempt is being retried: suppress its turn_completed, but
+            # keep it so close() can still terminate the turn if the retry
+            # never produces another turn_end.
+            if self._pending_turn_end is not None:
+                self._suppressed = (
+                    self._pending_turn_end,
+                    self._error or "provider error: turn interrupted during auto-retry",
+                )
+                self._pending_turn_end = None
             self._emitter.emit(map_pi_event(event))
             return
         if pi_type == "message_end":
@@ -179,7 +189,19 @@ class TurnLifecycle:
         self._emitter.emit(map_pi_event(event))
 
     def close(self) -> None:
-        self._flush()
+        if self._pending_turn_end is not None:
+            self._flush()
+            return
+        if self._suppressed is not None:
+            # The stream died after a retry announcement and before the next
+            # attempt finished: surface the suppressed attempt as the failed
+            # terminal event instead of leaving the turn open.
+            event, error = self._suppressed
+            self._suppressed = None
+            mapped = map_pi_event(event)
+            mapped["status"] = "error"
+            mapped["error"] = error
+            self._emitter.emit(mapped)
 
     def _flush(self) -> None:
         if self._pending_turn_end is None:
@@ -190,6 +212,7 @@ class TurnLifecycle:
             mapped["error"] = self._error
         self._pending_turn_end = None
         self._error = None
+        self._suppressed = None
         self._emitter.emit(mapped)
 
 

--- a/packages/pi-harnesses/engine/room_event_mapper.py
+++ b/packages/pi-harnesses/engine/room_event_mapper.py
@@ -98,6 +98,19 @@ def _text_delta(event: Json) -> str | None:
     return None
 
 
+def _message_error(event: Json) -> str | None:
+    """Return the provider error message when a message ended with stopReason error."""
+    for container in (event, event.get("message")):
+        if isinstance(container, dict) and container.get("stopReason") == "error":
+            message = container.get("errorMessage")
+            return message if isinstance(message, str) else "unknown provider error"
+    return None
+
+
+def _will_retry(event: Json) -> bool:
+    return bool(event.get("willRetry"))
+
+
 def map_pi_event(event: Json) -> Json:
     pi_type = _event_type(event)
     room_type = _room_event_type(event, pi_type)
@@ -116,6 +129,68 @@ def map_pi_event(event: Json) -> Json:
             mapped[key] = event[key]
 
     return mapped
+
+
+class TurnLifecycle:
+    """Coalesce pi's auto-retried attempts into one terminal turn_completed.
+
+    Pi retries provider errors up to three times: each failed attempt emits its
+    own turn_end, then agent_end with willRetry=true and auto_retry_start before
+    the next attempt. Room terminates the turn on the first turn_completed, so a
+    per-attempt mapping ends a retried turn early. This holds each turn_end
+    until agent_end (or the next event) reveals whether the attempt is final,
+    drops the suppressed attempts, and stamps the terminal turn_completed with
+    the provider error when the last attempt also failed.
+    """
+
+    def __init__(self, emitter: Emitter) -> None:
+        self._emitter = emitter
+        self._pending_turn_end: Json | None = None
+        self._error: str | None = None
+
+    def handle(self, event: Json) -> None:
+        pi_type = _event_type(event)
+        if pi_type in {"turn_start", "turn_started"}:
+            # A new turn in the same agent run: the previous turn really ended.
+            self._flush()
+            self._error = None
+            self._emitter.emit(map_pi_event(event))
+            return
+        if pi_type in {"turn_end", "turn_completed"}:
+            # Defer: only agent_end / auto_retry_start knows whether pi retries.
+            self._flush()
+            self._pending_turn_end = event
+            return
+        if pi_type == "auto_retry_start" or (pi_type == "agent_end" and _will_retry(event)):
+            # The attempt is being retried: suppress its turn_completed.
+            self._pending_turn_end = None
+            self._emitter.emit(map_pi_event(event))
+            return
+        if pi_type == "message_end":
+            error = _message_error(event)
+            if error is not None:
+                self._error = error
+            self._emitter.emit(map_pi_event(event))
+            return
+        if pi_type == "agent_end":
+            self._flush()
+            self._emitter.emit(map_pi_event(event))
+            return
+        self._emitter.emit(map_pi_event(event))
+
+    def close(self) -> None:
+        self._flush()
+
+    def _flush(self) -> None:
+        if self._pending_turn_end is None:
+            return
+        mapped = map_pi_event(self._pending_turn_end)
+        if self._error is not None:
+            mapped["status"] = "error"
+            mapped["error"] = self._error
+        self._pending_turn_end = None
+        self._error = None
+        self._emitter.emit(mapped)
 
 
 def _connect(path: Path) -> sqlite3.Connection | None:
@@ -324,6 +399,7 @@ def _strip_command_separator(command: list[str]) -> list[str]:
 def run(store: Path, interval: float, command: list[str] | None = None) -> int:
     os.environ["IX_MCP_STORE"] = str(store)
     emitter = Emitter()
+    lifecycle = TurnLifecycle(emitter)
     poller = StorePoller(store, interval, emitter)
     poller.start()
 
@@ -354,10 +430,11 @@ def run(store: Path, interval: float, command: list[str] | None = None) -> int:
                 emitter.emit({"type": "error", "source": "pi-harness", "message": str(exc), "line": stripped})
                 continue
             if isinstance(event, dict):
-                emitter.emit(map_pi_event(event))
+                lifecycle.handle(event)
             else:
                 emitter.emit({"type": "pi_event", "source": "pi", "raw": event})
     finally:
+        lifecycle.close()
         poller.stop()
     if process is None:
         return 0

--- a/packages/pi-harnesses/engine/room_event_mapper_test.py
+++ b/packages/pi-harnesses/engine/room_event_mapper_test.py
@@ -75,6 +75,107 @@ class MapperTest(unittest.TestCase):
         self.assertEqual(mapper.map_pi_event({"type": "tool_execution_start", "id": "t1"})["type"], "tool_call_started")
         self.assertEqual(mapper.map_pi_event({"type": "turn_end"})["type"], "turn_completed")
 
+    def _run_lifecycle(self, events):
+        emitter = CaptureEmitter()
+        lifecycle = mapper.TurnLifecycle(emitter)  # type: ignore[arg-type]
+        for event in events:
+            lifecycle.handle(event)
+        lifecycle.close()
+        return emitter.events
+
+    def test_single_attempt_emits_one_turn_completed_without_error(self) -> None:
+        emitted = self._run_lifecycle(
+            [
+                {"type": "agent_start"},
+                {"type": "turn_start"},
+                {"type": "message_start"},
+                {"type": "message_end", "message": {"stopReason": "stop"}},
+                {"type": "turn_end"},
+                {"type": "agent_end"},
+            ]
+        )
+        completed = [event for event in emitted if event["type"] == "turn_completed"]
+        self.assertEqual(len(completed), 1)
+        self.assertNotIn("error", completed[0])
+        self.assertNotIn("status", completed[0])
+        # The terminal turn_completed lands before agent_end, as in the raw stream.
+        self.assertEqual([event["pi_type"] for event in emitted[-2:]], ["turn_end", "agent_end"])
+
+    def test_retried_then_succeeded_emits_one_terminal_turn_completed(self) -> None:
+        emitted = self._run_lifecycle(
+            [
+                {"type": "agent_start"},
+                {"type": "turn_start"},
+                {"type": "message_start"},
+                {"type": "message_end", "message": {"stopReason": "error", "errorMessage": "overloaded"}},
+                {"type": "turn_end"},
+                {"type": "agent_end", "willRetry": True},
+                {"type": "auto_retry_start", "attempt": 2},
+                {"type": "turn_start"},
+                {"type": "message_start"},
+                {"type": "message_end", "message": {"stopReason": "stop"}},
+                {"type": "turn_end"},
+                {"type": "agent_end"},
+            ]
+        )
+        completed = [event for event in emitted if event["type"] == "turn_completed"]
+        self.assertEqual(len(completed), 1)
+        self.assertNotIn("error", completed[0])
+        self.assertNotIn("status", completed[0])
+        # The first attempt's turn_end is suppressed entirely; the retry
+        # bookkeeping events still pass through for observability.
+        self.assertIn("auto_retry_start", [event.get("pi_type") for event in emitted])
+
+    def test_all_attempts_failed_emits_one_turn_completed_with_error(self) -> None:
+        failed_attempt = [
+            {"type": "turn_start"},
+            {"type": "message_start"},
+            {"type": "message_end", "message": {"stopReason": "error", "errorMessage": "overloaded"}},
+            {"type": "turn_end"},
+        ]
+        emitted = self._run_lifecycle(
+            [{"type": "agent_start"}]
+            + failed_attempt
+            + [{"type": "agent_end", "willRetry": True}, {"type": "auto_retry_start", "attempt": 2}]
+            + failed_attempt
+            + [{"type": "agent_end", "willRetry": True}, {"type": "auto_retry_start", "attempt": 3}]
+            + failed_attempt
+            + [{"type": "agent_end"}]
+        )
+        completed = [event for event in emitted if event["type"] == "turn_completed"]
+        self.assertEqual(len(completed), 1)
+        self.assertEqual(completed[0]["status"], "error")
+        self.assertEqual(completed[0]["error"], "overloaded")
+
+    def test_stream_ending_after_turn_end_still_flushes(self) -> None:
+        # No agent_end (pi crashed or stream cut): close() must still emit the
+        # held turn_completed so Room sees the turn terminate.
+        emitted = self._run_lifecycle(
+            [
+                {"type": "turn_start"},
+                {"type": "message_end", "stopReason": "error", "errorMessage": "boom"},
+                {"type": "turn_end"},
+            ]
+        )
+        completed = [event for event in emitted if event["type"] == "turn_completed"]
+        self.assertEqual(len(completed), 1)
+        self.assertEqual(completed[0]["error"], "boom")
+
+    def test_multi_turn_run_keeps_each_turn_completed(self) -> None:
+        # Consecutive turns in one agent run are real completions, not retries.
+        emitted = self._run_lifecycle(
+            [
+                {"type": "turn_start"},
+                {"type": "turn_end"},
+                {"type": "turn_start"},
+                {"type": "turn_end"},
+                {"type": "agent_end"},
+            ]
+        )
+        completed = [event for event in emitted if event["type"] == "turn_completed"]
+        self.assertEqual(len(completed), 2)
+        self.assertNotIn("error", completed[0])
+
     def test_strips_command_separator(self) -> None:
         self.assertEqual(mapper._strip_command_separator(["--", "pi", "--mode", "json"]), ["pi", "--mode", "json"])
         self.assertEqual(mapper._strip_command_separator(["pi"]), ["pi"])

--- a/packages/pi-harnesses/engine/room_event_mapper_test.py
+++ b/packages/pi-harnesses/engine/room_event_mapper_test.py
@@ -161,6 +161,44 @@ class MapperTest(unittest.TestCase):
         self.assertEqual(len(completed), 1)
         self.assertEqual(completed[0]["error"], "boom")
 
+    def test_stream_cut_after_retry_announcement_still_terminates_turn(self) -> None:
+        # willRetry suppressed the attempt's turn_end, then the stream died
+        # before the next attempt produced one: the suppressed attempt must
+        # surface as the failed terminal event so Room sees the turn end.
+        emitted = self._run_lifecycle(
+            [
+                {"type": "turn_start"},
+                {"type": "message_end", "message": {"stopReason": "error", "errorMessage": "overloaded"}},
+                {"type": "turn_end"},
+                {"type": "agent_end", "willRetry": True},
+                {"type": "auto_retry_start", "attempt": 2},
+            ]
+        )
+        completed = [event for event in emitted if event["type"] == "turn_completed"]
+        self.assertEqual(len(completed), 1)
+        self.assertEqual(completed[0]["status"], "error")
+        self.assertEqual(completed[0]["error"], "overloaded")
+        self.assertEqual(emitted[-1], completed[0])
+
+    def test_stream_cut_during_second_attempt_uses_suppressed_fallback(self) -> None:
+        # The retry started (turn_start arrived) but died before its turn_end:
+        # the suppressed first attempt still terminates the turn.
+        emitted = self._run_lifecycle(
+            [
+                {"type": "turn_start"},
+                {"type": "message_end", "message": {"stopReason": "error", "errorMessage": "overloaded"}},
+                {"type": "turn_end"},
+                {"type": "agent_end", "willRetry": True},
+                {"type": "auto_retry_start", "attempt": 2},
+                {"type": "turn_start"},
+                {"type": "message_start"},
+            ]
+        )
+        completed = [event for event in emitted if event["type"] == "turn_completed"]
+        self.assertEqual(len(completed), 1)
+        self.assertEqual(completed[0]["status"], "error")
+        self.assertEqual(completed[0]["error"], "overloaded")
+
     def test_multi_turn_run_keeps_each_turn_completed(self) -> None:
         # Consecutive turns in one agent run are real completions, not retries.
         emitted = self._run_lifecycle(

--- a/packages/pi-harnesses/prosecutor/default.nix
+++ b/packages/pi-harnesses/prosecutor/default.nix
@@ -1,7 +1,10 @@
 {
   callPackage,
   git,
-  pi ? null,
+  pi-coding-agent,
+  # Pinned bare `pi` binary (see ../shared/mk-pi-harness.nix). Override here
+  # to swap the pi the wrapper execs.
+  pi ? pi-coding-agent,
 }:
 let
   mkPiHarness = callPackage ../shared/mk-pi-harness.nix { inherit pi; };

--- a/packages/pi-harnesses/shared/mk-pi-harness.nix
+++ b/packages/pi-harnesses/shared/mk-pi-harness.nix
@@ -13,9 +13,12 @@
   coreutils,
   git,
   nodejs,
-  # Pi is not yet packaged in this repo (same situation as the engine harness):
-  # the wrapper calls `pi` from PATH. Pass a derivation here to pin it.
-  pi ? null,
+  pi-coding-agent,
+  # The bare `pi` binary the wrapper execs. Pinned to nixpkgs' `pi-coding-agent`
+  # (same posture as the engine harness) so the wrapper never resolves `pi`
+  # from the caller's PATH, where a host-level wrapper can inject conflicting
+  # flags and extensions. Pass a derivation here to override.
+  pi ? pi-coding-agent,
 }:
 {
   name,
@@ -45,14 +48,14 @@
   checkLib ? [ ],
 }:
 let
-  piBin = if pi == null then "pi" else lib.getExe pi;
+  piBin = lib.getExe pi;
   path = lib.makeBinPath (
     [
       coreutils
       git
+      pi
     ]
     ++ runtimeInputs
-    ++ lib.optional (pi != null) pi
   );
 
   flags =


### PR DESCRIPTION
## What

Two fixes to `packages/pi-harnesses` for the Room engine path:

1. **Pin the `pi` binary** (engine C launcher and the shared `mk-pi-harness.nix` shell wrapper for pi-base / pi-beam / pi-prosecutor) to nixpkgs' bare `pi-coding-agent` instead of resolving `pi` from the caller's PATH at exec time.
2. **Coalesce pi's auto-retried attempts** in `room_event_mapper.py` into exactly one terminal `turn_completed` per turn, carrying the provider error when the final attempt failed.

## Failure modes

**PATH lookup (ENG-2459).** The launchers defaulted to `pi ? null` and did `execvp("pi", ...)`. On hosts where `pi` is a settings-merging wrapper that injects its own flags (e.g. a home-config wrapper that execs `pi --extension <its own ix-mcp-bridge copy> --no-builtin-tools --provider openai --model gpt-5.5 "$@"`), pi loads two different store-path copies of ix-mcp-bridge, every tool name conflicts (`python_exec`, `read`, `kernel_trace`), the extension fails to load, and pi exits 1. Reproduced 2026-06-09 on spark via the ix room-server. The shipped harness now execs a pinned `/nix/store/...-pi-coding-agent-*/bin/pi`; `.override { pi = ...; }` is the derivation-level override and `PI_HARNESS_PI_BIN` stays as the engine's runtime override.

**Per-attempt turn_completed (ENG-2458, index half).** Pi auto-retries provider errors up to 3 times: each failed attempt emits `turn_start ... message_end (stopReason: "error") ... turn_end, agent_end (willRetry: true), auto_retry_start`, then the cycle repeats. The mapper translated every `turn_end` into a Room `turn_completed`, so the ix room server - which terminates the turn on the first `turn_completed` - saw a retried turn as already over. The mapper now holds each `turn_end` until `agent_end` / `auto_retry_start` reveals whether the attempt is final, suppresses the retried attempts, and stamps the terminal `turn_completed` with top-level `status: "error"` and `error: <errorMessage>` when the last attempt's message ended with `stopReason: "error"`. Existing event shape (`type`, `raw`, `pi_type`) is unchanged; EOF still flushes a held `turn_end` so a cut stream terminates the turn.

## Validation

- `nix build .#pi-harness .#pi-base .#pi-beam .#pi-prosecutor` (aarch64-linux); the engine derivation's `checkPhase` ran `room_event_mapper_test.py` (13 tests, including the new single-attempt / retried-then-succeeded / all-attempts-failed / EOF-flush / cut-after-retry-announcement / multi-turn cases).
- The built `bin/pi-harness` and `bin/pi-base` now reference `/nix/store/...-pi-coding-agent-0.78.0/bin/pi`; no `pi` PATH lookup remains.
- `nix run .#lint` clean.

Closes ENG-2459
Part of ENG-2458


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin pi binary to nixpkgs' pi-coding-agent and emit one terminal turn_completed per turn
> - All pi harnesses (`base`, `beam`, `engine`, `prosecutor`, and `mk-pi-harness`) now default to the nixpkgs-pinned `pi-coding-agent` derivation instead of resolving `pi` from PATH. The binary can still be overridden via `.override { pi = ...; }`.
> - Introduces `TurnLifecycle` in [room_event_mapper.py](https://github.com/indexable-inc/index/pull/1019/files#diff-6eb7fac25c097a38a18d89103820da8bcba3ba33b2edf2872de5efcb9aa8395a) to ensure exactly one `turn_completed` event is emitted per turn: terminal events from retried attempts are suppressed, and the final event is annotated with `status: 'error'` and an error message when all attempts fail.
> - Adds helpers `_message_error` and `_will_retry` to extract error reasons and retry intent from pi events.
> - Risk: streams that are cut after a retry announcement now emit the previously suppressed terminal event as an error rather than dropping it silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e2c5a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->