### PR TITLE
tmux: enable Claude Code truecolor inside tmux

### DIFF
--- a/packages/tmux/tmux.conf
+++ b/packages/tmux/tmux.conf
@@ -9,6 +9,11 @@
 set -g  default-terminal "tmux-256color"
 set -as terminal-features ",*:RGB"      # 24-bit truecolor passthrough
 set -as terminal-features ",*:usstyle"  # colored / curly underlines (undercurl)
+# Claude Code defensively clamps its own rendering to 256-color whenever $TMUX is
+# set (colorize.ts clampChalkLevelForTmux; anthropics/claude-code#36785), ignoring
+# COLORTERM/FORCE_COLOR, which dulls its TUI inside tmux. We pass real truecolor
+# above, so flip its documented escape hatch on for every pane.
+set-environment -g CLAUDE_CODE_TMUX_TRUECOLOR 1
 
 # ── Responsiveness ──────────────────────────────────────────────────────
 set -sg escape-time 10   # don't treat a lone <Esc> as a key prefix (nvim lag)


### PR DESCRIPTION
## What

Add `set-environment -g CLAUDE_CODE_TMUX_TRUECOLOR 1` to the baked default tmux config (`packages/tmux/tmux.conf`).

## Why

Claude Code defensively clamps its **own** rendering to 256-color whenever `$TMUX` is set (`src/ink/colorize.ts` `clampChalkLevelForTmux`), ignoring `COLORTERM=truecolor` and `FORCE_COLOR=3`. Upstream: anthropics/claude-code#36785 (dupes: #35148, #32365, #59867, #60788). Our default tmux already advertises real RGB passthrough (`terminal-features ,*:RGB`), so the clamp only dulls Claude's TUI for no reason.

`CLAUDE_CODE_TMUX_TRUECOLOR=1` is the documented escape hatch that disables the clamp; it must be a real env var at process launch (read at module load), so `set-environment -g` in the tmux config is the right place: every pane inherits it.

## Proof

In a real tmux with an RGB client attached, captured the bytes tmux sends to the client:

| | truecolor codes from Claude |
|---|---|
| clamp active (before) | 0 |
| escape hatch (after) | 58, incl. off-cube hues like `38;2;255;193;7` |

```mermaid
flowchart LR
  A[Claude chalk level 3] -->|$TMUX set| B{clamp}
  B -->|no hatch| C[level 2: 256-color, dull]
  B -->|CLAUDE_CODE_TMUX_TRUECOLOR=1| D[level 3: 24-bit]
  D --> E[tmux RGB passthrough] --> F[terminal]
```

Built locally: `nix build .#packages.aarch64-darwin.tmux^out` → baked conf contains the line.

(sent by an AI agent via Claude Code, model Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable Claude Code truecolor inside tmux by setting `CLAUDE_CODE_TMUX_TRUECOLOR`
> Sets `CLAUDE_CODE_TMUX_TRUECOLOR=1` as a global environment variable in [tmux.conf](https://github.com/indexable-inc/index/pull/1094/files#diff-1c3111300c99c1a7edc6d318fc645e45a2835e10c5d03aa663d144cb456a3a05) so all tmux panes and sessions expose this variable to Claude Code.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2e9acd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->