### PR TITLE
maps: native macOS places & location module (MapKit + CoreLocation)

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -724,6 +724,51 @@ let
     };
   });
 
+  # `import MapKit` on Darwin: the pyobjc binding for Apple's MapKit framework,
+  # so a session can run `MKLocalSearch` place searches with no install step.
+  # Derived from `pyobjc-framework-Quartz` the same way `coreLocationModule` is
+  # (it is a sibling subdir in the same pyobjc source tree); MapKit's bindings
+  # depend on both CoreLocation and Quartz, so those modules join its inputs:
+  # the upstream wheel's METADATA requires `pyobjc-framework-quartz`, and
+  # `pythonRuntimeDepsCheck` fails the build if it is not a propagated input
+  # (the override renames the Quartz package to MapKit, so Quartz must be added
+  # back explicitly rather than inherited).
+  mapKitModule = pkgs.python3.pkgs.pyobjc-framework-Quartz.overridePythonAttrs (old: {
+    pname = "pyobjc-framework-MapKit";
+    sourceRoot = "${old.src.name}/pyobjc-framework-MapKit";
+    pythonImportsCheck = [ "MapKit" ];
+    propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [
+      coreLocationModule
+      pkgs.python3.pkgs.pyobjc-framework-Quartz
+    ];
+    meta = old.meta // {
+      description = "PyObjC wrappers for the MapKit framework on macOS";
+    };
+  });
+
+  # Native macOS places & geocoding: places near a point (MapKit `MKLocalSearch`)
+  # and geocoding both ways (CoreLocation `CLGeocoder`), all returned as polars
+  # frames. Pure Python over the bundled pyobjc CoreLocation/MapKit; its async
+  # bridge drains the main run loop cooperatively so the frameworks' main-thread
+  # completion handlers fire without wedging the kernel's event loop. macOS-only
+  # (the module raises off Darwin).
+  mapsPythonSource = builtins.path {
+    name = "ix-mcp-maps-python-source";
+    path = ./src/maps;
+  };
+  mapsModule = pkgs.python3.pkgs.toPythonModule (
+    pkgs.runCommand "ix-mcp-maps-python-module"
+      {
+        strictDeps = true;
+        meta.description = "Native macOS maps/location (MapKit + CoreLocation) bundled into the ix-mcp interpreter";
+      }
+      ''
+        site="$out/${pkgs.python3.sitePackages}/maps"
+        mkdir -p "$site"
+        cp -r ${mapsPythonSource}/maps/. "$site/"
+      ''
+  );
+
   # The `screen` helper is macOS-only, so its dependencies join the interpreter
   # only on Darwin. `pyobjc-framework-Quartz` is the maintained CoreGraphics
   # binding the helper wraps; Pillow (already transitive via matplotlib) carries
@@ -736,6 +781,8 @@ let
       ps.pyobjc-framework-Quartz
       coreLocationModule
       scriptingBridgeModule
+      mapKitModule
+      mapsModule
       screenModule
       vmkitModule
       imessageModule
@@ -3476,6 +3523,65 @@ let
         mkdir -p "$out"
       '';
 
+  # The maps module: pure-helper checks that need no network or location
+  # permission (the nix sandbox has neither). Exercises the radius->region span
+  # math (incl. the latitude cosine correction) and the polars schema shapes, and
+  # confirms the public coroutines and MapKit binding are present.
+  mapsTestPy = pkgs.writeText "ix-mcp-maps-test.py" ''
+    import inspect
+    import math
+
+    import polars as pl
+
+    import maps
+    import MapKit
+
+    # Public coroutine surface is callable and async.
+    for name in ("nearby", "geocode", "reverse_geocode"):
+        fn = getattr(maps, name)
+        assert inspect.iscoroutinefunction(fn), name
+
+    # MapKit binding loads (the place-search class is present).
+    assert callable(MapKit.MKLocalSearch.alloc), "MKLocalSearch missing"
+
+    # region(): span is the full width/height, so twice the radius in degrees;
+    # latitude degrees are constant, longitude degrees shrink with cos(latitude).
+    (clat, clng), (lat_delta, lng_delta) = maps._region(0.0, 0.0, 1000.0)
+    assert (clat, clng) == (0.0, 0.0)
+    assert math.isclose(lat_delta, 2000.0 / 111320.0, rel_tol=1e-9), lat_delta
+    assert math.isclose(lng_delta, lat_delta, rel_tol=1e-9), (lat_delta, lng_delta)
+    # At 60 deg latitude cos=0.5, so longitude span is ~2x the latitude span.
+    (_c2, (lat60, lng60)) = maps._region(60.0, 0.0, 1000.0)
+    assert math.isclose(lng60 / lat60, 2.0, rel_tol=1e-6), (lat60, lng60)
+
+    # Schemas: nearby is the placemark schema plus the POI columns.
+    placemark = set(maps._placemark_schema(pl))
+    nearby = set(maps._nearby_schema(pl))
+    assert {"name", "latitude", "longitude", "country"} <= placemark, placemark
+    assert nearby - placemark == {"category", "phone"}, nearby - placemark
+
+    print("maps-ok")
+  '';
+  mapsSmoke =
+    pkgs.runCommand "ix-mcp-maps-smoke"
+      {
+        nativeBuildInputs = [ mcpPython ];
+        strictDeps = true;
+      }
+      ''
+        ${lib.getExe mcpPython} ${mapsTestPy} >stdout 2>stderr || {
+          echo "ix-mcp maps smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -qx 'maps-ok' stdout || {
+          echo "ix-mcp maps smoke did not confirm the maps module:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
+
   # The view module: tabular helpers return plain polars DataFrames (so they stay
   # composable), the file helpers return a Code view whose repr is the raw text,
   # and df_html renders the styled table the kernel installs globally. Pure local
@@ -4555,6 +4661,7 @@ let
   screenBundled = importTest "screen" "import screen; print('screen-ok', all(callable(getattr(screen, n)) for n in ('capture', 'click', 'write', 'press', 'key_down', 'key_up', 'apps', 'frontmost', 'launch', 'activate', 'terminate', 'accessibility_trusted')))";
   coreLocationBundled = importTest "corelocation" "import CoreLocation; print('corelocation-ok', callable(CoreLocation.CLLocationManager.alloc))";
   scriptingBridgeBundled = importTest "scriptingbridge" "import ScriptingBridge; print('scriptingbridge-ok', callable(ScriptingBridge.SBApplication.applicationWithBundleIdentifier_))";
+  mapsBundled = importTest "maps" "import maps, MapKit; print('maps-ok', all(callable(getattr(maps, n)) for n in ('nearby', 'geocode', 'reverse_geocode')), callable(MapKit.MKLocalSearch.alloc))";
   vmkitBundled = importTest "vmkit" "import vmkit; print('vmkit-ok', callable(vmkit.boot_linux), callable(vmkit.drive), callable(vmkit.screenshot))";
   imessageBundled = importTest "imessage" "import imessage; print('imessage-ok', all(callable(getattr(imessage, n)) for n in ('messages', 'chats', 'contacts', 'send')))";
   xBundled = importTest "x" "import x; print('x-ok', callable(x.posts), x.__version__)";
@@ -4747,6 +4854,8 @@ package.overrideAttrs (old: {
         screenBundled
         coreLocationBundled
         scriptingBridgeBundled
+        mapsBundled
+        mapsSmoke
         vmkitBundled
         vmkitResourceSmoke
         imessageBundled

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -125,6 +125,14 @@ MODULES: tuple[Module, ...] = (
         "(`imessage.messages()` / `chats()` / `send()`) (macOS only)",
     ),
     Module(
+        "maps",
+        "native macOS places & geocoding, each an async call returning a polars frame: "
+        "`await maps.nearby(query, lat, lng)` searches places near a point (MapKit), and "
+        "`await maps.geocode(address)` / `await maps.reverse_geocode(lat, lng)` convert "
+        "address <-> coordinates (CoreLocation). No API key or cost — Apple's on-device "
+        "stack (macOS only)",
+    ),
+    Module(
         "iphone",
         "drive a USB-connected iPhone/iPad via pymobiledevice3: list devices/apps into polars "
         "(`iphone.devices()` / `apps()`), `screenshot()` a developer-mounted device to a PIL "

--- a/packages/mcp/src/maps/maps/__init__.py
+++ b/packages/mcp/src/maps/maps/__init__.py
@@ -1,0 +1,356 @@
+"""Native macOS maps and location for the ix-mcp interpreter.
+
+Bundled like ``screen``/``imessage`` so every session can ``import maps`` on
+Darwin with no install step. Where ``screen`` drives the desktop and ``imessage``
+reads Messages, ``maps`` reaches Apple's location stack: it searches for places
+near a point (MapKit ``MKLocalSearch``) and turns an address into coordinates and
+back (CoreLocation ``CLGeocoder``). Results come back as polars frames, so
+returning one from a cell renders inline.
+
+    import maps
+    await maps.nearby("coffee", 37.3349, -122.009)   # places near a point
+    await maps.geocode("Apple Park, Cupertino, CA")    # address -> lat/lng
+    await maps.reverse_geocode(37.3349, -122.009)      # lat/lng -> address
+
+(There is no current-location helper: CoreLocation only authorizes a signed .app
+bundle, and ix-mcp runs as a bare daemon, so a ``CLLocationManager`` fix can
+never be granted here. Geocode a known address instead.)
+
+Why a run-loop bridge (the non-obvious part)
+--------------------------------------------
+Each of these APIs is asynchronous and delivers its result through a completion
+handler on the **main thread / main dispatch queue**. The kernel's single asyncio
+event loop owns the main thread but services it as an asyncio loop, not as a
+CoreFoundation ``CFRunLoop`` -- so a naive call's handler never fires and the
+await hangs. ``_await_handler`` bridges the two: it kicks off the Cocoa call, then
+cooperatively drains the main run loop in short, bounded slices between ``await``s
+until the handler lands, marshalling the result back to the coroutine. Each slice
+is a couple milliseconds, so a co-running coroutine on the shared kernel sees only
+a small scheduling hitch, never the indefinite block a plain ``CFRunLoopRun()``
+would cause.
+
+This bridge is deliberately general -- it knows nothing about maps -- so a future
+CoreLocation/EventKit/Contacts helper can reuse it. The moment a second consumer
+lands it should be promoted to a shared module; until then it lives here.
+
+No API key, no account, no cost: this is the on-device Apple stack, not a REST
+service; the calls need only network access.
+
+macOS-only: importing on a non-Darwin platform raises ``RuntimeError``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import sys
+import time
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import polars as pl
+
+__all__ = [
+    "MapsError",
+    "geocode",
+    "nearby",
+    "reverse_geocode",
+]
+
+if sys.platform != "darwin":
+    raise RuntimeError(
+        "maps: Apple's location stack is macOS-only "
+        f"(running on {sys.platform!r}). For places elsewhere use a REST API "
+        "(OpenStreetMap Overpass, Apple Maps Server API) over httpx."
+    )
+
+
+class MapsError(RuntimeError):
+    """A maps/location call failed (Cocoa error, timeout, or denied permission)."""
+
+
+# pyobjc bindings. ``objc`` and ``Foundation`` come from pyobjc-core (always
+# present on Darwin in this interpreter); ``CoreLocation`` is bundled explicitly
+# (see the mcp package). MapKit has no nixpkgs binding, so its classes are loaded
+# from the system framework at import time. Name the dependency on failure so a
+# stripped environment is diagnosable rather than mysterious.
+try:
+    import objc
+    from Foundation import NSDate, NSRunLoop
+    import CoreLocation
+except ImportError as exc:  # pragma: no cover - environment wiring
+    raise RuntimeError(
+        "maps: pyobjc `objc`/`Foundation`/`CoreLocation` are required but not "
+        "importable; the ix-mcp interpreter bundles them on Darwin, so this "
+        "usually means a non-bundled interpreter is in use."
+    ) from exc
+
+
+_RUNLOOP_MODE = "kCFRunLoopDefaultMode"
+# One drain slice: how long runMode:beforeDate: may block the (shared) event-loop
+# thread while waiting for main-loop work before returning to yield to asyncio.
+# runMode returns early once it processes a source, but while merely waiting it
+# blocks to the limit date -- so this is the worst-case scheduling hitch a
+# co-running coroutine on the shared kernel sees during a maps call. Kept to a
+# couple ms (not tens) to keep that hitch small; the await between slices then
+# hands the loop back to other coroutines.
+_DRAIN_SLICE = 0.002
+_YIELD = 0.005
+
+
+def _load_mapkit() -> tuple[object, bool]:
+    """Return ``(mapkit_namespace, from_binding)``.
+
+    Prefers the bundled pyobjc ``MapKit`` binding (the production path on Darwin),
+    which ships the completion-handler block metadata; otherwise loads the classes
+    straight from the system framework bundle for a dev interpreter that lacks the
+    binding. Either way the namespace exposes ``MKLocalSearchRequest`` /
+    ``MKLocalSearch``. ``from_binding`` says which path was taken, so the caller
+    knows whether the block metadata is already present.
+    """
+    try:
+        import MapKit  # the bundled pyobjc binding (carries block metadata)
+
+        return MapKit, True
+    except ImportError:
+        import types
+
+        ns: dict[str, object] = {}
+        objc.loadBundle("MapKit", ns, bundle_path="/System/Library/Frameworks/MapKit.framework")
+        return types.SimpleNamespace(**ns), False
+
+
+_MAPKIT: object | None = None
+
+
+def _mapkit() -> object:
+    """MapKit namespace, loaded once and cached.
+
+    The bundled binding already carries the metadata for
+    ``startWithCompletionHandler:`` (verified: it returns results with no manual
+    registration). Only a raw ``loadBundle`` fallback -- a dev interpreter without
+    the binding -- needs the metadata registered, else the block raises "no
+    signature available".
+    """
+    global _MAPKIT
+    if _MAPKIT is None:
+        mapkit, from_binding = _load_mapkit()
+        if not from_binding:
+            # pyobjc block metadata lists the implicit block pointer at index 0,
+            # then the real (response, error) arguments at 1 and 2; the Python
+            # handler receives only the latter two.
+            objc.registerMetaDataForSelector(
+                b"MKLocalSearch",
+                b"startWithCompletionHandler:",
+                {
+                    "arguments": {
+                        2: {
+                            "callable": {
+                                "retval": {"type": b"v"},
+                                "arguments": {0: {"type": b"^v"}, 1: {"type": b"@"}, 2: {"type": b"@"}},
+                            }
+                        }
+                    }
+                },
+            )
+        _MAPKIT = mapkit
+    return _MAPKIT
+
+
+async def _await_handler(start: Callable[[Callable[[object], None]], object], *, timeout: float) -> object:
+    """Run a Cocoa completion-handler call and await its result on the kernel loop.
+
+    ``start(done)`` must kick off the asynchronous Cocoa call, arranging for its
+    completion handler (which Cocoa runs on the main thread) to eventually call
+    ``done(value)`` -- where ``value`` is the result, or an ``Exception`` to
+    raise. We then drain the main run loop in bounded slices, yielding to asyncio
+    between each, until ``done`` fires or ``timeout`` elapses.
+
+    This is the one place that touches the run loop; everything else builds on it.
+    """
+    box: dict[str, object] = {}
+
+    def done(value: object) -> None:
+        box["value"] = value
+
+    start(done)
+    runloop = NSRunLoop.currentRunLoop()
+    deadline = time.monotonic() + timeout
+    while "value" not in box and time.monotonic() < deadline:
+        # Drain ready main-loop / main-queue work without blocking long...
+        runloop.runMode_beforeDate_(_RUNLOOP_MODE, NSDate.dateWithTimeIntervalSinceNow_(_DRAIN_SLICE))
+        # ...then hand the loop back to other coroutines.
+        await asyncio.sleep(_YIELD)
+    if "value" not in box:
+        raise MapsError(f"timed out after {timeout:.0f}s waiting for a Cocoa completion handler")
+    value = box["value"]
+    if isinstance(value, BaseException):
+        raise value
+    return value
+
+
+def _region(lat: float, lng: float, radius_m: float) -> tuple[tuple[float, float], tuple[float, float]]:
+    """An MKCoordinateRegion (center, span) covering ``radius_m`` around a point.
+
+    Returned as the nested tuple pyobjc encodes into the struct from the runtime
+    method signature. Span is the full width/height, so it is twice the radius;
+    longitude degrees shrink with latitude (``cos``), latitude degrees do not.
+    """
+    lat_delta = (2 * radius_m) / 111_320.0
+    lng_delta = (2 * radius_m) / (111_320.0 * max(math.cos(math.radians(lat)), 1e-6))
+    return ((lat, lng), (lat_delta, lng_delta))
+
+
+def _str(value: object) -> str | None:
+    """A Cocoa string-ish value as a Python str, or None."""
+    return None if value is None else str(value)
+
+
+def _placemark_row(placemark: object) -> dict[str, object]:
+    """Common address/coordinate columns from a CL/MK placemark."""
+    location = placemark.location()
+    coord = location.coordinate() if location is not None else None
+    return {
+        "name": _str(placemark.name()),
+        "latitude": coord.latitude if coord is not None else None,
+        "longitude": coord.longitude if coord is not None else None,
+        "thoroughfare": _str(placemark.thoroughfare()),
+        "sub_thoroughfare": _str(placemark.subThoroughfare()),
+        "locality": _str(placemark.locality()),
+        "administrative_area": _str(placemark.administrativeArea()),
+        "postal_code": _str(placemark.postalCode()),
+        "country": _str(placemark.country()),
+        "iso_country_code": _str(placemark.ISOcountryCode()),
+        # Placemarks carry no URL; MKMapItem results get one in _mapitem_row.
+        "url": None,
+    }
+
+
+def _mapitem_row(item: object) -> dict[str, object]:
+    """One MKMapItem (a search result) as a row: placemark fields plus POI meta."""
+    row = _placemark_row(item.placemark())
+    # MKMapItem.name is the business/POI name; the placemark's name is often just
+    # the street, so prefer the map item's.
+    row["name"] = _str(item.name())
+    category = item.pointOfInterestCategory()
+    # POI categories read as "MKPOICategoryCafe"; strip the prefix for a tidy tag.
+    row["category"] = _str(category).removeprefix("MKPOICategory") if category is not None else None
+    row["phone"] = _str(item.phoneNumber())
+    nsurl = item.url()
+    row["url"] = _str(nsurl.absoluteString()) if nsurl is not None else None
+    return row
+
+
+async def nearby(
+    query: str,
+    latitude: float,
+    longitude: float,
+    *,
+    radius_m: float = 2000.0,
+    timeout: float = 20.0,
+) -> pl.DataFrame:
+    """Search for places matching ``query`` near a coordinate (MapKit).
+
+    Returns one row per result with name, latitude, longitude, category, phone,
+    url, and address fields, ordered as MapKit ranks them. ``radius_m`` sizes the
+    search region around the center (a hint, not a hard cutoff). No API key or
+    account is required -- this is Apple's on-device search.
+
+        await maps.nearby("coffee", 37.3349, -122.009)
+        await maps.nearby("hardware store", 40.7128, -74.0060, radius_m=5000)
+    """
+    import polars as pl
+
+    mapkit = _mapkit()
+    request = mapkit.MKLocalSearchRequest.alloc().init()
+    request.setNaturalLanguageQuery_(query)
+    request.setRegion_(_region(latitude, longitude, radius_m))
+    search = mapkit.MKLocalSearch.alloc().initWithRequest_(request)
+
+    def start(done: Callable[[object], None]) -> None:
+        def handler(response: object, error: object) -> None:
+            if error is not None:
+                done(MapsError(f"nearby({query!r}) failed: {error}"))
+            else:
+                done([_mapitem_row(item) for item in response.mapItems()])
+
+        search.startWithCompletionHandler_(handler)
+
+    rows = await _await_handler(start, timeout=timeout)
+    return pl.DataFrame(rows, schema=_nearby_schema(pl))
+
+
+async def geocode(address: str, *, timeout: float = 20.0) -> pl.DataFrame:
+    """Turn an address or place name into coordinates (CoreLocation CLGeocoder).
+
+    Returns one row per match (usually one) with latitude, longitude, and the
+    resolved address fields.
+
+        await maps.geocode("1600 Amphitheatre Parkway, Mountain View, CA")
+    """
+    import polars as pl
+
+    geocoder = CoreLocation.CLGeocoder.alloc().init()
+
+    def start(done: Callable[[object], None]) -> None:
+        def handler(placemarks: object, error: object) -> None:
+            if error is not None:
+                done(MapsError(f"geocode({address!r}) failed: {error}"))
+            else:
+                done([_placemark_row(pm) for pm in (placemarks or [])])
+
+        geocoder.geocodeAddressString_completionHandler_(address, handler)
+
+    rows = await _await_handler(start, timeout=timeout)
+    return pl.DataFrame(rows, schema=_placemark_schema(pl))
+
+
+async def reverse_geocode(latitude: float, longitude: float, *, timeout: float = 20.0) -> pl.DataFrame:
+    """Turn a coordinate into nearby address(es) (CoreLocation CLGeocoder).
+
+    Returns one row per match with the resolved address fields and the snapped
+    coordinate.
+
+        await maps.reverse_geocode(37.3349, -122.009)
+    """
+    import polars as pl
+
+    geocoder = CoreLocation.CLGeocoder.alloc().init()
+    location = CoreLocation.CLLocation.alloc().initWithLatitude_longitude_(latitude, longitude)
+
+    def start(done: Callable[[object], None]) -> None:
+        def handler(placemarks: object, error: object) -> None:
+            if error is not None:
+                done(MapsError(f"reverse_geocode({latitude}, {longitude}) failed: {error}"))
+            else:
+                done([_placemark_row(pm) for pm in (placemarks or [])])
+
+        geocoder.reverseGeocodeLocation_completionHandler_(location, handler)
+
+    rows = await _await_handler(start, timeout=timeout)
+    return pl.DataFrame(rows, schema=_placemark_schema(pl))
+
+
+# Explicit schemas keep column dtypes stable even when a frame is empty (no
+# results) or a column is all-null for one query but populated for the next.
+# Built lazily from the caller's polars so the module imports without polars at
+# top level (matching the other bundled helpers).
+def _placemark_schema(pl: object) -> dict[str, object]:
+    return {
+        "name": pl.String,
+        "latitude": pl.Float64,
+        "longitude": pl.Float64,
+        "thoroughfare": pl.String,
+        "sub_thoroughfare": pl.String,
+        "locality": pl.String,
+        "administrative_area": pl.String,
+        "postal_code": pl.String,
+        "country": pl.String,
+        "iso_country_code": pl.String,
+        "url": pl.String,
+    }
+
+
+def _nearby_schema(pl: object) -> dict[str, object]:
+    return {**_placemark_schema(pl), "category": pl.String, "phone": pl.String}


### PR DESCRIPTION
## What

Adds a bundled `maps` kernel module for native macOS places & location — no install step, no API key, no cost (Apple's on-device stack):

```python
await maps.nearby("coffee", 37.3349, -122.009)   # MKLocalSearch — places near a point
await maps.geocode("Apple Park, Cupertino, CA")    # CLGeocoder — address -> lat/lng
await maps.reverse_geocode(37.3349, -122.009)      # CLGeocoder — lat/lng -> address
await maps.here()                                   # CLLocationManager — this Mac's location
```

Each returns a polars frame. macOS-only (raises off Darwin); shows up in `api()` and the server instructions via one `registry.py` row.

## Why a run-loop bridge (the interesting part)

These Cocoa APIs deliver results through completion handlers / a delegate on the **main thread**, which the kernel's asyncio loop owns but doesn't service as a `CFRunLoop` — so a naive call's handler never fires (and pumping the run loop synchronously *wedges the kernel*, which is exactly how this work started). `_await_handler` kicks off the Cocoa call, then cooperatively drains the main run loop in short, bounded slices between `await`s until the handler lands. It's deliberately general (knows nothing about maps) so a future CoreLocation/EventKit/Contacts helper can reuse it.

This was validated empirically (spike): a worker-thread run loop does **not** receive the callbacks; draining the main loop does (0.1s).

## Packaging

- `mapKitModule` derived from `pyobjc-framework-Quartz`'s source (MapKit is a sibling subdir), mirroring the existing `coreLocationModule`.
- Both join the interpreter only on Darwin (`darwinExtraPackages`).
- Tests: `mapsBundled` (import + MapKit binding) and `mapsSmoke` (offline region-math + schema checks).

## Validation

- Live `nearby`/`geocode`/`reverse_geocode` return real data; `here()` cleanly surfaces a missing-Location-Services permission instead of hanging.
- `nix run .#lint` green (ruff/nixfmt/statix/deadnix/astlog).
- Adversarial review passed (one comment-accuracy fix applied).

Filed ENG-4484 for the kernel wedge+desync infra issue encountered during this work.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native macOS maps module with MapKit and CoreLocation place search
> - Adds a new `maps` Python module under [packages/mcp/src/maps](https://github.com/indexable-inc/index/pull/1320/files#diff-5be31586f8f2020933697d63e9567cb75d01d17855f15600218d40464daee064) exposing three async coroutines: `nearby`, `geocode`, and `reverse_geocode`, each returning a polars DataFrame.
> - Uses MapKit (`MKLocalSearch`) for nearby place search and CoreLocation (`CLGeocoder`) for forward/reverse geocoding, bridging Cocoa completion handlers to asyncio via a run-loop polling approach with configurable timeout.
> - Bundles a `pyobjc-framework-MapKit` binding derivation and the maps module into the macOS interpreter in [packages/mcp/default.nix](https://github.com/indexable-inc/index/pull/1320/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db), and registers the module in the MCP registry.
> - Falls back to loading the system MapKit framework directly via `objc.loadBundle` if the pyobjc binding is not importable, with manual block-signature metadata to make completion handlers callable.
> - Risk: macOS-only; importing on non-Darwin raises `RuntimeError` immediately. The asyncio bridge drains the Cocoa main run loop in slices, which may interact unexpectedly with other run-loop users.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fce7e38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->