### PR TITLE
mcp: add iphone helper for USB iOS device control

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -800,6 +800,137 @@ let
     ];
   });
 
+  # pymobiledevice3 9.27.0, the modern pure-python iDevice client the `iphone`
+  # helper drives. nixpkgs pins 7.7.0, which predates iOS 17+ RemoteXPC tunnel
+  # support maturing and cannot drive a current iOS 26 device; 9.27.0 can. It is
+  # an override of the nixpkgs derivation (src bumped to the 9.27.0 sdist, plus
+  # the handful of deps 9.x added) rather than a uv project, because the closure
+  # has two sdist-only deps (hexdump, lzfse) that uv cannot build offline in the
+  # sandbox — nixpkgs already ships both prebuilt, so the override reuses them and
+  # every native dep nixpkgs has solved (qh3, cryptography, pillow, av, …). The
+  # delta over 7.7.0 is five deps (asn1, pyimg4, pyiosbackup, prompt-toolkit,
+  # defusedxml) plus av off Darwin, and a relaxed typer floor.
+  #
+  # asn1 is pinned to 2.8.0 across the whole mcp interpreter's package set. nixpkgs
+  # ships asn1 3.3.0, whose Encoder/Decoder API shift is what marks pyimg4 0.8.8
+  # `broken` there (its gate is `asn1 >= "3"`); 0.8.8 + asn1 2.x is the
+  # combination verified to mount the Developer Disk Image on-device. pyimg4 is
+  # pulled both directly and transitively (pymobiledevice3 -> ipsw-parser), so the
+  # downgrade must be set-wide, not per-package — a `packageOverrides` interpreter
+  # makes every consumer see the unbroken 2.8.0. Nothing else in the closure needs
+  # asn1 3.x.
+  mcpPythonInterp = pkgs.python3.override {
+    self = mcpPythonInterp;
+    packageOverrides = final: prev: {
+      asn1 = prev.asn1.overridePythonAttrs (_: {
+        version = "2.8.0";
+        src = pkgs.fetchPypi {
+          pname = "asn1";
+          version = "2.8.0";
+          hash = "sha256-rfd93CcHz0IMDq47me4w6ROvzwk2Rn1CZpggzmt9FQo=";
+        };
+      });
+      # pymobiledevice3 9.27.0 needs ipsw-parser >= 1.6.0; nixpkgs pins 1.5.0.
+      # Bump to 1.7.3 (the verified resolution). 1.7.x swaps its click dep for
+      # typer, so add it (and relax the floor, since the set's typer is 0.24.0).
+      ipsw-parser = prev.ipsw-parser.overridePythonAttrs (old: {
+        version = "1.7.3";
+        src = pkgs.fetchPypi {
+          pname = "ipsw_parser";
+          version = "1.7.3";
+          hash = "sha256-QSu7t3O0NLD5lL0EPNtX2QqxpK5y+oSJtxkAzYVtNuo=";
+        };
+        env = (old.env or { }) // {
+          SETUPTOOLS_SCM_PRETEND_VERSION = "1.7.3";
+        };
+        dependencies = (old.dependencies or [ ]) ++ [ final.typer ];
+        pythonRelaxDeps = (old.pythonRelaxDeps or [ ]) ++ [ "typer" ];
+      });
+    };
+  };
+
+  # pyiosbackup: read/decrypt iOS backups. Required by pymobiledevice3 9.27.0 and
+  # absent from nixpkgs (the packaged `iosbackup` is an unrelated project). Pure
+  # Python; all of its deps are already in the interpreter. Built from the
+  # asn1-pinned set so it shares one consistent closure.
+  pyiosbackupModule =
+    let
+      pname = "pyiosbackup";
+      version = "0.2.4";
+    in
+    mcpPythonInterp.pkgs.buildPythonPackage {
+      inherit pname version;
+      pyproject = true;
+      src = pkgs.fetchPypi {
+        inherit pname version;
+        hash = "sha256-ELTSoRyb7ck6VGfK063b4YvC3ENBVpIOciMibtTQvrc=";
+      };
+      build-system = [ mcpPythonInterp.pkgs.setuptools ];
+      dependencies = [
+        mcpPythonInterp.pkgs.bpylist2
+        mcpPythonInterp.pkgs.cryptography
+        mcpPythonInterp.pkgs.packaging
+        mcpPythonInterp.pkgs.construct
+        mcpPythonInterp.pkgs.click
+      ];
+      pythonImportsCheck = [ "pyiosbackup" ];
+      doCheck = false;
+    };
+
+  # The 9.27.0 override itself, built from the asn1-pinned set (so pyimg4 and
+  # ipsw-parser resolve to the unbroken 2.8.0). Keeps the nixpkgs 7.7.0 dependency
+  # set (native deps stay nixpkgs-built) and adds the new 9.x deps; typer is
+  # relaxed because nixpkgs pins 0.24.0 while 9.27.0 floors at 0.25 (the CLI runs
+  # on 0.24's surface, exercised by the import-smoke check). setuptools-scm reads
+  # the version from the sdist's PKG-INFO, pinned so the build never needs a .git.
+  # Upstream tests need a device, so checks are off.
+  pymobiledevice3_927 = mcpPythonInterp.pkgs.pymobiledevice3.overridePythonAttrs (old: {
+    version = "9.27.0";
+    src = pkgs.fetchPypi {
+      pname = "pymobiledevice3";
+      version = "9.27.0";
+      hash = "sha256-pYRzvX86tRUjYDuU7fBSD0VCTfE/sITJSId012+O7+8=";
+    };
+    env = (old.env or { }) // {
+      SETUPTOOLS_SCM_PRETEND_VERSION = "9.27.0";
+    };
+    dependencies =
+      (old.dependencies or [ ])
+      ++ [
+        mcpPythonInterp.pkgs.asn1
+        mcpPythonInterp.pkgs.pyimg4
+        pyiosbackupModule
+        mcpPythonInterp.pkgs.prompt-toolkit
+        mcpPythonInterp.pkgs.defusedxml
+      ]
+      ++ lib.optional (!pkgs.stdenv.hostPlatform.isDarwin) mcpPythonInterp.pkgs.av;
+    pythonRelaxDeps = [ "typer" ];
+    doCheck = false;
+  });
+
+  # The `iphone` helper source, bundled like `screen`/`vmkit`/`imessage` so every
+  # session can `import iphone`. Pure Python: it shells out to the bundled
+  # `pymobiledevice3` console script (resolved next to the interpreter at runtime)
+  # and returns device data as polars frames and screenshots as PIL images.
+  # Cross-platform (USB + a root `tunneld` are what it needs, not macOS), so it
+  # builds and import-checks on Linux CI too.
+  iphonePythonSource = builtins.path {
+    name = "ix-mcp-iphone-python-source";
+    path = ./src/iphone;
+  };
+  iphoneModule = pkgs.python3.pkgs.toPythonModule (
+    pkgs.runCommand "ix-mcp-iphone-python-module"
+      {
+        strictDeps = true;
+        meta.description = "USB iOS device control (pymobiledevice3) bundled into the ix-mcp interpreter";
+      }
+      ''
+        site="$out/${pkgs.python3.sitePackages}/iphone"
+        mkdir -p "$site"
+        cp -r ${iphonePythonSource}/iphone/. "$site/"
+      ''
+  );
+
   # The interpreter the wrapper pins. Sessions build their venv from this with
   # `--system-site-packages`, so `tui`, `search`, `fff`, `exa_py`, numpy, polars
   # (incl. Postgres via psycopg + SQLAlchemy), duckdb, httpx, htpy, and playwright
@@ -937,9 +1068,16 @@ let
       linearModule
       noxAutotriageModule
       mcpClientModule
+      # pymobiledevice3 9.27.0 (defined above) + the `iphone` wrapper that drives
+      # its CLI. The wrapper resolves the `pymobiledevice3` console script next to
+      # the interpreter, so both ride in the same env. Cross-platform: a USB
+      # iDevice + a root `tunneld` are what the developer commands need, not macOS,
+      # so CI builds the whole closure and import-checks it on Linux too.
+      pymobiledevice3_927
+      iphoneModule
     ]
     ++ darwinExtraPackages ps;
-  mcpPython = pkgs.python3.withPackages mcpPythonPackages;
+  mcpPython = mcpPythonInterp.withPackages mcpPythonPackages;
 
   # Browser bundle that matches the playwright-driver the python package is
   # patched to use. Exposed to the worker through PLAYWRIGHT_BROWSERS_PATH on the
@@ -4358,7 +4496,9 @@ let
   # runs headless on set_content fixtures in the sandbox with no display or
   # network. The interpreter is mcpPython (the bundled browser module +
   # playwright) plus pytest and hypothesis, which the bare mcpPython omits.
-  vdomTestPython = pkgs.python3.withPackages (
+  # Reuses the full mcp module set (which includes the asn1-pinned pymobiledevice3
+  # override), so it must build from the same asn1-pinned interpreter.
+  vdomTestPython = mcpPythonInterp.withPackages (
     ps:
     mcpPythonPackages ps
     ++ [
@@ -4465,6 +4605,41 @@ let
         cat stdout
         mkdir -p "$out"
       '';
+
+  # The `iphone` helper imports in the real interpreter and exposes its surface.
+  # Cross-platform: pulls in the vendored pymobiledevice3 CLI, so it also proves
+  # that uv closure builds on Linux CI.
+  iphoneBundled = importTest "iphone" "import iphone; print('iphone-ok', all(callable(getattr(iphone, n)) for n in ('devices', 'apps', 'screenshot', 'launch', 'start_tunneld', 'tap', 'swipe')))";
+
+  # Device-free behaviour tests (exports, async signatures, explicit type hints,
+  # CLI-path resolution, the sudo guard, the no-device error).
+  iphoneTestPython = pkgs.python3.withPackages (ps: [
+    ps.pytest
+    ps.polars
+    iphoneModule
+  ]);
+  iphoneTestSource = builtins.path {
+    name = "ix-mcp-iphone-test";
+    path = ./tests/test_iphone.py;
+  };
+  iphoneTests =
+    pkgs.runCommand "ix-mcp-iphone-tests"
+      {
+        nativeBuildInputs = [ iphoneTestPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        cp ${iphoneTestSource} "$TMPDIR/test_iphone.py"
+        ${lib.getExe iphoneTestPython} -m pytest "$TMPDIR/test_iphone.py" -q -p no:cacheprovider >stdout 2>stderr || {
+          echo "ix-mcp iphone tests failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        cat stdout
+        mkdir -p "$out"
+      '';
 in
 package.overrideAttrs (old: {
   passthru = (old.passthru or { }) // {
@@ -4512,6 +4687,8 @@ package.overrideAttrs (old: {
         linearTriageTests
         noxAutotriageBundled
         noxAutotriageTests
+        iphoneBundled
+        iphoneTests
         ;
     }
     // lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -125,6 +125,14 @@ MODULES: tuple[Module, ...] = (
         "(`imessage.messages()` / `chats()` / `send()`) (macOS only)",
     ),
     Module(
+        "iphone",
+        "drive a USB-connected iPhone/iPad via pymobiledevice3: list devices/apps into polars "
+        "(`iphone.devices()` / `apps()`), `screenshot()` a developer-mounted device to a PIL "
+        "image, `tap`/`swipe`/`launch`, and mount the Developer Disk Image. Developer commands "
+        "need a root `tunneld` daemon — start it explicitly with `iphone.start_tunneld(sudo=True)` "
+        "— plus a USB device with Developer Mode on",
+    ),
+    Module(
         "tasks",
         "generate and read the task-graph demo's SQLite DAG (`tasks.seed` / `load` / `frame`)",
     ),

--- a/packages/mcp/src/iphone/iphone/__init__.py
+++ b/packages/mcp/src/iphone/iphone/__init__.py
@@ -1,0 +1,452 @@
+"""Drive a USB-connected iPhone/iPad from the ix-mcp interpreter.
+
+Bundled like `screen`/`vmkit`/`imessage` so any session can `import iphone` with
+no install step. It is a thin async wrapper over the vendored ``pymobiledevice3``
+CLI (pinned 9.27.0 for iOS 26 support): device data comes back as polars frames
+and screenshots as PIL images, so returning them from a cell renders inline.
+
+    import iphone
+    await iphone.devices()                 # connected devices, one row each
+    await iphone.start_tunneld(sudo=True)   # root tunnel daemon (iOS 17+)
+    await iphone.ensure_developer_ready()   # mount the Developer Disk Image
+    img = await iphone.screenshot()         # -> PIL.Image, renders inline
+    await iphone.apps()                     # installed apps as polars
+    await iphone.launch("com.apple.Preferences")
+
+What needs what (iOS 17+):
+
+- ``devices`` / ``info`` / ``apps`` work over plain USB (lockdown), no tunnel.
+- The *developer* commands (``screenshot``, ``launch``, ``ensure_developer_ready``,
+  ``simulate_location``, the ``wda`` family) need a running root ``tunneld`` AND
+  the device in Developer Mode with the Developer Disk Image mounted. Start the
+  daemon explicitly with ``start_tunneld(sudo=True)`` — no other call ever runs
+  sudo. Enabling Developer Mode itself is a one-time on-device step (Settings >
+  Privacy & Security > Developer Mode, then reboot + confirm); it cannot be done
+  remotely, so ``ensure_developer_ready`` raises a clear error when it is off.
+- Coordinate input (``tap``/``swipe``/``type_text``/``press``/``unlock``) goes
+  through WebDriverAgent and needs WDA installed/launchable on the device; the
+  calls raise a clear error if it is not.
+
+A single device is assumed when ``udid`` is omitted; pass ``udid`` when more than
+one is attached (``devices()`` lists them). Targeting is done through the CLI's
+``PYMOBILEDEVICE3_UDID``/``PYMOBILEDEVICE3_TUNNEL`` env vars.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import polars as pl
+    from PIL import Image
+
+__all__ = [
+    "IphoneError",
+    "apps",
+    "clear_location",
+    "developer_mode_status",
+    "devices",
+    "ensure_developer_ready",
+    "info",
+    "kill",
+    "launch",
+    "press",
+    "screenshot",
+    "simulate_location",
+    "start_tunneld",
+    "stop_tunneld",
+    "swipe",
+    "tap",
+    "tunnels",
+    "type_text",
+    "unlock",
+    "wda_status",
+]
+
+_TUNNELD_HOST = "127.0.0.1"
+_TUNNELD_PORT = 49151
+
+# The detached root daemon start_tunneld owns, so stop_tunneld can end it.
+_tunneld_proc: asyncio.subprocess.Process | None = None
+
+
+class IphoneError(RuntimeError):
+    """A pymobiledevice3 invocation failed, or a precondition was not met."""
+
+
+def _pmd3_argv() -> list[str]:
+    """Resolve the pymobiledevice3 executable as an argv prefix.
+
+    Prefers the console script sitting next to the running interpreter (where the
+    bundled interpreter installs it), then ``$PATH``, then ``python -m
+    pymobiledevice3`` so the module is usable from a source tree too.
+    """
+    sibling = Path(sys.executable).parent / "pymobiledevice3"
+    if sibling.exists():
+        return [str(sibling)]
+    found = shutil.which("pymobiledevice3")
+    if found is not None:
+        return [found]
+    return [sys.executable, "-m", "pymobiledevice3"]
+
+
+def _env(udid: str | None) -> dict[str, str]:
+    """Subprocess environment targeting a specific device, if given."""
+    env = dict(os.environ)
+    if udid is not None:
+        # PYMOBILEDEVICE3_UDID targets lockdown commands; PYMOBILEDEVICE3_TUNNEL
+        # routes developer commands through tunneld for that device.
+        env["PYMOBILEDEVICE3_UDID"] = udid
+        env["PYMOBILEDEVICE3_TUNNEL"] = udid
+    return env
+
+
+async def _run(
+    args: list[str],
+    *,
+    udid: str | None = None,
+    timeout: float = 120.0,
+    sudo: bool = False,
+) -> str:
+    """Run a pymobiledevice3 subcommand, returning stdout (raising on failure)."""
+    argv = _pmd3_argv() + args
+    if sudo:
+        # -n: never prompt. Passwordless sudo must be configured; otherwise this
+        # fails fast rather than hanging on a TTY prompt.
+        argv = ["sudo", "-n", *argv]
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=_env(udid),
+    )
+    try:
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError as exc:
+        proc.kill()
+        raise IphoneError(f"`{' '.join(args)}` timed out after {timeout:.0f}s") from exc
+    if proc.returncode != 0:
+        detail = (err or b"").decode(errors="replace").strip()
+        raise IphoneError(f"`{' '.join(args)}` failed (exit {proc.returncode}): {detail}")
+    return (out or b"").decode(errors="replace")
+
+
+async def _run_json(
+    args: list[str],
+    *,
+    udid: str | None = None,
+    timeout: float = 120.0,
+) -> object:
+    """Run a subcommand whose stdout is JSON and parse it."""
+    raw = await _run(args, udid=udid, timeout=timeout)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise IphoneError(f"`{' '.join(args)}` did not return JSON: {raw[:200]}") from exc
+
+
+async def _one_device() -> str:
+    """The UDID of the sole connected device, or an error if not exactly one."""
+    frame = await devices()
+    raw = frame["UniqueDeviceID"].to_list() if "UniqueDeviceID" in frame.columns else []
+    # One physical device can appear twice (USB + Wi-Fi) with the same UDID, so
+    # dedupe before deciding whether targeting is ambiguous.
+    udids = list(dict.fromkeys(str(u) for u in raw))
+    if not udids:
+        raise IphoneError("no device connected (plug in an iPhone/iPad over USB and trust it)")
+    if len(udids) > 1:
+        raise IphoneError(f"{len(udids)} devices connected; pass udid= (see iphone.devices())")
+    return udids[0]
+
+
+async def _resolve(udid: str | None) -> str:
+    """Return the given UDID, or auto-select the single connected device."""
+    return udid if udid is not None else await _one_device()
+
+
+async def devices() -> pl.DataFrame:
+    """Connected devices over usbmux, one row each.
+
+    Columns are the raw lockdown keys: UniqueDeviceID, DeviceName, ProductType,
+    ProductVersion, ConnectionType, ...
+    """
+    import polars as pl
+
+    data = await _run_json(["usbmux", "list"], timeout=30)
+    rows = data if isinstance(data, list) else []
+    return pl.DataFrame(rows)
+
+
+async def info(udid: str | None = None) -> dict[str, object]:
+    """Full lockdown device-info dictionary for the (selected) device."""
+    target = await _resolve(udid)
+    data = await _run_json(["lockdown", "info"], udid=target, timeout=30)
+    return data if isinstance(data, dict) else {"value": data}
+
+
+async def apps(udid: str | None = None) -> pl.DataFrame:
+    """Installed apps as a polars frame (bundle_id, name, version, type)."""
+    import polars as pl
+
+    target = await _resolve(udid)
+    data = await _run_json(["apps", "list"], udid=target, timeout=120)
+    items = data.items() if isinstance(data, dict) else []
+    rows = [
+        {
+            "bundle_id": bundle_id,
+            "name": meta.get("CFBundleDisplayName") if isinstance(meta, dict) else None,
+            "version": meta.get("CFBundleShortVersionString") if isinstance(meta, dict) else None,
+            "type": meta.get("ApplicationType") if isinstance(meta, dict) else None,
+        }
+        for bundle_id, meta in items
+    ]
+    return pl.DataFrame(rows)
+
+
+async def screenshot(udid: str | None = None) -> Image.Image:
+    """Capture the device screen as a PIL image (renders inline from a cell).
+
+    Needs a running tunnel + a mounted Developer Disk Image (see
+    ``start_tunneld`` and ``ensure_developer_ready``).
+    """
+    from PIL import Image
+
+    target = await _resolve(udid)
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "screenshot.png"
+        await _run(["developer", "dvt", "screenshot", str(out)], udid=target, timeout=120)
+        if not out.exists():
+            raise IphoneError("screenshot produced no file (is the developer tunnel up?)")
+        with Image.open(out) as img:
+            return img.copy()
+
+
+async def launch(bundle_id: str, udid: str | None = None) -> int:
+    """Launch an app by bundle id; returns its new process id (-1 if unknown)."""
+    target = await _resolve(udid)
+    out = await _run(["developer", "dvt", "launch", bundle_id], udid=target, timeout=60)
+    match = re.search(r"pid\s+(\d+)", out)
+    return int(match.group(1)) if match else -1
+
+
+async def kill(pid: int, udid: str | None = None) -> None:
+    """Kill a process on the device by pid."""
+    target = await _resolve(udid)
+    await _run(["developer", "dvt", "kill", str(pid)], udid=target, timeout=30)
+
+
+async def developer_mode_status(udid: str | None = None) -> bool:
+    """Whether Developer Mode is enabled on the device."""
+    target = await _resolve(udid)
+    out = await _run(["amfi", "developer-mode-status"], udid=target, timeout=30)
+    return "true" in out.lower()
+
+
+async def ensure_developer_ready(udid: str | None = None) -> None:
+    """Mount the Developer Disk Image, after verifying Developer Mode is on.
+
+    Raises a clear, actionable error if Developer Mode is off — enabling it is a
+    one-time on-device step (reboot + physical confirm) that cannot be automated.
+    """
+    target = await _resolve(udid)
+    if not await developer_mode_status(target):
+        raise IphoneError(
+            "Developer Mode is off. Enable it on the device: Settings > Privacy & "
+            "Security > Developer Mode, toggle on, then reboot and confirm with your "
+            "passcode. Apple requires this be done physically; it cannot be done remotely."
+        )
+    await _run(["mounter", "auto-mount"], udid=target, timeout=180)
+
+
+def _read_text(path: str) -> str:
+    """Read a small text file (run off-thread from async callers)."""
+    return Path(path).read_text(errors="replace")
+
+
+def _unlink(path: str) -> None:
+    """Remove a file, ignoring a missing one (run off-thread from async callers)."""
+    Path(path).unlink(missing_ok=True)
+
+
+def _tunneld_url() -> str:
+    return f"http://{_TUNNELD_HOST}:{_TUNNELD_PORT}/"
+
+
+def _fetch_tunnels() -> dict[str, object]:
+    """Query the tunneld HTTP API; empty dict if it is not running."""
+    try:
+        with urllib.request.urlopen(_tunneld_url(), timeout=2) as resp:  # noqa: S310 -- fixed localhost URL
+            parsed = json.loads(resp.read())
+            return parsed if isinstance(parsed, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+async def _tunneld_up() -> bool:
+    try:
+        await asyncio.to_thread(
+            lambda: urllib.request.urlopen(_tunneld_url(), timeout=2).close()  # noqa: S310 -- fixed localhost URL
+        )
+    except OSError:
+        return False
+    return True
+
+
+async def tunnels() -> pl.DataFrame:
+    """Active tunnels reported by tunneld, one row per device tunnel."""
+    import polars as pl
+
+    data = await asyncio.to_thread(_fetch_tunnels)
+    rows: list[dict[str, object]] = [
+        {
+            "udid": udid,
+            "tunnel_address": entry.get("tunnel-address"),
+            "tunnel_port": entry.get("tunnel-port"),
+            "interface": entry.get("interface"),
+        }
+        for udid, entries in data.items()
+        for entry in (entries if isinstance(entries, list) else [])
+        if isinstance(entry, dict)
+    ]
+    return pl.DataFrame(rows)
+
+
+async def start_tunneld(*, sudo: bool = False) -> str:
+    """Start the persistent root ``tunneld`` daemon required by iOS 17+ services.
+
+    This launches ``sudo pymobiledevice3 remote tunneld`` as a detached root
+    process that outlives the cell. Because it runs as root, it must be opted into
+    explicitly: calling without ``sudo=True`` raises rather than escalating. No
+    other function in this module ever invokes sudo.
+    """
+    global _tunneld_proc
+
+    if not sudo:
+        raise IphoneError(
+            "start_tunneld launches a ROOT daemon (`sudo pymobiledevice3 remote "
+            "tunneld`). Re-run as iphone.start_tunneld(sudo=True) to allow it "
+            "(passwordless sudo must be configured)."
+        )
+    if await _tunneld_up():
+        return "tunneld already running"
+
+    # Send the daemon's stderr to a file rather than a pipe: a healthy tunneld
+    # logs continuously and would eventually block on a full, undrained pipe,
+    # while a file lets us recover the message if it dies early (e.g. `sudo -n`
+    # failing on a host without passwordless sudo).
+    err_log = tempfile.NamedTemporaryFile(  # noqa: SIM115 -- handed to the child; closed below
+        prefix="ix-tunneld-", suffix=".log", delete=False
+    )
+    argv = ["sudo", "-n", *_pmd3_argv(), "remote", "tunneld"]
+    _tunneld_proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=err_log,
+        start_new_session=True,
+    )
+    err_log.close()
+    try:
+        for _ in range(40):
+            await asyncio.sleep(0.5)
+            if _tunneld_proc.returncode is not None:
+                detail = (await asyncio.to_thread(_read_text, err_log.name)).strip()
+                raise IphoneError(
+                    f"tunneld exited ({_tunneld_proc.returncode}) before becoming ready: "
+                    f"{detail or 'no output (check passwordless sudo)'}"
+                )
+            if await _tunneld_up():
+                return f"tunneld started (pid {_tunneld_proc.pid})"
+        raise IphoneError("tunneld did not become ready within 20s")
+    finally:
+        # The daemon keeps its own open fd (POSIX), so removing the path now is
+        # safe and avoids leaking a log file per start.
+        await asyncio.to_thread(_unlink, err_log.name)
+
+
+async def stop_tunneld() -> None:
+    """Stop the tunneld daemon started by this module (no-op if not running)."""
+    global _tunneld_proc
+
+    if _tunneld_proc is None:
+        return
+    if _tunneld_proc.returncode is None:
+        _tunneld_proc.terminate()
+        try:
+            await asyncio.wait_for(_tunneld_proc.wait(), timeout=10)
+        except TimeoutError:
+            _tunneld_proc.kill()
+    _tunneld_proc = None
+
+
+async def simulate_location(latitude: float, longitude: float, udid: str | None = None) -> None:
+    """Override the device's GPS location (iOS 17+, via DVT)."""
+    target = await _resolve(udid)
+    await _run(
+        ["developer", "dvt", "simulate-location", "set", "--", str(latitude), str(longitude)],
+        udid=target,
+        timeout=30,
+    )
+
+
+async def clear_location(udid: str | None = None) -> None:
+    """Stop simulating GPS and restore the device's real location."""
+    target = await _resolve(udid)
+    await _run(["developer", "dvt", "simulate-location", "clear"], udid=target, timeout=30)
+
+
+async def wda_status(udid: str | None = None) -> dict[str, object]:
+    """WebDriverAgent status (requires WDA installed/launchable on the device)."""
+    target = await _resolve(udid)
+    data = await _run_json(["developer", "wda", "status"], udid=target, timeout=60)
+    return data if isinstance(data, dict) else {"value": data}
+
+
+async def tap(selector: str, udid: str | None = None) -> None:
+    """Tap an element via WebDriverAgent (e.g. its visible label)."""
+    target = await _resolve(udid)
+    # `--` so a selector starting with `-` is not parsed as a CLI option.
+    await _run(["developer", "wda", "tap", "--", selector], udid=target, timeout=60)
+
+
+async def swipe(
+    start_x: int,
+    start_y: int,
+    end_x: int,
+    end_y: int,
+    udid: str | None = None,
+) -> None:
+    """Swipe between two screen coordinates via WebDriverAgent."""
+    target = await _resolve(udid)
+    await _run(
+        ["developer", "wda", "swipe", "--", str(start_x), str(start_y), str(end_x), str(end_y)],
+        udid=target,
+        timeout=60,
+    )
+
+
+async def type_text(text: str, udid: str | None = None) -> None:
+    """Type text into the focused element via WebDriverAgent."""
+    target = await _resolve(udid)
+    # `--` so text starting with `-` is not parsed as a CLI option.
+    await _run(["developer", "wda", "type", "--", text], udid=target, timeout=60)
+
+
+async def press(button: str, udid: str | None = None) -> None:
+    """Press a hardware button via WebDriverAgent (home/lock/volumeup/volumedown)."""
+    target = await _resolve(udid)
+    await _run(["developer", "wda", "press", "--", button], udid=target, timeout=60)
+
+
+async def unlock(udid: str | None = None) -> None:
+    """Unlock the device via WebDriverAgent."""
+    target = await _resolve(udid)
+    await _run(["developer", "wda", "unlock"], udid=target, timeout=60)

--- a/packages/mcp/tests/test_iphone.py
+++ b/packages/mcp/tests/test_iphone.py
@@ -1,0 +1,82 @@
+"""Device-free tests for the `iphone` helper.
+
+These never touch a real device: they check the module's shape (exports, async
+signatures, explicit type hints), that the CLI path resolver always yields a
+usable argv, that `start_tunneld` refuses to escalate without an explicit opt-in,
+and that a missing device produces a clear error.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+
+# Prefer the bundled module (nix check); fall back to the source tree (dev run).
+IPHONE_SRC = Path(__file__).resolve().parents[1] / "src" / "iphone"
+if IPHONE_SRC.is_dir() and str(IPHONE_SRC) not in sys.path:
+    sys.path.insert(0, str(IPHONE_SRC))
+
+import iphone
+
+# Public callables = everything exported except the error class.
+_PUBLIC_FUNCS = [
+    getattr(iphone, name)
+    for name in iphone.__all__
+    if name != "IphoneError"
+]
+
+
+def test_all_names_exist() -> None:
+    for name in iphone.__all__:
+        assert hasattr(iphone, name), f"{name} in __all__ but missing from module"
+
+
+def test_error_type() -> None:
+    assert issubclass(iphone.IphoneError, RuntimeError)
+
+
+def test_public_funcs_are_async() -> None:
+    for func in _PUBLIC_FUNCS:
+        assert inspect.iscoroutinefunction(func), f"{func.__name__} should be async"
+
+
+def test_type_hints_explicit() -> None:
+    # Mirrors the ruff ANN gate: every public function fully annotates its params
+    # and return type.
+    for func in _PUBLIC_FUNCS:
+        sig = inspect.signature(func)
+        assert sig.return_annotation is not inspect.Signature.empty, (
+            f"{func.__name__} missing return annotation"
+        )
+        for param in sig.parameters.values():
+            assert param.annotation is not inspect.Parameter.empty, (
+                f"{func.__name__}({param.name}) missing annotation"
+            )
+
+
+def test_pmd3_argv_resolves() -> None:
+    argv = iphone._pmd3_argv()
+    assert isinstance(argv, list)
+    assert argv, "argv must be a non-empty list"
+    # Either the located executable, or the `python -m pymobiledevice3` fallback.
+    assert argv[-1] == "pymobiledevice3" or argv[0].endswith("pymobiledevice3"), argv
+
+
+def test_start_tunneld_requires_sudo() -> None:
+    # Without sudo=True it must raise before spawning anything.
+    with pytest.raises(iphone.IphoneError, match="sudo"):
+        asyncio.run(iphone.start_tunneld())
+
+
+def test_no_device_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    import polars as pl
+
+    async def _empty() -> pl.DataFrame:
+        return pl.DataFrame({"UniqueDeviceID": []})
+
+    monkeypatch.setattr(iphone, "devices", _empty)
+    with pytest.raises(iphone.IphoneError, match="no device connected"):
+        asyncio.run(iphone._one_device())


### PR DESCRIPTION
## What

Adds an `iphone` kernel helper (bundled like `screen`/`vmkit`/`imessage`) so any
session can drive a USB-connected iPhone/iPad with no setup, backed by a
Nix-packaged **pymobiledevice3 9.27.0** (the version that actually drives iOS 26).

Surface (`import iphone`, all async, returns polars / PIL):
- `devices()` / `info()` / `apps()` — device + app inventory to polars
- `screenshot()` — developer-mounted capture as a PIL image (renders inline)
- `launch()` / `kill()` / `simulate_location()` / `clear_location()`
- `start_tunneld(sudo=True)` / `stop_tunneld()` / `tunnels()` — the iOS 17+ root tunnel daemon (explicit sudo opt-in; nothing else escalates)
- `developer_mode_status()` / `ensure_developer_ready()` — mount the Developer Disk Image
- `tap()` / `swipe()` / `type_text()` / `press()` / `unlock()` — UI control via WebDriverAgent

## Why the packaging is non-trivial

nixpkgs pins pymobiledevice3 **7.7.0** — too old for iOS 26, and its `pyimg4` dep
is marked broken. A uv.lock approach was tried first but uv can't build the two
sdist-only deps (`hexdump`, `lzfse`) offline in the sandbox, which nixpkgs already
ships prebuilt. So instead:

- override pymobiledevice3 to **9.27.0** from the PyPI sdist;
- a scoped interpreter pins **asn1 2.8.0** (set-wide, since `ipsw-parser` also
  pulls `pyimg4`), which unbreaks `pyimg4 0.8.8` — the exact combo verified to
  mount the DDI on-device;
- bump **ipsw-parser → 1.7.3** (9.27.0's floor);
- add **pyiosbackup 0.2.4** (absent from nixpkgs);
- relax the typer floor.

Cross-platform, so CI builds and import-checks the whole closure on Linux.

## Verification

- `nix build .#mcp .#mcp.tests.iphoneBundled .#mcp.tests.iphoneTests` — green; device-free tests 7 passed; import smoke `iphone-ok`.
- End-to-end on a real **iPhone 16 (iOS 26.5.1)**: `devices()`, `start_tunneld(sudo=True)`, `ensure_developer_ready()`, `screenshot()` (1206×2622).
- Adversarial review pass applied: tunneld now surfaces the real failure on early exit; WDA args use `--` end-of-options; `_one_device()` dedupes a phone seen over USB+Wi-Fi.

🤖 Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add iphone helper module for USB iOS device control via pymobiledevice3
> - Adds a new `iphone` Python module ([`__init__.py`](https://github.com/indexable-inc/index/pull/1311/files#diff-f92c2ac3b6f1cee30bc3c534269f16357522a2d23c4c9e1e984a8f32030227b7)) with async functions for device info, app enumeration, screenshots, app launch/kill, GPS simulation, and WDA-backed UI control (tap, swipe, type, press, unlock).
> - Adds `tunneld` management helpers to start/stop the root `pymobiledevice3 remote tunneld` daemon and an `ensure_developer_ready` gate that checks Developer Mode and mounts the DDI.
> - Pins `pymobiledevice3` to 9.27.0 and `asn1` to 2.8.0 in the Nix build, adds `pyiosbackup`, `pyimg4`, `prompt-toolkit`, and `defusedxml` as new dependencies.
> - Registers the `iphone` module in the MCP registry ([`registry.py`](https://github.com/indexable-inc/index/pull/1311/files#diff-92f567578e1217b8207dbbd21af1cdee4978728a8ca9e774cd65ed17170d2ae5)) and adds import + pytest tests to `passthru.tests`.
> - Risk: `start_tunneld` requires passwordless `sudo`; a connected USB device with Developer Mode enabled is needed at runtime for most functions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2b7329.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->