### PR TITLE
tmux: fix outputsToInstall so the wrapped package installs into profiles

### DIFF
--- a/packages/tmux/default.nix
+++ b/packages/tmux/default.nix
@@ -7,10 +7,16 @@
 # tmux with modern defaults baked in (truecolor, undercurl, mouse, vi copy mode,
 # sane history/escape-time). `-f` points at our config, which sources the user's
 # own ~/.config/tmux/tmux.conf last so personal settings still win. symlinkJoin
-# (not a bare wrapper) keeps tmux's man pages and the rest of the output intact.
+# (not a bare wrapper) folds tmux's man pages into the single `out` so they
+# survive the wrap.
 symlinkJoin {
   name = "tmux-${tmux.version}";
-  paths = [ tmux ];
+  # Include tmux.man explicitly: symlinkJoin only merges each input's default
+  # output, so without this the man pages (tmux's separate `man` output) are lost.
+  paths = [
+    tmux
+    tmux.man
+  ];
   nativeBuildInputs = [ makeWrapper ];
   postBuild = ''
     wrapProgram $out/bin/tmux --add-flags "-f ${./tmux.conf}"
@@ -18,5 +24,9 @@ symlinkJoin {
   meta = tmux.meta // {
     description = "${tmux.meta.description}, with modern truecolor defaults baked in";
     mainProgram = "tmux";
+    # This derivation has only `out` (man pages folded in above). Base tmux's
+    # meta lists outputsToInstall = [ "out" "man" ]; keeping `man` makes buildenv
+    # (e.g. home.packages) try to read a nonexistent `man` output and fail.
+    outputsToInstall = [ "out" ];
   };
 }


### PR DESCRIPTION
## Bug

The wrapped `tmux` (`packages/tmux`) builds via `.#tmux^out` but **fails to install into any profile**. `symlinkJoin` yields a single `out`, yet `meta = tmux.meta // {…}` inherits base tmux's `outputsToInstall = [ "out" "man" ]`. When a buildenv enumerates outputs (`home.packages`, `nix profile install`) it evaluates `drv.man` and dies:

```
error: attribute 'man' missing
  pkgs/build-support/buildenv/default.nix:123  map (outName: drv.${outName}) drv.meta.outputsToInstall
```

Hit while adding `index…tmux` to a home-manager `home.packages`.

## Fix

- `outputsToInstall = [ "out" ]` — this derivation only has `out`.
- Add `tmux.man` to `paths`: `symlinkJoin` only merges each input's *default* output, so the man pages the header comment promised were actually being dropped. Now folded into `out`.

## Verify

```
nix build .#packages.aarch64-darwin.tmux   # all outputs enumerated — was the failing path, now OK
# → /nix/store/…-tmux-3.6a ; share/man/man1/tmux.1.gz present ; outputsToInstall = ["out"]
```

(sent by an AI agent via Claude Code, model Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tmux wrapped package to include man pages and set `outputsToInstall` correctly
> The tmux wrapper in [default.nix](https://github.com/indexable-inc/index/pull/1095/files#diff-d11268d6251c90b8d2bb17d518773ba884503125e72f6bef9f8eba58239c0db0) uses `symlinkJoin` to produce a single `out` output. Previously, man pages were excluded and `outputsToInstall` was not set, causing profile consumers to request a non-existent `man` output.
>
> - Expands `symlinkJoin` paths to include both `tmux` and `tmux.man`, merging man pages into `out`.
> - Sets `meta.outputsToInstall = [ "out" ]` so consumers don't attempt to install a `man` output that doesn't exist on the wrapper derivation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c0e3d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->