### PR TITLE
dashboard: review fixes — namespace recompute dedup + dead-code cleanup

### DIFF
--- a/packages/dashboard-core/site/src/components/NamespaceBody.svelte
+++ b/packages/dashboard-core/site/src/components/NamespaceBody.svelte
@@ -6,14 +6,16 @@
   // (so the keyboard can walk the whole tree across sessions); this component just
   // renders the flattened item list the shared builder produces.
   import type { Pane } from '$lib/types';
-  import { buildNsItems, parseRows } from '$lib/namespace';
+  import { buildNsItems, parseRows, type NsItem } from '$lib/namespace';
   import NsRow from './NsRow.svelte';
 
   // Controlled by the Namespace view (selection + expansion lifted out for
-  // keyboard nav), or uncontrolled when used as the generic `namespace` renderer
-  // — in which case it keeps its own expand state and ignores selection.
+  // keyboard nav, and the flattened `items` built once there so the body never
+  // re-parses), or uncontrolled when used as the generic `namespace` renderer —
+  // in which case it parses its own body and keeps its own expand state.
   let {
     pane,
+    items: itemsProp,
     prefix = 'r',
     expanded,
     selected = null,
@@ -21,6 +23,7 @@
     onToggle,
   }: {
     pane: Pane;
+    items?: NsItem[];
     prefix?: string;
     expanded?: Record<string, boolean>;
     selected?: string | null;
@@ -39,7 +42,8 @@
       }),
   );
 
-  const items = $derived(buildNsItems(parseRows(pane.body), exp, prefix));
+  // Prefer the parent's precomputed list; only parse/flatten here when standalone.
+  const items = $derived(itemsProp ?? buildNsItems(parseRows(pane.body), exp, prefix));
 </script>
 
 <div class="ns">

--- a/packages/dashboard-core/site/src/components/NamespaceView.svelte
+++ b/packages/dashboard-core/site/src/components/NamespaceView.svelte
@@ -22,9 +22,6 @@
       .sort((a, b) => (a.key < b.key ? -1 : 1)),
   );
 
-  // Total top-level names across sessions, for the header count.
-  const total = $derived(sessions.reduce((n, s) => n + parseRows(s.pane.body).length, 0));
-
   // Selection + expansion are owned here so the keyboard can walk the whole tree
   // across sessions. Each session renders with the same `s<index>` path prefix the
   // flat nav list uses, so paths line up between rendering and navigation.
@@ -32,14 +29,31 @@
   let expanded = $state<Record<string, boolean>>({});
   const prefixOf = (si: number): string => `s${si}`;
 
+  // Parse + flatten each session once. `store.panes` is reassigned on every live
+  // frame, so every body-derived value re-runs each frame; building the item list
+  // here and feeding it to the header count, the nav list, and each NamespaceBody
+  // keeps it to a single parse + flatten per session per frame instead of 2–3×.
+  const sessionItems = $derived(
+    sessions.map((s, si) => ({
+      ...s,
+      items: buildNsItems(parseRows(s.pane.body), expanded, prefixOf(si)),
+    })),
+  );
+
+  // Total top-level names across sessions, for the header count.
+  const total = $derived(
+    sessionItems.reduce(
+      (n, s) => n + s.items.filter((it) => it.kind === 'row' && it.depth === 0).length,
+      0,
+    ),
+  );
+
   // The flattened, currently-visible rows in render order — what j/k walk.
   const flat = $derived.by(() => {
     const out: { path: string; row: Row }[] = [];
-    sessions.forEach((s, si) => {
-      for (const it of buildNsItems(parseRows(s.pane.body), expanded, prefixOf(si))) {
-        if (it.kind === 'row') out.push({ path: it.path, row: it.row });
-      }
-    });
+    for (const s of sessionItems) {
+      for (const it of s.items) if (it.kind === 'row') out.push({ path: it.path, row: it.row });
+    }
     return out;
   });
 
@@ -117,16 +131,16 @@
   </header>
 
   <div class="nsview-body">
-    {#if sessions.length === 0}
+    {#if sessionItems.length === 0}
       <div class="view-empty">{store.live ? 'no live namespace' : 'connecting…'}</div>
     {:else}
-      {#each sessions as s, si (s.key)}
-        {#if sessions.length > 1}
+      {#each sessionItems as s (s.key)}
+        {#if sessionItems.length > 1}
           <div class="nsview-session">{s.pane.subtitle || s.pane.scope || 'session'}</div>
         {/if}
         <NamespaceBody
           pane={s.pane}
-          prefix={prefixOf(si)}
+          items={s.items}
           {expanded}
           {selected}
           {onSelect}

--- a/packages/dashboard-core/site/src/lib/types.ts
+++ b/packages/dashboard-core/site/src/lib/types.ts
@@ -50,8 +50,3 @@ export interface Pane extends PaneRecord {
   key: string;
   scope: string;
 }
-
-export interface Point {
-  x: number;
-  y: number;
-}

--- a/packages/dashboard-core/site/src/style.css
+++ b/packages/dashboard-core/site/src/style.css
@@ -20,9 +20,6 @@
   --accent-soft: light-dark(rgba(83, 88, 224, 0.10), rgba(168, 176, 255, 0.13));
   --cursor:      light-dark(#9a9ba2, #a8b0ff);
   --sel:         light-dark(#ededf0, #18181c);
-  /* Faint dot grid on the board, so panning a mostly-empty canvas still reads
-     as motion. */
-  --grid-dot:    light-dark(#e2e2e5, #19191c);
 
   /* Kind/status hues for namespace badges and chips — used sparingly, tinted. */
   --k-green: light-dark(#3f9a52, #52c98e);
@@ -44,7 +41,7 @@
       --ink: #ececef; --ink-dim: #82828c; --ink-faint: #4a4a53;
       --live: #52c98e; --dead: #e0635b; --accent: #a8b0ff;
       --accent-soft: rgba(168, 176, 255, 0.13); --cursor: #a8b0ff;
-      --sel: #18181c; --grid-dot: #19191c;
+      --sel: #18181c;
       --k-green: #52c98e; --k-amber: #d6a44a; --k-red: #e0635b; --k-blue: #7fb4ff; --k-pink: #e08fc7;
     }
   }


### PR DESCRIPTION
Follow-up to #1109 acting on the adversarial review pass. The review returned **0 Correctness/Security blockers**; these are the confirmed Performance/Maintainability findings, all introduced by #1109.

- **Perf (medium)** — the Namespace view parsed + flattened each session 2–3× per live frame (`NamespaceView.flat` *and* each `NamespaceBody.items` recomputed the same `buildNsItems(parseRows(body))`). Now the view builds each session's flat item list once and passes it down; the header count and keyboard nav list read from the same list. Since `store.panes` is reassigned every frame, this turns 3× `JSON.parse` + 2× tree-flatten per session per frame into one of each. `NamespaceBody` still parses its own body when used standalone as the generic `namespace` renderer.
- **Maint (low)** — removed the dead `Point` interface (orphaned by the `positions.ts` deletion).
- **Maint (low)** — removed the dead `--grid-dot` CSS var + stale comment (orphaned by replacing the pannable dot-grid canvas with the tiling WM).

Declined: the feed `/`-filter re-lowercasing finding (perf/low) — the reviewer marked it optional and the idle/empty-query path is already zero-cost.

## Verification
- `svelte-check` + `vite build`: 0 errors, 0 warnings
- `nix build .#dashboard`: exit 0
- `nix run .#lint`: 5/5
- Demo: namespace tree renders + keyboard-navigates with the precomputed items

(sent by an AI agent via Claude Code, model Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate namespace recomputation in `NamespaceView` and clean up dead code
> - [`NamespaceView.svelte`](https://github.com/indexable-inc/index/pull/1112/files#diff-7800b17a415c2846268522453284cc3238f07d373d5552e2d04629d27290be2a) now parses and flattens each session's namespace once per reactive update into `sessionItems`, reusing that list for the header count, keyboard nav list, and `NamespaceBody` rendering instead of re-parsing multiple times.
> - [`NamespaceBody.svelte`](https://github.com/indexable-inc/index/pull/1112/files#diff-464b4974895c7bdd85a987f760c656e0a5fa17aa83f76e539294fbadb12cacb7) gains an optional `items` prop; when provided, it skips its own parse/flatten of `pane.body` and renders from the supplied list.
> - Removes the unused `Point` interface from [`types.ts`](https://github.com/indexable-inc/index/pull/1112/files#diff-e45cdc89a234b991792804f6d77e676ea3275e5fa0f3606b075e3aa41c18e3c8) and the `--grid-dot` CSS variable from [`style.css`](https://github.com/indexable-inc/index/pull/1112/files#diff-44e3e8358edb308d06622224230b9eb8d07683d2f280425d4ce181431cbd6566).
> - Behavioral Change: the header row count is now derived from flattened items filtered to `kind === 'row'` at `depth === 0`, rather than `parseRows(...).length`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07fb9f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->