### PR TITLE
fix CI on main: site fileset eval and pi engine drift test

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -363,23 +363,10 @@ let
     };
   };
 
-  siteSrc = fs.toSource {
-    root = paths.site;
-    fileset = fs.intersection (fs.gitTracked paths.site) (
-      fs.unions [
-        (paths.site + "/package.json")
-        (paths.site + "/package-lock.json")
-        (paths.site + "/mdsvex.config.js")
-        (paths.site + "/svelte.config.js")
-        (paths.site + "/vite.config.ts")
-        (paths.site + "/vitest.config.ts")
-        (paths.site + "/tsconfig.json")
-        (paths.site + "/eslint.config.js")
-        (paths.site + "/src")
-        (paths.site + "/static")
-      ]
-    );
-  };
+  # `paths.site` is the git-filtered `site` subtree input (a store copy, not
+  # a local path), so `lib.fileset`/`gitTracked` cannot apply to it; the input
+  # already scopes source identity to the subtree.
+  siteSrc = paths.site;
 
   siteBuild = ix.buildSvelteSite pkgs {
     pname = "ix-site";

--- a/packages/symphony/elixir/test/symphony_elixir_web/ir_run_controller_test.exs
+++ b/packages/symphony/elixir/test/symphony_elixir_web/ir_run_controller_test.exs
@@ -154,6 +154,7 @@ defmodule SymphonyElixirWeb.IRRunControllerTest do
   # non-Claude model under :claude, so each engine needs an agreeing model.
   defp model_for(:codex), do: "gpt-5.3-codex"
   defp model_for(:claude), do: "claude-opus-4-8"
+  defp model_for(:pi), do: "claude"
 
   test "GET /api/v1/ir/runs lists persisted run summaries" do
     persist_run("run_a", :succeeded)


### PR DESCRIPTION
Main has two red checks since #1018 and the :pi engine landed:

- **Pages**: `nix build .#site` fails to eval — `paths.site` is now the scoped `site` input (a git-filtered store copy), and `lib.fileset.toSource`/`gitTracked` require a local path. The input already provides git-filtered, subtree-scoped sources, so use it directly as `src`.
- **Check**: `symphony-elixir` fails — `Envelope.engines()` gained `:pi` but the schema-drift test's `model_for/1` had no clause for it. Add one with a pi-harness alias (`"claude"`).

Verified locally: `nix build .#site` succeeds; `nix build .#checks.x86_64-linux.symphony-elixir` passes (391 tests, 0 failures); `nix run .#lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI on main by correcting site fileset eval and pi engine drift test
> - Replaces the `siteSrc` fileset construction in [per-system.nix](https://github.com/indexable-inc/index/pull/1024/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) with a direct assignment of `paths.site`, since it is already a git-filtered subtree input where `lib.fileset`/`gitTracked` do not apply.
> - Adds a `model_for(:pi)` clause returning `"claude"` in [ir_run_controller_test.exs](https://github.com/indexable-inc/index/pull/1024/files#diff-368a3366e0569196b33fd7d9d78d5ec9ad79d31affbf0f95fe4f108800fd2e83) to fix a `FunctionClauseError` in the pi engine drift test.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5802af3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->