### PR TITLE
feat(ix-fleet): declarative per-VM secret refs

### DIFF
--- a/lib/image/fleet.nix
+++ b/lib/image/fleet.nix
@@ -53,6 +53,9 @@ let
     // {
       env = lib.mergeAttrsList (map (part: part.env or { }) parts);
       l7ProxyPorts = lib.unique (lib.concatMap (part: part.l7ProxyPorts or [ ]) parts);
+      # User-store secret names union across defaults/fleet/node layers (like
+      # l7ProxyPorts), so a fleet-wide default attaches alongside per-node refs.
+      secrets = lib.unique (lib.concatMap (part: part.secrets or [ ]) parts);
     };
 
   # Every deployment key the plan consumes. `deployment` is a plain attrset
@@ -69,8 +72,10 @@ let
     "env"
     "ipv4"
     "l7ProxyPorts"
+    "noDefaultSecrets"
     "recreateOnUp"
     "region"
+    "secrets"
     "snapshot"
     "switch"
   ];
@@ -289,6 +294,10 @@ let
       groups = nodeGroups;
       inherit (deploy) env;
       inherit (deploy) l7ProxyPorts;
+      # Per-VM user-store secret references, attached at create like
+      # `ix new --secret NAME`; `ix-fleet` verifies they exist before deploying.
+      secrets = deploy.secrets or [ ];
+      noDefaultSecrets = deploy.noDefaultSecrets or false;
       dependsOn = expandedDependencies.${name};
       healthChecks = planHealthChecks config;
     }

--- a/packages/ix-fleet/default.nix
+++ b/packages/ix-fleet/default.nix
@@ -38,6 +38,10 @@ let
       region = "us-west-1";
       ipv4 = false;
       snapshot = false;
+      # Exercise the declarative per-VM secret refs through the dry-run create
+      # path (no live call, so the names need not exist in any store here).
+      secrets = [ "GH_TOKEN" ];
+      noDefaultSecrets = true;
     };
   };
 

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -82,6 +82,14 @@ class FleetNode(BaseModel):
     tags: list[str] = Field(default_factory=empty_str_list)
     groups: list[str] = Field(default_factory=empty_str_list)
     env: dict[str, str] = Field(default_factory=empty_str_dict)
+    # Names of secrets in the per-user store (`ix secret set NAME`) to attach to
+    # this VM at create time. Resolved server-side and injected as env vars or
+    # files exactly like `ix new --secret NAME`. References only, never values:
+    # plaintext belongs in the store, not the fleet plan.
+    secrets: list[str] = Field(default_factory=empty_str_list)
+    # Skip auto-attach of secrets marked `--default` in the store, matching
+    # `ix new --no-default-secrets`.
+    noDefaultSecrets: bool = False
     l7ProxyPorts: list[int] = Field(default_factory=empty_int_list)
     dependsOn: list[str] = Field(default_factory=empty_str_list)
     healthChecks: dict[str, HealthCheck] = Field(default_factory=dict)
@@ -363,11 +371,44 @@ def find_node(rows: list[ix_sdk.BranchInfo], name: str) -> ix_sdk.BranchInfo | N
     return next((row for row in rows if row.name == name), None)
 
 
+async def verify_secrets_available(plan: FleetPlan, selectors: list[str], *, dry_run: bool) -> None:
+    """Fail before doing any work if a selected node references a secret that is
+    not in the user store, mirroring the `ix secret check` deploy-time bridge.
+
+    Only explicitly named references are validated: secrets marked `--default`
+    attach server-side and are not declared in the plan. Skipped on dry runs,
+    which make no live calls.
+    """
+    referenced: set[str] = set()
+    for node in selected_nodes(plan, selectors):
+        referenced.update(node.secrets)
+    if dry_run or not referenced:
+        return
+    stored = {secret.name for secret in await client().list_secrets()}
+    missing = sorted(referenced - stored)
+    if missing:
+        raise RuntimeError(
+            "missing secret(s) in the store: "
+            + ", ".join(missing)
+            + "; store them first with `ix secret set NAME`"
+        )
+
+
+def secrets_note(node: FleetNode) -> str:
+    parts: list[str] = []
+    if node.secrets:
+        parts.append(f"secrets={sorted(node.secrets)}")
+    if node.noDefaultSecrets:
+        parts.append("no-default-secrets")
+    return f", {', '.join(parts)}" if parts else ""
+
+
 async def create_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
     if dry_run:
         step(
             f"+ create {node.name} from {image} "
-            f"(region={node.region}, ipv4={node.ipv4}, l7={list(node.l7ProxyPorts)})"
+            f"(region={node.region}, ipv4={node.ipv4}, l7={list(node.l7ProxyPorts)}"
+            f"{secrets_note(node)})"
         )
         return
     await client().create(
@@ -377,6 +418,8 @@ async def create_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
         env=dict(sorted(node.env.items())),
         l7_proxy_ports=list(node.l7ProxyPorts),
         ipv4=node.ipv4,
+        secrets=sorted(node.secrets),
+        no_default_secrets=node.noDefaultSecrets,
     )
 
 
@@ -821,6 +864,7 @@ async def cmd_switch(plan: FleetPlan, args: argparse.Namespace) -> None:
             await run_switch_node_workflow(node, args)
         return
 
+    await verify_secrets_available(plan, args.on, dry_run=args.dry_run)
     extra_args: list[str] = []
     if args.no_snapshot:
         extra_args.append("--no-snapshot")
@@ -839,6 +883,7 @@ async def cmd_replace(plan: FleetPlan, args: argparse.Namespace) -> None:
             await run_replace_node_workflow(node, args)
         return
 
+    await verify_secrets_available(plan, args.on, dry_run=args.dry_run)
     extra_args: list[str] = []
     if args.skip_push:
         extra_args.append("--skip-push")
@@ -853,6 +898,7 @@ async def cmd_up(plan: FleetPlan, args: argparse.Namespace) -> None:
             await run_up_node_workflow(node, args)
         return
 
+    await verify_secrets_available(plan, args.on, dry_run=args.dry_run)
     extra_args: list[str] = []
     if args.skip_push:
         extra_args.append("--skip-push")
@@ -879,6 +925,7 @@ async def cmd_health(plan: FleetPlan, args: argparse.Namespace) -> None:
 
 
 async def cmd_bootstrap(plan: FleetPlan, args: argparse.Namespace) -> None:
+    await verify_secrets_available(plan, args.on, dry_run=args.dry_run)
     for batch in dependency_batches(plan, args.on):
         await asyncio.gather(*(bootstrap_node(node, dry_run=args.dry_run) for node in batch))
 

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -90,6 +90,64 @@ class FleetPlanValidationTests(unittest.TestCase):
         self.assertEqual(plan.secrets.values["sessionKey"].path, "/run/secrets/fleet/sessionKey")
         self.assertEqual(plan.secrets.values["sessionKey"].model_extra, {"generate": True})
 
+    def test_per_vm_secret_refs_default_empty_and_round_trip(self) -> None:
+        bare = ix_fleet.FleetNode.model_validate(fleet_node("web"))
+        self.assertEqual(bare.secrets, [])
+        self.assertFalse(bare.noDefaultSecrets)
+
+        node = fleet_node("api")
+        node["secrets"] = ["GH_TOKEN", "DATABASE_URL"]
+        node["noDefaultSecrets"] = True
+        parsed = ix_fleet.FleetNode.model_validate(node)
+        self.assertEqual(parsed.secrets, ["GH_TOKEN", "DATABASE_URL"])
+        self.assertTrue(parsed.noDefaultSecrets)
+
+
+class VerifySecretsAvailableTests(unittest.TestCase):
+    @staticmethod
+    def _fake_client(names: list[str]) -> typing.Any:
+        stored = [type("UserSecret", (), {"name": name})() for name in names]
+
+        class FakeClient:
+            async def list_secrets(self) -> list[typing.Any]:
+                return stored
+
+        return lambda: FakeClient()
+
+    def _plan(self, secrets: list[str]) -> typing.Any:
+        node = fleet_node("web")
+        node["secrets"] = secrets
+        return ix_fleet.FleetPlan.model_validate(fleet_plan(["web"], [node]))
+
+    def test_passes_when_every_referenced_secret_exists(self) -> None:
+        plan = self._plan(["GH_TOKEN"])
+        with patch.object(ix_fleet, "client", self._fake_client(["GH_TOKEN", "OTHER"])):
+            asyncio.run(ix_fleet.verify_secrets_available(plan, [], dry_run=False))
+
+    def test_raises_listing_missing_secrets(self) -> None:
+        plan = self._plan(["GH_TOKEN", "DATABASE_URL"])
+        with patch.object(ix_fleet, "client", self._fake_client(["GH_TOKEN"])):
+            with self.assertRaisesRegex(RuntimeError, "missing secret\\(s\\) in the store: DATABASE_URL"):
+                asyncio.run(ix_fleet.verify_secrets_available(plan, [], dry_run=False))
+
+    def test_dry_run_makes_no_live_call(self) -> None:
+        plan = self._plan(["MISSING"])
+
+        def fail_client() -> typing.Any:
+            raise AssertionError("dry-run preflight must not touch the store")
+
+        with patch.object(ix_fleet, "client", fail_client):
+            asyncio.run(ix_fleet.verify_secrets_available(plan, [], dry_run=True))
+
+    def test_no_references_makes_no_live_call(self) -> None:
+        plan = self._plan([])
+
+        def fail_client() -> typing.Any:
+            raise AssertionError("preflight must not query the store with no references")
+
+        with patch.object(ix_fleet, "client", fail_client):
+            asyncio.run(ix_fleet.verify_secrets_available(plan, [], dry_run=False))
+
 
 class PushReplacementImageTests(unittest.TestCase):
     def test_uses_image_subcommand(self) -> None:

--- a/packages/ix-sdk-python/default.nix
+++ b/packages/ix-sdk-python/default.nix
@@ -92,13 +92,20 @@ else
     # The surface ix-fleet depends on, asserted once so a bad wheel fails the
     # check rather than ix-fleet at runtime.
     assertSurface = ''
+      import inspect
       import ix_sdk
       assert ix_sdk.__version__, "missing __version__"
       for name in ("Client", "Group", "GroupMember"):
           assert hasattr(ix_sdk, name), f"missing ix_sdk.{name}"
-      for method in ("create_group", "add_group_member", "create", "branches"):
+      for method in ("create_group", "add_group_member", "create", "branches", "list_secrets"):
           assert hasattr(ix_sdk.Client, method), f"missing Client.{method}"
-      print("ix_sdk", ix_sdk.__version__, "imported; group + lifecycle surface present")
+      # ix-fleet declares per-VM secrets through these create kwargs; assert the
+      # packaged wheel accepts them so a stale wheel fails here, not at deploy.
+      for kwarg in ("secrets", "no_default_secrets"):
+          for method in ("create", "create_with_progress"):
+              params = inspect.signature(getattr(ix_sdk.Client, method)).parameters
+              assert kwarg in params, f"Client.{method} missing {kwarg} kwarg"
+      print("ix_sdk", ix_sdk.__version__, "imported; group + lifecycle + secret surface present")
     '';
 
     # Import through a real `withPackages` environment, the way consumers use it,

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1607,6 +1607,8 @@ let
 
   fleet = ix.mkFleet {
     deployment.region = "us-west-1";
+    # Fleet-wide per-VM user-store secret default; unions with per-node refs.
+    deployment.secrets = [ "FLEET_DEFAULT" ];
     secrets = {
       provider = {
         type = "vaultwarden";
@@ -1630,6 +1632,8 @@ let
         deployment = {
           destination = "fleet-web:latest";
           ipv4 = true;
+          secrets = [ "GH_TOKEN" ];
+          noDefaultSecrets = true;
         };
         modules = [
           (
@@ -4574,6 +4578,17 @@ let
           && fleet.planValue.secrets.values.sessionKey.path == "/run/secrets/fleet/sessionKey"
           && fleet.planValue.secrets.values.sessionKey.generate;
         message = "fleet plans should carry declarative secret specs";
+      }
+      {
+        assertion =
+          fleetPlan.web.secrets == [
+            "FLEET_DEFAULT"
+            "GH_TOKEN"
+          ]
+          && fleetPlan.web.noDefaultSecrets
+          && fleetPlan.db.secrets == [ "FLEET_DEFAULT" ]
+          && !fleetPlan.db.noDefaultSecrets;
+        message = "per-VM secret refs should union fleet-wide and node-level names and carry the default opt-out";
       }
       {
         assertion = fleetPlan."worker-0".baseName == "worker" && fleetPlan."worker-1".replicaIndex == 1;


### PR DESCRIPTION
## What

Fleet authors can now attach user-store secrets to a VM **declaratively**, instead of only imperatively via `ix new --secret NAME`.

```nix
web = {
  deployment = {
    secrets = [ "GH_TOKEN" "DATABASE_URL" ];  # names from `ix secret set`
    noDefaultSecrets = true;                   # opt out of --default auto-attach
  };
};
# deployment.secrets at the fleet level unions into every node (like l7ProxyPorts)
```

## Why

The user secret store (ENG-1779) is declarative-ready end to end - `build_commit_from_oci` takes `secrets`/`no_default_secrets`, `ix new --secret` uses it, and the Python SDK `create(secrets=, no_default_secrets=)` exposes it. The only missing surface was the fleet plan: `FleetNode` had no way to reference store secrets and `create_node` never passed them.

(`FleetPlan.secrets` already existed but is a different mechanism - the vaultwarden/runtime-directory provider for infra secrets, not the per-user store.)

## Changes

- **`FleetNode`** gains `secrets` (names from the per-user store) + `noDefaultSecrets`; `create_node` forwards them to `client.create`.
- **`lib/image/fleet.nix`** surfaces `deployment.secrets`/`noDefaultSecrets`, unioning names across fleet-wide and per-node layers, and emits them into the plan JSON.
- **`verify_secrets_available`** preflights `up`/`switch`/`replace`/`bootstrap`, failing fast on missing references before any image push (mirrors the `ix secret check` deploy-time bridge).

References only, never values: plaintext stays in the store, not the plan.

## Tests

- New Python unit tests (model round-trip + preflight pass/fail/dry-run/no-ref).
- New Nix assertion in `tests/default.nix` (fleet-wide + node-level union, opt-out).
- `dryRunUp` plan exercises the field through the dry-run create path.

Verified locally: Python tests pass against a stubbed SDK; the Nix generator pure-evaluates to the expected per-node `secrets`/`noDefaultSecrets`. Full NixOS eval / `dryRunUp` run in x86_64 CI.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add declarative per-VM secret refs and preflight validation to ix-fleet
> - Adds `secrets: list[str]` and `noDefaultSecrets: bool` fields to the `FleetNode` pydantic model, passed through to `client().create` at VM creation time.
> - Introduces `verify_secrets_available`, an async preflight that compares referenced secret names against `client().list_secrets()` and raises `RuntimeError` for any missing; called before work begins in `cmd_up`, `cmd_switch`, `cmd_replace`, and `cmd_bootstrap`.
> - Fleet-level and per-node secret refs are unioned in [fleet.nix](https://github.com/indexable-inc/index/pull/1117/files#diff-9836ea3ef1875452d04d6213563ea9b0df81e37a277277836b0cb9df0ced1fa0) and propagated through the plan; node-level `noDefaultSecrets` is preserved independently.
> - Adds build-time surface checks to [ix-sdk-python/default.nix](https://github.com/indexable-inc/index/pull/1117/files#diff-80f46c8d1744ebc070c811611b94e45d792b24cdeeae53fcaf78e4db15945032) asserting `list_secrets` and secret kwargs exist on the SDK client.
> - Risk: all four commands now abort before any VM work if a referenced secret is absent from the user store (no change in dry-run mode).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9cef4a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->