### PR TITLE
search-py: return a polars DataFrame from async semantic/grep/recent

### DIFF
--- a/agent-context/sections/18-searching.md
+++ b/agent-context/sections/18-searching.md
@@ -41,7 +41,9 @@ past.
 
 The shared store also indexes the whole fleet's history, not just code. From
 the index kernel: `import search`, then `await search.semantic("<task
-phrasing>", source=["claude_history"], top_k=5)`. Route by question type:
+phrasing>", source=["claude_history"], top_k=5)` — each verb is async and
+returns a polars frame (one row per hit; `.filter`/`.group_by`/`.head` it).
+Route by question type:
 `shell` answers "what is the command" for a few hundred tokens, `github`
 answers "why is it this way" with PR bodies and URLs, `claude_history` answers
 "how did someone do this". Pass `agentic=True` only for failure-shaped queries

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -81,8 +81,9 @@ MODULES: tuple[Module, ...] = (
         "search",
         "meaning-based recall across the fleet corpus (code + agent/shell history): "
         "`await search.semantic(q, since='7d', compact=True)` / `grep(pattern)` / "
-        "`recent(source=['shell'], since='6h')` newest-first; hits carry timestamp/"
-        "user/host/session_id provenance",
+        "`recent(source=['shell'], since='6h')` newest-first. Each is async and "
+        "returns a polars frame (one row per hit, compose `.filter`/`.group_by`/"
+        "`.head`) with timestamp/user/host/session_id provenance columns",
         # Mirrors the resolution order owned by packages/mixedbread/src/auth.rs
         # (env key, else the `mgrep login` token), which the bundled module
         # reaches through search-py.

--- a/packages/search-py/README.md
+++ b/packages/search-py/README.md
@@ -12,26 +12,27 @@ boundary.
 ```python
 import search
 
-hits = await search.semantic("where is retry backoff configured")
-for hit in hits:
-    print(hit["path"], hit["score"], hit.get("timestamp"))
+df = await search.semantic("where is retry backoff configured")
+df.select("path", "score", "timestamp").head()
+df.group_by("source").len().sort("len", descending=True)
 
 # only Claude history, only my records, last two weeks, token-frugal
-hits = await search.semantic(
+df = await search.semantic(
     "deploy steps", source=["claude_history"], user=["andrew"],
     since="2w", compact=True,
 )
 
 # my shell commands of the last six hours, newest first
-rows = await search.recent(source=["shell"], user=["andrew"], since="6h")
+df = await search.recent(source=["shell"], user=["andrew"], since="6h")
 
-hits = await search.grep(r"fn \w+\(", source=["code"], repo="indexable-inc/index")
-for hit in hits:
-    print(hit["path"], hit["text"])
+df = await search.grep(r"fn \w+\(", source=["code"], repo="indexable-inc/index")
+df.select("path", "text")
 ```
 
-Each verb returns a native asyncio coroutine, so `await` it on your own event
-loop.
+Each verb is an `async def` coroutine returning a [polars](https://pola.rs)
+`DataFrame` (one row per hit), so `await` it on your own event loop and then
+compose `.filter` / `.group_by` / `.sort` / `.head` on the result — the same
+shape `fff` and `view` return.
 
 ## `semantic(query, ...)`
 
@@ -80,9 +81,8 @@ fast; the `score` value in each hit is the API's placeholder, not relevance.
   `since`, `until`.
 
 ```python
-rows = await search.recent(source=["shell"], since="6h")
-for row in rows:
-    print(row["timestamp"], row["text"])
+df = await search.recent(source=["shell"], since="6h")
+df.select("timestamp", "text")
 ```
 
 ## Scope selectors
@@ -102,10 +102,14 @@ repeated values and comma-joined strings (`source=["code", "slack,linear"]`):
   `timestamp`. Each accepts an `int` (epoch seconds) or a `str` holding epoch
   seconds or a relative span: `"90s"`, `"30m"`, `"24h"`, `"7d"`, `"2w"`.
 
-## Hit shape
+## Result frame
 
-Each hit is a dict with `path`, `score`, `start_line`, `num_lines`, `text`,
-and `source`, plus provenance keys set only when the record carries them:
+Every verb returns a polars `DataFrame` with one row per hit and a stable
+column schema, so `df["timestamp"]` and `df.group_by("source")` work even when
+the result is empty or a provenance field is absent from every row (missing
+values are null). The six always-present columns are `path`, `score`,
+`start_line`, `num_lines`, `text`, and `source`; the provenance columns are set
+only when the record carries them:
 
 - `timestamp`: epoch seconds (the recency axis; every history record has one).
 - `user`, `host`: who recorded it, where.

--- a/packages/search-py/python/search/__init__.py
+++ b/packages/search-py/python/search/__init__.py
@@ -8,36 +8,40 @@ agent/shell history across the fleet):
 * ``recent()`` lists the newest records (descending timestamp), no semantic
   scoring -- a deterministic "what happened lately" feed.
 
+Each is a coroutine returning a :class:`polars.DataFrame` (one row per hit), so
+``await`` it and compose ``.filter`` / ``.group_by`` / ``.sort`` / ``.head`` on
+the result, exactly like ``fff`` and ``view``::
+
+    df = await search.semantic("where is retry backoff configured")
+    df.select("path", "score", "timestamp").head()
+    df.group_by("source").len().sort("len", descending=True)
+
 None of them indexes: this is a pure query surface, so importing ``search``
 never uploads the local checkout. Scope a query server-side with any of
 ``source``, ``not_source``, ``repo``, ``user``, ``host``, ``project``, and a
 time window ``since``/``until`` (epoch seconds or relative spans like
 ``"24h"``/``"7d"``); with no selector the whole corpus is searched.
 
-    hits = await search.semantic("where is retry backoff configured")
-    for hit in hits:
-        print(hit["path"], hit["score"], hit.get("timestamp"))
-
     # only Claude history, only my records, last two weeks, token-frugal
-    hits = await search.semantic(
+    df = await search.semantic(
         "deploy steps", source=["claude_history"], user=["andrew"],
         since="2w", compact=True,
     )
 
     # my shell commands of the last six hours, newest first
-    rows = await search.recent(source=["shell"], user=["andrew"], since="6h")
+    df = await search.recent(source=["shell"], user=["andrew"], since="6h")
 
-    hits = await search.grep(r"fn \\w+\\(", source=["code"], repo="indexable-inc/index")
+    df = await search.grep(r"fn \\w+\\(", source=["code"], repo="indexable-inc/index")
 
-Each awaitable is a native asyncio coroutine bridged from Rust via
-pyo3-async-runtimes, so ``await`` it on your own event loop. Each hit is a dict
-with keys ``path``, ``score``, ``start_line``, ``num_lines``, ``text``, and
-``source``, plus provenance keys when the record carries them: ``timestamp``
-(epoch seconds), ``user``, ``host``, ``session_id``, ``external_id``, ``url``,
-``repo``, ``project``. Valid sources: ``claude_history``, ``codex``, ``shell``,
-``claude_debug``, ``git``, ``github``, ``slack``, ``linear``, ``code``,
-``web`` -- an unknown source raises ``ValueError`` instead of silently
-returning zero hits.
+Every frame has the same stable schema (so ``df["timestamp"]`` and
+``df.group_by("source")`` work even on an empty result): the six always-present
+columns ``path``, ``score``, ``start_line``, ``num_lines``, ``text``,
+``source``, then provenance columns ``timestamp`` (epoch seconds), ``user``,
+``host``, ``session_id``, ``external_id``, ``url``, ``repo``, ``project`` --
+null where a record does not carry them. Valid sources: ``claude_history``,
+``codex``, ``shell``, ``claude_debug``, ``git``, ``github``, ``slack``,
+``linear``, ``code``, ``web`` -- an unknown source raises ``ValueError``
+instead of silently returning zero hits.
 
 ``compact=True`` collapses repeated chunks of one document and caps snippets
 at 400 chars (a default ``top_k=10`` full response measured ~20k tokens).
@@ -50,6 +54,109 @@ written by ``mgrep login``.
 
 from __future__ import annotations
 
-from ._search import __version__, grep, recent, semantic
+import functools
+from typing import TYPE_CHECKING
+
+from ._search import __version__
+from ._search import grep as _grep
+from ._search import recent as _recent
+from ._search import semantic as _semantic
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    import polars as pl
+
+    _Raw = Callable[..., Awaitable[list[dict[str, object]]]]
+    _Framed = Callable[..., Awaitable[pl.DataFrame]]
 
 __all__ = ["__version__", "grep", "recent", "semantic"]
+
+# The stable column set, in display order: the six fields every hit carries,
+# then the provenance fields a record may or may not carry. Enforced on every
+# result so callers can rely on the schema even when the result is empty or a
+# provenance key is absent from every row.
+_COLUMNS: tuple[str, ...] = (
+    "path",
+    "score",
+    "start_line",
+    "num_lines",
+    "text",
+    "source",
+    "timestamp",
+    "user",
+    "host",
+    "session_id",
+    "external_id",
+    "url",
+    "repo",
+    "project",
+)
+
+
+def _dtypes() -> dict[str, object]:
+    import polars as pl
+
+    return {
+        "path": pl.Utf8,
+        "score": pl.Float64,
+        "start_line": pl.Int64,
+        "num_lines": pl.Int64,
+        "text": pl.Utf8,
+        "source": pl.Utf8,
+        "timestamp": pl.Int64,
+        "user": pl.Utf8,
+        "host": pl.Utf8,
+        "session_id": pl.Utf8,
+        "external_id": pl.Utf8,
+        "url": pl.Utf8,
+        "repo": pl.Utf8,
+        "project": pl.Utf8,
+    }
+
+
+def _to_frame(rows: "list[dict[str, object]]") -> "pl.DataFrame":
+    try:
+        import polars as pl
+    except ModuleNotFoundError as exc:  # pragma: no cover - env always has polars
+        raise ModuleNotFoundError(
+            "search.semantic/grep/recent return polars DataFrames; "
+            "install polars to use them."
+        ) from exc
+
+    dtypes = _dtypes()
+    if not rows:
+        return pl.DataFrame(schema=dtypes)
+    df = pl.DataFrame(rows)
+    missing = [c for c in _COLUMNS if c not in df.columns]
+    if missing:
+        df = df.with_columns([pl.lit(None).cast(dtypes[c]).alias(c) for c in missing])
+    df = df.with_columns([pl.col(c).cast(dtypes[c]) for c in _COLUMNS])
+    # Standard columns first, in order; any unexpected key kept after them so a
+    # new provenance field is surfaced rather than silently dropped.
+    extra = [c for c in df.columns if c not in _COLUMNS]
+    return df.select([*_COLUMNS, *extra])
+
+
+def _framed(raw: "_Raw") -> "_Framed":
+    """Wrap a native PyO3 coroutine so awaiting it yields a polars DataFrame.
+
+    ``functools.wraps`` copies the binding's signature and docstring, so
+    ``help()`` and ``inspect.signature`` show the real parameters while
+    ``inspect.iscoroutinefunction`` reports ``True``.
+    """
+
+    @functools.wraps(raw)
+    async def wrapper(*args: object, **kwargs: object) -> "pl.DataFrame":
+        return _to_frame(await raw(*args, **kwargs))
+
+    wrapper.__doc__ = (raw.__doc__ or "") + (
+        "\n\nReturns a polars DataFrame (one row per hit) with the stable "
+        "schema documented on the `search` module."
+    )
+    return wrapper
+
+
+semantic = _framed(_semantic)
+grep = _framed(_grep)
+recent = _framed(_recent)

--- a/packages/search-py/python/search/_search.pyi
+++ b/packages/search-py/python/search/_search.pyi
@@ -3,7 +3,11 @@
 Hand-maintained to mirror packages/search-py/src/lib.rs. Keep in sync
 when changing the binding. `semantic`, `grep`, and `recent` each return a
 native asyncio-awaitable coroutine produced by pyo3-async-runtimes; awaiting it
-drives the underlying tokio future.
+drives the underlying tokio future and yields a `list[Hit]`.
+
+These are the private bindings. The public `search.semantic` / `grep` /
+`recent` (in `__init__.py`) wrap them: they are `async def`, so awaiting one
+yields a `polars.DataFrame` (one row per `Hit`) instead of the raw list.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What

`search.semantic` / `grep` / `recent` now return a polars `DataFrame` (one row
per hit) instead of a `list[dict]`, and are real `async def` coroutines.

Closes #1089 — the binding read as a sync `func` with no return annotation, so
nothing signalled `await` was required (`api()` tagged it `func`; calling it
gave `Future has no len()`).

Closes #1090 — a `list[dict]` renders with a polars `shape: (N, M)` header, so
it looked like a DataFrame; `.group_by` / `df["col"]` then raised. `fff` and
`view` already return frames, so the inconsistency invited the wrong guess.

## How

A thin Python wrapper in `python/search/__init__.py` wraps each PyO3 binding:

```python
@functools.wraps(raw)
async def wrapper(*args, **kwargs):
    return _to_frame(await raw(*args, **kwargs))
```

- `functools.wraps` preserves the binding's full signature + docstring, so
  `help()` / `inspect.signature` are unchanged, while `iscoroutinefunction` is
  now True and `api()` tags them `async`.
- `_to_frame` enforces a stable, typed 14-column schema (the six always-present
  fields + provenance columns, null where absent), so `df["timestamp"]` and
  `df.group_by("source")` work even on an empty result.
- No Rust change: the `_search` cdylib still returns `list[Hit]`; this is the
  Python boundary layer the package already owns.

## Validation

Built the package's `__init__.py` against the shipped `_search.abi3.so` in a
clean interpreter:

- `semantic` / `grep` / `recent` are all `iscoroutinefunction=True` with their
  full signatures intact.
- each returns a `(N, 14)` DataFrame; empty results return a typed `(0, 14)`
  frame; ragged provenance keys union and null-fill.
- `df.group_by("source")`, `df["timestamp"]`, dtype enforcement all hold.

Docs updated: `search-py/README.md`, the `registry.py` module catalog blurb,
`agent-context/sections/18-searching.md`, and the `_search.pyi` header.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return polars DataFrames from `search.semantic`, `search.grep`, and `search.recent`
> - Wraps the native PyO3 async functions with `_framed`, a decorator that converts `list[dict]` results to a polars DataFrame via `_to_frame`.
> - Enforces a stable column schema (`_COLUMNS`) with consistent ordering and correct dtypes; missing provenance columns are added as nulls.
> - Raises `ModuleNotFoundError` with a targeted message if polars is not installed.
> - Updates docs and MCP registry description to reflect the new DataFrame return type and show DataFrame operations like `.filter`, `.group_by`, and `.head`.
> - Behavioral Change: callers previously receiving `list[dict]` now receive a `polars.DataFrame`; polars becomes a required dependency at call time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6075c38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->