### PR TITLE
feat(astlog-rules): adopt ix's three Nix lint rules into the shared ruleset

### DIFF
--- a/astlog-rules/nix.astlog
+++ b/astlog-rules/nix.astlog
@@ -1010,10 +1010,10 @@
     (apply_expression
       function: (apply_expression
         function: (apply_expression
-          function: (select_expression) @f
+          function: [(variable_expression) (select_expression)] @f
           argument: (_))
         argument: (attrset_expression) @attrs)) @n")
-  (text f "pkgs.runCommand")
+  (text-match f "^(pkgs\\.)?runCommand$")
   (text-match attrs "^\\{\\s*\\}$"))
 (lint runcommand-missing-structured-attrs warning
   "runCommand with empty attrs {{}}; add {{ __structuredAttrs = true; }} for consistent derivation behavior")

--- a/astlog-rules/nix.astlog
+++ b/astlog-rules/nix.astlog
@@ -33,6 +33,20 @@
 (lint no-abort error
   "`abort` is a hard abort with no recovery; use `throw` (catchable) or `lib.assertMsg` (typed assertion) instead")
 
+;; no-allow-builtin-fetch-git: `allowBuiltinFetchGit = true` lets
+;; `builtins.fetchGit` run while Nix evaluates the package, so ordinary NixOS
+;; evaluation can hit the network and block on Git clones. Pin each Cargo git
+;; dependency under `rustPlatform.importCargoLock` `outputHashes` instead.
+(rule (no-allow-builtin-fetch-git n)
+  (match nix "
+    (binding
+      attrpath: (attrpath) @p
+      expression: (variable_expression) @v) @n")
+  (text p "allowBuiltinFetchGit")
+  (text v "true"))
+(lint no-allow-builtin-fetch-git error
+  "allowBuiltinFetchGit fetches Cargo git dependencies during evaluation; pin rustPlatform.importCargoLock outputHashes instead")
+
 ;; no-ambiguous-gpl-license: Ambiguous GPL/AGPL/LGPL license identifier. Use
 ;; the `-Only` / `-Plus` flavor: `gpl2Only`, `gpl3Plus`, `agpl3Only`, etc.
 (rule (no-ambiguous-gpl-license n)
@@ -423,6 +437,22 @@
   (text-match v "^(true|false)$"))
 (lint no-negate-bool-literal error
   "`!true` / `!false` is the opposite literal; use the literal directly")
+
+;; no-nix-in-generated-shell: a `writeShellApplication` whose body shells out to
+;; `nix run/build/flake check` hides dependencies from the evaluator and cache,
+;; repeats evaluation, and moves failures into runtime logs. Pass realized store
+;; paths into the script, or move orchestration into the outer workflow. Largely
+;; subsumed by `no-write-shell-application` (writeShellApplication is banned
+;; outright), but kept as a distinct rule for any suppressed use.
+(rule (no-nix-in-generated-shell n)
+  (match nix "
+    (apply_expression
+      function: [(variable_expression) (select_expression)] @f
+      argument: (attrset_expression) @attrs) @n")
+  (text-match f "^(pkgs\\.)?writeShellApplication$")
+  (text-match attrs "\\bnix (run|build|flake check)\\b"))
+(lint no-nix-in-generated-shell error
+  "Nix-generated shell applications must not call nix again; pass realized store paths into the script instead")
 
 ;; no-nixpkgs-channel-ref: '<nixpkgs>' channel reference is banned. Use flake
 ;; inputs.
@@ -969,3 +999,21 @@
   (text-match p "^(sha256|[a-zA-Z][a-zA-Z0-9]*Sha256)$"))
 (lint prefer-sri-hash error
   "legacy `sha256`-flavored hash attr; use the SRI `hash` slot: `hash` in fetchers, `cargoHash` / `vendorHash` / `npmDepsHash` in the language builders (or the typed `cargoLock` block for Rust)")
+
+;; runcommand-missing-structured-attrs: `pkgs.runCommand name {} body` passes an
+;; empty attrset, so the derivation gets no `__structuredAttrs = true`. Add
+;; `{ __structuredAttrs = true; }` for consistent derivation behavior (attrs
+;; passed as JSON: no env-var length limits, preserved list/nested types).
+;; Warning severity: a large pre-existing tail still carries `{}`.
+(rule (runcommand-missing-structured-attrs n)
+  (match nix "
+    (apply_expression
+      function: (apply_expression
+        function: (apply_expression
+          function: (select_expression) @f
+          argument: (_))
+        argument: (attrset_expression) @attrs)) @n")
+  (text f "pkgs.runCommand")
+  (text-match attrs "^\\{\\s*\\}$"))
+(lint runcommand-missing-structured-attrs warning
+  "runCommand with empty attrs {{}}; add {{ __structuredAttrs = true; }} for consistent derivation behavior")

--- a/astlog-rules/nix.astlog
+++ b/astlog-rules/nix.astlog
@@ -42,7 +42,7 @@
     (binding
       attrpath: (attrpath) @p
       expression: (variable_expression) @v) @n")
-  (text p "allowBuiltinFetchGit")
+  (text-match p "(^|\\.)allowBuiltinFetchGit$")
   (text v "true"))
 (lint no-allow-builtin-fetch-git error
   "allowBuiltinFetchGit fetches Cargo git dependencies during evaluation; pin rustPlatform.importCargoLock outputHashes instead")

--- a/astlog-rules/tests/no-allow-builtin-fetch-git/bad.fixture
+++ b/astlog-rules/tests/no-allow-builtin-fetch-git/bad.fixture
@@ -1,0 +1,4 @@
+{
+  cargoLock.lockFile = ./Cargo.lock;
+  allowBuiltinFetchGit = true;
+}

--- a/astlog-rules/tests/no-allow-builtin-fetch-git/good.fixture
+++ b/astlog-rules/tests/no-allow-builtin-fetch-git/good.fixture
@@ -1,0 +1,6 @@
+{
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+    outputHashes = { };
+  };
+}

--- a/astlog-rules/tests/no-nix-in-generated-shell/bad.fixture
+++ b/astlog-rules/tests/no-nix-in-generated-shell/bad.fixture
@@ -1,0 +1,6 @@
+pkgs.writeShellApplication {
+  name = "deploy";
+  text = ''
+    nix build .#thing
+  '';
+}

--- a/astlog-rules/tests/no-nix-in-generated-shell/good.fixture
+++ b/astlog-rules/tests/no-nix-in-generated-shell/good.fixture
@@ -1,0 +1,6 @@
+pkgs.writeShellApplication {
+  name = "deploy";
+  text = ''
+    ${thing}/bin/thing run
+  '';
+}

--- a/astlog-rules/tests/runcommand-missing-structured-attrs/bad.fixture
+++ b/astlog-rules/tests/runcommand-missing-structured-attrs/bad.fixture
@@ -1,0 +1,3 @@
+pkgs.runCommand "demo" { } ''
+  mkdir -p "$out"
+''

--- a/astlog-rules/tests/runcommand-missing-structured-attrs/good.fixture
+++ b/astlog-rules/tests/runcommand-missing-structured-attrs/good.fixture
@@ -1,0 +1,3 @@
+pkgs.runCommand "demo" { __structuredAttrs = true; } ''
+  mkdir -p "$out"
+''


### PR DESCRIPTION
## What

Make index's `astlog-rules/nix.astlog` the **absolute source of truth** for the Nix house-style lint shared with the **ix** monorepo. ix is migrating off its divergent ast-grep ruleset (62 YAML rules in `lints/`) to consume *this* file by reference, so the two repos converge on one ruleset and one engine.

This adds the three rules ix enforced that index did not yet have:

| rule | severity | what |
|---|---|---|
| `no-allow-builtin-fetch-git` | error | `allowBuiltinFetchGit = true` runs `builtins.fetchGit` during eval; pin `importCargoLock` `outputHashes` instead |
| `no-nix-in-generated-shell` | error | a `writeShellApplication` whose body shells out to `nix run/build/flake check` (largely subsumed by the existing `no-write-shell-application` ban, kept distinct for suppressed uses) |
| `runcommand-missing-structured-attrs` | warning | `runCommand name {} body` with an empty attrset; add `{ __structuredAttrs = true; }` |

Each rule ships a `good.fixture` / `bad.fixture` pair, so the existing `astlog-rules` flake check proves it fires on the violating snippet and stays silent on the valid one.

## Impact on index's own tree

Measured with `astlog scan` over index's tracked `.nix` files:

- `no-allow-builtin-fetch-git`: 0 findings
- `no-nix-in-generated-shell`: 0 findings (index already bans `writeShellApplication`)
- `runcommand-missing-structured-attrs`: 26 findings, all **warning** severity (non-blocking)

So `nix run .#lint` stays green; no source cleanup is required to land this.

## Verification

```
nix build .#checks.x86_64-linux.astlog-rules   # passes (3 new fixtures fire correctly)
```

---

This is the index half of a two-repo change; the ix half rewires its lint gate to scan against `astlog-rules/nix.astlog` from this flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Opened by an AI agent (Claude Code, model: Claude Opus 4.8) on behalf of @wyattjsmith._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add three Nix lint rules to the shared astlog ruleset
> - Adds `no-allow-builtin-fetch-git`: errors when `allowBuiltinFetchGit = true` is found in a binding, guiding users to pin `rustPlatform.importCargoLock` output hashes instead.
> - Adds `no-nix-in-generated-shell`: errors when `pkgs.writeShellApplication` shell text invokes `nix run`, `nix build`, or `nix flake check`, recommending realized store paths instead.
> - Adds `runcommand-missing-structured-attrs`: warns when `pkgs.runCommand` is called with an empty attrset, recommending `__structuredAttrs = true`.
> - Each rule ships with `bad` and `good` fixture files under [astlog-rules/tests/](https://github.com/indexable-inc/index/pull/1128/files#diff-9f230b62ab657270b48b2751892f65e386a5f04fe8de4368ff4acd0299a64aba).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7dccc47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->