### PR TITLE
feat(symphony): factory autonomous SDLC workflow pack (ENG-2921)

### DIFF
--- a/packages/symphony/docs/factory-workflow.md
+++ b/packages/symphony/docs/factory-workflow.md
@@ -1,0 +1,187 @@
+# Factory: autonomous SDLC workflow (ENG-2921)
+
+Status: design draft. Source: [ENG-2921](https://linear.app/indexable/issue/ENG-2921/agent-workflow).
+
+A self-driving software development loop built as a Symphony pack. Five agent
+roles plus two continuous feeders take an idea from conception to a
+green, auto-merged PR on `main`, with bounded self-correction loops and
+human escape hatches.
+
+```
+Idea generator (code . exa . prior art)
+        | new
+        v
+   Researcher  <---- issues ---- Cleaner (slop . CI . tests . bugs)  (runs continuously)
+ (deep research . scope)
+        | scoped              ^
+        v                     | new issues
+     Worker --------------------+
+ (execute . bench . test)
+   | completed      | denied -> Denied
+   v
+ Reviewer / judge  <-- suggestions (bounded loop) -- Worker
+ (checks code + metrics)
+   | merged (green)
+   v
+ Merged to main (auto-deploy follows)
+```
+
+## Locked decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Runtime | Symphony (`packages/symphony`) | Already a durable DAG runtime with Linear/GitHub/cron triggers, worktrees, dashboard. We write a pack, not a runtime. |
+| Target repo | `ix` (`indexable-inc/ix`) | Primary product; has a working bot-PR + auto-merge precedent. |
+| Merge policy | Auto-merge if green | Reuse the proven `ix-playbook-agent[bot]` path, generalized from playbook-only to code. |
+| First build | Full skeleton, thin | All five roles present end-to-end on one trivial issue, then deepen each. |
+| Loop model | All in one run | Per-issue pipeline = one Symphony run; Worker<->Reviewer is a bounded, unrolled `when`-cascade (NOT recursion - see below). Feeders are separate cron runs. |
+| Bot identity | Reuse `ix-playbook-agent` | Auto-merge infra already works; widen its scope. |
+
+## Two clocks
+
+1. **Continuous feeders** (Idea generator, Cleaner): `on cron` workflows. Each
+   run inspects ix + prior art, dedups against open AND closed Linear issues,
+   and creates at most one new issue tagged `factory:scope-needed`.
+2. **Per-issue pipeline** (Researcher -> Worker <-> Reviewer -> merge): one
+   Symphony run per issue, triggered `on linear { label: "factory:scope-needed" }`.
+   The Worker<->Reviewer correction loop is bounded recursion inside that run.
+
+Linear is the durable message bus. Labels are the wire (`on linear` triggers on
+a label, not a state). We keep human-readable workflow **states** in sync for
+the board, but the **label** is the machine trigger.
+
+### Label protocol (the wire)
+
+| Label | Set by | Triggers |
+|---|---|---|
+| `factory:scope-needed` | Idea gen / Cleaner | Researcher (pipeline run) |
+| `factory:ready-for-dev` | Researcher | Worker (within same run) |
+| `factory:in-review` | Worker (PR opened) | Reviewer (within same run) |
+| `factory:needs-human` | any role on cap/escalation | human |
+| `factory:denied` | Worker / Researcher | terminal |
+
+## Role -> skill mapping
+
+Each role is a Symphony **skill** (markdown + YAML frontmatter) invoked by an
+`agent` node. Every skill returns a **structured decision** (an enum + payload)
+as its final output so downstream `when` gates are deterministic.
+
+| Role | Engine/effort | Permissions | Key tools | Decision output |
+|---|---|---|---|---|
+| Idea generator | high | workspace read | exa/web, code read | `{created: bool, issue_id?}` |
+| Cleaner | medium | workspace read | code read, CI/log read | `{created: bool, issue_id?}` |
+| Researcher | high | workspace read | explore, deep-research, linear_graphql | `{decision: scoped\|rejected, plan, affected_crates, bench_cmd?}` |
+| Worker | high | workspace write | edit, bash, git worktree, gh | `{decision: completed\|denied\|delegate, pr_url?, new_issues?}` |
+| Reviewer/judge | high | workspace write | code review, bench, gh | `{decision: approved\|needs_changes, findings[], metrics?}` |
+
+## How loops work (Symphony is acyclic - this is the crux)
+
+Symphony has **no backward edges, ever**. There is no loop or recursion
+primitive. Loop-like behavior comes from two forward-only mechanisms:
+
+1. **Lazy gate re-expansion.** A `when ${x.flag} { ... }` emits a `:gate`
+   placeholder; when the gating agent output arrives, the `Materializer`
+   re-expands the AST and emits the body nodes then, with stable
+   content-derived ids (`interpreter.ex` `expand_effect :when`,
+   `materializer.ex` `expand_dynamic`). The graph grows forward; nothing
+   points back.
+2. **`subrun`** spawns a whole nested child run (a fresh DAG). It is NOT a
+   self-loop: `subrun_runner.ex` has a cycle guard that rejects any child
+   whose name is already on the ancestor chain (self-subrun is rejected
+   first) and a depth ceiling (`SYMPHONY_SUBRUN_MAX_DEPTH`, default 8). Use
+   it for distinct child workflows, never for the correction loop.
+
+### Bounded correction loop = unrolled `when`-cascade (one run)
+
+The tight Worker<->Reviewer loop is **statically unrolled** to `MAX_ROUNDS`
+nested `when` blocks. Later rounds only materialize if earlier reviews asked
+for changes, so we pay only for rounds we use. The nesting depth IS the cap -
+it cannot run away.
+
+```
+workflow "task-pipeline" on linear { label: "factory:ready-for-dev" } {
+  impl    <- agent { prompt: skill "worker" }
+  review1 <- agent { prompt: skill "reviewer"; inputs: { pr: impl.pr } }
+  r1 <- when ${review1.needs_changes} {
+    fix1    <- agent { prompt: skill "worker-fix"; inputs: { findings: review1.findings } }
+    review2 <- agent { prompt: skill "reviewer"; inputs: { pr: fix1.pr } }
+    r2 <- when ${review2.needs_changes} {
+      fix2    <- agent { prompt: skill "worker-fix"; inputs: { findings: review2.findings } }
+      review3 <- agent { prompt: skill "reviewer"; inputs: { pr: fix2.pr } }
+      r3 <- when ${review3.needs_changes} {
+        escalate <- agent { prompt: skill "escalate" }   # MAX_ROUNDS hit -> factory:needs-human
+      }
+    }
+  }
+}
+```
+
+`MAX_ROUNDS` (start at 4) is the convergence guarantee. Keep it DRY with a
+`_partials/review-round.md` template. Determinism holds: each round has
+distinct inputs, so distinct stable node ids.
+
+### Open-ended macro loops = cross-run re-triggering
+
+The genuinely open-ended arrows (Worker -> delegate back to Researcher,
+re-validation after new issues) are NOT one run. Each is a Linear **label
+flip that starts a fresh top-level run**. The loop counter lives in Linear (a
+round-count comment/field); each run reads it and bails to
+`factory:needs-human` past a threshold. Structurally unbounded, so the
+Linear-stored counter is the bound.
+
+## ix validation contract (what Worker/Reviewer must satisfy)
+
+- **Required check**: `build` = `scripts/ci/run-required-ci-checks.sh` -> `nix build .#required-ci-checks`.
+- **Inner-loop validation** (cheap): `nix build '.#affected { packages = [<changed crates>] }'` so the Worker does not pay the full 180-min gate on every iteration. Researcher declares `affected_crates`.
+- **Merge**: squash via merge queue (ALLGREEN). `main` push auto-deploys (`auto-deploy.yml`).
+- **Auto-merge guardrails** (inherit from playbook-agent): never touch `.github/**` or CODEOWNERS in an auto-mergeable PR; honor a `manual-merge` label as human override.
+- **Metrics**: ix has no standardized CI bench suite. The Researcher declares an optional `bench_cmd` per issue; Reviewer reports `metrics: n/a` when absent. (Do not block the skeleton on a metrics harness.)
+
+## Safety rails (non-negotiable)
+
+- Every loop has a hard depth/iteration cap + `factory:needs-human` escalation.
+- Per-issue token/time budget; exceed -> escalate.
+- Dedup at the source (Idea gen + Cleaner) against open and closed issues. Steal the pattern from ix's `antithesis-triage-linear` skill.
+- Atomic claim: Worker sets assignee + label, then re-reads to confirm it won (Symphony runs are parallel).
+- Auto-merge blast radius limited by the playbook guardrails above.
+- All nondeterminism lives in `agent` nodes; workflow topology and loop bounds are static.
+
+## Pack layout
+
+```
+packages/symphony/workflows/factory/
+  repositories.yaml          # primary: ix
+  workflows/
+    idea-generator.sym       # on cron
+    cleaner.sym              # on cron
+    task-pipeline.sym        # on linear { label: factory:ready-for-dev }; unrolled when-cascade
+  skills/
+    idea-generator.md
+    cleaner.md
+    researcher.md
+    worker.md
+    worker-fix.md
+    reviewer.md
+    escalate.md
+  _partials/
+    decision-contract.md     # shared "return this JSON shape" instructions
+    ix-validation.md         # shared validation commands
+```
+
+Point the runtime at it with `SYMPHONY_PACK_DIR=packages/symphony/workflows/factory`.
+
+## Thin-skeleton build sequence
+
+1. Scaffold the pack dir + `repositories.yaml` (ix) + shared partials.
+2. Write the five skill stubs with real envelopes and the decision contract.
+3. `task-pipeline.sym`: Researcher -> Worker -> `review-round` subrun -> squash-merge.
+4. `idea-generator.sym` + `cleaner.sym` cron stubs that each create one deduped issue.
+5. Wire triggers + reuse the playbook-agent bot for PR/auto-merge.
+6. Prove end-to-end on one trivial ix issue (idea -> issue -> scope -> tiny change -> PR -> green -> merge), then deepen each skill.
+
+## Open questions
+
+- `MAX_ROUNDS` and per-issue budget starting values (proposed: 4 rounds).
+- Cron cadence for feeders (proposed: idea gen daily, cleaner every few hours).
+- Whether Researcher auto-promotes to `ready-for-dev` or pauses for human sign-off on scope in v1.
+- RESOLVED: self-subrun is forbidden by the cycle guard; the loop is an unrolled `when`-cascade instead.

--- a/packages/symphony/workflows/factory/README.md
+++ b/packages/symphony/workflows/factory/README.md
@@ -1,0 +1,47 @@
+# factory pack
+
+Autonomous SDLC factory for **ix**, implementing [ENG-2921](https://linear.app/indexable/issue/ENG-2921/agent-workflow).
+Design doc: [`../../docs/factory-workflow.md`](../../docs/factory-workflow.md).
+
+Five agent roles + two continuous feeders take an idea to a green, auto-merged
+PR on `main`, with a bounded self-correction loop and human escape hatches.
+
+## Run it
+
+```sh
+SYMPHONY_PACK_DIR=packages/symphony/workflows/factory nix run .#symphony
+```
+
+Requires (see `.env.example`): `LINEAR_API_KEY` + `LINEAR_WEBHOOK_SECRET`
+(trigger + issue creation), GitHub App creds for the `ix-playbook-agent` bot
+(PRs + auto-merge), and an authenticated `codex` on PATH.
+
+## Shape
+
+- `workflows/idea-generator.sym` - cron (daily). Files one deduped idea issue.
+- `workflows/cleaner.sym` - cron (every 4h). Files one deduped cleanup issue.
+- `workflows/task-pipeline.sym` - `on linear label "factory:scope-needed"`.
+  Researcher -> Worker -> bounded review/fix cascade -> auto-merge. One run per
+  issue. The Worker<->Reviewer loop is an UNROLLED `when` cascade
+  (`MAX_ROUNDS = 3`) - Symphony is acyclic, so there is no recursion; the
+  nesting depth is the hard convergence cap.
+- `skills/*.md` - one per role, each returning a structured JSON decision that
+  the `when` gates read.
+- `_partials/` - shared `decision-contract` and `ix-validation` text.
+
+## Label protocol (the wire)
+
+| Label | Set by | Effect |
+|---|---|---|
+| `factory:scope-needed` | feeders / human | triggers `task-pipeline` |
+| `factory:in-review` | Worker (PR open) | marks issue under review |
+| `factory:needs-human` | escalate | human takeover |
+| `factory:denied` | Researcher / Worker | terminal reject |
+
+## Verify on first boot (runtime-dependent)
+
+- Agent final-message JSON is parsed into the fields `when ${node.field}` reads.
+- The Linear tool name (`linear_graphql`) and `web_search` match what the
+  engine exposes; adjust skill frontmatter `tools:` if not.
+- The reviewer's auto-merge action uses the existing `ix-playbook-agent` path;
+  that ix-side workflow may need its scope widened from playbook-only to code.

--- a/packages/symphony/workflows/factory/_partials/decision-contract.md
+++ b/packages/symphony/workflows/factory/_partials/decision-contract.md
@@ -1,0 +1,13 @@
+## Output contract
+
+End your turn by emitting EXACTLY ONE fenced JSON object as the final block of
+your message. Nothing after it. Downstream `when` gates read its fields, so the
+keys and types must match what your role declares. Booleans must be real JSON
+booleans, not strings.
+
+```json
+{ "decision": "<enum>", "...": "..." }
+```
+
+Do not invent fields. If a value is unknown, use `null`. If you cannot reach a
+decision, set the role's failure/escalation enum value rather than guessing.

--- a/packages/symphony/workflows/factory/_partials/ix-validation.md
+++ b/packages/symphony/workflows/factory/_partials/ix-validation.md
@@ -1,0 +1,16 @@
+## ix validation contract
+
+- Required CI check is **`build`** = `scripts/ci/run-required-ci-checks.sh`
+  (which runs `nix build .#required-ci-checks`). That is the only gate the merge
+  queue enforces.
+- In the inner edit loop, do NOT run the full gate every time - it is slow.
+  Validate only the crates you touched:
+  `nix build '.#affected { packages = [<changed crates>] }'`.
+  The scope/plan names the affected crates; trust it.
+- Merge strategy is **squash via the merge queue (ALLGREEN)**. A push to `main`
+  auto-deploys, so a red `build` after merge is a real incident - be confident
+  before you mark a PR mergeable.
+- Auto-merge guardrails (inherited from `ix-playbook-agent`): NEVER edit
+  `.github/**` or `CODEOWNERS` in an auto-mergeable PR, and honor a
+  `manual-merge` label as a human override - if present, stop and escalate.
+- House style: Conventional Commits for the PR title and commits.

--- a/packages/symphony/workflows/factory/repositories.yaml
+++ b/packages/symphony/workflows/factory/repositories.yaml
@@ -1,0 +1,5 @@
+repositories:
+  - name: ix
+    owner_repo: indexable-inc/ix
+    default_branch: main
+    primary: true

--- a/packages/symphony/workflows/factory/skills/cleaner.md
+++ b/packages/symphony/workflows/factory/skills/cleaner.md
@@ -1,0 +1,33 @@
+---
+description: Continuously scan ix for slop, flaky tests, CI failures, and latent bugs; file one cleanup issue per run, deduped.
+tools: [linear_graphql]
+---
+
+You are the Cleaner in an autonomous SDLC factory for the **ix** repo. You run
+continuously. Each run you find **one** concrete cleanup and file it.
+
+Hunt for (in priority order):
+1. Flaky or failing tests, broken/red CI signals.
+2. Latent bugs: unhandled error paths, TODO/FIXME that mask real issues,
+   panics, race-prone code.
+3. Slop: dead code, duplicated ownership, tangled fallback paths, complexity
+   that compensates for a missing invariant (the two-region simplification is a
+   north star - flag code that fights it).
+
+Steps:
+1. Inspect the workspace and any available CI/test signal. Pick the single
+   highest-value cleanup.
+2. **Dedup before filing.** Query Linear (open AND closed) via `linear_graphql`;
+   if it already exists, return `created: false` and stop.
+3. File a Linear issue with a precise problem statement, the exact
+   files/locations (`path:line`), and why it matters. Label it
+   `factory:scope-needed`. Keep scope small and self-contained - cleaners should
+   produce tractable issues, not epics.
+
+{{partial:decision-contract}}
+
+`decision` is one of: `created`, `skipped_duplicate`, `nothing_found`.
+
+```json
+{ "decision": "created", "issue_id": "ENG-1234", "title": "...", "locations": ["path:line"] }
+```

--- a/packages/symphony/workflows/factory/skills/escalate.md
+++ b/packages/symphony/workflows/factory/skills/escalate.md
@@ -1,0 +1,24 @@
+---
+description: Hand a stuck factory issue to a human with a clear summary of what was tried and why it is blocked.
+tools: [linear_graphql]
+---
+
+You are the escape hatch. The pipeline could not converge (e.g. the correction
+loop hit MAX_ROUNDS, `reason` is provided). Do NOT keep trying to fix it.
+
+Steps:
+1. Post a concise Linear comment: what the change was, what the Reviewer kept
+   flagging, what the Worker tried each round, and your best guess at the real
+   blocker.
+2. Label the issue `factory:needs-human` and assign it to the human owner
+   (resolve via the issue's existing assignee or the relevant code owner).
+3. Leave the PR open (do not merge, do not close) so the human can take over.
+
+Keep it short and high-signal - this is the message a human reads to decide what
+to do next.
+
+{{partial:decision-contract}}
+
+```json
+{ "decision": "escalated", "issue_id": "ENG-1234", "blocker": "…", "rounds_tried": 3 }
+```

--- a/packages/symphony/workflows/factory/skills/idea-generator.md
+++ b/packages/symphony/workflows/factory/skills/idea-generator.md
@@ -1,0 +1,34 @@
+---
+description: Propose one high-value improvement or feature idea for ix and file it as a Linear issue, deduped against existing work.
+tools: [linear_graphql, web_search]
+---
+
+You are the Idea Generator in an autonomous SDLC factory for the **ix** repo
+(custom rust-vmm VMM, ix-server RPC, two isolated regions, IPv6-as-identity).
+
+Goal: produce **one** concrete, valuable idea per run and file it as a Linear
+issue. Quality over quantity. One good idea beats three vague ones.
+
+Steps:
+1. Inspect the checked-out ix workspace. Look for: missing capabilities, rough
+   edges, places competitors/prior art do better. Use web search for prior art
+   and competitor features when it sharpens the idea.
+2. **Dedup before filing.** Query Linear for open AND closed issues with similar
+   titles/scope (use `linear_graphql`). If the idea already exists or was
+   already rejected, DO NOT file it - return `created: false` and stop.
+3. If it is genuinely new, create a Linear issue:
+   - Clear problem statement (what + why, from a user/system perspective).
+   - A short solution sketch.
+   - Label it `factory:scope-needed` (this is what triggers the pipeline).
+   - Team: Engineering. Priority: your best judgment.
+
+Be conservative: filing duplicate or low-value issues pollutes the board and is
+worse than filing nothing.
+
+{{partial:decision-contract}}
+
+`decision` is one of: `created`, `skipped_duplicate`, `skipped_low_value`.
+
+```json
+{ "decision": "created", "issue_id": "ENG-1234", "title": "...", "summary": "..." }
+```

--- a/packages/symphony/workflows/factory/skills/researcher.md
+++ b/packages/symphony/workflows/factory/skills/researcher.md
@@ -1,0 +1,43 @@
+---
+description: Deep-research a factory issue against the ix codebase, then either scope it into an actionable plan or reject it.
+tools: [linear_graphql]
+---
+
+You are the Researcher. A Linear issue (the trigger) is provided as input. Your
+job is to turn it into a precise, implementable scope - or to reject it.
+
+Steps:
+1. Read the triggering issue in full (`linear_graphql` by id if you need more).
+2. Investigate the ix codebase deeply: where the change lives, the relevant
+   invariants (architecture: one RPC through ix-server, two isolated regions,
+   direct VM data plane, IPv6-as-identity), prior art, and risks.
+3. Decide:
+   - **scoped**: it is worth doing and you understand it well enough to hand to
+     a Worker. Produce a plan.
+   - **rejected**: out of scope, wrong, already done, or not worth it. Say why.
+     Comment the rationale on the issue and label it `factory:denied`.
+
+A good plan contains: the problem restated, the concrete approach, the exact
+files/crates to change, acceptance criteria, an optional `bench_cmd` if there is
+a meaningful metric to measure, and the list of affected crates for narrowed
+validation.
+
+When you scope it, post the plan as a Linear comment and move the issue forward
+(remove `factory:scope-needed`, keep it assigned to the factory). Do NOT start
+implementing - that is the Worker's job.
+
+{{partial:ix-validation}}
+
+{{partial:decision-contract}}
+
+`scoped` is `true` only when `decision` == `scoped`.
+
+```json
+{
+  "decision": "scoped",
+  "scoped": true,
+  "plan": "…the implementable plan…",
+  "affected_crates": ["crates/ix/..."],
+  "bench_cmd": null
+}
+```

--- a/packages/symphony/workflows/factory/skills/reviewer.md
+++ b/packages/symphony/workflows/factory/skills/reviewer.md
@@ -1,0 +1,45 @@
+---
+description: Adversarially review an ix PR for correctness + metrics; approve and auto-merge when green, else return structured findings.
+tools: [linear_graphql]
+---
+
+You are the Reviewer / judge - the validation authority, not the Worker. An
+open PR (and the `round` number) is provided. Be skeptical: your default stance
+is that the change is wrong until it proves itself.
+
+Check, in order:
+1. **Correctness**: does it do what the issue asked? Edge cases, error paths,
+   the ix architecture invariants (one RPC through ix-server, two isolated
+   regions, direct VM data plane, IPv6-as-identity). Never proxy sessions
+   through ix-server.
+2. **CI gate**: is the required `build` check green / will it be? The merge
+   queue enforces only `build`; a red `build` on `main` auto-deploys and is an
+   incident. Be confident.
+3. **Metrics**: if the plan declared a `bench_cmd`, run it and compare; reject
+   on regression. If none, report `metrics: "n/a"` - do not block on missing
+   benchmarks.
+4. **Auto-merge safety**: refuse to approve if the PR edits `.github/**` or
+   `CODEOWNERS`, or if a `manual-merge` label is present - escalate instead.
+
+Decision:
+- **needs_changes**: emit specific, actionable findings (each with a location
+  and what would make it pass). This sends it back to the Worker (bounded loop).
+- **approved**: the change is correct and green. Mark the PR for auto-merge via
+  the `ix-playbook-agent` path (squash, merge queue), move the issue to done.
+
+Be decisive. Vague findings waste a whole correction round.
+
+{{partial:ix-validation}}
+
+{{partial:decision-contract}}
+
+`needs_changes` is `true` only when `decision` == `needs_changes`.
+
+```json
+{
+  "decision": "needs_changes",
+  "needs_changes": true,
+  "findings": [{ "id": "f1", "location": "path:line", "problem": "…", "fix": "…" }],
+  "metrics": "n/a"
+}
+```

--- a/packages/symphony/workflows/factory/skills/worker-fix.md
+++ b/packages/symphony/workflows/factory/skills/worker-fix.md
@@ -1,0 +1,31 @@
+---
+description: Apply Reviewer findings to an open ix PR in a tight correction loop - or push back if a finding is wrong.
+tools: [linear_graphql]
+---
+
+You are the Worker in the correction loop. An open PR and the Reviewer's
+`findings` are provided. Address them on the same branch.
+
+Steps:
+1. Read each finding. You are NOT obligated to blindly obey - if a finding is
+   wrong or out of scope, push back: leave a PR comment explaining why and do
+   not make that change. The Reviewer will reconcile next round.
+2. For valid findings, fix them on the existing branch with focused commits.
+3. **Re-validate** with the narrowed affected-crate gate before handing back.
+4. Push. Keep the PR description current.
+
+Do not open a new PR or branch - keep working the existing one. Do not widen
+scope; new problems become new issues, not changes to this PR.
+
+{{partial:ix-validation}}
+
+{{partial:decision-contract}}
+
+```json
+{
+  "decision": "fixed",
+  "pr": "https://github.com/indexable-inc/ix/pull/123",
+  "addressed": ["finding-id…"],
+  "rejected": [{ "finding": "…", "why": "…" }]
+}
+```

--- a/packages/symphony/workflows/factory/skills/worker.md
+++ b/packages/symphony/workflows/factory/skills/worker.md
@@ -1,0 +1,41 @@
+---
+description: Implement a scoped plan on a branch in ix, self-validate, and open a PR - or deny / delegate back to research.
+tools: [linear_graphql]
+---
+
+You are the Worker. You are handed a scoped `plan` (and `affected` crates) and
+run inside a per-run git worktree on the ix repo. Implement it end-to-end.
+
+Steps:
+1. Read the `plan`. If you disagree with it (wrong, unsafe, or it needs more
+   research), you are allowed to **deny** or **delegate** - do not build
+   something you think is wrong. Comment your reasoning on the issue.
+   - deny -> label `factory:denied`.
+   - delegate -> label `factory:scope-needed` again with a comment on what the
+     Researcher must resolve.
+2. Otherwise implement on a branch named `factory/eng-<issue-number>`.
+   Conventional Commits. Keep the change matched to the plan's scope.
+3. **Self-validate** before opening the PR: run the narrowed affected-crate gate
+   (see validation contract). Fix what you broke. Do not open a PR that you have
+   not validated locally.
+4. Open a PR authored by the `ix-playbook-agent` bot identity. Title in
+   Conventional Commits style; body links the issue and summarizes the change.
+   Apply the `factory:in-review` label to the issue.
+5. If implementation surfaces NEW, separate problems, file them as their own
+   Linear issues labelled `factory:scope-needed` (do not scope-creep this PR).
+
+{{partial:ix-validation}}
+
+{{partial:decision-contract}}
+
+`completed` is `true` only when `decision` == `completed` and a PR is open.
+
+```json
+{
+  "decision": "completed",
+  "completed": true,
+  "pr": "https://github.com/indexable-inc/ix/pull/123",
+  "branch": "factory/eng-1234",
+  "new_issues": []
+}
+```

--- a/packages/symphony/workflows/factory/workflows/cleaner.sym
+++ b/packages/symphony/workflows/factory/workflows/cleaner.sym
@@ -1,0 +1,12 @@
+# Continuous feeder: scans ix for slop / flaky tests / CI failures / latent
+# bugs and files ONE cleanup issue per run, labelled `factory:scope-needed`.
+# Runs every 4 hours, off the :00 mark. Dedups against existing issues.
+workflow "cleaner" on cron "23 */4 * * *" tz "UTC" {
+  sweep <- agent {
+    engine: codex
+    model: "gpt-5.3-codex"
+    effort: medium
+    permissions: read_only
+    prompt: skill "cleaner"
+  }
+}

--- a/packages/symphony/workflows/factory/workflows/idea-generator.sym
+++ b/packages/symphony/workflows/factory/workflows/idea-generator.sym
@@ -1,0 +1,12 @@
+# Continuous feeder: proposes ONE improvement/feature idea per run and files it
+# as a Linear issue labelled `factory:scope-needed` (which triggers
+# task-pipeline). Daily, off the :00 mark. Dedups against existing issues.
+workflow "idea-generator" on cron "17 9 * * *" tz "UTC" {
+  idea <- agent {
+    engine: codex
+    model: "gpt-5.3-codex"
+    effort: high
+    permissions: read_only
+    prompt: skill "idea-generator"
+  }
+}

--- a/packages/symphony/workflows/factory/workflows/task-pipeline.sym
+++ b/packages/symphony/workflows/factory/workflows/task-pipeline.sym
@@ -1,0 +1,93 @@
+# Per-issue pipeline: scope -> implement -> bounded review/fix cascade -> merge.
+# Triggered when a factory issue is ready (Idea generator / Cleaner / a human
+# apply the `factory:scope-needed` label). The whole loop runs in ONE Symphony
+# run.
+#
+# Symphony is acyclic and a `when` body holds exactly ONE statement, so the
+# Worker<->Reviewer correction loop is UNROLLED as a FLAT chain of individually
+# gated steps. Ordering is enforced by data dependencies (each step reads the
+# previous step's output), not by nesting. MAX_ROUNDS = 3 (review1/2/3) is the
+# hard convergence cap: there is no review4, so it cannot run away.
+workflow "task-pipeline" on linear label "factory:scope-needed" {
+  # Researcher: deep research + scope, or reject.
+  scope <- agent {
+    engine: codex
+    model: "gpt-5.3-codex"
+    effort: high
+    permissions: read_only
+    prompt: skill "researcher"
+  }
+
+  # Worker: implement the scoped plan on a branch and open a PR (only if scoped).
+  impl <- when ${scope.scoped} {
+    agent {
+      engine: codex
+      model: "gpt-5.3-codex"
+      effort: high
+      permissions: workspace_write
+      prompt: skill "worker" { plan: ${scope.plan}, affected: ${scope.affected_crates} }
+    }
+  }
+
+  # Review round 1 (only if the Worker completed and opened a PR).
+  review1 <- when ${impl.completed} {
+    agent {
+      engine: codex
+      model: "gpt-5.3-codex"
+      effort: high
+      permissions: workspace_write
+      prompt: skill "reviewer" { pr: ${impl.pr}, round: "1" }
+    }
+  }
+
+  # Round 2: fix + re-review, only if round 1 asked for changes.
+  fix1 <- when ${review1.needs_changes} {
+    agent {
+      engine: codex
+      model: "gpt-5.3-codex"
+      effort: high
+      permissions: workspace_write
+      prompt: skill "worker-fix" { pr: ${impl.pr}, findings: ${review1.findings} }
+    }
+  }
+  review2 <- when ${review1.needs_changes} {
+    agent {
+      engine: codex
+      model: "gpt-5.3-codex"
+      effort: high
+      permissions: workspace_write
+      prompt: skill "reviewer" { pr: ${fix1.pr}, round: "2" }
+    }
+  }
+
+  # Round 3 (final): fix + re-review, only if round 2 still wants changes.
+  fix2 <- when ${review2.needs_changes} {
+    agent {
+      engine: codex
+      model: "gpt-5.3-codex"
+      effort: high
+      permissions: workspace_write
+      prompt: skill "worker-fix" { pr: ${impl.pr}, findings: ${review2.findings} }
+    }
+  }
+  review3 <- when ${review2.needs_changes} {
+    agent {
+      engine: codex
+      model: "gpt-5.3-codex"
+      effort: high
+      permissions: workspace_write
+      prompt: skill "reviewer" { pr: ${fix2.pr}, round: "3" }
+    }
+  }
+
+  # MAX_ROUNDS hit and still not green -> hand to a human.
+  escalate <- when ${review3.needs_changes} {
+    agent {
+      engine: codex
+      model: "gpt-5.3-codex"
+      effort: medium
+      permissions: read_only
+      prompt: skill "escalate" { reason: "max-review-rounds" }
+    }
+  }
+}


### PR DESCRIPTION
## What

A Symphony pack implementing the autonomous agent workflow from [ENG-2921](https://linear.app/indexable/issue/ENG-2921/agent-workflow): five agent roles plus an escalate escape hatch that take an idea from conception to a green, auto-merged PR on **ix**.

```
Idea generator / Cleaner  --(factory:scope-needed)-->  Researcher -> Worker <-> Reviewer -> merge
        (cron feeders)                                        (one Symphony run per issue)
```

## How it works

- **Two cron feeders** (`idea-generator`, `cleaner`) scan ix + prior art and file **deduped** Linear issues labelled `factory:scope-needed`.
- **`task-pipeline`** triggers per issue on that label: Researcher scopes -> Worker implements on a branch + opens a PR -> bounded Reviewer/Worker correction loop -> auto-merge when `build` is green.
- **Loops on an acyclic runtime:** Symphony has no backward edges and a `when` body holds exactly one statement, so the Worker<->Reviewer loop is an **unrolled, flat `when`-cascade** ordered by data deps. `MAX_ROUNDS = 3` is a structural convergence cap (no `review4` exists). Open-ended macro arrows are cross-run via Linear labels.
- **Merge** reuses the existing `ix-playbook-agent` bot path (squash via merge queue; `main` auto-deploys), inheriting its `.github/**`/CODEOWNERS guardrails.

## Validation

All three `.sym` were run through the real parser + interpreter + materializer (pure Elixir, no hex deps):

| file | result |
|---|---|
| `cleaner.sym` | OK - 1 agent node |
| `idea-generator.sym` | OK - 1 agent node |
| `task-pipeline.sym` | OK - 8 nodes (1 agent + 7 lazy gates) |

The `1 agent + 7 gates` shape confirms the lazy forward cascade and that envelope validation passes.

## Scope / notes

- **No symphony runtime changes** - pure pack + config. Activate with `SYMPHONY_PACK_DIR=packages/symphony/workflows/factory`.
- Design doc: `packages/symphony/docs/factory-workflow.md`.
- Verify on first boot (documented in the pack README): agent JSON output parsing into `${node.field}`, tool names (`linear_graphql`, `web_search`), and widening the ix-side `ix-playbook-agent` auto-merge scope from playbook-only to code.

Closes ENG-2921.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add autonomous SDLC factory Symphony workflow pack for ix
> - Adds a new Symphony pack under [`packages/symphony/workflows/factory/`](https://github.com/indexable-inc/index/pull/1127/files#diff-e88c3e12779d5721128ef138a83120e7fa5c4cefaa9fa224ab0f64370e16d831) that implements a fully autonomous software development lifecycle for the `indexable-inc/ix` repository.
> - Defines six agent skill specs ([researcher](https://github.com/indexable-inc/index/pull/1127/files#diff-0c6e1b8a749d1af987c5e99ac6b2bfb78b6eb6015d976a27af321ae952491256), [worker](https://github.com/indexable-inc/index/pull/1127/files#diff-9339fbfc67f2539856b627e7507592eb1494031de875f338fa50bfdf87dd51b8), [reviewer](https://github.com/indexable-inc/index/pull/1127/files#diff-adf574bd1852e22499c6f61156f1755ed820d737e3fd0339fac1f438df241bfb), [worker-fix](https://github.com/indexable-inc/index/pull/1127/files#diff-9a33a1e9974007b15fde73667b96c6eb83715b8adc7e489f88e5f50f518c7307), [escalate](https://github.com/indexable-inc/index/pull/1127/files#diff-2fb2167f61f56788e2973a735c08299f066deed5028403fad23c86532d0d0889), [cleaner](https://github.com/indexable-inc/index/pull/1127/files#diff-9cbc9335d8b2c6818712f039a8c50d783e0aa412b2e09839ffc20542f708c17b), [idea-generator](https://github.com/indexable-inc/index/pull/1127/files#diff-b3a2318119768a79b4111cb9e2f2e1041061eacdd10d9537e445ad94185f2157)) each with structured JSON output contracts.
> - [`task-pipeline.sym`](https://github.com/indexable-inc/index/pull/1127/files#diff-32cbe7f6bd3b2f74e77f1352a2df0ff72ef188bb01a1bcb12e21b16cded50873) triggers on the `factory:scope-needed` Linear label and runs a gated scope → implement → review pipeline with a bounded 3-round reviewer/worker-fix correction loop and an escalation path on failure.
> - [`idea-generator.sym`](https://github.com/indexable-inc/index/pull/1127/files#diff-758bdb402b6a94ad356e02d6f193cbc4cb266a893016a294e9a0974a5006d8f2) runs daily and [`cleaner.sym`](https://github.com/indexable-inc/index/pull/1127/files#diff-59bc57c7715920deb68d919d685b5eea3f8460f723ae89a0031d2c7ff369e902) runs every 4 hours to file deduplicated idea and cleanup issues respectively.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a478e81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->