### PR TITLE
users/andrewgazelka: add cloudflare-warp + mullvad-vpn casks

### DIFF
--- a/users/andrewgazelka/darwin.nix
+++ b/users/andrewgazelka/darwin.nix
@@ -22,6 +22,10 @@
       "chatgpt"
       "chatgpt-atlas"
       "claude"
+      # Cloudflare WARP: tunnels IPv4+IPv6 to Cloudflare, so an IPv6-only or
+      # broken-IPv4 network (e.g. hotel wifi with dead DHCPv4) can still reach
+      # IPv4-only hosts like github and Apple's APNs. Needs UDP egress to work.
+      "cloudflare-warp"
       "codex-app"
       "contexts"
       "cursor"

--- a/users/andrewgazelka/darwin.nix
+++ b/users/andrewgazelka/darwin.nix
@@ -35,6 +35,7 @@
       "helium-browser"
       "linear"
       "lm-studio"
+      "mullvad-vpn"
       "notion"
       "obs"
       "obsidian"


### PR DESCRIPTION
Adds two VPN casks to the personal package set.

- **cloudflare-warp** — tunnels IPv4+IPv6 to Cloudflare; useful when a network's IPv4 is broken but UDP egress is allowed.
- **mullvad-vpn** — general-purpose VPN.

Caveat learned in practice: neither helps on an IPv6-only *and* UDP-blocked network (e.g. some hotel wifi) — WARP is UDP-only on both transports, and Mullvad's infra (cdn/api/relays) is IPv4-only with no AAAA. Tailscale (DERP over TCP/443, dual-stack) is the tool that works there.

(sent by an AI agent via Claude Code, model Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `cloudflare-warp` and `mullvad-vpn` casks to andrewgazelka's Darwin config
> Adds `cloudflare-warp` and `mullvad-vpn` to the casks list in [darwin.nix](https://github.com/indexable-inc/index/pull/1133/files#diff-8e50939d75ca47b003564ea6eb7afcd3cd3ab9bfa6b8876d3c079c94862fb7bc), along with comments describing `cloudflare-warp`'s purpose and network requirements.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69cf354.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->