### PR TITLE
fix(image): restore dev image name override precedence

### DIFF
--- a/images/dev/development-base/default.nix
+++ b/images/dev/development-base/default.nix
@@ -15,7 +15,7 @@
   # both. See lib/dev/agents.nix for the wrapper and policy rationale.
   imports = [ ../../../lib/dev/agents.nix ];
 
-  ix.image.name = lib.mkDefault "development-base";
+  ix.image.name = lib.mkOptionDefault "development-base";
 
   # `pkgs.claude-code` ships under Anthropic's commercial terms (unfree in
   # nixpkgs). The allow-by-name exception lives on the shared image nixpkgs

--- a/images/dev/kernel-dev/default.nix
+++ b/images/dev/kernel-dev/default.nix
@@ -2,7 +2,7 @@
 # /src/linux. The base profile already brings ripgrep, fd, neovim, gdb, perf.
 { lib, pkgs, ... }:
 {
-  ix.image.name = lib.mkDefault "linux-kernel-dev";
+  ix.image.name = lib.mkOptionDefault "linux-kernel-dev";
 
   environment.systemPackages = [
     pkgs.gnumake

--- a/images/dev/neovim-ci/default.nix
+++ b/images/dev/neovim-ci/default.nix
@@ -6,7 +6,7 @@ let
   ]);
 in
 {
-  ix.image.name = lib.mkDefault "neovim-ci";
+  ix.image.name = lib.mkOptionDefault "neovim-ci";
 
   environment.systemPackages = [
     pkgs.attr

--- a/images/dev/symphony-codex/default.nix
+++ b/images/dev/symphony-codex/default.nix
@@ -18,7 +18,7 @@ let
 in
 {
   ix.image = {
-    name = lib.mkDefault "ix/symphony-codex";
+    name = lib.mkOptionDefault "ix/symphony-codex";
     tag = "2026-05-31";
   };
 

--- a/lib/image/dev.nix
+++ b/lib/image/dev.nix
@@ -90,16 +90,16 @@ let
       shareSubdirs = map (b: b.shareSubdir) binds ++ lib.optional onShare "ix";
 
       # `defaults` apply to EVERY node (workload and server): the base image, the
-      # ix.dev options + agent layer, and the user's module. The base dev image
-      # provides only a default image name, so each node's replacement image is
-      # named after the node.
+      # ix.dev options + agent layer, and the user's module. Dev base images
+      # provide option defaults; this node default is stronger than those but
+      # still weaker than a user-supplied plain `ix.image.name` definition.
       defaults = [
         (paths.images + "/dev/${dev.baseImage}")
         agentsModule
         (
           { name, ... }:
           {
-            ix.image.name = name;
+            ix.image.name = lib.mkDefault name;
             ix.image.tag = lib.mkDefault "ix-dev";
           }
         )


### PR DESCRIPTION
## Summary
- keep base dev image self-names at option-default priority
- keep per-node image names at mkDefault priority so user modules can override them without merge conflicts
- remove the invalid SDK mock-link proof from this branch; the real SDK artifact fix is upstream in indexable-inc/ix#4929

## Validation
- pre-commit hooks on amend: statix, astlog, deadnix, nixfmt, astlog-rust

## SDK follow-up
The previous SDK AI finding was real: index cannot prove the current R2 rlib links because the published artifact lacks its rustc dependency metadata closure. I opened indexable-inc/ix#4929 to publish that closure and add a repeatable .#upload-sdk-rlib path.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore dev image name override precedence by switching to `mkOptionDefault`
> - In each dev image module ([development-base](https://github.com/indexable-inc/index/pull/1122/files#diff-01ce554385daab1b0da2fd5335a0d948fe85070d30d519bb38c343d5e5b33fd4), [kernel-dev](https://github.com/indexable-inc/index/pull/1122/files#diff-f14f69dc6062e74b1aca26e3c8e6e5099b85d85f8f53f13e6b1bbe9ebef6466b), [neovim-ci](https://github.com/indexable-inc/index/pull/1122/files#diff-f89caa71bfab920c7050e33bebefbb12e9a2ec3df6ebd4eaf32ea52cafa793ee), [symphony-codex](https://github.com/indexable-inc/index/pull/1122/files#diff-fa98741b6cea42742963877e10afa3971317522ac8a23331307fedfee04b1101)), `ix.image.name` is changed from `mkDefault` to `mkOptionDefault`, lowering its precedence so it can be overridden by higher-priority definitions.
> - In [lib/image/dev.nix](https://github.com/indexable-inc/index/pull/1122/files#diff-b0574b018c9f176e0ee521344c331ba0e543e2a1ac42037fa67601faa428867b), the per-node `ix.image.name` assignment is changed from a plain definition to `mkDefault`, making it overridable by user-supplied plain definitions while still taking precedence over `mkOptionDefault` values from base images.
> - Together these changes restore the intended precedence chain: user definitions > `mkDefault` (per-node) > `mkOptionDefault` (base image defaults).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e2d91b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->