### PR TITLE
feat(mcp): bundle pyobjc CoreLocation in the kernel on Darwin

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -669,14 +669,34 @@ let
   # carries no calendar logic of its own (RFC 0003).
   gcalBin = ix.rustWorkspace.units.binaries."gcal";
 
+  # `import CoreLocation` on Darwin: the pyobjc binding for Apple's Core Location
+  # framework, so a session can read the Mac's current location with no install
+  # step. nixpkgs ships only a curated subset of the pyobjc framework bindings and
+  # CoreLocation is not one of them, but every binding lives in pyobjc-core's
+  # monorepo src as a sibling subdir built by identical glue. So rather than
+  # duplicate that glue, derive it from the packaged `pyobjc-framework-Quartz`
+  # (same src, same version, same build/patch steps, same pyobjc-core + Cocoa
+  # deps) and only retarget the source subdir and the import check. This tracks
+  # any nixpkgs build fixes to Quartz automatically.
+  coreLocationModule = pkgs.python3.pkgs.pyobjc-framework-Quartz.overridePythonAttrs (old: {
+    pname = "pyobjc-framework-CoreLocation";
+    sourceRoot = "${old.src.name}/pyobjc-framework-CoreLocation";
+    pythonImportsCheck = [ "CoreLocation" ];
+    meta = old.meta // {
+      description = "PyObjC wrappers for the Core Location framework on macOS";
+    };
+  });
+
   # The `screen` helper is macOS-only, so its dependencies join the interpreter
   # only on Darwin. `pyobjc-framework-Quartz` is the maintained CoreGraphics
   # binding the helper wraps; Pillow (already transitive via matplotlib) carries
-  # the PIL image type capture returns.
+  # the PIL image type capture returns. `coreLocationModule` adds the Core
+  # Location binding so location reads work out of the box.
   darwinExtraPackages =
     ps:
     lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
       ps.pyobjc-framework-Quartz
+      coreLocationModule
       screenModule
       vmkitModule
       imessageModule
@@ -4291,6 +4311,7 @@ let
       '';
 
   screenBundled = importTest "screen" "import screen; print('screen-ok', all(callable(getattr(screen, n)) for n in ('capture', 'click', 'write', 'press', 'key_down', 'key_up', 'apps', 'frontmost', 'launch', 'activate', 'terminate', 'accessibility_trusted')))";
+  coreLocationBundled = importTest "corelocation" "import CoreLocation; print('corelocation-ok', callable(CoreLocation.CLLocationManager.alloc))";
   vmkitBundled = importTest "vmkit" "import vmkit; print('vmkit-ok', callable(vmkit.boot_linux), callable(vmkit.drive), callable(vmkit.screenshot))";
   imessageBundled = importTest "imessage" "import imessage; print('imessage-ok', all(callable(getattr(imessage, n)) for n in ('messages', 'chats', 'contacts', 'send')))";
   xBundled = importTest "x" "import x; print('x-ok', callable(x.posts), x.__version__)";
@@ -4410,6 +4431,7 @@ package.overrideAttrs (old: {
     // lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
       inherit
         screenBundled
+        coreLocationBundled
         vmkitBundled
         vmkitResourceSmoke
         imessageBundled


### PR DESCRIPTION
## What

Add `pyobjc-framework-CoreLocation` to the ix-mcp kernel's Darwin-only package set, so a session can `import CoreLocation` and read the Mac's current location with no install step.

```python
import CoreLocation
mgr = CoreLocation.CLLocationManager.alloc().init()
mgr.requestWhenInUseAuthorization()
mgr.startUpdatingLocation()
loc = mgr.location()   # CLLocation once a fix arrives
```

## Why this shape

nixpkgs packages only a curated subset of the pyobjc framework bindings (Cocoa, CoreAudio, CoreBluetooth, Quartz, Security, WebKit, libdispatch) and CoreLocation is not one of them. Every binding lives in `pyobjc-core`'s monorepo `src` as a sibling subdir built by identical glue, so rather than duplicate that glue we derive CoreLocation from the already-packaged `pyobjc-framework-Quartz`:

- same `pyobjc-core` monorepo `src`, same version (11.1)
- same build/patch steps (the `sw_vers`/`xcrun` postPatch) and `pyobjc-core` + Cocoa deps
- only the source subdir and the `pythonImportsCheck` are retargeted

This tracks any nixpkgs build fixes to Quartz automatically. The binding is lazy and Darwin-gated (`lib.optionals isDarwin`), so Linux builds never force or evaluate it.

## Tests

Adds `coreLocationBundled` to the Darwin-only `passthru.tests`, mirroring `screenBundled`: imports `CoreLocation` and checks `CLLocationManager` is constructible.

Verified locally on aarch64-darwin: the `mcp` package and every `passthru.test` build green on the head SHA, except the pre-existing `imessageSmoke` failure (`no such column: ZUNIQUEID`, an environment-dependent Contacts-DB schema issue that reproduces identically on `origin/main` and is unrelated to this change).

```python
>>> import CoreLocation
>>> CoreLocation.CLLocationManager.alloc().init()
<CLLocationManager ...>
```

(sent by an AI agent via Claude Code, model claude-opus-4-8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bundle `pyobjc-framework-CoreLocation` in the MCP kernel on Darwin
> - Adds a `coreLocationModule` package derived from `pyobjc-framework-Quartz` sources, overriding `pname`, `sourceRoot`, and `pythonImportsCheck` to target the CoreLocation subdirectory.
> - Includes `coreLocationModule` in `darwinExtraPackages` so `import CoreLocation` succeeds at runtime on macOS.
> - Adds a `coreLocationBundled` passthru test in [default.nix](https://github.com/indexable-inc/index/pull/1145/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) that verifies `CoreLocation.CLLocationManager.alloc` is callable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f7a991.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->