### PR TITLE
feat(fleet): image-declared east-west groups

### DIFF
--- a/examples/declared-groups/README.md
+++ b/examples/declared-groups/README.md
@@ -39,5 +39,5 @@ ix shell client -- curl -fsS http://api:8080/
 Group slugs are scoped to the deploying user (`UNIQUE (owner_id, slug)` on
 the server), so a common name like `declared-groups` in a published image
 never collides with another user's group of the same name. Slugs are
-`[a-z0-9_-]`, max 64 chars; the fleet eval rejects anything else before any
-RPC runs.
+`[a-z0-9_-]`, max 63 chars (the DNS label limit); the fleet eval rejects
+anything else before any RPC runs.

--- a/examples/declared-groups/README.md
+++ b/examples/declared-groups/README.md
@@ -1,0 +1,43 @@
+# Declared groups
+
+A two-VM fleet sharing one east-west network, where the group membership is
+declared in the image definition instead of at runtime. The `api` image sets
+`ix.networking.groups = [ "declared-groups" ]` in its own module, so any fleet
+deploying that image joins the deployer's `declared-groups` network. The
+`client` shows the other source: a fleet-level `nodes.client.groups` entry on a
+group-agnostic image. Both sources union into the same plan field.
+
+## Run
+
+```sh
+nix run .#declared-groups-up
+nix run .#declared-groups-health
+```
+
+The fleet wrapper get-or-creates the `declared-groups` group under your
+account, adds both VMs, then runs the health checks: the client curls the api
+over the private group network.
+
+## Verify manually
+
+```sh
+ix group members declared-groups
+ix shell client -- curl -fsS http://api:8080/
+```
+
+## Shape
+
+- [`default.nix`](default.nix) declares the fleet; note `api` has no
+  fleet-level `groups` entry.
+- [`api.nix`](api.nix) carries the group in the image
+  (`ix.networking.groups`) and exposes port 8080 to group members.
+- [`client.nix`](client.nix) joins via the fleet-level `groups` and checks
+  that `http://api:8080/` answers over the private network.
+
+## Where the slugs live
+
+Group slugs are scoped to the deploying user (`UNIQUE (owner_id, slug)` on
+the server), so a common name like `declared-groups` in a published image
+never collides with another user's group of the same name. Slugs are
+`[a-z0-9_-]`, max 64 chars; the fleet eval rejects anything else before any
+RPC runs.

--- a/examples/declared-groups/api.nix
+++ b/examples/declared-groups/api.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+let
+  httpPort = 8080;
+in
+{
+  # The image carries its own east-west membership: every fleet that
+  # deploys this image lands in the deployer's `declared-groups` network
+  # without a fleet-level `groups` entry.
+  ix.networking.groups = [ "declared-groups" ];
+
+  services.nginx = {
+    enable = true;
+    virtualHosts."declared-groups" = {
+      default = true;
+      listen = [
+        {
+          addr = "0.0.0.0";
+          port = httpPort;
+        }
+      ];
+      locations."/".return = "200 'declared-groups private api\n'";
+    };
+  };
+
+  environment.systemPackages = [ pkgs.curl ];
+
+  ix.networking.expose.http = {
+    port = httpPort;
+    description = "private HTTP API for east-west group members";
+  };
+
+  ix.healthChecks = {
+    nginx.unit = "nginx";
+
+    http-loopback = {
+      description = "private HTTP API answers locally";
+      command = [
+        (lib.getExe pkgs.curl)
+        "--fail"
+        "--silent"
+        "--show-error"
+        "http://127.0.0.1:${toString httpPort}/"
+      ];
+    };
+  };
+}

--- a/examples/declared-groups/client.nix
+++ b/examples/declared-groups/client.nix
@@ -1,0 +1,25 @@
+{
+  ix,
+  lib,
+  nodes,
+  pkgs,
+  ...
+}:
+let
+  # Resolve the api node's listener by the name it exposes it under.
+  api = ix.endpointOf nodes.api "http";
+in
+{
+  environment.systemPackages = [ pkgs.curl ];
+
+  ix.healthChecks.private-api = {
+    description = "image-declared group gives the client a private path to the api";
+    command = [
+      (lib.getExe pkgs.curl)
+      "--fail"
+      "--silent"
+      "--show-error"
+      "http://${api}/"
+    ];
+  };
+}

--- a/examples/declared-groups/default.nix
+++ b/examples/declared-groups/default.nix
@@ -1,0 +1,21 @@
+{ index }:
+index.lib.mkFleet {
+  defaults = [ { ix.image.tag = "declared-groups"; } ];
+
+  nodes = {
+    # No fleet-level `groups`: the api image itself declares
+    # `ix.networking.groups`, so its network identity travels with the
+    # image definition instead of the deployment.
+    api = {
+      modules = [ ./api.nix ];
+    };
+
+    client = {
+      dependsOn = [ "api" ];
+      # Fleet-level membership still works and unions with anything the
+      # image declares; this node's image is group-agnostic.
+      groups = [ "declared-groups" ];
+      modules = [ ./client.nix ];
+    };
+  };
+}

--- a/lib/image/fleet.nix
+++ b/lib/image/fleet.nix
@@ -244,9 +244,18 @@ let
         else
           config.system.build.toplevel.drvPath
       );
+      # Image-declared membership (`ix.networking.groups`) unions with the
+      # fleet-level `nodes.<name>.groups`: the image carries its own network
+      # identity, the fleet adds deployment-specific memberships on top.
+      nodeGroups = lib.unique (spec.groups ++ config.ix.networking.groups);
+      # Mirrors the server's validate_group_slug rule so a bad slug fails the
+      # eval, not the create RPC mid-deploy.
+      invalidGroups = filter (slug: builtins.match "[a-z0-9_-]{1,64}" slug == null) nodeGroups;
     in
     assert lib.assertMsg (deploy.ipv4 || ipv4HealthChecks == { })
       "fleet node '${name}' has health checks that require deployment.ipv4 = true: ${lib.concatStringsSep ", " (lib.attrNames ipv4HealthChecks)}";
+    assert lib.assertMsg (invalidGroups == [ ])
+      "fleet node '${name}' has invalid east-west group slug(s) (allowed: [a-z0-9_-], max 64 chars): ${lib.concatStringsSep ", " invalidGroups}";
     {
       inherit
         name
@@ -276,7 +285,7 @@ let
       inherit (deploy) snapshot;
       recreateOnUp = deploy.recreateOnUp or false;
       inherit (spec) tags;
-      inherit (spec) groups;
+      groups = nodeGroups;
       inherit (deploy) env;
       inherit (deploy) l7ProxyPorts;
       dependsOn = expandedDependencies.${name};

--- a/lib/image/fleet.nix
+++ b/lib/image/fleet.nix
@@ -248,14 +248,15 @@ let
       # fleet-level `nodes.<name>.groups`: the image carries its own network
       # identity, the fleet adds deployment-specific memberships on top.
       nodeGroups = lib.unique (spec.groups ++ config.ix.networking.groups);
-      # Mirrors the server's validate_group_slug rule so a bad slug fails the
-      # eval, not the create RPC mid-deploy.
-      invalidGroups = filter (slug: builtins.match "[a-z0-9_-]{1,64}" slug == null) nodeGroups;
+      # Mirrors the server's validate_group_slug rule (63 = the DNS label
+      # octet limit) so a bad slug fails the eval, not the create RPC
+      # mid-deploy.
+      invalidGroups = filter (slug: builtins.match "[a-z0-9_-]{1,63}" slug == null) nodeGroups;
     in
     assert lib.assertMsg (deploy.ipv4 || ipv4HealthChecks == { })
       "fleet node '${name}' has health checks that require deployment.ipv4 = true: ${lib.concatStringsSep ", " (lib.attrNames ipv4HealthChecks)}";
     assert lib.assertMsg (invalidGroups == [ ])
-      "fleet node '${name}' has invalid east-west group slug(s) (allowed: [a-z0-9_-], max 64 chars): ${lib.concatStringsSep ", " invalidGroups}";
+      "fleet node '${name}' has invalid east-west group slug(s) (allowed: [a-z0-9_-], max 63 chars): ${lib.concatStringsSep ", " invalidGroups}";
     {
       inherit
         name

--- a/lib/image/platform.nix
+++ b/lib/image/platform.nix
@@ -323,6 +323,25 @@ in
         type = lib.types.str;
         default = config.networking.hostName;
       };
+
+      groups = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = lib.literalExpression ''[ "shared-db" ]'';
+        description = ''
+          East-west group slugs this image's VM joins at creation.
+
+          Declared in the image so the network identity travels with the
+          definition: the fleet plan unions these with the fleet-level
+          `nodes.<name>.groups`, and the create path get-or-creates each
+          slug under the deploying user before first boot. VMs sharing a
+          slug reach each other privately as `<eastWest.hostName>.ix.internal`;
+          a VM outside the group has no route in.
+
+          Slugs are scoped per owner and limited to `[a-z0-9_-]`, max 64
+          chars; the fleet eval rejects anything else before any RPC runs.
+        '';
+      };
     };
   };
 

--- a/lib/image/platform.nix
+++ b/lib/image/platform.nix
@@ -338,8 +338,9 @@ in
           slug reach each other privately as `<eastWest.hostName>.ix.internal`;
           a VM outside the group has no route in.
 
-          Slugs are scoped per owner and limited to `[a-z0-9_-]`, max 64
-          chars; the fleet eval rejects anything else before any RPC runs.
+          Slugs are scoped per owner and limited to `[a-z0-9_-]`, max 63
+          chars (the DNS label limit); the fleet eval rejects anything else
+          before any RPC runs.
         '';
       };
     };


### PR DESCRIPTION
Server counterpart: indexable-inc/ix#4727.

## What

- `ix.networking.groups` (list of str, default `[]`) in `lib/image/platform.nix`: an image module can declare the east-west groups its VM joins at creation, next to `ix.networking.expose` / `eastWest.hostName`. The network identity travels with the image definition instead of living only in the deployment.
- `lib/image/fleet.nix` unions image-declared groups with the fleet-level `nodes.<name>.groups` into the plan's `groups` field (same field `ix-fleet up` already consumes), and rejects invalid slugs at eval time (`[a-z0-9_-]`, max 64 chars, mirroring the server's `validate_group_slug`) so a bad name fails the eval, not the create RPC mid-deploy.
- `examples/declared-groups`: two-VM fleet demonstrating both sources: `api` declares its group inside the image module, `client` joins via the fleet-level entry; the health check curls the api over the private group network.

With the ix PR, group slugs are owner-scoped server-side, so a common name in a published image (e.g. `shared-db`) cannot collide across users.

## Validation

- `nix fmt` clean on the changed files.
- `nix build .#declared-groups-up` is not buildable on my aarch64 host: it needs the x86_64-only rust toolchain via IFD. Control: `nix build .#east-west-firewall-up` (pre-existing example) fails with the identical `platform mismatch` on this host, so the limitation is environmental; CI's x86 runner covers the eval/build.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add image-declared east-west groups to fleet networking
> - Adds `ix.networking.groups` option in [platform.nix](https://github.com/indexable-inc/index/pull/1070/files#diff-4e9f8a1975e02453aa569916bd7b0c3a25baa581602e105115a45921f41bf7d7) so image modules can declare east-west group slugs directly, independent of fleet-level group assignment.
> - Updates [fleet.nix](https://github.com/indexable-inc/index/pull/1070/files#diff-9836ea3ef1875452d04d6213563ea9b0df81e37a277277836b0cb9df0ced1fa0) to merge image-declared groups with fleet-level groups using `lib.unique`, and asserts that all group slugs match `[a-z0-9_-]{1,63}`.
> - Adds a two-VM example fleet in [examples/declared-groups/](https://github.com/indexable-inc/index/pull/1070/files#diff-d37ec8f63c9984367b70af18f655562bff59795069ae744257e3e065914c554c) where `api` declares its group via the image and `client` joins via fleet-level config, with health checks validating private HTTP reachability between nodes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c080798.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->