### PR TITLE
image: share one nixpkgs instance across every image eval

### DIFF
--- a/lib/image/default.nix
+++ b/lib/image/default.nix
@@ -13,6 +13,29 @@
 }:
 let
   /**
+    One nixpkgs instance shared by every image evaluation. `lib.nixosSystem`
+    otherwise instantiates a fresh nixpkgs PER node, and a consumer that
+    evaluates many images in one evaluation (the ix fleet's regional-status
+    canary evaluates every example fleet x 2 regions inside one NixOS host
+    config) pays that instantiation 20-30 times over: 656M thunks / 5.5min
+    of nix CPU for one host, and an OOM-killed deploy under nox (ix
+    ENG-2728/ENG-2729). The parameters fold in exactly what the per-node
+    modules used to set: the repo overlay (previously a `nixpkgs.overlays`
+    module) and the platform config from `platform.nix`.
+
+    YourKit is the only unfree we currently allow into images, and only
+    because `ix.languages.java.yourkit` is an opt-in profiler agent that
+    an operator turns on for performance work. The predicate keeps every
+    other unfree (Oracle JDK, Adobe runtimes, NVIDIA blobs) failing at
+    eval until the platform decides to allow it explicitly.
+    Refs: https://www.yourkit.com/docs/java/help/agent.jsp
+  */
+  imagePkgs = import nixpkgs {
+    inherit system overlays;
+    config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "yourkit-java" ];
+  };
+
+  /**
     Run the platform config, OCI packaging, base profile, the full module
     registry, and the caller's `modules` through `lib.nixosSystem`, then
     return the evaluated `config`. This is the evaluation path every
@@ -30,7 +53,7 @@ let
       inherit system;
       specialArgs.ix = ixSpecialArgs;
       modules = [
-        { nixpkgs.overlays = overlays; }
+        { nixpkgs.pkgs = imagePkgs; }
         ./platform.nix
         ./oci-layer.nix
         # Home Manager as a NixOS module. Per-tool XDG config (Nushell,

--- a/lib/image/platform.nix
+++ b/lib/image/platform.nix
@@ -373,16 +373,10 @@ in
       }
     ];
 
-    nixpkgs.hostPlatform.system = "x86_64-linux";
-
-    # YourKit is the only unfree we currently allow into images, and only
-    # because `ix.languages.java.yourkit` is an opt-in profiler agent that
-    # an operator turns on for performance work. The predicate keeps every
-    # other unfree (Oracle JDK, Adobe runtimes, NVIDIA blobs) failing at
-    # eval until the platform decides to allow it explicitly.
-    #
-    # Refs: https://www.yourkit.com/docs/java/help/agent.jsp
-    nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "yourkit-java" ];
+    # The host platform (x86_64-linux) and the YourKit-only unfree predicate
+    # live on the shared `imagePkgs` instantiation in `default.nix`: every
+    # image shares ONE nixpkgs instance via `nixpkgs.pkgs`, and the nixpkgs
+    # module ignores `hostPlatform`/`config` once `pkgs` is set.
 
     boot = {
       isContainer = true;


### PR DESCRIPTION
Closes ENG-2729.

`lib.nixosSystem` instantiates a fresh nixpkgs per node; the ix fleet's regional-status canary evaluates every example fleet x 2 regions inside one host eval and paid that 20-30x over: 656M thunks / 5.5min nix CPU / 29GB RSS for one host toplevel, and an OOM-killed deploy under nox (ix ENG-2728).

One shared `imagePkgs` (repo overlay + x86_64-linux platform + YourKit-only unfree predicate, folded in from `platform.nix`) handed to every `evalImageConfig` via `nixpkgs.pkgs`. Measured on the ix hil-compute-2 toplevel: 656M -> 424M thunks, 329s -> 150s eval CPU, 29GB -> 14.3GB peak RSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share one nixpkgs instance across all image evaluations
> - Introduces a shared `imagePkgs` import in [default.nix](https://github.com/indexable-inc/index/pull/1069/files#diff-3883253618b080892e770f4ceb96188ed814f4f588df529f7a82d338874c14bd) with `allowUnfreePredicate` restricting unfree packages to `yourkit-java`.
> - Passes `nixpkgs.pkgs = imagePkgs` to downstream NixOS modules instead of passing overlays, so all image evals share a single nixpkgs instance.
> - Removes redundant `nixpkgs.hostPlatform.system` and `nixpkgs.config.allowUnfreePredicate` settings from [platform.nix](https://github.com/indexable-inc/index/pull/1069/files#diff-4e9f8a1975e02453aa569916bd7b0c3a25baa581602e105115a45921f41bf7d7), as they are ignored once `pkgs` is set upstream.
> - Behavioral Change: module-level `hostPlatform` and `allowUnfreePredicate` overrides in downstream modules are now silently ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4882b5e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->