### PR TITLE
fix(pi-harness): preserve suppressed attempts' usage as retried_usage

### DIFF
--- a/packages/pi-harnesses/engine/room_event_mapper.py
+++ b/packages/pi-harnesses/engine/room_event_mapper.py
@@ -142,7 +142,10 @@ class TurnLifecycle:
     suppresses the retried attempts, and stamps the terminal turn_completed
     with the provider error when the last attempt also failed. A suppressed
     attempt is kept as a fallback so a stream that dies between the retry
-    announcement and the next attempt's turn_end still terminates the turn.
+    announcement and the next attempt's turn_end still terminates the turn,
+    and usage carried on suppressed turn_ends is preserved on the terminal
+    event under retried_usage (a separate key, so consumers that sum the
+    per-attempt usage events do not double count).
     """
 
     def __init__(self, emitter: Emitter) -> None:
@@ -150,6 +153,7 @@ class TurnLifecycle:
         self._pending_turn_end: Json | None = None
         self._error: str | None = None
         self._suppressed: tuple[Json, str] | None = None
+        self._retried_usage: list[Any] = []
 
     def handle(self, event: Json) -> None:
         pi_type = _event_type(event)
@@ -169,6 +173,8 @@ class TurnLifecycle:
             # keep it so close() can still terminate the turn if the retry
             # never produces another turn_end.
             if self._pending_turn_end is not None:
+                if "usage" in self._pending_turn_end:
+                    self._retried_usage.append(self._pending_turn_end["usage"])
                 self._suppressed = (
                     self._pending_turn_end,
                     self._error or "provider error: turn interrupted during auto-retry",
@@ -199,6 +205,14 @@ class TurnLifecycle:
             event, error = self._suppressed
             self._suppressed = None
             mapped = map_pi_event(event)
+            # The fallback event carries its own usage; retried_usage keeps
+            # only the OTHER suppressed attempts to avoid double counting.
+            retried_usage = self._retried_usage
+            self._retried_usage = []
+            if "usage" in event and retried_usage:
+                retried_usage = retried_usage[:-1]
+            if retried_usage:
+                mapped["retried_usage"] = retried_usage
             mapped["status"] = "error"
             mapped["error"] = error
             self._emitter.emit(mapped)
@@ -210,6 +224,9 @@ class TurnLifecycle:
         if self._error is not None:
             mapped["status"] = "error"
             mapped["error"] = self._error
+        if self._retried_usage:
+            mapped["retried_usage"] = self._retried_usage
+            self._retried_usage = []
         self._pending_turn_end = None
         self._error = None
         self._suppressed = None

--- a/packages/pi-harnesses/engine/room_event_mapper_test.py
+++ b/packages/pi-harnesses/engine/room_event_mapper_test.py
@@ -161,6 +161,48 @@ class MapperTest(unittest.TestCase):
         self.assertEqual(len(completed), 1)
         self.assertEqual(completed[0]["error"], "boom")
 
+    def test_suppressed_attempt_usage_lands_on_terminal_event(self) -> None:
+        # Usage billed for a suppressed retry attempt must not vanish: it rides
+        # on the terminal turn_completed under retried_usage, separate from the
+        # final attempt's own usage so consumers cannot double count.
+        emitted = self._run_lifecycle(
+            [
+                {"type": "turn_start"},
+                {"type": "message_end", "message": {"stopReason": "error", "errorMessage": "overloaded"}},
+                {"type": "turn_end", "usage": {"input": 10, "output": 1}},
+                {"type": "agent_end", "willRetry": True},
+                {"type": "auto_retry_start", "attempt": 2},
+                {"type": "turn_start"},
+                {"type": "turn_end", "usage": {"input": 12, "output": 40}},
+                {"type": "agent_end"},
+            ]
+        )
+        completed = [event for event in emitted if event["type"] == "turn_completed"]
+        self.assertEqual(len(completed), 1)
+        self.assertEqual(completed[0]["usage"], {"input": 12, "output": 40})
+        self.assertEqual(completed[0]["retried_usage"], [{"input": 10, "output": 1}])
+        self.assertNotIn("error", completed[0])
+
+    def test_fallback_event_does_not_double_count_its_own_usage(self) -> None:
+        # Two suppressed attempts, then the stream dies: the fallback terminal
+        # event is the second attempt's turn_end, so retried_usage keeps only
+        # the first attempt's usage.
+        emitted = self._run_lifecycle(
+            [
+                {"type": "turn_start"},
+                {"type": "turn_end", "usage": {"input": 10}},
+                {"type": "agent_end", "willRetry": True},
+                {"type": "turn_start"},
+                {"type": "turn_end", "usage": {"input": 20}},
+                {"type": "agent_end", "willRetry": True},
+            ]
+        )
+        completed = [event for event in emitted if event["type"] == "turn_completed"]
+        self.assertEqual(len(completed), 1)
+        self.assertEqual(completed[0]["usage"], {"input": 20})
+        self.assertEqual(completed[0]["retried_usage"], [{"input": 10}])
+        self.assertEqual(completed[0]["status"], "error")
+
     def test_stream_cut_after_retry_announcement_still_terminates_turn(self) -> None:
         # willRetry suppressed the attempt's turn_end, then the stream died
         # before the next attempt produced one: the suppressed attempt must


### PR DESCRIPTION
Follow-up to #1019, addressing the AI review P2 that did not make the merge: suppressing a retried attempt's `turn_end` discarded any `usage` payload it carried, so Room could underreport tokens/cost for provider auto-retries.

The terminal `turn_completed` now carries the suppressed attempts' usage under a separate `retried_usage` key (a list, in attempt order). The final attempt's own usage stays in `usage`, and the EOF-fallback path excludes the fallback event's own usage from `retried_usage`, so consumers that sum per-attempt usage cannot double count.

Covered by `test_suppressed_attempt_usage_lands_on_terminal_event` and `test_fallback_event_does_not_double_count_its_own_usage` (15 tests total in `room_event_mapper_test.py`, run by the `pi-harness` derivation's checkPhase).

Part of ENG-2458


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve suppressed retry attempts' usage as `retried_usage` on terminal turn events
> - In `TurnLifecycle`, when a `turn_end` is suppressed due to a retry, its usage is now accumulated in a new `retried_usage` list rather than discarded.
> - When the final `turn_completed` event is flushed (via `_flush` or as a fallback suppressed event), any accumulated `retried_usage` is attached to the event under a `retried_usage` field.
> - When the terminal event is itself from a suppressed attempt (fallback path), that attempt's own usage is excluded from `retried_usage` to avoid double-counting.
> - Two new tests in [room_event_mapper_test.py](https://github.com/indexable-inc/index/pull/1020/files#diff-ce626fbc5faf88418ca0efb792088f2be85fd79df3a52d6e088b6df7c9e5c77d) cover the success retry case and the fallback double-count prevention case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ddaa87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->