### PR TITLE
mcp/sh: add Output.output alias for jobs[id].output symmetry

### DIFF
--- a/packages/mcp/src/sh/sh/__init__.py
+++ b/packages/mcp/src/sh/sh/__init__.py
@@ -227,6 +227,18 @@ class Output(_ResultBase):
         """
         return self.text
 
+    @property
+    def output(self) -> str:
+        """Alias for ``.text``, matching ``jobs['<id>'].output`` on a live job.
+
+        The docstring above and the kernel instructions teach
+        ``jobs['<id>'].output`` as the way to read a run's stdout; this alias
+        makes the direct ``(await sh(...))`` return symmetric so the same
+        attribute works whether the call ran in the foreground or in a tracked
+        background job.
+        """
+        return self.text
+
     def lines(self) -> list[str]:
         """The escape-stripped output split into lines (trailing newline dropped)."""
         return self.text.splitlines()


### PR DESCRIPTION
Closes #1035 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Output.output` property alias for `jobs['<id>'].output` symmetry
> Adds an `output` property to the `Output` class in [sh/__init__.py](https://github.com/indexable-inc/index/pull/1055/files#diff-f9700c17685e82e375a4176ad39ea4dfb7728f90008c6fe9c7678e7de72dd59d) that returns `self.text`. This mirrors the `output` attribute on background job results, so both foreground and background job outputs can be accessed via the same `.output` attribute.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44651e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->