### PR TITLE
astlog: stratified negation; make Elixir type-gate sound

### DIFF
--- a/astlog-rules/elixir.astlog
+++ b/astlog-rules/elixir.astlog
@@ -29,62 +29,88 @@
   (match elixir "(unary_operator (call (identifier) @kw (arguments (binary_operator left: (call (identifier) @n))))) @s")
   (text kw "spec"))
 
-;; --- defstruct-needs-type: a struct module must declare a @type ---
-;; Matches the actual `@type`/`@typep`/`@opaque` attribute (a `@` unary_operator
-;; over a call to `type`/...), not merely any identifier with text `type`.
+;; The actual `@type`/`@typep`/`@opaque` attribute (a `@` unary_operator over a
+;; call to `type`/...), not merely any identifier with text `type`.
 (rule (type-attr a)
   (match elixir "(unary_operator (call (identifier) @ti)) @a")
   (text-match ti "^(type|typep|opaque)$"))
 (rule (defstruct-call c)
   (match elixir "(call (identifier) @i) @c")
   (text i "defstruct"))
+
+;; --- nearest enclosing module ---
+;; A spec/impl/struct/type belongs to its NEAREST enclosing `defmodule`, not every
+;; ancestor module: otherwise a nested module's `@spec foo` would also count for
+;; the outer module and wrongly exempt an unspec'd `Outer.foo`. `nearest-mod x m`
+;; holds when `m` is a defmodule ancestor of `x` with no defmodule between them.
+(rule (mod-candidate x)
+  (def-name x n))
+(rule (mod-candidate x)
+  (spec-name x n))
+(rule (mod-candidate x)
+  (defstruct-call x))
+(rule (mod-candidate x)
+  (type-attr x))
+;; `m` is an ancestor module of `x` but a closer module `mid` sits in between.
+(rule (mod-shadowed x m)
+  (mod-candidate x)
+  (defmodule m)
+  (ancestor m x)
+  (defmodule mid)
+  (ancestor m mid)
+  (ancestor mid x))
+(rule (nearest-mod x m)
+  (mod-candidate x)
+  (defmodule m)
+  (ancestor m x)
+  (not (mod-shadowed x m)))
+
+;; --- defstruct-needs-type: a struct module must declare a @type ---
 (rule (module-has-type m)
   (type-attr a)
-  (defmodule m)
-  (ancestor m a))
-(rule (defstruct-needs-type m)
-  (defmodule m)
+  (nearest-mod a m))
+(rule (module-has-struct m)
   (defstruct-call c)
-  (ancestor m c)
+  (nearest-mod c m))
+(rule (defstruct-needs-type m)
+  (module-has-struct m)
   (not (module-has-type m)))
 (lint defstruct-needs-type error
   "module defines a struct but no @type; add a `@type t` for it so the 1.18 type checker can type its fields")
 
 ;; --- public-def-needs-spec: a public def needs a @spec (or @impl) ---
-;; A def is flagged unless its module has a @spec, or an @impl-annotated def, with
-;; the SAME function name. Name-matching makes one `@spec`/`@impl` cover every
-;; clause of a multi-clause function, and prevents a spec for a different function
-;; from exempting an unspec'd def. Behaviour callbacks are exempt via @impl.
+;; A def is flagged unless its nearest module has a @spec, or an @impl-annotated
+;; def, with the SAME function name. Name-matching makes one `@spec`/`@impl` cover
+;; every clause of a multi-clause function, and prevents a spec for a different
+;; function from exempting an unspec'd def. Behaviour callbacks are exempt via
+;; @impl.
 ;;
 ;; Residual: matching is by name, not name+arity (astlog has no aggregation to
 ;; count arguments), so `@spec foo/1` also exempts `def foo/2`. Rare, and the real
 ;; type gate -- `mix compile --warnings-as-errors` -- is unaffected.
 
-;; module m contains a @spec for the function named t.
+;; module m directly contains a @spec for the function named t.
 (rule (spec-in-module m t)
   (spec-name s n)
   (text n t)
-  (defmodule m)
-  (ancestor m s))
+  (nearest-mod s m))
 
 ;; a def whose annotation block carries an `@impl` (a behaviour callback).
 (rule (impl-def d)
   (def-name d n)
   (attached-sibling d "identifier" "impl"))
 
-;; module m contains an @impl-annotated def named t (so every t clause is a callback).
+;; module m directly contains an @impl-annotated def named t.
 (rule (impl-in-module m t)
   (impl-def d)
   (def-name d n)
   (text n t)
-  (defmodule m)
-  (ancestor m d))
+  (nearest-mod d m))
 
 (rule (public-def-needs-spec d)
   (def-name d n)
   (text n t)
-  (defmodule m)
-  (ancestor m d)
+  (nearest-mod d m)
   (not (spec-in-module m t))
   (not (impl-in-module m t)))
 (lint public-def-needs-spec error

--- a/astlog-rules/elixir.astlog
+++ b/astlog-rules/elixir.astlog
@@ -1,55 +1,91 @@
 
 ;; Elixir type-discipline rules. They push code toward the shape Elixir 1.18's
-;; set-theoretic type checker can actually check: typed structs and spec'd
-;; public functions. Fixtures live in astlog-rules/tests/<rule-id>/ and run as
-;; `.ex` by the `astlog-rules` flake-check self-test.
-;;
-;; These are best-effort lint nudges, not a sound type analysis: astlog matches
-;; text and structure, not names/arities, so each rule has documented blind
-;; spots noted below. They catch the common cases; `# astlog-ignore: <rule>`
-;; is the escape hatch for the rest.
+;; set-theoretic type checker can actually check: typed structs and spec'd public
+;; functions. Both rules are name/structure-matched via stratified negation, so
+;; they are sound up to arity (see the note on public-def-needs-spec). Fixtures
+;; live in astlog-rules/tests/<rule-id>/ and run as `.ex` by the `astlog-rules`
+;; flake-check self-test.
 
-;; defstruct-needs-type: a module that defines a struct but no `@type` cannot be
-;; given a precise struct type by the checker (`state.field` access stays
-;; `dynamic`). Require a `@type` (conventionally `@type t :: %__MODULE__{...}`).
-;; Heuristic: "has a @type" is approximated by the presence of any identifier
-;; with text `type` in the module, so a function or variable literally named
-;; `type` also satisfies it (a false negative). Good enough for a nudge.
-;;
-;; The `defmodule`/`defstruct` calls are matched inline (rather than via helper
-;; relations) because the `astlog-rules` self-test requires every `(rule ...)`
-;; to back a `(lint ...)`; folding them in keeps this rule self-contained.
+;; --- shared building blocks ---
+
+(rule (defmodule m)
+  (match elixir "(call (identifier) @i) @m")
+  (text i "defmodule"))
+
+;; A public `def` and the node of its function name, across the three surface
+;; forms: `def f(args)`, `def f(args) when guard`, and bare `def f`.
+(rule (def-name d n)
+  (match elixir "(call (identifier) @kw (arguments (call (identifier) @n))) @d")
+  (text kw "def"))
+(rule (def-name d n)
+  (match elixir "(call (identifier) @kw (arguments (binary_operator left: (call (identifier) @n)))) @d")
+  (text kw "def"))
+(rule (def-name d n)
+  (match elixir "(call (identifier) @kw (arguments (identifier) @n)) @d")
+  (text kw "def"))
+
+;; A `@spec` and the node of the function name it documents.
+(rule (spec-name s n)
+  (match elixir "(unary_operator (call (identifier) @kw (arguments (binary_operator left: (call (identifier) @n))))) @s")
+  (text kw "spec"))
+
+;; --- defstruct-needs-type: a struct module must declare a @type ---
+;; Matches the actual `@type`/`@typep`/`@opaque` attribute (a `@` unary_operator
+;; over a call to `type`/...), not merely any identifier with text `type`.
+(rule (type-attr a)
+  (match elixir "(unary_operator (call (identifier) @ti)) @a")
+  (text-match ti "^(type|typep|opaque)$"))
+(rule (defstruct-call c)
+  (match elixir "(call (identifier) @i) @c")
+  (text i "defstruct"))
+(rule (module-has-type m)
+  (type-attr a)
+  (defmodule m)
+  (ancestor m a))
 (rule (defstruct-needs-type m)
-  (match elixir "(call (identifier) @mi) @m")
-  (text mi "defmodule")
-  (match elixir "(call (identifier) @si) @c")
-  (text si "defstruct")
+  (defmodule m)
+  (defstruct-call c)
   (ancestor m c)
-  (no-descendant m "identifier" "type"))
+  (not (module-has-type m)))
 (lint defstruct-needs-type error
   "module defines a struct but no @type; add a `@type t` for it so the 1.18 type checker can type its fields")
 
-;; public-def-needs-spec: a public `def` whose annotation block carries no
-;; `@spec` gives the checker no declared signature. Require one (or, for a
-;; behaviour callback, an `@impl` — the contract then comes from the behaviour
-;; and the checker already knows the callback's type).
+;; --- public-def-needs-spec: a public def needs a @spec (or @impl) ---
+;; A def is flagged unless its module has a @spec, or an @impl-annotated def, with
+;; the SAME function name. Name-matching makes one `@spec`/`@impl` cover every
+;; clause of a multi-clause function, and prevents a spec for a different function
+;; from exempting an unspec'd def. Behaviour callbacks are exempt via @impl.
 ;;
-;; `no-attached-sibling` searches the annotation block directly above the def
-;; (preceding siblings up to the previous def of the same kind), so a `@spec`
-;; still counts with a `@doc` or comment between it and the def. Each clause of a
-;; multi-clause function is judged on its own: put a `@spec`/`@impl` above every
-;; clause, or suppress a continuation clause with `# astlog-ignore:
-;; public-def-needs-spec`.
-;;
-;; Blind spot: the check only looks for an identifier with text `spec`/`impl` in
-;; the block, it does NOT match the spec's name/arity to the def. So a `@spec`
-;; (or `@impl`) for a *different* function sitting directly above an unspec'd def
-;; will wrongly exempt it. It catches the overwhelmingly common case; it is not a
-;; soundness guarantee.
-(rule (public-def-needs-spec c)
-  (match elixir "(call (identifier) @i) @c")
-  (text i "def")
-  (no-attached-sibling c "identifier" "spec")
-  (no-attached-sibling c "identifier" "impl"))
+;; Residual: matching is by name, not name+arity (astlog has no aggregation to
+;; count arguments), so `@spec foo/1` also exempts `def foo/2`. Rare, and the real
+;; type gate -- `mix compile --warnings-as-errors` -- is unaffected.
+
+;; module m contains a @spec for the function named t.
+(rule (spec-in-module m t)
+  (spec-name s n)
+  (text n t)
+  (defmodule m)
+  (ancestor m s))
+
+;; a def whose annotation block carries an `@impl` (a behaviour callback).
+(rule (impl-def d)
+  (def-name d n)
+  (attached-sibling d "identifier" "impl"))
+
+;; module m contains an @impl-annotated def named t (so every t clause is a callback).
+(rule (impl-in-module m t)
+  (impl-def d)
+  (def-name d n)
+  (text n t)
+  (defmodule m)
+  (ancestor m d))
+
+(rule (public-def-needs-spec d)
+  (def-name d n)
+  (text n t)
+  (defmodule m)
+  (ancestor m d)
+  (not (spec-in-module m t))
+  (not (impl-in-module m t)))
 (lint public-def-needs-spec error
-  "public def without a preceding @spec; add a `@spec` directly above it so the type checker has a signature")
+  "public def without a @spec; add a `@spec` for it so the type checker has a signature")

--- a/astlog-rules/tests/defstruct-needs-type/bad.fixture
+++ b/astlog-rules/tests/defstruct-needs-type/bad.fixture
@@ -1,3 +1,7 @@
 defmodule Widget do
+  # No @type attribute. An identifier merely *named* `type` must not satisfy the
+  # rule (the pre-negation rule wrongly stayed silent here).
   defstruct [:id, :name]
+  @spec type(term()) :: term()
+  def type(x), do: x
 end

--- a/astlog-rules/tests/public-def-needs-spec/bad.fixture
+++ b/astlog-rules/tests/public-def-needs-spec/bad.fixture
@@ -1,3 +1,6 @@
 defmodule Service do
+  # A @spec for a *different* function must not exempt `call`: name-matching
+  # means this still fires (the pre-negation rule wrongly stayed silent here).
+  @spec other() :: :ok
   def call(x), do: x
 end

--- a/astlog-rules/tests/public-def-needs-spec/good.fixture
+++ b/astlog-rules/tests/public-def-needs-spec/good.fixture
@@ -2,11 +2,18 @@ defmodule Service do
   @spec call(integer()) :: integer()
   def call(x), do: x
 
-  @spec documented(integer()) :: integer()
-  @doc "a doc attribute between the spec and the def"
-  def documented(x), do: x
+  # One @spec covers every clause of a multi-clause function (name-matched).
+  @spec multi(integer()) :: :ok
+  def multi(0), do: :ok
+  def multi(_), do: :ok
 
-  @spec commented(integer()) :: integer()
-  # an explanatory comment between the spec and the def
-  def commented(x), do: x
+  # A behaviour callback is exempt via @impl, across all its clauses.
+  @impl true
+  def handle_event("a", _params, socket), do: {:noreply, socket}
+  def handle_event("b", _params, socket), do: {:noreply, socket}
+
+  # A @doc between the @spec and the def does not hide the spec.
+  @doc "documented"
+  @spec documented(integer()) :: integer()
+  def documented(x), do: x
 end

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -879,12 +879,12 @@ let
                 check_ruleset() {
                   rules="$1"
                   ext="$2"
-                  for rule in $(sed -n 's/^(rule (\([a-z0-9-]*\).*/\1/p' "$rules" | sort -u); do
-                    if ! grep -q "^(lint $rule " "$rules"; then
-                      echo "rule $rule has no (lint ...) declaration, so the scan gate skips it" >&2
-                      fail=1
-                    fi
-                  done
+                  # Rules without a (lint ...) are legitimate helper relations
+                  # (joins/negation need intermediate relations), so they are not
+                  # required to back a lint. The meaningful checks remain: every
+                  # lint has a good/bad fixture pair that fires/stays-clean, and
+                  # every fixture dir backs some lint. `astlog` itself rejects a
+                  # lint that names an undefined relation at parse time.
                   for rule in $(sed -n 's/^(lint \([a-z0-9-]*\).*/\1/p' "$rules" | sort -u); do
                     dir="$tests/$rule"
                     if [ ! -f "$dir/bad.fixture" ] || [ ! -f "$dir/good.fixture" ]; then

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/codex/provision.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/codex/provision.ex
@@ -221,7 +221,6 @@ defmodule SymphonyElixir.Codex.Provision do
     Path.join(dir, run_id)
   end
 
-  # astlog-ignore: public-def-needs-spec
   def host_run_root(%Config{}, home, run_id) when is_binary(home) do
     Path.join([home, @host_default_workspaces_subdir, run_id])
   end
@@ -496,7 +495,6 @@ defmodule SymphonyElixir.Codex.Provision do
   @spec env_export_lines([{String.t(), String.t()}]) :: String.t()
   def env_export_lines([]), do: ":"
 
-  # astlog-ignore: public-def-needs-spec
   def env_export_lines(env) do
     Enum.map_join(env, "\n", fn {key, value} -> "export #{key}=#{sh(value)}" end)
   end
@@ -514,9 +512,7 @@ defmodule SymphonyElixir.Codex.Provision do
     "#{id}: #{title} / #{node_id}"
   end
 
-  # astlog-ignore: public-def-needs-spec
   def backend_name(%{identifier: id}, _run_id, node_id) when is_binary(id), do: "#{id} / #{node_id}"
-  # astlog-ignore: public-def-needs-spec
   def backend_name(_context, run_id, node_id), do: "#{run_id} / #{node_id}"
 
   @doc """

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/codex/room_registry.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/codex/room_registry.ex
@@ -14,7 +14,6 @@ defmodule SymphonyElixir.Codex.RoomRegistry do
   @spec register(Config.t(), map()) :: :ok
   def register(%Config{room: %{registry_url: nil}}, _backend), do: :ok
 
-  # astlog-ignore: public-def-needs-spec
   def register(%Config{} = config, backend) when is_map(backend) do
     post(config, "/api/backends", backend, "register")
   end
@@ -22,7 +21,6 @@ defmodule SymphonyElixir.Codex.RoomRegistry do
   @spec unregister(Config.t(), String.t()) :: :ok
   def unregister(%Config{room: %{registry_url: nil}}, _id), do: :ok
 
-  # astlog-ignore: public-def-needs-spec
   def unregister(%Config{} = config, id) when is_binary(id) do
     case Req.delete(url(config, "/api/backends/" <> URI.encode(id)),
            headers: headers(config),

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/cron_expression.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/cron_expression.ex
@@ -64,7 +64,6 @@ defmodule SymphonyElixir.CronExpression do
     end
   end
 
-  # astlog-ignore: public-def-needs-spec
   def parse(_), do: {:error, :invalid_cron_expression}
 
   defp do_parse(expanded, source) do

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/dsl/ast.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/dsl/ast.ex
@@ -182,17 +182,13 @@ defmodule SymphonyElixir.DSL.AST do
   @doc "True when an AST expression is an effectful constructor (emits a node)."
   @spec effect?(term()) :: boolean()
   def effect?(%{kind: kind}) when kind in @effect_kinds, do: true
-  # astlog-ignore: public-def-needs-spec
   def effect?(_), do: false
 
   @doc "True when an AST expression is a pure value (evaluated, never a node)."
   @spec pure?(term()) :: boolean()
   def pure?({tag, _}) when tag in [:literal, :var], do: true
-  # astlog-ignore: public-def-needs-spec
   def pure?({tag, _, _}) when tag in [:field], do: true
-  # astlog-ignore: public-def-needs-spec
   def pure?({tag, list}) when tag in [:concat, :list] and is_list(list), do: true
-  # astlog-ignore: public-def-needs-spec
   def pure?(_), do: false
 
   # --- constructors -------------------------------------------------------

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/engine/envelope.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/engine/envelope.ex
@@ -114,7 +114,6 @@ defmodule SymphonyElixir.Engine.Envelope do
     end
   end
 
-  # astlog-ignore: public-def-needs-spec
   def from_map(_other), do: {:error, :envelope_not_map}
 
   @doc """

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/github_app.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/github_app.ex
@@ -99,7 +99,6 @@ defmodule SymphonyElixir.GithubApp do
     is_binary(id) and id != "" and is_binary(pem) and pem != ""
   end
 
-  # astlog-ignore: public-def-needs-spec
   def configured?(_), do: false
 
   @impl true

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/ir/graph.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/ir/graph.ex
@@ -147,7 +147,6 @@ defmodule SymphonyElixir.IR.Graph do
     Map.get(inputs, "__on_failure__") == {:literal, true}
   end
 
-  # astlog-ignore: public-def-needs-spec
   def trigger_runs_on_failure?(_node), do: false
 
   @doc """
@@ -200,7 +199,6 @@ defmodule SymphonyElixir.IR.Graph do
   @spec finished_status(RunGraph.t()) :: RunGraph.status() | :running
   def finished_status(%RunGraph{nodes: nodes}) when map_size(nodes) == 0, do: :succeeded
 
-  # astlog-ignore: public-def-needs-spec
   def finished_status(%RunGraph{} = graph) do
     cond do
       not all_terminal?(graph) -> :running

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/ir/materializer.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/ir/materializer.ex
@@ -116,7 +116,6 @@ defmodule SymphonyElixir.IR.Materializer do
   # A graph with no AST, or an `ast` that is not a reified workflow (a
   # hand-built graph in a test, or a pre-DSL run), has nothing to
   # re-expand. Return it unchanged.
-  # astlog-ignore: public-def-needs-spec
   def expand_dynamic(%RunGraph{} = graph), do: {:ok, graph, []}
 
   @placeholder_kinds [:gate, :map_fanout]

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/ir/run_notifier.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/ir/run_notifier.ex
@@ -69,7 +69,6 @@ defmodule SymphonyElixir.IR.RunNotifier do
   @spec notify?(RunGraph.t(), Config.t()) :: boolean()
   def notify?(%RunGraph{status: status}, _config) when status not in [:succeeded, :failed], do: false
 
-  # astlog-ignore: public-def-needs-spec
   def notify?(%RunGraph{trigger: trigger} = graph, %Config{} = config) do
     if trigger_kind(trigger) == :cron, do: cron_notify?(graph, config), else: true
   end

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/ir/view.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/ir/view.ex
@@ -49,19 +49,12 @@ defmodule SymphonyElixir.IR.View do
   """
   @spec trigger_label(map() | nil) :: String.t()
   def trigger_label(%{kind: :manual}), do: "manual"
-  # astlog-ignore: public-def-needs-spec
   def trigger_label(%{kind: :cron, schedule: schedule}), do: "cron " <> to_string(schedule)
-  # astlog-ignore: public-def-needs-spec
   def trigger_label(%{kind: :linear, label: label}), do: "linear: " <> to_string(label)
-  # astlog-ignore: public-def-needs-spec
   def trigger_label(%{kind: :slack_huddle_completed, channel: c}), do: "huddle #" <> to_string(c)
-  # astlog-ignore: public-def-needs-spec
   def trigger_label(%{kind: :slack_app_mention, channel: c}), do: "mention #" <> to_string(c)
-  # astlog-ignore: public-def-needs-spec
   def trigger_label(%{kind: :github_pr_label, label: label}), do: "github: " <> to_string(label)
-  # astlog-ignore: public-def-needs-spec
   def trigger_label(%{kind: kind}), do: to_string(kind)
-  # astlog-ignore: public-def-needs-spec
   def trigger_label(_), do: "manual"
 
   @doc "Full run view: nodes with attempts and outputs, plus expansion and audit logs."

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/prompt.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/prompt.ex
@@ -59,12 +59,9 @@ defmodule SymphonyElixir.Prompt do
   @spec build(SymphonyElixir.IR.Node.prompt_ref(), keyword()) :: {:ok, String.t()} | {:error, term()}
   def build(prompt_ref, opts \\ [])
 
-  # astlog-ignore: public-def-needs-spec
   def build({:inline, text}, _opts) when is_binary(text), do: {:ok, text}
-  # astlog-ignore: public-def-needs-spec
   def build({:inline, nil}, _opts), do: {:error, :unresolved_inline_prompt}
 
-  # astlog-ignore: public-def-needs-spec
   def build({:skill, name, bindings}, opts) when is_binary(name) and is_map(bindings) do
     with {:ok, resolver} <- fetch_resolver(opts),
          {:ok, body} <- resolver.(name),
@@ -73,9 +70,7 @@ defmodule SymphonyElixir.Prompt do
     end
   end
 
-  # astlog-ignore: public-def-needs-spec
   def build(nil, _opts), do: {:error, :missing_prompt_ref}
-  # astlog-ignore: public-def-needs-spec
   def build(other, _opts), do: {:error, {:invalid_prompt_ref, other}}
 
   @doc """

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/room_engine_client.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/room_engine_client.ex
@@ -65,12 +65,10 @@ defmodule SymphonyElixir.Runtime.RoomEngineClient do
     end
   end
 
-  # astlog-ignore: public-def-needs-spec
   def run_node(%Node{kind: :agent} = node, _run_opts) do
     {:error, {:missing_envelope, node.id}, nil}
   end
 
-  # astlog-ignore: public-def-needs-spec
   def run_node(%Node{kind: kind} = node, _run_opts) do
     # Only :agent nodes go through the engine host. :exec/:subrun/:gate
     # nodes have their own executors; routing one here is a wiring bug, so

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/runtime_registry.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/runtime_registry.ex
@@ -119,7 +119,6 @@ defmodule SymphonyElixir.Runtime.RuntimeRegistry do
     {:reply, :ok, put_in(state.monitors[ref], worker.worker_id)}
   end
 
-  # astlog-ignore: public-def-needs-spec
   def handle_call({:unregister, worker_id}, _from, state) do
     :ets.delete(@table, worker_id)
     Logger.info("RuntimeRegistry: unregistered worker=#{worker_id}")

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/worker_client.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/worker_client.ex
@@ -86,7 +86,6 @@ defmodule SymphonyElixir.Runtime.WorkerClient do
     {:ok, socket}
   end
 
-  # astlog-ignore: public-def-needs-spec
   def handle_message(@topic, "teardown", payload, socket) do
     %{"wire_id" => wire_id, "run_id" => run_id} = payload
     config = socket.assigns.config
@@ -101,7 +100,6 @@ defmodule SymphonyElixir.Runtime.WorkerClient do
     {:ok, assign(socket, :handles, handles)}
   end
 
-  # astlog-ignore: public-def-needs-spec
   def handle_message(_topic, _event, _payload, socket), do: {:ok, socket}
 
   @impl Slipstream
@@ -116,13 +114,11 @@ defmodule SymphonyElixir.Runtime.WorkerClient do
     {:noreply, assign(socket, :handles, Map.put(socket.assigns.handles, run_id, handle))}
   end
 
-  # astlog-ignore: public-def-needs-spec
   def handle_info({:provision_done, wire_id, _run_id, {:error, reason}}, socket) do
     push(socket, @topic, "provision_result", %{wire_id: wire_id, ok: false, error: inspect(reason)})
     {:noreply, socket}
   end
 
-  # astlog-ignore: public-def-needs-spec
   def handle_info({:teardown_done, wire_id}, socket) do
     push(socket, @topic, "teardown_result", %{wire_id: wire_id, ok: true})
     {:noreply, socket}

--- a/packages/agent/symphony/elixir/lib/symphony_elixir_web/channels/worker_channel.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir_web/channels/worker_channel.ex
@@ -48,7 +48,6 @@ defmodule SymphonyElixirWeb.WorkerChannel do
 
   @impl true
   def handle_in("provision_result", payload, socket), do: settle(socket, payload)
-  # astlog-ignore: public-def-needs-spec
   def handle_in("teardown_result", payload, socket), do: settle(socket, payload)
 
   @impl true

--- a/packages/agent/symphony/elixir/lib/symphony_elixir_web/live/ir_runs_live.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir_web/live/ir_runs_live.ex
@@ -61,7 +61,6 @@ defmodule SymphonyElixirWeb.IRRunsLive do
     {:noreply, assign(socket, live_action: :show, run_id: run_id, detail: detail)}
   end
 
-  # astlog-ignore: public-def-needs-spec
   def handle_params(params, uri, socket) do
     socket = resubscribe_run(socket, nil)
 
@@ -90,7 +89,6 @@ defmodule SymphonyElixirWeb.IRRunsLive do
     {:noreply, assign(socket, detail: detail)}
   end
 
-  # astlog-ignore: public-def-needs-spec
   def handle_info({:ir_run_event, _run_id, _summary}, %{assigns: %{live_action: :index}} = socket) do
     # Any run transitioned: refresh the index table. Re-reading the store
     # rather than splicing the one summary keeps sort order and the
@@ -100,7 +98,6 @@ defmodule SymphonyElixirWeb.IRRunsLive do
     {:noreply, assign(socket, runs: load_runs(), workflow_errors: load_workflow_errors())}
   end
 
-  # astlog-ignore: public-def-needs-spec
   def handle_info({:ir_run_event, _run_id, _summary}, socket), do: {:noreply, socket}
 
   @impl true
@@ -114,12 +111,10 @@ defmodule SymphonyElixirWeb.IRRunsLive do
     end
   end
 
-  # astlog-ignore: public-def-needs-spec
   def handle_event("run", _params, socket) do
     {:noreply, assign(socket, form_error: "pick a workflow to run")}
   end
 
-  # astlog-ignore: public-def-needs-spec
   def handle_event("cancel", _params, %{assigns: %{run_id: id}} = socket) do
     try do
       _ = Runtime.cancel(id, "dashboard")
@@ -130,7 +125,6 @@ defmodule SymphonyElixirWeb.IRRunsLive do
     {:noreply, assign(socket, detail: reload_detail(id))}
   end
 
-  # astlog-ignore: public-def-needs-spec
   def handle_event("retry_failed", _params, %{assigns: %{run_id: id}} = socket) do
     try do
       _ = Runtime.clear_failed(id, "dashboard")
@@ -141,7 +135,6 @@ defmodule SymphonyElixirWeb.IRRunsLive do
     {:noreply, assign(socket, detail: reload_detail(id))}
   end
 
-  # astlog-ignore: public-def-needs-spec
   def handle_event("rerun", _params, %{assigns: %{run_id: id}} = socket) do
     try do
       _ = Runtime.rerun(id, "dashboard")
@@ -159,7 +152,6 @@ defmodule SymphonyElixirWeb.IRRunsLive do
     """
   end
 
-  # astlog-ignore: public-def-needs-spec
   def render(assigns) do
     ~H"""
     {SymphonyElixirWeb.Layouts.app(%{inner_content: render_index(assigns), active_tab: :ir})}

--- a/packages/agent/symphony/elixir/lib/symphony_elixir_web/live/skills_live.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir_web/live/skills_live.ex
@@ -31,7 +31,6 @@ defmodule SymphonyElixirWeb.SkillsLive do
     {:noreply, assign(socket, live_action: :show, skill: skill, skill_name: name)}
   end
 
-  # astlog-ignore: public-def-needs-spec
   def handle_params(_params, _uri, socket) do
     {:noreply, assign(socket, live_action: :index)}
   end
@@ -43,7 +42,6 @@ defmodule SymphonyElixirWeb.SkillsLive do
     """
   end
 
-  # astlog-ignore: public-def-needs-spec
   def render(assigns) do
     ~H"""
     {SymphonyElixirWeb.Layouts.app(%{inner_content: render_index(assigns), active_tab: :skills})}

--- a/packages/agent/symphony/elixir/lib/symphony_elixir_web/live/workflows_live.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir_web/live/workflows_live.ex
@@ -31,7 +31,6 @@ defmodule SymphonyElixirWeb.WorkflowsLive do
     {:noreply, assign(socket, live_action: :show, workflow_name: name)}
   end
 
-  # astlog-ignore: public-def-needs-spec
   def handle_params(_params, _uri, socket) do
     {:noreply,
      assign(socket,
@@ -48,7 +47,6 @@ defmodule SymphonyElixirWeb.WorkflowsLive do
     """
   end
 
-  # astlog-ignore: public-def-needs-spec
   def render(assigns) do
     ~H"""
     {SymphonyElixirWeb.Layouts.app(%{inner_content: render_index(assigns), active_tab: :workflows})}

--- a/packages/code/astlog/core/src/error.rs
+++ b/packages/code/astlog/core/src/error.rs
@@ -132,6 +132,18 @@ pub enum Error {
         second_end: usize,
     },
 
+    #[snafu(display(
+        "rules:{line}: variable `{var}` is used only inside `(not ...)`; \
+         negation can only filter variables a positive atom already binds"
+    ))]
+    UnsafeNegation { var: String, line: usize },
+
+    #[snafu(display(
+        "rules: negation through recursion has no stratification (a relation \
+         depends on itself via `(not ...)`); first rule `{rule}` at rules:{line}"
+    ))]
+    UnstratifiableProgram { rule: String, line: usize },
+
     #[snafu(display("internal invariant broken: {what}"))]
     Internal { what: String },
 }

--- a/packages/code/astlog/core/src/eval.rs
+++ b/packages/code/astlog/core/src/eval.rs
@@ -123,7 +123,7 @@ impl<'a> Evaluator<'a> {
                         regexes.insert(pattern.clone(), compiled);
                     }
                 }
-                BodyAtom::App(_) => {}
+                BodyAtom::App(_) | BodyAtom::Negation(_) => {}
             }
         }
         Ok(Self {
@@ -149,42 +149,49 @@ impl<'a> Evaluator<'a> {
                 .entry(rule.name.clone())
                 .or_insert_with(|| Relation::new(rule.head_vars.clone()));
         }
-        loop {
-            let mut staged: Vec<(&str, Row)> = Vec::new();
-            for rule in &self.program.rules {
-                let mut envs = Vec::new();
-                self.solve(&db, &rule.body, Env::new(), &mut envs)?;
-                for env in envs {
-                    let row = rule
-                        .head_vars
-                        .iter()
-                        .map(|var| {
-                            env.get(var).cloned().ok_or_else(|| {
-                                UnboundHeadVarSnafu {
-                                    line: rule.line,
-                                    var: var.clone(),
-                                }
-                                .build()
+        // Evaluate stratum by stratum: every relation a rule negates lives in an
+        // earlier stratum, so by the time a stratum runs its negated relations are
+        // final. Within a stratum, iterate the usual naive fixpoint to convergence.
+        for stratum in self.program.strata()? {
+            loop {
+                let mut staged: Vec<(&str, Row)> = Vec::new();
+                for &index in &stratum {
+                    let rule = &self.program.rules[index];
+                    let mut envs = Vec::new();
+                    self.solve(&db, &rule.body, Env::new(), &mut envs)?;
+                    for env in envs {
+                        let row = rule
+                            .head_vars
+                            .iter()
+                            .map(|var| {
+                                env.get(var).cloned().ok_or_else(|| {
+                                    UnboundHeadVarSnafu {
+                                        line: rule.line,
+                                        var: var.clone(),
+                                    }
+                                    .build()
+                                })
                             })
-                        })
-                        .collect::<Result<Row, _>>()?;
-                    staged.push((&rule.name, row));
+                            .collect::<Result<Row, _>>()?;
+                        staged.push((&rule.name, row));
+                    }
+                }
+                let mut grew = false;
+                for (name, row) in staged {
+                    let relation = db.relations.get_mut(name).ok_or_else(|| {
+                        InternalSnafu {
+                            what: format!("relation `{name}` missing from database"),
+                        }
+                        .build()
+                    })?;
+                    grew |= relation.insert(row);
+                }
+                if !grew {
+                    break;
                 }
             }
-            let mut grew = false;
-            for (name, row) in staged {
-                let relation = db.relations.get_mut(name).ok_or_else(|| {
-                    InternalSnafu {
-                        what: format!("relation `{name}` missing from database"),
-                    }
-                    .build()
-                })?;
-                grew |= relation.insert(row);
-            }
-            if !grew {
-                return Ok(db);
-            }
         }
+        Ok(db)
     }
 
     /// All variable bindings satisfying `atoms` against a finished database.
@@ -252,6 +259,27 @@ impl<'a> Evaluator<'a> {
                     if let Some(next) = next {
                         self.solve(db, rest, next, out)?;
                     }
+                }
+            }
+            BodyAtom::Negation(neg) => {
+                // Succeed iff no row of the (lower-stratum, final) relation unifies
+                // with the current bindings. Negation filters; it binds nothing.
+                let relation = db.relations.get(&neg.name).ok_or_else(|| {
+                    UnknownRelationSnafu {
+                        name: neg.name.clone(),
+                        line: neg.line,
+                    }
+                    .build()
+                })?;
+                let matched = relation.rows().iter().any(|row| {
+                    let mut env = Some(env.clone());
+                    for (term, value) in neg.args.iter().zip(row) {
+                        env = env.and_then(|e| unify_term(&e, term, value));
+                    }
+                    env.is_some()
+                });
+                if !matched {
+                    self.solve(db, rest, env, out)?;
                 }
             }
         }
@@ -340,23 +368,21 @@ impl<'a> Evaluator<'a> {
                 );
                 Ok(absent.then(|| env.clone()).into_iter().collect())
             }
-            "no-attached-sibling" => {
+            "attached-sibling" => {
                 let node = bound_node(app, env, 0)?;
                 let kind = bound_value(app, env, 1)?;
                 let text = bound_value(app, env, 2)?;
-                // Holds when none of the named siblings *attached above* `node`
-                // has a descendant with this kind and exact text. "Attached
-                // above" = the preceding named siblings up to (not including) the
-                // nearest preceding sibling of the same kind as `node` -- i.e. the
-                // annotation block (`@spec`/`@impl`/`@doc`/comments) that sits
-                // directly above a definition, stopping at the previous
-                // definition/clause of the same kind. This lets a rule require an
-                // adjacent annotation without general negation, while skipping
-                // intervening comments and doc attributes.
+                // Holds when some named sibling *attached above* `node` has a
+                // descendant with this kind and exact text. "Attached above" = the
+                // preceding named siblings up to (not including) the nearest
+                // preceding sibling of the same kind as `node` -- i.e. the
+                // annotation block (`@spec`/`@impl`/`@doc`/comments) directly above
+                // a definition, stopping at the previous definition/clause of the
+                // same kind. Absence is expressed by negating this with `(not ...)`.
                 let kt = self.corpus.value_text(&kind);
                 let tt = self.corpus.value_text(&text);
-                let absent = !self.attached_has_descendant(node, kt, tt);
-                Ok(absent.then(|| env.clone()).into_iter().collect())
+                let present = self.attached_has_descendant(node, kt, tt);
+                Ok(present.then(|| env.clone()).into_iter().collect())
             }
             other => InternalSnafu {
                 what: format!("builtin `{other}` has no evaluator"),

--- a/packages/code/astlog/core/src/program.rs
+++ b/packages/code/astlog/core/src/program.rs
@@ -418,14 +418,14 @@ fn check_negation_safety(rule: &Rule) -> Result<(), Error> {
             continue;
         };
         for arg in &neg.args {
-            if let Term::Var(var) = arg {
-                if !bound.contains(var.as_str()) {
-                    return UnsafeNegationSnafu {
-                        var: var.clone(),
-                        line: neg.line,
-                    }
-                    .fail();
+            if let Term::Var(var) = arg
+                && !bound.contains(var.as_str())
+            {
+                return UnsafeNegationSnafu {
+                    var: var.clone(),
+                    line: neg.line,
                 }
+                .fail();
             }
         }
     }

--- a/packages/code/astlog/core/src/program.rs
+++ b/packages/code/astlog/core/src/program.rs
@@ -20,7 +20,7 @@ use ast_merge_langs::Lang;
 
 use crate::error::{
     ArityMismatchSnafu, BuiltinAritySnafu, DslSnafu, Error, LintSeveritySnafu, LintVarSnafu,
-    UnknownLangNameSnafu, UnknownRelationSnafu,
+    UnknownLangNameSnafu, UnknownRelationSnafu, UnsafeNegationSnafu, UnstratifiableProgramSnafu,
 };
 use crate::sexpr::{self, Sexpr};
 
@@ -35,7 +35,7 @@ pub const BUILTINS: &[(&str, usize)] = &[
     ("same-file", 2),
     ("text-match", 2),
     ("no-descendant", 3),
-    ("no-attached-sibling", 3),
+    ("attached-sibling", 3),
 ];
 
 /// A list S-expression destructured into its head atom and remaining items.
@@ -65,6 +65,10 @@ pub struct MatchAtom {
 pub enum BodyAtom {
     Match(MatchAtom),
     App(AppAtom),
+    /// `(not (relation args...))`: succeeds for a binding iff no row of the named
+    /// relation unifies with it. Stratified — the negated relation is always
+    /// computed in a lower stratum, so its rows are final before the negation runs.
+    Negation(AppAtom),
 }
 
 #[derive(Debug)]
@@ -208,6 +212,7 @@ impl Program {
                 .fail();
             }
             check_atoms(&rule.body, &arities)?;
+            check_negation_safety(rule)?;
         }
         for rewrite in &self.rewrites {
             check_atoms(&rewrite.body, &arities)?;
@@ -216,7 +221,68 @@ impl Program {
         for lint in &self.lints {
             self.check_lint(lint)?;
         }
+        // Reject negation through recursion: the stratification must exist.
+        self.strata()?;
         Ok(())
+    }
+
+    /// Rules grouped into strata: every relation a rule negates is computed in an
+    /// earlier stratum, so negation always reads a final relation. Returns rule
+    /// indices grouped by ascending stratum.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::UnstratifiableProgram`] if a relation depends on itself through a
+    /// negation (no stratification exists).
+    pub fn strata(&self) -> Result<Vec<Vec<usize>>, Error> {
+        // Relation dependency edges (head relation -> referenced relation), with a
+        // flag for edges that pass through `(not ...)`.
+        let mut edges: Vec<(&str, &str, bool)> = Vec::new();
+        for rule in &self.rules {
+            for atom in &rule.body {
+                match atom {
+                    BodyAtom::App(app) if builtin_arity(&app.name).is_none() => {
+                        edges.push((&rule.name, &app.name, false));
+                    }
+                    BodyAtom::Negation(neg) => edges.push((&rule.name, &neg.name, true)),
+                    _ => {}
+                }
+            }
+        }
+        // Relax stratum levels: a positive edge a->b needs level(a) >= level(b);
+        // a negative edge needs level(a) > level(b). A negative edge inside a cycle
+        // forces unbounded growth, so if anything still changes after one pass per
+        // relation the program is unstratifiable.
+        let mut level: HashMap<&str, usize> = self.rules.iter().map(|r| (r.name.as_str(), 0)).collect();
+        let passes = level.len() + 1;
+        for pass in 0..=passes {
+            let mut changed = false;
+            for &(a, b, negative) in &edges {
+                let need = level[b] + usize::from(negative);
+                if level[a] < need {
+                    level.insert(a, need);
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+            if pass == passes {
+                let (rule, line) = self
+                    .rules
+                    .iter()
+                    .map(|r| (r.name.clone(), r.line))
+                    .next()
+                    .unwrap_or_default();
+                return UnstratifiableProgramSnafu { rule, line }.fail();
+            }
+        }
+        let max_level = level.values().copied().max().unwrap_or(0);
+        let mut strata = vec![Vec::new(); max_level + 1];
+        for (index, rule) in self.rules.iter().enumerate() {
+            strata[level[rule.name.as_str()]].push(index);
+        }
+        Ok(strata)
     }
 
     /// A lint must name a defined relation, and its message may only splice
@@ -256,6 +322,34 @@ pub fn builtin_arity(name: &str) -> Option<usize> {
 
 fn check_atoms(atoms: &[BodyAtom], arities: &HashMap<&str, usize>) -> Result<(), Error> {
     for atom in atoms {
+        if let BodyAtom::Negation(neg) = atom {
+            // A negated atom must name a defined relation (not a builtin: builtins
+            // are filters, not finite relations to scan) with matching arity.
+            if builtin_arity(&neg.name).is_some() {
+                return DslSnafu {
+                    line: neg.line,
+                    message: format!("(not ...) cannot negate the builtin `{}`", neg.name),
+                }
+                .fail();
+            }
+            let expected = *arities.get(neg.name.as_str()).ok_or_else(|| {
+                UnknownRelationSnafu {
+                    name: neg.name.clone(),
+                    line: neg.line,
+                }
+                .build()
+            })?;
+            if neg.args.len() != expected {
+                return ArityMismatchSnafu {
+                    name: neg.name.clone(),
+                    expected,
+                    got: neg.args.len(),
+                    line: neg.line,
+                }
+                .fail();
+            }
+            continue;
+        }
         let BodyAtom::App(app) = atom else {
             continue;
         };
@@ -301,6 +395,43 @@ fn check_atoms(atoms: &[BodyAtom], arities: &HashMap<&str, usize>) -> Result<(),
     Ok(())
 }
 
+/// Every variable a negated atom uses must be bound by a positive atom in the
+/// same rule (range restriction). Negation only filters existing bindings; a
+/// variable that appears only inside `(not ...)` has nothing to filter against.
+fn check_negation_safety(rule: &Rule) -> Result<(), Error> {
+    let mut bound: HashSet<&str> = HashSet::new();
+    for atom in &rule.body {
+        match atom {
+            BodyAtom::Match(m) => bound.extend(capture_names(&m.query)),
+            BodyAtom::App(app) => {
+                for arg in &app.args {
+                    if let Term::Var(var) = arg {
+                        bound.insert(var);
+                    }
+                }
+            }
+            BodyAtom::Negation(_) => {}
+        }
+    }
+    for atom in &rule.body {
+        let BodyAtom::Negation(neg) = atom else {
+            continue;
+        };
+        for arg in &neg.args {
+            if let Term::Var(var) = arg {
+                if !bound.contains(var.as_str()) {
+                    return UnsafeNegationSnafu {
+                        var: var.clone(),
+                        line: neg.line,
+                    }
+                    .fail();
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 fn check_template(rewrite: &Rewrite) -> Result<(), Error> {
     let mut mentioned: HashSet<&str> = HashSet::new();
     for atom in &rewrite.body {
@@ -313,6 +444,10 @@ fn check_template(rewrite: &Rewrite) -> Result<(), Error> {
                     }
                 }
             }
+            // A negated atom only filters; it binds nothing, so it contributes no
+            // mentioned variables (its vars are bound by positive atoms via the
+            // safety check).
+            BodyAtom::Negation(_) => {}
         }
     }
     let template_vars = rewrite
@@ -523,6 +658,23 @@ fn parse_body_atom(form: &Sexpr) -> Result<BodyAtom, Error> {
             query: query.clone(),
             line: *line,
         }));
+    }
+    if name == "not" {
+        let [inner] = args else {
+            return DslSnafu {
+                line: form.line(),
+                message: "not form is (not (<relation> args...))".to_owned(),
+            }
+            .fail();
+        };
+        let BodyAtom::App(app) = parse_body_atom(inner)? else {
+            return DslSnafu {
+                line: form.line(),
+                message: "(not ...) may only negate a relation atom".to_owned(),
+            }
+            .fail();
+        };
+        return Ok(BodyAtom::Negation(app));
     }
     let args = args
         .iter()

--- a/packages/code/astlog/core/src/program.rs
+++ b/packages/code/astlog/core/src/program.rs
@@ -212,10 +212,11 @@ impl Program {
                 .fail();
             }
             check_atoms(&rule.body, &arities)?;
-            check_negation_safety(rule)?;
+            check_negation_safety(&rule.body)?;
         }
         for rewrite in &self.rewrites {
             check_atoms(&rewrite.body, &arities)?;
+            check_negation_safety(&rewrite.body)?;
             check_template(rewrite)?;
         }
         for lint in &self.lints {
@@ -256,25 +257,27 @@ impl Program {
         let mut level: HashMap<&str, usize> = self.rules.iter().map(|r| (r.name.as_str(), 0)).collect();
         let passes = level.len() + 1;
         for pass in 0..=passes {
-            let mut changed = false;
+            let mut grew: Option<&str> = None;
             for &(a, b, negative) in &edges {
                 let need = level[b] + usize::from(negative);
                 if level[a] < need {
                     level.insert(a, need);
-                    changed = true;
+                    grew = Some(a);
                 }
             }
-            if !changed {
-                break;
-            }
-            if pass == passes {
-                let (rule, line) = self
-                    .rules
-                    .iter()
-                    .map(|r| (r.name.clone(), r.line))
-                    .next()
-                    .unwrap_or_default();
-                return UnstratifiableProgramSnafu { rule, line }.fail();
+            match grew {
+                None => break,
+                // A relation whose level still grows after a full pass per
+                // relation sits on a negation cycle: report it, not rule #1.
+                Some(name) if pass == passes => {
+                    let line = self.rules.iter().find(|r| r.name == name).map_or(0, |r| r.line);
+                    return UnstratifiableProgramSnafu {
+                        rule: name.to_owned(),
+                        line,
+                    }
+                    .fail();
+                }
+                Some(_) => {}
             }
         }
         let max_level = level.values().copied().max().unwrap_or(0);
@@ -395,12 +398,15 @@ fn check_atoms(atoms: &[BodyAtom], arities: &HashMap<&str, usize>) -> Result<(),
     Ok(())
 }
 
-/// Every variable a negated atom uses must be bound by a positive atom in the
-/// same rule (range restriction). Negation only filters existing bindings; a
-/// variable that appears only inside `(not ...)` has nothing to filter against.
-fn check_negation_safety(rule: &Rule) -> Result<(), Error> {
+/// Every variable a negated atom uses must be bound by a positive atom that
+/// appears BEFORE it in the body (range restriction). The evaluator runs atoms
+/// left-to-right, so a variable first bound after the negation is still unbound
+/// when the negation runs and would be existentially bound per row (a wildcard)
+/// rather than filtering -- this check rejects exactly that. Applied to rule and
+/// rewrite bodies alike.
+fn check_negation_safety(body: &[BodyAtom]) -> Result<(), Error> {
     let mut bound: HashSet<&str> = HashSet::new();
-    for atom in &rule.body {
+    for atom in body {
         match atom {
             BodyAtom::Match(m) => bound.extend(capture_names(&m.query)),
             BodyAtom::App(app) => {
@@ -410,22 +416,18 @@ fn check_negation_safety(rule: &Rule) -> Result<(), Error> {
                     }
                 }
             }
-            BodyAtom::Negation(_) => {}
-        }
-    }
-    for atom in &rule.body {
-        let BodyAtom::Negation(neg) = atom else {
-            continue;
-        };
-        for arg in &neg.args {
-            if let Term::Var(var) = arg
-                && !bound.contains(var.as_str())
-            {
-                return UnsafeNegationSnafu {
-                    var: var.clone(),
-                    line: neg.line,
+            BodyAtom::Negation(neg) => {
+                for arg in &neg.args {
+                    if let Term::Var(var) = arg
+                        && !bound.contains(var.as_str())
+                    {
+                        return UnsafeNegationSnafu {
+                            var: var.clone(),
+                            line: neg.line,
+                        }
+                        .fail();
+                    }
                 }
-                .fail();
             }
         }
     }

--- a/packages/code/astlog/core/src/tests.rs
+++ b/packages/code/astlog/core/src/tests.rs
@@ -280,11 +280,11 @@ fn dirty() { danger(); }
 }
 
 #[test]
-fn no_attached_sibling_scans_the_annotation_block() -> TestResult {
-    // `no-attached-sibling` searches the annotation block directly above each
-    // def (preceding siblings up to the previous def), so a `@spec` counts even
-    // with a `@doc` or comment between it and the def. Only the def with no
-    // `@spec` in its block qualifies.
+fn attached_sibling_scans_the_annotation_block() -> TestResult {
+    // `attached-sibling` searches the annotation block directly above each def
+    // (preceding siblings up to the previous def), so a `@spec` counts even with a
+    // `@doc` or comment between it and the def. `(not (attached-sibling ...))`
+    // then keeps only the def with no `@spec` in its block.
     let source = "
 defmodule Demo do
   @spec documented() :: :ok
@@ -302,10 +302,9 @@ defmodule Demo do
 end
 ";
     let rules = r#"
-(rule (undocumented-def c)
-  (match elixir "(call (identifier) @i) @c")
-  (text i "def")
-  (no-attached-sibling c "identifier" "spec"))
+(rule (a-def c) (match elixir "(call (identifier) @i) @c") (text i "def"))
+(rule (spec-attached c) (a-def c) (attached-sibling c "identifier" "spec"))
+(rule (undocumented-def c) (a-def c) (not (spec-attached c)))
 "#;
     let dir = tempfile::tempdir()?;
     write_sample(&dir, "sample.ex", source)?;
@@ -321,6 +320,77 @@ end
     };
     assert!(analysis.corpus.node_text(*node).contains("undocumented"));
     Ok(())
+}
+
+#[test]
+fn negation_filters_by_name_join() -> TestResult {
+    // `keep` is a function that defines a spec for its own name; `drop` is spec'd
+    // for a *different* name. A name-matched negation flags only `drop`.
+    let source = "
+defmodule Demo do
+  @spec keep(integer()) :: integer()
+  def keep(x), do: x
+
+  @spec other() :: :ok
+  def drop(y), do: y
+end
+";
+    let rules = r#"
+(rule (def-name d n)
+  (match elixir "(call (identifier) @kw (arguments (call (identifier) @n))) @d")
+  (text kw "def"))
+(rule (spec-name n)
+  (match elixir "(unary_operator (call (identifier) @kw (arguments (binary_operator (call (identifier) @sn))))) ")
+  (text kw "spec")
+  (text sn n))
+(rule (unspecced d)
+  (def-name d n)
+  (text n t)
+  (not (spec-name t)))
+"#;
+    let dir = tempfile::tempdir()?;
+    write_sample(&dir, "sample.ex", source)?;
+    let analysis = analyze(rules, &[dir.path().to_path_buf()])?;
+    let rows = analysis.database.relations["unspecced"].rows();
+    assert_eq!(rows.len(), 1, "only the def with no same-named @spec qualifies");
+    let Value::Node(node) = &rows[0][0] else {
+        return Err("unspecced column 0 should be a node".into());
+    };
+    assert!(analysis.corpus.node_text(*node).contains("drop"));
+    Ok(())
+}
+
+#[test]
+fn unsafe_negation_is_rejected() {
+    // `y` appears only inside the negated atom, with nothing to filter against.
+    let rules = r#"
+(rule (thing x) (match rust "(identifier) @x"))
+(rule (bad x) (match rust "(identifier) @x") (not (thing y)))
+"#;
+    let Err(error) = analyze(rules, &[]) else {
+        panic!("negation over an unbound variable must be rejected");
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains("only inside `(not ...)`"),
+        "expected unsafe-negation error, got: {message}"
+    );
+}
+
+#[test]
+fn negation_through_recursion_is_rejected() {
+    let rules = r#"
+(rule (p x) (match rust "(identifier) @x"))
+(rule (p x) (match rust "(identifier) @x") (not (p x)))
+"#;
+    let Err(error) = analyze(rules, &[]) else {
+        panic!("negation through recursion must be rejected");
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains("stratif") || message.contains("recursion"),
+        "expected unstratifiable error, got: {message}"
+    );
 }
 
 /// One rule flagging every `.unwrap()` receiver, lint-declared as an error

--- a/packages/code/astlog/core/src/tests.rs
+++ b/packages/code/astlog/core/src/tests.rs
@@ -378,6 +378,41 @@ fn unsafe_negation_is_rejected() {
 }
 
 #[test]
+fn negation_before_its_binding_is_rejected() {
+    // `t` is bound by `(text n t)` only AFTER the negation. The evaluator runs
+    // left-to-right, so `t` would be unbound when `(not ...)` runs and bound
+    // existentially per row instead of filtering -- safety must reject it.
+    let rules = r#"
+(rule (named n) (match rust "(identifier) @n"))
+(rule (other t) (match rust "(identifier) @x") (text x t))
+(rule (bad n) (named n) (not (other t)) (text n t))
+"#;
+    let Err(error) = analyze(rules, &[]) else {
+        panic!("negation before its binding atom must be rejected");
+    };
+    assert!(
+        error.to_string().contains("only inside"),
+        "expected unsafe-negation error, got: {error}"
+    );
+}
+
+#[test]
+fn rewrite_negation_safety_is_checked() {
+    // The same range-restriction applies to rewrite bodies, not just rules.
+    let rules = r#"
+(rule (thing x) (match rust "(identifier) @x"))
+(rewrite r (match rust "(identifier) @x") (not (thing y)) (replace x "z"))
+"#;
+    let Err(error) = analyze(rules, &[]) else {
+        panic!("unbound negation in a rewrite body must be rejected");
+    };
+    assert!(
+        error.to_string().contains("only inside"),
+        "expected unsafe-negation error, got: {error}"
+    );
+}
+
+#[test]
 fn negation_through_recursion_is_rejected() {
     let rules = r#"
 (rule (p x) (match rust "(identifier) @x"))


### PR DESCRIPTION
## What & why

PR #1139 shipped the Elixir type-discipline lint with three documented blind spots, all rooted in astlog v0 having **no negation** — a rule couldn't say "there is no `@spec` *matching this def's name*." This adds **stratified negation** to the engine (a reusable capability, listed as a v0 gap in the README) and rewrites the Elixir rules to be name/structure-matched and sound.

```mermaid
flowchart TD
  A["(not (relation ...))"] --> B[range-restriction: vars bound by a positive atom]
  A --> C[stratification: no relation negates itself]
  C --> D[evaluate stratum by stratum]
  D --> E[negated relation is final before it is read]
```

## Engine — `packages/code/astlog/core`
- New `(not (relation args...))` body atom. Rejected if a negated variable isn't bound by a positive atom (`UnsafeNegation`) or if a relation depends on itself through negation (`UnstratifiableProgram`). `fixpoint` now runs stratum by stratum.
- Flipped `no-attached-sibling` → positive `attached-sibling`; absence is expressed with `(not ...)`. Kept #1139's bounded-walk perf.
- Unit tests: name-join negation, unsafe-negation rejected, recursion rejected, annotation-block scan.

## Rules — `astlog-rules/elixir.astlog`
- **`public-def-needs-spec`**: flag a public `def` unless its module has a `@spec`, or an `@impl`-annotated def, with the **same function name**. Fixes blind spot #1 (a spec for a *different* function no longer exempts a def) and removes the multi-clause `astlog-ignore` clutter (one spec/impl covers every clause). `@impl` callbacks exempt.
- **`defstruct-needs-type`**: matches the real `@type`/`@typep`/`@opaque` attribute, not any identifier named `type` (blind spot #2).
- **Residual (documented):** matching is by name, not arity — astlog has no aggregation to count args. The real type gate (`mix compile --warnings-as-errors`) is unaffected.

## Self-test — `lib/per-system.nix`
Dropped the "every `(rule ...)` must back a `(lint ...)`" check — helper relations are legitimate Datalog (joins/negation need them), and this invariant is what bit #1139. The meaningful checks remain: every lint has good/bad fixtures that fire/stay-clean, every fixture backs a lint, and `astlog` rejects a lint naming an undefined relation at parse.

## Cleanup
Removed the 49 now-redundant `# astlog-ignore: public-def-needs-spec` comments across symphony + hive `lib/`.

## Verified locally (darwin)
- `nix build .#astlog` builds; negation + every rule case checked end-to-end with the binary; self-test replica passes (bad fires, good clean for both lints).
- `nix run .#lint` → 6/6 green. `nix build .#symphony.passthru.tests.elixir .#hive.passthru.tests.elixir` → green (compile -Werror, format, credo, test). 0 findings across all `lib/`.
- The `astlog-rules` self-test + `*-elixir` checks are `x86_64-linux`-only, so CI builds those.

Reviewers from astlog: the stratification is in `program.rs::strata`; the negation eval arm is in `eval.rs::solve`.

🤖 Opened by an AI agent (Claude Code / claude-opus-4-8) on behalf of @andrewgazelka.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add stratified negation to astlog and fix Elixir type-gate soundness
> - Adds `(not (relation ...))` syntax to the astlog rule language, with parse-time safety checks (unsafe negation, unstratifiable cycles) and stratum-ordered evaluation in [eval.rs](https://github.com/indexable-inc/index/pull/1143/files#diff-582d2ea95f2cadbafa86621c62413054f21723e09bfe15a824bbcefcdf51a615) and [program.rs](https://github.com/indexable-inc/index/pull/1143/files#diff-49a2029f4d0a9f0a74b390eadfaf4fb3ae4c07fcb6da07928ba22eeb4bf4147d).
> - Rewrites the `defstruct-needs-type` lint in [elixir.astlog](https://github.com/indexable-inc/index/pull/1143/files#diff-7c3885af2a45aaf196cbe344831d5b87cf5d8d6554a44d9d747e083e0841e1a0) to match only true `@type`/`@typep`/`@opaque` attributes scoped to the nearest enclosing module, replacing a heuristic that matched any identifier named `type`.
> - Rewrites the `public-def-needs-spec` lint to require a same-named `@spec` (or `@impl`) in the same nearest module, so a spec for a different function or in an ancestor module no longer exempts a def; multi-clause functions are covered by name.
> - Renames the `no-attached-sibling` builtin to `attached-sibling` and inverts its polarity; callers must now use `(not (attached-sibling ...))` for absence checks.
> - Removes ~20 `# astlog-ignore: public-def-needs-spec` suppression comments from Elixir source files now that multi-clause defs are correctly handled by name.
> - Risk: any external `.astlog` file using `no-attached-sibling` will break; the builtin no longer exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fe6b63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->