### PR TITLE
mcp: open shared dashboard on demand, drop the dead redirect

### DIFF
--- a/docs/mcp/server/overview.md
+++ b/docs/mcp/server/overview.md
@@ -18,7 +18,7 @@ Subcommands (`cli.py:49-81`):
 | --- | --- |
 | `serve` | run the MCP server (default command, `cli.py:84`). `--http [ADDR]` serves streamable HTTP instead of stdio; `--session FILE` makes the store a persistent notebook; `--workdir DIR` sets the kernel cwd. |
 | `notebook [FILE]` | the engine alone (kernel + dashboard + optional session file, no MCP transport); `transport="none"` (`cli.py:294`). The same engine the MCP server is one client of. |
-| `dashboard` | print and open the running server's dashboard URL, read from `runtime_dir()/dashboard-url` (`cli.py:546`). |
+| `dashboard` | open the one shared dashboard UI, starting it if needed (`_dashboard`). Reuses a running hub recorded in `runtime_dir()/hub.json` (`config.live_hub`, port-probed and pid-checked) or spawns one detached on a stable port (8080, `IX_DASH_HUB_PORT`); `--no-open` prints the URL without opening a browser. |
 | `requirements` | report each external credential as present (and from where) or missing (and the remedy); exits non-zero if any is missing (`cli.py:89`). See [requirements](#credentials-requirements). |
 | `eval EXPR` / `exec SRC` | run one expression/statements on a throwaway kernel via `jupyter_client.start_new_kernel` (`cli.py:557`); not the shared kernel. |
 

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1946,6 +1946,219 @@ let
         mkdir -p "$out"
       '';
 
+  # Exercises the shared-dashboard launcher logic: live_hub() ignores a missing
+  # or stale (dead-port) hub-state file and accepts a live one, and the data
+  # API's `/` landing page names `ix-mcp dashboard` instead of redirecting to a
+  # dead hub port. This is the "no million dashboards" reuse contract plus the
+  # dead-redirect fix, both pure Python (real loopback sockets, no `dashboard`
+  # binary), so the sandbox runs it.
+  dashboardLauncherTest = pkgs.writeText "ix-mcp-dashboard-launcher-test.py" ''
+    import asyncio
+    import json
+    import os
+    import socket
+    import tempfile
+    import threading
+    import time
+    from pathlib import Path
+
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from ix_notebook_mcp import config, store
+    from ix_notebook_mcp.dashboard import build_app, landing_html
+
+    state = config.hub_state_path()
+
+    # No state file -> no hub (and no socket probe even happens).
+    state.unlink(missing_ok=True)
+    assert config.live_hub() is None, "missing state must read as no hub"
+
+    # Stale state: a record whose port has nothing listening is ignored.
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    dead = probe.getsockname()[1]
+    probe.close()
+    state.write_text(json.dumps({"pid": 1, "host": "0.0.0.0", "port": dead, "url": f"http://x:{dead}/"}))
+    assert config.port_open(dead) is False, "closed port must not read as open"
+    assert config.live_hub() is None, "stale state (dead port) must read as no hub"
+
+    # Live state: a record whose port is accepting connections is reused.
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", 0))
+    # Backlog must exceed the probes below: each port_open leaves a completed but
+    # un-accepted connection, so listen(1) would make the second probe time out.
+    srv.listen(16)
+    live = srv.getsockname()[1]
+    url = f"http://join.example:{live}/"
+    state.write_text(json.dumps({"pid": 1, "host": "0.0.0.0", "port": live, "url": url}))
+    assert config.port_open(live) is True, "listening port must read as open"
+    got = config.live_hub()
+    assert got is not None and got["port"] == live and got["url"] == url, got
+
+    # Dead pid: even with a live listener on the recorded port (port reuse by an
+    # unrelated service), a dead recorded pid means the file is stale -> no hub.
+    gone = os.fork()
+    if gone == 0:
+        os._exit(0)
+    os.waitpid(gone, 0)  # reap so the pid is truly dead
+    state.write_text(json.dumps({"pid": gone, "host": "127.0.0.1", "port": live, "url": url}))
+    assert config.live_hub() is None, "stale state (dead pid) must read as no hub"
+    srv.close()
+    state.unlink(missing_ok=True)
+
+    # _bind_ip hands the Rust hub a concrete, non-wildcard IP literal: IPs pass
+    # through, names resolve, and a wildcard is refused (mapped to loopback) so the
+    # board never binds every NIC.
+    from ix_notebook_mcp import cli
+    assert cli._bind_ip("127.0.0.1") == "127.0.0.1"
+    assert cli._bind_ip("localhost") == "127.0.0.1"
+    assert cli._bind_ip("0.0.0.0") == "127.0.0.1"  # noqa: S104 -- asserting the wildcard refusal
+    assert cli._bind_ip("::") == "127.0.0.1"
+    assert cli._bind_ip("::1") == "::1"  # a non-wildcard IPv6 literal passes through
+
+    # _host_arg brackets IPv6 for the binary's host:port and the URL; IPv4/names
+    # are returned raw (Python's own socket calls take the unbracketed host).
+    assert cli._host_arg("127.0.0.1") == "127.0.0.1"
+    assert cli._host_arg("::1") == "[::1]"
+
+    # The data API landing page points at the command, never a bare redirect.
+    html = landing_html()
+    assert "ix-mcp dashboard" in html, html
+    assert "/api/jobs" in html, html
+
+    # A non-numeric IX_DASH_HUB_PORT must not crash the launcher: fall back to 8080.
+    os.environ["IX_DASH_HUB_PORT"] = "not-a-port"
+    assert cli._stable_hub_port() == 8080
+    os.environ["IX_DASH_HUB_PORT"] = "9191"
+    assert cli._stable_hub_port() == 9191
+    os.environ.pop("IX_DASH_HUB_PORT")
+
+    # Drive the real aiohttp `/` handler: 302 to a live hub, else the landing
+    # page -- never the old dead redirect. Pins the off-loop probe too.
+    async def check_index() -> None:
+        conn = store.connect(os.path.join(tempfile.mkdtemp(), "s.db"))
+        client = TestClient(TestServer(build_app(config.Config(workdir=Path(tempfile.mkdtemp())), conn)))
+        await client.start_server()
+        try:
+            hub = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            hub.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            hub.bind(("127.0.0.1", 0))
+            hub.listen(16)
+            hub_port = hub.getsockname()[1]
+            hub_url = f"http://127.0.0.1:{hub_port}/"
+            state.write_text(json.dumps({"pid": 1, "host": "127.0.0.1", "port": hub_port, "url": hub_url}))
+            resp = await client.get("/", allow_redirects=False)
+            assert resp.status == 302 and resp.headers.get("Location") == hub_url, (
+                resp.status,
+                resp.headers.get("Location"),
+            )
+            hub.close()
+
+            state.unlink(missing_ok=True)
+            resp = await client.get("/", allow_redirects=False)
+            assert resp.status == 200, resp.status
+            assert "ix-mcp dashboard" in await resp.text()
+        finally:
+            await client.close()
+
+    asyncio.run(check_index())
+
+    # The auto-dashboard hub_port branch is gated on `auto_dashboard`: with it
+    # ON, a live hub_port redirects; with it OFF (the default), a live listener on
+    # hub_port must NOT redirect -- that port is reserved-but-unbound and could be
+    # any unrelated process. Pins the wrong-redirect fix.
+    async def check_auto_gate() -> None:
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(16)
+        hp = listener.getsockname()[1]
+        try:
+            auto = config.Config(
+                workdir=Path(tempfile.mkdtemp()), host="127.0.0.1", advertised_host="127.0.0.1",
+                hub_port=hp, auto_dashboard=True,
+            )
+            ca = TestClient(TestServer(build_app(auto, store.connect(os.path.join(tempfile.mkdtemp(), "a.db")))))
+            await ca.start_server()
+            try:
+                r = await ca.get("/", allow_redirects=False)
+                assert r.status == 302 and r.headers.get("Location") == auto.hub_url(), (r.status, r.headers.get("Location"))
+            finally:
+                await ca.close()
+
+            noauto = config.Config(
+                workdir=Path(tempfile.mkdtemp()), host="127.0.0.1", advertised_host="127.0.0.1",
+                hub_port=hp, auto_dashboard=False,
+            )
+            cn = TestClient(TestServer(build_app(noauto, store.connect(os.path.join(tempfile.mkdtemp(), "n.db")))))
+            await cn.start_server()
+            try:
+                r = await cn.get("/", allow_redirects=False)
+                assert r.status == 200 and "ix-mcp dashboard" in await r.text(), r.status
+            finally:
+                await cn.close()
+        finally:
+            listener.close()
+
+    asyncio.run(check_auto_gate())
+
+    # Concurrent launches must spawn exactly one hub (the flock in _dashboard
+    # serializes check-or-spawn): the loser blocks, then reuses the winner's
+    # hub.json instead of starting a second hub.
+    state.unlink(missing_ok=True)
+    hub = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    hub.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    hub.bind(("127.0.0.1", 0))
+    hub.listen(16)
+    hub_port = hub.getsockname()[1]
+    spawns = []
+
+    def fake_spawn() -> dict:
+        spawns.append(1)
+        time.sleep(0.3)  # hold the lock so the racer is forced to wait on it
+        st = {"pid": os.getpid(), "host": "127.0.0.1", "port": hub_port, "url": f"http://127.0.0.1:{hub_port}/"}
+        config.hub_state_path().write_text(json.dumps(st))
+        return st
+
+    real_spawn = cli._spawn_shared_hub
+    cli._spawn_shared_hub = fake_spawn
+    try:
+        threads = [threading.Thread(target=cli._dashboard, kwargs={"open_browser": False}) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        cli._spawn_shared_hub = real_spawn
+        hub.close()
+    assert len(spawns) == 1, f"expected exactly one spawn under the lock, got {len(spawns)}"
+    state.unlink(missing_ok=True)
+
+    print("dashboard-launcher-ok")
+  '';
+  dashboardLauncherSmoke =
+    pkgs.runCommand "ix-mcp-dashboard-launcher-smoke"
+      {
+        nativeBuildInputs = [ mcpPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        ${mcpPython}/bin/python3 ${dashboardLauncherTest} >stdout 2>stderr || {
+          echo "ix-mcp dashboard-launcher smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -qx 'dashboard-launcher-ok' stdout || {
+          echo "ix-mcp dashboard-launcher smoke did not confirm helper behaviour:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
+
   # Exercises the in-kernel runtime (ix_notebook_mcp/runtime.py) in-process: two
   # jobs run concurrently on one event loop, neither blocks the other, each keeps
   # its own captured stdout, and the trailing expression is captured as the
@@ -4831,6 +5044,7 @@ package.overrideAttrs (old: {
         bindingsSmoke
         bindDefaultSmoke
         sshAuthSockSmoke
+        dashboardLauncherSmoke
         viewSmoke
         nixSmoke
         fleetSmoke

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -10,9 +10,10 @@
 `serve` starts ONE shared IPython kernel, a read-only data API over the
 execution store, and the MCP transport, all on one event loop. It publishes its
 panes into the shared discovery dir but does NOT spawn a `dashboard` hub: that
-aggregator is a single machine-wide process you run yourself once
-(`nix run .#dashboard`), which renders every server behind one URL. Set
-`IX_MCP_AUTO_DASHBOARD` truthy to restore the old per-server auto-spawn.
+aggregator is a single machine-wide process, started once on demand by
+`ix-mcp dashboard` (which reuses a running hub or spawns one and opens it), and
+renders every server behind one URL. Set `IX_MCP_AUTO_DASHBOARD` truthy to
+restore the old per-server auto-spawn.
 `notebook` is the engine without the MCP surface: the same kernel and store,
 driven only by what is already in the session file and the humans watching it.
 
@@ -28,6 +29,8 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import fcntl
+import ipaddress
 import json
 import os
 import re
@@ -40,7 +43,7 @@ import webbrowser
 from collections.abc import Callable
 from pathlib import Path
 
-from .config import Config, runtime_dir, set_config
+from .config import Config, hub_state_path, live_hub, port_open, runtime_dir, set_config
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 _WILDCARD_HOSTS = {"0.0.0.0", "::"}  # noqa: S104 -- deliberate set of wildcard host strings for comparison
@@ -72,9 +75,14 @@ def main(argv: list[str] | None = None) -> int:
         "session", nargs="?", metavar="FILE", help="Session file to create or reopen"
     )
     notebook.add_argument("--workdir", help="Directory the kernel runs in (default: cwd)")
-    sub.add_parser(
+    dash = sub.add_parser(
         "dashboard",
-        help="Print/open this server's data-API URL (run `nix run .#dashboard` for the human UI)",
+        help="Open the shared dashboard UI, starting it once if it is not already running",
+    )
+    dash.add_argument(
+        "--no-open",
+        action="store_true",
+        help="Print the URL but do not open a browser",
     )
     sub.add_parser(
         "requirements",
@@ -92,7 +100,7 @@ def main(argv: list[str] | None = None) -> int:
     if command in ("serve", "notebook"):
         return _serve(args, engine_only=command == "notebook")
     if command == "dashboard":
-        return _dashboard()
+        return _dashboard(open_browser=not args.no_open)
     if command == "requirements":
         from . import requirements
 
@@ -416,6 +424,7 @@ def _serve(args: argparse.Namespace, *, engine_only: bool = False) -> int:
         advertised_host=advertised_host,
         dashboard_port=dashboard_port,
         hub_port=hub_port,
+        auto_dashboard=_auto_dashboard(),
         store_path=store_path,
         session_path=session_path,
         session_resume=session_resume,
@@ -473,7 +482,7 @@ def _spawn_hub(cfg: Config) -> subprocess.Popen | None:
     terminals, a VM's screen). Best-effort: if the binary is absent (a bare run
     outside nix, which bundles it on PATH), log and skip -- the read-only data
     API still serves embedders, there is just no UI."""
-    hub_bin = os.environ.get("IX_DASHBOARD_BIN") or shutil.which("dashboard")
+    hub_bin = _hub_bin()
     if not hub_bin:
         print(
             "[ix-mcp] dashboard hub binary not found; UI disabled "
@@ -549,7 +558,7 @@ async def _run(cfg: Config) -> None:
         print(f"[ix-mcp] dashboard (all running things + output): {url}", file=sys.stderr, flush=True)
     else:
         print(
-            f"[ix-mcp] data API: {url}  (aggregated UI: run `nix run .#dashboard`)",
+            f"[ix-mcp] data API: {url}  (open the UI: `ix-mcp dashboard`)",
             file=sys.stderr,
             flush=True,
         )
@@ -581,14 +590,163 @@ async def _run(cfg: Config) -> None:
         await kernel.shutdown()
 
 
-def _dashboard() -> int:
-    url_file = runtime_dir() / "dashboard-url"
-    if not url_file.exists():
-        print("no running ix-mcp server found (start one with `ix-mcp serve`)", file=sys.stderr)
+def _hub_bin() -> str | None:
+    """The `dashboard` aggregator binary: the nix wrapper bakes IX_DASHBOARD_BIN,
+    a bare run falls back to PATH."""
+    return os.environ.get("IX_DASHBOARD_BIN") or shutil.which("dashboard")
+
+
+def _stable_hub_port() -> int:
+    """The port the one shared hub binds. A fixed default (8080) so the URL is the
+    same every time; ``IX_DASH_HUB_PORT`` overrides. If it is taken by something
+    that is not our hub, the launcher falls back to an ephemeral port."""
+    pinned = os.environ.get("IX_DASH_HUB_PORT")
+    if not pinned:
+        return 8080
+    try:
+        return int(pinned)
+    except ValueError:
+        print(
+            f"[ix-mcp] IX_DASH_HUB_PORT={pinned!r} is not an integer; using 8080",
+            file=sys.stderr,
+        )
+        return 8080
+
+
+def _bind_ip(host: str) -> str:
+    """A concrete, non-wildcard IP literal to hand the `dashboard` binary. It
+    parses ``host:port`` as a SocketAddr (IP only), so a hostname like
+    ``localhost`` from ``IX_MCP_HOST`` would crash it on startup even though
+    Python's bind accepts the name. A wildcard (``0.0.0.0``/``::``) is refused --
+    it would serve the board (kernel data, outputs) on every NIC -- and mapped to
+    loopback. Otherwise: pass IPs through; resolve a name; loopback if unresolvable."""
+    if host in ("0.0.0.0", "::", ""):  # noqa: S104 -- refusing a wildcard bind, mapping it to loopback
+        return "127.0.0.1"
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        try:
+            return socket.gethostbyname(host)
+        except OSError:
+            return "127.0.0.1"
+    return host
+
+
+def _host_arg(host: str) -> str:
+    """Bracket an IPv6 literal for use in a ``host:port`` string. The dashboard
+    binary builds ``format!("{host}:{port}")`` and parses it as a SocketAddr,
+    which requires ``[::1]:8080`` form; the same bracketing makes a valid URL
+    authority. IPv4 and hostnames are returned unchanged (Python's own socket
+    calls take the raw, unbracketed host)."""
+    return f"[{host}]" if ":" in host else host
+
+
+def _spawn_shared_hub() -> dict | None:
+    """Start the one shared dashboard hub detached and record it in
+    :func:`hub_state_path`. Returns its state dict, or ``None`` if the binary is
+    missing or it never came up. Bound to the tailnet IP (or ``IX_MCP_HOST``, else
+    loopback), never ``0.0.0.0`` -- see the bind rationale below; a tailnet peer
+    joins via that IP. ``start_new_session`` so it outlives this launcher."""
+    binp = _hub_bin()
+    if not binp:
+        print(
+            "[ix-mcp] dashboard binary not found; build via nix (which bundles "
+            "`dashboard`) or put it on PATH",
+            file=sys.stderr,
+        )
+        return None
+
+    # Bind like the data API (see `_serve`): this machine's tailnet IP when
+    # Tailscale is up (the tailnet is the trust boundary, so a peer can join) or
+    # IX_MCP_HOST, else loopback. Never a wildcard -- 0.0.0.0/:: would serve the
+    # board (kernel namespace values, captured outputs) on every LAN/public NIC of
+    # a multi-homed host -- so a wildcard request falls through to tailnet/loopback.
+    requested = os.environ.get("IX_MCP_HOST") or ""
+    if requested in ("0.0.0.0", "::"):  # noqa: S104 -- treat a wildcard request as "unspecified"
+        requested = ""
+    bind = _bind_ip(requested or _tailscale_ip() or "127.0.0.1")
+    port = _stable_hub_port()
+    # `--port 0` would tell the binary to pick an ephemeral port we cannot predict,
+    # so the readiness probe below would wait on the wrong port and time out while
+    # leaking a live hub. Resolve a concrete port up front instead.
+    if port == 0:
+        port = _free_port()
+    elif not _bindable(bind, port):
+        # Stable port busy on that interface: take an ephemeral one. If even that
+        # fails the interface is unusable (a stopped-tailscale race) -> loopback.
+        port = _free_port()
+        if bind != "127.0.0.1" and not _bindable(bind, port):
+            bind, port = "127.0.0.1", _free_port()
+
+    # Advertise the actual bind IP, never the originally-requested host: after a
+    # hostname-resolution or bindability fallback the request may not be where we
+    # are listening, so a URL built from it would point users somewhere unreachable.
+    # Bracket IPv6 for the binary's host:port and the URL authority.
+    host_arg = _host_arg(bind)
+    url = f"http://{host_arg}:{port}/"
+    log = runtime_dir() / "hub.log"
+    try:
+        with log.open("ab") as logf:
+            proc = subprocess.Popen(
+                [binp, "--host", host_arg, "--port", str(port), "--record-ms", "0"],
+                stdout=logf,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+    except OSError as error:
+        print(f"[ix-mcp] failed to start dashboard: {error}", file=sys.stderr)
+        return None
+
+    deadline = time.monotonic() + 8.0
+    while time.monotonic() < deadline:
+        # Check our own child FIRST: if it died (e.g. lost a bind race to another
+        # launcher's hub), a `port_open` success would be the *winner's* listener,
+        # and we would wrongly record hub.json with our dead pid. The flock in
+        # `_dashboard` already serializes launches so this race should not occur,
+        # but ordering the poll first keeps the readiness check honest regardless.
+        if proc.poll() is not None:
+            print(f"[ix-mcp] dashboard exited on startup; see {log}", file=sys.stderr)
+            return None
+        if port_open(port, bind):
+            break
+        time.sleep(0.1)
+    else:
+        # Never observed it listen: kill the detached child so a slow/failed start
+        # does not leave an orphan hub running (the very pile-up this avoids).
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        print(f"[ix-mcp] dashboard did not start listening in time; see {log}", file=sys.stderr)
+        return None
+
+    state = {"pid": proc.pid, "host": bind, "port": port, "url": url}
+    hub_state_path().write_text(json.dumps(state))
+    return state
+
+
+def _dashboard(*, open_browser: bool = True) -> int:
+    """Open the one shared dashboard, starting it if needed. Idempotent: a hub
+    already running is reused (no second board), which is the whole point of the
+    machine-wide singleton -- repeated runs never pile up dashboards."""
+    # Serialize concurrent launches: without this, two `ix-mcp dashboard` runs can
+    # both see no hub and both spawn one (TOCTOU between the check and the bind).
+    # Holding an exclusive lock around check-or-spawn means the loser blocks, then
+    # finds the winner's hub.json and reuses it.
+    lock_path = runtime_dir() / "hub.lock"
+    with lock_path.open("w") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        state = live_hub() or _spawn_shared_hub()
+    if state is None:
         return 1
-    url = url_file.read_text().strip()
+    url = state["url"]
     print(url)
-    webbrowser.open(url)
+    # Open the advertised URL (the hub binds the tailnet IP or loopback, so this
+    # is reachable from this host too); only when attached to a terminal so an
+    # embedder shelling out to `ix-mcp dashboard` does not pop a browser.
+    if open_browser and sys.stdout.isatty():
+        webbrowser.open(url)
     return 0
 
 

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -8,7 +8,9 @@ keeps the wiring simple. The object is frozen so nothing mutates after launch.
 
 from __future__ import annotations
 
+import json
 import os
+import socket
 import stat
 from dataclasses import dataclass
 from pathlib import Path
@@ -30,6 +32,11 @@ class Config:
     # The Loro dashboard hub (the `dashboard` aggregator the CLI spawns) the human
     # opens: it renders this server's panes -- and every other producer's -- live.
     hub_port: int = 0
+    # True only when IX_MCP_AUTO_DASHBOARD made this server spawn its own per-server
+    # hub at `hub_port`. The data API's `/` only redirects to `hub_port` in that
+    # mode; in the default mode `hub_port` is a reserved-but-unbound port, so
+    # probing it could 302 to whatever unrelated process later reused it.
+    auto_dashboard: bool = False
 
     # Host advertised in the dashboard URL (distinct from the bind: a wildcard
     # bind is not a usable URL host, so the CLI resolves a reachable name).
@@ -132,3 +139,56 @@ def runtime_dir() -> Path:
     if info.st_mode & 0o077:
         path.chmod(0o700)
     return path
+
+
+def hub_state_path() -> Path:
+    """Where the ``ix-mcp dashboard`` launcher records the one shared hub it
+    started (``{pid, host, port, url}``), so a second launch reuses it instead of
+    spawning another. Machine-wide, distinct from any single ``serve``'s random
+    ``hub_port``: there is exactly one shared hub, not one per session."""
+    return runtime_dir() / "hub.json"
+
+
+def port_open(port: int, host: str = "127.0.0.1", timeout: float = 0.25) -> bool:
+    """Whether something is accepting TCP connections on ``host:port`` right now.
+    Distinct from ``cli._bindable`` (which asks whether the port is *free*): this
+    asks whether a server is *live* there, so a stale hub-state file pointing at a
+    dead port is detected and ignored."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def live_hub() -> dict | None:
+    """The shared dashboard hub's advertised state if one is actually running,
+    else ``None``. Reads :func:`hub_state_path` and confirms the port is live, so
+    a leftover file from a crashed hub is treated as no hub. Cheap when no file
+    exists (the common case): no socket probe happens unless a record is present.
+
+    Probes the recorded bind ``host`` (not a hardcoded loopback) so a hub bound to
+    this machine's tailnet IP is correctly seen as live; a wildcard bind is probed
+    via loopback."""
+    try:
+        data = json.loads(hub_state_path().read_text())
+    except (OSError, ValueError):
+        return None
+    # The recorded process must still be alive: a TCP listener on the port alone
+    # is not enough, since after the hub dies an unrelated service could bind the
+    # same (often default 8080) port and we would redirect users to it. A dead pid
+    # means the file is stale, regardless of who now holds the port.
+    pid = data.get("pid")
+    if isinstance(pid, int) and pid > 0:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return None
+        except PermissionError:
+            pass  # exists but owned by another user -- still alive
+    port = data.get("port")
+    host = data.get("host") or "127.0.0.1"
+    probe = "127.0.0.1" if host in ("0.0.0.0", "::", "") else host  # noqa: S104 -- mapping a wildcard record to a probeable loopback, not a bind
+    if not isinstance(port, int) or not port_open(port, probe):
+        return None
+    return data

--- a/packages/mcp/ix_notebook_mcp/dashboard.py
+++ b/packages/mcp/ix_notebook_mcp/dashboard.py
@@ -8,19 +8,44 @@ embedders poll (the room server reads ``/api/snapshot``; a peer's
 
 The human-facing UI is no longer served here: the MCP publishes its runs,
 resources, and live namespace as Loro panes to the shared ``dashboard`` hub
-(see :mod:`ix_notebook_mcp.pane_bridge`), which the CLI spawns and advertises.
-``/`` redirects there so an old bookmark still lands on the live board.
+(see :mod:`ix_notebook_mcp.pane_bridge`), which a human starts once with
+``ix-mcp dashboard``. ``/`` redirects to that hub when one is running, and
+otherwise serves a short page naming the command -- never a dead redirect.
 """
 
 from __future__ import annotations
 
+import asyncio
 import hmac
 import sqlite3
 
 from aiohttp import web
 
 from . import feed, store
-from .config import Config
+from .config import Config, live_hub, port_open
+
+
+def landing_html() -> str:
+    """The page ``/`` serves when no shared dashboard hub is running. It is a data
+    API, not the UI, so it points the human at the one command that opens the UI
+    rather than (as before) redirecting to a hub port that may be dead."""
+    return (
+        "<!doctype html><meta charset=utf-8>"
+        "<title>ix-mcp data API</title>"
+        "<style>body{font:15px/1.6 ui-monospace,monospace;max-width:40rem;"
+        "margin:4rem auto;padding:0 1rem;color:#ddd;background:#111}"
+        "code{background:#222;padding:.1rem .35rem;border-radius:4px}"
+        "a{color:#6cf}</style>"
+        "<h1>ix-mcp data API</h1>"
+        "<p>This is the read-only <b>data API</b> for one session, not the "
+        "dashboard UI. The UI is a single shared board across every session.</p>"
+        "<p>Open it with:</p>"
+        "<p><code>ix-mcp dashboard</code></p>"
+        "<p>Machine endpoints: "
+        "<a href=/api/jobs>/api/jobs</a> · "
+        "<a href=/api/resources>/api/resources</a> · "
+        "<a href=/api/snapshot>/api/snapshot</a></p>"
+    )
 
 # Binds for which "trust the network" must NOT relax the exec token: a loopback
 # bind is local-only, so tailnet trust is meaningless and could only mask a
@@ -37,8 +62,27 @@ def build_app(config: Config, conn: sqlite3.Connection) -> web.Application:
     app = web.Application()
 
     async def index(_request: web.Request) -> web.Response:
-        # The UI is the Loro hub now; send a stray visitor of the old URL there.
-        raise web.HTTPFound(config.hub_url())
+        # The UI is the shared Loro hub. Redirect there only when one is actually
+        # running (a human ran `ix-mcp dashboard`); otherwise serve a page naming
+        # that command. Never redirect to `config.hub_url()` -- that per-session
+        # `hub_port` is a free port reserved at startup but never bound here, so a
+        # bookmark to `/` used to 302 straight into a refused connection.
+        # `live_hub` does a blocking TCP probe, so run it off the shared event
+        # loop (the kernel, MCP transport, and this API all run on it -- a
+        # synchronous socket call here would freeze every concurrent job).
+        hub = await asyncio.to_thread(live_hub)
+        if hub and hub.get("url"):
+            raise web.HTTPFound(hub["url"])
+        # IX_MCP_AUTO_DASHBOARD spawns a per-server hub at `config.hub_port` but
+        # writes no shared state, so fall back to redirecting there when it is up.
+        # Gate strictly on `auto_dashboard`: in the default mode `hub_port` is a
+        # reserved-but-unbound ephemeral port, and an unrelated process could later
+        # reuse it -- probing it then would 302 to that wrong service.
+        if config.auto_dashboard and config.hub_port:
+            probe = "127.0.0.1" if config.host in ("0.0.0.0", "::", "") else config.host  # noqa: S104 -- wildcard mapped to a probeable loopback
+            if await asyncio.to_thread(port_open, config.hub_port, probe):
+                raise web.HTTPFound(config.hub_url())
+        return web.Response(text=landing_html(), content_type="text/html")
 
     async def jobs(_request: web.Request) -> web.Response:
         return web.json_response(store.recent(conn, limit=feed.JOBS_LIMIT))


### PR DESCRIPTION
## Problem

Opening the kernel's `DASHBOARD_URL` gave `ERR_CONNECTION_REFUSED`.

The per-session data API's `/` handler unconditionally `302`'d to `config.hub_url()` -- a free port reserved at startup (`_free_port()`) but never bound, because the human dashboard hub is **not** auto-spawned per session by default (that was the deliberate fix for "a new dashboard URL per MCP connection"). So the courtesy redirect always pointed at a dead port.

There was also no easy way to just open the one shared dashboard.

## Change (Python only -- no Rust rebuild)

- **Kill the dead redirect** (`dashboard.py`): `/` redirects to the shared hub only when one is actually running (recorded in `runtime_dir()/hub.json`, confirmed live via a TCP probe in `config.live_hub()`), otherwise serves a small page naming `ix-mcp dashboard`. The probe runs via `asyncio.to_thread` so it never blocks the shared event loop.
- **Singleton launcher** (`cli.py` `ix-mcp dashboard`): reuse a running hub or spawn one detached, then print the URL and open the browser. Repeated runs reuse the same hub -- no pile-up.
- **Bind like the data API**: the hub binds `IX_MCP_HOST` / the tailnet IP / loopback (honoring an operator's loopback pin), never `0.0.0.0`. Stable port `8080`, override `IX_DASH_HUB_PORT`.
- `config.py`: `hub_state_path()`, `port_open()`, `live_hub()`.

## Validation

- `nix build .#mcp` and `.#mcp.tests.dashboardLauncherSmoke` (new) green; `strictTypecheck` + ruff clean.
- New smoke covers `live_hub` (missing / stale-dead-port / live), the landing page, and the real aiohttp `/` handler (302 to live hub, 200 landing otherwise).
- End-to-end: `ix-mcp dashboard` spawns once, reuses on repeat (single process), hub serves 200; bind honors `IX_MCP_HOST`.

## Notes

- To join from another machine, run on a host where Tailscale is up and `IX_MCP_HOST` is not pinned to loopback (the hub then binds the tailnet IP), or set `IX_MCP_HOST`/`IX_DASH_HUB_PORT`.
- Out of scope: cleanup of stale `ix_notebook_mcp serve` sockets/processes from old sessions.

Reviewed by the code-reviewer agent; its correctness blocker (blocking socket call on the event loop) and security finding (wildcard bind) are both fixed above.

_Authored by Claude (Sonnet) via Claude Code._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open a shared dashboard hub on demand from `ix-mcp dashboard`, dropping dead redirects
> - `ix-mcp dashboard` now spawns or reuses a single shared hub process, persisting state in `hub.json` (pid, host, port, url) and using an `fcntl` file lock to serialize concurrent launches.
> - New helpers in [cli.py](https://github.com/indexable-inc/index/pull/1333/files#diff-7ce741e8223d63fdea11625cb78abad266299445db0213d2355bc93306df9ac5) resolve the bind IP (no wildcard), stable port (default 8080 or `IX_DASH_HUB_PORT`), and IPv6 bracketing for host:port strings.
> - `live_hub()` in [config.py](https://github.com/indexable-inc/index/pull/1333/files#diff-33f6f17aed79724ba72211bc8bf9dc1da1bbdb38de56be7ace76cc09837929ca) validates a recorded hub by checking pid liveness and TCP reachability before trusting it.
> - The `/` index handler in [dashboard.py](https://github.com/indexable-inc/index/pull/1333/files#diff-42d31638eb95030752ef7a84f47bf14ecd13cbfe141948c40115b8cae061ce5e) now only redirects to a verified live hub; otherwise it serves a static landing page pointing users to `ix-mcp dashboard`.
> - A `--no-open` flag suppresses browser launch; log messages and docs updated to reference `ix-mcp dashboard` instead of `nix run .#dashboard`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eac5f75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->