### PR TITLE
mcp: stop auto-spawning a dashboard hub per `serve` (default off)

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -3,8 +3,9 @@
 A Python execution MCP server. Its one general tool, `python_exec`, runs code on
 **one shared, persistent IPython kernel**. The namespace persists across calls,
 many executions run **concurrently** on the kernel's event loop, and work that
-outlives a short foreground budget keeps running in the background. An
-auto-started dashboard shows every running execution and its live output.
+outlives a short foreground budget keeps running in the background. Run one
+standalone dashboard (`nix run .#dashboard`) to see every running execution and
+its live output across all servers.
 
 ## Quickstart
 
@@ -91,8 +92,11 @@ repr on the dashboard and its text to you.
 
 ## How it works
 
-`ix-mcp serve` starts one IPython kernel (over `jupyter-client`), an auto-started
-read-only dashboard, and the MCP transport, all on one event loop.
+`ix-mcp serve` starts one IPython kernel (over `jupyter-client`), a read-only
+data API, and the MCP transport, all on one event loop. It publishes its panes
+to the shared discovery dir but does not spawn its own dashboard hub; run one
+standalone `dashboard` (`nix run .#dashboard`) to view every server at once, or
+set `IX_MCP_AUTO_DASHBOARD=1` to restore the old per-server auto-spawn.
 
 - `kernel.py` owns the single kernel; `python_exec` sends `await __ix_exec(code,
   budget)` to it.

--- a/packages/mcp/ix_notebook_mcp/__init__.py
+++ b/packages/mcp/ix_notebook_mcp/__init__.py
@@ -5,8 +5,9 @@ Every execution runs as an asyncio task on that kernel's event loop, so many run
 concurrently and none blocks the others. A call waits up to ``budget`` seconds;
 if the work is still going it keeps running in the background, registered in the
 in-kernel ``jobs`` dict that later ``python_exec`` calls inspect, await, or
-cancel. Each run is logged to a SQLite store that an auto-started dashboard
-renders, so a human can watch every running thing and its output live.
+cancel. Each run is logged to a SQLite store and published to the shared
+discovery dir, so a single standalone ``dashboard`` (``nix run .#dashboard``)
+renders every running thing and its output live for a human to watch.
 
 The pieces:
   - :mod:`ix_notebook_mcp.runtime` is the in-kernel runtime (``jobs``/``Job``/

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -7,11 +7,14 @@
   ix-mcp eval EXPR             evaluate one expression on a throwaway kernel
   ix-mcp exec SRC              run statements on a throwaway kernel
 
-`serve` starts ONE shared IPython kernel, an auto-started read-only dashboard
-over the execution store, and the MCP transport, all on one event loop.
-`notebook` is the engine without the MCP surface: the same kernel, store, and
-dashboard, driven only by what is already in the session file and the humans
-watching it.
+`serve` starts ONE shared IPython kernel, a read-only data API over the
+execution store, and the MCP transport, all on one event loop. It publishes its
+panes into the shared discovery dir but does NOT spawn a `dashboard` hub: that
+aggregator is a single machine-wide process you run yourself once
+(`nix run .#dashboard`), which renders every server behind one URL. Set
+`IX_MCP_AUTO_DASHBOARD` truthy to restore the old per-server auto-spawn.
+`notebook` is the engine without the MCP surface: the same kernel and store,
+driven only by what is already in the session file and the humans watching it.
 
 A session file (``--session work.ixnb`` or ``notebook work.ixnb``) makes the
 store persistent instead of per-run: every cell, its outputs, and a serialized
@@ -284,6 +287,28 @@ def _exec_trust_network() -> bool:
     )
 
 
+def _auto_dashboard() -> bool:
+    """Whether ``serve`` should spawn its own ``dashboard`` hub.
+
+    Off by default. The hub is a single, machine-wide, long-lived aggregator:
+    exactly one process binds the port, and every ``serve`` already publishes its
+    panes into the shared discovery dir (see ``pane_bridge``), so one hub renders
+    them all behind one stable URL. Spawning a hub per ``serve`` both duplicates
+    that singleton and leaks it -- a ``serve`` killed abnormally (SIGKILL/crash)
+    skips the cleanup ``finally``, so its hub reparents to init and survives
+    forever; a churning fleet of short-lived servers piles up thousands of
+    orphaned ``dashboard`` processes. Run the UI yourself once instead
+    (``nix run .#dashboard``). Set ``IX_MCP_AUTO_DASHBOARD`` truthy to restore the
+    old auto-spawn.
+    """
+    return os.environ.get("IX_MCP_AUTO_DASHBOARD", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
 def _serve(args: argparse.Namespace, *, engine_only: bool = False) -> int:
     wd = getattr(args, "workdir", None)
     workdir = Path(wd).resolve() if wd else Path.cwd()
@@ -407,8 +432,9 @@ def _serve(args: argparse.Namespace, *, engine_only: bool = False) -> int:
     os.environ["IX_MCP_STORE"] = str(store_path)
     # Surface the dashboard URL to the kernel so `DASHBOARD_URL` is one lookup
     # away (the agent should not have to spelunk the runtime dir to find it). The
-    # human-facing dashboard is the Loro hub, not the read-only data API.
-    os.environ["IX_MCP_DASHBOARD_URL"] = cfg.hub_url()
+    # human-facing dashboard is the Loro hub when we auto-spawn one; otherwise
+    # there is no per-server hub, so point at this server's own data API.
+    os.environ["IX_MCP_DASHBOARD_URL"] = cfg.hub_url() if _auto_dashboard() else cfg.dashboard_url()
     os.environ["IPYTHONDIR"] = str(_prepare_ipython_startup(dashboard_port))
 
     # On macOS the process env inherits the empty Apple launchd SSH agent
@@ -500,22 +526,30 @@ async def _run(cfg: Config) -> None:
         await locked.wait()
 
     runner = await dashboard.start(cfg)
-    # The human-facing dashboard is the Loro hub: spawn it, and publish this
-    # server's runs/resources/namespace as panes to the shared discovery dir it
-    # (and every other producer) feeds. Both are best-effort -- a missing hub
-    # binary or an unbindable producer socket just means no UI; the data API
-    # keeps serving embedders either way.
-    hub = _spawn_hub(cfg)
+    # Always publish this server's runs/resources/namespace as panes into the
+    # shared discovery dir; a single standalone `dashboard` (run separately,
+    # `nix run .#dashboard`) renders every producer behind one stable URL.
     bridge_task = asyncio.ensure_future(pane_bridge.run(cfg.store_path))
-    # Advertise the hub UI only if it actually started; otherwise point at the
+    # Only auto-spawn a per-server hub when explicitly opted in (see
+    # `_auto_dashboard`): the default leaks an orphaned `dashboard` per abnormal
+    # exit and duplicates the machine-wide singleton. Best-effort either way -- a
+    # missing hub binary or an unbindable producer socket just means no UI here.
+    hub = _spawn_hub(cfg) if _auto_dashboard() else None
+    # Advertise the hub UI only if we actually started one; otherwise point at the
     # live data API rather than a dead hub port.
     url = cfg.hub_url() if hub is not None else cfg.dashboard_url()
     (runtime_dir() / "dashboard-url").write_text(url)
     # Bake the live URL into the MCP instructions before serving, so the client
     # gets it in the `initialize` response -- no tool call to discover it.
     tools.set_dashboard_url(url)
-    label = "dashboard (all running things + output)" if hub is not None else "data API (UI unavailable)"
-    print(f"[ix-mcp] {label}: {url}", file=sys.stderr, flush=True)
+    if hub is not None:
+        print(f"[ix-mcp] dashboard (all running things + output): {url}", file=sys.stderr, flush=True)
+    else:
+        print(
+            f"[ix-mcp] data API: {url}  (aggregated UI: run `nix run .#dashboard`)",
+            file=sys.stderr,
+            flush=True,
+        )
     if cfg.session_path is not None:
         print(f"[ix-mcp] session file: {cfg.session_path}", file=sys.stderr, flush=True)
 


### PR DESCRIPTION
## What

`ix-mcp serve` no longer spawns its own `dashboard` hub by default.

## Why

The `dashboard` aggregator is a **single machine-wide process**: exactly one binds the port, every producer publishes into the shared discovery dir (`pane_bridge`), and one hub renders them all behind one URL. `serve` spawned its own hub anyway, and cleaned it up only in a `finally` block — so any `serve` killed abnormally (SIGKILL/crash) orphaned its `dashboard` to init (ppid 1). A churning fleet of short-lived MCP servers (many Claude Code worktrees) piled up leaked `dashboard` processes.

Observed on a dev machine: **2816 leaked `dashboard` processes**, 2808 reparented to launchd, ~89 GB reclaimed on kill (machine had ~14 MB free).

```mermaid
flowchart LR
  A[ix-mcp serve] -->|spawns| H[dashboard hub]
  A -.->|SIGKILL / crash| X[finally skipped]
  X --> O[hub orphaned to init]
  O --> L[(thousands leak)]
```

## Change

- Gate the spawn behind `IX_MCP_AUTO_DASHBOARD` (default **off**).
- `serve` still publishes its panes via `pane_bridge`; run one standalone `nix run .#dashboard` to view every server at once.
- Set `IX_MCP_AUTO_DASHBOARD=1` to restore the old per-server auto-spawn.
- Update stale "auto-started dashboard" docs in `cli.py`, `__init__.py`, `README.md`.

## Verification

- `nix build .#mcp` green (includes zuban `--strict` typecheck).
- pre-commit lint green (ruff/astlog/nixfmt/…).
- `_auto_dashboard()` parse logic verified (default off; `1/true/yes/on` truthy).

🤖 sent by an AI agent via Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop auto-spawning a per-server dashboard hub in `ix-mcp serve` by default
> - `ix-mcp serve` no longer spawns a per-server dashboard hub on startup; it always publishes panes to the shared discovery directory and serves the data API.
> - A new `_auto_dashboard()` helper in [cli.py](https://github.com/indexable-inc/index/pull/1307/files#diff-7ce741e8223d63fdea11625cb78abad266299445db0213d2355bc93306df9ac5) checks `IX_MCP_AUTO_DASHBOARD` (truthy values: `1`, `true`, `yes`, `on`) to opt back in to the old per-server hub behavior.
> - When no hub is spawned, `IX_MCP_DASHBOARD_URL` in the kernel environment points to the local data API URL instead of the hub URL, and startup logs suggest running a standalone `nix run .#dashboard`.
> - Behavioral Change: the default behavior changes from spawning a hub per `serve` invocation to requiring a single shared dashboard process started separately.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60af2be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->