### PR TITLE
feat(astlog): expose astlog-scan as a packageable Nix lint wrapper

### DIFF
--- a/packages/astlog/scan/default.nix
+++ b/packages/astlog/scan/default.nix
@@ -1,0 +1,42 @@
+# `astlog-scan`: turnkey Nix lint gate for downstream consumers.
+#
+# Bundles the `astlog` binary with the in-repo `astlog-rules/nix.astlog`
+# ruleset so a downstream flake (ix and others) can drop a single command
+# into a pre-commit hook or dev shell without re-deriving the rules path or
+# threading wrappers through its own per-system layer. Discovers `.nix`
+# files in the caller's working directory with `fd` and shells out to
+# `astlog scan`; the binary's exit code is the gate.
+#
+# Index's own `lib/per-system.nix` keeps using `lintStage` for the
+# four-stage local lint run (nixfmt | statix | deadnix | astlog | astlog-rust);
+# this package is the externally consumable surface.
+{
+  writeNushellApplication,
+  repoPackages,
+  fd,
+  git,
+}:
+let
+  rules = ../../../astlog-rules/nix.astlog;
+in
+writeNushellApplication {
+  name = "astlog-scan";
+  runtimeInputs = [
+    repoPackages.astlog
+    fd
+    git
+  ];
+  meta = {
+    description = "Scan a Nix tree with the index-owned astlog Nix lint rules";
+    mainProgram = "astlog-scan";
+  };
+  text = ''
+    def main [] {
+      let repo_root = (^git rev-parse --show-toplevel | str trim)
+      cd $repo_root
+      let nix_files = (^fd --hidden --extension nix --type file | lines)
+      if ($nix_files | is-empty) { return }
+      ^astlog scan ${rules} ...$nix_files
+    }
+  '';
+}

--- a/packages/astlog/scan/package.nix
+++ b/packages/astlog/scan/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "astlog-scan";
+  packageSet = true;
+  flake = true;
+}


### PR DESCRIPTION
## Summary

- New `packages/astlog/scan/` exposes `packages.<system>.astlog-scan`: a `writeNushellApplication` that bundles the `astlog` binary with the in-repo `astlog-rules/nix.astlog` ruleset. Discovers `.nix` files in the caller's repo with `fd` and shells to `astlog scan`.
- Lets downstream flakes (ix today, others later) point a pre-commit hook at one command without re-deriving the rules path or threading a custom per-system wrapper on their side. Lands as the externally-consumable counterpart to the existing `lintStage` nushell function in `lib/per-system.nix` (which keeps driving index's own four-stage local lint).

## Why

ix's current swap (https://github.com/indexable-inc/ix/pull/4986, landed as `dd6bbd76`) had to invent its own `astlog-scan` wrapper because index only published the bare `astlog` binary. Pushing the wrapper here means index owns the full ruleset + invocation surface — true SSOT — and ix can shrink down to a one-line overlay reference.

## Test plan

- [x] `nix build .#astlog-scan` on hari-compute-1
- [x] running the wrapper inside this checkout returns the expected `runcommand-missing-structured-attrs` warnings on `tests/default.nix` and `tests/portable-services.nix`, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `astlog-scan` as a packageable Nix lint wrapper
> Adds a new Nushell-based `astlog-scan` command in [packages/astlog/scan/](https://github.com/indexable-inc/index/pull/1132/files#diff-a499bfdc27318c9ad8575fe78b9c48fa7a608c39d0fe56a3c94af0fa34ab2a08) that runs `astlog scan` against all `.nix` files in a repository. The script resolves the Git repo root, discovers `.nix` files (including hidden) via `fd`, exits early if none are found, and otherwise invokes `astlog scan` with the bundled in-repo rules file. A [package.nix](https://github.com/indexable-inc/index/pull/1132/files#diff-7b228f021d978eedd1552709d04264e4768c459ef476a1f336ad9109a74517b2) descriptor marks it as a flake-exposed package set entry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce03016.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->