### PR TITLE
dashboard: Obsidian redesign + standalone recursive Namespace + run intents

### DIFF
--- a/packages/dashboard-core/site/src/App.svelte
+++ b/packages/dashboard-core/site/src/App.svelte
@@ -7,6 +7,7 @@
   import { seedDemo } from '$lib/demo';
   import Board from '$components/Board.svelte';
   import FeedView from '$components/FeedView.svelte';
+  import NamespaceView from '$components/NamespaceView.svelte';
   import FocusView from '$components/FocusView.svelte';
   import Timeline from '$components/Timeline.svelte';
 
@@ -25,28 +26,57 @@
     if (document.fonts?.ready) document.fonts.ready.then(refreshRatio);
     return onThemeChange(bumpTheme);
   });
+
+  // The icon rail's tabs, in order. Each drives the top-level view; the SVG is a
+  // minimal 1.7px-stroke glyph so the rail stays quiet.
+  const tabs = [
+    { view: 'feed' as const, label: 'Jobs' },
+    { view: 'namespace' as const, label: 'Namespace' },
+    { view: 'board' as const, label: 'Board' },
+  ];
 </script>
 
-<div class="topbar">
-  <span class="mark">ix<span class="accent">·dashboard</span></span>
-  <span class="dot" class:live={store.live}></span>
-  <span class="viewseg">
-    <button class:on={ui.view === 'feed'} onclick={() => setView('feed')}>feed</button>
-    <button class:on={ui.view === 'board'} onclick={() => setView('board')}>board</button>
-  </span>
-  <span class="spacer"></span>
-  <span class="stat">{store.status}</span>
-</div>
+<!-- The Obsidian shell: a thin icon rail on the left drives the view; the
+     workspace (the active surface + the shared timeline) fills the rest. -->
+<nav class="rail">
+  <div class="rail-logo">ix</div>
+  {#each tabs as t (t.view)}
+    <button
+      class="rail-btn"
+      class:on={ui.view === t.view}
+      title={t.label}
+      aria-label={t.label}
+      aria-current={ui.view === t.view}
+      onclick={() => setView(t.view)}
+    >
+      {#if t.view === 'feed'}
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="3" y="4" width="18" height="4" rx="1" /><rect x="3" y="11" width="18" height="4" rx="1" /><rect x="3" y="18" width="18" height="3" rx="1" /></svg>
+      {:else if t.view === 'namespace'}
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 3 3 7.5v9L12 21l9-4.5v-9L12 3zM3 7.5 12 12l9-4.5M12 12v9" /></svg>
+      {:else}
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="3" y="3" width="7" height="7" rx="1" /><rect x="14" y="3" width="7" height="7" rx="1" /><rect x="3" y="14" width="7" height="7" rx="1" /><rect x="14" y="14" width="7" height="7" rx="1" /></svg>
+      {/if}
+    </button>
+  {/each}
+  <div class="rail-spacer"></div>
+  <div class="rail-health" title={store.live ? 'connected' : store.status}>
+    <span class="rail-pulse" class:live={store.live}></span>
+  </div>
+</nav>
 
-<div class="stage">
-  {#if ui.view === 'feed'}
-    <FeedView />
-  {:else}
-    <Board />
-  {/if}
-  <!-- The fullscreen single-pane view overlays either surface, opened from a feed
-       entry or a board card. -->
-  {#if ui.focusKey}<FocusView />{/if}
-</div>
+<div class="workspace">
+  <div class="stage">
+    {#if ui.view === 'feed'}
+      <FeedView />
+    {:else if ui.view === 'namespace'}
+      <NamespaceView />
+    {:else}
+      <Board />
+    {/if}
+    <!-- The fullscreen single-pane view overlays the active surface, opened from a
+         feed entry or a board card. -->
+    {#if ui.focusKey}<FocusView />{/if}
+  </div>
 
-<Timeline />
+  <Timeline />
+</div>

--- a/packages/dashboard-core/site/src/components/FeedView.svelte
+++ b/packages/dashboard-core/site/src/components/FeedView.svelte
@@ -88,9 +88,24 @@
     showCode[key] = !showCode[key];
   }
 
+  // The short run id from a pane key (`scope<0x1f>id`): the trailing id, shown as
+  // quiet meta so a human can still correlate a row to a `jobs['<id>']` without it
+  // being the headline (the title/intent is).
+  function shortId(key: string): string {
+    const sep = key.indexOf(SCOPE_SEP);
+    const id = sep === -1 ? key : key.slice(sep + 1);
+    return id.includes('/') ? id.slice(id.lastIndexOf('/') + 1) : id;
+  }
+
+  // A namespace pane (the kernel's live globals) is not a run — it has its own
+  // rail view, so it must never appear interleaved in the chronological feed.
+  function isNamespace(p: Pane): boolean {
+    return (p.kind ?? 'data') === 'data' && p.renderer === 'namespace';
+  }
+
   // Panes oldest-first, so the newest run lands at the bottom and the list reads
   // as a live log that grows downward. created_at is the stamp; ties break by key
-  // for stability.
+  // for stability. Namespace panes are excluded — they belong to the Namespace view.
   const items = $derived(
     Object.keys(store.panes)
       .map((key) => {
@@ -98,11 +113,15 @@
         const scope = sep === -1 ? '' : key.slice(0, sep);
         return { key, pane: { ...store.panes[key], key, scope } as Pane };
       })
+      .filter((it) => !isNamespace(it.pane))
       .sort(
         (a, b) =>
           (a.pane.created_at ?? 0) - (b.pane.created_at ?? 0) || (a.key < b.key ? -1 : 1),
       ),
   );
+
+  // How many runs are currently executing, for the header's active badge.
+  const activeCount = $derived(items.filter((it) => ledRun(it.pane)).length);
 
   // Vim navigation: `j`/`k` move the selection down/up; the detail panel follows.
   // `o` (or Enter) toggles the source inside the detail. Selection follows clicks
@@ -157,7 +176,13 @@
 
 <svelte:window onkeydown={onKeydown} />
 
-<div class="feed feed-split">
+<div class="feedview">
+  <header class="view-head">
+    <h1 class="view-title">Jobs</h1>
+    {#if items.length}<span class="view-meta">{items.length} {items.length === 1 ? 'run' : 'runs'}</span>{/if}
+    {#if activeCount}<span class="view-active"><i></i>{activeCount} active</span>{/if}
+  </header>
+  <div class="feed feed-split">
   {#if items.length === 0}
     <div class="feed-empty">{store.live ? 'no panes yet' : 'connecting…'}</div>
   {:else}
@@ -171,7 +196,10 @@
         <li class="entry" class:err={isErr} class:selected={selectedKey === it.key} data-key={it.key}>
           <button class="entry-row" onclick={() => (selectedKey = it.key)} title={`${tag(p)}${p.subtitle ? ' · ' + p.subtitle : ''}`}>
             <span class="entry-dot" class:live={ledLive(p)} class:run={running} class:err={isErr}></span>
-            <span class="entry-title" title={p.title}>{p.title || '(pane)'}</span>
+            <span class="entry-main">
+              <span class="entry-title" title={p.title}>{p.title || '(pane)'}</span>
+              <span class="entry-sub">{shortId(it.key)}<span class="entry-sub-tag"> · {tag(p)}</span></span>
+            </span>
             {#if running}
               <span class="entry-now">running</span>
             {:else if p.duration_ms != null}
@@ -252,4 +280,5 @@
       {/if}
     </div>
   {/if}
+  </div>
 </div>

--- a/packages/dashboard-core/site/src/components/NamespaceBody.svelte
+++ b/packages/dashboard-core/site/src/components/NamespaceBody.svelte
@@ -1,145 +1,70 @@
 <script lang="ts">
-  import type { Pane } from '$lib/types';
-
   // The namespace renderer: a `data` pane whose body is a JSON array of variable
-  // rows produced by the kernel — one Python session's live globals. Each row is
-  // {name, type, kind, repr, size, shape}; we render them as a compact table, the
-  // heaviest first (the producer sorts), so the eye lands on what holds the memory.
-  type Row = {
-    name: string;
-    type: string;
-    kind: string;
-    repr: string;
-    size: number;
-    shape: string;
-  };
+  // rows produced by the kernel (`introspect.namespace_rows`) — one Python
+  // session's live globals. Rows are bucketed into Data / Modules / Functions and
+  // rendered as an expandable tree (containers drill into their members), heaviest
+  // first within each group, so the eye lands on what holds the memory.
+  import type { Pane } from '$lib/types';
+  import { groupOf, NS_GROUPS, parseRows, type NsGroup, type NsRow as Row } from '$lib/namespace';
+  import NsRow from './NsRow.svelte';
 
   let { pane }: { pane: Pane } = $props();
 
-  const rows = $derived.by<Row[]>(() => {
-    try {
-      const parsed = JSON.parse(pane.body ?? '[]');
-      return Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return [];
-    }
+  const rows = $derived(parseRows(pane.body));
+
+  // Group preserving the producer's heaviest-first order within each bucket.
+  const groups = $derived.by<{ name: NsGroup; rows: Row[] }[]>(() => {
+    const by: Record<NsGroup, Row[]> = { Data: [], Modules: [], Functions: [] };
+    for (const row of rows) by[groupOf(row)].push(row);
+    return NS_GROUPS.map((name) => ({ name, rows: by[name] })).filter((g) => g.rows.length > 0);
   });
-
-  // A short chip per kind so the lead column stays narrow and scannable.
-  const CHIP: Record<string, string> = {
-    module: 'mod',
-    class: 'cls',
-    function: 'fn',
-    scalar: 'num',
-    text: 'str',
-    sequence: 'seq',
-    mapping: 'map',
-    array: 'arr',
-    frame: 'df',
-    object: 'obj',
-  };
-  function chip(kind: string): string {
-    return CHIP[kind] ?? kind.slice(0, 3);
-  }
-
-  // Human byte size; empty for the sizeless (modules, functions report 0).
-  function fmtSize(n: number): string {
-    if (!n) return '';
-    if (n < 1024) return `${n} B`;
-    if (n < 1024 * 1024) return `${(n / 1024).toFixed(n < 10 * 1024 ? 1 : 0)} KB`;
-    if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
-    return `${(n / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-  }
-
-  // The middle column: a frame/array describes itself by shape; everything else
-  // shows its repr, falling back to a shape (a container's length).
-  function detail(row: Row): string {
-    if (row.shape && (row.kind === 'frame' || row.kind === 'array')) return row.shape;
-    return row.repr || row.shape;
-  }
 </script>
 
 <div class="ns">
   {#if rows.length === 0}
     <div class="ns-empty">no variables</div>
   {:else}
-    <table class="ns-table">
-      <tbody>
-        {#each rows as row (row.name)}
-          <tr>
-            <td class="ns-kind">
-              <span class="ns-chip" data-kind={row.kind}>{chip(row.kind)}</span>
-            </td>
-            <td class="ns-name" title={row.type}>{row.name}</td>
-            <td class="ns-detail" title={detail(row)}>{detail(row)}</td>
-            <td class="ns-size">{fmtSize(row.size)}</td>
-          </tr>
+    {#each groups as group (group.name)}
+      <div class="ns-group">
+        <div class="ns-grouphead">{group.name}<span class="ns-groupn">{group.rows.length}</span></div>
+        {#each group.rows as row, i (row.name + ':' + i)}
+          <NsRow {row} />
         {/each}
-      </tbody>
-    </table>
+      </div>
+    {/each}
   {/if}
 </div>
 
 <style>
   .ns {
-    padding: 4px 0;
-    font-family: var(--mono);
-    font-size: 12px;
-    line-height: 1.5;
+    padding: 4px 0 8px;
   }
   .ns-empty {
-    padding: 8px 12px;
+    padding: 10px 14px;
     color: var(--ink-faint);
+    font-family: var(--mono);
+    font-size: 12px;
     font-style: italic;
   }
-  .ns-table {
-    width: 100%;
-    border-collapse: collapse;
+  .ns-group + .ns-group {
+    margin-top: 6px;
   }
-  .ns-table td {
-    padding: 5px 12px;
-    vertical-align: baseline;
-    border-bottom: 1px solid var(--edge);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .ns-table tr:last-child td {
-    border-bottom: 0;
-  }
-  /* A quiet, square chip — flat like the rest of the canvas. */
-  .ns-kind {
-    width: 1%;
-  }
-  .ns-chip {
-    display: inline-block;
-    min-width: 2.6em;
-    text-align: center;
+  /* A quiet section label, the same uppercase micro-heading the rest of the app
+     uses for groups. */
+  .ns-grouphead {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 10px 14px 6px;
     font-size: 10px;
-    letter-spacing: 0.02em;
-    color: var(--ink-faint);
-    border: 1px solid var(--edge-strong);
-    padding: 0 4px;
-  }
-  /* Frames and arrays carry the data weight; tint them with the accent. */
-  .ns-chip[data-kind='frame'],
-  .ns-chip[data-kind='array'] {
-    color: var(--accent);
-    border-color: var(--accent);
-  }
-  .ns-name {
-    width: 1%;
-    color: var(--ink);
-  }
-  .ns-detail {
-    width: 100%;
-    max-width: 0;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
     color: var(--ink-faint);
   }
-  .ns-size {
-    width: 1%;
-    text-align: right;
-    color: var(--ink-dim);
+  .ns-groupn {
+    color: var(--ink-faint);
+    opacity: 0.6;
     font-variant-numeric: tabular-nums;
   }
 </style>

--- a/packages/dashboard-core/site/src/components/NamespaceView.svelte
+++ b/packages/dashboard-core/site/src/components/NamespaceView.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  // The Namespace rail view: the kernel's live globals, browsable on their own
+  // surface instead of interleaved into the run feed. Collects every namespace
+  // `data` pane (one per Python session) and renders each as an expandable tree.
+  import { store, SCOPE_SEP } from '$lib/stream.svelte';
+  import { parseRows } from '$lib/namespace';
+  import type { Pane } from '$lib/types';
+  import NamespaceBody from './NamespaceBody.svelte';
+
+  // Every namespace pane, oldest scope first for a stable order. A namespace pane
+  // is a `data` pane with the `namespace` renderer (see introspect / pane_bridge).
+  const sessions = $derived(
+    Object.keys(store.panes)
+      .map((key) => {
+        const sep = key.indexOf(SCOPE_SEP);
+        const scope = sep === -1 ? '' : key.slice(0, sep);
+        return { key, pane: { ...store.panes[key], key, scope } as Pane };
+      })
+      .filter((it) => (it.pane.kind ?? 'data') === 'data' && it.pane.renderer === 'namespace')
+      .sort((a, b) => (a.key < b.key ? -1 : 1)),
+  );
+
+  // Total top-level names across sessions, for the header count.
+  const total = $derived(sessions.reduce((n, s) => n + parseRows(s.pane.body).length, 0));
+</script>
+
+<div class="nsview">
+  <header class="view-head">
+    <h1 class="view-title">Namespace</h1>
+    {#if total > 0}<span class="view-meta">{total} {total === 1 ? 'name' : 'names'}</span>{/if}
+  </header>
+
+  <div class="nsview-body">
+    {#if sessions.length === 0}
+      <div class="view-empty">{store.live ? 'no live namespace' : 'connecting…'}</div>
+    {:else}
+      {#each sessions as s (s.key)}
+        {#if sessions.length > 1}
+          <div class="nsview-session">{s.pane.subtitle || s.pane.scope || 'session'}</div>
+        {/if}
+        <NamespaceBody pane={s.pane} />
+      {/each}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .nsview {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg);
+  }
+  .nsview-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
+    /* The tree centers in a readable measure rather than stretching edge-to-edge
+       on a wide window. */
+    padding: 6px clamp(8px, 2vw, 20px) 40px;
+  }
+  .nsview-body > :global(.ns) {
+    max-width: 880px;
+    margin: 0 auto;
+  }
+  .nsview-session {
+    max-width: 880px;
+    margin: 14px auto 0;
+    padding: 0 14px;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--ink-dim);
+  }
+</style>

--- a/packages/dashboard-core/site/src/components/NsRow.svelte
+++ b/packages/dashboard-core/site/src/components/NsRow.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  // One namespace row, rendered recursively: a container (dict/list/object) shows a
+  // caret and expands its `children` inline, each child the same row one level
+  // deeper. Leaves have no caret. Open state is local, so expanding one branch
+  // never disturbs another.
+  import { chip, fmtSize, detail, type NsRow as Row } from '$lib/namespace';
+  // Svelte 5 expresses recursion by importing the component itself rather than the
+  // old <svelte:self>.
+  import Self from './NsRow.svelte';
+
+  let { row, depth = 0 }: { row: Row; depth?: number } = $props();
+
+  const hasChildren = $derived(!!row.children && row.children.length > 0);
+  let open = $state(false);
+
+  function toggle(): void {
+    if (hasChildren) open = !open;
+  }
+</script>
+
+<div class="nsrow">
+  <button
+    class="nsrow-line"
+    class:has-children={hasChildren}
+    style="padding-left: {12 + depth * 15}px"
+    onclick={toggle}
+    aria-expanded={hasChildren ? open : undefined}
+  >
+    <span class="nsrow-caret" class:open class:hidden={!hasChildren}>›</span>
+    <span class="ns-chip" data-kind={row.kind}>{chip(row.kind)}</span>
+    <span class="nsrow-name" title={row.type}>{row.name}</span>
+    <span class="nsrow-detail" title={detail(row)}>{detail(row)}</span>
+    <span class="nsrow-size">{fmtSize(row.size)}</span>
+  </button>
+
+  {#if open && row.children}
+    {#each row.children as child, i (child.name + ':' + i)}
+      <Self row={child} depth={depth + 1} />
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .nsrow-line {
+    display: grid;
+    grid-template-columns: 14px 2.6em minmax(0, auto) minmax(0, 1fr) auto;
+    align-items: baseline;
+    column-gap: 10px;
+    width: 100%;
+    padding: 5px 12px;
+    font: inherit;
+    font-family: var(--mono);
+    font-size: 12px;
+    text-align: left;
+    color: var(--ink);
+    background: none;
+    border: 0;
+    border-radius: 7px;
+    cursor: default;
+    transition: background 0.12s ease;
+  }
+  .nsrow-line.has-children {
+    cursor: pointer;
+  }
+  .nsrow-line.has-children:hover {
+    background: var(--panel);
+  }
+  /* The caret: a quiet chevron that rotates open. Hidden (but space-preserving) on
+     leaves so every row's chip/name column stays aligned. */
+  .nsrow-caret {
+    justify-self: center;
+    color: var(--ink-faint);
+    transition: transform 0.12s ease;
+    transform: rotate(0deg);
+    user-select: none;
+  }
+  .nsrow-caret.open {
+    transform: rotate(90deg);
+  }
+  .nsrow-caret.hidden {
+    visibility: hidden;
+  }
+  .nsrow-name {
+    min-width: 0;
+    color: var(--ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .nsrow-detail {
+    min-width: 0;
+    color: var(--ink-faint);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .nsrow-size {
+    text-align: right;
+    color: var(--ink-dim);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+</style>

--- a/packages/dashboard-core/site/src/lib/demo.ts
+++ b/packages/dashboard-core/site/src/lib/demo.ts
@@ -90,7 +90,50 @@ export function seedDemo(): void {
         { name: 'X_train', type: 'ndarray', kind: 'array', repr: '', size: 156_800_000, shape: '50000×784' },
         { name: 'df', type: 'DataFrame', kind: 'frame', repr: '', size: 84_000_000, shape: '1204853×8' },
         { name: 'model', type: 'Sequential', kind: 'object', repr: '<Sequential: 4 layers>', size: 4_800_000, shape: '' },
-        { name: 'results', type: 'list', kind: 'sequence', repr: '[{...}, {...}, ...]', size: 31_700, shape: 'len 20' },
+        // A mapping with nested children, to exercise the recursive tree: `config`
+        // holds a nested `paths` dict (expandable two levels deep).
+        {
+          name: 'config',
+          type: 'dict',
+          kind: 'mapping',
+          repr: "{'lr': 0.001, 'paths': {...}, ...}",
+          size: 1_240,
+          shape: 'len 4',
+          children: [
+            { name: "'lr'", type: 'float', kind: 'scalar', repr: '0.001', size: 24, shape: '' },
+            { name: "'epochs'", type: 'int', kind: 'scalar', repr: '10', size: 28, shape: '' },
+            {
+              name: "'paths'",
+              type: 'dict',
+              kind: 'mapping',
+              repr: "{'data': '/mnt/data', 'ckpt': '/mnt/ckpt'}",
+              size: 320,
+              shape: 'len 2',
+              children: [
+                { name: "'data'", type: 'str', kind: 'text', repr: "'/mnt/data'", size: 58, shape: '' },
+                { name: "'ckpt'", type: 'str', kind: 'text', repr: "'/mnt/ckpt'", size: 58, shape: '' },
+              ],
+            },
+            { name: "'tags'", type: 'list', kind: 'sequence', repr: "['a', 'b']", size: 120, shape: 'len 2',
+              children: [
+                { name: '[0]', type: 'str', kind: 'text', repr: "'a'", size: 50, shape: '' },
+                { name: '[1]', type: 'str', kind: 'text', repr: "'b'", size: 50, shape: '' },
+              ] },
+          ],
+        },
+        {
+          name: 'results',
+          type: 'list',
+          kind: 'sequence',
+          repr: '[{...}, {...}, ...]',
+          size: 31_700,
+          shape: 'len 20',
+          children: [
+            { name: '[0]', type: 'dict', kind: 'mapping', repr: "{'id': 0, 'score': 0.91}", size: 232, shape: 'len 2' },
+            { name: '[1]', type: 'dict', kind: 'mapping', repr: "{'id': 1, 'score': 0.88}", size: 232, shape: 'len 2' },
+            { name: '…', type: '', kind: 'object', repr: '+18 more', size: 0, shape: '' },
+          ],
+        },
         { name: 'result', type: 'int', kind: 'scalar', repr: '4', size: 28, shape: '' },
         { name: 'pl', type: 'module', kind: 'module', repr: 'polars 1.12.0', size: 0, shape: '' },
         { name: 'embed', type: 'function', kind: 'function', repr: '<function embed>', size: 0, shape: '' },

--- a/packages/dashboard-core/site/src/lib/namespace.ts
+++ b/packages/dashboard-core/site/src/lib/namespace.ts
@@ -1,0 +1,72 @@
+// Shared helpers for the namespace browser: the row shape the kernel publishes
+// (`introspect.namespace_rows`), and the formatting both the inline body and the
+// full rail view use, so there is one implementation of "how a variable reads".
+
+// One variable (or, recursively, one member of a container). `children` is present
+// only for expandable containers (dict/list/object), depth- and breadth-bounded by
+// the producer; a single trailing `+N more` elision row may appear among them.
+export interface NsRow {
+  name: string;
+  type: string;
+  kind: string;
+  repr: string;
+  size: number;
+  shape: string;
+  children?: NsRow[];
+}
+
+// A short chip per kind so the lead column stays narrow and scannable.
+const CHIP: Record<string, string> = {
+  module: 'mod',
+  class: 'cls',
+  function: 'fn',
+  scalar: 'num',
+  text: 'str',
+  sequence: 'seq',
+  mapping: 'map',
+  array: 'arr',
+  frame: 'df',
+  object: 'obj',
+};
+
+export function chip(kind: string): string {
+  return CHIP[kind] ?? kind.slice(0, 3);
+}
+
+// Human byte size; empty for the sizeless (modules, functions report 0).
+export function fmtSize(n: number): string {
+  if (!n) return '';
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(n < 10 * 1024 ? 1 : 0)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+// The middle column: a frame/array describes itself by shape; everything else
+// shows its repr, falling back to a shape (a container's length).
+export function detail(row: NsRow): string {
+  if (row.shape && (row.kind === 'frame' || row.kind === 'array')) return row.shape;
+  return row.repr || row.shape;
+}
+
+// The three top-level groups the view buckets names into, in display order.
+export type NsGroup = 'Data' | 'Modules' | 'Functions';
+export const NS_GROUPS: readonly NsGroup[] = ['Data', 'Modules', 'Functions'];
+
+// Which group a row belongs to: modules and functions/classes are shared machinery,
+// everything else is the data the session holds.
+export function groupOf(row: NsRow): NsGroup {
+  if (row.kind === 'module') return 'Modules';
+  if (row.kind === 'function' || row.kind === 'class') return 'Functions';
+  return 'Data';
+}
+
+// Parse a namespace pane's JSON body into rows; malformed/absent → none.
+export function parseRows(body: string | undefined): NsRow[] {
+  try {
+    const parsed = JSON.parse(body ?? '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}

--- a/packages/dashboard-core/site/src/lib/ui.svelte.ts
+++ b/packages/dashboard-core/site/src/lib/ui.svelte.ts
@@ -2,15 +2,18 @@
 // view) and a once-a-second clock so every card's age stays current without each
 // card holding its own timer.
 
-// The feed (a single chronological column of output) or the board (free canvas).
-// Feed is the default: most of the time you just want to read the stream of
-// outputs top to bottom, with nothing competing for attention. Persisted.
-export type View = 'feed' | 'board';
+// The top-level surface: the run feed (a chronological master-detail of runs),
+// the namespace browser (the kernel's live globals, recursively expandable), or
+// the board (free canvas). Feed is the default: most of the time you just want to
+// read the stream of runs, with nothing competing for attention. Persisted.
+export type View = 'feed' | 'namespace' | 'board';
 const VIEW_KEY = 'dash-view-v1';
+const VIEWS: readonly View[] = ['feed', 'namespace', 'board'];
 
 function loadView(): View {
   try {
-    return localStorage.getItem(VIEW_KEY) === 'board' ? 'board' : 'feed';
+    const saved = localStorage.getItem(VIEW_KEY) as View | null;
+    return saved && VIEWS.includes(saved) ? saved : 'feed';
   } catch {
     return 'feed';
   }

--- a/packages/dashboard-core/site/src/style.css
+++ b/packages/dashboard-core/site/src/style.css
@@ -1,25 +1,35 @@
 :root {
   color-scheme: light dark;
 
-  /* Each token carries both schemes via light-dark(): the light value is taken
-     from the user's ghostty ~/.config/nix/ghostty/themes/custom-light, the dark
-     value from custom-dark. Each card is a ghostty surface (--panel) on a
-     slightly darker board. */
-  --bg: light-dark(#ececec, #151515);
-  --panel: light-dark(#f9f9f9, #1e1e1e);
-  --edge: light-dark(#dcdcdc, #2a2a2a);
-  --edge-strong: light-dark(#c4c4c4, #3a3a3a);
-  --ink: light-dark(#2a2c33, #d4d4d4);
-  --ink-dim: light-dark(#6a6c72, #808080);
-  --ink-faint: light-dark(#8f9096, #585b70);
-  --live: light-dark(#42933e, #a6e3a1);
-  --dead: light-dark(#db3f39, #f38ba8);
-  --accent: light-dark(#325eee, #89b4fa);
-  --cursor: light-dark(#bbbbbb, #f5e0dc);
-  --sel: light-dark(#e9e9e9, #313244);
+  /* The "Obsidian" palette: dark is near-black, flat, with one periwinkle accent;
+     light is a calm near-monochrome paper. Each token carries both schemes via
+     light-dark(). Surfaces step bg -> panel -> elev (board, card, raised); the
+     only saturated colors are the accent and the status/kind hues below. */
+  --bg:          light-dark(#f4f4f5, #08080a);
+  --panel:       light-dark(#fbfbfc, #0d0d10);
+  --elev:        light-dark(#ffffff, #141417);
+  --edge:        light-dark(#e6e6e9, #18181b);
+  --edge-strong: light-dark(#d3d3d8, #242429);
+  --ink:         light-dark(#1b1c21, #ececef);
+  --ink-dim:     light-dark(#5c5e66, #82828c);
+  --ink-faint:   light-dark(#9a9ba2, #4a4a53);
+  --live:        light-dark(#3f9a52, #52c98e);
+  --dead:        light-dark(#cf4b46, #e0635b);
+  --accent:      light-dark(#5358e0, #a8b0ff);
+  /* A faint accent wash for selected fills and text selection. */
+  --accent-soft: light-dark(rgba(83, 88, 224, 0.10), rgba(168, 176, 255, 0.13));
+  --cursor:      light-dark(#9a9ba2, #a8b0ff);
+  --sel:         light-dark(#ededf0, #18181c);
   /* Faint dot grid on the board, so panning a mostly-empty canvas still reads
      as motion. */
-  --grid-dot: light-dark(#d7d7d7, #262626);
+  --grid-dot:    light-dark(#e2e2e5, #19191c);
+
+  /* Kind/status hues for namespace badges and chips — used sparingly, tinted. */
+  --k-green: light-dark(#3f9a52, #52c98e);
+  --k-amber: light-dark(#b4801f, #d6a44a);
+  --k-red:   light-dark(#cf4b46, #e0635b);
+  --k-blue:  light-dark(#3a6fd0, #7fb4ff);
+  --k-pink:  light-dark(#b85a9c, #e08fc7);
 
   --ui: ui-sans-serif, system-ui, -apple-system, 'SF Pro Text', Segoe UI, sans-serif;
   --mono: 'Berkeley Mono', ui-monospace, 'SF Mono', SFMono-Regular, 'JetBrains Mono', Menlo, Consolas, monospace;
@@ -30,10 +40,12 @@
 @supports not (color: light-dark(#000, #fff)) {
   @media (prefers-color-scheme: dark) {
     :root {
-      --bg: #151515; --panel: #1e1e1e; --edge: #2a2a2a; --edge-strong: #3a3a3a;
-      --ink: #d4d4d4; --ink-dim: #808080; --ink-faint: #585b70;
-      --live: #a6e3a1; --dead: #f38ba8; --accent: #89b4fa; --cursor: #f5e0dc;
-      --sel: #313244; --grid-dot: #262626;
+      --bg: #08080a; --panel: #0d0d10; --elev: #141417; --edge: #18181b; --edge-strong: #242429;
+      --ink: #ececef; --ink-dim: #82828c; --ink-faint: #4a4a53;
+      --live: #52c98e; --dead: #e0635b; --accent: #a8b0ff;
+      --accent-soft: rgba(168, 176, 255, 0.13); --cursor: #a8b0ff;
+      --sel: #18181c; --grid-dot: #19191c;
+      --k-green: #52c98e; --k-amber: #d6a44a; --k-red: #e0635b; --k-blue: #7fb4ff; --k-pink: #e08fc7;
     }
   }
 }
@@ -54,41 +66,59 @@ body {
      board can use wheel events for panning. */
   overscroll-behavior: none;
 }
-/* Column layout so the header and the board never overlap: the board takes the
-   remaining height and owns all panning within its own box. */
-#app { height: 100%; display: flex; flex-direction: column; }
-::selection { background: var(--sel); }
+/* The shell is a row: a fixed icon rail, then the workspace column (active
+   surface + the shared timeline at its foot). The workspace owns all scrolling
+   and panning within its own box. */
+#app { height: 100%; display: flex; flex-direction: row; }
+.workspace { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; }
+::selection { background: var(--accent-soft); }
 
-/* ----- header ----------------------------------------------------------- */
-.topbar {
-  flex: none;
-  display: flex; align-items: center; gap: 12px;
-  padding: 12px clamp(16px, 3vw, 32px);
-  background: var(--bg);
-  border-bottom: 1px solid var(--edge);
+/* ----- icon rail -------------------------------------------------------- */
+/* The one piece of persistent chrome: a thin column that drives the top-level
+   view. A logo, the view tabs (each a quiet glyph that lights up when active),
+   then a pulsing health dot pinned to the foot. */
+.rail {
+  flex: none; width: 56px;
+  display: flex; flex-direction: column; align-items: center;
+  gap: 4px; padding: 14px 0;
+  background: var(--bg); border-right: 1px solid var(--edge);
 }
-.topbar .mark {
-  font-family: var(--mono); font-weight: 600; font-size: 13.5px;
-  letter-spacing: 0.3px; color: var(--ink);
+.rail-logo {
+  width: 28px; height: 28px; margin-bottom: 10px;
+  display: grid; place-items: center;
+  background: var(--ink); color: var(--bg);
+  font-family: var(--mono); font-weight: 700; font-size: 12px; letter-spacing: 0.2px;
+  border-radius: 8px;
 }
-.topbar .mark .accent { color: var(--ink-faint); font-weight: 500; }
-.topbar .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--ink-faint); }
-.topbar .dot.live { background: var(--live); }
-.topbar .spacer { flex: 1; }
-.topbar .stat {
-  color: var(--ink-dim); font-variant-numeric: tabular-nums;
-  font-family: var(--mono); font-size: 11.5px; letter-spacing: 0.2px;
+.rail-btn {
+  position: relative; width: 36px; height: 36px;
+  display: grid; place-items: center;
+  background: none; border: 0; border-radius: 9px;
+  color: var(--ink-faint); cursor: pointer;
+  transition: color 0.12s ease, background 0.12s ease;
 }
-/* Flat, square segmented toggle between the stream and board views. */
-.viewseg { display: flex; margin-left: 4px; }
-.viewseg button {
-  font-family: var(--mono); font-size: 11px; color: var(--ink-dim);
-  background: var(--bg); border: 1px solid var(--edge); border-right-width: 0;
-  padding: 3px 10px; cursor: pointer;
+.rail-btn svg { width: 18px; height: 18px; }
+.rail-btn:hover { color: var(--ink-dim); background: var(--panel); }
+.rail-btn.on { color: var(--ink); }
+/* The active tab is marked by a short accent bar on the rail's edge, the one
+   place the accent appears in the chrome. */
+.rail-btn.on::before {
+  content: ""; position: absolute; left: -14px; top: 9px; bottom: 9px;
+  width: 2px; border-radius: 0 2px 2px 0; background: var(--accent);
 }
-.viewseg button:last-child { border-right-width: 1px; }
-.viewseg button:hover { color: var(--ink); }
-.viewseg button.on { color: var(--ink); background: var(--panel); border-color: var(--edge-strong); }
+.rail-spacer { flex: 1; }
+.rail-health { display: grid; place-items: center; padding-bottom: 2px; }
+.rail-pulse {
+  width: 7px; height: 7px; border-radius: 50%; background: var(--ink-faint);
+}
+.rail-pulse.live { background: var(--live); animation: rail-breathe 2.6s ease-in-out infinite; }
+@keyframes rail-breathe {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--live) 45%, transparent); }
+  70% { box-shadow: 0 0 0 5px transparent; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .rail-pulse.live { animation: none; }
+}
 
 /* ----- board ------------------------------------------------------------ */
 .board {
@@ -227,6 +257,25 @@ body {
 .json-null { color: var(--ink-faint); font-style: italic; }
 .json-empty { color: var(--ink-faint); }
 .json-raw { margin: 0; white-space: pre-wrap; word-break: break-word; color: var(--ink); }
+
+/* ----- namespace chip --------------------------------------------------- */
+/* The lead chip on a namespace row, shared by NsRow (its own component) and the
+   body, so it lives here in global scope. A quiet outlined tag; the data-bearing
+   kinds (frame/array) and containers get a faint tint in their hue. */
+.ns-chip {
+  display: inline-block; min-width: 2.6em; box-sizing: border-box;
+  padding: 1px 5px; text-align: center;
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.02em;
+  color: var(--ink-faint); border: 1px solid var(--edge-strong); border-radius: 5px;
+}
+.ns-chip[data-kind='frame'],
+.ns-chip[data-kind='array'] { color: var(--k-blue); border-color: color-mix(in srgb, var(--k-blue) 45%, transparent); }
+.ns-chip[data-kind='mapping'],
+.ns-chip[data-kind='sequence'] { color: var(--k-green); border-color: color-mix(in srgb, var(--k-green) 40%, transparent); }
+.ns-chip[data-kind='module'] { color: var(--k-pink); border-color: color-mix(in srgb, var(--k-pink) 38%, transparent); }
+.ns-chip[data-kind='function'],
+.ns-chip[data-kind='class'] { color: var(--k-amber); border-color: color-mix(in srgb, var(--k-amber) 40%, transparent); }
+.ns-chip[data-kind='scalar'] { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 40%, transparent); }
 
 /* ----- stage (board + focus overlay) ------------------------------------ */
 /* Holds the board and, when a pane is focused, the fullscreen view over it. The
@@ -367,6 +416,31 @@ body {
 /* min-width:0 lets the split shrink to the viewport so a long, unwrapped output
    line scrolls inside its own box (.cell has overflow:auto) instead of widening
    the whole page. Without it the flex row sizes to the longest line's content. */
+/* A view's slim header strip: the view name, a quiet count, optional active
+   badge. Shared by the feed and the namespace view so both read as one app. */
+.view-head {
+  flex: none; display: flex; align-items: baseline; gap: 12px;
+  height: 52px; padding: 0 clamp(14px, 2vw, 22px);
+  border-bottom: 1px solid var(--edge);
+}
+.view-title { font-size: 14.5px; font-weight: 600; letter-spacing: -0.02em; color: var(--ink); margin: 0; }
+.view-meta { font-family: var(--mono); font-size: 11.5px; color: var(--ink-faint); font-variant-numeric: tabular-nums; }
+.view-active {
+  margin-left: auto; display: inline-flex; align-items: center; gap: 7px;
+  font-family: var(--mono); font-size: 11.5px; color: var(--ink-dim);
+}
+.view-active i {
+  width: 6px; height: 6px; border-radius: 50%; background: var(--k-amber);
+  animation: led-pulse 1.1s ease-in-out infinite;
+}
+.view-empty {
+  flex: 1 1 auto; display: grid; place-content: center;
+  color: var(--ink-faint); font-family: var(--mono); font-size: 13px;
+}
+@media (prefers-reduced-motion: reduce) { .view-active i { animation: none; } }
+
+/* The feed view fills the stage as a column: the header, then the split below. */
+.feedview { flex: 1 1 auto; min-height: 0; min-width: 0; display: flex; flex-direction: column; }
 .feed { flex: 1 1 auto; min-height: 0; min-width: 0; display: flex; background: var(--bg); }
 .feed-empty {
   flex: 1 1 auto; display: grid; place-content: center;
@@ -381,57 +455,57 @@ body {
   list-style: none; margin: 0; padding: 8px 6px 40px;
 }
 
-/* The dot column is 10px wide after 8px of row padding, so its centre (and the
-   rail) sit at 13px from the entry's left edge. */
+/* Each row: a status dot, a two-line main column (the intent/title headline over a
+   quiet `id · tag` sub-line), and the duration/age on the right. */
 .entry { position: relative; }
-.entry::before {
-  content: ""; position: absolute; left: 13px; top: 0; bottom: 0;
-  width: 1px; background: var(--edge);
-}
-.entry:first-child::before { top: 16px; }
-.entry:last-child::before { bottom: auto; height: 16px; }
-
 .entry-row {
-  display: grid; grid-template-columns: 10px minmax(0, 1fr) auto;
-  align-items: baseline; column-gap: 10px; width: 100%;
+  display: grid; grid-template-columns: 9px minmax(0, 1fr) auto;
+  align-items: center; column-gap: 12px; width: 100%;
   font: inherit; text-align: left; color: var(--ink);
-  background: none; border: 0; cursor: pointer; padding: 8px 10px;
-  /* Hover and selection read as soft pills rather than full-bleed bands, so the
-     list feels lighter; the threaded rail still runs behind them. */
-  border-radius: 6px;
-  transition: background 0.1s ease;
+  background: none; border: 0; cursor: pointer; padding: 9px 12px;
+  /* Hover and selection read as soft pills rather than full-bleed bands. */
+  border-radius: 9px;
+  transition: background 0.12s ease;
 }
-.entry-row:hover { background: light-dark(rgba(0, 0, 0, 0.045), rgba(255, 255, 255, 0.05)); }
-/* The selected row: a quiet fill plus a thin accent edge — the one place the
-   accent appears in the list, so the current selection is unambiguous. */
+.entry-row:hover { background: var(--panel); }
+/* The selected row: a quiet raised fill plus a thin accent edge — the one place
+   the accent appears in the list, so the current selection is unambiguous. */
 .entry.selected > .entry-row {
-  background: light-dark(rgba(0, 0, 0, 0.08), rgba(255, 255, 255, 0.09));
+  background: var(--elev);
   box-shadow: inset 2px 0 0 var(--accent);
 }
-.entry.selected > .entry-row .entry-title { color: var(--ink); }
 
-/* Only failure (red) and the transient running pulse (amber) get a dot. Success
-   and idle panes show nothing — the rail threads them, so a green column of "fine"
-   doesn't compete with the few states that actually want the eye. */
+/* Only failure (red) and the transient running pulse (amber) get a filled dot;
+   success and idle stay a faint ring, so a column of "fine" doesn't compete with
+   the few states that actually want the eye. */
 .entry-dot {
-  grid-column: 1; align-self: center; justify-self: center; z-index: 1;
-  width: 9px; height: 9px; border-radius: 50%; background: transparent;
+  grid-column: 1; align-self: center; justify-self: center;
+  width: 7px; height: 7px; border-radius: 50%;
+  background: transparent; box-shadow: inset 0 0 0 1px var(--edge-strong);
 }
-.entry-dot.err { background: var(--dead); }
-.entry-dot.run { background: light-dark(#d68a00, #e5c07b); animation: led-pulse 1.1s ease-in-out infinite; }
+.entry-dot.err { background: var(--dead); box-shadow: none; }
+.entry-dot.run { background: var(--k-amber); box-shadow: none; animation: led-pulse 1.1s ease-in-out infinite; }
 
+.entry-main { grid-column: 2; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
 .entry-title {
-  grid-column: 2; min-width: 0; font-size: 13px; color: var(--ink-dim);
+  min-width: 0; font-size: 13px; color: var(--ink); letter-spacing: -0.012em;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .entry.err .entry-title { color: light-dark(#c4314b, #f0a0ad); }
+.entry-sub {
+  min-width: 0; font-family: var(--mono); font-size: 10.5px; color: var(--ink-faint);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.entry-sub-tag { color: var(--ink-faint); opacity: 0.7; }
 
 .entry-now {
-  grid-column: 3; font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em;
-  color: light-dark(#d68a00, #e5c07b); text-transform: uppercase;
+  grid-column: 3; align-self: center;
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em;
+  color: var(--k-amber); text-transform: uppercase;
 }
 .entry-age {
-  grid-column: 3; font-family: var(--mono); font-size: 10.5px; color: var(--ink-faint);
+  grid-column: 3; align-self: center;
+  font-family: var(--mono); font-size: 10.5px; color: var(--ink-faint);
   font-variant-numeric: tabular-nums;
 }
 

--- a/packages/mcp/ix_notebook_mcp/introspect.py
+++ b/packages/mcp/ix_notebook_mcp/introspect.py
@@ -28,6 +28,15 @@ from itertools import islice
 # count well under this.
 _MAX_NAMES = 64
 
+# How many children to emit per expanded container, and how many levels deep to
+# descend. Both bound the tree the dashboard's namespace view can browse: a row at
+# depth 0 may carry children down to (but not past) ``_MAX_DEPTH``, and any one
+# container contributes at most ``_BREADTH`` real children plus a single elision
+# marker. Mirrors the spirit of ``_MAX_NAMES`` — a session with a million-entry
+# dict must not turn one job-finish into a million-row payload.
+_MAX_DEPTH = 2
+_BREADTH = 32
+
 # Bounded repr for previews: never walk a giant container or stringify megabytes.
 _repr = reprlib.Repr()
 _repr.maxstring = 120
@@ -160,8 +169,22 @@ _NS_KIND = {
 # sort below real data and show no size chip.
 _SIZELESS_KINDS = frozenset({"module", "function", "class"})
 
+# The short kinds whose *value* is worth drilling into. A mapping/sequence/object
+# holds browsable children; everything else (module, class, function, scalar,
+# text, frame, array) carries its weight in its own ``shape``/``repr``, so the UI
+# gets nothing useful from expanding it. We decide expandability from the live
+# value (see :func:`_children`), not the string alone, but this gates which kinds
+# are even candidates.
+_EXPANDABLE_KINDS = frozenset({"mapping", "sequence", "object"})
 
-def namespace_rows(ns: dict, *, max_names: int = _MAX_NAMES) -> list[dict]:
+
+def namespace_rows(
+    ns: dict,
+    *,
+    max_names: int = _MAX_NAMES,
+    max_depth: int = _MAX_DEPTH,
+    breadth: int = _BREADTH,
+) -> list[dict]:
     """Describe values in ``ns`` as namespace-view rows.
 
     ``ns`` is the already-filtered set of user names (the caller drops baseline
@@ -169,39 +192,180 @@ def namespace_rows(ns: dict, *, max_names: int = _MAX_NAMES) -> list[dict]:
     ``{name, type, kind, repr, size, shape}``: ``kind`` drives the chip, ``repr``
     a one-line preview (empty for frames/arrays, which describe themselves by
     ``shape``), ``size`` the shallow byte size (``getsizeof``, O(1) per name), and
-    ``shape`` the dims for arrays/frames. Sorted heaviest-first so the eye lands on
-    what holds the memory. Capped at ``max_names`` (like :func:`cell_bindings`) so a
-    session with thousands of globals cannot stall the kernel's event loop on a
-    job finish. Reuses :func:`describe`, so it is bounded and side-effect-free; a
-    value whose introspection raises is skipped, not fatal."""
+    ``shape`` the dims for arrays/frames. An expandable container (mapping,
+    sequence, or plain object) also carries ``children``: the same row shape for
+    its entries, recursively, so the view can drill in. Sorted heaviest-first so
+    the eye lands on what holds the memory. Capped at ``max_names`` (like
+    :func:`cell_bindings`) so a session with thousands of globals cannot stall the
+    kernel's event loop on a job finish. Reuses :func:`describe`, so it is bounded
+    and side-effect-free; a value whose introspection raises is skipped, not
+    fatal."""
     rows: list[dict] = []
     for name, value in islice(ns.items(), max_names):
+        row = _row(name, value, depth=0, max_depth=max_depth, breadth=breadth)
+        if row is not None:
+            rows.append(row)
+    # Only the top level sorts heaviest-first; children keep natural (dict/list)
+    # order so the user sees the container's own layout when they drill in.
+    rows.sort(key=lambda row: (-row["size"], row["name"]))
+    return rows
+
+
+def _row(name, value, *, depth: int, max_depth: int, breadth: int) -> dict | None:
+    """Build one namespace row for ``name``/``value``, the single construction
+    path shared by the top level and the recursion.
+
+    Returns None only when the value's own introspection raises (the caller drops
+    it — at the top level a name disappears, as a child it is simply absent), so a
+    pathological value never propagates an exception out of :func:`namespace_rows`.
+    ``depth`` is the row's level (top-level is 0); children are emitted only while
+    ``depth < max_depth``."""
+    try:
+        described = describe(value)
+    except Exception:
+        # A value whose introspection raises (an exotic __getattr__, a property
+        # with side effects) contributes no row rather than crashing the walk.
+        return None
+    kind = _NS_KIND.get(described["kind"], described["kind"])
+    if kind in _SIZELESS_KINDS:
+        size = 0
+    else:
         try:
-            described = describe(value)
+            size = int(sys.getsizeof(value))
+        except Exception:
+            size = 0
+    row = {
+        "name": name,
+        "type": described["type"],
+        "kind": kind,
+        # Frames/arrays carry their weight in `shape`; everything else shows the
+        # `describe` summary as a one-line preview.
+        "repr": "" if kind in ("frame", "array") else described.get("summary", ""),
+        "size": size,
+        "shape": _ns_shape(value, kind),
+    }
+    # Descend only into expandable kinds, and only while we have depth budget left.
+    # Children live one level deeper, so stop once depth would reach max_depth.
+    if kind in _EXPANDABLE_KINDS and depth < max_depth:
+        children = _children(value, kind, depth=depth + 1, max_depth=max_depth, breadth=breadth)
+        if children:
+            row["children"] = children
+    return row
+
+
+# The synthetic row appended when a container has more entries than ``breadth``:
+# a single marker that says how many were elided, carrying no children of its own.
+# Kept as ``object`` kind so the UI's existing chip vocabulary covers it.
+def _elision_row(extra: int) -> dict:
+    return {"name": "…", "type": "", "kind": "object", "repr": f"+{extra} more", "size": 0, "shape": ""}
+
+
+def _children(value, kind: str, *, depth: int, max_depth: int, breadth: int) -> list[dict]:
+    """Rows for the entries of an expandable container, in natural order.
+
+    Bounded to ``breadth`` real children plus at most one elision marker, and it
+    never iterates more than ``breadth + 1`` items of any container (so a
+    billion-entry dict costs the same as a small one). Decides what to expand from
+    the live ``value``: a mapping yields ``key -> value`` rows, a sequence yields
+    indexed (or, for sets, repr-named) element rows, and a plain object yields its
+    public instance attributes. Any failure degrades to no children, never a
+    raise."""
+    try:
+        if isinstance(value, dict):
+            return _mapping_children(value, depth=depth, max_depth=max_depth, breadth=breadth)
+        if isinstance(value, (list, tuple)):
+            return _sequence_children(value, depth=depth, max_depth=max_depth, breadth=breadth, indexed=True)
+        if isinstance(value, (set, frozenset)):
+            # Sets are unordered, so an index name would be meaningless; name each
+            # child by its bounded element repr instead.
+            return _sequence_children(value, depth=depth, max_depth=max_depth, breadth=breadth, indexed=False)
+        if kind == "object":
+            return _object_children(value, depth=depth, max_depth=max_depth, breadth=breadth)
+    except Exception:
+        # Introspecting the container itself misbehaved (a dict-like whose
+        # iteration raises, a __len__ that lies): show it as a leaf, not a crash.
+        return []
+    return []
+
+
+def _mapping_children(value, *, depth: int, max_depth: int, breadth: int) -> list[dict]:
+    """``key -> value`` rows for a dict, keyed by a short rendering of the key.
+
+    ``islice`` over ``value.items()`` so we touch at most ``breadth + 1`` pairs of
+    even an enormous dict; the extra pair is only probed to learn whether to emit
+    the elision marker."""
+    rows: list[dict] = []
+    for k, v in islice(value.items(), breadth + 1):
+        if len(rows) == breadth:
+            # We pulled one entry past the cap purely to detect overflow. Count
+            # the remainder via len() (O(1)) rather than walking the rest.
+            try:
+                extra = len(value) - breadth
+            except Exception:
+                extra = 1
+            rows.append(_elision_row(max(extra, 1)))
+            break
+        # str keys read cleanest unquoted-but-short; other keys go through the
+        # bounded repr so a giant key cannot blow up the child name.
+        name = k if isinstance(k, str) and len(k) <= 60 else _repr.repr(k)
+        child = _row(name, v, depth=depth, max_depth=max_depth, breadth=breadth)
+        if child is not None:
+            rows.append(child)
+    return rows
+
+
+def _sequence_children(value, *, depth: int, max_depth: int, breadth: int, indexed: bool) -> list[dict]:
+    """Element rows for a list/tuple/set, ``indexed`` choosing ``"[i]"`` names
+    (ordered sequences) versus the element repr (unordered sets)."""
+    rows: list[dict] = []
+    for i, v in enumerate(islice(value, breadth + 1)):
+        if len(rows) == breadth:
+            try:
+                extra = len(value) - breadth
+            except Exception:
+                extra = 1
+            rows.append(_elision_row(max(extra, 1)))
+            break
+        name = f"[{i}]" if indexed else _repr.repr(v)
+        child = _row(name, v, depth=depth, max_depth=max_depth, breadth=breadth)
+        if child is not None:
+            rows.append(child)
+    return rows
+
+
+def _object_children(value, *, depth: int, max_depth: int, breadth: int) -> list[dict]:
+    """Rows for a plain object's public instance attributes.
+
+    Conservative on purpose: only the instance ``__dict__`` (via ``vars``), never
+    class attributes, properties, or methods — those can run arbitrary code or
+    recurse forever. Dunders and callables are skipped, and every attribute read
+    is guarded because a value sitting in ``__dict__`` is inert but reading it back
+    through ``getattr`` could still hit a descriptor that raises."""
+    try:
+        members = vars(value)
+    except TypeError:
+        # No instance __dict__ (slots-only, or a C type): nothing browsable.
+        return []
+    rows: list[dict] = []
+    for attr in islice(members, breadth + 1):
+        if not isinstance(attr, str) or attr.startswith("__"):
+            continue
+        if len(rows) == breadth:
+            rows.append(_elision_row(max(len(members) - breadth, 1)))
+            break
+        try:
+            member = members[attr]
         except Exception:
             continue
-        kind = _NS_KIND.get(described["kind"], described["kind"])
-        if kind in _SIZELESS_KINDS:
-            size = 0
-        else:
-            try:
-                size = int(sys.getsizeof(value))
-            except Exception:
-                size = 0
-        shape = _ns_shape(value, kind)
-        rows.append(
-            {
-                "name": name,
-                "type": described["type"],
-                "kind": kind,
-                # Frames/arrays carry their weight in `shape`; everything else
-                # shows the `describe` summary as a one-line preview.
-                "repr": "" if kind in ("frame", "array") else described.get("summary", ""),
-                "size": size,
-                "shape": shape,
-            }
-        )
-    rows.sort(key=lambda row: (-row["size"], row["name"]))
+        # Skip methods/functions bound on the instance: they are behavior, not
+        # the object's data, and clutter the browsable view.
+        if callable(member) and isinstance(
+            member, (types.FunctionType, types.MethodType, types.BuiltinFunctionType, type)
+        ):
+            continue
+        child = _row(attr, member, depth=depth, max_depth=max_depth, breadth=breadth)
+        if child is not None:
+            rows.append(child)
     return rows
 
 

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -219,7 +219,7 @@ Content = list[outputs.Content]
 async def python_exec(
     code: Annotated[str, Field(description="Python source to run on the shared kernel")],
     budget: Annotated[float, Field(description="Seconds to wait before backgrounding the run (server-side cap: 120s; larger values are clamped and a notice is appended to the reply)")] = 15.0,
-    name: Annotated[str | None, Field(description="Optional label for the job in the dashboard")] = None,
+    intent: Annotated[str | None, Field(description="A short plain-language description of what this run does, e.g. 'count rows per host' or 'fetch and parse the open PR list'. Shown as the run's title in the dashboard feed so a human watching can follow your work; without it the feed falls back to the first line of code. Strongly recommended on every call — keep it under ~8 words.")] = None,
     ctx: Context | None = None,
 ) -> Content:
     _open_dashboard_once()
@@ -229,8 +229,10 @@ async def python_exec(
     # below so the caller knows to poll the job rather than silently lose the wait.
     cap = config().max_budget
     effective_budget = min(budget, cap)
+    # `intent` is the run's human label (the dashboard feed's title); it flows to
+    # the kernel as the job name and lands in the store's `name` column.
     cell_outputs, summary = await current_kernel().python_exec(
-        code, effective_budget, name, session=_session_id(ctx)
+        code, effective_budget, intent, session=_session_id(ctx)
     )
     rendered = outputs.to_mcp(cell_outputs)
     if summary is None:

--- a/packages/mcp/tests/test_introspect_children.py
+++ b/packages/mcp/tests/test_introspect_children.py
@@ -1,0 +1,210 @@
+"""Recursive namespace children (the dashboard's drill-in for containers).
+
+`namespace_rows` now hangs a `children` list off any expandable container
+(mapping, sequence, plain object) so the Namespace view can expand it in place.
+These tests pin the contract the UI relies on: the recursive row shape, the
+`max_depth` and `breadth` bounds, the elision marker, which kinds stay leaves,
+and — most important for a tool that runs inside the live kernel — that a value
+whose introspection misbehaves degrades to a plain row rather than raising.
+
+Imports only :mod:`ix_notebook_mcp.introspect`, which is pure stdlib, so this
+file runs without the MCP/kernel dependency stack the heavier suites need.
+"""
+
+from __future__ import annotations
+
+import os
+
+from ix_notebook_mcp import introspect
+
+
+def _only_row(value, **kwargs) -> dict:
+    """The single row for a one-name namespace (the common test fixture)."""
+    rows = introspect.namespace_rows({"v": value}, **kwargs)
+    assert len(rows) == 1
+    return rows[0]
+
+
+# --------------------------------------------------------------------------- #
+# recursion + the max_depth boundary
+# --------------------------------------------------------------------------- #
+
+
+def test_nested_dict_yields_children_with_a_depth_boundary() -> None:
+    # {"a": 1, "b": {"c": 2}}: the outer dict (depth 0) and the inner dict
+    # (depth 1) both expand, but the inner dict's child sits at depth 2 == max,
+    # so the inner dict itself carries children while a third level would not.
+    row = _only_row({"a": 1, "b": {"c": 2}}, max_depth=2)
+    assert row["kind"] == "mapping"
+    assert "children" in row
+
+    by_name = {child["name"]: child for child in row["children"]}
+    assert by_name["a"]["repr"] == "1"
+    inner = by_name["b"]
+    assert inner["kind"] == "mapping"
+    # The inner dict is at depth 1, so it still gets its own children (depth 2).
+    assert "children" in inner
+    assert inner["children"][0]["name"] == "c"
+    # ...but those depth-2 children are leaves: nothing emitted at depth 3.
+    assert "children" not in inner["children"][0]
+
+
+def test_max_depth_one_stops_after_the_top_level() -> None:
+    # With max_depth=1 the top dict expands (its children are depth 1 == max),
+    # but the nested dict child is a leaf — no depth-2 descent.
+    row = _only_row({"a": 1, "b": {"c": 2}}, max_depth=1)
+    inner = {child["name"]: child for child in row["children"]}["b"]
+    assert inner["kind"] == "mapping"
+    assert "children" not in inner
+
+
+# --------------------------------------------------------------------------- #
+# sequences: indexed names for lists, unordered names for sets
+# --------------------------------------------------------------------------- #
+
+
+def test_list_yields_indexed_children() -> None:
+    row = _only_row([10, 20, 30])
+    assert row["kind"] == "sequence"
+    names = [child["name"] for child in row["children"]]
+    assert names == ["[0]", "[1]", "[2]"]
+    assert [child["repr"] for child in row["children"]] == ["10", "20", "30"]
+
+
+def test_tuple_is_also_indexed() -> None:
+    row = _only_row((1, 2))
+    assert [child["name"] for child in row["children"]] == ["[0]", "[1]"]
+
+
+def test_set_children_are_named_by_repr_not_index() -> None:
+    row = _only_row({42})
+    assert row["kind"] == "sequence"
+    # Sets are unordered, so the child name is the bounded element repr.
+    assert row["children"][0]["name"] == "42"
+
+
+# --------------------------------------------------------------------------- #
+# the breadth cap + elision marker
+# --------------------------------------------------------------------------- #
+
+
+def test_list_over_breadth_emits_cap_plus_one_elision_marker() -> None:
+    cap = 5
+    row = _only_row(list(range(100)), breadth=cap)
+    children = row["children"]
+    # Exactly cap real children, then a single elision marker.
+    assert len(children) == cap + 1
+    marker = children[-1]
+    assert marker == {
+        "name": "…",
+        "type": "",
+        "kind": "object",
+        "repr": "+95 more",
+        "size": 0,
+        "shape": "",
+    }
+    assert "children" not in marker
+
+
+def test_dict_over_breadth_emits_cap_plus_one_elision_marker() -> None:
+    cap = 4
+    big = {f"k{i}": i for i in range(20)}
+    row = _only_row(big, breadth=cap)
+    children = row["children"]
+    assert len(children) == cap + 1
+    assert children[-1]["name"] == "…"
+    assert children[-1]["repr"] == "+16 more"
+
+
+def test_container_exactly_at_breadth_has_no_marker() -> None:
+    cap = 3
+    row = _only_row([1, 2, 3], breadth=cap)
+    # Exactly cap entries fit, so there is nothing to elide.
+    assert len(row["children"]) == cap
+    assert all(child["name"] != "…" for child in row["children"])
+
+
+# --------------------------------------------------------------------------- #
+# objects: public instance attrs only, no methods/dunders
+# --------------------------------------------------------------------------- #
+
+
+class _Thing:
+    def __init__(self) -> None:
+        self.x = 1
+        self.data = {"k": 2}
+
+    def method(self) -> None:  # behavior, not data — must not appear
+        pass
+
+
+def test_object_children_are_public_instance_attributes() -> None:
+    row = _only_row(_Thing())
+    assert row["kind"] == "object"
+    names = {child["name"] for child in row["children"]}
+    assert names == {"x", "data"}
+    # Nested container attrs recurse like any other value.
+    data = {child["name"]: child for child in row["children"]}["data"]
+    assert data["kind"] == "mapping"
+    assert data["children"][0]["name"] == "k"
+
+
+def test_object_without_vars_has_no_children() -> None:
+    class _Slotted:
+        __slots__ = ()
+
+    row = _only_row(_Slotted())
+    assert "children" not in row
+
+
+# --------------------------------------------------------------------------- #
+# leaf kinds: never carry children
+# --------------------------------------------------------------------------- #
+
+
+def test_non_expandable_kinds_have_no_children() -> None:
+    def fn() -> None:
+        pass
+
+    for value in (5, "hello", os, fn, _Thing):  # int, text, module, function, class
+        row = _only_row(value)
+        assert "children" not in row, (row["kind"], row["name"])
+
+
+# --------------------------------------------------------------------------- #
+# defensiveness: a misbehaving value/attr must never escape namespace_rows
+# --------------------------------------------------------------------------- #
+
+
+class _Exploding:
+    """An object whose property raises and whose data attr is a dict — the row
+    must still come back, the property must simply not show up."""
+
+    def __init__(self) -> None:
+        self.safe = 1
+
+    @property
+    def boom(self):  # a property that raises if anyone touches it
+        raise RuntimeError("do not read me")
+
+
+def test_property_that_raises_does_not_blow_up_namespace_rows() -> None:
+    # Should not raise. The exploding property lives on the class, not in vars(),
+    # so it is never read; the safe instance attr still surfaces.
+    row = _only_row(_Exploding())
+    assert row["kind"] == "object"
+    names = {child["name"] for child in row["children"]}
+    assert "safe" in names
+    assert "boom" not in names
+
+
+def test_value_whose_describe_raises_degrades_to_no_row() -> None:
+    class _Hostile:
+        def __getattribute__(self, name):  # type: ignore[override]
+            raise RuntimeError("everything explodes")
+
+    # The top-level value's introspection raises, so it is dropped, not fatal.
+    rows = introspect.namespace_rows({"ok": 1, "bad": _Hostile()})
+    names = {row["name"] for row in rows}
+    assert "ok" in names
+    assert "bad" not in names


### PR DESCRIPTION
## What

Reskin the Loro hub dashboard into the **Obsidian** design and fix three UX warts left after the MCP-site retirement (#1102).

- **Obsidian theme + shell.** `light-dark()` tokens remapped to the flat near-black Obsidian palette (one periwinkle accent, hairline rules, kind hues) with a clean light variant kept. A thin **icon rail** now drives the view — Jobs / Namespace / Board — with a pulsing kernel-health dot.
- **Namespace is its own view.** It was being interleaved into the run feed by timestamp ("randomly bundled" among the run ids). Now a dedicated rail view, grouped **Data / Modules / Functions**, heaviest-first, with color-coded kind chips.
- **Recursive namespace.** `introspect.py` emits depth-bounded, breadth-capped `children` for dict/list/tuple/set/object (with a `+N more` elision marker); `NamespaceBody`/`NsRow` render an expand/collapse tree. Shared row helpers live in `lib/namespace.ts` so the inline body and the full view are one implementation.
- **Feed shows a description, not a UUID.** Each run's title is the headline with a quiet `id · tag` sub-line. `python_exec`'s `name` param becomes **`intent`** with a strong description so agents state what a run is for; it flows to the feed title.

## Verification (local, on this head SHA)

- `svelte-check`: 0 errors · `vite build`: ✓
- `pytest tests/test_introspect_children.py`: **13 passed**
- `nix run .#lint`: astlog / deadnix / nixfmt / statix all green
- `nix build .#dashboard`: builds the binary with the site embedded
- Visually checked the demo (`?demo`) — feed + namespace, dark + light, recursion expanded — via headless Chrome.

```mermaid
flowchart LR
  rail[icon rail] --> jobs[Jobs feed]
  rail --> ns[Namespace view]
  rail --> board[Board]
  ns --> tree[recursive tree: introspect children]
```

(sent by an AI agent via Claude Code, model Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Obsidian-redesigned dashboard with icon rail navigation, recursive namespace view, and run intents
> - Replaces the topbar with a left icon rail in [App.svelte](https://github.com/indexable-inc/index/pull/1105/files#diff-3c9d2093c73c3bfcfe0a5b3aeac3d6ec6336ae39d8e253c0d7e7277ec189a8dd) that switches between Feed, Namespace, and Board views; connection health is shown as a pulse indicator in the rail.
> - Adds a dedicated [NamespaceView.svelte](https://github.com/indexable-inc/index/pull/1105/files#diff-7800b17a415c2846268522453284cc3238f07d373d5552e2d04629d27290be2a) that aggregates all live session globals and renders them as grouped, recursively expandable trees (Data / Modules / Functions) via the new [NsRow.svelte](https://github.com/indexable-inc/index/pull/1105/files#diff-5e41cb2d14295aece391aac719dde0c290836617f6fe72973157cc87487c46de) component.
> - Extends `namespace_rows` in [introspect.py](https://github.com/indexable-inc/index/pull/1105/files#diff-006579eb39a5fc5841047297950ecbb104d7094d82bdaec8fe1b9a4eeeda9cad) to emit bounded recursive `children` for mappings, sequences, and objects, controlled by `max_depth` and `breadth` parameters with elision markers when truncated.
> - Renames the `python_exec` tool parameter `name` to `intent` in [tools.py](https://github.com/indexable-inc/index/pull/1105/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) and forwards it as the job name.
> - Namespace panes are filtered out of the Feed view; the feed header now shows total runs and a live active count with a short id and tag per row.
> - Risk: the `intent` rename in `python_exec` is a breaking API change for any MCP clients passing the `name` parameter by keyword.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0124b0f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->