### PR TITLE
docs(dev): make the single-VM 'consume dev.nix for a new VM' path obvious

### DIFF
--- a/examples/dev-fleet/README.md
+++ b/examples/dev-fleet/README.md
@@ -11,6 +11,11 @@ topology, and an opt-in shared SMB volume that gives the whole fleet one Claude
 ix up
 ```
 
+This example declares a multi-node `ix.dev.fleet`. Omit that block and the same
+`dev.nix` is a **single VM named `dev`** that `ix up` (or `nix run .#up` in the
+forkable [template](../../templates/dev)) builds and creates - the simplest way
+to consume a `dev.nix` for one new VM. The fleet below is the scale-up.
+
 ## Shape
 
 - [`dev.nix`](dev.nix) is the module a user edits after `ix dev init`. Top-level

--- a/templates/dev/README.md
+++ b/templates/dev/README.md
@@ -17,11 +17,21 @@ fork it freely. `flake.nix` is boilerplate you should not need to touch.
 
 ## Use
 
-```sh
-# Bring up the fleet (or the single `dev` VM if no fleet is declared):
-nix run .#up
+Out of the box (no `ix.dev.fleet` declared) this config is a **single VM named
+`dev`**. One command builds `dev.nix` into an OCI image and creates that VM:
 
-# Mirror the other fleet verbs:
+```sh
+nix run .#up
+```
+
+That is the "consume my `dev.nix` for a new VM" path: `nix run .#up` realises
+the image from your config and creates the VM through the same call `ix new`
+uses. Re-run it after editing `dev.nix` to roll the VM forward.
+
+Declare nodes under `ix.dev.fleet` and the same command brings up the whole
+fleet instead. The other verbs mirror `ix fleet <sub>`:
+
+```sh
 nix run .#health
 nix run .#diff
 nix run .#down


### PR DESCRIPTION
## What

Makes the single-VM path in RFC 0007's `mkDev` discoverable. With a bare `dev.nix` (no `ix.dev.fleet` declared), `ix.dev.fleet` defaults to `{ dev = {}; }` - one VM named `dev`. `nix run .#up` realises the OCI image from your config and creates the VM through the same `client.create` RPC that `ix new --name` uses (`packages/ix-fleet/.../__init__.py` documents this as *"like `ix new --name`"*).

That **is** the "consume my `dev.nix` for a new VM" capability the imperative `ix new .#dev` idea was reaching for. It already works; the docs just buried it:

- `templates/dev/README.md` mentioned it only as a parenthetical (*"...or the single `dev` VM if no fleet is declared"*).
- `examples/dev-fleet/` is fleet-only, so it never showcases the one-VM case.

## Changes

- **`templates/dev/README.md`** - lead the Use section with the single-VM case as the default, framed explicitly as the "new VM from your `dev.nix`" path; the fleet becomes the scale-up.
- **`examples/dev-fleet/README.md`** - note that omitting `ix.dev.fleet` yields a single `dev` VM, pointing back at the template.

Docs only; no behavior change. The literal single-verb `ix new .#dev` / `ix dev use` ergonomic remains the cross-repo `ix`-CLI follow-up RFC 0007 already tracks.

## Note

`nix run .#lint` currently fails on pre-existing `.nix` issues under `lib/dev/` and `lib/image/dev.nix` (statix/astlog/nixfmt from the RFC 0007 merge) - unrelated to this markdown-only change and present on `main`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify the single-VM `dev.nix` workflow in dev and dev-fleet README docs
> Updates [templates/dev/README.md](https://github.com/indexable-inc/index/pull/1116/files#diff-d1d6b49ecd1f23b6bba11d1158f0f8ebabd310a6c811c584bb54da0a9ae5fce2) and [examples/dev-fleet/README.md](https://github.com/indexable-inc/index/pull/1116/files#diff-7c1e4f8c484fa4621c446f5f81a50ee6f5078f302472b29a0290eadee7b4c6e8) to make the single-VM path explicit.
>
> - Explains that omitting `ix.dev.fleet` produces a single VM named `dev`, built with `nix run .#up`
> - Adds a standalone `nix run .#up` invocation block and notes that re-running updates the VM
> - Frames `ix.dev.fleet` as the scale-up path from the single-VM setup, with the same command bringing up the whole fleet
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 792b25f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->