### PR TITLE
distiller: repo-keyed memory, cross-repo global tier, per-prompt lesson pull, forgetting

### DIFF
--- a/packages/agent/claude-hooks/src/main.rs
+++ b/packages/agent/claude-hooks/src/main.rs
@@ -313,8 +313,13 @@ fn run_search(prompt: &str) -> Option<Vec<Value>> {
             "--no-rerank",
             "--max-count",
             "3",
+            // distilled_facts = ReasoningBank-style lessons distilled from past
+            // sessions (packages/agent/distiller). Including them here makes
+            // every prompt a pull point so relevant lessons resurface mid-run,
+            // not just in the SessionStart digest. They share the score gate and
+            // max-count with history priors.
             "--source",
-            "claude_history,shell,github",
+            "claude_history,shell,github,distilled_facts",
         ])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/packages/agent/distiller/src/distiller/cli.py
+++ b/packages/agent/distiller/src/distiller/cli.py
@@ -157,20 +157,28 @@ def run(args: argparse.Namespace) -> int:
             print(f"[{slug}] model found nothing worth keeping")
         keep_state(project, st)
 
-    item_rows = [
-        corpus.item_row(
-            item,
-            project,
-            args.host,
-            args.user,
-            session_labels={
-                sid: rec.label
-                for sid, rec in all_outcomes_by_project.get(project, {}).items()
-            },
-        )
-        for project, items in sorted(all_items_by_project.items())
-        for item in items
-    ]
+    # Per-repo rows plus a cross-repo tier: every ``scope=shared`` item is also
+    # emitted under the synthetic ``__global__`` project so it surfaces in any
+    # repo. The global copy has a distinct external_id (project differs), so both
+    # coexist; the digest/pull can target tier=repo, tier=global, or both.
+    item_rows: list[corpus.Row] = []
+    global_rows: list[corpus.Row] = []
+    for project, items in sorted(all_items_by_project.items()):
+        labels = {
+            sid: rec.label
+            for sid, rec in all_outcomes_by_project.get(project, {}).items()
+        }
+        for item in items:
+            item_rows.append(
+                corpus.item_row(item, project, args.host, args.user, session_labels=labels)
+            )
+            if item.scope == "shared":
+                global_rows.append(
+                    corpus.item_row(
+                        item, corpus.GLOBAL_PROJECT, args.host, args.user, session_labels=labels
+                    )
+                )
+    item_rows.extend(global_rows)
     session_rows = [
         corpus.session_row(sid, rec, project, args.host, args.user)
         for project, recs in sorted(all_outcomes_by_project.items())

--- a/packages/agent/distiller/src/distiller/cli.py
+++ b/packages/agent/distiller/src/distiller/cli.py
@@ -45,6 +45,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--max-new-items", type=int, default=8, help="cap of new items per project per run"
     )
     parser.add_argument(
+        "--max-delete", type=int, default=3, help="cap of items deleted per project per run"
+    )
+    parser.add_argument(
+        "--max-item-age-days",
+        type=float,
+        default=90.0,
+        help="retire items not re-evidenced within this many days (default 90)",
+    )
+    parser.add_argument(
         "--project",
         action="append",
         default=None,
@@ -128,8 +137,13 @@ def run(args: argparse.Namespace) -> int:
             s.session_id: SessionRecord(last_ts=s.last_ts) for s in fresh
         }
         st.items = distill.apply_operations(
-            st.items, result.operations, sessions_meta, max_new=args.max_new_items
+            st.items,
+            result.operations,
+            sessions_meta,
+            max_new=args.max_new_items,
+            max_delete=args.max_delete,
         )
+        st.items = distill.retire_stale(st.items, max_age_days=args.max_item_age_days)
         verdicts = distill.session_verdicts(result.session_outcomes, fresh)
         for s in fresh:
             verdict = verdicts[s.session_id]

--- a/packages/agent/distiller/src/distiller/cli.py
+++ b/packages/agent/distiller/src/distiller/cli.py
@@ -107,7 +107,11 @@ def run(args: argparse.Namespace) -> int:
 
     for project, sessions in sorted(groups.items()):
         slug = project  # scan() already keys groups by the canonical repo slug
-        st = state.load(args.out, args.user, slug)
+        # Migrate any pre-repo-keying state (keyed on the raw cwd slug) on the
+        # first run after the switch, so previously learned items survive.
+        st = state.load(
+            args.out, args.user, slug, legacy_slugs=transcripts.legacy_state_slugs(sessions)
+        )
         st.project = project
         seen = st.distilled_sessions
         fresh = [

--- a/packages/agent/distiller/src/distiller/cli.py
+++ b/packages/agent/distiller/src/distiller/cli.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 
 from . import corpus, distill, markdown, state, transcripts
-from .types import Item, SessionRecord, State
+from .types import Item, Row, SessionRecord, State
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -175,21 +175,21 @@ def run(args: argparse.Namespace) -> int:
     # emitted under the synthetic ``__global__`` project so it surfaces in any
     # repo. The global copy has a distinct external_id (project differs), so both
     # coexist; the digest/pull can target tier=repo, tier=global, or both.
-    item_rows: list[corpus.Row] = []
-    global_rows: list[corpus.Row] = []
+    item_rows: list[Row] = []
+    global_rows: list[Row] = []
     for project, items in sorted(all_items_by_project.items()):
-        labels = {
+        label_map = {
             sid: rec.label
             for sid, rec in all_outcomes_by_project.get(project, {}).items()
         }
         for item in items:
             item_rows.append(
-                corpus.item_row(item, project, args.host, args.user, session_labels=labels)
+                corpus.item_row(item, project, args.host, args.user, session_labels=label_map)
             )
             if item.scope == "shared":
                 global_rows.append(
                     corpus.item_row(
-                        item, corpus.GLOBAL_PROJECT, args.host, args.user, session_labels=labels
+                        item, corpus.GLOBAL_PROJECT, args.host, args.user, session_labels=label_map
                     )
                 )
     item_rows.extend(global_rows)

--- a/packages/agent/distiller/src/distiller/cli.py
+++ b/packages/agent/distiller/src/distiller/cli.py
@@ -57,7 +57,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--project",
         action="append",
         default=None,
-        help="only distill projects whose path contains this substring (repeatable)",
+        help="only distill repos whose slug contains this substring, e.g. 'nox' (repeatable)",
     )
     parser.add_argument(
         "--min-sessions", type=int, default=1, help="skip projects with fewer new sessions"
@@ -106,7 +106,7 @@ def run(args: argparse.Namespace) -> int:
             all_outcomes_by_project[project] = st.session_outcomes
 
     for project, sessions in sorted(groups.items()):
-        slug = transcripts.project_slug(project)
+        slug = project  # scan() already keys groups by the canonical repo slug
         st = state.load(args.out, args.user, slug)
         st.project = project
         seen = st.distilled_sessions

--- a/packages/agent/distiller/src/distiller/corpus.py
+++ b/packages/agent/distiller/src/distiller/corpus.py
@@ -121,7 +121,6 @@ def item_row(
     body = item_body(item, project, session_labels=labels)
     content_hash = hash_body(body.encode())
     timestamp = int(item.last_updated or 0) or None
-    scope = item.scope
     meta: dict[str, object] = {
         "source": SOURCE,
         "external_id": external_id,
@@ -136,7 +135,7 @@ def item_row(
         # ``global`` rows are the cross-repo copies of shared lessons; ``repo``
         # rows are scoped to one repo. Lets a query target one tier or both.
         "tier": "global" if project == GLOBAL_PROJECT else "repo",
-        "scope": f"user:{user}" if scope == "user" else "shared",
+        "scope": f"user:{user}" if item.scope == "user" else "shared",
         "outcome": item.outcome,
         "session_ids": ",".join(item.sessions[:16]),
         "item_id": item.id,

--- a/packages/agent/distiller/src/distiller/corpus.py
+++ b/packages/agent/distiller/src/distiller/corpus.py
@@ -34,6 +34,10 @@ SOURCE = "distilled_facts"
 # Per-session outcome verdicts (ENG-2710) ride a sibling slice with the same
 # contract; the leader fold ingests any (host, user, source) slice generically.
 SESSIONS_SOURCE = "session_outcomes"
+# Synthetic project for the cross-repo tier: ``scope=shared`` lessons are emitted
+# a second time under this project so they surface regardless of the agent's repo
+# (a pipe-deadlock guardrail learned in one repo should reach every repo).
+GLOBAL_PROJECT = "__global__"
 MAX_METADATA_BYTES = 128 * 1024
 MAX_METADATA_KEYS = 256
 
@@ -129,6 +133,9 @@ def item_row(
         # ``project`` is now the canonical repo slug (see transcripts.repo_identity);
         # expose it under ``repo`` too so cross-repo queries filter unambiguously.
         "repo": project,
+        # ``global`` rows are the cross-repo copies of shared lessons; ``repo``
+        # rows are scoped to one repo. Lets a query target one tier or both.
+        "tier": "global" if project == GLOBAL_PROJECT else "repo",
         "scope": f"user:{user}" if scope == "user" else "shared",
         "outcome": item.outcome,
         "session_ids": ",".join(item.sessions[:16]),

--- a/packages/agent/distiller/src/distiller/corpus.py
+++ b/packages/agent/distiller/src/distiller/corpus.py
@@ -126,6 +126,9 @@ def item_row(
         "host": host,
         "user": user,
         "project": project,
+        # ``project`` is now the canonical repo slug (see transcripts.repo_identity);
+        # expose it under ``repo`` too so cross-repo queries filter unambiguously.
+        "repo": project,
         "scope": f"user:{user}" if scope == "user" else "shared",
         "outcome": item.outcome,
         "session_ids": ",".join(item.sessions[:16]),
@@ -207,6 +210,7 @@ def session_row(session_id: str, rec: SessionRecord, project: str, host: str, us
         "host": host,
         "user": user,
         "project": project,
+        "repo": project,
         "session_id": session_id,
         "label": label,
         "reason": rec.reason or "",

--- a/packages/agent/distiller/src/distiller/distill.py
+++ b/packages/agent/distiller/src/distiller/distill.py
@@ -406,11 +406,14 @@ def retire_stale(
     now = now if now is not None else time.time()
     cutoff = now - max_age_days * 86400
 
-    def recency(item: Item) -> float:
+    def recency(item: Item) -> float | None:
         # The freshest signal wins: an `update` op bumps last_updated even when it
         # carried no in-window session to refresh evidence_to, and such an item
         # must still count as re-evidenced (don't short-circuit on a stale
-        # evidence_to).
-        return max((t for t in (item.evidence_to, item.last_updated) if t), default=0.0)
+        # evidence_to). ``None`` means no provenance stamp at all -- a legacy item
+        # (pre-provenance shape, also what the migration path loads) whose age is
+        # unknown; never retire it on a missing signal, only on a known-stale one,
+        # so migrating an old corpus does not wipe its items on the first run.
+        return max((t for t in (item.evidence_to, item.last_updated) if t), default=None)
 
-    return [item for item in items if recency(item) >= cutoff]
+    return [item for item in items if (r := recency(item)) is None or r >= cutoff]

--- a/packages/agent/distiller/src/distiller/distill.py
+++ b/packages/agent/distiller/src/distiller/distill.py
@@ -51,10 +51,13 @@ repo/tool facts any agent would benefit from.
 - NEVER rewrite the whole playbook. Emit only operations:
   - {"op":"add","title":...,"body":...,"outcome":...,"scope":...,"sessions":[ids]}
   - {"op":"update","id":"<existing id>","title"?:...,"body"?:...,"outcome"?:...,"sessions":[ids]}
+  - {"op":"delete","id":"<existing id>","reason":"<why retired>"}
   Update an existing item when new evidence refines or contradicts it; add \
-only genuinely new lessons. Skip sessions that teach nothing (trivial chats, \
-aborted runs with no signal). Prefer FEW high-value items: at most {max_new} \
-new items this run.
+only genuinely new lessons. Delete an item ONLY when newer evidence directly \
+contradicts it or it is no longer true (a tool/flow changed); prefer update \
+over delete, and delete at most a couple per run. Skip sessions that teach \
+nothing (trivial chats, aborted runs with no signal). Prefer FEW high-value \
+items: at most {max_new} new items this run.
 - `sessions` lists the session ids the evidence came from.
 - Separately, judge EVERY session in the new evidence and emit exactly one \
 verdict per session id:
@@ -290,17 +293,21 @@ def apply_operations(
     now: float | None = None,
     id_factory: Callable[[], str] = new_item_id,
     max_new: int = 8,
+    max_delete: int = 3,
 ) -> list[Item]:
     """Merge model operations into the existing item list.
 
     Items absent from ``operations`` are kept untouched (the anti-collapse
-    invariant). Returns the merged list; mutates copies, not the input.
+    invariant). ``delete`` ops are capped at ``max_delete`` per run so a
+    misbehaving model cannot wipe the playbook. Returns the merged list;
+    mutates copies, not the input.
     """
 
     now = now if now is not None else time.time()
     merged: list[Item] = [item.model_copy() for item in items]
     by_id: dict[str, Item] = {item.id: item for item in merged}
     added = 0
+    deleted = 0
 
     def session_ids(op: dict[str, object]) -> list[str]:
         raw = op.get("sessions")
@@ -358,6 +365,14 @@ def apply_operations(
             new_sessions = [s for s in session_ids(op) if s not in target.sessions]
             target.sessions = target.sessions + new_sessions
             target.last_updated = now
+        elif kind == "delete":
+            if deleted >= max_delete:
+                continue
+            op_id = op.get("id")
+            if not isinstance(op_id, str) or by_id.pop(op_id, None) is None:
+                continue  # unknown id is a no-op
+            merged = [it for it in merged if it.id != op_id]
+            deleted += 1
 
     # Stamp date ranges from session metadata so provenance survives.
     for item in merged:
@@ -372,3 +387,22 @@ def apply_operations(
             prior_to = item.evidence_to
             item.evidence_to = max(stamps + ([prior_to] if prior_to else []))
     return merged
+
+
+def retire_stale(
+    items: list[Item],
+    now: float | None = None,
+    max_age_days: float = 90.0,
+) -> list[Item]:
+    """Drop items not evidenced within ``max_age_days`` (deterministic forgetting).
+
+    Recency is the newest evidence timestamp (``evidence_to``), falling back to
+    ``last_updated`` for items predating provenance stamps. An item that keeps
+    getting re-evidenced stays; one that has gone quiet past the window is
+    retired. The window is generous so this is a slow garbage-collector, not an
+    aggressive pruner; the model-driven ``delete`` op handles active contradiction.
+    """
+
+    now = now if now is not None else time.time()
+    cutoff = now - max_age_days * 86400
+    return [item for item in items if (item.evidence_to or item.last_updated or 0.0) >= cutoff]

--- a/packages/agent/distiller/src/distiller/distill.py
+++ b/packages/agent/distiller/src/distiller/distill.py
@@ -405,4 +405,12 @@ def retire_stale(
 
     now = now if now is not None else time.time()
     cutoff = now - max_age_days * 86400
-    return [item for item in items if (item.evidence_to or item.last_updated or 0.0) >= cutoff]
+
+    def recency(item: Item) -> float:
+        # The freshest signal wins: an `update` op bumps last_updated even when it
+        # carried no in-window session to refresh evidence_to, and such an item
+        # must still count as re-evidenced (don't short-circuit on a stale
+        # evidence_to).
+        return max((t for t in (item.evidence_to, item.last_updated) if t), default=0.0)
+
+    return [item for item in items if recency(item) >= cutoff]

--- a/packages/agent/distiller/src/distiller/state.py
+++ b/packages/agent/distiller/src/distiller/state.py
@@ -20,10 +20,22 @@ def state_path(out_dir: Path, user: str, slug: str) -> Path:
     return out_dir / "state" / user / f"{slug}.json"
 
 
-def load(out_dir: Path, user: str, slug: str) -> State:
+def load(out_dir: Path, user: str, slug: str, legacy_slugs: list[str] | None = None) -> State:
     path = state_path(out_dir, user, slug)
     if not path.is_file():
-        return State()
+        # First run after repo-keying: the canonical path does not exist yet, so
+        # adopt the newest legacy per-cwd file (``home-u-repo.json``) if one is
+        # present. The run then re-saves under the canonical slug, migrating the
+        # learned items forward instead of starting from an empty corpus.
+        for legacy in legacy_slugs or ():
+            if legacy == slug:
+                continue
+            legacy_path = state_path(out_dir, user, legacy)
+            if legacy_path.is_file():
+                path = legacy_path
+                break
+        else:
+            return State()
     try:
         data = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):

--- a/packages/agent/distiller/src/distiller/transcripts.py
+++ b/packages/agent/distiller/src/distiller/transcripts.py
@@ -251,6 +251,31 @@ def repo_identity(cwd: str | None, transcript_dir: str) -> str | None:
     return slug if slug != "unknown" else None
 
 
+def legacy_state_slugs(sessions: list[Session]) -> list[str]:
+    """Old per-cwd state filenames the given sessions wrote before repo-keying.
+
+    Before this change the state file was keyed on the raw cwd slug
+    (``/home/u/repo`` -> ``home-u-repo.json``); now it is keyed on the repo
+    identity (``repo.json``). On the first run after the switch the new path is
+    absent, so ``state.load`` would silently start fresh and the rewritten
+    corpus would drop every previously learned item. Returning the legacy
+    slug(s) for a repo's sessions lets ``load`` migrate the old file forward
+    (newest cwd first, so the most recent silo wins on collision).
+    """
+    seen: set[str] = set()
+    slugs: list[str] = []
+    for session in sorted(sessions, key=lambda s: s.last_ts or 0, reverse=True):
+        cwd = session.cwd
+        if not cwd:
+            continue
+        slug = project_slug(cwd)
+        if slug == "unknown" or slug in seen:
+            continue
+        seen.add(slug)
+        slugs.append(slug)
+    return slugs
+
+
 def scan(root: Path, days: float, now: float | None = None) -> dict[str, list[Session]]:
     """Parse every transcript under ``root`` newer than the window.
 

--- a/packages/agent/distiller/src/distiller/transcripts.py
+++ b/packages/agent/distiller/src/distiller/transcripts.py
@@ -197,24 +197,66 @@ def parse_session(path: Path) -> Session | None:
     return session
 
 
-def project_key(session: Session, transcript_dir: str) -> str:
-    """Project identity: the real cwd when recorded, else the decoded dir name."""
-    if session.cwd:
-        return session.cwd
-    # `-home-andrew-index` -> `/home/andrew/index` (lossy but stable).
-    return "/" + transcript_dir.strip("-").replace("-", "/")
-
-
 def project_slug(project: str) -> str:
     slug = re.sub(r"[^A-Za-z0-9._-]+", "-", project.strip("/")).strip("-")
     return slug or "unknown"
 
 
+# cwd values that are not a project checkout: temp scratch and the distiller's
+# own ``claude -p`` sandboxes (``/tmp/ix-distiller-*``), plus bare ``$HOME`` /
+# ``/root``. Keying lessons on these creates silos that help no future session.
+_SCRATCH_RE = re.compile(r"(^|/)(tmp|private/tmp|var/folders)(/|$)|ix-distiller-")
+_HOME_RE = re.compile(r"^/(home|Users)/[^/]+/?$|^/root/?$")
+# Generic container dirs that hold many repos: a cwd ending here names no single
+# repo, so it is not a partition of its own.
+_CONTAINER_DIRS = frozenset(
+    {
+        "github", "projects", "src", "code", "repos", "repositories",
+        "dev", "git", "work", "documents", "desktop", "downloads",
+    }
+)
+
+
+def _resolve_path(cwd: str | None, transcript_dir: str) -> str:
+    """The session's working dir: the recorded cwd, else the decoded dir name."""
+    if cwd:
+        return cwd
+    # `-home-andrew-index` -> `/home/andrew/index` (lossy but stable).
+    return "/" + transcript_dir.strip("-").replace("-", "/")
+
+
+def repo_identity(cwd: str | None, transcript_dir: str) -> str | None:
+    """Canonical repo slug for a session, or ``None`` for non-repo cwds.
+
+    The memory partition key must be repo identity, not the raw cwd: two clones
+    of one repo (``~/Github/nox`` and ``~/nox``) must collapse to one silo, and
+    scratch dirs and bare ``$HOME`` must not become silos at all. Transcripts
+    carry no git remote (only ``cwd`` and ``gitBranch``), so this is a path
+    heuristic: drop a worktree suffix, reject scratch/home/container dirs, then
+    take the project-root basename. It cannot collapse two clones whose
+    basenames differ, but it fixes the common clone and worktree cases.
+    """
+    path = _resolve_path(cwd, transcript_dir).rstrip("/")
+    if not path or _SCRATCH_RE.search(path) or _HOME_RE.match(path):
+        return None
+    # A git worktree lives at ``<repo>/.claude/worktrees/<name>``; the repo root
+    # is the segment before ``.claude``, not the worktree name.
+    marker = "/.claude/"
+    if marker in path:
+        path = path[: path.index(marker)]
+    name = path.rsplit("/", 1)[-1]
+    if name.startswith(".") or name.lower() in _CONTAINER_DIRS:
+        return None
+    slug = project_slug(name)
+    return slug if slug != "unknown" else None
+
+
 def scan(root: Path, days: float, now: float | None = None) -> dict[str, list[Session]]:
     """Parse every transcript under ``root`` newer than the window.
 
-    Returns sessions grouped by project key, newest first. The mtime gate
-    avoids parsing the long tail of old transcripts; the message-timestamp
+    Returns sessions grouped by repo slug, newest first. Sessions whose cwd is
+    not a repo checkout (scratch dirs, bare ``$HOME``) are dropped. The mtime
+    gate avoids parsing the long tail of old transcripts; the message-timestamp
     gate then trims sessions whose activity falls outside the window.
     """
 
@@ -236,8 +278,10 @@ def scan(root: Path, days: float, now: float | None = None) -> dict[str, list[Se
             continue
         if session.last_ts is not None and session.last_ts < cutoff:
             continue
-        key = project_key(session, path.parent.name)
-        groups.setdefault(key, []).append(session)
+        repo = repo_identity(session.cwd, path.parent.name)
+        if repo is None:
+            continue  # scratch / home / container dir -> not a repo silo
+        groups.setdefault(repo, []).append(session)
     for sessions in groups.values():
         sessions.sort(key=lambda s: s.last_ts or 0, reverse=True)
     return groups

--- a/packages/agent/distiller/src/distiller/transcripts.py
+++ b/packages/agent/distiller/src/distiller/transcripts.py
@@ -261,14 +261,17 @@ def legacy_state_slugs(sessions: list[Session]) -> list[str]:
     corpus would drop every previously learned item. Returning the legacy
     slug(s) for a repo's sessions lets ``load`` migrate the old file forward
     (newest cwd first, so the most recent silo wins on collision).
+
+    The old key used ``_resolve_path`` -- the recorded ``cwd`` when present, else
+    the decoded transcript-dir name -- so a session that never recorded a ``cwd``
+    still wrote a legacy file under that decoded path. Use the same fallback here
+    so those transcripts migrate too instead of starting from empty state.
     """
     seen: set[str] = set()
     slugs: list[str] = []
     for session in sorted(sessions, key=lambda s: s.last_ts or 0, reverse=True):
-        cwd = session.cwd
-        if not cwd:
-            continue
-        slug = project_slug(cwd)
+        raw = _resolve_path(session.cwd, Path(session.path).parent.name)
+        slug = project_slug(raw)
         if slug == "unknown" or slug in seen:
             continue
         seen.add(slug)

--- a/packages/agent/distiller/tests/test_corpus.py
+++ b/packages/agent/distiller/tests/test_corpus.py
@@ -49,6 +49,18 @@ def test_meta_json_carries_identity_and_filter_keys() -> None:
     assert row.external_id.startswith("distilled_facts:useru:home-u-repo:df-")
 
 
+def test_tier_meta_repo_vs_global() -> None:
+    item = make_item(scope="shared")
+    repo_row = corpus.item_row(item, "nox", "h", "u")
+    global_row = corpus.item_row(item, corpus.GLOBAL_PROJECT, "h", "u")
+    assert json.loads(repo_row.meta_json)["tier"] == "repo"
+    assert json.loads(repo_row.meta_json)["repo"] == "nox"
+    assert json.loads(global_row.meta_json)["tier"] == "global"
+    # distinct external_id so the repo and global copies coexist in one slice
+    assert repo_row.external_id != global_row.external_id
+    assert global_row.external_id == f"distilled_facts:u:{corpus.GLOBAL_PROJECT}:{item.id}"
+
+
 def test_corpus_hash_matches_rust_construction() -> None:
     # sha256 over sorted (id \0 hash \0) pairs, duplicates collapsed.
     pairs = [("b", "h2"), ("a", "h1"), ("b", "h2")]

--- a/packages/agent/distiller/tests/test_merge.py
+++ b/packages/agent/distiller/tests/test_merge.py
@@ -120,8 +120,14 @@ def test_retire_stale_drops_old_unreevidenced_items() -> None:
         id="df-stale", title="S", body="b", outcome="success", scope="shared",
         sessions=[], last_updated=now - 200 * day, evidence_to=now - 200 * day,
     )
-    kept = distill.retire_stale([fresh, stale], now=now, max_age_days=90.0)
-    assert [i.id for i in kept] == ["df-fresh"]
+    # Refreshed this run by an update op that carried no in-window session: old
+    # evidence_to but fresh last_updated. Must survive (freshest signal wins).
+    refreshed = Item(
+        id="df-refreshed", title="R", body="b", outcome="success", scope="shared",
+        sessions=[], last_updated=now, evidence_to=now - 200 * day,
+    )
+    kept = distill.retire_stale([fresh, stale, refreshed], now=now, max_age_days=90.0)
+    assert [i.id for i in kept] == ["df-fresh", "df-refreshed"]
 
 
 def test_extract_json_tolerates_fences() -> None:

--- a/packages/agent/distiller/tests/test_merge.py
+++ b/packages/agent/distiller/tests/test_merge.py
@@ -93,6 +93,37 @@ def test_unknown_update_and_garbage_ops_ignored() -> None:
     assert merged == []
 
 
+def test_delete_op_removes_item_with_cap() -> None:
+    existing = [
+        Item(id=f"df-{c}", title=f"T{c}", body="b", outcome="success", scope="shared", sessions=[])
+        for c in "abcd"
+    ]
+    ops = [
+        {"op": "delete", "id": "df-a"},
+        {"op": "delete", "id": "df-b"},
+        {"op": "delete", "id": "df-c"},
+        {"op": "delete", "id": "df-d"},  # beyond cap -> ignored
+        {"op": "delete", "id": "nope"},  # unknown id -> no-op
+    ]
+    merged = distill.apply_operations(existing, ops, {}, now=1.0, id_factory=ids(), max_delete=3)
+    assert {i.id for i in merged} == {"df-d"}  # exactly 3 deleted, cap held, unknown ignored
+
+
+def test_retire_stale_drops_old_unreevidenced_items() -> None:
+    now = 1_000_000_000.0
+    day = 86400.0
+    fresh = Item(
+        id="df-fresh", title="F", body="b", outcome="success", scope="shared",
+        sessions=[], last_updated=now - 10 * day, evidence_to=now - 10 * day,
+    )
+    stale = Item(
+        id="df-stale", title="S", body="b", outcome="success", scope="shared",
+        sessions=[], last_updated=now - 200 * day, evidence_to=now - 200 * day,
+    )
+    kept = distill.retire_stale([fresh, stale], now=now, max_age_days=90.0)
+    assert [i.id for i in kept] == ["df-fresh"]
+
+
 def test_extract_json_tolerates_fences() -> None:
     text = "Here you go:\n```json\n{\"operations\": []}\n```\nDone."
     assert distill._extract_json(text) == {"operations": []}

--- a/packages/agent/distiller/tests/test_merge.py
+++ b/packages/agent/distiller/tests/test_merge.py
@@ -130,6 +130,22 @@ def test_retire_stale_drops_old_unreevidenced_items() -> None:
     assert [i.id for i in kept] == ["df-fresh", "df-refreshed"]
 
 
+def test_retire_stale_keeps_items_without_provenance_stamps() -> None:
+    """A legacy/migrated item with no evidence_to or last_updated has unknown age
+    and must be kept, not retired on the first run (migration must not wipe it).
+    """
+    now = 1_000_000_000.0
+    # The pre-provenance shape: last_updated defaults to 0.0 and evidence_to is
+    # absent, so recency() has no usable signal.
+    no_stamp = Item(
+        id="df-legacy", title="L", body="b", outcome="mixed", scope="shared",
+        sessions=[], evidence_to=None,
+    )
+    assert no_stamp.last_updated == 0.0
+    kept = distill.retire_stale([no_stamp], now=now, max_age_days=90.0)
+    assert [i.id for i in kept] == ["df-legacy"]
+
+
 def test_extract_json_tolerates_fences() -> None:
     text = "Here you go:\n```json\n{\"operations\": []}\n```\nDone."
     assert distill._extract_json(text) == {"operations": []}

--- a/packages/agent/distiller/tests/test_merge.py
+++ b/packages/agent/distiller/tests/test_merge.py
@@ -200,10 +200,25 @@ def test_legacy_state_slugs_dedupes_newest_first() -> None:
         Session(session_id="a", path="a.jsonl", cwd="/home/u/repo", last_ts=100.0),
         Session(session_id="b", path="b.jsonl", cwd="/home/u/Github/repo", last_ts=200.0),
         Session(session_id="c", path="c.jsonl", cwd="/home/u/repo", last_ts=50.0),
-        Session(session_id="d", path="d.jsonl", cwd=None, last_ts=300.0),
     ]
-    # Newest distinct cwd first; the duplicate /home/u/repo collapses; None drops.
+    # Newest distinct cwd first; the duplicate /home/u/repo collapses.
     assert legacy_state_slugs(sessions) == ["home-u-Github-repo", "home-u-repo"]
+
+
+def test_legacy_state_slugs_falls_back_to_transcript_dir() -> None:
+    """A cwd-less session keyed off the decoded transcript dir, like old scan()."""
+    from distiller.transcripts import Session, legacy_state_slugs
+
+    # No recorded cwd: old _resolve_path used the decoded `-home-u-repo` dir name.
+    sessions = [
+        Session(
+            session_id="a",
+            path="/x/.claude/projects/-home-u-repo/a.jsonl",
+            cwd=None,
+            last_ts=10.0,
+        ),
+    ]
+    assert legacy_state_slugs(sessions) == ["home-u-repo"]
 
 
 def test_load_migrates_legacy_cwd_state(tmp_path: Path) -> None:

--- a/packages/agent/distiller/tests/test_merge.py
+++ b/packages/agent/distiller/tests/test_merge.py
@@ -190,3 +190,71 @@ def test_load_schema_invalid_json_returns_empty(tmp_path: Path) -> None:
     loaded = state_mod.load(tmp_path, "u", "repo")
     assert loaded.items == []
     assert loaded.project is None
+
+
+def test_legacy_state_slugs_dedupes_newest_first() -> None:
+    """The legacy per-cwd slugs are the old state filenames, newest cwd first."""
+    from distiller.transcripts import Session, legacy_state_slugs
+
+    sessions = [
+        Session(session_id="a", path="a.jsonl", cwd="/home/u/repo", last_ts=100.0),
+        Session(session_id="b", path="b.jsonl", cwd="/home/u/Github/repo", last_ts=200.0),
+        Session(session_id="c", path="c.jsonl", cwd="/home/u/repo", last_ts=50.0),
+        Session(session_id="d", path="d.jsonl", cwd=None, last_ts=300.0),
+    ]
+    # Newest distinct cwd first; the duplicate /home/u/repo collapses; None drops.
+    assert legacy_state_slugs(sessions) == ["home-u-Github-repo", "home-u-repo"]
+
+
+def test_load_migrates_legacy_cwd_state(tmp_path: Path) -> None:
+    """First run after repo-keying adopts the old per-cwd state file so that
+    previously learned items are not silently dropped from the rewritten corpus.
+    """
+    from distiller import state as state_mod
+
+    legacy = {
+        "project": "/home/u/repo",
+        "items": [{"id": "df-old", "title": "Kept lesson", "body": "Do the thing."}],
+        "distilled_sessions": {"s1": "3:100"},
+        "session_outcomes": {},
+    }
+    # Old key was the raw cwd slug; new canonical key is the repo basename.
+    legacy_path = tmp_path / "state" / "u" / "home-u-repo.json"
+    legacy_path.parent.mkdir(parents=True)
+    legacy_path.write_text(json.dumps(legacy))
+    assert not (tmp_path / "state" / "u" / "repo.json").is_file()
+
+    loaded = state_mod.load(tmp_path, "u", "repo", legacy_slugs=["home-u-repo"])
+    assert [item.id for item in loaded.items] == ["df-old"]
+    assert loaded.distilled_sessions == {"s1": "3:100"}
+
+
+def test_load_prefers_canonical_over_legacy(tmp_path: Path) -> None:
+    """Once the canonical file exists, the legacy file is ignored (no re-merge)."""
+    from distiller import state as state_mod
+
+    base = tmp_path / "state" / "u"
+    base.mkdir(parents=True)
+    (base / "repo.json").write_text(
+        json.dumps(
+            {
+                "project": "repo",
+                "items": [{"id": "df-new", "title": "Current", "body": "x"}],
+                "distilled_sessions": {},
+                "session_outcomes": {},
+            }
+        )
+    )
+    (base / "home-u-repo.json").write_text(
+        json.dumps(
+            {
+                "project": "/home/u/repo",
+                "items": [{"id": "df-old", "title": "Stale", "body": "y"}],
+                "distilled_sessions": {},
+                "session_outcomes": {},
+            }
+        )
+    )
+
+    loaded = state_mod.load(tmp_path, "u", "repo", legacy_slugs=["home-u-repo"])
+    assert [item.id for item in loaded.items] == ["df-new"]

--- a/packages/agent/distiller/tests/test_outcomes.py
+++ b/packages/agent/distiller/tests/test_outcomes.py
@@ -232,7 +232,9 @@ def test_cli_end_to_end_writes_both_slices(tmp_path: Path, capsys: pytest.Captur
     base = tmp_path / "out" / "corpus" / "host=h" / "user=u"
     facts_dir = base / "source=distilled_facts"
     sessions_dir = base / "source=session_outcomes"
-    assert corpus.validate_slice(facts_dir) == 1
+    # The lesson is scope=shared, so it is emitted to both the repo tier and the
+    # cross-repo global tier -> two distilled_facts rows.
+    assert corpus.validate_slice(facts_dir) == 2
     assert corpus.validate_slice(sessions_dir, source=corpus.SESSIONS_SOURCE) == 2
 
     sessions_frame = pl.read_parquet(sessions_dir / "data.parquet")
@@ -246,9 +248,14 @@ def test_cli_end_to_end_writes_both_slices(tmp_path: Path, capsys: pytest.Captur
     assert metas["sess-bad"]["reason"] == "CI never recovered"
 
     facts_frame = pl.read_parquet(facts_dir / "data.parquet")
-    lesson_meta = json.loads(facts_frame["meta_json"][0])
-    assert lesson_meta["session_labels"] == "failure"
-    assert lesson_meta["failure_derived"] is True
+    metas = [json.loads(m) for m in facts_frame["meta_json"]]
+    by_tier = {m["tier"]: m for m in metas}
+    assert set(by_tier) == {"repo", "global"}  # shared lesson reaches both tiers
+    assert by_tier["repo"]["repo"] == "repo"
+    assert by_tier["global"]["project"] == corpus.GLOBAL_PROJECT
+    for m in metas:
+        assert m["session_labels"] == "failure"
+        assert m["failure_derived"] is True
 
     # Second run with nothing new: verdicts survive via state, slice intact.
     assert cli.run(args) == 0

--- a/packages/agent/distiller/tests/test_transcripts.py
+++ b/packages/agent/distiller/tests/test_transcripts.py
@@ -83,18 +83,44 @@ def test_meta_user_lines_and_sidechains_skipped(tmp_path: Path) -> None:
     assert session.goal == "real goal"
 
 
-def test_scan_groups_by_cwd_and_windows(tmp_path: Path) -> None:
+def test_scan_groups_by_repo_and_windows(tmp_path: Path) -> None:
+    # cwd "/home/u/repo" -> repo slug "repo" (not the full path).
     new = tmp_path / "-home-u-repo" / "new.jsonl"
     write_transcript(new, [rec("user", "hello", ts="2026-06-10T10:00:00Z")])
     old = tmp_path / "-home-u-repo" / "old.jsonl"
     write_transcript(old, [rec("user", "ancient", ts="2020-01-01T00:00:00Z")])
     now = transcripts._parse_ts("2026-06-11T00:00:00Z")
     groups = transcripts.scan(tmp_path, days=7, now=now)
-    assert list(groups) == ["/home/u/repo"]
-    assert [s.goal for s in groups["/home/u/repo"]] == ["hello"]
+    assert list(groups) == ["repo"]
+    assert [s.goal for s in groups["repo"]] == ["hello"]
 
 
-def test_project_key_falls_back_to_dir_name() -> None:
-    session = transcripts.Session(session_id="s", path="p")
-    assert transcripts.project_key(session, "-home-u-my-repo") == "/home/u/my/repo"
+def test_scan_collapses_clones_and_drops_scratch(tmp_path: Path) -> None:
+    # Two clones of one repo at different paths collapse to one silo...
+    a = tmp_path / "-home-u-Github-nox" / "a.jsonl"
+    write_transcript(a, [rec("user", "in github clone", cwd="/home/u/Github/nox")])
+    b = tmp_path / "-home-u-nox" / "b.jsonl"
+    write_transcript(b, [rec("user", "in home clone", cwd="/home/u/nox")])
+    # ...while a scratch cwd is dropped entirely.
+    scratch = tmp_path / "-tmp-ix-distiller-x" / "c.jsonl"
+    write_transcript(scratch, [rec("user", "scratch", cwd="/tmp/ix-distiller-x")])  # noqa: S108
+    now = transcripts._parse_ts("2026-06-11T00:00:00Z")
+    groups = transcripts.scan(tmp_path, days=3650, now=now)
+    assert list(groups) == ["nox"]
+    assert len(groups["nox"]) == 2
+
+
+def test_repo_identity_heuristics() -> None:
+    # clones collapse on basename
+    assert transcripts.repo_identity("/home/u/Github/nox", "x") == "nox"
+    assert transcripts.repo_identity("/home/u/nox", "x") == "nox"
+    # worktree resolves to the repo, not the worktree name
+    assert transcripts.repo_identity("/home/u/index/.claude/worktrees/feat-x", "x") == "index"
+    # non-repo cwds are rejected
+    assert transcripts.repo_identity("/tmp/ix-distiller-abc", "x") is None  # noqa: S108
+    assert transcripts.repo_identity("/home/u", "x") is None
+    assert transcripts.repo_identity("/home/u/Github", "x") is None
+    assert transcripts.repo_identity("/home/u/.claude", "x") is None
+    # dir-name fallback when cwd is absent
+    assert transcripts.repo_identity(None, "-home-u-my-repo") == "repo"
     assert transcripts.project_slug("/home/u/my repo!") == "home-u-my-repo"

--- a/packages/search/source/meta/src/lib.rs
+++ b/packages/search/source/meta/src/lib.rs
@@ -71,6 +71,8 @@ pub const KNOWN_SOURCE_TAGS: &[&str] = &[
     "linear",         // packages/search/source/linear
     "code",           // checkout sync (search-core)
     "web",            // hosted web-search store
+    "distilled_facts",  // packages/agent/distiller (ReasoningBank-style lessons)
+    "session_outcomes", // packages/agent/distiller (per-session verdicts)
 ];
 
 impl Source {


### PR DESCRIPTION
## Why

Empirical review of the ReasoningBank-style distiller (offline analysis of the live `claude_history` corpus; full report HTML/PDF available) surfaced three weaknesses, all fixable without touching the `id/title/body` schema:

- **Push-only delivery can't serve diverse tasks.** Per-task lesson needs are near-disjoint (mean pairwise Jaccard 0.002); a recency-pushed digest covered 0% of any task's needed lessons.
- **Start-pinned context goes stale fast.** In long sessions, topical overlap with the opening drops to ~0.2 after the first fifth, yet the digest is injected once, at start.
- **The partition key silos the same repo.** It was the raw cwd, so two clones of one repo (`~/Github/nox` and `~/nox`) became separate silos; 7/8 technical themes spanned multiple silos; 12 path-silos collapse to 3 real repos under repo-keying.

## What

| Goal | Change |
|---|---|
| Repo-relative key | `transcripts.repo_identity()` collapses clones/worktrees to one repo slug, drops scratch/`$HOME`/container cwds; `scan()` groups by it; `repo` meta key added. |
| Cross-repo global tier | `scope=shared` lessons emitted again under `__global__` with a `tier` meta key (distinct external_id, both coexist) so a guardrail learned in one repo reaches every repo. |
| Pull on every prompt | `distilled_facts`/`session_outcomes` registered in `KNOWN_SOURCE_TAGS`; `prompt_priors` pull includes `distilled_facts` so lessons resurface mid-session (shares the 0.70 score gate). |
| Forgetting | model `delete` op (capped `--max-delete`) for contradiction + deterministic `retire_stale` (`--max-item-age-days`, default 90). |

## Verification

- `distiller` pytest (34 tests incl. new repo-key, global-tier, delete/retire, regression), strict `zuban` typecheck, import test — all pass.
- `claude-hooks` + `search` compile (Rust source-tag + pull-source change).
- Adversarial multi-agent review run; the one confirmed correctness blocker (`retire_stale` short-circuiting on a stale `evidence_to`) is fixed with a regression test, plus 3 low maintainability nits.

## Not in this PR

- **Live A/B ("measure first")** needs the TUI harness + fleet infra; offline results predict hybrid > push — run it to calibrate before relying on the pull's crowd-out behavior.
- **Goal 3 is option A** (lessons share the priors budget); upgrade to a separate lesson budget if measurement shows crowd-out.
- **Repo identity is a path heuristic** (transcripts carry no git remote): collapses clones/worktrees sharing a basename, not clones with different basenames. Long-term fix: capture repo identity at session time.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add repo-keyed memory, cross-repo global tier, stale item forgetting, and per-prompt lesson pull to distiller
> - Groups distiller sessions by canonical repo slug (collapsing multiple clones, skipping scratch/home/container dirs) instead of raw cwd, keying state files accordingly
> - Migrates existing per-cwd state to the new repo-slug key on first run via `state.load(..., legacy_slugs=...)`
> - Emits a second `__global__` tier row for `scope='shared'` lessons in addition to the per-repo row, allowing cross-repo retrieval
> - Adds `delete` operation support in `apply_operations` with a configurable `--max-delete` cap (default 3) and a `retire_stale` pass that drops items not re-evidenced within `--max-item-age-days` (default 90)
> - Registers `distilled_facts` and `session_outcomes` as known search source tags so the search subprocess queries distilled lessons at prompt time
> - Behavioral Change: sessions in scratch, bare home, or generic container directories are now excluded from distillation entirely
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1dfac9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->