### PR TITLE
feat(ix-fleet): batch switch through native multi-VM ix up (ENG-3065)

### DIFF
--- a/docs/ix-fleet/overview.md
+++ b/docs/ix-fleet/overview.md
@@ -44,15 +44,16 @@ subcommand would run without calling the API.
 | `bootstrap` | Create selected nodes from their `bootstrapImage`, wait for guest readiness, and ensure east-west group membership. Runs in dependency batches concurrently (`cmd_bootstrap`, `:881`). |
 | `up` | Push each node's replacement image and create-or-replace the node on it, then groups + health. Fans out via dag-runner (`cmd_up`, `:850`). |
 | `replace` | Like `up` but always delete-then-create the node on the pushed image (`cmd_replace`, `:836`). |
-| `switch` | In-place NixOS system switch of running nodes (target or build-from-source), snapshotting first. Fans out via dag-runner (`cmd_switch`, `:818`). |
+| `switch` | In-place NixOS system switch of running nodes (target or build-from-source), snapshotting first. Remote source builds go through the platform's native multi-VM `ix up` in dependency layers (`cmd_switch`). |
 | `health` | Run each selected node's health checks (`cmd_health`, `:876`). |
 | `down` | Remove selected nodes in reverse plan order, collecting failures (`cmd_down`, `:886`). |
 
 `switch` flags: `--no-snapshot`, `--skip-health`, `--source-root`,
 `--source-workdir`. `up`/`replace` flags: `--skip-push`, `--skip-health`. The
-hidden `_switch-node`/`_replace-node`/`_up-node` subparsers
-(`help=argparse.SUPPRESS`, `:943-959`) take a single node positional plus the
-forwarded flags; they are what dag-runner invokes per node, not for direct use.
+hidden `_replace-node`/`_up-node` subparsers (`help=argparse.SUPPRESS`) take a
+single node positional plus the forwarded flags; they are what dag-runner
+invokes per node for `up`/`replace`, not for direct use. `switch` no longer has
+a per-node subparser: it batches the switch in-process (see below).
 
 ## The plan schema (pydantic, `__init__.py:34-146`)
 
@@ -107,29 +108,40 @@ are what `switch` is for.
   the selected nodes with each node's `dependsOn` emitted before it (a DFS over
   plan order), and `dependency_batches` (`:489`) groups them into parallel
   batches for `bootstrap`.
-- **`up`/`replace`/`switch` fan out through dag-runner.** `run_node_workflow_dag`
-  (`:774`) builds a spec `{"nodes": {name: {command, depends_on}}}` where each
-  command re-invokes `ix-fleet ... _<verb>-node <name>` with the forwarded flags;
-  it also adds a serialization edge between nodes that share a
+- **`up`/`replace` fan out through dag-runner.** `run_node_workflow_dag`
+  builds a spec `{"nodes": {name: {command, depends_on}}}` where each command
+  re-invokes `ix-fleet ... _<verb>-node <name>` with the forwarded flags; it also
+  adds a serialization edge between nodes that share a
   `replacementImage.destination` so the same image tag is not pushed twice
-  concurrently. `run_dag_runner` (`:804`) resolves the runner from
-  `IX_FLEET_DAG_RUNNER` or `dag-runner` on `PATH`, writes a temp spec, execs it,
-  and turns a nonzero exit into the process exit status. `--dry-run` runs the
-  per-node workflows inline instead (so child output is visible).
-- **Per-node workflows.** `run_up_node_workflow` (`:764`): push image (unless
+  concurrently. `run_dag_runner` resolves the runner from `IX_FLEET_DAG_RUNNER`
+  or `dag-runner` on `PATH`, writes a temp spec, execs it, and turns a nonzero
+  exit into the process exit status. `--dry-run` runs the per-node workflows
+  inline instead (so child output is visible).
+- **`switch` batches in-process through the native multi-VM `ix up`.**
+  `cmd_switch` walks `dependency_batches` layers in order (so `dependsOn` still
+  gates the switch) and, within each layer, groups the batchable nodes by
+  `(buildVm, overrideInputs)` and runs one `ix up .#a .#b --build-vm <builder>`
+  per group (`switch_nodes_from_source`); the platform builds every closure on
+  the one warm builder and activates each on its own VM. Each group's VMs are
+  pre-created with their full fleet config and snapshotted first
+  (`switch_group_workflow`), then the batch only switches existing VMs. Groups
+  and single-node fallbacks within a layer run concurrently via `asyncio.gather`.
+- **Per-node workflows.** `run_up_node_workflow`: push image (unless
   `--skip-push`) -> `up_node` (create if absent, else recreate on the uploaded
   image) -> ensure groups -> health (unless `--skip-health`).
-  `run_replace_node_workflow` (`:754`) is the same with an unconditional recreate.
-  `run_switch_node_workflow` (`:734`): ensure the node exists -> ensure groups ->
-  snapshot (if `node.snapshot` and not `--no-snapshot` and the node was not just
-  created) -> switch -> health.
-- **Switch has two modes.** `buildOn == "remote"` builds from source by shelling
-  `ix up <sourceInstallable> --name <node> --workdir <rel>` from the source root
-  (`switch_node_from_source`, `:651`), with up to `MAX_SWITCH_RETRIES` retries on
-  a transient `stream framing error`; otherwise it calls the SDK
-  `switch_system`, bounded by `SWITCH_TIMEOUT_SECS = 1800`
-  (`switch_node`, `:430-458`). `buildOn == "local"` first runs a host-side
-  `nix build` of the installable.
+  `run_replace_node_workflow` is the same with an unconditional recreate.
+  `run_switch_node_workflow` (the single-node fallback): ensure the node exists
+  -> ensure groups -> snapshot (if `node.snapshot` and not `--no-snapshot` and
+  the node was not just created) -> switch -> health.
+- **Switch picks a path per node.** A node is batched into the native multi-VM
+  `ix up` only when it builds remotely, names a `buildVm`, and its installable is
+  exactly `.#<node-name>` (`is_batchable_switch`); the multi `ix up` derives each
+  VM name from that attr and rejects `--name`. Anything else falls back to the
+  single-target `ix up <installable> --name <node>` (`switch_node_from_source`,
+  `buildOn == "remote"` without a build VM or with a custom installable) or the
+  SDK `switch_system` (`switch_node`, `buildOn` `local`/`auto`), bounded by
+  `SWITCH_TIMEOUT_SECS = 1800`. Both source paths retry a transient
+  `stream framing error` up to `MAX_SWITCH_RETRIES` (`run_source_switch`).
 
 ## Health checks (`__init__.py:540-624`)
 

--- a/packages/ix-fleet/default.nix
+++ b/packages/ix-fleet/default.nix
@@ -62,6 +62,54 @@ let
         mkdir -p "$out"
       '';
 
+  # Two remote-source nodes that share a build VM, so `switch --dry-run` exercises
+  # the native multi-VM batch path: both must land in one `ix up .#web .#worker
+  # --build-vm builder` command.
+  dryRunSwitchPlan = jsonFormat.generate "ix-fleet-dry-run-switch-plan.json" {
+    order = [
+      "web"
+      "worker"
+    ];
+    nodes = lib.genAttrs [ "web" "worker" ] (name: {
+      inherit name;
+      baseName = name;
+      system = "/nix/store/${name}-system";
+      switch = {
+        target = "/nix/store/${name}-system.drv";
+        buildOn = "remote";
+        buildVm = "builder";
+        sourceInstallable = ".#${name}";
+      };
+      bootstrapImage = "registry.ix.dev/ix/base:latest";
+      replacementImage = {
+        imageName = name;
+        imageTag = "latest";
+        destination = "registry.ix.dev/example/${name}:latest";
+        source = "/nix/store/${name}-image.tar";
+        sourceDrv = "/nix/store/${name}-image.drv";
+      };
+      region = "us-west-1";
+      ipv4 = false;
+      snapshot = false;
+    });
+  };
+
+  # Walks the `switch` command's --dry-run control flow and asserts the two
+  # batchable nodes collapse into one native multi-VM `ix up` invocation rather
+  # than one per node. No API calls or network, so it runs in the sandbox.
+  dryRunSwitch =
+    pkgs.runCommand "ix-fleet-dry-run-switch"
+      {
+        nativeBuildInputs = [ package ];
+        strictDeps = true;
+      }
+      ''
+        ix-fleet --plan ${dryRunSwitchPlan} switch --skip-health --no-snapshot --dry-run | tee switch.log
+        grep -qE '\+ ix up \.#web \.#worker --build-vm builder' switch.log \
+          || { echo "expected a single batched 'ix up .#web .#worker --build-vm builder'" >&2; exit 1; }
+        mkdir -p "$out"
+      '';
+
   package = unwrapped.overrideAttrs (old: {
     postInstall = ''
       ${old.postInstall or ""}
@@ -76,7 +124,7 @@ let
 
     passthru = (old.passthru or { }) // {
       tests = (old.passthru.tests or { }) // {
-        inherit dryRunUp;
+        inherit dryRunUp dryRunSwitch;
       };
     };
   });

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -801,12 +801,11 @@ def batch_groups(nodes: list[FleetNode]) -> list[list[FleetNode]]:
     # region (CAS chunks are region-scoped). Grouping on region keeps a
     # cross-region fleet from failing a whole batch instead of just the
     # wrong-region nodes.
-    BatchKey = tuple[str, str, tuple[tuple[str, str], ...]]
-    groups: dict[BatchKey, list[FleetNode]] = {}
-    order: list[BatchKey] = []
+    groups: dict[tuple[str, str, tuple[tuple[str, str], ...]], list[FleetNode]] = {}
+    order: list[tuple[str, str, tuple[tuple[str, str], ...]]] = []
     for node in nodes:
         assert node.switch.buildVm is not None
-        key: BatchKey = (
+        key = (
             node.switch.buildVm,
             node.region,
             tuple(sorted(node.switch.overrideInputs.items())),

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -795,14 +795,22 @@ def is_batchable_switch(node: FleetNode) -> bool:
 
 
 def batch_groups(nodes: list[FleetNode]) -> list[list[FleetNode]]:
-    # One native multi-VM `ix up` per (build VM, override-input set): those are the
-    # inputs the CLI shares across every target in a single invocation, so nodes
-    # that disagree on them cannot ride the same command.
-    groups: dict[tuple[str, tuple[tuple[str, str], ...]], list[FleetNode]] = {}
-    order: list[tuple[str, tuple[tuple[str, str], ...]]] = []
+    # One native multi-VM `ix up` per (build VM, region, override-input set). The
+    # CLI shares one `--build-vm` and `--override-input` set across the batch, and
+    # the server's multi-switch requires every target to share the builder's
+    # region (CAS chunks are region-scoped). Grouping on region keeps a
+    # cross-region fleet from failing a whole batch instead of just the
+    # wrong-region nodes.
+    BatchKey = tuple[str, str, tuple[tuple[str, str], ...]]
+    groups: dict[BatchKey, list[FleetNode]] = {}
+    order: list[BatchKey] = []
     for node in nodes:
         assert node.switch.buildVm is not None
-        key = (node.switch.buildVm, tuple(sorted(node.switch.overrideInputs.items())))
+        key: BatchKey = (
+            node.switch.buildVm,
+            node.region,
+            tuple(sorted(node.switch.overrideInputs.items())),
+        )
         if key not in groups:
             groups[key] = []
             order.append(key)

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -691,6 +691,39 @@ MAX_SWITCH_RETRIES = 3
 RETRY_DELAY_SECS = 10
 
 
+def relative_source_workdir(source_root: Path, source_workdir: Path) -> Path:
+    # `ix up --workdir` is resolved relative to the uploaded source root, so an
+    # absolute workdir outside that root has no valid mapping. Reject it instead
+    # of forwarding a path `ix up` cannot interpret.
+    workdir = source_workdir
+    if workdir.is_absolute():
+        try:
+            workdir = workdir.relative_to(source_root)
+        except ValueError:
+            raise ValueError(
+                f"source workdir {source_workdir} is outside source root {source_root}"
+            ) from None
+    return workdir
+
+
+async def run_source_switch(command: list[str], source_root: Path, label: str, *, dry_run: bool) -> None:
+    # `ix up` auto-uploads its working directory as the build source, so it runs
+    # from `source_root`. A `stream framing error` is a transient upload/transport
+    # hiccup, so retry it; anything else fails the switch.
+    for attempt in range(1, MAX_SWITCH_RETRIES + 1):
+        try:
+            step(f"switching {label} from source (attempt {attempt}/{MAX_SWITCH_RETRIES})")
+            await run_cli(command, dry_run=dry_run, timeout=3600, cwd=source_root)
+            return
+        except (CliError, CliTimeoutError) as e:
+            error_msg = e.output or str(e)
+            if "stream framing error" in error_msg and attempt < MAX_SWITCH_RETRIES:
+                step(f"transient error, retrying in {RETRY_DELAY_SECS}s: {error_msg[:100]}")
+                await asyncio.sleep(RETRY_DELAY_SECS)
+            else:
+                raise
+
+
 async def switch_node_from_source(
     node: FleetNode,
     source_root: Path,
@@ -699,21 +732,9 @@ async def switch_node_from_source(
     dry_run: bool,
 ) -> None:
     # `ix switch` was folded into `ix up` (indexable-inc/ix#4442): `ix up
-    # <installable> --name <vm>` is the converge path. `ix up` auto-uploads its
-    # working directory as the build source, so run it from `source_root` instead
-    # of passing the removed `--source`; `--workdir` selects the eval subdir
-    # relative to that root.
-    workdir = source_workdir
-    if workdir.is_absolute():
-        try:
-            workdir = workdir.relative_to(source_root)
-        except ValueError:
-            # `ix up --workdir` is resolved relative to the uploaded source root,
-            # so an absolute workdir outside that root has no valid mapping.
-            # Reject it instead of forwarding a path `ix up` cannot interpret.
-            raise ValueError(
-                f"source workdir {source_workdir} is outside source root {source_root}"
-            ) from None
+    # <installable> --name <vm>` is the single-target converge path, used for a
+    # node that cannot join a native multi-VM batch (see `switch_nodes_from_source`).
+    workdir = relative_source_workdir(source_root, source_workdir)
     command = [
         "ix",
         "up",
@@ -727,19 +748,66 @@ async def switch_node_from_source(
         command.extend(["--build-vm", node.switch.buildVm])
     for name, path in sorted(node.switch.overrideInputs.items()):
         command.extend(["--override-input", f"{name}={path}"])
+    await run_source_switch(command, source_root, node.name, dry_run=dry_run)
 
-    for attempt in range(1, MAX_SWITCH_RETRIES + 1):
-        try:
-            step(f"switching {node.name} from source (attempt {attempt}/{MAX_SWITCH_RETRIES})")
-            await run_cli(command, dry_run=dry_run, timeout=3600, cwd=source_root)
-            return
-        except (CliError, CliTimeoutError) as e:
-            error_msg = e.output or str(e)
-            if "stream framing error" in error_msg and attempt < MAX_SWITCH_RETRIES:
-                step(f"transient error, retrying in {RETRY_DELAY_SECS}s: {error_msg[:100]}")
-                await asyncio.sleep(RETRY_DELAY_SECS)
-            else:
-                raise
+
+async def switch_nodes_from_source(
+    nodes: list[FleetNode],
+    source_root: Path,
+    source_workdir: Path,
+    *,
+    dry_run: bool,
+) -> None:
+    # The native multi-VM switch: `ix up .#a .#b .#c --build-vm <builder>` builds
+    # every closure on one warm builder and activates each on its own VM. The CLI
+    # rejects `--name` and derives each VM name from the installable's simple attr,
+    # and shares one `--build-vm`/`--workdir`/`--override-input` set across the
+    # batch, so `batch_groups` only ever passes nodes that agree on those.
+    workdir = relative_source_workdir(source_root, source_workdir)
+    build_vm = nodes[0].switch.buildVm
+    assert build_vm is not None, "batched switch requires a shared build VM"
+    command = [
+        "ix",
+        "up",
+        *[node.switch.sourceInstallable for node in nodes],
+        "--build-vm",
+        build_vm,
+        "--workdir",
+        str(workdir),
+    ]
+    for name, path in sorted(nodes[0].switch.overrideInputs.items()):
+        command.extend(["--override-input", f"{name}={path}"])
+    await run_source_switch(command, source_root, ", ".join(node.name for node in nodes), dry_run=dry_run)
+
+
+def is_batchable_switch(node: FleetNode) -> bool:
+    # The native multi-VM `ix up` builds on one shared `--build-vm` and names each
+    # VM from the installable's simple attr, so a node joins a batch only when it
+    # builds remotely, names a build VM, and its installable is exactly
+    # `.#<node-name>`. Anything else (local build, no build VM, a custom or dotted
+    # installable) falls back to the single-target `ix up --name` path.
+    switch = node.switch
+    return (
+        switch.buildOn == "remote"
+        and switch.buildVm is not None
+        and switch.sourceInstallable == f".#{node.name}"
+    )
+
+
+def batch_groups(nodes: list[FleetNode]) -> list[list[FleetNode]]:
+    # One native multi-VM `ix up` per (build VM, override-input set): those are the
+    # inputs the CLI shares across every target in a single invocation, so nodes
+    # that disagree on them cannot ride the same command.
+    groups: dict[tuple[str, tuple[tuple[str, str], ...]], list[FleetNode]] = {}
+    order: list[tuple[str, tuple[tuple[str, str], ...]]] = []
+    for node in nodes:
+        assert node.switch.buildVm is not None
+        key = (node.switch.buildVm, tuple(sorted(node.switch.overrideInputs.items())))
+        if key not in groups:
+            groups[key] = []
+            order.append(key)
+        groups[key].append(node)
+    return [groups[key] for key in order]
 
 
 # Replacing a node's image is delete-then-create (see recreate_node): a new
@@ -858,23 +926,44 @@ async def run_dag_runner(spec: dict[str, typing.Any]) -> None:
         raise SystemExit(returncode)
 
 
-async def cmd_switch(plan: FleetPlan, args: argparse.Namespace) -> None:
-    if args.dry_run:
-        for node in selected_nodes(plan, args.on):
-            await run_switch_node_workflow(node, args)
-        return
+async def switch_group_workflow(
+    group: list[FleetNode],
+    source_root: Path,
+    source_workdir: Path,
+    args: argparse.Namespace,
+) -> None:
+    # Pre-create every VM with its full fleet config (groups, region, secrets,
+    # ...) and snapshot it first, so the native multi-VM `ix up` only switches
+    # existing VMs instead of creating them with bare defaults.
+    for node in group:
+        created = await ensure_node(node, dry_run=args.dry_run)
+        await ensure_node_groups(node, dry_run=args.dry_run)
+        if not created and node.snapshot and not args.no_snapshot:
+            await snapshot_node(node, dry_run=args.dry_run)
+    await switch_nodes_from_source(group, source_root, source_workdir, dry_run=args.dry_run)
+    if not args.skip_health:
+        for node in group:
+            await run_node_health_checks(node, dry_run=args.dry_run)
 
-    await verify_secrets_available(plan, args.on, dry_run=args.dry_run)
-    extra_args: list[str] = []
-    if args.no_snapshot:
-        extra_args.append("--no-snapshot")
-    if args.skip_health:
-        extra_args.append("--skip-health")
-    if args.source_root is not None:
-        extra_args.extend(["--source-root", str(args.source_root)])
-    if args.source_workdir is not None:
-        extra_args.extend(["--source-workdir", str(args.source_workdir)])
-    await run_node_workflow_dag(plan, args, "_switch-node", extra_args)
+
+async def cmd_switch(plan: FleetPlan, args: argparse.Namespace) -> None:
+    if not args.dry_run:
+        await verify_secrets_available(plan, args.on, dry_run=args.dry_run)
+    source_root = (args.source_root or default_source_root(Path.cwd())).resolve()
+    source_workdir = args.source_workdir or default_source_workdir(Path.cwd(), source_root)
+    # `dependency_batches` yields dependency-ordered layers; switch them in order
+    # so `dependsOn` still gates the switch. Within a layer the nodes are
+    # independent, so each native multi-VM batch (one `ix up` per build VM /
+    # override set) and each single-node fallback run concurrently.
+    for layer in dependency_batches(plan, args.on):
+        batchable = [node for node in layer if is_batchable_switch(node)]
+        singles = [node for node in layer if not is_batchable_switch(node)]
+        tasks = [
+            switch_group_workflow(group, source_root, source_workdir, args)
+            for group in batch_groups(batchable)
+        ]
+        tasks.extend(run_switch_node_workflow(node, args) for node in singles)
+        await asyncio.gather(*tasks)
 
 
 async def cmd_replace(plan: FleetPlan, args: argparse.Namespace) -> None:
@@ -905,10 +994,6 @@ async def cmd_up(plan: FleetPlan, args: argparse.Namespace) -> None:
     if args.skip_health:
         extra_args.append("--skip-health")
     await run_node_workflow_dag(plan, args, "_up-node", extra_args)
-
-
-async def cmd_switch_node(plan: FleetPlan, args: argparse.Namespace) -> None:
-    await run_switch_node_workflow(plan.nodes[args.node], args)
 
 
 async def cmd_replace_node(plan: FleetPlan, args: argparse.Namespace) -> None:
@@ -987,13 +1072,6 @@ def parser() -> argparse.ArgumentParser:
     add_common_options(up, defaults=False)
     up.add_argument("--skip-push", action="store_true")
     up.add_argument("--skip-health", action="store_true")
-    switch_node_parser = sub.add_parser("_switch-node", help=argparse.SUPPRESS)
-    switch_node_parser.add_argument("node")
-    add_dry_run_option(switch_node_parser)
-    switch_node_parser.add_argument("--no-snapshot", action="store_true")
-    switch_node_parser.add_argument("--skip-health", action="store_true")
-    switch_node_parser.add_argument("--source-root", type=Path)
-    switch_node_parser.add_argument("--source-workdir", type=Path)
     replace_node_parser = sub.add_parser("_replace-node", help=argparse.SUPPRESS)
     replace_node_parser.add_argument("node")
     add_dry_run_option(replace_node_parser)
@@ -1027,8 +1105,6 @@ async def main() -> None:
         await cmd_replace(plan, args)
     elif args.command == "up":
         await cmd_up(plan, args)
-    elif args.command == "_switch-node":
-        await cmd_switch_node(plan, args)
     elif args.command == "_replace-node":
         await cmd_replace_node(plan, args)
     elif args.command == "_up-node":

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -739,17 +739,22 @@ class SwitchBatchTests(unittest.TestCase):
         custom["switch"]["sourceInstallable"] = ".#api-system"
         self.assertFalse(ix_fleet.is_batchable_switch(self._node(custom)))
 
-    def test_batch_groups_split_by_build_vm_and_overrides(self) -> None:
+    def test_batch_groups_split_by_build_vm_region_and_overrides(self) -> None:
         a = self._node(remote_node("a", build_vm="b1"))
         b = self._node(remote_node("b", build_vm="b1"))
         c = self._node(remote_node("c", build_vm="b2"))
         d = remote_node("d", build_vm="b1")
         d["switch"]["overrideInputs"] = {"ix": "github:indexable-inc/ix"}
         d_node = self._node(d)
+        # Same build VM as a/b, but a different region: the server's multi-switch
+        # requires every target to share the builder's region, so it splits off.
+        e = remote_node("e", build_vm="b1")
+        e["region"] = "us-east-1"
+        e_node = self._node(e)
 
-        groups = ix_fleet.batch_groups([a, b, c, d_node])
+        groups = ix_fleet.batch_groups([a, b, c, d_node, e_node])
         names = [[node.name for node in group] for group in groups]
-        self.assertEqual(names, [["a", "b"], ["c"], ["d"]])
+        self.assertEqual(names, [["a", "b"], ["c"], ["d"], ["e"]])
 
     def test_switch_nodes_from_source_builds_one_multi_ix_up(self) -> None:
         nodes = [self._node(remote_node("web")), self._node(remote_node("worker"))]

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -471,39 +471,6 @@ class NodeWorkflowDagTests(unittest.TestCase):
 
         self.assertEqual(spec["nodes"]["worker"]["depends_on"], ["api"])
 
-    def test_switch_dag_forwards_switch_flags(self) -> None:
-        plan = ix_fleet.FleetPlan.model_validate(fleet_plan(["api"], [fleet_node("api")]))
-        spec = captured_dag(
-            ix_fleet.cmd_switch,
-            plan,
-            argparse_namespace(
-                plan=Path("/plans/fleet.json"),
-                on=["api"],
-                dry_run=False,
-                no_snapshot=True,
-                skip_health=True,
-                source_root=Path("/source"),
-                source_workdir=Path("subdir"),
-            ),
-        )
-
-        self.assertEqual(
-            spec["nodes"]["api"]["command"],
-            [
-                "/bin/ix-fleet",
-                "--plan",
-                "/plans/fleet.json",
-                "_switch-node",
-                "api",
-                "--no-snapshot",
-                "--skip-health",
-                "--source-root",
-                "/source",
-                "--source-workdir",
-                "subdir",
-            ],
-        )
-
     def test_dag_runner_exit_status_becomes_process_exit_status(self) -> None:
         plan = ix_fleet.FleetPlan.model_validate(fleet_plan(["api"], [fleet_node("api")]))
         args = argparse_namespace(
@@ -614,7 +581,7 @@ class SingleNodeWorkflowTests(unittest.TestCase):
             patch.object(ix_fleet, "switch_node", async_recorder(calls, "switch")),
             patch.object(ix_fleet, "run_node_health_checks", async_recorder(calls, "health")),
         ):
-            asyncio.run(ix_fleet.cmd_switch_node(plan, args))
+            asyncio.run(ix_fleet.run_switch_node_workflow(plan.nodes["api"], args))
 
         self.assertEqual(calls, ["ensure", "groups", "snapshot", "switch", "health"])
 
@@ -738,6 +705,180 @@ class SwitchSourceTests(unittest.TestCase):
                         dry_run=False,
                     )
                 )
+
+
+def remote_node(
+    name: str,
+    *,
+    build_vm: str = "builder",
+    depends_on: list[str] | None = None,
+) -> dict[str, typing.Any]:
+    node = fleet_node(name, depends_on=depends_on)
+    node["switch"]["buildOn"] = "remote"
+    node["switch"]["buildVm"] = build_vm
+    return node
+
+
+class SwitchBatchTests(unittest.TestCase):
+    def _node(self, data: dict[str, typing.Any]) -> ix_fleet.FleetNode:
+        return ix_fleet.FleetNode.model_validate(data)
+
+    def test_is_batchable_switch(self) -> None:
+        self.assertTrue(ix_fleet.is_batchable_switch(self._node(remote_node("api"))))
+        # local build: no shared builder to batch on.
+        local = fleet_node("api")
+        local["switch"]["buildOn"] = "local"
+        self.assertFalse(ix_fleet.is_batchable_switch(self._node(local)))
+        # remote but no build VM: multi `ix up` requires --build-vm.
+        no_vm = fleet_node("api")
+        no_vm["switch"]["buildOn"] = "remote"
+        self.assertFalse(ix_fleet.is_batchable_switch(self._node(no_vm)))
+        # installable attr must equal the node name (multi derives the VM name
+        # from it and rejects --name).
+        custom = remote_node("api")
+        custom["switch"]["sourceInstallable"] = ".#api-system"
+        self.assertFalse(ix_fleet.is_batchable_switch(self._node(custom)))
+
+    def test_batch_groups_split_by_build_vm_and_overrides(self) -> None:
+        a = self._node(remote_node("a", build_vm="b1"))
+        b = self._node(remote_node("b", build_vm="b1"))
+        c = self._node(remote_node("c", build_vm="b2"))
+        d = remote_node("d", build_vm="b1")
+        d["switch"]["overrideInputs"] = {"ix": "github:indexable-inc/ix"}
+        d_node = self._node(d)
+
+        groups = ix_fleet.batch_groups([a, b, c, d_node])
+        names = [[node.name for node in group] for group in groups]
+        self.assertEqual(names, [["a", "b"], ["c"], ["d"]])
+
+    def test_switch_nodes_from_source_builds_one_multi_ix_up(self) -> None:
+        nodes = [self._node(remote_node("web")), self._node(remote_node("worker"))]
+        calls: list[list[str]] = []
+        cwds: list[Path | None] = []
+
+        async def fake_run_cli(
+            command: list[str],
+            *,
+            dry_run: bool,
+            timeout: int | None = None,
+            cwd: Path | None = None,
+        ) -> str:
+            del timeout
+            self.assertFalse(dry_run)
+            calls.append(command)
+            cwds.append(cwd)
+            return ""
+
+        with patch.object(ix_fleet, "run_cli", fake_run_cli):
+            asyncio.run(
+                ix_fleet.switch_nodes_from_source(
+                    nodes,
+                    Path("/source"),
+                    Path("/source/subdir"),
+                    dry_run=False,
+                )
+            )
+
+        # One native multi-VM `ix up`: every installable, one shared --build-vm,
+        # and no --name (multi derives each VM name from its installable attr).
+        self.assertEqual(
+            calls,
+            [
+                [
+                    "ix",
+                    "up",
+                    ".#web",
+                    ".#worker",
+                    "--build-vm",
+                    "builder",
+                    "--workdir",
+                    "subdir",
+                ]
+            ],
+        )
+        self.assertNotIn("--name", calls[0])
+        self.assertEqual(cwds, [Path("/source")])
+
+    def test_cmd_switch_batches_remote_nodes_and_runs_singles(self) -> None:
+        api = remote_node("api")
+        web = remote_node("web")
+        cache = fleet_node("cache")  # buildOn defaults to auto -> single fallback
+        plan = ix_fleet.FleetPlan.model_validate(fleet_plan(["api", "web", "cache"], [api, web, cache]))
+        groups: list[list[str]] = []
+        singles: list[str] = []
+
+        async def record_group(
+            group: list[ix_fleet.FleetNode],
+            source_root: Path,
+            source_workdir: Path,
+            args: typing.Any,
+        ) -> None:
+            del source_root, source_workdir, args
+            groups.append([node.name for node in group])
+
+        async def record_single(node: ix_fleet.FleetNode, args: typing.Any) -> None:
+            del args
+            singles.append(node.name)
+
+        async def no_verify(*args: typing.Any, **kwargs: typing.Any) -> None:
+            del args, kwargs
+
+        with (
+            patch.object(ix_fleet, "verify_secrets_available", no_verify),
+            patch.object(ix_fleet, "switch_group_workflow", record_group),
+            patch.object(ix_fleet, "run_switch_node_workflow", record_single),
+        ):
+            asyncio.run(
+                ix_fleet.cmd_switch(
+                    plan,
+                    argparse_namespace(
+                        on=[],
+                        dry_run=False,
+                        no_snapshot=False,
+                        skip_health=False,
+                        source_root=Path("/source"),
+                        source_workdir=Path("subdir"),
+                    ),
+                )
+            )
+
+        self.assertEqual(groups, [["api", "web"]])
+        self.assertEqual(singles, ["cache"])
+
+    def test_cmd_switch_respects_dependency_layers(self) -> None:
+        api = remote_node("api")
+        worker = remote_node("worker", depends_on=["api"])
+        plan = ix_fleet.FleetPlan.model_validate(fleet_plan(["api", "worker"], [api, worker]))
+        switched: list[list[str]] = []
+
+        async def record_group(
+            group: list[ix_fleet.FleetNode],
+            source_root: Path,
+            source_workdir: Path,
+            args: typing.Any,
+        ) -> None:
+            del source_root, source_workdir, args
+            switched.append([node.name for node in group])
+
+        with (
+            patch.object(ix_fleet, "switch_group_workflow", record_group),
+        ):
+            asyncio.run(
+                ix_fleet.cmd_switch(
+                    plan,
+                    argparse_namespace(
+                        on=[],
+                        dry_run=True,
+                        no_snapshot=False,
+                        skip_health=False,
+                        source_root=Path("/source"),
+                        source_workdir=Path("subdir"),
+                    ),
+                )
+            )
+
+        # `dependsOn` keeps the switch layered: api's batch runs before worker's.
+        self.assertEqual(switched, [["api"], ["worker"]])
 
 
 def argparse_namespace(**kwargs: typing.Any) -> typing.Any:


### PR DESCRIPTION
## Problem

`ix-fleet switch` re-implemented multi-VM fan-out itself: one dag-runner `_switch-node` task per node, each shelling a single-target `ix up <inst> --name <vm>`. The platform now has a native multi-VM switch (`ix up .#a .#b --build-vm <builder>` -> `switch_multi`) that shares one warm builder (delta-only closures), imports concurrently, and reports per-target results. ENG-2309.

## Change

- `cmd_switch` walks `dependency_batches` layers in order (so `dependsOn` still gates the switch) and, within each layer, groups batchable nodes by `(buildVm, overrideInputs)` into one `ix up .#a .#b --build-vm <builder>` per group (`switch_nodes_from_source`). Groups + single-node fallbacks run concurrently via `asyncio.gather`.
- A node is batched only when it builds remotely, names a `buildVm`, and its installable is exactly `.#<node>` (`is_batchable_switch`) - multi `ix up` derives each VM name from the attr and rejects `--name`. Everything else falls back to the single-target `ix up --name` (`switch_node_from_source`) or the SDK `switch_system`.
- VMs are pre-created with full fleet config and snapshotted before the batch (`switch_group_workflow`), so the native `ix up` only switches existing VMs (never creates with bare defaults).
- Shared `relative_source_workdir` + `run_source_switch` (keeps the `stream framing error` retry) back both the single and batched paths.
- Drop the now-unused `_switch-node` subparser / `cmd_switch_node` (switch no longer uses the dag-runner).

## Verify

- New `dryRunSwitch` nix check: `ix-fleet --plan <plan> switch --dry-run` collapses two batchable nodes into one `ix up .#web .#worker --build-vm builder` (asserted via grep). No API/network, runs in the sandbox.
- Unit tests (`tests/test_ix_fleet.py`): `is_batchable_switch`, `batch_groups`, the batched multi-`ix up` command (no `--name`), `cmd_switch` grouping, and dependency-layer ordering. Updated the single-node switch test to call `run_switch_node_workflow` directly.
- `nix run .#lint` passes (5/5).

Sub-issue of ENG-2309. **Depends on #1125 (ENG-3064)** - needs `.#<node>` to resolve via the fleet's `nixosConfigurations`. Merge #1125 first.

Closes ENG-3065

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Batch `ix-fleet switch` through native multi-VM `ix up` per dependency layer
> - `cmd_switch` now performs in-process dependency-layered batching instead of delegating per-node work to dag-runner. Eligible nodes in each dependency layer are grouped by `(buildVm, region, overrideInputs)` and switched with a single multi-target `ix up` invocation.
> - A node is batchable when it builds remotely, specifies a `buildVm`, and its `sourceInstallable` matches `.#<node-name>`. Non-batchable nodes fall back to single-node workflows run concurrently via `asyncio.gather`.
> - Pre-create, snapshot, and health-check steps are performed at the group level in `switch_group_workflow`.
> - The internal `_switch-node` subcommand and its dag-runner dispatch are removed; `dag-runner` fan-out is retained only for `up`/`replace`.
> - A dry-run integration test in [`default.nix`](https://github.com/indexable-inc/index/pull/1126/files#diff-652695031797bff850cdf5234a6a11a292b289ac6ca8701411d0d408d0345954) asserts that two nodes sharing a build VM produce a single batched `ix up` invocation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12479fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->