### PR TITLE
fix(ix-windows): gate to darwin systems so linux flake-check builds

### DIFF
--- a/packages/ix-windows/package.nix
+++ b/packages/ix-windows/package.nix
@@ -1,7 +1,19 @@
 {
   id = "ix-windows";
-  packageSet = true;
-  flake = true;
+  # macOS-only for now: wry links the system WebKit framework on darwin, while
+  # Linux (WebKitGTK) is a later add (see default.nix). Gating every target to
+  # darwin keeps the linux flake/package/rust-test paths from pulling the
+  # gtk/webkit2gtk build inputs that are not wired up, so a linux `flake-check`
+  # never compiles this crate. `inRustWorkspace` stays true so the workspace
+  # source/lockfile stay coherent (source files only, no compile).
+  packageSet.systems = [
+    "aarch64-darwin"
+    "x86_64-darwin"
+  ];
+  flake.systems = [
+    "aarch64-darwin"
+    "x86_64-darwin"
+  ];
   inRustWorkspace = true;
   passthruTests = true;
 }


### PR DESCRIPTION
## Problem

`flake-check` is **red on `main`**. The failing derivations are GTK/webkit native build scripts — `atk-sys`, `cairo-sys-rs`, `gdk-pixbuf-sys`, `gdk-sys`, `gio-sys`, `gtk-sys`, `webkit2gtk-sys`, `tao`, `wry` — failing `pkg-config` in the build sandbox.

## Root cause

`packages/ix-windows` is a `tao`+`wry` native-webview app. Its `default.nix` already documents itself as darwin-only (wry links the system WebKit framework on macOS; the Linux WebKitGTK path is unwired) and sets `meta.platforms` to darwin. But `meta.platforms` is advisory only — nothing in the Nix build honors it.

The real gate is the package **registry** (`packages/registry.nix`), which enumerates crates per system via `packageSet.systems` / `flake.systems`. `ix-windows/package.nix` left those as bare `true`, so on `x86_64-linux` the registry still included it. Its per-crate rust test/clippy units (`passthruTestEntriesFor`) then compiled `tao`/`wry`, pulling the gtk/webkit2gtk build scripts that fail.

## Fix

Gate `packageSet` and `flake` to the darwin systems, matching the established darwin-only packages (`chrome-vm`, `dia`):

```nix
packageSet.systems = [ "aarch64-darwin" "x86_64-darwin" ];
flake.systems      = [ "aarch64-darwin" "x86_64-darwin" ];
```

Because `packageSetEntriesFor` and `passthruTestEntriesFor` both gate `ix-windows` through the same `packageSet.systems` check, this removes it from the linux package set **and** the linux rust test/clippy units — so linux never compiles the crate. `inRustWorkspace = true` stays, so the workspace source/lockfile remain coherent (source files only, no compile); `ix-windows` is the only workspace consumer of `tao`/`wry`.

## Verification (eval, on this aarch64 host)

- `ix-windows` is now **absent** from `packages.x86_64-linux` (it is present on `main`).
- `ix-windows` is **still present** on `packages.aarch64-darwin` — no over-exclusion.

The x86_64 `flake-check`/`ciChecks` build runs in CI.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate `ix-windows` package to Darwin systems to fix Linux flake-check builds
> Limits the `ix-windows` crate to Darwin systems in [package.nix](https://github.com/indexable-inc/index/pull/1118/files#diff-b43640d4fc00d1791919192986e243e28798771dcb6d0320a0ce45f262c2b24c) by replacing boolean `packageSet` and `flake` flags with arrays scoped to `aarch64-darwin` and `x86_64-darwin`. This prevents Linux flake-check builds from pulling in WebKitGTK dependencies. The crate remains in the Rust workspace source and is unaffected on Darwin.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9375843.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->