### PR TITLE
Add Gate proxy for Minecraft

### DIFF
--- a/modules/services/gate/default.nix
+++ b/modules/services/gate/default.nix
@@ -1,0 +1,381 @@
+# Gate Minecraft proxy. https://gate.minekube.com/
+{
+  config,
+  ix,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
+
+  cfg = config.services.gate;
+  dataDir = "/var/lib/gate";
+  gate = lib.getExe cfg.package;
+  systemctl = lib.getExe' config.systemd.package "systemctl";
+  yamlFormat = pkgs.formats.yaml { };
+
+  hostPort =
+    address: port:
+    let
+      host = if lib.hasInfix ":" address && !lib.hasPrefix "[" address then "[${address}]" else address;
+    in
+    "${host}:${toString port}";
+
+  # Gate config is rooted under a `config:` key. Typed options below render
+  # to that subtree; cfg.settings is merged over the typed result so a caller
+  # can reach any key the typed surface does not cover.
+  renderedSettings = {
+    config = {
+      bind = hostPort cfg.address cfg.port;
+      onlineMode = cfg.onlineMode;
+      forceKeyAuthentication = cfg.forceKeyAuthentication;
+      acceptTransfers = cfg.acceptTransfers;
+      bungeePluginChannelEnabled = cfg.bungeePluginChannelEnabled;
+      announceProxyCommands = cfg.advanced.announceProxyCommands;
+
+      servers = cfg.servers;
+      try = cfg.try;
+      forcedHosts = cfg.forcedHosts;
+
+      status = {
+        motd = cfg.motd;
+        showMaxPlayers = cfg.showMaxPlayers;
+        logPingRequests = cfg.advanced.logPingRequests;
+        announceForge = cfg.announceForge;
+      };
+
+      compression = {
+        threshold = cfg.advanced.compressionThreshold;
+        level = cfg.advanced.compressionLevel;
+      };
+
+      connectionTimeout = cfg.advanced.connectionTimeout;
+      readTimeout = cfg.advanced.readTimeout;
+      failoverOnUnexpectedServerDisconnect = cfg.advanced.failoverOnUnexpectedServerDisconnect;
+    }
+    // lib.optionalAttrs (cfg.forwarding.mode != "none") {
+      forwarding = {
+        mode = cfg.forwarding.mode;
+      };
+    };
+  }
+  // cfg.settings;
+
+  configFile = yamlFormat.generate "gate-config.yml" renderedSettings;
+
+  forwardingSecretFile =
+    if cfg.forwarding.secret == null then
+      null
+    else
+      pkgs.writeText "gate-forwarding-secret" cfg.forwarding.secret;
+  installForwardingSecret =
+    if cfg.forwarding.secret != null then
+      "install -Dm0600 ${lib.escapeShellArg forwardingSecretFile} ${lib.escapeShellArg "${dataDir}/forwarding.secret"}"
+    else if cfg.forwarding.secretFile != null then
+      "install -Dm0600 ${lib.escapeShellArg cfg.forwarding.secretFile} ${lib.escapeShellArg "${dataDir}/forwarding.secret"}"
+    else
+      ''
+        if [ ! -s ${lib.escapeShellArg "${dataDir}/forwarding.secret"} ]; then
+          ${lib.getExe pkgs.openssl} rand -base64 32 > ${lib.escapeShellArg "${dataDir}/forwarding.secret"}
+          chmod 0600 ${lib.escapeShellArg "${dataDir}/forwarding.secret"}
+        fi
+      '';
+
+  wildcardClientAddresses = [
+    "0.0.0.0"
+    "::"
+    "[::]"
+  ];
+  gateProbeAddress =
+    if builtins.elem cfg.address wildcardClientAddresses then "127.0.0.1" else cfg.address;
+  gateProbeTarget = hostPort gateProbeAddress cfg.port;
+in
+{
+  options.services.gate = {
+    enable = mkEnableOption "Gate Minecraft proxy";
+
+    package = mkOption {
+      type = types.package;
+      default = ix.packages.gate;
+      defaultText = lib.literalExpression "ix.packages.gate";
+      description = "Gate proxy binary.";
+    };
+
+    address = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      description = "Address Gate binds for Java clients.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 25565;
+      description = "TCP port Gate binds for Java clients.";
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether to open the Gate client port in the firewall.";
+    };
+
+    motd = mkOption {
+      type = types.str;
+      default = "§bA Gate Proxy";
+      description = "MOTD shown in Java clients' server list. Accepts legacy '§' format or a modern text-component JSON string.";
+    };
+
+    health.motdContains = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "Survival" ];
+      description = ''
+        Substrings the rendered MOTD must contain for the `gate-status`
+        health check to pass. Empty list (the default) probes SLP without
+        asserting MOTD.
+      '';
+    };
+
+    showMaxPlayers = mkOption {
+      type = types.ints.positive;
+      default = 500;
+      description = "Displayed maximum player count in the server list.";
+    };
+
+    onlineMode = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether Gate authenticates Java players with Mojang.";
+    };
+
+    forceKeyAuthentication = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether Gate enforces Minecraft's public key authentication.";
+    };
+
+    acceptTransfers = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether Gate accepts incoming Minecraft transfer packets (1.20.5+).";
+    };
+
+    bungeePluginChannelEnabled = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether Gate supports the BungeeCord plugin messaging channel.";
+    };
+
+    announceForge = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether Gate announces Forge/FML compatibility.";
+    };
+
+    forwarding = {
+      mode = mkOption {
+        type = types.enum [
+          "none"
+          "legacy"
+          "bungeeguard"
+          "velocity"
+        ];
+        default = "velocity";
+        description = "Player information forwarding mode written to Gate's config.";
+      };
+
+      secret = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Inline forwarding secret copied to Gate's forwarding.secret file. This lands in the Nix store.";
+      };
+
+      secretFile = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Runtime file copied to Gate's forwarding.secret file.";
+      };
+    };
+
+    servers = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example.survival = "127.0.0.1:25566";
+      description = "Backend servers keyed by Gate server name.";
+    };
+
+    try = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Backend server names Gate tries when a player joins or is kicked.";
+    };
+
+    forcedHosts = mkOption {
+      type = types.attrsOf (types.listOf types.str);
+      default = { };
+      description = "Host name to backend server order mapping.";
+    };
+
+    advanced = {
+      compressionThreshold = mkOption {
+        type = types.int;
+        default = 256;
+        description = "Minimum packet size before Gate compresses it.";
+      };
+
+      compressionLevel = mkOption {
+        type = types.int;
+        default = -1;
+        description = "zlib compression level, or -1 for the default level.";
+      };
+
+      connectionTimeout = mkOption {
+        type = types.str;
+        default = "5s";
+        description = "Backend connection timeout (Go duration string).";
+      };
+
+      readTimeout = mkOption {
+        type = types.str;
+        default = "30s";
+        description = "Backend read timeout (Go duration string).";
+      };
+
+      failoverOnUnexpectedServerDisconnect = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether Gate fails players over after unexpected backend disconnects.";
+      };
+
+      announceProxyCommands = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether proxy commands are announced to 1.13+ clients.";
+      };
+
+      logPingRequests = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether ping requests are logged.";
+      };
+    };
+
+    settings = mkOption {
+      inherit (yamlFormat) type;
+      default = { };
+      description = "Raw Gate config merged over the typed options. Top-level key is `config:`.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.forwarding.secret == null || cfg.forwarding.secretFile == null;
+        message = "services.gate.forwarding cannot set both secret and secretFile";
+      }
+    ];
+
+    ix.networking.portClaims.gate = {
+      protocol = "tcp";
+      inherit (cfg) port address;
+      description = "Gate Minecraft proxy";
+    };
+
+    networking.firewall.allowedTCPPorts = lib.optional cfg.openFirewall cfg.port;
+
+    ix.healthChecks = {
+      gate = {
+        from = "guest";
+        description = "Gate systemd unit is active";
+        command = [
+          systemctl
+          "is-active"
+          "--quiet"
+          "gate.service"
+        ];
+      };
+
+      gate-status = {
+        from = "guest";
+        description =
+          "Gate answers SLP"
+          + lib.optionalString (
+            cfg.health.motdContains != [ ]
+          ) " and the MOTD contains the configured substrings";
+        # Gate speaks the standard Java SLP handshake even though it routes
+        # traffic to backends, so an SLP success here proves Gate itself is
+        # healthy independent of any individual Paper backend's state.
+        command = [
+          (lib.getExe ix.packages.mc-probe)
+          gateProbeTarget
+        ]
+        ++ lib.concatMap (needle: [
+          "--motd-contains"
+          needle
+        ]) cfg.health.motdContains;
+      };
+    }
+    // lib.optionalAttrs cfg.openFirewall {
+      gate-reachable = {
+        from = "host";
+        requiresIpv4 = true;
+        description = "Gate client port accepts TCP from operator host";
+        command = [
+          "nc"
+          "-z"
+          "-w"
+          "5"
+          "$IX_NODE_IPV4"
+          (toString cfg.port)
+        ];
+      };
+    };
+
+    environment.systemPackages = [ ix.packages.mc-probe ];
+
+    environment.etc."gate/config.yml".source = configFile;
+
+    users.groups.gate = { };
+    users.users.gate = {
+      description = "Gate service user";
+      isSystemUser = true;
+      group = "gate";
+      home = dataDir;
+    };
+
+    systemd.services.gate = {
+      description = "Gate Minecraft proxy";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      restartTriggers = [
+        configFile
+      ]
+      ++ lib.optional (forwardingSecretFile != null) forwardingSecretFile;
+      preStart = ''
+        set -eu
+        install -Dm0644 ${lib.escapeShellArg configFile} ${lib.escapeShellArg "${dataDir}/config.yml"}
+        ${installForwardingSecret}
+      '';
+      serviceConfig = ix.systemdHardening // {
+        Type = "simple";
+        User = "gate";
+        Group = "gate";
+        WorkingDirectory = dataDir;
+        ExecStart = lib.escapeShellArgs [
+          gate
+          "--config"
+          "${dataDir}/config.yml"
+        ];
+        Restart = "on-failure";
+        StateDirectory = "gate";
+      };
+    };
+  };
+}

--- a/packages/minecraft/gate/default.nix
+++ b/packages/minecraft/gate/default.nix
@@ -16,24 +16,27 @@ buildGoModule {
     owner = "minekube";
     repo = "gate";
     rev = "v${version}";
-    # First-build placeholder. Run `nix build .#gate` and replace with the
-    # `got: sha256-...` value from the hash-mismatch error.
-    hash = lib.fakeHash;
+    hash = "sha256-j+RdX2IfP1ILw6/HodRHM2dh5pQfln11EWKZNDrVOqY=";
   };
 
-  # Same placeholder pattern — buildGoModule prints the actual vendor hash
-  # on first build under "got: sha256-...".
-  vendorHash = lib.fakeHash;
+  vendorHash = "sha256-X3B+S2QG2WCsSderL2XwVQjLJDDP+bh6DQqe4kwjEcQ=";
 
-  subPackages = [ "cmd/gate" ];
+  # Upstream's Dockerfile builds the root `gate.go` rather than `cmd/gate`,
+  # and stamps the version into `pkg/version.Version`.
+  subPackages = [ "." ];
 
-  # Strip debug info and stamp the upstream version into the binary so
-  # `gate --version` reports the same string as the source tag.
   ldflags = [
     "-s"
     "-w"
-    "-X go.minekube.com/gate/pkg/internal/buildinfo.Version=${version}"
+    "-X go.minekube.com/gate/pkg/version.Version=${version}"
   ];
+
+  # The `go.minekube.com/geyserlite` transitive dep embeds prebuilt
+  # per-arch binaries that are not in the module tarball, so `go mod vendor`
+  # fails resolving its `assets/geyserlite-*` embed pattern. Use the
+  # module proxy path (no `vendor/` materialization) to fetch dependencies
+  # the way upstream's `go build` does.
+  proxyVendor = true;
 
   doCheck = false;
   strictDeps = true;

--- a/packages/minecraft/gate/default.nix
+++ b/packages/minecraft/gate/default.nix
@@ -1,0 +1,49 @@
+# Gate Minecraft proxy. https://gate.minekube.com/
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+let
+  version = "0.66.13";
+in
+buildGoModule {
+  pname = "gate";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "minekube";
+    repo = "gate";
+    rev = "v${version}";
+    # First-build placeholder. Run `nix build .#gate` and replace with the
+    # `got: sha256-...` value from the hash-mismatch error.
+    hash = lib.fakeHash;
+  };
+
+  # Same placeholder pattern — buildGoModule prints the actual vendor hash
+  # on first build under "got: sha256-...".
+  vendorHash = lib.fakeHash;
+
+  subPackages = [ "cmd/gate" ];
+
+  # Strip debug info and stamp the upstream version into the binary so
+  # `gate --version` reports the same string as the source tag.
+  ldflags = [
+    "-s"
+    "-w"
+    "-X go.minekube.com/gate/pkg/internal/buildinfo.Version=${version}"
+  ];
+
+  doCheck = false;
+  strictDeps = true;
+
+  meta = {
+    description = "Minecraft Java + Bedrock proxy by Minekube, Go-native peer to BungeeCord and Velocity";
+    homepage = "https://gate.minekube.com/";
+    license = lib.licenses.asl20;
+    mainProgram = "gate";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+  };
+}

--- a/packages/minecraft/gate/package.nix
+++ b/packages/minecraft/gate/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "gate";
+  packageSet = true;
+  flake = true;
+}

--- a/packages/minecraft/gate/package.nix
+++ b/packages/minecraft/gate/package.nix
@@ -2,4 +2,5 @@
   id = "gate";
   packageSet = true;
   flake = true;
+  overlay = true;
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2046,6 +2046,26 @@ let
     }
   ];
 
+  gateForwardingSecretMutexFailures = failedAssertionsFor [
+    {
+      services.gate = {
+        enable = true;
+        forwarding.secret = "inline";
+        forwarding.secretFile = "/run/secrets/gate";
+      };
+    }
+  ];
+  gateConcreteAddress = evalConfig [
+    {
+      services.gate = {
+        enable = true;
+        address = "10.0.0.6";
+        port = 25571;
+        openFirewall = false;
+      };
+    }
+  ];
+
   relativePathUnsafeShellEval = builtins.tryEval (
     builtins.deepSeq (ix.relativePath.shellPath "$out" "../bad") true
   );
@@ -3051,6 +3071,13 @@ let
         ) velocityDuplicatePluginFileNameFailures;
         message = "velocity plugin file names should reject duplicate managed jar names at eval time";
       }
+      {
+        assertion = lib.any (
+          failure:
+          lib.hasInfix "services.gate.forwarding cannot set both secret and secretFile" failure.message
+        ) gateForwardingSecretMutexFailures;
+        message = "gate forwarding should reject setting both inline secret and secretFile at eval time";
+      }
     ];
 
     extended-attributes = [
@@ -3253,6 +3280,14 @@ let
             "10.0.0.5:25570"
           ];
         message = "velocity SLP health checks should probe concrete bind addresses";
+      }
+      {
+        assertion =
+          gateConcreteAddress.ix.healthChecks.gate-status.command == [
+            (lib.getExe repoPackages.mc-probe)
+            "10.0.0.6:25571"
+          ];
+        message = "gate SLP health checks should probe concrete bind addresses";
       }
       {
         assertion =


### PR DESCRIPTION
Gate is a high-performance, resource-efficient Minecraft Java + Bedrock reverse proxy and library with multi-version support.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Gate Minecraft proxy NixOS module and package
> - Adds a `buildGoModule` derivation for the [Gate](https://gate.minekube.com/) Minecraft proxy at version 0.66.13 in [`packages/minecraft/gate/default.nix`](https://github.com/indexable-inc/index/pull/1054/files#diff-1b7524201a5b030c4fe507b900cd1957a4e366594119739d5554a5ead3a9ae90), exposed via the repo's flake and overlay.
> - Introduces a `services.gate` NixOS module in [`modules/services/gate/default.nix`](https://github.com/indexable-inc/index/pull/1054/files#diff-fa2dcef2c21c8289224d6dd6f5a6237670b235db4fb1ab14dd7e3e36cd6ec796) with typed options for bind address/port, forwarding mode, backend servers, MOTD, online mode, firewall, and a raw settings passthrough that merges over the typed config.
> - Manages a `gate` system user/group, writes a generated YAML config to `/etc/gate/config.yml`, and provisions the forwarding secret (inline, from file, or auto-generated via `openssl rand`) in `preStart`.
> - Health checks cover systemd liveness (`systemctl is-active`), SLP responsiveness via `mc-probe` with optional MOTD substring matching, and TCP reachability via `nc` when the firewall port is opened.
> - Tests in [`tests/default.nix`](https://github.com/indexable-inc/index/pull/1054/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) assert the forwarding `secret`/`secretFile` mutex at eval time and verify the SLP probe targets the correct concrete bind address.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7893ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->