### PR TITLE
feat(ix-fleet): bare-name nixosConfigurations for native multi-VM switch (ENG-3064)

### DIFF
--- a/docs/ix-fleet/overview.md
+++ b/docs/ix-fleet/overview.md
@@ -68,6 +68,13 @@ each node key matches its `name`; and that every `dependsOn` names a real node.
   `dependsOn`, `healthChecks` (name -> `HealthCheck`).
 - **`SwitchSpec`** (`:44`): `target`, `buildOn` (`auto`|`local`|`remote`,
   default `auto`), optional `buildVm`, `sourceInstallable`, `overrideInputs`.
+  `sourceInstallable` defaults to the bare node name `.#<node>` (not
+  `.#<node>-system`): `mkFleet` exposes a `nixosConfigurations.<node>` output
+  (bare external name -> the node's system) so `ix up .#<node>` resolves it, and
+  the simple attr lets the native multi-VM `ix up .#a .#b --build-vm <builder>`
+  derive each VM name. The `<node>-system` package stays as a build alias. Merge
+  the fleet's `nixosConfigurations` into your flake's top-level
+  `nixosConfigurations` (see `templates/dev/flake.nix`).
 - **`ReplacementImage`** (`:34`): `imageName`, `imageTag`, `destination`,
   `source`, `sourceDrv` (the OCI image derivation to realise and push).
 - **`HealthCheck`** (`:54`): `description`, `command` (argv), `timeoutSec`,

--- a/lib/image/fleet.nix
+++ b/lib/image/fleet.nix
@@ -273,7 +273,12 @@ let
         target = switchTarget;
         buildOn = switchBuildOn;
         buildVm = deploy.switch.buildVm or null;
-        sourceInstallable = deploy.switch.sourceInstallable or ".#${name}-system";
+        # Bare node name, not `.#${name}-system`: the native multi-VM `ix up`
+        # (`ix up .#a .#b --build-vm <builder>`) derives each VM name from the
+        # installable's simple attr and rejects `--name`, so the attr must equal
+        # the node name. `nixosConfigurations.<node>` (below) resolves this to the
+        # node's toplevel; the `<name>-system` package stays as a build alias.
+        sourceInstallable = deploy.switch.sourceInstallable or ".#${name}";
         overrideInputs = deploy.switch.overrideInputs or { };
       };
       inherit (deploy) bootstrapImage;
@@ -311,9 +316,14 @@ let
 
   # Rename a fleet's external identities without re-evaluating any NixOS
   # closure: only plan data (node names, `dependsOn`, east-west `groups`, the
-  # registry `destination` the replacement image is pushed to) carries the
-  # prefix, while `system`/`switch` targets and the OCI image `source`/
-  # `sourceDrv` keep pointing at the shared base closures. The health-check
+  # registry `destination` the replacement image is pushed to, and the default
+  # `switch.sourceInstallable` attr) carries the prefix, while `system`/`switch`
+  # `target` and the OCI image `source`/`sourceDrv` keep pointing at the shared
+  # base closures. The prefixed `sourceInstallable` (`.#${prefix}${name}`) still
+  # resolves to the shared base closure because `nixosConfigurations.<external>`
+  # is a thin `{ config }` wrapper over the once-evaluated `nodeConfigs.<name>`
+  # (see `resultFor`), so the native multi-VM `ix up` can name the prefixed VM
+  # without a second eval. The health-check
   # runner relies on this so the 10 example fleets are evaluated once per
   # `nix flake check`/`.#packages` eval instead of twice (ENG-2411). The
   # guest-side identity (`networking.hostName`, `ix.image.name`) therefore
@@ -339,6 +349,13 @@ let
             replacementImage = node.replacementImage // {
               destination = prefixName node.replacementImage.destination;
             };
+            # Only the default `.#${name}` installable is re-derived to the
+            # prefixed attr; a user-set `sourceInstallable` is left untouched.
+            switch =
+              node.switch
+              // lib.optionalAttrs (node.switch.sourceInstallable == ".#${name}") {
+                sourceInstallable = ".#${prefixName name}";
+              };
           }
         )
       ) planValue.nodes;
@@ -405,6 +422,14 @@ let
       systemPackages = lib.mapAttrs' (
         name: config: lib.nameValuePair "${externalName name}-system" config.system.build.toplevel
       ) nodeConfigs;
+      # Each node's NixOS system under its bare external name, so `ix up .#<node>`
+      # (and the native multi-VM `ix up .#a .#b --build-vm <builder>`) resolves
+      # `nixosConfigurations.<node>.config.system.build.toplevel`. `nodeConfigs`
+      # is already the evaluated `config` (`evalImageConfig` returns `.config`),
+      # so the `{ config }` wrapper reuses that closure with no second eval; this
+      # is the same closure `systemPackages.<node>-system` points at. Merge this
+      # into a flake's top-level `nixosConfigurations`.
+      nixosConfigurations = externalKeyed (lib.mapAttrs (_name: config: { inherit config; }) nodeConfigs);
       # Prepend `newPrefix` to every external name; the underlying NixOS
       # closures stay shared with the unprefixed fleet (see
       # `prefixedPlanValue` above).

--- a/lib/image/fleet.nix
+++ b/lib/image/fleet.nix
@@ -37,6 +37,14 @@ let
 
   moduleList = spec: toList (spec.modules or spec.module or [ ]);
 
+  # Default `switch.sourceInstallable`. The remote path goes through `ix up`,
+  # which rewrites a bare `.#<node>` to `nixosConfigurations.<node>...` and (for
+  # the native multi-VM switch) derives the VM name from that attr. The local
+  # path runs a plain `nix build <installable>` with no such rewrite, so it must
+  # name the `.#<node>-system` package alias that resolves to the toplevel.
+  defaultSourceInstallable =
+    nodeName: buildOn: if buildOn == "local" then ".#${nodeName}-system" else ".#${nodeName}";
+
   deploymentDefaults = {
     bootstrapImage = "registry.ix.dev/${bootstrapImage.name}:${bootstrapImage.tag}";
     region = "us-west-1";
@@ -273,12 +281,11 @@ let
         target = switchTarget;
         buildOn = switchBuildOn;
         buildVm = deploy.switch.buildVm or null;
-        # Bare node name, not `.#${name}-system`: the native multi-VM `ix up`
-        # (`ix up .#a .#b --build-vm <builder>`) derives each VM name from the
-        # installable's simple attr and rejects `--name`, so the attr must equal
-        # the node name. `nixosConfigurations.<node>` (below) resolves this to the
-        # node's toplevel; the `<name>-system` package stays as a build alias.
-        sourceInstallable = deploy.switch.sourceInstallable or ".#${name}";
+        # Remote switches default to the bare `.#<node>` so the native multi-VM
+        # `ix up` can derive each VM name from the attr; local switches keep the
+        # `.#<node>-system` package alias (see `defaultSourceInstallable`).
+        sourceInstallable =
+          deploy.switch.sourceInstallable or (defaultSourceInstallable name switchBuildOn);
         overrideInputs = deploy.switch.overrideInputs or { };
       };
       inherit (deploy) bootstrapImage;
@@ -349,12 +356,15 @@ let
             replacementImage = node.replacementImage // {
               destination = prefixName node.replacementImage.destination;
             };
-            # Only the default `.#${name}` installable is re-derived to the
-            # prefixed attr; a user-set `sourceInstallable` is left untouched.
+            # Re-derive only the default installable to the prefixed attr, keyed
+            # on whether the user set `switch.sourceInstallable` in the spec (not
+            # on the rendered string, which an explicit `.#<node>` override would
+            # match). An explicit installable points at a real flake attr and is
+            # left untouched.
             switch =
               node.switch
-              // lib.optionalAttrs (node.switch.sourceInstallable == ".#${name}") {
-                sourceInstallable = ".#${prefixName name}";
+              // lib.optionalAttrs (!((checkedNodeSpecs.${name}.deployment.switch or { }) ? sourceInstallable)) {
+                sourceInstallable = defaultSourceInstallable (prefixName name) node.switch.buildOn;
               };
           }
         )

--- a/templates/dev/flake.nix
+++ b/templates/dev/flake.nix
@@ -46,5 +46,16 @@
         }
         // dev.systemPackages
       );
+
+      # Each node's NixOS system under its bare name, so `ix up .#<node>` and the
+      # native multi-VM switch (`ix up .#a .#b --build-vm <builder>`) resolve it.
+      # ix VM closures are x86_64-linux, so the configs come from that builder.
+      inherit
+        (index.lib.mkDevFor "x86_64-linux" {
+          module = ./dev.nix;
+          src = self;
+        })
+        nixosConfigurations
+        ;
     };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1684,6 +1684,26 @@ let
 
   prefixedFleet = prefixedFleetBase.withNodePrefix "tprefix-";
 
+  # A local-build node: its source switch runs a plain `nix build`, so the
+  # default installable must be the `.#<node>-system` package alias, not the
+  # bare `.#<node>` (which only `ix up`'s resolver expands).
+  localBuildFleet = ix.mkFleet {
+    nodes.svc = {
+      deployment.switch.buildOn = "local";
+      modules = [ { } ];
+    };
+  };
+
+  # An explicit `sourceInstallable` that happens to equal the bare default must
+  # survive `withNodePrefix` unchanged: prefixing keys on provenance (user-set
+  # vs defaulted), not on the rendered string.
+  explicitInstallableFleet = ix.mkFleet {
+    nodes.svc = {
+      deployment.switch.sourceInstallable = ".#svc";
+      modules = [ { } ];
+    };
+  };
+
   fleetIpv4HealthCheckEval = builtins.tryEval (
     builtins.deepSeq
       (ix.mkFleet {
@@ -4650,6 +4670,16 @@ let
           prefixedFleet.nixosConfigurations."tprefix-api".config.system.build.toplevel
           == prefixedFleetBase.nixosConfigurations.api.config.system.build.toplevel;
         message = "withNodePrefix should expose nixosConfigurations under the prefixed name while reusing the base closure (no second eval)";
+      }
+      {
+        assertion = localBuildFleet.planValue.nodes.svc.switch.sourceInstallable == ".#svc-system";
+        message = "a local-build node should default to the `.#<node>-system` package alias, since its plain `nix build` has no `ix up` rewrite";
+      }
+      {
+        assertion =
+          (explicitInstallableFleet.withNodePrefix "tprefix-")
+          .planValue.nodes."tprefix-svc".switch.sourceInstallable == ".#svc";
+        message = "an explicit sourceInstallable equal to the default must survive withNodePrefix unchanged (prefixing keys on provenance, not the rendered string)";
       }
     ];
   };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4496,6 +4496,11 @@ let
         message = "fleet system package outputs should match default source switch installables";
       }
       {
+        assertion =
+          fleet.nixosConfigurations.web.config.system.build.toplevel == fleet.nodes.web.system.build.toplevel;
+        message = "fleet should expose nixosConfigurations.<node> so `ix up .#<node>` (native multi-VM switch) resolves the node toplevel";
+      }
+      {
         assertion = fleet.packages.web == fleet.nodes.web.ix.build.ociImage;
         message = "fleet replacement package outputs should keep node names";
       }
@@ -4505,7 +4510,7 @@ let
             target = builtins.unsafeDiscardStringContext fleet.nodes.web.system.build.toplevel.drvPath;
             buildOn = "remote";
             buildVm = null;
-            sourceInstallable = ".#web-system";
+            sourceInstallable = ".#web";
             overrideInputs = { };
           };
         message = "fleet plans should default to local eval and remote build switch metadata";
@@ -4635,6 +4640,16 @@ let
       {
         assertion = prefixedFleet.nodes."tprefix-worker".environment.etc."api-host".text == "api";
         message = "nodes module-arg should resolve by the example's base name even when prefixed";
+      }
+      {
+        assertion = prefixedFleet.planValue.nodes."tprefix-api".switch.sourceInstallable == ".#tprefix-api";
+        message = "withNodePrefix should re-derive the default `.#<node>` installable to the prefixed attr so the native multi-VM `ix up` names the prefixed VM";
+      }
+      {
+        assertion =
+          prefixedFleet.nixosConfigurations."tprefix-api".config.system.build.toplevel
+          == prefixedFleetBase.nixosConfigurations.api.config.system.build.toplevel;
+        message = "withNodePrefix should expose nixosConfigurations under the prefixed name while reusing the base closure (no second eval)";
       }
     ];
   };


### PR DESCRIPTION
## Problem

The native multi-VM `ix up .#a .#b --build-vm <builder>` derives each VM name from the installable's simple attr (`explicit_attr`), **rejects `--name`**, and resolves `.#web` -> `nixosConfigurations.web.config.system.build.toplevel`. Fleet emitted `switch.sourceInstallable = ".#${name}-system"` for a VM named `<name>` and only surfaced systems as `packages.<system>.<name>-system`, so the multi path would name the VM `web-system` and look up the wrong attr. This blocks ENG-2309.

## Change

- `lib/image/fleet.nix`: add a `nixosConfigurations` output keyed by the bare external node name -> the node's NixOS eval (a thin `{ config }` wrapper that reuses the already-evaluated `nodeConfigs` closure, so no second eval; same closure `systemPackages.<node>-system` points at).
- Default `switch.sourceInstallable` to `.#<node>` (bare). The `<node>-system` package stays as a build alias (`nix build .#<node>-system` still works).
- `withNodePrefix` re-derives only the default `.#<node>` installable to the prefixed attr `.#<prefix><node>`, still resolving to the shared base closure (ENG-2411 single-eval preserved).
- Update `templates/dev/flake.nix` (surface the fleet's `nixosConfigurations`), `docs/ix-fleet/overview.md`, and eval tests in `tests/default.nix`.

## Verify

- `nix run .#lint` passes (5/5).
- Confirmed via a minimal fleet: default installable `.#dev`, `nixosConfigurations.dev` present, `dev-system` alias retained, prefixed `.#p-dev` + `nixosConfigurations.p-dev`.
- New eval-test assertions: `nixosConfigurations.<node>.config.system.build.toplevel == nodes.<node>.system.build.toplevel`, default installable `.#web`, and the prefixed-fleet variants.

Sub-issue of ENG-2309. Prereq for ENG-3065 (ix-fleet batched switch).

Closes ENG-3064

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose bare `nixosConfigurations.<node>` entries from `mkFleet` for native multi-VM switch
> - Adds `nixosConfigurations.<node>` to flake outputs in [`lib/image/fleet.nix`](https://github.com/indexable-inc/index/pull/1125/files#diff-9836ea3ef1875452d04d6213563ea9b0df81e37a277277836b0cb9df0ced1fa0), exposing each node's NixOS config under its bare external name without re-evaluation.
> - Introduces `defaultSourceInstallable` helper that returns `.#<node>-system` for local builds and `.#<node>` for remote/auto builds, replacing the previous hardcoded `.#<node>-system` default.
> - `withNodePrefix` now rewrites defaulted `sourceInstallable` values to the prefixed attribute name while preserving any user-specified `sourceInstallable`.
> - Dev template flake in [`templates/dev/flake.nix`](https://github.com/indexable-inc/index/pull/1125/files#diff-6d38ace705954bd6542850aaaca20828b51c5a7b9355d29234a233d67ca5c2d8) now inherits `nixosConfigurations` from `mkDevFor`.
> - Behavioral Change: remote/auto builds now default `switch.sourceInstallable` to `.#<node>` instead of `.#<node>-system`; local builds retain the old default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 202e85f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->