### PR TITLE
docs: greenfield per-domain documentation tree

### DIFF
--- a/docs/agents/agents-md/overview.md
+++ b/docs/agents/agents-md/overview.md
@@ -1,0 +1,103 @@
+# agents-md
+
+`packages/agents-md` is the Rust CLI that renders, diffs, checks, and writes the
+always-on agent instruction files: `AGENTS.md` (Codex) and `CLAUDE.md` (Claude).
+The crate keeps the name `agents-md`, but its flake output is `agent-context`
+(`package.nix:5-9`) to match the `lib.agentContext` surface that owns both the
+always-on instructions and the on-demand skills.
+
+The actual instruction text is not in this crate. It is assembled by
+`lib/agent-context` (nix-lib domain) from the fragments under the repo's
+`agent-context/` tree and handed to this CLI through env at wrap time. The CLI is
+a thin, content-agnostic renderer: it only knows "a list of (target, file_name,
+generated_path) documents" and how to diff/check/write them.
+
+## Purpose
+
+`AGENTS.md`/`CLAUDE.md` are generated and gitignored, never committed
+(`agent-context/README.md`). This CLI is the contributor convenience that writes
+them to disk for preview (`nix run .#agent-context -- --write`) and the gate that
+verifies an on-disk copy still matches the assembled source (`--check`).
+
+## Public surface
+
+CLI flags (`src/main.rs:16-41`, clap):
+
+- `--target all|codex|claude` (default `all`): limit to one instruction target.
+  `codex` maps to internal target string `"codex"`, `claude` to `"claude"`
+  (`src/main.rs:50-58`).
+- `--write [PATH]` (default missing value `.`): write generated files. With a
+  directory, writes `<file_name>` into it; with a single selected target and a
+  file path, writes that path.
+- `--check [PATH]` (default missing value `.`): check on-disk files; exits
+  non-zero if any differ or are symlinks.
+- `--print`: print one generated file to stdout; requires a single target
+  (`src/main.rs:211-220`).
+- `--diff-renderer auto|plain|delta` (default `auto`): render the default
+  no-mode diff as plain unified text or piped through `delta`.
+
+The four flags `--write`, `--check`, `--print` are mutually exclusive; with none
+set the default mode is `Diff` against the current directory (`mode_for`,
+`src/main.rs:94-109`). Env inputs:
+
+- `AGENTS_MD_DOCUMENTS` (required, `src/main.rs:13`): path to a JSON array of
+  `{target, file_name, generated_path}` documents (`Document`,
+  `src/main.rs:67-72`). Set by the wrapper.
+- `AGENTS_MD_DELTA` (`src/main.rs:14`): path to the `delta` binary used by the
+  TTY diff renderer; defaults to `delta` on PATH.
+
+## Key behavior
+
+- **Target inference from a path.** With `--target all` and a path whose file
+  name matches a configured `file_name` (e.g. `AGENTS.md`), the CLI infers the
+  single matching document (`infer_document_from_path`, `src/main.rs:255-260`); a
+  directory path keeps all documents. A dotted directory that exists is treated
+  as a directory, not a file (`existing_path_is_file`, `src/main.rs:280-282`).
+- **Check is strict about symlinks.** `--check` treats a symlink at the target
+  path as stale (`src/main.rs:173-178`); `--write` removes an existing symlink
+  before writing a real file (`src/main.rs:348-350`). This matters because the
+  skills package is copied rather than symlinked (Claude Code's autocomplete
+  filters symlinks), and the same no-symlink policy is enforced here.
+- **Diff output.** `diff_documents` builds a unified diff with headers
+  `current/<path>` vs `generated/<file_name>` (`unified_diff`,
+  `src/main.rs:297-304`); `auto` renderer pipes through `delta` only when stdout
+  is a TTY, falling back to plain text if `delta` fails (`write_diff`,
+  `src/main.rs:306-320`).
+- **Empty/missing current file** reads as empty string for diffing, so the first
+  write shows a full add rather than erroring (`read_current_text`,
+  `src/main.rs:289-295`).
+
+Tests in `src/main.rs:355-438` cover target inference, file-vs-directory path
+resolution, and the dotted-directory edge cases.
+
+## How it is built and wired
+
+`default.nix` selects the `agents-md` binary via
+`ix.cargoUnit.selectBinaryWithTests`, then wraps it with `ix.agentContext.mkApp`
+(`lib/agent-context/default.nix:179-212`). `mkApp` writes each assembled document
+to a `writeText` file, generates the `agent-context-documents.json` config, and
+`makeWrapper`s the binary with `--set AGENTS_MD_DOCUMENTS <config>` and `--set
+AGENTS_MD_DELTA <delta>`. The wrapped derivation's `mainProgram` stays
+`agents-md`, so the command is `agents-md` even though the flake attr is
+`agent-context`:
+
+```
+nix run .#agent-context -- --write          # write AGENTS.md + CLAUDE.md
+nix run .#agent-context -- --check          # CI/contributor gate
+nix run .#agent-context -- --target claude --print
+```
+
+## Relationship to agent-context
+
+- `agent-context/` (repo root): the fragment tree. `sections/*.md` are fragments;
+  `agents/` holds named sub-agent context. Each fragment's `disclosure:
+  always|progressive` frontmatter decides whether it joins the always-on core
+  (what this CLI writes) or becomes a skill (what [skill-lint](../skill-lint/overview.md)
+  lints).
+- `lib/agent-context` (nix-lib domain): parses the fragments, asserts the
+  always-on character cap (`alwaysCharCap`), builds the `claude-md` / `codex-md`
+  / `skills` outputs, and provides `mkApp`. This crate documents only the CLI;
+  the assembly internals live in the nix-lib domain, not here.
+- The `SessionStart` hook `agent-instructions.sh` (`.claude/hooks/`) is what
+  actually delivers the core to a live session; this CLI is the disk-preview and
+  check path, not the runtime injector.

--- a/docs/agents/claude-hooks/overview.md
+++ b/docs/agents/claude-hooks/overview.md
@@ -1,0 +1,116 @@
+# claude-hooks
+
+`packages/claude-hooks` is one compiled binary with three Claude Code hook
+subcommands, replacing the old hand-rolled `writeShellScript` hooks in
+`packages/claude-code`. The governing rule: every hook fails OPEN and SILENT.
+Any missing input, parse error, or kill-switch returns with no stdout, because a
+noisy or broken hook is strictly worse than no hook
+(`src/main.rs:1-10`).
+
+```
+claude-hooks session-digest    # SessionStart
+claude-hooks worktree-guard    # PreToolUse
+claude-hooks prompt-priors     # UserPromptSubmit
+```
+
+Dispatch is on `argv[1]` (`main`, `src/main.rs:66-77`); an unknown subcommand
+prints to stderr and exits 2. Every other path exits 0. Output, when any, is a
+single JSON line wrapping a `hookSpecificOutput` object (`Wrap<T>`/`emit`,
+`src/main.rs:115-127`).
+
+## Shared conventions
+
+- **Kill switches.** A subcommand returns immediately if its
+  `CLAUDE_CODE_DISABLE_*` env var is present and non-empty (`flag_set`,
+  `src/main.rs:82-84`).
+- **Env-injected tool paths.** The claude-code wrapper passes tool paths and the
+  baked default via env: `IX_GIT`, `IX_SEARCH`, `IX_DEFAULT_PRIMARY_CHECKOUTS`
+  (`src/main.rs:7-10`). User-facing knobs keep their `CLAUDE_CODE_*` names.
+- **Char caps.** Injected context is truncated by char count, not bytes
+  (`cap_chars`, `src/main.rs:96-98`).
+
+## session-digest (SessionStart)
+
+Reads `~/.cache/ix/context-digest.md`, caps it to `DIGEST_CAP = 6000` chars
+(~1500 tokens, inside Claude Code's 10,000-char `additionalContext` limit), and
+emits it as `additionalContext` with `hookEventName: "SessionStart"`
+(`session_digest`, `src/main.rs:131-147`). Missing or empty file -> silent. Kill
+switch: `CLAUDE_CODE_DISABLE_CONTEXT_DIGEST`. The digest itself is rendered
+out-of-band (ENG-2708); this hook only cats it.
+
+## worktree-guard (PreToolUse)
+
+Denies a file-edit tool call whose TARGET path resolves into a protected primary
+checkout, so the agent is pushed to work in a dedicated worktree
+(`worktree_guard`, `src/main.rs:151-220`). Matcher in claude-code is
+`Edit|MultiEdit|Write|NotebookEdit` (`packages/claude-code/default.nix:258`).
+
+Flow:
+
+1. Read the `tool_input.file_path` (or `notebook_path`) from the hook stdin JSON
+   (`src/main.rs:159-166`). Absent/empty -> silent allow.
+2. Resolve the target: absolute path stands alone; a relative path resolves
+   against the payload `cwd` (falling back to `PWD`, then `.`). It judges the
+   target, never the session (`src/main.rs:168-180`).
+3. Walk up to the nearest existing ancestor directory, since a new file's parent
+   may not exist yet (`src/main.rs:182-191`).
+4. Run `git -C <dir> rev-parse --path-format=absolute` for `--git-dir`,
+   `--git-common-dir`, `--show-toplevel` using `IX_GIT` (`git_rev_parse`,
+   `src/main.rs:222-239`). If the private git-dir differs from the common dir it
+   is a linked worktree -> allow (`src/main.rs:200-203`).
+5. If `--show-toplevel` matches a protected pattern, emit a `deny` with
+   `hookEventName: "PreToolUse"`, `permissionDecision: "deny"`, and a reason that
+   tells the agent to create a worktree (`src/main.rs:208-219`).
+
+Protected patterns come from `CLAUDE_CODE_PRIMARY_CHECKOUTS` (user override) or
+`IX_DEFAULT_PRIMARY_CHECKOUTS` (wrapper-baked), colon-separated, empties dropped;
+an empty list disables the guard (`primary_checkouts`, `src/main.rs:243-251`).
+Matching uses `glob::Pattern` with shell `case`-glob semantics where `*` crosses
+`/` (`matches_protected`, `src/main.rs:255-259`). Kill switch:
+`CLAUDE_CODE_DISABLE_WORKTREE_GUARD`. In claude-code the whole `PreToolUse` block
+is only installed when `primaryCheckouts != []` (`default.nix:257`).
+
+## prompt-priors (UserPromptSubmit)
+
+Injects score-gated ambient priors from the corpus store, but only after passing
+several cheap gates so it stays net-positive (`prompt_priors`,
+`src/main.rs:263-289`). Kill switch: `CLAUDE_CODE_DISABLE_PROMPT_PRIORS`. Gates,
+all must pass:
+
+- **Word gate.** At least `MIN_WORDS = 8` whitespace tokens
+  (`passes_word_gate`, `src/main.rs:291-293`): below this, ambient recall is
+  measured net-negative.
+- **Fleet-noun gate.** The prompt must contain a whole word from the
+  `FLEET_NOUNS` allowlist (`src/main.rs:33-64`, `has_fleet_noun`); a prompt
+  without one embeds near everything and pulls vendored-code noise. Case
+  insensitive, whole-word (substring `reindexing` does not match `index`).
+- **Credential gate.** `MXBAI_API_KEY` set or `~/.mgrep/token.json` exists
+  (`has_credential`, `src/main.rs:302-304`).
+
+If gated through, it runs `IX_SEARCH` with the prompt and
+`--json --compact --no-rerank --max-count 3 --source
+claude_history,shell,github` (`run_search`, `src/main.rs:306-349`) under a hard
+2s budget (single-shot poll loop; kill on expiry). Hits are filtered to score >=
+`SCORE_GATE = 0.70` and rendered with a stale/cross-user disclaimer header,
+capped to `PRIORS_CAP = 4800` chars (~1200 tokens) (`render_priors`,
+`src/main.rs:351-372`). Each hit's provenance line is `source [by user]
+[timestamp] score N` (`provenance`, `src/main.rs:376-396`), matching the old jq
+projection so the model can discount stale content. In claude-code this hook (and
+`IX_SEARCH`) is wired only when the `search` sibling package is in scope
+(`hooks.nix:17-20,35`).
+
+## How it is built and wired
+
+`default.nix` selects the `claude-hooks` binary with
+`ix.cargoUnit.selectBinaryWithTests` (flake output `claude-hooks`,
+`package.nix`). The claude-code layer re-wraps it in
+`packages/claude-code/hooks.nix`: `makeBinaryWrapper` sets `IX_GIT`,
+`IX_DEFAULT_PRIMARY_CHECKOUTS`, and (conditionally) `IX_SEARCH`, then registers
+the three subcommands as hook commands in the generated settings JSON
+(`packages/claude-code/default.nix:244-285`) with generous per-hook timeouts (5s,
+10s, 5s) that sit well past the fail-open budgets. `install-check.nix` asserts
+the fail-open behavior, the digest cap, and the guard deny/allow paths.
+
+Unit tests (`src/main.rs:398-483`) cover the char cap, the word and fleet-noun
+gates, the protected-glob slash-crossing, the priors score gate and cap, and the
+provenance formatting.

--- a/docs/agents/claude-stories/overview.md
+++ b/docs/agents/claude-stories/overview.md
@@ -1,0 +1,108 @@
+# claude-stories
+
+`packages/claude-stories` puts an Instagram-style row of "stories" in the Claude
+Code status line: each teammate's avatar (initials in a gradient ring) and what
+they are working on right now, served peer-to-peer with no central server. It is
+a Tokio/axum CLI with four subcommands (`src/main.rs:33-59`).
+
+```
+claude-stories publish [--path DIR]            # write your story to a state file
+claude-stories serve [--port 4810] [--bind 0.0.0.0]   # serve /story over HTTP
+claude-stories render [--port 4810]            # status-line row of peers' stories
+claude-stories show [--path DIR]               # print your story as JSON (debug)
+```
+
+`DEFAULT_PORT = 4810` (`src/main.rs:24`). Wiring: `render` is the `statusLine`
+command, `publish` is a `SessionStart` hook, and `serve` runs once per host
+(README); none of that lives in this crate, it is `~/.claude/settings.json`
+config.
+
+## Modules
+
+- `story.rs`: the `Story` record, git derivation, and the shared state file.
+- `discovery.rs`: peer discovery (tailnet or explicit list).
+- `avatar.rs`: text-art avatar rendering for the status line.
+
+## Story and state (`story.rs`)
+
+A `Story` is `{name, repo, branch, subject, ts, url?}` (`src/story.rs:15-30`).
+`derive(path)` opens the git repo with `git2` (vendored libgit2, no system
+dependency, `Cargo.toml:15-19`) and fills it from `HEAD`: branch shorthand,
+latest commit summary as the "what I'm working on" caption, `user.name` (falling
+back to the commit author, then `"anonymous"`), the repo basename from the
+`origin` remote, and a GitHub https URL when the remote is GitHub
+(`src/story.rs:54-115`). Non-GitHub remotes get no URL rather than a guessed one.
+
+State lives at `$XDG_STATE_HOME/claude-stories/story.json` (or
+`~/.local/state/...`); `publish` writes it, `serve` reads it (`state_path`,
+`write_state`, `read_state`, `src/story.rs:126-152`). `is_fresh(now)` enforces the
+24h visibility window `TTL_SECS = 86400` with a checked subtraction so an
+`i64::MIN` peer timestamp cannot overflow, and future-dated stories are rejected
+(`src/story.rs:32-43`, test at `:169-177`).
+
+## Discovery (`discovery.rs`)
+
+`Discovery::from_env()` chooses a transport (`src/discovery.rs:19-37`):
+
+- `CLAUDE_STORIES_PEERS=host[:port],...` set -> `Peers` (explicit list, for
+  testing or off-tailnet use).
+- otherwise -> `Tailnet`.
+
+`Tailnet` runs `tailscale status --json` and takes every online peer's IPv4
+(`100.x`) address (`tailnet_endpoints`, `src/discovery.rs:79-106`). The tailnet
+is already an authenticated, NAT-traversed directory of online devices, so it
+doubles as the peer list: no DHT, no bootstrap nodes, no OAuth. `endpoints(port)`
+normalizes each peer into a `/story` URL (`story_url`, `src/discovery.rs:48-62`):
+bare host -> `http://host:port/story`, `host:port` -> `http://host:port/story`,
+full URL passed through.
+
+## Render and serve (`main.rs`)
+
+- **`serve`** is an axum router with one route `GET /story` returning the state
+  file as JSON (404 when nothing published, 500 on read error)
+  (`src/main.rs:96-118`). It binds `0.0.0.0` by default and is unauthenticated;
+  it serves low-sensitivity data (your latest commit subject) and relies on
+  tailnet ACLs, so firewall it or `--bind` your tailnet IP on shared networks
+  (README "Known limitations").
+- **`render`** builds the endpoint list, fans out concurrent fetches with a
+  1500ms-timeout `reqwest` client into a `JoinSet`, keeps only fresh stories, and
+  prints the avatar row (`src/main.rs:120-148`). A peer that is offline, slow, or
+  storyless is simply absent from the row: that is the expected steady state, not
+  an error (`src/main.rs:137-138`).
+
+## Avatars (`avatar.rs`)
+
+Claude Code strips Kitty graphics APC sequences from status-line output
+(`anthropics/claude-code#39024`), so real profile photos are impossible there;
+each avatar is two half-circle glyphs `◖ ◗` around up-to-two uppercase initials,
+colored along an Instagram-gradient (`GRADIENT`, `src/avatar.rs:11-18`;
+`initials`, `:59-77`). `row(stories)` sorts newest-first, prefixes a
+`STORIES` label (with a leading camera glyph) and a dim `+` "your story" bubble,
+and joins the avatars (`src/avatar.rs:110-118`).
+
+Security detail: a story's `url` comes from untrusted peer JSON, so it is wrapped
+in an OSC 8 hyperlink only when it is plain http(s) and free of control
+characters (`is_safe_url`/`link`, `src/avatar.rs:79-93`). Without that guard a
+tailnet host could inject terminal escapes into a victim's status line; the test
+at `:138-146` pins this.
+
+## How it is built
+
+`default.nix` selects the `claude-stories` binary via
+`ix.cargoUnit.selectBinaryWithTests` (flake output `claude-stories`,
+`package.nix`):
+
+```
+nix build .#claude-stories
+```
+
+Tests live inline in each module (`avatar`, `discovery`, `story`) and cover
+initials, gradient endpoints, URL safety, URL normalization, and freshness
+bounds.
+
+## Known limits
+
+From the README: no real avatars in the status line (escapes stripped);
+off-tailnet needs explicit `CLAUDE_STORIES_PEERS`; `serve` is unauthenticated and
+binds all interfaces; your story is the last repo you published from, not a live
+view of each session's cwd (re-run `publish`, which the `SessionStart` hook does).

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -1,0 +1,130 @@
+# Agents
+
+Tooling that wraps coding agents (Claude Code, Codex, Pi) for the index fleet:
+generate the instruction/skill context an agent reads at session start, run
+Claude Code hooks, share what teammates are working on, distill reusable lessons
+out of past transcripts, lint the skills the agents load, run small command DAGs,
+and wrap Pi into bounded-search and earned-trust executor harnesses. Every unit
+here is a developer-facing CLI or a thin Nix-built wrapper around an external
+agent binary; none runs in the production serving path.
+
+Read this page first, then the component page for the unit you are touching.
+
+## Units
+
+| unit | kind | flake output | role |
+| --- | --- | --- | --- |
+| [agents-md](agents-md/overview.md) | Rust crate | `agent-context` | render/check/write the always-on `AGENTS.md` (Codex) and `CLAUDE.md` (Claude) instruction files from Nix-assembled fragments. |
+| [claude-hooks](claude-hooks/overview.md) | Rust crate | `claude-hooks` | one binary, three Claude Code hook subcommands: `session-digest`, `worktree-guard`, `prompt-priors`. |
+| [claude-stories](claude-stories/overview.md) | Rust crate | `claude-stories` | Instagram-style status-line "stories": teammates' avatars + current work, served peer-to-peer over a Tailscale tailnet. |
+| [distiller](distiller/overview.md) | Python (Nix-only) | `distiller` (bin `ix-distiller`) | distill ReasoningBank-style lessons + per-session outcome verdicts from local Claude Code transcripts into corpus parquet slices. |
+| [skill-lint](skill-lint/overview.md) | Rust crate | `skill-lint` | lint and autofix `SKILL.md` files with a real YAML frontmatter parser. |
+| [dag-runner](dag-runner/overview.md) | Rust crate | `dag-runner` | tiny task runner: a JSON DAG of shell commands run in parallel as deps resolve, with graceful termination and progress. |
+| [pi-harnesses](pi-harnesses/overview.md) | Nix-only (TS/JS + C) | `pi-harness`, `pi-base`, `pi-prosecutor`, `pi-beam` | declarative wrappers around `pi`: the locked-down Room engine, a UX pack, an earned-trust prosecutor, and the bounded [beam-search](pi-harnesses/beam.md) executor. |
+
+The Rust crates are workspace members of the root `Cargo.toml` and build through
+`ix.cargoUnit.selectBinaryWithTests` (see the nix-lib domain). `distiller` is a
+pure-Python package built with `toPythonModule` + `makeWrapper`. The
+`pi-harnesses` outputs are not Rust: they are `stdenv`/`buildNpmPackage`
+derivations that wrap nixpkgs' pinned `pi-coding-agent`.
+
+## How it fits together
+
+These units are largely independent CLIs, but several share data and seams:
+
+- **The session-start context loop.** The repo's `agent-context/` tree
+  (fragments with YAML frontmatter) is assembled by `lib/agent-context` (nix-lib
+  domain) into two outputs: an always-on core document and a set of progressive
+  skills. [agents-md](agents-md/overview.md) is the Rust CLI that renders, diffs,
+  checks, and writes that core to `AGENTS.md`/`CLAUDE.md`; its `agent-context`
+  flake wrapper bakes the assembled documents in via `AGENTS_MD_DOCUMENTS`. The
+  files are not committed: a `SessionStart` hook (`agent-instructions.sh`) prints
+  the core as `additionalContext` and copies the skills into `.claude/skills`.
+  [skill-lint](skill-lint/overview.md) is the linter for those skill files (and
+  the handwritten ones under `skills/`).
+- **Claude Code hook injection.** [claude-hooks](claude-hooks/overview.md) is
+  wired into the `packages/claude-code` wrapper (`hooks.nix`, `default.nix`):
+  `session-digest` on
+  `SessionStart`, `worktree-guard` on `PreToolUse`, `prompt-priors` on
+  `UserPromptSubmit`. The hooks consume tool paths via env (`IX_GIT`,
+  `IX_SEARCH`) and emit Claude Code's `hookSpecificOutput` JSON.
+- **The transcript -> corpus -> search funnel.**
+  [distiller](distiller/overview.md) reads `~/.claude/projects/**/*.jsonl`, calls
+  `claude -p` headless to distill lessons + judge outcomes, and writes
+  `source=distilled_facts` and `source=session_outcomes` parquet slices that ride
+  the existing archive -> Iceberg lake -> Mixedbread funnel. The
+  `prompt-priors` hook in claude-hooks then surfaces those (and other corpus
+  sources) back into new sessions via `IX_SEARCH`.
+- **dag-runner is the batch substrate.** [dag-runner](dag-runner/overview.md)
+  powers `nix run .#health-checks` and is the planned replacement for
+  `ix-fleet`'s sequential loops. It is not specific to agents but lives here as
+  general developer task running; see the AGENTS.md "why dag-runner" section.
+- **pi-harnesses share one builder.** All four Pi wrappers select models from
+  one `models.nix` table (`claude` = opus-4-8, `codex` = gpt-5.5 medium) and take
+  API keys only from the caller's env; the engine keeps a hardened C launcher,
+  the rest use `shared/mk-pi-harness.nix`.
+
+## Invariants
+
+- **Hooks fail open and silent.** Every claude-hooks subcommand returns with no
+  stdout on any missing input, parse error, or kill-switch
+  (`packages/claude-hooks/src/main.rs:1-5`): a broken or noisy hook is strictly
+  worse than no hook. Kill switches are `CLAUDE_CODE_DISABLE_*` env vars.
+- **Instruction files are generated, never committed.** `AGENTS.md`/`CLAUDE.md`
+  stay gitignored; `agents-md --check` is the gate that they match the assembled
+  source, and the size of the always-on tier is a `nix build` invariant
+  (`alwaysCharCap`).
+- **Distilled slices obey the corpus contract exactly.** The 9-column schema,
+  `sha256:<hex>` body hashes, and `_manifest.json` corpus hash mirror
+  `packages/sink/parquet` byte-for-byte, and every slice is re-validated with a
+  second parquet reader (polars) before it is trusted
+  (`packages/distiller/src/distiller/corpus.py`).
+- **Beam/prosecutor judge on ground truth, not on a model's say-so.** beam ranks
+  branches by a score command's exit code then diff size
+  (`packages/pi-harnesses/shared/ext-lib/scoring.js`); the prosecutor isolates
+  context (a fresh `pi --no-session` with no transcript) so two agents cannot
+  launder each other's hallucinations.
+- **Untrusted peer/transcript input is bounded.** claude-stories rejects
+  future-dated or overflowing peer timestamps and refuses to emit non-http(s) or
+  control-char URLs as hyperlinks; distiller skips unparseable transcript lines
+  and clips every extracted field.
+
+## Glossary
+
+- **agent-context fragment**: a markdown file under `agent-context/sections/`
+  with YAML frontmatter (`name`, `disclosure`, `description`). `disclosure:
+  always` joins the always-on core; `disclosure: progressive` becomes a skill.
+- **always-on core**: the concatenated `always` fragments rendered to
+  `AGENTS.md` (Codex) / `CLAUDE.md` (Claude); every session reads it in full.
+- **skill**: a `SKILL.md` directory loaded on demand by Claude Code; only its
+  `name` + `description` stay always-visible. Linted by skill-lint.
+- **hook**: a Claude Code lifecycle callback (`SessionStart`, `PreToolUse`,
+  `UserPromptSubmit`) returning a `hookSpecificOutput` JSON object.
+- **kill switch**: a `CLAUDE_CODE_DISABLE_*` env var that makes a hook exit
+  silently.
+- **story**: a `{name, repo, branch, subject, ts, url}` record describing what a
+  developer is currently working on; visible for 24h (`TTL_SECS`).
+- **lesson / item**: one self-contained ReasoningBank-style fact distilled from
+  transcripts, carried with a stable id and merged incrementally.
+- **outcome verdict**: an LLM-judged per-session label (`success` / `partial` /
+  `failure` / `abandoned`) in the `session_outcomes` slice.
+- **corpus slice**: a `host=/user=/source=` parquet directory plus
+  `_manifest.json` that the leader fold ingests generically.
+- **DAG node**: one entry in a dag-runner spec: an argv `command` plus optional
+  `depends_on`, `env`, `timeout_secs`.
+- **harness posture**: whether a Pi wrapper removes the model's tools (engine
+  lockdown) or leaves them present (prosecutor, beam, base).
+- **beam search**: running 2-4 candidate approaches on isolated git worktrees
+  under turn + wall-clock budgets, then ranking by ground truth.
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| agents-md | [agents-md/overview.md](agents-md/overview.md) | render/check/write generated `AGENTS.md` + `CLAUDE.md` from assembled fragments |
+| claude-hooks | [claude-hooks/overview.md](claude-hooks/overview.md) | one binary, three fail-open Claude Code hooks |
+| claude-stories | [claude-stories/overview.md](claude-stories/overview.md) | status-line teammate stories over a Tailscale tailnet |
+| distiller | [distiller/overview.md](distiller/overview.md) | transcripts -> lessons + outcome verdicts -> corpus parquet slices |
+| skill-lint | [skill-lint/overview.md](skill-lint/overview.md) | lint + autofix `SKILL.md` frontmatter with a real YAML parser |
+| dag-runner | [dag-runner/overview.md](dag-runner/overview.md) | parallel JSON-DAG command runner with progress and graceful termination |
+| pi-harnesses | [pi-harnesses/overview.md](pi-harnesses/overview.md) | Pi wrappers: engine, base UX, prosecutor; plus [beam search](pi-harnesses/beam.md) |

--- a/docs/agents/dag-runner/overview.md
+++ b/docs/agents/dag-runner/overview.md
@@ -1,0 +1,112 @@
+# dag-runner
+
+`packages/dag-runner` is a tiny task runner: it takes a JSON DAG of shell
+commands, runs each node as soon as its dependencies finish (so graph shape, not
+fixed "levels", determines parallelism), and renders inline progress. It powers
+`nix run .#health-checks` and is the planned replacement for `ix-fleet`'s
+sequential per-node loops (`README.md`). It is meant for short, hands-off
+batches, not a long-running supervisor; rationale (why not `process-compose`/
+`devenv-tasks`) is in the AGENTS.md "why dag-runner" section
+(`agent-context/sections/08b-why-dag-runner.md`).
+
+It is a Tokio current-thread async binary (`src/main.rs:142`).
+
+```
+dag-runner <spec.json> [--output auto|tui|plain|json] [--only NAMES]
+```
+
+## Spec schema
+
+A single JSON object with a `nodes` map (`Spec`/`NodeSpec`, `src/main.rs:69-89`).
+Each node:
+
+| field | type | required | meaning |
+| --- | --- | --- | --- |
+| `command` | `string[]` | yes | argv; `command[0]` is the program. Must be non-empty. |
+| `depends_on` | `string[]` | no (`[]`) | names of nodes that must succeed first. |
+| `env` | `{string:string}` | no (`{}`) | extra env layered on the runner's own; entries shadow inherited vars. |
+| `timeout_secs` | `u64` | no (`null`) | wall-clock seconds before SIGTERM (then SIGKILL after ~500ms). |
+
+Validation runs before any node is spawned (`validate`, `src/main.rs:208-221`)
+and rejects an empty `command`, a `depends_on` naming an unknown node, and cycles
+(direct or indirect) via a three-color DFS that prints the cycle path
+(`detect_cycle`/`visit_cycle`, `src/main.rs:262-296`).
+
+`--only NAMES` (comma-separated, repeatable) restricts the run. The cut is
+validated up front (`filter_only`, `src/main.rs:226-260`): unknown names are
+rejected, and a kept node depending on a dropped one is rejected too, so a
+filtered run keeps the same "every kept node has every dep it needs" invariant
+(no silent skips, no exit-code surprises).
+
+## Scheduling and execution
+
+Spawn order is the deterministic topological order of the graph, with ties broken
+lexicographically so logs are stable across runs
+(`topological_order`/`visit_topo`, `src/main.rs:298-326`). Each node becomes a
+`Shared<BoxFuture<Outcome>>` that awaits its dependency futures, then either skips
+(if any dep did not `Succeeded`) or spawns the command; all node futures are
+`tokio::spawn`ed and awaited (`run`, `src/main.rs:330-423`). Independent nodes run
+concurrently.
+
+`run_command` (`src/main.rs:440-531`) builds a `tokio::process::Command` with the
+env overlay, piped stdout/stderr, and `kill_on_drop(true)` (so a dropped future
+never leaks a child). It then races, `biased`, in one `select!`:
+cancellation, then the optional timeout, then `child.wait()`
+(`src/main.rs:480-494`). Outcomes (`Completion` -> `Outcome`):
+
+- success -> `Succeeded`.
+- non-zero exit -> `Failed(code)`.
+- spawn failure (binary missing) -> `Failed(127)`.
+- timeout -> `terminate_child` then `Failed(124)` (matches `coreutils timeout`),
+  with stderr ending `dag-runner: node timed out after Ns`.
+- cancellation -> `terminate_child` then `Failed(130)`.
+
+`terminate_child` (`src/main.rs:571-588`) sends `SIGTERM` via
+`libc::kill` (Tokio only exposes `SIGKILL` through `start_kill`), waits a 500ms
+grace, then `SIGKILL`s if still alive. Child stdout/stderr is captured (not
+streamed) by `tee_lines` (`src/main.rs:593-613`), which in TUI mode also updates
+the node's spinner with the latest line.
+
+## Cancellation
+
+A background task listens for Ctrl-C (`spawn_cancel_listener`,
+`src/main.rs:179-193`): the first SIGINT broadcasts a `watch` cancel flag (every
+running child is SIGTERMed then SIGKILLed); a second SIGINT hard-exits 130
+immediately. A cancellation always exits 130 even if every node already finished,
+so callers distinguish operator-cancel from normal completion
+(`main`, `src/main.rs:169-175`).
+
+## Output modes
+
+`resolve_mode` (`src/main.rs:195-206`): `auto` picks `tui` on a TTY, else
+`plain`.
+
+- **tui**: an indicatif `MultiProgress` with one inline spinner per node (style
+  from the `progress-style` crate via `progress_style::spinner()`,
+  `src/main.rs:425-431`). Finished spinners stay in scrollback.
+- **plain**: timestamped `started` / `<outcome>` lines.
+- **json**: NDJSON event stream on stdout, three shapes discriminated by `event`
+  (`Event`, `src/main.rs:115-135`): `node_started` (`ts_ms`), `node_finished`
+  (`outcome`, `exit_code`, `duration_ms`), and a final `summary`. Ordering
+  guarantees: a node's `node_started` precedes its `node_finished` and does not
+  appear until every dependency's `node_finished` has; `summary` is last.
+
+In every non-json mode, after all nodes settle a one-line summary plus per-node
+breakdown and the captured stdout/stderr of failed nodes go to stderr
+(`print_summary`, `src/main.rs:719-756`).
+
+## Exit code
+
+`exit_code` (`src/main.rs:704-717`) = `max(worst node exit code, 1 if any node
+was skipped, else 0)`. Skipped counts as 1; a failure with exit `N` contributes
+`N`; multiple failures take the largest code. Operator Ctrl-C overrides to 130.
+
+## How it is built
+
+`default.nix` selects the `dag-runner` binary via
+`ix.cargoUnit.selectBinaryWithTests` (flake output `dag-runner`, `package.nix`).
+Note the renamed integration test target: cargo-unit flattens test targets into
+one namespace, so a bare `integration` name would collide with other crates'; the
+crate names it `integration_dag_runner` for a stable key
+(`Cargo.toml:27-33`). `tests/integration.rs` plus inline unit tests cover the
+graph semantics.

--- a/docs/agents/distiller/overview.md
+++ b/docs/agents/distiller/overview.md
@@ -1,0 +1,130 @@
+# distiller
+
+`packages/distiller` (`ix-distiller`) distills ReasoningBank-style lessons from
+local Claude Code transcripts into three artifacts: human-readable facts markdown
+per `(user, project)`, a `source=distilled_facts` corpus parquet slice (the
+lessons), and a `source=session_outcomes` slice with one LLM-judged outcome
+verdict per session. The slices ride the existing archive -> Iceberg lake ->
+Mixedbread funnel with zero Rust changes: the leader fold ingests any
+`(host, user, source)` slice generically (`README.md`, `default.nix:1-5`).
+
+It is a pure-Python package (not a Rust workspace member). Entry point
+`ix-distiller` runs `python -m distiller` (`default.nix:55-59`).
+
+```
+ix-distiller --days 7 --user andrew --out /var/lib/ix-distiller \
+  [--project index] [--model claude-haiku-4-5-20251001] \
+  [--upload [--env-file /run/ix-secret-store/env/ix-indexer]]
+```
+
+## Pipeline
+
+The CLI (`src/distiller/cli.py`) drives five stages:
+
+1. **Scan** (`transcripts.scan`, `transcripts.py:213-243`). Parse every
+   `~/.claude/projects/*/*.jsonl` newer than the `--days` window (mtime gate plus
+   a message-timestamp gate), skipping `subagents/` transcripts. Each file
+   becomes a `Session` (`transcripts.py:37-58`) with extracted signals: the goal
+   (first real user message), user corrections (regex `_CORRECTION_RE`,
+   `:21-26`), tool errors (`is_error` tool_results), success markers
+   (`_SUCCESS_RE` including "Pushed to main", `:30-34`), the final assistant
+   message, models used, and a noisy heuristic `outcome` label. Unparseable
+   lines are skipped, mirroring the Rust adapter `packages/source/claude`.
+2. **Group and filter** (`cli.run`, `cli.py:65-87`). Group sessions by project
+   (`cwd`), drop the distiller's own headless sessions via the `PROMPT_SENTINEL`
+   guard (`distill.py:25`), apply `--project` substring filters, and skip
+   projects under `--min-sessions`.
+3. **Distill + judge** (`distill.run_claude`, `distill.py:150-207`). One headless
+   `claude -p` call per project (default model `claude-haiku-4-5-20251001`,
+   `distill.py:20`), run from a throwaway cwd with `--strict-mcp-config
+   --mcp-config '{"mcpServers":{}}' --max-turns 2 --output-format json`. The
+   prompt (`distill.py:27-66`) carries the existing playbook items plus new
+   session digests and asks for itemized `add`/`update` operations only (never a
+   full rewrite) AND exactly one per-session verdict
+   (`success`/`partial`/`failure`/`abandoned`). The envelope parser tolerates
+   both old `{"result": ...}` and current event-array shapes (`distill.py:118-134`).
+4. **Merge** (`distill.apply_operations`, `distill.py:261-343`). Apply operations
+   into the existing item list with stable ids (`df-<hex>`,
+   `distill.py:257-258`): `add` (capped at `--max-new-items`, near-duplicate
+   title guard), `update` by id, and items not mentioned survive verbatim. This
+   is the anti-collapse invariant (ACE: incremental itemized updates, never
+   wholesale regeneration). `session_verdicts` (`distill.py:217-254`) normalizes
+   model verdicts to the closed `SESSION_LABELS` set and falls back to scan
+   heuristics for any unjudged session so the verdict set has no holes.
+5. **Write + validate + upload** (`cli.py:157-207`). Build rows, write each slice,
+   re-validate, and optionally upload.
+
+State (items, seen sessions, verdicts) is per `(user, project)` under
+`<out>/state/<user>/<slug>.json`, written atomically (`state.py`). A session is
+re-distilled only when its `fingerprint` (message count + last timestamp) changed
+(`cli.py:103-107`, `transcripts.py:56-58`), which is what makes runs incremental.
+
+## The corpus contract (`corpus.py`)
+
+Both slices use the exact 9-column schema mirroring `packages/sink/parquet`
+(`corpus.py:38-50`): `external_id, source, content_hash, title, url, host,
+timestamp(int64), body, meta_json`, all Utf8 but `timestamp`, with
+`external_id/source/content_hash/body/meta_json` non-null. Load-bearing details:
+
+- `content_hash` is exactly `sha256:<hex>` of the body bytes (`hash_body`,
+  `corpus.py:59-60`).
+- `_manifest.json` carries `content_hash` = sha256 over the sorted set of
+  `(external_id NUL content_hash NUL)` pairs (`corpus_hash`, `corpus.py:63-75`),
+  byte-for-byte the sink's construction.
+- `meta_json` is a flat object (<=128 KiB, <=256 keys) carrying the standard
+  filter keys (`user`/`host`/`project`/`timestamp`/`scope`) plus, for lessons,
+  `session_labels` and `failure_derived` when evidence includes a failed session
+  (`item_row`, `corpus.py:96-151`).
+- Files are written with pyarrow so the embedded Arrow schema says `Utf8` (what
+  the Rust source-parquet reader downcasts to); an empty row set writes nothing,
+  never a wipe (`write_slice`, `corpus.py:230-249`).
+
+`validate_slice` (`corpus.py:252-326`) re-reads each slice with polars (a second
+parquet implementation so pyarrow cannot self-certify), and asserts column
+order/dtypes, non-null contract, per-row body hashes, `meta_json` identity and
+limits, the manifest hash, and the physical Utf8 arrow types.
+
+Lessons also render to `<out>/facts/<user>/<slug>.md` (`markdown.py`). The
+`session_outcomes` slice carries one row per judged session: body = reason + key
+stats, `meta_json` = label, turns, duration, models (`session_row`,
+`corpus.py:191-227`).
+
+## Upload (`upload.py`)
+
+`--upload` puts `data.parquet` + `_manifest.json` under
+`corpus/host=<h>/user=<u>/source=<src>/` into the MinIO archive (default endpoint
+`http://127.0.0.1:9010`, bucket `ix-history`, prefix `corpus`) via boto3
+(`upload_slice`, `upload.py:42-66`). Credentials come from the environment
+(`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or `MINIO_ROOT_*`) or an
+`--env-file` in systemd EnvironmentFile format. The leader's hourly fold + view
+reconcile then make the rows searchable via
+`search.semantic(..., source=["distilled_facts"])` (or `["session_outcomes"]`).
+Updates fold each `external_id` to its newest `content_hash`; vanished ids are not
+deleted (append/merge fold, ENG-2696), so deletion needs an explicit tombstone.
+
+## How it is built and tested
+
+`default.nix` copies the pure-Python source into a pinned interpreter via
+`toPythonModule`, wraps `python -m distiller`, and runs two sandbox passthru
+tests: `pytest` over `tests/` and an import smoke test that also parses the CLI
+(`default.nix:73-110`). Runtime deps are polars (validation re-reader), pyarrow
+(writer), and boto3 (`--upload`) (`default.nix:34-43`). Flake output `distiller`
+(`package.nix`):
+
+```
+nix build .#distiller            # import smoke test
+```
+
+The `tests/` suite covers the parquet contract (schema, content/manifest hashes,
+tamper rejection), the incremental merge (stable ids, update-not-rewrite, caps),
+transcript signal extraction, and the outcome-labeling path (verdict
+normalization + fallback, the `session_outcomes` slice, failure-derived lesson
+marking, and an end-to-end run against a mocked `claude -p`).
+
+## Relationship to other agents tooling
+
+The slices distiller publishes are exactly what the
+[claude-hooks](../claude-hooks/overview.md) `prompt-priors` hook later surfaces
+back into new sessions (it searches `claude_history,shell,github` via
+`IX_SEARCH`; `distilled_facts`/`session_outcomes` become additional searchable
+sources). distiller closes the transcript -> lesson -> recall loop.

--- a/docs/agents/pi-harnesses/beam.md
+++ b/docs/agents/pi-harnesses/beam.md
@@ -1,0 +1,90 @@
+# pi-beam (bounded beam search)
+
+`packages/pi-harnesses/beam` (flake output `pi-beam`) is an executor that turns a
+hard decision into a bounded beam search instead of a linear commitment. At a
+decision point the executor explores 2-4 candidate approaches in parallel on
+isolated git worktrees under turn + time budgets, ranks them on ground truth, and
+applies the winner. Dead ends die in a few turns instead of after the executor
+commits to one bad path for forty (`beam/README.md`). See the collection
+[overview](overview.md) for the shared builder and model table.
+
+## The `explore` tool (`beam/extension/beam.ts`)
+
+The extension registers one tool, `explore`, with this schema
+(`beam/extension/beam.ts:13-42`):
+
+- `approaches`: array of 2-4 distinct approach strings (`minItems: 2`,
+  `maxItems: 4`).
+- `score` (optional): a shell command whose exit code (0 = pass) and resulting
+  diff size rank a branch, e.g. `cargo check` or `npm test`. Omit to rank on diff
+  size only.
+- `turnCap` (default 6): max model turns per branch (soft cap).
+- `timeoutSec` (default 180): hard wall-clock cap per branch.
+
+The goal is captured from `PI_BEAM_GOAL` or the first user message on
+`agent_start` (`beam.ts:45-52`). On invocation `explore` resolves the repo root
+(`git rev-parse --show-toplevel`, falling back to the ctx cwd) and calls
+`fanout(...)` (`beam.ts:62-80`), passing the active model selection through
+`PI_PROVIDER`/`PI_MODEL`/`PI_THINKING`. It returns a ranked table plus the winning
+patch as text; the executor then applies the winning patch itself. Beam proposes,
+the executor commits (`beam.ts:93-113`). It also records the run via
+`pi.appendEntry("beam", {...})` for the transcript.
+
+## Fan-out (`beam/runner/fanout.js`)
+
+`fanout({approaches, goal, repoRoot, scoreCmd, provider, model, thinking,
+turnCap, timeoutSec})` (`runner/fanout.js:47-106`) runs all approaches with
+`Promise.all`. For each approach:
+
+1. Create a temp dir and `git worktree add -q --detach <wt> HEAD` off the repo
+   root (`fanout.js:60-71`). Branches start from the last commit, not the dirty
+   working tree, so explore from a clean base or commit/stash first
+   (`beam/README.md`). A failed `worktree add` yields a failing branch result.
+2. Run `timeout <timeoutSec>s pi --print --no-session -e <turn-cap.js>
+   [--provider/--model/--thinking] "<goal + approach>"` with the worktree as cwd
+   and `PI_TURN_CAP` in env (`fanout.js:73-83`). Two budgets bound a branch: a
+   soft turn cap (the `turn-cap` extension, since Pi has no `--max-turns` flag)
+   and a hard wall-clock cap (`timeout`).
+3. Capture `git diff --no-color` (the patch) and `git diff --numstat` to count
+   changed lines (`countDiffLines`, `fanout.js:29-41`), then run the `score`
+   command in the worktree (`fanout.js:85-88`).
+4. Always remove the worktree (`git worktree remove --force`) and temp dir in a
+   `finally` (`fanout.js:98-101`).
+
+Each branch result is `{approach, exitCode, diffLines, patch, scoreOut, score}`,
+and `fanout` returns `rank(branches)`.
+
+## Scoring (`shared/ext-lib/scoring.js`)
+
+Ground truth decides, not a model (`shared/ext-lib/scoring.js:1-13`):
+
+```
+scoreBranch({exitCode, diffLines}) = (exitCode === 0 ? 1 : 0) * 1e6 - (diffLines ?? 0)
+```
+
+A branch that passes its score command (exit 0) always beats one that fails;
+among passers, the smaller diff wins (less churn for the same result).
+`rank(branches)` sorts by descending score. The function is pure and unit-tested
+(`beam/test/scoring.test.mjs`, run at build time via `checkFiles`).
+
+## How it is built
+
+`beam/default.nix` calls `../shared/mk-pi-harness.nix` with `lockdown = false`,
+`session = true`, the `beam.ts` entry extension, `runner/fanout.js` +
+`shared/ext-lib/scoring.js` as `libFiles`, and `shared/ext-lib/turn-cap.js` as an
+`auxFile` (loaded by branch subprocesses via absolute path, deliberately NOT
+auto-loaded into the main executor, which is not turn-capped)
+(`beam/default.nix:13-37`). Branches need the full tool surface to actually
+implement an approach, hence no lockdown.
+
+```
+ANTHROPIC_API_KEY=... nix run .#pi-beam -- "refactor the auth module; explore 3 designs"
+```
+
+## Limits
+
+From `beam/README.md`: branches start from the last commit, not the working tree;
+adoption is executor-driven in this first cut (it applies the returned patch;
+auto-adoption via `git apply`/session graft is a follow-up); and the in-process
+SDK fan-out (`createAgentSessionRuntime`) is the Tier-2 upgrade to this
+subprocess runner.

--- a/docs/agents/pi-harnesses/overview.md
+++ b/docs/agents/pi-harnesses/overview.md
@@ -1,0 +1,160 @@
+# pi-harnesses
+
+`packages/pi-harnesses` is a collection of Pi-based agent harnesses. Each harness
+is a thin, declarative wrapper around [`pi`](https://pi.dev) with a fixed posture
+and one or more bundled extensions, shipped as its own Nix package (`README.md`).
+There is no Rust here: the wrappers are `stdenv`/`buildNpmPackage` derivations
+around TypeScript/JavaScript extensions and (for the engine) a hardened C
+launcher.
+
+| sub-dir | id / flake output | what |
+| --- | --- | --- |
+| `engine/` | `pi-harness` | the locked-down Room engine: built-in tools ABSENT, only the `ix-mcp` surface, JSON event stream. |
+| `base/` | `pi-base` | base UX pack: live tok/s, git status widget, `/diff`, `/lg`. No agent behavior change. |
+| `prosecutor/` | `pi-prosecutor` | executor under a skeptical, context-isolated supervisor with earned-trust check-ins. |
+| `beam/` | `pi-beam` | executor that turns a hard decision into a bounded [beam search](beam.md) over isolated worktree branches. |
+
+This is ONE component directory; each member package is documented here, with the
+beam-search executor on its own page ([beam.md](beam.md)).
+
+## Shared builder (`shared/mk-pi-harness.nix`)
+
+`mk-pi-harness.nix` (`shared/mk-pi-harness.nix:1-147`) wraps `pi` with a
+build-time posture and produces a single `bin/<name>` launcher. It is used by
+`base`, `prosecutor`, and `beam`; the engine keeps its own hardened C launcher
+for the secret-bearing posture. Key arguments:
+
+- `pi` (default nixpkgs `pi-coding-agent`): the bare binary the wrapper execs.
+  Pinned so the wrapper never resolves `pi` from the caller's PATH, where a
+  host-level wrapper would inject conflicting flags/extensions; override with
+  `.override { pi = ...; }`.
+- `models`: the alias -> `{provider, model, thinking?}` table; `defaultModel`.
+- `extensions` (auto-loaded with `-e`), `libFiles` (helpers copied to
+  `share/<name>/lib`), `auxFiles` (copied but not auto-loaded).
+- posture knobs: `lockdown` (adds `--no-builtin-tools --no-extensions
+  --no-skills`), `session`, `headless`, `mode`, `systemPrompt`, `env`,
+  `runtimeInputs`.
+- `checkFiles`/`checkLib`: node `--test` files run at build time.
+
+`lockdown = false` is the whole point of the orchestration harnesses: the
+executor must do real work and child agents must probe real state. The launcher
+template `wrapper.sh.in` resolves the model alias to `PI_PROVIDER`/`PI_MODEL`/
+`PI_THINKING` and wires the `-e` extension flags.
+
+## Models and keys (`shared/models.nix`)
+
+One canonical table (`shared/models.nix`): `claude` = anthropic
+`claude-opus-4-8` (no thinking level; 4.8 is adaptive-only), `codex` = openai
+`gpt-5.5` at `thinking = medium`. Aliases map straight to `pi --provider --model
+[--thinking]`. API keys are NOT stored here: each harness receives them from the
+caller's environment (`ANTHROPIC_API_KEY`/`OPENAI_API_KEY`) and Pi reads the
+named var itself. The harness owns model selection only, not secret lookup. The
+engine keeps its own copy (`engine/models.nix`) rendered into C until the two
+converge.
+
+Select a model per run with `PI_HARNESS_MODEL`:
+
+```
+nix run .#pi-prosecutor -- "your task"               # claude (opus-4-8)
+PI_HARNESS_MODEL=codex nix run .#pi-beam -- "..."    # gpt-5.5 medium
+```
+
+## engine (`pi-harness`)
+
+The Index-side Pi engine harness (ENG-2261/2262): Pi as a Room-facing engine with
+the built-in tools absent, exposing only the `ix-mcp` tool surface, selecting the
+model declaratively, and emitting a machine-readable JSON event stream
+(`engine/README.md`). It is the Pi equivalent of the claude-code "tools removed"
+posture.
+
+Lockdown mechanism (`engine/default.nix`): a hardened C launcher (`launcher.c`,
+built in `buildPhase`) execs `pi --no-builtin-tools --no-extensions --no-skills
+--no-session --mode <json> --print --provider/--model --system-prompt
+--extension <ix-mcp-bridge>` (`engine/default.nix:269-289`). Built-ins are absent,
+not merely denied. The only tool surface is `extension/ix-mcp-bridge.ts`, which
+runs `ix-mcp serve` over stdio and re-exposes its tools (`python_exec`,
+`search_*`, `calendar_*`); it is packaged with `buildNpmPackage` so the shipped
+extension carries its `node_modules` (`engine/default.nix:49-69`). The MCP child
+receives a scrubbed env allowlist so `python_exec` cannot read provider keys; add
+non-provider vars with `PI_HARNESS_MCP_ENV_ALLOWLIST=NAME`.
+
+Process hardening (Linux): the launcher marks itself non-dumpable
+(`PR_SET_DUMPABLE 0`, `PR_SET_NO_NEW_PRIVS 1`) before env/model setup and
+`LD_PRELOAD`s a tiny constructor library into Pi so the post-exec Pi process
+reapplies the same boundary, denying same-UID `/proc/<pid>/environ` reads before
+MCP starts (`engine/default.nix:95-121,144-159,201-207`). Both fail closed
+(`_exit(126)`).
+
+Event stream: in JSON mode the launcher allocates a per-run `IX_MCP_STORE` if
+unset and execs `room_event_mapper.py`, which starts Pi and maps Pi's `--mode
+json` events to stable Room-facing names (`turn_started`, `text_delta`,
+`reasoning_delta`, `tool_call_started`, `tool_call_output`, `usage`,
+`turn_completed`, `error`), keeping the original under `raw`. It suppresses
+auto-retried `turn_end`s and emits exactly one terminal `turn_completed` per
+turn, carrying `status: "error"` when the final attempt failed. It also folds
+ix-mcp SQLite rows into `cell_update`/`resource_update` payloads shaped like the
+MCP dashboard's (`engine/README.md:48-101`). Config: `PI_HARNESS_MODE=text` for
+interactive dev, `PI_HARNESS_SYSTEM_PROMPT`, `PI_HARNESS_PI_BIN`. Validation:
+`engine/smoke/run.sh` (needs network + key) and the stdlib
+`room_event_mapper_test.py` (run at build time, `engine/default.nix:342-346`).
+
+## base (`pi-base`)
+
+Pi with a small base UX pack: quality-of-life extensions with no agent behavior
+change (`base/README.md`), adapted from `davis7dotsh/my-pi-setup` (MIT). Built via
+`mk-pi-harness.nix` with four auto-loaded extensions
+(`base/default.nix:17-22`):
+
+- `tps-tracker`: live tokens/sec in the footer while streaming, final per-run
+  summary toast.
+- `git-status-widget`: ` <branch> · N unstaged files` above the editor,
+  refreshed every 2s and on activity.
+- `turn-diff`: `/diff`, `/diff list`, `/diff clear` tracking exactly which files
+  the last run touched (git baseline + edit/write tool targets); picker opens one
+  in `$PI_DIFF_EDITOR`/`$EDITOR`.
+- `lg`: `/lg` concise unstaged-change summary with per-file +/- counts.
+
+The extension files also land in `share/pi-base/`, so they can be symlinked into
+`~/.pi/agent/extensions/` for the same UX in a plain `pi` session.
+
+## prosecutor (`pi-prosecutor`)
+
+An executor under a skeptical supervisor with earned-trust check-ins
+(`prosecutor/README.md`). The executor works with its full tool surface; on an
+adaptive interval it is forced to stop and state one falsifiable claim via the
+`claim({statement, verify})` tool, and until it does the `tool_call` gate blocks
+every other tool (`prosecutor/extension/prosecutor.ts`). The claim goes to a
+**prosecutor**: a fresh `pi --print --no-session` process on the same
+executor-class model with NO access to the executor's transcript
+(`shared/ext-lib/child-agent.js`). It runs the suggested check plus its own probes
+and returns `VERDICT: UPHELD` or `VERDICT: BROKEN <evidence>`
+(`shared/ext-lib/probes.js`, fails closed on ambiguity).
+
+The asymmetry that matters is context isolation, not a weaker model: no shared
+context means the two agents cannot launder each other's hallucinations. Trust is
+earned by the `shared/ext-lib/trust.js` state machine (`trust.js:10-30`): start at
+interval `min = 1` (verify every action); each upheld claim doubles the interval
+up to `max = 16`; a single broken claim snaps it back to 1 and tells the executor
+to recover. A competent run accelerates toward autonomy; a confused run gets
+babysat harder, with no constant to hand-tune. Config: `PI_HARNESS_MODEL`,
+`PI_PROSECUTOR_PROVIDER`/`_MODEL`/`_THINKING` (override the prosecutor model;
+defaults to the active executor model), `PI_PROSECUTOR_GOAL` (else captured from
+the first user message). Built via `mk-pi-harness.nix` with `lockdown = false`
+(`prosecutor/default.nix`); `trust.js` is unit-tested at build time.
+
+## beam (`pi-beam`)
+
+The bounded beam-search executor: see [beam.md](beam.md).
+
+## Building
+
+Each member ships its own flake output (`package.nix`: `{ id = "pi-<name>";
+packageSet = true; flake = true; }`); the registry auto-discovers new harnesses
+with no central list to edit.
+
+```
+nix run .#pi-harness    -- "prompt"     # locked-down Room engine, JSON stream
+nix run .#pi-base       -- "task"
+nix run .#pi-prosecutor -- "task"
+nix run .#pi-beam       -- "task"
+```

--- a/docs/agents/skill-lint/overview.md
+++ b/docs/agents/skill-lint/overview.md
@@ -1,0 +1,94 @@
+# skill-lint
+
+`packages/skill-lint` lints and autofixes `SKILL.md` files. It is a
+non-panicking replacement for the `skillsaw` Python linter: it recursively finds
+every `SKILL.md`, parses each file's frontmatter with a real YAML parser
+(`serde_norway`), and reports diagnostics, never aborting on bad input
+(`src/main.rs:1-6`). The motivating bug skillsaw had: a `description:` value with
+a bare `: ` inside it is read by YAML as a nested mapping and breaks the document;
+skillsaw reported that opaquely or panicked. skill-lint surfaces the precise YAML
+parser error with a file line number.
+
+```
+skill-lint [PATH] [--format human|json]    # lint (default cmd)
+skill-lint fix [PATH]                       # apply safe autofixes
+```
+
+`PATH` defaults to `.` (`src/main.rs:21-44`). A single `SKILL.md` file path is
+accepted directly; a directory is walked gitignore-aware via the `ignore` crate's
+`WalkBuilder` (respects `.gitignore`/global ignores, skips hidden dirs), so an
+ignored or hidden `SKILL.md` is intentionally skipped (`find_skills`,
+`src/main.rs:128-149`). `SKILL_FILE_NAME = "SKILL.md"` (`src/main.rs:19`).
+
+## Modules
+
+- `lint.rs`: pure analysis (frontmatter split, YAML parse, rules) producing
+  `Diagnostic`s. No IO, no panics.
+- `fix.rs`: pure safe autofixes producing new file contents.
+- `main.rs`: CLI, filesystem walk, output, exit codes.
+
+## Lint rules (`lint.rs`)
+
+`lint_skill(path, contents)` (`src/lint.rs:129-243`) runs in order, short-
+circuiting on structural failure:
+
+| rule_id | severity | trigger |
+| --- | --- | --- |
+| `skill-frontmatter` | error | no leading `---` … `---` block; or invalid YAML (carries the parser message + file line); or frontmatter is not a mapping |
+| `skill-name` | error | missing/empty `name` string |
+| `skill-description` | error | missing/empty `description` string |
+| `skill-name-matches-dir` | warning | `name` differs from the skill's directory name |
+| `skill-description-length` | warning | description over `DESCRIPTION_MAX_CHARS = 1024` (`src/lint.rs:14`); injected verbatim into context, so overlong is wasted budget |
+| `skill-file-budget` | warning | whole file over `FILE_TOKEN_BUDGET = 3000` estimated tokens, estimated as `len/4` (`src/lint.rs:19-22`) |
+
+`Severity` is only `Error`/`Warning` (no `Info`; the workspace denies dead code,
+so the unused variant is omitted until a rule needs it, `src/lint.rs:24-32`). A
+`Diagnostic` is `{severity, path, line?, rule_id, message}` (`src/lint.rs:43-51`)
+and renders as `severity path:line rule_id: message` (`render`, `:71-81`).
+
+`split_frontmatter` (`src/lint.rs:100-125`) is shared with the fixer so both
+agree on what counts as frontmatter. It tracks each line's byte span via
+`split_inclusive` to slice the YAML exactly (no `\r\n` terminator-width drift)
+and records `yaml_start_line = 2` so `serde_norway`'s 1-based parser line numbers
+offset back to the right file line (`src/lint.rs:148-165`).
+
+## Autofix (`fix.rs`)
+
+`fix_skill(path, contents)` (`src/fix.rs:17-57`) is conservative and pure (no
+IO). It refuses to touch a file whose frontmatter is missing or unparseable
+(surfaced as a lint error instead, never a corrupted document,
+`src/fix.rs:18-35`). On a valid mapping it:
+
+- inserts `name: <dir>` as the first frontmatter field when `name` is absent
+  (`insert_name`, `src/fix.rs:85-90`), so a re-lint comes back clean;
+- normalizes whitespace: strips trailing whitespace per line, collapses trailing
+  blank lines, ensures exactly one final newline (`normalize_whitespace`,
+  `src/fix.rs:97-114`).
+
+It preserves the file's dominant line ending: a CRLF-authored file keeps CRLF
+(`str::lines()` drops `\r`, so it rejoins with the detected newline). `fix` is
+idempotent: a second pass is a no-op (tests at `src/fix.rs:168-230`).
+
+## Exit codes
+
+`skill-lint` (lint) exits non-zero only when at least one error exists; warnings
+and info never fail the gate (`run_lint`, `src/main.rs:97-103`). Operational
+failures (unreadable path) are distinct: reported to stderr and exit non-zero
+(`main`, `src/main.rs:59-67`). `fix` always exits 0 after applying changes
+(`run_fix`, `src/main.rs:105-118`). `--format json` prints the diagnostics array
+(`print_json`, `:120-124`).
+
+## How it is built
+
+`default.nix` selects the `skill-lint` binary via
+`ix.cargoUnit.selectBinaryWithTests` (flake output `skill-lint`, `package.nix`):
+
+```
+nix run .#skill-lint -- skills
+nix run .#skill-lint -- fix skills
+```
+
+It lints the handwritten skills under `skills/` and the progressive skills
+generated from the [agent-context](../agents-md/overview.md) fragments. Inline
+tests in both `lint.rs` and `fix.rs` pin the rules and the conservative,
+content-preserving fix behavior.

--- a/docs/code-intel/ast-merge/overview.md
+++ b/docs/code-intel/ast-merge/overview.md
@@ -1,0 +1,127 @@
+# ast-merge
+
+`packages/ast-merge` is an AST-aware git merge driver: instead of merging text
+lines it parses base/left/right with tree-sitter, matches nodes across the three
+revisions with a GumTree-style tree differ, runs a 3DM structural merge, and
+falls back to a clean line-based merge whenever parsing fails or a structural
+conflict is found. It is one Cargo workspace package split into six member
+crates (root `Cargo.toml:9-14`); the `cli` crate is the flake output
+`ast-merge` (`packages/ast-merge/cli/default.nix`, `nix run .#ast-merge`). The
+`ast` and `langs` crates are also the shared tree-sitter substrate for
+[astlog](../astlog/overview.md) and [clone-detect](../clone-detect/overview.md).
+
+## Member crates
+
+| crate | id | role |
+| --- | --- | --- |
+| `ast-merge/ast` | `ast-merge-ast` | tree-sitter parsing + structural subtree hash |
+| `ast-merge/matcher` | `ast-merge-matcher` | GumTree tree matching (node correspondence) |
+| `ast-merge/diff` | `ast-merge-diff` | 3DM merge, PCS changesets, line-based fallback |
+| `ast-merge/langs` | `ast-merge-langs` | language profiles + grammar registry + detection |
+| `ast-merge/git` | `ast-merge-git` | git conflict marker parsing/formatting, revision IO |
+| `ast-merge/cli` | `ast-merge` | the `ast-merge` binary (flake output) |
+
+All six are Rust workspace members (`inRustWorkspace = true` in each
+`package.nix`); only `cli` is also a flake/packageSet output.
+
+## CLI surface (`cli/src/main.rs`)
+
+`ast-merge <command>` with four subcommands (`main.rs:18-42`):
+
+- `merge BASE LEFT RIGHT [-o OUT] [-l LANG] [--git]`: three-way merge. Without a
+  detected/forced language it line-merges; `--git` writes the result back to
+  `LEFT` (the merge-driver convention), otherwise to `-o`/`OUT` or `LEFT`
+  (`merge.rs:45-51`). Exit code `1` (`EXIT_CONFLICTS`, `main.rs:8`) signals
+  conflicts to git.
+- `solve FILE [-o OUT]`: parse existing conflict markers in a file (conflict
+  resolution is not yet fully implemented; logs a warning, `main.rs:130-156`).
+- `languages`: list supported languages with extensions/file names.
+- `info`: print version and the git merge-driver setup snippet.
+
+Wiring it as a git driver (`info` output, `main.rs:191-202`):
+
+```
+# .gitattributes
+*.rs merge=ast-merge
+# git config
+git config merge.ast-merge.driver 'ast-merge merge %O %A %B --git'
+```
+
+Tracing goes to stderr via `RUST_LOG` (default `info`, `main.rs:84-92`).
+
+## Pipeline (`cli/src/merge.rs:105-138`)
+
+```
+resolve_language(--language | path)            langs::detect / detect_by_name
+parse base/left/right                          ast::tree(src, &grammar)
+  any parse error -> diff::based (line merge)   merge.rs:112-115
+matcher::compute(base, left)                   GumTree Map base<->left
+matcher::compute(base, right)                  GumTree Map base<->right
+diff::ThreeWay { trees, both matchings }.merge()
+  structural conflict -> diff::based (line merge with git markers)
+```
+
+### ast (`ast-merge-ast`)
+
+Public surface (`ast/src/lib.rs:5-7`): `tree(source, &Language) -> Output`
+(parse, exposing `Tree`, `has_errors`, `PreorderIterator`), `compute(&Tree,
+node) -> u64` (structural subtree hash), and `Node`/`NodeId`/`Revision`. The
+hash (`ast/src/types.rs:80-97`) folds node kind plus child hashes (or leaf byte
+span) with `FxHasher`, so two subtrees hash equal iff structurally identical.
+`Revision` is the `Base`/`Left`/`Right` tag used throughout the merge.
+
+### matcher (`ast-merge-matcher`)
+
+`compute(tree_a, tree_b) -> Map` (`matcher/src/lib.rs:13-23`) runs GumTree
+(`gumtree.rs`): a top-down phase hashes nodes above `min_height` and matches
+unique subtree-hash pairs (`gumtree.rs:98-162`), a leaf/sibling phase matches
+small unmatched subtrees, and a bottom-up phase (`gumtree::bottomup`) matches
+parents by Dice coefficient over already-matched descendants. `Config`
+(`config.rs`) defaults: `min_height = 2`, `dice_threshold = 0.5`,
+`max_ted_size = 100`. `rayon` parallelizes matching. The result `Map` is the set
+of `(NodeId, NodeId)` correspondences the diff consumes.
+
+### diff (`ast-merge-diff`)
+
+`ThreeWay::new(ThreeWayParams { trees, base_left_matching, base_right_matching,
+config }).merge() -> Result` (`diff/src/engine.rs:59-89`). It builds a `Class`
+equivalence mapping from the two matchings, extracts `PcsTriple`s (parent,
+predecessor, successor) per revision into a `ChangeSet` (`changeset.rs`), then
+`detect_conflicts` applies the 3DM inconsistency rule: triples sharing a
+(parent, predecessor) but with different successors, coming from different
+non-base sides, and not converging to the same class, are a structural conflict
+(`engine.rs:147-276`). No conflict -> `reconcile_lists` reconstructs merged
+top-level items; conflict -> fall back to `based()` (`lines.rs`) which emits
+git-style markers with full text context. `Config` defaults: `marker_size = 7`,
+`diff3_style = true` (`engine.rs:28-43`). Public types: `ChangeSet`,
+`PcsTriple`, `Conflict`, `Region`, `Result`, `ThreeWay*`, `Config`, `based`,
+`Class` (`diff/src/lib.rs:10-14`).
+
+### langs (`ast-merge-langs`)
+
+`Lang` enum + `detect(path) -> Option<Lang>`, `detect_from_extension`,
+`Profile` (`langs/src/lib.rs:5-6`). A `Profile` (`langs/src/types.rs`) carries
+`name`, `extensions`, `file_names`, plus the merge-relevant `atomic_nodes`,
+`commutative_parents`, and `comment_nodes` predicate sets. The crate depends on
+~28 `tree-sitter-<lang>` grammar crates (`langs/Cargo.toml`: Rust, JS/TS,
+Python, Go, JVM langs, C/C++, C#, Swift, Ruby/PHP/Bash/Lua, Haskell/Elixir/
+OCaml, HTML/CSS/Svelte, JSON/TOML/YAML, Markdown, Dockerfile, Nix) and is the
+grammar registry the rest of this domain reuses. `Lang::to_tree_sitter()` yields
+the grammar for parsing.
+
+### git (`ast-merge-git`)
+
+Revision IO and git conflict-marker handling (`git/src/lib.rs:5-7`):
+`read_revision`/`write_result` (file IO returning `RevisionError`),
+`conflicts(content) -> ParsedFile` (parse `<<<<<<<`/`=======`/`>>>>>>>`
+markers), `conflict`/`extract_oid_from_marker` formatting, and
+`DisplaySettings`/`DriverResult`/`ParsedConflict`/`ParsedFile` types. Depends
+only on `snafu` and `lazy-regex`, no tree-sitter.
+
+## Build and tests
+
+Every member crate sets `passthruTests = true`, so each is checked through the
+cargo-unit Rust policy (`packages/*/package.nix`). `cli/default.nix` selects the
+`ast-merge` binary with `ix.cargoUnit.selectBinaryWithTests`. There is no extra
+runtime wrapper: the grammars are statically linked, so `nix run .#ast-merge`
+needs nothing on `PATH`.

--- a/docs/code-intel/astlog/overview.md
+++ b/docs/code-intel/astlog/overview.md
@@ -1,0 +1,112 @@
+# astlog
+
+`packages/astlog` runs Datalog over tree-sitter syntax trees: a tree-sitter
+query match becomes a relation (one row per match, one column per `@capture`),
+Datalog rules join those relations (structurally, by value, or recursively),
+`(rewrite ...)` forms turn derived rows into byte-range edits from templates, and
+`(lint ...)` forms turn derived rows into located findings filtered by
+`astlog-ignore` comments. It is the engine behind the repo's own lint gate:
+`nix run .#lint` runs `astlog scan astlog-rules/nix.astlog` and the Rust rules
+through a Nushell lint stage defined in `lib/per-system.nix`.
+
+The full language reference, prior-art comparison, and design rationale are in
+[`packages/astlog/README.md`](../../../packages/astlog/README.md); this page is
+the structural map.
+
+## Member crates
+
+| crate | id | role | flake output |
+| --- | --- | --- | --- |
+| `astlog/core` | `astlog-core` | the engine: reader, evaluator, rewrites, lints | none |
+| `astlog/cli` | `astlog` | the `astlog` binary | `astlog` |
+| `astlog/py` | `astlog-py` | PyO3 bindings (`import astlog` in the ix kernel) | none |
+
+All three are Rust workspace members; only `cli` is a flake/packageSet output
+(`packages/astlog/cli/default.nix`, `nix run .#astlog`). `core` depends on
+[`ast-merge-langs`](../ast-merge/overview.md) for grammars and language
+detection and on [`edit-applier`](../edit-applier/overview.md) for the rewrite
+step (`packages/astlog/core/Cargo.toml`). It parses with tree-sitter directly
+and matches with tree-sitter's `Query` engine; it does not use `ast-merge-ast`.
+
+## The language (four S-expression forms)
+
+- `(rule (head vars...) body-atom...)`: a relation. A `(match <lang> "<query>")`
+  atom is a verbatim tree-sitter query; other atoms are rule names or builtins.
+  Shared variables across body atoms are the join.
+- `(rewrite <name> (relation vars...) (replace <target> "<template>"))`: replace
+  the `<target>` node's bytes with the template, `{var}` splicing bound values.
+- `(lint <relation> <severity> "<message template>")`: emit one finding per row,
+  located at the row's first node-valued column.
+- Rules may be recursive; every value is a node or text derived from one, so the
+  universe is finite and naive fixpoint terminates.
+
+Builtins, with arity (`core/src/program.rs:29-38`, `BUILTINS`): `ancestor/2`,
+`parent/2`, `text/2`, `kind/2`, `same-text/2`, `same-file/2`, `text-match/2`
+(regex, compiled once), `no-descendant/3`. No general negation or aggregates in
+v0.
+
+## core (`astlog-core`)
+
+Module tree (`core/src/lib.rs:33-39`): `sexpr` (reader), `program` (forms +
+validation), `corpus` (loaded files/nodes), `eval` (Datalog), `rewrite`
+(edits/diff), `scan` (findings + suppression), `error`.
+
+Entry point `analyze(rules, paths) -> Analysis` (`core/src/lib.rs:109-122`):
+`Program::parse` -> `Corpus::load` (gitignore-aware via `ignore`) ->
+`Evaluator::fixpoint` -> `rewrite::collect`. `Analysis`
+(`core/src/lib.rs:57-100`) then offers `rewritten()` (changed files),
+`diff()` (unified diff via `edit-applier`), `findings()` (sorted, suppressed),
+and `suppressed()` (the audit view: each hidden finding plus the comment that
+hid it). Key public types: `Program`/`Rule`/`Rewrite`/`Lint`/`Severity`
+(`program.rs`), `Database`/`Relation`/`Row` (`eval.rs`),
+`Corpus`/`Value`/`NodeRef` (`corpus.rs`), `Edit`/`FileRewrite` (`rewrite.rs`),
+`Finding`/`SuppressedFinding` (`scan.rs`).
+
+Tree-sitter queries are validated at load (`Query::new`): a misspelled node kind
+or field is a hard error with a position, and `#`-predicates are rejected in
+favor of builtins (README). Languages come from `ast-merge-langs`, detected by
+extension, named by profile name or extension in `(match <lang> ...)`.
+
+## cli (`astlog`)
+
+Subcommands (`cli/src/main.rs:18-72`):
+
+- `query RULES PATHS... [--relation R] [--json]`: print derived relations. Pure
+  inspection, exits zero on success.
+- `scan RULES [PATHS...] [--json] [--error]`: the lint gate. One finding per
+  `(lint ...)` row minus `astlog-ignore` suppressions, sorted by
+  (file, line, column, rule). Exits non-zero iff an error-severity finding
+  survives; `--error` promotes warnings for the exit decision
+  (`blocking_count`, `main.rs:197-205`). `--json` emits the contract array
+  `{rule, severity, message, file, line, column, endLine, endColumn, text}`
+  (`main.rs:222-243`).
+- `suppressions RULES [PATHS...] [--json]`: list every suppressed finding with
+  the comment behind it. Pure inspection.
+- `fix RULES PATHS... [--write]`: print the rewrite diff, or apply with
+  `--write` (`main.rs:170-186`).
+
+`scan`/`suppressions` default `PATHS` to `.`; `query`/`fix` require paths.
+
+## Suppression
+
+A comment whose text contains `astlog-ignore` suppresses findings on its own
+line (trailing) or the line below; `astlog-ignore: a, b` limits it to named
+rules. Suppression filters at scan emission only, so the underlying Datalog rows
+still exist for joins and `query` output (README "Suppression").
+
+## py (`astlog-py`)
+
+PyO3 `cdylib` (`py/src/lib.rs`), module `_astlog`, wrapped by
+`python/astlog/__init__.py`. Conversion-only: `query`, `scan`, `suppressed`,
+`fixes` return plain dicts/records keyed exactly like the `scan --json`
+contract, and the Python wrapper builds polars frames; `fix(..., write=True)`
+returns the unified diff (`py/src/lib.rs:56-205`). Not a flake output; built and
+bundled into the ix-mcp kernel like the other `*-py` crates.
+
+## In production
+
+The repo's rules live in [`astlog-rules/nix.astlog`](../../../astlog-rules/nix.astlog)
+and [`astlog-rules/rust.astlog`](../../../astlog-rules/rust.astlog), each lint
+with a good/bad fixture pair under `astlog-rules/tests/` validated by the
+`astlog-rules` flake check through the same `astlog scan --json` surface the gate
+uses.

--- a/docs/code-intel/clone-detect/overview.md
+++ b/docs/code-intel/clone-detect/overview.md
@@ -1,0 +1,105 @@
+# clone-detect
+
+`packages/clone-detect` finds duplicated code across a tree. It parses every
+recognized file with tree-sitter, extracts significant subtrees, hashes them
+two ways (exact and identifier/literal-normalized), and reports clone groups:
+Type-1 (identical), Type-2 (identical modulo renaming), Type-3 (near-miss,
+structurally similar above a threshold), and statement Sequences. The `clone`
+binary emits JSON and a duplication percentage and exits non-zero when any clone
+survives, so it can gate CI; a repo-level [`clone.toml`](../../../clone.toml)
+tunes thresholds and ignore globs (`nix run .#clone`).
+
+## Member crates
+
+| crate | id | role |
+| --- | --- | --- |
+| `clone-detect/hash` | `clone-hash` | per-node content + normalized hashing, significant-node extraction |
+| `clone-detect/pragma` | `clone-pragma` | `clone:ignore` comment pragmas |
+| `clone-detect/scanner` | `clone-scanner` | parallel tree walk -> files + hash index |
+| `clone-detect/detect` | `clone-detect` | the detection algorithms (Type-1/2/3, sequences) |
+| `clone-detect/cli` | `clone` (pkg `clone-cli`) | the `clone` binary (flake output) |
+
+All five are Rust workspace members; only `cli` is the flake/packageSet output
+(`packages/clone-detect/cli/default.nix`, binary `clone`, package `clone-cli`,
+`nix run .#clone`). `hash`, `scanner`, and `pragma` build on
+[`ast-merge-ast`](../ast-merge/overview.md) (parse + structural hash) and
+[`ast-merge-langs`](../ast-merge/overview.md) (grammars + detection).
+
+## Pipeline (`cli/src/main.rs:157-199`)
+
+```
+find_config(path)            walk up for clone.toml (cli/src/main.rs:201-225)
+resolve_config              CLI flags > clone.toml > defaults (main.rs:232-269)
+Scanner::directory(path)    parse + index every file (scanner)
+instances(scan, config)     Type-1/2/3 + sequences (detect)
+filter::by_patterns         drop --ignore / clone.toml globs (cli/src/filter.rs)
+output_json                 DetectionResult as JSON (pretty optional)
+badge::write (optional)     SVG duplication badge (cli/src/badge.rs)
+```
+
+`run` returns "has clones", which `main` maps to exit `FAILURE`/`SUCCESS`
+(`main.rs:139-155`).
+
+## hash (`clone-hash`)
+
+`significant_nodes(&tree, min_lines, min_nodes) -> Vec<NodeInfo>` selects
+subtrees large enough to be clone candidates; each `NodeInfo` carries kind, byte
+range, line range, node count, `subtree_features`, and the two hashes
+(`hash/src/lib.rs:6-8`, `extract.rs`). `compute` (re-exported from
+`ast-merge-ast`) is the exact structural hash (Type-1 key). `hash` (the
+normalized hash, `normalize.rs`) walks the subtree renumbering identifiers in
+order of first appearance and replacing every literal with a fixed placeholder
+(`LITERAL_PLACEHOLDER`, `normalize.rs:8`), so two fragments that differ only in
+names/literals hash equal (Type-2 key). `kinds::is_significant`/`is_identifier`/
+`is_normalizable` decide what counts.
+
+## pragma (`clone-pragma`)
+
+`scan(&tree) -> Info` walks comments for `clone:ignore` pragmas
+(`pragma/src/lib.rs:84-148`): `clone:ignore` (next node), `clone:ignore-start`/
+`clone:ignore-end` (a region), `clone:ignore-file` (whole file). The space after
+the colon is rejected, so pragmas must be tight. `Info::is_ignored(range)` is
+how the scanner drops ignored nodes.
+
+## scanner (`clone-scanner`)
+
+`Scanner::new(Config).directory(path) -> Output` (`scanner/src/scan.rs:95-162`)
+walks with `ignore::WalkBuilder` honoring gitignore (always skipping `.git`),
+capped at `MAX_THREADS = 8` parallel parses, detecting language per file,
+skipping symlinks/non-UTF-8/`ignore-file` files, and collecting
+`significant_nodes` minus pragma-ignored ranges. `Config` defaults `min_lines =
+5`, `min_nodes = 10` (`scan.rs:35-49`). The `Output` holds the `files` and a
+`Hash` index (`index.rs`) mapping `content_hash -> locations` and
+`normalized_hash -> locations`, exposing `type1_candidates()` /
+`type2_candidates()` (buckets with more than one location).
+
+## detect (`clone-detect`)
+
+`instances(&Output, &DetectConfig) -> DetectionResult` (`detect/src/detector.rs:16-120`):
+
+- **Type-1**: content-hash buckets with 2+ fragments (`detector.rs:20-36`).
+- **Type-2**: normalized-hash buckets with 2+ fragments, skipping any already
+  fully covered by Type-1 (`detector.rs:38-62`).
+- **Type-3** (`--type3`, `detect/src/type3.rs`): per node-kind, dedup by
+  normalized hash, build a MinHash signature over `subtree_features`, bucket
+  with LSH (`lsh.rs`), pre-filter candidate pairs by estimated Jaccard, then
+  confirm with multiset Jaccard against `type3_threshold` (default `0.7`).
+  `rayon`-parallel across kinds.
+- **Sequence** (`--sequences`, `sequences.rs`): sliding window of statements.
+- `dedup_subsumed` drops groups whose fragments are byte-range contained in a
+  larger group (e.g. a function and its block, `detector.rs:139-202`).
+
+`DetectionResult` (`types.rs:65-84`) is `{ instances: Vec<CloneGroup>, stats }`;
+`Kind` is `Type1 | Type2 | Type3 { similarity } | Sequence { statements }`;
+`stats.duplication_pct` is deduplicated duplicated lines over total lines. All
+types are `serde`-serializable (the JSON output schema).
+
+## cli (`clone`) config and flags
+
+Flags (`cli/src/main.rs:14-49`): `[PATH]` (default `.`), `--type3`,
+`--threshold`, `--min-lines`, `--min-nodes`, `--sequences`, `--window-size`,
+`--ignore` (repeatable glob), `--pretty`, `--badge PATH`. `clone.toml` mirrors
+these keys (`FileConfig`, `main.rs:52-63`); CLI flags win, booleans OR, ignore
+lists concatenate (`resolve_config`). The repo's [`clone.toml`](../../../clone.toml)
+sets `min_lines = 8`, `min_nodes = 15`, and ignore globs for vendored/generated/
+test trees.

--- a/docs/code-intel/code-highlight/overview.md
+++ b/docs/code-intel/code-highlight/overview.md
@@ -1,0 +1,52 @@
+# code-highlight
+
+`packages/code-highlight` is a tree-sitter syntax highlighter that renders a
+source string (or a line range) as ANSI-colored terminal text. It owns one job:
+source plus a language hint (path or extension) into colored output, with a
+plain-text fallback for unsupported languages or any failure, so a caller always
+renders something. It is a single Rust workspace library crate (`id =
+code-highlight`, no flake output); the [search](../../search/common.md) tooling
+is its consumer (`packages/search/Cargo.toml`).
+
+## Public surface (`src/lib.rs`)
+
+- `highlight(path_or_lang, source, theme, color) -> String` (`lib.rs:426-432`):
+  color a whole file. With `color = false` the output is the input unchanged
+  (the `NO_COLOR` / non-TTY path).
+- `highlight_lines(path_or_lang, source, start_line, num_lines, theme, color) ->
+  String` (`lib.rs:447-490`): color the file, then slice a 1-based line window
+  and prefix a right-aligned, dimmed line-number gutter (` │ ` separator). This
+  is the snippet shape a search tool renders for context: highlight once with
+  full-file context, then slice.
+- `Theme` (`lib.rs:289-296`): `Dark` (default) or `Light`, so the caller can
+  match the terminal background.
+- `Language` is re-exported from [file-language](../file-language/overview.md)
+  (`lib.rs:34`).
+
+Both entry points resolve the language by trying the full path then a bare
+extension (`detect`, `lib.rs:412-414`), and never error.
+
+## Internals
+
+- **Grammar dispatch** (`grammar_query`, `lib.rs:97-229`): a flat
+  one-arm-per-`Language` table pairing a `tree-sitter-<lang>` grammar with its
+  highlights query. TypeScript/TSX prepend the JavaScript highlights query (the
+  TS query only adds type rules), and JS/TSX fold in the JSX query. Each grammar
+  exports its query under a different constant name, hence the explicit table.
+  An unmapped variant returns `None` -> plain text.
+- **Capture names** (`HIGHLIGHT_NAMES`, `lib.rs:45-78`): the fixed conventional
+  tree-sitter capture taxonomy; the index a grammar reports is the index into
+  this slice. Dotted names fall back to their prefix (`function.method` ->
+  `function`, `style_for`, `lib.rs:379-393`).
+- **Theme** (`lib.rs:298-365`): colors come from the embedded
+  `src/islands-theme.json`, the single source of truth shared with the
+  base-profile Neovim colorscheme. `slot_for_name` maps each capture to a
+  palette slot and italic flag; `parse_hex` reads `#RRGGBB` (alpha ignored).
+- **Caching** (`CONFIGS`, `lib.rs:271-282`): each language's
+  `HighlightConfiguration` is compiled once into a process-wide `LazyLock` map;
+  a language whose query fails to compile maps to `None` (treated as
+  unsupported) and the failure is printed once at first build
+  (`build_config`, `lib.rs:245-263`).
+
+The crate links ~30 grammar crates statically (`Cargo.toml`); no runtime deps.
+There is no separate flake package and no CLI: it is consumed as a library.

--- a/docs/code-intel/code-tokenizer/overview.md
+++ b/docs/code-intel/code-tokenizer/overview.md
@@ -1,0 +1,38 @@
+# code-tokenizer
+
+`packages/code-tokenizer` is a [tantivy](https://github.com/quickwit-oss/tantivy)
+tokenizer that splits identifiers the way a code reviewer reads them: on
+`camelCase`, `snake_case`, `kebab-case`, and any non-alphanumeric run. It is a
+single Rust workspace library crate (`id = code-tokenizer`, no flake output)
+consumed by the search index (`packages/file-search/Cargo.toml`).
+
+## Public surface (`src/lib.rs`)
+
+- `register_tokenizers(&tantivy::Index)` (`lib.rs:18-31`): registers both
+  analyzers on an index's tokenizer manager.
+- `CODE_TOKENIZER` = `"code"` (`lib.rs:15`): the raw split, for facet-style
+  exact lookup.
+- `CODE_STEMMED_TOKENIZER` = `"code_stemmed"` (`lib.rs:16`): the same split plus
+  `LowerCaser` and an English `Stemmer`, for ranked full-text search
+  (`lib.rs:24-30`).
+- `CodeTokenizer` / `CodeTokenStream`: the `Tokenizer` / `TokenStream` impls if
+  a caller wants to wire them manually.
+
+## Internals
+
+`CodeTokenizer::token_stream` first strips ANSI escape sequences from the input
+(`strip_ansi_escapes`, `lib.rs:39-44`), so a terminal capture tokenizes the same
+as its decoded text. The token stream (`advance`, `lib.rs:70-153`) emits one
+token per identifier word, lowercasing each character, and breaks on:
+
+- a separator (`_` or `-`, `is_separator`, `lib.rs:65-67`), which is consumed and
+  not included in either token;
+- a lower/digit -> upper transition (`fooBar` -> `foo`, `bar`);
+- the end of an uppercase acronym run when the next char is lowercase
+  (`HTTPServer` -> `http`, `server`; `getXValue` -> `get`, `x`, `value`,
+  `lib.rs:119-128`);
+- any non-alphanumeric character.
+
+The acronym handling uses one-character lookahead so it can break *before* the
+final uppercase that starts the next camel word. No flake package, no CLI:
+library only.

--- a/docs/code-intel/common.md
+++ b/docs/code-intel/common.md
@@ -1,0 +1,144 @@
+# Code intelligence
+
+AST and semantic code analysis and rewriting for the `index` workspace. These
+packages parse source into trees (mostly tree-sitter), match patterns or resolve
+symbols against them, and turn the results into reports or byte-range edits. They
+back the repo's own lint gate (`nix run .#lint` runs `astlog scan`, wired in
+`lib/per-system.nix`), an AST-aware git merge driver, a clone/duplication
+detector, a SCIP-backed find/replace, the Flecs query parser MCP server, and a
+set of small reusable
+crates (highlighting, identifier tokenizing, language detection, file walking,
+edit application) shared with the [search](../search/common.md) and corpus
+tooling.
+
+Read this page first, then the component page for the package you are touching.
+
+## Units
+
+Every package is a Cargo workspace member of the root [`Cargo.toml`](../../Cargo.toml)
+(`packages/...`) unless noted. A multi-crate package is one component directory;
+its member crates are documented inside it.
+
+| package | crates | role | flake output |
+| --- | --- | --- | --- |
+| [ast-merge](ast-merge/overview.md) | `ast`, `matcher`, `diff`, `langs`, `git`, `cli` | AST-aware git merge driver: GumTree tree matching + 3DM merge over tree-sitter | `ast-merge` |
+| [astlog](astlog/overview.md) | `core`, `cli`, `py` | Datalog over tree-sitter ASTs: patterns as relations, joins as rules, rewrites as templates | `astlog` |
+| [clone-detect](clone-detect/overview.md) | `hash`, `scanner`, `pragma`, `detect`, `cli` | Type-1/2/3 + sequence code clone detection | `clone` |
+| [scipql](scipql/overview.md) | `core`, `cli`, `py` | lower a SCIP semantic index to Souffle facts, run datalog, apply find/replace | `scipql` |
+| [flecs-query](flecs-query/overview.md) | `core`, `mcp`, `py` | parser for the Flecs Query Language: string to typed AST; MCP server | `ix-flecs-query-mcp` |
+| [code-highlight](code-highlight/overview.md) | (single crate) | tree-sitter syntax highlighter rendering ANSI-colored source/snippets | none (library) |
+| [code-tokenizer](code-tokenizer/overview.md) | (single crate) | tantivy tokenizer splitting identifiers on camel/snake/kebab boundaries | none (library) |
+| [file-language](file-language/overview.md) | (single crate) | map a path/name/extension to its source language, no parser deps | none (library) |
+| [repo-walker](repo-walker/overview.md) | (single crate) | iterator over text files honoring `.gitignore`, skipping binaries | none (library) |
+| [edit-applier](edit-applier/overview.md) | (single crate) | apply sorted non-overlapping byte-range edits + render a unified diff | none (library) |
+| [llm-clippy](llm-clippy/overview.md) | Nix-only | clippy fork tuned for LLM-assisted codebases | `llm-clippy` |
+
+`ast-merge`, `astlog`, `clone-detect`, `scipql`, `flecs-query` are multi-crate
+packages. The five small crates and `llm-clippy` build a single output each.
+`llm-clippy` is the only Nix-only package here: it is excluded from the Rust
+workspace and builds the [indexable-inc/clippy](https://github.com/indexable-inc/clippy)
+fork from the `clippy-fork` flake input (`flake.nix:85`).
+
+## How it fits together
+
+Two crates inside the `ast-merge` package are the shared tree-sitter substrate
+for this whole domain:
+
+- `ast-merge-langs` ([langs](ast-merge/overview.md)) registers ~28 tree-sitter
+  grammars and maps a path to a language profile. `astlog-core`,
+  `clone-detect` (`hash`/`scanner`/`pragma`), and the `ast-merge` driver all
+  resolve languages and grammars through it (root `Cargo.toml` dependents).
+- `ast-merge-ast` ([ast](ast-merge/overview.md)) wraps tree-sitter parsing
+  (`tree()`) and a recursive structural subtree hash (`compute`). `ast-merge`'s
+  matcher/diff and all three `clone-detect` analysis crates parse and hash
+  through it.
+
+`astlog` does not use `ast-merge-ast`: it parses through `ast-merge-langs` and
+runs tree-sitter's own `Query` engine directly (`packages/astlog/core/Cargo.toml`).
+`file-language` is a parser-free language detector with the same curated variant
+set as the highlighter; `code-highlight` depends on it
+(`packages/code-highlight/Cargo.toml:14`) and layers the grammar-to-query
+mapping on top.
+
+The pattern across the active tools is **analyze -> query -> rewrite**:
+
+```
+source files
+  -> parse / index        (tree-sitter via ast-merge-ast/langs; or rust-analyzer scip)
+  -> relations / matches   (astlog Datalog rows; scipql Souffle facts; clone hashes; gumtree maps)
+  -> findings              (astlog scan, clone JSON, query relations)   [report path]
+  -> byte-range edits      (astlog rewrite templates; scipql edit relation)
+       -> edit-applier::{apply, check_overlaps, unified_diff}           [rewrite path]
+```
+
+Both rewriters (`astlog`, `scipql`) converge on [edit-applier](edit-applier/overview.md)
+for the apply/overlap/diff step (`packages/astlog/core/Cargo.toml`,
+`packages/scipql/core/Cargo.toml`), so splice semantics cannot drift between
+them.
+
+## Invariants
+
+- **Tree-sitter query strings are validated at load, not at match.** Both
+  `astlog` (`Query::new`) and `code-highlight` (`HighlightConfiguration::new`)
+  compile grammar queries up front; a misspelled node kind or field is a hard
+  error with a position, never a silently empty result.
+- **Rewrites are byte-range edits applied right-to-left.** An [`edit_applier::Edit`](edit-applier/overview.md)
+  is `{file, start, end, replacement}`; edits in one file must be sorted and
+  non-overlapping (`check_overlaps`), and `apply` splices them in reverse so
+  earlier offsets stay valid. Overlap is a typed error, not a corrupt splice.
+- **Identity vs text.** `astlog` matches on tree-sitter *syntax* (text/kind
+  joins); `scipql` matches on resolved SCIP *monikers*, so `net::Socket` and
+  `mock::Socket` are distinct symbols. Pick the tool by whether the question
+  needs name resolution.
+- **Dry run by default.** The rewriting CLIs (`astlog fix`, `scipql fix`,
+  `scipql rename`) print a unified diff and only touch disk with `--write`.
+- **Exit code is the lint contract.** `astlog scan` and `clone` exit non-zero
+  when a blocking finding survives, so they gate CI directly.
+- **Fall back, do not fail.** `ast-merge` drops to line-based merge on a parse
+  error or structural conflict; `code-highlight` returns plain text for an
+  unsupported language or a query failure. The user always gets output.
+
+## Glossary
+
+- **tree-sitter**: incremental parser generator; every grammar is a
+  `tree-sitter-<lang>` crate. The shared parsing layer for this domain.
+- **language profile** (`ast-merge-langs::Profile`): per-language metadata
+  (extensions, file names, atomic/commutative/comment node kinds) driving merge
+  and detection.
+- **GumTree**: the tree-differencing algorithm `ast-merge-matcher` implements
+  (top-down subtree hash matching, then bottom-up Dice-similarity matching) to
+  map nodes between two revisions.
+- **3DM / PCS**: the three-way structural merge model in `ast-merge-diff`. A
+  `PcsTriple` is a (parent, predecessor, successor) ordering fact; conflicting
+  triples from different sides are a structural conflict.
+- **content hash vs normalized hash**: a clone-detection node carries an exact
+  structural hash (Type-1) and a hash with identifiers renumbered and literals
+  placeholdered (Type-2).
+- **Type-1/2/3 clone**: identical (modulo whitespace), identical modulo
+  identifier/literal renaming, and near-miss (structurally similar above a
+  Jaccard threshold) duplicated code.
+- **Datalog / fixpoint**: bottom-up rule evaluation to a fixed point.
+  `astlog` runs a small built-in evaluator; `scipql` shells out to `souffle`.
+- **moniker**: a SCIP symbol identity string (e.g.
+  `rust-analyzer cargo mycrate 0.1.0 net/Socket#`). `scipql` keys facts and
+  edits on it.
+- **pragma** (`clone:ignore`): a source comment suppressing clone findings for
+  a node, region, or file.
+- **`astlog-ignore`**: a source comment suppressing `astlog scan` findings on
+  its own line or the line below.
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| ast-merge | [ast-merge/overview.md](ast-merge/overview.md) | AST-aware git merge driver: GumTree matching + 3DM merge, line-based fallback |
+| astlog | [astlog/overview.md](astlog/overview.md) | Datalog over tree-sitter ASTs: query/scan/fix CLI, lint gate, Python bindings |
+| clone-detect | [clone-detect/overview.md](clone-detect/overview.md) | Type-1/2/3 + sequence clone detection, `clone.toml` config, SVG badge |
+| scipql | [scipql/overview.md](scipql/overview.md) | SCIP index -> Souffle facts -> datalog query and find/replace/rename |
+| flecs-query | [flecs-query/overview.md](flecs-query/overview.md) | Flecs Query Language parser to typed AST; stdio MCP server; Python bindings |
+| code-highlight | [code-highlight/overview.md](code-highlight/overview.md) | tree-sitter ANSI highlighter for files and line-numbered snippets |
+| code-tokenizer | [code-tokenizer/overview.md](code-tokenizer/overview.md) | tantivy identifier tokenizer (camel/snake/kebab splitting) |
+| file-language | [file-language/overview.md](file-language/overview.md) | path/name/extension -> `Language`, no parser deps |
+| repo-walker | [repo-walker/overview.md](repo-walker/overview.md) | gitignore-aware text-file iterator, binary-extension skip |
+| edit-applier | [edit-applier/overview.md](edit-applier/overview.md) | apply sorted non-overlapping byte-range edits, render unified diff |
+| llm-clippy | [llm-clippy/overview.md](llm-clippy/overview.md) | clippy fork with restriction lints for LLM-assisted codebases |

--- a/docs/code-intel/edit-applier/overview.md
+++ b/docs/code-intel/edit-applier/overview.md
@@ -1,0 +1,41 @@
+# edit-applier
+
+`packages/edit-applier` applies byte-range edits to source files and renders a
+unified diff. A consumer derives a set of edits (a byte range plus replacement
+text) from whatever analysis it runs, then hands them here to be checked for
+overlap, applied, and diffed. The logic is corpus-agnostic on purpose:
+[astlog](../astlog/overview.md) produces edits from tree-sitter rewrite
+templates and [scipql](../scipql/overview.md) from Souffle `edit` relations over
+a SCIP index, and both share this one apply/diff/overlap path so splice
+semantics cannot drift (`src/lib.rs:1-13`). Single Rust workspace library crate
+(`id = edit-applier`, no flake output); its only deps are `similar` (diffing) and
+`snafu`.
+
+## Public surface (`src/lib.rs`)
+
+- `Edit { file, start, end, replacement }` (`lib.rs:26-32`): one replacement of
+  `start..end` in file `file`, where `file` is an index into the caller's
+  `files`/`paths` slice (the caller owns the file numbering). `Edit` is
+  `Ord`, so callers sort with the derived ordering.
+- `Source = (PathBuf, String)` (`lib.rs:22`): a file's path and current
+  contents, the slice element `apply`/`unified_diff` consume.
+- `FileRewrite { path, content }` (`lib.rs:35-39`): a file with all its edits
+  applied.
+- `check_overlaps(&[PathBuf], &[Edit]) -> Result<(), OverlapError>`
+  (`lib.rs:65-88`): fail on the first pair of edits in the same file with
+  overlapping ranges. Requires `edits` sorted ascending by `(file, start, end)`;
+  it then only compares each edit to its successor. Adjacent ranges
+  (`second.start == first.end`) do not overlap.
+- `apply(&[Source], &[Edit]) -> Vec<FileRewrite>` (`lib.rs:97-119`): apply
+  edits, returning only changed files. Within a file the edits are spliced
+  right-to-left so earlier offsets stay valid as later ranges are replaced;
+  non-overlap is the caller's responsibility.
+- `unified_diff(&[Source], &[FileRewrite]) -> String` (`lib.rs:126-141`):
+  `a/<path>` vs `b/<path>` unified diff of each rewrite against its original,
+  via `similar::TextDiff`.
+- `OverlapError` (`lib.rs:48-54`): the typed overlap error, naming the file and
+  both ranges.
+
+The ordering contract is the load-bearing invariant: sort, then `check_overlaps`,
+then `apply`. `apply` itself re-sorts per file defensively but the overlap check
+depends on the caller's sort. No flake package, no CLI: library only.

--- a/docs/code-intel/file-language/overview.md
+++ b/docs/code-intel/file-language/overview.md
@@ -1,0 +1,34 @@
+# file-language
+
+`packages/file-language` maps a file path, name, or extension to the source
+`Language` it holds, with no grammar, parser, or highlighting dependencies. A
+consumer that only needs "what language is this file" (a chunker, tokenizer, or
+search ranker) can depend on it without pulling in a tree-sitter grammar
+closure. It is a single Rust workspace library crate (`id = file-language`, no
+flake output) with zero dependencies (`Cargo.toml`); [code-highlight](../code-highlight/overview.md)
+layers the grammar-to-query mapping on top of this enum
+(`packages/code-highlight/Cargo.toml:14`).
+
+## Public surface (`src/lib.rs`)
+
+- `Language` (`lib.rs:24`): a `#[non_exhaustive]` enum of the curated source
+  languages (Rust, Python, JS/TS/TSX, Go, C/C++, C#, Java, Scala, Swift, Ruby,
+  PHP, Lua, Haskell, Elixir, OCaml, HTML, CSS, JSON, TOML, YAML, SQL, Nix, Bash,
+  Markdown, ...). The same variant set the highlighter understands; being
+  `#[non_exhaustive]` keeps adding a language non-breaking for downstream
+  `match`es.
+- `Language::from_path(&Path) -> Option<Self>` (`lib.rs:121`): the usual entry
+  point. Prefers a recognized full filename over the extension, so
+  extension-less or misleading names (`Cargo.lock` -> TOML, `Gemfile` -> Ruby,
+  `Rakefile` -> Ruby, `mix.exs` -> Elixir) resolve correctly.
+- `Language::from_extension(&str) -> Option<Self>` (`lib.rs:139`): match a bare
+  extension (case-insensitive).
+- `Language::from_file_name(&str) -> Option<Self>` (`lib.rs:182`): match a known
+  filename.
+- `Language::ALL` (`lib.rs:85`): every variant, the iteration source for callers
+  that build per-language tables (the highlighter's config cache).
+- `Language::name(self) -> &'static str` (`lib.rs:197`): a stable, unique,
+  lowercase name per language.
+
+An unrecognized path yields `None`, which callers treat as unknown (plain text).
+The crate is a library with no flake package and no CLI.

--- a/docs/code-intel/flecs-query/overview.md
+++ b/docs/code-intel/flecs-query/overview.md
@@ -1,0 +1,69 @@
+# flecs-query
+
+`packages/flecs-query` is a pure-Rust parser for the
+[Flecs Query Language](https://github.com/SanderMertens/flecs/blob/master/docs/FlecsQueryLanguage.md),
+the string format flecs uses for ECS queries
+(`Position, [in] Velocity, (ChildOf, $parent)`). Flecs ships no standalone
+grammar: upstream's language is a hand-written C parser bound to a live
+`ecs_world_t`. This crate reimplements the same grammar as a standalone,
+world-independent parser, exposes it as a typed AST, an MCP server, and Python
+bindings, and round-trips (`parse(q.to_string()) == q`).
+
+## Member crates
+
+| crate | id | role | flake output |
+| --- | --- | --- | --- |
+| `flecs-query/core` | `flecs-query-core` | the parser: expression string -> typed `Query` AST | none |
+| `flecs-query/mcp` | `ix-flecs-query-mcp` (pkg `flecs-query-mcp`) | stdio MCP server | `ix-flecs-query-mcp` |
+| `flecs-query/py` | `flecs-query-py` | PyO3 bindings returning plain dicts | none |
+
+All three are Rust workspace members; only `mcp` is a flake/packageSet output
+(`packages/flecs-query/mcp/default.nix`, binary `ix-flecs-query-mcp`,
+`nix run .#ix-flecs-query-mcp`). `core` has no required dependencies; the
+optional `serde` feature (enabled by `mcp` and `py`) derives serialization of
+the AST.
+
+## core (`flecs-query-core`)
+
+`parse(&str) -> Result<Query, ParseError>` (`core/src/parser.rs`, re-exported
+`core/src/lib.rs:86`); `Query` also implements `FromStr` (`lib.rs:88-93`). The
+AST (`core/src/ast.rs`) covers terms, access modifiers, operators, pairs,
+traversal flags, equality terms, and references: public types `Access`, `EqOp`,
+`EqOperand`, `EqTerm`, `ExtraOper`, `IdFlag`, `IdTerm`, `Oper`, `Query`, `Ref`,
+`RefExpr`, `Src`, `Term`, `TermBody`, `Traversal` (`lib.rs:81-84`). `Display`
+(`fmt.rs`) renders the canonical form (normalized whitespace, comments dropped,
+implicit-source pairs in `(Rel, Tgt)` shape). Errors carry a byte `Span` and a
+caret-rendered message (`error.rs`, `ParseError::render`).
+
+The EBNF grammar, reverse-engineered from upstream's parser and test suite, is
+in the crate docs (`core/src/lib.rs:18-36`). It scopes to **form, not
+resolution**: `parse` answers "is this well-formed Flecs Query Language" and
+gives every term its structure, but whether `Position` names a real component is
+a property of a specific world that a parser without a world cannot and should
+not guess (`lib.rs:45-52`). It deliberately rejects two things upstream silently
+ignores: an unknown access modifier (`[foo]`) and an unknown word where a
+traversal flag belongs (`lib.rs:54-60`).
+
+## mcp (`ix-flecs-query-mcp`)
+
+A stateless stdio MCP server built on `rmcp` (`mcp/src/main.rs`), serving three
+tools, each taking one `expr` string (`ExprArgs`, `main.rs:31-36`):
+
+- `parse`: return the typed AST as JSON; a syntax error is an
+  `INVALID_PARAMS` error with the structured `ParseError` and a caret message
+  (`main.rs:63-78`, `parse_expr`).
+- `canonicalize`: return the normalized expression text (`main.rs:80-87`).
+- `validate`: never errors; returns `{valid, error?, rendered?}` for linting
+  loops (`main.rs:89-114`).
+
+`get_info` advertises the server as `ix-flecs-query-mcp` with tools enabled and
+states that parsing is world-independent (`main.rs:128-144`). Transport is
+`rmcp::transport::stdio` over a tokio runtime (`main.rs:17-22`).
+
+## py (`flecs-query-py`)
+
+PyO3 `cdylib`, module `_flecs_query` (`py/src/lib.rs`): `parse` (AST as plain
+dicts via `pythonize`, raising `ValueError` with a caret message on error),
+`canonicalize` (normalized text), and `validate` (a non-raising
+`{valid, error?, rendered?}` dict). Not a flake output; built and bundled into
+the kernel like the other `*-py` crates.

--- a/docs/code-intel/llm-clippy/overview.md
+++ b/docs/code-intel/llm-clippy/overview.md
@@ -1,0 +1,65 @@
+# llm-clippy
+
+`packages/llm-clippy` builds a fork of `rust-lang/rust-clippy` carrying extra
+restriction lints tuned for LLM-assisted codebases. It is the Clippy the rest of
+the repo's Rust packages are checked with: the cargo-unit policy wires this
+binary in as every package's Clippy gate (`lib/rust/tooling.nix:26`).
+
+## What is special: it is Nix-only
+
+Unlike every other package in this domain, `llm-clippy` is **not** a Rust
+workspace member: it is in the `exclude`/absent set of the root
+[`Cargo.toml`](../../../Cargo.toml) and its `package.nix` sets neither
+`inRustWorkspace`. It builds an external source tree, not workspace code.
+
+- The source is the `clippy-fork` flake input
+  (`github:indexable-inc/clippy`, `flake.nix:85-88`), consumed as a `flake =
+  false` source tree. `nix flake update clippy-fork` bumps it.
+- `default.nix` requires `clippy-fork` (it throws otherwise, taking the fork as
+  `clippy-fork`, never `src`, to avoid colliding with `pkgs.src`) and builds it
+  with `ix.buildRustPackage`. The toolchain is read from the fork's own
+  `rust-toolchain.toml` (`pkgs.rust-bin.fromRustupToolchainFile`), so a fork bump
+  advances the `rustc`/`rustc_private` ABI in lockstep. `cargoLock.lockFile`
+  reads the fork's lockfile (no checked-in lock to drift).
+- `env.RUSTC_BOOTSTRAP = "1"` because the fork links `rustc_private` crates;
+  `postInstall` wraps `cargo-clippy` and `clippy-driver` with the toolchain's lib
+  dir on `LD_LIBRARY_PATH` (or `DYLD_LIBRARY_PATH` on Darwin).
+- Its own build disables the recursive policy checks: `policy.clippy.enable =
+  false` (it is the Clippy others use; checking itself would recurse through
+  `llmClippyFor`) and `policy.cargoMachete.enable = false` (the fork ships UI
+  fixtures that are not build workspaces).
+
+## Outputs
+
+- Flake output `llm-clippy` (`package.nix`: `id = llm-clippy`, `flake = true`,
+  `packageSet = true`); `meta.mainProgram = clippy-driver`. `nix build
+  .#llm-clippy`.
+- Binaries `cargo-clippy` and `clippy-driver`; `passthru.toolchain` exposes the
+  pinned toolchain.
+
+## The extra lints
+
+The fork adds restriction lints the workspace then denies in the root
+`Cargo.toml` lint table (`Cargo.toml:121-130`):
+
+- `anonymous_tuple_return_type`: forbid an anonymous tuple return type, forcing a
+  named struct so a multi-value return is readable at the call site (used e.g. in
+  `packages/blast-radius/src/main.rs:110`).
+- `fallible_int_fallback`: forbid silently defaulting a fallible integer
+  conversion (`u8::try_from(x).unwrap_or(...)` / `.unwrap_or_default()` /
+  `.unwrap_or_else(...)`), which would clamp or zero an out-of-range value and
+  hide the overflow; propagate the `TryFromIntError` instead.
+
+Both are off even in Clippy's `all` group and only exist because this fork
+provides them, which is why the workspace must build against `llm-clippy` rather
+than stock Clippy.
+
+## Wiring (`lib/rust/tooling.nix`)
+
+`rustFor` calls `pkgs.callPackage (packagePath "llm-clippy")` with the
+`clippy-fork` input, then hands the resulting Clippy package to the Rust build
+(`lib/rust/build.nix`). `buildRustPackage` attaches the `llm-clippy` check as a
+policy dependency of every repo Rust package (`tooling.nix:81-88`), so a lint
+the fork adds fails the affected package's build, not just a separate gate.
+`llm-clippy` bootstraps before `cargoUnit`/`rustWorkspace` exist, so it receives
+only `buildRustPackage` from the `ix` closure (`tooling.nix:23-29`).

--- a/docs/code-intel/repo-walker/overview.md
+++ b/docs/code-intel/repo-walker/overview.md
@@ -1,0 +1,37 @@
+# repo-walker
+
+`packages/repo-walker` walks a directory tree the way a source-code consumer
+wants: honor `.gitignore` (plus global, exclude, and `.ignore` files), skip
+hidden entries, skip known binary extensions, and yield the remaining files
+through a fallible iterator. It wraps [`ignore::WalkBuilder`](https://docs.rs/ignore)
+and adds the binary-extension filter and error surfacing so callers do not
+reimplement them. Single Rust workspace library crate (`id = repo-walker`, no
+flake output); consumers are the search/corpus tooling
+(`packages/file-search/Cargo.toml`, `packages/search-core/Cargo.toml`).
+
+## Public surface (`src/lib.rs`)
+
+- `WalkOptions { respect_gitignore, follow_links }` (`lib.rs:16-33`): defaults
+  `respect_gitignore = true`, `follow_links = false`. Turning off
+  `respect_gitignore` silences *all* ignore sources (gitignore, global, exclude,
+  `.ignore`, parents, hidden), not just git ones (`lib.rs:43-56`).
+- `FileScanner::new(&Path, WalkOptions)` (`lib.rs:42`): an `Iterator<Item =
+  Result<PathBuf, WalkError>>` (`lib.rs:65-95`). It yields only regular files
+  (resolved without following symlinks unless `follow_links`), drops paths whose
+  extension is on the binary list, and surfaces walk errors as `Err` items
+  rather than dropping them silently. `WalkError` is re-exported `ignore::Error`
+  (`lib.rs:14`).
+- `GitignoreFilter::new(&Path, respect_gitignore)` + `filter_paths(Vec<PathBuf>)
+  -> Vec<PathBuf>` (`lib.rs:103-168`): apply a standalone gitignore matcher to a
+  path list that came from somewhere other than the walker (a watcher, a diff, a
+  manifest). It loads only the root `.gitignore`; for nested ignores use
+  `FileScanner`. Uses `matched_path_or_any_parents` so a directory rule like
+  `target/` excludes `target/debug/foo.rs` (`lib.rs:157-164`).
+- `is_indexable_file(&Path) -> bool` (`lib.rs:193`): regular file (via
+  `symlink_metadata`, so symlinks are excluded) whose extension is not binary.
+  No extension counts as text.
+- `is_binary_extension(&str) -> bool` (`lib.rs:210`): the case-insensitive
+  known-binary extension list (executables, objects, images, audio/video,
+  archives, office docs, wasm/jvm/python bytecode).
+
+No flake package, no CLI: library only.

--- a/docs/code-intel/scipql/overview.md
+++ b/docs/code-intel/scipql/overview.md
@@ -1,0 +1,120 @@
+# scipql
+
+`packages/scipql` runs Souffle Datalog plus find/replace over a SCIP semantic
+index. Where [astlog](../astlog/overview.md) queries tree-sitter *syntax*,
+scipql queries a *resolved* index: every occurrence carries its SCIP moniker, so
+`net::Socket` and `mock::Socket` are distinct symbols and a rename touches only
+the real definition and its references, never a same-named symbol elsewhere or a
+field of the same name. The full design and grammar are in
+[`packages/scipql/README.md`](../../../packages/scipql/README.md).
+
+## Member crates
+
+| crate | id | role | flake output |
+| --- | --- | --- | --- |
+| `scipql/core` | `scipql-core` | index, lower to facts, run Souffle, apply edits | none |
+| `scipql/cli` | `scipql` | the `scipql` binary, wrapped with toolchain + souffle | `scipql` |
+| `scipql/py` | `scipql-py` | PyO3 bindings (`import scipql` in the ix-mcp kernel) | none |
+
+All three are Rust workspace members; only `cli` is a flake/packageSet output.
+`core` reuses [`edit-applier`](../edit-applier/overview.md) for the rewrite step
+(`packages/scipql/core/Cargo.toml`) and depends on the `scip` and `protobuf`
+crates to read a SCIP index.
+
+## Pipeline (`core/src/lib.rs:1-14`)
+
+```mermaid
+flowchart LR
+  src["Rust project"] -->|"rust-analyzer scip"| scip["index.scip"]
+  scip -->|"scip crate"| facts["Souffle facts (by moniker)"]
+  facts --> souffle["souffle (your .dl)"]
+  souffle -->|"edit relation"| applier["edit-applier"]
+  souffle -->|"any relation"| out["tables / polars"]
+  applier -->|"default"| diff["unified diff (dry run)"]
+  applier -->|"--write"| disk["files on disk"]
+```
+
+`index` is the slow step (it loads the cargo workspace);
+`query`/`fix`/`rename` run on an already-built `index.scip`.
+
+## CLI surface (`cli/src/main.rs:17-65`)
+
+- `index PROJECT [-o index.scip]`: run `rust-analyzer scip PROJECT --output`.
+- `query INDEX PROGRAM [--root R]`: run the Souffle program, print every
+  `.output` relation as TSV (one block per relation).
+- `fix INDEX PROGRAM [--root R] [--write]`: apply the program's `edit` relation;
+  prints the unified diff, `--write` updates files.
+- `rename INDEX SELECTOR NEW_NAME [--root R] [--write]`: rename every occurrence
+  whose moniker ends with `SELECTOR` (e.g. `net/Socket#`) to `NEW_NAME`. A
+  generated `fix`.
+
+`--root` defaults to the index's project root; byte offsets and on-disk writes
+resolve relative document paths against it (`core/src/lib.rs:36-38`).
+
+## core (`scipql-core`)
+
+Modules (`core/src/lib.rs:21-26`): `index` (shell `rust-analyzer scip`),
+`facts` (lower SCIP -> relations), `souffle` (run the engine), `rewrite` (apply
+the `edit` relation), `rename` (generate a rename program), `error`. Public
+entry points: `index`, `load_index`, `facts_from_index`, `query`, `fix`,
+`rename`, plus the row types and `SCHEMA`/`EDIT_SCHEMA` constants
+(`core/src/lib.rs:28-34`).
+
+### Fact relations (`facts.rs:23-32`, `SCHEMA`)
+
+Prepended to every query, so always in scope:
+
+```
+occurrence(symbol, path, start, end, role)   # role: definition | reference; byte offsets
+symbol_info(symbol, kind, display_name)
+document(path)
+relationship(symbol, related, kind)          # implementation | type_definition | reference | definition
+```
+
+`symbol` is the SCIP moniker. A local symbol (`local 1`) is namespaced by its
+document path so it stays unique across files (`facts.rs`). Byte offsets come
+from each document's embedded UTF-8 text, or the file is read from `root` when a
+document omits it.
+
+### Writing a fix (`rewrite.rs:19-21`, `EDIT_SCHEMA`)
+
+A `fix`/`rename` program must `.output` an `edit` relation; the schema is
+prepended automatically:
+
+```
+.decl edit(path:symbol, start:number, end:number, replacement:symbol)
+.output edit
+```
+
+`fix` confines edits to files the index documents, sorts and dedups them, checks
+overlap, and applies via `edit-applier` (`rewrite.rs:42-104`). `rename` is just
+a generated program that suffix-matches the moniker (`rename.rs`); for anything
+more selective, write the `.dl` yourself.
+
+### Running Souffle (`souffle.rs:46-68`)
+
+`run` writes the facts as `.facts` TSV into a scratch dir, prepends the schema to
+the user program, and shells out to `souffle`, reading back every `.output`
+relation as `OutputRelation { name, columns, rows }`. The binary is resolved
+from `SCIPQL_SOUFFLE` (an absolute path a wrapper bakes) or `souffle` on `PATH`
+(`souffle.rs:58-62`); `index` resolves `rust-analyzer` from
+`SCIPQL_RUST_ANALYZER` or `PATH` (`index.rs:22-24`).
+
+## cli build (`cli/default.nix`)
+
+The flake output is not the bare binary: `default.nix` wraps it with
+`makeWrapper`, prefixing `PATH` with the repo's pinned nightly toolchain
+(`cargo`, `rustc`, `rust-std`, `rust-src`, `rust-analyzer`, channel read from
+[`rust-toolchain.toml`](../../../rust-toolchain.toml)) and `souffle`, so `scipql
+index` runs the exact rust-analyzer the repo builds against and `query`/`fix`/
+`rename` find `souffle` with no ambient setup. The prefix (not suffix) ensures
+the baked tools shadow any rustup shim.
+
+## py (`scipql-py`)
+
+PyO3 `cdylib` (`py/src/lib.rs`) returning polars frames: `scipql.facts`,
+`scipql.query` (`{relation: DataFrame}`), `scipql.rename`/`scipql.fix` (diff,
+`write=True` applies). The kernel bakes `souffle` via `SCIPQL_SOUFFLE`, so
+query/fix/rename work in the kernel; `index` needs rust-analyzer and is run from
+the `scipql` CLI instead (README "Python"). Rust today (via `rust-analyzer
+scip`); the facts/query/edit layers are language-agnostic.

--- a/docs/dashboard/common.md
+++ b/docs/dashboard/common.md
@@ -1,0 +1,139 @@
+# Dashboard
+
+A live, replayable web canvas for every resource an ix process exposes. Any
+producing process (a `tui` PTY manager, the MCP, a demo binary) writes its
+current panes to a unix socket in a shared discovery directory. Consumers watch
+that directory, connect to every socket, and render the fleet: the standalone
+[dashboard](dashboard/overview.md) aggregator folds every producer into one Loro
+document and serves it over HTTP + Server-Sent Events, while
+[ix-windows](ix-windows/overview.md) opens one borderless native webview window
+per live MCP resource. Both consumers and every producer build on one
+engine-free crate, [dashboard-core](dashboard-core/overview.md), so a process
+that only publishes panes links no HTTP, CRDT, or native engine.
+
+Read this page first, then the component pages it links.
+
+## Units
+
+| unit | kind | role |
+| --- | --- | --- |
+| `packages/dashboard-core` | Rust lib crate (workspace member, no flake output) | wire types ([`Pane`]/[`View`]/[`ProducerSnapshot`]), discovery paths, the [`Publisher`]/[`subscribe`] socket transport, the [`Hub`] Loro document + SSE server ([`serve_hub`]), the [`RecordingStore`], and the embedded Svelte canvas page. See [dashboard-core](dashboard-core/overview.md). |
+| `packages/dashboard` | Rust binary (`nix run .#dashboard`) | standalone aggregator: scan the discovery dir, fold every producer into one `Hub`, serve the board, persist recordings. Carries a `demo` subcommand. See [dashboard](dashboard/overview.md). |
+| `packages/ix-windows` | Rust binary + lib (`nix run .#ix-windows`, darwin-only) | tao+wry consumer: render each `resource/<id>` html pane as its own chrome-less native window. See [ix-windows](ix-windows/overview.md). |
+
+`dashboard-core` is the only shared dependency; `dashboard` and `ix-windows`
+each depend on it and on nothing else in this domain. The `tui` crate (other
+domain) re-exports these names and adapts its PTY manager into terminal panes;
+the MCP's `pane_bridge.py` (other domain) is the Python producer.
+
+## How it fits together
+
+```
+producers (out of process)                consumers
+  tui PTY manager  --\                 /-- dashboard  --> Hub (Loro doc) --> HTTP + SSE --> browser
+  mcp pane_bridge  ---> *.sock files --+                                 \-> RecordingStore (rec-*.loro)
+  dashboard demo   --/   (discovery dir)  \-- ix-windows --> WindowManager --> one webview window per resource
+```
+
+1. A producer builds a `Vec<Pane>` and calls [`Publisher::bind`] +
+   [`Publisher::publish`] (`packages/dashboard-core/src/publish.rs:109`,
+   `:176`). The publisher binds a `UnixListener` in the discovery directory and
+   streams the latest [`ProducerSnapshot`] as one NDJSON line to every connected
+   reader. Replacement semantics: the newest line fully describes that producer,
+   so a late-joining consumer needs no backlog.
+2. A consumer calls [`subscribe`] (`packages/dashboard-core/src/subscribe.rs:53`),
+   which rescans the directory on an interval, connects to each `*.sock`, parses
+   each line, and forwards a [`ProducerEvent::Snapshot`] or, on hangup, a
+   [`ProducerEvent::Gone`]. One reader task per socket; a re-created socket
+   reconnects on the next scan. Both consumers share this one transport.
+3. The [dashboard](dashboard/overview.md) aggregator applies each event to a
+   shared [`Hub`] under the producer's own scope ([`Hub::apply_scope`] /
+   [`Hub::remove_scope`], `src/dashboard/hub.rs:483`, `:489`) and serves the
+   document via [`serve_hub`]. [ix-windows](ix-windows/overview.md) instead feeds
+   each event to a `WindowManager` that opens, refreshes, and closes native
+   windows.
+
+## Cross-component invariants
+
+- **Discovery directory** is resolved identically everywhere by
+  [`discovery_dir`] (`pane.rs:300`): `$IX_DASH_DIR`, else
+  `$XDG_RUNTIME_DIR/ix-dash`, else `/tmp/ix-dash-<user>`. Kept short because
+  macOS caps a `sun_path` at 104 bytes. Producers create it mode `0700`; sockets
+  are mode `0600`.
+- **Naming.** A producer id is `"<pid>-<short-uuid>"` (`publish.rs:35`); its
+  socket file is `"<pid>-<short-uuid>.sock"` ([`socket_path`], `pane.rs:316`). A
+  pane `id` is unique only within its producer; consumers namespace it by
+  producer for a global key.
+- **Wire forward-compatibility.** New view fields are `#[serde(default)]`
+  (`pane.rs:162`), so a producer built before a field still parses; a consumer
+  skips a malformed line rather than dropping the producer
+  (`subscribe.rs:121`).
+- **Engine-free producers.** `dashboard-core` carries no native engine; the page
+  is embedded at compile time (below), and the producer half holds no HTTP or
+  CRDT dependency, so a process that only publishes stays lightweight.
+- **Scope isolation.** In the aggregator's `Hub`, one frame source is one scope;
+  reconciling a scope never touches another's panes, and a disconnected producer
+  removes only its own (`src/dashboard/hub.rs:265`, test at `:560`).
+- **Read-only sync.** Browsers never write back to the Loro document; it has one
+  editor per scope, so conflict resolution never runs. The CRDT is used only for
+  cheap incremental diffs, single-snapshot catch-up, and free replay of the
+  timestamped oplog.
+
+## The page is embedded, not committed
+
+The browser UI is a Svelte/Vite app under
+`packages/dashboard-core/site/`, built by Nix (`ix.buildSvelteSite`) to one
+self-contained `index.html` (viteSingleFile). The build points the workspace at
+that file through `IX_DASHBOARD_SITE_HTML` (`lib/rust/workspace.nix:218`), and
+`dashboard-core`'s `build.rs` copies it into `OUT_DIR` so `server.rs`
+`include_str!`s it at compile time (`build.rs:32`, `server.rs:40`). A bare
+`cargo build` outside Nix embeds a stub page. There is no committed artifact and
+no runtime asset directory, which is why the in-process `tui::serve` and a
+PyO3 `.so` can carry the page too.
+
+## Glossary
+
+- **producer**: a process that publishes its panes over a socket via
+  [`Publisher`]. It owns its resources; it never owns the server.
+- **consumer**: a process that reads producer sockets via [`subscribe`]. The
+  aggregator and `ix-windows` are the two consumers.
+- **pane**: one titled card on the canvas ([`Pane`], `pane.rs:35`): an `id`, a
+  `title`, a `subtitle`, and a [`View`] body.
+- **view**: a pane's body, a tagged union over render strategies: `Terminal`,
+  `Html`, `Exec`, `Data` ([`View`], `pane.rs:115`). The aggregator stores it by
+  `kind` and never learns what it means.
+- **producer snapshot**: a producer's full current pane set on the wire
+  ([`ProducerSnapshot`], `pane.rs:285`); one NDJSON line, replacement semantics.
+- **scope**: the key a frame source's panes live under in the hub document; one
+  per producer for the aggregator, the single `"local"` scope for `tui::serve`.
+- **hub**: the shared Loro document plus its SSE fan-out ([`Hub`],
+  `src/dashboard/hub.rs:465`).
+- **recording**: a persisted Loro snapshot of a board run (`rec-<start-ms>.loro`),
+  written on an interval by a [`RecordingStore`] and replayable in the browser.
+- **aggregator**: the `dashboard` binary, the multi-producer consumer that serves
+  the web board.
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| dashboard-core | [dashboard-core/overview.md](dashboard-core/overview.md) | wire types, discovery, publish/subscribe transport, Hub + SSE server, recordings, embedded page |
+| dashboard | [dashboard/overview.md](dashboard/overview.md) | standalone aggregator binary: fold every socket into one served board; `demo` subcommand |
+| ix-windows | [ix-windows/overview.md](ix-windows/overview.md) | darwin webview consumer: one borderless native window per live MCP resource |
+
+[`Pane`]: dashboard-core/overview.md
+[`View`]: dashboard-core/overview.md
+[`ProducerSnapshot`]: dashboard-core/overview.md
+[`Publisher`]: dashboard-core/overview.md
+[`Publisher::bind`]: dashboard-core/overview.md
+[`Publisher::publish`]: dashboard-core/overview.md
+[`subscribe`]: dashboard-core/overview.md
+[`ProducerEvent::Snapshot`]: dashboard-core/overview.md
+[`ProducerEvent::Gone`]: dashboard-core/overview.md
+[`Hub`]: dashboard-core/overview.md
+[`Hub::apply_scope`]: dashboard-core/overview.md
+[`Hub::remove_scope`]: dashboard-core/overview.md
+[`serve_hub`]: dashboard-core/overview.md
+[`RecordingStore`]: dashboard-core/overview.md
+[`discovery_dir`]: dashboard-core/overview.md
+[`socket_path`]: dashboard-core/overview.md

--- a/docs/dashboard/dashboard-core/internals.md
+++ b/docs/dashboard/dashboard-core/internals.md
@@ -1,0 +1,160 @@
+# dashboard-core internals: the Hub fold and recordings
+
+The non-obvious mechanism behind the read-only canvas: how the [`Hub`] folds
+many producers into one Loro document with cheap incremental diffs and free
+replay, and how a [`RecordingStore`] persists that document. The public surface
+(wire types, transport, server routes) is in [overview](overview.md).
+
+## The shared document (`src/dashboard/hub.rs`)
+
+[`Hub`] (`hub.rs:465`) owns one `LoroDoc` whose root `panes` map holds one entry
+per pane, keyed `"<scope>\x1f<id>"` (`SCOPE_SEP = U+001F`, `hub.rs:45`; neither a
+scope nor a pane id contains it, so the split back to `(scope, id)` is
+unambiguous). A scope is one frame source: `tui::serve` uses a single `"local"`
+scope, the aggregator one scope per producer.
+
+Each pane entry is a `meta` `LoroMap` of scalars (`kind`, `created_at`, `title`,
+`subtitle`, plus the view's own scalar fields) and one `LoroText` per large
+mutable field the view declares. Storing each big field as its own text
+container is what makes updates diff incrementally and the oplog replay: a Loro
+oplog *is* a recording.
+
+### Two projections, one reconcile loop
+
+A view tells the hub its storage shape through two pure functions, so adding a
+resource kind never touches the reconcile loop:
+
+- [`view_scalars`] (`hub.rs:90`) returns the scalar `meta` fields per kind, using
+  a `Scalar::Absent` sentinel to express "ensure this key is not present" (a
+  terminal's `exit_code` before exit, an exec's `ok` while running) uniformly
+  with the present cases.
+- [`view_texts`] (`hub.rs:136`) returns the large text fields per kind: a
+  terminal's `body` (its screen), an html `body`, an exec's
+  `source`/`stdout`/`stderr`/`result`/`trace`, a data `body`. A data view's JSON
+  and the exec `trace` are canonicalized to JSON text so they diff and replay
+  like any body; the frontend parses them back.
+
+The key set a view returns is fixed for its kind, so a slot created for one kind
+always sees the same set on every later tick.
+
+### Reconcile: `apply_scope` / `remove_scope`
+
+[`Hub::apply_scope(scope, panes)`] (`hub.rs:483`, core at `DocState::apply_scope`
+`hub.rs:265`) reconciles exactly the entries under `scope` to `panes` and leaves
+every other scope alone:
+
+1. For each pane, if a cached `Slot` exists under a *different* `kind`, drop it
+   first so a reused id recreates cleanly rather than editing the wrong fields
+   in place (`hub.rs:273`; test `kind_change_recreates_pane`, `hub.rs:761`).
+2. `create_slot` (`hub.rs:300`) for a new key: insert the `meta` map, write
+   `kind`, stamp `created_at` once with `now_ms()`, and create one empty text
+   container per declared field.
+3. `update_slot` (`hub.rs:341`) writes only changed values: `title`/`subtitle`,
+   each scalar whose cached value differs, each text whose cached value differs.
+   Caching is load-bearing: an unchanged insert is still a CRDT op, so the cache
+   is what keeps an idle pane from producing a delta (test
+   `unchanged_apply_yields_no_delta`, `hub.rs:583`). Sentinel initial values
+   (`hub.rs:428`) force the first write even when the real value is empty.
+4. Drop keys under this scope no longer present (`hub.rs:283`).
+5. `commit_delta` (`hub.rs:403`).
+
+[`Hub::remove_scope`] (`hub.rs:489`) drops every key under a prefix and commits;
+removing an empty scope is a silent no-op (`hub.rs:643`). The multi-producer
+invariant is `scopes_do_not_clobber_each_other` (`hub.rs:560`): one producer's
+reconcile never touches another's panes, and disconnecting a producer removes
+only its own.
+
+A failed apply is dropped, not retried: the next tick re-renders
+(`hub.rs:483-485`).
+
+### Body diff thresholds
+
+`set_text` (`hub.rs:178`) reconciles a text field. A body up to
+`MAX_DIFF_BODY = 32 KiB` (`hub.rs:165`) uses Loro's refined diff under a
+`BODY_DIFF_TIMEOUT_MS = 50.0` ceiling (`hub.rs:170`) for small deltas on the
+common case (a terminal screen, appended exec output). A larger body, or any
+diff that times out, is replaced wholesale (delete-all + insert), two bulk ops
+whose cost is independent of string similarity, so a pane that rewrites
+completely each tick (an html pane streaming a base64 data URL) cannot stall the
+single aggregator or bloat the oplog. After a timeout the wholesale path
+reconciles against the container's own current length, since the partial diff
+may have applied edits before bailing (`hub.rs:187`).
+
+### Timestamps and deltas
+
+`DocState::new` (`hub.rs:245`) sets `set_record_timestamp(true)`.
+`commit_delta` (`hub.rs:403`) stamps each commit with `set_next_commit_timestamp(now_ms())`,
+commits, and exports `ExportMode::updates(&self.streamed)` only when the oplog
+version moved, advancing `streamed`. So a tick that changes nothing yields
+`None` and no broadcast. `now_ms()` (`hub.rs:54`) saturates rather than panics
+on a clock before the epoch. Together the per-commit timestamp and the once-only
+per-pane `created_at` (test `created_at_is_stamped_once`, `hub.rs:630`) give the
+browser a fine-grained timeline axis and each resource's age with no producer
+opt-in.
+
+### Fan-out and snapshots
+
+`Hub::broadcast` (`hub.rs:494`) base64-encodes a delta onto a
+`broadcast` channel of capacity `BROADCAST_CAPACITY = 256` (`hub.rs:40`).
+`Hub::subscribe` (`hub.rs:504`) returns the current full snapshot and the live
+update receiver under one lock, so the snapshot version lines up with the first
+update a subscriber sees (consumed by `server::events`). `snapshot_b64`
+(`hub.rs:514`) re-snapshots a client the broadcast outran. [`Hub::export_snapshot`]
+(`hub.rs:521`) returns the full snapshot bytes including the complete oplog, used
+by the recorder; a snapshot is never shallow, so a receiver can replay any past
+version, not just the latest (test `hub_snapshot_decodes_exec_pane_with_history`,
+`tests/pipeline.rs:75`).
+
+## Recordings (`src/dashboard/recordings.rs`)
+
+The hub document is the recording: its oplog holds every change with a
+millisecond timestamp, so one full snapshot replays the whole session. A
+[`RecordingStore`] persists that snapshot to disk on an interval.
+
+- **One file per run.** Each run owns `rec-<start-ms>.loro` (`PREFIX`/`EXT`,
+  `recordings.rs:31`), rewritten in place as the document grows, not a growing
+  count of files. [`RecordingStore::spawn_recorder`] (`recordings.rs:157`) prunes
+  to `KEEP_RECORDINGS - 1` (50, `recordings.rs:27`), writes one snapshot up front
+  so a session shorter than the interval still produces its advertised recording,
+  then refreshes it each `interval`, returning a [`Recorder`] (`id` + task
+  handle). A final snapshot on graceful shutdown is the caller's job (the
+  aggregator does this; see [dashboard](../dashboard/overview.md)).
+- **Listing.** [`RecordingStore::list`] (`recordings.rs:104`) returns
+  [`RecordingInfo`] `{ id, started_ms, updated_ms, bytes }` newest first, parsing
+  `started_ms` out of the id and `updated_ms` from the file mtime.
+- **Default location.** [`RecordingStore::open_default`] resolves
+  `$IX_DASH_RECORDINGS`, else `$XDG_STATE_HOME/ix-dash/recordings`, else
+  `~/.local/state/ix-dash/recordings`, else `/tmp/ix-dash-recordings-<user>`
+  (`recordings.rs:245`).
+
+### Durability and security
+
+- **Atomic writes.** [`RecordingStore::save`] (`recordings.rs:131`) writes a temp
+  file then renames, so a reader never sees a half-written recording.
+- **Owner-only.** The directory is set `0700` and each file is created `0600`
+  via `write_private` (`recordings.rs:227`); recordings capture exec source,
+  stdout, and stderr, so they must not be world-readable even briefly, and the
+  tight directory blocks a symlink-plant before the rename.
+- **Id validation.** `path_for` (`recordings.rs:188`) accepts only a bare
+  `rec-<digits>` stem (no separators, no `..`), so `load`/`save` and the
+  `GET /recording/{id}` route can never read or write outside the store (test
+  `rejects_unsafe_ids`, `recordings.rs:310`).
+
+A store failure is non-fatal to the aggregator: the dashboard still serves live
+and replay works from the browser's own captured history.
+
+[overview]: overview.md
+[`Hub`]: overview.md
+[`Hub::apply_scope`]: overview.md
+[`Hub::apply_scope(scope, panes)`]: overview.md
+[`Hub::remove_scope`]: overview.md
+[`Hub::export_snapshot`]: overview.md
+[`view_scalars`]: #two-projections-one-reconcile-loop
+[`view_texts`]: #two-projections-one-reconcile-loop
+[`RecordingStore`]: overview.md
+[`RecordingStore::list`]: #recordings-srcdashboardrecordingsrs
+[`RecordingStore::save`]: #durability-and-security
+[`RecordingStore::open_default`]: #recordings-srcdashboardrecordingsrs
+[`RecordingStore::spawn_recorder`]: #recordings-srcdashboardrecordingsrs
+[`Recorder`]: overview.md
+[`RecordingInfo`]: overview.md

--- a/docs/dashboard/dashboard-core/overview.md
+++ b/docs/dashboard/dashboard-core/overview.md
@@ -1,0 +1,208 @@
+# dashboard-core
+
+`packages/dashboard-core` is the engine-free crate every dashboard process
+links. It holds the wire types and discovery paths a producer and a consumer
+agree on, the unix-socket [`Publisher`]/[`subscribe`] transport, the
+browser-facing [`Hub`] Loro document and its SSE server, the durable
+[`RecordingStore`], and the embedded single-page canvas. A process that only
+publishes panes pulls in no HTTP or CRDT code; only a consumer that serves the
+board touches the `dashboard` module.
+
+It is a workspace library crate (`packages/dashboard-core/package.nix`:
+`inRustWorkspace = true`, no `flake`/`packageSet`), so it has no flake output of
+its own. It is consumed by [`dashboard`](../dashboard/overview.md),
+[`ix-windows`](../ix-windows/overview.md), and the `tui` crate. The deep
+reconcile mechanism and recordings are documented in [internals](internals.md).
+
+## Modules (`src/lib.rs:28-43`)
+
+- **`pane`** - the wire types ([`Pane`], [`View`] and its variants,
+  [`ProducerSnapshot`]) and the discovery paths ([`discovery_dir`],
+  [`socket_path`]). Both halves of the system depend on this and nothing else of
+  each other. `src/pane.rs`.
+- **`publish`** - producer side: [`Publisher`] and the cloneable [`PaneSink`]
+  that stream a snapshot over a `UnixListener`. `src/publish.rs`.
+- **`subscribe`** - consumer side: [`subscribe`] discovers sockets and streams
+  [`ProducerEvent`]s. `src/subscribe.rs`.
+- **`dashboard`** - the read-only web canvas: the [`Hub`] document
+  (`src/dashboard/hub.rs`), the HTTP/SSE [`serve_hub`] server
+  (`src/dashboard/server.rs`), and the [`RecordingStore`]
+  (`src/dashboard/recordings.rs`). See [internals](internals.md).
+- **`error`** - one [`Error::Dashboard`] variant collapsing foreign-boundary
+  failures (TCP bind, Loro encode); `Result<T>` alias. `src/error.rs`.
+
+## Wire types (`src/pane.rs`)
+
+A [`Pane`] (`pane.rs:35`) is `{ id, title, subtitle, view }`. `id` is unique
+within a producer; the consumer namespaces it. Constructors set sensible titles:
+`Pane::terminal`/`html`/`exec`/`data` (`pane.rs:50-105`).
+
+[`View`] (`pane.rs:115`) is an internally tagged enum, `#[serde(tag = "kind",
+rename_all = "snake_case")]`, so each body serializes with a `kind`
+discriminant and the browser renders by tag with no schema negotiation:
+
+| `kind` | type | body |
+| --- | --- | --- |
+| `terminal` | [`TerminalView`] (`pane.rs:141`) | `command`, `args`, `rows`/`cols`, `alive`, `screen` (rows newline-joined with minimal ANSI SGR runs), cursor row/col/visible/shape, `exit_code`. |
+| `html` | [`HtmlView`] (`pane.rs:185`) | one self-contained `html` document, mounted sandboxed. |
+| `exec` | [`ExecView`] (`pane.rs:200`) | one captured process run: `source`, `lang`, `stdout`, `stderr`, `result`, `running`, `ok`, `duration_ms`, and an inline `trace` of [`ExecTraceLine`] (`pane.rs:242`) pairing each output chunk with the 1-based source line that emitted it. |
+| `data` | [`DataView`] (`pane.rs:268`) | arbitrary JSON `data` plus a `renderer` name; an unknown/empty name falls back to a generic JSON tree on the frontend. |
+
+[`View::kind`] (`pane.rs:129`) returns the wire tag. Adding a first-class
+resource adds a `View` variant and a native renderer; a user-defined one reuses
+`Html`/`Data` with no aggregator change. Fields added after the first wire shape
+carry `#[serde(default)]` so a mixed-version fleet keeps parsing (`pane.rs:156`;
+test `old_terminal_wire_shape_deserializes_with_field_defaults`, `pane.rs:346`).
+
+[`ProducerSnapshot`] (`pane.rs:285`) is `{ producer, panes }`: one producer's
+full pane set, the unit streamed over a socket.
+
+### Discovery paths
+
+- [`discovery_dir`] (`pane.rs:300`): `$IX_DASH_DIR`, else
+  `$XDG_RUNTIME_DIR/ix-dash`, else `/tmp/ix-dash-<user>`. Short by design: macOS
+  caps a unix `sun_path` at 104 bytes, and `$TMPDIR` would blow that budget.
+- [`socket_path`] (`pane.rs:316`): `<discovery_dir>/<pid>-<short-uuid>.sock`.
+
+## Producer side: `publish` (`src/publish.rs`)
+
+[`Publisher::bind(path, runtime)`] (`publish.rs:109`) binds a `UnixListener` at
+`path` (usually [`socket_path`]) and spawns an accept loop on the supplied
+runtime handle, so a producer can bind from a thread that is not itself a tokio
+worker (e.g. one driving a native run loop). It creates a missing parent dir
+mode `0700`, reaps a stale socket left by a crashed producer, and refuses to
+overwrite a non-socket at `path` (`reap_stale_socket`, `publish.rs:281`). The
+socket is set mode `0600`.
+
+[`Publisher::publish(&panes)`] (`publish.rs:176`) and the cloneable
+[`PaneSink::publish`] (`publish.rs:65`) replace the streamed snapshot. Each is
+cheap and synchronous: it serializes one NDJSON line into a `watch` channel; per
+connection a `write_loop` (`publish.rs:254`) writes the current line then each
+new one. A background sampling loop holds a [`PaneSink`] cloned from
+[`Publisher::sink`] (`publish.rs:184`) and is attached with
+[`Publisher::push_task`] so it stops with the publisher. [`Publisher::stop`]
+(`publish.rs:210`) / `Drop` signal the loops, abort tasks, and unlink the
+socket, so the aggregator stops listing a dead producer. [`Publisher::path`] and
+[`Publisher::producer_id`] expose the bound socket and the producer id.
+
+## Consumer side: `subscribe` (`src/subscribe.rs`)
+
+[`subscribe(dir, rescan, handle)`] (`subscribe.rs:53`) returns an
+`mpsc::Receiver<ProducerEvent>` (channel depth `256`, `subscribe.rs:43`). The
+`discover` loop (`subscribe.rs:63`) rescans `dir` every `rescan`, and for each
+new `*.sock` spawns exactly one reader (`connected` set, so a re-created socket
+reconnects only after its reader finishes). `read_producer` (`subscribe.rs:100`)
+connects, parses each NDJSON line, and forwards a
+[`ProducerEvent::Snapshot`]; on hangup it emits one
+[`ProducerEvent::Gone { producer }`] (`subscribe.rs:28`). A malformed line is
+skipped, not fatal (`subscribe.rs:121`); a connection refused on an actual
+socket reaps the stale file but never deletes a user's regular `*.sock`
+(`is_socket`, `subscribe.rs:138`). Dropping the receiver winds the loops down.
+Both the aggregator and `ix-windows` consume this one transport
+(`subscribe.rs:9`).
+
+## Web surface: `serve_hub` (`src/dashboard/server.rs`)
+
+[`serve_hub(hub, addr, recordings, runtime)`] (`server.rs:138`) binds a
+`TcpListener`, starts an `axum` server on `runtime`, and returns a
+[`ServedDashboard`] = a [`Dashboard`] handle plus a `watch` shutdown receiver
+the caller threads into its own frame-source tasks. One owner for the router
+means `tui::serve` and the standalone aggregator render through the same page and
+stream. Routes (`server.rs:155`):
+
+| route | handler | response |
+| --- | --- | --- |
+| `GET /`, `/index.html` | `index` | the embedded `DASHBOARD_HTML` page (`server.rs:40`, `:184`). |
+| `GET /events` | `events` | SSE: one `snapshot` event (base64 Loro snapshot) then `update` events (base64 deltas); a lagged client is re-sent a fresh `snapshot` (`server.rs:211`). |
+| `GET /recordings` | `list_recordings` | JSON list of [`RecordingInfo`], newest first; empty without a store (`server.rs:190`). |
+| `GET /recording/{id}` | `get_recording` | one recording's snapshot bytes (`application/octet-stream`); a bad or traversing id is a 404, validated by the store (`server.rs:201`). |
+
+[`Dashboard`] (`server.rs:63`) exposes `addr()`/`url()` (the bound `:0` port is
+resolved), `push_task` to tie a frame-source task's lifetime to the server, and
+`stop()` which aborts (not just signals) tasks: an open SSE stream never ends on
+its own, so `axum` graceful shutdown would block forever otherwise
+(`server.rs:91`). `recordings = None` leaves the replay routes reporting an empty
+list, which is what `tui::serve` passes.
+
+The [`Hub`] document fold, the projections that let a new view kind skip the
+reconcile loop, and the [`RecordingStore`] durability/security model are in
+[internals](internals.md).
+
+## Public surface
+
+Re-exported from `src/lib.rs:34-43`:
+
+- types: [`Pane`], [`View`], [`TerminalView`], [`HtmlView`], [`ExecView`],
+  [`ExecTraceLine`], [`DataView`], [`ProducerSnapshot`]
+- paths: [`discovery_dir`], [`socket_path`]
+- producer: [`Publisher`], [`PaneSink`]
+- consumer: [`subscribe`], [`ProducerEvent`]
+- web: [`Hub`], [`serve_hub`], [`Dashboard`], [`ServedDashboard`]
+- recordings: [`RecordingStore`], [`Recorder`], [`RecordingInfo`]
+- errors: [`Error`], [`Result`]
+
+## The embedded page (`src/dashboard/server.rs:40`, `build.rs`)
+
+`DASHBOARD_HTML` is `include_str!(concat!(env!("OUT_DIR"),
+"/dashboard.html"))`. The UI source is a Svelte/Vite app under `site/` whose
+renderer registry (`site/src/lib/renderers.ts`) maps each pane `kind` to a body
+component (`terminal`/`html`/`exec`/`data`) and dispatches a `data` pane's
+`renderer` name (e.g. `namespace`) to a named component. The frontend keeps the
+whole Loro oplog so it can scrub to any past version and replay
+(`site/src/lib/stream.svelte.ts`). Nix builds the app to one self-contained file
+(`ix.buildSvelteSite`, `lib/rust/workspace.nix:39`), exposes it through
+`IX_DASHBOARD_SITE_HTML` (`workspace.nix:218`), and `build.rs` (`build.rs:32`)
+copies it into `OUT_DIR`. Compile-time embedding is deliberate: `dashboard-core`
+is linked into non-wrappable artifacts (the `tui-py` PyO3 `.so` the MCP loads)
+that cannot carry a runtime `--site-dir`. A bare `cargo build` with no env var
+embeds a stub page (`build.rs:27`).
+
+## Tests
+
+- `src/pane.rs:321` - wire round-trips, the old-shape default-fill, exec titling.
+- `src/publish.rs:309`, `src/subscribe.rs:143` - stale-socket reaping refuses a
+  regular file; a producer that publishes then drops yields `Snapshot` then
+  `Gone`.
+- `tests/pipeline.rs` - end-to-end: a real producer socket streams an exec pane,
+  the hub fold + Loro snapshot decode preserves captured output and full history,
+  a recording round-trips through disk, and the HTTP server serves the page and
+  lists a recording.
+
+[internals]: internals.md
+[`Error::Dashboard`]: #
+[`Error`]: #
+[`Result`]: #
+[`Pane`]: #wire-types-srcpanrs
+[`View`]: #wire-types-srcpanrs
+[`View::kind`]: #wire-types-srcpanrs
+[`TerminalView`]: #wire-types-srcpanrs
+[`HtmlView`]: #wire-types-srcpanrs
+[`ExecView`]: #wire-types-srcpanrs
+[`ExecTraceLine`]: #wire-types-srcpanrs
+[`DataView`]: #wire-types-srcpanrs
+[`ProducerSnapshot`]: #wire-types-srcpanrs
+[`discovery_dir`]: #discovery-paths
+[`socket_path`]: #discovery-paths
+[`Publisher`]: #producer-side-publish-srcpublishrs
+[`Publisher::bind`]: #producer-side-publish-srcpublishrs
+[`Publisher::bind(path, runtime)`]: #producer-side-publish-srcpublishrs
+[`Publisher::publish`]: #producer-side-publish-srcpublishrs
+[`Publisher::publish(&panes)`]: #producer-side-publish-srcpublishrs
+[`Publisher::sink`]: #producer-side-publish-srcpublishrs
+[`Publisher::stop`]: #producer-side-publish-srcpublishrs
+[`PaneSink`]: #producer-side-publish-srcpublishrs
+[`PaneSink::publish`]: #producer-side-publish-srcpublishrs
+[`subscribe`]: #consumer-side-subscribe-srcsubscribers
+[`subscribe(dir, rescan, handle)`]: #consumer-side-subscribe-srcsubscribers
+[`ProducerEvent`]: #consumer-side-subscribe-srcsubscribers
+[`ProducerEvent::Snapshot`]: #consumer-side-subscribe-srcsubscribers
+[`ProducerEvent::Gone`]: #consumer-side-subscribe-srcsubscribers
+[`ProducerEvent::Gone { producer }`]: #consumer-side-subscribe-srcsubscribers
+[`serve_hub`]: #web-surface-serve_hub-srcdashboardserverrs
+[`serve_hub(hub, addr, recordings, runtime)`]: #web-surface-serve_hub-srcdashboardserverrs
+[`Dashboard`]: #web-surface-serve_hub-srcdashboardserverrs
+[`ServedDashboard`]: #web-surface-serve_hub-srcdashboardserverrs
+[`Hub`]: internals.md
+[`RecordingStore`]: internals.md
+[`Recorder`]: internals.md
+[`RecordingInfo`]: internals.md

--- a/docs/dashboard/dashboard/overview.md
+++ b/docs/dashboard/dashboard/overview.md
@@ -1,0 +1,103 @@
+# dashboard
+
+`packages/dashboard` is the standalone aggregator: one web canvas for every
+resource producer on the machine. It scans the discovery directory, connects to
+every producer socket, folds each producer's stream into one Loro document under
+its own scope, and serves the shared board over HTTP + SSE. No producer owns the
+server and exactly one process binds the TCP port, so any number of producers
+can come and go behind one stable URL.
+
+It is a thin binary over [dashboard-core](../dashboard-core/overview.md): it owns
+no wire types, no transport, and no rendering, only the process wiring (CLI,
+runtime, signal handling) plus a self-contained `demo` producer. Source is one
+file, `packages/dashboard/src/main.rs`.
+
+## Build and run
+
+Rust workspace binary (`packages/dashboard/Cargo.toml`: `[[bin]] name =
+"dashboard"`), built as the `dashboard` flake output
+(`packages/dashboard/package.nix`: `flake = true`, so `meta.mainProgram =
+"dashboard"`). Dependencies: `dashboard-core`, `clap`, `serde_json`, `tokio`
+(`Cargo.toml:15`).
+
+```
+nix run .#dashboard                      # serve on 127.0.0.1:8080, watch the discovery dir
+nix run .#dashboard -- --port 0          # ephemeral port, printed on startup
+nix run .#dashboard -- demo              # self-contained producer, no other process needed
+nix build .#dashboard                    # build the binary
+```
+
+`packages/dashboard/default.nix` selects the workspace binary via
+`ix.cargoUnit.selectBinaryWithTests` and additionally exposes the nix-built
+Svelte site under `passthru.tests.site` as a build check. The page itself is
+embedded into `dashboard-core` at compile time (see
+[dashboard-core](../dashboard-core/overview.md#the-embedded-page-srcdashboardserverrs-buildrs));
+this binary carries no runtime asset dependency.
+
+## CLI (`src/main.rs:29`)
+
+| flag | default | meaning |
+| --- | --- | --- |
+| `--host` | `127.0.0.1` | bind address; `0.0.0.0` exposes it on the network (`main.rs:33`). |
+| `--port` | `8080` | bind port; `0` picks an ephemeral port, printed on startup (`main.rs:37`). |
+| `--dir` | discovery dir | producer-socket directory to watch (serve) or publish into (demo); global so it works before or after the subcommand (`main.rs:44`). Defaults via [`discovery_dir`](../dashboard-core/overview.md#discovery-paths). |
+| `--rescan-ms` | `500` | how often to rescan the directory for new/removed sockets (`main.rs:49`). |
+| `--record-ms` | `5000` | how often to persist the board as a replayable recording; `0` disables on-disk recording (replay still works live in the browser) (`main.rs:55`). |
+| `--record-dir` | recordings dir | where recordings are written (`main.rs:61`). Defaults via the `RecordingStore` resolver. |
+
+Subcommand `demo` (`main.rs:68`): publish one pane of every kind to the
+discovery directory until interrupted.
+
+## Serve flow (`run_server`, `src/main.rs:85`)
+
+1. Resolve `dir` (`--dir` or [`discovery_dir`]) and parse the bind `SocketAddr`.
+2. Create a [`Hub`](../dashboard-core/overview.md) and take the current tokio
+   runtime handle (the process runtime outlives the dashboard, so the server and
+   discovery loop run for the binary's lifetime, `main.rs:103`).
+3. Open the [`RecordingStore`](../dashboard-core/internals.md#recordings-srcdashboardrecordingsrs)
+   (`--record-dir` or default). A store failure is logged and recording is
+   disabled, not fatal (`main.rs:95`).
+4. [`serve_hub`](../dashboard-core/overview.md#web-surface-serve_hub-srcdashboardserverrs)
+   binds the listener and starts the server; the binary prints the URL and the
+   watched directory (`main.rs:105`). The returned shutdown receiver is held for
+   the binary's lifetime.
+5. If `--record-ms > 0`, `store.spawn_recorder(hub, interval, handle)` starts the
+   periodic recorder and its task is attached with `Dashboard::push_task`
+   (`main.rs:118`).
+6. [`subscribe`](../dashboard-core/overview.md#consumer-side-subscribe-srcsubscribers)
+   yields a `ProducerEvent` stream; a spawned loop folds each event into the hub:
+   `Snapshot` -> `hub.apply_scope(producer, panes)`, `Gone` ->
+   `hub.remove_scope(producer)` (`main.rs:138`). The transport (directory scan,
+   per-socket read, stale-socket reaping) lives in `dashboard-core::subscribe`,
+   shared with [ix-windows](../ix-windows/overview.md).
+7. On `Ctrl-C`, `dashboard.stop()` aborts the server and tasks, then a final
+   snapshot is written so the recording does not lose the last interval of
+   changes the aborted recorder task would otherwise drop (`main.rs:150-158`).
+
+Scope discipline: the aggregator passes the wire `producer` id straight through
+as the hub scope, so each producer's panes stay isolated (see the scope
+invariant in [dashboard-core internals](../dashboard-core/internals.md#reconcile-apply_scope--remove_scope)).
+
+## Demo producer (`run_demo`, `src/main.rs:174`)
+
+`dashboard demo` binds a [`Publisher`](../dashboard-core/overview.md#producer-side-publish-srcpublishrs)
+at [`socket_path`] (or `<dir>/<pid>-demo.sock`) and republishes `demo_panes(tick)`
+once a second (`main.rs:185`). `demo_panes` (`main.rs:201`) emits one of each
+kind to exercise the whole pipeline and every renderer:
+
+- a `terminal` pane with a green SGR `tick` line and a growing bar,
+- an `html` pane (a producer-rendered fragment),
+- an `exec` pane alternating running/finished, the finished state carrying an
+  inline `trace` so the inline-trace view is exercised,
+- a `data` pane with the `kv` renderer and nested JSON.
+
+Run `dashboard demo` in one shell and `dashboard` in another to see the board
+populate with no MCP or `tui` process running.
+
+## Producers in the wild
+
+The aggregator is producer-agnostic: anything that drives a `Publisher` appears.
+Today's producers (other domains) are the `tui` crate (its PTY manager adapted
+into terminal panes) and the MCP's `pane_bridge.py` (one `exec` pane per run,
+one `html` pane per live resource, one `data`/`namespace` pane for the kernel
+globals). The `dashboard demo` subcommand is the self-contained one.

--- a/docs/dashboard/ix-windows/overview.md
+++ b/docs/dashboard/ix-windows/overview.md
@@ -1,0 +1,144 @@
+# ix-windows
+
+`packages/ix-windows` renders each live MCP resource as its own borderless,
+square, ghostty-styled native webview window. It is a second consumer of the
+dashboard producer stream, alongside the [dashboard](../dashboard/overview.md)
+web aggregator: instead of folding producers into a web board, it maps each
+`resource/<id>` html pane to one OS window. A window opens when a resource
+appears, re-renders in place on update (no reload, so scroll and focus survive),
+and closes when the resource closes or its producer disconnects.
+
+It reuses [dashboard-core](../dashboard-core/overview.md) for the entire
+transport, so the MCP needs no change: the MCP already publishes every
+`register_resource()` view as an [`HtmlView`] pane keyed `resource/<id>` (see
+`packages/mcp/ix_notebook_mcp/pane_bridge.py`), and this process just windows
+those panes. A producer's exec runs, namespace, and cells stay on the web
+canvas.
+
+It is split into a reusable engine library (`src/lib.rs`, `[lib] name =
+"ix_windows"`) and a thin binary (`src/main.rs`, `[[bin]] name = "ix-windows"`).
+
+## Build and run
+
+Rust workspace package (`packages/ix-windows/Cargo.toml`), built as the
+`ix-windows` flake output (`package.nix`: `flake = true`). Deps: `dashboard-core`,
+`clap`, `tao`, `wry`, `tokio`, `serde_json`; on macOS also `objc2` +
+`objc2-foundation` + `objc2-web-kit` for the WebKit/window tuning
+(`Cargo.toml:31`).
+
+```
+nix run .#ix-windows                 # watch the default discovery dir
+nix run .#ix-windows -- --dir /tmp/ixw
+nix build .#ix-windows
+```
+
+**Darwin-only flake output.** `wry` links the system WebKit framework on macOS;
+Linux (WebKitGTK) is a later add, so `default.nix` restricts `meta.platforms` to
+`aarch64-darwin` and `x86_64-darwin` (`packages/ix-windows/default.nix:11`). The
+macOS WebKit tuning (`src/lib.rs:294`) is behind `#[cfg(target_os = "macos")]`,
+so the crate still compiles on other targets, just without that tuning.
+
+## CLI (`src/main.rs:22`)
+
+| flag | default | meaning |
+| --- | --- | --- |
+| `--dir` | discovery dir | producer-socket directory to watch, matching the `dashboard` aggregator. Defaults via [`discovery_dir`](../dashboard-core/overview.md#discovery-paths) (`main.rs:28`). |
+| `--rescan-ms` | `500` | how often to rescan the directory for new/removed sockets (`main.rs:33`). |
+
+## Threading model (`src/main.rs:37`)
+
+Windows must be created and driven on the main thread (`tao`), but the
+subscriber is async. The binary:
+
+1. Builds a `tao` `EventLoop` parameterized on `ProducerEvent` as its user-event
+   type, and a proxy (`main.rs:43`).
+2. Spawns a side thread running a multi-thread tokio runtime that calls
+   [`subscribe`](../dashboard-core/overview.md#consumer-side-subscribe-srcsubscribers)
+   and forwards each `ProducerEvent` into the event loop via the proxy; it stops
+   when the loop has exited (`main.rs:49`).
+3. Runs the event loop with `ControlFlow::Wait` (reactive viewer, not an
+   animation loop) and dispatches to a [`WindowManager`] (`main.rs:65`):
+   `UserEvent(Snapshot)` -> `apply_snapshot`, `UserEvent(Gone)` ->
+   `producer_gone`, `WindowEvent::CloseRequested` -> `window_closed`.
+
+## The engine: `WindowManager` (`src/lib.rs`)
+
+[`WindowManager`] (`lib.rs:69`) owns the open windows and reconciles them against
+each producer snapshot. It is decoupled from the event source and generic over
+the loop's user-event type `T` so an embedder can drive it from its own `tao`
+loop; the binary's `main` is a thin wrapper. A window's global identity is the
+`PaneKey = (producer id, pane id)` (`lib.rs:35`), since a pane id is unique only
+within its producer.
+
+Public surface:
+
+- [`WindowManager::new`] (`lib.rs:89`) / `Default`: an empty manager.
+- [`apply_snapshot<T>(target, snapshot)`] (`lib.rs:99`): for each pane that is an
+  `Html` view whose id starts with `resource/` (`RESOURCE_PREFIX`, `lib.rs:31`),
+  refresh an open window or open a new one; close windows for this producer's
+  resources no longer present; and forget dismissals for resources that vanished.
+  Non-html or non-`resource/` panes are skipped, so exec/namespace/cell panes
+  stay on the web canvas.
+- [`producer_gone(producer)`] (`lib.rs:141`): drop every window of a disconnected
+  producer and clear its dismissals.
+- [`window_closed(window_id)`] (`lib.rs:157`): the user closed a window; remove
+  it and record the dismissal. Returns whether it was one of ours.
+- [`is_empty`] (`lib.rs:168`): whether any resource windows are open.
+
+### Reconcile invariants
+
+- **In-place refresh.** `OpenWindow::refresh` (`lib.rs:51`) swaps only the
+  `#ix-root` inner HTML via `evaluate_script` when the html changed, and resets
+  the title when it changed, so the document, scroll position, and focus survive
+  an update (a full reload would flicker and reset them). The new HTML is injected
+  as a `serde_json::to_string` JS string literal, so arbitrary resource HTML is
+  escaped safely (`lib.rs:55`).
+- **Dismissal tracking.** `dismissed` (`lib.rs:79`) records resources the user
+  closed while still live. Without it, the next snapshot (any content change
+  republishes one) would find the window gone and re-open it, fighting the user.
+  It is cleared when the resource actually vanishes or its producer disconnects,
+  so a genuine re-registration opens a fresh window.
+- **Reverse index.** `by_window` (`lib.rs:73`) maps an OS `WindowId` back to its
+  `PaneKey` for close events.
+- **Cascade.** `opened` (`lib.rs:83`) offsets each new window so they do not
+  stack exactly on a plain desktop; a tiling WM ignores the position hint.
+
+## Native window styling (macOS)
+
+- **Borderless, square corners.** Windows are built `with_decorations(false)`,
+  `with_transparent(true)`, 720x480 logical (`lib.rs:194`), exactly like
+  ghostty's `window-decoration = none`. The macOS window server only rounds
+  *titled* windows, so dropping decorations gives square corners for free.
+- **Ghostty-flavored shell.** `shell(title, body)` (`lib.rs:249`) wraps the
+  resource HTML in a dark, monospace, Catppuccin-ish document whose `#ix-root`
+  holds the body; the `<title>` is escaped, the body is injected verbatim (the
+  same trust model as the web dashboard's sandboxed html pane). Styling is the
+  `STYLE` constant (`lib.rs:270`).
+- **120Hz.** `enable_high_refresh` (`lib.rs:294`) disables WebKit's private
+  `PreferPageRenderingUpdatesNear60FPSEnabled` experimental feature via the
+  private `_setEnabled:forExperimentalFeature:` selector (gated by
+  `respondsToSelector:` checks), so the webview renders at the display's native
+  rate (ProMotion) instead of the ~60fps cap. Best-effort: an OS without those
+  selectors stays at the default.
+
+## Tiling under aerospace / yabai
+
+A borderless window has no fullscreen button, so aerospace's dialog heuristic
+floats it by default, and `ix-windows` has no bundle id to special-case. The
+crate `README.md` gives the rules: an aerospace `on-window-detected` rule
+matching `app-name-regex-substring = 'ix-windows'` with `run = 'layout tiling'`,
+or `yabai -m rule --add app='^ix-windows$' manage=on`.
+
+## Tests (`src/lib.rs:334`)
+
+`shell` wraps the body in `#ix-root` and escapes the title;
+`escape_text` covers `<`, `&`, `>`. The window/webview paths require a display
+and are exercised manually.
+
+[`HtmlView`]: ../dashboard-core/overview.md#wire-types-srcpanrs
+[`WindowManager`]: #the-engine-windowmanager-srclibrs
+[`WindowManager::new`]: #the-engine-windowmanager-srclibrs
+[`apply_snapshot<T>(target, snapshot)`]: #the-engine-windowmanager-srclibrs
+[`producer_gone(producer)`]: #the-engine-windowmanager-srclibrs
+[`window_closed(window_id)`]: #the-engine-windowmanager-srclibrs
+[`is_empty`]: #the-engine-windowmanager-srclibrs

--- a/docs/dev-tools/common.md
+++ b/docs/dev-tools/common.md
@@ -1,0 +1,102 @@
+# dev-tools
+
+Miscellaneous first-party developer utilities, benchmarking, and worked
+examples that do not belong to a larger domain. Nothing here runs in a deployed
+service: these are local-developer and CI tools (a pretty `git log`, a TLS
+reachability prober, a continuous-benchmarking framework) plus one standalone
+GPU example. Each is its own `packages/<name>` crate; three are members of the
+index Rust workspace surfaced as flake apps, one (`cuda-hello`) is a deliberately
+detached crate with its own toolchain.
+
+Read this page first, then the component page for the tool you are touching.
+
+## Units
+
+| package | crate / output | role |
+| --- | --- | --- |
+| `packages/git-log-pretty` | workspace member; `nix run .#git-log-pretty` | pretty `git log` viewer: commits ahead of `main` as colored file-icon trees, optional inline author avatars. See [git-log-pretty](git-log-pretty/overview.md). |
+| `packages/ix-dev-diagnose` | workspace member; `nix run .#ix-dev-diagnose` | one-shot HTTPS reachability prober for `ix.dev`: writes a JSON diagnostic of DNS, TCP, TLS (dual-trust-store), and HTTP results. See [ix-dev-diagnose](ix-dev-diagnose/overview.md). |
+| `packages/indexbench` | workspace member; `nix run .#indexbench` (CLI), `nix run .#bench` (perf job) | metric-centric continuous-benchmarking framework: micro + macro harnesses, durable history, statistical regression gate. See [indexbench](indexbench/overview.md). |
+| `packages/cuda-hello` | standalone crate (not a workspace member; no flake app) | minimal CUDA kernel in pure Rust lowered to PTX via cuda-oxide; custom pinned nightly, Linux only. See [cuda-hello](cuda-hello/overview.md). |
+
+## How it fits together
+
+These are independent CLIs, not a layered subsystem. What they share is build
+and packaging convention, not runtime code:
+
+- **Three are standard workspace units.** `git-log-pretty`, `ix-dev-diagnose`,
+  and `indexbench` each have a `default.nix` that calls
+  `ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units { binary = ...; }`
+  and a `package.nix` with `flake = true; inRustWorkspace = true;
+  passthruTests = true;`, so each gets a `nix run .#<name>` app and runs its
+  test target through the shared cargo-unit graph
+  (`packages/git-log-pretty/default.nix:3`, `packages/indexbench/default.nix:3`,
+  `packages/ix-dev-diagnose/default.nix:3`). `mainProgram` is set so `lib.getExe`
+  resolves the binary.
+- **`cuda-hello` is the exception by design.** Its `Cargo.toml` has an empty
+  `[workspace]` table to detach it from the repo workspace, it has no
+  `package.nix`, and its toolchain is a pinned nightly the workspace toolchain
+  cannot build, so the root `nix flake check` never touches it
+  (`packages/cuda-hello/Cargo.toml:1-15`). It ships its own `flake.nix` that
+  provides only dev shells.
+- **Terminal-output crates are reused, not reimplemented.** `git-log-pretty`
+  styles through sibling workspace crates `terminal-theme` (light/dark
+  detection), `kitty` (graphics protocol), `github-avatar` (login resolution and
+  avatar fetch), plus the external `devicons` for file glyphs
+  (`packages/git-log-pretty/Cargo.toml:11-29`). Those crates belong to other
+  domains; this domain only consumes them.
+- **`indexbench` is consumed by Nix, not just run by hand.** `ix.mkBenchSuite`
+  (`lib/util/bench.nix`) turns a data description of a suite into an `app` (a
+  `nix run`-able perf job) and an optional `check` (a hermetic `nix flake check`
+  that gates a deterministic allocation count). The repo's own self-demo suite
+  is wired in `lib/per-system.nix:404-420`.
+
+## Invariants
+
+- **Exit code is the contract, where there is one.** `indexbench run` and
+  `indexbench assert` exit non-zero on a regression / over-budget metric, which
+  is the CI gate (`packages/indexbench/src/main.rs:263-267`,
+  `:353-357`). `ix-dev-diagnose` is the opposite: it always returns success and
+  signals reachability only through its printed `success`/`failure` line and the
+  JSON `summary.ok`, never the process exit code
+  (`packages/ix-dev-diagnose/src/main.rs:271-293`).
+- **Read a local repo without system libraries.** Both git-aware tools depend on
+  `git2` with `default-features = false` plus `vendored-libgit2`, so the build
+  compiles bundled libgit2 with `cc` and needs no system libgit2, openssl, or
+  cmake (`packages/git-log-pretty/Cargo.toml:18-23`).
+- **Reproducible vs sandbox-sensitive metrics.** `indexbench` keeps deterministic
+  metrics (allocation counts) usable as `nix flake check`s and routes
+  timing/RSS to a perf job, because only the former are stable inside the Nix
+  sandbox (`packages/indexbench/src/lib.rs:24-26`).
+
+## Glossary
+
+- **workspace unit / cargo-unit**: a `packages/<name>` crate built through
+  `ix.cargoUnit.selectBinaryWithTests` over the shared `rustWorkspace.units`
+  graph; gives one binary plus a passthru test derivation.
+- **flake app**: an output exposed by `package.nix` `flake = true`, runnable as
+  `nix run .#<name>`.
+- **metric**: in `indexbench`, any named number with a unit and a direction
+  (`lower_is_better`); the framework's central abstraction, not "time".
+- **distributional / deterministic metric**: a metric with per-iteration
+  `samples` (gets a statistical test) versus one without (exact compare).
+- **regression gate**: `indexbench`'s rule that exits non-zero when a metric
+  worsened past its regime's threshold; see [indexbench](indexbench/overview.md).
+- **recording verifier**: `ix-dev-diagnose`'s custom rustls verifier that records
+  trust outcomes against two root stores but never fails the handshake, so the
+  full certificate chain is captured even when verification fails.
+- **kitty Unicode placeholder**: the terminal graphics mechanism `git-log-pretty`
+  uses to draw author avatars as ordinary scrolling text cells.
+- **PTX**: NVIDIA's GPU assembly; `cuda-hello` lowers a Rust `#[kernel]` to PTX
+  via cuda-oxide, with no GPU needed to compile.
+- **cuda-oxide**: NVIDIA's experimental rustc codegen backend (`cargo oxide`)
+  that compiles Rust to CUDA PTX.
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| git-log-pretty | [git-log-pretty/overview.md](git-log-pretty/overview.md) | commits-ahead-of-main `git log` with file-icon trees and kitty avatars |
+| ix-dev-diagnose | [ix-dev-diagnose/overview.md](ix-dev-diagnose/overview.md) | JSON HTTPS reachability diagnostics for ix.dev |
+| indexbench | [indexbench/overview.md](indexbench/overview.md) | continuous benchmarking: harnesses, durable history, regression gate |
+| cuda-hello | [cuda-hello/overview.md](cuda-hello/overview.md) | minimal pure-Rust CUDA kernel compiled to PTX (standalone) |

--- a/docs/dev-tools/cuda-hello/overview.md
+++ b/docs/dev-tools/cuda-hello/overview.md
@@ -1,0 +1,99 @@
+# cuda-hello
+
+`packages/cuda-hello` is a minimal CUDA kernel written in pure, idiomatic Rust
+and compiled to PTX with [cuda-oxide](https://github.com/NVlabs/cuda-oxide),
+NVIDIA's experimental Rust-to-CUDA codegen backend. Host and device code share
+one file (`src/main.rs`); each GPU thread writes the square of its own index, the
+GPU "hello, world" (`README.md:1-12`). It is the seed for first-class
+CUDA-in-Rust support in the repo, written against cuda-oxide's real API and
+verified to lower to PTX.
+
+## Why this crate is standalone
+
+Unlike every other package in this domain, `cuda-hello` is deliberately not a
+member of the index cargo workspace and has no `package.nix`, so there is no
+`nix run .#cuda-hello` and the root `nix flake check` never builds it
+(`Cargo.toml:1-15`, `README.md:53-59`). The detachment is structural:
+
+- An empty `[workspace]` table in `Cargo.toml` makes the crate its own workspace
+  root, off the repo's workspace toolchain (`Cargo.toml:15`).
+- cuda-oxide is a custom rustc codegen backend that hooks unstable rustc
+  internals, so it needs its own pinned nightly, the `cargo oxide` driver, LLVM
+  22 with the NVPTX backend, and the CUDA toolkit. The index workspace pins a
+  different stable toolchain that cannot build it (`Cargo.toml:1-8`).
+- A crate-local `flake.nix` carries that toolchain instead, exposing only dev
+  shells (no packages), so the repo flake is untouched.
+
+## Toolchain and pinning
+
+- `rust-toolchain.toml` pins `nightly-2026-04-03` with `rust-src`, `rustc-dev`,
+  `rust-analyzer`, `clippy`, and `llvm-tools`; the `rustc-dev`/`rust-src`/
+  `llvm-tools` components are required because cuda-oxide hooks rustc internals
+  (`rust-toolchain.toml:1-6`).
+- The cuda-oxide rev `d22af5f29738fce099ae38262faa7ab59828865f` is pinned in
+  lockstep in both `Cargo.toml` (the `cuda-device`, `cuda-host`, `cuda-core` git
+  deps) and `flake.nix` (the `cuda-oxide` input, with `nixpkgs` following it);
+  bump the rev and the toolchain channel together (`Cargo.toml:17-24`,
+  `flake.nix:4-11`).
+- `flake.nix` provides `devShells.default` for `x86_64-linux` and `aarch64-linux`
+  (cuda-oxide is Linux-only), inheriting cuda-oxide's dev shell verbatim via
+  `inputsFrom` so the full CUDA + Rust environment (driver, nightly, LLVM 22 with
+  NVPTX, CUDA 13, libclang) needs no manual setup (`flake.nix:13-40`).
+
+## Dependencies (`Cargo.toml:17-31`)
+
+- `cuda-device` - device-side intrinsics: thread indexing, the `#[kernel]` /
+  `#[cuda_module]` attributes, and the bounds-checked `DisjointSlice` device
+  pointer.
+- `cuda-core` - host-side CUDA runtime: context, stream, device buffers, launch
+  config.
+- `cuda-host` - host-side launch glue used only by the code the `#[cuda_module]` /
+  `#[kernel]` macros generate; `cargo-machete` is told to ignore it
+  (`Cargo.toml:26-31`) since its source scan cannot see macro-generated uses.
+
+## Kernel and host (`src/main.rs`)
+
+A `#[cuda_module] mod kernels` holds one `#[kernel] fn squares(mut out:
+DisjointSlice<u32>)`: each thread reads its 1-D global index via
+`thread::index_1d()` and, if `out.get_mut(idx)` is in bounds, writes `i * i`.
+`get_mut` returns `None` past the buffer end, so an over-launched grid can never
+write out of bounds (`src/main.rs:18-40`). `THREADS = 256` (`src/main.rs:16`).
+
+`main` is ordinary host Rust routed to the normal backend: open
+`CudaContext::new(0)`, take the default stream, allocate a zeroed
+`DeviceBuffer<u32>`, `kernels::load(&ctx)` the embedded PTX module, launch
+`module.squares(...)` with `LaunchConfig::for_num_elems(THREADS)`, copy results
+back with `to_host_vec`, and assert each element equals `i * i`
+(`src/main.rs:42-70`). `rustc-codegen-cuda` routes the `#[kernel]` function
+through the Rust -> MIR -> PTX pipeline and leaves `main` to the host backend, so
+one `cargo oxide run` produces a host binary with the PTX embedded.
+
+## Building and running (`README.md:14-52`)
+
+Compiling needs no GPU: lowering the kernel to PTX is a normal compile step that
+runs anywhere, including CI. Running the binary needs an NVIDIA GPU and driver,
+because `main` opens a CUDA context and launches the kernel.
+
+```sh
+nix develop            # enter the cuda-oxide toolchain (Linux only)
+cargo oxide build      # compile to PTX (no GPU required)
+cargo oxide run        # compile to PTX, then launch on the GPU
+```
+
+`cargo oxide` is cuda-oxide's driver: it sets the custom codegen backend and
+emits a `.ptx` next to the host binary. On a standalone crate it auto-fetches and
+builds `librustc_codegen_cuda.so` on first use and caches it (outside the Nix
+store), so the first build is much slower than later ones.
+
+## Status
+
+Verified end to end on the compile path (the kernel lowers to PTX via `cargo
+oxide build`, no GPU); the run path needs an NVIDIA device. Not yet done, and the
+work to reach a pure `nix build .#cuda-hello` (`README.md:61-79`):
+
+- Package the cuda-oxide backend in a pure derivation and build this crate as a
+  nix-cargo-unit. cuda-oxide itself does not yet ship a pure build
+  (`librustc_codegen_cuda.so` is built on first use and cached outside the Nix
+  store), so this is upstream work as much as repo work.
+- A compile-only CI check that asserts the kernel still lowers to PTX, so a bad
+  cuda-oxide rev bump surfaces here.

--- a/docs/dev-tools/git-log-pretty/overview.md
+++ b/docs/dev-tools/git-log-pretty/overview.md
@@ -1,0 +1,117 @@
+# git-log-pretty
+
+`packages/git-log-pretty` is a pretty `git log` viewer. With no subcommand it
+shows what HEAD is ahead of `main` (or recent history when HEAD is `main`), each
+commit a one-line summary plus an icon tree of the files it touched; the `diff`
+subcommand renders just the changed-file tree between two refs. On a TTY it pages
+like `git log`, and on a graphics terminal it can draw each author's GitHub
+avatar inline (`src/main.rs:1-10`).
+
+- Crate: `git-log-pretty` (workspace member, MIT, `Cargo.toml:1-6`).
+- Flake output: `nix run .#git-log-pretty`. Built by
+  `ix.cargoUnit.selectBinaryWithTests` with `mainProgram = "git-log-pretty"`
+  (`default.nix:3-9`); `package.nix` sets `flake`, `inRustWorkspace`,
+  `passthruTests`.
+
+## CLI surface (`src/main.rs:38-73`)
+
+Global flags (apply to both the default log and `diff`):
+
+| flag | default | effect |
+| --- | --- | --- |
+| `--no-pager` | off | write to stdout instead of paging (`src/main.rs:44-46`). |
+| `--no-avatar` | off | never draw inline author avatars (`src/main.rs:47-49`). |
+| `--avatar-rows <N>` | `2` | avatar height in terminal rows; `0` disables, capped at `64` (`src/main.rs:50-56`). |
+
+Subcommand:
+
+- `diff [BASE] [HEAD]` - changed-file tree between two refs, like `git diff
+  --stat` with icons. `BASE` defaults to `main`, `HEAD` to `HEAD`
+  (`src/main.rs:62-73`). Uses the merge-base (`base...head`) view, not a raw
+  two-tree diff.
+
+No subcommand runs the log view: on `main` it prints `recent_commits` capped at
+`MAX_COMMITS = 15`; on any other branch it prints commits ahead of `main`, with
+a `(showing first 15, N more hidden)` header when there are more, or
+`All caught up with main` when there are none (`src/main.rs:92-145`,
+`:29-32`).
+
+## Modules (`src/main.rs:19-25`)
+
+- **`git`** - repository queries on `git2`. `commits_ahead(repo, base)` is the
+  set difference of commits reachable from HEAD minus those reachable from
+  `base`, sorted newest-first (`src/git.rs:157-185`). `diff_stat_files` diffs the
+  merge base against `head` so commits that landed on `base` after the fork do
+  not pollute the tree (`src/git.rs:188-217`). `resolve_ref` tries
+  `refs/heads/<name>`, `refs/remotes/<name>`, `refs/remotes/origin/<name>`, then
+  the raw name, so a single-branch CI checkout still finds the base
+  (`src/git.rs:106-125`). Each delta becomes a `ChangedFile { path, kind }` where
+  `ChangeKind` collapses git's `Delta` into Added/Modified/Deleted/Renamed
+  (`src/git.rs:13-33`).
+- **`tree`** - renders changed files as a colored, icon-annotated tree. Paths
+  fold into a directory trie, single-child directory chains collapse (so
+  `a/b/c.rs` is one node), and each file gets its `devicons` glyph in the icon's
+  own color; deletions render gray and struck through end to end
+  (`src/tree.rs:1-6`, `:62-166`).
+- **`display`** - the per-commit block: a `shorthash summary - relative-time`
+  header plus the tree. A conventional-commit summary (`type(scope):
+  description`) gets a hashed background "chip" on the type and a dimmed scope
+  (`src/display.rs:21-66`). Avatar layout lays placeholder cells beside the text
+  with `avatar_cols(rows) = 2 * rows` columns (`src/display.rs:137-213`).
+- **`pager`** - routes output through `$PAGER` (run via `sh -c`, so `PAGER="less
+  -R"` and empty-disables-paging both work), else `less`. For `less` it appends
+  `-F -r -X` and defaults `$LESS` so Nerd Font glyphs pass through raw and stay in
+  scrollback; a reader quitting early (`BrokenPipe`) is swallowed, not an error
+  (`src/pager.rs:1-105`).
+- **`palette`** - re-exports `terminal_theme::{Theme, detect}` and builds
+  `anstyle` styles; light/dark picks foreground contrast and the devicons theme,
+  and conventional-commit types get a stable hashed HSV background
+  (`src/palette.rs:1-104`).
+- **`avatar`** - GitHub login resolution and avatar fetch (below).
+- **`time`** - coarse "N units ago" relative timestamps, "just now" under a
+  minute and for future (clock-skewed) times (`src/time.rs:1-26`).
+
+## Avatars: resolution and rendering
+
+`avatar::Resolver` maps a commit author to PNG bytes cheapest-first and ties
+each step to a real account (`src/avatar.rs:1-9`, `:88-129`):
+
+1. an explicit `git config githubLogin.map` override (`email=login` multivar,
+   `src/avatar.rs:260-283`),
+2. the login embedded in a GitHub `noreply` email, then
+3. GitHub's record of who authored the commit (origin remote slug + commit SHA).
+
+Caches are aggressive so a log view makes at most one network request per unique
+author: an in-memory `login`/`png` cache, an on-disk PNG cache, and a persisted
+`email\tlogin` map (`logins.tsv`) under
+`$XDG_CACHE_HOME`/`$HOME/.cache` `git-log-pretty/avatars`
+(`src/avatar.rs:285-311`). A GitHub token (for the authenticated lookups, not the
+download) is read from `GITHUB_TOKEN`, `GH_TOKEN`, then `gh auth token`
+(`src/avatar.rs:240-258`). The async client runs on a short-lived current-thread
+tokio runtime (`src/main.rs:239-263`).
+
+Rendering uses the kitty Unicode-placeholder graphics protocol. Each unique
+avatar's pixels are transmitted once up front via `kitty::transmit_virtual`, then
+the commit gutter is drawn with placeholder cells that resolve to that image id
+(image ids are 24-bit, seeded per-pid, masked by `ID_MASK`,
+`src/avatar.rs:20-22`, `:155-174`). Because placeholder cells are ordinary
+left-to-right text, the log scrolls like any output, but they must reach the
+terminal verbatim, so a graphics log bypasses the pager (a screen-repainting
+pager severs the cell from the foreground color carrying its image id);
+a plain log still pages (`src/main.rs:147-215`). Avatars draw only when
+`--avatar` is on, `avatar_rows > 0`, `kitty::is_supported()`, and stdout is a
+terminal; any fetch or transmit failure falls back to the plain renderer
+(`src/main.rs:171-188`).
+
+## Dependencies and build
+
+`anstyle`, `chrono`, `clap` (derive), `color-eyre`, `devicons` (external `0.6`),
+sibling workspace crates `github-avatar`, `kitty`, `terminal-theme`,
+`strip-ansi-escapes`, and `tokio` (`rt`/`net`/`time`). `git2` is built with
+`default-features = false` + `vendored-libgit2`, dropping the https/ssh
+transports and compiling bundled libgit2 with `cc`, so no system libgit2 or cmake
+is needed (`Cargo.toml:11-29`).
+
+`tests/integration.rs` drives the built binary against temporary `git2` repos
+(ahead-of-main, on-main, detached, `diff` ranges); it is the passthru test target
+(`tests/integration.rs:1-7`, `default.nix`).

--- a/docs/dev-tools/indexbench/gate.md
+++ b/docs/dev-tools/indexbench/gate.md
@@ -1,0 +1,102 @@
+# indexbench regression gate
+
+The comparator (`src/compare.rs`) classifies each candidate metric against a
+baseline metric of the same name and decides whether it regressed. This is the
+mechanism behind the CLI's non-zero exit. See [overview.md](overview.md) for the
+schema, harnesses, and CLI; this page is the statistical model.
+
+## Baseline selection
+
+The default baseline is the previous run on the same machine, supplied by the
+store's `previous_run` (filtered to `machine_id`); `--baseline <commit>` pins a
+specific commit's run via `run_at_commit` instead
+(`src/main.rs:219-223`, `src/store.rs:53-87`). Metrics are matched by name. A
+candidate metric with no baseline counterpart is reported as `NoBaseline` (never
+a regression); a baseline-only metric is dropped, since a metric the bench
+stopped emitting is not a behavior regression (`src/compare.rs:167-186`). A
+bench's first-ever run uses `first_run`, which reports every metric as
+`NoBaseline` with its measured value intact so `--output-json` is not empty
+(`src/compare.rs:188-206`).
+
+## The three regimes (`regime_for`, `src/compare.rs:269-298`)
+
+The regime is chosen from the data, not the metric name:
+
+- **Deterministic** - the candidate or baseline has no `samples` (an allocation
+  count, a one-shot byte size). Exact compare: any worsening is a `Regression`,
+  any bettering an `Improvement`, regardless of magnitude. There is no noise to
+  absorb, which is exactly what makes deterministic metrics usable as flake
+  checks (`exact_verdict`, `src/compare.rs:336-355`).
+- **Distributional** - both sides have `samples`, each with at least
+  `MIN_SAMPLES = 8` values and non-zero spread. A two-sided Mann-Whitney U test
+  gives significance and a relative effect-size threshold gives materiality; a
+  metric regresses only when the change is both significant and beyond the
+  threshold (`src/compare.rs:231-241`).
+- **Thresholded** - `samples` are present but a side has fewer than `MIN_SAMPLES`
+  or zero spread (e.g. RSS that reports an identical peak every run). A rank test
+  on identical values is meaningless and an exact compare would trip on a
+  sub-threshold environmental wobble, so the effect-size threshold alone decides;
+  no p-value is reported (`src/compare.rs:242-248`).
+
+`has_spread` treats an all-equal sample set as having none
+(`src/compare.rs:300-308`).
+
+## Effect size and direction (`src/compare.rs:310-334`)
+
+`relative_change = (candidate - baseline) / baseline`, then sign-flipped for a
+higher-is-better metric so that negative always means improvement and one rule
+reads both directions. It is `None` when the baseline value is zero. `classify`
+turns an oriented change plus a "meaningful" flag into the verdict: not meaningful
+is `Unchanged`; meaningful and positive is `Regression`; meaningful and negative
+is `Improvement`. The default threshold is `DEFAULT_THRESHOLD = 0.02` (2%),
+overridable with `--threshold` (`src/compare.rs:51-56`).
+
+## The Mann-Whitney U test (`mann_whitney_u_pvalue`, `src/compare.rs:357-424`)
+
+The distributional significance test is a two-sided Mann-Whitney U via the normal
+approximation with a tie correction. Mann-Whitney is chosen over Welch's t
+because bench timings are routinely right-skewed (GC pauses, scheduler hiccups)
+and a rank test assumes no normality.
+
+- Pool both sample sets, assign average ranks (ties get the block's mean rank),
+  and sum group A's ranks.
+- Compute `U`, its mean, and a tie-corrected variance; if the variance is
+  non-positive (no spread once ties are removed), return `p = 1.0`.
+- Apply a 0.5 continuity correction toward the mean, form the z-score, and convert
+  to a two-sided p-value via the standard-normal CDF, itself built from an
+  Abramowitz and Stegun `erf` approximation (`src/compare.rs:426-455`).
+
+The approximation is accurate for the sample sizes a bench produces
+(`MIN_SAMPLES` and up), so an exact U distribution is unnecessary. Significance is
+`p < alpha`, default `DEFAULT_ALPHA = 0.05`, overridable with `--alpha`
+(`src/compare.rs:51-52`, `:237`).
+
+`DEFAULT_MACRO_RUNS = 10` is deliberately above `MIN_SAMPLES` so the built-in
+`wall_clock`/`max_rss` distributions reach the distributional regime by default;
+a compile-time assertion guards that floor (`src/compare.rs:35-49`).
+
+## Verdicts and the two gates
+
+`Verdict` is `Improvement`, `Regression`, `Unchanged`, or `NoBaseline`
+(`src/compare.rs:58-73`). A `Comparison` exposes two gate predicates
+(`src/compare.rs:128-147`):
+
+- `has_regression()` is true if any metric regressed. The `--gate all` mode (the
+  default, the perf job) uses it, so timing, RSS, and deterministic metrics all
+  count.
+- `has_deterministic_regression()` is true only if a `Deterministic`-regime
+  metric regressed. The `--gate deterministic` mode uses it so a sandbox-noisy
+  timing/RSS verdict cannot fail the build while a worsened allocation count
+  still does.
+
+The CLI ORs the selected predicate across every compared run and returns
+`ExitCode::FAILURE` when any regressed (`src/main.rs:225-267`).
+
+## Reporting (`src/report.rs`)
+
+`human_table` renders one row per metric: candidate value, baseline, percent
+delta (oriented so a minus sign is improvement), a significance marker, and the
+verdict label. The marker is `=` for deterministic (exact), `~` for thresholded,
+`***` for a significant distributional change (`p < alpha`), and blank for a
+not-significant distributional metric (`src/report.rs:32-59`). `--output-json`
+serializes the `Comparison` verbatim for CI or the planned viewer to consume.

--- a/docs/dev-tools/indexbench/overview.md
+++ b/docs/dev-tools/indexbench/overview.md
@@ -1,0 +1,169 @@
+# indexbench
+
+`packages/indexbench` is a metric-centric continuous-benchmarking framework for
+the index repo. The core abstraction is a `Metric` (a named number with a unit
+and a direction), not a time: wall-clock ns, peak RSS bytes, allocation counts,
+match rates, and custom values all flow through one schema, one history store,
+and one comparator (`src/lib.rs:1-26`). Three harnesses produce metrics, runs are
+appended to durable history, and the comparator classifies each metric against a
+baseline and exits non-zero on a regression so it can gate CI.
+
+The statistical regression model (the three regimes, the two gates, the
+Mann-Whitney test) is its own page: [gate.md](gate.md).
+
+- Crate: `indexbench`, with a library (`src/lib.rs`), the `indexbench` CLI
+  (`src/main.rs`), and the `indexbench-alloc-demo` example binary
+  (`src/bin/alloc-demo.rs`) (`Cargo.toml:11-24`).
+- Flake outputs: `nix run .#indexbench` (the bare CLI) and `nix run .#bench`
+  (the repo's self-demo perf job, an `apps.bench` entry,
+  `lib/per-system.nix:1108-1114`). Built by `ix.cargoUnit.selectBinaryWithTests`,
+  `mainProgram = "indexbench"` (`default.nix:3-5`).
+
+## Schema (`src/schema.rs`)
+
+- `Metric { name, value, unit, lower_is_better, samples: Option<Vec<f64>> }`.
+  `samples` present means a distributional metric (the comparator runs a
+  significance test); absent means deterministic (exact compare). `value` is the
+  headline number; for a distribution it is the median of `samples`, computed at
+  construction (`src/schema.rs:18-86`). The presence of `samples`, not the metric
+  name, picks the regime, so a new kind of measurement never touches the schema.
+- `Run { suite, bench, metrics, machine_id, git_commit, git_dirty,
+  timestamp_unix }` is one bench execution, the unit the store appends and the
+  comparator diffs (`src/schema.rs:88-119`). `(machine_id, git_commit,
+  timestamp_unix)` is the natural key.
+- `machine_id()` is a 16-hex-char SHA-256 of hostname plus the first
+  `/proc/cpuinfo` `model name` (hostname alone off Linux). It is stable per box
+  but differs across CPUs, so timing baselines never cross hardware
+  (`src/schema.rs:121-162`).
+
+Runs serialize to JSON/JSONL; deterministic metrics omit `samples` entirely
+(`#[serde(skip_serializing_if)]`). That JSON form is the contract.
+
+## Three metric sources
+
+- **Micro harness** (`src/micro.rs`) times a Rust closure in-process. `time_fn`
+  runs a warm-up then a batched sampling loop and returns a distributional
+  `wall_clock` (ns), one sample per measured round; the default `TimingConfig` is
+  `warmup_iters = 100, samples = 30, batch = 100` (`src/micro.rs:102-165`).
+  `bench_fn` adds a deterministic `allocations` count when the `CountingAllocator`
+  global shim is installed. `count_allocations` probes the shim with a single
+  `Box` and returns `None` (not a misleading `0`) when it is absent
+  (`src/micro.rs:80-100`, `:167-189`). This is a small sampler, not a second
+  copy of tango; tango stays the tool for paired A/B comparison of two builds in
+  one process.
+- **Macro harness** (`src/macro_harness.rs`) runs an external command N times.
+  It reads `wall_clock` (ns) in the parent and `max_rss` (bytes) from
+  `libc::wait4`'s per-child `rusage`. `wait4` is used directly rather than
+  `std::process` (which discards `rusage`) and rather than
+  `getrusage(RUSAGE_CHILDREN)` (which accumulates peak across all reaped
+  children); `ru_maxrss` is normalized to bytes per platform (KiB on Linux, bytes
+  on macOS) (`src/macro_harness.rs:117-249`). stdout and stderr are drained
+  concurrently before reaping to avoid a full-pipe deadlock
+  (`src/macro_harness.rs:151-168`). A non-zero exit or signal is a typed error
+  (`src/macro_harness.rs:251-279`).
+- **Custom metrics** are the extensibility hook. A benchmarked command prints
+  lines of the form `@bench name=<id> value=<f64> unit=<str>
+  lower_is_better=<bool>` to stdout or stderr; `unit` defaults to `count` and
+  `lower_is_better` to `true` (`src/macro_harness.rs:26-107`). A malformed
+  `@bench` line is a hard error, not a silent drop. The harness folds these into
+  the same `Run`, so a consumer reports match-rate, force-steps, or NAR bytes
+  without the framework knowing those metrics exist.
+
+Aggregation across N runs (`aggregate`/`fold_custom`,
+`src/macro_harness.rs:333-395`): `wall_clock` and `max_rss` become distributions
+(one sample per run). A custom metric reported in every run also becomes a
+distribution; one reported in only some runs stays deterministic (its last
+value), since a partial sample set would mislead the test. First-run metadata
+(unit, direction) wins.
+
+## History store (`src/store.rs`)
+
+`HistoryStore` is a small trait: `append` (durable before returning), `runs_for`
+(ascending by timestamp), and the derived `previous_run` and `run_at_commit`
+baseline lookups (`src/store.rs:31-88`). Two implementations:
+
+- **`GitBranchStore` (default)** commits one `history.jsonl` blob to an orphan
+  `bench-history` branch (`DEFAULT_BRANCH`) using pure git plumbing:
+  `hash-object -w` writes the blob, `mktree` builds the one-entry tree,
+  `commit-tree` makes the commit, and `update-ref` does a compare-and-swap
+  against the tip read at start, so a concurrent append fails loudly instead of
+  silently dropping a run (`src/store.rs:181-339`). The working tree and index
+  are never touched, so it works mid-bench from a dirty checkout; the orphan
+  branch shares no ancestry with `main`, so the growing JSONL never enters
+  `main`'s tree. A CI job can `git push origin bench-history` to share results.
+- **`LocalDirStore`** appends to `<dir>/history.jsonl` and `fsync`s, for laptop
+  iteration and tests where committing every run is noise (`src/store.rs:116-179`).
+
+A future object-store backend implements the same trait without touching the
+harnesses or the comparator.
+
+## CLI (`src/main.rs`)
+
+Subcommands: `run`, `assert`, `history`, `viewer` (`src/main.rs:55-66`). `main`
+maps any library error to `ExitCode::FAILURE` and prints it; the library never
+panics on operational failure (`src/main.rs:175-184`).
+
+- `run [--suite S] [--cmd CMD]... [--cmd-name N]... [--runs N] [--baseline SHA]
+  [--threshold F] [--alpha F] [--gate all|deterministic] [--output-json]`
+  executes a suite, records each run, and compares it to its baseline. The
+  baseline is read before the run is appended, so a run is never its own baseline;
+  the append happens before any reporting, so a later failure cannot lose the
+  measurement (`src/main.rs:198-268`). `--runs` defaults to `DEFAULT_MACRO_RUNS`
+  (10). Without `--cmd`, suite `self-demo` runs a built-in micro `fib` plus a
+  macro `true` (`src/main.rs:362-401`). Exits non-zero per `--gate` (see
+  [gate.md](gate.md)).
+- `assert --cmd CMD --max METRIC=VALUE... [--runs N]` runs a command and gates
+  each measured metric against a fixed budget, with no history. This is the
+  hermetic, reproducible `nix flake check` path: a self-comparing run could only
+  compare a binary against itself, so a fixed budget is what actually gates.
+  `--runs` defaults to 1 so a deterministic metric stays deterministic; a metric
+  over budget or never reported fails (`src/main.rs:140-155`, `:320-358`).
+- `history --suite S --bench B` lists recorded runs for a `(suite, bench)`
+  (`src/main.rs:404-427`).
+- `viewer` is a documented stub for a planned HTML time-series viewer
+  (`src/main.rs:437-443`).
+
+Store selection is shared global flags (`StoreArgs`, `src/main.rs:68-100`):
+`--store git|local` (default `git`), `--repo` (default `.`), `--branch` (default
+`bench-history`), `--local-dir` (default `.indexbench`).
+
+The runner (`src/run.rs`) ties it together: it resolves the git context
+(`commit`, `dirty`; `unknown`/clean outside a repo), runs micro benches then
+macro benches, stamps each `Run` with the machine id and timestamp, and returns
+them for the CLI to record and compare (`src/run.rs:21-94`). A failing macro
+bench aborts the whole invocation so a partial suite never records a misleading
+baseline. Errors are one `snafu` enum (`src/error.rs`).
+
+## Nix wiring (`lib/util/bench.nix`, `lib/per-system.nix`)
+
+`ix.mkBenchSuite pkgs { name; indexbench; macros ? []; allocCheck ? null; runs ?
+5 }` turns a suite description into two outputs (`lib/util/bench.nix:23-102`):
+
+- `app`: a `writeNushellApplication` wrapper `bench-<name>` that runs the macro
+  commands through `indexbench run --suite <name> --runs <runs> --cmd ...`,
+  forwarding extra args (e.g. `--store local`, `--baseline`). This is a perf job
+  (`apps.bench`), never a flake check, because timing and RSS are not
+  reproducible in the sandbox.
+- `check` (only when `allocCheck` is set): a `runCommand bench-<name>-alloc-check`
+  that runs the consumer's bench once through `indexbench assert --runs 1 --max
+  <metric>=<budget>`, the reproducible hermetic gate.
+
+The repo's own suite is `indexbenchSelfDemo` (`lib/per-system.nix:404-420`):
+`nix run .#bench` runs it as the perf job, and its `allocCheck` wires the
+`indexbench-alloc-demo` binary into the `indexbench-self-demo-alloc` flake check
+with `budgets.allocations = 64` (`lib/per-system.nix:958-963`). That binary
+installs the `CountingAllocator` and makes exactly 64 `Box::new` allocations
+(`EXPECTED_ALLOCATIONS`), so the count is a toolchain-stable constant and only an
+actual added allocation reddens the gate (`src/bin/alloc-demo.rs:1-53`).
+
+`nix develop .#bench` provides `indexbench` plus `hyperfine`, `valgrind`,
+`samply`, and `jemalloc` (`lib/per-system.nix:1127-1135`). `tango-bench` is a
+separate workspace dependency for paired A/B micro comparisons (see
+`packages/file-search/benches`).
+
+## Tests
+
+`tests/loop.rs` is the end-to-end proof of the loop (run, record to a
+`LocalDirStore`, a second run finds the first as baseline, report, and a
+deterministic regression is gated), driving the library surface rather than the
+CLI (`tests/loop.rs:1-13`). It is the passthru test target.

--- a/docs/dev-tools/ix-dev-diagnose/overview.md
+++ b/docs/dev-tools/ix-dev-diagnose/overview.md
@@ -1,0 +1,110 @@
+# ix-dev-diagnose
+
+`packages/ix-dev-diagnose` probes `https://ix.dev/` (or any HTTPS URL) from the
+caller's network path and writes a single JSON diagnostic capturing every layer
+of the request: system DNS answers, one TCP/TLS/HTTP probe per resolved address,
+the certificate chain with fingerprints and parsed issuers, verification results
+against both the OS trust store and the Mozilla root set, response headers, and a
+bounded base64 body sample (`README.md:1-21`). It exists to triage the case where
+`ix.dev` works on one network but fails with a browser error like
+`SEC_ERROR_UNKNOWN_ISSUER` on another: the JSON is shareable evidence.
+
+- Crate: `ix-dev-diagnose` (workspace member, MIT, `Cargo.toml:1-7`).
+- Flake output: `nix run .#ix-dev-diagnose`. Built by
+  `ix.cargoUnit.selectBinaryWithTests`, `mainProgram = "ix-dev-diagnose"`
+  (`default.nix:3-5`); `package.nix` sets `flake`, `inRustWorkspace`,
+  `passthruTests`.
+
+## CLI surface (`src/main.rs:35-72`)
+
+| arg | default | effect |
+| --- | --- | --- |
+| `URL` (positional) | `https://ix.dev/` | target; must be `https`, else it bails (`src/main.rs:359-362`). |
+| `--family <any\|ipv4\|ipv6>` | `any` | restrict probes to one address family. |
+| `--connect-timeout-ms <N>` | `5000` | per-address TCP connect timeout. |
+| `--read-timeout-ms <N>` | `5000` | per-address TLS/HTTP read+write timeout. |
+| `--max-body-bytes <N>` | `65536` (64 KiB) | response body bytes retained in the report. |
+| `--output <PATH>` | none | write the JSON report here. |
+| `--pretty` | off | pretty-print the JSON. |
+| `--json` | off | print the JSON report to stdout instead of the status summary. |
+
+Default output: `success` or `failure` (plus a `diagnoses:` line and the report
+path) on stdout, with the report written to `--output` or a default
+`ix-dev-diagnose-<host>-<unix-ms>.json` in the cwd (`src/main.rs:282-351`,
+`:316-322`). With `--json`, the JSON goes to stdout and a file is written only if
+`--output` was given.
+
+Exit code is not the signal: `main` returns `Ok` whether or not the host is
+reachable, so callers must read the printed `success`/`failure` or the JSON
+`summary.ok`, not `$?` (`src/main.rs:271-293`). A file write error is the only
+failure that changes the exit status.
+
+## Probe flow (`run`, `src/main.rs:353-407`)
+
+1. Install the rustls `ring` crypto provider; parse and validate the URL
+   (HTTPS-only), extract host, port (`port_or_known_default`, else 443), and
+   path+query.
+2. Build two trust stores: native via `rustls_native_certs::load_native_certs`
+   and Mozilla via `webpki_roots::TLS_SERVER_ROOTS`, each reported as a
+   `RootStoreReport { loaded, accepted, ignored, errors }`
+   (`src/main.rs:409-455`). A native store with zero parsable certs becomes
+   `None` (verification then reports `not_run`).
+3. Resolve `host:port` through the system resolver, filter by `--family`, dedup
+   and sort via a `BTreeSet` (`src/main.rs:463-481`).
+4. Run one probe per address: `TcpStream::connect_timeout`, then the TLS
+   handshake, then a single HTTP GET (`src/main.rs:483-537`).
+5. Summarize into diagnoses (below).
+
+## The recording verifier (`src/main.rs:1183-1238`)
+
+TLS uses a custom `ServerCertVerifier` installed through rustls'
+`dangerous().with_custom_certificate_verifier`. On `verify_server_cert` it runs
+the presented chain through both the native and Mozilla `WebPkiServerVerifier`s,
+records the peer certificate DERs and both `VerificationStatus`es
+(`passed`/`failed`/`not_run`), and then always returns
+`ServerCertVerified::assertion()` so the handshake completes regardless of trust
+outcome. That is the whole point: completing the handshake lets the tool capture
+the full chain and the per-store verdicts even when the certificate would
+normally be rejected. Signature verification (`verify_tls12/13_signature`,
+`supported_verify_schemes`) is delegated to the Mozilla verifier. ALPN is pinned
+to `http/1.1` (`src/main.rs:570-574`).
+
+## Report schema (`src/main.rs:81-244`)
+
+`Report { command, target, trust_roots, dns, probes[], summary }`:
+
+- `command`: tool name, `CARGO_PKG_VERSION`, start time in unix ms.
+- `target`: url, host, port, path_and_query.
+- `trust_roots`: the two `RootStoreReport`s.
+- `dns`: `resolver: "system"`, the resolved addresses, any error.
+- `probes[]`: per address, a tagged `tcp` (`connected`/`failed`), `tls`
+  (`completed`/`failed`, each with `certificate_verification` against both stores
+  and parsed `peer_certificates`), and `http`. Each `CertificateReport` carries a
+  SHA-256 fingerprint, subject, issuer, serial, validity window, and SANs
+  (DNS/IP/URI), parsed with `x509-parser` (`src/main.rs:992-1051`).
+- `http`: status code/reason, headers, header byte count, completeness flags, and
+  a body sample (length, SHA-256, base64) bounded by `--max-body-bytes`, plus a
+  96-byte hex prefix of the raw response (`src/main.rs:209-232`, `:33`).
+
+HTTP is hand-rolled: a `GET ... HTTP/1.1` with `Connection: close`, then framing
+detection that understands `Content-Length`, `Transfer-Encoding: chunked`, the
+bodyless `204`/`205`/`304` statuses, and close-delimited responses, plus `1xx`
+interim-header skipping (`src/main.rs:640-943`).
+
+## Diagnoses and the verdict (`summarize`, `src/main.rs:1053-1091`)
+
+The summary collects a sorted set of diagnosis strings:
+`dns_failed`, `dns_returned_no_addresses`,
+`tcp_connect_failed_for_all_addresses`, `tls_handshake_failed`,
+`certificate_verification_failed`, `certificate_unknown_issuer` (matched on the
+verifier error text), `unexpected_http_status` (a code outside `200..400`),
+`http_response_bytes_unavailable`, `http_response_incomplete`, and `reachable`.
+`summary.ok` is true only when the set is exactly `{ reachable }`, i.e. a probe
+connected, completed TLS, did not fail verification, and returned a `2xx`/`3xx`
+with a complete (or read-limit-truncated) body (`src/main.rs:1144-1162`).
+
+## Dependencies
+
+`anyhow`, `base64`, `clap` (derive), `rustls`, `rustls-native-certs`,
+`webpki-roots`, `x509-parser`, `serde`/`serde_json`, `sha2`, `url`
+(`Cargo.toml:12-23`). No async runtime: probes are synchronous blocking sockets.

--- a/docs/games/bossbar-overlay/engine.md
+++ b/docs/games/bossbar-overlay/engine.md
@@ -1,0 +1,126 @@
+# overlay engine (overlay-core)
+
+`packages/bossbar-overlay/app/crates/overlay-core` is the reusable engine behind
+every overlay in [bossbar-overlay](overview.md). It owns the mechanics every
+overlay shares and none of the domain: a transparent float window, one
+textured-quad wgpu pipeline with the Minecraft bitmap font baked in, gesture
+disambiguation, a native context menu, headless snapshotting, and shared
+animation primitives. A consumer builds a `Vec<Quad>` and hands it to `Gpu::draw`
+(live window) or `snapshot::render_to_png` (headless PNG) (`src/lib.rs:16`).
+
+## Modules (`src/lib.rs:21`)
+
+- **`window`** - float-window attributes and surface/adapter plumbing.
+- **`gpu`** - the textured-quad pipeline, texture registry, and text layout.
+- **`bitmap_font`** - the vanilla `ascii.png` face and its metrics.
+- **`gesture`** - press/drag/click and scroll-drag math.
+- **`menu`** - a native right-click context menu.
+- **`snapshot`** - headless render-to-PNG.
+- **`anim`** - easing curves, a hover stepper, a breathe oscillator.
+
+Re-exports: `HoverAnim`, `BitmapFont`, `DragClick`, `scroll_drag_delta`, `Gpu`,
+`Quad`, `TexHandle`, `SHADOW`, and the pinned `glam`/`wgpu`/`winit`
+(`src/lib.rs:29`), so consumers name the exact versions this workspace pins.
+
+## Float window (`window.rs`)
+
+`float_attributes` builds a transparent, borderless, non-resizable,
+`AlwaysOnTop` window sized in physical pixels (`window.rs:193`). The desktop stays
+click-through wherever no overlay window sits because there is simply no window
+there to intercept the pointer. Surface helpers pick an sRGB format
+(`window.rs:213`), a transparent alpha mode (PostMultiplied/PreMultiplied/Inherit,
+warning if only Opaque is available, `window.rs:224`), and a FIFO config
+(`window.rs:244`). `request_adapter_device` blocks once on first window
+(`window.rs:264`).
+
+macOS specifics (winit exposes no API for these, so they drop to AppKit through
+the raw window handle):
+
+- `build_event_loop` uses `ActivationPolicy::Accessory` so the HUD takes no Dock
+  slot or app-switcher entry (`window.rs:285`).
+- `raise_to_front` calls `-[NSWindow orderFrontRegardless]` to raise a hovered
+  overlay above same-level siblings without taking keyboard focus
+  (`window.rs:308`).
+- `enable_background_hover` adds an `NSTrackingArea` with `NSTrackingActiveAlways`
+  so a background overlay receives hover while another app is active
+  (`window.rs:349`).
+- `suppress_scroll_momentum` installs a local `NSEvent` monitor that drops
+  momentum-phase scroll events, so a two-finger scroll-drag stops on lift instead
+  of coasting (`window.rs:148`).
+- `move_window_with_cursor` warps the pointer with `CGWarpMouseCursorPosition`
+  anchored to the just-set position, so a fast scroll-drag keeps the pointer glued
+  to the window (`window.rs:28`).
+- `visible_frame_logical` returns the screen area minus menu bar/Dock for
+  auto-placement (`window.rs:409`).
+
+Off macOS these are no-ops or defer to the compositor (X11/Wayland deliver hover
+and need no non-activating raise). On wlroots Wayland the boss bar uses a separate
+layer-shell backend instead of toplevel windows; see
+`crates/bossbar/src/layer_shell.rs:1` in [overview](overview.md).
+
+## wgpu pipeline (`gpu.rs`)
+
+One `RenderPipeline` draws textured quads with alpha blending (`gpu.rs:161`).
+Vertices arrive in physical pixels with a top-left origin; the vertex stage
+(`src/sprite.wgsl`) converts to clip space using the framebuffer size, so all
+layout math stays in pixel units on the CPU, matching how Minecraft blits GUI
+sprites (`gpu.rs:3`). The sampler is `Nearest` to keep pixel art crisp when
+scaled (`gpu.rs:206`).
+
+- `Quad` (`gpu.rs:48`) is `{tex, x, y, w, h, uv, color}` in physical pixels;
+  `uv` is `(u0,v0,u1,v1)` and passing `u0>u1` mirrors horizontally (used for the
+  book's right page). `color` is a straight-alpha RGBA tint multiplied into the
+  texel, so the 1x1 white texture turns the tint into a flat fill (`gpu.white`,
+  `gpu.rs:271`).
+- `Gpu::new` registers the white pixel and the embedded font sheet up front
+  (`gpu.rs:113`). `register_png`/`register_rgba`/`register_image_scaled` add
+  textures and return a `TexHandle` (`gpu.rs:276`); `register_image_scaled` is
+  fallible and downscales to a max side, for untrusted-ish images like avatars
+  (`gpu.rs:294`).
+- `text`/`text_shadow` emit one glyph quad per character through the same
+  pipeline, so titles and page text are just more sprites; `text_shadow` draws a
+  one-pixel grey `SHADOW` offset first (`gpu.rs:324`, `gpu.rs:339`). `measure`
+  sizes text without drawing (`gpu.rs:354`).
+- `draw` expands quads to 6 vertices each, clears the target to
+  `Color::TRANSPARENT` so the desktop shows through, and draws in submission
+  order so later quads layer over earlier ones (`gpu.rs:360`).
+
+## Bitmap font (`bitmap_font.rs`)
+
+The whole text stack: no TTF, no shaper. `ascii.png` is a 128x128 sheet of 8x8
+glyph cells indexed by code value, white-on-transparent so the per-vertex color
+tints glyphs directly (`bitmap_font.rs:1`). `BitmapFont::from_ascii_rgba`
+measures each glyph's inked width as the rightmost inked column + 1, the same
+measurement the vanilla client makes; the space glyph's advance is pinned to 4
+since it has no ink (`bitmap_font.rs:58`). `shared()` decodes the embedded
+`ASCII_PNG` once via `LazyLock` so window-sizing can measure before any GPU
+exists, and the live `Gpu` shares the same metrics (`bitmap_font.rs:24`). The
+sheet is `include_bytes!`-d from `assets/ascii.png`, supplied by
+[minecraft-assets](../minecraft-assets/overview.md).
+
+## Gestures (`gesture.rs`)
+
+`DragClick` watches the cursor and left-button events to disambiguate a press
+into a drag or a click: a press defers the decision, `cursor_moved` returns
+`true` exactly once when travel crosses the threshold (hand off to
+`Window::drag_window`), and `released` returns `true` only if the pointer never
+crossed it (a click) (`gesture.rs:47`). `scroll_drag_delta` converts a winit
+scroll delta into a logical-point translation; the sign is negated so the window
+follows the gesture (grab-and-move), inheriting the user's scroll-direction
+preference (`gesture.rs:39`). Trackpad `PixelDelta` is divided by the scale
+factor; a notched wheel `LineDelta` steps by `LINE_POINTS=16` (`gesture.rs:21`).
+
+## Menu, snapshot, animation
+
+- **`menu::popup`** builds an `NSMenu`, attaches a tiny `NSObject` target, and
+  pops it up at the pointer, blocking until the user picks or dismisses; returns
+  the chosen index. A no-op returning `None` off macOS (`menu.rs:17`).
+- **`snapshot::render_to_png`** runs the same `Gpu` against an offscreen texture
+  and reads it back (handling wgpu's 256-byte row alignment) into a transparent
+  PNG, so an always-on-top transparent window is verifiable pixel-for-pixel from
+  a file (`snapshot.rs:15`). This backs every app's `--snapshot` flag.
+- **`anim`** holds `ease_out_cubic`/`ease_out_back` (`anim.rs:17`), `breathe`
+  (a sine oscillator off a continuous clock, `anim.rs:35`), `HoverAnim` (a
+  `0..=1` hover amount eased toward a target each frame, `anim.rs:47`), and
+  `scale_quads_about` (scale a laid-out group in place for the hover grow,
+  `anim.rs:89`). Durations and rationale live in the repo `animation` skill.

--- a/docs/games/bossbar-overlay/overview.md
+++ b/docs/games/bossbar-overlay/overview.md
@@ -1,0 +1,154 @@
+# bossbar-overlay
+
+`packages/bossbar-overlay` is three transparent, always-on-top, click-through
+desktop overlays drawn in the Minecraft style with `wgpu`: a boss bar HUD
+(`bossbar`), an open book (`book`), and a floating experience orb (`orb`). Each is
+driven entirely by a single SQLite file: write rows from anything and the change
+appears within ~200ms. They share one engine, `overlay-core`, documented
+separately in [engine.md](engine.md). This page covers the package layout, the
+three apps, their data contracts, the CLI, and how it all builds.
+
+The apps are a separate Cargo workspace under `app/` (root `Cargo.toml:10`), off
+the repo's main graph so winit/wgpu deps and lints stay isolated (`Cargo.toml:1`).
+All Mojang art comes from [minecraft-assets](../minecraft-assets/overview.md);
+nothing is vendored.
+
+## Units and flake outputs
+
+| path | unit | output |
+| --- | --- | --- |
+| `app/crates/overlay-core` | shared engine (lib) | internal; see [engine.md](engine.md) |
+| `app/crates/bossbar` | boss bar overlay bin | `.#bossbar-overlay` (main program) |
+| `app/crates/book` | book overlay bin | `.#book-overlay` |
+| `app/crates/orb` | XP-orb overlay bin | `.#xp-orb-overlay` |
+| `bossbar` (shell script) | boss bar DB CLI | `.#bossbar` |
+
+`app/default.nix` builds all three binaries from one `Cargo.lock` as the
+`minecraft-overlays` derivation (`app/default.nix:44`), `mainProgram =
+bossbar-overlay` (`app/default.nix:100`). `.#book-overlay`
+(`book-overlay/book.nix`) and `.#xp-orb-overlay` (`xp-orb-overlay/orb.nix`) are
+trivial symlink derivations that re-expose the already-built binaries with a
+different main program, so there is no second wgpu/winit compile
+(`book-overlay/book.nix:6`). The top-level `.#bossbar`
+(`package.nix:2`, `cli.nix`) is a separate shell-script wrapper, not the overlay.
+
+Run:
+
+```sh
+nix run .#bossbar-overlay     # boss bar HUD across the top of the screen
+nix run .#book-overlay        # floating open book
+nix run .#xp-orb-overlay      # floating experience orb
+nix run .#xp-orb-overlay -- feed   # full-screen "rise & pop" karma feed
+```
+
+Platforms: `aarch64`/`x86_64` darwin and linux (`app/default.nix:101`). On Linux,
+`app/default.nix` patchelfs and wraps each binary with the X11/Wayland/Vulkan
+runtime libraries it dlopens (`app/default.nix:86`).
+
+## Common app shape
+
+Every app is a winit + wgpu loop (no webview) following the same pattern:
+`main.rs` parses args and env, resolves the DB path, then either runs a headless
+`--snapshot OUT` to a transparent PNG and exits, or runs the live overlay
+(`crates/bossbar/src/main.rs:89`). Scale is set by an env var or `--scale`
+(`BOSSBAR_SCALE` / `BOOK_SCALE` / `ORB_SCALE`). Each app has `assets.rs`
+(embedded Mojang PNGs via `include_bytes!`), `db.rs` (the SQLite source +
+watcher), `scene.rs` (build a `Vec<Quad>`), and `overlay.rs` (the winit
+`ApplicationHandler`); the boss bar also has `layer_shell.rs` for Wayland and
+`theme.rs` for user textures.
+
+The SQLite contract is identical across apps (`crates/bossbar/src/db.rs:1`): open
+in WAL mode, create the schema if missing, run additive `ALTER TABLE` migrations,
+seed example rows only when the file is newly created, and poll `PRAGMA
+data_version` every 200ms (`POLL`, `db.rs:20`) to detect any other connection's
+commit. Dragged positions persist to `x`/`y` via a separate write connection
+(`db.rs:120`).
+
+## boss bar (`bossbar`)
+
+Each bar is its own small float window sized to that bar, so only the bars
+intercept the mouse. Bars render from Mojang's actual boss bar sprites layered
+the way the game's `BossHealthOverlay` does (color background, color progress
+clipped to the fill, then the notch overlay). Hover eases to opaque with a
+breathing pulse; a press past a few pixels starts a native window drag (saved to
+`x`/`y`); a stationary click opens the bar's `url`; a `description` unfolds a
+panel; a `since` shows a live elapsed timer in the title.
+
+Typed domain in `crates/bossbar/src/bars.rs`: `Color` (7 variants,
+`bars.rs:10`), `Overlay`/`Notch` (smooth or `notched_6/10/12/20`, `bars.rs:54`),
+and `BossBar` (`bars.rs:97`). Unknown color/overlay strings fall back to
+`purple`/smooth so a typo still draws a bar (`bars.rs:23`).
+
+Data contract (`bossbars` table, `crates/bossbar/src/db.rs:22`): `id, title,
+description, progress (0..1), color, overlay, visible, position, x, y, since
+(epoch), url, expandable, eta, icon, theme`. Notes:
+- `since`+`eta` together make the fill extrapolate live as `(now-since)/eta`,
+  ignoring the static `progress` (`bars.rs:113`).
+- `expandable=0` keeps a `description`-carrying bar bar-sized on hover, for many
+  compact bars (`bars.rs:120`).
+- `icon` is a path to a small image drawn left of the title (e.g. a PR author's
+  avatar); a missing/undecodable path is skipped (`bars.rs:135`).
+- `theme` names a user-supplied texture set; see below.
+
+DB path: `$BOSSBAR_DB`, else `<data-dir>/bossbar-overlay/bossbars.db`
+(`db.rs:70`). Snapshot: `--snapshot out.png [--scale N] [--size WxH]`.
+
+### Themed textures (`theme.rs`)
+
+A non-empty `theme` renders a bar from a user-supplied directory under the themes
+root (`$BOSSBAR_THEMES`, else `themes/` next to the DB, `theme.rs:68`). Required
+`background.png`/`progress.png`, optional per-notch overrides; any PNG size is
+drawn into the bar's 182:5 box (`theme.rs:139`). Theme names are validated as a
+single safe path component, so `../escape` is just an unknown theme that draws
+vanilla (`theme.rs:85`). Sprites are downscaled to <=2048px and memoized
+(`theme.rs:113`). This repo ships no themed art; import your own with
+`app/scripts/import-theme.sh`.
+
+### bossbar CLI (`.#bossbar`)
+
+`bossbar` is a hand-written shell script wrapped with `sqlite3` + coreutils on
+PATH (`cli.nix:8`). It writes the same DB the overlay reads, works whether or not
+the overlay is running, and creates the schema on demand:
+
+```sh
+bossbar add "Ender Dragon" --color pink --overlay notched_20 --progress 0.8
+bossbar set "Ender Dragon" --progress 0.5     # by title ...
+bossbar set 1 --color red --visible 1         # ... or by id
+bossbar list ; bossbar rm "Ender Dragon" ; bossbar db
+```
+
+The `services.ciBars` home module
+(`packages/bossbar-overlay/ci-bars-home-module.nix`) drives this DB to draw one
+bar per in-flight GitHub Actions run.
+
+## book (`book`)
+
+One floating window shows an open book as a two-page spread (Mojang's one-page
+texture drawn twice, mirrored on the left). Page-turn arrows advance, drag/scroll
+moves it (position saved), hover raises it. Schema (`crates/book/src/db.rs:19`):
+a singleton `book` row (`id=1`, `title`, `x`, `y`) and a `pages` table (`id`,
+`idx` order, `body` with newlines as paragraph breaks). Current page is in-memory
+state; only position persists. DB: `$BOOK_DB`, else
+`<data-dir>/book-overlay/book.db` (`db.rs:42`). Turning a page plays a vanilla
+flip sound by shelling out to `minecraft-sound` (`crates/book/src/sound.rs:32`,
+override `BOOK_SOUND_CMD`).
+
+## orb (`orb`)
+
+A floating experience orb that bobs and shimmers; its XP `amount` picks the orb
+size. Two modes (`crates/orb/src/main.rs:10`): the default pinned single-orb
+overlay, and `feed`, a full-screen "rise & pop" karma feed. `push TEXT [--amount
+N] [--kind orb|villager]` queues one labelled pop and exits. Schema
+(`crates/orb/src/db.rs:20`): singleton `orb` row (`id=1`, `amount`, `url`, `x`,
+`y`) and an append-only `events` table (`text`, `amount`, `kind`, `created`) the
+feed consumes. DB: `$ORB_DB`, else `<data-dir>/xp-orb-overlay/orb.db`
+(`db.rs:42`). A success pop plays the orb-pickup sound, a failure (villager) pop
+plays a cycled villager "no" grunt, again via `minecraft-sound`
+(`crates/orb/src/sound.rs:22`, override `ORB_SOUND_CMD`).
+
+## Limits
+
+No tray icon; quit like any foreground process. Click-through is structural (no
+window where no overlay sits), not `set_cursor_hittest`, so some Wayland tiling
+compositors may still fight free placement (`README.md:218`). The boss bar covers
+the primary monitor only; the book opens centered there.

--- a/docs/games/common.md
+++ b/docs/games/common.md
@@ -1,0 +1,122 @@
+# games
+
+Minecraft data/server tooling and Minecraft-styled desktop overlays. This domain
+holds the buildable artifacts under `packages/`: small command-line tools that
+read and write Minecraft data formats, fetch and play Mojang assets, reconcile a
+running server's mutable files, probe a server over the wire, a from-scratch
+Minestom server jar, and a reusable transparent-overlay engine plus three
+SQLite-driven desktop HUDs drawn in the Minecraft style. These are the leaf
+tools; the Nix library helpers that wrap them (`lib/minecraft/**`), the NixOS
+service modules that run servers (`modules/services/{minecraft,minecraft-bedrock,minestom}`),
+and the runnable server images (`images/games/**`) live in other domains and are
+cross-referenced here, not documented here.
+
+Read this page first, then the component pages it links.
+
+## Units
+
+| unit | kind | flake output | what |
+| --- | --- | --- | --- |
+| `packages/minecraft/nbt` (`minecraft-nbt`) | Rust bin (workspace member) | `.#minecraft-nbt` | JSON -> binary NBT / SNBT encoder. See [minecraft](minecraft/overview.md). |
+| `packages/minecraft/sound` (`minecraft-sound`) | Rust bin (workspace member) | `.#minecraft-sound` | local Minecraft sound-effect player + bundled Mojang pack. |
+| `packages/minecraft/sync-managed` (`minecraft-sync-managed`) | Rust bin (workspace member) | `.#minecraft-sync-managed` | reconcile ix-managed files into a live server data dir. |
+| `packages/minecraft/probe` (`mc-probe`) | Python (uv) | `.#mc-probe` | exit-code Server-List-Ping health probe. |
+| `packages/minecraft/rcon` (`minecraft-rcon`) | Python script | overlay only (`pkgs.minecraft-rcon`) | minimal RCON client. |
+| `packages/minecraft/hot-reload-agent` | Java agent (jar) | overlay only (`pkgs.minecraft-hot-reload-agent`) | dev JVM agent: redefine plugin classes over a Unix socket. |
+| `packages/minecraft-assets` | Nix-only FOD | `.#minecraft-assets` | extract GUI textures + bitmap font from Mojang's client jar. See [minecraft-assets](minecraft-assets/overview.md). |
+| `packages/minestom/servers/hello` | Gradle fat jar (Java) | `.#minestom-hello-server-jar` | example Minestom server. See [minestom](minestom/overview.md). |
+| `packages/bossbar-overlay/app/crates/overlay-core` | Rust lib (own workspace) | (internal) | reusable float-window + wgpu pixel/text engine. See [bossbar-overlay engine](bossbar-overlay/engine.md). |
+| `packages/bossbar-overlay/app/crates/{bossbar,book,orb}` | Rust bins (own workspace) | `.#bossbar-overlay` / `.#book-overlay` / `.#xp-orb-overlay` | the three desktop overlays. See [bossbar-overlay](bossbar-overlay/overview.md). |
+| `packages/bossbar-overlay/bossbar` | shell script + Nix wrapper | `.#bossbar` | CLI over the boss bar SQLite DB. |
+
+Rust crates `minecraft-nbt`/`minecraft-sound`/`minecraft-sync-managed` are members
+of the repo's top-level Cargo workspace. The overlay crates are a separate,
+self-contained Cargo workspace under `packages/bossbar-overlay/app` (root
+`Cargo.toml:10`), kept off the main graph so winit/wgpu deps and lints do not
+touch the rest of the repo.
+
+## How it fits together
+
+Two loosely coupled clusters share one domain:
+
+```
+SERVER TOOLING                                  DESKTOP OVERLAYS
+  lib/minecraft/nbt.nix (__minecraftNbt JSON)     minecraft-assets (Mojang client.jar)
+      -> minecraft-nbt --format nbt|snbt              -> font + sprites baked into
+  modules/services/minecraft                              overlay-core / bossbar / book / orb
+      -> minecraft-sync-managed (reconcile)         bossbar / book / orb  <--driven by-- SQLite file
+      -> minecraft-hot-reload-agent (dev)               -> book/orb shell out to minecraft-sound
+  mc-probe / minecraft-rcon  --over the wire-->         bossbar CLI ----writes----> bossbars.db
+  minestom-hello-server-jar  (services.minestom)
+```
+
+- **NBT pipeline.** `lib/minecraft/nbt.nix` (lib domain) emits a JSON tree of
+  `{"__minecraftNbt": <tag>, "value": ...}` wrappers; `minecraft-nbt` decodes
+  exactly that wrapper format and writes binary NBT or SNBT. `lib/minecraft/nbt-format.nix:22`
+  runs the binary as a `pkgs.formats`-style generator.
+- **Managed-server reconcile.** `minecraft-sync-managed` is invoked (with a long
+  flag list) by `lib/minecraft/sync-managed.nix:53`, which the
+  `services.minecraft` module wires into the server's start sequence.
+- **Asset provenance.** `minecraft-assets` is a fixed-output derivation that
+  fetches Mojang's `client.jar` (pinned by Mojang's own hash) and unzips the
+  exact texture and font paths the overlays embed. `packages/bossbar-overlay/app/default.nix:73`
+  copies those slices into each crate's `assets/` before compiling, so no Mojang
+  art is committed to the repo.
+- **Sound bridge.** The book and orb overlays play cues by shelling out to the
+  `minecraft-sound` binary (`crates/book/src/sound.rs:27`, `crates/orb/src/sound.rs:32`),
+  overridable via `BOOK_SOUND_CMD` / `ORB_SOUND_CMD`. No audio backend is linked
+  into the overlays.
+- **One SQLite file per overlay.** Each overlay reads exactly one SQLite DB and
+  re-reads it within ~200ms of any external write. Anything (a shell, the
+  `bossbar` CLI, a cron job, the `services.ciBars` module) can write rows.
+
+## Invariants
+
+- **Untrusted input falls back, never crashes.** NBT decoding rejects bad input
+  with typed errors (`packages/minecraft/nbt/src/lib.rs:21`); a fuzz target
+  asserts the decoder never panics (`nbt/tests/property.rs:42`). Overlay row
+  parsing defaults an unknown color/overlay to `purple`/smooth rather than
+  drawing nothing (`crates/bossbar/src/bars.rs:23`). A bad sound name errors
+  loudly with suggestions (`crates/.../sound assets`), and a theme name that
+  escapes its directory is treated as an unknown theme (`crates/bossbar/src/theme.rs:85`).
+- **Mojang art is fetched, not vendored.** Both `minecraft-assets` and the
+  `minecraft-sound` pack are fixed-output derivations that download from Mojang
+  at build time; the sound pack carries a DO-NOT-UPLOAD banner
+  (`packages/minecraft/sound/sounds.nix:3`) and must stay out of shared caches.
+- **SQLite change detection uses `PRAGMA data_version`.** Overlays poll it every
+  200ms (`crates/bossbar/src/db.rs:20`); it bumps on any other connection's
+  commit, so WAL writes are never missed the way file-mtime watching can be.
+- **Overlay placement is OS-specific.** macOS uses winit plus raw AppKit
+  (non-activating raise, background hover, context menu); wlroots Wayland uses a
+  layer-shell backend (`crates/bossbar/src/layer_shell.rs:1`). Click-through is
+  structural: there is simply no window where no overlay sits.
+
+## Glossary
+
+- **NBT**: Named Binary Tag, Minecraft's binary tree format. **SNBT** is its
+  stringified form.
+- **`__minecraftNbt` wrapper**: the JSON convention (`{"__minecraftNbt": tag,
+  "value": v}`) that `minecraft-nbt` decodes; produced by `lib/minecraft/nbt.nix`.
+- **managed-* tree**: ix-owned input directories (`managed-dropins`,
+  `managed-config`, `managed-server-files`, `managed-datapacks`, `managed-access`)
+  that `minecraft-sync-managed` symlinks/reconciles into a server's mutable data
+  dir, tracked by `.ix-managed-*` manifests.
+- **SLP**: Server List Ping, the handshake `mc-probe` asserts against.
+- **Minestom**: a from-scratch Java server library (not a Mojang server fork);
+  no loaders, mods, or EULA.
+- **overlay-core**: the shared engine (float window + one textured-quad wgpu
+  pipeline + bitmap font) every desktop overlay builds on.
+- **quad**: one textured rectangle in physical pixels; the overlays' only draw
+  primitive, including each glyph of text.
+- **float window**: a transparent, borderless, always-on-top, click-through,
+  drag-to-move overlay window with no Dock presence.
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| minecraft tools | [minecraft/overview.md](minecraft/overview.md) | nbt, sound, sync-managed, probe, rcon, hot-reload-agent |
+| minecraft-assets | [minecraft-assets/overview.md](minecraft-assets/overview.md) | reproducible Mojang texture + font extraction |
+| minestom | [minestom/overview.md](minestom/overview.md) | example Minestom server fat jar |
+| bossbar-overlay | [bossbar-overlay/overview.md](bossbar-overlay/overview.md) | the three SQLite-driven desktop overlays + CLI |
+| overlay engine | [bossbar-overlay/engine.md](bossbar-overlay/engine.md) | `overlay-core` float window + wgpu pixel/text engine |

--- a/docs/games/minecraft-assets/overview.md
+++ b/docs/games/minecraft-assets/overview.md
@@ -1,0 +1,65 @@
+# minecraft-assets
+
+`packages/minecraft-assets` is a Nix-only package (no Rust, no source code of its
+own) that produces authentic Minecraft GUI textures and the vanilla bitmap font
+by extracting them straight from Mojang's official `client.jar`. It exists so the
+[desktop overlays](../bossbar-overlay/overview.md) render real Mojang art without
+vendoring any copyrighted asset into this repo or trusting a third-party mirror.
+
+- **Flake output:** `nix build .#minecraft-assets`. Also exposed in the package
+  overlay (`pkgs.minecraft-assets`) so overlay derivations can `callPackage` it
+  (`package.nix:6`).
+- **Build kind:** a fixed-output derivation (`stdenvNoCC.mkDerivation`,
+  `default.nix:37`), `platforms = all` (`default.nix:103`).
+
+## What it extracts
+
+The build unzips a pinned `client.jar` with `unzip -j` (flattening archive paths)
+into a flat output layout (`default.nix:49`):
+
+- `boss_bar/` - every PNG under `assets/minecraft/textures/gui/sprites/boss_bar/`
+  (the color/progress/notch sprites the boss bar overlay layers).
+- `gui/` - `book.png` plus the page-forward/backward and button widget sprites
+  (`default.nix:65`), for the book overlay.
+- `entity/experience_orb.png` - the 4x4 grid of 16x16 XP-orb icons, for the orb
+  overlay (`default.nix:58`).
+- `particle/angry.png` - the angry-villager puff (8x8), for the orb feed's
+  failure pop (`default.nix:63`).
+- `font/` - `ascii.png` (the basic-Latin face the overlays render with) plus
+  `accented.png` and `nonlatin_european.png` for future coverage (`default.nix:79`).
+
+Each `unzip` group fails the build if a path stops existing in a future jar, so a
+silently missing sprite cannot slip through as an empty asset directory
+(`default.nix:46`).
+
+## Provenance and pinning
+
+The DAG is `version_manifest_v2 -> <version>.json -> client.jar -> extraction`
+(`default.nix:8`). Only the leaves that matter are pinned:
+
+- `version = "1.21"` (`default.nix:28`).
+- `client.jar` is fetched with `fetchurl` from a Mojang object URL whose path is
+  Mojang's own SHA-1, with the matching Nix `sha256` hash (`default.nix:30`), so
+  the fetch is reproducible and never trusts a mirror.
+
+The refresh recipe (resolve a new `client.jar` from the manifest and read back
+the hash) is documented inline at `default.nix:18`. Mojang's art is fetched at
+build time and is not redistributed by this repository; the packaging itself is
+MIT (`default.nix:102`).
+
+## How consumers use it
+
+The overlay build (`packages/bossbar-overlay/app/default.nix:73`) copies the
+slices into each crate's `assets/` directory before compiling, where
+`include_bytes!` bakes them into the binaries: `font/ascii.png` into
+`overlay-core`, the boss bar sprites into `bossbar`, the gui sprites into `book`,
+and the entity/particle sprites into `orb`. For local Rust development,
+`packages/bossbar-overlay/app/scripts/fetch-assets.sh` nix-builds this package
+and copies the same slices into the gitignored `assets/` trees. See the
+[overlay engine](../bossbar-overlay/engine.md) for how the font sheet is measured
+and rendered.
+
+Note: this package extracts the GUI/font art for overlays; the separate Mojang
+sound pack the overlays play through `minecraft-sound` is a different
+fixed-output derivation (`packages/minecraft/sound/sounds.nix`, see
+[minecraft tools](../minecraft/overview.md)).

--- a/docs/games/minecraft/overview.md
+++ b/docs/games/minecraft/overview.md
@@ -1,0 +1,160 @@
+# minecraft tools
+
+`packages/minecraft` is a directory of small, single-purpose Minecraft tools in
+three languages. Three are Rust binaries and members of the repo's top-level
+Cargo workspace; the rest are a Python uv app, a Python script, and a Java agent.
+None of them run a server: they encode data, play sounds, reconcile files, probe
+a server, or hot-reload plugin classes. The NixOS modules and images that consume
+them are cross-referenced, not documented here (see [common](../common.md)).
+
+| member | lang | entry | flake output |
+| --- | --- | --- | --- |
+| `nbt` (`minecraft-nbt`) | Rust | `nbt/src/main.rs` | `.#minecraft-nbt` |
+| `sound` (`minecraft-sound`) | Rust | `sound/src/main.rs` | `.#minecraft-sound` |
+| `sync-managed` (`minecraft-sync-managed`) | Rust | `sync-managed/src/main.rs` | `.#minecraft-sync-managed` |
+| `probe` (`mc-probe`) | Python (uv) | `probe/src/mc_probe/__init__.py` | `.#mc-probe` |
+| `rcon` (`minecraft-rcon`) | Python | `rcon/minecraft-rcon.py` | overlay only |
+| `hot-reload-agent` | Java | `hot-reload-agent/src/dev/ix/minecraft/hotreload/HotReloadAgent.java` | overlay only |
+
+## minecraft-nbt: JSON -> NBT/SNBT
+
+Encodes a JSON description of an NBT document into Mojang binary NBT or
+stringified NBT (SNBT). It is a pure encoder: there is no decode-from-binary
+path.
+
+- **Library surface** (`nbt/src/lib.rs`): `pub fn decode_document(value: &Value,
+  default_root_name: &str) -> Result<Document>` (`lib.rs:21`) and `pub struct
+  Document { root_name, compound }` (`lib.rs:9`). Constants `TAG_KEY =
+  "__minecraftNbt"` and `VALUE_KEY = "value"` (`lib.rs:5`) define the wrapper
+  convention.
+- **Input format.** A value is either an implicit type (JSON object -> compound,
+  array -> homogeneous list, string -> string, bool -> byte, integer -> int or
+  long by range, float -> double) or an explicit `{"__minecraftNbt": <tag>,
+  "value": v}` wrapper. Tags: `byte short int long float double string byteArray
+  intArray longArray list compound` plus the document-only `root` wrapper that
+  also carries a `name` (`lib.rs:22`, `lib.rs:64`). The matching producer is
+  `lib/minecraft/nbt.nix` (lib domain).
+- **Validation invariants.** Integer tags are range-checked
+  (`-128..=127` for byte, etc., `lib.rs:248`); floats must be finite and within
+  32-bit range for `float` (`lib.rs:239`); lists must be homogeneous
+  (`lib.rs:155`); the document root must be a compound (`lib.rs:36`); `null` has
+  no NBT tag (`lib.rs:60`).
+- **CLI** (`nbt/src/main.rs:16`): `--format nbt|snbt` (required), `--flavor
+  uncompressed|gzip|zlib` (default uncompressed; binary only), `--root-name`
+  (default empty), `--input <json>`, `--output <file>`. Binary uses
+  `quartz_nbt::io::write_nbt`; SNBT uses `to_pretty_snbt` (`main.rs:77`,
+  `main.rs:87`).
+- **Tests.** Unit tests cover explicit tags and rejections (`lib.rs:308`).
+  Hegel property tests assert the decoder never panics on arbitrary JSON and that
+  byte round-trips match the range check (`nbt/tests/property.rs:42`). A
+  `cargo-fuzz` target lives at `nbt/fuzz/fuzz_targets/decode_document.rs` and is
+  run by `.github/workflows/fuzz-nbt.yml`.
+- **Build/wiring.** `nbt/default.nix` builds via
+  `ix.cargoUnit.selectBinaryWithTests`. `lib/minecraft/nbt-format.nix:22` builds
+  the tool with `buildIxRustTool` and exposes a `pkgs.formats`-style `generate`
+  that shells out to `minecraft-nbt` (lib domain cross-ref).
+
+## minecraft-sound: local sound-effect player
+
+Plays a Minecraft sound `.ogg` by name (e.g. `mob/zombie/death`) on the default
+audio device, via `rodio`.
+
+- **CLI** (`sound/src/main.rs:25`): `list [PATTERN]` and `play <SOUND> [--wait]
+  [--pitch P] [--volume V]`. An empty/omitted name is a silent no-op (so a hook
+  can disable an event with `""`); a non-empty unknown name is a loud error
+  (`main.rs:113`). Without `--wait`, it re-spawns itself detached in
+  `--foreground --wait` mode so the caller returns immediately, but resolves the
+  name first so a typo fails before spawning (`main.rs:122`).
+- **Asset resolution** (`sound/src/assets.rs:84`): `MinecraftAssets::Bundled`
+  reads a flat `<name>.ogg` tree from `$MCSOUND_ASSETS`; `MinecraftAssets::Install`
+  auto-detects a Minecraft install (`$MINECRAFT_HOME`, else the per-OS default,
+  `assets.rs:319`) and maps names through the highest-versioned
+  `assets/indexes/<n>.json` to hashed objects. An unknown name yields
+  `UnknownSound` with up to three Levenshtein-close suggestions (`assets.rs:238`).
+- **Playback** (`sound/src/audio.rs:72`): pitch is Minecraft-style (speed + pitch
+  together, no resampling) clamped to `[0.5, 2.0]` (`audio.rs:10`); volume is a
+  non-negative linear multiplier.
+- **Build/wiring.** `sound/default.nix` wraps the binary and bakes the Nix sound
+  pack in with `--set-default MCSOUND_ASSETS` (`sound/default.nix:29`), so it
+  plays with zero config and no Minecraft install. The pack itself is
+  `sound/sounds.nix`: a fixed-output derivation that downloads sounds from
+  Mojang's CDN, pinned by `sound/sounds/lock.json` (Minecraft `26.1.2`, asset
+  index `30`), excluding `music`/`records`. That store path contains Mojang
+  content and MUST NOT be pushed to a shared cache (`sounds.nix:3`). This binary
+  is what the [book and orb overlays](../bossbar-overlay/overview.md) shell out
+  to for sound cues.
+
+## minecraft-sync-managed: reconcile managed files
+
+Reconciles ix-owned input trees into a running server's mutable data directory by
+symlinking managed files, removing files it previously managed but no longer
+owns, merging access lists by UUID, planning PlugManX hot-reloads, and
+configuring RCON.
+
+- **CLI** (`sync-managed/src/main.rs:12`): `--data-dir`, `--dropin-dir`,
+  `--managed-root`, `--plugman-reload`, `--rcon-enable`, repeatable
+  `--plugman-ignored-plugin` and `--datapack-world`, `--rcon-port`,
+  `--rcon-password-file`, `--rcon-broadcast-to-ops`. The flag list is assembled
+  by `lib/minecraft/sync-managed.nix:50` and run by `services.minecraft`.
+- **Sync model** (`main.rs:157` `sync_tree`): for each tree (`managed-dropins`
+  -> `<dropin-dir>`, `managed-config` -> `config`, `managed-server-files` ->
+  data root, `managed-datapacks` -> `<world>/datapacks`), it deletes files
+  recorded in the prior `.ix-managed-<name>` manifest, then symlinks the current
+  managed files and rewrites the manifest as `rel <abs source>` lines. Paths are
+  validated against traversal and shell-unsafe characters (`main.rs:80`,
+  `main.rs:65`); `ops.json`/`whitelist.json` are preserved from the
+  server-files sweep (`main.rs:734`).
+- **Access reconcile** (`main.rs:679`): `whitelist.json` and `ops.json` are
+  three-way merged by player `uuid` (current vs previous-applied vs desired), so
+  manual entries survive and managed entries update; duplicate or missing UUIDs
+  are a hard error (`main.rs:604`).
+- **PlugManX plan** (`main.rs:430`): emits a `.reload-plan` of `load`/`reload`/
+  `unload` lines for changed plugin jars and changed per-plugin config files, in
+  a deterministic order, skipping `PlugManX.jar` and ignored plugins.
+- **RCON** (`main.rs:526`): generates a password from two kernel UUIDs if absent
+  (chmod 0600), de-symlinks `server.properties`, and sets `enable-rcon`,
+  `rcon.port`, `rcon.password`, `broadcast-rcon-to-ops`.
+- **Build.** `sync-managed/default.nix` via `ix.cargoUnit.selectBinaryWithTests`.
+
+## mc-probe: Server List Ping health check
+
+A `mcstatus`-based exit-code probe for fleet health checks (`probe/src/mc_probe/__init__.py:1`).
+
+- **CLI** (`__init__.py:66`): `mc-probe <host[:port]>` with optional
+  `--motd-contains SUBSTRING` (repeatable; strips `section`/`&` format codes both
+  sides, `__init__.py:25`), `--protocol-version N`, `--min-max-players N`,
+  `--timeout SECONDS` (default 5). Resolves SRV records like the vanilla client.
+- **Contract.** Exit 0 only if the SLP handshake answered and every requested
+  assertion held; otherwise each failure is named on stderr and it exits 1
+  (`__init__.py:108`). Built with `ix.buildUvApplication` (`probe/default.nix`).
+
+## minecraft-rcon: minimal RCON client
+
+A dependency-free Source RCON client (`rcon/minecraft-rcon.py`): packs and reads
+the little-endian RCON frame format itself (`AUTH=3`, `COMMAND=2`,
+`minecraft-rcon.py:11`).
+
+- **CLI** (`minecraft-rcon.py:44`): `--host` (default `127.0.0.1`), `--port`
+  (required), one of `--password` / `--password-file`, then the command words.
+  Authenticates, prints any server output, exits 1 on auth failure
+  (`minecraft-rcon.py:77`). Built with `writePythonApplication`; exposed only as
+  `pkgs.minecraft-rcon` (overlay, no flake output). The RCON password it speaks
+  is the one `minecraft-sync-managed` provisions.
+
+## minecraft-hot-reload-agent: dev JVM agent
+
+A development-only Java agent (`HotReloadAgent.java:25`) that redefines loaded
+plugin classes in place so a server picks up rebuilt code without a restart.
+
+- **Mechanism.** Loaded as `premain`/`agentmain` (`HotReloadAgent.java:31`), it
+  starts a daemon thread serving a Unix domain socket (default
+  `/run/minecraft-hot-reload/socket`, override `socket=<path>`). The line
+  protocol is `PING` -> `OK pong` and `REDEFINE_DIR <dir>` -> iterate `*.jar`,
+  redefine every already-loaded, modifiable class via
+  `Instrumentation.redefineClasses`, and report counts/failures
+  (`HotReloadAgent.java:117`). Its own `main` is a tiny client for the same
+  socket (`HotReloadAgent.java:187`).
+- **Build.** `hot-reload-agent/default.nix` compiles with `jdk25` (`--release
+  21`) and jars it with `MANIFEST.MF`; exposed as
+  `pkgs.minecraft-hot-reload-agent` (overlay only). Used by the
+  `services.minecraft` dev path (modules domain cross-ref).

--- a/docs/games/minestom/overview.md
+++ b/docs/games/minestom/overview.md
@@ -1,0 +1,54 @@
+# minestom
+
+`packages/minestom` packages a minimal, from-scratch Minecraft server built on
+[Minestom](https://minestom.net), the Java server library. Unlike a Mojang server
+or a Paper/Fabric fork, Minestom ships no built-in world, loaders, mods, or EULA:
+it is a library you write a server against. This package contains one example
+server, `servers/hello`, built into a runnable fat jar.
+
+- **Flake output:** `nix build .#minestom-hello-server-jar`. Also exposed at the
+  package-set path `minestom.helloServerJar` (`servers/hello/package.nix:2`), so
+  consumers reference it as `ix.packages.minestom.helloServerJar` /
+  `pkgs.minestom.helloServerJar`.
+- **Build kind:** `ix.buildGradleFatJar` (`servers/hello/default.nix:13`),
+  pinned by `gradle.lockfile` and `gradle/verification-metadata.xml`.
+
+## The hello server
+
+`servers/hello/src/main/java/dev/ix/minestom/Main.java` is the whole server
+(~30 lines):
+
+- `MinecraftServer.init()` then create one `InstanceContainer`
+  (`Main.java:11`).
+- A chunk generator fills a flat world: bedrock at Y0, stone to Y36, dirt to Y39,
+  grass at Y39 (`Main.java:15`).
+- On `AsyncPlayerConfigurationEvent`, spawn each joining player into that
+  instance with a respawn point at `(0, 42, 0)` (`Main.java:23`).
+- `server.start("0.0.0.0", 25565)` (`Main.java:29`), the default Minecraft port.
+
+## Build details
+
+`servers/hello/build.gradle.kts` (`build.gradle.kts:1`):
+
+- `application` + `java` plugins; main class `dev.ix.minestom.Main`
+  (`build.gradle.kts:21`).
+- Dependencies: `net.minestom:minestom:2026.04.13-1.21.11` and
+  `ch.qos.logback:logback-classic:1.5.32` (`build.gradle.kts:9`). The Minestom
+  version string encodes the targeted Minecraft protocol (`1.21.11`).
+- Java toolchain 25, `options.release = 25` (`build.gradle.kts:14`).
+- `dependencyLocking { lockAllConfigurations() }` (`build.gradle.kts:24`) and the
+  `jar` task assembles a fat jar by zipping the runtime classpath
+  (`build.gradle.kts:32`).
+- `settings.gradle.kts:8` resolves dependencies from an `ix.mavenRepository`
+  Gradle property when present (the Nix-pinned offline repo), else Maven Central;
+  `RepositoriesMode.FAIL_ON_PROJECT_REPOS` forbids per-project repos. Logging
+  config is `src/main/resources/logback.xml`.
+
+## How it is run
+
+The jar is not a service by itself. The `services.minestom` NixOS module (modules
+domain) runs a user-supplied fat jar under a JVM with no loaders/mods/EULA, and
+the `images/games/minestom` image (images domain) builds a runnable container by
+setting `services.minestom.serverJar = ix.packages.minestom.helloServerJar`
+(`images/games/minestom/default.nix:11`). Both are cross-referenced here, not
+documented in this domain. See [common](../common.md) for the domain map.

--- a/docs/images/common.md
+++ b/docs/images/common.md
@@ -1,0 +1,163 @@
+# Images
+
+`images/` is the set of runnable NixOS systems the repo ships as OCI archives
+for ix VMs (`flake.nix:2`, "Pre-built OCI images for ix VMs"; `README.md:67`).
+Each directory under `images/<family>/<name>/` is a thin NixOS module that names
+itself (`ix.image.name`/`tag`) and turns on the services it wants; the shared
+image library evaluates it into a full NixOS system and streams the closure out
+as one self-contained OCI tar. There is no runtime image stacking: ix runs one
+image (`lib/image/default.nix:92-95`).
+
+Read this page first, then the per-image component page. The OCI packaging
+mechanics (the layer planner and the Rust tar/describe tool) are owned by the
+[nix-build](../nix-build/oci-image-builder/overview.md) domain; VM lifecycle and
+fleet convergence by [vm-fleet](../vm-fleet/common.md). This domain owns the
+image definitions only.
+
+## Images in this domain
+
+| image | family | flake output | what it builds |
+| --- | --- | --- | --- |
+| `images/desktop/remote-desktop` | desktop | `.#remote-desktop` | Xpra browser HTML5 desktop (icewm + xterm + firefox). See [remote-desktop](remote-desktop/overview.md). |
+| `images/dev/development-base` | dev | `.#development-base` | default agent dev box: Claude Code + Codex, build toolchain, browser automation. See [development-base](development-base/overview.md). |
+| `images/dev/kernel-dev` | dev | `.#kernel-dev` | Linux kernel build box; shallow Linus tree cloned to `/src/linux`. See [kernel-dev](kernel-dev/overview.md). |
+| `images/dev/neovim-ci` | dev | `.#neovim-ci` | Neovim upstream CI toolchain (clang-21, lua/luajit, test deps). See [neovim-ci](neovim-ci/overview.md). |
+| `images/dev/symphony-codex` | dev | `.#symphony-codex` | disposable Symphony agent runner: tmpfs `/workspace`, room-server ports. See [symphony-codex](symphony-codex/overview.md). |
+| `images/games/minecraft` | games | `.#minecraft`, `.#minecraft_<ver>` | Java Minecraft server; per-version variants via `versions.nix`. See [minecraft](minecraft/overview.md). |
+| `images/games/minecraft-bedrock` | games | `.#minecraft-bedrock` | Bedrock Dedicated Server (native Linux). See [minecraft-bedrock](minecraft-bedrock/overview.md). |
+| `images/games/minecraft-status` | games | `.#minecraft-status` | minimal Fabric server used as the ix status/lifecycle canary. See [minecraft-status](minecraft-status/overview.md). |
+| `images/games/minestom` | games | `.#minestom` | Minestom hello-world fat-jar server. See [minestom](minestom/overview.md). |
+| `images/system/test-cluster-bootstrap` | system | `.#test-cluster-bootstrap` | bare NixOS bootstrap image used to materialize missing fleet nodes. See [test-cluster-bootstrap](test-cluster-bootstrap/overview.md). |
+
+These are Nix-only packages (no Rust crate). They are not enumerated in the root
+`Cargo.toml`; they are discovered from the tree (below).
+
+## The OCI-from-NixOS-closure model
+
+An image is built by `ix.mkImage` (`lib/image/default.nix:90-97`):
+`mkImage args = (evalImageConfig args).ix.build.ociImage`. `evalImageConfig`
+(`lib/image/default.nix:59-88`) runs `lib.nixosSystem` over, in order:
+
+1. one shared `nixpkgs.pkgs` instance (`imagePkgs`, `lib/image/default.nix:39-47`)
+   so evaluating many images in one eval does not reinstantiate nixpkgs per node;
+   unfree packages enter only by name in this predicate (`yourkit-java`,
+   `claude-code`), never by flipping `allowUnfree`.
+2. `./platform.nix` - the baseline applied to every image (below).
+3. `./oci-layer.nix` - the OCI packaging and `ix.image.{name,tag}` options.
+4. Home Manager as a NixOS module (root's per-tool XDG config).
+5. `moduleList` - the entire `modules/` registry, added unconditionally.
+6. the caller's `modules` (the image's own `default.nix` plus any version overlay).
+
+`oci-layer.nix:64-119` does the packaging. It builds a `systemRoot` FHS layer
+(`/init`, `/bin`, `/etc`, `/usr`, ... pointing into `config.system.build.toplevel`),
+runs the closure through `pkgs.dockerTools.streamLayeredImage` with
+`maxLayers = 67` and `config.Entrypoint = ["${toplevel}/init"]`
+(`oci-layer.nix:84-91`), then pipes `streamLayeredImage`'s `passthru.conf` layer
+plan into `oci-image-builder` to produce the final `<name>-oci.tar`
+(`oci-layer.nix:109-119`). Splitting the closure into ~67 layers lets a registry
+dedupe shared store paths across images. The build fails if the layers waste more
+than the configured payload budget (`ix.build.ociEfficiency.*`,
+`oci-layer.nix:32-58`, default `minEfficiency = 0.95`, `maxWastedBytes = 20 MiB`).
+
+## How an image composes modules
+
+The whole `modules/` registry is in scope for every image:
+`moduleList = lib.collect builtins.isPath nixosModules` and
+`nixosModules = discoverModules { root = paths.modules }`
+(`lib/default.nix:78,94`). Each module stays inert until its `enable` flag is
+set, so an image definition is small: set `ix.image.name`/`tag`, flip the
+`services.*.enable` it needs, and add `environment.systemPackages`. The Minecraft
+loader sub-modules (fabric, paper, ...) are present in every image and gated on
+`services.minecraft.<loader>.enable` the same way. The base runtime profile is
+auto-enabled (`ix.profiles.base.enable = lib.mkDefault true`,
+`oci-layer.nix:62`), so every image already carries the operator toolchain.
+
+## Cross-image invariants (`lib/image/platform.nix`)
+
+Every image inherits these from `platform.nix` and the base profile, so a
+component page can assume them:
+
+- Container boot: `boot.isContainer = true`, `/tmp` on tmpfs
+  (`platform.nix:401-417`). ix VMs share the host `linux-ix` kernel.
+- Networking: `useDHCP = false` (ix provisions the guest address;
+  `platform.nix:438`), nftables firewall on (`platform.nix:453-464`). The base
+  always opens TCP 5001 (`ix-console`) and UDP 8443 (`ix-agent`)
+  (`platform.nix:350-364,456-463`).
+- One port/firewall source of truth: `ix.networking.expose.<name>` registers a
+  port claim, opens the in-guest firewall, and makes the listener discoverable
+  across the fleet (`platform.nix:194-247,292-313`). `ix.networking.portClaims`
+  is the lower-level primitive it desugars to; same-namespace collisions fail at
+  eval (`platform.nix:366-375`).
+- `ix.healthChecks.<name>` declares readiness probes (`unit` sugar for
+  `systemctl is-active`, or a `command` run `from = "guest"`/`"host"`) consumed
+  by fleet `health`/`up`/`replace` (`platform.nix:264-277,20-118`).
+- Operator shell is Nushell (`users.defaultUserShell`, `platform.nix:431`);
+  `nix-ld` on so prebuilt binaries find an FHS linker (`platform.nix:424`);
+  systemd coredumps captured (`platform.nix:503-510`). The base profile adds
+  git/neovim/btop/gdb/strace/ripgrep/fd and a `/work/ix` login workspace
+  (`modules/profiles/base/default.nix`).
+
+## How images are discovered and built
+
+`ix.discoverImages { root = paths.images }` walks `images/<family>/<name>/`
+and exposes every directory whose path is exactly two segments deep as a flake
+package keyed by the directory name (`lib/discovery.nix:124-166`, asserts
+`images/<category>/<name>/default.nix` at `:144-146`). The result is merged into
+`packages.<system>` (`lib/per-system.nix:693-696,1043-1044`), so:
+
+```
+nix build .#<image>     # realize one image OCI tar, e.g. nix build .#minecraft
+nix flake show          # list every image package
+```
+
+A directory with a sibling `versions.nix` is special: each version key becomes
+`<name>_<ver>` and the `default` key gets the unsuffixed `<name>` alias
+(`lib/discovery.nix:81-111`). Only `minecraft` uses this
+([minecraft](minecraft/overview.md)). Every image also gets an `image-<name>`
+build check in `ciChecks` (`lib/per-system.nix:1018-1027`) and an attached
+`passthru.tests.eval` evaluation test when `tests/imageTests` has a matching key
+(`lib/discovery.nix:152-164`, `tests/default.nix:5063`).
+
+The four families are organizational only (they map to the
+`images/<family>/<name>` layout; the package name drops the family):
+`desktop`, `dev`, `games`, `system`.
+
+## Glossary
+
+- OCI archive: the output tar of `mkImage`, an OCI image streamed from a NixOS
+  closure (`oci-layer.nix:64-119`). Push it with `ix image push` or run it as a
+  VM.
+- NixOS closure / toplevel: `config.system.build.toplevel`, the activated system
+  the OCI `Entrypoint` boots via `/init` (`oci-layer.nix:73,90`).
+- base profile: `modules/profiles/base`, auto-enabled cross-cutting operator
+  toolchain and shell config (`oci-layer.nix:62`).
+- moduleList: the flattened `modules/` registry added to every image; inert
+  until an `enable` is flipped (`lib/default.nix:94`).
+- loader: a Minecraft server-jar provider module (fabric/paper/folia/...) merged
+  into `services.minecraft` and gated on `services.minecraft.<loader>.enable`
+  (`modules/services/minecraft/default.nix:1-7`).
+- modCatalog: the slug-to-locked-jar map a Minecraft image installs, defaulted
+  from `ix.artifacts.minecraft.modCatalogs.<version>` plus `common`
+  (`modules/services/minecraft/default.nix:858-872`).
+- expose / portClaim: the declarative listener registry; `expose` opens the
+  firewall and adds cross-node discovery, `portClaim` is the eval-time collision
+  registry (`platform.nix:194-247,280-313`).
+- healthCheck: a declared readiness probe surfaced to fleet tooling
+  (`platform.nix:264-277`).
+- versions.nix: per-image version overlay sidecar; produces `<name>_<ver>`
+  packages plus a `<name>` default alias (`lib/discovery.nix:81-111`).
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| remote-desktop | [remote-desktop/overview.md](remote-desktop/overview.md) | Xpra HTML5 browser desktop |
+| development-base | [development-base/overview.md](development-base/overview.md) | default agent dev box (Claude Code + Codex + toolchain) |
+| kernel-dev | [kernel-dev/overview.md](kernel-dev/overview.md) | Linux kernel build box with first-boot git-clone |
+| neovim-ci | [neovim-ci/overview.md](neovim-ci/overview.md) | Neovim upstream CI toolchain |
+| symphony-codex | [symphony-codex/overview.md](symphony-codex/overview.md) | disposable Symphony agent runner |
+| minecraft | [minecraft/overview.md](minecraft/overview.md) | Java Minecraft server + per-version variants |
+| minecraft-bedrock | [minecraft-bedrock/overview.md](minecraft-bedrock/overview.md) | Bedrock Dedicated Server |
+| minecraft-status | [minecraft-status/overview.md](minecraft-status/overview.md) | status/lifecycle canary server |
+| minestom | [minestom/overview.md](minestom/overview.md) | Minestom hello-world fat-jar server |
+| test-cluster-bootstrap | [test-cluster-bootstrap/overview.md](test-cluster-bootstrap/overview.md) | NixOS bootstrap image for fleet node creation |

--- a/docs/images/development-base/overview.md
+++ b/docs/images/development-base/overview.md
@@ -1,0 +1,66 @@
+# development-base
+
+`images/dev/development-base` is the default ix dev box: the wrapped agent CLIs
+(Claude Code + Codex) plus a normal build toolchain on top of the auto-enabled
+base profile. Flake output `.#development-base`. It and `index.lib.mkDev` share
+one agent module so a dev fleet and this image cannot drift.
+
+## What it builds
+
+`images/dev/development-base/default.nix` (50 lines):
+
+- `ix.image.name = "development-base"` (`:17`).
+- imports the agent CLI layer: `imports = [ ../../../lib/dev/agents.nix ]`
+  (`:15`). That module ships both agents by default (`ix.dev.agents.{claude,codex}`).
+- adds the build/runtime toolchain to `environment.systemPackages`
+  (`:25-49`): `agent-browser` + `chromium` (local browser automation, no cloud
+  provider), `cmake`, `gcc`, `gnumake`, `ninja`, `pkg-config`, `rustup`,
+  `nodejs`, `python3`.
+
+The base profile already supplies version control, neovim, the Nushell `/work/ix`
+workspace, gdb/lldb, strace, tcpdump, jq, btop, bpftrace, and the tar/gzip/zstd
+trio needed to stay `ix up`-switchable (`default.nix:1-9`).
+
+## Composed module: `lib/dev/agents.nix`
+
+The single source of truth for "our versions of the agents" (`lib/dev/agents.nix:1-13`).
+
+- `ix.dev.agents.codex` (default true): adds `pkgs.codex` (Apache-2.0; no unfree
+  exception; authenticates at first use in the VM) (`:47-51`).
+- `ix.dev.agents.claude` (default true): adds a wrapped `claude` binary built
+  with `makeWrapper ... --set IS_SANDBOX 1` (`:36-41,53-56`). The wrapper is how
+  Claude Code's bypass-permissions mode is accepted while running as root inside
+  the guest, without a global `environment.variables`.
+- Claude policy is enforced through `/etc/claude-code/managed-settings.json`
+  (read-only, highest precedence): `permissions.defaultMode = "bypassPermissions"`,
+  `skipDangerousModePermissionPrompt = true`, summarized thinking forced back on,
+  and a ~forever transcript retention (`cleanupPeriodDays = 999999`)
+  (`:86-101`). `~/.claude/settings.json` stays app-owned.
+
+`pkgs.claude-code` is unfree; the allow-by-name exception lives on the shared
+image nixpkgs instance (`lib/image/default.nix:41-46`), not in this image. Setting
+a per-image `nixpkgs.config` is ignored and in fact fails an assertion
+(`development-base/default.nix:19-23`).
+
+## Build
+
+```
+nix build .#development-base
+```
+
+## Eval test (`tests/default.nix:3319-3351`)
+
+The attached eval test asserts the image ships `claude-code` and `codex`, does
+NOT enable `allowUnfree` globally, keeps unrelated unfree CLIs (e.g.
+`cursor-cli`) out, and enforces root's Claude bypass via the parsed
+`managed-settings.json` (`defaultMode == "bypassPermissions"` and
+`skipDangerousModePermissionPrompt`). These pin the one-exception-by-name
+discipline so a refactor cannot silently widen it.
+
+## Notes
+
+- This is the closest thing to a "default" interactive ix dev VM. For a
+  fork-and-deploy dev fleet built on the same agent module, see `index.lib.mkDev`
+  (`lib/image/dev.nix`), owned by [vm-fleet](../../vm-fleet/common.md).
+- Browser automation is local-only (`agent-browser` drives the bundled
+  `chromium`), so sandboxes work offline (`default.nix:27-33`).

--- a/docs/images/kernel-dev/overview.md
+++ b/docs/images/kernel-dev/overview.md
@@ -1,0 +1,61 @@
+# kernel-dev
+
+`images/dev/kernel-dev` is a Linux kernel build box: a C build toolchain plus a
+shallow clone of Linus' tree at `/src/linux`, fetched after boot so it does not
+block startup. Flake output `.#kernel-dev`.
+
+## What it builds
+
+`images/dev/kernel-dev/default.nix` (20 lines):
+
+- `ix.image.name = "linux-kernel-dev"` (`:5`). Note the OCI image name differs
+  from the flake output name (`kernel-dev`).
+- adds `gnumake`, `gcc`, `gnugrep`, `findutils` to `environment.systemPackages`
+  (`:7-12`). The base profile already brings ripgrep, fd, neovim, gdb, and perf
+  (`default.nix:1-2`).
+- clones the kernel on first boot via a timer:
+
+```nix
+services.git-clone = {
+  enable = true;
+  activation = "timer";                         # default.nix:14-19
+  url = "https://github.com/torvalds/linux.git";
+  dest = "/src/linux";
+};
+```
+
+## Composed module: `services.git-clone`
+
+Defined in `modules/services/git-clone/default.nix`. Clones a repo once and is
+idempotent: a later boot sees `.git` present and does nothing (`:1-2,76-79`).
+
+- `enable` (`:21`), `url` (`:23`), `dest` (default `/repo`, `:25-28`),
+  `shallow` (default true, renders `--depth 1`, `:30-33,71`), `ref`
+  (default null, `:35-38`).
+- `activation` enum `multi-user` | `timer` (default `multi-user`, `:40-50`).
+  `timer` is for large repos: the clone runs after boot readiness instead of
+  blocking `multi-user.target`. kernel-dev sets `timer` because the Linux tree is
+  large.
+- Runtime: ships `pkgs.gitoxide` and runs `gix clone <flags> <url> <dest>` in a
+  oneshot `git-clone.service` after `network-online.target`
+  (`:53-81`); with `activation = "timer"` the service is not `wantedBy`
+  `multi-user.target` and is instead started by a `git-clone.timer`
+  (`OnBootSec = 15s`, `wantedBy = timers.target`, `:83-90`).
+
+## Build
+
+```
+nix build .#kernel-dev
+```
+
+After boot wait ~15s, then build in `/src/linux` with the standard kernel
+toolchain. The clone is shallow (`--depth 1`); pass `services.git-clone.shallow =
+false` in a fork if you need history.
+
+## Eval test (`tests/default.nix:3304-3317`)
+
+Asserts git-clone is enabled, and that the timer activation does NOT make the
+clone service `wantedBy = multi-user.target` while the timer IS `wantedBy =
+timers.target` (`kernelDev.git.clone.service.wantedBy == []`,
+`...timer.wantedBy == ["timers.target"]`). This pins the "do not block boot on a
+large clone" behavior.

--- a/docs/images/minecraft-bedrock/overview.md
+++ b/docs/images/minecraft-bedrock/overview.md
@@ -1,0 +1,64 @@
+# minecraft-bedrock
+
+`images/games/minecraft-bedrock` builds a Minecraft Bedrock Dedicated Server.
+Bedrock is a native Linux binary, so it is a separate module family from the Java
+[minecraft](../minecraft/overview.md) loader stack. Flake output
+`.#minecraft-bedrock`.
+
+## What it builds
+
+`images/games/minecraft-bedrock/default.nix` (18 lines):
+
+- `ix.image.name = "minecraft-bedrock"` and a tag that tracks the pinned server
+  version: `tag = config.services.minecraft-bedrock.package.version` (`:4-9`), so
+  bumping the Bedrock package in the module moves the image tag automatically.
+- enables the server with a couple of settings (`:11-17`):
+
+```nix
+services.minecraft-bedrock = {
+  enable = true;
+  settings = { server-name = "ix-powered Bedrock"; max-players = 20; };
+};
+```
+
+## Composed module: `services.minecraft-bedrock`
+
+Defined in `modules/services/minecraft-bedrock/default.nix`. It packages the
+Bedrock zip itself (`bedrockServer`, version `1.26.14.1`,
+`pkgs.fetchurl` + `autoPatchelfHook` for the native ELF, `:20-65`). Key surface:
+
+- `enable` (`:105`), `package` (default the built `bedrockServer`, `:107-111`).
+- `port` (IPv4 UDP, default 19132, `:113-117`), `portv6` (IPv6 UDP, default
+  19133, `:119-123`), `openFirewall` (default true, `:125-129`).
+- `settings` (`server.properties` key/value, `:131-135`), `allowlist`
+  (`allowlist.json`, `:137-141`), `permissions` (`permissions.json`, `:143-147`).
+
+Runtime wiring (`:150-199`): claims both UDP ports
+(`minecraft-bedrock-ipv4` on `0.0.0.0`, `minecraft-bedrock-ipv6` on `::`),
+seeds `server-port`/`server-portv6` and `enable-lan-visibility = false`, opens
+the firewall for both UDP ports when `openFirewall`, and runs
+`systemd.services.minecraft-bedrock` (hardened, `KillSignal = SIGINT`,
+`StateDirectory = minecraft-bedrock`). `preStart` symlinks the static server
+files out of the package into `/var/lib/minecraft-bedrock` and installs the
+generated `server.properties`/`allowlist.json`/`permissions.json` (`:178-198`).
+
+## Build
+
+```
+nix build .#minecraft-bedrock
+```
+
+Bedrock listens on UDP 19132 (IPv4) and UDP 19133 (IPv6); both are opened by
+default. The base platform also opens its standard ix-console/ix-agent ports; see
+[common](../common.md).
+
+## Eval test (`tests/default.nix:3718+`)
+
+The `minecraft-bedrock` test group is attached to this image name and pins the
+Bedrock module wiring (ports, settings, service).
+
+## Notes
+
+- Bump the Bedrock version by editing `version` (and the `hash`) in
+  `modules/services/minecraft-bedrock/default.nix:20-34`; the image tag follows
+  automatically.

--- a/docs/images/minecraft-status/overview.md
+++ b/docs/images/minecraft-status/overview.md
@@ -1,0 +1,62 @@
+# minecraft-status
+
+`images/games/minecraft-status` is a minimal Fabric Minecraft server tuned to act
+as the ix status / lifecycle canary: small, fast to boot, and reachable through
+ix port-forwarding rather than a guest-managed public port. Flake output
+`.#minecraft-status`. It is a hand-rolled single-version image (no `versions.nix`),
+separate from the multi-variant [minecraft](../minecraft/overview.md) image.
+
+## What it builds
+
+`images/games/minecraft-status/default.nix` (30 lines):
+
+- `ix.image = { name = "minecraft-status"; tag = "1.21.11-fabric"; }` (`:2-5`).
+- turns the NixOS firewall unit OFF entirely
+  (`networking.firewall.enable = false`, `:10`): the canary is reached over ix
+  port-forwarding and exposes no north-south port, so dropping the firewall unit
+  removes boot work from the five-minute lifecycle probe (`:7-9`).
+- enables a Fabric server at 1.21.11 with the firewall closed and a stripped-down
+  property set sized for the canary (`:12-29`):
+
+```nix
+services.minecraft = {
+  enable = true;
+  version = "1.21.11";
+  fabric.enable = true;
+  openFirewall = false;
+  properties = {
+    motd = "ix status Minecraft";
+    max-players = 8; online-mode = false;
+    enforce-secure-profile = false; spawn-protection = 0;
+    view-distance = 6; simulation-distance = 4;   # small, the canary loads spawn + 6 bot logins
+  };
+};
+```
+
+## Composed module
+
+Same `services.minecraft` runtime as the main [minecraft](../minecraft/overview.md)
+image (`modules/services/minecraft/default.nix`), here with the Fabric loader and
+`openFirewall = false`. With the firewall closed, the relevant health check is
+`minecraft-status`, which probes the listener on `127.0.0.1:<port>` inside the
+guest via `ix.packages.mc-probe` and asserts the MOTD substring
+(`modules/services/minecraft/default.nix:1206-1225`). Because the loopback probe
+runs in-guest, it works even though no public port is opened. `online-mode =
+false` and `enforce-secure-profile = false` let the canary's bot logins connect
+without Mojang auth.
+
+## Build
+
+```
+nix build .#minecraft-status
+```
+
+## Notes
+
+- The low `view-distance`/`simulation-distance` and `max-players = 8` keep the
+  five-minute lifecycle probe cheap; this image is intentionally not a general
+  play server. Use [minecraft](../minecraft/overview.md) for that.
+- No dedicated image eval-test group is attached to this name; the
+  `services.minecraft` module assertions and the SLP health check are its gate.
+  The `minecraft-status` health-check command shape is itself pinned by
+  module-level tests (`tests/default.nix:2683-2686,2802-2804`).

--- a/docs/images/minecraft/overview.md
+++ b/docs/images/minecraft/overview.md
@@ -1,0 +1,103 @@
+# minecraft
+
+`images/games/minecraft` builds a Java Minecraft server. The image directory is a
+version-agnostic base plus a `versions.nix` sidecar, so discovery produces one
+package per version variant (`.#minecraft_<key>`) and a `.#minecraft` alias for
+the default variant. This is the only image in the tree that uses the
+`versions.nix` multi-version mechanism (`README.md:61`, `nix build .#minecraft`).
+
+## What it builds
+
+`images/games/minecraft/default.nix` (23 lines) is the version-agnostic base:
+
+- `ix.image.name = "minecraft"` (`:16`).
+- enables the server and seeds the cross-version `common` mod set so every
+  variant ships the baseline performance/QoL mods (`:11-22`):
+
+```nix
+commonCatalog = ix.artifacts.minecraft.modCatalogs.common;
+services.minecraft = {
+  enable = true;
+  properties.motd = "ix-powered Minecraft";
+  mods = lib.genAttrs (lib.attrNames commonCatalog) (_: { });
+};
+```
+
+It deliberately does NOT set `version` or a loader; the version overlay does.
+
+## Per-version variants (`versions.nix`)
+
+`images/games/minecraft/versions.nix` declares each variant as `{ loader,
+version, mods }` and renders it into a module that sets `ix.image.tag`,
+`services.minecraft.version`, the enabled mod slugs, and
+`services.minecraft.<loader>.enable` (`:65-79`). `default = "26.1.2-fabric"`
+(`:13`). The variants (`:15-63`):
+
+| variant key (`.#minecraft_<key>`) | loader | version | notable mods |
+| --- | --- | --- | --- |
+| `26w17a-fabric` | fabric | 26.2-snapshot-5 | fabric-api, c2me-fabric |
+| `26.1.2-fabric` (default `.#minecraft`) | fabric | 26.1.2 | lithium, krypton, ferrite-core, servercore, vmp-fabric, spark, grimac, ... |
+| `26.1.2-paper` | paper | 26.1.2 | (none; Paper) |
+| `1.21.11-fabric` | fabric | 1.21.11 | fabric-api, spark, terrain-diffusion |
+| `1.21.11-paper` | paper | 1.21.11 | (none; Paper) |
+
+Discovery maps each key to `minecraft_<key>` and aliases `minecraft` to the
+`default` key (`lib/discovery.nix:81-111`); the discovery layer asserts the
+`default` key exists (`:107-108`). The `mods` list per variant is unioned with
+the base `common` set from `default.nix`.
+
+## Composed module: `services.minecraft`
+
+Defined in `modules/services/minecraft/default.nix`. It is loader-agnostic: a
+loader module fills the `serverJar` and `dropinDir` slots via module merge
+(`:1-7`). `version` is the single source of truth (`:809-821`): a loader derives
+the jar from `ix.artifacts.minecraft.servers."${version}-${loader}"` and the
+default `modCatalog` is `modCatalogs.common` merged with `modCatalogs.${version}`
+(`:858-872`, `lib/util/artifacts.nix:44-48`). Key surface:
+
+- `enable` (`:807`), `version` (`:809`), `serverJar` slot (`:823-826`),
+  `dropinDir` (default `mods`; paper uses `plugins`, `:828-832`).
+- `mods` keyed by Modrinth slug, `plugins`, `datapacks`, `players`, `worlds`,
+  `worldBorder` (`:840-856,880-884,219-279`).
+- `properties` (freeform `server.properties`; `port` default 25565 seeds
+  `server-port`; defaults include `online-mode = true`, `view-distance = 32`,
+  `:1028-1061,1130-1150`).
+- `openFirewall` (default true, `:1063`), `rcon` (default off, port 25575,
+  `:934-947`), `maxRAMPercentage` (default 85, JVM auto-scales to VM RAM,
+  `:834-838`), `jvmFlags` (Aikar's G1GC flags, `:902-932`), `javaPackage`
+  (Temurin JRE, `:900`).
+- Loaders are sibling modules under `modules/services/minecraft/<loader>/`,
+  built via `ix.mkMinecraftLoader` (e.g. fabric:
+  `modules/services/minecraft/fabric/default.nix:15-24`), all present in every
+  image and gated on `services.minecraft.<loader>.enable`.
+
+Runtime wiring (`:1167-1285`): claims TCP `port` (`minecraft`) plus RCON when
+enabled, opens the firewall for `openFirewall`, declares two health checks
+(`minecraft` unit active + `minecraft-status` SLP probe via
+`ix.packages.mc-probe` against `127.0.0.1:<port>`, asserting the configured MOTD;
+plus a host-side reachability check when the firewall is open), writes managed
+dropins/datapacks/config/server-files/access via `environment.etc`, and runs
+`systemd.services.minecraft` with `eula=true` written at `preStart`
+(`:1280-1282`) and hardened service config.
+
+## Build
+
+```
+nix build .#minecraft            # default variant (26.1.2-fabric)
+nix build .#minecraft_1.21.11-paper
+```
+
+## Eval test (`tests/default.nix:3456+`)
+
+The `minecraft` test group exercises the loader/version wiring and the SLP health
+check command (`mc-probe 127.0.0.1:<port> --motd-contains ...`), so a misrouted
+loader or a wrong port lands as a check failure rather than a bad server.
+
+## Related images
+
+- [minecraft-status](../minecraft-status/overview.md): a stripped Fabric variant
+  used as the ix status canary.
+- [minecraft-bedrock](../minecraft-bedrock/overview.md): the native Bedrock
+  server (separate module family).
+- [minestom](../minestom/overview.md): a from-scratch JVM server library, no
+  loaders/mods/EULA.

--- a/docs/images/minestom/overview.md
+++ b/docs/images/minestom/overview.md
@@ -1,0 +1,58 @@
+# minestom
+
+`images/games/minestom` is a Minestom hello-world server image. Minestom is a
+from-scratch server library (not a Minecraft loader), so there are no loaders,
+mods, or EULA: the image runs a user-built fat jar. Flake output `.#minestom`.
+
+## What it builds
+
+`images/games/minestom/default.nix` (13 lines):
+
+```nix
+ix.image.name = "minestom-hello";          # default.nix:7
+services.minestom = {
+  enable = true;
+  serverJar = ix.packages.minestom.helloServerJar;   # default.nix:9-12
+};
+```
+
+The OCI image name is `minestom-hello` while the flake output is `minestom`. The
+`serverJar` is the repo-built demo fat jar `ix.packages.minestom.helloServerJar`.
+
+## Composed module: `services.minestom`
+
+Defined in `modules/services/minestom/default.nix`. Runs the fat jar under a JVM
+(`:1-4`). Key surface:
+
+- `enable` (`:40`), `serverJar` (the fat jar to launch, built from a
+  Gradle/Maven project depending on Minestom, `:42-45`).
+- `port` (default 25565, `:70-73`), `openFirewall` (default true, `:75-79`).
+- `maxRAMPercentage` (default 85, `:47-50`), `javaPackage` (Temurin JRE,
+  `:52`), `jvmFlags` (default `-XX:+UseZGC` for sub-millisecond pauses, chosen
+  over the Java-Minecraft Aikar G1GC flags because a long pause drops 20 TPS
+  ticks, `:54-68`).
+- `yourkit` (optional YourKit profiler agent; `ix.languages.java.yourkit`,
+  `:81-90`).
+
+Runtime wiring (`:93-122`): claims TCP `port` (`minestom`) plus the YourKit port
+when enabled, opens the firewall for `openFirewall`, and runs
+`systemd.services.minestom` (hardened, `StateDirectory = minestom`) execing
+`java -XX:MaxRAMPercentage=85 <yourkit flags> <jvmFlags> -jar <serverJar>`
+(`:27-36,109-121`).
+
+## Build
+
+```
+nix build .#minestom
+```
+
+Minestom listens on TCP 25565 by default (opened by default). The base platform
+also opens its standard ix-console/ix-agent ports; see [common](../common.md).
+
+## Notes
+
+- To run your own server, set `services.minestom.serverJar` to your fat jar
+  (built e.g. via `ix.buildGradleFatJar`, `lib/build/gradle-fat-jar.nix`).
+- The `services.minestom` module's YourKit and JVM-flag wiring is pinned by eval
+  tests (`tests/default.nix:2159-2202,4413-4445`), e.g. `-agentpath:` injection
+  and the default YourKit port 10001.

--- a/docs/images/neovim-ci/overview.md
+++ b/docs/images/neovim-ci/overview.md
@@ -1,0 +1,41 @@
+# neovim-ci
+
+`images/dev/neovim-ci` is a Neovim Linux CI image: the toolchain and test
+dependencies needed to build and test Neovim upstream inside an ix-backed job.
+Flake output `.#neovim-ci`.
+
+## What it builds
+
+`images/dev/neovim-ci/default.nix` (44 lines):
+
+- `ix.image.name = "neovim-ci"` (`:9`).
+- builds a Python with the `pynvim` host module:
+  `python = pkgs.python3.withPackages (ps: [ ps.pynvim ])` (`:3-6,39`).
+- ships the full Neovim build/test dependency set in `environment.systemPackages`
+  (`:11-43`): build tools `cmake`, `gcc`, `gnumake`, `ninja`, `pkg-config`,
+  `gettext`, `unzip`; the LLVM 21 toolchain (`llvmPackages_21.clang`,
+  `clang-tools`, `:41-42`); the Lua stack `luajit`, `lua51Packages.{lpeg,
+  luafilesystem,luv}`; language runtimes `nodejs`, `perl`
+  (`perlPackages.Appcpanminus`, `NeovimExt`), `ruby`, `zig`; and test/lint helpers
+  `attr`, `diffutils`, `fish`, `glibcLocales`, `inotify-tools`, `shellcheck`,
+  `stylua`, `ts_query_ls`, `xdg-utils`.
+
+There is no service: this image is a build/test environment, not a long-running
+daemon. It composes only the auto-enabled base profile plus this package set.
+
+## Build
+
+```
+nix build .#neovim-ci
+```
+
+Run the image as a VM and execute Neovim's test suite (the `pynvim` host, the Lua
+deps, clang/luajit, and the language providers are all present). The base profile
+supplies the operator shell, git, and editors; see [common](../common.md).
+
+## Notes
+
+- No eval test group is attached to this image name; its contract is the package
+  list above plus the shared platform invariants.
+- The package set tracks Neovim upstream CI dependencies; bump the pins in
+  `default.nix` when upstream's CI requirements change.

--- a/docs/images/remote-desktop/overview.md
+++ b/docs/images/remote-desktop/overview.md
@@ -1,0 +1,71 @@
+# remote-desktop
+
+`images/desktop/remote-desktop` builds a browser-accessible graphical desktop:
+an Xpra server rendering its built-in HTML5 client, so an operator opens the VM's
+desktop in a web browser with no native client. Flake output `.#remote-desktop`.
+
+## What it builds
+
+`images/desktop/remote-desktop/default.nix` is the entire image (16 lines). It:
+
+- names the image `ix-remote-desktop` (`default.nix:4`).
+- ships `xterm` and `firefox` so first boot has a terminal and a browser
+  (`default.nix:6-9`). `firefox` is the GUI app you exercise the desktop with.
+- turns on the desktop service with the firewall open and authentication off:
+
+```nix
+services.remote-desktop = {
+  enable = true;
+  openFirewall = true;
+  allowUnauthenticated = true;   # default.nix:11-15
+};
+```
+
+`allowUnauthenticated = true` is required here because `openFirewall = true` with
+`auth = "none"` is otherwise an eval error: the module refuses to expose an
+unauthenticated desktop to the network without the explicit opt-in
+(`modules/services/remote-desktop/default.nix:116-124,143-147`). Treat this image
+as trusted-network/per-tenant-VM only.
+
+## Composed module: `services.remote-desktop`
+
+Defined in `modules/services/remote-desktop/default.nix`. Key surface:
+
+- `enable` (`:69`), `package` (default `pkgs.xpra`, `:71`).
+- `port` (default 6080, `:73-77`), `bindAddress` (default `0.0.0.0`, `:79-83`),
+  `openFirewall` (default false, `:85-89`).
+- `display` (default `:100`, `:91-95`), `resolution` (default `1920x1080`,
+  `:97-101`), `desktopCommand` (default an icewm session that spawns xterm,
+  `:20-32,103-108`).
+- `auth` (default `none`, `:110-114`) and `allowUnauthenticated` (`:116-124`).
+- `settings` (freeform `xpra start-desktop` flags rendered by
+  `lib.cli.toCommandLineGNU`, `:126-139`); the module seeds `bind-tcp`,
+  `html = on`, `ssl = off`, `clipboard = on`, audio/printing/webcam off
+  (`:165-182`).
+
+Runtime wiring: registers an `ix.networking.portClaims.remote-desktop` TCP claim
+on `port` (`:158-163`), opens the firewall when `openFirewall`
+(`:190`), runs as a dedicated `remote-desktop` system user
+(`:192-198`), and starts `systemd.services.remote-desktop` after
+`network-online.target` from a Nushell launcher that execs
+`xpra start-desktop <display> <flags>` (`:46-65,200-216`). `icewm` + `xterm` are
+added to `environment.systemPackages` (`:184-188`).
+
+## Build and access
+
+```
+nix build .#remote-desktop          # realize the OCI tar
+```
+
+After boot, Xpra listens on TCP 6080 (the module default `port`); the HTML5
+client is served at that port. The base platform always also opens TCP 5001
+(ix-console) and UDP 8443 (ix-agent); see [common](../common.md). For port-level
+policy beyond on/off, set `networking.firewall.*` inside the image.
+
+## Notes
+
+- No eval test group is attached to this image name; the `services.remote-desktop`
+  module assertions (firewall-vs-auth, `bind-tcp` alignment) are the eval gate
+  (`modules/services/remote-desktop/default.nix:143-156`).
+- To require auth, set `services.remote-desktop.auth` to a real Xpra auth module
+  and drop `allowUnauthenticated`.

--- a/docs/images/symphony-codex/overview.md
+++ b/docs/images/symphony-codex/overview.md
@@ -1,0 +1,71 @@
+# symphony-codex
+
+`images/dev/symphony-codex` is a disposable VM that runs Symphony agent jobs: a
+Codex/Claude agent workspace with a RAM-backed `/workspace`, the room-server
+network ports declared, and the agent + repo tooling needed to drive a run.
+Flake output `.#symphony-codex`.
+
+## What it builds
+
+`images/dev/symphony-codex/default.nix` (111 lines):
+
+- `ix.image = { name = "ix/symphony-codex"; tag = "2026-05-31"; }` (`:20-23`)
+  and `networking.hostName = "symphony-codex"` (`:25`).
+- backs `/workspace` with a sized tmpfs (`:40-47`):
+
+```nix
+fileSystems."/workspace" = {
+  device = "tmpfs"; fsType = "tmpfs";
+  options = [ "size=32g" "mode=0755" ];
+};
+```
+
+  Symphony clones each run's repo checkouts under `/workspace`. The VM's writable
+  root is virtiofs-from-CAS, whose small-file write path is slow (~5-6k files/s,
+  collapsing under host load), so a full `git checkout` of the ~9k-file repo onto
+  the root never finishes inside the provision timeout (ENG-2007/ENG-2004). tmpfs
+  writes into guest RAM (~36k files/s) and the node-agent virtio-mem autoscaler
+  grows guest RAM on demand; `size=32g` is a lazily-allocated ceiling, not a
+  reservation (`:27-39`).
+
+- ships its own wrapped Claude binary (`makeWrapper ... --set IS_SANDBOX 1`,
+  `:8-17,59`), the same narrow sandbox-signal wrapper [development-base](../development-base/overview.md)
+  uses, because Symphony agents run as root in this disposable VM.
+- `environment.systemPackages` (`:55-89`): `claude-code` (wrapped), `pkgs.codex`,
+  the repo `mcp` server (`ix.packages.mcp`, `:76`), `ix.packages.pi-harness`
+  (`:79`), `nodejs_24`, `python3`, plus the agent workspace toolchain
+  (`ast-grep`, `bashInteractive`, `cacert`, `cmake`, `curl`, `direnv`, `fd`,
+  `findutils`, `gcc`, `gh`, `git`, `gnugrep`, `gnumake`, `gnused`, `gnutar`,
+  `gzip`, `jq`, `openssh`, `pkg-config`, `ripgrep`, `unzip`, `which`, `zstd`).
+
+## Room-server networking
+
+The image opens and claims the Symphony room-server ports even though the
+room-server package itself is not currently shipped (`:91-110`):
+
+- TCP 8080: `symphony-room-http` (`networking.firewall.allowedTCPPorts = [ 8080 ]`,
+  `ix.networking.portClaims.symphony-room-http`, `:92,96-102`).
+- UDP 4433: `symphony-room-webtransport`
+  (`networking.firewall.allowedUDPPorts = [ 4433 ]`,
+  `ix.networking.portClaims.symphony-room-webtransport`, `:93,104-109`).
+
+The room-server (`pkgs.symphony-room-server`) is a `TODO` pending re-add: its
+real home is the ix monorepo (`crates/room`), and ix already inputs index, so
+index cannot source it without a circular flake dependency (`flake.nix:131-137`,
+`default.nix:83-85`). The ports/claims stay so re-adding the package is a one-line
+change.
+
+## Build
+
+```
+nix build .#symphony-codex
+```
+
+## Eval test (`tests/default.nix:3376-3426`)
+
+Asserts the image includes `codex`, `gh`+`git`, and common agent workspace tools
+(`direnv`, `ripgrep`); opens room-server HTTP (8080) and WebTransport (4433) on
+top of the base firewall ports; registers the two room listener port claims with
+the right protocol/port; and backs `/workspace` with a `tmpfs` carrying
+`size=32g`. The room-server-presence assertion is a `TODO` parked until the
+package is restored (`:377-379`).

--- a/docs/images/test-cluster-bootstrap/overview.md
+++ b/docs/images/test-cluster-bootstrap/overview.md
@@ -1,0 +1,58 @@
+# test-cluster-bootstrap
+
+`images/system/test-cluster-bootstrap` is the bare NixOS bootstrap image the
+fleet uses to materialize a node that does not exist yet. It is the smallest
+image in the tree: just a name, a tag, and a hostname, riding entirely on the
+base platform. Flake output `.#test-cluster-bootstrap`.
+
+## What it builds
+
+`images/system/test-cluster-bootstrap/default.nix` (8 lines, takes no module
+args):
+
+```nix
+ix.image = {
+  name = "ix/test-cluster-bootstrap";
+  tag = "zstd-tools-2026-05-12";          # default.nix:2-5
+};
+networking.hostName = "test-cluster-bootstrap";   # default.nix:7
+```
+
+It enables no services. Everything it carries comes from the auto-enabled base
+profile and `platform.nix` (container boot, nftables firewall with ix-console
+and ix-agent ports, Nushell, the operator toolchain); see [common](../common.md).
+The tag is hand-bumped to capture closure changes (the `zstd`/tools state the
+bootstrap depends on).
+
+## How it is used
+
+This is not a workload image; it is the seed image for fleet node creation. The
+image library evaluates it once as the canonical bootstrap and reads its name/tag
+so the fleet default and the published image cannot drift
+(`lib/image/default.nix:99-105`):
+
+```nix
+bootstrapImage =
+  (evalImageConfig {
+    modules = [ (paths.images + "/system/test-cluster-bootstrap") ];
+  }).ix.image;
+```
+
+A fleet switch that finds a missing node creates it from
+`registry.ix.dev/${bootstrap.name}:${bootstrap.tag}`
+(`tests/default.nix:4470-4480`, asserting
+`fleetPlan.web.bootstrapImage == "registry.ix.dev/${bootstrap.name}:${bootstrap.tag}"`).
+The full fleet/lifecycle machinery (`mkFleet`, `ix-fleet`) is owned by
+[vm-fleet](../../vm-fleet/common.md).
+
+## Build
+
+```
+nix build .#test-cluster-bootstrap
+```
+
+## Notes
+
+- Because the bootstrap is intentionally minimal, any change to the base profile
+  fans out into this image and every other discovered image; bump the tag when
+  the closure meaningfully changes so consumers re-pull.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,375 @@
+# index documentation index
+
+From-source documentation for the `index` repo: a shared, open-source Nix + Rust monorepo of developer tools (semantic code search, a PTY terminal driver, agent loops and an MCP server, ready-to-run OCI images, and reusable NixOS modules). The docs are a per-domain wiki: each domain has a `common.md` orientation page plus one directory per package/component. Start at a domain's `common.md`, then drill into the component pages.
+
+## Conventions
+
+- `docs/index.md` is the only bare markdown file at the docs root; `docs/<domain>/common.md` is the only bare file in a domain dir; every other page lives under `docs/<domain>/<component>/`.
+- Per-package: every repo-owned package (and every NixOS module/image) has its own component page.
+- `genre`: `living` (current-state reference, kept in sync with source), `recipe` (operational procedure), `historical` (frozen dated note).
+- `owns`: the source globs a page documents, so a change to that code maps to the page that must be updated.
+- The `docs/demo-*` files are README assets, not documentation pages.
+
+## Code and search
+
+### code-intel
+
+AST and semantic code analysis and rewriting: tree-sitter merge/clone/datalog tools, a SCIP find/replace, the Flecs query parser, and shared parsing/highlighting/edit crates.
+
+`owns: packages/ast-merge/** packages/astlog/** packages/clone-detect/** packages/scipql/** packages/flecs-query/** packages/code-highlight/** packages/code-tokenizer/** packages/file-language/** packages/repo-walker/** packages/edit-applier/** packages/llm-clippy/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [code-intel/common.md](code-intel/common.md) | living | Domain orientation: units, shared tree-sitter foundation, analyze/query/rewrite flow, glossary |
+| [code-intel/ast-merge/overview.md](code-intel/ast-merge/overview.md) | living | AST-aware git merge driver: GumTree matching + 3DM merge over tree-sitter, line-based fallback, 6 member crates |
+| [code-intel/astlog/overview.md](code-intel/astlog/overview.md) | living | Datalog over tree-sitter ASTs: query/scan/fix CLI, lint gate, suppression, Python bindings |
+| [code-intel/clone-detect/overview.md](code-intel/clone-detect/overview.md) | living | Type-1/2/3 + sequence clone detection: hashing, scanner, pragmas, clone.toml, SVG badge |
+| [code-intel/scipql/overview.md](code-intel/scipql/overview.md) | living | SCIP index to Souffle facts to datalog query and find/replace/rename, toolchain-wrapped CLI |
+| [code-intel/flecs-query/overview.md](code-intel/flecs-query/overview.md) | living | Flecs Query Language parser to typed AST; stdio MCP server; Python bindings |
+| [code-intel/code-highlight/overview.md](code-intel/code-highlight/overview.md) | living | tree-sitter ANSI syntax highlighter for files and line-numbered snippets |
+| [code-intel/code-tokenizer/overview.md](code-intel/code-tokenizer/overview.md) | living | tantivy identifier tokenizer splitting camel/snake/kebab boundaries |
+| [code-intel/file-language/overview.md](code-intel/file-language/overview.md) | living | path/name/extension to Language enum, no parser dependencies |
+| [code-intel/repo-walker/overview.md](code-intel/repo-walker/overview.md) | living | gitignore-aware text-file iterator skipping binaries |
+| [code-intel/edit-applier/overview.md](code-intel/edit-applier/overview.md) | living | apply sorted non-overlapping byte-range edits, render unified diff |
+| [code-intel/llm-clippy/overview.md](code-intel/llm-clippy/overview.md) | living | Nix-only clippy fork with restriction lints for LLM-assisted codebases |
+
+### search
+
+Semantic + full-text code search for index: the content-addressed search core, the read CLIs/bindings, the corpus indexer, source adapters, and the Mixedbread/parquet/Iceberg backends.
+
+`owns: packages/search-core/** packages/search/** packages/search-py/** packages/search-eval/** packages/indexer/** packages/file-search/** packages/fff/** packages/source/** packages/sink/** packages/lake/** packages/mixedbread/** packages/polars-mixedbread/** packages/polars-sftp/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [search/common.md](search/common.md) | living | Domain orientation: the corpus/Document model, source -> sink -> store -> search pipeline, dedup/content-addressing invariants, glossary, components table |
+| [search/search-core/overview.md](search/search-core/overview.md) | living | Content-addressed core: content hash, manifest, dedup sync, the Store backend trait, MixedbreadStore/MemoryStore, pipeline, config |
+| [search/search-core/internals.md](search/search-core/internals.md) | living | Query/projection layer: semantic/grep/recent/stats/ask, projection rules, CodeScope/RenderMode, conversation context, the metadata filter builder, repo slug |
+| [search/search/overview.md](search/search/overview.md) | living | Read-only semantic + regex search CLI over the shared store, subcommands/flags/scope selectors, pipe-in rerank mode |
+| [search/search-py/overview.md](search/search-py/overview.md) | living | PyO3 binding (import search): async semantic/grep/recent returning polars frames; Linux wheel + MCP bundling |
+| [search/search-eval/overview.md](search/search-eval/overview.md) | recipe | Exa-style retrieval + agentic quality harness grading the real search engine over a fixed corpus |
+| [search/indexer/overview.md](search/indexer/overview.md) | living | Sync every source into Mixedbread + S3/R2 parquet + the Iceberg lake; scan/consume modes, scan cursor, GC, the services.indexer module |
+| [search/source/overview.md](search/source/overview.md) | living | The shared source-meta envelope, Document/Source/SourceAdapter/Reconciler traits, canonical keys, and the body sanitizer |
+| [search/source/adapters.md](search/source/adapters.md) | living | Per-adapter table (grain, external_id, tags) for atuin/claude/codex/debug/git/github/journald/linear/slack plus the source-parquet log reader |
+| [search/sink/overview.md](search/sink/overview.md) | living | Mixedbread reconcile/replace/apply/GC sink and the S3/R2 parquet corpus-log sink |
+| [search/lake/overview.md](search/lake/overview.md) | living | The Iceberg corpus lake: append+tombstone document log, per-slice version fold, snapshot-cursor reads |
+| [search/mixedbread/overview.md](search/mixedbread/overview.md) | living | Minimal async Rust client for the Mixedbread vector store API: endpoints, auth, retry/timeouts, filter DSL |
+| [search/file-search/overview.md](search/file-search/overview.md) | living | Local BM25 file indexer/searcher on Tantivy: SearchIndex(Reader)/EphemeralSearch, chunking, schema, CLI |
+| [search/fff/overview.md](search/fff/overview.md) | living | Third-party fast file-search toolkit packaged for Nix: fff-mcp CLI/MCP server + fff-c cdylib |
+| [search/polars-mixedbread/overview.md](search/polars-mixedbread/overview.md) | living | PyO3 scan_mixedbread polars IO source: predicate pushdown, top_k/min_results retrieval depth, typed metadata columns |
+| [search/polars-sftp/overview.md](search/polars-sftp/overview.md) | living | PyO3 scan_sftp polars IO source over SFTP: Rust reader + Python plugin, auth/host-key handling |
+
+## Terminal surfaces
+
+### terminal
+
+PTY-backed terminal control: spawn and drive interactive programs (tui + Node/Python bindings), the libghostty-vt VT engine (vt), a session manager (tap), and terminal utilities (terminal-theme, run, kitty).
+
+`owns: packages/tui/** packages/tui-node/** packages/tui-py/** packages/tap/** packages/vt/** packages/terminal-theme/** packages/run/** packages/kitty/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [terminal/common.md](terminal/common.md) | living | Domain orientation: the PTY-driver model, how tui/tap/vt relate, the bindings story, glossary, components table |
+| [terminal/tui/overview.md](terminal/tui/overview.md) | living | tui PTY-driver library: TuiManager/TuiInstance, VT-rendered reads, lifecycle, dashboard/publish feature wiring |
+| [terminal/tui/internals.md](terminal/tui/internals.md) | living | tui internals: per-child actor task + dedicated !Send VT engine thread, DECCKM cursor-key rewrite, first-paint wait, scrollback walk |
+| [terminal/tui-node/overview.md](terminal/tui-node/overview.md) | living | Node N-API binding over tui: Tui/serve/Dashboard, Key/waitFor JS helpers, npm @indexable/tui packaging |
+| [terminal/tui-py/overview.md](terminal/tui-py/overview.md) | living | Python PyO3 binding over tui: _tui extension, high-level async Tui API, Playwright-style agent harness, ix-tui wheel |
+| [terminal/tap/overview.md](terminal/tap/overview.md) | living | tap terminal session manager (daemon + clients), tap-pty multiplex engine (vt100 mirror + fan-out + resync), tap-protocol wire types |
+| [terminal/vt/overview.md](terminal/vt/overview.md) | living | VT engine: ix-vt safe wrapper, ix-vt-sys raw FFI, libghostty-vt C/Zig build and link wiring |
+| [terminal/terminal-theme/overview.md](terminal/terminal-theme/overview.md) | living | Light/dark terminal background detection gated on stdout being a TTY |
+| [terminal/run/overview.md](terminal/run/overview.md) | recipe | run a command under a recorded PTY session: output.log, asciinema cast, JSONL events, replay scripts, env knobs |
+| [terminal/kitty/overview.md](terminal/kitty/overview.md) | living | kitty terminal graphics protocol encoder: transmit/place, Unicode placeholders, base64 chunking |
+
+### dashboard
+
+A live, replayable web canvas plus native-window viewer that aggregates every ix resource-producer socket into one board, built on the engine-free dashboard-core crate.
+
+`owns: packages/dashboard/** packages/dashboard-core/** packages/ix-windows/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [dashboard/common.md](dashboard/common.md) | living | Domain orientation: units, producer->canvas data flow, invariants, glossary, component links |
+| [dashboard/dashboard-core/overview.md](dashboard/dashboard-core/overview.md) | living | Engine-free crate: wire types, discovery paths, publish/subscribe socket transport, serve_hub HTTP/SSE server, embedded page, public surface |
+| [dashboard/dashboard-core/internals.md](dashboard/dashboard-core/internals.md) | living | The Hub Loro fold (scopes, projections, body-diff thresholds, timestamps) and the durable RecordingStore |
+| [dashboard/dashboard/overview.md](dashboard/dashboard/overview.md) | living | Standalone aggregator binary: CLI flags, serve flow, demo producer, flake output .#dashboard |
+| [dashboard/ix-windows/overview.md](dashboard/ix-windows/overview.md) | living | Darwin webview consumer: WindowManager reconcile, threading, macOS borderless/120Hz tuning, flake output .#ix-windows |
+
+### media
+
+Terminal-reel recording, macOS screen capture/streaming and HLS ingest, and audio (noise mixing, TTS) tools, four of five driving ffmpeg as the codec engine.
+
+`owns: packages/reel/** packages/screencast/** packages/screencast-ingest/** packages/mynoise/** packages/elevenlabs-say/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [media/common.md](media/common.md) | living | Media domain orientation: units, capture/encode/serve flow, shared ffmpeg/HLS invariants, glossary, components |
+| [media/reel/overview.md](media/reel/overview.md) | living | reel: drive real CLIs through the tui PTY driver, rasterize the styled grid, encode animated AVIF/WebP; generates the README demo |
+| [media/screencast/overview.md](media/screencast/overview.md) | living | screencast: macOS H.265 (avfoundation+VideoToolbox) desktop capture client streaming fMP4 HLS to ingest (Darwin-only) |
+| [media/screencast-ingest/overview.md](media/screencast-ingest/overview.md) | living | screencast-ingest: axum HTTP server storing H.265 HLS per user/session and serving it back for replay/live/indexing |
+| [media/mynoise/overview.md](media/mynoise/overview.md) | living | mynoise: resolve, stream, cache, and locally mix myNoise.net band loops with rodio |
+| [media/elevenlabs-say/overview.md](media/elevenlabs-say/overview.md) | living | elevenlabs-say: say-style ElevenLabs TTS CLI with WebSocket streaming input and macOS say-compatible flags |
+
+## Agents and orchestration
+
+### agents
+
+Tooling that wraps coding agents (Claude Code, Codex, Pi): session-start context/skills generation, Claude Code hooks, peer status stories, transcript lesson distillation, skill linting, a parallel task runner, and Pi executor harnesses.
+
+`owns: packages/agents-md/** packages/claude-hooks/** packages/claude-stories/** packages/distiller/** packages/skill-lint/** packages/dag-runner/** packages/pi-harnesses/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [agents/common.md](agents/common.md) | living | Domain orientation: units, session-start context loop, transcript->corpus funnel, invariants, glossary, components |
+| [agents/agents-md/overview.md](agents/agents-md/overview.md) | living | agents-md CLI: render/diff/check/write generated AGENTS.md+CLAUDE.md from Nix-assembled fragments (flake output agent-context) |
+| [agents/claude-hooks/overview.md](agents/claude-hooks/overview.md) | living | One binary, three fail-open Claude Code hooks: session-digest, worktree-guard, prompt-priors |
+| [agents/claude-stories/overview.md](agents/claude-stories/overview.md) | living | Status-line teammate stories (avatars + current work) served peer-to-peer over a Tailscale tailnet |
+| [agents/distiller/overview.md](agents/distiller/overview.md) | living | Distill ReasoningBank lessons + per-session outcome verdicts from Claude Code transcripts into corpus parquet slices |
+| [agents/skill-lint/overview.md](agents/skill-lint/overview.md) | living | Lint and autofix SKILL.md frontmatter with a real YAML parser; rules, severities, exit codes |
+| [agents/dag-runner/overview.md](agents/dag-runner/overview.md) | living | Parallel JSON-DAG command runner: validation, scheduling, timeouts/cancellation, output modes, exit codes |
+| [agents/pi-harnesses/overview.md](agents/pi-harnesses/overview.md) | living | Pi harness collection: shared builder, model table, engine (pi-harness), base UX, prosecutor |
+| [agents/pi-harnesses/beam.md](agents/pi-harnesses/beam.md) | living | pi-beam: bounded beam search over isolated worktree branches scored on ground truth |
+
+### mcp
+
+ix-mcp (ix_notebook_mcp): a Python execution MCP server whose one tool python_exec runs code on a shared persistent IPython kernel preloaded with the repo's developer primitives.
+
+`owns: packages/mcp/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [mcp/common.md](mcp/common.md) | living | Domain orientation: what ix-mcp is, the one-tool/no-install provider model, components table, invariants, glossary |
+| [mcp/server/overview.md](mcp/server/overview.md) | living | The host process: ix-mcp CLI/subcommands, stdio+HTTP transports, kernel manager, the three MCP tools, generated instructions, config, the Nix build/flake output |
+| [mcp/runtime/overview.md](mcp/runtime/overview.md) | living | The in-kernel runtime: install(), execution flow, jobs/Job, Result, cells/resources, concurrency+capture, the flusher, api()/introspect, the bundled-module registry |
+| [mcp/sessions/overview.md](mcp/sessions/overview.md) | living | The SQLite execution store (schema, single-writer, WAL) and the --session reopenable notebook (dill checkpoint + replay-the-gap restore, per-MCP-session namespaces) |
+| [mcp/dashboard/overview.md](mcp/dashboard/overview.md) | living | The read-only /api/* data API, the feed embed contract, and the pane_bridge/produce path that publishes the MCP as a producer into the shared Loro dashboard hub |
+| [mcp/tool-providers/overview.md](mcp/tool-providers/overview.md) | living | The bundled-module architecture (registry, two-audience Result, async rules, credentials, incognito gate) and a table of every provider under packages/mcp/src |
+| [mcp/task-graph/overview.md](mcp/task-graph/overview.md) | living | The standalone Vite+Svelte demo site and its tasks data generator (one SQLite schema, one generator, two consumers) |
+
+### symphony
+
+A boring DAG runtime for deterministic agent workflows: an Elixir/OTP control plane that lowers .sym workflows to a durable IR run graph and drives Codex/Claude turns over a room-server.
+
+`owns: packages/symphony/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [symphony/common.md](symphony/common.md) | living | Domain orientation: deterministic-workflow model, how DSL/engine/pack relate, invariants, glossary, components |
+| [symphony/dsl/overview.md](symphony/dsl/overview.md) | living | The .sym language: lexer, grammar, AST, node types (agent/exec/when/every/map), triggers, fields, interpreter |
+| [symphony/engine/overview.md](symphony/engine/overview.md) | living | IR run graph and supervised DAG runtime: scheduling, executors, crash recovery, deadlock guard, placement |
+| [symphony/engine/contract.md](symphony/engine/contract.md) | living | Engine wire seam: Envelope plus TurnRequest/EngineEvent/AgentTurnResponse and the shared golden fixtures |
+| [symphony/pack/overview.md](symphony/pack/overview.md) | living | Workflow-pack format (workflows/, skills/, repositories.yaml), hot-reload catalogs, prompt rendering, the example pack |
+| [symphony/operations/overview.md](symphony/operations/overview.md) | recipe | Running it: nix run .#symphony, env vars, state dirs, placements, dashboard at :4040, triggers, the NixOS module |
+
+## Integrations
+
+### integrations
+
+Third-party service API clients and their MCP/CLI/Python surfaces: the google workspace (Gmail + Calendar over one shared installed-app OAuth grant) and github-avatar (commit author to GitHub avatar PNG).
+
+`owns: packages/google/** packages/github-avatar/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [integrations/common.md](integrations/common.md) | living | Domain orientation: units table, the shared-OAuth-grant model, invariants, glossary, components table |
+| [integrations/google/overview.md](integrations/google/overview.md) | living | The google workspace orientation, member crates, Nix/flake wiring, and the shared google-auth OAuth flow (PKCE, token store, refresh+rotation, access-token cache) |
+| [integrations/google/clients.md](integrations/google/clients.md) | living | Typed google-calendar and google-gmail crates: client methods, wire models, and the Gmail MIME builder |
+| [integrations/google/cli.md](integrations/google/cli.md) | living | The gcal and gmail shell CLIs: subcommands and flags |
+| [integrations/google/mcp.md](integrations/google/mcp.md) | living | ix-google-mcp stdio MCP server: transport, auth construction, and the 25 calendar_*/mail_* tools |
+| [integrations/google/python.md](integrations/google/python.md) | living | ix_google PyO3 async bindings: GmailClient and CalendarClient over the shared grant |
+| [integrations/github-avatar/overview.md](integrations/github-avatar/overview.md) | living | github-avatar library: layered commit-author-to-login resolution, login validation, and PNG avatar fetch/re-encode |
+
+## Build and packaging
+
+### nix-build
+
+Nix build-system integration for the index repo: the Cargo-to-Nix per-unit derivation engine, build monitors, OCI image builder, PR rebuild-impact reporter, package registry, and shared CLI build helpers.
+
+`owns: packages/nix-cargo-unit/** packages/nix-web-monitor/** packages/nix-output-monitor/** packages/oci-image-builder/** packages/blast-radius/** packages/registry.nix packages/snix/** packages/build-version/** packages/config-launch/** packages/progress-style/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [nix-build/common.md](nix-build/common.md) | living | Domain orientation: units, Cargo->Nix unit-graph + monitors + image builder + CLI helpers flow, invariants, glossary, components |
+| [nix-build/nix-cargo-unit/overview.md](nix-build/nix-cargo-unit/overview.md) | living | Render a Cargo unit graph into per-unit Nix derivations; CLI (render/merge/scan-panics) and the units.nix surface |
+| [nix-build/nix-cargo-unit/internals.md](nix-build/nix-cargo-unit/internals.md) | living | Unit identity hashing, graph merge dedup, per-crate source scoping, and the relocation-based panic-reachability scan |
+| [nix-build/nix-web-monitor/overview.md](nix-build/nix-web-monitor/overview.md) | living | Run a Nix build with quiet terminal output and a live web monitor; parser + server crates, CLI, and HTTP routes |
+| [nix-build/nix-web-monitor/internals.md](nix-build/nix-web-monitor/internals.md) | living | internal-json state machine, msgpack delta transport, out-of-band dependency DAG, copy-size measurement, and the nix-daemon syscall tracer |
+| [nix-build/nix-output-monitor/overview.md](nix-build/nix-output-monitor/overview.md) | living | nix-output-monitor (nom) repackaged with a nix-derivation patch so it parses content-addressed derivations |
+| [nix-build/oci-image-builder/overview.md](nix-build/oci-image-builder/overview.md) | living | Turn a streamLayeredImage layer plan into an OCI image: legacy one-shot, content-addressed describe/materialize, per-layer sharding, efficiency policy |
+| [nix-build/blast-radius/overview.md](nix-build/blast-radius/overview.md) | living | Report how many .#checks.x86_64-linux derivations a PR rebuilds and the changed-input frontier that caused each rebuild |
+| [nix-build/registry/overview.md](nix-build/registry/overview.md) | living | Package registry helper: discover every packages/** package.nix and drive the flake/overlay/packageSet/test lists |
+| [nix-build/snix/overview.md](nix-build/snix/overview.md) | living | snix default CLI (Rust reimplementation of Nix) built through ix.cargoUnit instead of crate2nix |
+| [nix-build/build-version/overview.md](nix-build/build-version/overview.md) | living | Format a binary's --version line from Nix-stamped IX_BUILD_REV/IX_BUILD_EPOCH build metadata |
+| [nix-build/config-launch/overview.md](nix-build/config-launch/overview.md) | living | Spec-driven exec launcher: set env/PATH and inject static, argv-conditional, and config-file-gated --config flags, then exec preserving argv0 |
+| [nix-build/progress-style/overview.md](nix-build/progress-style/overview.md) | living | Shared indicatif progress-bar and spinner styling for ix CLIs |
+
+### packaging
+
+Repo-owned Nix repackages of third-party tools, each rebuilt with baked-in defaults, patches, or version pins for this fleet.
+
+`owns: packages/btop/** packages/claude-code/** packages/codex/** packages/dia/** packages/launchk/** packages/spark-gluten/** packages/spark-hive/** packages/tonbo-artifacts/** packages/tmux/** packages/vineflower/** packages/yc/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [packaging/common.md](packaging/common.md) | living | Packaging domain orientation: wrapper conventions, structure, flake/registry wiring, pinning/update model, glossary |
+| [packaging/btop/overview.md](packaging/btop/overview.md) | living | btop rebuilt via overrideAttrs against a repo-fork source pinned by flake input |
+| [packaging/claude-code/overview.md](packaging/claude-code/overview.md) | living | Claude Code CLI wrapper: baked flags/env/settings/MCP/system-prompt/hooks via config-launch, signed-manifest version pin |
+| [packaging/codex/overview.md](packaging/codex/overview.md) | living | OpenAI Codex CLI wrapper: forced + soft -c config defaults via config-launch, additive flake-only output |
+| [packaging/dia/overview.md](packaging/dia/overview.md) | living | Dia browser .dmg repackaged verbatim with manifest pin and latest-pointer updater, aarch64-darwin only |
+| [packaging/launchk/overview.md](packaging/launchk/overview.md) | living | launchd-observer Rust TUI built from a pinned flake-input rev with bindgen and git_version fixups, Darwin only |
+| [packaging/spark-gluten/overview.md](packaging/spark-gluten/overview.md) | living | Apache Gluten Velox bundle, native libs autopatchelf'd for NixOS and repacked, x86_64-linux only |
+| [packaging/spark-hive/overview.md](packaging/spark-hive/overview.md) | living | Apache Spark hadoop3+Hive distribution, launchers wrapped to pin JDK 17 and TZDIR, x86_64-linux only |
+| [packaging/tonbo-artifacts/overview.md](packaging/tonbo-artifacts/overview.md) | living | Prebuilt Tonbo Artifacts CLI binary installed by URL rev pin, x86_64-linux only |
+| [packaging/tmux/overview.md](packaging/tmux/overview.md) | living | tmux wrapped via symlinkJoin + wrapProgram to bake a truecolor/mouse/vi config layered under the user's |
+| [packaging/vineflower/overview.md](packaging/vineflower/overview.md) | living | Vineflower decompiler release jar with a baked java -jar launcher, inline version pin |
+| [packaging/yc/overview.md](packaging/yc/overview.md) | living | YC CLI prebuilt per-platform binaries with manifest pin and latest-pointer updater (no provenance check) |
+
+## Nix infrastructure
+
+### nix-lib
+
+The repo's Nix helper/builder/library API under lib/: the cargo-unit Rust builder, per-language toolchains, OCI image and fleet builders, service and dev-fleet helpers, macOS cross toolchain, Minecraft and agent-context helpers, pure utilities, non-Rust build helpers, and the auto-discovery glue that wires it all into the flake.
+
+`owns: lib/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [nix-lib/common.md](nix-lib/common.md) | living | What lib/ is, how it is assembled in lib/default.nix and exposed via the flake (ix/ixSpecialArgs/ixReturn), the auto-discovery model, glossary, and components table |
+| [nix-lib/discovery/overview.md](nix-lib/discovery/overview.md) | living | The discovery/registration glue: registry.nix package index, discoverTree/discoverImages/discoverModules, packageSetFor, overlay, per-system outputs |
+| [nix-lib/rust/overview.md](nix-lib/rust/overview.md) | living | cargo-unit core Rust builder: resolve, vendor, policy gates, buildWorkspace unit graph, selectors, prebuilt injection, shared workspace, single-derivation buildPackage |
+| [nix-lib/languages/overview.md](nix-lib/languages/overview.md) | living | Per-language toolchain/compiler/interpreter selectors, the common errors-validated pattern, and a per-language table |
+| [nix-lib/image/overview.md](nix-lib/image/overview.md) | living | mkImage/mkNonNixImage/evalImageConfig OCI builders, the base platform module, mkFleet fleet eval, mkDev, health-checks |
+| [nix-lib/services/overview.md](nix-lib/services/overview.md) | living | portable-services (launchd+systemd), systemd-hardening attrset, mutable-json 3-way-merge home module |
+| [nix-lib/dev/overview.md](nix-lib/dev/overview.md) | living | ix.dev.* option surface, agent CLI layer, identity binds, and SMB shared-mount builders for dev fleets |
+| [nix-lib/darwin/overview.md](nix-lib/darwin/overview.md) | living | Pinned macOS SDK and the zig + SDK cross toolchain for Linux-to-Darwin Rust builds |
+| [nix-lib/minecraft/overview.md](nix-lib/minecraft/overview.md) | living | Typed NBT constructors + format generator, loader module factory, sync-managed wrapper, dimension-type snapshots |
+| [nix-lib/agent-context/overview.md](nix-lib/agent-context/overview.md) | living | Always-on instruction doc + progressive skills, skills/agents directory assembly, and the frontmatter parser |
+| [nix-lib/util/overview.md](nix-lib/util/overview.md) | living | Pure utilities: errors, deep-merge, attrs/lists, endpoint, toml, mcp, relative-path, secrets, writers, bench, artifacts |
+| [nix-lib/build-helpers/overview.md](nix-lib/build-helpers/overview.md) | living | Non-Rust build helpers: bun/npm/uv lock vendoring, JS/Svelte sites, npm-vitest, Go units, Gradle fat-jars, Zig, libghostty-vt |
+
+### modules
+
+Auto-discovered NixOS service modules, opt-in runtime profiles, and the raycast home-manager module under modules/, with the discovery + option-namespace + port-claim conventions that tie them together.
+
+`owns: modules/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [modules/common.md](modules/common.md) | living | Domain orientation: module auto-discovery, option-namespace convention, port-claim/health-check/hardening invariants, services/profiles/home tables, glossary |
+| [modules/ci-runner/overview.md](modules/ci-runner/overview.md) | living | Self-hosted GitHub Actions runner pool with warm Nix/Cachix cache (services.ci-runner) |
+| [modules/git-clone/overview.md](modules/git-clone/overview.md) | living | Idempotent boot-time gix clone of a repo (services.git-clone) |
+| [modules/postgresql/overview.md](modules/postgresql/overview.md) | living | PostgreSQL 18 tuned for Zen 5 with hugepages (services.ix-postgresql) |
+| [modules/seaweedfs/overview.md](modules/seaweedfs/overview.md) | living | Single-node S3 object store via weed server -s3 (services.ix-seaweedfs) |
+| [modules/observability/overview.md](modules/observability/overview.md) | living | OpenTelemetry Collector + ClickHouse + Grafana telemetry stack (services.ix-observability) |
+| [modules/resource-monitor/overview.md](modules/resource-monitor/overview.md) | living | stats-writer Rust crate + Svelte UI for VM usage/billing (services.resource-monitor) |
+| [modules/remote-desktop/overview.md](modules/remote-desktop/overview.md) | living | Browser desktop over Xpra HTML5 (services.remote-desktop) |
+| [modules/symphony/overview.md](modules/symphony/overview.md) | living | Symphony runtime systemd unit + host codex placement (services.symphony) |
+| [modules/ray/overview.md](modules/ray/overview.md) | living | Tailnet Ray cluster + ix-mcp engine for the fleet API (services.ix-ray) |
+| [modules/spark/overview.md](modules/spark/overview.md) | living | Standalone Spark 3.5 + Gluten/Velox native engine (services.ix-spark) |
+| [modules/minecraft/overview.md](modules/minecraft/overview.md) | living | Loader-agnostic Java Minecraft server core module (services.minecraft) |
+| [modules/minecraft/loaders-and-mods.md](modules/minecraft/loaders-and-mods.md) | living | Minecraft loader family (mkMinecraftLoader) and mod/plugin submodules |
+| [modules/minecraft-bedrock/overview.md](modules/minecraft-bedrock/overview.md) | living | Bedrock Dedicated Server module (services.minecraft-bedrock) |
+| [modules/minestom/overview.md](modules/minestom/overview.md) | living | Minestom fat-jar runtime with ZGC (services.minestom) |
+| [modules/velocity/overview.md](modules/velocity/overview.md) | living | Velocity Minecraft proxy with managed plugins/config (services.velocity) |
+| [modules/geyser/overview.md](modules/geyser/overview.md) | living | Bedrock-to-Java bridge installed as a Velocity plugin (services.geyser) |
+| [modules/floodgate/overview.md](modules/floodgate/overview.md) | living | Floodgate Bedrock auth bridge installed as a Velocity plugin (services.floodgate) |
+| [modules/profiles/overview.md](modules/profiles/overview.md) | living | base/jvm runtime profiles and extended-attributes (ix.profiles.*, ix.extendedAttributes) |
+| [modules/home/overview.md](modules/home/overview.md) | living | raycast Focus session home-manager module, macOS (programs.raycast.focus) |
+
+### images
+
+Runnable NixOS systems packaged as OCI archives under images/, one thin module per image composing modules/ services and built with nix build .#<name>.
+
+`owns: images/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [images/common.md](images/common.md) | living | What images/ is, the OCI-from-NixOS-closure build model, how an image composes modules, discovery/build, the four families, glossary, components |
+| [images/remote-desktop/overview.md](images/remote-desktop/overview.md) | living | Xpra HTML5 browser desktop image (icewm/xterm/firefox), services.remote-desktop wiring and unauthenticated-exposure opt-in |
+| [images/development-base/overview.md](images/development-base/overview.md) | living | Default agent dev box: wrapped Claude Code + Codex via lib/dev/agents.nix, build toolchain, one-exception-by-name unfree discipline |
+| [images/kernel-dev/overview.md](images/kernel-dev/overview.md) | living | Linux kernel build box; C toolchain plus timer-activated services.git-clone of torvalds/linux to /src/linux |
+| [images/neovim-ci/overview.md](images/neovim-ci/overview.md) | living | Neovim upstream CI toolchain image (clang-21, lua/luajit, pynvim, language providers, no service) |
+| [images/symphony-codex/overview.md](images/symphony-codex/overview.md) | living | Disposable Symphony agent runner: tmpfs /workspace, wrapped claude, mcp/pi-harness, room-server port claims |
+| [images/minecraft/overview.md](images/minecraft/overview.md) | living | Java Minecraft server image with versions.nix per-version variants (minecraft_<ver> + default alias), loader/modCatalog model |
+| [images/minecraft-bedrock/overview.md](images/minecraft-bedrock/overview.md) | living | Bedrock Dedicated Server image (native Linux), UDP 19132/19133, tag tracks pinned server version |
+| [images/minecraft-status/overview.md](images/minecraft-status/overview.md) | living | Minimal Fabric server used as the ix status/lifecycle canary; firewall off, in-guest SLP health probe |
+| [images/minestom/overview.md](images/minestom/overview.md) | living | Minestom hello-world fat-jar server image (no loaders/mods/EULA, ZGC flags, optional YourKit) |
+| [images/test-cluster-bootstrap/overview.md](images/test-cluster-bootstrap/overview.md) | living | Bare NixOS bootstrap image (name/tag/hostname only) used to materialize missing fleet nodes |
+
+## VMs and games
+
+### vm-fleet
+
+VM lifecycle (vmkit), fleet convergence (ix-fleet), guest disk images, host/guest demo runners, and live process/kernel debugging (drgn).
+
+`owns: packages/vmkit/** packages/ix-fleet/** packages/chrome-vm/** packages/chrome-vm-image/** packages/vz-linux-guest/** packages/drgn/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [vm-fleet/common.md](vm-fleet/common.md) | living | Domain orientation: units, host/guest/VM-backend relationships, invariants, glossary, components table |
+| [vm-fleet/vmkit/overview.md](vm-fleet/vmkit/overview.md) | living | vmkit CLI surface, modules, macOS-guest workflow, entitlement self-signing, MCP cross-ref |
+| [vm-fleet/vmkit/linux-guests.md](vm-fleet/vmkit/linux-guests.md) | living | vmkit libkrun Linux-guest backend: EFI/OVMF, GPU/Venus, gvproxy/TSI networking, VZ capture limits, linking |
+| [vm-fleet/ix-fleet/overview.md](vm-fleet/ix-fleet/overview.md) | living | Declarative fleet-plan CLI: schema, subcommands, ix SDK control-plane calls, dag-runner fan-out, health checks |
+| [vm-fleet/chrome-vm/overview.md](vm-fleet/chrome-vm/overview.md) | living | macOS host runner: build chrome-vm-image, boot under vmkit/libkrun, decode console screenshot, open PNG |
+| [vm-fleet/chrome-vm-image/overview.md](vm-fleet/chrome-vm-image/overview.md) | living | aarch64 NixOS guest disk (systemd-repart) with boot-time headless-Chromium screenshot oneshot over the console |
+| [vm-fleet/vz-linux-guest/overview.md](vm-fleet/vz-linux-guest/overview.md) | living | aarch64 NixOS GUI guest disk (make-disk-image) booting sway + bossbar-overlay on software graphics for vmkit boot-linux-gui |
+| [vm-fleet/drgn/overview.md](vm-fleet/drgn/overview.md) | living | Nix repackaging of drgn v0.2.0 (live process/kernel debugger); build inputs, flake output, platform gating, base-profile use |
+
+### games
+
+Minecraft data/server tooling (NBT, sound, managed-file sync, probe, RCON, hot-reload, a Minestom server) plus reproducible Mojang asset extraction and SQLite-driven Minecraft-style desktop overlays.
+
+`owns: packages/minecraft/** packages/minecraft-assets/** packages/minestom/** packages/bossbar-overlay/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [games/common.md](games/common.md) | living | Domain orientation: units, server-tooling vs desktop-overlay flow, invariants, glossary, components. |
+| [games/minecraft/overview.md](games/minecraft/overview.md) | living | minecraft-nbt/sound/sync-managed (Rust), mc-probe/minecraft-rcon (Python), hot-reload-agent (Java) tools. |
+| [games/minecraft-assets/overview.md](games/minecraft-assets/overview.md) | living | Reproducible extraction of Mojang GUI textures and bitmap font from the pinned client.jar. |
+| [games/minestom/overview.md](games/minestom/overview.md) | living | Example Minestom server fat jar (minestom-hello-server-jar) built via buildGradleFatJar. |
+| [games/bossbar-overlay/overview.md](games/bossbar-overlay/overview.md) | living | The boss bar/book/orb desktop overlays, their SQLite contracts, themes, and the bossbar CLI. |
+| [games/bossbar-overlay/engine.md](games/bossbar-overlay/engine.md) | living | overlay-core: transparent float window + one wgpu textured-quad pipeline with the bitmap font. |
+
+## Developer tools, SDK, and site
+
+### dev-tools
+
+Miscellaneous first-party developer utilities, benchmarking, and worked examples not belonging to a larger domain: a pretty git-log viewer, an HTTPS reachability prober, a continuous-benchmarking framework, and a standalone CUDA-in-Rust example.
+
+`owns: packages/git-log-pretty/** packages/ix-dev-diagnose/** packages/indexbench/** packages/cuda-hello/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [dev-tools/common.md](dev-tools/common.md) | living | dev-tools domain orientation: units table, cross-component build/packaging invariants, glossary, components table |
+| [dev-tools/git-log-pretty/overview.md](dev-tools/git-log-pretty/overview.md) | living | pretty git-log viewer: commits-ahead-of-main file-icon trees, diff subcommand, pager, kitty avatar rendering and GitHub login resolution |
+| [dev-tools/ix-dev-diagnose/overview.md](dev-tools/ix-dev-diagnose/overview.md) | living | one-shot HTTPS reachability prober for ix.dev: DNS/TCP/TLS/HTTP probes, dual-trust-store recording verifier, JSON report schema and diagnoses |
+| [dev-tools/indexbench/overview.md](dev-tools/indexbench/overview.md) | living | continuous-benchmarking framework: Metric/Run schema, micro/macro/custom harnesses, git-branch and local history stores, CLI, and mkBenchSuite Nix wiring |
+| [dev-tools/indexbench/gate.md](dev-tools/indexbench/gate.md) | living | indexbench statistical regression gate: baseline selection, the three regimes, effect size, Mann-Whitney U test, the two CI gates, and reporting |
+| [dev-tools/cuda-hello/overview.md](dev-tools/cuda-hello/overview.md) | living | minimal pure-Rust CUDA kernel lowered to PTX via cuda-oxide: why standalone, pinned nightly/flake toolchain, kernel+host code, build/run, status |
+
+### sdk
+
+The Rust, Python, and TypeScript client SDKs for the hosted ix microVM service plus the Nix packaging of the precompiled Python bindings.
+
+`owns: sdk/** packages/ix-sdk-python/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [sdk/common.md](sdk/common.md) | living | What the ix SDKs are, the shared wire protocol/endpoint, the three language surfaces, packaging, glossary, components table |
+| [sdk/rust/overview.md](sdk/rust/overview.md) | living | ix-sdk + ix-sdk-wire stub; wire types and the prebuilt-rlib R2 injection/link proof |
+| [sdk/python/overview.md](sdk/python/overview.md) | living | ix_sdk async client wrapper over the native _ix_sdk PyO3 extension; Client/Branch/Snapshot/VM surface |
+| [sdk/typescript/overview.md](sdk/typescript/overview.md) | living | @indexable/sdk thin wrapper dispatching to napi .node or wasm; Sandbox/Repl + Client/Branch |
+| [sdk/packaging/overview.md](sdk/packaging/overview.md) | living | packages/ix-sdk-python: fetches the prebuilt R2 wheel and wraps it as pkgs.ix-sdk-python |
+
+### site
+
+The ix.dev marketing/changelog website: a prerendered SvelteKit + Svelte 5 static site (filterable update log, permalinks, RSS) built by ix.buildSvelteSite and deployed to GitHub Pages.
+
+`owns: site/**`
+
+| page | genre | summary |
+| --- | --- | --- |
+| [site/common.md](site/common.md) | living | Domain orientation: what the site is, units, data/control flow, invariants, glossary, components table |
+| [site/routes/overview.md](site/routes/overview.md) | living | SvelteKit route tree (layout, home feed, [id] permalink, feed.xml) plus app shell, prerender, and base path |
+| [site/lib/overview.md](site/lib/overview.md) | living | Shared layer: updates.ts content data layer, UpdateEntry/FilterBar components, tag filter, mdsvex pipeline, styling, tests |
+| [site/lib/diagrams.md](site/lib/diagrams.md) | living | The @xyflow/svelte diagram subsystem: DiagramFrame, BoxNode, and per-update diagram wrappers |
+| [site/build-deploy/overview.md](site/build-deploy/overview.md) | recipe | Building, previewing, testing, and deploying the site: npm scripts, ix.buildSvelteSite, .#site/.#site-dev, vitest checks, GitHub Pages |
+

--- a/docs/integrations/common.md
+++ b/docs/integrations/common.md
@@ -1,0 +1,123 @@
+# integrations
+
+Third-party service API clients in the repo, plus the MCP and CLI surfaces
+built on top of them. Today that is two things: the [google](google/overview.md)
+workspace (one installed-app OAuth flow shared by typed Gmail and Calendar
+clients, the `gcal`/`gmail` CLIs, the `ix-google-mcp` server, and PyO3 Python
+bindings), and [github-avatar](github-avatar/overview.md) (resolve a git commit
+author to a GitHub account and fetch their avatar as PNG). The shared shape of
+the domain: a small Rust crate owns the HTTP client, wire types, and error
+mapping for one external API, and every user-facing surface over it (CLI, MCP
+tool, Python class) stays a thin argument-shaper so they cannot drift
+([RFC 0003](../../rfcs/0003-mcp-composable-clis.html), cross-referenced not
+documented here).
+
+## Units
+
+| unit | kind | role |
+| --- | --- | --- |
+| `packages/google/auth` | Rust crate (lib `google_auth`) | installed-app OAuth (PKCE) flow, scoped token store, refresh-with-rotation, expiry-aware access-token cache. See [google](google/overview.md). |
+| `packages/google/calendar` | Rust crate (lib `google_calendar`) | typed Calendar v3 events client (list/get/create/cancel). See [google clients](google/clients.md). |
+| `packages/google/calendar/cli` | Rust crate `google-calendar-cli`, `gcal` binary, flake `.#gcal` | the `gcal` shell CLI. See [google CLIs](google/cli.md). |
+| `packages/google/gmail` | Rust crate (lib `google_gmail`) | typed Gmail v1 client (messages/threads/labels/drafts/send/attachments) + MIME builder. See [google clients](google/clients.md). |
+| `packages/google/gmail/cli` | Rust crate `google-gmail-cli`, `gmail` binary, flake `.#gmail` | the `gmail` shell CLI. See [google CLIs](google/cli.md). |
+| `packages/google/mcp` | Rust crate `google-mcp`, `ix-google-mcp` binary, flake `.#ix-google-mcp` | stdio MCP server, 25 Gmail + Calendar tools. See [google MCP](google/mcp.md). |
+| `packages/google/py` | Rust cdylib `ix-google-py` (PyO3) -> Python `ix_google` | async Python bindings for both clients. See [google Python](google/python.md). |
+| `packages/github-avatar` | Rust crate (library, no binary, no flake output) | git commit author -> GitHub login -> avatar PNG. See [github-avatar](github-avatar/overview.md). |
+
+The google units are one Cargo/Nix workspace member tree under `packages/google`
+(root `Cargo.toml:44-50`), documented as the single
+[google](google/overview.md) component dir. `github-avatar` is a standalone
+library crate (`Cargo.toml:43`) consumed by `packages/git-log-pretty` (a
+different domain).
+
+## The shared-OAuth-grant model (google)
+
+Everything in the google component shares one auth story (RFC 0003): one team
+OAuth client, one per-user consent, one token file, one set of scopes.
+
+- **One OAuth client, from the environment.** `ClientSecrets::from_env`
+  (`packages/google/auth/src/lib.rs:89`) reads `GOOGLE_OAUTH_CLIENT_ID` and
+  `GOOGLE_OAUTH_CLIENT_SECRET` (`lib.rs:48`, `:51`). For an installed app the
+  "secret" is not confidential; it stays in the team vault, out of the repo.
+- **One consent, PKCE.** `begin_consent` (`lib.rs:653`) binds a loopback
+  listener on `127.0.0.1:0`, builds the consent URL with `access_type=offline`,
+  `prompt=consent`, and PKCE `S256` (`lib.rs:665-676`), and exchanges the code
+  for an offline refresh token. The headless path
+  (`PendingConsent::code_from_redirect_url`, `lib.rs:736`) accepts the redirect
+  URL pasted back when the browser cannot reach this host.
+- **One token file.** `TokenStore::new` writes
+  `~/.config/google/token.json` mode 0600 (`lib.rs:147-153`, `:226-257`), with
+  the pre-extraction `~/.config/gcal/token.json` adopted forward on first load
+  (`lib.rs:196-215`). A `StoredToken` is `{refresh_token, scopes}`
+  (`lib.rs:104`).
+- **One scope union.** Consent always requests `ALL_KNOWN_SCOPES`
+  (`calendar.events`, `gmail.modify`, `gmail.send`;
+  `packages/google/auth/src/scopes.rs:27`), so one `gcal auth` or `gmail auth`
+  grants every capability the repo exposes. Each binary then asks
+  `Authenticator::new` only for the scopes it needs (`lib.rs:482`), and minting
+  fails with `ScopeMissing` if the stored grant lacks one (`lib.rs:606-616`).
+  Scope check happens at mint time, not construction.
+- **Refresh with rotation, cached.** `Authenticator` mints short-lived access
+  tokens from the refresh token, persisting a rotated refresh token when Google
+  returns one (`lib.rs:590-597`). The access-token cache is expiry-aware:
+  refreshed `ACCESS_TOKEN_REFRESH_MARGIN` (1 min, `lib.rs:67`) before expiry,
+  falling back to a 1-hour lifetime when the endpoint omits `expires_in`
+  (`lib.rs:325`). A CLI mints one token per run; the MCP server and Python
+  bindings hold one `Authenticator` per process and refresh transparently.
+- **Wire types are the contract.** The crate model types
+  (`packages/google/calendar/src/model.rs`,
+  `packages/google/gmail/src/model.rs`) mirror upstream camelCase JSON, and
+  `--json`, the MCP tool results, and the Python dicts all emit exactly these,
+  so the surfaces cannot drift.
+
+Auth bootstrap is out of band for the long-lived surfaces: `gmail auth` (or
+`gcal auth`) on the host mints the refresh token; the MCP server
+(`packages/google/mcp/src/main.rs:11-15`) and Python bindings
+(`packages/google/py/src/lib.rs:9-13`) only refresh from it, never run consent.
+
+## Invariants
+
+- **Header-injection rejected.** The Gmail MIME builder refuses bare control
+  characters and CR/LF in any header value
+  (`packages/google/gmail/src/mime.rs:297-302`), so a user-supplied subject or
+  address cannot smuggle extra headers.
+- **`notify` and `format` never guessed.** Across CLI, MCP, and Python an
+  unknown `notify` (who Google emails) or message `format` is a hard error, not
+  a silent default to "email everyone" or "full bodies"
+  (`packages/google/calendar/src/model.rs:183-197`,
+  `packages/google/gmail/src/messages.rs:62-76`).
+- **Login validated before any URL use.** `github-avatar` validates a GitHub
+  login (1-39 chars, ASCII alnum + hyphen, no leading/trailing hyphen) before
+  interpolating it into an avatar URL
+  (`packages/github-avatar/src/lib.rs:90-98`).
+
+## Glossary
+
+- **installed-app OAuth**: RFC 6749 + RFC 7636 (PKCE) flow for a desktop app,
+  consenting as a person through a team-owned client, no third-party broker.
+- **loopback redirect**: the consent redirect lands on a local
+  `127.0.0.1:<port>` listener; over SSH/VM the URL is pasted back instead
+  (`--paste`).
+- **refresh token**: the offline, long-lived credential in `token.json`; minted
+  once at consent, occasionally rotated.
+- **access token**: the short-lived bearer minted from the refresh token per
+  Google call, cached per `Authenticator`.
+- **scope union**: the full set (`calendar.events`, `gmail.modify`,
+  `gmail.send`) granted by one consent; least privilege is enforced per binary
+  at mint time.
+- **thin surface**: a CLI/MCP/Python layer that only shapes arguments and
+  renders output; all domain logic lives in the core crate (RFC 0003).
+- **noreply email**: a `<id>+<login>@users.noreply.github.com` commit address
+  that `github-avatar` resolves to a login with no network call.
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| google | [google/overview.md](google/overview.md) | the workspace, the shared `google-auth` flow, build/flake wiring |
+| google clients | [google/clients.md](google/clients.md) | typed `google-calendar` and `google-gmail` crates + MIME builder |
+| google CLIs | [google/cli.md](google/cli.md) | `gcal` and `gmail` shell commands and flags |
+| google MCP | [google/mcp.md](google/mcp.md) | `ix-google-mcp` stdio server, the 25 tools |
+| google Python | [google/python.md](google/python.md) | `ix_google` PyO3 async bindings |
+| github-avatar | [github-avatar/overview.md](github-avatar/overview.md) | commit author -> GitHub login -> avatar PNG |

--- a/docs/integrations/github-avatar/overview.md
+++ b/docs/integrations/github-avatar/overview.md
@@ -1,0 +1,73 @@
+# github-avatar
+
+`packages/github-avatar` (crate `github-avatar`) resolves a git commit author to
+a GitHub account and downloads their avatar as PNG bytes (`Cargo.toml:6`,
+`src/lib.rs:1-12`). It is a library only: no binary, no flake output
+(`package.nix:1-4`, no `flake = true`), consumed by `packages/git-log-pretty`
+(a different domain; `src/avatar.rs:15` there) to render avatars in a kitty
+graphics protocol (`f=100`, which needs PNG).
+
+## Resolution is layered (cheapest first)
+
+`src/lib.rs:3-12` documents the order, so the offline path runs before any
+network call:
+
+1. `parse_noreply(email) -> Option<User>` (`lib.rs:68-82`): reads the login
+   straight out of a `<...>@users.noreply.github.com` commit email, no network.
+   Handles both `49699333+octocat@...` (id+login) and the older
+   `octocat@...`, lowercases, and returns `None` unless the embedded login is
+   valid (see [Key internals](#key-internals)).
+2. `Client::resolve_commit(owner, repo, sha) -> Result<Option<User>>`
+   (`lib.rs:176-193`): asks `GET /repos/{owner}/{repo}/commits/{sha}` who
+   authored the commit, resolving any linked email. A 404 or 422 is "no answer"
+   (`Ok(None)`), not an error.
+
+Once a login is known, `Client::avatar_png(login, size_px) -> Result<Vec<u8>>`
+(`lib.rs:209-231`) downloads `https://github.com/{login}.png?size=...` and
+returns PNG.
+
+## Public surface
+
+- `User { login }` (`lib.rs:27-30`) and `RepoSlug { owner, repo }`
+  (`lib.rs:101-107`).
+- `parse_noreply(email)` (`lib.rs:68`), `is_valid_login(login)` (`lib.rs:90`),
+  `parse_remote(url)` (`lib.rs:114`): parses a GitHub remote (https/http/ssh/scp
+  forms, strips `.git`) into a `RepoSlug`, `None` for non-GitHub remotes so a
+  caller can skip the lookup entirely off GitHub (`lib.rs:109-127`).
+- `Client::new(token: Option<String>)` (`lib.rs:156`): one connection pool plus
+  an optional token (e.g. `GITHUB_TOKEN` or `gh auth token`) used only for the
+  API lookup (higher rate limits, private repos); the avatar download needs no
+  token.
+- `Client::resolve_commit` (`lib.rs:176`), `Client::avatar_png` (`lib.rs:209`).
+- `Error`/`Result` (`lib.rs:32-57`): `Request { url, source }`,
+  `InvalidLogin { login }`, `Decode { login, source }`, `Encode { login,
+  source }`.
+
+## Key internals
+
+- **Login validation (`is_valid_login`, `lib.rs:90-98`).** 1 to 39 chars, ASCII
+  alphanumerics and hyphens, no leading/trailing hyphen. The noreply local part
+  is attacker-controlled, so validating here is what keeps stray characters
+  (slash, `?`, `[bot]`) out of the avatar URL; `parse_noreply` only returns a
+  `User` for a valid login (`lib.rs:79-81`, tested `:267-291`).
+- **PNG re-encoding (`avatar_png`, `lib.rs:225-230`).** GitHub's `.png`
+  endpoint sometimes serves the original upload (JPEG, WebP, GIF). The bytes are
+  decoded (`image` with the `png`/`jpeg`/`gif`/`webp` input features,
+  `Cargo.toml:15`), resized to an exact `size_px` square with a triangle
+  filter, and re-encoded as PNG so the caller always gets PNG. Decode/encode
+  failures are `Error::Decode`/`Error::Encode`.
+- **HTTP details.** A 5s per-request timeout keeps a stalled api.github.com or
+  github.com response from hanging the caller, falling back to an untimed client
+  if the builder fails (`lib.rs:160-164`). Every request sends a `User-Agent`
+  (`git-log-pretty/<version>`, required by GitHub) and the API calls add
+  `Accept: application/vnd.github+json` and `X-GitHub-Api-Version: 2022-11-28`,
+  plus bearer auth when a token is set (`lib.rs:21-24`, `:234-247`).
+- **Async, rustls.** `reqwest` with `json` + `rustls-tls` (`Cargo.toml:16`);
+  both `Client` methods are `async`.
+
+## Build wiring
+
+`inRustWorkspace` with `passthruTests`; root workspace member
+(`Cargo.toml:43`), published as a path dependency `github-avatar`
+(`Cargo.toml:161`). Unit tests cover noreply parsing (including unsafe-login
+rejection), login charset edges, and remote URL forms (`src/lib.rs:250-310`).

--- a/docs/integrations/google/cli.md
+++ b/docs/integrations/google/cli.md
@@ -1,0 +1,75 @@
+# google CLIs
+
+The two shell binaries under [google](overview.md): `gcal`
+(`packages/google/calendar/cli`, flake `.#gcal`) and `gmail`
+(`packages/google/gmail/cli`, flake `.#gmail`). Both are thin argument-shapers
+over their [client crate](clients.md) per RFC 0003: the file parses flags and
+renders output, the crate owns the API call, OAuth, and error mapping
+(`calendar/cli/src/main.rs:1-6`, `gmail/cli/src/main.rs:1-6`). `--json` on any
+command emits the crate's wire types verbatim, the same contract the
+[MCP tools](mcp.md) and [Python bindings](python.md) return.
+
+Both require `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` in the
+environment. Run `auth` once per workstation; the grant is shared (see
+[../common.md](../common.md)).
+
+## gcal (`packages/google/calendar/cli/src/main.rs`)
+
+Subcommands (`Command` enum, `main.rs:28-58`):
+
+| subcommand | what | key flags |
+| --- | --- | --- |
+| `auth` | consent and store the refresh token | `--paste` (headless), `--json` (NDJSON: `{auth_url}` then `{signed_in,scopes,token_path}`) (`main.rs:68-83`) |
+| `logout` | delete this host's grant (idempotent) | `--json` (`main.rs:85-91`, `:336-361`) |
+| `print-access-token` | mint and print a current access token | `--json` -> `{access_token, expires_in, scopes}` for the Python helper (`main.rs:60-66`, `:238-254`) |
+| `list` | events in a window (default now..+7d) | `--calendar`, `--from`, `--to`, `--max` (20), `--query`, `--json` (`main.rs:101-125`) |
+| `show <event-id>` | one event | `--calendar`, `--json` (`main.rs:127-138`) |
+| `create` | create an event | `--summary`, `--start`, `--end`, `--all-day`, `--description`, `--location`, `--attendee` (repeatable), `--notify`, `--calendar`, `--json` (`main.rs:140-181`) |
+| `cancel <event-id>` | cancel/delete an event | `--notify`, `--calendar`, `--json` (`main.rs:183-198`) |
+
+- **Auth consents to the union.** `auth` calls `begin_consent(.., ALL_KNOWN_SCOPES)`
+  (`main.rs:274`) then proves the grant with a 1-event probe read before
+  reporting success (`main.rs:307-330`). Reads/writes build an authenticator
+  scoped to `[EVENTS_SCOPE]` (`main.rs:256-264`).
+- **Time parsing.** `--start`/`--end`/`--from`/`--to` accept RFC 3339 with
+  offset, local `YYYY-MM-DD HH:MM`, or a bare date; a wall-clock time made
+  ambiguous by DST is rejected, not guessed (`main.rs:513-529`). For
+  `--all-day`, `--end` is the inclusive last day and the CLI converts to the
+  API's exclusive end (`main.rs:484-511`).
+- **`--notify`** maps to `SendUpdates` via a `Notify` value-enum
+  (`all`/`external-only`/`none`, default `all` matching the Calendar UI)
+  (`main.rs:200-219`).
+
+## gmail (`packages/google/gmail/cli/src/main.rs`)
+
+Subcommands (`Command` enum, `main.rs:26-79`; dispatch `main.rs:318-334`):
+
+| subcommand | what | notes |
+| --- | --- | --- |
+| `auth` | consent and store the refresh token | `--paste`, `--json` (`main.rs:81-96`) |
+| `logout` | delete this host's grant | `--json` (`main.rs:98-104`) |
+| `list` | messages, most recent first | `-q/--query`, `--label` (repeatable), `--include-spam-trash`, `--max` (20), `--json` (`main.rs:106-127`) |
+| `show <message-id>` | one message (headers + body) | `--metadata` (headers only), `--json` (`main.rs:129-139`) |
+| `search <query>` | Gmail query search (alias for `list -q`) | `--threads` (group by thread), `--max`, `--json` (`main.rs:141-154`) |
+| `send` | compose and send | shared `ComposeArgs`, `--json` (`main.rs:156-192`) |
+| `draft create\|update\|send\|list\|delete\|show` | drafts | `DraftCommand` (`main.rs:194-208`) |
+| `thread show <thread-id>` | one thread, messages in order | `--metadata`, `--json` (`main.rs:249-265`) |
+| `label list\|apply\|remove` | labels on a message | `LabelCommand` (`main.rs:267-290`) |
+| `attach get <message-id> <attachment-id>` | download an attachment | `-o/--output` (default stdout) (`main.rs:292-308`) |
+| `archive\|trash\|untrash\|mark-read\|mark-unread <message-id>` | single-message mutations | `SingleIdArgs` (`main.rs:69-78`, `:310-314`) |
+
+- **Bodies come from a file or stdin, never argv.** `ComposeArgs` takes
+  `--to`/`--cc`/`--bcc` (repeatable), `--subject`, `--body FILE` (`-` for
+  stdin), `--html FILE`, `--attach FILE` (repeatable), `--thread`
+  (`main.rs:165-192`). Subjects and addresses are argv; the crate's MIME builder
+  rejects header injection in them ([clients](clients.md)).
+- **`auth` consents to the union.** Like `gcal`, `gmail auth` requests
+  `ALL_KNOWN_SCOPES` so one consent covers both products (`main.rs:355`);
+  reads/writes use `[GMAIL_MODIFY, GMAIL_SEND]` (`main.rs:339-343`).
+- **No `print-access-token`.** That command exists only on `gcal`
+  (`grep` confirms `PrintAccessToken` only in `calendar/cli`); both CLIs share
+  one token file, so `gcal print-access-token` serves the gmail grant too.
+
+Both binaries are built by `cargoUnit.selectBinaryWithTests` with a
+`packageName` distinct from the binary name so package-keyed checks attach
+(`calendar/cli/default.nix:5-8`, `gmail/cli/default.nix:5-8`).

--- a/docs/integrations/google/clients.md
+++ b/docs/integrations/google/clients.md
@@ -1,0 +1,119 @@
+# google clients
+
+The two typed API crates under [google](overview.md). Each owns the HTTP client,
+wire types, and error mapping for one product; OAuth is the shared
+[`google-auth`](overview.md) `Authenticator`. The wire types are the contract
+the [CLIs](cli.md), [MCP tools](mcp.md), and [Python bindings](python.md) all
+emit verbatim (RFC 0003), so the surfaces cannot drift.
+
+## google-calendar (`packages/google/calendar`)
+
+Typed Calendar v3 `events` client: list, get, create, cancel
+(`src/lib.rs:1-9`). Re-exports the OAuth types from `google_auth` plus
+`EVENTS_SCOPE`/`ALL_KNOWN_SCOPES` (`lib.rs:15-18`).
+
+### Public surface
+
+- `Client::new(auth)` and `with_base_url(auth, url)` (tests)
+  (`lib.rs:73-96`). `DEFAULT_BASE_URL = https://www.googleapis.com/calendar/v3`
+  (`lib.rs:31`); `PRIMARY_CALENDAR = "primary"` (`lib.rs:34`).
+- `list_events(calendar_id, &EventQuery) -> Vec<Event>` (`lib.rs:106`):
+  always sets `singleEvents=true` and `orderBy=startTime` (so recurring events
+  expand and can be ordered), paginates `nextPageToken` until `max_events`,
+  caps each page at `MAX_PAGE_SIZE = 250` (`lib.rs:38`, `:111-151`).
+- `get_event(calendar_id, event_id)` (`lib.rs:158`).
+- `create_event(calendar_id, &EventDraft, SendUpdates) -> Event` (`lib.rs:175`)
+  and `cancel_event(calendar_id, event_id, SendUpdates)` (`lib.rs:201`); both
+  append the `sendUpdates` query param.
+- Model (`src/model.rs`): `Event`, `EventDraft`, `EventTime` (untagged
+  `AllDay { date }` vs `Timed { date_time, time_zone }`, `model.rs:15-33`),
+  `Attendee`/`AttendeeDraft`, `Person`, `EventQuery`
+  (`time_min`/`time_max`/`text`/`max_events`), and `SendUpdates`
+  (`All`/`ExternalOnly`/`None` -> `all`/`externalOnly`/`none`,
+  `model.rs:145-165`).
+- `Error`/`Result` (`src/error.rs`): API errors carry the message from Google's
+  `{"error":{"message":..}}` envelope, decoded by `api_message`
+  (`lib.rs:238-277`).
+
+### Key behaviour
+
+- **All-day end is exclusive on the wire.** `EventTime::all_day_end_from_inclusive`
+  converts a human inclusive last day to Google's exclusive `end.date`
+  (`model.rs:35-45`); the day after the last. The CLI/MCP take the inclusive
+  form and convert at the boundary.
+- **`SendUpdates` parsing is strict.** `FromStr` accepts `all`,
+  `external-only`/`externalOnly`, `none` and errors on anything else, because a
+  typo decides who Google emails (`model.rs:183-197`).
+- **Lenient reads.** A cancelled-event stub with only `id`+`status` parses
+  (start/end optional); an all-day boundary parses even with a stray `timeZone`
+  attached (`model.rs:244-252`, `:235-242`).
+
+Tests: wire-level pagination, request bodies, and error-envelope mapping in
+`packages/google/calendar/tests/client.rs`.
+
+## google-gmail (`packages/google/gmail`)
+
+Typed Gmail v1 client: messages, threads, labels, drafts, send, attachments,
+plus the RFC 5322/MIME builder for outgoing mail (`src/lib.rs:1-16`). Uses
+`gmail.modify` + `gmail.send`; both must be on the grant or
+`Authenticator::access_token` returns `ScopeMissing` (`lib.rs:14-16`).
+
+### Public surface
+
+- `Client::new(auth)`, `with_base_url`, and `as_user(user_id)` for delegated
+  mailboxes (`lib.rs:82-114`). `DEFAULT_BASE_URL =
+  https://gmail.googleapis.com/gmail/v1` (`lib.rs:47`); `USER_ME = "me"`
+  (`lib.rs:50`). Internal `user_url`/`get`/`post`/`put`/`delete` builders attach
+  the bearer token and the `users/{user_id}/...` prefix (`lib.rs:116-158`).
+- Messages (`src/messages.rs`): `list_messages(&MessageQuery) ->
+  Vec<MessageStub>` (paginated, `MAX_PAGE_SIZE = 500`, `lib.rs:54`),
+  `get_message(id, MessageFormat)`, `modify_labels(id, add, remove)`,
+  `trash_message`, `untrash_message`, and the helpers `archive_message`
+  (remove `INBOX`), `mark_message_read`/`mark_message_unread` (toggle `UNREAD`)
+  (`messages.rs:109-239`). `MessageFormat` is `Minimal`/`Full`/`Raw`/`Metadata`
+  with strict `FromStr` (`messages.rs:17-76`); `LABEL_INBOX`/`LABEL_UNREAD`
+  constants (`messages.rs:11-15`).
+- Threads (`src/threads.rs`): `list_threads(&MessageQuery)`,
+  `get_thread(id, MessageFormat)` (`threads.rs:36-92`).
+- Labels (`src/labels.rs`): `list_labels()`, `get_label(id)`
+  (`labels.rs:17-37`); add/remove on a message is `modify_labels`.
+- Drafts and send (`src/drafts.rs`): `send_message(&OutgoingMessage)`,
+  `create_draft`, `update_draft`, `get_draft`, `list_drafts(max)`,
+  `delete_draft`, `send_draft(id)` (`drafts.rs:59-194`).
+- Attachments (`src/attachments.rs`): `get_attachment(message_id,
+  attachment_id) -> Bytes`, base64url-decoded for the caller
+  (`attachments.rs:27-43`).
+- Model (`src/model.rs`): `Message`, `MessagePart`/`MessagePartBody`, `Header`
+  (with case-insensitive `MessagePart::header`, `model.rs:76-85`), `Thread`,
+  `Label`, `Draft`, `MessageQuery`
+  (`q`/`label_ids`/`include_spam_trash`/`max_results`), `OutgoingMessage`,
+  `Attachment`. `internalDate` round-trips through a typed `DateTime<Utc>` via
+  custom serde (`model.rs:217-258`).
+- `Error` (`src/error.rs`): API-envelope mapping plus `UnsafeHeader { header }`
+  and `Base64 { field }` (`error.rs:65-82`).
+
+### The MIME builder (`src/mime.rs`)
+
+`build_raw(&OutgoingMessage)` produces the base64url RFC 5322 bytes Gmail's
+`messages.send`/`drafts.create` take (`mime.rs:33-36`). Layout is decided once
+(`Layout::pick`, `mime.rs:74-117`):
+
+- text-only or html-only: a single leaf part, no boundary.
+- text + html: `multipart/alternative`.
+- any body + attachments: `multipart/mixed` wrapping the body (leaf or nested
+  `multipart/alternative`) followed by one base64 attachment per leaf (76-char
+  lines per RFC 2045, `mime.rs:260-265`).
+
+`check_safe` rejects any header value with a byte `< 0x20` or `0x7f` (bare
+CR/LF, NUL, control chars), so a crafted subject or address cannot inject
+headers (`mime.rs:297-302`); this returns `Error::UnsafeHeader` naming the
+offending header. Body LF endings are normalized to CRLF on the wire
+(`mime.rs:152-168`). Header-injection rejection and the layouts are tested in
+`mime.rs:304-419`.
+
+### Known gaps (from README)
+
+No Gmail push (`users.watch` + Pub/Sub) yet; `historyId` is exposed for a later
+push loop. The MIME builder is text + html + attachments, one nesting level: no
+inline CID images or S/MIME. Quota/rate limits are not modeled (a saturating
+workflow hits the API's 429). Tests: `packages/google/gmail/tests/client.rs`.

--- a/docs/integrations/google/mcp.md
+++ b/docs/integrations/google/mcp.md
@@ -1,0 +1,94 @@
+# google MCP
+
+`packages/google/mcp` (crate `google-mcp`, binary `ix-google-mcp`, flake
+`.#ix-google-mcp`) is a stdio MCP server exposing Gmail and Google Calendar to
+an MCP client (Claude, Codex) in one process, sharing one
+[`google-auth`](overview.md) grant (`Cargo.toml:6`, `src/main.rs:1-9`). Each
+tool is a thin shaper over a [client](clients.md) method and returns the crate's
+wire JSON; domain logic and OAuth refresh stay in the core crates (RFC 0003,
+`src/tools.rs:1-8`).
+
+## Transport, server info, logging
+
+- **stdio.** `main` builds `GoogleMcp::new()` and serves over `stdio()` via
+  `rmcp` (`src/main.rs:28-38`); `rmcp 1.7` with `server`/`macros`/`transport-io`
+  (`Cargo.toml:22`).
+- **Server info.** Reported name `ix-google-mcp`, version from
+  `CARGO_PKG_VERSION`, capability `tools`, with instructions telling the client
+  to run `gmail auth` (or `gcal auth`) on the host first
+  (`tools.rs:488-504`).
+- **Logging to stderr only** (stdout is the MCP wire), filter from
+  `IX_GOOGLE_MCP_LOG`, default `info` (`main.rs:40-49`).
+
+## Auth and client construction
+
+`build_clients` reads `GOOGLE_OAUTH_CLIENT_ID`/`GOOGLE_OAUTH_CLIENT_SECRET` and
+the on-disk token store, then builds two `Authenticator`s over the full scope
+set `[CALENDAR_EVENTS, GMAIL_MODIFY, GMAIL_SEND]`, one per client
+(`main.rs:64-84`). The clients share the on-disk refresh token but hold their
+own expiry-aware access-token caches, so a refresh in one does not block the
+other; if Google rotates the refresh token during one client's refresh, the
+other's in-flight refresh can lose the race and fail once, then heal on its next
+mint by re-reading the rotated token (`main.rs:51-62`). Auth bootstrap is out of
+band: this server only refreshes, never runs consent (`main.rs:11-15`).
+
+## Tools (25)
+
+Tool methods live on `GoogleMcp` behind `#[tool_router]` (`tools.rs:51`);
+schemas are derived with `schemars`. Calendar tools keep the `calendar_*` prefix
+of the Python `FastMCP` they replace; mail tools use `mail_*` and match the
+`superhuman-mail` surface 1:1 so swapping it out is one config change (#599,
+`tools.rs:4-8`).
+
+### Calendar (4)
+
+| tool | method -> client call | args |
+| --- | --- | --- |
+| `calendar_events` | `list_events` | `calendar_id?`, `time_min?`, `time_max?`, `text?`, `max_events?` (50) (`tools.rs:61`, `:513-530`) |
+| `calendar_event_get` | `get_event` | `event_id`, `calendar_id?` (`tools.rs:85`) |
+| `calendar_event_create` | `create_event` | `summary`, `start`, `end`, `all_day?`, `description?`, `location?`, `attendees?`, `notify?`, `calendar_id?` (`tools.rs:109`, `:539-561`) |
+| `calendar_event_cancel` | `cancel_event` | `event_id`, `calendar_id?`, `notify?` (`tools.rs:141`) |
+
+### Gmail search/read (5)
+
+`mail_search` (`list_messages` with `q`), `mail_list_messages` (no free-text
+`q`), `mail_get_message`, `mail_list_threads`, `mail_get_thread`
+(`tools.rs:168-252`). Search args: `query`/`q`, `label_ids?`,
+`include_spam_trash?`, `max_results?` (20). `format?` on get is
+`full`(default)/`minimal`/`metadata`/`raw`.
+
+### Gmail send/drafts (7)
+
+`mail_send_message`, `mail_draft_create`, `mail_draft_update`, `mail_draft_get`,
+`mail_draft_list`, `mail_draft_delete`, `mail_draft_send`
+(`tools.rs:263-353`). Compose args (`MailComposeArgs`, `tools.rs:617-640`):
+`to`, `cc?`, `bcc?`, `subject`, `body_text?`, `body_html?`, `thread_id?`,
+`attachments?` (each `filename`, `content_type`, `content_base64`, decoded by
+`build_outgoing`, `tools.rs:772-811`).
+
+### Gmail single-message mutations (5)
+
+`mail_archive`, `mail_trash`, `mail_untrash`, `mail_mark_read`,
+`mail_mark_unread`, each taking `message_id` (`tools.rs:360-420`).
+
+### Gmail labels and attachments (4)
+
+`mail_label_list`, `mail_label_apply` (`message_id`, `label_id`),
+`mail_label_remove`, `mail_attachment_get` (`message_id`, `attachment_id` ->
+`{content_base64, size}`, standard base64) (`tools.rs:426-484`).
+
+## Argument validation
+
+- `notify` and message `format` default only when absent; an unrecognized value
+  is `INVALID_PARAMS`, never a silent "email everyone" or "full bodies"
+  (`tools.rs:752-770`, tested `:838-850`).
+- All-day event `end` is the inclusive last day at the tool and exclusive on the
+  wire, converted by `parse_event_end` (`tools.rs:734-750`, tested `:821-830`).
+- Compose requires at least one of `body_text`/`body_html`
+  (`tools.rs:774-780`).
+- Client errors map to `INTERNAL_ERROR` via `into_tool_error`
+  (`tools.rs:701-703`); the underlying `google-auth` message (for example a
+  revoked grant or missing scope) is preserved in the text.
+
+Built by `cargoUnit.selectBinaryWithTests` (binary `ix-google-mcp`, package
+`google-mcp`, `default.nix:3-6`).

--- a/docs/integrations/google/overview.md
+++ b/docs/integrations/google/overview.md
@@ -1,0 +1,148 @@
+# google
+
+`packages/google` is one Cargo/Nix workspace bringing Gmail and Google Calendar
+into the repo as typed Rust clients with three thin surfaces (shell CLIs, an MCP
+server, Python bindings) over one shared OAuth grant (RFC 0003). This page
+covers the orientation and the load-bearing shared crate, `google-auth`. The
+other members have their own pages:
+
+- [clients](clients.md): the typed `google-calendar` and `google-gmail` crates
+  and the Gmail MIME builder.
+- [cli](cli.md): the `gcal` and `gmail` shell binaries.
+- [mcp](mcp.md): `ix-google-mcp`, the stdio MCP server and its 25 tools.
+- [python](python.md): `ix_google`, the PyO3 async bindings.
+
+Read [../common.md](../common.md) first for the shared-OAuth-grant model that
+every member assumes.
+
+## Member crates
+
+| crate | path | lib/bin | flake output |
+| --- | --- | --- | --- |
+| `google-auth` | `packages/google/auth` | lib `google_auth` | none (library) |
+| `google-calendar` | `packages/google/calendar` | lib `google_calendar` | none (library) |
+| `google-calendar-cli` | `packages/google/calendar/cli` | bin `gcal` | `.#gcal` |
+| `google-gmail` | `packages/google/gmail` | lib `google_gmail` | none (library) |
+| `google-gmail-cli` | `packages/google/gmail/cli` | bin `gmail` | `.#gmail` |
+| `google-mcp` | `packages/google/mcp` | bin `ix-google-mcp` | `.#ix-google-mcp` |
+| `ix-google-py` | `packages/google/py` | cdylib -> Python `ix_google` | none (built as a Python extension) |
+
+Dependency direction: `calendar`, `gmail` -> `auth`; `cli`s -> their client;
+`mcp` and `py` -> `auth` + both clients (`packages/google/mcp/Cargo.toml:19-21`,
+`packages/google/py/Cargo.toml:17-19`).
+
+## How it is built and wired
+
+Each surface is a `cargoUnit.selectBinaryWithTests` package keyed by its binary,
+with `flake = true` in `package.nix` surfacing the flake output:
+
+- `.#gcal`: binary `gcal`, package `google-calendar-cli`
+  (`packages/google/calendar/cli/default.nix:3-9`,
+  `cli/package.nix:2-6`). `nix run .#gcal -- auth`.
+- `.#gmail`: binary `gmail`, package `google-gmail-cli`
+  (`packages/google/gmail/cli/default.nix:3-9`). `nix run .#gmail -- auth`.
+- `.#ix-google-mcp`: binary `ix-google-mcp`, package `google-mcp`
+  (`packages/google/mcp/default.nix:3-6`, `mcp/package.nix:2`).
+
+The library crates (`auth`, `calendar`, `gmail`) and `ix-google-py` are
+`inRustWorkspace` units without their own flake output
+(`packages/google/auth/package.nix`, `.../py/package.nix`); the Python cdylib is
+packaged as an extension module (`crate-type = ["cdylib"]`,
+`packages/google/py/Cargo.toml:10`). All members run their package-keyed checks
+via `passthruTests`.
+
+## google-auth: the shared OAuth flow
+
+`packages/google/auth` (lib `google_auth`) owns installed-app OAuth (RFC 6749 +
+RFC 7636 PKCE) for the repo's Google APIs: a team OAuth client from the
+environment, a per-person browser consent on a loopback redirect, an offline
+refresh token in a user-only file, and short-lived access tokens minted on
+demand (`src/lib.rs:1-18`). No `Debug` on `ClientSecrets`, `StoredToken`, or
+`AccessToken` keeps the secret and the tokens out of logs
+(`lib.rs:72`, `:114-121`, `:344-352`).
+
+### Public surface
+
+- `ClientSecrets { client_id, client_secret }` and `ClientSecrets::from_env`
+  (`lib.rs:73-97`) reading `CLIENT_ID_ENV` / `CLIENT_SECRET_ENV`
+  (`GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, `lib.rs:48`, `:51`).
+- `TokenStore` (`lib.rs:124`): `new` -> default `~/.config/google/token.json`
+  with the legacy `~/.config/gcal/token.json` migration shim
+  (`lib.rs:147-153`); `at`/`with_legacy_path` for tests; `load`, `save`,
+  `remove`, `path`. `save` writes mode 0600 and tightens an existing looser
+  file (`lib.rs:226-257`); `remove` is idempotent and returns the deleted paths
+  (`lib.rs:270-287`).
+- `StoredToken { refresh_token, scopes }` (`lib.rs:104`), the persisted grant.
+- `scopes` module (`src/scopes.rs`): `CALENDAR_EVENTS`
+  (`calendar.events`), `GMAIL_MODIFY` (`gmail.modify`), `GMAIL_SEND`
+  (`gmail.send`), and `ALL_KNOWN` (the union, `scopes.rs:27`).
+- `begin_consent(secrets, scopes) -> PendingConsent` (`lib.rs:653`).
+  `PendingConsent` carries the `auth_url`, and offers `wait_loopback`
+  (`lib.rs:703`), `code_from_redirect_url` (`lib.rs:736`, the `--paste` path),
+  and `exchange(code) -> StoredToken` (`lib.rs:749`). `AuthCode` is a one-shot
+  opaque code (`lib.rs:622`).
+- `Authenticator::new(secrets, store, required_scopes)` (`lib.rs:482`);
+  `access_token()` (cached, `lib.rs:514`) and `mint_access_token() ->
+  AccessToken` (always a network refresh, `lib.rs:528`). `AccessToken { token,
+  expires_in, scopes }` (`lib.rs:335`).
+- `http_client()` (`lib.rs:853`): one reqwest client builder shared with the
+  API clients.
+- `Error` (`src/error.rs`): one variant per unavailable prerequisite, each
+  message naming the operator's next step: `MissingClientId`/`MissingClientSecret`,
+  `NoToken` (names the path and `gmail auth`/`gcal auth`), `TokenRevoked`,
+  `ScopeMissing { missing }`, `ConsentDenied`, `StateMismatch`,
+  `MissingRefreshToken` (`error.rs:26-157`).
+
+### Flow and invariants
+
+- **Consent URL.** `begin_consent` binds `127.0.0.1:0`, derives the
+  `redirect_uri` from the bound port, generates a random `state` and a PKCE
+  verifier (two v4 UUIDs = 64 hex chars, inside RFC 7636's 43..=128 window), and
+  sets `access_type=offline`, `prompt=consent`, `code_challenge_method=S256`
+  (`lib.rs:653-686`). PKCE challenge is verified against the RFC 7636 test
+  vector (`lib.rs:866-873`).
+- **Redirect intake.** `wait_loopback` accepts on the listener, ignores
+  non-redirect probes (favicon, etc.) with a 404, and only returns on a request
+  carrying `code`/`error` (`lib.rs:703-727`, `:799-828`); `extract_code` checks
+  the `state` matches this attempt and maps Google's `error` to `ConsentDenied`
+  (`lib.rs:775-796`).
+- **Exchange.** `exchange` POSTs `authorization_code` + `code_verifier`, then
+  requires a refresh token in the response or fails `MissingRefreshToken`
+  (`lib.rs:749-773`).
+- **Refresh + rotation.** `refresh_from` POSTs `grant_type=refresh_token`; on a
+  rotated refresh token it immediately persists the replacement
+  (`lib.rs:575-604`). A token-endpoint `invalid_grant` on refresh maps to
+  `TokenRevoked` (consent gone, re-auth needed), distinct from a code-exchange
+  failure (`lib.rs:354-390`).
+- **Scope enforcement at mint.** `check_scopes` runs on every mint and returns
+  `ScopeMissing` for any required scope absent from the stored grant
+  (`lib.rs:606-616`), so a binary requesting `gmail.send` against a
+  calendar-only consent fails with a clear message rather than a 403.
+- **Expiry-aware cache.** `access_token` serves a cached token while its
+  `deadline` is in the future, otherwise mints under the write lock with a
+  recheck so concurrent callers serialize on one refresh round-trip
+  (`lib.rs:534-571`). Deadline = `now + lifetime - ACCESS_TOKEN_REFRESH_MARGIN`.
+
+### How callers build an authenticator
+
+Each surface constructs `Authenticator::new` with only the scopes it needs:
+
+- `gcal` reads use `&[EVENTS_SCOPE]` (`packages/google/calendar/cli/src/main.rs:258-262`);
+  `gmail` uses `&[GMAIL_MODIFY, GMAIL_SEND]`
+  (`packages/google/gmail/cli/src/main.rs:339-343`).
+- `gcal auth` and `gmail auth` both call `begin_consent(.., ALL_KNOWN_SCOPES)`
+  so one consent covers both products
+  (`calendar/cli/src/main.rs:274`, `gmail/cli/src/main.rs:352-353`).
+- `gcal print-access-token` builds an authenticator with no required scopes and
+  calls `mint_access_token`, handing the token (and `expires_in`, `scopes`) to a
+  downstream caller via `--json` (`calendar/cli/src/main.rs:238-254`); this is
+  the only surface that exposes the raw access token, and it lives on the
+  calendar CLI, not gmail.
+- `ix-google-mcp` and `ix_google` build authenticators with the full
+  `[CALENDAR_EVENTS, GMAIL_MODIFY, GMAIL_SEND]` set
+  (`packages/google/mcp/src/main.rs:71`, `packages/google/py/src/lib.rs:114`,
+  `:525`).
+
+OAuth-flow tests live in `packages/google/auth/tests/oauth.rs`; the token-store
+round-trip, 0600 mode, and idempotent `remove` are unit-tested in
+`src/lib.rs:859-957`.

--- a/docs/integrations/google/python.md
+++ b/docs/integrations/google/python.md
@@ -1,0 +1,66 @@
+# google Python bindings
+
+`packages/google/py` (crate `ix-google-py`, cdylib, Python package `ix_google`)
+is the PyO3 binding layer over [`google-gmail`](clients.md) and
+[`google-calendar`](clients.md), sharing the same [`google-auth`](overview.md)
+grant as the CLIs and the [MCP server](mcp.md) (`Cargo.toml:6-10`,
+`src/lib.rs:1-13`). Two `Client` classes, one per product; every method is an
+`await`-able coroutine bridged from Rust to asyncio via `pyo3-async-runtimes`,
+returning dicts shaped exactly like the crate wire types
+(`src/lib.rs:1-7`).
+
+## Package layout
+
+- Rust cdylib `crate-type = ["cdylib"]` exporting the `_ix_google` module
+  (`src/lib.rs:673-679`), registering `GmailClient` (Python name `GmailClient`),
+  `CalendarClient`, and `__version__`.
+- Python wrapper `python/ix_google/`: `__init__.py` re-exports the `calendar`
+  and `gmail` submodules; `gmail.py`/`calendar.py` re-export the cdylib classes
+  as `Client` (`python/ix_google/gmail.py:5`,
+  `python/ix_google/calendar.py:5`). Typed via `_ix_google.pyi` + `py.typed`.
+- Usage: `await ix_google.gmail.Client().search("from:alice")`,
+  `await ix_google.calendar.Client().events()` (`__init__.py:17-24`).
+
+## Auth and conversion
+
+`build_authenticator(scopes)` reads the env credentials and the token store and
+builds an `Authenticator` (`src/lib.rs:29-33`). `GmailClient()` requests
+`[GMAIL_MODIFY, GMAIL_SEND]` (`lib.rs:114`); `CalendarClient()` requests
+`[CALENDAR_EVENTS]` (`lib.rs:525`). Bootstrap is out of band: run `gmail auth`
+(or `gcal auth`) on the host first; the constructor only reads the env vars and
+`~/.config/google/token.json` (`lib.rs:9-13`). Results are converted with
+`pythonize_owned` (serde -> JSON -> Python, `lib.rs:43-50`); Rust errors map to
+`RuntimeError`, bad inputs to `ValueError` (`lib.rs:35-41`).
+
+## GmailClient methods (`src/lib.rs:102-473`)
+
+`search(query, label_ids?, include_spam_trash=False, max_results=20)`,
+`list_messages(...)`, `get_message(message_id, format?)`,
+`list_threads(query?, ...)`, `get_thread(thread_id, format?)`,
+`send(to, subject, body_text?, body_html?, cc?, bcc?, thread_id?, attachments?)`,
+`create_draft(...)`, `send_draft(draft_id)`, `list_drafts(max_results=20)`,
+`delete_draft(draft_id)`, `modify_labels(message_id, add?, remove?)`,
+`archive`, `trash`, `untrash`, `mark_read`, `mark_unread` (each by
+`message_id`), `list_labels()`, and `get_attachment(message_id, attachment_id)`
+which returns raw `bytes` (not base64, unlike the MCP tool) via `PyBytes`
+(`lib.rs:457-472`). `attachments` is a list of `(filename, content_type,
+content_bytes)` tuples (`lib.rs:241-242`, `:475-510`).
+
+## CalendarClient methods (`src/lib.rs:516-671`)
+
+`events(time_min?, time_max?, text?, max_events=50, calendar_id?)`,
+`event(event_id, calendar_id?)`,
+`create_event(summary, start, end, all_day=False, description?, location?,
+attendees?, notify?, calendar_id?)`, `cancel_event(event_id, calendar_id?,
+notify?)`. `time_min`/`time_max`/`start`/`end` are parsed as RFC 3339 (or
+`YYYY-MM-DD` for all-day), and all-day `end` is the inclusive last day converted
+to the API's exclusive end (`lib.rs:72-96`, `:626-627`).
+
+## Validation (mirrors the other surfaces)
+
+`format` and `notify` default only when absent and reject unknown values
+(`parse_message_format`, `parse_send_updates`, `lib.rs:52-70`); `send`/
+`create_draft` require at least one of `body_text`/`body_html`
+(`build_outgoing`, `lib.rs:486-489`). The crate is `inRustWorkspace` but has no
+flake output; it is built as a Python extension module
+(`packages/google/py/package.nix:1-4`, `Cargo.toml:20`).

--- a/docs/mcp/common.md
+++ b/docs/mcp/common.md
@@ -1,0 +1,133 @@
+# mcp
+
+`packages/mcp` is `ix-mcp` (the `ix_notebook_mcp` Python package): a Python
+execution MCP server. It exposes essentially one general tool, `python_exec`,
+which runs code on a single shared, persistent IPython kernel. The kernel runs
+on a pinned interpreter that already bundles the repo's developer primitives
+(semantic search, file search, a PTY driver, a fleet/Ray client, browser
+automation, and more) so an LLM gets those primitives by `import`-ing a module in
+a cell, with no `pip`/`uv install` and no `playwright install` step. The
+namespace persists across calls, executions run concurrently on one event loop,
+and work that outlives a short foreground budget keeps running in the background
+as a job the agent inspects with more `python_exec`. A read-only data API and a
+Loro dashboard hub render every run and its live output for a human to watch.
+
+This is one Nix package (`package.nix` declares `id = "mcp"`, so the flake output
+is `.#mcp`; `nix run .#mcp -- serve`), not a Rust workspace member. It bundles
+several first-party Rust cdylibs and binaries from other packages into its
+interpreter (see [Glossary](#glossary)). Read this page first, then the
+component page for the area you are touching.
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| server | [server/overview.md](server/overview.md) | the host process: `ix-mcp` CLI, transports (stdio/HTTP), the kernel manager, the MCP tools (`python_exec`/`read`/`kernel_trace`), instruction composition, the Nix build |
+| runtime | [runtime/overview.md](runtime/overview.md) | the in-kernel runtime loaded into ipykernel: `jobs`/`Job`, `Result`, `cells`, `resources`, the concurrency + capture model, `api()` catalog, bundled-module registry |
+| sessions | [sessions/overview.md](sessions/overview.md) | the SQLite execution store (schema, single-writer rule) and the `--session` notebook (dill checkpoint + replay-the-gap restore) |
+| dashboard | [dashboard/overview.md](dashboard/overview.md) | the read-only `/api/*` data API, the `feed` embed contract, and the `pane_bridge` that publishes the MCP as a producer into the shared Loro hub |
+| tool-providers | [tool-providers/overview.md](tool-providers/overview.md) | the bundled-module architecture and a table of every provider under `packages/mcp/src` (browser, fleet, nix, sh, view, ...) |
+| task-graph | [task-graph/overview.md](task-graph/overview.md) | the standalone Svelte demo site and its `tasks` data generator (one schema, one generator, two consumers) |
+
+## Units
+
+| unit | role |
+| --- | --- |
+| `ix_notebook_mcp` | the server package: CLI, kernel manager, in-kernel runtime, store, dashboard data API, MCP tool surface. Nix-only Python. |
+| `src/<module>` | bundled tool providers imported inside cells: `browser`, `fff`, `fleet`, `google_auth`, `imessage`, `linear`, `mcp_client`, `nix`, `nox_autotriage`, `screen`, `sh`, `slack`, `tasks`, `view`, `vmkit`, `worktree`, `x`. Each is its own Python package baked into the interpreter. |
+| `task-graph/` | a Vite + Svelte demo visualizing a ~100-node dependency DAG; reads `public/tasks.sqlite` produced by the `tasks` module. |
+| `default.nix` | assembles the pinned interpreter (`pkgs.python3.withPackages`), bundles every module + first-party cdylib, and wraps it as the `ix-mcp` and `ix-notebook` binaries. |
+
+The server core is one package (`ix_notebook_mcp`) split across files: `cli.py`
+(entrypoint), `kernel.py` (the one kernel + bridge), `runtime.py` (the in-kernel
+runtime, the largest file), `store.py` (SQLite log), `config.py`, `transport.py`,
+`tools.py` (MCP surface), `dashboard.py`/`feed.py`/`pane_bridge.py`/`produce.py`
+(views), `registry.py`/`guide.py`/`requirements.py` (instructions + module
+index), `outputs.py`/`introspect.py` (rendering + introspection).
+
+## How it fits together
+
+```
+MCP client --stdio/HTTP--> ix-mcp server (kernel.py)  --execute_request-->  one ipykernel
+   python_exec(code,budget)        |  one asyncio.Lock serializes the shell channel        |
+                                   |                                                        v
+                          tools.py / transport.py                         runtime.install(): jobs/Job/Result/
+                                   |                                       cells/resources + bundled modules
+                                   v                                                        |
+                        SQLite store (store.py)  <---- runtime writes every run, output, namespace
+                          ^               ^
+              dashboard.py /api/*    pane_bridge.py -> produce.py -> Loro `dashboard` hub
+              (embedders poll)       (publishes panes; human UI)
+```
+
+- One kernel, one namespace. `serve` starts exactly one ipykernel for the
+  process lifetime (`kernel.py:68`). Every `python_exec` becomes
+  `await __ix_exec(code, budget, ...)` sent over `jupyter-client`
+  (`kernel.py:204`). A single `asyncio.Lock` serializes the shell channel
+  (`kernel.py:73`, `kernel.py:135`); the per-call budget keeps each request short
+  so background work never holds the channel.
+- Concurrency on one loop. Inside the kernel each run is an asyncio task on the
+  kernel's event loop (`runtime._runner`, `runtime.py:1189`), so many run at once
+  and none blocks the others, provided no cell makes a synchronous blocking call.
+  Per-job stdout is captured by a `ContextVar` (`runtime.py:49`) so interleaved
+  prints land in the right job.
+- The store is the single source of truth. The kernel writes every run, its
+  output tail, rich outputs, and a namespace snapshot to one SQLite file
+  (`store.py`); the dashboard and every embedder only read it. The feed (`jobs`,
+  `cells`, `resources`) is derived from it once (`feed.py`) and exposed both
+  in-process and over `/api/*`.
+- Instructions and the module index are generated, not hand-written. `tools.py`
+  composes the server `instructions` from `guide.py` fragments plus a
+  registry-derived module/tool index (`registry.py`), so a tool or bundled module
+  is declared in exactly one place and the prose cannot drift from the code.
+
+## Invariants
+
+- One general tool. Only `python_exec`, `read`, and `kernel_trace` are MCP tools
+  (`tools.py:208`, `tools.py:289`, `tools.py:315`). Everything else (search,
+  shell, calendar, git worktrees) is reached by importing a bundled module in a
+  cell, so it never earns a dedicated tool.
+- Budget is a hold on the one shell channel. `budget` is how long a call holds
+  the kernel before the run backgrounds; it is clamped to `max_budget` (120s,
+  `config.py:86`). A run that outlives its budget keeps going as `jobs['<id>']`.
+- Never block the loop. A synchronous wait (`subprocess.run`, `time.sleep`,
+  `requests`, a long CPU op) freezes every job; wrap it in
+  `await asyncio.to_thread(...)` or use an async API (`sh`, `httpx`). A cell that
+  wedges the loop past `budget + wedge_grace` (15s, `config.py:78`) is rescued by
+  a SIGUSR2 watchdog (`kernel.py:216`, `runtime.py:2744`).
+- stdio owns fd 0/1. In stdio mode the CLI dups the real stdin/stdout to private
+  fds and points fd 0/1 at `/dev/null`+stderr before anything else writes them,
+  so nothing corrupts the JSON-RPC stream (`cli.py:299`).
+- Fresh log unless a session. An ephemeral server wipes its store (and `-wal`/
+  `-shm`) at startup (`cli.py:377`); only `--session FILE` keeps state across runs
+  and refuses to combine with a pinned `IX_MCP_STORE` (`cli.py:340`).
+
+## Glossary
+
+- python_exec: the one general MCP tool; runs `code` on the shared kernel, waits
+  up to `budget` seconds, backgrounds the rest as a job.
+- kernel: the single shared ipykernel the server drives over `jupyter-client`;
+  one namespace, one event loop, for the process lifetime.
+- in-kernel runtime: the code `runtime.install()` injects into the kernel
+  namespace (`jobs`, `Job`, `Result`, `cells`, `resources`, `__ix_exec`, the
+  bundled modules); see [runtime](runtime/overview.md).
+- job: one execution, tracked in the `jobs` dict and as a row in the store; the
+  agent inspects/awaits/cancels/pages it with more `python_exec`.
+- Result: the opt-in split of a cell value into a human view (`user_html`) and a
+  model view (`llm_result`/`llm_images`), carried as a mime bundle.
+- session file (`.ixnb`): a SQLite store kept across runs; reopening restores the
+  dill namespace checkpoint and replays only newer cells.
+- store: the append-only SQLite execution log at `IX_MCP_STORE`; the single
+  source of truth all views derive from.
+- data API: the read-only aiohttp server (`/api/jobs|resources|cells|snapshot`)
+  plus the gated `/api/exec` write path embedders poll.
+- Loro hub / `dashboard`: the standalone Rust aggregator (the
+  [dashboard](../dashboard/common.md) domain) the MCP publishes panes into as one
+  producer; the human-facing UI.
+- bundled module: a Python module baked into the pinned interpreter and listed in
+  `registry.py`, importable in a cell with no install.
+- provider: a bundled module under `packages/mcp/src` that gives the kernel a
+  capability (shell, browser, fleet, ...); see
+  [tool-providers](tool-providers/overview.md).
+- fleet: the tailnet treated as one cluster; `import fleet` drives Ray, Spark
+  Connect, SSH fan-out, and a peer's live kernel.

--- a/docs/mcp/dashboard/overview.md
+++ b/docs/mcp/dashboard/overview.md
@@ -1,0 +1,97 @@
+# mcp dashboard and embedding
+
+The MCP server is a data producer, not a UI owner. Three modules turn the SQLite
+[store](../sessions/overview.md) into something a human or an embedder can read:
+`feed.py` defines the presentation as structured data, `dashboard.py` serves it
+read-only over HTTP, and `pane_bridge.py`/`produce.py` republish it as panes into
+the shared Loro `dashboard` hub (the [dashboard](../../dashboard/common.md) domain),
+which renders the human-facing UI alongside every other producer. The store is
+read-only here; the kernel owns all writes (see [runtime](../runtime/overview.md)).
+
+## feed: the embed contract (`feed.py`)
+
+`feed.py` is the single source of truth for the agent's presentation, consumed
+both in-process (import it) and over HTTP (the `/api/*` routes wrap it). Three
+kinds, mirroring the store tables and `site/src/lib/types.ts` (`feed.py:11-21`):
+
+- `jobs`: every run, newest first with running pinned. Each carries rich `outputs`
+  as nbformat-style mime bundles, where `text/html` is the human view and
+  `application/x-ix-llm+json` is what the model received.
+- `cells`: the agent's curated highlight reel, in display order.
+- `resources`: live, self-updating views.
+
+`snapshot(conn)` returns `{jobs, cells, resources, rev}` (`feed.py:36`); `rev`
+(`feed.py:60`) is a cheap change marker built from each row's id and last-write
+time plus a running job's live output length, so a poller re-renders only when
+something moved without hashing whole payloads. `job(conn, id)` returns one
+execution (`feed.py:53`) for an embedder to join the `jobs['<id>']` a
+`python_exec` result already names. `JOBS_LIMIT` is 200 (`feed.py:33`).
+
+## dashboard: the read-only data API (`dashboard.py`)
+
+Auto-started by the CLI (`dashboard.start`, `dashboard.py:131`), an aiohttp app
+bound to `config.host:dashboard_port`. Routes (`dashboard.py:121-127`):
+
+| route | returns |
+| --- | --- |
+| `GET /` | redirect to the Loro hub URL (`dashboard.py:38`) |
+| `GET /api/jobs` | `store.recent` (the `jobs` feed) |
+| `GET /api/jobs/{id}` | one execution by id, 404 if absent |
+| `GET /api/resources` | live resources |
+| `GET /api/cells` | the presentation reel |
+| `GET /api/snapshot` | the whole `feed.snapshot` (the embed contract) |
+| `POST /api/exec` | the one WRITE path: run a line in THIS node's live kernel |
+
+`/api/exec` (`dashboard.py:65`) backs a peer's `fleet.in_kernel`: it runs code in
+the live kernel so a peer can read this node's real running state. It is gated two
+ways (`dashboard.py:74-89`): a shared bearer token (`config.exec_token`, from
+`IX_MCP_EXEC_TOKEN`(`_FILE`)) is always required if set (constant-time compared),
+and trusting the bound network (`exec_trust_network`, the tailnet) is honored only
+on a non-loopback bind. With neither it returns 403 (disabled, the safe default).
+The body's `budget` is validated and clamped to `[0, max_budget]`.
+
+`build_app` (`dashboard.py:30`) is split from `start` so the routes are testable
+with an in-memory app and a fake kernel without binding a socket.
+
+Bind host: the dashboard renders whatever the agent ran, so the default bind is
+the node's Tailscale IPv4 when Tailscale is up (the tailnet is the trust
+boundary) and loopback otherwise; `IX_MCP_HOST` overrides
+(`config.py:22-26`, resolved in `cli._serve`).
+
+## pane_bridge + produce: the Loro hub (`pane_bridge.py`, `produce.py`)
+
+The CLI spawns the standalone `dashboard` aggregator (`IX_DASHBOARD_BIN`) as the
+human UI and runs `pane_bridge.run` as a background task (`cli.py:507-508`,
+`cli.py:438`). The bridge polls the store every 0.25s and republishes it as
+dashboard-core panes only when the pane set changes, so an idle session is silent
+(`pane_bridge.py:136`). The mapping (`pane_bridge._panes`, `pane_bridge.py:78`):
+one `exec` pane per run (running -> done/failed LED, duration, the run's intent as
+title), an extra `html` pane for a run's rich outputs (tables/plots/images), one
+`html` pane per curated cell, one `html` pane per live resource, and one `data`
+pane (the `namespace` renderer) for the kernel's live globals.
+
+`produce.py` is the Python side of the dashboard-core producer protocol (the Rust
+contract is `packages/dashboard-core/src/pane.rs`/`publish.rs`,
+`produce.py:1-15`). `PaneProducer` (`produce.py:126`) binds a unix socket in the
+discovery directory and streams its full pane set as one NDJSON
+`ProducerSnapshot` line to every reader (replacement semantics, so a late-joining
+aggregator needs no backlog). The discovery dir is resolved in the same order as
+`dashboard_core::discovery_dir`: `$IX_DASH_DIR`, then `$XDG_RUNTIME_DIR/ix-dash`,
+then `/tmp/ix-dash-<user>` (`produce.py:32`). `exec_pane`/`data_pane`/`html_pane`
+(`produce.py:64-123`) build the pane dicts. The whole path is best-effort: if the
+hub binary is absent or the socket cannot bind, the MCP keeps working and the
+data API still serves embedders, there is just no UI (`cli.py:446-454`,
+`produce.py:151-165`).
+
+## Two readers, one feed
+
+```
+store.db --(reads)--> feed.snapshot --(HTTP)--> /api/* --> embedder (room server polls /api/snapshot)
+         \--(reads)--> pane_bridge --> produce (unix socket) --> dashboard hub --> human browser
+```
+
+The room server (an out-of-process embedder) spawns `ix-mcp` as its agent's only
+tool and polls `/api/snapshot` to render a turn's tables/plots/HTML inline beside
+the agent's text; an in-process embedder calls `feed.snapshot(conn)` directly. The
+human-facing dashboard is the Loro hub, which folds the MCP's panes into one
+canvas with every other producer (a TUI's terminals, a VM's screen).

--- a/docs/mcp/runtime/overview.md
+++ b/docs/mcp/runtime/overview.md
@@ -1,0 +1,153 @@
+# mcp in-kernel runtime
+
+`ix_notebook_mcp/runtime.py` is the code that runs INSIDE the ipykernel (not the
+server process). It is loaded once per kernel by the shipped IPython startup
+script (`ipython/00-ix-runtime.py:12` calls `runtime.install`) and defines the
+agent-facing programming model: the `jobs` registry, the `Job` handle, `Result`,
+`cells`, `resources`, the `api()` catalog, plus the `__ix_*` entrypoints the
+[server](../server/overview.md) drives. It is the largest file in the package
+(~2860 lines); this page is the map.
+
+## install (`runtime.py:2763`)
+
+`install(user_ns)` wires the runtime into the kernel: tee stdout/stderr through
+`_Tee` so per-job capture works (`runtime.py:2772`), install the SIGUSR1/SIGUSR2
+signal handlers (`runtime.py:2717`), capture rich display output and register
+rich formatters on the shell, open the SQLite store at `IX_MCP_STORE`
+(`runtime.py:2786`), and bind the runtime surface into the user namespace
+(`runtime.py:2798-2848`): `jobs`, `history`, `doc`, `Job`, `Result`, `cells`,
+`Cells`, `resources`, `Resource`, `register_resource`, `api`, the `__ix_*`
+functions, `DASHBOARD_URL`, the pre-imported modules from
+`registry.preimport_names()` (`fff`, `view`), and `sh`/`asyncio`/`json`/`pl`.
+Everything bound up to this point is the runtime baseline (`_baseline_names`,
+`runtime.py:2853`); only names a user binds AFTER it are covered by session
+checkpoints. A second startup script, `ipython/01-ix-polars.py`, widens polars'
+text repr for the agent and installs `view.df_html` as the global
+`DataFrame._repr_html_` (`ipython/01-ix-polars.py:13-26`).
+
+## Execution flow
+
+The server sends `await __ix_exec(code, budget, name, session)`
+(`runtime.py:2516`), which calls `__ix_run` then `_emit`:
+
+- `__ix_run` (`runtime.py:2417`): pick the namespace for `session` (`_session_ns`,
+  below), build a `Job`, register it in `jobs`, launch `_runner` as an asyncio
+  task, and `await asyncio.wait({task}, timeout=budget)`. It returns the `Job`
+  whether the run finished or is still going, so a run that outlives `budget` just
+  stays in `jobs`.
+- `_runner` (`runtime.py:1189`): set the per-job `ContextVar` so captured stdout
+  routes to this job, write the `start` row, compile the cell (a `SyntaxError`
+  becomes a failed job, not an escape), and execute it. A cell with a top-level
+  `yield` is compiled as an async generator and each yielded value is displayed as
+  it streams (`runtime.py:1210-1230`); otherwise the trailing expression is the
+  result, coerced via `Result.of` with stdout merged in (`runtime.py:1231-1254`).
+  `CancelledError` -> `cancelled`; a watchdog `KeyboardInterrupt` -> a crisp
+  blocking-call message; any other exception -> `error` with a cell-trimmed
+  traceback and the failing line. `finally` persists the final row and marks the
+  snapshot dirty.
+- `_emit` (`runtime.py:2499`) attaches the structured `_job_summary`
+  (`runtime.py:2457`) as the `application/x-ix-job+json` mime bundle the server
+  parses (status, running, full output/result sizes for truncation detection).
+
+## Concurrency and capture
+
+Each run is an asyncio task on the kernel's one event loop, so many run at once
+and none blocks the others (module docstring, `runtime.py:13-18`). Per-job
+stdout/stderr is captured by routing `_Tee` writes through the `_ix_current`
+`ContextVar` set inside each task (`runtime.py:49`, `runtime.py:137`), so
+interleaved prints from concurrent jobs land in the right job buffer (capped at
+`_MAX_OUTPUT_CHARS` = 256k, `runtime.py:54`, `runtime.py:234`). The invariant
+agents must respect: a synchronous blocking call freezes the whole loop; wrap it
+in `await asyncio.to_thread(...)` or use an async API. A blocked cell is rescued
+by the SIGUSR2 watchdog (`runtime.py:2744`, raised inline at the blocked frame
+because a task-cancel never breaks a synchronous call).
+
+## Job (`runtime.py:187`)
+
+`Job` is the awaitable handle over the task. State: `id` (8-hex), `code`, `name`
+(defaults to `id`), `kind` (`cell`/`replay`), `status`, `started`/`ended`,
+`budget`, `line` (live executing line, sampled off the suspended coroutine chain
+by `_current_line`, `runtime.py:1117`), `error_line`, `_result`. Public surface
+agents drive with more `python_exec`:
+
+- inspect/control: `running()`, `done()`, `ok()`, `cancel()`, `wait(timeout)`,
+  `await job` (`runtime.py:325-391`); `result` raises while still running rather
+  than return a misleading `None` (`runtime.py:345`).
+- paging (`runtime.py:259-316`): `output` (full stdout), `tail(n)`, `head(n)`,
+  `slice(a,b)`, `lines(a,b)` (numbered), `grep(pattern, ctx)`. These operate on
+  `pageable` (stdout, else the result's model text), so the truncation notices in
+  `tools.python_exec` reach a big returned value too.
+
+`history(n)` (`runtime.py:2478`) lists recent runs; `doc(obj)` returns an object's
+signature + docstring as a `Result` (`runtime.py:1922`).
+
+## Result (`runtime.py:442`)
+
+`Result` is the opt-in split of a cell value into the human view (`user_html`,
+rendered on the dashboard) and the model view (`llm_result` text plus
+`llm_images`), carried as a mime bundle: `text/html` for the human, the internal
+`application/x-ix-llm+json` for the model, `text/plain` as a fallback
+(`runtime.py:471-474`). Shortcuts: `Result.text(s)` (same text both ways),
+`Result.ok(msg)` (a quiet confirmation), `Result.of(value)` (render any value
+richly for the human, concise text to the model; a polars DataFrame becomes the
+styled table for the human and compact untruncated CSV for the model,
+`runtime.py:528`). `Result(a, b, ...)` stacks several values each with its own
+view. `llm_images` accept bytes/base64/data-URI/matplotlib/PIL/path and are
+downscaled and re-encoded to fit `IX_MCP_IMAGE_MAX_DIM`/`IX_MCP_IMAGE_MAX_BYTES`
+(`runtime.py:1518`, `runtime.py:60-77`). A cell that never mentions `Result`
+still returns exactly what a notebook would (the trailing expression plus
+stdout).
+
+## cells and resources
+
+- `cells` (`runtime.py:826`, the `Cells` instance): the agent's curated highlight
+  reel the dashboard shows as the answer. `cells.add(value, title=, id=)`,
+  `set(key, value)`, `remove(key)`, `clear()`; `_sync()` (`runtime.py:932`)
+  mirrors the whole ordered set into the store's `cells` table on change.
+- `resources` / `Resource` / `register_resource` (`runtime.py:728-820`): live,
+  self-updating views (a running terminal, a custom widget) re-rendered to HTML
+  each flush tick. `_discover_tui_resources`/`_discover_vmkit_resources`
+  (`runtime.py:1751`, `runtime.py:1807`) auto-publish a `tui` terminal or a
+  `vmkit` guest display as a resource.
+
+## The flusher (`runtime.py:2058`)
+
+One throttled background loop (every 0.5s) persists each running job's output tail
+and live line to the store, re-renders live resources, syncs `cells`, and (in a
+session) fires a debounced namespace checkpoint. It is the single mechanism that
+makes the dashboard show in-flight work without ever touching the kernel from
+another process. See [dashboard](../dashboard/overview.md) and
+[sessions](../sessions/overview.md).
+
+## Discovery: `api()` and `introspect.py`
+
+`api(filter)` (`runtime.py:1939`) is the live catalog of every helper: the
+namespace builtins and each bundled module's public surface, each with its real
+signature (from live introspection, never copied prose) and a one-line summary,
+returned as a polars DataFrame to filter. The catalog is built from `registry.py`
+(`_api_rows`, `runtime.py:1850`) so a module declared there shows up in `api()`,
+gets pre-imported if marked, and is listed in the server instructions, with no
+signature duplicated anywhere. `introspect.py` backs the dashboard's namespace
+pane and inlay hints: `describe(value)` (`introspect.py:143`), `namespace_rows`
+(`introspect.py:230`), and `cell_bindings(code, ns)` (`introspect.py:59`) snapshot
+each variable's live value, type, and shape.
+
+## The bundled-module registry (`registry.py`)
+
+`registry.py` is the single source of truth for what the kernel offers: `MODULES`
+(first-party bundled modules catalogued by `api()`, with `preimport` and optional
+`credential`), `BUILTINS` (names always present: `Result`, `cells`, `jobs`,
+`history`, `doc`, `resources`, `register_resource`, `sh`, `api`, `asyncio`,
+`json`, `pl`, `DASHBOARD_URL`), and `LIBRARIES` (bundled third-party libs:
+numpy, polars, duckdb, httpx, matplotlib, pypdf, playwright, exa_py). `fff` and
+`view` are pre-imported (`registry.py:62-73`). Credentialed entries declare an
+external service, env vars, token path, and remedy used by `requirements.py` and
+the instructions: `search` (Mixedbread), `google_auth` (Google), `slack` (Slack),
+`linear` (Linear), `exa_py` (Exa). Per-provider detail is in
+[tool-providers](../tool-providers/overview.md).
+
+## Session entrypoints
+
+`__ix_snapshot`/`__ix_restore`/`__ix_run`(`kind="replay"`) and the per-MCP-session
+namespaces (`_session_ns`, `runtime.py:2400`) implement the persistent notebook;
+they are documented in [sessions](../sessions/overview.md).

--- a/docs/mcp/server/overview.md
+++ b/docs/mcp/server/overview.md
@@ -1,0 +1,172 @@
+# mcp server
+
+The server is the host process: the `ix-mcp` CLI, the one kernel it manages, the
+MCP transport, the three MCP tools, and the generated instructions a client reads
+at `initialize`. It does not run user code itself: it forwards each call into the
+single ipykernel where the [runtime](../runtime/overview.md) executes it, then
+renders the kernel's reply back over MCP. The in-process plumbing is a frozen
+`Config` (`config.py`) decided once by the CLI and read by every other module.
+
+## Entrypoint and CLI (`cli.py`)
+
+`python -m ix_notebook_mcp` runs `cli.main` (`__main__.py:5`, `cli.py:45`). The
+Nix wrapper adds `-m ix_notebook_mcp` for the `ix-mcp` binary and
+`-m ix_notebook_mcp notebook` for the `ix-notebook` binary (see [build](#build)).
+Subcommands (`cli.py:49-81`):
+
+| command | what it does |
+| --- | --- |
+| `serve` | run the MCP server (default command, `cli.py:84`). `--http [ADDR]` serves streamable HTTP instead of stdio; `--session FILE` makes the store a persistent notebook; `--workdir DIR` sets the kernel cwd. |
+| `notebook [FILE]` | the engine alone (kernel + dashboard + optional session file, no MCP transport); `transport="none"` (`cli.py:294`). The same engine the MCP server is one client of. |
+| `dashboard` | print and open the running server's dashboard URL, read from `runtime_dir()/dashboard-url` (`cli.py:546`). |
+| `requirements` | report each external credential as present (and from where) or missing (and the remedy); exits non-zero if any is missing (`cli.py:89`). See [requirements](#credentials-requirements). |
+| `eval EXPR` / `exec SRC` | run one expression/statements on a throwaway kernel via `jupyter_client.start_new_kernel` (`cli.py:557`); not the shared kernel. |
+
+`_serve` (`cli.py:286`) resolves everything before the kernel spawns: the
+dashboard bind host (`IX_MCP_HOST`, else the Tailscale IPv4 when up, else
+loopback, probed for bindability and degraded to `127.0.0.1` if unbindable,
+`cli.py:321-334`), the data-API port (`IX_MCP_DASHBOARD_PORT` or a free port,
+`cli.py:145`), the Loro hub port (`cli.py:382`), the store path, and the session
+mode. It builds the frozen `Config`, sets `IX_MCP_STORE`/`IX_MCP_DASHBOARD_URL`/
+`IPYTHONDIR` in the environment the kernel inherits (`cli.py:406-411`), then
+`asyncio.run(_run(cfg))`.
+
+`_run` (`cli.py:471`) is the lifecycle: start the kernel, set it as the global
+kernel, optionally restore a session (holding the shell channel until the restore
+locks it so later calls queue behind it, `cli.py:480-499`), start the dashboard
+data API, spawn the Loro hub and the pane bridge, bake the live URL into the
+instructions (`tools.set_dashboard_url`), then `transport.serve()`. On exit it
+checkpoints the session, cleans up the runner, and shuts the kernel down.
+
+## Transports (`transport.py`)
+
+stdio is what MCP clients launch and the default. The CLI dups the real
+stdin/stdout to private fds and points fd 0/1 at `/dev/null`+stderr first
+(`cli.py:299-306`), so nothing else can corrupt the JSON-RPC stream;
+`_serve_stdio` hands the low-level `mcp` server those private fds
+(`transport.py:25`). `--http` selects `mcp.run_streamable_http_async()` bound to
+`mcp_http_host:port` (default `127.0.0.1:8000`, `transport.py:39`). The transport
+serves the FastMCP server `mcp` from `tools.py`.
+
+## Kernel manager (`kernel.py`)
+
+`Kernel` owns the one `AsyncKernelManager(kernel_name="python3")` and its client
+(`kernel.py:78`). `python_exec` wraps the user code as
+`await __ix_exec(<code repr>, budget=..., name=..., session=...)` and runs it with
+`timeout = budget + wedge_grace` (`kernel.py:204-211`). `_execute`
+(`kernel.py:132`) holds one `asyncio.Lock`, shields the `execute_interactive`
+task from client-side cancellation (a cancel mid-reply would desync the shared
+shell socket and hang every later call, `kernel.py:154-183`), and collects the
+IOPub outputs plus the runtime's structured job summary (`outputs.job_summary`).
+
+Two rescue paths for a wedged kernel (a cell blocking the event loop with a
+synchronous call):
+
+- `kernel_trace` -> `dump_trace` (`kernel.py:103`) sends `SIGUSR1` to the kernel
+  pid; the runtime's faulthandler writes an all-thread stack to the
+  `IX_MCP_KERNEL_TRACE` file even while the loop is frozen, and the newest dump is
+  returned.
+- A `TimeoutError` past `budget + wedge_grace` -> `_interrupt` (`kernel.py:216`)
+  sends `SIGUSR2`, which the runtime handler turns into an inline
+  `KeyboardInterrupt` at the blocked frame (a plain task-cancel cannot break a
+  synchronous call), and the call returns an actionable `_wedged_summary`
+  (`kernel.py:33`).
+
+`restore_session`/`snapshot_session` (`kernel.py:233`, `kernel.py:242`) drive the
+session machinery; see [sessions](../sessions/overview.md).
+
+## MCP tools (`tools.py`)
+
+The FastMCP server is `mcp = FastMCP("ix-mcp")` (`tools.py:75`); its
+`serverInfo.version` is stamped from `IX_MCP_VERSION` (the flake rev) onto the
+low-level server (`tools.py:197`). Three tools, all with
+`structured_output=False` so FastMCP does not duplicate the reply as
+`structuredContent` (which doubled image blocks and blew the token cap,
+`tools.py:202-207`):
+
+- `python_exec(code, budget=15.0, intent=None)` (`tools.py:219`): clamps `budget`
+  to `config().max_budget`, calls `current_kernel().python_exec(...)`, renders the
+  kernel outputs with `outputs.to_mcp`, and appends notices when the budget was
+  clamped or the reply was truncated (pointing the caller at `jobs['<id>']` paging
+  helpers). `intent` is the run's human-facing title in the dashboard feed.
+- `read(target, start=None, end=None)` (`tools.py:289`): pulls a file or a kernel
+  value into the model's context via `await __ix_read(...)` while the dashboard
+  shows only a one-line note, so a large file does not flood the human's view.
+- `kernel_trace()` (`tools.py:315`): the out-of-band stack dump for a wedged
+  kernel.
+
+The first tool call of a session pops the dashboard in the human's browser once
+(`_open_dashboard_once`, `tools.py:162`; disabled by `IX_MCP_NO_BROWSER=1`).
+
+### Generated instructions
+
+`_compose_instructions` (`tools.py:133`) builds the server `instructions` from
+the authored `guide.py` fragments (`_KERNEL_GUIDE`, `tools.py:54`), a per-tool
+overview derived from the registry (`_tools_overview`, `tools.py:123`), and the
+live dashboard URL once it is bound (`set_dashboard_url`, `tools.py:144`). The
+bundled-module index and the credentialed-services sentence come from
+`registry.py` via `guide.modules_index()`/`guide.credentials_note()`, so every
+tool and module is described in exactly one place. Fragment ORDER is deliberate:
+clients truncate long instruction blocks from the tail, so the rules that shape
+every call come first and operational mechanics follow (`tools.py:47-53`).
+
+## Configuration (`config.py`)
+
+`Config` is a frozen dataclass set once via `set_config` and read with `config()`
+(`config.py:104-115`). Key fields: `workdir`, `host`/`advertised_host`,
+`dashboard_port`/`hub_port`, `store_path`/`session_path`/`session_resume`,
+`transport`, `mcp_http_host`/`port`, `stdin_fd`/`stdout_fd`, `exec_token`/
+`exec_trust_network` (gating `/api/exec`), `wedge_grace=15.0`, `max_budget=120.0`.
+`resolve` rejects a path that escapes `workdir` (`config.py:96`). `runtime_dir()`
+(`config.py:118`) is a hardened 0700 dir under `XDG_RUNTIME_DIR`/`TMPDIR`/`/tmp`
+holding the store and the `dashboard-url` handoff (CWE-377 checks).
+
+Environment variables the server reads: `IX_MCP_HOST`, `IX_MCP_PUBLIC_HOST`,
+`IX_MCP_DASHBOARD_PORT`, `IX_MCP_HUB_PORT`, `IX_MCP_STORE`, `IX_MCP_SESSION`,
+`IX_MCP_NO_BROWSER`, `IX_MCP_EXEC_TOKEN`(`_FILE`), `IX_MCP_EXEC_TRUST_NETWORK`,
+`IX_MCP_VERSION`, `IX_MCP_DASHBOARD_URL`, `IX_MCP_KERNEL_TRACE`, plus output caps
+read in [runtime](../runtime/overview.md) and `outputs.py`
+(`IX_MCP_MAX_RESULT_CHARS`, `IX_MCP_IMAGE_MAX_BYTES`, `IX_MCP_IMAGE_MAX_DIM`).
+
+## Output rendering (`outputs.py`)
+
+`output_from_message` turns IOPub messages into nbformat output dicts
+(`outputs.py:56`); `to_mcp` renders them as MCP content blocks for the agent
+(`outputs.py:71`): real image blocks for plots, a `Result`'s explicit model view
+from the `application/x-ix-llm+json` bundle, and text clipped to `MAX_TEXT_CHARS`
+(default 50k, `outputs.py:26`) as a head+tail preview that points at paging. The
+internal job summary (`application/x-ix-job+json`, `outputs.py:47`) is pulled out
+separately by `job_summary` and never shown as content. Oversize images are
+dropped with a note rather than dumped as base64 (`outputs.py:131`).
+
+## Credentials (`requirements.py`)
+
+`statuses()` probes every credential declared in `registry.credentialed()`
+locally (env vars and token-file existence only, never the value or the network,
+`requirements.py:44`). `report(emit)` prints one line each and returns whether
+all are present (`requirements.py:82`). Three fail-fast consumers: `ix-mcp serve`
+yells on stderr at startup (`cli.py:430`), the `requirements` subcommand turns the
+bool into its exit code, and the instructions name the credentialed modules.
+
+## Build (`default.nix`)
+
+`default.nix` builds the pinned interpreter with `pkgs.python3.withPackages`
+(`default.nix:893`), bundling the data libraries (numpy, polars, duckdb, httpx,
+matplotlib, pypdf), the execution engine (`ipykernel`, `jupyter-client`,
+`nbformat`, `aiohttp`, the `mcp` SDK, `dill`, `ray`, a Spark Connect `pyspark`,
+`playwright`, `htpy`, `ansi2html`), and every first-party module as a
+`toPythonModule` (`ix_notebook_mcp` plus each `src/<module>`, and cdylib modules
+`tui`/`search`/`astlog`/`scipql`/`flecs_query`/`fff`/`ix_google` bundled from
+other packages). `makeWrapper` then emits two binaries (`default.nix:918-948`):
+
+- `ix-mcp` (`mainProgram`): `<interpreter> -m ix_notebook_mcp`, with
+  `IX_MCP_VERSION` (flake rev), `PLAYWRIGHT_BROWSERS_PATH`, `IX_GCAL_BIN`
+  (the `gcal` binary), `IX_DASHBOARD_BIN` (the `dashboard` hub binary),
+  `SCIPQL_SOUFFLE`, and on Darwin `IX_VMKIT_BIN`.
+- `ix-notebook`: the same interpreter entered at the `notebook` subcommand.
+
+Flake output: `nix run .#mcp -- serve` / `nix build .#mcp` (`package.nix:2-4`).
+`passthruTests = true` (`package.nix:5`) wires the in-`default.nix` import and
+behavior smoke tests (e.g. `serverTools`, `runtimeSmoke`, `sessionSmoke`,
+`feedSmoke`, per-module `*Bundled`/`*Smoke`) as passthru checks
+(`default.nix:4220-4275`).

--- a/docs/mcp/sessions/overview.md
+++ b/docs/mcp/sessions/overview.md
@@ -1,0 +1,109 @@
+# mcp sessions and the store
+
+Two related concerns: the SQLite execution store every run is written to
+(`store.py`), and the `--session` mode that turns that one file into a reopenable
+notebook whose namespace comes back (`runtime.py` checkpoint/restore +
+`cli.py`/`kernel.py` wiring). The store is the single source of truth the
+[runtime](../runtime/overview.md) writes and the [dashboard](../dashboard/overview.md)
+reads; the session machinery layers durability and replay on top of it.
+
+## The store (`store.py`)
+
+One append-only SQLite file at `IX_MCP_STORE`, opened in WAL mode with a
+`busy_timeout` so a reader never blocks the writer and sees in-flight rows
+(`store.py:77-92`). Single-writer by contract: the kernel process owns all
+writes, the dashboard and embedders only read (`store.py:1-11`). A `None` path is
+rejected explicitly so it cannot silently create a file named `None`
+(`store.py:85`). `_migrate` (`store.py:95`) adds columns introduced after a store
+was first created, idempotently (two processes can race the `ALTER`).
+
+Tables (`store.py:24-74`):
+
+| table | purpose | key columns |
+| --- | --- | --- |
+| `executions` | every `python_exec` run | `id`, `name`, `code`, `status`, `started_at`/`ended_at`, `budget`, `output`, `result`, `error`, `line`, `error_line`, `outputs` (rich mime bundles), `bindings`, `kind` (`cell`/`replay`), `namespace` |
+| `snapshots` | namespace checkpoints (only the newest kept) | `created_at`, `blob` (dill), `names`, `skipped` |
+| `cells` | the agent's curated presentation reel | `id`, `title`, `position`, `outputs`, `updated_at` |
+| `resources` | live self-updating views | `id`, `title`, `kind`, `html`, `status` (`live`/`closed`), timestamps |
+
+Write API: `start` (`store.py:132`), `update_output` (a running job's live output
+tail + current `line` + rich outputs, `store.py:154`), `finish` (final status,
+result, error, rich outputs, bindings, namespace, `store.py:178`), `rename`,
+`replace_cells` (one transaction, `store.py:290`), `upsert_resource`/
+`close_resource`. Read API: `recent` (running jobs pinned first so a long run is
+never dropped by the LIMIT, `store.py:230`), `get`, `latest_namespace`
+(the newest finished run's globals, `store.py:243`), `cells`, `live_resources`.
+
+## Ephemeral vs session
+
+An ephemeral server (no `--session`) wipes its store plus the `-wal`/`-shm`
+sidecars at startup so a leftover database never shows stale runs (`cli.py:373-378`).
+The store path is `IX_MCP_STORE` if pinned (an embedder like the pi-harness room
+mapper pins it so both sides agree on one file, `cli.py:156`), else a per-port
+file in the private runtime dir (`store-<dashboard_port>.db`) so concurrent
+servers never collide.
+
+`--session FILE` (or the standalone `notebook FILE`) makes that file the durable
+store, kept across restarts (`cli.py:336-368`). It refuses to combine with a
+pinned `IX_MCP_STORE` rather than guess which contract was meant (`cli.py:340`).
+Reopening an existing file first marks any rows left `running` by a dead server as
+`interrupted` and closes live resources (`store.mark_interrupted`, `store.py:417`).
+The runtime keys session behavior on `IX_MCP_SESSION=1` (`runtime.py:2103`).
+
+## Checkpoint (`runtime.py` snapshot path)
+
+In a session the flusher debounces a namespace checkpoint after cells finish
+(`_mark_snapshot_dirty` -> `_snapshot_tick`, at most one per
+`_SNAPSHOT_MIN_INTERVAL` = 5s, `runtime.py:2078`, `runtime.py:2117`). A checkpoint
+serializes per-name with `dill` (`runtime.py:2131`) so functions and classes
+defined in cells survive where stdlib `pickle` cannot. `_snapshot_candidates`
+(`runtime.py:2186`) covers only names a user bound after the `install()` baseline;
+modules, underscore names, and values no serializer can carry (open sockets, live
+jobs, terminals) are skipped and reported, and a single value over
+`_SNAPSHOT_MAX_VALUE_BYTES` (64 MB, `runtime.py:2122`) is skipped so the file
+cannot balloon. `save_snapshot` writes the new row and prunes older ones in one
+transaction, so the file holds exactly one checkpoint (`store.py:377`). The server
+takes one final checkpoint on shutdown via `kernel.snapshot_session` so the last
+cells' state reopens instantly (`cli.py:538-541`).
+
+Failure is self-healing by construction: a checkpoint that fails to save leaves
+the previous one in place, and replay (below) covers everything since it
+(`runtime.py:2091-2093`).
+
+## Restore (`runtime.py:2305`, `__ix_restore`)
+
+On reopen the server runs `await __ix_restore()` while holding the shell channel,
+so every tool call submitted later queues behind it and the first new cell always
+sees the restored state (`cli.py:480-499`, `kernel.py:233`). `_restore_body`
+(`runtime.py:2321`):
+
+1. Load the latest checkpoint and `dill`-load each name into the namespace
+   (instant state); a checkpoint that fails to decode falls back to replaying the
+   full log.
+2. `store.replayable(since)` (`store.py:436`) returns the original
+   (`kind='cell'`) successful cells that finished AFTER the checkpoint's
+   `created_at`, oldest first, and re-runs each with `kind="replay"` and a
+   `_REPLAY_BUDGET` of 600s (`runtime.py:2302`, `runtime.py:2353`). Replay rows are
+   excluded from future replay sets so a session never double-runs its history.
+   The anchor is `ended_at` (not `started_at`) so a cell mid-run at checkpoint
+   time re-runs and overwrites its partial state (`store.py:444-447`).
+3. Take one fresh checkpoint folding in the replayed state, so the NEXT reopen is
+   all-instant (`runtime.py:2362`).
+
+`__ix_restore` prints a summary (names restored, not-in-checkpoint, load
+failures, cells replayed, replay failures) to the server log, not a job buffer
+(`runtime.py:2377`). The replaying flag (`_restoring`) blocks the debounced
+checkpoint mid-restore so the anchor cannot advance past not-yet-replayed cells
+(`runtime.py:2108-2113`).
+
+## Per-MCP-session namespaces
+
+Distinct from session FILES: the HTTP transport multiplexes several MCP clients
+onto the one kernel, so each client session gets its own globals dict keyed by the
+session id the server passes through `__ix_exec` (`_session_ns`,
+`runtime.py:2400`). Each is seeded from the shared baseline (the helper surface)
+but isolates name bindings so parallel agents do not clobber each other; the
+helper OBJECTS (`jobs`/`cells`/`resources`) stay shared so the dashboard and
+cross-session paging keep working. The stdio transport serves one client per
+process and uses the shared namespace, which is also what session
+checkpoint/restore covers (`tools.py:82-110`).

--- a/docs/mcp/task-graph/overview.md
+++ b/docs/mcp/task-graph/overview.md
@@ -1,0 +1,73 @@
+# task-graph
+
+`packages/mcp/task-graph` is a standalone Vite + Svelte demo: an interactive
+force-directed visualization of a ~100-node task dependency DAG in the Obsidian
+graph-view style. It is the showcase for a tidy data-flow pattern, one schema and
+one generator with two independent consumers: the Python
+[`tasks`](../tool-providers/overview.md) module (a bundled provider) generates a
+DAG into a real SQLite file, and the website reads that very file in the browser.
+It is a demo, not part of the running server: it is run separately via npm and is
+not built by [`default.nix`](../server/overview.md#build).
+
+## The data: `tasks` (`packages/mcp/src/tasks/tasks/__init__.py`)
+
+`tasks` generates and reads a deliberately tiny, acyclic dependency graph and is
+the single source of truth for the demo's data (`tasks/__init__.py:1-7`). Public
+surface:
+
+- `generate(count, seed)` (`tasks/__init__.py:151`): a deterministic DAG where a
+  task only depends on tasks defined before it, so edges never form a cycle.
+- `status_of(task, by_id)` (`tasks/__init__.py:216`): derive `done`/`blocked`/
+  `in-progress`/`ready` from whether a task's dependencies are complete, the same
+  rule the website colors nodes by.
+- `write`/`read` (`load`) (`tasks/__init__.py:244`, `tasks/__init__.py:270`):
+  persist/load the DAG to/from SQLite.
+- `seed(path, count, seed)` (`tasks/__init__.py:303`): generate and write in one
+  call (default `tasks.sqlite`).
+- `frame(source)` (`tasks/__init__.py:308`): a polars DataFrame with derived
+  status, rendered as a styled table in the MCP dashboard.
+
+The schema (`tasks/__init__.py:227`, `SCHEMA`) is two tables: `tasks`
+(`id`, `title`, `category`, `estimate`, `complete`, `active`) and `deps`
+(`task_id`, `depends_on`). It is pure stdlib at the core (`sqlite3`,
+`dataclasses`); `polars` is imported lazily only for `frame`, so `import tasks`
+works as a plain module outside the MCP kernel too.
+
+Regenerate the committed asset with:
+
+```sh
+python3 -c 'import tasks; tasks.seed("public/tasks.sqlite")'
+```
+
+## The site (`packages/mcp/task-graph`)
+
+The website reads `public/tasks.sqlite` in the browser via sql.js (a WASM build
+of SQLite), so that one file is the contract between the two languages
+(`src/lib/db.ts:1-3`). `loadTasks(url)` (`src/lib/db.ts:16`) fetches the asset and
+runs `SELECT ... FROM deps` and `SELECT ... FROM tasks` against the in-browser
+database, mirroring `tasks.SCHEMA`; the model is mirrored in `src/lib/types.ts`.
+
+Layout:
+
+| path | role |
+| --- | --- |
+| `index.html`, `src/main.ts`, `src/App.svelte` | the app shell and entry |
+| `src/lib/db.ts` | load the DAG from `tasks.sqlite` via sql.js |
+| `src/lib/types.ts` | the `Task`/`Category` model mirrored from `tasks.SCHEMA` |
+| `src/lib/TaskGraph.svelte` | the `force-graph` + d3 collision-force visualization |
+| `public/tasks.sqlite` | the committed data asset produced by `tasks.seed` |
+| `vite.config.ts`, `svelte.config.js`, `tsconfig.json`, `package.json` | the Vite/Svelte build config |
+
+Run it separately (`task-graph/README.md`): `npm install`, then `npm run dev`
+(dev server), `npm run build` (type-check + production bundle), or
+`npm run preview`. Interaction: color nodes by status or category, hover/select a
+node to fade connected tasks by BFS hop-distance, toggle a layered DAG layout, and
+search to jump to a node.
+
+## Relation to the rest of the package
+
+This component is independent of the running server: the `tasks` provider is one
+of many [tool-providers](../tool-providers/overview.md) (it appears in `api()` and
+the instructions like any other), and the site is a static front end over its
+output. It does not touch the [kernel](../runtime/overview.md), the
+[store](../sessions/overview.md), or the [dashboard hub](../dashboard/overview.md).

--- a/docs/mcp/tool-providers/overview.md
+++ b/docs/mcp/tool-providers/overview.md
@@ -1,0 +1,87 @@
+# mcp tool providers
+
+The providers under `packages/mcp/src` are the bundled Python modules an agent
+imports inside a `python_exec` cell to get a capability: search, shell, browser,
+fleet, calendar, git worktrees, and more. There is no MCP tool per provider; the
+[one general tool](../server/overview.md) plus the import-in-a-cell model means a
+provider is reached the same way any Python is. Each provider is its own package
+baked into the pinned interpreter by [`default.nix`](../server/overview.md#build),
+so it imports with no `pip`/`uv install` step.
+
+## Architecture
+
+- One registry, generated surface. A first-party provider is declared once in
+  [`registry.py`](../runtime/overview.md#the-bundled-module-registry-registrypy)
+  with a tagline and optional credential. That single row feeds the live `api()`
+  catalog (signatures come from introspection, never copied prose), the
+  startup pre-import list (`fff`, `view`), and the server instructions
+  (`guide.modules_index()`). Adding a row lists the module everywhere with no
+  drift.
+- Two return audiences. Providers follow the kernel's `Result` contract: a human
+  watching the dashboard gets a rich render (a styled polars table, a
+  syntax-highlighted file, ANSI color as HTML) while the model gets concise text.
+  `sh` returns an `Output` that IS a `Result`; `view`/`fff`/`nix`/`fleet` return
+  polars frames the global `_repr_html_` renders. See
+  [runtime](../runtime/overview.md#result-runtimepy442).
+- Async where it touches the network or a subprocess. The kernel is one shared
+  event loop, so anything that would block (`ssh`, HTTP, a child process) is
+  `async def` and awaited, or runs off-loop via `asyncio.to_thread`. `sh`,
+  `fleet`, `slack`, `linear`, `x`, `browser`, `nix`, `worktree`, `mcp_client` are
+  async; `fff`/`view` are sync-but-fast (a cached, file-watching index).
+- Credentials are declarative and fail-fast. A credentialed provider's env/token
+  sources are declared in `registry.py` and probed by
+  [`requirements.py`](../server/overview.md#credentials-requirements); a call with
+  a missing credential fails immediately with the remedy.
+- Incognito gate. Providers that reach a personal account (`google_auth`,
+  `slack`, `x`) refuse to run in a shared (multiplayer) room: the room marks its
+  shared MCP with `IX_MCP_SHARED=1` and the provider raises rather than leak
+  personal data into a shared transcript.
+
+## Providers (`packages/mcp/src`)
+
+| provider | what it does | key entrypoints | notes |
+| --- | --- | --- | --- |
+| [`fff`](../../../packages/mcp/src/fff/fff/__init__.py) | typo-tolerant fuzzy file find + SIMD content grep over an in-memory index, bound to the `fff-c` cdylib via ctypes | `find`, `grep`, `tree`, `map` (+ async `afind`/`agrep`/`atree`/`amap`), `FileFinder` | pre-imported; results are dataclasses with a `.df` polars frame; cdylib from `packages/fff` |
+| [`view`](../../../packages/mcp/src/view/view/__init__.py) | pretty composable file/listing/search views: directories as polars frames, files as syntax-highlighted renders | `ls`, `tree`, `cat`/`read`, `head`, `tail`, `json`, `diff`, `edit`, `img` | pre-imported; installs the global `DataFrame._repr_html_` (`df_html`) every frame renders through |
+| [`sh`](../../../packages/mcp/src/sh/sh/__init__.py) | run a shell command on the async loop, rendered two ways | `await sh(cmd)` -> `Output` (a `Result`); `.text`/`.code`/`.ok`, `.json()`/`.jsonl()`/`.df()` | a builtin (pre-bound, no import); ANSI color captured to HTML for the human, stripped for the model; process-group kill on timeout |
+| [`nix`](../../../packages/mcp/src/nix/nix/__init__.py) | parse a `nix --log-format internal-json` stream into polars and a live build DAG | `run`, `build`, `attrs`, `eval`, `parse`; `NixLog.events`/`.activities` | pure Python over polars; publishes a live build-DAG dashboard resource |
+| [`fleet`](../../../packages/mcp/src/fleet/fleet/__init__.py) | the tailnet as one cluster: SSH fan-out, Ray, Spark Connect, and a peer's live kernel | `scan`/`read_text`/`read_ndjson`; `nodes`/`run`/`submit`/`get`/`put`/`in_kernel`/`spark` (`cluster.py`) | all async; drives Ray + Spark Connect; `in_kernel` calls a peer's `/api/exec` |
+| [`browser`](../../../packages/mcp/src/browser/browser/__init__.py) | drive a running browser over CDP with Playwright (debug port 9222 by default) | `get_or_create_browser`, `goto`, `shot`, `read`, `vdom`, `page`, `connect`, `close` | launches a VISIBLE, never-headless window; publishes a live page resource; `vdom()` is a filtered virtual DOM map |
+| [`x`](../../../packages/mcp/src/x/x/__init__.py) | read recent X (Twitter) posts into polars by driving the signed-in browser over CDP | `await x.posts(source)` (home, `@handle`, `#tag`, notifications, a thread URL) | reuses `browser`'s CDP connection; incognito only |
+| [`worktree`](../../../packages/mcp/src/worktree/worktree/__init__.py) | git worktrees as the unit of isolated/parallel work | `add`, `remove`, `prune`, `list`; `Worktree.build`/`sh`/`commit`, `wt / "path"` | async git; `build` runs `git add -A` first so new files are seen by `nix build` |
+| [`mcp_client`](../../../packages/mcp/src/mcp_client/mcp_client/__init__.py) | call any other MCP server's tools from a cell | `await connect(url_or_command)` -> `Server`; `srv.tools` (frame), `await srv.call(tool, **args)`, `close` | thin wrapper over the `mcp` SDK; stdio + streamable-HTTP/SSE; bearer/header auth + interactive OAuth 2.0 PKCE with cached tokens (`_oauth.py`) |
+| [`google_auth`](../../../packages/mcp/src/google_auth/google_auth/__init__.py) | Gmail + Calendar for the user's own account via the official googleapiclient | `await login()`, `gmail()`, `calendar()`, `credentials()`, `status()`, `logout()` | credential: Google (token `~/.config/google/token.json` minted by the `gcal` binary, `IX_GCAL_BIN`); incognito only |
+| [`slack`](../../../packages/mcp/src/slack/slack/__init__.py) | read Slack channels/DMs/threads to polars, send, search | `channels`, `dms`, `messages`, `thread`, `send`, `search`; `login`/`status`/`logout` | credential: Slack (`SLACK_USER_TOKEN`/`SLACK_TOKEN` or `~/.config/slack/token`); incognito only |
+| [`linear`](../../../packages/mcp/src/linear/linear/__init__.py) | Linear issue tracker over GraphQL | `issue`, `issue_update`, `issue_create`, `project_create`, `issue_search`, `comment_create` | credential: Linear (`LINEAR_API_KEY`); `triage.py` is a source-agnostic dedup/triage core (`Finding`, `TriageConfig`, `triage`) |
+| [`nox_autotriage`](../../../packages/mcp/src/nox_autotriage/nox_autotriage/__init__.py) | convert a nox conformance JSON report into deduped Linear issues via `linear.triage` | `findings_from_conformance`, `config_from_env`, `run`; `python -m nox_autotriage --report PATH` | a CI/Symphony CLI, not a kernel helper (not in the registry); `DRY_RUN=1` default |
+| [`tasks`](../../../packages/mcp/src/tasks/tasks/__init__.py) | generate/read the task-graph demo's SQLite dependency DAG | `seed`, `load`, `frame`, `generate`, `status_of`, `read`/`write`, `SCHEMA` | the data generator for the [task-graph](../task-graph/overview.md) site |
+| [`screen`](../../../packages/mcp/src/screen/screen/__init__.py) | native macOS desktop control via CoreGraphics | `capture`, `cursor`, `move`, `click`, `drag`, `write`, `press`, `apps`, `frontmost`, `activate`, `launch`, `terminate` | macOS only; synthetic input needs Accessibility permission |
+| [`vmkit`](../../../packages/mcp/src/vmkit/vmkit/__init__.py) | boot and drive a guest VM fully off-screen and screenshot its display | `info`, `install`, `screenshot`, `boot_linux`, `Driver`, `drive`, `run_app`/`run_binary`/`run_oci` | macOS only; needs the `vmkit` binary (`IX_VMKIT_BIN`); a booted `Driver` is a live dashboard resource |
+| [`imessage`](../../../packages/mcp/src/imessage/imessage/__init__.py) | read Messages + Contacts into polars and send iMessages | `messages`, `chats`, `contacts`, `send`, `add_contact`/`update_contact`/`delete_contact` | macOS only; reads `~/Library/Messages/chat.db` and the AddressBook DB |
+
+## Bundled from other packages
+
+The kernel namespace also exposes modules the registry lists but `packages/mcp`
+does not own; they are baked into the same interpreter from their home packages:
+`tui` (PTY driver, `packages/tui-py`), `search` (semantic recall over the fleet
+corpus, `packages/search-py`; credential: Mixedbread), and `astlog`/`scipql`/
+`flecs_query` (the [code-intel](../../code-intel/astlog/overview.md) family). The
+third-party libraries `numpy`/`polars`/`duckdb`/`httpx`/`matplotlib`/`pypdf`/
+`playwright`/`exa_py` (credential: Exa) are import-ready too. These are documented
+in their own domains; this page owns only the `packages/mcp/src` providers above.
+
+## Provider groups
+
+- Data and code: `fff`, `view`, `nix` (and bundled `search`, `astlog`,
+  `scipql`/`flecs_query`) keep an agent off `ls`/`cat`/`grep`/`rg` and on
+  composable polars frames and syntax-highlighted views.
+- Distributed: `fleet` is the one cluster surface (Ray for distributed Python,
+  Spark Connect for big-data SQL, SSH fan-out, peer live-kernel peek). See the
+  fleet deployment note in [common](../common.md).
+- Workflow: `sh`, `worktree`, `mcp_client` run shells, isolate risky work on a
+  throwaway branch, and call other MCP servers.
+- Accounts (incognito only): `google_auth`, `slack`, `x`.
+- macOS native: `screen`, `vmkit`, `imessage` drive the desktop, a guest VM, and
+  Messages; `browser`/`x` drive a browser cross-platform.
+- Triage: `linear` + its `triage` core + the `nox_autotriage` CI adapter file
+  conformance regressions as deduped Linear issues.

--- a/docs/media/common.md
+++ b/docs/media/common.md
@@ -1,0 +1,132 @@
+# media
+
+Recording, screen capture, and audio for index: the tools that turn a terminal
+session, a Mac desktop, a remote noise generator, or a line of text into a
+playable media stream or file. Four of the five drive [ffmpeg](#glossary) as the
+codec engine; none implement their own video or audio codec. The domain spans
+one capture/encode/serve pipeline (screencast client to screencast-ingest
+server) plus three standalone CLIs (a terminal-reel recorder, a noise mixer, and
+a TTS speaker).
+
+Read this page first, then the component page for the unit you are changing. The
+[reel](reel/overview.md) recorder is also what generates the animated demo at
+the top of the repo `README.md` (`docs/demo-{dark,light}.{avif,webp}`), so it is
+the most load-bearing unit here.
+
+## Units
+
+| unit | kind | flake output | notes |
+| --- | --- | --- | --- |
+| `packages/reel` | Rust workspace crate, Nix wrapper | `.#reel` | records a terminal reel through the [tui](../terminal/tui/overview.md) PTY driver; wraps ffmpeg + the demoed CLIs |
+| `packages/screencast` | Rust workspace crate, Nix wrapper | `.#screencast` | macOS-only capture client; wraps ffmpeg (avfoundation + VideoToolbox) |
+| `packages/screencast-ingest` | Rust workspace crate, Nix package | `.#screencast-ingest` | cross-platform HTTP server; stores and serves HLS |
+| `packages/mynoise` | Rust workspace crate, Nix package | `.#mynoise` | streams and mixes myNoise.net band loops with rodio (no ffmpeg) |
+| `packages/elevenlabs-say` | Python uv app, Nix package | `.#elevenlabs-say` | `say`-style ElevenLabs TTS; wraps ffplay/ffmpeg for playback |
+
+All four Rust units are members of the root `Cargo.toml` workspace and build via
+`ix.cargoUnit.selectBinaryWithTests` (`packages/*/default.nix`). `elevenlabs-say`
+is a Python app built with `ix.buildUvApplication`
+(`packages/elevenlabs-say/default.nix:18`). Each package is discovered from its
+`package.nix` (`id` + `flake = true`); `screencast` advertises its flake/package
+outputs only on Darwin (`packages/screencast/package.nix:7-14`).
+
+## How it fits together
+
+```
+reel:         tui PTY grid ---> rasterize RGBA ---> ffmpeg ---> docs/demo-*.{avif,webp}
+screencast:   desktop --(avfoundation)--> hevc_videotoolbox --(fMP4 HLS)--> local scratch
+                  --(HTTP PUT /ingest/{user}/{session}/{file})--> screencast-ingest
+screencast-ingest:  PUT -> {root}/{user}/{session}/ ; GET -> playback (Safari/hls.js)
+mynoise:      mynoise.net/Data/<CODE>/<n>a.ogg --(cache)--> rodio decode+mix --> speakers
+elevenlabs-say:  text -> ElevenLabs convert / WebSocket --> mp3 --> ffplay / file
+```
+
+- **Capture vs encode vs serve.** Only screencast + screencast-ingest form a
+  client/server pipeline: the client captures and encodes, the server only
+  stores and serves (no transcode, the bytes the hardware encoder produced are
+  what land on disk, `packages/screencast-ingest/src/main.rs:15-16`). reel
+  captures a synthetic source (the terminal grid) and encodes to a file. mynoise
+  and elevenlabs-say only fetch+play; they neither encode nor serve.
+- **ffmpeg is the shared codec engine.** reel
+  (`packages/reel/src/encode.rs:103`), screencast
+  (`packages/screencast/src/main.rs:276`), and elevenlabs-say
+  (`apply_tempo`/`play`, `__init__.py:375,439`) all shell out to ffmpeg/ffplay,
+  put on PATH by their Nix wrappers (`makeWrapper ... --prefix PATH`). mynoise is
+  the exception: it decodes OGG/Vorbis and mixes in-process with `rodio`
+  (`packages/mynoise/src/audio.rs`).
+- **HLS is the transport between the two screencast units.** Fragmented-MP4 HLS
+  over plain HTTP: an `init.mp4` init segment, `seg_NNNNN.m4s` media segments,
+  and an `index.m3u8` playlist (`packages/screencast/src/main.rs:45-46,510-515`).
+  The client uploads only segments the local playlist already lists, and ships
+  the playlist last, so the server never advertises a segment that has not landed
+  (`packages/screencast/src/main.rs:376-405`).
+- **The filesystem is the screencast source of truth.** screencast-ingest tracks
+  nothing separately: the session list, live/complete state, and dashboard are
+  all derived from a directory scan (`scan_sessions`,
+  `packages/screencast-ingest/src/main.rs:335`). A session is `complete` once its
+  playlist carries `#EXT-X-ENDLIST` and `live` if written within 30s
+  (`LIVE_WINDOW_SECS`, `main.rs:42,424`).
+- **Auth is upload-only and optional.** Both screencast units take a bearer
+  `--token`/`SCREENCAST_TOKEN`; reads (playback, dashboard, `/api/sessions`) stay
+  open, writes are guarded (`check_auth`, `main.rs:201`). There is no transport
+  encryption; run behind a private network or tailnet.
+
+## Cross-component invariants
+
+- **No transcoding in the screencast path.** Segments are stored and served
+  byte-for-byte; content type is inferred from extension only
+  (`content_type`, `screencast-ingest/src/main.rs:149`). A session plays from the
+  same URLs it was uploaded to.
+- **Atomic writes for concurrently read files.** Both the client cache
+  (`mynoise/src/resolve.rs:137-141`) and the server upload path
+  (`screencast-ingest/src/main.rs:257-263`) write to a temp file then rename, so
+  a reader (a player polling the playlist, a re-run reusing a cache) never sees a
+  half-written file.
+- **Path components are sanitized at both ends.** The client folds unsafe chars
+  to `-` (`sanitize`, `screencast/src/main.rs:196`); the server independently
+  rejects any component that is not a safe plain name (`safe_component`,
+  `screencast-ingest/src/main.rs:139`), the sole guard between a client path and
+  a disk write.
+- **Secrets come only from the environment.** elevenlabs-say reads
+  `ELEVENLABS_API_KEY` and refuses to run without it (`make_client`,
+  `__init__.py:232`); there is no embedded key.
+
+## Glossary
+
+- **PTY grid / styled cell**: reel's capture source. The [tui](../terminal/tui/overview.md)
+  driver renders a VT100 screen to an `Array2<StyledCell>` (character + fg/bg +
+  bold/italic/underline/inverse), which reel rasterizes.
+- **ffmpeg / ffplay**: the external codec processes. ffmpeg encodes/transcodes;
+  ffplay is its headless player. Provided on PATH by the Nix wrappers.
+- **AVIF / WebP**: reel's two animated outputs. AVIF (AV1 in an AVIF container)
+  is primary and smallest; WebP is the broadly-supported, lower-frame-rate
+  fallback (`reel/src/encode.rs:22-28`).
+- **H.265 / HEVC**: the screencast video codec. `hevc_videotoolbox` is Apple's
+  hardware encoder; `hvc1` is the fMP4-compatible HEVC sample-entry tag
+  (`screencast/src/main.rs:482-489`).
+- **VideoToolbox / avfoundation**: macOS frameworks. VideoToolbox is the
+  hardware media engine ffmpeg uses to encode; avfoundation is the capture input
+  device (the screen is a `Capture screen N` device).
+- **HLS**: HTTP Live Streaming. A playlist (`.m3u8`) plus media segments. Here
+  segments are fragmented-MP4 (`fmp4`): one `init.mp4` plus `seg_NNNNN.m4s`.
+- **VOD / ENDLIST**: a finished session. ffmpeg writes `#EXT-X-ENDLIST` on a
+  clean exit, turning a live `event` playlist into a complete, replayable VOD
+  (`screencast/src/main.rs:320-323`).
+- **session**: one capture run, stored under `{root}/{user}/{session}/`. Each
+  ffmpeg (re)start is its own session id (`screencast/src/main.rs:267`).
+- **band loop / generator**: mynoise terms. A myNoise generator (`<CODE>`) is a
+  set of per-frequency-band stereo OGG loops (`<n>a.ogg`); the mix is per-band
+  volume, summed locally.
+- **atempo / wpm**: elevenlabs-say's `--rate` retiming. ffmpeg's `atempo` filter
+  changes tempo while preserving pitch, against a 175 wpm baseline, emulating
+  macOS `say -r` (`__init__.py:337`).
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| reel | [reel/overview.md](reel/overview.md) | record a terminal reel through the tui PTY driver, rasterize, encode AVIF/WebP; generates the README demo |
+| screencast | [screencast/overview.md](screencast/overview.md) | macOS H.265 desktop capture client, streams fMP4 HLS to ingest (Darwin-only) |
+| screencast-ingest | [screencast-ingest/overview.md](screencast-ingest/overview.md) | HTTP server: store HLS per user/session, serve back for replay/live/indexing |
+| mynoise | [mynoise/overview.md](mynoise/overview.md) | stream and mix myNoise.net band loops locally with rodio |
+| elevenlabs-say | [elevenlabs-say/overview.md](elevenlabs-say/overview.md) | `say`-style ElevenLabs TTS CLI with streaming input and macOS `say` flags |

--- a/docs/media/elevenlabs-say/overview.md
+++ b/docs/media/elevenlabs-say/overview.md
@@ -1,0 +1,125 @@
+# elevenlabs-say
+
+`packages/elevenlabs-say` is a `say`-style CLI that speaks text with the
+[ElevenLabs](https://elevenlabs.io) text-to-speech API. It reads text from a
+positional argument, a file, or stdin, synthesizes speech, and either plays it
+through the speakers with `ffplay` or writes it to a file (`README.md:1-5`,
+`src/elevenlabs_say/__init__.py:1-12`). With stdin it streams by default over the
+ElevenLabs WebSocket input-streaming endpoint, so it can sit at the end of a pipe
+whose producer emits text over time (an LLM token stream).
+
+Unlike the rest of the domain this is a **Python** app (single module
+`src/elevenlabs_say/__init__.py`, `requires-python >= 3.13`), built with
+`ix.buildUvApplication`; flake output `.#elevenlabs-say`. Its one runtime
+dependency is `elevenlabs>=2.50.0,<3.0.0` (`pyproject.toml:6-8`); the console
+script `elevenlabs-say = elevenlabs_say:main` is the entry point
+(`pyproject.toml:10-11`).
+
+## Public surface: CLI (`parse_args`, `__init__.py:74-162`)
+
+| flag | macOS `say` analog | default | meaning |
+| --- | --- | --- | --- |
+| `text` (positional) | | none | text to speak; omit to use `--file` or stdin |
+| `-f`, `--file` | `say -f` | none | read text from this file |
+| `-o`, `--output` | `say -o` | none | write audio to this file instead of playing |
+| `-v`, `--voice` | `say -v` | George (`JBFqnCBsd6RMkjVDRZzb`) | voice name or id |
+| `-r`, `--rate WPM` | `say -r` | none | playback tempo in words/min (pitch preserved) |
+| `--model` | | `eleven_flash_v2_5` | model id |
+| `--format` | | `mp3_44100_128` | output audio format |
+| `--stream` / `--no-stream` | | auto | force or disable WebSocket input streaming |
+
+Defaults are constants at `__init__.py:37-42`. Text source precedence is
+positional, then `--file`, then stdin (`read_text`/`text_source`,
+`__init__.py:165-229`). The API key is read from `ELEVENLABS_API_KEY`
+(`API_KEY_ENV`, `__init__.py:44`); `make_client` raises a `SayError` if unset,
+with no embedded key and no silent fallback (`__init__.py:232-238`).
+
+## Key flow (`run`, `__init__.py:505-542`)
+
+1. Build the client (env key required) and the optional `atempo` filter from
+   `--rate`.
+2. `should_stream` (`__init__.py:492-502`): an explicit `--stream`/`--no-stream`
+   wins; otherwise stream when text is piped on stdin (where incremental playback
+   matters) and batch for a positional arg or `--file` (the whole text is in
+   hand and the plain `convert` endpoint gives slightly better prosody).
+3. Resolve the voice (`resolve_voice_id`, `__init__.py:264-291`): a value
+   matching the 20-char base62 id shape (`_VOICE_ID_RE`, `__init__.py:261`) is
+   used verbatim without calling the voices API, so a synthesis-only key lacking
+   `voices_read` still works (the common case, including the default voice);
+   otherwise it searches voices by name and falls back to treating the value as a
+   literal id.
+4. Synthesize and play or write.
+
+### Batch path
+`synthesize` (`__init__.py:294-304`) calls `client.text_to_speech.convert` and
+joins the chunks. With `--output` the bytes are written (after an `atempo` pass
+if `--rate` is set); otherwise `play` writes them to a temp `.mp3` and runs
+`ffplay -nodisp -autoexit` (`__init__.py:424-445`).
+
+### Streaming path
+`stream_synthesize` (`__init__.py:307-328`) narrows the client to a
+`RealtimeTextToSpeechClient` (`stream_client`, `__init__.py:241-255`) and calls
+`convert_realtime` with `chunk_length_schedule=[50]` for low latency and
+`voice_settings=None` (passing `None` explicitly is required: the SDK's `OMIT`
+sentinel is the truthy `Ellipsis`, which crashes the init-frame build,
+`__init__.py:317-321`). stdin is read with `os.read` in 4096-byte reads through
+an incremental UTF-8 decoder so a slow producer's tokens are forwarded
+immediately and multi-byte chars split across reads stay intact
+(`stdin_text_chunks`, `__init__.py:187-207`). Audio is piped to `ffplay` via
+`pipe:0` as it arrives (`play_stream`, `__init__.py:448-478`) or written
+incrementally with `--output` (`write_stream`, `__init__.py:407-421`); empty
+input is a clear error rather than a silent zero-byte file. The default
+`eleven_flash_v2_5` supports this endpoint; `eleven_v3` does not, so forcing
+`--stream` with it fails (`README.md:73-75`).
+
+## `--rate` / atempo (`__init__.py:337-397`)
+
+`atempo_filter` builds an ffmpeg `atempo` chain emulating `say -r`: `tempo =
+rate / 175` (`DEFAULT_WPM`, `__init__.py:42`). Since `atempo` accepts only
+0.5..100.0 per stage, the multiplier is factored into in-range chained stages.
+It changes tempo while preserving pitch and does not change synthesis, so it
+works on every model including the default Flash (whose API `speed` is ignored).
+For playback the filter is passed straight to `ffplay -af`; for `--output` (no
+player) `apply_tempo` runs one extra ffmpeg pass (mp3 in, mp3 out), so a raw PCM
+`--format` is not supported there (`__init__.py:367-373`, `README.md:51-56`).
+
+## Errors (`SayError`, `__init__.py:56-57`)
+
+All operator-facing failures raise `SayError` with an actionable message;
+`main` (`__init__.py:545-551`) prints `elevenlabs-say: <msg>` to stderr and exits
+1. API errors are formatted with status + body (`format_api_error`,
+`__init__.py:331-334`). A 401/403 while resolving a voice name explains the
+`voices_read` permission gap (`__init__.py:277-284`).
+
+## Build and wiring (`default.nix`)
+
+Built with `ix.buildUvApplication` from a `fileset` source of `pyproject.toml`,
+`src`, and `uv.lock` (`default.nix:7-31`). `runtimeLibraryInputs =
+[ pkgs.stdenv.cc.cc.lib ]` because pydantic-core and websockets ship binary
+wheels that dlopen libstdc++ at import on Linux (`default.nix:23-25`). The result
+is `makeWrapper`-wrapped to put `pkgs.ffmpeg` (which supplies `ffplay`) on PATH;
+`afplay` is macOS-only and absent from nixpkgs, so `ffplay` is the portable
+choice (`default.nix:33-50`). Passthru tests: `printsHelp` (asserts `usage:
+elevenlabs-say`, `default.nix:52-70`) and `streaming` (exercises the `--stream`
+input path offline by constructing the realtime client without connecting,
+`default.nix:72-87`, test at `tests/test_streaming.py`).
+
+## Run (`README.md:18-41`)
+
+```
+nix run .#elevenlabs-say -- "the first move sets everything in motion"
+nix run .#elevenlabs-say -- --file notes.txt
+my-llm --prompt "tell me a story" | nix run .#elevenlabs-say     # streams stdin
+nix run .#elevenlabs-say -- "save me" --output /tmp/out.mp3
+nix run .#elevenlabs-say -- -v Adam -r 300 "talk faster"
+```
+
+## Caveats
+
+- Playback needs a working audio device; on a headless host use `--output`
+  (`README.md:92-95`).
+- `--stream` plays MP3 over a pipe, so it assumes an MP3 `--format`; a raw PCM
+  format has no container for `ffplay` to detect from the stream and will not play
+  (`README.md:99-101`).
+- The default voice id is scheduled to retire 2026-12-31 and may need refreshing
+  then (`__init__.py:31-37`).

--- a/docs/media/mynoise/overview.md
+++ b/docs/media/mynoise/overview.md
@@ -1,0 +1,109 @@
+# mynoise
+
+`packages/mynoise` plays [myNoise.net](https://mynoise.net) generators from the
+CLI by streaming and mixing their band loops locally. myNoise has no server-side
+audio generation: each generator is a handful of stereo OGG loops served as
+static files at `https://mynoise.net/Data/<CODE>/<n>a.ogg`, one per frequency
+band, and the website's sliders are pure per-band volume mixed in the browser
+(`src/main.rs:1-8`). This tool resolves a name to its `<CODE>`, downloads the
+bands (cached locally), then loops and mixes them with the same per-band gains.
+The audio is copyright Stephane Pigeon; streaming for personal listening is fine,
+redistribution is not (`src/main.rs:10-11`).
+
+A Rust workspace crate (`Cargo.toml`); flake output `.#mynoise`. Unlike the rest
+of the domain it uses no ffmpeg: it decodes OGG/Vorbis and mixes in-process with
+`rodio` (`Cargo.toml:19-22`). HTTP is `reqwest` over rustls (no system OpenSSL),
+fetching over a small current-thread tokio runtime that drives only the download
+phase (`Cargo.toml:15-23`, `src/main.rs:67-71`).
+
+## Public surface: CLI (`src/main.rs:24-56`)
+
+| arg / flag | default | meaning |
+| --- | --- | --- |
+| `name` (positional) | (required unless `--list`) | a bare data code (`RAIN`, `OSMOSIS`) or a generator-page slug (`rainNoiseGenerator`) |
+| `gains` (positional, repeated) | per-band default | per-band gains in band order, each `0..=100`; extras past the band count are ignored |
+| `--list` | | list generator slugs scraped from the myNoise index and exit |
+| `--volume` | `50` | master volume `0..=100` on top of every per-band gain |
+| `--default-gain` | `70` | gain `0..=100` for any band without an explicit value |
+| `--cache-dir` | OS cache dir + `mynoise` | cache directory for downloaded band files |
+
+Bare `mynoise` prints help (`arg_required_else_help`); clap requires exactly one
+of `name` or `--list` via a required `ArgGroup`, so the "no target" usage error
+is a clean exit 2 with no backtrace (`src/main.rs:26-30`).
+
+## Modules (`src/main.rs:13-14`)
+
+- **`resolve`** (`src/resolve.rs`) - name/slug -> `CODE`, then download the bands.
+- **`audio`** (`src/audio.rs`) - decode, loop, mix, and play until interrupted.
+
+## Resolution and download (`src/resolve.rs`)
+
+- **`resolve_code`** (`src/resolve.rs:76-97`). Tries the name as a bare
+  upper-cased code first, verifying it by a HEAD probe of its `0a.ogg` (band 0 is
+  the lowest band and always present for a valid code, `src/resolve.rs:79-82`).
+  Otherwise it fetches the generator page
+  `https://mynoise.net/NoiseMachines/<name>.php` and scrapes it
+  (`src/resolve.rs:84-96`).
+- **`parse_data_code`** (`src/resolve.rs:49-64`). Pulls the audio `CODE` out of
+  the page HTML by finding the first `Data/<CODE>/` whose code is immediately
+  followed by a band file. Anchoring on the band file (`is_band_file`,
+  `src/resolve.rs:27-38`: digits then `a`/`b` then a non-alphanumeric boundary)
+  is robust to a page whose first `Data/` reference is a share image like
+  `Data/RAIN/fb.jpg`. Pure, so it is unit-tested offline (`src/resolve.rs:183-240`).
+- **`download_bands`** (`src/resolve.rs:101-149`). Probes `0a.ogg`, `1a.ogg`, ...
+  up to `MAX_BANDS` = 16 (`src/resolve.rs:20`); the first 404 marks the end of
+  the band list (`src/resolve.rs:124-127`). Bands are 0-indexed; starting at 1
+  would drop the lowest band and shift every per-band gain by one
+  (`src/resolve.rs:110-111`). Existing files are reused. Each download is written
+  to a `.ogg.part` temp then renamed, so a Ctrl-C mid-download (the normal way to
+  quit) cannot leave a truncated `.ogg` that the next run reuses as complete
+  (`src/resolve.rs:134-141`). Only the `a` takes are used; `b` files are the
+  site's alternate randomized takes (`src/resolve.rs:4-9`).
+- **`list_slugs`** (`src/resolve.rs:152-181`). Fetches `noiseMachines.php` and
+  scrapes `NoiseMachines/<slug>` references, sorted and de-duped.
+
+A real `User-Agent` is set so the index/page scrape is not served a bot stub
+(`src/main.rs:61-65`).
+
+## Gain math and playback
+
+`main` resolves per-band gains in band order (explicit value, else
+`--default-gain`), each `/100.0` (`src/main.rs:98-103`). The master is
+`volume/100 / sqrt(active band count)` (`src/main.rs:105-111`): the bands are
+decorrelated noise, so their power (not amplitude) adds; dividing by
+`sqrt(active)` keeps a full mix from clipping in rodio's mixer while holding
+roughly constant perceived loudness as the band count changes. Each band's final
+linear amplitude is `gain * master` (`src/main.rs:113-120`).
+
+`audio::play` (`src/audio.rs:25-60`) opens the default device sink
+(`DeviceSinkBuilder::open_default_sink`), then for each non-zero band decodes the
+OGG, wraps it `.buffered().repeat_infinite().amplify(amplitude)` (the `Buffered`
+wrapper is needed because `Decoder` is not `Clone`, caching decoded samples to
+replay each loop), and connects a per-band `rodio::Player` to the shared mixer
+(`src/audio.rs:1-6,37-48`). Every player is held for the life of playback;
+dropping one stops its band. If all bands are muted it bails
+(`src/audio.rs:51-53`). The loops never end on their own, so it `thread::park()`s
+forever until Ctrl-C tears down the process (`src/audio.rs:55-60`).
+
+## Build and wiring (`default.nix`)
+
+Built directly with `ix.cargoUnit.selectBinaryWithTests` (`default.nix:3-9`); no
+wrapper. No extra Nix plumbing for audio on Linux: the workspace already wires
+ALSA's pkg-config and `-lasound` link path for every unit (see
+`lib/rust/workspace.nix`, noted at `Cargo.toml:19-21`). Flake output `.#mynoise`.
+
+## Run
+
+```
+nix run .#mynoise -- RAIN              # play the RAIN generator at default gains
+nix run .#mynoise -- --list            # list generator slugs
+nix run .#mynoise -- OSMOSIS 100 80 0  # per-band gains in band order
+```
+
+## Caveats
+
+- Needs network on first play of a code (to scrape/download); subsequent plays
+  reuse the cache. `--list` and slug resolution always hit the network.
+- Needs a working audio output device; there is no file-output mode.
+- `MAX_BANDS = 16` caps probing; real generators top out around 10 bands
+  (`src/resolve.rs:17-20`).

--- a/docs/media/reel/overview.md
+++ b/docs/media/reel/overview.md
@@ -1,0 +1,140 @@
+# reel
+
+`packages/reel` records a terminal demo reel "as code": it drives a real CLI
+session through the [tui](../../terminal/tui/overview.md) PTY driver, samples the
+VT-rendered grid of styled cells over time, rasterizes each frame to RGBA with a
+flat palette and a vendored monospace face, and muxes the frames through ffmpeg
+into an animated AVIF (with a WebP fallback). It emits a dark and a light variant
+sized for a GitHub README `<picture>` element (`src/main.rs:1-15`). This is the
+tool that generates the repo's top-of-README demo:
+`docs/demo-{dark,light}.{avif,webp}` (root `README.md:13-19,46-54`). The clip is
+not a screen recording; it is rendered from a recorded transcript of real
+programs.
+
+A Rust workspace crate (`Cargo.toml`); flake output `.#reel`. Its only repo
+dependency is `tui` (`Cargo.toml:11-16`).
+
+## Public surface
+
+The binary is the surface. CLI flags (`src/main.rs:55-76`, all `--long`):
+
+| flag | default | meaning |
+| --- | --- | --- |
+| `--out-dir` | `docs` | directory the `demo-{dark,light}.{avif,webp}` files are written into |
+| `--width` | `880` | output width in px; height follows the recorded aspect ratio |
+| `--font-size` | `30.0` | body font size in px before downscaling |
+| `--cols` | `88` | terminal width in columns |
+| `--rows` | `24` | terminal height in rows |
+| `--fps` | `60` | AVIF capture frame rate; the WebP fallback is capped at 24 (`src/main.rs:100`) |
+
+Output naming is fixed: `demo-<theme>.<ext>` where theme is `dark`/`light`
+(`theme.rs:46-52`) and ext is `avif`/`webp` (`encode.rs:33-38`), so four files
+per run (`src/main.rs:101-115`).
+
+## Modules (`src/main.rs:35-40`)
+
+- **`theme`** (`src/theme.rs`) - the two flat palettes (`DARK`, `LIGHT`) and
+  `Palette::resolve`, which maps a tui `Color` to concrete RGB. `Color::Default`
+  returns `None` so the caller substitutes the surface default
+  (`theme.rs:69-75`); xterm-256 indices are computed (16-231 color cube,
+  232-255 grayscale ramp, `theme.rs:77-108`).
+- **`font`** (`src/font.rs`) - `FontSet`: four JetBrains Mono Nerd Font faces
+  (regular/bold/italic/bold-italic) `include_bytes!`-embedded so a render never
+  needs a system font and is identical in CI (`font.rs:14-17`). Caches rasterized
+  body glyphs by `(char, face)`; `rasterize_at` bypasses the cache for the larger
+  card text. The base font is SIL OFL 1.1 (`fonts/OFL.txt`).
+- **`raster`** (`src/raster.rs`) - `Layout` (constant per-reel geometry derived
+  from font metrics, `raster.rs:88-107`) and `render_frame`, which paints a flat
+  window chrome (bar, three squared dots, hairline rule) plus either the terminal
+  grid or a centered card onto an RGBA `Canvas`.
+- **`scene`** (`src/scene.rs`) - the `Frame` enum (`Terminal { cells, cursor }`
+  or `Card`), the `Action` script DSL, the demo `script(fps)`, and the
+  `title_card`/`outro_card`.
+- **`record`** (`src/record.rs`) - drives a real `bash` through tui and collects
+  frames.
+- **`encode`** (`src/encode.rs`) - streams rendered frames to ffmpeg.
+
+## Recording flow (`src/record.rs`)
+
+`record` spawns `bash --noprofile --norc -i` via `tui::TuiManager::spawn` with a
+`SpawnConfig { rows, cols, scrollback_lines: 2000 }` (`record.rs:19-34`). Hidden
+setup (not captured) sets a clean `PS1`, empty `PS2`, `TERM=xterm-256color`,
+`HISTFILE=/dev/null`, then clears the screen (`record.rs:38-44`). Each scripted
+`Action` is then replayed, capturing one `Frame` per wall-clock frame interval
+via `term.read_styled_cells()` + `term.read_cursor()` (`record.rs:57-69`):
+
+- `Type` reveals one char at a time, holding each for `frames_per_char` frames so
+  typing reads at a steady ~18 chars/sec at any capture rate
+  (`record.rs:47-48,80-91`).
+- `Send` writes raw bytes (e.g. `\r`, `\x04` EOF) and captures one frame.
+- `Hold(n)` captures `n` frames of the static screen.
+- `WaitFor { needle, max }` captures until `term.read_viewport()` contains
+  `needle` or `max` frames pass (`record.rs:103-112`) - used to wait for the
+  Python `>>>` prompt before typing into the REPL.
+
+Sampling on wall-clock cadence means the child's real output streams into the
+capture: the recording shows actual programs running, not a faked transcript
+(`record.rs:1-6`). The current script (`scene.rs:57-90`) runs `git-log-pretty
+--no-pager`, then a live `python3 -q` REPL; both run offline so the clip is
+reproducible. `main` bookends the recording with held title/outro cards
+(2.2s/3.0s, `src/main.rs:86-93`).
+
+## Rasterization (`src/raster.rs`)
+
+Everything is flat: no gradients, shadows, or rounded corners (`raster.rs:1-8`).
+`Layout::new` derives padding, chrome height, and cell size from the font metrics
+(`raster.rs:91-106`); all frames in one reel share these dimensions.
+`draw_terminal` paints, per cell: background fill (honoring `inverse` by swapping
+ink/back), the glyph (face chosen by `FontSet::face_index(bold, italic)`),
+underline, and an accent-colored cursor block with the underlying glyph redrawn
+in the background color (`raster.rs:168-242`). Each cell is placed at one
+monospace advance, so a wide glyph would overflow; the demo scenes are ASCII so
+this never bites (`raster.rs:7-8`). `draw_card` centers a large title, optional
+subtitle, optional footer (`raster.rs:245-297`).
+
+## Encoding (`src/encode.rs`)
+
+`encode` renders every frame at full size and pipes it to ffmpeg as raw RGBA
+(`-f rawvideo -pix_fmt rgba`), then lanczos-downscales to `--width`
+(`scale={w}:-2:flags=lanczos`); rendering full and downscaling supersamples text
+for clean edges (`encode.rs:2-8,98-120`). Per-codec encoder args
+(`encode.rs:41-72`):
+
+- **AVIF** (primary): `libsvtav1 -crf 30 -preset 7 -pix_fmt yuv420p -loop 0 -an`.
+  AV1 inter-frame compression makes the many identical hold frames nearly free,
+  so a 60fps clip stays under GitHub's 10 MB image cap.
+- **WebP** (fallback): `libwebp -q:v 50 -compression_level 6 -preset picture
+  -loop 0 -an`, emitted at <=24 fps to stay small.
+
+If ffmpeg dies mid-stream the broken-pipe write error is recorded but the code
+still `wait()`s so ffmpeg's own exit status (the real cause) is reported
+(`encode.rs:126-150`).
+
+## Build and wiring (`default.nix`)
+
+The bare binary is built via `ix.cargoUnit.selectBinaryWithTests`
+(`default.nix:40-43`) then wrapped with `makeWrapper` to prepend a runtime PATH
+(`default.nix:59-70`) because reel shells out by name while recording. Runtime
+inputs (`default.nix:50-57`): `ffmpeg` (encode), `bashInteractive` (the driven
+shell), `git` + `python3` (the demoed scene), and the repo's own `file-search`
+and `git-log-pretty`, each built from the shared workspace unit graph so the
+wrapper gets host-correct binaries without the repo overlay (`default.nix:8-27`).
+The license is dual MIT + OFL because the binary embeds JetBrains Mono
+(`default.nix:29-38`). A `printsHelp` passthru test asserts `reel --help` exits 0
+and prints `Usage: reel` (`default.nix:72-90`).
+
+Regenerate the README assets with `nix run .#reel` (writes
+`docs/demo-{dark,light}.{avif,webp}`). reel must not be run by docs authoring
+itself; the demo files are owned outputs and are not edited here.
+
+## Gotchas
+
+- The demo `script` (`scene.rs:57-90`) is hard-coded; changing the shown tools or
+  pacing means editing it, and the outro card text (`scene.rs:104-109`) is
+  likewise static.
+- Frame count scales with `--fps` and the script's hold seconds; the RGBA frames
+  are streamed (not all held in memory) but the `Vec<Frame>` of captured grids is
+  (`src/main.rs:89-93`).
+- See [tui](../../terminal/tui/overview.md) for `TuiManager::spawn`, `SpawnConfig`
+  (defaults 80x24, 10k scrollback; reel overrides to 2000), `read_styled_cells`,
+  `read_cursor`, `read_viewport`, and the `StyledCell`/`Color` types reel renders.

--- a/docs/media/screencast-ingest/overview.md
+++ b/docs/media/screencast-ingest/overview.md
@@ -1,0 +1,113 @@
+# screencast-ingest
+
+`packages/screencast-ingest` is the server half of the screencast pipeline: an
+`axum` HTTP server that receives the fragmented-MP4 HLS streams the
+[screencast](../screencast/overview.md) client `PUT`s, writes them under a root
+directory (one folder per user and session), and serves them back so the same
+URLs play in any HLS client (Safari natively, others via hls.js)
+(`src/main.rs:1-9`). Everything is retained: a finished session is a complete VOD
+ready to feed downstream data/context pipelines (frame sampling, OCR, indexing)
+(`src/main.rs:11-13`). Cross-platform, so it deploys on the Linux fleet; there is
+no transcoding (`src/main.rs:15-16`).
+
+A Rust workspace crate (`Cargo.toml`); flake output `.#screencast-ingest`. The
+filesystem is the single source of truth: the session index and dashboard are
+derived from what is on disk, nothing is tracked separately (`src/main.rs:7-9`).
+
+## Public surface
+
+### CLI flags (`src/main.rs:50-65`)
+
+| flag | env | default | meaning |
+| --- | --- | --- | --- |
+| `--root` | `SCREENCAST_ROOT` | `./screencast-data` | directory streams are stored under as `{user}/{session}/...` |
+| `--addr` | `SCREENCAST_ADDR` | `0.0.0.0:8080` | listen address |
+| `--token` | `SCREENCAST_TOKEN` | none | if set, uploads must carry `Authorization: Bearer <token>`; reads stay open |
+
+`--root` is created and canonicalized at startup (`src/main.rs:94-100`). Logging
+is `tracing` + `EnvFilter`, default `info`, with a `tower_http` trace layer
+(`src/main.rs:86-91,118`). Graceful shutdown on Ctrl-C (`src/main.rs:127-130`).
+
+### Routes (`src/main.rs:110-119`)
+
+| method + path | handler | purpose |
+| --- | --- | --- |
+| `GET /` | `dashboard` | single-page dashboard (static HTML, `src/main.rs:449`) |
+| `GET /healthz` | inline | returns `ok` |
+| `GET /api/sessions` | `api_sessions` | JSON `Vec<SessionInfo>`, for the dashboard and indexers |
+| `PUT /ingest/{user}/{session}/{file}` | `upload` | store a playlist or segment |
+| `GET /ingest/{user}/{session}/{file}` | `serve` | play back a stored file |
+| `DELETE /ingest/{user}/{session}/{file}` | `remove` | delete a file (for expiring HLS muxers; rarely used) |
+
+The dashboard is `include_str!("dashboard.html")` (`src/main.rs:449-450`), a
+fully static page that fetches `/api/sessions` itself and plays sessions with
+hls.js; no server-side templating.
+
+### SessionInfo JSON (`src/main.rs:312-330`)
+
+Per session: `user`, `session`, `playlist` (URL
+`/ingest/{user}/{session}/index.m3u8`), `started`/`updated` (epoch-second file
+mtimes), `segments` (count of `.m4s`/`.ts`), `bytes` (total on disk), `live`
+(written within the live window and not complete), `complete` (playlist has
+`#EXT-X-ENDLIST`). Sorted most-recently-active first (`src/main.rs:364`).
+
+## Key internals
+
+- **Path safety** (`safe_component`, `src/main.rs:139-146`; `resolve`,
+  `src/main.rs:181-196`). Every `{user}/{session}/{file}` component must be a
+  non-empty, `<=128`-char plain name (alphanumeric plus `_ - .`, not `.`/`..`).
+  This is the sole guard between a client path and a disk write; it rejects
+  anything it does not positively recognize. It mirrors the client's own
+  `sanitize` but is enforced independently.
+- **Atomic uploads** (`upload`, `src/main.rs:235-265`). Auth is checked before
+  the body is read, so an unauthenticated request never buffers a large upload.
+  The extension must be `m3u8`/`m4s`/`mp4`/`ts`. The body (`<= MAX_UPLOAD` = 64
+  MiB, `src/main.rs:39`) is written to a hidden temp file in the destination dir
+  and renamed into place, so a reader polling the playlist never sees a
+  half-written file. Returns `201 Created`.
+- **Serve** (`serve`, `src/main.rs:268-283`). Reads the resolved file and returns
+  it with a `Content-Type` mapped from extension (`content_type`,
+  `src/main.rs:149-156`): `.m3u8` -> `application/vnd.apple.mpegurl`, `.m4s`/`.mp4`
+  -> `video/mp4`, `.ts` -> `video/mp2t`. No transcoding.
+- **Auth** (`check_auth`/`ct_eq`, `src/main.rs:201-229`). When `--token` is set,
+  mutating requests (`PUT`, `DELETE`) require a matching bearer token, compared
+  constant-time (length may leak). Reads are always open.
+- **Scan + cache** (`scan_sessions`/`summarize`, `src/main.rs:335-427`). Two-level
+  directory walk (`root/user/session`); per-session it sums bytes, counts
+  segments, tracks earliest/latest mtime, requires an `index.m3u8`, and reads it
+  for `#EXT-X-ENDLIST`. Hidden `.`-prefixed files (in-flight temps) are skipped.
+  Per-entry errors are skipped rather than failing the whole listing.
+  `api_sessions` caches the scan for `SCAN_CACHE_TTL` = 2s
+  (`src/main.rs:44-47,432-445`) so a poll storm (many dashboard tabs, or an
+  unauthenticated caller) cannot amplify into a per-request full-tree walk.
+- **Live window** `LIVE_WINDOW_SECS` = 30s (`src/main.rs:42,424`): a session is
+  `live` if not complete and its newest file changed within 30s.
+- **Error hygiene** (`internal`, `src/main.rs:303-309`). Logs the detailed cause
+  and returns a generic 500 so an OS error string (which can include absolute
+  server paths) never reaches the client. `HttpError` (`src/main.rs:161-170`) is
+  the typed `(status, message)` response shape returned from handlers.
+
+## Build and wiring (`default.nix`)
+
+Built directly with `ix.cargoUnit.selectBinaryWithTests`; no wrapper is needed
+(it shells out to nothing, `default.nix:15-18`). A `printsHelp` passthru test
+asserts `screencast-ingest --help` prints `Usage: screencast-ingest`
+(`default.nix:20-37`).
+
+## Run
+
+```
+nix run .#screencast-ingest -- --root /var/lib/screencast --addr 0.0.0.0:8080
+```
+
+Open `http://<host>:8080/` for the dashboard; `GET /api/sessions` is the same
+data as JSON. Add `--token <secret>` (or `SCREENCAST_TOKEN`) to require auth on
+uploads; reads stay open. No transport encryption of its own; run behind a
+private network or tailnet (`screencast/README.md:20-29`).
+
+## Caveats
+
+- Storage grows unbounded by design (everything retained). `DELETE` exists for
+  expiring muxers but the default client keeps everything (`src/main.rs:285-287`).
+- The dashboard pins hls.js from a CDN (`src/dashboard.html:7`), so the dashboard
+  UI needs outbound internet; playback itself does not.

--- a/docs/media/screencast/overview.md
+++ b/docs/media/screencast/overview.md
@@ -1,0 +1,129 @@
+# screencast
+
+`packages/screencast` is the macOS capture client: it streams a Mac's desktop to
+a [screencast-ingest](../screencast-ingest/overview.md) server as
+hardware-encoded H.265, so a whole team can push screens to one place that stores
+every session for replay and downstream data/context use (`README.md:3-14`). It
+does not implement capture or encoding itself; it configures, supervises, and
+ships the output of `ffmpeg` (`src/main.rs:1-13`).
+
+A Rust workspace crate (`Cargo.toml`); flake output `.#screencast`.
+**Darwin-only**: avfoundation capture and `hevc_videotoolbox` are macOS APIs, so
+`meta.platforms = lib.platforms.darwin` (`default.nix:13-14`) and the package
+advertises its flake/package outputs only on `aarch64-darwin`/`x86_64-darwin`
+(`package.nix:7-14`, mirroring vmkit). The server half is cross-platform; only
+this client is Mac-only (`README.md:59-60`).
+
+## The pipeline (`src/main.rs:4-24`)
+
+1. Capture the desktop through the avfoundation input device.
+2. Encode with `hevc_videotoolbox`, Apple's hardware H.265 encoder (near-free on
+   battery/CPU).
+3. Mux to fragmented-MP4 HLS written to a local scratch directory.
+4. Upload each finalized segment plus the rolling playlist to the ingest server
+   with ordinary sized HTTP `PUT`s.
+
+ffmpeg can `PUT` HLS directly, but its HTTP muxer keeps connections open without
+finalizing each request body in a way a strict HTTP/1.1 server accepts, so
+segments hang server-side. Writing locally and uploading from here sidesteps that
+and buys retries: a failed upload is simply retried on the next sync, so a brief
+blip does not drop the stream (`src/main.rs:15-19`, `README.md:44-52`).
+
+The HLS playlist is `event` type with an unbounded list (`-hls_list_size 0`), so
+a session is a live stream while recording and a complete VOD once ffmpeg writes
+`#EXT-X-ENDLIST` (`src/main.rs:21-24,496-506`). Only segments the local playlist
+already lists are uploaded, so the server never references a segment that has not
+landed yet.
+
+## Public surface: CLI flags (`src/main.rs:51-108`)
+
+| flag | env | default | meaning |
+| --- | --- | --- | --- |
+| `--server` | `SCREENCAST_SERVER` | (required) | base URL of the ingest server, e.g. `http://ingest.host:8080` |
+| `--user` | `SCREENCAST_USER` | `$USER` | stream owner; top-level folder on the server |
+| `--screen N` | | auto | avfoundation device index; auto-detects the first `Capture screen` device |
+| `--list-screens` | | | list capturable avfoundation devices and exit |
+| `--fps` | | `30` | capture frame rate |
+| `--bitrate` | | `6M` | target H.265 bitrate (ffmpeg `-b:v`), e.g. `10M` |
+| `--segment-seconds` | | `4` | HLS segment length; also drives the keyframe interval |
+| `--sync-ms` | | `1000` | how often the scratch dir is checked for finalized segments to push |
+| `--max-height` | | none | downscale so output is at most this tall (cuts Retina bandwidth) |
+| `--no-cursor` | | off | exclude the mouse cursor from capture |
+| `--token` | `SCREENCAST_TOKEN` | none | bearer token sent as `Authorization: Bearer <token>` on every upload |
+| `--ffmpeg` | | `ffmpeg` | ffmpeg binary to invoke |
+
+Logging is `tracing` with `RUST_LOG`-style `EnvFilter`, default `info`
+(`src/main.rs:113-118`). Upload URL shape is
+`{server}/ingest/{user}/{session}/{file}` (`src/main.rs:272`), matching the
+server's ingest route.
+
+## Key internals
+
+- **Screen resolution** (`resolve_screen`, `src/main.rs:144-184`). With no
+  `--screen`, it runs `ffmpeg -f avfoundation -list_devices true` and
+  `parse_screen_index` scrapes the first `[N] Capture screen` line (the index is
+  the bracket immediately before the label, since the line carries two bracketed
+  fields). Device 0 is often a camera, so auto-detect is necessary
+  (`src/main.rs:61-64`).
+- **Preflight** (`preflight`, `src/main.rs:210-229`). Verifies ffmpeg runs and
+  its `-encoders` list contains `hevc_videotoolbox`, failing with a clear message
+  rather than a black stream or cryptic error later.
+- **Supervisor** (`supervise`, `src/main.rs:256-318`). A loop that spawns ffmpeg,
+  then `tokio::select!`s over a sync tick (`uploader.sync()`), `child.wait()`
+  (ffmpeg died: sync once more, restart with exponential backoff capped at 30s),
+  and `ctrl_c` (graceful stop, final sync, return). Each (re)start gets a fresh
+  session id `{UTC timestamp}-{attempt:02}` so a crash never reuses or corrupts
+  an earlier session's segment numbering (`src/main.rs:253-255,267`).
+- **Graceful stop** (`stop_gracefully`, `src/main.rs:324-337`). Writes `q` to
+  ffmpeg's stdin (its documented interactive stop) so it flushes the final
+  segment and writes `#EXT-X-ENDLIST`, turning the session into a finished VOD;
+  falls back to `kill` after 10s.
+- **Uploader** (`Uploader`, `src/main.rs:341-440`). Tracks `sent` names so it
+  never re-ships a file. `sync` reads the local playlist, uploads `init.mp4` then
+  each listed segment not yet sent, and ships the playlist last and only when
+  every referenced file is uploaded and the playlist changed
+  (`src/main.rs:381-405`). `reqwest::Client` has bounded connect (5s) and request
+  (30s) timeouts so a hung upload cannot stall the supervisor select loop; on
+  timeout the `PUT` errors and is retried next sync (`src/main.rs:351-360`).
+
+## ffmpeg argv (`build_ffmpeg_args`, `src/main.rs:455-518`)
+
+Input: `-f avfoundation -capture_cursor {0|1} -framerate {fps} -i {screen}:none`
+(`:none` = no audio). Optional `-vf scale=-2:{max_height}`. Encode:
+`-c:v hevc_videotoolbox -realtime 1 -b:v {bitrate} -tag:v hvc1 -pix_fmt yuv420p
+-g {fps*segment_seconds}` (the `hvc1` tag is the fMP4/Apple-compatible HEVC
+sample entry; some players refuse the stream without it; keyframe interval ==
+segment length so HLS splits on IDR boundaries). Output: `-f hls -hls_time
+{segment_seconds} -hls_playlist_type event -hls_list_size 0 -hls_flags
+independent_segments -hls_segment_type fmp4 -hls_fmp4_init_filename init.mp4
+-hls_segment_filename {dir}/seg_%05d.m4s {dir}/index.m3u8`. The playlist and
+init names are constants (`PLAYLIST = "index.m3u8"`, `INIT = "init.mp4"`,
+`src/main.rs:45-46`).
+
+## Build and wiring (`default.nix`)
+
+Built via `ix.cargoUnit.selectBinaryWithTests` then `makeWrapper`-wrapped to put
+`pkgs.ffmpeg` on PATH (`default.nix:25-36`); nixpkgs ffmpeg is built with
+VideoToolbox on Darwin, so it carries `hevc_videotoolbox` (`default.nix:22-24`).
+A `printsHelp` passthru test asserts `screencast --help` prints `Usage:
+screencast` (`default.nix:38-55`). Unit tests cover `parse_screen_index`,
+`parse_segments`, and `sanitize` (`src/main.rs:520-559`).
+
+## Run
+
+```
+nix run .#screencast -- --server http://<host>:8080
+```
+
+Auto-detects the display, captures at 30 fps / 6 Mbit/s H.265, streams under
+`<you>/<timestamp>`, Ctrl-C to finalize. Grant the terminal Screen Recording
+permission first, or avfoundation captures a black frame with no error
+(`src/main.rs:26-28`, `README.md:31-42`).
+
+## Bad fit / caveats
+
+- Not for sub-second live latency: HLS buffers a few segments. Reach for WebRTC
+  or SRT if glass-to-glass latency matters (`README.md:54-58`).
+- No transport encryption of its own; run behind a private network/tailnet
+  (`README.md:27-29`).
+- macOS only (see above).

--- a/docs/modules/ci-runner/overview.md
+++ b/docs/modules/ci-runner/overview.md
@@ -1,0 +1,56 @@
+# ci-runner
+
+`modules/services/ci-runner/default.nix` runs a static pool of self-hosted
+GitHub Actions runners on a persistent NixOS host. The point is cache locality:
+jobs reuse the host's shared `/nix/store` and the `indexable-inc` Cachix
+substituter, so `nix build .#...` pulls warm artifacts instead of rebuilding
+from a cold store each run. Per-job work directories are still wiped (ephemeral
+runners); only the shared store survives. It is the small counterpart to the
+repo's webhook dispatcher, with no just-in-time minting and no per-job VM.
+
+Option namespace: `services.ci-runner` (`default.nix:28`).
+
+## Public surface (options)
+
+- `enable` - turn on the runner pool (`default.nix:29`).
+- `url` (str) - repository or org URL the runners register against
+  (`default.nix:31`).
+- `tokenFile` (str, runtime path not `types.path`) - file with a fine-grained
+  GitHub PAT with read/write to the repo's self-hosted runners
+  (`default.nix:40`). A PAT, not a one-hour registration token, is required
+  because ephemeral runners mint a fresh registration on every restart. The
+  path is a runtime string so the PAT never enters the world-readable Nix store.
+- `count` (positive int, default 2) - runners registered in parallel; each
+  processes one job at a time, so this is the host's CI concurrency
+  (`default.nix:55`). Runner names are `index-1 .. index-<count>`
+  (`default.nix:25`).
+- `labels` (list of str, default `[ "nix" ]`) - extra labels appended to every
+  runner (`default.nix:64`).
+- `ephemeral` (bool, default true) - register single-use runners that
+  de-register after one job and re-register on restart (`default.nix:73`).
+- `packages` (list of package, default `[]`) - extra packages on each job's
+  PATH on top of git, Nix, and Cachix tooling (`default.nix:85`).
+
+## What it produces
+
+`config` (`default.nix:96`) does two things and declares no port claim:
+
+- **Nix daemon settings** (`default.nix:101-117`), all `extra-*` so they add to
+  rather than replace host defaults: enables `nix-command`/`flakes`,
+  `accept-flake-config = true` (avoids the interactive substituter prompt that
+  stalls `nix flake check`), adds the `indexable-inc.cachix.org` substituter and
+  trusted key, and advertises `extra-system-features = [ "gccarch-znver5" ]`
+  (index images pin `gcc.arch = znver5`, so the daemon must advertise that
+  builder feature or refuse the builds).
+- **Runner instances** via `services.github-runners` (`default.nix:119`), one
+  per generated name with `enable`, `url`, `tokenFile`, `ephemeral`,
+  `extraLabels = labels`, `replace = true` (re-register under the same name
+  after a host config change instead of failing on a name clash), and
+  `extraPackages = [ cachix gh git config.nix.package ] ++ packages`.
+
+## How it is wired
+
+Auto-discovered as `services/ci-runner`. No flake package output of its own; it
+configures the upstream nixpkgs `services.github-runners` module. Imports
+`config`, `lib`, `pkgs` only (no `ix` argument), so it carries no port claim or
+health check.

--- a/docs/modules/common.md
+++ b/docs/modules/common.md
@@ -1,0 +1,158 @@
+# modules
+
+`modules/` is the repo's reusable NixOS configuration: auto-discovered service
+modules (`modules/services/`), opt-in runtime profiles (`modules/profiles/`),
+and one home-manager module (`modules/home/`). Each is an inert option set that
+an image, fleet, or example imports and turns on with an `enable` flag. The
+modules are the deploy-time face of the Rust/Nix packages under `packages/`: a
+service module wires a built package into a systemd unit, a port, and a health
+check on a VM. This page is the orientation; read it before any component page.
+
+Read alongside the build/lib domain ([nix-lib](../nix-lib/common.md)): the
+`ix.networking.portClaims` / `ix.healthChecks` / `ix.systemdHardening`
+primitives these modules write into are defined there, not here.
+
+## How modules are discovered and wired
+
+There is no module registry to edit. `lib/discovery.nix` walks the tree:
+
+- `discoverModules { root = paths.modules; }` (`lib/default.nix:78`) calls the
+  generic `discoverTree` walker (`lib/discovery.nix:20`). A directory becomes a
+  module when it has its own `default.nix` (`lib/discovery.nix:184-218`).
+- A directory or `.nix` file whose name starts with `_` is skipped with its
+  subtree (`lib/discovery.nix:34`), so a module can keep helper data
+  (`observability/_dashboards/`, the Nushell/Lua under `profiles/base/`)
+  beside its `default.nix` without being treated as a module.
+- Sibling directories that each have a `default.nix` nest: `services/minecraft/`
+  ships `{ default = ./minecraft; fabric = ./minecraft/fabric; ...; mods = { bluemap = ...; }; }`
+  (`lib/discovery.nix:204-216`). A category directory (`services/`, `profiles/`)
+  must NOT have its own `default.nix` (`lib/discovery.nix:196-197`).
+- The walk returns a nested attrset of paths, exposed as `ix.nixosModules`
+  and as the flake's `nixosModules` output (`flake.nix:274`).
+- `moduleList = lib.collect builtins.isPath nixosModules` (`lib/default.nix:94`)
+  flattens it; `lib/image/default.nix:86` appends `moduleList` to every built
+  image unconditionally, so every option is always in scope and each module
+  stays inert until its `enable` flag is set (`lib/default.nix:91-94`).
+
+`modules/home/` is NOT swept into `nixosModules`: it contains a bare
+`raycast.nix`, not a `default.nix` directory, so discovery yields nothing for it.
+It is wired by explicit path as `homeModules.raycast` (`flake.nix:295`). The
+other home-manager modules (`portable-services`, `mutable-json`) live outside
+`modules/` in `lib/services/` on purpose (`lib/default.nix:80-89`).
+
+## Option-namespace convention
+
+- A service module owns `options.services.<name>` matching its directory name:
+  `services.minecraft`, `services.velocity`, `services.geyser`,
+  `services.symphony`, `services.ci-runner`, `services.git-clone`,
+  `services.remote-desktop`, `services.resource-monitor`, `services.minestom`,
+  `services.minecraft-bedrock`, `services.floodgate`.
+- A module that wraps or extends an upstream nixpkgs service, or is a cluster
+  orchestrator, uses an `ix-` prefix to avoid clobbering the stock option tree:
+  `services.ix-postgresql`, `services.ix-seaweedfs`, `services.ix-observability`,
+  `services.ix-ray`, `services.ix-spark`.
+- Profiles own `options.ix.profiles.<name>` (`base`, `jvm`) or a bare option
+  tree (`ix.extendedAttributes`). The home module owns
+  `options.programs.raycast.focus`.
+
+## Cross-component invariants
+
+Every service page below assumes these, supplied by the `ix` specialArg and the
+platform module (see [nix-lib](../nix-lib/common.md)):
+
+- **Ports are claimed, not hard-coded.** A module registers
+  `ix.networking.portClaims.<name>` (one source of truth: protocol, port,
+  address) and separately opens `networking.firewall.allowed{TCP,UDP}Ports`,
+  gated by a per-module `openFirewall` option. The port-claim registry detects
+  same-namespace collisions at eval time (`lib/image/platform.nix`).
+- **Readiness is a probe.** Modules register `ix.healthChecks.<name>` with a
+  real command (`pg_isready`, `mc-probe`, an HTTP `/healthz`) or `unit` sugar
+  (`systemctl is-active`), run from the guest or the operator host.
+- **Units are hardened.** A service merges `ix.systemdHardening`
+  (`lib/services/systemd-hardening.nix`, surfaced as `ix.systemdHardening`)
+  into `serviceConfig`, then overrides only what it must (Ray and Spark turn
+  `PrivateDevices`/`PrivateUsers` off for shared memory).
+- **`ix` carries the toolbox.** Modules read `ix.artifacts.minecraft.*` (locked
+  jars), `ix.packages.*` (`mc-probe`, `mcp`), `ix.languages.java.yourkit`,
+  `ix.writeNushellApplication`, `ix.buildSvelteSite`, `ix.cargoUnit`,
+  `ix.relativePath`, and `ix.minecraft.*` from this argument.
+- **The base profile is automatic.** `lib/image/oci-layer.nix:62` sets
+  `ix.profiles.base.enable = lib.mkDefault true`, so every image gets the base
+  CLI unless an image opts out.
+- **Ray and Spark are repo-agnostic.** They declare no `ix.*` options and take
+  the index lib through `_module.args.indexLib` (named, not `ix`, to avoid the
+  host's `ix` specialArg), so they import into any NixOS system.
+
+## Services table
+
+| service | option namespace | runs | default ports |
+| --- | --- | --- | --- |
+| [ci-runner](ci-runner/overview.md) | `services.ci-runner` | nixpkgs `github-runners` pool | none (outbound) |
+| [git-clone](git-clone/overview.md) | `services.git-clone` | `gitoxide` (`gix clone`) oneshot | none |
+| [postgresql](postgresql/overview.md) | `services.ix-postgresql` | `postgresql_18` tuned for Zen 5 | 5432/tcp |
+| [seaweedfs](seaweedfs/overview.md) | `services.ix-seaweedfs` | `weed server -s3` (single node) | 8333/tcp (S3) |
+| [observability](observability/overview.md) | `services.ix-observability` | OTel Collector + ClickHouse + Grafana | 4317/4318, 9000/8123, 3000 |
+| [resource-monitor](resource-monitor/overview.md) | `services.resource-monitor` | `resource-monitor-stats-writer` crate + Svelte site via nginx | 80/tcp |
+| [remote-desktop](remote-desktop/overview.md) | `services.remote-desktop` | Xpra `start-desktop` + icewm | 6080/tcp |
+| [symphony](symphony/overview.md) | `services.symphony` | `packages/symphony` (`/bin/symphony`, Phoenix) | 4040/tcp |
+| [ray](ray/overview.md) | `services.ix-ray` | `python3Packages.ray` + ix-mcp engine (`packages/mcp`) | 6379/6380/6381, 10001, 10002-10031, 8799 |
+| [spark](spark/overview.md) | `services.ix-spark` | `spark-hive` + Gluten/Velox | 7077/8080/8081, 15002, 7078-7080 |
+| [minecraft](minecraft/overview.md) | `services.minecraft` | Java server jar (loader-set) via Temurin JRE | 25565/tcp, 25575 rcon |
+| [minecraft-bedrock](minecraft-bedrock/overview.md) | `services.minecraft-bedrock` | Bedrock Dedicated Server (fetched) | 19132/19133 udp |
+| [minestom](minestom/overview.md) | `services.minestom` | user fat jar via Temurin JRE (ZGC) | 25565/tcp |
+| [velocity](velocity/overview.md) | `services.velocity` | Velocity proxy jar (`ix.artifacts`) | 25565/tcp |
+| [geyser](geyser/overview.md) | `services.geyser` | Geyser jar as a Velocity plugin | 19132/udp |
+| [floodgate](floodgate/overview.md) | `services.floodgate` | Floodgate jar as a Velocity plugin | none (rides Velocity) |
+
+## Profiles and home
+
+- [profiles](profiles/overview.md): `ix.profiles.base` (auto-enabled CLI/shell
+  toolbox + BBR + Home Manager root config), `ix.profiles.jvm` (JRE + `JAVA_HOME`),
+  `ix.extendedAttributes` (apply `user.*` xattrs at activation).
+- [home](home/overview.md): `programs.raycast.focus`, a macOS home-manager module
+  writing the `com.raycast.macos` Focus session defaults.
+
+## Glossary
+
+- **port claim**: `ix.networking.portClaims.<name>`, the single declared owner
+  of a (namespace, protocol, port). Firewall opening is separate and gated by
+  `openFirewall`.
+- **health check**: `ix.healthChecks.<name>`, a readiness probe run by
+  `nix run .#health-checks`, from `guest` or operator `host`.
+- **systemd hardening**: the shared `serviceConfig` baseline merged from
+  `ix.systemdHardening` before per-service overrides.
+- **loader**: a Minecraft server flavor (fabric, paper, vanilla, ...) that fills
+  the `serverJar`/`dropinDir` slots of `services.minecraft` via `mkMinecraftLoader`.
+- **dropinDir**: the subdirectory mod/plugin jars are symlinked into; `mods` for
+  fabric/neoforge/sponge, `plugins` for paper/folia/purpur/spigot.
+- **agent / stack**: the two observability roles; an agent forwards OTLP to a
+  stack node that runs ClickHouse + Grafana.
+- **fleet**: the Python distributed API (in `packages/mcp`) that `services.ix-ray`
+  is the deployment side of.
+- **Geyser / Floodgate**: Bedrock-to-Java protocol bridge and its auth bridge,
+  both installed as Velocity proxy plugins.
+- **EnvironmentFile**: a systemd secrets file path a module reads (symphony) so
+  any secret manager can be wired underneath.
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| ci-runner | [ci-runner/overview.md](ci-runner/overview.md) | self-hosted GitHub Actions runner pool with warm Nix cache |
+| git-clone | [git-clone/overview.md](git-clone/overview.md) | idempotent boot-time `gix clone` of a repo |
+| postgresql | [postgresql/overview.md](postgresql/overview.md) | PostgreSQL 18 tuned + hugepages, `services.ix-postgresql` |
+| seaweedfs | [seaweedfs/overview.md](seaweedfs/overview.md) | single-node S3 object store (`weed server -s3`) |
+| observability | [observability/overview.md](observability/overview.md) | OpenTelemetry + ClickHouse + Grafana telemetry stack |
+| resource-monitor | [resource-monitor/overview.md](resource-monitor/overview.md) | stats-writer crate + Svelte UI for VM usage/billing |
+| remote-desktop | [remote-desktop/overview.md](remote-desktop/overview.md) | browser desktop over Xpra HTML5 |
+| symphony | [symphony/overview.md](symphony/overview.md) | Symphony runtime systemd unit + host codex placement |
+| ray | [ray/overview.md](ray/overview.md) | tailnet Ray cluster + ix-mcp engine for `fleet` |
+| spark | [spark/overview.md](spark/overview.md) | standalone Spark + Gluten/Velox native engine |
+| minecraft | [minecraft/overview.md](minecraft/overview.md) | loader-agnostic Java server, mods/plugins/datapacks, loaders + mod submodules |
+| minecraft-bedrock | [minecraft-bedrock/overview.md](minecraft-bedrock/overview.md) | Bedrock Dedicated Server |
+| minestom | [minestom/overview.md](minestom/overview.md) | Minestom fat-jar runtime |
+| velocity | [velocity/overview.md](velocity/overview.md) | Velocity Minecraft proxy + managed plugins/config |
+| geyser | [geyser/overview.md](geyser/overview.md) | Bedrock-to-Java bridge as a Velocity plugin |
+| floodgate | [floodgate/overview.md](floodgate/overview.md) | Floodgate Bedrock auth bridge as a Velocity plugin |
+| profiles | [profiles/overview.md](profiles/overview.md) | base / jvm runtime profiles + extended-attributes |
+| home | [home/overview.md](home/overview.md) | raycast Focus home-manager module (macOS) |

--- a/docs/modules/floodgate/overview.md
+++ b/docs/modules/floodgate/overview.md
@@ -1,0 +1,51 @@
+# floodgate
+
+`modules/services/floodgate/default.nix` installs Floodgate, the Bedrock
+identity/auth bridge, as a Velocity plugin beside [geyser](../geyser/overview.md).
+Floodgate lets Bedrock players join without a Java (Mojang/Microsoft) account.
+Like Geyser it runs no unit of its own; it composes onto
+[velocity](../velocity/overview.md).
+
+Option namespace: `services.floodgate` (`default.nix:58`).
+
+## What it runs
+
+The Floodgate Velocity plugin jar. Default `package` is
+`ix.artifacts.minecraft.velocityPluginCatalog.floodgate-velocity.src`
+(`default.nix:67`). `platform` is fixed to `velocity` (`default.nix:61`).
+
+## Public surface (selected options)
+
+- `enable`, `platform`, `package` (`default.nix:59-72`).
+- `keyFileName` (`key.pem`), `usernamePrefix` (`.`), `replaceSpaces` (true),
+  `sendFloodgateData` (false) (`default.nix:74-96`).
+- `disconnect.{invalidKey,invalidArgumentsLength}` - Geyser-user disconnect
+  messages (`default.nix:98`).
+- `playerLink.*`: `enable` (true), `requireLink`, `enableOwnLinking`, `allowed`,
+  `linkCodeTimeout` (300s), `type` (`sqlite`), `enableGlobalLinking` (true)
+  (`default.nix:112-154`).
+- `metrics.{enable,uuid}` - bStats (`default.nix:156`).
+- `settings` / `proxySettings` - raw `config.yml` / `proxy-config.yml` merged
+  over the typed options (`default.nix:170`, `:176`).
+
+## What it produces
+
+The whole `config` (`default.nix:183`) composes onto other modules; it declares
+no port claim:
+
+- **Velocity plugin** (`default.nix:184-194`): sets `services.velocity.enable =
+  mkDefault true`, adds `services.velocity.plugins.floodgate = { src = package;
+  fileName = "floodgate-velocity.jar"; }`, and writes two managed config files,
+  `plugins/floodgate/config.yml` (rendered from the typed options + `config-version
+  = 3`, merged with `settings`) and `plugins/floodgate/proxy-config.yml` (from
+  `sendFloodgateData` + `proxySettings`).
+- **Geyser integration** (`default.nix:196-198`): when `services.geyser.enable`,
+  defaults `services.geyser.remote.authType` to `floodgate` so Geyser hands
+  Bedrock identities to Floodgate.
+
+## How it is wired
+
+Auto-discovered as `services/floodgate`. Plugin jar comes from
+`ix.artifacts.minecraft.velocityPluginCatalog`. Runs only as a managed plugin of
+the [velocity](../velocity/overview.md) unit, paired with
+[geyser](../geyser/overview.md).

--- a/docs/modules/geyser/overview.md
+++ b/docs/modules/geyser/overview.md
@@ -1,0 +1,56 @@
+# geyser
+
+`modules/services/geyser/default.nix` installs Geyser, the Bedrock-to-Java
+protocol bridge, as a Velocity proxy plugin. It lets Bedrock (mobile/console)
+clients join a Java server fronted by [velocity](../velocity/overview.md). It
+does not run its own systemd unit: it composes onto `services.velocity`.
+
+Option namespace: `services.geyser` (`default.nix:77`).
+
+## What it runs
+
+The Geyser Velocity plugin jar. Default `package` is
+`ix.artifacts.minecraft.velocityPluginCatalog.geyser-velocity.src`
+(`default.nix:86`). `platform` is fixed to `velocity` (`default.nix:80`).
+
+## Public surface (selected options)
+
+Geyser exposes the full Geyser `config.yml` as typed options merged with a raw
+`settings` escape hatch (`default.nix:377`). Highlights:
+
+- `enable`, `platform`, `package` (`default.nix:78-91`).
+- `bedrock.*`: `address` (`0.0.0.0`), `port` (udp, default 19132),
+  `openFirewall` (true), `cloneRemotePort`, `motd1`/`motd2`, `serverName`,
+  `compressionLevel`, `enableProxyProtocol` (`default.nix:93-147`).
+- `remote.*`: `address` (`auto`), `port` (25565), `authType`
+  (`online`|`offline`|`floodgate`, default `online`), `useProxyProtocol`,
+  `forwardHostname` (`default.nix:149-183`).
+- `floodgateKeyFile`, `commandSuggestions`, `passthrough.*`, `maxPlayers` (100),
+  `debug`, skull/render/item options, `metrics.enable`, `mtu` (1400),
+  `useDirectConnection`, `disableCompression` (`default.nix:185-375`).
+
+## What it produces
+
+- **Composes onto Velocity** (`default.nix:384-392`): sets
+  `services.velocity.enable = mkDefault true`, adds
+  `services.velocity.plugins.geyser = { src = package; fileName =
+  "Geyser-Velocity.jar"; }`, and writes the rendered `config.yml` to
+  `services.velocity.configFiles."plugins/geyser/config.yml"`. The rendered config
+  is the typed options mapped to Geyser's hyphenated keys plus `config-version =
+  4`, merged with `settings` (`default.nix:21-74`).
+- **Port claim + firewall** (`default.nix:394-400`):
+  `ix.networking.portClaims.geyser` (udp, `bedrock.address`/`bedrock.port`) and
+  `networking.firewall.allowedUDPPorts` gated by `bedrock.openFirewall`.
+
+## Relationship to Floodgate
+
+When [floodgate](../floodgate/overview.md) is also enabled, it defaults
+`services.geyser.remote.authType` to `floodgate`
+(`floodgate/default.nix:196-198`), so Bedrock players authenticate through the
+Floodgate identity bridge rather than needing a Java account.
+
+## How it is wired
+
+Auto-discovered as `services/geyser`. Plugin jar comes from
+`ix.artifacts.minecraft.velocityPluginCatalog`. Runs only as a managed plugin of
+the [velocity](../velocity/overview.md) unit.

--- a/docs/modules/git-clone/overview.md
+++ b/docs/modules/git-clone/overview.md
@@ -1,0 +1,41 @@
+# git-clone
+
+`modules/services/git-clone/default.nix` clones a git repository on first boot
+and does nothing on later boots. The clone is idempotent: a boot that finds
+`<dest>/.git` already present skips the fetch. It uses `gitoxide` (`gix`), not C
+git.
+
+Option namespace: `services.git-clone` (`default.nix:20`).
+
+## Public surface (options)
+
+- `enable` (`default.nix:21`).
+- `url` (str, required) - repository to clone (`default.nix:23`).
+- `dest` (str, default `/repo`) - clone target (`default.nix:25`).
+- `shallow` (bool, default true) - clone with `--depth 1` (`default.nix:30`).
+- `ref` (nullable str, default null) - branch/tag/ref to check out; renders
+  `--ref` when set (`default.nix:35`).
+- `activation` (enum `multi-user` | `timer`, default `multi-user`) - how the
+  clone is started (`default.nix:40`). Use `timer` for large repositories that
+  should be fetched after boot readiness rather than blocking
+  `multi-user.target`.
+
+## What it produces
+
+- `environment.systemPackages = [ pkgs.gitoxide ]` (`default.nix:54`).
+- `systemd.services.git-clone` (`default.nix:56`): a `Type = oneshot`,
+  `RemainAfterExit = true` unit after `network-online.target`. Its `path`
+  carries `coreutils` and `gitoxide`; the script guards on
+  `[ ! -d "<dest>/.git" ]`, makes the parent dir, then runs
+  `gix clone <depthFlag> <refFlag> <url> <dest>` (`default.nix:69-80`). The unit
+  is wanted by `multi-user.target` only when `activation == "multi-user"`.
+- `systemd.timers.git-clone` (`default.nix:83`): present only when
+  `activation == "timer"`; `OnBootSec = 15s`, fires `git-clone.service`.
+
+No port claim, no health check, no `ix` argument.
+
+`TODO` in source: use cross-VM shared CAS to speed up clones (`default.nix:3`).
+
+## How it is wired
+
+Auto-discovered as `services/git-clone`. No flake output; pure NixOS module.

--- a/docs/modules/home/overview.md
+++ b/docs/modules/home/overview.md
@@ -1,0 +1,58 @@
+# home
+
+`modules/home/` holds home-manager modules (workstation-facing, not NixOS
+system modules). It currently contains one file, `raycast.nix`. Unlike the
+service and profile modules, `modules/home/` is NOT auto-discovered:
+`discoverModules` only treats a directory with its own `default.nix` as a module,
+and `raycast.nix` is a bare file, so the walk yields nothing here (see
+[common](../common.md)). It is wired by explicit path as the flake output
+`homeModules.raycast` (`flake.nix:295`).
+
+The repo's other home-manager modules (`portable-services`, `mutable-json`,
+`andrewgazelka`, `ci-bars`, `indexer`) live outside `modules/` (in `lib/services/`
+and under `packages/`/`users/`) and are out of this domain's scope.
+
+## raycast (`programs.raycast.focus`)
+
+`modules/home/raycast.nix` declares Raycast Focus session defaults on macOS.
+Raycast stores Focus settings in the `com.raycast.macos` preferences domain. The
+title and filter mode are plain strings, but the session duration is a plist
+`<data>` value whose bytes are a JSON document; nix-darwin's attrset-to-plist
+generator has no `<data>` type, so this module writes every managed key with
+`defaults` instead, encoding the duration as JSON-in-data via `/usr/bin/od`
+(`raycast.nix:1-9`).
+
+Option namespace: `programs.raycast.focus` (`raycast.nix:58`).
+
+- `enable` (`raycast.nix:59`).
+- `title` (str, default `Deep Work`) - Focus session title (`raycast.nix:61`).
+- `filterMode` (enum `block`|`allow`, default `block`) - whether the blockable
+  list is a blocklist or allowlist (`raycast.nix:68`).
+- `duration.seconds` (positive int, default 900), `duration.title` (str,
+  `15 minutes`), `duration.id` (opaque preset identifier) (`raycast.nix:77-94`).
+- `categoryBlockableItems` / `blockableItems` (nullable str) - raw JSON for the
+  blockable apps/sites lists; unmanaged by default because the value is a large
+  Raycast-internal blob (`raycast.nix:96`, `:107`).
+
+## What it produces
+
+`config` (`raycast.nix:114`):
+
+- **Assertion** (`raycast.nix:115-120`): the module is macOS-only; it asserts
+  `pkgs.stdenv.hostPlatform.isDarwin` because it writes the `com.raycast.macos`
+  defaults domain.
+- **Activation script** `home.activation.raycastFocus` (`raycast.nix:122`),
+  ordered after `writeBoundary`: writes the string keys
+  (`raycast-startFocusSession-title`, `-filter-mode`) with `defaults write` and
+  the data keys (`-duration`, optional blockable lists) with `defaults write
+  -data` (hex via `od`).
+
+Caveat from source (`raycast.nix:11-14`): Raycast rewrites these keys when you
+edit a Focus session in its UI, so values apply at `home-manager switch` time
+and a running Raycast may not pick them up until relaunched.
+
+## How it is wired
+
+Referenced directly as `homeModules.raycast` in `flake.nix:295`; import it into a
+macOS home-manager configuration and set `programs.raycast.focus`. It pulls in no
+extra packages (uses the macOS-bundled `/usr/bin/defaults`, `od`, `tr`).

--- a/docs/modules/minecraft-bedrock/overview.md
+++ b/docs/modules/minecraft-bedrock/overview.md
@@ -1,0 +1,48 @@
+# minecraft-bedrock
+
+`modules/services/minecraft-bedrock/default.nix` runs the Minecraft Bedrock
+Dedicated Server. Bedrock is a native Linux server, so it is deliberately
+separate from the Java [minecraft](../minecraft/overview.md) loader family.
+
+Option namespace: `services.minecraft-bedrock` (`default.nix:104`).
+
+## What it runs
+
+The module builds the server itself (`default.nix:22-65`): a
+`stdenv.mkDerivation` that fetches `bedrock-server-1.26.14.1.zip` from
+`minecraft.net` (pinned hash, `--http1.1` + a browser UA), autopatchelfs the
+ELF, and installs `bedrock_server` with `meta.mainProgram`. This is the default
+`package`.
+
+## Public surface (options)
+
+- `enable` (`default.nix:105`).
+- `package` (default the built Bedrock server) (`default.nix:107`).
+- `port` (port, default 19132) - IPv4 UDP (`default.nix:113`).
+- `portv6` (port, default 19133) - IPv6 UDP (`default.nix:119`).
+- `openFirewall` (bool, default true) - opens both UDP ports (`default.nix:125`).
+- `settings` (keyValue) - `server.properties` values (`default.nix:131`).
+- `allowlist` (json) - `allowlist.json` (`default.nix:137`).
+- `permissions` (json) - `permissions.json` (`default.nix:143`).
+
+## What it produces
+
+- **Port claims** (`default.nix:151`): `minecraft-bedrock-ipv4` (udp, address
+  `0.0.0.0`) and `minecraft-bedrock-ipv6` (udp, address `::`).
+- **Settings defaults** (`default.nix:167`): `server-port`/`server-portv6`
+  default to the typed ports, `enable-lan-visibility = false`, all `mkDefault`.
+- **Firewall** opens both UDP ports when `openFirewall` (`default.nix:173`).
+- **systemd.services.minecraft-bedrock** (`default.nix:178`):
+  `ix.systemdHardening` + `WorkingDirectory=/var/lib/minecraft-bedrock`,
+  `ExecStart` the server, `StateDirectory=minecraft-bedrock`,
+  `KillSignal=SIGINT`, `TimeoutStopSec=30`. `preStart` (`default.nix:192`)
+  symlinks the static server assets (behavior_packs, resource_packs, config,
+  data, definitions, ...) from the package into the data dir and installs the
+  generated `server.properties`, `allowlist.json`, `permissions.json`.
+
+No health check is declared.
+
+## How it is wired
+
+Auto-discovered as `services/minecraft-bedrock`. The server package is built in
+the module itself via `fetchurl` (no flake output, no nixpkgs package).

--- a/docs/modules/minecraft/loaders-and-mods.md
+++ b/docs/modules/minecraft/loaders-and-mods.md
@@ -1,0 +1,65 @@
+# minecraft loaders and mods
+
+Companion to [overview](overview.md). The loader modules and mod submodules
+nested under `services/minecraft/` are discovered as nested keys
+(`services.minecraft.<loader>` and `services.minecraft.mods.<mod>`), because a
+sibling directory with its own `default.nix` nests under its parent (see
+[common](../common.md), discovery rules).
+
+## Loaders
+
+Each loader directory is a one-expression call to `ix.mkMinecraftLoader`
+(`lib/minecraft/loader.nix`). The helper owns `services.minecraft.<name>` with
+an `enable` flag and a `src` server-jar slot, assigns that jar to
+`services.minecraft.serverJar`, and defaults `services.minecraft.enable` and
+`dropinDir` (`lib/minecraft/loader.nix:38-60`). `src` defaults to
+`ix.artifacts.minecraft.servers."<version>-<name>"`, so a caller that sets
+`services.minecraft.version` rarely overrides anything per loader.
+
+| loader | option | dropinDir | notes |
+| --- | --- | --- | --- |
+| vanilla | `services.minecraft.vanilla` | mods | caller passes locked Mojang jar (`vanilla/default.nix`) |
+| paper | `services.minecraft.paper` | plugins | defaults `pluginCatalog` from `paperPluginCatalogs`; wires `paper-global.yml` `proxies.velocity` from `services.velocity.forwarding.secret` when present (`paper/default.nix`) |
+| folia | `services.minecraft.folia` | plugins | PaperMC regionized-multithreading fork (`folia/default.nix`) |
+| purpur | `services.minecraft.purpur` | plugins | Paper fork (`purpur/default.nix`) |
+| spigot | `services.minecraft.spigot` | plugins | CraftBukkit fork; caller passes the jar (BuildTools has no download API) (`spigot/default.nix`) |
+| neoforge | `services.minecraft.neoforge` | mods | installer-generated server jar (`neoforge/default.nix`) |
+| sponge | `services.minecraft.sponge` | mods | standalone SpongeVanilla (`sponge/default.nix`) |
+| fabric | `services.minecraft.fabric` | mods | defaults `javaPackage` to the shared Temurin major; loader/installer versions are baked into the pinned upstream URL (`fabric/default.nix`) |
+
+## Mods and plugins
+
+Each mod submodule activates only when the operator names it under
+`services.minecraft.mods.<slug>` or `services.minecraft.plugins.<slug>`. They
+merge config into the core module's `configFiles`/`serverFiles` and, where
+needed, open ports or provision a database.
+
+- **bluemap** (`mods/bluemap/default.nix`): 3D web map. Writes
+  `bluemap/{core,webserver,storages/sql}.conf`. Port claim `bluemap` (tcp,
+  default 8100) and opens it in the firewall. Optionally provisions MariaDB
+  (`services.mysql`) for tile storage when `mysql = true`.
+- **distant-horizons** (`mods/distant-horizons/default.nix`): server-side LOD
+  generation. Generates `DistantHorizons.toml` from the attrset (defaults
+  `serverSideLodGeneration = true`, `maxRenderDistance = 256`). Activated as
+  `services.minecraft.mods.distanthorizons`.
+- **luckperms** (`mods/luckperms/default.nix`): permissions. Optionally
+  provisions MariaDB and writes `LuckPerms/config.yml` with `storage-method =
+  mysql` when `mysql = true`.
+- **simple-voice-chat** (`mods/simple-voice-chat/default.nix`): proximity voice.
+  Writes `voicechat-server.properties`, claims and opens UDP port (default
+  24454). Works as a mod or a plugin.
+- **terraformgenerator** (`mods/terraformgenerator/default.nix`): Bukkit world
+  generation. Binds the generator to the plugin's `worlds` (or the configured
+  `level-name`) via `services.minecraft.worlds.<name>.generator =
+  "TerraformGenerator"`. Plugin only.
+
+bluemap and simple-voice-chat distinguish a mod install (`configFiles` under the
+mod's config dir) from a plugin install (`serverFiles` under `plugins/`) using
+the `mods.<slug>` vs `plugins.<slug>` entry the operator set.
+
+## How they are wired
+
+Loaders and mods are discovered as nested keys of the `minecraft` component, not
+as separate top-level modules. They consume `ix.artifacts.minecraft.*` for jars
+and catalogs. See [overview](overview.md) for the core option set the loaders
+fill and the mods extend.

--- a/docs/modules/minecraft/overview.md
+++ b/docs/modules/minecraft/overview.md
@@ -1,0 +1,84 @@
+# minecraft
+
+`modules/services/minecraft/default.nix` is the loader-agnostic Java Minecraft
+server runtime. It provides the systemd unit, the JVM, the port, and the
+managed-files machinery; `serverJar` and `dropinDir` are slots filled by a
+loader module (fabric, paper, vanilla, ...) via module merging. Loader and mod
+submodules are documented in [loaders-and-mods](loaders-and-mods.md); this page
+is the core module.
+
+Option namespace: `services.minecraft` (`default.nix:806`). This is one
+component dir (`services/minecraft/`) whose loaders and mods are nested module
+keys discovered as `services.minecraft.{fabric,paper,...}` and
+`services.minecraft.mods.{bluemap,...}` (see [common](../common.md) for the
+nesting rule).
+
+## How a server is assembled
+
+- A loader module (e.g. paper) sets `services.minecraft.serverJar` and
+  `dropinDir`, and defaults `enable` true (`mkMinecraftLoader`,
+  `lib/minecraft/loader.nix`). Set `services.minecraft.version` once and the
+  loader derives the jar from `ix.artifacts.minecraft.servers."<version>-<loader>"`.
+- `dropinDir` is where mod jars are symlinked: `mods` for fabric/neoforge/sponge,
+  `plugins` for paper/folia/purpur/spigot (`default.nix:828`).
+- All server config (server.properties, bukkit.yml, NBT) goes through
+  `serverFiles`; mod config files go through `configFiles` (placed under
+  `config/`) (`default.nix:9-11`).
+
+## Public surface (selected options)
+
+- `enable`, `version` (nullable str, single source of truth for jar + catalogs)
+  (`default.nix:807`, `:809`).
+- `serverJar` (package, loader-set), `dropinDir` (str, default `mods`)
+  (`default.nix:823`, `:828`).
+- `maxRAMPercentage` (int, 85), `javaPackage` (default Temurin JRE from
+  `lib/languages/jvm-defaults.nix`), `jvmFlags` (Aikar's G1 flags)
+  (`default.nix:834`, `:900`, `:902`).
+- `mods` (attrs keyed by Modrinth slug), `plugins` (Bukkit-family),
+  `datapacks`, `modCatalog` (defaults from `ix.artifacts.minecraft.modCatalogs`),
+  `pluginCatalog`, `players` (generate whitelist.json/ops.json by UUID)
+  (`default.nix:840-883`).
+- `whitelist.{enable,enforce}` (`default.nix:886`).
+- `properties` (server.properties), `bukkit`, `worlds`, `worldBorder`,
+  `serverFiles`, `configFiles` (`default.nix:1022-1052`).
+- `port` (port, 25565), `openFirewall` (bool, default false)
+  (`default.nix:1058`, `:1063`).
+- `rcon.{enable,port=25575,passwordFile,openFirewall,broadcastToOps}`
+  (`default.nix:934`).
+- `autoReload.{enable,driver,socketPath,rconPort,rconPasswordFile}` - reload
+  managed mods/plugins during `nixos switch` without restarting; `driver=auto`
+  uses JVM class redefinition for Fabric and PlugManX for Bukkit-family
+  (`default.nix:962`).
+- `yourkit` - YourKit profiler agent (`default.nix:1069`, semantics in
+  `ix.languages.java.yourkit`).
+
+## What it produces
+
+- **Port claims** (`default.nix:1180`): `minecraft` (tcp, `port`),
+  `minecraft-rcon` (when rcon enabled, `rconPort`), plus a YourKit claim.
+  Firewall opens `port`/`rconPort`/yourkit ports by their `openFirewall` flags
+  (`default.nix:1248`).
+- **Health checks** (`default.nix:1199`): `minecraft` (unit active),
+  `minecraft-status` (`mc-probe` SLP against loopback, optional
+  `--motd-contains`), and `minecraft-reachable` (host `nc` to `$IX_NODE_IPV4`)
+  when the firewall is open. `mc-probe` is `packages/minecraft/probe`, added to
+  `environment.systemPackages` (`default.nix:1246`).
+- **Extended attributes** (`default.nix:1167`): stamps `user.ix.minecraft.*`
+  xattrs on the data dir, dropin dir, config dir, worlds, datapacks (via
+  `ix.extendedAttributes`, see [profiles](../profiles/overview.md)).
+- **systemd.services.minecraft** (`default.nix:1260`): `ix.systemdHardening` +
+  `WorkingDirectory=/var/lib/minecraft`, `ExecStart` the JVM argv, `ExecReload`
+  the reload command, `StateDirectory=minecraft`. `reloadTriggers`/
+  `restartTriggers` are the managed roots depending on `autoReload`. `preStart`
+  writes `eula=true` and runs the managed-files sync.
+- **systemd.services.minecraft-world-border** (`default.nix:1287`, when
+  `worldBorder.enable`): a oneshot applying the border after the server is up.
+- `environment.etc."minecraft/managed-*"` expose the managed config/dropins/
+  datapacks/server-files/access trees (`default.nix:1252`).
+
+## How it is wired
+
+Auto-discovered as `services/minecraft` with nested loader/mod keys. Server jars
+and mod catalogs come from `ix.artifacts.minecraft.*` (built from
+`images/games/minecraft/`). JRE defaults to the pinned Temurin major. See
+[loaders-and-mods](loaders-and-mods.md).

--- a/docs/modules/minestom/overview.md
+++ b/docs/modules/minestom/overview.md
@@ -1,0 +1,44 @@
+# minestom
+
+`modules/services/minestom/default.nix` runs a Minestom server: a user-built fat
+jar. Minestom is a from-scratch server library, not a Minecraft fork, so unlike
+[minecraft](../minecraft/overview.md) there are no loaders, mods, or EULA. The
+repo's example server is `packages/minestom/servers/hello`.
+
+Option namespace: `services.minestom` (`default.nix:39`).
+
+## Public surface (options)
+
+- `enable` (`default.nix:40`).
+- `serverJar` (package, required) - the fat jar to launch, built from a
+  Gradle/Maven project that depends on Minestom (`default.nix:42`).
+- `maxRAMPercentage` (int, default 85) (`default.nix:47`).
+- `javaPackage` - default Temurin JRE from `lib/languages/jvm-defaults.nix`
+  (`default.nix:52`).
+- `jvmFlags` (list of str) - default `[ "-XX:+UseZGC" ]` (`default.nix:54`).
+  ZGC is chosen for sub-millisecond, heap-size-independent pauses; a single G1
+  pause near `MaxGCPauseMillis` would drop multiple 20-TPS ticks. Generational
+  ZGC is the default mode on the JDK 24+ Temurin JRE this module targets.
+- `port` (port, default 25565) (`default.nix:70`).
+- `openFirewall` (bool, default true) (`default.nix:75`).
+- `yourkit` - YourKit profiler agent (`default.nix:81`, type from
+  `ix.languages.java.yourkit`).
+
+## What it produces
+
+- **Port claim** (`default.nix:94`): `minestom` (tcp, `port`) plus a YourKit
+  claim when the profiler is enabled.
+- **Firewall** opens `port` (and yourkit ports) when `openFirewall`
+  (`default.nix:106`).
+- **systemd.services.minestom** (`default.nix:109`): `ix.systemdHardening` +
+  `WorkingDirectory=/var/lib/minestom`, `ExecStart` the JVM argv
+  (`<java> -XX:MaxRAMPercentage=<n> <yourkit flags> <jvmFlags> -jar <serverJar>`,
+  `default.nix:27-36`), `Restart=on-failure`, `StateDirectory=minestom`.
+
+No health check.
+
+## How it is wired
+
+Auto-discovered as `services/minestom`. The `serverJar` is passed in by the
+consumer (e.g. built from `packages/minestom/servers/<name>`); the JRE defaults
+to the pinned Temurin major.

--- a/docs/modules/observability/overview.md
+++ b/docs/modules/observability/overview.md
@@ -1,0 +1,78 @@
+# observability
+
+`modules/services/observability/default.nix` is a self-hosted OpenTelemetry
+pipeline for an ix fleet: one module, one OpenTelemetry Collector, telemetry
+landing in ClickHouse and rendered in Grafana. The same module runs everywhere;
+two flags pick what a node is. See the in-repo `README.md` for the flow
+diagrams.
+
+Option namespace: `services.ix-observability` (`default.nix:112`).
+
+## Two roles
+
+- **agent** (`agent.enable`): a local Collector on loopback that collects host
+  metrics, app logs, and SDK telemetry and forwards OTLP/gRPC to a stack node.
+- **stack** (`stack.enable`): the gateway Collector (binds `0.0.0.0`) plus
+  ClickHouse and Grafana. Writes the ClickHouse exporter.
+
+`enable = true` turns on both for a single node. The role-deriving defaults:
+`stack.enable` defaults to `enable` (`default.nix:134-138`); `agent.enable`
+defaults to `enable` (`default.nix:274`); `collector.enable` defaults to
+`stack.enable || agent.enable` (`default.nix:194`); `grafana.enable` and
+`query.enable` default to `stack.enable`.
+
+## Public surface (selected options)
+
+- `environment` (str, default `dev`) - stamped as `deployment.environment`
+  (`default.nix:115`).
+- `resourceAttributes` (attrs) - extra resource attrs inserted only when the
+  signal does not set them (`default.nix:121`).
+- `clickhouse.*`: `package` (default `pkgs.clickhouse`), `database` (`otel`),
+  `host` (`127.0.0.1`), `listenAddress`, `nativePort` (9000), `httpPort` (8123),
+  `ttl` (`168h` = 7 days), `openFirewall` (false) (`default.nix:140-191`).
+- `collector.*`: `package` (default `opentelemetry-collector-contrib`, required
+  for the ClickHouse exporter), `listenAddress`, `grpcPort` (4317), `httpPort`
+  (4318), `healthPort` (13133, loopback), `openFirewall` (default
+  `stack.enable`), `validateConfig` (true), `clickhouse.enable`, and
+  `forward.{enable,endpoint,insecure}` for east-west forwarding
+  (`default.nix:193-271`).
+- `agent.*`: `endpoint` (remote collector for an agent-only node),
+  `hostMetrics.enable` (true), `filelog.paths` (log globs), `journal.enable`
+  (`default.nix:273-305`).
+- `grafana.*`: `enable`, `port` (3000), `openFirewall` (false),
+  `anonymousViewer`, `secretKeyFile` (`default.nix:307-337`).
+- `query.enable` - install the `ix-observe` CLI (`default.nix:339`).
+
+## What it produces
+
+The `config` is an `mkMerge` of four gated blocks (`default.nix:346`):
+
+- **stack** (`default.nix:357`): enables `services.clickhouse` with the native
+  and HTTP ports, port claims `clickhouse-native`/`clickhouse-http`, firewall
+  gated by `clickhouse.openFirewall`, and a `SELECT 1` health check.
+- **collector** (`default.nix:403`): enables `services.opentelemetry-collector`
+  with generated `settings`. Receivers: `otlp` always, plus `hostmetrics`
+  (cpu/disk/filesystem/load/memory/network/paging/processes),
+  `filelog/app`, and `journald` on an agent. Processors run in order:
+  `memory_limiter`, `resource` (stamps `service.namespace=ix`,
+  `deployment.environment`, `ix.collector.node`), `batch`. Exporters:
+  `clickhouse` (on the stack; `create_schema`, `async_insert`, `lz4`,
+  `otel_logs`/`otel_traces`/`otel_metrics_*` tables, `ttl`) and `otlp` (forward).
+  Three pipelines (traces, metrics, logs) share the exporters. Asserts at least
+  one exporter exists and a forward endpoint is set when forwarding
+  (`default.nix:404-413`). Port claims `otel-grpc`/`otel-http`; health check hits
+  the loopback health extension.
+- **grafana** (`default.nix:570`): enables `services.grafana` with the
+  ClickHouse datasource plugin, the provisioned `ClickHouse` datasource
+  (uid `ix-clickhouse`), the provisioned `overview` dashboard
+  (`_dashboards/overview.nix`), a generated secret key (preStart,
+  `default.nix:651`), port claim `grafana`, and an `/api/health` check.
+- **query** (`default.nix:675`): installs `ix-observe`, a Nushell helper
+  (`default.nix:55-109`) with subcommands `logs`, `errors`, `slow-spans`,
+  `trace <id>`, `sql ...` querying ClickHouse as `JSONEachRow`.
+
+## How it is wired
+
+Auto-discovered as `services/observability`. Dashboards live under
+`_dashboards/` (underscore-prefixed, so discovery skips them). All packages are
+nixpkgs (clickhouse, opentelemetry-collector-contrib, grafana); no flake output.

--- a/docs/modules/postgresql/overview.md
+++ b/docs/modules/postgresql/overview.md
@@ -1,0 +1,50 @@
+# postgresql
+
+`modules/services/postgresql/default.nix` runs PostgreSQL 18 with defaults tuned
+for an AMD EPYC Gen 5 (Zen 5) VM. It is a thin opinionated layer over the
+upstream nixpkgs `services.postgresql`, which is why it claims its own `ix-`
+namespace rather than clobbering the stock option tree.
+
+Option namespace: `services.ix-postgresql` (`default.nix:20`).
+
+## Public surface (options)
+
+- `enable` (`default.nix:21`).
+- `port` (port, default 5432) (`default.nix:23`).
+- `openFirewall` (bool, default true) (`default.nix:28`).
+- `dataDir` (str, default `/var/lib/postgresql/18`) (`default.nix:34`).
+- `sharedBuffersMiB` (positive int, default 256) (`default.nix:39`). The single
+  resize knob: it drives both the rendered `shared_buffers` and the kernel
+  `vm.nr_hugepages` reservation so the two stay coherent.
+
+## What it produces
+
+- **Port claim + firewall.** `ix.networking.portClaims.ix-postgresql` (tcp) and
+  `networking.firewall.allowedTCPPorts` gated by `openFirewall`
+  (`default.nix:53-59`).
+- **Health check.** `ix.healthChecks.ix-postgresql` runs `pg_isready --quiet
+  --host /run/postgresql --port <port>` from the guest (`default.nix:61-76`). It
+  is a real readiness probe (accepts connections), catching "starting up" /
+  "rejecting connections" / crashed-but-not-failed states that
+  `systemctl is-active` misses.
+- **Kernel sysctls** (`default.nix:95-100`): `vm.nr_hugepages =
+  (sharedBuffersMiB / 2) + 32` (sized for `shared_buffers` plus 64 MiB
+  `wal_buffers` and per-connection mappings; required because `huge_pages =
+  "on"` makes postmaster refuse to start without the pool), `vm.swappiness = 1`,
+  `vm.dirty_background_ratio = 5`, `vm.dirty_ratio = 10`.
+- **`services.postgresql`** (`default.nix:102`): `package = pkgs.postgresql_18`,
+  `enableJIT = true`, and tuned `settings` written with `mkDefault` so a user
+  `services.postgresql.settings.<key>` overrides them (`default.nix:110`). Notable
+  defaults: `max_connections = 200`, `effective_cache_size = 768MB`,
+  `wal_compression = zstd`, `io_method = worker` / `io_workers = 8` (PG 18 async
+  I/O), NVMe planner costs (`random_page_cost = 1.1`,
+  `effective_io_concurrency = 200`), `huge_pages = on`, `jit = on`,
+  `log_min_duration_statement = 1000` (log queries over 1s).
+
+## How it is wired
+
+Auto-discovered as `services/postgresql`. Takes `config`, `lib`, `pkgs` (no `ix`
+argument), but still uses `ix.networking.portClaims` / `ix.healthChecks`, which
+are option namespaces from the platform module (see
+[nix-lib](../../nix-lib/common.md)), not the `ix` specialArg. No flake package
+output; the engine is `pkgs.postgresql_18`.

--- a/docs/modules/profiles/overview.md
+++ b/docs/modules/profiles/overview.md
@@ -1,0 +1,99 @@
+# profiles
+
+`modules/profiles/` holds opt-in runtime profiles: cross-cutting NixOS config a
+VM turns on once instead of repeating per service. Three modules are discovered
+here (`profiles/base`, `profiles/jvm`, `profiles/extended-attributes`); each owns
+its own option namespace. They are auto-discovered like any module (see
+[common](../common.md)), but only `base` is auto-enabled.
+
+## base (`ix.profiles.base`)
+
+`modules/profiles/base/default.nix` ships the cross-cutting CLI and shell setup
+every VM should have for debugging and introspection. It is auto-enabled by
+`lib/image/oci-layer.nix:62` (`mkDefault true`), so it is on unless an image
+opts out.
+
+Option namespace: `ix.profiles.base` (`default.nix:17`).
+
+- `enable` (`default.nix:18`).
+- `shellWorkspace.enable` (bool, default true) - pre-create a writable workspace
+  and auto-cd login shells into it (`default.nix:21`).
+- `shellWorkspace.directory` (str, default `/work/ix`) (`default.nix:31`).
+
+What it produces (`default.nix:39`):
+
+- **Networking sysctls** (`default.nix:56-59`): BBR congestion control + `fq`
+  qdisc, chosen for loss-insensitive throughput on residential last-miles that
+  every inbound workload here faces (Minecraft players, Xpra clients, repo
+  fetches). A no-op if `tcp_bbr` is absent.
+- **Home Manager root config** (`default.nix:66`, Home Manager used as a NixOS
+  module): Nushell as the login shell with `config.nu`/`login.nu`, plus
+  `bash`/`zsh`/`fish` rc ownership so the integration flags below are not inert;
+  `btop` (tuned gotham layout), `starship`, `atuin`, `zoxide`, `direnv`
+  (nix-direnv), `fzf`, `mergiraf` (AST merge driver), `delta`, and a large `git`
+  config (aliases, rebase/rerere/maintenance defaults). `env.nu` surfaces the
+  workspace path as `$env.IX_WORKDIR`.
+- **System shells + editor** (`default.nix:381`): `zsh`/`fish` NixOS modules and
+  `neovim` wired through the NixOS module (config baked into the wrapper:
+  treesitter with all grammars, telescope, gitsigns, which-key, oil, a Lua
+  agent dispatcher, and the `ix-islands` colorscheme generated from
+  `ix.islandsTheme`). `defaultEditor`, `vi`/`vim` aliases.
+- **`environment.systemPackages`** (`default.nix:473`): debugging and editing
+  CLI (`ast-grep`, `bat`, `bpftrace`, `gdb`, `lldb`, `strace`, `tcpdump`,
+  `pahole`, `drgn`, `eu-*` from elifutils, `ripgrep`, `fd`, `mgrep`, `jq`,
+  `nh`/`nix-tree`/`nix-output-monitor`, `zellij`, `helix`/`micro`, `gnutar`/
+  `gzip`/`zstd`), plus the `ix.packages.mcp` engine.
+- **tmpfiles** pre-create the workspace dir when `shellWorkspace.enable`
+  (`default.nix:550`).
+
+## jvm (`ix.profiles.jvm`)
+
+`modules/profiles/jvm/default.nix` is the runtime side of the JVM toolchain:
+opt-in, ships a JRE on PATH and sets `JAVA_HOME` so a VM that exists to run a
+`.jar` (Minecraft, Velocity, Minestom) does not repeat the boilerplate. Build-time
+helpers (`ix.languages.java.{jdk,maven,gradle}`) stay separate.
+
+Option namespace: `ix.profiles.jvm` (`default.nix:20`).
+
+- `enable` (`default.nix:21`).
+- `package` (package) - JRE added to `systemPackages` and pointed at by
+  `JAVA_HOME`; default is the Temurin JRE pinned in
+  `lib/languages/jvm-defaults.nix`, the same major the Minecraft/Minestom/Velocity
+  service modules default to, so an image and a service share one store path
+  (`default.nix:23`).
+
+Config sets `environment.systemPackages = [ package ]` and
+`environment.variables.JAVA_HOME` (`default.nix:43-47`).
+
+## extended-attributes (`ix.extendedAttributes`)
+
+`modules/profiles/extended-attributes/default.nix` applies filesystem extended
+attributes during system activation. This is the option backing the
+`ix.extendedAttributes` writes other modules make (e.g.
+[minecraft](../minecraft/overview.md) stamps `user.ix.minecraft.*` on its data
+dirs).
+
+Option namespace: `ix.extendedAttributes` (`default.nix:107`), an attrset keyed
+by absolute path; each entry is `{ create, attributes }` (`default.nix:16-30`):
+
+- `create` (bool) - create the path as a directory first; missing paths are
+  otherwise skipped (`default.nix:18`).
+- `attributes` (attrs of str) - xattrs to set; names must use the `user.`
+  namespace (`default.nix:24`).
+
+Config (`default.nix:120`):
+
+- **Assertions**: keys must be absolute paths without empty or `..` segments;
+  attribute names must use the `user.*` namespace (`default.nix:121-130`).
+- Adds `pkgs.attr` and registers
+  `system.activationScripts.ix-extended-attributes` (`default.nix:132-134`),
+  which runs `setfattr` per path. It gracefully skips paths on filesystems
+  without xattr support and refuses to write through a symlink. This is metadata,
+  not a containment boundary.
+
+## How they are wired
+
+All three are auto-discovered under `profiles/`. `base` is auto-enabled by the
+OCI image layer; `jvm` and `extended-attributes` stay inert until enabled (or, for
+extended-attributes, until another module writes a non-empty
+`ix.extendedAttributes`).

--- a/docs/modules/ray/overview.md
+++ b/docs/modules/ray/overview.md
@@ -1,0 +1,80 @@
+# ray
+
+`modules/services/ray/default.nix` runs one Ray cluster spanning the tailnet,
+plus the ix-mcp engine that drives it. It is the deployment side of the `fleet`
+Python module bundled in ix-mcp (`packages/mcp`): `fleet.run`/`fleet.submit`
+ship cloudpickled callables to Ray and the object store carries the data;
+`fleet.in_kernel` runs code in a node's live ix-mcp session over `/api/exec`.
+
+Option namespace: `services.ix-ray` (`default.nix:192`).
+
+## Topology and repo-agnostic shape
+
+One Ray cluster. Exactly one node sets `role = "head"` (it holds the GCS); every
+other node is `role = "worker"` pointing `headAddress` at the head's tailscale
+IP. Daemons bind their tailscale IPv4 (resolved at runtime), so the cluster
+lives on the tailnet, which is the trust boundary (Ray has no per-call auth).
+
+The module declares no `ix.*` NixOS options, so it imports into any NixOS
+system. It takes the index lib through `_module.args.indexLib` (named, not `ix`,
+because a host binds `ix` to its own specialArg) for
+`writeNushellApplication`/`systemdHardening` (`default.nix:30-43`). The ix-mcp
+engine is handed in via `notebookPackage`.
+
+## Public surface (options)
+
+- `enable`, `role` (`head`|`worker`, default `worker`), `headAddress` (nullable;
+  required on workers, null on head) (`default.nix:193-216`).
+- `package` (default `python3Packages.ray`) - the same Ray the ix-mcp
+  interpreter imports, so cluster and kernels run identical versions
+  (`default.nix:218`).
+- `notebookPackage` (nullable package) - the ix-mcp package providing the
+  `ix-notebook` engine binary; required when `notebook.enable`
+  (`default.nix:226`).
+- Pinned ports: `gcsPort` (6379), `clientServerPort` (10001, head only, the
+  `ray://` endpoint `fleet.connect()` uses), `nodeManagerPort` (6380),
+  `objectManagerPort` (6381), `workerPortLow`/`workerPortHigh` (10002-10031),
+  `execPort` (8799, the ix-mcp `/api/exec` port, must match the `fleet` module's
+  `IX_FLEET_EXEC_PORT`) (`default.nix:237-285`).
+- `objectStoreMemory` (nullable bytes) - Plasma store size; null autodetects
+  (~30% RAM). Spills to `/var/lib/ray/spill` when full (`default.nix:287`).
+- `notebook.enable` (default true) - run the ix-mcp engine on this node
+  (`default.nix:299`).
+- `execTrustNetwork` (default true) - trust the tailnet as the `/api/exec` auth
+  boundary; `tokenFile` adds a bearer token (`default.nix:309`, `:321`).
+- `openFirewall` (default false) - open inter-node ports; usually unnecessary on
+  a tailnet (`default.nix:333`).
+
+## Key internals
+
+- **Mode args** (`default.nix:74-89`): head gets `--head --port <gcsPort>
+  --ray-client-server-port <clientServerPort> --include-dashboard false` (the web
+  dashboard needs `ray[default]` extras nixpkgs omits); worker gets `--address
+  <headAddress>:<gcsPort>`. Common args pin the node/object manager and worker
+  ports, `--temp-dir /run/ray` (short path so the AF_UNIX plasma socket stays
+  under the 108-byte `sun_path` limit), and the filesystem spill config.
+- **Launchers** (`default.nix:115`, `:152`): Nushell apps that resolve this
+  node's tailscale IPv4 at runtime, fail loudly if tailscale is down, then exec
+  `ray start ... --node-ip-address <ip> --block`. The notebook launcher also sets
+  `IX_MCP_HOST` and `RAY_ADDRESS` and execs `ix-notebook`.
+- **Assertions** (`default.nix:346-359`): head must not set `headAddress`; a
+  worker must; `notebook.enable` requires `notebookPackage`.
+
+## What it produces
+
+- `networking.firewall` (only when `openFirewall`): exec + node/object manager
+  ports, worker range, and on the head the GCS + client-server ports
+  (`default.nix:361-377`).
+- `systemd.services.ix-ray` (`default.nix:379`): `indexLib.systemdHardening` +
+  `DynamicUser`, `RuntimeDirectory`/`StateDirectory = ray`, after
+  `tailscaled.service`. `PrivateDevices` and `PrivateUsers` are forced off so an
+  attaching kernel can map the shared-memory object store.
+- `systemd.services.ix-ray-notebook` (`default.nix:408`, when
+  `notebook.enable`): the ix-mcp engine, requires `ix-ray.service`, same
+  shared-memory exceptions.
+
+## How it is wired
+
+Auto-discovered as `services/ray`, but consumed standalone via `indexLib` +
+`notebookPackage`. Runs `python3Packages.ray` and the ix-mcp engine from
+`packages/mcp`.

--- a/docs/modules/remote-desktop/overview.md
+++ b/docs/modules/remote-desktop/overview.md
@@ -1,0 +1,54 @@
+# remote-desktop
+
+`modules/services/remote-desktop/default.nix` exposes a browser-accessible
+remote desktop backed by Xpra's built-in HTML5 client. The default session is an
+icewm window manager with an xterm, built as a Nushell launcher.
+
+Option namespace: `services.remote-desktop` (`default.nix:68`).
+
+## Public surface (options)
+
+- `enable` (`default.nix:69`).
+- `package` (default `pkgs.xpra`) (`default.nix:71`).
+- `port` (port, default 6080) - HTML5 client port (`default.nix:73`).
+- `bindAddress` (str, default `0.0.0.0`) (`default.nix:79`).
+- `openFirewall` (bool, default false) (`default.nix:85`).
+- `display` (str, default `:100`) - X display Xpra manages (`default.nix:91`).
+- `resolution` (str, default `1920x1080`) (`default.nix:97`).
+- `desktopCommand` (str, default the bundled icewm+xterm session)
+  (`default.nix:103`).
+- `auth` (str, default `none`) - Xpra auth module (`default.nix:110`).
+- `allowUnauthenticated` (bool, default false) - explicit opt-in to open the
+  firewall while `auth = "none"` (`default.nix:116`).
+- `settings` (attrs of bool/int/str/list) - raw `xpra start-desktop` flags
+  rendered via `lib.cli.toCommandLineGNU` (`default.nix:126`). Convenience
+  options seed this set via `mkDefault` (`default.nix:165-182`): `start`,
+  `bind-tcp`, `auth`, `resize-display`, `socket-dirs`, `html=on`, `ssl=off`,
+  `daemon=no`, and various feature toggles (clipboard on; pulseaudio,
+  notifications, webcam, printing, file-transfer off).
+
+## Key internals
+
+- The launcher (`ix-remote-desktop`, a `writeNushellApplication`) execs
+  `xpra start-desktop <display> <flags...>` (`default.nix:46-65`).
+- Two assertions keep the endpoint coherent (`default.nix:143-156`): opening the
+  firewall with the rendered auth `none` requires `allowUnauthenticated`; and the
+  rendered `settings.bind-tcp` must equal `<bindAddress>:<port>` so Xpra, the
+  port claim, and the firewall all use one endpoint.
+
+## What it produces
+
+- `ix.networking.portClaims.remote-desktop` (tcp, address `bindAddress`)
+  (`default.nix:158`). Firewall on `port` when `openFirewall`
+  (`default.nix:190`). No health check.
+- A dedicated `remote-desktop` system user/group with home
+  `/var/lib/remote-desktop` (`default.nix:192-198`).
+- `systemd.services.remote-desktop` (`default.nix:200`): runs as that user,
+  `HOME=/var/lib/remote-desktop`, `StateDirectory`/`RuntimeDirectory =
+  remote-desktop`, `ExecStart` = the launcher.
+- `environment.systemPackages` adds `xpra`, `icewm`, `xterm`
+  (`default.nix:184`).
+
+## How it is wired
+
+Auto-discovered as `services/remote-desktop`. Runs `pkgs.xpra`; no flake output.

--- a/docs/modules/resource-monitor/overview.md
+++ b/docs/modules/resource-monitor/overview.md
@@ -1,0 +1,57 @@
+# resource-monitor
+
+`modules/services/resource-monitor/default.nix` serves a browser-accessible VM
+resource monitor: a small Rust sampler writes a stats JSON on an interval and an
+nginx-served Svelte single-page app renders live CPU / memory / storage usage and
+a billing estimate. Both halves live in this module directory.
+
+Option namespace: `services.resource-monitor` (`default.nix:126`).
+
+## What it runs
+
+- **`resource-monitor-stats-writer`** - a Rust workspace crate in
+  `modules/services/resource-monitor/stats-writer/` (a root `Cargo.toml`
+  workspace member, listed at `Cargo.toml:3`). `src/main.rs` loops every
+  `interval-seconds`, samples `/proc/stat` CPU deltas and memory, shells out to
+  `df` for storage, computes a USD/hour billing estimate, and writes the JSON
+  (`stats-writer/src/main.rs:44-52`). The module selects the binary via
+  `ix.cargoUnit.selectBinaryWithTests` (`default.nix:100`).
+- **the Svelte site** - `modules/services/resource-monitor/site/`, built with
+  `ix.buildSvelteSite` (`default.nix:85`). A generated `vm-config.json`
+  (advertised capacities + billing rates) is copied in at build time
+  (`default.nix:89-91`), so the UI shows the same numbers the writer bills with.
+
+## Public surface (options)
+
+- `enable` (`default.nix:127`).
+- `port` (port, default 80) - nginx port (`default.nix:129`).
+- `openFirewall` (bool, default true) (`default.nix:135`).
+- `intervalSeconds` (positive int, default 1) - seconds between samples
+  (`default.nix:141`).
+- `runtimeDirectory` (str, default `/run/resource-monitor`) - where the stats
+  JSON is written; asserted to be a managed `/run` subdirectory with safe
+  segments (`default.nix:147`, asserted `default.nix:155-160`).
+- Capacity/billing knobs are generated from `metricOptions`
+  (`default.nix:22-65`) and merged into the option set
+  (`metricOptionAttrs`, `default.nix:126`): `vcpu` (64), `memoryGiB` (256),
+  `storageTiB` (1024), `cpuUsdPerVcpuMonth` (20), `memoryUsdPerGibHour` (0.005),
+  `storageUsdPerTibHour` (0.0031), `marginMultiplier` (2).
+
+## What it produces
+
+- `ix.networking.portClaims.resource-monitor` (tcp, address `0.0.0.0`)
+  (`default.nix:162`). Firewall opened on `port` when `openFirewall`
+  (`default.nix:198`). No health check.
+- `systemd.services.resource-monitor` (`default.nix:169`): `ix.systemdHardening`
+  + `DynamicUser = true`, `RuntimeDirectory` = the `/run` subdir,
+  `ExecStart` = the stats-writer binary with `--<flag> <value>` args derived from
+  `statsWriterSettings` (`default.nix:105-123`).
+- `services.nginx` (`default.nix:182`): a default virtual host listening on
+  `port`, root at the built site, `/stats.json` rooted at `runtimeDirectory`, and
+  SPA fallback `tryFiles $uri $uri/ /index.html`.
+
+## How it is wired
+
+Auto-discovered as `services/resource-monitor`. The stats-writer is built from
+the Rust workspace; the site via the repo Svelte builder. No standalone flake
+output.

--- a/docs/modules/seaweedfs/overview.md
+++ b/docs/modules/seaweedfs/overview.md
@@ -1,0 +1,54 @@
+# seaweedfs
+
+`modules/services/seaweedfs/default.nix` runs single-node S3-compatible object
+storage. One `weed server -s3` process runs the master, volume, filer, and S3
+gateway in a single binary, so a single node needs no orchestration (enabling
+`-s3` auto-starts the filer it depends on). SeaweedFS is chosen as the fastest
+single-node S3 surface in nixpkgs (Apache-2.0); the source note rejects MinIO
+(AGPL, gutted OSS console) and Garage (AGPL, weaker on small objects).
+
+Option namespace: `services.ix-seaweedfs` (`default.nix:54`).
+
+## Public surface (options)
+
+- `enable` (`default.nix:55`).
+- `package` (default `pkgs.seaweedfs`) (`default.nix:57`).
+- `port` (port, default 8333) - S3 gateway listen port (`default.nix:59`).
+- `bindAddress` (str, default `0.0.0.0`) - listen address for every listener;
+  exposure is bounded by the firewall, which only opens `port` (`default.nix:65`).
+- `openFirewall` (bool, default true) (`default.nix:75`).
+- `configFile` (nullable path) - SeaweedFS S3 identities config (`-s3.config`)
+  with access/secret key pairs; point at a runtime secret so credentials never
+  enter the store (`default.nix:81`).
+- `allowAnonymous` (enable option) - explicit opt-in to unauthenticated S3
+  access (`default.nix:93`).
+- `extraArgs` (list of str) - appended to `weed server` (`default.nix:98`).
+
+## Key internals
+
+- The server argv pins `-dir=/var/lib/seaweedfs` (equal to the systemd
+  `StateDirectory`, because `weed server` refuses to start unless `-dir` exists
+  and is writable and does not create it), `-ip=127.0.0.1` (peers advertise
+  loopback on one node), `-ip.bind=<bindAddress>`, `-s3`, `-s3.port=<port>`, plus
+  optional `-s3.config` and `extraArgs` (`default.nix:42-51`).
+- **Credentials assertion** (`default.nix:110-118`): refuses to evaluate unless
+  `configFile != null` or `allowAnonymous` is set, so an unauthenticated S3
+  endpoint is never the silent default.
+
+## What it produces
+
+- `ix.networking.portClaims.ix-seaweedfs` (tcp) + firewall gated by
+  `openFirewall` (`default.nix:120-126`).
+- `ix.healthChecks.ix-seaweedfs`: `curl --fail
+  http://127.0.0.1:<port>/healthz`, served unauthenticated and only once the
+  gateway and its filer are up (`default.nix:128-143`).
+- `systemd.services.ix-seaweedfs` (`default.nix:145`): `ix.systemdHardening` +
+  `DynamicUser = true`, `StateDirectory = seaweedfs`, and `WorkingDirectory =
+  /var/lib/seaweedfs` (ProtectSystem=strict makes CWD `/` read-only, but `weed`
+  resolves filer.toml/security.toml relative to CWD, so it points at the
+  writable state dir).
+
+## How it is wired
+
+Auto-discovered as `services/seaweedfs`. Runs `pkgs.seaweedfs`; no flake output
+of its own.

--- a/docs/modules/spark/overview.md
+++ b/docs/modules/spark/overview.md
@@ -1,0 +1,80 @@
+# spark
+
+`modules/services/spark/default.nix` runs Apache Spark 3.5 as a standalone
+cluster over Tailscale, shipping the Gluten + Velox native execution engine by
+default. Plain Spark runs physical operators on the JVM; Gluten offloads them to
+Velox, a vectorized C++ engine, which is the source of the analytical speedups.
+Enabling it is more than a classpath jar: Velox allocates off-heap and needs a
+columnar shuffle manager, so the generated `spark-defaults.conf` wires the
+plugin, off-heap memory, and columnar shuffle together.
+
+Option namespace: `services.ix-spark` (`default.nix:191`).
+
+## Topology and repo-agnostic shape
+
+One Spark cluster. Exactly one node is `role = "master"` (runs the master daemon
+and optionally a Spark Connect server); every other node is `role = "worker"`
+and sets `masterAddress` to the master's tailscale IPv4. Daemons bind their
+tailscale IPv4 at runtime (the `__IP__` token in argv is substituted by the
+launcher), so the cluster and trust boundary are the tailnet.
+
+Like [ray](../ray/overview.md), it declares no `ix.*` options and takes the
+index lib via `_module.args.indexLib` (`default.nix:30-33`). The Spark
+distribution and Gluten bundle are index-overlay packages, so an off-index
+consumer passes them via `package` / `nativeEngine.package`.
+
+## Public surface (options)
+
+- `enable`, `role` (`master`|`worker`, default `master`), `masterAddress`
+  (nullable; required on workers) (`default.nix:192-217`).
+- `package` (default `pkgs.spark-hive`) - the complete Spark 3.5 distribution
+  (hadoop3 + Hive) on JDK 17. Hive is mandatory: Gluten's
+  `HiveTableScanExecTransformer` eagerly loads Hive input-format classes during
+  planning, so the lean nixpkgs `spark` cannot initialize it (`default.nix:219`).
+- `master.port` (7077), `master.webUiPort` (8080) (`default.nix:230-241`).
+- `worker.enable` (true; co-locate a worker with the master),
+  `worker.webUiPort` (8081), `worker.cores` (nullable), `worker.memory`
+  (nullable size string) (`default.nix:243-265`).
+- `connect.enable` (true; Spark Connect gRPC server on the master),
+  `connect.port` (15002) (`default.nix:267-282`).
+- `nativeEngine.enable` (true), `nativeEngine.package` (default
+  `pkgs.spark-gluten`), `nativeEngine.offHeapSize` (`2g`, the main Velox memory
+  knob) (`default.nix:284-305`).
+- `openFirewall` (false) (`default.nix:307`).
+- `settings` (attrs) - extra `spark-defaults.conf` entries merged over the tuned
+  defaults; your keys win (`default.nix:313`).
+
+## Key internals
+
+- **Generated config** (`default.nix:98-119`): tuned defaults (adaptive query
+  execution, Kryo serializer, pinned driver port 7078 / block-manager ports
+  7079-7080) plus the native-engine block when enabled (Gluten plugin, Velox
+  backend, columnar shuffle, off-heap memory, the Gluten jar on driver/executor
+  classpaths, and `nativeJavaOpts`). `cfg.settings` is merged on top.
+- **`nativeJavaOpts`** (`default.nix:74-81`): `--add-opens` for Arrow's JNI on
+  JDK 17, `io.netty.tryReflectionSetAccessible=true` for Arrow's off-heap
+  allocator, and `java.io.tmpdir` pinned to on-disk state (Gluten extracts
+  ~270 MiB of native libs per JVM, which would burn RAM on the tmpfs `/tmp`).
+- **Launcher** (`default.nix:135-156`): a Nushell app resolving the tailscale
+  IPv4, setting `SPARK_LOCAL_IP`, substituting `__IP__` in every arg, then
+  exec'ing the Spark daemon.
+- **tzdata workaround** (`default.nix:349-351`): symlinks
+  `/usr/share/zoneinfo` to the nixpkgs tzdata path because Velox hardcodes the
+  FHS path; without it every Gluten query fails with `discover_tz_dir`.
+
+## What it produces
+
+- Firewall (when `openFirewall`): inter-node data ports 7078-7080 always, plus
+  master RPC/web UI/Connect and worker web UI by role (`default.nix:361-376`).
+- `spark` system user/group (`default.nix:353-359`).
+- `systemd.services` built from `mkUnit` (`default.nix:158-178`,
+  `indexLib.systemdHardening`, after `tailscaled.service`), gated by role:
+  `spark-master`, co-located `spark-worker`, `spark-connect` (launched through
+  `start-connect-server.sh`, not `spark-class`, so spark-submit args take
+  effect), and a remote `spark-worker` on worker nodes
+  (`default.nix:378-465`). No `ix.*` port claims or health checks (repo-agnostic).
+
+## How it is wired
+
+Auto-discovered as `services/spark`, consumed standalone via `indexLib`. Runs
+`spark-hive` + `spark-gluten` from the index overlay.

--- a/docs/modules/symphony/overview.md
+++ b/docs/modules/symphony/overview.md
@@ -1,0 +1,71 @@
+# symphony
+
+`modules/services/symphony/default.nix` is a minimal, opinionated systemd unit
+for the Symphony runtime (`packages/symphony`, the Phoenix/Elixir agent
+orchestrator whose `package` provides `/bin/symphony`). The module is
+deliberately small: it reads secrets from an `EnvironmentFile` you control, so
+any secret manager (sops-nix, agenix, Bitwarden Secrets Manager, ...) wires
+underneath.
+
+Option namespace: `services.symphony` (`default.nix:26`).
+
+## Public surface (options)
+
+- `enable` (`default.nix:27`).
+- `package` (package, required) - the Symphony build providing `/bin/symphony`
+  (`default.nix:29`).
+- `user` (str, default `symphony`) - run-as user (`default.nix:34`).
+- `stateDir` (path, default `/var/lib/symphony`) - runs, workspaces, logs,
+  staged runtime (`default.nix:40`).
+- `httpPort` (port, default 4040) - Phoenix HTTP listener (`default.nix:46`).
+- `primaryRepo` / `repoRoot` (nullable path) - `SYMPHONY_PRIMARY_REPO` /
+  `SYMPHONY_REPO_ROOT` (`default.nix:52`, `:58`).
+- `workflowPack` (str, default `example`) / `packDir` (nullable path,
+  precedence) - built-in vs external workflow pack (`default.nix:64`, `:70`).
+- `roomRegistryUrl` / `roomAdvertiseHost` / `roomServerUrl` (nullable str) -
+  room.ix.dev registration and per-run room-server addressing
+  (`default.nix:76`, `:88`, `:100`).
+- `extraEnvironment` (attrs of str) - non-secret env (LINEAR_WORKSPACE_SLUG,
+  SYMPHONY_BOT_*, ...) (`default.nix:109`).
+- `environmentFile` (nullable path) - systemd EnvironmentFile holding secrets
+  (LINEAR_API_KEY, GITHUB_TOKEN, webhook secrets, Slack tokens, ...)
+  (`default.nix:120`).
+- `secretsCommand` (nullable list of str) - a wrapper that injects secrets and
+  execs its trailing args, e.g. `bws run -- ...`; prepended to ExecStart
+  (`default.nix:134`).
+- `path` (list of package) - extra packages on the service PATH, e.g.
+  `pkgs.bws` (`default.nix:157`).
+- `hostRuntime` (submodule) - the host codex placement (`default.nix:163`):
+  `enable`, `user`, `group`, `workspacesDir`, `roomServerPackage`, `keep`. When
+  enabled, a workflow node declaring `location: host` runs codex directly on this
+  machine as a real OS user via transient `systemd-run --uid` units.
+
+## Key internals
+
+- **Assertions** (`default.nix:214-223`): `hostRuntime.user` and
+  `hostRuntime.roomServerPackage` must be set when `hostRuntime.enable`.
+- **polkit grant** (`default.nix:231-244`): host runtime calls
+  `StartTransientUnit` over D-Bus to run codex as another user; a non-root
+  service needs polkit authorization, scoped to the `symphony-host-` unit-name
+  prefix so it cannot manage unrelated units.
+- **Environment mapping** (`default.nix:279-320`): typed options become
+  `SYMPHONY_*` env vars (state/workspaces/runs/logs dirs, HTTP port, workflow
+  pack, room URLs, host-runtime vars), merged with `extraEnvironment`.
+- **ExecStart** (`default.nix:326-333`): `<secretsCommand?> <package>/bin/symphony`.
+- **tmpfiles** create `stateDir` and `workspaces`/`runs`/`log` subdirs at 0750
+  (`default.nix:258-263`).
+
+## What it produces
+
+`systemd.services.symphony` (`default.nix:265`), wanted by `multi-user.target`,
+after `network-online.target`. Sandboxing is intentionally light
+(`default.nix:339-347`: only `NoNewPrivileges`, `PrivateTmp`,
+`ProtectKernelTunables`/`Modules`/`ControlGroups`) because Symphony spawns codex
+subprocesses and clones git repos. No port claim or health check is declared
+(the module imports only `config`/`lib`/`pkgs`).
+
+## How it is wired
+
+Auto-discovered as `services/symphony`. The `package` is passed in by the
+consumer (this flake's `symphony` default output, built from
+`packages/symphony`).

--- a/docs/modules/velocity/overview.md
+++ b/docs/modules/velocity/overview.md
@@ -1,0 +1,86 @@
+# velocity
+
+`modules/services/velocity/default.nix` runs the Velocity Minecraft proxy
+(papermc.io/software/velocity). It fronts backend Java servers, manages a set of
+plugins, and renders `velocity.toml` plus arbitrary managed config files. It is
+the host for the [geyser](../geyser/overview.md) and
+[floodgate](../floodgate/overview.md) plugins.
+
+Option namespace: `services.velocity` (`default.nix:238`).
+
+## What it runs
+
+The Velocity proxy jar. Default `package` is
+`ix.artifacts.minecraft.velocityServers."3.4.0-SNAPSHOT".src` (`default.nix:241`),
+a locked artifact from the generated catalog. The JVM is the pinned Temurin JRE
+(`default.nix:248`); the argv is `<java> -XX:MaxRAMPercentage=<n> <yourkit>
+<jvmFlags> -jar <package>` (`default.nix:226-235`).
+
+## Public surface (selected options)
+
+- `enable`, `package`, `javaPackage`, `maxRAMPercentage` (75), `jvmFlags`,
+  `yourkit` (`default.nix:239-291`).
+- `address` (`0.0.0.0`), `port` (25565), `openFirewall` (true)
+  (`default.nix:264-280`).
+- `motd`, `health.motdContains` (substrings the rendered MOTD must contain for
+  the `velocity-status` check) (`default.nix:293`, `:299`).
+- `onlineMode` (true), `forceKeyAuthentication`, `forwarding.{mode,secret,secretFile}`
+  (`mode` default `modern`; secret lands in the store, secretFile is a runtime
+  file) (`default.nix:320-361`).
+- `servers` (backend name -> address), `try`, `forcedHosts` (`default.nix:398-415`).
+- `advanced.*` (compression, timeouts, rate limits, reuse-port, ...)
+  (`default.nix:417`).
+- `query.{enable,port=25565,openFirewall,map,showPlugins}` - GameSpy 4 query
+  listener (UDP) (`default.nix:539`).
+- `plugins` (attrs of `{enable,src,fileName}`; empty `{}` resolves a catalog
+  plugin by slug, `src` installs a local jar), `pluginCatalog` (default
+  `ix.artifacts.minecraft.velocityPluginCatalog`) (`default.nix:567`, `:573`).
+- `configFiles` (managed files relative to the data dir; `.json/.properties/
+  .toml/.yaml/.yml`), `settings` (raw `velocity.toml` merged over typed options)
+  (`default.nix:588`, `:594`).
+
+## Key internals
+
+- **Managed config and plugins** (`default.nix:153-206`): `velocity.toml` is
+  rendered from typed options merged with `settings`, plus every `configFiles`
+  entry, into a `runCommand` symlink farm; plugins are resolved from `src` or the
+  catalog into another farm. `preStart` (`default.nix:722`) reconciles the
+  managed plugin manifest, installs config files, and either copies the
+  forwarding secret or generates one with `openssl rand` if none is set
+  (`installForwardingSecret`, `default.nix:213-224`).
+- **Assertions** (`default.nix:602-623`): cannot set both `forwarding.secret`
+  and `secretFile`; `configFiles` cannot manage `velocity.toml`; reject unsafe
+  relative paths/names and duplicate plugin file names (via `ix.relativePath`,
+  `ix.lists`).
+
+## What it produces
+
+- **Port claims** (`default.nix:625`): `velocity` (tcp), `velocity-query` (udp,
+  when query enabled), yourkit. Firewall opens the client port, query port, and
+  yourkit ports by their flags (`default.nix:644-648`).
+- **Health checks** (`default.nix:650`): `velocity` (unit active),
+  `velocity-status` (`mc-probe` SLP against the bind address, loopback for
+  wildcard binds, optional `--motd-contains`), and `velocity-reachable` (host
+  `nc`) when the firewall is open. `mc-probe` (`packages/minecraft/probe`) is on
+  PATH (`default.nix:697`).
+- A `velocity` system user/group with home `/var/lib/velocity`
+  (`default.nix:704`).
+- **systemd.services.velocity** (`default.nix:712`): runs as that user,
+  `ix.systemdHardening`, `WorkingDirectory`/`StateDirectory = velocity`,
+  `ExecStart` the JVM argv. `restartTriggers` track the managed config/plugins
+  and forwarding secret.
+- `environment.etc."velocity/managed-{config,plugins}"` (`default.nix:699`).
+
+## Relationship to Geyser / Floodgate
+
+[geyser](../geyser/overview.md) and [floodgate](../floodgate/overview.md) do not
+run their own units: each composes onto `services.velocity` by adding a plugin
+entry (with `src` and `fileName`) and managed config files, defaulting
+`services.velocity.enable` true. Paper backends behind Velocity pick up the
+shared forwarding secret via the paper loader (see
+[minecraft loaders](../minecraft/loaders-and-mods.md)).
+
+## How it is wired
+
+Auto-discovered as `services/velocity`. Jar and plugin catalog come from
+`ix.artifacts.minecraft.*`.

--- a/docs/nix-build/blast-radius/overview.md
+++ b/docs/nix-build/blast-radius/overview.md
@@ -1,0 +1,99 @@
+# blast-radius
+
+`packages/blast-radius` reports how many `.#checks.x86_64-linux` derivations a PR
+would rebuild and which changed inputs caused each rebuild. It is the engine
+behind the sticky PR comment from `.github/workflows/blast-radius.yml`, and runs
+locally as `nix run .#blast-radius` for the same report in Markdown.
+
+## Purpose
+
+A PR that touches a shared input can rebuild thousands of checks; one that edits a
+single crate rebuilds a handful. blast-radius quantifies that radius and, crucially,
+attributes it: it walks the derivation graph down to the *frontier* of change so
+the report blames the crate source or dependency a human actually edited, not the
+dozens of intermediate per-unit derivations whose hashes merely propagate the
+change upward (`src/causes.rs:1-15`). This is meaningful only because every Rust
+check is a per-unit [nix-cargo-unit](../nix-cargo-unit/overview.md) derivation
+whose input-addressed `.drv` basename moves iff the build really changed.
+
+## How it runs (`src/main.rs:196`)
+
+```
+blast-radius [BASE] [HEAD] [--json] [--timings PATH]
+```
+
+1. **Resolve revs** (`git::resolve`, `src/git.rs:36`): `BASE` defaults to
+   `origin/main`, `HEAD` to `HEAD`; the diff base is their merge-base, so the
+   report reflects only what this branch changed.
+2. **Pick the catalog output** (`nix::catalog_attr`, `src/nix.rs:131`): prefer the
+   sharded `ciChecks` flake output, but fall back to flat `checks` for both revs
+   if either lacks it (a merge base can predate `ciChecks`); choosing per revision
+   would mis-key every derivation as removed+added.
+3. **Evaluate both revs concurrently** (`concurrent_evals`, `src/main.rs:123`):
+   two `nix-eval-jobs` runs (pinned rev, eval cache off, 4 workers each so the
+   peak memory matches one 8-worker eval), timing each thread's own work.
+4. **Guard eval failures** (`guard_eval_failures`, `src/main.rs:68`): fail closed
+   if any check newly fails to evaluate at head (a regression this change
+   introduced); failures present at both base and head are pre-existing catalog
+   issues, excluded from the diff and only reported.
+5. **Diff** (`src/main.rs:216-247`): a check is `changed` when its attr's
+   `drvPath` differs between base and head, `added`/`removed` by attr presence.
+6. **Attribute causes** for the changed set (`compute_causes`, `src/main.rs:159`):
+   load the recursive derivation graph at each rev with `nix derivation show
+   --recursive` and walk to the frontier (below).
+7. **Annotate timings** (optional `--timings`, `src/timings.rs`): per-attr
+   wall-clock seconds from a prior successful Check run's nix-fast-build result
+   file; a missing or unreadable file is ignored, not fatal (`src/main.rs:256`).
+8. **Render**: `--json` emits `report.json` (the workflow contract); otherwise
+   Markdown (`src/report.rs`).
+
+## Root-cause frontier (`src/causes.rs`)
+
+The derivation graph is keyed by `.drv` basename (`<hash>-<name>.drv`), which is
+input-addressed: a head node is unchanged iff its basename also exists at base
+(`is_changed`, `src/causes.rs:52`). `collect_frontier` (`src/causes.rs:71`) walks
+the changed sub-DAG reachable from each rebuilt check and collects the *frontier*:
+changed nodes whose own `.drv` inputs are all unchanged. Unchanged subtrees are
+pruned and descent stops at each frontier node, so the traversal is bounded by the
+change, not the closure. Only `.drv` inputs are followed, not bare source inputs:
+a changed source already moves its consuming unit's basename, so a crate edit
+lands on the readable `mynoise-0.1.0` unit rather than a raw `cargo-unit-source-*`
+path (`src/causes.rs:64-70`). `root_causes` (`src/causes.rs:105`) ranks causes by
+fan-out (how many checks each rebuilds) and applies the graph `Caps`
+(`max_causes: 6`, `max_checks_per_cause: 5`, `src/main.rs:34`); the changed-check
+list itself stays complete.
+
+This replaces the old nushell tool's "blame every direct input whose hash moved",
+which under per-unit builds credited every changed crate as a cause of every check
+near it (a hairball); the frontier walk collapses that to the inputs actually
+edited (`src/causes.rs:10-15`, tests at `src/causes.rs:173-320`).
+
+## Report shape (`src/report.rs`)
+
+`Report` (`src/report.rs:48`) serializes to `report.json`: `base`/`head` (short
+SHAs), `total`, `changed`/`added`/`removed` attr lists, `categories` (counts by
+the segment before the first dash, e.g. `rust`/`image`/`lint`,
+`src/causes.rs:145`), `causes` (`{ name, checks }`), optional `timings`, and
+`phaseTimings` (per-phase producer seconds, kebab-case stable keys). The JSON
+schema is a contract with the trusted workflow job, which validates the shape and
+rebuilds the comment; the Markdown renderer mirrors that job's renderer (capped
+node graph, `CHANGED_LIST_CAP = 200` bullets) so a local run previews the comment
+(`src/report.rs:16-23`).
+
+## Attr normalization (`src/nix.rs:321`)
+
+`nix-eval-jobs` joins nested attr paths with `.` and quotes any segment
+containing a dot. A sharded `ciChecks` doctest leaf carries a file path
+(`rust-foo."doctest-src/lib.rs - (line 12)"`), so `normalize_attr` drops every
+`"` and splits on dots outside quotes, then rejoins, producing a bare name that
+passes the workflow's safename regex and matches nix-fast-build's `--timings`
+records identically (`src/nix.rs:302-334`).
+
+## Build and packaging
+
+`default.nix` selects the binary via `ix.cargoUnit.selectBinaryWithTests`
+(MIT license). It is `inRustWorkspace`, `flake = true`, `packageSet = true`. Flake
+output / main program: `blast-radius`. Deps: `clap`, `color-eyre`,
+`serde`/`serde_json`. Modules: `git`, `nix`, `causes`, `report`, `timings`. An
+end-to-end run needs a Linux builder (the per-unit Cargo graph is x86_64-linux,
+import-from-derivation heavy; `src/nix.rs:1-7`).

--- a/docs/nix-build/build-version/overview.md
+++ b/docs/nix-build/build-version/overview.md
@@ -1,0 +1,52 @@
+# build-version
+
+`packages/build-version` is a tiny library crate that formats a binary's
+`--version` line from build metadata a Nix wrapper stamps into the environment,
+so every ix tool reports its revision, commit date, and how long ago it was built
+in one consistent shape. No binary, no flake output: it is a dependency of the
+tools that want a stamped version.
+
+## Purpose
+
+A reproducible build has no wall-clock compile time, so the "when" is the flake's
+commit time, not the build time. The Nix wrapper sets the revision and commit
+epoch in the environment; this crate reads them at startup and renders the line.
+"How long ago" is computed at run time against the current clock, which is why it
+cannot be baked into the binary and rides the env instead (`src/lib.rs:1-8`).
+
+## Public surface (`src/lib.rs`)
+
+- `version_static(crate_version: &str) -> &'static str` (`:41`): the entry point.
+  Hand the result straight to clap's `Command::version`. When the wrapper env is
+  present it returns e.g. `0.1.0 (7e42ccdb1882, 2026-06-07, 2 days ago)`; outside
+  the packaged wrapper (a dev `cargo run`) the env is unset and it returns the
+  bare crate version. Computed once per process via a `OnceLock`, matching how
+  clap reads the version once at startup.
+- `stamp(rev, epoch: Option<i64>, now: SystemTime) -> String` (`:69`): builds the
+  parenthesised stamp. Split out so it is testable without touching the
+  environment or the wall clock. Abbreviates the revision to 12 chars
+  (`SHORT_REV_LEN`, `:30`); degrades to the short revision alone when no epoch is
+  known, and treats `epoch == 0` as unknown (the `revEpoch ? 0` sentinel for a
+  non-git eval, so it never prints `1970-01-01, 56 years ago`, `:71-76`).
+- `humanize_ago(seconds: i64) -> String` (`:96`): renders an elapsed span as
+  `just now` / `5 minutes ago` / `2 days ago` / `1 year ago`. Spans under a
+  minute and negative spans (build clock ahead of ours) collapse to `just now`.
+
+## Environment contract
+
+- `REV_ENV = "IX_BUILD_REV"` (`:23`): the build's flake revision: full git SHA on
+  a clean tree, `<sha>-dirty` when dirty, `dev` off a non-git source. Mirrors
+  `ix.rev`.
+- `EPOCH_ENV = "IX_BUILD_EPOCH"` (`:27`): the build's commit time as unix epoch
+  seconds (`self.lastModified`). Mirrors `ix.revEpoch`.
+
+These are the shared names every ix tool reads. The Nix wrapper for
+[nix-web-monitor](../nix-web-monitor/overview.md) is the worked example of setting
+them (`packages/nix-web-monitor/server/default.nix:59-62`), and its
+`server/src/main.rs:107` is a worked example of consuming `version_static`.
+
+## Build and packaging
+
+`package.nix`: `inRustWorkspace`, `passthruTests`. Library crate, no flake
+output. Only dependency: `chrono` (alloc feature) for the date formatting
+(`Cargo.toml:12`).

--- a/docs/nix-build/common.md
+++ b/docs/nix-build/common.md
@@ -1,0 +1,177 @@
+# nix-build
+
+Nix build-system integration for the `index` repo: the tooling that turns the
+Cargo workspace into a per-unit Nix derivation graph, watches and explains those
+builds, packages their outputs as OCI images, and supplies the small CLI helpers
+every ix tool shares. The center of gravity is [nix-cargo-unit](nix-cargo-unit/overview.md),
+the bootstrap renderer that the [nix-lib](../nix-lib/common.md) domain
+(`lib/rust/cargo-unit.nix`) wraps into `ix.cargoUnit`; every Rust package here is
+then built one rustc invocation at a time as its own derivation. The rest of the
+domain is observability and packaging around that engine: terminal/web build
+monitors, a CA-aware `nom`, an OCI image builder, a PR rebuild-impact reporter,
+the package registry that drives the flake outputs, an out-of-tree Nix
+reimplementation built through the same engine, and two reusable runtime crates.
+
+Read this page first, then the component page for the unit you are touching.
+
+## Units
+
+| unit | kind | role |
+| --- | --- | --- |
+| `packages/nix-cargo-unit` | standalone Cargo workspace, Nix package + flake output `nix-cargo-unit` | render a Cargo `--unit-graph` into composable Nix derivations; merge graphs; scan rlibs for panic reachability. See [nix-cargo-unit](nix-cargo-unit/overview.md). |
+| `packages/nix-web-monitor` | Rust workspace crates (`parser`, `server`), flake output `nix-web-monitor` | run a Nix build with quiet terminal output and a live web monitor; the parser models the `internal-json` event stream. See [nix-web-monitor](nix-web-monitor/overview.md). |
+| `packages/nix-output-monitor` | Nix-only (Haskell override), flake output `nix-output-monitor` (`nom`) | upstream nix-output-monitor patched so `nix-derivation` parses content-addressed derivations. See [nix-output-monitor](nix-output-monitor/overview.md). |
+| `packages/oci-image-builder` | Rust workspace crate, flake output + overlay `oci-image-builder` | turn a `streamLayeredImage` layer plan into an OCI tar, or describe/materialize it through a content-addressed `image.json`. See [oci-image-builder](oci-image-builder/overview.md). |
+| `packages/blast-radius` | Rust workspace crate, flake output `blast-radius` | report how many `.#checks.x86_64-linux` derivations a PR rebuilds and which changed inputs caused each rebuild. See [blast-radius](blast-radius/overview.md). |
+| `packages/registry.nix` | Nix-only library (not a flake output) | discover every `packages/**` unit's `package.nix` metadata and drive the flake/overlay/packageSet/test lists. See [registry.nix](registry/overview.md). |
+| `packages/snix` | Nix-only (external Cargo workspace built via cargo-unit), flake output `snix` | the snix `default` CLI (a Rust reimplementation of Nix) built through `ix.cargoUnit`. See [snix](snix/overview.md). |
+| `packages/build-version` | Rust workspace crate (library) | format a binary's `--version` line from Nix-stamped build metadata. See [build-version](build-version/overview.md). |
+| `packages/config-launch` | Rust workspace crate, flake output `config-launch` | spec-driven exec launcher: set env/PATH and inject CLI flags, then `exec` the target preserving argv0. See [config-launch](config-launch/overview.md). |
+| `packages/progress-style` | Rust workspace crate (library) | shared `indicatif` progress-bar/spinner styling for ix CLIs. See [progress-style](progress-style/overview.md). |
+
+Rust workspace members (root `Cargo.toml`): `nix-web-monitor/parser`,
+`nix-web-monitor/server`, `oci-image-builder`, `blast-radius`, `build-version`,
+`config-launch`, `progress-style`. Standalone/Nix-only: `nix-cargo-unit`
+(excluded from the root workspace, carries its own `Cargo.lock`),
+`nix-output-monitor` (Haskell), `registry.nix` (Nix), `snix` (external Cargo
+workspace fetched as a flake input).
+
+## How it fits together
+
+```
+Cargo.toml workspace
+   cargo +toolchain build --unit-graph -Z unstable-options   (per cargoTargets entry)
+      -> unit-graph JSON  --(nix-cargo-unit merge)-->  one merged graph
+         --(nix-cargo-unit render --cargo-lock ...)-->  units.nix
+            ix.cargoUnit.buildWorkspace imports units.nix:
+               one stdenv.mkDerivation per rustc unit (lib/bin/test/doc/build-script)
+               source-scoped per crate; optional --content-addressed; clippy/panic/audit checks
+   ix.cargoUnit.selectBinaryWithTests -> packages/<tool>/default.nix flake outputs
+                                         (oci-image-builder, blast-radius, config-launch, nix-web-monitor, snix)
+
+build observability:
+   nix build --log-format internal-json
+      -> nix-web-monitor/parser  (events -> MonitorState/Delta -> web UI + JSON)
+      -> nix-output-monitor (nom)  (terminal DAG; CA-derivation aware)
+   blast-radius  diffs .#checks at base vs head over the same per-unit graph
+
+packaging / runtime:
+   dockerTools.streamLayeredImage conf.json -> oci-image-builder -> OCI tar / image.json (lib/image)
+   build-version    renders --version from IX_BUILD_REV / IX_BUILD_EPOCH the Nix wrapper stamps
+   progress-style   the shared indicatif styles ix CLIs draw with
+
+discovery:
+   packages/registry.nix reads every package.nix -> flake/overlay/packageSet/passthruTests lists (lib/per-system.nix)
+```
+
+- **One derivation per rustc unit.** A Cargo unit graph node (one crate compiled
+  in one mode with one feature set) becomes one Nix derivation, identity-hashed
+  from its package, target, profile, features, flags, and the hashes of its
+  dependency units (`packages/nix-cargo-unit/src/model.rs:612`,
+  `:638`). Editing one crate moves only that unit's hash and its dependents',
+  so a build reuses the rest of the store. This is the shared substrate every
+  Rust tool in this domain (and most of the repo) is built on.
+
+- **nix-cargo-unit bootstraps itself.** It renders the rest of the workspace's
+  unit graph, so it cannot be built through `ix.cargoUnit`. It is a standalone
+  Cargo workspace built as a plain `ix.buildRustPackage`
+  (`packages/nix-cargo-unit/default.nix:16`), excluded from the root workspace
+  (`Cargo.toml` `exclude`) so a root-lock churn never recompiles it.
+
+- **Build identity is input-addressed by basename.** Because each unit is a
+  derivation whose `.drv` basename is `<hash>-<name>.drv` and the hash folds in
+  every input, an identical basename across two revisions means an identical
+  build. [blast-radius](blast-radius/overview.md) and the CA-derivation handling
+  in the monitors both rely on this: a moved basename is a real rebuild.
+
+- **The monitors read Nix's `internal-json`, not the build graph.** That stream
+  names each derivation Nix builds but carries no edges and no per-activity
+  success marker. [nix-web-monitor](nix-web-monitor/overview.md) reconstructs the
+  DAG out-of-band with `nix-store --query --requisites`, taps the daemon's
+  syscalls for the otherwise-invisible `addToStore` phase, and folds
+  content-addressed `resolved derivation` pairs into one row;
+  [nom](nix-output-monitor/overview.md) needs a patched `nix-derivation` to parse
+  the empty output path a floating CA derivation carries.
+
+- **Nix stamps the build, runtime renders it.** A Nix wrapper sets `IX_BUILD_REV`
+  and `IX_BUILD_EPOCH` (mirroring `ix.rev` / `ix.revEpoch`) in the environment;
+  [build-version](build-version/overview.md) reads them at startup to format the
+  `--version` line, so a new commit re-stamps a tiny wrapper instead of
+  rebuilding the Rust unit. nix-web-monitor's wrapper is the worked example
+  (`packages/nix-web-monitor/server/default.nix:59`).
+
+## Invariants
+
+- **Fail closed on a missing or unreadable input.** nix-cargo-unit's panic gate
+  errors when it finds no artifacts to scan rather than passing
+  (`packages/nix-cargo-unit/src/main.rs:144`), and treats an unparseable
+  artifact as an error (`src/panic_scan.rs:107`). blast-radius bails when a check
+  newly fails to evaluate at head (`packages/blast-radius/src/main.rs:81`) and
+  when a `nix-eval-jobs` row has neither `drvPath` nor `error`
+  (`src/nix.rs:194`). The web monitor propagates Nix's exit code instead of
+  masking it (`packages/nix-web-monitor/server/src/main.rs:160`).
+
+- **Best-effort overlays never fail the run.** The daemon syscall tracer degrades
+  to a status string on any error rather than aborting
+  (`packages/nix-web-monitor/server/src/daemon.rs:42`); blast-radius ignores an
+  unreadable `--timings` file (`src/main.rs:257`); build-version falls back to
+  the bare crate version when the stamp env vars are unset
+  (`packages/build-version/src/lib.rs:46`).
+
+- **Materialized image bytes are verified against the description.**
+  `oci-image-builder materialize` regenerates each layer deterministically and
+  checks it against the recorded digest, so a description that no longer
+  reproduces its bytes fails rather than ships a wrong image
+  (`packages/oci-image-builder/README.md:33`).
+
+- **Generated Nix is reproducible and deterministic.** nix-cargo-unit sorts
+  every hashed set (dependencies, features, crate types) before digesting
+  (`src/model.rs:620`) and the template emits a fixed shape; the renderer is a
+  pure stdin->stdout transform driven only by the unit graph, `Cargo.lock`, and
+  flags.
+
+## Glossary
+
+- **unit / Cargo unit**: one node of `cargo build --unit-graph`: a single crate
+  compiled in one mode (build/check/test/doc/run-custom-build) with one feature
+  set and profile. The atom nix-cargo-unit turns into a derivation.
+- **unit graph**: Cargo's `--unit-graph` JSON (version 1): `units`, `roots`, and
+  per-unit `dependencies` by index. nix-cargo-unit parses, merges, and renders it.
+- **identity hash**: the 16-hex SHA-256 prefix nix-cargo-unit derives per unit
+  from its package/target/profile/features/flags plus its sorted dependency
+  hashes; the stable tag in unit names and `-C metadata`.
+- **content-addressed (CA) derivation**: a Nix derivation whose output path is
+  assigned only after realisation; its `.drv` carries an empty output path and
+  Nix builds it via a `resolved derivation` rewrite. The `--content-addressed`
+  render flag, nom's patch, and the monitor's resolve-folding all exist for these.
+- **internal-json**: Nix's `--log-format internal-json` event stream (`start`,
+  `stop`, `result`, `msg` actions); what both monitors consume.
+- **layer plan / `conf.json`**: the `passthru.conf` that
+  `dockerTools.streamLayeredImage` emits, naming base image, store layers, and
+  the customisation layer. oci-image-builder's input.
+- **describe / materialize**: oci-image-builder's two passes: a tiny
+  content-addressed `image.json` description (no layer bytes), and the
+  regeneration of bytes from it back into an OCI tar.
+- **blast radius**: the set of `.#checks.x86_64-linux` derivations a PR would
+  rebuild, attributed to the changed-input frontier that caused them.
+- **frontier (root cause)**: a derivation that differs between base and head but
+  whose own inputs are all unchanged: the genuine cause, not a propagating
+  intermediate (`packages/blast-radius/src/causes.rs`).
+- **package.nix metadata**: the small attrset every `packages/**` unit declares
+  (`id`, `flake`, `packageSet`, `overlay`, `inRustWorkspace`, `passthruTests`,
+  ...) that `registry.nix` reads to build the flake.
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| nix-cargo-unit | [nix-cargo-unit/overview.md](nix-cargo-unit/overview.md) | Cargo unit graph -> per-unit Nix derivations; merge; panic scan |
+| nix-web-monitor | [nix-web-monitor/overview.md](nix-web-monitor/overview.md) | run a Nix build with a live web monitor; internal-json parser + state model |
+| nix-output-monitor | [nix-output-monitor/overview.md](nix-output-monitor/overview.md) | `nom` patched to parse content-addressed derivations |
+| oci-image-builder | [oci-image-builder/overview.md](oci-image-builder/overview.md) | layer plan -> OCI tar / content-addressed image.json |
+| blast-radius | [blast-radius/overview.md](blast-radius/overview.md) | PR rebuild-impact report over `.#checks` with root-cause attribution |
+| registry.nix | [registry/overview.md](registry/overview.md) | package.nix discovery driving flake/overlay/packageSet lists |
+| snix | [snix/overview.md](snix/overview.md) | snix `default` CLI built through cargo-unit |
+| build-version | [build-version/overview.md](build-version/overview.md) | `--version` line from Nix-stamped build metadata |
+| config-launch | [config-launch/overview.md](config-launch/overview.md) | spec-driven exec launcher: env/PATH/flag injection |
+| progress-style | [progress-style/overview.md](progress-style/overview.md) | shared indicatif progress-bar/spinner styles |

--- a/docs/nix-build/config-launch/overview.md
+++ b/docs/nix-build/config-launch/overview.md
@@ -1,0 +1,75 @@
+# config-launch
+
+`packages/config-launch` is a spec-driven exec launcher: it reads a JSON spec,
+sets environment variables and `PATH`, injects CLI flags (static,
+argv-conditional, and config-file-gated `--config`), then `exec`s a target binary
+while preserving argv0. It is a small Rust workspace crate used to wrap
+third-party CLIs (codex, claude-code) with repo defaults.
+
+## Purpose
+
+Several vendored CLIs need to launch with ix-specific environment and flag
+defaults, but each defaults differently and should not be patched. config-launch
+moves that policy into a declarative JSON spec a Nix wrapper writes, so one tiny
+launcher handles every case and `exec`s the real binary (no extra process in the
+tree). Because it `exec`s rather than spawns and sets argv0 to the original argv0
+(`src/main.rs:163`, `:180`), the target sees itself as if invoked directly.
+
+## Spec (`IX_LAUNCH_SPEC`, `src/main.rs:28`)
+
+The launcher reads the path in `IX_LAUNCH_SPEC` and parses it as the `Spec` JSON
+(`load_spec`, `src/main.rs:147`). Every field beyond `target` is optional, so each
+consumer uses only the layers it needs (`src/main.rs:23-26`):
+
+- `target` (`:30`): the real binary to `exec`.
+- **Generic launcher layers**:
+  - `env` (`:48`): variables set unconditionally.
+  - `env_defaults` (`:52`): set only when not already present in the caller's
+    environment (the `export NAME="${NAME-default}"` idiom).
+  - `path_prepend` (`:55`): directories prepended ahead of the caller's `PATH`.
+  - `flags` (`:58`): flags prepended before the user argv, unconditionally.
+  - `conditional_flags` (`:61`): flag blocks (`ConditionalFlags`, `:18`) prepended
+    only when the user passed no equivalent option.
+- **codex `--config k=v` layer**:
+  - `forced` (`:41`): `--config key=value` injected always.
+  - `soft` (`:43`): `--config key=value` injected only when the dotted key is
+    absent from the target's config file.
+  - `config_dir_env` / `config_dir_default` / `config_file` (`:34-39`): locate
+    that config file (env var, else a `~`-expanded default dir, joined with the
+    file name; `config_path`, `:71`).
+
+## Order of operations (`main`, `src/main.rs:153`)
+
+1. Load the spec; a missing/unreadable/invalid spec exits 78 (`EX_CONFIG`,
+   `:156-159`).
+2. Split argv into argv0 and the user args (`:162-164`).
+3. Read the config file only when there are `soft` keys whose presence it gates
+   (claude-code sets none, so it never needs a config dir; `:168-174`).
+4. Build the prepended args: `flags` plus each conditional block the user did not
+   override (`build_arg_flags`, `:127`), then the `--config` layer
+   (`build_config_flags`, `:91`).
+5. Build the command: `arg0(argv0)`, apply `env` then `env_defaults` (only when
+   unset), prepend `path_prepend` to `PATH` (`build_path`, `:138`), then the
+   prepended flags, then the user args (`:179-194`).
+6. `exec` the target; a failed `exec` prints an error and exits 127 (`:196-198`).
+
+## Conditional and soft gating semantics
+
+- **`arg_present`** (`src/main.rs:108`): a user arg counts as overriding a
+  conditional block when it equals one of the block's `unless_present` names or
+  starts with `"<name>="`. Scanning stops at the first `--`, so a value after `--`
+  is treated as a positional, not the option (`:111`, tested at `:459`).
+- **`is_set`** (`src/main.rs:78`): a `soft` key is withheld only when its exact
+  dotted path is present in the parsed TOML config; a sibling leaf under the same
+  table is still injected (tested at `:330-363`). Partial paths count as present
+  (`features.multi_agent_v2` is set when `features.multi_agent_v2.enabled` is).
+- **`forced`** always wins, even over a user config that sets the key
+  (`:280-299`).
+
+## Build and packaging
+
+`default.nix` selects the binary via `ix.cargoUnit.selectBinaryWithTests` (MIT).
+It is `inRustWorkspace`, `flake = true`, `packageSet = true`. Flake output /
+main program: `config-launch`. Deps: `serde`/`serde_json` (spec) and `toml`
+(target config). Unix-only (`std::os::unix::process::CommandExt` for `arg0`/
+`exec`, `src/main.rs:2`). Tests in `src/main.rs` and `tests/cli.rs`.

--- a/docs/nix-build/nix-cargo-unit/internals.md
+++ b/docs/nix-build/nix-cargo-unit/internals.md
@@ -1,0 +1,122 @@
+# nix-cargo-unit internals
+
+The non-obvious mechanisms behind [overview](overview.md): unit identity hashing,
+graph merge, source scoping, and the panic-reachability scan.
+
+## Unit identity hash (`src/model.rs:612`)
+
+Each unit's identity is a SHA-256 (first 8 bytes, 16 hex chars; `src/hash.rs:18`)
+over a canonical encoding of everything that affects its compiled output, plus
+its dependencies' hashes. `write_unit_identity` (`src/model.rs:638`) folds in:
+package identity, target name and edition, sorted crate types, sorted features,
+profile name/opt-level, and identity bytes for `lto`/`debuginfo`/`panic`/`strip`,
+the boolean profile flags, codegen units, split-debuginfo, profile `rustflags`,
+lint rustflags, check-cfg args, and the unit mode.
+
+The dependency hashes are appended sorted, each as `dep\0<crate>:<public>:
+<noprelude>:<hash>\0` (`src/model.rs:620`), so the identity is recursive: a
+change deep in the graph propagates up to every dependent's hash but leaves
+unrelated units untouched. An optional `--toolchain-id` is folded in last
+(`src/model.rs:628`), so a toolchain bump invalidates the whole graph.
+
+Sorting before hashing is what makes the output deterministic regardless of the
+order Cargo emitted dependencies or features. The hash is the `<hash>` segment of
+every unit name and feeds rustc's `-C metadata`, so two units that would compile
+identically share an identity (and a store path under content-addressing).
+
+## Package id parsing (`src/model.rs:479`)
+
+`parse_pkg_id` handles both the legacy `<name> <version> (<source>)` form and the
+modern `path+file://...`, `registry+...`, `git+...`, `sparse+...#name@version`
+forms, extracting name and version (and stripping a trailing `.git`). `is_external`
+(`src/model.rs:603`) classifies a unit as third-party by its source scheme; the
+renderer uses this to skip clippy, the panic scan, and audit on vendored code.
+
+## Merge (`src/model.rs:298`)
+
+`UnitGraph::merge` unions several graphs into one. It first computes every unit's
+identity hash within each graph (`merge_identity_hash`, recursively, with
+memoization), then walks each unit, rewriting its dependency indices into the
+merged graph and deduplicating by hash through `merged_by_hash`: two units with
+the same identity across input graphs become one node. Each input graph's roots
+are recorded both in the flat `roots` and as a `root_sets` entry, so a consumer
+can tell which target each root came from. `validate` (`src/model.rs:353`) checks
+every root and dependency index is in range before and after merge.
+
+## Source scoping (`src/render.rs`)
+
+A unit's source is emitted as one `sources.<name>` entry, not the whole tree, so
+editing one crate does not invalidate its siblings. `SourceEntry`
+(`src/render.rs:171`) carries a `SourceBase` and `SourceScope`:
+
+- `SourceBase` (`src/render.rs:182`): `Workspace` / `WorkspaceClosure` /
+  `VendorPackage` / `VendorClosure` selects which Nix helper builds the source
+  (`scopedWorkspaceSource`, `scopedWorkspaceClosureSource`,
+  `vendorSources.<key>`, `scopedVendorClosureSource`; rendered in
+  `nix_expr`, `src/render.rs:241`).
+- `SourceScope` (`src/render.rs:190`): `Package` (one crate dir) vs `Closure` (a
+  crate plus the sibling paths it includes, for a workspace member that reaches
+  outside its own dir).
+
+The template's `scopedWorkspaceSource` builds a package-shaped `builtins.path`
+rooted at `workspaceRoot/<relative>` (`units.nix.askama:105`), and the closure
+variants use a `filter` that keeps only the include set
+(`sourceClosureFilter`, `units.nix.askama:90`). A vendor closure asserts
+`vendorDir != null` (`units.nix.askama:121`). The external-source map is built
+from `Cargo.lock` (`CargoLockSources::from_path`, `src/render.rs:73`);
+`source_for_unit` (`src/render.rs:102`) matches a unit's package id against the
+lock to pick the exact source, erroring on a missing or ambiguous match so a
+mis-resolved vendor path fails loudly. `cargo_lock_source_matches_pkg_id`
+(`src/render.rs:146`) tolerates the git rev suffix the lock carries.
+
+## Build-script handling
+
+A package's `build.rs` appears as two units: a `custom-build` compile unit (real
+workspace Rust, so it keeps clippy) and a `run-custom-build` unit that executes
+the script. `prepare_graph` folds these into a `BuildScriptRun`
+(`src/render.rs:166`) so the run unit depends on the compile unit and its own
+dependency runs, and the renderer emits the run unit before the rustc units
+(`render_unit_entries`, `src/render.rs:327`). The run unit is named
+`<pkg>-build-script-run-<version>-<hash>` (`src/render.rs:582`).
+
+## Panic-freedom scan (`src/panic_scan.rs`)
+
+`scan-panics` is a relocation-based reachability check, not a disassembler. A
+function that can panic emits a call to a `core::panicking::*` entrypoint; in a
+relocatable object that call survives as a relocation targeting the undefined
+panic symbol, at an offset inside the calling function's text range. The scanner
+reads symbols and relocations with the `object` crate and attributes each panic
+relocation to its containing function (`scan_object`, `src/panic_scan.rs:125`),
+so the same logic covers ELF and Mach-O.
+
+Key points:
+
+- **Operates on `.o`/`.rlib`, not linked binaries** (`src/panic_scan.rs:11`): a
+  linked binary resolves panic calls to direct branches with no relocation left
+  to read.
+- **Monomorphization attribution** (`src/panic_scan.rs:14`): a library generic is
+  codegened where it is instantiated, so a panic in it carries the library's
+  crate token in the consumer's object. Scanning every production unit and scoping
+  findings to the whole workspace crate set
+  (`workspace_crate_names`, `src/render.rs:446`) attributes it back to the
+  defining crate. `crate_token` (`src/panic_scan.rs:78`) is the length-prefixed,
+  dash-normalized crate name shared by legacy and v0 mangling.
+- **Panic sinks** (`PANIC_SINKS`, `src/panic_scan.rs:202`): `core::panicking` and
+  `std::panicking` plus the `unwrap_failed`/`expect_failed` cold paths that
+  `unwrap`/`expect` route through. `at_crate_boundary` (`src/panic_scan.rs:222`)
+  matches only when `core`/`std` is the crate root, so a user `crate::core::
+  panicking` module does not trip it.
+- **Fail closed** (`src/main.rs:144`, `src/panic_scan.rs:107`): finding no
+  artifacts to scan, or an artifact that is neither an archive nor a parseable
+  object, is an error, not a pass.
+- **Scope** (`is_panic_freedom_candidate`, `src/render.rs:433`): only non-external,
+  non-proc-macro, non-build-script, non-test, non-bench units are scanned: test
+  and bench bodies legitimately panic. The rendered check
+  (`render_panic_freedom_check`, `src/render.rs:463`) builds one scan derivation
+  per candidate unit (so a touched unit re-scans only itself), joined under one
+  aggregate, and asserts the `cargoUnit` scanner package is non-null.
+
+This is a best-effort detector, not a soundness proof: a generic no production
+unit instantiates, or a panic through an uncatalogued std cold path, is missed by
+construction (`src/panic_scan.rs:21`). The sound successor is whole-binary
+call-graph reachability.

--- a/docs/nix-build/nix-cargo-unit/overview.md
+++ b/docs/nix-build/nix-cargo-unit/overview.md
@@ -1,0 +1,127 @@
+# nix-cargo-unit
+
+`packages/nix-cargo-unit` renders a Cargo unit graph into composable Nix
+derivations: one `stdenv.mkDerivation` per rustc invocation, wired into a graph
+that mirrors Cargo's own. It is the bootstrap build tool for the whole repo's
+Rust tree. The [nix-lib](../../nix-lib/common.md) domain
+(`lib/rust/cargo-unit.nix`) wraps this binary into `ix.cargoUnit`, which every
+Rust package's `default.nix` consumes via `selectBinaryWithTests` /
+`buildWorkspace`. This page covers the purpose, CLI, and the Nix surface it
+emits; the hashing, source-scoping, merge, and panic-scan mechanics are in
+[internals](internals.md).
+
+## Why it exists
+
+Cargo's unit graph (`cargo build --unit-graph -Z unstable-options`) is the exact
+plan Cargo would execute: every crate, in every mode, with its resolved features
+and flags, and edges between them. nix-cargo-unit transcribes that plan into Nix
+so each unit is a separately cached, separately invalidated derivation. Editing
+one crate moves only that unit's identity hash (and its dependents'), so the
+store reuses everything else: far finer-grained than one derivation per crate
+(`buildRustPackage`) or one per crate-version (crate2nix), and shared by the rest
+of the repo through `ix.cargoUnit`.
+
+## CLI surface (`src/main.rs`)
+
+Three subcommands (`src/main.rs:25`):
+
+- **`render`** (`src/main.rs:60`): read a unit-graph JSON on stdin, write
+  `units.nix` to stdout. Flags:
+  - `--workspace-root <PATH>` (`:62`): canonical workspace root from the graph.
+  - `--vendor-root <PATH>` (`:67`): Cargo vendor dir for registry/git crates.
+  - `--cargo-lock <PATH>` (`:71`, required): resolves each external unit's exact
+    registry/sparse/git source identity (`src/render.rs:102`).
+  - `--content-addressed` (`:75`): emit CA-derivation attributes on units.
+  - `--toolchain-id <ID>` (`:79`): salt every unit identity hash with a Rust
+    toolchain id, so a toolchain bump invalidates the graph.
+  - `--deny-unused-crate-dependencies` (`:83`): emit a per-package check that
+    fails on dependencies unused across all of a package's local units.
+  - `--deny-panics` (`:88`): emit a per-unit panic-freedom policy check (see
+    [internals](internals.md)).
+- **`merge`** (`src/main.rs:53`): merge several unit-graph JSON files into one,
+  deduplicating units by identity hash and recording each input's roots as a
+  `root_set`. Used when a workspace is built for several `cargoTargets`
+  (e.g. a host plus a wasm target) and the graphs are unioned before render.
+- **`scan-panics`** (`src/main.rs:38`): scan compiled `.rlib`/`.o` artifacts for
+  functions that can reach panic machinery, scoped to `--crate-name <NAME>`
+  (repeatable). Exits 1 and lists `function -> panic_entrypoint` on any finding.
+  This is the engine behind `--deny-panics`; see [internals](internals.md).
+
+`main` installs `color_eyre` and dispatches (`src/main.rs:179`). `render` and
+`scan-panics` are pure transforms over their inputs; nothing shells out to Cargo
+or Nix (the wrapper in `lib/rust/cargo-unit.nix` runs Cargo and the IFD).
+
+## The `units.nix` it emits
+
+`render_units_nix` (`src/render.rs:289`) fills one Askama template
+(`templates/units.nix.askama`) whose output is a Nix function. The function takes
+`pkgs`, `rustToolchain`, `src`, `workspaceRoot`, and many optional knobs
+(`vendorSources`, `extraEnv`, `packageBuildEnv`, `extraUnits`, `clippyEnabled`,
+`includeIgnored`, ...), and returns an attrset. The load-bearing outputs
+(template lines `812`-`843`):
+
+| output | what |
+| --- | --- |
+| `units` | every rustc unit as `mkUnit` derivation, keyed `<name>-<version>-<hash>`; merged over `extraUnits` so a prebuilt unit can be injected or override one. |
+| `roots`, `checkedRoots` | root unit references; `default` is the first root wrapped in `withPolicyChecks`. |
+| `packages`, `binaries`, `libraries` | root units filtered by kind, keyed by target name. |
+| `tests`, `doctests`, `benchmarks` | per-target entries; each `.all` runs the whole binary, `.cases` fans out one derivation per `#[test]`/doctest via a manifest IFD. |
+| `testPlan`, `benchmarkPlan`, `coverageReport`, `compareTangoBenchmarks` | aggregate test/bench plans and an `llvm-cov` coverage report builder. |
+| `clippyUnits`, `clippyByPackage` | per-unit clippy-driver derivations, joined per package so editing one crate rebuilds only its clippy gate. |
+| `policyChecks`, `unusedCrateDependenciesByPackage` | workspace panic-freedom / audit checks (aggregate) and the per-package unused-dependency gate. |
+| `sourceAudit` | per-source `{ base, scope, relative, includeRelatives, sourceKey }` records for the coverage and audit paths. |
+
+Each unit is built with `dontUnpack`/`dontConfigure` and an `env` merged from the
+unit's own env, workspace `extraEnv`, and per-package `packageBuildEnv`
+(`units.nix.askama:153`). A render-time `packageName` tag lets per-package env
+target a package's own compile and build-script-run units without touching the
+shared dependency closure.
+
+## Source scoping
+
+Each unit references a `sources.<name>` entry rather than the whole tree, so one
+workspace crate edit does not invalidate its siblings. The renderer classifies
+every unit's source into one of four `SourceBase` shapes (workspace package,
+workspace closure, vendor package, vendor closure; `src/render.rs:182`) and emits
+a `builtins.path` with a filter scoped to just that crate's directory (or the
+include set a closure needs). The `Cargo.lock` source map disambiguates which
+vendored path a registry/git unit resolves to (`src/render.rs:102`-`155`). Detail
+in [internals](internals.md).
+
+## How it is built and wired
+
+- **Package** (`default.nix:16`): built as a plain `ix.buildRustPackage` with
+  `srcRoot = ./.`, NOT through `ix.cargoUnit`: it bootstraps the unit graph, so
+  it cannot consume itself. The version is read from `Cargo.toml`
+  (`default.nix:20`) so it cannot drift.
+- **Standalone workspace** (`Cargo.toml:32`): its own `[workspace]` and
+  `Cargo.lock`, excluded from the root workspace (root `Cargo.toml` `exclude`),
+  so a root-lock bump elsewhere never recompiles it and its Nix build keys only
+  on `packages/nix-cargo-unit/`.
+- **Flake output** (`package.nix`): `flake = true`, `packageSet = true`,
+  `passthruTests = true`. Run as `nix run .#nix-cargo-unit`. NOT
+  `inRustWorkspace` (it is its own workspace).
+- **Consumed by** `lib/rust/cargo-unit.nix`: `buildWorkspace` runs
+  `cargo ... --unit-graph` per `cargoTargets` entry, pipes the graphs through
+  `nix-cargo-unit merge`, then `nix-cargo-unit render --cargo-lock ...`
+  (two IFD stages), imports the resulting `units.nix`, and exposes the result as
+  `ix.cargoUnit` / `ix.rustWorkspace.units`. The `--deny-panics` check calls back
+  into this same package as the `scan-panics` scanner
+  (`src/render.rs:489`).
+
+## Dependencies
+
+`askama` (template), `clap` (CLI), `color-eyre` (errors), `object` (rlib/object
+parsing for the panic scan), `serde`/`serde_json` (unit graph), `sha2` (identity
+hashing), `toml` (`Cargo.lock` and manifests), `url` (package-id parsing).
+
+## Module map
+
+- `model.rs`: unit-graph types, `parse_pkg_id`, identity hashing, `merge`.
+- `render.rs`: the whole `units.nix` renderer (sources, units, tests, policy).
+- `panic_scan.rs`: relocation-based panic-reachability scan.
+- `hash.rs`: `short`/`short_digest` (16-hex SHA-256 prefix).
+- `shell.rs`: shell single/double quoting helpers for generated scripts.
+
+See [internals](internals.md) for hashing, merge dedup, source closures, and the
+panic scanner.

--- a/docs/nix-build/nix-output-monitor/overview.md
+++ b/docs/nix-build/nix-output-monitor/overview.md
@@ -1,0 +1,56 @@
+# nix-output-monitor
+
+`packages/nix-output-monitor` is the upstream `nix-output-monitor` (`nom`),
+re-packaged with one patch so it parses content-addressed derivations. It is a
+Nix-only package: no Rust, no source crate, just a Haskell-package override and a
+smoke test.
+
+## Purpose
+
+`nom` wraps a Nix build and renders a live terminal dependency graph: which
+derivations are building, queued, downloaded, and done. The `index` repo builds
+heavily with content-addressed derivations (the `--content-addressed` render flag
+of [nix-cargo-unit](../nix-cargo-unit/overview.md)), and stock `nom` cannot draw
+a graph for them: it crashes on every CA `.drv`. This package fixes that so `nom`
+is usable on this repo's builds. For the in-house web alternative see
+[nix-web-monitor](../nix-web-monitor/overview.md).
+
+## The bug and the patch
+
+`nom build` reads every `.drv` with the `nix-derivation` Haskell library. Its
+1.1.3 parser runs each output path through `filepathParser`, which fails on an
+empty string. A floating content-addressed (or deferred) output is exactly
+`("out","","r:sha256","")` with an empty path (the store path is assigned only
+after realisation), so `nom` spams `DerivationParseError "string"` and renders no
+dependency graph for CA derivations (`default.nix:7-13`).
+
+`ca-empty-output-path.patch` widens `filepathParser` to accept an empty path
+(returning the empty string) alongside the existing valid-absolute-path case
+(`ca-empty-output-path.patch:9-15`). `nom` is then unchanged: its
+`insertDerivation` calls `parseStorePath ""`, which returns `Nothing`, so the
+still-unrealised floating output is dropped via `traverseMaybeWithKey` instead of
+crashing on a partial field selector (`default.nix:14-21`). This is deliberately
+smaller than upstream PR #26, which turns `DerivationOutput` into a sum type and
+would force a matching `nom` source patch.
+
+## How it builds (`default.nix`)
+
+- Extends `pkgs.haskellPackages` so `nix-derivation` carries the patch via
+  `haskell.lib.compose.appendPatch` (`:30-34`).
+- nixpkgs builds `nom` as a top-level `callPackage` (not inside the
+  `haskellPackages` set), so the override is fed through the top-level package's
+  `haskellPackages` argument with `pkgs.nix-output-monitor.override`
+  (`:23-36`), preserving by-name postInstall symlinks and completions.
+- `overrideAttrs` attaches a `smoke` passthru test that runs `nom --help` and
+  asserts the usage banner (`--version` shells out to `nix`, absent in the
+  sandbox, so `--help` is used) (`:38-65`).
+- `meta.mainProgram = "nom"`, description set (`:66-69`).
+
+## Packaging
+
+`package.nix`: `packageSet = true`, `flake = true`, `passthruTests = true`. Not a
+Rust workspace member. Flake output: `nix-output-monitor`; binary: `nom`. Run as
+`nix run .#nix-output-monitor -- build .#ix` (or `nix build ... |& nom`).
+
+Upstream tracking: nix-output-monitor#122 and the Haskell-Nix-Derivation-Library
+issue #28 referenced in `default.nix:28-29`.

--- a/docs/nix-build/nix-web-monitor/internals.md
+++ b/docs/nix-build/nix-web-monitor/internals.md
@@ -1,0 +1,108 @@
+# nix-web-monitor internals
+
+The state machine, transport, dependency resolution, and daemon tracing behind
+[overview](overview.md).
+
+## Event parsing (`parser/src/lib.rs:1073`)
+
+`parse_line` keys on the `@nix ` prefix (`NIX_JSON_PREFIX`, `:13`): a line
+without it is `Plain`; with it, the JSON is parsed and the `action` field selects
+`start`/`stop`/`result`/`msg` (`parse_event`, `:1095`). Unknown actions become
+`NixEvent::Unknown` rather than an error, so a newer Nix never breaks parsing.
+Result codes and activity codes are named constants (`result_code`,
+`activity_code`, `:37`-`:56`).
+
+## State machine (`MonitorState`, `parser/src/lib.rs:276`)
+
+`apply_parsed_line` mutates an in-memory model: `activities` (by id), `builds`
+(by derivation path), a capped `logs` tail, `errors`, aggregate `progress`,
+`optimise` totals, `daemon` view, and `expected` counts. Two outputs ride out:
+
+- **`snapshot()`** (`:342`): a full `MonitorSnapshot`, used once to seed a new
+  client. The log tail is capped at `SNAPSHOT_LOG_LIMIT` (500, `:26`) because the
+  UI only renders the tail and re-broadcast would otherwise be O(n^2) in build
+  verbosity. Server-side retention is capped separately (`STATE_LOG_RETAIN`
+  5000, `STATE_ERROR_RETAIN` 2000) from the head.
+- **`drain_deltas()`** (`:367`): the incremental `Delta`s accumulated since the
+  last drain, broadcast per applied line. `Delta` (`:248`) is a tagged union
+  (`BuildUpsert`, `ActivityUpsert`, `LogsAppend`, `ProgressSet`, `OptimiseSet`,
+  `DaemonSet`, `ExpectedSet`, `ErrorAppend`, `DependenciesSet`, `Finished`, plus
+  `Reset` used only for the seed).
+
+Non-obvious behaviors:
+
+- **No positive success marker.** Nix never says an activity succeeded, so
+  `finish(exit_code)` (`:475`) waits for the wrapped process: on a clean exit it
+  promotes still-`Stopped`/`Planned` builds to `Succeeded`. `BuildStatus`
+  (`:1042`) is `Planned` (announced in the build plan, seeds the tree top-down) ->
+  `Running` -> `Stopped` -> `Succeeded`/`Failed`.
+- **CA resolve folding.** A content-addressed build emits `resolved derivation:
+  A -> B` then builds `B`; `resolved_to_original` (`:311`) maps `B` back to `A` so
+  the row stays the one the user asked for, flagged `content_addressed`
+  (`:1037`), instead of a look-alike pair.
+- **Build plan sections.** `PlanSection` (`:63`) tracks whether the indented
+  store paths after a "these N derivations will be built" header belong to the
+  build list (seeded as `Planned`) versus the "will be fetched" list.
+- **Optimise totals.** Per-file `FileLinked` results are summed into
+  `OptimiseStats` (`:229`) so the run-wide hard-linking cost behind a slow
+  "copying to the store" is visible; Nix reports no aggregate.
+
+## Transport (`server/src/main.rs`)
+
+`run_nix_command` (`:325`) spawns `nix --log-format internal-json` (and `-v`
+under `--nix-verbose`), forwards stdout byte-for-byte (so `nix eval --raw` is
+exact, `:380`), and reads stderr line by line, decoding lossily so a builder's
+non-UTF-8 byte never stalls the pipe (`parse_stderr`, `:405`). Each line is
+applied under the write lock, then `broadcast_deltas` (`:555`) drains and sends
+the deltas as msgpack binary frames; draining and sending under one lock keeps
+concurrent callers from interleaving frames out of order.
+
+Per-client (`serve_socket`, `:233`): seed with a `Reset` snapshot and subscribe
+under the read lock (no gap or duplicate between seed and stream), then forward
+broadcast frames. A client that outruns the `DELTA_CHANNEL_CAPACITY` (1024) ring
+is re-seeded with a fresh snapshot rather than replayed (replay would
+double-apply non-idempotent `LogsAppend` deltas, `:281`). Sends are bounded by
+`SEND_TIMEOUT` (30s) so a stalled reader is dropped, not pinned (`:310`).
+
+## Dependency DAG (`server/src/dependencies.rs`)
+
+The internal-json stream has no edges, so for every derivation Nix reports,
+`resolve_dependencies` (`:38`) queries `nix-store --query --requisites` (the
+decade-stable interface, not the version-dependent `nix derivation show` JSON,
+`:94`) for its full transitive `.drv` closure and feeds it to
+`MonitorState::record_closure`. Querying the transitive closure (not just direct
+refs) lets the DAG bridge through cached intermediates Nix never reports building
+(`parser/src/lib.rs:420`). `snapshot` reduces the closures to a minimal
+`DerivationEdge` set over built derivations only (`:355`), and `emit_dependencies`
+(`:437`) suppresses an unchanged edge set so redundant `DependenciesSet` frames
+do not ride the wire. Queries run on their own task, bounded to
+`MAX_CONCURRENT_QUERIES` (16, `:22`) so a large build's hundreds of derivations
+fill the tree while builds are still in flight.
+
+## Copy-size measurement (`server/src/main.rs:482`)
+
+Nix reports a local "copying <path> to the store" as an unstructured activity
+with no byte progress. `copy_to_store_source` (`parser/src/lib.rs:941`) extracts
+the source path; the server then walks it on a blocking thread following
+gitignore semantics (skipping `.git`, `parents(false)`), sums apparent file
+sizes, and attaches the figure with `set_activity_size` (`:396`). It is an
+approximate hint: a failed walk leaves the row unannotated rather than failing
+the build (`copied_size`, `:516`).
+
+## Daemon syscall tracer (`server/src/daemon.rs`)
+
+`run_daemon_probe` (`:43`) is the one view the internal-json stream cannot give:
+it attaches a platform tracer to the running `nix-daemon` so the silent
+`addToStore` phase is visible. It finds daemon pids via `pgrep` (`:72`), then
+spawns `fs_usage -w -f filesys nix-daemon` on macOS or `strace -f -p <pid>` on
+Linux (`tracer_command`, `:101`), wrapped in `sudo -n` when not root (`-n` never
+prompts, so a user without privilege gets a "needs root" status instead of a
+hang, `:98`). The tracer's stdout lines are parsed by the parser's
+`parse_fs_usage_line`/`parse_strace_line`, folded into a `DaemonTrace`, and a
+`DaemonInfo` is published every `SAMPLE_INTERVAL` (exactly 1s, so the per-window
+syscall delta is the per-second rate with no division, `:30`). Every failure path
+(no daemon, missing tracer, denied attach) degrades to a status string the panel
+shows and the loop retries after `RETRY_INTERVAL` (5s); the probe never returns
+an error (`:41`). `OpClass::classify` (`parser/src/daemon.rs:37`) groups
+syscalls so the panel shows work kind (Link/Rename dominate store optimisation,
+Write/Fsync dominate writing a path).

--- a/docs/nix-build/nix-web-monitor/overview.md
+++ b/docs/nix-build/nix-web-monitor/overview.md
@@ -1,0 +1,95 @@
+# nix-web-monitor
+
+`packages/nix-web-monitor` runs a Nix command with quiet terminal output and a
+live browser monitor: a build tree, log tail, activity DAG, store-optimisation
+totals, and a `nix-daemon` syscall panel, all on one HTTP port. It is two Rust
+workspace crates:
+
+- **`parser`** (`nix-web-monitor-parser`): the pure, testable parser and state
+  model for Nix's `internal-json` event stream. No I/O. Also exports the
+  per-tracer syscall line parsers in its `daemon` module.
+- **`server`** (`nix-web-monitor`): the `axum` binary that spawns `nix`, feeds
+  stderr through the parser, resolves dependency edges, traces the daemon, and
+  streams deltas to browsers over a WebSocket. Wrapped with a built Svelte site.
+
+The state-machine, transport, dependency-resolution, and daemon-tracing mechanics
+are in [internals](internals.md).
+
+## Why it exists
+
+Nix's `--log-format internal-json` is a flat event stream: it names each
+derivation built but carries no dependency edges, no per-activity success marker,
+and goes silent inside a single long `addToStore` (writing a path, or
+hard-linking every file under `auto-optimise-store`), which is exactly when a
+build looks hung. nix-web-monitor reconstructs the build DAG out-of-band, folds
+content-addressed `resolved derivation` pairs into one row, measures the
+otherwise-unsized "copying to the store" source, and taps the daemon's syscalls
+so the silent phase is visible. The browser feed is plain `ws://` on the page's
+own origin, so off-host access (LAN/Tailscale) needs no certificate.
+
+## CLI surface (`server/src/main.rs:42`)
+
+```
+nix-web-monitor [--host H] [--port N] [--exit-when-done]
+                [--terminal-output summary|logs|quiet] [--nix-verbose]
+                -- <nix args...>
+```
+
+- `--host` (default `0.0.0.0`, `:49`) / `--port` (default `7532`, `:53`): the UI,
+  the `/api/state` JSON snapshot, and the `/ws` delta feed all share this port.
+- `--exit-when-done` (`:61`): exit when the Nix command finishes instead of
+  keeping the UI alive for inspection.
+- `--terminal-output` (`:65`): `summary` (URL, plain output, warnings/errors,
+  status), `logs` (also parsed build logs), or `quiet` (wrapper status only). The
+  browser always gets the full parsed stream regardless.
+- `--nix-verbose` (`:69`): pass `-v` to Nix for richer activity events.
+- trailing args (`:73`): forwarded to `nix` verbatim, e.g. `build .#ix
+  --keep-going`. The wrapper runs whatever `nix` is on the operator's PATH so the
+  build matches a bare `nix build`.
+- `--version` carries the shared build stamp via
+  [build-version](../build-version/overview.md) (`server/src/main.rs:107`).
+
+HTTP routes (`server/src/main.rs:189`): `/` serves `index.html` with
+`Cache-Control: no-store` (so a rebuilt server's asset hashes are never stale),
+`/api/state` is a one-shot `MonitorSnapshot` JSON, `/ws` upgrades to the delta
+feed, and everything else falls through to `ServeDir` (a missing asset 404s
+rather than serving HTML for the wrong MIME type).
+
+## Parser public surface (`parser/src/lib.rs`)
+
+- `parse_line(&str) -> ParsedLine` (`:1073`): classify one Nix stderr line into
+  an `Event(NixEvent)`, `Plain { text }`, or `ParseError`. Events are tagged by
+  `action`: `Start` / `Stop` / `Result` / `Message` / `Unknown`
+  (`:115`), with `ActivityResult` variants for build-log lines, phases, progress,
+  expected counts, fetch status, and `FileLinked` store-optimisation events
+  (`:172`).
+- `MonitorState` (`:276`): the accumulating state machine. `new(command)`,
+  `apply_line` / `apply_parsed_line`, `snapshot() -> MonitorSnapshot`,
+  `drain_deltas() -> Vec<Delta>`, `finish(exit_code)`, plus out-of-band setters
+  `record_closure`, `set_daemon`, `set_activity_size`.
+- `MonitorSnapshot` (`:958`) and `Delta` (`:248`): the seed-once / stream-deltas
+  wire model the browser consumes. `BuildNode`/`BuildStatus` (`:1025`),
+  `ActivityNode` (`:991`), `LogEntry` (`:1058`), `DerivationEdge` (`:984`),
+  `OptimiseStats` (`:229`), `DaemonInfo` (`daemon::DaemonInfo`).
+- `daemon` module (`parser/src/daemon.rs`): `OpClass::classify`,
+  `parse_fs_usage_line` (macOS), `parse_strace_line` (Linux), and the rolling
+  `DaemonTrace` -> `DaemonInfo` aggregator.
+
+## Build and packaging
+
+- `parser/package.nix`: `inRustWorkspace`, `passthruTests`; library crate, no
+  flake output.
+- `server/default.nix`: builds the Svelte UI with `ix.buildSvelteSite`, selects
+  the `nix-web-monitor` binary via `ix.cargoUnit.selectBinaryWithTests`
+  (`:24`), then wraps it (`makeBinaryWrapper`) to set `NIX_WEB_MONITOR_SITE_DIR`
+  to the bundled site and stamp `IX_BUILD_REV`/`IX_BUILD_EPOCH` for
+  [build-version](../build-version/overview.md) (`:59`). Deliberately no PATH
+  wrapping for `nix` (`:48`).
+- Flake output / main program: `nix-web-monitor` (`server/package.nix`,
+  `flake = true`). Run as `nix run .#nix-web-monitor -- build .#ix`.
+
+## Dependencies
+
+Parser: `serde`(+json), `snafu`, `strip-ansi-escapes`. Server: `axum` (+ws),
+`tokio`, `tower-http`, `bytes`, `rmp-serde` (msgpack deltas), `ignore` (gitignore
+walk for copy-size), `clap`, and the parser + `build-version` crates.

--- a/docs/nix-build/oci-image-builder/overview.md
+++ b/docs/nix-build/oci-image-builder/overview.md
@@ -1,0 +1,94 @@
+# oci-image-builder
+
+`packages/oci-image-builder` turns a `dockerTools.streamLayeredImage` layer plan
+into an OCI image. Beyond the legacy one-shot (plan -> tar) it splits the work
+into a tiny content-addressed description (`image.json`) and a separate
+materialization step, so an image can be described cheaply and its bytes built
+only when needed. It is a Rust workspace crate; the layer model it serves is the
+[nix-lib](../../nix-lib/common.md) `lib/image` tree.
+
+## Purpose
+
+`streamLayeredImage` produces a `conf.json` layer plan; turning it into an OCI tar
+is expensive (tens of MiB and up). The description records each layer's digest and
+how to regenerate it, not its bytes, so it is a few KiB: cheap to build and cache,
+and the same description can later target a registry push that uploads only
+missing layers, or a rootfs image, without rebuilding (`README.md:29-37`).
+
+## Modes (`src/main.rs`)
+
+The `Mode` enum (`src/main.rs:36`) plus two sharded subcommands dispatched before
+the positional parser (`src/main.rs:189`):
+
+| invocation | input -> output |
+| --- | --- |
+| `oci-image-builder <conf.json> <out.tar>` | legacy one-shot: plan -> OCI tar (`Build`). Default, so the NixOS image path is unchanged. |
+| `oci-image-builder describe <conf.json> <image.json>` | plan -> description, no layer bytes (`Describe`). |
+| `oci-image-builder materialize <image.json> <out.tar>` | description -> OCI tar, regenerating and verifying bytes (`Materialize`). |
+| `oci-image-builder base-desc <base-archive.tar> <base.json>` | describe the immutable base image's layers (`run_base_desc`, `src/main.rs:267`). |
+| `oci-image-builder layer-desc --uid N --gid N --mtime T <layer.json> <store-path>...` | describe one store layer as its own derivation (`run_layer_desc`, `src/main.rs:218`). |
+| `oci-image-builder assemble-desc --base <base.json> <conf.json> <image.json> <layer.json>...` | stitch precomputed layer descriptions into one `image.json`, re-tarring nothing (`run_assemble_desc`, `src/main.rs:308`). |
+
+`<conf.json>` is the `passthru.conf` `streamLayeredImage` produces (`Config`,
+`src/main.rs:62`). The legacy one-shot is `describe` then `materialize` in one
+pass (`README.md:20-22`).
+
+## Per-layer sharding
+
+`describe` hashes every layer in one process, so changing one store path re-tars
+the whole closure. The sharded path (`base-desc` / `layer-desc` /
+`assemble-desc`) makes each layer its own content-addressed derivation, driven by
+an IFD that reads the layer partition out of `conf.json` (`README.md:39-61`):
+
+```
+conf.json --(IFD)--> Nix
+   base archive  --> base-desc     --> base.json   (cached; base is pinned + immutable)
+   store_layers[k]--> layer-desc   --> layerK.json (one derivation each; same paths = same drv)
+   base.json + layerK.json + conf --> assemble-desc --> image.json (pure stitch, no bytes)
+```
+
+`assemble-desc` reads the precomputed digests, computes the customisation layer's
+digest from its prebuilt checksum, and merges the config, so editing one store
+path re-tars only that layer; the rest and the base are cache hits.
+
+## image.json schema (`Description`, `src/main.rs:89`)
+
+A `Description` records `schema_version`, architecture, `created`/`mtime`/
+`uid`/`gid`/`store_dir`, the merged OCI `config`, and a `layers` list. Each
+`LayerDesc` (`src/main.rs:105`) carries `digest`/`diff_id`/`size` plus a flattened
+`LayerSource` (`src/main.rs:116`) that selects how `materialize` regenerates the
+bytes:
+
+- `store`: re-tar the listed Nix store paths (deterministic from the paths).
+- `base`: copy the named member out of the base docker-archive.
+- `customisation`: copy the prebuilt `layer.tar` from its derivation output.
+
+For uncompressed tar layers the blob digest equals the diff id, which is why a
+pulled base layer (skopeo writes them uncompressed) round-trips without a separate
+compressed digest (`README.md:95-97`, schema in `README.md:65-93`).
+
+## Verification and efficiency policy
+
+- **Materialize verifies bytes.** Each layer is regenerated deterministically and
+  checked against the recorded digest, so a description that no longer reproduces
+  its bytes fails the build instead of shipping a wrong image
+  (`README.md:33-36`).
+- **Efficiency policy** (`EfficiencyPolicy`, `src/main.rs:43`): the layer set is
+  analyzed for paths repeated across layers (wasted bytes). Flags
+  `--min-efficiency`, `--max-wasted-bytes`, `--max-wasted-percent`,
+  `--efficiency-top-paths`, `--skip-efficiency-check` apply to `build`,
+  `describe`, and `materialize` (`README.md:24-27`). Defaults: min efficiency
+  0.95, max wasted 20 MiB, max wasted 20%, top 10 paths (`src/main.rs:14-17`).
+  Base layers from a `fromImage` are excluded (pulled and immutable). Because the
+  cross-layer analysis needs layer bytes the sharded path does not keep, the
+  policy is enforced at `materialize` time where the bytes already exist
+  (`README.md:59-61`).
+
+## Build and packaging
+
+`default.nix` selects the binary via `ix.cargoUnit.selectBinaryWithTests`. It is
+`inRustWorkspace`, `flake = true`, `packageSet = true`, and also an `overlay`
+entry built with `buildIxRustTool` (`package.nix:7-17`). Flake output /
+main program: `oci-image-builder`. Deps (`Cargo.toml`): `tar`, `sha2`, `hex`,
+`chrono`, `serde`/`serde_json`, `tempfile`. See `bench.sh` for the cold/warm
+benchmark.

--- a/docs/nix-build/progress-style/overview.md
+++ b/docs/nix-build/progress-style/overview.md
@@ -1,0 +1,49 @@
+# progress-style
+
+`packages/progress-style` is a small library crate that owns the shared
+[`indicatif`](https://docs.rs/indicatif) progress-bar and spinner styling for ix
+command-line tools, so `search`, `dag-runner`, and future commands render the
+same shape instead of each hand-rolling a template. No binary, no flake output.
+
+## Purpose
+
+One owner for the glyphs, colors, and templates every ix CLI uses to draw
+progress (`src/lib.rs:1-7`). A caller picks a style here, then sets the per-run
+label with `ProgressBar::set_prefix` and the per-run status with
+`ProgressBar::set_message`; the template itself stays fixed.
+
+## Public surface (`src/lib.rs`)
+
+- `bar(accent: &str) -> ProgressStyle` (`:45`): a determinate progress bar: a
+  green braille spinner, the caller's `{prefix}` label, a `pos/len` counter, the
+  contiguous block bar, and elapsed time. `accent` is an `indicatif` color name
+  applied to the filled run over a `blue` track (e.g. `"cyan"`, `"magenta"`) so
+  callers can mark distinct phases. The returned style is reusable across bars.
+- `spinner() -> ProgressStyle` (`:75`): an indeterminate spinner for work with no
+  known total: a cyan braille spinner, a bold `{prefix}` label, a `{wide_msg}`
+  status line, and dimmed elapsed time, sized for one task in a `MultiProgress`
+  group.
+
+Both return `indicatif::ProgressStyle`. The `# Panics` docs note they never panic
+in practice: the templates are fixed shapes, and the internal `expect` only
+guards against an edit that makes a template malformed (`:37-41`, `:67-69`); the
+single unit test builds both to prove the templates parse (`:90-95`).
+
+## Glyphs
+
+- `BAR_CHARS = "█▉▊▋▌▍▎▏░"` (`:23`): a full block, seven fractional blocks, and a
+  light-shade track, in `indicatif`'s `progress_chars` order (first fills a cell,
+  last marks empty, middle render the partially-filled head from 7/8 down to
+  1/8). The empty glyph is `░` not a space so the track stays visible.
+- `TICK_CHARS = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ "` (`:27`): a braille spinner wheel with a trailing
+  blank frame so the final tick clears cleanly. Shared by `bar` and `spinner`.
+
+Templates are built through `format!` (with doubled braces for literal indicatif
+keys) rather than string literals to sidestep a clippy
+`literal_string_with_formatting_args` false positive on indicatif's `{key:.style}`
+syntax (`:46-50`, `:76-77`).
+
+## Build and packaging
+
+`package.nix`: `inRustWorkspace`, `passthruTests`. Library crate, no flake
+output. Only dependency: `indicatif` (`Cargo.toml:12`).

--- a/docs/nix-build/registry/overview.md
+++ b/docs/nix-build/registry/overview.md
@@ -1,0 +1,75 @@
+# registry.nix
+
+`packages/registry.nix` is the package-registry helper: a single Nix file that
+discovers every unit under `packages/**` by reading its `package.nix` metadata
+and produces the per-system lists the flake uses to assemble its outputs. It is a
+Nix-only library, not a flake output and not a package itself.
+
+## Purpose
+
+Rather than enumerate flake outputs by hand, the repo declares per-package intent
+in a small `package.nix` next to each unit, and `registry.nix` walks the tree,
+validates that metadata, and answers "which packages are flake outputs / overlay
+entries / package-set entries / Rust workspace members / have passthru tests, on
+this system". It is imported by `lib/default.nix` and `lib/per-system.nix` as
+`packageRegistry` (`lib/default.nix:30`, `lib/per-system.nix:26`).
+
+## Signature and discovery
+
+Called as `import packages/registry.nix { lib; root; }` where `root` is the
+packages directory (`registry.nix:1`). It recursively finds every directory
+containing a `package.nix` (`dirsWithFile`/`packageDirs`, `:16-24`) and, for
+diagnostics, every `default.nix` dir lacking a `package.nix`
+(`packageDirsWithoutMetadata`, `:25-28`).
+
+## package.nix metadata schema
+
+Each `package.nix` is an attrset (or a `{ lib }`-function returning one) whose
+keys are validated against `allowedMetadataKeys` (`:30-39`); an unknown key is a
+hard assertion failure (`assertKnownKeys`, `:41-49`). Recognized keys:
+
+- `id` (required): the unique package id; duplicate ids across the tree fail
+  (`:176-178`).
+- `flake`: expose a flake output. `true` takes the id as the attr name; an
+  attrset overrides `attrName` and/or `systems` (`normalizeFlake`, `:89`).
+- `overlay`: an overlay entry, with an extra `build` key (`normalizeOverlay`,
+  `:95`).
+- `packageSet`: a package-set entry selected by `attrPath` (defaults to `[ id ]`;
+  `normalizePackageSet`, `:83`).
+- `inRustWorkspace`: a member of the root Cargo workspace (built through
+  [nix-cargo-unit](../nix-cargo-unit/overview.md) via `ix.cargoUnit`) (`:134`).
+- `passthruTests`: expose passthru tests under a prefix (default `rust-<id>`;
+  `normalizePassthruTests`, `:102`).
+- `updateScript`: marks a package exposing a `passthru.updateScript`, driving the
+  generated `update` aggregator (`:136-140`).
+- `path`: override the source path (defaults to the discovered dir, `:128`).
+
+`flake`/`overlay`/`packageSet`/`passthruTests` are all system-scoped: a target is
+`null`/`false` to disable, `true` for the default selector, or an attrset to
+override the selector key and `systems` (`normalizeTarget`, `:55-81`).
+
+## Outputs
+
+The returned attrset (`registry.nix:179-190`):
+
+- `entries`: every package's normalized metadata; `byId`: the same keyed by id.
+- `packageDirsWithoutMetadata`: `default.nix` dirs missing a `package.nix`.
+- `packageSetEntriesFor system`, `flakeEntriesFor system`,
+  `overlayEntriesFor system`, `updateScriptEntriesFor system`,
+  `passthruTestEntriesFor system`: the per-system filtered lists
+  (`enabledForSystem`, `:148-150`, gates on each target's `systems`).
+- `rustWorkspaceEntries`: every `inRustWorkspace` package.
+
+`passthruTestEntriesFor` includes a package when its `packageSet` is enabled for
+the system, or (for a pure workspace crate) when it is `inRustWorkspace`
+(`:164-172`), so library crates like [build-version](../build-version/overview.md)
+and [progress-style](../progress-style/overview.md) still get gated.
+
+## Relation to the rest of the domain
+
+Every other unit in this domain declares its `package.nix` here: nix-cargo-unit
+(`packageSet`/`flake`, not `inRustWorkspace`), the Rust workspace tools
+(`inRustWorkspace` + `flake`), snix and nix-output-monitor (`flake`/`packageSet`,
+not in the workspace), and the library crates (`inRustWorkspace` only). This file
+is what turns those declarations into the flake's `packages`, `overlays`, and
+check lists.

--- a/docs/nix-build/snix/overview.md
+++ b/docs/nix-build/snix/overview.md
@@ -1,0 +1,58 @@
+# snix
+
+`packages/snix` builds the snix `default` CLI (a Rust reimplementation of Nix,
+TVL depot `git.snix.dev/snix/snix`) through this repo's
+[nix-cargo-unit](../nix-cargo-unit/overview.md) engine instead of snix's own
+crate2nix packaging. It is a Nix-only package: the source is an external,
+fetched Cargo workspace, not a member of this repo's workspace.
+
+## Purpose
+
+snix upstream packages itself with crate2nix (`snix/Cargo.nix` +
+`crate-hashes.json`): roughly 1100 one-derivation-per-crate builds plus feature
+powersets, with no shared incrementality (`default.nix:11-17`). This package
+builds the same CLI through `ix.cargoUnit.buildWorkspace`, so snix compiles as
+one Nix derivation per Cargo rustc unit with source-scoped, content-addressed
+inputs: the same engine that builds the rest of the repo's Rust tree. It is also
+the worked example of `cargoUnit` building an arbitrary external workspace, not
+just this repo's.
+
+## How it builds (`default.nix`)
+
+- **Source**: the `snix-src` flake input, surfaced as `ix.snixSrc`; the Cargo
+  workspace lives in its `snix/` subdirectory (`default.nix:19-22`).
+- **`ix.cargoUnit.buildWorkspace`** (`default.nix:24`) with `pname = "snix"`,
+  `src`/`workspaceRoot` both the `snix/` dir, `cargoLock` its `Cargo.lock`, and
+  `cargoArgs = [ "--workspace" ]`.
+- **Relaxed third-party policy** (`default.nix:36-41`): build it, do not lint or
+  audit it: `denyUnusedCrateDependencies`, `cargoAudit`, `cargoMachete`, and
+  `clippy` all disabled (snix is not this repo's code to gate).
+- **Build-script tooling** applied to every unit (`default.nix:49-64`):
+  `protobuf` (prost/tonic `protoc`), `pkg-config` (`*-sys` crates), `cmake`+`perl`
+  (aws-lc-sys, rustls' default backend). `PROTOC`/`PROTOC_INCLUDE` are set, and
+  `PROTO_ROOT` points at the whole snix checkout because cargo-unit gives each
+  build script a per-crate scoped `CARGO_MANIFEST_DIR`, which snix's `.proto`
+  resolution would otherwise break on.
+- **Git dependency hashes** pinned by exact lock source string in `outputHashes`
+  (`default.nix:69-76`); refresh with `nix flake update snix-src`.
+
+## The `default` CLI assembly
+
+snix ships a base `snix` dispatcher (crate `snix-cli`, bin `snix`) that finds each
+`snix-<subcommand>` binary on `SNIX_LIBEXEC_PATH`, mirroring snix's own
+`cli/make-cli.nix` + `cli/default-cli.nix` (`default.nix:79-83`). The package
+`runCommand` symlinks the eight subcommand binaries from
+`workspace.binaries.<name>` into `$out/libexec` and `makeWrapper`s the `snix`
+binary with `SNIX_LIBEXEC_PATH` suffixed to that dir (`default.nix:95-114`):
+
+`snix-build`, `snix-castore`, `snix-castore-http`, `snix-derivation-show`,
+`snix-eval`, `snix-nar-bridge`, `snix-nix-daemon`, `snix-store`
+(`default.nix:84-93`). virtiofs is a Linux-only non-default feature, so the plain
+`--workspace` graph omits it and the binary set is identical across platforms.
+
+## Packaging
+
+`package.nix`: `flake = true`, `packageSet = true`; NOT `inRustWorkspace` (it is
+an external fetched workspace). `meta`: GPL-3.0-only, `mainProgram = "snix"`,
+`platforms = unix`. Flake output / package-set name: `snix`. `passthru.workspace`
+exposes the full `buildWorkspace` result. Run as `nix run .#snix`.

--- a/docs/nix-lib/agent-context/overview.md
+++ b/docs/nix-lib/agent-context/overview.md
@@ -1,0 +1,74 @@
+# lib/agent-context: agent context and skills assembly
+
+`lib/agent-context/` assembles the instructions and skills delivered to a coding
+agent at session start: the always-on instruction document, the progressive
+on-demand skills, the handwritten skills directory, declarative subagents, and
+the frontmatter parser they share. `lib/default.nix` imports it as
+`ix.agentContext` (`lib/default.nix:120`), `ix.skills`
+(`lib/default.nix:121`), and `ix.agents` (`lib/default.nix:122`). It pairs with
+the [agents-md](../../agents/agents-md/overview.md) Rust CLI, which writes and
+diffs the generated instruction files on disk.
+
+## default.nix: the always/progressive split
+
+`ix.agentContext` (`lib/agent-context/default.nix:1`) parses every file under
+`agent-context/sections/`. Each section carries YAML frontmatter naming it and
+declaring a disclosure tier (`lib/agent-context/default.nix:38-56`):
+
+- `disclosure: always` sections are concatenated into one small `alwaysDoc` the
+  SessionStart hook prints in full (`lib/agent-context/default.nix:76-87`).
+- `disclosure: progressive` sections each become a Claude Code skill: only
+  `name` + `description` stay always-visible; the body loads on demand.
+
+The always tier size is a build-time invariant: `alwaysDoc` asserts it stays
+under `alwaysCharCap` (9000, below Claude's ~10000-char SessionStart limit), so
+marking too much `always` fails the build instead of silently truncating
+(`lib/agent-context/default.nix:24-28`, `84-87`). Duplicate section names throw
+(`lib/agent-context/default.nix:61-71`).
+
+Public surface (`lib/agent-context/default.nix:118-212`): `alwaysCharCap`,
+`sections` (keyed by name), `alwaysSections`/`progressiveSections`,
+`alwaysDoc`/`alwaysDocLength`, `documents` (the doc rendered per target,
+CLAUDE.md and AGENTS.md), `mkProgressiveSkills { pkgs }` (progressive sections ->
+skill directories), and `mkApp { pkgs, binary }` (wrap the `agents-md` CLI for
+`nix run .#agent-context -- --write`).
+
+## skills.nix: the handwritten skills directory
+
+`ix.skills` (`lib/agent-context/skills.nix:1`) auto-discovers skill directories
+under `paths.skills` (each a directory with a `SKILL.md`, optional
+`assets/`/`references/`), so adding a directory there is the only step to publish
+a shared skill (`lib/agent-context/skills.nix:4-13`). Surface
+(`lib/agent-context/skills.nix:64-107`): `sources` (name -> path), `allSkills`,
+`profiles.{antithesis,common}` (partitioned by an `antithesis` name prefix), and
+`mkSkillsDir { pkgs, names ? allSkills, extraSkills ? {} }`. `mkSkillsDir` builds
+one directory of selected skills (merging `mkProgressiveSkills` output via
+`extraSkills`), materialized as real directories of real files with no symlinks,
+because Claude Code's `/`-autocomplete drops symlinked entries
+(`lib/agent-context/skills.nix:47-62`). Unknown names throw.
+
+## agents.nix: declarative subagents
+
+`ix.agents.mkAgentsDir { pkgs, agents }` (`lib/agent-context/agents.nix:47`,
+exported `90`) renders declarative subagents to a `.claude/agents/<name>.md`
+directory. An agent is `{ frontmatter; body }`: `frontmatter` is an attrset (its
+`mcpServers` value comes straight from `ix.mcp.toAgentMcpServers`, so a
+subagent's servers are declared from the same registry the wrappers bake,
+`lib/agent-context/agents.nix:1-7`), `body` is the markdown system prompt.
+Frontmatter is rendered with a fixed lead-key order (name, description, tools,
+model, mcpServers), nested values as inline JSON
+(`lib/agent-context/agents.nix:15-34`); a `frontmatter.name` must equal the key.
+Like skills, output is real files, no symlinks
+(`lib/agent-context/agents.nix:60-72`). Used in `lib/per-system.nix` to ship the
+`index-action-runner` subagent with a fresh inline `index` MCP server.
+
+## frontmatter.nix: the parser
+
+`import ./frontmatter.nix { inherit lib }` returns a function `text ->
+{ frontmatter; body }` (`lib/agent-context/frontmatter.nix:19`). It parses the
+constrained shape this repo controls (a leading `---` fence, single-line
+`key: value` pairs preserving colons in the value and stripping surrounding
+quotes, a closing `---`, then the body), not arbitrary YAML; multi-line block
+scalars are unsupported on purpose (`lib/agent-context/frontmatter.nix:2-17`). A
+string with no leading fence yields empty frontmatter and the whole string as
+body. Used by `default.nix` to parse section files.

--- a/docs/nix-lib/build-helpers/overview.md
+++ b/docs/nix-lib/build-helpers/overview.md
@@ -1,0 +1,74 @@
+# lib/build: non-Rust build helpers
+
+`lib/build/` holds the builders for everything that is not the
+[cargo-unit Rust path](../rust/overview.md): JS/TS sites, Python uv apps, Go
+units, Gradle fat-jars, Zig packages, and the libghostty-vt C library, plus the
+lockfile-vendoring helpers they sit on. `lib/default.nix` imports each and
+surfaces them on `ix.<name>` (`lib/default.nix:96-116`, `164-170`); the
+`bunLockFor`/`uvLockFor`/`goUnitFor` factories and the `buildJsSite`/
+`buildSvelteSite`/`buildNpmVitest`/`buildUvApplication`/`buildGradleFatJar`/
+`buildZigPackage`/`buildLibghosttyVt`/`goUnit` builders ride
+`sharedHelpers`/`ixReturn` (`lib/default.nix:398-426`, `494-518`).
+
+The shared shape: dependency hashes come from the project's own lockfile, so
+updating deps is `<pkgmgr> lock` + commit, not maintaining a separate Nix hash.
+Most builders are curried `pkgs: args:` so they build for the caller's system.
+
+## Lockfile vendoring
+
+- `bunLockFor pkgs` (`lib/build/bun-lock.nix`, `lib/default.nix:96-100`): parse a
+  `bun.lock`/`package.json` and build the offline node_modules
+  (`buildNodeModules`, `lib/build/bun-lock.nix:137`). The sidecar
+  `bun-lock-to-json.js` converts Bun's lock to JSON. Consumed by the site
+  builders, not usually called directly.
+- `uvLockFor pkgs` (`lib/build/uv-lock.nix`, `lib/default.nix:110-114`): read a
+  `uv.lock`, convert uv hashes to SRI, and build a wheelhouse of fetched
+  distributions (`buildWheelhouse`) for offline install. Consumed by
+  `buildUvApplication`.
+
+## JS / TS sites
+
+- `buildJsSite pkgs { ... }` (`lib/build/js-site.nix`): build a static frontend
+  from a locked npm or Bun project; pick the package manager with
+  `packageManager` (`lib/build/js-site.nix:6-17`). Dependencies are built
+  separately and linked in, so source-only changes do not reinstall.
+- `buildSvelteSite pkgs { pname, version, src, packageManager?, distDir?, serve?,
+  devServer? }` (`lib/build/svelte-site.nix`): wraps the same package-manager
+  branching with a static-preview server (`miniserve` over the immutable output)
+  and a checkout dev server (Vite from a mutable checkout). Used for the repo
+  site and the dashboard UI (`lib/per-system.nix:427-440`,
+  `lib/rust/workspace.nix:39-51`).
+- `buildNpmVitest pkgs { pname, version, src, preTest?, ... }`
+  (`lib/build/npm-vitest.nix`): run a Vitest browser-mode suite in the sandbox
+  with playwright's bundled chromium. Exposes `all` (one runCommand for the whole
+  suite, good as a `checks.<name>`) and `cases.<id>` (one per `#test`, gated on a
+  single `vitest list` IFD, `lib/build/npm-vitest.nix:1-13`).
+
+## Other language builders
+
+- `buildUvApplication pkgs { srcRoot | src, ... }`
+  (`lib/build/uv-application.nix`): build a Python app from a uv project.
+  Distributions are fetched into a wheelhouse, installed offline into a venv, the
+  local project built as a wheel, and `ty` type-checks the venv by default
+  (matching `writePythonApplication`, `lib/build/uv-application.nix:4-16`).
+- `goUnit` / `goUnitFor pkgs` (`lib/build/go-unit.nix`, `lib/default.nix:164-170`):
+  Go build helpers taking `go = languages.go`; `buildWorkspace`
+  (`lib/build/go-unit.nix:241`, exported `278`) builds a Go workspace with
+  `buildPackage`/`testPackage` per package, keyed by a `vendorHashKey`.
+- `buildGradleFatJar { pname, version, src, verificationMetadata, ... }`
+  (`lib/build/gradle-fat-jar.nix`): build a Gradle fat-jar fixed-output and
+  network-isolated, with dependency hashes from a Gradle dependency-verification
+  XML reproduced into the sandbox and the task run offline
+  (`lib/build/gradle-fat-jar.nix:1-18`).
+- `buildZigPackage pkgs { pname, version, src, zigDepsHash?, ... }`
+  (`lib/build/zig-package.nix`): build a `build.zig`/`build.zig.zon` project;
+  remote deps are content-addressed by Zig hashes plus one `zigDepsHash` for the
+  realized package cache. Named Zig test steps become separate
+  `passthru.tests` derivations so flake checks parallelize them
+  (`lib/build/zig-package.nix:3-14`).
+- `buildLibghosttyVt pkgs { ghosttySource, version? }`
+  (`lib/build/libghostty-vt.nix:10-14`): build ghostty's VT engine as a
+  standalone C library via `-Demit-lib-vt=true` (parser, screen model,
+  render-state API; no GUI). Emits `libghostty-vt.a`, a self-contained
+  `.dylib`/`.so`, the `ghostty/` headers, and a pkg-config file. Linked by
+  `ix-vt-sys` in the Rust workspace (`lib/rust/workspace.nix:26-31`).

--- a/docs/nix-lib/common.md
+++ b/docs/nix-lib/common.md
@@ -1,0 +1,121 @@
+# nix-lib
+
+`lib/` is the repo's Nix helper/builder/library layer: the functions, builders,
+and attrsets that build the Rust workspace, per-language toolchains, OCI images,
+fleets, systemd/home-manager service helpers, and the cross-cutting utilities
+every package and module reaches for. `lib/default.nix` wires all of it into one
+attrset (`ixReturn`, `lib/default.nix:491-528`), which the flake exposes as the
+`lib` output (`flake.nix:273`) and threads into every module as
+`specialArgs.ix`. If you write Nix in this repo, this is the surface you call.
+
+Read this page first, then the component page for the area you are touching.
+
+## How `lib` is assembled and exposed
+
+`flake.nix` calls `import ./lib { ... }` once (`flake.nix:234-251`), passing
+nixpkgs, the flake inputs (rust-overlay, home-manager, source-tree pins), the
+flake `rev`/`revEpoch`, and a `paths` attrset (`flake.nix:206-232`) that is the
+single source of truth for every path literal. `lib/default.nix` is one big
+recursive `let`: each helper is imported from its subdir and the file's job is
+to wire them together (`lib/default.nix:1-2`).
+
+Three derived surfaces come out of that `let`, all built from one
+`sharedHelpers` base (`lib/default.nix:388-433`) so a new helper reaches every
+consumer from a single edit:
+
+| surface | binding | who reads it |
+| --- | --- | --- |
+| `ixReturn` | `lib/default.nix:491` | the flake `lib` output (`flake.nix:273`); examples receive it as `index.lib` |
+| `ixSpecialArgs` | `lib/default.nix:440` | every NixOS module as `specialArgs.ix` (`lib/image/default.nix:65`) |
+| `sharedHelpers` | `lib/default.nix:388` | the common base both of the above splice with `//` |
+
+The flake then maps `ixReturn` into outputs: `lib`, `nixosModules`,
+`overlays.default`, `homeModules`, and (via `lib/per-system.nix` evaluated per
+system in `flake.nix:258-269`) `packages`, `checks`, `ciChecks`, `apps`,
+`devShells`, `formatter` (`flake.nix:272-341`).
+
+`lib/per-system.nix` is the per-system half: it instantiates nixpkgs with the
+rust-overlay and `ix.overlay`, then defines the workflow tools (`lint`,
+`check`, `update`, `bench`, `health-checks`, `site`, ...) as
+`packages.<system>.<name>` derivations with `meta.mainProgram` so each is both
+`nix run`-able and `nix build`-able (`lib/per-system.nix:1-8`).
+
+## Areas (`lib/` subdirs)
+
+| area | what | page |
+| --- | --- | --- |
+| discovery glue | `default.nix` + `discovery.nix` + `packages.nix` + `per-system.nix` + `overlay.nix`: how packages/modules/images/examples are auto-discovered and wired | [discovery](discovery/overview.md) |
+| `lib/rust` | cargo-unit: the core Rust builder (vendor, unit graph, per-unit build, policy gates, prebuilt injection, cross) | [rust](rust/overview.md) |
+| `lib/languages` | per-language toolchain/compiler/interpreter selectors (rust, python, go, java, ...) | [languages](languages/overview.md) |
+| `lib/image` | `mkImage`/`mkNonNixImage`/`mkFleet`/`mkDev`: NixOS->OCI builders, fleet eval, dev fleets, the base platform module | [image](image/overview.md) |
+| `lib/services` | portable-services (launchd+systemd), systemd-hardening, mutable-json: home-manager and systemd helpers | [services](services/overview.md) |
+| `lib/dev` | `ix.dev.*` options, agent CLI layer, identity binds, SMB shared mount for dev fleets | [dev](dev/overview.md) |
+| `lib/darwin` | pinned macOS SDK + zig cross toolchain for Linux->Darwin Rust builds | [darwin](darwin/overview.md) |
+| `lib/minecraft` | NBT tag constructors + format generator, dimension-type snapshots, loader module factory, sync-managed wrapper | [minecraft](minecraft/overview.md) |
+| `lib/agent-context` | always-on instruction doc + progressive skills, skills/agents directory assembly, frontmatter parser | [agent-context](agent-context/overview.md) |
+| `lib/util` | pure utilities: errors, deep-merge, endpoint, attrs, lists, toml, mcp, relative-path, secrets, writers, bench, artifacts | [util](util/overview.md) |
+| `lib/build` | non-Rust language builders: bun/npm/uv lock vendoring, JS/Svelte sites, Go units, Gradle fat-jars, Zig, libghostty-vt | [build-helpers](build-helpers/overview.md) |
+
+## Cross-component invariants
+
+- **One `pkgs` per surface.** `lib/default.nix` pins `system = "x86_64-linux"`
+  (`lib/default.nix:28`) and builds one overlaid `pkgs` for image/module eval
+  (`lib/default.nix:74`). Image builds share one nixpkgs instance via
+  `nixpkgs.pkgs` (`lib/image/default.nix:39-47`) rather than re-instantiating
+  per node. Most builders are curried `pkgs: args:` so a caller can rebind them
+  to the host system (`lib/packages.nix:14-23`).
+- **The registry is the package index.** `packages/registry.nix` walks
+  `packages/**` for `package.nix` metadata files and returns `byId`,
+  `packageSetEntriesFor`, `flakeEntriesFor`, `overlayEntriesFor`, etc.
+  (`packages/registry.nix:179-190`). `packageSetFor`, `overlay`, and
+  `buildIxRustTool` all resolve packages by id through it. See
+  [discovery](discovery/overview.md).
+- **Discovery, not manifests.** `images/`, `modules/`, and `examples/` are
+  walked by `discoverTree` (`lib/discovery.nix:20-79`): a directory with the
+  required files becomes an output, duplicate output names throw, and `_`-
+  prefixed dirs are skipped. Adding an image/module/example is a `mkdir` + edit,
+  no registry change (`lib/discovery.nix:235-237`).
+- **Validate-then-return helpers.** Language and many util helpers route bad
+  args through `ix.errors` (`assertEnum`/`requireArg`/`requireAttr`,
+  `lib/util/errors.nix`) so a typo throws with the valid set listed instead of
+  `attribute missing` deep in eval.
+- **`deepMerge` is the only sanctioned recursive merge.** `lib/util/deep-merge.nix`
+  replaces hand-rolled merges and the `no-recursive-update` lint points at it;
+  `strict` throws on leaf collision, `rhs` lets the override win,
+  `strictList` folds N attrsets.
+- **Content-addressed Rust units.** The Rust workspace units default to
+  `contentAddressed = true` (`lib/rust/cargo-unit.nix:301`), which is why the
+  flake declares `ca-derivations` in `nixConfig.extra-experimental-features`
+  (`flake.nix:18-20`).
+
+## Glossary
+
+- **`specialArgs.ix`**: the `ixSpecialArgs` bundle handed to every NixOS module;
+  the cross-module contract (helpers, `packages`, `buildRustPackage`,
+  `islandsTheme`). Keep it small and stable (`lib/default.nix:435-443`).
+- **`ix` / `index.lib`**: the public `ixReturn` attrset; `flake.nix` exports it
+  as `lib`, examples consume it as `index.lib`.
+- **cargo unit**: one Cargo rustc compile step (a crate target at a profile with
+  fixed features/deps), built as its own Nix derivation. See [rust](rust/overview.md).
+- **unit graph**: Cargo's `--unit-graph` JSON, the planning input the
+  nix-cargo-unit renderer turns into one derivation per unit.
+- **vendor dir**: a package-shaped directory (one entry per `Cargo.lock`
+  dependency) plus the cargo config pointing at it, so builds fetch nothing
+  (`lib/rust/vendor.nix`).
+- **toolchain id**: the basename of a Rust toolchain store path, baked into
+  every unit hash (`lib/rust/resolve.nix:37-41`).
+- **policy**: the Rust quality/correctness gates (clippy, cargo-audit,
+  cargo-machete, unused-dep denial, panic-freedom, tests, linker) resolved from
+  a typed schema (`lib/rust/policy.nix`).
+- **registry**: `packages/registry.nix`, the metadata index of every package
+  under `packages/**` keyed by `id`.
+- **sidecar**: an optional per-directory metadata file discovery imports
+  (`versions.nix` for images, `package.nix` for packages).
+- **overlay package vs flake-output package**: overlay packages enter the
+  nixpkgs namespace as `pkgs.<name>` for modules (`lib/overlay.nix`);
+  flake-output-only packages reach consumers as `packages.<system>.<name>`
+  without leaking into images (`lib/packages.nix`).
+- **fleet**: a Colmena-style set of VM nodes evaluated by `mkFleet`
+  (`lib/image/fleet.nix`); each node is a NixOS image plus deployment metadata.
+- **portable service**: one spec rendered to a native launchd agent (macOS) and
+  systemd user units (Linux) (`lib/services/portable-services.nix`).

--- a/docs/nix-lib/darwin/overview.md
+++ b/docs/nix-lib/darwin/overview.md
@@ -1,0 +1,52 @@
+# lib/darwin: macOS cross-compilation helpers
+
+`lib/darwin/` cross-compiles a Rust workspace (and its C/C++ deps) from Linux to
+Darwin without an Apple machine. Two files: a pinned macOS SDK and the zig + SDK
+toolchain that consumes it. `lib/default.nix` exposes both as `ix.macosSdk` and
+`ix.appleSdkToolchain` (`lib/default.nix:368-380`); the Rust workspace's cross
+path wires them together (`lib/rust/workspace.nix:147-157`,
+`unitsFor { target }`).
+
+## macos-sdk.nix
+
+`macosSdk { pkgs }` (`lib/darwin/macos-sdk.nix:10`) fetches a public repackaged
+`MacOSX15.4.sdk` tarball pinned by SRI hash and unpacks it
+(`lib/darwin/macos-sdk.nix:12-20`). Clang and zig respect `-isysroot` / `SDKROOT`
+pointing at the unpacked SDK, so one fetched SDK covers both the C compile and
+the Rust link. Apple licenses the SDK for use on Apple hardware; override
+`ix.macosSdk` with your own SDK derivation for a stricter licensing posture
+(`lib/darwin/macos-sdk.nix:6-9`). The same tarball + hash is shared with the
+sibling `ix` repo, so the store path is shared.
+
+## apple-sdk-toolchain.nix
+
+`appleSdkToolchain { appleSdk, lib, pkgs, target }`
+(`lib/darwin/apple-sdk-toolchain.nix:13-18`) builds a cross toolchain for a
+Darwin `target` (`aarch64-apple-darwin` or `x86_64-apple-darwin`; others throw,
+`lib/darwin/apple-sdk-toolchain.nix:232-233`). `zig cc` / `zig c++` are the cross
+C/C++ compilers with the SDK as sysroot; `clang -fuse-ld=lld` is the Rust linker
+(`lib/darwin/apple-sdk-toolchain.nix:1-7`). The wrappers go through the checked
+`writeBashApplication` (so `bash -n` + shellcheck run at build time) and rewrite
+incoming args: normalize Apple `--target=` spellings to zig's, drop `-arch`/`-m64`
+and sanitizer flags, and pin `ZIG_GLOBAL_CACHE_DIR` to an action-local writable
+path so a sandboxed `HOME=/var/empty` does not make zig fail silently
+(`lib/darwin/apple-sdk-toolchain.nix:30-138`).
+
+It returns three fields the Rust workspace consumes
+(`lib/darwin/apple-sdk-toolchain.nix:234-275`):
+
+- `env`: `CC`/`CXX`/`AR`/`RANLIB`/`SDKROOT`/`CFLAGS`/`CMAKE_TOOLCHAIN_FILE` plus
+  the per-target `CARGO_TARGET_<T>_LINKER` and `CARGO_TARGET_<T>_AR` the
+  nix-cargo-unit renderer picks up per unit.
+- `runtimeInputs`: the wrapper packages (cc/cxx/linker/ar/ranlib/xcrun) + LLVM
+  bintools.
+- `rustcArgsForPlatform platform`: returns the framework search path only when
+  `platform == target` (`lib/darwin/apple-sdk-toolchain.nix:239-244`), so host
+  (platform=null) and other-target units are unaffected. This is the hook
+  `buildWorkspace` calls per unit.
+
+`lib/rust/workspace.nix` invokes `appleSdkToolchain` for an
+`*-apple-darwin` cross target and folds its `env`/`runtimeInputs`/
+`extraRustcArgsForPlatform` into the cross unit graph
+(`lib/rust/workspace.nix:147-157`, `236`, `281-282`). See
+[rust](../rust/overview.md) for the cross-graph entry point `unitsFor`.

--- a/docs/nix-lib/dev/overview.md
+++ b/docs/nix-lib/dev/overview.md
@@ -1,0 +1,78 @@
+# lib/dev: dev environment helpers
+
+`lib/dev/` is the option surface and module builders behind `mkDev`
+(RFC 0007, see [image/dev](../image/overview.md)). It lets a forked `dev.nix`
+read like an ordinary NixOS module: write `environment.systemPackages` at the
+top level as usual, and reach for `ix.dev.*` only to describe the agents, fleet
+shape, and shared identity volume. These files live in `lib/dev/` (not
+`modules/`) so the surface is only in scope where a dev image pulls it in: it
+must not add `claude-code` to every image in the repo
+(`lib/dev/options.nix:10-11`).
+
+`lib/image/dev.nix` consumes all four files: `options.nix`/`agents.nix` as
+modules, and `identity.nix`/`shared-mount.nix` as builders it applies per node
+(`lib/image/dev.nix:36-43`).
+
+## options.nix: the `ix.dev.*` surface
+
+Declares the option tree `mkDev` reads to plan the fleet
+(`lib/dev/options.nix:23-156`):
+
+- `ix.dev.agents.{claude,codex}` (both default true): which agent CLIs to install.
+- `ix.dev.baseImage` (default `development-base`): the `images/dev/` image every
+  node builds on.
+- `ix.dev.selfSource` (default true): materialize the dev source at `/ix` on
+  every node so a VM can bring up more VMs from the same spec.
+- `ix.dev.fleet.<node> = { replicas, dependsOn, groups, modules }`: the fleet
+  topology, mirroring `mkFleet` nodes; default is a single `dev` node
+  (`lib/dev/options.nix:56-96`).
+- `ix.dev.shared.*`: the shared SMB identity volume:
+  `enable`, `mountPoint` (`/shared`), `claude` (bind `~/.claude`, on by default
+  so one `claude login` covers the fleet), `ix` (bind `~/.n`, off by default
+  since it hands out VM-creation ability), `excludeNodes`, `server`
+  (`file-server`), `group` (`ix-dev-shared`, private east-west), `guestOk`
+  (`lib/dev/options.nix:98-155`).
+
+## agents.nix: the agent CLI layer
+
+The single source of truth for "our versions of the agents", imported by both
+`images/dev/development-base` and `mkDev` so the wrapped `claude` binary and its
+managed-settings policy cannot drift (`lib/dev/agents.nix:1-13`). It imports
+`options.nix` and, gated on `ix.dev.agents.*`, installs `pkgs.codex` and a
+`claude-code` wrapper that bakes `IS_SANDBOX=1` (the guest VM is the sandbox
+Claude's root-user guard asks about, `lib/dev/agents.nix:36-41`). It also writes
+`/etc/claude-code/managed-settings.json` (Claude's highest-precedence, read-only
+layer) to set `permissions.defaultMode = "bypassPermissions"`,
+`skipDangerousModePermissionPrompt`, summarized thinking, and effectively
+infinite transcript retention (`lib/dev/agents.nix:86-101`). Leaving
+`~/.claude/settings.json` app-owned is why binding it onto the shared volume does
+not collide with this managed layer.
+
+## identity.nix: what lives on the volume
+
+Module builders for the bound identity directories and `/ix`
+(`lib/dev/identity.nix:30-92`):
+
+- `bindModule { mountPoint, binds }`: bind-mounts each `{ localPath,
+  shareSubdir }` (e.g. `/root/.claude`) onto `<mountPoint>/<shareSubdir>` with
+  `nofail` + `x-systemd.requires-mounts-for` ordering after the CIFS mount
+  (`lib/dev/identity.nix:38-52`). Only `~/.claude` / `~/.n` are shared, never the
+  whole `~/.config`.
+- `sourceNode` / `sourceServerSeed`: materialize `/ix` for recursion: on the
+  volume when one exists (writable, fleet-wide), else a local writable copy
+  seeded once from the read-only store source.
+
+## shared-mount.nix: the SMB share
+
+`{ serverModule, clientModule }` builders for the dev-fleet identity volume
+(`lib/dev/shared-mount.nix:30-`). One node runs userspace `smbd` (ix guests
+share the host `linux-ix` kernel, so the server cannot be in-kernel `ksmbd`) and
+exports one share; every other node mounts it over CIFS with `cifs.ko`. The
+locking knobs keep a concurrent `~/.claude/.credentials.json` token refresh
+honest (`lib/dev/shared-mount.nix:5-10`). `serverModule { shareName, shareDir,
+guestOk ? true, subdirs ? [] }` pre-creates the bind-mount targets;
+`mkDev` calls these with the elected server node (it does not configure Samba
+itself). `guestOk` defaults true so the example fleet comes up with no secrets
+plumbing; the share is only reachable on the private east-west group. A
+production identity volume should set `guestOk = false` and add a Samba user
+(`lib/dev/shared-mount.nix:16-23`).

--- a/docs/nix-lib/discovery/overview.md
+++ b/docs/nix-lib/discovery/overview.md
@@ -1,0 +1,122 @@
+# discovery and registration glue
+
+The wiring that turns directory trees into flake outputs. Five files:
+`lib/default.nix` (assembly), `lib/discovery.nix` (tree walks),
+`lib/packages.nix` (flake-output package set), `lib/overlay.nix` (nixpkgs
+overlay), and `lib/per-system.nix` (per-system outputs), plus the package index
+at `packages/registry.nix`. Together they mean adding a package, module, image,
+or example is a filesystem edit, not a registry edit.
+
+## `packages/registry.nix`: the package index
+
+Walks `packages/**` for every directory containing a `package.nix` metadata
+file (`packages/registry.nix:24`, `116-141`) and returns the index every other
+glue file resolves package ids through (`packages/registry.nix:179-190`):
+
+- `byId.<id>` and `entries`: all package metadata records.
+- `packageSetEntriesFor system` / `flakeEntriesFor system` /
+  `overlayEntriesFor system`: entries enabled for a system, filtered by each
+  entry's optional `systems` list (`packages/registry.nix:148-156`).
+- `rustWorkspaceEntries`, `updateScriptEntriesFor`, `passthruTestEntriesFor`.
+
+A `package.nix` is an attrset (or `{ lib }:` function) with `id` required and
+the allowed keys `flake`, `inRustWorkspace`, `overlay`, `packageSet`,
+`passthruTests`, `path`, `updateScript` (`packages/registry.nix:30-39`); an
+unknown key throws (`assertKnownKeys`, `packages/registry.nix:41-49`), as do
+duplicate ids (`packages/registry.nix:176-178`). `packageSet`/`flake`/`overlay`
+are normalized into target descriptors: `true` takes the id as the selector, an
+attrset overrides the selector key and/or `systems`
+(`normalizeTarget`, `packages/registry.nix:55-100`).
+
+## `lib/discovery.nix`: tree walks
+
+`discoverTree` (`lib/discovery.nix:20-79`) is the shared walker. Given a `root`,
+`requiredFiles` (default `[ "default.nix" ]`), an optional `metadataFile`
+sidecar, and a `validate` hook, it returns `{ <name> = { path; metadata; }; }`
+for every directory holding the required files. Rules: directories named with a
+leading `_` are skipped with their subtree (`lib/discovery.nix:34`); each entry
+`claims` its `name` plus any `outputNames` the validator adds; duplicate claims
+across the tree throw with the offending paths (`lib/discovery.nix:67-76`).
+
+Three consumers wrap it:
+
+- `discoverImages { root, imageTests ? {} }` (`lib/discovery.nix:124-166`):
+  walks `images/<category>/<name>/`. A `versions.nix` sidecar makes each version
+  key a `<name>_<ver>` package plus a `<name>` alias for the `default` version
+  (`imagePackages`, `lib/discovery.nix:85-111`). `imageTests.<name>` attaches an
+  eval test as `passthru.tests.eval` (RFC 0119).
+- `discoverModules { root }` (`lib/discovery.nix:184-218`): walks
+  `modules/<category>/<name>/`, returns a nested attrset of module paths. A
+  directory with descendant modules gets a `default` key so
+  `services/minecraft/` ships `{ default = ...; fabric = ...; mods = {...}; }`.
+  Built with `strictList` so overlapping subtrees throw.
+- `exampleFleetsFor { hostSystem }` (`lib/discovery.nix:239-258`): walks both
+  `examples/<name>/` and `examples/<category>/<name>/`, imports each with
+  `{ index = { lib = ix // { mkFleet = mkFleetFor hostSystem; ... }; }; }`.
+
+`lib/default.nix` calls `discoverModules` at eval (`lib/default.nix:78`) to build
+`nixosModules`; `lib.collect builtins.isPath` flattens it to `moduleList`
+(`lib/default.nix:94`), pulled into every image unconditionally so every option
+is in scope and inert until enabled.
+
+## `lib/packages.nix`: flake-output package set
+
+`packageSetFor pkgs` (curried, `lib/packages.nix:11`) builds the
+`packages.<system>.*` set. For each registry `packageSetEntriesFor` entry it
+`callPackageWith`s the package's `path` against `pkgs // context`, where
+`context` carries `ix` (the `ixSpecialArgs` bundle rebound to the caller's
+`pkgs`, with `cargoUnit`/`goUnit`/`rustWorkspace` rebound too,
+`lib/packages.nix:14-23`), `clippy-fork`, `ghostty`, and `repoPackages` (the
+lazy fix-point of the set itself, so a package can depend on a sibling by id,
+`lib/packages.nix:41-53`). Trees are assembled with `strictList`
+(`lib/packages.nix:56-57`). These are reachable as
+`packages.<system>.<name>` but never injected into the nixpkgs namespace.
+
+## `lib/overlay.nix`: the repo nixpkgs overlay
+
+`final: prev:` overlay (`lib/overlay.nix:15`) exposing the few repo-owned
+packages that NixOS modules expect at `pkgs.<name>`. It reads the target system
+from `prev` (not `final`, to avoid a recursion through `stdenv`,
+`lib/overlay.nix:17-26`), then for each `overlayEntriesFor` registry entry builds
+the package: via `entry.overlay.build context` if the metadata supplies a custom
+builder, else `callPackageWith` (`lib/overlay.nix:39-48`). The `ix` arg threaded
+in is the `sharedHelpers` surface so overlay packages resolve `ix.deepMerge` etc.
+exactly as flake-output packages do (`lib/overlay.nix:7-13`). Also pins
+`ixDefaultJre` from `lib/languages/jvm-defaults.nix` (`lib/overlay.nix:59-62`).
+Exposed as `overlays.default` (`flake.nix:325`).
+
+## `lib/per-system.nix`: per-system outputs
+
+Evaluated once per dev system (`flake.nix:258-269`). Instantiates nixpkgs with
+`rust-overlay.overlays.default` and `ix.overlay` (`lib/per-system.nix:18-24`),
+binds `repoPackages = ix.packageSetFor pkgs` (`lib/per-system.nix:459`), and
+defines the repo workflow tools as `nix run`-able packages
+(`lib/per-system.nix:1-8`): `lint` (a DAG of nixfmt/statix/deadnix/astlog stages
+via `dag-runner`, `lib/per-system.nix:35-124`), `check` (the full CI gate:
+`nix-fast-build` over `ciChecks` then `nix-eval-jobs` over `packages`,
+`lib/per-system.nix:165-293`), `update-mods`/`update-loaders`/`update-sounds`,
+`mc-source`, the `bench`/`site`/`health-checks` apps, and the auto-discovered
+`update` aggregator (registry `updateScript` flag). The file (~1150 lines) also
+assembles `checks`, `ciChecks`, `apps`, `devShells`, and `formatter`.
+
+## `lib/default.nix`: the assembly
+
+One recursive `let` (`lib/default.nix:25-528`). It imports each helper from its
+subdir, builds `packageRegistry` (`lib/default.nix:30-33`), the `overlay`/`pkgs`
+(`lib/default.nix:55-74`), the language/rust/image/discovery surfaces, then
+returns `ixReturn` (`lib/default.nix:491-528`). The three exported surfaces
+(`sharedHelpers`, `ixSpecialArgs`, `ixReturn`) are described in
+[common.md](../common.md). `ixReturn` is self-referential: `exampleFleetsFor`
+passes it back into examples as `index.lib` (`lib/default.nix:488-490`).
+
+## Adding things
+
+- A package: `mkdir packages/<name>` + write `package.nix` (with `id`) and a
+  `default.nix`/`package.nix` builder. Set `packageSet = true` for a flake
+  output, `overlay = true` for a `pkgs.<name>`, `flake = true` for both,
+  `inRustWorkspace = true` to join the shared Rust unit graph.
+- A module: `mkdir modules/<category>/<name>` + `default.nix`. Picked up by
+  `discoverModules`; `_`-prefixed siblings are ignored.
+- An image: `mkdir images/<category>/<name>` + `default.nix` (+ optional
+  `versions.nix`). Picked up by `discoverImages`.
+- An example fleet: `mkdir examples/<category>/<name>` + `default.nix`.

--- a/docs/nix-lib/image/overview.md
+++ b/docs/nix-lib/image/overview.md
@@ -1,0 +1,131 @@
+# lib/image: OCI image and fleet builders
+
+`lib/image/` turns NixOS module sets into OCI archives, evaluates Colmena-style
+fleets of those images, and adds the opinionated dev-fleet layer. It also owns
+the base platform module every image inherits. `lib/default.nix:445-468` imports
+this directory and re-exports `evalImageConfig`, `mkImage`, `mkNonNixImage`,
+`mkFleet`/`mkFleetFor`, and `mkDev`/`mkDevFor`. The OCI tar is produced by the
+[oci-image-builder](../../nix-build/oci-image-builder/overview.md) Rust CLI;
+this directory is the Nix front end.
+
+## Files
+
+| file | role |
+| --- | --- |
+| `lib/image/default.nix` | the builder front ends; one shared `imagePkgs` instance |
+| `lib/image/platform.nix` | base platform module: `ix.healthChecks`, `ix.networking.*`, boot/firewall/journald defaults |
+| `lib/image/oci-layer.nix` | `ix.image.*` options + the `streamLayeredImage` -> OCI tar build |
+| `lib/image/non-nix-oci.nix` | `mkNonNixImage`: OCI on a pinned non-Nix base |
+| `lib/image/fleet.nix` | `mkFleet`: fleet spec -> plan + per-node images + CLI wrappers |
+| `lib/image/dev.nix` | `mkDev`: dev-fleet layer over `mkFleet` (RFC 0007) |
+| `lib/image/health-checks.nix` | the `health-checks` apps that boot every example fleet and verify it |
+
+## evalImageConfig and mkImage
+
+`evalImageConfig { modules ? [] }` (`lib/image/default.nix:59-88`) is the one
+evaluation path every image build and eval test uses. It runs `lib.nixosSystem`
+with `specialArgs.ix = ixSpecialArgs` (`lib/image/default.nix:65`) over
+`platform.nix`, `oci-layer.nix`, the home-manager NixOS module, the full
+auto-discovered `moduleList`, and the caller's `modules`, returning the evaluated
+`config`. Every image shares ONE `imagePkgs` nixpkgs instance (via
+`nixpkgs.pkgs`, `lib/image/default.nix:39-47`, `66-67`) instead of
+re-instantiating per node, which is what keeps multi-image evals from paying
+nixpkgs instantiation 20-30 times over.
+
+`mkImage args` (`lib/image/default.nix:90-97`) is `(evalImageConfig
+args).ix.build.ociImage`. Each image is self-contained; ix runs one, it does not
+stack images at runtime. The result is an OCI-archive derivation usable as a
+`packages.<system>.<name>` output or pushed with `ix image push`.
+
+Unfree packages enter images only by explicit name in the
+`allowUnfreePredicate` on `imagePkgs` (`yourkit-java`, `claude-code`,
+`lib/image/default.nix:41-46`), never by flipping `allowUnfree`.
+
+## oci-layer.nix: the OCI build
+
+Declares `ix.image.{name,tag}`, `ix.build.ociImage` (internal), and
+`ix.build.ociEfficiency.*` (`lib/image/oci-layer.nix:16-58`). The build splits
+the NixOS toplevel closure into `maxLayers = 67` OCI layers via
+`dockerTools.streamLayeredImage` (under the 127-layer registry cap), adds a
+`systemRoot` FHS layer (`/init`, `/bin`, `/etc`, ...,
+`lib/image/oci-layer.nix:71-82`), then runs `oci-image-builder` to stream the
+final tar (`lib/image/oci-layer.nix:108-119`). The efficiency gate fails the
+build when wasted layer payload crosses `minEfficiency` (0.95),
+`maxWastedBytes` (20 MiB), or `maxWastedPercent` (0.20).
+
+## platform.nix: the base every image inherits
+
+The baseline module merged into every image (`lib/image/platform.nix:1`). Its
+option surface is the cross-image contract:
+
+- `ix.healthChecks.<name>` (`lib/image/platform.nix:264-277`): commands that
+  prove a service is ready. Each is `{ command | unit, from = "guest"|"host",
+  timeoutSec, attempts, intervalSec, requiresIpv4 }`. Setting `unit = "nginx"`
+  desugars to a `systemctl is-active` probe (`lib/image/platform.nix:114-116`);
+  `from = "host"` runs the probe on the operator host with `IX_NODE*` env vars
+  for public-reachability checks. Fleet `up`/`replace`/`switch` wait on these.
+- `ix.networking.expose.<name>` (`lib/image/platform.nix:292-313`): the one
+  declaration for "this image listens here". It registers a port claim (so
+  same-namespace collisions throw at eval time,
+  `lib/image/platform.nix:366-375`), opens the in-guest firewall unless
+  `firewall = false`, and makes the listener discoverable cross-node via
+  `ix.endpointOf` (see [util/endpoint](../util/overview.md)).
+- `ix.networking.portClaims.<name>` (`lib/image/platform.nix:280-290`): the
+  lower-level claim registry `expose` desugars to; `ix.networking.groups` and
+  `eastWest.hostName` are the east-west membership primitives.
+
+It also sets the platform defaults: `boot.isContainer`, tmpfs `/tmp`,
+`nftables` firewall opening the exposed ports, Nushell as default shell,
+bounded journald, `userdbd`, coredump capture, and modern nix features
+(`lib/image/platform.nix:401-510`).
+
+## non-nix-oci.nix: mkNonNixImage
+
+`mkNonNixImage { name, baseImage, tag?, contents?, config?, maxLayers?, efficiency? }`
+(`lib/image/non-nix-oci.nix:52-181`) builds an OCI image on a pinned non-Nix
+base (ubuntu, debian, distroless): no NixOS, no systemd PID 1; the base
+userland is the rootfs and `contents` are extra Nix store layers on top. The
+base is pulled by digest (`dockerTools.pullImage`). The build is sharded into a
+content-addressed `image.json` description (one derivation per store layer, so a
+one-path change re-tars one layer) and a `materialize` step that regenerates the
+tar and enforces the efficiency gate (`lib/image/non-nix-oci.nix:91-181`). The
+description is on `passthru.description`.
+
+## fleet.nix: mkFleet
+
+Curried `mkFleetFor hostSystem` (`lib/image/default.nix:112-129`), then a fleet
+spec `{ defaults ? [], deployment ? {}, secrets ? {}, nodes }`
+(`lib/image/fleet.nix:19-24`). Each node is a NixOS module set (or a wrapped
+`{ modules, deployment, tags, groups, dependsOn, replicas }` node,
+`lib/image/fleet.nix:94-104`) built through `evalImageConfig`. The `deployment`
+attrset is typo-checked against the known keys (`lib/image/fleet.nix:66-92`):
+`bootstrapImage`, `region`, `ipv4`, `snapshot`, `switch`, `env`, `l7ProxyPorts`,
+`recreateOnUp`, `destination`. `secrets` is normalized via the
+[secrets](../util/overview.md) helper.
+
+The result (`lib/image/fleet.nix:377-403`) exposes the rendered `plan`, per-node
+`packages` (the OCI images), `systemPackages` (toplevels), `nodes`/`meta`, the
+CLI subcommands `up`/`down`/`diff`/`health`/`switch`/`replace`/`bootstrap`
+(each a Nushell wrapper over the `ix-fleet` binary with `--plan`,
+`lib/image/fleet.nix:368-386`), and `withNodePrefix` for renaming nodes while
+sharing the underlying closures.
+
+## dev.nix: mkDev
+
+`mkDevFor hostSystem { module, src ? null }` (`lib/image/dev.nix:49-54`): an
+opinionated dev-fleet layer over `mkFleet` (RFC 0007) that consumes one forkable
+`dev.nix` module and returns the same result shape `mkFleet` does. It reads
+`ix.dev.*` (see [dev](../dev/overview.md)) via a probe eval
+(`lib/image/dev.nix:60-66`), then synthesizes: the agent layer + user module as
+`mkFleet` `defaults`, `ix.dev.fleet` as nodes, an optional `file-server` SMB node
+plus identity binds when `ix.dev.shared.enable`, and `/ix` source materialization
+on every node. `templates/dev` is the forkable starting point
+(`flake.nix:326-329`).
+
+## health-checks.nix
+
+`health-checks` / `health-checks-zellij` apps (`lib/image/health-checks.nix`)
+that boot every example fleet in parallel through `ix-fleet up`, verify the
+declared `ix.healthChecks`, and tear the VMs down. The `dag` front end uses
+`dag-runner` for headless/CI use; `zellij` gives one pane per fleet for
+interactive triage. Wired in `lib/per-system.nix`.

--- a/docs/nix-lib/languages/overview.md
+++ b/docs/nix-lib/languages/overview.md
@@ -1,0 +1,85 @@
+# lib/languages: per-language toolchains
+
+`lib/languages/` selects compilers, interpreters, runtimes, and dev tools for
+21 languages from a caller's `pkgs`. Each language is one `.nix` file (Java is a
+directory) returning an attrset of helper functions, exposed as
+`ix.languages.<lang>.<fn>`. `lib/default.nix:128-146` imports each, passing
+`errors` (and `rust-overlay` for Rust, `lib` for Java).
+
+These are selectors, not builders: they return a package (a JDK, a Go toolchain,
+a compiler) for a module to drop into `environment.systemPackages` or feed to a
+builder. For building Rust crates see [rust](../rust/overview.md); for building
+JS/Python/Go/Gradle/Zig projects see [build-helpers](../build-helpers/overview.md).
+
+## The common pattern
+
+Every helper is curried `pkgs: args:` and returns a package
+(`packages/registry.nix`-style consumers pass their own `pkgs` so the result
+comes from the image's evaluation, not the lib default):
+
+- A **version map** `xxxFor pkgs` lists each supported version string against the
+  nixpkgs attribute (e.g. `lib/languages/go.nix:13-18`,
+  `lib/languages/python.nix:9-15`). Listing them explicitly means an unknown
+  version throws with the supported set instead of `attribute missing` deep in
+  eval; bump the top entry when nixpkgs ships a newer release.
+- The main selector requires `version` via `errors.requireArg` and looks it up
+  via `errors.requireAttr` (`lib/languages/go.nix:45-58`). A floating default is
+  avoided on purpose: it would silently retarget every consumer on a nixpkgs
+  bump (`lib/languages/python.nix:25-28`).
+- `version = "latest"` follows the channel default (`pkgs.go`, `pkgs.ghc`, ...)
+  where the language file provides that key.
+- Validation goes through [`ix.errors`](../util/overview.md): `assertEnum` for
+  enum fields (Rust channel/profile, `lib/languages/rust.nix:115-125`),
+  `requireArg`/`requireAttr` for required selectors.
+- Secondary tools (`languageServer`, `cmake`, `delve`, `sbt`, ...) are usually
+  `pkgs: _: pkgs.<tool>`, ignoring args and returning a floating package
+  (`lib/languages/go.nix:82`, `lib/languages/cpp.nix:142`).
+
+`lib/languages/jvm-defaults.nix` is the one shared constant: the default JVM
+major (`"25"`) read by `java`, `scala`, the overlay's `ixDefaultJre`
+(`lib/overlay.nix:62`), and the JVM service modules so they agree without
+pinning.
+
+## Per-language surface
+
+| language | file | main selector(s) | versions / notes |
+| --- | --- | --- | --- |
+| rust | `rust.nix` | `toolchain pkgs { channel, version, components?, targets?, profile? }` | rust-overlay `fromRustupToolchain`; channel `stable\|beta\|nightly`, version `latest`/semver/date |
+| python | `python.nix` | `interpreter pkgs { version }` | 3.10-3.14 |
+| go | `go.nix` | `toolchain`, `delve`, `languageServer` | latest, 1.23, 1.25, 1.26 |
+| java | `java/default.nix` | `jdk pkgs { version, distribution }`, `maven`, `gradle`, `languageServer`, `yourkit` | versions 8-25; distributions openjdk/temurin/corretto/zulu; gradle 7/8/9 |
+| javascript | `javascript.nix` | `node pkgs { version }`, `bun`, `deno`, `typescript`, `languageServer` | node latest, 20, 22, 24, 25 |
+| scala | `scala.nix` | `compiler pkgs { version, jdk? }`, `sbt`, `mill`, `languageServer` | Scala 2 / 3; JDK from jvm-defaults |
+| kotlin | `kotlin.nix` | `compiler pkgs { target }`, `languageServer`, `repl` | target `jvm`/`native` |
+| haskell | `haskell.nix` | `compiler pkgs { version }`, `cabal`, `stack`, `languageServer` | latest, 9.6-9.14 |
+| ocaml | `ocaml.nix` | `compiler pkgs { version }`, `dune`, `opam`, `ocamlformat`, `utop`, `languageServer` | latest, 4.14, 5.1-5.4 |
+| elixir | `elixir.nix` | `toolchain pkgs { version }`, `languageServer` | latest, 1.15-1.19 |
+| erlang | `erlang.nix` | `toolchain pkgs { version }`, `rebar3`, `languageServer` | latest, 26, 27, 28 |
+| cpp | `cpp.nix` | `compiler pkgs { vendor, version }`, `cmake`, `ninja`, `meson`, `make`, `languageServer` | gcc 9-15, clang 16-22 |
+| zig | `zig.nix` | `toolchain pkgs { version }`, `languageServer` | latest, 0.12-0.16 |
+| dhall | `dhall.nix` | `interpreter`, `json`, `nix`, `languageServer` | floating; no version map |
+| gleam | `gleam.nix` | `compiler` | floating (skips network test); pair with erlang/node |
+| idris | `idris.nix` | `compiler` | floating `pkgs.idris2` |
+| futhark | `futhark.nix` | `compiler` | floating `pkgs.futhark` |
+
+Java is a directory: `java/default.nix` holds the JDK/maven/gradle selectors and
+re-exports `yourkit = import ./yourkit.nix` (`lib/languages/java/default.nix:246`),
+the YourKit profiler agent options/flags module (an opt-in unfree agent,
+`lib/languages/java/yourkit.nix`). `jvm-defaults.nix` is the shared JDK major.
+
+## Examples
+
+```nix
+{ pkgs, ix, ... }:
+let
+  rust = ix.languages.rust.toolchain pkgs { channel = "nightly"; version = "2025-12-01"; };
+  jdk  = ix.languages.java.jdk pkgs { version = "21"; distribution = "temurin"; };
+  go   = ix.languages.go.toolchain pkgs { version = "1.25"; };
+in {
+  environment.systemPackages = [ rust jdk go ];
+}
+```
+
+The full attrset is also on `ix.languages` directly (e.g. for builders:
+`lib/rust/tooling.nix:30` uses `languages.rust.toolchain`,
+`lib/build/go-unit.nix` takes `go = languages.go`).

--- a/docs/nix-lib/minecraft/overview.md
+++ b/docs/nix-lib/minecraft/overview.md
@@ -1,0 +1,70 @@
+# lib/minecraft: Minecraft Nix helpers
+
+`lib/minecraft/` is the repo-owned Minecraft support surfaced through
+`specialArgs.ix` and the flake `lib`. It covers typed NBT data, the loader
+module factory, the managed-sync wrapper, and vanilla dimension-type snapshots.
+`lib/default.nix` exposes `ix.minecraft.{nbt,dimensionType}`
+(`lib/default.nix:273-276`), `ix.mkMinecraftLoader` (`lib/default.nix:234`),
+`ix.mkMinecraftNbtFormat` (`lib/default.nix:289-291`), and
+`ix.mkMinecraftSyncManaged` (`lib/default.nix:302-310`). The two Rust tools it
+drives (`minecraft-nbt`, `minecraft-sync-managed`) are built via
+`buildIxRustTool`.
+
+## nbt.nix: typed tag constructors
+
+`ix.minecraft.nbt` (`lib/minecraft/nbt.nix`) is the escape hatch for Minecraft's
+narrower tag types that plain Nix scalars cannot express. Plain values
+round-trip (attrset->compound, list->list, string->string, bool->byte,
+int->int/long, float->double); the constructors force a specific tag:
+`byte`/`short`/`int`/`long`/`float`/`double`/`string`, the typed arrays
+`byteArray`/`intArray`/`longArray`, `list`, `compound`, `bool`, and `root name
+value` for a named root (`lib/minecraft/nbt.nix:7-25`). Each wraps a value as
+`{ __minecraftNbt = <tag>; value = ...; }` that `mkMinecraftNbtFormat` encodes.
+
+## nbt-format.nix: a pkgs.formats-style generator
+
+`mkMinecraftNbtFormat pkgs { format, flavor ? "uncompressed" }`
+(`lib/minecraft/nbt-format.nix:6-10`) returns `{ type, generate }` matching
+`pkgs.formats.*`. `format` is `snbt` (readable stringified NBT) or `nbt`
+(binary); `flavor` is the binary compression: `uncompressed`/`gzip`/`zlib`
+(`lib/minecraft/nbt-format.nix:12-25`). `generate name value` writes the value
+to JSON then runs the `minecraft-nbt` Rust tool to emit the encoded output
+(`lib/minecraft/nbt-format.nix:28-39`). Invalid `format`/`flavor` throw at eval.
+
+## loader.nix: the loader module factory
+
+`mkMinecraftLoader { ix, config, lib, name, dropinDir ? "mods", extraOptions ?
+{}, configFragment ? _: {} }` (`lib/minecraft/loader.nix:17-25`) builds a
+structurally-identical Minecraft loader module (Fabric, Paper, Vanilla, ...).
+Each loader owns `services.minecraft.<name>` with an `enable` flag and a `src`
+server-jar slot, and assigns the jar to `services.minecraft.serverJar`
+(`lib/minecraft/loader.nix:38-60`). `src` defaults to
+`ix.artifacts.minecraft.servers."${version}-${name}"`
+(`lib/minecraft/loader.nix:30-35`), so a caller that sets
+`services.minecraft.version` rarely overrides per loader. Reached from loader
+modules via `specialArgs.ix.mkMinecraftLoader`; a loader needing more `config`
+passes a `configFragment cfg` hook.
+
+## sync-managed.nix: the sync wrapper
+
+`mkMinecraftSyncManaged args` (`lib/default.nix:302-310`) builds the
+`minecraft-sync-managed` Nushell wrapper around the Rust sync tool
+(`lib/minecraft/sync-managed.nix`). It assembles the tool's argv from the mutable
+data dir, managed `/etc/minecraft` roots, datapack worlds, plugman-reload and
+RCON settings, and ignored plugins (`lib/minecraft/sync-managed.nix:19-50`). The
+tool syncs managed files and datapacks and reconciles `whitelist.json` /
+`ops.json` against the live server files by UUID. `default.nix` pre-binds the
+`package` (the built `minecraft-sync-managed` binary) and `writeNushellApplication`.
+
+## dimension-type.nix: vanilla snapshots + withBase
+
+`ix.minecraft.dimensionType` (`lib/minecraft/dimension-type.nix:1`) exposes
+`defaults` (vanilla dimension-type JSON snapshots from
+`dimension-type-defaults.nix`, e.g. `minecraft:overworld`), `bases` (their
+names), and `withBase name value` (`lib/minecraft/dimension-type.nix:71-83`).
+`withBase` lets `services.minecraft.datapacks.<n>.dimensionTypes.<dim>` set
+`base = "minecraft:overworld"` and override only the height knobs: it strips
+`base`, merges the named snapshot underneath with `deepMerge.rhs`, defaults
+`logical_height` to `height`, and validates the Java height constraints (16-block
+alignment, the [-2032, 2031] band, the 4064 cap,
+`lib/minecraft/dimension-type.nix:8-67`).

--- a/docs/nix-lib/rust/overview.md
+++ b/docs/nix-lib/rust/overview.md
@@ -1,0 +1,192 @@
+# lib/rust: cargo-unit Rust build
+
+`lib/rust/` is the core builder: it compiles a Rust workspace as one Nix
+derivation per Cargo rustc unit, so a source edit in `crates/api` does not
+rehash the input for `crates/worker` or any vendored crate. It also offers a
+single-derivation `buildPackage` path (`rustPlatform.buildRustPackage` wrapped
+with the repo policy gates) for standalone crates. The heavy lifting (unit-graph
+parse, render, hashing) lives in the [nix-cargo-unit](../../nix-build/nix-cargo-unit/overview.md)
+Rust CLI; this directory is the Nix front end that drives it.
+
+## Files
+
+| file | role |
+| --- | --- |
+| `lib/rust/cargo-unit.nix` | `buildWorkspace` and the binary/library selectors; the per-unit build front end |
+| `lib/rust/build.nix` | `buildPackage`: single-derivation `buildRustPackage` + policy |
+| `lib/rust/resolve.nix` | resolution boundary: raw args -> one `{ context, policy, effects, checks }` bundle, applied once |
+| `lib/rust/vendor.nix` | `Cargo.lock` -> package-shaped vendor dir + cargo config script |
+| `lib/rust/policy.nix` | the quality-gate schema and check derivations (clippy, audit, machete, ...) |
+| `lib/rust/workspace.nix` | the shared repo-wide unit graph (`rustWorkspaceFor`) |
+| `lib/rust/tooling.nix` | bootstrap: `buildIxRustTool`, `cargoUnitFor`, `buildRustPackage` factories |
+
+## How it is wired
+
+`lib/rust/tooling.nix` is the bootstrap seam. `rustFor pkgs`
+(`lib/rust/tooling.nix:19-35`) imports `build.nix` with the repo's pinned
+nightly toolchain (read from `rust-toolchain.toml`, `lib/rust/tooling.nix:13-18`)
+and the `llm-clippy` package. `cargoUnitFor pkgs`
+(`lib/rust/tooling.nix:74-80`) imports `cargo-unit.nix` with
+`rust = rustFor pkgs` and `nixCargoUnit = buildIxRustTool pkgs (packagePath
+"nix-cargo-unit")`. `buildIxRustTool` (`lib/rust/tooling.nix:40-72`) builds a
+repo Rust tool while keeping `nix-cargo-unit` itself on the pre-cargo-unit path
+(it is what builds the graph), and prefers the policy-unchecked variant so a
+generator does not drag the check graph into its closure.
+
+`lib/default.nix` exposes `cargoUnit = cargoUnitFor pkgs`
+(`lib/default.nix:163`), `buildRustPackage` (in `ixSpecialArgs`,
+`lib/default.nix:441`), and `cargoUnitFor`/`buildRustPackage` factories in
+`ixReturn`. Most repo crates do not call these directly; they select out of the
+shared workspace (below).
+
+## resolve.nix: the resolution boundary
+
+`resolveArgs args` (`lib/rust/resolve.nix:59-147`) is where every multiply-read
+default/transform happens once. It returns:
+
+- `context`: the "run cargo in the vendored tree" bundle: `src`,
+  `rustToolchain` (default from `rust-toolchain.toml`), `vendorDir`,
+  `vendorSources`, `env`, `nativeBuildInputs`, plus `cargoLockPath`,
+  `toolchainId`, and `configScript` resolved once (`lib/rust/resolve.nix:80-93`).
+- `policy`: the resolved gate decisions (typed schema, below).
+- `effects`: policy consequences computed once: rustc args (mold), linker native
+  inputs, clippy lint flags, renderer deny-flags (`lib/rust/resolve.nix:95-103`).
+- `checks`: the two altitude-appropriate check sets bound to this context:
+  `crate` (audit+machete+clippy) and `workspace` (audit+machete; per-unit clippy
+  runs in the renderer) (`lib/rust/resolve.nix:120-136`).
+
+The **toolchain id** is the basename of the toolchain store path
+(`lib/rust/resolve.nix:37-41`); it is baked into every unit hash, so it is
+derived here once rather than re-spelled at each use.
+
+## vendor.nix: vendoring
+
+`mkVendor { cargoLock, outputHashes, sourceOverrides }`
+(`lib/rust/vendor.nix:146-313`) reads `Cargo.lock` and produces, lazily:
+
+- `vendorSources`: one package-shaped directory per dependency. Registry crates
+  are fetched from `static.crates.io` (the direct CDN; the legacy
+  `api.crates.io` endpoint now 403s curl, `lib/rust/vendor.nix:49-61`) and
+  verified against the lockfile checksum; git crates are `fetchgit`'d, reduced to
+  the referenced package, and have workspace inheritance flattened by the
+  vendored `replace-workspace-values.py` (`lib/rust/vendor.nix:216-272`).
+- `vendorDir`: an aggregate `linkFarm` symlinking each entry under
+  `<name>-<version>` (`lib/rust/vendor.nix:290-309`).
+
+Git deps require `outputHashes."git+<url>#<rev>" = "sha256-..."` keyed by the
+exact `Cargo.lock` source string; a missing or extra key throws
+(`lib/rust/vendor.nix:155-175`). `vendorConfigScript`
+(`lib/rust/vendor.nix:78-138`) emits the `$CARGO_HOME/config.toml` that points
+cargo at the vendor dir plus a `[source."<git>"]` replace block per git dep.
+
+## policy.nix: the quality gates
+
+The schema is declared once as NixOS module options
+(`lib/rust/policy.nix:35-143`) so defaults, the caller-merge, and typo rejection
+(no freeform type) all come from `resolvePolicy` via `evalModules`
+(`lib/rust/policy.nix:164-185`). Knobs and defaults:
+
+- `denyUnusedCrateDependencies` (true): rustc gate on unused declared deps.
+- `denyPanics` (false): best-effort panic-reachability scan.
+- `cargoAudit.enable` (true): offline, lockfile-only `cargo-audit` against a
+  pinned advisory-db (`lib/rust/policy.nix:49-78`, `279-308`).
+- `cargoMachete.enable` (true): unused-dep scan (disabled for the repo workspace
+  in favor of the per-crate rustc gate, `lib/rust/workspace.nix:264-268`).
+- `clippy.enable` (true): per unit in a workspace, whole-crate otherwise; lints
+  default to denying warnings (`lib/rust/policy.nix:91-122`).
+- `tests.enable`/`useNextest` (true), `linker.useMold` (Linux).
+
+`clippyLintFlagsFromManifest` (`lib/rust/policy.nix:208-261`) parses
+`[lints.clippy]` from the workspace `Cargo.toml` into `-D|-W|-A` flags, because
+cargo only injects those into the unit graph under `cargo clippy`, not
+`cargo build`. `policyPresets.pureBuild` turns every gate off
+(`lib/rust/policy.nix:150-157`) for pure artifacts (cross graphs, prebuilt
+injection) where another graph already ran the gates.
+
+## cargo-unit.nix: buildWorkspace
+
+`buildWorkspace rawArgs` (`lib/rust/cargo-unit.nix:121-505`) is the entry point.
+Two IFD stages:
+
+1. `unitGraphJson` (`lib/rust/cargo-unit.nix:211-287`): runs
+   `cargo build --unit-graph` once per `cargoTargets` entry (in parallel) in the
+   vendored tree, merging them with `nix-cargo-unit merge`.
+2. `unitsNix` (`lib/rust/cargo-unit.nix:299-319`): renders `units.nix` from the
+   graph via `nix-cargo-unit render`, passing `--workspace-root`,
+   `--vendor-root`, `--toolchain-id`, `--cargo-lock`, and `--content-addressed`
+   (default true, `lib/rust/cargo-unit.nix:301`).
+
+Importing `units.nix` (`importUnits`, `lib/rust/cargo-unit.nix:333-386`) yields
+the per-unit derivations and threads the workspace `env`, `extraRustcArgs`,
+per-package test/build env, and the resolved clippy/policy flags. The returned
+attrset carries `units`, `binaries`, `libraries`, `benchmarks`, `tests`,
+`doctests`, `targetSets.<name>`, `coverageReport`, plus the intermediate
+`unitGraphJson`/`unitsNix`/`vendorDir` for inspection
+(`lib/rust/cargo-unit.nix:108-111`, `500-505`).
+
+Key arguments: `workspaceRoot` (required, the real checkout root scopes are
+carved from, `lib/rust/cargo-unit.nix:140-145`); `src` (the filtered build
+input); `cargoTargets`/`cargoTargetNames` (several Cargo executions through one
+graph, e.g. `[["--workspace"] ["--workspace" "--tests"]]`); `profile`/`target`;
+`policy`; `env` (folds into every unit, so use `packageBuildEnv.<pkg>` for a
+value that changes often, `lib/rust/cargo-unit.nix:79-84`); `extraRustcArgs` and
+`extraRustcArgsForPlatform`; `cargoConfigRustflags` (apply
+`.cargo/config.toml` rustflags). Selecting `binaries.<n>`, `libraries.<n>`, or a
+`targetSets.<set>` entry builds only that root's unit closure
+(`lib/rust/cargo-unit.nix:74-91`).
+
+### Selectors
+
+- `buildBinary { binary, ... }` / `buildBinaries { binaries, ... }`: build a
+  fresh workspace and pick a root (`lib/rust/cargo-unit.nix:519-524`, `670-675`).
+- `selectBinaryWithTests workspace { binary, packageName ? binary, ... }`
+  (`lib/rust/cargo-unit.nix:539-557`) and `selectLibraryWithTests`
+  (`lib/rust/cargo-unit.nix:568-586`): pick a root out of a **shared** workspace
+  plus its test/doctest/policy derivations as `passthru.tests`. This is the
+  common path: a crate's `default.nix` is often just
+  `ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units { binary = "tap"; }`
+  (`packages/tap/default.nix`).
+
+### Prebuilt unit injection
+
+`mkPrebuiltLibraryUnit { name, version, hash, rlib, rmeta, toolchainId, depUnits ? [] }`
+(`lib/rust/cargo-unit.nix:749-819`) builds a library unit from already-compiled
+artifacts, byte-contract-identical to what the renderer emits, keyed by
+`<name>-<version>-<hash>`. Pass it through `buildWorkspace`'s `extraUnits` to
+link a downstream crate against a prebuilt rlib with no source present
+(rlib-only; bypasses per-unit policy gates, so inject only trusted artifacts).
+Four eval-time guards (C1-C4, `lib/rust/cargo-unit.nix:397-474`) reject an
+injection key absent from the graph, a toolchain-id mismatch, a key disagreeing
+with the unit's recorded `unitKey`, or two prebuilts claiming one key.
+
+## workspace.nix: the shared repo unit graph
+
+`rustWorkspaceFor pkgs` (`lib/rust/workspace.nix:16`) returns
+`{ root, src, cargoLock, units, dashboardSite, unitsFor }`. `units` is one
+`buildWorkspace` over every `inRustWorkspace` registry crate
+(`lib/rust/workspace.nix:124-285`), with `cargoTargets` covering build, test, and
+bench root sets (`lib/rust/workspace.nix:171-190`) and the policy that gates the
+whole repo (`lib/rust/workspace.nix:257-270`). It also wires the non-obvious
+native-link plumbing: `IX_VT_GHOSTTY_LIB_DIR` + a workspace `-L`/rpath for
+libghostty-vt, `IX_DASHBOARD_SITE_HTML`, ALSA pkg-config for the minecraft sound
+crate, and host-gated libkrun for vmkit (`lib/rust/workspace.nix:191-252`).
+`unitsFor { target }` (`lib/rust/workspace.nix:308-312`) builds a cross graph
+(Apple targets go through the [darwin](../darwin/overview.md) zig+SDK toolchain);
+it skips tests/benches and policy, building only the `--workspace` root set.
+
+`lib/default.nix` binds `rustWorkspace = rustWorkspaceFor pkgs`
+(`lib/default.nix:366`); both `rustWorkspace` and `rustWorkspaceFor` ride
+`ixSpecialArgs`/`ixReturn`.
+
+## build.nix: single-derivation buildPackage
+
+`buildPackage` (`lib/rust/build.nix:32-163`) wraps
+`rustPlatform.buildRustPackage` for a standalone crate. `srcRoot = ./.` is the
+shortcut for a repo crate (gitTracked filter + `meta.mainProgram` default,
+`lib/rust/build.nix:43-58`). It vendors through the repo's own `vendorDir`
+(faster than nixpkgs `importCargoLock`, `lib/rust/build.nix:81-99`), enables
+nextest, and returns a `symlinkJoin` carrying the policy checks as
+`passthru.tests` and under `$out/rust-policy` with the unchecked package at
+`passthru.unchecked` (`lib/rust/build.nix:140-163`). Reached as
+`ix.buildRustPackage pkgs` and used by tools that need their own workspace
+(different policy, fetched source) rather than the shared graph.

--- a/docs/nix-lib/services/overview.md
+++ b/docs/nix-lib/services/overview.md
@@ -1,0 +1,70 @@
+# lib/services: service helpers
+
+`lib/services/` holds three home-manager / systemd helpers that live outside
+`modules/` on purpose: they are home-manager modules or pure attrsets, not NixOS
+modules, so the [discovery](../discovery/overview.md) walk must not sweep them
+into `nixosModules`. `lib/default.nix` imports them directly
+(`lib/default.nix:84-89`, `172`) and the flake exposes the two home-manager ones
+as `homeModules.portable-services` / `homeModules.mutable-json`
+(`flake.nix:286-289`).
+
+## portable-services.nix
+
+One declarative spec rendered to a native launchd agent on macOS and native
+systemd user units on Linux (`lib/services/portable-services.nix:1-22`). Write
+the service once instead of two hand-synced schemas; the transforms are pure
+functions of a fully-defaulted spec so they can be golden-tested.
+
+Public surface (`lib/services/portable-services.nix:355-366`):
+
+- `serviceSubmodule`: the per-service option type
+  (`lib/services/portable-services.nix:40`). The portable subset
+  (`enable`, `description`, `command`, `environment`, `workingDirectory`,
+  `runAtLoad`, `interval`, ...) maps onto both init systems; platform-specific
+  keys go through the `launchd.config` / `systemd.service` escape hatches, merged
+  last so they always win.
+- `toLaunchdConfig svc` / `toSystemdUnits svc`: the pure transforms
+  (`lib/services/portable-services.nix:192`, `249`).
+- `homeModule`: the home-manager module exposing
+  `services.portable.<name>` (`lib/services/portable-services.nix:353`). It
+  dispatches on host platform: `launchd.agents` on Darwin,
+  `systemd.user.services` (+ `timers` for interval services) on Linux
+  (`lib/services/portable-services.nix:334-344`). A stable `key` collapses
+  duplicate imports so two composed modules can each import it.
+
+`ExecStart`/`command[0]` must be an absolute path (systemd does not search PATH;
+launchd is the same in practice). Consumed by `users/andrewgazelka`,
+`ci-bars`, and `indexer` home modules (`flake.nix:301-323`).
+
+## systemd-hardening.nix
+
+A plain attrset of baseline `serviceConfig` hardening for long-running network
+daemons (`lib/services/systemd-hardening.nix`). Imported as
+`ix.systemdHardening` (`lib/default.nix:172`) and merged into a service's
+`serviceConfig`, overriding fields per service as needed. It sets
+`ProtectSystem = "strict"` (so a service that writes to `/var` must declare a
+`StateDirectory`), empties the capability bounding set and `DeviceAllow`, turns
+on the `Protect*`/`Restrict*` family, and keeps `AF_INET`/`AF_INET6`/`AF_UNIX`
+open so inbound TCP/UDP still works (`lib/services/systemd-hardening.nix:16-41`).
+
+## mutable-json.nix
+
+Declarative-but-writable JSON config: the fallback for app config Nix cannot
+deliver read-only because the app also writes the file at runtime
+(`lib/services/mutable-json.nix:1-38`). Prefer the app's own managed/policy layer
+to ENFORCE a key (a read-only `/etc` file); reach for this only to SEED an
+overridable default or own a key in a file the app rewrites.
+
+`homeModule` (`lib/services/mutable-json.nix:43`, exported at `125`) exposes
+`home.mutableJsonFiles.<name> = { target, value }`
+(`lib/services/mutable-json.nix:91-110`). On activation it reconciles with a
+last-applied 3-way merge (the kubectl-apply model,
+`lib/services/mutable-json.nix:24-32`): `result = deepMerge(prune(live, last \
+new), new)`, so Nix enforces the keys it declares, prunes keys it stops
+declaring, and preserves the app's own writes. The previous declaration is
+recorded under `xdg.stateHome`; the merge itself is the sidecar
+`mutable-json-merge.jq`. Scope is a single declarative owner per file.
+
+The minecraft systemd integration helper `mkMinecraftSyncManaged` and the
+`portable-services` model are the two service-shaped wrappers most images touch;
+for the minecraft one see [minecraft](../minecraft/overview.md).

--- a/docs/nix-lib/util/overview.md
+++ b/docs/nix-lib/util/overview.md
@@ -1,0 +1,115 @@
+# lib/util: utility functions
+
+`lib/util/` is the pure cross-cutting helper layer: error helpers, the sanctioned
+deep-merge, attrset/list helpers, value encoders, the network endpoint type, the
+MCP registry renderers, the secrets surface, the executable writers, and the
+bench/artifacts catalogs. Most are imported into `lib/default.nix` and surfaced
+on `ix.<name>` (e.g. `ix.errors`, `ix.deepMerge`, `ix.attrs`, `ix.lists`,
+`ix.toml`, `ix.mcp`, `ix.relativePath`, `ix.secrets`, `ix.endpoint`,
+`ix.mkBenchSuite`, `ix.artifacts`, and the `write*Application` writers,
+`lib/default.nix:174-317`, `388-427`).
+
+## errors.nix
+
+`ix.errors`: validate-then-return helpers that throw a fixable message instead
+of a deep-eval crash (`lib/util/errors.nix`). `assertEnum { name, value, valid }`
+returns `value` or throws listing every valid value
+(`lib/util/errors.nix:24-33`); `requireArg { context, args, name }` returns a
+required arg or throws naming the helper (`lib/util/errors.nix:52-61`);
+`requireAttr { context, attrset, key }` looks up a key or throws listing the
+available keys (`lib/util/errors.nix:72-81`). The
+[languages](../languages/overview.md) helpers and many builders route bad args
+through these.
+
+## deep-merge.nix
+
+`ix.deepMerge`: the single sanctioned recursive attrset merge; the
+`no-recursive-update` lint points here (`lib/util/deep-merge.nix:1-5`). Recurses
+only when both sides are non-derivation attrsets; lists and derivations are
+leaves; one-sided keys pass through. Three exports
+(`lib/util/deep-merge.nix:62-84`): `strict` (throws on a leaf collision, naming
+the dotted path), `rhs` (rhs wins at a collision), `strictList` (strict fold over
+a list, the N-ary shape `discoverModules`/`packageSet` need).
+
+## attrs.nix and lists.nix
+
+- `ix.attrs.flattenToDotted`: collapse a nested attrset to one keyed by
+  `.`-joined paths to each leaf (`{ a.b = 1; } => { "a.b" = 1; }`), recursing
+  only into plain attrsets (`lib/util/attrs.nix:34-46`). Compose with
+  `mapAttrsToList` for `--config a.b=1` flags or dotted env names.
+- `ix.lists`: `findDuplicatesBy keyfn list` (keys mapping >1 element) and
+  `findDuplicates` (repeated string elements), both sorted, used by the discovery
+  and registry duplicate guards (`lib/util/lists.nix:11-19`).
+
+## endpoint.nix
+
+`ix.endpoint { host, port, scheme ? null, path ? "" }` returns a stringifiable
+endpoint: it renders to `host:port` in string context (`__toString`) yet exposes
+`.host`/`.port`/`.authority`/`.url` (`lib/util/endpoint.nix:24-47`). `ix.endpointOf
+node "name"` resolves a peer's declared `ix.networking.expose.<name>` listener
+and pairs its port with the node's east-west hostname, so a consumer never reaches
+into a sibling's option tree (`lib/util/endpoint.nix:49-62`). This is the
+cross-node wiring primitive `expose` (see [image](../image/overview.md)) feeds.
+
+## toml.nix and mcp.nix
+
+- `ix.toml.scalar value`: encode one Nix scalar as the TOML literal a
+  `key = value` line expects (bool bare, string JSON-quoted, int/float as-is);
+  throws on lists/attrsets (`lib/util/toml.nix:17-26`). Scalars only; use
+  `pkgs.formats.toml` for whole files.
+- `ix.mcp`: the single source of truth for the MCP servers the house wrappers
+  bake in. Define a server once in a neutral shape
+  (`{ transport = "stdio"; command; args?; env? }` or `{ transport = "http";
+  url }`) and render it per tool: `toClaudeJson` (Claude Code `mcpServers` JSON),
+  `toAgentMcpServers` (subagent frontmatter array), `toCodexEntries` (dotted
+  `mcp_servers.*` codex `-c` flags), plus `houseServers { indexCommand }`
+  (`lib/util/mcp.nix:76-137`). Consumed by the agent wrappers and
+  `lib/agent-context/agents.nix`.
+
+## relative-path.nix
+
+`ix.relativePath`: validate option values later joined under a runtime directory
+(`lib/util/relative-path.nix`). `isSafe` accepts ordinary relative paths and
+rejects empty/absolute/`.`/`..`/repeated-slash; `isSafeName` requires a single
+segment; `shellPath`/`shellParent` return shell snippets joining a root
+expression with a validated path; `unsafe`/`unsafeNames` filter a list to the
+offenders (`lib/util/relative-path.nix:11-38`).
+
+## secrets.nix
+
+`ix.secrets` (`lib/default.nix:117-119`): normalize a secret spec and render it
+to each consumer. `normalize` turns a spec into `{ provider, values, refs }`;
+the surface exposes the vaultwarden provider (`rbwCheckCommand`,
+`rbwMaterializeCommand`) and per-consumer renderers under `consumers`: `vm.refs`,
+`nomad` (`envTemplates`/`runCommand`/`renderJob`), and
+`kubernetes.renderExternalSecret` (`lib/util/secrets.nix:314-337`). `mkFleet`
+normalizes its `secrets` through this (`lib/image/fleet.nix:47-48`).
+
+## writers.nix
+
+The checked executable writers, all curried `pkgs:`
+(`lib/util/writers.nix:266-272`). `writeNushellApplication` is the default for
+repo commands (Nu syntax checked at build via `nushell --ide-check`);
+`writeBashApplication` is the one sanctioned bash escape hatch (runs under
+`set -euo pipefail`, checked with `bash -n` + shellcheck,
+`lib/util/writers.nix:132-177`); `writePythonApplication` wraps a Python
+entrypoint and runs `ty` over it at build time (`lib/util/writers.nix:3-130`);
+`writeProcessComposeApplication` wraps a process-compose spec
+(`lib/util/writers.nix:179-`). All default `meta.mainProgram`.
+
+## bench.nix and artifacts.nix
+
+- `ix.mkBenchSuite pkgs { name, indexbench, macros ? [], allocCheck ? null,
+  runs ? 10 }` (`lib/util/bench.nix:27-47`) declares a continuous-benchmark suite
+  against the `indexbench` CLI, returning `{ app; check? }`: `app` is a `nix
+  run`-able perf job (timing/RSS not reproducible, so never a flake check);
+  `check` (present only with `allocCheck`) is a hermetic flake check asserting
+  reproducible allocation counts stay within budget
+  (`lib/util/bench.nix:1-22`).
+- `ix.artifacts` (`lib/default.nix:312-317`): pinned artifact catalogs surfaced
+  to images and presets by name. `attachArtifactSources` wraps catalog entries in
+  `fetchurl` derivations; the `minecraft` sub-attrset exposes mod/plugin catalogs,
+  server jars by version, and the loader manifests
+  (`lib/util/artifacts.nix:159-189`). Presets must consume entries through this
+  set rather than inlining URLs and hashes. Consumed by
+  [minecraft](../minecraft/overview.md) loaders.

--- a/docs/packaging/btop/overview.md
+++ b/docs/packaging/btop/overview.md
@@ -1,0 +1,35 @@
+# btop
+
+`packages/btop` repackages [btop](https://github.com/aristocratos/btop), the
+resource monitor (CPU, memory, disk, network, process TUI), rebuilt from a
+repo-owned fork instead of the upstream source. It is the minimal repackage
+shape: take the nixpkgs `btop` derivation and override only its source.
+
+## What this repo changes
+
+`default.nix` is the whole delta: `btop.overrideAttrs` swaps `src` to
+`ix.btopSrc` and rewrites `meta.homepage` to the fork
+(`packages/btop/default.nix:6-11`). Everything else (build inputs, phases,
+flags, the rest of `meta`) is inherited from nixpkgs `btop` unchanged.
+
+- Source pin: `ix.btopSrc` resolves to the `btop-src` flake input, a
+  `flake = false` GitHub source pinned at a commit rev
+  (`flake.nix:90-93`, `github:indexable-inc/btop/711f4a1...`), threaded into the
+  `ix` bundle as `btopSrc` (`lib/default.nix:428`). The fork carries whatever
+  repo-specific changes are committed at that rev; this package just builds it.
+- `meta.homepage` points at `indexable-inc/btop` so the built package advertises
+  the fork, not upstream (`packages/btop/default.nix:10`).
+
+## Build and wiring
+
+- Flake output: `nix run .#btop` / `nix build .#btop`. `package.nix` sets
+  `packageSet = true` and `flake = true` (`packages/btop/package.nix:1-5`); no
+  overlay, so `pkgs.btop` stays the plain nixpkgs monitor.
+- Bump: `nix flake update btop-src` (or repoint the input rev in `flake.nix`).
+  There is no `manifest.json` and no `updateScript`; the flake lock owns the
+  pin.
+- Platforms: inherited from nixpkgs `btop` (unix); no extra `systems` gate.
+
+Because the derivation is `overrideAttrs` over the upstream package, a nixpkgs
+bump to `btop` (new build inputs, phase changes) flows through automatically;
+only a source incompatible with the upstream build recipe would need work here.

--- a/docs/packaging/claude-code/overview.md
+++ b/docs/packaging/claude-code/overview.md
@@ -1,0 +1,182 @@
+# claude-code
+
+`packages/claude-code` repackages
+[Claude Code](https://www.anthropic.com/claude-code), Anthropic's agentic coding
+CLI, as a prebuilt-binary install with a thick layer of baked-in fleet defaults.
+The upstream artifact is a Bun single-file executable pinned per platform; this
+package wraps it so every session starts with the repo's flags, env, settings,
+MCP servers, system prompt, and hooks already applied, while keeping the store
+binary itself read-only and pristine. It is the richest wrapper in this domain.
+
+The injection is done through the shared `config-launch` launcher
+(`packages/config-launch`), the same mechanism [codex](../codex/overview.md)
+uses: the wrapper bakes a launch-spec JSON and points `config-launch` at it via
+a `makeBinaryWrapper` `--set IX_LAUNCH_SPEC`
+(`packages/claude-code/default.nix:451-459`).
+
+## Version pin and provenance
+
+`manifest.json` holds `version` and per-platform `{ slug, hash }`, read with
+`lib.importJSON` and never hand-edited (`packages/claude-code/default.nix:128-129`;
+`manifest.json` currently pins `2.1.170` for four platforms). The binary is
+`fetchurl`ed from the Anthropic-branded CDN with the GCS bucket as a hash-pinned
+mirror (`packages/claude-code/default.nix:402-408`).
+
+- Bump: `nix run .#claude-code.updateScript -- [version]`. The updater
+  (`update.nix`) refetches Anthropic's per-version manifest, converts its hex
+  checksums to SRI, and rewrites `manifest.json`
+  (`packages/claude-code/update.nix:33-67`).
+- Fails closed on provenance: the updater verifies the manifest's detached GPG
+  signature against the pinned release key (`release-signing-key.asc`,
+  fingerprint `31DD DE24 ... 1A7E CACE`) in an isolated `GNUPGHOME` and aborts
+  if `gpg --verify` is non-zero, so a spoofed manifest cannot inject hashes for
+  attacker-controlled binaries (`packages/claude-code/update.nix:1-8`, `43-52`).
+- Pin is by raw version, not the npm `latest` tag, because Anthropic ships to
+  the `next` prerelease tag days before promoting to `latest`
+  (`packages/claude-code/default.nix:121-127`).
+
+## Baked defaults
+
+All flag/env/PATH/settings injection is declared as data in `launchSpec`
+(`packages/claude-code/default.nix:375-391`) and applied by `config-launch`.
+
+### Forced env (always set)
+
+Because the store output is read-only, the bundled self-updater could never
+write, so the wrapper turns it off hard (`default.nix:375-381`):
+`DISABLE_AUTOUPDATER=1`, `DISABLE_INSTALLATION_CHECKS=1`, and
+`USE_BUILTIN_RIPGREP=0` (search uses the Nix `ripgrep` on PATH so the wrapper
+owns the version pin).
+
+### Soft env defaults (set only when unset)
+
+`env_defaults` are applied only if the user has not set them
+(`default.nix:147-152`, `382`): `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` keeps every
+session on the standard 200K window instead of the silently auto-upgraded 1M
+window (uncached, slower per turn). Re-enable per machine with
+`export CLAUDE_CODE_DISABLE_1M_CONTEXT=`.
+
+### Prepended flags (`wrapperFlags`, `default.nix:353-361`)
+
+Flags ride BEFORE the user argv (so root options parse before subcommand
+dispatch, e.g. `claude --settings=F mcp list`), and every option-argument uses
+the `=` form (one self-contained token, so a variadic flag cannot swallow a
+positional). Both rules are learned from real breakage; see the long comment at
+`default.nix:315-352`.
+
+- `--debug`: writes operational telemetry to `~/.claude/debug/` (pruned on the
+  `cleanupPeriodDays` sweep). It is an optional-value flag, so it cannot take
+  `=`; it is safe only because `--thinking-display` follows it.
+- `--thinking-display=summarized`: forces visible reasoning. The API default
+  flipped to "omitted" on Opus 4.7/4.8, hiding thinking in the UI and
+  transcript; this hidden flag is the only lever that restores it (verified on
+  2.1.159).
+- `--dangerously-skip-permissions` (default on): start every session with the
+  permission layer skipped (the fleet runs trusted configs in disposable
+  sandboxes). Gated on `dangerouslySkipPermissions` (below). Mind the upstream
+  uid-0 guard: the CLI refuses this flag for an unsandboxed root user, so root
+  consumers carry their own `IS_SANDBOX=1` or turn the flag off.
+- `--append-system-prompt-file=<store path>`: the house system prompt (below),
+  baked by path so content needs no shell quoting.
+- `--mcp-config=<file>`: the baked MCP server set (below).
+
+### Conditional `--settings` (injected only when the caller passes none)
+
+The CLI is first-wins between two `--settings` flags (they do not merge), so the
+wrapper injects its defaults file only `unless_present` a caller `--settings`
+(`default.nix:385-390`, `conditional_flags`). The file is a deep-merge of caller
+`extraSettings` UNDER the computed defaults so package-owned keys always win
+(`default.nix:226-293`):
+
+- `cleanupPeriodDays = 365`: keep transcripts and `--debug` logs ~1yr.
+- `skipDangerousModePermissionPrompt = true` (when
+  `dangerouslySkipPermissions`): pre-accept the one-time dangerous-mode warning
+  the flag alone does not suppress.
+- `permissions.ask`: `gh pr merge --admin` / `--force` pause for confirmation
+  so the local-build gate in the system prompt is applied (postmortem
+  ENG-2391); ask rules are not enforced under the baked skip-permissions, so
+  this is the practical gate for consumers who turn the flag off.
+- `permissions.deny` `WebSearch` / `WebFetch` (only while the `exa` MCP server
+  is baked): one web surface, not two; deny rules are enforced in every
+  permission mode.
+- `hooks` (below).
+
+### MCP servers (`--mcp-config`, `default.nix:90-94`, `295-297`)
+
+Rendered from the shared `ix.mcp` registry (`lib/util/mcp.nix`) so `index` is
+declared once for both this wrapper and codex. CLI `--mcp-config` layers merge,
+so a user's `--mcp-config` and a project `.mcp.json` still load alongside.
+Defaults to the house pair, additions only:
+
+- `index`: the ix notebook kernel (`ix-mcp serve`, `packages/mcp`) over stdio, present
+  only when the `mcp` sibling is in scope (the flake package set, not the
+  overlay; see `repoPackages`, `default.nix:59-69`).
+- `exa`: Exa's hosted web-search server over streamable HTTP at
+  `https://mcp.exa.ai/mcp` (keyless, rate-limited).
+
+### Appended system prompt (`system-prompt.nix`)
+
+`appendSystemPrompt` appends the house rules to the stock system prompt, never
+replacing it (`default.nix:96-112`). The text is the shokunin craft ethos plus
+fleet engineering rules: pre-v1 no-backward-compatibility, one-concept-one-
+implementation, always work in a git worktree, spawn background subagents for
+independent work, do work through the index Python kernel and `search` priors,
+gate admin/force merges on a fresh local build, never use em dashes, and more
+(`system-prompt.nix:7-37`). Set to `null` to ship the stock prompt alone.
+
+### Hooks (`hooks.nix`, `default.nix:209-285`)
+
+Three hooks, all subcommands of one compiled binary (`packages/claude-hooks`)
+wrapped with their tool paths and the baked primary-checkout default; each fails
+open and silent
+(`hooks.nix:1-20`):
+
+- `SessionStart` -> `session-digest`: cats the pre-rendered fleet context digest
+  (`~/.cache/ix/context-digest.md`), capped ~6000 chars. Kill switch
+  `CLAUDE_CODE_DISABLE_CONTEXT_DIGEST=1`.
+- `PreToolUse` (Edit|MultiEdit|Write|NotebookEdit) -> `worktree-guard`: denies a
+  file-edit whose TARGET path resolves into a protected primary checkout
+  (judging the target, not the session cwd, which closes the
+  project-hook bypass, ENG-2692). Protected globs default to `/home/*/index` and
+  `/home/*/ix` (`default.nix:54-57`), overridable per machine via
+  `CLAUDE_CODE_PRIMARY_CHECKOUTS`; `[ ]` disables it. Kill switch
+  `CLAUDE_CODE_DISABLE_WORKTREE_GUARD=1`.
+- `UserPromptSubmit` -> `prompt-priors` (only when the `search` sibling is in
+  scope): score-gated ambient priors from the corpus store, capped ~1200
+  tokens. Kill switch `CLAUDE_CODE_DISABLE_PROMPT_PRIORS=1`.
+
+### Prepended PATH (`pathPrepend`, `default.nix:299-313`)
+
+`procps` (process checks), the pinned `ripgrep`, the `minecraft-sound` chime,
+and on Linux the sandbox helpers `bubblewrap` and `socat`.
+
+## Overrides
+
+`default.nix` exposes these args: `binName` (default `claude`),
+`dangerouslySkipPermissions`, `extraSettings`, `primaryCheckouts`, `mcpServers`,
+`appendSystemPrompt`. Example: `claude-code.override { dangerouslySkipPermissions = false; }`.
+
+## Build and wiring
+
+- Install (`default.nix:435-462`): the real binary is installed to
+  `$out/libexec/Claude Code` (off PATH, named for the product so 1Password's
+  "CLI access requested" prompt reads "Claude Code"); the launch spec's
+  `@helper@` placeholder is substituted with its real path; `$out/bin/${binName}`
+  is a `makeBinaryWrapper` over `config-launch` with `--inherit-argv0` and
+  `--set IX_LAUNCH_SPEC`. `dontStrip = true` because stripping corrupts Bun's
+  appended trailer (`default.nix:425-427`); `autoPatchelfHook` runs on ELF
+  hosts.
+- Install checks (`install-check.nix`): an offline argv regression net driven
+  through the real launcher against a stub target (flags prepend, `=` form,
+  `--settings` defers to the caller) plus behavioral nets for all three hooks
+  (`default.nix:464-480`).
+- Flake output: `nix run .#claude-code` / `nix build .#claude-code`, plus
+  `pkgs.claude-code` (overlay). `package.nix` sets `packageSet`, `flake`,
+  `overlay`, `updateScript` all `true` (`packages/claude-code/package.nix`).
+  Note: the overlay build gets `repoPackages = { }`, so it drops sibling-
+  dependent defaults (the `index` MCP server, the search-gated prompt-priors
+  hook) and omits `passthru.updateScript`; the full-featured build is the flake
+  package set.
+- Platforms: aarch64/x86_64 darwin and linux (the four `manifest.json` keys).
+  `meta.license` is omitted so the no-`allowUnfree` flake set can still build it
+  (`default.nix:489-492`).

--- a/docs/packaging/codex/overview.md
+++ b/docs/packaging/codex/overview.md
@@ -1,0 +1,85 @@
+# codex
+
+`packages/codex` repackages the OpenAI Codex CLI (the nixpkgs `codex` package)
+with baked-in `-c` config defaults. The binary is unchanged; the wrapper injects
+config on every invocation through the shared `config-launch` launcher
+(`packages/config-launch`), the same mechanism
+[claude-code](../claude-code/overview.md) uses. The base `codex` is a nixpkgs
+dependency, so there is no source pin or updater here; bumping codex is a
+nixpkgs/flake-lock bump.
+
+## Why an additive flake output, not an overlay
+
+`package.nix` sets `flake = true` but deliberately NOT `overlay`
+(`packages/codex/package.nix:7-13`): `pkgs.codex` must stay the plain nixpkgs
+CLI because symphony's room-server wrapper pins `pkgs.codex` as the binary it
+spawns over JSON-RPC. This wrapper is an additive output
+(`nix run .#codex`, `index.packages.<sys>.codex`) that bakes defaults on top of
+the same base without changing what the overlay hands other code.
+
+## Baked defaults
+
+The wrapper builds a launch spec (`packages/codex/default.nix:74-81`) the
+launcher reads: it targets `lib.getExe codex`, sets `config_dir_env = CODEX_HOME`
+/ `config_dir_default = ~/.codex` / `config_file = config.toml`, and carries two
+kinds of `-c key=value` overrides.
+
+### Forced settings (`forcedSettings`, `default.nix:24-26`)
+
+Applied on EVERY invocation (`-c` is codex's highest-precedence layer, above
+`~/.codex/config.toml`), so reserved for wrapper invariants the user must not
+silently lose. The only one baked: `check_for_update_on_startup = false`, since
+the store binary is read-only and the wrapper owns the version pin, so the check
+only ever costs a network round-trip it can never act on. Anything
+security-shaped (sandbox mode, approval policy) is left to the user's config.
+
+### Soft defaults (`settings`, `default.nix:41-47`)
+
+Injected ONLY when the user's `config.toml` does not already set that exact
+dotted-key path; detection is per-leaf via exact TOML path lookup in the
+compiled launcher (not substring grep), and a user's own later `-c` still wins.
+Defaults bump multi-agent fan-out well above stock:
+
+- `features.multi_agent_v2.enabled = true` and
+  `features.multi_agent_v2.max_concurrent_threads_per_session = 16` (stock is 4:
+  root + 3 subagents; 16 => root + 15 concurrent subagents). The cap lives under
+  the v2 feature because v2 rejects `agents.max_threads`.
+- `agents.max_depth = 3` (parent -> child -> grandchild -> great-grandchild),
+  still read under v2.
+
+### Baked MCP server (`default.nix:62-73`, `80`)
+
+The `index` MCP server is added as soft `-c mcp_servers.index.*` defaults from
+the same `ix.mcp` registry the claude-code wrapper renders, so the kernel is
+declared once for both tools. Only stdio servers are baked
+(`mcpStdioServers` filters `transport == "stdio"`): codex's streamable-HTTP MCP
+support is gated behind version-specific keys, so the keyless `exa` HTTP server
+stays claude-only. The `index` server is present only when the `mcp` sibling is
+in scope (the flake package set, not the overlay; `repoPackages`,
+`default.nix:10-15`, `71`).
+
+### Remote-SSH reach (`default.nix:83-92`)
+
+These baked defaults also reach the Codex GUI app's remote-SSH sessions: the
+desktop app bootstraps the host through the remote user's login shell and runs
+`codex app-server` from the remote PATH, so whenever this wrapper is the first
+`codex` on the remote login-shell PATH it intercepts that launch and injects the
+same `-c` flags. Caveats noted inline: the wrapper must win the login shell PATH
+(`$SHELL -lc`, which skips `~/.bashrc`/`~/.zshrc`), and a stale already-running
+`app-server` is reused without re-injecting (kill it once after a bump).
+
+## Build and wiring
+
+- The wrapper is a `symlinkJoin` over `codex` whose only change is replacing the
+  `$out/bin/${binName}` entrypoint with a `makeBinaryWrapper` over the launcher
+  (`--inherit-argv0`, `--set IX_LAUNCH_SPEC`), so everything else (libexec,
+  completions) stays pristine (`default.nix:93-105`). `binName` defaults to
+  `codex`.
+- Flake output: `nix run .#codex` / `nix build .#codex`. `package.nix` sets
+  `packageSet = true`, `flake = true` (`packages/codex/package.nix`). The
+  `packageSet` here is the index package set, not a nixpkgs overlay injection.
+- The overlay eval context provides no `repoPackages`, so a `{ }` build bakes no
+  MCP server (the same fallback claude-code uses); the flake package set is
+  where the `index` server is wired.
+- No source pin/manifest/updateScript: the base `codex` and its version come
+  from nixpkgs.

--- a/docs/packaging/common.md
+++ b/docs/packaging/common.md
@@ -1,0 +1,153 @@
+# Packaging
+
+Repo-owned Nix repackages of third-party tools. Each package under `packages/`
+documented here is a thin wrapper around an upstream tool (a CLI, a TUI, a JVM
+distribution, or a GUI bundle) that this repo rebuilds with its own baked-in
+defaults, patches, source pins, or NixOS fixups. Nothing here is original
+software: the value is the deltas (forced flags, config injection, ELF
+patching, version pinning) layered on top of the upstream artifact so it runs
+correctly and consistently inside this fleet.
+
+Read this page first for the shared conventions (how a wrapper is structured,
+how it is wired into the flake, how versions are pinned and bumped), then the
+per-package page for the specific deltas that package adds. The intake policy
+these packages follow is `agent-context/sections/13-dependency-intake.md`.
+
+## Packages
+
+| package | upstream | what this repo changes |
+| --- | --- | --- |
+| [btop](btop/overview.md) | btop system monitor | `overrideAttrs` swaps `src` to a repo fork pinned by flake input rev |
+| [claude-code](claude-code/overview.md) | Anthropic Claude Code CLI | baked flags/env/settings/MCP/system-prompt/hooks via the `config-launch` launcher; signed-manifest version pin |
+| [codex](codex/overview.md) | OpenAI Codex CLI (nixpkgs) | baked forced + soft `-c` config via `config-launch`; additive flake output only |
+| [dia](dia/overview.md) | The Browser Company Dia browser | unpacks the signed `.dmg` verbatim; manifest pin + updater; aarch64-darwin only |
+| [launchk](launchk/overview.md) | mach-kernel/launchk launchd TUI | `buildRustPackage` from a pinned flake-input rev; bindgen + `git_version!()` fixups; Darwin only |
+| [spark-gluten](spark-gluten/overview.md) | Apache Gluten Velox bundle | explodes the bundle jar, `autoPatchelf`s the CentOS-7 native libs for NixOS, repacks; x86_64-linux only |
+| [spark-hive](spark-hive/overview.md) | Apache Spark hadoop3+Hive | full distribution, wrappers pin JDK 17 + TZDIR; x86_64-linux only |
+| [tonbo-artifacts](tonbo-artifacts/overview.md) | Tonbo Artifacts CLI | installs a prebuilt binary pinned by URL rev; x86_64-linux only |
+| [tmux](tmux/overview.md) | tmux | `symlinkJoin` + `wrapProgram -f` to bake a truecolor/mouse/vi config |
+| [vineflower](vineflower/overview.md) | Vineflower Java decompiler | downloads the release jar, writes a `java -jar` launcher; inline version pin |
+| [yc](yc/overview.md) | Y Combinator CLI | installs prebuilt per-platform binaries; manifest pin + updater (no provenance check) |
+
+## How a wrapper is structured
+
+Every package is one directory under `packages/<id>/`. The recurring files:
+
+- `default.nix`: the derivation. It does one of four things (see the per-package
+  pages for which): rebuild upstream with a swapped source (`overrideAttrs`,
+  btop), build from source (`rustPlatform.buildRustPackage`, launchk), wrap an
+  existing package (`symlinkJoin` + a wrapper, tmux/codex/claude-code), or
+  install a prebuilt artifact (`stdenv.mkDerivation` + `fetchurl`, dia, yc,
+  tonbo-artifacts, vineflower, spark-gluten, spark-hive). The baked defaults and
+  patches live here.
+- `package.nix`: registry metadata, an attrset (`packages/registry.nix:30-39`
+  lists the allowed keys). The load-bearing keys:
+  - `id`: the package name (and default flake/overlay attr name, default
+    package-set attr path).
+  - `packageSet` / `flake` / `overlay`: where the package surfaces. `true` uses
+    the `id` as selector; an attrset can set `systems` to gate platforms (so
+    `nix flake check` does not try to build an off-platform package) or override
+    the attr name/path (`packages/registry.nix:55-100`).
+  - `updateScript = true`: declares the package exposes a
+    `passthru.updateScript` and joins the repo-wide `update` aggregator
+    (`packages/registry.nix:136-140`, `161-162`).
+- `manifest.json` (prebuilt-binary packages only): the generated
+  `{ version, hash }` or `{ version, platforms.<sys>.{slug,hash} }` pin, read
+  with `lib.importJSON` and never hand-edited. Present for claude-code, dia, yc.
+- update logic (manifest packages only): a `passthru.updateScript`
+  (`writeNushellApplication`) that refetches the upstream pointer and rewrites
+  `manifest.json`. claude-code factors it into `update.nix`; dia and yc inline
+  it in `default.nix`.
+
+## How a package is wired into the flake
+
+The registry discovers every directory containing a `package.nix`
+(`packages/registry.nix:24`, `116-141`); there is no central list to edit.
+
+- Package set: `lib/packages.nix` calls each `default.nix` with `pkgs`, the
+  `ix` helper bundle, and `repoPackages` (the package set itself, a lazy
+  fix-point, so one package can depend on a sibling by id without a flat merge
+  that would shadow nixpkgs attrs: `lib/packages.nix:38-57`). This is the eval
+  context where sibling-dependent defaults (the baked `index` MCP server, the
+  `config-launch` launcher) are available.
+- Flake output: `lib/per-system.nix:537-541` turns every `flake`-enabled entry
+  into `packages.<system>.<attrName>`, so `nix run .#<name>` and
+  `nix build .#<name>` work (no `apps` entry needed; the wrapper sets
+  `meta.mainProgram`).
+- Overlay: `overlay`-enabled entries also surface as `pkgs.<name>` for NixOS
+  modules (`lib/overlay.nix`). Some packages (codex) are deliberately
+  flake-only so `pkgs.<name>` stays the plain nixpkgs version.
+- Source pinning: a wrapper pins its upstream three ways. Flake-input rev
+  (`flake.nix` `*-src` inputs, exposed as `ix.<name>Src`): btop, launchk. Inline
+  `version` + `hash` in `default.nix`: vineflower, tonbo-artifacts, spark-gluten,
+  spark-hive. Generated `manifest.json` + updater: claude-code, dia, yc.
+- Bumping a manifest pin: `nix run .#<id>.updateScript -- [version]` refreshes
+  that one package; `nix run .#update` runs every `updateScript = true`
+  package's updater in parallel via `dag-runner`
+  (`lib/per-system.nix:461-501`), and `update.yml` runs it hourly into one PR.
+  Inline-pinned packages bump by editing `version` and refreshing `hash` with
+  `nix-prefetch-url`; flake-input packages bump by `nix flake update <input>`.
+
+## Conventions
+
+- `meta.platforms` and the `package.nix` `systems` gates are kept in sync so an
+  off-platform `nix flake check` never forces a build nixpkgs refuses to
+  evaluate (`packages/launchk/package.nix:3-14`,
+  `packages/spark-gluten/package.nix:3-12`). Linux-only or macOS-only packages
+  list only their systems.
+- A proprietary/unfree vendored binary omits `meta.license` rather than tagging
+  it `licenses.unfree`, because the per-system flake package set evaluates
+  nixpkgs without `allowUnfree` and the tag would block `nix run .#<name>`
+  (`packages/claude-code/default.nix:489-492`, `packages/dia/default.nix:96-99`,
+  `packages/yc/default.nix:100-103`).
+- A prebuilt binary sets `sourceProvenance = [ lib.sourceTypes.binaryNativeCode ]`
+  (or `binaryBytecode` for JVM), `dontStrip` where stripping would corrupt the
+  artifact (claude-code's Bun trailer, spark-gluten's vendored `.so`), and
+  `strictDeps = true`.
+- The shared launcher `config-launch` (`packages/config-launch`, a compiled Rust
+  binary) is the injection mechanism for the two config-baking CLIs: it reads a
+  baked `IX_LAUNCH_SPEC` JSON (target binary, forced flags, soft defaults, env,
+  PATH), does per-key presence detection against the user's config, then execs
+  the real binary preserving argv0. claude-code and codex both use it.
+
+## Glossary
+
+- **wrapper / repackage**: a repo-owned derivation that takes an upstream
+  artifact and adds deltas (flags, config, patches, source pin). Every package
+  on this page is one.
+- **baked default**: a flag, env var, or settings key the wrapper injects on
+  every invocation. Forced (always wins) or soft (only when the user has not
+  set it).
+- **config-launch / launch spec**: the shared Rust launcher and its
+  `IX_LAUNCH_SPEC` JSON. The mechanism claude-code and codex use to inject
+  config without editing the read-only store binary.
+- **manifest pin**: a generated `manifest.json` holding a version and SRI
+  hash(es), read with `lib.importJSON`, refreshed only by the package's
+  `updateScript`.
+- **updateScript**: a `passthru.updateScript` that refetches an upstream
+  pointer and rewrites `manifest.json`. Flagged in `package.nix`
+  (`updateScript = true`) to join `nix run .#update`.
+- **autoPatchelf**: the nixpkgs hook that rewrites a foreign-built ELF's
+  interpreter and rpath to Nix store paths so it loads on NixOS (used by
+  spark-gluten, yc Linux).
+- **flake-input rev**: an upstream source pinned as a `flake = false` input in
+  `flake.nix` at a git commit, surfaced to a package as `ix.<name>Src`.
+- **soft vs forced**: a soft default is injected only when the user's config
+  does not already set that exact key; a forced setting is applied
+  unconditionally (a wrapper invariant the user must not silently lose).
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| btop | [btop/overview.md](btop/overview.md) | btop rebuilt against a repo fork source |
+| claude-code | [claude-code/overview.md](claude-code/overview.md) | Claude Code CLI with baked flags/env/settings/MCP/prompt/hooks |
+| codex | [codex/overview.md](codex/overview.md) | OpenAI Codex CLI with baked `-c` config defaults |
+| dia | [dia/overview.md](dia/overview.md) | Dia browser `.dmg` repackaged verbatim, manifest + updater |
+| launchk | [launchk/overview.md](launchk/overview.md) | launchd-observer Rust TUI built from a pinned rev |
+| spark-gluten | [spark-gluten/overview.md](spark-gluten/overview.md) | Gluten Velox bundle, native libs patched for NixOS |
+| spark-hive | [spark-hive/overview.md](spark-hive/overview.md) | Spark hadoop3+Hive distribution, JDK 17 wrappers |
+| tonbo-artifacts | [tonbo-artifacts/overview.md](tonbo-artifacts/overview.md) | prebuilt Tonbo Artifacts CLI binary |
+| tmux | [tmux/overview.md](tmux/overview.md) | tmux wrapped with a truecolor/mouse/vi config |
+| vineflower | [vineflower/overview.md](vineflower/overview.md) | Vineflower decompiler jar with a `java -jar` launcher |
+| yc | [yc/overview.md](yc/overview.md) | YC CLI prebuilt binaries, manifest + updater |

--- a/docs/packaging/dia/overview.md
+++ b/docs/packaging/dia/overview.md
@@ -1,0 +1,62 @@
+# dia
+
+`packages/dia` packages [Dia](https://www.diabrowser.com), The Browser
+Company's AI browser, by unpacking its signed, notarized macOS `.dmg` verbatim.
+There is no patching: the bundle is installed byte-for-byte so the code
+signature stays valid. The repo owns the version pin (a generated
+`manifest.json`) and an updater that refreshes it.
+
+## What this repo changes
+
+`default.nix` is a prebuilt GUI-bundle install with a maintainer-facing updater
+(`packages/dia/default.nix`):
+
+- Source pin: `version` and `hash` come from `manifest.json`
+  (`lib.importJSON ./manifest.json`, `default.nix:24-25`; currently
+  `1.34.1-81705`). `version` is `<short>-<build>` matching the upstream filename
+  `Dia-<version>.dmg`. The `.dmg` is `fetchurl`ed from
+  `releases.diabrowser.com/release/Dia-${version}.dmg`
+  (`default.nix:65-68`).
+- Verbatim install: `undmg` extracts the `.app` into the build dir
+  (`sourceRoot = "."`), and the install phase copies `Dia.app` into
+  `$out/Applications/` and symlinks the bundle executable to `$out/bin/dia`
+  (`default.nix:70-87`). `dontConfigure`, `dontBuild`, and crucially
+  `dontFixup = true`: the bundle is signed and notarized, so any byte rewrite
+  (strip, patch, the default fixup) would void the signature
+  (`default.nix:74-78`).
+- `meta`: `mainProgram = "dia"`, `platforms = [ "aarch64-darwin" ]`,
+  `sourceProvenance = [ binaryNativeCode ]`. `meta.license` is omitted (not
+  tagged `licenses.unfree`) so the no-`allowUnfree` flake set can still
+  `nix run .#dia`; terms are The Browser Company's Dia license
+  (`default.nix:93-103`).
+
+## Updater (`updateScript`)
+
+`passthru.updateScript` is a `writeNushellApplication` that refreshes
+`manifest.json` to a Dia release (`default.nix:32-59`). It is bound only on the
+flake package path (the overlay context passes `writeNushellApplication = null`,
+so `pkgs.dia` carries no updateScript, `default.nix:7-11`, `89-91`).
+
+- `nix run .#dia.updateScript` with no argument tracks the `Dia-latest.dmg`
+  pointer, reading the resolved version out of the `Content-Disposition`
+  filename the CDN returns (there is no appcast/manifest); pass a version to pin
+  an exact one (`default.nix:43-52`).
+- It runs `nix store prefetch-file` to download the `.dmg` once and emit the SRI
+  hash, then writes `{ version, hash }` to `packages/dia/manifest.json`
+  (`default.nix:53-56`).
+- Pinning by raw bytes makes any exact version installable and verifiable,
+  unlike Homebrew which can only freeze an already-installed cask
+  (`default.nix:17-20`).
+- Run from the repo root; joins `nix run .#update` via `updateScript = true`
+  (`packages/dia/package.nix:15`).
+
+## Build and wiring
+
+- Flake output: `nix run .#dia` / `nix build .#dia`, gated to aarch64-darwin.
+  `package.nix` sets `packageSet`, `flake`, and `overlay` all to
+  `systems = [ "aarch64-darwin" ]`, plus `updateScript = true`
+  (`packages/dia/package.nix:6-15`).
+- Platform constraint: Dia ships a single Apple-Silicon `.app` and requires
+  macOS 14+ on M1+, so every target is gated to aarch64-darwin and the
+  linux flake/overlay/update paths never see it
+  (`packages/dia/package.nix:3-5`).

--- a/docs/packaging/launchk/overview.md
+++ b/docs/packaging/launchk/overview.md
@@ -1,0 +1,49 @@
+# launchk
+
+`packages/launchk` builds [launchk](https://github.com/mach-kernel/launchk), a
+cursive (Rust TUI) tool for observing launchd agents and daemons, from source.
+It is the reference shape for the external-Rust-tool house style
+(`agent-context/sections/13-dependency-intake.md`, "Packaging external Rust
+CLI/TUI tools"), and is macOS-only because launchk talks to launchd over XPC.
+
+## What this repo changes
+
+`default.nix` builds the upstream crate with
+`rustPlatform.buildRustPackage` from a pinned source, with two build fixups
+(`packages/launchk/default.nix`):
+
+- Source pin: `ix.launchkSrc`, the `launchk-src` flake input
+  (`flake = false`, `github:mach-kernel/launchk/6f5f09e...`,
+  `flake.nix:105-108`), threaded into the `ix` bundle as `launchkSrc`
+  (`lib/default.nix:431`).
+- Version: `"0.3.1-unstable-2025-06-07"`, the nixpkgs unstable-version spelling
+  because there is no upstream release tag past the crate version, so a rev bump
+  reads as a dated change (`packages/launchk/default.nix:14-16`).
+- Lockfile: `cargoLock.lockFile = src + "/Cargo.lock"` reads upstream's
+  committed pure-crates.io lock, so a rev bump carries the dependency set with
+  no checked-in lock to drift and no coarse `cargoHash` to refresh
+  (`packages/launchk/default.nix:20-23`).
+- Fixup 1 (bindgen): `xpc-sys` generates XPC framework bindings with bindgen,
+  which needs libclang, so `rustPlatform.bindgenHook` is in `nativeBuildInputs`
+  (`packages/launchk/default.nix:27-29`).
+- Fixup 2 (`git_version!()`): the about-box string shells out to `git describe`
+  at build time, but the fetched tarball has no `.git`; `postPatch` rewrites the
+  macro to `env!("CARGO_PKG_VERSION")` with `--replace-fail` (which errors if
+  upstream moves the call, keeping the patch honest)
+  (`packages/launchk/default.nix:31-37`).
+- Build scope: `cargoBuildFlags`/`cargoTestFlags` restrict to `-p launchk`
+  (`packages/launchk/default.nix:39-46`).
+- `meta`: MIT, `mainProgram = "launchk"`, `platforms = darwin`
+  (`packages/launchk/default.nix:48-54`).
+
+## Build and wiring
+
+- Flake output: `nix run .#launchk` / `nix build .#launchk`, gated to Darwin.
+  `package.nix` sets both `packageSet.systems` and `flake.systems` to
+  `aarch64-darwin` + `x86_64-darwin` (`packages/launchk/package.nix:7-14`) so
+  `nix flake check` does not force nixpkgs to evaluate this Linux-impossible
+  package off-platform.
+- Platform constraint: launchd/XPC is macOS-only; the `meta.platforms` gate and
+  the `package.nix` systems gate are kept in sync per the intake policy.
+- Bump: `nix flake update launchk-src` (or repoint the rev in `flake.nix`) and
+  update the dated `version` string. No `manifest.json`/`updateScript`.

--- a/docs/packaging/spark-gluten/overview.md
+++ b/docs/packaging/spark-gluten/overview.md
@@ -1,0 +1,72 @@
+# spark-gluten
+
+`packages/spark-gluten` packages the
+[Apache Gluten](https://gluten.apache.org/) Velox-backend bundle for Spark 3.5,
+patched so its native libraries load on NixOS. Stock Spark runs queries on the
+JVM; Gluten offloads the physical operators to Velox, a vectorized C++ engine,
+which is where the large analytical speedups come from. Upstream ships one fat
+jar per Spark line with the Velox/Arrow JNI native libraries packed inside;
+Gluten extracts them to a temp dir and `dlopen()`s them at runtime. This
+package is consumed by the spark service module alongside
+[spark-hive](../spark-hive/overview.md).
+
+## The NixOS problem and the fix
+
+The bundled `.so`s (`libvelox.so`, `libgluten.so`, `libarrow_*_jni.so`) are
+built on CentOS 7, so their ELF interpreter is `/lib64/ld-linux-x86-64.so.2` and
+their rpath points at FHS paths that do not exist on NixOS: the stock jar fails
+to load (`packages/spark-gluten/default.nix:1-15`). The fix is to explode the
+jar, autopatchelf the native libs against the Nix store, and repack; the patched
+interpreter and rpath are absolute store paths, so they survive Gluten's runtime
+re-extraction.
+
+`buildPhase` (`default.nix:73-94`):
+
+1. `tar xzf` the release tarball, then `unzip` the bundle jar into `exploded/`.
+2. `autoPatchelf exploded` validates every native dependency is satisfiable from
+   `buildInputs` (it errors the build if one is missing) and rewrites
+   interpreters/rpaths.
+3. For each `exploded/linux/amd64/*.so` and `exploded/x86_64/*.so`, `patchelf
+   --set-rpath "$ORIGIN:<libPath>"`: autoPatchelf records the absolute build-
+   sandbox path for the intra-bundle `libvelox.so -> libgluten.so` link, which
+   vanishes once Gluten extracts to a runtime temp dir, so re-rooting each
+   library at `$ORIGIN` lets a co-extracted sibling resolve, and the appended
+   store paths cover external deps.
+
+`installPhase` repacks `exploded/` into
+`$out/share/java/gluten-velox-bundle.jar` (`default.nix:96-101`).
+
+Notable build settings:
+
+- `buildInputs = [ (lib.getLib stdenv.cc.cc) ]`: the CentOS 7 build statically
+  links Velox/Arrow and their vcpkg deps, so the only dynamic deps are glibc
+  (provided by the host JVM's namespace at runtime) and the intra-bundle link;
+  libgcc_s/libstdc++ are kept as a defensive rpath entry
+  (`default.nix:56-64`).
+- `dontStrip = true` (libvelox.so is ~246 MiB; stripping a vendored binary is
+  slow and pointless) and `dontAutoPatchelf = true` (patching happens inside the
+  exploded jar in `buildPhase`, so the automatic fixup has nothing to find)
+  (`default.nix:66-72`).
+
+## Versions and passthru
+
+Pinned inline in `default.nix`: `version = "1.6.0"`, `sparkVersion = "3.5"`,
+`scalaVersion = "2.12"` (`default.nix:30-33`); `src` is `fetchurl` of the
+`apache-gluten-${version}-bin-spark-${sparkVersion}.tar.gz` from
+`archive.apache.org` with an inline SRI `hash` (`default.nix:41-44`).
+`passthru` exposes `sparkVersion`, `scalaVersion`, and `jar` (the absolute path
+consumers put on the Spark driver/executor classpath, `default.nix:103-107`).
+
+## Build and wiring
+
+- Bump: change `version`, refresh `src.hash` with `nix-prefetch-url`, and check
+  the tarball against its published `.sha512` on archive.apache.org
+  (`default.nix:17-19`). No `manifest.json`/`updateScript`.
+- Flake output: `nix run .#spark-gluten` (rarely run directly; it is a classpath
+  jar). `package.nix` gates `packageSet` and `flake` to `x86_64-linux` (only a
+  linux_amd64 native build is published upstream and the package autopatchelfs
+  ELF objects), while `overlay = true` stays unconditional and lazy:
+  `pkgs.spark-gluten` is only forced inside an x86_64-linux closure (the spark
+  service module), mirroring `drgn` (`packages/spark-gluten/package.nix:3-13`).
+- Platform constraint: `meta.platforms = [ "x86_64-linux" ]`
+  (`default.nix:109-115`).

--- a/docs/packaging/spark-hive/overview.md
+++ b/docs/packaging/spark-hive/overview.md
@@ -1,0 +1,65 @@
+# spark-hive
+
+`packages/spark-hive` packages [Apache Spark](https://spark.apache.org/) 3.5,
+the official complete (hadoop3 + Hive) binary distribution, self-contained for
+NixOS and pinned to JDK 17. It is the Spark base the spark service module runs;
+[spark-gluten](../spark-gluten/overview.md) layers the Velox backend on top.
+
+## Why this and not nixpkgs `spark`
+
+The nixpkgs `spark` uses the lean `bin-without-hadoop` tarball and injects an
+external hadoop classpath at runtime, shipping no `hive-exec` (only
+`hive-storage-api`). Apache Gluten's `HiveTableScanExecTransformer` eagerly
+`classForName`s Hive's ORC and Parquet input-format classes during query
+planning with no config gate, so on the lean build Gluten fails to initialize
+for any query. This distribution bundles hadoop and the full Hive jar set
+(`hive-exec`, `hive-common`, `hive-metastore`, `hive-serde`, `spark-hive`, ...),
+so Gluten and other Hive-dependent features work with no external classpath
+(`packages/spark-hive/default.nix:1-12`).
+
+## What this repo changes
+
+`default.nix` installs the distribution and wraps every launcher
+(`packages/spark-hive/default.nix`):
+
+- Source: `fetchurl` of `spark-${version}-bin-hadoop3.tgz` from
+  `archive.apache.org`, pinned by `version = "3.5.5"` and an inline SRI `hash`
+  (`default.nix:40-45`).
+- Install (`default.nix:50-76`): move the distribution into `$out`, then
+  `patchShebangs $out/bin $out/sbin` to rewrite the `#!/usr/bin/env bash`
+  launchers to a store bash (systemd units run with a minimal PATH). Every
+  executable launcher except the sourced `find-spark-home` is then
+  `wrapProgram`ed with `--set JAVA_HOME ${jdk17_headless}`,
+  `--set TZDIR ${tzdata}/share/zoneinfo`, and `bash`/`coreutils`/pyspark-Python/
+  `procps` (`ps`, used by `load-spark-env.sh`) on PATH, so the units are
+  self-sufficient when Spark's scripts re-exec each other.
+- JDK 17 pin: `jdk17_headless` is a hard dependency arg, NOT a `jdk ? ...`
+  default, because a `jdk ? jdk17_headless` arg would collide with the
+  `pkgs.jdk` callPackage auto-fill (openjdk 21, which Spark 3.5 does not
+  support) and silently override it. Spark 3.5 supports 8/11/17 and Gluten 1.6
+  supports 8/17, so 17 is the overlap the spark service module standardizes on.
+  The bin wrappers `--set JAVA_HOME`, so this is the JVM Spark runs on regardless
+  of the caller's environment (`default.nix:14-17`, `31-35`).
+- TZDIR: Velox (via Gluten) calls `discover_tz_dir`, which needs the IANA tz
+  database; NixOS has none at the FHS `/usr/share/zoneinfo`, so the wrappers
+  point `TZDIR` at the tzdata store path and executors inherit it from the
+  worker's environment (`default.nix:78-80`).
+- `passthru.jdk = jdk17_headless` (`default.nix:81`).
+- `meta`: `mainProgram = "spark-submit"`,
+  `sourceProvenance = [ binaryBytecode ]`, `platforms = [ "x86_64-linux" ]`
+  (`default.nix:83-90`).
+
+## Build and wiring
+
+- Bump: change `version`, refresh `src.hash` with `nix-prefetch-url`, and check
+  the tarball against its published `.sha512` on archive.apache.org
+  (`default.nix:19-20`). No `manifest.json`/`updateScript`.
+- Flake output: `nix run .#spark-hive` runs `spark-submit`. `package.nix` gates
+  `packageSet` and `flake` to `x86_64-linux` (keeping `nix flake check` from
+  fetching the ~400 MiB distribution on platforms nothing builds it for), while
+  `overlay = true` stays unconditional and lazy, mirroring
+  [spark-gluten](../spark-gluten/overview.md) and `drgn`
+  (`packages/spark-hive/package.nix:3-10`).
+- Platform constraint: x86_64-linux only (the spark service module that consumes
+  it is x86_64-linux only because the Gluten Velox bundle has no other native
+  build).

--- a/docs/packaging/tmux/overview.md
+++ b/docs/packaging/tmux/overview.md
@@ -1,0 +1,57 @@
+# tmux
+
+`packages/tmux` repackages [tmux](https://github.com/tmux/tmux) with a modern
+default config baked in (truecolor, undercurl, mouse, vi copy mode, sane
+history and escape-time). The tmux binary is unchanged; the delta is a config
+file forced onto every launch with the user's own config still layered on top.
+
+## What this repo changes
+
+The wrapper is a `symlinkJoin` over upstream `tmux` plus its man output, with a
+`wrapProgram` that points tmux at the repo config
+(`packages/tmux/default.nix:12-23`):
+
+```
+wrapProgram $out/bin/tmux --add-flags "-f ${./tmux.conf}"
+```
+
+- `symlinkJoin` (not a bare wrapper) folds tmux's separate `man` output into the
+  single `out`, because `symlinkJoin` only merges each input's default output;
+  `tmux.man` is listed explicitly in `paths` so the man pages survive the wrap
+  (`packages/tmux/default.nix:14-19`).
+- `meta.outputsToInstall` is forced to `[ "out" ]`: this derivation has only
+  `out`, and inheriting base tmux's `[ "out" "man" ]` would make buildEnv (e.g.
+  `home.packages`) try to read a nonexistent `man` output and fail
+  (`packages/tmux/default.nix:27-30`).
+- `meta.description` is suffixed "with modern truecolor defaults baked in" and
+  `mainProgram = "tmux"` (`packages/tmux/default.nix:24-26`).
+
+### The baked config (`tmux.conf`)
+
+These are defaults: the config sources the user's own
+`~/.config/tmux/tmux.conf` and `~/.tmux.conf` last, so personal settings win
+(`packages/tmux/tmux.conf:33-35`). Key settings:
+
+- Truecolor: `default-terminal "tmux-256color"`, `terminal-features ",*:RGB"`
+  (24-bit passthrough) and `,*:usstyle` (curly/colored underlines)
+  (`packages/tmux/tmux.conf:9-11`). Without an RGB terminfo tmux quantizes
+  24-bit color to the 256-color palette (the washed-out look inside tmux).
+- `CLAUDE_CODE_TMUX_TRUECOLOR 1` set in the tmux environment
+  (`packages/tmux/tmux.conf:16`): Claude Code clamps its own rendering to
+  256-color whenever `$TMUX` is set (anthropics/claude-code#36785); this flips
+  its documented escape hatch on for every pane since the config already passes
+  real truecolor.
+- Responsiveness: `escape-time 10`, `focus-events on`, `repeat-time 600`
+  (`packages/tmux/tmux.conf:19-21`).
+- Comfort: `mouse on`, `history-limit 50000`, `set-clipboard on` (OSC 52),
+  `base-index 1` / `pane-base-index 1`, `renumber-windows on`, `mode-keys vi`,
+  `allow-passthrough on` (`packages/tmux/tmux.conf:24-31`).
+
+## Build and wiring
+
+- Flake output: `nix run .#tmux` / `nix build .#tmux`. `package.nix` sets
+  `packageSet = true`, `flake = true` (`packages/tmux/package.nix:1-5`); no
+  overlay, so `pkgs.tmux` stays stock.
+- The binary, version, and platforms all come from upstream `tmux` (the
+  derivation name is `tmux-${tmux.version}`); there is no separate source pin
+  or updater. Editing `tmux.conf` rebuilds the wrapper.

--- a/docs/packaging/tonbo-artifacts/overview.md
+++ b/docs/packaging/tonbo-artifacts/overview.md
@@ -1,0 +1,37 @@
+# tonbo-artifacts
+
+`packages/tonbo-artifacts` packages the
+[Tonbo Artifacts](https://artifacts.tonbo.io/docs/overview/) CLI, a prebuilt
+binary served from Tonbo's release host. It installs the binary as-is; there is
+no build, patch, or wrapper.
+
+## What this repo changes
+
+`default.nix` is a minimal prebuilt-binary install
+(`packages/tonbo-artifacts/default.nix`):
+
+- Source: `fetchurl` of
+  `https://artifacts.tonbo.dev/release/${version}/artifacts`, pinned by
+  `version = "e16636b0e5ce"` (a release rev, not a semver tag) and an inline SRI
+  `hash` (`packages/tonbo-artifacts/default.nix:6-16`).
+- Build: `stdenvNoCC.mkDerivation` with `dontUnpack`/`dontBuild`; the install
+  phase is one `install -Dm755 "$src" "$out/bin/artifacts"`
+  (`packages/tonbo-artifacts/default.nix:18-28`). No ELF patching is applied.
+- `meta`: `description = "Tonbo Artifacts CLI"`, `mainProgram = "artifacts"`,
+  `platforms = [ "x86_64-linux" ]`
+  (`packages/tonbo-artifacts/default.nix:30-35`). No `license`.
+
+The flake output name is `tonbo-artifacts` but the installed command is
+`artifacts` (`mainProgram`), so `nix run .#tonbo-artifacts` invokes `artifacts`.
+
+## Build and wiring
+
+- Flake output: `package.nix` sets `packageSet = true` and
+  `flake.systems = [ "x86_64-linux" ]`
+  (`packages/tonbo-artifacts/package.nix:1-5`), so `nix run .#tonbo-artifacts`
+  resolves only on x86_64-linux (the only platform the binary is published and
+  tagged for). No overlay.
+- Bump: edit `version` and refresh `hash` with `nix-prefetch-url`. There is no
+  `manifest.json` and no `updateScript`; unlike [yc](../yc/overview.md) and
+  [claude-code](../claude-code/overview.md) it does not track an upstream
+  "latest" pointer, so a bump is a manual rev change.

--- a/docs/packaging/vineflower/overview.md
+++ b/docs/packaging/vineflower/overview.md
@@ -1,0 +1,39 @@
+# vineflower
+
+`packages/vineflower` packages [Vineflower](https://vineflower.org/), the
+actively-maintained fork of Fernflower, the Java decompiler. It downloads the
+upstream release jar and wraps it in a `java -jar` launcher; there is no
+recompilation.
+
+## What this repo changes
+
+`default.nix` fetches the release jar and writes a thin launcher
+(`packages/vineflower/default.nix`):
+
+- Source: `fetchurl` of
+  `vineflower-${version}.jar` from the upstream GitHub release, pinned by
+  `version = "1.12.0"` and an inline SRI `hash`
+  (`packages/vineflower/default.nix:9-13`).
+- Build: `stdenvNoCC.mkDerivation` with `dontUnpack = true`; the install phase
+  copies the jar to `$out/share/java/vineflower.jar` and writes
+  `$out/bin/vineflower`, a shell script that `exec`s `${jdk}/bin/java -jar`
+  against it with `"$@"` (`packages/vineflower/default.nix:25-34`). `jdk` is the
+  nixpkgs default JDK, baked into the launcher path.
+- `meta`: `description` "Modern fork of Fernflower...", `license = asl20`,
+  `mainProgram = "vineflower"`, `platforms = unix`
+  (`packages/vineflower/default.nix:37-43`).
+
+This is the JVM-tool shape: the repo owns only the version pin and the launcher
+that hard-codes the JDK, so the tool runs without the user having a `java` on
+PATH.
+
+## Build and wiring
+
+- Flake output: `package.nix` carries only `id = "vineflower"`
+  (`packages/vineflower/package.nix`); with no `packageSet`/`flake`/`overlay`
+  target set, it surfaces in the package set under its id but is not exposed as
+  a top-level `nix run` flake output. It is consumed directly through the
+  registry: the Minecraft decompile-server tool callPackages it as a runtime
+  input (`lib/per-system.nix:372`).
+- Bump: edit `version` and refresh the `hash` with `nix-prefetch-url`. There is
+  no `manifest.json` and no `updateScript`; the pin is inline in `default.nix`.

--- a/docs/packaging/yc/overview.md
+++ b/docs/packaging/yc/overview.md
@@ -1,0 +1,56 @@
+# yc
+
+`packages/yc` packages the Y Combinator CLI (`yc`: search Bookface and chat with
+the YC Agent from the terminal), installing the upstream prebuilt per-platform
+binaries. The repo owns a generated `manifest.json` pin and an updater. It is
+the worked example, alongside [claude-code](../claude-code/overview.md), for the
+prebuilt-binary intake shape, but with NO upstream provenance check.
+
+## What this repo changes
+
+`default.nix` selects the right prebuilt binary, installs it, and patches it for
+NixOS on Linux (`packages/yc/default.nix`):
+
+- Source pin: `version` and per-platform `{ slug, hash }` come from
+  `manifest.json` (`lib.importJSON`, `default.nix:16-17`; currently `0.0.8` for
+  four platforms). The binary for the host system is `fetchurl`ed from
+  `${baseUrl}/${version}/yc-${target.slug}` where `target` is
+  `manifest.platforms.${system}`, with a clear `throw` listing supported systems
+  if the host is unsupported (`default.nix:19-29`).
+- Install (`default.nix:87-91`): `install -Dm755 $src $out/bin/yc`. On Linux,
+  `autoPatchelfHook` patches the dynamically-linked interpreter to the Nix store
+  (`default.nix:83-85`); Darwin binaries need no patching.
+- `meta`: `mainProgram = "yc"`, `platforms = builtins.attrNames
+  manifest.platforms`, `sourceProvenance = [ binaryNativeCode ]`. `meta.license`
+  is omitted (not `licenses.unfree`) so the no-`allowUnfree` flake set can
+  `nix run .#yc`; terms are Y Combinator's (`default.nix:97-107`).
+
+## Updater (`updateScript`) and the no-provenance caveat
+
+`passthru.updateScript` is a `writeNushellApplication`, bound only on the flake
+package path (the overlay passes `writeNushellApplication = null`, so `pkgs.yc`
+carries no updateScript, `default.nix:7-11`, `93-95`):
+
+- `nix run .#yc.updateScript -- [version]` tracks the upstream `cli/latest`
+  pointer (a 6-byte text file holding the version) when no version is given,
+  then `nix store prefetch-file`s all four platform binaries and writes
+  `{ version, platforms }` with per-platform SRI hashes to
+  `packages/yc/manifest.json` (`default.nix:41-76`). The S3 bucket denies
+  `ListBucket`, hence the `latest` pointer rather than enumerating versions.
+- No provenance check: unlike claude-code, Y Combinator publishes no signed
+  manifest, so the updater pins whatever bytes the release host serves (the
+  version tag is not even immutable; `0.0.5` was observed republished under the
+  same tag). The `nix build .#yc` step in the update workflow only proves the
+  pinned bytes fetch and patch, not that they are authentic, so the real gate is
+  human review of the four hash changes in the auto-bump PR
+  (`default.nix:31-40`).
+
+## Build and wiring
+
+- Flake output: `nix run .#yc` / `nix build .#yc`, plus `pkgs.yc` (overlay).
+  `package.nix` sets `packageSet`, `flake`, `overlay`, and `updateScript` all
+  `true` (`packages/yc/package.nix`).
+- Joins `nix run .#update` via `updateScript = true`, which runs every flagged
+  package's updater in parallel (`lib/per-system.nix:461-501`); the `update.yml`
+  workflow runs it hourly into one PR.
+- Platforms: aarch64/x86_64 darwin and linux (the four `manifest.json` keys).

--- a/docs/sdk/common.md
+++ b/docs/sdk/common.md
@@ -1,0 +1,127 @@
+# SDKs
+
+The language SDKs for ix. Everything under `sdk/` is a client library for the
+hosted ix service (the sandbox/microVM API at `https://api.ix.dev`), shipped in
+three languages, plus the Nix packaging that turns the precompiled Python
+bindings into a `pkgs.ix-sdk-python` for in-repo consumers. These are public,
+source-available wrappers: the load-bearing cores are compiled in the private
+`indexable-inc/ix` monorepo and distributed as prebuilt artifacts (a Rust rlib,
+a Python wheel, a napi `.node` addon, a wasm bundle) fetched from a public R2
+bucket. The `sdk/` tree carries the wrapper/glue layer and metadata stubs only,
+never the private source.
+
+Read this page first, then the per-language component pages it links.
+
+## Licensing (read before reusing)
+
+Everything under `sdk/` is governed by `sdk/LICENSE` (the Indexable SDK
+License), which supersedes the repo-root MIT for this directory and the compiled
+components the SDK fetches (`sdk/README.md:6-14`). It is source-available, not
+open source: you may build apps that access the hosted ix service, but not
+reverse-engineer, modify, redistribute, or build a competing service. The Rust
+crates set `license-file` (not an SPDX id) and the Python project carries the
+`License :: Other/Proprietary License` classifier so crawlers surface the real
+terms (`sdk/rust/crates/ix-sdk/Cargo.toml:5-9`,
+`sdk/python/pyproject.toml:14-15`).
+
+## Units
+
+| unit | kind | role |
+| --- | --- | --- |
+| `sdk/rust` (`ix-sdk`) | Rust workspace member | public Rust crate; re-exports the wire-protocol surface, links the prebuilt `ix-sdk-wire` rlib. See [rust](rust/overview.md). |
+| `sdk/rust/vendor/ix-sdk-wire` | Rust crate (metadata stub) | self-contained C-ABI wire types; here only as a metadata-faithful stub, the real rlib is fetched from R2. See [rust](rust/overview.md). |
+| `sdk/python` (`ix_sdk`) | Python package | async client wrapper over the native `_ix_sdk` PyO3 extension. See [python](python/overview.md). |
+| `sdk/typescript` (`@indexable/sdk`) | TypeScript package | thin wrapper dispatching to a napi `.node` addon (Node/Bun) or a wasm bundle (browser). See [typescript](typescript/overview.md). |
+| `packages/ix-sdk-python` | Nix package | fetches the prebuilt `ix_sdk` wheel from R2, wraps it as `pkgs.ix-sdk-python`. See [packaging](packaging/overview.md). |
+
+The Rust SDK in this tree is the wire-protocol layer (boundary types + a link
+proof), not a full client. The Python and TypeScript packages are the full
+clients (`Client`, `Branch`, `Sandbox`, ...); their cores are the compiled
+`_ix_sdk` / `ix_sdk.node` / wasm binaries built from `crates/ix/sdk-py`,
+`crates/ix/sdk-ts`, `crates/ix/sdk-wasm` in the private repo.
+
+## How it fits together
+
+```
+your app (Rust / Python / TS / browser)
+  -> language wrapper (sdk/rust, sdk/python, sdk/typescript)
+     -> precompiled core (ix-sdk-wire rlib / _ix_sdk wheel / ix_sdk.node / wasm)
+        -> hosted ix service at base_url (default https://api.ix.dev)
+           Client -> Branch (a microVM) -> exec/fs/secrets/fork/snapshot/...
+```
+
+- **One service, one auth model.** All three SDKs talk to the same hosted ix
+  API. Auth is an API token (a bearer token), passed to the client constructor
+  or resolved from the environment (`IX_TOKEN`, then `IX_API_KEY` for the TS
+  `Sandbox`; `sdk/typescript/src/index.ts:1421`). The base URL defaults to
+  `https://api.ix.dev` (`sdk/typescript/src/index.ts:1428`,
+  `sdk/typescript/README.md:27`); the Python/native client resolves its default
+  internally and exposes it via `Client.base_url`
+  (`sdk/python/ix_sdk/__init__.py:886-888`).
+- **Shared object model.** The same nouns recur across languages: `Client`
+  (auth + account/fleet ops), `Branch` (a running microVM, also surfaced as
+  `VM`/`Sandbox`), `Commit`/`Snapshot` (a paused VM image you can branch or
+  fork), `FsHandle`, `SecretsHandle`, `StreamConnection`, `ExecResult`,
+  `RegionInfo`. The Python `_ix_sdk.pyi` and the TS `native.d.ts` are
+  hand-maintained mirrors of the same Rust binding surface
+  (`sdk/python/ix_sdk/_ix_sdk.pyi:3`, `sdk/typescript/src/native.d.ts:6-9`).
+- **Prebuilt, not built here.** Each package fetches its compiled core from the
+  public R2 bucket by SRI hash; the source-available tree never compiles the
+  private core. The Rust workspace injects the R2 rlib over a stub
+  (`sdk/rust/default.nix:69-93`); `packages/ix-sdk-python` fetches the R2 wheel
+  (`packages/ix-sdk-python/default.nix:24-33`); the TS package loads
+  `../native/ix_sdk.node` or `../dist/ix_sdk.js`, which `build-native.sh`
+  populates (`sdk/typescript/src/index.ts:53-73`).
+- **Default region** is `us-west-1` (`sdk/python/ix_sdk/__init__.py:176`,
+  `sdk/typescript/src/index.ts:81-83`), overridable per call or via `IX_REGION`.
+
+## Invariants
+
+- **Source-available wrapper, private core.** No private ix source ships under
+  `sdk/`. The Rust build even asserts the from-source stub unit is excluded from
+  the consumer closure (`sdk/rust/default.nix:238-254`); the wire stub source is
+  never compiled (`sdk/rust/vendor/ix-sdk-wire/src/lib.rs:3-6`).
+- **Stub fidelity is load-bearing.** The `ix-sdk-wire` stub's Cargo metadata
+  (name, version, edition, deps, profile, lints, toolchain) must match the real
+  crate exactly, because cargo-unit hashes those and not source bytes; a mismatch
+  makes the R2 rlib un-injectable (`sdk/rust/vendor/ix-sdk-wire/Cargo.toml:8-22`,
+  `sdk/rust/default.nix:56-63`).
+- **Type stubs track Rust by hand.** `_ix_sdk.pyi` and `native.d.ts` are
+  hand-synced to `crates/ix/sdk-py` / `sdk-ts`; add a Rust method, add it to the
+  stub (`sdk/python/ix_sdk/_ix_sdk.pyi:3-8`, `sdk/typescript/src/native.d.ts:6-9`).
+- **Async everywhere.** Every network call is async: `async def` in Python,
+  `Promise` in TS. Resources clean up on scope exit (`async with` /
+  `await using` via `__aexit__` / `Symbol.asyncDispose`).
+
+## Glossary
+
+- **Branch**: a running microVM instance; the primary handle for exec, fs,
+  secrets, fork, snapshot. Also surfaced as `VM` (Python) and wrapped by
+  `Sandbox` (TS).
+- **Commit / Snapshot**: a paused, persisted VM image. `branch()` boots a fresh
+  branch from it; `fork()` makes a divergent copy. Python calls it `Snapshot`,
+  the native layer calls it `Commit`.
+- **Sandbox / Repl** (TS): opinionated high-level surface; `Sandbox` is a
+  Client+Branch convenience, `Repl` is a stateful interpreter session over a PTY
+  shell (`sdk/typescript/src/index.ts:1182-1376`).
+- **wire protocol**: the self-contained types crossing the SDK C-ABI boundary,
+  defined by `ix-sdk-wire` (`IxBuf`, `IxError`, error codes;
+  `sdk/rust/crates/ix-sdk/src/lib.rs:12-14`).
+- **cargo-unit / extraUnits**: the `nix-cargo-unit` build system; `extraUnits`
+  is the seam that injects a prebuilt library unit over a from-source one
+  (`sdk/rust/default.nix:174-184`).
+- **R2**: the public Cloudflare R2 bucket hosting the prebuilt rlib/rmeta and
+  wheels (`pub-559bccbc8be94bed84821cb943b580f3.r2.dev`).
+- **abi3 wheel**: the stable-ABI CPython wheel (`cp313-abi3`) the Nix package
+  fetches (`packages/ix-sdk-python/default.nix:26`).
+- **napi-rs / wasm-bindgen**: the two binding generators behind the TS package;
+  napi produces the Node/Bun `.node` addon, wasm-bindgen the browser bundle.
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| rust | [rust/overview.md](rust/overview.md) | `ix-sdk` + the `ix-sdk-wire` stub; wire types and the prebuilt-rlib link proof |
+| python | [python/overview.md](python/overview.md) | `ix_sdk` async client over the native `_ix_sdk` PyO3 extension |
+| typescript | [typescript/overview.md](typescript/overview.md) | `@indexable/sdk`; Sandbox/Repl + Client/Branch over napi or wasm |
+| packaging | [packaging/overview.md](packaging/overview.md) | `packages/ix-sdk-python`: the R2 wheel wrapped as `pkgs.ix-sdk-python` |

--- a/docs/sdk/packaging/overview.md
+++ b/docs/sdk/packaging/overview.md
@@ -1,0 +1,88 @@
+# Python SDK Nix packaging (`ix-sdk-python`)
+
+`packages/ix-sdk-python` is the Nix package that makes the precompiled Python
+SDK bindings available in-repo as `pkgs.ix-sdk-python` /
+`nix build .#ix-sdk-python`. It does not build the SDK: it fetches the prebuilt
+`ix_sdk` wheel from the public R2 bucket by SRI hash and wraps it as a normal
+Python module, the index side of the index <-> ix artifact boundary (ENG-2151,
+`default.nix:10-14`). The wheel's native `_ix_sdk` cdylib is built, stripped, and
+scanned store-clean by ix's `nix/packages/workspace-sdks.nix`, then uploaded to
+R2 with `wrangler`; this consumer only downloads and installs it.
+
+See [python](../python/overview.md) for the `ix_sdk` API the wheel exposes, and
+[common](../common.md) for the cross-SDK prebuilt-artifact model.
+
+## Flake metadata (`package.nix`)
+
+```
+id = "ix-sdk-python"; packageSet = true; flake = true;
+passthruTests.prefix = "ix-sdk-python";
+```
+
+`packageSet = true` puts it in `pkgs` (`pkgs.ix-sdk-python`); `flake = true`
+exposes it as a flake package output (`nix build .#ix-sdk-python`); the
+registry (`packages/registry.nix`) discovers it from this `package.nix`. Tests
+register under the `ix-sdk-python` prefix (`package.nix:1-8`).
+
+## Inputs and the wheel catalog
+
+`default.nix` takes `lib`, `pkgs`, and `python3 ? pkgs.python3`; it matches a
+consumer's interpreter and the wheel is `cp313-abi3`, so 3.13+ is required
+(`default.nix:1-7`). The per-system `catalog` maps `system` to a `{ url; hash; }`
+of the published wheel (`default.nix:24-33`):
+
+- `x86_64-linux`: `ix_sdk-0.1.0-cp313-abi3-manylinux_2_34_x86_64.whl`
+  (`default.nix:25-28`).
+- `aarch64-darwin`: `ix_sdk-0.1.0-cp313-abi3-macosx_11_0_arm64.whl`; its one
+  nix-store dylib (libiconv) is repointed at `/usr/lib` so it loads off-nix
+  (`default.nix:20-23`, `29-32`).
+
+URLs and SRI hashes live here next to the consumer (not in `flake.lock`), so a
+routine bump is: re-publish the wheel to R2 and edit this catalog; each URL path
+embeds the wheel's nix-store hash so distinct builds never collide
+(`default.nix:16-19`). An eval-time assert rejects a non-`https://` URL or a
+non-`sha256-` hash (`default.nix:39-46`). Unsupported systems return an
+eval-safe placeholder derivation that fails loudly at realization with
+instructions, rather than guessing a wheel (`default.nix:48-60`).
+
+## How it builds
+
+For a supported system (`default.nix:61-124`):
+
+1. `pkgs.fetchurl { inherit (entry) url hash; }` downloads the wheel
+   (`default.nix:63`).
+2. `python3.pkgs.toPythonModule (...)` wraps a `runCommand` that unzips the
+   wheel (`python3 -m zipfile -e`) straight into `$out/${sitePackages}` so
+   consumers `import ix_sdk` with no shim (`default.nix:69-90`). `toPythonModule`
+   stamps `pythonModule = python3` so the package composes via
+   `python3.withPackages`; without it nixpkgs' `hasPythonModule` filter silently
+   drops it (the convention from `packages/mcp`, `default.nix:65-68`).
+   `passthru` carries `python3`, `wheel`, and `sitePackages`; `meta.platforms`
+   is the catalog's systems (`default.nix:74-82`).
+3. The result is `overrideAttrs`'d to attach `passthru.tests.import`
+   (`default.nix:118-124`).
+
+## Import / surface test
+
+`importTest` builds a real `python3.withPackages` environment and runs
+`assertSurface` through it, so the `toPythonModule` wiring cannot silently
+regress (`default.nix:104-116`). `assertSurface` (`default.nix:94-102`) imports
+`ix_sdk`, checks `__version__`, and asserts the attributes `ix_sdk` depends on
+downstream:
+
+- module-level `Client`, `Group`, `GroupMember`;
+- `Client` methods `create_group`, `add_group_member`, `create`, `branches`.
+
+Note: `Group`, `GroupMember`, `create_group`, and `add_group_member` are NOT
+present in the source-available `sdk/python/ix_sdk/__init__.py` in this tree
+(verified absent). They exist in the prebuilt wheel, which is compiled from a
+newer/fuller private `crates/ix/sdk-py`. The packaging test therefore validates
+the wheel's surface, which is a superset of the public source mirror. See the
+domain NOTES.
+
+## Consumers
+
+`packages/ix-fleet` is the in-repo consumer: it calls `pkgs.callPackage
+../ix-sdk-python { }` and copies the unpacked `ix_sdk` into its uv-built venv
+site-packages, since the SDK is a prebuilt wheel rather than a uv/PyPI
+dependency (`packages/ix-fleet/default.nix:7-11`, `60-66`).

--- a/docs/sdk/python/overview.md
+++ b/docs/sdk/python/overview.md
@@ -1,0 +1,159 @@
+# Python SDK
+
+`sdk/python` is the `ix-sdk` Python distribution (`pyproject.toml:9`). The
+importable package is `ix_sdk`: a pure-Python, async-first wrapper layer
+(`ix_sdk/__init__.py`, ~1364 lines) over a native PyO3 extension `_ix_sdk` that
+is NOT in this tree. The extension is compiled from the private
+`crates/ix/sdk-py` and ships inside the published wheel (see
+[packaging](../packaging/overview.md)); `ix_sdk/_ix_sdk.pyi` is the
+hand-maintained type stub for it (`_ix_sdk.pyi:1-9`).
+
+See [common](../common.md) for the cross-SDK model, auth, and licensing.
+
+## Packaging metadata
+
+- Distribution `ix-sdk`, version `0.1.0`, `requires-python = ">=3.10"`,
+  `License :: Other/Proprietary License` (`pyproject.toml:9-19`).
+- setuptools backend; `ix_sdk` package data ships `py.typed` and `*.pyi` so
+  consumers get typing (`pyproject.toml:21-29`). The shipped tree is just
+  `__init__.py`, `_ix_sdk.pyi`, `py.typed`; the compiled `_ix_sdk` is added by
+  the wheel build.
+- Note: `requires-python >=3.10` here, but the prebuilt wheel the Nix package
+  fetches is `cp313-abi3` (`packages/ix-sdk-python/default.nix:26`), so a
+  realized `pkgs.ix-sdk-python` needs CPython 3.13+.
+
+## Object model
+
+The wrapper exposes both a low-level client surface and a high-level `VM`/`Snapshot`
+convenience. Two namespaces import from `_ix_sdk`: the raw native classes
+(aliased `_Raw*`) and the public dataclasses/enums re-exported as-is
+(`__init__.py:14-66`). `__all__` (`__init__.py:1294-1353`) is the public API.
+
+### `Client` (`__init__.py:882-1067`)
+
+Constructed with keyword-only `token` and `base_url`, both optional; the native
+`_RawClient(token, base_url)` resolves defaults and `Client.base_url` reports the
+effective URL (`__init__.py:883-888`). All methods are `async`. Key methods:
+
+- Lookup: `get(branch_id)`, `get_by_name(name)`, `find_by_name(name)` (returns
+  `None` on `IxNotFoundError`), `branches()`, `regions()`
+  (`__init__.py:890-922`, `989-993`).
+- Create: `create(image, *, region, name, env, l7_proxy_ports, ipv4,
+  on_progress)` drives `create_with_progress(...)` and drains the progress
+  stream (`__init__.py:945-987`); `build_snapshot_from_oci(image, *, region,
+  ...)` returns a `Snapshot` (`__init__.py:893-913`).
+- VM image ops: `snapshot(*, name)`, `switch_system(*, name, target/system,
+  build_on=...)` (`__init__.py:924-943`).
+- Account: `me()`, `current_username()`, `billing_status()`,
+  `list_api_tokens()`, `revoke_api_token(token_id)` (`__init__.py:995-1011`).
+- Volumes: `get_volume`, `list_volumes`, `list_volume_snapshots`
+  (`__init__.py:1013-1020`).
+- Previews: `create_preview`, `list_previews`, `stop_preview`, `get_preview`,
+  `promote_preview` (`__init__.py:1022-1042`).
+- Observability: `query_logs(...)`, `search_traces(...)`
+  (`__init__.py:1044-1064`).
+
+### `Branch` (`__init__.py:564-733`)
+
+A running microVM. Wraps `_RawBranch` and pre-builds an `FsHandle` and
+`SecretsHandle` (`__init__.py:565-569`). Surface:
+
+- Lifecycle: `id`, `info()`, `delete()`, `pause()` -> `Snapshot`, `start()`,
+  `start_with_progress()`, `restart()`, `snapshot()` -> `Snapshot`, `log()` ->
+  `list[Snapshot]` (`__init__.py:571-595`, `651-652`).
+- Execution: `bash(script, *, working_dir, check=True, quiet=False)`,
+  `exec(command, ...)`, `exec_stream(command, ...)`, `spawn(command, ...)`. When
+  not `quiet`, output is streamed to stdout/stderr via `_stream_to_result`
+  (`__init__.py:127-143`, `596-649`); a non-zero exit with `check=True` raises
+  `CommandError` (`__init__.py:101-124`).
+- Files/secrets: `fs` (`FsHandle`), `secrets` (`SecretsHandle`), `path(...)` ->
+  `RemotePath` (`__init__.py:654-663`).
+- Logs/metrics: `logs_stream(*, stream="workload")`, `logs(*, limit, since,
+  stream)`, `runtime_status()`, `startup_info()`, `metrics()`
+  (`__init__.py:665-684`).
+- Fork/migrate: `fork(snapshot_id=None, *, name)`, `fork_with_progress(...)`,
+  `migrate(*, target_node_id)`, `cancel_migration(id)`, `migration()`
+  (`__init__.py:686-710`).
+- Streams: `subscribe_status()` -> `VmStatusStream`, `console_connect()` /
+  `port_forward(port)` -> `StreamConnection` (`__init__.py:712-719`).
+- `async with branch:` deletes on exit (`__init__.py:721-730`).
+
+### `Snapshot` (`__init__.py:807-877`)
+
+Wraps `_RawCommit` (the native type is `Commit`). `Snapshot.from_oci(image,
+*, token, base_url, region, ...)` is a one-call helper that builds a `Client`
+and calls `build_snapshot_from_oci` (`__init__.py:812-832`). Read-only props
+mirror the `.pyi` `Commit` (`id`, `branch_id`, `parent_id`, `status`,
+`memory_mib`, `manifest_key`, `created_at_millis`; `__init__.py:834-860`).
+`branch(*, name)` boots a fresh branch, `branch_with_progress(...)` returns a
+`StartProgress`, `fork(*, name)` makes a divergent branch
+(`__init__.py:866-877`).
+
+### `VM` (`__init__.py:1120-1291`)
+
+The opinionated high-level handle. `VM.start(snapshot, *, name,
+stream_output=True)` returns an awaitable `_VMContext` that boots a branch and
+(optionally) streams workload logs to stdout; `VM.attach(vm_id, ...)` and
+`VM.get(name, ...)` adopt an existing VM (`__init__.py:1140-1180`). It forwards
+`exec`/`bash`/`spawn`, `read`/`write`/`read_bytes`/`write_bytes`/`list`, and
+`fork`/`snapshot`/`info` to the underlying `Branch`/`FsHandle`
+(`__init__.py:1184-1245`). `close()` cancels the log task then deletes the
+branch, shielded to completion (`__init__.py:1256-1288`, `1109-1118`); `wait()`
+blocks until SIGINT/SIGTERM (`__init__.py:1249-1254`).
+
+### Files: `FsHandle` and `RemotePath`
+
+`FsHandle` (`__init__.py:416-516`) wraps `_RawFsHandle` with text/bytes helpers
+(`read_text`, `write_text`, `read_bytes`, `write_bytes`, `list`) and an async
+`open(path, mode, ...)` that buffers the remote file in a `_VmBytesBuffer`
+(`io.BytesIO` subclass) and flushes dirty bytes back on context exit
+(`__init__.py:244-338`, `466-485`). `_parse_open_mode` enforces Python-style
+mode strings and rejects exclusive `x` (`__init__.py:208-241`). `RemotePath`
+(`__init__.py:343-411`) is a `PurePosixPath`-backed, `os.PathLike` remote path
+with `open`/`read_text`/`write_text`/`read_bytes`/`write_bytes`.
+
+### Progress, streams, secrets
+
+- Progress handles iterate `ProgressEvent`s then yield the final `Branch`:
+  `_ProgressBase` / `_Progress` and the concrete `CreateProgress`,
+  `StartProgress`, `ForkProgress` (`__init__.py:738-798`). `ProgressEvent` is a
+  dataclass built from the native event via `from_native`
+  (`__init__.py:146-172`).
+- `StreamConnection` wraps the raw duplex stream with `read`/`write`/`close` and
+  an async context manager (`__init__.py:521-543`).
+- `SecretsHandle.set/delete/list` (`__init__.py:548-559`).
+
+### Errors
+
+`IxError(RuntimeError)` plus subclasses `IxAuthError`, `IxNotFoundError`,
+`IxValidationError`, `IxRateLimitError`, `IxConflictError`, `IxCapacityError`,
+`IxPaymentError`, `IxUnavailableError`, `IxConnectionError`, `IxTimeoutError`,
+all imported from `_ix_sdk` (`__init__.py:69-79`, `_ix_sdk.pyi:19-29`).
+`CommandError(RuntimeError)` carries `command`, `exit_code`, `stdout`, `stderr`
+and a stderr-tail message for failed `exec`/`bash` (`__init__.py:101-124`).
+
+## Regions and env
+
+`Region` is a `str` type alias; `DEFAULT_REGION = "us-west-1"`,
+`DEFAULT_CREATE_IPV4 = False` (`__init__.py:175-177`). `_default_region()` reads
+`IX_REGION`, falling back to `DEFAULT_REGION` (`__init__.py:801-802`).
+
+## Type stub drift (`_ix_sdk.pyi`)
+
+The stub mirrors `crates/ix/sdk-py/src/` by hand and intentionally omits
+native methods the wrapper does not call (`_ix_sdk.pyi:1-9`). It is the type
+contract for the native `Client`, `Branch`, `Commit`, handles, streams,
+enums (`BranchStatus`, `RuntimeState`, `MigrationPhase`, ...), and data classes
+(`BranchInfo`, `MetricsInfo`, `RuntimeStatusInfo`, ...). Keep it in sync when
+the Rust binding changes.
+
+## How it is built and consumed
+
+`sdk/python` itself has no `default.nix`; it is the source of the wheel built in
+the private repo. The in-repo Nix consumer is
+[packaging](../packaging/overview.md) (`packages/ix-sdk-python`), which fetches
+the prebuilt wheel from R2 and exposes `pkgs.ix-sdk-python` /
+`nix build .#ix-sdk-python`. That package's import test asserts a surface
+(`Group`, `GroupMember`, `create_group`, `add_group_member`) that the wheel
+provides but this source-available `ix_sdk/__init__.py` does not currently
+expose; see [packaging](../packaging/overview.md) and the domain NOTES.

--- a/docs/sdk/rust/overview.md
+++ b/docs/sdk/rust/overview.md
@@ -1,0 +1,120 @@
+# Rust SDK
+
+`sdk/rust` is a two-crate Cargo workspace (`sdk/rust/Cargo.toml:15-20`) that
+demonstrates and exports the ix SDK wire-protocol layer. The public crate
+`ix-sdk` re-exports the boundary types from `ix-sdk-wire`, and the Nix build
+links the real `ix-sdk-wire` rlib fetched from R2 over a metadata-faithful
+source stub, proving the consumer can typecheck and link the prebuilt artifact
+with no private source in its closure. This is the wire layer, not a full HTTP
+client: the `Client`/`Branch` surface lives only in the Python and TypeScript
+packages.
+
+See [common](../common.md) for the cross-SDK model and licensing.
+
+## Member crates
+
+| crate | path | role |
+| --- | --- | --- |
+| `ix-sdk` | `sdk/rust/crates/ix-sdk` | public crate; re-exports the wire surface and a `normalize_error_code` helper; also builds the `ix-sdk-wire-probe` binary |
+| `ix-sdk-wire` | `sdk/rust/vendor/ix-sdk-wire` | metadata-faithful STUB of the private wire crate; exists only to give Cargo a dep edge and to reproduce the prebuilt's unit hash |
+
+Both are `version = "0.1.0"`, `edition = "2024"`, `publish = false`, governed by
+`sdk/LICENSE` via `license-file` (`sdk/rust/crates/ix-sdk/Cargo.toml:1-11`,
+`sdk/rust/vendor/ix-sdk-wire/Cargo.toml:23-35`).
+
+## Public surface (`ix-sdk`)
+
+`crates/ix-sdk/src/lib.rs` re-exports the wire types so consumers reach them
+through `ix_sdk::*` (`src/lib.rs:12-14`):
+
+- `IxBuf`, `IX_BUF_VERSION` - the buffer type and version constant crossing the
+  C-ABI boundary.
+- `Encoder`, `Decoder`, `DecodeError` - serialization of wire messages.
+- `IxError`, `IxErrorCode`, `IxErrorKind` - the structured error surface; error
+  codes are an append-only roster (`strum::VariantArray`-backed) with `0` as the
+  reserved `Unknown` sentinel.
+
+`normalize_error_code(raw: u32) -> u32` (`src/lib.rs:21-24`) round-trips a code
+through `IxErrorCode::from_u32(raw).as_u32()`. The `use` itself is the compile
+gate: those symbols must exist in the injected rlib for the crate to link
+(`src/lib.rs:9-14`).
+
+The `ix-sdk-wire-probe` binary (`[[bin]]`,
+`crates/ix-sdk/Cargo.toml:15-20`, `src/bin/probe.rs`) calls
+`normalize_error_code(0)` and `normalize_error_code(u32::MAX)`, both of which
+fold to `0`, and prints `ix-sdk-wire linked: normalize(0)=0 normalize(MAX)=0`.
+That string is what the Nix proof greps for (`default.nix:236`) to prove the
+prebuilt rlib was linked and run, not merely typechecked.
+
+## The wire stub (`ix-sdk-wire`)
+
+`vendor/ix-sdk-wire` is NOT the real wire crate; its `src/lib.rs` is a trivial,
+never-compiled body (`vendor/ix-sdk-wire/src/lib.rs:1-8`). What matters is its
+Cargo metadata, which must match the real crate exactly because cargo-unit
+folds package identity (name + version), edition, crate-types, features,
+resolved dependency identities, profile, lints, and toolchain id into a
+source-independent unit hash, never the source bytes
+(`vendor/ix-sdk-wire/Cargo.toml:8-22`). The dependencies are pinned to mirror
+ix: `snafu` from the shepmaster git fork (bare URL, rev pinned in `Cargo.lock`)
+and `strum = "0.28"` with `derive` (`Cargo.toml:39-47`). `[lints] workspace =
+true` inherits the workspace lint table so `lint_rustflags` (hence the hash)
+matches (`Cargo.toml:49-50`).
+
+## Profiles and lints (hash inputs)
+
+The workspace `Cargo.toml` reproduces ix's build profile byte-for-byte because
+the profile is a hash input. `[profile.release]` turns on `debug-assertions`
+and `overflow-checks` (`Cargo.toml:29-31`); `[profile.release.package."*"]`
+turns them off for third-party crates (`Cargo.toml:38-40`); and
+`[profile.public-rlib]` is the exact profile the R2 rlib was compiled under:
+`codegen-units=1`, `lto="off"`, `opt-level="z"`, `panic="unwind"`, `strip=true`,
+no debuginfo, plus `-Zlocation-detail=none` and a `/nix/store=/source` path
+remap (`Cargo.toml:50-60`). `cargo-features = ["profile-rustflags"]` opts into
+the unstable per-profile `rustflags` (`Cargo.toml:4`). `[workspace.lints.rust]`
+mirrors ix's deny/allow/warn table (`Cargo.toml:69-86`).
+
+## How it is built and wired (`sdk/rust/default.nix`)
+
+The build links the prebuilt `ix-sdk-wire` rlib WITHOUT its source
+(`default.nix:1-16`):
+
+1. **Fetch from R2 by SRI** (`default.nix:69-76`): `pkgs.fetchurl` pulls
+   `libix_sdk_wire-<hash>.rlib` and `.rmeta` from
+   `r2.dev/rlib/ix-sdk-wire/<wireHash>`; the SRI hash is the store identity, so
+   the URL carries no secret. `wireHash = "a95096d6b0ee69a6"` is the prebuilt's
+   source-independent unit hash (`default.nix:62`).
+2. **Wrap as a library unit** (`default.nix:83-93`):
+   `cargoUnit.mkPrebuiltLibraryUnit` records the rlib, rmeta, and the
+   `wireToolchainId`
+   (`iz0mdcq43pxl3fmxmznc6n38sals6q0x-rust-default-1.98.0-nightly-2026-05-27`,
+   `default.nix:63`). An eval-time assert rejects a wrong toolchain before link.
+3. **Inject over the stub** (`default.nix:174-184`):
+   `cargoUnit.buildWorkspace` is called with `extraUnits` / `extraLibraries`
+   keyed by `wireUnitKey = "ix_sdk_wire-${wireVersion}-${wireHash}"`
+   (`default.nix:98`). The stub's generated key must equal this, or
+   `buildWorkspace`'s C1 assert fires.
+
+To make the generated stub hash equal the prebuilt's, the workspace builds with
+the same toolchain (`ix.languages.rust.toolchain`, `default.nix:39-54`), the
+same `--target` (`hostRustTarget`, `default.nix:120-127`, `144`), the same
+`profile = "public-rlib"` (`default.nix:152`), and the same snafu git tree SRI
+(`outputHashes`, `default.nix:134-137`).
+
+### The proof derivation
+
+`proof` (`default.nix:199-258`) is the end-to-end check, built on the fleet. It
+asserts: (a) the injected unit drv differs from the from-source stub unit drv
+and the unit map resolves to the prebuilt (`default.nix:211-223`); (b) the
+prebuilt unit's `$out` holds the rlib, rmeta, and `nix-support/extern-path`
+(`default.nix:225-229`); (c) running `ix-sdk-wire-probe` prints the expected
+linked-rlib line (`default.nix:231-236`); (d) via `exportReferencesGraph`, the
+from-source stub unit drv is absent from the consumer's build closure while the
+prebuilt unit is present (`default.nix:238-254`).
+
+### Flake wiring
+
+`sdk/rust` has no `package.nix`, so it is not a `nix run .#<name>` flake output.
+It is imported directly by the eval tests
+(`tests/default.nix:21`, `sdkRust = import ../sdk/rust { ... }`) and exposed as
+the check `sdkRustPrebuilt = sdkRust.proof` (`tests/default.nix:5091`), which
+gates the prebuilt-link contract in CI.

--- a/docs/sdk/typescript/overview.md
+++ b/docs/sdk/typescript/overview.md
@@ -1,0 +1,141 @@
+# TypeScript SDK
+
+`sdk/typescript` is the `@indexable/sdk` package (`package.json:2`): a thin
+TypeScript wrapper that runs on Node, Bun, and browsers. It dispatches at
+runtime to one of two precompiled cores - a napi-rs `.node` addon on Node/Bun,
+or a wasm-bindgen bundle over WebTransport in browsers - neither of which is in
+this tree. Both are built from the private `crates/ix/sdk-ts` (napi) and
+`crates/ix/sdk-wasm` (wasm); `src/native.d.ts` is the hand-maintained type
+declaration for the napi binding, mirroring the wasm `.d.ts`
+(`native.d.ts:1-10`).
+
+See [common](../common.md) for the cross-SDK model, auth, and licensing.
+
+## Package metadata
+
+- Name `@indexable/sdk`, version `0.3.0`, ESM (`type: module`),
+  `license: SEE LICENSE IN LICENSE` (`package.json:2-5`).
+- Entry is the TS source itself: `main`/`types` -> `./src/index.ts`
+  (`package.json:6-7`). `exports` also surface the native addon
+  (`./native/ix_sdk.node`) and the wasm bundle (`./dist/ix_sdk.js`)
+  (`package.json:8-12`). Published files: `src`, `native`, `dist`, `LICENSE`
+  (`package.json:13-18`). `engines.node >= 22` (`package.json:19-21`).
+- The wrapper is "intentionally thin": core behavior lives in the Rust SDK;
+  this layer adds `await using`, async iterators, overloads, and typed options
+  (`README.md:38-40`).
+
+## Runtime dispatch (`src/index.ts:32-83`)
+
+`isNodeOrBun()` checks for a global `Bun` or `process.versions.node`
+(`index.ts:34-43`). The `Client` constructor branches on it
+(`index.ts:871-880`):
+
+- **Node / Bun**: `loadNative()` resolves `../native/ix_sdk.node` and loads it
+  through `createRequire` (imported via a runtime-stringified `'node:module'`
+  specifier so browser bundlers do not pull Node types). The `.node` file is
+  populated by `build-native.sh` from the `libix_sdk_ts` cdylib
+  (`index.ts:53-73`).
+- **Browser**: `ensureSdkReady()` runs the wasm-bindgen `init()` once, then
+  constructs the `WasmClient` over native WebTransport (`index.ts:589-598`,
+  `876-879`). Node/Bun never boot the wasm path; browsers never see the native
+  path (`index.ts:9-12`).
+
+Inner handles are typed as unions of the wasm and napi classes, which share
+identical signatures, so each wrapper method delegates straight through
+(`index.ts:600-614`).
+
+## Public surface
+
+### `Client` (`src/index.ts:868-1033`)
+
+Constructed with `ClientOptions { token, baseUrl }` (`index.ts:86-91`). All
+methods return `Promise`. The full surface mirrors the Python `Client` plus the
+richer billing/usage and API-token surface that the napi binding exposes
+(`native.d.ts:564-591`):
+
+- `get(id)`, `getByName(name)`, `branches()`, `regions()`, `currentUsername()`
+  (`index.ts:886-906`).
+- `create(...)` with two overloads (`(image, options, onProgress?)` and
+  `(options, onProgress?)`); it normalizes args and passes `onProgress` through
+  only when the inner `create` accepts it (the napi core does not yet;
+  `index.ts:908-950`). `buildCommitFromOci(options)` returns a `Commit`
+  (`index.ts:952-954`).
+- Account/billing: `me()`, `billingStatus()`, `listApiTokens()`,
+  `createApiToken(options)`, `createTopUpSession(options)`,
+  `usageEvents(options)`, `usageSummary(options)`, `revokeApiToken(id)`
+  (`index.ts:956-994`).
+- Volumes/previews/observability: `getVolume`, `listVolumes`,
+  `listVolumeSnapshots`, `createPreview`, `listPreviews`, `stopPreview`,
+  `queryLogs`, `searchTraces` (`index.ts:996-1032`).
+
+### `Branch` (`src/index.ts:744-864`)
+
+Wraps the inner branch. Surface: `id`, `fs()`, `secrets()`, `info()`,
+`delete()` (also `Symbol.asyncDispose`), `start()`, `restart()`, `pause()`,
+`commit()`, `runtimeStatus()` / `runtimeStatusObservation()`, `metrics()`,
+`fork(name?)`, `migrate(targetNodeId?)`, `cancelMigration(id)`, `migration()`,
+`exec`/`execChecked`/`bash`/`bashChecked` (options objects), `spawn`,
+`logs`/`log`, `consoleConnect()`, `portForward(port)`, `shell(options)`,
+`shellList()`, `subscribeStatus()` (`index.ts:747-863`). The PTY `shell` /
+`ShellSession` / `shellList` surface has no Python equivalent
+(`native.d.ts:507-562`).
+
+### Handles and streams
+
+- `FsHandle` (`index.ts:688-722`): `read`/`write` (options), `readBytes`,
+  `readAllBytes`, `writeAllBytes`, `list`.
+- `SecretsHandle` (`index.ts:726-740`): `set`/`delete`/`list`.
+- `StreamConnection` (`index.ts:618-636`): `read`/`write`/`close` +
+  `Symbol.asyncDispose`. `ShellSession` (`index.ts:640-666`) adds `resize`.
+- `VmStatusStream` (`index.ts:670-684`): `next()` plus `Symbol.asyncIterator`,
+  so `for await (const e of vm.subscribeStatus())` works.
+
+### `Sandbox` (`src/index.ts:1283-1443`)
+
+The opinionated high-level surface over `Client` + `Branch`. Static
+constructors: `oci(image, options)`, `ubuntu(version)`, `python(version)`,
+`node(version)`, `bun(version)`, and `attach(vmId, options)`
+(`index.ts:1290-1343`). Instance methods: `exec(command, {cwd})` (fire-and-forget
+subprocess), `repl(language, options)`, `read`/`write`/`readBytes`/`writeBytes`/
+`list`, `fork(name?)`, `close()`, and `Symbol.asyncDispose`
+(`index.ts:1357-1415`). `buildClient` resolves the token from `options.token`,
+then `IX_TOKEN`, then `IX_API_KEY` (throwing if none), and the base URL from
+`options.baseUrl`, `IX_API_BASE_URL`, else `https://api.ix.dev`
+(`index.ts:1417-1430`). `resolveRegion` uses `options.region`, then `IX_REGION`,
+then the first region the API returns (`index.ts:1432-1442`).
+
+### `Repl` (`src/index.ts:1182-1281`)
+
+A stateful interpreter session over a PTY `shell` (`mode: 'create'`,
+`index.ts:1192-1213`). `exec(code)` frames the code with a random marker, writes
+it to the PTY, and reads until a sentinel line, returning `{ output, exitCode }`
+(`index.ts:1219-1255`). Bash uses a brace-group wrapper with `printf` of the
+exit code; Python and JS use base64 `EXEC:<marker>:<payload>` lines consumed by
+embedded harnesses: `PYTHON_HARNESS` keeps a persistent namespace dict so
+variables survive across `exec` calls (`index.ts:1094-1121`), and `JS_HARNESS`
+uses a shared `vm.createContext` for the same effect (`index.ts:1126-1150`).
+`replCommand` maps `'bash' | 'python' | 'node' | 'bun' | 'typescript'` to the
+launch argv (`index.ts:1152-1164`).
+
+## Region
+
+`Region` is both a type and a frozen runtime constant `{ UsWest1: 'us-west-1',
+UsEast1: 'us-east-1' }`, kept in the TS layer (not a wasm call) so module-load
+and SSR do not trigger wasm init (`index.ts:75-84`).
+
+## Examples (`sdk/typescript/examples/`)
+
+Run with Bun. `sandbox/python.ts` and `sandbox/bash.ts` show stateful REPLs and
+that independent sessions do not share state; `sandbox/fork.ts` forks one
+sandbox into 10 branches with a shared seed file; `minecraft/vanilla.ts` and
+`minecraft/vanilla-ubuntu.ts` use the low-level `Client.create` with env vars to
+boot game servers (`examples/sandbox/*.ts`, `examples/minecraft/*.ts`). Both
+example dirs depend on `@indexable/sdk` via a workspace `*` version
+(`examples/sandbox/package.json:5-6`).
+
+## How it is built and wired
+
+`sdk/typescript` has no `package.nix`/`default.nix`; the napi `.node` and wasm
+`dist/` artifacts are produced in the private repo and dropped into `native/`
+and `dist/` at publish time. There is no in-repo Nix consumer for the TS package
+(unlike the Python wheel; see [packaging](../packaging/overview.md)).

--- a/docs/search/common.md
+++ b/docs/search/common.md
@@ -1,0 +1,168 @@
+# Search
+
+Semantic and full-text code search for index, plus the corpus pipeline that
+feeds it. One shared vector store (Mixedbread) holds the whole fleet's corpus:
+code from every checkout, plus agent and shell history (Claude Code, Codex,
+atuin), bulk exports (Slack, Linear, GitHub, git commits), and journald logs.
+Source adapters turn each of those into embeddable [`Document`]s, the `indexer`
+syncs them into the store (and a durable parquet/Iceberg log), and the `search`
+CLI, the `search` Python binding, and `search-eval` query and grade them.
+Two local-only full-text tools (`file-search`, `fff`) round out the domain but
+do not touch the corpus store.
+
+Read this page first, then the component page for the unit you are touching.
+The load-bearing concepts (the [`Document`] envelope, content addressing, the
+[`Store`]/`Reconciler` contracts) live in [search-core](search-core/overview.md)
+and [source](source/overview.md).
+
+## Units
+
+Everything except `fff` is a Rust workspace member (root `Cargo.toml`). `fff`
+is a pinned third-party Rust toolkit built outside the workspace. Library
+crates (`search-core`, `source/*`, `sink/*`, `lake-iceberg`, `mixedbread`) have
+no flake output; the binaries and wheels do (`nix run`/`nix build .#<id>`).
+
+| unit | role |
+| --- | --- |
+| `packages/search-core` | content-addressed semantic+regex search core: manifest, dedup sync, the [`Store`] backend trait, the query/projection/filter logic. Library. See [search-core](search-core/overview.md). |
+| `packages/search` | read-only semantic + regex search CLI over the shared store (`nix run .#search`). Thin wrapper over `search-core`. See [search](search/overview.md). |
+| `packages/search-py` | PyO3 binding (`import search`): async `semantic`/`grep`/`recent` returning polars frames (`nix build .#search-py`). See [search-py](search-py/overview.md). |
+| `packages/search-eval` | Exa-style retrieval+agentic quality harness for `search` (Python, `nix run .#search-eval`). See [search-eval](search-eval/overview.md). |
+| `packages/indexer` | drives every source adapter and fans documents out to Mixedbread + S3/R2 parquet + the Iceberg lake (`nix run .#indexer`). See [indexer](indexer/overview.md). |
+| `packages/source` (workspace: meta, atuin, claude, codex, debug, git, github, journald, linear, parquet, slack) | source adapters turning each data source into tagged `Document`s, behind the shared `source-meta` envelope/trait. See [source](source/overview.md). |
+| `packages/sink` (workspace: mixedbread, parquet) | reconcile a source's documents into a view: a Mixedbread store, or an S3/R2 parquet corpus log. See [sink](sink/overview.md). |
+| `packages/lake` (iceberg) | the Iceberg corpus lake: append+tombstone document log with snapshot-cursor reads. Library. See [lake](lake/overview.md). |
+| `packages/mixedbread` | minimal async Rust client for the Mixedbread vector store API. Library. See [mixedbread](mixedbread/overview.md). |
+| `packages/file-search` | BM25 file indexer/searcher on Tantivy; local, no corpus store (`nix build .#file-search`). See [file-search](file-search/overview.md). |
+| `packages/fff` | fast file-search toolkit (`fff-mcp` CLI/MCP server + `fff-c` cdylib), third-party (`nix run .#fff`). See [fff](fff/overview.md). |
+| `packages/polars-mixedbread` | PyO3 `scan_mixedbread` polars IO source over a Mixedbread search (`nix build .#polars-mixedbread`). See [polars-mixedbread](polars-mixedbread/overview.md). |
+| `packages/polars-sftp` | PyO3 `scan_sftp` polars IO source over SFTP (`nix build .#polars-sftp`). See [polars-sftp](polars-sftp/overview.md). |
+
+## How it fits together
+
+```
+data source                 adapter (source/*)        sinks (indexer fan-out)        query (read)
+checkout files          ->  search-core code sync  ->  Mixedbread store         <-  search CLI
+~/.claude, ~/.codex     ->  SourceAdapter          ->  + sink-parquet (S3/R2)   <-  search-py (import search)
+atuin db, journald      ->    -> [Document]         ->  + lake-iceberg          <-  scan_mixedbread
+Slack/Linear/GitHub     ->                              (durable corpus log)        search-eval (grades search)
+git history             ->                              \--> consume: log -> Mixedbread (rebuild/catch-up)
+```
+
+- **One Document model, one envelope.** Every record, whatever its source, is a
+  [`source_meta::Document`] (`packages/source/meta/src/lib.rs:199`): an
+  `external_id`, the UTF-8 `body` to embed, a flat `meta_json` (a common
+  [`DocumentMeta`] header flattened to top-level keys, merged with
+  source-specific extras), and a `content_hash`. The canonical metadata key
+  names are `source_meta::keys` (`packages/source/meta/src/keys.rs`), shared by
+  adapters (which write them) and the filter builder (which queries them).
+- **Adapters produce desired state.** A [`SourceAdapter`]
+  (`packages/source/meta/src/lib.rs:219`) turns one corpus into an iterator of
+  `Document`s; a [`Reconciler`] (`...:251`) converges a view (a store, a
+  parquet log, the lake) to that set. The contract: desired state not deltas,
+  idempotent on `(external_id, content_hash)`, source-scoped.
+- **The indexer is the only writer of the corpus.** It opens each selected
+  source, makes one pass over its `documents()`, and fans the set out to every
+  configured sink (`packages/indexer/src/main.rs:1593`). Code repos go straight
+  to Mixedbread via `search-core`'s content-addressed sync; everything else can
+  also land in the durable parquet/Iceberg log, which a separate consume run
+  replays back into Mixedbread.
+- **Reads go through `search-core`.** The `search` CLI, the `search` Python
+  binding, `scan_mixedbread`, and `search-eval` all query the store the indexer
+  populated; none of them index (code sync lives only in `search-core`'s
+  pipeline, used by the indexer, not the read CLIs).
+
+## Invariants
+
+- **content_hash is the hash of the embedded bytes.** `source_meta::hash_body`
+  (`packages/source/meta/src/lib.rs:271`) is the only constructor, formatted
+  `sha256:<hex>`. It is the change-detection key everywhere: a re-sync of
+  unchanged content is a no-op; a changed body re-embeds. For code it equals the
+  manifest's content hash (`packages/search-core/src/content.rs`), which doubles
+  as the store `external_id`, so byte-identical files across many worktrees share
+  one stored embedding.
+- **Code sync never deletes.** A stored code entry is shared across checkouts,
+  so deletion can only be decided by reference counting across every manifest;
+  it lives in a separate GC pass, never in ordinary sync
+  (`packages/search-core/src/sync.rs:1`). Record sources delete only via an
+  explicit `--gc` pass (`MixedbreadReconciler::gc`) or, in the lake, explicit
+  tombstones; absence from a newer pass never deletes.
+- **The store is shared; waits are scoped to the run.** Every embedding wait
+  gates on exactly the ids this pass uploaded, never the store-wide pending
+  counts, so another source's backlog cannot stall a run (ENG-2699,
+  `packages/search-core/src/sync.rs:226`).
+- **Scoped listings are verified.** A reconcile/GC pass that lists by
+  `source == X` rechecks every returned record's own `source` before acting; a
+  backend that drops the filter aborts loudly instead of feeding a store-wide
+  delete set in (`packages/sink/mixedbread/src/lib.rs:92`).
+- **source is the primary scope filter, an open set.** [`Source`] is a string
+  tag, not an enum (`packages/source/meta/src/lib.rs:50`); adding a corpus is a
+  new tag value. Query edges validate user-supplied tags against
+  `KNOWN_SOURCE_TAGS` (`...:62`) because the store silently returns zero hits
+  for a typo.
+- **Code results are worktree-scoped by the manifest; record sources by the
+  server filter.** Search over-fetches and keeps only code whose content hash is
+  in the local manifest (`CodeScope::WorktreeExact`); record sources have no
+  checkout, so their server-side metadata filter is authoritative
+  (`packages/search-core/src/search.rs`).
+- **Auth is uniform.** Every Mixedbread surface resolves `MXBAI_API_KEY`, else
+  the OAuth token written by `mgrep login` (exchanged for a short-lived API JWT),
+  via `mixedbread::auth` (`packages/mixedbread/src/auth.rs`).
+
+## Glossary
+
+- **Document**: one record ready to embed: `external_id`, `body`, flat
+  `meta_json`, `content_hash` (`packages/source/meta/src/lib.rs:199`).
+- **DocumentMeta**: the common header every record carries, flattened to
+  top-level metadata keys (`source`, `external_id`, `content_hash`, `title`,
+  `url`, `timestamp`).
+- **content_hash / external_id**: the sha256 of the embedded body, and the
+  store-stable per-record id. For code they are the same value.
+- **source / source tag**: which corpus a record came from (`code`, `shell`,
+  `slack`, ...); the primary scope filter, an open string set.
+- **manifest**: a checkout's `relative path -> content hash` view, persisted in
+  SQLite, used to scope code search and decide what to upload
+  (`packages/search-core/src/manifest.rs`).
+- **signature**: a content-addressed digest of a manifest's hash set; an
+  unchanged signature lets sync skip the network entirely.
+- **Store**: `search-core`'s backend trait (search/grep/upload/list/facets/...);
+  `MixedbreadStore` is the production impl, `MemoryStore` the test one.
+- **Reconciler**: a view that converges to a source's desired-state documents
+  (Mixedbread, parquet, lake). reconcile keeps absences; replace deletes them.
+- **tombstone**: an explicit lake `op = delete` row; the lake's only deletion
+  path, never inferred from absence (ENG-2696).
+- **slice / version**: the lake's writer identity (`host`, optional `user`) and
+  per-slice revision counter that orders the append-only log.
+- **overfetch / projection**: search asks for more than `top_k`, then projects
+  raw chunks into display hits, dropping out-of-scope code and capping the list.
+- **rerank / agentic / enhance**: second-stage listwise reranking (on by
+  default), multi-round backend search (off by default, slow/costly), and
+  server-side query-to-filter rewriting.
+- **corpus log / lake**: the durable, replayable source of truth (S3/R2 parquet
+  or Iceberg) under the Mixedbread index, which is a materialized view of it.
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| search-core | [search-core/overview.md](search-core/overview.md) | content-addressed core: manifest, dedup sync, Store trait, query/projection/filter |
+| search | [search/overview.md](search/overview.md) | read-only semantic + regex search CLI + pipe-rerank mode |
+| search-py | [search-py/overview.md](search-py/overview.md) | `import search`: async semantic/grep/recent polars frames |
+| search-eval | [search-eval/overview.md](search-eval/overview.md) | Exa-style retrieval + agentic quality harness |
+| indexer | [indexer/overview.md](indexer/overview.md) | sync every source into Mixedbread + parquet + the lake |
+| source | [source/overview.md](source/overview.md) | the source-meta envelope/trait and the adapters ([adapters.md](source/adapters.md)) |
+| sink | [sink/overview.md](sink/overview.md) | Mixedbread reconcile/replace/GC and the parquet corpus log |
+| lake | [lake/overview.md](lake/overview.md) | the Iceberg append+tombstone corpus log with cursor reads |
+| mixedbread | [mixedbread/overview.md](mixedbread/overview.md) | minimal async Rust client for the Mixedbread API |
+| file-search | [file-search/overview.md](file-search/overview.md) | local BM25 file indexer/searcher on Tantivy |
+| fff | [fff/overview.md](fff/overview.md) | third-party fast file-search toolkit (fff-mcp + fff-c) |
+| polars-mixedbread | [polars-mixedbread/overview.md](polars-mixedbread/overview.md) | `scan_mixedbread` polars IO source |
+| polars-sftp | [polars-sftp/overview.md](polars-sftp/overview.md) | `scan_sftp` polars IO source over SFTP |
+
+[`Document`]: source/overview.md
+[`source_meta::Document`]: source/overview.md
+[`DocumentMeta`]: source/overview.md
+[`SourceAdapter`]: source/overview.md
+[`Reconciler`]: source/overview.md
+[`Source`]: source/overview.md
+[`Store`]: search-core/overview.md

--- a/docs/search/fff/overview.md
+++ b/docs/search/fff/overview.md
@@ -1,0 +1,43 @@
+# fff
+
+`packages/fff` packages [fff](https://github.com/dmtrKovalenko/fff), a fast
+file-search toolkit for humans and AI agents, as a repo Nix package. It is a
+third-party Rust tool, not a workspace member: built from a pinned flake source
+input (`fff-src`, `github:dmtrKovalenko/fff/v0.9.1`) with
+`rustPlatform.buildRustPackage`, the external-Rust-tool house style
+(`default.nix:9-11`). It is independent of the corpus stack (`search-core`,
+the Mixedbread store, the source adapters); it is a local file-search toolkit.
+
+## Artifacts
+
+One build emits two artifacts (`default.nix:13-17`):
+
+- `bin/fff-mcp`: the CLI / MCP server over fff's in-memory file index. It is the
+  package `mainProgram` (`nix run .#fff`, `default.nix:80`).
+- `lib/libfff_c.{so,dylib}`: the stable C ABI (crate `fff-c`), a cdylib the
+  `mcp` package loads via ctypes to expose `import fff` in notebook sessions.
+
+`cargoBuildFlags`/`cargoTestFlags` scope the build to `fff-mcp` and `fff-c` in
+one cargo invocation (sharing the dependency compile) rather than the whole
+upstream workspace, which keeps out `fff-nvim`'s mlua/Lua build
+(`default.nix:48-59`). `buildNoDefaultFeatures = true` skips the upstream `zlob`
+feature, which shells out to a system Zig at build time; without it the crate
+falls back to the pure-Rust globset matcher (`default.nix:44-47`,
+`buildNoDefaultFeatures` at `:60`). `postInstall` copies the unhashed
+`libfff_c` cdylib into `lib/` for both Linux `.so` and macOS `.dylib`
+(`default.nix:65-74`).
+
+## Build wiring
+
+`cargoLock.lockFile` reads fff's committed pure-crates.io `Cargo.lock` straight
+from the source, so a rev bump carries the dependency set with no coarse
+`cargoHash` to refresh (`default.nix:27-30`). `nativeBuildInputs` are `cmake` and
+`pkg-config` for libgit2-sys (vendored libgit2) and lmdb-master-sys
+(`default.nix:34-39`).
+
+`package.nix` sets `packageSet`, `flake`, and `overlay = true`, so fff is
+`pkgs.fff` in the repo package set, the `fff` flake output, and available to
+other repo packages through the nixpkgs overlay: the `mcp` package takes
+`pkgs.fff` as an input and bundles the `fff-c` cdylib for its ctypes-backed
+`import fff` (`package.nix:3-10`). It builds on Linux and macOS
+(`meta.platforms = unix`, `default.nix:81`).

--- a/docs/search/file-search/overview.md
+++ b/docs/search/file-search/overview.md
@@ -1,0 +1,75 @@
+# file-search
+
+`packages/file-search` is a BM25 file indexer and searcher built on
+[Tantivy](https://github.com/quickwit-oss/tantivy) (`Cargo.toml:6`). It is a
+purely local full-text tool: it builds an on-disk index over a directory tree
+and answers keyword queries. It does not touch the shared corpus store, the
+Mixedbread client, or any source adapter; it is the lexical counterpart to the
+semantic [`search`](../search/overview.md) stack. Library crate `file_search`
+plus a `file-search` binary (`Cargo.toml:11-17`), `nix build .#file-search`.
+
+## Public surface (`src/lib.rs`)
+
+- [`SearchIndexReader`] (`src/lib.rs:35`): read-only view over an on-disk index.
+  `open(index_dir)` (`src/lib.rs:50`) registers the code tokenizers and builds a
+  reader without taking the writer lock, so many readers run concurrently with at
+  most one writer. `search(query, limit, filter_directory)` (`src/lib.rs:76`)
+  returns the top hits; `filter_directory` restricts to a directory and its
+  descendants.
+- [`SearchIndex`] (`src/lib.rs:96`): read-write handle. `open_or_create`
+  (`src/lib.rs:112`) opens or creates the index (deriving the schema from the
+  on-disk index, not the freshly built one, so an older field order cannot
+  corrupt reads), `index_directory(dir, respect_gitignore)` (`src/lib.rs:156`)
+  walks and indexes, `search(...)` mirrors the reader.
+- [`EphemeralSearch`] (`src/ephemeral.rs:24`): an in-memory BM25 reranker over a
+  `RamDirectory`. `from_texts(texts)` builds a one-shot index; `search(query,
+  limit)` returns `RankResult { id, score }` where `id` is the text's position in
+  the input iterator. For callers that just want to rerank a batch in memory.
+- Re-exports the `repo_walker` walk API and `types::{IndexStats, SearchResult}`
+  (`src/lib.rs:20-23`).
+
+## Indexing (`src/indexing.rs`)
+
+`index_directory` (`src/indexing.rs:79`) first wipes every doc whose `directory`
+lives under the indexed root (a Tantivy `RangeQuery` over the trailing-slash
+`[<root>/, <root>0)` encoding, `src/indexing.rs:91`), so files deleted, renamed,
+or newly gitignored between runs disappear; a walk failure rolls the wipe back so
+a transient error never blows away the previous index (`src/indexing.rs:109`).
+Per-file: files over `MAX_FILE_SIZE` (1 MiB) are skipped, paths are canonicalized
+once so a re-index with an equivalent spelling lines up with the prior
+`path_exact` term, and the file is split into 500-char chunks with 100-char
+overlap (`chunk_content`, `src/indexing.rs:33`), each indexed as its own document
+with a `chunk_offset`. The delete-then-add keys on the untokenized `path_exact`
+term (`src/indexing.rs:196`); deleting via the stemmed `path` field would no-op.
+Per-file read/parse errors are recorded in `IndexStats.errors`, not fatal.
+
+## Schema (`src/schema.rs`)
+
+`build_schema` (`src/schema.rs:4`) defines fields: `path` and `content` and
+`filename` (tokenized with the `CODE_STEMMED_TOKENIZER` from the
+`code-tokenizer` crate, stored, with freqs+positions), `path_exact` (untokenized
+keyword, for exact-match deletes), `chunk_offset` (stored u64), and `directory`
+and `extension` (untokenized keyword strings, so byte-range filters match an
+exact dir plus descendants without catching same-prefix siblings like
+`src-old`).
+
+## CLI (`src/main.rs`)
+
+Two subcommands (`src/main.rs:18-43`): `index <directory> [--no-gitignore]`
+opens-or-creates the index and walks the tree (printing indexed/skipped/error
+counts); `search <query> [--limit N] [--filter PATH]` opens a read-only reader
+and prints `score path[ @offset]`. Search avoids the writer so it can run against
+a shared or read-only index concurrently with an indexing run (`src/main.rs:83`).
+The index dir comes from `--index-dir`, else `FILE_SEARCH_INDEX_DIR`, else
+`<cache>/file-search/index` (`src/main.rs:113`). Query syntax is Tantivy's.
+
+## Build
+
+`default.nix` selects the `file-search` binary from the workspace graph;
+`package.nix` sets `flake`/`packageSet`, so `nix build .#file-search` and
+`pkgs.file-search`. Deps: tantivy, `code-tokenizer`, `repo-walker`, clap, snafu
+(`Cargo.toml:19-24`); a tango-bench benchmark lives at `benches/search_bench.rs`.
+
+[`SearchIndexReader`]: #public-surface-srclibrs
+[`SearchIndex`]: #public-surface-srclibrs
+[`EphemeralSearch`]: #public-surface-srclibrs

--- a/docs/search/indexer/overview.md
+++ b/docs/search/indexer/overview.md
@@ -1,0 +1,125 @@
+# indexer
+
+`packages/indexer` syncs every configured corpus source into Mixedbread (the
+semantic search index) and a durable corpus log (the S3/R2 parquet archive
+and/or the [Iceberg lake](../lake/overview.md)). It is the only writer of the
+shared corpus. Binary `indexer` (`nix run .#indexer`, `default.nix`), plus a
+home-manager module `services.indexer` (`home-module.nix`).
+
+Each source is an adapter implementing
+[`source_meta::SourceAdapter`](../source/overview.md); the indexer drives them
+and fans documents out to [sinks](../sink/overview.md) (`src/main.rs:1-20`). The
+log-as-source-of-truth model: the parquet/Iceberg log is the append-only truth,
+the Mixedbread index a materialized view replayable from it (issues #736, #752).
+
+## Sinks and modes
+
+`main` (`src/main.rs:232`) connects up to three sinks once per run (so a bad
+config fails at startup, not mid-source): the Mixedbread store
+(`--mixedbread-store`, `MixedbreadReconciler`), the S3/R2 parquet sink
+(`--bucket`, `ParquetReconciler`), and the Iceberg lake (`--catalog-uri`,
+`IcebergReconciler`). At least one sink and one source are required.
+
+Two top-level paths:
+
+- **Scan** (default): open each selected source, read its `documents()` once, and
+  reconcile into every sink (`run_sources`, `src/main.rs:795`).
+- **Consume** (exactly one of `--from-parquet-prefix`, `--from-iceberg`,
+  `--from-snapshot`, `--cursor-file`, mutually exclusive, `src/main.rs:260`):
+  replay a corpus log back into Mixedbread/the lake instead of scanning local
+  sources (`run_consume_mode`, `src/main.rs:350`).
+
+## Source selection
+
+History sources (per host/user): `--local` (claude, codex, atuin at default
+paths), `--claude-dir`, `--codex-file`, `--codex-sessions`, `--atuin-db`,
+`--journald-since` (`src/main.rs:125-169`). Bulk exports:
+`--slack-export`, `--linear-export`, `--github-export`, `--git-repo`
+(repeatable). Code: `--code-repo` (repeatable, Mixedbread only, content-addressed
+like a bare `search`, `src/main.rs:171`). Multi-user: `--user NAME:HOME`
+(repeatable) lets one root process index every account, tagging each user's
+records (`src/main.rs:176`); symlinked history paths are skipped so a privileged
+run cannot be a confused deputy (`safe_path_under`, `src/main.rs:1450`).
+
+`--host` tags records (default the system hostname). `--gc` runs a
+garbage-collection pass after a successful sync for export-complete sources
+(slack, linear, github, git): delete records whose `external_id` vanished from
+this run's complete input, plus exact-duplicate file objects from retried
+uploads; with the lake active, the vanished set is appended as explicit
+tombstones (the lake's only deletion path, ENG-2696, `src/main.rs:188`). The
+append-only history sources are never GC'd: their scans are incremental windows,
+not complete snapshots.
+
+## One pass, fan-out (`run_source`, `src/main.rs:1593`)
+
+`run_source` reads the adapter's `documents()` exactly once into a `Vec`
+(`src/main.rs:1613`) and reconciles that one set into the parquet, lake, and
+Mixedbread sinks in turn. A selected source with no sink is an error, not a
+silent no-op. An adapter parse error fails the source before any sink is touched;
+a sink error is collected so a second sink still runs, and every sink failure is
+surfaced. It returns the produced `external_id` set so `--gc` can diff against
+it. Codex's two inputs (prompt log + session rollouts) are one adapter and one
+`run_source` so they share a reconcile and cannot clobber each other
+(`src/main.rs:841`).
+
+## Scan cursor (`src/scan_cursor.rs`)
+
+Per-`(user, source)` input-file cursor (ENG-2698): a history source whose input
+files (size + mtime) are unchanged since its last successful run is skipped
+without re-parsing a single transcript. `snapshot` (`scan_cursor.rs:58`) lstats
+every regular file a source would read (no symlinks below a named root);
+`ScanCursor::unchanged` (`scan_cursor.rs:161`) compares against the stored
+snapshot; `store` (`scan_cursor.rs:191`) writes it atomically (temp + rename)
+only after every sink succeeded. The skip is all-or-nothing per source: the
+durable sinks consume the complete document set (parquet overwrites in full, the
+lake derives tombstones from absences), so a partial parse would erase the
+documents of every file it left out (`scan_cursor.rs:9`). Cursor state lives
+under `--cursor-dir` (the fleet passes systemd's `$STATE_DIRECTORY`); an absent
+or malformed cursor just forces a full reingest.
+
+## Consume modes (`run_consume_mode`, `src/main.rs:350`)
+
+- `--from-iceberg`: fold the whole lake into its current per-source sets and
+  REPLACE each source's Mixedbread records (deleting view records the lake has
+  tombstoned), via `MixedbreadReconciler::replace`.
+- `--from-snapshot <id>`: apply the lake's changes since an explicit cursor
+  (stateless, the caller owns the cursor); prints the snapshot to use next.
+- `--cursor-file <path>`: steady-state lake catch-up; read the cursor, apply the
+  delta, write the new cursor back; an absent/expired cursor falls back to a full
+  rebuild (`run_cursor_consume`, `src/main.rs:499`).
+- `--from-parquet-prefix`: read the per-source `data.parquet` files
+  [`sink-parquet`](../sink/overview.md) wrote and reconcile them into Mixedbread,
+  or, with `--catalog-uri`, fold the parquet archive into the lake
+  (`fold_parquet_into_lake`, `src/main.rs:1135`).
+
+Lake reads (`read_state`, `added_since`) and writes come from
+[lake-iceberg](../lake/overview.md); the parquet reader is
+[source-parquet](../source/overview.md).
+
+## Config and auth
+
+S3/R2 sink flags: `--bucket`, `--endpoint`, `--region` (default `auto`),
+`--prefix` (default `corpus`); keys are host/user/source hive partitions so many
+hosts indexing the same account (e.g. `root`) into one bucket do not clobber each
+other (`src/main.rs:293-313`). Lake flags: `--catalog-uri`, `--warehouse`,
+`--catalog-token`. Auth: Mixedbread via `MXBAI_API_KEY` else the `mgrep login`
+token; S3 via `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`. `INDEX_TIMEOUT` is
+2 minutes for embedding waits (`src/main.rs:44`).
+
+## NixOS / home-manager module
+
+`home-module.nix` exposes `services.indexer`: run the indexer on a timer (default
+daily) as the current user via the portable-services module (a launchd agent on
+macOS, a systemd user unit + timer on Linux). Options map one-to-one onto the
+CLI flags (`local`, `claudeDir`, ..., `bucket`, `mixedbreadStore`, `interval`,
+`environment`). It asserts at least one sink and one source, and warns that
+`environment` is rendered into the world-readable Nix store, so secrets should
+come from a runtime wrapper or the `mgrep login` token, never inlined
+(`home-module.nix:12-18`).
+
+## Build
+
+`default.nix` selects the `indexer` binary from the workspace graph;
+`package.nix` sets `flake`/`packageSet`, so `nix run .#indexer` and `pkgs.indexer`.
+It depends on every `source-*` adapter, `search-core`, `sink-mixedbread`,
+`sink-parquet`, `lake-iceberg`, and the `mixedbread` client (`Cargo.toml:15-31`).

--- a/docs/search/lake/overview.md
+++ b/docs/search/lake/overview.md
@@ -1,0 +1,93 @@
+# lake
+
+`packages/lake` (member `lake/iceberg`, crate `lake-iceberg`) is the Iceberg
+corpus lake: the durable, replayable log under the multi-source search corpus
+(issue #752), succeeding the full-file-overwrite [parquet log](../sink/overview.md).
+One table, `corpus.documents` (`NAMESPACE`/`TABLE`, `src/lib.rs:90`), holds an
+append-only revision log of [`Document`](../source/overview.md) observations.
+Library crate, no flake output; the [`indexer`](../indexer/overview.md) is its
+sole caller. Both the write half (a [`Reconciler`](../source/overview.md)) and
+the read half live in this one crate because they share the table schema, codec,
+catalog connection, and fold (`src/lib.rs:19-22`).
+
+## The log model (`src/lib.rs`, `src/codec.rs`)
+
+Each reconcile pass appends only the documents that are new or changed, tagged
+`op = upsert` (`OP_UPSERT`, `codec.rs:45`). Deletion is never inferred from
+absence: a record missing from a newer pass stays live, so pruned local
+transcripts or a reimaged host cannot erase already-folded history (ENG-2696,
+`src/lib.rs:6-9`). The only deletes are explicit tombstones (`op = delete`,
+`OP_DELETE`) that [`gc`](#write-half) appends for an export-complete source whose
+complete input proves a record vanished.
+
+One row is one observation by one writer **slice** (`host`, optional `user`,
+`codec::Slice`). Current state is a per-slice fold ordered by `version`, the
+slice's revision counter (its previous maximum plus one), which is committed data
+so it survives compaction and wall-clock steps (`codec.rs:11-15`). An
+`external_id` is live while any slice's latest op for it is an upsert, so one
+host's tombstone cannot erase a record another slice still observes
+(`src/lib.rs:11-16`). `observed_at` (epoch ms) is kept for queryability and as
+the freshness arbiter between live replicas of one id in different slices, never
+to order one slice's operations.
+
+The first nine columns are exactly `sink-parquet`'s flat corpus schema, so an
+existing polars/duckdb query ports by adding `op != 'delete'` to its filter;
+`user`, `op`, `observed_at`, `version` are the log's additions
+(`codec.rs:17-19`). A [`Document`] is reconstructed from `external_id`,
+`content_hash`, `body`, `meta_json` alone (`CODEC_COLUMNS`, `codec.rs:68`).
+Nullability rule: `content_hash`/`body`/`meta_json` are null exactly on a
+tombstone; a null on an upsert row is a malformed log and a typed decode error
+(`codec.rs:24-27`).
+
+## Write half
+
+[`IcebergReconciler`] (`src/lib.rs:234`): `new(catalog, ident, host)`
+(`src/lib.rs:248`) sets the slice's host; `with_user(name)` (`src/lib.rs:259`)
+derives a per-account reconciler. `reconcile` (`src/lib.rs:372`, the
+`Reconciler` impl) diffs the writer's slice against the desired set and appends
+only the new or changed documents (per id the fold keeps the newest
+`content_hash`; ids absent from the pass simply remain). `gc`
+(`src/lib.rs:317`) is the explicit deletion path: append tombstones for an
+export-complete source's vanished ids. A conflicted append commit is retried up
+to `COMMIT_ATTEMPTS` (5) times, each reloading the table and re-applying the
+written data files (`src/lib.rs:94`). Returns [`Report`] (`src/lib.rs:205`).
+
+## Read half
+
+- [`read_state`] (`src/lib.rs:449`) folds the whole log into the current
+  per-source [`Document`] sets ([`LakeState`], `src/lib.rs:430`), including
+  sources whose records are all tombstoned, so a full rebuild can also
+  garbage-collect a view.
+- [`added_since`] (`src/lib.rs:518`) walks only the `Append` snapshots a cursor
+  has not seen and returns a [`Delta`] (`src/lib.rs:484`) of upserts and
+  tombstoned ids, so a steady-state view catch-up applies just the change
+  (`Replace`/compaction snapshots rewrite files without adding rows, so the
+  cursor walk follows `Append` only). An expired cursor (snapshot pruned from
+  catalog metadata) is a typed error so the caller can fall back to `read_state`.
+- [`current_snapshot_id`] (`src/lib.rs:473`) returns the cursor to persist for
+  next time.
+
+These feed the indexer's consume modes: `--from-iceberg` (full `read_state` ->
+`replace`), `--from-snapshot`/`--cursor-file` (incremental `added_since` ->
+`apply`).
+
+## Build and connection
+
+[`Config::connect`] (`src/lib.rs:121`) connects a REST catalog (production:
+Cloudflare R2 Data Catalog) over an S3-compatible data plane, with S3
+credentials from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`; tests run the
+same code against iceberg's in-memory catalog. `ensure_table`
+(`src/lib.rs:165`) creates the table if absent. It pins `iceberg` 0.9 (which
+pulls arrow/parquet ^57, an isolated `parquet_57` tree distinct from the
+workspace's 59, `Cargo.toml` / root `Cargo.toml:181`). `package.nix` is
+`inRustWorkspace = true` with `passthruTests`; no flake output.
+
+[`IcebergReconciler`]: #write-half
+[`Report`]: #write-half
+[`read_state`]: #read-half
+[`LakeState`]: #read-half
+[`added_since`]: #read-half
+[`Delta`]: #read-half
+[`current_snapshot_id`]: #read-half
+[`Document`]: ../source/overview.md
+[`Config::connect`]: #build-and-connection

--- a/docs/search/mixedbread/overview.md
+++ b/docs/search/mixedbread/overview.md
@@ -1,0 +1,86 @@
+# mixedbread
+
+`packages/mixedbread` (crate `mixedbread`) is a minimal async Rust client for the
+[Mixedbread](https://www.mixedbread.com) vector store API. It owns HTTP and JSON
+shapes only, no domain logic, so it backs the search stack
+([`search-core`](../search-core/overview.md)'s `MixedbreadStore`, the
+[sinks](../sink/overview.md), the [indexer](../indexer/overview.md)) and the
+[`polars-mixedbread`](../polars-mixedbread/overview.md) binding alike. Library
+crate, no flake output; `passthruTests` runs its (wire-shape) tests in CI.
+
+## Endpoints (`src/lib.rs`)
+
+[`Client`] (`src/lib.rs:592`) covers: store create/get (`/v1/stores`); the
+two-step file upload (`/v1/files` then `/v1/stores/{store}/files`), file listing,
+per-file status, and delete; search (`/v1/stores/search`), regex grep
+(`/v1/stores/grep`), metadata-only chunk listing (`/v1/stores/list-chunks`),
+question-answering (`/v1/stores/question-answering`), query enhancement
+(`/v1/stores/queries/enhance`), metadata facets (`/v1/stores/metadata-facets`),
+the standalone reranker (`/v1/rerank`-style `rerank`), and the per-store event
+histogram (`src/lib.rs:1-12`). The methods (all `pub async fn`):
+`ensure_store` (`:698`), `list_files` (`:725`), `upload_file` (`:767`),
+`file_status` (`:817`), `delete_file` (`:834`), `search` (`:848`), `grep`
+(`:885`), `list_chunks` (`:925`), `ask` (`:957`), `enhance_query` (`:1001`),
+`rerank` (`:1032`), `store_status` (`:1066`), `metadata_facets` (`:1092`),
+`events_histogram` (`:1126`).
+
+## Construction and auth
+
+`Client::new(base_url, api_key)` (`src/lib.rs:603`), `from_env` (the
+`MXBAI_API_KEY` env var only, `src/lib.rs:617`), or `from_login`
+(`src/lib.rs:632`): the production path, which resolves the credential via
+`auth::resolve_token` (`src/auth.rs:39`), preferring `MXBAI_API_KEY` and
+otherwise reading the OAuth token `mgrep login` wrote at `~/.mgrep/token.json`
+and exchanging it for a short-lived API JWT at the platform auth endpoint
+(`PLATFORM_URL`, the same exchange the `mgrep` CLI does, `src/auth.rs:18`).
+`DEFAULT_BASE_URL` is `https://api.mixedbread.com` (`src/lib.rs:30`);
+`API_KEY_ENV` is `MXBAI_API_KEY` (`src/lib.rs:40`).
+
+## Reliability
+
+Every request is bounded: a 30s connect timeout and a 2-minute request timeout
+(`bounded_http_builder`, `src/lib.rs:95`), so a shed stream surfaces as a
+retryable transport error rather than an unbounded await (this once wedged the
+leader's reconcile bootstrap for over an hour, `src/lib.rs:81-89`). Retryable
+statuses (429 and 5xx) are retried up to `MAX_RETRIES` (6) honoring the server's
+`Retry-After`, otherwise equal-jitter exponential backoff from `BACKOFF_BASE`
+(500ms) capped at `BACKOFF_CAP` (30s) (`src/lib.rs:60-75`). Listing pages at
+`LIST_PAGE_SIZE` (100, the API max) following a cursor (`src/lib.rs:32-37`).
+External ids are percent-encoded into URL paths (a `/` in `github:org/repo` would
+otherwise split the route) via the `PATH_SEGMENT` set (`src/lib.rs:42-58`).
+
+## Types and filters
+
+Option/result types: [`SearchOptions`] (`src/lib.rs:350`), [`QaOptions`]
+(`src/lib.rs:387`), [`Rerank`] (`src/lib.rs:197`, `DEFAULT_RERANK_MODEL =
+mixedbread-ai/mxbai-rerank-v3-listwise`, `src/lib.rs:186`), [`Agentic`] /
+`AgenticConfig` (`src/lib.rs:251`), [`Chunk`] (`src/lib.rs:450`, a search hit),
+[`StoredFile`] (`src/lib.rs:433`), [`FileStatus`] (`src/lib.rs:562`),
+[`FacetLimits`] / `FACETS_MAX_FILES` (100000, `src/lib.rs:501`), `EventType`,
+`StoreStatus`, `HistogramBucket`.
+
+The `filter` module (`src/filter.rs`) is the metadata filter DSL: a recursive
+[`Filter`] of leaf [`Condition`]s (`{key, operator, value}`) and [`Group`]s
+(`all`/`any`/`none`), mirroring the API's wire shape across search, grep,
+question-answering, and file listing (`src/filter.rs:1-9`). [`Operator`]
+(`src/filter.rs:29`) serializes to the exact API tokens (`eq`, `not_eq`, `gt`,
+`gte`, `in`, `like`, `starts_with`, `regex`, ...). It is `Deserialize` too, so a
+caller passing a JSON-built filter (the polars binding) parses it into the typed
+DSL rather than an unchecked blob. The `enhance` module
+(`src/enhance.rs`) carries `EnhancedQuery`/`FilterMode`/`SortDirection` for the
+query-enhance endpoint. `search-core` re-exports these types so its consumers
+depend only on `search-core`.
+
+[`Client`]: #endpoints-srclibrs
+[`SearchOptions`]: #types-and-filters
+[`QaOptions`]: #types-and-filters
+[`Rerank`]: #types-and-filters
+[`Agentic`]: #types-and-filters
+[`Chunk`]: #types-and-filters
+[`StoredFile`]: #types-and-filters
+[`FileStatus`]: #types-and-filters
+[`FacetLimits`]: #types-and-filters
+[`Filter`]: #types-and-filters
+[`Condition`]: #types-and-filters
+[`Group`]: #types-and-filters
+[`Operator`]: #types-and-filters

--- a/docs/search/polars-mixedbread/overview.md
+++ b/docs/search/polars-mixedbread/overview.md
@@ -1,0 +1,87 @@
+# polars-mixedbread
+
+`packages/polars-mixedbread` is a [Polars](https://pola.rs) IO source backed by
+[Mixedbread](https://www.mixedbread.com) store search. `scan_mixedbread(query,
+store=...)` returns a lazy `pl.LazyFrame` whose rows are the hits of one search,
+with file metadata flattened into typed columns, so you can do in Polars
+everything Mixedbread does not, above all `group_by` (README:1-6). PyO3 cdylib
+plus a Python wrapper; `nix build .#polars-mixedbread`.
+
+## Split: thin Rust, logic in Python
+
+The Rust crate is deliberately thin (`src/lib.rs:1-15`): `search_mixedbread`
+(`src/lib.rs:54`) reuses the workspace [`mixedbread`](../mixedbread/overview.md)
+client (HTTP, retry, auth, the filter DSL), blocks on one async search, and
+converts the `mixedbread::Chunk`s into a dict of column-name to list, always six
+columns: `text`, `score`, `filename`, `start_line`, `num_lines`, `metadata` (the
+raw JSON string). `filters` arrives as a JSON string (the recursive filter
+shape) and is pushed server-side. Auth mirrors the `search` surface
+(`MXBAI_API_KEY`, else the `mgrep login` token). Polars never appears on the Rust
+side, so there is no Rust/Python Polars version coupling (unlike
+[`polars-sftp`](../polars-sftp/overview.md), which decodes in Rust)
+(`src/lib.rs:12`).
+
+Everything else lives in the Python wrapper
+(`python/polars_mixedbread/__init__.py`), where the runtime Polars is:
+`scan_mixedbread` (`__init__.py:110`) registers an IO source via
+`register_io_source`, flattens declared metadata keys out of the JSON `metadata`
+column into typed columns, applies the predicate, and applies projection and the
+row limit.
+
+## Predicate pushdown
+
+One unified API: you filter with ordinary Polars expressions, and the source
+parses the predicate and pushes the parts that map to a Mixedbread metadata
+filter (string `==`/`!=` on a metadata column, combined with `&`/`|`/`~`)
+server-side (`_pushdown.pushdown`); anything else (a `score` threshold, `is_in`,
+substring) runs client-side. The full predicate is always re-applied locally, so
+every returned row satisfies it (`__init__.py:182-186`).
+
+Pushdown is not transparent, and that is the point of a search source: a pushed
+filter is applied by Mixedbread BEFORE ranking and `top_k`, so you get the
+`top_k` best hits within the filter; the same predicate written so it cannot push
+(`is_in(["code"])` vs `== "code"`) filters after ranking and can return a
+different set (both correct, README:30-38). Only string columns push down (string
+equality is unambiguous); a non-string declared column still filters and groups,
+just in Polars.
+
+## top_k, min_results, depth
+
+`top_k` is retrieval depth (how many ranked hits come back), not a final row
+count. A server-pushed filter applies before `top_k` (up to `top_k` of the
+filtered set); a client-side filter applies after (can leave fewer). For a final
+cap use Polars' `.head(n)`. For an output floor, pass `min_results=N`: a
+client-side filter that trims below N triggers a re-search with a growing `top_k`
+(doubling, `_overfetch.grow_until`) until N rows survive or the store is
+exhausted; `max_top_k` is the hard ceiling (README:47-75). `scan_mixedbread`
+parameters (`__init__.py:110`): `query`, `store` (name or list, default `index`),
+`top_k`, `min_results`, `max_top_k`, `base_url`, `rerank` / `reranker`,
+`agentic`, `score_threshold`, `metadata_columns`.
+
+## Columns
+
+`_INTRINSIC` (the six always-present, `__init__.py:91`) plus one typed column per
+`metadata_columns` entry; the default surfaces the `index` store's keys
+(`source`, `repo`, `path`, `title`, `__init__.py:103`). Point it at another store
+by passing that store's keys. The raw `metadata` column is always present, so
+undeclared keys stay reachable via `pl.col("metadata").str.json_decode()`.
+
+```python
+from polars_mixedbread import scan_mixedbread
+lf = scan_mixedbread("how does retry backoff work", store="index", top_k=500)
+lf.filter(pl.col("source") == "code").group_by("repo").agg(pl.len()).collect()
+```
+
+Bad fit for a full table scan or store-wide aggregation: this is top-k
+retrieval, so a `group_by` aggregates only the retrieved window
+(README:108-113).
+
+## Build
+
+`package.nix` is `inRustWorkspace = true` (the cdylib is built by the shared
+unit graph, reusing the `mixedbread` client) with `flake`/`packageSet`, so
+`nix build .#polars-mixedbread`; `default.nix` only packages the wheel. It is
+cross-platform (consumed inside the Nix env, e.g. the MCP Python session, not
+redistributed, so darwin needs no install-name fixups, `package.nix:6-9`). The
+pure-Python pushdown test surfaces as the CI check
+`checks.<system>.polars-mixedbread-pushdown` (`package.nix:12-16`).

--- a/docs/search/polars-sftp/overview.md
+++ b/docs/search/polars-sftp/overview.md
@@ -1,0 +1,63 @@
+# polars-sftp
+
+`packages/polars-sftp` is a [Polars](https://pola.rs) IO source that reads a
+remote file over SFTP and hands it back as a lazy `LazyFrame`. Point
+`scan_sftp(host, path, ...)` at a parquet, IPC, CSV, or NDJSON (`.jsonl`) file on
+an SSH host and query it like any other Polars source (README:1-18). PyO3 cdylib
+plus a Python wrapper; `nix build .#polars-sftp`. Included in the search domain
+as a data-access source for the corpus stack (e.g. reading remote NDJSON exports
+into Polars), independent of the Mixedbread store.
+
+## Split: Rust reader, Python plugin
+
+The IO-plugin interface is Python by design (Polars moves data zero-copy over
+Arrow FFI), so the surface is split (README:24-36):
+
+- **Rust core** (`src/lib.rs`, a PyO3 cdylib): opens the SFTP connection with
+  [`ssh2`](https://crates.io/crates/ssh2), reads the file fully into memory, and
+  decodes it with Polars' own parquet/IPC/CSV/NDJSON readers into a
+  `DataFrame` returned as a `pyo3_polars::PyDataFrame` (`src/lib.rs:1-14`).
+  Because it decodes in Rust, the crate's `polars` version is pinned to match the
+  Python-side Polars so the Arrow-FFI transfer lines up (unlike
+  [`polars-mixedbread`](../polars-mixedbread/overview.md), which never touches
+  Polars in Rust). `resolve_format` (`src/lib.rs:37`) infers the format from the
+  extension or an explicit `storage_format` hint.
+- **Python wrapper** (`python/polars_sftp/__init__.py`): `scan_sftp` probes the
+  schema, then `register_io_source`s a generator that calls the Rust reader with
+  the engine's projected columns and row limit and applies the predicate.
+
+## API and auth
+
+```python
+scan_sftp(host, path, port=22, username=None, password=None,
+          private_key="~/.ssh/id_ed25519", storage_format=None,
+          timeout_ms=30_000, check_host_key=True)
+```
+
+Authentication is tried in order: explicit `password`, then a `private_key`
+file, then the SSH agent; `username` defaults to `$USER` (README:38-47). The
+server's host key is checked against `~/.ssh/known_hosts` before any credential
+is sent (a recorded mismatch is rejected as a possible MITM; an unrecorded host
+is trust-on-first-use); `check_host_key=False` skips it. `timeout_ms` bounds
+connect and read. `storage_format` (`"parquet"`|`"ipc"`|`"csv"`|`"ndjson"`)
+overrides the extension guess.
+
+## Known limitations
+
+- The remote file is fetched in full and decoded in memory (Polars' readers need
+  `MmapBytesReader`, which an `ssh2::File` is not), so projection trims decode and
+  output, not the bytes pulled over the wire (`src/lib.rs:10-14`, README:67-72).
+- One chunk per scan: the reader does not stream row groups, so `batch_size` is a
+  no-op.
+- The wheel links `libssh2`/`openssl` from the Nix store by rpath, so it runs in
+  this Nix environment; it is not a portable manylinux wheel (README:75).
+
+## Build
+
+`default.nix` builds the standalone cdylib (vendored `Cargo.lock`) with
+`rustPlatform.buildRustPackage`, links the nix `libssh2`/`openssl` via
+`OPENSSL_NO_VENDOR` + `LIBSSH2_SYS_USE_PKG_CONFIG` (no vendored C build), and
+packages the abi3 wheel with `wheel/mkwheel.py`, stamping per-platform tags for
+the four Linux/darwin systems (`default.nix:22-30`, `:62-86`). `package.nix` sets
+`flake`/`packageSet`, so `nix build .#polars-sftp`. The Rust `polars` and the
+runtime Python `polars` must be the matching release.

--- a/docs/search/search-core/internals.md
+++ b/docs/search/search-core/internals.md
@@ -1,0 +1,109 @@
+# search-core: query, projection, and filters
+
+The read layer of [search-core](overview.md): how a backend result set becomes
+displayable hits, how code is scoped to a worktree, how a recency feed and a
+census are built, how a hit expands into its surrounding conversation, and how
+scope selectors become a server-side metadata filter. Source files:
+`src/search.rs`, `src/context.rs`, `src/query_filter.rs`, `src/repo.rs`.
+
+## Projection (`src/search.rs`)
+
+The store holds one shared entry per unique record across every source, so a raw
+result can include code from other worktrees. `project` (`src/search.rs:553`)
+decides what survives, per source (`src/search.rs:509`, `display_hit`):
+
+- **Code** in `CodeScope::WorktreeExact` is kept only when its content hash is in
+  this checkout's manifest, then relabeled to the local path; in
+  `CodeScope::ServerFiltered` (a repo / all-repos query) the server filter
+  already decided, so code passes through labeled by its stored path
+  (`src/search.rs:528`).
+- **Record sources** (slack, linear, claude_history, ...) have no checkout, so
+  the server-side metadata filter is authoritative and they always pass through
+  (`src/search.rs:544`).
+- **Web** hits pass through only when the caller asked for them, line metadata
+  stripped (`src/search.rs:517`).
+
+[`overfetch`] (`src/search.rs:499`) asks the backend for `4*top_k` (min
+`top_k+10`) so client-side filtering still leaves a full page. [`DisplayHit`]
+(`src/search.rs:55`) is the projected hit; it serializes to the stable
+`search --json` object (`label` renamed to `path`, absent provenance keys
+skipped), the same shape the [`search-py`](../search-py/overview.md) dict uses.
+
+[`RenderMode`] (`src/search.rs:36`): `Full` passes every chunk; `Compact`
+collapses overlapping chunks of one document to the best-scoring one (refilling
+from the overfetch buffer so `top_k` distinct documents still return) and caps
+each snippet at `COMPACT_SNIPPET_CHARS = 400` (`src/search.rs:32`).
+
+## Query verbs (`src/search.rs`)
+
+- [`semantic`] (`src/search.rs:170`): search the store (plus the web store when
+  `include_web`), project the hits.
+- [`grep`] (`src/search.rs:198`): regex over the same chunks; local-corpus only.
+- [`recent`] / [`ranked`] (`src/search.rs:224`): a metadata-only chunk listing
+  sorted by descending `timestamp` (or any `SortBy`); no semantic scoring, so
+  scores are the API placeholder.
+- [`ask`] (`src/search.rs:390`): question-answering. The backend's
+  `<cite i="N"/>` markers index its raw over-fetched source list; `align_citations`
+  (`src/search.rs:432`) rewrites them to `[n]` over the projected `sources`,
+  appending a cited-but-past-`top_k` hit so the citation still resolves and
+  dropping a marker whose source was excluded ([`AnswerView`], `src/search.rs:139`).
+- [`stats`] (`src/search.rs:319`): a per-source census. One discovery facet call
+  finds which `source` tags exist (a bounded scan, `FACETS_MAX_FILES`), unioned
+  with `KNOWN_SOURCE_TAGS`; each candidate is then counted by its own
+  source-scoped facet call and probed for freshness with a single-chunk ranked
+  listing, all concurrently. A source bigger than the scan bound reports the cap,
+  marked [`SourceStat`]`.truncated` (`src/search.rs:282`).
+
+## Conversation context (`src/context.rs`)
+
+[`context`] (`src/context.rs:50`) expands one record into the conversation around
+it. Given a hit's `external_id`, it lists the record's own chunks (resolving its
+`session_id` and `timestamp`), then `window_around` (`src/context.rs:102`)
+fetches `before` earlier and `after` later turns of the same session AND source
+(a transcript shares its session id with its debug log, so both are scoped),
+ordered by timestamp, one turn per record. Sources with no session (git, github,
+code) fall back to the record's own chunks in document order; a bare session id
+lists that session from its start (`src/context.rs:184`). [`ContextView`]
+(`src/context.rs:28`) carries the turns and the anchor index.
+
+## The metadata filter builder
+
+[`FilterSpec`] (`src/query_filter.rs:13`) is the scope selectors a caller
+applies: `sources` / `exclude_sources`, `repo`, `users`, `hosts`, `projects`,
+and a `since`/`until` epoch-second window. [`build_filter`]
+(`src/query_filter.rs:104`) turns it into a `mixedbread::Filter`: an `in` over
+`source`, a `none` over excluded sources, `eq` on `repo`, `in` over user/host/
+project, and inclusive `gte`/`lte` on `timestamp`, combined under `all` when
+more than one clause is present, or `None` (search everything) when empty. One
+builder, shared by the CLI, the Python binding, and the MCP tool, so the mapping
+lives in one place (`src/query_filter.rs:1`).
+
+[`parse_time_spec`] (`src/query_filter.rs:73`) accepts a bare integer (epoch
+seconds) or a relative span `<n><unit>` with unit `s`/`m`/`h`/`d`/`w` resolved
+against `now`, so both query edges accept the same `--since 7d` grammar.
+
+## Repo slug (`src/repo.rs`)
+
+[`repo_slug`] (`src/repo.rs:18`) derives a stable per-checkout name: the
+`origin` remote URL parsed to `owner/repo` (so every worktree of one repo shares
+a slug, `RepoSlug::Remote`), falling back to the directory name
+(`RepoSlug::Local`) when there is no remote, never a silent empty string. This
+is what scopes the sync dedup listing and the `--repo` query filter.
+
+[`overfetch`]: #projection-srcsearchrs
+[`DisplayHit`]: #projection-srcsearchrs
+[`RenderMode`]: #projection-srcsearchrs
+[`semantic`]: #query-verbs-srcsearchrs
+[`grep`]: #query-verbs-srcsearchrs
+[`recent`]: #query-verbs-srcsearchrs
+[`ranked`]: #query-verbs-srcsearchrs
+[`ask`]: #query-verbs-srcsearchrs
+[`stats`]: #query-verbs-srcsearchrs
+[`AnswerView`]: #query-verbs-srcsearchrs
+[`SourceStat`]: #query-verbs-srcsearchrs
+[`context`]: #conversation-context-srccontextrs
+[`ContextView`]: #conversation-context-srccontextrs
+[`FilterSpec`]: #the-metadata-filter-builder
+[`build_filter`]: #the-metadata-filter-builder
+[`parse_time_spec`]: #the-metadata-filter-builder
+[`repo_slug`]: #repo-slug-srcrepors

--- a/docs/search/search-core/overview.md
+++ b/docs/search/search-core/overview.md
@@ -1,0 +1,176 @@
+# search-core
+
+`packages/search-core` is the content-addressed semantic code search core:
+content hashing, the local manifest, dedup-aware sync, the backend `Store`
+trait, and the query/projection/filter logic. It is a library (crate
+`search_core`, `packages/search-core/Cargo.toml:12`); the [`search`](../search/overview.md)
+CLI, the [`search-py`](../search-py/overview.md) binding, and the
+[`indexer`](../indexer/overview.md) all depend on it. No flake output; it is a
+workspace unit.
+
+The design in one paragraph (`src/lib.rs:1-16`): files are identified by the
+hash of their bytes, not their path, so byte-identical files across many
+worktrees, branches, or repos share a single stored embedding. Sync uploads
+only content the store is missing and never deletes. A local [`Manifest`]
+records this checkout's `path -> hash` view; search over-fetches from the shared
+store and keeps only hits whose hash is in the manifest, so results reflect the
+current tree. There is no daemon: each run rebuilds the manifest cheaply (mtime
+skips re-hashing) and uploads what is new.
+
+## Modules (`src/lib.rs:23-35`)
+
+- **`content`** - [`ContentHash`], `sha256:<hex>` over a file's bytes; doubles
+  as the Mixedbread `external_id`, which is what makes the store dedup
+  (`src/content.rs:12`).
+- **`manifest`** - [`Manifest`]/[`FileEntry`]: build by walking a root, persist,
+  and the content [`signature`](#manifest-and-signature). See below.
+- **`db`** - SQLite persistence of every checkout's manifest, keyed by
+  `(root, rel_path)`, plus the per-`(root, store)` synced signature
+  (`src/db.rs`).
+- **`backend`** - the [`Store`] trait and `MemoryStore` test impl, plus the
+  query option/hit/provenance types (`src/backend.rs`).
+- **`adapter`** - [`MixedbreadStore`], the production `Store` over the
+  [`mixedbread`](../mixedbread/overview.md) client (`src/adapter.rs`).
+- **`sync`** - dedup-aware upload and `wait_until_indexed` (`src/sync.rs`).
+- **`pipeline`** - `index_and_{semantic,grep,answer}`: build the manifest, embed
+  new files, then query, in one call (`src/pipeline.rs`).
+- **`search`, `context`, `query_filter`, `repo`, `config`** - the read/query
+  layer (projection, conversation windows, the metadata filter builder, repo
+  slug derivation, runtime limits). See [internals](internals.md).
+
+## Content addressing and dedup
+
+[`ContentHash::of_bytes`] (`src/content.rs:23`) formats `sha256:<hex>`. Two
+uploads with the same content produce the same `external_id`, so the second is a
+store no-op the sync skips. The crate re-exports `source_meta::Document`,
+`Source`, `RepoSlug`, and `hash_body` (`src/lib.rs:64`), so the content hash a
+code file gets here is the same `content_hash` every other source uses (see
+[source](../source/overview.md)).
+
+## Manifest and signature
+
+[`Manifest::build`] (`src/manifest.rs:66`) walks `root` with the `repo-walker`
+crate (a separate package), honoring gitignore and skipping
+binary/oversized/empty files. Enumeration is sequential; the expensive
+read+sha256 runs in parallel over rayon. A `previous` manifest lets an unchanged
+file (matching mtime and size) reuse its prior hash with no disk read
+(`src/manifest.rs:96`), so a re-run is a cheap negative check.
+
+- [`Manifest::hashes`] (`src/manifest.rs:123`) is the set search intersects
+  against.
+- [`Manifest::signature`] (`src/manifest.rs:136`) is a sha256 over the sorted,
+  deduped content-hash set: path-independent, so a pure rename does not change
+  it (a content-addressed store needs no re-upload for a move), but an edit
+  does. Sync compares it against the last synced signature to skip the network
+  entirely when nothing changed.
+- [`Db`] (`src/db.rs:37`) stores every checkout's entries in one shared SQLite
+  DB at `<cache>/semantic-search/index.db` (`src/db.rs:224`), keyed by
+  `(root, rel_path)`, in WAL mode with a busy timeout so several `search`
+  processes share it. `save` is transactional and removes stale rows for that
+  root only, never touching a sibling worktree's rows (`src/db.rs:143`). The
+  `synced` table keys the signature by `(root, store)` so switching stores
+  forces a fresh sync (`src/db.rs:207`).
+
+## Dedup-aware sync (`src/sync.rs`)
+
+[`sync`] (`src/sync.rs:64`) uploads every manifest file whose content is not
+already in the store:
+
+1. `ensure_store`, then list existing `external_id`s scoped by
+   `source == code AND repo == <slug>` (`src/sync.rs:89`): listing the whole
+   shared store unfiltered is the dominant first-run stall, so dedup is scoped
+   per repo. A too-narrow scope only ever re-uploads a byte-identical blob (a
+   cheap idempotent overwrite by content hash), never duplicates or corrupts.
+2. Keep only hashes the store lacks, collapsing duplicate content within the
+   checkout, refuse if over `max_files`, then upload at concurrency 16.
+3. Each file becomes a code [`Document`] whose `external_id`, `content_hash`,
+   and manifest hash are all the same value, with `source: "code"`, `repo`, and
+   `path` in `meta_json` (`code_document`, `src/sync.rs:202`).
+4. [`SyncReport`] (`src/sync.rs:39`) names `uploaded_ids` so the caller's wait
+   covers only this run's files.
+
+The deliberate departures from the prior `mgrep` tool, stated at
+`src/sync.rs:1`: content addressing (one embedding per blob across N worktrees)
+and never deleting in ordinary sync (deletion needs cross-manifest refcounting,
+a separate GC pass).
+
+[`wait_until_indexed`] (`src/sync.rs:245`) polls per-file status for exactly the
+uploaded ids and returns once each has settled (embedded, failed, cancelled, or
+deleted) or `timeout` elapses. It never consults the store's aggregate pending
+counts, so an unrelated source's backlog cannot stall the wait (ENG-2699).
+
+## The Store backend (`src/backend.rs`)
+
+[`Store`] (`src/backend.rs:206`) abstracts the vector store so sync and search
+run against `MemoryStore` in tests and `MixedbreadStore` in production. Methods
+return `impl Future + Send` rather than `async fn` so callers can add the `Send`
+bound the concurrent paths need (`src/backend.rs:8`). The surface:
+`ensure_store`, `list_external_ids`, `list_records`, `upload`, `delete`,
+`search`, `grep`, `list_chunks`, `facets`, `ask`, `store_status`, `file_status`.
+
+Hit and option types live here: [`SearchHit`] with its [`Provenance`]
+(`src/backend.rs:114`), [`SearchOptions`]/[`AskOptions`]/[`GrepOptions`]
+(`src/backend.rs:25`), [`StoreStatus`], and [`StoredRecord`] (the listed record
+with `content_hash`, `source`, `file_id`, `created_at` used by reconcile/GC,
+`src/backend.rs:181`).
+
+[`MemoryStore`] (`src/backend.rs:360`) is keyed by `external_id` like the real
+store (so dedup-as-overwrite is exercised faithfully), evaluates metadata
+filters, and tracks `upload_count` so tests can assert redundant syncs stay
+flat.
+
+[`MixedbreadStore`] (`src/adapter.rs:18`) wraps a `mixedbread::Client`. It maps
+a `Document` to the client's upload and each `mixedbread::Chunk` back to a
+`SearchHit`, reading `source`/`content_hash`/provenance from chunk metadata and
+normalizing the API's 1-based `start_line` / line-span to a 0-based start and a
+line count (`src/adapter.rs:122`). Build it with `from_env`
+(`MXBAI_API_KEY`-only) or `from_login` (key, else `mgrep login` token,
+`src/adapter.rs:33-49`). Inherent extras with no offline analogue:
+`events_histogram` and `enhance_query` (`src/adapter.rs:59`).
+
+## Pipeline and config
+
+[`pipeline`](../indexer/overview.md) functions `index_and_semantic`,
+`index_and_grep`, `index_and_answer` (`src/pipeline.rs:141`) are the
+index-then-query flow: `prepare` builds and persists the manifest, skips sync
+when the signature matches the last synced one for this `(base_url, store)`
+(`src/pipeline.rs:79`), otherwise uploads and waits, and marks success on upload
+acceptance (not embedding completion). A query whose sources exclude `code`
+skips the worktree walk entirely (`src/pipeline.rs:72`). [`Config`]
+(`src/config.rs`) carries the limits (`max_file_bytes` 1 MiB, `max_files`
+10000); `DEFAULT_STORE = "index"` and `WEB_STORE = "mixedbread/web"`
+(`src/config.rs:8`).
+
+## Build
+
+`package.nix` marks it `inRustWorkspace = true` with `passthruTests = true`: it
+builds through the shared cargo-unit graph and its tests surface as a CI check.
+No `default.nix`, no flake output; consumers take it as the
+`search-core`/`search_core` workspace library.
+
+See [internals](internals.md) for the query, projection, context, and
+filter-building layer.
+
+[`Manifest`]: #manifest-and-signature
+[`FileEntry`]: #manifest-and-signature
+[`ContentHash`]: #content-addressing-and-dedup
+[`ContentHash::of_bytes`]: #content-addressing-and-dedup
+[`Manifest::build`]: #manifest-and-signature
+[`Manifest::hashes`]: #manifest-and-signature
+[`Manifest::signature`]: #manifest-and-signature
+[`Db`]: #manifest-and-signature
+[`sync`]: #dedup-aware-sync-srcsyncrs
+[`SyncReport`]: #dedup-aware-sync-srcsyncrs
+[`wait_until_indexed`]: #dedup-aware-sync-srcsyncrs
+[`Document`]: ../source/overview.md
+[`Store`]: #the-store-backend-srcbackendrs
+[`SearchHit`]: #the-store-backend-srcbackendrs
+[`Provenance`]: #the-store-backend-srcbackendrs
+[`SearchOptions`]: #the-store-backend-srcbackendrs
+[`AskOptions`]: #the-store-backend-srcbackendrs
+[`GrepOptions`]: #the-store-backend-srcbackendrs
+[`StoreStatus`]: #the-store-backend-srcbackendrs
+[`StoredRecord`]: #the-store-backend-srcbackendrs
+[`MemoryStore`]: #the-store-backend-srcbackendrs
+[`MixedbreadStore`]: #the-store-backend-srcbackendrs
+[`Config`]: #pipeline-and-config

--- a/docs/search/search-eval/overview.md
+++ b/docs/search/search-eval/overview.md
@@ -1,0 +1,80 @@
+# search-eval
+
+`packages/search-eval` measures how good [`search`](../search/overview.md) is,
+the way the neural-search community (Exa's "open evals") measures retrieval. It
+runs a versioned query set against the real `search` engine over a fixed,
+committed corpus and scores it. Python (an evaluation harness, not domain logic),
+`nix run .#search-eval` (`default.nix`, `package.nix`).
+
+## Two tiers
+
+- **Tier A, retrieval grading** (`retrieval`): rank the corpus for each query and
+  score the ranking against gold labels (nDCG@10, Recall@k, MRR), plus an
+  optional label-free LLM relevance judge (README:8-11). The cheap, reproducible
+  signal to gate on; the ranking metrics are the only hermetic, CI-gated part.
+- **Tier B, agentic downstream** (`agentic`): give a headless `claude -p` agent
+  exactly one tool, a corpus-scoped search, and a question it cannot answer from
+  memory, then grade whether it answered correctly (README:12-15). The "does
+  search actually help an agent" signal.
+
+```sh
+nix run .#search-eval -- retrieval            # Tier A (LLM judge on by default)
+nix run .#search-eval -- retrieval --no-judge # rank metrics only, no API key
+nix run .#search-eval -- agentic              # Tier B
+nix run .#search-eval -- all --json-out report.json
+```
+
+## CLI (`src/search_eval/cli.py`)
+
+`_build_parser` (`cli.py:53`) defines `retrieval`, `agentic`, and `all`. Common
+flags (`cli.py:41`): `--search-bin` (default `search` on PATH), `--corpus`
+(default the packaged fixture), `--store`, `--max-count`, `--limit`,
+`--json-out`, `--judge-model`. `retrieval` adds `--no-rerank` / `--reranker`,
+`--no-judge`, `--judge-top-n`, `--dataset`, `--fail-under` (exit 1 when mean
+nDCG@10 falls below). `agentic` adds `--claude-bin`, `--backend local|ixvm`,
+`--agent-model`, `--fail-under` (on accuracy). `main` (`cli.py:145`) wires the
+thresholds into the exit code.
+
+## Corpus, datasets, metrics
+
+The corpus is a committed fixture under `corpus/`: a dozen tiny modules on
+distinct topics with deliberately made-up constants, so a correct answer is
+evidence the retrieval worked rather than the model's memory (Exa's
+anti-contamination recipe, README:42-49). Query sets are JSONL data:
+`datasets/retrieval.jsonl` (`{id, query, relevant}` with graded relevance) and
+`datasets/tasks.jsonl` (`{id, task, answer}` for Tier B). Point either tier at
+your own set with `--dataset` or any checkout with `--corpus`.
+
+Metrics (README:65-73): **nDCG@10** (the headline graded, position-discounted
+metric), **Recall@5/@10**, **MRR**, **jNDCG** (rank-discounted nDCG over the LLM
+judge's per-result scores), and Tier B **accuracy**. The LLM judge follows the
+LLM-as-judge robustness measures: a forced tool call for structured output,
+`temperature=0`, a calibrated rubric, and a `reasoning` field before the score;
+grading is pointwise so position bias does not apply (README:79-86).
+
+## Agent isolation (Tier B)
+
+The agent runs behind a pluggable backend (README:88-108):
+
+- `--backend local` (default): each `claude -p` runs in a throwaway temp dir
+  whose only declared tool is a one-tool MCP search server (`mcp_server.py`),
+  with Bash and file/web readers denied and the corpus path kept out of view.
+  This is best-effort isolation for a cooperative agent, not a security boundary
+  (Claude Code can still run read-only shell), so the number reflects search.
+- `--backend ixvm`: the typed seam for the airtight boundary (run each agent in a
+  disposable ix VM). Not implemented yet; it returns an explicit error rather
+  than silently falling back (`agent.py`).
+
+The agent's search tool runs with `--no-sync`, so the local backend indexes the
+corpus first via `SearchBackend.warmup()` before running tasks (`cli.py:133`).
+
+## Build
+
+`default.nix` builds the uv application with `ix.buildUvApplication` and wraps it
+so the real `search` binary (from the workspace graph) and `claude-code` are on
+its PATH, with the committed corpus/datasets staged at `SEARCH_EVAL_DATA_DIR`
+(`default.nix:8-55`). The offline ranking metrics are unit-tested as the
+CI-gating `passthru.tests.metrics`, plus a `printsHelp` smoke test
+(`default.nix:59-87`). It depends on the live `search` engine, so Tier numbers
+need a real Mixedbread credential and (for the judge / agent)
+`ANTHROPIC_API_KEY`.

--- a/docs/search/search-py/overview.md
+++ b/docs/search/search-py/overview.md
@@ -1,0 +1,73 @@
+# search-py
+
+`packages/search-py` is the PyO3 binding for
+[`search-core`](../search-core/overview.md), imported as `search`. A read-only
+query surface over the shared corpus store the
+[`indexer`](../indexer/overview.md) populates: importing `search` and querying
+never uploads the local checkout (`src/lib.rs:1-13`). All query, dedup, and
+filter logic lives in the Rust core; this crate converts at the boundary. Crate
+`search_py`, `crate-type = ["cdylib"]` (`Cargo.toml:8-10`).
+
+## Entry points
+
+Three thin async functions, each a `#[pyfunction]` returning a native asyncio
+coroutine bridged through `pyo3-async-runtimes` (so callers `await` on their own
+loop, `src/lib.rs:15`):
+
+- `semantic(query, ...)` (`src/lib.rs:125`): natural-language search.
+- `grep(pattern, ...)` (`src/lib.rs:214`): regex over the same chunks.
+- `recent(...)` (`src/lib.rs:293`): newest records by descending timestamp, no
+  semantic scoring (`compact` defaults `True` here).
+
+The module is registered as `_search` (`src/lib.rs:493`); the Python package
+`search/__init__.py` wraps each native coroutine with `_framed`
+(`python/search/__init__.py:141`) so awaiting it yields a polars `DataFrame`
+instead of a list of dicts.
+
+Each Rust function resolves the store name (default `index`,
+`DEFAULT_STORE`), the base URL (`mixedbread::DEFAULT_BASE_URL`), and builds the
+scope filter with the shared `search_core::build_filter`, so the mapping matches
+the [`search`](../search/overview.md) CLI exactly (`scope_filter`,
+`src/lib.rs:338`). Each connects with `MixedbreadStore::from_login`
+(`MXBAI_API_KEY`, else the `mgrep login` token) and runs with an empty manifest
+and `CodeScope::ServerFiltered` (no checkout is read, `src/lib.rs:413`).
+
+## Arguments and result frame
+
+Keyword arguments mirror the CLI: `top_k`, `store`, `base_url`, `rerank` /
+`reranker`, `web`, `agentic`, `compact`, and scope selectors `source` /
+`not_source` / `repo` / `user` / `host` / `project` / `since` / `until`
+(`src/lib.rs:98-120`). `since`/`until` accept an int (epoch seconds) or a string
+(epoch or a relative span `"24h"`/`"7d"`, `TimeSpec`, `src/lib.rs:30`). An
+unknown `source` raises `ValueError` listing the valid tags, since the store
+silently returns zero hits for a typo (`parse_sources`, `src/lib.rs:365`).
+`agentic` defaults `False` everywhere (slow and costly).
+
+`hit_to_dict` (`src/lib.rs:465`) sets the six always-present keys (`path`,
+`score`, `start_line`, `num_lines`, `text`, `source`) plus provenance keys only
+when the record carries them. The Python wrapper enforces a stable column schema
+on every frame (`_COLUMNS` / `_dtypes`, `__init__.py:79-115`), filling missing
+provenance columns with nulls, so `df["timestamp"]` and `df.group_by("source")`
+work even on an empty result.
+
+```python
+import search
+df = await search.semantic("where is retry backoff configured")
+df.group_by("source").len().sort("len", descending=True)
+df = await search.recent(source=["shell"], user=["andrew"], since="6h")
+```
+
+## Build and distribution
+
+`default.nix` packages the cdylib already built by the shared workspace unit
+graph (`ix.rustWorkspace.units.libraries.search_py`) into the `ix-search` wheel
+with `wheel/mkwheel.py`: no maturin, no second compile (`default.nix:10-13`). It
+strips the build rpath and nixpkgs references and stamps manylinux tags. The
+wheel is Linux-only (`package.nix:11`, `flake.systems = x86_64/aarch64-linux`):
+the cdylib links on macOS too, but the wheel packaging strips an ELF rpath and
+needs install-name fixups for macOS that no caller wants yet. `nix build
+.#search-py` builds it.
+
+For cross-platform `import search` (Linux and macOS), the `mcp` package bundles
+this cdylib straight from the workspace graph into the `ix-mcp` interpreter, so
+every MCP Python session can `import search` with no install step (README:126).

--- a/docs/search/search/overview.md
+++ b/docs/search/search/overview.md
@@ -1,0 +1,83 @@
+# search
+
+`packages/search` is the read-only semantic and regex search CLI over the shared
+corpus store: one Mixedbread store holding code plus agent/shell history across
+the fleet. It is a thin wrapper over [`search-core`](../search-core/overview.md)
+(`packages/search/Cargo.toml:6`), binary `search`
+(`nix run .#search`, `default.nix`).
+
+`search` never indexes (`src/main.rs:1-8`). The separate
+[`indexer`](../indexer/overview.md) owns all ingestion; this CLI queries the
+store and projects hits. Querying never reads or uploads the local checkout, so
+running it from any directory is safe (code is scoped entirely server-side via a
+metadata filter, `src/main.rs:118`).
+
+## Commands
+
+A bare invocation runs a natural-language semantic search; subcommands cover the
+rest (`Cli`/`Command`, `src/main.rs:36-68`):
+
+- `search <pattern> [path]` - semantic search. Calls `search_core::semantic`
+  (`src/main.rs:639`), or `search_core::ask` with `-a/--answer`
+  (`src/main.rs:623`), or `search_core::ranked` when `--enhance` derives a sort
+  (`src/main.rs:604`).
+- `search grep <pattern>` - regex over the same indexed chunks
+  (`search_core::grep`, `src/main.rs:1035`); local-corpus only (no web).
+- `search recent` - newest records by descending `timestamp`, no semantic
+  scoring (`search_core::recent`, `src/main.rs:675`).
+- `search context <id>` - expand a hit's `external_id` (or a bare session id)
+  into the surrounding conversation (`search_core::context`, `src/main.rs:698`).
+- `search stats` - per-source census: document counts and freshness
+  (`search_core::stats`, `src/main.rs:723`).
+
+## Flags
+
+Key semantic-path flags (`SemanticArgs`, `src/main.rs:206`): `-m/--max-count`,
+`-c/--content`, `-a/--answer` (+ `--instructions`, `--no-cite`,
+`--no-multimodal`), `--no-rerank` / `--reranker <model>` / `--rerank-top-k`,
+`-w/--web`, `--agentic` (+ `--agentic-max-rounds`, `--agentic-instructions`),
+`--rewrite-query`, `--no-search-rules`, `--enhance`, `--json`, `--compact`.
+`--agentic` is off by default on every surface: it costs 10-23s per query (vs
+3-6s reranked) at ~5x the price and may return fewer than `--max-count` hits
+(`src/main.rs:265`).
+
+Scope selectors are shared by the semantic, grep, recent, and stats paths
+(`ScopeArgs`, `src/main.rs:73`): `--source` / `--not-source`, `--repo`,
+`--user` / `--mine` (the current `$USER`), `--host`, `--project`,
+`--since` / `--until`. An unknown `--source` is a hard error: the store
+silently returns zero hits for a typo, indistinguishable from an empty corpus
+(`parse_sources`, `src/main.rs:169`, validated against `KNOWN_SOURCE_TAGS`).
+`resolve_scope` (`src/main.rs:121`) maps them into a `search_core::FilterSpec`
+and `build_filter`, the same builder the Python binding uses.
+
+Connection flags on every subcommand: `--store` / `MXBAI_STORE` (default
+`index`), `--base-url` / `MXBAI_BASE_URL`. `connect` (`src/main.rs:504`)
+authenticates with `MixedbreadStore::from_login` (`MXBAI_API_KEY`, else the
+`mgrep login` token; README:18-24).
+
+## Pipe-in rerank mode
+
+Piped stdin switches behavior: `ls | search "query"` ranks the piped lines
+against the query with the reranking model instead of searching the corpus
+(`src/main.rs:10`, `run`/`run_piped` at `src/main.rs:538`/`1100`,
+`piped_stdin_lines` at `src/main.rs:1058`). A TTY, `</dev/null`, or an empty
+pipe falls through to the normal corpus search. Pipe mode rejects flags that
+make no sense for it (`--answer`, `--web`, `--agentic`, `--enhance`, scope
+selectors, a path arg) with explicit errors, and uses `mixedbread`'s `rerank`
+endpoint directly.
+
+## Output
+
+Human listing by default with TTY-gated color (`NO_COLOR` / `CLICOLOR_FORCE`
+honored, syntax highlight via `code-highlight`); `--json` emits the stable
+`search_core::hits_to_json` array (`src/main.rs:1305`); `--compact` collapses
+repeated chunks and caps snippets. `--answer` prints the synthesized answer with
+`[n]` citations over a numbered source list (`print_answer`, `src/main.rs:513`).
+
+## Build
+
+`default.nix` uses `ix.cargoUnit.selectBinaryWithTests` (binary `search`,
+`mainProgram` `search`); `package.nix` sets `flake = true` and `packageSet =
+true`, so it is `nix run .#search` and `pkgs.search`. Dependencies are
+`search-core`, `mixedbread`, `code-highlight`, `terminal-theme`,
+`progress-style`, clap, indicatif (`Cargo.toml:15-31`).

--- a/docs/search/sink/overview.md
+++ b/docs/search/sink/overview.md
@@ -1,0 +1,83 @@
+# sink
+
+`packages/sink` is the workspace of search-Document sinks: the write half of the
+corpus, paired with the [source adapters](../source/overview.md). Each sink
+implements [`source_meta::Reconciler`](../source/overview.md), converging one
+view to a source's desired-state documents. Two members, both library crates (no
+flake outputs, CI checks via `passthruTests`):
+
+- `sink/mixedbread` (crate `sink-mixedbread`): reconcile a record source into a
+  Mixedbread store (upload changed, skip unchanged, replace, or GC).
+- `sink/parquet` (crate `sink-parquet`): write each source as one parquet file
+  in an S3/R2 corpus log.
+
+The [`lake-iceberg`](../lake/overview.md) reconciler is the third sink the
+[`indexer`](../indexer/overview.md) fans out to; it lives in its own package
+because its read and write halves share a schema and codec.
+
+## sink-mixedbread (`sink/mixedbread/src/lib.rs`)
+
+Records are addressed by a source-defined `external_id`; change detection
+compares each document's `content_hash` against the value stored under that id
+(`src/lib.rs:1-10`). [`MixedbreadReconciler`] (`src/lib.rs:115`) holds a
+[`Store`](../search-core/overview.md) (production `MixedbreadStore`, tests
+`MemoryStore`), the store name, and the embedding-wait timeout. Its shared upload
+half `sync_source` (`src/lib.rs:152`):
+
+1. `ensure_store`, then list the source's records scoped by `source == X`.
+2. [`verify_scope`] (`src/lib.rs:92`): every returned record's own `source` must
+   match; a backend that drops the filter aborts with `ScopeLeak` instead of
+   feeding a store-wide delete set into replace/GC (it has happened: the API once
+   renamed the list-filter parameter and ignored the old name).
+3. Upload only the new or changed documents (a record with no stored hash
+   predates hash tracking and re-embeds) at concurrency 16, then wait until those
+   ids embed, gated on this pass's ids only (ENG-2699, `src/lib.rs:189`).
+
+Four entry points over that half:
+
+- `reconcile` (`src/lib.rs:474`, the `Reconciler` impl): upload changed, skip
+  unchanged, KEEP remote absences. Used for live scans whose read can be
+  transiently partial, where absence is not authoritative. Returns [`SyncReport`].
+- `replace` (`src/lib.rs:241`): the log-replay sibling. Make the store's records
+  for a source exactly `documents`, DELETING remote ids absent from the desired
+  set, because a log fold's absences are explicit tombstones (including an empty
+  set for a fully tombstoned source). Returns [`ReplaceReport`].
+- `apply` (`src/lib.rs:279`): apply a log-derived delta (upserts + tombstones),
+  trusting the log's change detection (no remote listing for skip decisions);
+  idempotent, with deletes filtered against the store's current ids so a replayed
+  cursor cannot wedge on a missing-id hard error. Returns [`ApplyReport`].
+- `gc` (`src/lib.rs:354`): after a fully successful sync of an export-complete
+  source, delete file objects whose `external_id` vanished from the COMPLETE
+  produced set, plus exact-duplicate `(external_id, content_hash)` file objects
+  from retried uploads, keeping the newest of each. `plan_gc` (`src/lib.rs:405`)
+  derives the deletions purely from the scoped listing and the produced set (so
+  the policy is testable without a store): condemn every file object of a vanished
+  id, and trim a surviving id to one file object per content hash. Returns
+  [`GcReport`].
+
+## sink-parquet (`sink/parquet/src/lib.rs`)
+
+A generic S3/R2 parquet sink: every source's documents share one flat schema
+(one row per document), so the whole corpus is one polars/duckdb query regardless
+of source; per-source extras live in the `meta_json` column rather than typed
+columns (`src/lib.rs:1-6`). [`ParquetReconciler`] (`src/lib.rs:120`) writes one
+file per source at `<prefix>/source=<source>/data.parquet`, rewritten in full
+each run, with a sibling `_manifest.json` recording a content hash over the
+source's `(external_id, content_hash)` set; a run whose corpus is unchanged skips
+the rewrite (`src/lib.rs:8-12`). This trades incremental writes for idempotence
+and zero dedup-on-read: a source's file always reflects its current desired
+state. A very large source rewrites its whole file each change (sharding is a
+future refinement). The consumer half that reads this log back is
+[`source-parquet`](../source/adapters.md). [`Config::connect`] (`src/lib.rs:127`)
+builds the `AmazonS3` store from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`;
+the indexer host-partitions the prefix so many hosts sharing a bucket do not
+clobber each other.
+
+[`MixedbreadReconciler`]: #sink-mixedbread-sinkmixedbreadsrclibrs
+[`verify_scope`]: #sink-mixedbread-sinkmixedbreadsrclibrs
+[`SyncReport`]: #sink-mixedbread-sinkmixedbreadsrclibrs
+[`ReplaceReport`]: #sink-mixedbread-sinkmixedbreadsrclibrs
+[`ApplyReport`]: #sink-mixedbread-sinkmixedbreadsrclibrs
+[`GcReport`]: #sink-mixedbread-sinkmixedbreadsrclibrs
+[`ParquetReconciler`]: #sink-parquet-sinkparquetsrclibrs
+[`Config::connect`]: #sink-parquet-sinkparquetsrclibrs

--- a/docs/search/source/adapters.md
+++ b/docs/search/source/adapters.md
@@ -1,0 +1,71 @@
+# source adapters
+
+The concrete [`SourceAdapter`](overview.md) implementations under
+`packages/source/*`, plus the `source-parquet` log reader. Each turns one corpus
+into [`Document`](overview.md)s carrying the common envelope (`source`,
+`external_id`, `content_hash`, `title`, `timestamp`) merged with the
+source-specific filter tags below. All are library crates; the
+[`indexer`](../indexer/overview.md) selects which to run.
+
+## Adapter table
+
+| crate | `source` tag | grain (one Document per ...) | `external_id` | source-specific tags |
+| --- | --- | --- | --- | --- |
+| `source/atuin` | `shell` | recorded shell command (nushell/zsh/bash, one atuin db) | `atuin:{id}` | `host`, `user`, `cwd`, `session_id`, `exit_status` |
+| `source/claude` | `claude_history` | transcript message (tool result folded into its tool_use) | `claude:{session_id}:{uuid}` | `host`, `user`, `project`, `session_id`, `message_uuid`, `parent_uuid`, `role`, `record_type`, `model`, `cwd`, `git_branch`, `tool_name`, token counts |
+| `source/codex` | `codex` | submitted prompt, and each session-rollout item | prompt `codex:{session_id}:{ts}:{content_hash}`; rollout `codex:{session_id}:{content_hash}` | `host`, `user`, `session_id`; rollout adds `role`, `record_type`, `model`, `cwd`/`project`, `tool_name` |
+| `source/debug` | `claude_debug` | session `--debug` log file | `claude_debug:{session_id}` | `host`, `user`, `session_id` |
+| `source/git` | `git` | commit (message only; diff stays in git) | `git:{repo}:{sha}` | `repo`, `commit`, `author_name`, `author_email` |
+| `source/github` | `github` | issue, pull request, and failed CI run | item `github:{owner}/{repo}:{number}`; CI `github:ci:{owner}/{repo}:{run_id}` | `repo`, `number`, `state`, `is_pr`, `labels`; CI adds `kind=ci_run`, `workflow`, `branch`, `conclusion`, `run_number`, `commit` |
+| `source/journald` | `journald` | (unit, UTC day) slice of priority<=4 messages | `journald:{host}:{unit}:{date}` | `host`, `unit` |
+| `source/linear` | `linear` | issue (description + comments, oldest first) | `linear:issue:{id}` | `identifier`, `team_key`, `state_type`, `assignee_email`, `labels`, `is_archived`, `url` |
+| `source/slack` | `slack` | thread (every message sharing `channel_id`+`thread_ts`) | `slack:{channel_id}:{thread_ts}` | `channel_id`, `channel_name`, `authors`, `is_archived`, `is_external`, `is_bot_thread`, `message_count`, `has_files`, `thread_ts` |
+
+Each crate exports its tag as a `SOURCE_TAG` const (e.g. `atuin/src/lib.rs:35`,
+`claude/src/lib.rs:39`, `codex/src/lib.rs:56`, `debug/src/lib.rs:40`,
+`git/src/lib.rs:32`, `journald/src/lib.rs:46`); github/linear write `"github"` /
+`"linear"` inline. When a new tag appears, add it to
+[`KNOWN_SOURCE_TAGS`](overview.md) so the query edges accept it.
+
+## Reading shapes
+
+- **History (per host/user): atuin, claude, codex, debug.** Read live local
+  files (an atuin SQLite db opened `immutable=1` so a live shell is never
+  blocked, `atuin/src/lib.rs:75`; `*.jsonl` transcripts; the codex prompt log
+  plus session rollouts; `--debug` text logs). Append-only, so an unchanged file
+  re-ingests nothing under the content-hash gate, and a live file (the current
+  codex session, today's debug log) re-uploads only while it grows. The
+  privileged fleet run reads other accounts' homes as root, so these adapters
+  index only regular files and the caller does a symlink-safe path check, and
+  index only regular files to refuse a planted symlink (`debug/src/lib.rs:17-22`).
+  These are never `--gc`'d: their scans are incremental windows, not complete
+  snapshots.
+- **Bulk exports (export-complete): github, linear, slack.** Read a directory of
+  JSON an exporter wrote. github/linear are pure readers (the joins live in the
+  exporter; `github/src/lib.rs:1`, `linear/src/lib.rs:1`); slack streams channel
+  by channel so a 344 MB tree is never fully in memory (`slack/src/lib.rs:13-19`).
+  Their complete input makes them eligible for the indexer's `--gc` pass.
+- **git, journald** shell out once (`git log` with a US/NUL pretty format,
+  `git/src/lib.rs:34`; `journalctl -o json --priority 4 --since`,
+  `journald/src/lib.rs:22`) and project the parsed output. git is export-complete
+  (GC-eligible); journald is a windowed read.
+
+All transcript and log adapters route message text through the shared
+[`source_meta::sanitize`](overview.md) pipeline (ANSI stripped, credential
+shapes redacted, blobs collapsed, tool sections capped) before hashing and
+embedding.
+
+## source-parquet (the log reader)
+
+`source/parquet` (crate `source-parquet`) is the consumer half of the parquet
+corpus log written by [`sink-parquet`](../sink/overview.md), not an adapter. It
+lists an S3/R2 prefix, reads each `<prefix>/source=<source>/data.parquet`, and
+reconstructs [`Document`](overview.md)s from four columns (`external_id`,
+`content_hash`, `body`, `meta_json`); the rest of the schema is a projection out
+of `meta_json` and ignored on read (`parquet/src/lib.rs:14-22`). The
+`_manifest.json` sidecar and any non-`/data.parquet` object are skipped. This is
+the materialized-view-over-a-log model: the parquet log is the append-only truth
+and the Mixedbread index is one view replayed from it (issue #736). The indexer's
+`--from-parquet-prefix` consume mode uses it. Known limitation: it lists the
+whole prefix and materializes every row each run (`parquet/src/lib.rs:23`); the
+incremental cursor lives in the [Iceberg lake](../lake/overview.md) instead.

--- a/docs/search/source/overview.md
+++ b/docs/search/source/overview.md
@@ -1,0 +1,107 @@
+# source
+
+`packages/source` is the workspace of source adapters that turn each data source
+(a code checkout's neighbors: Slack, Linear, GitHub, git history, Claude/Codex
+transcripts, shell history, journald) into embeddable, tagged search
+[`Document`]s. One member, `source/meta` (crate `source-meta`), holds the shared
+data model and traits every other member implements; the rest are the adapters.
+The [`indexer`](../indexer/overview.md) drives them and the [sinks](../sink/overview.md)
+consume them. All members are library crates (no flake outputs); they surface as
+CI checks via `passthruTests`.
+
+This page documents the shared `source-meta` model. The per-adapter grains,
+ids, and tags are in [adapters.md](adapters.md).
+
+## The Document model (`source/meta/src/lib.rs`)
+
+[`Document`] (`meta/src/lib.rs:199`) is one record ready to upload: an
+`external_id` (the store-stable id), a `file_name`, a static `mime`, the UTF-8
+`body` to embed, a flat `meta_json` object, and a `content_hash`. Every record,
+whatever its source, carries the common header [`DocumentMeta`]
+(`meta/src/lib.rs:178`) flattened to top-level metadata keys, so each field is a
+filter key: `source`, `external_id`, `content_hash`, `title`, optional `url`,
+optional `timestamp`. The adapter merges source-specific extras into the same
+flat object.
+
+[`Source`] (`meta/src/lib.rs:50`) is the corpus tag: an open string newtype, not
+an enum, so adding a corpus is a new tag value, never a match arm. `Source::code`
+and `Source::web` name the two corpora the search pipeline treats specially
+(local-manifest scoping, opt-in web results); every other tag is a generic
+record source. [`KNOWN_SOURCE_TAGS`] (`meta/src/lib.rs:62`) is the list the query
+edges validate user input against (a mistyped tag returns zero hits silently);
+add an entry when an adapter gains a new `SOURCE_TAG`. [`RepoSlug`]
+(`meta/src/lib.rs:151`) is the code-record repo identity (`Remote` from the git
+origin, else `Local` from the directory name, never a silent empty string).
+
+## Traits (`source/meta/src/lib.rs`)
+
+- [`SourceAdapter`] (`meta/src/lib.rs:219`): turns one corpus into
+  `documents() -> impl Iterator<Item = Result<Document, Error>>` plus a
+  `source()` tag. Returning an iterator (not a `Vec`) lets a large export (a 344
+  MB Slack tree) stream; a record that cannot be parsed is a typed `Err`, never
+  silently dropped.
+- [`Reconciler`] (`meta/src/lib.rs:251`): the consumer counterpart, implemented
+  by the [sinks](../sink/overview.md). Its contract: desired state not deltas
+  (`documents` is the source's complete current set), idempotent on
+  `external_id` + `content_hash`, and source-scoped (a pass reads and writes only
+  one source's records). A view can also satisfy idempotence at the storage
+  engine level (e.g. a ClickHouse `ReplacingMergeTree`) instead of implementing
+  the trait.
+
+## Invariants enforced by construction
+
+- **content_hash is the hash of the embedded bytes.** [`hash_body`]
+  (`meta/src/lib.rs:271`) formats `sha256:<hex>` and is the only constructor, so
+  a record's change-detection key can never drift from what was embedded.
+  Re-ingesting an unchanged export is a no-op; a changed body re-embeds. Because
+  the hash is over the sanitized bytes (below), the first re-sync after a sanitize
+  change re-uploads the clean form.
+- **Metadata stays in the store's limits.** [`check_metadata`]
+  (`meta/src/lib.rs:327`) is a typed gate (`MAX_METADATA_BYTES` 128 KiB,
+  `MAX_METADATA_KEYS` 256), so an over-budget record fails observably before
+  upload rather than as an opaque 400 mid-ingest. It returns the serialized
+  bytes so the caller does not serialize twice.
+
+## Canonical keys (`source/meta/src/keys.rs`)
+
+`keys` is the single source of truth for metadata key names, shared by adapters
+(which write them) and the filter builder (which queries them), as `const`s so a
+query can never target a key no adapter writes without the mismatch being visible
+in one place (`keys.rs:1-6`). Groups: common (`SOURCE`, `CONTENT_HASH`, `TITLE`,
+`EXTERNAL_ID`, `URL`, `TIMESTAMP`), code (`REPO`, `PATH`), git commits (`COMMIT`,
+`AUTHOR_NAME`, `AUTHOR_EMAIL`), Slack (`CHANNEL_ID`/`CHANNEL_NAME`, `AUTHORS`,
+`IS_EXTERNAL`, `IS_BOT_THREAD`), agent history (`HOST`, `USER`, `PROJECT`,
+`SESSION_ID`, `MESSAGE_UUID`, `PARENT_UUID`, `ROLE`, `RECORD_TYPE`, `MODEL`,
+`CWD`, `GIT_BRANCH`, `TOOL_NAME`, token counts), shell (`EXIT_STATUS`), journald
+(`UNIT`), Linear (`IDENTIFIER`, `TEAM_KEY`, `STATE_TYPE`, `ASSIGNEE_EMAIL`,
+`LABELS`, `IS_ARCHIVED`), and GitHub (`NUMBER`, `STATE`, `IS_PR`, `KIND`,
+`WORKFLOW`, `BRANCH`, `CONCLUSION`, `RUN_NUMBER`).
+
+## Body sanitization (`source/meta/src/sanitize.rs`)
+
+One shared pipeline every adapter applies before a body is hashed and embedded
+(`sanitize.rs:1-27`). Three concerns: strip terminal ANSI/OSC noise; redact
+secrets (a conservative, prefixed pattern table mapping a credential shape to
+`[redacted:<kind>]`, e.g. GitHub/Linear tokens found verbatim in past indexed
+transcripts); and collapse base64/hex blobs longer than `BLOB_TOKEN_CHARS` (120)
+to a `[blob NNN chars]` marker. `sanitize_tool_result` additionally caps one
+tool-result section at `TOOL_RESULT_CAP_CHARS` (4000, head+tail around a
+truncation marker) so a huge CI log cannot dominate the document it folds into.
+Sanitizing before hashing means a re-sync sees previously raw bodies as changed
+and replaces them with the clean form.
+
+## Adapters
+
+The 10 source adapters plus the `source-parquet` log reader are tabulated in
+[adapters.md](adapters.md): each one's grain, `external_id` shape, and the filter
+tags it writes.
+
+[`Document`]: #the-document-model-sourcemetasrclibrs
+[`DocumentMeta`]: #the-document-model-sourcemetasrclibrs
+[`Source`]: #the-document-model-sourcemetasrclibrs
+[`KNOWN_SOURCE_TAGS`]: #the-document-model-sourcemetasrclibrs
+[`RepoSlug`]: #the-document-model-sourcemetasrclibrs
+[`SourceAdapter`]: #traits-sourcemetasrclibrs
+[`Reconciler`]: #traits-sourcemetasrclibrs
+[`hash_body`]: #invariants-enforced-by-construction
+[`check_metadata`]: #invariants-enforced-by-construction

--- a/docs/site/build-deploy/overview.md
+++ b/docs/site/build-deploy/overview.md
@@ -1,0 +1,117 @@
+# build
+
+Genre: recipe. How the site is built, previewed, tested, and deployed. The site
+is a JavaScript package (`site/package.json` name `ix-site`); the reproducible
+build is a Nix derivation produced by the shared `ix.buildSvelteSite` helper, and
+deployment is GitHub Pages via `.github/workflows/pages.yml`.
+
+## Toolchain
+
+- SvelteKit 2 (`@sveltejs/kit ^2.61`), Svelte 5 (`^5.55`), Vite 8, TypeScript 6
+  (`site/package.json:15-31`).
+- `@sveltejs/adapter-static ^3` (`:17`) prerenders to flat files.
+- Runtime deps: `@xyflow/svelte` (diagrams), `mdsvex` (`.svx`), `shiki`
+  (highlighting) (`site/package.json:36-40`).
+- Two lockfiles are committed: `site/package-lock.json` and `site/bun.lock`. The
+  Nix build path uses npm (below); `bun.lock` supports local `bun install`.
+
+## npm scripts (`site/package.json:6-14`)
+
+- `dev` -> `vite dev` - local dev server with HMR.
+- `build` -> `svelte-kit sync && svelte-check --tsconfig ./tsconfig.json &&
+  eslint . && vite build` - typecheck + lint + production build. Output goes to
+  `build/` (the adapter `pages`/`assets` dir, `svelte.config.js:15-16`).
+- `preview` -> `vite preview`.
+- `check` -> `svelte-kit sync && svelte-check`.
+- `lint` -> `eslint .` (flat config, `eslint.config.js`; strict typed rules,
+  `no-explicit-any: error`).
+- `test` -> `svelte-kit sync && vitest run`; `test:list` enumerates cases as JSON.
+
+## Nix package (`ix.buildSvelteSite`)
+
+Defined in `lib/build/svelte-site.nix`, exported as `ix.buildSvelteSite`
+(`lib/default.nix:104`). It wraps the same `buildJsSite`-style
+package-manager branching (`lib/build/js-site.nix`) and adds a static preview
+command and a checkout dev server. The site instance is configured in `lib/per-system.nix:427-440`:
+
+```nix
+siteBuild = ix.buildSvelteSite pkgs {
+  pname = "ix-site";
+  version = "0.1.0";
+  src = siteSrc;            # paths.site: the git-filtered site subtree input
+  distDir = "build";        # adapter-static output
+  serve   = { name = "ix-site";     routePrefix = "/index"; };
+  devServer = { name = "ix-site-dev"; checkoutSubdir = "site"; };
+};
+```
+
+- `packageManager` is not set, so it defaults to `npm` (`svelte-site.nix:37`);
+  deps are built from `package-lock.json` via `pkgs.importNpmLock.buildNodeModules`
+  (`svelte-site.nix:111`). `node_modules` is linked in, the `build` script runs in
+  a pure sandbox (`buildPhase` `:168-173`), and the output is installed to
+  `$out/share/ix-site` (`installDir` default `share/${pname}`, `:42,175-180`).
+- `src` is `paths.site`, the `flake = false` path input `./site`
+  (`flake.nix:61-64`, `flake.nix:215`), so the build's source identity is scoped
+  to the `site/` subtree and edits elsewhere do not re-hash it
+  (`per-system.nix:422-425`).
+- `serve` builds a miniserve wrapper that serves `$out/share/ix-site` at
+  `127.0.0.1:8080` with `--route-prefix /index` and SPA fallback
+  (`svelte-site.nix:185-230`). This previews the exact `/index` build Pages
+  deploys, without a `BASE_PATH` rebuild.
+- `devServer` builds a Nushell wrapper that runs `npm run dev` from a mutable
+  checkout (`checkoutSubdir = "site"`), auto-installing `node_modules` when
+  missing and passing `--host`/`--port` (`svelte-site.nix:247-306`). Dev state
+  (installs, caches, HMR) stays outside the Nix store.
+
+`site` (the flake output) overrides the build to also expose
+`passthru.preview`/`passthru.static` (`per-system.nix:443-448`).
+
+## Flake outputs
+
+Wired in `lib/per-system.nix:1069-1070`:
+
+- `nix build .#site` - the GitHub Pages tree; assets land under
+  `result/share/ix-site/`.
+- `nix run .#site` - boots the miniserve preview at
+  `http://127.0.0.1:8080/index/`.
+- `nix run .#site-dev` - the checkout dev server
+  (`site.passthru.devServer`).
+
+## Tests as checks
+
+`siteTests = ix.buildNpmVitest` (`per-system.nix:450-457`) runs the vitest
+browser suite (playwright chromium) in the Nix sandbox, after
+`@sveltejs/kit sync` (`preTest`). Exposed as flake checks
+(`per-system.nix:1013-1016`): `site-test` (the whole suite) and
+`site-case-tests` (a link farm of one derivation per `#test`). See the tests
+section in [lib](../lib/overview.md).
+
+## Deploy: GitHub Pages (`.github/workflows/pages.yml`)
+
+On push to `main` (or manual dispatch):
+
+1. `Build site`: `nix build .#site -L` (`pages.yml:38`), with Determinate Nix and
+   the `indexable-inc` Cachix cache.
+2. `Prepare Pages artifact`: copy `result/share/ix-site/.` into `site-dist/` and
+   `touch site-dist/.nojekyll` (`pages.yml:41-44`).
+3. `Upload Pages artifact` then a `deploy` job runs `actions/deploy-pages`
+   (`pages.yml:49-63`).
+
+The build serves under the `/index` base path (`svelte.config.js:24`), matching
+project-pages hosting at `https://indexable-inc.github.io/index/` (the canonical
+`siteUrl`, `updates.ts:50`). The header links to `https://ix.dev`
+(`+layout.svelte:21`) as the project's external/brand URL; the current source
+contains no `static/CNAME`, so a custom-domain deploy would set `BASE_PATH=""`
+(per the override note in `svelte.config.js:22-23`). See NOTES in the domain
+index for this gap.
+
+## Local recipes
+
+```bash
+nix build .#site            # produce result/share/ix-site (Pages tree)
+nix run   .#site            # preview at http://127.0.0.1:8080/index/
+nix run   .#site-dev        # Vite dev server from the site/ checkout
+# from site/ with node_modules installed:
+npm run build               # typecheck + lint + vite build -> build/
+npm test                    # vitest (browser mode, needs chromium)
+```

--- a/docs/site/common.md
+++ b/docs/site/common.md
@@ -1,0 +1,103 @@
+# site
+
+The `site/` domain is the marketing/changelog website for the `index` repo: a
+SvelteKit 2 + Svelte 5 app that is fully prerendered to static HTML by
+`@sveltejs/adapter-static` and published to GitHub Pages. It is content-first: a
+flat, filterable "log" of short updates (one `.svx` file per entry) plus a hero
+intro, per-entry permalink pages, and an RSS feed. There is no server runtime;
+every route is computed at build time.
+
+The site is a single JavaScript package (`site/package.json` name `ix-site`,
+`site/package.json:2`); it is not a Rust crate and not a Nix-only package. It is
+packaged for the flake by the shared Nix builder
+`ix.buildSvelteSite` (`lib/build/svelte-site.nix`; see
+[build-deploy](build-deploy/overview.md)) and exposed as `nix run .#site` / `nix build .#site`.
+Read this page first, then the component pages it links.
+
+## Units
+
+| unit | kind | role |
+| --- | --- | --- |
+| `site/src/routes` | SvelteKit routes | page/endpoint tree: home feed, permalink, RSS, layout. See [routes](routes/overview.md). |
+| `site/src/lib` | shared TS + Svelte | content data layer (`updates.ts`), components, the tag filter, diagrams, styling. See [lib](lib/overview.md). |
+| `site/mdsvex.config.js` | preprocessor config | `.svx` -> Svelte: shiki dual-theme highlighting + a link-sanitizing rehype plugin. Covered in [lib](lib/overview.md). |
+| `site/src/lib/updates/*.svx` | content | 27 changelog entries; markdown body + YAML frontmatter, optionally embedding diagram components. |
+| flake build/deploy | Nix + CI | `ix.buildSvelteSite` in `lib/per-system.nix:427`, `.#site` output, GitHub Pages via `.github/workflows/pages.yml`. See [build-deploy](build-deploy/overview.md). |
+
+## How it fits together
+
+```
+site/src/lib/updates/*.svx  (frontmatter + markdown + optional <script>)
+   -> mdsvex (svelte.config.js:11) compiles each .svx to a Svelte Component
+   -> updates.ts import.meta.glob (eager) collects them into siteUpdates[]
+        (sorted newest-first, tags lowercased)
+   -> routes read siteUpdates:
+        /            +page.svelte   feed: FilterBar + UpdateEntry list
+        /[id]        +page.svelte   one entry (prerendered per id)
+        /feed.xml    +server.ts     RSS 2.0 over the same data
+   -> adapter-static prerenders every route to build/ (HTML + assets)
+   -> nix build .#site -> result/share/ix-site -> GitHub Pages (/index)
+```
+
+- **Content is the source of truth.** Each entry lives in one `.svx` file. Its
+  frontmatter (`id`, `postedAt`, `title`, `tags`, `links`) is parsed by mdsvex
+  and normalized in `updates.ts:41`; the compiled component is its rendered body.
+  Adding an entry is adding a file; nothing else is registered by hand.
+- **Everything prerenders.** `+layout.ts:1` sets `prerender = true` for the whole
+  tree; `[id]/+page.ts` enumerates entries via `entries` (`[id]/+page.ts:7`) so
+  every permalink is emitted; `feed.xml/+server.ts:11` prerenders the feed. The
+  static adapter (`svelte.config.js:14`) writes `build/` with a `404.html`
+  fallback.
+- **Base path is `/index`.** GitHub project pages serve under a repo subpath, so
+  `svelte.config.js:24` sets `paths.base = process.env.BASE_PATH ?? '/index'`.
+  In-app links use `resolve()` from `$app/paths` so the prefix is applied once.
+- **Dual-theme, no JS for color.** shiki emits both light and dark colors per
+  span as CSS variables (`mdsvex.config.js:10`); `app.css` picks one with
+  `prefers-color-scheme`. The whole UI is plain CSS variables, no framework.
+- **Hydration-safe time.** Prerendered HTML renders dates in UTC; after mount
+  each page re-renders `<time>` in the visitor's zone (`+page.svelte:11`,
+  `format-posted-at.ts`).
+
+## Invariants
+
+- **One entry = one `.svx` file** under `site/src/lib/updates/`. `id` must be a
+  lowercase slug, `postedAt` an ISO 8601 timestamp with offset, link hrefs
+  absolute `https://` (enforced by `updates.test.ts`).
+- **No raw HTML injection.** Titles go through `inlineTitleHtml` (escape then
+  re-wrap backtick runs, `updates.ts:73`); body links are sanitized by the
+  rehype plugin `safeHref` (`mdsvex.config.js:34`), which drops
+  `javascript:`/protocol-relative URLs and keeps only `https`/`http`/`mailto`/
+  root/fragment hrefs.
+- **The default front-page filter is `interesting`** (`+page.svelte:18`); only
+  entries tagged `interesting` show until the visitor edits or clears the filter
+  expression.
+- **Local preview == deploy.** `nix run .#site` serves the same `/index` build
+  Pages deploys, via a miniserve `--route-prefix /index` wrapper
+  (`lib/per-system.nix:432`), not a separate `BASE_PATH` rebuild.
+
+## Glossary
+
+- **update / entry**: one changelog post; a `.svx` file in
+  `site/src/lib/updates/` with frontmatter + markdown body.
+- **`.svx`**: an mdsvex file - markdown that may contain a Svelte `<script>` and
+  components; compiled to a Svelte component by the mdsvex preprocessor.
+- **mdsvex**: the markdown-in-Svelte preprocessor wired in `svelte.config.js:11`
+  and configured by `mdsvex.config.js`.
+- **filter expression**: the flecs-style boolean tag query on the home page
+  (`nix & (rust | zig)`), parsed by `filter-expression.ts`.
+- **frontmatter**: the YAML block at the top of each `.svx`; becomes
+  `metadata` and is normalized to `SiteUpdateMeta` (`updates.ts:8`).
+- **adapter-static**: the SvelteKit adapter that prerenders the app to flat
+  files (`svelte.config.js:14`); output lands in `build/`.
+- **base path**: the `/index` URL prefix for GitHub project pages
+  (`svelte.config.js:24`).
+- **shiki dual-theme**: syntax highlighting that ships both light and dark colors
+  per token as CSS variables (`mdsvex.config.js:10`).
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| routes | [routes/overview.md](routes/overview.md) | the page/endpoint tree: layout, home feed, `[id]` permalink, `feed.xml`, prerender + base path |
+| lib | [lib/overview.md](lib/overview.md) | content data layer, components (`UpdateEntry`, `FilterBar`), the tag filter, xyflow diagrams, mdsvex, styling |
+| build-deploy | [build-deploy/overview.md](build-deploy/overview.md) | recipe: `ix.buildSvelteSite`, `.#site`/`.#site-dev`, vitest checks, GitHub Pages deploy |

--- a/docs/site/lib/diagrams.md
+++ b/docs/site/lib/diagrams.md
@@ -1,0 +1,67 @@
+# lib / diagrams
+
+`site/src/lib/diagrams/` is the interactive flowchart system embedded inside
+`.svx` entries. It is built on `@xyflow/svelte` (the Svelte port of React Flow,
+`site/package.json:37`). Three layers: a reusable frame
+(`DiagramFrame.svelte`), one custom node type (`BoxNode.svelte`), and thin
+data-only diagram wrappers (`*Diagram.svelte`). All styling uses the same
+`app.css` theme tokens, so diagrams follow light/dark automatically.
+
+## `DiagramFrame.svelte`
+
+The reusable wrapper around `<SvelteFlow>`. Props (`:15-20`): `nodes: Node[]`,
+`edges: Edge[]`, `height = 300`, `caption?`.
+
+- **Edge defaults.** `decoratedEdges` (`:29-35`) gives each edge a `smoothstep`
+  type and an `ArrowClosed` marker unless the caller overrides them.
+- **Prop -> state sync.** SvelteFlow's `bind:` needs `$state` containers but the
+  prop stays the source of truth, so `$effect.pre` copies props into
+  `inlineNodes/inlineEdges` and `modalNodes/modalEdges` (`:40-49`). `$state.raw`
+  avoids deep proxying of the graph arrays.
+- **Custom node type.** `nodeTypes = { box: BoxNode }` (`:54`); the structural
+  cast is needed because xyflow's `NodeTypes` index signature is wider than the
+  concrete `BoxNode` type (comment `:51-53`).
+- **Mount gate.** `<SvelteFlow>` needs the DOM (ResizeObserver,
+  getBoundingClientRect), so it renders only after `onMount` sets `mounted`
+  (`:56-61,150`). This keeps it out of the static prerender; the prerendered HTML
+  has an empty, `aria-hidden` placeholder until hydration.
+- **Inline view (`:150-191`).** Non-interactive: `fitView`, dragging/zoom/pan all
+  disabled, attribution hidden, dotted background. A single "Expand" button opens
+  the modal.
+- **Modal view (`:195-259`).** A `role="dialog" aria-modal="true"` overlay with a
+  backdrop button, a fully interactive `<SvelteFlow>` (drag, zoom, pan,
+  `<Controls>`), and a close button. It implements a manual focus trap and Escape
+  handling (`onModalKeydown` `:87-125`, `modalFocusableElements` `:127-134`),
+  focuses the close button on open, restores focus to the trigger on close
+  (`:81-85`), and freezes body scroll while open (`$effect` `:136-145`).
+- **Theming.** Scoped `:global(...)` rules restyle the xyflow edges, arrowheads,
+  edge labels, controls, and background to the `--fg-*`/`--rule`/`--bg`/`--code`
+  tokens (`:397-453`); `.dashed` edges get a dash array.
+
+## `BoxNode.svelte`
+
+The one custom node renderer (`type: 'box'`). Data shape `BoxData` (`:4-9`):
+optional `kicker`, required `label`, optional `sublabel`, and `kind`
+(`'default' | 'proc' | 'artifact' | 'agent' | 'gate'`). Each `kind` is a distinct
+border/background style (`:46-69`): `proc` filled, `artifact` dashed, `agent`
+double border, `gate` a skewed parallelogram (with counter-skewed text). It
+declares eight xyflow `Handle`s (target+source on all four sides, `:22-29`) so
+edges can attach to any side via `sourceHandle`/`targetHandle`; the handle dots
+are hidden but connection points stay live (`:104-112`). `label` may contain
+`<code>`.
+
+## Diagram wrappers (`*Diagram.svelte`)
+
+Each is a data-only module: it defines `nodes`/`edges` arrays and renders one
+`<DiagramFrame {nodes} {edges} height caption />`. No logic beyond layout data.
+
+| file | embedded by | depicts |
+| --- | --- | --- |
+| `IxMcpDiagram.svelte` | `updates/ix-mcp-python.svx` | agent -> `ix-mcp` stdio -> python worker + session globals + recorded `lines.jsonl` |
+| `RunRecorderDiagram.svelte` | `updates/run-recorder.svx` | `nix run .#run` PTY recorder capturing a command to a log |
+| `AiReviewGateDiagram.svelte` | `updates/ai-review-gate.svx` | a GitHub PR event flowing through the AI review gate |
+
+To add a diagram: create a `*Diagram.svelte` with `nodes`/`edges` (use `BoxNode`
+`kind`s for visual roles) and embed it from an entry's `<script>` block (see
+`updates/ix-mcp-python.svx:11-17`). It will render statically as a placeholder and
+become interactive after hydration.

--- a/docs/site/lib/overview.md
+++ b/docs/site/lib/overview.md
@@ -1,0 +1,148 @@
+# lib
+
+`site/src/lib` is the shared layer the [routes](../routes/overview.md) build on:
+the content data layer that turns `.svx` files into `siteUpdates[]`, the
+presentation components, the boolean tag filter, the global stylesheet, and the
+mdsvex rendering pipeline. The xyflow diagram system is large enough to have its
+own page: [diagrams](diagrams.md).
+
+Imported via SvelteKit's `$lib` alias. vitest re-wires `$lib` and mdsvex by hand
+(`vitest.config.ts:16-27`) because the browser test runner does not load the full
+SvelteKit plugin.
+
+## Content data layer (`updates.ts`)
+
+The single source of truth for entries. Public surface (`updates.ts`):
+
+- Types: `SiteUpdateLink` (`:3`), `SiteUpdateMeta` (`:8`: `id`, `postedAt`,
+  `title`, `links`, `tags`), `SiteUpdate` (`:22`: meta + compiled `component` +
+  `rawBody`).
+- `siteUpdates: SiteUpdate[]` (`:41`) - the entry list. Built from two
+  `import.meta.glob` calls over `./updates/*.svx`: one eager import of the
+  compiled module (`:34`, gives `metadata` + default `Component`) and one
+  `query: '?raw'` import of the source text (`:35-39`). For each file it spreads
+  `metadata`, lowercases `tags` (`:44`), keeps the compiled `default` as
+  `component`, and strips frontmatter from the raw text into `rawBody` (`:46`,
+  `stripFrontmatter` `:55`). Sorted newest-first by `Date.parse(postedAt)`
+  (`:48`). Adding an entry needs no registration; the glob discovers it.
+- Constants: `siteUrl = 'https://indexable-inc.github.io/index/'` (`:50`),
+  `siteFeedUrl = siteUrl + 'feed.xml'` (`:51`), `siteIntro` (`:52`).
+- Text helpers:
+  - `plainText(markdown)` (`:59`) - strips `<script>` blocks, capitalized
+    component tags, fenced/inline code, bold/italic, and link syntax for plain
+    text (titles in `<title>`, RSS bodies).
+  - `inlineTitleHtml(markdown)` (`:73`) - HTML-escapes, then re-wraps backtick
+    runs as `<code>`; the only sanctioned HTML for titles.
+  - `updateScript(update)` (`:90`) - `plainText(title) + '. ' + plainText(body)`,
+    used by the RSS `<description>`.
+  - `updateUrl(id)` (`:96`) - absolute permalink for a slug (`siteUrl + id`).
+
+`SvxModule.metadata.tags` is optional because mdsvex does not validate
+frontmatter; the loader normalizes it to a required `string[]` (`:31,44`).
+
+## Tag filter (`filter-expression.ts`)
+
+A tiny flecs-style boolean tag query (`nix & (rust | zig)`), used by the home
+feed. Precedence NOT > AND > OR; empty input matches everything (`:10,30`).
+
+- `parseFilter(input): FilterExpression` (`:32`) - tokenizes (`tokenize` `:56`),
+  recursive-descent parses (`Parser` `:102`: `parseOr`/`parseAnd`/`parseNot`/
+  `parseAtom`), and returns either `{ ok: true, matches }` or `{ ok: false,
+  error }`. `matches(tags)` evaluates the AST against a `Set` (`evaluate` `:216`).
+  Adjacent terms are an implicit AND (`:139-140`).
+- `highlightExpression(input): HighlightToken[]` (`:181`) - a tolerant tokenizer
+  that never fails: every character lands in some span (`tag`/`op-*`/`paren`/
+  `space`/`error`) so the rendered overlay matches the input character for
+  character. Used by `FilterBar`. Covered by `filter-expression.test.ts`.
+
+## Components
+
+### `UpdateEntry.svelte`
+
+Renders one entry, shared by the feed and permalink pages. Props (`:6-11`):
+`update: SiteUpdate`, `timeZone`, `titleTag?: 'h1' | 'h2'` (default `h2`).
+
+- `<time datetime={postedAt}>` labeled via `formatPostedAt` (`:17,22`).
+- Title is `inlineTitleHtml(update.title)` rendered with `{@html}` (eslint
+  disabled inline, `:25-32`); on the feed it is an `<a>` to the permalink
+  (`resolve('/[id]', { id })`, `:18`), on a permalink page a bare `<h1>`.
+- `<Body />` is the compiled `.svx` component (`update.component`, `:15,35`).
+- Optional `.refs` (frontmatter `links`, `rel="external"`, `:37-44`) and `.tags`
+  list (`:45-51`).
+
+### `FilterBar.svelte`
+
+The home-page filter input with live syntax highlighting. Props (`:4-10`):
+`value`, `onChange`, `matchCount`, `totalCount`, `error?`.
+
+- Technique: a transparent-text `<input>` (visible caret) layered over an
+  `.overlay` that paints `highlightExpression(value)` tokens (`:14,32-53`).
+  Padding/font/line-height match pixel-for-pixel (CSS comment `:98-101`).
+- `syncScroll` (`:21-25`) mirrors the input's `scrollLeft` onto the overlay so
+  long expressions stay aligned. `matchCount / totalCount` shown live; `error`
+  rendered below when the expression fails to parse. Token colors are scoped
+  CSS using `light-dark()` (`:143-166`).
+
+### Time formatting (`format-posted-at.ts`)
+
+`formatPostedAt(postedAt, zone)` (`:4`) renders `Mon D, YYYY . HH:MM TZ` via
+`Intl.DateTimeFormat`. `zone` defaults to `'UTC'` so SSR output is identical for
+every visitor; callers pass the resolved local zone after hydration. Both pages
+follow this SSR-UTC / client-local pattern.
+
+## Diagrams
+
+The `lib/diagrams/` directory is an interactive flowchart system built on
+`@xyflow/svelte`, embedded inside `.svx` bodies. It has its own page:
+[diagrams](diagrams.md). Summary: `DiagramFrame.svelte` wraps `<SvelteFlow>`
+(mount-gated, non-interactive inline, expandable modal with focus trap),
+`BoxNode.svelte` is the one custom node type, and the `*Diagram.svelte` files are
+thin data-only wrappers.
+
+## Content entries (`lib/updates/*.svx`)
+
+27 changelog entries plus `fixtures/mdsvex-safety.svx` (a test fixture). Each
+entry is YAML frontmatter (`id`, `postedAt`, `title`, `tags`, `links`) followed
+by markdown; a few open with a Svelte `<script>` that imports a diagram and embed
+it inline (e.g. `updates/ix-mcp-python.svx:11-17`). Frontmatter is parsed by
+mdsvex into `metadata`; the body compiles to the component rendered as `<Body />`.
+
+## mdsvex pipeline (`mdsvex.config.js`)
+
+`.svx` is registered in `svelte.config.js:8` and preprocessed by `mdsvex` with
+`siteMdsvexOptions` (`svelte.config.js:11`). The config:
+
+- `highlight.highlighter = highlightCode` (`:10-14`) - shiki dual-theme. Each
+  code block renders with both `github-light` and `github-dark`, colors emitted
+  as CSS variables (`defaultColor: false`, `:53`); `app.css` selects one per
+  `prefers-color-scheme`. Unknown languages fall back to `text`
+  (`isMissingShikiLanguage`, `:57`).
+- `rehypePlugins: [sanitizeLinks]` (`:9`) - rewrites every `<a href>` in body
+  content through `safeHref` (`:34`): keeps root (`/`) and fragment (`#`) hrefs,
+  allows only `https`/`http`/`mailto` absolute URLs, and drops everything else
+  (e.g. `javascript:`, protocol-relative `//`). A dropped href removes the
+  attribute, leaving inert text. Verified by `mdsvex-safety.test.ts` against
+  `fixtures/mdsvex-safety.svx`.
+
+## Styling (`src/app.css`)
+
+Plain CSS, no framework. `:root` declares `color-scheme: light dark` and a token
+set (`--bg`, `--fg`, `--fg-muted`, `--fg-faint`, `--rule`, `--code`, fonts);
+`@media (prefers-color-scheme: dark)` overrides the colors (`app.css:1-24`).
+Layout is a centered `max-width: 42rem` column (`:74-111`). shiki output is
+themed by `.body pre.shiki span { color: var(--shiki-light) }` with a dark
+override (`:220-235`). Components scope their own styles (`FilterBar`, the
+diagram frame/node) and rely on the same tokens.
+
+## Tests
+
+vitest in browser mode (playwright chromium, `vitest.config.ts:29-41`):
+
+- `updates.test.ts` - `inlineTitleHtml`/`plainText`/`updateScript` behavior and
+  invariants over `siteUpdates` (slug ids, ISO dates, lowercased tags,
+  newest-first order, absolute https links, unique ids).
+- `filter-expression.test.ts` - parser semantics (AND/OR/NOT, precedence,
+  grouping, errors).
+- `mdsvex-safety.test.ts` - mounts the fixture and asserts unsafe links are inert
+  and unknown code languages fall back. See [build-deploy](../build-deploy/overview.md) for how
+  these run as flake checks.

--- a/docs/site/routes/overview.md
+++ b/docs/site/routes/overview.md
@@ -1,0 +1,98 @@
+# routes
+
+`site/src/routes` is the SvelteKit route tree. It is small: a root layout, a home
+feed, a dynamic permalink, and one non-HTML endpoint (the RSS feed). Every route
+is prerendered to static files (no server runtime). All page data comes from
+[`$lib/updates`](../lib/overview.md); routes hold presentation and prerender
+config only.
+
+## App shell
+
+The HTML template and global config live next to the routes under `site/src`:
+
+- `src/app.html` - the document shell. `%sveltekit.head%`/`%sveltekit.body%`
+  placeholders, `data-sveltekit-preload-data="hover"` (prefetch on hover), and
+  the favicon at `%sveltekit.assets%/favicon.svg` (`src/app.html:5,9`). The only
+  static asset is `static/favicon.svg`.
+- `src/app.css` - the global stylesheet, imported once by the layout. Theme
+  tokens and component styles; see styling in [lib](../lib/overview.md).
+- `src/app.d.ts` - the empty SvelteKit `App` namespace (no custom `Locals` etc.).
+- `src/mdsvex.d.ts` - ambient module decl for `*.svx` (default `Component` +
+  `metadata`).
+
+## Prerender + base path (tree-wide)
+
+- `routes/+layout.ts:1` - `export const prerender = true;`. This applies to the
+  whole route subtree, so the entire app is static.
+- `svelte.config.js:24` sets `paths.base = process.env.BASE_PATH ?? '/index'`.
+  Code never hardcodes `/index`; it calls `resolve()` from `$app/paths`
+  (`+layout.svelte:3`, `UpdateEntry.svelte:2`) so the base is applied in one
+  place. Override `BASE_PATH=""` for apex/custom-domain deploys.
+
+## `+layout.svelte` (`routes/+layout.svelte`)
+
+The chrome wrapped around every page.
+
+- Imports `app.css` (`:5`) so global styles load once.
+- `<svelte:head>` adds the RSS `<link rel="alternate" type="application/rss+xml">`
+  pointing at `siteFeedUrl` (`:13-15`).
+- `<header>`: wordmark link to home (`resolve('/')`, `:9,18`) and a `<nav>` with
+  three external/site links: GitHub repo, `https://ix.dev`, and the RSS feed
+  (`resolve('/feed.xml')`, `:19-23`).
+- `<main>{@render children()}</main>` renders the active page (Svelte 5 snippet
+  prop, `:7,26-28`).
+
+## `/` home feed (`routes/+page.svelte`)
+
+The landing page: a hero plus the filterable update log.
+
+- State (Svelte 5 runes):
+  - `timeZone` resolved in `onMount` (`:11-14`); SSR renders UTC, hydration
+    switches `<time>` to the visitor's zone.
+  - `filter` initialized to `'interesting'` (`:18`) - the default narrows the log
+    to author-flagged headline items.
+  - `parsed = parseFilter(filter)` and `filtered` derived from it (`:20-23`);
+    when the expression is invalid, the full list is shown and `error` is set.
+- `<svelte:head>` sets `<title>` and the `description` meta from `siteIntro`
+  (`:27-30`).
+- Renders `siteIntro` in a `.hero`, then [`FilterBar`](../lib/overview.md) (value,
+  `onChange`, match/total counts, error), then an ordered list of
+  [`UpdateEntry`](../lib/overview.md) keyed by `update.id` (`:47-53`).
+
+## `/[id]` permalink (`routes/[id]/`)
+
+One page per update, addressable by slug.
+
+- `[id]/+page.ts`:
+  - `prerender = true` (`:5`).
+  - `entries` (`:7-8`) returns `{ id }` for every entry in `siteUpdates`, so the
+    static adapter emits one HTML file per update.
+  - `load` (`:10-13`) finds the entry by `params.id`; an unknown id throws
+    `error(404, ...)`, which adapter-static renders against the `404.html`
+    fallback.
+- `[id]/+page.svelte`:
+  - Same `timeZone` onMount pattern (`:9-12`).
+  - `titleText = plainText(data.update.title)` feeds `<title>`/description
+    (`:14,17-20`).
+  - Renders one [`UpdateEntry`](../lib/overview.md) with `titleTag="h1"` (the
+    feed uses the default `h2`).
+
+## `/feed.xml` RSS endpoint (`routes/feed.xml/+server.ts`)
+
+A non-HTML route: a `+server.ts` `GET` that returns an RSS 2.0 document.
+
+- `prerender = true` (`:11`) so the feed is emitted as a static `feed.xml`.
+- `GET()` (`:50-72`) builds `<channel>` metadata from `siteUrl`/`siteFeedUrl`/
+  `siteIntro`, `lastBuildDate` from the newest entry, and one `<item>` per update
+  via `itemXml` (`:36-48`).
+- Item bodies use `updateScript(update)` (title + flattened body,
+  `updates.ts:90`); all text is run through a local `escapeXml` (`:13-30`) and
+  dates through `rssDate` -> `toUTCString` (`:32-34`).
+- Returns `content-type: application/rss+xml; charset=utf-8` (`:67-71`).
+
+## Notes
+
+- There is no error page component (`+error.svelte`) or non-prerendered route;
+  the static `404.html` fallback (`svelte.config.js:17`) handles unknown paths.
+- All in-app navigation is base-path-aware via `resolve()`; external links in the
+  header and in entry frontmatter are absolute URLs.

--- a/docs/symphony/common.md
+++ b/docs/symphony/common.md
@@ -1,0 +1,122 @@
+# Symphony
+
+Symphony is a boring DAG runtime for deterministic agent workflows. It is an
+Elixir/OTP control plane (`packages/symphony/elixir`) that orchestrates Codex
+and Claude agent sessions across one or more git repositories. Workflows are
+authored in the `.sym` surface language, lowered to an intermediate-representation
+(IR) run graph, and walked by a supervised per-run GenServer with a LiveView
+dashboard, cron/Slack/Linear/GitHub triggers, and per-run git worktrees. The
+single Nix flake output is `nix run .#symphony` (`packages/symphony/default.nix:148`);
+the runtime drives a Rust `room-server` (in the ix monorepo, not here) over HTTP
+to actually run each agent turn.
+
+Read this page first, then the component pages it links. Symphony moved here from
+the standalone `indexable-inc/symphony` repo at rev `c9e7092`
+(`packages/symphony/README.md:10`).
+
+## Units
+
+This domain is one package (`packages/symphony`) whose Elixir source is layered.
+The layers, and where each is documented:
+
+| layer | path | role |
+| --- | --- | --- |
+| DSL | `elixir/lib/symphony_elixir/dsl/` | the `.sym` lexer, parser, reified AST, interpreter (eval-as-emission), and schema. See [dsl](dsl/overview.md). |
+| IR + runtime | `elixir/lib/symphony_elixir/ir/`, `runtime/` | the durable `RunGraph`, the per-run scheduler, executors, crash recovery, and per-run room-server placement. See [engine](engine/overview.md). |
+| engine wire | `elixir/lib/symphony_elixir/engine/` | the typed `Engine.Envelope` and the `Engine.Client` that lowers a turn to the room-server `TurnRequest`. See [engine contract](engine/contract.md). |
+| pack | `elixir/lib/symphony_elixir/{catalog,workflow_catalog,skill,prompt}.ex`, `repository_catalog.ex`, `workflows/example/` | the hot-reloaded workflow-pack format (`.sym` + skills + `repositories.yaml`). See [pack](pack/overview.md). |
+| operations | `default.nix`, `bin/run-nix`, `config.ex`, `*_web/`, triggers, `../../modules/services/symphony` | launching, env vars, the dashboard at `:4040`, triggers, and the NixOS module. See [operations](operations/overview.md). |
+
+It is a Nix-only package (a Nushell launcher wrapping `bin/run-nix`), not a Rust
+workspace member. The `room-server` it drives is a separate package in the ix
+monorepo (`crates/room`, `packages/room`); only the Elixir control plane lives
+here (`packages/symphony/default.nix:9-13`).
+
+## How it fits together
+
+```
+.sym source --parse--> reified AST --interpret/expand--> IR RunGraph --schedule--> agent turn
+  DSL.Parser            DSL.AST          DSL.Interpreter      IR.*           Engine.Client -> room-server
+```
+
+The layering is a strict one-way dependency the overhaul encodes:
+`DSL -> IR -> Runtime -> Engine.Client -> room-server`, with `Engine.Client`
+the only module in `elixir/lib/` that names the room-server HTTP contract
+(`engine/client.ex:1-8`). A producer (cron, a webhook, the dashboard) resolves
+a trigger event to a `WorkflowCatalog` entry, `Runtime.Ingress` materializes its
+AST into a `RunGraph`, and `Runtime.Supervisor` starts one `Runtime` GenServer
+that schedules ready nodes as monitored BEAM tasks until every node is terminal.
+
+- A workflow is a `do`-block of statements. A `name <- effect` binding introduces
+  a data dependency; statements whose inputs do not reference each other have no
+  edge and run in parallel (`dsl/ast.ex:15-28`). The graph gets auto-parallelism
+  from data flow, never a `needs:` list.
+- Only effectful constructors (`agent`, `exec`, `subrun`) become `IR.Node`s. Pure
+  values (string concat, `${node.field}` reads) are evaluated inside the
+  interpreter at expand time and never fill the graph with trivial nodes
+  (`dsl/interpreter.ex:22-27`).
+- Each agent node carries an `Engine.Envelope` (engine/model/effort/permissions/
+  location), validated and lowered at load (`ir/materializer.ex:41-45`).
+
+## Invariants
+
+- **Determinism by replay.** A run is durable as a `RunGraph` (`ir/run_graph.ex`):
+  the reified AST, the materialized nodes, and an append-only `expansion_log`. On
+  restart the runtime does not resurrect a live computation; it re-runs the
+  interpreter against the recorded outputs and log, rebuilding the identical node
+  set. The asserted invariant is `replay(ast, expansion_log) == nodes`
+  (`ir/run_graph.ex:14-19`). Gates (`when`, `every`, `map`) are pure functions of
+  `known_outputs` and persisted counters: no wall clock, no RNG
+  (`dsl/interpreter.ex:35-39`).
+- **Edges are derived, never declared.** `IR.Node.deps` is computed from `inputs`
+  (`ir/node.ex:170-180`); an input that reads another node's output is the only
+  thing that makes an edge. A node is ready only when every dep `:succeeded`
+  (`ir/graph.ex:56-65`).
+- **Crash bias is conservative.** Agent turns are not idempotent (a turn may push
+  a commit), so a node stranded by a task/BEAM crash is auto-retried only if it
+  opted in AND showed no side effect (no `thread_id` recorded); otherwise it is
+  left `:stranded` for human review (`runtime/recovery.ex:23-41`).
+- **Workspace safety.** Every run gets a fresh `git worktree` under
+  `SYMPHONY_WORKSPACES_DIR`; an agent turn never runs with cwd inside the source
+  repo, and workspace-relative paths route through `PathSafety.canonicalize/1`
+  (`workspace.ex:66-85`).
+- **Pack-agnostic core.** No workflow names, repo slugs, labels, or ticket schemes
+  are hardcoded in `elixir/lib/`; workflow shape lives in the pack
+  (`packages/symphony/AGENTS.md:29-35`).
+
+## Glossary
+
+- **`.sym`**: the surface workflow language, parsed to a reified AST
+  (`dsl/parser.ex`). See [dsl](dsl/overview.md).
+- **effect**: an `agent`, `exec`, or `subrun` constructor; the only kinds that
+  become IR nodes (`dsl/ast.ex:176-180`).
+- **combinator / gate**: `when`, `every n of <counter>`, `map ... as`: dynamic
+  constructs that emit a placeholder node, then emit their body deterministically
+  once the gating input resolves (`dsl/interpreter.ex:31-34`).
+- **eval-as-emission**: evaluating the AST against known outputs emits IR nodes;
+  re-evaluating with more outputs emits the next delta (`ir/materializer.ex:13-28`).
+- **RunGraph**: the durable per-run state (AST, nodes, expansion log)
+  persisted as JSON by `IR.Store` (`ir/run_graph.ex`).
+- **expansion log**: the append-only record of each dynamic expansion; replaying
+  it rebuilds the materialized graph (`ir/run_graph.ex:7-19`).
+- **envelope**: a node's typed execution spec (engine, model, effort, permissions,
+  location), validated by `Engine.Envelope` (`engine/envelope.ex`).
+- **placement / location**: where an agent's engine process runs (`:local`,
+  `:ixvm`, `{:host, _}`, `{:room, url}`); the run provisions its own room-server
+  for `:ixvm`/`:host` (`runtime/placement.ex`).
+- **room-server**: the Rust engine host (ix monorepo) that runs one agent turn
+  over `POST /api/agent/turns`; Symphony speaks to it only through `Engine.Client`.
+- **pack**: a directory of `workflows/*.sym`, `skills/*.md`, and
+  `repositories.yaml` selected with `SYMPHONY_PACK_DIR` (`config.ex:16-24`).
+- **skill**: a markdown system prompt under `skills/`, model-agnostic, referenced
+  by an agent node as `prompt: skill "name"` (`skill.ex:1-27`).
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| dsl | [dsl/overview.md](dsl/overview.md) | the `.sym` language: lexer, grammar, AST, node types, triggers, fields, interpreter |
+| engine | [engine/overview.md](engine/overview.md) | the IR run graph and the supervised DAG runtime: scheduling, executors, recovery, placement |
+| engine contract | [engine/contract.md](engine/contract.md) | the cross-language wire seam: `Envelope`, `TurnRequest`/`EngineEvent`/`AgentTurnResponse`, golden fixtures |
+| pack | [pack/overview.md](pack/overview.md) | the workflow-pack format (workflows, skills, repositories.yaml), hot-reload catalogs, the bundled example |
+| operations | [operations/overview.md](operations/overview.md) | running it: `nix run .#symphony`, env vars, placements, the dashboard at `:4040`, triggers, the NixOS module |

--- a/docs/symphony/dsl/overview.md
+++ b/docs/symphony/dsl/overview.md
@@ -1,0 +1,209 @@
+# DSL: the `.sym` workflow language
+
+`elixir/lib/symphony_elixir/dsl/` is the front end that turns `.sym` source into
+the durable IR graph the [engine](../engine/overview.md) walks. The pipeline has
+three representations (`dsl/ast.ex:5-13`):
+
+```
+.sym source --parse--> reified AST --interpret/expand--> IR.Node delta
+  Parser/Lexer          AST              Interpreter
+```
+
+Everything is plain data, never a host closure: a closure could not be serialized
+into the durable `RunGraph`, shown in the dashboard, or replayed deterministically
+after a restart, so the whole surface is reified as structs the interpreter walks.
+
+## Modules
+
+- **`parser/lexer.ex`** - tokenizes source into a flat list, each token carrying a
+  1-based line/column for precise diagnostics (`lexer.ex:1-17`).
+- **`parser.ex`** - the recursive-descent parser; `parse/2` returns `{:ok, ast}`
+  or `{:error, diagnostic}` with a source span (`parser.ex:1-12`).
+- **`ast.ex`** - the reified constructors and types (workflow, bind, let, effects,
+  combinators, pure values).
+- **`interpreter.ex`** - `expand/3`: the eval step that emits `IR.Node`s.
+- **`schema.ex`** - one JSON-able snapshot of the runtime's enum vocabulary, fed
+  to the dashboard forms (`schema.ex:1-12`).
+
+## Lexer (`parser/lexer.ex`)
+
+Keywords (`lexer.ex:19`): `workflow agent exec subrun when every of map as skill
+inline timeout true false null`. Punctuation tokens: `<-` (`:larrow`), `{` `}`
+`[` `]` `:` `,` `=`. Three non-obvious decisions (`lexer.ex:7-16`):
+
+- String literals are emitted as segment lists of `{:lit, text}` and `{:ref,
+  path}`, so `"summarize ${session.report}"` tokenizes with the interpolation
+  already split out.
+- A bare `${path}` outside a string is its own `:interp` token (the common
+  `when ${gate.ok} { ... }` shape).
+- `#` starts a line comment to end of line. `\n`/`\t`/`\r`/`"`/`\\` escapes are
+  recognized in strings (`lexer.ex:154-159`); numbers lex to `:int` or `:float`.
+
+## Grammar
+
+A workflow is an optional name and trigger header, then a brace `do`-block of
+statements (`parser.ex:122-132`):
+
+```
+workflow [ "<name>" ] [ on <trigger> ] { stmt* }
+stmt    := name "<-" expr      # bind: name binds an effect's output
+         | name "=" pure       # let: name binds a pure value
+         | expr                # a bare effect
+expr    := effect | pure
+```
+
+Effects (the only constructors that become IR nodes, `ast.ex:29-37`):
+
+```
+agent  { engine: .. model: .. effort: .. permissions: .. location: ..
+         inputs: { k: pure } prompt: <prompt_ref> }
+exec   <pure> [ timeout <int> ] [ { k: pure } ]
+subrun <pure> [ { k: pure } ]
+```
+
+Combinators (dynamic expansion, `ast.ex:44-59`), each body is a brace block with
+exactly one statement (`parser.ex:483-492`):
+
+```
+when <pure> { stmt }                # run body only if pure is truthy
+every <int> of <counter> { stmt }   # run body every nth tick of a named counter
+map <pure> as <name> { stmt }       # fan the body out once per list element
+```
+
+Pure values (`ast.ex:61-72`, `parser.ex:539-568`): string literals (with `${path}`
+interpolation), integers, floats, `true`/`false`/`null`, bracketed lists `[a, b]`,
+and `${name.field.path}` references. A bare `${name}` lowers to a `var`; a dotted
+`${name.a.b}` lowers to a `field` read; an interpolated string lowers to a
+`concat` of literal and field segments (`parser.ex:593-615`).
+
+A `prompt:` field is either `skill "name" [ { bindings } ]` or `inline <pure>`
+(`parser.ex:384-409`). The agent envelope keys are exactly `engine model effort
+permissions location` (`parser.ex:330`); an unknown agent field or a missing
+`prompt` is a located error (`parser.ex:364-365`, `parser.ex:619-620`).
+
+### Example
+
+`elixir/test/symphony_elixir/dsl/fixtures/release.sym`:
+
+```
+workflow "release" {
+  inspect <- agent {
+    engine: codex
+    model: "gpt-5.3-codex"
+    effort: medium
+    permissions: workspace_write
+    location: local
+    prompt: skill "inspect" { repo: "symphony" }
+  }
+
+  report <- agent {
+    engine: claude
+    model: haiku
+    permissions: read_only
+    prompt: inline "write a status report and stop"
+  }
+
+  summary <- agent {
+    engine: codex
+    model: "gpt-5.3-codex"
+    permissions: read_only
+    prompt: inline "summarize ${inspect.area}"
+  }
+
+  when ${inspect.changed} {
+    notify <- exec "./scripts/notify.sh" timeout 30
+  }
+}
+```
+
+`inspect` and `report` read disjoint inputs, so they have no edge and run in
+parallel; `summary` reads `${inspect.area}`, so it waits on `inspect`.
+
+## Triggers (the `on` header)
+
+The header `on <kind> <params>` declares what fires the workflow; omitting it
+yields a `nil` trigger (an operator-only workflow). The kinds are the source of
+truth in `parser.ex:80` (`@trigger_kinds`), exposed through `Parser.trigger_kinds/0`
+so the [schema](#schema-vocabulary) and dashboard forms offer exactly what the
+parser accepts:
+
+| kind | surface | normalized map (`parser.ex:156-189`) |
+| --- | --- | --- |
+| `manual` | `on manual` | `%{kind: :manual}` |
+| `cron` | `on cron "<sched>" [tz "<zone>"] [input {..}]` | `%{kind: :cron, schedule, timezone, input}` |
+| `linear` | `on linear label "<label>"` | `%{kind: :linear, label}` (downcased) |
+| `slack_huddle` | `on slack_huddle channel "<ch>"` | `%{kind: :slack_huddle_completed, channel}` |
+| `slack_mention` | `on slack_mention channel "<ch>"` | `%{kind: :slack_app_mention, channel}` |
+| `github_pr_label` | `on github_pr_label repo "<r>" label "<l>"` | `%{kind: :github_pr_label, repo, label}` |
+
+The normalized maps match the runtime's trigger shapes so a producer can match an
+inbound event against a workflow with one shared matcher
+([Runtime.Trigger](../engine/overview.md#triggers-and-ingress)). The `cron`
+schedule grammar is parsed separately by `CronExpression`
+(see [operations](../operations/overview.md#triggers)).
+
+## Interpreter: expand (`interpreter.ex`)
+
+`expand(ast, known_outputs, expansion_log)` returns `{ir_delta, pending, new_log}`
+(`interpreter.ex:7-20`):
+
+- `ir_delta` is the list of `IR.Node`s to materialize this pass. Re-running with
+  more `known_outputs` yields the next delta.
+- `pending` is `{:awaiting, ast_id, needed_node_ids}` for effects that cannot
+  materialize until upstream outputs arrive (a prompt or input mixing a literal
+  with a node read cannot be one input ref, so it is deferred, `interpreter.ex:41-51`).
+- `new_log` extends the expansion log with one event per dynamic expansion that
+  fired; its order is load-bearing for replay.
+
+The four rules (`interpreter.ex:22-39`):
+
+1. Only `agent`/`exec`/`subrun` become nodes; pure computation is evaluated here.
+2. `IR.Node.deps` is derived from `inputs`; the interpreter never hand-writes edges.
+3. `when`/`every`/`map` emit a `:gate` or `:map_fanout` placeholder when their
+   gating input is unresolved, and emit children deterministically when re-expanded
+   with the resolved output.
+4. Gates are pure functions of `known_outputs` and counters recovered from the
+   log: no wall clock, no RNG. The same `(ast, known_outputs, expansion_log)`
+   always yields the same `ir_delta`.
+
+### Pure value resolution
+
+`resolve_value/3` reduces a pure to `{:value, v}`, `{:node, id, path}` (the one
+shape that makes a dependency edge), or `:deferred` (`interpreter.ex:433-490`). A
+fully-literal value folds to a literal; a single `${node.path}` read becomes a
+node ref; a `concat`/`list` mixing literals with a node read is deferred until the
+referenced outputs are known, then folds on re-expansion.
+
+### Combinator semantics
+
+- `when`: evaluates `cond`; emits the body if truthy (`true`/non-nil), else logs a
+  closed gate and emits nothing (`interpreter.ex:193-210`).
+- `every n of counter`: deterministic gate keyed on a persisted counter recovered
+  from the log; fires when the next tick is a multiple of `n`. To keep a re-pass
+  within one run idempotent, an already-recorded tick is reproduced from the log
+  rather than recomputed (`interpreter.ex:212-272`).
+- `map over as elem`: fans the body out once per list element with a stable
+  `{:fanout, id, index}` expansion key, binding each element to `as`. A non-list
+  `over` is a typed mismatch surfaced as an empty fan-out, not a crash
+  (`interpreter.ex:235-339`). A `name <- map ...` binding is dropped: a fan-out
+  binds no single node (`interpreter.ex:316-318`).
+
+## Stable node ids and diagnostics
+
+The parser assigns each effect a positional id (`agent-0`, `exec-1`, ...) in
+source pre-order (`parser.ex:688-695`); the interpreter combines it with an
+expansion key to derive the final `IR.Node` id, so re-parsing identical source
+yields identical ids, the property replay needs (`ast.ex:74-79`). Every diagnostic
+is `%{message, line, column, file, got}` with a 1-based span pointing at the
+failing token; `file` is stamped by the `WorkflowCatalog` so an author sees which
+`.sym` broke (`parser.ex:53-61`).
+
+## Schema vocabulary
+
+`Schema.to_map/0` (`dsl/schema.ex`) collects the runtime's enums into one map: `engines`, `efforts`,
+`permissions`, `locations` (from `Engine.Envelope`), `node_kinds`/`node_states`
+(from `IR.Node`), `effect_kinds` (from `AST`), and `trigger_kinds` (from
+`Parser`). Each field reads the single accessor on the module that owns the enum,
+so the schema cannot drift from what a turn, node, or the parser will accept
+(`schema.ex:6-11`). It is served at `GET /api/v1/ir/schema` and drives the
+dashboard's option lists.

--- a/docs/symphony/engine/contract.md
+++ b/docs/symphony/engine/contract.md
@@ -1,0 +1,129 @@
+# Engine contract: the room-server wire seam
+
+`elixir/lib/symphony_elixir/engine/` is the only part of `elixir/lib/` that names
+the room-server HTTP contract. It is the WS-0 seam of the overhaul: the DSL, the
+runtime, and the Rust room-server all code against these shapes, so a change here
+is a deliberate cross-language change with a golden fixture proving both sides
+still agree (`packages/symphony/docs/engine-contract.md:1-7`). The room-server
+itself lives in the ix monorepo (`crates/room/src/engine.rs`), not here.
+
+Two modules own the Elixir side:
+
+- **`Engine.Envelope`** (`engine/envelope.ex`) - the typed, validated execution
+  spec for one agent node.
+- **`Engine.Client`** (`engine/client.ex`) - lowers an envelope + a turn to the
+  room-server `TurnRequest`, resolves the target URL, POSTs `/api/agent/turns`,
+  and maps the `AgentTurnResponse` back to a runtime result.
+
+## Envelope
+
+`engine/envelope.ex` makes every axis of execution explicit and validated at load; the pre-overhaul code
+sniffed the engine from the model name and silently ignored mismatched fields
+(`engine/envelope.ex:6-11`). Fields (`engine/envelope.ex:13-32`):
+
+| field | values | notes |
+| --- | --- | --- |
+| `engine` | `:codex`, `:claude`, `:pi` | explicit, never inferred from the model |
+| `model` | string | passed through verbatim (`gpt-5.3-codex`, `claude-opus-4-8`, or the `opus`/`sonnet`/`haiku` aliases) |
+| `effort` | `:none :minimal :low :medium :high :xhigh` or `nil` | `nil` lets the engine pick its default |
+| `permissions` | `:read_only :workspace_write :danger_full_access` | each adapter lowers it to its native shape |
+| `location` | `:local`, `:ixvm`, `{:host, name}`, `{:room, url}` | deployment topology, resolved by `Engine.Client` |
+
+The accessors (`engines/0`, `efforts/0`, `permission_levels/0`, `locations/0`) are
+the source of truth the [DSL schema](../dsl/overview.md#schema-vocabulary) reads.
+`from_map/1` builds a validated envelope from the parser's raw spec map, rejecting
+unknown keys (`engine/envelope.ex:99-117`). `validate/1` defaults a missing
+`permissions` to `:workspace_write` and a missing `location` to `:local`
+(`engine/envelope.ex:119-140`). The mismatch guard the old code could not express:
+a Claude-looking model under `engine: :codex` (or a non-Claude model under
+`:claude`) is a load error, not a silent mis-route (`engine/envelope.ex:232-241`);
+`:pi` is exempt because its model is a harness alias resolved downstream. The
+dynamic-tool surface (`tools`) is deliberately NOT on the envelope: it is a
+property of the prompt/skill, not of execution (`engine/envelope.ex:34-35`).
+
+## Casing and tagging
+
+Wire conventions (`packages/symphony/docs/engine-contract.md:31-39`): field names
+are camelCase (`turnId`, `runId`); enum bodies carry a `type` tag
+(`EngineEventBody`) or a `kind` tag (`TurnOutcome`, `EngineAnswer`); scalar enums
+serialize as lowercase/snake_case strings (`engine: "claude"`, `permissions:
+"danger_full_access"`).
+
+## TurnRequest (Elixir produces, Rust consumes)
+
+`Engine.Client.request_body/2` lowers a validated envelope + turn to the canonical
+`TurnRequest` JSON (`engine/client.ex:129-149`). `effort` is omitted entirely when
+unset (the room-server uses serde `skip_serializing_if`, mirrored by `drop_nil`),
+and any nil field is dropped. The golden fixture
+(`contracts/fixtures/turn_request.json`):
+
+```json
+{
+  "engine": "codex",
+  "model": "gpt-5.3-codex",
+  "effort": "medium",
+  "permissions": "workspace_write",
+  "cwd": "/workspace/run_x/primary",
+  "prompt": "write FOO to ./hello.txt and stop",
+  "tools": [],
+  "runId": "run_x",
+  "nodeId": "n0"
+}
+```
+
+`request_body/2` requires a non-empty `prompt` and `cwd`; a missing `cwd` fails
+loudly with `:missing_cwd` rather than running a turn in an unknown directory
+(`engine/client.ex:158-162`). The Elixir fixture test asserts `request_body/2`
+reproduces this JSON byte-for-byte after a round-trip, so the lowering and the
+shared fixture cannot drift (`packages/symphony/docs/engine-contract.md:109-117`).
+
+## EngineEvent (Rust produces, Elixir will consume)
+
+One normalized event for one turn. `EngineEventBody` is the superset Codex emits;
+Claude is a subset producer (it self-executes tools under
+`--dangerously-skip-permissions`, so it never emits `approvalRequest`/
+`toolCallRequest`). Body variants: `turnStarted`, `textDelta`, `reasoningDelta`,
+`toolCallStarted`, `toolCallOutput`, `fileChanged`, `statusChanged`, `usage`,
+`approvalRequest`, `toolCallRequest`, `turnCompleted`
+(`packages/symphony/docs/engine-contract.md:64-77`). Only the Rust side parses the
+fixture today; the Elixir `EngineEvent` decoder lands with the streaming client.
+
+## AgentTurnResponse (the synchronous result)
+
+`POST /api/agent/turns` is request/response: the room-server runs the whole turn
+and returns its terminal outcome, the `threadId` it assigned, the event count, and
+the turn's terminal `usage` totals. `parse_response/1` maps `outcome.kind`:
+`"ok"` succeeds, `"error"` carries a message + thread id, `"cancelled"` carries
+the thread id (`engine/client.ex:231-249`). `parse_cost/1` maps the camelCase
+`usage` to the `IR.Attempt.cost` shape (`usd`, `tokens_in`, `tokens_out`,
+`cache_read`, `cache_creation`); a response with no `usage` (an older server)
+yields `nil` so the attempt records "unknown" rather than a sham zero, and
+`costUsd` is dropped when the engine did not price the turn
+(`engine/client.ex:253-269`, `docs/engine-contract.md:103-107`).
+
+## Location resolution
+
+`resolve_base_url/2` is the deployment-topology seam (`engine/client.ex:164-204`):
+`:local` and a default resolve to the configured `SYMPHONY_ROOM_SERVER_URL`;
+`{:room, url}` is explicit; `:ixvm` and `{:host, _}` resolve to the per-run URL the
+run's [`Runtime.Placement`](overview.md#placement) provisioned, looked up by
+`run_id` in ETS. A turn submitted without the runtime's `run_id` context fails with
+`{:unresolved_location, _}` rather than silently routing to the default server.
+
+## Known limitation
+
+The synchronous path blocks until the turn completes, so `submit_turn/2` sets a
+60-minute receive timeout and the caller must run it off the runtime process (the
+runtime already schedules each attempt in a monitored task). Approvals and
+interrupts are not reachable on this path; use `:danger_full_access` or a
+self-executing engine until the streaming client lands (`engine/client.ex:39-50`).
+
+## Golden fixtures (`contracts/fixtures/`)
+
+`contracts/` sits beside `elixir/` (not under it) because the Elixir contract test
+resolves it relatively (`packages/symphony/README.md:26`,
+`packages/symphony/default.nix:26-29`). The fixtures are shared with the
+room-server: `turn_request.json` (both sides assert), `engine_event.json` (Rust
+asserts today), and `agent_turn_response.json` (both sides assert). A field rename
+fails a check on both sides rather than silently at runtime
+(`packages/symphony/docs/engine-contract.md:17-29`).

--- a/docs/symphony/engine/overview.md
+++ b/docs/symphony/engine/overview.md
@@ -1,0 +1,204 @@
+# Engine: the IR run graph and DAG runtime
+
+`elixir/lib/symphony_elixir/ir/` and `runtime/` are the deterministic core:
+the durable run-graph model the [DSL](../dsl/overview.md) interpreter emits into,
+and the supervised per-run scheduler that walks it. One `Runtime` GenServer owns
+one active run; it schedules ready nodes as monitored BEAM tasks, commits each
+result into the durable `RunGraph`, and resolves the run when every node is
+terminal (`runtime.ex:1-10`). The actual agent turn is run by a Rust room-server
+the runtime reaches only through the [engine contract](contract.md).
+
+## IR data model (`ir/`)
+
+- **`IR.Node`** (`ir/node.ex`) - one durable unit the runtime schedules,
+  persists, recovers, and shows operators. Kinds: `:agent` (an engine turn,
+  carries an `envelope` and prompt), `:exec` (a pack shell script), `:subrun` (a
+  child run), and the `:gate`/`:map_fanout` dynamic-expansion placeholders
+  (`ir/node.ex:30-37`). States: `pending ready running succeeded failed skipped
+  upstream_failed retrying cancelled stranded` (`ir/node.ex:67-77`). `id` is
+  content-derived (hash of `ast_origin` + `expansion_key`) so a logical node keeps
+  its id across a deterministic replay. `deps` is DERIVED from `inputs` via
+  `deps_from_inputs/1`, never hand-written (`ir/node.ex:23-28`, `170-180`).
+- **`IR.Attempt`** (`ir/attempt.ex`) - one execution attempt of a node, with the
+  executor (`:codex`/`:claude`/`:pi`/`:exec`/`:subrun`), `thread_id`, state,
+  outcome, and cost. A node accumulates attempts across retries and recoveries.
+- **`IR.RunGraph`** (`ir/run_graph.ex`) - the durable per-run state: the reified
+  `ast`, the materialized `nodes`, the `trigger` context, the `placement`, an
+  append-only `expansion_log`, and an `audit_log` of operator actions. Statuses:
+  `pending running succeeded failed cancelled`. `source_hash` snapshots the
+  `.sym` bytes the run started with, so editing the pack never perturbs runs in
+  flight (`ir/run_graph.ex:21-23`).
+- **`IR.Graph`** (`ir/graph.ex`) - the pure graph algebra (no process state, no
+  IO): `ready_nodes/1` (schedulable kinds with every dep `:succeeded`, sorted by
+  id for deterministic order), `apply_output/3` (commit a result and re-derive
+  dependents), `propagate_upstream_failed/2`, `reset_node/2`, and
+  `finished_status/1`. Placeholder kinds are excluded from scheduling
+  (`ir/graph.ex:39-54`). Failure propagates: a failed node marks each still-waiting
+  transitive dependent `:upstream_failed` unless it opts to run on failure
+  (`inputs["__on_failure__"] == {:literal, true}`, `ir/graph.ex:137-150`).
+
+## Materialization (`ir/materializer.ex`)
+
+The seam between the interpreter and the durable graph. `materialize/3` builds the
+initial `RunGraph`, validating every agent envelope at load (`from_map/1`) and
+failing the whole run with `{:invalid_envelope, node_id, reason}` rather than
+scheduling a malformed node (`ir/materializer.ex:35-61`). `expand_dynamic/1`
+re-expands the AST against the outputs of succeeded nodes and merges by id
+(`ir/materializer.ex:63-114`):
+
+- a never-seen id is added;
+- an existing `:pending` node is replaced (this is how a deferred prompt folds
+  from `{:inline, nil}` to its real text once the awaited output arrives),
+  preserving `created_at`/`attempts` and unioning deps;
+- an existing `:running` or terminal node keeps its live state, never clobbered.
+
+A resolved gate's placeholder is retired to `:skipped` so it leaves the
+schedulable set and never deadlocks the run (`ir/materializer.ex:121-139`). This is
+exactly the restart-replay invariant: a live re-expansion and a cold replay
+produce identical graphs.
+
+## Durable store (`ir/store.ex`)
+
+One JSON file per run under `runs_dir/ir/<run_id>.json`, written atomically
+(temp-then-rename) so a crash mid-write never leaves a half file
+(`ir/store.ex:1-13`). `Runtime` calls `persist/2` after every transition.
+`load_all/1` quarantines a file that fails to decode as `<run_id>.json.bad` and
+keeps booting, so one corrupt run never blocks startup (`ir/store.ex:42-65`).
+Tuples that JSON cannot represent (`{:node, id, path}`, AST fragments) round-trip
+through `:erlang.term_to_binary/1` + Base64, decoded with
+`:erlang.binary_to_term/1` (not `:safe`, because the store is root-owned local
+state and `:safe` would refuse to recreate symphony's own failure-path atoms,
+`ir/store.ex:228-234`, `390-405`). Enum strings decode against each owning
+module's set, so a tampered file cannot mint arbitrary atoms (`ir/store.ex:371-388`).
+
+## The runtime GenServer (`runtime.ex`)
+
+One `Runtime` per run, supervised by `Runtime.Supervisor` (a `DynamicSupervisor`,
+one child per run, `runtime/supervisor.ex:1-18`). The scheduling loop
+(`advance`/`schedule`, `runtime.ex:336-447`):
+
+1. If every node is terminal, `finish/1` stamps the final status and stops a
+   succeeded/cancelled run (a failed run stays alive so operators can act on it,
+   `runtime.ex:352-366`).
+2. Otherwise it schedules `Graph.ready_nodes/1`: each is marked + persisted
+   `:running`, its placement acquired if needed, then run in a
+   `Task.Supervisor.start_child` task whose pid the runtime monitors itself
+   (`runtime.ex:412-447`).
+3. A task reports `{:node_done, id, result, thread_id}`; the runtime records the
+   attempt, applies the output, and on success re-expands the AST to emit any
+   newly-justified gate/fan-out children before the next pass (`runtime.ex:258-271`).
+
+Each kind is dispatched to its executor (`runtime.ex:802-809`): `:agent` to the
+injected `EngineClient`, `:exec` to `ExecRunner`, `:subrun` to `SubrunRunner`. The
+engine client is injected (`Runtime.RoomEngineClient` in production), so tests
+drive the runtime with an in-process fake and no room-server
+(`runtime/supervisor.ex:16-17`).
+
+### Crash recovery and the deadlock guard
+
+Two failure modes, same conservative bias (`runtime.ex:12-38`):
+
+- **Executor crash.** A monitored task's `:DOWN` that arrives without a prior
+  `{:node_done, ...}` means the task died mid-attempt. The runtime cannot assume
+  the turn had no side effect, so it marks the attempt `:stranded` and routes by
+  the non-idempotent retry policy in [`Runtime.Recovery`](#recovery) (auto-retry
+  only when the node opted in and showed no side effect, else `:stranded`).
+- **BEAM restart.** At boot `Runtime.Supervisor.resume_pending/1` reloads every
+  non-terminal run from `IR.Store` and restarts it with `recover: true`
+  (`runtime/supervisor.ex:49-69`); the runtime reconciles orphaned `:running`
+  nodes through `Recovery.reconcile/2` before its first scheduling pass.
+- **Deadlock guard.** A pass with no ready nodes, no live tasks, and a
+  non-terminal run cannot progress; the runtime fails it with `:deadlock` rather
+  than hanging (`runtime.ex:373-398`). A graph that materialized to zero
+  schedulable work (every gate resolved its body off) is a no-op completion, not a
+  deadlock.
+
+### Operator hooks
+
+`cancel/2`, `retry_node/3`, `rerun/2`, and `clear_failed/2` are the operator
+surface (`runtime.ex:103-146`), each recorded in the `RunGraph.audit_log`. They
+back the `POST /api/v1/ir/runs/:run_id/*` routes; a run with no live process
+returns 409 (see [operations](../operations/overview.md#dashboard-and-json-api)).
+`clear_failed` resets `:failed`/`:upstream_failed`/`:stranded` nodes to `:pending`
+and reschedules, leaving succeeded nodes intact, the surgical recovery after
+fixing a failure cause.
+
+## Recovery
+
+`runtime/recovery.ex` is the correctness core of restart. `replay/2` re-runs each expansion in log order to
+rebuild the materialized graph; the asserted invariant is `replay(ast, log) ==
+live graph` (`runtime/recovery.ex:10-16`). `reconcile/2` resolves each orphaned
+`:running` node by probing `EngineClient.status/1`: `:running` is left alone (the
+engine still owns it), `{:finished, result}` is harvested, `:unknown` falls to the
+strand/retry policy (`runtime/recovery.ex:88-105`). `auto_retryable?/1` is the
+locked safety rule: opt-in (`inputs["__retry__"] == {:literal, true}`), no
+observed side effect (no `thread_id` recorded), and under the 3-attempt budget
+(`runtime/recovery.ex:126-139`). The synchronous room-server path has no
+probe-by-thread route, so the production `status/1` returns `:unknown`
+conservatively (`runtime/room_engine_client.ex:29-37`).
+
+## Executors
+
+- **`RoomEngineClient`** (`runtime/room_engine_client.ex`) - the production
+  `EngineClient`. Renders the node's `prompt_ref` through `SymphonyElixir.Prompt`
+  (inline text passes through; a `skill` ref is rendered from the active pack's
+  skill body with the resolved bindings), appends the run's trigger as an
+  `<input>` block, and submits the turn through [`Engine.Client`](contract.md). A
+  skill naming an unbound input is a render error, so a half-rendered prompt never
+  reaches an engine (`runtime/room_engine_client.ex:17-27`).
+- **`ExecRunner`** (`runtime/exec_runner.ex`) - runs one pack shell script in the
+  pack directory. The script path resolves relative to the pack so a pack carries
+  no absolute paths. Resolved DSL inputs are exported as `SYMPHONY_INPUT_<NAME>`;
+  a fresh `SYMPHONY_OUTPUT_FILE` lets a script return a JSON document as the
+  node's structured output (which is what makes `when ${node.output.field}` and
+  `map ${node.output.items}` work over exec nodes, `runtime/exec_runner.ex:20-26`).
+  A finite default timeout (300s) kills a runaway via `kill -KILL`
+  (`runtime/exec_runner.ex:176-205`).
+- **`SubrunRunner`** (`runtime/subrun_runner.ex`) - a first-class nested run. It
+  resolves the child workflow against `WorkflowCatalog`, starts it through
+  `Runtime.Ingress.start_workflow/3` under the same supervisor, monitors it, and
+  reads the child's terminal `RunGraph` from the store. Two guards bound the tree:
+  a cycle guard rejects a name already on the ancestor chain, and a depth ceiling
+  rejects a chain past `Config.subrun_max_depth` (default 8) for mutually
+  recursive workflows the cycle guard cannot catch (`runtime/subrun_runner.ex:15-31`).
+
+## Placement
+
+`runtime/placement.ex` owns the per-run room-server lifecycle for `:ixvm` and `{:host, _}` agent
+placements. A run provisions one room-server before its first agent turn and tears
+it down at run end; resolved placements live in a public ETS table keyed by
+`run_id` so the off-process `Engine.Client` can read the URL without a GenServer
+round-trip (`runtime/placement.ex:21-27`). `:ixvm` runs in a short-lived iXVM via
+`ix`; `{:host, _}` runs as a privilege-dropped `systemd-run` unit prefixed
+`symphony-host-` (the prefix the polkit grant scopes to). When `:ixvm`
+provisioning fails before the first turn, `acquire/3` retries on
+`Config.placement_fallback` (default `:host`; also `:remote` to a worker, `:local`
+to the in-process server, or `:none`); the fallback registers under the same
+`run_id` so the turn resolves without the node knowing it fell back
+(`runtime/placement.ex:36-51`). `:local`/`{:room, url}` need no per-run server.
+`reconcile/2` reaps host units orphaned by a restart and re-attaches the live ones
+(`runtime/placement.ex:205-253`).
+
+## Triggers and ingress
+
+- **`Runtime.Ingress`** (`runtime/ingress.ex`) - the single door from a workflow +
+  event to a live run. `start_workflow/3` materializes the AST, stamps the trigger
+  onto `graph.trigger`, and starts the run. `start_by_trigger/2` resolves every
+  workflow that declared interest (via `WorkflowCatalog.for_trigger_kind/1` +
+  `Runtime.Trigger.matches?/2`) and starts one run per match; `seen_trigger?/2` is
+  the shared dedup read over the run history in `IR.Store`.
+- **`Runtime.Trigger`** (`runtime/trigger.ex`) - the one matcher every producer
+  shares: it compares a declared `on` trigger's selector fields (cron schedule,
+  Linear label, GitHub repo/label, Slack channel) against an inbound event, so the
+  selector vocabulary lives in one module.
+- **`Runtime.Events`** (`runtime/events.ex`) - IR-run PubSub. `Runtime` broadcasts
+  an `{:ir_run_event, run_id, summary}` after each persisted transition on an
+  index topic and a per-run topic, so the dashboard updates without polling.
+
+## Read view (`ir/view.ex`)
+
+`IR.View` renders a `RunGraph` as flat, string-keyed JSON facts for the API and
+dashboard: `summary/1` (the index row: status, counts, cost) and `detail/1` (every
+node with deps, attempts, output, plus the expansion and audit logs). Keeping the
+emitter out of the runtime means a wire-format change never touches scheduling
+(`ir/view.ex:4-16`).

--- a/docs/symphony/operations/overview.md
+++ b/docs/symphony/operations/overview.md
@@ -1,0 +1,199 @@
+# Operations: running Symphony
+
+Genre: recipe. How to launch the runtime, the env vars it reads, the dashboard and
+API it serves, the triggers that fire workflows, and the NixOS module that deploys
+it. Source of truth for env vars is `config.ex`; for the unit, `default.nix`,
+`bin/run-nix`, and `../../modules/services/symphony/default.nix`.
+
+## Launch
+
+```sh
+export SYMPHONY_PRIMARY_REPO=/path/to/your/repo
+nix run .#symphony
+# dashboard on http://127.0.0.1:4040
+```
+
+`symphony` is the single flake output, a Nushell launcher wrapping `bin/run-nix`
+(`default.nix:148-171`). It refuses to start without an authenticated `codex` on
+PATH (`bin/run-nix:23-26`); `codex` is intentionally not in the package's
+`runtimeInputs`, so the binary and its credentials stay host-owned
+(`default.nix:154-156`). `runtimeInputs` provide `bash`, `cacert`, `coreutils`,
+`elixir`, `erlang`, `gh`, `git`, `openssh` (`default.nix:157-166`).
+
+`bin/run-nix` (`bin/run-nix:1-63`): stages this source tree into
+`$SYMPHONY_STATE_DIR/runtime` (so `mix` can write `_build` without touching a
+read-only nix-store or live working-tree checkout), sets `SYMPHONY_ROOT` to that
+copy, creates the state dirs, then runs `mix deps.get`, `mix compile
+--warnings-as-errors`, and `exec mix run --no-halt` (which boots
+`SymphonyElixir.Application`). `MIX_ENV` defaults to `prod`.
+
+Run an external pack:
+
+```sh
+export SYMPHONY_PACK_DIR=/path/to/your/pack
+export SYMPHONY_PRIMARY_REPO=/path/to/your/primary/repo
+nix run github:indexable-inc/index#symphony
+```
+
+Develop:
+
+```sh
+nix develop .#symphony      # Elixir 1.19 / OTP 28, plus codex, gh, git
+cd packages/symphony/elixir
+make all                    # setup, compile -Werror, fmt-check, credo
+mix test
+```
+
+## State directories
+
+`bin/run-nix` anchors mutable state under `SYMPHONY_STATE_DIR` (default
+`$HOME/.local/state/symphony`), separate from the staged runtime copy that is
+wiped on every restart (`bin/run-nix:6-21`):
+
+| var | default | holds |
+| --- | --- | --- |
+| `SYMPHONY_STATE_DIR` | `$HOME/.local/state/symphony` | root of mutable state |
+| `SYMPHONY_RUNS_DIR` | `$SYMPHONY_STATE_DIR/runs` | per-run `RunGraph` JSON (`runs/ir/*.json`) and `cron_state.json` |
+| `SYMPHONY_WORKSPACES_DIR` | `$SYMPHONY_STATE_DIR/workspaces` | per-run git worktrees (accepts the legacy `SYMPHONY_WORKSPACE_ROOT`) |
+| `SYMPHONY_LOGS_ROOT` | `$SYMPHONY_STATE_DIR/log` | run logs |
+| `SYMPHONY_HTTP_PORT` | `4040` | Phoenix listener (accepts `SYMPHONY_PORT`) |
+
+`Config` reads its env snapshot once at boot; to pick up an env change, restart the
+BEAM. Pack files and skills hot-reload without a restart (`config.ex:1-9`).
+
+## Core configuration (`config.ex`)
+
+Required: `SYMPHONY_ROOT` (set by the launcher) and `SYMPHONY_PRIMARY_REPO`
+(`config.ex:11-14`). Pack selection and runtime paths are covered in
+[pack](../pack/overview.md). Other commonly-set knobs (`config.ex:26-140`):
+
+- `SYMPHONY_CODEX_COMMAND` (default `codex app-server`), `SYMPHONY_CLAUDE_COMMAND`
+  (default `claude`), `ANTHROPIC_API_KEY` (required for any Claude-model node).
+- `SYMPHONY_ROOM_SERVER_URL` for `:local`/`{:room, url}` placements;
+  `SYMPHONY_ROOM_REGISTRY_URL`/`_TOKEN`/`SYMPHONY_ROOM_ADVERTISE_HOST` for the
+  central room.ix.dev that aggregates run transcripts.
+- `SYMPHONY_SUBRUN_MAX_DEPTH` (default 8), `SYMPHONY_CATALOG_POLL_MS` (1000),
+  `SYMPHONY_CRON_POLL_MS` (60000), `SYMPHONY_SLACK_POLL_MS` (60000).
+- GitHub App (commit/push as a bot): `SYMPHONY_GITHUB_APP_ID`,
+  `SYMPHONY_GITHUB_APP_PRIVATE_KEY_BASE64` (base64 so it fits one env line),
+  `SYMPHONY_GITHUB_APP_OWNER_REPO`, `SYMPHONY_BOT_USERNAME`, `SYMPHONY_BOT_EMAIL`.
+- Integrations: `LINEAR_API_KEY`, `GITHUB_TOKEN`, the webhook secrets, and the
+  Slack tokens (see [Triggers](#triggers)). `.env.example` is the full list.
+
+## Boot supervision tree (`application.ex`)
+
+`SYMPHONY_ROLE` selects the tree (`application.ex:45-83`). The default
+`control_plane` boots, in order: `Phoenix.PubSub`, `Task.Supervisor`, `Config`,
+`GithubApp`, `Catalog` (skills), `WorkflowCatalog` (workflows), `CronState`,
+`Runtime.Registry`, `Runtime.Placement`, `Runtime.RuntimeRegistry`,
+`Runtime.Supervisor`, `Triggers.Slack`, `Triggers.Cron`, and the Phoenix
+`Endpoint`. After the tree starts it calls `Runtime.Supervisor.resume_pending/1`
+to reload and resume non-terminal runs. The `worker` role boots only enough to
+dial the control plane and provision per-run room-servers (no DB, triggers,
+engine, or HTTP).
+
+## Placements
+
+Each agent node picks where its engine process runs with `location:` in the
+`.sym` ([envelope](../engine/contract.md#envelope)). `host` runs codex directly on
+the Symphony machine as `SYMPHONY_HOST_USER` (no VM); `ixvm` runs it in a
+short-lived iXVM; `local`/`room` use `SYMPHONY_ROOM_SERVER_URL`
+(`packages/symphony/docs/setup.md:53-73`). When an `ixvm` placement fails to
+provision, the run retries on `SYMPHONY_PLACEMENT_FALLBACK` (default `host`; also
+`remote`, `local`, `none`, `config.ex:74-83`). Host placement needs
+`SYMPHONY_HOST_USER` (and optionally `_GROUP`, `_WORKSPACES_DIR`, `_KEEP`); on
+NixOS, `services.symphony.hostRuntime` wires the polkit grant and PATH it requires.
+The lifecycle is owned by [`Runtime.Placement`](../engine/overview.md#placement).
+
+## Dashboard and JSON API
+
+The Phoenix `Endpoint` serves on `SYMPHONY_HTTP_PORT` (default 4040) and is
+described as the optional observability UI and API (`endpoint.ex:1-4`). Routes
+(`*_web/router.ex`):
+
+LiveView dashboard (`router.ex:25-40`):
+
+- `/` and `/ir` - the IR runs index; also carries the schema-driven control to
+  start a workflow by name. `/ir/:run_id` - one run in detail with per-node state
+  pills. Live updates ride `Runtime.Events` PubSub, so pills move without polling
+  (`live/ir_runs_live.ex:13-18`).
+- `/workflows`, `/workflows/:name` - the workflow catalog (and parse errors).
+- `/skills`, `/skills/:name` - the skill catalog.
+- `/statistics` - GitHub-backed stats for bot-authored PRs
+  (`SYMPHONY_GITHUB_STATS_QUERY`).
+
+JSON API under `/api/v1` (`router.ex:42-61`):
+
+- `POST /runs` - manual-trigger enqueue: `{"workflow": "..", "input": {..}}`
+  starts that `.sym`; without `workflow` it fires every `on manual` workflow
+  (`controllers/api_controller.ex:1-29`).
+- `GET /ir/schema` - the runtime enum vocabulary (drives form option lists).
+- `GET /ir/runs`, `POST /ir/runs`, `GET /ir/runs/:run_id` - list/create/read runs.
+- `POST /ir/runs/:run_id/{cancel,rerun,clear-failed}` and
+  `.../nodes/:node_id/retry` - the operator hooks; a run with no live process
+  returns 409 (`controllers/ir_run_controller.ex:96-110`).
+- `POST /triggers/{linear,github,slack/events}` - the webhook receivers.
+
+## Triggers
+
+Producers all funnel through `Runtime.Ingress` and the shared `Runtime.Trigger`
+matcher (see [engine](../engine/overview.md#triggers-and-ingress)). The trigger
+kinds and their `.sym` `on` syntax are in [dsl](../dsl/overview.md#triggers-the-on-header).
+
+- **Cron** (`triggers/cron.ex`) - a GenServer ticking every
+  `SYMPHONY_CRON_POLL_MS` (default 60s). It persists `last_fired_at` per workflow
+  via `CronState`; a brand-new cron workflow is seeded without firing (no boot
+  catch-up), and at most one catch-up fire happens per restart (the
+  `systemd Persistent=true` semantic, `triggers/cron.ex:8-22`). Schedules are
+  parsed by `CronExpression` (`cron_expression.ex:1-30`): standard 5-field cron
+  with `*`, lists, ranges, and `*/n` steps, plus `@yearly`/`@monthly`/`@weekly`/
+  `@daily`/`@hourly` nicknames, all in UTC.
+- **Webhooks** - `LinearWebhookController`, `GithubWebhookController`, and
+  `SlackEventsController` verify the inbound signature against
+  `LINEAR_WEBHOOK_SECRET`/`GITHUB_WEBHOOK_SECRET`/`SLACK_SIGNING_SECRET` (absent
+  rejects 401), extract the event, dedup, and call `Ingress.start_by_trigger/2`.
+  `RawBodyReader` retains the raw body for signature checks (`*_web/raw_body_reader.ex`).
+- **Slack huddle** (`triggers/slack.ex`) - an opt-in poller enabled by
+  `SLACK_BOT_OAUTH_TOKEN`.
+- Failed (and optionally successful) cron runs post to Slack per
+  `SYMPHONY_SLACK_NOTIFY_CHANNEL`, `SYMPHONY_SLACK_NOTIFY_CRON_FAILURES` (default
+  true), and `SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS` (`config.ex:107-110`).
+
+## NixOS module (`modules/services/symphony`)
+
+`services.symphony` is a minimal opinionated systemd unit
+(`modules/services/symphony/default.nix:1-7`). Key options: `package` (this flake's
+`symphony`), `user` (default `symphony`), `stateDir` (`/var/lib/symphony`),
+`httpPort` (4040), `primaryRepo`, `repoRoot`, `workflowPack`/`packDir`, the room
+options, `extraEnvironment` (non-secret config), and `environmentFile` or
+`secretsCommand` for secrets (`modules/services/symphony/default.nix:26-161`).
+`secretsCommand` wraps `ExecStart` (designed for Bitwarden `bws run -- ...`). The
+module creates `stateDir` and the `workspaces`/`runs`/`log` subdirs via tmpfiles,
+sets the `SYMPHONY_*` env, and keeps sandboxing permissive because the service
+spawns codex subprocesses and clones repos
+(`modules/services/symphony/default.nix:258-347`). `hostRuntime.enable` adds the
+polkit rule scoping `org.freedesktop.systemd1.manage-units` to the
+`symphony-host-` unit prefix so the non-root service can run codex as another user
+(`modules/services/symphony/default.nix:225-244`); it requires `user` and
+`roomServerPackage`.
+
+```nix
+services.symphony = {
+  enable = true;
+  package = index.packages.${system}.symphony;
+  packDir = "/var/lib/symphony-pack";
+  primaryRepo = "/var/lib/repos/my-app";
+  environmentFile = "/run/secrets/symphony.env";
+};
+```
+
+## Quality gates
+
+The required lane (compile `--warnings-as-errors`, `mix format --check-formatted`,
+`mix credo`, `mix test`) runs sandboxed in CI as the `symphony-elixir` flake check,
+defined in `default.nix` (`elixirCheck`, exposed via `passthru.tests.elixir`,
+`default.nix:74-176`). After changing `elixir/mix.lock`, refresh the `fetchMixDeps`
+hash there (`default.nix:40-54`). The advisory lane (`make quality`: format check,
+Credo, Sobelow, `deps.audit`, Dialyzer, plus `mix coveralls`) stays a local run,
+since those tools want network or large mutable caches; see
+`packages/symphony/docs/quality.md`.

--- a/docs/symphony/pack/overview.md
+++ b/docs/symphony/pack/overview.md
@@ -1,0 +1,137 @@
+# Pack: the workflow-pack format
+
+The runtime is pack-agnostic: workflow shape lives in a pack directory, not in
+`elixir/lib/` (`packages/symphony/AGENTS.md:29-35`). A pack is three things:
+
+```
+<pack>/
+  workflows/   one .sym file per workflow (hot-reloaded by WorkflowCatalog)
+  skills/      one .md system prompt per skill (hot-reloaded by Catalog)
+    _partials/ shared markdown fragments included with {{partial:name}}
+  repositories.yaml   the repos cloned into each run's workspace
+```
+
+The active pack is chosen by `SYMPHONY_PACK_DIR` (an external directory) or
+`SYMPHONY_WORKFLOW_PACK` (a pack name under the symphony repo's `workflows/`,
+default `example`). Each subpath is overridable individually
+(`SYMPHONY_WORKFLOWS_DIR`, `SYMPHONY_SKILLS_DIR`, `SYMPHONY_REPOSITORIES_FILE`)
+and defaults under the pack dir (`config.ex:16-24`). `Config` validates at boot
+that the pack dir, workflows dir, skills dir, and repositories file all exist,
+raising a clear error otherwise (`config.ex:548-571`). Symphony treats the pack
+as read-only runtime input; mutable state goes under `SYMPHONY_RUNS_DIR` and
+`SYMPHONY_WORKSPACES_DIR` (`packages/symphony/docs/setup.md:36-38`).
+
+## Workflows (`workflows/*.sym`, `workflow_catalog.ex`)
+
+Each `.sym` file is one workflow in the [DSL](../dsl/overview.md). The
+`WorkflowCatalog` GenServer watches `workflows/*.sym` and publishes the latest
+parsed AST per file, polling every `SYMPHONY_CATALOG_POLL_MS` (default 1000ms) and
+comparing SHA-256 hashes (`workflow_catalog.ex:1-29`). Reload semantics: a new file
+is parsed and added, changed bytes re-parsed, a deleted file removed; a parse
+error keeps the last-good entry published and records the located diagnostic
+(message, line, column, file) so the workflows view shows exactly where one `.sym`
+broke while the rest keep working (`workflow_catalog.ex:22-28`, `153-180`).
+
+Entries are keyed by file basename and carry `name`, `ast`, the declared `trigger`
+(lifted from the AST for cheap matching), the raw `source`, and the `hash` a run
+records as `RunGraph.source_hash` (`workflow_catalog.ex:42-49`). A run snapshots
+that hash at start, so editing the pack only affects new runs. `for_trigger_kind/1`
+is the producer's first filter; `workflow/1` resolves one by name for the manual
+path. The catalog owns parsing and freshness only; it never starts runs.
+
+## Skills (`skills/*.md`, `catalog.ex`, `skill.ex`)
+
+A skill is a markdown file whose body is the system prompt for an agent node, with
+optional YAML frontmatter in the model-agnostic Agent Skills shape: a one-line
+`description` and a `tools` allowlist (`skill.ex:1-6`, `72-83`). The skill carries
+no engine, model, effort, or permissions: those are the node's
+[envelope](../engine/contract.md#envelope), so the skill body stays
+model-agnostic (`skill.ex:21-27`). The body is the lever for improving an agent
+without code changes. The bundled `skills/inspect.md`:
+
+```markdown
+---
+description: Sample skill that inspects the checked-out workspace and reports, without mutating anything.
+tools: []
+---
+
+You are running inside a sample Symphony workflow.
+Read the input and inspect the checked-out workspace. ...
+```
+
+The `Catalog` GenServer watches `skills/*.md` non-recursively, hot-reloading on
+the same 1s hash-compare tick (`catalog.ex:1-22`). `Skill.load/1` splits
+frontmatter, decodes the YAML, and expands shared partials at load time. Active
+runs snapshot the skills they resolve at run start; a reload affects only new runs.
+
+### Partials (`skills/_partials/*.md`)
+
+A skill body includes a shared fragment by writing `{{partial:<name>}}`, resolved
+to `skills/_partials/<name>.md` (`skill.ex:29-43`). Files under `_partials/` are
+not skills: the catalog globs `*.md` non-recursively, so they are ignored.
+Expansion runs to a fixpoint with a seen-set so each named partial inlines at most
+once and a partial that documents its own token name does not loop or leave a
+residual token; a genuinely missing partial is a load error so the catalog refuses
+to publish a half-rendered body (`skill.ex:45-71`). Partials are not hot-reloaded
+on their own; touch a referencing skill to pick up a partial edit.
+
+## Prompt rendering (`prompt.ex`)
+
+`SymphonyElixir.Prompt.build/2` turns a node's `prompt_ref` into the text an engine
+runs (`prompt.ex:1-24`). `{:inline, text}` passes through; `{:skill, name,
+bindings}` loads the body through an injected resolver (production: the `Catalog`),
+expands any `{{partial:name}}`, and interpolates `${path}` placeholders from the
+bindings the interpreter resolved (`${ticket.id}` reads `bindings["ticket"]["id"]`).
+A placeholder with no matching binding is a render error, not a silent empty
+substitution, so a skill referencing an input the node never bound fails loudly
+(`prompt.ex:26-33`). Write `$${path}` to emit a literal `${path}`: skill bodies
+routinely embed shell/Make/JS `${VAR}` snippets the doubled `$$` protects
+(`prompt.ex:35-39`). At turn time `RoomEngineClient` appends the run's trigger as
+an `<input>` JSON block so a dispatch-driven skill reads its payload
+(`runtime/room_engine_client.ex:96-108`).
+
+## Repositories (`repositories.yaml`, `repository_catalog.ex`)
+
+`repositories.yaml` lists the repos cloned into every run's workspace. Each entry
+is `name`, `owner_repo`, `default_branch`, and an optional `primary` flag; exactly
+one repo must be `primary: true` (`repository_catalog.ex:30-49`). The bundled
+`workflows/example/repositories.yaml`:
+
+```yaml
+repositories:
+  - name: example
+    owner_repo: example/example
+    default_branch: main
+    primary: true
+```
+
+`Workspace.create/1` clones every listed repo for each run under
+`SYMPHONY_WORKSPACES_DIR/<run_id>/`, the primary at the run cwd and siblings
+beside it, each with writable refs and a run-scoped branch so an agent can branch,
+commit, and open PRs in any listed repo (`workspace.ex:1-17`,
+`repository_catalog.ex:2-9`). Workspace paths are canonicalized under the
+workspaces root, rejecting symlink escapes (`workspace.ex:66-85`).
+
+## The bundled example pack (`workflows/example/`)
+
+The public default, intentionally narrow: a single manual-trigger workflow plus a
+read-only skill that pushes nothing anywhere, meant as a starting point to copy
+(`packages/symphony/docs/setup.md:15-18`). `workflows/example/workflows/inspect.sym`:
+
+```
+workflow "inspect" on manual {
+  inspect <- agent {
+    engine: codex
+    model: "gpt-5.3-codex"
+    effort: medium
+    permissions: workspace_write
+    prompt: skill "inspect"
+  }
+}
+```
+
+It pairs with `skills/inspect.md` (above) and the one-repo `repositories.yaml`.
+Real deployments point `SYMPHONY_PACK_DIR` at their own pack; keeping the example
+narrow is a deliberate constraint so no workflow names, repo slugs, labels, or
+ticket schemes leak into the core (`packages/symphony/AGENTS.md:29-35`). See
+[operations](../operations/overview.md) for running a pack.

--- a/docs/terminal/common.md
+++ b/docs/terminal/common.md
@@ -1,0 +1,142 @@
+# Terminal
+
+PTY-backed terminal control for the repo: spawn interactive programs on real
+pseudo-terminals, drive them like a human typing, read back a rendered screen,
+multiplex one session across many clients, and emit terminal escape sequences.
+The flagship is [tui](tui/overview.md), a PTY-driver library that runs gdb, vim,
+a shell, or a REPL under a real PTY and exposes a VT-rendered viewport,
+scrollback, and per-cell styling; [tui-node](tui-node/overview.md) and
+[tui-py](tui-py/overview.md) are its Node and Python bindings. The VT engine
+itself lives in [vt](vt/overview.md) (a safe Rust wrapper over ghostty's
+libghostty-vt). [tap](tap/overview.md) is a separate, self-contained terminal
+session manager (detach/attach/share). [terminal-theme](terminal-theme/overview.md),
+[run](run/overview.md), and [kitty](kitty/overview.md) are small terminal
+utilities used across the repo.
+
+Read this page first, then the component page for the unit you are touching.
+
+## Units
+
+| unit | kind | role |
+| --- | --- | --- |
+| `packages/tui` | Rust lib crate (workspace member, no standalone flake output) | the PTY-driver: `TuiManager` spawns processes, each `TuiInstance` reads/writes one PTY through an actor backed by the [vt](vt/overview.md) engine. Optional `dashboard`/`publish` features re-export [dashboard-core](../dashboard/dashboard-core/overview.md). See [tui](tui/overview.md). |
+| `packages/tui-node` | Rust `cdylib` + npm package (`nix build .#tui-node`, Linux only) | thin N-API binding over `tui`; npm `@indexable/tui`. See [tui-node](tui-node/overview.md). |
+| `packages/tui-py` | Rust `cdylib` + wheel (`nix build .#tui-py`, Linux only) | PyO3 binding over `tui` plus a Python high-level API and a Playwright-style agent harness; PyPI `ix-tui`. See [tui-py](tui-py/overview.md). |
+| `packages/tap` (`tap`, `tap-protocol`, `tap-pty`) | Rust workspace: `tap` binary (`nix run .#tap`), `tap-protocol`/`tap-pty` lib crates | terminal session manager for tiling-WM users: one daemon per session over a Unix socket, multiplayer attach, min-size negotiation. `tap-pty` is its multiplexable PTY engine (vt100 mirror + fan-out). See [tap](tap/overview.md). |
+| `packages/vt` (`ix-vt`, `ix-vt-sys`, `libghostty-vt`) | `ix-vt`/`ix-vt-sys` Rust crates (`nix build .#ix-vt`); `libghostty-vt` Nix/Zig package (`nix build .#libghostty-vt`) | the VT engine: `ix-vt` is a safe wrapper, `ix-vt-sys` the raw FFI, `libghostty-vt` the ghostty C library it links. See [vt](vt/overview.md). |
+| `packages/terminal-theme` | Rust lib crate (no standalone flake output) | detect light vs dark terminal background, gated on stdout being a TTY. See [terminal-theme](terminal-theme/overview.md). |
+| `packages/run` | Nix-wrapped Python script (`nix run .#run`) | run a command under a recorded PTY session and keep the output (logs, asciinema cast, JSONL events). See [run](run/overview.md). |
+| `packages/kitty` | Rust lib crate (no standalone flake output) | encoder for the kitty terminal graphics protocol (escape-sequence framing only). See [kitty](kitty/overview.md). |
+
+The Rust crates above are all members of the repo's single Cargo workspace
+(`lib/rust/workspace.nix` builds them through the shared cargo-unit graph). A
+unit becomes a `nix run`/`nix build` flake output only when its `package.nix`
+sets `flake`/`packageSet` (see [tap](tap/overview.md), [vt](vt/overview.md),
+[run](run/overview.md), and the two binding packages); the plain library crates
+(`tui`, `kitty`, `terminal-theme`, `ix-vt-sys`, `tap-pty`, `tap-protocol`) have
+no flake output and are consumed only as dependencies.
+
+## The PTY-driver model
+
+Every "drive a real program" unit here follows the same shape:
+
+```
+caller --write--> PTY master --(kernel)--> PTY slave == child's controlling tty
+child output --> PTY master --> VT engine (feed bytes) --> render snapshot
+caller reads <-- viewport / scrollback / styled cells (rendered, not raw bytes)
+```
+
+1. Open a pseudo-terminal pair (master + slave) with
+   [`pty-process`](https://docs.rs/pty-process). The child runs on the slave, so
+   it sees a real terminal device: line discipline, job control, `SIGWINCH`, and
+   terminfo all work, unlike a dumb pipe.
+2. Read the child's output off the master and feed it into a VT emulator. The
+   caller never parses escape sequences: it reads the rendered grid (a viewport
+   of cells, scrollback above it, the cursor).
+3. Write input to the master. A real terminal applies one input-side transform
+   that the driver must reproduce: when the program enables DECCKM, arrow keys
+   must be sent in application form (see glossary), or full-screen programs go
+   blind to the arrows.
+
+There are two VT engine choices in this domain, and they do not share code:
+[tui](tui/overview.md) (and therefore both bindings) feeds the
+[vt](vt/overview.md) / libghostty-vt engine; [tap](tap/overview.md)'s `tap-pty`
+feeds the [`vt100`](https://docs.rs/vt100) crate. Both expose a viewport, a
+cursor, and scrollback, but the types are independent.
+
+## Cross-component invariants
+
+- **Unix only.** PTY devices, `SIGWINCH`, and `setsid` are required, so
+  everything here targets Linux and macOS, never Windows. The two binding wheels
+  (`tui-node`, `tui-py`) additionally restrict their *Nix* output to Linux
+  because the shared cdylib graph does not thread macOS's
+  `-undefined dynamic_lookup` through to the link step (`packages/tui-py/package.nix:11`,
+  `packages/tui-node/package.nix:8`); macOS dev uses a plain `cargo build`.
+- **One actor owns each PTY.** In both `tui` and `tap-pty`, a single async task
+  owns the PTY master and the child; every read, write, resize, kill, and the
+  child reap funnel through one mailbox, so concurrent callers serialize without
+  a lock on the fd. A child that has exited keeps its final screen readable;
+  writes to it then error.
+- **Default geometry is 80x24 with 10,000 lines of scrollback**
+  (`packages/tui/src/types.rs:122-130`, `packages/tap/src/daemon.rs:32-34`).
+  Resize delivers `SIGWINCH` to the child and updates the emulator together.
+- **The xterm-256color contract.** `tui` spawns children with
+  `TERM=xterm-256color` and `COLORTERM=truecolor` (`packages/tui/src/manager/spawn.rs:78-79`),
+  because libghostty-vt implements an xterm-256color superset; without a fixed
+  TERM, terminfo capabilities would vary by host.
+- **Bindings are thin.** `tui-node` and `tui-py` add no terminal behavior: each
+  holds a single process-wide `tui::TuiManager` in a `OnceLock`
+  (`packages/tui-node/src/lib.rs:38`, `packages/tui-py/src/manager.rs:13`) and
+  delegates every call to the `tui` crate, which owns the runtime and the engine
+  thread.
+- **The dashboard is out of this domain.** `tui`'s `dashboard`/`publish`
+  features and both bindings expose a live web grid of terminals, but the HTTP
+  server, the Loro CRDT document, the socket transport, and the wire types all
+  live in [dashboard-core](../dashboard/dashboard-core/overview.md). This domain
+  only adapts a live PTY manager into terminal panes; see the
+  [dashboard domain](../dashboard/common.md) for everything downstream of that.
+
+## Glossary
+
+- **PTY (pseudo-terminal)**: a master/slave fd pair. The child runs on the slave
+  (its controlling tty); the driver reads/writes the master.
+- **VT engine / emulator**: the state machine that consumes a child's raw output
+  (text plus escape sequences) and maintains a screen grid. Here it is either
+  libghostty-vt (via [ix-vt](vt/overview.md)) or the `vt100` crate
+  ([tap](tap/overview.md)).
+- **viewport**: the visible screen, one row per line. **scrollback**: rows that
+  have scrolled above the viewport, oldest first.
+- **render snapshot**: an owned, point-in-time copy of the screen state
+  (`ix_vt::Snapshot`): viewport cells, scrollback count, cursor. Valid after the
+  terminal is written to again.
+- **styled cell**: one screen cell with its character plus typed fg/bg color and
+  bold/italic/underline/inverse flags (`tui::StyledCell`).
+- **DECCKM / application cursor keys**: DEC private mode 1. A program enables it
+  (terminfo `smkx`, as ncurses/vim/less do) to receive cursor keys as `ESC O A`
+  rather than `ESC [ A`. The driver tracks the mode and rewrites arrows on
+  write (`packages/tui/src/actor/mod.rs:238`).
+- **alternate screen**: the full-screen buffer a TUI switches to (vim, less);
+  exposed by `tap-pty` so a late attach can repaint it.
+- **resync snapshot**: in `tap`, the escape sequences that reproduce the current
+  screen, handed to a newly attached client so it paints correctly without
+  replaying history (`packages/tap/pty/src/lib.rs:195`).
+- **fan-out**: one child's output broadcast to many subscribers (tap multiplayer,
+  tap `subscribe`).
+- **producer / aggregator**: in the dashboard split, a process *publishes* its
+  panes over a socket (producer); a standalone *aggregator* renders many. Both
+  defined in the [dashboard domain](../dashboard/common.md).
+- **kitty graphics protocol**: the `APC _G ... ST` escape framing terminals use
+  to draw images; [kitty](kitty/overview.md) encodes it.
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| tui | [tui/overview.md](tui/overview.md) | PTY-driver library: manager, instance handle, VT-rendered reads, lifecycle; dashboard/publish wiring. Threading model in [internals](tui/internals.md). |
+| tui-node | [tui-node/overview.md](tui-node/overview.md) | N-API bindings; `@indexable/tui` npm package |
+| tui-py | [tui-py/overview.md](tui-py/overview.md) | PyO3 bindings, async Python API, agent harness; `ix-tui` wheel |
+| tap | [tap/overview.md](tap/overview.md) | terminal session manager (daemon + clients) and the `tap-pty` multiplex engine + `tap-protocol` wire types |
+| vt | [vt/overview.md](vt/overview.md) | `ix-vt` safe wrapper, `ix-vt-sys` FFI, `libghostty-vt` C library build |
+| terminal-theme | [terminal-theme/overview.md](terminal-theme/overview.md) | light/dark background detection, TTY-gated |
+| run | [run/overview.md](run/overview.md) | record a command's PTY session: logs, cast, JSONL events |
+| kitty | [kitty/overview.md](kitty/overview.md) | kitty graphics protocol encoder |

--- a/docs/terminal/kitty/overview.md
+++ b/docs/terminal/kitty/overview.md
@@ -1,0 +1,70 @@
+# kitty
+
+`packages/kitty` is an encoder for the
+[kitty terminal graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/):
+it turns image bytes into the `APC _G ... ST` escape sequences that `kitty`,
+`ghostty`, and `wezterm` understand, and nothing else. It does not open a
+terminal, decode images, or do I/O: callers own those concerns and decide where
+the returned `String` is written (`src/lib.rs:1-6`). It is a small Rust library
+crate (workspace member, no flake output), consumed by `packages/git-log-pretty`.
+
+## Two display models
+
+- **Cursor placement** (`transmit` / `place`): draw at the cursor. Simplest, but
+  pins the image to a screen position, so it cannot survive a program that
+  repaints the screen (a pager, tmux, an editor).
+- **Unicode placeholder** (`transmit_virtual` + `placeholder_row`): transmit the
+  pixels once, then display the image wherever ordinary `U+10EEEE` placeholder
+  cells are printed. Because those cells are normal text, a host that knows
+  nothing about graphics reflows the image with the text, so it scrolls and pages
+  cleanly (`src/lib.rs:8-16`).
+
+## Public surface (`src/lib.rs`)
+
+- `Image<'a>` (`:48`): `Png(&[u8])` (terminal decodes it, protocol `f=100`) or
+  `Rgba { width, height, pixels }` (raw 8-bit RGBA, `f=32`).
+- `Placement { cols: Option<u32>, rows: Option<u32>, move_cursor: bool }` (`:63`):
+  cell-grid scaling (`c=`/`r=`); `move_cursor = false` emits `C=1` so the caller
+  can lay out text around the image. `Default` is `move_cursor = true`.
+- `transmit(&Image, id: Option<u32>, &Placement) -> String` (`:113`): transmit and
+  display at the cursor; `Some(id)` stores the image so `place` can redraw it
+  later without resending pixels (`a=T`).
+- `place(id: u32, &Placement) -> String` (`:138`): redisplay a stored image, no
+  payload (`a=p`).
+- `transmit_virtual(&Image, id: u32, cols: u32, rows: u32) -> String` (`:161`):
+  transmit and create an invisible virtual placement sized to a `cols`x`rows`
+  cell box (`a=T,U=1`). `id` must be non-zero and fit 24 bits, because
+  `placeholder_row` encodes it in a cell's 24-bit foreground color.
+- `PLACEHOLDER: char` = `U+10EEEE` (`:149`).
+- `placeholder_row(id: u32, row: u32, cols: u32) -> String` (`:191`): render one
+  row of a virtual image as ordinary text: a `SGR 38;2;r;g;b` foreground escape
+  carrying the `id`, then `cols` placeholder cells each tagged with a row and
+  column diacritic, then `SGR 39` to reset only the foreground. Row/col indices
+  past the diacritic table are dropped (clipping only an unreasonably large
+  placement).
+- `is_supported() -> bool` (`:91`): env-only best-effort detection. `false` under
+  tmux/screen (`TMUX`/`STY`, which swallow graphics escapes); `true` for
+  `KITTY_WINDOW_ID` or a `TERM`/`TERM_PROGRAM` advertising kitty/ghostty/wezterm.
+  A `true` is a hint, not a guarantee, so callers should still offer an opt-out.
+
+## Encoding details
+
+- Payloads are base64 (`base64` is the sole dependency, `Cargo.toml:12`) and
+  chunked: the protocol caps each command's base64 at 4096 bytes (`MAX_CHUNK`,
+  `:44`), so `encode_chunks` (`:247`) splits into continuation commands. The first
+  chunk carries the real control keys plus `m=1`; middles are `m=1`; the last is
+  `m=0`. A payload at or under the cap is one `m=0` command.
+- Quiet mode `q=2` is set on transmits so the terminal sends no acknowledgement
+  that could corrupt a host program's output.
+- The row/column diacritics come from kitty's `gen/rowcolumn-diacritics.txt`,
+  vendored as `src/rowcolumn-diacritics.txt` and parsed once into a `Vec<char>`
+  indexed by number (`diacritics`, `:217`). Index 0 is COMBINING OVERLINE
+  (`U+0305`), index 1 is COMBINING VERTICAL LINE ABOVE (`U+030D`).
+
+## Build
+
+`package.nix` is `{ id = "kitty"; inRustWorkspace = true; passthruTests = true; }`:
+a library, no flake output. The unit tests (`src/lib.rs:284`) assert the control
+fields and chunk boundaries for PNG and RGBA, the virtual-placement keys, the
+foreground-encoded id in placeholder rows, and that the diacritic table matches
+the kitty spec.

--- a/docs/terminal/run/overview.md
+++ b/docs/terminal/run/overview.md
@@ -1,0 +1,75 @@
+# run
+
+`packages/run` executes a command under a recorded PTY session and keeps the
+output: a full log, a replayable cast, and queryable structured events, while
+keeping printed output small enough for agent logs by default. It is a single
+Python script (`run.py`, 912 lines) wrapped by Nix as the flake output
+`nix run .#run` (`package.nix:3-4`), not part of the Cargo workspace.
+
+```sh
+nix run .#run -- nix build .#base   # everything after `run` is the command, verbatim
+```
+
+The first argument is the command; every following argument is passed through
+unchanged (`run.py:900`, `usage` at `:640`).
+
+## What it does
+
+`run` opens its own PTY (`pty.openpty`, `run.py:476`), forks the command onto the
+slave as a new session leader (`setsid` + `TIOCSCTTY`, `:481-489`), and copies
+the master's output to disk and (partially) to the caller's stdout. It forwards
+the caller's stdin to the child on a daemon thread (`forward_stdin`, `:584`), puts
+the caller's tty in raw mode while attached (`:786`), forwards `SIGINT`/`SIGTERM`/
+`SIGHUP` to the child's process group, and on `SIGWINCH` resizes the PTY and
+re-signals the child (`resize`/`forward`, `:805-821`). The main loop reads the
+PTY non-blocking via a selector, reaps the child, and finalizes the summary
+(`run`, `:718`).
+
+## Recorded files (one session dir per run)
+
+Sessions land under `./.ix/run/<timestamp>-<slug>-<pid>/` with `./.ix/run/latest`
+symlinked to the newest (`session_paths`, `run.py:347`). Each session writes
+(`ArtifactPaths`, `:38`):
+
+- `output.log`: full terminal output, flushed live.
+- `typescript` + `timing.log`: the `scriptreplay` pair.
+- `session.cast`: an asciinema v2 stream (header carries terminal size, command,
+  env; one `["o", text]` event per chunk, `Recorder._write_cast_header`, `:281`).
+- `events.jsonl`: one JSON object per PTY output chunk (elapsed time, byte count,
+  decoded text, base64 bytes, `Recorder.record`, `:241`).
+- `lines.jsonl`: one object per completed output line, shaped for
+  `polars.read_ndjson` (`LineRecorder`, `:145`).
+- `summary.json`: command, cwd, terminal metadata, artifact paths, limits,
+  duration, and exit status; written first as `running`, then replaced with the
+  final result (`initial_summary` `:675`, finalized `:874`). Exit status maps a
+  signal to `128 + signum` (`status_code`, `:615`).
+- `replay` + `live`: generated helper scripts (`replay [divisor]` runs
+  scriptreplay; `live` is `tail -f output.log`, `write_helper_scripts`, `:405`).
+
+## Printed-output limiting
+
+By default `run` prints the first 80 and last 80 output lines and records the rest
+to `output.log`, so a long build does not flood an agent log (`DisplayLimiter`,
+`run.py:73`; defaults `DEFAULT_HEAD_LINES`/`DEFAULT_TAIL_LINES = 80`, `:29`). When
+output exceeds the head limit it announces the live-stream path on stderr and
+buffers the tail; on finish it prints the tail with a count of omitted middle
+lines.
+
+## Environment knobs
+
+- `IX_RUN_HEAD_LINES` / `IX_RUN_TAIL_LINES`: lines to print (`env_int`, `:313`).
+- `IX_RUN_PRINT`: `summary` (default), `full` (mirror every line), or `none`
+  (`print_mode`, `:326`).
+- `IX_RUN_DIR`: session root, default `./.ix/run` (`state_root`, `:334`).
+- `IX_RUN_SCRIPTREPLAY`: the scriptreplay binary, set by the Nix wrapper
+  (`replay_command`, `:392`).
+
+## Build
+
+`default.nix` wraps `run.py` with `ix.writePythonApplication` and uses
+`makeWrapper` to bake `IX_RUN_SCRIPTREPLAY` to `util-linux`'s `scriptreplay` on
+Linux (`default.nix:8-32`), so replay works without the binary on `PATH`. The
+`recordsSession` passthru test drives the wrapped binary through a real run and
+asserts every artifact exists, that summarized stdout shows head+tail but not the
+middle, and that stdin forwarding (redirected, non-blocking, and closed) and a
+closed stdout all behave (`default.nix:33-184`). `meta.mainProgram = "run"`.

--- a/docs/terminal/tap/overview.md
+++ b/docs/terminal/tap/overview.md
@@ -1,0 +1,139 @@
+# tap
+
+`packages/tap` is a terminal session manager for tiling-WM users: start a
+command, detach, reattach later from any terminal, and share a session with
+others, with no in-terminal tiling layer to fight a window manager. It is a
+self-contained Cargo workspace of three crates, independent of
+[tui](../tui/overview.md) (it mirrors the same PTY-actor pattern but uses the
+[`vt100`](https://docs.rs/vt100) emulator, not the [vt](../vt/overview.md)
+engine). The `tap` binary is the flake output `nix run .#tap`
+(`package.nix:3-4`).
+
+## The three crates
+
+| crate | role |
+| --- | --- |
+| `packages/tap` (`tap`) | the CLI, the session daemon, and the attach client (`src/`). Binary `tap`. |
+| `packages/tap/pty` (`tap-pty`) | the reusable multiplexable PTY session engine: spawn a child on a PTY, mirror it with vt100, fan raw output out to many subscribers with atomic resync snapshots. Library, no flake output. |
+| `packages/tap/protocol` (`tap-protocol`) | wire types and runtime paths, no I/O. Library, no flake output. |
+
+## Architecture: one daemon per session, thin clients
+
+Every interactive `tap` (even for a single user) is a client of a per-session
+daemon, connected over a Unix socket speaking newline-delimited JSON. The daemon
+owns the PTY and the screen; clients only render it and forward keystrokes. That
+uniformity is what makes resize-while-attached and multi-client sharing fall out
+(`src/daemon.rs:1-13`).
+
+```
+tap start <cmd>  --spawns--> daemon (setsid, owns PtySession + client registry)
+                                |  UnixListener at <runtime>/<id>.sock
+tap attach [id] --connects--> client (raw-mode terminal: render output, send input)
+tap subscribe   --connects--> read-only observer (output stream only)
+```
+
+`tap start` resolves the command (default interactive `$SHELL`, forced
+`-i`/`-l`), then spawns the daemon as a detached child (`stdin/out` to
+`/dev/null`, `stderr` to a per-session log) and polls for its socket to appear
+before attaching (`src/client.rs:32-104`). The daemon spawns the PTY child first,
+then calls `setsid` so closing the launching client does not SIGHUP it; the order
+matters because macOS rejects the child's `TIOCSCTTY` if the parent is already a
+session leader (`src/daemon.rs:250-256`).
+
+## CLI (`src/main.rs`)
+
+`tap` with no subcommand defaults to `start` (`main.rs:114`). Subcommands
+(`main.rs:35`):
+
+- `start [-d|--detached] [--id <id>] [cmd...]`: start a session; `-d` does not
+  attach.
+- `attach [session]`: attach to a session (most recent if omitted).
+- `list`: table of live sessions.
+- `scrollback [-s id] [-l lines]`, `cursor [-s id]`, `size [-s id]`: one-shot
+  reads of the screen text, cursor, negotiated size.
+- `inject [-s id] <text>`: type text into a session without attaching.
+- `subscribe [-s id]`: stream raw output to stdout.
+- `kill [session]`: terminate the child and shut the daemon down.
+- `daemon --id --socket -- <cmd...>`: hidden, spawned by `start`; not for direct
+  use (`main.rs:96`).
+
+Interactive keybinds (configurable): `Ctrl-\` detaches, `Alt-e` opens the
+scrollback in `$EDITOR` (`README.md:36`).
+
+## tap-pty: the session engine (`pty/src/lib.rs`)
+
+`PtySession::spawn(SessionConfig { command, rows, cols, scrollback_lines })`
+(`pty/src/lib.rs:136`) runs the child on a `pty-process` PTY and mirrors output
+into a `vt100::Parser` behind a `parking_lot::Mutex`. An actor task owns the PTY
+master and is the only writer (`pty/src/lib.rs:307`); a `Command` channel
+serializes `Write`/`ResizePty`/`Kill`. Output is broadcast on a
+`tokio::sync::broadcast` channel of capacity 1024.
+
+The load-bearing property is **atomic late attach** (`pty/src/lib.rs:9-13,
+190-199`): `subscribe() -> Attachment { snapshot, output }` takes the emulator
+lock, reads `screen().contents_formatted()` (the escape sequences that reproduce
+the current screen), and subscribes to the broadcast under that same lock. The
+actor also holds the lock across `process(bytes)` + `send(bytes)`
+(`pty/src/lib.rs:345-348`), so the snapshot/stream join is exactly once: no byte
+is both in the snapshot and the first stream item, and none is dropped between.
+That is what makes attaching to a running full-screen TUI paint correctly.
+
+Other handle methods: `snapshot()`, `write_input`, `resize` (updates the
+emulator immediately, queues the kernel PTY resize that delivers `SIGWINCH`),
+`kill`, `scrollback(lines)`, `cursor`, `size`, `alternate_screen`, `exit_watch`
+(a `watch::Receiver<Option<i32>>`), `exit_code`. Exit codes resolve to
+`128 + signal` when signalled (`pty/src/lib.rs:294`). A lagged subscriber resyncs
+from a fresh snapshot rather than a torn byte replay (`src/daemon.rs:408`).
+
+## Size negotiation (multiplayer)
+
+The daemon keeps a client registry (`src/daemon.rs:55-59`). The session size is
+the element-wise minimum over all attached clients (tmux's rule), so no client
+sees clipped output (`recompute`, `src/daemon.rs:189`). On any change it resizes
+the PTY and pushes a fresh repaint (`Response::Resized`) to every attached client
+except the requester. Observers from `subscribe` do not contribute to size
+negotiation (`add_observer`, `src/daemon.rs:136`). A client whose own terminal is
+larger than the negotiated size gets a dim "unused space" warning row.
+
+## tap-protocol: the wire (`protocol/src/lib.rs`)
+
+A client and daemon exchange one JSON object per line; binary payloads (raw PTY
+bytes, resync snapshots) ride as base64 so a frame never contains a literal
+newline (`protocol/src/lib.rs:178`). `Request` variants (`protocol/src/lib.rs:39`):
+`Attach{rows,cols}`, `Detach`, `Input{data}`, `Resize{rows,cols}`, `Inject{data}`,
+`Subscribe`, `GetScrollback{lines}`, `GetCursor`, `GetSize`, `Kill`. `Response`
+variants (`:86`): `Attached{rows,cols,snapshot}`, `Output{data}`,
+`Resized{rows,cols,snapshot}`, `Scrollback`, `Cursor`, `Size`, `Subscribed`,
+`SessionEnded{exit_code}`, `Ok`, `Error{message}`. `Session` (`:23`) is the index
+record (id, daemon pid, start time, command, socket path); liveness is resolved
+from pid/socket, not trusted from the record.
+
+Runtime paths (`protocol/src/lib.rs:156-176`): `runtime_dir()` honors
+`TAP_RUNTIME_DIR` (`RUNTIME_DIR_ENV`), else the XDG runtime dir, else `~/.tap`,
+else a temp dir; `socket_path(id)` is `<dir>/<id>.sock`; `sessions_file()` is
+`<dir>/sessions.json`.
+
+## Configuration
+
+Optional `~/.config/tap/config.toml` (`src/config.rs`): `editor` (overrides
+`$EDITOR`/`$VISUAL`), `[keybinds] editor`/`detach`, `[timing] escape_timeout_ms`
+(distinguishing a lone `ESC` from an `Alt-` sequence, default 50). Keybinds match
+both legacy byte sequences and the Kitty keyboard protocol's CSI-u form
+(`config.rs:135-179`), so a bind fires whether or not an inner app negotiated
+Kitty input.
+
+## Build and tests
+
+`default.nix` selects the `tap` binary from the shared workspace graph
+(`ix.cargoUnit.selectBinaryWithTests`). `tap`, `tap-pty`, and `tap-protocol` all
+set `passthruTests = true`. Integration tests (`tests/session.rs`) drive the real
+`tap` binary on a PTY using this repo's [tui](../tui/overview.md) driver
+(`Cargo.toml:27`) and assert on the rendered grid: input round-trip, full-screen
+resync on a second attach, multiplayer min-size, and resize-while-attached.
+
+## Known limits
+
+Unix only (PTYs, `SIGWINCH`, `setsid`). Sessions are local to one machine and
+user (the socket is in the user's runtime dir); no network or cross-user access.
+A client that falls far behind is resynced from a snapshot, so a burst can skip
+intermediate frames on a slow link (`README.md:110-117`).

--- a/docs/terminal/terminal-theme/overview.md
+++ b/docs/terminal/terminal-theme/overview.md
@@ -1,0 +1,39 @@
+# terminal-theme
+
+`packages/terminal-theme` owns one decision shared across the repo's terminal
+tools: is the terminal background light or dark. It is a tiny Rust library crate
+(`Cargo.toml:2`), a workspace member with no flake output, consumed by
+`packages/search` and `packages/git-log-pretty` (`Cargo.toml:30` and
+`:26` respectively) to pick a palette.
+
+## Public surface (`src/lib.rs`)
+
+- `Theme::{Light, Dark}` (`src/lib.rs:20`), `Dark` being the default and the
+  fallback (`#[default]`, `:24`).
+- `detect() -> Theme` (`src/lib.rs:35`): probe the terminal and classify.
+
+The whole crate is two enum variants and one function.
+
+## Behavior and the TTY gate
+
+`detect` probes the background luma via the
+[`terminal-light`](https://docs.rs/terminal-light) crate and classifies anything
+brighter than mid-gray (luma > 0.5) as `Light`, everything else (including an
+unreadable or absent response) as `Dark` (`src/lib.rs:39-42`).
+
+The load-bearing invariant is the TTY gate: the probe works by writing an OSC
+color query and waiting for the terminal to answer, so it only runs when stdout
+is a terminal (`std::io::stdout().is_terminal()`, `src/lib.rs:36`). Under a pipe,
+a capture, or a test, those query bytes would corrupt the output or block on a
+reply that never comes, so non-interactive stdout returns `Theme::Dark` without
+probing. A caller with its own "should I emit color at all" switch (a `--color`
+flag) keeps that decision local and only calls `detect` once it has decided
+color is wanted (`src/lib.rs:11-13`).
+
+## Build
+
+`package.nix` is `{ id; inRustWorkspace = true; passthruTests = true; }`: no
+`default.nix`, no flake output, built only as a workspace library. Its single
+dependency is `terminal-light` (`Cargo.toml:12`). Unit tests assert the default
+is `Dark` and that the test harness's captured (non-TTY) stdout returns the dark
+fallback (`src/lib.rs:49-59`).

--- a/docs/terminal/tui-node/overview.md
+++ b/docs/terminal/tui-node/overview.md
@@ -1,0 +1,81 @@
+# tui-node
+
+`packages/tui-node` is the Node.js (N-API) binding for [tui](../tui/overview.md):
+spawn and drive PTY-backed programs (vim, a REPL, a shell) from Node with full
+VT100 emulation, plus the in-process web dashboard. It is a thin binding built
+with [napi-rs](https://napi.rs/); the `tui` crate owns every behavior. npm name
+`@indexable/tui`, native addon `tui_node.node` (`packages/tui-node/README.md:12`).
+
+## What it is
+
+- Rust crate `tui-node` (`Cargo.toml:2`), `crate-type = ["cdylib"]`
+  (`Cargo.toml:9`), depending on `tui` with the `dashboard` feature
+  (`Cargo.toml:17`) and `napi`/`napi-derive`.
+- A hand-written JS wrapper (`npm/index.js`) plus TypeScript types
+  (`npm/index.d.ts`) layered over the addon.
+- A `nix build .#tui-node` output that emits an npm package tree
+  (`package.json`, `index.js`, `index.d.ts`, `native/tui_node.node`). Linux only
+  (`package.nix:8`), like [tui-py](../tui-py/overview.md), because the shared
+  cargo-unit graph does not thread macOS's `-undefined dynamic_lookup` through
+  the link step; for macOS dev use plain `cargo build -p tui-node`
+  (`README.md:64-69`).
+
+## Public surface
+
+The native addon exports three items (`src/lib.rs`); the JS wrapper re-exports
+them and adds two pure-JS helpers (`npm/index.js:72-76`).
+
+`Tui` (`src/lib.rs:74`), one spawned process:
+
+- `new(command, args?, options?)` (`src/lib.rs:83`): spawn on a fresh PTY and
+  track it. `SpawnOptions { rows?, cols?, scrollbackLines? }` (`src/lib.rs:60`),
+  unset fields fall back to 80x24 / 10,000.
+- Static `Tui.listAll()` (`src/lib.rs:108`).
+- Synchronous getters: `id`, `command`, `args`, `rows`, `cols`,
+  `scrollbackLimit` (`src/lib.rs:118-146`); instant state `isAlive()`,
+  `exitCode()` (`src/lib.rs:191,197`).
+- Async I/O (each returns a `Promise`, runs on the tui actor, never blocks the
+  event loop): `write(data)`, `readViewport()`, `readScrollback()`, `readFull()`
+  (`{ scrollback, viewport }`), `readBlocking(timeoutMs)` (`src/lib.rs:152-185`).
+- Lifecycle: `wait()` (resolves to the exit code, `null` if signalled),
+  `kill()` (SIGKILL), `resize(rows, cols)` (delivers `SIGWINCH`),
+  `close()` (force-kill and drop from `listAll` and the dashboard,
+  `src/lib.rs:207-234`).
+
+`serve(host?, port?, pollMs?) -> Promise<Dashboard>` (`src/lib.rs:279`): start
+the in-process Loro-backed web dashboard for every live `Tui`. `host` must be an
+IP literal (a hostname is not resolved, `src/lib.rs:289`); `port = 0` binds an
+ephemeral port read back from `Dashboard.url`. `Dashboard` (`src/lib.rs:239`)
+exposes `url`, `addr`, and `stop()`. The server, the CRDT document, and the SSE
+stream are all in Rust ([dashboard-core](../../dashboard/dashboard-core/overview.md));
+the browser imports updates with `loro-crdt`.
+
+JS-only helpers (`npm/index.js`):
+
+- `Key` (`index.js:12`): frozen ANSI keystroke constants (`ENTER`, `ESC`, arrows,
+  `PAGE_UP`, `CTRL_C`, ...) plus `Key.ctrl(letter)` and `Key.alt(letter)`. They
+  are plain strings, so they concatenate with literal text and pass to `write`.
+- `waitFor(tui, pattern, { timeoutMs, pollMs })` (`index.js:51`): poll the
+  viewport until a substring, RegExp, or predicate matches, returning the lines;
+  throws on timeout.
+
+## Wiring
+
+The addon holds a single process-wide `tui::TuiManager` in a `OnceLock`
+(`src/lib.rs:38`); every `Tui` is a handle into it, mirroring the Python binding.
+JS numbers cross in as `u32`; `narrow_u16` rejects out-of-range rows/cols/ports
+rather than wrapping (`src/lib.rs:52`). Errors become rejected Promises via
+`Error::from_reason` (`src/lib.rs:46`).
+
+## Build details
+
+`package.nix` sets `id = "tui-node"`, `inRustWorkspace = true`, and restricts the
+flake/package set to `x86_64-linux`/`aarch64-linux` (`package.nix:8-15`). The Nix
+build (`default.nix`) does not run `napi build` or `node-gyp`: it takes the
+cdylib already produced by the shared workspace graph
+(`ix.rustWorkspace.units.libraries.tui_node`, `default.nix:10`), renames it to
+`native/tui_node.node`, strips the build-time rpath and toolchain references with
+`patchelf`/`remove-references-to` so the artifact is not pinned to a store path
+(`default.nix:67-75`), and stamps `package.json`'s `cpu`/`libc` for the build
+arch (`default.nix:62`). `package.json` declares `"os": ["linux"]` and
+`engines.node >= 20` (`npm/package.json`).

--- a/docs/terminal/tui-py/overview.md
+++ b/docs/terminal/tui-py/overview.md
@@ -1,0 +1,111 @@
+# tui-py
+
+`packages/tui-py` is the Python binding for [tui](../tui/overview.md): spawn and
+control PTY-backed programs from Python with full vt100 emulation, scrollback,
+NumPy cell access, an in-process web dashboard, and a Playwright-style harness for
+driving interactive coding agents. PyPI distribution name `ix-tui`, import name
+`tui` (`README.md:14`). The API is async-only and built on
+[pyo3-async-runtimes](https://docs.rs/pyo3-async-runtimes): every I/O method is a
+native asyncio coroutine bridged from a Rust future with no thread-pool hop.
+
+## Three layers
+
+1. **The PyO3 extension `tui._tui`** (`src/lib.rs`): a `cdylib`
+   (`Cargo.toml:9`) over the `tui` crate built with the `pyo3`, `dashboard`, and
+   `publish` features (`Cargo.toml:20`). It is thin: it exposes the low-level
+   `TuiInstance`, `StyledCell`, `Dashboard`, `Publisher`, and the functions
+   `serve`, `publish`, `ensure_published`, `socket_dir` (`src/lib.rs:21-30`).
+   Blocking work releases the GIL via `Python::detach`; async methods return
+   asyncio-awaitable coroutines (`src/manager.rs` doc).
+2. **The Python package `tui`** (`python/tui/__init__.py`): the high-level,
+   documented surface. It wraps `_tui.TuiInstance` in the ergonomic `Tui` class
+   and adds value types (`Snapshot`, `Size`, `Theme`, `Key`, `Color`) and HTML
+   rendering. This is what callers import.
+3. **`tui.harness`** (`python/tui/harness.py`): the agent-driving layer.
+
+## Layer 1: the extension (`src/`)
+
+- `TuiInstance` (`src/manager.rs:30`, `frozen`): constructor `(command, args=None,
+  rows=None, cols=None, scrollback_lines=None)` spawns into a single process-wide
+  `tui::TuiManager` held in a `OnceLock` (`src/manager.rs:13`). Sync accessors
+  (`id`, `command`, `args`, `rows`, `cols`, `scrollback_limit`, `is_alive`,
+  `exit_code`); async coroutines `write_async`, `read_viewport_async`,
+  `read_scrollback_async`, `read_full_async`, `read_blocking_async`,
+  `read_chars_array_async` (a `numpy.uint32` array), `read_styled_cells_async`,
+  `resize_async`, `kill_async`, `wait_async`, `close_async`.
+- `StyledCell` (`src/types.rs:11`): `char`, `fg`/`bg` (pythonic `Color`: `None`,
+  `int`, or `(r,g,b)`), `bold`/`italic`/`underline`/`inverse`.
+- `Dashboard` + `serve(host, port, poll_ms)` (`src/dashboard.rs`): the
+  Loro-backed web dashboard for the global manager; same engine as the Rust
+  `tui::serve`.
+- `Publisher` + `publish(path, poll_ms)` + `ensure_published(poll_ms)` +
+  `socket_dir()` (`src/publish.rs`): the producer side (below).
+
+## Layer 2: the Python API (`python/tui/__init__.py`)
+
+`Tui` (`__init__.py:524`) is the workhorse. Construction and the cached accessors
+(`id`, `command`, `args`, `size`, `is_alive`, `exit_code`) are synchronous;
+everything else is a coroutine. Highlights:
+
+- Input: `write(data)`, `send(*parts)`, `enter(text="")`, `interrupt()`
+  (Ctrl+C).
+- Reads: `read(timeout=None)`, `viewport()`, `scrollback()`, `text()`,
+  `snapshot(styled=True) -> Snapshot`, `chars() -> NDArray[uint32]`,
+  `styled_cells() -> list[list[StyledCell]]`.
+- `wait_for(pattern, timeout) -> Snapshot` (`__init__.py:697`): poll until a
+  substring, compiled `re.Pattern`, or `Snapshot` predicate matches; raises
+  `WaitTimeout` on the deadline. (The returned snapshot is text-only; the poll
+  loop skips the styling read.)
+- Lifecycle: `resize`, `wait(timeout)`, `kill`, `close`; `async with` calls
+  `close` on exit.
+- `Tui.list_all()` (sync, `__init__.py:583`).
+
+Value types: `Snapshot` (`__init__.py:343`, frozen: viewport, scrollback, size,
+styled cells; supports `str()`, `in`, `.text`/`.full_text`, and a colored
+`_repr_html_` for Jupyter), `Size` (`__init__.py:320`), `Key` (a `StrEnum` of
+ANSI sequences with `.ctrl`/`.alt`, `__init__.py:423`), `Theme`
+(`__init__.py:140`, default fg/bg + 16 ANSI; `Theme.from_ghostty(...)` parses a
+ghostty theme file), the bundled `DARK_THEME`/`LIGHT_THEME`/`DEFAULT_THEME`,
+`Color`, and `WaitTimeout`. `serve`/`Dashboard` and `publish`/`Publisher` are
+re-exported wrappers over layer 1.
+
+## Auto-publish to the dashboard
+
+The first `Tui(...)` calls `ensure_published()` (`src/publish.rs:132`), which
+binds one process-global producer on the discovery socket so spawned terminals
+appear in the standalone aggregator with no explicit `tui.publish()`. It is
+idempotent, skipped when `IX_TUI_AUTOPUBLISH=0`, and superseded by an explicit
+`tui.publish(...)` so a process never exposes two producers
+(`src/publish.rs:38,98`). The producer/consumer transport and the aggregator
+live in the [dashboard domain](../../dashboard/common.md); the README and Python
+docstrings invoke the aggregator as `nix run .#tui-dashboard`, but the registered
+flake output for the aggregator is `nix run .#dashboard`
+([dashboard](../../dashboard/dashboard/overview.md)).
+<!-- TODO: verify whether `tui-dashboard` is an intended alias for the `dashboard` flake output; it is not registered in packages/*/package.nix. -->
+
+## Layer 3: the agent harness (`python/tui/harness.py`)
+
+`tui.harness` drives interactive coding agents (Claude Code, Codex) the way
+Playwright drives a browser: `Tui` is the raw page, a harness adds
+`launch`/`keyboard`/`wait_for_idle`/`content`/`expect`. Classes (`harness.py`):
+`Agent` (base, `:112`), `Claude` (`:405`, grounded against Claude Code 2.1.x),
+`Codex` (`:429`, quiescence-only), `Keyboard` (`:91`), `Gate` (`:72`, an
+onboarding screen cleared on launch), `AgentAssertions` + `expect(agent)`
+(`:449,502`). Idle detection is quiescence-first: a turn is done when the
+viewport stops changing for `settle` seconds and a `busy_marker` substring is
+absent (`harness.py` `_settle`/`wait_for_idle`). The point of driving the real
+TUI (not `claude -p`) is observability: the session shows up live on the web
+dashboard. The harness symbols are re-exported at the package top level
+(`__init__.py` `__all__`).
+
+## Build
+
+`nix build .#tui-py` writes a PEP 427 wheel
+(`ix_tui-<version>-cp311-abi3-manylinux_2_34_<arch>.whl`, `README.md:25`). Linux
+only (`package.nix:11`); the cdylib comes from the shared cargo-unit graph
+(`ix.rustWorkspace.units.libraries.tui_py`, `default.nix:13`) and
+`wheel/mkwheel.py` packages it with the Python source. There is no PEP 517
+backend and no maturin: `pip install .` is not supported (`README.md:21`). The
+extension is abi3 (`pyo3/abi3-py311`), so one wheel loads on CPython 3.11+. For
+macOS, the mcp bundles the cdylib straight from the workspace graph for a
+cross-platform `import tui` (`package.nix:8`).

--- a/docs/terminal/tui/internals.md
+++ b/docs/terminal/tui/internals.md
@@ -1,0 +1,103 @@
+# tui internals
+
+The non-obvious mechanism behind [tui](overview.md): a two-tier per-child
+threading model, the cursor-key rewrite on write, the first-paint wait, and the
+scrollback read. Read [overview](overview.md) first for the public surface.
+
+## Two tiers per child: actor task + engine thread
+
+Each spawned child gets two owners (`src/manager/spawn.rs:96-119`):
+
+1. A **PTY actor**, an async task on the manager's runtime (`actor::pty_actor`,
+   `src/actor/mod.rs:59`). It owns the PTY master and the `tokio::process::Child`
+   and is the only thing that touches them. A `select!` loop services the command
+   mailbox (`mpsc::Receiver<PtyCommand>`), reads PTY output into an 8 KiB buffer,
+   and reaps the child. Because the actor is single, reads/writes/kill/resize
+   from many threads serialize through one mailbox instead of locking the fd.
+2. A **VT engine thread**, a dedicated OS thread (`actor::engine::spawn`,
+   `src/actor/engine.rs:62`). It owns the `ix_vt::Terminal`. This split exists
+   because libghostty-vt's terminal is `!Send + !Sync` (it has thread affinity,
+   `src/lib.rs` doc and `packages/vt/ix-vt/src/lib.rs:289`): it cannot live in a
+   tokio task that may migrate worker threads. The actor forwards every byte feed
+   and read request to the engine thread as an `EngineRequest`
+   (`engine.rs:25`); replies ride back on per-request `oneshot` channels, so the
+   async side never touches the terminal.
+
+```
+caller (any thread)
+  -> TuiInstance method -> runtime.block_on / await
+  -> PtyCommand on mpsc  -> PTY actor task (owns PTY master + Child)
+                              -> EngineRequest on std::mpsc -> VT engine thread (owns !Send Terminal)
+                              <- oneshot reply (Snapshot / lines / ())
+```
+
+Engine init is a handshake: `Terminal::new` runs on the new thread, and `spawn`
+blocks on a sync channel so a failed construction surfaces as `Error::VtEngine`
+instead of a channel into a dead thread (`engine.rs:91-96`).
+
+`PtyCommand` variants (`src/actor/mod.rs:17`): `Write`, `Kill`, `Resize`, and the
+five reads (`ReadViewport`, `ReadScrollback`, `ReadChars`, `ReadStyledCells`,
+`ReadCursor`). `EngineRequest` variants (`engine.rs:25`): `Process` (fire-and-
+forget byte feed), `Resize`, `Snapshot`, `Scrollback`.
+
+The actor's `select!` is `biased` (`actor/mod.rs:74`): commands first, then PTY
+reads, then the child-exit reap. Child reap publishes the exit code through a
+`watch::Sender<ExitState>` that `exit_state`/`is_alive`/`wait` read. After the
+child exits, the actor keeps serving reads (the final screen stays inspectable)
+and stays alive until every handle drops; a write then returns `TuiNotFound`
+(`actor/mod.rs:92`).
+
+## Cursor-key rewrite (DECCKM)
+
+A real terminal emits cursor keys in application form (`ESC O A`..`D`,
+Home/End as `ESC O H`/`F`) once a program enables DECCKM via terminfo `smkx`
+(ncurses, vim, less all do on entry). Sending the normal `ESC [ A` form instead
+leaves those programs blind to the arrows. So on every `Write`, the actor calls
+`apply_cursor_key_mode` (`src/actor/mod.rs:238`): when application mode is on, it
+rewrites the exact 3-byte `ESC [ {A,B,C,D,H,F}` sequences to their `ESC O` form
+and passes everything else through. A modified arrow carries parameters
+(`ESC [ 1 ; 5 A` for Ctrl+Up), so the byte after `[` is a digit, not a final
+letter, and it is left untouched. The rewrite is per-write, not across writes: an
+arrow split across two `write` calls is not reassembled.
+
+The mode itself is read from the engine. After each `Process`, the engine thread
+queries `terminal.application_cursor_keys()` and updates a shared
+`Arc<RwLock<bool>>` (`engine.rs:156`), which the actor reads on the next write.
+A failed query keeps the last known value.
+
+## Cursor shape cache
+
+`CursorShape` is updated on every render: the engine writes
+`CursorShape::from(snapshot.cursor.visual_style)` into a shared
+`Arc<RwLock<CursorShape>>` (`engine.rs:169`), so `TuiInstance::cursor_shape()`
+reads it synchronously without a round trip. `size` is shared the same way so a
+`resize` on one handle is visible from every clone (`manager/mod.rs:39`).
+
+## First-paint wait
+
+`spawn_tui` ends with `wait_for_initial_output` (`src/manager/spawn.rs:25`): it
+polls the viewport for up to 100ms (5ms interval) until a non-empty read, so a
+caller that reads immediately after `spawn` sees content rather than a blank
+screen. `read_viewport` drops trailing blank rows, so a non-empty result means
+the child actually painted.
+
+## Reading the screen
+
+`render` always reads the active viewport, so scrollback is read by walking it
+(`src/actor/engine.rs:186`): scroll the viewport to the top, render one row at a
+time stepping down by one, then restore the bottom. Each row is joined into a
+`String` with trailing blanks trimmed (`row_to_string`, `engine.rs:210`). An
+all-blank viewport yields an empty `Vec` (`snapshot_to_viewport_lines`,
+`engine.rs:220`), which is what `read_blocking` polls on for first paint.
+
+`snapshot_to_styled_cells` (`engine.rs:271`) flattens the viewport into a
+`rows x cols` `ndarray::Array2<StyledCell>`, mapping each `ix_vt::Cell`'s declared
+style colors and SGR flags; an empty viewport is `NoOutputAvailable`, a shape
+mismatch is `ArrayConversion`. `snapshot_to_cursor` (`engine.rs:299`) swaps the
+snapshot's `(col, row)` into `CursorPos { row, col, visible }`.
+
+## Tuning constants
+
+`src/manager/spawn.rs`: `CHANNEL_BUFFER_SIZE = 100` (command mailbox depth),
+`INITIAL_OUTPUT_TIMEOUT = 100ms`, `INITIAL_OUTPUT_POLL_INTERVAL = 5ms`. The PTY
+read buffer is 8192 bytes (`src/actor/mod.rs:68`).

--- a/docs/terminal/tui/overview.md
+++ b/docs/terminal/tui/overview.md
@@ -1,0 +1,137 @@
+# tui
+
+`packages/tui` is the repo's flagship PTY primitive: spawn and control multiple
+interactive terminal programs (gdb, vim, a shell, a REPL) from one process as if
+a human were typing, and read back a VT-rendered screen instead of a raw byte
+stream. It is a Rust library crate (`name = "tui"`,
+`packages/tui/Cargo.toml:2`), a workspace member with no standalone flake output;
+it is consumed directly by [tui-node](../tui-node/overview.md),
+[tui-py](../tui-py/overview.md), and `tap`'s integration tests, and indirectly
+anywhere those bindings are used.
+
+The crate-level mechanism (the actor mailbox, the dedicated VT engine thread,
+the cursor-key rewrite, the initial-paint wait) is in
+[internals](internals.md). This page is the public surface and how it builds.
+
+## Module map (`src/lib.rs:38-61`)
+
+- `manager` (`mod.rs`, `spawn.rs`, `reader.rs`): `TuiManager` and `TuiInstance`,
+  the public entry points.
+- `actor` (`mod.rs`, `engine.rs`): the per-child PTY actor task and the VT engine
+  thread. Private; see [internals](internals.md).
+- `types`: the plain value types (`SpawnConfig`, `StyledCell`, `Color`,
+  `CursorPos`, `CursorShape`, `ExitState`, `FullOutput`).
+- `slice`: `slice_2d` with `RowRange`/`ColRange` for sub-rectangle extraction.
+- `error`: the `snafu`-derived `Error` enum and `Result` alias.
+- `frame` + `publish` + `dashboard`: gated on the `publish`/`dashboard` features
+  (below); the bridge from a live manager to dashboard panes.
+
+## Public surface
+
+`TuiManager` (`src/manager/mod.rs:249`):
+
+- `new()` / `default()`: create a manager owning a fresh multi-threaded tokio
+  runtime (`mod.rs:266`). Panics only if the runtime cannot be created.
+- `spawn(command, args, SpawnConfig) -> Result<TuiInstance>` (`mod.rs:277`):
+  open a PTY, launch the child, register the instance, and wait briefly for the
+  first paint before returning.
+- `list() -> Vec<TuiInstance>` (`mod.rs:290`), `get(&Uuid) -> Result<TuiInstance>`
+  (`mod.rs:306`), `remove(&Uuid) -> Option<TuiInstance>` (`mod.rs:301`). Removal
+  stops tracking; the actor keeps running until every handle drops, so kill
+  first if you want the process gone.
+
+`TuiInstance` (`src/manager/mod.rs:26`) is a cheap `Clone` handle; every clone
+addresses the same process and carries its own clone of the runtime, so it keeps
+working as long as held. Public fields: `id: Uuid`, `command`, `args`,
+`spawned_at`, `scrollback_limit`. Every blocking method below has an `_async`
+twin returning a future for callers already inside tokio.
+
+- Shape: `rows()`, `cols()` (`mod.rs:51,57`), `cursor_shape() -> CursorShape`
+  (`mod.rs:64`), `read_cursor() -> Result<CursorPos>` (`mod.rs:69`).
+- Input: `write(&str)` (`mod.rs:106`). Applies the DECCKM cursor-key rewrite
+  (see [internals](internals.md)); all other bytes pass through.
+- Reads: `read_viewport() -> Vec<String>` (`mod.rs:115`),
+  `read_scrollback()` (`mod.rs:121`), `read_full() -> FullOutput` (`mod.rs:127`),
+  `read_blocking(timeout)` (polls the viewport until non-empty or timeout, then
+  `NoOutputAvailable`, `mod.rs:133`), `read_chars() -> Vec<Vec<char>>`
+  (`mod.rs:139`), `read_styled_cells() -> ndarray::Array2<StyledCell>`
+  (`mod.rs:145`).
+- Lifecycle: `exit_state() -> ExitState` (`mod.rs:154`), `is_alive()`
+  (`mod.rs:160`), `wait(Option<Duration>) -> Option<ExitState>` (`mod.rs:169`,
+  `None` on timeout), `kill()` (SIGKILL, `mod.rs:190`),
+  `resize(rows, cols)` (resizes the kernel PTY window, which delivers `SIGWINCH`,
+  and the emulator together; visible from every clone, `mod.rs:84`).
+
+Value types (`src/types.rs`):
+
+- `SpawnConfig { rows, cols, scrollback_lines }`, default 24x80 / 10,000 lines
+  (`types.rs:122`).
+- `StyledCell { character, fg, bg, bold, italic, underline, inverse }`
+  (`types.rs:35`); an unwritten cell is a space with `Color::Default`.
+- `Color::{Default, Indexed(u8), Rgb(u8,u8,u8)}` (`types.rs:10`), converted from
+  `ix_vt::StyleColor`.
+- `CursorShape::{Block, Underline, Bar}` (`types.rs:66`), from the engine's
+  DECSCUSR state; blink and ghostty's hollow block collapse to `Block`.
+- `ExitState::{Running, Exited(Option<i32>)}` (`types.rs:100`); `Exited(None)`
+  means a signal killed it.
+- `CursorPos { row, col, visible }` (viewport coordinates, 0-based, cursor
+  scrolled off the viewport reports `(0,0)`).
+- `FullOutput { scrollback, viewport }`.
+
+`slice_2d(&[String], RowRange, ColRange) -> Result<Vec<String>>`
+(`src/slice/core.rs:53`): extract a rectangular sub-region, 1-indexed inclusive,
+`None` endpoints filled from the available extent. An empty input is `Ok(empty)`;
+bad bounds are `InvalidRowRange`/`InvalidColRange`/`RowIndexOutOfBounds`/
+`ColIndexOutOfBounds`.
+
+## Errors (`src/error.rs:4`)
+
+`Error` is a `snafu` enum: `ProcessSpawn`, `TuiNotFound` (the actor has exited /
+the channel is closed), `WriteToTui`, `ReadFromTui`, `SignalTui`, `ResizeTui`,
+`NoOutputAvailable`, `VtEngine`, the four slice-bounds variants, `ArrayConversion`,
+and the feature-gated `Dashboard` / `Publish`. Under the `pyo3` feature the enum
+also implements `From<Error> for pyo3::PyErr`, mapping each variant to a Python
+exception class (`error.rs:78`); [tui-py](../tui-py/overview.md) turns that on.
+
+## Features and the dashboard bridge
+
+Three optional features (`packages/tui/Cargo.toml`), all off by default so the
+core PTY library stays free of the HTTP/CRDT closure:
+
+- `pyo3`: adds the `PyErr` conversion only. Used by `tui-py`.
+- `publish`: producer side. `tui::publish(&manager, path, poll) -> Publisher`
+  (`src/publish/mod.rs:32`) binds a Unix socket and streams the manager's
+  terminals as NDJSON pane snapshots on a poll loop. `socket_path()` and
+  `discovery_dir()` (re-exported from `dashboard-core`) give the per-process
+  path.
+- `dashboard`: in-process viewer. `tui::serve(&manager, addr, poll) -> Dashboard`
+  (`src/dashboard/mod.rs:52`) binds the `dashboard-core` server and drives it
+  from a poll loop over one manager, filing every terminal as a pane under the
+  single `"local"` scope.
+
+Both features re-export `dashboard-core` names (`Dashboard`, `Hub`, `serve_hub`,
+`Pane`, `ProducerSnapshot`, `TerminalView`, `View`, `discovery_dir`,
+`socket_path`, `src/lib.rs:50-55`). The only engine-bound code here is
+`frame::collect_panes` (`src/frame/mod.rs:23`), which samples each terminal's
+styled cells, encodes the screen as minimal ANSI SGR (`frame/sgr.rs`), and wraps
+it as a `TerminalView`. Everything downstream (the Loro document, the SSE stream,
+the browser page, the multi-process aggregator) lives in the
+[dashboard domain](../../dashboard/common.md); see
+[dashboard-core](../../dashboard/dashboard-core/overview.md). The poll and accept
+loops run on the manager's own runtime (`runtime_handle`,
+`src/manager/mod.rs:321`), so a dashboard started from a temporary runtime keeps
+running after that runtime drops.
+
+## How it builds
+
+`packages/tui/package.nix` is just `{ id = "tui"; inRustWorkspace = true; }`: no
+flake output, built only as a workspace library. It depends on
+[ix-vt](../vt/overview.md) (`Cargo.toml:21`), so a build links the libghostty-vt
+dylib that the workspace injects via `IX_VT_GHOSTTY_LIB_DIR`
+(`lib/rust/workspace.nix:215`). Other deps: `pty-process` (PTY creation), `tokio`
+(runtime), `ndarray` (the cell grid), `parking_lot` (registry lock), `uuid`,
+`snafu`.
+
+Note: the README still says "no runtime resize today"
+(`packages/tui/README.md:143`), but `resize`/`resize_async` exist
+(`src/manager/mod.rs:84,92`) and the bindings expose them; trust the source.

--- a/docs/terminal/vt/overview.md
+++ b/docs/terminal/vt/overview.md
@@ -1,0 +1,104 @@
+# vt
+
+`packages/vt` is the VT engine: drive a terminal state machine with raw bytes and
+snapshot its render state. It wraps [ghostty](https://ghostty.org/)'s
+`libghostty-vt` C library in three layers, each its own crate/package under
+`packages/vt/`:
+
+| member | kind | role |
+| --- | --- | --- |
+| `ix-vt` | Rust lib crate (`nix build .#ix-vt`) | the safe, owned API: `Terminal`, `Snapshot`, `Cell`, `Cursor`. The only layer callers use. |
+| `ix-vt-sys` | Rust `-sys` crate (no flake output) | mechanically generated raw FFI (`bindgen`) over `ghostty/vt.h`. No logic, no safety. |
+| `libghostty-vt` | Nix/Zig package (`nix build .#libghostty-vt`) | ghostty's VT engine built as a standalone C library: the `.a`, the self-contained `.dylib`/`.so`, and the headers. |
+
+[tui](../tui/overview.md) is the in-repo consumer: its engine thread owns an
+`ix_vt::Terminal` (`packages/tui/src/actor/engine.rs`). The conversion from
+`ix_vt` types to `tui`'s `Color`/`CursorShape`/`StyledCell` is in
+`packages/tui/src/types.rs`.
+
+## ix-vt: the safe wrapper (`ix-vt/src/lib.rs`)
+
+`Terminal` (`ix-vt/src/lib.rs:285`) owns a `GhosttyTerminal` pointer and frees it
+on drop. It is deliberately `!Send + !Sync`: libghostty-vt's terminal has thread
+affinity, so the handle must stay on the thread that created it
+(`ix-vt/src/lib.rs:289`). A caller needing it across threads pins it behind a
+channel API (which is exactly what `tui`'s engine thread does); do not add an
+`unsafe impl Send`.
+
+Public API:
+
+- `Terminal::new(rows, cols, scrollback) -> Result<Terminal>`
+  (`ix-vt/src/lib.rs:312`) and `with_options(TerminalOptions { cols, rows,
+  max_scrollback })` (`:325`). The `new` argument order reads as a screen size.
+- `vt_write(&mut self, &[u8])` (`:338`): feed raw VT bytes (text + escapes).
+- `resize(&mut self, rows, cols) -> Result<()>` (`:347`): both must be > 0.
+- `scroll_viewport(ScrollViewport::{Top, Bottom, Delta(isize)})` (`:357`): move
+  the viewport over scrollback. `render` always reads the active viewport, so
+  reading history is scroll-up, render, scroll-back.
+- `render(&self) -> Result<Snapshot>` (`:393`): capture an owned snapshot.
+- `application_cursor_keys(&self) -> Result<bool>` (`:434`): query DECCKM (DEC
+  private mode 1); `tui` reads this after each feed to pick the arrow-key form on
+  write.
+
+`Snapshot` (`ix-vt/src/lib.rs:245`) is fully owned and copied out of the C
+structures, so it stays valid after the terminal is written to or dropped:
+`cols`, `rows`, `viewport: Vec<Vec<Cell>>`, `scrollback: u64`, `cursor: Cursor`.
+
+- `Cell` (`:186`): `ch: Option<char>` (base codepoint, `None` for empty),
+  `combining: Vec<char>`, `style: Style`, and `fg`/`bg: Option<Rgb>` (resolved
+  RGB with palette indices already looked up; `None` is the terminal default).
+- `Style` (`:128`): the SGR booleans (`bold`, `italic`, `faint`, `blink`,
+  `inverse`, `invisible`, `strikethrough`, `overline`), `underline: Option<u8>`,
+  and the declared `fg_color`/`bg_color`/`underline_color: StyleColor` (before
+  palette resolution).
+- `StyleColor::{None, Palette(u8), Rgb(Rgb)}` (`:90`), `Rgb { r, g, b }` (`:66`).
+- `Cursor` (`:227`): `visible`, `blinking`, `visual_style: CursorVisualStyle`,
+  `viewport: Option<(col, row)>` (`None` when scrolled out of view).
+- `CursorVisualStyle::{Bar, Block, Underline, BlockHollow}` (`:203`), the
+  DECSCUSR shape.
+
+`Error::{OutOfMemory, InvalidValue, OutOfSpace, Unknown(i32)}`
+(`ix-vt/src/lib.rs:27`) wraps the non-success `GhosttyResult` codes; `check`
+(`:55`) maps them.
+
+## ix-vt-sys: the FFI (`ix-vt-sys/`)
+
+A 1:1 binding of `ghostty/vt.h` produced by bindgen (`src/bindings.rs` is checked
+in; `regen-bindings.sh` regenerates it). `src/lib.rs` just re-exports
+`bindings::*`. It declares `links = "ghostty-vt"` (`Cargo.toml:9`) and its
+`build.rs` links the **self-contained dynamic** library
+(`cargo:rustc-link-lib=dylib=ghostty-vt`, `build.rs:39`), not the static archive:
+the static `.a` does not bundle its C++ deps (libhighway, libsimdutf, libutfcpp),
+while the dylib carries them, so one link directive suffices (`build.rs:9-13`).
+The library directory is supplied out of band through the `IX_VT_GHOSTTY_LIB_DIR`
+env var (`build.rs:25`), which the workspace sets for every unit
+(`lib/rust/workspace.nix:215`) because a build-script `rustc-link-search` does
+not propagate to the final per-unit Nix link.
+
+## libghostty-vt: the C library (`libghostty-vt/`)
+
+ghostty is consumed as a pinned source tree (the `ghostty` flake input, a fixed
+commit, `flake.nix:146`), not a flake. The build recipe lives in
+`lib/build/libghostty-vt.nix` (exposed as `ix.buildLibghosttyVt`) so the Rust
+workspace can reuse the exact artifact when linking `ix-vt-sys`; the package's
+`default.nix` is a thin wrapper plus a layout smoke test. It is a Zig build
+(`-Demit-lib-vt=true`) with zon2nix-vendored dependencies, built with
+`pkgs.zig_0_15` (the `requireZig` minor in `build.zig.zon`,
+`flake.nix:139-149`, `lib/languages/zig.nix:14`). The output carries
+`lib/libghostty-vt.a`, a versioned self-contained shared library, and
+`include/ghostty/vt.h` + `include/ghostty/vt/`; the `layout` passthru test
+asserts those exist (`libghostty-vt/default.nix:19-42`).
+
+## Build wiring summary
+
+```
+nix build .#libghostty-vt  -> .a + .so/.dylib + headers (ghostty source, zig 0.15)
+ix-vt-sys build.rs         -> links dylib=ghostty-vt from IX_VT_GHOSTTY_LIB_DIR
+ix-vt                      -> safe wrapper over ix-vt-sys  (nix build .#ix-vt)
+tui engine thread          -> owns an ix_vt::Terminal
+```
+
+`ix-vt`'s tests dlopen the dylib at runtime, so the workspace adds the
+libghostty-vt lib dir to that unit's runtime inputs
+(`lib/rust/workspace.nix:196-198`). `ix-vt` round-trip tests are in
+`ix-vt/tests/round_trip.rs`.

--- a/docs/vm-fleet/chrome-vm-image/overview.md
+++ b/docs/vm-fleet/chrome-vm-image/overview.md
@@ -1,0 +1,85 @@
+# chrome-vm-image
+
+`packages/chrome-vm-image` is the raw EFI-bootable aarch64 NixOS disk image that
+the [chrome-vm](../chrome-vm/overview.md) demo boots under
+[vmkit](../vmkit/overview.md)/libkrun. The guest's only job is a boot-time
+oneshot that screenshots a baked proof page with headless Chromium, base64-encodes
+the PNG onto the serial console, and powers off; the host runner decodes the
+base64 between markers into a PNG.
+
+## What it is
+
+- Nix-only package, `aarch64-linux` only (`package.nix:7-8`). Flake output
+  `chrome-vm-image`: `nix build .#packages.aarch64-linux.chrome-vm-image`. The
+  package output is the raw disk file itself (`chrome-vm.raw`), copied out of the
+  evaluated system's repart image (`default.nix:20-24`).
+- Built by evaluating a standalone NixOS system from nixpkgs' `eval-config.nix`
+  with the one module `./nixos.nix` (`default.nix:14-19`); `path` is `pkgs.path`
+  supplied by the package autoArgs.
+
+## How the disk is built: systemd-repart, not a VM
+
+The disk is assembled with **systemd-repart** (the `image/repart.nix` module
+imported at `nixos.nix:56`), not `make-disk-image`. repart runs in the Nix build
+sandbox with no nested qemu/kvm VM, so the image builds on a plain aarch64-linux
+builder with no `/dev/kvm` (e.g. hydra's OrbStack remote builder)
+(`default.nix:6-9`, `nixos.nix:6-11`).
+
+Boot path: libkrun-efi's embedded OVMF -> systemd-boot (placed at the EFI
+removable path) -> a UKI in `/EFI/Linux` (`nixos.nix:58-59`). The repart layout
+(`nixos.nix:89-127`):
+
+- `sectorSize = 512` is **required**: OVMF does not handle repart's 4096-byte
+  default (`nixos.nix:91-92`).
+- an `esp` (`Type = esp`, vfat, 256 MiB) holds `BOOTAA64.EFI` (systemd-boot
+  aa64), the UKI, and a `loader.conf` with `timeout 0` to auto-boot the single
+  UKI with no menu (`nixos.nix:94-116`).
+- a `root` partition (`Type = root`, ext4, label `root`, `Minimize = "guess"`)
+  holds the system closure; the rootfs is found by GPT partition label
+  `/dev/disk/by-partlabel/root` (`nixos.nix:78-82,117-125`).
+
+grub is disabled since the bootloader + UKI are placed manually by repart
+(`nixos.nix:60-61`).
+
+## The screenshot oneshot (`nixos.nix:129-182`)
+
+`systemd.services.chrome-shot` is a `oneshot` wanted by and after
+`multi-user.target`. It runs Chromium against a baked HTML proof page and writes
+the result to the console:
+
+- The page (`demoPage`, `nixos.nix:23-53`) prints the live Chromium user-agent,
+  a fresh timestamp, and a JS-drawn canvas gradient, so a blank/placeholder
+  capture is obvious.
+- Chromium runs `--headless=new --no-sandbox --disable-gpu` with software raster
+  (no GPU), `--virtual-time-budget=2500` so the page JS runs before the shot, and
+  `--screenshot=/tmp/shot.png` at `1280x800` (`nixos.nix:166-170`).
+- The script `exec`s its stdout/stderr straight to `/dev/console`
+  (`nixos.nix:155`), bypassing systemd's `journal+console` connector. That
+  connector prefixes every line with `[ts] chrome-shot[pid]: `, whose
+  alphanumerics would survive a non-base64 strip and corrupt the decode.
+- It emits `===VMKIT-CHROME-DEMO===` plus `uname`/`chromium --version`, then the
+  PNG between `===VMKIT-SHOT-BEGIN===` / `===VMKIT-SHOT-END===` as one
+  `base64 -w0` line (or `===VMKIT-NO-SHOT===` on failure), then
+  `systemctl poweroff` so vmkit returns (`nixos.nix:161-180`).
+
+## Keeping the base64 line clean
+
+The serial console (`hvc0`) carries both kernel output and the single long
+base64 line, so a stray kernel `printk` mid-line would corrupt the decode. The
+image defends against this two ways: `console=hvc0 loglevel=0` keeps kernel
+printk off the console at boot (`nixos.nix:66-69`), and the oneshot writes
+`1` to `/proc/sys/kernel/printk` to drop the console level to emergency-only
+before emitting the base64 (`nixos.nix:158`). The needed virtio modules
+(`virtio_pci`, `virtio_blk`, `virtio_console`, `sd_mod`) are in the initrd
+(`nixos.nix:70-75`).
+
+The image is trimmed for an offline, no-GUI demo: `documentation.enable` and
+`networking.useDHCP` are off, and `NetworkManager-wait-online` is disabled so
+boot does not wait on a network the demo never uses (`nixos.nix:184-191`).
+
+## Related
+
+- [chrome-vm](../chrome-vm/overview.md): the macOS host runner that builds this
+  image, boots it with `vmkit boot-linux --console-file`, and decodes the shot.
+- [vmkit linux-guests](../vmkit/linux-guests.md): the libkrun-efi backend and
+  the embedded OVMF that boots this disk.

--- a/docs/vm-fleet/chrome-vm/overview.md
+++ b/docs/vm-fleet/chrome-vm/overview.md
@@ -1,0 +1,73 @@
+# chrome-vm
+
+`packages/chrome-vm` runs headless Chromium inside a real Linux VM on a macOS
+host and gives the screenshot back, in one command. It is the host-side runner
+that wires the [chrome-vm-image](../chrome-vm-image/overview.md) guest disk to
+[vmkit](../vmkit/overview.md)'s libkrun Linux-guest path, then decodes and opens
+the PNG the guest captured. It exists as an end-to-end proof that a real browser
+runs real JS inside a libkrun guest booted by vmkit, not a placeholder.
+
+```sh
+nix run .#chrome-vm [out.png]        # default out: ./chrome-vm-shot.png
+```
+
+## What it is
+
+- Nix-only package: a macOS nushell app built by
+  `writeNushellApplication` (`packages/chrome-vm/default.nix:25-90`). Not a Rust
+  workspace member.
+- Flake output `chrome-vm`, `aarch64-darwin` only (`package.nix:5-6`): the host
+  must be Apple Silicon because vmkit's Linux-guest path there is libkrun-efi.
+- `runtimeInputs`: the `vmkit` binary (reached through
+  `ix.rustWorkspace.units.binaries."vmkit"`, since repo crates are not overlaid
+  into `pkgs`, `default.nix:19-23`), plus `bash`, `gawk`, `coreutils`,
+  `gnugrep`.
+
+## Flow (`default.nix:34-89`)
+
+1. **Build the guest image.** `nix build <flake>#packages.aarch64-linux.chrome-vm-image`
+   produces the raw EFI disk (`default.nix:42-46`). Building it needs an
+   aarch64-linux builder; on hydra that offloads to the local OrbStack remote
+   builder. The source flake defaults to `github:indexable-inc/index` and is
+   overridable with `IX_CHROME_VM_FLAKE=/path/to/checkout` for local testing
+   (`default.nix:36`).
+2. **Copy the disk writable.** libkrun needs a writable disk; the Nix store
+   image is read-only, so it is copied to a temp dir and `chmod u+w`
+   (`default.nix:48-51`).
+3. **Boot under vmkit.** `vmkit boot-linux --disk <disk> --console-file <log>
+   --memory-mib 2048 --cpus 4 --timeout-secs 150` (`default.nix:54-61`). The
+   guest screenshots on boot, prints the PNG as base64 over the serial console,
+   and powers off; vmkit captures the console to `<log>`. A nonzero vmkit exit is
+   swallowed because vmkit `exit()`s 0 on both clean poweroff and timeout, so the
+   PNG check below is the real success gate.
+4. **Decode the screenshot.** `awk` extracts the base64 between the
+   `===VMKIT-SHOT-BEGIN===`/`===VMKIT-SHOT-END===` markers, strips whitespace,
+   and `base64 -d`s it to the output path (`default.nix:66-68`).
+5. **Verify and open.** Success requires the output to start with the PNG magic
+   `89 50 4E 47 0D 0A 1A 0A` (guards a truncated decode); on success it prints
+   the guest's demo banner lines and `open`s the PNG, on failure it dumps the
+   last 40 console lines and exits 1 (`default.nix:70-88`).
+
+## Why it is self-contained
+
+The guest needs no network, no GPU, and no host directory sharing: the
+screenshot travels back as base64 over the guest's serial console, which
+`vmkit --console-file` captures and this runner decodes. That is the whole
+transport. See [chrome-vm-image](../chrome-vm-image/overview.md) for the guest
+side (the boot-time Chromium oneshot and why it writes to `/dev/console`).
+
+## Requirements and limits (`README.md:36-45`)
+
+- Host is `aarch64-darwin` (Apple Silicon); vmkit's Linux-guest path is
+  libkrun-efi there.
+- Building the guest image needs an aarch64-linux builder; the first run also
+  fetches Chromium's closure (~1.5 GiB upstream estimate), so it is slow once,
+  then cached.
+- `IX_CHROME_VM_FLAKE=/path/to/checkout` overrides the image source flake for
+  local testing.
+
+## Related
+
+- [vmkit](../vmkit/overview.md) / [vmkit linux-guests](../vmkit/linux-guests.md):
+  the `boot-linux` backend and `--console-file` capture this depends on.
+- [chrome-vm-image](../chrome-vm-image/overview.md): the guest disk booted here.

--- a/docs/vm-fleet/common.md
+++ b/docs/vm-fleet/common.md
@@ -1,0 +1,140 @@
+# vm-fleet
+
+VM lifecycle, fleet tooling, guest images, and process/kernel debugging for the
+index repo. This domain owns the code that boots and drives a guest virtual
+machine (`vmkit`), the disk images those VMs run (`chrome-vm-image`,
+`vz-linux-guest`), an end-to-end demo runner that ties a host to a guest
+(`chrome-vm`), the CLI that converges a fleet of remote ix VMs from a declared
+plan (`ix-fleet`), and the live-memory debugger packaged for the base system
+image (`drgn`). The unifying concern is a host running guest VMs and the tooling
+to start, drive, image, fleet-manage, and debug them.
+
+Read this page first, then the component page for the unit you are touching.
+[vmkit](vmkit/overview.md) is the load-bearing component; most others build on
+it.
+
+## Units
+
+| unit | kind | role |
+| --- | --- | --- |
+| `packages/vmkit` | Rust workspace binary (`nix run .#vmkit`) | Own a guest VM lifecycle from Rust: macOS guests on Virtualization.framework, Linux guests on libkrun. See [vmkit](vmkit/overview.md). |
+| `packages/ix-fleet` | Nix-only Python CLI (`nix run .#ix-fleet`) | Render and execute declarative fleet plans against the ix control plane (create/switch/replace/health-check remote VM nodes). See [ix-fleet](ix-fleet/overview.md). |
+| `packages/chrome-vm` | Nix-only nushell app (aarch64-darwin) | One-command demo: boot a Linux guest under `vmkit`, run headless Chromium inside it, open the screenshot the guest captured. See [chrome-vm](chrome-vm/overview.md). |
+| `packages/chrome-vm-image` | Nix-only NixOS disk image (aarch64-linux) | The raw EFI guest disk `chrome-vm` boots: a boot-time Chromium screenshot oneshot. See [chrome-vm-image](chrome-vm-image/overview.md). |
+| `packages/vz-linux-guest` | Nix-only NixOS disk image (aarch64-linux) | The raw EFI Linux GUI guest for `vmkit boot-linux-gui` (a sway compositor running `bossbar-overlay` on software graphics). See [vz-linux-guest](vz-linux-guest/overview.md). |
+| `packages/drgn` | Nix-only Python app wrapper (Linux) | Programmable debugger for live processes and kernels over `/proc/kcore`; shipped in the base system profile. See [drgn](drgn/overview.md). |
+
+Only `vmkit` is a Rust workspace member (root `Cargo.toml`); the rest are
+Nix-only packages. `ix-fleet` is a `uv`-built Python application; `chrome-vm` is
+a nushell wrapper; `chrome-vm-image` and `vz-linux-guest` are NixOS systems
+rendered to raw disks; `drgn` is a `buildPythonApplication` repackage of an
+upstream release.
+
+## Host, guest, and VM-backend relationships
+
+Two host platforms and two guest OS families pair with three hypervisor
+backends. The choice of backend is fixed by the host+guest pair, not a runtime
+flag:
+
+```
+host = macOS (aarch64-darwin)                         host = Linux (aarch64/x86_64)
+  guest = macOS        -> Virtualization.framework      (no macOS guest)
+  guest = Linux (GUI)  -> Virtualization.framework      (no VZ GUI path)
+                          (software GPU: lavapipe)
+  guest = Linux (head) -> libkrun-efi                  guest = Linux -> libkrun (KVM)
+                          (Hypervisor.framework;          (bundled libkrunfw kernel;
+                           GPU via Venus/MoltenVK)         rootfs + exec; /dev/kvm)
+```
+
+- **Virtualization.framework (VZ)** is macOS-host only and the only backend for
+  macOS guests. It also drives the off-screen Linux **GUI** capture path, where
+  it gives the guest no 3D acceleration (the guest falls back to Mesa lavapipe
+  software Vulkan). VZ is the only working framebuffer-capture path today.
+- **libkrun** runs Linux guests headless on both hosts, with a different library
+  per host: `libkrun-efi` (Hypervisor.framework, boots an EFI disk, GPU via a
+  virtio-gpu Venus device backed by MoltenVK) on a macOS host, and classic KVM
+  `libkrun` (boots a rootfs directory under a bundled `libkrunfw` kernel) on a
+  Linux host. See [vmkit/linux-guests](vmkit/linux-guests.md).
+- A guest gets a **GPU or Rosetta, never both**: the GPU is a libkrun feature,
+  Rosetta is a VZ feature.
+
+`vmkit` is the single binary that owns all of these. On macOS it carries the
+virtualization/hypervisor entitlements by self-signing into a per-user cache, so
+callers that cannot hold entitlements (notably the ix-mcp Python interpreter)
+spawn it instead of driving a hypervisor in-process. `vmkit` is also exposed as
+an ix-mcp tool provider; that Python module lives in the
+[mcp](../mcp/tool-providers/overview.md) domain and is not documented here.
+
+The two image packages produce guest disks for `vmkit`'s Linux paths:
+`chrome-vm-image` is booted headless by libkrun (`boot-linux`), `vz-linux-guest`
+is booted off-screen by VZ for GUI capture (`boot-linux-gui`). `chrome-vm` is
+the host-side runner that wires `chrome-vm-image` to `vmkit`.
+
+`ix-fleet` and `drgn` are independent of `vmkit`'s local hypervisor: `ix-fleet`
+manages **remote** ix VMs (called branches/nodes) over the ix SDK control plane,
+and `drgn` is a debugger that runs inside any Linux system (it ships in the base
+profile).
+
+## Cross-component invariants
+
+- **One backend per host+guest pair.** Code that boots a VM does not pick a
+  hypervisor at runtime; the pair determines it (table above). `vmkit`'s CLI even
+  changes shape per host: `boot-linux --disk` exists only on macOS, `--root -- <cmd>`
+  only on Linux (`packages/vmkit/src/main.rs:53-103`).
+- **macOS VM creation needs an entitled, signed process.** `vmkit` self-signs
+  and re-execs (`packages/vmkit/src/main.rs:270-333`) carrying
+  `com.apple.security.virtualization` (VZ) and `com.apple.security.hypervisor`
+  (libkrun). A Linux host needs no signing (libkrun talks to `/dev/kvm`).
+- **Off-screen and cursor-safe by construction.** macOS/Linux GUI capture reads
+  the guest framebuffer `IOSurface` directly from an off-screen, non-activating
+  window; synthetic input goes straight to the guest's USB devices. Nothing
+  appears on the host desktop and the host cursor is never moved.
+- **Guest disks build without a VM.** `chrome-vm-image` uses `systemd-repart`
+  and `vz-linux-guest` uses `make-disk-image`, so both build on a plain
+  aarch64-linux builder with no nested `/dev/kvm`.
+- **Platform gating.** The VM packages advertise their flake output and
+  package-set attr only on supported systems (`package.nix` in each), so
+  `nix flake check` never forces an off-platform build: `vmkit` on
+  aarch64-darwin + aarch64/x86_64-linux, `chrome-vm` on aarch64-darwin,
+  `chrome-vm-image`/`vz-linux-guest` on aarch64-linux, `drgn` on Linux.
+
+## Glossary
+
+- **VZ / Virtualization.framework**: Apple's host virtualization framework. The
+  only macOS-guest backend; also the only working Linux-GUI framebuffer-capture
+  path. macOS host only.
+- **libkrun**: the Linux-guest hypervisor library. `libkrun-efi` (boots an EFI
+  disk via Hypervisor.framework) on a macOS host; classic KVM `libkrun` (boots a
+  rootfs under its bundled `libkrunfw` kernel) on a Linux host.
+- **Venus / MoltenVK**: libkrun-efi's virtio-gpu device exposes Mesa's "venus"
+  Vulkan driver in the guest, backed by MoltenVK (Vulkan-on-Metal) on the host,
+  giving a Linux guest a real GPU on Apple Silicon.
+- **gvproxy / TSI**: the two guest-networking backends `vmkit` wires: gvproxy
+  (gvisor-tap-vsock userspace NAT) on a macOS host, TSI (libkrun transparent
+  socket impersonation) on a Linux host.
+- **IOSurface**: the shared GPU surface holding the guest framebuffer; read
+  directly to PNG without a Screen-Recording grant.
+- **bundle**: a macOS-guest directory (`disk.img`, `aux.img`,
+  `hardware-model.bin`, `machine-id.bin`) created by `install-macos`.
+- **raw EFI disk**: a self-booting disk image carrying its own kernel/bootloader
+  (the shape VZ's `VZEFIBootLoader` and libkrun-efi's OVMF both take). What
+  `chrome-vm-image` and `vz-linux-guest` produce.
+- **fleet plan**: an `ix-fleet` JSON document (`FleetPlan`): an ordered set of
+  nodes with their images, switch targets, dependencies, and health checks.
+- **node / branch**: an ix control-plane VM. `ix-fleet` calls it a node; the ix
+  SDK type is `BranchInfo`/`BranchStatus`.
+- **switch**: an in-place NixOS system switch of a running node (vs. a
+  delete-then-create image swap, which `ix-fleet` calls `up`/`replace`).
+- **drgn**: programmable debugger that walks live struct graphs in a process or
+  kernel over `/proc/kcore`; complements `pahole`'s type-layout queries.
+
+## Components
+
+| component | page | what |
+| --- | --- | --- |
+| vmkit | [vmkit/overview.md](vmkit/overview.md) | own a guest VM lifecycle from Rust; CLI, signing, modules. [linux-guests](vmkit/linux-guests.md) covers the libkrun backend. |
+| ix-fleet | [ix-fleet/overview.md](ix-fleet/overview.md) | declarative fleet-plan CLI: create/switch/replace/health remote ix VM nodes via the SDK + dag-runner |
+| chrome-vm | [chrome-vm/overview.md](chrome-vm/overview.md) | one-command demo: headless Chromium in a Linux guest under vmkit, screenshot back over the console |
+| chrome-vm-image | [chrome-vm-image/overview.md](chrome-vm-image/overview.md) | the aarch64 NixOS guest disk chrome-vm boots (systemd-repart, boot-time screenshot oneshot) |
+| vz-linux-guest | [vz-linux-guest/overview.md](vz-linux-guest/overview.md) | the aarch64 NixOS GUI guest disk for vmkit boot-linux-gui (sway + bossbar-overlay on software graphics) |
+| drgn | [drgn/overview.md](drgn/overview.md) | programmable live-process/kernel debugger packaged against drgn v0.2.0 |

--- a/docs/vm-fleet/drgn/overview.md
+++ b/docs/vm-fleet/drgn/overview.md
@@ -1,0 +1,54 @@
+# drgn
+
+`packages/drgn` is the index repo's Nix repackaging of
+[drgn](https://github.com/osandov/drgn), Meta's programmable debugger for live
+processes and kernels. It is a thin packaging/wrapper unit: it builds drgn from a
+pinned upstream release and exposes it as a flake output and an overlay
+attribute. It does not modify drgn's behavior; this page describes what is
+packaged and how it is wired, not drgn's own API.
+
+drgn complements `pahole`'s type-layout queries with live struct-graph
+traversal: starting from a typed root, it dereferences pointers, walks intrusive
+lists, and dumps fields off a running process or kernel over `/proc/kcore`
+(`default.nix:42-48`). It is included in the base system profile so any switched
+ix system has it (`modules/profiles/base/default.nix:521-527`).
+
+## What is packaged
+
+- `python3.pkgs.buildPythonApplication` (`pyproject = true`), `pname = "drgn"`,
+  `version = "0.2.0"` (`default.nix:14-17`).
+- Source is `ix.drgnSrc` (`default.nix:19`), a non-flake input pinned in
+  `flake.nix` to the upstream tag `v0.2.0` with submodules
+  (`flake.nix:95-97`: `git+https://github.com/osandov/drgn?ref=refs/tags/v0.2.0&submodules=1`),
+  exposed to packages as `drgnSrc` in `lib/default.nix:429`.
+- `build-system = [ setuptools ]`. drgn's `setup.py` shells out to autotools
+  (`autoreconf -i`, `./configure`, `make`) via `build_ext`, so the
+  `autoconf`/`automake`/`libtool`/`pkg-config` quartet plus `gcc` and `gnumake`
+  are `nativeBuildInputs` (`default.nix:23-37`).
+- `buildInputs = [ elfutils ]`: libdrgn's optional features (libkdumpfile core
+  dumps, libdebuginfod, lzma, pcre2, json-c) auto-detect and stay disabled when
+  absent; the target workload (live struct-graph traversal over `/proc/kcore`)
+  needs only `libelf` + `libdw`, both from elfutils (`default.nix:25-39`).
+- `meta`: `mainProgram = "drgn"`, license LGPL-2.1+, platforms `x86_64-linux`
+  and `aarch64-linux` (`default.nix:41-57`).
+
+## Flake output and platform gating
+
+- Flake output `drgn` on Linux: `nix run .#drgn`, `nix build .#drgn`.
+- Also an overlay attribute (`overlay = true`, `package.nix:19`), so `pkgs.drgn`
+  resolves; the base system profile consumes it that way.
+- drgn debugs over `/proc/kcore`, so it builds only on Linux. The flake output
+  and the darwin package-set attr are gated to `x86_64-linux` + `aarch64-linux`
+  (`package.nix:11-18`) so `nix flake check` never forces a package nixpkgs
+  refuses to evaluate off-platform. The overlay stays unconditional (an
+  `overlay.systems` filter would force `hostPlatform.system` while building the
+  overlay spine and infinite-loop); `pkgs.drgn` on darwin is lazy and only the
+  Linux base profile ever forces it (`package.nix:3-14`).
+
+## Why it is in this domain
+
+drgn pairs with the rest of vm-fleet as the live-introspection tool for what runs
+inside a system: where [vmkit](../vmkit/overview.md) boots and drives a guest,
+drgn inspects a running process or kernel from the inside. The pin tracks the
+v0.2.0 upstream release until the open nixpkgs PR lands and the pin moves
+(`modules/profiles/base/default.nix:524-527`).

--- a/docs/vm-fleet/ix-fleet/overview.md
+++ b/docs/vm-fleet/ix-fleet/overview.md
@@ -1,0 +1,159 @@
+# ix-fleet
+
+`packages/ix-fleet` renders and executes declarative **fleet plans**: a single
+JSON document describes a set of remote ix VMs (nodes) and their images, NixOS
+switch targets, east-west groups, dependencies, and health checks, and the CLI
+converges the live fleet to it. It is the operational front end over the ix
+control plane: where [vmkit](../vmkit/overview.md) owns one local guest, `ix-fleet`
+manages many remote ix VMs (the SDK calls them branches) by name.
+
+Unlike the rest of this domain, `ix-fleet` does not touch a local hypervisor. It
+talks to the ix API through the Python SDK (`ix_sdk.Client`) and fans per-node
+work out through [dag-runner](../../agents/dag-runner/overview.md). All logic
+lives in one module, `packages/ix-fleet/src/ix_fleet/__init__.py`.
+
+## Build and flake output
+
+- Nix-only Python application (not a Rust workspace member). `pyproject.toml`
+  declares `name = "ix-fleet"`, the console script `ix-fleet = "ix_fleet:run"`,
+  and one runtime dep, `pydantic` (`pyproject.toml:1-11`).
+- Built by `packages/ix-fleet/default.nix` with `ix.buildUvApplication`. Flake
+  output `ix-fleet` (`package.nix:4`): `nix run .#ix-fleet -- --plan plan.json up`.
+- The ix Python SDK is a prebuilt wheel fetched from R2
+  ([ix-sdk-python](../../sdk/packaging/overview.md)), copied into the venv at
+  `postInstall` rather than resolved by uv (`default.nix:9-11,61-67`).
+- The wrapper sets `IX_FLEET_DAG_RUNNER` to the
+  [dag-runner](../../agents/dag-runner/overview.md) binary (`default.nix:69-70`),
+  which the CLI uses to run per-node workflows in parallel.
+- Passthru test `dryRunUp` (`default.nix:50-59`) runs
+  `ix-fleet --plan <plan> up --skip-push --skip-health --dry-run` in the sandbox:
+  it exercises the dry-run control flow (no API, no network) and proves the
+  prebuilt SDK wheel imports from the built venv.
+
+## CLI surface (`__init__.py:897-990`)
+
+`ix-fleet --plan <path> [--on NODE_OR_@TAG ...] [--dry-run] <subcommand>`. The
+global `--plan` is required; `--on` is repeatable and selects nodes by name or
+by `@tag` (empty selects all, in plan order). `--dry-run` prints the steps each
+subcommand would run without calling the API.
+
+| subcommand | what it does |
+| --- | --- |
+| `plan` | Print the resolved node set (dependency-ordered) as JSON. No API calls (`__init__.py:966-968`). |
+| `diff` | Print each selected node's desired switch target / source installable (`cmd_diff`, `:726`). |
+| `bootstrap` | Create selected nodes from their `bootstrapImage`, wait for guest readiness, and ensure east-west group membership. Runs in dependency batches concurrently (`cmd_bootstrap`, `:881`). |
+| `up` | Push each node's replacement image and create-or-replace the node on it, then groups + health. Fans out via dag-runner (`cmd_up`, `:850`). |
+| `replace` | Like `up` but always delete-then-create the node on the pushed image (`cmd_replace`, `:836`). |
+| `switch` | In-place NixOS system switch of running nodes (target or build-from-source), snapshotting first. Fans out via dag-runner (`cmd_switch`, `:818`). |
+| `health` | Run each selected node's health checks (`cmd_health`, `:876`). |
+| `down` | Remove selected nodes in reverse plan order, collecting failures (`cmd_down`, `:886`). |
+
+`switch` flags: `--no-snapshot`, `--skip-health`, `--source-root`,
+`--source-workdir`. `up`/`replace` flags: `--skip-push`, `--skip-health`. The
+hidden `_switch-node`/`_replace-node`/`_up-node` subparsers
+(`help=argparse.SUPPRESS`, `:943-959`) take a single node positional plus the
+forwarded flags; they are what dag-runner invokes per node, not for direct use.
+
+## The plan schema (pydantic, `__init__.py:34-146`)
+
+A plan is a `FleetPlan`: `order` (list of node names), `nodes` (name -> `FleetNode`),
+and `secrets` (`FleetSecrets`). `validate_graph` (`:122`) enforces that `order`
+has no duplicates, references only defined nodes, and covers every node; that
+each node key matches its `name`; and that every `dependsOn` names a real node.
+
+- **`FleetNode`** (`:68`): `name`, `baseName`, optional `replicaIndex`, `system`,
+  a `switch` (`SwitchSpec`), `bootstrapImage`, a `replacementImage`
+  (`ReplacementImage`), `region`, `ipv4`, `snapshot`, `recreateOnUp` (default
+  false), and the lists/maps `tags`, `groups`, `env`, `l7ProxyPorts`,
+  `dependsOn`, `healthChecks` (name -> `HealthCheck`).
+- **`SwitchSpec`** (`:44`): `target`, `buildOn` (`auto`|`local`|`remote`,
+  default `auto`), optional `buildVm`, `sourceInstallable`, `overrideInputs`.
+- **`ReplacementImage`** (`:34`): `imageName`, `imageTag`, `destination`,
+  `source`, `sourceDrv` (the OCI image derivation to realise and push).
+- **`HealthCheck`** (`:54`): `description`, `command` (argv), `timeoutSec`,
+  `attempts`, `intervalSec`, `requiresIpv4`, and `from` (`guest`|`host`, stored
+  as `from_` since `from` is a keyword).
+- **`FleetSecrets`** (`:104`): a `provider` (`type`, `mountRoot`, plus arbitrary
+  extra keys) and `values` (name -> `SecretSpec`: `key`, `path`, extra keys).
+  Default provider is `runtime-directory` at `/run/secrets` (`:116-120`).
+
+## Backend: the ix SDK control plane
+
+The CLI drives the ix API through `ix_sdk.Client`, constructed lazily so
+`--dry-run` never needs a token (`client()`, `:200-210`). The client resolves
+`IX_TOKEN` and the base URL from the environment, the same inputs the `ix` CLI
+uses. A node maps to an ix branch (`ix_sdk.BranchInfo`/`BranchStatus`:
+`RUNNING`/`STOPPED`/`FAILED`). Key SDK calls:
+
+- create / delete / start a branch: `client().create(...)`, `branch.delete()`,
+  `branch.start()` (`create_node` `:366`, `remove_node` `:509`).
+- image push: `client().image_push(source, destination, region)` after a
+  host-side `nix-store --realise` of `sourceDrv` (`push_replacement_image`, `:338`).
+- snapshot: `client().snapshot(name=...)` (`snapshot_node`, `:423`).
+- in-place switch: `client().switch_system(name, target, build_on)`
+  (`switch_node`, `:430`).
+- east-west groups: `client().create_group(...)` / `add_group_member(...)`,
+  idempotent on `ix_sdk.IxConflictError` (`ensure_group` `:461`,
+  `ensure_node_groups` `:472`).
+
+Image swap is **delete-then-create**, not in-place: `client.create` inserts
+against a UNIQUE (owner, name) constraint, so changing a node's image means
+`recreate_node` = remove + create (`recreate_node`, `:383-393`). In-place updates
+are what `switch` is for.
+
+## Workflows and ordering
+
+- **Node selection is dependency-ordered.** `selected_nodes` (`:167`) returns
+  the selected nodes with each node's `dependsOn` emitted before it (a DFS over
+  plan order), and `dependency_batches` (`:489`) groups them into parallel
+  batches for `bootstrap`.
+- **`up`/`replace`/`switch` fan out through dag-runner.** `run_node_workflow_dag`
+  (`:774`) builds a spec `{"nodes": {name: {command, depends_on}}}` where each
+  command re-invokes `ix-fleet ... _<verb>-node <name>` with the forwarded flags;
+  it also adds a serialization edge between nodes that share a
+  `replacementImage.destination` so the same image tag is not pushed twice
+  concurrently. `run_dag_runner` (`:804`) resolves the runner from
+  `IX_FLEET_DAG_RUNNER` or `dag-runner` on `PATH`, writes a temp spec, execs it,
+  and turns a nonzero exit into the process exit status. `--dry-run` runs the
+  per-node workflows inline instead (so child output is visible).
+- **Per-node workflows.** `run_up_node_workflow` (`:764`): push image (unless
+  `--skip-push`) -> `up_node` (create if absent, else recreate on the uploaded
+  image) -> ensure groups -> health (unless `--skip-health`).
+  `run_replace_node_workflow` (`:754`) is the same with an unconditional recreate.
+  `run_switch_node_workflow` (`:734`): ensure the node exists -> ensure groups ->
+  snapshot (if `node.snapshot` and not `--no-snapshot` and the node was not just
+  created) -> switch -> health.
+- **Switch has two modes.** `buildOn == "remote"` builds from source by shelling
+  `ix up <sourceInstallable> --name <node> --workdir <rel>` from the source root
+  (`switch_node_from_source`, `:651`), with up to `MAX_SWITCH_RETRIES` retries on
+  a transient `stream framing error`; otherwise it calls the SDK
+  `switch_system`, bounded by `SWITCH_TIMEOUT_SECS = 1800`
+  (`switch_node`, `:430-458`). `buildOn == "local"` first runs a host-side
+  `nix build` of the installable.
+
+## Health checks (`__init__.py:540-624`)
+
+Each `HealthCheck` runs up to `attempts` times with `intervalSec` between tries:
+
+- **guest** (`from: guest`): run the check argv inside the VM through the SDK
+  exec channel (`branch.exec`), bounded by `timeoutSec`.
+- **host** (`from: host`): run on the operator's machine via subprocess, with
+  `IX_NODE_*` env (`node_env_vars`, `:520`: `IX_NODE`, `IX_NODE_NAME`,
+  `IX_NODE_IMAGE`, `IX_NODE_STATUS`, `IX_NODE_IPV6`, `IX_NODE_IPV4`,
+  `IX_NODE_SUBDOMAIN`, `IX_NODE_REGION`) substituted into the command via
+  `string.Template`. `requiresIpv4` gates the check until the node reports an
+  IPv4 address.
+
+## Bootstrap readiness
+
+`wait_node_ready` (`:313`) polls (180s deadline) by running a probe script in
+the guest via `branch.bash` that starts `nix-daemon.socket` and runs
+`nix ... store info`; the node is ready when the probe exits 0. This is what
+`bootstrap` and the create paths wait on before proceeding.
+
+## Errors
+
+`run()` (`:993`) wraps `main` and maps `OSError`, `ValidationError`,
+`ValueError`, `TypeError`, `RuntimeError`, and `CalledProcessError` to a
+`ix-fleet: <msg>` line on stderr and `SystemExit(1)`. Shelled commands raise
+`CliError`/`CliTimeoutError` (`:223-246`) carrying the captured output.

--- a/docs/vm-fleet/vmkit/linux-guests.md
+++ b/docs/vm-fleet/vmkit/linux-guests.md
@@ -1,0 +1,141 @@
+# vmkit: Linux guests on libkrun
+
+Linux guests boot on [libkrun](https://github.com/containers/libkrun), not
+Virtualization.framework, with a different libkrun per host
+(`packages/vmkit/src/linuxkrun.rs:1-21`). The macOS split is deliberate: VZ
+gives a Linux guest no GPU, while libkrun-efi ships a virtio-gpu Venus device
+backed by MoltenVK, so a Linux guest gets real Vulkan on Apple Silicon. The two
+boot models share the ctx/config/gpu/console/watchdog/`krun_start_enter`
+skeleton in `linuxkrun.rs`; only the payload step is `cfg`-split. See the
+[overview](overview.md) for the CLI flags and the source of truth at
+`packages/vmkit/docs/linux-libkrun.md`.
+
+## The two boot models
+
+The `BootLinux` params struct (`linuxkrun.rs:144-179`) carries the per-host
+payload (`disk` on macOS, `root` + `exec` on Linux) plus shared fields
+(`gpu`, `cpus`, `memory_mib`, `net`, `console_file`, `timeout`).
+
+### macOS host: EFI disk under libkrun-efi
+
+`vmkit boot-linux --disk <raw-efi-disk> [--gpu]` boots a raw EFI-bootable disk
+(a NixOS `raw-efi` image, Fedora CoreOS raw, etc.) and streams its serial
+console. nixpkgs only provides libkrun on Darwin as `libkrun-efi` (classic
+libkrun's `libkrunfw` kernel package does not build on macOS). The EFI build
+always boots its embedded OVMF/EDK2 firmware, so `krun_set_kernel`/`krun_set_root`
+are ignored and a guest must be an EFI-bootable disk carrying its own
+kernel/bootloader (the same disk shape `VZEFIBootLoader` takes).
+
+Call sequence: `krun_create_ctx` -> `krun_set_vm_config` -> `krun_set_firmware`
+-> `krun_add_disk2` -> (optional) `krun_set_gpu_options2` -> (optional)
+`krun_set_console_output` -> `krun_start_enter`.
+
+The OVMF blob (`KRUN_EFI.silent.fd`, ~2 MiB) is embedded into the binary at
+build time (`KRUN_EFI_FIRMWARE`, `linuxkrun.rs:142`) and written to a per-user
+cache file at runtime because `krun_set_firmware` wants a path
+(`firmware_path`, `linuxkrun.rs:188`); embedding keeps the binary self-contained
+across the entitlement self-sign re-exec.
+
+### Linux host: rootfs under classic KVM libkrun
+
+`vmkit boot-linux --root <rootfs-dir> [--gpu] -- <cmd> [args...]` shares a host
+directory into the guest over virtiofs as `/`, boots it under libkrun's bundled
+`libkrunfw` kernel, and runs `<cmd>` as the guest init. Same model
+`podman --runtime krun` / `crun` use: no firmware, no guest-supplied kernel, no
+EFI disk. Needs `/dev/kvm`.
+
+Call sequence: `krun_create_ctx` -> `krun_set_vm_config` -> `krun_set_root` ->
+`krun_set_workdir` -> `krun_set_exec` -> (optional) `krun_set_gpu_options2` ->
+(optional) `krun_set_console_output` -> `krun_start_enter`.
+
+`krun_set_exec(exec_path, argv, envp)` uses `exec_path` as the guest's `argv[0]`,
+so `vmkit` passes `exec[0]` as `exec_path` and `exec[1..]` as `argv`; passing the
+full vector would duplicate `argv[0]` (e.g. `/bin/sh /bin/sh -c ...`).
+
+`krun_start_enter` does not return on success on either host: libkrun takes over
+the process and `exit()`s with the guest's exit code when the VM stops, so the
+console has streamed by then. A watchdog thread bounds the run so a background
+invocation never hangs (`--timeout-secs`; `0` disables it for a persistent
+server).
+
+## GPU (`--gpu`)
+
+`--gpu` attaches a virtio-gpu Venus device; rendering on it also needs guest
+drivers. The guest kernel must load `virtio_gpu` (creates `/dev/dri/renderD128`)
+and guest userspace needs Mesa's venus Vulkan driver (nixpkgs builds it into
+`mesa` as `virtio_icd.aarch64.json`). When the stack works,
+`vulkaninfo --summary` reports a `Virtio-GPU Venus` device; a lavapipe/llvmpipe
+device means a software fallback (the venus ICD was not loaded). The known trap
+is an old guest Mesa (venus against MoltenVK needed Mesa fixes that some
+stable-distro Mesas lacked); a current Mesa, including a stock NixOS guest from
+this repo's pin, has them.
+
+## Guest networking (`src/net.rs`)
+
+libkrun's default backend is TSI (transparent socket impersonation), which needs
+a TSI-aware guest kernel: the bundled `libkrunfw` kernel (Linux host) has it, a
+stock NixOS kernel from an EFI disk (macOS host) does not. So `vmkit` wires
+networking two ways behind `--net` / `--port HOST:GUEST` (`net.rs:1-23`,
+`Net`/`Forward` at `net.rs:26-36`):
+
+- **Linux host** (classic libkrun + libkrunfw): TSI. Outbound works with no
+  setup; inbound host->guest ports use `krun_set_port_map` (a list of
+  `"host:guest"` strings).
+- **macOS host** (libkrun-efi + stock guest kernel): `gvproxy`
+  (gvisor-tap-vsock), the same proxy krunkit/podman-machine use. `vmkit` spawns
+  gvproxy on a temp unix socket, attaches the guest NIC with
+  `krun_set_gvproxy_path`, and POSTs each forward to gvproxy's HTTP control API
+  (`/services/forwarder/expose`). `krun_set_port_map` is TSI-only (`-ENOTSUP`
+  under a proxy). gvproxy is resolved from `IX_VMKIT_GVPROXY` (a Nix store path)
+  or `gvproxy` on `PATH`.
+
+gvproxy puts the guest on `192.168.127.0/24` (gateway `.1`, guest `.2` via
+DHCP), so a macOS-host guest image must DHCP its NIC. `--port 3200:3200` makes
+the guest's `:3200` reachable on the host's `:3200`, bound on all host
+interfaces. Combined with `--timeout-secs 0`, this is the persistent-server case
+(e.g. hosting a service in a NixOS EFI guest).
+
+## Linking and entitlements
+
+The crate links `-lkrun`, resolved per host by the Nix build: `libkrun-efi.dylib`
+on macOS (`${libkrun-efi}/lib`), classic `libkrun.so` on Linux
+(`${libkrun}/lib64`). `build.rs` emits the `-l` (gated on the `have_libkrun`
+cfg, set when libkrun is available for the build host); the search path and
+rpath are injected by the workspace build (`lib/rust/workspace.nix`). On Linux,
+nixpkgs `libkrun` force-links `-lkrunfw` with an rpath, so `libkrun.so` resolves
+the bundled kernel itself.
+
+On macOS, libkrun needs `com.apple.security.hypervisor` on the running process
+(distinct from VZ's `com.apple.security.virtualization`); the one `vmkit` binary
+carries both plus `com.apple.security.cs.disable-library-validation`, applied by
+the self-signer (see [overview](overview.md)). On Linux no signing is needed
+(the process needs read/write access to `/dev/kvm`).
+
+## Capture limitations: GUI stays on VZ
+
+The off-screen Linux **GUI** capture paths (`boot-linux-gui`, `drive-linux`) use
+VZ's `VZVirtualMachineView` IOSurface, not libkrun, even though libkrun-efi
+exposes a display backend API (`krun_add_display` + `krun_set_display_backend`).
+A backend wired to it registers cleanly but does not produce a frame on macOS
+with the current libkrun + nixpkgs venus-only `virglrenderer-krunkit` build: the
+only path reaching `present_frame` is a virgl GL `glReadPixels` readback, and
+this build has no GL backend on macOS (venus/Vulkan only); `SET_SCANOUT_BLOB` is
+an unimplemented `panic!`. Capturing via libkrun on macOS needs upstream
+Metal-texture scanout work (virglrenderer `create_handle_for_scanout` +
+libkrun `SET_SCANOUT_BLOB`), i.e. source patches to two upstream projects. Until
+then VZ is the only working Linux-GUI capture path. The headless `boot-linux`
+path needs none of this and runs on libkrun on both hosts.
+
+Related constraint: **GPU and Rosetta are mutually exclusive per VM.** Rosetta
+for Linux guests is a VZ API (`VZLinuxRosettaDirectoryShare`), so a libkrun VM
+can never run x86_64 binaries through Rosetta, and a VZ VM never gets the GPU.
+`vmkit`'s VZ Linux paths do not wire Rosetta today.
+
+## Guest images in this domain
+
+- [chrome-vm-image](../chrome-vm-image/overview.md): the aarch64 raw EFI disk
+  `boot-linux` boots headless for the [chrome-vm](../chrome-vm/overview.md) demo
+  (screenshot back over the console).
+- [vz-linux-guest](../vz-linux-guest/overview.md): the aarch64 raw EFI disk
+  `boot-linux-gui` boots off-screen under VZ for GUI capture (software graphics
+  via lavapipe).

--- a/docs/vm-fleet/vmkit/overview.md
+++ b/docs/vm-fleet/vmkit/overview.md
@@ -1,0 +1,177 @@
+# vmkit
+
+`packages/vmkit` owns a guest VM's lifecycle from Rust, with one hypervisor
+backend per host and guest OS: macOS guests on Apple's Virtualization.framework
+(VZ), Linux guests on libkrun. A single CLI fronts all of it, so other parts of
+the system can start and control a VM without holding the macOS entitlements
+themselves. The motivating use case: boot and drive a guest fully off-screen and
+screenshot its display, so an agent can verify on-screen rendering inside an
+isolated VM without the app appearing on the operator's desktop or grabbing the
+operator's cursor (`packages/vmkit/src/main.rs:1-24`).
+
+This page covers the CLI surface, the module layout, and the macOS signing
+model. The libkrun Linux-guest backend (EFI firmware, GPU/Venus, networking,
+capture limits) is in [linux-guests](linux-guests.md).
+
+## Build and flake output
+
+- Rust workspace member (root `Cargo.toml`); binary built by
+  `packages/vmkit/default.nix` via `ix.cargoUnit.selectBinaryWithTests`. Flake
+  output `vmkit`: `nix run .#vmkit -- info`, `nix build .#vmkit`.
+- Platforms (`packages/vmkit/default.nix:9-13`, `package.nix:11-15`):
+  `aarch64-darwin`, `aarch64-linux`, `x86_64-linux`. `x86_64-darwin` is omitted
+  (libkrun-efi is aarch64-only). The crate compiles everywhere (off-host code is
+  `cfg`'d out) but the output is advertised only on supported hosts.
+- Dependencies (`packages/vmkit/Cargo.toml`): `clap` + `snafu` are
+  unconditional (every host parses args and reports errors). The Apple-framework
+  crates (`objc2*`, `block2`, `dispatch2`, `image`, plus `dashboard-core`,
+  `tokio`, `base64` for live publishing) are gated to `cfg(target_os = "macos")`,
+  so a Linux build pulls none of them (`Cargo.toml:28-61`). The libkrun backend
+  is plain FFI with no extra crate; `libkrun` is linked by `build.rs` per host.
+
+## CLI surface
+
+`vmkit` is a `clap` derive CLI (`packages/vmkit/src/main.rs:30-239`). The
+`Command` enum is `cfg`-split: only `Info` and `BootLinux` exist on Linux; the
+macOS-guest and GUI-capture variants are macOS-only. Dispatch is
+`imp::dispatch` on macOS (`src/main.rs:519`) and `dispatch_linux` on Linux
+(`src/main.rs:369`).
+
+| subcommand | host | what it does |
+| --- | --- | --- |
+| `info` | both | Report whether the host can run a VM: `VZVirtualMachine.isSupported()` on macOS (`src/main.rs:686`), `/dev/kvm` present on Linux (`src/main.rs:374`). Prints `virtualization_supported=<bool>`. |
+| `boot-linux` | both | Boot a Linux guest under libkrun, stream its serial console, stop on timeout. Guest arg differs by host (below). See [linux-guests](linux-guests.md). |
+| `boot-linux-gui` | macOS | Boot an aarch64 Linux GUI guest from a raw EFI disk under VZ, fully off-screen, screenshot the framebuffer to `<out-prefix>.NNN.png` (`src/main.rs:104-129`). |
+| `drive-linux` | macOS | Boot a Linux GUI guest off-screen under VZ and drive it from stdin (same protocol as `drive-macos`) (`src/main.rs:130-149`). |
+| `install-macos` | macOS | Install macOS into a fresh bundle from a local IPSW via `VZMacOSInstaller`, bypassing Apple's online catalog (`src/main.rs:150-163`). |
+| `boot-macos` | macOS | Boot an installed macOS guest off-screen and screenshot its display via the framebuffer `IOSurface`; supports `--share TAG=HOSTDIR` virtio-fs (`src/main.rs:164-184`). |
+| `drive-macos` | macOS | Boot a macOS guest off-screen and drive it from stdin: synthetic keyboard/mouse + on-demand screenshots, plus `--share` (`src/main.rs:185-200`). |
+| `stage-binary` | macOS | Copy a nix-built binary and rewrite its `/nix/store` dylib refs so it runs on a vanilla guest, then re-sign (`src/main.rs:201-214`). |
+| `provision` | macOS | Edit a STOPPED guest bundle's disk to mark Setup Assistant complete (system + per-user), optionally enable auto-login (`src/main.rs:215-238`). |
+
+### `boot-linux` flags (`src/main.rs:53-103`)
+
+- `--disk <raw-efi-disk>` (macOS only): boot a raw EFI disk under libkrun-efi's
+  embedded OVMF.
+- `--root <dir>` and trailing `-- <cmd>` (Linux only): share a rootfs in over
+  virtiofs as `/` and run `<cmd>` as guest init (`exec[0]` is the binary path).
+- `--gpu`: attach a virtio-gpu Venus device (`/dev/dri`). On macOS the only way a
+  Linux guest gets a GPU.
+- `--cpus` (u8, default 2), `--memory-mib` (u32, default 1024): typed to
+  libkrun's widths so an out-of-range value is rejected at parse time.
+- `--port HOST:GUEST` (repeatable, implies `--net`), `--net`: guest networking
+  (gvproxy on macOS, TSI on Linux). Parsed by `build_net` (`src/main.rs:423`).
+- `--console-file <path>`: capture the serial console to a file instead of
+  stdout (for a background/lockstep caller).
+- `--timeout-secs` (default 20): stop after N seconds; `0` runs until the guest
+  powers off (persistent-server case).
+
+### `drive-*` command protocol (`src/drive.rs:1-22`)
+
+`drive-macos`/`drive-linux` read newline commands from stdin and ack each on
+stdout, so a controller drives the guest in lockstep (capture a frame, locate a
+control, click, capture again). Commands: `key <name> [count]`,
+`down`/`up <name>` (modifier chords), `type <text>`, `click <fx> <fy>` and
+`move`/`scroll` (display fractions, resolution-independent), `cursor`, `size`,
+`cursor-show <on|off>`, `wait <seconds>`, `shot <path>`, `quit`. Synthetic
+events are delivered straight to the guest's USB keyboard/pointing device by
+handing built `NSEvent`s to `VZVirtualMachineView` (`src/input.rs:1-7`), so the
+host event system and cursor are never involved.
+
+A `drive-*` session also publishes the live guest screen to the local dashboard
+as an image pane (a downscaled PNG sampled ~1/s, unchanged frames dropped),
+using `dashboard-core`'s `Publisher` over a producer socket in the discovery
+directory. Set `IX_VMKIT_NO_DASHBOARD` to any value to disable it. See
+[dashboard-core](../../dashboard/dashboard-core/overview.md).
+
+## Modules (`packages/vmkit/src`)
+
+| module | host | role |
+| --- | --- | --- |
+| `main.rs` | both | CLI, dispatch, `ensure_signed_and_reexec` (macOS), `build_net`, crate `Error` (`imp::Error`). |
+| `linuxkrun.rs` | both | libkrun Linux-guest backend; payload step `cfg`-split per host. See [linux-guests](linux-guests.md). |
+| `net.rs` | both | Guest networking: `Net`/`Forward` types (`net.rs:26-36`); gvproxy `Proxy` (macOS) and TSI port map (Linux). |
+| `macguest.rs` | macOS | macOS-guest boot, install, off-screen `IOSurface` capture; the off-screen view/capture helpers reused by `linuxguest`. |
+| `drive.rs` | macOS | interactive stdin driver + dashboard publishing. |
+| `input.rs` | macOS | synthetic `NSEvent` keyboard/key-code map to the guest USB keyboard. |
+| `linuxguest.rs` | macOS | Linux GUI guest under VZ (`VZGenericPlatformConfiguration` + `VZEFIBootLoader` + `VZVirtioGraphicsDevice`), reusing `macguest`'s capture path (`linuxguest.rs:1-15`). |
+| `provision.rs` | macOS | offline Setup Assistant bypass (host-side disk edit). |
+| `stagebin.rs` | macOS | rewrite a Mach-O's `/nix/store` dylib refs to be guest-portable, then re-sign. |
+
+## macOS entitlement self-signing
+
+Creating a VM on macOS requires an entitlement on the *running* process, and the
+binary must be code-signed to carry it: `com.apple.security.virtualization` for
+the VZ (macOS-guest) paths, `com.apple.security.hypervisor` for the libkrun
+(Linux-guest) path. The ix-mcp Python interpreter is an unsigned, immutable Nix
+store binary and cannot gain the entitlement, so `vmkit` is a separate signed
+binary that owns the VM and callers spawn it.
+
+The signing is automatic (`ensure_signed_and_reexec`, `src/main.rs:269-333`):
+any non-`info` command checks the `IX_VMKIT_SIGNED` sentinel; if unset it copies
+the read-only store binary into `$XDG_CACHE_HOME/ix/vmkit` (keyed by a hash of
+the store path so a rebuild re-signs), ad-hoc-signs the copy with
+`src/virtualization.entitlements` (which carries both entitlements plus
+`com.apple.security.cs.disable-library-validation` so it can load the libkrun
+dylib), and re-execs it with `IX_VMKIT_SIGNED=1`. Concurrent first-runs write to
+per-pid temp paths and publish by atomic rename; `prune_stale_signed`
+(`src/main.rs:339`) drops copies from prior store paths. On a Linux host no
+signing happens (`main` on Linux is `src/main.rs:357`); libkrun talks to
+`/dev/kvm` directly. The manual equivalent is `codesign --force --sign -
+--entitlements src/virtualization.entitlements <bin>`.
+
+All Virtualization.framework calls run on the process main thread (the queue VZ
+binds the VM to); `dispatch_main` drains it so completion handlers fire.
+
+## macOS-guest workflow
+
+The macOS-guest lifecycle is bundle-oriented. A *bundle* is a directory with
+`disk.img`, `aux.img`, `hardware-model.bin`, `machine-id.bin`.
+
+1. `install-macos --ipsw <ipsw> --bundle <dir> [--disk-gib 64]` creates the
+   bundle from a local restore image via `VZMacOSInstaller`.
+2. `provision --bundle <dir> --user <name> [--autologin --password-stdin]`
+   marks Setup Assistant complete with the guest STOPPED, so the next boot lands
+   on a logged-in desktop. It attaches `disk.img` read-write with no auto-mount,
+   finds the synthesized container's APFS Data and System volumes, ensures
+   `/var/db/.AppleSetupDone` (system SA), sets per-user `DidSee*` keys plus
+   `LastSeenCloudProductVersion`/`LastSeenBuddyBuildVersion` from the System
+   volume's `SystemVersion.plist`, and (with `--autologin`) writes `kcpassword`
+   (read from stdin, never an argument) and the loginwindow `autoLoginUser`
+   (`provision.rs:1-22`). A teardown guard detaches on every exit path and it
+   refuses to run on an already-attached image.
+3. `boot-macos`/`drive-macos --bundle <dir>` boot off-screen and screenshot or
+   drive the guest. `--share TAG=HOSTDIR` shares a host dir over virtio-fs; tag
+   `auto` mounts at `/Volumes/My Shared Files` (`parse_shares`, `src/main.rs:658`).
+4. `stage-binary <in> <out>` makes a nix-built GUI app guest-portable: for each
+   `/nix/store` dylib it repoints to the `/usr/lib` system equivalent when the
+   guest ships one (an explicit allowlist, since macOS 11+ serves these from the
+   dyld shared cache with no on-disk file) or bundles it next to the output with
+   an `@loader_path` reference, recursively over the dependency closure, then
+   ad-hoc re-signs and verifies no `/nix/store` path remains (`stagebin.rs:1-24`).
+
+### Off-screen capture (`src/macguest.rs:1-9`)
+
+The guest framebuffer is an `IOSurface` in the `VZVirtualMachineView`'s
+framebuffer subview's layer contents; `vmkit` reads its BGRA bytes directly and
+encodes PNG with the pure-Rust `image` crate, in-process. The view lives in an
+off-screen, non-activating window. This sidesteps the host-side capture paths
+that do not work for a headless VM (AppKit `cacheDisplay` reads the Metal layer
+black; ScreenCaptureKit needs a per-process Screen-Recording grant;
+`screencapture -l` cannot capture a fully off-screen window), so no
+Screen-Recording permission is needed.
+
+## MCP tool provider
+
+`vmkit` is also exposed as an ix-mcp tool provider: a `vmkit` Python module
+bundled into the pinned interpreter wraps the binary (`info`, `install`,
+`provision`, `stage_binary`, `screenshot`, `screenshot_many`, `drive`,
+`Driver`, `run_app`, plus Linux `boot_linux`/`boot_linux_gui`/`drive_linux`),
+returning PIL images that render inline. That module is owned by the
+[mcp](../../mcp/tool-providers/overview.md) domain; its internals are not documented here.
+
+## Not yet built
+
+A vsock control channel and a long-lived `serve` mode for IPC are designed but
+not implemented (`packages/vmkit/README.md` roadmap). Today each guest is an
+independent `vmkit` process spawned per operation.

--- a/docs/vm-fleet/vz-linux-guest/overview.md
+++ b/docs/vm-fleet/vz-linux-guest/overview.md
@@ -1,0 +1,76 @@
+# vz-linux-guest
+
+`packages/vz-linux-guest` is the raw EFI-bootable aarch64 NixOS disk image that
+[vmkit](../vmkit/overview.md)'s `boot-linux-gui` / `drive-linux` path boots under
+Apple's Virtualization.framework (VZ) on Apple Silicon. It boots straight into a
+Wayland compositor running [bossbar-overlay](../../games/bossbar-overlay/overview.md)
+on software graphics, so the host can screenshot a real Linux GUI render off the
+VZ framebuffer (`nixos.nix:1-7`). It is the Linux-GUI counterpart to
+[chrome-vm-image](../chrome-vm-image/overview.md) (which is headless under
+libkrun): this one targets VZ specifically because VZ is the only working
+Linux-GUI framebuffer-capture path (see
+[vmkit linux-guests](../vmkit/linux-guests.md)).
+
+## What it is
+
+- Nix-only package, `aarch64-linux` only (`package.nix:7-8`). Flake output
+  `vz-linux-guest`: `nix build .#packages.aarch64-linux.vz-linux-guest`. The
+  output is the raw disk image.
+- Built by evaluating a standalone NixOS system from nixpkgs' `eval-config.nix`
+  (one module `./nixos.nix`, the overlaid aarch64-linux `bossbar-overlay` passed
+  as a `specialArg`) and rendering it with `make-disk-image`
+  (`default.nix:14-28`): `format = "raw"`, `partitionTableType = "efi"`,
+  `additionalSpace = "512M"` headroom. No nixos-generators/disko input needed.
+
+`make-disk-image` (unlike `chrome-vm-image`'s `systemd-repart`) is used here; it
+labels the partitions `ESP` and `nixos`, which the system mounts by label
+(`nixos.nix:64-74`).
+
+## Boot and display (`nixos.nix:38-62`)
+
+- Boots under VZ's EFI firmware (`VZEFIBootLoader`) off the raw disk via
+  systemd-boot (`boot.loader.systemd-boot.enable = true`, `timeout = 0`,
+  `efi.canTouchEfiVariables = false`).
+- `kernelParams = [ "console=tty0" "console=hvc0" ]`: tty0 writes to the
+  virtio-gpu framebuffer; hvc0 (the serial console) is streamed to the host by
+  `boot-linux-gui` for boot debugging.
+- initrd has `virtio_pci`, `virtio_blk`, `virtio_scsi`, `usbhid`, `sd_mod`; the
+  `virtio_gpu` DRM module is loaded so the compositor runs on the paravirtual
+  display whose scanout VZ exposes to the host framebuffer.
+
+## Software graphics
+
+Apple's virtio-gpu has no 3D acceleration, so the whole GUI stack runs on
+software rendering (`nixos.nix:5-7,76-81`):
+
+- the compositor (sway/wlroots) uses the pixman software renderer
+  (`WLR_RENDERER = "pixman"`, `WLR_RENDERER_ALLOW_SOFTWARE = "1"`).
+- the wgpu overlay uses Mesa lavapipe (software Vulkan). The launch wrapper
+  `bossbarLaunch` (`nixos.nix:24-29`) sets `VK_DRIVER_FILES` to the lavapipe ICD
+  (`lvp_icd.aarch64.json`) and `LD_LIBRARY_PATH` to Mesa, which is mandatory:
+  with no ICD wgpu hard-panics and there is no GL fallback. It also seeds a fresh
+  `BOSSBAR_DB=/tmp/bossbars.db` so the overlay auto-populates demo bars.
+
+## Autologin to the overlay (`nixos.nix:31-98`)
+
+The image logs in automatically and lands in the overlay with no interaction:
+
+- `services.getty.autologinUser = "ix"` (a passwordless normal user in the
+  `wheel`/`video`/`input` groups).
+- `programs.bash.loginShellInit` execs `sway -c <swayConfig>` when the tty is
+  `/dev/tty1`.
+- the sway config (`nixos.nix:32-36`) sets a fixed `1920x1080` output, no border,
+  and `exec`s `bossbarLaunch` as the only client.
+
+`environment.systemPackages` includes `sway`, `grim` (screenshots), `mesa`,
+`vulkan-loader`, `vulkan-tools`, and `bossbar-overlay` (`nixos.nix:100-107`).
+The image is trimmed: `documentation.enable` and `networking.useDHCP` are off
+(`nixos.nix:109-112`).
+
+## Related
+
+- [vmkit linux-guests](../vmkit/linux-guests.md): the VZ GUI-capture path
+  (`boot-linux-gui`/`drive-linux`) that boots this disk, and why it stays on VZ
+  rather than libkrun.
+- [bossbar-overlay](../../games/bossbar-overlay/overview.md): the wgpu GUI app
+  this guest runs (verifying it renders on Linux without a real GPU).


### PR DESCRIPTION
## Summary

Greenfields a from-source documentation tree under `docs/`, porting the per-domain docs model already shipped in the ix repo (its #4904) to `index`.

- `docs/index.md` is the only bare markdown file at the docs root and acts as the catalog: per-domain sections, one row per page with its `genre` and the source globs it `owns`.
- Each domain has a `common.md` orientation page (units table, how-it-fits-together flow, glossary, components table) plus one component directory per package/module/image.
- Per-package: every repo-owned package gets its own `overview.md`, including the third-party Nix wrappers. Pages cite real `path:line` references and were authored from current source.

**19 domains, 176 pages** covering every package under `packages/`, the SDKs, the site, and the `lib/`, `modules/`, and `images/` Nix trees:

| section | domains |
| --- | --- |
| Code and search | `code-intel`, `search` |
| Terminal surfaces | `terminal`, `dashboard`, `media` |
| Agents and orchestration | `agents`, `mcp`, `symphony` |
| Integrations | `integrations` |
| Build and packaging | `nix-build`, `packaging` |
| Nix infrastructure | `nix-lib`, `modules`, `images` |
| VMs and games | `vm-fleet`, `games` |
| Developer tools, SDK, and site | `dev-tools`, `sdk`, `site` |

Docs-only: no source, README, or `docs/demo-*` assets were touched.

#### Test plan

- [x] `docs/index.md` catalog rows match the files on disk exactly (176/176, no dangling rows, no orphans)
- [x] Structure invariants: only `index.md` bare at root, only `common.md` bare per domain
- [x] All 887 relative markdown links resolve
- [x] No em dashes, no en dashes, no emojis
- [ ] Human review of page accuracy (subagent NOTES flag a few source/README drifts worth a look: `ast-merge solve` is unimplemented; `tui` README says no runtime resize but source has it; `ix-fleet` tests are stale vs the SDK-based module; sdk python wheel is cp313 while pyproject says >=3.10)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-domain documentation tree covering all major repo components
> - Introduces a large greenfield documentation tree under `docs/` with overview, internals, and cross-domain orientation pages for every major package and module in the repository.
> - Covers domains including search, terminal, MCP, Symphony, agents, SDK, media, games, nix-build, nix-lib, vm-fleet, dashboard, code-intel, modules, images, packaging, and integrations.
> - Adds a top-level [docs/index.md](https://github.com/indexable-inc/index/pull/1119/files#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6) establishing documentation structure, page genres, and domain ownership conventions.
> - Each domain gets a `common.md` orientation page listing units and inter-component relationships, with per-component `overview.md` and (where warranted) `internals.md` pages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9fb4049.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->