### PR TITLE
mcp: bundle pyobjc ScriptingBridge binding on Darwin

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -687,16 +687,33 @@ let
     };
   });
 
+  # `import ScriptingBridge` on Darwin: the pyobjc binding for Apple's Scripting
+  # Bridge, so a session can drive any scriptable macOS app (Things, Music,
+  # Finder, ...) as native Objective-C objects — `SBApplication` — with no
+  # AppleScript strings and no install step. nixpkgs omits this binding too, so
+  # derive it from Quartz the same way as `coreLocationModule` above (same
+  # monorepo src, only the source subdir and import check change).
+  scriptingBridgeModule = pkgs.python3.pkgs.pyobjc-framework-Quartz.overridePythonAttrs (old: {
+    pname = "pyobjc-framework-ScriptingBridge";
+    sourceRoot = "${old.src.name}/pyobjc-framework-ScriptingBridge";
+    pythonImportsCheck = [ "ScriptingBridge" ];
+    meta = old.meta // {
+      description = "PyObjC wrappers for the Scripting Bridge framework on macOS";
+    };
+  });
+
   # The `screen` helper is macOS-only, so its dependencies join the interpreter
   # only on Darwin. `pyobjc-framework-Quartz` is the maintained CoreGraphics
   # binding the helper wraps; Pillow (already transitive via matplotlib) carries
   # the PIL image type capture returns. `coreLocationModule` adds the Core
-  # Location binding so location reads work out of the box.
+  # Location binding so location reads work out of the box, and
+  # `scriptingBridgeModule` the Scripting Bridge binding for app automation.
   darwinExtraPackages =
     ps:
     lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
       ps.pyobjc-framework-Quartz
       coreLocationModule
+      scriptingBridgeModule
       screenModule
       vmkitModule
       imessageModule
@@ -4312,6 +4329,7 @@ let
 
   screenBundled = importTest "screen" "import screen; print('screen-ok', all(callable(getattr(screen, n)) for n in ('capture', 'click', 'write', 'press', 'key_down', 'key_up', 'apps', 'frontmost', 'launch', 'activate', 'terminate', 'accessibility_trusted')))";
   coreLocationBundled = importTest "corelocation" "import CoreLocation; print('corelocation-ok', callable(CoreLocation.CLLocationManager.alloc))";
+  scriptingBridgeBundled = importTest "scriptingbridge" "import ScriptingBridge; print('scriptingbridge-ok', callable(ScriptingBridge.SBApplication.applicationWithBundleIdentifier_))";
   vmkitBundled = importTest "vmkit" "import vmkit; print('vmkit-ok', callable(vmkit.boot_linux), callable(vmkit.drive), callable(vmkit.screenshot))";
   imessageBundled = importTest "imessage" "import imessage; print('imessage-ok', all(callable(getattr(imessage, n)) for n in ('messages', 'chats', 'contacts', 'send')))";
   xBundled = importTest "x" "import x; print('x-ok', callable(x.posts), x.__version__)";
@@ -4432,6 +4450,7 @@ package.overrideAttrs (old: {
       inherit
         screenBundled
         coreLocationBundled
+        scriptingBridgeBundled
         vmkitBundled
         vmkitResourceSmoke
         imessageBundled


### PR DESCRIPTION
## What

Bundle the **pyobjc `ScriptingBridge`** framework binding into the kernel interpreter on Darwin, so a session can drive any scriptable macOS app (Things, Music, Finder, Safari, ...) via native `SBApplication` objects — no AppleScript strings, no install step.

Before this, the kernel had pyobjc-core (`objc`, `Foundation`, `AppKit`) but `import ScriptingBridge` failed (`find_spec` → None); you had to fall back to `objc.loadBundle(...)` by hand each session.

## How

nixpkgs ships only a curated subset of pyobjc framework bindings and omits ScriptingBridge. Every binding lives as a sibling subdir in the pyobjc monorepo `src`, so this derives the wrapper from `pyobjc-framework-Quartz` by retargeting only `sourceRoot` + `pythonImportsCheck` — exactly the existing `coreLocationModule` pattern. Tracks nixpkgs Quartz build fixes automatically.

- New `scriptingBridgeModule`, added to `darwinExtraPackages`.
- New `scriptingBridgeBundled` import smoke test, wired into the Darwin `passthru.tests`.

## Verification

```
nix build .#mcp.tests.scriptingBridgeBundled   # builds + import check passes
nix run .#lint                                  # 7/7 succeeded
```

Confirmed live: listed 5 Things3 to-dos through `SBApplication.applicationWithBundleIdentifier_("com.culturedcode.ThingsMac")`.

🤖 Authored by Claude (Opus 4.8) via Claude Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bundle pyobjc ScriptingBridge binding in the MCP package on Darwin
> - Adds a new `pyobjc-framework-ScriptingBridge` derivation in [default.nix](https://github.com/indexable-inc/index/pull/1294/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) by overriding the pyobjc-framework-Quartz package attributes to point at the ScriptingBridge subdirectory.
> - Includes the binding in `darwinExtraPackages` so `import ScriptingBridge` is available at runtime on macOS.
> - Adds a build-time import test that checks `SBApplication.applicationWithBundleIdentifier_` is callable, wired into the package's test phase.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7dfd73d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->