### PR TITLE
claude-code: compiled launcher + Rust hooks; ban writeShellScript

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,6 +1230,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "claude-hooks"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "glob",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "claude-stories"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "packages/agents-md",
   "packages/blast-radius",
   "packages/build-version",
+  "packages/claude-hooks",
   "packages/claude-stories",
   "packages/ast-merge/ast",
   "packages/ast-merge/cli",

--- a/astlog-rules/nix.astlog
+++ b/astlog-rules/nix.astlog
@@ -648,6 +648,19 @@
 (lint no-write-shell-application error
   "writeShellApplication is banned; use ix.writeNushellApplication instead")
 
+;; no-write-shell-script: writeShellScript hand-rolls an UNCHECKED shell script
+;; (no shellcheck, no declared runtime deps, the same gap that bans
+;; writeShellApplication / writeShellScriptBin). Prefer a compiled Rust
+;; launcher/tool (ix.rustWorkspace, see packages/config-launch and
+;; packages/claude-hooks), or ix.writeNushellApplication /
+;; ix.writePythonApplication for logic; for a genuine POSIX-process script that
+;; must be bash, use ix.writeBashApplication (checked: bash -n + shellcheck).
+(rule (no-write-shell-script n)
+  (match nix "(identifier) @n")
+  (text n "writeShellScript"))
+(lint no-write-shell-script error
+  "writeShellScript is unchecked (no shellcheck, no declared deps); prefer a compiled Rust launcher/tool (ix.rustWorkspace, see packages/config-launch / packages/claude-hooks), else ix.writeNushellApplication / ix.writePythonApplication for logic, else ix.writeBashApplication (checked) for must-be-bash")
+
 ;; no-write-shell-script-bin: writeShellScriptBin is banned. Use
 ;; ix.writeNushellApplication instead.
 (rule (no-write-shell-script-bin n)

--- a/astlog-rules/tests/no-write-shell-script/bad.fixture
+++ b/astlog-rules/tests/no-write-shell-script/bad.fixture
@@ -1,0 +1,1 @@
+{ pkgs }: pkgs.writeShellScript "x" "true"

--- a/astlog-rules/tests/no-write-shell-script/good.fixture
+++ b/astlog-rules/tests/no-write-shell-script/good.fixture
@@ -1,0 +1,1 @@
+{ ix, pkgs }: ix.writeBashApplication pkgs { name = "x"; text = "true"; }

--- a/examples/minecraft-blocks/log.nix
+++ b/examples/minecraft-blocks/log.nix
@@ -13,6 +13,7 @@
 */
 {
   config,
+  ix,
   lib,
   pkgs,
   ...
@@ -26,17 +27,18 @@ let
   # requires a fixed base64 UUID; this one is constant for the example.
   clusterId = "mc-blocks-kraft-000001";
 
-  createTopic = pkgs.writeShellScript "mc-blocks-create-topic" ''
-    set -eu
-    until ${kafkaBin}/kafka-broker-api-versions.sh --bootstrap-server 127.0.0.1:${toString brokerPort} >/dev/null 2>/tmp/kafka-probe.err; do
-      sleep 1
-    done
-    ${kafkaBin}/kafka-topics.sh \
-      --bootstrap-server 127.0.0.1:${toString brokerPort} \
-      --create --if-not-exists \
-      --topic ${schema.topic} \
-      --partitions 3 --replication-factor 1
-  '';
+  createTopic = lib.getExe (
+    ix.writeNushellApplication pkgs {
+      name = "mc-blocks-create-topic";
+      text = ''
+        # Wait for the broker to answer, then create the one topic (idempotent).
+        while (^${kafkaBin}/kafka-broker-api-versions.sh --bootstrap-server "127.0.0.1:${toString brokerPort}" | complete).exit_code != 0 {
+          sleep 1sec
+        }
+        ^${kafkaBin}/kafka-topics.sh --bootstrap-server "127.0.0.1:${toString brokerPort}" --create --if-not-exists --topic "${schema.topic}" --partitions 3 --replication-factor 1
+      '';
+    }
+  );
 in
 {
   services.apache-kafka = {

--- a/examples/minecraft-blocks/producer.nix
+++ b/examples/minecraft-blocks/producer.nix
@@ -52,17 +52,20 @@ let
   # honest pattern is at-least-once transport feeding an idempotent view, which
   # is effectively-once end to end; the log, not the transport, is the source of
   # truth, and duplicate delivery never corrupts a count.
-  shipToKafka = pkgs.writeShellScript "mc-blocks-ship" ''
-    set -eu
-    touch ${blockLog}
-    until ${kafkaBin}/kafka-broker-api-versions.sh --bootstrap-server ${kafka} >/dev/null 2>/tmp/kafka-probe.err; do
-      sleep 2
-    done
-    exec ${pkgs.coreutils}/bin/tail -F -n +1 ${blockLog} \
-      | ${kafkaBin}/kafka-console-producer.sh \
-          --bootstrap-server ${kafka} \
-          --topic ${schema.topic}
-  '';
+  shipToKafka = lib.getExe (
+    ix.writeNushellApplication pkgs {
+      name = "mc-blocks-ship";
+      text = ''
+        touch "${blockLog}"
+        while (^${kafkaBin}/kafka-broker-api-versions.sh --bootstrap-server "${kafka}" | complete).exit_code != 0 {
+          sleep 2sec
+        }
+        # Stream the append-only file into the topic (at-least-once; the view is
+        # idempotent). nushell keeps the pipe as the long-running service body.
+        ^${pkgs.coreutils}/bin/tail -F -n +1 "${blockLog}" | ^${kafkaBin}/kafka-console-producer.sh --bootstrap-server "${kafka}" --topic "${schema.topic}"
+      '';
+    }
+  );
 in
 {
   # The Minecraft server with the custom block-events plugin.

--- a/examples/minecraft-blocks/view.nix
+++ b/examples/minecraft-blocks/view.nix
@@ -56,12 +56,16 @@ let
       AS SELECT ${columnList} FROM ${schema.database}.${schema.table}_queue;
   '';
 
-  applyInit = pkgs.writeShellScript "mc-blocks-apply-init" ''
-    set -eu
-    ch() { ${lib.getExe pkgs.clickhouse} client --host ${clickhouseHost} --port ${toString clickhousePort} "$@"; }
-    until ch --query "SELECT 1" >/dev/null 2>/tmp/ch-probe.err; do sleep 1; done
-    ch --multiquery < ${initSql}
-  '';
+  applyInit = lib.getExe (
+    ix.writeNushellApplication pkgs {
+      name = "mc-blocks-apply-init";
+      text = ''
+        let base = [ "client" "--host" "${clickhouseHost}" "--port" "${toString clickhousePort}" ]
+        while (^${lib.getExe pkgs.clickhouse} ...$base --query "SELECT 1" | complete).exit_code != 0 { sleep 1sec }
+        open --raw "${initSql}" | ^${lib.getExe pkgs.clickhouse} ...$base --multiquery
+      '';
+    }
+  );
 in
 {
   # The shared observability stack: ONE ClickHouse holds both the `otel_*`

--- a/examples/observability-stack/app.nix
+++ b/examples/observability-stack/app.nix
@@ -23,26 +23,28 @@ let
   serviceName = "ix-observability-demo";
   spanName = "demo.lifecycle";
   marker = "ix-observability-demo log line";
-  emitTelemetry = pkgs.writeShellScript "ix-observability-demo-emit" ''
-    set -eu
-    mkdir -p ${lib.escapeShellArg logDir}
-    printf '%s service=%s event=started\n' ${lib.escapeShellArg marker} ${lib.escapeShellArg serviceName} >> ${lib.escapeShellArg logPath}
-    ${lib.getExe pkgs.otel-cli} span \
-      --service ${lib.escapeShellArg serviceName} \
-      --name ${lib.escapeShellArg spanName} \
-      --endpoint 127.0.0.1:${toString config.services.ix-observability.collector.grpcPort} \
-      --protocol grpc \
-      --insecure \
-      --fail \
-      --attrs ix.example=observability-stack,ix.node=${lib.escapeShellArg config.networking.hostName}
-  '';
-  checkTelemetry = pkgs.writeShellScript "ix-observability-demo-check" ''
-    set -eu
-    trace_count="$(${lib.getExe pkgs.clickhouse} client --host ${lib.escapeShellArg observability.host} --port ${toString observability.clickhousePort} --database ${lib.escapeShellArg observability.database} --query "SELECT count() FROM otel_traces WHERE ServiceName = '${serviceName}' AND SpanName = '${spanName}' AND Timestamp >= now() - INTERVAL 1 DAY")"
-    log_count="$(${lib.getExe pkgs.clickhouse} client --host ${lib.escapeShellArg observability.host} --port ${toString observability.clickhousePort} --database ${lib.escapeShellArg observability.database} --query "SELECT count() FROM otel_logs WHERE Body LIKE '%${marker}%' AND Timestamp >= now() - INTERVAL 1 DAY")"
-    test "$trace_count" -gt 0
-    test "$log_count" -gt 0
-  '';
+  emitTelemetry = lib.getExe (
+    ix.writeNushellApplication pkgs {
+      name = "ix-observability-demo-emit";
+      text = ''
+        mkdir "${logDir}"
+        "${marker} service=${serviceName} event=started\n" | save --append "${logPath}"
+        ^${lib.getExe pkgs.otel-cli} span --service "${serviceName}" --name "${spanName}" --endpoint "127.0.0.1:${toString config.services.ix-observability.collector.grpcPort}" --protocol grpc --insecure --fail --attrs "ix.example=observability-stack,ix.node=${config.networking.hostName}"
+      '';
+    }
+  );
+  checkTelemetry = lib.getExe (
+    ix.writeNushellApplication pkgs {
+      name = "ix-observability-demo-check";
+      text = ''
+        let base = [ "client" "--host" "${observability.host}" "--port" "${toString observability.clickhousePort}" "--database" "${observability.database}" ]
+        let traces = (^${lib.getExe pkgs.clickhouse} ...$base --query "SELECT count() FROM otel_traces WHERE ServiceName = '${serviceName}' AND SpanName = '${spanName}' AND Timestamp >= now() - INTERVAL 1 DAY" | str trim | into int)
+        let logs = (^${lib.getExe pkgs.clickhouse} ...$base --query "SELECT count() FROM otel_logs WHERE Body LIKE '%${marker}%' AND Timestamp >= now() - INTERVAL 1 DAY" | str trim | into int)
+        if $traces <= 0 { exit 1 }
+        if $logs <= 0 { exit 1 }
+      '';
+    }
+  );
 in
 {
   services.ix-observability = {

--- a/examples/synced-github-auth/agent.nix
+++ b/examples/synced-github-auth/agent.nix
@@ -26,6 +26,13 @@ let
   #      scope.
   # No external binaries: `[`, `printf`, `read`, `case`, and `$(<file)` are all
   # bash builtins, so the helper has no runtime PATH requirement.
+  #
+  # Kept as raw bash, not migrated to a checked writer: this is a perf-sensitive
+  # git credential helper invoked per git operation, deliberately NOT `set -e`
+  # (its control flow is built on intentional nonzero `|| exit 0` fall-throughs),
+  # builtins-only with no PATH. A nushell rewrite adds startup latency and the
+  # bash writer's `set -euo pipefail` would change its semantics.
+  # astlog-ignore: no-write-shell-script
   credentialHelper = pkgs.writeShellScript "github-token-credential-helper" ''
     [ "$1" = get ] || exit 0
     [ -r ${lib.escapeShellArg tokenPath} ] || exit 0
@@ -57,6 +64,12 @@ let
   # delivered; the stdout redirect is belt-and-suspenders against a token
   # reaching the health-check log). Passes in CI and on a fresh boot with no
   # token.
+  #
+  # Kept as raw bash: the `git config --get-all | grep -qxF` probe relies on
+  # `grep -q` exiting early, which under the bash writer's `set -o pipefail`
+  # would surface git's SIGPIPE as a failure on a successful match. Pairs with
+  # the credential helper above.
+  # astlog-ignore: no-write-shell-script
   credentialHelperCheck = pkgs.writeShellScript "check-github-credential-helper" ''
     set -eu
     ${lib.getExe pkgs.git} config --get-all 'credential.https://github.com.helper' \

--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -4,8 +4,8 @@
   stdenv,
   fetchurl,
   runtimeShell,
-  writeText,
-  writeShellScript,
+  makeBinaryWrapper,
+  runCommand,
   autoPatchelfHook,
   procps,
   ripgrep,
@@ -17,8 +17,6 @@
   gnupg,
   formats,
   jq,
-  gnugrep,
-  coreutils,
   binName ? "claude",
 
   # Default posture: bake `--dangerously-skip-permissions` into the wrapper so
@@ -44,7 +42,7 @@
   extraSettings ? { },
 
   # Shell glob patterns for the durable primary checkouts the PreToolUse
-  # worktree guard protects (see `worktreeGuardHook`): a file-edit tool call
+  # worktree guard protects (the claude-hooks `worktree-guard` subcommand): a file-edit tool call
   # whose target resolves into a PRIMARY checkout (git-dir == git-common-dir,
   # i.e. not a linked worktree) whose toplevel matches one of these globs is
   # denied, regardless of the session's cwd. The list deliberately names the
@@ -166,10 +164,11 @@ let
   manifest = lib.importJSON ./manifest.json;
   inherit (manifest) version;
 
-  # Env defaults applied through the wrapper, declared as data (single source)
-  # and derived into flags below rather than hand-written into the install phase.
-  # Exported by the wrapper only when unset (the old `--set-default`), so an
-  # explicit env or settings.json `env` value still overrides per machine. Three groups:
+  # Env defaults applied through the launcher, declared as data (single source)
+  # and rendered into the spec's `env_defaults` below rather than hand-written
+  # into the install phase. Set by the launcher only when unset (the old
+  # `--set-default`), so an explicit env or settings.json `env` value still
+  # overrides per machine. Three groups:
   #  - Output-truncation caps raised to the CLI's built-in maxima: we run a
   #    trusted config (our own CLAUDE.md / AGENTS.md / hooks / MCP servers), so
   #    prefer full output over pruning. BASH_MAX_OUTPUT_LENGTH default 30000
@@ -187,14 +186,9 @@ let
     # Re-enable 1M per machine: `export CLAUDE_CODE_DISABLE_1M_CONTEXT=`.
     CLAUDE_CODE_DISABLE_1M_CONTEXT = 1;
   };
-  # Rendered as `export NAME="${NAME-default}"` lines: assign only when the
-  # variable is UNSET. No colon in the expansion, so an explicit empty value
-  # survives (e.g. `export CLAUDE_CODE_DISABLE_1M_CONTEXT=` re-enables 1M).
-  envDefaultExports = lib.concatStringsSep "\n" (
-    lib.mapAttrsToList (
-      name: value: "export ${name}=\"\${${name}-${toString value}}\""
-    ) wrapperEnvDefaults
-  );
+  # Rendered into the launcher spec as `env_defaults` (set only when unset), so
+  # an explicit env value still overrides per machine (e.g.
+  # `export CLAUDE_CODE_DISABLE_1M_CONTEXT=` re-enables 1M).
 
   # Settings-key defaults that have no env knob, shipped as a JSON the wrapper
   # injects via `--settings`. The package wraps the binary, so it can carry env
@@ -206,8 +200,8 @@ let
   #
   # IMPORTANT: between two `--settings` *flags* the CLI is first-wins (they do
   # NOT merge with each other), so the wrapper injects this file only when the
-  # caller passed no `--settings` of their own (see the argv scan in
-  # `wrapperScript`): a user's CLI `--settings` applies untouched, and ours
+  # caller passed no `--settings` of their own (the launcher's `conditional_flags`
+  # in `launchSpec`): a user's CLI `--settings` applies untouched, and ours
   # applies only when they pass none. Injecting ours unconditionally up front
   # would silently shadow theirs, and the old approach of appending it after the
   # user argv put it inside subcommand argv, where a parser that does not define
@@ -222,12 +216,12 @@ let
   #     layer. The dev image (images/dev/development-base) enforces the same
   #     posture via managed settings; see its comment for the full rationale.
   #   hooks.UserPromptSubmit (only when the `search` sibling is in scope):
-  #     the score-gated ambient-priors hook; see `promptPriorsHook` below for
-  #     the full design and its measured rationale.
-  #   hooks.SessionStart: the context-digest hook; see `sessionDigestHook`
-  #     below.
-  #   hooks.PreToolUse: the worktree isolation guard for file-edit tools; see
-  #     `worktreeGuardHook` below. Shipped from this layer (not a project
+  #     the score-gated ambient-priors hook (claude-hooks `prompt-priors`); see
+  #     `claudeHooks` below and packages/claude-hooks for the design.
+  #   hooks.SessionStart: the context-digest hook (claude-hooks `session-digest`);
+  #     see `claudeHooks` below.
+  #   hooks.PreToolUse: the worktree isolation guard for file-edit tools
+  #     (claude-hooks `worktree-guard`). Shipped from this layer (not a project
   #     .claude/settings.json) on purpose: project hooks only load for
   #     sessions started inside that project, which is exactly the bypass the
   #     guard closes (ENG-2692).
@@ -248,199 +242,34 @@ let
   #     exa` so a consumer who overrides the server set away gets the
   #     built-ins back instead of no web access at all.
 
-  # UserPromptSubmit hook: score-gated ambient priors from the shared corpus
-  # store ("push a small hint, pull details on demand"; ENG-2707). Measured on
-  # the live store (2026-06-12 audit): un-gated ambient injection is net
-  # negative (3/5 casual prompts pulled 0.3-9k tokens of pure noise at scores
-  # 0.64-0.67) while fleet-specific task prompts hit gold at 0.70+, so this
-  # hook is triple-gated and every miss path fails OPEN and SILENT (exit 0, no
-  # output): a noisy or broken hook is strictly worse than no hook.
-  #  - Pre-flight gates, no network and well under 50ms: skip prompts under 8
-  #    words (ambient recall measures net negative on simple tasks) and prompts
-  #    with no fleet-specific noun (generic refactor verbs embed near
-  #    everything and pull vendored-code noise). The noun list is a dumb,
-  #    cheap allowlist of repo/tool names, deliberately not clever.
-  #  - The query is single-shot (rerank off; measured ~1.3s live, never the
-  #    10-23s agentic path), compact, top 3, scoped to the three sources whose
-  #    hits carry conventions and decisions (claude_history, shell, github),
-  #    under a 2s hard timeout.
-  #  - Only hits scoring >= 0.70 are injected, capped at ~1200 tokens (4800
-  #    chars, comfortably inside Claude Code's 10,000-char additionalContext
-  #    limit), each prefixed with provenance (source, user, date, score) so
-  #    the model can discount stale or cross-user content.
-  # Kill switch: export CLAUDE_CODE_DISABLE_PROMPT_PRIORS=1. Tools the hook
-  # needs ride as absolute store paths so it works under any user PATH; the
-  # `search` CLI is a flake-package-set sibling, so like the index MCP server
-  # the hook ships only there, not from the overlay (see `repoPackages`).
-  promptPriorsHook = writeShellScript "claude-prompt-priors-hook" ''
-    # Generated by packages/claude-code/default.nix (promptPriorsHook).
-    # Fail open and silent: every miss/error path is `exit 0` with no output.
-    set -f # `set -- $prompt` below word-splits; never glob
-    [ -z "''${CLAUDE_CODE_DISABLE_PROMPT_PRIORS-}" ] || exit 0
-
-    # Hook stdin is the UserPromptSubmit event JSON; only .prompt matters.
-    prompt=$(${lib.getExe jq} -r '.prompt // empty' 2>/dev/null) || exit 0
-    [ -n "$prompt" ] || exit 0
-
-    # Gate 1: short prompts are conversation or trivial edits; ambient recall
-    # on simple tasks is measured pure overhead.
-    set -- $prompt
-    [ "$#" -ge 8 ] || exit 0
-
-    # Gate 2: no fleet-specific noun, no query. Whole-word, case-insensitive,
-    # entries all >= 4 chars; built from this monorepo's repo/tool names.
-    printf '%s' "$prompt" | ${lib.getExe gnugrep} -qiwE \
-      'index|indexer|colmena|mixedbread|mgrep|flake|flakes|nixos|fleet|deploy|claude|codex|kernel|iceberg|parquet|atuin|graphite|worktree|worktrees|rebase|linear|slack|github|tailscale|cargo|clippy|nushell|symphony|vmkit|cachix' ||
-      exit 0
-
-    # Gate 3: no credential, no query. `search` resolves MXBAI_API_KEY or the
-    # mgrep login token; checking here keeps the unauthenticated path instant.
-    [ -n "''${MXBAI_API_KEY-}" ] || [ -r "''${HOME-/var/empty}/.mgrep/token.json" ] || exit 0
-
-    # Single-shot compact query under a hard 2s budget; a slow store, a dead
-    # network, or zero hits must never stall or pollute the prompt.
-    hits=$(${coreutils}/bin/timeout 2 ${lib.getExe repoPackages.search} "$prompt" \
-      --json --compact --no-rerank --max-count 3 \
-      --source claude_history,shell,github 2>/dev/null) || exit 0
-    [ -n "$hits" ] || exit 0
-
-    # Score gate + projection: provenance-prefixed snippets for hits >= 0.70.
-    # Empty selection produces no output, which the -n test turns into a
-    # silent exit.
-    context=$(${lib.getExe jq} -r '
-      def prov:
-        [ (.source // "corpus"),
-          (if .user then "by " + .user else empty end),
-          (if .timestamp then (.timestamp | todate) else empty end),
-          "score " + ((.score // 0) * 100 | floor / 100 | tostring)
-        ] | join(" ");
-      [ .[]
-        | select((.score // 0) >= 0.70)
-        | "[" + prov + "] " + (.path // "") + "\n" + (.text // "")
-      ]
-      | select(length > 0)
-      | "Possibly relevant fleet history (ambient, score-gated; may be stale or from another user, verify before relying on it):\n\n"
-        + join("\n\n")
-    ' <<<"$hits" 2>/dev/null) || exit 0
-    [ -n "$context" ] || exit 0
-
-    # Hard cap ~1200 tokens (4800 chars), inside the 10,000-char
-    # additionalContext limit even after JSON escaping.
-    context=''${context:0:4800}
-
-    ${lib.getExe jq} -cn --arg context "$context" \
-      '{hookSpecificOutput: {hookEventName: "UserPromptSubmit", additionalContext: $context}}' 2>/dev/null
-    exit 0
+  # The three hooks are subcommands of one compiled binary (packages/claude-hooks)
+  # rather than hand-rolled shell scripts. Each fails OPEN and SILENT (any
+  # missing input, parse error, or kill-switch exits with no stdout: a noisy or
+  # broken hook is strictly worse than no hook). See that crate for the full
+  # design and its measured rationale:
+  #  - session-digest (SessionStart): cat the pre-rendered fleet context digest
+  #    (`~/.cache/ix/context-digest.md`, ENG-2708), capped ~1500 tokens. Kill
+  #    switch: CLAUDE_CODE_DISABLE_CONTEXT_DIGEST=1.
+  #  - worktree-guard (PreToolUse): deny edits whose TARGET path resolves into a
+  #    protected primary checkout, judging the target not the session (ENG-2692).
+  #    Kill switch: CLAUDE_CODE_DISABLE_WORKTREE_GUARD=1.
+  #  - prompt-priors (UserPromptSubmit): triple-gated, score-gated ambient priors
+  #    from the corpus store (ENG-2707), capped ~1200 tokens. Kill switch:
+  #    CLAUDE_CODE_DISABLE_PROMPT_PRIORS=1.
+  # Tool paths and the baked primary-checkout default ride as env on a thin
+  # makeBinaryWrapper so the hook is self-contained under any user PATH, while
+  # user knobs keep their CLAUDE_CODE_* names. IX_SEARCH (and the prompt-priors
+  # hook itself) is wired only when the `search` sibling is in scope: like the
+  # index MCP server it ships from the flake package set, not the overlay (see
+  # `repoPackages`).
+  claudeHooks = runCommand "claude-hooks-wrapped" { nativeBuildInputs = [ makeBinaryWrapper ]; } ''
+    makeBinaryWrapper ${ix.rustWorkspace.units.binaries."claude-hooks"}/bin/claude-hooks \
+      $out/bin/claude-hooks \
+      --set IX_GIT ${lib.getExe git} \
+      --set IX_DEFAULT_PRIMARY_CHECKOUTS ${lib.escapeShellArg (lib.concatStringsSep ":" primaryCheckouts)} \
+      ${lib.optionalString (repoPackages ? search) "--set IX_SEARCH ${lib.getExe repoPackages.search}"}
   '';
-
-  # PreToolUse hook: worktree isolation for the durable primary checkouts
-  # (ENG-2692). The predecessor guard (ix `.agents/hooks/enforce-worktree.sh`)
-  # keyed "primary checkout" off the session-start project dir, so an agent
-  # that session-started elsewhere or cd'd around bypassed it, and agents
-  # learned to. This guard ignores the session entirely and judges only the
-  # TARGET path of the edit:
-  #  - resolve the tool call's file path (relative paths against the payload
-  #    cwd), walking unbuilt parents up to the nearest existing ancestor so
-  #    new-file Writes are judged by their containing repo;
-  #  - ask git whether that ancestor sits in a PRIMARY checkout: in one,
-  #    `--git-dir` and `--git-common-dir` resolve to the same path, while a
-  #    linked worktree's private git-dir differs from the shared common dir
-  #    (git resolves the physical path, so a symlinked alias of the checkout
-  #    cannot dodge the match);
-  #  - deny when that primary checkout's toplevel matches a protected glob
-  #    (`primaryCheckouts` above). Everything else (linked worktrees, scratch
-  #    clones, non-repo paths) passes through, and every error path fails
-  #    open: a guard that bricks all edits is worse than no guard.
-  # Escape hatch, consistent with promptPriorsHook's kill switch: export
-  # CLAUDE_CODE_DISABLE_WORKTREE_GUARD=1. Tools ride as absolute store paths
-  # so the hook works under any user PATH.
-  worktreeGuardHook = writeShellScript "claude-worktree-guard-hook" ''
-    # Generated by packages/claude-code/default.nix (worktreeGuardHook).
-    [ -z "''${CLAUDE_CODE_DISABLE_WORKTREE_GUARD-}" ] || exit 0
-
-    input=$(cat) || exit 0
-    file=$(${lib.getExe jq} -r \
-      '.tool_input.file_path // .tool_input.notebook_path // empty' \
-      <<<"$input" 2>/dev/null) || exit 0
-    [ -n "$file" ] || exit 0
-
-    # Judge the target, never the session: a relative path resolves against
-    # the payload cwd, an absolute one stands alone, so neither a cd nor a
-    # session started outside the repo changes what gets inspected.
-    case "$file" in
-    /*) ;;
-    *)
-      cwd=$(${lib.getExe jq} -r '.cwd // empty' <<<"$input" 2>/dev/null) || cwd=
-      file="''${cwd:-$PWD}/$file"
-      ;;
-    esac
-
-    # A new file's parent may not exist yet; the nearest existing ancestor's
-    # repo decides.
-    dir=$(dirname -- "$file")
-    while [ "$dir" != / ] && [ ! -d "$dir" ]; do
-      dir=$(dirname -- "$dir")
-    done
-
-    gitdir=$(${lib.getExe git} -C "$dir" rev-parse --path-format=absolute \
-      --git-dir 2>/dev/null) || exit 0
-    common=$(${lib.getExe git} -C "$dir" rev-parse --path-format=absolute \
-      --git-common-dir 2>/dev/null) || exit 0
-    # Linked worktree: private git-dir differs from the shared common dir.
-    [ "$gitdir" = "$common" ] || exit 0
-
-    toplevel=$(${lib.getExe git} -C "$dir" rev-parse --show-toplevel 2>/dev/null) ||
-      exit 0
-
-    # set -f: the IFS split below must word-split the glob list without
-    # expanding the globs against the filesystem; `case` matches them as
-    # patterns.
-    set -f
-    IFS=:
-    for pattern in ''${CLAUDE_CODE_PRIMARY_CHECKOUTS-${lib.concatStringsSep ":" primaryCheckouts}}; do
-      case "$toplevel" in
-      $pattern)
-        ${lib.getExe jq} -nc --arg toplevel "$toplevel" '{
-          hookSpecificOutput: {
-            hookEventName: "PreToolUse",
-            permissionDecision: "deny",
-            permissionDecisionReason: ("Refusing to edit \($toplevel): it is a primary checkout, not a worktree, and other work may be in flight there. Create a dedicated worktree (`git -C \($toplevel) worktree add <dir> -b <branch> origin/main`) and edit the file there instead. Reads are always fine.")
-          }
-        }'
-        exit 0
-        ;;
-      esac
-    done
-    exit 0
-  '';
-
-  # SessionStart hook: cat the pre-rendered fleet context digest (ENG-2708).
-  # The fleet's `ix-context-digest` timer materializes
-  # `~/.cache/ix/context-digest.md` every few hours from the corpus lake's
-  # distilled_facts slices (top distilled lessons + a corpus-freshness line).
-  # Session start deliberately reads a static file instead of querying the
-  # store live: ambient live queries measured net-negative (see
-  # promptPriorsHook's rationale), while distilled lessons are pre-curated
-  # signal and a local read costs no latency and fails open by absence. Every
-  # miss path is silent `exit 0`; output is hard-capped at ~1500 tokens (6000
-  # chars, inside the 10,000-char additionalContext limit). Kill switch:
-  # export CLAUDE_CODE_DISABLE_CONTEXT_DIGEST=1.
-  sessionDigestHook = writeShellScript "claude-session-digest-hook" ''
-    # Generated by packages/claude-code/default.nix (sessionDigestHook).
-    # Fail open and silent: every miss/error path is `exit 0` with no output.
-    [ -z "''${CLAUDE_CODE_DISABLE_CONTEXT_DIGEST-}" ] || exit 0
-    digest="''${HOME-/var/empty}/.cache/ix/context-digest.md"
-    [ -r "$digest" ] || exit 0
-
-    # The renderer already targets the same cap; head -c is the hook-side
-    # guarantee so a corrupt or hand-edited file cannot flood the context.
-    context=$(${coreutils}/bin/head -c 6000 "$digest" 2>/dev/null) || exit 0
-    [ -n "$context" ] || exit 0
-
-    ${lib.getExe jq} -cn --arg context "$context" \
-      '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $context}}' 2>/dev/null
-    exit 0
-  '';
+  hookCmd = sub: "${claudeHooks}/bin/claude-hooks ${sub}";
 
   # Caller's extraSettings first, then the computed defaults recursively merged
   # ON TOP, so the keys below always win a conflict while the caller's other
@@ -466,7 +295,7 @@ let
             hooks = [
               {
                 type = "command";
-                command = toString sessionDigestHook;
+                command = hookCmd "session-digest";
                 # A local file read; generous next to the CLI's 60s default.
                 timeout = 5;
               }
@@ -478,7 +307,7 @@ let
           hooks = [
             {
               type = "command";
-              command = toString worktreeGuardHook;
+              command = hookCmd "worktree-guard";
               # The hook runs a handful of local `git rev-parse` calls; well
               # past that something is wedged and failing open beats stalling
               # every edit.
@@ -493,7 +322,7 @@ let
             hooks = [
               {
                 type = "command";
-                command = toString promptPriorsHook;
+                command = hookCmd "prompt-priors";
                 # Generous ceiling over the script's own 2s search budget; the
                 # CLI default is 60s, far past fail-open.
                 timeout = 5;
@@ -515,10 +344,11 @@ let
     inherit mcpServers;
   };
 
-  # PATH additions the CLI expects at runtime (prepended, like the old
-  # `--prefix PATH :`): ps for process checks, the pinned ripgrep, the house
-  # minecraft-sound chime, and the Linux sandbox helpers.
-  wrapperPath = lib.makeBinPath (
+  # Dirs prepended to PATH at launch (the old `--prefix PATH :`): ps for process
+  # checks, the pinned ripgrep, the house minecraft-sound chime, and the Linux
+  # sandbox helpers. Passed to the launcher as `path_prepend` (it joins them
+  # ahead of the caller's PATH).
+  pathPrepend = map (p: "${lib.getBin p}/bin") (
     [
       procps
       ripgrep
@@ -578,51 +408,35 @@ let
       "--append-system-prompt-file=${builtins.toFile "claude-code-append-system-prompt.txt" appendSystemPrompt}"
   ++ lib.optional (mcpServers != { }) "--mcp-config=${mcpConfigFile}";
 
-  # The wrapper itself: a plain shell script rather than a compiled
-  # makeBinaryWrapper, because the one thing a static wrapper cannot express is
-  # the conditional `--settings` injection below, and a readable script beats
-  # `strings`-ing a Mach-O when debugging argv anyway. `@helper@` is substituted
-  # with the real binary's path at install time (it lives under $out, which is
-  # unknowable here). The store output is read-only, so the bundled self-updater
-  # could never write; DISABLE_AUTOUPDATER turns it off cleanly, the install
-  # checks are skipped, and USE_BUILTIN_RIPGREP=0 pins search to the Nix ripgrep
-  # on PATH so the wrapper owns the version pin.
-  # Hot-path launch wrapper that needs install-time `@helper@` substitution (the
-  # helper lives under $out, unknowable to the house writers) and an argv0-
-  # preserving exec; covered by the installCheck argv tests below.
-  # astlog-ignore: no-handrolled-shell-script
-  wrapperScript = writeText "claude-wrapper.sh" ''
-    #!${runtimeShell}
-    # Generated by packages/claude-code/default.nix; see wrapperFlags there.
-    export DISABLE_AUTOUPDATER=1
-    export DISABLE_INSTALLATION_CHECKS=1
-    export USE_BUILTIN_RIPGREP=0
-    ${envDefaultExports}
-    export PATH=${wrapperPath}''${PATH:+:$PATH}
+  envEntries = attrs: lib.mapAttrsToList (key: value: { inherit key value; }) attrs;
 
-    flags=(${lib.escapeShellArgs wrapperFlags})
-
-    # --settings is first-wins between two flags (they never merge), so inject
-    # the package defaults only when the caller passed none; see the
-    # settingsDefaults comment.
-    inject_settings=1
-    for arg in "$@"; do
-      case "$arg" in
-      --settings | --settings=*)
-        inject_settings=0
-        break
-        ;;
-      --)
-        break
-        ;;
-      esac
-    done
-    if ((inject_settings)); then
-      flags+=(--settings=${settingsDefaultsFile})
-    fi
-
-    exec -a "$0" "@helper@" "''${flags[@]}" "$@"
-  '';
+  # The launch spec consumed by the shared Rust launcher (packages/config-launch):
+  # it sets env/PATH, prepends `wrapperFlags`, injects `--settings` only when the
+  # caller passed none (the CLI is first-wins between two `--settings` flags),
+  # then execs the real binary preserving argv0. The store output is read-only so
+  # the bundled self-updater could never write: DISABLE_AUTOUPDATER turns it off,
+  # the install checks are skipped, and USE_BUILTIN_RIPGREP=0 pins search to the
+  # Nix ripgrep on PATH so the wrapper owns the version pin. `target` is an
+  # `@helper@` placeholder substituted at install time (the real binary lives
+  # under `$out/libexec`, unknowable here). Covered by the installCheck argv
+  # tests below.
+  launchSpec = (formats.json { }).generate "claude-code-launch-spec.json" {
+    target = "@helper@";
+    env = envEntries {
+      DISABLE_AUTOUPDATER = "1";
+      DISABLE_INSTALLATION_CHECKS = "1";
+      USE_BUILTIN_RIPGREP = "0";
+    };
+    env_defaults = envEntries (lib.mapAttrs (_: toString) wrapperEnvDefaults);
+    path_prepend = pathPrepend;
+    flags = wrapperFlags;
+    conditional_flags = [
+      {
+        unless_present = [ "--settings" ];
+        flags = [ "--settings=${settingsDefaultsFile}" ];
+      }
+    ];
+  };
 
   inherit (stdenv.hostPlatform) system;
   target =
@@ -720,11 +534,14 @@ stdenv.mkDerivation {
   dontStrip = true;
   strictDeps = true;
 
-  nativeBuildInputs = lib.optional stdenv.hostPlatform.isElf autoPatchelfHook;
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ]
+  ++ lib.optional stdenv.hostPlatform.isElf autoPatchelfHook;
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/bin $out/libexec
+    mkdir -p $out/bin $out/libexec $out/share
 
     # 1Password's "CLI access requested" prompt labels the request with the
     # basename of the process that spawns `op`, which is this real binary rather
@@ -738,38 +555,45 @@ stdenv.mkDerivation {
     helper="$out/libexec/Claude Code"
     install -m755 ${nativeBinary} "$helper"
 
-    # All flag and env injection lives in `wrapperScript` (see its let-binding
-    # and `wrapperFlags` for the per-flag rationale); here it only learns the
-    # helper's real path.
-    install -m755 ${wrapperScript} $out/bin/${binName}
-    substituteInPlace $out/bin/${binName} --subst-var-by helper "$helper"
+    # All flag/env/PATH injection lives in `launchSpec` (see its let-binding and
+    # `wrapperFlags` for the per-flag rationale); bake the helper's real path
+    # into the @helper@ placeholder, then point the launcher at the spec.
+    install -m644 ${launchSpec} $out/share/claude-code-launch-spec.json
+    substituteInPlace $out/share/claude-code-launch-spec.json --subst-var-by helper "$helper"
+    makeBinaryWrapper ${ix.rustWorkspace.units.binaries."config-launch"}/bin/config-launch \
+      $out/bin/${binName} \
+      --inherit-argv0 \
+      --set IX_LAUNCH_SPEC $out/share/claude-code-launch-spec.json
 
     runHook postInstall
   '';
 
-  # Argv regression net for the wrapper, run against a stub helper so it is
+  # Argv regression net for the launcher spec, run against a stub target so it is
   # offline and instant. Guards the properties the wrapper exists for: injected
   # flags ride BEFORE the user argv (subcommands keep parsing), every injected
   # option-argument is one `=` token (nothing can swallow a positional), and
   # `--settings` defers to a caller-provided one (the CLI is first-wins between
-  # two `--settings` flags).
+  # two `--settings` flags). Drives the real generated spec with its `@helper@`
+  # target swapped for the stub, through the actual launcher binary (the built
+  # `$out/bin/${binName}` forces IX_LAUNCH_SPEC via makeBinaryWrapper `--set`, so
+  # the launcher is exercised directly here).
   doInstallCheck = true;
   installCheckPhase = ''
     runHook preInstallCheck
 
+    launcher=${ix.rustWorkspace.units.binaries."config-launch"}/bin/config-launch
     stub="$PWD/stub"
     printf '%s\n' '#!${runtimeShell}' 'printf "%s\n" "$@"' > "$stub"
     chmod +x "$stub"
-    sed "s|$helper|$stub|" $out/bin/${binName} > test-wrapper
-    chmod +x test-wrapper
+    sed "s|@helper@|$stub|" ${launchSpec} > "$PWD/test-spec.json"
 
     check() {
       local desc="$1" expected="$2"
       shift 2
       local got
-      got="$(./test-wrapper "$@")"
+      got="$(IX_LAUNCH_SPEC="$PWD/test-spec.json" "$launcher" "$@")"
       if [ "$got" != "$expected" ]; then
-        printf 'claude wrapper argv check failed: %s\nexpected:\n%s\ngot:\n%s\n' \
+        printf 'claude launcher argv check failed: %s\nexpected:\n%s\ngot:\n%s\n' \
           "$desc" "$expected" "$got" >&2
         exit 1
       fi
@@ -810,19 +634,19 @@ stdenv.mkDerivation {
     # present digest rides additionalContext verbatim, and an oversized digest
     # is hard-capped at 6000 chars.
     mkdir -p digest-home/.cache/ix
-    if got="$(HOME="$PWD/no-such-home" ${sessionDigestHook} </dev/null)" && [ -z "$got" ]; then :; else
+    if got="$(HOME="$PWD/no-such-home" ${claudeHooks}/bin/claude-hooks session-digest </dev/null)" && [ -z "$got" ]; then :; else
       printf 'session-digest hook check failed (missing digest): expected silent exit 0, got:\n%s\n' "$got" >&2
       exit 1
     fi
     printf 'Distilled lesson: prefer rg over grep.' > digest-home/.cache/ix/context-digest.md
-    got="$(HOME="$PWD/digest-home" ${sessionDigestHook} </dev/null)"
+    got="$(HOME="$PWD/digest-home" ${claudeHooks}/bin/claude-hooks session-digest </dev/null)"
     want='{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"Distilled lesson: prefer rg over grep."}}'
     if [ "$got" != "$want" ]; then
       printf 'session-digest hook check failed (digest present)\nexpected:\n%s\ngot:\n%s\n' "$want" "$got" >&2
       exit 1
     fi
     printf 'x%.0s' $(seq 9000) > digest-home/.cache/ix/context-digest.md
-    cap="$(HOME="$PWD/digest-home" ${sessionDigestHook} </dev/null \
+    cap="$(HOME="$PWD/digest-home" ${claudeHooks}/bin/claude-hooks session-digest </dev/null \
       | ${lib.getExe jq} -r '.hookSpecificOutput.additionalContext | length')"
     if [ "$cap" != 6000 ]; then
       printf 'session-digest hook check failed (cap): expected 6000 chars, got %s\n' "$cap" >&2
@@ -839,7 +663,7 @@ stdenv.mkDerivation {
       mkdir -p no-home
       hook_silent() {
         local desc="$1" input="$2" got
-        if ! got="$(printf '%s' "$input" | HOME="$PWD/no-home" ${promptPriorsHook})" \
+        if ! got="$(printf '%s' "$input" | HOME="$PWD/no-home" ${claudeHooks}/bin/claude-hooks prompt-priors)" \
           || [ -n "$got" ]; then
           printf 'prompt-priors hook check failed (%s): expected silent exit 0, got:\n%s\n' \
             "$desc" "$got" >&2
@@ -872,7 +696,7 @@ stdenv.mkDerivation {
     guard() {
       local desc="$1" expect="$2" input="$3" got verdict
       got="$(printf '%s' "$input" \
-        | CLAUDE_CODE_PRIMARY_CHECKOUTS="$primary" ${worktreeGuardHook})"
+        | CLAUDE_CODE_PRIMARY_CHECKOUTS="$primary" ${claudeHooks}/bin/claude-hooks worktree-guard)"
       case "$got" in
       ''') verdict=allow ;;
       *'"permissionDecision":"deny"'*) verdict=deny ;;
@@ -902,7 +726,7 @@ stdenv.mkDerivation {
     guard "malformed payload fails open" allow 'not json'
     if [ -n "$(printf '%s' "{\"tool_input\":{\"file_path\":\"$primary/a.txt\"}}" \
       | CLAUDE_CODE_DISABLE_WORKTREE_GUARD=1 \
-        CLAUDE_CODE_PRIMARY_CHECKOUTS="$primary" ${worktreeGuardHook})" ]; then
+        CLAUDE_CODE_PRIMARY_CHECKOUTS="$primary" ${claudeHooks}/bin/claude-hooks worktree-guard)" ]; then
       printf 'worktree guard check failed: kill switch must allow silently\n' >&2
       exit 1
     fi

--- a/packages/claude-hooks/Cargo.toml
+++ b/packages/claude-hooks/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "claude-hooks"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Claude Code hook commands (session-digest, worktree-guard, prompt-priors) as one compiled binary"
+
+[lints]
+workspace = true
+
+[dependencies]
+chrono = { workspace = true, features = ["alloc"] }
+glob.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+[[bin]]
+name = "claude-hooks"
+path = "src/main.rs"

--- a/packages/claude-hooks/default.nix
+++ b/packages/claude-hooks/default.nix
@@ -1,0 +1,10 @@
+{ ix, lib, ... }:
+
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "claude-hooks";
+  meta = {
+    description = "Claude Code hook commands (session-digest, worktree-guard, prompt-priors) as one compiled binary";
+    license = lib.licenses.mit;
+    mainProgram = "claude-hooks";
+  };
+}

--- a/packages/claude-hooks/package.nix
+++ b/packages/claude-hooks/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "claude-hooks";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/claude-hooks/src/main.rs
+++ b/packages/claude-hooks/src/main.rs
@@ -18,8 +18,8 @@ use chrono::{DateTime, SecondsFormat};
 use serde::Serialize;
 use serde_json::Value;
 
-/// SessionStart digest cap (~1500 tokens), inside the 10,000-char
-/// additionalContext limit.
+/// `SessionStart` digest cap (~1500 tokens), inside the 10,000-char
+/// `additionalContext` limit.
 const DIGEST_CAP: usize = 6000;
 /// Prompt-priors cap (~1200 tokens).
 const PRIORS_CAP: usize = 4800;
@@ -84,9 +84,7 @@ fn flag_set(name: &str) -> bool {
 }
 
 fn home() -> PathBuf {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/var/empty"))
+    std::env::var_os("HOME").map_or_else(|| PathBuf::from("/var/empty"), PathBuf::from)
 }
 
 fn read_stdin() -> Option<String> {

--- a/packages/claude-hooks/src/main.rs
+++ b/packages/claude-hooks/src/main.rs
@@ -1,0 +1,486 @@
+//! Claude Code hook commands, one compiled binary with three subcommands that
+//! replace the old hand-rolled `writeShellScript` hooks in
+//! `packages/claude-code`. Every hook fails OPEN and SILENT: any missing input,
+//! parse error, or kill-switch returns with no stdout, because a noisy or broken
+//! hook is strictly worse than no hook.
+//!
+//! Tool paths and the baked primary-checkout default are passed by the
+//! claude-code wrapper via env (`IX_GIT`, `IX_SEARCH`,
+//! `IX_DEFAULT_PRIMARY_CHECKOUTS`); user-facing knobs keep their
+//! `CLAUDE_CODE_*` names.
+
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode, Stdio};
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, SecondsFormat};
+use serde::Serialize;
+use serde_json::Value;
+
+/// SessionStart digest cap (~1500 tokens), inside the 10,000-char
+/// additionalContext limit.
+const DIGEST_CAP: usize = 6000;
+/// Prompt-priors cap (~1200 tokens).
+const PRIORS_CAP: usize = 4800;
+/// Only inject corpus hits at or above this relevance score.
+const SCORE_GATE: f64 = 0.70;
+/// Ambient recall is measured net-negative below this many words.
+const MIN_WORDS: usize = 8;
+
+/// Fleet-specific nouns; a prompt without one embeds near everything and pulls
+/// vendored-code noise, so it gets no query. Cheap allowlist, deliberately dumb.
+const FLEET_NOUNS: &[&str] = &[
+    "index",
+    "indexer",
+    "colmena",
+    "mixedbread",
+    "mgrep",
+    "flake",
+    "flakes",
+    "nixos",
+    "fleet",
+    "deploy",
+    "claude",
+    "codex",
+    "kernel",
+    "iceberg",
+    "parquet",
+    "atuin",
+    "graphite",
+    "worktree",
+    "worktrees",
+    "rebase",
+    "linear",
+    "slack",
+    "github",
+    "tailscale",
+    "cargo",
+    "clippy",
+    "nushell",
+    "symphony",
+    "vmkit",
+    "cachix",
+];
+
+fn main() -> ExitCode {
+    match std::env::args().nth(1).as_deref() {
+        Some("session-digest") => session_digest(),
+        Some("worktree-guard") => worktree_guard(),
+        Some("prompt-priors") => prompt_priors(),
+        other => {
+            eprintln!("claude-hooks: unknown subcommand {other:?}");
+            return ExitCode::from(2);
+        }
+    }
+    ExitCode::SUCCESS
+}
+
+// --- shared helpers ---
+
+/// True when an env var is present and non-empty (the kill-switch convention).
+fn flag_set(name: &str) -> bool {
+    std::env::var_os(name).is_some_and(|v| !v.is_empty())
+}
+
+fn home() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/var/empty"))
+}
+
+fn read_stdin() -> Option<String> {
+    let mut buf = String::new();
+    std::io::stdin().read_to_string(&mut buf).ok()?;
+    Some(buf)
+}
+
+fn cap_chars(s: &str, max: usize) -> String {
+    s.chars().take(max).collect()
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ContextOutput {
+    hook_event_name: &'static str,
+    additional_context: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DenyOutput {
+    hook_event_name: &'static str,
+    permission_decision: &'static str,
+    permission_decision_reason: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Wrap<T> {
+    hook_specific_output: T,
+}
+
+fn emit<T: Serialize>(inner: T) {
+    if let Ok(s) = serde_json::to_string(&Wrap {
+        hook_specific_output: inner,
+    }) {
+        println!("{s}");
+    }
+}
+
+// --- session-digest ---
+
+fn session_digest() {
+    if flag_set("CLAUDE_CODE_DISABLE_CONTEXT_DIGEST") {
+        return;
+    }
+    let path = home().join(".cache/ix/context-digest.md");
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    let context = cap_chars(&text, DIGEST_CAP);
+    if context.is_empty() {
+        return;
+    }
+    emit(ContextOutput {
+        hook_event_name: "SessionStart",
+        additional_context: context,
+    });
+}
+
+// --- worktree-guard ---
+
+fn worktree_guard() {
+    if flag_set("CLAUDE_CODE_DISABLE_WORKTREE_GUARD") {
+        return;
+    }
+    let Some(input) = read_stdin() else { return };
+    let Ok(payload) = serde_json::from_str::<Value>(&input) else {
+        return;
+    };
+    let Some(file) = payload
+        .get("tool_input")
+        .and_then(|t| t.get("file_path").or_else(|| t.get("notebook_path")))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+    else {
+        return;
+    };
+
+    // Judge the target, never the session: a relative path resolves against the
+    // payload cwd, an absolute one stands alone.
+    let target = if file.starts_with('/') {
+        PathBuf::from(file)
+    } else {
+        let cwd = payload
+            .get("cwd")
+            .and_then(Value::as_str)
+            .map(PathBuf::from)
+            .or_else(|| std::env::var_os("PWD").map(PathBuf::from))
+            .unwrap_or_else(|| PathBuf::from("."));
+        cwd.join(file)
+    };
+
+    // A new file's parent may not exist yet; the nearest existing ancestor's
+    // repo decides.
+    let mut dir = target
+        .parent()
+        .map_or_else(|| PathBuf::from("/"), Path::to_path_buf);
+    while dir.as_path() != Path::new("/") && !dir.is_dir() {
+        dir = dir
+            .parent()
+            .map_or_else(|| PathBuf::from("/"), Path::to_path_buf);
+    }
+
+    let git = std::env::var("IX_GIT").unwrap_or_else(|_| "git".to_owned());
+    let Some(gitdir) = git_rev_parse(&git, &dir, "--git-dir") else {
+        return;
+    };
+    let Some(common) = git_rev_parse(&git, &dir, "--git-common-dir") else {
+        return;
+    };
+    // Linked worktree: private git-dir differs from the shared common dir.
+    if gitdir != common {
+        return;
+    }
+    let Some(toplevel) = git_rev_parse(&git, &dir, "--show-toplevel") else {
+        return;
+    };
+
+    if matches_protected(&toplevel, &primary_checkouts()) {
+        emit(DenyOutput {
+            hook_event_name: "PreToolUse",
+            permission_decision: "deny",
+            permission_decision_reason: format!(
+                "Refusing to edit {toplevel}: it is a primary checkout, not a worktree, \
+                 and other work may be in flight there. Create a dedicated worktree \
+                 (`git -C {toplevel} worktree add <dir> -b <branch> origin/main`) and edit \
+                 the file there instead. Reads are always fine."
+            ),
+        });
+    }
+}
+
+fn git_rev_parse(git: &str, dir: &Path, what: &str) -> Option<String> {
+    let out = Command::new(git)
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--path-format=absolute", what])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?;
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}
+
+/// User override first, else the wrapper-baked default; colon-separated, empties
+/// dropped. Empty list means no guard.
+fn primary_checkouts() -> Vec<String> {
+    let raw = std::env::var("CLAUDE_CODE_PRIMARY_CHECKOUTS")
+        .or_else(|_| std::env::var("IX_DEFAULT_PRIMARY_CHECKOUTS"))
+        .unwrap_or_default();
+    raw.split(':')
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Shell `case`-glob semantics: `*` crosses `/` (glob's default
+/// `require_literal_separator = false`), matching the whole `toplevel`.
+fn matches_protected(toplevel: &str, patterns: &[String]) -> bool {
+    patterns
+        .iter()
+        .any(|p| glob::Pattern::new(p).is_ok_and(|pat| pat.matches(toplevel)))
+}
+
+// --- prompt-priors ---
+
+fn prompt_priors() {
+    if flag_set("CLAUDE_CODE_DISABLE_PROMPT_PRIORS") {
+        return;
+    }
+    let Some(input) = read_stdin() else { return };
+    let prompt = serde_json::from_str::<Value>(&input)
+        .ok()
+        .and_then(|v| v.get("prompt").and_then(Value::as_str).map(str::to_owned))
+        .unwrap_or_default();
+    if prompt.is_empty()
+        || !passes_word_gate(&prompt)
+        || !has_fleet_noun(&prompt)
+        || !has_credential()
+    {
+        return;
+    }
+    let Some(hits) = run_search(&prompt) else {
+        return;
+    };
+    let Some(context) = render_priors(&hits) else {
+        return;
+    };
+    emit(ContextOutput {
+        hook_event_name: "UserPromptSubmit",
+        additional_context: context,
+    });
+}
+
+fn passes_word_gate(prompt: &str) -> bool {
+    prompt.split_whitespace().count() >= MIN_WORDS
+}
+
+fn has_fleet_noun(prompt: &str) -> bool {
+    prompt
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .any(|t| FLEET_NOUNS.contains(&t.to_ascii_lowercase().as_str()))
+}
+
+fn has_credential() -> bool {
+    flag_set("MXBAI_API_KEY") || home().join(".mgrep/token.json").exists()
+}
+
+fn run_search(prompt: &str) -> Option<Vec<Value>> {
+    let search = std::env::var("IX_SEARCH").ok()?;
+    let mut child = Command::new(search)
+        .arg(prompt)
+        .args([
+            "--json",
+            "--compact",
+            "--no-rerank",
+            "--max-count",
+            "3",
+            "--source",
+            "claude_history,shell,github",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    // Single-shot under a hard 2s budget; a slow store, dead network, or zero
+    // hits must never stall the prompt. Output is tiny (--max-count 3 --compact),
+    // so the unread pipe cannot fill before the child exits.
+    let started = Instant::now();
+    let status = loop {
+        match child.try_wait().ok()? {
+            Some(status) => break status,
+            None if started.elapsed() >= Duration::from_secs(2) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            None => std::thread::sleep(Duration::from_millis(20)),
+        }
+    };
+    if !status.success() {
+        return None;
+    }
+    let mut out = String::new();
+    child.stdout.take()?.read_to_string(&mut out).ok()?;
+    serde_json::from_str::<Value>(&out)
+        .ok()?
+        .as_array()
+        .cloned()
+}
+
+fn render_priors(hits: &[Value]) -> Option<String> {
+    let snippets: Vec<String> = hits
+        .iter()
+        .filter(|h| h.get("score").and_then(Value::as_f64).unwrap_or(0.0) >= SCORE_GATE)
+        .map(|h| {
+            let path = h.get("path").and_then(Value::as_str).unwrap_or("");
+            let text = h.get("text").and_then(Value::as_str).unwrap_or("");
+            format!("[{}] {path}\n{text}", provenance(h))
+        })
+        .collect();
+    if snippets.is_empty() {
+        return None;
+    }
+    let body = snippets.join("\n\n");
+    Some(cap_chars(
+        &format!(
+            "Possibly relevant fleet history (ambient, score-gated; may be stale or from \
+             another user, verify before relying on it):\n\n{body}"
+        ),
+        PRIORS_CAP,
+    ))
+}
+
+/// `source [by user] [timestamp] score N`, matching the old jq projection so the
+/// model can discount stale or cross-user content.
+fn provenance(hit: &Value) -> String {
+    let mut parts = vec![
+        hit.get("source")
+            .and_then(Value::as_str)
+            .unwrap_or("corpus")
+            .to_owned(),
+    ];
+    if let Some(user) = hit.get("user").and_then(Value::as_str) {
+        parts.push(format!("by {user}"));
+    }
+    if let Some(dt) = hit
+        .get("timestamp")
+        .and_then(Value::as_i64)
+        .and_then(|ts| DateTime::from_timestamp(ts, 0))
+    {
+        parts.push(dt.to_rfc3339_opts(SecondsFormat::Secs, true));
+    }
+    let score = hit.get("score").and_then(Value::as_f64).unwrap_or(0.0);
+    parts.push(format!("score {}", (score * 100.0).floor() / 100.0));
+    parts.join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        cap_chars, has_fleet_noun, matches_protected, passes_word_gate, provenance, render_priors,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn cap_chars_truncates_on_char_count() {
+        assert_eq!(cap_chars(&"x".repeat(9000), 6000).chars().count(), 6000);
+        assert_eq!(cap_chars("short", 6000), "short");
+    }
+
+    #[test]
+    fn word_gate() {
+        assert!(!passes_word_gate("fix this typo now"));
+        assert!(passes_word_gate(
+            "how do we deploy the fleet to every host today"
+        ));
+    }
+
+    #[test]
+    fn fleet_noun_gate() {
+        assert!(has_fleet_noun(
+            "how do we deploy the fleet with colmena to every host"
+        ));
+        assert!(!has_fleet_noun(
+            "please rename this function to something clearer for readability"
+        ));
+        // whole-word, case-insensitive
+        assert!(has_fleet_noun("rebuild the NixOS image"));
+        assert!(!has_fleet_noun("reindexing is unrelated")); // substring, not a word
+    }
+
+    #[test]
+    fn protected_glob_crosses_slash() {
+        let pats = vec!["/home/*/index".to_owned(), "/home/*/ix".to_owned()];
+        assert!(matches_protected("/home/andrew/index", &pats));
+        // `*` crosses `/` like shell `case`
+        assert!(matches_protected("/home/a/b/index", &pats));
+        assert!(!matches_protected("/tmp/scratch/index-clone", &pats));
+        assert!(matches_protected(
+            "/srv/x",
+            &["/srv/x".to_owned()] // exact path, no glob
+        ));
+    }
+
+    #[test]
+    fn priors_score_gate_and_header() {
+        let hits = vec![
+            json!({ "score": 0.82, "source": "github", "path": "a", "text": "keep me" }),
+            json!({ "score": 0.55, "source": "shell", "path": "b", "text": "drop me" }),
+        ];
+        let out = render_priors(&hits).expect("a hit above gate");
+        assert!(out.starts_with("Possibly relevant fleet history"));
+        assert!(out.contains("keep me"));
+        assert!(!out.contains("drop me"));
+    }
+
+    #[test]
+    fn priors_none_when_all_below_gate() {
+        let hits = vec![json!({ "score": 0.69, "path": "a", "text": "t" })];
+        assert!(render_priors(&hits).is_none());
+    }
+
+    #[test]
+    fn priors_capped() {
+        let hits = vec![json!({
+            "score": 0.9,
+            "source": "github",
+            "path": "p",
+            "text": "x".repeat(9000),
+        })];
+        let out = render_priors(&hits).expect("hit");
+        assert_eq!(out.chars().count(), 4800);
+    }
+
+    #[test]
+    fn provenance_formats_fields() {
+        let p = provenance(&json!({
+            "source": "claude_history",
+            "user": "andrew",
+            "score": 0.726,
+        }));
+        assert_eq!(p, "claude_history by andrew score 0.72");
+    }
+}

--- a/packages/codex/default.nix
+++ b/packages/codex/default.nix
@@ -45,7 +45,12 @@ let
   # and soft defaults), performs per-key TOML presence detection against the
   # user's config.toml, then exec's the target preserving argv0.
   launcher = ix.rustWorkspace.units.binaries."config-launch";
-  entriesOf = flat: lib.mapAttrsToList (key: v: { inherit key; value = ix.toml.scalar v; }) flat;
+  entriesOf =
+    flat:
+    lib.mapAttrsToList (key: v: {
+      inherit key;
+      value = ix.toml.scalar v;
+    }) flat;
   spec = (formats.json { }).generate "codex-launch-spec.json" {
     target = lib.getExe codex;
     config_dir_env = "CODEX_HOME";

--- a/packages/config-launch/Cargo.toml
+++ b/packages/config-launch/Cargo.toml
@@ -3,7 +3,7 @@ name = "config-launch"
 version.workspace = true
 edition.workspace = true
 publish.workspace = true
-description = "Config-driven exec launcher: inject CLI --config flags (forced always, soft only when absent from a config file) then exec a target, preserving argv0"
+description = "Spec-driven exec launcher: set env/PATH and inject CLI flags (static, argv-conditional, and config-file-gated --config) then exec a target, preserving argv0"
 
 [lints]
 workspace = true

--- a/packages/config-launch/default.nix
+++ b/packages/config-launch/default.nix
@@ -3,7 +3,7 @@
 ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
   binary = "config-launch";
   meta = {
-    description = "Config-driven exec launcher: inject CLI --config flags (forced always, soft only when absent from a config file) then exec a target, preserving argv0";
+    description = "Spec-driven exec launcher: set env/PATH and inject CLI flags (static, argv-conditional, and config-file-gated --config) then exec a target, preserving argv0";
     license = lib.licenses.mit;
     mainProgram = "config-launch";
   };

--- a/packages/config-launch/src/main.rs
+++ b/packages/config-launch/src/main.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Command, ExitCode};
@@ -10,14 +11,54 @@ struct Entry {
     value: String,
 }
 
+/// A flag block injected only when the user did not already pass an equivalent
+/// option: withheld if any user arg (scanning until the first `--`) equals a
+/// name in `unless_present` or starts with `"<name>="`.
+#[derive(Deserialize)]
+struct ConditionalFlags {
+    unless_present: Vec<String>,
+    flags: Vec<String>,
+}
+
+/// The launch spec, read as JSON from `IX_LAUNCH_SPEC`. Every field beyond
+/// `target` is optional so each consumer uses only the layers it needs: codex
+/// sets the `forced`/`soft` `--config` layer; claude-code sets
+/// `env`/`env_defaults`/`path_prepend`/`flags`/`conditional_flags`.
 #[derive(Deserialize)]
 struct Spec {
+    /// Real binary to exec.
     target: String,
+
+    // --- codex `--config` layer (forced always; soft only when the dotted key
+    // is absent from the target's config file) ---
+    #[serde(default)]
     config_dir_env: String,
+    #[serde(default)]
     config_dir_default: String,
+    #[serde(default)]
     config_file: String,
+    #[serde(default)]
     forced: Vec<Entry>,
+    #[serde(default)]
     soft: Vec<Entry>,
+
+    // --- generic launcher layers ---
+    /// Environment variables set unconditionally.
+    #[serde(default)]
+    env: Vec<Entry>,
+    /// Environment variables set only when not already present in the caller's
+    /// environment (the old `export NAME="${NAME-default}"`).
+    #[serde(default)]
+    env_defaults: Vec<Entry>,
+    /// Directories prepended to `PATH` (ahead of the caller's PATH).
+    #[serde(default)]
+    path_prepend: Vec<String>,
+    /// Flags prepended before the user argv, unconditionally.
+    #[serde(default)]
+    flags: Vec<String>,
+    /// Flag blocks prepended only when the user passed no equivalent option.
+    #[serde(default)]
+    conditional_flags: Vec<ConditionalFlags>,
 }
 
 fn expand_tilde(path: &str) -> String {
@@ -45,7 +86,9 @@ fn is_set(cfg: &toml::Value, dotted: &str) -> bool {
     true
 }
 
-fn build_flags(spec: &Spec, cfg: Option<&toml::Value>) -> Vec<String> {
+/// The codex `--config k=v` layer: forced always, soft only when absent from
+/// the parsed config file.
+fn build_config_flags(spec: &Spec, cfg: Option<&toml::Value>) -> Vec<String> {
     let mut out = Vec::new();
     for entry in &spec.forced {
         out.push("--config".to_owned());
@@ -58,6 +101,47 @@ fn build_flags(spec: &Spec, cfg: Option<&toml::Value>) -> Vec<String> {
         }
     }
     out
+}
+
+/// True if any user arg (up to the first `--`) is `name` or `name=...` for some
+/// name in `names`.
+fn arg_present(user_args: &[OsString], names: &[String]) -> bool {
+    for arg in user_args {
+        let Some(s) = arg.to_str() else { continue };
+        if s == "--" {
+            break;
+        }
+        for name in names {
+            if s == name
+                || s.strip_prefix(name)
+                    .is_some_and(|rest| rest.starts_with('='))
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// `flags` plus each conditional block whose options the user did not supply.
+fn build_arg_flags(spec: &Spec, user_args: &[OsString]) -> Vec<String> {
+    let mut out = spec.flags.clone();
+    for block in &spec.conditional_flags {
+        if !arg_present(user_args, &block.unless_present) {
+            out.extend(block.flags.iter().cloned());
+        }
+    }
+    out
+}
+
+/// `path_prepend` joined ahead of the current `PATH` (or alone if PATH is unset).
+fn build_path(prepend: &[String], current: Option<&str>) -> String {
+    let mut p = prepend.join(":");
+    if let Some(cur) = current.filter(|c| !c.is_empty()) {
+        p.push(':');
+        p.push_str(cur);
+    }
+    p
 }
 
 fn load_spec() -> Result<Spec, String> {
@@ -74,46 +158,107 @@ fn main() -> ExitCode {
             return ExitCode::from(78);
         }
     };
-    let cfg = std::fs::read_to_string(config_path(&spec))
-        .ok()
-        .and_then(|text| toml::from_str::<toml::Value>(&text).ok());
-    let flags = build_flags(&spec, cfg.as_ref());
 
-    let mut args = std::env::args_os();
-    let argv0 = args.next().unwrap_or_else(|| spec.target.clone().into());
-    let err = Command::new(&spec.target)
-        .arg0(&argv0)
-        .args(&flags)
-        .args(args)
-        .exec();
+    let mut argv = std::env::args_os();
+    let argv0 = argv.next().unwrap_or_else(|| spec.target.clone().into());
+    let user_args: Vec<OsString> = argv.collect();
+
+    // Read the config file only when there are soft keys whose presence it
+    // gates (claude-code sets no soft keys, so it never needs a config dir).
+    let cfg = if spec.soft.is_empty() {
+        None
+    } else {
+        std::fs::read_to_string(config_path(&spec))
+            .ok()
+            .and_then(|text| toml::from_str::<toml::Value>(&text).ok())
+    };
+
+    let mut prepended = build_arg_flags(&spec, &user_args);
+    prepended.extend(build_config_flags(&spec, cfg.as_ref()));
+
+    let mut cmd = Command::new(&spec.target);
+    cmd.arg0(&argv0);
+    for entry in &spec.env {
+        cmd.env(&entry.key, &entry.value);
+    }
+    for entry in &spec.env_defaults {
+        if std::env::var_os(&entry.key).is_none() {
+            cmd.env(&entry.key, &entry.value);
+        }
+    }
+    if !spec.path_prepend.is_empty() {
+        let current = std::env::var("PATH").ok();
+        cmd.env("PATH", build_path(&spec.path_prepend, current.as_deref()));
+    }
+    cmd.args(&prepended);
+    cmd.args(&user_args);
+
+    let err = cmd.exec();
     eprintln!("config-launch: exec {} failed: {err}", spec.target);
     ExitCode::from(127)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Entry, Spec, build_flags, is_set};
+    use std::ffi::OsString;
 
-    fn make_spec(forced: Vec<(&str, &str)>, soft: Vec<(&str, &str)>) -> Spec {
+    use super::{
+        ConditionalFlags, Entry, Spec, arg_present, build_arg_flags, build_config_flags,
+        build_path, is_set,
+    };
+
+    #[derive(Default)]
+    struct SpecBuilder {
+        forced: Vec<(&'static str, &'static str)>,
+        soft: Vec<(&'static str, &'static str)>,
+        flags: Vec<&'static str>,
+        conditional: Vec<(Vec<&'static str>, Vec<&'static str>)>,
+    }
+
+    fn entries(pairs: Vec<(&str, &str)>) -> Vec<Entry> {
+        pairs
+            .into_iter()
+            .map(|(k, v)| Entry {
+                key: k.to_owned(),
+                value: v.to_owned(),
+            })
+            .collect()
+    }
+
+    fn make_spec(b: SpecBuilder) -> Spec {
         Spec {
             target: "/bin/stub".to_owned(),
             config_dir_env: "TEST_HOME".to_owned(),
             config_dir_default: "~/.test".to_owned(),
             config_file: "config.toml".to_owned(),
-            forced: forced
+            forced: entries(b.forced),
+            soft: entries(b.soft),
+            env: Vec::new(),
+            env_defaults: Vec::new(),
+            path_prepend: Vec::new(),
+            flags: b.flags.into_iter().map(str::to_owned).collect(),
+            conditional_flags: b
+                .conditional
                 .into_iter()
-                .map(|(k, v)| Entry {
-                    key: k.to_owned(),
-                    value: v.to_owned(),
+                .map(|(unless, flags)| ConditionalFlags {
+                    unless_present: unless.into_iter().map(str::to_owned).collect(),
+                    flags: flags.into_iter().map(str::to_owned).collect(),
                 })
                 .collect(),
-            soft: soft
-                .into_iter()
-                .map(|(k, v)| Entry {
-                    key: k.to_owned(),
-                    value: v.to_owned(),
-                })
-                .collect(),
+        }
+    }
+
+    fn forced(pairs: Vec<(&'static str, &'static str)>) -> SpecBuilder {
+        SpecBuilder {
+            forced: pairs,
+            ..SpecBuilder::default()
+        }
+    }
+
+    fn soft(pairs: Vec<(&'static str, &'static str)>) -> SpecBuilder {
+        SpecBuilder {
+            soft: pairs,
+            ..SpecBuilder::default()
         }
     }
 
@@ -128,10 +273,14 @@ mod tests {
         toml::from_str(s).expect("valid toml")
     }
 
+    fn os(args: &[&str]) -> Vec<OsString> {
+        args.iter().map(OsString::from).collect()
+    }
+
     #[test]
     fn forced_always_injected_no_config() {
-        let spec = make_spec(vec![("check_for_update_on_startup", "false")], vec![]);
-        let flags = build_flags(&spec, None);
+        let spec = make_spec(forced(vec![("check_for_update_on_startup", "false")]));
+        let flags = build_config_flags(&spec, None);
         assert!(
             has_config(&flags, "check_for_update_on_startup=false"),
             "forced flag should always be injected; got: {flags:?}"
@@ -140,9 +289,9 @@ mod tests {
 
     #[test]
     fn forced_always_injected_with_config() {
-        let spec = make_spec(vec![("check_for_update_on_startup", "false")], vec![]);
+        let spec = make_spec(forced(vec![("check_for_update_on_startup", "false")]));
         let cfg = parse_toml("check_for_update_on_startup = true\n");
-        let flags = build_flags(&spec, Some(&cfg));
+        let flags = build_config_flags(&spec, Some(&cfg));
         assert!(
             has_config(&flags, "check_for_update_on_startup=false"),
             "forced flag must override even when user config sets the key; got: {flags:?}"
@@ -151,18 +300,15 @@ mod tests {
 
     #[test]
     fn soft_injected_when_absent() {
-        let spec = make_spec(
-            vec![],
-            vec![
-                ("features.multi_agent_v2.enabled", "true"),
-                (
-                    "features.multi_agent_v2.max_concurrent_threads_per_session",
-                    "16",
-                ),
-                ("agents.max_depth", "3"),
-            ],
-        );
-        let flags = build_flags(&spec, None);
+        let spec = make_spec(soft(vec![
+            ("features.multi_agent_v2.enabled", "true"),
+            (
+                "features.multi_agent_v2.max_concurrent_threads_per_session",
+                "16",
+            ),
+            ("agents.max_depth", "3"),
+        ]));
+        let flags = build_config_flags(&spec, None);
         assert!(
             has_config(&flags, "features.multi_agent_v2.enabled=true"),
             "soft flag should be injected when config absent; got: {flags:?}"
@@ -188,25 +334,21 @@ mod tests {
         //   - `features.multi_agent_v2.max_concurrent_threads_per_session` is still
         //     injected (that leaf is absent from config)
         //   - `agents.max_depth` is injected (different subtree)
-        let spec = make_spec(
-            vec![],
-            vec![
-                ("features.multi_agent_v2.enabled", "true"),
-                (
-                    "features.multi_agent_v2.max_concurrent_threads_per_session",
-                    "16",
-                ),
-                ("agents.max_depth", "3"),
-            ],
-        );
+        let spec = make_spec(soft(vec![
+            ("features.multi_agent_v2.enabled", "true"),
+            (
+                "features.multi_agent_v2.max_concurrent_threads_per_session",
+                "16",
+            ),
+            ("agents.max_depth", "3"),
+        ]));
         let cfg = parse_toml("[features.multi_agent_v2]\nenabled = false\n");
-        let flags = build_flags(&spec, Some(&cfg));
+        let flags = build_config_flags(&spec, Some(&cfg));
 
         assert!(
             !has_config(&flags, "features.multi_agent_v2.enabled=true"),
             "enabled soft key should be withheld because config sets it; got: {flags:?}"
         );
-        // max_concurrent_threads_per_session is NOT set in config, so it IS injected
         assert!(
             has_config(
                 &flags,
@@ -214,7 +356,6 @@ mod tests {
             ),
             "threads soft key should be injected because config does not set it; got: {flags:?}"
         );
-        // agents.max_depth is a different subtree, should be injected
         assert!(
             has_config(&flags, "agents.max_depth=3"),
             "max_depth should be injected when only v2.enabled is set; got: {flags:?}"
@@ -223,9 +364,9 @@ mod tests {
 
     #[test]
     fn soft_withheld_when_exact_key_set() {
-        let spec = make_spec(vec![], vec![("agents.max_depth", "3")]);
+        let spec = make_spec(soft(vec![("agents.max_depth", "3")]));
         let cfg = parse_toml("[agents]\nmax_depth = 5\n");
-        let flags = build_flags(&spec, Some(&cfg));
+        let flags = build_config_flags(&spec, Some(&cfg));
         assert!(
             flags.is_empty(),
             "soft key should be withheld when exact path is in config; got: {flags:?}"
@@ -235,12 +376,9 @@ mod tests {
     #[test]
     fn is_set_partial_path() {
         let cfg = parse_toml("[features.multi_agent_v2]\nenabled = false\n");
-        // full path present
         assert!(is_set(&cfg, "features.multi_agent_v2.enabled"));
-        // parent path also considered set
         assert!(is_set(&cfg, "features.multi_agent_v2"));
         assert!(is_set(&cfg, "features"));
-        // absent path
         assert!(!is_set(&cfg, "features.other"));
         assert!(!is_set(&cfg, "agents.max_depth"));
     }
@@ -254,23 +392,96 @@ mod tests {
 
     #[test]
     fn no_flags_when_all_soft_set() {
-        let spec = make_spec(
-            vec![],
-            vec![
-                ("features.multi_agent_v2.enabled", "true"),
-                (
-                    "features.multi_agent_v2.max_concurrent_threads_per_session",
-                    "16",
-                ),
-                ("agents.max_depth", "3"),
-            ],
-        );
+        let spec = make_spec(soft(vec![
+            ("features.multi_agent_v2.enabled", "true"),
+            (
+                "features.multi_agent_v2.max_concurrent_threads_per_session",
+                "16",
+            ),
+            ("agents.max_depth", "3"),
+        ]));
         let toml_text = "[features.multi_agent_v2]\nenabled = true\nmax_concurrent_threads_per_session = 8\n[agents]\nmax_depth = 5\n";
         let cfg = parse_toml(toml_text);
-        let flags = build_flags(&spec, Some(&cfg));
+        let flags = build_config_flags(&spec, Some(&cfg));
         assert!(
             flags.is_empty(),
             "no soft flags should be injected when all keys present; got: {flags:?}"
         );
+    }
+
+    #[test]
+    fn static_flags_prepend() {
+        let spec = make_spec(SpecBuilder {
+            flags: vec!["--debug", "--thinking-display=summarized"],
+            ..SpecBuilder::default()
+        });
+        let flags = build_arg_flags(&spec, &os(&["mcp", "list"]));
+        assert_eq!(flags, vec!["--debug", "--thinking-display=summarized"]);
+    }
+
+    #[test]
+    fn conditional_flag_injected_when_option_absent() {
+        let spec = make_spec(SpecBuilder {
+            conditional: vec![(vec!["--settings"], vec!["--settings=/def.json"])],
+            ..SpecBuilder::default()
+        });
+        let flags = build_arg_flags(&spec, &os(&["-p", "hi"]));
+        assert_eq!(flags, vec!["--settings=/def.json"]);
+    }
+
+    #[test]
+    fn conditional_flag_withheld_when_bare_option_present() {
+        let spec = make_spec(SpecBuilder {
+            conditional: vec![(vec!["--settings"], vec!["--settings=/def.json"])],
+            ..SpecBuilder::default()
+        });
+        let flags = build_arg_flags(&spec, &os(&["--settings", "/user.json"]));
+        assert!(
+            flags.is_empty(),
+            "conditional should be withheld when user passes the bare option; got: {flags:?}"
+        );
+    }
+
+    #[test]
+    fn conditional_flag_withheld_when_equals_option_present() {
+        let spec = make_spec(SpecBuilder {
+            conditional: vec![(vec!["--settings"], vec!["--settings=/def.json"])],
+            ..SpecBuilder::default()
+        });
+        let flags = build_arg_flags(&spec, &os(&["--settings=/user.json"]));
+        assert!(
+            flags.is_empty(),
+            "conditional should be withheld for the `=` form; got: {flags:?}"
+        );
+    }
+
+    #[test]
+    fn arg_present_stops_at_double_dash() {
+        // a `--settings` after `--` is a positional, not our option.
+        assert!(!arg_present(
+            &os(&["--", "--settings", "x"]),
+            &["--settings".to_owned()]
+        ));
+        assert!(arg_present(
+            &os(&["--settings", "x"]),
+            &["--settings".to_owned()]
+        ));
+    }
+
+    #[test]
+    fn build_path_prepends_ahead_of_current() {
+        let p = build_path(
+            &["/a/bin".to_owned(), "/b/bin".to_owned()],
+            Some("/usr/bin"),
+        );
+        assert_eq!(p, "/a/bin:/b/bin:/usr/bin");
+    }
+
+    #[test]
+    fn build_path_without_current() {
+        let p = build_path(&["/a/bin".to_owned()], None);
+        assert_eq!(p, "/a/bin");
+        let p_empty = build_path(&["/a/bin".to_owned()], Some(""));
+        assert_eq!(p_empty, "/a/bin");
     }
 }

--- a/packages/config-launch/tests/cli.rs
+++ b/packages/config-launch/tests/cli.rs
@@ -265,10 +265,23 @@ fn env_always_set_and_defaults_only_when_unset() {
     assert!(!lines2.contains(&"DEF=d".to_owned()), "got: {lines2:?}");
 }
 
+/// A stub that prints only `PATH=<value>` using the shell builtin `echo`, so it
+/// does not depend on any external command being resolvable on the (rewritten)
+/// PATH. `env`/`printf`-via-PATH would fail in the build sandbox once PATH is
+/// replaced with dirs that hold no coreutils.
+fn write_path_stub(dir: &TempDir) -> std::path::PathBuf {
+    let path = dir.path().join("path-stub");
+    let mut f = fs::File::create(&path).expect("create path stub");
+    f.write_all(b"#!/bin/sh\necho \"PATH=$PATH\"\n")
+        .expect("write path stub");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).expect("chmod path stub");
+    path
+}
+
 #[test]
 fn path_prepend_rides_ahead_of_caller_path() {
     let tmp = TempDir::new().unwrap();
-    let stub = write_env_stub(&tmp);
+    let stub = write_path_stub(&tmp);
     let spec = write_json_spec(
         &tmp,
         &serde_json::json!({

--- a/packages/config-launch/tests/cli.rs
+++ b/packages/config-launch/tests/cli.rs
@@ -208,6 +208,144 @@ fn argv_passthrough() {
     assert!(lines.contains(&"o3"), "expected 'o3' in passthrough");
 }
 
+/// A stub that prints its full environment (one `KEY=VALUE` per line).
+fn write_env_stub(dir: &TempDir) -> std::path::PathBuf {
+    let path = dir.path().join("env-stub");
+    let mut f = fs::File::create(&path).expect("create env stub");
+    f.write_all(b"#!/bin/sh\nenv\n").expect("write env stub");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).expect("chmod env stub");
+    path
+}
+
+fn write_json_spec(dir: &TempDir, spec: &serde_json::Value) -> std::path::PathBuf {
+    let path = dir.path().join("spec.json");
+    fs::write(&path, spec.to_string()).expect("write spec");
+    path
+}
+
+#[test]
+fn env_always_set_and_defaults_only_when_unset() {
+    let tmp = TempDir::new().unwrap();
+    let stub = write_env_stub(&tmp);
+    let spec = write_json_spec(
+        &tmp,
+        &serde_json::json!({
+            "target": stub.to_str().unwrap(),
+            "env": [{ "key": "ALWAYS", "value": "a" }],
+            "env_defaults": [{ "key": "DEF", "value": "d" }],
+        }),
+    );
+
+    // DEF unset in the caller env -> the default is injected.
+    let out = Command::new(BIN)
+        .env("IX_LAUNCH_SPEC", &spec)
+        .env_remove("DEF")
+        .output()
+        .expect("run");
+    let lines: Vec<String> = String::from_utf8(out.stdout)
+        .unwrap()
+        .lines()
+        .map(str::to_owned)
+        .collect();
+    assert!(lines.contains(&"ALWAYS=a".to_owned()), "got: {lines:?}");
+    assert!(lines.contains(&"DEF=d".to_owned()), "got: {lines:?}");
+
+    // DEF already set -> the caller value is preserved, default withheld.
+    let out2 = Command::new(BIN)
+        .env("IX_LAUNCH_SPEC", &spec)
+        .env("DEF", "preset")
+        .output()
+        .expect("run");
+    let lines2: Vec<String> = String::from_utf8(out2.stdout)
+        .unwrap()
+        .lines()
+        .map(str::to_owned)
+        .collect();
+    assert!(lines2.contains(&"DEF=preset".to_owned()), "got: {lines2:?}");
+    assert!(!lines2.contains(&"DEF=d".to_owned()), "got: {lines2:?}");
+}
+
+#[test]
+fn path_prepend_rides_ahead_of_caller_path() {
+    let tmp = TempDir::new().unwrap();
+    let stub = write_env_stub(&tmp);
+    let spec = write_json_spec(
+        &tmp,
+        &serde_json::json!({
+            "target": stub.to_str().unwrap(),
+            "path_prepend": ["/ix/bin"],
+        }),
+    );
+    let out = Command::new(BIN)
+        .env("IX_LAUNCH_SPEC", &spec)
+        .env("PATH", "/usr/bin:/bin")
+        .output()
+        .expect("run");
+    let path_line = String::from_utf8(out.stdout)
+        .unwrap()
+        .lines()
+        .find(|l| l.starts_with("PATH="))
+        .expect("PATH line")
+        .to_owned();
+    assert_eq!(path_line, "PATH=/ix/bin:/usr/bin:/bin", "got: {path_line}");
+}
+
+#[test]
+fn static_and_conditional_flags_prepend_before_argv() {
+    let tmp = TempDir::new().unwrap();
+    let stub = write_stub(&tmp);
+    let spec = write_json_spec(
+        &tmp,
+        &serde_json::json!({
+            "target": stub.to_str().unwrap(),
+            "flags": ["--debug", "--thinking-display=summarized"],
+            "conditional_flags": [
+                { "unless_present": ["--settings"], "flags": ["--settings=/def.json"] }
+            ],
+        }),
+    );
+
+    // No user --settings: defaults inject, before the subcommand argv.
+    let out = Command::new(BIN)
+        .env("IX_LAUNCH_SPEC", &spec)
+        .args(["mcp", "list"])
+        .output()
+        .expect("run");
+    let lines: Vec<String> = String::from_utf8(out.stdout)
+        .unwrap()
+        .lines()
+        .map(str::to_owned)
+        .collect();
+    assert_eq!(
+        lines,
+        vec![
+            "--debug",
+            "--thinking-display=summarized",
+            "--settings=/def.json",
+            "mcp",
+            "list"
+        ],
+        "flags must prepend before the user argv"
+    );
+
+    // User passes their own --settings: the conditional block is withheld.
+    let out2 = Command::new(BIN)
+        .env("IX_LAUNCH_SPEC", &spec)
+        .args(["--settings=/user.json", "-p", "hi"])
+        .output()
+        .expect("run");
+    let lines2: Vec<String> = String::from_utf8(out2.stdout)
+        .unwrap()
+        .lines()
+        .map(str::to_owned)
+        .collect();
+    assert!(
+        !lines2.iter().any(|l| l == "--settings=/def.json"),
+        "package --settings must defer to the caller's; got: {lines2:?}"
+    );
+    assert!(lines2.contains(&"--settings=/user.json".to_owned()));
+}
+
 #[test]
 fn missing_spec_env_exits_78() {
     let output = Command::new(BIN)

--- a/packages/vz-linux-guest/nixos.nix
+++ b/packages/vz-linux-guest/nixos.nix
@@ -15,6 +15,12 @@ let
   # Wrapper that points the wgpu overlay at the lavapipe software-Vulkan ICD
   # (mandatory: with no ICD wgpu hard-panics, there is no GL fallback) and seeds
   # a fresh BOSSBAR_DB path so the overlay auto-populates its demo bars.
+  #
+  # Kept as raw bash: this module is a standalone `eval-config.nix` system whose
+  # only specialArg is `bossbar-overlay` (no package `ix` in scope), so the
+  # checked `ix.writeBashApplication` / `ix.writeNushellApplication` writers are
+  # unreachable here. It is a trivial env-setup + exec launch wrapper.
+  # astlog-ignore: no-write-shell-script
   bossbarLaunch = pkgs.writeShellScript "bossbar-launch" ''
     export VK_DRIVER_FILES=${pkgs.mesa}/share/vulkan/icd.d/lvp_icd.aarch64.json
     export LD_LIBRARY_PATH=${pkgs.mesa}/lib


### PR DESCRIPTION
## What

Clean up `packages/claude-code` the way `packages/codex` was cleaned up (PR #1071), and add a proper `writeShellScript` ban.

- **Generalize `config-launch`** into a spec-driven exec launcher: optional spec fields `env` (always), `env_defaults` (only when unset), `path_prepend`, `flags` (static, prepended), `conditional_flags` (inject unless a user arg matches `unless_present`, scanning until `--`), alongside the existing codex `--config` forced/soft layer. argv0 preserved. codex's spec is unchanged (all new fields `#[serde(default)]`).
- **claude-code entrypoint -> launcher**: drop the hand-rolled `writeText "claude-wrapper.sh"`; the entrypoint is now `makeBinaryWrapper ${config-launch} --inherit-argv0 --set IX_LAUNCH_SPEC <spec>`, where the spec is `(formats.json{}).generate` with `target="@helper@"` substituted at install time. env/PATH/flags/conditional `--settings` all move into the spec.
- **Hooks -> Rust**: new `packages/claude-hooks` crate, one binary with `session-digest` / `worktree-guard` / `prompt-priors` subcommands replacing the three `writeShellScript` hooks. Native serde_json (no jq); `git`/`search` via `IX_GIT`/`IX_SEARCH` baked by a thin wrapper; fail-open, kill switches, caps/gates preserved.
- **astlog `no-write-shell-script` (error)** + fixtures. Demo process scripts migrated to `ix.writeNushellApplication`; three genuinely-bash holdouts carry an `astlog-ignore` with reasons (the non-`set -e` git credential helper + its `grep -q | ` check that `pipefail` would break on a match, and the vz guest launcher whose standalone `eval-config` has no `ix` in scope).

## Verification

- `cargo test -p config-launch -p claude-hooks`: **15 + 8 + 8 pass**; `cargo fmt --check` clean.
- `nu --ide-check` clean on all 5 migrated nushell bodies.
- `nox fmt` clean on all touched Nix files.
- Adversarial `code-reviewer` pass: no blocking correctness/security findings.
- nix can't build on the author's machine; relying on CI `flake-check` per-attr for `config-launch`, `claude-hooks`, `claude-code` (build + installCheck), `astlog-nix-rules`, and the touched example/guest attrs.

```mermaid
flowchart LR
  claude["$out/bin/claude (makeBinaryWrapper)"] -->|--set IX_LAUNCH_SPEC| L[config-launch]
  L -->|env/PATH/flags/--settings, argv0| H["$out/libexec/Claude Code"]
  H -.->|hooks.command| HK[claude-hooks session-digest / worktree-guard / prompt-priors]
```

Generated with Claude Code (Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace shell script hooks with a compiled Rust binary and a generic config-driven launcher for claude-code
> - Introduces a new `claude-hooks` Rust crate ([src/main.rs](https://github.com/indexable-inc/index/pull/1072/files#diff-1a517c4ccfd3a26c409768ca118d4b36041ac41a4af8e011f3b77fd5538fdcaa)) implementing three hook subcommands (`session-digest`, `worktree-guard`, `prompt-priors`) previously written as inline shell scripts.
> - Replaces the handwritten shell wrapper for `claude-code` with a JSON launch spec consumed by the shared `config-launch` binary, which now supports `env`, `env_defaults`, `path_prepend`, static flags, and conditional flags (e.g. injecting `--settings` only when absent from user args).
> - Migrates example Nix scripts in `minecraft-blocks`, `observability-stack`, and related packages from `pkgs.writeShellScript` to `ix.writeNushellApplication`.
> - Adds a `no-write-shell-script` lint rule to [astlog-rules/nix.astlog](https://github.com/indexable-inc/index/pull/1072/files#diff-de5bc8426aac324b41bb80bf1cfa277c527b5423c78e6e4767189c3b0330cc60) that errors on any use of `writeShellScript`; existing necessary uses are suppressed with `astlog-ignore` comments.
> - Risk: `claude-code` now launches via `config-launch` with `IX_LAUNCH_SPEC`; any environment or PATH setup previously done by the shell wrapper must now be expressed in the JSON spec.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9967e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->