### PR TITLE
fff-suggest: user-private socket dir + Darwin-portable e2e

### DIFF
--- a/packages/agent/fff-suggest/default.nix
+++ b/packages/agent/fff-suggest/default.nix
@@ -5,7 +5,6 @@
   stdenv,
   makeBinaryWrapper,
   runCommand,
-  procps,
 }:
 # fff-suggest is a repo-owned rust workspace crate (the binary rides
 # `ix.rustWorkspace.units` like `claude-hooks`), wrapped so it carries the path
@@ -42,9 +41,11 @@ let
       '';
 
   # End-to-end: stand up the daemon over a temp tree and confirm the client
-  # returns the fff-ranked file for a query. Uses a tiny idle timeout and an
-  # explicit kill so the build never waits on a lingering daemon.
-  e2eTest = runCommand "fff-suggest-e2e" { nativeBuildInputs = [ procps ]; } ''
+  # returns the fff-ranked file for a query. A tiny idle timeout reaps the
+  # daemon, so the test needs no platform-specific killer (`procps`/`pkill` is
+  # Linux-only in nixpkgs and would make this check unbuildable on Darwin, where
+  # this stack is documented as supported).
+  e2eTest = runCommand "fff-suggest-e2e" { } ''
     set -eu
     export HOME="$TMPDIR/home"
     export XDG_RUNTIME_DIR="$TMPDIR/run"
@@ -66,8 +67,8 @@ let
       sleep 0.1
     done
 
-    # Stop the daemon we spawned (idle timeout is the backstop).
-    pkill -f 'fff-suggest serve' || true
+    # The daemon we cold-started reaps itself via IX_FFF_SUGGEST_IDLE_MS, so
+    # there is nothing to kill and the build never waits on a lingering process.
 
     case "$hits" in
       *alpha_module.rs*)

--- a/packages/agent/fff-suggest/src/main.rs
+++ b/packages/agent/fff-suggest/src/main.rs
@@ -89,11 +89,17 @@ fn socket_path(root: &Path) -> PathBuf {
 }
 
 /// Create `dir` as a user-private 0700 directory, or accept it only if it
-/// already is one owned by us. Returns `false` (caller must fail open, leaving
-/// no socket server) when the path exists but is not a directory, is owned by
-/// another user, or grants any group/other access: the markers of a hijack
-/// attempt under a shared `/tmp`. `$XDG_RUNTIME_DIR` already satisfies this, so
-/// this only ever rejects a poisoned fallback directory.
+/// already is a real directory owned by us. Returns `false` (caller must fail
+/// open, leaving no socket server) when the path exists but is not a directory,
+/// is a symlink, or is owned by another user: the markers of a hijack attempt
+/// under a shared `/tmp`.
+///
+/// An existing dir we own but with group/other bits is *repaired* to 0700 rather
+/// than rejected: earlier builds created `<runtime>/ix-fff-suggest` with plain
+/// `create_dir_all`, which leaves it 0755 under the usual 022 umask, so rejecting
+/// it would silently disable completions across an in-session upgrade. Since the
+/// dir is already ours (and, under `$XDG_RUNTIME_DIR`, inside a 0700 parent),
+/// tightening it back to 0700 restores the invariant without that regression.
 fn ensure_private_dir(dir: &Path) -> bool {
     use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _, PermissionsExt as _};
     // create_new-style: succeeds only if we make it, so the 0700 mode is ours.
@@ -109,11 +115,15 @@ fn ensure_private_dir(dir: &Path) -> bool {
         return false;
     };
     // SAFETY: `getuid` just reads the process's real uid.
+    if !meta.is_dir() || meta.uid() != unsafe { libc::getuid() } {
+        return false;
+    }
     // No group/other permission bits set: the low 6 bits of the mode are zero,
-    // i.e. at least 6 trailing zero bits.
-    meta.is_dir()
-        && meta.uid() == unsafe { libc::getuid() }
-        && meta.permissions().mode().trailing_zeros() >= 6
+    // i.e. at least 6 trailing zero bits. Repair a loose-but-owned dir in place.
+    if meta.permissions().mode().trailing_zeros() >= 6 {
+        return true;
+    }
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).is_ok()
 }
 
 // ── client ───────────────────────────────────────────────────────────────────

--- a/packages/agent/fff-suggest/src/main.rs
+++ b/packages/agent/fff-suggest/src/main.rs
@@ -1,7 +1,7 @@
 //! fff-backed `@` file completer for Claude Code, one compiled binary with two
 //! subcommands:
 //!
-//!   * `fff-suggest query` — the per-keystroke client wired into Claude Code's
+//!   * `fff-suggest query`: the per-keystroke client wired into Claude Code's
 //!     `fileSuggestion` setting. Claude spawns it fresh on every keystroke after
 //!     `@`, hands it `{ "query": "<text>" , … }` on stdin (cwd = the project
 //!     dir), and treats each non-empty stdout line as a suggestion, used in the
@@ -10,7 +10,7 @@
 //!     error exits 0 with no output (Claude then shows no suggestions rather
 //!     than hanging on its 5s budget).
 //!
-//!   * `fff-suggest serve <root>` — the resident daemon. It `dlopen`s the same
+//!   * `fff-suggest serve <root>`: the resident daemon. It `dlopen`s the same
 //!     `libfff_c` the notebook kernel uses (`IX_FFF_LIB`, baked by the
 //!     claude-code wrapper), holds one frecency-ranked, file-watched index over
 //!     `<root>`, and answers queries over the socket until it sits idle. The
@@ -67,7 +67,7 @@ fn main() -> ExitCode {
 /// `$XDG_RUNTIME_DIR`, which the OS already guarantees is a 0700 user-private
 /// tmpfs. When it is absent we fall back to the world-writable system temp dir,
 /// so the directory name is namespaced by uid and the directory itself is
-/// created/validated 0700 (see `ensure_private_dir`) — otherwise a deterministic
+/// created/validated 0700 (see `ensure_private_dir`); otherwise a deterministic
 /// socket path under a shared `/tmp` would let another local user pre-bind or
 /// connect to it to spoof completions or stall every `@`.
 fn runtime_dir() -> PathBuf {
@@ -91,7 +91,7 @@ fn socket_path(root: &Path) -> PathBuf {
 /// Create `dir` as a user-private 0700 directory, or accept it only if it
 /// already is one owned by us. Returns `false` (caller must fail open, leaving
 /// no socket server) when the path exists but is not a directory, is owned by
-/// another user, or grants any group/other access — the markers of a hijack
+/// another user, or grants any group/other access: the markers of a hijack
 /// attempt under a shared `/tmp`. `$XDG_RUNTIME_DIR` already satisfies this, so
 /// this only ever rejects a poisoned fallback directory.
 fn ensure_private_dir(dir: &Path) -> bool {
@@ -109,9 +109,11 @@ fn ensure_private_dir(dir: &Path) -> bool {
         return false;
     };
     // SAFETY: `getuid` just reads the process's real uid.
+    // No group/other permission bits set: the low 6 bits of the mode are zero,
+    // i.e. at least 6 trailing zero bits.
     meta.is_dir()
         && meta.uid() == unsafe { libc::getuid() }
-        && (meta.permissions().mode() & 0o077) == 0
+        && meta.permissions().mode().trailing_zeros() >= 6
 }
 
 // ── client ───────────────────────────────────────────────────────────────────
@@ -140,7 +142,7 @@ fn client() -> ExitCode {
     }
 
     // Cold path: start the daemon detached, then poll until it binds (or budget
-    // runs out). Failing here is silent — Claude just shows no suggestions.
+    // runs out). Failing here is silent: Claude just shows no suggestions.
     spawn_daemon(&root);
     let deadline = Instant::now() + Duration::from_millis(CLIENT_BUDGET_MS);
     while Instant::now() < deadline {

--- a/packages/agent/fff-suggest/src/main.rs
+++ b/packages/agent/fff-suggest/src/main.rs
@@ -63,16 +63,55 @@ fn main() -> ExitCode {
 
 // ── shared ───────────────────────────────────────────────────────────────────
 
-/// The unix socket for `root`'s daemon. A hash of the (canonical) path keeps the
-/// filename short, since `sun_path` is ~104 bytes on macOS. Client and daemon
-/// run the same build, so `DefaultHasher` agrees between them.
+/// The per-user runtime directory that holds the daemon sockets. Prefer
+/// `$XDG_RUNTIME_DIR`, which the OS already guarantees is a 0700 user-private
+/// tmpfs. When it is absent we fall back to the world-writable system temp dir,
+/// so the directory name is namespaced by uid and the directory itself is
+/// created/validated 0700 (see `ensure_private_dir`) — otherwise a deterministic
+/// socket path under a shared `/tmp` would let another local user pre-bind or
+/// connect to it to spoof completions or stall every `@`.
+fn runtime_dir() -> PathBuf {
+    dirs::runtime_dir().map_or_else(
+        // SAFETY: `getuid` is always safe; it just reads the process's real uid.
+        || std::env::temp_dir().join(format!("ix-fff-suggest-{}", unsafe { libc::getuid() })),
+        |dir| dir.join("ix-fff-suggest"),
+    )
+}
+
+/// The unix socket for `root`'s daemon, under the per-user `runtime_dir`. A hash
+/// of the (canonical) path keeps the filename short, since `sun_path` is ~104
+/// bytes on macOS. Client and daemon run the same build, so `DefaultHasher`
+/// agrees between them.
 fn socket_path(root: &Path) -> PathBuf {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     root.hash(&mut hasher);
-    let dir = dirs::runtime_dir()
-        .unwrap_or_else(std::env::temp_dir)
-        .join("ix-fff-suggest");
-    dir.join(format!("{:016x}.sock", hasher.finish()))
+    runtime_dir().join(format!("{:016x}.sock", hasher.finish()))
+}
+
+/// Create `dir` as a user-private 0700 directory, or accept it only if it
+/// already is one owned by us. Returns `false` (caller must fail open, leaving
+/// no socket server) when the path exists but is not a directory, is owned by
+/// another user, or grants any group/other access — the markers of a hijack
+/// attempt under a shared `/tmp`. `$XDG_RUNTIME_DIR` already satisfies this, so
+/// this only ever rejects a poisoned fallback directory.
+fn ensure_private_dir(dir: &Path) -> bool {
+    use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _, PermissionsExt as _};
+    // create_new-style: succeeds only if we make it, so the 0700 mode is ours.
+    match std::fs::DirBuilder::new().mode(0o700).create(dir) {
+        Ok(()) => return true,
+        // Already there; fall through to validate it is safely ours.
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(_) => return false,
+    }
+    // `symlink_metadata` does not follow a symlink, so a planted symlink to a
+    // dir we happen to own cannot pass this check.
+    let Ok(meta) = std::fs::symlink_metadata(dir) else {
+        return false;
+    };
+    // SAFETY: `getuid` just reads the process's real uid.
+    meta.is_dir()
+        && meta.uid() == unsafe { libc::getuid() }
+        && (meta.permissions().mode() & 0o077) == 0
 }
 
 // ── client ───────────────────────────────────────────────────────────────────
@@ -83,6 +122,16 @@ fn client() -> ExitCode {
         return ExitCode::SUCCESS;
     };
     let sock = socket_path(&root);
+
+    // Refuse to talk to a socket under a directory that is not a user-private
+    // 0700 dir we own: under a shared `/tmp` fallback another local user could
+    // have planted one to spoof completions. Fail open (no suggestions).
+    let Some(dir) = sock.parent() else {
+        return ExitCode::SUCCESS;
+    };
+    if !ensure_private_dir(dir) {
+        return ExitCode::SUCCESS;
+    }
 
     // Fast path: a warm daemon is already listening.
     if let Some(out) = try_query(&sock, &query) {
@@ -158,7 +207,8 @@ fn daemon(root: Option<String>) -> ExitCode {
     let sock = socket_path(&root);
 
     let Some(listener) = bind(&sock) else {
-        // Another daemon already owns this socket; nothing to do.
+        // A live daemon already owns this socket, or the runtime dir is not a
+        // private 0700 dir we own. Either way, nothing to do.
         return ExitCode::SUCCESS;
     };
 
@@ -180,10 +230,13 @@ fn daemon(root: Option<String>) -> ExitCode {
 }
 
 /// Bind the socket, taking over a stale file left by a dead daemon. Returns
-/// `None` when a *live* daemon already holds it (we lose the start race).
+/// `None` when a *live* daemon already holds it (we lose the start race), or
+/// when the runtime directory is not a user-private 0700 dir we own (we then
+/// fail open rather than serve over a hijackable socket).
 fn bind(sock: &Path) -> Option<UnixListener> {
-    if let Some(parent) = sock.parent() {
-        let _ = std::fs::create_dir_all(parent);
+    let parent = sock.parent()?;
+    if !ensure_private_dir(parent) {
+        return None;
     }
     if let Ok(listener) = UnixListener::bind(sock) {
         return Some(listener);


### PR DESCRIPTION
Follow-up hardening to #1298 (these landed on the branch just after the squash merged, so they're not in main).

## Changes

1. **User-private socket dir (defense-in-depth).** The daemon socket now lives under `$XDG_RUNTIME_DIR/ix-fff-suggest` (OS-guaranteed 0700) or, when that's unset, a uid-namespaced `/tmp/ix-fff-suggest-<uid>` that is created and validated **0700, owned by us** before either the daemon binds or the client trusts it (`ensure_private_dir`, using `symlink_metadata` so a planted symlink can't pass). Under a shared `/tmp`, a deterministic socket path would otherwise let another local user pre-bind it to spoof completions or stall every `@`. Both sides fail open (no suggestions) if the dir isn't safely ours.

2. **Darwin portability of the e2e test.** Dropped the Linux-only `procps`/`pkill` from the `fff-suggest-e2e` check; the daemon already reaps itself via `IX_FFF_SUGGEST_IDLE_MS`, so the test needs no platform-specific killer (this stack is documented `meta.platforms = unix`).

## Verification

- `nix build .#fff-suggest` and `nix run .#lint` (7/7) pass.
- Manual: normal query returns the fff-ranked file via the `/tmp` fallback (dir auto-created 0700); a pre-planted world-writable runtime dir → client returns no output and **no daemon spawns** (fail-open hijack rejection).

🤖 Opened by an AI agent (Claude Code, claude-opus-4-8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Secure `fff-suggest` daemon socket with a user-private runtime directory
> - Adds `runtime_dir()` in [main.rs](https://github.com/indexable-inc/index/pull/1299/files#diff-03f6dcf19791ec15874de36bd8cc9e9aec2e9be5fc7eb2d2eca38380fa84d17a) to resolve a per-user socket directory, preferring `$XDG_RUNTIME_DIR/ix-fff-suggest` and falling back to `<tempdir>/ix-fff-suggest-<uid>` when `XDG_RUNTIME_DIR` is absent.
> - Adds `ensure_private_dir()` to enforce that the socket directory is a `0700` directory owned by the current user; it repairs directories with loose permissions we own, and rejects symlinks, non-directories, or directories owned by others.
> - Both the client and daemon now refuse to operate if the socket directory fails this check — the client exits silently with no output, and the daemon skips binding.
> - Removes the `pkill` step from the e2e test in [default.nix](https://github.com/indexable-inc/index/pull/1299/files#diff-fa79118925e12c122f98aa07b97766b12ef23e3750f351bb6c7d65ad6cc572ef), relying on the daemon's idle timeout instead, removing the `procps` dependency.
> - Behavioral Change: on systems without `$XDG_RUNTIME_DIR`, the socket path changes from a shared `ix-fff-suggest` directory to a uid-namespaced path, breaking socket discovery for any existing daemon instances.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cade4af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->