### PR TITLE
fix(mcp): honor a caller-pinned IX_MCP_STORE in serve

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -113,6 +113,15 @@ and HTML inline beside the agent's text. `cells` is the agent's curated highligh
 reel (`cells.add(...)`), and `resources` are live, self-updating views. The JSON
 shape mirrors `site/src/lib/types.ts`.
 
+An embedder that polls the SQLite store directly (the pi-harness room event
+mapper) pins its path with `IX_MCP_STORE` before launching `serve`; the server
+uses that path verbatim, so both sides agree on one file. The pinning caller
+owns the parent directory, and the fresh-log invariant still holds: the store
+and its `-wal`/`-shm` sidecars are wiped at startup. Unset, the store is minted
+in the private runtime dir, keyed by the data-API port
+(`IX_MCP_DASHBOARD_PORT`, free port if unset) so concurrent servers never
+collide.
+
 ## Remote access
 
 - `IX_MCP_HOST`: the address the dashboard binds. Default is this node's

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1400,6 +1400,16 @@ let
     assert isinstance(cli._dashboard_port(), int)
 
     tmp = Path(tempfile.mkdtemp())
+
+    # An embedder pins the execution store the same way (the pi-harness room
+    # event mapper polls exactly this file); unset, the store is minted in the
+    # runtime dir keyed by the data-API port.
+    os.environ["IX_MCP_STORE"] = str(tmp / "pinned-store.sqlite")
+    assert cli._store_path(54321) == tmp / "pinned-store.sqlite", cli._store_path(54321)
+    os.environ["IX_MCP_STORE"] = ""
+    assert cli._store_path(54321).name == "store-54321.db", cli._store_path(54321)
+    os.environ.pop("IX_MCP_STORE")
+    assert cli._store_path(54321).name == "store-54321.db", cli._store_path(54321)
     store_path = tmp / "store.db"
     conn = store.connect(store_path)
     rich = [

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -96,6 +96,19 @@ def _dashboard_port() -> int:
     return _free_port()
 
 
+def _store_path(dashboard_port: int) -> Path:
+    """The SQLite execution store. An embedder (the pi-harness room event
+    mapper polls the store for cell/resource updates) pins it with
+    ``IX_MCP_STORE`` so both sides agree on one file; the path is used
+    verbatim and the pinning caller owns its parent directory. Left unset,
+    the store lives in the private runtime dir, keyed by the data-API port
+    so concurrent servers never collide."""
+    pinned = os.environ.get("IX_MCP_STORE")
+    if pinned:
+        return Path(pinned)
+    return runtime_dir() / f"store-{dashboard_port}.db"
+
+
 def _tailscale_status() -> dict | None:
     tailscale = shutil.which("tailscale") or next(
         (p for p in ("/usr/local/bin/tailscale", "/usr/bin/tailscale") if os.path.exists(p)), None
@@ -171,9 +184,10 @@ def _serve(args: argparse.Namespace) -> int:
         mcp_http_host, mcp_http_port = host or "127.0.0.1", int(port) if port else 8000
 
     dashboard_port = _dashboard_port()
-    store_path = runtime_dir() / f"store-{dashboard_port}.db"
-    # Fresh execution log per server: if this port was used by a prior server,
-    # drop its database (and WAL sidecars) so the dashboard never shows stale runs.
+    store_path = _store_path(dashboard_port)
+    # Fresh execution log per server, pinned or minted: a leftover database
+    # (and WAL sidecars) from a prior run would otherwise show stale runs in
+    # the dashboard and the room feed.
     for suffix in ("", "-wal", "-shm"):
         (store_path.parent / (store_path.name + suffix)).unlink(missing_ok=True)
 

--- a/packages/pi-harnesses/engine/smoke/run.sh
+++ b/packages/pi-harnesses/engine/smoke/run.sh
@@ -5,15 +5,17 @@
 # - so it exercises the generated Nushell wrapper, the model-alias table, and the
 # Nix-packaged bridge (with its bundled node_modules), not a hand-rolled pi call.
 #
-# Proves three things from the ticket without Room:
+# Proves four things from the ticket without Room:
 #   1. one prompt runs through the packaged harness,
 #   2. the model has NO built-in bash/read/write/edit tools (absent, not denied),
 #      only the ix-mcp surface,
-#   3. the turn produces a stable JSON event stream.
+#   3. the turn produces a stable JSON event stream,
+#   4. a caller-pinned IX_MCP_STORE is honored end-to-end: ix-mcp writes the
+#      run's executions into exactly that file and cell_update events flow.
 #
 # Needs network + an API key for the selected model (ANTHROPIC_API_KEY by
-# default; set PI_HARNESS_MODEL=codex + OPENAI_API_KEY for gpt-5.5). `pi` must be
-# on PATH. Run it yourself - first build can exceed a couple of minutes.
+# default; set PI_HARNESS_MODEL=codex + OPENAI_API_KEY for gpt-5.5). Run it
+# yourself - first build can exceed a couple of minutes.
 #
 #   ANTHROPIC_API_KEY=... ./packages/pi-harnesses/engine/smoke/run.sh
 set -euo pipefail
@@ -33,8 +35,12 @@ harness="$(nix build "$repo_root#pi-harness" --no-link --print-out-paths --accep
 [ -x "$harness/bin/pi-harness" ] || { echo "[smoke] pi-harness not built" >&2; exit 1; }
 
 # 3. Run one prompt through the packaged wrapper and capture its JSON events.
+#    Pin the run store the way the room server does, so step 4 can prove
+#    ix-mcp writes into the caller's file instead of minting its own.
 events="$(mktemp)"
-trap 'rm -f "$events"' EXIT
+store_dir="$(mktemp -d)"
+export IX_MCP_STORE="$store_dir/mcp-store.sqlite"
+trap 'rm -f "$events"; rm -rf "$store_dir"' EXIT
 echo "[smoke] running one turn through bin/pi-harness..." >&2
 "$harness/bin/pi-harness" "What is 2+2? Compute it with python_exec." | tee "$events" >&2
 
@@ -49,6 +55,14 @@ for forbidden in '"bash"' '"read"' '"write"' '"edit"'; do
 done
 grep -q "python_exec" "$events" || { echo "[smoke] FAIL: python_exec not exposed" >&2; fail=1; }
 grep -q '"type":"turn_' "$events" || { echo "[smoke] FAIL: no turn lifecycle events" >&2; fail=1; }
+
+# The pinned store must be the one ix-mcp wrote: the python_exec above must
+# have landed at least one executions row there, and the mapper polling the
+# same path must have surfaced it as cell_update events.
+echo "[smoke] checking the pinned IX_MCP_STORE received the run..." >&2
+rows="$(python3 -c "import sqlite3; print(sqlite3.connect('$IX_MCP_STORE').execute('SELECT count(*) FROM executions').fetchone()[0])" 2>/dev/null || echo 0)"
+[ "$rows" -ge 1 ] || { echo "[smoke] FAIL: pinned IX_MCP_STORE has no executions rows (ix-mcp ignored the pinned store)" >&2; fail=1; }
+grep -q '"type":"cell_update"' "$events" || { echo "[smoke] FAIL: no cell_update events flowed from the pinned store" >&2; fail=1; }
 
 if [ "$fail" -eq 0 ]; then
   echo "[smoke] PASS: built-ins absent, ix-mcp exposed, JSON events emitted via the shipped artifact" >&2


### PR DESCRIPTION
## The dead seam

Reproduced end-to-end on spark: the Pi-cells-in-Room feed never produced a single `cell_update`/`resource_update` event because the two sides of the `IX_MCP_STORE` contract never met.

- The pi-harness C launcher exports a fresh per-run `IX_MCP_STORE` (tmpdir) and `room_event_mapper.py` polls exactly that path for dashboard-shaped rows.
- `ix-mcp serve` (`packages/mcp/ix_notebook_mcp/cli.py`) ignored the inherited variable: it unconditionally minted `runtime_dir()/store-<dashboard_port>.db` and then overwrote `os.environ["IX_MCP_STORE"]` with the minted path for the kernel.

Result: ix-mcp wrote all executions/cells/resources to `runtime_dir()/store-<port>.db`, the mapper polled the harness's tmpdir file forever (verified: the pinned file stayed empty, no tables), and zero cell events flowed from pi runs (ENG-2263/ENG-2267 dead at this seam).

## Fix

In `serve`, a non-empty `IX_MCP_STORE` in the environment is now used verbatim as the store path (new `_store_path()` helper, same shape as the existing `_dashboard_port()` pinning); the runtime-dir store is only minted when the variable is absent or empty. Invariants preserved:

- Fresh log per run, pinned or minted: the store and its `-wal`/`-shm` sidecars are wiped at startup. The pinning caller owns the parent directory (documented in the README embedding section).
- The resolved path is still re-exported for the kernel.
- Nothing else assumed the store lives in `runtime_dir()`: the dashboard reads `config.store_path`, the in-kernel runtime reads the re-exported `IX_MCP_STORE`.

## Validation

- `nix build .#mcp.tests.apiSmoke` passes with new assertions that `_store_path()` honors a pinned `IX_MCP_STORE` (including the empty-string case) and mints `store-<port>.db` otherwise.
- `packages/pi-harnesses/engine/smoke/run.sh` (manual, needs network + API key) now pins `IX_MCP_STORE` and asserts the pinned file gains `executions` rows after a `python_exec` turn and `cell_update` events appear in the stream.
- `nix run .#lint`: my files are clean; the 7 remaining ast-grep errors are pre-existing on main (`path:` flake refs introduced by 4323344d, the same failure currently breaking ix-images-lint in CI).

Part of ENG-2263
Part of ENG-2267


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Honor caller-pinned `IX_MCP_STORE` environment variable in `_serve`
> - Adds `_store_path(dashboard_port)` helper in [`cli.py`](https://github.com/indexable-inc/index/pull/1022/files#diff-7ce741e8223d63fdea11625cb78abad266299445db0213d2355bc93306df9ac5) that returns `IX_MCP_STORE` verbatim if set and non-empty, otherwise falls back to `store-<port>.db` in the private runtime directory.
> - Updates `_serve` to resolve the store path via `_store_path` and export the resolved path back into the environment so the kernel sees the correct value.
> - Updates the smoke test in [`run.sh`](https://github.com/indexable-inc/index/pull/1022/files#diff-b4c5e3fe3b74933f38d114e80c58dd056eb17765cd242a8d3f51e87f4098dc7b) to pin `IX_MCP_STORE` to a temp file and assert that the store receives execution rows and that `cell_update` events flow.
> - Behavioral Change: the store and its `-wal`/`-shm` sidecars are wiped at startup regardless of whether the path was pinned or defaulted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b844b9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->