### PR TITLE
fff-suggest: fff-backed @ file completer for Claude Code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,6 +2489,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fff-suggest"
+version = "0.1.0"
+dependencies = [
+ "dirs",
+ "libc",
+ "libloading 0.8.9",
+ "serde_json",
+]
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "packages/build-version",
   "packages/agent/claude-hooks",
   "packages/agent/claude-stories",
+  "packages/agent/fff-suggest",
   "packages/code/ast-merge/ast",
   "packages/code/ast-merge/cli",
   "packages/code/ast-merge/diff",
@@ -191,6 +192,7 @@ indicatif = "0.18"
 insta = { version = "1.42", features = ["json"] }
 lazy-regex = "3.4"
 libc = "0.2"
+libloading = "0.8"
 source-linear = { path = "packages/search/source/linear" }
 source-github = { path = "packages/search/source/github" }
 mixedbread = { path = "packages/search/mixedbread" }

--- a/docs/fff/overview.md
+++ b/docs/fff/overview.md
@@ -41,3 +41,32 @@ other repo packages through the nixpkgs overlay: the `mcp` package takes
 `pkgs.fff` as an input and bundles the `fff-c` cdylib for its ctypes-backed
 `import fff` (`package.nix:3-10`). It builds on Linux and macOS
 (`meta.platforms = unix`, `default.nix:81`).
+
+## Claude Code `@` completion (`packages/agent/fff-suggest`)
+
+fff also backs Claude Code's `@`-mention file completion, replacing the CLI's
+built-in index. Claude Code exposes a statusLine-shaped custom completer via the
+`fileSuggestion` setting: it runs a command per keystroke (5s budget, cwd = the
+project dir), passes `{ query, … }` on stdin, and uses each non-empty stdout line
+as a suggestion **in the returned order** (no re-ranking) — so fff owns the
+ranking.
+
+That command is the per-keystroke client half of `packages/agent/fff-suggest`, a
+repo-owned rust workspace crate with one binary and two subcommands:
+
+- `fff-suggest query` — the tiny native client wired into `fileSuggestion`. It
+  reads the query, round-trips it to the daemon over a unix socket, prints the
+  ranked relative paths, and **fails open** (any error exits 0 with no output, so
+  Claude never hangs on its budget).
+- `fff-suggest serve <root>` — the resident per-project daemon. It `dlopen`s the
+  same `libfff_c` the kernel uses (`IX_FFF_LIB`, baked by the `fff-suggest`
+  wrapper), holds one frecency-ranked, file-watched index over `<root>`, and
+  answers over the socket until it sits idle (`IX_FFF_SUGGEST_IDLE_MS`, default
+  10 min). The client auto-starts it detached on the first `@` in a project;
+  every keystroke after that is a warm socket round-trip with **no Python on the
+  hot path** and no re-index.
+
+The socket lives at `<runtime-dir>/ix-fff-suggest/<hash(root)>.sock`. The wiring
+is gated on the `fff-suggest` sibling in `packages/agent/claude-code` (like the
+`search`/`mcp` siblings, only the flake package set provides it), and an
+install-check there guards the `fileSuggestion.command` shape against a CLI bump.

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -206,6 +206,12 @@ let
   #     the baked `--dangerously-skip-permissions`. Scoped to `mcpServers ?
   #     exa` so a consumer who overrides the server set away gets the
   #     built-ins back instead of no web access at all.
+  #   fileSuggestion (only when the `fff-suggest` sibling is in scope): routes
+  #     `@`-mention file completion through fff's frecency-ranked fuzzy finder
+  #     instead of the CLI's built-in index, via the statusLine-shaped custom
+  #     completer hook (per-keystroke command, query on stdin, stdout lines used
+  #     in order). Fails open. See its `lib.optionalAttrs` block below for the
+  #     full contract and the resident-daemon design.
 
   # The three hooks (session-digest, worktree-guard, prompt-priors) are
   # subcommands of one compiled binary, wrapped with their tool paths and the
@@ -283,6 +289,23 @@ let
             ];
           }
         ];
+      };
+    }
+    // lib.optionalAttrs (repoPackages ? fff-suggest) {
+      # `@`-mention file completion served by fff (frecency-ranked fuzzy finder)
+      # instead of Claude's built-in index. `fileSuggestion` is the CLI's
+      # statusLine-shaped custom-completer hook: Claude runs this command per
+      # keystroke (5s budget, cwd = project dir), passes `{ query, … }` on stdin,
+      # and uses each non-empty stdout line as a suggestion in the returned order
+      # (no re-ranking), so fff owns the ranking. The command is the tiny native
+      # client half of `fff-suggest`, which round-trips the query to a resident
+      # per-project daemon over a unix socket (no Python on the hot path) and
+      # fails open: any error exits 0 with no output. Gated on the `fff-suggest`
+      # sibling, which (like the `search`/`mcp` siblings) only the flake package
+      # set provides, so the overlay build of `pkgs.claude-code` simply omits it.
+      fileSuggestion = {
+        type = "command";
+        command = "${repoPackages.fff-suggest}/bin/fff-suggest query";
       };
     }
     // lib.optionalAttrs dangerouslySkipPermissions {

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -93,6 +93,20 @@
     printf 'session-digest hook check failed (cap): expected 6000 chars, got %s\n' "$cap" >&2
     exit 1
   fi
+  ${lib.optionalString (repoPackages ? fff-suggest) ''
+
+    # The fff `@`-completer wiring: the flagSettings layer must carry a
+    # fileSuggestion command pointing at the fff-suggest client. Guards against a
+    # silent drop if the gate or the key shape regresses on a CLI bump.
+    fs_cmd="$(${lib.getExe jq} -r '.fileSuggestion.command // ""' ${settingsDefaultsFile})"
+    case "$fs_cmd" in
+    *"/bin/fff-suggest query") : ;;
+    *)
+      printf 'fileSuggestion check failed: expected a */bin/fff-suggest query command, got:\n%s\n' "$fs_cmd" >&2
+      exit 1
+      ;;
+    esac
+  ''}
   ${lib.optionalString (repoPackages ? search) ''
 
     # Fail-open net for the prompt-priors hook: every skip path must exit 0

--- a/packages/agent/fff-suggest/Cargo.toml
+++ b/packages/agent/fff-suggest/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fff-suggest"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "fff-backed @ file completer for Claude Code: a resident per-project daemon and a tiny per-keystroke client"
+
+[lints]
+workspace = true
+
+[dependencies]
+dirs.workspace = true
+libc.workspace = true
+libloading.workspace = true
+serde_json.workspace = true
+
+[[bin]]
+name = "fff-suggest"
+path = "src/main.rs"

--- a/packages/agent/fff-suggest/default.nix
+++ b/packages/agent/fff-suggest/default.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  ix,
+  fff,
+  stdenv,
+  makeBinaryWrapper,
+  runCommand,
+  procps,
+}:
+# fff-suggest is a repo-owned rust workspace crate (the binary rides
+# `ix.rustWorkspace.units` like `claude-hooks`), wrapped so it carries the path
+# to the `libfff_c` cdylib it `dlopen`s at runtime. Baking `IX_FFF_LIB` makes the
+# binary self-contained under any PATH (the daemon needs no extra env), exactly
+# how `claude-code/hooks.nix` bakes `IX_GIT` for the hook binary.
+let
+  libName = if stdenv.hostPlatform.isDarwin then "libfff_c.dylib" else "libfff_c.so";
+  fffLib = "${fff}/lib/${libName}";
+
+  raw = ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+    binary = "fff-suggest";
+    meta = {
+      description = "fff-backed @ file completer for Claude Code (resident daemon + per-keystroke client)";
+      license = lib.licenses.mit;
+      mainProgram = "fff-suggest";
+    };
+  };
+
+  wrapped =
+    runCommand "fff-suggest"
+      {
+        nativeBuildInputs = [ makeBinaryWrapper ];
+        passthru = (raw.passthru or { }) // {
+          tests = (raw.passthru.tests or { }) // {
+            e2e = e2eTest;
+          };
+        };
+        meta = raw.meta or { };
+      }
+      ''
+        makeBinaryWrapper ${raw}/bin/fff-suggest $out/bin/fff-suggest \
+          --set IX_FFF_LIB ${fffLib}
+      '';
+
+  # End-to-end: stand up the daemon over a temp tree and confirm the client
+  # returns the fff-ranked file for a query. Uses a tiny idle timeout and an
+  # explicit kill so the build never waits on a lingering daemon.
+  e2eTest = runCommand "fff-suggest-e2e" { nativeBuildInputs = [ procps ]; } ''
+    set -eu
+    export HOME="$TMPDIR/home"
+    export XDG_RUNTIME_DIR="$TMPDIR/run"
+    export IX_FFF_SUGGEST_IDLE_MS=1500
+    mkdir -p "$HOME" "$XDG_RUNTIME_DIR"
+
+    work="$TMPDIR/work"
+    mkdir -p "$work/src"
+    : > "$work/src/alpha_module.rs"
+    : > "$work/src/beta_module.rs"
+    : > "$work/README.md"
+    cd "$work"
+
+    # First query cold-starts the daemon; retry briefly while it scans.
+    hits=""
+    for _ in $(seq 1 50); do
+      hits="$(printf '{"query":"alpha"}' | ${wrapped}/bin/fff-suggest query || true)"
+      case "$hits" in *alpha_module.rs*) break ;; esac
+      sleep 0.1
+    done
+
+    # Stop the daemon we spawned (idle timeout is the backstop).
+    pkill -f 'fff-suggest serve' || true
+
+    case "$hits" in
+      *alpha_module.rs*)
+        echo "ok: client returned fff-ranked match"
+        printf '%s\n' "$hits"
+        ;;
+      *)
+        echo "FAIL: expected alpha_module.rs in suggestions, got:" >&2
+        printf '%s\n' "$hits" >&2
+        exit 1
+        ;;
+    esac
+    touch "$out"
+  '';
+in
+wrapped

--- a/packages/agent/fff-suggest/package.nix
+++ b/packages/agent/fff-suggest/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "fff-suggest";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/agent/fff-suggest/src/main.rs
+++ b/packages/agent/fff-suggest/src/main.rs
@@ -1,0 +1,468 @@
+//! fff-backed `@` file completer for Claude Code, one compiled binary with two
+//! subcommands:
+//!
+//!   * `fff-suggest query` — the per-keystroke client wired into Claude Code's
+//!     `fileSuggestion` setting. Claude spawns it fresh on every keystroke after
+//!     `@`, hands it `{ "query": "<text>" , … }` on stdin (cwd = the project
+//!     dir), and treats each non-empty stdout line as a suggestion, used in the
+//!     order returned. It round-trips the query to the resident daemon over a
+//!     unix socket and prints the ranked paths. It fails OPEN and FAST: any
+//!     error exits 0 with no output (Claude then shows no suggestions rather
+//!     than hanging on its 5s budget).
+//!
+//!   * `fff-suggest serve <root>` — the resident daemon. It `dlopen`s the same
+//!     `libfff_c` the notebook kernel uses (`IX_FFF_LIB`, baked by the
+//!     claude-code wrapper), holds one frecency-ranked, file-watched index over
+//!     `<root>`, and answers queries over the socket until it sits idle. The
+//!     client auto-starts it detached on the first `@` in a project; every
+//!     keystroke after that is a warm socket round-trip with no Python and no
+//!     re-index.
+//!
+//! The socket lives at `<runtime-dir>/ix-fff-suggest/<hash(root)>.sock`; the
+//! hash keeps the name short enough for the platform's `sun_path` limit. Client
+//! and daemon are the same executable, so they hash an identical `root` to the
+//! same path.
+
+use std::ffi::{CStr, CString, c_char, c_void};
+use std::hash::{Hash as _, Hasher as _};
+use std::io::{Read as _, Write as _};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::os::unix::process::CommandExt as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode, Stdio};
+use std::time::{Duration, Instant};
+
+use libloading::{Library, Symbol};
+
+/// Mirrors `FFF_CREATE_OPTIONS_VERSION` in fff-c. The options struct only ever
+/// appends fields, so v1 stays valid forever.
+const OPTIONS_VERSION: u32 = 1;
+/// Suggestions to return; Claude caps its own menu well below this.
+const SEARCH_LIMIT: u32 = 40;
+/// Daemon exits after this long with no connections; the next `@` respawns it.
+/// Overridable via `IX_FFF_SUGGEST_IDLE_MS` (the e2e test uses a small value so
+/// it never leaves a long-lived daemon behind).
+const IDLE_MS: i32 = 10 * 60 * 1000;
+/// Bounded wait for the initial scan before the daemon starts serving, so the
+/// first keystroke gets a reasonably full index rather than an empty one.
+const INITIAL_SCAN_MS: u64 = 1000;
+/// Total client budget, kept under Claude's 5s `fileSuggestion` timeout.
+const CLIENT_BUDGET_MS: u64 = 3500;
+
+fn main() -> ExitCode {
+    match std::env::args().nth(1).as_deref() {
+        // `query` is the default so the wired command can be just the binary.
+        None | Some("query") => client(),
+        Some("serve") => daemon(std::env::args().nth(2)),
+        other => {
+            eprintln!("fff-suggest: unknown subcommand {other:?}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+// ── shared ───────────────────────────────────────────────────────────────────
+
+/// The unix socket for `root`'s daemon. A hash of the (canonical) path keeps the
+/// filename short, since `sun_path` is ~104 bytes on macOS. Client and daemon
+/// run the same build, so `DefaultHasher` agrees between them.
+fn socket_path(root: &Path) -> PathBuf {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    root.hash(&mut hasher);
+    let dir = dirs::runtime_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("ix-fff-suggest");
+    dir.join(format!("{:016x}.sock", hasher.finish()))
+}
+
+// ── client ───────────────────────────────────────────────────────────────────
+
+fn client() -> ExitCode {
+    let query = read_query();
+    let Ok(root) = std::env::current_dir().and_then(|c| c.canonicalize()) else {
+        return ExitCode::SUCCESS;
+    };
+    let sock = socket_path(&root);
+
+    // Fast path: a warm daemon is already listening.
+    if let Some(out) = try_query(&sock, &query) {
+        print!("{out}");
+        return ExitCode::SUCCESS;
+    }
+
+    // Cold path: start the daemon detached, then poll until it binds (or budget
+    // runs out). Failing here is silent — Claude just shows no suggestions.
+    spawn_daemon(&root);
+    let deadline = Instant::now() + Duration::from_millis(CLIENT_BUDGET_MS);
+    while Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+        if let Some(out) = try_query(&sock, &query) {
+            print!("{out}");
+            break;
+        }
+    }
+    ExitCode::SUCCESS
+}
+
+/// The text typed after `@`, read from Claude's JSON stdin. Any missing input or
+/// parse error yields an empty query (the daemon then returns top files).
+fn read_query() -> String {
+    let mut raw = String::new();
+    if std::io::stdin().read_to_string(&mut raw).is_err() {
+        return String::new();
+    }
+    serde_json::from_str::<serde_json::Value>(&raw)
+        .ok()
+        .and_then(|v| v.get("query").and_then(|q| q.as_str()).map(str::to_owned))
+        .unwrap_or_default()
+}
+
+/// Connect, send the query, return the daemon's reply (possibly empty). `None`
+/// means no daemon answered, which is the signal to (try to) start one.
+fn try_query(sock: &Path, query: &str) -> Option<String> {
+    let mut stream = UnixStream::connect(sock).ok()?;
+    let budget = Duration::from_millis(CLIENT_BUDGET_MS);
+    stream.set_read_timeout(Some(budget)).ok()?;
+    stream.set_write_timeout(Some(budget)).ok()?;
+    // One request line; newlines in a path fragment are meaningless, so drop them.
+    let line = format!("{}\n", query.replace('\n', ""));
+    stream.write_all(line.as_bytes()).ok()?;
+    let mut out = String::new();
+    stream.read_to_string(&mut out).ok()?;
+    Some(out)
+}
+
+/// Re-exec ourselves as the daemon, fully detached, so it outlives this client.
+fn spawn_daemon(root: &Path) {
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    let _ = Command::new(exe)
+        .arg("serve")
+        .arg(root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .process_group(0)
+        .spawn();
+}
+
+// ── daemon ───────────────────────────────────────────────────────────────────
+
+fn daemon(root: Option<String>) -> ExitCode {
+    let Some(root) = root else {
+        eprintln!("fff-suggest serve: missing <root>");
+        return ExitCode::from(2);
+    };
+    let root = PathBuf::from(root);
+    let sock = socket_path(&root);
+
+    let Some(listener) = bind(&sock) else {
+        // Another daemon already owns this socket; nothing to do.
+        return ExitCode::SUCCESS;
+    };
+
+    let index = match Index::open(&root) {
+        Ok(index) => index,
+        Err(err) => {
+            eprintln!("fff-suggest serve: {err}");
+            let _ = std::fs::remove_file(&sock);
+            return ExitCode::FAILURE;
+        }
+    };
+    // Give the initial scan a moment so the first keystroke isn't empty; clients
+    // that connect meanwhile wait in the listen backlog.
+    index.wait_for_scan(INITIAL_SCAN_MS);
+
+    serve(&listener, &index);
+    let _ = std::fs::remove_file(&sock);
+    ExitCode::SUCCESS
+}
+
+/// Bind the socket, taking over a stale file left by a dead daemon. Returns
+/// `None` when a *live* daemon already holds it (we lose the start race).
+fn bind(sock: &Path) -> Option<UnixListener> {
+    if let Some(parent) = sock.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(listener) = UnixListener::bind(sock) {
+        return Some(listener);
+    }
+    if UnixStream::connect(sock).is_ok() {
+        return None;
+    }
+    let _ = std::fs::remove_file(sock);
+    UnixListener::bind(sock).ok()
+}
+
+/// Accept loop with an idle timeout: `poll` the listener and exit once it sits
+/// quiet for `IDLE_MS`, so abandoned per-project daemons don't linger.
+fn serve(listener: &UnixListener, index: &Index) {
+    use std::os::unix::io::AsRawFd as _;
+    let idle_ms = std::env::var("IX_FFF_SUGGEST_IDLE_MS")
+        .ok()
+        .and_then(|v| v.parse::<i32>().ok())
+        .unwrap_or(IDLE_MS);
+    let fd = listener.as_raw_fd();
+    loop {
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: `pfd` is a valid, initialized single-element array for `poll`.
+        let ready = unsafe { libc::poll(&raw mut pfd, 1, idle_ms) };
+        if ready == 0 {
+            return; // idle timeout
+        }
+        if ready < 0 {
+            continue; // EINTR and friends; retry
+        }
+        if let Ok((stream, _)) = listener.accept() {
+            handle_conn(stream, index);
+        }
+    }
+}
+
+fn handle_conn(mut stream: UnixStream, index: &Index) {
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+    let mut buf = Vec::new();
+    let mut byte = [0u8; 1];
+    // Read one request line (the query).
+    loop {
+        match stream.read(&mut byte) {
+            Ok(0) => break,
+            Ok(_) if byte[0] == b'\n' => break,
+            Ok(_) => buf.push(byte[0]),
+            Err(_) => return,
+        }
+    }
+    let query = String::from_utf8_lossy(&buf);
+    let mut reply = String::new();
+    for path in index.search(query.trim(), SEARCH_LIMIT) {
+        reply.push_str(&path);
+        reply.push('\n');
+    }
+    let _ = stream.write_all(reply.as_bytes());
+}
+
+// ── libfff_c binding ─────────────────────────────────────────────────────────
+//
+// We drive the same stable C ABI the notebook kernel binds via ctypes
+// (`packages/mcp/src/fff/fff/__init__.py`). Only the file-search slice is bound.
+
+/// Options for `fff_create_instance_with`. `#[repr(C)]`, layout asserted stable
+/// by fff-c (88 bytes); fields only ever appended, so v1 stays valid.
+#[repr(C)]
+struct FffCreateOptions {
+    version: u32,
+    base_path: *const c_char,
+    frecency_db_path: *const c_char,
+    history_db_path: *const c_char,
+    enable_mmap_cache: bool,
+    enable_content_indexing: bool,
+    watch: bool,
+    ai_mode: bool,
+    log_file_path: *const c_char,
+    log_level: *const c_char,
+    cache_budget_max_files: u64,
+    cache_budget_max_bytes: u64,
+    cache_budget_max_file_size: u64,
+    enable_fs_root_scanning: bool,
+    enable_home_dir_scanning: bool,
+}
+
+/// The envelope every `fff_*` call returns by pointer. `handle` carries the
+/// typed payload; `int_value` carries scalar returns.
+#[repr(C)]
+struct FffResult {
+    success: bool,
+    error: *const c_char,
+    handle: *mut c_void,
+    int_value: i64,
+}
+
+type CreateFn = unsafe extern "C" fn(*const FffCreateOptions) -> *mut FffResult;
+type DestroyFn = unsafe extern "C" fn(*mut c_void);
+type WaitFn = unsafe extern "C" fn(*mut c_void, u64) -> *mut FffResult;
+type SearchFn =
+    unsafe extern "C" fn(*mut c_void, *const c_char, *const c_char, u32, u32, u32, i32, u32) -> *mut FffResult;
+type FreeResultFn = unsafe extern "C" fn(*mut FffResult);
+type FreeSearchFn = unsafe extern "C" fn(*mut c_void);
+type CountFn = unsafe extern "C" fn(*const c_void) -> u32;
+type ItemFn = unsafe extern "C" fn(*const c_void, u32) -> *const c_void;
+type RelPathFn = unsafe extern "C" fn(*const c_void) -> *const c_char;
+
+/// The dlopen'd symbols, kept alive for the daemon's lifetime. The `Library` is
+/// leaked so the borrowed `Symbol`s are `'static`; the process owns it until
+/// exit, which reclaims it.
+struct Fff {
+    create: Symbol<'static, CreateFn>,
+    destroy: Symbol<'static, DestroyFn>,
+    wait: Symbol<'static, WaitFn>,
+    search: Symbol<'static, SearchFn>,
+    free_result: Symbol<'static, FreeResultFn>,
+    free_search: Symbol<'static, FreeSearchFn>,
+    count: Symbol<'static, CountFn>,
+    item: Symbol<'static, ItemFn>,
+    rel_path: Symbol<'static, RelPathFn>,
+}
+
+impl Fff {
+    fn load() -> Result<Self, String> {
+        let path = std::env::var_os("IX_FFF_LIB")
+            .ok_or_else(|| "IX_FFF_LIB is unset (no libfff_c path baked in)".to_owned())?;
+        // SAFETY: loading the trusted, baked libfff_c; its init runs no
+        // attacker-controlled code.
+        let lib: &'static Library = Box::leak(Box::new(
+            unsafe { Library::new(&path) }
+                .map_err(|e| format!("dlopen {}: {e}", Path::new(&path).display()))?,
+        ));
+        // SAFETY: every symbol below matches the fff-c declaration it is typed
+        // against (verified against crates/fff-c/include/fff.h).
+        unsafe {
+            Ok(Self {
+                create: get(lib, b"fff_create_instance_with")?,
+                destroy: get(lib, b"fff_destroy")?,
+                wait: get(lib, b"fff_wait_for_scan")?,
+                search: get(lib, b"fff_search")?,
+                free_result: get(lib, b"fff_free_result")?,
+                free_search: get(lib, b"fff_free_search_result")?,
+                count: get(lib, b"fff_search_result_get_count")?,
+                item: get(lib, b"fff_search_result_get_item")?,
+                rel_path: get(lib, b"fff_file_item_get_relative_path")?,
+            })
+        }
+    }
+}
+
+/// SAFETY: `name` must name a symbol whose true signature is `T`.
+unsafe fn get<T>(lib: &'static Library, name: &[u8]) -> Result<Symbol<'static, T>, String> {
+    unsafe { lib.get(name) }
+        .map_err(|e| format!("missing symbol {}: {e}", String::from_utf8_lossy(name)))
+}
+
+/// One resident, watched fff index over a directory tree.
+struct Index {
+    fff: Fff,
+    handle: *mut c_void,
+    // Kept alive so `FffCreateOptions.base_path` stays valid for the instance.
+    _base: CString,
+}
+
+impl Index {
+    fn open(root: &Path) -> Result<Self, String> {
+        let fff = Fff::load()?;
+        let base = CString::new(root.as_os_str().as_encoded_bytes())
+            .map_err(|_| "root path contains an interior NUL".to_owned())?;
+        let opts = FffCreateOptions {
+            version: OPTIONS_VERSION,
+            base_path: base.as_ptr(),
+            frecency_db_path: std::ptr::null(),
+            history_db_path: std::ptr::null(),
+            enable_mmap_cache: false,
+            // Filename search only: no content index keeps it light and fast.
+            enable_content_indexing: false,
+            watch: true,
+            ai_mode: true,
+            log_file_path: std::ptr::null(),
+            log_level: std::ptr::null(),
+            cache_budget_max_files: 0,
+            cache_budget_max_bytes: 0,
+            cache_budget_max_file_size: 0,
+            enable_fs_root_scanning: false,
+            enable_home_dir_scanning: false,
+        };
+        // SAFETY: `opts` is fully initialized and outlives the call; `base`
+        // outlives the returned instance (held in `_base`).
+        let res = unsafe { (fff.create)(&raw const opts) };
+        let handle = unsafe { take_handle(&fff, res) }?;
+        Ok(Self {
+            fff,
+            handle,
+            _base: base,
+        })
+    }
+
+    fn wait_for_scan(&self, timeout_ms: u64) {
+        // SAFETY: `self.handle` is a live instance from `fff_create_instance_with`.
+        let res = unsafe { (self.fff.wait)(self.handle, timeout_ms) };
+        if !res.is_null() {
+            // SAFETY: a non-null result is owned by us; free the envelope only.
+            unsafe { (self.fff.free_result)(res) };
+        }
+    }
+
+    /// Fuzzy file search, frecency-ranked, returning relative paths in rank order.
+    fn search(&self, query: &str, limit: u32) -> Vec<String> {
+        let Ok(cquery) = CString::new(query) else {
+            return Vec::new();
+        };
+        // SAFETY: live instance, valid NUL-terminated query, null current_file;
+        // trailing args mirror the kernel binding (no combo boost).
+        let res = unsafe {
+            (self.fff.search)(self.handle, cquery.as_ptr(), std::ptr::null(), 0, 0, limit, 0, 0)
+        };
+        if res.is_null() {
+            return Vec::new();
+        }
+        // SAFETY: `res` is a valid, owned `*mut FffResult`.
+        let result = unsafe { &*res };
+        let mut out = Vec::new();
+        if result.success && !result.handle.is_null() {
+            let sr = result.handle;
+            // SAFETY: `sr` is a valid `FffSearchResult` until we free it below.
+            let count = unsafe { (self.fff.count)(sr) };
+            for i in 0..count {
+                // SAFETY: `i < count`, so the item pointer is valid (or null).
+                let item = unsafe { (self.fff.item)(sr, i) };
+                if item.is_null() {
+                    continue;
+                }
+                // SAFETY: `item` is a valid `FffFileItem`; the returned C string
+                // is owned by `sr` and valid until `free_search`.
+                let ptr = unsafe { (self.fff.rel_path)(item) };
+                if !ptr.is_null() {
+                    out.push(unsafe { CStr::from_ptr(ptr) }.to_string_lossy().into_owned());
+                }
+            }
+            // SAFETY: `sr` came from this result and is freed exactly once.
+            unsafe { (self.fff.free_search)(sr) };
+        }
+        // SAFETY: `res` is freed exactly once after we are done reading it.
+        unsafe { (self.fff.free_result)(res) };
+        out
+    }
+}
+
+impl Drop for Index {
+    fn drop(&mut self) {
+        // SAFETY: `self.handle` is a live instance, destroyed exactly once.
+        unsafe { (self.fff.destroy)(self.handle) };
+    }
+}
+
+/// Read the instance/handle out of a create-style `FffResult`, freeing the
+/// envelope (which never owns the handle). Errors carry fff-c's message.
+unsafe fn take_handle(fff: &Fff, res: *mut FffResult) -> Result<*mut c_void, String> {
+    if res.is_null() {
+        return Err("fff returned a null result".to_owned());
+    }
+    // SAFETY: caller passes a valid, owned `*mut FffResult`.
+    let result = unsafe { &*res };
+    let success = result.success;
+    let handle = result.handle;
+    let error = if result.error.is_null() {
+        None
+    } else {
+        // SAFETY: non-null error is a valid C string owned by the envelope.
+        Some(unsafe { CStr::from_ptr(result.error) }.to_string_lossy().into_owned())
+    };
+    // SAFETY: free the envelope only; the handle (when present) stays alive.
+    unsafe { (fff.free_result)(res) };
+    if success {
+        Ok(handle)
+    } else {
+        Err(error.unwrap_or_else(|| "unknown fff error".to_owned()))
+    }
+}


### PR DESCRIPTION
## What

Route Claude Code's `@`-mention file completion through **fff** (frecency-ranked
fuzzy finder) instead of the CLI's built-in index, wired into
`packages/agent/claude-code`, native end-to-end (no Python on the hot path).

## How it works

Claude Code has an undocumented first-class custom completer: the `fileSuggestion`
setting (statusLine-shaped `{ type = "command"; command = ...; }`). Reverse-engineered
from the installed `claude` 2.1.170 binary (`D4q`/`ab_`): on `@`, Claude runs the
command **per keystroke** (5s budget, cwd = project dir), passes `{ query, … }` on
stdin, and uses each non-empty stdout line as a suggestion **in the returned order**
(no re-ranking) — so fff owns the ranking.

fff ships only as `fff-mcp` (a stdio MCP server) + `libfff_c` (C ABI), neither of which
fits a fresh per-keystroke spawn. So this adds a small native bridge.

```mermaid
flowchart LR
  K["@ keystroke"] -->|stdin {query}, cwd=proj| C["fff-suggest query (tiny native client)"]
  C -->|unix socket| D["fff-suggest serve (resident daemon)"]
  C -. on no daemon: spawn detached .-> D
  D -->|libfff_c fff_search| I[("resident watched index")]
  D -->|ranked rel paths| C
  C -->|stdout lines| K
```

## Changes

- **New crate `packages/agent/fff-suggest`** (rides `ix.rustWorkspace.units` like
  `claude-hooks`), one binary, two subcommands:
  - `query` — per-keystroke client wired into `fileSuggestion`; round-trips to the
    daemon over a unix socket, prints ranked paths, **fails open** (any error exits 0
    with no output, so Claude never hangs on its budget).
  - `serve` — resident per-project daemon that `dlopen`s the same `libfff_c` the kernel
    uses (`IX_FFF_LIB`, baked by the wrapper), holds a frecency-ranked, file-watched
    index, answers over the socket until idle (`IX_FFF_SUGGEST_IDLE_MS`, default 10 min).
    Auto-started detached on the first `@` in a project; every keystroke after is a warm
    socket round-trip with no re-index.
  - Socket at `<runtime-dir>/ix-fff-suggest/<hash(root)>.sock`.
- **`packages/agent/claude-code`**: gated `fileSuggestion` default (on the `fff-suggest`
  sibling, like `search`/`mcp`), plus an install-check on the key shape.
- Workspace registration (`Cargo.toml` member + `libloading` dep; 0 new dep versions).
- Docs in `docs/fff/overview.md`.

## Verification

- `nix build .#fff-suggest` and `.#claude-code` pass (install-check confirms the baked
  `fileSuggestion.command`).
- Manual end-to-end against the wrapped binary: cold-start spawns one resident daemon,
  warm queries reuse it, fff ranking returned (e.g. `alpha` → both alpha files), empty
  query → top files.
- All 7 `nix run .#lint` tasks pass.
- A `passthru.tests.e2e` exercises daemon spawn + query in-sandbox (runs in CI; the full
  workspace test manifest OOMs locally on this machine — unrelated transient `num_modular`
  build failures under parallel load).

🤖 Opened by an AI agent (Claude Code, claude-opus-4-8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fff-backed `@` file completer daemon for Claude Code
> - Adds a new `fff-suggest` Rust binary crate ([src/main.rs](https://github.com/indexable-inc/index/pull/1298/files#diff-03f6dcf19791ec15874de36bd8cc9e9aec2e9be5fc7eb2d2eca38380fa84d17a)) that runs as a per-project daemon serving fuzzy, frecency-ranked filename queries over a Unix domain socket.
> - The client re-execs itself as `serve <root>` on first use, polls until the daemon is ready, queries it, and always exits 0 (fail-open) — so Claude Code's `@`-mention completion degrades gracefully if the daemon is unavailable.
> - The daemon dynamically loads `libfff_c` via `dlopen` using the `IX_FFF_LIB` env var (set at build time by the Nix wrapper), maintains a watched index over the project tree, and shuts down after 10 minutes of idle.
> - [default.nix](https://github.com/indexable-inc/index/pull/1298/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) wires the `fileSuggestion` command in Claude Code's settings to `fff-suggest query` when `fff-suggest` is present in `repoPackages`.
> - Risk: the daemon startup path involves a bounded busy-poll (`CLIENT_BUDGET_MS`); if the daemon fails to start within budget, the client exits silently with no suggestions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d3fe45.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->