### PR TITLE
andrewgazelka: switch slack cask to slack@beta

### DIFF
--- a/users/andrewgazelka/darwin.nix
+++ b/users/andrewgazelka/darwin.nix
@@ -47,7 +47,7 @@
       "setapp"
       "signal"
       "skim"
-      "slack"
+      "slack@beta"
       "stremio"
       "superhuman"
       "superwhisper"

--- a/users/andrewgazelka/darwin.nix
+++ b/users/andrewgazelka/darwin.nix
@@ -17,7 +17,7 @@
 {
   homebrew = {
     casks = [
-      "1password-cli"
+      "1password-cli@beta"
       "beeper"
       "chatgpt"
       "chatgpt-atlas"
@@ -25,19 +25,19 @@
       # Cloudflare WARP: tunnels IPv4+IPv6 to Cloudflare, so an IPv6-only or
       # broken-IPv4 network (e.g. hotel wifi with dead DHCPv4) can still reach
       # IPv4-only hosts like github and Apple's APNs. Needs UDP egress to work.
-      "cloudflare-warp"
+      "cloudflare-warp@beta"
       "codex-app"
       "contexts"
       "cursor"
-      "emacs-app"
-      "ghostty"
+      "emacs-app@nightly"
+      "ghostty@tip"
       "google-chrome"
       "helium-browser"
       "linear"
       "lm-studio"
-      "mullvad-vpn"
+      "mullvad-vpn@beta"
       "notion"
-      "obs"
+      "obs@beta"
       "obsidian"
       "orbstack"
       "postico"
@@ -45,10 +45,10 @@
       "raycast"
       "screen-studio"
       "setapp"
-      "signal"
+      "signal@beta"
       "skim"
       "slack@beta"
-      "stremio"
+      "stremio@beta"
       "superhuman"
       "superwhisper"
       "tailscale-app"
@@ -61,7 +61,7 @@
       # refuses no-auth servers, so a third-party client is required to reach
       # `vnc://<host>.tail368802.ts.net:5900`. See ix nix/modules/desktop/remote-desktop.nix.
       "vnc-viewer"
-      "zed"
+      "zed@preview"
       "zoom"
     ];
 


### PR DESCRIPTION
Switch my Slack desktop cask from stable `slack` to `slack@beta` (beta channel, slack.com/beta/osx). No nightly cask exists in homebrew-cask, so beta is the closest to nightly.

Already swapped locally via `brew` so the running app matches; this makes it stick across `darwin-rebuild` (cleanup=zap would otherwise revert it).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch Homebrew casks to pre-release channels in andrewgazelka's darwin config
> Updates [darwin.nix](https://github.com/indexable-inc/index/pull/1303/files#diff-8e50939d75ca47b003564ea6eb7afcd3cd3ab9bfa6b8876d3c079c94862fb7bc) to use beta/nightly/preview/tip variants for all tracked casks, including `slack@beta`, `zed@preview`, `emacs-app@nightly`, `ghostty@tip`, and several others. Homebrew will now install and track pre-release builds for these apps instead of stable releases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2aa53d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->