### PR TITLE
claude-code: add extractSystemPrompt tool to dump the stock system prompt

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   ix,
+  pkgs,
   stdenv,
   fetchurl,
   runtimeShell,
@@ -418,7 +419,7 @@ let
     else
       import ./update.nix { inherit writeNushellApplication nix gnupg; };
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "claude-code";
   inherit version;
 
@@ -480,7 +481,16 @@ stdenv.mkDerivation {
       ;
   };
 
-  passthru = lib.optionalAttrs (updateScript != null) {
+  passthru = {
+    # Prints the stock upstream system prompt (no house overrides) by capturing
+    # what the unwrapped libexec helper sends to a local ANTHROPIC_BASE_URL
+    # server. See ./extract-system-prompt.nix and ./extract-system-prompt.py.
+    extractSystemPrompt = import ./extract-system-prompt.nix {
+      inherit ix pkgs;
+      claudeBinary = "${finalAttrs.finalPackage}/libexec/Claude Code";
+    };
+  }
+  // lib.optionalAttrs (updateScript != null) {
     inherit updateScript;
   };
 
@@ -495,4 +505,4 @@ stdenv.mkDerivation {
     platforms = builtins.attrNames manifest.platforms;
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };
-}
+})

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -487,7 +487,8 @@ stdenv.mkDerivation (finalAttrs: {
     # server. See ./extract-system-prompt.nix and ./extract-system-prompt.py.
     extractSystemPrompt = import ./extract-system-prompt.nix {
       inherit ix pkgs;
-      claudeBinary = "${finalAttrs.finalPackage}/libexec/Claude Code";
+      stockBinary = "${finalAttrs.finalPackage}/libexec/Claude Code";
+      wrappedBinary = "${finalAttrs.finalPackage}/bin/${binName}";
     };
   }
   // lib.optionalAttrs (updateScript != null) {

--- a/packages/agent/claude-code/extract-system-prompt.nix
+++ b/packages/agent/claude-code/extract-system-prompt.nix
@@ -1,0 +1,32 @@
+# Maintainer-facing tool that prints the STOCK Claude Code system prompt, with
+# none of this package's house overrides applied. It works without binary
+# disassembly or TLS interception: Claude Code honors `ANTHROPIC_BASE_URL`, so
+# the script points the unwrapped upstream binary at a throwaway localhost
+# server, runs it once in print mode from a clean HOME/cwd, and dumps the exact
+# `system` blocks (and tool schemas) the binary transmits. The CLI assembles the
+# prompt itself, so the result is faithful rather than reconstructed from
+# fragments. See extract-system-prompt.py for the full rationale.
+#
+#   nix run .#claude-code.extractSystemPrompt              # readable prompt text
+#   nix run .#claude-code.extractSystemPrompt -- --json    # {model, system, tools}
+#   nix run .#claude-code.extractSystemPrompt -- --tools   # prompt + tool schemas
+{
+  ix,
+  pkgs,
+  # The unwrapped upstream binary: this package's libexec helper, which is the
+  # stock download (autopatchelfed on Linux) with NO baked
+  # --append-system-prompt-file, MCP config, or settings. Running the
+  # `$out/bin` wrapper instead would fold the house prompt into the capture.
+  claudeBinary,
+}:
+ix.writePythonApplication pkgs {
+  name = "claude-code-extract-system-prompt";
+  src = ./extract-system-prompt.py;
+  # Bake the stock binary as the default probe target; a user-supplied
+  # `--claude-binary` on the CLI lands later in argv and overrides it.
+  args = [
+    "--claude-binary"
+    claudeBinary
+  ];
+  meta.description = "Capture the stock Claude Code system prompt via a local ANTHROPIC_BASE_URL server";
+}

--- a/packages/agent/claude-code/extract-system-prompt.nix
+++ b/packages/agent/claude-code/extract-system-prompt.nix
@@ -1,32 +1,38 @@
-# Maintainer-facing tool that prints the STOCK Claude Code system prompt, with
-# none of this package's house overrides applied. It works without binary
-# disassembly or TLS interception: Claude Code honors `ANTHROPIC_BASE_URL`, so
-# the script points the unwrapped upstream binary at a throwaway localhost
-# server, runs it once in print mode from a clean HOME/cwd, and dumps the exact
-# `system` blocks (and tool schemas) the binary transmits. The CLI assembles the
-# prompt itself, so the result is faithful rather than reconstructed from
+# Maintainer-facing tool that prints the Claude Code system prompt as actually
+# sent, and can diff the stock upstream prompt against this package's overridden
+# one. It works without binary disassembly or TLS interception: Claude Code
+# honors `ANTHROPIC_BASE_URL`, so the script points a binary at a throwaway
+# localhost server, runs it once in print mode from a clean HOME/cwd, and dumps
+# the exact `system` blocks (and tool schemas) it transmits. The CLI assembles
+# the prompt itself, so the result is faithful rather than reconstructed from
 # fragments. See extract-system-prompt.py for the full rationale.
 #
-#   nix run .#claude-code.extractSystemPrompt              # readable prompt text
-#   nix run .#claude-code.extractSystemPrompt -- --json    # {model, system, tools}
-#   nix run .#claude-code.extractSystemPrompt -- --tools   # prompt + tool schemas
+#   nix run .#claude-code.extractSystemPrompt                  # stock prompt text
+#   nix run .#claude-code.extractSystemPrompt -- --mode wrapped  # house-overridden
+#   nix run .#claude-code.extractSystemPrompt -- --mode diff     # stock vs wrapped
+#   nix run .#claude-code.extractSystemPrompt -- --json          # {model,system,tools}
 {
   ix,
   pkgs,
-  # The unwrapped upstream binary: this package's libexec helper, which is the
-  # stock download (autopatchelfed on Linux) with NO baked
-  # --append-system-prompt-file, MCP config, or settings. Running the
-  # `$out/bin` wrapper instead would fold the house prompt into the capture.
-  claudeBinary,
+  # The unwrapped upstream binary: this package's libexec helper, the stock
+  # download (autopatchelfed on Linux) with NO baked --system-prompt-file, MCP
+  # config, or settings.
+  stockBinary,
+  # The wrapped launcher (`bin/claude`): the config-launch wrapper that applies
+  # the house --system-prompt-file (full prompt replacement), --mcp-config, and
+  # --settings. Probing this shows what our daily-driver prompt collapses to.
+  wrappedBinary,
 }:
 ix.writePythonApplication pkgs {
   name = "claude-code-extract-system-prompt";
   src = ./extract-system-prompt.py;
-  # Bake the stock binary as the default probe target; a user-supplied
-  # `--claude-binary` on the CLI lands later in argv and overrides it.
+  # Bake both probe targets as defaults; a user-supplied --stock-binary /
+  # --wrapped-binary on the CLI lands later in argv and overrides them.
   args = [
-    "--claude-binary"
-    claudeBinary
+    "--stock-binary"
+    stockBinary
+    "--wrapped-binary"
+    wrappedBinary
   ];
-  meta.description = "Capture the stock Claude Code system prompt via a local ANTHROPIC_BASE_URL server";
+  meta.description = "Capture and diff the stock vs house-overridden Claude Code system prompt via a local ANTHROPIC_BASE_URL server";
 }

--- a/packages/agent/claude-code/extract-system-prompt.py
+++ b/packages/agent/claude-code/extract-system-prompt.py
@@ -132,6 +132,8 @@ async def capture(
                 )
                 await writer.drain()
         except (ConnectionError, asyncio.IncompleteReadError):
+            # The CLI hung up mid-exchange (it got its response, or we killed it
+            # after capture). Expected teardown, nothing to handle.
             pass
         finally:
             with contextlib.suppress(Exception):

--- a/packages/agent/claude-code/extract-system-prompt.py
+++ b/packages/agent/claude-code/extract-system-prompt.py
@@ -1,0 +1,260 @@
+"""Extract the stock Claude Code system prompt by capturing what the binary sends.
+
+Claude Code natively honors `ANTHROPIC_BASE_URL`, so there is no need to defeat
+the binary's packaging or do TLS interception: point the real upstream `claude`
+at a throwaway localhost server, run it once in print mode, and read the exact
+`system` blocks (and tool schemas) out of the request it transmits. The CLI does
+the prompt assembly for us, interpolating its environment block, and hands over
+the finished payload on a socket we own.
+
+Two deliberate isolation choices keep the result the *stock* prompt:
+
+  - It runs the unwrapped upstream binary (the package's `libexec` helper baked
+    in as `--claude-binary`), never the Nix wrapper that bakes our house
+    `--append-system-prompt-file`, MCP config, and settings.
+  - It runs from a fresh temp HOME and an empty temp cwd, so no `~/.claude`
+    settings, no project `CLAUDE.md`, and no git status leak into the capture.
+
+The capture is print mode (`claude -p`), which uses the Agent SDK entrypoint, so
+the identity line reads "You are a Claude agent, built on Anthropic's Claude
+Agent SDK." rather than the interactive "You are Claude Code, ...". The body of
+the prompt is otherwise the same; the interactive variant requires driving the
+TUI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+from typing import Any
+
+# Baked at build time via the writePythonApplication `args` prefix
+# (`--claude-binary <libexec helper>`); a user-supplied `--claude-binary` on the
+# CLI appears later in argv and wins, so this is only the default.
+DEFAULT_BINARY = "claude"
+
+
+async def _read_http_request(reader: asyncio.StreamReader) -> tuple[str, bytes]:
+    """Read one HTTP/1.1 request, returning (request_line, body)."""
+    head = b""
+    while b"\r\n\r\n" not in head:
+        chunk = await reader.read(65536)
+        if not chunk:
+            break
+        head += chunk
+    raw_head, _, rest = head.partition(b"\r\n\r\n")
+    lines = raw_head.decode("latin1").split("\r\n")
+    request_line = lines[0] if lines else ""
+    content_length = 0
+    for line in lines[1:]:
+        if line.lower().startswith("content-length:"):
+            with contextlib.suppress(ValueError):
+                content_length = int(line.split(":", 1)[1].strip())
+    body = rest
+    while len(body) < content_length:
+        chunk = await reader.read(65536)
+        if not chunk:
+            break
+        body += chunk
+    return request_line, body
+
+
+async def capture(
+    binary: str,
+    *,
+    model: str,
+    prompt: str,
+    timeout: float,
+) -> dict[str, Any]:
+    """Run `binary` against a one-shot capture server; return the Messages body.
+
+    Raises RuntimeError if the binary never sends a `/v1/messages` request.
+    """
+    captured: list[dict[str, Any]] = []
+    done = asyncio.Event()
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        request_line, body = await _read_http_request(reader)
+        is_messages = (
+            request_line.startswith("POST ")
+            and "/v1/messages" in request_line
+            and "count_tokens" not in request_line
+        )
+        if is_messages and body and not captured:
+            with contextlib.suppress(json.JSONDecodeError):
+                parsed: dict[str, Any] = json.loads(body)
+                captured.append(parsed)
+                done.set()
+        # Minimal valid Messages response so the CLI exits cleanly; by now we
+        # already hold the request we came for, so its fate does not matter.
+        payload = json.dumps(
+            {
+                "id": "msg_capture",
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            }
+        ).encode()
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+            b"Content-Length: %d\r\n\r\n" % len(payload) + payload
+        )
+        with contextlib.suppress(Exception):
+            await writer.drain()
+            writer.close()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    serving = asyncio.create_task(server.serve_forever())
+
+    home = tempfile.mkdtemp(prefix="claude-extract-home-")
+    cwd = tempfile.mkdtemp(prefix="claude-extract-cwd-")
+    env = {
+        **os.environ,
+        "HOME": home,
+        "XDG_CONFIG_HOME": f"{home}/.config",
+        "ANTHROPIC_BASE_URL": f"http://127.0.0.1:{port}",
+        "ANTHROPIC_API_KEY": "sk-ant-extract-dummy",
+        "DISABLE_TELEMETRY": "1",
+        "DISABLE_ERROR_REPORTING": "1",
+        "DISABLE_AUTOUPDATER": "1",
+        "DISABLE_INSTALLATION_CHECKS": "1",
+    }
+    proc = await asyncio.create_subprocess_exec(
+        binary,
+        "-p",
+        prompt,
+        "--model",
+        model,
+        cwd=cwd,
+        env=env,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    try:
+        comm = asyncio.create_task(proc.communicate())
+        _, pending = await asyncio.wait(
+            {comm, asyncio.create_task(done.wait())},
+            timeout=timeout,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+    finally:
+        if proc.returncode is None:
+            proc.kill()
+            with contextlib.suppress(Exception):
+                await proc.wait()
+        serving.cancel()
+        server.close()
+        with contextlib.suppress(Exception):
+            await server.wait_closed()
+        shutil.rmtree(home, ignore_errors=True)
+        shutil.rmtree(cwd, ignore_errors=True)
+
+    if not captured:
+        raise RuntimeError(
+            f"{binary} sent no /v1/messages request within {timeout:.0f}s; "
+            "the binary may have failed to start (check it runs standalone)."
+        )
+    return captured[0]
+
+
+def render_text(body: dict[str, Any], *, include_tools: bool) -> str:
+    """Render the captured system blocks (and optionally tools) as readable text."""
+    out: list[str] = []
+    system = body.get("system", [])
+    blocks = system if isinstance(system, list) else [{"text": system}]
+    for i, block in enumerate(blocks):
+        cache = block.get("cache_control")
+        out.append(f"===== system block {i} (cache_control={cache}) =====")
+        out.append(str(block.get("text", "")))
+        out.append("")
+    if include_tools:
+        tools = body.get("tools", [])
+        out.append(f"===== tools ({len(tools)}) =====")
+        for tool in tools:
+            name = tool.get("name", "?")
+            desc = (tool.get("description") or "").strip()
+            out.append(f"\n## {name}\n")
+            out.append(desc)
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="claude-code-extract-system-prompt",
+        description="Capture and print the stock Claude Code system prompt.",
+    )
+    parser.add_argument(
+        "--claude-binary",
+        default=DEFAULT_BINARY,
+        help="Path to the upstream claude binary to probe (default: baked libexec helper).",
+    )
+    parser.add_argument(
+        "--model",
+        default="claude-opus-4-8",
+        help="Model id passed to `claude -p` (default: claude-opus-4-8).",
+    )
+    parser.add_argument(
+        "--prompt",
+        default="hi",
+        help="Throwaway user message used to trigger one request (default: 'hi').",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=90.0,
+        help="Seconds to wait for the request before giving up (default: 90).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print {model, system, tools} as JSON instead of readable text.",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Print the entire captured request body as JSON.",
+    )
+    parser.add_argument(
+        "--tools",
+        action="store_true",
+        help="In text mode, also print tool names and descriptions.",
+    )
+    parsed = parser.parse_args()
+
+    try:
+        body = asyncio.run(
+            capture(
+                parsed.claude_binary,
+                model=parsed.model,
+                prompt=parsed.prompt,
+                timeout=parsed.timeout,
+            )
+        )
+    except RuntimeError as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+    if parsed.raw:
+        print(json.dumps(body, indent=2, ensure_ascii=False))
+    elif parsed.json:
+        subset = {key: body[key] for key in ("model", "system", "tools") if key in body}
+        print(json.dumps(subset, indent=2, ensure_ascii=False))
+    else:
+        sys.stdout.write(render_text(body, include_tools=parsed.tools))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/agent/claude-code/extract-system-prompt.py
+++ b/packages/agent/claude-code/extract-system-prompt.py
@@ -41,14 +41,17 @@ DEFAULT_BINARY = "claude"
 
 
 async def _read_http_request(reader: asyncio.StreamReader) -> tuple[str, bytes]:
-    """Read one HTTP/1.1 request, returning (request_line, body)."""
-    head = b""
-    while b"\r\n\r\n" not in head:
-        chunk = await reader.read(65536)
-        if not chunk:
-            break
-        head += chunk
-    raw_head, _, rest = head.partition(b"\r\n\r\n")
+    """Read exactly one HTTP/1.1 request, returning (request_line, body).
+
+    Consumes precisely the headers and Content-Length body from the stream and
+    leaves anything after untouched, so a keep-alive connection that pipelines a
+    second request (e.g. count_tokens then messages on one socket) reads cleanly
+    on the next call. Returns ("", b"") at end of stream.
+    """
+    try:
+        raw_head = await reader.readuntil(b"\r\n\r\n")
+    except (asyncio.IncompleteReadError, asyncio.LimitOverrunError):
+        return "", b""
     lines = raw_head.decode("latin1").split("\r\n")
     request_line = lines[0] if lines else ""
     content_length = 0
@@ -56,12 +59,12 @@ async def _read_http_request(reader: asyncio.StreamReader) -> tuple[str, bytes]:
         if line.lower().startswith("content-length:"):
             with contextlib.suppress(ValueError):
                 content_length = int(line.split(":", 1)[1].strip())
-    body = rest
-    while len(body) < content_length:
-        chunk = await reader.read(65536)
-        if not chunk:
-            break
-        body += chunk
+    body = b""
+    if content_length:
+        try:
+            body = await reader.readexactly(content_length)
+        except asyncio.IncompleteReadError as err:
+            body = err.partial
     return request_line, body
 
 
@@ -80,55 +83,83 @@ async def capture(
     done = asyncio.Event()
 
     async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-        request_line, body = await _read_http_request(reader)
-        is_messages = (
-            request_line.startswith("POST ")
-            and "/v1/messages" in request_line
-            and "count_tokens" not in request_line
-        )
-        if is_messages and body and not captured:
-            with contextlib.suppress(json.JSONDecodeError):
-                parsed: dict[str, Any] = json.loads(body)
-                captured.append(parsed)
-                done.set()
-        # Minimal valid Messages response so the CLI exits cleanly; by now we
-        # already hold the request we came for, so its fate does not matter.
-        payload = json.dumps(
-            {
-                "id": "msg_capture",
-                "type": "message",
-                "role": "assistant",
-                "model": model,
-                "content": [{"type": "text", "text": "ok"}],
-                "stop_reason": "end_turn",
-                "usage": {"input_tokens": 1, "output_tokens": 1},
-            }
-        ).encode()
-        writer.write(
-            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
-            b"Content-Length: %d\r\n\r\n" % len(payload) + payload
-        )
-        with contextlib.suppress(Exception):
-            await writer.drain()
-            writer.close()
+        # Serve every request on the connection until EOF, so a keep-alive CLI
+        # that reuses one socket for count_tokens then messages is still caught.
+        try:
+            while True:
+                request_line, body = await _read_http_request(reader)
+                if not request_line:
+                    break
+                is_messages = (
+                    request_line.startswith("POST ")
+                    and "/v1/messages" in request_line
+                    and "count_tokens" not in request_line
+                )
+                if is_messages and body and not captured:
+                    with contextlib.suppress(json.JSONDecodeError):
+                        parsed: dict[str, Any] = json.loads(body)
+                        captured.append(parsed)
+                        done.set()
+                # Minimal valid Messages response so the CLI exits cleanly; by
+                # now we already hold the request we came for, so its fate does
+                # not matter.
+                payload = json.dumps(
+                    {
+                        "id": "msg_capture",
+                        "type": "message",
+                        "role": "assistant",
+                        "model": model,
+                        "content": [{"type": "text", "text": "ok"}],
+                        "stop_reason": "end_turn",
+                        "usage": {"input_tokens": 1, "output_tokens": 1},
+                    }
+                ).encode()
+                writer.write(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                    b"Content-Length: %d\r\n\r\n" % len(payload) + payload
+                )
+                await writer.drain()
+        except (ConnectionError, asyncio.IncompleteReadError):
+            pass
+        finally:
+            with contextlib.suppress(Exception):
+                writer.close()
 
-    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    # Raise the per-connection buffer limit well above a captured request body
+    # (prompt + ~20 tool schemas runs tens of KiB) so readuntil never overruns.
+    server = await asyncio.start_server(handle, "127.0.0.1", 0, limit=4 * 1024 * 1024)
     port = server.sockets[0].getsockname()[1]
     serving = asyncio.create_task(server.serve_forever())
 
     home = tempfile.mkdtemp(prefix="claude-extract-home-")
     cwd = tempfile.mkdtemp(prefix="claude-extract-cwd-")
-    env = {
-        **os.environ,
-        "HOME": home,
-        "XDG_CONFIG_HOME": f"{home}/.config",
-        "ANTHROPIC_BASE_URL": f"http://127.0.0.1:{port}",
-        "ANTHROPIC_API_KEY": "sk-ant-extract-dummy",
-        "DISABLE_TELEMETRY": "1",
-        "DISABLE_ERROR_REPORTING": "1",
-        "DISABLE_AUTOUPDATER": "1",
-        "DISABLE_INSTALLATION_CHECKS": "1",
+    # Drop anything that would defeat the capture: a *_PROXY would route the
+    # loopback request away from our server, and a real auth token would let the
+    # CLI pick a non-API-key auth mode. We pin our own base URL + dummy key below.
+    stripped = {
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
     }
+    env = {k: v for k, v in os.environ.items() if k.upper() not in stripped}
+    env.update(
+        {
+            "HOME": home,
+            "XDG_CONFIG_HOME": f"{home}/.config",
+            "ANTHROPIC_BASE_URL": f"http://127.0.0.1:{port}",
+            "ANTHROPIC_API_KEY": "sk-ant-extract-dummy",
+            "NO_PROXY": "127.0.0.1,localhost",
+            "no_proxy": "127.0.0.1,localhost",
+            "DISABLE_TELEMETRY": "1",
+            "DISABLE_ERROR_REPORTING": "1",
+            "DISABLE_AUTOUPDATER": "1",
+            "DISABLE_INSTALLATION_CHECKS": "1",
+        }
+    )
     proc = await asyncio.create_subprocess_exec(
         binary,
         "-p",
@@ -141,6 +172,10 @@ async def capture(
         stderr=asyncio.subprocess.STDOUT,
     )
     try:
+        # Return as soon as the request is captured (done) OR the child exits
+        # early without sending one (comm). `comm` exists only to detect that
+        # early exit so we don't wait the full timeout; the process is reaped in
+        # the `finally` below, so the cancelled task here leaks nothing.
         comm = asyncio.create_task(proc.communicate())
         _, pending = await asyncio.wait(
             {comm, asyncio.create_task(done.wait())},

--- a/packages/agent/claude-code/extract-system-prompt.py
+++ b/packages/agent/claude-code/extract-system-prompt.py
@@ -1,25 +1,29 @@
-"""Extract the stock Claude Code system prompt by capturing what the binary sends.
+"""Capture the Claude Code system prompt by reading what the binary sends.
 
 Claude Code natively honors `ANTHROPIC_BASE_URL`, so there is no need to defeat
-the binary's packaging or do TLS interception: point the real upstream `claude`
-at a throwaway localhost server, run it once in print mode, and read the exact
+the binary's packaging or do TLS interception: point the real `claude` binary at
+a throwaway localhost server, run it once in print mode, and read the exact
 `system` blocks (and tool schemas) out of the request it transmits. The CLI does
 the prompt assembly for us, interpolating its environment block, and hands over
 the finished payload on a socket we own.
 
-Two deliberate isolation choices keep the result the *stock* prompt:
+It can probe two binaries and compare them (`--mode`):
 
-  - It runs the unwrapped upstream binary (the package's `libexec` helper baked
-    in as `--claude-binary`), never the Nix wrapper that bakes our house
-    `--append-system-prompt-file`, MCP config, and settings.
-  - It runs from a fresh temp HOME and an empty temp cwd, so no `~/.claude`
-    settings, no project `CLAUDE.md`, and no git status leak into the capture.
+  - stock: the unwrapped upstream binary (the package's `libexec` helper), which
+    is the plain download with no house overrides.
+  - wrapped: this package's launcher (`bin/claude`), which bakes the house
+    --system-prompt-file (a full replacement of the stock prompt), --mcp-config,
+    and --settings.
+  - diff: a unified diff of the two, plus which tools the wrapper adds/removes.
+
+Every capture runs from a fresh temp HOME and an empty temp cwd, so no
+`~/.claude` settings, no project `CLAUDE.md`, and no git status leak in; the
+only difference between stock and wrapped is the wrapper's own baked flags.
 
 The capture is print mode (`claude -p`), which uses the Agent SDK entrypoint, so
-the identity line reads "You are a Claude agent, built on Anthropic's Claude
-Agent SDK." rather than the interactive "You are Claude Code, ...". The body of
-the prompt is otherwise the same; the interactive variant requires driving the
-TUI.
+the stock identity line reads "You are a Claude agent, built on Anthropic's
+Claude Agent SDK." rather than the interactive "You are Claude Code, ...". The
+interactive variant requires driving the TUI.
 """
 
 from __future__ import annotations
@@ -27,6 +31,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import contextlib
+import difflib
 import json
 import os
 import shutil
@@ -35,9 +40,13 @@ import tempfile
 from typing import Any
 
 # Baked at build time via the writePythonApplication `args` prefix
-# (`--claude-binary <libexec helper>`); a user-supplied `--claude-binary` on the
-# CLI appears later in argv and wins, so this is only the default.
-DEFAULT_BINARY = "claude"
+# (`--stock-binary <libexec helper>` / `--wrapped-binary <bin/claude>`); a
+# user-supplied value on the CLI lands later in argv and wins, so these are only
+# defaults. "stock" is the unwrapped upstream binary; "wrapped" is the Nix
+# launcher that bakes this package's --system-prompt-file / --mcp-config /
+# --settings overrides.
+DEFAULT_STOCK_BINARY = "claude"
+DEFAULT_WRAPPED_BINARY = "claude"
 
 
 async def _read_http_request(reader: asyncio.StreamReader) -> tuple[str, bytes]:
@@ -204,12 +213,34 @@ async def capture(
     return captured[0]
 
 
+def _blocks(body: dict[str, Any]) -> list[dict[str, Any]]:
+    system = body.get("system", [])
+    return system if isinstance(system, list) else [{"text": system}]
+
+
+def system_text(body: dict[str, Any], *, skip_metadata: bool = False) -> str:
+    """Concatenate the system blocks into one string.
+
+    With skip_metadata, drop the leading `x-anthropic-billing-header` block,
+    which carries a per-run nonce that is noise in a diff.
+    """
+    out: list[str] = []
+    for block in _blocks(body):
+        text = str(block.get("text", ""))
+        if skip_metadata and text.startswith("x-anthropic-billing-header:"):
+            continue
+        out.append(text)
+    return "\n".join(out)
+
+
+def tool_names(body: dict[str, Any]) -> list[str]:
+    return [t.get("name", "?") for t in body.get("tools", [])]
+
+
 def render_text(body: dict[str, Any], *, include_tools: bool) -> str:
     """Render the captured system blocks (and optionally tools) as readable text."""
     out: list[str] = []
-    system = body.get("system", [])
-    blocks = system if isinstance(system, list) else [{"text": system}]
-    for i, block in enumerate(blocks):
+    for i, block in enumerate(_blocks(body)):
         cache = block.get("cache_control")
         out.append(f"===== system block {i} (cache_control={cache}) =====")
         out.append(str(block.get("text", "")))
@@ -225,15 +256,55 @@ def render_text(body: dict[str, Any], *, include_tools: bool) -> str:
     return "\n".join(out).rstrip() + "\n"
 
 
+def render_diff(stock: dict[str, Any], wrapped: dict[str, Any]) -> str:
+    """Unified diff of stock vs wrapped system prompt, plus a tool-set summary."""
+    out: list[str] = []
+    diff = difflib.unified_diff(
+        system_text(stock, skip_metadata=True).splitlines(),
+        system_text(wrapped, skip_metadata=True).splitlines(),
+        fromfile="stock (upstream)",
+        tofile="wrapped (house overrides)",
+        lineterm="",
+    )
+    out.extend(diff)
+    if not out:
+        out.append("(system prompts are identical)")
+
+    stock_tools, wrapped_tools = set(tool_names(stock)), set(tool_names(wrapped))
+    added = sorted(wrapped_tools - stock_tools)
+    removed = sorted(stock_tools - wrapped_tools)
+    out.append("")
+    out.append("===== tools =====")
+    out.append(f"stock: {len(stock_tools)}  |  wrapped: {len(wrapped_tools)}")
+    out.append(f"added by wrapper:   {', '.join(added) or '(none)'}")
+    out.append(f"removed by wrapper: {', '.join(removed) or '(none)'}")
+    return "\n".join(out) + "\n"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         prog="claude-code-extract-system-prompt",
-        description="Capture and print the stock Claude Code system prompt.",
+        description="Capture the Claude Code system prompt and tools as actually sent.",
     )
     parser.add_argument(
-        "--claude-binary",
-        default=DEFAULT_BINARY,
-        help="Path to the upstream claude binary to probe (default: baked libexec helper).",
+        "--mode",
+        choices=("stock", "wrapped", "diff"),
+        default="stock",
+        help=(
+            "stock: unwrapped upstream prompt (default). wrapped: this package's "
+            "binary with its --system-prompt-file / MCP / settings overrides. "
+            "diff: a unified diff of stock vs wrapped."
+        ),
+    )
+    parser.add_argument(
+        "--stock-binary",
+        default=DEFAULT_STOCK_BINARY,
+        help="Unwrapped upstream binary (default: baked libexec helper).",
+    )
+    parser.add_argument(
+        "--wrapped-binary",
+        default=DEFAULT_WRAPPED_BINARY,
+        help="Wrapped launcher with house overrides (default: baked bin/claude).",
     )
     parser.add_argument(
         "--model",
@@ -249,17 +320,17 @@ def main() -> int:
         "--timeout",
         type=float,
         default=90.0,
-        help="Seconds to wait for the request before giving up (default: 90).",
+        help="Seconds to wait for each request before giving up (default: 90).",
     )
     parser.add_argument(
         "--json",
         action="store_true",
-        help="Print {model, system, tools} as JSON instead of readable text.",
+        help="Print {model, system, tools} as JSON (stock/wrapped modes).",
     )
     parser.add_argument(
         "--raw",
         action="store_true",
-        help="Print the entire captured request body as JSON.",
+        help="Print the entire captured request body as JSON (stock/wrapped modes).",
     )
     parser.add_argument(
         "--tools",
@@ -268,15 +339,17 @@ def main() -> int:
     )
     parsed = parser.parse_args()
 
-    try:
-        body = asyncio.run(
-            capture(
-                parsed.claude_binary,
-                model=parsed.model,
-                prompt=parsed.prompt,
-                timeout=parsed.timeout,
-            )
+    def grab(binary: str) -> dict[str, Any]:
+        return asyncio.run(
+            capture(binary, model=parsed.model, prompt=parsed.prompt, timeout=parsed.timeout)
         )
+
+    try:
+        if parsed.mode == "diff":
+            sys.stdout.write(render_diff(grab(parsed.stock_binary), grab(parsed.wrapped_binary)))
+            return 0
+        binary = parsed.wrapped_binary if parsed.mode == "wrapped" else parsed.stock_binary
+        body = grab(binary)
     except RuntimeError as err:
         print(f"error: {err}", file=sys.stderr)
         return 1

--- a/packages/agent/claude-code/extract-system-prompt.py
+++ b/packages/agent/claude-code/extract-system-prompt.py
@@ -278,6 +278,10 @@ def render_diff(stock: dict[str, Any], wrapped: dict[str, Any]) -> str:
     out.append(f"stock: {len(stock_tools)}  |  wrapped: {len(wrapped_tools)}")
     out.append(f"added by wrapper:   {', '.join(added) or '(none)'}")
     out.append(f"removed by wrapper: {', '.join(removed) or '(none)'}")
+    if any(t.startswith("mcp__") for t in added):
+        # MCP tools only appear if the baked servers actually connected; the exa
+        # server is HTTP to the internet, so an offline run under-reports them.
+        out.append("note: mcp__* tools depend on those servers connecting (exa needs network).")
     return "\n".join(out) + "\n"
 
 
@@ -335,7 +339,7 @@ def main() -> int:
     parser.add_argument(
         "--tools",
         action="store_true",
-        help="In text mode, also print tool names and descriptions.",
+        help="In text mode, also print tool names and descriptions (stock/wrapped modes).",
     )
     parsed = parser.parse_args()
 

--- a/packages/agent/claude-code/extract-system-prompt.py
+++ b/packages/agent/claude-code/extract-system-prompt.py
@@ -109,11 +109,14 @@ async def capture(
                         parsed: dict[str, Any] = json.loads(body)
                         captured.append(parsed)
                         done.set()
-                # Minimal valid Messages response so the CLI exits cleanly; by
-                # now we already hold the request we came for, so its fate does
-                # not matter.
-                payload = json.dumps(
-                    {
+                # Reply with the shape each endpoint expects so the CLI doesn't
+                # error or retry before it gets to the messages request we want:
+                # count_tokens wants {input_tokens}, messages wants a message. By
+                # the time we hold our capture, the response's fate is moot.
+                if "count_tokens" in request_line:
+                    reply: dict[str, Any] = {"input_tokens": 1}
+                else:
+                    reply = {
                         "id": "msg_capture",
                         "type": "message",
                         "role": "assistant",
@@ -122,7 +125,7 @@ async def capture(
                         "stop_reason": "end_turn",
                         "usage": {"input_tokens": 1, "output_tokens": 1},
                     }
-                ).encode()
+                payload = json.dumps(reply).encode()
                 writer.write(
                     b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
                     b"Content-Length: %d\r\n\r\n" % len(payload) + payload
@@ -142,19 +145,19 @@ async def capture(
 
     home = tempfile.mkdtemp(prefix="claude-extract-home-")
     cwd = tempfile.mkdtemp(prefix="claude-extract-cwd-")
-    # Drop anything that would defeat the capture: a *_PROXY would route the
-    # loopback request away from our server, and a real auth token would let the
-    # CLI pick a non-API-key auth mode. We pin our own base URL + dummy key below.
-    stripped = {
-        "HTTP_PROXY",
-        "HTTPS_PROXY",
-        "ALL_PROXY",
-        "NO_PROXY",
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_AUTH_TOKEN",
-        "CLAUDE_CODE_OAUTH_TOKEN",
-    }
-    env = {k: v for k, v in os.environ.items() if k.upper() not in stripped}
+    # Build a hermetic child env so the capture reflects the binary, not the
+    # maintainer's shell. Drop every ANTHROPIC_*/CLAUDE_* var (model, token,
+    # context-window, thinking-budget knobs that would skew what is sent) and any
+    # *_PROXY (which would route the loopback request away from our server), then
+    # set back only what we control. The wrapped launcher gets its own settings
+    # from baked flags / IX_LAUNCH_SPEC, not from these, so this is safe for both.
+    def _hermetic(key: str) -> bool:
+        upper = key.upper()
+        if upper in {"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"}:
+            return False
+        return not (upper.startswith(("ANTHROPIC_", "CLAUDE_")))
+
+    env = {k: v for k, v in os.environ.items() if _hermetic(k)}
     env.update(
         {
             "HOME": home,


### PR DESCRIPTION
## What

`nix run .#claude-code.extractSystemPrompt` prints the **stock** upstream Claude Code system prompt, with none of this package's house overrides applied (now a full `--system-prompt-file` replacement on the wrapper).

## How (no disassembly, no MITM)

Claude Code natively honors `ANTHROPIC_BASE_URL`, so the tool:

1. Points the **unwrapped** `libexec` helper (stock download: no baked system-prompt / MCP / settings) at a throwaway localhost server.
2. Runs it once in print mode (`claude -p`) from a **clean HOME + empty cwd** (no `~/.claude`, no `CLAUDE.md`, no git status leak).
3. Captures the first `/v1/messages` request and dumps the exact `system` blocks and tool schemas it sends.

The CLI assembles the prompt itself, so the result is faithful rather than reconstructed from the fragmented JSC-bytecode string table inside the 212MB Bun binary. TLS interception is unnecessary because the base-URL knob exists.

```mermaid
flowchart LR
  A[nix run extractSystemPrompt] --> B[temp HOME + empty cwd]
  B --> C[libexec/Claude Code -p hi<br/>ANTHROPIC_BASE_URL=127.0.0.1:PORT]
  C -->|POST /v1/messages| D[local capture server]
  D --> E[dump system blocks + tools]
```

## Note on the variant

Print mode uses the Agent SDK entrypoint, so the identity line reads *"You are a Claude agent, built on Anthropic's Claude Agent SDK."* rather than the interactive *"You are Claude Code, ..."*. The body is otherwise identical; the interactive variant would require driving the TUI.

## Flags

`--json` ({model, system, tools}), `--raw` (full body), `--tools`, plus `--model` / `--prompt` / `--claude-binary` / `--timeout` overrides.

## Testing

- `nix build .#claude-code.extractSystemPrompt` and `.#claude-code` both green on latest main.
- `nix run .#lint` clean.
- End-to-end `nix run` captures the full prompt + all 22 tools; verified no house content (`shokunin`/`indexable`) leaks.

(sent by an AI agent via Claude Code, model claude-opus-4-8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `extractSystemPrompt` tool to claude-code to capture and diff the stock system prompt
> - Adds a new Python CLI ([extract-system-prompt.py](https://github.com/indexable-inc/index/pull/1296/files#diff-117fb0d1ab244ebdb140a6da5ae2ef3a61123c31c8a183aff5ff061d7d68ca18)) that starts a local HTTP server to intercept the first `/v1/messages` request sent by a Claude binary, capturing the system prompt and tool schemas before returning a minimal response.
> - Supports three modes: `stock`, `wrapped`, and `diff` — the diff mode produces a unified diff of system prompt blocks and summarizes tool additions/removals between the two binaries.
> - Wraps the CLI as a Nix app in [extract-system-prompt.nix](https://github.com/indexable-inc/index/pull/1296/files#diff-33949570a6ee1904c27b014e3cc54f8237294e7231ccdf02f50222990f5ac8f9) with baked-in defaults for `--stock-binary` and `--wrapped-binary`.
> - Exposes the app as `passthru.extractSystemPrompt` on the [claude-code derivation](https://github.com/indexable-inc/index/pull/1296/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) so it can be accessed as a Nix attribute.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 781d095.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->