### PR TITLE
users/andrewgazelka: use indexPkgs.claude-code in home services (fix #1085)

### DIFF
--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -61,6 +61,13 @@
 let
   cfg = config.users.andrewgazelka;
 
+  # The index flake's package set for the *host* system. Use this (not the
+  # `pkgs.<name>` overlay attrs) for any index-built rust package: the overlay's
+  # `pkgs.claude-code` carries an x86_64-linux `config-launch` even on an
+  # aarch64-darwin host, so its install-check drags the whole x86_64-linux cargo
+  # unit graph (alsa-sys et al.) into a Mac home build, which real nix cannot
+  # place. `indexPkgs.claude-code` is the correctly host-targeted build.
+  # See indexable-inc/index#1085.
   indexPkgs = indexPackages pkgs.stdenv.hostPlatform.system;
 
   isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
@@ -99,7 +106,7 @@ let
       pkgs.jaq
       pkgs.sqlite
       sayDetached
-      pkgs.claude-code
+      indexPkgs.claude-code
       pkgs.coreutils
       pkgs.perl # the intrinsic non-overlap flock guard at the top of the script
       indexPkgs.bossbar
@@ -120,7 +127,7 @@ let
     runtimeInputs = [
       pkgs.gh
       pkgs.jq
-      pkgs.claude-code
+      indexPkgs.claude-code
       pkgs.coreutils
     ];
     text = builtins.readFile ./scripts/ci-triage.sh;


### PR DESCRIPTION
## What

Fixes #1085. On an **aarch64-darwin** home-manager build, evaluating
`services.portable.pr-watch.command` failed with:

```
error: Failed to find a machine for remote build!
  derivation: …-alsa-sys-0.4.0.drv
  required (system, features): (x86_64-linux, [])
```

## Root cause

`ci-triage` and `ix-downtime` (in `users/andrewgazelka/home.nix`) pulled
`pkgs.claude-code` — the **overlay** attr. The overlay binds
`ix.rustWorkspace` to the repo's fixed x86_64-linux pkgs
(`lib/default.nix`), so the overlay `claude-code` resolves its baked
`config-launch` launcher (`ix.rustWorkspace.units.binaries.config-launch`,
`packages/claude-code/default.nix:456`) to the **x86_64-linux** unit graph.
That graph instantiates the whole workspace's crate derivations, including the
Linux-only `alsa-sys`/`alsa` (gated on `targetIsLinux`). A Mac has no
x86_64-linux builder, so the whole `pr-watch` eval fails.

`indexPkgs.claude-code` (= `index.packages.${hostSystem}.claude-code`,
`lib/packages.nix` rebinds `rustWorkspace` to the host pkgs) resolves
`config-launch` to the native aarch64-darwin graph — no alsa.

## Fix

Switch the two services to `indexPkgs.claude-code`, matching how this module
already sources `bossbar` / `bossbar-overlay` via `indexPkgs`. One-line swap
(×2) plus an explanatory comment.

## Verification

Reproduced on `main`, then re-evaluated with this branch:

```
$ nix eval --json '…homeConfigurations."andrewgazelka@hydra".config.services.portable.pr-watch.command' \
    --override-input index 'git+file://…?ref=fix-1085-portable-platform&shallow=1'
EXIT=0
x86_64-linux refs: 0
["…/bin/pr-watch"]
```

Clean eval, zero x86_64-linux derivations. Host-targeted
`packages.aarch64-darwin.claude-code` (which carries `config-launch`) builds
clean on this Mac.

## Note (follow-up, not fixed here)

The deeper latent bug is that the overlay's `pkgs.claude-code` carries a
foreign-arch `config-launch` on darwin (a darwin stdenv package bundling an
x86_64-linux binary). Any darwin consumer of `pkgs.claude-code` hits this. The
overlay's `rustWorkspace` binding should follow the consuming pkgs' system;
left for a maintainer who owns the overlay/lib assembly.

---
*(sent by an AI agent via Claude Code, Opus 4.8)*


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch `claude-code` to use `indexPkgs` in andrewgazelka's home services
> Replaces `pkgs.claude-code` with `indexPkgs.claude-code` in [home.nix](https://github.com/indexable-inc/index/pull/1092/files#diff-b9c7bb705f699ec210f648820aef5c561583845b682d07d6e1dc19de7685cb0f), where `indexPkgs` is derived from `indexPackages` scoped to the host platform. This ensures `claude-code` is selected from the host-targeted index package set rather than the default package set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8beb8e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->