### PR TITLE
ix-windows: floating blurred overlays that auto-size to content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4112,6 +4112,7 @@ dependencies = [
  "clap",
  "dashboard-core",
  "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
  "objc2-web-kit",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,7 @@ nix = "0.31"
 nix-web-monitor-parser = { path = "packages/nix/nix-web-monitor/parser" }
 numpy = "0.28"
 objc2 = "0.6"
+objc2-app-kit = "0.3"
 objc2-foundation = "0.3"
 objc2-web-kit = "0.3"
 object_store = { version = "0.13", features = ["aws"] }

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ From-source documentation for the packages in the `index` repo (a shared, open-s
 | [ix-dev-diagnose](ix-dev-diagnose/overview.md) | `packages/ix-dev-diagnose` probes `https://ix.dev/` (or any HTTPS URL) from the caller's network path and writes a single JSON diagnostic capturing every layer of the request: system DNS... |
 | [ix-fleet](ix-fleet/overview.md) | `packages/ix-fleet` renders and executes declarative **fleet plans**: a single JSON document describes a set of remote ix VMs (nodes) and their images, NixOS switch targets, east-west gro... |
 | [ix-sdk-python](ix-sdk-python/overview.md) | `packages/ix-sdk-python` is the Nix package that makes the precompiled Python SDK bindings available in-repo as `pkgs.ix-sdk-python` / `nix build .#ix-sdk-python`. |
-| [ix-windows](ix-windows/overview.md) | `packages/ix-windows` renders each live MCP resource as its own borderless, square, ghostty-styled native webview window. |
+| [ix-windows](ix-windows/overview.md) | `packages/ix-windows` renders each live MCP resource as its own floating, blurred overlay webview window that auto-sizes to its content. |
 | [kitty](kitty/overview.md) | `packages/kitty` is an encoder for the kitty terminal graphics protocol: it turns image bytes into the `APC _G ... |
 | [lake](lake/overview.md) | `packages/lake` (member `lake/iceberg`, crate `lake-iceberg`) is the Iceberg corpus lake: the durable, replayable log under the multi-source search corpus (issue #752), succeeding the ful... |
 | [launchk](launchk/overview.md) | `packages/launchk` builds launchk, a cursive (Rust TUI) tool for observing launchd agents and daemons, from source. |

--- a/docs/ix-windows/overview.md
+++ b/docs/ix-windows/overview.md
@@ -1,12 +1,13 @@
 # ix-windows
 
-`packages/ix-windows` renders each live MCP resource as its own borderless,
-square, ghostty-styled native webview window. It is a second consumer of the
-dashboard producer stream, alongside the [dashboard](../dashboard/overview.md)
-web aggregator: instead of folding producers into a web board, it maps each
-`resource/<id>` html pane to one OS window. A window opens when a resource
-appears, re-renders in place on update (no reload, so scroll and focus survive),
-and closes when the resource closes or its producer disconnects.
+`packages/ix-windows` renders each live MCP resource as its own floating,
+blurred **overlay** webview window that auto-sizes to its content. It is a second
+consumer of the dashboard producer stream, alongside the
+[dashboard](../dashboard/overview.md) web aggregator: instead of folding
+producers into a web board, it maps each `resource/<id>` html pane to one OS
+window. A window opens when a resource appears, re-renders in place on update (no
+reload, so scroll and focus survive), and closes when the resource closes or its
+producer disconnects.
 
 It reuses [dashboard-core](../dashboard-core/overview.md) for the entire
 transport, so the MCP needs no change: the MCP already publishes every
@@ -23,8 +24,8 @@ It is split into a reusable engine library (`src/lib.rs`, `[lib] name =
 Rust workspace package (`packages/ix-windows/Cargo.toml`), built as the
 `ix-windows` flake output (`package.nix`: `flake = true`). Deps: `dashboard-core`,
 `clap`, `tao`, `wry`, `tokio`, `serde_json`; on macOS also `objc2` +
-`objc2-foundation` + `objc2-web-kit` for the WebKit/window tuning
-(`Cargo.toml:31`).
+`objc2-app-kit` + `objc2-foundation` + `objc2-web-kit` for the native blur and
+WebKit tuning.
 
 ```
 nix run .#ix-windows                 # watch the default discovery dir
@@ -34,111 +35,126 @@ nix build .#ix-windows
 
 **Darwin-only flake output.** `wry` links the system WebKit framework on macOS;
 Linux (WebKitGTK) is a later add, so `default.nix` restricts `meta.platforms` to
-`aarch64-darwin` and `x86_64-darwin` (`packages/ix-windows/default.nix:11`). The
-macOS WebKit tuning (`src/lib.rs:294`) is behind `#[cfg(target_os = "macos")]`,
-so the crate still compiles on other targets, just without that tuning.
+`aarch64-darwin` and `x86_64-darwin`. The native blur and WebKit tuning are
+behind `#[cfg(target_os = "macos")]`, so the crate still compiles on other
+targets, just without that styling (no blur, no auto-resize is unaffected since
+it is plain `tao`).
 
-## CLI (`src/main.rs:22`)
+## CLI (`src/main.rs`)
 
 | flag | default | meaning |
 | --- | --- | --- |
-| `--dir` | discovery dir | producer-socket directory to watch, matching the `dashboard` aggregator. Defaults via [`discovery_dir`](../dashboard-core/overview.md#discovery-paths) (`main.rs:28`). |
-| `--rescan-ms` | `500` | how often to rescan the directory for new/removed sockets (`main.rs:33`). |
+| `--dir` | discovery dir | producer-socket directory to watch, matching the `dashboard` aggregator. Defaults via [`discovery_dir`](../dashboard-core/overview.md#discovery-paths). |
+| `--rescan-ms` | `500` | how often to rescan the directory for new/removed sockets. |
 
-## Threading model (`src/main.rs:37`)
+## Threading model (`src/main.rs`)
 
 Windows must be created and driven on the main thread (`tao`), but the
-subscriber is async. The binary:
+subscriber is async, and the page's measuring script also feeds events back. The
+binary:
 
-1. Builds a `tao` `EventLoop` parameterized on `ProducerEvent` as its user-event
-   type, and a proxy (`main.rs:43`).
+1. Builds a `tao` `EventLoop` parameterized on [`UserEvent`] as its user-event
+   type, and a proxy. [`UserEvent`] wraps either a `ProducerEvent`
+   (`UserEvent::Producer`) or a content-size report (`UserEvent::Resize`).
 2. Spawns a side thread running a multi-thread tokio runtime that calls
    [`subscribe`](../dashboard-core/overview.md#consumer-side-subscribe-srcsubscribers)
-   and forwards each `ProducerEvent` into the event loop via the proxy; it stops
-   when the loop has exited (`main.rs:49`).
+   and forwards each event as `UserEvent::Producer` into the loop via a clone of
+   the proxy; it stops when the loop has exited.
 3. Runs the event loop with `ControlFlow::Wait` (reactive viewer, not an
-   animation loop) and dispatches to a [`WindowManager`] (`main.rs:65`):
-   `UserEvent(Snapshot)` -> `apply_snapshot`, `UserEvent(Gone)` ->
-   `producer_gone`, `WindowEvent::CloseRequested` -> `window_closed`.
+   animation loop) and dispatches to a [`WindowManager`]:
+   `Producer(Snapshot)` -> `apply_snapshot`, `Producer(Gone)` -> `producer_gone`,
+   `Resize { window, .. }` -> `resize`, `WindowEvent::CloseRequested` ->
+   `window_closed`.
 
 ## The engine: `WindowManager` (`src/lib.rs`)
 
-[`WindowManager`] (`lib.rs:69`) owns the open windows and reconciles them against
-each producer snapshot. It is decoupled from the event source and generic over
-the loop's user-event type `T` so an embedder can drive it from its own `tao`
-loop; the binary's `main` is a thin wrapper. A window's global identity is the
-`PaneKey = (producer id, pane id)` (`lib.rs:35`), since a pane id is unique only
-within its producer.
+[`WindowManager`] owns the open windows and reconciles them against each producer
+snapshot. The window-creation path is generic over the loop's user-event type
+`T` (it only needs the `EventLoopWindowTarget<T>` to build windows), but the
+manager also emits [`UserEvent::Resize`] through the loop proxy, so it holds an
+`EventLoopProxy<UserEvent>` and is constructed with one. A window's global
+identity is the `PaneKey = (producer id, pane id)`, since a pane id is unique
+only within its producer.
 
 Public surface:
 
-- [`WindowManager::new`] (`lib.rs:89`) / `Default`: an empty manager.
-- [`apply_snapshot<T>(target, snapshot)`] (`lib.rs:99`): for each pane that is an
-  `Html` view whose id starts with `resource/` (`RESOURCE_PREFIX`, `lib.rs:31`),
-  refresh an open window or open a new one; close windows for this producer's
-  resources no longer present; and forget dismissals for resources that vanished.
-  Non-html or non-`resource/` panes are skipped, so exec/namespace/cell panes
-  stay on the web canvas.
-- [`producer_gone(producer)`] (`lib.rs:141`): drop every window of a disconnected
-  producer and clear its dismissals.
-- [`window_closed(window_id)`] (`lib.rs:157`): the user closed a window; remove
-  it and record the dismissal. Returns whether it was one of ours.
-- [`is_empty`] (`lib.rs:168`): whether any resource windows are open.
+- [`WindowManager::new`]`(proxy)`: an empty manager that emits resize events
+  through `proxy`.
+- [`apply_snapshot<T>(target, snapshot)`]: for each pane that is an `Html` view
+  whose id starts with `resource/` (`RESOURCE_PREFIX`), refresh an open window or
+  open a new one; close windows for this producer's resources no longer present;
+  and forget dismissals for resources that vanished. Non-html or non-`resource/`
+  panes are skipped, so exec/namespace/cell panes stay on the web canvas.
+- [`resize(window, width, height)`]: fit the overlay window to the natural pixel
+  size its content reported, clamped to the window's monitor work area; a report
+  within 1px of the last applied size is ignored, which also breaks any
+  resize/reflow loop.
+- [`producer_gone(producer)`]: drop every window of a disconnected producer and
+  clear its dismissals.
+- [`window_closed(window_id)`]: the user closed a window; remove it and record
+  the dismissal. Returns whether it was one of ours.
+- [`is_empty`]: whether any resource windows are open.
 
 ### Reconcile invariants
 
-- **In-place refresh.** `OpenWindow::refresh` (`lib.rs:51`) swaps only the
-  `#ix-root` inner HTML via `evaluate_script` when the html changed, and resets
-  the title when it changed, so the document, scroll position, and focus survive
-  an update (a full reload would flicker and reset them). The new HTML is injected
-  as a `serde_json::to_string` JS string literal, so arbitrary resource HTML is
-  escaped safely (`lib.rs:55`).
-- **Dismissal tracking.** `dismissed` (`lib.rs:79`) records resources the user
-  closed while still live. Without it, the next snapshot (any content change
-  republishes one) would find the window gone and re-open it, fighting the user.
-  It is cleared when the resource actually vanishes or its producer disconnects,
-  so a genuine re-registration opens a fresh window.
-- **Reverse index.** `by_window` (`lib.rs:73`) maps an OS `WindowId` back to its
-  `PaneKey` for close events.
-- **Cascade.** `opened` (`lib.rs:83`) offsets each new window so they do not
-  stack exactly on a plain desktop; a tiling WM ignores the position hint.
+- **In-place refresh.** `OpenWindow::refresh` swaps only the `#ix-root` inner
+  HTML via `evaluate_script` when the html changed, and resets the title when it
+  changed, so the document, scroll position, and focus survive an update (a full
+  reload would flicker and reset them). The new HTML is injected as a
+  `serde_json::to_string` JS string literal, so arbitrary resource HTML is
+  escaped safely. The page's `ResizeObserver` notices the resulting size change
+  and drives a `resize`.
+- **Dismissal tracking.** `dismissed` records resources the user closed while
+  still live. Without it, the next snapshot (any content change republishes one)
+  would find the window gone and re-open it, fighting the user. It is cleared
+  when the resource actually vanishes or its producer disconnects, so a genuine
+  re-registration opens a fresh window.
+- **Reverse index.** `by_window` maps an OS `WindowId` back to its `PaneKey` for
+  close and resize events.
+- **Cascade.** `opened` offsets each new overlay so several do not stack exactly
+  on top of each other.
 
-## Native window styling (macOS)
+## Overlay styling and auto-size
 
-- **Borderless, square corners.** Windows are built `with_decorations(false)`,
-  `with_transparent(true)`, 720x480 logical (`lib.rs:194`), exactly like
-  ghostty's `window-decoration = none`. The macOS window server only rounds
-  *titled* windows, so dropping decorations gives square corners for free.
-- **Ghostty-flavored shell.** `shell(title, body)` (`lib.rs:249`) wraps the
-  resource HTML in a dark, monospace, Catppuccin-ish document whose `#ix-root`
-  holds the body; the `<title>` is escaped, the body is injected verbatim (the
-  same trust model as the web dashboard's sandboxed html pane). Styling is the
-  `STYLE` constant (`lib.rs:270`).
-- **120Hz.** `enable_high_refresh` (`lib.rs:294`) disables WebKit's private
+- **Floating overlay.** Windows are built `with_decorations(false)`,
+  `with_transparent(true)`, `with_always_on_top(true)`. On macOS the window also
+  joins all spaces and floats over fullscreen apps (`NSWindowCollectionBehavior`).
+- **Blur behind.** `install_blur` (macOS) inserts an `NSVisualEffectView`
+  (`HUDWindow` material, `BehindWindow` blending) as the content view's first
+  subview, beneath the transparent webview, with a rounded, shadowed layer. The
+  rendered HTML paints on top of it.
+- **Transparent shell.** `shell(title, body)` wraps the resource HTML in a fully
+  transparent document whose `#ix-root` panel shrink-wraps its content with a
+  faint tint and rounded corners (the `STYLE` constant); the `<title>` is
+  escaped, the body injected verbatim (the same trust model as the web
+  dashboard's sandboxed html pane).
+- **Auto-size to content.** The shell embeds `MEASURE_JS`: a `ResizeObserver` on
+  `#ix-root` posts the panel's `offsetWidth`x`offsetHeight` over `wry`'s IPC
+  channel (coalesced to one report per frame, deduped). The IPC handler forwards
+  it as `UserEvent::Resize`, and `WindowManager::resize` fits the OS window. The
+  panel is `inline-block` / `max-width` so its intrinsic size does not depend on
+  the window width, which keeps the measurement stable (no resize loop).
+- **120Hz.** `enable_high_refresh` disables WebKit's private
   `PreferPageRenderingUpdatesNear60FPSEnabled` experimental feature via the
   private `_setEnabled:forExperimentalFeature:` selector (gated by
   `respondsToSelector:` checks), so the webview renders at the display's native
   rate (ProMotion) instead of the ~60fps cap. Best-effort: an OS without those
   selectors stays at the default.
 
-## Tiling under aerospace / yabai
+## Tests (`src/lib.rs`)
 
-A borderless window has no fullscreen button, so aerospace's dialog heuristic
-floats it by default, and `ix-windows` has no bundle id to special-case. The
-crate `README.md` gives the rules: an aerospace `on-window-detected` rule
-matching `app-name-regex-substring = 'ix-windows'` with `run = 'layout tiling'`,
-or `yabai -m rule --add app='^ix-windows$' manage=on`.
-
-## Tests (`src/lib.rs:334`)
-
-`shell` wraps the body in `#ix-root` and escapes the title;
-`escape_text` covers `<`, `&`, `>`. The window/webview paths require a display
-and are exercised manually.
+`shell` wraps the body in `#ix-root` and embeds the measuring script and escapes
+the title; `escape_text` covers `<`, `&`, `>`; `parse_size` reads the
+`"<w>x<h>"` IPC body. The window/webview/blur paths require a display and are
+exercised manually.
 
 [`HtmlView`]: ../dashboard-core/overview.md#wire-types-srcpanrs
 [`WindowManager`]: #the-engine-windowmanager-srclibrs
+[`UserEvent`]: #threading-model-srcmainrs
+[`UserEvent::Resize`]: #threading-model-srcmainrs
 [`WindowManager::new`]: #the-engine-windowmanager-srclibrs
 [`apply_snapshot<T>(target, snapshot)`]: #the-engine-windowmanager-srclibrs
+[`resize(window, width, height)`]: #the-engine-windowmanager-srclibrs
 [`producer_gone(producer)`]: #the-engine-windowmanager-srclibrs
 [`window_closed(window_id)`]: #the-engine-windowmanager-srclibrs
 [`is_empty`]: #the-engine-windowmanager-srclibrs

--- a/packages/ix-windows/Cargo.toml
+++ b/packages/ix-windows/Cargo.toml
@@ -24,11 +24,12 @@ tao.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "net", "io-util", "time"] }
 wry.workspace = true
 
-# Native macOS window tuning via objc2: WebKit's private 120Hz experimental-
-# feature API and the `canBecomeKey`/`canBecomeMain` overrides that let a
-# borderless window tile under aerospace. Versions tracked to wry's own objc2
+# Native macOS overlay styling via objc2: the `NSVisualEffectView` blur behind
+# the transparent webview (objc2-app-kit) and WebKit's private 120Hz
+# experimental-feature API (objc2-web-kit). Versions tracked to wry's own objc2
 # graph.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { workspace = true }
+objc2-app-kit = { workspace = true }
 objc2-foundation = { workspace = true }
 objc2-web-kit = { workspace = true }

--- a/packages/ix-windows/README.md
+++ b/packages/ix-windows/README.md
@@ -1,7 +1,7 @@
 # ix-windows
 
-Render each live MCP resource as its own borderless, square, ghostty-styled
-native webview window.
+Render each live MCP resource as its own floating, blurred **overlay** webview
+window that auto-sizes to its content.
 
 `ix-windows` is a standalone consumer of the dashboard producer stream. The MCP
 already publishes every resource onto the producer sockets as an `html` pane
@@ -14,27 +14,25 @@ nix run .#ix-windows            # watch the default discovery dir
 nix run .#ix-windows -- --dir /tmp/ixw
 ```
 
+## Overlay, not tiles
+
+Each window is a chrome-less, always-on-top card floating above the desktop. No
+tiling, no layout manager.
+
+- **Blur behind.** The `wry` webview is transparent and is painted on top of a
+  native `NSVisualEffectView` (behind-window blur), so the overlay frosts
+  whatever is behind it. The content lives in a faintly tinted, rounded `#ix-root`
+  panel for legibility; the blur layer is rounded and shadowed to match.
+- **Auto-size to content.** There is no fixed window size. A `ResizeObserver` in
+  the page measures the rendered panel and posts its pixel size over `wry`'s IPC
+  channel; the OS window is grown or shrunk to fit (clamped to the monitor work
+  area), so a window is exactly as big as the HTML it holds and expands as the
+  content grows.
+- **Floating across spaces.** The window is always-on-top and joins all spaces /
+  floats over fullscreen apps (`NSWindowCollectionBehavior`).
+
 ## macOS
 
-- **Square corners.** Windows are borderless (`with_decorations(false)`), exactly
-  like ghostty's `window-decoration = none`. The macOS window server only rounds
-  *titled* windows, so dropping decorations gives square corners for free.
 - **120Hz.** WebKit's private experimental flag
   `PreferPageRenderingUpdatesNear60FPSEnabled` is disabled so the webview renders
   at the display's full refresh rate (ProMotion).
-
-### Tiling under aerospace
-
-A borderless window has no fullscreen button, so aerospace's dialog heuristic
-floats it by default. This is the same reason terminals like `kitty` and
-`alacritty` are special-cased in aerospace, and the reason `ghostty`'s bundle id
-is hardcoded to tile. `ix-windows` is a bare binary with no bundle id, so tiling
-relies on an `on-window-detected` rule matching the app name:
-
-```toml
-[[on-window-detected]]
-if.app-name-regex-substring = 'ix-windows'
-run = 'layout tiling'
-```
-
-yabai users want the equivalent `yabai -m rule --add app='^ix-windows$' manage=on`.

--- a/packages/ix-windows/src/lib.rs
+++ b/packages/ix-windows/src/lib.rs
@@ -1,14 +1,23 @@
 //! The reusable engine behind `ix-windows`: map a stream of dashboard
-//! [`ProducerSnapshot`]s onto one borderless webview window per live MCP
-//! resource.
+//! [`ProducerSnapshot`]s onto one floating, blurred **overlay** webview window
+//! per live MCP resource.
 //!
 //! A [`WindowManager`] owns the open windows and reconciles them against each
 //! snapshot: a new resource opens a window, a changed one re-renders in place
 //! (no reload, so scroll and focus survive), a vanished one closes. It is
-//! deliberately decoupled from the event source and the user-event type so an
-//! embedder can drive it from its own `tao` event loop — the binary
-//! ([`crate`]'s `main`) is a thin wrapper that feeds it
-//! [`dashboard_core::subscribe`] events.
+//! deliberately decoupled from the event source for the window-creation target,
+//! but it emits [`UserEvent::Resize`] back into the loop (so it needs the loop's
+//! proxy), which fixes the loop's user-event type to [`UserEvent`].
+//!
+//! ## Overlay, not tiles
+//!
+//! Each window is a chrome-less, always-on-top card floating above the desktop:
+//! a transparent `wry` webview painted on top of a native `NSVisualEffectView`
+//! that blurs whatever is behind the window. There is no tiling and no layout
+//! manager. Instead the window auto-sizes to its content: a `ResizeObserver` in
+//! the page posts the rendered panel's pixel size over `wry`'s IPC channel, and
+//! [`WindowManager::resize`] grows or shrinks the OS window to match (clamped to
+//! the monitor), so a window is exactly as big as the HTML it holds.
 //!
 //! ## What counts as a resource
 //!
@@ -20,9 +29,9 @@
 
 use std::collections::{HashMap, HashSet};
 
-use dashboard_core::{Pane, ProducerSnapshot, View};
+use dashboard_core::{Pane, ProducerEvent, ProducerSnapshot, View};
 use tao::dpi::{LogicalPosition, LogicalSize};
-use tao::event_loop::EventLoopWindowTarget;
+use tao::event_loop::{EventLoopProxy, EventLoopWindowTarget};
 use tao::window::{Window, WindowId};
 use wry::{WebView, WebViewBuilder};
 
@@ -30,24 +39,48 @@ use wry::{WebView, WebViewBuilder};
 /// `pane_bridge.py` (`f"resource/{res['id']}"`).
 const RESOURCE_PREFIX: &str = "resource/";
 
+/// Logical size a freshly opened window starts at, before its content reports a
+/// natural size and [`WindowManager::resize`] snaps it to fit.
+const INITIAL_SIZE: (f64, f64) = (480.0, 300.0);
+
+/// Events the binary's `tao` event loop carries. The subscriber thread feeds
+/// [`UserEvent::Producer`]; the page's content-measuring script feeds
+/// [`UserEvent::Resize`] back through `wry`'s IPC handler and the loop proxy.
+#[derive(Debug, Clone)]
+pub enum UserEvent {
+    /// A producer-stream event (a new/updated snapshot or a gone producer).
+    Producer(ProducerEvent),
+    /// A window's content reported its natural pixel size; fit the OS window to
+    /// it. `window` identifies the source webview's window.
+    Resize {
+        window: WindowId,
+        width: f64,
+        height: f64,
+    },
+}
+
 /// A pane's global identity across producers: `(producer id, pane id)`. A pane id
 /// is unique only within its producer, so the producer scopes it.
 type PaneKey = (String, String);
 
-/// One open resource window: its `tao` window, its `wry` webview, and the last
-/// content rendered into it (so an unchanged snapshot is a no-op).
+/// One open resource window: its `tao` window, its `wry` webview, the last
+/// content rendered into it (so an unchanged snapshot is a no-op), and the last
+/// logical size applied (so a repeated resize report is a no-op).
 struct OpenWindow {
     // Held to keep the OS window alive; dropping `OpenWindow` closes the window.
     window: Window,
     webview: WebView,
     last_html: String,
     last_title: String,
+    last_size: (f64, f64),
 }
 
 impl OpenWindow {
     /// Re-render in place if the resource's html or title changed. The body swap
     /// targets `#ix-root` so the document, its scroll position, and focus survive
-    /// an update — a full reload would flicker and reset them.
+    /// an update — a full reload would flicker and reset them. The page's
+    /// `ResizeObserver` notices the resulting size change and posts a new size,
+    /// which drives [`WindowManager::resize`].
     fn refresh(&mut self, pane: &Pane, html: &str) {
         if self.last_html != html {
             // `serde_json::to_string` emits a valid JS string literal (quoted and
@@ -64,12 +97,14 @@ impl OpenWindow {
     }
 }
 
-/// Owns the resource windows and reconciles them against producer snapshots.
-#[derive(Default)]
+/// Owns the resource overlay windows and reconciles them against producer
+/// snapshots. Emits [`UserEvent::Resize`] through the loop proxy, so it is tied
+/// to a `tao` loop whose user-event type is [`UserEvent`].
 pub struct WindowManager {
+    proxy: EventLoopProxy<UserEvent>,
     windows: HashMap<PaneKey, OpenWindow>,
-    /// Reverse index so an OS close event (the user closing a window) maps back
-    /// to the pane it represented.
+    /// Reverse index so an OS event (a close, a resize report) maps back to the
+    /// pane it represents.
     by_window: HashMap<WindowId, PaneKey>,
     /// Resources the user explicitly closed while still live. Without this, the
     /// next snapshot (any resource content change republishes one) would find
@@ -77,25 +112,30 @@ pub struct WindowManager {
     /// resource actually vanishes or its producer disconnects, so a genuine
     /// re-registration opens a fresh window.
     dismissed: HashSet<PaneKey>,
-    /// How many windows have been opened, used to cascade each new one so they
-    /// do not stack exactly on top of each other on a plain desktop. A tiling
-    /// WM ignores the position hint and lays them out itself.
+    /// How many windows have been opened, used to cascade each new overlay so
+    /// they do not stack exactly on top of each other.
     opened: u32,
 }
 
 impl WindowManager {
-    /// An empty manager with no windows.
+    /// An empty manager that emits resize events through `proxy`.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(proxy: EventLoopProxy<UserEvent>) -> Self {
+        Self {
+            proxy,
+            windows: HashMap::new(),
+            by_window: HashMap::new(),
+            dismissed: HashSet::new(),
+            opened: 0,
+        }
     }
 
     /// Reconcile this producer's resource windows against its latest snapshot:
     /// open new resources, refresh changed ones, and close those that vanished.
     ///
     /// `target` is the running event loop, needed to create windows; it is
-    /// generic over the loop's user-event type so the engine stays independent of
-    /// the binary's event enum.
+    /// generic over the loop's user-event type so the window-creation path stays
+    /// independent of the binary's event enum.
     pub fn apply_snapshot<T: 'static>(
         &mut self,
         target: &EventLoopWindowTarget<T>,
@@ -163,14 +203,46 @@ impl WindowManager {
         true
     }
 
+    /// Fit the overlay window to the natural pixel size its content reported.
+    /// Clamped to the window's monitor work area so an oversized resource grows
+    /// scrollbars rather than spilling off-screen.
+    ///
+    /// The resize/reflow loop is broken primarily on the page side: `MEASURE_JS`
+    /// only posts when the measured panel size actually changes, and the panel's
+    /// intrinsic (`inline-block` / `max-width`) size does not depend on the
+    /// window width. The 1px guard here only suppresses sub-pixel jitter and a
+    /// repeated clamped-to-max report.
+    pub fn resize(&mut self, window: WindowId, width: f64, height: f64) {
+        let Some(key) = self.by_window.get(&window) else {
+            return;
+        };
+        let Some(open) = self.windows.get_mut(key) else {
+            return;
+        };
+        let (max_w, max_h) = open.window.current_monitor().map_or(
+            (1600.0, 1000.0),
+            |monitor| {
+                let size = monitor.size().to_logical::<f64>(monitor.scale_factor());
+                (size.width * 0.92, size.height * 0.92)
+            },
+        );
+        let w = width.clamp(120.0, max_w);
+        let h = height.clamp(80.0, max_h);
+        if (w - open.last_size.0).abs() < 1.0 && (h - open.last_size.1).abs() < 1.0 {
+            return;
+        }
+        open.last_size = (w, h);
+        open.window.set_inner_size(LogicalSize::new(w, h));
+    }
+
     /// Whether any resource windows are currently open.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.windows.is_empty()
     }
 
-    /// Create a chrome-less, square, transparent webview window for a resource
-    /// pane.
+    /// Create a chrome-less, transparent, always-on-top overlay window for a
+    /// resource pane, with a native blur behind its transparent webview.
     fn open<T: 'static>(
         &mut self,
         target: &EventLoopWindowTarget<T>,
@@ -178,25 +250,19 @@ impl WindowManager {
         pane: &Pane,
         html: &str,
     ) {
-        // Cascade each window so they do not perfectly overlap on a plain
-        // desktop; a tiling WM ignores the position and tiles them itself.
-        let step = f64::from(self.opened % 8) * 28.0;
+        // Cascade each overlay so several do not perfectly overlap.
+        let step = f64::from(self.opened % 8) * 32.0;
         self.opened = self.opened.wrapping_add(1);
-        // Borderless, exactly like ghostty's `window-decoration = none`: the macOS
-        // window server only rounds *titled* windows, so dropping decorations gives
-        // square corners for free, matching ghostty under a tiling WM.
-        //
-        // A borderless window has no fullscreen button, so aerospace's dialog
-        // heuristic floats it by default (the same reason terminals like kitty are
-        // special-cased, and the reason ghostty's bundle id is hardcoded to tile).
-        // ix-windows has no bundle id, so tiling relies on an `on-window-detected`
-        // rule matching the app name; see this crate's README / the aerospace config.
+        // Borderless + transparent + always-on-top: a floating overlay card. The
+        // macOS window server only rounds *titled* windows, so dropping
+        // decorations leaves the corners to the blur view's own rounded layer.
         let builder = tao::window::WindowBuilder::new()
             .with_title(&pane.title)
             .with_decorations(false)
             .with_transparent(true)
-            .with_inner_size(LogicalSize::new(720.0, 480.0))
-            .with_position(LogicalPosition::new(96.0 + step, 96.0 + step));
+            .with_always_on_top(true)
+            .with_inner_size(LogicalSize::new(INITIAL_SIZE.0, INITIAL_SIZE.1))
+            .with_position(LogicalPosition::new(64.0 + step, 64.0 + step));
         let window = match builder.build(target) {
             Ok(window) => window,
             Err(error) => {
@@ -205,8 +271,21 @@ impl WindowManager {
             }
         };
         let id = window.id();
+
+        // The page measures its content and posts `"<w>x<h>"`; forward that as a
+        // resize event tagged with this window so the loop can fit it.
+        let proxy = self.proxy.clone();
         let webview = match WebViewBuilder::new()
             .with_transparent(true)
+            .with_ipc_handler(move |request| {
+                if let Some((w, h)) = parse_size(request.body().as_str()) {
+                    let _ = proxy.send_event(UserEvent::Resize {
+                        window: id,
+                        width: w,
+                        height: h,
+                    });
+                }
+            })
             .with_html(shell(&pane.title, html))
             .build(&window)
         {
@@ -217,10 +296,13 @@ impl WindowManager {
             }
         };
 
-        // Let WebKit render at the display's native rate (120Hz on ProMotion)
-        // rather than its default ~60fps cap.
+        // macOS native tuning: a blur behind the transparent webview, and the
+        // 120Hz render-rate uncap. Both no-ops on an OS without the selectors.
         #[cfg(target_os = "macos")]
-        enable_high_refresh(&webview);
+        {
+            install_blur(&window);
+            enable_high_refresh(&webview);
+        }
 
         self.by_window.insert(id, key.clone());
         self.windows.insert(
@@ -230,6 +312,7 @@ impl WindowManager {
                 webview,
                 last_html: html.to_owned(),
                 last_title: pane.title.clone(),
+                last_size: INITIAL_SIZE,
             },
         );
     }
@@ -243,15 +326,33 @@ impl WindowManager {
     }
 }
 
-/// The chrome-less, ghostty-flavored document a resource renders inside: a dark
-/// monospace shell whose `#ix-root` holds the resource's own HTML, swapped in
-/// place on update.
+/// Parse a `"<width>x<height>"` IPC body (the page's measured panel size) into a
+/// pair of logical pixels. Returns `None` on anything malformed.
+///
+/// The body is attacker-controlled (any resource's verbatim HTML can call
+/// `window.ipc.postMessage`), so non-finite or non-positive values are rejected
+/// here rather than reaching [`WindowManager::resize`]: `f64::clamp` *panics* on
+/// `NaN`, which would abort the whole event loop and kill every overlay.
+fn parse_size(body: &str) -> Option<(f64, f64)> {
+    let (w, h) = body.trim().split_once('x')?;
+    let w: f64 = w.trim().parse().ok()?;
+    let h: f64 = h.trim().parse().ok()?;
+    if !w.is_finite() || !h.is_finite() || w <= 0.0 || h <= 0.0 {
+        return None;
+    }
+    Some((w, h))
+}
+
+/// The chrome-less document a resource renders inside: a transparent shell whose
+/// `#ix-root` panel holds the resource's own HTML (swapped in place on update)
+/// and shrink-wraps it, plus a measuring script that posts the panel's pixel
+/// size over `wry`'s IPC channel so the OS window can fit it.
 fn shell(title: &str, body: &str) -> String {
     format!(
         "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">\
 <meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">\
 <title>{title}</title><style>{STYLE}</style></head>\
-<body><div id=\"ix-root\">{body}</div></body></html>",
+<body><div id=\"ix-root\">{body}</div><script>{MEASURE_JS}</script></body></html>",
         title = escape_text(title),
     )
 }
@@ -265,22 +366,126 @@ fn escape_text(text: &str) -> String {
         .replace('>', "&gt;")
 }
 
-/// Ghostty-flavored shell styling: a dark background, system monospace, and a
-/// themed scrollbar. Catppuccin-ish tones to match the dashboard. The root holds
-/// the resource content full-bleed (no padding) so a window is just the content.
+/// Overlay shell styling: the document is fully transparent so the native blur
+/// shows through; the content lives in `#ix-root`, an inline-block panel that
+/// shrink-wraps its content (so the window can be sized to fit) with a faint
+/// tint for legibility over the blur and rounded corners matching the blur layer.
 const STYLE: &str = "\
 :root { color-scheme: dark; }
-html, body { margin: 0; height: 100%; }
+html, body { margin: 0; padding: 0; background: transparent; }
 body {
-  background: #1e1e2e;
   color: #cdd6f4;
   font: 14px/1.5 ui-monospace, 'SF Mono', Menlo, monospace;
 }
-#ix-root { padding: 0; }
+#ix-root {
+  display: inline-block;
+  box-sizing: border-box;
+  min-width: 120px;
+  max-width: 1200px;
+  padding: 16px 18px;
+  background: rgba(30, 30, 46, 0.30);
+  border-radius: 14px;
+}
 ::-webkit-scrollbar { width: 10px; height: 10px; }
-::-webkit-scrollbar-thumb { background: #45475a; border-radius: 5px; }
+::-webkit-scrollbar-thumb { background: rgba(137, 140, 160, 0.5); border-radius: 5px; }
 ::-webkit-scrollbar-track { background: transparent; }
 ";
+
+/// Measure the content panel and post its pixel size back to Rust whenever it
+/// changes. `offsetWidth`/`offsetHeight` include the panel padding, so the OS
+/// window ends up exactly as big as the rendered card. A `ResizeObserver` covers
+/// both content swaps (the in-place `#ix-root` update) and late reflows (images,
+/// fonts); reports are coalesced to one per frame and deduped, so a stable panel
+/// posts once.
+const MEASURE_JS: &str = "\
+(function () {
+  var root = document.getElementById('ix-root');
+  if (!root) return;
+  var lastW = -1, lastH = -1, pending = false;
+  function report() {
+    pending = false;
+    var w = Math.ceil(root.offsetWidth);
+    var h = Math.ceil(root.offsetHeight);
+    if (w === lastW && h === lastH) return;
+    lastW = w; lastH = h;
+    if (window.ipc && window.ipc.postMessage) window.ipc.postMessage(w + 'x' + h);
+  }
+  function schedule() {
+    if (pending) return;
+    pending = true;
+    requestAnimationFrame(report);
+  }
+  new ResizeObserver(schedule).observe(root);
+  window.addEventListener('load', schedule);
+  schedule();
+})();
+";
+
+/// Put a native `NSVisualEffectView` behind the (transparent) webview so the
+/// window blurs whatever is behind it, and give the overlay a rounded, shadowed,
+/// all-spaces-floating look.
+///
+/// Best-effort and main-thread-only: bails if the main-thread marker, the
+/// `NSWindow` pointer, or its content view are unavailable.
+#[cfg(target_os = "macos")]
+fn install_blur(window: &Window) {
+    use objc2::MainThreadMarker;
+    use objc2::rc::Retained;
+    use objc2_app_kit::{
+        NSAutoresizingMaskOptions, NSVisualEffectBlendingMode, NSVisualEffectMaterial,
+        NSVisualEffectState, NSVisualEffectView, NSWindow, NSWindowCollectionBehavior,
+        NSWindowOrderingMode,
+    };
+    use tao::platform::macos::WindowExtMacOS;
+
+    let Some(mtm) = MainThreadMarker::new() else {
+        return;
+    };
+    // SAFETY: on the main thread `tao` hands back a live, retained `NSWindow`
+    // pointer; `Retained::retain` balances the +1 when this scope ends.
+    let ns_window = unsafe { Retained::retain(window.ns_window().cast::<NSWindow>()) };
+    let Some(ns_window): Option<Retained<NSWindow>> = ns_window else {
+        return;
+    };
+
+    // SAFETY: ordinary Objective-C message sends on the main thread to freshly
+    // created / live AppKit objects of the expected classes.
+    unsafe {
+        let Some(content) = ns_window.contentView() else {
+            return;
+        };
+        let frame = content.bounds();
+        let effect = NSVisualEffectView::initWithFrame(mtm.alloc(), frame);
+        effect.setMaterial(NSVisualEffectMaterial::HUDWindow);
+        effect.setBlendingMode(NSVisualEffectBlendingMode::BehindWindow);
+        effect.setState(NSVisualEffectState::Active);
+        // The window opens at `INITIAL_SIZE` and then auto-grows via
+        // `set_inner_size`. A flexible width+height mask keeps the blur filling
+        // the content view as it resizes: an `NSWindow` always resizes its
+        // content view to the content rect, and `contentView.autoresizesSubviews`
+        // defaults on, so this tracks every resize with no explicit handler -
+        // the same mechanism that keeps wry's own webview filling the window.
+        effect.setAutoresizingMask(
+            NSAutoresizingMaskOptions::ViewWidthSizable | NSAutoresizingMaskOptions::ViewHeightSizable,
+        );
+        effect.setWantsLayer(true);
+        if let Some(layer) = effect.layer() {
+            layer.setCornerRadius(14.0);
+            layer.setMasksToBounds(true);
+        }
+        // Place the blur beneath the webview (added as the content view's first
+        // subview), so the rendered HTML paints on top of it.
+        content.addSubview_positioned_relativeTo(&effect, NSWindowOrderingMode::Below, None);
+
+        ns_window.setHasShadow(true);
+        ns_window.invalidateShadow();
+        // A true overlay: float over other spaces and over fullscreen apps.
+        ns_window.setCollectionBehavior(
+            NSWindowCollectionBehavior::CanJoinAllSpaces
+                | NSWindowCollectionBehavior::FullScreenAuxiliary,
+        );
+    }
+}
 
 /// Let the webview render at the display's native refresh rate (120Hz on
 /// `ProMotion`) instead of `WebKit`'s default ~60fps cap, by disabling the
@@ -334,7 +539,7 @@ fn enable_high_refresh(webview: &WebView) {
 
 #[cfg(test)]
 mod tests {
-    use super::{escape_text, shell};
+    use super::{escape_text, parse_size, shell};
 
     #[test]
     fn shell_wraps_body_in_ix_root_and_escapes_title() {
@@ -346,5 +551,23 @@ mod tests {
     #[test]
     fn escape_text_covers_markup_metachars() {
         assert_eq!(escape_text("<&>"), "&lt;&amp;&gt;");
+    }
+
+    #[test]
+    fn parse_size_reads_width_x_height() {
+        assert_eq!(parse_size("640x480"), Some((640.0, 480.0)));
+        assert_eq!(parse_size(" 12.5 x 7 "), Some((12.5, 7.0)));
+        assert_eq!(parse_size("nope"), None);
+        assert_eq!(parse_size("640x"), None);
+    }
+
+    #[test]
+    fn parse_size_rejects_non_finite_and_non_positive() {
+        // These reach the parser straight from attacker-controlled page script.
+        assert_eq!(parse_size("NaNx100"), None);
+        assert_eq!(parse_size("infx100"), None);
+        assert_eq!(parse_size("1e400x100"), None); // overflows to +inf
+        assert_eq!(parse_size("-5x100"), None);
+        assert_eq!(parse_size("0x0"), None);
     }
 }

--- a/packages/ix-windows/src/main.rs
+++ b/packages/ix-windows/src/main.rs
@@ -1,4 +1,4 @@
-//! `ix-windows`: open one borderless native webview window per live MCP
+//! `ix-windows`: open one floating, blurred overlay webview window per live MCP
 //! resource.
 //!
 //! A thin wrapper around [`ix_windows::WindowManager`]. It subscribes to the
@@ -14,11 +14,11 @@ use std::time::Duration;
 
 use clap::Parser;
 use dashboard_core::{ProducerEvent, discovery_dir, subscribe};
-use ix_windows::WindowManager;
+use ix_windows::{UserEvent, WindowManager};
 use tao::event::{Event, WindowEvent};
 use tao::event_loop::{ControlFlow, EventLoopBuilder};
 
-/// Render live MCP resources as borderless webview windows.
+/// Render live MCP resources as floating, blurred overlay webview windows.
 #[derive(Parser)]
 #[command(name = "ix-windows", version, about)]
 struct Cli {
@@ -39,13 +39,15 @@ fn main() {
     let dir = cli.dir.unwrap_or_else(discovery_dir);
     let rescan = Duration::from_millis(cli.rescan_ms);
 
-    // The user-event loop carries `ProducerEvent`s from the subscriber thread.
-    let event_loop = EventLoopBuilder::<ProducerEvent>::with_user_event().build();
+    // The loop carries `UserEvent`s: producer-stream events from the subscriber
+    // thread, plus resize reports posted by each window's measuring script.
+    let event_loop = EventLoopBuilder::<UserEvent>::with_user_event().build();
     let proxy = event_loop.create_proxy();
 
     // Windows must be created and driven on the main thread, but the subscriber
     // is async. Run it on its own tokio runtime in a side thread and forward
-    // every event into the event loop via the proxy.
+    // every producer event into the event loop via the proxy.
+    let producer_proxy = proxy.clone();
     thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
@@ -54,24 +56,31 @@ fn main() {
         runtime.block_on(async move {
             let mut events = subscribe(dir, rescan, &tokio::runtime::Handle::current());
             while let Some(event) = events.recv().await {
-                if proxy.send_event(event).is_err() {
+                if producer_proxy.send_event(UserEvent::Producer(event)).is_err() {
                     break; // the event loop has exited; stop forwarding.
                 }
             }
         });
     });
 
-    let mut manager = WindowManager::new();
+    let mut manager = WindowManager::new(proxy);
     event_loop.run(move |event, target, control_flow| {
         // Idle until the next OS or producer event; this is a reactive viewer,
         // not an animation loop.
         *control_flow = ControlFlow::Wait;
         match event {
-            Event::UserEvent(ProducerEvent::Snapshot(snapshot)) => {
+            Event::UserEvent(UserEvent::Producer(ProducerEvent::Snapshot(snapshot))) => {
                 manager.apply_snapshot(target, &snapshot);
             }
-            Event::UserEvent(ProducerEvent::Gone { producer }) => {
+            Event::UserEvent(UserEvent::Producer(ProducerEvent::Gone { producer })) => {
                 manager.producer_gone(&producer);
+            }
+            Event::UserEvent(UserEvent::Resize {
+                window,
+                width,
+                height,
+            }) => {
+                manager.resize(window, width, height);
             }
             Event::WindowEvent {
                 window_id,


### PR DESCRIPTION
## What

Reworks `ix-windows` from tiled borderless webview windows into floating, blurred **overlay** cards that auto-size to their content. No tiling, no layout manager.

- **Blur behind.** Each window paints its transparent `wry` webview on top of a native `NSVisualEffectView` (behind-window blur, `HUDWindow` material), inserted as the content view's first subview with a rounded, shadowed layer. The rendered HTML sits on top.
- **Auto-size to content.** A page `ResizeObserver` measures the `#ix-root` panel and posts its pixel size over `wry`'s IPC channel; the new `UserEvent::Resize` drives `WindowManager::resize`, which fits the OS window (clamped to the monitor, 1px hysteresis to break any reflow loop). The panel is `inline-block`/`max-width` so its intrinsic size doesn't depend on window width.
- **Floating overlay.** Windows are transparent + borderless + always-on-top, and join all spaces / float over fullscreen apps (`NSWindowCollectionBehavior`).

## Why

The previous behavior relied on an external tiling WM (aerospace/yabai rules) to lay windows out. This makes each resource a self-contained, self-sizing HUD overlay instead.

## Validation

- `nix build .#ix-windows` passes (darwin).
- New `parse_size` unit test; existing `shell`/`escape_text` tests retained. Window/webview/blur paths need a display and are exercised manually.
- Docs + README updated (`docs/ix-windows/overview.md`).

🤖 Drafted with Claude Code (Opus).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add floating blurred overlay windows with auto-size to content in ix-windows
> - Windows are now always-on-top transparent overlays instead of borderless square windows, with initial size reduced to 480x300 and position cascade adjusted.
> - A `ResizeObserver`-based script ([MEASURE_JS](https://github.com/indexable-inc/index/pull/1327/files#diff-1e1abdcf7151daee9cdb984d29eca28bda3ded2eaa1b78937674b8156ef55a43)) measures the `#ix-root` panel and reports pixel dimensions to the native layer via wry IPC, driving `WindowManager::resize` to clamp and apply the new size against monitor bounds.
> - On macOS, `install_blur()` uses `objc2-app-kit` to insert an `NSVisualEffectView` beneath the webview and sets collection behavior to float across spaces and over fullscreen apps.
> - A new `UserEvent` enum wraps both producer stream events and `Resize` reports; `main.rs` forwards producer events as `UserEvent::Producer` and dispatches `UserEvent::Resize` to `WindowManager::resize`.
> - `parse_size` strictly validates IPC size messages, rejecting non-finite or non-positive values to avoid panics during clamping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1895a3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->