### PR TITLE
slack(mcp): support in-thread replies in send

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -4640,6 +4640,38 @@ let
         cat stdout
         mkdir -p "$out"
       '';
+
+  # Network-free unit tests for the `slack` helper: module shape plus that
+  # `send` builds the right chat.postMessage params for top-level vs. in-thread
+  # replies (stubbing the one network primitive).
+  slackTestPython = pkgs.python3.withPackages (ps: [
+    ps.pytest
+    ps.polars
+    ps.pydantic
+    slackModule
+  ]);
+  slackTestSource = builtins.path {
+    name = "ix-mcp-slack-test";
+    path = ./tests/test_slack.py;
+  };
+  slackTests =
+    pkgs.runCommand "ix-mcp-slack-tests"
+      {
+        nativeBuildInputs = [ slackTestPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        cp ${slackTestSource} "$TMPDIR/test_slack.py"
+        ${lib.getExe slackTestPython} -m pytest "$TMPDIR/test_slack.py" -q -p no:cacheprovider >stdout 2>stderr || {
+          echo "ix-mcp slack tests failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        cat stdout
+        mkdir -p "$out"
+      '';
 in
 package.overrideAttrs (old: {
   passthru = (old.passthru or { }) // {
@@ -4657,6 +4689,7 @@ package.overrideAttrs (old: {
         googleAuthBundled
         ixGoogleBundled
         slackBundled
+        slackTests
         beeperBundled
         requirementsSmoke
         engineBundled

--- a/packages/mcp/src/slack/slack/__init__.py
+++ b/packages/mcp/src/slack/slack/__init__.py
@@ -18,6 +18,7 @@ No token is baked into the repo.
     await slack.messages("@hari")     # recent messages in your DM with @hari
     await slack.thread("general", "1234567890.123456")  # a single thread
     await slack.send("general", "hello from ix")        # post a message
+    await slack.send("general", "in-thread reply", thread_ts="1234567890.123456")
     await slack.search("deploy staging")                # search across Slack
 
 Each call returns a polars DataFrame with a fixed schema so empty results stay
@@ -62,7 +63,7 @@ __all__ = [
     "thread",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 # The env var a shared (multiplayer) room sets on the one MCP it replicates
 # across participants. Incognito is the default: an unset (or empty) value means
@@ -681,20 +682,50 @@ async def thread(
     )
 
 
-async def send(channel: str, text: str) -> dict[str, Any]:
+async def send(
+    channel: str,
+    text: str,
+    *,
+    thread_ts: str | None = None,
+    reply_broadcast: bool = False,
+) -> dict[str, Any]:
     """Post ``text`` to ``channel`` and return Slack's response metadata.
 
     ``channel`` is resolved like :func:`messages` (channel, ``@user``, or id).
-    Returns ``{"ok": True, "ts": "<timestamp>", "channel": "<id>"}`` on success.
-    Needs ``chat:write``. Raises :exc:`SlackError` on failure or in a shared
-    room.
+
+    Pass ``thread_ts`` -- the Slack timestamp of a parent message (the ``ts``
+    from :func:`messages` or :func:`thread`, e.g. ``"1234567890.123456"``) -- to
+    reply *inside* that thread instead of posting a new top-level message. Set
+    ``reply_broadcast=True`` to also surface a threaded reply to the whole
+    channel; it is only valid with ``thread_ts`` and raises otherwise.
+
+    Returns ``{"ok": True, "ts": "<timestamp>", "channel": "<id>",
+    "thread_ts": "<parent ts, or "">"}`` on success (``thread_ts`` is non-empty
+    for a threaded reply). Needs ``chat:write``. Raises :exc:`SlackError` on
+    failure or in a shared room.
     """
     _require_incognito()
+    if reply_broadcast and not thread_ts:
+        raise SlackError("reply_broadcast=True is only valid together with thread_ts")
     token = _token()
     channel_id = _resolve_channel(channel, token)
 
-    data = _api_call("chat.postMessage", token, {"channel": channel_id, "text": text})
-    return {"ok": True, "ts": data.get("ts", ""), "channel": data.get("channel", "")}
+    params: dict[str, Any] = {"channel": channel_id, "text": text}
+    if thread_ts:
+        params["thread_ts"] = thread_ts
+        if reply_broadcast:
+            params["reply_broadcast"] = "true"
+
+    data = _api_call("chat.postMessage", token, params)
+    # chat.postMessage echoes the stored message; a threaded reply carries its
+    # parent's `thread_ts`, so surface it (empty for a top-level post).
+    posted: dict[str, Any] = data.get("message") or {}
+    return {
+        "ok": True,
+        "ts": data.get("ts", ""),
+        "channel": data.get("channel", ""),
+        "thread_ts": posted.get("thread_ts", "") or "",
+    }
 
 
 async def search(

--- a/packages/mcp/tests/test_slack.py
+++ b/packages/mcp/tests/test_slack.py
@@ -1,0 +1,104 @@
+"""Network-free tests for the `slack` helper.
+
+These never reach Slack: they check the module's shape (exports, explicit type
+hints) and that `send` builds the right `chat.postMessage` params for top-level
+posts vs. in-thread replies, by stubbing the one network primitive
+(`_api_call`) and a token.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Prefer the bundled module (nix check); fall back to the source tree (dev run).
+SLACK_SRC = Path(__file__).resolve().parents[1] / "src" / "slack"
+if SLACK_SRC.is_dir() and str(SLACK_SRC) not in sys.path:
+    sys.path.insert(0, str(SLACK_SRC))
+
+import slack
+
+# Public callables = everything exported except the error class.
+_PUBLIC_FUNCS = [getattr(slack, name) for name in slack.__all__ if name != "SlackError"]
+
+# A channel id resolves without any API call (no _resolve_channel network hop).
+_CHANNEL_ID = "C0123456789"
+_PARENT_TS = "1781738574.768059"
+
+
+def test_all_names_exist() -> None:
+    for name in slack.__all__:
+        assert hasattr(slack, name), f"{name} in __all__ but missing from module"
+
+
+def test_error_type() -> None:
+    assert issubclass(slack.SlackError, RuntimeError)
+
+
+def test_type_hints_explicit() -> None:
+    # Mirrors the ruff ANN gate: every public function fully annotates its params
+    # and return type.
+    for func in _PUBLIC_FUNCS:
+        sig = inspect.signature(func)
+        assert sig.return_annotation is not inspect.Signature.empty, (
+            f"{func.__name__} missing return annotation"
+        )
+        for pname, param in sig.parameters.items():
+            assert param.annotation is not inspect.Parameter.empty, (
+                f"{func.__name__}({pname}) missing annotation"
+            )
+
+
+@pytest.fixture
+def stub_slack(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, dict[str, Any]]]:
+    """Stub the token + the one network primitive; capture (method, params)."""
+    monkeypatch.setenv("SLACK_USER_TOKEN", "xoxp-test")
+    monkeypatch.delenv(slack.SHARED_ENV, raising=False)
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_api(method: str, token: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        calls.append((method, params or {}))
+        # Echo a threaded reply when thread_ts was sent, like Slack does.
+        message = {"thread_ts": (params or {}).get("thread_ts", "")}
+        return {"ok": True, "ts": "1781738999.000100", "channel": _CHANNEL_ID, "message": message}
+
+    monkeypatch.setattr(slack, "_api_call", fake_api)
+    return calls
+
+
+def test_send_top_level_omits_thread_ts(stub_slack: list[tuple[str, dict[str, Any]]]) -> None:
+    out = asyncio.run(slack.send(_CHANNEL_ID, "hello"))
+    method, params = stub_slack[-1]
+    assert method == "chat.postMessage"
+    assert "thread_ts" not in params
+    assert out["thread_ts"] == ""
+    assert out["ok"] is True
+
+
+def test_send_in_thread_passes_thread_ts(stub_slack: list[tuple[str, dict[str, Any]]]) -> None:
+    out = asyncio.run(slack.send(_CHANNEL_ID, "reply", thread_ts=_PARENT_TS))
+    _, params = stub_slack[-1]
+    assert params["thread_ts"] == _PARENT_TS
+    assert "reply_broadcast" not in params
+    assert out["thread_ts"] == _PARENT_TS
+
+
+def test_send_reply_broadcast_sets_flag(stub_slack: list[tuple[str, dict[str, Any]]]) -> None:
+    asyncio.run(slack.send(_CHANNEL_ID, "loud reply", thread_ts=_PARENT_TS, reply_broadcast=True))
+    _, params = stub_slack[-1]
+    assert params["thread_ts"] == _PARENT_TS
+    assert params["reply_broadcast"] == "true"
+
+
+def test_send_reply_broadcast_without_thread_ts_raises(
+    stub_slack: list[tuple[str, dict[str, Any]]],
+) -> None:
+    with pytest.raises(slack.SlackError, match="reply_broadcast"):
+        asyncio.run(slack.send(_CHANNEL_ID, "oops", reply_broadcast=True))
+    # No network call should have been made before the guard fired.
+    assert stub_slack == []


### PR DESCRIPTION
Adds in-thread reply support to the slack MCP helper.

- slack.send(channel, text, *, thread_ts=None, reply_broadcast=False): pass thread_ts (the ts from messages/thread) to reply inside a thread instead of a new top-level message. reply_broadcast=True also surfaces the reply to the channel; only valid with thread_ts (raises otherwise).
- Return value gains thread_ts (echoed parent ts, empty for top-level posts).
- New tests/test_slack.py (+ slackTests nix derivation): network-free, stubs _api_call to assert param-building for top-level vs threaded vs broadcast, plus the guard. 7 pass under nix build .#...mcp.tests.slackTests.

Motivation: the helper could only post top-level messages, so replying inside an existing Slack thread was impossible via the MCP.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add thread reply support to `slack.send` with `thread_ts` and `reply_broadcast` parameters
> - Extends `send` in [__init__.py](https://github.com/indexable-inc/index/pull/1315/files#diff-9bc1f36f1d0804b7fbccbd9004d9c261d8373000eac3b44d1f41bb877a1216e9) to accept `thread_ts` and `reply_broadcast` keyword arguments, enabling replies within existing Slack threads.
> - Raises `SlackError` if `reply_broadcast=True` is passed without `thread_ts`.
> - The returned dict now includes a `thread_ts` field (empty string for top-level posts, parent thread's `ts` for replies).
> - Adds a network-free pytest suite in [test_slack.py](https://github.com/indexable-inc/index/pull/1315/files#diff-6afb14b6b874622cfc097a1efe504e3202ca3e134ef2084ced8dfaf1067861b9) covering parameter construction, threading behavior, and public API contracts, wired into `nix build` via [default.nix](https://github.com/indexable-inc/index/pull/1315/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db).
> - Bumps version from `0.2.0` to `0.3.0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c3243e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->