### PR TITLE
ci: gate images on the system closure, not the OCI tar

### DIFF
--- a/lib/image/oci-layer.nix
+++ b/lib/image/oci-layer.nix
@@ -113,6 +113,13 @@
             pkgs.gnutar
             pkgs.oci-image-builder
           ];
+          # Expose the NixOS system closure the OCI archive is packed from, so
+          # CI can gate on "the image's closure builds" (cheap: a relink over
+          # already-built store paths) without paying the streamLayeredImage
+          # tar+compress pass. The full archive is still this derivation's
+          # output, built only where the bytes are consumed (a registry push at
+          # release). See `imageChecks` in lib/per-system.nix.
+          passthru.toplevel = toplevel;
         }
         ''
           oci-image-builder ${lib.escapeShellArgs (efficiencyArgs ++ [ "${stream.passthru.conf}" ])} "$out"

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1076,16 +1076,30 @@ let
           );
           site-test = siteTests.all;
         };
-        # One check per image OCI archive, built by nix-fast-build in step 1 of
-        # `.#check`. Without this, `.#packages` carries the image derivations
-        # but `.#checks` does not, so blast-radius under-reports any change
-        # that rebuilds every image because the drvPath shift never reaches a
-        # check. The `eval` aggregate at tests/default.nix:3890 only closes
-        # over per-image `extraScript` text, not `config.system.build.toplevel`,
-        # so it stays stable across semantic edits to shared image libs.
-        imageChecks = lib.mapAttrs' (n: v: lib.nameValuePair "image-${n}" v) (
-          discoveredImages // nonNixExampleImages
-        );
+        # One check per image, built by nix-fast-build in step 1 of `.#check`.
+        # Without this, `.#packages` carries the image derivations but `.#checks`
+        # does not, so blast-radius under-reports any change that rebuilds every
+        # image because the drvPath shift never reaches a check. The `eval`
+        # aggregate at tests/default.nix:3890 only closes over per-image
+        # `extraScript` text, not `config.system.build.toplevel`, so it stays
+        # stable across semantic edits to shared image libs.
+        #
+        # For Nix images the check builds the system *closure*
+        # (`passthru.toplevel`), not the OCI tar the package output is. Packing
+        # the closure into a layered, compressed OCI archive
+        # (`streamLayeredImage`) is ~60-100s of deterministic tar+compress per
+        # image, and the gate consumes none of those bytes: it only needs "this
+        # image's closure builds", and the archive is rebuilt at release where a
+        # registry push actually uploads the layers. Gating on the closure keeps
+        # that signal (and gives blast-radius the toplevel drvPath directly)
+        # while dropping the tar pass, which dominated CI wall-clock because the
+        # closure includes frequently-changing packages (e.g. the base-profile
+        # mcp), so any edit re-packed all ~15 archives. Non-Nix example images
+        # (`mkNonNixImage`: a pulled Debian/Ubuntu base) have no Nix toplevel, so
+        # their check stays the assembled archive.
+        imageChecks =
+          lib.mapAttrs' (n: v: lib.nameValuePair "image-${n}" v.toplevel) discoveredImages
+          // lib.mapAttrs' (n: v: lib.nameValuePair "image-${n}" v) nonNixExampleImages;
         # Rust crate prefixes can be overridden in `package.nix` and image
         # names are user-chosen, so a stray collision with an explicit check
         # would otherwise be silently swallowed by the `//` merge. Two pairwise


### PR DESCRIPTION
## What

The per-image CI checks (`image-*` in `.#ciChecks`) built the full OCI tar
(`streamLayeredImage` → `oci-image-builder` → `<name>-oci.tar`). That tar pack
(serialize + compress the whole NixOS closure, then the layer-efficiency pass)
is ~60-100s **per image** and dominated CI wall-clock.

This repoints the checks at the image's **system closure**
(`config.system.build.toplevel`) instead of the tar. The tar is still the
package output, built only at release where a registry push actually consumes
the bytes.

- `lib/image/oci-layer.nix`: expose `passthru.toplevel` on the image derivation.
- `lib/per-system.nix`: `imageChecks` build `.toplevel` for Nix images. Non-Nix
  example images (`mkNonNixImage`, a pulled Debian/Ubuntu base) have no Nix
  toplevel, so their check stays the assembled archive.

## Why

The gate's only signal from an image check is "this image's closure builds." It
does not boot the VM or test any behavior, and the OCI assembly itself is
deterministic plumbing. So building the tar in the gate spends ~60-100s/image to
re-prove something the per-package checks already cover.

Worse, the closure includes frequently-changing packages — notably the
base-profile `mcp` (in **every** image). Editing any mcp file changes every
image's closure, so all ~15 tars re-packed on essentially every commit. Verified
on a Linux builder: a one-line comment in `packages/mcp/ix_notebook_mcp/runtime.py`
changed the `image-minecraft` derivation hash, and a darwin-cask / prompt-only PR
re-packed all 15 images in CI.

Building the closure is a relink over already-built store paths: **~2s** vs
~100s for the tar (measured on a warm Linux builder after an mcp edit).

## Impact

This removes the tar-pack cascade from the gate. Image-touching PRs (and the
merge-queue run) drop from ~3.5-5 min to roughly the eval floor (~1.5-2 min),
about **2-3x**. It does not touch eval cost (genuinely uncacheable across
commits) or the release/registry path.

## Validation

On a Linux builder against this branch:
- Flake evaluates; all `image-*` checks present; no check-name collisions.
- `.#ciChecks.x86_64-linux.image-minecraft.drvPath` now resolves to
  `nixos-system-...drv` (the closure), not `minecraft-oci.tar.drv`.
- `.#packages.x86_64-linux` still carries the image tar derivations (release
  path intact).

---
<sub>Authored with Claude (Opus). Review the eval-cost follow-up separately;
caching can't reduce the remaining eval floor.</sub>


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate image CI checks on the NixOS system closure instead of the OCI archive
> - Adds `passthru.toplevel` to the OCI layer derivation in [oci-layer.nix](https://github.com/indexable-inc/index/pull/1332/files#diff-2f593cc5e1a07acba76a950c1132a06b5d7646750989d806816be811310a32f4), exposing the NixOS system closure as a separate build target.
> - Updates `imageChecks` in [per-system.nix](https://github.com/indexable-inc/index/pull/1332/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) so Nix image checks depend on `v.toplevel` (the closure) rather than `v` (the OCI tar). Non-Nix example image checks are unchanged.
> - Behavioral Change: CI no longer builds the full OCI archive to gate image checks for Nix images — only the system closure is required.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec04fc2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->