### PR TITLE
claude-code: bake house prompt as system prompt, not append

### DIFF
--- a/docs/claude-code/overview.md
+++ b/docs/claude-code/overview.md
@@ -76,8 +76,9 @@ positional). Both rules are learned from real breakage; see the long comment at
   sandboxes). Gated on `dangerouslySkipPermissions` (below). Mind the upstream
   uid-0 guard: the CLI refuses this flag for an unsandboxed root user, so root
   consumers carry their own `IS_SANDBOX=1` or turn the flag off.
-- `--append-system-prompt-file=<store path>`: the house system prompt (below),
-  baked by path so content needs no shell quoting.
+- `--system-prompt-file=<store path>`: the house system prompt (below),
+  baked by path so content needs no shell quoting. It REPLACES the stock prompt
+  rather than appending to it.
 - `--mcp-config=<file>`: the baked MCP server set (below).
 
 ### Conditional `--settings` (injected only when the caller passes none)
@@ -114,10 +115,10 @@ Defaults to the house pair, additions only:
 - `exa`: Exa's hosted web-search server over streamable HTTP at
   `https://mcp.exa.ai/mcp` (keyless, rate-limited).
 
-### Appended system prompt (`system-prompt.nix`)
+### System prompt (`system-prompt.nix`)
 
-`appendSystemPrompt` appends the house rules to the stock system prompt, never
-replacing it (`default.nix:96-112`). The text is the shokunin craft ethos plus
+`systemPrompt` is baked as the session's system prompt, REPLACING the stock one
+rather than appending to it (`default.nix:95-113`). The text is the shokunin craft ethos plus
 fleet engineering rules: pre-v1 no-backward-compatibility, one-concept-one-
 implementation, always work in a git worktree, spawn background subagents for
 independent work, do work through the index Python kernel and `search` priors,
@@ -154,7 +155,7 @@ and on Linux the sandbox helpers `bubblewrap` and `socat`.
 
 `default.nix` exposes these args: `binName` (default `claude`),
 `dangerouslySkipPermissions`, `extraSettings`, `primaryCheckouts`, `mcpServers`,
-`appendSystemPrompt`. Example: `claude-code.override { dangerouslySkipPermissions = false; }`.
+`systemPrompt`. Example: `claude-code.override { dangerouslySkipPermissions = false; }`.
 
 ## Build and wiring
 

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -92,23 +92,23 @@
       (import (ix.paths.packagesRoot + "/agent/common.nix") { inherit lib ix repoPackages; })
       .houseServers,
 
-  # Text APPENDED to Claude Code's stock system prompt. The string is
-  # materialized to a store file and baked into the wrapper as
-  # `--append-system-prompt-file=<path>`: passing by path (not inline text)
-  # keeps arbitrary content free of shell quoting, and the store path makes the
-  # flag one self-contained argv token (see `wrapperFlags` for why every
-  # injected option-argument uses the `=` form).
-  # Append, never replace: the stock prompt (tool guidance, safety rules,
-  # coding conventions) stays intact and these house rules ride on top.
-  # Prepended before the user argv so an explicit
-  # `--append-system-prompt`/`--append-system-prompt-file` on the CLI still
-  # wins (single-value options are last-wins), and a caller who really wants a
-  # wholesale replacement can still pass `--system-prompt[-file]`. Defaults to
-  # the shared house prompt (`systemPrompt` in ../common.nix, authored in
-  # ../system-prompt.nix: the shokunin craft ethos plus the pre-v1
+  # Text used AS Claude Code's system prompt, REPLACING the stock prompt. The
+  # string is materialized to a store file and baked into the wrapper as
+  # `--system-prompt-file=<path>`: passing by path (not inline text) keeps
+  # arbitrary content free of shell quoting, and the store path makes the flag
+  # one self-contained argv token (see `wrapperFlags` for why every injected
+  # option-argument uses the `=` form).
+  # Set, not append: this wholly replaces the stock prompt (tool guidance,
+  # safety rules, coding conventions) rather than riding on top of it, so the
+  # baked text owns the entire system prompt. Prepended before the user argv so
+  # an explicit `--system-prompt`/`--system-prompt-file` on the CLI still wins
+  # (single-value options are last-wins), and a caller who wants the stock
+  # prompt plus additions can still pass `--append-system-prompt[-file]`.
+  # Defaults to the shared house prompt (`systemPrompt` in ../common.nix,
+  # authored in ../system-prompt.nix: the shokunin craft ethos plus the pre-v1
   # backward-compatibility engineering rule, plus a preference for working in git
   # worktrees); set to `null` to bake no flag and ship the stock prompt alone.
-  appendSystemPrompt ?
+  systemPrompt ?
     (import (ix.paths.packagesRoot + "/agent/common.nix") { inherit lib ix repoPackages; })
     .systemPrompt,
 
@@ -356,9 +356,9 @@ let
     "--thinking-display=summarized"
   ]
   ++ lib.optional dangerouslySkipPermissions "--dangerously-skip-permissions"
-  ++
-    lib.optional (appendSystemPrompt != null)
-      "--append-system-prompt-file=${builtins.toFile "claude-code-append-system-prompt.txt" appendSystemPrompt}"
+  ++ lib.optional (
+    systemPrompt != null
+  ) "--system-prompt-file=${builtins.toFile "claude-code-system-prompt.txt" systemPrompt}"
   ++ lib.optional (mcpServers != { }) "--mcp-config=${mcpConfigFile}";
 
   envEntries = attrs: lib.mapAttrsToList (key: value: { inherit key value; }) attrs;

--- a/packages/agent/common.nix
+++ b/packages/agent/common.nix
@@ -13,9 +13,9 @@
   repoPackages ? { },
 }:
 {
-  # House rules a wrapper appends to its agent's stock system prompt. One
-  # paragraph per list element; see ./system-prompt.nix for the authored text
-  # and how claude-code bakes it (`appendSystemPrompt`).
+  # The house system prompt a wrapper bakes for its agent. One paragraph per
+  # list element; see ./system-prompt.nix for the authored text and how
+  # claude-code bakes it (`systemPrompt`, which REPLACES the stock prompt).
   systemPrompt = import ./system-prompt.nix { inherit lib; };
 
   # The house MCP servers (the `index` kernel plus `exa` web search), rendered

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -1,7 +1,7 @@
 { lib }:
-# House rules appended to Claude Code's stock system prompt (see the
-# `appendSystemPrompt` argument in ./claude-code/default.nix for how this string
-# is baked into the wrapper, surfaced as `systemPrompt` by ./common.nix).
+# The house system prompt Claude Code runs with, REPLACING the stock prompt
+# (see the `systemPrompt` argument in ./claude-code/default.nix for how this
+# string is baked into the wrapper, surfaced as `systemPrompt` by ./common.nix).
 # Each rule is a named binding so it is addressable from source; `order` then
 # fixes how the rules read top-to-bottom, and they are joined with blank lines so
 # a rule reads as a self-contained line instead of buried in indented-string prose.


### PR DESCRIPTION
## What

Default the `claude-code` wrapper to bake the house prompt as the session's **system prompt** (`--system-prompt-file`) instead of **appending** it (`--append-system-prompt-file`). The house prompt (`packages/agent/system-prompt.nix`) now *replaces* Claude Code's stock system prompt rather than riding on top of it.

## Changes

- `packages/agent/claude-code/default.nix`: rename override arg `appendSystemPrompt` → `systemPrompt`; switch the baked flag to `--system-prompt-file=`; rewrite the arg + `wrapperFlags` comments for the new (set, not append) semantics.
- `packages/agent/common.nix`, `packages/agent/system-prompt.nix`: update comments to reflect that the shared `systemPrompt` now replaces the stock prompt (it is consumed only by claude-code; codex uses only `houseServers`).
- `docs/claude-code/overview.md`: update flag docs, the system-prompt section, and the overrides list.

A caller who still wants stock + additions can pass `--append-system-prompt[-file]` on the CLI (last-wins single-value option). `systemPrompt = null` ships the stock prompt alone.

## Verification

- `nix build .#claude-code -L` passes, including the `install-check.nix` argv net (it computes expected argv from `wrapperFlags`, so it tracked the flag change automatically). Baked flag confirmed: `--system-prompt-file=/nix/store/...-claude-code-system-prompt.txt`.
- `nix run .#lint` green.

(sent by an AI agent via Claude Code, Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `--append-system-prompt-file` with `--system-prompt-file` in claude-code wrapper
> Changes the baked house prompt from appending to the stock Claude Code system prompt to fully replacing it. Updates the wrapper flag from `--append-system-prompt-file` to `--system-prompt-file`, renames the `appendSystemPrompt` argument to `systemPrompt` in [default.nix](https://github.com/indexable-inc/index/pull/1295/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8), and renames the materialized file from `claude-code-append-system-prompt.txt` to `claude-code-system-prompt.txt`. Behavioral Change: when a system prompt is baked, the stock Claude Code prompt is no longer present at runtime — it is fully replaced by the custom text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3854c34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->