### PR TITLE
style(lib): use inherit for ruffAnnArgs (fix statix, unblock merge queue)

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -42,7 +42,7 @@ let
   # Shared ruff selector (ANN explicit-annotations + TID251 no-typing.cast),
   # imported once here and injected into every Python build gate so the policy
   # has a single source of truth. See lib/build/ruff-ann.nix.
-  ruffAnnArgs = (import ./build/ruff-ann.nix { inherit lib; }).ruffAnnArgs;
+  inherit (import ./build/ruff-ann.nix { inherit lib; }) ruffAnnArgs;
 
   inherit (import ./util/writers.nix { inherit lib ruffAnnArgs; })
     writePythonApplication


### PR DESCRIPTION
One-line statix fix. `lib/default.nix:45` used `ruffAnnArgs = (import ./build/ruff-ann.nix { inherit lib; }).ruffAnnArgs;`, which statix flags ("assignment is better written with inherit"); this fails the merge-queue `flake-check` lint and is **currently blocking all merges to main**. Rewritten to the equivalent `inherit (…) ruffAnnArgs;` form. No behavior change.

---
🤖 Authored by Claude (Opus 4.8) via Claude Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ruffAnnArgs` binding in `lib/default.nix` to use `inherit` syntax
> Replaces explicit attribute access with `inherit`-from-set syntax when binding `ruffAnnArgs` from `./build/ruff-ann.nix` in [lib/default.nix](https://github.com/indexable-inc/index/pull/1141/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188). This fixes a statix lint violation that was blocking the merge queue.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 469bc8e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->