### PR TITLE
fix: sync ix sdk

### DIFF
--- a/packages/ix-sdk-python/default.nix
+++ b/packages/ix-sdk-python/default.nix
@@ -23,8 +23,8 @@ let
   # workspace-sdks.nix. Other systems fall through to the loud placeholder below.
   catalog = {
     x86_64-linux = {
-      url = "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/wheel/ix-sdk/i8isn1mld0vilr6prxd283kkq2pk8q02/ix_sdk-0.1.0-cp313-abi3-manylinux_2_34_x86_64.whl";
-      hash = "sha256-SiLtLWRzUT+++6+M0WlPqMB/0Dca7iJRU075uajw7Rg=";
+      url = "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/wheel/ix-sdk/5azviwv34h5k6s63wj4pvx1y0bw5831v/ix_sdk-0.1.0-cp313-abi3-manylinux_2_34_x86_64.whl";
+      hash = "sha256-jys0Rb8ZeZ7GWDIKTspuc5lt0TmkIQbBNayT0hObgQY=";
     };
     aarch64-darwin = {
       url = "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/wheel/ix-sdk/jmj8q0gsq5lnvv8aap6j7zh874bpzqjh/ix_sdk-0.1.0-cp313-abi3-macosx_11_0_arm64.whl";

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -11,12 +11,6 @@ version = 4
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -67,7 +61,7 @@ name = "snafu-derive"
 version = "0.9.1"
 source = "git+https://github.com/shepmaster/snafu.git#ff50133848f39de1b1fd40c74daa9d781fdda544"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -88,7 +82,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -42,7 +42,7 @@ overflow-checks = false
 # Profile under which the R2-hosted `ix-sdk-wire` rlib was compiled in the ix
 # repo. The cargo-unit hash folds in the profile, so the public SDK workspace
 # MUST build under this exact profile for the stub's generated unit key to equal
-# the prebuilt's (`134ac8c636bf38ee`). Byte-faithful to ix's `[profile.public-rlib]`
+# the prebuilt's (`a95096d6b0ee69a6`). Byte-faithful to ix's `[profile.public-rlib]`
 # (indexable-inc/ix Cargo.toml): a clean, consumer-linkable rlib (lto off so no
 # LLVM bitcode is embedded; panic unwind to match the consumer) with every
 # no-source-leak guarantee (strip, no debuginfo, no split sidecar, location

--- a/sdk/rust/default.nix
+++ b/sdk/rust/default.nix
@@ -59,7 +59,7 @@ let
   # must GENERATE this same hash for its `ix-sdk-wire` stub or the injection is
   # rejected by buildWorkspace's C1 assert.
   wireVersion = "0.1.0";
-  wireHash = "4e5d4b3c3884e404";
+  wireHash = "a95096d6b0ee69a6";
   wireToolchainId = "iz0mdcq43pxl3fmxmznc6n38sals6q0x-rust-default-1.98.0-nightly-2026-05-27";
   r2Base = "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/rlib/ix-sdk-wire/${wireHash}";
 
@@ -68,11 +68,11 @@ let
   # compiled artifacts produced in the ix repo, not rebuilt here.
   wireRlib = pkgs.fetchurl {
     url = "${r2Base}/libix_sdk_wire-${wireHash}.rlib";
-    hash = "sha256-ShWsIGI6UAjCA/rWgRs9CMJ7kdak0L3Yzvn8Wjgb+X8=";
+    hash = "sha256-JCv83V3NQeSuA/oG/zYoX3AmM5u9jKPOxSH6V6OQQDs=";
   };
   wireRmeta = pkgs.fetchurl {
     url = "${r2Base}/libix_sdk_wire-${wireHash}.rmeta";
-    hash = "sha256-zz7SV4SgbuGRzh+nbbLXT09S+HWaZRPgd635fMhXT04=";
+    hash = "sha256-Bt37uG3ImMhjt9dPX3W+pIoNAQvUMAFVOIdNMvUcT3E=";
   };
 
   # Wrap the fetched rlib+rmeta as a cargo-unit library unit. The Cargo lib


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Sync ix SDK by updating wire artifact hashes and Python wheel URLs
- Updates the `wireHash` in [default.nix](https://github.com/indexable-inc/index/pull/1075/files#diff-46fa88d41982cdb7255a084462fcb03966b09864f14b1626c3dab5187c433886) from `4e5d4b3c3884e404` to `a95096d6b0ee69a6`, along with matching sha256 sums for the fetched `libix_sdk_wire` rlib and rmeta artifacts.
- Updates the x86_64-linux wheel URL and sha256 in [packages/ix-sdk-python/default.nix](https://github.com/indexable-inc/index/pull/1075/files#diff-80f46c8d1744ebc070c811611b94e45d792b24cdeeae53fcaf78e4db15945032) to point to the new `ix_sdk-0.1.0` build.
- Updates the inline hash comment in [Cargo.toml](https://github.com/indexable-inc/index/pull/1075/files#diff-8dd85bbe8e2c547e5fff86a8f9c37b0bbed131445ea7dd4631fa1cee8a72a827) to match the new prebuilt cargo-unit hash.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 443eb80.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->