### PR TITLE
symphony: provision run workspaces as linked worktrees

### DIFF
--- a/packages/symphony/elixir/lib/symphony_elixir/codex/provision.ex
+++ b/packages/symphony/elixir/lib/symphony_elixir/codex/provision.ex
@@ -386,11 +386,18 @@ defmodule SymphonyElixir.Codex.Provision do
   end
 
   @doc """
-  Clone every repository in the active catalog into `run_root`, on a
+  Provision every repository in the active catalog into `run_root`, on a
   run-scoped `branch`, stamping the bot identity and (when `token` is
   present) a GitHub Basic auth header so plain `git push` authors as the
-  App. Returns the concatenated `bash` blocks; the caller owns the
-  surrounding `set -euo pipefail` and the `mkdir -p` of `run_root`.
+  App. Each workspace is a linked worktree of a hidden base clone under
+  `run_root/.base`, not a standalone clone: repo-side guards distinguish
+  a human's canonical checkout from an agent worktree by comparing
+  `git-dir` to `git-common-dir`, and a standalone clone is misclassified
+  as the canonical checkout, denying the run's own commits on its
+  sanctioned branch (index#1038). The base clone is `--no-checkout` so a
+  run carries one working tree per repo, not two. Returns the
+  concatenated `bash` blocks; the caller owns the surrounding
+  `set -euo pipefail` and the `mkdir -p` of `run_root`.
   """
   @spec repo_blocks(Config.t(), Path.t(), String.t(), String.t() | nil, [RepositoryCatalog.t()] | nil) :: String.t()
   def repo_blocks(%Config{} = config, run_root, branch, token, repositories \\ nil) do
@@ -402,18 +409,22 @@ defmodule SymphonyElixir.Codex.Provision do
 
   defp clone_repo_block(repo, run_root, branch, basic, config) do
     target = Path.join(run_root, repo.name)
+    base = Path.join([run_root, ".base", repo.name])
     remote = "https://github.com/#{repo.owner_repo}.git"
     clone_auth = if is_binary(basic), do: "-c http.https://github.com/.extraheader=#{sh("Authorization: Basic " <> basic)}", else: ""
 
+    # `git config --local` from a linked worktree writes to the base
+    # clone's shared config, so the header and identity stamped on the
+    # worktree below cover every push and commit made from it.
     extraheader =
       if is_binary(basic),
         do: "git -C #{sh(target)} config --local http.https://github.com/.extraheader #{sh("Authorization: Basic " <> basic)}",
         else: ":"
 
     """
-    rm -rf #{sh(target)}
-    git #{clone_auth} clone --depth 1 --branch #{sh(repo.default_branch)} #{sh(remote)} #{sh(target)}
-    git -C #{sh(target)} checkout -b #{sh(branch)}
+    rm -rf #{sh(target)} #{sh(base)}
+    git #{clone_auth} clone --depth 1 --no-checkout --branch #{sh(repo.default_branch)} #{sh(remote)} #{sh(base)}
+    git -C #{sh(base)} worktree add #{sh(target)} -b #{sh(branch)}
     #{git_identity_lines(target, config)}
     #{extraheader}
     """

--- a/packages/symphony/elixir/test/codex/provision_test.exs
+++ b/packages/symphony/elixir/test/codex/provision_test.exs
@@ -86,12 +86,29 @@ defmodule SymphonyElixir.Codex.ProvisionTest do
     config = config_with_repos()
     blocks = Provision.repo_blocks(config, "/home/u/symphony-workspaces/run1", "symphony/run1", "ghs_tok")
 
-    assert blocks =~ "clone --depth 1 --branch 'main' 'https://github.com/acme/app.git'"
+    assert blocks =~ "clone --depth 1 --no-checkout --branch 'main' 'https://github.com/acme/app.git'"
     assert blocks =~ "http.https://github.com/.extraheader"
-    assert blocks =~ "checkout -b 'symphony/run1'"
     assert blocks =~ "user.name' 'acme-bot[bot]'"
     assert blocks =~ "user.email' 'bot@acme.dev'"
     assert blocks =~ Base.encode64("x-access-token:ghs_tok")
+  end
+
+  test "repo_blocks provisions the workspace as a linked worktree of a hidden base clone" do
+    config = config_with_repos()
+    blocks = Provision.repo_blocks(config, "/home/u/symphony-workspaces/run1", "symphony/run1", nil)
+
+    # The agent-facing workspace must be a linked worktree, not a
+    # standalone clone: repo-side guards treat git-dir == git-common-dir
+    # as the human's canonical checkout and deny commits (index#1038).
+    assert blocks =~
+             "clone --depth 1 --no-checkout --branch 'main' " <>
+               "'https://github.com/acme/app.git' '/home/u/symphony-workspaces/run1/.base/app'"
+
+    assert blocks =~
+             "git -C '/home/u/symphony-workspaces/run1/.base/app' worktree add " <>
+               "'/home/u/symphony-workspaces/run1/app' -b 'symphony/run1'"
+
+    refute blocks =~ "checkout -b"
   end
 
   test "repo_blocks omits the auth header when no token is available" do
@@ -111,7 +128,7 @@ defmodule SymphonyElixir.Codex.ProvisionTest do
     blocks =
       Provision.repo_blocks(config, "/home/u/symphony-workspaces/run1", "symphony/run1", "ghs_tok", repositories)
 
-    assert blocks =~ "clone --depth 1 --branch 'main' 'https://github.com/indexable-inc/ix.git'"
+    assert blocks =~ "clone --depth 1 --no-checkout --branch 'main' 'https://github.com/indexable-inc/ix.git'"
     refute blocks =~ "acme/app"
   end
 


### PR DESCRIPTION
## Why

Symphony provisioned each run repo as a standalone clone, where `git-dir == git-common-dir`. The ix repo's `.agents/hooks/enforce-worktree.sh` PreToolUse guard uses exactly that comparison to detect the human's canonical checkout, so it denied `Edit`/`Write` and `git add`/`git commit` inside the run's own throwaway workspace on its sanctioned `symphony/<run_id>` branch. The run could not escape to a worktree either: the branch was already checked out in the clone.

This is option 1 from the issue (the one it recommends): make the workspace a linked worktree so the guard passes for run workspaces and stays meaningful inside the run, instead of exempting `symphony/*` branches in the guard.

## What

`Provision.clone_repo_block/5` now clones a hidden `--no-checkout` base under `<run_root>/.base/<repo>` and attaches the agent-facing workspace at the unchanged `<run_root>/<repo>` path via `git worktree add -b symphony/<run_id>`. The bot identity and GitHub auth extraheader are still stamped through the worktree: `git config --local` from a linked worktree writes to the shared base config, so commits and pushes from the workspace keep authoring as the App.

Workspace paths, cleanup (`rm -rf <run_root>` reaps base and worktree together), and both the iXVM and host provisioning paths are unchanged; they share `repo_blocks`.

## Verification

- Ran the emitted script shape against a local origin: `git-dir != git-common-dir` in the workspace (guard would allow), branch checked out, commit authors as the bot, extraheader visible from the worktree, push lands, base has no working tree.
- `mix test` (392 tests, 0 failures), `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo`, and `nix run .#lint` all pass.

Fixes #1038

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Provision symphony run workspaces as linked git worktrees
> - Changes the repo provisioning in [`provision.ex`](https://github.com/indexable-inc/index/pull/1039/files#diff-e80a47e38c3cad3d53e5eda7bbc2c3b9af00ae8b8dacdec60243b76e3fe43c31) to perform a depth-1 `--no-checkout` clone into a hidden base directory at `run_root/.base/<repo>`, then creates the agent-facing workspace at `run_root/<repo>` via `git worktree add`.
> - Cleanup now removes both the worktree directory and the base clone directory before re-cloning.
> - Git identity stamping and optional GitHub Basic auth extraheader are written via the worktree path, which propagates to the shared base clone config.
> - Behavioral Change: workspaces are now linked worktrees rather than standalone clones; the base clone at `run_root/.base/<repo>` is a new artifact that must be cleaned up alongside the workspace.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cffde13.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->