### PR TITLE
nix-web-monitor: show why a derivation rebuilt (root causes + what changed)

### DIFF
--- a/packages/nix/nix-web-monitor/parser/src/lib.rs
+++ b/packages/nix/nix-web-monitor/parser/src/lib.rs
@@ -267,6 +267,14 @@ pub enum Delta {
     ErrorAppend { message: String },
     /// The dependency DAG was recomputed after learning new edges.
     DependenciesSet { edges: Vec<DerivationEdge> },
+    /// The set of root-cause derivations was recomputed. A root cause is a built
+    /// derivation whose entire input closure is cache hits, so it is what
+    /// actually changed; every other build is a forced cascade beneath one.
+    RootCausesSet { derivations: Vec<String> },
+    /// A human "what changed" explanation for one (root-cause) derivation, learned
+    /// out-of-band by the server diffing its `.drv` against the previous build
+    /// (e.g. "input rustc changed", "source changed", "no prior build").
+    RebuildReasonSet { derivation: String, reason: String },
     /// The wrapped Nix process exited; `exit_code` is its status if any.
     Finished { exit_code: Option<i32> },
 }
@@ -302,6 +310,14 @@ pub struct MonitorState {
     /// an identical `DependenciesSet`.
     #[serde(skip)]
     last_dependencies: Option<Vec<DerivationEdge>>,
+    /// Last root-cause set broadcast, to drop redundant `RootCausesSet` frames
+    /// the same way `last_dependencies` drops redundant `DependenciesSet` ones.
+    #[serde(skip)]
+    last_root_causes: Option<Vec<String>>,
+    /// Per-derivation "what changed" explanations, learned out-of-band by the
+    /// server diffing each root cause's `.drv` against its previous build. Keyed
+    /// by derivation path; only root causes are populated.
+    rebuild_reasons: BTreeMap<String, String>,
     /// Which section of a build-plan announcement the message stream is inside.
     /// Nix prints the plan as a header line followed by indented store paths;
     /// this tracks that the indented lines belong to the build list rather than
@@ -353,9 +369,37 @@ impl MonitorState {
             daemon: self.daemon.clone(),
             expected: self.expected.clone(),
             dependencies: dependency_edges(&self.closure_deps, &observed),
+            root_causes: root_cause_derivations(&self.closure_deps, &observed),
+            rebuild_reasons: self.rebuild_reasons.clone(),
             exit_code: self.exit_code,
             finished: self.finished,
         }
+    }
+
+    /// Whether `derivation` is a root cause right now: it is a built derivation
+    /// whose input closure has been queried and contains no other built
+    /// derivation (all its inputs are cache hits). The server calls this to
+    /// decide whether to compute a "what changed" reason for it.
+    #[must_use]
+    pub fn is_root_cause(&self, derivation: &str) -> bool {
+        if !self.builds.contains_key(derivation) {
+            return false;
+        }
+        self.closure_deps.get(derivation).is_some_and(|closure| {
+            !closure
+                .iter()
+                .any(|input| self.builds.contains_key(input.as_str()))
+        })
+    }
+
+    /// Record a server-computed "what changed" explanation for one derivation and
+    /// broadcast it, skipping a no-op repeat.
+    pub fn set_rebuild_reason(&mut self, derivation: String, reason: String) {
+        if self.rebuild_reasons.get(&derivation) == Some(&reason) {
+            return;
+        }
+        self.rebuild_reasons.insert(derivation.clone(), reason.clone());
+        self.emit(Delta::RebuildReasonSet { derivation, reason });
     }
 
     /// Take the deltas accumulated since the last drain. The transport calls
@@ -426,8 +470,13 @@ impl MonitorState {
     pub fn record_closure(&mut self, derivation: String, closure_drvs: BTreeSet<String>) {
         self.closure_deps.insert(derivation, closure_drvs);
         let observed: BTreeSet<&str> = self.builds.keys().map(String::as_str).collect();
+        // Compute both before emitting: `observed` borrows `self.builds`, so its
+        // borrow must end before the `emit_*` calls take `&mut self`.
         let edges = dependency_edges(&self.closure_deps, &observed);
+        let causes = root_cause_derivations(&self.closure_deps, &observed);
+        drop(observed);
         self.emit_dependencies(edges);
+        self.emit_root_causes(causes);
     }
 
     /// Broadcast a recomputed edge set only when it differs from the last one.
@@ -440,6 +489,17 @@ impl MonitorState {
         }
         self.last_dependencies = Some(edges.clone());
         self.emit(Delta::DependenciesSet { edges });
+    }
+
+    /// Broadcast a recomputed root-cause set only when it differs from the last,
+    /// mirroring [`emit_dependencies`](Self::emit_dependencies): closure queries
+    /// arrive faster than the classification actually changes.
+    fn emit_root_causes(&mut self, derivations: Vec<String>) {
+        if self.last_root_causes.as_ref() == Some(&derivations) {
+            return;
+        }
+        self.last_root_causes = Some(derivations.clone());
+        self.emit(Delta::RootCausesSet { derivations });
     }
 
     pub fn apply_line(&mut self, line: &str) -> ParsedLine {
@@ -902,6 +962,33 @@ fn dependency_edges(
     edges
 }
 
+/// The built derivations that are *root causes* of this build: those whose entire
+/// transitive input `.drv` closure is cache hits (none of their inputs are
+/// themselves being built). These are what actually changed; every other built
+/// derivation is a forced cascade, since Nix rehashes everything downstream of a
+/// changed input.
+///
+/// A derivation whose closure has not been queried yet cannot be classified, so
+/// it is omitted rather than guessed (the next closure that arrives recomputes
+/// this). Sorted for a stable wire order.
+fn root_cause_derivations(
+    closure_deps: &BTreeMap<String, BTreeSet<String>>,
+    built: &BTreeSet<&str>,
+) -> Vec<String> {
+    let mut causes: Vec<String> = built
+        .iter()
+        .filter(|derivation| {
+            // Only classify once the closure is known; a root has no built input.
+            closure_deps.get(**derivation).is_some_and(|closure| {
+                !closure.iter().any(|input| built.contains(input.as_str()))
+            })
+        })
+        .map(|derivation| (*derivation).to_owned())
+        .collect();
+    causes.sort();
+    causes
+}
+
 /// Whether `text` is the header that precedes Nix's "will be built" derivation
 /// list. Nix uses the plural "these N derivations will be built:" and the
 /// singular "this derivation will be built:"; matching the shared suffix covers
@@ -972,6 +1059,18 @@ pub struct MonitorSnapshot {
     /// `from` directly requires `to`. Derived from `direct_deps` at snapshot
     /// time, restricted to built derivations and transitively reduced.
     pub dependencies: Vec<DerivationEdge>,
+    /// Built derivations whose entire transitive input closure is cache hits, so
+    /// they are the actual *cause* of this build: their own source/inputs changed.
+    /// Every other build is a forced cascade beneath one of these (Nix rehashes
+    /// everything downstream of a changed input). A build whose closure has not
+    /// been queried yet is omitted until it can be classified. Derived at
+    /// snapshot time from the closures and the built set, like `dependencies`.
+    pub root_causes: Vec<String>,
+    /// Per-derivation "what changed" explanations for root causes (e.g. "input
+    /// rustc changed", "source changed", "no prior build to compare"), learned by
+    /// the server diffing each root's `.drv` against its previous build. Keyed by
+    /// derivation path; absent for derivations not yet (or never) explained.
+    pub rebuild_reasons: BTreeMap<String, String>,
     pub exit_code: Option<i32>,
     pub finished: bool,
 }
@@ -1704,6 +1803,25 @@ mod tests {
             dependency_edges(&closure, &rendered),
             vec![edge("a", "b"), edge("b", "c")]
         );
+    }
+
+    #[test]
+    fn root_causes_are_builds_with_no_built_input() {
+        // a -> b -> c, all being built; only c (no built input) is the root
+        // cause. a and b are forced cascades. d has no closure recorded yet, so
+        // it is omitted (not yet classifiable) rather than wrongly called a root.
+        let closure = closures(&[("a", &["b", "c"]), ("b", &["c"]), ("c", &[])]);
+        let built = BTreeSet::from(["a", "b", "c", "d"]);
+        assert_eq!(root_cause_derivations(&closure, &built), vec!["c".to_owned()]);
+    }
+
+    #[test]
+    fn root_causes_ignore_cached_inputs() {
+        // a's only input `x` is not being built (a cache hit), so a is a root
+        // cause even though its closure is non-empty.
+        let closure = closures(&[("a", &["x"])]);
+        let built = BTreeSet::from(["a"]);
+        assert_eq!(root_cause_derivations(&closure, &built), vec!["a".to_owned()]);
     }
 
     #[test]

--- a/packages/nix/nix-web-monitor/server/site/src/App.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/App.svelte
@@ -201,6 +201,8 @@
         <BuildTable
           builds={snapshot.builds}
           dependencies={snapshot.dependencies}
+          rootCauses={snapshot.rootCauses}
+          rebuildReasons={snapshot.rebuildReasons}
           command={snapshot.command}
           expected={snapshot.expected}
           finished={snapshot.finished}

--- a/packages/nix/nix-web-monitor/server/site/src/components/BuildTable.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/components/BuildTable.svelte
@@ -16,6 +16,13 @@
   type Props = {
     builds: BuildNode[];
     dependencies: DerivationEdge[];
+    /// Root-cause derivations: builds whose whole input closure is cache hits, so
+    /// their own inputs changed. Marked with a `cause` badge; every other build
+    /// is a forced cascade beneath one.
+    rootCauses: string[];
+    /// "What changed" per root-cause derivation (path -> reason), shown on those
+    /// rows: the answer to why Nix rebuilt them.
+    rebuildReasons: Record<string, string>;
     /// The Nix invocation, shown as the tree's single root label.
     command: string;
     expected: Record<string, number>;
@@ -33,6 +40,8 @@
   const {
     builds,
     dependencies,
+    rootCauses,
+    rebuildReasons,
     command,
     expected,
     finished,
@@ -42,6 +51,9 @@
   }: Props = $props();
 
   const now = useNow();
+
+  /// Root-cause derivations as a set for O(1) per-row lookup.
+  const rootCauseSet = $derived(new Set(rootCauses));
 
   /// Running first, then failed, stopped, and finally succeeded; ties broken by
   /// derivation path. Shared by the flat list and the dependency tree so both
@@ -254,6 +266,8 @@
           isLast={index === tree.roots.length - 1}
           isRoot={true}
           ancestors={new Set()}
+          rootCauses={rootCauseSet}
+          {rebuildReasons}
         />
       {:else}
         <div class="empty wide">{emptyLabel}</div>
@@ -287,6 +301,11 @@
                 >{shortHash(parts)}</span
               >{/if}{#if build.contentAddressed}<span class="drv-ca"
                 title="content-addressed: Nix resolved this derivation before building it">ca</span
+              >{/if}{#if rootCauseSet.has(build.derivation)}<span class="drv-cause"
+                title="root cause: this derivation's own inputs changed (its whole input closure is cache hits), so it is why this build happened">cause</span
+              >{/if}{#if rootCauseSet.has(build.derivation) && (rebuildReasons[build.derivation] ?? '').length > 0}<span
+                class="drv-reason" title="why this rebuilt: {rebuildReasons[build.derivation]}"
+                >{rebuildReasons[build.derivation]}</span
               >{/if}
           </div>
           <div class="where" class:remote={isRemote(build.host)} title={whereLabel(build.host)}>

--- a/packages/nix/nix-web-monitor/server/site/src/components/BuildTree.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/components/BuildTree.svelte
@@ -26,6 +26,13 @@
     /// Derivations on the path from the root to here. Guards against re-entering
     /// a node already above us, which a malformed cyclic edge set could induce.
     ancestors: ReadonlySet<string>;
+    /// Root-cause derivations (their whole input closure is cache hits, so they
+    /// are what actually changed). Such rows get a `cause` badge; everything else
+    /// is a forced cascade beneath one.
+    rootCauses: ReadonlySet<string>;
+    /// "What changed" per derivation (derivation path -> reason), shown on
+    /// root-cause rows: the answer to why Nix rebuilt this.
+    rebuildReasons: Record<string, string>;
   };
 
   const {
@@ -40,8 +47,15 @@
     guideLines,
     isLast,
     isRoot,
-    ancestors
+    ancestors,
+    rootCauses,
+    rebuildReasons
   }: Props = $props();
+
+  const isRootCause = $derived(rootCauses.has(drv));
+  /// "What changed" for this row, shown only on root causes (cascades are
+  /// explained by sitting under a root in the tree).
+  const reason = $derived(isRootCause ? (rebuildReasons[drv] ?? '') : '');
 
   const isCommandRoot = $derived(drv === ROOT_SENTINEL);
   const node = $derived(tree.nodeByDrv.get(drv));
@@ -88,6 +102,11 @@
     <span class="root-stats">
       {#if summary.failed > 0}<span class="stat failed">{summary.failed} failed</span>{/if}
       {#if summary.running > 0}<span class="stat running">{summary.running} running</span>{/if}
+      {#if rootCauses.size > 0}<span
+          class="stat cause"
+          title="root causes: builds whose own inputs changed; every other build is a forced cascade beneath one"
+          >{rootCauses.size} cause{rootCauses.size === 1 ? '' : 's'}</span
+        >{/if}
       <span class="stat done" title="succeeded / total">
         {summary.succeeded}<span class="stat-sep">/</span>{summary.total}
       </span>
@@ -142,6 +161,8 @@
           class="drv-version">{parts.version}</span
         >{/if}{#if parts.hash.length > 0}<span class="drv-hash">{shortHash(parts)}</span
         >{/if}{#if node.contentAddressed}<span class="drv-ca" title="content-addressed: Nix resolved this derivation before building it">ca</span
+        >{/if}{#if isRootCause}<span class="drv-cause" title="root cause: this derivation's own inputs changed (its whole input closure is cache hits), so it is why this build happened">cause</span
+        >{/if}{#if reason.length > 0}<span class="drv-reason" title="why this rebuilt: {reason}">{reason}</span
         >{/if}
     </span>
     {#if node.status !== 'planned'}
@@ -178,6 +199,8 @@
       isLast={index === children.length - 1}
       isRoot={false}
       ancestors={childAncestors}
+      {rootCauses}
+      {rebuildReasons}
     />
   {/each}
 {/if}

--- a/packages/nix/nix-web-monitor/server/site/src/lib/monitor-transport.ts
+++ b/packages/nix/nix-web-monitor/server/site/src/lib/monitor-transport.ts
@@ -41,6 +41,8 @@ type Working = {
   daemon: MonitorSnapshot['daemon'];
   expected: Record<string, number>;
   dependencies: DerivationEdge[];
+  rootCauses: string[];
+  rebuildReasons: Record<string, string>;
   exitCode: number | null;
   finished: boolean;
 };
@@ -64,6 +66,8 @@ function createWorking(): Working {
     },
     expected: {},
     dependencies: [],
+    rootCauses: [],
+    rebuildReasons: {},
     exitCode: null,
     finished: false
   };
@@ -108,6 +112,12 @@ export function applyDelta(working: Working, delta: Delta): Working {
     case 'dependenciesSet':
       working.dependencies = delta.edges;
       return working;
+    case 'rootCausesSet':
+      working.rootCauses = delta.derivations;
+      return working;
+    case 'rebuildReasonSet':
+      working.rebuildReasons = { ...working.rebuildReasons, [delta.derivation]: delta.reason };
+      return working;
     case 'finished':
       working.exitCode = delta.exitCode;
       working.finished = true;
@@ -127,6 +137,8 @@ function fromSnapshot(snapshot: MonitorSnapshot): Working {
     daemon: snapshot.daemon,
     expected: { ...snapshot.expected },
     dependencies: snapshot.dependencies,
+    rootCauses: snapshot.rootCauses,
+    rebuildReasons: { ...snapshot.rebuildReasons },
     exitCode: snapshot.exitCode,
     finished: snapshot.finished
   };
@@ -164,6 +176,8 @@ export function projectSnapshot(working: Working): MonitorSnapshot {
     daemon: working.daemon,
     expected: { ...working.expected },
     dependencies: working.dependencies,
+    rootCauses: working.rootCauses,
+    rebuildReasons: { ...working.rebuildReasons },
     exitCode: working.exitCode,
     finished: working.finished
   };

--- a/packages/nix/nix-web-monitor/server/site/src/lib/types.ts
+++ b/packages/nix/nix-web-monitor/server/site/src/lib/types.ts
@@ -124,6 +124,15 @@ export const snapshotSchema = v.object({
   daemon: daemonInfoSchema,
   expected: v.record(v.string(), v.number()),
   dependencies: v.array(derivationEdgeSchema),
+  /// Built derivations that are root *causes*: their whole input closure is
+  /// cache hits, so their own source/inputs changed. Every other build is a
+  /// forced cascade beneath one of these. Used to mark which builds are the
+  /// actual triggers vs. dragged-along rebuilds.
+  rootCauses: v.array(v.string()),
+  /// "What changed" per root-cause derivation: derivation path -> human reason
+  /// (e.g. "input rustc changed", "source changed", "no prior build to compare").
+  /// Computed by the server diffing each root's `.drv` against its previous build.
+  rebuildReasons: v.record(v.string(), v.string()),
   exitCode: v.nullable(v.number()),
   finished: v.boolean()
 });
@@ -143,6 +152,8 @@ export const deltaSchema = v.variant('type', [
   v.object({ type: v.literal('expectedSet'), name: v.string(), value: v.number() }),
   v.object({ type: v.literal('errorAppend'), message: v.string() }),
   v.object({ type: v.literal('dependenciesSet'), edges: v.array(derivationEdgeSchema) }),
+  v.object({ type: v.literal('rootCausesSet'), derivations: v.array(v.string()) }),
+  v.object({ type: v.literal('rebuildReasonSet'), derivation: v.string(), reason: v.string() }),
   v.object({ type: v.literal('finished'), exitCode: v.nullable(v.number()) })
 ]);
 
@@ -192,6 +203,8 @@ export const EMPTY_SNAPSHOT: MonitorSnapshot = Object.freeze({
   },
   expected: {},
   dependencies: [],
+  rootCauses: [],
+  rebuildReasons: {},
   exitCode: null,
   finished: false
 });

--- a/packages/nix/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix/nix-web-monitor/server/site/src/style.css
@@ -974,6 +974,37 @@ main.dragging-v .splitter-v::after {
   letter-spacing: 0.05em;
 }
 
+/* Marks a root-cause derivation: its whole input closure is cache hits, so its
+ * own inputs changed and it is *why* this build happened. Every other build is a
+ * forced cascade beneath one of these. Filled accent so the triggers stand out
+ * from the cascade in a wall of rebuilding rows. */
+.drv-cause {
+  margin-left: 0.5ch;
+  padding: 0 0.3ch;
+  border-radius: 3px;
+  font-size: 0.85em;
+  background: var(--accent);
+  color: var(--bg);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.stat.cause {
+  color: var(--accent);
+}
+
+/* The "what changed" reason on a root-cause row (e.g. "input rustc changed").
+ * Muted accent text so it reads as an annotation, not a badge. */
+.drv-reason {
+  margin-left: 0.5ch;
+  font-size: 0.85em;
+  color: var(--accent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 32ch;
+}
+
 .where {
   font-size: inherit !important;
   color: var(--muted);

--- a/packages/nix/nix-web-monitor/server/src/dependencies.rs
+++ b/packages/nix/nix-web-monitor/server/src/dependencies.rs
@@ -9,6 +9,7 @@ use tokio::sync::{RwLock, Semaphore, broadcast, mpsc};
 use tokio::task::JoinSet;
 
 use crate::broadcast_deltas;
+use crate::reasons::resolve_reason;
 
 /// Suffix Nix uses for derivation files. A derivation's closure also contains
 /// source paths; only the `.drv` entries are nodes in the build DAG.
@@ -87,8 +88,27 @@ async fn resolve_one(
         }
     };
 
-    monitor.write().await.record_closure(derivation, closure);
-    broadcast_deltas(monitor, deltas).await
+    monitor.write().await.record_closure(derivation.clone(), closure);
+    broadcast_deltas(monitor, deltas).await?;
+
+    // If this derivation is a root cause (all its inputs are cache hits, so it is
+    // the actual trigger), explain *what* changed by diffing it against its
+    // previous build. Cascades need no reason: they sit under a root in the tree.
+    //
+    // Detach it: reason resolution runs extra `nix` queries and is purely
+    // best-effort, so it must not hold this dependency-query permit, nor delay
+    // the resolver's completion -- `run_nix_command` waits on the resolver before
+    // emitting `finished`, so awaiting reasons here could hang the UI / a
+    // `--exit-when-done` run behind a slow store query. The spawned task writes
+    // the reason and broadcasts it whenever it lands (or is dropped at exit).
+    if monitor.read().await.is_root_cause(&derivation) {
+        let monitor = Arc::clone(monitor);
+        let deltas = deltas.clone();
+        tokio::spawn(async move {
+            let _ = resolve_reason(derivation, &monitor, &deltas).await;
+        });
+    }
+    Ok(())
 }
 
 /// Transitive input derivations of `derivation`, via the decade-stable

--- a/packages/nix/nix-web-monitor/server/src/main.rs
+++ b/packages/nix/nix-web-monitor/server/src/main.rs
@@ -27,6 +27,7 @@ use tower_http::services::ServeDir;
 
 mod daemon;
 mod dependencies;
+mod reasons;
 use daemon::run_daemon_probe;
 use dependencies::resolve_dependencies;
 
@@ -108,6 +109,10 @@ async fn main() -> Result<()> {
         .get_matches();
     let args = Args::from_arg_matches(&matches).unwrap_or_else(|error| error.exit());
     validate_site_dir(&args.site_dir)?;
+
+    // Record startup before any build runs: the "what changed" reason baseline
+    // uses it to exclude outputs registered during this run (see `reasons`).
+    reasons::record_start_time();
 
     let index_html =
         Bytes::from(std::fs::read(args.site_dir.join("index.html")).context("reading index.html")?);

--- a/packages/nix/nix-web-monitor/server/src/reasons.rs
+++ b/packages/nix/nix-web-monitor/server/src/reasons.rs
@@ -1,0 +1,399 @@
+//! "What changed" explanations for root-cause derivations.
+//!
+//! The build stream says *that* a derivation rebuilt, never *why* -- and in Nix a
+//! tiny input change silently rehashes everything downstream, so a rebuild often
+//! looks unprovoked. For a root cause (its whole input closure is cache hits, so
+//! it is the actual trigger) we diff its `.drv` against the *previous* build of
+//! the same output and report what differs: "input rustc changed", "source
+//! changed", etc. That is the answer to "why did Nix rebuild this".
+//!
+//! The baseline is the `.drv` that built the currently-installed output of the
+//! same name (found via `nix-store --query --deriver`), so an explanation is
+//! available on the very first run with no history file. The store is scanned
+//! once and the name->paths index cached for the process.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use nix_web_monitor_parser::MonitorState;
+use serde_json::Value;
+use tokio::process::Command;
+use tokio::sync::{OnceCell, RwLock, broadcast};
+
+use crate::broadcast_deltas;
+
+/// How many changed input names to name before summarising the rest as "+N more",
+/// so a reason line stays scannable.
+const MAX_NAMED: usize = 3;
+
+/// Unix-seconds when the monitor started, recorded once at startup. Candidate
+/// baselines registered at or after this are outputs produced by the *current*
+/// run -- in particular the very build being explained, which for a
+/// content-addressed derivation registers under its *resolved* deriver (not the
+/// original drv the row is keyed by) and would otherwise be mistaken for the
+/// previous build. Excluding them keeps the baseline a genuinely prior build.
+static START_TIME: std::sync::OnceLock<i64> = std::sync::OnceLock::new();
+
+/// Record the monitor's start time. Call once at startup, before any build runs.
+pub fn record_start_time() {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .and_then(|elapsed| i64::try_from(elapsed.as_secs()).ok())
+        .unwrap_or(i64::MAX);
+    let _ = START_TIME.set(now);
+}
+
+/// The start-time cutoff; `i64::MAX` (exclude nothing) when unset, e.g. in tests.
+fn start_cutoff() -> i64 {
+    START_TIME.get().copied().unwrap_or(i64::MAX)
+}
+
+/// Compute a "what changed" reason for one root-cause derivation and record it.
+/// Best-effort: a query failure leaves the row unexplained rather than aborting.
+pub async fn resolve_reason(
+    derivation: String,
+    monitor: &Arc<RwLock<MonitorState>>,
+    deltas: &broadcast::Sender<Bytes>,
+) -> Result<()> {
+    let reason = match reason_for(&derivation).await {
+        Ok(reason) => reason,
+        Err(error) => {
+            eprintln!("nix-web-monitor: reason query failed for {derivation}: {error:#}");
+            return Ok(());
+        }
+    };
+    monitor.write().await.set_rebuild_reason(derivation, reason);
+    broadcast_deltas(monitor, deltas).await
+}
+
+/// The "what changed" explanation for `drv`: find the previous build of the same
+/// output and diff the two `.drv`s.
+async fn reason_for(drv: &str) -> Result<String> {
+    let Some(name) = output_name(drv) else {
+        return Ok("rebuilt".to_owned());
+    };
+    let Some(baseline) = previous_drv(drv, name).await? else {
+        return Ok("no prior build to compare".to_owned());
+    };
+    diff_reason(drv, &baseline).await
+}
+
+/// The output name of a store derivation path: `/nix/store/<32-hash>-<name>.drv`
+/// -> `<name>`. `None` if it does not have that shape. Shares the basename parse
+/// with [`store_path_name`] (the `.drv` is just an extra suffix).
+fn output_name(drv: &str) -> Option<&str> {
+    store_path_name(drv.strip_suffix(".drv")?)
+}
+
+/// Whether a store path or basename names a derivation (ends in `.drv`). Uses the
+/// path extension (case-insensitive) rather than a `.ends_with(".drv")` literal,
+/// which clippy's pedantic lint rejects.
+fn is_drv(path: &str) -> bool {
+    std::path::Path::new(path)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("drv"))
+}
+
+/// The `.drv` that built the previous build of the same `name` to diff against:
+/// among installed outputs of that exact name, the deriver of the one *most
+/// recently registered* in the store (excluding `current`). Picking the newest
+/// (not an arbitrary match) makes the diff reflect the build you most likely had
+/// before, when several old versions of a name are still in the store. `None`
+/// when nothing else of that name is installed (a genuinely new derivation).
+///
+/// Uses a single batched `nix path-info` for all candidates: a frequently-built
+/// name can have hundreds of same-name outputs in the store, so a per-candidate
+/// query would spawn hundreds of subprocesses.
+async fn previous_drv(current: &str, name: &str) -> Result<Option<String>> {
+    let outputs = store_outputs_named(name).await?;
+    if outputs.is_empty() {
+        return Ok(None);
+    }
+    let cutoff = start_cutoff();
+    Ok(path_infos(&outputs)
+        .await?
+        .into_iter()
+        // `registered < cutoff` drops this-run outputs (e.g. the CA build's own
+        // resolved-deriver output) so the baseline is a genuinely prior build.
+        .filter(|candidate| {
+            candidate.deriver != current && is_drv(&candidate.deriver) && candidate.registered < cutoff
+        })
+        .max_by_key(|candidate| candidate.registered)
+        .map(|candidate| candidate.deriver))
+}
+
+/// One candidate baseline: a prior build's deriver `.drv` and its store
+/// registration time (used to pick the newest).
+struct Candidate {
+    deriver: String,
+    registered: i64,
+}
+
+/// A [`Candidate`] for each store path that records a deriver, from a single
+/// `nix path-info --json` over all `paths` (one subprocess, not one per path).
+/// Handles both the array and path-keyed-object shapes the command has used
+/// across Nix versions; a failed query yields an empty list (best-effort:
+/// produce no reason rather than error the build view).
+async fn path_infos(paths: &[String]) -> Result<Vec<Candidate>> {
+    let out = Command::new("nix")
+        .args(["path-info", "--json"])
+        .args(paths)
+        .output()
+        .await
+        .context("spawning nix path-info")?;
+    if !out.status.success() {
+        return Ok(Vec::new());
+    }
+    let json: Value = serde_json::from_slice(&out.stdout).unwrap_or_default();
+    let entries: Vec<&Value> = match &json {
+        Value::Array(items) => items.iter().collect(),
+        Value::Object(map) => map.values().collect(),
+        _ => return Ok(Vec::new()),
+    };
+    Ok(entries
+        .into_iter()
+        .filter_map(|entry| {
+            let deriver = entry.get("deriver")?.as_str()?.to_owned();
+            let registered = entry
+                .get("registrationTime")
+                .and_then(Value::as_i64)
+                .unwrap_or(i64::MIN);
+            Some(Candidate { deriver, registered })
+        })
+        .collect())
+}
+
+/// Store output paths (non-`.drv`) whose output name is *exactly* `name`, from a
+/// cached one-time scan of `/nix/store`. Exact-name (not suffix) match: many
+/// names are dash-suffixes of others (`cargo-package-serde` vs `serde`), so a
+/// suffix match would diff the root cause against an unrelated derivation. The
+/// index is taken once and reused: it only needs the *pre-existing* outputs, so
+/// a snapshot is correct.
+async fn store_outputs_named(name: &str) -> Result<Vec<String>> {
+    static INDEX: OnceCell<Vec<String>> = OnceCell::const_new();
+    let entries = INDEX
+        .get_or_try_init(|| async {
+            let mut names = Vec::new();
+            let mut dir = tokio::fs::read_dir("/nix/store")
+                .await
+                .context("reading /nix/store")?;
+            while let Some(entry) = dir.next_entry().await.context("scanning /nix/store")? {
+                if let Ok(name) = entry.file_name().into_string()
+                    && !is_drv(&name)
+                {
+                    names.push(name);
+                }
+            }
+            Ok::<_, anyhow::Error>(names)
+        })
+        .await?;
+    Ok(entries
+        .iter()
+        .filter(|basename| store_path_name(basename) == Some(name))
+        .map(|basename| format!("/nix/store/{basename}"))
+        .collect())
+}
+
+/// Diff two derivations via `nix derivation show` and name what changed, in
+/// priority order: a changed input derivation (the usual culprit, e.g. a bumped
+/// `rustc`), then a changed source, then changed build env.
+async fn diff_reason(current: &str, baseline: &str) -> Result<String> {
+    let out = Command::new("nix")
+        .args(["derivation", "show", current, baseline])
+        .output()
+        .await
+        .context("spawning nix derivation show")?;
+    if !out.status.success() {
+        return Ok("rebuilt".to_owned());
+    }
+    let json: Value = serde_json::from_slice(&out.stdout).context("parsing derivation show")?;
+    let obj = json.as_object().context("derivation show is not an object")?;
+    // CA derivations can key by a resolved path, so when the requested key is
+    // absent fall back to the *other* entry by key identity (not map-iteration
+    // order, which could pick the baseline for both and compare it with itself).
+    let cur = obj
+        .get(current)
+        .or_else(|| obj.iter().find(|(key, _)| key.as_str() != baseline).map(|(_, value)| value));
+    let base = obj
+        .get(baseline)
+        .or_else(|| obj.iter().find(|(key, _)| key.as_str() != current).map(|(_, value)| value));
+    let (Some(cur), Some(base)) = (cur, base) else {
+        return Ok("rebuilt".to_owned());
+    };
+
+    let changed = changed_input_names(cur, base);
+    if !changed.is_empty() {
+        return Ok(format!("input {} changed", summarise(&changed)));
+    }
+    // Sources are compared by full store path (not name): the path encodes the
+    // content hash, so a same-named source whose *content* changed (the common
+    // case -- a project's own `src`) shows up as a different path here.
+    if path_set(set_field(cur, "inputSrcs")) != path_set(set_field(base, "inputSrcs")) {
+        return Ok("source changed".to_owned());
+    }
+    let env_keys = changed_env_keys(cur, base);
+    if !env_keys.is_empty() {
+        return Ok(format!("build env changed ({})", summarise(&env_keys)));
+    }
+    Ok("rebuilt (inputs identical; output was not cached)".to_owned())
+}
+
+/// Names of input derivations whose contributing `.drv` differs between the two
+/// derivations -- the inputs that actually changed. Compared by output *name* so
+/// a hash bump on the same logical input is what registers.
+fn changed_input_names(cur: &Value, base: &Value) -> BTreeSet<String> {
+    let cur_inputs = inputs_by_name(cur);
+    let base_inputs = inputs_by_name(base);
+    let mut changed = BTreeSet::new();
+    for (name, drvs) in &cur_inputs {
+        if base_inputs.get(name) != Some(drvs) {
+            changed.insert(name.clone());
+        }
+    }
+    for name in base_inputs.keys() {
+        if !cur_inputs.contains_key(name) {
+            changed.insert(name.clone());
+        }
+    }
+    changed
+}
+
+/// Map each input derivation's output *name* to the set of input `.drv` paths
+/// contributing it, from a derivation's `inputDrvs` object.
+fn inputs_by_name(drv: &Value) -> BTreeMap<String, BTreeSet<String>> {
+    let mut by_name: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let Some(inputs) = drv.get("inputDrvs").and_then(Value::as_object) else {
+        return by_name;
+    };
+    for path in inputs.keys() {
+        if let Some(name) = output_name(path) {
+            by_name.entry(name.to_owned()).or_default().insert(path.clone());
+        }
+    }
+    by_name
+}
+
+/// The string array at `field`, or empty.
+fn set_field<'a>(drv: &'a Value, field: &str) -> &'a [Value] {
+    drv.get(field).and_then(Value::as_array).map_or(&[], Vec::as_slice)
+}
+
+/// The set of full store paths in a JSON string array. Full paths (not names):
+/// a store path encodes its content hash, so comparing paths detects a content
+/// change even when the name is unchanged.
+fn path_set(paths: &[Value]) -> BTreeSet<&str> {
+    paths.iter().filter_map(Value::as_str).collect()
+}
+
+/// The `<name>` of a `/nix/store/<hash>-<name>` path (no `.drv` stripping).
+fn store_path_name(path: &str) -> Option<&str> {
+    path.rsplit('/').next()?.get(33..).filter(|name| !name.is_empty())
+}
+
+/// Build-environment keys whose value differs between the two derivations.
+fn changed_env_keys(cur: &Value, base: &Value) -> BTreeSet<String> {
+    let empty = serde_json::Map::new();
+    let cur_env = cur.get("env").and_then(Value::as_object).unwrap_or(&empty);
+    let base_env = base.get("env").and_then(Value::as_object).unwrap_or(&empty);
+    let mut changed = BTreeSet::new();
+    for (key, value) in cur_env {
+        if base_env.get(key) != Some(value) {
+            changed.insert(key.clone());
+        }
+    }
+    for key in base_env.keys() {
+        if !cur_env.contains_key(key) {
+            changed.insert(key.clone());
+        }
+    }
+    changed
+}
+
+/// Render up to [`MAX_NAMED`] names, then "+N more", so a reason stays short.
+fn summarise(names: &BTreeSet<String>) -> String {
+    let shown: Vec<&str> = names.iter().take(MAX_NAMED).map(String::as_str).collect();
+    let rest = names.len().saturating_sub(shown.len());
+    if rest == 0 {
+        shown.join(", ")
+    } else {
+        format!("{}, +{rest} more", shown.join(", "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_name_strips_hash_and_drv() {
+        assert_eq!(
+            output_name("/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bitflags-1.3.2.drv"),
+            Some("bitflags-1.3.2")
+        );
+        assert_eq!(output_name("/nix/store/short.drv"), None);
+        assert_eq!(output_name("not-a-store-path"), None);
+    }
+
+    #[test]
+    fn source_content_change_is_detected_by_path() {
+        // Same source name `src` but a different store hash (content changed): the
+        // path sets must differ so "source changed" is reported, not collapsed.
+        let cur = serde_json::json!({
+            "inputSrcs": ["/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-src"]
+        });
+        let base = serde_json::json!({
+            "inputSrcs": ["/nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-src"]
+        });
+        assert_ne!(
+            path_set(set_field(&cur, "inputSrcs")),
+            path_set(set_field(&base, "inputSrcs"))
+        );
+    }
+
+    #[test]
+    fn changed_inputs_detects_a_bumped_dependency() {
+        // Same logical input `rustc` but a different `.drv` hash -> changed.
+        let cur = serde_json::json!({
+            "inputDrvs": {
+                "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-rustc-1.90.drv": {},
+                "/nix/store/cccccccccccccccccccccccccccccccc-libc-2.40.drv": {}
+            }
+        });
+        let base = serde_json::json!({
+            "inputDrvs": {
+                "/nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-rustc-1.89.drv": {},
+                "/nix/store/cccccccccccccccccccccccccccccccc-libc-2.40.drv": {}
+            }
+        });
+        assert_eq!(
+            changed_input_names(&cur, &base),
+            BTreeSet::from(["rustc-1.90".to_owned(), "rustc-1.89".to_owned()])
+        );
+    }
+
+    #[test]
+    fn store_path_name_distinguishes_dash_suffixed_names() {
+        // The baseline lookup matches on this exact name, so `serde` must NOT be
+        // considered the same output as `cargo-package-serde` (a real collision
+        // shape in the store) -- otherwise the root cause is diffed against an
+        // unrelated derivation.
+        let h = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        assert_eq!(
+            store_path_name(&format!("/nix/store/{h}-serde-1.0.0")),
+            Some("serde-1.0.0")
+        );
+        assert_eq!(
+            store_path_name(&format!("/nix/store/{h}-cargo-package-serde-1.0.0")),
+            Some("cargo-package-serde-1.0.0")
+        );
+    }
+
+    #[test]
+    fn summarise_caps_the_list() {
+        let names = BTreeSet::from(["a", "b", "c", "d", "e"].map(ToOwned::to_owned));
+        assert_eq!(summarise(&names), "a, b, c, +2 more");
+    }
+}


### PR DESCRIPTION
## What

Make `nix-web-monitor` (nwm) answer **why** a derivation rebuilt — the thing Nix never tells you, where a tiny input change silently rehashes everything downstream and a rebuild looks unprovoked.

Two layers:

- **Root cause vs cascade.** A built derivation whose entire transitive input closure is cache hits is the actual *trigger*; everything reachable above it is a forced cascade. Computed server-side in the parser snapshot from the closures nwm already queries (`nix-store --query --requisites`), like the dependency DAG. Shown as a blue **`cause`** badge + a "N causes" count on the root.
- **What changed.** For each root cause, the server (`reasons.rs`) finds the *previous* build of the same output — the `.drv` behind the currently-installed same-name output (`nix-store --query --deriver`; store scanned once, cached, so it works on the first run) — and `nix derivation show`-diffs the two: a changed `inputDrvs` → "input rustc changed", changed `inputSrcs` → "source changed", changed `env` → "build env changed". Shown inline on the row.

So out of 200 rebuilding rows, a human sees *these 3* are causes and they say *`input rustc changed`* — one toolchain bump rebuilt the world.

All work is server-side nix CLI queries off the parse path (bounded concurrency); the parser does pure classification; the browser renders. New deltas `RootCausesSet` / `RebuildReasonSet`; new snapshot fields `rootCauses` / `rebuildReasons`.

## Validation

- `nix build .#nix-web-monitor` passes (Rust server+parser compile; Svelte site passes svelte-check + eslint + vite build).
- Unit tests: root-cause classification, `.drv` diff (changed input by name), exact-name baseline matching.
- Adversarial review pass; fixed a confirmed bug (baseline matched by name *suffix* → could diff against an unrelated `cargo-package-<x>` style output; now exact-name).

🤖 Drafted with Claude Code (Opus).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show root cause derivations and rebuild reasons in nix-web-monitor
> - Adds a `reasons.rs` module to the server that, for each root-cause derivation, diffs the current `.drv` against the most recent prior build to produce a human-readable reason (e.g. "input X changed", "source changed", "build env changed").
> - Extends `MonitorState` in [lib.rs](https://github.com/indexable-inc/index/pull/1329/files#diff-88f540c220f609c6ee81a458c740f318e2505d1bfb3bddc5ac4aef399dedcc6a) with `root_cause_derivations` computation and `set_rebuild_reason`, emitting new `RootCausesSet` and `RebuildReasonSet` delta frames to clients.
> - Updates the client transport, schema, and Svelte UI components ([BuildTable.svelte](https://github.com/indexable-inc/index/pull/1329/files#diff-c0f6c0efe878d902b8ed1bf17027827d03b4a1d777c0baf84612c412eb3b6064), [BuildTree.svelte](https://github.com/indexable-inc/index/pull/1329/files#diff-17141051a2c195b23342164f47bc29d99b2d976789e78e2940faa7008443a461)) to display a "cause" badge and inline reason text on root-cause rows.
> - Reason resolution is async and best-effort: spawned in a detached task after closure recording, so it never blocks dependency resolution.
> - Risk: `store_outputs_named` scans `/nix/store` on first use (cached); on large stores this may be slow on first root-cause resolution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c870c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->