### PR TITLE
agent-context: restore the hand-written nix-style checklist

### DIFF
--- a/agent-context/sections/15-nix-style-ast-grep-enforced.md
+++ b/agent-context/sections/15-nix-style-ast-grep-enforced.md
@@ -2,19 +2,51 @@
 name: nix-style
 disclosure: progressive
 description: "Nix code style, general and mechanical: a design and idiom checklist for new code, plus the rules enforced by ast-grep and lint (no with/rec/mkForce, derivation hygiene, typed options, fetchers, licenses). Use when writing or reviewing Nix, or fixing a lint failure."
+# The checklist below is hand-written operator guidance, restored from PR #687
+# after PR #825 paraphrased it away. The wording was tuned for prompt
+# effectiveness by reading most of the repo's Nix and iterating on phrasings.
+# Do not condense, summarize, or restyle it. This section is progressive-tier,
+# so its body never counts against the always-on character cap.
 ---
 
-## Adding a new Nix thing
+## So you're about to add a new Nix thing
 
-Craft-standard governs ownership, DRY, layering, consumers, and not being
-defensive. The Nix-specific checks on top:
+### STOP!
 
-- Functional over imperative: index-driven iteration (`imap0`, `lib.range`,
-  `elemAt`) usually means a missing `map`, `genList`, or higher-level combinator.
-- Reuse `builtins` and `nixpkgs.lib` before hand-rolling; an experienced Nix
-  reader should have no complaints on first read.
-- Reify latent structure, parse rather than validate, and leave room for future
-  needs in the design without writing dead code.
+Check these first:
+- Is your code **idiomatic**?
+- Is your code **elegant**?
+- Is your code **needed** and **useful**?
+  - Are there any consumers of your new abstraction or is it DOA?
+  - If you do not need something but it might be wanted in the future, _leave room for it_ in the design, but don't write dead code.
+- Are you writing imperative code rather than using **functional programming as your guiding philosophy**?
+  - Common code smells like index-driven iteration (often using `imap0`, `lib.range`, `elemAt`, for example) usually signal a missing `map`, `genList`, etc.
+  - Prefer higher-level combinators over composition of many low-level structures.
+- Are you **reimplementing** code that is already in builtins or nixpkgs.lib? Could you write simpler code if you used existing functions?
+- Does your code **make sense**? What would it be like for an experienced Nix dev to see it for the first time? Would they have any complaints? If so, address them.
+- Are you **repeating yourself**? Are you writing the same construct over and over?
+  - Consider factoring when repetition obscures intent or makes changes error-prone.
+  - As a heuristic, it may be time to add an abstraction if you're writing the same line 3+ times, or a 3+ line block at least twice.
+  - Readability is the deciding factor.
+- Are you **layering** properly?
+  - Your function hierarchy should mirror the conceptual hierarchy and the domain.
+  - Helper functions should make sense as a self-contained unit; fracturing an overly large tree is not a valid way of making it easier to understand.
+    - If a helper function is only used once, consider making it a `let`/`in` binding or inlining it.
+- Are you adding **special cases** or exceptions that aren't a natural part of your domain?
+  - That often means something is wrong at a deeper level.
+  - Refine the overarching structure instead.
+  - If you're making exceptions just because other parts of the codebase use your code, consider just refactoring the callers - this often makes things much simpler.
+- Who are the **consumers** of your code?
+  - If your function is only ever used in the same file or within the repo, *do not worry about keeping its API compatible;* refactor the caller along with it.
+- Is your code **overly defensive**?
+  - Trust your own code. Don't add checks everywhere to values you pass around yourself.
+  - Your system should be coherent instead of constantly doubting itself.
+
+### Maxims
+
+- Reify latent structure
+- Don't over-abstract
+- Parse rather than validate
 
 ## Nix style (ast-grep enforced)
 


### PR DESCRIPTION
## Summary

PR #825 condensed the always-on agent-context tier to fit the 9,000-char cap, and in the same pass trimmed the "So you're about to add a new Nix thing" checklist and Maxims out of the `nix-style` fragment, replacing them with a short paraphrase. That text was hand-written operator guidance added in #687: the wording was tuned for prompt effectiveness by reading most of the repo's Nix code and iterating on phrasings. The paraphrase kept the spirit but dropped the operative content, including the repetition heuristic (same line 3+ times, or a 3+ line block twice), the layering and single-use-helper inlining guidance, the special-cases-signal-deeper-problems rule, the internal-API-compatibility rule (refactor callers instead), and the anti-defensiveness item.

The trim also did not serve #825's goal: `nix-style` is `disclosure: progressive`, so its body loads on demand as a skill and never counts against `alwaysCharCap`, which only sums `disclosure: always` sections.

This restores the checklist and Maxims byte-identical to #687 (fbc27460) and leaves the ast-grep rules section untouched. A comment in the frontmatter records the provenance and asks future condensing passes to leave the body alone; the repo's frontmatter parser (`lib/agent-context/frontmatter.nix`) drops lines without a `": "` separator, so plain `#` comment lines parse cleanly and do not leak into the generated skill.

## Verification

The restored block diffs empty against the #687 commit. The frontmatter evals to exactly `name`/`disclosure`/`description`. `nix build .#skills .#agent-context` succeeds and the generated `nix-style/SKILL.md` carries the checklist verbatim. `nix run .#lint` is green (ast-grep, ast-grep-test, deadnix, nixfmt, statix).

Refs #687, #825.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore hand-written Nix-style checklist in agent-context guidelines
> Expands the `Adding a new Nix thing` section in [15-nix-style-ast-grep-enforced.md](https://github.com/indexable-inc/index/pull/1059/files#diff-53847252eac087e7ae98daf4d6e38599f2dad504a738319dafcda19847d77b10) with a detailed `STOP!` checklist covering idiomatic Nix criteria: consumer presence, functional vs. imperative style, reuse of builtins and `nixpkgs.lib`, DRY/abstraction heuristics, layering and helper placement, and avoiding over-defensive checks. Adds a new `Maxims` subsection with three guiding principles: "Reify latent structure", "Don't over-abstract", and "Parse rather than validate". Includes inline comments marking the section as intentionally verbose and not to be condensed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a50bfdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->