### PR TITLE
andrewgazelka: wire OBS Source Record plugin on darwin

### DIFF
--- a/users/andrewgazelka/darwin.nix
+++ b/users/andrewgazelka/darwin.nix
@@ -37,6 +37,9 @@
       "lm-studio"
       "mullvad-vpn@beta"
       "notion"
+      # OBS Studio. The Source Record plugin (ISO per-source recording) is wired
+      # in home.nix (`obsSourceRecord`): nixpkgs' OBS plugin path is Linux-only,
+      # so on macOS it drops the upstream .plugin into the OBS user plugin dir.
       "obs@beta"
       "obsidian"
       "orbstack"

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -175,6 +175,47 @@ let
       {
         inherit indexPackages portableServicesModule ix;
       };
+
+  # OBS Studio "Source Record" plugin (exeldro): records individual sources to
+  # their own files (ISO recordings) simultaneously with the main capture. OBS
+  # itself is the `obs` Homebrew cask (darwinModules.andrewgazelka). nixpkgs'
+  # obs-studio / wrapOBS plugin path is Linux-only and wraps a nix-built OBS, so
+  # on macOS we instead extract the upstream signed .plugin bundle from the
+  # release .pkg (an xar wrapping a gzip'd cpio Payload) and drop it into the OBS
+  # user plugin dir via home.file below. Darwin-only; bump version + hash on
+  # upgrade (latest tag at github.com/exeldro/obs-source-record/releases).
+  obsSourceRecord = pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
+    pname = "obs-source-record";
+    version = "0.4.8";
+    src = pkgs.fetchurl {
+      url = "https://github.com/exeldro/obs-source-record/releases/download/${finalAttrs.version}/source-record-${finalAttrs.version}-macos-universal.pkg";
+      hash = "sha256-YURjKZWFhI9KgoOxXVDF2bmr0jZCLeqKl+k0/b9w/hk=";
+    };
+    nativeBuildInputs = [
+      pkgs.xar
+      pkgs.libarchive
+    ];
+    # The .pkg is a flat installer; bsdtar auto-detects the gzip'd cpio Payload,
+    # which lays the bundle under ./Library/Application Support/obs-studio/plugins.
+    unpackPhase = ''
+      runHook preUnpack
+      xar -xf "$src"
+      bsdtar -xf source-record.pkg/Payload
+      runHook postUnpack
+    '';
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out"
+      cp -R "Library/Application Support/obs-studio/plugins/source-record.plugin" "$out/"
+      runHook postInstall
+    '';
+    meta = {
+      description = "OBS Studio plugin to record individual sources to separate files";
+      homepage = "https://github.com/exeldro/obs-source-record";
+      license = lib.licenses.gpl2Only;
+      platforms = lib.platforms.darwin;
+    };
+  });
 in
 {
   imports = [
@@ -382,6 +423,15 @@ in
 
     # Expose the shared speaker on PATH so the user can announce by hand too.
     home.packages = [ sayDetached ];
+
+    # Drop the Source Record OBS plugin into the OBS user plugin dir (OBS scans
+    # it on launch). Symlinking the whole signed .plugin bundle (not its
+    # contents, so home.file's default non-recursive link) keeps its code
+    # signature intact. Darwin-only: the plugin and the `obs` cask are both macOS.
+    home.file = lib.mkIf isDarwin {
+      "Library/Application Support/obs-studio/plugins/source-record.plugin".source =
+        "${obsSourceRecord}/source-record.plugin";
+    };
 
     services.portable = lib.mkMerge [
       (lib.mkIf cfg.downtime.enable {


### PR DESCRIPTION
Adds the exeldro **Source Record** OBS plugin declaratively on macOS so OBS can record individual sources to their own files (ISO recordings) simultaneously with the main capture.

### Why not the normal nix path
nixpkgs' `obs-studio` is Linux-only (issue #411190) and `wrapOBS`/`programs.obs-studio.plugins` wraps a *nix-built* OBS — but ours is the `obs` Homebrew cask. So instead we extract the upstream signed universal `.plugin` from the release `.pkg` (an xar wrapping a gzip'd cpio Payload, via `bsdtar`) and symlink the whole bundle into the OBS user plugin dir with `home.file`.

Symlinking the bundle (not its contents — `home.file` default non-recursive) keeps the ad-hoc code signature intact; nix-store files carry no `com.apple.quarantine` xattr so Gatekeeper doesn't block it.

### Verified on hydra
- Derivation builds with the pinned hash (isolated build).
- Bundle is universal (`x86_64 arm64`) and `codesign` reports a valid ad-hoc signature.
- Full `darwinConfigurations.hydra` evaluates with the change.
- **OBS loads it at launch:** log shows `[Source Record] loaded version 0.4.8` and `source-record` in Loaded Modules.

Darwin-only (`lib.mkIf isDarwin`). Bump `version` + `hash` on upgrade.

```mermaid
flowchart LR
  A[release .pkg<br/>pinned hash] -->|xar + bsdtar| B[source-record.plugin<br/>nix store]
  B -->|home.file symlink| C["~/Library/.../obs-studio/plugins"]
  C -->|OBS scans on launch| D[Source Record loaded]
```


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire OBS Source Record plugin installation on macOS via Home Manager
> - Defines `obsSourceRecord` in [home.nix](https://github.com/indexable-inc/index/pull/1323/files#diff-b9c7bb705f699ec210f648820aef5c561583845b682d07d6e1dc19de7685cb0f) as a derivation that fetches the upstream `.pkg` for exeldro's OBS Source Record plugin, unpacks it with `xar` and `bsdtar`, and copies the signed `source-record.plugin` bundle to the derivation output.
> - Adds a `home.file` entry (guarded by `isDarwin`) that symlinks the plugin bundle into `~/Library/Application Support/obs-studio/plugins`, using a non-recursive link to preserve macOS code signatures.
> - Adds comments in [darwin.nix](https://github.com/indexable-inc/index/pull/1323/files#diff-8e50939d75ca47b003564ea6eb7afcd3cd3ab9bfa6b8876d3c079c94862fb7bc) explaining the split between the OBS cask and the separately managed plugin.
> - Risk: the derivation fetches a fixed upstream `.pkg` by hash; if the upstream URL changes or the hash drifts, the build will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95718d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->