### PR TITLE
mcp: don't auto-open the dashboard in a browser on tool call

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -110,9 +110,10 @@ set `IX_MCP_AUTO_DASHBOARD=1` to restore the old per-server auto-spawn.
   program-counter highlight while a job runs, and the failing line highlighted in
   red with the exception headline when it errors.
 - `store.py` is the append-only execution log (one SQLite file in WAL mode).
-- `dashboard.py` serves a one-page live view of that log. Open it manually with
-  `nix run .#mcp -- dashboard`; the server never auto-pops a browser on a tool
-  call.
+- `dashboard.py` serves a one-page live view of that log. The server never
+  auto-pops a browser on a tool call; view it by running the standalone
+  aggregator (`nix run .#dashboard`, see above), or set `IX_MCP_AUTO_DASHBOARD=1`
+  to restore the per-server auto-spawn.
 - `outputs.py` renders kernel messages for the agent (text, images).
 - `tools.py` is the MCP surface: the general `python_exec`, plus `read` (pull a
   file or kernel value into the model's context while the dashboard stays quiet)

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -14,7 +14,7 @@ nix run .#mcp -- serve                       # MCP over stdio (what an MCP clien
 nix run .#mcp -- serve --http :8000          # MCP over streamable HTTP instead
 nix run .#mcp -- serve --session work.ixnb   # same, recorded in a reopenable session file
 nix run .#mcp -- notebook work.ixnb          # the engine alone: kernel + dashboard, no MCP
-nix run .#mcp -- dashboard                   # open the running server's dashboard URL
+nix run .#mcp -- dashboard                   # print/open this server's data-API URL (human UI: nix run .#dashboard)
 nix run .#mcp -- eval '1 + 2'                # one-shot expression on a throwaway kernel
 ```
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -110,11 +110,9 @@ set `IX_MCP_AUTO_DASHBOARD=1` to restore the old per-server auto-spawn.
   program-counter highlight while a job runs, and the failing line highlighted in
   red with the exception headline when it errors.
 - `store.py` is the append-only execution log (one SQLite file in WAL mode).
-- `dashboard.py` serves a one-page live view of that log. The first tool call
-  of a session pops that page in the local browser (via Python's
-  platform-independent `webbrowser`, a no-op on headless machines), so the
-  human is watching the moment work begins; an embedder with no human at
-  this machine's display disables it with `IX_MCP_NO_BROWSER=1`.
+- `dashboard.py` serves a one-page live view of that log. Open it manually with
+  `nix run .#mcp -- dashboard`; the server never auto-pops a browser on a tool
+  call.
 - `outputs.py` renders kernel messages for the agent (text, images).
 - `tools.py` is the MCP surface: the general `python_exec`, plus `read` (pull a
   file or kernel value into the model's context while the dashboard stays quiet)

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -72,7 +72,10 @@ def main(argv: list[str] | None = None) -> int:
         "session", nargs="?", metavar="FILE", help="Session file to create or reopen"
     )
     notebook.add_argument("--workdir", help="Directory the kernel runs in (default: cwd)")
-    sub.add_parser("dashboard", help="Open the running server's dashboard URL")
+    sub.add_parser(
+        "dashboard",
+        help="Print/open this server's data-API URL (run `nix run .#dashboard` for the human UI)",
+    )
     sub.add_parser(
         "requirements",
         help="Report each external credential the bundled tooling needs: present "

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -191,8 +191,9 @@ def set_dashboard_url(url: str) -> None:
     it straight out of the ``initialize`` response -- the agent has the URL from
     the first message, with no tool call to look it up. The CLI calls this once
     the dashboard has bound its port, before the transport serves ``initialize``.
-    The URL is stashed so a tool call can surface it; the dashboard is opened
-    manually (`nix run .#mcp -- dashboard`), never auto-popped on a tool call.
+    The URL is stashed so a tool call can surface it, never auto-popped in a
+    browser. The human-facing UI is the standalone aggregator (`nix run
+    .#dashboard`), which renders every server at once.
     """
     global _dashboard_url
     _dashboard_url = url

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -32,10 +32,8 @@ from __future__ import annotations
 import contextlib
 import json
 import os
-import threading
 import uuid
 import weakref
-import webbrowser
 from typing import Annotated
 
 from mcp.server.fastmcp import Context, FastMCP
@@ -193,46 +191,17 @@ def set_dashboard_url(url: str) -> None:
     it straight out of the ``initialize`` response -- the agent has the URL from
     the first message, with no tool call to look it up. The CLI calls this once
     the dashboard has bound its port, before the transport serves ``initialize``.
-    The URL is also stashed so the first tool call can pop it in a browser.
+    The URL is stashed so a tool call can surface it; the dashboard is opened
+    manually (`nix run .#mcp -- dashboard`), never auto-popped on a tool call.
     """
     global _dashboard_url
     _dashboard_url = url
     mcp._mcp_server.instructions = _compose_instructions(url)
 
 
-# The live dashboard URL (set by `set_dashboard_url`) and a once-latch for the
-# browser pop below. Module-level because the tool functions are module-level.
+# The live dashboard URL (set by `set_dashboard_url`). Module-level because the
+# tool functions are module-level.
 _dashboard_url: str | None = None
-_browser_opened = False
-
-
-def _open_dashboard_once() -> None:
-    """Open the live dashboard in the human's browser on the FIRST tool call.
-
-    The server is launched eagerly when a client session starts, so opening at
-    startup would pop a window for sessions that never touch index; the first
-    tool call is the moment work actually begins. ``webbrowser`` is the
-    platform-independent opener (macOS ``open``, Linux ``xdg-open``, Windows
-    ``start``) and degrades to a no-op where no browser is reachable (headless,
-    SSH); failures are swallowed because the pop is a courtesy, never worth
-    failing a tool call over. The call runs on a daemon thread since spawning
-    the opener is synchronous and must not block the event loop. An embedder
-    that drives this server programmatically (no human at this machine's
-    display) disables it with ``IX_MCP_NO_BROWSER=1``.
-    """
-    global _browser_opened
-    if _browser_opened:
-        return
-    _browser_opened = True
-    url = _dashboard_url
-    if not url or os.environ.get("IX_MCP_NO_BROWSER"):
-        return
-
-    def _open() -> None:
-        with contextlib.suppress(Exception):  # browser unavailable (headless/SSH): best-effort pop
-            webbrowser.open(url)
-
-    threading.Thread(target=_open, name="ix-mcp-open-dashboard", daemon=True).start()
 
 # Report the build's source revision as the MCP `serverInfo.version` so a client
 # can see exactly which commit of the server it is talking to. The nix wrapper
@@ -267,7 +236,6 @@ async def python_exec(
     budget: Annotated[float, Field(description="Seconds to wait before backgrounding the run (server-side cap: 120s; larger values are clamped and a notice is appended to the reply)")] = 15.0,
     ctx: Context | None = None,
 ) -> Content:
-    _open_dashboard_once()
     await _identify_client_once(ctx)
     # A foreground budget is how long the run holds the one shared shell channel
     # before it backgrounds, so cap it: a giant budget (a 15-minute `await
@@ -347,7 +315,6 @@ async def read(
     end: Annotated[int | None, Field(description="Last line to include (inclusive)")] = None,
     ctx: Context | None = None,
 ) -> Content:
-    _open_dashboard_once()
     await _identify_client_once(ctx)
     sid = _session_id(ctx)
     code = f"await __ix_read({target!r}, {start!r}, {end!r}, session={sid!r})"
@@ -365,7 +332,6 @@ async def read(
 
 @mcp.tool(structured_output=False, description=guide.TRACE)
 async def kernel_trace() -> str:
-    _open_dashboard_once()
     return await current_kernel().dump_trace()
 
 


### PR DESCRIPTION
## What

Remove the auto-open of the index dashboard in the local browser.

The MCP server is launched eagerly when a client session starts, and the **first tool call** popped the dashboard URL (`localhost:<port>`) in the browser via `_open_dashboard_once()`. That opens a page unbidden even when the human isn't expecting the server to be up.

## Change

- Delete `_open_dashboard_once()` and the `_browser_opened` latch.
- Remove its three call sites (`python_exec`, `read`, `kernel_trace`).
- Drop the now-unused `threading` / `webbrowser` imports.
- `set_dashboard_url` still stashes the URL (baked into server instructions); README updated.

The dashboard is now opened **manually**:

```
nix run .#mcp -- dashboard
```

## Note

The `IX_MCP_NO_BROWSER=1` env var is now obsolete (it only gated the auto-open). Left unreferenced; can scrub remaining mentions in a follow-up if desired.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove auto-open browser behavior from MCP tool calls in `ix_notebook_mcp`
> The `python_exec`, `read`, and `kernel_trace` tools previously attempted to open the dashboard URL in a browser on the first tool call, using a background thread and `webbrowser`. This behavior is removed entirely.
>
> - Deletes the `_open_dashboard_once` helper, its once-latch, the env var check, and the `threading`/`webbrowser` imports from [tools.py](https://github.com/indexable-inc/index/pull/1321/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6)
> - Updates the `dashboard` subcommand help text in [cli.py](https://github.com/indexable-inc/index/pull/1321/files#diff-7ce741e8223d63fdea11625cb78abad266299445db0213d2355bc93306df9ac5) to clarify it prints the data-API URL; the human UI is launched separately via `nix run .#dashboard`
> - Behavioral Change: no browser window is opened on tool invocation; the previously available opt-in env var to restore this behavior is also removed
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5eeefc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->