### PR TITLE
dashboard: deep namespace nesting, IDE kind icons, feed dedup, auto-hide timeline; review fixes

### DIFF
--- a/packages/dashboard-core/site/src/App.svelte
+++ b/packages/dashboard-core/site/src/App.svelte
@@ -78,5 +78,10 @@
     {#if ui.focusKey}<FocusView />{/if}
   </div>
 
-  <Timeline />
+  <!-- The replay scrubber is hidden until you reach for it: a thin hover zone at
+       the foot reveals it as a floating overlay, so an idle session (no recording,
+       just 0:00 / 0:00) isn't paying for a permanent bar. -->
+  <div class="timeline-dock">
+    <Timeline />
+  </div>
 </div>

--- a/packages/dashboard-core/site/src/components/FeedView.svelte
+++ b/packages/dashboard-core/site/src/components/FeedView.svelte
@@ -103,11 +103,23 @@
     return (p.kind ?? 'data') === 'data' && p.renderer === 'namespace';
   }
 
+  // A run's rich output (a table/plot/image) is published as a separate
+  // `<id>/out` html pane beside its exec pane. It is an *attachment* to the run,
+  // not its own entry, so it must not appear as a duplicate feed row — it is folded
+  // into the run's detail panel instead (see `outPane` below).
+  function isOutputAttachment(key: string): boolean {
+    const sep = key.indexOf(SCOPE_SEP);
+    const id = sep === -1 ? key : key.slice(sep + 1);
+    return id.endsWith('/out');
+  }
+
   // Panes oldest-first, so the newest run lands at the bottom and the list reads
   // as a live log that grows downward. created_at is the stamp; ties break by key
-  // for stability. Namespace panes are excluded — they belong to the Namespace view.
+  // for stability. Namespace panes and per-run output attachments are excluded —
+  // the former has its own view, the latter folds into its run's detail.
   const items = $derived(
     Object.keys(store.panes)
+      .filter((key) => !isOutputAttachment(key))
       .map((key) => {
         const sep = key.indexOf(SCOPE_SEP);
         const scope = sep === -1 ? '' : key.slice(0, sep);
@@ -128,6 +140,14 @@
   // too, so mouse and keyboard agree.
   let selectedKey: string | null = $state(null);
   const selected = $derived(items.find((it) => it.key === selectedKey) ?? null);
+  // The selected run's rich-output attachment, if any: the `<key>/out` html pane
+  // published beside the exec (a table/plot/image). Rendered inside the detail so
+  // the run is one entry, not two.
+  const selectedOut = $derived.by<Pane | null>(() => {
+    if (!selected) return null;
+    const rec = store.panes[selected.key + '/out'];
+    return rec ? ({ ...rec, key: selected.key + '/out', scope: selected.pane.scope } as Pane) : null;
+  });
   $effect(() => {
     // Keep the selection valid as panes come and go; default to the newest row
     // (now the last, since the list grows downward) and scroll it into view.
@@ -248,6 +268,12 @@
               </div>
             {/if}
             <div class="entry-box cell cell-out"><ExecBody pane={p} chrome={false} expanded /></div>
+            {#if selectedOut}
+              {@const OutBody = rendererFor(selectedOut.kind, selectedOut.renderer)}
+              <div class="entry-box pane entry-body detail-out">
+                <div class="body html-body"><OutBody pane={selectedOut} /></div>
+              </div>
+            {/if}
             {#if hasSource}
               <button
                 class="entry-code-toggle"

--- a/packages/dashboard-core/site/src/components/KindIcon.svelte
+++ b/packages/dashboard-core/site/src/components/KindIcon.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  // A small IDE-autocomplete-style glyph per namespace kind, in place of a text
+  // chip — frames read as a table, sequences as brackets, scalars as a hash, and
+  // so on. Monochrome `currentColor` so the parent tints it by kind. 16px box,
+  // 1.4px stroke to match the rest of the rail iconography.
+  let { kind }: { kind: string } = $props();
+</script>
+
+<span class="ns-icon" data-kind={kind} aria-hidden="true">
+  <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+    {#if kind === 'frame' || kind === 'array'}
+      <!-- table / grid -->
+      <rect x="2.5" y="3" width="11" height="10" rx="1.2" />
+      <path d="M2.5 6.5h11M6 6.5V13" />
+    {:else if kind === 'mapping' || kind === 'object'}
+      <!-- braces -->
+      <path d="M6.2 3c-1.2 0-1.6.6-1.6 1.9 0 1.1-.2 1.8-1.1 2.1.9.3 1.1 1 1.1 2.1 0 1.3.4 1.9 1.6 1.9" />
+      <path d="M9.8 3c1.2 0 1.6.6 1.6 1.9 0 1.1.2 1.8 1.1 2.1-.9.3-1.1 1-1.1 2.1 0 1.3-.4 1.9-1.6 1.9" />
+    {:else if kind === 'sequence'}
+      <!-- brackets -->
+      <path d="M6.5 3H4.3v10h2.2M9.5 3h2.2v10H9.5" />
+    {:else if kind === 'scalar'}
+      <!-- hash (number) -->
+      <path d="M6.2 3 5 13M11 3l-1.2 10M3.4 6.4h9.2M2.8 9.6h9.2" />
+    {:else if kind === 'text'}
+      <!-- text lines -->
+      <path d="M3.5 4.5h9M3.5 8h9M3.5 11.5h5.5" />
+    {:else if kind === 'module'}
+      <!-- package / cube -->
+      <path d="M8 2.5 13 5v6l-5 2.5L3 11V5zM3 5l5 2.5 5-2.5M8 7.5V13" />
+    {:else if kind === 'function'}
+      <!-- callable: parentheses -->
+      <path d="M6 3.2c-1.6 1.8-1.6 7.8 0 9.6M10 3.2c1.6 1.8 1.6 7.8 0 9.6" />
+    {:else if kind === 'class'}
+      <!-- class: C -->
+      <path d="M11.5 5.2A4.2 4.2 0 1 0 11.5 10.8" />
+    {:else}
+      <!-- fallback: a small diamond -->
+      <path d="M8 3.5 12.5 8 8 12.5 3.5 8z" />
+    {/if}
+  </svg>
+</span>

--- a/packages/dashboard-core/site/src/components/NsRow.svelte
+++ b/packages/dashboard-core/site/src/components/NsRow.svelte
@@ -3,7 +3,8 @@
   // caret and expands its `children` inline, each child the same row one level
   // deeper. Leaves have no caret. Open state is local, so expanding one branch
   // never disturbs another.
-  import { chip, fmtSize, detail, type NsRow as Row } from '$lib/namespace';
+  import { fmtSize, detail, type NsRow as Row } from '$lib/namespace';
+  import KindIcon from './KindIcon.svelte';
   // Svelte 5 expresses recursion by importing the component itself rather than the
   // old <svelte:self>.
   import Self from './NsRow.svelte';
@@ -27,7 +28,7 @@
     aria-expanded={hasChildren ? open : undefined}
   >
     <span class="nsrow-caret" class:open class:hidden={!hasChildren}>›</span>
-    <span class="ns-chip" data-kind={row.kind}>{chip(row.kind)}</span>
+    <KindIcon kind={row.kind} />
     <span class="nsrow-name" title={row.type}>{row.name}</span>
     <span class="nsrow-detail" title={detail(row)}>{detail(row)}</span>
     <span class="nsrow-size">{fmtSize(row.size)}</span>
@@ -43,8 +44,8 @@
 <style>
   .nsrow-line {
     display: grid;
-    grid-template-columns: 14px 2.6em minmax(0, auto) minmax(0, 1fr) auto;
-    align-items: baseline;
+    grid-template-columns: 14px 16px minmax(0, auto) minmax(0, 1fr) auto;
+    align-items: center;
     column-gap: 10px;
     width: 100%;
     padding: 5px 12px;

--- a/packages/dashboard-core/site/src/lib/demo.ts
+++ b/packages/dashboard-core/site/src/lib/demo.ts
@@ -45,6 +45,19 @@ export function seedDemo(): void {
       duration_ms: 38,
       created_at: now - 9000,
     },
+    // A run's rich output (a table/plot/image) arrives as a `<id>/out` html pane
+    // beside its exec. The feed folds it into the run's detail rather than showing
+    // it as a duplicate row.
+    [`demo${SEP}json/out`]: {
+      kind: 'html',
+      title: 'checking dashboard status',
+      subtitle: 'output',
+      body:
+        '<table style="border-collapse:collapse;font:12px ui-monospace,monospace">' +
+        '<tr><th style="text-align:left;padding:3px 12px 3px 0">service</th><th style="text-align:left;padding:3px 0">ok</th></tr>' +
+        '<tr><td style="padding:3px 12px 3px 0">dashboard</td><td style="padding:3px 0;color:#52c98e">true</td></tr></table>',
+      created_at: now - 9000,
+    },
     // An error: prints before failing, traceback below the trace; red LED.
     [`demo${SEP}boom`]: {
       kind: 'exec',

--- a/packages/dashboard-core/site/src/lib/namespace.ts
+++ b/packages/dashboard-core/site/src/lib/namespace.ts
@@ -15,24 +15,6 @@ export interface NsRow {
   children?: NsRow[];
 }
 
-// A short chip per kind so the lead column stays narrow and scannable.
-const CHIP: Record<string, string> = {
-  module: 'mod',
-  class: 'cls',
-  function: 'fn',
-  scalar: 'num',
-  text: 'str',
-  sequence: 'seq',
-  mapping: 'map',
-  array: 'arr',
-  frame: 'df',
-  object: 'obj',
-};
-
-export function chip(kind: string): string {
-  return CHIP[kind] ?? kind.slice(0, 3);
-}
-
 // Human byte size; empty for the sizeless (modules, functions report 0).
 export function fmtSize(n: number): string {
   if (!n) return '';

--- a/packages/dashboard-core/site/src/style.css
+++ b/packages/dashboard-core/site/src/style.css
@@ -70,7 +70,7 @@ body {
    surface + the shared timeline at its foot). The workspace owns all scrolling
    and panning within its own box. */
 #app { height: 100%; display: flex; flex-direction: row; }
-.workspace { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; }
+.workspace { position: relative; flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; }
 ::selection { background: var(--accent-soft); }
 
 /* ----- icon rail -------------------------------------------------------- */
@@ -258,24 +258,29 @@ body {
 .json-empty { color: var(--ink-faint); }
 .json-raw { margin: 0; white-space: pre-wrap; word-break: break-word; color: var(--ink); }
 
-/* ----- namespace chip --------------------------------------------------- */
-/* The lead chip on a namespace row, shared by NsRow (its own component) and the
-   body, so it lives here in global scope. A quiet outlined tag; the data-bearing
-   kinds (frame/array) and containers get a faint tint in their hue. */
-.ns-chip {
-  display: inline-block; min-width: 2.6em; box-sizing: border-box;
-  padding: 1px 5px; text-align: center;
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.02em;
-  color: var(--ink-faint); border: 1px solid var(--edge-strong); border-radius: 5px;
+/* ----- namespace kind icon ---------------------------------------------- */
+/* The lead glyph on a namespace row (KindIcon), an IDE-autocomplete-style icon
+   tinted by kind. Lives in global scope because KindIcon is its own component.
+   currentColor drives the SVG, so the data-kind rules below just set the hue. */
+.ns-icon {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 16px; height: 16px; color: var(--ink-dim);
 }
-.ns-chip[data-kind='frame'],
-.ns-chip[data-kind='array'] { color: var(--k-blue); border-color: color-mix(in srgb, var(--k-blue) 45%, transparent); }
-.ns-chip[data-kind='mapping'],
-.ns-chip[data-kind='sequence'] { color: var(--k-green); border-color: color-mix(in srgb, var(--k-green) 40%, transparent); }
-.ns-chip[data-kind='module'] { color: var(--k-pink); border-color: color-mix(in srgb, var(--k-pink) 38%, transparent); }
-.ns-chip[data-kind='function'],
-.ns-chip[data-kind='class'] { color: var(--k-amber); border-color: color-mix(in srgb, var(--k-amber) 40%, transparent); }
-.ns-chip[data-kind='scalar'] { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 40%, transparent); }
+.ns-icon svg { width: 16px; height: 16px; display: block; }
+.ns-icon[data-kind='frame'],
+.ns-icon[data-kind='array'] { color: var(--k-blue); }
+.ns-icon[data-kind='mapping'],
+.ns-icon[data-kind='sequence'] { color: var(--k-green); }
+.ns-icon[data-kind='object'] { color: var(--ink-dim); }
+.ns-icon[data-kind='module'] { color: var(--k-pink); }
+.ns-icon[data-kind='function'],
+.ns-icon[data-kind='class'] { color: var(--k-amber); }
+.ns-icon[data-kind='scalar'] { color: var(--accent); }
+.ns-icon[data-kind='text'] { color: var(--ink-dim); }
+
+/* The rich-output pane folded into a run's detail (no longer a duplicate feed
+   row), set apart from the text output above it. */
+.detail-out { margin-top: 10px; }
 
 /* ----- stage (board + focus overlay) ------------------------------------ */
 /* Holds the board and, when a pane is focused, the fullscreen view over it. The
@@ -375,26 +380,48 @@ body {
 .focus-pane .exec { max-height: none; }
 .focus-absent { color: var(--ink-faint); font-family: var(--mono); align-self: center; }
 
-/* ----- timeline bar ----------------------------------------------------- */
-/* The replay scrubber, shared by the board and the focus view. Fixed at the
-   foot of the window so it controls whichever surface is showing. */
-.timeline {
-  flex: none; z-index: 30;
-  display: flex; align-items: center; gap: 8px;
-  padding: 7px clamp(12px, 2vw, 24px);
-  background: var(--bg); border-top: 1px solid var(--edge);
-  font-family: var(--mono); font-size: 11.5px; color: var(--ink-dim);
+/* ----- timeline (auto-hiding overlay) ----------------------------------- */
+/* The replay scrubber floats over the foot of the workspace and stays hidden
+   until reached for, so an idle session (no recording — just 0:00 / 0:00) shows
+   no permanent bar. A thin hover strip along the bottom edge, hovering the pill,
+   or focusing a control reveals it. */
+.timeline-dock {
+  position: absolute; left: 0; right: 0; bottom: 0; z-index: 30;
+  display: flex; justify-content: center; align-items: flex-end;
+  height: 26px; padding-bottom: 8px; pointer-events: none;
 }
+/* Invisible catch strip along the very bottom that triggers the reveal. */
+.timeline-dock::before {
+  content: ""; position: absolute; left: 0; right: 0; bottom: 0; height: 16px;
+  pointer-events: auto;
+}
+.timeline {
+  pointer-events: auto;
+  display: flex; align-items: center; gap: 8px;
+  width: max-content; max-width: min(880px, calc(100% - 24px));
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--panel) 86%, transparent);
+  -webkit-backdrop-filter: blur(12px); backdrop-filter: blur(12px);
+  border: 1px solid var(--edge); border-radius: 12px;
+  box-shadow: 0 8px 28px -10px rgba(0, 0, 0, 0.5);
+  font-family: var(--mono); font-size: 11.5px; color: var(--ink-dim);
+  opacity: 0; transform: translateY(14px);
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+.timeline-dock:hover .timeline,
+.timeline:hover,
+.timeline:focus-within { opacity: 1; transform: none; }
+@media (prefers-reduced-motion: reduce) { .timeline { transition: none; } }
 .tl-btn {
   font: inherit; color: var(--ink-dim);
-  background: var(--panel); border: 1px solid var(--edge);
+  background: var(--panel); border: 1px solid var(--edge); border-radius: 7px;
   padding: 3px 9px; cursor: pointer; min-width: 28px;
 }
 .tl-btn:hover:not(:disabled) { color: var(--ink); border-color: var(--edge-strong); }
 .tl-btn:disabled { opacity: 0.4; cursor: default; }
 .tl-btn.on { color: var(--bg); background: var(--accent); border-color: var(--accent); }
 .tl-btn.live.on { background: var(--live); border-color: var(--live); }
-.tl-range { flex: 1 1 auto; min-width: 80px; accent-color: var(--accent); cursor: pointer; }
+.tl-range { flex: 1 1 auto; min-width: 120px; accent-color: var(--accent); cursor: pointer; }
 .tl-time { font-variant-numeric: tabular-nums; white-space: nowrap; min-width: 76px; text-align: center; }
 .tl-speed { display: flex; gap: 3px; }
 .tl-rec {
@@ -468,11 +495,14 @@ body {
   transition: background 0.12s ease;
 }
 .entry-row:hover { background: var(--panel); }
-/* The selected row: a quiet raised fill plus a thin accent edge — the one place
-   the accent appears in the list, so the current selection is unambiguous. */
+/* The selected row: a modern Raycast-style filled pill — a soft accent-tinted
+   fill across the whole rounded row, no left bar. The fill alone reads as
+   "selected" against the plain hover. */
 .entry.selected > .entry-row {
-  background: var(--elev);
-  box-shadow: inset 2px 0 0 var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, var(--panel));
+}
+.entry.selected > .entry-row:hover {
+  background: color-mix(in srgb, var(--accent) 18%, var(--panel));
 }
 
 /* Only failure (red) and the transient running pulse (amber) get a filled dot;

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -49,7 +49,7 @@ client of that engine; the dashboard and the room feed are others.
 
 ## The main tool
 
-`python_exec(code, budget=15, name=None)` runs `code` on the shared kernel and
+`python_exec(code, budget=15, intent=None)` runs `code` on the shared kernel and
 waits up to `budget` seconds. If the code finishes in time you get its output and
 result. If it is still running, it keeps going in the background as an entry in
 the in-kernel `jobs` dict and the call returns a job handle.

--- a/packages/mcp/ix_notebook_mcp/introspect.py
+++ b/packages/mcp/ix_notebook_mcp/introspect.py
@@ -34,8 +34,16 @@ _MAX_NAMES = 64
 # container contributes at most ``_BREADTH`` real children plus a single elision
 # marker. Mirrors the spirit of ``_MAX_NAMES`` — a session with a million-entry
 # dict must not turn one job-finish into a million-row payload.
-_MAX_DEPTH = 2
+#
+# Depth is generous so genuinely nested data (config trees, parsed JSON) expands
+# all the way; what actually keeps the payload bounded is ``_MAX_TOTAL_CHILDREN``,
+# a single ceiling on the *total* child rows emitted across the whole tree in one
+# ``namespace_rows`` call. Without it, ``_BREADTH ** _MAX_DEPTH`` is astronomical;
+# with it, deep nesting is free until the global budget runs out (then deeper
+# branches simply stop expanding).
+_MAX_DEPTH = 6
 _BREADTH = 32
+_MAX_TOTAL_CHILDREN = 2000
 
 # Bounded repr for previews: never walk a giant container or stringify megabytes.
 _repr = reprlib.Repr()
@@ -200,9 +208,13 @@ def namespace_rows(
     kernel's event loop on a job finish. Reuses :func:`describe`, so it is bounded
     and side-effect-free; a value whose introspection raises is skipped, not
     fatal."""
+    # One shared budget for the whole call: a mutable [remaining] cell decremented
+    # as child rows are emitted, so the total tree (across every top-level name) is
+    # bounded regardless of how deep or wide any one branch goes.
+    budget = [_MAX_TOTAL_CHILDREN]
     rows: list[dict] = []
     for name, value in islice(ns.items(), max_names):
-        row = _row(name, value, depth=0, max_depth=max_depth, breadth=breadth)
+        row = _row(name, value, depth=0, max_depth=max_depth, breadth=breadth, budget=budget)
         if row is not None:
             rows.append(row)
     # Only the top level sorts heaviest-first; children keep natural (dict/list)
@@ -211,7 +223,7 @@ def namespace_rows(
     return rows
 
 
-def _row(name, value, *, depth: int, max_depth: int, breadth: int) -> dict | None:
+def _row(name, value, *, depth: int, max_depth: int, breadth: int, budget: list[int]) -> dict | None:
     """Build one namespace row for ``name``/``value``, the single construction
     path shared by the top level and the recursion.
 
@@ -244,10 +256,11 @@ def _row(name, value, *, depth: int, max_depth: int, breadth: int) -> dict | Non
         "size": size,
         "shape": _ns_shape(value, kind),
     }
-    # Descend only into expandable kinds, and only while we have depth budget left.
-    # Children live one level deeper, so stop once depth would reach max_depth.
-    if kind in _EXPANDABLE_KINDS and depth < max_depth:
-        children = _children(value, kind, depth=depth + 1, max_depth=max_depth, breadth=breadth)
+    # Descend only into expandable kinds, while we have depth budget left, and while
+    # the global row budget is not yet spent. Children live one level deeper, so
+    # stop once depth would reach max_depth.
+    if kind in _EXPANDABLE_KINDS and depth < max_depth and budget[0] > 0:
+        children = _children(value, kind, depth=depth + 1, max_depth=max_depth, breadth=breadth, budget=budget)
         if children:
             row["children"] = children
     return row
@@ -260,7 +273,7 @@ def _elision_row(extra: int) -> dict:
     return {"name": "…", "type": "", "kind": "object", "repr": f"+{extra} more", "size": 0, "shape": ""}
 
 
-def _children(value, kind: str, *, depth: int, max_depth: int, breadth: int) -> list[dict]:
+def _children(value, kind: str, *, depth: int, max_depth: int, breadth: int, budget: list[int]) -> list[dict]:
     """Rows for the entries of an expandable container, in natural order.
 
     Bounded to ``breadth`` real children plus at most one elision marker, and it
@@ -268,19 +281,19 @@ def _children(value, kind: str, *, depth: int, max_depth: int, breadth: int) -> 
     billion-entry dict costs the same as a small one). Decides what to expand from
     the live ``value``: a mapping yields ``key -> value`` rows, a sequence yields
     indexed (or, for sets, repr-named) element rows, and a plain object yields its
-    public instance attributes. Any failure degrades to no children, never a
-    raise."""
+    public instance attributes. ``budget`` is the shared global row ceiling. Any
+    failure degrades to no children, never a raise."""
     try:
         if isinstance(value, dict):
-            return _mapping_children(value, depth=depth, max_depth=max_depth, breadth=breadth)
+            return _mapping_children(value, depth=depth, max_depth=max_depth, breadth=breadth, budget=budget)
         if isinstance(value, (list, tuple)):
-            return _sequence_children(value, depth=depth, max_depth=max_depth, breadth=breadth, indexed=True)
+            return _sequence_children(value, depth=depth, max_depth=max_depth, breadth=breadth, budget=budget, indexed=True)
         if isinstance(value, (set, frozenset)):
             # Sets are unordered, so an index name would be meaningless; name each
             # child by its bounded element repr instead.
-            return _sequence_children(value, depth=depth, max_depth=max_depth, breadth=breadth, indexed=False)
+            return _sequence_children(value, depth=depth, max_depth=max_depth, breadth=breadth, budget=budget, indexed=False)
         if kind == "object":
-            return _object_children(value, depth=depth, max_depth=max_depth, breadth=breadth)
+            return _object_children(value, depth=depth, max_depth=max_depth, breadth=breadth, budget=budget)
     except Exception:
         # Introspecting the container itself misbehaved (a dict-like whose
         # iteration raises, a __len__ that lies): show it as a leaf, not a crash.
@@ -288,7 +301,7 @@ def _children(value, kind: str, *, depth: int, max_depth: int, breadth: int) -> 
     return []
 
 
-def _mapping_children(value, *, depth: int, max_depth: int, breadth: int) -> list[dict]:
+def _mapping_children(value, *, depth: int, max_depth: int, breadth: int, budget: list[int]) -> list[dict]:
     """``key -> value`` rows for a dict, keyed by a short rendering of the key.
 
     ``islice`` over ``value.items()`` so we touch at most ``breadth + 1`` pairs of
@@ -296,6 +309,8 @@ def _mapping_children(value, *, depth: int, max_depth: int, breadth: int) -> lis
     the elision marker."""
     rows: list[dict] = []
     for k, v in islice(value.items(), breadth + 1):
+        if budget[0] <= 0:
+            break
         if len(rows) == breadth:
             # We pulled one entry past the cap purely to detect overflow. Count
             # the remainder via len() (O(1)) rather than walking the rest.
@@ -308,17 +323,20 @@ def _mapping_children(value, *, depth: int, max_depth: int, breadth: int) -> lis
         # str keys read cleanest unquoted-but-short; other keys go through the
         # bounded repr so a giant key cannot blow up the child name.
         name = k if isinstance(k, str) and len(k) <= 60 else _repr.repr(k)
-        child = _row(name, v, depth=depth, max_depth=max_depth, breadth=breadth)
+        budget[0] -= 1
+        child = _row(name, v, depth=depth, max_depth=max_depth, breadth=breadth, budget=budget)
         if child is not None:
             rows.append(child)
     return rows
 
 
-def _sequence_children(value, *, depth: int, max_depth: int, breadth: int, indexed: bool) -> list[dict]:
+def _sequence_children(value, *, depth: int, max_depth: int, breadth: int, budget: list[int], indexed: bool) -> list[dict]:
     """Element rows for a list/tuple/set, ``indexed`` choosing ``"[i]"`` names
     (ordered sequences) versus the element repr (unordered sets)."""
     rows: list[dict] = []
     for i, v in enumerate(islice(value, breadth + 1)):
+        if budget[0] <= 0:
+            break
         if len(rows) == breadth:
             try:
                 extra = len(value) - breadth
@@ -327,13 +345,14 @@ def _sequence_children(value, *, depth: int, max_depth: int, breadth: int, index
             rows.append(_elision_row(max(extra, 1)))
             break
         name = f"[{i}]" if indexed else _repr.repr(v)
-        child = _row(name, v, depth=depth, max_depth=max_depth, breadth=breadth)
+        budget[0] -= 1
+        child = _row(name, v, depth=depth, max_depth=max_depth, breadth=breadth, budget=budget)
         if child is not None:
             rows.append(child)
     return rows
 
 
-def _object_children(value, *, depth: int, max_depth: int, breadth: int) -> list[dict]:
+def _object_children(value, *, depth: int, max_depth: int, breadth: int, budget: list[int]) -> list[dict]:
     """Rows for a plain object's public instance attributes.
 
     Conservative on purpose: only the instance ``__dict__`` (via ``vars``), never
@@ -346,13 +365,15 @@ def _object_children(value, *, depth: int, max_depth: int, breadth: int) -> list
     except TypeError:
         # No instance __dict__ (slots-only, or a C type): nothing browsable.
         return []
-    rows: list[dict] = []
-    for attr in islice(members, breadth + 1):
+    # Collect the *eligible* attributes (public, str-named, data not behavior)
+    # first, then bound — so dunders and methods never consume a breadth slot nor
+    # inflate the `+N more` count. Unlike a dict/list (which can be enormous, so we
+    # cap iteration at breadth+1), an instance __dict__ is modest, so scanning it in
+    # full to filter correctly is cheap.
+    eligible: list[tuple[str, object]] = []
+    for attr in members:
         if not isinstance(attr, str) or attr.startswith("__"):
             continue
-        if len(rows) == breadth:
-            rows.append(_elision_row(max(len(members) - breadth, 1)))
-            break
         try:
             member = members[attr]
         except Exception:
@@ -363,9 +384,18 @@ def _object_children(value, *, depth: int, max_depth: int, breadth: int) -> list
             member, (types.FunctionType, types.MethodType, types.BuiltinFunctionType, type)
         ):
             continue
-        child = _row(attr, member, depth=depth, max_depth=max_depth, breadth=breadth)
+        eligible.append((attr, member))
+    rows: list[dict] = []
+    for attr, member in eligible[:breadth]:
+        if budget[0] <= 0:
+            break
+        budget[0] -= 1
+        child = _row(attr, member, depth=depth, max_depth=max_depth, breadth=breadth, budget=budget)
         if child is not None:
             rows.append(child)
+    extra = len(eligible) - breadth
+    if extra > 0:
+        rows.append(_elision_row(extra))
     return rows
 
 

--- a/packages/mcp/ix_notebook_mcp/pane_bridge.py
+++ b/packages/mcp/ix_notebook_mcp/pane_bridge.py
@@ -85,6 +85,11 @@ def _panes(conn) -> list[dict]:
         started = row.get("started_at")
         ended = row.get("ended_at")
         duration_ms = round((ended - started) * 1000) if ended and started else None
+        # The run's intent (its human title). The kernel defaults a nameless job's
+        # `name` to the run id, so treat name==id as "no intent" and pass None —
+        # exec_pane then titles the run by its first source line, never a bare id.
+        name = row.get("name")
+        intent = name if name and name != row["id"] else None
         panes.append(
             exec_pane(
                 row["id"],
@@ -95,7 +100,7 @@ def _panes(conn) -> list[dict]:
                 result=row.get("result") or "",
                 ok=_ok(status),
                 duration_ms=duration_ms,
-                title=row.get("name") or None,
+                title=intent,
             )
         )
         # Rich outputs (tables, plots, images) get their own html pane beside the
@@ -103,7 +108,7 @@ def _panes(conn) -> list[dict]:
         outputs = row.get("outputs") or []
         if any(_is_rich(out) for out in outputs) and (rendered := _render_outputs(outputs)):
             panes.append(
-                html_pane(f"{row['id']}/out", row.get("name") or "output", rendered, subtitle="output")
+                html_pane(f"{row['id']}/out", intent or "output", rendered, subtitle="output")
             )
     # The agent's curated presentation cells (the highlight reel the old UI's
     # cells pane showed), each rendered as an html pane in position order.

--- a/packages/mcp/tests/test_introspect_children.py
+++ b/packages/mcp/tests/test_introspect_children.py
@@ -157,6 +157,37 @@ def test_object_without_vars_has_no_children() -> None:
     assert "children" not in row
 
 
+def test_object_dunder_attrs_do_not_consume_breadth_or_hide_public_attrs() -> None:
+    # Regression: dunder instance attrs sitting in __dict__ must be filtered
+    # *before* the breadth window is applied. A naive islice(__dict__, breadth+1)
+    # lets dunders eat slots, silently dropping real public attrs (and skipping the
+    # elision marker), and inflates the `+N more` count with the hidden members.
+    class _C:
+        pass
+
+    obj = _C()
+    # Two leading dunder instance attrs, then four public ones (insertion order is
+    # preserved, so the dunders fall inside a naive window).
+    obj.__dict__["__hidden1"] = 1
+    obj.__dict__["__hidden2"] = 2
+    obj.a = 10
+    obj.b = 20
+    obj.c = 30
+    obj.d = 40
+
+    row = _only_row(obj, breadth=2)
+    children = row["children"]
+    # Exactly breadth real public attrs survive, then one elision marker — the
+    # dunders neither appear nor consume a slot.
+    assert [c["name"] for c in children[:2]] == ["a", "b"]
+    marker = children[-1]
+    assert marker["name"] == "…"
+    # The count reflects only the unrendered *eligible* attrs (c, d) — not the
+    # hidden dunders.
+    assert marker["repr"] == "+2 more"
+    assert len(children) == 3
+
+
 # --------------------------------------------------------------------------- #
 # leaf kinds: never carry children
 # --------------------------------------------------------------------------- #
@@ -208,3 +239,39 @@ def test_value_whose_describe_raises_degrades_to_no_row() -> None:
     names = {row["name"] for row in rows}
     assert "ok" in names
     assert "bad" not in names
+
+
+# --------------------------------------------------------------------------- #
+# deep nesting + the global row budget
+# --------------------------------------------------------------------------- #
+
+
+def _count_rows(rows: list[dict]) -> int:
+    """Total rows in a tree, including elision markers."""
+    return sum(1 + _count_rows(r.get("children") or []) for r in rows)
+
+
+def test_deep_nesting_expands_past_the_old_depth_two_limit() -> None:
+    # {"a": {"b": {"c": {"d": 1}}}} with the default depth: 'c' lives at depth 3
+    # and still expands to 'd' at depth 4 — impossible under the old _MAX_DEPTH=2.
+    row = _only_row({"a": {"b": {"c": {"d": 1}}}})
+    cur = row
+    for key in ("a", "b", "c"):
+        cur = {child["name"]: child for child in cur["children"]}[key]
+    assert "children" in cur
+    assert cur["children"][0]["name"] == "d"
+
+
+def test_global_budget_bounds_total_rows() -> None:
+    # A structure that, unbounded, is exponential (40-wide x 6 deep ≈ 4e9 nodes).
+    # The shared budget must cap the total emitted rows regardless of depth/breadth,
+    # proving the tree can never become a runaway payload.
+    nested: object = 1
+    for _ in range(6):
+        nested = {f"k{i}": nested for i in range(40)}
+    rows = introspect.namespace_rows({"v": nested})
+    total = _count_rows(rows)
+    # Real children are capped at _MAX_TOTAL_CHILDREN; elision markers (one per
+    # over-breadth container) add at most as many again. Far below the exponential
+    # blowup the budget prevents.
+    assert total <= 2 * introspect._MAX_TOTAL_CHILDREN + 100


### PR DESCRIPTION
## What

Follow-up polish on the Obsidian dashboard (#1105), plus the correctness/contract fixes from the post-merge review.

**UX**
- **Feed dedup** — a run's rich-output `<id>/out` html pane no longer shows as a duplicate feed row; it folds into the run's detail panel. One row per job.
- **IDE kind icons** — IntelliJ-autocomplete-style glyphs (KindIcon) replace the text chips in the namespace (table / `{}` / `[]` / `#` / text / cube / `()` / `C`), tinted by kind.
- **Raycast-style selection** — a soft accent-tinted filled pill, no dated left bar.
- **Auto-hide timeline** — the replay scrubber is hidden by default and reveals as a floating, blurred overlay pill on hover, so an idle session (no recording — just `0:00 / 0:00`) shows no permanent bar.

**Namespace recursion (proper deep nesting)**
- `_MAX_DEPTH` 2 → 6, made safe by a single global row budget (`_MAX_TOTAL_CHILDREN`) threaded through the walk, so a deep/wide tree can never become a runaway payload (also resolves the review's payload-ceiling note).

**Review fixes**
- **C1** — `_object_children` filters eligible attrs *before* the breadth window, so dunders/methods no longer silently drop real public attributes.
- **C2** — object `+N more` elision counts only eligible-but-unrendered attrs.
- **M2** — a run with no `intent` titles by its first source line, not the run id (`pane_bridge` treats `name==id` as "no intent"); matches the documented fallback.
- **M1** — README `python_exec` signature `name=` → `intent=`.

## Verification (local, on this head SHA)

- `pytest tests/test_introspect_children.py`: **16 passed** (incl. new C1/C2 + deep-nesting + global-budget)
- `svelte-check` + `vite build`: clean
- `nix run .#lint`: 5/5 green · `nix build .#dashboard`: builds (site embedded)
- Headless-Chrome screenshots of all four UX changes, dark + light.

(sent by an AI agent via Claude Code, model Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add deep namespace nesting, kind icons, feed dedup, and auto-hide timeline to dashboard
> - Increases namespace introspection max depth from 2 to 6 and adds a global 2000-row budget cap in [`introspect.py`](https://github.com/indexable-inc/index/pull/1106/files#diff-006579eb39a5fc5841047297950ecbb104d7094d82bdaec8fe1b9a4eeeda9cad); dunder attributes no longer distort breadth or elision counts
> - Replaces text chips with SVG kind icons in namespace rows via a new [`KindIcon.svelte`](https://github.com/indexable-inc/index/pull/1106/files#diff-a061c70cb555f413ab7f0725b208ea676853266f8c0abbf4be7afb7482d384a8) component
> - Filters `<run-id>/out` panes from the feed list in [`FeedView.svelte`](https://github.com/indexable-inc/index/pull/1106/files#diff-78efb5ebd6c72ecf149c6db5f83d3226d1df16b5d517fd1f813afe1ad8c7587c), rendering rich output inline in the selected run's detail panel instead
> - Wraps the timeline in a `.timeline-dock` container and reworks CSS so it auto-hides as a blurred floating pill, revealed on hover/focus
> - Behavioral Change: selected feed rows now render as a filled accent pill instead of a left-edge accent bar
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d51f735.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->