### PR TITLE
darwin(andrewgazelka): add spotify cask

### DIFF
--- a/users/andrewgazelka/darwin.nix
+++ b/users/andrewgazelka/darwin.nix
@@ -48,6 +48,7 @@
       "signal@beta"
       "skim"
       "slack@beta"
+      "spotify"
       "stremio@beta"
       "superhuman"
       "superwhisper"


### PR DESCRIPTION
Add `spotify` Homebrew cask to my personal nix-darwin module so it installs declaratively (imperative `brew install` gets zapped by `--zap` on activation).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Spotify cask to andrewgazelka's Darwin configuration
> Adds Spotify to the list of managed applications in [darwin.nix](https://github.com/indexable-inc/index/pull/1314/files#diff-8e50939d75ca47b003564ea6eb7afcd3cd3ab9bfa6b8876d3c079c94862fb7bc).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc1dd6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->